### PR TITLE
Exposing sky properties fixes

### DIFF
--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -219,12 +219,12 @@ class Scene extends EventHandler {
         this._skyboxLuminance = 0;
         this._skyboxMip = 0;
 
-        this._skyboxScale = new Vec3(1, 1, 1);
         this._skyboxPosition = new Vec3();
         this._skyboxRotationShaderInclude = false;
         this._skyboxRotation = new Quat();
         this._skyboxRotationMat3 = new Mat3();
         this._skyboxRotationMat4 = new Mat4();
+        this._skyboxScale = new Vec3(1, 1, 1);
 
         this._skyboxTripod = new Vec3();
 
@@ -618,21 +618,6 @@ class Scene extends EventHandler {
     }
 
     /**
-     * The scale of the skybox to be displayed. Defaults to {@link Vec3.ONE}.
-     *
-     * @type {Vec3}
-     */
-    set skyboxScale(value) {
-        if (!this._skyboxScale.equals(value)) {
-            this._skyboxScale.copy(value);
-        }
-    }
-
-    get skyboxScale() {
-        return this._skyboxScale;
-    }
-
-    /**
      * The position of the skybox to be displayed. Defaults to {@link Vec3.ZERO}.
      *
      * @type {Vec3}
@@ -675,6 +660,21 @@ class Scene extends EventHandler {
 
     get skyboxRotation() {
         return this._skyboxRotation;
+    }
+
+    /**
+     * The scale of the skybox to be displayed. Defaults to {@link Vec3.ONE}.
+     *
+     * @type {Vec3}
+     */
+    set skyboxScale(value) {
+        if (!this._skyboxScale.equals(value)) {
+            this._skyboxScale.copy(value);
+        }
+    }
+
+    get skyboxScale() {
+        return this._skyboxScale;
     }
 
     /**

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -10,7 +10,7 @@ import { Mat4 } from '../core/math/mat4.js';
 import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
 import { PIXELFORMAT_RGBA8, ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR } from '../platform/graphics/constants.js';
 
-import { BAKE_COLORDIR, FOG_NONE, GAMMA_SRGB, LAYERID_IMMEDIATE } from './constants.js';
+import { BAKE_COLORDIR, FOG_NONE, GAMMA_SRGB, LAYERID_IMMEDIATE, SKYTYPE_INFINITE } from './constants.js';
 import { LightingParams } from './lighting/lighting-params.js';
 import { Sky } from './skybox/sky.js';
 import { Immediate } from './immediate/immediate.js';
@@ -219,10 +219,14 @@ class Scene extends EventHandler {
         this._skyboxLuminance = 0;
         this._skyboxMip = 0;
 
+        this._skyboxScale = new Vec3(1, 1, 1);
+        this._skyboxPosition = new Vec3();
         this._skyboxRotationShaderInclude = false;
         this._skyboxRotation = new Quat();
         this._skyboxRotationMat3 = new Mat3();
         this._skyboxRotationMat4 = new Mat4();
+
+        this._skyboxTripod = new Vec3();
 
         // ambient light lightmapping properties
         this._ambientBakeNumSamples = 1;
@@ -552,6 +556,19 @@ class Scene extends EventHandler {
     }
 
     /**
+     * Type of sky. Defaults to {@link SKYTYPE_INFINITE}.
+     *
+     * @type {number}
+     */
+    set skyType(value) {
+        this._sky.type = value;
+    }
+
+    get skyType() {
+        return this._sky.type;
+    }
+
+    /**
      * Multiplier for skybox intensity. Defaults to 1. Unused if physical units are used.
      *
      * @type {number}
@@ -601,6 +618,36 @@ class Scene extends EventHandler {
     }
 
     /**
+     * The scale of the skybox to be displayed. Defaults to {@link Vec3.ONE}.
+     *
+     * @type {Vec3}
+     */
+    set skyboxScale(value) {
+        if (!this._skyboxScale.equals(value)) {
+            this._skyboxScale.copy(value);
+        }
+    }
+
+    get skyboxScale() {
+        return this._skyboxScale;
+    }
+
+    /**
+     * The position of the skybox to be displayed. Defaults to {@link Vec3.ZERO}.
+     *
+     * @type {Vec3}
+     */
+    set skyboxPosition(value) {
+        if (!this._skyboxPosition.equals(value)) {
+            this._skyboxPosition.copy(value);
+        }
+    }
+
+    get skyboxPosition() {
+        return this._skyboxPosition;
+    }
+
+    /**
      * The rotation of the skybox to be displayed. Defaults to {@link Quat.IDENTITY}.
      *
      * @type {Quat}
@@ -628,6 +675,21 @@ class Scene extends EventHandler {
 
     get skyboxRotation() {
         return this._skyboxRotation;
+    }
+
+    /**
+     * The tripod position of the skybox to be displayed. Defaults to {@link Vec3.ZERO}.
+     *
+     * @type {Vec3}
+     */
+    set skyboxTripod(value) {
+        if (!this._skyboxTripod.equals(value)) {
+            this._skyboxTripod.copy(value);
+        }
+    }
+
+    get skyboxTripod() {
+        return this._skyboxTripod;
     }
 
     /**
@@ -694,12 +756,25 @@ class Scene extends EventHandler {
         this.lightmapMaxResolution = render.lightmapMaxResolution;
         this.lightmapMode = render.lightmapMode;
         this.exposure = render.exposure;
+        this.skyType = render.skyType ?? SKYTYPE_INFINITE;
         this._skyboxIntensity = render.skyboxIntensity ?? 1;
         this._skyboxLuminance = render.skyboxLuminance ?? 20000;
         this._skyboxMip = render.skyboxMip ?? 0;
 
+        if (render.skyboxScale) {
+            this.skyboxScale = new Vec3(render.skyboxScale[0], render.skyboxScale[1], render.skyboxScale[2]);
+        }
+
+        if (render.skyboxPosition) {
+            this.skyboxPosition = new Vec3(render.skyboxPosition[0], render.skyboxPosition[1], render.skyboxPosition[2]);
+        }
+
         if (render.skyboxRotation) {
             this.skyboxRotation = (new Quat()).setFromEulerAngles(render.skyboxRotation[0], render.skyboxRotation[1], render.skyboxRotation[2]);
+        }
+
+        if (render.skyboxTripod) {
+            this.skyboxTripod = new Vec3(render.skyboxTripod[0], render.skyboxTripod[1], render.skyboxTripod[2]);
         }
 
         this.clusteredLightingEnabled = render.clusteredLightingEnabled ?? false;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -219,14 +219,10 @@ class Scene extends EventHandler {
         this._skyboxLuminance = 0;
         this._skyboxMip = 0;
 
-        this._skyboxPosition = new Vec3();
         this._skyboxRotationShaderInclude = false;
         this._skyboxRotation = new Quat();
         this._skyboxRotationMat3 = new Mat3();
         this._skyboxRotationMat4 = new Mat4();
-        this._skyboxScale = new Vec3(1, 1, 1);
-
-        this._skyboxTripod = new Vec3();
 
         // ambient light lightmapping properties
         this._ambientBakeNumSamples = 1;
@@ -605,21 +601,6 @@ class Scene extends EventHandler {
     }
 
     /**
-     * The position of the skybox to be displayed. Defaults to {@link Vec3.ZERO}.
-     *
-     * @type {Vec3}
-     */
-    set skyboxPosition(value) {
-        if (!this._skyboxPosition.equals(value)) {
-            this._skyboxPosition.copy(value);
-        }
-    }
-
-    get skyboxPosition() {
-        return this._skyboxPosition;
-    }
-
-    /**
      * The rotation of the skybox to be displayed. Defaults to {@link Quat.IDENTITY}.
      *
      * @type {Quat}
@@ -647,36 +628,6 @@ class Scene extends EventHandler {
 
     get skyboxRotation() {
         return this._skyboxRotation;
-    }
-
-    /**
-     * The scale of the skybox to be displayed. Defaults to {@link Vec3.ONE}.
-     *
-     * @type {Vec3}
-     */
-    set skyboxScale(value) {
-        if (!this._skyboxScale.equals(value)) {
-            this._skyboxScale.copy(value);
-        }
-    }
-
-    get skyboxScale() {
-        return this._skyboxScale;
-    }
-
-    /**
-     * The tripod position of the skybox to be displayed. Defaults to {@link Vec3.ZERO}.
-     *
-     * @type {Vec3}
-     */
-    set skyboxTripod(value) {
-        if (!this._skyboxTripod.equals(value)) {
-            this._skyboxTripod.copy(value);
-        }
-    }
-
-    get skyboxTripod() {
-        return this._skyboxTripod;
     }
 
     /**
@@ -747,21 +698,11 @@ class Scene extends EventHandler {
         this._skyboxLuminance = render.skyboxLuminance ?? 20000;
         this._skyboxMip = render.skyboxMip ?? 0;
 
-        if (render.skyboxScale) {
-            this.skyboxScale = new Vec3(render.skyboxScale[0], render.skyboxScale[1], render.skyboxScale[2]);
-        }
-
-        if (render.skyboxPosition) {
-            this.skyboxPosition = new Vec3(render.skyboxPosition[0], render.skyboxPosition[1], render.skyboxPosition[2]);
-        }
-
         if (render.skyboxRotation) {
             this.skyboxRotation = (new Quat()).setFromEulerAngles(render.skyboxRotation[0], render.skyboxRotation[1], render.skyboxRotation[2]);
         }
 
-        if (render.skyboxTripod) {
-            this.skyboxTripod = new Vec3(render.skyboxTripod[0], render.skyboxTripod[1], render.skyboxTripod[2]);
-        }
+        this.sky.applySettings(render);
 
         this.clusteredLightingEnabled = render.clusteredLightingEnabled ?? false;
         this.lighting.applySettings(render);

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -10,7 +10,7 @@ import { Mat4 } from '../core/math/mat4.js';
 import { GraphicsDeviceAccess } from '../platform/graphics/graphics-device-access.js';
 import { PIXELFORMAT_RGBA8, ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR } from '../platform/graphics/constants.js';
 
-import { BAKE_COLORDIR, FOG_NONE, GAMMA_SRGB, LAYERID_IMMEDIATE, SKYTYPE_INFINITE } from './constants.js';
+import { BAKE_COLORDIR, FOG_NONE, GAMMA_SRGB, LAYERID_IMMEDIATE } from './constants.js';
 import { LightingParams } from './lighting/lighting-params.js';
 import { Sky } from './skybox/sky.js';
 import { Immediate } from './immediate/immediate.js';
@@ -556,19 +556,6 @@ class Scene extends EventHandler {
     }
 
     /**
-     * Type of sky. Defaults to {@link SKYTYPE_INFINITE}.
-     *
-     * @type {number}
-     */
-    set skyType(value) {
-        this._sky.type = value;
-    }
-
-    get skyType() {
-        return this._sky.type;
-    }
-
-    /**
      * Multiplier for skybox intensity. Defaults to 1. Unused if physical units are used.
      *
      * @type {number}
@@ -756,7 +743,6 @@ class Scene extends EventHandler {
         this.lightmapMaxResolution = render.lightmapMaxResolution;
         this.lightmapMode = render.lightmapMode;
         this.exposure = render.exposure;
-        this.skyType = render.skyType ?? SKYTYPE_INFINITE;
         this._skyboxIntensity = render.skyboxIntensity ?? 1;
         this._skyboxLuminance = render.skyboxLuminance ?? 20000;
         this._skyboxMip = render.skyboxMip ?? 0;

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -61,7 +61,7 @@ class Sky {
 
 
     applySettings(render) {
-        this.type = render.skyType;
+        this.type = render.skyType ?? this.type;
         this.node.setLocalPosition(new Vec3(render.skyMeshPosition ?? [0, 0, 0]));
         this.node.setLocalEulerAngles(new Vec3(render.skyMeshRotation ?? [0, 0, 0]));
         this.node.setLocalScale(new Vec3(render.skyMeshScale ?? [1, 1, 1]));

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -61,6 +61,7 @@ class Sky {
 
 
     applySettings(render) {
+        this.type = render.skyType;
         this.node.setLocalPosition(new Vec3(render.skyMeshPosition ?? [0, 0, 0]));
         this.node.setLocalEulerAngles(new Vec3(render.skyMeshRotation ?? [0, 0, 0]));
         this.node.setLocalScale(new Vec3(render.skyMeshScale ?? [1, 1, 1]));

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -61,7 +61,7 @@ class Sky {
 
 
     applySettings(render) {
-        this.type = render.skyType ?? this.type;
+        this.type = render.skyType ?? SKYTYPE_INFINITE;
         this.node.setLocalPosition(new Vec3(render.skyMeshPosition ?? [0, 0, 0]));
         this.node.setLocalEulerAngles(new Vec3(render.skyMeshRotation ?? [0, 0, 0]));
         this.node.setLocalScale(new Vec3(render.skyMeshScale ?? [1, 1, 1]));

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -26,22 +26,6 @@ class Sky {
     _center = new Vec3(0, 1, 0);
 
     /**
-     * The position of the sky.
-     *
-     * @type {Vec3}
-     * @private
-     */
-    position = new Vec3(0, 0, 0);
-
-    /**
-     * The scale of the sky.
-     *
-     * @type {Vec3}
-     * @private
-     */
-    scale = new Vec3(1, 1, 1);
-
-    /**
      * The sky mesh of the scene.
      *
      * @type {SkyMesh|null}
@@ -77,14 +61,10 @@ class Sky {
 
 
     applySettings(render) {
-        if (render.skyPosition) {
-            this.position = new Vec3(render.skyPosition[0], render.skyPosition[1], render.skyPosition[2]);
-        }
-        if (render.skyScale) {
-            this.scale = new Vec3(render.skyScale[0], render.skyScale[1], render.skyScale[2]);
-        }
-        if (render.skyTripod) {
-            this.center = new Vec3(render.skyTripod[0], render.skyTripod[1], render.skyTripod[2]);
+        this.node.setLocalPosition(new Vec3(render.skyPosition ?? [0, 0, 0]));
+        this.node.setLocalScale(new Vec3(render.skyScale ?? [1, 1, 1]));
+        if (render.skyCenter) {
+            this._center = new Vec3(render.skyCenter);
         }
     }
 

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -26,6 +26,22 @@ class Sky {
     _center = new Vec3(0, 1, 0);
 
     /**
+     * The position of the sky.
+     *
+     * @type {Vec3}
+     * @private
+     */
+    position = new Vec3(0, 0, 0);
+
+    /**
+     * The scale of the sky.
+     *
+     * @type {Vec3}
+     * @private
+     */
+    scale = new Vec3(1, 1, 1);
+
+    /**
      * The sky mesh of the scene.
      *
      * @type {SkyMesh|null}
@@ -57,6 +73,19 @@ class Sky {
 
         this.centerArray = new Float32Array(3);
         this.projectedSkydomeCenterId = this.device.scope.resolve('projectedSkydomeCenter');
+    }
+
+
+    applySettings(render) {
+        if (render.skyPosition) {
+            this.position = new Vec3(render.skyPosition[0], render.skyPosition[1], render.skyPosition[2]);
+        }
+        if (render.skyScale) {
+            this.scale = new Vec3(render.skyScale[0], render.skyScale[1], render.skyScale[2]);
+        }
+        if (render.skyTripod) {
+            this.center = new Vec3(render.skyTripod[0], render.skyTripod[1], render.skyTripod[2]);
+        }
     }
 
     /**

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -61,9 +61,9 @@ class Sky {
 
 
     applySettings(render) {
-        this.node.setLocalPosition(new Vec3(render.skyPosition ?? [0, 0, 0]));
-        this.node.setLocalEulerAngles(new Vec3(render.skyRotation ?? [0, 0, 0]));
-        this.node.setLocalScale(new Vec3(render.skyScale ?? [1, 1, 1]));
+        this.node.setLocalPosition(new Vec3(render.skyMeshPosition ?? [0, 0, 0]));
+        this.node.setLocalEulerAngles(new Vec3(render.skyMeshRotation ?? [0, 0, 0]));
+        this.node.setLocalScale(new Vec3(render.skyMeshScale ?? [1, 1, 1]));
         if (render.skyCenter) {
             this._center = new Vec3(render.skyCenter);
         }

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -62,6 +62,7 @@ class Sky {
 
     applySettings(render) {
         this.node.setLocalPosition(new Vec3(render.skyPosition ?? [0, 0, 0]));
+        this.node.setLocalEulerAngles(new Vec3(render.skyRotation ?? [0, 0, 0]));
         this.node.setLocalScale(new Vec3(render.skyScale ?? [1, 1, 1]));
         if (render.skyCenter) {
             this._center = new Vec3(render.skyCenter);


### PR DESCRIPTION
Extension of the PR [https://github.com/playcanvas/engine/pull/5901](url)

Set the sky type from render property `skyType` in applySettings.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
