### PR TITLE
[Fix] Particle system handle different IB formats of incoming mesh

### DIFF
--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -17,7 +17,8 @@ import {
     PIXELFORMAT_RGBA8, PIXELFORMAT_RGBA32F,
     PRIMITIVE_TRIANGLES,
     SEMANTIC_ATTR0, SEMANTIC_ATTR1, SEMANTIC_ATTR2, SEMANTIC_ATTR3, SEMANTIC_ATTR4, SEMANTIC_TEXCOORD0,
-    TYPE_FLOAT32
+    TYPE_FLOAT32,
+    typedArrayIndexFormats
 } from '../../platform/graphics/constants.js';
 import { DeviceCache } from '../../platform/graphics/device-cache.js';
 import { IndexBuffer } from '../../platform/graphics/index-buffer.js';
@@ -1057,7 +1058,12 @@ class ParticleEmitter {
             // Fill the index buffer
             let dst = 0;
             const indices = new Uint32Array(this.indexBuffer.lock());
-            if (this.useMesh) meshData = new Uint32Array(this.mesh.indexBuffer[0].lock());
+
+            if (this.useMesh) {
+                const ib = this.mesh.indexBuffer[0];
+                meshData = new typedArrayIndexFormats[ib.format](ib.lock());
+            }
+
             for (let i = 0; i < numParticles; i++) {
                 if (!this.useMesh) {
                     const baseIndex = i * 4;


### PR DESCRIPTION
- initially the particle system assumed meshes it instances use 16bit indices
- in https://github.com/playcanvas/engine/pull/6291 this was incorrectly change to assume 32bit indices
- this PR fixes it and handles any format the mesh is using