### PR TITLE
Convert ResourceHandler to class (Removes ts-ignore from app options)

### DIFF
--- a/examples/src/examples/animation/blend-trees-1d.mjs
+++ b/examples/src/examples/animation/blend-trees-1d.mjs
@@ -52,15 +52,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, data, glsla
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.AnimClipHandler,
-        // @ts-ignore
         pc.AnimStateGraphHandler
     ];
 

--- a/examples/src/examples/animation/blend-trees-2d-cartesian.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.mjs
@@ -157,15 +157,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.AnimClipHandler,
-        // @ts-ignore
         pc.AnimStateGraphHandler
     ];
 

--- a/examples/src/examples/animation/blend-trees-2d-directional.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-directional.mjs
@@ -114,15 +114,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.AnimClipHandler,
-        // @ts-ignore
         pc.AnimStateGraphHandler
     ];
 

--- a/examples/src/examples/animation/component-properties.mjs
+++ b/examples/src/examples/animation/component-properties.mjs
@@ -45,11 +45,8 @@ async function example({ canvas, deviceType, data, assetPath, glslangPath, twgsl
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.AnimClipHandler,
-        // @ts-ignore
         pc.AnimStateGraphHandler
     ];
 

--- a/examples/src/examples/animation/events.mjs
+++ b/examples/src/examples/animation/events.mjs
@@ -33,15 +33,10 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.AnimClipHandler,
-        // @ts-ignore
         pc.AnimStateGraphHandler
     ];
 

--- a/examples/src/examples/animation/layer-masks.mjs
+++ b/examples/src/examples/animation/layer-masks.mjs
@@ -118,15 +118,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.AnimClipHandler,
-        // @ts-ignore
         pc.AnimStateGraphHandler
     ];
 

--- a/examples/src/examples/animation/locomotion.mjs
+++ b/examples/src/examples/animation/locomotion.mjs
@@ -74,15 +74,10 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
         pc.RigidBodyComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.AnimClipHandler,
-        // @ts-ignore
         pc.AnimStateGraphHandler
     ];
 

--- a/examples/src/examples/animation/tween.mjs
+++ b/examples/src/examples/animation/tween.mjs
@@ -31,13 +31,9 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler,
-        // @ts-ignore
         pc.JsonHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/camera/first-person.mjs
+++ b/examples/src/examples/camera/first-person.mjs
@@ -28,11 +28,8 @@ async function example({ canvas, deviceType, glslangPath, twgslPath, assetPath, 
         pc.RigidBodyComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/camera/fly.mjs
+++ b/examples/src/examples/camera/fly.mjs
@@ -24,7 +24,6 @@ async function example({ canvas, deviceType, glslangPath, twgslPath, scriptsPath
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/camera/orbit.mjs
+++ b/examples/src/examples/camera/orbit.mjs
@@ -24,11 +24,8 @@ async function example({ canvas, deviceType, glslangPath, twgslPath, assetPath, 
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/area-lights.mjs
+++ b/examples/src/examples/graphics/area-lights.mjs
@@ -33,13 +33,9 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.JsonHandler,
-        // @ts-ignore
         pc.CubemapHandler
     ];
 

--- a/examples/src/examples/graphics/area-picker.mjs
+++ b/examples/src/examples/graphics/area-picker.mjs
@@ -29,9 +29,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.TextureHandler
     ];
 

--- a/examples/src/examples/graphics/asset-viewer.mjs
+++ b/examples/src/examples/graphics/asset-viewer.mjs
@@ -58,15 +58,10 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.JsonHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/graphics/clustered-area-lights.mjs
+++ b/examples/src/examples/graphics/clustered-area-lights.mjs
@@ -71,13 +71,9 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.JsonHandler
     ];
 

--- a/examples/src/examples/graphics/clustered-lighting.mjs
+++ b/examples/src/examples/graphics/clustered-lighting.mjs
@@ -30,11 +30,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/clustered-omni-shadows.mjs
+++ b/examples/src/examples/graphics/clustered-omni-shadows.mjs
@@ -80,11 +80,8 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.CubemapHandler
     ];
 

--- a/examples/src/examples/graphics/clustered-spot-shadows.mjs
+++ b/examples/src/examples/graphics/clustered-spot-shadows.mjs
@@ -136,9 +136,7 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/contact-hardening-shadows.mjs
+++ b/examples/src/examples/graphics/contact-hardening-shadows.mjs
@@ -160,17 +160,11 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.JsonHandler,
-        // @ts-ignore
         pc.AnimClipHandler,
-        // @ts-ignore
         pc.AnimStateGraphHandler
     ];
 

--- a/examples/src/examples/graphics/grab-pass.mjs
+++ b/examples/src/examples/graphics/grab-pass.mjs
@@ -31,7 +31,6 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler
     ];
 

