### PR TITLE
Use @ignore over @hideconstructor

### DIFF
--- a/src/framework/anim/evaluator/anim-track.js
+++ b/src/framework/anim/evaluator/anim-track.js
@@ -24,7 +24,7 @@ class AnimTrack {
      * @param {import('./anim-data.js').AnimData[]} outputs - List of curve value data.
      * @param {import('./anim-curve.js').AnimCurve[]} curves - The list of curves.
      * @param {AnimEvents} animEvents - A sequence of animation events.
-     * @hideconstructor
+     * @ignore
      */
     constructor(name, duration, inputs, outputs, curves, animEvents = new AnimEvents([])) {
         this._name = name;

--- a/src/framework/anim/state-graph/anim-state-graph.js
+++ b/src/framework/anim/state-graph/anim-state-graph.js
@@ -17,7 +17,7 @@ class AnimStateGraph {
      * Create an AnimStateGraph instance from JSON data.
      *
      * @param {object} data - The JSON data to create the AnimStateGraph from.
-     * @hideconstructor
+     * @ignore
      */
     constructor(data) {
         this._layers = [];

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -152,8 +152,6 @@ class AppBase extends EventHandler {
      *
      * // Start the application's main loop
      * app.start();
-     *
-     * @hideconstructor
      */
     constructor(canvas) {
         super();

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -19,7 +19,7 @@ class AnimComponentSystem extends ComponentSystem {
      * Create an AnimComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application managing this system.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/animation/system.js
+++ b/src/framework/components/animation/system.js
@@ -18,7 +18,7 @@ class AnimationComponentSystem extends ComponentSystem {
      * Create an AnimationComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application managing this system.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/audio-listener/system.js
+++ b/src/framework/components/audio-listener/system.js
@@ -18,7 +18,7 @@ class AudioListenerComponentSystem extends ComponentSystem {
      * Create a new AudioListenerComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application managing this system.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/audio-source/system.js
+++ b/src/framework/components/audio-source/system.js
@@ -37,7 +37,7 @@ class AudioSourceComponentSystem extends ComponentSystem {
      * Create a new AudioSourceComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application managing this system.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -31,7 +31,7 @@ class ButtonComponentSystem extends ComponentSystem {
      * Create a new ButtonComponentSystem.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -28,7 +28,7 @@ class CameraComponentSystem extends ComponentSystem {
      * Create a new CameraComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The Application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -624,7 +624,7 @@ class CollisionComponentSystem extends ComponentSystem {
      * Creates a new CollisionComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The running {@link AppBase}.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -28,7 +28,7 @@ class ElementComponentSystem extends ComponentSystem {
      * Create a new ElementComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -28,7 +28,7 @@ class GSplatComponentSystem extends ComponentSystem {
      * Create a new GSplatComponentSystem.
      *
      * @param {import('../../app-base.js').AppBase} app - The Application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/joint/system.js
+++ b/src/framework/components/joint/system.js
@@ -16,7 +16,7 @@ class JointComponentSystem extends ComponentSystem {
      * Create a new JointComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/layout-child/system.js
+++ b/src/framework/components/layout-child/system.js
@@ -16,7 +16,7 @@ class LayoutChildComponentSystem extends ComponentSystem {
      * Create a new LayoutChildComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -21,7 +21,7 @@ class LayoutGroupComponentSystem extends ComponentSystem {
      * Create a new LayoutGroupComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -19,7 +19,7 @@ class LightComponentSystem extends ComponentSystem {
      * Create a new LightComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -27,7 +27,7 @@ class ModelComponentSystem extends ComponentSystem {
      * Create a new ModelComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The Application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -85,7 +85,7 @@ class ParticleSystemComponentSystem extends ComponentSystem {
      * Create a new ParticleSystemComponentSystem.
      *
      * @param {import('../../app-base.js').AppBase} app - The Application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -44,7 +44,7 @@ class RenderComponentSystem extends ComponentSystem {
      * Create a new RenderComponentSystem.
      *
      * @param {import('../../app-base.js').AppBase} app - The Application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -20,6 +20,35 @@ let ammoRayStart, ammoRayEnd;
  */
 class RaycastResult {
     /**
+     * The entity that was hit.
+     *
+     * @type {import('../../entity.js').Entity}
+     */
+    entity;
+
+    /**
+     * The point at which the ray hit the entity in world space.
+     *
+     * @type {Vec3}
+     */
+    point;
+
+    /**
+     * The normal vector of the surface where the ray hit in world space.
+     *
+     * @type {Vec3}
+     */
+    normal;
+
+    /**
+     * The normalized distance (between 0 and 1) at which the ray hit occurred from the
+     * starting point.
+     *
+     * @type {number}
+     */
+    hitFraction;
+
+    /**
      * Create a new RaycastResult instance.
      *
      * @param {import('../../entity.js').Entity} entity - The entity that was hit.
@@ -27,36 +56,12 @@ class RaycastResult {
      * @param {Vec3} normal - The normal vector of the surface where the ray hit in world space.
      * @param {number} hitFraction - The normalized distance (between 0 and 1) at which the ray hit
      * occurred from the starting point.
-     * @hideconstructor
+     * @ignore
      */
     constructor(entity, point, normal, hitFraction) {
-        /**
-         * The entity that was hit.
-         *
-         * @type {import('../../entity.js').Entity}
-         */
         this.entity = entity;
-
-        /**
-         * The point at which the ray hit the entity in world space.
-         *
-         * @type {Vec3}
-         */
         this.point = point;
-
-        /**
-         * The normal vector of the surface where the ray hit in world space.
-         *
-         * @type {Vec3}
-         */
         this.normal = normal;
-
-        /**
-         * The normalized distance (between 0 and 1) at which the ray hit occurred from the
-         * starting point.
-         *
-         * @type {number}
-         */
         this.hitFraction = hitFraction;
     }
 }
@@ -68,72 +73,72 @@ class RaycastResult {
  */
 class SingleContactResult {
     /**
+     * The first entity involved in the contact.
+     *
+     * @type {import('../../entity.js').Entity}
+     */
+    a;
+
+    /**
+     * The second entity involved in the contact.
+     *
+     * @type {import('../../entity.js').Entity}
+     */
+    b;
+
+    /**
+     * The total accumulated impulse applied by the constraint solver during the last
+     * sub-step. Describes how hard two bodies collided.
+     *
+     * @type {number}
+     */
+    impulse;
+
+    /**
+     * The point on Entity A where the contact occurred, relative to A.
+     *
+     * @type {Vec3}
+     */
+    localPointA;
+
+    /**
+     * The point on Entity B where the contact occurred, relative to B.
+     *
+     * @type {Vec3}
+     */
+    localPointB;
+
+    /**
+     * The point on Entity A where the contact occurred, in world space.
+     *
+     * @type {Vec3}
+     */
+    pointA;
+
+    /**
+     * The point on Entity B where the contact occurred, in world space.
+     *
+     * @type {Vec3}
+     */
+    pointB;
+
+    /**
+     * The normal vector of the contact on Entity B, in world space.
+     *
+     * @type {Vec3}
+     */
+    normal;
+
+    /**
      * Create a new SingleContactResult instance.
      *
      * @param {import('../../entity.js').Entity} a - The first entity involved in the contact.
      * @param {import('../../entity.js').Entity} b - The second entity involved in the contact.
      * @param {ContactPoint} contactPoint - The contact point between the two entities.
-     * @hideconstructor
+     * @ignore
      */
     constructor(a, b, contactPoint) {
-        if (arguments.length === 0) {
-            /**
-             * The first entity involved in the contact.
-             *
-             * @type {import('../../entity.js').Entity}
-             */
-            this.a = null;
-
-            /**
-             * The second entity involved in the contact.
-             *
-             * @type {import('../../entity.js').Entity}
-             */
-            this.b = null;
-
-            /**
-             * The total accumulated impulse applied by the constraint solver during the last
-             * sub-step. Describes how hard two bodies collided.
-             *
-             * @type {number}
-             */
-            this.impulse = 0;
-
-            /**
-             * The point on Entity A where the contact occurred, relative to A.
-             *
-             * @type {Vec3}
-             */
-            this.localPointA = new Vec3();
-
-            /**
-             * The point on Entity B where the contact occurred, relative to B.
-             *
-             * @type {Vec3}
-             */
-            this.localPointB = new Vec3();
-
-            /**
-             * The point on Entity A where the contact occurred, in world space.
-             *
-             * @type {Vec3}
-             */
-            this.pointA = new Vec3();
-
-            /**
-             * The point on Entity B where the contact occurred, in world space.
-             *
-             * @type {Vec3}
-             */
-            this.pointB = new Vec3();
-
-            /**
-             * The normal vector of the contact on Entity B, in world space.
-             *
-             * @type {Vec3}
-             */
-            this.normal = new Vec3();
-        } else {
+        if (arguments.length !== 0) {
             this.a = a;
             this.b = b;
             this.impulse = contactPoint.impulse;
@@ -142,6 +147,15 @@ class SingleContactResult {
             this.pointA = contactPoint.point;
             this.pointB = contactPoint.pointOther;
             this.normal = contactPoint.normal;
+        } else {
+            this.a = null;
+            this.b = null;
+            this.impulse = 0;
+            this.localPointA = new Vec3();
+            this.localPointB = new Vec3();
+            this.pointA = new Vec3();
+            this.pointB = new Vec3();
+            this.normal = new Vec3();
         }
     }
 }
@@ -152,6 +166,49 @@ class SingleContactResult {
  * @category Physics
  */
 class ContactPoint {
+    /**
+     * The point on the entity where the contact occurred, relative to the entity.
+     *
+     * @type {Vec3}
+     */
+    localPoint;
+
+    /**
+     * The point on the other entity where the contact occurred, relative to the other entity.
+     *
+     * @type {Vec3}
+     */
+    localPointOther;
+
+    /**
+     * The point on the entity where the contact occurred, in world space.
+     *
+     * @type {Vec3}
+     */
+    point;
+
+    /**
+     * The point on the other entity where the contact occurred, in world space.
+     *
+     * @type {Vec3}
+     */
+    pointOther;
+
+    /**
+     * The normal vector of the contact on the other entity, in world space.
+     *
+     * @type {Vec3}
+     */
+    normal;
+
+    /**
+     * The total accumulated impulse applied by the constraint solver during the last sub-step.
+     * Describes how hard two objects collide.
+     *
+     * @type {number}
+     */
+    impulse;
+
     /**
      * Create a new ContactPoint instance.
      *
@@ -166,50 +223,14 @@ class ContactPoint {
      * space.
      * @param {number} [impulse] - The total accumulated impulse applied by the constraint solver
      * during the last sub-step. Describes how hard two objects collide. Defaults to 0.
-     * @hideconstructor
+     * @ignore
      */
     constructor(localPoint = new Vec3(), localPointOther = new Vec3(), point = new Vec3(), pointOther = new Vec3(), normal = new Vec3(), impulse = 0) {
-        /**
-         * The point on the entity where the contact occurred, relative to the entity.
-         *
-         * @type {Vec3}
-         */
         this.localPoint = localPoint;
-
-        /**
-         * The point on the other entity where the contact occurred, relative to the other entity.
-         *
-         * @type {Vec3}
-         */
         this.localPointOther = localPointOther;
-
-        /**
-         * The point on the entity where the contact occurred, in world space.
-         *
-         * @type {Vec3}
-         */
         this.point = point;
-
-        /**
-         * The point on the other entity where the contact occurred, in world space.
-         *
-         * @type {Vec3}
-         */
         this.pointOther = pointOther;
-
-        /**
-         * The normal vector of the contact on the other entity, in world space.
-         *
-         * @type {Vec3}
-         */
         this.normal = normal;
-
-        /**
-         * The total accumulated impulse applied by the constraint solver during the last sub-step.
-         * Describes how hard two objects collide.
-         *
-         * @type {number}
-         */
         this.impulse = impulse;
     }
 }
@@ -221,26 +242,29 @@ class ContactPoint {
  */
 class ContactResult {
     /**
+     * The entity that was involved in the contact with this entity.
+     *
+     * @type {import('../../entity.js').Entity}
+     */
+    other;
+
+    /**
+     * An array of ContactPoints with the other entity.
+     *
+     * @type {ContactPoint[]}
+     */
+    contacts;
+
+    /**
      * Create a new ContactResult instance.
      *
      * @param {import('../../entity.js').Entity} other - The entity that was involved in the
      * contact with this entity.
      * @param {ContactPoint[]} contacts - An array of ContactPoints with the other entity.
-     * @hideconstructor
+     * @ignore
      */
     constructor(other, contacts) {
-        /**
-         * The entity that was involved in the contact with this entity.
-         *
-         * @type {import('../../entity.js').Entity}
-         */
         this.other = other;
-
-        /**
-         * An array of ContactPoints with the other entity.
-         *
-         * @type {ContactPoint[]}
-         */
         this.contacts = contacts;
     }
 }
@@ -322,7 +346,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * Create a new RigidBodyComponentSystem.
      *
      * @param {import('../../app-base.js').AppBase} app - The Application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -20,7 +20,7 @@ class ScreenComponentSystem extends ComponentSystem {
      * Create a new ScreenComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -27,7 +27,7 @@ class ScriptComponentSystem extends ComponentSystem {
      * Create a new ScriptComponentSystem.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -36,7 +36,7 @@ class ScrollViewComponentSystem extends ComponentSystem {
      * Create a new ScrollViewComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/scrollbar/system.js
+++ b/src/framework/components/scrollbar/system.js
@@ -22,7 +22,7 @@ class ScrollbarComponentSystem extends ComponentSystem {
      * Create a new ScrollbarComponentSystem.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -20,7 +20,7 @@ class SoundComponentSystem extends ComponentSystem {
      * Create a SoundComponentSystem.
      *
      * @param {import('../../app-base.js').AppBase} app - The Application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -27,7 +27,7 @@ class SpriteComponentSystem extends ComponentSystem {
      * Create a new SpriteComponentSystem instance.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/components/zone/system.js
+++ b/src/framework/components/zone/system.js
@@ -18,7 +18,7 @@ class ZoneComponentSystem extends ComponentSystem {
      * Create a new ZoneComponentSystem.
      *
      * @param {import('../../app-base.js').AppBase} app - The application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app);

--- a/src/framework/handlers/gsplat.js
+++ b/src/framework/handlers/gsplat.js
@@ -7,7 +7,7 @@ class GSplatHandler extends ResourceHandler {
      * Create a new GSplatHandler instance.
      *
      * @param {import('../app-base.js').AppBase} app - The running {@link AppBase}.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super(app, 'gsplat');

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -71,7 +71,7 @@ class Lightmapper {
      * renderer.
      * @param {import('../asset/asset-registry.js').AssetRegistry} assets - Registry of assets to
      * lightmap.
-     * @hideconstructor
+     * @ignore
      */
     constructor(device, root, scene, renderer, assets) {
         this.device = device;

--- a/src/framework/parsers/gsplat-resource.js
+++ b/src/framework/parsers/gsplat-resource.js
@@ -30,7 +30,7 @@ class GSplatResource {
     /**
      * @param {import('../../platform/graphics/graphics-device.js').GraphicsDevice} device - The graphics device.
      * @param {import('../../scene/gsplat/gsplat-data.js').GSplatData} splatData - The splat data.
-     * @hideconstructor
+     * @ignore
      */
     constructor(device, splatData) {
         this.device = device;

--- a/src/framework/xr/xr-anchor.js
+++ b/src/framework/xr/xr-anchor.js
@@ -105,7 +105,7 @@ class XrAnchor extends EventHandler {
      * @param {import('./xr-anchors.js').XrAnchors} anchors - Anchor manager.
      * @param {object} xrAnchor - native XRAnchor object that is provided by WebXR API
      * @param {string|null} uuid - ID string associated with a persistent anchor
-     * @hideconstructor
+     * @ignore
      */
     constructor(anchors, xrAnchor, uuid = null) {
         super();

--- a/src/framework/xr/xr-anchors.js
+++ b/src/framework/xr/xr-anchors.js
@@ -148,7 +148,7 @@ class XrAnchors extends EventHandler {
 
     /**
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager) {
         super();

--- a/src/framework/xr/xr-depth-sensing.js
+++ b/src/framework/xr/xr-depth-sensing.js
@@ -57,7 +57,7 @@ class XrDepthSensing extends EventHandler {
 
     /**
      * @param {import('./xr-manager.js').XrManager} manager - manager
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager) {
         super();

--- a/src/framework/xr/xr-dom-overlay.js
+++ b/src/framework/xr/xr-dom-overlay.js
@@ -43,14 +43,10 @@ class XrDomOverlay {
     _root = null;
 
     /**
-     * DOM Overlay provides the ability to use DOM elements as an overlay in a WebXR AR session. It
-     * requires that the root DOM element is provided for session start. That way, input source
-     * select events are first tested against DOM Elements and then propagated down to the XR
-     * Session. If this propagation is not desirable, use the `beforexrselect` event on a DOM
-     * element and the `preventDefault` function to stop propagation.
+     * Create a new XrDomOverlay instance.
      *
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager) {
         this._manager = manager;

--- a/src/framework/xr/xr-finger.js
+++ b/src/framework/xr/xr-finger.js
@@ -33,7 +33,7 @@ class XrFinger {
      *
      * @param {number} index - Index of a finger.
      * @param {import('./xr-hand.js').XrHand} hand - Hand that finger relates to.
-     * @hideconstructor
+     * @ignore
      */
     constructor(index, hand) {
         this._index = index;

--- a/src/framework/xr/xr-hand.js
+++ b/src/framework/xr/xr-hand.js
@@ -108,7 +108,7 @@ class XrHand extends EventHandler {
      *
      * @param {import('./xr-input-source.js').XrInputSource} inputSource - Input Source that hand
      * is related to.
-     * @hideconstructor
+     * @ignore
      */
     constructor(inputSource) {
         super();

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -92,7 +92,7 @@ class XrHitTestSource extends EventHandler {
      * @param {*} xrHitTestSource - XRHitTestSource object that is created by WebXR API.
      * @param {boolean} transient - True if XRHitTestSource created for input source profile.
      * @param {null|import('./xr-input-source.js').XrInputSource} inputSource - Input Source for which hit test is created for, or null.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager, xrHitTestSource, transient, inputSource = null) {
         super();

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -122,7 +122,7 @@ class XrHitTest extends EventHandler {
      * Create a new XrHitTest instance.
      *
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager) {
         super();

--- a/src/framework/xr/xr-image-tracking.js
+++ b/src/framework/xr/xr-image-tracking.js
@@ -52,7 +52,7 @@ class XrImageTracking extends EventHandler {
      * their estimate sizes.
      *
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager) {
         super();

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -301,7 +301,7 @@ class XrInputSource extends EventHandler {
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
      * @param {*} xrInputSource - [XRInputSource](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSource)
      * object that is created by WebXR API.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager, xrInputSource) {
         super();

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -150,7 +150,7 @@ class XrInput extends EventHandler {
      * Create a new XrInput instance.
      *
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager) {
         super();

--- a/src/framework/xr/xr-joint.js
+++ b/src/framework/xr/xr-joint.js
@@ -115,7 +115,7 @@ class XrJoint {
      * @param {import('./xr-hand.js').XrHand} hand - Hand that joint relates to.
      * @param {import('./xr-finger.js').XrFinger|null} finger - Finger that joint is related to.
      * Can be null in the case of the wrist joint.
-     * @hideconstructor
+     * @ignore
      */
     constructor(index, id, hand, finger = null) {
         this._index = index;

--- a/src/framework/xr/xr-light-estimation.js
+++ b/src/framework/xr/xr-light-estimation.js
@@ -102,7 +102,7 @@ class XrLightEstimation extends EventHandler {
      * Create a new XrLightEstimation instance.
      *
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager) {
         super();

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -292,7 +292,7 @@ class XrManager extends EventHandler {
      * Create a new XrManager instance.
      *
      * @param {import('../app-base.js').AppBase} app - The main application.
-     * @hideconstructor
+     * @ignore
      */
     constructor(app) {
         super();

--- a/src/framework/xr/xr-mesh-detection.js
+++ b/src/framework/xr/xr-mesh-detection.js
@@ -102,7 +102,7 @@ class XrMeshDetection extends EventHandler {
      * Create a new XrMeshDetection instance.
      *
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager) {
         super();

--- a/src/framework/xr/xr-mesh.js
+++ b/src/framework/xr/xr-mesh.js
@@ -70,7 +70,7 @@ class XrMesh extends EventHandler {
      * @param {import('./xr-mesh-detection.js').XrMeshDetection} meshDetection - Mesh Detection
      * interface.
      * @param {XRMesh} xrMesh - XRMesh that is instantiated by WebXR system.
-     * @hideconstructor
+     * @ignore
      */
     constructor(meshDetection, xrMesh) {
         super();

--- a/src/framework/xr/xr-plane-detection.js
+++ b/src/framework/xr/xr-plane-detection.js
@@ -102,7 +102,7 @@ class XrPlaneDetection extends EventHandler {
      * Create a new XrPlaneDetection instance.
      *
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager) {
         super();

--- a/src/framework/xr/xr-plane.js
+++ b/src/framework/xr/xr-plane.js
@@ -82,7 +82,7 @@ class XrPlane extends EventHandler {
      * @param {import('./xr-plane-detection.js').XrPlaneDetection} planeDetection - Plane detection
      * system.
      * @param {*} xrPlane - XRPlane that is instantiated by WebXR system.
-     * @hideconstructor
+     * @ignore
      */
     constructor(planeDetection, xrPlane) {
         super();

--- a/src/framework/xr/xr-tracked-image.js
+++ b/src/framework/xr/xr-tracked-image.js
@@ -104,7 +104,7 @@ class XrTrackedImage extends EventHandler {
      * repeating patterns will reduce tracking stability.
      * @param {number} width - Width (in meters) of image in real world. Providing this value as
      * close to the real value will improve tracking quality.
-     * @hideconstructor
+     * @ignore
      */
     constructor(image, width) {
         super();

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -136,7 +136,7 @@ class XrView extends EventHandler {
      * @param {XRView} xrView - [XRView](https://developer.mozilla.org/en-US/docs/Web/API/XRView)
      * object that is created by WebXR API.
      * @param {number} viewsCount - Number of views available for the session.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager, xrView, viewsCount) {
         super();

--- a/src/framework/xr/xr-views.js
+++ b/src/framework/xr/xr-views.js
@@ -107,7 +107,7 @@ class XrViews extends EventHandler {
 
     /**
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @hideconstructor
+     * @ignore
      */
     constructor(manager) {
         super();

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -316,7 +316,7 @@ class GamePadButton {
      *
      * @param {number|GamepadButton} current - The original Gamepad API gamepad button.
      * @param {number|GamepadButton} [previous] - The previous Gamepad API gamepad button.
-     * @hideconstructor
+     * @ignore
      */
     constructor(current, previous) {
         if (typeof current === 'number') {
@@ -386,7 +386,7 @@ class GamePad {
      *
      * @param {Gamepad} gamepad - The original Gamepad API gamepad.
      * @param {object} map - The buttons and axes map.
-     * @hideconstructor
+     * @ignore
      */
     constructor(gamepad, map) {
         /**

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -219,7 +219,7 @@ class Scene extends EventHandler {
      *
      * @param {import('../platform/graphics/graphics-device.js').GraphicsDevice} graphicsDevice -
      * The graphics device used to manage this scene.
-     * @hideconstructor
+     * @ignore
      */
     constructor(graphicsDevice) {
         super();

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -47,7 +47,7 @@ class Sky {
      * Constructs a new sky.
      *
      * @param {import('../scene.js').Scene} scene - The scene owning the sky.
-     * @hideconstructor
+     * @ignore
      */
     constructor(scene) {
         this.device = scene.device;


### PR DESCRIPTION
The `@hideconstructor` JSDoc tag is not supported by TypeDoc. `@ignore` should be used instead. This PR makes that switch.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
