### PR TITLE
Link WebGL shaders immediately after compilation

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1353,15 +1353,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
     }
 
     /**
-     * Called after a batch of shaders was created, to guide in their optimal preparation for rendering.
-     *
-     * @ignore
-     */
-    endShaderBatch() {
-        WebglShader.endShaderBatch(this);
-    }
-
-    /**
      * Set the active rectangle for rendering on the specified device.
      *
      * @param {number} x - The pixel space x-coordinate of the bottom left corner of the viewport.

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -530,9 +530,6 @@ class ForwardRenderer extends Renderer {
             prevLightMask = lightMask;
         }
 
-        // process the batch of shaders created here
-        device.endShaderBatch?.();
-
         return _drawCallList;
     }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -300,9 +300,6 @@ class ShadowRenderer {
         const passFlags = 1 << SHADER_SHADOW;
         const shadowPass = this.getShadowPass(light);
 
-        // TODO: Similarly to forward renderer, a shader creation part of this loop should be split into a separate loop,
-        // and endShaderBatch should be called at its end
-
         // Render
         const count = visibleCasters.length;
         for (let i = 0; i < count; i++) {


### PR DESCRIPTION
Based on https://github.com/playcanvas/engine/pull/5914, thanks @erikdubbelboer for the work on this.

I tested and confirmed the behaviour on Chrome (and also Safari) has changed compared to my findings in https://github.com/mvaligursky/webgl-parallel_shader_compile

Chrome can now compile 50 large shaders without locking the main thead (as long as the result is not needed), unlike before. Likely some change in ANGLE, as that's where the expected fix was supposed to land.

It seems link right after compile step is beneficial. Before, we would trigger compilation step on all shaders in a pass, and then trigger linking on all of them, to get the best speed. Now it seems no work is done during compile step (on Chrome), and so unless we call the link step, browser does not start the compilation at all. 

By this change we're gaining little time it takes to trigger the compilation for all shaders - this time now seems to be used to link the first few shaders.

I also stripped out some code managing the delayed linking, as that is no longer needed.