### PR TITLE
Fix material error on scale gizmo

### DIFF
--- a/extras/gizmo/scale-gizmo.js
+++ b/extras/gizmo/scale-gizmo.js
@@ -21,7 +21,8 @@ class ScaleGizmo extends TransformGizmo {
             axis: 'xyz',
             layers: [this._layer.id],
             defaultMaterial: this._materials.axis.xyz,
-            hoverMaterial: this._materials.hover.xyz
+            hoverMaterial: this._materials.hover.xyz,
+            disabledMaterial: this._materials.disabled.cullBack
         }),
         yz: new AxisPlane(this._device, {
             axis: 'x',


### PR DESCRIPTION
Adds disabled material to center shape on scale gizmo

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
