### PR TITLE
Added worker environment

### DIFF
--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -17,7 +17,8 @@ const detectPassiveEvents = () => {
 };
 
 const ua = (typeof navigator !== 'undefined') ? navigator.userAgent : '';
-const environment = (typeof window !== 'undefined') ? 'browser' : 'node';
+const environment = typeof window !== 'undefined' ? 'browser' :
+    typeof global !== 'undefined' ? 'node' : 'worker';
 
 // detect platform
 const platformName =
@@ -62,19 +63,22 @@ const platform = {
     name: platformName,
 
     /**
-     * String identifying the current runtime environment. Either 'browser' or 'node'.
+     * String identifying the current runtime environment. Either 'browser', 'node' or 'worker'.
      *
-     * @type {'browser' | 'node'}
+     * @type {'browser' | 'node' | 'worker'}
      */
     environment: environment,
 
     /**
      * The global object. This will be the window object when running in a browser and the global
-     * object when running in nodejs.
+     * object when running in nodejs and self when running in a worker.
      *
      * @type {object}
      */
-    global: (environment === 'browser') ? window : global,
+    global: globalThis ??
+        (environment === 'browser' && window) ??
+        (environment === 'node' && global) ??
+        (environment === 'worker' && self),
 
     /**
      * Convenience boolean indicating whether we're running in the browser.


### PR DESCRIPTION
When a user script is parsed in the editor, it's executed in a Worker which doesn't have `window` or `global`.  

This means that when the following ESM Script is parsed in the editor, it will import the engine and immediately throw because neither `window` nor `global` exists.

```javascript
import { ScriptType } from 'playcanvas';
class MyRotator extends ScriptType {}
```

This PR adds `environment: 'worker'` and `global: self` as additional values which prevents this error.

