### PR TITLE
Added ES6 bundle output

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "main": "build/playcanvas.js",
-  "module": "build/playcanvas.mjs/index.js",
+  "module": "build/playcanvas.mjs",
   "types": "build/playcanvas.d.ts",
   "sideEffects": false,
   "type": "module",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -65,7 +65,7 @@ export default (args) => {
             });
 
             // Add an unbundled es6 build
-            targets.push(buildTarget(t, 'es6', 'src/index.js', 'build', false));
+            if (t !== 'min') targets.push(buildTarget(t, 'es6', 'src/index.js', 'build', false));
 
         });
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -60,14 +60,13 @@ export default (args) => {
         ['release', 'debug', 'profiler', 'min'].forEach((t) => {
             ['es5', 'es6'].forEach((m) => {
                 if (envTarget === null || envTarget === t || envTarget === m || envTarget === `${t}_${m}`) {
-                    const shouldBundle = m === 'es5';
-                    targets.push(buildTarget(t, m, 'src/index.js', 'build', shouldBundle));
+                    targets.push(buildTarget(t, m, 'src/index.js', 'build', true));
                 }
             });
-
-            // Manually add an bundled es6 build
-            targets.push(buildTarget(t, 'es6', 'src/index.js', 'build', true));
         });
+
+        // Manually add a single unbundled es6 build
+        targets.push(buildTarget('release', 'es6', 'src/index.js', 'build', false));
 
         if (envTarget === null) {
             // no targets specified, build them all

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -63,10 +63,12 @@ export default (args) => {
                     targets.push(buildTarget(t, m, 'src/index.js', 'build', true));
                 }
             });
+
+            // Add an unbundled es6 build
+            targets.push(buildTarget(t, 'es6', 'src/index.js', 'build', false));
+
         });
 
-        // Manually add a single unbundled es6 build
-        targets.push(buildTarget('release', 'es6', 'src/index.js', 'build', false));
 
         if (envTarget === null) {
             // no targets specified, build them all

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -60,9 +60,13 @@ export default (args) => {
         ['release', 'debug', 'profiler', 'min'].forEach((t) => {
             ['es5', 'es6'].forEach((m) => {
                 if (envTarget === null || envTarget === t || envTarget === m || envTarget === `${t}_${m}`) {
-                    targets.push(buildTarget(t, m));
+                    const shouldBundle = m === 'es5';
+                    targets.push(buildTarget(t, m, 'src/index.js', 'build', shouldBundle));
                 }
             });
+
+            // Manually add an bundled es6 build
+            targets.push(buildTarget(t, 'es6', 'src/index.js', 'build', true));
         });
 
         if (envTarget === null) {

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -105,7 +105,7 @@ function buildTarget(buildType, moduleFormat, input = 'src/index.js', buildDir =
 
     const outputExtension = {
         es5: '.js',
-        es6: shouldBundle ? '.esm.js' : '.mjs'
+        es6: shouldBundle ? '.mjs' : ''
     };
 
     /** @type {Record<string, ModuleFormat>} */

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -169,8 +169,6 @@ function buildTarget(buildType, moduleFormat, input = 'src/index.js', buildDir =
         es6: moduleOptions(buildType)
     };
 
-    console.log(babelOptions[moduleFormat])
-
     return {
         input,
         output: outputOptions,

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -56,9 +56,10 @@ const stripFunctions = [
  * @param {'es5'|'es6'} moduleFormat - The module format.
  * @param {string} input - Only used for Examples to change it to `../src/index.js`.
  * @param {string} [buildDir] - Only used for examples to change the output location.
+ * @param {Boolean} [shouldBundle] - Whether the target should be bundled.
  * @returns {RollupOptions} One rollup target.
  */
-function buildTarget(buildType, moduleFormat, input = 'src/index.js', buildDir = 'build') {
+function buildTarget(buildType, moduleFormat, input = 'src/index.js', buildDir = 'build', shouldBundle = false) {
     const banner = {
         debug: ' (DEBUG)',
         release: ' (RELEASE)',
@@ -104,7 +105,7 @@ function buildTarget(buildType, moduleFormat, input = 'src/index.js', buildDir =
 
     const outputExtension = {
         es5: '.js',
-        es6: '.mjs'
+        es6: shouldBundle ? '.esm.js' : '.mjs'
     };
 
     /** @type {Record<string, ModuleFormat>} */
@@ -125,11 +126,11 @@ function buildTarget(buildType, moduleFormat, input = 'src/index.js', buildDir =
         indent: '\t',
         sourcemap: sourceMap[buildType] || sourceMap.release,
         name: 'pc',
-        preserveModules: moduleFormat === 'es6'
+        preserveModules: !shouldBundle
     };
 
     const loc = `${buildDir}/${outputFile[buildType]}${outputExtension[moduleFormat]}`;
-    outputOptions[moduleFormat === 'es6' ? 'dir' : 'file'] = loc;
+    outputOptions[shouldBundle ? 'file' : 'dir'] = loc;
 
     const sdkVersion = {
         _CURRENT_SDK_VERSION: version,
@@ -167,6 +168,8 @@ function buildTarget(buildType, moduleFormat, input = 'src/index.js', buildDir =
         es5: es5Options(buildType),
         es6: moduleOptions(buildType)
     };
+
+    console.log(babelOptions[moduleFormat])
 
     return {
         input,


### PR DESCRIPTION
This PR adds an additional ES6 bundle `playcanvas.esm.js` as a build output. It uses the same ES6 build configuration as the unbundled `playcanvas.mjs` but instead simply outputs to a single output. 

We plan on upgrading the launcher and exported projects to use this ES6 build to support ESM Scripts.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
