### PR TITLE
Removed circular self dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,8 +105,7 @@
   ],
   "dependencies": {
     "@types/webxr": "^0.5.14",
-    "@webgpu/types": "^0.1.40",
-    "playcanvas": "file:."
+    "@webgpu/types": "^0.1.40"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",


### PR DESCRIPTION
Fixes yarn install issue https://forum.playcanvas.com/t/engine-release-v1-69-0/35174/12

Removes circular dependency `file:.` in `package.json` 

N.B Using extras will now break due to `playcanvas` dependency not being resolved.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
