### PR TITLE
Update to skybox shader to map it closer to the infinity

### DIFF
--- a/src/scene/shader-lib/chunks/skybox/vert/skybox.js
+++ b/src/scene/shader-lib/chunks/skybox/vert/skybox.js
@@ -39,6 +39,6 @@ void main(void) {
     // still push pixels beyond far Z. See:
     // https://community.khronos.org/t/skybox-problem/61857
 
-    gl_Position.z = gl_Position.w - 0.00001;
+    gl_Position.z = gl_Position.w - 1.0e-7;
 }
 `;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/6656

- smaller but still safe constant to render the sky geometry closer to the far distance of the camera
