### PR TITLE
Add convex hull support to CollisionComponent

### DIFF
--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -106,6 +106,7 @@ class CollisionComponent extends Component {
         this.entity.on('insert', this._onInsert, this);
 
         this.on('set_type', this.onSetType, this);
+        this.on('set_convexHull', this.onSetModel, this);
         this.on('set_halfExtents', this.onSetHalfExtents, this);
         this.on('set_linearOffset', this.onSetOffset, this);
         this.on('set_angularOffset', this.onSetOffset, this);
@@ -272,6 +273,21 @@ class CollisionComponent extends Component {
 
     get renderAsset() {
         return this.data.renderAsset;
+    }
+
+    /**
+     * Whether the collision mesh should be treated as a convex hull. When false, the mesh can only
+     * be used with a static body. When true, the mesh can be used with a static, dynamic or
+     * kinematic body. Defaults to `false`.
+     *
+     * @type {boolean}
+     */
+    set convexHull(arg) {
+        this._setValue('convexHull', arg);
+    }
+
+    get convexHull() {
+        return this.data.convexHull;
     }
 
     /**

--- a/src/framework/components/collision/data.js
+++ b/src/framework/components/collision/data.js
@@ -11,6 +11,7 @@ class CollisionComponentData {
         this.radius = 0.5;
         this.axis = 1;
         this.height = 2;
+        this.convexHull = false;
         /** @type {import('../../../framework/asset/asset.js').Asset | number} */
         this.asset = null;
         /** @type {import('../../../framework/asset/asset.js').Asset | number} */


### PR DESCRIPTION
Hints to the physics engine that a collision mesh should be treated as a convex hull. This enables dynamic body meshes to collide with each other.

Here it is in action with `app.timeScale` set to `0.1` so you can observe the collisions more easily:

![convexhull](https://github.com/playcanvas/engine/assets/697563/98f594de-e522-48fe-990e-8d6b75f25237)

Adds new API:

`CollisionComponent#convexHull: boolean`

Needs to be exposed in the Editor. For now, you can experiment using the following script:

```js
var ConvexHull = pc.createScript('convexHull');

ConvexHull.attributes.add('convexHull', { type: 'boolean', default: false });

// initialize code called once per entity
ConvexHull.prototype.initialize = function() {
    this.entity.collision.convexHull = this.convexHull;

    this.on('attr', (name, value, prev) => {
        this.entity.collision.convexHull = value;
    });
};
```

Fixes #123

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