--- a/examples/src/examples/graphics/ground-fog.mjs
+++ b/examples/src/examples/graphics/ground-fog.mjs
@@ -52,11 +52,8 @@ async function example({ canvas, deviceType, files, assetPath, scriptsPath, glsl
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/hardware-instancing.mjs
+++ b/examples/src/examples/graphics/hardware-instancing.mjs
@@ -25,7 +25,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler
     ];
 

--- a/examples/src/examples/graphics/integer-textures.mjs
+++ b/examples/src/examples/graphics/integer-textures.mjs
@@ -102,7 +102,6 @@ async function example({ canvas, data, deviceType, assetPath, files, glslangPath
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler
     ];
 

--- a/examples/src/examples/graphics/light-physical-units.mjs
+++ b/examples/src/examples/graphics/light-physical-units.mjs
@@ -143,13 +143,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.JsonHandler
     ];
 

--- a/examples/src/examples/graphics/lights-baked-a-o.mjs
+++ b/examples/src/examples/graphics/lights-baked-a-o.mjs
@@ -184,13 +184,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.CubemapHandler
     ];
 

--- a/examples/src/examples/graphics/lights.mjs
+++ b/examples/src/examples/graphics/lights.mjs
@@ -126,11 +126,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.CubemapHandler
     ];
 

--- a/examples/src/examples/graphics/lines.mjs
+++ b/examples/src/examples/graphics/lines.mjs
@@ -26,7 +26,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler
     ];
 

--- a/examples/src/examples/graphics/lit-material.mjs
+++ b/examples/src/examples/graphics/lit-material.mjs
@@ -37,15 +37,10 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.JsonHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/graphics/material-anisotropic.mjs
+++ b/examples/src/examples/graphics/material-anisotropic.mjs
@@ -30,9 +30,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/graphics/material-basic.mjs
+++ b/examples/src/examples/graphics/material-basic.mjs
@@ -27,9 +27,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/graphics/material-clear-coat.mjs
+++ b/examples/src/examples/graphics/material-clear-coat.mjs
@@ -31,7 +31,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler
     ];
 

--- a/examples/src/examples/graphics/material-physical.mjs
+++ b/examples/src/examples/graphics/material-physical.mjs
@@ -27,9 +27,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/graphics/material-translucent-specular.mjs
+++ b/examples/src/examples/graphics/material-translucent-specular.mjs
@@ -28,9 +28,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/graphics/mesh-decals.mjs
+++ b/examples/src/examples/graphics/mesh-decals.mjs
@@ -25,7 +25,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler
     ];
 

--- a/examples/src/examples/graphics/mesh-deformation.mjs
+++ b/examples/src/examples/graphics/mesh-deformation.mjs
@@ -27,9 +27,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/mesh-generation.mjs
+++ b/examples/src/examples/graphics/mesh-generation.mjs
@@ -26,7 +26,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler
     ];
 

