### PR TITLE
Keep correct paths for build output even when build is invoked outside of repo root

### DIFF
--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -18,6 +18,15 @@ import { version, revision } from './rollup-version-revision.mjs';
 import { getBanner } from './rollup-get-banner.mjs';
 import { babelOptions } from './rollup-babel-options.mjs';
 
+import { dirname, resolve as pathResolve } from 'path';
+import { fileURLToPath } from 'url';
+
+// Find path to the repo root
+// @ts-ignore import.meta not allowed by tsconfig module:es6, but it works
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = pathResolve(__dirname, '..');
+
 /** @typedef {import('rollup').RollupOptions} RollupOptions */
 /** @typedef {import('rollup').OutputOptions} OutputOptions */
 /** @typedef {import('rollup').ModuleFormat} ModuleFormat */
@@ -192,6 +201,7 @@ function buildTarget({ moduleFormat, buildType, input = 'src/index.js', dir = 'b
             sourcemap: bundled && isDebug && 'inline',
             name: 'pc',
             preserveModules: !bundled,
+            preserveModulesRoot: !bundled ? rootDir : undefined,
             file: bundled ? `${dir}/${OUT_PREFIX[buildType]}${isUMD ? '.js' : '.mjs'}` : undefined,
             dir: !bundled ? `${dir}/${OUT_PREFIX[buildType]}` : undefined,
             footer: isUMD ? 'this.pcx = pc;' : undefined


### PR DESCRIPTION
This fixes a (possibly niche) problem that occurs when PlayCanvas is included in a monorepo with a central build system like [turborepo](https://turbo.build/) or [pnpm workspaces](https://pnpm.io/workspaces).

The problem: build output paths in the `build` directory are relative to the cwd of the shell executing the npm script. 

#### Example 
If you are using a monorepo-wide runner and have a structure like this:
`<root>/packages/vendor/playcanvas`

Then the expected output of `build/playcanvas/src/index.js` instead becomes `build/playcanvas/packages/vendor/playcanvas/src/index.js`. This causes subsequent build steps to fail. 

#### Solution
To fix the issue above, we find the actual repo root of `playcanvas` and set _this_ as the base path using the rollup option `preserveModulesRoot`. Now the output paths are correct regardless of where you run `npm run build` from.

-------

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
