### PR TITLE
Particles example using compute shader simulation

### DIFF
--- a/examples/src/examples/compute/particles/config.mjs
+++ b/examples/src/examples/compute/particles/config.mjs
@@ -1,0 +1,145 @@
+/**
+ * @type {import('../../../../types.mjs').ExampleConfig}
+ */
+export default {
+    HIDDEN: true,
+    WEBGPU_REQUIRED: true,
+    FILES: {
+
+        // part of the shader containing the Particle struct that is shared between the simulation
+        // and rendering shaders
+        'shader-shared.wgsl': /* wgsl */`
+            struct Particle {
+                position: vec3<f32>,
+                collisionTime: f32,
+                positionOld: vec3<f32>,
+                originalVelocity: vec3<f32>
+            }
+        `,
+
+        // simulation compute shader
+        'shader-simulation.wgsl': /* wgsl */ `
+
+            // uniform buffer for the compute shader
+            struct ub_compute {
+                count: u32,              // number of particles
+                dt: f32,                 // delta time
+                sphereCount: u32         // number of spheres
+            }
+
+            // sphere struct used for the colliders
+            struct Sphere {
+                center: vec3<f32>,
+                radius: f32
+            }
+
+            @group(0) @binding(0) var<uniform> ubCompute : ub_compute;
+            @group(0) @binding(1) var<storage, read_write> particles: array<Particle>;
+            @group(0) @binding(2) var<storage, read> spheres: array<Sphere>;
+            
+            @compute @workgroup_size(64)
+            fn main(@builtin(global_invocation_id) global_invocation_id: vec3u) {
+
+                // particle index - ignore if out of bounds (as they get batched into groups of 64)
+                let index = global_invocation_id.x * 1024 + global_invocation_id.y;
+                if (index >= ubCompute.count) { return; }
+
+                // update times
+                var particle = particles[index];
+                particle.collisionTime += ubCompute.dt;
+
+                // if particle gets too far, reset it to its original position / velocity
+                var distance = length(particle.position);
+                if (distance > 300.0) {
+                    var temp = particle.position;
+                    var wrapDistance = distance - 300.0;
+                    particle.collisionTime = 100.0;
+                    particle.positionOld = vec3f(0.0, 0.0, 0.0) + wrapDistance * particle.originalVelocity;
+                    particle.position = particle.originalVelocity;
+                }
+
+                // Verlet integration for a simple physics simulation
+                var delta = (particle.position - particle.positionOld);
+                var next = particle.position + delta;
+
+                // handle collisions with spheres
+                for (var i = 0u; i < ubCompute.sphereCount; i++) {
+                    var center = spheres[i].center;
+                    var radius = spheres[i].radius;
+
+                    // if the particle is inside the sphere, move it to the surface
+                    if (length(next - center) < radius) {
+                        next = center + normalize(next - center) * radius;
+                        particle.collisionTime = 0.0;
+                    }
+                }
+
+                // write out the changes
+                particle.positionOld = particle.position;
+                particle.position = next;
+                particles[index] = particle;
+            }
+        `,
+
+        // rendering shader
+        'shader-rendering.wgsl': /* wgsl */`
+
+            // uniform buffer for the mesh
+            struct ub_mesh {
+                matrix_model : mat4x4f
+            }
+
+            // uniform buffer per view - this is provided by the engine and the layout just needs to match
+            struct ub_view {
+                matrix_viewProjection : mat4x4f
+            }
+
+            @group(0) @binding(0) var<uniform> uvMesh : ub_mesh;
+            @group(0) @binding(1) var<storage, read> particles: array<Particle>;
+            @group(1) @binding(0) var<uniform> ubView : ub_view;
+
+            // quad vertices - used to expand the particles into quads
+            var<private> pos : array<vec2f, 4> = array<vec2f, 4>(
+                vec2(-1.0, 1.0), vec2(1.0, 1.0), vec2(-1.0, -1.0), vec2(1.0, -1.0)
+            );
+
+            const particleSize = 0.04;
+
+            struct VertexOutput {
+                @builtin(position) position : vec4f,
+                @location(0) color: vec4f
+            }
+
+            @vertex
+            fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
+
+                // get particle position from the storage buffer
+                var particleIndex = vertexIndex / 4;
+                var particlePos = particles[particleIndex].position;
+
+                // extract camera left and up vectors from the view-projection matrix
+                var left = vec3f(ubView.matrix_viewProjection[0][0], ubView.matrix_viewProjection[1][0], ubView.matrix_viewProjection[2][0]);
+                var up = vec3f(ubView.matrix_viewProjection[0][1], ubView.matrix_viewProjection[1][1], ubView.matrix_viewProjection[2][1]);
+
+                // expand the particle into a quad
+                var quadVertexIndex = vertexIndex % 4;
+                var quadPos = vec3f(pos[quadVertexIndex] * particleSize, 0.0);
+                var expandedPos = quadPos.x * left + quadPos.y * up;
+
+                // projected position
+                var output : VertexOutput;
+                output.position = ubView.matrix_viewProjection * vec4(particlePos + expandedPos, 1.0);
+
+                // lerp between red and yellow based on the time since the particle collision
+                output.color = mix(vec4f(1.0, 1.0, 0.0, 1.0), vec4f(1.0, 0.0, 0.0, 1.0), particles[particleIndex].collisionTime / 7.0);
+
+                return output;
+            }
+
+            @fragment
+            fn fragmentMain(input : VertexOutput) -> @location(0) vec4f {
+                return input.color;
+            }
+        `
+    }
+};

