### PR TITLE
Engine export fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@types/webxr": "^0.5.7",
-        "@webgpu/types": "^0.1.38"
+        "@webgpu/types": "^0.1.38",
+        "playcanvas": "file:."
       },
       "devDependencies": {
         "@babel/core": "^7.23.2",
@@ -6851,6 +6852,10 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/playcanvas": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,16 @@
   "main": "build/playcanvas.js",
   "module": "build/playcanvas.mjs",
   "types": "build/playcanvas.d.ts",
+  "exports": {
+    ".": {
+      "import": "./build/playcanvas.mjs",
+      "require": "./build/playcanvas.js"
+    },
+    "./extras": {
+      "import": "./build/playcanvas-extras.mjs",
+      "require": "./build/playcanvas-extras.js"
+    }
+  },
   "sideEffects": false,
   "type": "module",
   "bugs": {
@@ -94,7 +104,8 @@
   ],
   "dependencies": {
     "@types/webxr": "^0.5.7",
-    "@webgpu/types": "^0.1.38"
+    "@webgpu/types": "^0.1.38",
+    "playcanvas": "file:."
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
@@ -136,6 +147,7 @@
     "build:release": "rollup -c --environment target:release",
     "build:debug": "rollup -c --environment target:debug",
     "build:dts": "tsc src/index.js --outDir types --allowJs --declaration --emitDeclarationOnly",
+    "build:dts:extras": "tsc extras/index.js --allowJs --declaration --emitDeclarationOnly --outDir build/playcanvas-extras",
     "build:extras": "rollup -c --environment target:extras",
     "build:es5": "rollup -c --environment target:es5",
     "build:es6": "rollup -c --environment target:es6",
@@ -146,7 +158,7 @@
     "build:treenet": "npm run build:es5 -- --environment treenet",
     "build:treesun": "npm run build:es5 -- --environment treesun",
     "build:types": "npm run build:dts && node utils/types-fixup.mjs && rollup -c --environment target:types && node utils/types-undollar.mjs && npm run build:types:extras",
-    "build:types:extras": "tsc extras/index.js --allowJs --declaration --emitDeclarationOnly --outDir build/playcanvas-extras",
+    "build:types:extras": "npm run build:dts:extras",
     "build:sourcemaps": "npm run build -- -m",
     "build:publish": "npm run build && npm run build:types",
     "watch": "npm run build -- -w",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,7 +14,8 @@ console.log(`Building PlayCanvas Engine v${version} revision ${revision}`);
 
 const target_extras = [
     scriptTarget('pcx', 'extras/index.js', 'build/playcanvas-extras.js'),
-    scriptTargetEs6('pcx', 'extras/index.js', 'build/playcanvas-extras'),
+    scriptTargetEs6('pcx', 'extras/index.js', 'build/playcanvas-extras', false),
+    scriptTargetEs6('pcx', 'extras/index.js', 'build/playcanvas-extras.mjs', true),
     scriptTarget('VoxParser', 'scripts/parsers/vox-parser.mjs')
 ];
 

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -11,7 +11,7 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import { shaderChunks } from './rollup-shader-chunks.mjs';
 import { engineLayerImportValidation } from './rollup-import-validation.mjs';
 import { spacesToTabs } from './rollup-spaces-to-tabs.mjs';
-import { dynamicImportTransform } from './rollup-dynamic-import-transform.mjs';
+import { dynamicImportLegacyBrowserSupport, dynamicImportViteSupress } from './rollup-dynamic-import-transform.mjs';
 
 import { version, revision } from './rollup-version-revision.mjs';
 import { getBanner } from './rollup-get-banner.mjs';
@@ -178,11 +178,12 @@ function buildTarget(buildType, moduleFormat, input = 'src/index.js', buildDir =
         output: outputOptions,
         plugins: [
             jscc(jsccParam),
-            moduleFormat === 'es5' ? dynamicImportTransform() : undefined,
+            moduleFormat === 'es5' ? dynamicImportLegacyBrowserSupport() : undefined,
             shaderChunks({ enabled: buildType !== 'debug' }),
             engineLayerImportValidation(input, buildType === 'debug'),
             buildType !== 'debug' ? strip(stripOptions) : undefined,
             babel(babelOptions[moduleFormat]),
+            moduleFormat === 'es6' && buildType !== 'debug' ? dynamicImportViteSupress() : undefined,
             spacesToTabs(buildType !== 'debug')
         ]
     };

--- a/utils/rollup-dynamic-import-transform.mjs
+++ b/utils/rollup-dynamic-import-transform.mjs
@@ -4,11 +4,12 @@
  * without support for dynamic imports.
  *
  * Note that whilst this will prevent parsing errors, it can trigger CSP errors.
+ *
+ * @returns {import('rollup').Plugin} The rollup plugin
  */
-
-export function dynamicImportTransform() {
+export function dynamicImportLegacyBrowserSupport() {
     return {
-        name: 'dynamic-import-transform',
+        name: 'dynamic-import-old-browsers',
         transform(code, id) {
             /**
              * Transforms the code by replacing `import(` with `new Function("return import")(`.
@@ -18,6 +19,30 @@ export function dynamicImportTransform() {
              */
             return {
                 code: code.replace(/([^\w])import\(/g, '$1new Function("modulePath", "return import(modulePath)")('),
+                map: null
+            };
+        }
+    };
+}
+
+/**
+ * This rollup plugin transform code with import statements and adds a \/* vite-ignore *\/ comment to supress vite warnings
+ * generated from dynamic-import-vars {@link https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations}
+ *
+ * @returns {import('rollup').Plugin} The rollup plugin
+ */
+export function dynamicImportViteSupress() {
+    return {
+        name: 'dynamic-import-vite-suppress',
+        transform(code, id) {
+            /**
+             * Transforms the code by replacing `import(` with `import(\/* vite-ignore *\/(`.
+             * @param {string} code - The code to transform.
+             * @param {string} id - The id of the code.
+             * @returns {object} - The transformed code and map.
+             */
+            return {
+                code: code.replace(/([^\w])import\(/g, '$1import(/* @vite-ignore */'),
                 map: null
             };
         }

--- a/utils/rollup-script-target-es6.mjs
+++ b/utils/rollup-script-target-es6.mjs
@@ -7,6 +7,7 @@ import { moduleOptions } from './rollup-module-options.mjs';
 import { spacesToTabs } from './rollup-spaces-to-tabs.mjs';
 
 /** @typedef {import('rollup').RollupOptions} RollupOptions */
+/** @typedef {import('rollup').OutputOptions} OutputOptions */
 
 /**
  * Build an ES6 target that rollup is supposed to build.
@@ -14,19 +15,23 @@ import { spacesToTabs } from './rollup-spaces-to-tabs.mjs';
  * @param {string} name - The name, like `pcx` or `VoxParser`.
  * @param {string} input - The input file, like `extras/index.js`.
  * @param {string} output - The output file, like `build/playcanvas-extras.mjs`.
+ * @param {Boolean} [shouldBundle] - Whether the target should be bundled.
  * @returns {RollupOptions} One rollup target.
  */
-function scriptTargetEs6(name, input, output) {
+function scriptTargetEs6(name, input, output, shouldBundle = false) {
+    /** @type {OutputOptions} */
+    const outputOptions = {
+        name: name,
+        banner: getBanner(''),
+        format: 'es',
+        indent: '\t',
+        preserveModules: !shouldBundle
+    };
+    outputOptions[shouldBundle ? 'file' : 'dir'] = output;
+
     return {
         input: input,
-        output: {
-            name: name,
-            banner: getBanner(''),
-            dir: output,
-            format: 'es',
-            indent: '\t',
-            preserveModules: true
-        },
+        output: outputOptions,
         plugins: [
             resolve(),
             babel(moduleOptions('release')),


### PR DESCRIPTION
Fixes #6105

- Adds `import` and `require` to `package.json` for importing in svelte
- Adds plugin to add `/* @vite-ignore */` to dynamic imports to suppress vite warning for failed `dynamic-import-vars` plugin resolution
- Adds `import` and `require` for path extras & bundled module (required `playcanvas` recursive dependency in `package.json`)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