--- a/examples/src/examples/graphics/mesh-morph-many.mjs
+++ b/examples/src/examples/graphics/mesh-morph-many.mjs
@@ -30,9 +30,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/model-asset.mjs
+++ b/examples/src/examples/graphics/model-asset.mjs
@@ -26,9 +26,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/model-outline.mjs
+++ b/examples/src/examples/graphics/model-outline.mjs
@@ -27,7 +27,6 @@ async function example({ canvas, deviceType, scriptsPath, glslangPath, twgslPath
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/model-textured-box.mjs
+++ b/examples/src/examples/graphics/model-textured-box.mjs
@@ -26,7 +26,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler
     ];
 

--- a/examples/src/examples/graphics/multi-render-targets.mjs
+++ b/examples/src/examples/graphics/multi-render-targets.mjs
@@ -40,13 +40,9 @@ async function example({ canvas, deviceType, files, dracoPath, assetPath, glslan
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/graphics/multi-view.mjs
+++ b/examples/src/examples/graphics/multi-view.mjs
@@ -72,11 +72,8 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/paint-mesh.mjs
+++ b/examples/src/examples/graphics/paint-mesh.mjs
@@ -31,9 +31,7 @@ async function example({ canvas, files, deviceType, assetPath, glslangPath, twgs
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.CubemapHandler
     ];
 

--- a/examples/src/examples/graphics/painter.mjs
+++ b/examples/src/examples/graphics/painter.mjs
@@ -27,9 +27,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ParticleSystemComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/particles-spark.mjs
+++ b/examples/src/examples/graphics/particles-spark.mjs
@@ -26,7 +26,6 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ParticleSystemComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler
     ];
 

--- a/examples/src/examples/graphics/point-cloud.mjs
+++ b/examples/src/examples/graphics/point-cloud.mjs
@@ -22,9 +22,7 @@ async function example({ canvas, deviceType, glslangPath, twgslPath, files, asse
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
     ];
 

--- a/examples/src/examples/graphics/portal.mjs
+++ b/examples/src/examples/graphics/portal.mjs
@@ -30,11 +30,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/post-effects.mjs
+++ b/examples/src/examples/graphics/post-effects.mjs
@@ -192,13 +192,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/graphics/post-processing.mjs
+++ b/examples/src/examples/graphics/post-processing.mjs
@@ -244,13 +244,9 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/graphics/reflection-box.mjs
+++ b/examples/src/examples/graphics/reflection-box.mjs
@@ -88,11 +88,8 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/reflection-cubemap.mjs
+++ b/examples/src/examples/graphics/reflection-cubemap.mjs
@@ -28,9 +28,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/reflection-planar.mjs
+++ b/examples/src/examples/graphics/reflection-planar.mjs
@@ -29,11 +29,8 @@ async function example({ canvas, deviceType, files, scriptsPath, assetPath, glsl
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/render-asset.mjs
+++ b/examples/src/examples/graphics/render-asset.mjs
@@ -28,9 +28,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/render-pass.mjs
+++ b/examples/src/examples/graphics/render-pass.mjs
@@ -60,9 +60,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/render-to-texture.mjs
+++ b/examples/src/examples/graphics/render-to-texture.mjs
@@ -42,9 +42,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.ParticleSystemComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/shader-burn.mjs
+++ b/examples/src/examples/graphics/shader-burn.mjs
@@ -32,9 +32,7 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/shader-compile.mjs
+++ b/examples/src/examples/graphics/shader-compile.mjs
@@ -36,11 +36,8 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.JsonHandler
     ];
 

--- a/examples/src/examples/graphics/shader-toon.mjs
+++ b/examples/src/examples/graphics/shader-toon.mjs
@@ -31,9 +31,7 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/shader-wobble.mjs
+++ b/examples/src/examples/graphics/shader-wobble.mjs
@@ -31,9 +31,7 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/shadow-cascades.mjs
+++ b/examples/src/examples/graphics/shadow-cascades.mjs
@@ -102,11 +102,8 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/shapes.mjs
+++ b/examples/src/examples/graphics/shapes.mjs
@@ -23,9 +23,7 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/texture-array.mjs
+++ b/examples/src/examples/graphics/texture-array.mjs
@@ -102,11 +102,8 @@ async function example({ canvas, deviceType, data, files, assetPath, scriptsPath
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/graphics/texture-basis.mjs
+++ b/examples/src/examples/graphics/texture-basis.mjs
@@ -42,9 +42,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/graphics/transform-feedback.mjs
+++ b/examples/src/examples/graphics/transform-feedback.mjs
@@ -23,9 +23,7 @@ async function example({ canvas, deviceType, glslangPath, twgslPath, files, asse
         pc.LightComponentSystem,
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
     ];
 

--- a/examples/src/examples/graphics/video-texture.mjs
+++ b/examples/src/examples/graphics/video-texture.mjs
@@ -21,9 +21,7 @@ async function example({ canvas, deviceType, glslangPath, twgslPath, assetPath }
         pc.LightComponentSystem,
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
     ];
 

--- a/examples/src/examples/input/gamepad.mjs
+++ b/examples/src/examples/input/gamepad.mjs
@@ -28,9 +28,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/input/keyboard.mjs
+++ b/examples/src/examples/input/keyboard.mjs
@@ -26,9 +26,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/input/mouse.mjs
+++ b/examples/src/examples/input/mouse.mjs
@@ -25,9 +25,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.CameraComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/loaders/draco-glb.mjs
+++ b/examples/src/examples/loaders/draco-glb.mjs
@@ -28,9 +28,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/loaders/glb.mjs
+++ b/examples/src/examples/loaders/glb.mjs
@@ -29,9 +29,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/loaders/gltf-export.mjs
+++ b/examples/src/examples/loaders/gltf-export.mjs
@@ -52,9 +52,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/loaders/gsplat-many.mjs
+++ b/examples/src/examples/loaders/gsplat-many.mjs
@@ -47,13 +47,9 @@ async function example({ canvas, deviceType, data, assetPath, scriptsPath, glsla
         pc.GSplatComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.GSplatHandler
     ];
 

--- a/examples/src/examples/loaders/gsplat.mjs
+++ b/examples/src/examples/loaders/gsplat.mjs
@@ -29,13 +29,9 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.GSplatComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.GSplatHandler
     ];
 

--- a/examples/src/examples/loaders/loaders-gl.mjs
+++ b/examples/src/examples/loaders/loaders-gl.mjs
@@ -34,9 +34,7 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/loaders/obj.mjs
+++ b/examples/src/examples/loaders/obj.mjs
@@ -23,13 +23,9 @@ async function example({ canvas, deviceType, glslangPath, twgslPath, assetPath, 
         pc.ModelComponentSystem,
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.ModelHandler,
     ];
 

--- a/examples/src/examples/loaders/usdz-export.mjs
+++ b/examples/src/examples/loaders/usdz-export.mjs
@@ -39,9 +39,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath, 
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/misc/gizmos.mjs
+++ b/examples/src/examples/misc/gizmos.mjs
@@ -410,11 +410,8 @@ async function example({ pcx, canvas, deviceType, data, glslangPath, twgslPath, 
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/examples/src/examples/misc/hello-world.mjs
+++ b/examples/src/examples/misc/hello-world.mjs
@@ -22,9 +22,7 @@ async function example({ canvas, deviceType, glslangPath, twgslPath }) {
         pc.LightComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler
     ];
 

--- a/examples/src/examples/misc/spineboy.mjs
+++ b/examples/src/examples/misc/spineboy.mjs
@@ -28,13 +28,9 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.JsonHandler,
-        // @ts-ignore
         pc.TextHandler
     ];
 

--- a/examples/src/examples/physics/compound-collision.mjs
+++ b/examples/src/examples/physics/compound-collision.mjs
@@ -34,15 +34,10 @@ async function example({ canvas, deviceType, ammoPath, glslangPath, twgslPath })
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.JsonHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/physics/falling-shapes.mjs
+++ b/examples/src/examples/physics/falling-shapes.mjs
@@ -38,15 +38,10 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.JsonHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/physics/offset-collision.mjs
+++ b/examples/src/examples/physics/offset-collision.mjs
@@ -40,15 +40,10 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
         pc.AnimComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.AnimClipHandler,
-        // @ts-ignore
         pc.AnimStateGraphHandler
     ];
 

--- a/examples/src/examples/physics/raycast.mjs
+++ b/examples/src/examples/physics/raycast.mjs
@@ -38,15 +38,10 @@ async function example({ canvas, deviceType, assetPath, ammoPath, glslangPath, t
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.JsonHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/physics/vehicle.mjs
+++ b/examples/src/examples/physics/vehicle.mjs
@@ -41,13 +41,9 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, ammoPath, g
         pc.RigidBodyComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.ScriptHandler,
-        // @ts-ignore
         pc.JsonHandler
     ];
 

--- a/examples/src/examples/sound/positional.mjs
+++ b/examples/src/examples/sound/positional.mjs
@@ -27,19 +27,12 @@ async function example({ canvas, deviceType, glslangPath, twgslPath, assetPath }
         pc.AudioListenerComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.ContainerHandler,
-        // @ts-ignore
         pc.AudioHandler,
-        // @ts-ignore
         pc.JsonHandler,
-        // @ts-ignore
         pc.AnimationHandler,
-        // @ts-ignore
         pc.ModelHandler,
-        // @ts-ignore
         pc.MaterialHandler
     ];
 

--- a/examples/src/examples/user-interface/button-basic.mjs
+++ b/examples/src/examples/user-interface/button-basic.mjs
@@ -31,9 +31,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/button-sprite.mjs
+++ b/examples/src/examples/user-interface/button-sprite.mjs
@@ -33,9 +33,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/custom-shader.mjs
+++ b/examples/src/examples/user-interface/custom-shader.mjs
@@ -34,9 +34,7 @@ async function example({ canvas, deviceType, files, assetPath, glslangPath, twgs
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/layout-group.mjs
+++ b/examples/src/examples/user-interface/layout-group.mjs
@@ -33,9 +33,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LayoutChildComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/particle-system.mjs
+++ b/examples/src/examples/user-interface/particle-system.mjs
@@ -33,9 +33,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ParticleSystemComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/scroll-view.mjs
+++ b/examples/src/examples/user-interface/scroll-view.mjs
@@ -34,9 +34,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ScrollbarComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/text-auto-font-size.mjs
+++ b/examples/src/examples/user-interface/text-auto-font-size.mjs
@@ -35,9 +35,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ScrollbarComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/text-emojis.mjs
+++ b/examples/src/examples/user-interface/text-emojis.mjs
@@ -35,9 +35,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.LayoutChildComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/text-localization.mjs
+++ b/examples/src/examples/user-interface/text-localization.mjs
@@ -31,9 +31,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/text-typewriter.mjs
+++ b/examples/src/examples/user-interface/text-typewriter.mjs
@@ -32,9 +32,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/text.mjs
+++ b/examples/src/examples/user-interface/text.mjs
@@ -33,9 +33,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ScrollbarComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/world-to-screen.mjs
+++ b/examples/src/examples/user-interface/world-to-screen.mjs
@@ -33,9 +33,7 @@ async function example({ canvas, deviceType, assetPath, glslangPath, twgslPath }
         pc.ElementComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler
     ];
 

--- a/examples/src/examples/user-interface/world-ui.mjs
+++ b/examples/src/examples/user-interface/world-ui.mjs
@@ -35,11 +35,8 @@ async function example({ canvas, deviceType, assetPath, scriptsPath, glslangPath
         pc.ScriptComponentSystem
     ];
     createOptions.resourceHandlers = [
-        // @ts-ignore
         pc.TextureHandler,
-        // @ts-ignore
         pc.FontHandler,
-        // @ts-ignore
         pc.ScriptHandler
     ];
 

--- a/src/framework/app-options.js
+++ b/src/framework/app-options.js
@@ -100,7 +100,7 @@ class AppOptions {
     /**
      * The resource handlers the app requires.
      *
-     * @type {import('./handlers/handler.js').ResourceHandler[]}
+     * @type {typeof import('./handlers/handler.js').ResourceHandler[]}
      */
     resourceHandlers = [];
 }

--- a/src/framework/handlers/anim-clip.js
+++ b/src/framework/handlers/anim-clip.js
@@ -4,15 +4,15 @@ import { AnimCurve } from '../anim/evaluator/anim-curve.js';
 import { AnimData } from '../anim/evaluator/anim-data.js';
 import { AnimTrack } from '../anim/evaluator/anim-track.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 /**
  * Resource handler used for loading {@link AnimClip} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @ignore
  */
-class AnimClipHandler {
+class AnimClipHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -21,6 +21,7 @@ class AnimClipHandler {
     handlerType = "animclip";
 
     constructor(app) {
+        super(app);
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/anim-state-graph.js
+++ b/src/framework/handlers/anim-state-graph.js
@@ -1,15 +1,15 @@
 import { http, Http } from '../../platform/net/http.js';
 import { AnimStateGraph } from '../anim/state-graph/anim-state-graph.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 /**
  * Resource handler used for loading {@link AnimStateGraph} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @ignore
  */
-class AnimStateGraphHandler {
+class AnimStateGraphHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -18,6 +18,7 @@ class AnimStateGraphHandler {
     handlerType = "animstategraph";
 
     constructor(app) {
+        super(app);
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/animation.js
+++ b/src/framework/handlers/animation.js
@@ -10,15 +10,15 @@ import { AnimEvents } from '../anim/evaluator/anim-events.js';
 
 import { GlbParser } from '../parsers/glb-parser.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 /**
  * Resource handler used for loading {@link Animation} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Animation
  */
-class AnimationHandler {
+class AnimationHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -28,6 +28,7 @@ class AnimationHandler {
 
     /** @hideconstructor */
     constructor(app) {
+        super(app);
         this.device = app.graphicsDevice;
         this.assets = app.assets;
         this.maxRetries = 0;

--- a/src/framework/handlers/animation.js
+++ b/src/framework/handlers/animation.js
@@ -26,7 +26,10 @@ class AnimationHandler extends ResourceHandler {
      */
     handlerType = "animation";
 
-    /** @hideconstructor */
+    /**
+     * @param {import('../app-base.js').AppBase} app - The running {@link AppBase}.
+     * @hideconstructor
+     */
     constructor(app) {
         super(app);
         this.device = app.graphicsDevice;

--- a/src/framework/handlers/audio.js
+++ b/src/framework/handlers/audio.js
@@ -7,7 +7,7 @@ import { hasAudioContext } from '../../platform/audio/capabilities.js';
 
 import { Sound } from '../../platform/sound/sound.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 // checks if user is running IE
 const ie = (function () {
@@ -47,10 +47,10 @@ const supportedExtensions = [
 /**
  * Resource handler used for loading {@link Sound} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Sound
  */
-class AudioHandler {
+class AudioHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -65,6 +65,7 @@ class AudioHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this.manager = app.soundManager;
         Debug.assert(this.manager, "AudioSourceComponentSystem cannot be created without sound manager");
 

--- a/src/framework/handlers/binary.js
+++ b/src/framework/handlers/binary.js
@@ -1,6 +1,11 @@
 import { http, Http } from '../../platform/net/http.js';
 
-class BinaryHandler {
+import { ResourceHandler } from './handler.js';
+
+/**
+ * @augments ResourceHandler
+ */
+class BinaryHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -9,6 +14,7 @@ class BinaryHandler {
     handlerType = "binary";
 
     constructor(app) {
+        super(app);
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/bundle.js
+++ b/src/framework/handlers/bundle.js
@@ -5,15 +5,15 @@ import { http, Http } from '../../platform/net/http.js';
 import { Bundle } from '../bundle/bundle.js';
 import { Untar, UntarWorker } from './untar.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 /**
  * Loads Bundle Assets.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @ignore
  */
-class BundleHandler {
+class BundleHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -28,6 +28,7 @@ class BundleHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this._assets = app.assets;
         this._worker = null;
         this.maxRetries = 0;

--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -2,7 +2,7 @@ import { path } from '../../core/path.js';
 
 import { GlbContainerParser } from '../parsers/glb-container-parser.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 /**
  * @interface
@@ -160,10 +160,10 @@ class ContainerResource {
  * });
  * ```
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Graphics
  */
-class ContainerHandler {
+class ContainerHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -178,6 +178,7 @@ class ContainerHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this.glbContainerParser = new GlbContainerParser(app.graphicsDevice, app.assets, 0);
         this.parsers = { };
     }

--- a/src/framework/handlers/css.js
+++ b/src/framework/handlers/css.js
@@ -1,6 +1,11 @@
 import { http } from '../../platform/net/http.js';
 
-class CssHandler {
+import { ResourceHandler } from './handler.js';
+
+/**
+ * @augments ResourceHandler
+ */
+class CssHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -9,6 +14,7 @@ class CssHandler {
     handlerType = "css";
 
     constructor(app) {
+        super(app);
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/cubemap.js
+++ b/src/framework/handlers/cubemap.js
@@ -6,15 +6,15 @@ import { Texture } from '../../platform/graphics/texture.js';
 
 import { Asset } from '../asset/asset.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 /**
  * Resource handler used for loading cubemap {@link Texture} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Graphics
  */
-class CubemapHandler {
+class CubemapHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -29,6 +29,7 @@ class CubemapHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this._device = app.graphicsDevice;
         this._registry = app.assets;
         this._loader = app.loader;

--- a/src/framework/handlers/folder.js
+++ b/src/framework/handlers/folder.js
@@ -1,4 +1,9 @@
-class FolderHandler {
+import { ResourceHandler } from "./handler.js";
+
+/**
+ * @augments ResourceHandler
+ */
+class FolderHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *

--- a/src/framework/handlers/font.js
+++ b/src/framework/handlers/font.js
@@ -5,7 +5,7 @@ import { http } from '../../platform/net/http.js';
 
 import { Font } from '../font/font.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 function upgradeDataSchema(data) {
     // convert v1 and v2 to v3 font data schema
@@ -34,10 +34,10 @@ function upgradeDataSchema(data) {
 /**
  * Resource handler used for loading {@link Font} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category User Interface
  */
-class FontHandler {
+class FontHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -52,6 +52,7 @@ class FontHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this._loader = app.loader;
         this.maxRetries = 0;
     }

--- a/src/framework/handlers/gsplat.js
+++ b/src/framework/handlers/gsplat.js
@@ -1,6 +1,11 @@
 import { PlyParser } from '../parsers/ply.js';
 
-class GSplatHandler {
+import { ResourceHandler } from './handler.js';
+
+/**
+ * @augments ResourceHandler
+ */
+class GSplatHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -15,6 +20,7 @@ class GSplatHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this.parser = new PlyParser(app.graphicsDevice, app.assets, 3);
     }
 

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -38,7 +38,6 @@ class ResourceHandler {
         throw new Error('not implemented');
     }
 
-    /* eslint-disable jsdoc/require-returns-check */
     /**
      * @function
      * @name ResourceHandler#open
@@ -53,7 +52,6 @@ class ResourceHandler {
     open(url, data, asset) {
         throw new Error('not implemented');
     }
-    /* eslint-enable jsdoc/require-returns-check */
 
     /**
      * @function

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -7,11 +7,18 @@
  */
 
 /**
- * @interface
- * @name ResourceHandler
- * @description Interface for ResourceHandlers used by {@link ResourceLoader}.
+ * @description Base class for ResourceHandlers used by {@link ResourceLoader}.
  */
 class ResourceHandler {
+    /**
+     * Create a new ResourceHandler instance.
+     *
+     * @param {import('../app-base.js').AppBase} app - The running {@link AppBase}.
+     */
+    constructor(app) {
+        // no implementation
+    }
+
     /**
      * @function
      * @name ResourceHandler#load

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -16,7 +16,7 @@ class ResourceHandler {
      * @param {import('../app-base.js').AppBase} app - The running {@link AppBase}.
      */
     constructor(app) {
-        // no implementation
+        this._app = app;
     }
 
     /**

--- a/src/framework/handlers/hierarchy.js
+++ b/src/framework/handlers/hierarchy.js
@@ -1,7 +1,12 @@
 import { SceneParser } from '../parsers/scene.js';
 import { SceneUtils } from './scene-utils.js';
 
-class HierarchyHandler {
+import { ResourceHandler } from './handler.js';
+
+/**
+ * @augments ResourceHandler
+ */
+class HierarchyHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -10,6 +15,7 @@ class HierarchyHandler {
     handlerType = "hierarchy";
 
     constructor(app) {
+        super(app);
         this._app = app;
         this.maxRetries = 0;
     }

--- a/src/framework/handlers/hierarchy.js
+++ b/src/framework/handlers/hierarchy.js
@@ -16,7 +16,6 @@ class HierarchyHandler extends ResourceHandler {
 
     constructor(app) {
         super(app);
-        this._app = app;
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/html.js
+++ b/src/framework/handlers/html.js
@@ -1,6 +1,11 @@
 import { http } from '../../platform/net/http.js';
 
-class HtmlHandler {
+import { ResourceHandler } from './handler.js';
+
+/**
+ * @augments ResourceHandler
+ */
+class HtmlHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -9,6 +14,7 @@ class HtmlHandler {
     handlerType = "html";
 
     constructor(app) {
+        super(app);
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/json.js
+++ b/src/framework/handlers/json.js
@@ -1,6 +1,11 @@
 import { http, Http } from '../../platform/net/http.js';
 
-class JsonHandler {
+import { ResourceHandler } from './handler.js';
+
+/**
+ * @augments ResourceHandler
+ */
+class JsonHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -9,6 +14,7 @@ class JsonHandler {
     handlerType = "json";
 
     constructor(app) {
+        super(app);
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/material.js
+++ b/src/framework/handlers/material.js
@@ -9,7 +9,7 @@ import { standardMaterialCubemapParameters, standardMaterialTextureParameters } 
 import { AssetReference } from '../asset/asset-reference.js';
 import { JsonStandardMaterialParser } from '../parsers/material/json-standard-material.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 const PLACEHOLDER_MAP = {
     aoMap: 'white',
@@ -35,10 +35,10 @@ const PLACEHOLDER_MAP = {
 /**
  * Resource handler used for loading {@link Material} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Graphics
  */
-class MaterialHandler {
+class MaterialHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -53,6 +53,7 @@ class MaterialHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this._assets = app.assets;
         this._device = app.graphicsDevice;
 

--- a/src/framework/handlers/model.js
+++ b/src/framework/handlers/model.js
@@ -7,7 +7,7 @@ import { getDefaultMaterial } from '../../scene/materials/default-material.js';
 import { GlbModelParser } from '../parsers/glb-model.js';
 import { JsonModelParser } from '../parsers/json-model.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 /**
  * Callback used by {@link ModelHandler#addParser} to decide on which parser to use.
@@ -22,10 +22,10 @@ import { JsonModelParser } from '../parsers/json-model.js';
 /**
  * Resource handler used for loading {@link Model} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Graphics
  */
-class ModelHandler {
+class ModelHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -40,6 +40,7 @@ class ModelHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this._parsers = [];
         this.device = app.graphicsDevice;
         this.assets = app.assets;

--- a/src/framework/handlers/render.js
+++ b/src/framework/handlers/render.js
@@ -1,6 +1,6 @@
 import { Render } from '../../scene/render.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 // The scope of this function is the render asset
 function onContainerAssetLoaded(containerAsset) {
@@ -44,10 +44,10 @@ function onContainerAssetRemoved(containerAsset) {
 /**
  * Resource handler used for loading {@link Render} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Graphics
  */
-class RenderHandler {
+class RenderHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -62,6 +62,7 @@ class RenderHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this._registry = app.assets;
     }
 

--- a/src/framework/handlers/scene-settings.js
+++ b/src/framework/handlers/scene-settings.js
@@ -8,7 +8,6 @@ import { ResourceHandler } from './handler.js';
 class SceneSettingsHandler extends ResourceHandler {
     constructor(app) {
         super(app);
-        this._app = app;
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/scene-settings.js
+++ b/src/framework/handlers/scene-settings.js
@@ -1,7 +1,13 @@
 import { SceneUtils } from './scene-utils.js';
 
-class SceneSettingsHandler {
+import { ResourceHandler } from './handler.js';
+
+/**
+ * @augments ResourceHandler
+ */
+class SceneSettingsHandler extends ResourceHandler {
     constructor(app) {
+        super(app);
         this._app = app;
         this.maxRetries = 0;
     }

--- a/src/framework/handlers/scene.js
+++ b/src/framework/handlers/scene.js
@@ -1,15 +1,15 @@
 import { SceneUtils } from './scene-utils.js';
 import { SceneParser } from '../parsers/scene.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 /**
  * Resource handler used for loading {@link Scene} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Graphics
  */
-class SceneHandler {
+class SceneHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -24,6 +24,7 @@ class SceneHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this._app = app;
         this.maxRetries = 0;
     }

--- a/src/framework/handlers/scene.js
+++ b/src/framework/handlers/scene.js
@@ -25,7 +25,6 @@ class SceneHandler extends ResourceHandler {
      */
     constructor(app) {
         super(app);
-        this._app = app;
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -5,17 +5,17 @@ import { ScriptTypes } from '../script/script-types.js';
 import { registerScript } from '../script/script.js';
 import { ResourceLoader } from './loader.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 /**
  * Resource handler for loading JavaScript files dynamically.  Two types of JavaScript files can be
  * loaded, PlayCanvas scripts which contain calls to {@link createScript}, or regular JavaScript
  * files, such as third-party libraries.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Script
  */
-class ScriptHandler {
+class ScriptHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -30,6 +30,7 @@ class ScriptHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this._app = app;
         this._scripts = { };
         this._cache = { };

--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -31,7 +31,6 @@ class ScriptHandler extends ResourceHandler {
      */
     constructor(app) {
         super(app);
-        this._app = app;
         this._scripts = { };
         this._cache = { };
     }

--- a/src/framework/handlers/shader.js
+++ b/src/framework/handlers/shader.js
@@ -1,6 +1,11 @@
 import { http } from '../../platform/net/http.js';
 
-class ShaderHandler {
+import { ResourceHandler } from './handler.js';
+
+/**
+ * @augments ResourceHandler
+ */
+class ShaderHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -9,6 +14,7 @@ class ShaderHandler {
     handlerType = "shader";
 
     constructor(app) {
+        super(app);
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/sprite.js
+++ b/src/framework/handlers/sprite.js
@@ -4,7 +4,7 @@ import { http } from '../../platform/net/http.js';
 
 import { Sprite } from '../../scene/sprite.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 // The scope of this function is the sprite asset
 function onTextureAtlasLoaded(atlasAsset) {
@@ -23,10 +23,10 @@ function onTextureAtlasAdded(atlasAsset) {
 /**
  * Resource handler used for loading {@link Sprite} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Graphics
  */
-class SpriteHandler {
+class SpriteHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -41,6 +41,7 @@ class SpriteHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this._assets = app.assets;
         this._device = app.graphicsDevice;
         this.maxRetries = 0;

--- a/src/framework/handlers/template.js
+++ b/src/framework/handlers/template.js
@@ -17,7 +17,6 @@ class TemplateHandler extends ResourceHandler {
 
     constructor(app) {
         super(app);
-        this._app = app;
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/template.js
+++ b/src/framework/handlers/template.js
@@ -2,7 +2,12 @@ import { http } from '../../platform/net/http.js';
 
 import { Template } from '../template.js';
 
-class TemplateHandler {
+import { ResourceHandler } from './handler.js';
+
+/**
+ * @augments ResourceHandler
+ */
+class TemplateHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -11,6 +16,7 @@ class TemplateHandler {
     handlerType = "template";
 
     constructor(app) {
+        super(app);
         this._app = app;
         this.maxRetries = 0;
     }

--- a/src/framework/handlers/text.js
+++ b/src/framework/handlers/text.js
@@ -1,6 +1,11 @@
 import { http } from '../../platform/net/http.js';
 
-class TextHandler {
+import { ResourceHandler } from './handler.js';
+
+/**
+ * @augments ResourceHandler
+ */
+class TextHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -9,6 +14,7 @@ class TextHandler {
     handlerType = "text";
 
     constructor(app) {
+        super(app);
         this.maxRetries = 0;
     }
 

--- a/src/framework/handlers/texture-atlas.js
+++ b/src/framework/handlers/texture-atlas.js
@@ -11,7 +11,7 @@ import { http } from '../../platform/net/http.js';
 
 import { TextureAtlas } from '../../scene/texture-atlas.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 const JSON_ADDRESS_MODE = {
     'repeat': ADDRESS_REPEAT,
@@ -33,10 +33,10 @@ const regexFrame = /^data\.frames\.(\d+)$/;
 /**
  * Resource handler used for loading {@link TextureAtlas} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Graphics
  */
-class TextureAtlasHandler {
+class TextureAtlasHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -51,6 +51,7 @@ class TextureAtlasHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         this._loader = app.loader;
         this.maxRetries = 0;
     }

--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -17,7 +17,7 @@ import { Ktx2Parser } from '../parsers/texture/ktx2.js';
 import { DdsParser } from '../parsers/texture/dds.js';
 import { HdrParser } from '../parsers/texture/hdr.js';
 
-/** @typedef {import('./handler.js').ResourceHandler} ResourceHandler */
+import { ResourceHandler } from './handler.js';
 
 const JSON_ADDRESS_MODE = {
     'repeat': ADDRESS_REPEAT,
@@ -159,10 +159,10 @@ const _completePartialMipmapChain = function (texture) {
 /**
  * Resource handler used for loading 2D and 3D {@link Texture} resources.
  *
- * @implements {ResourceHandler}
+ * @augments ResourceHandler
  * @category Graphics
  */
-class TextureHandler {
+class TextureHandler extends ResourceHandler {
     /**
      * Type of the resource the handler handles.
      *
@@ -177,6 +177,7 @@ class TextureHandler {
      * @hideconstructor
      */
     constructor(app) {
+        super(app);
         const assets = app.assets;
         const device = app.graphicsDevice;
 

--- a/utils/types-fixup.mjs
+++ b/utils/types-fixup.mjs
@@ -559,6 +559,5 @@ fs.writeFileSync(path, dts);
 
 path = './types/framework/handlers/handler.d.ts';
 dts = fs.readFileSync(path, 'utf8');
-dts = dts.replace('export class ResourceHandler', 'export interface ResourceHandler');
 dts = dts.replace('patch(', 'patch?(');
 fs.writeFileSync(path, dts);

--- a/utils/types-fixup.mjs
+++ b/utils/types-fixup.mjs
@@ -556,8 +556,3 @@ dts = dts.replace('get enabled(): boolean;', `get enabled(): boolean;
     swap?(old: ScriptType): void;
 `);
 fs.writeFileSync(path, dts);
-
-path = './types/framework/handlers/handler.d.ts';
-dts = fs.readFileSync(path, 'utf8');
-dts = dts.replace('patch(', 'patch?(');
-fs.writeFileSync(path, dts);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/pull/5986

This PR converts the ResourceHandler interface into a class and all implementations into child classes. This removes the need to add `@ts-ignore` to each Handler used in app options in examples

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
