### PR TITLE
Show configurable example descriptions

### DIFF
--- a/examples/scripts/generate-standalone-files.mjs
+++ b/examples/scripts/generate-standalone-files.mjs
@@ -316,6 +316,7 @@ ${exampleClass.example.toString()}
                 constructor(deviceType) {
                     super("exampleLoad");
                     this.files = files;
+                    this.description = ${JSON.stringify(exampleClass.DESCRIPTION || '')};
                 }
             }
             const finalFunc = () => {

--- a/examples/src/examples/animation/component-properties.mjs
+++ b/examples/src/examples/animation/component-properties.mjs
@@ -296,6 +296,7 @@ async function example({ canvas, deviceType, data, assetPath, glslangPath, twgsl
 class ComponentPropertiesExample {
     static CATEGORY = 'Animation';
     static WEBGPU_ENABLED = true;
+    static DESCRIPTION = 'This example demonstrates how to use the Anim Component to animate the properties of other Components.';
     static controls = controls;
     static example = example;
 }

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -401,6 +401,25 @@ body {
     background-color: #364346;
 }
 
+#descriptionPanel {
+    /* center on the bottom of the page */
+    position: absolute;
+    left: 50%;
+    bottom: 8px;
+    transform: translateX(-50%);
+    color: #f2f2f2;
+    width: 50%;
+}
+
+#descriptionPanel.mobile {
+    bottom: 100px;
+    width: 90%;
+}
+
+#descriptionPanel a {
+    color: #f2f2f2;
+}
+
 @media only screen and (max-width: 600px) {
     #controls-wrapper {
         position: absolute;


### PR DESCRIPTION
Add new `static DESCRIPTION = '...';` to example classes. This description is a HTML string and can contain tags such as `<a>`.

Fixes #5178


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
