### PR TITLE
Avoid using WebGPU 'timestamp-query' which has been removed in Chrome 121

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -222,7 +222,11 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.extCompressedTextureS3TC = requireFeature('texture-compression-bc');
         this.extCompressedTextureETC = requireFeature('texture-compression-etc2');
         this.extCompressedTextureASTC = requireFeature('texture-compression-astc');
-        this.supportsTimestampQuery = requireFeature('timestamp-query');
+
+        // Do not request timestamp feature as it has changed and current form is not supported.
+        // See engine issue #5989
+        //this.supportsTimestampQuery = requireFeature('timestamp-query');
+
         this.textureRG11B10Renderable = requireFeature('rg11b10ufloat-renderable');
         Debug.log(`WEBGPU features: ${requiredFeatures.join(', ')}`);
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -225,7 +225,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
         // Do not request timestamp feature as it has changed and current form is not supported.
         // See engine issue #5989
-        //this.supportsTimestampQuery = requireFeature('timestamp-query');
+        // this.supportsTimestampQuery = requireFeature('timestamp-query');
 
         this.textureRG11B10Renderable = requireFeature('rg11b10ufloat-renderable');
         Debug.log(`WEBGPU features: ${requiredFeatures.join(', ')}`);


### PR DESCRIPTION
Fixes #5973
New ticket to address this: #5989