--- a/examples/src/examples/compute/particles/example.mjs
+++ b/examples/src/examples/compute/particles/example.mjs
@@ -1,0 +1,275 @@
+import * as pc from 'playcanvas';
+import { deviceType, rootPath } from '@examples/utils';
+import files from '@examples/files';
+
+const canvas = document.getElementById('application-canvas');
+if (!(canvas instanceof HTMLCanvasElement)) {
+    throw new Error('No canvas found');
+}
+
+const assets = {
+    orbit: new pc.Asset('script', 'script', { url: rootPath + '/static/scripts/camera/orbit-camera.js' }),
+    helipad: new pc.Asset(
+        'helipad-env-atlas',
+        'texture',
+        { url: rootPath + '/static/assets/cubemaps/helipad-env-atlas.png' },
+        { type: pc.TEXTURETYPE_RGBP, mipmaps: false }
+    )
+};
+
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    glslangUrl: rootPath + '/static/lib/glslang/glslang.js',
+    twgslUrl: rootPath + '/static/lib/twgsl/twgsl.js'
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(document.body);
+createOptions.touch = new pc.TouchDevice(document.body);
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.ScriptComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ScriptHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
+app.start();
+
+// Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+// Ensure canvas is resized when window changes size
+const resize = () => app.resizeCanvas();
+window.addEventListener('resize', resize);
+app.on('destroy', () => {
+    window.removeEventListener('resize', resize);
+});
+
+const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+assetListLoader.load(() => {
+
+    // set up some general scene rendering properties
+    app.scene.toneMapping = pc.TONEMAP_ACES;
+    app.scene.skyboxMip = 2;
+    app.scene.skyboxIntensity = 0.2;
+    app.scene.envAtlas = assets.helipad.resource;
+
+    // create camera entity
+    const cameraEntity = new pc.Entity('camera');
+    cameraEntity.addComponent('camera');
+    app.root.addChild(cameraEntity);
+    cameraEntity.setPosition(-150, -60, 190);
+
+    // add orbit camera script with a mouse and a touch support
+    cameraEntity.addComponent('script');
+    cameraEntity.script.create("orbitCamera", {
+        attributes: {
+            inertiaFactor: 0.2,
+            frameOnStart: false,
+            distanceMax: 500
+        }
+    });
+    cameraEntity.script.create("orbitCameraInputMouse");
+    cameraEntity.script.create("orbitCameraInputTouch");
+
+    // ------- Particle simulation -------
+
+    const numParticles = 1024 * 1024;
+
+    // a compute shader that will simulate the particles stored in a storage buffer
+    const shader = device.supportsCompute ? new pc.Shader(device, {
+        name: 'SimulationShader',
+        shaderLanguage: pc.SHADERLANGUAGE_WGSL,
+        cshader: files['shader-shared.wgsl'] + files['shader-simulation.wgsl'],
+
+        // format of a uniform buffer used by the compute shader
+        computeUniformBufferFormat: new pc.UniformBufferFormat(device, [
+            new pc.UniformFormat('count', pc.UNIFORMTYPE_UINT),
+            new pc.UniformFormat('dt', pc.UNIFORMTYPE_FLOAT),
+            new pc.UniformFormat('sphereCount', pc.UNIFORMTYPE_UINT)
+        ]),
+
+        // format of a bind group, providing resources for the compute shader
+        computeBindGroupFormat: new pc.BindGroupFormat(device, [
+            // a uniform buffer we provided the format for
+            new pc.BindUniformBufferFormat(pc.UNIFORM_BUFFER_DEFAULT_SLOT_NAME, pc.SHADERSTAGE_COMPUTE),
+            // particle storage buffer
+            new pc.BindStorageBufferFormat('particles', pc.SHADERSTAGE_COMPUTE),
+            // rad only collision spheres
+            new pc.BindStorageBufferFormat('spheres', pc.SHADERSTAGE_COMPUTE, true)
+        ])
+    }) : null;
+
+    // Create a storage buffer to store particles
+    // see the particle size / alignment / padding here: https://tinyurl.com/particle-structure
+    const particleFloatSize = 12;
+    const particleStructSize = particleFloatSize * 4; // 4 bytes per float
+    const particleStorageBuffer = new pc.StorageBuffer(device, numParticles * particleStructSize,
+                                                       pc.BUFFERUSAGE_VERTEX | // vertex buffer reads it
+                                                       pc.BUFFERUSAGE_COPY_DST // CPU copies initial data to it
+    );
+
+    // generate initial particle data
+    const particleData = new Float32Array(numParticles * particleFloatSize);
+    const velocity = new pc.Vec3();
+    for (let i = 0; i < numParticles; ++i) {
+
+        // random velocity inside a cone
+        const r = 0.4 * Math.sqrt(Math.random());
+        const theta = Math.random() * 2 * Math.PI;
+        velocity.set(r * Math.cos(theta), -1, r * Math.sin(theta));
+        const speed = 0.6 + Math.random() * 0.6;
+        velocity.normalize().mulScalar(speed);
+
+        // store the data in the buffer at matching offsets
+        const base = i * particleFloatSize;
+
+        // position
+        particleData[base + 0] = velocity.x;
+        particleData[base + 1] = velocity.y;
+        particleData[base + 2] = velocity.z;
+
+        // time since collision - large as no recent collision
+        particleData[base + 3] = 100;
+
+        // old position (spawn position)
+        particleData[base + 4] = 0;
+        particleData[base + 5] = 0;
+        particleData[base + 6] = 0;
+
+        // original velocity
+        particleData[base + 8] = velocity.x;
+        particleData[base + 9] = velocity.y;
+        particleData[base + 10] = velocity.z;
+    }
+
+    // upload the data to the buffer
+    particleStorageBuffer.write(0, particleData);
+
+    // collision spheres
+    const numSpheres = 3;
+    const sphereData = new Float32Array(numSpheres * 4);
+
+    const sphereMaterial = new pc.StandardMaterial();
+    sphereMaterial.gloss = 0.6;
+    sphereMaterial.metalness = 0.4;
+    sphereMaterial.useMetalness = true;
+    sphereMaterial.update();
+
+    const addSphere = (index, x, y, z, r) => {
+        const base = index * 4;
+        sphereData[base + 0] = x;
+        sphereData[base + 1] = y;
+        sphereData[base + 2] = z;
+        sphereData[base + 3] = r;
+
+        // visuals
+        const sphere = new pc.Entity();
+        sphere.addComponent('render', {
+            type: 'sphere',
+            material: sphereMaterial
+        });
+        sphere.setLocalScale(r * 2, r * 2, r * 2);
+        sphere.setLocalPosition(x, y, z);
+        app.root.addChild(sphere);
+
+        return sphere;
+    };
+
+    // add 3 sphere
+    addSphere(0, 28, -70, 0, 27);
+    const s1 = addSphere(1, -38, -130, 0, 35);
+    addSphere(2, 45, -210, 35, 70);
+
+    // camera focuses on one of the spheres
+    cameraEntity.script.orbitCamera.focusEntity = s1;
+
+    // upload the sphere data to the buffer
+    const sphereStorageBuffer = new pc.StorageBuffer(device, numSpheres * 16, pc.BUFFERUSAGE_COPY_DST);
+    sphereStorageBuffer.write(0, sphereData);
+
+    // Create an instance of the compute shader and assign buffers to it
+    const compute = new pc.Compute(device, shader, 'ComputeParticles');
+    compute.setParameter('particles', particleStorageBuffer);
+    compute.setParameter('spheres', sphereStorageBuffer);
+
+    // constant uniforms
+    compute.setParameter('count', numParticles);
+    compute.setParameter('sphereCount', numSpheres);
+
+    // ------- Particle rendering -------
+
+    // use WGSL shader for rendering as GLSL does not have access to storage buffers
+    const shaderSource = files['shader-shared.wgsl'] + files['shader-rendering.wgsl'];
+    const shaderDefinition = {
+        vshader: shaderSource,
+        fshader: shaderSource,
+        shaderLanguage: pc.SHADERLANGUAGE_WGSL,
+
+        // For now WGSL shaders need to provide their own bind group formats as they aren't processed.
+        // This has to match the structs in the shader.
+        meshUniformBufferFormat: new pc.UniformBufferFormat(app.graphicsDevice, [
+            new pc.UniformFormat('matrix_model', pc.UNIFORMTYPE_MAT4)
+        ]),
+        meshBindGroupFormat: new pc.BindGroupFormat(app.graphicsDevice, [
+            // uniforms
+            new pc.BindUniformBufferFormat(pc.UNIFORM_BUFFER_DEFAULT_SLOT_NAME, pc.SHADERSTAGE_VERTEX | pc.SHADERSTAGE_FRAGMENT),
+            // particle storage buffer in read-only mode
+            new pc.BindStorageBufferFormat('particles', pc.SHADERSTAGE_VERTEX | pc.SHADERSTAGE_FRAGMENT, true)
+        ])
+    };
+
+    // material to render the particles
+    const material = new pc.Material();
+    material.shader = new pc.Shader(app.graphicsDevice, shaderDefinition);
+
+    // index buffer - two triangles (6 indices) per particle using 4 vertices
+    const indices = new Uint32Array(numParticles * 6);
+    for (let i = 0; i < numParticles; ++i) {
+        const vertBase = i * 4;
+        const triBase = i * 6;
+        indices[triBase + 0] = vertBase;
+        indices[triBase + 1] = vertBase + 2;
+        indices[triBase + 2] = vertBase + 1;
+        indices[triBase + 3] = vertBase + 1;
+        indices[triBase + 4] = vertBase + 2;
+        indices[triBase + 5] = vertBase + 3;
+    }
+
+    // create a mesh without vertex buffer - we will use the particle storage buffer to supply positions
+    const mesh = new pc.Mesh(device);
+    mesh.setIndices(indices);
+    mesh.update();
+    const meshInstance = new pc.MeshInstance(mesh, material);
+    meshInstance.cull = false;  // disable culling as we did not supply custom aabb for the mesh instance
+
+    const entity = new pc.Entity();
+    entity.addComponent('render', {
+        meshInstances: [meshInstance]
+    });
+    app.root.addChild(entity);
+
+    app.on('update', function (/** @type {number} */ dt) {
+
+        if (device.supportsCompute) {
+
+            // update non-constant parameters each frame
+            compute.setParameter('dt', dt);
+
+            // dispatch the compute shader to simulate the particles
+            compute.setupDispatch(1024 / 64, 1024);
+            device.computeDispatch([compute]);
+        }
+    });
+});
+
+export { app };

