### PR TITLE
[Fix] WebGPU mesh rendering uses primitive.base correctly

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -463,9 +463,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             if (ib) {
                 this.indexBuffer = null;
                 passEncoder.setIndexBuffer(ib.impl.buffer, ib.impl.format);
-                passEncoder.drawIndexed(primitive.count, numInstances, 0, 0, 0);
+                passEncoder.drawIndexed(primitive.count, numInstances, primitive.base, 0, 0);
             } else {
-                passEncoder.draw(primitive.count, numInstances, 0, 0);
+                passEncoder.draw(primitive.count, numInstances, primitive.base, 0);
             }
 
             WebgpuDebug.end(this, {


### PR DESCRIPTION
- WebGPU renderer was not using mesh.primitive.base (bese index for indexed, base vertex for non-indexed rendering), which is used by the json mesh file format. This was causing incorrect geometry for most of the json meshes (broken examples: titan, x-wing, slot machine).