### PR TITLE
Simplify and optimize some GraphNode find functions

### DIFF
--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -24,6 +24,27 @@ const target = new Vec3();
 const up = new Vec3();
 
 /**
+ * Helper function that handles signature overloading to receive a test function.
+ *
+ * @param {FindNodeCallback|string} attr - Attribute or lambda.
+ * @param {*} [value] - Optional value in case of `attr` being a `string`
+ * @returns {FindNodeCallback} Test function that receives a GraphNode and returns a boolean.
+ * @ignore
+ */
+function createTest(attr, value) {
+    if (attr instanceof Function) {
+        return attr;
+    }
+    return (node) => {
+        let x = node[attr];
+        if (x instanceof Function) {
+            x = x();
+        }
+        return x === value;
+    };
+}
+
+/**
  * Callback used by {@link GraphNode#find} and {@link GraphNode#findOne} to search through a graph
  * node and all of its descendants.
  *
@@ -534,40 +555,13 @@ class GraphNode extends EventHandler {
      * const entities = parent.find('name', 'Test');
      */
     find(attr, value) {
-        let result, results = [];
-        const len = this._children.length;
+        const results = [];
+        const test = createTest(attr, value);
 
-        if (attr instanceof Function) {
-            const fn = attr;
-
-            result = fn(this);
-            if (result)
-                results.push(this);
-
-            for (let i = 0; i < len; i++) {
-                const descendants = this._children[i].find(fn);
-                if (descendants.length)
-                    results = results.concat(descendants);
-            }
-        } else {
-            let testValue;
-
-            if (this[attr]) {
-                if (this[attr] instanceof Function) {
-                    testValue = this[attr]();
-                } else {
-                    testValue = this[attr];
-                }
-                if (testValue === value)
-                    results.push(this);
-            }
-
-            for (let i = 0; i < len; ++i) {
-                const descendants = this._children[i].find(attr, value);
-                if (descendants.length)
-                    results = results.concat(descendants);
-            }
-        }
+        this.forEach((node) => {
+            if (test(node))
+                results.push(node);
+        });
 
         return results;
     }
@@ -597,39 +591,16 @@ class GraphNode extends EventHandler {
      * const node = parent.findOne('name', 'Test');
      */
     findOne(attr, value) {
+        const test = createTest(attr, value);
         const len = this._children.length;
-        let result = null;
 
-        if (attr instanceof Function) {
-            const fn = attr;
+        if (test(this))
+            return this;
 
-            result = fn(this);
+        for (let i = 0; i < len; ++i) {
+            const result = this._children[i].findOne(test);
             if (result)
-                return this;
-
-            for (let i = 0; i < len; i++) {
-                result = this._children[i].findOne(fn);
-                if (result)
-                    return result;
-            }
-        } else {
-            let testValue;
-            if (this[attr]) {
-                if (this[attr] instanceof Function) {
-                    testValue = this[attr]();
-                } else {
-                    testValue = this[attr];
-                }
-                if (testValue === value) {
-                    return this;
-                }
-            }
-
-            for (let i = 0; i < len; i++) {
-                result = this._children[i].findOne(attr, value);
-                if (result !== null)
-                    return result;
-            }
+                return result;
         }
 
         return null;
@@ -683,13 +654,7 @@ class GraphNode extends EventHandler {
      * null if no node is found.
      */
     findByName(name) {
-        if (this.name === name) return this;
-
-        for (let i = 0; i < this._children.length; i++) {
-            const found = this._children[i].findByName(name);
-            if (found !== null) return found;
-        }
-        return null;
+        return this.findOne('name', name);
     }
 
     /**


### PR DESCRIPTION
Follow-up of #4603

This PR simplify `GraphNode.find` and `GraphNode.findOne`.
It also avoids creating and merging lots of arrays in `GraphNode.find` which means less garbage.
In addition, `GraphNode.findByName` now simply calls `GraphNode.findOne` so the traversing logic isn't duplicated anymore.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
