### PR TITLE
Examples ar-link flag

### DIFF
--- a/examples/scripts/generate-standalone-files.mjs
+++ b/examples/scripts/generate-standalone-files.mjs
@@ -69,13 +69,13 @@ function generateExampleFile(category, example, exampleClass) {
         <div id="app">
             <div id="appInner">
                 <!--A link without href, which makes it invisible. Setting href in an example would trigger a download when clicked.-->
-                <div style="width:100%; position:absolute; top:10px">
+                ${exampleClass.INCLUDE_AR_LINK ? `<div style="width:100%; position:absolute; top:10px">
                     <div style="text-align: center;">
                         <a id="ar-link" rel="ar" download="asset.usdz">
                             <img src="./arkit.png" id="button" width="200"/>
                         </a>    
                     </div>
-                </div>
+                </div>` : ''}
                 ${exampleClass.NO_CANVAS ? '' : '<canvas id="application-canvas"></canvas>'}
             </div>
         </div>

--- a/examples/src/examples/loaders/gltf-export.mjs
+++ b/examples/src/examples/loaders/gltf-export.mjs
@@ -172,6 +172,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 export class GltfExportExample {
     static CATEGORY = 'Loaders';
     static WEBGPU_ENABLED = true;
+    static INCLUDE_AR_LINK = true;
     static controls = controls;
     static example = example;
 }

--- a/examples/src/examples/loaders/usdz-export.mjs
+++ b/examples/src/examples/loaders/usdz-export.mjs
@@ -125,6 +125,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
 export class UsdzExportExample {
     static CATEGORY = 'Loaders';
     static WEBGPU_ENABLED = true;
+    static INCLUDE_AR_LINK = true;
     static controls = controls;
     static example = example;
 }


### PR DESCRIPTION
Adds a flag to only include ar-link code block in projects that use it. (Fixes mouse over selection of invisible image `arkit.png`).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
