### PR TITLE
Depth bias support for WebGPU and refactor to add it to the DepthState

### DIFF
--- a/examples/src/examples/graphics/mesh-decals.mjs
+++ b/examples/src/examples/graphics/mesh-decals.mjs
@@ -7,7 +7,7 @@ import * as pc from 'playcanvas';
  */
 async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }) {
     const assets = {
-        'spark': new pc.Asset('spark', 'texture', { url: assetPath + 'textures/spark.png' })
+        heart: new pc.Asset('heart', 'texture', { url: assetPath + 'textures/heart.png' })
     };
 
     const gfxOptions = {
@@ -56,8 +56,9 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         // create material for the plane
         const planeMaterial = new pc.StandardMaterial();
         planeMaterial.gloss = 0.6;
-        planeMaterial.metalness = 0.3;
+        planeMaterial.metalness = 0.5;
         planeMaterial.useMetalness = true;
+        planeMaterial.gloss = 0.6;
         planeMaterial.update();
 
         // create plane primitive
@@ -67,9 +68,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
             material: planeMaterial
         });
 
-        // set position and scale and add it to scene
+        // set scale and add it to scene
         primitive.setLocalScale(new pc.Vec3(20, 20, 20));
-        primitive.setLocalPosition(new pc.Vec3(0, -0.01, 0));
         app.root.addChild(primitive);
 
         // Create an Entity with a omni light component
@@ -77,6 +77,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         light.addComponent("light", {
             type: "omni",
             color: new pc.Color(0.2, 0.2, 0.2),
+            intensity: 2.5,
             range: 30,
             castShadows: true,
             shadowBias: 0.1,
@@ -93,10 +94,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
         // Add the camera to the hierarchy
         app.root.addChild(camera);
-
-        // Position the camera
-        camera.translate(0, 10, 20);
-        camera.lookAt(pc.Vec3.ZERO);
 
         // Create bouncing ball model and add it to hierarchy
         const ball = new pc.Entity();
@@ -214,9 +211,12 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         material.useLighting = false;      // turn off lighting - we use emissive texture only. Also, lighting needs normal maps which we don't generate
         material.diffuse = new pc.Color(0, 0, 0);
         material.emissiveVertexColor = true;
-        material.blendType = pc.BLEND_ADDITIVE;     // additive alpha blend
+        material.blendType = pc.BLEND_ADDITIVEALPHA;     // additive alpha blend
         material.depthWrite = false;        // optimization - no need to write to depth buffer, as decals are part of the ground plane
-        material.emissiveMap = assets.spark.resource;
+        material.emissiveMap = assets.heart.resource;
+        material.opacityMap = assets.heart.resource;
+        material.depthBias = -0.1;          // depth biases to avoid z-fighting with ground plane
+        material.slopeDepthBias = -0.1;
         material.update();
 
         // Create the mesh instance
@@ -272,6 +272,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
 
             // update mesh with the streams that were updated
             updateMesh(mesh, positionsUpdated, colorsUpdated);
+
+            // orbit camera around
+            camera.setLocalPosition(20 * Math.sin(time * 0.3), 10, 20 * Math.cos(time * 0.3));
+            camera.lookAt(pc.Vec3.ZERO);
         });
     });
     return app;

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -70,7 +70,7 @@ class LightComponentSystem extends ComponentSystem {
             data.shape = LIGHTSHAPE_PUNCTUAL;
         }
 
-        const light = new Light(this.app.graphicsDevice);
+        const light = new Light(this.app.graphicsDevice, this.app.scene.clusteredLightingEnabled);
         light.type = lightTypes[data.type];
         light._node = component.entity;
         component.data.light = light;

--- a/src/platform/graphics/depth-state.js
+++ b/src/platform/graphics/depth-state.js
@@ -1,7 +1,10 @@
 import { BitPacking } from "../../core/math/bit-packing.js";
+import { StringIds } from "../../core/string-ids.js";
 import {
     FUNC_LESSEQUAL, FUNC_ALWAYS
 } from './constants.js';
+
+const stringIds = new StringIds();
 
 // masks (to only keep relevant bits)
 const funcMask = 0b111;
