### PR TITLE
Allocate smaller WebGPU dynamic buffers

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -310,8 +310,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
         this.gpuProfiler = new WebgpuGpuProfiler(this);
 
-        // init dynamic buffer using 1MB allocation
-        this.dynamicBuffers = new WebgpuDynamicBuffers(this, 1024 * 1024, this.limits.minUniformBufferOffsetAlignment);
+        // init dynamic buffer using 100kB allocation
+        this.dynamicBuffers = new WebgpuDynamicBuffers(this, 100 * 1024, this.limits.minUniformBufferOffsetAlignment);
 
         // empty bind group
         this.emptyBindGroup = new BindGroup(this, new BindGroupFormat(this, []));


### PR DESCRIPTION
- allocate more smaller dynamic buffers instead of smaller number of large buffers (100kB instead of 1MB)
- now that the dynamic buffers offset use has been reworked to avoid BindGroup reallocation when different buffer is used, this has no negative impact on performance, but allows us to save memory.
- specifically in the Hierarchy engine example, before this change, just over 10MB of dynamic buffers were allocated over time, now around 6MB buffers are allocated.

This might help with https://github.com/playcanvas/engine/issues/6676, even though the spec does not specify any special limits for Staging buffers.