### PR TITLE
ESM attributes rename

### DIFF
--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -155,13 +155,13 @@ class ScriptHandler extends ResourceHandler {
                 const extendsScriptType = scriptClass.prototype instanceof ScriptType;
 
                 if (extendsScriptType) {
-                    const attributes = new ScriptAttributes(scriptClass);
                     if (scriptClass.attributes) {
+                        const attributes = new ScriptAttributes(scriptClass);
                         for (const key in script.attributes) {
                             attributes.add(key, scriptClass.attributes[key]);
                         }
+                        scriptClass.attributes = attributes;
                     }
-                    scriptClass.attributes = attributes;
                     registerScript(scriptClass, scriptClass.name.toLowerCase());
                 }
             }

--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -6,6 +6,7 @@ import { registerScript } from '../script/script.js';
 import { ResourceLoader } from './loader.js';
 
 import { ResourceHandler } from './handler.js';
+import { ScriptAttributes } from '../script/script-attributes.js';
 
 /**
  * Resource handler for loading JavaScript files dynamically.  Two types of JavaScript files can be
@@ -154,13 +155,13 @@ class ScriptHandler extends ResourceHandler {
                 const extendsScriptType = scriptClass.prototype instanceof ScriptType;
 
                 if (extendsScriptType) {
-
-                    if (script.attributesDefinition) {
-                        for (const key in script.attributesDefinition) {
-                            scriptClass.attributes.add(key, script.attributesDefinition[key]);
+                    const attributes = new ScriptAttributes(scriptClass);
+                    if (scriptClass.attributes) {
+                        for (const key in script.attributes) {
+                            attributes.add(key, scriptClass.attributes[key]);
                         }
                     }
-
+                    scriptClass.attributes = attributes;
                     registerScript(scriptClass, scriptClass.name.toLowerCase());
                 }
             }


### PR DESCRIPTION
Currently ESM Scripts attributes are defined as follows

```javascript
class MyScript extends ScriptType {
    static attributesDefinition = { ... }
}
```

The static `attributesDefinition` is both verbose and confusingly names as we already use `attributes`. This PR uses the existing static `attributes` property which makes for a cleaner, more intuitive interface, and helps users migrate

```javascript
class MyScript extends ScriptType {
    static attributes = { ...  }
}
```

When the script is registered, this is used to populate the ScriptAttributes class and so becomes equivalent to using MyScript.attributes.add(...)`. Ini addition the `attributes` property [can already be](https://github.com/playcanvas/engine/blob/4ab0aceb0a4440eebb854a6e24e07dcf02805d66/src/framework/script/script-type.js#L253) a [plain object](https://github.com/playcanvas/engine/blob/4ab0aceb0a4440eebb854a6e24e07dcf02805d66/src/framework/script/script-type.js#L305), so this doesn't change things significantly, but it improves the overall usability of the class.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
