### PR TITLE
Do not create a sky shader variant based on skyIntensity being equal to 1

### DIFF
--- a/src/scene/materials/lit-material-options-builder.js
+++ b/src/scene/materials/lit-material-options-builder.js
@@ -130,7 +130,7 @@ class LitMaterialOptionsBuilder {
         }
 
         const hasSkybox = !!litOptions.reflectionSource;
-        litOptions.skyboxIntensity = hasSkybox && (scene.skyboxIntensity !== 1 || scene.physicalUnits);
+        litOptions.skyboxIntensity = hasSkybox;
         litOptions.useCubeMapRotation = hasSkybox && scene._skyboxRotationShaderInclude;
     }
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -355,7 +355,7 @@ class StandardMaterialOptionsBuilder {
         }
 
         // TODO: add a test for if non skybox cubemaps have rotation (when this is supported) - for now assume no non-skybox cubemap rotation
-        options.litOptions.skyboxIntensity = usingSceneEnv && (scene.skyboxIntensity !== 1 || scene.physicalUnits);
+        options.litOptions.skyboxIntensity = usingSceneEnv;
         options.litOptions.useCubeMapRotation = usingSceneEnv && scene._skyboxRotationShaderInclude;
     }
 

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -40,7 +40,6 @@ import encodePS from './common/frag/encode.js';
 import endPS from './lit/frag/end.js';
 import endVS from './lit/vert/end.js';
 import envAtlasPS from './common/frag/envAtlas.js';
-import envConstPS from './common/frag/envConst.js';
 import envMultiplyPS from './common/frag/envMultiply.js';
 import extensionPS from './lit/frag/extension.js';
 import extensionVS from './lit/vert/extension.js';
@@ -253,7 +252,6 @@ const shaderChunks = {
     endPS,
     endVS,
     envAtlasPS,
-    envConstPS,
     envMultiplyPS,
     extensionPS,
     extensionVS,

--- a/src/scene/shader-lib/chunks/common/frag/envConst.js
+++ b/src/scene/shader-lib/chunks/common/frag/envConst.js
@@ -1,5 +1,0 @@
-export default /* glsl */`
-vec3 processEnvironment(vec3 color) {
-    return color;
-}
-`;

--- a/src/scene/shader-lib/chunks/skybox/frag/skyboxHDR.js
+++ b/src/scene/shader-lib/chunks/skybox/frag/skyboxHDR.js
@@ -26,7 +26,7 @@ void main(void) {
     #endif
 
     dir.x *= -1.0;
-    vec3 linear = $DECODE(textureCube(texture_cubeMap, fixSeamsStatic(dir, $FIXCONST)));
+    vec3 linear = $DECODE(textureCube(texture_cubeMap, fixSeamsStatic(dir, SKYBOX_MIP)));
     gl_FragColor = vec4(gammaCorrectOutput(toneMap(processEnvironment(linear))), 1.0);
 }
 `;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -770,7 +770,7 @@ class LitShader {
         if (this.needsNormal) {
             func.append(chunks.cubeMapRotatePS);
             func.append(options.cubeMapProjection > 0 ? chunks.cubeMapProjectBoxPS : chunks.cubeMapProjectNonePS);
-            func.append(options.skyboxIntensity ? chunks.envMultiplyPS : chunks.envConstPS);
+            func.append(chunks.envMultiplyPS);
         }
 
         if ((this.lighting && options.useSpecular) || this.reflections) {

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -38,7 +38,6 @@ class SkyMesh {
             const options = {
                 pass: pass,
                 encoding: texture.encoding,
-                useIntensity: scene.skyboxIntensity !== 1 || scene.physicalUnits,
                 gamma: (pass === SHADER_FORWARDHDR ? (scene.gammaCorrection ? GAMMA_SRGBHDR : GAMMA_NONE) : scene.gammaCorrection),
                 toneMapping: (pass === SHADER_FORWARDHDR ? TONEMAP_LINEAR : scene.toneMapping),
                 skymesh: type


### PR DESCRIPTION
- before, a sky shader variant would be created based on skyIntensity being equal to 1 or not. 
- this PR always includes intensity multiplication in the shader, and so this is not needed
- also slight refactor of skydome code generation - handling of mipmap selection using define instead of string replace