### PR TITLE
Add Asset category for API reference

### DIFF
--- a/src/framework/asset/asset-list-loader.js
+++ b/src/framework/asset/asset-list-loader.js
@@ -21,6 +21,7 @@ import { Asset } from './asset.js';
  * ```
  *
  * @augments EventHandler
+ * @category Asset
  */
 class AssetListLoader extends EventHandler {
     /**

--- a/src/framework/asset/asset-reference.js
+++ b/src/framework/asset/asset-reference.js
@@ -2,6 +2,8 @@
  * An object that manages the case where an object holds a reference to an asset and needs to be
  * notified when changes occur in the asset. e.g. notifications include load, add and remove
  * events.
+ *
+ * @category Asset
  */
 class AssetReference {
     /**

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -31,6 +31,7 @@ import { Asset } from './asset.js';
  * are provided with an AssetRegistry instance as `app.assets`.
  *
  * @augments EventHandler
+ * @category Asset
  */
 class AssetRegistry extends EventHandler {
     /**

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -45,6 +45,7 @@ const VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
  * See the {@link AssetRegistry} for details on loading resources from assets.
  *
  * @augments EventHandler
+ * @category Asset
  */
 class Asset extends EventHandler {
     /**

--- a/src/framework/asset/constants.js
+++ b/src/framework/asset/constants.js
@@ -24,6 +24,7 @@ export const ABSOLUTE_URL = new RegExp(
  * Asset type name for animation.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_ANIMATION = 'animation';
 
@@ -31,6 +32,7 @@ export const ASSET_ANIMATION = 'animation';
  * Asset type name for audio.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_AUDIO = 'audio';
 
@@ -38,6 +40,7 @@ export const ASSET_AUDIO = 'audio';
  * Asset type name for image.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_IMAGE = 'image';
 
@@ -45,6 +48,7 @@ export const ASSET_IMAGE = 'image';
  * Asset type name for json.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_JSON = 'json';
 
@@ -52,6 +56,7 @@ export const ASSET_JSON = 'json';
  * Asset type name for model.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_MODEL = 'model';
 
@@ -59,6 +64,7 @@ export const ASSET_MODEL = 'model';
  * Asset type name for material.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_MATERIAL = 'material';
 
@@ -66,6 +72,7 @@ export const ASSET_MATERIAL = 'material';
  * Asset type name for text.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_TEXT = 'text';
 
@@ -73,6 +80,7 @@ export const ASSET_TEXT = 'text';
  * Asset type name for texture.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_TEXTURE = 'texture';
 
@@ -80,6 +88,7 @@ export const ASSET_TEXTURE = 'texture';
  * Asset type name for textureatlas.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_TEXTUREATLAS = 'textureatlas';
 
@@ -87,6 +96,7 @@ export const ASSET_TEXTUREATLAS = 'textureatlas';
  * Asset type name for cubemap.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_CUBEMAP = 'cubemap';
 
@@ -94,6 +104,7 @@ export const ASSET_CUBEMAP = 'cubemap';
  * Asset type name for shader.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_SHADER = 'shader';
 
@@ -101,6 +112,7 @@ export const ASSET_SHADER = 'shader';
  * Asset type name for CSS.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_CSS = 'css';
 
@@ -108,6 +120,7 @@ export const ASSET_CSS = 'css';
  * Asset type name for HTML.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_HTML = 'html';
 
@@ -115,6 +128,7 @@ export const ASSET_HTML = 'html';
  * Asset type name for script.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_SCRIPT = 'script';
 
@@ -122,5 +136,6 @@ export const ASSET_SCRIPT = 'script';
  * Asset type name for a container.
  *
  * @type {string}
+ * @category Asset
  */
 export const ASSET_CONTAINER = 'container';


### PR DESCRIPTION
Separates out the `Asset` API:

![image](https://github.com/playcanvas/engine/assets/697563/86635291-531d-4d7d-91b9-faf69d645e40)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
