### PR TITLE
[Fix] reset internal cached state for face culling when the device is restored

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -337,7 +337,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this._contextLostHandler = (event) => {
             event.preventDefault();
-            this.contextLost = true;
             this.loseContext();
             Debug.log('pc.GraphicsDevice: WebGL context lost.');
             this.fire('devicelost');
@@ -345,7 +344,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this._contextRestoredHandler = () => {
             Debug.log('pc.GraphicsDevice: WebGL context restored.');
-            this.contextLost = false;
             this.restoreContext();
             this.fire('devicerestored');
         };
@@ -1229,6 +1227,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
         gl.blendColor(0, 0, 0, 0);
 
         gl.enable(gl.CULL_FACE);
+
+        this.cullFace = gl.BACK;
         gl.cullFace(gl.BACK);
 
         // default depth state
@@ -1321,6 +1321,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
      */
     loseContext() {
 
+        this.contextLost = true;
+
         // force the backbuffer to be recreated on restore
         this.backBufferSize.set(-1, -1);
 
@@ -1355,6 +1357,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @ignore
      */
     restoreContext() {
+
+        this.contextLost = false;
+
         this.initializeExtensions();
         this.initializeCapabilities();
         this.initializeRenderState();


### PR DESCRIPTION
This was causing skydome mesh in some examples to not render after the contest lost and restored, as incorrect face culling mode was believed to be set.