### PR TITLE
Make more examples WebGPU compatible

### DIFF
--- a/examples/src/examples/camera/first-person.mjs
+++ b/examples/src/examples/camera/first-person.mjs
@@ -5,15 +5,40 @@ import * as pc from 'playcanvas';
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas, assetPath, scriptsPath, ammoPath }) {
+async function example({ canvas, deviceType, glslangPath, twgslPath, assetPath, scriptsPath, ammoPath }) {
+    const gfxOptions = {
+        deviceTypes: [deviceType],
+        glslangUrl: glslangPath + 'glslang.js',
+        twgslUrl: twgslPath + 'twgsl.js'
+    };
 
-    // Create the application and start the update loop
-    const app = new pc.Application(canvas, {
-        mouse: new pc.Mouse(document.body),
-        touch: new pc.TouchDevice(document.body),
-        gamepads: new pc.GamePads(),
-        keyboard: new pc.Keyboard(window)
-    });
+    const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+    const createOptions = new pc.AppOptions();
+    createOptions.graphicsDevice = device;
+    createOptions.mouse = new pc.Mouse(document.body);
+    createOptions.touch = new pc.TouchDevice(document.body);
+    createOptions.gamepads = new pc.GamePads();
+    createOptions.keyboard = new pc.Keyboard(window);
+
+    createOptions.componentSystems = [
+        pc.RenderComponentSystem,
+        pc.CameraComponentSystem,
+        pc.LightComponentSystem,
+        pc.ScriptComponentSystem,
+        pc.CollisionComponentSystem,
+        pc.RigidBodyComponentSystem
+    ];
+    createOptions.resourceHandlers = [
+        // @ts-ignore
+        pc.TextureHandler,
+        // @ts-ignore
+        pc.ContainerHandler,
+        // @ts-ignore
+        pc.ScriptHandler
+    ];
+
+    const app = new pc.AppBase(canvas);
+    app.init(createOptions);
 
     // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
     app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
@@ -142,6 +167,7 @@ async function example({ canvas, assetPath, scriptsPath, ammoPath }) {
 
 class FirstPersonExample {
     static CATEGORY = 'Camera';
+    static WEBGPU_ENABLED = true;
     static example = example;
 }
 

--- a/examples/src/examples/camera/fly.mjs
+++ b/examples/src/examples/camera/fly.mjs
@@ -5,13 +5,33 @@ import * as pc from 'playcanvas';
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas, scriptsPath }) {
+async function example({ canvas, deviceType, glslangPath, twgslPath, scriptsPath }) {
+    const gfxOptions = {
+        deviceTypes: [deviceType],
+        glslangUrl: glslangPath + 'glslang.js',
+        twgslUrl: twgslPath + 'twgsl.js'
+    };
 
-    // Create the application and start the update loop
-    const app = new pc.Application(canvas, {
-        mouse: new pc.Mouse(canvas),
-        keyboard: new pc.Keyboard(window)
-    });
+    const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+    const createOptions = new pc.AppOptions();
+    createOptions.graphicsDevice = device;
+    createOptions.mouse = new pc.Mouse(document.body);
+    createOptions.keyboard = new pc.Keyboard(window);
+
+    createOptions.componentSystems = [
+        pc.RenderComponentSystem,
+        pc.CameraComponentSystem,
+        pc.LightComponentSystem,
+        pc.ScriptComponentSystem
+    ];
+    createOptions.resourceHandlers = [
+        // @ts-ignore
+        pc.ScriptHandler
+    ];
+
+    const app = new pc.AppBase(canvas);
+    app.init(createOptions);
+
     // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
     app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
     app.setCanvasResolution(pc.RESOLUTION_AUTO);
@@ -128,6 +148,7 @@ async function example({ canvas, scriptsPath }) {
 
 class FlyExample {
     static CATEGORY = 'Camera';
+    static WEBGPU_ENABLED = true;
     static example = example;
 }
 

--- a/examples/src/examples/camera/orbit.mjs
+++ b/examples/src/examples/camera/orbit.mjs
@@ -5,12 +5,36 @@ import * as pc from 'playcanvas';
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas, assetPath, scriptsPath }) {
-    // Create the app and start the update loop
-    const app = new pc.Application(canvas, {
-        mouse: new pc.Mouse(document.body),
-        touch: new pc.TouchDevice(document.body)
-    });
+async function example({ canvas, deviceType, glslangPath, twgslPath, assetPath, scriptsPath }) {
+    const gfxOptions = {
+        deviceTypes: [deviceType],
+        glslangUrl: glslangPath + 'glslang.js',
+        twgslUrl: twgslPath + 'twgsl.js'
+    };
+
+    const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+    const createOptions = new pc.AppOptions();
+    createOptions.graphicsDevice = device;
+    createOptions.mouse = new pc.Mouse(document.body);
+    createOptions.touch = new pc.TouchDevice(document.body);
+
+    createOptions.componentSystems = [
+        pc.RenderComponentSystem,
+        pc.CameraComponentSystem,
+        pc.LightComponentSystem,
+        pc.ScriptComponentSystem
+    ];
+    createOptions.resourceHandlers = [
+        // @ts-ignore
+        pc.TextureHandler,
+        // @ts-ignore
+        pc.ContainerHandler,
+        // @ts-ignore
+        pc.ScriptHandler
+    ];
+
+    const app = new pc.AppBase(canvas);
+    app.init(createOptions);
 
     const assets = {
         statue: new pc.Asset('statue', 'container', { url: assetPath + 'models/statue.glb' }),
@@ -75,6 +99,7 @@ async function example({ canvas, assetPath, scriptsPath }) {
 
 class OrbitExample {
     static CATEGORY = 'Camera';
+    static WEBGPU_ENABLED = true;
     static example = example;
 }
 

--- a/examples/src/examples/graphics/paint-mesh.mjs
+++ b/examples/src/examples/graphics/paint-mesh.mjs
@@ -31,7 +31,9 @@ async function example({ canvas, files, deviceType, assetPath, glslangPath, twgs
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
+        // @ts-ignore
         pc.TextureHandler,
+        // @ts-ignore
         pc.CubemapHandler
     ];
 
@@ -215,7 +217,7 @@ async function example({ canvas, files, deviceType, assetPath, glslangPath, twgs
 
 export class PaintMeshExample {
     static CATEGORY = 'Graphics';
-
+    static WEBGPU_ENABLED = true;
     static FILES = {
         'shader.vert': /* glsl */`
             // Attributes per vertex: position and uv

--- a/examples/src/examples/graphics/transform-feedback.mjs
+++ b/examples/src/examples/graphics/transform-feedback.mjs
@@ -6,9 +6,31 @@ import * as pc from 'playcanvas';
  * @param {Options} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas, files, assetPath }) {
-    // Create the app and start the update loop
-    const app = new pc.Application(canvas, {});
+async function example({ canvas, deviceType, glslangPath, twgslPath, files, assetPath }) {
+    const gfxOptions = {
+        deviceTypes: [deviceType],
+        glslangUrl: glslangPath + 'glslang.js',
+        twgslUrl: twgslPath + 'twgsl.js'
+    };
+
+    const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+    const createOptions = new pc.AppOptions();
+    createOptions.graphicsDevice = device;
+
+    createOptions.componentSystems = [
+        pc.RenderComponentSystem,
+        pc.CameraComponentSystem,
+        pc.LightComponentSystem,
+    ];
+    createOptions.resourceHandlers = [
+        // @ts-ignore
+        pc.TextureHandler,
+        // @ts-ignore
+        pc.ContainerHandler,
+    ];
+
+    const app = new pc.AppBase(canvas);
+    app.init(createOptions);
 
     const assets = {
         'statue': new pc.Asset('statue', 'container', { url: assetPath + 'models/statue.glb' })
@@ -162,6 +184,7 @@ async function example({ canvas, files, assetPath }) {
 
 export class TransformFeedbackExample {
     static CATEGORY = 'Graphics';
+    static WEBGPU_ENABLED = false; // No errors, but screen is completely black.
     static FILES = {
         'shaderFeedback.vert': /* glsl */`
 // vertex shader used to move particles during transform-feedback simulation step

--- a/examples/src/examples/graphics/video-texture.mjs
+++ b/examples/src/examples/graphics/video-texture.mjs
@@ -5,10 +5,31 @@ import * as pc from 'playcanvas';
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas, assetPath }) {
+async function example({ canvas, deviceType, glslangPath, twgslPath, assetPath }) {
+    const gfxOptions = {
+        deviceTypes: [deviceType],
+        glslangUrl: glslangPath + 'glslang.js',
+        twgslUrl: twgslPath + 'twgsl.js'
+    };
 
-    // Create the application and start the update loop
-    const app = new pc.Application(canvas, {});
+    const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+    const createOptions = new pc.AppOptions();
+    createOptions.graphicsDevice = device;
+
+    createOptions.componentSystems = [
+        pc.RenderComponentSystem,
+        pc.CameraComponentSystem,
+        pc.LightComponentSystem,
+    ];
+    createOptions.resourceHandlers = [
+        // @ts-ignore
+        pc.TextureHandler,
+        // @ts-ignore
+        pc.ContainerHandler,
+    ];
+
+    const app = new pc.AppBase(canvas);
+    app.init(createOptions);
 
     const assets = {
         tv: new pc.Asset('tv', 'container', { url: assetPath + 'models/tv.glb' })
@@ -128,5 +149,6 @@ async function example({ canvas, assetPath }) {
 
 export class VideoTextureExample {
     static CATEGORY = 'Graphics';
+    static WEBGPU_ENABLED = false; // Video textures don't work yet in WebGPU.
     static example = example;
 }

--- a/examples/src/examples/loaders/obj.mjs
+++ b/examples/src/examples/loaders/obj.mjs
@@ -5,9 +5,37 @@ import * as pc from 'playcanvas';
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas, assetPath, scriptsPath }) {
-    // Create the app and start the update loop
-    const app = new pc.Application(canvas, {});
+async function example({ canvas, deviceType, glslangPath, twgslPath, assetPath, scriptsPath }) {
+    const gfxOptions = {
+        deviceTypes: [deviceType],
+        glslangUrl: glslangPath + 'glslang.js',
+        twgslUrl: twgslPath + 'twgsl.js'
+    };
+
+    const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+    const createOptions = new pc.AppOptions();
+    createOptions.graphicsDevice = device;
+
+    createOptions.componentSystems = [
+        pc.RenderComponentSystem,
+        pc.CameraComponentSystem,
+        pc.LightComponentSystem,
+        pc.ScriptComponentSystem,
+        pc.ModelComponentSystem,
+    ];
+    createOptions.resourceHandlers = [
+        // @ts-ignore
+        pc.TextureHandler,
+        // @ts-ignore
+        pc.ContainerHandler,
+        // @ts-ignore
+        pc.ScriptHandler,
+        // @ts-ignore
+        pc.ModelHandler,
+    ];
+
+    const app = new pc.AppBase(canvas);
+    app.init(createOptions);
 
     // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
     app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
@@ -83,5 +111,6 @@ async function example({ canvas, assetPath, scriptsPath }) {
 
 export class ObjExample {
     static CATEGORY = 'Loaders';
+    static WEBGPU_ENABLED = true;
     static example = example;
 }

--- a/examples/src/examples/sound/positional.mjs
+++ b/examples/src/examples/sound/positional.mjs
@@ -4,10 +4,47 @@ import * as pc from 'playcanvas';
  * @param {import('../../options.mjs').ExampleOptions} options - The example options.
  * @returns {Promise<pc.AppBase>} The example application.
  */
-async function example({ canvas, assetPath }) {
+async function example({ canvas, deviceType, glslangPath, twgslPath, assetPath }) {
+    const gfxOptions = {
+        deviceTypes: [deviceType],
+        glslangUrl: glslangPath + 'glslang.js',
+        twgslUrl: twgslPath + 'twgsl.js'
+    };
 
-    // Create the application and start the update loop
-    const app = new pc.Application(canvas, {});
+    const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+    const createOptions = new pc.AppOptions();
+    createOptions.graphicsDevice = device;
+    createOptions.soundManager = new pc.SoundManager();
+
+    createOptions.componentSystems = [
+        pc.RenderComponentSystem,
+        pc.CameraComponentSystem,
+        pc.LightComponentSystem,
+        pc.SoundComponentSystem,
+        pc.AnimationComponentSystem,
+        pc.AnimComponentSystem,
+        pc.ModelComponentSystem,
+        pc.AudioListenerComponentSystem,
+    ];
+    createOptions.resourceHandlers = [
+        // @ts-ignore
+        pc.TextureHandler,
+        // @ts-ignore
+        pc.ContainerHandler,
+        // @ts-ignore
+        pc.AudioHandler,
+        // @ts-ignore
+        pc.JsonHandler,
+        // @ts-ignore
+        pc.AnimationHandler,
+        // @ts-ignore
+        pc.ModelHandler,
+        // @ts-ignore
+        pc.MaterialHandler,
+    ];
+
+    const app = new pc.AppBase(canvas);
+    app.init(createOptions);
 
     // Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
     app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
@@ -117,6 +154,7 @@ async function example({ canvas, assetPath }) {
 
 class PositionalExample {
     static CATEGORY = 'Sound';
+    static WEBGPU_ENABLED = false; // Failed to transpile webgl fragment shader.
     static example = example;
 }
 


### PR DESCRIPTION
Switch examples from using `pc.AppBase` instead of `pc.Application`. This allows the examples to be WebGPU compatible.

`TransformFeedbackExample`, `VideoTextureExample` and `PositionalExample` have been updated but have `WEBGPU_ENABLED = false` as they don't work with WebGPU yet. I have added a comment to each for why.


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
