### PR TITLE
WebGPU: Improved filtering on float textures

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -225,7 +225,6 @@ class WebgpuTexture {
 
             } else if (sampleType === SAMPLETYPE_UNFILTERABLE_FLOAT) {
 
-                // webgpu cannot currently filter float / half float textures, or integer textures
                 descr.magFilter = 'nearest';
                 descr.minFilter = 'nearest';
                 descr.mipmapFilter = 'nearest';
@@ -233,10 +232,10 @@ class WebgpuTexture {
 
             } else {
 
-                // TODO: this is temporary and needs to be made generic
-                if (this.texture.format === PIXELFORMAT_RGBA32F ||
-                    this.texture.format === PIXELFORMAT_DEPTHSTENCIL ||
-                    this.texture.format === PIXELFORMAT_RGBA16F || isIntegerPixelFormat(this.texture.format)) {
+                // if the device cannot filter float textures, force nearest filtering
+                const forceNearest = !device.textureFloatFilterable && (texture.format === PIXELFORMAT_RGBA32F || texture.format === PIXELFORMAT_RGBA16F);
+
+                if (forceNearest || this.texture.format === PIXELFORMAT_DEPTHSTENCIL || isIntegerPixelFormat(this.texture.format)) {
                     descr.magFilter = 'nearest';
                     descr.minFilter = 'nearest';
                     descr.mipmapFilter = 'nearest';

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -634,14 +634,15 @@ class LitShader {
             hasAreaLights = true;
         }
 
-        let areaLutsPrecision = 'highp';
-        if (device.areaLightLutFormat === PIXELFORMAT_RGBA8) {
-            // use offset and scale for rgb8 format luts
-            decl.append("#define AREA_R8_G8_B8_A8_LUTS");
-            areaLutsPrecision = 'lowp';
-        }
-
         if (hasAreaLights || options.clusteredLightingEnabled) {
+
+            let areaLutsPrecision = 'highp';
+            if (device.areaLightLutFormat === PIXELFORMAT_RGBA8) {
+                // use offset and scale for rgb8 format luts
+                decl.append("#define AREA_R8_G8_B8_A8_LUTS");
+                areaLutsPrecision = 'lowp';
+            }
+
             decl.append("#define AREA_LIGHTS");
             decl.append(`uniform ${areaLutsPrecision} sampler2D areaLightsLutTex1;`);
             decl.append(`uniform ${areaLutsPrecision} sampler2D areaLightsLutTex2;`);


### PR DESCRIPTION
- cleanup of texture sampler set up for WebGPU texture that was written before WebGPU added support for float texture filtering. Now we use it when available.
- Fixes area light reflections using float LUTs

before:
![Screenshot 2024-04-24 at 15 53 59](https://github.com/playcanvas/engine/assets/59932779/8cfafdc3-a477-4b02-bb79-1faf1ae7bd05)

now:
![Screenshot 2024-04-24 at 15 54 21](https://github.com/playcanvas/engine/assets/59932779/87a94dc1-1a58-4851-87b4-55dc6aa32dfd)

