### PR TITLE
Gsplat rendering fix

### DIFF
--- a/src/scene/gsplat/gsplat-data.js
+++ b/src/scene/gsplat/gsplat-data.js
@@ -563,7 +563,7 @@ class GSplatData {
             data.f_dc_0[i] = (c.x - 0.5) / SH_C0;
             data.f_dc_1[i] = (c.y - 0.5) / SH_C0;
             data.f_dc_2[i] = (c.z - 0.5) / SH_C0;
-            data.opacity[i] = -Math.log(1 / c.w - 1);
+            data.opacity[i] = (c.w <= 0) ? -20 : (c.w >= 1) ? 20 : -Math.log(1 / c.w - 1);
         }
 
         return new GSplatData([{

--- a/src/scene/gsplat/gsplat-data.js
+++ b/src/scene/gsplat/gsplat-data.js
@@ -563,7 +563,7 @@ class GSplatData {
             data.f_dc_0[i] = (c.x - 0.5) / SH_C0;
             data.f_dc_1[i] = (c.y - 0.5) / SH_C0;
             data.f_dc_2[i] = (c.z - 0.5) / SH_C0;
-            data.opacity[i] = (c.w <= 0) ? -20 : (c.w >= 1) ? 20 : -Math.log(1 / c.w - 1);
+            data.opacity[i] = (c.w <= 0) ? -40 : (c.w >= 1) ? 40 : -Math.log(1 / c.w - 1);
         }
 
         return new GSplatData([{

--- a/src/scene/gsplat/gsplat-data.js
+++ b/src/scene/gsplat/gsplat-data.js
@@ -563,6 +563,7 @@ class GSplatData {
             data.f_dc_0[i] = (c.x - 0.5) / SH_C0;
             data.f_dc_1[i] = (c.y - 0.5) / SH_C0;
             data.f_dc_2[i] = (c.z - 0.5) / SH_C0;
+            // convert opacity to log sigmoid taking into account infinities at 0 and 1
             data.opacity[i] = (c.w <= 0) ? -40 : (c.w >= 1) ? 40 : -Math.log(1 / c.w - 1);
         }
 

--- a/src/scene/gsplat/gsplat.js
+++ b/src/scene/gsplat/gsplat.js
@@ -88,9 +88,7 @@ class GSplat {
         result.setParameter('transformA', this.transformATexture);
         result.setParameter('transformB', this.transformBTexture);
         result.setParameter('transformC', this.transformCTexture);
-
-        const { width, height } = this.colorTexture;
-        result.setParameter('tex_params', new Float32Array([width, height, 1 / width, 1 / height]));
+        result.setParameter('tex_params', new Float32Array([this.colorTexture.width, this.numSplats, 0, 0]));
         return result;
     }
 

--- a/src/scene/gsplat/gsplat.js
+++ b/src/scene/gsplat/gsplat.js
@@ -88,7 +88,7 @@ class GSplat {
         result.setParameter('transformA', this.transformATexture);
         result.setParameter('transformB', this.transformBTexture);
         result.setParameter('transformC', this.transformCTexture);
-        result.setParameter('tex_params', new Float32Array([this.colorTexture.width, this.numSplats, 0, 0]));
+        result.setParameter('tex_params', new Float32Array([this.colorTexture.width, this.numSplats]));
         return result;
     }
 

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -33,13 +33,14 @@ const splatCoreVS = /* glsl */ `
     attribute vec3 vertex_position;
     attribute uint vertex_id_attrib;
 
+    uint orderId;
     uint splatId;
     ivec2 splatUV;
     void evalSplatUV() {
         int bufferSizeX = int(tex_params.x);
 
         // sample order texture
-        uint orderId = vertex_id_attrib + uint(vertex_position.z);
+        orderId = vertex_id_attrib + uint(vertex_position.z);
         ivec2 orderUV = ivec2(
             int(orderId) % bufferSizeX,
             int(orderId) / bufferSizeX
@@ -82,7 +83,7 @@ const splatCoreVS = /* glsl */ `
         vec4 splat_proj = matrix_projection * splat_cam;
 
         // cull behind camera
-        if (splat_proj.z < -splat_proj.w) {
+        if (splat_proj.z < -splat_proj.w || orderId >= uint(tex_params.y)) {
             return vec4(0.0, 0.0, 2.0, 1.0);
         }
 

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -18,7 +18,8 @@ const splatCoreVS = /* glsl */ `
     varying vec4 color;
     varying float id;
 
-    uniform vec4 tex_params;
+    // width, numSplats
+    uniform vec2 tex_params;
     uniform sampler2D splatColor;
 
     uniform highp usampler2D splatOrder;


### PR DESCRIPTION
Fixes #

Changes in this PR:
* refrain from rendering the out-of-bounds splats.
* fix opacity decompress to handle 0 and 1.