### PR TITLE
Simplified BindGroup constructor

### DIFF
--- a/examples/src/examples/compute/histogram/example.mjs
+++ b/examples/src/examples/compute/histogram/example.mjs
@@ -102,13 +102,8 @@ assetListLoader.load(() => {
 
         // format of a bind group, providing resources for the compute shader
         computeBindGroupFormat: new pc.BindGroupFormat(device, [
-            // no uniform buffer
-        ], [
             // input texture - the scene color map, without a sampler
-            new pc.BindTextureFormat('uSceneColorMap', pc.SHADERSTAGE_COMPUTE, undefined, undefined, false)
-        ], [
-            // no storage textures
-        ], [
+            new pc.BindTextureFormat('uSceneColorMap', pc.SHADERSTAGE_COMPUTE, undefined, undefined, false),
             // output storage buffer
             new pc.BindStorageBufferFormat('outBuffer', pc.SHADERSTAGE_COMPUTE)
         ])

--- a/examples/src/examples/compute/texture-gen/example.mjs
+++ b/examples/src/examples/compute/texture-gen/example.mjs
@@ -101,11 +101,9 @@ assetListLoader.load(() => {
         // format of a bind group, providing resources for the compute shader
         computeBindGroupFormat: new pc.BindGroupFormat(device, [
             // a uniform buffer we provided format for
-            new pc.BindBufferFormat(pc.UNIFORM_BUFFER_DEFAULT_SLOT_NAME, pc.SHADERSTAGE_COMPUTE)
-        ], [
+            new pc.BindBufferFormat(pc.UNIFORM_BUFFER_DEFAULT_SLOT_NAME, pc.SHADERSTAGE_COMPUTE),
             // input textures
-            new pc.BindTextureFormat('inTexture', pc.SHADERSTAGE_COMPUTE, undefined, undefined, false)
-        ], [
+            new pc.BindTextureFormat('inTexture', pc.SHADERSTAGE_COMPUTE, undefined, undefined, false),
             // output storage textures
             new pc.BindStorageTextureFormat('outTexture', pc.PIXELFORMAT_RGBA8, pc.TEXTUREDIMENSION_2D)
         ])

--- a/src/platform/graphics/shader-processor.js
+++ b/src/platform/graphics/shader-processor.js
@@ -307,7 +307,7 @@ class ShaderProcessor {
             // validate types in else
 
         });
-        const meshBindGroupFormat = new BindGroupFormat(device, bufferFormats, textureFormats);
+        const meshBindGroupFormat = new BindGroupFormat(device, [...bufferFormats, ...textureFormats]);
 
         // generate code for uniform buffers
         let code = '';

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -71,18 +71,6 @@ class WebgpuBindGroupFormat {
     }
 
     /**
-     * Returns texture binding slot.
-     *
-     * @param {import('../bind-group-format.js').BindGroupFormat} bindGroupFormat - Bind group format.
-     * @param {number} index - The index of the texture.
-     * @returns {number} - The slot index.
-     */
-    getTextureSlot(bindGroupFormat, index) {
-        // each texture takes 2 slots (texture, sampler) and those are added after uniform buffers
-        return bindGroupFormat.bufferFormats.length + index * 2;
-    }
-
-    /**
      * @param {any} bindGroupFormat - The format of the bind group.
      * @returns {any} Returns the bind group descriptor.
      */
@@ -98,16 +86,15 @@ class WebgpuBindGroupFormat {
 
         // generate unique key
         let key = '';
-        let index = 0;
 
         // buffers
         bindGroupFormat.bufferFormats.forEach((bufferFormat) => {
 
             const visibility = WebgpuUtils.shaderStage(bufferFormat.visibility);
-            key += `#${index}U:${visibility}`;
+            key += `#${bufferFormat.slot}U:${visibility}`;
 
             entries.push({
-                binding: index++,
+                binding: bufferFormat.slot,
                 visibility: visibility,
 
                 buffer: {
@@ -137,11 +124,11 @@ class WebgpuBindGroupFormat {
             const gpuSampleType = sampleTypes[sampleType];
             Debug.assert(gpuSampleType);
 
-            key += `#${index}T:${visibility}-${gpuSampleType}-${viewDimension}-${multisampled}`;
+            key += `#${textureFormat.slot}T:${visibility}-${gpuSampleType}-${viewDimension}-${multisampled}`;
 
             // texture
             entries.push({
-                binding: index++,
+                binding: textureFormat.slot,
                 visibility: visibility,
                 texture: {
                     // Indicates the type required for texture views bound to this binding.
@@ -162,10 +149,10 @@ class WebgpuBindGroupFormat {
                 const gpuSamplerType = samplerTypes[sampleType];
                 Debug.assert(gpuSamplerType);
 
-                key += `#${index}S:${visibility}-${gpuSamplerType}`;
+                key += `#${textureFormat.slot + 1}S:${visibility}-${gpuSamplerType}`;
 
                 entries.push({
-                    binding: index++,
+                    binding: textureFormat.slot + 1,
                     visibility: visibility,
                     sampler: {
                         // Indicates the required type of a sampler bound to this bindings
@@ -180,11 +167,11 @@ class WebgpuBindGroupFormat {
         bindGroupFormat.storageTextureFormats.forEach((textureFormat) => {
 
             const { format, textureDimension } = textureFormat;
-            key += `#${index}ST:${format}-${textureDimension}`;
+            key += `#${textureFormat.slot}ST:${format}-${textureDimension}`;
 
             // storage texture
             entries.push({
-                binding: index++,
+                binding: textureFormat.slot,
                 visibility: GPUShaderStage.COMPUTE,
                 storageTexture: {
 
@@ -206,10 +193,10 @@ class WebgpuBindGroupFormat {
 
             const readOnly = false;
             const visibility = WebgpuUtils.shaderStage(bufferFormat.visibility);
-            key += `#${index}SB:${visibility}-${readOnly ? 'ro' : 'rw'}`;
+            key += `#${bufferFormat.slot}SB:${visibility}-${readOnly ? 'ro' : 'rw'}`;
 
             entries.push({
-                binding: index++,
+                binding: bufferFormat.slot,
                 visibility: visibility,
                 buffer: {
 

--- a/src/platform/graphics/webgpu/webgpu-bind-group.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group.js
@@ -59,16 +59,17 @@ class WebgpuBindGroup {
         });
 
         // uniform buffers
-        let index = 0;
-        bindGroup.uniformBuffers.forEach((ub) => {
+        const uniformBufferFormats = bindGroup.format.bufferFormats;
+        bindGroup.uniformBuffers.forEach((ub, i) => {
+            const slot = uniformBufferFormats[i].slot;
             const buffer = ub.persistent ? ub.impl.buffer : ub.allocation.gpuBuffer.buffer;
             Debug.assert(buffer, 'NULL uniform buffer cannot be used by the bind group');
             Debug.call(() => {
-                this.debugFormat += `${index}: UB\n`;
+                this.debugFormat += `${slot}: UB\n`;
             });
 
             entries.push({
-                binding: index++,
+                binding: slot,
                 resource: {
                     buffer: buffer,
                     offset: 0,
@@ -78,21 +79,23 @@ class WebgpuBindGroup {
         });
 
         // textures
+        const textureFormats = bindGroup.format.textureFormats
         bindGroup.textures.forEach((tex, textureIndex) => {
 
             /** @type {import('./webgpu-texture.js').WebgpuTexture} */
             const wgpuTexture = tex.impl;
             const textureFormat = format.textureFormats[textureIndex];
+            const slot = textureFormats[textureIndex].slot;
 
             // texture
             const view = wgpuTexture.getView(device);
             Debug.assert(view, 'NULL texture view cannot be used by the bind group');
             Debug.call(() => {
-                this.debugFormat += `${index}: ${bindGroup.format.textureFormats[textureIndex].name}\n`;
+                this.debugFormat += `${slot}: ${bindGroup.format.textureFormats[textureIndex].name}\n`;
             });
 
             entries.push({
-                binding: index++,
+                binding: slot,
                 resource: view
             });
 
@@ -101,47 +104,51 @@ class WebgpuBindGroup {
                 const sampler = wgpuTexture.getSampler(device, textureFormat.sampleType);
                 Debug.assert(sampler, 'NULL sampler cannot be used by the bind group');
                 Debug.call(() => {
-                    this.debugFormat += `${index}: ${sampler.label}\n`;
+                    this.debugFormat += `${slot + 1}: ${sampler.label}\n`;
                 });
 
                 entries.push({
-                    binding: index++,
+                    binding: slot + 1,
                     resource: sampler
                 });
             }
         });
 
         // storage textures
+        const storageTextureFormats = bindGroup.format.storageTextureFormats;
         bindGroup.storageTextures.forEach((tex, textureIndex) => {
 
             /** @type {import('./webgpu-texture.js').WebgpuTexture} */
             const wgpuTexture = tex.impl;
+            const slot = storageTextureFormats[textureIndex].slot;
 
             // texture
             const view = wgpuTexture.getView(device);
             Debug.assert(view, 'NULL texture view cannot be used by the bind group');
             Debug.call(() => {
-                this.debugFormat += `${index}: ${bindGroup.format.storageTextureFormats[textureIndex].name}\n`;
+                this.debugFormat += `${slot}: ${bindGroup.format.storageTextureFormats[textureIndex].name}\n`;
             });
 
             entries.push({
-                binding: index++,
+                binding: slot,
                 resource: view
             });
         });
 
         // storage buffers
+        const storageBufferFormats = bindGroup.format.storageBufferFormats;
         bindGroup.storageBuffers.forEach((buffer, bufferIndex) => {
             /** @type {GPUBuffer} */
             const wgpuBuffer = buffer.impl.buffer;
+            const slot = storageBufferFormats[bufferIndex].slot;
 
             Debug.assert(wgpuBuffer, 'NULL storage buffer cannot be used by the bind group');
             Debug.call(() => {
-                this.debugFormat += `${index}: SB\n`;
+                this.debugFormat += `${slot}: SB\n`;
             });
 
             entries.push({
-                binding: index++,
+                binding: slot,
                 resource: {
                     buffer: wgpuBuffer
                 }

--- a/src/platform/graphics/webgpu/webgpu-bind-group.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group.js
@@ -79,7 +79,7 @@ class WebgpuBindGroup {
         });
 
         // textures
-        const textureFormats = bindGroup.format.textureFormats
+        const textureFormats = bindGroup.format.textureFormats;
         bindGroup.textures.forEach((tex, textureIndex) => {
 
             /** @type {import('./webgpu-texture.js').WebgpuTexture} */

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -815,11 +815,11 @@ class Renderer {
             this.viewUniformFormat = new UniformBufferFormat(this.device, uniforms);
 
             // format of the view bind group - contains single uniform buffer, and some textures
-            const buffers = [
-                new BindBufferFormat(UNIFORM_BUFFER_DEFAULT_SLOT_NAME, SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT)
-            ];
+            const formats = [
 
-            const textures = [
+                // uniform buffer needs to be first, as the shader processor assumes slot 0 for it
+                new BindBufferFormat(UNIFORM_BUFFER_DEFAULT_SLOT_NAME, SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT),
+
                 new BindTextureFormat('lightsTextureFloat', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT),
                 new BindTextureFormat('lightsTexture8', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT),
                 new BindTextureFormat('shadowAtlasTexture', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_DEPTH),
@@ -830,12 +830,12 @@ class Renderer {
             ];
 
             if (isClustered) {
-                textures.push(...[
+                formats.push(...[
                     new BindTextureFormat('clusterWorldTexture', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT)
                 ]);
             }
 
-            this.viewBindGroupFormat = new BindGroupFormat(this.device, buffers, textures);
+            this.viewBindGroupFormat = new BindGroupFormat(this.device, formats);
         }
     }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -580,7 +580,6 @@ class ShadowRenderer {
             // format of the view bind group - contains single uniform buffer, and no textures
             this.viewBindGroupFormat = new BindGroupFormat(this.device, [
                 new BindBufferFormat(UNIFORM_BUFFER_DEFAULT_SLOT_NAME, SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT)
-            ], [
             ]);
         }
     }


### PR DESCRIPTION
- Simplified constructor of the BindGroup, which is manually specified for Compute shaders, to require a single array instead of up to 4 arrays.
- Slot allocation is also moved to platform independent level, to make it available and easy to understand to the user.

**Before:**
```
new pc.BindGroupFormat(device, [
        // no uniform buffer
    ], [
        new pc.BindTextureFormat('uSceneColorMap', pc.SHADERSTAGE_COMPUTE, undefined, undefined, false)
    ], [
        // no storage textures
    ], [
        new pc.BindStorageBufferFormat('outBuffer', pc.SHADERSTAGE_COMPUTE)
    ])
)
```

**Now:**
```
new pc.BindGroupFormat(device, [
    new pc.BindTextureFormat('uSceneColorMap', pc.SHADERSTAGE_COMPUTE, undefined, undefined, false),
    new pc.BindStorageBufferFormat('outBuffer', pc.SHADERSTAGE_COMPUTE)
])
```