--- a/examples/src/examples/graphics/wgsl-shader/config.mjs
+++ b/examples/src/examples/graphics/wgsl-shader/config.mjs
@@ -21,12 +21,12 @@ export default {
             }
 
             @group(0) @binding(0) var<uniform> uvMesh : ub_mesh;
-            @group(1) @binding(0) var<uniform> uvView : ub_view;
+            @group(1) @binding(0) var<uniform> ubView : ub_view;
 
             @vertex
             fn vertexMain(@location(0) position : vec4f) -> VertexOutput {
                 var output : VertexOutput;
-                output.position = uvView.matrix_viewProjection * (uvMesh.matrix_model * position);
+                output.position = ubView.matrix_viewProjection * (uvMesh.matrix_model * position);
                 output.fragPosition = 0.5 * (position + vec4(1.0));
                 return output;
             }

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -3,7 +3,7 @@ import { Debug, DebugHelper } from '../../core/debug.js';
 
 import {
     TEXTUREDIMENSION_2D, TEXTUREDIMENSION_CUBE, TEXTUREDIMENSION_3D, TEXTUREDIMENSION_2D_ARRAY,
-    SAMPLETYPE_FLOAT, PIXELFORMAT_RGBA8, SAMPLETYPE_INT, SAMPLETYPE_UINT, SHADERSTAGE_COMPUTE
+    SAMPLETYPE_FLOAT, PIXELFORMAT_RGBA8, SAMPLETYPE_INT, SAMPLETYPE_UINT, SHADERSTAGE_COMPUTE, SHADERSTAGE_VERTEX
 } from './constants.js';
 
 let id = 0;
