### PR TITLE
The Preprocessor class now handles includes

### DIFF
--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -4,7 +4,7 @@ import { Debug } from './debug.js';
 const TRACEID = 'Preprocessor';
 
 // accepted keywords
-const KEYWORD = /[ \t]*#(ifn?def|if|endif|else|elif|define|undef|extension)/g;
+const KEYWORD = /[ \t]*#(ifn?def|if|endif|else|elif|define|undef|extension|include)/g;
 
 // #define EXPRESSION
 const DEFINE = /define[ \t]+([^\n]+)\r?(?:\n|$)/g;
@@ -30,6 +30,9 @@ const DEFINED = /(!|\s)?defined\(([\w-]+)\)/;
 // currently unsupported characters in the expression: | & < > = + -
 const INVALID = /[><=|&+-]/g;
 
+// #include "identifier"
+const INCLUDE = /include[ \t]+"([\w-]+)"\r?(?:\n|$)/g;
+
 /**
  * Pure static class implementing subset of C-style preprocessor.
  * inspired by: https://github.com/dcodeIO/Preprocessor.js
@@ -41,10 +44,12 @@ class Preprocessor {
      * Run c-like preprocessor on the source code, and resolves the code based on the defines and ifdefs
      *
      * @param {string} source - The source code to work on.
+     * @param {object} [includes] - An object containing key-value pairs of include names and their
+     * content.
      * @param {boolean} [stripUnusedColorAttachments] - If true, strips unused color attachments.
      * @returns {string|null} Returns preprocessed source code, or null in case of error.
      */
