### PR TITLE
Typedoc hide exported classes

### DIFF
--- a/extras/exporters/core-exporter.js
+++ b/extras/exporters/core-exporter.js
@@ -22,6 +22,7 @@ const textureBlitFragmentShader = `
  * The base class for the exporters, implementing shared functionality.
  *
  * @category Exporter
+ * @ignore
  */
 class CoreExporter {
     /**

--- a/extras/gizmo/mesh-tri-data.js
+++ b/extras/gizmo/mesh-tri-data.js
@@ -14,6 +14,8 @@ const tmpV3 = new Vec3();
 
 /**
  * The class for holding mesh triangle data.
+ *
+ * @ignore
  */
 class MeshTriData {
     /**

--- a/src/framework/xr/xr-mesh.js
+++ b/src/framework/xr/xr-mesh.js
@@ -8,6 +8,7 @@ import { Quat } from "../../core/math/quat.js";
  * change during its lifetime.
  *
  * @category XR
+ * @ignore
  */
 class XrMesh extends EventHandler {
     /**

--- a/src/platform/graphics/gpu-profiler.js
+++ b/src/platform/graphics/gpu-profiler.js
@@ -4,6 +4,8 @@ import { Tracing } from "../../core/tracing.js";
 
 /**
  * Base class of a simple GPU profiler.
+ *
+ * @ignore
  */
 class GpuProfiler {
     /**

--- a/src/platform/graphics/vertex-iterator.js
+++ b/src/platform/graphics/vertex-iterator.js
@@ -71,6 +71,7 @@ function arrayGet4(offset, outputArray, outputIndex) {
  * Helps with accessing a specific vertex attribute.
  *
  * @category Graphics
+ * @ignore
  */
 class VertexIteratorAccessor {
     /**

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -267,7 +267,6 @@ function sleep(ms) {
  * A GamePadButton stores information about a button from the Gamepad API.
  *
  * @category Input
- * @ignore
  */
 class GamePadButton {
     /**
@@ -369,7 +368,6 @@ const dummyButton = Object.freeze(new GamePadButton(0));
  * A GamePad stores information about a gamepad from the Gamepad API.
  *
  * @category Input
- * @hidden
  */
 class GamePad {
     /**

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -267,6 +267,7 @@ function sleep(ms) {
  * A GamePadButton stores information about a button from the Gamepad API.
  *
  * @category Input
+ * @ignore
  */
 class GamePadButton {
     /**
@@ -368,6 +369,7 @@ const dummyButton = Object.freeze(new GamePadButton(0));
  * A GamePad stores information about a gamepad from the Gamepad API.
  *
  * @category Input
+ * @hidden
  */
 class GamePad {
     /**

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -7,6 +7,7 @@ import { SkyMesh } from "./sky-mesh.js";
  * Implementation of the sky.
  *
  * @category Graphics
+ * @ignore
  */
 class Sky {
     /**


### PR DESCRIPTION
Added ignore jsdoc to non-exported classes

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
