### PR TITLE
Small clean up to depth rendering

### DIFF
--- a/extras/render-passes/render-pass-camera-frame.js
+++ b/extras/render-passes/render-pass-camera-frame.js
@@ -4,6 +4,8 @@ import {
     PIXELFORMAT_RGBA8,
     ADDRESS_CLAMP_TO_EDGE,
     FILTER_LINEAR,
+    FILTER_NEAREST,
+    PIXELFORMAT_DEPTH,
     RenderPass,
     RenderPassColorGrab,
     RenderPassForward,
@@ -132,9 +134,21 @@ class RenderPassCameraFrame extends RenderPass {
             addressV: ADDRESS_CLAMP_TO_EDGE
         });
 
+        const sceneDepth = new Texture(device, {
+            name: 'SceneDepth',
+            width: 4,
+            height: 4,
+            format: PIXELFORMAT_DEPTH,  // TODO: handle stencil support
+            mipmaps: false,
+            minFilter: FILTER_NEAREST,
+            magFilter: FILTER_NEAREST,
+            addressU: ADDRESS_CLAMP_TO_EDGE,
+            addressV: ADDRESS_CLAMP_TO_EDGE
+        });
+
         const rt = new RenderTarget({
             colorBuffer: sceneTexture,
-            depth: true,
+            depthBuffer: sceneDepth,
             samples: options.samples
         });
         this._rt = rt;

--- a/src/scene/graphics/render-pass-depth.js
+++ b/src/scene/graphics/render-pass-depth.js
@@ -99,7 +99,7 @@ class RenderPassDepth extends RenderPass {
                         const meshInstance = meshInstances[j];
 
                         // only collect meshes that update the depth
-                        if (meshInstance.material?.depthWrite && !meshInstance._noDepthDrawGl1) {
+                        if (meshInstance.material?.depthWrite) {
                             tempMeshInstances.push(meshInstance);
                         }
                     }

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -251,7 +251,6 @@ class MeshInstance {
         this._renderStyle = RENDERSTYLE_SOLID;
         this._receiveShadow = true;
         this._screenSpace = false;
-        this._noDepthDrawGl1 = false;
 
         /**
          * Controls whether the mesh instance can be culled by frustum culling

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -701,7 +701,6 @@ class ParticleEmitter {
         this.meshInstance.pick = false;
         this.meshInstance.updateKey(); // shouldn't be here?
         this.meshInstance.cull = true;
-        this.meshInstance._noDepthDrawGl1 = true;
         if (this.localSpace) {
             this.meshInstance.aabb.setFromTransformedAabb(this.worldBounds, this.node.getWorldTransform());
         } else {

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -76,7 +76,6 @@ class SkyMesh {
             this.meshInstance = meshInstance;
 
             meshInstance.cull = false;
-            meshInstance._noDepthDrawGl1 = true;
 
             // disable picker, the material has custom update shader and does not handle picker variant
             meshInstance.pick = false;


### PR DESCRIPTION
- render pass based rendering allocates the depth buffer internally, instead of letting the render target managing this, to allow us to render depth pre-pass to the same target (separate PR)
- removed _noDepthDrawGl1 flag on mesh instance that is not needed. This makes depth rendering on gl1 to match the one on gl2, and is based on the `material.depthWrite` flag.