### PR TITLE
Fix Gizmo nodes type

### DIFF
--- a/extras/gizmo/gizmo.js
+++ b/extras/gizmo/gizmo.js
@@ -209,7 +209,7 @@ class Gizmo extends EventHandler {
     /**
      * The graph nodes attached to the gizmo.
      *
-     * @type {import('playcanvas').GraphNode}
+     * @type {import('playcanvas').GraphNode[]}
      */
     nodes = [];
 


### PR DESCRIPTION
Small fix to `Gizmo#nodes` type.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
