### PR TITLE
[Examples] Fix error handling and display errors in Monaco editor

### DIFF
--- a/examples/scripts/generate-standalone-files.mjs
+++ b/examples/scripts/generate-standalone-files.mjs
@@ -294,23 +294,33 @@ ${exampleClass.example.toString()}
                 // console.log("Dispatch exampleLoading!");
                 const event = new CustomEvent("exampleLoading"); // just notify to clean UI, but not during hot-reload
                 window.top.dispatchEvent(event);
+            } else {
+                window.top.dispatchEvent(new CustomEvent("exampleHotReload"));
             }
-            const example = resolveFunction(files['example.mjs']);
             files['example.mjs'] = files['example.mjs'].toString();
-            const app = await example({
-                canvas,
-                deviceType,
-                data,
-                assetPath,
-                scriptsPath,
-                ammoPath,
-                basisPath,
-                dracoPath,
-                glslangPath,
-                twgslPath,
-                pcx,
-                files,
-            });
+            let app;
+            try {
+                const example = resolveFunction(files['example.mjs']);
+                app = await example({
+                    canvas,
+                    deviceType,
+                    data,
+                    assetPath,
+                    scriptsPath,
+                    ammoPath,
+                    basisPath,
+                    dracoPath,
+                    glslangPath,
+                    twgslPath,
+                    pcx,
+                    files,
+                });
+            } catch (e) {
+                console.error(e, "Stack:", e.stack);
+                window.top.dispatchEvent(new CustomEvent('exampleError', {detail: e}));
+                allowRestart = true;
+                return;
+            }
             ready = true;
             class ExampleLoadEvent extends CustomEvent {
                 constructor(deviceType) {

--- a/examples/src/app/code-editor.mjs
+++ b/examples/src/app/code-editor.mjs
@@ -24,8 +24,6 @@ const FILE_TYPE_LANGUAGES = {
     'mjs': 'javascript',
 };
 
-let monacoEditor;
-
 /**
  * @typedef {object} Props
  */
@@ -165,12 +163,11 @@ class CodeEditor extends TypedComponent {
     }
 
     /**
-     * @param {import('monaco-editor').editor.IStandaloneCodeEditor} editor
+     * @param {import('monaco-editor').editor.IStandaloneCodeEditor} editor - The Monaco editor.
      */
     editorDidMount(editor) {
         this.editor = editor;
         window.editor = editor;
-        monacoEditor = editor;
         // Hot reload code via Shift + Enter
         editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, iframeHotReload);
         const codePane = document.getElementById('codePane');
@@ -229,7 +226,7 @@ class CodeEditor extends TypedComponent {
      */
     selectFile(selectedFile) {
         this.mergeState({ selectedFile });
-        monacoEditor?.setScrollPosition({ scrollTop: 0, scrollLeft: 0 });
+        this.editor?.setScrollPosition({ scrollTop: 0, scrollLeft: 0 });
     }
 
     renderTabs() {

--- a/examples/src/app/code-editor.mjs
+++ b/examples/src/app/code-editor.mjs
@@ -104,23 +104,21 @@ class CodeEditor extends TypedComponent {
             return;
         }
         // error can be an actual error or e.g. only a string in case of throw "oh ohhh"
-        const error = event.detail;
-        if (!error.message) {
+        const { lineno, colno, filename, error, message } = event.detail;
+        const stack = error.stack || 'missing';
+        const messageMarkdown = `**Error**\n${message}\n\n**Stack**\n${stack}\n\n**Filename**${filename}\n`;
+        const realLineNumber = lineno - 2;
+        // console.log("handleExampleError", { messageMarkdown, realLineNumber });
+        if (lineno < 1 || lineno > editor.getModel().getLineCount()) {
             return;
         }
-        const message = `**Error**\n${error.message}\n\n**Stack**\n ${error.stack}`;
-        const lines = error.stack.split('\n');
-        const firstLineWithAt = lines.find(line => / *at/.test(line));
-        // -2 to map to correct line in editor
-        const line = firstLineWithAt.split(':').at(-2) - 2;
-        const lineText = editor.getModel().getLineContent(line);
-        // const oldDecorators = [];
+        const lineText = editor.getModel().getLineContent(realLineNumber);
         const newDecorator = {
-            range: new monaco.Range(line, 0, line, lineText.length),
+            range: new monaco.Range(realLineNumber, 0, realLineNumber, lineText.length),
             options: {
                 className: 'squiggly-error',
                 hoverMessage: {
-                    value: message
+                    value: messageMarkdown
                 }
             }
         };


### PR DESCRIPTION
Partly implements #5846

This PR is implementing what's needed to deal with errors in the UI, so if someone else wants to add nicer error displaying, they can do so quite easily, just listen to: `window.addEventListener('exampleError', event => console.log("TEST", event.detail));`

So far errors are only added in the UI:

![image](https://github.com/playcanvas/engine/assets/5236548/893a8375-b8f9-4793-83ea-2a8bf2a4054c)

The `allowRestart` variable also wasn't reset in case of an error, so once an error happened, the hot-reload wouldn't do anything afterwards.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
