### PR TITLE
WebXR request hand-tracking for AR as well.

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -486,9 +486,9 @@ class XrManager extends EventHandler {
             if (webgl && options && options.cameraColor && this.views.supportedColor) {
                 opts.optionalFeatures.push('camera-access');
             }
-        } else if (type === XRTYPE_VR) {
-            opts.optionalFeatures.push('hand-tracking');
         }
+
+        opts.optionalFeatures.push('hand-tracking');
 
         if (options && options.optionalFeatures)
             opts.optionalFeatures = opts.optionalFeatures.concat(options.optionalFeatures);


### PR DESCRIPTION
By default, hand-tracking is requested for VR session types only. As more and more platforms erase the difference between VR and AR, this PR updates and sends optional requests for a hand-tracking feature for AR sessions as well.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
