### PR TITLE
Assign categories to constants

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -2,6 +2,7 @@
  * Logs a frame number.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_RENDER_FRAME = 'RenderFrame';
 
@@ -9,6 +10,7 @@ export const TRACEID_RENDER_FRAME = 'RenderFrame';
  * Logs a frame time.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_RENDER_FRAME_TIME = 'RenderFrameTime';
 
@@ -16,6 +18,7 @@ export const TRACEID_RENDER_FRAME_TIME = 'RenderFrameTime';
  * Logs basic information about generated render passes.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_RENDER_PASS = 'RenderPass';
 
@@ -23,6 +26,7 @@ export const TRACEID_RENDER_PASS = 'RenderPass';
  * Logs additional detail for render passes.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_RENDER_PASS_DETAIL = 'RenderPassDetail';
 
@@ -31,6 +35,7 @@ export const TRACEID_RENDER_PASS_DETAIL = 'RenderPassDetail';
  * layer composition changes.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_RENDER_ACTION = 'RenderAction';
 
@@ -38,6 +43,7 @@ export const TRACEID_RENDER_ACTION = 'RenderAction';
  * Logs the allocation of render targets.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_RENDER_TARGET_ALLOC = 'RenderTargetAlloc';
 
@@ -45,6 +51,7 @@ export const TRACEID_RENDER_TARGET_ALLOC = 'RenderTargetAlloc';
  * Logs the allocation of textures.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_TEXTURE_ALLOC = 'TextureAlloc';
 
@@ -52,6 +59,7 @@ export const TRACEID_TEXTURE_ALLOC = 'TextureAlloc';
  * Logs the creation of shaders.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_SHADER_ALLOC = 'ShaderAlloc';
 
@@ -59,6 +67,7 @@ export const TRACEID_SHADER_ALLOC = 'ShaderAlloc';
  * Logs the compilation time of shaders.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_SHADER_COMPILE = 'ShaderCompile';
 
@@ -66,6 +75,7 @@ export const TRACEID_SHADER_COMPILE = 'ShaderCompile';
  * Logs the vram use by the textures.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_VRAM_TEXTURE = 'VRAM.Texture';
 
@@ -73,6 +83,7 @@ export const TRACEID_VRAM_TEXTURE = 'VRAM.Texture';
  * Logs the vram use by the vertex buffers.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_VRAM_VB = 'VRAM.Vb';
 
@@ -80,6 +91,7 @@ export const TRACEID_VRAM_VB = 'VRAM.Vb';
  * Logs the vram use by the index buffers.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_VRAM_IB = 'VRAM.Ib';
 
@@ -87,6 +99,7 @@ export const TRACEID_VRAM_IB = 'VRAM.Ib';
  * Logs the creation of bind groups.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_BINDGROUP_ALLOC = 'BindGroupAlloc';
 
@@ -94,6 +107,7 @@ export const TRACEID_BINDGROUP_ALLOC = 'BindGroupAlloc';
  * Logs the creation of bind group formats.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_BINDGROUPFORMAT_ALLOC = 'BindGroupFormatAlloc';
 
@@ -101,6 +115,7 @@ export const TRACEID_BINDGROUPFORMAT_ALLOC = 'BindGroupFormatAlloc';
  * Logs the creation of render pipelines. WebBPU only.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_RENDERPIPELINE_ALLOC = 'RenderPipelineAlloc';
 
@@ -108,6 +123,7 @@ export const TRACEID_RENDERPIPELINE_ALLOC = 'RenderPipelineAlloc';
  * Logs the creation of compute pipelines. WebGPU only.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_COMPUTEPIPELINE_ALLOC = 'ComputePipelineAlloc';
 
@@ -115,6 +131,7 @@ export const TRACEID_COMPUTEPIPELINE_ALLOC = 'ComputePipelineAlloc';
  * Logs the creation of pipeline layouts. WebBPU only.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_PIPELINELAYOUT_ALLOC = 'PipelineLayoutAlloc';
 
@@ -122,6 +139,7 @@ export const TRACEID_PIPELINELAYOUT_ALLOC = 'PipelineLayoutAlloc';
  * Logs the internal debug information for Elements.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACE_ID_ELEMENT = "Element";
 
@@ -129,6 +147,7 @@ export const TRACE_ID_ELEMENT = "Element";
  * Logs the vram use by all textures in memory.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_TEXTURES = 'Textures';
 
@@ -136,6 +155,7 @@ export const TRACEID_TEXTURES = 'Textures';
  * Logs the render queue commands.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_RENDER_QUEUE = 'RenderQueue';
 
@@ -143,5 +163,6 @@ export const TRACEID_RENDER_QUEUE = 'RenderQueue';
  * Logs the GPU timings.
  *
  * @type {string}
+ * @category Debug
  */
 export const TRACEID_GPU_TIMINGS = 'GpuTimings';

--- a/src/core/math/constants.js
+++ b/src/core/math/constants.js
@@ -2,6 +2,7 @@
  * A linear interpolation scheme.
  *
  * @type {number}
+ * @category Math
  */
 export const CURVE_LINEAR = 0;
 
@@ -9,6 +10,7 @@ export const CURVE_LINEAR = 0;
  * A smooth step interpolation scheme.
  *
  * @type {number}
+ * @category Math
  */
 export const CURVE_SMOOTHSTEP = 1;
 
@@ -36,6 +38,7 @@ export const CURVE_CARDINAL = 3;
  * Cardinal spline interpolation scheme. For Catmull-Rom, specify curve tension 0.5.
  *
  * @type {number}
+ * @category Math
  */
 export const CURVE_SPLINE = 4;
 
@@ -43,5 +46,6 @@ export const CURVE_SPLINE = 4;
  * A stepped interpolator, free from the shackles of blending.
  *
  * @type {number}
+ * @category Math
  */
 export const CURVE_STEP = 5;

