### PR TITLE
[Fix] Fix to skydomeIntensity handling - Standard materials do not use it in some cases

### DIFF
--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -39,6 +39,7 @@ import encodePS from './common/frag/encode.js';
 import endPS from './lit/frag/end.js';
 import endVS from './lit/vert/end.js';
 import envAtlasPS from './common/frag/envAtlas.js';
+import envConstPS from './common/frag/envConst.js';
 import envMultiplyPS from './common/frag/envMultiply.js';
 import extensionPS from './lit/frag/extension.js';
 import extensionVS from './lit/vert/extension.js';
@@ -252,6 +253,7 @@ const shaderChunks = {
     endPS,
     endVS,
     envAtlasPS,
+    envConstPS,
     envMultiplyPS,
     extensionPS,
     extensionVS,

--- a/src/scene/shader-lib/chunks/common/frag/envConst.js
+++ b/src/scene/shader-lib/chunks/common/frag/envConst.js
@@ -1,0 +1,5 @@
+export default /* glsl */`
+vec3 processEnvironment(vec3 color) {
+    return color;
+}
+`;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -758,7 +758,7 @@ class LitShader {
         if (this.needsNormal) {
             func.append(chunks.cubeMapRotatePS);
             func.append(options.cubeMapProjection > 0 ? chunks.cubeMapProjectBoxPS : chunks.cubeMapProjectNonePS);
-            func.append(chunks.envMultiplyPS);
+            func.append(options.skyboxIntensity ? chunks.envMultiplyPS : chunks.envConstPS);
         }
 
         if ((this.lighting && options.useSpecular) || this.reflections) {


### PR DESCRIPTION
Fix to a bug introduced in https://github.com/playcanvas/engine/pull/6254 - Standard materials only sometimes use the skydomeIntensity, and so that needs to be handled.