### PR TITLE
[Examples] Remove redundant static NAME property on Example classes

### DIFF
--- a/examples/src/examples/animation/blend-trees-1d.mjs
+++ b/examples/src/examples/animation/blend-trees-1d.mjs
@@ -200,7 +200,6 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, data, glsla
 }
 class BlendTrees1DExample {
     static CATEGORY = 'Animation';
-    static NAME = 'Blend Trees 1D';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/animation/blend-trees-2d-cartesian.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.mjs
@@ -315,7 +315,6 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 }
 class BlendTrees2DCartesianExample {
     static CATEGORY = 'Animation';
-    static NAME = 'Blend Trees 2D Cartesian';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/animation/blend-trees-2d-directional.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-directional.mjs
@@ -276,7 +276,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 class BlendTrees2DDirectionalExample {
     static CATEGORY = 'Animation';
-    static NAME = 'Blend Trees 2D Directional';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/animation/component-properties.mjs
+++ b/examples/src/examples/animation/component-properties.mjs
@@ -299,7 +299,6 @@ async function example({ canvas, deviceType, data, assetPath, glslangPath, twgsl
 
 class ComponentPropertiesExample {
     static CATEGORY = 'Animation';
-    static NAME = 'Component Properties';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/animation/events.mjs
+++ b/examples/src/examples/animation/events.mjs
@@ -201,7 +201,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 }
 class EventsExample {
     static CATEGORY = 'Animation';
-    static NAME = 'Events';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/animation/layer-masks.mjs
+++ b/examples/src/examples/animation/layer-masks.mjs
@@ -298,7 +298,6 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
 class LayerMasksExample {
     static CATEGORY = 'Animation';
-    static NAME = 'Layer Masks';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/animation/locomotion.mjs
+++ b/examples/src/examples/animation/locomotion.mjs
@@ -421,7 +421,6 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
 }
 class LocomotionExample {
     static CATEGORY = 'Animation';
-    static NAME = 'Locomotion';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/animation/tween.mjs
+++ b/examples/src/examples/animation/tween.mjs
@@ -175,7 +175,6 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
 class TweenExample {
     static CATEGORY = 'Animation';
-    static NAME = 'Tween';
     static WEBGPU_ENABLED = true;
     static example = example;
     // added by examples/scripts/generate-standalone-files.mjs

--- a/examples/src/examples/camera/first-person.mjs
+++ b/examples/src/examples/camera/first-person.mjs
@@ -142,7 +142,6 @@ async function example({ canvas, assetPath, scriptsPath, ammoPath }) {
 
 class FirstPersonExample {
     static CATEGORY = 'Camera';
-    static NAME = 'First Person';
     static example = example;
 }
 

--- a/examples/src/examples/camera/fly.mjs
+++ b/examples/src/examples/camera/fly.mjs
@@ -128,7 +128,6 @@ async function example({ canvas, scriptsPath }) {
 
 class FlyExample {
     static CATEGORY = 'Camera';
-    static NAME = 'Fly';
     static example = example;
 }
 

--- a/examples/src/examples/camera/orbit.mjs
+++ b/examples/src/examples/camera/orbit.mjs
@@ -75,7 +75,6 @@ async function example({ canvas, assetPath, scriptsPath }) {
 
 class OrbitExample {
     static CATEGORY = 'Camera';
-    static NAME = 'Orbit';
     static example = example;
 }
 

--- a/examples/src/examples/graphics/area-lights.mjs
+++ b/examples/src/examples/graphics/area-lights.mjs
@@ -258,7 +258,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class AreaLightsExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Area Lights';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/area-picker.mjs
+++ b/examples/src/examples/graphics/area-picker.mjs
@@ -257,7 +257,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class AreaPickerExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Area Picker';
     static example = example;
     static WEBGPU_ENABLED = false; // device.updateBegin() is not a function
 }

--- a/examples/src/examples/graphics/asset-viewer.mjs
+++ b/examples/src/examples/graphics/asset-viewer.mjs
@@ -267,7 +267,6 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
 
 export class AssetViewerExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Asset Viewer';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/graphics/batching-dynamic.mjs
+++ b/examples/src/examples/graphics/batching-dynamic.mjs
@@ -144,7 +144,6 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
 
 export class BatchingDynamicExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Batching Dynamic';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/clustered-area-lights.mjs
+++ b/examples/src/examples/graphics/clustered-area-lights.mjs
@@ -314,7 +314,6 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
 class ClusteredAreaLightsExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Clustered Area Lights';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/graphics/clustered-lighting.mjs
+++ b/examples/src/examples/graphics/clustered-lighting.mjs
@@ -246,7 +246,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class ClusteredLightingExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Clustered Lighting';
     static ENGINE = 'PERFORMANCE';
     static WEBGPU_ENABLED = true;
     static example = example;

--- a/examples/src/examples/graphics/clustered-omni-shadows.mjs
+++ b/examples/src/examples/graphics/clustered-omni-shadows.mjs
@@ -311,7 +311,6 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
 
 export class ClusteredOmniShadowsExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Clustered Omni Shadows';
     static controls = controls;
     static example = example;
 }

--- a/examples/src/examples/graphics/clustered-spot-shadows.mjs
+++ b/examples/src/examples/graphics/clustered-spot-shadows.mjs
@@ -464,7 +464,6 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
 
 export class ClusteredSpotShadowsExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Clustered Spot Shadows';
     static ENGINE = 'DEBUG';
     static WEBGPU_ENABLED = true;
     static controls = controls;

--- a/examples/src/examples/graphics/contact-hardening-shadows.mjs
+++ b/examples/src/examples/graphics/contact-hardening-shadows.mjs
@@ -483,7 +483,6 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
 
 export class ContactHardeningShadowsExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Contact Hardening Shadows';
     static WEBGPU_ENABLED = false;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/graphics/grab-pass.mjs
+++ b/examples/src/examples/graphics/grab-pass.mjs
@@ -180,7 +180,6 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
 
 export class GrabPassExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Grab Pass';
     static WEBGPU_ENABLED = true;
 
     static FILES = {

--- a/examples/src/examples/graphics/ground-fog.mjs
+++ b/examples/src/examples/graphics/ground-fog.mjs
@@ -205,7 +205,6 @@ async function example({ canvas, deviceType, files, assetPath, scriptsPath, glsl
 
 export class GroundFogExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Ground Fog';
     static WEBGPU_ENABLED = true;
 
     static FILES = {

--- a/examples/src/examples/graphics/hardware-instancing.mjs
+++ b/examples/src/examples/graphics/hardware-instancing.mjs
@@ -135,7 +135,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class HardwareInstancingExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Hardware Instancing';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/hierarchy.mjs
+++ b/examples/src/examples/graphics/hierarchy.mjs
@@ -152,7 +152,6 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
 
 export class HierarchyExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Hierarchy';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/index.mjs
+++ b/examples/src/examples/graphics/index.mjs
@@ -33,7 +33,7 @@ export * from "./model-asset.mjs";
 export * from "./model-outline.mjs";
 export * from "./model-textured-box.mjs";
 export * from "./multi-view.mjs";
-export * from "./mrt.mjs";
+export * from "./multi-render-targets.mjs";
 export * from "./painter.mjs";
 export * from "./paint-mesh.mjs";
 export * from "./particles-anim-index.mjs";

--- a/examples/src/examples/graphics/layers.mjs
+++ b/examples/src/examples/graphics/layers.mjs
@@ -125,7 +125,6 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
 
 export class LayersExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Layers';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/light-physical-units.mjs
+++ b/examples/src/examples/graphics/light-physical-units.mjs
@@ -429,7 +429,6 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
 
 export class LightPhysicalUnitsExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Light Physical Units';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/graphics/lights-baked-a-o.mjs
+++ b/examples/src/examples/graphics/lights-baked-a-o.mjs
@@ -419,7 +419,6 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
 
 export class LightsBakedAOExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Lights Baked AO';
     static controls = controls;
     static example = example;
     static WEBGPU_ENABLED = false; // house is just gray

--- a/examples/src/examples/graphics/lights-baked.mjs
+++ b/examples/src/examples/graphics/lights-baked.mjs
@@ -154,7 +154,6 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
 
 export class LightsBakedExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Lights Baked';
     static example = example;
     static WEBGPU_ENABLED = false; // house is black
 }

--- a/examples/src/examples/graphics/lights.mjs
+++ b/examples/src/examples/graphics/lights.mjs
@@ -343,7 +343,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class LightsExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Lights';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/graphics/lines.mjs
+++ b/examples/src/examples/graphics/lines.mjs
@@ -211,7 +211,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class LinesExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Lines';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/lit-material.mjs
+++ b/examples/src/examples/graphics/lit-material.mjs
@@ -166,7 +166,6 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
 class LitMaterialExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Lit Material';
     static HIDDEN = true;
     static WEBGPU_ENABLED = true;
     static example = example;

--- a/examples/src/examples/graphics/material-anisotropic.mjs
+++ b/examples/src/examples/graphics/material-anisotropic.mjs
@@ -145,7 +145,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class MaterialAnisotropicExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Material Anisotropic';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/material-basic.mjs
+++ b/examples/src/examples/graphics/material-basic.mjs
@@ -167,7 +167,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class MaterialBasicExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Material Basic';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/material-clear-coat.mjs
+++ b/examples/src/examples/graphics/material-clear-coat.mjs
@@ -145,7 +145,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class MaterialClearCoatExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Material Clear Coat';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/material-physical.mjs
+++ b/examples/src/examples/graphics/material-physical.mjs
@@ -143,7 +143,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class MaterialPhysicalExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Material Physical';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/material-translucent-specular.mjs
+++ b/examples/src/examples/graphics/material-translucent-specular.mjs
@@ -149,7 +149,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class MaterialTranslucentSpecularExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Material Translucent Specular';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/mesh-decals.mjs
+++ b/examples/src/examples/graphics/mesh-decals.mjs
@@ -279,7 +279,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class MeshDecalsExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Mesh Decals';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/mesh-deformation.mjs
+++ b/examples/src/examples/graphics/mesh-deformation.mjs
@@ -141,7 +141,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class MeshDeformationExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Mesh Deformation';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/mesh-generation.mjs
+++ b/examples/src/examples/graphics/mesh-generation.mjs
@@ -231,7 +231,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class MeshGenerationExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Mesh Generation';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/mesh-morph-many.mjs
+++ b/examples/src/examples/graphics/mesh-morph-many.mjs
@@ -114,7 +114,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class MeshMorphManyExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Mesh Morph Many';
     static example = example;
     static WEBGPU_ENABLED = false; // doesn't morph anything
 }

--- a/examples/src/examples/graphics/mesh-morph.mjs
+++ b/examples/src/examples/graphics/mesh-morph.mjs
@@ -218,7 +218,6 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
 
 export class MeshMorphExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Mesh Morph';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/model-asset.mjs
+++ b/examples/src/examples/graphics/model-asset.mjs
@@ -99,7 +99,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class ModelAssetExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Model Asset';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/model-outline.mjs
+++ b/examples/src/examples/graphics/model-outline.mjs
@@ -188,7 +188,6 @@ async function example({ canvas, deviceType, scriptsPath, glslangPath, twgslPath
 
 export class ModelOutlineExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Model Outline';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/model-textured-box.mjs
+++ b/examples/src/examples/graphics/model-textured-box.mjs
@@ -113,7 +113,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class ModelTexturedBoxExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Model Textured Box';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/multi-render-targets.mjs
+++ b/examples/src/examples/graphics/multi-render-targets.mjs
@@ -197,11 +197,9 @@ async function example({ canvas, deviceType, files, dracoPath, assetPath, glslan
     return app;
 }
 
-export class MrtExample {
+export class MultiRenderTargetsExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Multi Render Targets';
     static WEBGPU_ENABLED = true;
-
     static FILES = {
 
         // shader chunk which outputs to multiple render targets

--- a/examples/src/examples/graphics/multi-view.mjs
+++ b/examples/src/examples/graphics/multi-view.mjs
@@ -234,7 +234,6 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
 
 export class MultiViewExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Multi View';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/graphics/paint-mesh.mjs
+++ b/examples/src/examples/graphics/paint-mesh.mjs
@@ -200,7 +200,6 @@ async function example({ canvas, files, assetPath }) {
 
 export class PaintMeshExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Paint Mesh';
 
     static FILES = {
         'shader.vert': /* glsl */`

--- a/examples/src/examples/graphics/painter.mjs
+++ b/examples/src/examples/graphics/painter.mjs
@@ -225,7 +225,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class PainterExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Painter';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/particles-anim-index.mjs
+++ b/examples/src/examples/graphics/particles-anim-index.mjs
@@ -153,6 +153,5 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class ParticlesAnimIndexExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Particles: Anim Index';
     static example = example;
 }

--- a/examples/src/examples/graphics/particles-random-sprites.mjs
+++ b/examples/src/examples/graphics/particles-random-sprites.mjs
@@ -155,6 +155,5 @@ async function example({ canvas, assetPath }) {
 
 export class ParticlesRandomSpritesExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Particles: Random Sprites';
     static example = example;
 }

--- a/examples/src/examples/graphics/particles-snow.mjs
+++ b/examples/src/examples/graphics/particles-snow.mjs
@@ -97,7 +97,6 @@ async function example({ canvas, assetPath }) {
 
 export class ParticlesSnowExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Particles: Snow';
     static example = example;
     static WEBGPU_ENABLED = false; // no particles visible after hot-reload
 }

--- a/examples/src/examples/graphics/particles-spark.mjs
+++ b/examples/src/examples/graphics/particles-spark.mjs
@@ -143,7 +143,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class ParticlesSparkExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Particles: Spark';
     static example = example;
     static WEBGPU_ENABLED = false; // no particles visible
 }

--- a/examples/src/examples/graphics/point-cloud-simulation.mjs
+++ b/examples/src/examples/graphics/point-cloud-simulation.mjs
@@ -144,7 +144,6 @@ async function example({ canvas, files }) {
 
 export class PointCloudSimulationExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Point Cloud Simulation';
     static FILES = {
         'shader.vert': /* glsl */`
 // Attributes per vertex: position

--- a/examples/src/examples/graphics/point-cloud.mjs
+++ b/examples/src/examples/graphics/point-cloud.mjs
@@ -88,7 +88,6 @@ async function example({ canvas, files, assetPath }) {
 
 export class PointCloudExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Point Cloud';
     static FILES = {
         'shader.vert': /* glsl */`
 // Attributes per vertex: position

--- a/examples/src/examples/graphics/portal.mjs
+++ b/examples/src/examples/graphics/portal.mjs
@@ -231,7 +231,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class PortalExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Portal';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/post-effects.mjs
+++ b/examples/src/examples/graphics/post-effects.mjs
@@ -433,7 +433,6 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
 
 export class PostEffectsExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Post Effects';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/graphics/post-processing.mjs
+++ b/examples/src/examples/graphics/post-processing.mjs
@@ -418,7 +418,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class PostprocessingExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Post Processing XX';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/graphics/reflection-box.mjs
+++ b/examples/src/examples/graphics/reflection-box.mjs
@@ -429,7 +429,6 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
 
 class ReflectionBoxExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Reflection Box';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/graphics/reflection-cubemap.mjs
+++ b/examples/src/examples/graphics/reflection-cubemap.mjs
@@ -313,7 +313,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class ReflectionCubemapExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Reflection Cubemap';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/reflection-planar.mjs
+++ b/examples/src/examples/graphics/reflection-planar.mjs
@@ -205,7 +205,6 @@ async function example({ canvas, deviceType, files, scriptsPath, assetPath, glsl
 
 export class ReflectionPlanarExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Reflection Planar';
     static WEBGPU_ENABLED = true;
 
     static FILES = {

--- a/examples/src/examples/graphics/render-asset.mjs
+++ b/examples/src/examples/graphics/render-asset.mjs
@@ -112,7 +112,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class RenderAssetExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Render Asset';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/render-pass.mjs
+++ b/examples/src/examples/graphics/render-pass.mjs
@@ -177,7 +177,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class RenderPassExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Render Pass';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/render-to-texture.mjs
+++ b/examples/src/examples/graphics/render-to-texture.mjs
@@ -294,7 +294,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class RenderToTextureExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Render to Texture';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/shader-burn.mjs
+++ b/examples/src/examples/graphics/shader-burn.mjs
@@ -141,7 +141,6 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
 
 export class ShaderBurnExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Shader Burn';
     static WEBGPU_ENABLED = true;
 
     static FILES = {

--- a/examples/src/examples/graphics/shader-compile.mjs
+++ b/examples/src/examples/graphics/shader-compile.mjs
@@ -205,7 +205,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 export class ShaderCompileExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Shader Compile';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/shader-toon.mjs
+++ b/examples/src/examples/graphics/shader-toon.mjs
@@ -132,7 +132,6 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
 
 export class ShaderToonExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Shader Toon';
     static WEBGPU_ENABLED = true;
 
     static FILES = {

--- a/examples/src/examples/graphics/shader-wobble.mjs
+++ b/examples/src/examples/graphics/shader-wobble.mjs
@@ -133,7 +133,6 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
 
 export class ShaderWobbleExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Shader Wobble';
     static WEBGPU_ENABLED = true;
 
     static FILES = {

--- a/examples/src/examples/graphics/shadow-cascades.mjs
+++ b/examples/src/examples/graphics/shadow-cascades.mjs
@@ -293,7 +293,6 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
 
 export class ShadowCascadesExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Shadow Cascades';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/graphics/shapes.mjs
+++ b/examples/src/examples/graphics/shapes.mjs
@@ -97,7 +97,6 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
 
 export class ShapesExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Shapes';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/texture-array.mjs
+++ b/examples/src/examples/graphics/texture-array.mjs
@@ -264,7 +264,6 @@ async function example({ canvas, deviceType, data, files, assetPath, scriptsPath
 
 export class TextureArrayExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Texture Array';
     static WEBGPU_ENABLED = false;
 
     static FILES = {

--- a/examples/src/examples/graphics/texture-basis.mjs
+++ b/examples/src/examples/graphics/texture-basis.mjs
@@ -140,7 +140,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class TextureBasisExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Texture Basis';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/graphics/transform-feedback.mjs
+++ b/examples/src/examples/graphics/transform-feedback.mjs
@@ -162,7 +162,6 @@ async function example({ canvas, files, assetPath }) {
 
 export class TransformFeedbackExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Transform Feedback';
     static FILES = {
         'shaderFeedback.vert': /* glsl */`
 // vertex shader used to move particles during transform-feedback simulation step

--- a/examples/src/examples/graphics/video-texture.mjs
+++ b/examples/src/examples/graphics/video-texture.mjs
@@ -128,6 +128,5 @@ async function example({ canvas, assetPath }) {
 
 export class VideoTextureExample {
     static CATEGORY = 'Graphics';
-    static NAME = 'Video Texture';
     static example = example;
 }

--- a/examples/src/examples/input/gamepad.mjs
+++ b/examples/src/examples/input/gamepad.mjs
@@ -94,7 +94,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class GamepadExample {
     static CATEGORY = 'Input';
-    static NAME = 'Gamepad';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/input/keyboard.mjs
+++ b/examples/src/examples/input/keyboard.mjs
@@ -86,7 +86,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class KeyboardExample {
     static CATEGORY = 'Input';
-    static NAME = 'Keyboard';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/input/mouse.mjs
+++ b/examples/src/examples/input/mouse.mjs
@@ -88,7 +88,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class MouseExample {
     static CATEGORY = 'Input';
-    static NAME = 'Mouse';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/loaders/draco-glb.mjs
+++ b/examples/src/examples/loaders/draco-glb.mjs
@@ -97,7 +97,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class DracoGlbExample {
     static CATEGORY = 'Loaders';
-    static NAME = 'Draco GLB';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/loaders/glb.mjs
+++ b/examples/src/examples/loaders/glb.mjs
@@ -114,7 +114,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class GlbExample {
     static CATEGORY = 'Loaders';
-    static NAME = 'GLB';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/loaders/gltf-export.mjs
+++ b/examples/src/examples/loaders/gltf-export.mjs
@@ -174,7 +174,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class GltfExportExample {
     static CATEGORY = 'Loaders';
-    static NAME = 'GLTF Export';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/loaders/loaders-gl.mjs
+++ b/examples/src/examples/loaders/loaders-gl.mjs
@@ -164,7 +164,6 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
 
 class LoadersGlExample {
     static CATEGORY = 'Loaders';
-    static NAME = 'Loaders.gl';
     static FILES = {
         'shader.vert': vshader,
         'shader.frag': fshader,

--- a/examples/src/examples/loaders/obj.mjs
+++ b/examples/src/examples/loaders/obj.mjs
@@ -83,6 +83,5 @@ async function example({ canvas, assetPath, scriptsPath }) {
 
 export class ObjExample {
     static CATEGORY = 'Loaders';
-    static NAME = 'OBJ';
     static example = example;
 }

--- a/examples/src/examples/loaders/splat-many.mjs
+++ b/examples/src/examples/loaders/splat-many.mjs
@@ -124,7 +124,6 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
 export class SplatManyExample {
     static CATEGORY = 'Loaders';
-    static NAME = 'Splat Many';
     static example = example;
 
     static FILES = {

--- a/examples/src/examples/loaders/splat.mjs
+++ b/examples/src/examples/loaders/splat.mjs
@@ -106,6 +106,5 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
 export class SplatExample {
     static CATEGORY = 'Loaders';
-    static NAME = 'Splat';
     static example = example;
 }

--- a/examples/src/examples/loaders/usdz-export.mjs
+++ b/examples/src/examples/loaders/usdz-export.mjs
@@ -127,7 +127,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
 export class UsdzExportExample {
     static CATEGORY = 'Loaders';
-    static NAME = 'USDZ Export';
     static WEBGPU_ENABLED = true;
     static controls = controls;
     static example = example;

--- a/examples/src/examples/misc/hello-world.mjs
+++ b/examples/src/examples/misc/hello-world.mjs
@@ -74,7 +74,6 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
 
 class HelloWorldExample {
     static CATEGORY = 'Misc';
-    static NAME = 'Hello World';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/misc/mini-stats.mjs
+++ b/examples/src/examples/misc/mini-stats.mjs
@@ -244,7 +244,6 @@ async function example({ canvas, pcx }) {
 
 class MiniStatsExample {
     static CATEGORY = 'Misc';
-    static NAME = 'Mini Stats';
     static WEBGPU_ENABLED = true;
     static ENGINE = 'PERFORMANCE';
     static MINISTATS = true;

--- a/examples/src/examples/misc/spineboy.mjs
+++ b/examples/src/examples/misc/spineboy.mjs
@@ -107,7 +107,6 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
 class SpineboyExample {
     static CATEGORY = 'Misc';
-    static NAME = 'Spineboy';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/physics/compound-collision.mjs
+++ b/examples/src/examples/physics/compound-collision.mjs
@@ -420,7 +420,6 @@ async function example({ canvas, deviceType, ammoPath, glslangPath, twgslPath })
 
 class CompoundCollisionExample {
     static CATEGORY = 'Physics';
-    static NAME = 'Compound Collision';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/physics/falling-shapes.mjs
+++ b/examples/src/examples/physics/falling-shapes.mjs
@@ -275,7 +275,6 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
 
 class FallingShapesExample {
     static CATEGORY = 'Physics';
-    static NAME = 'Falling Shapes';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/physics/offset-collision.mjs
+++ b/examples/src/examples/physics/offset-collision.mjs
@@ -273,7 +273,6 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
 
 class OffsetCollisionExample {
     static CATEGORY = 'Physics';
-    static NAME = 'Offset Collision';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/physics/raycast.mjs
+++ b/examples/src/examples/physics/raycast.mjs
@@ -236,7 +236,6 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
 
 class RaycastExample {
     static CATEGORY = 'Physics';
-    static NAME = 'Raycast';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/physics/vehicle.mjs
+++ b/examples/src/examples/physics/vehicle.mjs
@@ -237,7 +237,6 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, ammoPath, g
 
 class VehicleExample {
     static CATEGORY = 'Physics';
-    static NAME = 'Vehicle';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/sound/positional.mjs
+++ b/examples/src/examples/sound/positional.mjs
@@ -117,7 +117,6 @@ async function example({ canvas, assetPath }) {
 
 class PositionalExample {
     static CATEGORY = 'Sound';
-    static NAME = 'Positional';
     static example = example;
 }
 

--- a/examples/src/examples/user-interface/button-basic.mjs
+++ b/examples/src/examples/user-interface/button-basic.mjs
@@ -118,7 +118,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class ButtonBasicExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Button Basic';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/user-interface/button-sprite.mjs
+++ b/examples/src/examples/user-interface/button-sprite.mjs
@@ -189,7 +189,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class ButtonSpriteExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Button Sprite';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/user-interface/custom-shader.mjs
+++ b/examples/src/examples/user-interface/custom-shader.mjs
@@ -120,7 +120,6 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
 
 class CustomShaderExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Custom Shader';
     static WEBGPU_ENABLED = true;
 
     static FILES = {

--- a/examples/src/examples/user-interface/layout-group.mjs
+++ b/examples/src/examples/user-interface/layout-group.mjs
@@ -145,7 +145,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class LayoutGroupExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Layout Group';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/user-interface/particle-system.mjs
+++ b/examples/src/examples/user-interface/particle-system.mjs
@@ -181,7 +181,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class ParticleSystemExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Particle System';
     static example = example;
 }
 

--- a/examples/src/examples/user-interface/scroll-view.mjs
+++ b/examples/src/examples/user-interface/scroll-view.mjs
@@ -255,7 +255,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class ScrollViewExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Scroll View';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/user-interface/text-auto-font-size.mjs
+++ b/examples/src/examples/user-interface/text-auto-font-size.mjs
@@ -128,7 +128,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class TextAutoFontSizeExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Text Auto Font Size';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/user-interface/text-emojis.mjs
+++ b/examples/src/examples/user-interface/text-emojis.mjs
@@ -189,7 +189,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class TextEmojisExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Text Emojis';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/user-interface/text-localization.mjs
+++ b/examples/src/examples/user-interface/text-localization.mjs
@@ -182,7 +182,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class TextLocalizationExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Text Localization';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/user-interface/text-typewriter.mjs
+++ b/examples/src/examples/user-interface/text-typewriter.mjs
@@ -113,7 +113,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class TextTypewriterExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Text Typewriter';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/user-interface/text.mjs
+++ b/examples/src/examples/user-interface/text.mjs
@@ -151,7 +151,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class TextExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'Text';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/user-interface/world-to-screen.mjs
+++ b/examples/src/examples/user-interface/world-to-screen.mjs
@@ -247,7 +247,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
 class WorldToScreenExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'World to Screen';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/user-interface/world-ui.mjs
+++ b/examples/src/examples/user-interface/world-ui.mjs
@@ -186,7 +186,6 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
 class WorldUiExample {
     static CATEGORY = 'User Interface';
-    static NAME = 'World UI';
     static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/xr/ar-anchors-persistence.mjs
+++ b/examples/src/examples/xr/ar-anchors-persistence.mjs
@@ -283,7 +283,6 @@ async function example({ canvas }) {
 
 class ArAnchorsPersistentExample {
     static CATEGORY = 'XR';
-    static NAME = 'AR Anchors Persistence';
     static example = example;
 }
 

--- a/examples/src/examples/xr/ar-basic.mjs
+++ b/examples/src/examples/xr/ar-basic.mjs
@@ -142,7 +142,6 @@ async function example({ canvas }) {
 
 class ArBasicExample {
     static CATEGORY = 'XR';
-    static NAME = 'AR Basic';
     static example = example;
 }
 

--- a/examples/src/examples/xr/ar-hit-test-anchors.mjs
+++ b/examples/src/examples/xr/ar-hit-test-anchors.mjs
@@ -251,7 +251,6 @@ async function example({ canvas }) {
 
 class ArHitTestAnchorsExample {
     static CATEGORY = 'XR';
-    static NAME = 'AR Hit Test Anchors';
     static example = example;
 }
 

--- a/examples/src/examples/xr/ar-hit-test.mjs
+++ b/examples/src/examples/xr/ar-hit-test.mjs
@@ -183,7 +183,6 @@ async function example({ canvas }) {
 
 class ArHitTestExample {
     static CATEGORY = 'XR';
-    static NAME = 'AR Hit Test';
     static example = example;
 }
 

--- a/examples/src/examples/xr/ar-plane-detection.mjs
+++ b/examples/src/examples/xr/ar-plane-detection.mjs
@@ -304,7 +304,6 @@ async function example({ canvas }) {
 
 class ArPlanesDetectionExample {
     static CATEGORY = 'XR';
-    static NAME = 'AR Plane Detection';
     static example = example;
 }
 

--- a/examples/src/examples/xr/vr-basic.mjs
+++ b/examples/src/examples/xr/vr-basic.mjs
@@ -140,7 +140,6 @@ async function example({ canvas }) {
 
 class VrBasicExample {
     static CATEGORY = 'XR';
-    static NAME = 'VR Basic';
     static example = example;
 }
 

--- a/examples/src/examples/xr/vr-controllers.mjs
+++ b/examples/src/examples/xr/vr-controllers.mjs
@@ -182,7 +182,6 @@ async function example({ canvas, assetPath }) {
 
 class VrControllersExample {
     static CATEGORY = 'XR';
-    static NAME = 'VR Controllers';
     static example = example;
 }
 

--- a/examples/src/examples/xr/vr-hands.mjs
+++ b/examples/src/examples/xr/vr-hands.mjs
@@ -228,7 +228,6 @@ async function example({ canvas }) {
 
 class VrHandsExample {
     static CATEGORY = 'XR';
-    static NAME = 'VR Hands';
     static example = example;
 }
 

--- a/examples/src/examples/xr/vr-movement.mjs
+++ b/examples/src/examples/xr/vr-movement.mjs
@@ -260,7 +260,6 @@ async function example({ canvas }) {
 
 class VrMovementExample {
     static CATEGORY = 'XR';
-    static NAME = 'VR Movement';
     static example = example;
 }
 

--- a/examples/src/examples/xr/xr-picking.mjs
+++ b/examples/src/examples/xr/xr-picking.mjs
@@ -184,7 +184,6 @@ async function example({ canvas }) {
 
 class XrPickingExample {
     static CATEGORY = 'XR';
-    static NAME = 'XR Picking';
     static example = example;
 }
 


### PR DESCRIPTION
Fixes #5832

We could also remove 116x `static CATEGORY`, since the category names are defined here:

https://github.com/playcanvas/engine/blob/d93d0d6a47667e8ed7422a455ab9597b4ab03091/examples/src/examples/index.mjs#L1-L10

VSCode search and replace query: `[ ]*static Name = .*\n` (replace with nothing)

Summary:

 - This PR establishes the Example class names as single source of truth (SSOT)
 - reducing redundancy
 - KISS principle

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
