### PR TITLE
Removed WebGL1 OES_texture_float extension support

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -697,6 +697,13 @@ Object.defineProperty(GraphicsDevice.prototype, 'textureHalfFloatUpdatable', {
     }
 });
 
+Object.defineProperty(GraphicsDevice.prototype, 'extTextureFloat', {
+    get: function () {
+        Debug.deprecated('pc.GraphicsDevice#extTextureFloat is deprecated as it is always true');
+        return true;
+    }
+});
+
 Object.defineProperty(GraphicsDevice.prototype, 'extStandardDerivatives', {
     get: function () {
         Debug.deprecated('pc.GraphicsDevice#extStandardDerivatives is deprecated as it is always true.');

--- a/src/platform/graphics/null/null-graphics-device.js
+++ b/src/platform/graphics/null/null-graphics-device.js
@@ -46,7 +46,6 @@ class NullGraphicsDevice extends GraphicsDevice {
         this.supportsAreaLights = true;
         this.supportsGpuParticles = false;
         this.supportsMrt = true;
-        this.extTextureFloat = true;
         this.textureFloatRenderable = true;
         this.extTextureHalfFloat = true;
         this.textureHalfFloatRenderable = true;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -732,12 +732,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this.constantTexSource = this.scope.resolve("source");
 
-        if (this.extTextureFloat) {
-            // In WebGL2 float texture renderability is dictated by the EXT_color_buffer_float extension
-            this.textureFloatRenderable = !!this.extColorBufferFloat;
-        } else {
-            this.textureFloatRenderable = false;
-        }
+        // In WebGL2 float texture renderability is dictated by the EXT_color_buffer_float extension
+        this.textureFloatRenderable = !!this.extColorBufferFloat;
 
         // two extensions allow us to render to half float buffers
         if (this.extColorBufferHalfFloat) {
@@ -757,7 +753,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.areaLightLutFormat = PIXELFORMAT_RGBA8;
         if (this.extTextureHalfFloat && this.extTextureHalfFloatLinear) {
             this.areaLightLutFormat = PIXELFORMAT_RGBA16F;
-        } else if (this.extTextureFloat && this.extTextureFloatLinear) {
+        } else if (this.extTextureFloatLinear) {
             this.areaLightLutFormat = PIXELFORMAT_RGBA32F;
         }
 
@@ -951,7 +947,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.extBlendMinmax = true;
             this.extDrawBuffers = true;
             this.drawBuffers = gl.drawBuffers.bind(gl);
-            this.extTextureFloat = true;
             this.extTextureHalfFloat = true;
             this.textureHalfFloatFilterable = true;
             this.extTextureLod = true;
@@ -962,7 +957,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.extDrawBuffers = this.getExtension('WEBGL_draw_buffers');
             this.drawBuffers = this.extDrawBuffers?.drawBuffersWEBGL.bind(this.extDrawBuffers);
 
-            this.extTextureFloat = this.getExtension("OES_texture_float");
             this.extTextureLod = this.getExtension('EXT_shader_texture_lod');
             this.extColorBufferFloat = null;
             this.extDepthTexture = gl.getExtension('WEBGL_depth_texture');

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -148,7 +148,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsGpuParticles = true;
         this.supportsMrt = true;
         this.supportsCompute = true;
-        this.extTextureFloat = true;
         this.textureFloatRenderable = true;
         this.textureHalfFloatFilterable = true;
         this.extTextureHalfFloat = true;

--- a/src/scene/graphics/env-lighting.js
+++ b/src/scene/graphics/env-lighting.js
@@ -21,7 +21,7 @@ const supportsFloat16 = (device) => {
 };
 
 const supportsFloat32 = (device) => {
-    return device.extTextureFloat && device.textureFloatRenderable;
+    return device.textureFloatRenderable;
 };
 
 // lighting source should be stored HDR

--- a/src/scene/gsplat/gsplat.js
+++ b/src/scene/gsplat/gsplat.js
@@ -144,27 +144,12 @@ class GSplat {
      */
     getTextureFormat(device, preferHighPrecision) {
 
-        // on WebGL1 R32F is not supported, always use half precision
-        if (device.isWebGL1)
-            preferHighPrecision = false;
-
-        const halfSupported = device.extTextureHalfFloat;
-        const floatSupported = device.extTextureFloat;
-
         // true if half format should be used, false is float format should be used or undefined if none are available.
         let halfFormat;
         if (preferHighPrecision) {
-            if (floatSupported) {
-                halfFormat = false;
-            } else if (halfSupported) {
-                halfFormat = true;
-            }
+            halfFormat = false;
         } else {
-            if (halfSupported) {
-                halfFormat = true;
-            } else if (floatSupported) {
-                halfFormat = false;
-            }
+            halfFormat = device.extTextureHalfFloat;
         }
 
         return halfFormat;

--- a/src/scene/lighting/lights-buffer.js
+++ b/src/scene/lighting/lights-buffer.js
@@ -103,7 +103,7 @@ class LightsBuffer {
     static getLightTextureFormat(device) {
         // precision for texture storage
         // don't use float texture on devices with small number of texture units (as it uses both float and 8bit textures at the same time)
-        return (device.extTextureFloat && device.maxTextures > 8) ? FORMAT_FLOAT : FORMAT_8BIT;
+        return device.maxTextures > 8 ? FORMAT_FLOAT : FORMAT_8BIT;
     }
 
     static getShaderDefines(device) {

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -56,13 +56,13 @@ class Morph extends RefCountedObject {
 
             // renderable format
             const renderableHalf = (device.extTextureHalfFloat && device.textureHalfFloatRenderable) ? PIXELFORMAT_RGBA16F : undefined;
-            const renderableFloat = (device.extTextureFloat && device.textureFloatRenderable) ? PIXELFORMAT_RGBA32F : undefined;
+            const renderableFloat = device.textureFloatRenderable ? PIXELFORMAT_RGBA32F : undefined;
             this._renderTextureFormat = this.preferHighPrecision ?
                 (renderableFloat ?? renderableHalf) : (renderableHalf ?? renderableFloat);
 
             // texture format
             const textureHalf = (device.extTextureHalfFloat) ? PIXELFORMAT_RGBA16F : undefined;
-            const textureFloat = device.extTextureFloat ? PIXELFORMAT_RGB32F : undefined;
+            const textureFloat = PIXELFORMAT_RGB32F;
             this._textureFormat = this.preferHighPrecision ?
                 (textureFloat ?? textureHalf) : (textureHalf ?? textureFloat);
 

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -567,8 +567,7 @@ class ParticleEmitter {
         this.useCpu = this.useCpu || this.sort > PARTICLESORT_NONE ||  // force CPU if desirable by user or sorting is enabled
         gd.maxVertexTextures <= 1 || // force CPU if can't use enough vertex textures
         gd.fragmentUniformsCount < 64 || // force CPU if can't use many uniforms; TODO: change to more realistic value (this one is iphone's)
-        gd.forceCpuParticles ||
-        !gd.extTextureFloat; // no float texture extension
+        gd.forceCpuParticles;
 
         this._destroyResources();
 


### PR DESCRIPTION
- extTextureFloat is deprecated as it's always supported
- removed it's used from the code base