--- a/src/core/math/float-packing.js
+++ b/src/core/math/float-packing.js
@@ -8,6 +8,8 @@ const int32View = new Int32Array(floatView.buffer);
 /**
  * Utility static class providing functionality to pack float values to various storage
  * representations.
+ *
+ * @category Math
  */
 class FloatPacking {
     /**

--- a/src/core/math/math.js
+++ b/src/core/math/math.js
@@ -2,6 +2,7 @@
  * Math API.
  *
  * @namespace
+ * @category Math
  */
 const math = {
     /**

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -2,6 +2,8 @@
  * Log tracing functionality, allowing for tracing of the internal functionality of the engine.
  * Note that the trace logging only takes place in the debug build of the engine and is stripped
  * out in other builds.
+ *
+ * @category Debug
  */
 class Tracing {
     /**

--- a/src/framework/anim/constants.js
+++ b/src/framework/anim/constants.js
@@ -2,6 +2,7 @@
  * A stepped interpolation scheme.
  *
  * @type {number}
+ * @category Animation
  */
 export const INTERPOLATION_STEP = 0;
 
@@ -9,6 +10,7 @@ export const INTERPOLATION_STEP = 0;
  * A linear interpolation scheme.
  *
  * @type {number}
+ * @category Animation
  */
 export const INTERPOLATION_LINEAR = 1;
 
@@ -16,5 +18,6 @@ export const INTERPOLATION_LINEAR = 1;
  * A cubic spline interpolation scheme.
  *
  * @type {number}
+ * @category Animation
  */
 export const INTERPOLATION_CUBIC = 2;

--- a/src/framework/anim/controller/constants.js
+++ b/src/framework/anim/controller/constants.js
@@ -2,6 +2,7 @@
  * Used to set the anim state graph transition interruption source to no state.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_INTERRUPTION_NONE = 'NONE';
 
@@ -9,6 +10,7 @@ export const ANIM_INTERRUPTION_NONE = 'NONE';
  * Used to set the anim state graph transition interruption source as the previous state only.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_INTERRUPTION_PREV = 'PREV_STATE';
 
@@ -16,6 +18,7 @@ export const ANIM_INTERRUPTION_PREV = 'PREV_STATE';
  * Used to set the anim state graph transition interruption source as the next state only.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_INTERRUPTION_NEXT = 'NEXT_STATE';
 
@@ -24,6 +27,7 @@ export const ANIM_INTERRUPTION_NEXT = 'NEXT_STATE';
  * by the next state.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_INTERRUPTION_PREV_NEXT = 'PREV_STATE_NEXT_STATE';
 
@@ -32,6 +36,7 @@ export const ANIM_INTERRUPTION_PREV_NEXT = 'PREV_STATE_NEXT_STATE';
  * the previous state.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_INTERRUPTION_NEXT_PREV = 'NEXT_STATE_PREV_STATE';
 
@@ -39,6 +44,7 @@ export const ANIM_INTERRUPTION_NEXT_PREV = 'NEXT_STATE_PREV_STATE';
  * Used to set an anim state graph transition condition predicate as '>'.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_GREATER_THAN = 'GREATER_THAN';
 
@@ -46,6 +52,7 @@ export const ANIM_GREATER_THAN = 'GREATER_THAN';
  * Used to set an anim state graph transition condition predicate as '<'.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_LESS_THAN = 'LESS_THAN';
 
@@ -53,6 +60,7 @@ export const ANIM_LESS_THAN = 'LESS_THAN';
  * Used to set an anim state graph transition condition predicate as '>='.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_GREATER_THAN_EQUAL_TO = 'GREATER_THAN_EQUAL_TO';
 
@@ -60,6 +68,7 @@ export const ANIM_GREATER_THAN_EQUAL_TO = 'GREATER_THAN_EQUAL_TO';
  * Used to set an anim state graph transition condition predicate as '<='.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_LESS_THAN_EQUAL_TO = 'LESS_THAN_EQUAL_TO';
 
@@ -67,6 +76,7 @@ export const ANIM_LESS_THAN_EQUAL_TO = 'LESS_THAN_EQUAL_TO';
  * Used to set an anim state graph transition condition predicate as '==='.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_EQUAL_TO = 'EQUAL_TO';
 
@@ -74,6 +84,7 @@ export const ANIM_EQUAL_TO = 'EQUAL_TO';
  * Used to set an anim state graph transition condition predicate as '!=='.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_NOT_EQUAL_TO = 'NOT_EQUAL_TO';
 
@@ -81,6 +92,7 @@ export const ANIM_NOT_EQUAL_TO = 'NOT_EQUAL_TO';
   * Used to set an anim state graph parameter as type integer.
   *
   * @type {string}
+  * @category Animation
   */
 export const ANIM_PARAMETER_INTEGER = 'INTEGER';
 
@@ -88,6 +100,7 @@ export const ANIM_PARAMETER_INTEGER = 'INTEGER';
  * Used to set an anim state graph parameter as type float.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_PARAMETER_FLOAT = 'FLOAT';
 
@@ -95,6 +108,7 @@ export const ANIM_PARAMETER_FLOAT = 'FLOAT';
  * Used to set an anim state graph parameter as type boolean.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_PARAMETER_BOOLEAN = 'BOOLEAN';
 
@@ -102,26 +116,31 @@ export const ANIM_PARAMETER_BOOLEAN = 'BOOLEAN';
  * Used to set an anim state graph parameter as type trigger.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_PARAMETER_TRIGGER = 'TRIGGER';
 
 /**
  * @type {string}
+ * @category Animation
  */
 export const ANIM_BLEND_1D = '1D';
 
 /**
  * @type {string}
+ * @category Animation
  */
 export const ANIM_BLEND_2D_DIRECTIONAL = '2D_DIRECTIONAL';
 
 /**
  * @type {string}
+ * @category Animation
  */
 export const ANIM_BLEND_2D_CARTESIAN = '2D_CARTESIAN';
 
 /**
  * @type {string}
+ * @category Animation
  */
 export const ANIM_BLEND_DIRECT = 'DIRECT';
 
@@ -129,6 +148,7 @@ export const ANIM_BLEND_DIRECT = 'DIRECT';
  * The starting state in an anim state graph layer.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_STATE_START = 'START';
 
@@ -136,6 +156,7 @@ export const ANIM_STATE_START = 'START';
  * The ending state in an anim state graph layer.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_STATE_END = 'END';
 
@@ -143,6 +164,7 @@ export const ANIM_STATE_END = 'END';
  * Used to indicate any state in an anim state graph layer.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_STATE_ANY = 'ANY';
 
@@ -152,6 +174,7 @@ export const ANIM_CONTROL_STATES = [ANIM_STATE_START, ANIM_STATE_END, ANIM_STATE
  * Used to indicate that a layers animations should overwrite all previous layers.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_LAYER_OVERWRITE = 'OVERWRITE';
 
@@ -159,5 +182,6 @@ export const ANIM_LAYER_OVERWRITE = 'OVERWRITE';
  * Used to indicate that a layers animations should blend additively with previous layers.
  *
  * @type {string}
+ * @category Animation
  */
 export const ANIM_LAYER_ADDITIVE = 'ADDITIVE';

--- a/src/framework/components/button/constants.js
+++ b/src/framework/components/button/constants.js
@@ -2,6 +2,7 @@
  * Specifies different color tints for the hover, pressed and inactive states.
  *
  * @type {number}
+ * @category User Interface
  */
 export const BUTTON_TRANSITION_MODE_TINT = 0;
 
@@ -9,5 +10,6 @@ export const BUTTON_TRANSITION_MODE_TINT = 0;
  * Specifies different sprites for the hover, pressed and inactive states.
  *
  * @type {number}
+ * @category User Interface
  */
 export const BUTTON_TRANSITION_MODE_SPRITE_CHANGE = 1;

--- a/src/framework/components/element/constants.js
+++ b/src/framework/components/element/constants.js
@@ -2,6 +2,7 @@
  * A {@link ElementComponent} that contains child {@link ElementComponent}s.
  *
  * @type {string}
+ * @category User Interface
  */
 export const ELEMENTTYPE_GROUP = 'group';
 
@@ -9,6 +10,7 @@ export const ELEMENTTYPE_GROUP = 'group';
  * A {@link ElementComponent} that displays an image.
  *
  * @type {string}
+ * @category User Interface
  */
 export const ELEMENTTYPE_IMAGE = 'image';
 
@@ -16,6 +18,7 @@ export const ELEMENTTYPE_IMAGE = 'image';
  * A {@link ElementComponent} that displays text.
  *
  * @type {string}
+ * @category User Interface
  */
 export const ELEMENTTYPE_TEXT = 'text';
 
@@ -23,6 +26,7 @@ export const ELEMENTTYPE_TEXT = 'text';
  * Fit the content exactly to Element's bounding box.
  *
  * @type {string}
+ * @category User Interface
  */
 export const FITMODE_STRETCH = 'stretch';
 
@@ -30,6 +34,7 @@ export const FITMODE_STRETCH = 'stretch';
  * Fit the content within the Element's bounding box while preserving its Aspect Ratio.
  *
  * @type {string}
+ * @category User Interface
  */
 export const FITMODE_CONTAIN = 'contain';
 
@@ -37,5 +42,6 @@ export const FITMODE_CONTAIN = 'contain';
  * Fit the content to cover the entire Element's bounding box while preserving its Aspect Ratio.
  *
  * @type {string}
+ * @category User Interface
  */
 export const FITMODE_COVER = 'cover';

--- a/src/framework/components/layout-group/constants.js
+++ b/src/framework/components/layout-group/constants.js
@@ -2,6 +2,7 @@
  * Disable all fitting logic.
  *
  * @type {number}
+ * @category User Interface
  */
 export const FITTING_NONE = 0;
 
@@ -9,6 +10,7 @@ export const FITTING_NONE = 0;
  * Stretch child elements to fit the parent container.
  *
  * @type {number}
+ * @category User Interface
  */
 export const FITTING_STRETCH = 1;
 
@@ -16,6 +18,7 @@ export const FITTING_STRETCH = 1;
  * Shrink child elements to fit the parent container.
  *
  * @type {number}
+ * @category User Interface
  */
 export const FITTING_SHRINK = 2;
 
@@ -23,5 +26,6 @@ export const FITTING_SHRINK = 2;
  * Apply both STRETCH and SHRINK fitting logic where applicable.
  *
  * @type {number}
+ * @category User Interface
  */
 export const FITTING_BOTH = 3;

--- a/src/framework/components/rigid-body/constants.js
+++ b/src/framework/components/rigid-body/constants.js
@@ -2,6 +2,7 @@
  * Rigid body has infinite mass and cannot move.
  *
  * @type {string}
+ * @category Physics
  */
 export const BODYTYPE_STATIC = 'static';
 
@@ -9,6 +10,7 @@ export const BODYTYPE_STATIC = 'static';
  * Rigid body is simulated according to applied forces.
  *
  * @type {string}
+ * @category Physics
  */
 export const BODYTYPE_DYNAMIC = 'dynamic';
 
@@ -17,6 +19,7 @@ export const BODYTYPE_DYNAMIC = 'dynamic';
  * their velocity or position.
  *
  * @type {string}
+ * @category Physics
  */
 export const BODYTYPE_KINEMATIC = 'kinematic';
 

--- a/src/framework/components/screen/constants.js
+++ b/src/framework/components/screen/constants.js
@@ -2,6 +2,7 @@
  * Always use the application's resolution as the resolution for the {@link ScreenComponent}.
  *
  * @type {string}
+ * @category User Interface
  */
 export const SCALEMODE_NONE = 'none';
 
@@ -10,5 +11,6 @@ export const SCALEMODE_NONE = 'none';
  * ScreenComponent's referenceResolution.
  *
  * @type {string}
+ * @category User Interface
  */
 export const SCALEMODE_BLEND = 'blend';

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -16,6 +16,7 @@ import { Entity } from '../../entity.js';
  * details on scripting see [Scripting](https://developer.playcanvas.com/user-manual/scripting/).
  *
  * @augments Component
+ * @category Script
  */
 class ScriptComponent extends Component {
     /**

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -21,6 +21,7 @@ let executionOrderCounter = 0;
  * Allows scripts to be attached to an Entity and executed.
  *
  * @augments ComponentSystem
+ * @category Script
  */
 class ScriptComponentSystem extends ComponentSystem {
     /**

--- a/src/framework/components/scroll-view/constants.js
+++ b/src/framework/components/scroll-view/constants.js
@@ -2,6 +2,7 @@
  * Content does not scroll any further than its bounds.
  *
  * @type {number}
+ * @category User Interface
  */
 export const SCROLL_MODE_CLAMP = 0;
 
@@ -9,6 +10,7 @@ export const SCROLL_MODE_CLAMP = 0;
  * Content scrolls past its bounds and then gently bounces back.
  *
  * @type {number}
+ * @category User Interface
  */
 export const SCROLL_MODE_BOUNCE = 1;
 
@@ -16,6 +18,7 @@ export const SCROLL_MODE_BOUNCE = 1;
  * Content can scroll forever.
  *
  * @type {number}
+ * @category User Interface
  */
 export const SCROLL_MODE_INFINITE = 2;
 
@@ -23,6 +26,7 @@ export const SCROLL_MODE_INFINITE = 2;
  * The scrollbar will be visible all the time.
  *
  * @type {number}
+ * @category User Interface
  */
 export const SCROLLBAR_VISIBILITY_SHOW_ALWAYS = 0;
 
@@ -30,5 +34,6 @@ export const SCROLLBAR_VISIBILITY_SHOW_ALWAYS = 0;
  * The scrollbar will be visible only when content exceeds the size of the viewport.
  *
  * @type {number}
+ * @category User Interface
  */
 export const SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED = 1;

--- a/src/framework/components/sprite/constants.js
+++ b/src/framework/components/sprite/constants.js
@@ -2,6 +2,7 @@
  * A {@link SpriteComponent} that displays a single frame from a sprite asset.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SPRITETYPE_SIMPLE = 'simple';
 
@@ -9,5 +10,6 @@ export const SPRITETYPE_SIMPLE = 'simple';
  * A {@link SpriteComponent} that renders sprite animations.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SPRITETYPE_ANIMATED = 'animated';

--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -13,6 +13,7 @@ import { ResourceLoader } from './loader.js';
  * files, such as third-party libraries.
  *
  * @implements {ResourceHandler}
+ * @category Script
  */
 class ScriptHandler {
     /**

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -30,6 +30,7 @@ let _createdLoadingScreen = false;
  * PlayCanvas loading screen.
  *
  * @namespace
+ * @category Script
  */
 const script = {
     // set during script load to be used for initializing script

--- a/src/framework/script/script-attributes.js
+++ b/src/framework/script/script-attributes.js
@@ -152,6 +152,8 @@ function rawToValue(app, args, value, old) {
  * Container of Script Attribute definitions. Implements an interface to add/remove attributes and
  * store their definition for a {@link ScriptType}. Note: An instance of ScriptAttributes is
  * created automatically by each {@link ScriptType}.
+ *
+ * @category Script
  */
 class ScriptAttributes {
     /**

--- a/src/framework/script/script-registry.js
+++ b/src/framework/script/script-registry.js
@@ -6,6 +6,7 @@ import { EventHandler } from '../../core/event-handler.js';
  * {@link AppBase#scripts}.
  *
  * @augments EventHandler
+ * @category Script
  */
 class ScriptRegistry extends EventHandler {
     /**

--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -31,6 +31,7 @@ const funcNameRegex = new RegExp('^\\s*function(?:\\s|\\s*\\/\\*.*\\*\\/\\s*)+([
  * reload at runtime.
  *
  * @augments EventHandler
+ * @category Script
  */
 class ScriptType extends EventHandler {
     /**

--- a/src/framework/script/script.js
+++ b/src/framework/script/script.js
@@ -54,6 +54,7 @@ function getReservedScriptNames() {
  * Turning.prototype.update = function (dt) {
  *     this.entity.rotate(0, this.speed * dt, 0);
  * };
+ * @category Script
  */
 function createScript(name, app) {
     if (script.legacy) {
@@ -123,6 +124,7 @@ createScript.reservedAttributes = reservedAttributes;
  *
  * // declare script attributes (Must be after pc.registerScript())
  * PlayerController.attributes.add('attribute1', {type: 'number'});
+ * @category Script
  */
 function registerScript(script, name, app) {
     if (script.legacy) {

--- a/src/framework/xr/constants.js
+++ b/src/framework/xr/constants.js
@@ -3,6 +3,7 @@
  * into HTML element.
  *
  * @type {string}
+ * @category XR
  */
 export const XRTYPE_INLINE = 'inline';
 
@@ -11,6 +12,7 @@ export const XRTYPE_INLINE = 'inline';
  * features.
  *
  * @type {string}
+ * @category XR
  */
 export const XRTYPE_VR = 'immersive-vr';
 
@@ -19,6 +21,7 @@ export const XRTYPE_VR = 'immersive-vr';
  * blended with real-world environment.
  *
  * @type {string}
+ * @category XR
  */
 export const XRTYPE_AR = 'immersive-ar';
 
@@ -26,6 +29,7 @@ export const XRTYPE_AR = 'immersive-ar';
  * Viewer - always supported space with some basic tracking capabilities.
  *
  * @type {string}
+ * @category XR
  */
 export const XRSPACE_VIEWER = 'viewer';
 
@@ -38,6 +42,7 @@ export const XRSPACE_VIEWER = 'viewer';
  * to the user's environment.
  *
  * @type {string}
+ * @category XR
  */
 export const XRSPACE_LOCAL = 'local';
 
@@ -51,6 +56,7 @@ export const XRSPACE_LOCAL = 'local';
  * keeping the origin stable relative to the user's environment.
  *
  * @type {string}
+ * @category XR
  */
 export const XRSPACE_LOCALFLOOR = 'local-floor';
 
@@ -61,6 +67,7 @@ export const XRSPACE_LOCALFLOOR = 'local-floor';
  * user's environment.
  *
  * @type {string}
+ * @category XR
  */
 export const XRSPACE_BOUNDEDFLOOR = 'bounded-floor';
 
@@ -71,6 +78,7 @@ export const XRSPACE_BOUNDEDFLOOR = 'bounded-floor';
  * native origin may drift over time.
  *
  * @type {string}
+ * @category XR
  */
 export const XRSPACE_UNBOUNDED = 'unbounded';
 
@@ -80,6 +88,7 @@ export const XRSPACE_UNBOUNDED = 'unbounded';
  * displays.
  *
  * @type {string}
+ * @category XR
  */
 export const XRTARGETRAY_GAZE = 'gaze';
 
@@ -88,6 +97,7 @@ export const XRTARGETRAY_GAZE = 'gaze';
  * with an inline session's output context, such as a mouse click or touch event.
  *
  * @type {string}
+ * @category XR
  */
 export const XRTARGETRAY_SCREEN = 'screen';
 
@@ -97,6 +107,7 @@ export const XRTARGETRAY_SCREEN = 'screen';
  * device for pointing.
  *
  * @type {string}
+ * @category XR
  */
 export const XRTARGETRAY_POINTER = 'tracked-pointer';
 
@@ -104,6 +115,7 @@ export const XRTARGETRAY_POINTER = 'tracked-pointer';
  * None - view associated with a monoscopic screen, such as mobile phone screens.
  *
  * @type {string}
+ * @category XR
  */
 export const XREYE_NONE = 'none';
 
@@ -111,6 +123,7 @@ export const XREYE_NONE = 'none';
  * Left - view associated with left eye.
  *
  * @type {string}
+ * @category XR
  */
 export const XREYE_LEFT = 'left';
 
@@ -118,6 +131,7 @@ export const XREYE_LEFT = 'left';
  * Right - view associated with right eye.
  *
  * @type {string}
+ * @category XR
  */
 export const XREYE_RIGHT = 'right';
 
@@ -125,6 +139,7 @@ export const XREYE_RIGHT = 'right';
  * None - input source is not meant to be held in hands.
  *
  * @type {string}
+ * @category XR
  */
 export const XRHAND_NONE = 'none';
 
@@ -132,6 +147,7 @@ export const XRHAND_NONE = 'none';
  * Left - indicates that input source is meant to be held in left hand.
  *
  * @type {string}
+ * @category XR
  */
 export const XRHAND_LEFT = 'left';
 
@@ -139,6 +155,7 @@ export const XRHAND_LEFT = 'left';
  * Right - indicates that input source is meant to be held in right hand.
  *
  * @type {string}
+ * @category XR
  */
 export const XRHAND_RIGHT = 'right';
 
@@ -147,6 +164,7 @@ export const XRHAND_RIGHT = 'right';
  * detected by the underlying Augmented Reality system.
  *
  * @type {string}
+ * @category XR
  */
 export const XRTRACKABLE_POINT = 'point';
 
@@ -155,6 +173,7 @@ export const XRTRACKABLE_POINT = 'point';
  * underlying Augmented Reality system.
  *
  * @type {string}
+ * @category XR
  */
 export const XRTRACKABLE_PLANE = 'plane';
 
@@ -163,6 +182,7 @@ export const XRTRACKABLE_PLANE = 'plane';
  * underlying Augmented Reality system.
  *
  * @type {string}
+ * @category XR
  */
 export const XRTRACKABLE_MESH = 'mesh';
 
@@ -171,6 +191,7 @@ export const XRTRACKABLE_MESH = 'mesh';
  * supported.
  *
  * @type {string}
+ * @category XR
  */
 export const XRDEPTHSENSINGUSAGE_CPU = 'cpu-optimized';
 
@@ -178,6 +199,7 @@ export const XRDEPTHSENSINGUSAGE_CPU = 'cpu-optimized';
  * GPU - indicates that depth sensing preferred usage is GPU.
  *
  * @type {string}
+ * @category XR
  */
 export const XRDEPTHSENSINGUSAGE_GPU = 'gpu-optimized';
 
@@ -186,6 +208,7 @@ export const XRDEPTHSENSINGUSAGE_GPU = 'gpu-optimized';
  * This format is guaranteed to be supported.
  *
  * @type {string}
+ * @category XR
  */
 export const XRDEPTHSENSINGFORMAT_L8A8 = 'luminance-alpha';
 
@@ -193,5 +216,6 @@ export const XRDEPTHSENSINGFORMAT_L8A8 = 'luminance-alpha';
  * Float 32 - indicates that depth sensing preferred raw data format is Float 32.
  *
  * @type {string}
+ * @category XR
  */
 export const XRDEPTHSENSINGFORMAT_F32 = 'float32';

--- a/src/platform/audio/constants.js
+++ b/src/platform/audio/constants.js
@@ -2,6 +2,7 @@
  * Linear distance model.
  *
  * @type {string}
+ * @category Sound
  */
 export const DISTANCE_LINEAR = 'linear';
 
@@ -9,6 +10,7 @@ export const DISTANCE_LINEAR = 'linear';
  * Inverse distance model.
  *
  * @type {string}
+ * @category Sound
  */
 export const DISTANCE_INVERSE = 'inverse';
 
@@ -16,5 +18,6 @@ export const DISTANCE_INVERSE = 'inverse';
  * Exponential distance model.
  *
  * @type {string}
+ * @category Sound
  */
 export const DISTANCE_EXPONENTIAL = 'exponential';

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -2,6 +2,7 @@
  * Ignores the integer part of texture coordinates, using only the fractional part.
  *
  * @type {number}
+ * @category Graphics
  */
 export const ADDRESS_REPEAT = 0;
 
@@ -9,6 +10,7 @@ export const ADDRESS_REPEAT = 0;
  * Clamps texture coordinate to the range 0 to 1.
  *
  * @type {number}
+ * @category Graphics
  */
 export const ADDRESS_CLAMP_TO_EDGE = 1;
 
@@ -17,6 +19,7 @@ export const ADDRESS_CLAMP_TO_EDGE = 1;
  * part is odd, then the texture coordinate is set to 1 minus the fractional part.
  *
  * @type {number}
+ * @category Graphics
  */
 export const ADDRESS_MIRRORED_REPEAT = 2;
 
@@ -24,6 +27,7 @@ export const ADDRESS_MIRRORED_REPEAT = 2;
  * Multiply all fragment components by zero.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_ZERO = 0;
 
@@ -31,6 +35,7 @@ export const BLENDMODE_ZERO = 0;
  * Multiply all fragment components by one.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_ONE = 1;
 
@@ -38,6 +43,7 @@ export const BLENDMODE_ONE = 1;
  * Multiply all fragment components by the components of the source fragment.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_SRC_COLOR = 2;
 
@@ -45,6 +51,7 @@ export const BLENDMODE_SRC_COLOR = 2;
  * Multiply all fragment components by one minus the components of the source fragment.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_ONE_MINUS_SRC_COLOR = 3;
 
@@ -52,6 +59,7 @@ export const BLENDMODE_ONE_MINUS_SRC_COLOR = 3;
  * Multiply all fragment components by the components of the destination fragment.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_DST_COLOR = 4;
 
@@ -59,6 +67,7 @@ export const BLENDMODE_DST_COLOR = 4;
  * Multiply all fragment components by one minus the components of the destination fragment.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_ONE_MINUS_DST_COLOR = 5;
 
@@ -66,6 +75,7 @@ export const BLENDMODE_ONE_MINUS_DST_COLOR = 5;
  * Multiply all fragment components by the alpha value of the source fragment.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_SRC_ALPHA = 6;
 
@@ -73,6 +83,7 @@ export const BLENDMODE_SRC_ALPHA = 6;
  * Multiply all fragment components by the alpha value of the source fragment.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_SRC_ALPHA_SATURATE = 7;
 
@@ -80,6 +91,7 @@ export const BLENDMODE_SRC_ALPHA_SATURATE = 7;
  * Multiply all fragment components by one minus the alpha value of the source fragment.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_ONE_MINUS_SRC_ALPHA = 8;
 
@@ -87,6 +99,7 @@ export const BLENDMODE_ONE_MINUS_SRC_ALPHA = 8;
  * Multiply all fragment components by the alpha value of the destination fragment.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_DST_ALPHA = 9;
 
@@ -94,6 +107,7 @@ export const BLENDMODE_DST_ALPHA = 9;
  * Multiply all fragment components by one minus the alpha value of the destination fragment.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_ONE_MINUS_DST_ALPHA = 10;
 
@@ -101,6 +115,7 @@ export const BLENDMODE_ONE_MINUS_DST_ALPHA = 10;
  * Multiplies all fragment components by a constant.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_CONSTANT = 11;
 
@@ -108,6 +123,7 @@ export const BLENDMODE_CONSTANT = 11;
  * Multiplies all fragment components by 1 minus a constant.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDMODE_ONE_MINUS_CONSTANT = 12;
 
@@ -115,6 +131,7 @@ export const BLENDMODE_ONE_MINUS_CONSTANT = 12;
  * Add the results of the source and destination fragment multiplies.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDEQUATION_ADD = 0;
 
@@ -122,6 +139,7 @@ export const BLENDEQUATION_ADD = 0;
  * Subtract the results of the source and destination fragment multiplies.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDEQUATION_SUBTRACT = 1;
 
@@ -129,6 +147,7 @@ export const BLENDEQUATION_SUBTRACT = 1;
  * Reverse and subtract the results of the source and destination fragment multiplies.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDEQUATION_REVERSE_SUBTRACT = 2;
 
@@ -136,6 +155,7 @@ export const BLENDEQUATION_REVERSE_SUBTRACT = 2;
  * Use the smallest value. Check app.graphicsDevice.extBlendMinmax for support.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDEQUATION_MIN = 3;
 
@@ -143,6 +163,7 @@ export const BLENDEQUATION_MIN = 3;
  * Use the largest value. Check app.graphicsDevice.extBlendMinmax for support.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLENDEQUATION_MAX = 4;
 
@@ -150,6 +171,7 @@ export const BLENDEQUATION_MAX = 4;
  * The data store contents will be modified once and used many times.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BUFFER_STATIC = 0;
 
@@ -157,6 +179,7 @@ export const BUFFER_STATIC = 0;
  * The data store contents will be modified repeatedly and used many times.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BUFFER_DYNAMIC = 1;
 
@@ -164,6 +187,7 @@ export const BUFFER_DYNAMIC = 1;
  * The data store contents will be modified once and used at most a few times.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BUFFER_STREAM = 2;
 
@@ -172,6 +196,7 @@ export const BUFFER_STREAM = 2;
  * transform feedback usage (WebGL2 only).
  *
  * @type {number}
+ * @category Graphics
  */
 export const BUFFER_GPUDYNAMIC = 3;
 
@@ -179,6 +204,7 @@ export const BUFFER_GPUDYNAMIC = 3;
  * Clear the color buffer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CLEARFLAG_COLOR = 1;
 
@@ -186,6 +212,7 @@ export const CLEARFLAG_COLOR = 1;
  * Clear the depth buffer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CLEARFLAG_DEPTH = 2;
 
@@ -193,6 +220,7 @@ export const CLEARFLAG_DEPTH = 2;
  * Clear the stencil buffer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CLEARFLAG_STENCIL = 4;
 
@@ -200,6 +228,7 @@ export const CLEARFLAG_STENCIL = 4;
  * The positive X face of a cubemap.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CUBEFACE_POSX = 0;
 
@@ -207,6 +236,7 @@ export const CUBEFACE_POSX = 0;
  * The negative X face of a cubemap.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CUBEFACE_NEGX = 1;
 
@@ -214,6 +244,7 @@ export const CUBEFACE_NEGX = 1;
  * The positive Y face of a cubemap.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CUBEFACE_POSY = 2;
 
@@ -221,6 +252,7 @@ export const CUBEFACE_POSY = 2;
  * The negative Y face of a cubemap.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CUBEFACE_NEGY = 3;
 
@@ -228,6 +260,7 @@ export const CUBEFACE_NEGY = 3;
  * The positive Z face of a cubemap.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CUBEFACE_POSZ = 4;
 
@@ -235,6 +268,7 @@ export const CUBEFACE_POSZ = 4;
  * The negative Z face of a cubemap.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CUBEFACE_NEGZ = 5;
 
@@ -242,6 +276,7 @@ export const CUBEFACE_NEGZ = 5;
  * No triangles are culled.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CULLFACE_NONE = 0;
 
@@ -249,6 +284,7 @@ export const CULLFACE_NONE = 0;
  * Triangles facing away from the view direction are culled.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CULLFACE_BACK = 1;
 
@@ -256,6 +292,7 @@ export const CULLFACE_BACK = 1;
  * Triangles facing the view direction are culled.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CULLFACE_FRONT = 2;
 
@@ -265,6 +302,7 @@ export const CULLFACE_FRONT = 2;
  *
  * @type {number}
  * @ignore
+ * @category Graphics
  */
 export const CULLFACE_FRONTANDBACK = 3;
 
@@ -272,6 +310,7 @@ export const CULLFACE_FRONTANDBACK = 3;
  * Point sample filtering.
  *
  * @type {number}
+ * @category Graphics
  */
 export const FILTER_NEAREST = 0;
 
@@ -279,6 +318,7 @@ export const FILTER_NEAREST = 0;
  * Bilinear filtering.
  *
  * @type {number}
+ * @category Graphics
  */
 export const FILTER_LINEAR = 1;
 
@@ -286,6 +326,7 @@ export const FILTER_LINEAR = 1;
  * Use the nearest neighbor in the nearest mipmap level.
  *
  * @type {number}
+ * @category Graphics
  */
 export const FILTER_NEAREST_MIPMAP_NEAREST = 2;
 
@@ -293,6 +334,7 @@ export const FILTER_NEAREST_MIPMAP_NEAREST = 2;
  * Linearly interpolate in the nearest mipmap level.
  *
  * @type {number}
+ * @category Graphics
  */
 export const FILTER_NEAREST_MIPMAP_LINEAR = 3;
 
@@ -300,6 +342,7 @@ export const FILTER_NEAREST_MIPMAP_LINEAR = 3;
  * Use the nearest neighbor after linearly interpolating between mipmap levels.
  *
  * @type {number}
+ * @category Graphics
  */
 export const FILTER_LINEAR_MIPMAP_NEAREST = 4;
 
@@ -307,6 +350,7 @@ export const FILTER_LINEAR_MIPMAP_NEAREST = 4;
  * Linearly interpolate both the mipmap levels and between texels.
  *
  * @type {number}
+ * @category Graphics
  */
 export const FILTER_LINEAR_MIPMAP_LINEAR = 5;
 
@@ -314,6 +358,7 @@ export const FILTER_LINEAR_MIPMAP_LINEAR = 5;
  * Never pass.
  *
  * @type {number}
+ * @category Graphics
  */
 export const FUNC_NEVER = 0;
 
@@ -321,6 +366,7 @@ export const FUNC_NEVER = 0;
  * Pass if (ref & mask) < (stencil & mask).
  *
  * @type {number}
+ * @category Graphics
  */
 export const FUNC_LESS = 1;
 
@@ -328,6 +374,7 @@ export const FUNC_LESS = 1;
  * Pass if (ref & mask) == (stencil & mask).
  *
  * @type {number}
+ * @category Graphics
  */
 export const FUNC_EQUAL = 2;
 
@@ -335,6 +382,7 @@ export const FUNC_EQUAL = 2;
  * Pass if (ref & mask) <= (stencil & mask).
  *
  * @type {number}
+ * @category Graphics
  */
 export const FUNC_LESSEQUAL = 3;
 
@@ -342,6 +390,7 @@ export const FUNC_LESSEQUAL = 3;
  * Pass if (ref & mask) > (stencil & mask).
  *
  * @type {number}
+ * @category Graphics
  */
 export const FUNC_GREATER = 4;
 
@@ -349,6 +398,7 @@ export const FUNC_GREATER = 4;
  * Pass if (ref & mask) != (stencil & mask).
  *
  * @type {number}
+ * @category Graphics
  */
 export const FUNC_NOTEQUAL = 5;
 
@@ -356,6 +406,7 @@ export const FUNC_NOTEQUAL = 5;
  * Pass if (ref & mask) >= (stencil & mask).
  *
  * @type {number}
+ * @category Graphics
  */
 export const FUNC_GREATEREQUAL = 6;
 
@@ -363,6 +414,7 @@ export const FUNC_GREATEREQUAL = 6;
  * Always pass.
  *
  * @type {number}
+ * @category Graphics
  */
 export const FUNC_ALWAYS = 7;
 
@@ -370,6 +422,7 @@ export const FUNC_ALWAYS = 7;
  * 8-bit unsigned vertex indices (0 to 255).
  *
  * @type {number}
+ * @category Graphics
  */
 export const INDEXFORMAT_UINT8 = 0;
 
@@ -377,6 +430,7 @@ export const INDEXFORMAT_UINT8 = 0;
  * 16-bit unsigned vertex indices (0 to 65,535).
  *
  * @type {number}
+ * @category Graphics
  */
 export const INDEXFORMAT_UINT16 = 1;
 
@@ -384,6 +438,7 @@ export const INDEXFORMAT_UINT16 = 1;
  * 32-bit unsigned vertex indices (0 to 4,294,967,295).
  *
  * @type {number}
+ * @category Graphics
  */
 export const INDEXFORMAT_UINT32 = 2;
 
@@ -391,6 +446,7 @@ export const INDEXFORMAT_UINT32 = 2;
  * 8-bit alpha.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_A8 = 0;
 
@@ -398,6 +454,7 @@ export const PIXELFORMAT_A8 = 0;
  * 8-bit luminance.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_L8 = 1;
 
@@ -405,6 +462,7 @@ export const PIXELFORMAT_L8 = 1;
  * 8-bit luminance with 8-bit alpha.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_LA8 = 2;
 
@@ -412,6 +470,7 @@ export const PIXELFORMAT_LA8 = 2;
  * 16-bit RGB (5-bits for red channel, 6 for green and 5 for blue).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGB565 = 3;
 
@@ -419,6 +478,7 @@ export const PIXELFORMAT_RGB565 = 3;
  * 16-bit RGBA (5-bits for red channel, 5 for green, 5 for blue with 1-bit alpha).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA5551 = 4;
 
@@ -426,6 +486,7 @@ export const PIXELFORMAT_RGBA5551 = 4;
  * 16-bit RGBA (4-bits for red channel, 4 for green, 4 for blue with 4-bit alpha).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA4 = 5;
 
@@ -433,6 +494,7 @@ export const PIXELFORMAT_RGBA4 = 5;
  * 24-bit RGB (8-bits for red channel, 8 for green and 8 for blue).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGB8 = 6;
 
@@ -440,6 +502,7 @@ export const PIXELFORMAT_RGB8 = 6;
  * 32-bit RGBA (8-bits for red channel, 8 for green, 8 for blue with 8-bit alpha).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA8 = 7;
 
@@ -448,6 +511,7 @@ export const PIXELFORMAT_RGBA8 = 7;
  * RGB 5:6:5 color values and a 4x4 two bit lookup table.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_DXT1 = 8;
 
@@ -457,6 +521,7 @@ export const PIXELFORMAT_DXT1 = 8;
  * 64 bits of color data; encoded the same way as DXT1.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_DXT3 = 9;
 
@@ -466,6 +531,7 @@ export const PIXELFORMAT_DXT3 = 9;
  * of color data (encoded the same way as DXT1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_DXT5 = 10;
 
@@ -473,6 +539,7 @@ export const PIXELFORMAT_DXT5 = 10;
  * 16-bit floating point RGB (16-bit float for each red, green and blue channels).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGB16F = 11;
 
@@ -480,6 +547,7 @@ export const PIXELFORMAT_RGB16F = 11;
  * 16-bit floating point RGBA (16-bit float for each red, green, blue and alpha channels).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA16F = 12;
 
@@ -487,6 +555,7 @@ export const PIXELFORMAT_RGBA16F = 12;
  * 32-bit floating point RGB (32-bit float for each red, green and blue channels).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGB32F = 13;
 
@@ -494,6 +563,7 @@ export const PIXELFORMAT_RGB32F = 13;
  * 32-bit floating point RGBA (32-bit float for each red, green, blue and alpha channels).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA32F = 14;
 
@@ -501,6 +571,7 @@ export const PIXELFORMAT_RGBA32F = 14;
  * 32-bit floating point single channel format (WebGL2 only).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_R32F = 15;
 
@@ -508,6 +579,7 @@ export const PIXELFORMAT_R32F = 15;
  * A readable depth buffer format.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_DEPTH = 16;
 
@@ -515,6 +587,7 @@ export const PIXELFORMAT_DEPTH = 16;
  * A readable depth/stencil buffer format (WebGL2 only).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_DEPTHSTENCIL = 17;
 
@@ -523,6 +596,7 @@ export const PIXELFORMAT_DEPTHSTENCIL = 17;
  * blue channel (WebGL2 only).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_111110F = 18;
 
@@ -530,6 +604,7 @@ export const PIXELFORMAT_111110F = 18;
  * Color-only sRGB format (WebGL2 only).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_SRGB = 19;
 
@@ -537,6 +612,7 @@ export const PIXELFORMAT_SRGB = 19;
  * Color sRGB format with additional alpha channel (WebGL2 only).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_SRGBA = 20;
 
@@ -544,6 +620,7 @@ export const PIXELFORMAT_SRGBA = 20;
  * ETC1 compressed format.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_ETC1 = 21;
 
@@ -551,6 +628,7 @@ export const PIXELFORMAT_ETC1 = 21;
  * ETC2 (RGB) compressed format.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_ETC2_RGB = 22;
 
@@ -558,6 +636,7 @@ export const PIXELFORMAT_ETC2_RGB = 22;
  * ETC2 (RGBA) compressed format.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_ETC2_RGBA = 23;
 
@@ -565,6 +644,7 @@ export const PIXELFORMAT_ETC2_RGBA = 23;
  * PVRTC (2BPP RGB) compressed format.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_PVRTC_2BPP_RGB_1 = 24;
 
@@ -572,6 +652,7 @@ export const PIXELFORMAT_PVRTC_2BPP_RGB_1 = 24;
  * PVRTC (2BPP RGBA) compressed format.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_PVRTC_2BPP_RGBA_1 = 25;
 
@@ -579,6 +660,7 @@ export const PIXELFORMAT_PVRTC_2BPP_RGBA_1 = 25;
  * PVRTC (4BPP RGB) compressed format.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_PVRTC_4BPP_RGB_1 = 26;
 
@@ -586,6 +668,7 @@ export const PIXELFORMAT_PVRTC_4BPP_RGB_1 = 26;
  * PVRTC (4BPP RGBA) compressed format.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_PVRTC_4BPP_RGBA_1 = 27;
 
@@ -593,6 +676,7 @@ export const PIXELFORMAT_PVRTC_4BPP_RGBA_1 = 27;
  * ATC compressed format with alpha channel in blocks of 4x4.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_ASTC_4x4 = 28;
 
@@ -600,6 +684,7 @@ export const PIXELFORMAT_ASTC_4x4 = 28;
  * ATC compressed format with no alpha channel.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_ATC_RGB = 29;
 
@@ -607,6 +692,7 @@ export const PIXELFORMAT_ATC_RGB = 29;
  * ATC compressed format with alpha channel.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_ATC_RGBA = 30;
 
@@ -615,6 +701,7 @@ export const PIXELFORMAT_ATC_RGBA = 30;
  *
  * @type {number}
  * @ignore
+ * @category Graphics
  */
 export const PIXELFORMAT_BGRA8 = 31;
 
@@ -622,6 +709,7 @@ export const PIXELFORMAT_BGRA8 = 31;
  * 8-bit signed integer single-channel (R) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_R8I = 32;
 
@@ -629,6 +717,7 @@ export const PIXELFORMAT_R8I = 32;
  * 8-bit unsigned integer single-channel (R) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_R8U = 33;
 
@@ -636,6 +725,7 @@ export const PIXELFORMAT_R8U = 33;
  * 16-bit signed integer single-channel (R) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_R16I = 34;
 
@@ -643,6 +733,7 @@ export const PIXELFORMAT_R16I = 34;
  * 16-bit unsigned integer single-channel (R) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_R16U = 35;
 
@@ -650,6 +741,7 @@ export const PIXELFORMAT_R16U = 35;
  * 32-bit signed integer single-channel (R) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_R32I = 36;
 
@@ -657,6 +749,7 @@ export const PIXELFORMAT_R32I = 36;
  * 32-bit unsigned integer single-channel (R) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_R32U = 37;
 
@@ -664,6 +757,7 @@ export const PIXELFORMAT_R32U = 37;
  * 8-bit per-channel signed integer (RG) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RG8I = 38;
 
@@ -671,6 +765,7 @@ export const PIXELFORMAT_RG8I = 38;
  * 8-bit per-channel unsigned integer (RG) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RG8U = 39;
 
@@ -678,6 +773,7 @@ export const PIXELFORMAT_RG8U = 39;
  * 16-bit per-channel signed integer (RG) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RG16I = 40;
 
@@ -685,6 +781,7 @@ export const PIXELFORMAT_RG16I = 40;
  * 16-bit per-channel unsigned integer (RG) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RG16U = 41;
 
@@ -692,6 +789,7 @@ export const PIXELFORMAT_RG16U = 41;
  * 32-bit per-channel signed integer (RG) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RG32I = 42;
 
@@ -699,6 +797,7 @@ export const PIXELFORMAT_RG32I = 42;
  * 32-bit per-channel unsigned integer (RG) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RG32U = 43;
 
@@ -706,6 +805,7 @@ export const PIXELFORMAT_RG32U = 43;
  * 8-bit per-channel signed integer (RGBA) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA8I = 44;
 
@@ -713,6 +813,7 @@ export const PIXELFORMAT_RGBA8I = 44;
  * 8-bit per-channel unsigned integer (RGBA) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA8U = 45;
 
@@ -720,6 +821,7 @@ export const PIXELFORMAT_RGBA8U = 45;
  * 16-bit per-channel signed integer (RGBA) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA16I = 46;
 
@@ -727,6 +829,7 @@ export const PIXELFORMAT_RGBA16I = 46;
  * 16-bit per-channel unsigned integer (RGBA) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA16U = 47;
 
@@ -734,6 +837,7 @@ export const PIXELFORMAT_RGBA16U = 47;
  * 32-bit per-channel signed integer (RGBA) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA32I = 48;
 
@@ -741,6 +845,7 @@ export const PIXELFORMAT_RGBA32I = 48;
  * 32-bit per-channel unsigned integer (RGBA) format (Not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const PIXELFORMAT_RGBA32U = 49;
 
@@ -854,6 +959,7 @@ export const getPixelFormatArrayType = (format) => {
  * List of distinct points.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PRIMITIVE_POINTS = 0;
 
@@ -861,6 +967,7 @@ export const PRIMITIVE_POINTS = 0;
  * Discrete list of line segments.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PRIMITIVE_LINES = 1;
 
@@ -869,6 +976,7 @@ export const PRIMITIVE_LINES = 1;
  * between the last and first points.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PRIMITIVE_LINELOOP = 2;
 
@@ -876,6 +984,7 @@ export const PRIMITIVE_LINELOOP = 2;
  * List of points that are linked sequentially by line segments.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PRIMITIVE_LINESTRIP = 3;
 
@@ -883,6 +992,7 @@ export const PRIMITIVE_LINESTRIP = 3;
  * Discrete list of triangles.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PRIMITIVE_TRIANGLES = 4;
 
@@ -890,6 +1000,7 @@ export const PRIMITIVE_TRIANGLES = 4;
  * Connected strip of triangles where a specified vertex forms a triangle using the previous two.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PRIMITIVE_TRISTRIP = 5;
 
@@ -897,6 +1008,7 @@ export const PRIMITIVE_TRISTRIP = 5;
  * Connected fan of triangles where the first vertex forms triangles with the following pairs of vertices.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PRIMITIVE_TRIFAN = 6;
 
@@ -904,6 +1016,7 @@ export const PRIMITIVE_TRIFAN = 6;
  * Vertex attribute to be treated as a position.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_POSITION = "POSITION";
 
@@ -911,6 +1024,7 @@ export const SEMANTIC_POSITION = "POSITION";
  * Vertex attribute to be treated as a normal.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_NORMAL = "NORMAL";
 
@@ -918,6 +1032,7 @@ export const SEMANTIC_NORMAL = "NORMAL";
  * Vertex attribute to be treated as a tangent.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_TANGENT = "TANGENT";
 
@@ -925,6 +1040,7 @@ export const SEMANTIC_TANGENT = "TANGENT";
  * Vertex attribute to be treated as skin blend weights.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_BLENDWEIGHT = "BLENDWEIGHT";
 
@@ -932,6 +1048,7 @@ export const SEMANTIC_BLENDWEIGHT = "BLENDWEIGHT";
  * Vertex attribute to be treated as skin blend indices.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_BLENDINDICES = "BLENDINDICES";
 
@@ -939,6 +1056,7 @@ export const SEMANTIC_BLENDINDICES = "BLENDINDICES";
  * Vertex attribute to be treated as a color.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_COLOR = "COLOR";
 
@@ -949,6 +1067,7 @@ export const SEMANTIC_TEXCOORD = "TEXCOORD";
  * Vertex attribute to be treated as a texture coordinate (set 0).
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_TEXCOORD0 = "TEXCOORD0";
 
@@ -956,6 +1075,7 @@ export const SEMANTIC_TEXCOORD0 = "TEXCOORD0";
  * Vertex attribute to be treated as a texture coordinate (set 1).
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_TEXCOORD1 = "TEXCOORD1";
 
@@ -963,6 +1083,7 @@ export const SEMANTIC_TEXCOORD1 = "TEXCOORD1";
  * Vertex attribute to be treated as a texture coordinate (set 2).
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_TEXCOORD2 = "TEXCOORD2";
 
@@ -970,6 +1091,7 @@ export const SEMANTIC_TEXCOORD2 = "TEXCOORD2";
  * Vertex attribute to be treated as a texture coordinate (set 3).
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_TEXCOORD3 = "TEXCOORD3";
 
@@ -977,6 +1099,7 @@ export const SEMANTIC_TEXCOORD3 = "TEXCOORD3";
  * Vertex attribute to be treated as a texture coordinate (set 4).
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_TEXCOORD4 = "TEXCOORD4";
 
@@ -984,6 +1107,7 @@ export const SEMANTIC_TEXCOORD4 = "TEXCOORD4";
  * Vertex attribute to be treated as a texture coordinate (set 5).
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_TEXCOORD5 = "TEXCOORD5";
 
@@ -991,6 +1115,7 @@ export const SEMANTIC_TEXCOORD5 = "TEXCOORD5";
  * Vertex attribute to be treated as a texture coordinate (set 6).
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_TEXCOORD6 = "TEXCOORD6";
 
@@ -998,6 +1123,7 @@ export const SEMANTIC_TEXCOORD6 = "TEXCOORD6";
  * Vertex attribute to be treated as a texture coordinate (set 7).
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_TEXCOORD7 = "TEXCOORD7";
 
@@ -1008,6 +1134,7 @@ export const SEMANTIC_ATTR = "ATTR";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR0 = "ATTR0";
 
@@ -1015,6 +1142,7 @@ export const SEMANTIC_ATTR0 = "ATTR0";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR1 = "ATTR1";
 
@@ -1022,6 +1150,7 @@ export const SEMANTIC_ATTR1 = "ATTR1";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR2 = "ATTR2";
 
@@ -1029,6 +1158,7 @@ export const SEMANTIC_ATTR2 = "ATTR2";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR3 = "ATTR3";
 
@@ -1036,6 +1166,7 @@ export const SEMANTIC_ATTR3 = "ATTR3";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR4 = "ATTR4";
 
@@ -1043,6 +1174,7 @@ export const SEMANTIC_ATTR4 = "ATTR4";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR5 = "ATTR5";
 
@@ -1050,6 +1182,7 @@ export const SEMANTIC_ATTR5 = "ATTR5";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR6 = "ATTR6";
 
@@ -1057,6 +1190,7 @@ export const SEMANTIC_ATTR6 = "ATTR6";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR7 = "ATTR7";
 
@@ -1064,6 +1198,7 @@ export const SEMANTIC_ATTR7 = "ATTR7";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR8 = "ATTR8";
 
@@ -1071,6 +1206,7 @@ export const SEMANTIC_ATTR8 = "ATTR8";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR9 = "ATTR9";
 
@@ -1078,6 +1214,7 @@ export const SEMANTIC_ATTR9 = "ATTR9";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR10 = "ATTR10";
 
@@ -1085,6 +1222,7 @@ export const SEMANTIC_ATTR10 = "ATTR10";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR11 = "ATTR11";
 
@@ -1092,6 +1230,7 @@ export const SEMANTIC_ATTR11 = "ATTR11";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR12 = "ATTR12";
 
@@ -1099,6 +1238,7 @@ export const SEMANTIC_ATTR12 = "ATTR12";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR13 = "ATTR13";
 
@@ -1106,6 +1246,7 @@ export const SEMANTIC_ATTR13 = "ATTR13";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR14 = "ATTR14";
 
@@ -1113,6 +1254,7 @@ export const SEMANTIC_ATTR14 = "ATTR14";
  * Vertex attribute with a user defined semantic.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SEMANTIC_ATTR15 = "ATTR15";
 
@@ -1122,6 +1264,7 @@ export const SHADERTAG_MATERIAL = 1;
  * Don't change the stencil buffer value.
  *
  * @type {number}
+ * @category Graphics
  */
 export const STENCILOP_KEEP = 0;
 
@@ -1129,6 +1272,7 @@ export const STENCILOP_KEEP = 0;
  * Set value to zero.
  *
  * @type {number}
+ * @category Graphics
  */
 export const STENCILOP_ZERO = 1;
 
@@ -1136,6 +1280,7 @@ export const STENCILOP_ZERO = 1;
  * Replace value with the reference value (see {@link StencilParameters}).
  *
  * @type {number}
+ * @category Graphics
  */
 export const STENCILOP_REPLACE = 2;
 
@@ -1143,6 +1288,7 @@ export const STENCILOP_REPLACE = 2;
  * Increment the value.
  *
  * @type {number}
+ * @category Graphics
  */
 export const STENCILOP_INCREMENT = 3;
 
@@ -1150,6 +1296,7 @@ export const STENCILOP_INCREMENT = 3;
  * Increment the value but wrap it to zero when it's larger than a maximum representable value.
  *
  * @type {number}
+ * @category Graphics
  */
 export const STENCILOP_INCREMENTWRAP = 4;
 
@@ -1157,6 +1304,7 @@ export const STENCILOP_INCREMENTWRAP = 4;
  * Decrement the value.
  *
  * @type {number}
+ * @category Graphics
  */
 export const STENCILOP_DECREMENT = 5;
 
@@ -1164,6 +1312,7 @@ export const STENCILOP_DECREMENT = 5;
  * Decrement the value but wrap it to a maximum representable value if the current value is 0.
  *
  * @type {number}
+ * @category Graphics
  */
 export const STENCILOP_DECREMENTWRAP = 6;
 
@@ -1171,6 +1320,7 @@ export const STENCILOP_DECREMENTWRAP = 6;
  * Invert the value bitwise.
  *
  * @type {number}
+ * @category Graphics
  */
 export const STENCILOP_INVERT = 7;
 
@@ -1178,6 +1328,7 @@ export const STENCILOP_INVERT = 7;
  * Read only. Any changes to the locked mip level's pixels will not update the texture.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TEXTURELOCK_READ = 1;
 
@@ -1185,6 +1336,7 @@ export const TEXTURELOCK_READ = 1;
  * Write only. The contents of the specified mip level will be entirely replaced.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TEXTURELOCK_WRITE = 2;
 
@@ -1192,6 +1344,7 @@ export const TEXTURELOCK_WRITE = 2;
  * Texture is a default type.
  *
  * @type {string}
+ * @category Graphics
  */
 export const TEXTURETYPE_DEFAULT = 'default';
 
@@ -1199,6 +1352,7 @@ export const TEXTURETYPE_DEFAULT = 'default';
  * Texture stores high dynamic range data in RGBM format.
  *
  * @type {string}
+ * @category Graphics
  */
 export const TEXTURETYPE_RGBM = 'rgbm';
 
@@ -1206,6 +1360,7 @@ export const TEXTURETYPE_RGBM = 'rgbm';
  * Texture stores high dynamic range data in RGBE format.
  *
  * @type {string}
+ * @category Graphics
  */
 export const TEXTURETYPE_RGBE = 'rgbe';
 
@@ -1213,6 +1368,7 @@ export const TEXTURETYPE_RGBE = 'rgbe';
  * Texture stores high dynamic range data in RGBP encoding.
  *
  * @type {string}
+ * @category Graphics
  */
 export const TEXTURETYPE_RGBP = 'rgbp';
 
@@ -1222,6 +1378,7 @@ export const TEXTURETYPE_RGBP = 'rgbp';
  * higher quality when the texture data is compressed.
  *
  * @type {string}
+ * @category Graphics
  */
 export const TEXTURETYPE_SWIZZLEGGGR = 'swizzleGGGR';
 
@@ -1247,6 +1404,7 @@ export const SAMPLETYPE_UINT = 4;
  * Texture data is not stored a specific projection format.
  *
  * @type {string}
+ * @category Graphics
  */
 export const TEXTUREPROJECTION_NONE = "none";
 
@@ -1254,6 +1412,7 @@ export const TEXTUREPROJECTION_NONE = "none";
  * Texture data is stored in cubemap projection format.
  *
  * @type {string}
+ * @category Graphics
  */
 export const TEXTUREPROJECTION_CUBE = "cube";
 
@@ -1261,6 +1420,7 @@ export const TEXTUREPROJECTION_CUBE = "cube";
  * Texture data is stored in equirectangular projection format.
  *
  * @type {string}
+ * @category Graphics
  */
 export const TEXTUREPROJECTION_EQUIRECT = "equirect";
 
@@ -1268,6 +1428,7 @@ export const TEXTUREPROJECTION_EQUIRECT = "equirect";
  * Texture data is stored in octahedral projection format.
  *
  * @type {string}
+ * @category Graphics
  */
 export const TEXTUREPROJECTION_OCTAHEDRAL = "octahedral";
 
@@ -1275,6 +1436,7 @@ export const TEXTUREPROJECTION_OCTAHEDRAL = "octahedral";
  * Shader source code uses GLSL language.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERLANGUAGE_GLSL = 'glsl';
 
@@ -1282,6 +1444,7 @@ export const SHADERLANGUAGE_GLSL = 'glsl';
  * Shader source code uses WGSL language.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERLANGUAGE_WGSL = 'wgsl';
 
@@ -1289,6 +1452,7 @@ export const SHADERLANGUAGE_WGSL = 'wgsl';
  * Signed byte vertex element type.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TYPE_INT8 = 0;
 
@@ -1296,6 +1460,7 @@ export const TYPE_INT8 = 0;
  * Unsigned byte vertex element type.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TYPE_UINT8 = 1;
 
@@ -1303,6 +1468,7 @@ export const TYPE_UINT8 = 1;
  * Signed short vertex element type.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TYPE_INT16 = 2;
 
@@ -1310,6 +1476,7 @@ export const TYPE_INT16 = 2;
  * Unsigned short vertex element type.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TYPE_UINT16 = 3;
 
@@ -1317,6 +1484,7 @@ export const TYPE_UINT16 = 3;
  * Signed integer vertex element type.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TYPE_INT32 = 4;
 
@@ -1324,6 +1492,7 @@ export const TYPE_INT32 = 4;
  * Unsigned integer vertex element type.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TYPE_UINT32 = 5;
 
@@ -1331,6 +1500,7 @@ export const TYPE_UINT32 = 5;
  * Floating point vertex element type.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TYPE_FLOAT32 = 6;
 
@@ -1338,6 +1508,7 @@ export const TYPE_FLOAT32 = 6;
  * 16-bit floating point vertex element type (not supported by WebGL1).
  *
  * @type {number}
+ * @category Graphics
  */
 export const TYPE_FLOAT16 = 7;
 
@@ -1511,6 +1682,7 @@ export const uniformTypeToStorage = new Uint8Array([
  * A WebGL 1 device type.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DEVICETYPE_WEBGL1 = 'webgl1';
 
@@ -1518,6 +1690,7 @@ export const DEVICETYPE_WEBGL1 = 'webgl1';
  * A WebGL 2 device type.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DEVICETYPE_WEBGL2 = 'webgl2';
 
@@ -1525,6 +1698,7 @@ export const DEVICETYPE_WEBGL2 = 'webgl2';
  * A WebGPU device type.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DEVICETYPE_WEBGPU = 'webgpu';
 
@@ -1532,6 +1706,7 @@ export const DEVICETYPE_WEBGPU = 'webgpu';
  * A Null device type.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DEVICETYPE_NULL = 'null';
 
@@ -1578,6 +1753,7 @@ export const typedArrayIndexFormatsByteSize = [1, 2, 4];
  *
  * @type {object}
  * @ignore
+ * @category Graphics
  */
 export const semanticToLocation = {};
 
@@ -1617,6 +1793,7 @@ semanticToLocation[SEMANTIC_ATTR15] = 15;
  * Chunk API versions
  *
  * @type {string}
+ * @category Graphics
  */
 export const CHUNKAPI_1_51 = '1.51';
 export const CHUNKAPI_1_55 = '1.55';

--- a/src/platform/input/constants.js
+++ b/src/platform/input/constants.js
@@ -14,6 +14,7 @@ export const AXIS_KEY = 'key';
  * Name of event fired when a key is pressed.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_KEYDOWN = 'keydown';
 
@@ -21,6 +22,7 @@ export const EVENT_KEYDOWN = 'keydown';
  * Name of event fired when a key is released.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_KEYUP = 'keyup';
 
@@ -28,6 +30,7 @@ export const EVENT_KEYUP = 'keyup';
  * Name of event fired when a mouse button is pressed.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_MOUSEDOWN = 'mousedown';
 
@@ -35,6 +38,7 @@ export const EVENT_MOUSEDOWN = 'mousedown';
  * Name of event fired when the mouse is moved.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_MOUSEMOVE = 'mousemove';
 
@@ -42,6 +46,7 @@ export const EVENT_MOUSEMOVE = 'mousemove';
  * Name of event fired when a mouse button is released.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_MOUSEUP = 'mouseup';
 
@@ -49,6 +54,7 @@ export const EVENT_MOUSEUP = 'mouseup';
  * Name of event fired when the mouse wheel is rotated.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_MOUSEWHEEL = 'mousewheel';
 
@@ -56,6 +62,7 @@ export const EVENT_MOUSEWHEEL = 'mousewheel';
  * Name of event fired when a new touch occurs. For example, a finger is placed on the device.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_TOUCHSTART = 'touchstart';
 
@@ -63,6 +70,7 @@ export const EVENT_TOUCHSTART = 'touchstart';
  * Name of event fired when touch ends. For example, a finger is lifted off the device.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_TOUCHEND = 'touchend';
 
@@ -70,6 +78,7 @@ export const EVENT_TOUCHEND = 'touchend';
  * Name of event fired when a touch moves.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_TOUCHMOVE = 'touchmove';
 
@@ -80,6 +89,7 @@ export const EVENT_TOUCHMOVE = 'touchmove';
  * device supports, in which case the earliest touch point is canceled.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_TOUCHCANCEL = 'touchcancel';
 
@@ -87,6 +97,7 @@ export const EVENT_TOUCHCANCEL = 'touchcancel';
  * Name of event fired when a new xr select occurs. For example, primary trigger was pressed.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_SELECT = 'select';
 
@@ -94,6 +105,7 @@ export const EVENT_SELECT = 'select';
  * Name of event fired when a new xr select starts. For example, primary trigger is now pressed.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_SELECTSTART = 'selectstart';
 
@@ -101,491 +113,589 @@ export const EVENT_SELECTSTART = 'selectstart';
  * Name of event fired when xr select ends. For example, a primary trigger is now released.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_SELECTEND = 'selectend';
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_BACKSPACE = 8;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_TAB = 9;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_RETURN = 13;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_ENTER = 13;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_SHIFT = 16;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_CONTROL = 17;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_ALT = 18;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_PAUSE = 19;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_CAPS_LOCK = 20;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_ESCAPE = 27;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_SPACE = 32;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_PAGE_UP = 33;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_PAGE_DOWN = 34;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_END = 35;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_HOME = 36;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_LEFT = 37;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_UP = 38;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_RIGHT = 39;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_DOWN = 40;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_PRINT_SCREEN = 44;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_INSERT = 45;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_DELETE = 46;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_0 = 48;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_1 = 49;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_2 = 50;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_3 = 51;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_4 = 52;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_5 = 53;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_6 = 54;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_7 = 55;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_8 = 56;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_9 = 57;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_SEMICOLON = 59;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_EQUAL = 61;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_A = 65;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_B = 66;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_C = 67;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_D = 68;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_E = 69;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F = 70;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_G = 71;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_H = 72;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_I = 73;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_J = 74;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_K = 75;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_L = 76;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_M = 77;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_N = 78;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_O = 79;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_P = 80;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_Q = 81;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_R = 82;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_S = 83;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_T = 84;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_U = 85;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_V = 86;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_W = 87;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_X = 88;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_Y = 89;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_Z = 90;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_WINDOWS = 91;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_CONTEXT_MENU = 93;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_NUMPAD_0 = 96;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_NUMPAD_1 = 97;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_NUMPAD_2 = 98;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_NUMPAD_3 = 99;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_NUMPAD_4 = 100;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_NUMPAD_5 = 101;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_NUMPAD_6 = 102;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_NUMPAD_7 = 103;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_NUMPAD_8 = 104;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_NUMPAD_9 = 105;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_MULTIPLY = 106;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_ADD = 107;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_SEPARATOR = 108;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_SUBTRACT = 109;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_DECIMAL = 110;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_DIVIDE = 111;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F1 = 112;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F2 = 113;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F3 = 114;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F4 = 115;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F5 = 116;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F6 = 117;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F7 = 118;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F8 = 119;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F9 = 120;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F10 = 121;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F11 = 122;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_F12 = 123;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_COMMA = 188;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_PERIOD = 190;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_SLASH = 191;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_OPEN_BRACKET = 219;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_BACK_SLASH = 220;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_CLOSE_BRACKET = 221;
 
 /**
  * @type {number}
+ * @category Input
  */
 export const KEY_META = 224;
 
@@ -593,6 +703,7 @@ export const KEY_META = 224;
  * No mouse buttons pressed.
  *
  * @type {number}
+ * @category Input
  */
 export const MOUSEBUTTON_NONE = -1;
 
@@ -600,6 +711,7 @@ export const MOUSEBUTTON_NONE = -1;
  * The left mouse button.
  *
  * @type {number}
+ * @category Input
  */
 export const MOUSEBUTTON_LEFT = 0;
 
@@ -607,6 +719,7 @@ export const MOUSEBUTTON_LEFT = 0;
  * The middle mouse button.
  *
  * @type {number}
+ * @category Input
  */
 export const MOUSEBUTTON_MIDDLE = 1;
 
@@ -614,6 +727,7 @@ export const MOUSEBUTTON_MIDDLE = 1;
  * The right mouse button.
  *
  * @type {number}
+ * @category Input
  */
 export const MOUSEBUTTON_RIGHT = 2;
 
@@ -621,6 +735,7 @@ export const MOUSEBUTTON_RIGHT = 2;
  * Index for pad 1.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_1 = 0;
 
@@ -628,6 +743,7 @@ export const PAD_1 = 0;
  * Index for pad 2.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_2 = 1;
 
@@ -635,6 +751,7 @@ export const PAD_2 = 1;
  * Index for pad 3.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_3 = 2;
 
@@ -642,6 +759,7 @@ export const PAD_3 = 2;
  * Index for pad 4.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_4 = 3;
 
@@ -649,6 +767,7 @@ export const PAD_4 = 3;
  * The first face button, from bottom going clockwise.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_FACE_1 = 0;
 
@@ -656,6 +775,7 @@ export const PAD_FACE_1 = 0;
  * The second face button, from bottom going clockwise.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_FACE_2 = 1;
 
@@ -663,6 +783,7 @@ export const PAD_FACE_2 = 1;
  * The third face button, from bottom going clockwise.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_FACE_3 = 2;
 
@@ -670,6 +791,7 @@ export const PAD_FACE_3 = 2;
  * The fourth face button, from bottom going clockwise.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_FACE_4 = 3;
 
@@ -677,6 +799,7 @@ export const PAD_FACE_4 = 3;
  * The first shoulder button on the left.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_L_SHOULDER_1 = 4;
 
@@ -684,6 +807,7 @@ export const PAD_L_SHOULDER_1 = 4;
  * The first shoulder button on the right.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_R_SHOULDER_1 = 5;
 
@@ -691,6 +815,7 @@ export const PAD_R_SHOULDER_1 = 5;
  * The second shoulder button on the left.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_L_SHOULDER_2 = 6;
 
@@ -698,6 +823,7 @@ export const PAD_L_SHOULDER_2 = 6;
  * The second shoulder button on the right.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_R_SHOULDER_2 = 7;
 
@@ -705,6 +831,7 @@ export const PAD_R_SHOULDER_2 = 7;
  * The select button.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_SELECT = 8;
 
@@ -712,6 +839,7 @@ export const PAD_SELECT = 8;
  * The start button.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_START = 9;
 
@@ -719,6 +847,7 @@ export const PAD_START = 9;
  * The button when depressing the left analogue stick.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_L_STICK_BUTTON = 10;
 
@@ -726,6 +855,7 @@ export const PAD_L_STICK_BUTTON = 10;
  * The button when depressing the right analogue stick.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_R_STICK_BUTTON = 11;
 
@@ -733,6 +863,7 @@ export const PAD_R_STICK_BUTTON = 11;
  * Direction pad up.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_UP = 12;
 
@@ -740,6 +871,7 @@ export const PAD_UP = 12;
  * Direction pad down.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_DOWN = 13;
 
@@ -747,6 +879,7 @@ export const PAD_DOWN = 13;
  * Direction pad left.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_LEFT = 14;
 
@@ -754,6 +887,7 @@ export const PAD_LEFT = 14;
  * Direction pad right.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_RIGHT = 15;
 
@@ -761,6 +895,7 @@ export const PAD_RIGHT = 15;
  * Vendor specific button.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_VENDOR = 16;
 
@@ -768,6 +903,7 @@ export const PAD_VENDOR = 16;
  * Horizontal axis on the left analogue stick.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_L_STICK_X = 0;
 
@@ -775,6 +911,7 @@ export const PAD_L_STICK_X = 0;
  * Vertical axis on the left analogue stick.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_L_STICK_Y = 1;
 
@@ -782,6 +919,7 @@ export const PAD_L_STICK_Y = 1;
  * Horizontal axis on the right analogue stick.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_R_STICK_X = 2;
 
@@ -789,6 +927,7 @@ export const PAD_R_STICK_X = 2;
  * Vertical axis on the right analogue stick.
  *
  * @type {number}
+ * @category Input
  */
 export const PAD_R_STICK_Y = 3;
 
@@ -796,6 +935,7 @@ export const PAD_R_STICK_Y = 3;
  * Name of event fired when a gamepad connects.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_GAMEPADCONNECTED = 'gamepadconnected';
 
@@ -803,6 +943,7 @@ export const EVENT_GAMEPADCONNECTED = 'gamepadconnected';
  * Name of event fired when a gamepad disconnects.
  *
  * @type {string}
+ * @category Input
  */
 export const EVENT_GAMEPADDISCONNECTED = 'gamepaddisconnected';
 
@@ -810,6 +951,7 @@ export const EVENT_GAMEPADDISCONNECTED = 'gamepaddisconnected';
  * Horizontal axis on the touchpad of a XR pad.
  *
  * @type {number}
+ * @category Input
  */
 export const XRPAD_TOUCHPAD_X = 0;
 
@@ -817,6 +959,7 @@ export const XRPAD_TOUCHPAD_X = 0;
  * Vertical axis on the thouchpad of a XR pad.
  *
  * @type {number}
+ * @category Input
  */
 export const XRPAD_TOUCHPAD_Y = 1;
 
@@ -824,6 +967,7 @@ export const XRPAD_TOUCHPAD_Y = 1;
  * Horizontal axis on the stick of a XR pad.
  *
  * @type {number}
+ * @category Input
  */
 export const XRPAD_STICK_X = 2;
 
@@ -831,6 +975,7 @@ export const XRPAD_STICK_X = 2;
  * Vertical axis on the stick of a XR pad.
  *
  * @type {number}
+ * @category Input
  */
 export const XRPAD_STICK_Y = 3;
 
@@ -838,6 +983,7 @@ export const XRPAD_STICK_Y = 3;
  * The button when pressing the XR pad's touchpad.
  *
  * @type {number}
+ * @category Input
  */
 export const XRPAD_TOUCHPAD_BUTTON = 2;
 
@@ -845,6 +991,7 @@ export const XRPAD_TOUCHPAD_BUTTON = 2;
  * The trigger button from XR pad.
  *
  * @type {number}
+ * @category Input
  */
 export const XRPAD_TRIGGER = 0;
 
@@ -852,6 +999,7 @@ export const XRPAD_TRIGGER = 0;
  * The squeeze button from XR pad.
  *
  * @type {number}
+ * @category Input
  */
 export const XRPAD_SQUEEZE = 1;
 
@@ -859,6 +1007,7 @@ export const XRPAD_SQUEEZE = 1;
  * The button when pressing the XR pad's stick.
  *
  * @type {number}
+ * @category Input
  */
 export const XRPAD_STICK_BUTTON = 3;
 
@@ -866,6 +1015,7 @@ export const XRPAD_STICK_BUTTON = 3;
  * The A button from XR pad.
  *
  * @type {number}
+ * @category Input
  */
 export const XRPAD_A = 4;
 
@@ -873,5 +1023,6 @@ export const XRPAD_A = 4;
  * The B button from XR pad.
  *
  * @type {number}
+ * @category Input
  */
 export const XRPAD_B = 5;

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -3,6 +3,7 @@
  * the frame buffer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_SUBTRACTIVE = 0;
 
@@ -11,6 +12,7 @@ export const BLEND_SUBTRACTIVE = 0;
  * frame buffer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_ADDITIVE = 1;
 
@@ -20,6 +22,7 @@ export const BLEND_ADDITIVE = 1;
  * {@link BLENDMODE_ONE_MINUS_SRC_ALPHA}.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_NORMAL = 2;
 
@@ -27,6 +30,7 @@ export const BLEND_NORMAL = 2;
  * Disable blending.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_NONE = 3;
 
@@ -35,6 +39,7 @@ export const BLEND_NONE = 3;
  * multiplied by the source alpha value.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_PREMULTIPLIED = 4;
 
@@ -43,6 +48,7 @@ export const BLEND_PREMULTIPLIED = 4;
  * result to the frame buffer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_MULTIPLICATIVE = 5;
 
@@ -50,6 +56,7 @@ export const BLEND_MULTIPLICATIVE = 5;
  * Same as {@link BLEND_ADDITIVE} except the source RGB is multiplied by the source alpha.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_ADDITIVEALPHA = 6;
 
@@ -57,6 +64,7 @@ export const BLEND_ADDITIVEALPHA = 6;
  * Multiplies colors and doubles the result.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_MULTIPLICATIVE2X = 7;
 
@@ -64,6 +72,7 @@ export const BLEND_MULTIPLICATIVE2X = 7;
  * Softer version of additive.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_SCREEN = 8;
 
@@ -71,6 +80,7 @@ export const BLEND_SCREEN = 8;
  * Minimum color. Check app.graphicsDevice.extBlendMinmax for support.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_MIN = 9;
 
@@ -78,6 +88,7 @@ export const BLEND_MIN = 9;
  * Maximum color. Check app.graphicsDevice.extBlendMinmax for support.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLEND_MAX = 10;
 
@@ -85,6 +96,7 @@ export const BLEND_MAX = 10;
  * No fog is applied to the scene.
  *
  * @type {string}
+ * @category Graphics
  */
 export const FOG_NONE = 'none';
 
@@ -92,6 +104,7 @@ export const FOG_NONE = 'none';
  * Fog rises linearly from zero to 1 between a start and end depth.
  *
  * @type {string}
+ * @category Graphics
  */
 export const FOG_LINEAR = 'linear';
 
@@ -99,6 +112,7 @@ export const FOG_LINEAR = 'linear';
  * Fog rises according to an exponential curve controlled by a density value.
  *
  * @type {string}
+ * @category Graphics
  */
 export const FOG_EXP = 'exp';
 
@@ -106,6 +120,7 @@ export const FOG_EXP = 'exp';
  * Fog rises according to an exponential curve controlled by a density value.
  *
  * @type {string}
+ * @category Graphics
  */
 export const FOG_EXP2 = 'exp2';
 
@@ -113,6 +128,7 @@ export const FOG_EXP2 = 'exp2';
  * No Fresnel.
  *
  * @type {number}
+ * @category Graphics
  */
 export const FRESNEL_NONE = 0;
 
@@ -120,6 +136,7 @@ export const FRESNEL_NONE = 0;
  * Schlick's approximation of Fresnel.
  *
  * @type {number}
+ * @category Graphics
  */
 export const FRESNEL_SCHLICK = 2;
 
@@ -135,6 +152,7 @@ export const LAYER_WORLD = 15;
  * The world layer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LAYERID_WORLD = 0;
 
@@ -142,6 +160,7 @@ export const LAYERID_WORLD = 0;
  * The depth layer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LAYERID_DEPTH = 1;
 
@@ -149,6 +168,7 @@ export const LAYERID_DEPTH = 1;
  * The skybox layer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LAYERID_SKYBOX = 2;
 
@@ -156,6 +176,7 @@ export const LAYERID_SKYBOX = 2;
  * The immediate layer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LAYERID_IMMEDIATE = 3;
 
@@ -163,6 +184,7 @@ export const LAYERID_IMMEDIATE = 3;
  * The UI layer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LAYERID_UI = 4;
 
@@ -170,6 +192,7 @@ export const LAYERID_UI = 4;
  * Directional (global) light source.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LIGHTTYPE_DIRECTIONAL = 0;
 
@@ -177,6 +200,7 @@ export const LIGHTTYPE_DIRECTIONAL = 0;
  * Omni-directional (local) light source.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LIGHTTYPE_OMNI = 1;
 
@@ -185,6 +209,7 @@ export const LIGHTTYPE_OMNI = 1;
  *
  * @type {number}
  * @ignore
+ * @category Graphics
  */
 export const LIGHTTYPE_POINT = LIGHTTYPE_OMNI;
 
@@ -192,6 +217,7 @@ export const LIGHTTYPE_POINT = LIGHTTYPE_OMNI;
  * Spot (local) light source.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LIGHTTYPE_SPOT = 2;
 
@@ -202,6 +228,7 @@ export const LIGHTTYPE_COUNT = 3;
  * Infinitesimally small point light source shape.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LIGHTSHAPE_PUNCTUAL = 0;
 
@@ -209,6 +236,7 @@ export const LIGHTSHAPE_PUNCTUAL = 0;
  * Rectangle shape of light source.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LIGHTSHAPE_RECT = 1;
 
@@ -216,6 +244,7 @@ export const LIGHTSHAPE_RECT = 1;
  * Disk shape of light source.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LIGHTSHAPE_DISK = 2;
 
@@ -223,6 +252,7 @@ export const LIGHTSHAPE_DISK = 2;
  * Sphere shape of light source.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LIGHTSHAPE_SPHERE = 3;
 
@@ -230,6 +260,7 @@ export const LIGHTSHAPE_SPHERE = 3;
  * Linear distance falloff model for light attenuation.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LIGHTFALLOFF_LINEAR = 0;
 
@@ -237,6 +268,7 @@ export const LIGHTFALLOFF_LINEAR = 0;
  * Inverse squared distance falloff model for light attenuation.
  *
  * @type {number}
+ * @category Graphics
  */
 export const LIGHTFALLOFF_INVERSESQUARED = 1;
 
@@ -244,6 +276,7 @@ export const LIGHTFALLOFF_INVERSESQUARED = 1;
  * Render depth (color-packed on WebGL 1.0), can be used for PCF 3x3 sampling.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADOW_PCF3 = 0;
 export const SHADOW_DEPTH = 0; // alias for SHADOW_PCF3 for backwards compatibility
@@ -253,6 +286,7 @@ export const SHADOW_DEPTH = 0; // alias for SHADOW_PCF3 for backwards compatibil
  * work correctly.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADOW_VSM8 = 1;
 
@@ -261,6 +295,7 @@ export const SHADOW_VSM8 = 1;
  * back to {@link SHADOW_VSM8}, if not supported.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADOW_VSM16 = 2;
 
@@ -269,6 +304,7 @@ export const SHADOW_VSM16 = 2;
  * to {@link SHADOW_VSM16}, if not supported.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADOW_VSM32 = 3;
 
@@ -277,6 +313,7 @@ export const SHADOW_VSM32 = 3;
  * WebGL 2. Falls back to {@link SHADOW_PCF3} on WebGL 1.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADOW_PCF5 = 4;
 
@@ -284,6 +321,7 @@ export const SHADOW_PCF5 = 4;
  * Render depth (color-packed on WebGL 1.0), can be used for PCF 1x1 sampling.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADOW_PCF1 = 5;
 
@@ -291,6 +329,7 @@ export const SHADOW_PCF1 = 5;
  * Render depth as color for PCSS software filtering.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADOW_PCSS = 6;
 
@@ -299,6 +338,7 @@ export const SHADOW_PCSS = 6;
  *
  * @type {object}
  * @ignore
+ * @category Graphics
  */
 export const shadowTypeToString = {};
 shadowTypeToString[SHADOW_PCF3] = 'PCF3';
@@ -313,6 +353,7 @@ shadowTypeToString[SHADOW_PCSS] = 'PCSS';
  * Box filter.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLUR_BOX = 0;
 
@@ -320,6 +361,7 @@ export const BLUR_BOX = 0;
  * Gaussian filter. May look smoother than box, but requires more samples.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BLUR_GAUSSIAN = 1;
 
@@ -327,6 +369,7 @@ export const BLUR_GAUSSIAN = 1;
  * No sorting, particles are drawn in arbitrary order. Can be simulated on GPU.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PARTICLESORT_NONE = 0;
 
@@ -334,6 +377,7 @@ export const PARTICLESORT_NONE = 0;
  * Sorting based on distance to the camera. CPU only.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PARTICLESORT_DISTANCE = 1;
 
@@ -341,6 +385,7 @@ export const PARTICLESORT_DISTANCE = 1;
  * Newer particles are drawn first. CPU only.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PARTICLESORT_NEWER_FIRST = 2;
 
@@ -348,6 +393,7 @@ export const PARTICLESORT_NEWER_FIRST = 2;
  * Older particles are drawn first. CPU only.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PARTICLESORT_OLDER_FIRST = 3;
 
@@ -358,6 +404,7 @@ export const PARTICLEMODE_CPU = 1;
  * Box shape parameterized by emitterExtents. Initial velocity is directed towards local Z axis.
  *
  * @type {number}
+ * @category Graphics
  */
 export const EMITTERSHAPE_BOX = 0;
 
@@ -366,6 +413,7 @@ export const EMITTERSHAPE_BOX = 0;
  * center.
  *
  * @type {number}
+ * @category Graphics
  */
 export const EMITTERSHAPE_SPHERE = 1;
 
@@ -373,6 +421,7 @@ export const EMITTERSHAPE_SPHERE = 1;
  * Particles are facing camera.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PARTICLEORIENTATION_SCREEN = 0;
 
@@ -380,6 +429,7 @@ export const PARTICLEORIENTATION_SCREEN = 0;
  * User defines world space normal (particleNormal) to set planes orientation.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PARTICLEORIENTATION_WORLD = 1;
 
@@ -387,6 +437,7 @@ export const PARTICLEORIENTATION_WORLD = 1;
  * Similar to previous, but the normal is affected by emitter(entity) transformation.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PARTICLEORIENTATION_EMITTER = 2;
 
@@ -394,6 +445,7 @@ export const PARTICLEORIENTATION_EMITTER = 2;
  * A perspective camera projection where the frustum shape is essentially pyramidal.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PROJECTION_PERSPECTIVE = 0;
 
@@ -401,6 +453,7 @@ export const PROJECTION_PERSPECTIVE = 0;
  * An orthographic camera projection where the frustum shape is essentially a cuboid.
  *
  * @type {number}
+ * @category Graphics
  */
 export const PROJECTION_ORTHOGRAPHIC = 1;
 
@@ -408,6 +461,7 @@ export const PROJECTION_ORTHOGRAPHIC = 1;
  * Render mesh instance as solid geometry.
  *
  * @type {number}
+ * @category Graphics
  */
 export const RENDERSTYLE_SOLID = 0;
 
@@ -415,6 +469,7 @@ export const RENDERSTYLE_SOLID = 0;
  * Render mesh instance as wireframe.
  *
  * @type {number}
+ * @category Graphics
  */
 export const RENDERSTYLE_WIREFRAME = 1;
 
@@ -422,6 +477,7 @@ export const RENDERSTYLE_WIREFRAME = 1;
  * Render mesh instance as points.
  *
  * @type {number}
+ * @category Graphics
  */
 export const RENDERSTYLE_POINTS = 2;
 
@@ -429,6 +485,7 @@ export const RENDERSTYLE_POINTS = 2;
  * The cube map is treated as if it is infinitely far away.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CUBEPROJ_NONE = 0;
 
@@ -436,6 +493,7 @@ export const CUBEPROJ_NONE = 0;
  * The cube map is box-projected based on a world space axis-aligned bounding box.
  *
  * @type {number}
+ * @category Graphics
  */
 export const CUBEPROJ_BOX = 1;
 
@@ -444,6 +502,7 @@ export const CUBEPROJ_BOX = 1;
  * older projects.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SPECULAR_PHONG = 0;
 
@@ -451,6 +510,7 @@ export const SPECULAR_PHONG = 0;
  * Energy-conserving Blinn-Phong.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SPECULAR_BLINN = 1;
 
@@ -458,6 +518,7 @@ export const SPECULAR_BLINN = 1;
  * Multiply together the primary and secondary colors.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DETAILMODE_MUL = 'mul';
 
@@ -465,6 +526,7 @@ export const DETAILMODE_MUL = 'mul';
  * Add together the primary and secondary colors.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DETAILMODE_ADD = 'add';
 
@@ -472,6 +534,7 @@ export const DETAILMODE_ADD = 'add';
  * Softer version of {@link DETAILMODE_ADD}.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DETAILMODE_SCREEN = 'screen';
 
@@ -479,6 +542,7 @@ export const DETAILMODE_SCREEN = 'screen';
  * Multiplies or screens the colors, depending on the primary color.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DETAILMODE_OVERLAY = 'overlay';
 
@@ -486,6 +550,7 @@ export const DETAILMODE_OVERLAY = 'overlay';
  * Select whichever of the primary and secondary colors is darker, component-wise.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DETAILMODE_MIN = 'min';
 
@@ -493,6 +558,7 @@ export const DETAILMODE_MIN = 'min';
  * Select whichever of the primary and secondary colors is lighter, component-wise.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DETAILMODE_MAX = 'max';
 
@@ -500,6 +566,7 @@ export const DETAILMODE_MAX = 'max';
  * No gamma correction.
  *
  * @type {number}
+ * @category Graphics
  */
 export const GAMMA_NONE = 0;
 
@@ -507,6 +574,7 @@ export const GAMMA_NONE = 0;
  * Apply sRGB gamma correction.
  *
  * @type {number}
+ * @category Graphics
  */
 export const GAMMA_SRGB = 1;
 
@@ -516,6 +584,7 @@ export const GAMMA_SRGB = 1;
  * @type {number}
  * @deprecated
  * @ignore
+ * @category Graphics
  */
 export const GAMMA_SRGBFAST = 2; // deprecated
 
@@ -523,6 +592,7 @@ export const GAMMA_SRGBFAST = 2; // deprecated
  * Apply sRGB (HDR) gamma correction.
  *
  * @type {number}
+ * @category Graphics
  */
 export const GAMMA_SRGBHDR = 3;
 
@@ -530,6 +600,7 @@ export const GAMMA_SRGBHDR = 3;
  * Linear tonemapping.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TONEMAP_LINEAR = 0;
 
@@ -537,6 +608,7 @@ export const TONEMAP_LINEAR = 0;
  * Filmic tonemapping curve.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TONEMAP_FILMIC = 1;
 
@@ -544,6 +616,7 @@ export const TONEMAP_FILMIC = 1;
  * Hejl filmic tonemapping curve.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TONEMAP_HEJL = 2;
 
@@ -551,6 +624,7 @@ export const TONEMAP_HEJL = 2;
  * ACES filmic tonemapping curve.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TONEMAP_ACES = 3;
 
@@ -558,6 +632,7 @@ export const TONEMAP_ACES = 3;
  * ACES v2 filmic tonemapping curve.
  *
  * @type {number}
+ * @category Graphics
  */
 export const TONEMAP_ACES2 = 4;
 
@@ -565,6 +640,7 @@ export const TONEMAP_ACES2 = 4;
  * No specular occlusion.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SPECOCC_NONE = 0;
 
@@ -572,6 +648,7 @@ export const SPECOCC_NONE = 0;
  * Use AO directly to occlude specular.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SPECOCC_AO = 1;
 
@@ -579,6 +656,7 @@ export const SPECOCC_AO = 1;
  * Modify AO based on material glossiness/view angle to occlude specular.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SPECOCC_GLOSSDEPENDENT = 2;
 
@@ -602,6 +680,7 @@ export const SHADERDEF_LMAMBIENT = 8192; // lightmaps contain ambient
  * The shadow map is not to be updated.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADOWUPDATE_NONE = 0;
 
@@ -609,6 +688,7 @@ export const SHADOWUPDATE_NONE = 0;
  * The shadow map is regenerated this frame and not on subsequent frames.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADOWUPDATE_THISFRAME = 1;
 
@@ -616,6 +696,7 @@ export const SHADOWUPDATE_THISFRAME = 1;
  * The shadow map is regenerated every frame.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADOWUPDATE_REALTIME = 2;
 
@@ -631,6 +712,7 @@ export const MASK_BAKE = 4;
  * Render shaded materials with gamma correction and tonemapping.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADER_FORWARD = 0;
 
@@ -638,6 +720,7 @@ export const SHADER_FORWARD = 0;
  * Render shaded materials without gamma correction and tonemapping.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADER_FORWARDHDR = 1;
 
@@ -645,6 +728,7 @@ export const SHADER_FORWARDHDR = 1;
  * Render RGBA-encoded depth value.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SHADER_DEPTH = 2;
 
@@ -658,6 +742,7 @@ export const SHADER_SHADOW = 4;
  * Shader that performs forward rendering.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_FORWARD = 'forward';
 
@@ -665,6 +750,7 @@ export const SHADERPASS_FORWARD = 'forward';
  * Shader used for debug rendering of albedo.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_ALBEDO = 'debug_albedo';
 
@@ -672,6 +758,7 @@ export const SHADERPASS_ALBEDO = 'debug_albedo';
  * Shader used for debug rendering of world normal.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_WORLDNORMAL = 'debug_world_normal';
 
@@ -679,6 +766,7 @@ export const SHADERPASS_WORLDNORMAL = 'debug_world_normal';
  * Shader used for debug rendering of opacity.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_OPACITY = 'debug_opacity';
 
@@ -686,6 +774,7 @@ export const SHADERPASS_OPACITY = 'debug_opacity';
  * Shader used for debug rendering of specularity.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_SPECULARITY = 'debug_specularity';
 
@@ -693,6 +782,7 @@ export const SHADERPASS_SPECULARITY = 'debug_specularity';
  * Shader used for debug rendering of gloss.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_GLOSS = 'debug_gloss';
 
@@ -700,6 +790,7 @@ export const SHADERPASS_GLOSS = 'debug_gloss';
  * Shader used for debug rendering of metalness.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_METALNESS = 'debug_metalness';
 
@@ -707,6 +798,7 @@ export const SHADERPASS_METALNESS = 'debug_metalness';
  * Shader used for debug rendering of ao.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_AO = 'debug_ao';
 
@@ -714,6 +806,7 @@ export const SHADERPASS_AO = 'debug_ao';
  * Shader used for debug rendering of emission.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_EMISSION = 'debug_emission';
 
@@ -721,6 +814,7 @@ export const SHADERPASS_EMISSION = 'debug_emission';
  * Shader used for debug rendering of lighting.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_LIGHTING = 'debug_lighting';
 
@@ -728,6 +822,7 @@ export const SHADERPASS_LIGHTING = 'debug_lighting';
  * Shader used for debug rendering of UV0 texture coordinates.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SHADERPASS_UV0 = 'debug_uv0';
 
@@ -735,6 +830,7 @@ export const SHADERPASS_UV0 = 'debug_uv0';
  * This mode renders a sprite as a simple quad.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SPRITE_RENDERMODE_SIMPLE = 0;
 
@@ -744,6 +840,7 @@ export const SPRITE_RENDERMODE_SIMPLE = 0;
  * region both horizontally and vertically.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SPRITE_RENDERMODE_SLICED = 1;
 
@@ -753,6 +850,7 @@ export const SPRITE_RENDERMODE_SLICED = 1;
  * both horizontally and vertically.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SPRITE_RENDERMODE_TILED = 2;
 
@@ -760,6 +858,7 @@ export const SPRITE_RENDERMODE_TILED = 2;
  * Single color lightmap.
  *
  * @type {number}
+ * @category Graphics
  */
 export const BAKE_COLOR = 0;
 
@@ -767,6 +866,7 @@ export const BAKE_COLOR = 0;
  * Single color lightmap + dominant light direction (used for bump/specular).
  *
  * @type {number}
+ * @category Graphics
  */
 export const BAKE_COLORDIR = 1;
 
@@ -774,6 +874,7 @@ export const BAKE_COLORDIR = 1;
  * Center of view.
  *
  * @type {number}
+ * @category Graphics
  */
 export const VIEW_CENTER = 0;
 
@@ -781,6 +882,7 @@ export const VIEW_CENTER = 0;
  * Left of view. Only used in stereo rendering.
  *
  * @type {number}
+ * @category Graphics
  */
 export const VIEW_LEFT = 1;
 
@@ -788,6 +890,7 @@ export const VIEW_LEFT = 1;
  * Right of view. Only used in stereo rendering.
  *
  * @type {number}
+ * @category Graphics
  */
 export const VIEW_RIGHT = 2;
 
@@ -795,6 +898,7 @@ export const VIEW_RIGHT = 2;
  * No sorting is applied. Mesh instances are rendered in the same order they were added to a layer.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SORTMODE_NONE = 0;
 
@@ -802,6 +906,7 @@ export const SORTMODE_NONE = 0;
  * Mesh instances are sorted based on {@link MeshInstance#drawOrder}.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SORTMODE_MANUAL = 1;
 
@@ -810,6 +915,7 @@ export const SORTMODE_MANUAL = 1;
  * rendering performance.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SORTMODE_MATERIALMESH = 2;
 
@@ -818,6 +924,7 @@ export const SORTMODE_MATERIALMESH = 2;
  * semi-transparent objects on different depth, one is blended on top of another.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SORTMODE_BACK2FRONT = 3;
 
@@ -826,6 +933,7 @@ export const SORTMODE_BACK2FRONT = 3;
  * better performance than {@link SORTMODE_MATERIALMESH} due to reduced overdraw.
  *
  * @type {number}
+ * @category Graphics
  */
 export const SORTMODE_FRONT2BACK = 4;
 
@@ -834,6 +942,7 @@ export const SORTMODE_FRONT2BACK = 4;
  *
  * @type {number}
  * @ignore
+ * @category Graphics
  */
 export const SORTMODE_CUSTOM = 5;
 
@@ -841,6 +950,7 @@ export const SORTMODE_CUSTOM = 5;
  * Automatically set aspect ratio to current render target's width divided by height.
  *
  * @type {number}
+ * @category Graphics
  */
 export const ASPECT_AUTO = 0;
 
@@ -848,6 +958,7 @@ export const ASPECT_AUTO = 0;
  * Use the manual aspect ratio value.
  *
  * @type {number}
+ * @category Graphics
  */
 export const ASPECT_MANUAL = 1;
 
@@ -855,6 +966,7 @@ export const ASPECT_MANUAL = 1;
  * Horizontal orientation.
  *
  * @type {number}
+ * @category Graphics
  */
 export const ORIENTATION_HORIZONTAL = 0;
 
@@ -862,6 +974,7 @@ export const ORIENTATION_HORIZONTAL = 0;
  * Vertical orientation.
  *
  * @type {number}
+ * @category Graphics
  */
 export const ORIENTATION_VERTICAL = 1;
 
@@ -869,6 +982,7 @@ export const ORIENTATION_VERTICAL = 1;
  * A sky texture is rendered using an infinite projection.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SKYTYPE_INFINITE = 'infinite';
 
@@ -877,6 +991,7 @@ export const SKYTYPE_INFINITE = 'infinite';
  * environments.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SKYTYPE_BOX = 'box';
 
@@ -885,6 +1000,7 @@ export const SKYTYPE_BOX = 'box';
  * environments.
  *
  * @type {string}
+ * @category Graphics
  */
 export const SKYTYPE_DOME = 'dome';
 
@@ -892,6 +1008,7 @@ export const SKYTYPE_DOME = 'dome';
  * Opacity dithering is disabled.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DITHER_NONE = 'none';
 
@@ -899,6 +1016,7 @@ export const DITHER_NONE = 'none';
  * Opacity is dithered using a Bayer 8 matrix.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DITHER_BAYER8 = 'bayer8';
 
@@ -906,5 +1024,6 @@ export const DITHER_BAYER8 = 'bayer8';
  * Opacity is dithered using a blue noise texture.
  *
  * @type {string}
+ * @category Graphics
  */
 export const DITHER_BLUENOISE = 'bluenoise';

--- a/src/scene/shader-lib/utils.js
+++ b/src/scene/shader-lib/utils.js
@@ -23,6 +23,7 @@ import { ShaderGenerator } from './programs/shader-generator.js';
  * attachments. Passing an array will set the output type for each color attachment.
  * @see ShaderUtils.createDefinition
  * @returns {Shader} The newly created shader.
+ * @category Graphics
  */
 function createShader(device, vsName, fsName, useTransformFeedback = false, shaderDefinitionOptions = {}) {
 


### PR DESCRIPTION
Assign engine constants to TypeDoc categories. Gives this:

![image](https://github.com/playcanvas/engine/assets/697563/aa006c0b-7a8e-48f3-a748-a6492f51bc1c)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
