### PR TITLE
Improve docs for Entity#destroy

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -548,8 +548,8 @@ class Entity extends GraphNode {
 
     /**
      * Destroy the entity and all of its descendants. First, all of the entity's components are
-     * disabled and then removed. Then, it is removed from the hierarchy. This is then repeated
-     * recursively for all descendants of the entity.
+     * disabled and then removed. Then, the entity is removed from the hierarchy. This is then
+     * repeated recursively for all descendants of the entity.
      *
      * The last thing the entity does is fire the `destroy` event.
      *

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -547,12 +547,15 @@ class Entity extends GraphNode {
     }
 
     /**
-     * Remove all components from the Entity and detach it from the Entity hierarchy. Then
-     * recursively destroy all ancestor Entities.
+     * Destroy the entity and all of its descendants. First, all of the entity's components are
+     * disabled and then removed. Then, it is removed from the hierarchy. This is then repeated
+     * recursively for all descendants of the entity.
+     *
+     * The last thing the entity does is fire the `destroy` event.
      *
      * @example
      * const firstChild = this.entity.children[0];
-     * firstChild.destroy(); // delete child, all components and remove from hierarchy
+     * firstChild.destroy(); // destroy child and all of its descendants
      */
     destroy() {
         this._destroying = true;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -524,11 +524,14 @@ class GraphNode extends EventHandler {
 
 
     /**
-     * Detach a GraphNode from the hierarchy and recursively destroy all children.
+     * Destroy the graph node and all of its descendants. First, the graph node is removed from the
+     * hierarchy. This is then repeated recursively for all descendants of the graph node.
+     *
+     * The last thing the graph node does is fire the `destroy` event.
      *
      * @example
-     * const firstChild = this.entity.children[0];
-     * firstChild.destroy(); // delete child, all components and remove from hierarchy
+     * const firstChild = graphNode.children[0];
+     * firstChild.destroy(); // destroy child and all of its descendants
      */
     destroy() {
         // Detach from parent


### PR DESCRIPTION
The docs for `Entity#destroy` currently say:

```
Remove all components from the Entity and detach it from the Entity hierarchy. Then recursively destroy all ancestor Entities.
```

However, it actually destroys *descendant* entities.

This PR also generally improves the docs for the graph node/entity destroy functions.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
