### PR TITLE
Ensure screen scale is always valid

### DIFF
--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -124,9 +124,9 @@ class ScreenComponent extends Component {
         // Using log of scale values
         // This produces a nicer outcome where if you have a xscale = 2 and yscale = 0.5
         // the combined scale is 1 for an even blend
-        const lx = Math.log2(resolution.x / referenceResolution.x);
-        const ly = Math.log2(resolution.y / referenceResolution.y);
-        return Math.pow(2, (lx * (1 - this._scaleBlend) + ly * this._scaleBlend)) || 1;
+        const lx = Math.log2((resolution.x || 1) / referenceResolution.x);
+        const ly = Math.log2((resolution.y || 1) / referenceResolution.y);
+        return Math.pow(2, (lx * (1 - this._scaleBlend) + ly * this._scaleBlend));
     }
 
     _onResize(width, height) {

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -126,7 +126,7 @@ class ScreenComponent extends Component {
         // the combined scale is 1 for an even blend
         const lx = Math.log2(resolution.x / referenceResolution.x);
         const ly = Math.log2(resolution.y / referenceResolution.y);
-        return Math.pow(2, (lx * (1 - this._scaleBlend) + ly * this._scaleBlend));
+        return Math.pow(2, (lx * (1 - this._scaleBlend) + ly * this._scaleBlend)) || 1;
     }
 
     _onResize(width, height) {


### PR DESCRIPTION
Fixes #5841 

When hiding canvas, resolution is set to 0x0, thus screen scale computation is giving NaN and it will never recover from it. This PR ensures the scale can't be NaN but default to 1 instead.

However I'm not sure about coding standards here. Is this syntax acceptable or does it need some explicit early exit condition by checking resolution components (and maybe referenceResolution components too)?

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
