### PR TITLE
Fix to recent VertexBuffer refactoring

### DIFF
--- a/src/platform/graphics/vertex-buffer.js
+++ b/src/platform/graphics/vertex-buffer.js
@@ -11,6 +11,8 @@ let id = 0;
  * @category Graphics
  */
 class VertexBuffer {
+    usage = BUFFER_STATIC;
+
     /**
      * Create a new VertexBuffer instance.
      *


### PR DESCRIPTION
usage could be uninitialized if both conditions fail.