### PR TITLE
ESM Attributes check

### DIFF
--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -155,9 +155,11 @@ class ScriptHandler extends ResourceHandler {
                 const extendsScriptType = scriptClass.prototype instanceof ScriptType;
 
                 if (extendsScriptType) {
-                    if (scriptClass.attributes) {
+
+                    // Check if attributes is defined directly on the class and not inherited
+                    if (scriptClass.hasOwnProperty('attributes')) {
                         const attributes = new ScriptAttributes(scriptClass);
-                        for (const key in script.attributes) {
+                        for (const key in scriptClass.attributes) {
                             attributes.add(key, scriptClass.attributes[key]);
                         }
                         scriptClass.attributes = attributes;


### PR DESCRIPTION
This PR changes the `attributes` check to check if it's defined directly on the class itself as opposed to being inherited from ScriptType, which was invoking the ScriptType getter.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
