### PR TITLE
Mesh can be created and used without vertex attributes

### DIFF
--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -240,10 +240,13 @@ class MeshInstance {
         this.material = material;   // The material with which to render this instance
 
         this._shaderDefs = MASK_AFFECT_DYNAMIC << 16; // 2 byte toggles, 2 bytes light mask; Default value is no toggles and mask = pc.MASK_AFFECT_DYNAMIC
-        this._shaderDefs |= mesh.vertexBuffer.format.hasUv0 ? SHADERDEF_UV0 : 0;
-        this._shaderDefs |= mesh.vertexBuffer.format.hasUv1 ? SHADERDEF_UV1 : 0;
-        this._shaderDefs |= mesh.vertexBuffer.format.hasColor ? SHADERDEF_VCOLOR : 0;
-        this._shaderDefs |= mesh.vertexBuffer.format.hasTangents ? SHADERDEF_TANGENTS : 0;
+        if (mesh.vertexBuffer) {
+            const format = mesh.vertexBuffer.format;
+            this._shaderDefs |= format.hasUv0 ? SHADERDEF_UV0 : 0;
+            this._shaderDefs |= format.hasUv1 ? SHADERDEF_UV1 : 0;
+            this._shaderDefs |= format.hasColor ? SHADERDEF_VCOLOR : 0;
+            this._shaderDefs |= format.hasTangents ? SHADERDEF_TANGENTS : 0;
+        }
 
         // Render options
         this.layer = LAYER_WORLD; // legacy
@@ -517,7 +520,7 @@ class MeshInstance {
             if (!shaderInstance.shader) {
 
                 const shader = mat.getShaderVariant(this.mesh.device, scene, shaderDefs, null, shaderPass, sortedLights,
-                                                    viewUniformFormat, viewBindGroupFormat, this._mesh.vertexBuffer.format);
+                                                    viewUniformFormat, viewBindGroupFormat, this._mesh.vertexBuffer?.format);
 
                 // add it to the material variants cache
                 mat.variants.set(variantKey, shader);

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -935,7 +935,8 @@ class Mesh extends RefCountedObject {
 
         // if we don't have index buffer, create new one, otherwise update existing one
         if (this.indexBuffer.length <= 0 || !this.indexBuffer[0]) {
-            const createFormat = this._geometryData.maxVertices > 0xffff ? INDEXFORMAT_UINT32 : INDEXFORMAT_UINT16;
+            const maxVertices = this._geometryData.maxVertices;
+            const createFormat = ((maxVertices > 0xffff) || (maxVertices === 0)) ? INDEXFORMAT_UINT32 : INDEXFORMAT_UINT16;
             const options = this._storageIndex ? { storage: true } : undefined;
             this.indexBuffer[0] = new IndexBuffer(this.device, createFormat, this._geometryData.maxIndices, this._geometryData.indicesUsage, undefined, options);
         }


### PR DESCRIPTION
- we can now render meshes without vertex buffer
- this is useful for cases where vertex data are procedurally generated, or loaded from textures / storage buffers