### PR TITLE
[Fix] Fix compatibility with deprecated Layer.renderTarget

### DIFF
--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1077,9 +1077,8 @@ class Renderer {
         for (let i = 0; i < numCameras; i++) {
             const camera = comp.cameras[i];
 
-            // update camera and frustum
-            camera.frameUpdate(camera.renderTarget);
-            this.updateCameraFrustum(camera.camera);
+            let currentRenderTarget;
+            let cameraChanged = true;
             this._camerasRendered++;
 
             // for all of its enabled layers
@@ -1087,6 +1086,17 @@ class Renderer {
             for (let j = 0; j < layerIds.length; j++) {
                 const layer = comp.getLayerById(layerIds[j]);
                 if (layer && layer.enabled) {
+
+                    // update camera and frustum when the render target changes
+                    // TODO: This is done here to handle the backwards compatibility with the deprecated Layer.renderTarget,
+                    // when this is no longer needed, this code can be moved up to execute once per camera.
+                    const renderTarget = camera.renderTarget ?? layer.renderTarget;
+                    if (cameraChanged || renderTarget !== currentRenderTarget) {
+                        cameraChanged = false;
+                        currentRenderTarget = renderTarget;
+                        camera.frameUpdate(renderTarget);
+                        this.updateCameraFrustum(camera.camera);
+                    }
 
                     // cull each layer's non-directional lights once with each camera
                     // lights aren't collected anywhere, but marked as visible


### PR DESCRIPTION
Fix the camera where a Layer specifies renderTarget and the camera matrices were not updated for it (aspect ratio). Issue introduced in refactoring in #5738