### PR TITLE
Khronos PBR Neutral tone mapper for e-commerce

### DIFF
--- a/examples/src/examples/graphics/asset-viewer/example.mjs
+++ b/examples/src/examples/graphics/asset-viewer/example.mjs
@@ -195,7 +195,7 @@ assetListLoader.load(() => {
     app.root.addChild(directionalLight);
 
     app.scene.envAtlas = assets.helipad.resource;
-    app.scene.toneMapping = pc.TONEMAP_ACES;
+    app.scene.toneMapping = pc.TONEMAP_KHRONOS_NEUTRAL;
     app.scene.skyboxMip = 1;
     app.scene.skyboxRotation = new pc.Quat().setFromEulerAngles(0, 70, 0);
     app.scene.skyboxIntensity = 1.5;

--- a/examples/src/examples/graphics/post-processing/controls.mjs
+++ b/examples/src/examples/graphics/post-processing/controls.mjs
@@ -55,7 +55,8 @@ export function controls({ observer, ReactPCUI, React, jsx, fragment }) {
                         { v: pc.TONEMAP_FILMIC, t: 'FILMIC' },
                         { v: pc.TONEMAP_HEJL, t: 'HEJL' },
                         { v: pc.TONEMAP_ACES, t: 'ACES' },
-                        { v: pc.TONEMAP_ACES2, t: 'ACES2' }
+                        { v: pc.TONEMAP_ACES2, t: 'ACES2' },
+                        { v: pc.TONEMAP_KHRONOS_NEUTRAL, t: 'KHRONOS_NEUTRAL' }
                     ]
                 })
             )

--- a/src/extras/render-passes/render-pass-compose.js
+++ b/src/extras/render-passes/render-pass-compose.js
@@ -2,7 +2,7 @@ import { math } from '../../core/math/math.js';
 import { Color } from '../../core/math/color.js';
 import { RenderPassShaderQuad } from '../../scene/graphics/render-pass-shader-quad.js';
 import { shaderChunks } from '../../scene/shader-lib/chunks/chunks.js';
-import { TONEMAP_LINEAR, TONEMAP_FILMIC, TONEMAP_HEJL, TONEMAP_ACES, TONEMAP_ACES2 } from '../../scene/constants.js';
+import { TONEMAP_LINEAR, TONEMAP_FILMIC, TONEMAP_HEJL, TONEMAP_ACES, TONEMAP_ACES2, TONEMAP_KHRONOS_NEUTRAL } from '../../scene/constants.js';
 
 
 // Contrast Adaptive Sharpening (CAS) is used to apply the sharpening. It's based on AMD's
