### PR TITLE
Fix transform not destroyed on Ammo Hull creation

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -353,7 +353,9 @@ class CollisionMeshSystemImpl extends CollisionSystemImpl {
         hull.recalcLocalAabb();
         hull.setMargin(0.01);   // Note: default margin is 0.04
 
-        shape.addChildShape(this.system._getNodeTransform(node), hull);
+        const transform = this.system._getNodeTransform(node);
+        shape.addChildShape(transform, hull);
+        Ammo.destroy(transform);
     }
 
     createAmmoMesh(mesh, node, shape, scale, checkDupes = true) {


### PR DESCRIPTION
When calling `CollisionComponentSystem#_getNodeTransform`, it creates an `Ammo.btTransform`.

This transform is already correctly destroyed on other use of the function but on the Hull implementation, fixing through this PR.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
