### PR TITLE
Workaround for Firefox WebGPU device creation fail

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -170,7 +170,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
         // WGSL features
         const wgslFeatures = navigator.gpu.wgslLanguageFeatures;
-        this.supportsStorageTextureRead = wgslFeatures.has('readonly_and_readwrite_storage_textures');
+        this.supportsStorageTextureRead = wgslFeatures?.has('readonly_and_readwrite_storage_textures');
     }
 
     async initWebGpu(glslangUrl, twgslUrl) {


### PR DESCRIPTION
WebGPU on Firefox does not supply wgslFeatures and so the creation fails.