### PR TITLE
Update scheduling of directional light shadow render passes to be compatible with manual render passes

### DIFF
--- a/examples/src/examples/graphics/post-processing.mjs
+++ b/examples/src/examples/graphics/post-processing.mjs
@@ -180,7 +180,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         // setup skydome
         app.scene.envAtlas = assets.helipad.resource;
         app.scene.skyboxMip = 2;
-        app.scene.exposure = 0.5;
+        app.scene.exposure = 0.3;
 
         // render in HDR mode
         app.scene.toneMapping = pc.TONEMAP_LINEAR;
@@ -194,6 +194,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         const createBox = (x, y, z, sx, sy, sz, r, g, b) => {
             // create material of random color
             const material = new pc.StandardMaterial();
+            material.diffuse = pc.Color.BLACK;
             material.emissive = new pc.Color(r, g, b);
             material.update();
 
@@ -254,6 +255,21 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         });
         app.root.addChild(screen);
 
+        // add a directional light
+        const light = new pc.Entity();
+        light.addComponent("light", {
+            type: "directional",
+            color: pc.Color.WHITE,
+            intensity: 3,
+            range: 500,
+            shadowDistance: 500,
+            castShadows: true,
+            shadowBias: 0.2,
+            normalOffsetBias: 0.05
+        });
+        app.root.addChild(light);
+        light.setLocalEulerAngles(45, 30, 0);
+
         // a helper function to add a label to the screen
         const addLabel = (name, text, x, y, layer) => {
             const label = new pc.Entity(name);
@@ -289,7 +305,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
             // create a multi-sampled HDR render target to render the scene into
             const format = app.graphicsDevice.getRenderableHdrFormat() || pc.PIXELFORMAT_RGBA8;
             const sceneTexture = new pc.Texture(device, {
-                name: 'RTTexture',
+                name: 'SceneTexture',
                 width: 4,
                 height: 4,
                 format: format,

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -41,10 +41,6 @@ class RenderAction {
         // true if this is the last render action using this camera
         this.lastCameraUse = false;
 
-        // directional lights that needs to update their shadows for this render action. The array is
-        // filled in during light culling each frame.
-        this.directionalLights = [];
-
         // an array of view bind groups (the number of these corresponds to the number of views when XR is used)
         /** @type {import('../../platform/graphics/bind-group.js').BindGroup[]} */
         this.viewBindGroups = [];
@@ -66,10 +62,6 @@ class RenderAction {
         this.clearColor = camera?.clearColorBuffer || layer.clearColorBuffer;
         this.clearDepth = camera?.clearDepthBuffer || layer.clearDepthBuffer;
         this.clearStencil = camera?.clearStencilBuffer || layer.clearStencilBuffer;
-    }
-
-    get hasDirectionalShadowLights() {
-        return this.directionalLights.length > 0;
     }
 }
 

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -38,7 +38,6 @@ class FrameGraph {
         }
 
         if (renderPass.enabled) {
-            renderPass.frameUpdate();
             passes.push(renderPass);
         }
 

--- a/src/scene/renderer/render-pass-render-actions.js
+++ b/src/scene/renderer/render-pass-render-actions.js
@@ -47,10 +47,12 @@ class RenderPassRenderActions extends RenderPass {
     addRenderAction(renderAction) {
         this.renderActions.push(renderAction);
 
-        // first render action sets up clear params
+        // first render action
         if (this.renderActions.length === 1) {
 
             const camera = renderAction.camera;
+
+            // set up clear params
             this.fullSizeClearRect = camera.camera.fullSizeClearRect;
 
             // only if camera rendering covers the full viewport
@@ -90,6 +92,38 @@ class RenderPassRenderActions extends RenderPass {
         this.addRenderAction(ra);
     }
 
+    frameUpdate() {
+        super.frameUpdate();
+
+        // add directional shadow passes if needed for the cameras used in this render pass
+        const { renderer, renderActions } = this;
+        for (let i = 0; i < renderActions.length; i++) {
+            const renderAction = renderActions[i];
+            const cameraComp = renderAction.camera;
+            const camera = cameraComp.camera;
+
+            // if this camera uses directional shadow lights
+            const shadowDirLights = this.renderer.cameraDirShadowLights.get(camera);
+            if (shadowDirLights) {
+
+                for (let l = 0; l < shadowDirLights.length; l++) {
+                    const light = shadowDirLights[l];
+
+                    // the the shadow map is not already rendered for this light
+                    if (renderer.dirLightShadows.get(light) !== camera) {
+                        renderer.dirLightShadows.set(light, camera);
+
+                        // render the shadow before this render pass
+                        const shadowPass = renderer._shadowRendererDirectional.getLightRenderPass(light, camera);
+                        if (shadowPass) {
+                            this.beforePasses.push(shadowPass);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     before() {
         const { renderActions } = this;
         if (renderActions.length) {
@@ -121,6 +155,9 @@ class RenderPassRenderActions extends RenderPass {
                 ra.camera.onPostRender();
             }
         }
+
+        // remove shadow before-passes
+        this.beforePasses.length = 0;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5844

- added a directional shadow casting light to post-processing example
- updated RenderPassRenderAction to automatically schedule required shadow passes for directional light before it
- this is done by tracking the camera that the directional shadow is currently rendered for, and scheduling rendering if a new camera is used