### PR TITLE
Small cleanup of SkinInstance

### DIFF
--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -42,7 +42,6 @@ import { getBlueNoiseTexture } from '../graphics/blue-noise-texture.js';
 import { BlueNoise } from '../../core/math/blue-noise.js';
 
 let _skinUpdateIndex = 0;
-const boneTextureSize = [0, 0, 0, 0];
 const viewProjMat = new Mat4();
 const viewInvMat = new Mat4();
 const viewMat = new Mat4();
@@ -748,18 +747,15 @@ class Renderer {
     }
 
     setSkinning(device, meshInstance) {
-        if (meshInstance.skinInstance) {
+        const skinInstance = meshInstance.skinInstance;
+        if (skinInstance) {
             this._skinDrawCalls++;
             if (device.supportsBoneTextures) {
-                const boneTexture = meshInstance.skinInstance.boneTexture;
+                const boneTexture = skinInstance.boneTexture;
                 this.boneTextureId.setValue(boneTexture);
-                boneTextureSize[0] = boneTexture.width;
-                boneTextureSize[1] = boneTexture.height;
-                boneTextureSize[2] = 1.0 / boneTexture.width;
-                boneTextureSize[3] = 1.0 / boneTexture.height;
-                this.boneTextureSizeId.setValue(boneTextureSize);
+                this.boneTextureSizeId.setValue(skinInstance.boneTextureSize);
             } else {
-                this.poseMatrixId.setValue(meshInstance.skinInstance.matrixPalette);
+                this.poseMatrixId.setValue(skinInstance.matrixPalette);
             }
         }
     }

--- a/src/scene/skin-instance.js
+++ b/src/scene/skin-instance.js
@@ -2,7 +2,7 @@ import { Debug } from '../core/debug.js';
 import { math } from '../core/math/math.js';
 import { Mat4 } from '../core/math/mat4.js';
 
-import { FILTER_NEAREST, PIXELFORMAT_RGBA32F } from '../platform/graphics/constants.js';
+import { FILTER_NEAREST, PIXELFORMAT_RGBA32F, TEXTURELOCK_READ } from '../platform/graphics/constants.js';
 import { Texture } from '../platform/graphics/texture.js';
 
 const _invMatrix = new Mat4();
@@ -20,6 +20,8 @@ class SkinInstance {
      * @type {import('./graph-node.js').GraphNode[]}
      */
     bones;
+
+    boneTextureSize;
 
     /**
      * Create a new SkinInstance instance.
@@ -72,7 +74,10 @@ class SkinInstance {
                 name: 'skin'
             });
 
-            this.matrixPalette = this.boneTexture.lock();
+            this.boneTextureSize = [width, height, 1.0 / width, 1.0 / height];
+
+            this.matrixPalette = this.boneTexture.lock({ mode: TEXTURELOCK_READ });
+            this.boneTexture.unlock();
 
         } else {
             this.matrixPalette = new Float32Array(numBones * 12);


### PR DESCRIPTION
- make sure the initial bone texture lock has unlock, to avoid recently introduced asserts for non-matching locking
- skin-instance stores uniform array with texture sizes, to avoid filling this in for each drawcall