### PR TITLE
[Fix] Fix additional shaders getting processed on WebGPU

### DIFF
--- a/src/platform/graphics/shader-processor-options.js
+++ b/src/platform/graphics/shader-processor-options.js
@@ -87,7 +87,7 @@ class ShaderProcessorOptions {
 
         // WebGPU shaders are processed per vertex format
         if (device.isWebGPU) {
-            key += this.vertexFormat?.renderingHashString;
+            key += this.vertexFormat?.shaderProcessingHashString;
         }
 
         return key;

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -255,32 +255,29 @@ class VertexFormat {
      * @private
      */
     _evaluateHash() {
-        let stringElementBatch;
         const stringElementsBatch = [];
-        let stringElementRender;
         const stringElementsRender = [];
         const len = this._elements.length;
         for (let i = 0; i < len; i++) {
-            const element = this._elements[i];
+            const { name, dataType, numComponents, normalize, offset, stride, size, asInt } = this._elements[i];
 
             // create string description of each element that is relevant for batching
-            stringElementBatch = element.name;
-            stringElementBatch += element.dataType;
-            stringElementBatch += element.numComponents;
-            stringElementBatch += element.normalize;
+            const stringElementBatch = name + dataType + numComponents + normalize + asInt;
             stringElementsBatch.push(stringElementBatch);
 
             // create string description of each element that is relevant for rendering
-            stringElementRender = stringElementBatch;
-            stringElementRender += element.offset;
-            stringElementRender += element.stride;
-            stringElementRender += element.size;
+            const stringElementRender = stringElementBatch + offset + stride + size;
             stringElementsRender.push(stringElementRender);
         }
 
         // sort batching ones alphabetically to make the hash order independent
         stringElementsBatch.sort();
-        this.batchingHash = hashCode(stringElementsBatch.join());
+        const batchingString = stringElementsBatch.join();
+        this.batchingHash = hashCode(batchingString);
+
+        // shader processing hash - all elements that are used by the ShaderProcessor processing attributes
+        // at the moment this matches the batching hash
+        this.shaderProcessingHashString = batchingString;
 
         // rendering hash
         this.renderingHashString = stringElementsRender.join('_');


### PR DESCRIPTION
On WPU in the LightsBaked example (and others using primitives) we create more shaders compared to WebGL. The reason is that we process the shader for WebGPU, and the hash value used to avoid this by getting a cached shader used VertexFormat.element.offset. This offset depends on the number of vertices of a mesh when non-interleaved vertex format is used. But as the offset does not affect the shader processing, there is no real reason to process the shader again - the result is the same.

Solution - use a newly added processing hash string which contains only data relevant to the shader processing.

Note: The actual difference in vertex format is already handled by the rendering pipeline, which is created per unique vertex format (similarly to how VertexArrayObject is used on WebGL).