### PR TITLE
Simplify jsdocs types for the Mesh and VertexIterators API

### DIFF
--- a/src/platform/graphics/vertex-iterator.js
+++ b/src/platform/graphics/vertex-iterator.js
@@ -192,7 +192,7 @@ class VertexIteratorAccessor {
      *
      * @param {number} offset - The component offset at which to read data from the buffer. Will be
      * used instead of the iterator's current index.
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} outputArray - The output array to write data into.
+     * @param {number[]|ArrayBufferView} outputArray - The output array to write data into.
      * @param {number} outputIndex - The output index at which to write into the output array.
      */
     getToArray(offset, outputArray, outputIndex) {
@@ -204,7 +204,7 @@ class VertexIteratorAccessor {
      *
      * @param {number} index - The starting index at which to write data into the buffer. Will be
      * used instead of the iterator's current index.
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} inputArray - The input array to read data from.
+     * @param {number[]|ArrayBufferView} inputArray - The input array to read data from.
      * @param {number} inputIndex - The input index at which to read from the input array.
      */
     setFromArray(index, inputArray, inputIndex) {
@@ -304,7 +304,7 @@ class VertexIterator {
      * and non-interleaved (fast) vertex buffers.
      *
      * @param {string} semantic - The semantic of the vertex element to set.
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} data - The data to set.
+     * @param {number[]|ArrayBufferView} data - The data to set.
      * @param {number} numVertices - The number of vertices to write.
      * @ignore
      */
@@ -358,7 +358,7 @@ class VertexIterator {
      * only part of the data gets copied out (typed arrays ignore read/write out of range).
      *
      * @param {string} semantic - The semantic of the vertex element to read.
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} data - The
+     * @param {number[]|ArrayBufferView} data - The
      * array to receive the data.
      * @returns {number} The number of vertices read.
      * @ignore

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -504,7 +504,7 @@ class Mesh extends RefCountedObject {
      *
      * @param {string} semantic - The meaning of the vertex element. For supported semantics, see
      * SEMANTIC_* in {@link VertexFormat}.
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} data - Vertex
+     * @param {number[]|ArrayBufferView} data - Vertex
      * data for the specified semantic.
      * @param {number} componentCount - The number of values that form a single Vertex element. For
      * example when setting a 3D position represented by 3 numbers per vertex, number 3 should be
@@ -536,7 +536,7 @@ class Mesh extends RefCountedObject {
      *
      * @param {string} semantic - The semantic of the vertex element to get. For supported
      * semantics, see SEMANTIC_* in {@link VertexFormat}.
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} data - An
+     * @param {number[]|ArrayBufferView} data - An
      * array to populate with the vertex data. When typed array is supplied, enough space needs to
      * be reserved, otherwise only partial data is copied.
      * @returns {number} Returns the number of vertices populated.
@@ -578,7 +578,7 @@ class Mesh extends RefCountedObject {
     /**
      * Sets the vertex positions array. Vertices are stored using {@link TYPE_FLOAT32} format.
      *
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} positions - Vertex
+     * @param {number[]|ArrayBufferView} positions - Vertex
      * data containing positions.
      * @param {number} [componentCount] - The number of values that form a single position element.
      * Defaults to 3 if not specified, corresponding to x, y and z coordinates.
@@ -592,7 +592,7 @@ class Mesh extends RefCountedObject {
     /**
      * Sets the vertex normals array. Normals are stored using {@link TYPE_FLOAT32} format.
      *
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} normals - Vertex
+     * @param {number[]|ArrayBufferView} normals - Vertex
      * data containing normals.
      * @param {number} [componentCount] - The number of values that form a single normal element.
      * Defaults to 3 if not specified, corresponding to x, y and z direction.
@@ -607,7 +607,7 @@ class Mesh extends RefCountedObject {
      * Sets the vertex uv array. Uvs are stored using {@link TYPE_FLOAT32} format.
      *
      * @param {number} channel - The uv channel in [0..7] range.
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} uvs - Vertex
+     * @param {number[]|ArrayBufferView} uvs - Vertex
      * data containing uv-coordinates.
      * @param {number} [componentCount] - The number of values that form a single uv element.
      * Defaults to 2 if not specified, corresponding to u and v coordinates.
@@ -622,7 +622,7 @@ class Mesh extends RefCountedObject {
      * Sets the vertex color array. Colors are stored using {@link TYPE_FLOAT32} format, which is
      * useful for HDR colors.
      *
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} colors - Vertex
+     * @param {number[]|ArrayBufferView} colors - Vertex
      * data containing colors.
      * @param {number} [componentCount] - The number of values that form a single color element.
      * Defaults to 4 if not specified, corresponding to r, g, b and a.
@@ -638,7 +638,7 @@ class Mesh extends RefCountedObject {
      * useful for LDR colors. Values in the array are expected in [0..255] range, and are mapped to
      * [0..1] range in the shader.
      *
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} colors - Vertex
+     * @param {number[]|ArrayBufferView} colors - Vertex
      * data containing colors. The array is expected to contain 4 components per vertex,
      * corresponding to r, g, b and a.
      * @param {number} [numVertices] - The number of vertices to be used from data array. If not
@@ -667,7 +667,7 @@ class Mesh extends RefCountedObject {
     /**
      * Gets the vertex positions data.
      *
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} positions - An
+     * @param {number[]|ArrayBufferView} positions - An
      * array to populate with the vertex data. When typed array is supplied, enough space needs to
      * be reserved, otherwise only partial data is copied.
      * @returns {number} Returns the number of vertices populated.
@@ -679,7 +679,7 @@ class Mesh extends RefCountedObject {
     /**
      * Gets the vertex normals data.
      *
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} normals - An
+     * @param {number[]|ArrayBufferView} normals - An
      * array to populate with the vertex data. When typed array is supplied, enough space needs to
      * be reserved, otherwise only partial data is copied.
      * @returns {number} Returns the number of vertices populated.
@@ -692,7 +692,7 @@ class Mesh extends RefCountedObject {
      * Gets the vertex uv data.
      *
      * @param {number} channel - The uv channel in [0..7] range.
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} uvs - An
+     * @param {number[]|ArrayBufferView} uvs - An
      * array to populate with the vertex data. When typed array is supplied, enough space needs to
      * be reserved, otherwise only partial data is copied.
      * @returns {number} Returns the number of vertices populated.
@@ -704,7 +704,7 @@ class Mesh extends RefCountedObject {
     /**
      * Gets the vertex color data.
      *
-     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array} colors - An
+     * @param {number[]|ArrayBufferView} colors - An
      * array to populate with the vertex data. When typed array is supplied, enough space needs to
      * be reserved, otherwise only partial data is copied.
      * @returns {number} Returns the number of vertices populated.


### PR DESCRIPTION
No need to list all typed array types, as the `ArrayBufferView` is the base class for all of those.