@@ -49,6 +49,7 @@ class BindStorageBufferFormat extends BindBaseFormat {
 
         // whether the buffer is read-only
         this.readOnly = readOnly;
+        Debug.assert(readOnly || !(visibility & SHADERSTAGE_VERTEX), "Storage buffer can only be used in read-only mode in SHADERSTAGE_VERTEX.");
     }
 }
 

--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -81,7 +81,7 @@ class BindGroup {
      */
     setUniformBuffer(name, uniformBuffer) {
         const index = this.format.bufferFormatsMap.get(name);
-        Debug.assert(index !== undefined, `Setting a uniform [${name}] on a bind group with id ${this.id} which does not contain in, while rendering [${DebugGraphics.toString()}]`, this);
+        Debug.assert(index !== undefined, `Setting a uniform [${name}] on a bind group with id ${this.id} which does not contain it, while rendering [${DebugGraphics.toString()}]`, this);
         if (this.uniformBuffers[index] !== uniformBuffer) {
             this.uniformBuffers[index] = uniformBuffer;
             this.dirty = true;
@@ -97,7 +97,7 @@ class BindGroup {
      */
     setStorageBuffer(name, storageBuffer) {
         const index = this.format.storageBufferFormatsMap.get(name);
-        Debug.assert(index !== undefined, `Setting a storage buffer [${name}] on a bind group with id: ${this.id} which does not contain in, while rendering [${DebugGraphics.toString()}]`, this);
+        Debug.assert(index !== undefined, `Setting a storage buffer [${name}] on a bind group with id: ${this.id} which does not contain it, while rendering [${DebugGraphics.toString()}]`, this);
         if (this.storageBuffers[index] !== storageBuffer) {
             this.storageBuffers[index] = storageBuffer;
             this.dirty = true;
@@ -112,7 +112,7 @@ class BindGroup {
      */
     setTexture(name, texture) {
         const index = this.format.textureFormatsMap.get(name);
-        Debug.assert(index !== undefined, `Setting a texture [${name}] on a bind group with id: ${this.id} which does not contain in, while rendering [${DebugGraphics.toString()}]`, this);
+        Debug.assert(index !== undefined, `Setting a texture [${name}] on a bind group with id: ${this.id} which does not contain it, while rendering [${DebugGraphics.toString()}]`, this);
         if (this.textures[index] !== texture) {
             this.textures[index] = texture;
             this.dirty = true;
@@ -130,7 +130,7 @@ class BindGroup {
      */
     setStorageTexture(name, texture) {
         const index = this.format.storageTextureFormatsMap.get(name);
-        Debug.assert(index !== undefined, `Setting a storage texture [${name}] on a bind group with id: ${this.id} which does not contain in, while rendering [${DebugGraphics.toString()}]`, this);
+        Debug.assert(index !== undefined, `Setting a storage texture [${name}] on a bind group with id: ${this.id} which does not contain it, while rendering [${DebugGraphics.toString()}]`, this);
         if (this.storageTextures[index] !== texture) {
             this.storageTextures[index] = texture;
             this.dirty = true;

--- a/src/platform/graphics/storage-buffer.js
+++ b/src/platform/graphics/storage-buffer.js
@@ -20,11 +20,12 @@ class StorageBuffer {
      * @param {import('./graphics-device.js').GraphicsDevice} graphicsDevice - The graphics device
      * used to manage this storage buffer.
      * @param {number} byteSize - The size of the storage buffer in bytes.
-     * @param {number} bufferUsage - The usage type of the storage buffer. Can be a combination of
+     * @param {number} [bufferUsage] - The usage type of the storage buffer. Can be a combination of
      * {@link BUFFERUSAGE_READ}, {@link BUFFERUSAGE_WRITE}, {@link BUFFERUSAGE_COPY_SRC} and
-     * {@link BUFFERUSAGE_COPY_DST} flags.
+     * {@link BUFFERUSAGE_COPY_DST} flags. This parameter can be omitted if no special usage is
+     * required.
      */
-    constructor(graphicsDevice, byteSize, bufferUsage) {
+    constructor(graphicsDevice, byteSize, bufferUsage = 0) {
         this.device = graphicsDevice;
         this.byteSize = byteSize;
         this.bufferUsage = bufferUsage;
@@ -59,6 +60,10 @@ class StorageBuffer {
 
     read(offset = 0, size = this.byteSize, data = null) {
         return this.impl.read(this.device, offset, size, data);
+    }
+
+    write(bufferOffset = 0, data, dataOffset = 0, size) {
+        this.impl.write(this.device, bufferOffset, data, dataOffset, size);
     }
 
     clear(offset = 0, size = this.byteSize) {

--- a/src/platform/graphics/webgpu/webgpu-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-buffer.js
@@ -98,6 +98,10 @@ class WebgpuBuffer {
         return device.readStorageBuffer(this, offset, size, data);
     }
 
+    write(device, bufferOffset, data, dataOffset, size) {
+        device.writeStorageBuffer(this, bufferOffset, data, dataOffset, size);
+    }
+
     clear(device, offset, size) {
         device.clearStorageBuffer(this, offset, size);
     }

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -852,7 +852,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      *
      * @param {import('./webgpu-buffer.js').WebgpuBuffer} storageBuffer - The storage buffer.
      * @param {number} [offset] - The offset of data to read. Defaults to 0.
-     * @param {number} [size] - The size of data to read. Defaults to the full size of the buffer.
+     * @param {number} [size] - The byte size of data to read. Defaults to the full size of the
+     * buffer.
      * @param {ArrayBufferView} [data] - Typed array to populate with the data read from the storage
      * buffer. When typed array is supplied, enough space needs to be reserved, otherwise only
      * partial data is copied. If not specified, the data is returned in an Uint8Array. Defaults to
@@ -919,6 +920,23 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
                 });
             }
         });
+    }
+
+    /**
+     * Issues a write operation of the provided data into a storage buffer.
+     *
+     * @param {import('./webgpu-buffer.js').WebgpuBuffer} storageBuffer - The storage buffer.
+     * @param {number} bufferOffset - The offset in bytes to start writing to the storage buffer.
+     * @param {ArrayBufferView} data - The data to write to the storage buffer.
+     * @param {number} dataOffset - Offset in data to begin writing from. Given in elements if data
+     * is a TypedArray and bytes otherwise.
+     * @param {number} size - Size of content to write from data to buffer. Given in elements if
+     * data is a TypedArray and bytes otherwise.
+     */
+    writeStorageBuffer(storageBuffer, bufferOffset = 0, data, dataOffset = 0, size) {
+        Debug.assert(storageBuffer.buffer);
+        Debug.assert(data);
+        this.wgpu.queue.writeBuffer(storageBuffer.buffer, bufferOffset, data, dataOffset, size);
     }
 
     /**


### PR DESCRIPTION
- feature to upload data to compute buffer
- example that simulates 1M of particles using compute shader, renders them using WGSL vertex / fragment shader by reading data from the simulated storage buffer

screenshot:
![Screenshot 2024-04-10 at 11 24 41](https://github.com/playcanvas/engine/assets/59932779/bdf6d07a-9d5c-4f56-b5f3-1ea3f492b4c0)

very heavily compressed video, destroying the visuals completely:

https://github.com/playcanvas/engine/assets/59932779/d73428f4-04ca-4f17-93f7-028c611b5cf6

