### PR TITLE
ESM Scripts lower camel case

### DIFF
--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -8,6 +8,8 @@ import { ResourceLoader } from './loader.js';
 import { ResourceHandler } from './handler.js';
 import { ScriptAttributes } from '../script/script-attributes.js';
 
+const toLowerCamelCase = str => str[0].toLowerCase() + str.substring(1);
+
 /**
  * Resource handler for loading JavaScript files dynamically.  Two types of JavaScript files can be
  * loaded, PlayCanvas scripts which contain calls to {@link createScript}, or regular JavaScript
@@ -164,7 +166,7 @@ class ScriptHandler extends ResourceHandler {
                         }
                         scriptClass.attributes = attributes;
                     }
-                    registerScript(scriptClass, scriptClass.name.toLowerCase());
+                    registerScript(scriptClass, toLowerCamelCase(scriptClass.name));
                 }
             }
 


### PR DESCRIPTION
The PR changes the ESM script registration to use lower camel case instead of plain lowercase which is more inline with existing scripts.

`entity.script.scriptwithattributes` => `entity.script.scriptWithAttributes`

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
