### PR TITLE
Make sure render pass name is valid for derived classes

### DIFF
--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -91,7 +91,7 @@ class DepthStencilAttachmentOps {
  */
 class RenderPass {
     /** @type {string} */
-    name = '';
+    _name;
 
     /**
      * The graphics device.
@@ -193,9 +193,18 @@ class RenderPass {
      * graphics device.
      */
     constructor(graphicsDevice) {
-        DebugHelper.setName(this, this.constructor.name);
         Debug.assert(graphicsDevice);
         this.device = graphicsDevice;
+    }
+
+    set name(value) {
+        this._name = value;
+    }
+
+    get name() {
+        if (!this._name)
+            this._name = this.constructor.name;
+        return this._name;
     }
 
     set options(value) {

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -1,4 +1,4 @@
-import { Debug, DebugHelper } from '../../core/debug.js';
+import { Debug } from '../../core/debug.js';
 import { Tracing } from '../../core/tracing.js';
 import { Color } from '../../core/math/color.js';
 import { TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL } from '../../core/constants.js';

--- a/src/platform/graphics/uniform-buffer.js
+++ b/src/platform/graphics/uniform-buffer.js
@@ -6,6 +6,7 @@ import {
     UNIFORMTYPE_FLOATARRAY, UNIFORMTYPE_VEC2ARRAY, UNIFORMTYPE_VEC3ARRAY,
     UNIFORMTYPE_MAT2, UNIFORMTYPE_MAT3, UNIFORMTYPE_UINT, UNIFORMTYPE_UVEC2, UNIFORMTYPE_UVEC3, UNIFORMTYPE_UVEC4, UNIFORMTYPE_INTARRAY, UNIFORMTYPE_UINTARRAY, UNIFORMTYPE_BOOLARRAY, UNIFORMTYPE_IVEC2ARRAY, UNIFORMTYPE_IVEC3ARRAY, UNIFORMTYPE_UVEC2ARRAY, UNIFORMTYPE_UVEC3ARRAY, UNIFORMTYPE_BVEC2ARRAY, UNIFORMTYPE_BVEC3ARRAY
 } from './constants.js';
+import { DebugGraphics } from './debug-graphics.js';
 import { DynamicBufferAllocation } from './dynamic-buffers.js';
 
 // Uniform buffer set functions - only implemented for types for which the default
@@ -319,7 +320,7 @@ class UniformBuffer {
             }
         } else {
             Debug.warnOnce(`Value was not set when assigning to uniform [${uniformFormat.name}]` +
-                            `, expected type ${uniformTypeToName[uniformFormat.type]}`);
+                            `, expected type ${uniformTypeToName[uniformFormat.type]} while rendering ${DebugGraphics.toString()}`);
         }
     }
 


### PR DESCRIPTION
- initialising name in the constructor of the base class would always give us base class name instead of derived.