### PR TITLE
CollisionComponent properties port to get/set 

### DIFF
--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -24,37 +24,6 @@ const _quat = new Quat();
  * | **Rigid Body (Dynamic or Kinematic)** | <ul><li>contact</li><li>collisionstart</li><li>collisionend</li></ul> | <ul><li>contact</li><li>collisionstart</li><li>collisionend</li></ul> | <ul><li>triggerenter</li><li>triggerleave</li></ul> |
  * | **Trigger Volume**                    |                                                                       | <ul><li>triggerenter</li><li>triggerleave</li></ul>                   |                                                     |
  *
- * @property {string} type The type of the collision volume. Can be:
- *
- * - "box": A box-shaped collision volume.
- * - "capsule": A capsule-shaped collision volume.
- * - "compound": A compound shape. Any descendant entities with a collision component
- * of type box, capsule, cone, cylinder or sphere will be combined into a single, rigid
- * shape.
- * - "cone": A cone-shaped collision volume.
- * - "cylinder": A cylinder-shaped collision volume.
- * - "mesh": A collision volume that uses a model asset as its shape.
- * - "sphere": A sphere-shaped collision volume.
- *
- * Defaults to "box".
- * @property {Vec3} halfExtents The half-extents of the
- * box-shaped collision volume in the x, y and z axes. Defaults to [0.5, 0.5, 0.5].
- * @property {Vec3} linearOffset The positional offset of the collision shape from the Entity position along the local axes.
- * Defaults to [0, 0, 0].
- * @property {Quat} angularOffset The rotational offset of the collision shape from the Entity rotation in local space.
- * Defaults to identity.
- * @property {number} radius The radius of the sphere, capsule, cylinder or cone-shaped collision
- * volumes. Defaults to 0.5.
- * @property {number} axis The local space axis with which the capsule, cylinder or cone-shaped
- * collision volume's length is aligned. 0 for X, 1 for Y and 2 for Z. Defaults to 1 (Y-axis).
- * @property {number} height The total height of the capsule, cylinder or cone-shaped collision
- * volume from tip to tip. Defaults to 2.
- * @property {Asset|number} asset The asset for the model of the mesh collision volume - can also
- * be an asset id. Defaults to null.
- * @property {Asset|number} renderAsset The render asset of the mesh collision volume - can also be
- * an asset id. Defaults to null. If not set then the asset property will be checked instead.
- * @property {import('../../../scene/model.js').Model} model The model that is added to the scene
- * graph for the mesh collision volume.
  * @augments Component
  * @category Physics
  */
@@ -150,6 +119,220 @@ class CollisionComponent extends Component {
         this.on('set_render', this.onSetRender, this);
     }
 
