### PR TITLE
WebXR - expose APIs to docs and some minor improvements

### DIFF
--- a/src/framework/xr/xr-anchor.js
+++ b/src/framework/xr/xr-anchor.js
@@ -165,10 +165,11 @@ class XrAnchor extends EventHandler {
     }
 
     /**
-     * This method provides a way to persist anchor and get a string with UUID.
-     * UUID can be used later to restore anchor.
+     * This method provides a way to persist anchor between WebXR sessions by
+     * providing a unique UUID of an anchor, that can be used later for restoring
+     * an anchor from underlying system.
      * Bear in mind that underlying systems might have a limit on number of anchors
-     * allowed to be persisted.
+     * allowed to be persisted per origin.
      *
      * @param {XrAnchorPersistCallback} [callback] - Callback to fire when anchor
      * persistent UUID has been generated or error if failed.
@@ -212,7 +213,7 @@ class XrAnchor extends EventHandler {
     }
 
     /**
-     * This method provides a way to remove persistent UUID of an anchor for underlying systems.
+     * Remove persistent UUID of an anchor from an underlying system.
      *
      * @param {XrAnchorForgetCallback} [callback] - Callback to fire when anchor has been
      * forgotten or error if failed.
@@ -231,7 +232,7 @@ class XrAnchor extends EventHandler {
     }
 
     /**
-     * UUID string of a persistent anchor or null if not presisted.
+     * UUID string of a persistent anchor or null if not persisted.
      *
      * @type {null|string}
      */

--- a/src/framework/xr/xr-anchors.js
+++ b/src/framework/xr/xr-anchors.js
@@ -225,11 +225,14 @@ class XrAnchors extends EventHandler {
     }
 
     /**
-     * Create anchor with position, rotation and a callback.
+     * Create an anchor using position and rotation, or from hit test result.
      *
-     * @param {import('../../core/math/vec3.js').Vec3|XRHitTestResult} position - Position for an anchor.
-     * @param {import('../../core/math/quat.js').Quat|XrAnchorCreateCallback} [rotation] - Rotation for an anchor.
-     * @param {XrAnchorCreateCallback} [callback] - Callback to fire when anchor was created or failed to be created.
+     * @param {import('../../core/math/vec3.js').Vec3|XRHitTestResult} position - Position for an anchor or
+     * a hit test result.
+     * @param {import('../../core/math/quat.js').Quat|XrAnchorCreateCallback} [rotation] - Rotation for an
+     * anchor or a callback if creating from a hit test result.
+     * @param {XrAnchorCreateCallback} [callback] - Callback to fire when anchor was created or failed to be
+     * created.
      * @example
      * // create an anchor using a position and rotation
      * app.xr.anchors.create(position, rotation, function (err, anchor) {

--- a/src/framework/xr/xr-dom-overlay.js
+++ b/src/framework/xr/xr-dom-overlay.js
@@ -66,8 +66,8 @@ class XrDomOverlay {
     }
 
     /**
-     * True if DOM Overlay is available. This information becomes available only when session has
-     * started and a valid root DOM element been provided.
+     * True if DOM Overlay is available. This information becomes available only when the session has
+     * started and a valid root DOM element has been provided.
      *
      * @type {boolean}
      */

--- a/src/framework/xr/xr-dom-overlay.js
+++ b/src/framework/xr/xr-dom-overlay.js
@@ -66,8 +66,8 @@ class XrDomOverlay {
     }
 
     /**
-     * True if DOM Overlay is available. It can only be available if it is supported, during a
-     * valid WebXR session and if a valid root element is provided.
+     * True if DOM Overlay is available. This information becomes available only when session has
+     * started and a valid root DOM element been provided.
      *
      * @type {boolean}
      */
