### PR TITLE
Tech to allow async shader compilation, disabled

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -489,6 +489,7 @@ class GraphicsDevice extends EventHandler {
         this.vertexBuffers = [];
         this.shader = null;
         this.shaderValid = undefined;
+        this.shaderAsyncCompile = false;
         this.renderTarget = null;
     }
 

--- a/src/platform/graphics/null/null-graphics-device.js
+++ b/src/platform/graphics/null/null-graphics-device.js
@@ -106,7 +106,7 @@ class NullGraphicsDevice extends GraphicsDevice {
     draw(primitive, numInstances = 1, keepBuffers) {
     }
 
-    setShader(shader) {
+    setShader(shader, asyncCompile = false) {
     }
 
     setBlendState(blendState) {

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -390,6 +390,23 @@ class WebglShader {
     }
 
     /**
+     * Check the linking status of a shader.
+     *
+     * @param {import('./webgl-graphics-device.js').WebglGraphicsDevice} device - The graphics device.
+     * @returns {boolean} True if the shader is already linked, false otherwise. Note that unless the
+     * device supports the KHR_parallel_shader_compile extension, this will always return true.
+     */
+    isLinked(device) {
+
+        const { extParallelShaderCompile } = device;
+        if (extParallelShaderCompile) {
+            return device.gl.getProgramParameter(this.glProgram, extParallelShaderCompile.COMPLETION_STATUS_KHR);
+        }
+
+        return true;
+    }
+
+    /**
      * Truncate the WebGL shader compilation log to just include the error line plus the 5 lines
      * before and after it.
      *

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -479,7 +479,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         }
     }
 
-    setShader(shader) {
+    setShader(shader, asyncCompile = false) {
 
         if (shader !== this.shader) {
             this.shader = shader;

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -555,7 +555,8 @@ class ForwardRenderer extends Renderer {
 
             if (newMaterial) {
 
-                device.setShader(shaderInstance.shader);
+                const asyncCompile = false;
+                device.setShader(shaderInstance.shader, asyncCompile);
 
                 // Uniforms I: material
                 material.setParameters(device);


### PR DESCRIPTION
Tech needed for using KHR_parallel_shader_compile for async shader compilation.

A shader can be assigned on a device with true parameter (defaults to false) to skip the rendering with this shader until it is compiled and linked. The test is done using non-blocking API.

```
device.setShader(shader, true);
```

This is currently not used (false is always passed), as the situation described here is still very relevant: https://github.com/mvaligursky/webgl-parallel_shader_compile

Tests using ShaderCompile engine example with more spheres (unique shaders)

![mac](https://github.com/playcanvas/engine/assets/59932779/1946bb6d-b5d9-4db8-b6dd-c89d722ccbd8)

## Findings on MacOS 14.3.1 and Chrome 121:
- the extensions returns true in vast majority of cases, even when the shader is not ready, which block the rendering when the shader us used. The bahaviour is pretty much equivalent to not using the extension at all:

![Screenshot 2024-02-23 at 14 33 08](https://github.com/playcanvas/engine/assets/59932779/1a3fa054-d89b-4ba1-a223-75ede73ab131)

## Findings on Windows 10, Chrome 121:
- the situation is somehow better. The extension correctly reports shader not being done compiling, so we can correctly skip rendering with it. But the browser is somehow blocked on its internal threads during the compilation, and so the application is still very much unresponsive during those times.

![image](https://github.com/playcanvas/engine/assets/59932779/83c328ef-a8b0-4a0b-b78c-6eb2890dc3a2)