@@ -28,6 +31,17 @@ class DepthState {
      */
     data = 0;
 
+    _depthBias = 0;
+
+    _depthBiasSlope = 0;
+
+    /**
+     * A unique number representing the depth state. You can use this number to quickly compare
+     * two depth states for equality. The key is always maintained valid without a dirty flag,
+     * to avoid condition check at runtime, considering these change rarely.
+     */
+    key = 0;
+
     /**
      * Create a new Depth State instance.
      *
@@ -51,6 +65,7 @@ class DepthState {
      */
     set test(value) {
         this.func = value ? FUNC_LESSEQUAL : FUNC_ALWAYS;
+        this.updateKey();
     }
 
     get test() {
@@ -65,6 +80,7 @@ class DepthState {
      */
     set write(value) {
         this.data = BitPacking.set(this.data, value ? 1 : 0, writeShift);
+        this.updateKey();
     }
 
     get write() {
@@ -88,10 +104,41 @@ class DepthState {
      */
     set func(value) {
         this.data = BitPacking.set(this.data, value, funcShift, funcMask);
+        this.updateKey();
     }
 
     get func() {
         return BitPacking.get(this.data, funcShift, funcMask);
+    }
+
+    /**
+     * Constant depth bias added to each fragment's depth. Useful for decals to prevent z-fighting.
+     * Typically a small negative value (-0.1) is used to render the mesh slightly closer to the
+     * camera. Defaults to 0.
+     *
+     * @type {number}
+     */
+    set depthBias(value) {
+        this._depthBias = value;
+        this.updateKey();
+    }
+
+    get depthBias() {
+        return this._depthBias;
+    }
+
+    /**
+     * Depth bias that scales with the fragment’s slope. Defaults to 0.
+     *
+     * @type {number}
+     */
+    set depthBiasSlope(value) {
+        this._depthBiasSlope = value;
+        this.updateKey();
+    }
+
+    get depthBiasSlope() {
+        return this._depthBiasSlope;
     }
 
     /**
@@ -102,6 +149,9 @@ class DepthState {
      */
     copy(rhs) {
         this.data = rhs.data;
+        this._depthBias = rhs._depthBias;
+        this._depthBiasSlope = rhs._depthBiasSlope;
+        this.key = rhs.key;
         return this;
     }
 
@@ -115,8 +165,12 @@ class DepthState {
         return clone.copy(this);
     }
 
-    get key() {
-        return this.data;
+    updateKey() {
+        const { data, _depthBias, _depthBiasSlope } = this;
+        const key = `${data}-${_depthBias}-${_depthBiasSlope}`;
+
+        // convert string to a unique number
+        this.key = stringIds.get(key);
     }
 
     /**
@@ -126,7 +180,7 @@ class DepthState {
      * @returns {boolean} True if the depth states are equal and false otherwise.
      */
     equals(rhs) {
-        return this.data === rhs.data;
+        return this.key === rhs.key;
     }
 
     /**

--- a/src/platform/graphics/null/null-graphics-device.js
+++ b/src/platform/graphics/null/null-graphics-device.js
@@ -126,12 +126,6 @@ class NullGraphicsDevice extends GraphicsDevice {
     clear(options) {
     }
 
-    setDepthBias(on) {
-    }
-
-    setDepthBiasValues(constBias, slopeBias) {
-    }
-
     setViewport(x, y, w, h) {
     }
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2390,37 +2390,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
     }
 
-    /**
-     * Toggles the polygon offset render state.
-     *
-     * @param {boolean} on - True to enable polygon offset and false to disable it.
-     * @ignore
-     */
-    setDepthBias(on) {
-        if (this.depthBiasEnabled === on) return;
-
-        this.depthBiasEnabled = on;
-
-        if (on) {
-            this.gl.enable(this.gl.POLYGON_OFFSET_FILL);
-        } else {
-            this.gl.disable(this.gl.POLYGON_OFFSET_FILL);
-        }
-    }
-
-    /**
-     * Specifies the scale factor and units to calculate depth values. The offset is added before
-     * the depth test is performed and before the value is written into the depth buffer.
-     *
-     * @param {number} constBias - The multiplier by which an implementation-specific value is
-     * multiplied with to create a constant depth offset.
-     * @param {number} slopeBias - The scale factor for the variable depth offset for each polygon.
-     * @ignore
-     */
-    setDepthBiasValues(constBias, slopeBias) {
-        this.gl.polygonOffset(slopeBias, constBias);
-    }
-
     setStencilTest(enable) {
         if (this.stencil !== enable) {
             const gl = this.gl;
@@ -2616,6 +2585,28 @@ class WebglGraphicsDevice extends GraphicsDevice {
                     gl.enable(gl.DEPTH_TEST);
                 } else {
                     gl.disable(gl.DEPTH_TEST);
+                }
+            }
+
+            // depth bias
+            const { depthBias, depthBiasSlope } = depthState;
+            if (depthBias || depthBiasSlope) {
+
+                // enable bias
+                if (!this.depthBiasEnabled) {
+                    this.depthBiasEnabled = true;
+                    this.gl.enable(this.gl.POLYGON_OFFSET_FILL);
+                }
+
+                // values
+                gl.polygonOffset(depthBiasSlope, depthBias);
+
+            } else {
+
+                // disable bias
+                if (this.depthBiasEnabled) {
+                    this.depthBiasEnabled = false;
+                    this.gl.disable(this.gl.POLYGON_OFFSET_FILL);
                 }
             }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -731,12 +731,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         }
     }
 
-    setDepthBias(on) {
-    }
-
-    setDepthBiasValues(constBias, slopeBias) {
-    }
-
     setViewport(x, y, w, h) {
         // TODO: only execute when it changes. Also, the viewport of encoder  matches the rendering attachments,
         // so we can skip this if fullscreen

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -224,6 +224,8 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
             if (depth) {
                 depthStencil.depthWriteEnabled = depthState.write;
                 depthStencil.depthCompare = _compareFunction[depthState.func];
+                depthStencil.depthBias = depthState.depthBias;
+                depthStencil.depthBiasSlopeScale = depthState.depthBiasSlope;
             } else {
                 // if render target does not have depth buffer
                 depthStencil.depthWriteEnabled = false;

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -149,11 +149,18 @@ class Material {
     stencilBack = null;
 
     /**
-     * Offsets the output depth buffer value. Useful for decals to prevent z-fighting.
+     * Offsets the output depth buffer value. Useful for decals to prevent z-fighting. Typically
+     * a small negative value (-0.1) is used to render the mesh slightly closer to the camera.
      *
      * @type {number}
      */
-    depthBias = 0;
+    set depthBias(value) {
+        this._depthState.depthBias = value;
+    }
+
+    get depthBias() {
+        return this._depthState.depthBias;
+    }
 
     /**
      * Same as {@link Material#depthBias}, but also depends on the slope of the triangle relative
@@ -161,7 +168,13 @@ class Material {
      *
      * @type {number}
      */
-    slopeDepthBias = 0;
+    set slopeDepthBias(value) {
+        this._depthState.depthBiasSlope = value;
+    }
+
+    get slopeDepthBias() {
+        return this._depthState.depthBiasSlope;
+    }
 
     _shaderVersion = 0;
 
@@ -419,9 +432,6 @@ class Material {
         this._depthState.copy(source._depthState);
 
         this.cull = source.cull;
-
-        this.depthBias = source.depthBias;
-        this.slopeDepthBias = source.slopeDepthBias;
 
         this.stencilFront = source.stencilFront?.clone();
         if (source.stencilBack) {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -584,15 +584,7 @@ class ForwardRenderer extends Renderer {
 
                 device.setBlendState(material.blendState);
                 device.setDepthState(material.depthState);
-
                 device.setAlphaToCoverage(material.alphaToCoverage);
-
-                if (material.depthBias || material.slopeDepthBias) {
-                    device.setDepthBias(true);
-                    device.setDepthBiasValues(material.depthBias, material.slopeDepthBias);
-                } else {
-                    device.setDepthBias(false);
-                }
 
                 DebugGraphics.popGpuMarker(device);
             }

--- a/src/scene/renderer/render-pass-render-actions.js
+++ b/src/scene/renderer/render-pass-render-actions.js
@@ -268,7 +268,6 @@ class RenderPassRenderActions extends RenderPass {
             device.setBlendState(BlendState.NOBLEND);
             device.setStencilState(null, null);
             device.setAlphaToCoverage(false);
-            device.setDepthBias(false);
         }
 
         // Call layer's post-render callback if there's one

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -24,7 +24,6 @@ import { LightCamera } from './light-camera.js';
 import { UniformBufferFormat, UniformFormat } from '../../platform/graphics/uniform-buffer-format.js';
 import { BindBufferFormat, BindGroupFormat } from '../../platform/graphics/bind-group-format.js';
 import { BlendState } from '../../platform/graphics/blend-state.js';
-import { DepthState } from '../../platform/graphics/depth-state.js';
 
 function gauss(x, sigma) {
     return Math.exp(-(x * x) / (2.0 * sigma * sigma));
@@ -206,17 +205,8 @@ class ShadowRenderer {
 
     setupRenderState(device, light) {
 
-        const isClustered = this.renderer.scene.clusteredLightingEnabled;
-
-        // depth bias
-        if (device.isWebGL2 || device.isWebGPU) {
-            if (light._type === LIGHTTYPE_OMNI && !isClustered) {
-                device.setDepthBias(false);
-            } else {
-                device.setDepthBias(true);
-                device.setDepthBiasValues(light.shadowBias * -1000.0, light.shadowBias * -1000.0);
-            }
-        } else if (device.extStandardDerivatives) {
+        // webgl1 depth bias (not rendering to a shadow map, so cannot use hardware depth bias)
+        if (device.isWebGL1 && device.extStandardDerivatives) {
             if (light._type === LIGHTTYPE_OMNI) {
                 this.polygonOffset[0] = 0;
                 this.polygonOffset[1] = 0;
@@ -229,25 +219,15 @@ class ShadowRenderer {
         }
 
         // Set standard shadowmap states
+        const isClustered = this.renderer.scene.clusteredLightingEnabled;
         const gpuOrGl2 = device.isWebGL2 || device.isWebGPU;
         const useShadowSampler = isClustered ?
             light._isPcf && gpuOrGl2 :     // both spot and omni light are using shadow sampler on webgl2 when clustered
             light._isPcf && gpuOrGl2 && light._type !== LIGHTTYPE_OMNI;    // for non-clustered, point light is using depth encoded in color buffer (should change to shadow sampler)
 
         device.setBlendState(useShadowSampler ? this.blendStateNoWrite : this.blendStateWrite);
-        device.setDepthState(DepthState.DEFAULT);
+        device.setDepthState(light.shadowDepthState);
         device.setStencilState(null, null);
-    }
-
-    restoreRenderState(device) {
-
-        if (device.isWebGL2 || device.isWebGPU) {
-            device.setDepthBias(false);
-        } else if (device.extStandardDerivatives) {
-            this.polygonOffset[0] = 0;
-            this.polygonOffset[1] = 0;
-            this.polygonOffsetId.setValue(this.polygonOffset);
-        }
     }
 
     dispatchUniforms(light, shadowCam, lightRenderData, face) {
@@ -478,8 +458,6 @@ class ShadowRenderer {
 
         // render mesh instances
         this.submitCasters(lightRenderData.visibleCasters, light);
-
-        this.restoreRenderState(device);
 
         DebugGraphics.popGpuMarker(device);
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5688

- depth bias is supported on WebGPU (both Material and Shadow map)
- bias values are now part of the DepthState to avoid some conditions for each draw call - lights now stores the depth state used by it's shadow renderer, and that contains the shadow bias
- removed private API no longer needed from GraphicsDevice: `setDepthBias` and `setDepthBiasValues` 
- updated MeshDecals example to not offset the plane to avoid z-fighting with decals, but to use bias on the decal material
![Screenshot 2023-12-01 at 11 35 06](https://github.com/playcanvas/engine/assets/59932779/dfed8016-da27-4722-900f-b1bf26721e4d)
