### PR TITLE
Don't upload texture if locked using TEXTURELOCK_READ

### DIFF
--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1175,6 +1175,13 @@ export const STENCILOP_DECREMENTWRAP = 6;
 export const STENCILOP_INVERT = 7;
 
 /**
+ * The texture is not in a locked state.
+ *
+ * @type {number}
+ */
+export const TEXTURELOCK_NONE = 0;
+
+/**
  * Read only. Any changes to the locked mip level's pixels will not update the texture.
  *
  * @type {number}

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -790,10 +790,17 @@ class Texture {
         options.face ??= 0;
         options.mode ??= TEXTURELOCK_WRITE;
 
-        if (options.mode === TEXTURELOCK_NONE) {
-            Debug.log("pc.Texture#lock: To unlock a texture, call texture.unlock(). Defaulting to 'TEXTURELOCK_READ'.", this);
-            options.mode = TEXTURELOCK_READ;
-        }
+        Debug.assert(
+            this._lockedMode === TEXTURELOCK_NONE,
+            'The texture is already locked. Call `texture.unlock()` before attempting to lock again.',
+            this
+        );
+
+        Debug.assert(
+            options.mode === TEXTURELOCK_READ || options.mode === TEXTURELOCK_WRITE,
+            'Cannot lock a texture with TEXTURELOCK_NONE. To unlock a texture, call `texture.unlock()`.',
+            this
+        );
 
         this._lockedMode = options.mode;
         this._lockedLevel = options.level;
@@ -924,7 +931,7 @@ class Texture {
      */
     unlock() {
         if (this._lockedMode === TEXTURELOCK_NONE) {
-            Debug.log("pc.Texture#unlock: Attempting to unlock a texture that is not locked.", this);
+            Debug.warn("pc.Texture#unlock: Attempting to unlock a texture that is not locked.", this);
         }
 
         // Upload the new pixel data if locked in write mode (default)

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -381,17 +381,6 @@ class Texture {
     }
 
     /**
-     * If a texture lock is active and a specific mip level was specificed, returns the locked
-     * mip level. If no mip level was specified or a lock is not active, returns -1.
-     *
-     * @ignore
-     * @type {number}
-     */
-    get lockedLevel() {
-        return this._lockedLevel;
-    }
-
-    /**
      * Returns the current lock mode. One of:
      *
      * - {@link TEXTURELOCK_NONE}


### PR DESCRIPTION
The API docs suggest that you can call `texture.lock()` with a `mode` of either `TEXTURELOCK_READ` or `TEXTURELOCK_WRITE`, but in this option doesn't do anything.

This is a small change so that a lock that's opened with `TEXTURELOCK_READ` will not call `texture.upload()` when unlocked. It also uses the mode to check the state, instead of overloading `texture._lockedLevel` for this purpose.

I also have some related questions about how we should handle mip updates via API - please see #6004 
