### PR TITLE
Reverting recent glb alpha depth write change for transparent meshes

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -1247,6 +1247,7 @@ const createMaterial = (gltfMaterial, textures, flipV) => {
             material.bumpiness = normalTexture.scale;
         }
     }
+
     if (gltfMaterial.hasOwnProperty('occlusionTexture')) {
         const occlusionTexture = gltfMaterial.occlusionTexture;
         material.aoMap = textures[occlusionTexture.index];
@@ -1255,6 +1256,7 @@ const createMaterial = (gltfMaterial, textures, flipV) => {
         extractTextureTransform(occlusionTexture, material, ['ao']);
         // TODO: support 'strength'
     }
+
     if (gltfMaterial.hasOwnProperty('emissiveFactor')) {
         color = gltfMaterial.emissiveFactor;
         // Convert from linear space to sRGB space
@@ -1264,12 +1266,14 @@ const createMaterial = (gltfMaterial, textures, flipV) => {
         material.emissive.set(0, 0, 0);
         material.emissiveTint = false;
     }
+
     if (gltfMaterial.hasOwnProperty('emissiveTexture')) {
         const emissiveTexture = gltfMaterial.emissiveTexture;
         material.emissiveMap = textures[emissiveTexture.index];
 
         extractTextureTransform(emissiveTexture, material, ['emissive']);
     }
+
     if (gltfMaterial.hasOwnProperty('alphaMode')) {
         switch (gltfMaterial.alphaMode) {
             case 'MASK':
@@ -1281,10 +1285,10 @@ const createMaterial = (gltfMaterial, textures, flipV) => {
                 }
                 break;
             case 'BLEND':
-                // Blended materials will be rendered back to front, but continue to write depth
-                // along with alpha test. This helps to composite the scene.
                 material.blendType = BLEND_NORMAL;
-                material.alphaTest = 1.0 / 255.0;
+
+                // note: by default don't write depth on semitransparent materials
+                material.depthWrite = false;
                 break;
             default:
             case 'OPAQUE':


### PR DESCRIPTION
Fixes #5902
Reverting the change introduced in #5705

another forum thread: https://forum.playcanvas.com/t/alphatest-coverage-changes-in-latest-vs-1-64-6/34641