### PR TITLE
Initial experimental support for static TAA

### DIFF
--- a/extras/index.js
+++ b/extras/index.js
@@ -16,3 +16,4 @@ export { RenderPassCompose } from './render-passes/render-pass-compose.js';
 export { RenderPassDownSample } from './render-passes/render-pass-downsample.js';
 export { RenderPassUpSample } from './render-passes/render-pass-upsample.js';
 export { RenderPassBloom } from './render-passes/render-pass-bloom.js';
+export { RenderPassTAA } from './render-passes/render-pass-taa.js';

--- a/extras/render-passes/render-pass-taa.js
+++ b/extras/render-passes/render-pass-taa.js
@@ -1,0 +1,93 @@
+import {
+    FILTER_LINEAR, ADDRESS_CLAMP_TO_EDGE,
+    BLENDEQUATION_ADD, BLENDMODE_CONSTANT, BLENDMODE_ONE_MINUS_CONSTANT,
+    Color,
+    BlendState,
+    RenderPassShaderQuad,
+    Texture,
+    RenderTarget
+} from "playcanvas";
+
+class RenderPassTAA extends RenderPassShaderQuad {
+    /**
+     * @type {Texture}
+     */
+    accumulationTexture;
+
+    constructor(device, sourceTexture) {
+        super(device);
+        this.sourceTexture = sourceTexture;
+
+        this.shader = this.createQuadShader('TaaResolveShader', `
+
+            uniform sampler2D sourceTexture;
+            varying vec2 uv0;
+
+            void main()
+            {
+                vec4 src = texture2D(sourceTexture, uv0);
+                gl_FragColor = src;
+            }`
+        );
+
+        this.sourceTextureId = device.scope.resolve('sourceTexture');
+
+        this.blendState = new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_CONSTANT, BLENDMODE_ONE_MINUS_CONSTANT);
+
+        this.setup();
+    }
+
+    destroy() {
+        if (this.renderTarget) {
+            this.renderTarget.destroyTextureBuffers();
+            this.renderTarget.destroy();
+            this.renderTarget = null;
+        }
+    }
+
+    setup() {
+
+        const { device } = this;
+
+        // create the accumulation render target
+        const texture = new Texture(device, {
+            name: 'TAA Accumulation Texture',
+            width: 4,
+            height: 4,
+            format: this.sourceTexture.format,
+            mipmaps: false,
+            minFilter: FILTER_LINEAR,
+            magFilter: FILTER_LINEAR,
+            addressU: ADDRESS_CLAMP_TO_EDGE,
+            addressV: ADDRESS_CLAMP_TO_EDGE
+        });
+        this.accumulationTexture = texture;
+
+        const rt = new RenderTarget({
+            colorBuffer: texture,
+            depth: false
+        });
+
+        this.init(rt, {
+            resizeSource: this.sourceTexture
+        });
+
+        // clear it to black initially
+        this.setClearColor(Color.BLACK);
+    }
+
+    execute() {
+        this.sourceTextureId.setValue(this.sourceTexture);
+
+        // TODO: add this to the parent class
+        const blend = 0.05;
+        this.device.setBlendColor(blend, blend, blend, blend);
+
+        super.execute();
+
+        // disable clearing
+        this.setClearColor();
+    }
+}
+
+export { RenderPassTAA };

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -492,6 +492,22 @@ class CameraComponent extends Component {
     }
 
     /**
+     * A jitter intensity applied in the projection matrix. Used for jittered sampling by TAA.
+     * A value of 1 represents a jitter in the range of [-1 to 1] of a pixel. Smaller values result
+     * in a crisper yet more aliased outcome, whereas increased values produce smoother but blurred
+     * result. Defaults to 0, representing no jitter.
+     *
+     * @type {number}
+     */
+    set jitter(value) {
+        this._camera.jitter = value;
+    }
+
+    get jitter() {
+        return this._camera.jitter;
+    }
+
+    /**
      * The distance from the camera before which no rendering will take place. Defaults to 0.1.
      *
      * @type {number}

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -524,6 +524,20 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
+     * Sets the constant blend color and alpha values used with {@link BLENDMODE_CONSTANT} and
+     * {@link BLENDMODE_ONE_MINUS_CONSTANT} factors specified in {@link BlendState}. Defaults to
+     * [0, 0, 0, 0].
+     *
+     * @param {number} r - The value for red.
+     * @param {number} g - The value for green.
+     * @param {number} b - The value for blue.
+     * @param {number} a - The value for alpha.
+     */
+    setBlendColor(r, g, b, a) {
+        Debug.assert(false);
+    }
+
+    /**
      * Sets the specified depth state.
      *
      * @param {DepthState} depthState - New depth state.

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -4,6 +4,7 @@ import { platform } from '../../core/platform.js';
 import { now } from '../../core/time.js';
 import { Vec2 } from '../../core/math/vec2.js';
 import { Tracing } from '../../core/tracing.js';
+import { Color } from '../../core/math/color.js';
 import { TRACEID_TEXTURES } from '../../core/constants.js';
 
 import {
@@ -496,6 +497,8 @@ class GraphicsDevice extends EventHandler {
         // Cached viewport and scissor dimensions
         this.vx = this.vy = this.vw = this.vh = 0;
         this.sx = this.sy = this.sw = this.sh = 0;
+
+        this.blendColor = new Color(0, 0, 0, 0);
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1110,7 +1110,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         gl.blendEquation(gl.FUNC_ADD);
         gl.colorMask(true, true, true, true);
 
-        this.blendColor = new Color(0, 0, 0, 0);
         gl.blendColor(0, 0, 0, 0);
 
         gl.enable(gl.CULL_FACE);

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -50,6 +50,9 @@ class Camera {
      */
     renderPasses = [];
 
+    /** @type {number} */
+    jitter = 0;
+
     constructor() {
         this._aspectRatio = 16 / 9;
         this._aspectRatioMode = ASPECT_AUTO;
@@ -447,6 +450,7 @@ class Camera {
         this.sensitivity = other.sensitivity;
 
         this.shaderPassInfo = other.shaderPassInfo;
+        this.jitter = other.jitter;
 
         this._projMatDirty = true;
 


### PR DESCRIPTION
this mostly implements: https://github.com/playcanvas/engine/issues/3361

### New API
- **CameraComponent.jitter** - a number representing the amount of jitter, defaults to0 (disabled)
- **GraphicsDevice.setBlendColor** - made the existing function public, as it is required by few blend modes.

### Other changes:
- support for TAA, but only for the static scene / static camera. Full TAA in later PRs.
- support for `setBlendColor` on WebGPU platform


https://github.com/playcanvas/engine/assets/59932779/dfd75dee-395f-412a-9e24-3abdc7782528