+    // TODO: Remove this override in upgrading component
+    /**
+     * @type {import('./data.js').CollisionComponentData}
+     * @ignore
+     */
+    get data() {
+        const record = this.system.store[this.entity.getGuid()];
+        return record ? record.data : null;
+    }
+
+    /**
+     * @type {boolean}
+     */
+    set enabled(arg) {
+        this._setValue('enabled', arg);
+    }
+
+    get enabled() {
+        return this.data.enabled;
+    }
+
+    /**
+     * The type of the collision volume. Can be:
+     *
+     * - "box": A box-shaped collision volume.
+     * - "capsule": A capsule-shaped collision volume.
+     * - "compound": A compound shape. Any descendant entities with a collision component  of type
+     * box, capsule, cone, cylinder or sphere will be combined into a single, rigid  shape.
+     * - "cone": A cone-shaped collision volume.  - "cylinder": A cylinder-shaped collision volume.
+     * - "mesh": A collision volume that uses a model asset as its shape.
+     * - "sphere": A sphere-shaped collision volume.
+     *
+     * Defaults to "box".
+     *
+     * @type {string}
+     */
+    set type(arg) {
+        this._setValue('type', arg);
+    }
+
+    get type() {
+        return this.data.type;
+    }
+
+    /**
+     * The half-extents of the  box-shaped collision volume in the x, y and z axes. Defaults to
+     * [0.5, 0.5, 0.5].
+     *
+     * @type {Vec3}
+     */
+    set halfExtents(arg) {
+        this._setValue('halfExtents', arg);
+    }
+
+    get halfExtents() {
+        return this.data.halfExtents;
+    }
+
+    /**
+     * The positional offset of the collision shape from the Entity position along the local axes.
+     * Defaults to [0, 0, 0].
+     *
+     * @type {Vec3}
+     */
+    set linearOffset(arg) {
+        this._setValue('linearOffset', arg);
+    }
+
+    get linearOffset() {
+        return this.data.linearOffset;
+    }
+
+    /**
+     * The rotational offset of the collision shape from the Entity rotation in local space.
+     * Defaults to identity.
+     *
+     * @type {Quat}
+     */
+    set angularOffset(arg) {
+        this._setValue('angularOffset', arg);
+    }
+
+    get angularOffset() {
+        return this.data.angularOffset;
+    }
+
+    /**
+     * The radius of the sphere, capsule, cylinder or cone-shaped collision  volumes.
+     * Defaults to 0.5.
+     *
+     * @type {number}
+     */
+    set radius(arg) {
+        this._setValue('radius', arg);
+    }
+
+    get radius() {
+        return this.data.radius;
+    }
+
+    /**
+     * The local space axis with which the capsule, cylinder or cone-shaped  collision volume's
+     * length is aligned. 0 for X, 1 for Y and 2 for Z. Defaults to 1 (Y-axis).
+     *
+     * @type {number}
+     */
+    set axis(arg) {
+        this._setValue('axis', arg);
+    }
+
+    get axis() {
+        return this.data.axis;
+    }
+
+    /**
+     * The total height of the capsule, cylinder or cone-shaped collision  volume from tip to tip.
+     * Defaults to 2.
+     *
+     * @type {number}
+     */
+    set height(arg) {
+        this._setValue('height', arg);
+    }
+
+    get height() {
+        return this.data.height;
+    }
+
+    /**
+     * The asset for the model of the mesh collision volume - can also  be an asset id. Defaults to
+     * null.
+     *
+     * @type {Asset}
+     */
+    set asset(arg) {
+        this._setValue('asset', arg);
+    }
+
+    get asset() {
+        return this.data.asset;
+    }
+
+    /**
+     * The render asset of the mesh collision volume - can also be  an asset id. Defaults to null.
+     * If not set then the asset property will be checked instead.
+     *
+     * @type {Asset | number}
+     */
+    set renderAsset(arg) {
+        this._setValue('renderAsset', arg);
+    }
+
+    get renderAsset() {
+        return this.data.renderAsset;
+    }
+
+    /**
+     * @type {any}
+     * @ignore
+     */
+    set shape(arg) {
+        this._setValue('shape', arg);
+    }
+
+    get shape() {
+        return this.data.shape;
+    }
+
+    /**
+     * The model that is added to the scene graph for the mesh collision volume.
+     *
+     * @type {import('../../../scene/model.js').Model | null}
+     */
+    set model(arg) {
+        this._setValue('model', arg);
+    }
+
+    get model() {
+        return this.data.model;
+    }
+
+    /**
+     * @type {any}
+     * @ignore
+     */
+    set render(arg) {
+        this._setValue('render', arg);
+    }
+
+    get render() {
+        return this.data.render;
+    }
+
+    /**
+     * Enable checking for duplicate vertices.
+     *
+     * @type {boolean}
+     */
+    set checkVertexDuplicates(arg) {
+        this._setValue('checkVertexDuplicates', arg);
+    }
+
+    get checkVertexDuplicates() {
+        return this.data.checkVertexDuplicates;
+    }
+
+    /** @ignore */
+    _setValue(name, value) {
+        const data = this.data;
+        const oldValue = data[name];
+        data[name] = value;
+        this.fire('set', name, oldValue, value);
+    }
+
     /**
      * @param {string} name - Property name.
      * @param {*} oldValue - Previous value of the property.
@@ -182,7 +365,9 @@ class CollisionComponent extends Component {
      * @private
      */
     onSetOffset(name, oldValue, newValue) {
-        this._hasOffset = !this.data.linearOffset.equals(Vec3.ZERO) || !this.data.angularOffset.equals(Quat.IDENTITY);
+        this._hasOffset =
+            !this.data.linearOffset.equals(Vec3.ZERO) ||
+            !this.data.angularOffset.equals(Quat.IDENTITY);
 
         if (this.data.initialized) {
             this.system.recreatePhysicalShapes(this);
@@ -197,7 +382,10 @@ class CollisionComponent extends Component {
      */
     onSetRadius(name, oldValue, newValue) {
         const t = this.data.type;
-        if (this.data.initialized && (t === 'sphere' || t === 'capsule' || t === 'cylinder' || t === 'cone')) {
+        if (
+            this.data.initialized &&
+            (t === 'sphere' || t === 'capsule' || t === 'cylinder' || t === 'cone')
+        ) {
             this.system.recreatePhysicalShapes(this);
         }
     }
@@ -384,8 +572,7 @@ class CollisionComponent extends Component {
         // and there is no change of compoundParent, then update child transform
         // once updateChildTransform is exposed in ammo.js
 
-        if (typeof Ammo === 'undefined')
-            return;
+        if (typeof Ammo === 'undefined') return;
 
         if (this._compoundParent) {
             this.system.recreatePhysicalShapes(this);
@@ -412,25 +599,24 @@ class CollisionComponent extends Component {
             let dirty = entity._dirtyLocal;
             let parent = entity;
             while (parent && !dirty) {
-                if (parent.collision && parent.collision === this._compoundParent)
-                    break;
+                if (parent.collision && parent.collision === this._compoundParent) break;
 
-                if (parent._dirtyLocal)
-                    dirty = true;
+                if (parent._dirtyLocal) dirty = true;
 
                 parent = parent.parent;
             }
 
             if (dirty) {
-                entity.forEach(this.system.implementations.compound._updateEachDescendantTransform, entity);
+                entity.forEach(
+                    this.system.implementations.compound._updateEachDescendantTransform,
+                    entity
+                );
 
                 const bodyComponent = this._compoundParent.entity.rigidbody;
-                if (bodyComponent)
-                    bodyComponent.activate();
+                if (bodyComponent) bodyComponent.activate();
             }
         }
     }
-
 
     /**
      * @description Returns the world position for the collision shape taking into account of any offsets.
@@ -464,9 +650,12 @@ class CollisionComponent extends Component {
         return rot;
     }
 
-    /** @private */
     onEnable() {
-        if (this.data.type === 'mesh' && (this.data.asset || this.data.renderAsset) && this.data.initialized) {
+        if (
+            this.data.type === 'mesh' &&
+            (this.data.asset || this.data.renderAsset) &&
+            this.data.initialized
+        ) {
             const asset = this.system.app.assets.get(this.data.asset || this.data.renderAsset);
             // recreate the collision shape if the model asset is not loaded
             // or the shape does not exist
@@ -484,7 +673,10 @@ class CollisionComponent extends Component {
             if (this._compoundParent.shape.getNumChildShapes() === 0) {
                 this.system.recreatePhysicalShapes(this._compoundParent);
             } else {
-                const transform = this.system._getNodeTransform(this.entity, this._compoundParent.entity);
+                const transform = this.system._getNodeTransform(
+                    this.entity,
+                    this._compoundParent.entity
+                );
                 this._compoundParent.shape.addChildShape(transform, this.data.shape);
                 Ammo.destroy(transform);
 
@@ -496,7 +688,6 @@ class CollisionComponent extends Component {
         }
     }
 
-    /** @private */
     onDisable() {
         if (this.entity.rigidbody) {
             this.entity.rigidbody.disableSimulation();

--- a/src/framework/components/collision/data.js
+++ b/src/framework/components/collision/data.js
@@ -11,12 +11,17 @@ class CollisionComponentData {
         this.radius = 0.5;
         this.axis = 1;
         this.height = 2;
+        /** @type {import('../../../framework/asset/asset.js').Asset | number} */
+        // @ts-ignore
         this.asset = null;
+        /** @type {import('../../../framework/asset/asset.js').Asset | number} */
+        // @ts-ignore
         this.renderAsset = null;
         this.checkVertexDuplicates = true;
 
         // Non-serialized properties
         this.shape = null;
+        /** @type {import('../../../scene/model.js').Model | null} */
         this.model = null;
         this.render = null;
         this.initialized = false;

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -9,7 +9,6 @@ import { SEMANTIC_POSITION } from '../../../platform/graphics/constants.js';
 import { GraphNode } from '../../../scene/graph-node.js';
 import { Model } from '../../../scene/model.js';
 
-import { Component } from '../component.js';
 import { ComponentSystem } from '../system.js';
 
 import { CollisionComponent } from './component.js';
@@ -887,7 +886,5 @@ class CollisionComponentSystem extends ComponentSystem {
         super.destroy();
     }
 }
-
-Component._buildAccessors(CollisionComponent.prototype, _schema);
 
 export { CollisionComponentSystem };

--- a/utils/types-fixup.mjs
+++ b/utils/types-fixup.mjs
@@ -52,25 +52,6 @@ import { Asset } from '../../../framework/asset/asset.js';
 `;
 fs.writeFileSync(path, dts);
 
-const collisionComponentProps = [
-    ['axis', 'number'],
-    ['halfExtents', 'Vec3'],
-    ['height', 'number'],
-    ['model', 'Model|null'],
-    ['radius', 'number'],
-    ['type', 'string']
-];
-
-path = './types/framework/components/collision/component.d.ts';
-dts = fs.readFileSync(path, 'utf8');
-dts = dts.replace(regexConstructor, '$&\n' + getDeclarations(collisionComponentProps));
-// We need to import types that are newly introduced in the property list above
-dts += `
-import { Vec3 } from '../../../core/math/vec3.js';
-import { Model } from '../../../scene/model.js';
-`;
-fs.writeFileSync(path, dts);
-
 const elementComponentProps = [
     ['alignment', 'Vec2'],
     ['autoFitHeight', 'boolean'],


### PR DESCRIPTION
Port of `CollisionComponent` from using `Object.defineProperty` to using `get/set`

- [x] TS linter
- [x] API reference

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
