### PR TITLE
Examples mobile fixes

### DIFF
--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -307,7 +307,7 @@ class Example extends TypedComponent {
     }
 
     renderPortrait() {
-        const { collapsed, controls, show, files, description } = this.state;
+        const { collapsed, show, files, description } = this.state;
         return fragment(
             jsx(
                 Panel,

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
-import MonacoEditor from '@monaco-editor/react';
 import { withRouter } from 'react-router-dom';
 import * as PCUI from '@playcanvas/pcui';
 import * as ReactPCUI from '@playcanvas/pcui/react';
 import { Panel, Container, Button, Spinner } from '@playcanvas/pcui/react';
 
 import { DeviceSelector } from './DeviceSelector.mjs';
+import { CodeEditorMobile } from './CodeEditor.mjs';
 import { ErrorBoundary } from './ErrorBoundary.mjs';
 
 import { MIN_DESKTOP_WIDTH } from '../constants.mjs';
@@ -323,8 +323,7 @@ class Example extends TypedComponent {
                 jsx(
                     Container,
                     {
-                        id: 'controls-wrapper',
-                        class: controls ? 'has-controls' : null
+                        id: 'controls-wrapper'
                     },
                     jsx(
                         Container,
@@ -361,15 +360,7 @@ class Example extends TypedComponent {
                             },
                             this.renderControls()
                         ),
-                    show === 'code' &&
-                        jsx(MonacoEditor, {
-                            options: {
-                                readOnly: true,
-                                theme: 'vs-dark'
-                            },
-                            defaultLanguage: 'javascript',
-                            value: files['example.mjs']
-                        })
+                    show === 'code' && jsx(CodeEditorMobile, { files })
                 )
             ),
             this.renderDescription()

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -5,7 +5,7 @@ import * as ReactPCUI from '@playcanvas/pcui/react';
 import { Panel, Container, Button, Spinner } from '@playcanvas/pcui/react';
 
 import { DeviceSelector } from './DeviceSelector.mjs';
-import { CodeEditorMobile } from './CodeEditor.mjs';
+import { CodeEditorMobile } from './code-editor/CodeEditorMobile.mjs';
 import { ErrorBoundary } from './ErrorBoundary.mjs';
 
 import { MIN_DESKTOP_WIDTH } from '../constants.mjs';

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -2,7 +2,7 @@ import { Component } from 'react';
 import { HashRouter, Switch, Route, Redirect } from 'react-router-dom';
 import { Container } from '@playcanvas/pcui/react';
 
-import { CodeEditor } from './CodeEditor.mjs';
+import { CodeEditorDesktop } from './code-editor/CodeEditorDesktop.mjs';
 import { Example } from './Example.mjs';
 import { Menu } from './Menu.mjs';
 import { SideBar } from './Sidebar.mjs';
@@ -84,7 +84,7 @@ class MainLayout extends TypedComponent {
                             jsx(
                                 Container,
                                 { id: 'main-view' },
-                                orientation === 'landscape' && jsx(CodeEditor),
+                                orientation === 'landscape' && jsx(CodeEditorDesktop),
                                 jsx(Example, null)
                             )
                         )

--- a/examples/src/app/components/code-editor/CodeEditorBase.mjs
+++ b/examples/src/app/components/code-editor/CodeEditorBase.mjs
@@ -1,0 +1,143 @@
+import { Component } from 'react';
+import { loader } from '@monaco-editor/react';
+
+import { pcTypes } from '../../paths.mjs';
+import { jsx } from '../../jsx.mjs';
+import { playcanvasTheme } from '../../monaco/theme.mjs';
+import { jsRules } from '../../monaco/tokenizer-rules.mjs';
+import * as languages from '../../monaco/languages/index.mjs';
+
+import '../../events.js';
+
+loader.config({ paths: { vs: './modules/monaco-editor/min/vs' } });
+
+function getShowMinimap() {
+    let showMinimap = true;
+    if (localStorage.getItem('showMinimap')) {
+        showMinimap = localStorage.getItem('showMinimap') === 'true';
+    }
+    return showMinimap;
+}
+
+// eslint-disable-next-line jsdoc/require-property
+/**
+ * @typedef {Record<string, any>} Props
+ */
+
+/**
+ * @typedef {object} State
+ * @property {Record<string, string>} files - The example files.
+ * @property {string} selectedFile - The selected file.
+ * @property {boolean} showMinimap - The state of showing the Minimap
+ */
+
+/** @type {typeof Component<Props, State>} */
+const TypedComponent = Component;
+
+class CodeEditorBase extends TypedComponent {
+    /** @type {State} */
+    state = {
+        files: { 'example.mjs': '// init' },
+        selectedFile: 'example.mjs',
+        showMinimap: getShowMinimap()
+    };
+
+    /**
+     * @param {Props} props - Component properties.
+     */
+    constructor(props) {
+        super(props);
+        this._handleExampleLoad = this._handleExampleLoad.bind(this);
+        this._handleExampleLoading = this._handleExampleLoading.bind(this);
+    }
+
+    /**
+     * @param {StateEvent} event - The event.
+     */
+    _handleExampleLoad(event) {
+        const { files } = event.detail;
+        this.mergeState({ files, selectedFile: 'example.mjs' });
+    }
+
+    _handleExampleLoading() {
+        this.mergeState({ files: { 'example.mjs': '// reloading' } });
+    }
+
+    /**
+     * @param {Partial<State>} state - New partial state.
+     */
+    mergeState(state) {
+        // new state is always calculated from the current state,
+        // avoiding any potential issues with asynchronous updates
+        this.setState(prevState => ({ ...prevState, ...state }));
+    }
+
+    componentDidMount() {
+        window.addEventListener('exampleLoad', this._handleExampleLoad);
+        window.addEventListener('exampleLoading', this._handleExampleLoading);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('exampleLoad', this._handleExampleLoad);
+        window.removeEventListener('exampleLoading', this._handleExampleLoading);
+    }
+
+    /**
+     * @param {import('@monaco-editor/react').Monaco} monaco - The monaco editor.
+     */
+    beforeMount(monaco) {
+        fetch(pcTypes)
+            .then((r) => {
+                return r.text();
+            })
+            .then((playcanvasDefs) => {
+                // set types
+                monaco.languages.typescript.typescriptDefaults.addExtraLib(
+                    playcanvasDefs,
+                    '@playcanvas/playcanvas.d.ts'
+                );
+                monaco.languages.typescript.javascriptDefaults.addExtraLib(
+                    playcanvasDefs,
+                    '@playcanvas/playcanvas.d.ts'
+                );
+
+                // set languages
+                for (const id in languages) {
+                    monaco.languages.register({ id });
+                    // @ts-ignore
+                    monaco.languages.setLanguageConfiguration(id, languages[id].conf);
+                    // @ts-ignore
+                    monaco.languages.setMonarchTokensProvider(id, languages[id].language);
+                }
+
+                // patches highlighter tokenizer for javascript to include jsdoc
+                const allLangs = monaco.languages.getLanguages();
+                const jsLang = allLangs.find(({ id }) => id === 'javascript');
+                // @ts-ignore
+                jsLang?.loader()?.then(({ language }) => {
+                    Object.assign(language.tokenizer, jsRules);
+                });
+            });
+    }
+
+    /**
+     * @param {import('monaco-editor').editor.IStandaloneCodeEditor} editor - The monaco editor.
+     */
+    editorDidMount(editor) {
+        // @ts-ignore
+        const monaco = window.monaco;
+
+        // set theme
+        monaco.editor.defineTheme('playcanvas', playcanvasTheme);
+        monaco.editor.setTheme('playcanvas');
+    }
+
+    /**
+     * @returns {JSX.Element} - The rendered component.
+     */
+    render() {
+        return jsx('pre', null, 'Not implemented');
+    }
+}
+
+export { CodeEditorBase };

--- a/examples/src/app/components/code-editor/CodeEditorBase.mjs
+++ b/examples/src/app/components/code-editor/CodeEditorBase.mjs
@@ -117,6 +117,8 @@ class CodeEditorBase extends TypedComponent {
                 jsLang?.loader()?.then(({ language }) => {
                     Object.assign(language.tokenizer, jsRules);
                 });
+
+                this.mergeState({});
             });
     }
 

--- a/examples/src/app/components/code-editor/CodeEditorDesktop.mjs
+++ b/examples/src/app/components/code-editor/CodeEditorDesktop.mjs
@@ -1,16 +1,13 @@
-import { Component } from 'react';
 import { Button, Container, Panel } from '@playcanvas/pcui/react';
 import MonacoEditor, { loader } from '@monaco-editor/react';
 
-import { pcTypes } from '../paths.mjs';
-import { jsx } from '../jsx.mjs';
-import { iframe } from '../iframe.mjs';
-import { removeRedundantSpaces } from '../strings.mjs';
-import { playcanvasTheme } from '../monaco/theme.mjs';
-import { jsRules } from '../monaco/tokenizer-rules.mjs';
-import * as languages from '../monaco/languages/index.mjs';
+import { CodeEditorBase } from './CodeEditorBase.mjs';
 
-import '../events.js';
+import { jsx } from '../../jsx.mjs';
+import { iframe } from '../../iframe.mjs';
+import { removeRedundantSpaces } from '../../strings.mjs';
+
+import '../../events.js';
 
 loader.config({ paths: { vs: './modules/monaco-editor/min/vs' } });
 
@@ -46,24 +43,7 @@ let monacoEditor;
  * @typedef {Record<string, any>} Props
  */
 
-/**
- * @typedef {object} State
- * @property {Record<string, string>} files - The example files.
- * @property {string} selectedFile - The selected file.
- * @property {boolean} showMinimap - The state of showing the Minimap
- */
-
-/** @type {typeof Component<Props, State>} */
-const TypedComponent = Component;
-
-class CodeEditor extends TypedComponent {
-    /** @type {State} */
-    state = {
-        files: { 'example.mjs': '// init' },
-        selectedFile: 'example.mjs',
-        showMinimap: getShowMinimap()
-    };
-
+class CodeEditorDesktop extends CodeEditorBase {
     /** @type {string[]} */
     _decorators = [];
 
@@ -75,23 +55,9 @@ class CodeEditor extends TypedComponent {
      */
     constructor(props) {
         super(props);
-        this._handleExampleLoad = this._handleExampleLoad.bind(this);
-        this._handleExampleLoading = this._handleExampleLoading.bind(this);
         this._handleExampleHotReload = this._handleExampleHotReload.bind(this);
         this._handleExampleError = this._handleExampleError.bind(this);
         this._handleRequestedFiles = this._handleRequestedFiles.bind(this);
-    }
-
-    /**
-     * @param {StateEvent} event - The event.
-     */
-    _handleExampleLoad(event) {
-        const { files } = event.detail;
-        this.mergeState({ files, selectedFile: 'example.mjs' });
-    }
-
-    _handleExampleLoading() {
-        this.mergeState({ files: { 'example.mjs': '// reloading' } });
     }
 
     /**
@@ -153,8 +119,7 @@ class CodeEditor extends TypedComponent {
     }
 
     componentDidMount() {
-        window.addEventListener('exampleLoad', this._handleExampleLoad);
-        window.addEventListener('exampleLoading', this._handleExampleLoading);
+        super.componentDidMount();
         window.addEventListener('exampleHotReload', this._handleExampleHotReload);
         window.addEventListener('exampleError', this._handleExampleError);
         window.addEventListener('requestedFiles', this._handleRequestedFiles);
@@ -162,64 +127,24 @@ class CodeEditor extends TypedComponent {
     }
 
     componentWillUnmount() {
-        window.removeEventListener('exampleLoad', this._handleExampleLoad);
-        window.removeEventListener('exampleLoading', this._handleExampleLoading);
+        super.componentWillUnmount();
         window.removeEventListener('exampleHotReload', this._handleExampleHotReload);
         window.removeEventListener('exampleError', this._handleExampleError);
         window.removeEventListener('requestedFiles', this._handleRequestedFiles);
     }
 
-    /**
-     * @param {import('@monaco-editor/react').Monaco} monaco - The monaco editor.
-     */
-    beforeMount(monaco) {
-        fetch(pcTypes)
-            .then((r) => {
-                return r.text();
-            })
-            .then((playcanvasDefs) => {
-                // set types
-                monaco.languages.typescript.typescriptDefaults.addExtraLib(
-                    playcanvasDefs,
-                    '@playcanvas/playcanvas.d.ts'
-                );
-                monaco.languages.typescript.javascriptDefaults.addExtraLib(
-                    playcanvasDefs,
-                    '@playcanvas/playcanvas.d.ts'
-                );
-
-                // set languages
-                for (const id in languages) {
-                    monaco.languages.register({ id });
-                    // @ts-ignore
-                    monaco.languages.setLanguageConfiguration(id, languages[id].conf);
-                    // @ts-ignore
-                    monaco.languages.setMonarchTokensProvider(id, languages[id].language);
-                }
-
-                // patches highlighter tokenizer for javascript to include jsdoc
-                const allLangs = monaco.languages.getLanguages();
-                const jsLang = allLangs.find(({ id }) => id === 'javascript');
-                // @ts-ignore
-                jsLang?.loader()?.then(({ language }) => {
-                    Object.assign(language.tokenizer, jsRules);
-                });
-            });
-    }
 
     /**
      * @param {import('monaco-editor').editor.IStandaloneCodeEditor} editor - The monaco editor.
      */
     editorDidMount(editor) {
+        super.editorDidMount(editor);
+
         // @ts-ignore
         window.editor = editor;
         monacoEditor = editor;
         // @ts-ignore
         const monaco = window.monaco;
-
-        // set theme
-        monaco.editor.defineTheme('playcanvas', playcanvasTheme);
-        monaco.editor.setTheme('playcanvas');
 
         // Hot reload code via Shift + Enter
         editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
@@ -390,116 +315,4 @@ class CodeEditor extends TypedComponent {
     }
 }
 
-class CodeEditorMobile extends TypedComponent {
-    /** @type {State} */
-    state = {
-        files: { 'example.mjs': '// init' },
-        selectedFile: 'example.mjs',
-        showMinimap: true
-    };
-
-    /**
-     * @param {Props} props - Component properties.
-     */
-    constructor(props) {
-        super(props);
-        if (props.files) {
-            this.state.files = props.files;
-        }
-        this._handleExampleLoad = this._handleExampleLoad.bind(this);
-    }
-
-    /**
-     * @param {StateEvent} event - The event.
-     */
-    _handleExampleLoad(event) {
-        const { files } = event.detail;
-        this.mergeState({ files });
-    }
-
-    /**
-     * @param {Partial<State>} state - New partial state.
-     */
-    mergeState(state) {
-        // new state is always calculated from the current state,
-        // avoiding any potential issues with asynchronous updates
-        this.setState(prevState => ({ ...prevState, ...state }));
-    }
-
-    componentDidMount() {
-        window.addEventListener('exampleLoad', this._handleExampleLoad);
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener('exampleLoad', this._handleExampleLoad);
-    }
-
-    /**
-     * @param {import('@monaco-editor/react').Monaco} monaco - The monaco editor.
-     */
-    beforeMount(monaco) {
-        fetch(pcTypes)
-            .then((r) => {
-                return r.text();
-            })
-            .then((playcanvasDefs) => {
-                // set types
-                monaco.languages.typescript.typescriptDefaults.addExtraLib(
-                    playcanvasDefs,
-                    '@playcanvas/playcanvas.d.ts'
-                );
-                monaco.languages.typescript.javascriptDefaults.addExtraLib(
-                    playcanvasDefs,
-                    '@playcanvas/playcanvas.d.ts'
-                );
-
-                // set languages
-                for (const id in languages) {
-                    monaco.languages.register({ id });
-                    // @ts-ignore
-                    monaco.languages.setLanguageConfiguration(id, languages[id].conf);
-                    // @ts-ignore
-                    monaco.languages.setMonarchTokensProvider(id, languages[id].language);
-                }
-
-                // patches highlighter tokenizer for javascript to include jsdoc
-                const allLangs = monaco.languages.getLanguages();
-                const jsLang = allLangs.find(({ id }) => id === 'javascript');
-                // @ts-ignore
-                jsLang?.loader()?.then(({ language }) => {
-                    Object.assign(language.tokenizer, jsRules);
-                });
-            });
-    }
-
-    editorDidMount() {
-        // @ts-ignore
-        const monaco = window.monaco;
-
-        // set theme
-        monaco.editor.defineTheme('playcanvas', playcanvasTheme);
-        monaco.editor.setTheme('playcanvas');
-    }
-
-    render() {
-        const { files, selectedFile, showMinimap } = this.state;
-        const options = {
-            className: 'code-editor-mobile',
-            value: files[selectedFile],
-            language: 'javascript',
-            beforeMount: this.beforeMount.bind(this),
-            onMount: this.editorDidMount.bind(this),
-            options: {
-                theme: 'playcanvas',
-                readOnly: true,
-                minimap: {
-                    enabled: showMinimap
-                }
-            }
-        };
-
-        return jsx(MonacoEditor, options);
-    }
-}
-
-export { CodeEditor, CodeEditorMobile };
+export { CodeEditorDesktop };

--- a/examples/src/app/components/code-editor/CodeEditorMobile.mjs
+++ b/examples/src/app/components/code-editor/CodeEditorMobile.mjs
@@ -1,0 +1,46 @@
+import MonacoEditor from '@monaco-editor/react';
+
+import { CodeEditorBase } from './CodeEditorBase.mjs';
+
+import { jsx } from '../../jsx.mjs';
+
+import '../../events.js';
+
+// eslint-disable-next-line jsdoc/require-property
+/**
+ * @typedef {Record<string, any>} Props
+ */
+
+class CodeEditorMobile extends CodeEditorBase {
+    /**
+     * @param {Props} props - Component properties.
+     */
+    constructor(props) {
+        super(props);
+        if (props.files) {
+            this.state.files = props.files;
+        }
+    }
+
+    render() {
+        const { files, selectedFile, showMinimap } = this.state;
+        const options = {
+            className: 'code-editor-mobile',
+            value: files[selectedFile],
+            language: 'javascript',
+            beforeMount: this.beforeMount.bind(this),
+            onMount: this.editorDidMount.bind(this),
+            options: {
+                theme: 'playcanvas',
+                readOnly: true,
+                minimap: {
+                    enabled: showMinimap
+                }
+            }
+        };
+
+        return jsx(MonacoEditor, options);
+    }
+}
+
+export { CodeEditorMobile };

--- a/examples/src/examples/animation/blend-trees-1d/example.mjs
+++ b/examples/src/examples/animation/blend-trees-1d/example.mjs
@@ -27,6 +27,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/animation/blend-trees-2d-cartesian/example.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian/example.mjs
@@ -28,6 +28,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/animation/blend-trees-2d-directional/example.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-directional/example.mjs
@@ -28,6 +28,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/animation/component-properties/example.mjs
+++ b/examples/src/examples/animation/component-properties/example.mjs
@@ -19,6 +19,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/animation/events/example.mjs
+++ b/examples/src/examples/animation/events/example.mjs
@@ -24,6 +24,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/animation/layer-masks/example.mjs
+++ b/examples/src/examples/animation/layer-masks/example.mjs
@@ -31,6 +31,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/animation/locomotion/example.mjs
+++ b/examples/src/examples/animation/locomotion/example.mjs
@@ -40,6 +40,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/animation/tween/example.mjs
+++ b/examples/src/examples/animation/tween/example.mjs
@@ -20,6 +20,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/camera/first-person/example.mjs
+++ b/examples/src/examples/camera/first-person/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/camera/fly/example.mjs
+++ b/examples/src/examples/camera/fly/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/camera/orbit/example.mjs
+++ b/examples/src/examples/camera/orbit/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/compute/histogram/example.mjs
+++ b/examples/src/examples/compute/histogram/example.mjs
@@ -28,6 +28,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/compute/particles/example.mjs
+++ b/examples/src/examples/compute/particles/example.mjs
@@ -24,6 +24,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/compute/texture-gen/example.mjs
+++ b/examples/src/examples/compute/texture-gen/example.mjs
@@ -25,6 +25,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/compute/vertex-update/example.mjs
+++ b/examples/src/examples/compute/vertex-update/example.mjs
@@ -27,6 +27,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/area-lights/example.mjs
+++ b/examples/src/examples/graphics/area-lights/example.mjs
@@ -27,6 +27,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/area-picker/example.mjs
+++ b/examples/src/examples/graphics/area-picker/example.mjs
@@ -23,6 +23,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/asset-viewer/example.mjs
+++ b/examples/src/examples/graphics/asset-viewer/example.mjs
@@ -30,6 +30,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/batching-dynamic/example.mjs
+++ b/examples/src/examples/graphics/batching-dynamic/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/clustered-area-lights/example.mjs
+++ b/examples/src/examples/graphics/clustered-area-lights/example.mjs
@@ -30,6 +30,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/clustered-lighting/example.mjs
+++ b/examples/src/examples/graphics/clustered-lighting/example.mjs
@@ -18,6 +18,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/clustered-omni-shadows/example.mjs
+++ b/examples/src/examples/graphics/clustered-omni-shadows/example.mjs
@@ -25,6 +25,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/clustered-spot-shadows/example.mjs
+++ b/examples/src/examples/graphics/clustered-spot-shadows/example.mjs
@@ -28,6 +28,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/contact-hardening-shadows/example.mjs
+++ b/examples/src/examples/graphics/contact-hardening-shadows/example.mjs
@@ -37,6 +37,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/graphics/dispersion/example.mjs
+++ b/examples/src/examples/graphics/dispersion/example.mjs
@@ -24,6 +24,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/dithered-transparency/example.mjs
+++ b/examples/src/examples/graphics/dithered-transparency/example.mjs
@@ -29,6 +29,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/grab-pass/example.mjs
+++ b/examples/src/examples/graphics/grab-pass/example.mjs
@@ -25,6 +25,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/ground-fog/example.mjs
+++ b/examples/src/examples/graphics/ground-fog/example.mjs
@@ -27,6 +27,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/hardware-instancing/example.mjs
+++ b/examples/src/examples/graphics/hardware-instancing/example.mjs
@@ -22,6 +22,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/hierarchy/example.mjs
+++ b/examples/src/examples/graphics/hierarchy/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/integer-textures/example.mjs
+++ b/examples/src/examples/graphics/integer-textures/example.mjs
@@ -50,6 +50,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/graphics/layers/example.mjs
+++ b/examples/src/examples/graphics/layers/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/light-physical-units/example.mjs
+++ b/examples/src/examples/graphics/light-physical-units/example.mjs
@@ -30,6 +30,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/graphics/lights-baked-a-o/example.mjs
+++ b/examples/src/examples/graphics/lights-baked-a-o/example.mjs
@@ -25,6 +25,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/lights-baked/example.mjs
+++ b/examples/src/examples/graphics/lights-baked/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/lights/example.mjs
+++ b/examples/src/examples/graphics/lights/example.mjs
@@ -34,6 +34,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/graphics/lines/example.mjs
+++ b/examples/src/examples/graphics/lines/example.mjs
@@ -22,6 +22,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/lit-material/example.mjs
+++ b/examples/src/examples/graphics/lit-material/example.mjs
@@ -27,6 +27,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/graphics/material-anisotropic/example.mjs
+++ b/examples/src/examples/graphics/material-anisotropic/example.mjs
@@ -23,6 +23,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/material-basic/example.mjs
+++ b/examples/src/examples/graphics/material-basic/example.mjs
@@ -18,6 +18,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/material-clear-coat/example.mjs
+++ b/examples/src/examples/graphics/material-clear-coat/example.mjs
@@ -25,6 +25,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/material-physical/example.mjs
+++ b/examples/src/examples/graphics/material-physical/example.mjs
@@ -23,6 +23,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/material-translucent-specular/example.mjs
+++ b/examples/src/examples/graphics/material-translucent-specular/example.mjs
@@ -23,6 +23,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/mesh-decals/example.mjs
+++ b/examples/src/examples/graphics/mesh-decals/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/mesh-deformation/example.mjs
+++ b/examples/src/examples/graphics/mesh-deformation/example.mjs
@@ -23,6 +23,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/mesh-generation/example.mjs
+++ b/examples/src/examples/graphics/mesh-generation/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/mesh-morph-many/example.mjs
+++ b/examples/src/examples/graphics/mesh-morph-many/example.mjs
@@ -23,6 +23,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/mesh-morph/example.mjs
+++ b/examples/src/examples/graphics/mesh-morph/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/model-asset/example.mjs
+++ b/examples/src/examples/graphics/model-asset/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/model-outline/example.mjs
+++ b/examples/src/examples/graphics/model-outline/example.mjs
@@ -15,6 +15,7 @@ const gfxOptions = {
     twgslUrl: rootPath + '/static/lib/twgsl/twgsl.js'
 };
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/model-textured-box/example.mjs
+++ b/examples/src/examples/graphics/model-textured-box/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/multi-render-targets/example.mjs
+++ b/examples/src/examples/graphics/multi-render-targets/example.mjs
@@ -31,6 +31,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/graphics/multi-view/example.mjs
+++ b/examples/src/examples/graphics/multi-view/example.mjs
@@ -36,6 +36,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/normals-and-tangents/example.mjs
+++ b/examples/src/examples/graphics/normals-and-tangents/example.mjs
@@ -24,6 +24,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/paint-mesh/example.mjs
+++ b/examples/src/examples/graphics/paint-mesh/example.mjs
@@ -26,6 +26,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/painter/example.mjs
+++ b/examples/src/examples/graphics/painter/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/particles-anim-index/example.mjs
+++ b/examples/src/examples/graphics/particles-anim-index/example.mjs
@@ -19,6 +19,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/particles-mesh/example.mjs
+++ b/examples/src/examples/graphics/particles-mesh/example.mjs
@@ -24,6 +24,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/particles-random-sprites/example.mjs
+++ b/examples/src/examples/graphics/particles-random-sprites/example.mjs
@@ -22,6 +22,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/particles-snow/example.mjs
+++ b/examples/src/examples/graphics/particles-snow/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/particles-spark/example.mjs
+++ b/examples/src/examples/graphics/particles-spark/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/point-cloud-simulation/example.mjs
+++ b/examples/src/examples/graphics/point-cloud-simulation/example.mjs
@@ -14,6 +14,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 // render to low resolution to make particles more visible on WebGPU, as it doesn't support point
 // size and those are very small otherwise. This is not a proper solution, and only a temporary

--- a/examples/src/examples/graphics/point-cloud/example.mjs
+++ b/examples/src/examples/graphics/point-cloud/example.mjs
@@ -14,6 +14,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/portal/example.mjs
+++ b/examples/src/examples/graphics/portal/example.mjs
@@ -25,6 +25,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/graphics/post-effects/example.mjs
+++ b/examples/src/examples/graphics/post-effects/example.mjs
@@ -37,6 +37,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/graphics/post-processing/example.mjs
+++ b/examples/src/examples/graphics/post-processing/example.mjs
@@ -39,6 +39,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/reflection-box/example.mjs
+++ b/examples/src/examples/graphics/reflection-box/example.mjs
@@ -20,6 +20,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/reflection-cubemap/example.mjs
+++ b/examples/src/examples/graphics/reflection-cubemap/example.mjs
@@ -23,6 +23,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/reflection-planar/example.mjs
+++ b/examples/src/examples/graphics/reflection-planar/example.mjs
@@ -25,6 +25,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/render-asset/example.mjs
+++ b/examples/src/examples/graphics/render-asset/example.mjs
@@ -24,6 +24,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/render-pass/example.mjs
+++ b/examples/src/examples/graphics/render-pass/example.mjs
@@ -57,6 +57,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/graphics/render-to-texture/example.mjs
+++ b/examples/src/examples/graphics/render-to-texture/example.mjs
@@ -33,6 +33,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/shader-burn/example.mjs
+++ b/examples/src/examples/graphics/shader-burn/example.mjs
@@ -19,6 +19,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/shader-compile/example.mjs
+++ b/examples/src/examples/graphics/shader-compile/example.mjs
@@ -29,6 +29,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/shader-toon/example.mjs
+++ b/examples/src/examples/graphics/shader-toon/example.mjs
@@ -18,6 +18,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/shader-wobble/example.mjs
+++ b/examples/src/examples/graphics/shader-wobble/example.mjs
@@ -18,6 +18,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/shadow-cascades/example.mjs
+++ b/examples/src/examples/graphics/shadow-cascades/example.mjs
@@ -25,6 +25,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/shapes/example.mjs
+++ b/examples/src/examples/graphics/shapes/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/graphics/sky/example.mjs
+++ b/examples/src/examples/graphics/sky/example.mjs
@@ -21,6 +21,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/taa/example.mjs
+++ b/examples/src/examples/graphics/taa/example.mjs
@@ -28,6 +28,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/texture-array/example.mjs
+++ b/examples/src/examples/graphics/texture-array/example.mjs
@@ -64,6 +64,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/graphics/texture-basis/example.mjs
+++ b/examples/src/examples/graphics/texture-basis/example.mjs
@@ -37,6 +37,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/graphics/transform-feedback/example.mjs
+++ b/examples/src/examples/graphics/transform-feedback/example.mjs
@@ -14,6 +14,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/video-texture/example.mjs
+++ b/examples/src/examples/graphics/video-texture/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/graphics/wgsl-shader/example.mjs
+++ b/examples/src/examples/graphics/wgsl-shader/example.mjs
@@ -16,6 +16,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 if (!device.isWebGPU) {
     throw new Error('WebGPU is required for this example.');

--- a/examples/src/examples/input/gamepad/example.mjs
+++ b/examples/src/examples/input/gamepad/example.mjs
@@ -25,6 +25,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/input/keyboard/example.mjs
+++ b/examples/src/examples/input/keyboard/example.mjs
@@ -23,6 +23,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/input/mouse/example.mjs
+++ b/examples/src/examples/input/mouse/example.mjs
@@ -23,6 +23,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/loaders/bundle/example.mjs
+++ b/examples/src/examples/loaders/bundle/example.mjs
@@ -28,6 +28,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/loaders/draco-glb/example.mjs
+++ b/examples/src/examples/loaders/draco-glb/example.mjs
@@ -22,6 +22,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/loaders/glb/example.mjs
+++ b/examples/src/examples/loaders/glb/example.mjs
@@ -20,6 +20,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/loaders/gltf-export/example.mjs
+++ b/examples/src/examples/loaders/gltf-export/example.mjs
@@ -38,6 +38,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/loaders/gsplat-many/example.mjs
+++ b/examples/src/examples/loaders/gsplat-many/example.mjs
@@ -18,6 +18,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/loaders/gsplat/example.mjs
+++ b/examples/src/examples/loaders/gsplat/example.mjs
@@ -16,6 +16,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/loaders/loaders-gl/example.mjs
+++ b/examples/src/examples/loaders/loaders-gl/example.mjs
@@ -20,6 +20,7 @@ const gfxOptions = {
 
 /** @type {pc.GraphicsDevice} */
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/loaders/obj/example.mjs
+++ b/examples/src/examples/loaders/obj/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/loaders/usdz-export/example.mjs
+++ b/examples/src/examples/loaders/usdz-export/example.mjs
@@ -24,6 +24,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/misc/gizmos/example.mjs
+++ b/examples/src/examples/misc/gizmos/example.mjs
@@ -175,7 +175,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
-device.maxPixelRatio = window.devicePixelRatio;
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/misc/gizmos/example.mjs
+++ b/examples/src/examples/misc/gizmos/example.mjs
@@ -309,7 +309,7 @@ camera.script.create('orbitCameraInputMouse');
 camera.script.create('orbitCameraInputTouch');
 camera.setPosition(1, 1, 1);
 app.root.addChild(camera);
-orbitCamera.distance = 14;
+orbitCamera.distance = 5 * camera.camera?.aspectRatio;
 
 // create light entity
 const light = new pc.Entity('light');

--- a/examples/src/examples/misc/hello-world/example.mjs
+++ b/examples/src/examples/misc/hello-world/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/misc/mini-stats/example.mjs
+++ b/examples/src/examples/misc/mini-stats/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/misc/spineboy/example.mjs
+++ b/examples/src/examples/misc/spineboy/example.mjs
@@ -20,6 +20,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 

--- a/examples/src/examples/physics/compound-collision/example.mjs
+++ b/examples/src/examples/physics/compound-collision/example.mjs
@@ -22,6 +22,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/physics/falling-shapes/example.mjs
+++ b/examples/src/examples/physics/falling-shapes/example.mjs
@@ -26,6 +26,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/physics/offset-collision/example.mjs
+++ b/examples/src/examples/physics/offset-collision/example.mjs
@@ -33,6 +33,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/physics/raycast/example.mjs
+++ b/examples/src/examples/physics/raycast/example.mjs
@@ -26,6 +26,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/physics/vehicle/example.mjs
+++ b/examples/src/examples/physics/vehicle/example.mjs
@@ -36,6 +36,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);

--- a/examples/src/examples/sound/positional/example.mjs
+++ b/examples/src/examples/sound/positional/example.mjs
@@ -13,6 +13,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.soundManager = new pc.SoundManager();

--- a/examples/src/examples/user-interface/button-basic/example.mjs
+++ b/examples/src/examples/user-interface/button-basic/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/user-interface/button-sprite/example.mjs
+++ b/examples/src/examples/user-interface/button-sprite/example.mjs
@@ -20,6 +20,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/user-interface/custom-shader/example.mjs
+++ b/examples/src/examples/user-interface/custom-shader/example.mjs
@@ -18,6 +18,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/user-interface/layout-group/example.mjs
+++ b/examples/src/examples/user-interface/layout-group/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/user-interface/particle-system/example.mjs
+++ b/examples/src/examples/user-interface/particle-system/example.mjs
@@ -18,6 +18,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/user-interface/scroll-view/example.mjs
+++ b/examples/src/examples/user-interface/scroll-view/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/user-interface/text-auto-font-size/example.mjs
+++ b/examples/src/examples/user-interface/text-auto-font-size/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/user-interface/text-emojis/example.mjs
+++ b/examples/src/examples/user-interface/text-emojis/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/user-interface/text-localization/example.mjs
+++ b/examples/src/examples/user-interface/text-localization/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/user-interface/text-typewriter/example.mjs
+++ b/examples/src/examples/user-interface/text-typewriter/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;

--- a/examples/src/examples/user-interface/text/example.mjs
+++ b/examples/src/examples/user-interface/text/example.mjs
@@ -17,6 +17,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/user-interface/world-to-screen/example.mjs
+++ b/examples/src/examples/user-interface/world-to-screen/example.mjs
@@ -18,6 +18,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/user-interface/world-ui/example.mjs
+++ b/examples/src/examples/user-interface/world-ui/example.mjs
@@ -19,6 +19,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);

--- a/examples/src/examples/xr/xr-ui/example.mjs
+++ b/examples/src/examples/xr/xr-ui/example.mjs
@@ -39,6 +39,7 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.xr = pc.XrManager;
 createOptions.graphicsDevice = device;

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -427,8 +427,13 @@ body {
         height: calc(100% - 48px);
     }
 
-    #controls-wrapper.has-controls {
-        height: calc(100% - 100px);
+    #controlPanel-controls {
+        height: calc(100% - 48px);
+        overflow: auto;
+    }
+
+    .code-editor-mobile {
+        height: calc(100% - 48px);
     }
 }
 

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -363,7 +363,7 @@ body {
     min-height: calc(100% - 116px);
 }
 
-#controlPanel.mobile:has(#controlPanel-controls){
+#controlPanel.mobile:has(#controlPanel-controls):not(.pcui-collapsed){
     min-height: 300px;
 }
 

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -360,7 +360,11 @@ body {
     width: calc(100% - 16px);
     top: inherit;
     background-color: rgba(54, 67, 70, 1);
-    min-height: calc(100% - 112px);
+    min-height: calc(100% - 116px);
+}
+
+#controlPanel.mobile:has(#controlPanel-controls){
+    min-height: 300px;
 }
 
 #controlPanel.mobile.pcui-collapsed {

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -148,7 +148,7 @@ class Gizmo extends EventHandler {
     static EVENT_RENDERUPDATE = 'render:update';
 
     /**
-     * Internal device start width.
+     * Internal device start size.
      *
      * @type {number}
      * @private

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -153,7 +153,7 @@ class Gizmo extends EventHandler {
      * @type {number}
      * @private
      */
-    _deviceStartWidth;
+    _deviceStartSize;
 
     /**
      * Internal version of the gizmo size. Defaults to 1.
@@ -254,7 +254,7 @@ class Gizmo extends EventHandler {
 
         this._app = app;
         this._device = app.graphicsDevice;
-        this._deviceStartWidth = this._device.width;
+        this._deviceStartSize = Math.max(this._device.width, this._device.height);
         this._camera = camera;
         this._layer = layer;
 
@@ -335,7 +335,7 @@ class Gizmo extends EventHandler {
         const gizmoPos = this.root.getPosition();
         const cameraPos = this._camera.entity.getPosition();
         const dist = tmpV1.copy(gizmoPos).sub(cameraPos).dot(this._camera.entity.forward);
-        return dist * Math.tan(this._camera.fov * math.DEG_TO_RAD / 2);
+        return dist * Math.tan(0.5 * this._camera.fov * math.DEG_TO_RAD);
     }
 
     _createGizmo() {
@@ -370,7 +370,7 @@ class Gizmo extends EventHandler {
         if (this._camera.projection === PROJECTION_PERSPECTIVE) {
             let canvasMult = 1;
             if (this._device.width > 0 && this._device.height > 0) {
-                canvasMult = this._deviceStartWidth / Math.min(this._device.width, this._device.height);
+                canvasMult = this._deviceStartSize / Math.min(this._device.width, this._device.height);
             }
             this._scale = this._getProjFrustumWidth() * canvasMult * PERS_SCALE_RATIO;
         } else {


### PR DESCRIPTION
Fixes #3991
Fixes #5215

- Upgraded mobile code editor for mobile with proper highlighting and theme (read only)
- Fixed controls and code editor styling (clipped under Examples header)
- Made long controls scrollable
- Increased device pixel ratio to of the window (capped at 2)
- Gizmo distance and size invariant for different aspect ratios

### Preview
**Code editor**
![image](https://github.com/playcanvas/engine/assets/48248865/bf733fa2-8eeb-4db9-9c0f-71592ded2f81)

**Scrollable & Smaller controls**
![image](https://github.com/playcanvas/engine/assets/48248865/3bf23067-1ffd-448e-ac2e-cdab3c5f40ad)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
