### PR TITLE
Update post effect queue type mismatch

### DIFF
--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -136,7 +136,7 @@ class PostEffectQueue {
      * Adds a post effect to the queue. If the queue is disabled adding a post effect will
      * automatically enable the queue.
      *
-     * @param {PostEffect} effect - The post effect to add to the queue.
+     * @param {PostEffectEntry} effect - The post effect to add to the queue.
      */
     addEffect(effect) {
         // first rendering of the scene requires depth buffer

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -5,7 +5,7 @@ import { Texture } from '../../../platform/graphics/texture.js';
 
 import { LAYERID_DEPTH } from '../../../scene/constants.js';
 
-class PostEffect {
+class PostEffectEntry {
     constructor(effect, inputTarget) {
         this.effect = effect;
         this.inputTarget = inputTarget;
@@ -144,7 +144,7 @@ class PostEffectQueue {
         const isFirstEffect = effects.length === 0;
 
         const inputTarget = this._createOffscreenTarget(isFirstEffect, effect.hdr);
-        const newEntry = new PostEffect(effect, inputTarget);
+        const newEntry = new PostEffectEntry(effect, inputTarget);
         effects.push(newEntry);
 
         this._sourceTarget = newEntry.inputTarget;


### PR DESCRIPTION
currently, first argument of addEffect() function is typed as PostEffect which is wrong because it refers to PostEffect class that is declared on the same file, it should have been pointing to pc.PostEffect. but pc. prefix removed from docs so renamed it to PostEffectEntry, as it is assigned to variable named "newEntry".

Fixes #
renamed PostEffect class declared in post-effect-queue.js to PostEffectEntry. it is not exported so there is no need for renaming in other files.