### PR TITLE
Hide data getter overrides in LightComponent and ParticleSystemComponent

### DIFF
--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -57,6 +57,7 @@ class LightComponent extends Component {
     // TODO: Remove this override in upgrading component
     /**
      * @type {import('./data.js').LightComponentData}
+     * @ignore
      */
     get data() {
         const record = this.system.store[this.entity.getGuid()];

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -141,6 +141,7 @@ class ParticleSystemComponent extends Component {
     // TODO: Remove this override in upgrading component
     /**
      * @type {import('./data.js').ParticleSystemComponentData}
+     * @ignore
      */
     get data() {
         const record = this.system.store[this.entity.getGuid()];


### PR DESCRIPTION
Ignored override for `data` in light and particle components.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
