### PR TITLE
Use indexed rendering for gplats

### DIFF
--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -70,9 +70,8 @@ class GSplatInstance {
             });
         } else {
             this.mesh = new Mesh(device);
-            this.mesh.setPositions(new Float32Array([
-                -1, -1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1
-            ]), 2);
+            this.mesh.setPositions(new Float32Array([-1, -1, 1, -1, 1, 1, -1, 1]), 2);
+            this.mesh.setIndices([0, 1, 2, 0, 2, 3]);
             this.mesh.update();
         }
 


### PR DESCRIPTION
Originally non-indexed instanced rendering was used, now indexed rendering is used. 

In my test scene with 21 splat models at a small size (to force vertex cost to dominate over fragment / fillrate), the GPU performance has improved from **24.6 -> 11.0ms**, so more than doubled. Tested on Mac M1 Max.

<img width="947" alt="Screenshot 2024-03-26 at 12 24 18" src="https://github.com/playcanvas/engine/assets/59932779/a7b6da68-68ad-4ee9-9bbc-48bff85c1a55">
