### PR TITLE
Mesh collision optimization

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -445,7 +445,7 @@ class CollisionMeshSystemImpl extends CollisionSystemImpl {
                     this.createAmmoMesh(meshes[i], tempGraphNode, shape, scale, data.checkVertexDuplicates);
                 }
             }
-            
+
             return shape;
         }
 


### PR DESCRIPTION
This is a follow up on #5818 

After we have created a mesh collider, the engine proceeds with setting the scale of the mesh. This is an expensive operation in Ammo, as it triggers another loop over all verts and recalculating AABB, which was already calculated once when we created `btBvhTriangleMeshShape`.
Since we are already looping over verts on JS side, we can apply scale in place instead.

This. further improves collider generation (24k verts) from `~181 ms` down to `~115 ms`.

Note:
This optimization is only for Render Asset types. There is no change to legacy Model Assets, which will continue using Ammo scaling as they do now.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
