### PR TITLE
JSDoc import dollar fixes

### DIFF
--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -116,8 +116,9 @@ class ElementInputEvent {
     /**
      * Create a new ElementInputEvent instance.
      *
-     * @param {MouseEvent|TouchEvent} event - The MouseEvent or TouchEvent that was originally
-     * raised.
+     * @param {import('../../platform/input/mouse-event.js').MouseEvent
+     * |import('../../platform/input/touch-event.js').TouchEvent} event - MouseEvent or TouchEvent
+     * that was originally raised.
      * @param {import('../components/element/component.js').ElementComponent} element - The
      * ElementComponent that this event was originally raised on.
      * @param {import('../components/camera/component.js').CameraComponent} camera - The
@@ -125,9 +126,10 @@ class ElementInputEvent {
      */
     constructor(event, element, camera) {
         /**
-         * The MouseEvent or TouchEvent that was originally raised.
+         * MouseEvent or TouchEvent that was originally raised.
          *
-         * @type {MouseEvent|TouchEvent}
+         * @type {import('../../platform/input/mouse-event.js').MouseEvent
+         * |import('../../platform/input/touch-event.js').TouchEvent}
          */
         this.event = event;
 
@@ -170,7 +172,8 @@ class ElementMouseEvent extends ElementInputEvent {
     /**
      * Create an instance of an ElementMouseEvent.
      *
-     * @param {MouseEvent} event - The MouseEvent that was originally raised.
+     * @param {import('../../platform/input/mouse-event.js').MouseEvent} event - The MouseEvent that
+     * was originally raised.
      * @param {import('../components/element/component.js').ElementComponent} element - The
      * ElementComponent that this event was originally raised on.
      * @param {import('../components/camera/component.js').CameraComponent} camera - The
@@ -264,14 +267,14 @@ class ElementTouchEvent extends ElementInputEvent {
     /**
      * Create an instance of an ElementTouchEvent.
      *
-     * @param {TouchEvent} event - The TouchEvent that was originally raised.
+     * @param {import('../../platform/input/touch-event.js').TouchEvent} event - The TouchEvent that was originally raised.
      * @param {import('../components/element/component.js').ElementComponent} element - The
      * ElementComponent that this event was originally raised on.
      * @param {import('../components/camera/component.js').CameraComponent} camera - The
      * CameraComponent that this event was originally raised via.
      * @param {number} x - The x coordinate of the touch that triggered the event.
      * @param {number} y - The y coordinate of the touch that triggered the event.
-     * @param {Touch} touch - The touch object that triggered the event.
+     * @param {import('../../platform/input/touch-event.js').Touch} touch - The touch object that triggered the event.
      */
     constructor(event, element, camera, x, y, touch) {
         super(event, element, camera);
@@ -280,14 +283,14 @@ class ElementTouchEvent extends ElementInputEvent {
          * The Touch objects representing all current points of contact with the surface,
          * regardless of target or changed status.
          *
-         * @type {Touch[]}
+         * @type {import('../../platform/input/touch-event.js').Touch[]}
          */
         this.touches = event.touches;
         /**
          * The Touch objects representing individual points of contact whose states changed between
          * the previous touch event and this one.
          *
-         * @type {Touch[]}
+         * @type {import('../../platform/input/touch-event.js').Touch[]}
          */
         this.changedTouches = event.changedTouches;
         this.x = x;
@@ -295,7 +298,7 @@ class ElementTouchEvent extends ElementInputEvent {
         /**
          * The touch object that triggered the event.
          *
-         * @type {Touch}
+         * @type {import('../../platform/input/touch-event.js').Touch}
          */
         this.touch = touch;
     }

--- a/src/platform/audio/channel.js
+++ b/src/platform/audio/channel.js
@@ -33,6 +33,7 @@ class Channel {
 
         this.manager = manager;
 
+        /** @type {globalThis.Node | null} */
         this.source = null;
 
         if (hasAudioContext()) {

--- a/src/platform/input/touch-event.js
+++ b/src/platform/input/touch-event.js
@@ -2,7 +2,7 @@
  * This function takes a browser Touch object and returns the coordinates of the touch relative to
  * the target DOM element.
  *
- * @param {Touch} touch - The browser Touch object.
+ * @param {globalThis.Touch} touch - The browser Touch object.
  * @returns {object} The coordinates of the touch relative to the touch.target DOM element. In the
  * format \{x, y\}.
  * @category Input
@@ -65,14 +65,14 @@ class Touch {
     /**
      * The original browser Touch object.
      *
-     * @type {Touch}
+     * @type {globalThis.Touch}
      */
     touch;
 
     /**
      * Create a new Touch object from the browser Touch.
      *
-     * @param {Touch} touch - The browser Touch object.
+     * @param {globalThis.Touch} touch - The browser Touch object.
      */
     constructor(touch) {
         const coords = getTouchTargetCoords(touch);
@@ -102,7 +102,7 @@ class TouchEvent {
     /**
      * The original browser TouchEvent.
      *
-     * @type {TouchEvent}
+     * @type {globalThis.TouchEvent}
      */
     event;
 
@@ -125,7 +125,7 @@ class TouchEvent {
      *
      * @param {import('./touch-device.js').TouchDevice} device - The source device of the touch
      * events.
-     * @param {TouchEvent} event - The original browser TouchEvent.
+     * @param {globalThis.TouchEvent} event - The original browser TouchEvent.
      */
     constructor(device, event) {
         this.element = event.target;

--- a/src/platform/input/touch-event.js
+++ b/src/platform/input/touch-event.js
@@ -2,7 +2,7 @@
  * This function takes a browser Touch object and returns the coordinates of the touch relative to
  * the target DOM element.
  *
- * @param {globalThis.Touch} touch - The browser Touch object.
+ * @param {Touch} touch - The browser Touch object.
  * @returns {object} The coordinates of the touch relative to the touch.target DOM element. In the
  * format \{x, y\}.
  * @category Input
@@ -65,14 +65,14 @@ class Touch {
     /**
      * The original browser Touch object.
      *
-     * @type {globalThis.Touch}
+     * @type {Touch}
      */
     touch;
 
     /**
      * Create a new Touch object from the browser Touch.
      *
-     * @param {globalThis.Touch} touch - The browser Touch object.
+     * @param {Touch} touch - The browser Touch object.
      */
     constructor(touch) {
         const coords = getTouchTargetCoords(touch);
@@ -102,7 +102,7 @@ class TouchEvent {
     /**
      * The original browser TouchEvent.
      *
-     * @type {globalThis.TouchEvent}
+     * @type {TouchEvent}
      */
     event;
 
@@ -125,7 +125,7 @@ class TouchEvent {
      *
      * @param {import('./touch-device.js').TouchDevice} device - The source device of the touch
      * events.
-     * @param {globalThis.TouchEvent} event - The original browser TouchEvent.
+     * @param {TouchEvent} event - The original browser TouchEvent.
      */
     constructor(device, event) {
         this.element = event.target;


### PR DESCRIPTION
- Use `import` when declaring types from files not referenced in current file (removes dollar on type rollup).
- Set type of `source` in `Channel` to explicitly be `globalThis.Node` to stop conflict with animation `Node` class.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
