### PR TITLE
Fix npm run build:thumbnails

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
     "prebuild": "npm run build:example:data && npm run build:standalone && npm run build:directory",
     "build:directory": "node ./scripts/example-directory.mjs",
     "build:example:data": "node ./scripts/example-data.mjs",
-    "build:thumbnails": "npm run build && node ./scripts/thumbnails.mjs",
+    "build:thumbnails": "npm run prebuild && cross-env NODE_ENV=development rollup -c && node ./scripts/thumbnails.mjs",
     "build:standalone": "node ./scripts/generate-standalone-files.mjs",
     "rollup:watch": "cross-env NODE_ENV=development rollup -c -w",
     "serve": "serve dist -l 5000 --no-request-logging --config ../serve.json",

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
     "prebuild": "npm run build:example:data && npm run build:standalone && npm run build:directory",
     "build:directory": "node ./scripts/example-directory.mjs",
     "build:example:data": "node ./scripts/example-data.mjs",
-    "build:thumbnails": "npm run prebuild && cross-env NODE_ENV=development rollup -c && node ./scripts/thumbnails.mjs",
+    "build:thumbnails": "npm run build && node ./scripts/thumbnails.mjs",
     "build:standalone": "node ./scripts/generate-standalone-files.mjs",
     "rollup:watch": "cross-env NODE_ENV=development rollup -c -w",
     "serve": "serve dist -l 5000 --no-request-logging --config ../serve.json",

--- a/examples/rollup.config.js
+++ b/examples/rollup.config.js
@@ -218,22 +218,25 @@ const targets = [
 // We skip building PlayCanvas ourselves when ENGINE_PATH is given.
 // In that case we have a watcher which copies all necessary files.
 if (ENGINE_PATH === '') {
-    /** @type {RollupOptions|undefined} */
-    let target;
+    /** @type {buildTarget} */
+    const pushTarget = (...args) => {
+        targets.push(buildTarget(...args));
+    };
     if (NODE_ENV === 'production') {
         // Outputs: dist/iframe/playcanvas.js
-        target = buildTarget('release', 'es5', '../src/index.js', 'dist/iframe');
+        pushTarget('release', 'es5', '../src/index.js', 'dist/iframe');
+        // Outputs: dist/iframe/playcanvas.dbg.js
+        pushTarget('debug', 'es5', '../src/index.js', 'dist/iframe');
+        // Outputs: dist/iframe/playcanvas.prf.js
+        pushTarget('profiler', 'es5', '../src/index.js', 'dist/iframe');
     } else if (NODE_ENV === 'development') {
         // Outputs: dist/iframe/playcanvas.dbg.js
-        target = buildTarget('debug', 'es5', '../src/index.js', 'dist/iframe');
+        pushTarget('debug', 'es5', '../src/index.js', 'dist/iframe');
     } else if (NODE_ENV === 'profiler') {
         // Outputs: dist/iframe/playcanvas.prf.js
-        target = buildTarget('profiler', 'es5', '../src/index.js', 'dist/iframe');
+        pushTarget('profiler', 'es5', '../src/index.js', 'dist/iframe');
     } else {
         console.warn("NODE_ENV is neither production, development nor profiler.");
-    }
-    if (target) {
-        targets.push(target);
     }
 }
 


### PR DESCRIPTION
Building thumbnails fails for `ClusteredLightingExample` and `MiniStatsExample` because they have `ENGINE = 'PERFORMANCE'` which doesn't work with thumbnail generation and fails with

```
Failed to fetch dynamically imported module: http://localhost:12321/iframe/playcanvas.prf.js
```


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
