### PR TITLE
Introduction of RenderPassCamera - pass describing typical render passes for the camera

### DIFF
--- a/examples/src/examples/graphics/post-processing.mjs
+++ b/examples/src/examples/graphics/post-processing.mjs
@@ -403,7 +403,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 
         // Use a render pass camera, which is a render pass that implements typical rendering of a camera.
         // Internally this sets up additional passes it needs, based on the options passed to it.
-        const renderPassCamera = new pcx.RenderPassCamera(app, {
+        const renderPassCamera = new pcx.RenderPassCameraFrame(app, {
             camera: cameraEntity.camera,    // camera used to render those passes
             samples: 2,                     // number of samples for multi-sampling
             sceneColorMap: true             // true if the scene color should be captured

--- a/extras/index.js
+++ b/extras/index.js
@@ -11,6 +11,7 @@ export { SplatData } from './splat/splat-data.js';
 export { SplatInstance } from './splat/splat-instance.js';
 
 // render passes
+export { RenderPassCamera } from './render-passes/render-pass-camera.js';
 export { RenderPassCompose } from './render-passes/render-pass-compose.js';
 export { RenderPassDownSample } from './render-passes/render-pass-downsample.js';
 export { RenderPassUpSample } from './render-passes/render-pass-upsample.js';

--- a/extras/index.js
+++ b/extras/index.js
@@ -11,7 +11,7 @@ export { SplatData } from './splat/splat-data.js';
 export { SplatInstance } from './splat/splat-instance.js';
 
 // render passes
-export { RenderPassCamera } from './render-passes/render-pass-camera.js';
+export { RenderPassCameraFrame } from './render-passes/render-pass-camera-frame.js';
 export { RenderPassCompose } from './render-passes/render-pass-compose.js';
 export { RenderPassDownSample } from './render-passes/render-pass-downsample.js';
 export { RenderPassUpSample } from './render-passes/render-pass-upsample.js';

--- a/extras/render-passes/render-pass-bloom.js
+++ b/extras/render-passes/render-pass-bloom.js
@@ -115,6 +115,15 @@ class RenderPassBloom extends RenderPass {
         }
     }
 
+    onDisable() {
+        // resize down the persistent render target
+        this.renderTargets[0]?.resize(1, 1);
+
+        // release the rest
+        this.destroyRenderPasses();
+        this.destroyRenderTargets(1);
+    }
+
     frameUpdate() {
         super.frameUpdate();
 

--- a/extras/render-passes/render-pass-camera-frame.js
+++ b/extras/render-passes/render-pass-camera-frame.js
@@ -13,7 +13,7 @@ import {
 import { RenderPassBloom } from "./render-pass-bloom.js";
 import { RenderPassCompose } from "./render-pass-compose.js";
 
-class RenderPassCamera extends RenderPass {
+class RenderPassCameraFrame extends RenderPass {
     app;
 
     scenePass;
@@ -178,4 +178,4 @@ class RenderPassCamera extends RenderPass {
     }
 }
 
-export { RenderPassCamera };
+export { RenderPassCameraFrame };

--- a/extras/render-passes/render-pass-camera.js
+++ b/extras/render-passes/render-pass-camera.js
@@ -1,0 +1,181 @@
+import {
+    LAYERID_SKYBOX,
+    LAYERID_IMMEDIATE,
+    PIXELFORMAT_RGBA8,
+    ADDRESS_CLAMP_TO_EDGE,
+    FILTER_LINEAR,
+    RenderPass,
+    RenderPassColorGrab,
+    RenderPassRenderActions,
+    RenderTarget,
+    Texture
+} from "playcanvas";
+import { RenderPassBloom } from "./render-pass-bloom.js";
+import { RenderPassCompose } from "./render-pass-compose.js";
+
+class RenderPassCamera extends RenderPass {
+    app;
+
+    scenePass;
+
+    composePass;
+
+    bloomPass;
+
+    _bloomEnabled = true;
+
+    _renderTargetScale = 1;
+
+    constructor(app, options = {}) {
+        super(app.graphicsDevice);
+        this.app = app;
+        this.options = this.sanitizeOptions(options);
+
+        this.setupRenderPasses(this.options);
+    }
+
+    sanitizeOptions(options) {
+
+        const defaults = {
+            camera: null,
+            samples: 2,
+            sceneColorMap: true,
+
+            // skybox is the last layer rendered before the grab passes
+            lastGrabLayerId: LAYERID_SKYBOX,
+            lastGrabLayerIsTransparent: false,
+
+            // immediate layer is the last layer rendered before the post-processing
+            lastSceneLayerId: LAYERID_IMMEDIATE,
+            lastSceneLayerIsTransparent: true
+        };
+
+        return Object.assign({}, defaults, options);
+    }
+
+    set renderTargetScale(value) {
+        this._renderTargetScale = value;
+        if (this.scenePass) {
+            this.scenePass.options.scaleX = value;
+            this.scenePass.options.scaleY = value;
+        }
+    }
+
+    get renderTargetScale() {
+        return this._renderTargetScale;
+    }
+
+    set bloomEnabled(value) {
+        if (this._bloomEnabled !== value) {
+            this._bloomEnabled = value;
+            this.composePass.bloomTexture = value ? this.bloomPass.bloomTexture : null;
+            this.bloomPass.enabled = value;
+        }
+    }
+
+    get bloomEnabled() {
+        return this._bloomEnabled;
+    }
+
+    set lastMipLevel(value) {
+        this.bloomPass.lastMipLevel = value;
+    }
+
+    get lastMipLevel() {
+        return this.bloomPass.lastMipLevel;
+    }
+
+    setupRenderPasses(options) {
+
+        const { app, device } = this;
+        const { scene, renderer } = app;
+        const composition = scene.layers;
+        const cameraComponent = options.camera;
+        const targetRenderTarget = cameraComponent.renderTarget;
+
+        // create a render target to render the scene into
+        const format = device.getRenderableHdrFormat() || PIXELFORMAT_RGBA8;
+        const sceneTexture = new Texture(device, {
+            name: 'SceneTexture',
+            width: 4,
+            height: 4,
+            format: format,
+            mipmaps: false,
+            minFilter: FILTER_LINEAR,
+            magFilter: FILTER_LINEAR,
+            addressU: ADDRESS_CLAMP_TO_EDGE,
+            addressV: ADDRESS_CLAMP_TO_EDGE
+        });
+
+        const rt = new RenderTarget({
+            colorBuffer: sceneTexture,
+            depth: true,
+            samples: options.samples
+        });
+
+        // ------ SCENE RENDERING WITH OPTIONAL GRAB PASS ------
+
+        // render pass that renders the scene to the render target. Render target size automatically
+        // matches the back-buffer size with the optional scale. Note that the scale parameters
+        // allow us to render the 3d scene at lower resolution, improving performance.
+        this.scenePass = new RenderPassRenderActions(device, composition, scene, renderer);
+        this.scenePass.init(rt, {
+            resizeSource: targetRenderTarget,
+            scaleX: this.renderTargetScale,
+            scaleY: this.renderTargetScale
+        });
+
+        // layers this pass renders depend on the grab pass being used
+        const lastLayerId = options.sceneColorMap ? options.lastGrabLayerId : options.lastSceneLayerId;
+        const lastLayerIsTransparent = options.sceneColorMap ? options.lastGrabLayerIsTransparent : options.lastSceneLayerIsTransparent;
+
+        let clearRenderTarget = true;
+        let lastAddedIndex = 0;
+        lastAddedIndex = this.scenePass.addLayers(composition, cameraComponent, lastAddedIndex, clearRenderTarget, lastLayerId, lastLayerIsTransparent);
+        clearRenderTarget = false;
+
+        // grab pass allowing us to copy the render scene into a texture and use for refraction
+        // the source for the copy is the texture we render the scene to
+        let colorGrabPass;
+        let scenePassTransparent;
+        if (options.sceneColorMap) {
+            colorGrabPass = new RenderPassColorGrab(device);
+            colorGrabPass.source = rt;
+
+            // if grab pass is used, render the layers after it (otherwise they were already rendered)
+            scenePassTransparent = new RenderPassRenderActions(device, composition, scene, renderer);
+            scenePassTransparent.init(rt);
+            lastAddedIndex = scenePassTransparent.addLayers(composition, cameraComponent, lastAddedIndex, clearRenderTarget, options.lastSceneLayerId, options.lastSceneLayerIsTransparent);
+        }
+
+        // ------ BLOOM GENERATION ------
+
+        // create a bloom pass, which generates bloom texture based on the just rendered scene texture
+        this.bloomPass = new RenderPassBloom(app.graphicsDevice, sceneTexture, format);
+
+        // ------ COMPOSITION ------
+
+        // create a compose pass, which combines the scene texture with the bloom texture
+        this.composePass = new RenderPassCompose(app.graphicsDevice);
+        this.composePass.sceneTexture = sceneTexture;
+        this.composePass.bloomTexture = this.bloomPass.bloomTexture;
+
+        // compose pass renders directly to target renderTarget
+        this.composePass.init(targetRenderTarget);
+
+        // ------ AFTER COMPOSITION RENDERING ------
+
+        // final pass renders directly to the target renderTarget on top of the bloomed scene, and it renders a transparent UI layer
+        const afterPass = new RenderPassRenderActions(device, composition, scene, renderer);
+        afterPass.init(targetRenderTarget);
+
+        // add all remaining layers the camera renders
+        afterPass.addLayers(composition, cameraComponent, lastAddedIndex, clearRenderTarget);
+
+        // use these prepared render passes in the order they should be executed
+        const allPasses = [this.scenePass, colorGrabPass, scenePassTransparent, this.bloomPass, this.composePass, afterPass];
+        this.beforePasses = allPasses.filter(element => element !== undefined);
+    }
+}
+
+export { RenderPassCamera };

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -96,7 +96,7 @@ class RenderPass {
     /**
      * The graphics device.
      *
-     * @type {import('../graphics/graphics-device.js').GraphicsDevice};
+     * @type {import('../graphics/graphics-device.js').GraphicsDevice}
      */
     device;
 

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -94,11 +94,19 @@ class RenderPass {
     name = '';
 
     /**
+     * The graphics device.
+     *
+     * @type {import('../graphics/graphics-device.js').GraphicsDevice};
+     */
+    device;
+
+    /**
      * True if the render pass is enabled.
      *
      * @type {boolean}
+     * @private
      */
-    enabled = true;
+    _enabled = true;
 
     /**
      * True if the render pass is enabled and execute function will be called. Note that before and
@@ -215,6 +223,8 @@ class RenderPass {
         this.depthStencilOps = new DepthStencilAttachmentOps();
 
         const numColorOps = renderTarget ? renderTarget._colorBuffers?.length : 1;
+
+        this.colorArrayOps.length = 0;
         for (let i = 0; i < numColorOps; i++) {
             const colorOps = new ColorAttachmentOps();
             this.colorArrayOps[i] = colorOps;
@@ -257,6 +267,27 @@ class RenderPass {
     }
 
     after() {
+    }
+
+    onEnable() {
+    }
+
+    onDisable() {
+    }
+
+    set enabled(value) {
+        if (this._enabled !== value) {
+            this._enabled = value;
+            if (value) {
+                this.onEnable();
+            } else {
+                this.onDisable();
+            }
+        }
+    }
+
+    get enabled() {
+        return this._enabled;
     }
 
     /**

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -26,27 +26,23 @@ class FrameGraph {
         Debug.assert(renderPass);
         renderPass.frameUpdate();
 
-        const passes = this.renderPasses;
-
         const beforePasses = renderPass.beforePasses;
         for (let i = 0; i < beforePasses.length; i++) {
             const pass = beforePasses[i];
             if (pass.enabled) {
-                pass.frameUpdate();
-                passes.push(pass);
+                this.addRenderPass(pass);
             }
         }
 
         if (renderPass.enabled) {
-            passes.push(renderPass);
+            this.renderPasses.push(renderPass);
         }
 
         const afterPasses = renderPass.afterPasses;
         for (let i = 0; i < afterPasses.length; i++) {
             const pass = afterPasses[i];
             if (pass.enabled) {
-                pass.frameUpdate();
-                passes.push(pass);
+                this.addRenderPass(pass);
             }
         }
     }

--- a/src/scene/renderer/render-pass-render-actions.js
+++ b/src/scene/renderer/render-pass-render-actions.js
@@ -48,25 +48,84 @@ class RenderPassRenderActions extends RenderPass {
         this.renderActions.push(renderAction);
     }
 
-    addLayer(camera, layer, transparent, autoClears = true) {
+    /**
+     * Adds a layer to be rendered by this render pass.
+     *
+     * @param {import('../../framework/components/camera/component.js').CameraComponent} cameraComponent -
+     * The camera component that is used to render the layers.
+     * @param {import ('../layer.js').Layer} layer - The layer to be added.
+     * @param {boolean} transparent - True if the layer is transparent.
+     * @param {boolean} autoClears - True if the render target should be cleared based on the camera
+     * and layer clear flags. Defaults to true.
+     */
+    addLayer(cameraComponent, layer, transparent, autoClears = true) {
 
-        Debug.assert(camera);
+        Debug.assert(cameraComponent);
         Debug.assert(this.renderTarget !== undefined, `Render pass needs to be initialized before adding layers`);
-        Debug.assert(camera.camera.layersSet.has(layer.id), `Camera ${camera.entity.name} does not render layer ${layer.name}.`);
+        Debug.assert(cameraComponent.camera.layersSet.has(layer.id), `Camera ${cameraComponent.entity.name} does not render layer ${layer.name}.`);
 
         const ra = new RenderAction();
         ra.renderTarget = this.renderTarget;
-        ra.camera = camera;
+        ra.camera = cameraComponent;
         ra.layer = layer;
         ra.transparent = transparent;
 
         // camera / layer clear flags
         if (autoClears) {
             const firstRa = this.renderActions.length === 0;
-            ra.setupClears(firstRa ? camera : undefined, layer);
+            ra.setupClears(firstRa ? cameraComponent : undefined, layer);
         }
 
         this.addRenderAction(ra);
+    }
+
+    /**
+     * Adds layers to be rendered by this render pass, starting from the given index of the layer
+     * in the layer composition, till the end of the layer list, or till the last layer with the
+     * given id and transparency is reached (inclusive). Note that only layers that are enabled
+     * and are rendered by the specified camera are added.
+     *
+     * @param {import('../composition/layer-composition.js').LayerComposition} composition - The
+     * layer composition containing the layers to be added, typically the scene layer composition.
+     * @param {import('../../framework/components/camera/component.js').CameraComponent} cameraComponent -
+     * The camera component that is used to render the layers.
+     * @param {number} startIndex - The index of the first layer to be considered for adding.
+     * @param {boolean} firstLayerClears - True if the first layer added should clear the render
+     * target.
+     * @param {number} [lastLayerId] - The id of the last layer to be added. If not specified, all
+     * layers till the end of the layer list are added.
+     * @param {boolean} [lastLayerIsTransparent] - True if the last layer to be added is transparent.
+     * Defaults to true.
+     * @returns {number} Returns the index of last layer added.
+     */
+    addLayers(composition, cameraComponent, startIndex, firstLayerClears, lastLayerId, lastLayerIsTransparent = true) {
+
+        const { layerList, subLayerEnabled, subLayerList } = composition;
+        let clearRenderTarget = firstLayerClears;
+
+        let index = startIndex;
+        while (index < layerList.length) {
+
+            const layer = layerList[index];
+            const isTransparent = subLayerList[index];
+            const enabled = layer.enabled && subLayerEnabled[index];
+            const renderedbyCamera = cameraComponent.camera.layersSet.has(layer.id);
+
+            // add it for rendering
+            if (enabled && renderedbyCamera) {
+                this.addLayer(cameraComponent, layer, isTransparent, clearRenderTarget);
+                clearRenderTarget = false;
+            }
+
+            index++;
+
+            // stop at last requested layer
+            if (layer.id === lastLayerId && isTransparent === lastLayerIsTransparent) {
+                break;
+            }
+        }
+
+        return index;
     }
 
     updateDirectionalShadows() {

--- a/src/scene/renderer/render-pass-render-actions.js
+++ b/src/scene/renderer/render-pass-render-actions.js
@@ -53,7 +53,7 @@ class RenderPassRenderActions extends RenderPass {
      *
      * @param {import('../../framework/components/camera/component.js').CameraComponent} cameraComponent -
      * The camera component that is used to render the layers.
-     * @param {import ('../layer.js').Layer} layer - The layer to be added.
+     * @param {import('../layer.js').Layer} layer - The layer to be added.
      * @param {boolean} transparent - True if the layer is transparent.
      * @param {boolean} autoClears - True if the render target should be cleared based on the camera
      * and layer clear flags. Defaults to true.


### PR DESCRIPTION
- new class RenderPassCamera, which internally uses other passes passes to render a typical rendering by the camera, including new post-processing. The only unsupported passes for now are depth grab passes (separate PR).

This allows new post-processing to be used by simply creating this pass and specifying it on a camera:
```
// Use a render pass camera, which is a render pass that implements typical rendering of a camera.
// Internally this sets up additional passes it needs, based on the options passed to it.
const renderPassCamera = new pcx.RenderPassCamera(app, {
    camera: cameraEntity.camera,    // camera used to render those passes
    samples: 2,                     // number of samples for multi-sampling
    sceneColorMap: true             // true if the scene color should be captured
});

// and set up these rendering passes to be used by the camera, instead of its default rendering
cameraEntity.camera.renderPasses = [renderPassCamera];
```
it exposes properties / internal passes to allow their control, for example:
```
renderPassCamera.bloomEnabled = true;

renderPassCamera.composePass.gradingEnabled = true;
renderPassCamera.composePass.gradingSaturation = 2;
```