### PR TITLE
Disable treeshaking polyfills

### DIFF
--- a/utils/plugins/rollup-treeshake-ignore.mjs
+++ b/utils/plugins/rollup-treeshake-ignore.mjs
@@ -1,0 +1,25 @@
+/**
+ * A rollup plugin that filters out modules from treeshaking
+ *
+ * @param {RegExp[]} pathRegexList - A list of regexes to match against module paths
+ * @returns {import('rollup').Plugin} The rollup plugin
+ */
+export function treeshakeIgnore(pathRegexList = []) {
+    return {
+        name: 'treeshake-ignore',
+        transform(code, id) {
+            if (pathRegexList.some(regex => regex.test(id))) {
+                return {
+                    code,
+                    map: null,
+                    moduleSideEffects: 'no-treeshake'
+                };
+            }
+
+            return {
+                code,
+                map: null
+            };
+        }
+    };
+}

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -13,6 +13,7 @@ import { shaderChunks } from './plugins/rollup-shader-chunks.mjs';
 import { engineLayerImportValidation } from './plugins/rollup-import-validation.mjs';
 import { spacesToTabs } from './plugins/rollup-spaces-to-tabs.mjs';
 import { dynamicImportLegacyBrowserSupport, dynamicImportViteSupress } from './plugins/rollup-dynamic.mjs';
+import { treeshakeIgnore } from './plugins/rollup-treeshake-ignore.mjs';
 
 import { version, revision } from './rollup-version-revision.mjs';
 import { getBanner } from './rollup-get-banner.mjs';
@@ -22,6 +23,10 @@ import { babelOptions } from './rollup-babel-options.mjs';
 /** @typedef {import('rollup').OutputOptions} OutputOptions */
 /** @typedef {import('rollup').ModuleFormat} ModuleFormat */
 /** @typedef {import('@rollup/plugin-strip').RollupStripOptions} RollupStripOptions */
+
+const TREESHAKE_IGNORE_REGEXES = [
+    /polyfill/
+];
 
 const STRIP_FUNCTIONS = [
     'Debug.assert',
@@ -198,6 +203,7 @@ function buildTarget({ moduleFormat, buildType, input = 'src/index.js', dir = 'b
         plugins: [
             resolve(),
             jscc(getJSCCOptions(isMin ? 'release' : buildType, isUMD)),
+            isUMD ? treeshakeIgnore(TREESHAKE_IGNORE_REGEXES) : undefined,
             isUMD ? dynamicImportLegacyBrowserSupport() : undefined,
             !isDebug ? shaderChunks() : undefined,
             isDebug ? engineLayerImportValidation(input) : undefined,


### PR DESCRIPTION
Fixes #6328 

Adds a custom plugin to disable treeshaking on certain module paths (polyfills in this case)
