### PR TITLE
[Examples] Load examples without internet

### DIFF
--- a/examples/rollup.config.js
+++ b/examples/rollup.config.js
@@ -35,6 +35,7 @@ const staticFiles = [
     { src: '../build/playcanvas.prf.js', dest: 'dist/iframe/playcanvas.prf.js' },
     { src: '../build/playcanvas-extras.js', dest: 'dist/iframe/playcanvas-extras.js' },
     { src: './node_modules/@playcanvas/observer/dist/index.js', dest: 'dist/iframe/playcanvas-observer.js' },
+    { src: './node_modules/monaco-editor/min/vs', dest: 'dist/node_modules/monaco-editor/min/vs' },
 ];
 
 // ^ = beginning of line

--- a/examples/src/app/code-editor.mjs
+++ b/examples/src/app/code-editor.mjs
@@ -2,9 +2,11 @@ import { Component } from 'react';
 import { Button, Container, Panel } from '@playcanvas/pcui/react';
 import { pcTypes } from '../assetPath.mjs';
 import { jsx } from './jsx.mjs';
-import MonacoEditor from "@monaco-editor/react";
+import MonacoEditor, { loader } from "@monaco-editor/react";
 import { iframeHotReload, iframeRequestFiles, iframeResize } from './iframeUtils.mjs';
 import { removeRedundantSpaces } from './helpers/strings.mjs';
+
+loader.config({ paths: { vs: './node_modules/monaco-editor/min/vs' } });
 
 function getShowMinimap() {
     let showMinimap = true;

--- a/examples/src/app/menu.mjs
+++ b/examples/src/app/menu.mjs
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import { Button, Container } from '@playcanvas/pcui/react';
 import { jsx } from './jsx.mjs';
+import { logo } from '../assetPath.mjs';
 //import { iframeShowStats } from './code-editor.mjs';
 
 /**
@@ -83,7 +84,7 @@ class Menu extends TypedComponent {
                 },
                 jsx("img", {
                     id: 'playcanvas-icon',
-                    src: 'https://playcanvas.com/viewer/static/playcanvas-logo.png',
+                    src: logo,
                     onClick: () => {
                         window.open("https://github.com/playcanvas/engine");
                     }

--- a/examples/src/assetPath.mjs
+++ b/examples/src/assetPath.mjs
@@ -150,3 +150,20 @@ function getThumbnailPath() {
     return href.substring(0, i) + "/examples/dist/thumbnails/";
 }
 export const thumbnailPath = getThumbnailPath();
+
+/**
+ * @example
+ * console.log(getLogo());
+ * // Via app.html, outputs:
+ * // 'http://127.0.0.1/playcanvas-engine/examples/src/static/playcanvas-logo.png'
+ * // Via `npm run serve`, outputs: './playcanvas-logo.png'
+ * @returns {string} URL of logo.
+ */
+function getLogo() {
+    const i = href.lastIndexOf("/examples/");
+    if (i === -1) { // npm run serve
+        return './playcanvas-logo.png';
+    }
+    return href.substring(0, i) + "/examples/src/static/playcanvas-logo.png";
+}
+export const logo = getLogo();


### PR DESCRIPTION
Fixes #5859 

Page loading for local development also feels faster, since Monaco downloads:

![image](https://github.com/playcanvas/engine/assets/5236548/b61e84ab-9ee9-4beb-a54f-7c5046647dae)

300ms + 180ms + etc.

Served from same `npm run serve` instance:

![image](https://github.com/playcanvas/engine/assets/5236548/a6685103-d996-47e6-9690-e0324a5e4ce9)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
