### PR TITLE
Extracted renderForwardLayer function to the renderer

### DIFF
--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -11,6 +11,7 @@ import {
     LIGHTSHAPE_PUNCTUAL,
     LAYERID_DEPTH
 } from '../constants.js';
+import { WorldClustersDebug } from '../lighting/world-clusters-debug.js';
 
 import { Renderer } from './renderer.js';
 import { LightCamera } from './light-camera.js';
@@ -669,6 +670,100 @@ class ForwardRenderer extends Renderer {
         // #if _PROFILER
         this._forwardTime += now() - forwardStartTime;
         // #endif
+    }
+
+    /**
+     * Forward render mesh instances on a specified layer, using a camera and a render target.
+     * Shaders used are based on the shaderPass provided, with optional clustered lighting support.
+     *
+     * @param {import('../../framework/components/camera/component.js').CameraComponent} camera - The
+     * camera.
+     * @param {import('../../platform/graphics/render-target.js').RenderTarget} renderTarget - The
+     * render target.
+     * @param {import('../layer.js').Layer} layer - The layer.
+     * @param {boolean} transparent - True if transparent sublayer should be rendered, opaque
+     * otherwise.
+     * @param {number} shaderPass - A type of shader to use during rendering.
+     * @param {import('../../platform/graphics/bind-group.js').BindGroup[]} viewBindGroups - An array
+     * storing the view level bing groups (can be empty array, and this function populates if per
+     * view).
+     * @param {object} [options] - Object for passing optional arguments.
+     * @param {boolean} [options.clearColors] - True if the color buffer should be cleared.
+     * @param {boolean} [options.clearDepth] - True if the depth buffer should be cleared.
+     * @param {boolean} [options.clearStencil] - True if the stencil buffer should be cleared.
+     * @param {import('../lighting/world-clusters.js').WorldClusters} [options.lightClusters] - The
+     * world clusters object to be used for clustered lighting.
+     */
+    renderForwardLayer(camera, renderTarget, layer, transparent, shaderPass, viewBindGroups, options = {}) {
+
+        const { scene, device } = this;
+        const clusteredLightingEnabled = scene.clusteredLightingEnabled;
+
+        this.setupViewport(camera.camera, renderTarget);
+
+        // clearing
+        const clearColor = options.clearColors ?? false;
+        const clearDepth = options.clearDepth ?? false;
+        const clearStencil = options.clearStencil ?? false;
+        if (clearColor || clearDepth || clearStencil) {
+            this.clear(camera.camera, clearColor, clearDepth, clearStencil);
+        }
+
+        // #if _PROFILER
+        const sortTime = now();
+        // #endif
+
+        layer.sortVisible(camera.camera, transparent);
+
+        // #if _PROFILER
+        this._sortTime += now() - sortTime;
+        // #endif
+
+        const culledInstances = layer.getCulledInstances(camera.camera);
+        const visible = transparent ? culledInstances.transparent : culledInstances.opaque;
+
+        // add debug mesh instances to visible list
+        scene.immediate.onPreRenderLayer(layer, visible, transparent);
+
+        // set up layer uniforms
+        if (layer.requiresLightCube) {
+            this.lightCube.update(scene.ambientLight, layer._lights);
+            this.constantLightCube.setValue(this.lightCube.colors);
+        }
+
+        // upload clustered lights uniforms
+        const { lightClusters } = options;
+        if (clusteredLightingEnabled && lightClusters) {
+            lightClusters.activate();
+
+            // debug rendering of clusters
+            if (!this.clustersDebugRendered && scene.lighting.debugLayer === layer.id) {
+                this.clustersDebugRendered = true;
+                WorldClustersDebug.render(lightClusters, this.scene);
+            }
+        }
+
+        // Set the not very clever global variable which is only useful when there's just one camera
+        scene._activeCamera = camera.camera;
+
+        const viewCount = this.setCameraUniforms(camera.camera, renderTarget);
+        if (device.supportsUniformBuffers) {
+            this.setupViewUniformBuffers(viewBindGroups, this.viewUniformFormat, this.viewBindGroupFormat, viewCount);
+        }
+
+        // enable flip faces if either the camera has _flipFaces enabled or the render target has flipY enabled
+        const flipFaces = !!(camera.camera._flipFaces ^ renderTarget?.flipY);
+
+        const forwardDrawCalls = this._forwardDrawCalls;
+        this.renderForward(camera.camera,
+                           visible,
+                           layer.splitLights,
+                           shaderPass,
+                           layer.onDrawCall,
+                           layer,
+                           flipFaces);
+
+        layer._forwardDrawCalls += this._forwardDrawCalls - forwardDrawCalls;
     }
 
     setSceneConstants() {

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -8,8 +8,6 @@ import { DebugGraphics } from "../../platform/graphics/debug-graphics.js";
 import { RenderPass } from "../../platform/graphics/render-pass.js";
 import { RenderAction } from "../composition/render-action.js";
 
-import { WorldClustersDebug } from "../lighting/world-clusters-debug.js";
-
 /**
  * A render pass used render a set of layers using a camera.
  *
@@ -224,8 +222,7 @@ class RenderPassForward extends RenderPass {
      */
     renderRenderAction(renderAction, firstRenderAction) {
 
-        const { scene, renderer, layerComposition } = this;
-        const clusteredLightingEnabled = scene.clusteredLightingEnabled;
+        const { renderer, layerComposition } = this;
         const device = renderer.device;
 
         // layer
@@ -256,70 +253,23 @@ class RenderPassForward extends RenderPass {
 
         if (camera) {
 
-            renderer.setupViewport(camera.camera, renderAction.renderTarget);
-
-            // if this is not a first render action to the render target, or if the render target was not
-            // fully cleared on pass start, we need to execute clears here
-            if (!firstRenderAction || !camera.camera.fullSizeClearRect) {
-                renderer.clear(camera.camera, renderAction.clearColor, renderAction.clearDepth, renderAction.clearStencil);
-            }
-
-            // #if _PROFILER
-            const sortTime = now();
-            // #endif
-
-            layer.sortVisible(camera.camera, transparent);
-
-            // #if _PROFILER
-            renderer._sortTime += now() - sortTime;
-            // #endif
-
-            const culledInstances = layer.getCulledInstances(camera.camera);
-            const visible = transparent ? culledInstances.transparent : culledInstances.opaque;
-
-            // add debug mesh instances to visible list
-            scene.immediate.onPreRenderLayer(layer, visible, transparent);
-
-            // set up layer uniforms
-            if (layer.requiresLightCube) {
-                renderer.lightCube.update(scene.ambientLight, layer._lights);
-                renderer.constantLightCube.setValue(renderer.lightCube.colors);
-            }
-
-            // upload clustered lights uniforms
-            if (clusteredLightingEnabled && renderAction.lightClusters) {
-                renderAction.lightClusters.activate();
-
-                // debug rendering of clusters
-                if (!renderer.clustersDebugRendered && scene.lighting.debugLayer === layer.id) {
-                    renderer.clustersDebugRendered = true;
-                    WorldClustersDebug.render(renderAction.lightClusters, this.scene);
-                }
-            }
-
-            // Set the not very clever global variable which is only useful when there's just one camera
-            scene._activeCamera = camera.camera;
-
-            const viewCount = renderer.setCameraUniforms(camera.camera, renderAction.renderTarget);
-            if (device.supportsUniformBuffers) {
-                renderer.setupViewUniformBuffers(renderAction.viewBindGroups, renderer.viewUniformFormat, renderer.viewBindGroupFormat, viewCount);
-            }
-
-            // enable flip faces if either the camera has _flipFaces enabled or the render target has flipY enabled
-            const flipFaces = !!(camera.camera._flipFaces ^ renderAction?.renderTarget?.flipY);
+            const options = {
+                lightClusters: renderAction.lightClusters
+            };
 
             // shader pass - use setting from camera if available, otherwise use layer setting
             const shaderPass = camera.camera.shaderPassInfo?.index ?? layer.shaderPass;
 
-            const draws = renderer._forwardDrawCalls;
-            renderer.renderForward(camera.camera,
-                                   visible,
-                                   layer.splitLights,
-                                   shaderPass,
-                                   layer.onDrawCall,
-                                   layer,
-                                   flipFaces);
-            layer._forwardDrawCalls += renderer._forwardDrawCalls - draws;
+            // if this is not a first render action to the render target, or if the render target was not
+            // fully cleared on pass start, we need to execute clears here
+            if (!firstRenderAction || !camera.camera.fullSizeClearRect) {
+                options.clearColor = renderAction.clearColor;
+                options.clearDepth = renderAction.clearDepth;
+                options.clearStencil = renderAction.clearStencil;
+            }
+
+            renderer.renderForwardLayer(camera, renderAction.renderTarget, layer, transparent,
+                                        shaderPass, renderAction.viewBindGroups, options);
 
             // Revert temp frame stuff
             // TODO: this should not be here, as each rendering / clearing should explicitly set up what


### PR DESCRIPTION
Extracted renderForwardLayer function to the renderer to allow of its reuse, and many render passes need to forward render meshes. This functions is a wrapper of renderForward, with handling of the set up it requires, allowing a lot simpler use.