### PR TITLE
Treeshake plugin fix

### DIFF
--- a/utils/plugins/rollup-treeshake-ignore.mjs
+++ b/utils/plugins/rollup-treeshake-ignore.mjs
@@ -8,7 +8,7 @@ export function treeshakeIgnore(pathRegexList = []) {
     return {
         name: 'treeshake-ignore',
         transform(code, id) {
-            if (pathRegexList.some(regex => regex.test(id))) {
+            if (pathRegexList.some(regex => regex.test(id.replace(/\\/g, '/')))) {
                 return {
                     code,
                     map: null,


### PR DESCRIPTION
Replaces backslashes with forwards on treeshake filtering