### PR TITLE
GS cleanup

### DIFF
--- a/src/core/math/mat3.js
+++ b/src/core/math/mat3.js
@@ -265,6 +265,48 @@ class Mat3 {
     }
 
     /**
+     * Sets this matrix to the given quaternion rotation.
+     *
+     * @param {import('./quat.js').Quat} r - A quaternion rotation.
+     * @returns {Mat3} Self for chaining.
+     */
+    setFromQuat(r) {
+        const qx = r.x;
+        const qy = r.y;
+        const qz = r.z;
+        const qw = r.w;
+
+        const x2 = qx + qx;
+        const y2 = qy + qy;
+        const z2 = qz + qz;
+        const xx = qx * x2;
+        const xy = qx * y2;
+        const xz = qx * z2;
+        const yy = qy * y2;
+        const yz = qy * z2;
+        const zz = qz * z2;
+        const wx = qw * x2;
+        const wy = qw * y2;
+        const wz = qw * z2;
+
+        const m = this.data;
+
+        m[0] = (1 - (yy + zz));
+        m[1] = (xy + wz);
+        m[2] = (xz - wy);
+
+        m[3] = (xy - wz);
+        m[4] = (1 - (xx + zz));
+        m[5] = (yz + wx);
+
+        m[6] = (xz + wy);
+        m[7] = (yz - wx);
+        m[8] = (1 - (xx + yy));
+
+        return this;
+    }
+
+    /**
      * Set the matrix to the inverse of the specified 4x4 matrix.
      *
      * @param {import('./mat4.js').Mat4} src - The 4x4 matrix to invert.

--- a/src/core/math/mat3.js
+++ b/src/core/math/mat3.js
@@ -269,7 +269,12 @@ class Mat3 {
      *
      * @param {import('./quat.js').Quat} r - A quaternion rotation.
      * @returns {Mat3} Self for chaining.
-     */
+     * @example
+     * const r = new pc.Quat(1, 2, 3, 4).normalize();
+     * 
+     * const m = new pc.Mat4();
+     * m.setFromQuat(r);
+    */
     setFromQuat(r) {
         const qx = r.x;
         const qy = r.y;

--- a/src/scene/gsplat/gsplat-data.js
+++ b/src/scene/gsplat/gsplat-data.js
@@ -116,10 +116,10 @@ class GSplatData {
         const y = this.getProp('y');
         const z = this.getProp('z');
 
-        const rx = this.getProp('rot_0');
-        const ry = this.getProp('rot_1');
-        const rz = this.getProp('rot_2');
-        const rw = this.getProp('rot_3');
+        const rx = this.getProp('rot_1');
+        const ry = this.getProp('rot_2');
+        const rz = this.getProp('rot_3');
+        const rw = this.getProp('rot_0');
 
         quat2.setFromMat4(mat);
 
@@ -132,11 +132,11 @@ class GSplatData {
             z[i] = vec3.z;
 
             // transform orientation
-            quat.set(ry[i], rz[i], rw[i], rx[i]).mul2(quat2, quat);
-            rx[i] = quat.w;
-            ry[i] = quat.x;
-            rz[i] = quat.y;
-            rw[i] = quat.z;
+            quat.set(rx[i], ry[i], rz[i], rw[i]).mul2(quat2, quat);
+            rx[i] = quat.x;
+            ry[i] = quat.y;
+            rz[i] = quat.z;
+            rw[i] = quat.w;
 
             // TODO: transform SH
         }

--- a/src/scene/gsplat/gsplat.js
+++ b/src/scene/gsplat/gsplat.js
@@ -17,7 +17,6 @@ const _m0 = new Vec3();
 const _m1 = new Vec3();
 const _m2 = new Vec3();
 const _s = new Vec3();
-const _r = new Vec3();
 
 /** @ignore */
 class GSplat {
@@ -223,10 +222,10 @@ class GSplat {
      * @param {Float32Array} x - The array containing the 'x' component of the center points.
      * @param {Float32Array} y - The array containing the 'y' component of the center points.
      * @param {Float32Array} z - The array containing the 'z' component of the center points.
-     * @param {Float32Array} rot0 - The array containing the 'x' component of quaternion rotations.
-     * @param {Float32Array} rot1 - The array containing the 'y' component of quaternion rotations.
-     * @param {Float32Array} rot2 - The array containing the 'z' component of quaternion rotations.
-     * @param {Float32Array} rot3 - The array containing the 'w' component of quaternion rotations.
+     * @param {Float32Array} rot0 - The array containing the 'w' component of quaternion rotations.
+     * @param {Float32Array} rot1 - The array containing the 'x' component of quaternion rotations.
+     * @param {Float32Array} rot2 - The array containing the 'y' component of quaternion rotations.
+     * @param {Float32Array} rot3 - The array containing the 'z' component of quaternion rotations.
      * @param {Float32Array} scale0 - The first scale component associated with the x-dimension.
      * @param {Float32Array} scale1 - The second scale component associated with the y-dimension.
      * @param {Float32Array} scale2 - The third scale component associated with the z-dimension.
@@ -251,12 +250,8 @@ class GSplat {
         for (let i = 0; i < this.numSplats; i++) {
 
             // rotation
-            quat.set(rot0[i], rot1[i], rot2[i], rot3[i]).normalize();
-            if (quat.w < 0) {
-                quat.conjugate();
-            }
-            _r.set(quat.x, quat.y, quat.z);
-            this.quatToMat3(_r, mat);
+            quat.set(rot1[i], rot2[i], rot3[i], rot0[i]).normalize();
+            mat.setFromQuat(quat);
 
             // scale
             _s.set(
@@ -300,32 +295,6 @@ class GSplat {
         this.transformATexture.unlock();
         this.transformBTexture.unlock();
         this.transformCTexture.unlock();
-    }
-
-    /**
-     * Convert quaternion rotation stored in Vec3 to a rotation matrix.
-     *
-     * @param {Vec3} R - Rotation stored in Vec3.
-     * @param {Mat3} mat - The output rotation matrix.
-     */
-    quatToMat3(R, mat) {
-        const x = R.x;
-        const y = R.y;
-        const z = R.z;
-        const w = Math.sqrt(1.0 - R.dot(R));
-
-        const d = mat.data;
-        d[0] = 1.0 - 2.0 * (z * z + w * w);
-        d[1] = 2.0 * (y * z + x * w);
-        d[2] = 2.0 * (y * w - x * z);
-
-        d[3] = 2.0 * (y * z - x * w);
-        d[4] = 1.0 - 2.0 * (y * y + w * w);
-        d[5] = 2.0 * (z * w + x * y);
-
-        d[6] = 2.0 * (y * w + x * z);
-        d[7] = 2.0 * (z * w - x * y);
-        d[8] = 1.0 - 2.0 * (y * y + z * z);
     }
 
     /**


### PR DESCRIPTION
This PR:
- correctly handles the rotation elements in .ply data (order is wxyz)
- moves the quaterion -> mat3 conversion to mat3 class
- removes the remnants of WebGL1 support for GS rendering (which doesn't work anyway)
- small GS sort speedup 