### PR TITLE
Small fixups for JSDocs

### DIFF
--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -367,7 +367,7 @@ class RenderTarget {
      * average all samples and create a simple texture with one color per pixel. This function
      * performs this averaging and updates the colorBuffer and the depthBuffer. If autoResolve is
      * set to true, the resolve will happen after every rendering to this render target, otherwise
-     * you can do it manually, during the app update or inside a {@link Command}.
+     * you can do it manually, during the app update or similar.
      *
      * @param {boolean} [color] - Resolve color buffer. Defaults to true.
      * @param {boolean} [depth] - Resolve depth buffer. Defaults to true if the render target has a

--- a/src/platform/graphics/uniform-buffer-format.js
+++ b/src/platform/graphics/uniform-buffer-format.js
@@ -192,7 +192,7 @@ class UniformFormat {
 }
 
 /**
- * A descriptor that defines the layout of of data inside the {@link UniformBuffer}.
+ * A descriptor that defines the layout of of data inside the uniform buffer.
  */
 class UniformBufferFormat {
     /**


### PR DESCRIPTION
- removed reference to non existing `Command` and non-public `UniformBuffer`