### PR TITLE
Re-add deprecated L8 anbd LA8 formats to WebGL2 removed by mistake

### DIFF
--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -952,6 +952,8 @@ export const pixelFormatInfo = new Map([
     // float formats
     [PIXELFORMAT_A8,            { name: 'A8', size: 1 }],
     [PIXELFORMAT_R8,            { name: 'R8', size: 1 }],
+    [PIXELFORMAT_L8,            { name: 'L8', size: 1 }],
+    [PIXELFORMAT_LA8,           { name: 'LA8', size: 2 }],
     [PIXELFORMAT_RG8,           { name: 'RG8', size: 2 }],
     [PIXELFORMAT_RGB565,        { name: 'RGB565', size: 2 }],
     [PIXELFORMAT_RGBA5551,      { name: 'RGBA5551', size: 2 }],


### PR DESCRIPTION
Fixed an issue introduced in https://github.com/playcanvas/engine/pull/6602 where L8 and LA8 format was incorrectly deprecated, making it un-useable.