### PR TITLE
WebGPU - skip unsupported device limits when creating device

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -239,6 +239,10 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         const requiredLimits = {};
         if (adapterLimits) {
             for (const limitName in adapterLimits) {
+                // skip these as they fail on Windows Chrome and are not part of spec currently
+                if (limitName === "minSubgroupSize" || limitName === "maxSubgroupSize") {
+                    continue;
+                }
                 requiredLimits[limitName] = adapterLimits[limitName];
             }
         }


### PR DESCRIPTION
- related to recent change to request maximum supported limits when creating WebGPU device
- currently in Chrome Windows, two limits are exposed, but not supported to set them it seem, so skip them to avoid device creation failing. Those are not part of the official spec currently:
```
DOMException: Failed to execute 'requestDevice' on 'GPUAdapter': The limit "minSubgroupSize" is not recognized.
    at WebgpuGraphicsDevice.initWebGpu (http://localhost:5000/iframe//ENGINE_PATH/platform/graphics/webgpu/webgpu-graphics-device.js:262:43)
```