### PR TITLE
RenderPassPrepass implementation

### DIFF
--- a/examples/src/examples/graphics/post-processing.mjs
+++ b/examples/src/examples/graphics/post-processing.mjs
@@ -419,6 +419,7 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
             sceneColorMap: true,            // true if the scene color should be captured
 
             // disabled by default as this is WIP
+            prepassEnabled: false,
             taaEnabled: false               // true if temporal anti-aliasing should be used
         };
 

--- a/extras/render-passes/render-pass-prepass.js
+++ b/extras/render-passes/render-pass-prepass.js
@@ -1,0 +1,111 @@
+import {
+    LAYERID_DEPTH,
+    SHADER_DEPTH,
+    RenderPass,
+    RenderTarget
+} from "playcanvas";
+
+const tempMeshInstances = [];
+
+// uniform name of the depth texture
+const DEPTH_UNIFORM_NAME = 'uSceneDepthMap';
+
+/**
+ * A render pass which typically executes before the rendering of the main scene, and renders data
+ * that is required for the main rendering pass (and also in following passes) into separate render
+ * targets. This can include depth, normals, velocity, etc, used by TAA, motion blur, SSAO, etc.
+ *
+ * @ignore
+ */
+class RenderPassPrepass extends RenderPass {
+    /** @type {import("playcanvas").BindGroup[]} */
+    viewBindGroups = [];
+
+    constructor(device, scene, renderer, camera, depthBuffer, options) {
+        super(device);
+        this.scene = scene;
+        this.renderer = renderer;
+        this.camera = camera;
+
+        this.setupRenderTarget(depthBuffer, options);
+    }
+
+    destroy() {
+        super.destroy();
+        this.releaseRenderTarget(this.renderTarget);
+
+        this.viewBindGroups.forEach((bg) => {
+            bg.defaultUniformBuffer.destroy();
+            bg.destroy();
+        });
+        this.viewBindGroups.length = 0;
+    }
+
+    setupRenderTarget(depthBuffer, options) {
+
+        const renderTarget = new RenderTarget({
+            name: 'PrepassRT',
+            depthBuffer: depthBuffer
+        });
+
+        this.init(renderTarget, options);
+        this.depthStencilOps.storeDepth = true;
+    }
+
+    before() {
+
+        // Assign the depth to the uniform. Note that the depth buffer is still used as a render
+        // target in the following scene passes, and cannot be used as a texture inside those passes.
+        this.device.scope.resolve(DEPTH_UNIFORM_NAME).setValue(this.renderTarget.depthBuffer);
+    }
+
+    execute() {
+
+        const { renderer, scene, renderTarget } = this;
+        const camera = this.camera.camera;
+        const layers = scene.layers.layerList;
+        const subLayerEnabled = scene.layers.subLayerEnabled;
+        const isTransparent = scene.layers.subLayerList;
+
+        for (let i = 0; i < layers.length; i++) {
+            const layer = layers[i];
+
+            if (layer.enabled && subLayerEnabled[i]) {
+
+                // if the layer is rendered by the camera
+                if (layer.camerasSet.has(camera)) {
+
+                    // only render the layers before the depth layer
+                    if (layer.id === LAYERID_DEPTH)
+                        break;
+
+                    const culledInstances = layer.getCulledInstances(camera);
+                    const meshInstances = isTransparent[i] ? culledInstances.transparent : culledInstances.opaque;
+
+                    for (let j = 0; j < meshInstances.length; j++) {
+                        const meshInstance = meshInstances[j];
+
+                        // only collect meshes that update the depth
+                        if (meshInstance.material?.depthWrite) {
+                            tempMeshInstances.push(meshInstance);
+                        }
+                    }
+
+                    renderer.renderForwardLayer(camera, renderTarget, null, undefined, SHADER_DEPTH, this.viewBindGroups, {
+                        meshInstances: tempMeshInstances
+                    });
+
+                    tempMeshInstances.length = 0;
+                }
+            }
+        }
+    }
+
+    frameUpdate() {
+        // depth clear value (1 or no clear) set up each frame
+        const { camera } = this;
+        this.setClearDepth(camera.clearDepthBuffer ? 1 : undefined);
+    }
+}
+
+export { RenderPassPrepass };

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -18,6 +18,8 @@ import { LightCamera } from './light-camera.js';
 import { RenderPassForward } from './render-pass-forward.js';
 import { RenderPassPostprocessing } from './render-pass-postprocessing.js';
 
+const _noLights = [[], [], []];
+
 const _drawCallList = {
     drawCalls: [],
     shaderInstances: [],
@@ -740,14 +742,14 @@ class ForwardRenderer extends Renderer {
 
         } else {
             visible = options.meshInstances;
-            splitLights = options.splitLights;
+            splitLights = options.splitLights ?? _noLights;
         }
 
         Debug.assert(visible, 'Either layer or options.meshInstances must be provided');
 
         // upload clustered lights uniforms
-        const { lightClusters } = options;
-        if (clusteredLightingEnabled && lightClusters) {
+        if (clusteredLightingEnabled) {
+            const lightClusters = options.lightClusters ?? this.worldClustersAllocator.empty;
             lightClusters.activate();
 
             // debug rendering of clusters

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -34,6 +34,14 @@ class RenderPassForward extends RenderPass {
      */
     renderActions = [];
 
+    /**
+     * If true, do not clear the depth buffer before rendering, as it was already primed by a depth
+     * pre-pass.
+     *
+     * @type {boolean}
+     */
+    noDepthClear = false;
+
     constructor(device, layerComposition, scene, renderer) {
         super(device);
 
@@ -168,7 +176,7 @@ class RenderPassForward extends RenderPass {
             const fullSizeClearRect = camera.fullSizeClearRect;
 
             this.setClearColor(fullSizeClearRect && renderAction.clearColor ? camera.clearColor : undefined);
-            this.setClearDepth(fullSizeClearRect && renderAction.clearDepth ? camera.clearDepth : undefined);
+            this.setClearDepth(fullSizeClearRect && renderAction.clearDepth && !this.noDepthClear ? camera.clearDepth : undefined);
             this.setClearStencil(fullSizeClearRect && renderAction.clearStencil ? camera.clearStencil : undefined);
         }
     }


### PR DESCRIPTION
- prepass render pass, currently priming the depth buffer only, before the main pass
- this pass will be updated to render additional render targets such as velocity buffer in follow up PRs
- disabled for now till some pass uses it (TAA will)