### PR TITLE
Added docs for supported HDR formats

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -864,8 +864,10 @@ class GraphicsDevice extends EventHandler {
     /**
      * Get a renderable HDR pixel format supported by the graphics device.
      *
-     * Note: On WebGL2 and WebGPU, this function returns at least one of the supported formats on
-     * all devices apart from some very old iOS and Android devices.
+     * Note: On WebGL2 and WebGPU, when the `filterable` parameter is set to false, this function
+     * returns one of the supported formats on majority of the devices apart from some very old iOS
+     * and Android devices (99%). When the `filterable` parameter is set to true, the function
+     * returns a format on considerably lower number of devices (70%).
      *
      * @param {number[]} [formats] - An array of pixel formats to check for support. Can contain:
      *

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -864,10 +864,11 @@ class GraphicsDevice extends EventHandler {
     /**
      * Get a renderable HDR pixel format supported by the graphics device.
      *
-     * Note: On WebGL2 and WebGPU, when the `filterable` parameter is set to false, this function
-     * returns one of the supported formats on majority of the devices apart from some very old iOS
-     * and Android devices (99%). When the `filterable` parameter is set to true, the function
-     * returns a format on considerably lower number of devices (70%).
+     * Note:
+     * - When the `filterable` parameter is set to false, this function returns one of the supported
+     * formats on majority of the devices apart from some very old iOS and Android devices (99%).
+     * - When the `filterable` parameter is set to true, the function returns a format on a
+     * considerably lower number of devices (70%).
      *
      * @param {number[]} [formats] - An array of pixel formats to check for support. Can contain:
      *

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -264,6 +264,15 @@ class GraphicsDevice extends EventHandler {
       */
     textureHalfFloatRenderable;
 
+    /**
+     * True if small-float texture in format {@link PIXELFORMAT_111110F} can be used as a frame
+     * buffer. This is always true on WebGL2, but optional on WebGPU device.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    textureRG11B10Renderable = false;
+
      /**
       * True if filtering can be applied when sampling float textures.
       *
@@ -854,6 +863,9 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * Get a renderable HDR pixel format supported by the graphics device.
+     *
+     * Note: On WebGL2 and WebGPU, this function returns at least one of the supported formats on
+     * all devices apart from some very old iOS and Android devices.
      *
      * @param {number[]} [formats] - An array of pixel formats to check for support. Can contain:
      *

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -265,7 +265,7 @@ class GraphicsDevice extends EventHandler {
     textureHalfFloatRenderable;
 
     /**
-     * True if small-float texture in format {@link PIXELFORMAT_111110F} can be used as a frame
+     * True if small-float textures with format {@link PIXELFORMAT_111110F} can be used as a frame
      * buffer. This is always true on WebGL2, but optional on WebGPU device.
      *
      * @type {boolean}
@@ -866,7 +866,7 @@ class GraphicsDevice extends EventHandler {
      *
      * Note:
      * - When the `filterable` parameter is set to false, this function returns one of the supported
-     * formats on majority of the devices apart from some very old iOS and Android devices (99%).
+     * formats on the majority of devices apart from some very old iOS and Android devices (99%).
      * - When the `filterable` parameter is set to true, the function returns a format on a
      * considerably lower number of devices (70%).
      *

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -25,6 +25,26 @@ let id = 0;
  * A texture is a container for texel data that can be utilized in a fragment shader. Typically,
  * the texel data represents an image that is mapped over geometry.
  *
+ * Note on **HDR texture format** support:
+ * 1. **As textures**:
+ * - float (e.x. {@link PIXELFORMAT_RGBA32F}), half-float (e.x. {@link PIXELFORMAT_RGBA16F}) and
+ * small-float ({@link PIXELFORMAT_111110F}) formats are always supported on both WebGL2 and WebGPU
+ * with point sampling.
+ * - half-float and small-float formats are always supported on WebGL2 and WebGPU with linear sampling.
+ * - float formats are supported on WebGL2 and WebGPU with linear sampling only if
+ * {@link GraphicsDevice#textureFloatFilterable} is true.
+ *
+ * 2. **As renderable textures** that can be used as color buffers in a {@link RenderTarget}:
+ * - on WebGPU, rendering to float and half-float formats is always supported.
+ * - on WebGPU, rendering to small-float format is supported only if
+ * {@link GraphicsDevice#textureRG11B10Renderable} is true.
+ * - on WebGL2, rendering to these 3 formats formats is supported only if
+ * {@link GraphicsDevice#textureFloatRenderable} is true.
+ * - on WebGL2, if {@link GraphicsDevice#textureFloatRenderable} is false, but
+ * {@link GraphicsDevice#textureHalfFloatRenderable} is true, rendering to half-float formats only
+ * is supported. This is the case of many mobile iOS devices.
+ * - you can determine available renderable HDR format using
+ * {@link GraphicsDevice#getRenderableHdrFormat}.
  * @category Graphics
  */
 class Texture {

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -27,7 +27,7 @@ let id = 0;
  *
  * Note on **HDR texture format** support:
  * 1. **As textures**:
- *     - float (e.x. {@link PIXELFORMAT_RGBA32F}), half-float (e.x. {@link PIXELFORMAT_RGBA16F}) and
+ *     - float (i.e. {@link PIXELFORMAT_RGBA32F}), half-float (i.e. {@link PIXELFORMAT_RGBA16F}) and
  * small-float ({@link PIXELFORMAT_111110F}) formats are always supported on both WebGL2 and WebGPU
  * with point sampling.
  *     - half-float and small-float formats are always supported on WebGL2 and WebGPU with linear

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -27,23 +27,24 @@ let id = 0;
  *
  * Note on **HDR texture format** support:
  * 1. **As textures**:
- * - float (e.x. {@link PIXELFORMAT_RGBA32F}), half-float (e.x. {@link PIXELFORMAT_RGBA16F}) and
+ *     - float (e.x. {@link PIXELFORMAT_RGBA32F}), half-float (e.x. {@link PIXELFORMAT_RGBA16F}) and
  * small-float ({@link PIXELFORMAT_111110F}) formats are always supported on both WebGL2 and WebGPU
  * with point sampling.
- * - half-float and small-float formats are always supported on WebGL2 and WebGPU with linear sampling.
- * - float formats are supported on WebGL2 and WebGPU with linear sampling only if
+ *     - half-float and small-float formats are always supported on WebGL2 and WebGPU with linear
+ * sampling.
+ *     - float formats are supported on WebGL2 and WebGPU with linear sampling only if
  * {@link GraphicsDevice#textureFloatFilterable} is true.
  *
  * 2. **As renderable textures** that can be used as color buffers in a {@link RenderTarget}:
- * - on WebGPU, rendering to float and half-float formats is always supported.
- * - on WebGPU, rendering to small-float format is supported only if
+ *     - on WebGPU, rendering to float and half-float formats is always supported.
+ *     - on WebGPU, rendering to small-float format is supported only if
  * {@link GraphicsDevice#textureRG11B10Renderable} is true.
- * - on WebGL2, rendering to these 3 formats formats is supported only if
+ *     - on WebGL2, rendering to these 3 formats formats is supported only if
  * {@link GraphicsDevice#textureFloatRenderable} is true.
- * - on WebGL2, if {@link GraphicsDevice#textureFloatRenderable} is false, but
+ *     - on WebGL2, if {@link GraphicsDevice#textureFloatRenderable} is false, but
  * {@link GraphicsDevice#textureHalfFloatRenderable} is true, rendering to half-float formats only
  * is supported. This is the case of many mobile iOS devices.
- * - you can determine available renderable HDR format using
+ *     - you can determine available renderable HDR format using
  * {@link GraphicsDevice#getRenderableHdrFormat}.
  * @category Graphics
  */


### PR DESCRIPTION
- this is always pretty unclear and complicated, and this tries to explain is plainly now that we only need to handle WebGL2 and WebGPU:

<img width="970" alt="Screenshot 2024-05-10 at 16 35 16" src="https://github.com/playcanvas/engine/assets/59932779/140abe1c-3d2d-4e22-bddc-b3086e64b742">

<img width="978" alt="Screenshot 2024-05-10 at 16 14 12" src="https://github.com/playcanvas/engine/assets/59932779/831f3950-1a57-4567-a417-32662c5e0190">

