### PR TITLE
Fixes to automated testing to work without VAO extension

### DIFF
--- a/src/platform/graphics/webgl/webgl-vertex-buffer.js
+++ b/src/platform/graphics/webgl/webgl-vertex-buffer.js
@@ -14,8 +14,7 @@ class WebglVertexBuffer extends WebglBuffer {
         super.destroy(device);
 
         // clear up bound vertex buffers
-        device.boundVao = null;
-        device.gl.bindVertexArray(null);
+        device.unbindVertexArray();
     }
 
     loseContext() {


### PR DESCRIPTION
small change to avoid `this.gl.bindVertexArray` to execute during the tests as it does not seem supported there.