### PR TITLE
On WebGPU flip the image for drawDepthTexture

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1911,7 +1911,7 @@ class AppBase extends EventHandler {
         material.shader = this.scene.immediate.getDepthTextureShader();
         material.update();
 
-        this.drawTexture(x, y, width, height, null, material, layer);
+        this.drawTexture(x, y, width, this.graphicsDevice?.isWebGPU ? -height : height, null, material, layer);
     }
 
     /**


### PR DESCRIPTION
Without this the depth buffer is rendered upside down. See WebGPU for https://playcanvas.github.io/#/graphics/ground-fog

This was the best way I found to fix it, making changes to drawTexture to fix it for depth textures makes other textures wrong instead that are already correct.


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
