### PR TITLE
Updated babel target list to exlude dead browsers (IE11)

### DIFF
--- a/utils/rollup-es5-options.mjs
+++ b/utils/rollup-es5-options.mjs
@@ -18,7 +18,11 @@ const es5Options = buildType => ({
                 loose: true,
                 modules: false,
                 targets: {
-                    ie: '11'
+                    browsers: [
+                        'fully supports webgl',
+                        '> 0.1%',
+                        'not dead'
+                    ]
                 }
             }
         ]


### PR DESCRIPTION
- removed babel support for dead browsers, which at the moment includes: `IE 11, IE Mobile 11, BlackBerry 10, BlackBerry 7, Samsung 4, Opera Mobile 12.1, and all versions of Baidu.` (browsers without official support or updates for more than 24 months)
- note that this made no impact to the generated output, and `playcanvas.min.js` is still exactly the same at 1,542,487 bytes.

sandbox to see supported browsers with the change: https://browsersl.ist/#q=%3E+0.1%25%2C+partially+supports+webgl%2C+not+dead

and without the change:
https://browsersl.ist/#q=fully+supports+webgl

We'd need to move to a lot higher browser versions to make a file size difference.