### PR TITLE
Link WebGL shaders in parallel

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1097,7 +1097,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.extCompressedTextureS3TC = this.getExtension('WEBGL_compressed_texture_s3tc', 'WEBKIT_WEBGL_compressed_texture_s3tc');
         this.extCompressedTextureATC = this.getExtension('WEBGL_compressed_texture_atc');
         this.extCompressedTextureASTC = this.getExtension('WEBGL_compressed_texture_astc');
-        this.extParallelShaderCompile = this.getExtension('KHR_parallel_shader_compile');
 
         // iOS exposes this for half precision render targets on both Webgl1 and 2 from iOS v 14.5beta
         this.extColorBufferHalfFloat = this.getExtension("EXT_color_buffer_half_float");

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -58,9 +58,11 @@ class WebglShader {
     constructor(shader) {
         this.init();
 
-        // kick off vertex and fragment shader compilation, but not linking here, as that would
-        // make it blocking.
+        // kick off vertex and fragment shader compilation.
         this.compile(shader.device, shader);
+
+        // link the shader right away, this is not blocking
+        this.link(shader.device, shader);
 
         // add the shader to recently created list
         WebglShader.getBatchShaders(shader.device).push(shader);
@@ -305,6 +307,7 @@ class WebglShader {
             linkStartTime = now();
         });
 
+        // check the link status of a shader is a blocking operation
         const linkStatus = gl.getProgramParameter(glProgram, gl.LINK_STATUS);
         if (!linkStatus) {
 


### PR DESCRIPTION
In https://github.com/playcanvas/engine/pull/1374/files `KHR_parallel_shader_compile` was added but was never used. This extension is not needed for parallel compiling and linking.

We can link the shader in parallel right away without blocking. Only `getProgramParameter(prog, gl.LINK_STATUS)` will block until both compiling and linking are done.

Before this change every shader would be linked in serial as we would block right after linking until it is done before continuing with the next shader.


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
