### PR TITLE
When WebGPU validation fails, current markers are logged out

### DIFF
--- a/examples/src/examples/graphics/shapes/example.mjs
+++ b/examples/src/examples/graphics/shapes/example.mjs
@@ -47,7 +47,7 @@ let x = -1,
 
 shapes.forEach(function (shape) {
     // Create an entity with a render component
-    const entity = new pc.Entity();
+    const entity = new pc.Entity(shape);
     entity.addComponent('render', {
         type: shape
     });

--- a/src/platform/graphics/webgpu/webgpu-debug.js
+++ b/src/platform/graphics/webgpu/webgpu-debug.js
@@ -1,4 +1,5 @@
 import { Debug } from "../../../core/debug.js";
+import { DebugGraphics } from "../debug-graphics.js";
 
 // Maximum number of times a duplicate error message is logged.
 const MAX_DUPLICATES = 5;
@@ -12,6 +13,8 @@ const MAX_DUPLICATES = 5;
 class WebgpuDebug {
     static _scopes = [];
 
+    static _markers = [];
+
     /** @type {Map<string,number>} */
     static _loggedMessages = new Map();
 
@@ -24,6 +27,7 @@ class WebgpuDebug {
     static validate(device) {
         device.wgpu.pushErrorScope('validation');
         WebgpuDebug._scopes.push('validation');
+        WebgpuDebug._markers.push(DebugGraphics.toString());
     }
 
     /**
@@ -35,6 +39,7 @@ class WebgpuDebug {
     static memory(device) {
         device.wgpu.pushErrorScope('out-of-memory');
         WebgpuDebug._scopes.push('out-of-memory');
+        WebgpuDebug._markers.push(DebugGraphics.toString());
     }
 
     /**
@@ -46,6 +51,7 @@ class WebgpuDebug {
     static internal(device) {
         device.wgpu.pushErrorScope('internal');
         WebgpuDebug._scopes.push('internal');
+        WebgpuDebug._markers.push(DebugGraphics.toString());
     }
 
     /**
@@ -57,6 +63,7 @@ class WebgpuDebug {
      */
     static end(device, ...args) {
         const header = WebgpuDebug._scopes.pop();
+        const marker = WebgpuDebug._markers.pop();
         Debug.assert(header, 'Non matching end.');
 
         device.wgpu.popErrorScope().then((error) => {
@@ -65,7 +72,7 @@ class WebgpuDebug {
                 if (count < MAX_DUPLICATES) {
                     const tooMany = count === MAX_DUPLICATES - 1 ? ' (Too many errors, ignoring this one from now)' : '';
                     WebgpuDebug._loggedMessages.set(error.message, count + 1);
-                    console.error(`WebGPU ${header} error: ${error.message}`, tooMany, ...args);
+                    console.error(`WebGPU ${header} error: ${error.message}`, tooMany, "while rendering", marker, ...args);
                 }
             }
         });


### PR DESCRIPTION
- this helps to identify the source (Entity, material …) of the issues

example validation errors, note the `While Rendering` + the following string.

<img width="1139" alt="Screenshot 2024-02-26 at 12 29 20" src="https://github.com/playcanvas/engine/assets/59932779/9fe15404-0cbc-43ff-9b44-28f5c9e7102b">
