### PR TITLE
WebXR FrameRate

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -623,6 +623,25 @@ class XrManager extends EventHandler {
     }
 
     /**
+     * @param {number} frameRate - Target frame rate. It should be any value from the list
+     * of supportedFrameRates.
+     * @param {Function} [callback] - Callback that will be called when frameRate has been
+     * updated or failed to update with error provided.
+     */
+    updateTargetFrameRate(frameRate, callback) {
+        if (!this._session?.updateTargetFrameRate)
+            return callback?.(new Error('unable to update frameRate'));
+
+        this._session.updateTargetFrameRate(frameRate)
+            .then(() => {
+                callback?.();
+            })
+            .catch((err) => {
+                callback?.(err);
+            });
+    }
+
+    /**
      * @param {string} type - Session type.
      * @private
      */
@@ -697,6 +716,10 @@ class XrManager extends EventHandler {
         Debug.assert(window, 'window is needed to scale the XR framebuffer. Are you running XR headless?');
 
         this._createBaseLayer();
+
+        this._session.addEventListener('frameratechange', () => {
+            this.fire('frameratechange', this._session?.frameRate);
+        });
 
         // request reference space
         session.requestReferenceSpace(spaceType).then((referenceSpace) => {
@@ -936,6 +959,25 @@ class XrManager extends EventHandler {
      */
     get session() {
         return this._session;
+    }
+
+    /**
+     * XR session frameRate or null if this information is not available. This value can change
+     * during an active XR session.
+     *
+     * @type {number|null}
+     */
+    get frameRate() {
+        return this._session?.frameRate ?? null;
+    }
+
+    /**
+     * List of supported frame rates, or null if this data is not available.
+     *
+     * @type {Float32Array|null}
+     */
+    get supportedFrameRates() {
+        return this._session?.supportedFrameRates ?? null;
     }
 
     /**


### PR DESCRIPTION
The developer will be able to control the target frame rate of an XR session based on a provided list of supported frame rates.

XR device can change framerate based on its underlying mechanics, but the user has control over it also. For example, Quest 3 provides these supported frame rates: [ 72, 80, 90, 120 ], and by default it will use 90 Hz. But you can ask it to render with 120 Hz if your app can manage such performance.

New APIs:
```javascript
// pc.XrManager
xr.frameRate // (number) a target frame rate of the current session, or null if not supported or no XR session is available
xr.supportedFrameRates // (Float32Array) list of supported frame rates, or null if not supported or no XR session is available
xr.updateTargetFrameRate(frameRate: number, (err) => { }); // async method to update frame rate based on list of supported values
xr.on('frameratechange', (frameRate: number) => { }); // event when framerate has been changed 
```

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
