### PR TITLE
Updated the way WebGPU dynamic UBs are used for rendering

### DIFF
--- a/examples/src/examples/compute/particles.example.mjs
+++ b/examples/src/examples/compute/particles.example.mjs
@@ -220,11 +220,6 @@ assetListLoader.load(() => {
             new pc.UniformFormat('matrix_model', pc.UNIFORMTYPE_MAT4)
         ]),
         meshBindGroupFormat: new pc.BindGroupFormat(app.graphicsDevice, [
-            // uniforms
-            new pc.BindUniformBufferFormat(
-                pc.UNIFORM_BUFFER_DEFAULT_SLOT_NAME,
-                pc.SHADERSTAGE_VERTEX | pc.SHADERSTAGE_FRAGMENT
-            ),
             // particle storage buffer in read-only mode
             new pc.BindStorageBufferFormat('particles', pc.SHADERSTAGE_VERTEX | pc.SHADERSTAGE_FRAGMENT, true)
         ])
@@ -232,6 +227,7 @@ assetListLoader.load(() => {
 
     // material to render the particles
     const material = new pc.Material();
+    material.name = 'ParticleRenderingMaterial';
     material.shader = new pc.Shader(app.graphicsDevice, shaderDefinition);
 
     // index buffer - two triangles (6 indices) per particle using 4 vertices
@@ -254,7 +250,7 @@ assetListLoader.load(() => {
     const meshInstance = new pc.MeshInstance(mesh, material);
     meshInstance.cull = false; // disable culling as we did not supply custom aabb for the mesh instance
 
-    const entity = new pc.Entity();
+    const entity = new pc.Entity('ParticleRenderingEntity');
     entity.addComponent('render', {
         meshInstances: [meshInstance]
     });

--- a/examples/src/examples/compute/particles.shader-rendering.wgsl
+++ b/examples/src/examples/compute/particles.shader-rendering.wgsl
@@ -8,9 +8,9 @@ struct ub_view {
     matrix_viewProjection : mat4x4f
 }
 
-@group(0) @binding(0) var<uniform> uvMesh : ub_mesh;
-@group(0) @binding(1) var<storage, read> particles: array<Particle>;
-@group(1) @binding(0) var<uniform> ubView : ub_view;
+@group(2) @binding(0) var<uniform> ubMesh : ub_mesh;
+@group(1) @binding(0) var<storage, read> particles: array<Particle>;
+@group(0) @binding(0) var<uniform> ubView : ub_view;
 
 // quad vertices - used to expand the particles into quads
 var<private> pos : array<vec2f, 4> = array<vec2f, 4>(

--- a/examples/src/examples/graphics/wgsl-shader.example.mjs
+++ b/examples/src/examples/graphics/wgsl-shader.example.mjs
@@ -56,12 +56,7 @@ const shaderDefinition = {
         new pc.UniformFormat('matrix_model', pc.UNIFORMTYPE_MAT4),
         new pc.UniformFormat('amount', pc.UNIFORMTYPE_FLOAT)
     ]),
-    meshBindGroupFormat: new pc.BindGroupFormat(app.graphicsDevice, [
-        new pc.BindUniformBufferFormat(
-            pc.UNIFORM_BUFFER_DEFAULT_SLOT_NAME,
-            pc.SHADERSTAGE_VERTEX | pc.SHADERSTAGE_FRAGMENT
-        )
-    ])
+    meshBindGroupFormat: new pc.BindGroupFormat(app.graphicsDevice, [])
 };
 const shader = new pc.Shader(app.graphicsDevice, shaderDefinition);
 

--- a/examples/src/examples/graphics/wgsl-shader.shader.wgsl
+++ b/examples/src/examples/graphics/wgsl-shader.shader.wgsl
@@ -12,8 +12,8 @@ struct VertexOutput {
     @location(0) fragPosition: vec4f,
 }
 
-@group(0) @binding(0) var<uniform> uvMesh : ub_mesh;
-@group(1) @binding(0) var<uniform> ubView : ub_view;
+@group(2) @binding(0) var<uniform> uvMesh : ub_mesh;
+@group(0) @binding(0) var<uniform> ubView : ub_view;
 
 @vertex
 fn vertexMain(@location(0) position : vec4f) -> VertexOutput {

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -2054,13 +2054,13 @@ export const SHADERSTAGE_FRAGMENT = 2;
  */
 export const SHADERSTAGE_COMPUTE = 4;
 
-// indices of commonly used bind groups
-// sorted in a way that any trailing bind groups can be unused in any render pass
-export const BINDGROUP_MESH = 0;
-export const BINDGROUP_VIEW = 1;
+// indices of commonly used bind groups, sorted from the least commonly changing to avoid internal rebinding
+export const BINDGROUP_VIEW = 0;        // view bind group, textures, samplers and uniforms
+export const BINDGROUP_MESH = 1;        // mesh bind group - textures and samplers
+export const BINDGROUP_MESH_UB = 2;     // mesh bind group - a single uniform buffer
 
 // names of bind groups
-export const bindGroupNames = ['mesh', 'view'];
+export const bindGroupNames = ['view', 'mesh', 'mesh_ub'];
 
 // name of the default uniform buffer slot in a bind group
 export const UNIFORM_BUFFER_DEFAULT_SLOT_NAME = 'default';

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -29,6 +29,8 @@ import { WebgpuGpuProfiler } from './webgpu-gpu-profiler.js';
 import { WebgpuResolver } from './webgpu-resolver.js';
 import { WebgpuCompute } from './webgpu-compute.js';
 import { WebgpuBuffer } from './webgpu-buffer.js';
+import { BindGroupFormat } from '../bind-group-format.js';
+import { BindGroup } from '../bind-group.js';
 
 const _uniqueLocations = new Map();
 
@@ -71,6 +73,14 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      * @type {WebgpuBindGroupFormat[]}
      */
     bindGroupFormats = [];
+
+    /**
+     * An empty bind group, used when the draw call is using a typical bind group layout based on
+     * BINDGROUP_*** constants but some bind groups are not needed, for example clear renderer.
+     *
+     * @type {BindGroup}
+     */
+    emptyBindGroup;
 
     /**
      * Current command buffer encoder.
@@ -310,6 +320,10 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
         // init dynamic buffer using 1MB allocation
         this.dynamicBuffers = new WebgpuDynamicBuffers(this, 1024 * 1024, this.limits.minUniformBufferOffsetAlignment);
+
+        // empty bind group
+        this.emptyBindGroup = new BindGroup(this, new BindGroupFormat(this, []));
+        this.emptyBindGroup.update();
     }
 
     createBackbuffer() {

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -7,6 +7,7 @@ import { WebgpuVertexBufferLayout } from "./webgpu-vertex-buffer-layout.js";
 import { WebgpuDebug } from "./webgpu-debug.js";
 import { WebgpuPipeline } from "./webgpu-pipeline.js";
 import { DebugGraphics } from "../debug-graphics.js";
+import { bindGroupNames } from "../constants.js";
 
 let _pipelineId = 0;
 
@@ -119,6 +120,12 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
         depthState, cullMode, stencilEnabled, stencilFront, stencilBack) {
 
         Debug.assert(bindGroupFormats.length <= 3);
+
+        // all bind groups must be set as the WebGPU layout cannot have skipped indices. Not having a bind
+        // group would assign incorrect slots to the following bind groups, causing a validation errors.
+        Debug.assert(bindGroupFormats[0], `BindGroup with index 0 [${bindGroupNames[0]}] is not set.`);
+        Debug.assert(bindGroupFormats[1], `BindGroup with index 1 [${bindGroupNames[1]}] is not set.`);
+        Debug.assert(bindGroupFormats[2], `BindGroup with index 2 [${bindGroupNames[2]}] is not set.`);
 
         // render pipeline unique hash
         const lookupHashes = this.lookupHashes;

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -59,11 +59,18 @@ class ShaderInstance {
     shader;
 
     /**
-     * A bind group storing mesh uniforms for the shader.
+     * A bind group storing mesh textures / samplers for the shader. but not the uniform buffer.
      *
      * @type {BindGroup|null}
      */
     bindGroup = null;
+
+    /**
+     * A uniform buffer storing mesh uniforms for the shader.
+     *
+     * @type {UniformBuffer|null}
+     */
+    uniformBuffer = null;
 
     /**
      * Returns the mesh bind group for the shader.
@@ -79,28 +86,43 @@ class ShaderInstance {
             const shader = this.shader;
             Debug.assert(shader);
 
-            // mesh uniform buffer
-            const ubFormat = shader.meshUniformBufferFormat;
-            Debug.assert(ubFormat);
-            const uniformBuffer = new UniformBuffer(device, ubFormat, false);
-
-            // mesh bind group
             const bindGroupFormat = shader.meshBindGroupFormat;
             Debug.assert(bindGroupFormat);
-            this.bindGroup = new BindGroup(device, bindGroupFormat, uniformBuffer);
+            this.bindGroup = new BindGroup(device, bindGroupFormat/*, uniformBuffer*/);
             DebugHelper.setName(this.bindGroup, `MeshBindGroup_${this.bindGroup.id}`);
         }
 
         return this.bindGroup;
     }
 
-    destroy() {
-        const group = this.bindGroup;
-        if (group) {
-            group.defaultUniformBuffer?.destroy();
-            group.destroy();
-            this.bindGroup = null;
+    /**
+     * Returns the uniform buffer for the shader.
+     *
+     * @param {import('../platform/graphics/graphics-device.js').GraphicsDevice} device - The
+     * graphics device.
+     * @returns {UniformBuffer} - The uniform buffer.
+     */
+    getUniformBuffer(device) {
+
+        // create uniform buffer
+        if (!this.uniformBuffer) {
+            const shader = this.shader;
+            Debug.assert(shader);
+
+            const ubFormat = shader.meshUniformBufferFormat;
+            Debug.assert(ubFormat);
+            this.uniformBuffer = new UniformBuffer(device, ubFormat, false);
         }
+
+        return this.uniformBuffer;
+    }
+
+    destroy() {
+        this.bindGroup?.destroy();
+        this.bindGroup = null;
+
+        this.uniformBuffer?.destroy();
+        this.uniformBuffer = null;
     }
 }
 

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -88,7 +88,7 @@ class ShaderInstance {
 
             const bindGroupFormat = shader.meshBindGroupFormat;
             Debug.assert(bindGroupFormat);
-            this.bindGroup = new BindGroup(device, bindGroupFormat/*, uniformBuffer*/);
+            this.bindGroup = new BindGroup(device, bindGroupFormat);
             DebugHelper.setName(this.bindGroup, `MeshBindGroup_${this.bindGroup.id}`);
         }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -685,14 +685,6 @@ class ForwardRenderer extends Renderer {
 
         this.setupViewport(camera, renderTarget);
 
-        // clearing
-        const clearColor = options.clearColor ?? false;
-        const clearDepth = options.clearDepth ?? false;
-        const clearStencil = options.clearStencil ?? false;
-        if (clearColor || clearDepth || clearStencil) {
-            this.clear(camera, clearColor, clearDepth, clearStencil);
-        }
-
         let visible, splitLights;
         if (layer) {
             // #if _PROFILER
@@ -746,6 +738,14 @@ class ForwardRenderer extends Renderer {
         const viewCount = this.setCameraUniforms(camera, renderTarget);
         if (device.supportsUniformBuffers) {
             this.setupViewUniformBuffers(viewBindGroups, this.viewUniformFormat, this.viewBindGroupFormat, viewCount);
+        }
+
+        // clearing - do it after the view bind groups are set up, to avoid overriding those
+        const clearColor = options.clearColor ?? false;
+        const clearDepth = options.clearDepth ?? false;
+        const clearStencil = options.clearStencil ?? false;
+        if (clearColor || clearDepth || clearStencil) {
+            this.clear(camera, clearColor, clearDepth, clearStencil);
         }
 
         // enable flip faces if either the camera has _flipFaces enabled or the render target has flipY enabled

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -24,11 +24,12 @@ import {
     SHADERSTAGE_VERTEX, SHADERSTAGE_FRAGMENT,
     SEMANTIC_ATTR,
     CULLFACE_BACK, CULLFACE_FRONT, CULLFACE_NONE,
-    TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT, SAMPLETYPE_FLOAT, SAMPLETYPE_DEPTH
+    TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT, SAMPLETYPE_FLOAT, SAMPLETYPE_DEPTH,
+    BINDGROUP_MESH_UB
 } from '../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { UniformBuffer } from '../../platform/graphics/uniform-buffer.js';
-import { BindGroup } from '../../platform/graphics/bind-group.js';
+import { BindGroup, DynamicBindGroup } from '../../platform/graphics/bind-group.js';
 import { UniformFormat, UniformBufferFormat } from '../../platform/graphics/uniform-buffer-format.js';
 import { BindGroupFormat, BindUniformBufferFormat, BindTextureFormat } from '../../platform/graphics/bind-group-format.js';
 
@@ -50,6 +51,7 @@ const tempSphere = new BoundingSphere();
 const _flipYMat = new Mat4().setScale(1, -1, 1);
 const _tempLightSet = new Set();
 const _tempLayerSet = new Set();
+const _dynamicBindGroup = new DynamicBindGroup();
 
 // Converts a projection matrix in OpenGL style (depth range of -1..1) to a DirectX style (depth range of 0..1).
 const _fixProjRangeMat = new Mat4().set([
@@ -866,10 +868,12 @@ class Renderer {
 
             // update mesh bind group / uniform buffer
             const meshBindGroup = shaderInstance.getBindGroup(device);
-
-            meshBindGroup.defaultUniformBuffer.update();
             meshBindGroup.update();
             device.setBindGroup(BINDGROUP_MESH, meshBindGroup);
+
+            const meshUniformBuffer = shaderInstance.getUniformBuffer(device);
+            meshUniformBuffer.update(_dynamicBindGroup);
+            device.setBindGroup(BINDGROUP_MESH_UB, _dynamicBindGroup.bindGroup, _dynamicBindGroup.offsets);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/6315 based on this comment: https://github.com/playcanvas/engine/issues/6315#issuecomment-2093250305

- mesh bind group is split into two, one for a uniform buffer, and one for the rest of resources (textures and storage buffers and similar)
- this allows us to re-use the same bind ground from the dynamic uniform buffer for all meshes using the same dynamic buffer (per UB size). When a UB buffer jumps to a different per frame bump allocated buffer, it would simply use it's existing bind group instead of creating a new one
- a good example to demonstrate this is the `hierarchy' engine example, where due to large amount of meshes rendered in different order over time, many of them would need to allocate a new bind group. This does not happen now at all.
- note that this does not solve the case where a new bind group needs to be created due to assigning a different texture to it, as that is unavoidable

Separately, the order of bind groups in the layout is sorted the opposite way:
-  original order: `mesh -> view`
- new order: `view -> mesh -> mesh_ub`
This is a recommended way to sort, from the least frequently updated to more frequently updated, to allow the underlying platform to skip all follow up bind groups to be re-set on their device.

Few engine examples that use WGSL directly had to be change to work with this, as there is no automatic bind group allocation yet. This is a non-breaking change as those are not public APIs yet.