### PR TITLE
Remove @augments JSDoc tag

### DIFF
--- a/extras/gizmo/rotate-gizmo.js
+++ b/extras/gizmo/rotate-gizmo.js
@@ -21,7 +21,6 @@ const tmpQ2 = new Quat();
 /**
  * Rotation gizmo.
  *
- * @augments TransformGizmo
  * @category Gizmo
  */
 class RotateGizmo extends TransformGizmo {

--- a/extras/gizmo/scale-gizmo.js
+++ b/extras/gizmo/scale-gizmo.js
@@ -9,7 +9,6 @@ import { TransformGizmo } from "./transform-gizmo.js";
 /**
  * Scaling gizmo.
  *
- * @augments TransformGizmo
  * @category Gizmo
  */
 class ScaleGizmo extends TransformGizmo {

--- a/extras/gizmo/transform-gizmo.js
+++ b/extras/gizmo/transform-gizmo.js
@@ -99,7 +99,6 @@ export const SHAPEAXIS_FACE = 'face';
 /**
  * The base class for all transform gizmos.
  *
- * @augments Gizmo
  * @category Gizmo
  */
 class TransformGizmo extends Gizmo {

--- a/extras/gizmo/translate-gizmo.js
+++ b/extras/gizmo/translate-gizmo.js
@@ -15,7 +15,6 @@ const tmpQ1 = new Quat();
 /**
  * Translation gizmo.
  *
- * @augments TransformGizmo
  * @category Gizmo
  */
 class TranslateGizmo extends TransformGizmo {

--- a/src/core/tags.js
+++ b/src/core/tags.js
@@ -3,8 +3,6 @@ import { EventHandler } from './event-handler.js';
 /**
  * Set of tag names. Tags are automatically available on {@link Entity} and {@link Asset} as `tags`
  * field.
- *
- * @augments EventHandler
  */
 class Tags extends EventHandler {
     /**

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -105,8 +105,6 @@ let app = null;
  *
  * If you are using the Engine without the Editor, you have to create the application instance
  * manually.
- *
- * @augments EventHandler
  */
 class AppBase extends EventHandler {
     /**

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -87,8 +87,6 @@ import { XrManager } from './xr/xr-manager.js';
  *
  * If you are using the Engine without the Editor, you have to create the application instance
  * manually.
- *
- * @augments AppBase
  */
 class Application extends AppBase {
     /**

--- a/src/framework/asset/asset-list-loader.js
+++ b/src/framework/asset/asset-list-loader.js
@@ -20,7 +20,6 @@ import { Asset } from './asset.js';
  * });
  * ```
  *
- * @augments EventHandler
  * @category Asset
  */
 class AssetListLoader extends EventHandler {

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -38,7 +38,6 @@ import { Asset } from './asset.js';
  * Container for all assets that are available to this application. Note that PlayCanvas scripts
  * are provided with an AssetRegistry instance as `app.assets`.
  *
- * @augments EventHandler
  * @category Asset
  */
 class AssetRegistry extends EventHandler {

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -44,7 +44,6 @@ const VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
  *
  * See the {@link AssetRegistry} for details on loading resources from assets.
  *
- * @augments EventHandler
  * @category Asset
  */
 class Asset extends EventHandler {

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -18,7 +18,6 @@ import { AnimTrack } from '../../anim/evaluator/anim-track.js';
 /**
  * The Anim Component allows an Entity to playback animations on models and entity properties.
  *
- * @augments Component
  * @category Animation
  */
 class AnimComponent extends Component {

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -12,7 +12,6 @@ const _schema = [
 /**
  * The AnimComponentSystem manages creating and deleting AnimComponents.
  *
- * @augments ComponentSystem
  * @category Animation
  */
 class AnimComponentSystem extends ComponentSystem {

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -14,7 +14,6 @@ import { Component } from '../component.js';
 /**
  * The Animation Component allows an Entity to playback animations on models.
  *
- * @augments Component
  * @category Animation
  */
 class AnimationComponent extends Component {

--- a/src/framework/components/animation/system.js
+++ b/src/framework/components/animation/system.js
@@ -11,7 +11,6 @@ const _schema = [
 /**
  * The AnimationComponentSystem manages creating and deleting AnimationComponents.
  *
- * @augments ComponentSystem
  * @category Animation
  */
 class AnimationComponentSystem extends ComponentSystem {

--- a/src/framework/components/audio-listener/component.js
+++ b/src/framework/components/audio-listener/component.js
@@ -4,7 +4,6 @@ import { Component } from '../component.js';
  * Represents the audio listener in the 3D world, so that 3D positioned audio sources are heard
  * correctly.
  *
- * @augments Component
  * @category Sound
  */
 class AudioListenerComponent extends Component {

--- a/src/framework/components/audio-listener/system.js
+++ b/src/framework/components/audio-listener/system.js
@@ -11,7 +11,6 @@ const _schema = ['enabled'];
 /**
  * Component System for adding and removing {@link AudioListenerComponent} objects to Entities.
  *
- * @augments ComponentSystem
  * @category Sound
  */
 class AudioListenerComponentSystem extends ComponentSystem {

--- a/src/framework/components/audio-source/component.js
+++ b/src/framework/components/audio-source/component.js
@@ -30,7 +30,7 @@ import { Component } from '../component.js';
  * stops. Note the volume of the audio is not 0 after this distance, but just doesn't fall off
  * anymore.
  * @property {number} rollOffFactor The factor used in the falloff equation.
- * @augments Component
+ *
  * @ignore
  */
 class AudioSourceComponent extends Component {

--- a/src/framework/components/audio-source/system.js
+++ b/src/framework/components/audio-source/system.js
@@ -30,7 +30,6 @@ const _schema = [
  * Controls playback of an audio sample. This class will be deprecated in favor of
  * {@link SoundComponentSystem}.
  *
- * @augments ComponentSystem
  * @ignore
  */
 class AudioSourceComponentSystem extends ComponentSystem {

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -39,7 +39,6 @@ STATES_TO_SPRITE_FRAME_NAMES[VisualState.INACTIVE] = 'inactiveSpriteFrame';
  * A ButtonComponent enables a group of entities to behave like a button, with different visual
  * states for hover and press interactions.
  *
- * @augments Component
  * @category User Interface
  */
 class ButtonComponent extends Component {

--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -24,7 +24,6 @@ const _schema = [
 /**
  * Manages creation of {@link ButtonComponent}s.
  *
- * @augments ComponentSystem
  * @category User Interface
  */
 class ButtonComponentSystem extends ComponentSystem {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -37,7 +37,6 @@ import { PostEffectQueue } from './post-effect-queue.js';
  * entity.camera.nearClip = 2;
  * ```
  *
- * @augments Component
  * @category Graphics
  */
 class CameraComponent extends Component {

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -14,7 +14,6 @@ const _schema = ['enabled'];
  * Used to add and remove {@link CameraComponent}s from Entities. It also holds an array of all
  * active cameras.
  *
- * @augments ComponentSystem
  * @category Graphics
  */
 class CameraComponentSystem extends ComponentSystem {

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -24,7 +24,6 @@ const _quat = new Quat();
  * | **Rigid Body (Dynamic or Kinematic)** | <ul><li>contact</li><li>collisionstart</li><li>collisionend</li></ul> | <ul><li>contact</li><li>collisionstart</li><li>collisionend</li></ul> | <ul><li>triggerenter</li><li>triggerleave</li></ul> |
  * | **Trigger Volume**                    |                                                                       | <ul><li>triggerenter</li><li>triggerleave</li></ul>                   |                                                     |
  *
- * @augments Component
  * @category Physics
  */
 class CollisionComponent extends Component {

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -617,7 +617,6 @@ class CollisionCompoundSystemImpl extends CollisionSystemImpl {
 /**
  * Manages creation of {@link CollisionComponent}s.
  *
- * @augments ComponentSystem
  * @category Physics
  */
 class CollisionComponentSystem extends ComponentSystem {

--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -3,8 +3,6 @@ import { EventHandler } from '../../core/event-handler.js';
 /**
  * Components are used to attach functionality on a {@link Entity}. Components can receive update
  * events each frame, and expose properties to the PlayCanvas Editor.
- *
- * @augments EventHandler
  */
 class Component extends EventHandler {
     /**

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -75,7 +75,6 @@ const matD = new Mat4();
  * - [Text localization](https://playcanvas.github.io/#/user-interface/text-localization)
  * - [Typewriter text](https://playcanvas.github.io/#/user-interface/text-typewriter)
  *
- * @augments Component
  * @category User Interface
  */
 class ElementComponent extends Component {

--- a/src/framework/components/element/element-drag-helper.js
+++ b/src/framework/components/element/element-drag-helper.js
@@ -25,7 +25,6 @@ const OPPOSITE_AXIS = {
 /**
  * Helper class that makes it easy to create Elements that can be dragged by the mouse or touch.
  *
- * @augments EventHandler
  * @category User Interface
  */
 class ElementDragHelper extends EventHandler {

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -21,7 +21,6 @@ const _schema = ['enabled'];
 /**
  * Manages creation of {@link ElementComponent}s.
  *
- * @augments ComponentSystem
  * @category User Interface
  */
 class ElementComponentSystem extends ComponentSystem {

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -6,7 +6,6 @@ import { Component } from '../component.js';
 /**
  * Enables an Entity to render a Gaussian Splat (asset of the 'gsplat' type).
  *
- * @augments Component
  * @category Graphics
  */
 class GSplatComponent extends Component {

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -21,7 +21,6 @@ const _properties = [
 /**
  * Allows an Entity to render a gsplat.
  *
- * @augments ComponentSystem
  * @category Graphics
  */
 class GSplatComponentSystem extends ComponentSystem {

--- a/src/framework/components/joint/component.js
+++ b/src/framework/components/joint/component.js
@@ -28,7 +28,6 @@ const properties = [
 /**
  * The JointComponent adds a physics joint constraint linking two rigid bodies.
  *
- * @augments Component
  * @ignore
  */
 class JointComponent extends Component {

--- a/src/framework/components/joint/system.js
+++ b/src/framework/components/joint/system.js
@@ -9,7 +9,6 @@ const _schema = ['enabled'];
 /**
  * Creates and manages physics joint components.
  *
- * @augments ComponentSystem
  * @ignore
  */
 class JointComponentSystem extends ComponentSystem {

--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -4,7 +4,6 @@ import { Component } from '../component.js';
  * A LayoutChildComponent enables the Entity to control the sizing applied to it by its parent
  * {@link LayoutGroupComponent}.
  *
- * @augments Component
  * @category User Interface
  */
 class LayoutChildComponent extends Component {

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -9,7 +9,6 @@ const _schema = ['enabled'];
 /**
  * Manages creation of {@link LayoutChildComponent}s.
  *
- * @augments ComponentSystem
  * @category User Interface
  */
 class LayoutChildComponentSystem extends ComponentSystem {

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -20,7 +20,6 @@ function isEnabledAndHasEnabledElement(entity) {
  * A LayoutGroupComponent enables the Entity to position and scale child {@link ElementComponent}s
  * according to configurable layout rules.
  *
- * @augments Component
  * @category User Interface
  */
 class LayoutGroupComponent extends Component {

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -14,7 +14,6 @@ const MAX_ITERATIONS = 100;
 /**
  * Manages creation of {@link LayoutGroupComponent}s.
  *
- * @augments ComponentSystem
  * @category User Interface
  */
 class LayoutGroupComponentSystem extends ComponentSystem {

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -33,7 +33,6 @@ import { properties } from './data.js';
  * entity.light.range = 20;
  * ```
  *
- * @augments Component
  * @category Graphics
  */
 class LightComponent extends Component {

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -12,7 +12,6 @@ import { properties, LightComponentData } from './data.js';
 /**
  * A Light Component is used to dynamically light the scene.
  *
- * @augments ComponentSystem
  * @category Graphics
  */
 class LightComponentSystem extends ComponentSystem {

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -16,7 +16,6 @@ import { Component } from '../component.js';
  * Enables an Entity to render a model or a primitive shape. This Component attaches additional
  * model geometry in to the scene graph below the Entity.
  *
- * @augments Component
  * @category Graphics
  */
 class ModelComponent extends Component {

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -20,7 +20,6 @@ const _schema = ['enabled'];
  * Allows an Entity to render a model or a primitive shape like a box, capsule, sphere, cylinder,
  * cone etc.
  *
- * @augments ComponentSystem
  * @category Graphics
  */
 class ModelComponentSystem extends ComponentSystem {

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -95,7 +95,6 @@ let depthLayer;
  * time. Most of the curve parameters can also be specified by 2 minimum/maximum curves, this way
  * each particle will pick a random value in-between.
  *
- * @augments Component
  * @category Graphics
  */
 class ParticleSystemComponent extends Component {

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -78,7 +78,6 @@ const _schema = [
 /**
  * Allows an Entity to render a particle system.
  *
- * @augments ComponentSystem
  * @category Graphics
  */
 class ParticleSystemComponentSystem extends ComponentSystem {

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -20,7 +20,7 @@ import { EntityReference } from '../../utils/entity-reference.js';
  *
  * @property {import('../../entity.js').Entity} rootBone A reference to the entity to be used as
  * the root bone for any skinned meshes that are rendered by this component.
- * @augments Component
+ *
  * @category Graphics
  */
 class RenderComponent extends Component {

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -37,7 +37,6 @@ const _properties = [
  * Allows an Entity to render a mesh or a primitive shape like a box, capsule, sphere, cylinder,
  * cone etc.
  *
- * @augments ComponentSystem
  * @category Graphics
  */
 class RenderComponentSystem extends ComponentSystem {

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -51,7 +51,6 @@ const _vec3 = new Vec3();
  * - [Falling shapes](https://playcanvas.github.io/#/physics/falling-shapes)
  * - [Vehicle physics](https://playcanvas.github.io/#/physics/vehicle)
  *
- * @augments Component
  * @category Physics
  */
 class RigidBodyComponent extends Component {

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -253,7 +253,6 @@ const _schema = ['enabled'];
  * valid if 3D Physics is enabled in your application. You can enable this in the application
  * settings for your project.
  *
- * @augments ComponentSystem
  * @category Physics
  */
 class RigidBodyComponentSystem extends ComponentSystem {

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -14,7 +14,6 @@ const _transform = new Mat4();
  * A ScreenComponent enables the Entity to render child {@link ElementComponent}s using anchors and
  * positions in the ScreenComponent's space.
  *
- * @augments Component
  * @category User Interface
  */
 class ScreenComponent extends Component {

--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -13,7 +13,6 @@ const _schema = ['enabled'];
 /**
  * Manages creation of {@link ScreenComponent}s.
  *
- * @augments ComponentSystem
  * @category User Interface
  */
 class ScreenComponentSystem extends ComponentSystem {

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -15,7 +15,6 @@ import { Entity } from '../../entity.js';
  * Script Types defined in JavaScript files to be executed with access to the Entity. For more
  * details on scripting see [Scripting](https://developer.playcanvas.com/user-manual/scripting/).
  *
- * @augments Component
  * @category Script
  */
 class ScriptComponent extends Component {

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -20,7 +20,6 @@ let executionOrderCounter = 0;
 /**
  * Allows scripts to be attached to an Entity and executed.
  *
- * @augments ComponentSystem
  * @category Script
  */
 class ScriptComponentSystem extends ComponentSystem {

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -54,7 +54,7 @@ const _tempScrollValue = new Vec2();
  * the vertical scrollbar. This entity must have a Scrollbar component.
  * @property {import('../../entity.js').Entity} verticalScrollbarEntity The entity to be used as
  * the vertical scrollbar. This entity must have a Scrollbar component.
- * @augments Component
+ *
  * @category User Interface
  */
 class ScrollViewComponent extends Component {

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -29,7 +29,6 @@ const DEFAULT_DRAG_THRESHOLD = 10;
 /**
  * Manages creation of {@link ScrollViewComponent}s.
  *
- * @augments ComponentSystem
  * @category User Interface
  */
 class ScrollViewComponentSystem extends ComponentSystem {

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -24,7 +24,7 @@ import { EntityReference } from '../../utils/entity-reference.js';
  * height of the track.
  * @property {import('../../entity.js').Entity} handleEntity The entity to be used as the scrollbar
  * handle. This entity must have a Scrollbar component.
- * @augments Component
+ *
  * @category User Interface
  */
 class ScrollbarComponent extends Component {

--- a/src/framework/components/scrollbar/system.js
+++ b/src/framework/components/scrollbar/system.js
@@ -15,7 +15,6 @@ const _schema = [
 /**
  * Manages creation of {@link ScrollbarComponent}s.
  *
- * @augments ComponentSystem
  * @category User Interface
  */
 class ScrollbarComponentSystem extends ComponentSystem {

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -9,7 +9,6 @@ import { SoundSlot } from './slot.js';
 /**
  * The Sound Component controls playback of {@link Sound}s.
  *
- * @augments Component
  * @category Sound
  */
 class SoundComponent extends Component {

--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -31,7 +31,6 @@ const instanceOptions = {
 /**
  * The SoundSlot controls playback of an audio asset.
  *
- * @augments EventHandler
  * @category Sound
  */
 class SoundSlot extends EventHandler {

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -13,7 +13,6 @@ const _schema = ['enabled'];
 /**
  * Manages creation of {@link SoundComponent}s.
  *
- * @augments ComponentSystem
  * @category Sound
  */
 class SoundComponentSystem extends ComponentSystem {

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -30,7 +30,6 @@ const PARAM_ATLAS_RECT = 'atlasRect';
 /**
  * Enables an Entity to render a simple static sprite or sprite animations.
  *
- * @augments Component
  * @category Graphics
  */
 class SpriteComponent extends Component {

--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -9,7 +9,6 @@ import { SPRITE_RENDERMODE_SIMPLE } from '../../../scene/constants.js';
 /**
  * Handles playing of sprite animations and loading of relevant sprite assets.
  *
- * @augments EventHandler
  * @category Graphics
  */
 class SpriteAnimationClip extends EventHandler {

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -20,7 +20,6 @@ const _schema = ['enabled'];
 /**
  * Manages creation of {@link SpriteComponent}s.
  *
- * @augments ComponentSystem
  * @category Graphics
  */
 class SpriteComponentSystem extends ComponentSystem {

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -8,8 +8,6 @@ import { Vec4 } from '../../core/math/vec4.js';
 /**
  * Component Systems contain the logic and functionality to update all Components of a particular
  * type.
- *
- * @augments EventHandler
  */
 class ComponentSystem extends EventHandler {
     /**

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -9,7 +9,6 @@ import { Component } from '../component.js';
  * performance reasons. And many other possible options. Zones are building blocks and meant to be
  * used in many different ways.
  *
- * @augments Component
  * @ignore
  */
 class ZoneComponent extends Component {

--- a/src/framework/components/zone/system.js
+++ b/src/framework/components/zone/system.js
@@ -11,7 +11,6 @@ const _schema = ['enabled'];
 /**
  * Creates and manages {@link ZoneComponent} instances.
  *
- * @augments ComponentSystem
  * @ignore
  */
 class ZoneComponentSystem extends ComponentSystem {

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -23,8 +23,6 @@ const _enableList = [];
  * e.g. the ability to render a model or play a sound. Components are specific to an instance of an
  * Entity and are attached (e.g. `this.entity.model`) ComponentSystems allow access to all Entities
  * and Components and are attached to the {@link AppBase}.
- *
- * @augments GraphNode
  */
 class Entity extends GraphNode {
     /**

--- a/src/framework/font/canvas-font.js
+++ b/src/framework/font/canvas-font.js
@@ -56,7 +56,6 @@ class Atlas {
 /**
  * Represents the resource of a canvas font asset.
  *
- * @augments EventHandler
  * @ignore
  */
 class CanvasFont extends EventHandler {

--- a/src/framework/handlers/untar.js
+++ b/src/framework/handlers/untar.js
@@ -4,7 +4,6 @@ import { EventHandler } from '../../core/event-handler.js';
  * A utility class for untaring archives from a fetch request. It processes files from a tar file
  * in a streamed manner, so asset parsing can happen in parallel instead of all at once at the end.
  *
- * @augments EventHandler
  * @ignore
  */
 class Untar extends EventHandler {

--- a/src/framework/i18n/i18n.js
+++ b/src/framework/i18n/i18n.js
@@ -19,8 +19,6 @@ import {
  * Handles localization. Responsible for loading localization assets and returning translations for
  * a certain key. Can also handle plural forms. To override its default behavior define a different
  * implementation for {@link I18n#getText} and {@link I18n#getPluralText}.
- *
- * @augments EventHandler
  */
 class I18n extends EventHandler {
     /**

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -164,7 +164,6 @@ class ElementInputEvent {
 /**
  * Represents a Mouse event fired on a {@link ElementComponent}.
  *
- * @augments ElementInputEvent
  * @category User Interface
  */
 class ElementMouseEvent extends ElementInputEvent {
@@ -259,7 +258,6 @@ class ElementMouseEvent extends ElementInputEvent {
 /**
  * Represents a TouchEvent fired on a {@link ElementComponent}.
  *
- * @augments ElementInputEvent
  * @category User Interface
  */
 class ElementTouchEvent extends ElementInputEvent {
@@ -306,7 +304,6 @@ class ElementTouchEvent extends ElementInputEvent {
 /**
  * Represents a XRInputSourceEvent fired on a {@link ElementComponent}.
  *
- * @augments ElementInputEvent
  * @category User Interface
  */
 class ElementSelectEvent extends ElementInputEvent {

--- a/src/framework/script/script-registry.js
+++ b/src/framework/script/script-registry.js
@@ -5,7 +5,6 @@ import { EventHandler } from '../../core/event-handler.js';
  * PlayCanvas scripts can access the Script Registry from inside the application with
  * {@link AppBase#scripts}.
  *
- * @augments EventHandler
  * @category Script
  */
 class ScriptRegistry extends EventHandler {

--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -30,7 +30,6 @@ const funcNameRegex = new RegExp('^\\s*function(?:\\s|\\s*\\/\\*.*\\*\\/\\s*)+([
  * new ScriptType has a `swap` method in its prototype, then it will be executed to perform hot-
  * reload at runtime.
  *
- * @augments EventHandler
  * @category Script
  */
 class ScriptType extends EventHandler {

--- a/src/framework/utils/entity-reference.js
+++ b/src/framework/utils/entity-reference.js
@@ -110,7 +110,6 @@ import { EventHandler } from '../../core/event-handler.js';
  * of the parent component – you should never have to worry about manually calling
  * `Function.bind()`.
  *
- * @augments EventHandler
  * @ignore
  */
 class EntityReference extends EventHandler {

--- a/src/framework/xr/xr-anchor.js
+++ b/src/framework/xr/xr-anchor.js
@@ -25,7 +25,6 @@ import { Quat } from '../../core/math/quat.js';
  * scene in a way that helps with maintaining the illusion that the placed objects are really
  * present in the user’s environment.
  *
- * @augments EventHandler
  * @category XR
  */
 class XrAnchor extends EventHandler {

--- a/src/framework/xr/xr-anchors.js
+++ b/src/framework/xr/xr-anchors.js
@@ -22,7 +22,7 @@ import { XrAnchor } from './xr-anchor.js';
  *     anchors: true
  * });
  * ```
- * @augments EventHandler
+ *
  * @category XR
  */
 class XrAnchors extends EventHandler {

--- a/src/framework/xr/xr-depth-sensing.js
+++ b/src/framework/xr/xr-depth-sensing.js
@@ -2,7 +2,6 @@ import { EventHandler } from '../../core/event-handler.js';
 import { Mat4 } from '../../core/math/mat4.js';
 
 /**
- * @augments EventHandler
  * @category XR
  * @deprecated
  * @ignore

--- a/src/framework/xr/xr-hand.js
+++ b/src/framework/xr/xr-hand.js
@@ -30,7 +30,6 @@ if (platform.browser && window.XRHand) {
 /**
  * Represents a hand with fingers and joints.
  *
- * @augments EventHandler
  * @category XR
  */
 class XrHand extends EventHandler {

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -31,7 +31,7 @@ const poolQuat = [];
  *     }
  * });
  * ```
- * @augments EventHandler
+ *
  * @category XR
  */
 class XrHitTestSource extends EventHandler {

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -18,7 +18,6 @@ import { XrHitTestSource } from './xr-hit-test-source.js';
  * sources: the view, input sources, or an arbitrary ray in space. Results reflect the underlying
  * AR system's understanding of the real world.
  *
- * @augments EventHandler
  * @category XR
  */
 class XrHitTest extends EventHandler {

--- a/src/framework/xr/xr-image-tracking.js
+++ b/src/framework/xr/xr-image-tracking.js
@@ -8,7 +8,6 @@ import { XrTrackedImage } from './xr-tracked-image.js';
  * their estimated sizes. The underlying system will assume that tracked image can move and rotate
  * in the real world and will try to provide transformation estimates and its tracking state.
  *
- * @augments EventHandler
  * @category XR
  */
 class XrImageTracking extends EventHandler {

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -18,7 +18,6 @@ let ids = 0;
  * are not limited to: handheld controllers, optically tracked hands, touch screen taps, and
  * gaze-based input methods that operate on the viewer's pose.
  *
- * @augments EventHandler
  * @category XR
  */
 class XrInputSource extends EventHandler {

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -11,7 +11,6 @@ import { XrInputSource } from './xr-input-source.js';
  * - hands - with their individual joints
  * - transient sources - such as touch screen taps and voice commands
  *
- * @augments EventHandler
  * @category XR
  */
 class XrInput extends EventHandler {

--- a/src/framework/xr/xr-light-estimation.js
+++ b/src/framework/xr/xr-light-estimation.js
@@ -18,7 +18,6 @@ const mat4B = new Mat4();
  * Spherical Harmonics data. And the most simple level of light estimation is the most prominent
  * directional light, its rotation, intensity and color.
  *
- * @augments EventHandler
  * @category XR
  */
 class XrLightEstimation extends EventHandler {

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -36,7 +36,6 @@ import { XrViews } from './xr-views.js';
 /**
  * Manage and update XR session and its states.
  *
- * @augments EventHandler
  * @category XR
  */
 class XrManager extends EventHandler {

--- a/src/framework/xr/xr-tracked-image.js
+++ b/src/framework/xr/xr-tracked-image.js
@@ -7,7 +7,6 @@ import { Quat } from '../../core/math/quat.js';
  * list from {@link XrImageTracking#images}. It contains information about the tracking state as
  * well as the position and rotation of the tracked image.
  *
- * @augments EventHandler
  * @category XR
  */
 class XrTrackedImage extends EventHandler {

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -26,7 +26,6 @@ import { StencilParameters } from './stencil-parameters.js';
  * specific canvas HTML element. It is valid to have more than one canvas element per page and
  * create a new graphics device against each.
  *
- * @augments EventHandler
  * @category Graphics
  */
 class GraphicsDevice extends EventHandler {

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -251,7 +251,6 @@ function testTextureFloatHighPrecision(device) {
  * specific canvas HTML element. It is valid to have more than one canvas element per page and
  * create a new graphics device against each.
  *
- * @augments GraphicsDevice
  * @category Graphics
  */
 class WebglGraphicsDevice extends GraphicsDevice {

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -771,7 +771,6 @@ class GamePad {
 /**
  * Input handler for accessing GamePad input.
  *
- * @augments EventHandler
  * @category Input
  */
 class GamePads extends EventHandler {

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -56,7 +56,6 @@ const _keyCodeToKeyIdentifier = {
  * A Keyboard device bound to an Element. Allows you to detect the state of the key presses. Note
  * that the Keyboard object must be attached to an Element before it can detect any key presses.
  *
- * @augments EventHandler
  * @category Input
  */
 class Keyboard extends EventHandler {

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -13,7 +13,6 @@ import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
 /**
  * A Mouse Device, bound to a DOM Element.
  *
- * @augments EventHandler
  * @category Input
  */
 class Mouse extends EventHandler {

--- a/src/platform/input/touch-device.js
+++ b/src/platform/input/touch-device.js
@@ -6,7 +6,6 @@ import { TouchEvent } from './touch-event.js';
  * Attach a TouchDevice to an element and it will receive and fire events when the element is
  * touched. See also {@link Touch} and {@link TouchEvent}.
  *
- * @augments EventHandler
  * @category Input
  */
 class TouchDevice extends EventHandler {

--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -23,7 +23,6 @@ function capTime(time, duration) {
 /**
  * A SoundInstance plays a {@link Sound}.
  *
- * @augments EventHandler
  * @category Sound
  */
 class SoundInstance extends EventHandler {

--- a/src/platform/sound/instance3d.js
+++ b/src/platform/sound/instance3d.js
@@ -13,7 +13,6 @@ const MAX_DISTANCE = 10000;
 /**
  * A SoundInstance3d plays a {@link Sound} in 3D.
  *
- * @augments SoundInstance
  * @category Sound
  */
 class SoundInstance3d extends SoundInstance {

--- a/src/platform/sound/manager.js
+++ b/src/platform/sound/manager.js
@@ -22,7 +22,6 @@ const USER_INPUT_EVENTS = [
  * The SoundManager is used to load and play audio. It also applies system-wide settings like
  * global volume, suspend and resume.
  *
- * @augments EventHandler
  * @category Sound
  */
 class SoundManager extends EventHandler {

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -10,7 +10,6 @@ import { RenderAction } from './render-action.js';
  * Layer Composition is a collection of {@link Layer} that is fed to {@link Scene#layers} to define
  * rendering order.
  *
- * @augments EventHandler
  * @category Graphics
  */
 class LayerComposition extends EventHandler {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -88,8 +88,6 @@ function findNode(node, test) {
 
 /**
  * A hierarchical scene node.
- *
- * @augments EventHandler
  */
 class GraphNode extends EventHandler {
     /**

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -26,7 +26,6 @@ import { Material } from './material.js';
  * material.update();
  * ```
  *
- * @augments Material
  * @category Graphics
  */
 class BasicMaterial extends Material {

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -553,7 +553,7 @@ let _params = new Set();
  * split into two sections, generic standard material options and lit options. Properties of the
  * standard material options are {@link StandardMaterialOptions} and the options for the lit options
  * are {@link LitShaderOptions}.
- * @augments Material
+ *
  * @category Graphics
  */
 class StandardMaterial extends Material {

--- a/src/scene/render.js
+++ b/src/scene/render.js
@@ -5,7 +5,6 @@ import { EventHandler } from '../core/event-handler.js';
  * model, and are accessible using {@link ContainerResource#renders} property. The render is the
  * resource of a Render Asset.
  *
- * @augments EventHandler
  * @ignore
  */
 class Render extends EventHandler {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -19,7 +19,6 @@ import { EnvLighting } from './graphics/env-lighting.js';
  * A scene is graphical representation of an environment. It manages the scene hierarchy, all
  * graphical objects, lights, and scene-wide properties.
  *
- * @augments EventHandler
  * @category Graphics
  */
 class Scene extends EventHandler {

--- a/src/scene/sprite.js
+++ b/src/scene/sprite.js
@@ -23,7 +23,6 @@ const spriteIndices = [
  * the {@link SpriteComponent} or the {@link ElementComponent} to render a single frame or a sprite
  * animation.
  *
- * @augments EventHandler
  * @category Graphics
  */
 class Sprite extends EventHandler {

--- a/src/scene/texture-atlas.js
+++ b/src/scene/texture-atlas.js
@@ -4,7 +4,6 @@ import { EventHandler } from '../core/event-handler.js';
  * A TextureAtlas contains a number of frames from a texture. Each frame defines a region in a
  * texture. The TextureAtlas is referenced by {@link Sprite}s.
  *
- * @augments EventHandler
  * @category Graphics
  */
 class TextureAtlas extends EventHandler {


### PR DESCRIPTION
The `@augments` JSDoc tag is now redundant because the docs and types are generated using the TypeScript compiler `tsc` which can automatically discern class inheritance.

I have verified the docs and types are unaffected by this change.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
