### PR TITLE
npm run docs: fix three errors and remove non-existed argument comment

### DIFF
--- a/src/platform/graphics/depth-state.js
+++ b/src/platform/graphics/depth-state.js
@@ -39,6 +39,8 @@ class DepthState {
      * A unique number representing the depth state. You can use this number to quickly compare
      * two depth states for equality. The key is always maintained valid without a dirty flag,
      * to avoid condition check at runtime, considering these change rarely.
+     *
+     * @type {number}
      */
     key = 0;
 

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -62,6 +62,8 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * True if the back buffer should use anti-aliasing.
+     *
+     * @type {boolean}
      */
     backBufferAntialias = false;
 

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1215,10 +1215,6 @@ class Renderer {
         }
     }
 
-    /**
-     * @param {import('../composition/layer-composition.js').LayerComposition} comp - The layer
-     * composition.
-     */
     updateLightTextureAtlas() {
         this.lightTextureAtlas.update(this.localLights, this.scene.lighting);
     }


### PR DESCRIPTION
`npm run docs` currently produces these errors:

```sh
npm run docs 

> playcanvas@1.68.0-dev docs
> jsdoc -c conf-api.json

Can't generate type link. Search output for {{TYPE-ERROR}}
Can't generate type link. Search output for {{TYPE-ERROR}}
Can't generate type link. Search output for {{TYPE-ERROR}}
```

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
