### PR TITLE
fix opacity conversion when 0.0, remove extraneous clamp

### DIFF
--- a/extras/splat/splat.js
+++ b/extras/splat/splat.js
@@ -198,8 +198,9 @@ class Splat {
                 data[i * 4 + 2] = math.clamp((0.5 + SH_C0 * c2[i]) * 255, 0, 255);
             }
 
-            // opacity
-            data[i * 4 + 3] = opacity ? math.clamp(sigmoid(opacity[i]) * 255, 0, 255) : 255;
+            
+            // opacity (-inf..+inf, at 0.0 it returns 0.5)
+            data[i * 4 + 3] = (opacity !== undefined) ? sigmoid(opacity[i]) * 255 : 255;
         }
 
         texture.unlock();


### PR DESCRIPTION
The opacity value ranges from NEGATIVE_INFINITY to POSITIVE_INFINITY and at opacity === 0.0 the sigmoid will return 0.5.
The original code would convert this to an alpha of 255 instead of 128.
It is possible that the condition is intended to catch an undefined opacity, so I have made that explicit. If this is not the case, then the ternary condition can be removed entirely. However if there is a possibility of opacity === null, that should be handled as well.
The sigmoid function cannot return < 0 or > 1 so the clamp is not needed.

Fixes #
I don't think there's bug report, but I've been having problems with opacity and went into the engine to find out why.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
