### PR TITLE
Dispatch multiple compute shaders in a single compute pass

### DIFF
--- a/examples/src/examples/compute/texture-gen/config.mjs
+++ b/examples/src/examples/compute/texture-gen/config.mjs
@@ -8,7 +8,7 @@ export default {
         'compute-shader.wgsl': /* wgsl */`
 
             struct ub_compute {
-                tint : vec4<f32>,
+                tint : vec4f,
                 offset: f32,
                 frequency: f32
             }
@@ -28,16 +28,16 @@ export default {
                 var texColor = textureLoad(inputTexture, uv, 0);
 
                 // tint it
-                var tintColor: vec4<f32> = ubCompute.tint;
+                var tintColor: vec4f = ubCompute.tint;
                 texColor *= tintColor;
 
                 // scroll a darkness effect over the texture
-                let uvFloat = vec2<f32>(f32(uv.x), f32(uv.y));
+                let uvFloat = vec2f(f32(uv.x), f32(uv.y));
                 var darkness: f32 = sin(ubCompute.offset + ubCompute.frequency * length(uvFloat)) * 0.2 + 0.8;
                 texColor *= darkness;
 
                 // write it to the output texture
-                textureStore(outputTexture, vec2<i32>(global_id.xy), texColor);
+                textureStore(outputTexture, vec2i(global_id.xy), texColor);
             }
         `
     }

