### PR TITLE
Fixed trigger body not set to null once destroyed

### DIFF
--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -85,6 +85,7 @@ class Trigger {
         this.disable();
 
         this.app.systems.rigidbody.destroyBody(body);
+        this.body = null;
     }
 
     _getEntityTransform(transform) {


### PR DESCRIPTION
When a trigger body is destroyed its reference is currently kept within the Trigger object until a new body is created.

Only changing this to remove the reference to the destroyed `Ammo.btRigidBody`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
