### PR TITLE
WebXR Fixed Foveation

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -1028,6 +1028,10 @@ class XrManager extends EventHandler {
      */
     set fixedFoveation(value) {
         if ((this._baseLayer?.fixedFoveation ?? null) !== null) {
+            if (this.app.graphicsDevice.samples > 1) {
+                Debug.warn('Fixed Foveation is ignored. Disable anti-aliasing for it to be effective.');
+            }
+
             this._baseLayer.fixedFoveation = value;
         }
     }

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -960,6 +960,30 @@ class XrManager extends EventHandler {
     }
 
     /**
+     * Set fixed foveation to the value between 0 and 1. Where 0 - no foveation, and 1 - highest
+     * foveation. It only can be set during an active XR session.
+     * Fixed foveation will reduce the resolution of the back buffer at the edges of the sceen,
+     * which can improve rendering performance.
+     *
+     * @type {number}
+     */
+    set fixedFoveation(value) {
+        if ((this._baseLayer?.fixedFoveation ?? null) !== null) {
+            this._baseLayer.fixedFoveation = value;
+        }
+    }
+
+    /**
+     * Current fixed foveation level, which is between 0 and 1. 0 - no forveation, and 1 - highest
+     * foveation. If fixed foveation is not supported, this value returns null.
+     *
+     * @type {number|null}
+     */
+    get fixedFoveation() {
+        return this._baseLayer?.fixedFoveation ?? null;
+    }
+
+    /**
      * Active camera for which XR session is running or null.
      *
      * @type {import('../entity.js').Entity|null}


### PR DESCRIPTION
The developer can provide a fixed foveation level value (0..1). Underlying rendering system will change the resolution of a framebuffer on the edges of the screens, that way it can improve the rendering performance of fragment shaders, as fewer details will be rendered on the edges.

New APIs:
```javascript
// pc.XrManager
xr.fixedFoveation // (number|null) a value that can be set and read during an active XR session
```

## Caveat:

Currently, the PlayCanvas engine renders into the intermediate buffer, resolves MSAA and then blits it to the back buffer. With such behaviour, the foveation will not work as the intermediate buffer is not foveated. So currently it only works if no anti-aliasing is enabled for rendering, that way engine renders directly into the back buffer and foveation is beneficial.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
