### PR TITLE
Correctly flip the depth texture in drawDepthTexture

### DIFF
--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -128,7 +128,7 @@ class Immediate {
             ${shaderChunks.screenDepthPS}
             varying vec2 uv0;
             void main() {
-                float depth = getLinearScreenDepth(uv0) * camera_params.x;
+                float depth = getLinearScreenDepth(getImageEffectUV(uv0)) * camera_params.x;
                 gl_FragColor = vec4(vec3(depth), 1.0);
             }
         `);


### PR DESCRIPTION
a better solution to this problem: https://github.com/playcanvas/engine/pull/5912

drawDepthTexture now renders the image correctly for both Gl and GPU

Closes #5912 