### PR TITLE
Use spread to handle variadic args of path.join

### DIFF
--- a/src/core/path.js
+++ b/src/core/path.js
@@ -1,5 +1,3 @@
-import { Debug } from './debug.js';
-
 /**
  * File path API.
  *

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -16,7 +16,7 @@ const path = {
     /**
      * Join two or more sections of file path together, inserting a delimiter if needed.
      *
-     * @param {...string} section - Section of path to join. 2 or more can be provided as parameters.
+     * @param {...string} sections - Sections of the path to join.
      * @returns {string} The joined file path.
      * @example
      * const path = pc.path.join('foo', 'bar');
@@ -25,16 +25,12 @@ const path = {
      * const path = pc.path.join('alpha', 'beta', 'gamma');
      * console.log(path); // Prints 'alpha/beta/gamma'
      */
-    join() {
-        const num = arguments.length;
-        let result = arguments[0];
+    join(...sections) {
+        let result = sections[0];
 
-        for (let index = 0; index < num - 1; ++index) {
-            const one = arguments[index];
-            Debug.assert(one !== undefined);
-
-            const two = arguments[index + 1];
-            Debug.assert(two !== undefined);
+        for (let i = 0; i < sections.length - 1; i++) {
+            const one = sections[i];
+            const two = sections[i + 1];
 
             if (two[0] === path.delimiter) {
                 result = two;
@@ -44,7 +40,7 @@ const path = {
             if (one && two && one[one.length - 1] !== path.delimiter && two[0] !== path.delimiter) {
                 result += (path.delimiter + two);
             } else {
-                result += (two);
+                result += two;
             }
         }
 


### PR DESCRIPTION
Changes this:

![image](https://github.com/playcanvas/engine/assets/697563/86c77d30-7c29-437a-b3fc-7cedb6be79d7)

To this:

![image](https://github.com/playcanvas/engine/assets/697563/92bc9505-f55c-415c-af26-d389b04a61d3)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
