### PR TITLE
Compute shader bind group can specify textures without samplers

### DIFF
--- a/examples/src/examples/compute/histogram/config.mjs
+++ b/examples/src/examples/compute/histogram/config.mjs
@@ -8,8 +8,7 @@ export default {
         'compute-shader.wgsl': /* wgsl */ `
 
             @group(0) @binding(0) var inputTexture: texture_2d<f32>;
-            // @group(0) @binding(1) is a sampler of the inputTexture, but we don't need it in the shader.
-            @group(0) @binding(2) var<storage, read_write> bins: array<atomic<u32>>;
+            @group(0) @binding(1) var<storage, read_write> bins: array<atomic<u32>>;
     
             fn luminance(color: vec3f) -> f32 {
                 return saturate(dot(color, vec3f(0.2126, 0.7152, 0.0722)));

--- a/examples/src/examples/compute/histogram/example.mjs
+++ b/examples/src/examples/compute/histogram/example.mjs
@@ -104,8 +104,8 @@ assetListLoader.load(() => {
         computeBindGroupFormat: new pc.BindGroupFormat(device, [
             // no uniform buffer
         ], [
-            // input texture - the scene color map
-            new pc.BindTextureFormat('uSceneColorMap', pc.SHADERSTAGE_COMPUTE)
+            // input texture - the scene color map, without a sampler
+            new pc.BindTextureFormat('uSceneColorMap', pc.SHADERSTAGE_COMPUTE, undefined, undefined, false)
         ], [
             // no storage textures
         ], [

--- a/examples/src/examples/compute/texture-gen/config.mjs
+++ b/examples/src/examples/compute/texture-gen/config.mjs
@@ -14,10 +14,8 @@ export default {
             }
 
             @group(0) @binding(0) var<uniform> ubCompute : ub_compute;
-
             @group(0) @binding(1) var inputTexture: texture_2d<f32>;
-            // @group(0) @binding(2) is a sampler of the inputTexture, but we don't need it in the shader.
-            @group(0) @binding(3) var outputTexture: texture_storage_2d<rgba8unorm, write>;
+            @group(0) @binding(2) var outputTexture: texture_storage_2d<rgba8unorm, write>;
 
             @compute @workgroup_size(1, 1, 1)
             fn main(@builtin(global_invocation_id) global_id : vec3u) {

--- a/examples/src/examples/compute/texture-gen/example.mjs
+++ b/examples/src/examples/compute/texture-gen/example.mjs
@@ -104,7 +104,7 @@ assetListLoader.load(() => {
             new pc.BindBufferFormat(pc.UNIFORM_BUFFER_DEFAULT_SLOT_NAME, pc.SHADERSTAGE_COMPUTE)
         ], [
             // input textures
-            new pc.BindTextureFormat('inTexture', pc.SHADERSTAGE_COMPUTE)
+            new pc.BindTextureFormat('inTexture', pc.SHADERSTAGE_COMPUTE, undefined, undefined, false)
         ], [
             // output storage textures
             new pc.BindStorageTextureFormat('outTexture', pc.PIXELFORMAT_RGBA8, pc.TEXTUREDIMENSION_2D)

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -51,7 +51,7 @@ class BindTextureFormat {
     /** @type {import('./scope-id.js').ScopeId} */
     scopeId;
 
-    constructor(name, visibility, textureDimension = TEXTUREDIMENSION_2D, sampleType = SAMPLETYPE_FLOAT) {
+    constructor(name, visibility, textureDimension = TEXTUREDIMENSION_2D, sampleType = SAMPLETYPE_FLOAT, useSampler = true) {
         /** @type {string} */
         this.name = name;
 
@@ -63,6 +63,9 @@ class BindTextureFormat {
 
         // SAMPLETYPE_***
         this.sampleType = sampleType;
+
+        // whether to use a sampler with this texture
+        this.useSampler = useSampler;
     }
 }
 

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -51,7 +51,7 @@ class BindTextureFormat {
     /** @type {import('./scope-id.js').ScopeId} */
     scopeId;
 
-    constructor(name, visibility, textureDimension = TEXTUREDIMENSION_2D, sampleType = SAMPLETYPE_FLOAT, useSampler = true) {
+    constructor(name, visibility, textureDimension = TEXTUREDIMENSION_2D, sampleType = SAMPLETYPE_FLOAT, hasSampler = true) {
         /** @type {string} */
         this.name = name;
 
@@ -65,7 +65,7 @@ class BindTextureFormat {
         this.sampleType = sampleType;
 
         // whether to use a sampler with this texture
-        this.useSampler = useSampler;
+        this.hasSampler = hasSampler;
     }
 }
 

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -158,20 +158,22 @@ class WebgpuBindGroupFormat {
             });
 
             // sampler
-            const gpuSamplerType = samplerTypes[sampleType];
-            Debug.assert(gpuSamplerType);
+            if (textureFormat.useSampler) {
+                const gpuSamplerType = samplerTypes[sampleType];
+                Debug.assert(gpuSamplerType);
 
-            key += `#${index}S:${visibility}-${gpuSamplerType}`;
+                key += `#${index}S:${visibility}-${gpuSamplerType}`;
 
-            entries.push({
-                binding: index++,
-                visibility: visibility,
-                sampler: {
-                    // Indicates the required type of a sampler bound to this bindings
-                    // 'filtering', 'non-filtering', 'comparison'
-                    type: gpuSamplerType
-                }
-            });
+                entries.push({
+                    binding: index++,
+                    visibility: visibility,
+                    sampler: {
+                        // Indicates the required type of a sampler bound to this bindings
+                        // 'filtering', 'non-filtering', 'comparison'
+                        type: gpuSamplerType
+                    }
+                });
+            }
         });
 
         // storage textures

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -158,7 +158,7 @@ class WebgpuBindGroupFormat {
             });
 
             // sampler
-            if (textureFormat.useSampler) {
+            if (textureFormat.hasSampler) {
                 const gpuSamplerType = samplerTypes[sampleType];
                 Debug.assert(gpuSamplerType);
 

--- a/src/platform/graphics/webgpu/webgpu-bind-group.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group.js
@@ -97,7 +97,7 @@ class WebgpuBindGroup {
             });
 
             // sampler
-            if (textureFormat.useSampler) {
+            if (textureFormat.hasSampler) {
                 const sampler = wgpuTexture.getSampler(device, textureFormat.sampleType);
                 Debug.assert(sampler, 'NULL sampler cannot be used by the bind group');
                 Debug.call(() => {

--- a/src/platform/graphics/webgpu/webgpu-bind-group.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group.js
@@ -97,16 +97,18 @@ class WebgpuBindGroup {
             });
 
             // sampler
-            const sampler = wgpuTexture.getSampler(device, textureFormat.sampleType);
-            Debug.assert(sampler, 'NULL sampler cannot be used by the bind group');
-            Debug.call(() => {
-                this.debugFormat += `${index}: ${sampler.label}\n`;
-            });
+            if (textureFormat.useSampler) {
+                const sampler = wgpuTexture.getSampler(device, textureFormat.sampleType);
+                Debug.assert(sampler, 'NULL sampler cannot be used by the bind group');
+                Debug.call(() => {
+                    this.debugFormat += `${index}: ${sampler.label}\n`;
+                });
 
-            entries.push({
-                binding: index++,
-                resource: sampler
-            });
+                entries.push({
+                    binding: index++,
+                    resource: sampler
+                });
+            }
         });
 
         // storage textures


### PR DESCRIPTION
- as compute shader often loads texture values without sampler (raw data), provide an option to not supply the sampler.