### PR TITLE
Assert when current version of Ammo does not implement now required triMesh.getIndexedMeshArray

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -364,6 +364,7 @@ class CollisionMeshSystemImpl extends CollisionSystemImpl {
             system._triMeshCache[mesh.id] = triMesh;
 
             const vertexCache = new Map();
+            Debug.assert(typeof triMesh.getIndexedMeshArray === 'function', 'Ammo.js version is too old, please update to a newer Ammo.');
             const indexedArray = triMesh.getIndexedMeshArray();
             indexedArray.at(0).m_numTriangles = numTriangles;
 


### PR DESCRIPTION
- instead of just failing on tryig to use it.

related change: https://github.com/playcanvas/engine/pull/5818