### PR TITLE
Update Graphics markers to display better with hierarchy

### DIFF
--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -20,6 +20,7 @@ import {
 import { GraphNode } from './graph-node.js';
 import { getDefaultMaterial } from './materials/default-material.js';
 import { LightmapCache } from './graphics/lightmap-cache.js';
+import { DebugGraphics } from '../platform/graphics/debug-graphics.js';
 
 let id = 0;
 const _tmpAabb = new BoundingBox();
@@ -519,8 +520,13 @@ class MeshInstance {
             // cache miss in the material variants
             if (!shaderInstance.shader) {
 
+                // marker to allow us to see the source node for shader alloc
+                DebugGraphics.pushGpuMarker(this.mesh.device, `Node: ${this.node.name}`);
+
                 const shader = mat.getShaderVariant(this.mesh.device, scene, shaderDefs, null, shaderPass, sortedLights,
                                                     viewUniformFormat, viewBindGroupFormat, this._mesh.vertexBuffer?.format);
+
+                DebugGraphics.popGpuMarker(this.mesh.device);
 
                 // add it to the material variants cache
                 mat.variants.set(variantKey, shader);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -516,12 +516,7 @@ class ForwardRenderer extends Renderer {
                 }
             }
 
-            // marker to allow us to see the source node for shader alloc
-            DebugGraphics.pushGpuMarker(device, `Node: ${drawCall.node.name}`);
-
             const shaderInstance = drawCall.getShaderInstance(pass, lightHash, scene, this.viewUniformFormat, this.viewBindGroupFormat, sortedLights);
-
-            DebugGraphics.popGpuMarker(device);
 
             addCall(drawCall, shaderInstance, material !== prevMaterial, !prevMaterial || lightMask !== prevLightMask);
 
@@ -576,8 +571,7 @@ class ForwardRenderer extends Renderer {
                 device.setAlphaToCoverage(material.alphaToCoverage);
             }
 
-            DebugGraphics.pushGpuMarker(device, `Node: ${drawCall.node.name}`);
-            DebugGraphics.pushGpuMarker(device, `Material: ${material.name}`);
+            DebugGraphics.pushGpuMarker(device, `Node: ${drawCall.node.name}, Material: ${material.name}`);
 
             this.setupCullMode(camera._cullFaces, flipFactor, drawCall);
 
@@ -636,7 +630,6 @@ class ForwardRenderer extends Renderer {
                 material.setParameters(device, drawCall.parameters);
             }
 
-            DebugGraphics.popGpuMarker(device);
             DebugGraphics.popGpuMarker(device);
         }
     }

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -237,8 +237,7 @@ class RenderPassForward extends RenderPass {
         const { layer, transparent, camera } = renderAction;
         const cameraPass = layerComposition.camerasMap.get(camera);
 
-        DebugGraphics.pushGpuMarker(this.device, camera ? camera.entity.name : 'Unnamed');
-        DebugGraphics.pushGpuMarker(this.device, `${layer.name}(${transparent ? 'TRANSP' : 'OPAQUE'})`);
+        DebugGraphics.pushGpuMarker(this.device, `Camera: ${camera ? camera.entity.name : 'Unnamed'}, Layer: ${layer.name}(${transparent ? 'TRANSP' : 'OPAQUE'})`);
 
         // #if _PROFILER
         const drawTime = now();
@@ -302,7 +301,6 @@ class RenderPassForward extends RenderPass {
             }
         }
 
-        DebugGraphics.popGpuMarker(this.device);
         DebugGraphics.popGpuMarker(this.device);
 
         // #if _PROFILER

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -314,8 +314,6 @@ class Renderer {
     setupViewport(camera, renderTarget) {
 
         const device = this.device;
-        DebugGraphics.pushGpuMarker(device, 'SETUP-VIEWPORT');
-
         const pixelWidth = renderTarget ? renderTarget.width : device.width;
         const pixelHeight = renderTarget ? renderTarget.height : device.height;
 
@@ -335,8 +333,6 @@ class Renderer {
             h = Math.floor(scissorRect.w * pixelHeight);
         }
         device.setScissor(x, y, w, h);
-
-        DebugGraphics.popGpuMarker(device);
     }
 
     setCameraUniforms(camera, target) {
@@ -883,8 +879,6 @@ class Renderer {
 
     drawInstance(device, meshInstance, mesh, style, normal) {
 
-        DebugGraphics.pushGpuMarker(device, meshInstance.node.name);
-
         const modelMatrix = meshInstance.node.worldTransform;
         this.modelMatrixId.setValue(modelMatrix.data);
         if (normal) {
@@ -903,14 +897,10 @@ class Renderer {
         } else {
             device.draw(mesh.primitive[style]);
         }
-
-        DebugGraphics.popGpuMarker(device);
     }
 
     // used for stereo
     drawInstance2(device, meshInstance, mesh, style) {
-
-        DebugGraphics.pushGpuMarker(device, meshInstance.node.name);
 
         const instancingData = meshInstance.instancingData;
         if (instancingData) {
@@ -924,8 +914,6 @@ class Renderer {
             // matrices are already set
             device.draw(mesh.primitive[style], undefined, true);
         }
-
-        DebugGraphics.popGpuMarker(device);
     }
 
     /**


### PR DESCRIPTION
updated markers to display hierarchy better - before it was 4 layers deep for no good reason

now:
1. render pass
2. camera + layer
3. entity name + material name

<img width="705" alt="Screenshot 2024-04-25 at 17 39 02" src="https://github.com/playcanvas/engine/assets/59932779/22f73d38-a4de-48e0-b141-184f3a8bbcea">
