### PR TITLE
Remove type global function

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -27,26 +27,25 @@ const data = { }; // Storage for exported entity data
  * @returns {string} The type string: "null", "undefined", "number", "string", "boolean", "array", "object", "function", "date", "regexp" or "float32array".
  * @ignore
  */
-const type = (() => {
-    const _typeLookup = { };
-    ['Array', 'Object', 'Function', 'Date', 'RegExp', 'Float32Array'].forEach((name) => {
-        _typeLookup[`[object ${name}]`] = name.toLowerCase();
-    });
+function type (obj) {
+    if (obj === null) {
+        return 'null';
+    }
 
-    return (obj) => {
-        if (obj === null) {
-            return 'null';
-        }
+    const typeString = typeof obj;
+    if (['undefined', 'number', 'string', 'boolean'].includes(typeString)) {
+        return typeString;
+    }
 
-        const type = typeof obj;
-
-        if (type === 'undefined' || type === 'number' || type === 'string' || type === 'boolean') {
-            return type;
-        }
-
-        return _typeLookup[Object.prototype.toString.call(obj)];
-    };
-})();
+    return {
+        '[object array]': 'Array',
+        '[object object]': 'Object',
+        '[object function]': 'Function',
+        '[object date]': 'Date',
+        '[object regexp]': 'RegExp',
+        '[object float32array]': 'Float32Array'
+    }[Object.prototype.toString.call(obj)];
+};
 
 /**
  * Merge the contents of two objects into a single object.

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -21,41 +21,32 @@ const apps = { }; // Storage for the applications using the PlayCanvas Engine
 const data = { }; // Storage for exported entity data
 
 /**
- * Create look up table for types.
- *
- * @returns {object} A hash table containing all types in this format: { '[object Type]': 'type' }
- * @private
- */
-const _typeLookup = function () {
-    const result = { };
-    const names = ['Array', 'Object', 'Function', 'Date', 'RegExp', 'Float32Array'];
-
-    for (let i = 0; i < names.length; i++)
-        result['[object ' + names[i] + ']'] = names[i].toLowerCase();
-
-    return result;
-}();
-
-/**
  * Extended typeof() function, returns the type of the object.
  *
  * @param {object} obj - The object to get the type of.
  * @returns {string} The type string: "null", "undefined", "number", "string", "boolean", "array", "object", "function", "date", "regexp" or "float32array".
  * @ignore
  */
-function type(obj) {
-    if (obj === null) {
-        return 'null';
-    }
+const type = (() => {
+    const _typeLookup = { };
+    ['Array', 'Object', 'Function', 'Date', 'RegExp', 'Float32Array'].forEach((name) => {
+        _typeLookup[`[object ${name}]`] = name.toLowerCase();
+    });
 
-    const type = typeof obj;
+    return (obj) => {
+        if (obj === null) {
+            return 'null';
+        }
 
-    if (type === 'undefined' || type === 'number' || type === 'string' || type === 'boolean') {
-        return type;
-    }
+        const type = typeof obj;
 
-    return _typeLookup[Object.prototype.toString.call(obj)];
-}
+        if (type === 'undefined' || type === 'number' || type === 'string' || type === 'boolean') {
+            return type;
+        }
+
+        return _typeLookup[Object.prototype.toString.call(obj)];
+    };
+})();
 
 /**
  * Merge the contents of two objects into a single object.

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -20,6 +20,16 @@ const common = { };
 const apps = { }; // Storage for the applications using the PlayCanvas Engine
 const data = { }; // Storage for exported entity data
 
+const typeofs = ['undefined', 'number', 'string', 'boolean'];
+const objectTypes = {
+    '[object Array]': 'array',
+    '[object Object]': 'object',
+    '[object Function]': 'function',
+    '[object Date]': 'date',
+    '[object RegExp]': 'regexp',
+    '[object Float32Array]': 'float32array'
+};
+
 /**
  * Extended typeof() function, returns the type of the object.
  *
@@ -33,18 +43,11 @@ function type(obj) {
     }
 
     const typeString = typeof obj;
-    if (['undefined', 'number', 'string', 'boolean'].includes(typeString)) {
+    if (typeofs.includes(typeString)) {
         return typeString;
     }
 
-    return {
-        '[object Array]': 'array',
-        '[object Object]': 'object',
-        '[object Function]': 'function',
-        '[object Date]': 'date',
-        '[object RegExp]': 'regexp',
-        '[object Float32Array]': 'float32array'
-    }[Object.prototype.toString.call(obj)];
+    return objectTypes[Object.prototype.toString.call(obj)];
 }
 
 /**

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -38,12 +38,12 @@ function type(obj) {
     }
 
     return {
-        '[object array]': 'Array',
-        '[object object]': 'Object',
-        '[object function]': 'Function',
-        '[object date]': 'Date',
-        '[object regexp]': 'RegExp',
-        '[object float32array]': 'Float32Array'
+        '[object Array]': 'array',
+        '[object Object]': 'object',
+        '[object Function]': 'function',
+        '[object Date]': 'date',
+        '[object RegExp]': 'regexp',
+        '[object Float32Array]': 'float32array'
     }[Object.prototype.toString.call(obj)];
 };
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -45,7 +45,7 @@ function type(obj) {
         '[object RegExp]': 'regexp',
         '[object Float32Array]': 'float32array'
     }[Object.prototype.toString.call(obj)];
-};
+}
 
 /**
  * Merge the contents of two objects into a single object.

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -27,7 +27,7 @@ const data = { }; // Storage for exported entity data
  * @returns {string} The type string: "null", "undefined", "number", "string", "boolean", "array", "object", "function", "date", "regexp" or "float32array".
  * @ignore
  */
-function type (obj) {
+function type(obj) {
     if (obj === null) {
         return 'null';
     }


### PR DESCRIPTION
I noticed the following unused core function being included in an optimised, tree-shaken build of an engine app:

<img width="827" alt="Screenshot 2024-01-15 at 13 36 39" src="https://github.com/playcanvas/engine/assets/11276292/5b64aae9-ecab-4fb3-b756-4dfade8c0828">

This PR changes the implementation so the function will be removed correctly.