### PR TITLE
Add JSDoc typeof support via JSDoc plugin

### DIFF
--- a/conf-api.json
+++ b/conf-api.json
@@ -1,7 +1,8 @@
 {
     "plugins": [
         "plugins/markdown",
-        "./node_modules/jsdoc-tsimport-plugin/index.js"
+        "./node_modules/jsdoc-tsimport-plugin/index.js",
+        "./node_modules/jsdoc-typeof-plugin"
     ],
     "recurseDepth": 10,
     "source": {
@@ -10,7 +11,7 @@
     "sourceType": "module",
     "tags": {
         "allowUnknownTags": true,
-        "dictionaries": ["jsdoc","closure"]
+        "dictionaries": ["jsdoc", "closure"]
     },
     "templates": {
         "cleverLinks": false,

--- a/examples/src/examples/animation/blend-trees-1d.mjs
+++ b/examples/src/examples/animation/blend-trees-1d.mjs
@@ -46,15 +46,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, data, glsla
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/animation/blend-trees-2d-cartesian.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.mjs
@@ -150,15 +150,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/animation/blend-trees-2d-directional.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-directional.mjs
@@ -107,15 +107,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/animation/component-properties.mjs
+++ b/examples/src/examples/animation/component-properties.mjs
@@ -39,13 +39,9 @@ async function example({ canvas, deviceType, data, assetPath, glslangPath, twgsl
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/animation/events.mjs
+++ b/examples/src/examples/animation/events.mjs
@@ -26,15 +26,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/animation/layer-masks.mjs
+++ b/examples/src/examples/animation/layer-masks.mjs
@@ -112,15 +112,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/animation/locomotion.mjs
+++ b/examples/src/examples/animation/locomotion.mjs
@@ -66,19 +66,12 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.AnimComponentSystem,
-        // @ts-ignore
         pc.CollisionComponentSystem,
-        // @ts-ignore
         pc.RigidBodyComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/animation/tween.mjs
+++ b/examples/src/examples/animation/tween.mjs
@@ -24,15 +24,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/area-lights.mjs
+++ b/examples/src/examples/graphics/area-lights.mjs
@@ -28,11 +28,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/area-picker.mjs
+++ b/examples/src/examples/graphics/area-picker.mjs
@@ -24,11 +24,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/asset-viewer.mjs
+++ b/examples/src/examples/graphics/asset-viewer.mjs
@@ -23,7 +23,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
 /**
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
- */    
+ */
 async function example({ canvas, deviceType, data, assetPath, scriptsPath, glslangPath, twgslPath }) {
 
     const assets = {
@@ -51,15 +51,10 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/batching-dynamic.mjs
+++ b/examples/src/examples/graphics/batching-dynamic.mjs
@@ -20,11 +20,8 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
     createOptions.batchManager = pc.BatchManager;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
 

--- a/examples/src/examples/graphics/clustered-area-lights.mjs
+++ b/examples/src/examples/graphics/clustered-area-lights.mjs
@@ -66,13 +66,9 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/clustered-lighting.mjs
+++ b/examples/src/examples/graphics/clustered-lighting.mjs
@@ -24,13 +24,9 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/clustered-omni-shadows.mjs
+++ b/examples/src/examples/graphics/clustered-omni-shadows.mjs
@@ -47,7 +47,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
 /**
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
- */    
+ */
 async function example({ canvas, deviceType, data, assetPath, scriptsPath, glslangPath, twgslPath }) {
 
     const assets = {
@@ -74,13 +74,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/clustered-spot-shadows.mjs
+++ b/examples/src/examples/graphics/clustered-spot-shadows.mjs
@@ -106,7 +106,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
 /**
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
- */    
+ */
 async function example({ canvas, deviceType, data, assetPath, scriptsPath, glslangPath, twgslPath }) {
     const observer = data;
     const assets = {
@@ -130,13 +130,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/contact-hardening-shadows.mjs
+++ b/examples/src/examples/graphics/contact-hardening-shadows.mjs
@@ -120,7 +120,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
 /**
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
- */    
+ */
 async function example({ canvas, deviceType, data, assetPath, scriptsPath, glslangPath, twgslPath, dracoPath }) {
 
     pc.WasmModule.setConfig('DracoDecoderModule', {

--- a/examples/src/examples/graphics/contact-hardening-shadows.mjs
+++ b/examples/src/examples/graphics/contact-hardening-shadows.mjs
@@ -153,15 +153,10 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/grab-pass.mjs
+++ b/examples/src/examples/graphics/grab-pass.mjs
@@ -27,9 +27,7 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/ground-fog.mjs
+++ b/examples/src/examples/graphics/ground-fog.mjs
@@ -46,13 +46,9 @@ async function example({ canvas, deviceType, files, assetPath, scriptsPath, glsl
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/hardware-instancing.mjs
+++ b/examples/src/examples/graphics/hardware-instancing.mjs
@@ -21,9 +21,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/hierarchy.mjs
+++ b/examples/src/examples/graphics/hierarchy.mjs
@@ -17,11 +17,8 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
 

--- a/examples/src/examples/graphics/layers.mjs
+++ b/examples/src/examples/graphics/layers.mjs
@@ -17,11 +17,8 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
 

--- a/examples/src/examples/graphics/light-physical-units.mjs
+++ b/examples/src/examples/graphics/light-physical-units.mjs
@@ -109,7 +109,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
 /**
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
- */    
+ */
 async function example({ canvas, deviceType, data, assetPath, scriptsPath, glslangPath, twgslPath }) {
 
     const assets = {
@@ -137,13 +137,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/lights-baked-a-o.mjs
+++ b/examples/src/examples/graphics/lights-baked-a-o.mjs
@@ -153,7 +153,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
 /**
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
- */    
+ */
 async function example({ canvas, deviceType, data, assetPath, scriptsPath, glslangPath, twgslPath }) {
 
     const assets = {
@@ -178,13 +178,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     createOptions.lightmapper = pc.Lightmapper;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/lights-baked.mjs
+++ b/examples/src/examples/graphics/lights-baked.mjs
@@ -20,11 +20,8 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
     createOptions.lightmapper = pc.Lightmapper;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
 

--- a/examples/src/examples/graphics/lights.mjs
+++ b/examples/src/examples/graphics/lights.mjs
@@ -122,11 +122,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/lines.mjs
+++ b/examples/src/examples/graphics/lines.mjs
@@ -21,11 +21,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/lit-material.mjs
+++ b/examples/src/examples/graphics/lit-material.mjs
@@ -30,15 +30,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/material-anisotropic.mjs
+++ b/examples/src/examples/graphics/material-anisotropic.mjs
@@ -24,13 +24,9 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/material-basic.mjs
+++ b/examples/src/examples/graphics/material-basic.mjs
@@ -22,11 +22,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/material-clear-coat.mjs
+++ b/examples/src/examples/graphics/material-clear-coat.mjs
@@ -26,11 +26,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/material-physical.mjs
+++ b/examples/src/examples/graphics/material-physical.mjs
@@ -22,11 +22,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/material-translucent-specular.mjs
+++ b/examples/src/examples/graphics/material-translucent-specular.mjs
@@ -22,13 +22,9 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/mesh-decals.mjs
+++ b/examples/src/examples/graphics/mesh-decals.mjs
@@ -21,11 +21,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/mesh-deformation.mjs
+++ b/examples/src/examples/graphics/mesh-deformation.mjs
@@ -23,11 +23,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/mesh-generation.mjs
+++ b/examples/src/examples/graphics/mesh-generation.mjs
@@ -21,11 +21,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/mesh-morph-many.mjs
+++ b/examples/src/examples/graphics/mesh-morph-many.mjs
@@ -25,11 +25,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/mesh-morph.mjs
+++ b/examples/src/examples/graphics/mesh-morph.mjs
@@ -17,11 +17,8 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
 

--- a/examples/src/examples/graphics/model-asset.mjs
+++ b/examples/src/examples/graphics/model-asset.mjs
@@ -21,11 +21,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.ModelComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/model-outline.mjs
+++ b/examples/src/examples/graphics/model-outline.mjs
@@ -21,13 +21,9 @@ async function example({ canvas, deviceType, scriptsPath, glslangPath, twgslPath
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/model-textured-box.mjs
+++ b/examples/src/examples/graphics/model-textured-box.mjs
@@ -21,11 +21,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/multi-render-targets.mjs
+++ b/examples/src/examples/graphics/multi-render-targets.mjs
@@ -32,17 +32,11 @@ async function example({ canvas, deviceType, files, dracoPath, assetPath, glslan
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/multi-view.mjs
+++ b/examples/src/examples/graphics/multi-view.mjs
@@ -35,7 +35,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
 /**
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
- */    
+ */
 async function example({ canvas, deviceType, data, assetPath, scriptsPath, glslangPath, twgslPath, dracoPath }) {
 
     // set up and load draco module, as the glb we load is draco compressed
@@ -66,13 +66,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/painter.mjs
+++ b/examples/src/examples/graphics/painter.mjs
@@ -20,15 +20,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.ParticleSystemComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/particles-spark.mjs
+++ b/examples/src/examples/graphics/particles-spark.mjs
@@ -20,13 +20,9 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ParticleSystemComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/portal.mjs
+++ b/examples/src/examples/graphics/portal.mjs
@@ -24,13 +24,9 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/post-effects.mjs
+++ b/examples/src/examples/graphics/post-effects.mjs
@@ -151,7 +151,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
 /**
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
- */    
+ */
 async function example({ canvas, deviceType, data, assetPath, scriptsPath, glslangPath, twgslPath, dracoPath }) {
 
     // set up and load draco module, as the glb we load is draco compressed
@@ -184,17 +184,11 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/post-processing.mjs
+++ b/examples/src/examples/graphics/post-processing.mjs
@@ -183,7 +183,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, dracoPath, pcx, data }) {
+async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath, twgslPath, dracoPath, pcx, data }) {
 
     // set up and load draco module, as the glb we load is draco compressed
     pc.WasmModule.setConfig('DracoDecoderModule', {
@@ -218,17 +218,11 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/reflection-box.mjs
+++ b/examples/src/examples/graphics/reflection-box.mjs
@@ -60,7 +60,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
 /**
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
- */    
+ */
 async function example({ canvas, deviceType, data, assetPath, scriptsPath, glslangPath, twgslPath }) {
 
     const assets = {
@@ -82,13 +82,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/reflection-cubemap.mjs
+++ b/examples/src/examples/graphics/reflection-cubemap.mjs
@@ -22,13 +22,9 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/reflection-planar.mjs
+++ b/examples/src/examples/graphics/reflection-planar.mjs
@@ -24,11 +24,8 @@ async function example({ canvas, deviceType, files, scriptsPath, assetPath, glsl
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/render-asset.mjs
+++ b/examples/src/examples/graphics/render-asset.mjs
@@ -23,11 +23,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/render-pass.mjs
+++ b/examples/src/examples/graphics/render-pass.mjs
@@ -55,11 +55,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/render-to-texture.mjs
+++ b/examples/src/examples/graphics/render-to-texture.mjs
@@ -35,15 +35,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.ParticleSystemComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/shader-burn.mjs
+++ b/examples/src/examples/graphics/shader-burn.mjs
@@ -27,11 +27,8 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/shader-compile.mjs
+++ b/examples/src/examples/graphics/shader-compile.mjs
@@ -31,11 +31,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/shader-toon.mjs
+++ b/examples/src/examples/graphics/shader-toon.mjs
@@ -26,11 +26,8 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/shader-wobble.mjs
+++ b/examples/src/examples/graphics/shader-wobble.mjs
@@ -26,11 +26,8 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/shadow-cascades.mjs
+++ b/examples/src/examples/graphics/shadow-cascades.mjs
@@ -74,7 +74,7 @@ function controls({ observer, ReactPCUI, React, jsx, fragment }) {
 /**
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
- */    
+ */
 async function example({ canvas, deviceType, data, assetPath, scriptsPath, glslangPath, twgslPath }) {
 
     const assets = {
@@ -96,13 +96,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/shapes.mjs
+++ b/examples/src/examples/graphics/shapes.mjs
@@ -18,11 +18,8 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/texture-array.mjs
+++ b/examples/src/examples/graphics/texture-array.mjs
@@ -95,13 +95,9 @@ async function example({ canvas, deviceType, data, files, assetPath, scriptsPath
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/graphics/texture-basis.mjs
+++ b/examples/src/examples/graphics/texture-basis.mjs
@@ -37,11 +37,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/input/gamepad.mjs
+++ b/examples/src/examples/input/gamepad.mjs
@@ -24,9 +24,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/input/keyboard.mjs
+++ b/examples/src/examples/input/keyboard.mjs
@@ -23,9 +23,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/input/mouse.mjs
+++ b/examples/src/examples/input/mouse.mjs
@@ -21,9 +21,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/loaders/draco-glb.mjs
+++ b/examples/src/examples/loaders/draco-glb.mjs
@@ -23,11 +23,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/loaders/glb.mjs
+++ b/examples/src/examples/loaders/glb.mjs
@@ -24,11 +24,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/loaders/gltf-export.mjs
+++ b/examples/src/examples/loaders/gltf-export.mjs
@@ -48,11 +48,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/loaders/loaders-gl.mjs
+++ b/examples/src/examples/loaders/loaders-gl.mjs
@@ -57,11 +57,8 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/loaders/splat-many.mjs
+++ b/examples/src/examples/loaders/splat-many.mjs
@@ -20,13 +20,9 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/loaders/splat.mjs
+++ b/examples/src/examples/loaders/splat.mjs
@@ -20,13 +20,9 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     createOptions.touch = new pc.TouchDevice(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/loaders/usdz-export.mjs
+++ b/examples/src/examples/loaders/usdz-export.mjs
@@ -35,11 +35,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/misc/hello-world.mjs
+++ b/examples/src/examples/misc/hello-world.mjs
@@ -17,11 +17,8 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/misc/spineboy.mjs
+++ b/examples/src/examples/misc/spineboy.mjs
@@ -24,9 +24,7 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     createOptions.graphicsDevice = device;
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/physics/compound-collision.mjs
+++ b/examples/src/examples/physics/compound-collision.mjs
@@ -25,19 +25,12 @@ async function example({ canvas, deviceType, ammoPath, glslangPath, twgslPath })
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.CollisionComponentSystem,
-        // @ts-ignore
         pc.RigidBodyComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
@@ -70,8 +63,8 @@ async function example({ canvas, deviceType, ammoPath, glslangPath, twgslPath })
 
     app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
     /**
-     * @param {pc.Color} color 
-     * @returns {pc.StandardMaterial}
+     * @param {pc.Color} color - The diffuse color.
+     * @returns {pc.StandardMaterial} The standard material.
      */
     function createMaterial(color) {
         const material = new pc.StandardMaterial();

--- a/examples/src/examples/physics/falling-shapes.mjs
+++ b/examples/src/examples/physics/falling-shapes.mjs
@@ -29,19 +29,12 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.CollisionComponentSystem,
-        // @ts-ignore
         pc.RigidBodyComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/physics/offset-collision.mjs
+++ b/examples/src/examples/physics/offset-collision.mjs
@@ -32,19 +32,12 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.CollisionComponentSystem,
-        // @ts-ignore
         pc.RigidBodyComponentSystem,
-        // @ts-ignore
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/physics/raycast.mjs
+++ b/examples/src/examples/physics/raycast.mjs
@@ -30,19 +30,12 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.CollisionComponentSystem,
-        // @ts-ignore
         pc.RigidBodyComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/physics/vehicle.mjs
+++ b/examples/src/examples/physics/vehicle.mjs
@@ -34,17 +34,11 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, ammoPath, g
     createOptions.keyboard = new pc.Keyboard(document.body);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.ModelComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem,
-        // @ts-ignore
         pc.CollisionComponentSystem,
-        // @ts-ignore
         pc.RigidBodyComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/button-basic.mjs
+++ b/examples/src/examples/user-interface/button-basic.mjs
@@ -25,15 +25,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/button-sprite.mjs
+++ b/examples/src/examples/user-interface/button-sprite.mjs
@@ -27,15 +27,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/custom-shader.mjs
+++ b/examples/src/examples/user-interface/custom-shader.mjs
@@ -27,15 +27,10 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/layout-group.mjs
+++ b/examples/src/examples/user-interface/layout-group.mjs
@@ -24,19 +24,12 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem,
-        // @ts-ignore
         pc.LayoutGroupComponentSystem,
-        // @ts-ignore
         pc.LayoutChildComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/particle-system.mjs
+++ b/examples/src/examples/user-interface/particle-system.mjs
@@ -25,17 +25,11 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem,
-        // @ts-ignore
         pc.ParticleSystemComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/scroll-view.mjs
+++ b/examples/src/examples/user-interface/scroll-view.mjs
@@ -24,21 +24,13 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem,
-        // @ts-ignore
         pc.LayoutGroupComponentSystem,
-        // @ts-ignore
         pc.ScrollViewComponentSystem,
-        // @ts-ignore
         pc.ScrollbarComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/text-auto-font-size.mjs
+++ b/examples/src/examples/user-interface/text-auto-font-size.mjs
@@ -25,21 +25,13 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem,
-        // @ts-ignore
         pc.LayoutGroupComponentSystem,
-        // @ts-ignore
         pc.ScrollViewComponentSystem,
-        // @ts-ignore
         pc.ScrollbarComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/text-emojis.mjs
+++ b/examples/src/examples/user-interface/text-emojis.mjs
@@ -24,23 +24,14 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem,
-        // @ts-ignore
         pc.LayoutGroupComponentSystem,
-        // @ts-ignore
         pc.ScrollViewComponentSystem,
-        // @ts-ignore
         pc.ScrollbarComponentSystem,
-        // @ts-ignore
         pc.LayoutChildComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/text-localization.mjs
+++ b/examples/src/examples/user-interface/text-localization.mjs
@@ -24,15 +24,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/text-typewriter.mjs
+++ b/examples/src/examples/user-interface/text-typewriter.mjs
@@ -25,15 +25,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/text.mjs
+++ b/examples/src/examples/user-interface/text.mjs
@@ -23,21 +23,13 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem,
-        // @ts-ignore
         pc.LayoutGroupComponentSystem,
-        // @ts-ignore
         pc.ScrollViewComponentSystem,
-        // @ts-ignore
         pc.ScrollbarComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/world-to-screen.mjs
+++ b/examples/src/examples/user-interface/world-to-screen.mjs
@@ -25,17 +25,11 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/user-interface/world-ui.mjs
+++ b/examples/src/examples/user-interface/world-ui.mjs
@@ -26,19 +26,12 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     createOptions.elementInput = new pc.ElementInput(canvas);
 
     createOptions.componentSystems = [
-        // @ts-ignore
         pc.RenderComponentSystem,
-        // @ts-ignore
         pc.CameraComponentSystem,
-        // @ts-ignore
         pc.LightComponentSystem,
-        // @ts-ignore
         pc.ScreenComponentSystem,
-        // @ts-ignore
         pc.ButtonComponentSystem,
-        // @ts-ignore
         pc.ElementComponentSystem,
-        // @ts-ignore
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [

--- a/examples/src/examples/xr/ar-mesh-detection.mjs
+++ b/examples/src/examples/xr/ar-mesh-detection.mjs
@@ -5,7 +5,7 @@ import * as pc from 'playcanvas';
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas }) {
+async function example({ canvas, assetPath }) {
     /**
      * @param {string} msg - The message.
      */

--- a/examples/src/examples/xr/ar-plane-detection.mjs
+++ b/examples/src/examples/xr/ar-plane-detection.mjs
@@ -5,7 +5,7 @@ import * as pc from 'playcanvas';
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas }) {
+async function example({ canvas, assetPath }) {
     /**
      * @param {string} msg - The message.
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playcanvas",
-  "version": "1.67.0-dev",
+  "version": "1.68.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playcanvas",
-      "version": "1.67.0-dev",
+      "version": "1.68.0-dev",
       "license": "MIT",
       "dependencies": {
         "@types/webxr": "^0.5.7",
@@ -30,6 +30,7 @@
         "fflate": "^0.8.1",
         "jsdoc": "^4.0.2",
         "jsdoc-tsimport-plugin": "^1.0.5",
+        "jsdoc-typeof-plugin": "^1.0.0",
         "karma": "^6.4.2",
         "karma-chrome-launcher": "^3.2.0",
         "karma-mocha": "2.0.1",
@@ -5498,6 +5499,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/jsdoc-typeof-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-typeof-plugin/-/jsdoc-typeof-plugin-1.0.0.tgz",
+      "integrity": "sha512-iG/LKaVnwRgi+EET6oi6uWNi+hVSUNM1t1NAywfCPIayDgsbQ4LWynnqO4IDTOPS7qObEWLJOjoqNby8+oiqXg==",
+      "dev": true
     },
     "node_modules/jsdoc/node_modules/escape-string-regexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "fflate": "^0.8.1",
     "jsdoc": "^4.0.2",
     "jsdoc-tsimport-plugin": "^1.0.5",
+    "jsdoc-typeof-plugin": "^1.0.0",
     "karma": "^6.4.2",
     "karma-chrome-launcher": "^3.2.0",
     "karma-mocha": "2.0.1",

--- a/src/framework/app-options.js
+++ b/src/framework/app-options.js
@@ -100,7 +100,7 @@ class AppOptions {
     /**
      * The resource handlers the app requires.
      *
-     * @type {typeof import('./handlers/handler.js').ResourceHandler[]}
+     * @type {import('./handlers/handler.js').ResourceHandler[]}
      */
     resourceHandlers = [];
 }

--- a/src/framework/app-options.js
+++ b/src/framework/app-options.js
@@ -93,14 +93,14 @@ class AppOptions {
     /**
      * The component systems the app requires.
      *
-     * @type {import('./components/system.js').ComponentSystem[]}
+     * @type {typeof import('./components/system.js').ComponentSystem[]}
      */
     componentSystems = [];
 
     /**
      * The resource handlers the app requires.
      *
-     * @type {import('./handlers/handler.js').ResourceHandler[]}
+     * @type {typeof import('./handlers/handler.js').ResourceHandler[]}
      */
     resourceHandlers = [];
 }


### PR DESCRIPTION
We had many issues around `typeof` and at some point simply settled on... the wrong type.

This caused a trail of `ts-ignore` comments, but I never realized that JSDoc has a plugin for exactly this issue: jsdoc-typeof-plugin

So this PR simply integrates that plugin and since now we have a correct type, we can let go of maaany `ts-ignore` comments.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
