### PR TITLE
Fix ENV var target

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -65,7 +65,9 @@ export default (args) => {
             });
 
             // Add an unbundled es6 build
-            if (t !== 'min') targets.push(buildTarget(t, 'es6', 'src/index.js', 'build', false));
+            if (t !== 'min' && envTarget === null || envTarget === t || envTarget === `${t}_es6`) {
+                if (t !== 'min') targets.push(buildTarget(t, 'es6', 'src/index.js', 'build', false));
+            }
 
         });
 


### PR DESCRIPTION
This PR adds a fix to prevent the ES6 builds from running when  the `_target es5` is set. 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
