### PR TITLE
Make MiniStatsExample WebGPU compatible

### DIFF
--- a/examples/src/examples/misc/mini-stats.mjs
+++ b/examples/src/examples/misc/mini-stats.mjs
@@ -5,9 +5,26 @@ import * as pc from 'playcanvas';
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas, pcx }) {
-    // Create the application and start the update loop
-    const app = new pc.Application(canvas, {});
+async function example({ canvas, deviceType, glslangPath, twgslPath, pcx }) {
+    const gfxOptions = {
+        deviceTypes: [deviceType],
+        glslangUrl: glslangPath + 'glslang.js',
+        twgslUrl: twgslPath + 'twgsl.js'
+    };
+
+    const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+    const createOptions = new pc.AppOptions();
+    createOptions.graphicsDevice = device;
+
+    createOptions.componentSystems = [
+        pc.ModelComponentSystem,
+        pc.RenderComponentSystem,
+        pc.CameraComponentSystem,
+        pc.LightComponentSystem
+    ];
+
+    const app = new pc.AppBase(canvas);
+    app.init(createOptions);
     app.start();
 
     // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
@@ -211,8 +228,11 @@ async function example({ canvas, pcx }) {
                 // ensure texture is uploaded (actual VRAM is allocated)
                 texture.lock();
                 texture.unlock();
-                // @ts-ignore engine-tsd
-                app.graphicsDevice.setTexture(texture, 0);
+
+                if (!app.graphicsDevice.isWebGPU) {
+                    // @ts-ignore engine-tsd
+                    app.graphicsDevice.setTexture(texture, 0);
+                }
 
             } else {    // de-allocating resources
 
@@ -244,7 +264,6 @@ async function example({ canvas, pcx }) {
 
 class MiniStatsExample {
     static CATEGORY = 'Misc';
-    static WEBGPU_ENABLED = true;
     static ENGINE = 'PERFORMANCE';
     static MINISTATS = true;
     static example = example;


### PR DESCRIPTION
But don't make WebGPU the default as it's super slow on WebGPU.


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