--- a/examples/src/examples/compute/texture-gen/example.mjs
+++ b/examples/src/examples/compute/texture-gen/example.mjs
@@ -175,19 +175,22 @@ assetListLoader.load(() => {
         time += dt;
 
         if (device.supportsCompute) {
+
+            // set uniform buffer parameters
             compute1.setParameter('offset', 20 * time);
             compute1.setParameter('frequency', 0.1);
             compute1.setParameter('tint', [Math.sin(time) * 0.5 + 0.5, 1, 0, 1]);
-
-            // run the compute shader each frame to update the texture
-            compute1.dispatch(srcTexture.width, srcTexture.height);
 
             compute2.setParameter('offset', 10 * time);
             compute2.setParameter('frequency', 0.03);
             compute2.setParameter('tint', [1, 0, Math.sin(time) * 0.5 + 0.5, 1]);
 
-            // run the compute shader each frame to update the texture
-            compute2.dispatch(srcTexture.width, srcTexture.height);
+            // set up both dispatches
+            compute1.setupDispatch(srcTexture.width, srcTexture.height);
+            compute2.setupDispatch(srcTexture.width, srcTexture.height);
+
+            // dispatch both compute shaders in a single compute pass
+            device.computeDispatch([compute1, compute2]);
 
             // debug render the generated textures
             app.drawTexture(0.6, 0.5, 0.6, 0.3, compute1.getParameter('outTexture'));

--- a/examples/src/examples/compute/texture-gen/example.mjs
+++ b/examples/src/examples/compute/texture-gen/example.mjs
@@ -108,9 +108,7 @@ assetListLoader.load(() => {
         ], [
             // output storage textures
             new pc.BindStorageTextureFormat('outTexture', pc.PIXELFORMAT_RGBA8, pc.TEXTUREDIMENSION_2D)
-        ], {
-            compute: true
-        })
+        ])
     }) : null;
 
     // helper function, which creates a cube entity, and an instance of the compute shader that will

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -84,16 +84,10 @@ class BindGroupFormat {
      * Defaults to an empty array.
      * @param {BindStorageTextureFormat[]} [storageTextureFormats] - An array of bind storage texture
      * formats (storage textures), used by the compute shader. Defaults to an empty array.
-     * @param {object} [options] - Object for passing optional arguments.
-     * @param {boolean} [options.compute] - If true, this bind group format is used by the compute
-     * shader.
      */
-    constructor(graphicsDevice, bufferFormats = [], textureFormats = [], storageTextureFormats = [], options = {}) {
+    constructor(graphicsDevice, bufferFormats = [], textureFormats = [], storageTextureFormats = []) {
         this.id = id++;
         DebugHelper.setName(this, `BindGroupFormat_${this.id}`);
-
-        this.compute = options.compute ?? false;
-        Debug.assert(this.compute || storageTextureFormats.length === 0, "Storage textures can be specified only for compute");
 
         /** @type {import('./graphics-device.js').GraphicsDevice} */
         this.device = graphicsDevice;

--- a/src/platform/graphics/compute.js
+++ b/src/platform/graphics/compute.js
@@ -24,8 +24,29 @@ class Compute {
      */
     shader = null;
 
-    /** @type {Map<string, ComputeParameter>} */
+    /**
+     * @type {Map<string, ComputeParameter>}
+     * @ignore
+     */
     parameters = new Map();
+
+    /**
+     * @type {number}
+     * @ignore
+     */
+    countX = 1;
+
+    /**
+     * @type {number|undefined}
+     * @ignore
+     */
+    countY;
+
+    /**
+     * @type {number|undefined}
+     * @ignore
+     */
+    countZ;
 
     /**
      * Create a compute instance. Note that this is supported on WebGPU only and is a no-op on
@@ -93,15 +114,16 @@ class Compute {
     }
 
     /**
-     * Dispatch the compute work.
+     * Prepare the compute work dispatch.
      *
      * @param {number} x - X dimension of the grid of work-groups to dispatch.
      * @param {number} [y] - Y dimension of the grid of work-groups to dispatch.
      * @param {number} [z] - Z dimension of the grid of work-groups to dispatch.
      */
-    dispatch(x, y, z) {
-        this.applyParameters();
-        this.impl?.dispatch(x, y, z);
+    setupDispatch(x, y, z) {
+        this.countX = x;
+        this.countY = y;
+        this.countZ = z;
     }
 }
 

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -894,6 +894,15 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
+     * Dispatch multiple compute shaders inside a single compute shader pass.
+     *
+     * @param {Array<import('./compute.js').Compute>} computes - An array of compute shaders to
+     * dispatch.
+     */
+    computeDispatch(computes) {
+    }
+
+    /**
      * Get a renderable HDR pixel format supported by the graphics device.
      *
      * @param {number[]} [formats] - An array of pixel formats to check for support. Can contain:

--- a/src/platform/graphics/webgpu/webgpu-compute.js
+++ b/src/platform/graphics/webgpu/webgpu-compute.js
@@ -29,25 +29,24 @@ class WebgpuCompute {
         this.pipeline = device.computePipeline.get(shader, computeBindGroupFormat);
     }
 
-    dispatch(x, y, z) {
-
-        // TODO: currently each dispatch is a separate compute pass, which is not optimal, and we should
-        // batch multiple dispatches into a single compute pass
-        const device = this.compute.device;
-        device.startComputePass();
+    updateBindGroup() {
 
         // bind group data
         const { bindGroup } = this;
         bindGroup.defaultUniformBuffer?.update();
         bindGroup.update();
-        device.setBindGroup(0, bindGroup);
+    }
+
+    dispatch(x, y, z) {
+
+        // bind group
+        const device = this.compute.device;
+        device.setBindGroup(0, this.bindGroup);
 
         // dispatch
         const passEncoder = device.passEncoder;
         passEncoder.setPipeline(this.pipeline);
         passEncoder.dispatchWorkgroups(x, y, z);
-
-        device.endComputePass();
     }
 }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -721,6 +721,26 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         WebgpuDebug.end(this);
     }
 
+    computeDispatch(computes) {
+
+        this.startComputePass();
+
+        // update uniform buffers and bind groups
+        for (let i = 0; i < computes.length; i++) {
+            const compute = computes[i];
+            compute.applyParameters();
+            compute.impl.updateBindGroup();
+        }
+
+        // dispatch
+        for (let i = 0; i < computes.length; i++) {
+            const compute = computes[i];
+            compute.impl.dispatch(compute.countX, compute.countY, compute.countZ);
+        }
+
+        this.endComputePass();
+    }
+
     addCommandBuffer(commandBuffer, front = false) {
         if (front) {
             this.commandBuffers.unshift(commandBuffer);


### PR DESCRIPTION
Instead of creating a compute pass for each compute dispatch, pass an array of those to be dispatched in a single pass.