### PR TITLE
Fix to WebGPU vertex buffer setup

### DIFF
--- a/examples/src/examples/graphics/mesh-morph-many/config.mjs
+++ b/examples/src/examples/graphics/mesh-morph-many/config.mjs
@@ -2,5 +2,5 @@
  * @type {import('../../../../types.mjs').ExampleConfig}
  */
 export default {
-    WEBGPU_ENABLED: false
+    WEBGPU_ENABLED: true
 };

--- a/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
+++ b/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
@@ -66,6 +66,12 @@ class WebgpuVertexBufferLayout {
         // type  {GPUVertexBufferLayout[]}
         const layout = [];
 
+        // Note: If the VertexFormat is interleaved, we use a single vertex buffer with multiple
+        // attributes. This uses a smaller number of vertex buffers (1), which has performance
+        // benefits when setting it up on the device.
+        // If the VertexFormat is not interleaved, we use multiple vertex buffers, one per
+        // attribute. This is less efficient, but is required as there is a pretty small
+        // limit on the attribute offsets in the vertex buffer layout.
         const addFormat = (format) => {
             const interleaved = format.interleaved;
             const stepMode = format.instancing ? 'instance' : 'vertex';


### PR DESCRIPTION
- a case of interleaved VBs was not handled correctly, especially visible in cases of two VBs used at the same time (as instancing or morphing). This PR handles this case correctly.
- this fixes morphing on WebGPU and so the example is now enabled
- WebGPU shaders do not provide reflection, and so all vertex attributes are set on the device. This has a potential of additional errors where unused attribute in VB is mapped to a location of another used attribute. This is now handled by debug checking. Example: a mesh with tangent space, which is not used, is used by instancing. Instancing maps one of its elements to the same location as tangent element, creating a validation error.

Fixes / reports issues from https://github.com/playcanvas/engine/pull/6270