### PR TITLE
ResourceHandler type fix (constructor parameters)

### DIFF
--- a/src/framework/handlers/anim-clip.js
+++ b/src/framework/handlers/anim-clip.js
@@ -12,8 +12,9 @@ import { ResourceHandler } from './handler.js';
  * @ignore
  */
 class AnimClipHandler extends ResourceHandler {
-    constructor() {
-        super('animclip');
+    constructor(app) {
+        super(app);
+        this.handlerType = 'animclip';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/anim-state-graph.js
+++ b/src/framework/handlers/anim-state-graph.js
@@ -9,8 +9,9 @@ import { ResourceHandler } from './handler.js';
  * @ignore
  */
 class AnimStateGraphHandler extends ResourceHandler {
-    constructor() {
-        super('animstategraph');
+    constructor(app) {
+        super(app);
+        this.handlerType = 'animstategraph';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/animation.js
+++ b/src/framework/handlers/animation.js
@@ -23,7 +23,8 @@ class AnimationHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('animation');
+        super(app);
+        this.handlerType = 'animation';
 
         this.device = app.graphicsDevice;
         this.assets = app.assets;

--- a/src/framework/handlers/audio.js
+++ b/src/framework/handlers/audio.js
@@ -57,7 +57,8 @@ class AudioHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('audio');
+        super(app);
+        this.handlerType = 'audio';
 
         this.manager = app.soundManager;
         Debug.assert(this.manager, "AudioSourceComponentSystem cannot be created without sound manager");

--- a/src/framework/handlers/binary.js
+++ b/src/framework/handlers/binary.js
@@ -3,8 +3,9 @@ import { http, Http } from '../../platform/net/http.js';
 import { ResourceHandler } from './handler.js';
 
 class BinaryHandler extends ResourceHandler {
-    constructor() {
-        super('binary');
+    constructor(app) {
+        super(app);
+        this.handlerType = 'binary';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/bundle.js
+++ b/src/framework/handlers/bundle.js
@@ -19,7 +19,8 @@ class BundleHandler extends ResourceHandler {
      * @param {import('../app-base.js').AppBase} app - The running {@link AppBase}.
      */
     constructor(app) {
-        super('bundle');
+        super(app);
+        this.handlerType = 'bundle';
 
         this._assets = app.assets;
         this._worker = null;

--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -170,7 +170,8 @@ class ContainerHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('container');
+        super(app);
+        this.handlerType = 'container';
 
         this.glbContainerParser = new GlbContainerParser(app.graphicsDevice, app.assets, 0);
         this.parsers = { };

--- a/src/framework/handlers/css.js
+++ b/src/framework/handlers/css.js
@@ -3,8 +3,9 @@ import { http } from '../../platform/net/http.js';
 import { ResourceHandler } from './handler.js';
 
 class CssHandler extends ResourceHandler {
-    constructor() {
-        super('css');
+    constructor(app) {
+        super(app);
+        this.handlerType = 'css';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/cubemap.js
+++ b/src/framework/handlers/cubemap.js
@@ -21,7 +21,8 @@ class CubemapHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('cubemap');
+        super(app);
+        this.handlerType = 'cubemap';
 
         this._device = app.graphicsDevice;
         this._registry = app.assets;

--- a/src/framework/handlers/folder.js
+++ b/src/framework/handlers/folder.js
@@ -1,8 +1,9 @@
 import { ResourceHandler } from './handler.js';
 
 class FolderHandler extends ResourceHandler {
-    constructor() {
-        super('folder');
+    constructor(app) {
+        super(app);
+        this.handlerType = 'folder';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/font.js
+++ b/src/framework/handlers/font.js
@@ -44,7 +44,8 @@ class FontHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('font');
+        super(app);
+        this.handlerType = 'font';
 
         this._loader = app.loader;
         this.maxRetries = 0;

--- a/src/framework/handlers/gsplat.js
+++ b/src/framework/handlers/gsplat.js
@@ -10,7 +10,8 @@ class GSplatHandler extends ResourceHandler {
      * @hideconstructor
      */
     constructor(app) {
-        super('gsplat');
+        super(app);
+        this.handlerType = 'gsplat';
         this.parser = new PlyParser(app.graphicsDevice, app.assets, 3);
     }
 

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -15,16 +15,23 @@ class ResourceHandler {
      *
      * @type {string}
      */
-    handlerType;
+    handlerType = '';
+
+    /**
+     * The running app instance.
+     *
+     * @type {import('../app-base').AppBase}
+     */
+    _app;
 
     /** @private */
     _maxRetries = 0;
 
     /**
-     * @param {string} type - The type of resource the handler will load.
+     * @param {import('../app-base').AppBase} app - The running {@link AppBase}.
      */
-    constructor(type) {
-        this.handlerType = type;
+    constructor(app) {
+        this._app = app;
     }
 
     /**

--- a/src/framework/handlers/hierarchy.js
+++ b/src/framework/handlers/hierarchy.js
@@ -4,10 +4,12 @@ import { SceneUtils } from './scene-utils.js';
 import { ResourceHandler } from './handler.js';
 
 class HierarchyHandler extends ResourceHandler {
+    /**
+     * @param {import('../app-base').AppBase} app - The running {@link AppBase}.
+     */
     constructor(app) {
-        super('hierarchy');
-
-        this._app = app;
+        super(app);
+        this.handlerType = 'hierarchy';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/html.js
+++ b/src/framework/handlers/html.js
@@ -3,8 +3,9 @@ import { http } from '../../platform/net/http.js';
 import { ResourceHandler } from './handler.js';
 
 class HtmlHandler extends ResourceHandler {
-    constructor() {
-        super('html');
+    constructor(app) {
+        super(app);
+        this.handlerType = 'html';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/json.js
+++ b/src/framework/handlers/json.js
@@ -3,8 +3,9 @@ import { http, Http } from '../../platform/net/http.js';
 import { ResourceHandler } from './handler.js';
 
 class JsonHandler extends ResourceHandler {
-    constructor() {
-        super('json');
+    constructor(app) {
+        super(app);
+        this.handlerType = 'json';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/material.js
+++ b/src/framework/handlers/material.js
@@ -45,7 +45,8 @@ class MaterialHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('material');
+        super(app);
+        this.handlerType = 'material';
 
         this._assets = app.assets;
         this._device = app.graphicsDevice;

--- a/src/framework/handlers/model.js
+++ b/src/framework/handlers/model.js
@@ -32,7 +32,8 @@ class ModelHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('model');
+        super(app);
+        this.handlerType = 'model';
 
         this._parsers = [];
         this.device = app.graphicsDevice;

--- a/src/framework/handlers/render.js
+++ b/src/framework/handlers/render.js
@@ -54,7 +54,8 @@ class RenderHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('render');
+        super(app);
+        this.handlerType = 'render';
 
         this._registry = app.assets;
     }

--- a/src/framework/handlers/scene-settings.js
+++ b/src/framework/handlers/scene-settings.js
@@ -4,9 +4,8 @@ import { ResourceHandler } from './handler.js';
 
 class SceneSettingsHandler extends ResourceHandler {
     constructor(app) {
-        super('scenesettings');
-
-        this._app = app;
+        super(app);
+        this.handlerType = 'scenesettings';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/scene.js
+++ b/src/framework/handlers/scene.js
@@ -16,9 +16,8 @@ class SceneHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('scene');
-
-        this._app = app;
+        super(app);
+        this.handlerType = 'scene';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -22,9 +22,9 @@ class ScriptHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('script');
+        super(app);
+        this.handlerType = 'script';
 
-        this._app = app;
         this._scripts = { };
         this._cache = { };
     }

--- a/src/framework/handlers/shader.js
+++ b/src/framework/handlers/shader.js
@@ -3,8 +3,9 @@ import { http } from '../../platform/net/http.js';
 import { ResourceHandler } from './handler.js';
 
 class ShaderHandler extends ResourceHandler {
-    constructor() {
-        super('shader');
+    constructor(app) {
+        super(app);
+        this.handlerType = 'shader';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/sprite.js
+++ b/src/framework/handlers/sprite.js
@@ -33,7 +33,8 @@ class SpriteHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('sprite');
+        super(app);
+        this.handlerType = 'sprite';
 
         this._assets = app.assets;
         this._device = app.graphicsDevice;

--- a/src/framework/handlers/template.js
+++ b/src/framework/handlers/template.js
@@ -6,9 +6,8 @@ import { ResourceHandler } from './handler.js';
 
 class TemplateHandler extends ResourceHandler {
     constructor(app) {
-        super('template');
-
-        this._app = app;
+        super(app);
+        this.handlerType = 'template';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/text.js
+++ b/src/framework/handlers/text.js
@@ -4,7 +4,8 @@ import { ResourceHandler } from './handler.js';
 
 class TextHandler extends ResourceHandler {
     constructor(app) {
-        super('text');
+        super(app);
+        this.handlerType = 'text';
     }
 
     load(url, callback) {

--- a/src/framework/handlers/texture-atlas.js
+++ b/src/framework/handlers/texture-atlas.js
@@ -43,7 +43,8 @@ class TextureAtlasHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('textureatlas');
+        super(app);
+        this.handlerType = 'textureatlas';
 
         this._loader = app.loader;
     }

--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -169,7 +169,8 @@ class TextureHandler extends ResourceHandler {
      * @ignore
      */
     constructor(app) {
-        super('texture');
+        super(app);
+        this.handlerType = 'texture';
 
         const assets = app.assets;
         const device = app.graphicsDevice;


### PR DESCRIPTION
- Fixes mismatched constructor types of child and parent classes for `ResourceHandler` which caused linting errors.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
