### PR TITLE
Fix initial value of _assetReference in RenderComponent

### DIFF
--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -82,7 +82,7 @@ class RenderComponent extends Component {
      * @type {AssetReference}
      * @private
      */
-    _assetReference = [];
+    _assetReference;
 
     /**
      * @type {AssetReference[]}


### PR DESCRIPTION
It was copied from Material where an array of references is stored. This gets properly set in the constructor, so this empty array is unused.