### PR TITLE
When glslang transpilation fails on WebGPU, add stack trace to the error message

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1852,8 +1852,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * call.
      * @param {boolean} [primitive.indexed] - True to interpret the primitive as indexed, thereby
      * using the currently set index buffer and false otherwise.
-     * @param {number} [numInstances] - The number of instances to render when using
-     * ANGLE_instanced_arrays. Defaults to 1.
+     * @param {number} [numInstances] - The number of instances to render when using instancing.
+     * Defaults to 1.
      * @param {boolean} [keepBuffers] - Optionally keep the current set of vertex / index buffers /
      * VAO. This is used when rendering of multiple views, for example under WebXR.
      * @example

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -150,12 +150,15 @@ class WebgpuShader {
     transpile(src, shaderType, originalSrc) {
         try {
             const spirv = this.shader.device.glslang.compileGLSL(src, shaderType);
-            return this.shader.device.twgsl.convertSpirV2WGSL(spirv);
+            const wgsl = this.shader.device.twgsl.convertSpirV2WGSL(spirv);
+            return wgsl;
         } catch (err) {
-            console.error(`Failed to transpile webgl ${shaderType} shader [${this.shader.label}] to WebGPU: [${err.message}] while rendering ${DebugGraphics.toString()}`, {
+            console.error(`Failed to transpile webgl ${shaderType} shader [${this.shader.label}] to WebGPU while rendering ${DebugGraphics.toString()}, error:\n [${err.stack}]`, {
                 processed: src,
                 original: originalSrc,
-                shader: this.shader
+                shader: this.shader,
+                error: err,
+                stack: err.stack
             });
         }
     }


### PR DESCRIPTION
This gives us slightly more info on the error (even though still not the actual parsing error).

Now:
![Screenshot 2024-06-10 at 11 17 49](https://github.com/playcanvas/engine/assets/59932779/73c46028-518e-41d5-8cca-b0aa4dae2f0a)
