### PR TITLE
Removed UMD polyfill for pcx

### DIFF
--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -193,8 +193,7 @@ function buildTarget({ moduleFormat, buildType, input = 'src/index.js', dir = 'b
             name: 'pc',
             preserveModules: !bundled,
             file: bundled ? `${dir}/${OUT_PREFIX[buildType]}${isUMD ? '.js' : '.mjs'}` : undefined,
-            dir: !bundled ? `${dir}/${OUT_PREFIX[buildType]}` : undefined,
-            footer: isUMD ? 'this.pcx = pc;' : undefined
+            dir: !bundled ? `${dir}/${OUT_PREFIX[buildType]}` : undefined
         },
         plugins: [
             resolve(),


### PR DESCRIPTION
Fixes #6287

- Removes remapping from pcx to pc

N.B. Editor launcher needs to be updated first to check for pc MiniStats first
