### PR TITLE
Gizmo Axis shape disable fix

### DIFF
--- a/src/extras/gizmo/axis-shapes.js
+++ b/src/extras/gizmo/axis-shapes.js
@@ -178,7 +178,7 @@ class AxisShape {
 
     set disabled(value) {
         for (let i = 0; i < this.meshInstances.length; i++) {
-            setShadowMeshColor(this.meshInstances[i].mesh, this._disabledColor);
+            setShadowMeshColor(this.meshInstances[i].mesh, value ? this._disabledColor : this._defaultColor);
         }
         this._disabled = value ?? false;
     }


### PR DESCRIPTION
Fixes #6585 

Restores default color when disabled set to false
