### PR TITLE
Fix buildUrl relative path support

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1,6 +1,5 @@
 import { TRACEID_RENDER_QUEUE } from '../../../core/constants.js';
 import { Debug, DebugHelper } from '../../../core/debug.js';
-import { path } from '../../../core/path.js';
 
 import {
     PIXELFORMAT_RGBA8, PIXELFORMAT_BGRA8, DEVICETYPE_WEBGPU,
@@ -167,16 +166,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // temporary message to confirm Webgpu is being used
         Debug.log("WebgpuGraphicsDevice initialization ..");
 
-        // build a full URL from a relative path
+        // build a full URL from a relative or absolute path
         const buildUrl = (srcPath) => {
-            if (!path.isRelativePath(srcPath)) {
-                return srcPath;
-            }
-
-            const url = new URL(window.location.href);
-            url.pathname = srcPath;
-            url.search = '';
-            return url.toString();
+            return new URL(srcPath, window.location.href).toString();
         };
 
         const results = await Promise.all([


### PR DESCRIPTION
`buildUrl` never worked with relative paths as it would always replace the path in the url, instead of adding to it.
Using the other mode of the URL constructor we can use it to always give us a correct url:
```
  `new URL('glslang/glslang.js', 'https://example.com/foo/bar.html')` is `https://example.com/foo/glslang/glslang.js`
  `new URL('/glslang/glslang.js', 'https://example.com/foo/bar.html')` is `https://example.com/glslang/glslang.js`
  `new URL('glslang/glslang.js', 'https://example.com/')` is `https://example.com/glslang/glslang.js`
  `new URL('/glslang/glslang.js', 'https://example.com/')` is `https://example.com/glslang/glslang.js`
```
This bug currently prevents Playcanvas Editor exports from being run on a non root path with WebGPU. The editor export will pass just `glslang.js` as path.
So on a url like https://94176748-9ef8-42c9-a44e-a95b70ec5680.poki-gdn.com/7a8f1fc6-7162-473a-b1dc-4479ed5d60cf/index.html 
the old code would turn it into https://94176748-9ef8-42c9-a44e-a95b70ec5680.poki-gdn.com/glslang.js 
while the actual paths should be https://94176748-9ef8-42c9-a44e-a95b70ec5680.poki-gdn.com/7a8f1fc6-7162-473a-b1dc-4479ed5d60cf/glslang.js

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
