### PR TITLE
Handle a render pass debug logging issue where index is not provided

### DIFF
--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -386,7 +386,7 @@ class RenderPass {
     }
 
     // #if _DEBUG
-    log(device, index) {
+    log(device, index = 0) {
         if (Tracing.get(TRACEID_RENDER_PASS) || Tracing.get(TRACEID_RENDER_PASS_DETAIL)) {
 
             const rt = this.renderTarget ?? (this.renderTarget === null ? device.backBuffer : null);


### PR DESCRIPTION
when render passes are manually rendered before the engine's first frame, the index is undefined, and `.string()` on it throws.