### PR TITLE
ScriptType handlers type fix

### DIFF
--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -356,39 +356,37 @@ class ScriptType extends EventHandler {
     }
 
     /**
-     * @function
-     * @name ScriptType#[initialize]
-     * @description Called when script is about to run for the first time.
+     * Called when script is about to run for the first time.
      */
+    initialize() {}
 
     /**
-     * @function
-     * @name ScriptType#[postInitialize]
-     * @description Called after all initialize methods are executed in the same tick or enabling chain of actions.
+     * Called after all initialize methods are executed in the same tick or enabling chain of actions.
      */
+    postInitialize() {}
 
     /**
-     * @function
-     * @name ScriptType#[update]
-     * @description Called for enabled (running state) scripts on each tick.
+     * Called for enabled (running state) scripts on each tick.
+     *
      * @param {number} dt - The delta time in seconds since the last frame.
      */
+    update(dt) {}
 
     /**
-     * @function
-     * @name ScriptType#[postUpdate]
-     * @description Called for enabled (running state) scripts on each tick, after update.
+     * Called for enabled (running state) scripts on each tick, after update.
+     *
      * @param {number} dt - The delta time in seconds since the last frame.
      */
+    postUpdate(dt) {}
 
     /**
-     * @function
-     * @name ScriptType#[swap]
-     * @description Called when a ScriptType that already exists in the registry
+     * Called when a ScriptType that already exists in the registry
      * gets redefined. If the new ScriptType has a `swap` method in its prototype,
      * then it will be executed to perform hot-reload at runtime.
+     *
      * @param {ScriptType} old - Old instance of the scriptType to copy data to the new instance.
      */
+    swap(old) {}
 }
 
 export { ScriptType };

--- a/utils/types-fixup.mjs
+++ b/utils/types-fixup.mjs
@@ -525,34 +525,3 @@ import { BoundingBox } from '../../core/shape/bounding-box.js';
 import { Texture } from '../../platform/graphics/texture.js';
 `;
 fs.writeFileSync(path, dts);
-
-path = './types/framework/script/script-type.d.ts';
-dts = fs.readFileSync(path, 'utf8');
-dts = dts.replace('get enabled(): boolean;', `get enabled(): boolean;
-    /**
-     * Called when script is about to run for the first time.
-     */
-    initialize?(): void;
-    /**
-     * Called after all initialize methods are executed in the same tick or enabling chain of actions.
-     */
-    postInitialize?(): void;
-    /**
-     * Called for enabled (running state) scripts on each tick.
-     * @param dt - The delta time in seconds since the last frame.
-     */
-    update?(dt: number): void;
-    /**
-     * Called for enabled (running state) scripts on each tick, after update.
-     * @param dt - The delta time in seconds since the last frame.
-     */
-    postUpdate?(dt: number): void;
-    /**
-     * Called when a ScriptType that already exists in the registry gets redefined. If the new
-     * ScriptType has a \`swap\` method in its prototype, then it will be executed to perform
-     * hot-reload at runtime.
-     * @param old - Old instance of the scriptType to copy data to the new instance.
-     */
-    swap?(old: ScriptType): void;
-`);
-fs.writeFileSync(path, dts);


### PR DESCRIPTION
- Embeds empty `ScriptType` handlers into class to remove post type gen fixup

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
