### PR TITLE
Remove section on source maps from README

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -140,15 +140,6 @@ Node.jsがインストールされていることを確認します。
 * https://code.playcanvas.com/playcanvas-1.38.4.js
 * https://code.playcanvas.com/playcanvas-1.38.4.min.js
 
-### Generate Source Maps
-
-エンジンのデバッグがしやすいようにソースマップを構築するには、任意のエンジン構築コマンドに`-- -m`を追加します。例えば、以下のようになります。
-
-
-    npm run build -- -m
-
-これにより`build/playcanvas.js.map`が出力されます。
-
 ## PlayCanvasエディター
 
 PlayCanvas エンジンは、HTML5 アプリやゲームを作成するためのオープンソースのエンジンです。エンジンに加えて、[PlayCanvasエディター](https://playcanvas.com/)があります。

--- a/README-kr.md
+++ b/README-kr.md
@@ -149,14 +149,6 @@ PlayCanvas는 완전한 기능의 게임 엔진입니다.
 * https://code.playcanvas.com/playcanvas-1.38.4.js
 * https://code.playcanvas.com/playcanvas-1.38.4.min.js
 
-### Generate Source Maps
-
-엔진의 디버깅이 쉽도록 소스 맵을 구축하려면 임의의 엔진 구축 명령에 `---m`을 추가합니다. 예시는 다음과 같습니다.
-
-    npm run build -- -m
-
-그러면  `build/playcanvas.js.map` 이 출력이 됩니다.
-
 ## PlayCanvas 에디터
 
 PlayCanvas 엔진은 HTML5 앱 및 게임을 만들기 위한 오픈 소스 엔진입니다.엔진 외에 [PlayCanvas 에디터](https://playcanvas.com/)가 있습니다.

--- a/README-zh.md
+++ b/README-zh.md
@@ -148,14 +148,6 @@ PlayCanvas 是一款优秀的全功能游戏引擎。
 - https://code.playcanvas.com/playcanvas-1.38.4.js
 - https://code.playcanvas.com/playcanvas-1.38.4.min.js
 
-### 生成 Source Maps
-
-您可以在任何构建指令之后添加 `-- -m` 来生成 Source map 更好更方便地对引擎进行调试和排错：
-
-    npm run build -- -m
-
-此条指令将会将结果输出到 `build/playcanvas.js.map`
-
 ## PlayCanvas 平台
 
 PlayCanvas 引擎是一款可以基于浏览器的用于制作游戏以及 3D 可视化的开源引擎。除此之外，我们还开发了[PlayCanvas 开发平台](https://playcanvas.com/)， 为我们的用户提供了可视化编辑器，资源管理，代码编辑，代码托管以及发布等服务。

--- a/README.md
+++ b/README.md
@@ -147,14 +147,6 @@ Specific engine versions:
 * https://code.playcanvas.com/playcanvas-1.38.4.js
 * https://code.playcanvas.com/playcanvas-1.38.4.min.js
 
-### Generate Source Maps
-
-To build the source map to allow for easier engine debugging, you can add `-- -m` to any engine build command. For example:
-
-    npm run build -- -m
-
-This will output to `build/playcanvas.js.map`
-
 ## PlayCanvas Editor
 
 The PlayCanvas Engine is an open source engine which you can use to create HTML5 apps/games. In addition to the engine, we also make the [PlayCanvas Editor](https://playcanvas.com/):


### PR DESCRIPTION
Delete the section added by @yaustar here: https://github.com/playcanvas/engine/pull/2008

The debug build of the engine now incorporates source maps and that's the version you should use for debugging.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
