### PR TITLE
add cors

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "docs": "typedoc",
     "lint": "eslint --ext .js,.mjs extras scripts src test utils rollup.config.mjs",
     "publint": "publint",
-    "serve": "serve build -l 51000",
+    "serve": "serve build -l 51000 --cors",
     "test": "mocha --recursive --require test/fixtures.mjs",
     "test:coverage": "c8 npm test",
     "test:karma": "karma start tests/karma.conf.cjs -- --single-run",


### PR DESCRIPTION
Running `use_local_engine` with ESM script requires engine is served with CORS headers.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
