### PR TITLE
Adjust camera clip plane distances for the dispersion example

### DIFF
--- a/examples/src/examples/graphics/dispersion/example.mjs
+++ b/examples/src/examples/graphics/dispersion/example.mjs
@@ -73,7 +73,9 @@ assetListLoader.load(() => {
     // Create an Entity with a camera component
     const camera = new pc.Entity();
     camera.addComponent('camera', {
-        clearColor: new pc.Color(0.2, 0.2, 0.2)
+        clearColor: new pc.Color(0.2, 0.2, 0.2),
+        nearClip: 0.01,
+        farClip: 2
     });
 
     // the color grab pass is needed


### PR DESCRIPTION
The scene is very small (<1) and so the near clipping plane clips at a large distance. Now we can zoom right in.