### PR TITLE
Remove support for OES_element_index_uint on WebGL1

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -809,24 +809,8 @@ const createMesh = (device, gltfMesh, accessors, bufferViews, flipV, vertexBuffe
                     indexFormat = INDEXFORMAT_UINT32;
                 }
 
-                // 32bit index buffer is used but not supported
-                if (indexFormat === INDEXFORMAT_UINT32 && !device.extUintElement) {
-
-                    // #if _DEBUG
-                    if (vertexBuffer.numVertices > 0xFFFF) {
-                        console.warn('Glb file contains 32bit index buffer but these are not supported by this device - it may be rendered incorrectly.');
-                    }
-                    // #endif
-
-                    // convert to 16bit
-                    indexFormat = INDEXFORMAT_UINT16;
-                    indices = new Uint16Array(indices);
-                }
-
                 if (indexFormat === INDEXFORMAT_UINT8 && device.isWebGPU) {
-                    Debug.warn('Glb file contains 8bit index buffer but these are not supported by WebGPU - converting to 16bit.');
-
-                    // convert to 16bit
+                    // silently convert to 16bit
                     indexFormat = INDEXFORMAT_UINT16;
                     indices = new Uint16Array(indices);
                 }

--- a/src/framework/parsers/json-model.js
+++ b/src/framework/parsers/json-model.js
@@ -329,7 +329,7 @@ class JsonModelParser {
             maxVerts = Math.max(maxVerts, vertexBuffers[i].numVertices);
         }
         if (numIndices > 0) {
-            if (maxVerts > 0xFFFF && this._device.extUintElement) {
+            if (maxVerts > 0xFFFF) {
                 indexBuffer = new IndexBuffer(this._device, INDEXFORMAT_UINT32, numIndices);
                 indexData = new Uint32Array(indexBuffer.lock());
             } else {

--- a/src/platform/graphics/null/null-graphics-device.js
+++ b/src/platform/graphics/null/null-graphics-device.js
@@ -46,7 +46,6 @@ class NullGraphicsDevice extends GraphicsDevice {
         this.supportsAreaLights = true;
         this.supportsGpuParticles = false;
         this.supportsMrt = true;
-        this.extUintElement = true;
         this.extTextureFloat = true;
         this.textureFloatRenderable = true;
         this.extTextureHalfFloat = true;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -945,6 +945,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.supportedExtensions = gl.getSupportedExtensions() ?? [];
         this._extDisjointTimerQuery = null;
 
+        this.textureRG11B10Renderable = true;
+
         if (this.isWebGL2) {
             this.extBlendMinmax = true;
             this.extDrawBuffers = true;
@@ -953,10 +955,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.extTextureHalfFloat = true;
             this.textureHalfFloatFilterable = true;
             this.extTextureLod = true;
-            this.extUintElement = true;
             this.extColorBufferFloat = this.getExtension('EXT_color_buffer_float');
             this.extDepthTexture = true;
-            this.textureRG11B10Renderable = true;
         } else {
             this.extBlendMinmax = this.getExtension("EXT_blend_minmax");
             this.extDrawBuffers = this.getExtension('WEBGL_draw_buffers');
@@ -964,7 +964,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
             this.extTextureFloat = this.getExtension("OES_texture_float");
             this.extTextureLod = this.getExtension('EXT_shader_texture_lod');
-            this.extUintElement = this.getExtension("OES_element_index_uint");
             this.extColorBufferFloat = null;
             this.extDepthTexture = gl.getExtension('WEBGL_depth_texture');
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -148,7 +148,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsGpuParticles = true;
         this.supportsMrt = true;
         this.supportsCompute = true;
-        this.extUintElement = true;
         this.extTextureFloat = true;
         this.textureFloatRenderable = true;
         this.textureHalfFloatFilterable = true;

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -436,9 +436,9 @@ class BatchManager {
         const halfMaxAabbSize = maxAabbSize * 0.5;
         const maxInstanceCount = this.device.supportsBoneTextures ? 1024 : this.device.boneLimit;
 
-        // maximum number of vertices that can be used in batch depends on 32bit index buffer support (do this for non-indexed as well,
+        // maximum number of vertices that can be used in batch (do this for non-indexed as well,
         // as in some cases (UI elements) non-indexed geometry gets batched into indexed)
-        const maxNumVertices = this.device.extUintElement ? 0xffffffff : 0xffff;
+        const maxNumVertices = 0xffffffff;
 
         const aabb = new BoundingBox();
         const testAabb = new BoundingBox();


### PR DESCRIPTION
- 32bit indices are now available on all platforms