### PR TITLE
Support for sharpening inside the compose render pass, needed for TAA

### DIFF
--- a/examples/src/examples/graphics/taa/controls.mjs
+++ b/examples/src/examples/graphics/taa/controls.mjs
@@ -45,6 +45,17 @@ export function controls({ observer, ReactPCUI, React, jsx, fragment }) {
             ),
             jsx(
                 LabelGroup,
+                { text: 'sharpness' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.scene.sharpness' },
+                    min: 0,
+                    max: 1,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
                 { text: 'jitter' },
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),

--- a/examples/src/examples/graphics/taa/example.mjs
+++ b/examples/src/examples/graphics/taa/example.mjs
@@ -163,15 +163,20 @@ assetListLoader.load(() => {
         if (noPasses || taaEnabled !== currentOptions.taaEnabled) {
             currentOptions.taaEnabled = taaEnabled;
 
+            // TAA has been flipped, setup sharpening appropriately
+            data.set('data.scene.sharpness', taaEnabled ? 1 : 0);
+
             // create new pass
             setupRenderPass();
         }
-
 
         // apply all runtime settings
         const renderPassCamera = cameraEntity.camera.renderPasses[0];
         renderPassCamera.renderTargetScale = data.get('data.scene.scale');
         renderPassCamera.bloomEnabled = data.get('data.scene.bloom');
+
+        const composePass = renderPassCamera.composePass;
+        composePass.sharpness = data.get('data.scene.sharpness');
 
         // taa - enable camera jitter if taa is enabled
         cameraEntity.camera.jitter = taaEnabled ? data.get('data.taa.jitter') : 0;
@@ -188,6 +193,7 @@ assetListLoader.load(() => {
         scene: {
             scale: 1,
             bloom: true,
+            sharpness: 0.5,
             tonemapping: pc.TONEMAP_ACES
         },
         taa: {

--- a/extras/render-passes/render-pass-compose.js
+++ b/extras/render-passes/render-pass-compose.js
@@ -1,13 +1,21 @@
 import {
+    math,
     Color,
     RenderPassShaderQuad,
     shaderChunks,
     TONEMAP_LINEAR, TONEMAP_FILMIC, TONEMAP_HEJL, TONEMAP_ACES, TONEMAP_ACES2
 } from "playcanvas";
 
-const fragmentShader = `
+// Contrast Adaptive Sharpening (CAS) is used to apply the sharpening. It's based on AMD's
+// FidelityFX CAS, WebGL implementation: https://www.shadertoy.com/view/wtlSWB. It's best to run it
+// on a tone-mapped color buffer after post-processing, but before the UI, and so this is the
+// obvious place to put it to avoid a separate render pass, even though we need to handle running it
+// before the tone-mapping.
+
+const fragmentShader = /* glsl */ `
     varying vec2 uv0;
     uniform sampler2D sceneTexture;
+    uniform vec2 sceneTextureInvRes;
 
     #ifdef BLOOM
         uniform sampler2D bloomTexture;
@@ -68,6 +76,41 @@ const fragmentShader = `
 
     #endif
 
+    #ifdef CAS
+
+        uniform float sharpness;
+
+        // reversible LDR <-> HDR tone mapping, as CAS needs LDR input
+        // based on: https://gpuopen.com/learn/optimized-reversible-tonemapper-for-resolve/
+        float maxComponent(float x, float y, float z) { return max(x, max(y, z)); }
+        vec3 toSDR(vec3 c) { return c / (1.0 + maxComponent(c.r, c.g, c.b)); }
+        vec3 toHDR(vec3 c) { return c / (1.0 - maxComponent(c.r, c.g, c.b)); }
+
+        vec3 cas(vec3 color, vec2 uv, float sharpness) {
+
+            float x = sceneTextureInvRes.x;
+            float y = sceneTextureInvRes.y;
+
+            // sample 4 neighbors around the already sampled pixel, and convert it to SDR
+            vec3 a = toSDR(texture2DLodEXT(sceneTexture, uv + vec2(0.0, -y), 0.0).rgb);
+            vec3 b = toSDR(texture2DLodEXT(sceneTexture, uv + vec2(-x, 0.0), 0.0).rgb);
+            vec3 c = toSDR(color.rgb);
+            vec3 d = toSDR(texture2DLodEXT(sceneTexture, uv + vec2(x, 0.0), 0.0).rgb);
+            vec3 e = toSDR(texture2DLodEXT(sceneTexture, uv + vec2(0.0, y), 0.0).rgb);
+
+            // apply the sharpening
+            float min_g = min(a.g, min(b.g, min(c.g, min(d.g, e.g))));
+            float max_g = max(a.g, max(b.g, max(c.g, max(d.g, e.g))));
+            float sharpening_amount = sqrt(min(1.0 - max_g, min_g) / max_g);
+            float w = sharpening_amount * sharpness;
+            vec3 res = (w * (a + b + d + e) + c) / (4.0 * w + 1.0);
+
+            // convert back to HDR
+            return toHDR(res);
+        }
+
+    #endif
+
     void main() {
 
         vec2 uv = uv0;
@@ -79,15 +122,19 @@ const fragmentShader = `
         #endif
         #endif
 
-        vec4 scene = texture2D(sceneTexture, uv);
+        vec4 scene = texture2DLodEXT(sceneTexture, uv, 0.0);
         vec3 result = scene.rgb;
+
+        #ifdef CAS
+            result = cas(result, uv, sharpness);
+        #endif
 
         #ifdef FRINGING
             result = fringing(uv, result);
         #endif
 
         #ifdef BLOOM
-            vec3 bloom = texture2D(bloomTexture, uv).rgb;
+            vec3 bloom = texture2DLodEXT(bloomTexture, uv, 0.0).rgb;
             result += bloom * bloomIntensity;
         #endif
 
@@ -142,17 +189,23 @@ class RenderPassCompose extends RenderPassShaderQuad {
 
     _taaEnabled = false;
 
+    _sharpness = 0.5;
+
     _key = '';
 
     constructor(graphicsDevice) {
         super(graphicsDevice);
 
-        this.sceneTextureId = graphicsDevice.scope.resolve('sceneTexture');
-        this.bloomTextureId = graphicsDevice.scope.resolve('bloomTexture');
-        this.bloomIntensityId = graphicsDevice.scope.resolve('bloomIntensity');
-        this.bcsId = graphicsDevice.scope.resolve('brightnessContrastSaturation');
-        this.vignetterParamsId = graphicsDevice.scope.resolve('vignetterParams');
-        this.fringingIntensityId = graphicsDevice.scope.resolve('fringingIntensity');
+        const { scope } = graphicsDevice;
+        this.sceneTextureId = scope.resolve('sceneTexture');
+        this.bloomTextureId = scope.resolve('bloomTexture');
+        this.bloomIntensityId = scope.resolve('bloomIntensity');
+        this.bcsId = scope.resolve('brightnessContrastSaturation');
+        this.vignetterParamsId = scope.resolve('vignetterParams');
+        this.fringingIntensityId = scope.resolve('fringingIntensity');
+        this.sceneTextureInvResId = scope.resolve('sceneTextureInvRes');
+        this.sceneTextureInvResValue = new Float32Array(2);
+        this.sharpnessId = scope.resolve('sharpness');
     }
 
     set bloomTexture(value) {
@@ -232,6 +285,21 @@ class RenderPassCompose extends RenderPassShaderQuad {
         return shaderChunks.tonemappingNonePS;
     }
 
+    set sharpness(value) {
+        if (this._sharpness !== value) {
+            this._sharpness = value;
+            this._shaderDirty = true;
+        }
+    }
+
+    get sharpness() {
+        return this._sharpness;
+    }
+
+    get isSharpnessEnabled() {
+        return this._sharpness > 0;
+    }
+
     postInit() {
         // clear all buffers to avoid them being loaded from memory
         this.setClearColor(Color.BLACK);
@@ -249,7 +317,8 @@ class RenderPassCompose extends RenderPassShaderQuad {
                 `-${this.gradingEnabled ? 'grading' : 'nograding'}` +
                 `-${this.vignetteEnabled ? 'vignette' : 'novignette'}` +
                 `-${this.fringingEnabled ? 'fringing' : 'nofringing'}` +
-                `-${this.taaEnabled ? 'taa' : 'notaa'}`;
+                `-${this.taaEnabled ? 'taa' : 'notaa'}` +
+                `-${this.isSharpnessEnabled ? 'cas' : 'nocas'}`;
 
             if (this._key !== key) {
                 this._key = key;
@@ -259,7 +328,8 @@ class RenderPassCompose extends RenderPassShaderQuad {
                     (this.gradingEnabled ? `#define GRADING\n` : '') +
                     (this.vignetteEnabled ? `#define VIGNETTE\n` : '') +
                     (this.fringingEnabled ? `#define FRINGING\n` : '') +
-                    (this.taaEnabled ? `#define TAA\n` : '');
+                    (this.taaEnabled ? `#define TAA\n` : '') +
+                    (this.isSharpnessEnabled ? `#define CAS\n` : '');
 
                 const fsChunks =
                 shaderChunks.decodePS +
@@ -274,6 +344,9 @@ class RenderPassCompose extends RenderPassShaderQuad {
     execute() {
 
         this.sceneTextureId.setValue(this.sceneTexture);
+        this.sceneTextureInvResValue[0] = 1.0 / this.sceneTexture.width;
+        this.sceneTextureInvResValue[1] = 1.0 / this.sceneTexture.height;
+        this.sceneTextureInvResId.setValue(this.sceneTextureInvResValue);
 
         if (this._bloomTexture) {
             this.bloomTextureId.setValue(this._bloomTexture);
@@ -291,6 +364,10 @@ class RenderPassCompose extends RenderPassShaderQuad {
         if (this._fringingEnabled) {
             // relative to a fixed texture resolution to preserve size regardless of the resolution
             this.fringingIntensityId.setValue(this.fringingIntensity / 1024);
+        }
+
+        if (this.isSharpnessEnabled) {
+            this.sharpnessId.setValue(math.lerp(-0.125, -0.2, this.sharpness));
         }
 
         super.execute();


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4416 (at least reasonably well, for TAA improvements we have a separate ticket)

A compose render pass can optionally apply sharpening. This is useful especially for TAA to recovered the sharpness introduced by the TAA.

Note that the sharpening can be used without TAA as well.

No TAA:
<img width="432" alt="Screenshot 2024-03-12 at 10 45 44" src="https://github.com/playcanvas/engine/assets/59932779/8517ad91-55bf-4440-a132-01565ee07d78">

TAA without sharpening:
<img width="440" alt="Screenshot 2024-03-12 at 10 46 13" src="https://github.com/playcanvas/engine/assets/59932779/d60cd073-2300-4a86-9288-23c40a76e106">

TAA with sharpening:
<img width="436" alt="Screenshot 2024-03-12 at 10 46 40" src="https://github.com/playcanvas/engine/assets/59932779/4dde30b5-83e7-46fe-bca1-8df00e8d4d0d">

References:
https://www.shadertoy.com/view/wtlSWB
https://gpuopen.com/fidelityfx-cas/
https://gpuopen.com/learn/optimized-reversible-tonemapper-for-resolve/
