### PR TITLE
Adding globalThis typeof check

### DIFF
--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -75,7 +75,7 @@ const platform = {
      *
      * @type {object}
      */
-    global: globalThis ??
+    global: (typeof globalThis !== 'undefined' && globalThis) ??
         (environment === 'browser' && window) ??
         (environment === 'node' && global) ??
         (environment === 'worker' && self),


### PR DESCRIPTION
This PR adds a `typeof` check on globalThis to gracefully fallback on older browsers

Addresses https://github.com/playcanvas/engine/pull/6108#discussion_r1517427432

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
