### PR TITLE
Fix crash in GsplatMany example on WebGL due to no WebGL1 splat support

### DIFF
--- a/examples/src/examples/loaders/gsplat-many/example.mjs
+++ b/examples/src/examples/loaders/gsplat-many/example.mjs
@@ -132,8 +132,8 @@ assetListLoader.load(() => {
     app.on('update', function (dt) {
         currentTime += dt;
 
-        const material = guitar.gsplat.material;
-        material.setParameter('uTime', currentTime);
+        const material = guitar.gsplat?.material;
+        material?.setParameter('uTime', currentTime);
 
 
         biker2.rotate(0, 80 * dt, 0);


### PR DESCRIPTION
avoid undefined access