### PR TITLE
Use function shorthand in objects

### DIFF
--- a/src/core/array-utils.js
+++ b/src/core/array-utils.js
@@ -1,7 +1,7 @@
 const array = {
 
     // helper function to compare two arrays for equality
-    equals: function (arr1, arr2) {
+    equals(arr1, arr2) {
 
         if (arr1.size !== arr2.size) {
             return false;

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -11,7 +11,7 @@ const events = {
      * pc.events.attach(obj);
      * @ignore
      */
-    attach: function (target) {
+    attach(target) {
         const ev = events;
         target._addCallback = ev._addCallback;
         target.on = ev.on;

--- a/src/core/guid.js
+++ b/src/core/guid.js
@@ -10,7 +10,7 @@ const guid = {
      *
      * @returns {string} A new GUID.
      */
-    create: function () {
+    create() {
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
             const r = Math.random() * 16 | 0;
             const v = (c === 'x') ? r : (r & 0x3 | 0x8);

--- a/src/core/math/bit-packing.js
+++ b/src/core/math/bit-packing.js
@@ -15,7 +15,7 @@ const BitPacking = {
      * @param {number} [mask] - Mask for the value to limit the number of storage bits. Defaults to 1.
      * @returns {number} Returns the storage updated with the value.
      */
-    set: function (storage, value, shift, mask = 1) {
+    set(storage, value, shift, mask = 1) {
         // clear the space
         const data = storage & ~(mask << shift);
 
@@ -31,7 +31,7 @@ const BitPacking = {
      * @param {number} [mask] - Mask for the value to limit the number of storage bits. Defaults to 1.
      * @returns {number} Returns the extracted value.
      */
-    get: function (storage, shift, mask = 1) {
+    get(storage, shift, mask = 1) {
         return (storage >> shift) & mask;
     },
 
@@ -43,7 +43,7 @@ const BitPacking = {
      * @param {number} [mask] - Mask to limit the number of storage bits. Defaults to 1.
      * @returns {boolean} Returns true if all bits in the mask are set in the storage.
      */
-    all: function (storage, shift, mask = 1) {
+    all(storage, shift, mask = 1) {
         const shifted = mask << shift;
         return (storage & shifted) === shifted;
     },
@@ -56,7 +56,7 @@ const BitPacking = {
      * @param {number} [mask] - Mask to limit the number of storage bits. Defaults to 1.
      * @returns {boolean} Returns true if any bits in the mask are set in the storage.
      */
-    any: function (storage, shift, mask = 1) {
+    any(storage, shift, mask = 1) {
         return (storage & (mask << shift)) !== 0;
     }
 };

--- a/src/core/math/math.js
+++ b/src/core/math/math.js
@@ -26,7 +26,7 @@ const math = {
      * @param {number} max - Max value.
      * @returns {number} The clamped value.
      */
-    clamp: function (value, min, max) {
+    clamp(value, min, max) {
         if (value >= max) return max;
         if (value <= min) return min;
         return value;
@@ -41,7 +41,7 @@ const math = {
      * // Set bytes to [0x11, 0x22, 0x33]
      * const bytes = pc.math.intToBytes24(0x112233);
      */
-    intToBytes24: function (i) {
+    intToBytes24(i) {
         const r = (i >> 16) & 0xff;
         const g = (i >> 8) & 0xff;
         const b = (i) & 0xff;
@@ -58,7 +58,7 @@ const math = {
      * // Set bytes to [0x11, 0x22, 0x33, 0x44]
      * const bytes = pc.math.intToBytes32(0x11223344);
      */
-    intToBytes32: function (i) {
+    intToBytes32(i) {
         const r = (i >> 24) & 0xff;
         const g = (i >> 16) & 0xff;
         const b = (i >> 8) & 0xff;
@@ -81,7 +81,7 @@ const math = {
      * // Set result2 to 0x112233 from 3 discrete values
      * const result2 = pc.math.bytesToInt24(0x11, 0x22, 0x33);
      */
-    bytesToInt24: function (r, g, b) {
+    bytesToInt24(r, g, b) {
         if (r.length) {
             b = r[2];
             g = r[1];
@@ -105,7 +105,7 @@ const math = {
      * // Set result2 to 0x11223344 from 4 discrete values
      * const result2 = pc.math.bytesToInt32(0x11, 0x22, 0x33, 0x44);
      */
-    bytesToInt32: function (r, g, b, a) {
+    bytesToInt32(r, g, b, a) {
         if (r.length) {
             a = r[3];
             b = r[2];
@@ -130,7 +130,7 @@ const math = {
      * between a and b is returned. alpha is clamped between 0 and 1.
      * @returns {number} The linear interpolation of two numbers.
      */
-    lerp: function (a, b, alpha) {
+    lerp(a, b, alpha) {
         return a + (b - a) * math.clamp(alpha, 0, 1);
     },
 
@@ -145,7 +145,7 @@ const math = {
      * between a and b is returned. alpha is clamped between 0 and 1.
      * @returns {number} The linear interpolation of two angles.
      */
-    lerpAngle: function (a, b, alpha) {
+    lerpAngle(a, b, alpha) {
         if (b - a > 180) {
             b -= 360;
         }
@@ -161,7 +161,7 @@ const math = {
      * @param {number} x - Number to check for power-of-two property.
      * @returns {boolean} true if power-of-two and false otherwise.
      */
-    powerOfTwo: function (x) {
+    powerOfTwo(x) {
         return ((x !== 0) && !(x & (x - 1)));
     },
 
@@ -171,7 +171,7 @@ const math = {
      * @param {number} val - The value for which to calculate the next power of 2.
      * @returns {number} The next power of 2.
      */
-    nextPowerOfTwo: function (val) {
+    nextPowerOfTwo(val) {
         val--;
         val |= (val >> 1);
         val |= (val >> 2);
@@ -188,7 +188,7 @@ const math = {
      * @param {number} val - The value for which to calculate the nearest power of 2.
      * @returns {number} The nearest power of 2.
      */
-    nearestPowerOfTwo: function (val) {
+    nearestPowerOfTwo(val) {
         return Math.pow(2, Math.round(Math.log(val) / Math.log(2)));
     },
 
@@ -200,7 +200,7 @@ const math = {
      * @param {number} max - Upper bound for range.
      * @returns {number} Pseudo-random number between the supplied range.
      */
-    random: function (min, max) {
+    random(min, max) {
         const diff = max - min;
         return Math.random() * diff + min;
     },
@@ -220,7 +220,7 @@ const math = {
      * @param {number} x - The value to interpolate.
      * @returns {number} The smoothly interpolated value clamped between zero and one.
      */
-    smoothstep: function (min, max, x) {
+    smoothstep(min, max, x) {
         if (x <= min) return 0;
         if (x >= max) return 1;
 
@@ -240,7 +240,7 @@ const math = {
      * @param {number} x - The value to interpolate.
      * @returns {number} The smoothly interpolated value clamped between zero and one.
      */
-    smootherstep: function (min, max, x) {
+    smootherstep(min, max, x) {
         if (x <= min) return 0;
         if (x >= max) return 1;
 
@@ -256,7 +256,7 @@ const math = {
      * @param {number} multiple - The multiple to round up to.
      * @returns {number} A number rounded up to nearest multiple.
      */
-    roundUp: function (numToRound, multiple) {
+    roundUp(numToRound, multiple) {
         if (multiple === 0)
             return numToRound;
         return Math.ceil(numToRound / multiple) * multiple;
@@ -272,7 +272,7 @@ const math = {
      * @returns {boolean} true if between or false otherwise.
      * @ignore
      */
-    between: function (num, a, b, inclusive) {
+    between(num, a, b, inclusive) {
         const min = Math.min(a, b);
         const max = Math.max(a, b);
         return inclusive ? num >= min && num <= max : num > min && num < max;

--- a/src/core/math/random.js
+++ b/src/core/math/random.js
@@ -16,7 +16,7 @@ const random = {
      * @param {import('./vec2.js').Vec2} point - The returned generated point.
      * @ignore
      */
-    circlePoint: function (point) {
+    circlePoint(point) {
         const r = Math.sqrt(Math.random());
         const theta = Math.random() * 2 * Math.PI;
         point.x = r * Math.cos(theta);
@@ -32,7 +32,7 @@ const random = {
      * @param {number} numPoints - The total number of points of the set.
      * @ignore
      */
-    circlePointDeterministic: function (point, index, numPoints) {
+    circlePointDeterministic(point, index, numPoints) {
         const theta = index * _goldenAngle;
         const r = Math.sqrt(index) / Math.sqrt(numPoints);
 
@@ -56,7 +56,7 @@ const random = {
      * 0 and 1. Defaults to 1.
      * @ignore
      */
-    spherePointDeterministic: function (point, index, numPoints, start = 0, end = 1) {
+    spherePointDeterministic(point, index, numPoints, start = 0, end = 1) {
 
         // y coordinate needs to go from -1 (top) to 1 (bottom) for the full sphere
         // evaluate its value for this point and specified start and end
@@ -83,7 +83,7 @@ const random = {
      * @returns {number} The pseudo-random value.
      * @ignore
      */
-    radicalInverse: function (i) {
+    radicalInverse(i) {
         let bits = ((i << 16) | (i >>> 16)) >>> 0;
         bits = (((bits & 0x55555555) << 1) | ((bits & 0xAAAAAAAA) >>> 1)) >>> 0;
         bits = (((bits & 0x33333333) << 2) | ((bits & 0xCCCCCCCC) >>> 2)) >>> 0;

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -25,7 +25,7 @@ const path = {
      * const path = pc.path.join('alpha', 'beta', 'gamma');
      * console.log(path); // Prints 'alpha/beta/gamma'
      */
-    join: function () {
+    join() {
         const num = arguments.length;
         let result = arguments[0];
 
@@ -57,7 +57,7 @@ const path = {
      * @param {string} pathname - The path to normalize.
      * @returns {string} The normalized path.
      */
-    normalize: function (pathname) {
+    normalize(pathname) {
         const lead = pathname.startsWith(path.delimiter);
         const trail = pathname.endsWith(path.delimiter);
 
@@ -101,7 +101,7 @@ const path = {
      * @returns {string[]} The split path which is an array of two strings, the path and the
      * filename.
      */
-    split: function (pathname) {
+    split(pathname) {
         const lastDelimiterIndex = pathname.lastIndexOf(path.delimiter);
         if (lastDelimiterIndex !== -1) {
             return [pathname.substring(0, lastDelimiterIndex), pathname.substring(lastDelimiterIndex + 1)];
@@ -119,7 +119,7 @@ const path = {
      * pc.path.getBasename("/path/to/file.txt"); // returns "file.txt"
      * pc.path.getBasename("/path/to/dir"); // returns "dir"
      */
-    getBasename: function (pathname) {
+    getBasename(pathname) {
         return path.split(pathname)[1];
     },
 
@@ -130,7 +130,7 @@ const path = {
      * @param {string} pathname - The path to get the directory from.
      * @returns {string} The directory part of the path.
      */
-    getDirectory: function (pathname) {
+    getDirectory(pathname) {
         return path.split(pathname)[0];
     },
 
@@ -145,7 +145,7 @@ const path = {
      * pc.path.getExtension("/path/to/file.jpg"); // returns ".jpg"
      * pc.path.getExtension("/path/to/file.txt?function=getExtension"); // returns ".txt"
      */
-    getExtension: function (pathname) {
+    getExtension(pathname) {
         const ext = pathname.split('?')[0].split('.').pop();
         if (ext !== pathname) {
             return '.' + ext;
@@ -168,7 +168,7 @@ const path = {
      * pc.path.isRelativePath("/path/to/file.jpg"); // returns false
      * pc.path.isRelativePath("http://path/to/file.jpg"); // returns false
      */
-    isRelativePath: function (pathname) {
+    isRelativePath(pathname) {
         return pathname.charAt(0) !== '/' && pathname.match(/:\/\//) === null;
     },
 
@@ -183,7 +183,7 @@ const path = {
      * pc.path.extractPath("../path/to/file.txt"); // returns "../path/to"
      * pc.path.extractPath("/path/to/file.txt");   // returns "/path/to"
      */
-    extractPath: function (pathname) {
+    extractPath(pathname) {
         let result = '';
         const parts = pathname.split('/');
         let i = 0;

--- a/src/core/set-utils.js
+++ b/src/core/set-utils.js
@@ -1,7 +1,7 @@
 const set = {
 
     // helper function to compare two sets for equality
-    equals: function (set1, set2) {
+    equals(set1, set2) {
 
         if (set1.size !== set2.size) {
             return false;

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -133,7 +133,7 @@ const string = {
      * const s = pc.string.format("Hello {0}", "world");
      * console.log(s); // Prints "Hello world"
      */
-    format: function (s, ...args) {
+    format(s, ...args) {
         for (let i = 0; i < args.length; i++) {
             s = s.replace(`{${i}}`, args[i]);
         }
@@ -148,7 +148,7 @@ const string = {
      * @param {number} [i] - The index in the string.
      * @returns {number} The code point value for the character in the string.
      */
-    getCodePoint: function (string, i) {
+    getCodePoint(string, i) {
         const codePointData = getCodePointData(string, i);
         return codePointData && codePointData.code;
     },
@@ -159,7 +159,7 @@ const string = {
      * @param {string} string - The string to get code points from.
      * @returns {number[]} The code points in the string.
      */
-    getCodePoints: function (string) {
+    getCodePoints(string) {
         if (typeof string !== 'string') {
             throw new TypeError('Not a string');
         }
@@ -182,7 +182,7 @@ const string = {
      * @param {string} string - The string to break into symbols.
      * @returns {string[]} The symbols in the string.
      */
-    getSymbols: function (string) {
+    getSymbols(string) {
         if (typeof string !== 'string') {
             throw new TypeError('Not a string');
         }
@@ -221,7 +221,7 @@ const string = {
      * @param {...number} args - The code points to convert to a string.
      * @returns {string} The converted string.
      */
-    fromCodePoint: function (/* ...args */) {
+    fromCodePoint(/* ...args */) {
         const chars = [];
         let current;
         let codePoint;

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -60,7 +60,7 @@ const script = {
      * });
      * @ignore
      */
-    create: function (name, callback) {
+    create(name, callback) {
         if (!_legacy)
             return;
 
@@ -131,7 +131,7 @@ const script = {
      * });
      * @ignore
      */
-    attribute: function (name, type, defaultValue, options) {
+    attribute(name, type, defaultValue, options) {
         // only works when parsing the script...
     },
 
@@ -153,7 +153,7 @@ const script = {
      *     app.on("start", hideSplashScreen);
      * });
      */
-    createLoadingScreen: function (callback) {
+    createLoadingScreen(callback) {
         if (_createdLoadingScreen)
             return;
 


### PR DESCRIPTION
Use the more succinct ES6-based function shorthand for functions declared in objects.

While this is generally better anyway, it does get around a problem in TypeDoc where namespaced functions don't show in the generated API reference (as of TypeDoc 0.25.4 - could be related to this: https://github.com/TypeStrong/typedoc/issues/2436).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
