### PR TITLE
Component properties port to get/set

### DIFF
--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -113,6 +113,19 @@ class Component extends EventHandler {
         const record = this.system.store[this.entity.getGuid()];
         return record ? record.data : null;
     }
+
+    /**
+     * TODO: implement once all classes are upgraded.
+     *
+     * @type {boolean}
+     * @ignore
+     */
+    set enabled(arg) {
+    }
+
+    get enabled() {
+        return true;
+    }
 }
 
 export { Component };

--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -4,7 +4,6 @@ import { EventHandler } from '../../core/event-handler.js';
  * Components are used to attach functionality on a {@link Entity}. Components can receive update
  * events each frame, and expose properties to the PlayCanvas Editor.
  *
- * @property {boolean} enabled Enables or disables the component.
  * @augments EventHandler
  */
 class Component extends EventHandler {
@@ -115,10 +114,9 @@ class Component extends EventHandler {
     }
 
     /**
-     * TODO: implement once all classes are upgraded.
+     * Enables or disables the component.
      *
      * @type {boolean}
-     * @ignore
      */
     set enabled(arg) {
     }

--- a/utils/types-fixup.mjs
+++ b/utils/types-fixup.mjs
@@ -24,15 +24,6 @@ const getDeclarations = (properties) => {
     return declarations;
 };
 
-// const componentProps = [
-//     ['enabled', 'boolean']
-// ];
-
-// path = './types/framework/components/component.d.ts';
-// dts = fs.readFileSync(path, 'utf8');
-// dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(componentProps));
-// fs.writeFileSync(path, dts);
-
 const buttonComponentProps = [
     ['active', 'boolean'],
     ['fadeDuration', 'number'],

--- a/utils/types-fixup.mjs
+++ b/utils/types-fixup.mjs
@@ -24,14 +24,14 @@ const getDeclarations = (properties) => {
     return declarations;
 };
 
-const componentProps = [
-    ['enabled', 'boolean']
-];
+// const componentProps = [
+//     ['enabled', 'boolean']
+// ];
 
-path = './types/framework/components/component.d.ts';
-dts = fs.readFileSync(path, 'utf8');
-dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(componentProps));
-fs.writeFileSync(path, dts);
+// path = './types/framework/components/component.d.ts';
+// dts = fs.readFileSync(path, 'utf8');
+// dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(componentProps));
+// fs.writeFileSync(path, dts);
 
 const buttonComponentProps = [
     ['active', 'boolean'],


### PR DESCRIPTION
Added enabled base implementation of `get/set` for `enabled` for `Component` base class

- [x] TS linter
- [x] API reference

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

