### PR TITLE
Corrected Spelling without Any Functional Changes

### DIFF
--- a/src/core/event-handle.js
+++ b/src/core/event-handle.js
@@ -90,7 +90,7 @@ class EventHandle {
     }
 
     once(name, callback, scope = this) {
-        Debug.deprecated('Using chaning with EventHandler.once is deprecated, subscribe to an event from EventHandler directly instead.');
+        Debug.deprecated('Using chaining with EventHandler.once is deprecated, subscribe to an event from EventHandler directly instead.');
         return this.handler._addCallback(name, callback, scope, true);
     }
 


### PR DESCRIPTION
Fixes [#5855](https://github.com/playcanvas/engine/issues/5855)

* Replace ['chaning'](https://github.com/playcanvas/engine/blob/main/src/core/event-handle.js#L93) with 'chaining'.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
