### PR TITLE
Removed Trigger double Body deletion

### DIFF
--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -79,12 +79,7 @@ class Trigger {
     }
 
     destroy() {
-        const body = this.body;
-        if (!body) return;
-
         this.disable();
-
-        this.app.systems.rigidbody.destroyBody(body);
     }
 
     _getEntityTransform(transform) {


### PR DESCRIPTION
Fixes #6364 

Trigger#destroy was calling `destroyBody` while already being called earlier from `this.disable` within the same function leading to Ammo.js trying to destroy an empty reference

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
