### PR TITLE
Small JSDoc normalization/fixes

### DIFF
--- a/examples/utils/plugins/rollup-copy-static.mjs
+++ b/examples/utils/plugins/rollup-copy-static.mjs
@@ -13,7 +13,10 @@ const copied = new Set();
  * This plugin copies static files from source to destination.
  *
  * @param {string} nodeEnv - The node environment.
- * @param {{ src: string, dest: string, once: boolean }[]} targets - Array of source and destination objects.
+ * @param {object[]} targets - Array of source and destination objects.
+ * @param {string} targets.src - File or entire dir.
+ * @param {string} targets.dest - File or entire dir, usually into `dist/`.
+ * @param {boolean} [targets.once] - Copy files only once for speed-up (external libs).
  * @param {boolean} log - Log the copy status.
  * @returns {import('rollup').Plugin} The plugin.
  */

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1735,8 +1735,8 @@ class ElementComponent extends Component {
      * Patched method for setting the position.
      *
      * @param {number|Vec3} x - The x coordinate or Vec3
-     * @param {number} y - The y coordinate
-     * @param {number} z - The z coordinate
+     * @param {number} [y] - The y coordinate
+     * @param {number} [z] - The z coordinate
      * @private
      */
     _setPosition(x, y, z) {
@@ -1764,8 +1764,8 @@ class ElementComponent extends Component {
      * Patched method for setting the local position.
      *
      * @param {number|Vec3} x - The x coordinate or Vec3
-     * @param {number} y - The y coordinate
-     * @param {number} z - The z coordinate
+     * @param {number} [y] - The y coordinate
+     * @param {number} [z] - The z coordinate
      * @private
      */
     _setLocalPosition(x, y, z) {


### PR DESCRIPTION
Problem with TS style types is:

1) Can't add inline-documentation to the properties.
2) Quickly escalate line length (was > 100).

So I normalized that into JSDoc style and added some description what it is about. `targets.once` is also optional, which the TS type didn't point out, leading to type mismatch.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
