### PR TITLE
Add module docs

### DIFF
--- a/extras/index.js
+++ b/extras/index.js
@@ -1,3 +1,11 @@
+/**
+ * EngineExtras is a collection of supplementary APIs designed to extend the capabilities of the
+ * PlayCanvas Engine. They cover features such as gizmos, file export, runtime performance
+ * profiling and advanced post-processing effects.
+ *
+ * @module EngineExtras
+ */
+
 export { MiniStats } from './mini-stats/mini-stats.js';
 
 // exporters

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,13 @@
+/**
+ * This module provides the core functionality for the PlayCanvas Engine. It includes the main
+ * classes and methods used to create and manage a PlayCanvas application. It provides APIs for
+ * graphics, audio, input, physics, asset management, scripting and much more. It also includes an
+ * application framework and entity-component system, making it easy to manage the lifetime of your
+ * application.
+ *
+ * @module Engine
+ */
+
 // POLYFILLS
 import './polyfill/array-fill.js';
 import './polyfill/array-find.js';


### PR DESCRIPTION
This PR uses the JSDoc `@module` tag to document the Engine and EngineExtras modules. These are picked up by TypeDoc when building the combined API reference manual.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
