### PR TITLE
Fix docs 404 for XrAnchorCreateCallback

### DIFF
--- a/src/framework/xr/xr-anchors.js
+++ b/src/framework/xr/xr-anchors.js
@@ -5,7 +5,7 @@ import { XrAnchor } from './xr-anchor.js';
 /**
  * Callback used by {@link XrAnchors#create}.
  *
- * @callback XrAnchorCreate
+ * @callback XrAnchorCreateCallback
  * @param {Error|null} err - The Error object if failed to create an anchor or null.
  * @param {XrAnchor|null} anchor - The anchor that is tracked against real world geometry.
  */
@@ -72,7 +72,7 @@ class XrAnchors extends EventHandler {
      * Map of callbacks to XRAnchors so that we can call its callback once
      * an anchor is updated with a pose for the first time.
      *
-     * @type {Map<XrAnchor,XrAnchorCreate>}
+     * @type {Map<XrAnchor, XrAnchorCreateCallback>}
      * @private
      */
     _callbacksAnchors = new Map();
@@ -174,8 +174,8 @@ class XrAnchors extends EventHandler {
      * Create anchor with position, rotation and a callback.
      *
      * @param {import('../../core/math/vec3.js').Vec3|XRHitTestResult} position - Position for an anchor.
-     * @param {import('../../core/math/quat.js').Quat|XrAnchorCreate} [rotation] - Rotation for an anchor.
-     * @param {XrAnchorCreate} [callback] - Callback to fire when anchor was created or failed to be created.
+     * @param {import('../../core/math/quat.js').Quat|XrAnchorCreateCallback} [rotation] - Rotation for an anchor.
+     * @param {XrAnchorCreateCallback} [callback] - Callback to fire when anchor was created or failed to be created.
      * @example
      * // create an anchor using a position and rotation
      * app.xr.anchors.create(position, rotation, function (err, anchor) {
@@ -231,7 +231,7 @@ class XrAnchors extends EventHandler {
      * Restore anchor using persistent UUID.
      *
      * @param {string} uuid - UUID string associated with persistent anchor.
-     * @param {XrAnchorCreate} [callback] - Callback to fire when anchor was created or failed to be created.
+     * @param {XrAnchorCreateCallback} [callback] - Callback to fire when anchor was created or failed to be created.
      * @example
      * // restore an anchor using uuid string
      * app.xr.anchors.restore(uuid, function (err, anchor) {


### PR DESCRIPTION
Little oversight of @Maksims, currently we have a 404 in the docs:

https://developer.playcanvas.com/en/api/pc.XrAnchors.html#create

What makes it a bit worse ... the HTTP redirection goes into an endless loop:

https://developer.playcanvas.com/en/en/en/en/en/en/en/en/en/en/en/en/en/en/en/en/en/en/en/en/api/pc.XrAnchorCreate.html

The reason is pretty much that internally a callback is defined as a typedef, but instead of having properties, callbacks have params. So in order to differentiate between the two, the `name.endsWith('Callback')` logic was introduced. We could change that logic of course and check for "does the typedef has params?", but I personally like the Callback ending (since the ending makes it immediately clear what it is).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
