### PR TITLE
Fix URL handling in ScriptHandler

### DIFF
--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -146,7 +146,7 @@ class ScriptHandler extends ResourceHandler {
     _loadModule(url, callback) {
 
         // if we're in the browser, we need to use the full URL
-        const baseUrl = platform.browser ? window.location.origin : import.meta.url;
+        const baseUrl = platform.browser ? window.location.origin + window.location.pathname : import.meta.url;
         const importUrl = new URL(url, baseUrl);
 
         // @ts-ignore


### PR DESCRIPTION
This pull request fixes the URL handling in  ScriptHandler for ESM Scripts when projects are not served from the root. 

Partially solves https://github.com/playcanvas/engine/issues/6638