### PR TITLE
Compute shader JSDocs + small API changes

### DIFF
--- a/examples/src/examples/compute/histogram/example.mjs
+++ b/examples/src/examples/compute/histogram/example.mjs
@@ -112,7 +112,7 @@ assetListLoader.load(() => {
     // Create a storage buffer to which the compute shader will write the histogram values.
     const numBins = 256;
     const histogramStorageBuffer = new pc.StorageBuffer(
-        device, numBins * 4,     // 4 bytes per value, storing unsigned int
+        device, numBins * 4,      // 4 bytes per value, storing unsigned int
         pc.BUFFERUSAGE_COPY_SRC | // needed for reading back the data to CPU
         pc.BUFFERUSAGE_COPY_DST   // needed for clearing the buffer
     );

--- a/examples/src/examples/compute/particles/example.mjs
+++ b/examples/src/examples/compute/particles/example.mjs
@@ -92,16 +92,18 @@ assetListLoader.load(() => {
         cshader: files['shader-shared.wgsl'] + files['shader-simulation.wgsl'],
 
         // format of a uniform buffer used by the compute shader
-        computeUniformBufferFormat: new pc.UniformBufferFormat(device, [
-            new pc.UniformFormat('count', pc.UNIFORMTYPE_UINT),
-            new pc.UniformFormat('dt', pc.UNIFORMTYPE_FLOAT),
-            new pc.UniformFormat('sphereCount', pc.UNIFORMTYPE_UINT)
-        ]),
+        computeUniformBufferFormats: {
+            'ub': new pc.UniformBufferFormat(device, [
+                new pc.UniformFormat('count', pc.UNIFORMTYPE_UINT),
+                new pc.UniformFormat('dt', pc.UNIFORMTYPE_FLOAT),
+                new pc.UniformFormat('sphereCount', pc.UNIFORMTYPE_UINT)
+            ])
+        },
 
         // format of a bind group, providing resources for the compute shader
         computeBindGroupFormat: new pc.BindGroupFormat(device, [
             // a uniform buffer we provided the format for
-            new pc.BindUniformBufferFormat(pc.UNIFORM_BUFFER_DEFAULT_SLOT_NAME, pc.SHADERSTAGE_COMPUTE),
+            new pc.BindUniformBufferFormat('ub', pc.SHADERSTAGE_COMPUTE),
             // particle storage buffer
             new pc.BindStorageBufferFormat('particles', pc.SHADERSTAGE_COMPUTE),
             // rad only collision spheres

--- a/examples/src/examples/compute/texture-gen/example.mjs
+++ b/examples/src/examples/compute/texture-gen/example.mjs
@@ -91,17 +91,18 @@ assetListLoader.load(() => {
         shaderLanguage: pc.SHADERLANGUAGE_WGSL,
         cshader: files['compute-shader.wgsl'],
 
-        // format of a uniform buffer used by the compute shader
-        computeUniformBufferFormat: new pc.UniformBufferFormat(device, [
-            new pc.UniformFormat('tint', pc.UNIFORMTYPE_VEC4),
-            new pc.UniformFormat('offset', pc.UNIFORMTYPE_FLOAT),
-            new pc.UniformFormat('frequency', pc.UNIFORMTYPE_FLOAT)
-        ]),
+        computeUniformBufferFormats: {
+            'ub': new pc.UniformBufferFormat(device, [
+                new pc.UniformFormat('tint', pc.UNIFORMTYPE_VEC4),
+                new pc.UniformFormat('offset', pc.UNIFORMTYPE_FLOAT),
+                new pc.UniformFormat('frequency', pc.UNIFORMTYPE_FLOAT)
+            ])
+        },
 
         // format of a bind group, providing resources for the compute shader
         computeBindGroupFormat: new pc.BindGroupFormat(device, [
             // a uniform buffer we provided format for
-            new pc.BindUniformBufferFormat(pc.UNIFORM_BUFFER_DEFAULT_SLOT_NAME, pc.SHADERSTAGE_COMPUTE),
+            new pc.BindUniformBufferFormat('ub', pc.SHADERSTAGE_COMPUTE),
             // input textures
             new pc.BindTextureFormat('inTexture', pc.SHADERSTAGE_COMPUTE, undefined, undefined, false),
             // output storage textures

--- a/examples/src/examples/compute/vertex-update/example.mjs
+++ b/examples/src/examples/compute/vertex-update/example.mjs
@@ -118,17 +118,19 @@ assetListLoader.load(() => {
         cshader: files['compute-shader.wgsl'],
 
         // format of a uniform buffer used by the compute shader
-        computeUniformBufferFormat: new pc.UniformBufferFormat(device, [
-            new pc.UniformFormat('count', pc.UNIFORMTYPE_UINT),
-            new pc.UniformFormat('positionOffset', pc.UNIFORMTYPE_UINT),
-            new pc.UniformFormat('normalOffset', pc.UNIFORMTYPE_UINT),
-            new pc.UniformFormat('time', pc.UNIFORMTYPE_FLOAT)
-        ]),
+        computeUniformBufferFormats: {
+            'ub': new pc.UniformBufferFormat(device, [
+                new pc.UniformFormat('count', pc.UNIFORMTYPE_UINT),
+                new pc.UniformFormat('positionOffset', pc.UNIFORMTYPE_UINT),
+                new pc.UniformFormat('normalOffset', pc.UNIFORMTYPE_UINT),
+                new pc.UniformFormat('time', pc.UNIFORMTYPE_FLOAT)
+            ])
+        },
 
         // format of a bind group, providing resources for the compute shader
         computeBindGroupFormat: new pc.BindGroupFormat(device, [
             // a uniform buffer we provided format for
-            new pc.BindUniformBufferFormat(pc.UNIFORM_BUFFER_DEFAULT_SLOT_NAME, pc.SHADERSTAGE_COMPUTE),
+            new pc.BindUniformBufferFormat('ub', pc.SHADERSTAGE_COMPUTE),
             // the vertex buffer we want to modify
             new pc.BindStorageBufferFormat('vb', pc.SHADERSTAGE_COMPUTE)
         ])

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -16,15 +16,34 @@ const textureDimensionInfo = {
 };
 
 /**
- * @ignore
+ * A base class to describe the format of the resource for {@link BindGroupFormat}.
+ *
+ * @category Graphics
  */
 class BindBaseFormat {
-    /** @type {number} */
+    /**
+     * @type {number}
+     * @ignore
+     */
     slot = -1;
 
-    /** @type {import('./scope-id.js').ScopeId|null} */
+    /**
+     * @type {import('./scope-id.js').ScopeId|null}
+     * @ignore
+     */
     scopeId = null;
 
+    /**
+     * Create a new instance.
+     *
+     * @param {string} name - The name of the resource.
+     * @param {number} visibility - A bit-flag that specifies the shader stages in which the resource
+     * is visible. Can be:
+     *
+     * - {@link SHADERSTAGE_VERTEX}
+     * - {@link SHADERSTAGE_FRAGMENT}
+     * - {@link SHADERSTAGE_COMPUTE}
+     */
     constructor(name, visibility) {
         /** @type {string} */
         this.name = name;
@@ -35,15 +54,33 @@ class BindBaseFormat {
 }
 
 /**
- * @ignore
+ * A class to describe the format of the uniform buffer for {@link BindGroupFormat}.
+ *
+ * @category Graphics
  */
 class BindUniformBufferFormat extends BindBaseFormat {
 }
 
 /**
- * @ignore
+ * A class to describe the format of the storage buffer for {@link BindGroupFormat}.
+ *
+ * @category Graphics
  */
 class BindStorageBufferFormat extends BindBaseFormat {
+    /**
+     * Create a new instance.
+     *
+     * @param {string} name - The name of the storage buffer.
+     * @param {number} visibility - A bit-flag that specifies the shader stages in which the storage
+     * buffer is visible. Can be:
+     *
+     * - {@link SHADERSTAGE_VERTEX}
+     * - {@link SHADERSTAGE_FRAGMENT}
+     * - {@link SHADERSTAGE_COMPUTE}
+     *
+     * @param {boolean} readOnly - Whether the storage buffer is read-only, or read-write. Defaults
+     * to false. This has to be true for the storage buffer used in the vertex shader.
+     */
     constructor(name, visibility, readOnly = false) {
         super(name, visibility);
 
@@ -54,9 +91,45 @@ class BindStorageBufferFormat extends BindBaseFormat {
 }
 
 /**
- * @ignore
+ * A class to describe the format of the texture for {@link BindGroupFormat}.
+ *
+ * @category Graphics
  */
 class BindTextureFormat extends BindBaseFormat {
+    /**
+     * Create a new instance.
+     *
+     * @param {string} name - The name of the storage buffer.
+     * @param {number} visibility - A bit-flag that specifies the shader stages in which the storage
+     * buffer is visible. Can be:
+     *
+     * - {@link SHADERSTAGE_VERTEX}
+     * - {@link SHADERSTAGE_FRAGMENT}
+     * - {@link SHADERSTAGE_COMPUTE}
+     *
+     * @param {string} textureDimension - The dimension of the texture. Defaults to
+     * {@link TEXTUREDIMENSION_2D}. Can be:
+     *
+     * - {@link TEXTUREDIMENSION_1D}
+     * - {@link TEXTUREDIMENSION_2D}
+     * - {@link TEXTUREDIMENSION_2D_ARRAY}
+     * - {@link TEXTUREDIMENSION_CUBE}
+     * - {@link TEXTUREDIMENSION_CUBE_ARRAY}
+     * - {@link TEXTUREDIMENSION_3D}
+     *
+     * @param {number} sampleType - The type of the texture samples. Defaults to
+     * {@link SAMPLETYPE_FLOAT}. Can be:
+     *
+     * - {@link SAMPLETYPE_FLOAT}
+     * - {@link SAMPLETYPE_UNFILTERABLE_FLOAT}
+     * - {@link SAMPLETYPE_DEPTH}
+     * - {@link SAMPLETYPE_INT}
+     * - {@link SAMPLETYPE_UINT}
+     *
+     * @param {boolean} hasSampler - True if the sampler for the texture is needed. Note that if the
+     * sampler is used, it will take up an additional slot, directly following the texture slot.
+     * Defaults to true.
+     */
     constructor(name, visibility, textureDimension = TEXTUREDIMENSION_2D, sampleType = SAMPLETYPE_FLOAT, hasSampler = true) {
         super(name, visibility);
 
@@ -72,9 +145,28 @@ class BindTextureFormat extends BindBaseFormat {
 }
 
 /**
- * @ignore
+ * A class to describe the format of the storage texture for. Storage texture is a texture created
+ * with the storage flag set to true, which allows it to be used as an output of a compute shader.
+ * Note: At the current time, storage textures are only supported in compute shaders, in a
+ * write-only mode.
+ *
+ * @category Graphics
  */
 class BindStorageTextureFormat extends BindBaseFormat {
+    /**
+     * Create a new instance.
+     *
+     * @param {string} name - The name of the storage buffer.
+     * @param {number} format - The pixel format of the texture. Note that not all formats can be
+     * used. Defaults to {@link PIXELFORMAT_RGBA8}.
+     * @param {string} textureDimension - The dimension of the texture. Defaults to
+     * {@link TEXTUREDIMENSION_2D}. Can be:
+     *
+     * - {@link TEXTUREDIMENSION_1D}
+     * - {@link TEXTUREDIMENSION_2D}
+     * - {@link TEXTUREDIMENSION_2D_ARRAY}
+     * - {@link TEXTUREDIMENSION_3D}
+     */
     constructor(name, format = PIXELFORMAT_RGBA8, textureDimension = TEXTUREDIMENSION_2D) {
         super(name, SHADERSTAGE_COMPUTE);
 
@@ -87,26 +179,48 @@ class BindStorageTextureFormat extends BindBaseFormat {
 }
 
 /**
- * @ignore
+ * BindGroupFormat is a data structure that defines the layout of resources (buffers, textures,
+ * samplers) used by rendering or compute shaders. It describes the binding points for each
+ * resource type, and the visibility of these resources in the shader stages.
+ * Currently this class is only used on WebGPU platform to specify the input and output resources
+ * for vertex, fragment and compute shaders written in {@link SHADERLANGUAGE_WGSL} language.
+ *
+ * @category Graphics
  */
 class BindGroupFormat {
-    /** @type {BindUniformBufferFormat[]} */
+    /**
+     * @type {BindUniformBufferFormat[]}
+     * @private
+     */
     uniformBufferFormats = [];
 
-    /** @type {BindTextureFormat[]} */
+    /**
+     * @type {BindTextureFormat[]}
+     * @private
+     */
     textureFormats = [];
 
-    /** @type {BindStorageTextureFormat[]} */
+    /**
+     * @type {BindStorageTextureFormat[]}
+     * @private
+     */
     storageTextureFormats = [];
 
-    /** @type {BindStorageBufferFormat[]} */
+    /**
+     * @type {BindStorageBufferFormat[]}
+     * @private
+     */
     storageBufferFormats = [];
 
     /**
+     * Create a new instance.
+     *
      * @param {import('./graphics-device.js').GraphicsDevice} graphicsDevice - The graphics device
      * used to manage this vertex format.
-     * @param {(BindBaseFormat|BindTextureFormat|BindStorageTextureFormat|BindStorageBufferFormat)[]} formats
-     * - An array of bind formats.
+     * @param {(BindTextureFormat|BindStorageTextureFormat|BindUniformBufferFormat|BindStorageBufferFormat)[]} formats
+     * - An array of bind formats. Note that each entry in the array uses up one slot. The exception
+     * is a texture format that has a sampler, which uses up two slots. The slots are allocated
+     * sequentially, starting from 0.
      */
     constructor(graphicsDevice, formats) {
         this.id = id++;
@@ -193,6 +307,7 @@ class BindGroupFormat {
      *
      * @param {string} name - The name of the texture slot.
      * @returns {BindTextureFormat|null} - The format.
+     * @ignore
      */
     getTexture(name) {
         const index = this.textureFormatsMap.get(name);
@@ -208,6 +323,7 @@ class BindGroupFormat {
      *
      * @param {string} name - The name of the texture slot.
      * @returns {BindStorageTextureFormat|null} - The format.
+     * @ignore
      */
     getStorageTexture(name) {
         const index = this.storageTextureFormatsMap.get(name);

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -147,7 +147,7 @@ class BindTextureFormat extends BindBaseFormat {
 /**
  * A class to describe the format of the storage texture for. Storage texture is a texture created
  * with the storage flag set to true, which allows it to be used as an output of a compute shader.
- * Note: At the current time, storage textures are only supported in compute shaders, in a
+ * Note: At the current time, storage textures are only supported in compute shaders in a
  * write-only mode.
  *
  * @category Graphics

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -145,8 +145,9 @@ class BindTextureFormat extends BindBaseFormat {
 }
 
 /**
- * A class to describe the format of the storage texture for. Storage texture is a texture created
- * with the storage flag set to true, which allows it to be used as an output of a compute shader.
+ * A class to describe the format of the storage texture for {@link BindGroupFormat}. Storage
+ * texture is a texture created with the storage flag set to true, which allows it to be used as an
+ * output of a compute shader.
  * Note: At the current time, storage textures are only supported in compute shaders in a
  * write-only mode.
  *

--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -141,7 +141,17 @@ class BindGroup {
     }
 
     /**
-     * Applies any changes made to the bind group's properties.
+     * Updates the uniform buffers in this bind group.
+     */
+    updateUniformBuffers() {
+        for (let i = 0; i < this.uniformBuffers.length; i++) {
+            this.uniformBuffers[i].update();
+        }
+    }
+
+    /**
+     * Applies any changes made to the bind group's properties. Note that the content of used
+     * uniform buffers needs to be updated before calling this method.
      */
     update() {
 

--- a/src/platform/graphics/compute.js
+++ b/src/platform/graphics/compute.js
@@ -11,9 +11,8 @@ class ComputeParameter {
 }
 
 /**
- * A representation of a compute shader with the associated data, that can be executed on the GPU.
- *
- * @ignore
+ * A representation of a compute shader with the associated resources, that can be executed on the
+ * GPU. Only supported on WebGPU platform.
  */
 class Compute {
     /**
@@ -24,7 +23,11 @@ class Compute {
      */
     shader = null;
 
-    /** @type {string} */
+    /**
+     * The non-unique name of an instance of the class. Defaults to 'Unnamed'.
+     *
+     * @type {string}
+     */
     name;
 
     /**

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -203,10 +203,42 @@ export const BUFFERUSAGE_COPY_SRC = 0x0004;
  */
 export const BUFFERUSAGE_COPY_DST = 0x0008;
 
-// internal flags
+/**
+ * A flag utilized during the construction of a {@link StorageBuffer} to ensure its compatibility
+ * when used as an index buffer.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const BUFFERUSAGE_INDEX = 0x0010;
+
+/**
+ * A flag utilized during the construction of a {@link StorageBuffer} to ensure its compatibility
+ * when used as a vertex buffer.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const BUFFERUSAGE_VERTEX = 0x0020;
+
+/**
+ * A flag utilized during the construction of a {@link StorageBuffer} to ensure its compatibility
+ * when used as an uniform buffer.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const BUFFERUSAGE_UNIFORM = 0x0040;
+
+/**
+ * An internal flag utilized during the construction of a {@link StorageBuffer} to ensure its
+ * compatibility when used as a storage buffer.
+ * This flag is hidden as it's automatically used by the StorageBuffer constructor.
+ *
+ * @type {number}
+ * @category Graphics
+ * @ignore
+ */
 export const BUFFERUSAGE_STORAGE = 0x0080;
 
 /**
@@ -1467,17 +1499,94 @@ export const TEXHINT_SHADOWMAP = 1;
 export const TEXHINT_ASSET = 2;
 export const TEXHINT_LIGHTMAP = 3;
 
+/**
+ * Texture data is stored in a 1-dimensional texture.
+ *
+ * @type {string}
+ * @category Graphics
+ */
 export const TEXTUREDIMENSION_1D = '1d';
+
+/**
+ * Texture data is stored in a 2-dimensional texture.
+ *
+ * @type {string}
+ * @category Graphics
+ */
 export const TEXTUREDIMENSION_2D = '2d';
+
+/**
+ * Texture data is stored in an array of 2-dimensional textures.
+ *
+ * @type {string}
+ * @category Graphics
+ */
 export const TEXTUREDIMENSION_2D_ARRAY = '2d-array';
+
+/**
+ * Texture data is stored in a cube texture.
+ *
+ * @type {string}
+ * @category Graphics
+ */
 export const TEXTUREDIMENSION_CUBE = 'cube';
+
+/**
+ * Texture data is stored in an array of cube textures.
+ *
+ * @type {string}
+ * @category Graphics
+ */
 export const TEXTUREDIMENSION_CUBE_ARRAY = 'cube-array';
+
+/**
+ * Texture data is stored in a 3-dimensional texture.
+ *
+ * @type {string}
+ * @category Graphics
+ */
 export const TEXTUREDIMENSION_3D = '3d';
 
+/**
+ * A sampler type of a texture that contains floating-point data. Typically stored for color
+ * textures, where data can be filtered.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const SAMPLETYPE_FLOAT = 0;
+
+/**
+ * A sampler type of a texture that contains floating-point data, but cannot be filtered. Typically
+ * used for textures storing data that cannot be interpolated.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const SAMPLETYPE_UNFILTERABLE_FLOAT = 1;
+
+/**
+ * A sampler type of a texture that contains depth data. Typically used for depth textures.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const SAMPLETYPE_DEPTH = 2;
+
+/**
+ * A sampler type of a texture that contains signed integer data.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const SAMPLETYPE_INT = 3;
+
+/**
+ * A sampler type of a texture that contains unsigned integer data.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const SAMPLETYPE_UINT = 4;
 
 /**
@@ -1592,22 +1701,131 @@ export const TYPE_FLOAT32 = 6;
  */
 export const TYPE_FLOAT16 = 7;
 
-// Uniform types
+// ---------- Uniform types ------------
+// Note: Only types which can be used in uniform buffers are exported here, others are internal.
+// The arrays are exposed as a base type with number of elements, and textures are not part of the
+// uniform buffers.
+
+/**
+ * Boolean uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_BOOL = 0;
+
+/**
+ * Integer uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_INT = 1;
+
+/**
+ * Float uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_FLOAT = 2;
+
+/**
+ * 2 x Float uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_VEC2 = 3;
+
+/**
+ * 3 x Float uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_VEC3 = 4;
+
+/**
+ * 4 x Float uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_VEC4 = 5;
+
+/**
+ * 2 x Integer uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_IVEC2 = 6;
+
+/**
+ * 3 x Integer uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_IVEC3 = 7;
+
+/**
+ * 4 x Integer uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_IVEC4 = 8;
+
+/**
+ * 2 x Boolean uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_BVEC2 = 9;
+
+/**
+ * 3 x Boolean uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_BVEC3 = 10;
+
+/**
+ * 4 x Boolean uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_BVEC4 = 11;
+
+/**
+ * 2 x 2 x Float uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_MAT2 = 12;
+
+/**
+ * 3 x 3 x Float uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_MAT3 = 13;
+
+/**
+ * 4 x 4 x Float uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_MAT4 = 14;
+
 export const UNIFORMTYPE_TEXTURE2D = 15;
 export const UNIFORMTYPE_TEXTURECUBE = 16;
 export const UNIFORMTYPE_FLOATARRAY = 17;
@@ -1621,9 +1839,37 @@ export const UNIFORMTYPE_MAT4ARRAY = 24;
 export const UNIFORMTYPE_TEXTURE2D_ARRAY = 25;
 
 // Unsigned uniform types
+
+/**
+ * Unsigned integer uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_UINT = 26;
+
+/**
+ * 2 x Unsigned integer uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_UVEC2 = 27;
+
+/**
+ * 3 x Unsigned integer uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_UVEC3 = 28;
+
+/**
+ * 4 x Unsigned integer uniform type.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const UNIFORMTYPE_UVEC4 = 29;
 
 // Integer uniform array types
@@ -1649,6 +1895,8 @@ export const UNIFORMTYPE_ITEXTURE3D = 46;
 export const UNIFORMTYPE_UTEXTURE3D = 47;
 export const UNIFORMTYPE_ITEXTURE2D_ARRAY = 48;
 export const UNIFORMTYPE_UTEXTURE2D_ARRAY = 49;
+
+// ----------
 
 export const uniformTypeToName = [
     // Uniforms
@@ -1790,9 +2038,28 @@ export const DEVICETYPE_WEBGPU = 'webgpu';
  */
 export const DEVICETYPE_NULL = 'null';
 
-// (bit-flags) shader stages for resource visibility on the GPU
+/**
+ * The resource is visible to the vertex shader.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const SHADERSTAGE_VERTEX = 1;
+
+/**
+ * The resource is visible to the fragment shader.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const SHADERSTAGE_FRAGMENT = 2;
+
+/**
+ * The resource is visible to the compute shader.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const SHADERSTAGE_COMPUTE = 4;
 
 // indices of commonly used bind groups

--- a/src/platform/graphics/storage-buffer.js
+++ b/src/platform/graphics/storage-buffer.js
@@ -59,7 +59,7 @@ class StorageBuffer {
     }
 
     /**
-     * Read a content of a storage buffer.
+     * Read the contents of a storage buffer.
      *
      * @param {number} [offset] - The byte offset of data to read. Defaults to 0.
      * @param {number} [size] - The byte size of data to read. Defaults to the full size of the

--- a/src/platform/graphics/storage-buffer.js
+++ b/src/platform/graphics/storage-buffer.js
@@ -58,14 +58,45 @@ class StorageBuffer {
         vram.sb += size;
     }
 
+    /**
+     * Read a content of a storage buffer.
+     *
+     * @param {number} [offset] - The byte offset of data to read. Defaults to 0.
+     * @param {number} [size] - The byte size of data to read. Defaults to the full size of the
+     * buffer minus the offset.
+     * @param {ArrayBufferView|null} [data] - Typed array to populate with the data read from the storage
+     * buffer. When typed array is supplied, enough space needs to be reserved, otherwise only
+     * partial data is copied. If not specified, the data is returned in an Uint8Array. Defaults to
+     * null.
+     * @returns {Promise<ArrayBufferView>} A promise that resolves with the data read from the storage
+     * buffer.
+     * @ignore
+     */
     read(offset = 0, size = this.byteSize, data = null) {
         return this.impl.read(this.device, offset, size, data);
     }
 
+    /**
+     * Issues a write operation of the provided data into a storage buffer.
+     *
+     * @param {number} bufferOffset - The offset in bytes to start writing to the storage buffer.
+     * @param {ArrayBufferView} data - The data to write to the storage buffer.
+     * @param {number} dataOffset - Offset in data to begin writing from. Given in elements if data
+     * is a TypedArray and bytes otherwise.
+     * @param {number} size - Size of content to write from data to buffer. Given in elements if
+     * data is a TypedArray and bytes otherwise.
+     */
     write(bufferOffset = 0, data, dataOffset = 0, size) {
         this.impl.write(this.device, bufferOffset, data, dataOffset, size);
     }
 
+    /**
+     * Clear the content of a storage buffer to 0.
+     *
+     * @param {number} [offset] - The byte offset of data to clear. Defaults to 0.
+     * @param {number} [size] - The byte size of data to clear. Defaults to the full size of the
+     * buffer minus the offset.
+     */
     clear(offset = 0, size = this.byteSize) {
         this.impl.clear(this.device, offset, size);
     }

--- a/src/platform/graphics/uniform-buffer-format.js
+++ b/src/platform/graphics/uniform-buffer-format.js
@@ -37,34 +37,46 @@ uniformTypeToNumComponents[UNIFORMTYPE_UVEC4] = 4;
 
 /**
  * A class storing description of an individual uniform, stored inside a uniform buffer.
- *
- * @ignore
  */
 class UniformFormat {
-    /** @type {string} */
+    /**
+     * @type {string}
+     * @ignore
+     */
     name;
 
     // UNIFORMTYPE_***
-    /** @type {number} */
+    /**
+     * @type {number}
+     * @ignore
+     */
     type;
 
-    /** @type {number} */
+    /**
+     * @type {number}
+     * @ignore
+     */
     byteSize;
 
     /**
      * Index of the uniform in an array of 32bit values (Float32Array and similar)
      *
      * @type {number}
+     * @ignore
      */
     offset;
 
-    /** @type {import('./scope-id.js').ScopeId} */
+    /**
+     * @type {import('./scope-id.js').ScopeId}
+     * @ignore
+     */
     scopeId;
 
     /**
      * Count of elements for arrays, otherwise 0.
      *
      * @type {number}
+     * @ignore
      */
     count;
 
@@ -72,6 +84,7 @@ class UniformFormat {
      * Number of components in each element (e.g. vec2 has 2 components, mat4 has 16 components)
      *
      * @type {number}
+     * @ignore
      */
     numComponents;
 
@@ -84,6 +97,14 @@ class UniformFormat {
         return this.count > 0;
     }
 
+    /**
+     * Create a new UniformFormat instance.
+     *
+     * @param {string} name - The name of the uniform.
+     * @param {number} type - The type of the uniform. One of the UNIFORMTYPE_*** constants.
+     * @param {number} count - The number of elements in the array. Defaults to 0, which represents
+     * a single element (not an array).
+     */
     constructor(name, type, count = 0) {
 
         // just a name
@@ -154,7 +175,7 @@ class UniformFormat {
     }
 
     // std140 rules: https://registry.khronos.org/OpenGL/specs/gl/glspec45.core.pdf#page=159
-    // TODO: this support limited subset of functionality, arrays and structs are not supported.
+    // TODO: this supports limited subset of functionality, arrays and arrays of structs are not supported.
     calculateOffset(offset) {
 
         // Note: vec3 has the same alignment as vec4
@@ -172,14 +193,18 @@ class UniformFormat {
 
 /**
  * A descriptor that defines the layout of of data inside the {@link UniformBuffer}.
- *
- * @ignore
  */
 class UniformBufferFormat {
-    /** @type {number} */
+    /**
+     * @type {number}
+     * @ignore
+     */
     byteSize = 0;
 
-    /** @type {Map<string,UniformFormat>} */
+    /**
+     * @type {Map<string,UniformFormat>}
+     * @ignore
+     */
     map = new Map();
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -857,9 +857,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      * Read a content of a storage buffer.
      *
      * @param {import('./webgpu-buffer.js').WebgpuBuffer} storageBuffer - The storage buffer.
-     * @param {number} [offset] - The offset of data to read. Defaults to 0.
+     * @param {number} [offset] - The byte offset of data to read. Defaults to 0.
      * @param {number} [size] - The byte size of data to read. Defaults to the full size of the
-     * buffer.
+     * buffer minus the offset.
      * @param {ArrayBufferView} [data] - Typed array to populate with the data read from the storage
      * buffer. When typed array is supplied, enough space needs to be reserved, otherwise only
      * partial data is copied. If not specified, the data is returned in an Uint8Array. Defaults to
@@ -871,7 +871,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      * buffer.
      * @ignore
      */
-    readStorageBuffer(storageBuffer, offset = 0, size = storageBuffer.byteSize, data = null, immediate = false) {
+    readStorageBuffer(storageBuffer, offset = 0, size = storageBuffer.byteSize - offset, data = null, immediate = false) {
 
         // create a temporary staging buffer
         const stagingBuffer = this.createBufferImpl(BUFFERUSAGE_READ | BUFFERUSAGE_COPY_DST);

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -66,7 +66,7 @@ class WebgpuShader {
             this.meshUniformBufferFormat = definition.meshUniformBufferFormat;
             this.meshBindGroupFormat = definition.meshBindGroupFormat;
 
-            this.computeUniformBufferFormat = definition.computeUniformBufferFormat;
+            this.computeUniformBufferFormats = definition.computeUniformBufferFormats;
             this.computeBindGroupFormat = definition.computeBindGroupFormat;
 
             this.vertexEntryPoint = 'vertexMain';


### PR DESCRIPTION
- feature: compute shader can use multiple uniform buffers, instead of just a single default one
- all API needed to use Compute shader is now public, from Uniform buffer / Bind group formats to StorageBuffer and device submission.