@@ -283,6 +283,7 @@ class RenderPassCompose extends RenderPassShaderQuad {
             case TONEMAP_HEJL: return shaderChunks.tonemappingHejlPS;
             case TONEMAP_ACES: return shaderChunks.tonemappingAcesPS;
             case TONEMAP_ACES2: return shaderChunks.tonemappingAces2PS;
+            case TONEMAP_KHRONOS_NEUTRAL: return shaderChunks.tonemappingKhronosNeutralPS;
         }
         return shaderChunks.tonemappingNonePS;
     }

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1492,6 +1492,8 @@ class AppBase extends EventHandler {
      * - {@link TONEMAP_FILMIC}
      * - {@link TONEMAP_HEJL}
      * - {@link TONEMAP_ACES}
+     * - {@link TONEMAP_ACES2}
+     * - {@link TONEMAP_KHRONOS_NEUTRAL}
      *
      * @param {number} settings.render.exposure - The exposure value tweaks the overall brightness
      * of the scene.

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -637,6 +637,14 @@ export const TONEMAP_ACES = 3;
 export const TONEMAP_ACES2 = 4;
 
 /**
+ * Khronos PBR Neutral tonemapping curve.
+ *
+ * @type {number}
+ * @category Graphics
+ */
+export const TONEMAP_KHRONOS_NEUTRAL = 5;
+
+/**
  * No specular occlusion.
  *
  * @type {number}

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -639,6 +639,7 @@ class Scene extends EventHandler {
      * - {@link TONEMAP_HEJL}
      * - {@link TONEMAP_ACES}
      * - {@link TONEMAP_ACES2}
+     * - {@link TONEMAP_KHRONOS_NEUTRAL}
      *
      * Defaults to {@link TONEMAP_LINEAR}.
      *

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -190,6 +190,7 @@ import tonemappingAcesPS from './common/frag/tonemappingAces.js';
 import tonemappingAces2PS from './common/frag/tonemappingAces2.js';
 import tonemappingFilmicPS from './common/frag/tonemappingFilmic.js';
 import tonemappingHejlPS from './common/frag/tonemappingHejl.js';
+import tonemappingKhronosNeutralPS from './common/frag/tonemappingKhronosNeutral.js';
 import tonemappingLinearPS from './common/frag/tonemappingLinear.js';
 import tonemappingNonePS from './common/frag/tonemappingNone.js';
 import transformVS from './common/vert/transform.js';
@@ -402,6 +403,7 @@ const shaderChunks = {
     tonemappingAces2PS,
     tonemappingFilmicPS,
     tonemappingHejlPS,
+    tonemappingKhronosNeutralPS,
     tonemappingLinearPS,
     tonemappingNonePS,
     transformVS,

--- a/src/scene/shader-lib/chunks/common/frag/tonemappingKhronosNeutral.js
+++ b/src/scene/shader-lib/chunks/common/frag/tonemappingKhronosNeutral.js
@@ -1,0 +1,23 @@
+// https://modelviewer.dev/examples/tone-mapping
+export default /* glsl */`
+uniform float exposure;
+
+vec3 toneMap(vec3 color) {
+    float startCompression = 0.8 - 0.04;
+    float desaturation = 0.15;
+
+    float x = min(color.r, min(color.g, color.b));
+    float offset = x < 0.08 ? x - 6.25 * x * x : 0.04;
+    color -= offset;
+
+    float peak = max(color.r, max(color.g, color.b));
+    if (peak < startCompression) return color;
+
+    float d = 1. - startCompression;
+    float newPeak = 1. - d * d / (peak + d - startCompression);
+    color *= newPeak / peak;
+
+    float g = 1. - 1. / (desaturation * (peak - newPeak) + 1.);
+    return mix(color, newPeak * vec3(1, 1, 1), g);
+}
+`;

--- a/src/scene/shader-lib/programs/shader-generator.js
+++ b/src/scene/shader-lib/programs/shader-generator.js
@@ -1,6 +1,6 @@
 import {
     GAMMA_SRGB, GAMMA_SRGBFAST, GAMMA_SRGBHDR,
-    TONEMAP_ACES, TONEMAP_ACES2, TONEMAP_FILMIC, TONEMAP_HEJL, TONEMAP_LINEAR
+    TONEMAP_ACES, TONEMAP_ACES2, TONEMAP_FILMIC, TONEMAP_HEJL, TONEMAP_KHRONOS_NEUTRAL, TONEMAP_LINEAR
 } from '../../constants.js';
 import { shaderChunks } from '../chunks/chunks.js';
 
@@ -41,18 +41,15 @@ class ShaderGenerator {
     }
 
     static tonemapCode(value, chunks = shaderChunks) {
-        if (value === TONEMAP_FILMIC) {
-            return chunks.tonemappingFilmicPS ? chunks.tonemappingFilmicPS : shaderChunks.tonemappingFilmicPS;
-        } else if (value === TONEMAP_LINEAR) {
-            return chunks.tonemappingLinearPS ? chunks.tonemappingLinearPS : shaderChunks.tonemappingLinearPS;
-        } else if (value === TONEMAP_HEJL) {
-            return chunks.tonemappingHejlPS ? chunks.tonemappingHejlPS : shaderChunks.tonemappingHejlPS;
-        } else if (value === TONEMAP_ACES) {
-            return chunks.tonemappingAcesPS ? chunks.tonemappingAcesPS : shaderChunks.tonemappingAcesPS;
-        } else if (value === TONEMAP_ACES2) {
-            return chunks.tonemappingAces2PS ? chunks.tonemappingAces2PS : shaderChunks.tonemappingAces2PS;
+        switch (value) {
+            case TONEMAP_FILMIC: return chunks.tonemappingFilmicPS ?? shaderChunks.tonemappingFilmicPS;
+            case TONEMAP_LINEAR: return chunks.tonemappingLinearPS ?? shaderChunks.tonemappingLinearPS;
+            case TONEMAP_HEJL: return chunks.tonemappingHejlPS ?? shaderChunks.tonemappingHejlPS;
+            case TONEMAP_ACES: return chunks.tonemappingAcesPS ?? shaderChunks.tonemappingAcesPS;
+            case TONEMAP_ACES2: return chunks.tonemappingAces2PS ?? shaderChunks.tonemappingAces2PS;
+            case TONEMAP_KHRONOS_NEUTRAL: return chunks.tonemappingKhronosNeutralPS ?? shaderChunks.tonemappingKhronosNeutralPS;
         }
-        return chunks.tonemapingNonePS ? chunks.tonemapingNonePS : shaderChunks.tonemappingNonePS;
+        return chunks.tonemapingNonePS ?? shaderChunks.tonemappingNonePS;
     }
 }
 


### PR DESCRIPTION
A tone mapper designed for color accuracy, that Khronos is making a standard via the Khronos 3D Commerce group. In-depth writeup [here](https://modelviewer.dev/examples/tone-mapping). The summary is this is an improved alternative to No/Linear/Clamped tone mapping. It preserves the baseColor sRGB values as faithfully as possible through to the final render under uncolored lighting.

https://twitter.com/modelviewer/status/1781421793691279547?t=Zz5AAUZVF3qYtdNM95tOaQ&s=03

Asset viewer before, with ACES:
![aces](https://github.com/playcanvas/engine/assets/59932779/7a1d2f11-b563-4e8a-8ca2-8213da7e2cde)

And with the new neutral:
![neutral](https://github.com/playcanvas/engine/assets/59932779/97801814-7b4f-4446-b361-beecce7c54bb)