@@ -79,12 +79,12 @@ class XrDomOverlay {
      * State of the DOM Overlay, which defines how the root DOM element is rendered. Possible
      * options:
      *
-     * - screen: Screen - indicates that the DOM element is covering whole physical screen,
+     * - screen - indicates that the DOM element is covering whole physical screen,
      * matching XR viewports.
-     * - floating: Floating - indicates that the underlying platform renders the DOM element as
+     * - floating - indicates that the underlying platform renders the DOM element as
      * floating in space, which can move during the WebXR session or allow the application to move
      * the element.
-     * - head-locked: Head Locked - indicates that the DOM element follows the user's head movement
+     * - head-locked - indicates that the DOM element follows the user's head movement
      * consistently, appearing similar to a helmet heads-up display.
      *
      * @type {string|null}
@@ -97,8 +97,8 @@ class XrDomOverlay {
     }
 
     /**
-     * The DOM element to be used as the root for DOM Overlay. Can be changed only outside of an
-     * active WebXR session.
+     * The DOM element to be used as the root for DOM Overlay. Can be changed only when XR session
+     * is not running.
      *
      * @type {Element|null}
      * @example

--- a/src/framework/xr/xr-hand.js
+++ b/src/framework/xr/xr-hand.js
@@ -257,9 +257,9 @@ class XrHand extends EventHandler {
     }
 
     /**
-     * Returns joint by XRHand id from list in specs: https://immersive-web.github.io/webxr-hand-input/.
+     * Returns joint by its XRHand id.
      *
-     * @param {string} id - Id of a joint based on specs ID's in XRHand: https://immersive-web.github.io/webxr-hand-input/.
+     * @param {string} id - Id of a joint based on specs ID's in XRHand: https://immersive-web.github.io/webxr-hand-input/#skeleton-joints-section.
      * @returns {XrJoint|null} Joint or null if not available.
      */
     getJointById(id) {

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -18,6 +18,19 @@ const poolQuat = [];
  * Represents XR hit test source, which provides access to hit results of real world geometry from
  * AR session.
  *
+ * ```javascript
+ * // start a hit test from a viewer origin forward
+ * app.xr.hitTest.start({
+ *     spaceType: pc.XRSPACE_VIEWER,
+ *     callback: function (err, hitTestSource) {
+ *         if (err) return;
+ *         // subscribe to hit test results
+ *         hitTestSource.on('result', function (position, rotation, inputSource, hitTestResult) {
+ *             // position and rotation of hit test result
+ *         });
+ *     }
+ * });
+ * ```
  * @augments EventHandler
  * @category XR
  */
@@ -35,13 +48,13 @@ class XrHitTestSource extends EventHandler {
 
     /**
      * Fired when the hit test source receives new results. It provides transform information that
-     * tries to match real world picked geometry. The handler is passed the {@link Vec3} position,
-     * the {@link Quat} rotation, the {@link XrInputSource} (if it is a transient hit test source)
+     * tries to match real world geometry. Callback provides the {@link Vec3} position, the
+     * {@link Quat} rotation, the {@link XrInputSource} (if it is a transient hit test source)
      * and the {@link XRHitTestResult} object that is created by WebXR API.
      *
      * @event
      * @example
-     * hitTestSource.on('result', (position, rotation) => {
+     * hitTestSource.on('result', (position, rotation, inputSource, hitTestReult) => {
      *     target.setPosition(position);
      *     target.setRotation(rotation);
      * });

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -194,7 +194,7 @@ class XrHitTest extends EventHandler {
      * @param {XrHitTestStartCallback} [options.callback] - Optional callback function called once
      * hit test source is created or failed.
      * @example
-     * // start a hit testing from viewer position facing forward
+     * // start hit testing from viewer position facing forwards
      * app.xr.hitTest.start({
      *     spaceType: pc.XRSPACE_VIEWER,
      *     callback: function (err, hitTestSource) {

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -205,7 +205,7 @@ class XrHitTest extends EventHandler {
      *     }
      * });
      * @example
-     * // start a hit testing using an arbitrary ray
+     * // start hit testing using an arbitrary ray
      * const ray = new pc.Ray(new pc.Vec3(0, 0, 0), new pc.Vec3(0, -1, 0));
      * app.xr.hitTest.start({
      *     spaceType: pc.XRSPACE_LOCAL,

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -332,7 +332,7 @@ class XrHitTest extends EventHandler {
     }
 
     /**
-     * True if Hit Test is available. This information is available only when session has started.
+     * True if Hit Test is available. This information is available only when the session has started.
      *
      * @type {boolean}
      */

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -1,7 +1,7 @@
 import { platform } from '../../core/platform.js';
 import { EventHandler } from '../../core/event-handler.js';
 
-import { XRSPACE_VIEWER, XRTYPE_AR } from './constants.js';
+import { XRSPACE_VIEWER } from './constants.js';
 import { XrHitTestSource } from './xr-hit-test-source.js';
 
 /**
@@ -14,13 +14,36 @@ import { XrHitTestSource } from './xr-hit-test-source.js';
  */
 
 /**
- * Hit Test provides ability to get position and rotation of ray intersecting point with
- * representation of real world geometry by underlying AR system.
+ * The Hit Test interface allows initiating hit testing against real-world geometry from various
+ * sources: the view, input sources, or an arbitrary ray in space. Results reflect the underlying
+ * AR system's understanding of the real world.
  *
  * @augments EventHandler
  * @category XR
  */
 class XrHitTest extends EventHandler {
+    /**
+     * Fired when hit test becomes available.
+     *
+     * @event
+     * @example
+     * app.xr.hitTest.on('available', () => {
+     *     console.log('Hit Testing is available');
+     * });
+     */
+    static EVENT_AVAILABLE = 'available';
+
+    /**
+     * Fired when hit test becomes unavailable.
+     *
+     * @event
+     * @example
+     * app.xr.hitTest.on('unavailable', () => {
+     *     console.log('Hit Testing is unavailable');
+     * });
+     */
+    static EVENT_UNAVAILABLE = 'unavailable';
+
     /**
      * Fired when new {@link XrHitTestSource} is added to the list. The handler is passed the
      * {@link XrHitTestSource} object that has been added.
@@ -84,10 +107,10 @@ class XrHitTest extends EventHandler {
     _supported = platform.browser && !!(window.XRSession && window.XRSession.prototype.requestHitTestSource);
 
     /**
-     * @type {XRSession}
+     * @type {boolean}
      * @private
      */
-    _session = null;
+    _available = false;
 
     /**
      * List of active {@link XrHitTestSource}.
@@ -115,52 +138,23 @@ class XrHitTest extends EventHandler {
 
     /** @private */
     _onSessionStart() {
-        if (this.manager.type !== XRTYPE_AR)
-            return;
-
-        this._session = this.manager.session;
+        const available = this.manager.session.enabledFeatures.indexOf('hit-test') !== -1;
+        if (!available) return;
+        this._available = available;
+        this.fire('available');
     }
 
     /** @private */
     _onSessionEnd() {
-        if (!this._session)
-            return;
-
-        this._session = null;
+        if (!this._available) return;
+        this._available = false;
 
         for (let i = 0; i < this.sources.length; i++) {
             this.sources[i].onStop();
         }
         this.sources = [];
-    }
 
-    /**
-     * Checks if hit testing is available.
-     *
-     * @param {Function} callback - Error callback.
-     * @param {*} fireError - Event handler on while to fire error event.
-     * @returns {boolean} True if hit test is available.
-     * @private
-     */
-    isAvailable(callback, fireError) {
-        let err;
-
-        if (!this._supported)
-            err = new Error('XR HitTest is not supported');
-
-        if (!this._session)
-            err = new Error('XR Session is not started (1)');
-
-        if (this.manager.type !== XRTYPE_AR)
-            err = new Error('XR HitTest is available only for AR');
-
-        if (err) {
-            if (callback) callback(err);
-            if (fireError) fireError.fire('error', err);
-            return false;
-        }
-
-        return true;
+        this.fire('unavailable');
     }
 
     /**
@@ -200,17 +194,18 @@ class XrHitTest extends EventHandler {
      * @param {XrHitTestStartCallback} [options.callback] - Optional callback function called once
      * hit test source is created or failed.
      * @example
+     * // start a hit testing from viewer position facing forward
      * app.xr.hitTest.start({
      *     spaceType: pc.XRSPACE_VIEWER,
      *     callback: function (err, hitTestSource) {
      *         if (err) return;
      *         hitTestSource.on('result', function (position, rotation) {
      *             // position and rotation of hit test result
-     *             // based on Ray facing forward from the Viewer reference space
      *         });
      *     }
      * });
      * @example
+     * // start a hit testing using an arbitrary ray
      * const ray = new pc.Ray(new pc.Vec3(0, 0, 0), new pc.Vec3(0, -1, 0));
      * app.xr.hitTest.start({
      *     spaceType: pc.XRSPACE_LOCAL,
@@ -221,6 +216,7 @@ class XrHitTest extends EventHandler {
      *     }
      * });
      * @example
+     * // start a hit testing for a touch screen taps
      * app.xr.hitTest.start({
      *     profile: 'generic-touchscreen',
      *     callback: function (err, hitTestSource) {
@@ -233,8 +229,15 @@ class XrHitTest extends EventHandler {
      * });
      */
     start(options = {}) {
-        if (!this.isAvailable(options.callback, this))
+        if (!this._supported) {
+            options.callback?.(new Error('XR HitTest is not supported'), null);
             return;
+        }
+
+        if (!this._available) {
+            options.callback?.(new Error('XR HitTest is not available'), null);
+            return;
+        }
 
         if (!options.profile && !options.spaceType)
             options.spaceType = XRSPACE_VIEWER;
@@ -250,15 +253,15 @@ class XrHitTest extends EventHandler {
         const callback = options.callback;
 
         if (options.spaceType) {
-            this._session.requestReferenceSpace(options.spaceType).then((referenceSpace) => {
-                if (!this._session) {
+            this.manager.session.requestReferenceSpace(options.spaceType).then((referenceSpace) => {
+                if (!this.manager.session) {
                     const err = new Error('XR Session is not started (2)');
                     if (callback) callback(err);
                     this.fire('error', err);
                     return;
                 }
 
-                this._session.requestHitTestSource({
+                this.manager.session.requestHitTestSource({
                     space: referenceSpace,
                     entityTypes: options.entityTypes || undefined,
                     offsetRay: xrRay
@@ -273,7 +276,7 @@ class XrHitTest extends EventHandler {
                 this.fire('error', ex);
             });
         } else {
-            this._session.requestHitTestSourceForTransientInput({
+            this.manager.session.requestHitTestSourceForTransientInput({
                 profile: options.profile,
                 entityTypes: options.entityTypes || undefined,
                 offsetRay: xrRay
@@ -294,7 +297,7 @@ class XrHitTest extends EventHandler {
      * @private
      */
     _onHitTestSource(xrHitTestSource, transient, inputSource, callback) {
-        if (!this._session) {
+        if (!this.manager.session) {
             xrHitTestSource.cancel();
             const err = new Error('XR Session is not started (3)');
             if (callback) callback(err);
@@ -326,6 +329,15 @@ class XrHitTest extends EventHandler {
      */
     get supported() {
         return this._supported;
+    }
+
+    /**
+     * True if Hit Test is available. This information is available only when session has started.
+     *
+     * @type {boolean}
+     */
+    get available() {
+        return this._available;
     }
 }
 

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -216,7 +216,7 @@ class XrHitTest extends EventHandler {
      *     }
      * });
      * @example
-     * // start a hit testing for a touch screen taps
+     * // start hit testing for touch screen taps
      * app.xr.hitTest.start({
      *     profile: 'generic-touchscreen',
      *     callback: function (err, hitTestSource) {

--- a/src/framework/xr/xr-image-tracking.js
+++ b/src/framework/xr/xr-image-tracking.js
@@ -4,8 +4,9 @@ import { platform } from '../../core/platform.js';
 import { XrTrackedImage } from './xr-tracked-image.js';
 
 /**
- * Image Tracking provides the ability to track real world images by provided image samples and
- * their estimated sizes.
+ * Image Tracking provides the ability to track real world images using provided image samples and
+ * their estimated sizes. Underlying system will assume that tracked image can move and rotate
+ * in the real world and will try to provide transformation estimates and its tracking state.
  *
  * @augments EventHandler
  * @category XR
@@ -80,7 +81,7 @@ class XrImageTracking extends EventHandler {
      * @returns {XrTrackedImage|null} Tracked image object that will contain tracking information.
      * Returns null if image tracking is not supported or if the XR manager is not active.
      * @example
-     * // image with width of 20cm (0.2m)
+     * // image of a book cover that has width of 20cm (0.2m)
      * app.xr.imageTracking.add(bookCoverImg, 0.2);
      */
     add(image, width) {
@@ -196,8 +197,9 @@ class XrImageTracking extends EventHandler {
     }
 
     /**
-     * True if Image Tracking is available. This property will be false if no images were provided
-     * for the AR session or there was an error processing the provided images.
+     * True if Image Tracking is available. This information is only available when
+     * XR session has started, and will be true if image tracking is supported and
+     * images were provided and they have been processed successfully.
      *
      * @type {boolean}
      */

--- a/src/framework/xr/xr-image-tracking.js
+++ b/src/framework/xr/xr-image-tracking.js
@@ -197,7 +197,7 @@ class XrImageTracking extends EventHandler {
     }
 
     /**
-     * True if Image Tracking is available. This information is only available when
+     * True if Image Tracking is available. This information is only available when the
      * XR session has started, and will be true if image tracking is supported and
      * images were provided and they have been processed successfully.
      *

--- a/src/framework/xr/xr-image-tracking.js
+++ b/src/framework/xr/xr-image-tracking.js
@@ -5,7 +5,7 @@ import { XrTrackedImage } from './xr-tracked-image.js';
 
 /**
  * Image Tracking provides the ability to track real world images using provided image samples and
- * their estimated sizes. Underlying system will assume that tracked image can move and rotate
+ * their estimated sizes. The underlying system will assume that tracked image can move and rotate
  * in the real world and will try to provide transformation estimates and its tracking state.
  *
  * @augments EventHandler

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -141,7 +141,7 @@ class XrInputSource extends EventHandler {
      * Fired when hit test source receives new results. It provides transform information that
      * tries to match real world picked geometry. The handler is passed the {@link XrHitTestSource}
      * object that produced the hit result, the {@link Vec3} position, the {@link Quat}
-     * rotation and the {@link XRHitTestResult} object that is created by WebXR API
+     * rotation and the {@link XRHitTestResult} object that is created by the WebXR API.
      *
      * @event
      * @example

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -15,8 +15,8 @@ let ids = 0;
 /**
  * Represents XR input source, which is any input mechanism which allows the user to perform
  * targeted actions in the same virtual space as the viewer. Example XR input sources include, but
- * are not limited to, handheld controllers, optically tracked hands, and gaze-based input methods
- * that operate on the viewer's pose.
+ * are not limited to: handheld controllers, optically tracked hands, touch screen taps, and
+ * gaze-based input methods that operate on the viewer's pose.
  *
  * @augments EventHandler
  * @category XR
@@ -140,12 +140,12 @@ class XrInputSource extends EventHandler {
     /**
      * Fired when hit test source receives new results. It provides transform information that
      * tries to match real world picked geometry. The handler is passed the {@link XrHitTestSource}
-     * object that produced the hit result, the {@link Vec3} position and the {@link Quat}
-     * rotation.
+     * object that produced the hit result, the {@link Vec3} position, the {@link Quat}
+     * rotation and the {@link XRHitTestResult} object that is created by WebXR API
      *
      * @event
      * @example
-     * inputSource.on('hittest:result', (hitTestSource, position, rotation) => {
+     * inputSource.on('hittest:result', (hitTestSource, position, rotation, hitTestResult) => {
      *     target.setPosition(position);
      *     target.setRotation(rotation);
      * });
@@ -380,7 +380,7 @@ class XrInputSource extends EventHandler {
 
     /**
      * If input source can be held, then it will have node with its world transformation, that can
-     * be used to position and rotate virtual joysticks based on it.
+     * be used to position and rotate visual object based on it.
      *
      * @type {boolean}
      */
@@ -456,7 +456,7 @@ class XrInputSource extends EventHandler {
     }
 
     /**
-     * List of active {@link XrHitTestSource} instances created by this input source.
+     * List of active {@link XrHitTestSource} instances associated with this input source.
      *
      * @type {import('./xr-hit-test-source.js').XrHitTestSource[]}
      */
@@ -667,7 +667,7 @@ class XrInputSource extends EventHandler {
      *     inputSource.hitTestStart({
      *         callback: function (err, hitTestSource) {
      *             if (err) return;
-     *             hitTestSource.on('result', function (position, rotation) {
+     *             hitTestSource.on('result', function (position, rotation, inputSource, hitTestResult) {
      *                 // position and rotation of hit test result
      *                 // that will be created from touch on mobile devices
      *             });
@@ -698,11 +698,9 @@ class XrInputSource extends EventHandler {
 
         this.fire('hittest:add', hitTestSource);
 
-        hitTestSource.on('result', (position, rotation, inputSource) => {
-            if (inputSource !== this)
-                return;
-
-            this.fire('hittest:result', hitTestSource, position, rotation);
+        hitTestSource.on('result', (position, rotation, inputSource, hitTestResult) => {
+            if (inputSource !== this) return;
+            this.fire('hittest:result', hitTestSource, position, rotation, hitTestResult);
         });
         hitTestSource.once('remove', () => {
             this.onHitTestSourceRemove(hitTestSource);

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -5,7 +5,8 @@ import { XrInputSource } from './xr-input-source.js';
 /**
  * Provides access to input sources for WebXR.
  *
- * Input sources represend:
+ * Input sources represent:
+ *
  * - hand held controllers - and their optional capabilities: gamepad and vibration
  * - hands - with their individual joints
  * - transient sources - such as touch screen taps and voice commands

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -5,6 +5,11 @@ import { XrInputSource } from './xr-input-source.js';
 /**
  * Provides access to input sources for WebXR.
  *
+ * Input sources represend:
+ * - hand held controllers - and their optional capabilities: gamepad and vibration
+ * - hands - with their individual joints
+ * - transient sources - such as touch screen taps and voice commands
+ *
  * @augments EventHandler
  * @category XR
  */
@@ -22,7 +27,7 @@ class XrInput extends EventHandler {
     static EVENT_ADD = 'add';
 
     /**
-     * Fired when an {@link XrInputSource} is removed to the list. The handler is passed the
+     * Fired when an {@link XrInputSource} is removed from the list. The handler is passed the
      * {@link XrInputSource} that has been removed.
      *
      * @event

--- a/src/framework/xr/xr-light-estimation.js
+++ b/src/framework/xr/xr-light-estimation.js
@@ -280,7 +280,7 @@ class XrLightEstimation extends EventHandler {
     }
 
     /**
-     * Spherical harmonics coefficients of estimated to be ambient light. Or null if data is not available.
+     * Spherical harmonic coefficients of estimated ambient light. Or null if data is not available.
      *
      * @type {Float32Array|null}
      */

--- a/src/framework/xr/xr-light-estimation.js
+++ b/src/framework/xr/xr-light-estimation.js
@@ -280,11 +280,9 @@ class XrLightEstimation extends EventHandler {
     }
 
     /**
-     * Spherical harmonics coefficients of what is estimated to be the most prominent directional
-     * light. Or null if data is not available.
+     * Spherical harmonics coefficients of estimated to be ambient light. Or null if data is not available.
      *
      * @type {Float32Array|null}
-     * @ignore
      */
     get sphericalHarmonics() {
         return this._available ? this._sphericalHarmonics : null;

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -175,7 +175,6 @@ class XrManager extends EventHandler {
      * Provides access to DOM overlay capabilities.
      *
      * @type {XrDomOverlay}
-     * @ignore
      */
     domOverlay;
 
@@ -191,7 +190,6 @@ class XrManager extends EventHandler {
      * Provides access to image tracking capabilities.
      *
      * @type {XrImageTracking}
-     * @ignore
      */
     imageTracking;
 
@@ -199,7 +197,6 @@ class XrManager extends EventHandler {
      * Provides access to plane detection capabilities.
      *
      * @type {XrPlaneDetection}
-     * @ignore
      */
     planeDetection;
 
@@ -207,7 +204,6 @@ class XrManager extends EventHandler {
      * Provides access to mesh detection capabilities.
      *
      * @type {XrMeshDetection}
-     * @ignore
      */
     meshDetection;
 
@@ -222,7 +218,6 @@ class XrManager extends EventHandler {
      * Provides access to light estimation capabilities.
      *
      * @type {XrLightEstimation}
-     * @ignore
      */
     lightEstimation;
 
@@ -230,7 +225,6 @@ class XrManager extends EventHandler {
      * Provides access to views and their capabilities.
      *
      * @type {XrViews}
-     * @ignore
      */
     views;
 

--- a/src/framework/xr/xr-mesh-detection.js
+++ b/src/framework/xr/xr-mesh-detection.js
@@ -197,7 +197,7 @@ class XrMeshDetection extends EventHandler {
     /**
      * Array of {@link XrMesh} instances that contain transform, vertices and label information.
      *
-     * @type {XrMesh[]|null}
+     * @type {XrMesh[]}
      */
     get meshes() {
         return this._list;

--- a/src/framework/xr/xr-mesh.js
+++ b/src/framework/xr/xr-mesh.js
@@ -98,7 +98,7 @@ class XrMesh extends EventHandler {
     }
 
     /**
-     * Float 32 array of mesh vertices.
+     * Float 32 array of mesh vertices. This array contains 3 components per vertex: x,y,z coordinates.
      *
      * @type {Float32Array}
      */

--- a/src/framework/xr/xr-plane-detection.js
+++ b/src/framework/xr/xr-plane-detection.js
@@ -192,7 +192,7 @@ class XrPlaneDetection extends EventHandler {
     }
 
     /**
-     * True if Plane Detection is available. This information is available only when session has started.
+     * True if Plane Detection is available. This information is available only when the session has started.
      *
      * @type {boolean}
      */

--- a/src/framework/xr/xr-plane-detection.js
+++ b/src/framework/xr/xr-plane-detection.js
@@ -192,8 +192,7 @@ class XrPlaneDetection extends EventHandler {
     }
 
     /**
-     * True if Plane Detection is available. This property can be set to true only during a running
-     * session.
+     * True if Plane Detection is available. This information is available only when session has started.
      *
      * @type {boolean}
      */
@@ -202,8 +201,7 @@ class XrPlaneDetection extends EventHandler {
     }
 
     /**
-     * Array of {@link XrPlane} instances that contain individual plane information, or null if
-     * plane detection is not available.
+     * Array of {@link XrPlane} instances that contain individual plane information.
      *
      * @type {XrPlane[]}
      */

--- a/src/framework/xr/xr-plane.js
+++ b/src/framework/xr/xr-plane.js
@@ -5,8 +5,8 @@ import { Vec3 } from '../../core/math/vec3.js';
 let ids = 0;
 
 /**
- * Detected Plane instance that provides position, rotation and polygon points. Plane is a subject
- * to change during its lifetime.
+ * Detected Plane instance that provides position, rotation, polygon points and its semantic label.
+ * Plane data is a subject to change during its lifetime.
  *
  * @category XR
  */

--- a/src/framework/xr/xr-plane.js
+++ b/src/framework/xr/xr-plane.js
@@ -6,7 +6,7 @@ let ids = 0;
 
 /**
  * Detected Plane instance that provides position, rotation, polygon points and its semantic label.
- * Plane data is a subject to change during its lifetime.
+ * Plane data is subject to change during its lifetime.
  *
  * @category XR
  */

--- a/src/framework/xr/xr-tracked-image.js
+++ b/src/framework/xr/xr-tracked-image.js
@@ -206,8 +206,7 @@ class XrTrackedImage extends EventHandler {
     }
 
     /**
-     * Get the position of the tracked image. The position is the most recent one based on the
-     * tracked image state.
+     * Get the world position of the tracked image.
      *
      * @returns {Vec3} Position in world space.
      * @example
@@ -220,8 +219,7 @@ class XrTrackedImage extends EventHandler {
     }
 
     /**
-     * Get the rotation of the tracked image. The rotation is the most recent based on the tracked
-     * image state.
+     * Get the world rotation of the tracked image.
      *
      * @returns {Quat} Rotation in world space.
      * @example

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -7,9 +7,9 @@ import { Mat4 } from "../../core/math/mat4.js";
 import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, PIXELFORMAT_RGB8 } from '../../platform/graphics/constants.js';
 
 /**
- * Represents XR View which represents a screen (monoscopic scenario such as mobile phones) or an eye
- * (stereoscopic scenarion such as HMD context). It provides access to view's color and depth information
- * based on capabilities of underlying AR system.
+ * Represents an XR View which represents a screen (monoscopic scenario such as a mobile phone) or an eye
+ * (stereoscopic scenario such as an HMD context). It provides access to the view's color and depth information
+ * based on the capabilities of underlying AR system.
  *
  * @category XR
  */

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -7,9 +7,9 @@ import { Mat4 } from "../../core/math/mat4.js";
 import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, PIXELFORMAT_RGB8 } from '../../platform/graphics/constants.js';
 
 /**
- * Represents XR View which represents a screen (mobile phone context) or an eye (HMD context).
- * It provides access to view's color and depth information based on capabilities of underlying
- * AR system.
+ * Represents XR View which represents a screen (monoscopic scenario such as mobile phones) or an eye
+ * (stereoscopic scenarion such as HMD context). It provides access to view's color and depth information
+ * based on capabilities of underlying AR system.
  *
  * @category XR
  */
@@ -190,7 +190,7 @@ class XrView extends EventHandler {
 
     /**
      * Texture associated with this view's camera color. Equals to null if camera color is
-     * not available or not supported.
+     * not available or is not supported.
      *
      * @type {Texture|null}
      */
@@ -544,9 +544,7 @@ class XrView extends EventHandler {
         return this._depthInfo?.getDepthInMeters(u, v) ?? null;
     }
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     destroy() {
         this._depthInfo = null;
 

--- a/src/framework/xr/xr-views.js
+++ b/src/framework/xr/xr-views.js
@@ -245,7 +245,7 @@ class XrViews extends EventHandler {
     }
 
     /**
-     * Get a {@link XrView} by its associated eye contant.
+     * Get an {@link XrView} by its associated eye constant.
      *
      * @param {string} eye - An XREYE_* view is associated with. Can be 'none' for monoscope views.
      * @returns {XrView|null} View or null if view of such eye is not available.

--- a/src/framework/xr/xr-views.js
+++ b/src/framework/xr/xr-views.js
@@ -6,7 +6,7 @@ import { PIXELFORMAT_LA8, PIXELFORMAT_R32F } from '../../platform/graphics/const
 
 /**
  * Provides access to list of {@link XrView}'s. And information about their capabilities,
- * such as support and availability of view's camera color texture.
+ * such as support and availability of view's camera color texture, depth texture and other parameters.
  *
  * @category XR
  */
@@ -169,10 +169,17 @@ class XrViews extends EventHandler {
     }
 
     /**
+     * @type {string}
+     * @ignore
+     */
+    get depthUsage() {
+        return this._depthUsage;
+    }
+
+    /**
      * Whether the depth sensing is GPU optimized.
      *
      * @type {boolean}
-     * @ignore
      */
     get depthGpuOptimized() {
         return this._depthUsage === XRDEPTHSENSINGUSAGE_GPU;
@@ -194,14 +201,6 @@ class XrViews extends EventHandler {
      */
     get depthPixelFormat() {
         return this._depthFormats[this._depthFormat] ?? null;
-    }
-
-    /**
-     * @type {string}
-     * @ignore
-     */
-    get depthUsage() {
-        return this._depthUsage;
     }
 
     /**
@@ -246,6 +245,8 @@ class XrViews extends EventHandler {
     }
 
     /**
+     * Get a {@link XrView} by its associated eye contant.
+     *
      * @param {string} eye - An XREYE_* view is associated with. Can be 'none' for monoscope views.
      * @returns {XrView|null} View or null if view of such eye is not available.
      */

--- a/src/index.js
+++ b/src/index.js
@@ -364,11 +364,15 @@ export { XrHitTestSource } from './framework/xr/xr-hit-test-source.js';
 export { XrImageTracking } from './framework/xr/xr-image-tracking.js';
 export { XrInput } from './framework/xr/xr-input.js';
 export { XrInputSource } from './framework/xr/xr-input-source.js';
+export { XrJoint } from './framework/xr/xr-joint.js';
 export { XrLightEstimation } from './framework/xr/xr-light-estimation.js';
 export { XrManager } from './framework/xr/xr-manager.js';
+export { XrMeshDetection } from './framework/xr/xr-mesh-detection.js';
 export { XrPlane } from './framework/xr/xr-plane.js';
 export { XrPlaneDetection } from './framework/xr/xr-plane-detection.js';
 export { XrTrackedImage } from './framework/xr/xr-tracked-image.js';
+export { XrView } from './framework/xr/xr-view.js';
+export { XrViews } from './framework/xr/xr-views.js';
 
 // BACKWARDS COMPATIBILITY
 export * from './deprecated/deprecated.js';


### PR DESCRIPTION
Currently some essential WebXR APIs are not available in docs, these include: XrJoint (for hand tracking), XrMeshDetection, XrView and XrViews - to access color and depth textures.

This PR exposes and slightly improves docs for WebXR APIs.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
