### PR TITLE
Build fixes

### DIFF
--- a/examples/rollup.config.js
+++ b/examples/rollup.config.js
@@ -86,14 +86,14 @@ function getEnginePathFiles() {
 function checkAppEngine() {
     // types
     if (!fs.existsSync('../build/playcanvas.d.ts')) {
-        const cmd = `npm run build:types --prefix ../`;
+        const cmd = `npm run build target:types --prefix ../`;
         console.log("\x1b[32m%s\x1b[0m", cmd);
         execSync(cmd);
     }
 
     // engine
     if (!fs.existsSync('../build/playcanvas/src/index.js')) {
-        const cmd = `npm run build:esm:release --prefix ../`;
+        const cmd = `npm run build target:esm:release:bundled --prefix ../`;
         console.log("\x1b[32m%s\x1b[0m", cmd);
         execSync(cmd);
     }

--- a/examples/rollup.config.js
+++ b/examples/rollup.config.js
@@ -93,7 +93,7 @@ function checkAppEngine() {
 
     // engine
     if (!fs.existsSync('../build/playcanvas/src/index.js')) {
-        const cmd = `npm run build target:esm:release:bundled --prefix ../`;
+        const cmd = `npm run build target:esm:release:unbundled --prefix ../`;
         console.log("\x1b[32m%s\x1b[0m", cmd);
         execSync(cmd);
     }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
   "types": "build/playcanvas.d.ts",
   "exports": {
     ".": {
+      "require": "./build/playcanvas.js",
       "import": "./build/playcanvas/src/index.js",
-      "require": "./build/playcanvas.js"
+      "types": "./build/playcanvas.d.ts"
     },
     "./build/*": "./build/*"
   },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -36,7 +36,7 @@ const BUNDLE_STATES = ['unbundled', 'bundled'];
  * @type {RollupOptions[]}
  */
 const TYPES_TARGET = [{
-    input: 'build/playcanvas/index.d.ts',
+    input: 'build/playcanvas/src/index.d.ts',
     output: [{
         file: 'build/playcanvas.d.ts',
         footer: 'export as namespace pc;\nexport as namespace pcx;',

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,6 +4,6 @@
         "allowJs": true,
         "declaration": true,
         "emitDeclarationOnly": true,
-        "outDir": "build/playcanvas"
+        "outDir": "build/playcanvas/src"
     }
 }

--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -4,7 +4,7 @@ const GREEN_OUT = '\x1b[32m';
 const BOLD_OUT = `\x1b[1m`;
 const REGULAR_OUT = `\x1b[22m`;
 
-const TYPES_PATH = './build/playcanvas';
+const TYPES_PATH = './build/playcanvas/src';
 
 const STANDARD_MAT_PROPS = [
     ['alphaFade', 'boolean'],

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -225,9 +225,7 @@ function buildTarget({ moduleFormat, buildType, bundleState, input = 'src/index.
             preserveModules: !bundled,
             file: bundled ? `${dir}/${OUT_PREFIX[buildType]}${isUMD ? '.js' : '.mjs'}` : undefined,
             dir: !bundled ? `${dir}/${OUT_PREFIX[buildType]}` : undefined,
-            entryFileNames: (chunkInfo) => {
-                return `${chunkInfo.name.replace(/node_modules/g, 'modules')}.js`;
-            }
+            entryFileNames: chunkInfo => `${chunkInfo.name.replace(/node_modules/g, 'modules')}.js`
         },
         plugins: [
             resolve(),

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -224,7 +224,10 @@ function buildTarget({ moduleFormat, buildType, bundleState, input = 'src/index.
             name: 'pc',
             preserveModules: !bundled,
             file: bundled ? `${dir}/${OUT_PREFIX[buildType]}${isUMD ? '.js' : '.mjs'}` : undefined,
-            dir: !bundled ? `${dir}/${OUT_PREFIX[buildType]}` : undefined
+            dir: !bundled ? `${dir}/${OUT_PREFIX[buildType]}` : undefined,
+            entryFileNames: (chunkInfo) => {
+                return `${chunkInfo.name.replace(/node_modules/g, 'modules')}.js`;
+            }
         },
         plugins: [
             resolve(),


### PR DESCRIPTION
- Added types to package json (typescript type checking gets types from exports)
- Remapped node_modules folder to modules in unbundled build (fixes tsnode cjs issue)
- Changed examples to use narrower build target (unbundled only)
