### PR TITLE
New GraphicsDevice.getRenderableHdrFormat function

### DIFF
--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -1,4 +1,4 @@
-import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_RGBA8 } from '../../../platform/graphics/constants.js';
+import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F, PIXELFORMAT_RGBA8 } from '../../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../../platform/graphics/debug-graphics.js';
 import { RenderTarget } from '../../../platform/graphics/render-target.js';
 import { Texture } from '../../../platform/graphics/texture.js';
@@ -104,7 +104,7 @@ class PostEffectQueue {
     _createOffscreenTarget(useDepth, hdr) {
 
         const device = this.app.graphicsDevice;
-        const format = hdr && device.getHdrFormat(false, true, false, false) || PIXELFORMAT_RGBA8;
+        const format = hdr && device.getRenderableHdrFormat([PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F], true) || PIXELFORMAT_RGBA8;
         const name = this.camera.entity.name + '-posteffect-' + this.effects.length;
 
         const colorBuffer = this._allocateColorBuffer(format, name);

--- a/src/platform/graphics/blend-state.js
+++ b/src/platform/graphics/blend-state.js
@@ -251,6 +251,14 @@ class BlendState {
      * @readonly
      */
     static ALPHABLEND = Object.freeze(new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_SRC_ALPHA, BLENDMODE_ONE_MINUS_SRC_ALPHA));
+
+    /**
+     * A blend state that does simple additive blending.
+     *
+     * @type {BlendState}
+     * @readonly
+     */
+    static ADDBLEND = Object.freeze(new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE));
 }
 
 export { BlendState };

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -827,7 +827,7 @@ class GraphicsDevice extends EventHandler {
      * - {@link PIXELFORMAT_RGBA16F}
      * - {@link PIXELFORMAT_RGBA32F}
      *
-     * @param {boolean} [filterable] - If true, the format aso needs to be filterable. Defaults to
+     * @param {boolean} [filterable] - If true, the format also needs to be filterable. Defaults to
      * true.
      * @returns {number|undefined} The first supported renderable HDR format or undefined if none is
      * supported.

--- a/src/platform/graphics/texture-utils.js
+++ b/src/platform/graphics/texture-utils.js
@@ -30,7 +30,7 @@ class TextureUtils {
      * @returns {number} The number of mip levels required for the texture.
      */
     static calcMipLevelsCount(width, height, depth = 1) {
-        return 1 + Math.log2(Math.max(width, height, depth));
+        return 1 + Math.floor(Math.log2(Math.max(width, height, depth)));
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -932,6 +932,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.extStandardDerivatives = true;
             this.extTextureFloat = true;
             this.extTextureHalfFloat = true;
+            this.textureHalfFloatFilterable = true;
             this.extTextureLod = true;
             this.extUintElement = true;
             this.extVertexArrayObject = true;
@@ -953,7 +954,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
             this.extStandardDerivatives = this.getExtension("OES_standard_derivatives");
             this.extTextureFloat = this.getExtension("OES_texture_float");
-            this.extTextureHalfFloat = this.getExtension("OES_texture_half_float");
             this.extTextureLod = this.getExtension('EXT_shader_texture_lod');
             this.extUintElement = this.getExtension("OES_element_index_uint");
             this.extVertexArrayObject = this.getExtension("OES_vertex_array_object");
@@ -967,11 +967,17 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
             this.extColorBufferFloat = null;
             this.extDepthTexture = gl.getExtension('WEBGL_depth_texture');
+
+            this.extTextureHalfFloat = this.getExtension("OES_texture_half_float");
+            this.extTextureHalfFloatLinear = this.getExtension("OES_texture_half_float_linear");
+            this.textureHalfFloatFilterable = !!this.extTextureHalfFloatLinear;
         }
 
         this.extDebugRendererInfo = this.getExtension('WEBGL_debug_renderer_info');
+
         this.extTextureFloatLinear = this.getExtension("OES_texture_float_linear");
-        this.extTextureHalfFloatLinear = this.getExtension("OES_texture_half_float_linear");
+        this.textureFloatFilterable = !!this.extTextureFloatLinear;
+
         this.extFloatBlend = this.getExtension("EXT_float_blend");
         this.extTextureFilterAnisotropic = this.getExtension('EXT_texture_filter_anisotropic', 'WEBKIT_EXT_texture_filter_anisotropic');
         this.extCompressedTextureETC1 = this.getExtension('WEBGL_compressed_texture_etc1');
@@ -2648,39 +2654,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.attributesInvalidated = true;
         }
         return true;
-    }
-
-    /**
-     * Get a supported HDR pixel format given a set of hardware support requirements.
-     *
-     * @param {boolean} preferLargest - If true, prefer the highest precision format. Otherwise prefer the lowest precision format.
-     * @param {boolean} renderable - If true, only include pixel formats that can be used as render targets.
-     * @param {boolean} updatable - If true, only include formats that can be updated by the CPU.
-     * @param {boolean} filterable - If true, only include formats that support texture filtering.
-     *
-     * @returns {number} The HDR pixel format or null if there are none.
-     * @ignore
-     */
-    getHdrFormat(preferLargest, renderable, updatable, filterable) {
-        // Note that for WebGL2, PIXELFORMAT_RGB16F and PIXELFORMAT_RGB32F are not renderable according to this:
-        // https://developer.mozilla.org/en-US/docs/Web/API/EXT_color_buffer_float
-        // For WebGL1, only PIXELFORMAT_RGBA16F and PIXELFORMAT_RGBA32F are tested for being renderable.
-        const f16Valid = this.extTextureHalfFloat &&
-            (!renderable || this.textureHalfFloatRenderable) &&
-            (!updatable || this.textureHalfFloatUpdatable) &&
-            (!filterable || this.extTextureHalfFloatLinear);
-        const f32Valid = this.extTextureFloat &&
-            (!renderable || this.textureFloatRenderable) &&
-            (!filterable || this.extTextureFloatLinear);
-
-        if (f16Valid && f32Valid) {
-            return preferLargest ? PIXELFORMAT_RGBA32F : PIXELFORMAT_RGBA16F;
-        } else if (f16Valid) {
-            return PIXELFORMAT_RGBA16F;
-        } else if (f32Valid) {
-            return PIXELFORMAT_RGBA32F;
-        } /* else */
-        return null;
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -151,6 +151,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.extUintElement = true;
         this.extTextureFloat = true;
         this.textureFloatRenderable = true;
+        this.textureHalfFloatFilterable = true;
         this.extTextureHalfFloat = true;
         this.textureHalfFloatRenderable = true;
         this.textureHalfFloatUpdatable = true;

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -90,6 +90,8 @@ class WebgpuTexture {
         const wgpu = device.wgpu;
         const mipLevelCount = texture.requiredMipLevels;
 
+        Debug.assert(texture.width > 0 && texture.height > 0, `Invalid texture dimensions ${texture.width}x${texture.height} for texture ${texture.name}`, texture);
+
         this.descr = {
             size: {
                 width: texture.width,

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -791,7 +791,7 @@ class Scene extends EventHandler {
      * @type {number}
      */
     get lightmapPixelFormat() {
-        return this.lightmapHDR && this.device.getHdrFormat(false, true, false, true) || PIXELFORMAT_RGBA8;
+        return this.lightmapHDR && this.device.getRenderableHdrFormat() || PIXELFORMAT_RGBA8;
     }
 }
 


### PR DESCRIPTION
## New public API:

![Screenshot 2023-11-17 at 14 02 58](https://github.com/playcanvas/engine/assets/59932779/50d55245-62c7-47a0-a3cc-bf6be1498107)

New public constant: `BlendState.ADDBLEND` - predefined constant for additive blending

- few small fixes
- removed no longer needed `WebglGraphicsDevice. getHdrFormat`