-    static run(source, stripUnusedColorAttachments = false) {
+    static run(source, includes = {}, stripUnusedColorAttachments = false) {
 
         // strips comments, handles // and many cases of /*
         source = source.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, '$1');
@@ -76,7 +81,7 @@ class Preprocessor {
         }
 
         // preprocess defines / ifdefs ..
-        source = this._preprocess(source, defines);
+        source = this._preprocess(source, defines, includes);
 
         // extract defines that evaluate to an integer number
         const intDefines = new Map();
@@ -131,9 +136,11 @@ class Preprocessor {
      * @param {Map<string, string>} defines - Supplied defines which are used in addition to those
      * defined in the source code. Maps a define name to its value. Note that the map is modified
      * by the function.
+     * @param {object} [includes] - An object containing key-value pairs of include names and their
+     * content.
      * @returns {string} Returns preprocessed source code.
      */
-    static _preprocess(source, defines = new Map()) {
+    static _preprocess(source, defines = new Map(), includes) {
 
         const originalSource = source;
 
@@ -299,6 +306,33 @@ class Preprocessor {
                         Debug.trace(TRACEID, `${keyword}: [${endif[2]}] => ${result}`);
                     }
 
+                    break;
+                }
+
+                case 'include': {
+                    // match the include
+                    INCLUDE.lastIndex = match.index;
+                    const include = INCLUDE.exec(source);
+                    error ||= include === null;
+                    Debug.assert(include, `Invalid [${keyword}]: ${source.substring(match.index, match.index + 100)}...`);
+                    const identifier = include[1].trim();
+
+                    // are we inside if-blocks that are accepted
+                    const keep = Preprocessor._keep(stack);
+
+                    if (keep) {
+
+                        // cut out the include line and replace it with the included string
+                        const includeSource = includes[identifier];
+                        if (includeSource) {
+                            source = source.substring(0, include.index - 1) + includeSource + source.substring(INCLUDE.lastIndex);
+                        } else {
+                            console.error(`Include not found: ${identifier}`);
+                            error = true;
+                        }
+                    }
+
+                    Debug.trace(TRACEID, `${keyword}: [${identifier}] ${keep ? "" : "IGNORED"}`);
                     break;
                 }
             }

--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -326,6 +326,9 @@ class Preprocessor {
                         const includeSource = includes[identifier];
                         if (includeSource) {
                             source = source.substring(0, include.index - 1) + includeSource + source.substring(INCLUDE.lastIndex);
+
+                            // process the just included test
+                            KEYWORD.lastIndex = include.index;
                         } else {
                             console.error(`Include not found: ${identifier}`);
                             error = true;

--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -44,12 +44,12 @@ class Preprocessor {
      * Run c-like preprocessor on the source code, and resolves the code based on the defines and ifdefs
      *
      * @param {string} source - The source code to work on.
-     * @param {object} [includes] - An object containing key-value pairs of include names and their
+     * @param {Map<string, string>} [includes] - An object containing key-value pairs of include names and their
      * content.
      * @param {boolean} [stripUnusedColorAttachments] - If true, strips unused color attachments.
      * @returns {string|null} Returns preprocessed source code, or null in case of error.
      */
-    static run(source, includes = {}, stripUnusedColorAttachments = false) {
+    static run(source, includes = new Map(), stripUnusedColorAttachments = false) {
 
         // strips comments, handles // and many cases of /*
         source = source.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, '$1');
@@ -136,7 +136,7 @@ class Preprocessor {
      * @param {Map<string, string>} defines - Supplied defines which are used in addition to those
      * defined in the source code. Maps a define name to its value. Note that the map is modified
      * by the function.
-     * @param {object} [includes] - An object containing key-value pairs of include names and their
+     * @param {Map<string, string>} [includes] - An object containing key-value pairs of include names and their
      * content.
      * @returns {string} Returns preprocessed source code.
      */
@@ -323,7 +323,7 @@ class Preprocessor {
                     if (keep) {
 
                         // cut out the include line and replace it with the included string
-                        const includeSource = includes[identifier];
+                        const includeSource = includes?.get(identifier);
                         if (includeSource) {
                             source = source.substring(0, include.index - 1) + includeSource + source.substring(INCLUDE.lastIndex);
 

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -112,7 +112,7 @@ class Shader {
             // Note: this is only needed for iOS 15 on WebGL2 where there seems to be a bug where color attachments that are not
             // written to generate metal linking errors. This is fixed on iOS 16, and iOS 14 does not support WebGL2.
             const stripUnusedColorAttachments = graphicsDevice.isWebGL2 && (platform.name === 'osx' || platform.name === 'ios');
-            definition.fshader = Preprocessor.run(definition.fshader, stripUnusedColorAttachments);
+            definition.fshader = Preprocessor.run(definition.fshader, {}, stripUnusedColorAttachments);
         }
 
         this.impl = graphicsDevice.createShaderImpl(this);

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -112,7 +112,7 @@ class Shader {
             // Note: this is only needed for iOS 15 on WebGL2 where there seems to be a bug where color attachments that are not
             // written to generate metal linking errors. This is fixed on iOS 16, and iOS 14 does not support WebGL2.
             const stripUnusedColorAttachments = graphicsDevice.isWebGL2 && (platform.name === 'osx' || platform.name === 'ios');
-            definition.fshader = Preprocessor.run(definition.fshader, {}, stripUnusedColorAttachments);
+            definition.fshader = Preprocessor.run(definition.fshader, undefined, stripUnusedColorAttachments);
         }
 
         this.impl = graphicsDevice.createShaderImpl(this);

--- a/test/core/preprocessor.test.mjs
+++ b/test/core/preprocessor.test.mjs
@@ -4,16 +4,15 @@ import { expect } from 'chai';
 
 describe('Preprocessor', function () {
 
-    const includes = {
-        'inc1': `
+    const includes = new Map([
+        ['inc1', `
             block1
             #ifdef FEATURE2
                 nested
             #endif
-        `,
-        'inc2': 'block2'
-    };
-
+        `],
+        ['inc2', 'block2']
+    ]);
     const srcData = `
         
         #define FEATURE1

--- a/test/core/preprocessor.test.mjs
+++ b/test/core/preprocessor.test.mjs
@@ -4,6 +4,11 @@ import { expect } from 'chai';
 
 describe('Preprocessor', function () {
 
+    const includes = {
+        'inc1': 'block1',
+        'inc2': 'block2'
+    };
+
     const srcData = `
         
         #define FEATURE1
@@ -11,6 +16,7 @@ describe('Preprocessor', function () {
 
         #ifdef FEATURE1
             TEST1
+            #include "inc1"
         #endif
 
         #if defined(FEATURE1)
@@ -23,12 +29,13 @@ describe('Preprocessor', function () {
             #endif
         #endif
 
-        #ifndef UNKOWN
+        #ifndef UNKNOWN
             TEST4
         #endif
 
         #if defined (UNKNOWN)
             TEST5
+            #include "inc2"
         #else
             TEST6
         #endif
@@ -130,4 +137,13 @@ describe('Preprocessor', function () {
     it('returns false for TEST14', function () {
         expect(Preprocessor.run(srcData).includes('TEST14')).to.equal(false);
     });
+
+    it('returns true for INC1', function () {
+        expect(Preprocessor.run(srcData, includes).includes('block1')).to.equal(true);
+    });
+
+    it('returns false for INC2', function () {
+        expect(Preprocessor.run(srcData, includes).includes('block2')).to.equal(false);
+    });
+
 });

--- a/test/core/preprocessor.test.mjs
+++ b/test/core/preprocessor.test.mjs
@@ -5,7 +5,12 @@ import { expect } from 'chai';
 describe('Preprocessor', function () {
 
     const includes = {
-        'inc1': 'block1',
+        'inc1': `
+            block1
+            #ifdef FEATURE2
+                nested
+            #endif
+        `,
         'inc2': 'block2'
     };
 
@@ -146,4 +151,7 @@ describe('Preprocessor', function () {
         expect(Preprocessor.run(srcData, includes).includes('block2')).to.equal(false);
     });
 
+    it('returns true for nested', function () {
+        expect(Preprocessor.run(srcData, includes).includes('nested')).to.equal(true);
+    });
 });

--- a/test/core/preprocessor.test.mjs
+++ b/test/core/preprocessor.test.mjs
@@ -76,71 +76,71 @@ describe('Preprocessor', function () {
     `;
 
     it('returns false for MORPH_A', function () {
-        expect(Preprocessor.run(srcData).includes('MORPH_A')).to.equal(false);
+        expect(Preprocessor.run(srcData, includes).includes('MORPH_A')).to.equal(false);
     });
 
     it('returns false for MORPH_B', function () {
-        expect(Preprocessor.run(srcData).includes('MORPH_B')).to.equal(false);
+        expect(Preprocessor.run(srcData, includes).includes('MORPH_B')).to.equal(false);
     });
 
     it('returns true for $', function () {
-        expect(Preprocessor.run(srcData).includes('$')).to.equal(true);
+        expect(Preprocessor.run(srcData, includes).includes('$')).to.equal(true);
     });
 
     it('returns true for TEST1', function () {
-        expect(Preprocessor.run(srcData).includes('TEST1')).to.equal(true);
+        expect(Preprocessor.run(srcData, includes).includes('TEST1')).to.equal(true);
     });
 
     it('returns true for TEST2', function () {
-        expect(Preprocessor.run(srcData).includes('TEST2')).to.equal(true);
+        expect(Preprocessor.run(srcData, includes).includes('TEST2')).to.equal(true);
     });
 
     it('returns true for TEST3', function () {
-        expect(Preprocessor.run(srcData).includes('TEST3')).to.equal(true);
+        expect(Preprocessor.run(srcData, includes).includes('TEST3')).to.equal(true);
     });
 
     it('returns true for TEST4', function () {
-        expect(Preprocessor.run(srcData).includes('TEST4')).to.equal(true);
+        expect(Preprocessor.run(srcData, includes).includes('TEST4')).to.equal(true);
     });
 
     it('returns false for TEST5', function () {
-        expect(Preprocessor.run(srcData).includes('TEST5')).to.equal(false);
+        expect(Preprocessor.run(srcData, includes).includes('TEST5')).to.equal(false);
     });
 
     it('returns true for TEST6', function () {
-        expect(Preprocessor.run(srcData).includes('TEST6')).to.equal(true);
+        expect(Preprocessor.run(srcData, includes).includes('TEST6')).to.equal(true);
     });
 
     it('returns false for TEST7', function () {
-        expect(Preprocessor.run(srcData).includes('TEST7')).to.equal(false);
+        expect(Preprocessor.run(srcData, includes).includes('TEST7')).to.equal(false);
     });
 
     it('returns false for TEST8', function () {
-        expect(Preprocessor.run(srcData).includes('TEST8')).to.equal(false);
+        expect(Preprocessor.run(srcData, includes).includes('TEST8')).to.equal(false);
     });
 
     it('returns false for TEST9', function () {
-        expect(Preprocessor.run(srcData).includes('TEST9')).to.equal(false);
+        expect(Preprocessor.run(srcData, includes).includes('TEST9')).to.equal(false);
     });
 
     it('returns true for TEST10', function () {
-        expect(Preprocessor.run(srcData).includes('TEST10')).to.equal(true);
+        expect(Preprocessor.run(srcData, includes).includes('TEST10')).to.equal(true);
     });
 
     it('returns false for TEST11', function () {
-        expect(Preprocessor.run(srcData).includes('TEST11')).to.equal(false);
+        expect(Preprocessor.run(srcData, includes).includes('TEST11')).to.equal(false);
     });
 
     it('returns false for TEST12', function () {
-        expect(Preprocessor.run(srcData).includes('TEST12')).to.equal(false);
+        expect(Preprocessor.run(srcData, includes).includes('TEST12')).to.equal(false);
     });
 
     it('returns true for TEST13', function () {
-        expect(Preprocessor.run(srcData).includes('TEST13')).to.equal(true);
+        expect(Preprocessor.run(srcData, includes).includes('TEST13')).to.equal(true);
     });
 
     it('returns false for TEST14', function () {
-        expect(Preprocessor.run(srcData).includes('TEST14')).to.equal(false);
+        expect(Preprocessor.run(srcData, includes).includes('TEST14')).to.equal(false);
     });
 
     it('returns true for INC1', function () {


### PR DESCRIPTION
The generic c-style preprocessor we use to preprocess shaders now handles includes, where the include line is replaced by the string specified in the includes dictionary. Accepted syntax:

```
#include "include-identifier"
```