### PR TITLE
Fix multi-app example

### DIFF
--- a/examples/src/examples/misc/multi-app.mjs
+++ b/examples/src/examples/misc/multi-app.mjs
@@ -194,9 +194,9 @@ async function example({ glslangPath, twgslPath, data }) {
 
             // rotate the box according to the delta time since the last frame
             app.on('update', (/** @type {number} */ dt) => box.rotate(10 * dt, 20 * dt, 30 * dt));
-
-            return app;
         });
+
+        return app;
     };
 
     const apps = {


### PR DESCRIPTION
`createApp` just needs to return the app. The introduction of `assetListLoader` moved the return statement to the wrong place.

Fixes #6018

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
