### PR TITLE
Fix color buffer clear when using partial viewport

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-clear-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-clear-renderer.js
@@ -112,7 +112,7 @@ class WebgpuClearRenderer {
             DebugGraphics.pushGpuMarker(device, 'CLEAR-RENDERER');
 
             // setup clear color
-            if ((flags & CLEARFLAG_COLOR) && renderTarget.colorBuffer) {
+            if ((flags & CLEARFLAG_COLOR) && (renderTarget.colorBuffer || renderTarget.impl.assignedColorTexture)) {
                 const color = options.color ?? defaultOptions.color;
                 this.colorData.set(color);
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -676,7 +676,7 @@ class ForwardRenderer extends Renderer {
      * storing the view level bing groups (can be empty array, and this function populates if per
      * view).
      * @param {object} [options] - Object for passing optional arguments.
-     * @param {boolean} [options.clearColors] - True if the color buffer should be cleared.
+     * @param {boolean} [options.clearColor] - True if the color buffer should be cleared.
      * @param {boolean} [options.clearDepth] - True if the depth buffer should be cleared.
      * @param {boolean} [options.clearStencil] - True if the stencil buffer should be cleared.
      * @param {import('../lighting/world-clusters.js').WorldClusters} [options.lightClusters] - The
@@ -693,7 +693,7 @@ class ForwardRenderer extends Renderer {
         this.setupViewport(camera, renderTarget);
 
         // clearing
-        const clearColor = options.clearColors ?? false;
+        const clearColor = options.clearColor ?? false;
         const clearDepth = options.clearDepth ?? false;
         const clearStencil = options.clearStencil ?? false;
         if (clearColor || clearDepth || clearStencil) {


### PR DESCRIPTION
Fixed https://github.com/playcanvas/engine/issues/6231

fixes both WebGL and WebGPU issues when clearing only a viewport. WebGPU worked on render targets, but didn't handle the default backbuffer.