### PR TITLE
Add rollup import transform

### DIFF
--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -11,6 +11,7 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import { shaderChunks } from './rollup-shader-chunks.mjs';
 import { engineLayerImportValidation } from './rollup-import-validation.mjs';
 import { spacesToTabs } from './rollup-spaces-to-tabs.mjs';
+import { dynamicImportTransform } from './rollup-dynamic-import-transform.mjs';
 
 import { version, revision } from './rollup-version-revision.mjs';
 import { getBanner } from './rollup-get-banner.mjs';
@@ -177,6 +178,7 @@ function buildTarget(buildType, moduleFormat, input = 'src/index.js', buildDir =
         output: outputOptions,
         plugins: [
             jscc(jsccParam),
+            moduleFormat === 'es5' ? dynamicImportTransform() : undefined,
             shaderChunks({ enabled: buildType !== 'debug' }),
             engineLayerImportValidation(input, buildType === 'debug'),
             buildType !== 'debug' ? strip(stripOptions) : undefined,

--- a/utils/rollup-dynamic-import-transform.mjs
+++ b/utils/rollup-dynamic-import-transform.mjs
@@ -17,7 +17,7 @@ export function dynamicImportTransform() {
              * @returns {object} - The transformed code and map.
              */
             return {
-                code: code.replace(/import\(/g, 'new Function("modulePath", "return import(modulePath)")('),
+                code: code.replace(/([^\w])import\(/g, '$1new Function("modulePath", "return import(modulePath)")('),
                 map: null
             };
         }

--- a/utils/rollup-dynamic-import-transform.mjs
+++ b/utils/rollup-dynamic-import-transform.mjs
@@ -3,7 +3,7 @@
  * in a `new Function('import("modulePath")')` statement, in order to avoid parsing errors in older browsers
  * without support for dynamic imports.
  *
- * Note that whilst this will prevent parsing errors, it will
+ * Note that whilst this will prevent parsing errors, it can trigger CSP errors.
  */
 
 export function dynamicImportTransform() {

--- a/utils/rollup-dynamic-import-transform.mjs
+++ b/utils/rollup-dynamic-import-transform.mjs
@@ -1,0 +1,25 @@
+/**
+ * This rollup plugin transform code with dynamic import statements and wraps them
+ * in a `new Function('import("modulePath")')` statement, in order to avoid parsing errors in older browsers
+ * without support for dynamic imports.
+ *
+ * Note that whilst this will prevent parsing errors, it will
+ */
+
+export function dynamicImportTransform() {
+    return {
+        name: 'dynamic-import-transform',
+        transform(code, id) {
+            /**
+             * Transforms the code by replacing `import(` with `new Function("return import")(`.
+             * @param {string} code - The code to transform.
+             * @param {string} id - The id of the code.
+             * @returns {object} - The transformed code and map.
+             */
+            return {
+                code: code.replace(/import\(/g, 'new Function("modulePath", "return import(modulePath)")('),
+                map: null
+            };
+        }
+    };
+}


### PR DESCRIPTION
This PR addresses a long standing issue with the UMD build not running on devices without dynamic `import()` support. See #6011.

This issue stemmed from the use of dynamic `import()` statement, where `import` is a reserved keyword and would throw a SyntaxError during parsing on older browsers, even if the code path was never executed.

This PR adds a rollup transform to the UMD build only, which wraps `import()` statements in a dynamic function. This is only evaluated at runtime, thereby avoiding the parsing on load error. Note that this does not polyfill dynamic imports, it will simply prevent parsing errors on browser without support.

### Caveats
This does put a limitation on CSP for UMD builds, however this only applies if *all of the following conditions are met*

1. The UMD build is used (not applicable to the ES6 build) **AND**
2. Hosting blocks `unsafe-eval` in their CSP **AND**
3. When using either WebGPU or importing an ESM ScriptType

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
