### PR TITLE
[Fix] DepthGrab now supports render target without stencil

### DIFF
--- a/examples/src/examples/graphics/post-effects.mjs
+++ b/examples/src/examples/graphics/post-effects.mjs
@@ -175,7 +175,7 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
     const gfxOptions = {
         deviceTypes: [deviceType],
         glslangUrl: glslangPath + 'glslang.js',
-        twgslUrl: twgslPath + 'twgsl.js',
+        twgslUrl: twgslPath + 'twgsl.js'
     };
 
     const device = await pc.createGraphicsDevice(canvas, gfxOptions);

--- a/src/scene/graphics/render-pass-depth-grab.js
+++ b/src/scene/graphics/render-pass-depth-grab.js
@@ -1,4 +1,4 @@
-import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_R32F } from "../../platform/graphics/constants.js";
+import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_R32F } from "../../platform/graphics/constants.js";
 import { DebugGraphics } from "../../platform/graphics/debug-graphics.js";
 import { RenderPass } from "../../platform/graphics/render-pass.js";
 import { RenderTarget } from "../../platform/graphics/render-target.js";
@@ -91,11 +91,12 @@ class RenderPassDepthGrab extends RenderPass {
 
         const camera = this.camera;
         const device = this.device;
+        const destinationRt = camera?.renderTarget ?? device.backBuffer;
 
         let useDepthBuffer = true;
-        let format = PIXELFORMAT_DEPTHSTENCIL;
+        let format = destinationRt.stencil ? PIXELFORMAT_DEPTHSTENCIL : PIXELFORMAT_DEPTH;
         if (device.isWebGPU) {
-            const numSamples = camera.renderTarget?.samples ?? device.samples;
+            const numSamples = destinationRt.samples;
 
             // when depth buffer is multi-sampled, instead of copying it out, we use custom shader to resolve it
             // to a R32F texture, used as a color attachment of the render target


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5664

depth grabbing now creates buffer with compatible format, matching depth and stencil options, instead of ignoring stencil option.