### PR TITLE
GSplatComponent that allows native integration of splat tech with the Entity

### DIFF
--- a/examples/src/examples/loaders/gsplat-many.mjs
+++ b/examples/src/examples/loaders/gsplat-many.mjs
@@ -26,7 +26,8 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.RenderComponentSystem,
         pc.CameraComponentSystem,
         pc.LightComponentSystem,
-        pc.ScriptComponentSystem
+        pc.ScriptComponentSystem,
+        pc.GSplatComponentSystem
     ];
     createOptions.resourceHandlers = [
         // @ts-ignore
@@ -55,8 +56,8 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
     const assets = {
         gallery: new pc.Asset('gallery', 'container', { url: assetPath + 'models/vr-gallery.glb' }),
-        guitar: new pc.Asset('splat', 'gsplat', { url: assetPath + 'splats/guitar.ply' }),
-        biker: new pc.Asset('splat', 'gsplat', { url: assetPath + 'splats/biker.ply' }),
+        guitar: new pc.Asset('gsplat', 'gsplat', { url: assetPath + 'splats/guitar.ply' }),
+        biker: new pc.Asset('gsplat', 'gsplat', { url: assetPath + 'splats/biker.ply' }),
         orbit: new pc.Asset('script', 'script', { url: scriptsPath + 'camera/orbit-camera.js' })
     };
 
@@ -80,8 +81,7 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
         const createSplatInstance = (name, resource, px, py, pz, scale, vertex, fragment) => {
 
-            const splat = resource.instantiateRenderEntity({
-                cameraEntity: camera,
+            const splat = resource.instantiate({
                 debugRender: false,
                 fragment: fragment,
                 vertex: vertex
@@ -95,8 +95,12 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
         const guitar = createSplatInstance('guitar', assets.guitar.resource, 0, 0.8, 0, 0.4, files['shader.vert'], files['shader.frag']);
         const biker1 = createSplatInstance('biker1', assets.biker.resource, -1.5, 0.05, 0, 0.7);
-        const biker2 = createSplatInstance('biker2', assets.biker.resource, 1.5, 0.05, 0.8, 0.7);
+
+        // clone the biker and add the clone to the scene
+        const biker2 = biker1.clone();
+        biker2.setLocalPosition(1.5, 0.05, 0);
         biker2.rotate(0, 150, 0);
+        app.root.addChild(biker2);
 
         // add orbit camera script with a mouse and a touch support
         camera.addComponent("script");
@@ -116,7 +120,7 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         app.on("update", function (dt) {
             currentTime += dt;
 
-            const material = guitar.render.meshInstances[0].material;
+            const material = guitar.gsplat.material;
             material.setParameter('uTime', currentTime);
         });
     });

--- a/examples/src/examples/loaders/gsplat.mjs
+++ b/examples/src/examples/loaders/gsplat.mjs
@@ -26,7 +26,8 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.RenderComponentSystem,
         pc.CameraComponentSystem,
         pc.LightComponentSystem,
-        pc.ScriptComponentSystem
+        pc.ScriptComponentSystem,
+        pc.GSplatComponentSystem
     ];
     createOptions.resourceHandlers = [
         // @ts-ignore
@@ -54,7 +55,7 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
     });
 
     const assets = {
-        biker: new pc.Asset('splat', 'gsplat', { url: assetPath + 'splats/biker.ply' }),
+        biker: new pc.Asset('gsplat', 'gsplat', { url: assetPath + 'splats/biker.ply' }),
         orbit: new pc.Asset('script', 'script', { url: scriptsPath + 'camera/orbit-camera.js' })
     };
 
@@ -74,8 +75,7 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
 
         const createSplatInstance = (resource, px, py, pz, scale, vertex, fragment) => {
 
-            const splat = resource.instantiateRenderEntity({
-                cameraEntity: camera,
+            const splat = resource.instantiate({
                 debugRender: false,
                 fragment: fragment,
                 vertex: vertex

--- a/scripts/camera/orbit-camera.js
+++ b/scripts/camera/orbit-camera.js
@@ -310,6 +310,15 @@ OrbitCamera.prototype._buildAabb = function (entity) {
         }
     }
 
+    var gsplats = entity.findComponents("gsplat");
+    for (i = 0; i < gsplats.length; i++) {
+        var gsplat = gsplats[i];
+        var instance = gsplat.instance;
+        if (instance) {
+            meshInstances.push(instance.meshInstance);
+        }
+    }
+
     for (i = 0; i < meshInstances.length; i++) {
         if (i === 0) {
             this._modelsAabb.copy(meshInstances[i].aabb);

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -1,0 +1,343 @@
+import { LAYERID_WORLD } from '../../../scene/constants.js';
+import { Asset } from '../../asset/asset.js';
+import { AssetReference } from '../../asset/asset-reference.js';
+import { Component } from '../component.js';
+
+/**
+ * Enables an Entity to render a Gaussian Splat (asset of the 'gsplat' type).
+ *
+ * @augments Component
+ * @category Graphics
+ */
+class GSplatComponent extends Component {
+    /** @private */
+    _layers = [LAYERID_WORLD]; // assign to the default world layer
+
+    /**
+     * @type {import('../../../scene/gsplat/gsplat-instance.js').GSplatInstance|null}
+     * @private
+     */
+    _instance = null;
+
+    /**
+     * @type {import('../../../core/shape/bounding-box.js').BoundingBox|null}
+     * @private
+     */
+    _customAabb = null;
+
+    /**
+     * @type {AssetReference}
+     * @private
+     */
+    _assetReference;
+
+    /**
+     * Create a new GSplatComponent.
+     *
+     * @param {import('./system.js').GSplatComponentSystem} system - The ComponentSystem that
+     * created this Component.
+     * @param {import('../../entity.js').Entity} entity - The Entity that this Component is
+     * attached to.
+     */
+    constructor(system, entity) {
+        super(system, entity);
+
+        // gsplat asset reference
+        this._assetReference = new AssetReference(
+            'asset',
+            this,
+            system.app.assets, {
+                add: this._onGSplatAssetAdded,
+                load: this._onGSplatAssetLoad,
+                remove: this._onGSplatAssetRemove,
+                unload: this._onGSplatAssetUnload
+            },
+            this
+        );
+
+        // handle events when the entity is directly (or indirectly as a child of sub-hierarchy)
+        // added or removed from the parent
+        entity.on('remove', this.onRemoveChild, this);
+        entity.on('removehierarchy', this.onRemoveChild, this);
+        entity.on('insert', this.onInsertChild, this);
+        entity.on('inserthierarchy', this.onInsertChild, this);
+    }
+
+    /**
+     * If set, the object space bounding box is used as a bounding box for visibility culling of
+     * attached gsplat. This allows a custom bounding box to be specified.
+     *
+     * @type {import('../../../core/shape/bounding-box.js').BoundingBox}
+     */
+    set customAabb(value) {
+        this._customAabb = value;
+
+        // set it on meshInstance
+        this._instance?.meshInstance.setCustomAabb(this._customAabb);
+    }
+
+    get customAabb() {
+        return this._customAabb;
+    }
+
+    /**
+     * A {@link GSplatInstance} contained in the component. If not set or loaded, it returns null.
+     *
+     * @ignore
+     */
+    set instance(value) {
+
+        // destroy existing instance
+        this.destroyInstance();
+
+        this._instance = value;
+
+        if (this._instance) {
+
+            // if mesh instance was created without a node, assign it here
+            const mi = this._instance.meshInstance;
+            if (!mi.node) {
+                mi.node = this.entity;
+            }
+
+            mi.setCustomAabb(this._customAabb);
+
+            if (this.enabled && this.entity.enabled) {
+                this.addToLayers();
+            }
+        }
+    }
+
+    get instance() {
+        return this._instance;
+    }
+
+    /**
+     * Material used to render the gsplat.
+     *
+     * @type {import('../../../scene/materials/material.js').Material|undefined}
+     */
+    get material() {
+        return this._instance?.material;
+    }
+
+    /**
+     * An array of layer IDs ({@link Layer#id}) to which gsplats should belong. Don't push, pop,
+     * splice or modify this array, if you want to change it - set a new one instead.
+     *
+     * @type {number[]}
+     */
+    set layers(value) {
+
+        // remove the mesh instances from old layers
+        this.removeFromLayers();
+
+        // set the layer list
+        this._layers.length = 0;
+        for (let i = 0; i < value.length; i++) {
+            this._layers[i] = value[i];
+        }
+
+        // don't add into layers until we're enabled
+        if (!this.enabled || !this.entity.enabled)
+            return;
+
+        // add the mesh instance to new layers
+        this.addToLayers();
+    }
+
+    get layers() {
+        return this._layers;
+    }
+
+    /**
+     * The gsplat asset for the gsplat component - can also be an asset id.
+     *
+     * @type {Asset|number}
+     */
+    set asset(value) {
+
+        const id = value instanceof Asset ? value.id : value;
+        if (this._assetReference.id === id) return;
+
+        if (this._assetReference.asset && this._assetReference.asset.resource) {
+            this._onGSplatAssetRemove();
+        }
+
+        this._assetReference.id = id;
+
+        if (this._assetReference.asset) {
+            this._onGSplatAssetAdded();
+        }
+    }
+
+    get asset() {
+        return this._assetReference.id;
+    }
+
+    /**
+     * Assign asset id to the component, without updating the component with the new asset.
+     * This can be used to assign the asset id to already fully created component.
+     *
+     * @param {Asset|number} asset - The gsplat asset or asset id to assign.
+     * @ignore
+     */
+    assignAsset(asset) {
+        const id = asset instanceof Asset ? asset.id : asset;
+        this._assetReference.id = id;
+    }
+
+    /** @private */
+    destroyInstance() {
+        if (this._instance) {
+            this.removeFromLayers();
+            this._instance?.destroy();
+            this._instance = null;
+        }
+    }
+
+    /** @private */
+    addToLayers() {
+        const meshInstance = this.instance?.meshInstance;
+        if (meshInstance) {
+            const layers = this.system.app.scene.layers;
+            for (let i = 0; i < this._layers.length; i++) {
+                layers.getLayerById(this._layers[i])?.addMeshInstances([meshInstance]);
+            }
+        }
+    }
+
+    removeFromLayers() {
+        const meshInstance = this.instance?.meshInstance;
+        if (meshInstance) {
+            const layers = this.system.app.scene.layers;
+            for (let i = 0; i < this._layers.length; i++) {
+                layers.getLayerById(this._layers[i])?.removeMeshInstances([meshInstance]);
+            }
+        }
+    }
+
+    /** @private */
+    onRemoveChild() {
+        this.removeFromLayers();
+    }
+
+    /** @private */
+    onInsertChild() {
+        if (this._instance && this.enabled && this.entity.enabled) {
+            this.addToLayers();
+        }
+    }
+
+    onRemove() {
+        this.destroyInstance();
+
+        this.asset = null;
+        this._assetReference.id = null;
+
+        this.entity.off('remove', this.onRemoveChild, this);
+        this.entity.off('insert', this.onInsertChild, this);
+    }
+
+    onLayersChanged(oldComp, newComp) {
+        this.addToLayers();
+        oldComp.off('add', this.onLayerAdded, this);
+        oldComp.off('remove', this.onLayerRemoved, this);
+        newComp.on('add', this.onLayerAdded, this);
+        newComp.on('remove', this.onLayerRemoved, this);
+    }
+
+    onLayerAdded(layer) {
+        const index = this.layers.indexOf(layer.id);
+        if (index < 0) return;
+        if (this._instance) {
+            layer.addMeshInstances(this._instance.meshInstance);
+        }
+    }
+
+    onLayerRemoved(layer) {
+        const index = this.layers.indexOf(layer.id);
+        if (index < 0) return;
+        if (this._instance) {
+            layer.removeMeshInstances(this._instance.meshInstance);
+        }
+    }
+
+    onEnable() {
+        const scene = this.system.app.scene;
+        scene.on('set:layers', this.onLayersChanged, this);
+        if (scene.layers) {
+            scene.layers.on('add', this.onLayerAdded, this);
+            scene.layers.on('remove', this.onLayerRemoved, this);
+        }
+
+        if (this._instance) {
+            this.addToLayers();
+        } else if (this.asset) {
+            this._onGSplatAssetAdded();
+        }
+    }
+
+    onDisable() {
+        const scene = this.system.app.scene;
+        scene.off('set:layers', this.onLayersChanged, this);
+        if (scene.layers) {
+            scene.layers.off('add', this.onLayerAdded, this);
+            scene.layers.off('remove', this.onLayerRemoved, this);
+        }
+
+        this.removeFromLayers();
+    }
+
+    /**
+     * Stop rendering this component without removing its mesh instance from the scene hierarchy.
+     */
+    hide() {
+        if (this._instance) {
+            this._instance.meshInstance.visible = false;
+        }
+    }
+
+    /**
+     * Enable rendering of the component if hidden using {@link GSplatComponent#hide}.
+     */
+    show() {
+        if (this._instance) {
+            this._instance.meshInstance.visible = true;
+        }
+    }
+
+    _onGSplatAssetAdded() {
+        if (!this._assetReference.asset)
+            return;
+
+        if (this._assetReference.asset.resource) {
+            this._onGSplatAssetLoad();
+        } else if (this.enabled && this.entity.enabled) {
+            this.system.app.assets.load(this._assetReference.asset);
+        }
+    }
+
+    _onGSplatAssetLoad() {
+
+        // remove existing instance
+        this.destroyInstance();
+
+        // create new instance
+        const asset = this._assetReference.asset;
+        if (asset) {
+            this.instance = asset.resource.createInstance();
+        }
+    }
+
+    _onGSplatAssetUnload() {
+        // when unloading asset, only remove the instance
+        this.destroyInstance();
+    }
+
+    _onGSplatAssetRemove() {
+        this._onGSplatAssetUnload();
+    }
+}
+
+export { GSplatComponent };

--- a/src/framework/components/gsplat/data.js
+++ b/src/framework/components/gsplat/data.js
@@ -1,0 +1,7 @@
+class GSplatComponentData {
+    constructor() {
+        this.enabled = true;
+    }
+}
+
+export { GSplatComponentData };

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -1,0 +1,100 @@
+import { Vec3 } from '../../../core/math/vec3.js';
+import { BoundingBox } from '../../../core/shape/bounding-box.js';
+
+import { Component } from '../component.js';
+import { ComponentSystem } from '../system.js';
+
+import { GSplatComponent } from './component.js';
+import { GSplatComponentData } from './data.js';
+
+const _schema = [
+    'enabled'
+];
+
+// order matters here
+const _properties = [
+    'instance',
+    'asset',
+    'layers'
+];
+
+/**
+ * Allows an Entity to render a gsplat.
+ *
+ * @augments ComponentSystem
+ * @category Graphics
+ */
+class GSplatComponentSystem extends ComponentSystem {
+    /**
+     * Create a new GSplatComponentSystem.
+     *
+     * @param {import('../../app-base.js').AppBase} app - The Application.
+     * @hideconstructor
+     */
+    constructor(app) {
+        super(app);
+
+        this.id = 'gsplat';
+
+        this.ComponentType = GSplatComponent;
+        this.DataType = GSplatComponentData;
+
+        this.schema = _schema;
+
+        this.on('beforeremove', this.onRemove, this);
+    }
+
+    initializeComponentData(component, _data, properties) {
+        // duplicate layer list
+        if (_data.layers && _data.layers.length) {
+            _data.layers = _data.layers.slice(0);
+        }
+
+        for (let i = 0; i < _properties.length; i++) {
+            if (_data.hasOwnProperty(_properties[i])) {
+                component[_properties[i]] = _data[_properties[i]];
+            }
+        }
+
+        if (_data.aabbCenter && _data.aabbHalfExtents) {
+            component.customAabb = new BoundingBox(new Vec3(_data.aabbCenter), new Vec3(_data.aabbHalfExtents));
+        }
+
+        super.initializeComponentData(component, _data, _schema);
+    }
+
+    cloneComponent(entity, clone) {
+
+        const gSplatComponent = entity.gsplat;
+
+        // copy properties
+        const data = {};
+        for (let i = 0; i < _properties.length; i++) {
+            data[_properties[i]] = gSplatComponent[_properties[i]];
+        }
+        data.enabled = gSplatComponent.enabled;
+
+        // gsplat instance cannot be used this way, remove it and manually clone it later
+        delete data.instance;
+
+        // clone component
+        const component = this.addComponent(clone, data);
+
+        // clone gsplat instance
+        component.instance = gSplatComponent.instance.clone();
+
+        if (gSplatComponent.customAabb) {
+            component.customAabb = gSplatComponent.customAabb.clone();
+        }
+
+        return component;
+    }
+
+    onRemove(entity, component) {
+        component.onRemove();
+    }
+}
+
+Component._buildAccessors(GSplatComponent.prototype, _schema);
+
+export { GSplatComponentSystem };

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -95,6 +95,14 @@ class Entity extends GraphNode {
     element;
 
     /**
+     * Gets the {@link GSplatComponent} attached to this entity.
+     *
+     * @type {import('./components/gsplat/component.js').GSplatComponent|undefined}
+     * @readonly
+     */
+    gsplat;
+
+    /**
      * Gets the {@link LayoutChildComponent} attached to this entity.
      *
      * @type {import('./components/layout-child/component.js').LayoutChildComponent|undefined}
@@ -288,6 +296,7 @@ class Entity extends GraphNode {
      * - "camera" - see {@link CameraComponent}
      * - "collision" - see {@link CollisionComponent}
      * - "element" - see {@link ElementComponent}
+     * - "gsplat" - see {@link GSplatComponent}
      * - "layoutchild" - see {@link LayoutChildComponent}
      * - "layoutgroup" - see {@link LayoutGroupComponent}
      * - "light" - see {@link LightComponent}

--- a/src/framework/handlers/gsplat.js
+++ b/src/framework/handlers/gsplat.js
@@ -34,7 +34,6 @@ class GSplatHandler {
     }
 
     patch(asset, assets) {
-
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -181,7 +181,7 @@ export { ShaderGenerator } from './scene/shader-lib/programs/shader-generator.js
 
 // SCENE / SPLAT
 export { GSplatData } from './scene/gsplat/gsplat-data.js';
-export { Splat } from './scene/gsplat/gsplat.js';
+export { GSplat } from './scene/gsplat/gsplat.js';
 export { GSplatInstance } from './scene/gsplat/gsplat-instance.js';
 
 // FRAMEWORK
@@ -215,6 +215,7 @@ export { ElementComponentSystem } from './framework/components/element/system.js
 export { ElementDragHelper } from './framework/components/element/element-drag-helper.js';
 export { Entity } from './framework/entity.js';
 export { EntityReference } from './framework/utils/entity-reference.js';
+export { GSplatComponentSystem } from './framework/components/gsplat/system.js';
 export { ImageElement } from './framework/components/element/image-element.js';
 export * from './framework/components/joint/constants.js';
 export { JointComponent } from './framework/components/joint/component.js';

--- a/src/scene/gsplat/gsplat.js
+++ b/src/scene/gsplat/gsplat.js
@@ -17,7 +17,8 @@ import { createGSplatMaterial } from './gsplat-material.js';
  * @property {boolean} isHalf - Indicates if the format uses half-precision floats.
  */
 
-class Splat {
+/** @ignore */
+class GSplat {
     device;
 
     numSplats;
@@ -305,4 +306,4 @@ class Splat {
     }
 }
 
-export { Splat };
+export { GSplat };

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -280,6 +280,12 @@ class MeshInstance {
          */
         this._morphInstance = null;
 
+        /**
+         * @type {import('./gsplat/gsplat-instance.js').GSplatInstance|null}
+         * @ignore
+         */
+        this.gsplatInstance = null;
+
         this.instancingData = null;
 
         /**

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -674,6 +674,19 @@ class Renderer {
     }
 
     /**
+     * Update gsplats ahead of rendering.
+     *
+     * @param {import('../mesh-instance.js').MeshInstance[]|Set<import('../mesh-instance.js').MeshInstance>} drawCalls - MeshInstances
+     * containing gsplatInstances.
+     * @ignore
+     */
+    updateGSplats(drawCalls) {
+        for (const drawCall of drawCalls) {
+            drawCall.gsplatInstance.update();
+        }
+    }
+
+    /**
      * Update draw calls ahead of rendering.
      *
      * @param {import('../mesh-instance.js').MeshInstance[]|Set<import('../mesh-instance.js').MeshInstance>} drawCalls - MeshInstances
@@ -685,6 +698,7 @@ class Renderer {
         // that are visible in this frame
         this.updateGpuSkinMatrices(drawCalls);
         this.updateMorphing(drawCalls);
+        this.updateGSplats(drawCalls);
     }
 
     setVertexBuffers(device, mesh) {
@@ -930,8 +944,14 @@ class Renderer {
                     const bucket = drawCall.transparent ? transparent : opaque;
                     bucket.push(drawCall);
 
-                    if (drawCall.skinInstance || drawCall.morphInstance)
+                    if (drawCall.skinInstance || drawCall.morphInstance || drawCall.gsplatInstance) {
                         this.processingMeshInstances.add(drawCall);
+
+                        // register visible cameras
+                        if (drawCall.gsplatInstance) {
+                            drawCall.gsplatInstance.cameras.push(camera);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
- renamed `Splat` to `GSplat` to match the rest of the tech
- new component: GSplatComponent, available as `entity.gsplat`
- splat instance no longer needs camera specified which is used for sorting, this is supplied by the engine after the culling (sorting only takes place if the entity is visible)
- updated orbit camera to take bounds of splats into account when using them as focus entity

New API (all internals are hidden, at least for now, as they have very limited value to the users)

![Screenshot 2024-01-24 at 16 13 08](https://github.com/playcanvas/engine/assets/59932779/eaceb6f2-b894-4813-bde6-a336b4e556da)

![Screenshot 2024-01-24 at 16 13 40](https://github.com/playcanvas/engine/assets/59932779/87ed6424-8b11-414b-98f8-e1f01e03a4a5)
