### PR TITLE
Small refactor to separate composition update from framegraph building

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1195,6 +1195,10 @@ class AppBase extends EventHandler {
     // render a layer composition
     renderComposition(layerComposition) {
         DebugGraphics.clearGpuMarkers();
+
+        // update composition, cull everything, assign atlas slots for clustered lighting
+        this.renderer.update(layerComposition);
+
         this.renderer.buildFrameGraph(this.frameGraph, layerComposition);
         this.frameGraph.render(this.graphicsDevice);
     }

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -814,9 +814,6 @@ class ForwardRenderer extends Renderer {
         const scene = this.scene;
         frameGraph.reset();
 
-        // update composition, cull everything, assign atlas slots for clustered lighting
-        this.update(layerComposition);
-
         if (scene.clusteredLightingEnabled) {
 
             // clustered lighting passes


### PR DESCRIPTION
- this is to make profiling easier to understand - framegraph is not expensive, but the cost is coming from culling inside the composition update