### PR TITLE
Engine Watch fix

### DIFF
--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -172,6 +172,7 @@ function buildTarget(buildType, moduleFormat, input = 'src/index.js', buildDir =
 
     const jsccParam = jsccOptions[buildType] || jsccOptions.release;
     if (moduleFormat === 'es5') jsccParam.values._IS_UMD = 1;
+    jsccParam.asloader = false;
 
     return {
         input,


### PR DESCRIPTION
- Use JSCC as transformer instead of loader - rollup 4.x.x breaking changes (https://github.com/rollup/rollup/releases/tag/v4.0.0)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
