### PR TITLE
Add webpack ignore

### DIFF
--- a/utils/plugins/rollup-dynamic.mjs
+++ b/utils/plugins/rollup-dynamic.mjs
@@ -20,17 +20,18 @@ export function dynamicImportLegacyBrowserSupport() {
 }
 
 /**
- * This rollup plugin transform code with import statements and adds a \/* vite-ignore *\/ comment to supress vite warnings
+ * This rollup plugin transform code with import statements and adds a \/* vite-ignore *\/ comment to suppress bundler warnings
  * generated from dynamic-import-vars {@link https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations}
+ * {@link https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import}
  *
  * @returns {import('rollup').Plugin} The rollup plugin
  */
-export function dynamicImportViteSupress() {
+export function dynamicImportBundlerSuppress() {
     return {
-        name: 'dynamic-import-vite-suppress',
+        name: 'dynamic-import-bundler-suppress',
         transform(code, id) {
             return {
-                code: code.replace(/import\(([^'])/g, 'import(/* @vite-ignore */$1'),
+                code: code.replace(/import\(([^'])/g, 'import(/* @vite-ignore */ /* webpackIgnore: true */ $1'),
                 map: null
             };
         }

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -12,7 +12,7 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import { shaderChunks } from './plugins/rollup-shader-chunks.mjs';
 import { engineLayerImportValidation } from './plugins/rollup-import-validation.mjs';
 import { spacesToTabs } from './plugins/rollup-spaces-to-tabs.mjs';
-import { dynamicImportLegacyBrowserSupport, dynamicImportViteSupress } from './plugins/rollup-dynamic.mjs';
+import { dynamicImportLegacyBrowserSupport, dynamicImportBundlerSuppress } from './plugins/rollup-dynamic.mjs';
 import { treeshakeIgnore } from './plugins/rollup-treeshake-ignore.mjs';
 
 import { version, revision } from './rollup-version-revision.mjs';
@@ -236,7 +236,7 @@ function buildTarget({ moduleFormat, buildType, bundleState, input = 'src/index.
             isDebug ? engineLayerImportValidation(input) : undefined,
             !isDebug ? strip({ functions: STRIP_FUNCTIONS }) : undefined,
             babel(babelOptions(isDebug, isUMD)),
-            !isUMD ? dynamicImportViteSupress() : undefined,
+            !isUMD ? dynamicImportBundlerSuppress() : undefined,
             !isDebug ? spacesToTabs() : undefined
         ]
     };


### PR DESCRIPTION
Adds `/* webpackIgnore: true */` to the bundler plugin to suppress webpack warnings with dynamic expressions. 

See https://forum.playcanvas.com/t/webpack-issue-with-playcanvas-engine-1-70-2/35856/2

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
