### PR TITLE
Add extras.mjs to exported files

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "build/playcanvas.prf.mjs",
     "build/playcanvas.d.ts",
     "build/playcanvas-extras.js",
+    "build/playcanvas-extras.mjs",
     "build/playcanvas-extras/index.js",
     "scripts",
     "LICENSE",


### PR DESCRIPTION
Adds `playcanvas-extras.mjs` to the exported files. Fixes #6152

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
