### PR TITLE
[Fix] Fix picker support in BasicMaterial

### DIFF
--- a/src/scene/shader-lib/programs/basic.js
+++ b/src/scene/shader-lib/programs/basic.js
@@ -86,6 +86,10 @@ const fShader = `
         #include "packDepthPS"
     #endif
 
+    #ifdef PICK_PASS
+        uniform uint meshInstanceId;
+    #endif
+
     void main(void) {
 
         #ifdef VERTEX_COLORS
@@ -102,7 +106,14 @@ const fShader = `
             alphaTest(gl_FragColor.a);
         #endif
 
-        #ifndef PICK_PASS
+        #ifdef PICK_PASS
+
+            const vec4 inv = vec4(1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0);
+            const uvec4 shifts = uvec4(16, 8, 0, 24);
+            uvec4 col = (uvec4(meshInstanceId) >> shifts) & uvec4(0xff);
+            gl_FragColor = vec4(col) * inv;
+
+        #else
 
             #ifdef DEPTH_PASS
                 gl_FragColor = packFloat(vDepth);


### PR DESCRIPTION
- before the shader worked as a picker, as it used the same `vec4 uColor;` uniform
- now the picker uses `uint meshInstanceId` uniform, and so add support for it to basic shader generator
- fixes picking Zones gizmos in the Editor