### PR TITLE
Disable MSAA for splat examples

### DIFF
--- a/examples/src/examples/loaders/splat-many.mjs
+++ b/examples/src/examples/loaders/splat-many.mjs
@@ -10,7 +10,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     const gfxOptions = {
         deviceTypes: [deviceType],
         glslangUrl: glslangPath + 'glslang.js',
-        twgslUrl: twgslPath + 'twgsl.js'
+        twgslUrl: twgslPath + 'twgsl.js',
+
+        // disable antialiasing as gaussian splats do not benefit from it and it's expensive
+        antialias: false
     };
 
     const device = await pc.createGraphicsDevice(canvas, gfxOptions);

--- a/examples/src/examples/loaders/splat.mjs
+++ b/examples/src/examples/loaders/splat.mjs
@@ -10,7 +10,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     const gfxOptions = {
         deviceTypes: [deviceType],
         glslangUrl: glslangPath + 'glslang.js',
-        twgslUrl: twgslPath + 'twgsl.js'
+        twgslUrl: twgslPath + 'twgsl.js',
+
+        // disable antialiasing as gaussian splats do not benefit from it and it's expensive
+        antialias: false
     };
 
     const device = await pc.createGraphicsDevice(canvas, gfxOptions);


### PR DESCRIPTION
- it almost doubles the GPU cost to have it enabled, for no visibie benefit as splats are soft-edged already