### PR TITLE
Update banner to mention MIT license

### DIFF
--- a/utils/rollup-get-banner.mjs
+++ b/utils/rollup-get-banner.mjs
@@ -7,13 +7,14 @@ import { version, revision } from './rollup-version-revision.mjs';
  * @returns {string} - The banner.
  */
 function getBanner(config) {
-    return [
-        '/**',
-        ' * @license',
-        ' * PlayCanvas Engine v' + version + ' revision ' + revision + config,
-        ' * Copyright 2011-' + new Date().getFullYear() + ' PlayCanvas Ltd. All rights reserved.',
-        ' */'
-    ].join('\n');
+    return `/**
+ * @license
+ * PlayCanvas Engine v${version} revision ${revision}${config}
+ * Copyright 2011-${new Date().getFullYear()} PlayCanvas Ltd. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */`;
 }
 
 export { getBanner };


### PR DESCRIPTION
Update built engine banner to explicitly call out that the build is under an MIT license.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
