### PR TITLE
Fix typo: Change console.logWarn to console.warn in gltf-exporter.js

### DIFF
--- a/extras/exporters/gltf-exporter.js
+++ b/extras/exporters/gltf-exporter.js
@@ -328,7 +328,7 @@ class GltfExporter extends CoreExporter {
 
         if (texture) {
             const textureIndex = resources.textures.indexOf(texture);
-            if (textureIndex < 0) console.logWarn(`Texture ${texture.name} wasn't collected.`);
+            if (textureIndex < 0) console.warn(`Texture ${texture.name} wasn't collected.`);
             destination[name] = {
                 index: textureIndex
             };


### PR DESCRIPTION
Fixes #5949

Updated to console.warn method, as the previous console.logWarn was considered a typo.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
