### PR TITLE
GPU optimization to gsplat rendering

### DIFF
--- a/examples/src/examples/loaders/gsplat-many/config.mjs
+++ b/examples/src/examples/loaders/gsplat-many/config.mjs
@@ -2,6 +2,7 @@
  * @type {import('../../../../types.mjs').ExampleConfig}
  */
 export default {
+    WEBGPU_ENABLED: true,
     FILES: {
         "shader.vert": /* glsl */`
             uniform float uTime;

--- a/examples/src/examples/loaders/gsplat/config.mjs
+++ b/examples/src/examples/loaders/gsplat/config.mjs
@@ -1,0 +1,6 @@
+/**
+ * @type {import('../../../../types.mjs').ExampleConfig}
+ */
+export default {
+    WEBGPU_ENABLED: true
+};

--- a/src/core/math/mat3.js
+++ b/src/core/math/mat3.js
@@ -91,6 +91,36 @@ class Mat3 {
     }
 
     /**
+     * Extracts the x-axis from the specified matrix.
+     *
+     * @param {Vec3} [x] - The vector to receive the x axis of the matrix.
+     * @returns {Vec3} The x-axis of the specified matrix.
+     */
+    getX(x = new Vec3()) {
+        return x.set(this.data[0], this.data[1], this.data[2]);
+    }
+
+    /**
+     * Extracts the y-axis from the specified matrix.
+     *
+     * @param {Vec3} [y] - The vector to receive the y axis of the matrix.
+     * @returns {Vec3} The y-axis of the specified matrix.
+     */
+    getY(y = new Vec3()) {
+        return y.set(this.data[3], this.data[4], this.data[5]);
+    }
+
+    /**
+     * Extracts the z-axis from the specified matrix.
+     *
+     * @param {Vec3} [z] - The vector to receive the z axis of the matrix.
+     * @returns {Vec3} The z-axis of the specified matrix.
+     */
+    getZ(z = new Vec3()) {
+        return z.set(this.data[6], this.data[7], this.data[8]);
+    }
+
+    /**
      * Reports whether two matrices are equal.
      *
      * @param {Mat3} rhs - The other matrix.

--- a/src/framework/parsers/gsplat-resource.js
+++ b/src/framework/parsers/gsplat-resource.js
@@ -57,9 +57,9 @@ class GSplatResource {
 
             // texture data
             splat.updateColorData(splatData.getProp('f_dc_0'), splatData.getProp('f_dc_1'), splatData.getProp('f_dc_2'), splatData.getProp('opacity'));
-            splat.updateScaleData(splatData.getProp('scale_0'), splatData.getProp('scale_1'), splatData.getProp('scale_2'));
-            splat.updateRotationData(splatData.getProp('rot_0'), splatData.getProp('rot_1'), splatData.getProp('rot_2'), splatData.getProp('rot_3'));
             splat.updateCenterData(splatData.getProp('x'), splatData.getProp('y'), splatData.getProp('z'));
+            splat.updateCovData(splatData.getProp('rot_0'), splatData.getProp('rot_1'), splatData.getProp('rot_2'), splatData.getProp('rot_3'),
+                                splatData.getProp('scale_0'), splatData.getProp('scale_1'), splatData.getProp('scale_2'));
 
             // centers - constant buffer that is sent to the worker
             const x = splatData.getProp('x');

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -20,6 +20,18 @@ const splatCoreVS = `
     varying vec4 color;
     varying float id;
 
+    #ifndef GL2
+    #ifndef WEBGPU
+    mat3 transpose(in mat3 m) {
+        return mat3(
+            m[0].x, m[1].x, m[2].x,
+            m[0].y, m[1].y, m[2].y,
+            m[0].z, m[1].z, m[2].z
+        );
+    }
+    #endif
+    #endif
+
     mat3 quatToMat3(vec3 R)
     {
         float x = R.x;
@@ -44,9 +56,10 @@ const splatCoreVS = `
 
     uniform vec4 tex_params;
     uniform sampler2D splatColor;
-    uniform highp sampler2D splatScale;
-    uniform highp sampler2D splatRotation;
     uniform highp sampler2D splatCenter;
+
+    uniform highp sampler2D splatCovA;
+    uniform highp sampler2D splatCovB;
 
     #ifdef INT_INDICES
 
@@ -67,16 +80,16 @@ const splatCoreVS = `
             return texelFetch(splatColor, dataUV, 0);
         }
 
-        vec3 getScale() {
-            return texelFetch(splatScale, dataUV, 0).xyz;
-        }
-
-        vec3 getRotation() {
-            return texelFetch(splatRotation, dataUV, 0).xyz;
-        }
-
         vec3 getCenter() {
             return texelFetch(splatCenter, dataUV, 0).xyz;
+        }
+
+        vec3 getCovA() {
+            return texelFetch(splatCovA, dataUV, 0).xyz;
+        }
+
+        vec3 getCovB() {
+            return texelFetch(splatCovB, dataUV, 0).xyz;
         }
 
     #else
@@ -101,58 +114,24 @@ const splatCoreVS = `
             return texture2D(splatColor, dataUV);
         }
 
-        vec3 getScale() {
-            return texture2D(splatScale, dataUV).xyz;
-        }
-
-        vec3 getRotation() {
-            return texture2D(splatRotation, dataUV).xyz;
-        }
-
         vec3 getCenter() {
             return texture2D(splatCenter, dataUV).xyz;
         }
 
+        vec3 getCovA() {
+            return texture2D(splatCovA, dataUV).xyz;
+        }
+
+        vec3 getCovB() {
+            return texture2D(splatCovB, dataUV).xyz;
+        }
+
     #endif
-
-    void computeCov3d(in mat3 rot, in vec3 scale, out vec3 covA, out vec3 covB)
-    {
-        // M = S * R
-        mat3 M = transpose(mat3(
-            scale[0] * rot[0],
-            scale[1] * rot[1],
-            scale[2] * rot[2]
-        ));
-
-        covA = vec3(
-            dot(M[0], M[0]),
-            dot(M[0], M[1]),
-            dot(M[0], M[2])
-        );
-
-        covB = vec3(
-            dot(M[1], M[1]),
-            dot(M[1], M[2]),
-            dot(M[2], M[2])
-        );
-    }
 
     vec3 evalCenter() {
         evalDataUV();
         return getCenter();
     }
-
-    #ifndef GL2
-    #ifndef WEBGPU
-    mat3 transpose(in mat3 m) {
-        return mat3(
-            m[0].x, m[1].x, m[2].x,
-            m[0].y, m[1].y, m[2].y,
-            m[0].z, m[1].z, m[2].z
-        );
-    }
-    #endif
-    #endif
 
     vec4 evalSplat(vec4 centerWorld)
     {
@@ -164,63 +143,54 @@ const splatCoreVS = `
             return vec4(0.0, 0.0, 2.0, 1.0);
         }
 
-        vec3 scale = getScale();
-        vec3 rotation = getRotation();
-
         color = getColor();
 
-        #ifdef DEBUG_RENDER
-            vec3 local = quatToMat3(rotation) * (vertex_position * scale * 2.0) + center;
-            return matrix_viewProjection * matrix_model * vec4(local, 1.0);
-        #else
-            vec3 splat_cova;
-            vec3 splat_covb;
-            computeCov3d(quatToMat3(rotation), scale, splat_cova, splat_covb);
+        vec3 splat_cova = getCovA();
+        vec3 splat_covb = getCovB();
 
-            mat3 Vrk = mat3(
-                splat_cova.x, splat_cova.y, splat_cova.z, 
-                splat_cova.y, splat_covb.x, splat_covb.y,
-                splat_cova.z, splat_covb.y, splat_covb.z
-            );
+        mat3 Vrk = mat3(
+            splat_cova.x, splat_cova.y, splat_cova.z, 
+            splat_cova.y, splat_covb.x, splat_covb.y,
+            splat_cova.z, splat_covb.y, splat_covb.z
+        );
 
-            float focal = viewport.x * matrix_projection[0][0];
+        float focal = viewport.x * matrix_projection[0][0];
 
-            mat3 J = mat3(
-                focal / splat_cam.z, 0., -(focal * splat_cam.x) / (splat_cam.z * splat_cam.z), 
-                0., focal / splat_cam.z, -(focal * splat_cam.y) / (splat_cam.z * splat_cam.z), 
-                0., 0., 0.
-            );
+        mat3 J = mat3(
+            focal / splat_cam.z, 0., -(focal * splat_cam.x) / (splat_cam.z * splat_cam.z), 
+            0., focal / splat_cam.z, -(focal * splat_cam.y) / (splat_cam.z * splat_cam.z), 
+            0., 0., 0.
+        );
 
-            mat3 W = transpose(mat3(matrix_view) * mat3(matrix_model));
+        mat3 W = transpose(mat3(matrix_view) * mat3(matrix_model));
 
-            mat3 T = W * J;
-            mat3 cov = transpose(T) * Vrk * T;
+        mat3 T = W * J;
+        mat3 cov = transpose(T) * Vrk * T;
 
-            float diagonal1 = cov[0][0] + 0.3;
-            float offDiagonal = cov[0][1];
-            float diagonal2 = cov[1][1] + 0.3;
+        float diagonal1 = cov[0][0] + 0.3;
+        float offDiagonal = cov[0][1];
+        float diagonal2 = cov[1][1] + 0.3;
 
-            float mid = 0.5 * (diagonal1 + diagonal2);
-            float radius = length(vec2((diagonal1 - diagonal2) / 2.0, offDiagonal));
-            float lambda1 = mid + radius;
-            float lambda2 = max(mid - radius, 0.1);
-            vec2 diagonalVector = normalize(vec2(offDiagonal, lambda1 - diagonal1));
-            vec2 v1 = min(sqrt(2.0 * lambda1), 1024.0) * diagonalVector;
-            vec2 v2 = min(sqrt(2.0 * lambda2), 1024.0) * vec2(diagonalVector.y, -diagonalVector.x);
+        float mid = 0.5 * (diagonal1 + diagonal2);
+        float radius = length(vec2((diagonal1 - diagonal2) / 2.0, offDiagonal));
+        float lambda1 = mid + radius;
+        float lambda2 = max(mid - radius, 0.1);
+        vec2 diagonalVector = normalize(vec2(offDiagonal, lambda1 - diagonal1));
+        vec2 v1 = min(sqrt(2.0 * lambda1), 1024.0) * diagonalVector;
+        vec2 v2 = min(sqrt(2.0 * lambda2), 1024.0) * vec2(diagonalVector.y, -diagonalVector.x);
 
-            // early out tiny splats
-            // TODO: figure out length units and expose as uniform parameter
-            // TODO: perhaps make this a shader compile-time option
-            if (dot(v1, v1) < 4.0 && dot(v2, v2) < 4.0) {
-                return vec4(0.0, 0.0, 2.0, 1.0);
-            }
+        // early out tiny splats
+        // TODO: figure out length units and expose as uniform parameter
+        // TODO: perhaps make this a shader compile-time option
+        if (dot(v1, v1) < 4.0 && dot(v2, v2) < 4.0) {
+            return vec4(0.0, 0.0, 2.0, 1.0);
+        }
 
-            texCoord = vertex_position.xy * 2.0;
+        texCoord = vertex_position.xy * 2.0;
 
-            return splat_proj +
-                vec4((vertex_position.x * v1 + vertex_position.y * v2) / viewport * 2.0,
-                    0.0, 0.0) * splat_proj.w;
-        #endif
+        return splat_proj +
+            vec4((vertex_position.x * v1 + vertex_position.y * v2) / viewport * 2.0,
+                0.0, 0.0) * splat_proj.w;
 
         id = float(vertex_id);
     }

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -32,28 +32,6 @@ const splatCoreVS = `
     #endif
     #endif
 
-    mat3 quatToMat3(vec3 R)
-    {
-        float x = R.x;
-        float y = R.y;
-        float z = R.z;
-        float w = sqrt(1.0 - dot(R, R));
-
-        return mat3(
-            1.0 - 2.0 * (z * z + w * w),
-                2.0 * (y * z + x * w),
-                2.0 * (y * w - x * z),
-
-                2.0 * (y * z - x * w),
-            1.0 - 2.0 * (y * y + w * w),
-                2.0 * (z * w + x * y),
-
-                2.0 * (y * w + x * z),
-                2.0 * (z * w - x * y),
-            1.0 - 2.0 * (y * y + z * z)
-        );
-    }
-
     uniform vec4 tex_params;
     uniform sampler2D splatColor;
     uniform highp sampler2D splatCenter;


### PR DESCRIPTION
- GPU used to read scale and rotation data (both Vec3), and evaluate covariance matrix from those (again two Vec3s). As that evaluation was completely constant, it has been moved to CPU, and stored in the textures instead of scale and rotation. This saves about 15% of GPU time on my Mac.
- enabled both GSplat examples for WebGPU (as they're supported)