### PR TITLE
Implement changes to WebGPU timestamp-query

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-gpu-profiler.js
+++ b/src/platform/graphics/webgpu/webgpu-gpu-profiler.js
@@ -1,4 +1,3 @@
-import { DebugHelper } from "../../../core/debug.js";
 import { GpuProfiler } from "../gpu-profiler.js";
 import { WebgpuQuerySet } from "./webgpu-query-set.js";
 
@@ -21,47 +20,18 @@ class WebgpuGpuProfiler extends GpuProfiler {
         this.timestampQueriesSet = null;
     }
 
-    frameMarker(isStart) {
-
-        if (this.timestampQueriesSet) {
-
-            const suffix = isStart ? 'Start' : 'End';
-            const commandEncoder = this.device.wgpu.createCommandEncoder();
-            DebugHelper.setLabel(commandEncoder, `GPUTimestampEncoder-${suffix}`);
-
-            this.frameGPUMarkerSlot = isStart ? this.getSlot('GpuFrame') : this.frameGPUMarkerSlot;
-            commandEncoder.writeTimestamp(this.timestampQueriesSet.querySet, this.frameGPUMarkerSlot * 2 + (isStart ? 0 : 1));
-
-            const cb = commandEncoder.finish();
-            DebugHelper.setLabel(cb, `GPUTimestampEncoder-${suffix}-CommandBuffer`);
-
-            this.device.addCommandBuffer(cb, isStart);
-        }
-    }
-
     frameStart() {
-
         this.processEnableRequest();
-
-        if (this._enabled) {
-            // initial timing marker
-            this.frameMarker(true);
-        }
     }
 
     frameEnd() {
-
         if (this._enabled) {
-            // final timing marker
-            this.frameMarker(false);
-
             // schedule command buffer where timestamps are copied to CPU
             this.timestampQueriesSet?.resolve(this.slotCount * 2);
         }
     }
 
     request() {
-
         if (this._enabled) {
             // request results
             const renderVersion = this.device.renderVersion;

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -222,10 +222,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.extCompressedTextureS3TC = requireFeature('texture-compression-bc');
         this.extCompressedTextureETC = requireFeature('texture-compression-etc2');
         this.extCompressedTextureASTC = requireFeature('texture-compression-astc');
-
-        // Do not request timestamp feature as it has changed and current form is not supported.
-        // See engine issue #5989
-        // this.supportsTimestampQuery = requireFeature('timestamp-query');
+        this.supportsTimestampQuery = requireFeature('timestamp-query');
 
         this.textureRG11B10Renderable = requireFeature('rg11b10ufloat-renderable');
         Debug.log(`WEBGPU features: ${requiredFeatures.join(', ')}`);


### PR DESCRIPTION
Remove call to `GPURenderPassEncoder.writeTimestamp` as it is not part of the spec anymore, and was removed by Chrome. It is also not needed anymore.

The new interface, `GPURenderPassDescriptor.timestampWrites` was already implemented so nothing is needed there.

Fixes #5989

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
