### PR TITLE
ES6 createScript 

### DIFF
--- a/src/framework/script/script-create.js
+++ b/src/framework/script/script-create.js
@@ -65,19 +65,12 @@ function createScript(name, app) {
     if (reservedScriptNames.has(name))
         throw new Error(`Script name '${name}' is reserved, please rename the script`);
 
-    const scriptType = function (args) {
-        EventHandler.prototype.initEventHandler.call(this);
-        Script.prototype.initScriptType.call(this, args);
-    };
+    class ScriptWithAttributes extends Script {
+        attributes = new ScriptAttributes(ScriptWithAttributes);
+    }
 
-    scriptType.prototype = Object.create(Script.prototype);
-    scriptType.prototype.constructor = scriptType;
-
-    scriptType.extend = Script.extend;
-    scriptType.attributes = new ScriptAttributes(scriptType);
-
-    registerScript(scriptType, name, app);
-    return scriptType;
+    registerScript(ScriptWithAttributes, name, app);
+    return ScriptWithAttributes;
 }
 
 // Editor uses this - migrate to ScriptAttributes.reservedNames and delete this

--- a/src/framework/script/script-create.js
+++ b/src/framework/script/script-create.js
@@ -1,5 +1,4 @@
 import { Debug } from '../../core/debug.js';
-import { EventHandler } from '../../core/event-handler.js';
 
 import { script } from '../script.js';
 import { AppBase } from '../app-base.js';


### PR DESCRIPTION
- Modifies `scriptType` extension of `ScriptType` to use ES6 syntax

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
