### PR TITLE
Remove unused Texture._isRenderTarget

### DIFF
--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -198,11 +198,6 @@ class RenderTarget {
             }
         });
 
-        // mark color buffer textures as render target
-        this._colorBuffers?.forEach((colorBuffer) => {
-            colorBuffer._isRenderTarget = true;
-        });
-
         const { maxSamples } = this._device;
         this._samples = Math.min(options.samples ?? 1, maxSamples);
 

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -35,9 +35,6 @@ class Texture {
     name;
 
     /** @protected */
-    _isRenderTarget = false;
-
-    /** @protected */
     _gpuSize = 0;
 
     /** @protected */


### PR DESCRIPTION
Code that used it was removed at some point.


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
