### PR TITLE
Small refactor in a way bloom render pass is managed

### DIFF
--- a/examples/src/examples/graphics/ambient-occlusion.example.mjs
+++ b/examples/src/examples/graphics/ambient-occlusion.example.mjs
@@ -171,6 +171,7 @@ assetListLoader.load(() => {
         camera: cameraEntity.camera, // camera used to render those passes
         samples: 1, // number of samples for multi-sampling
         sceneColorMap: false,
+        bloomEnabled: false,
 
         // enable the pre-pass to generate the depth buffer, which is needed by the SSAO
         prepassEnabled: true,
@@ -191,7 +192,6 @@ assetListLoader.load(() => {
         // Use a render pass camera frame, which is a render pass that implements typical rendering of a camera.
         // Internally this sets up additional passes it needs, based on the options passed to it.
         const renderPassCamera = new pc.RenderPassCameraFrame(app, currentOptions);
-        renderPassCamera.bloomEnabled = false;
 
         renderPassCamera.ssaoEnabled = currentOptions.ssaoEnabled;
 

--- a/examples/src/examples/graphics/post-processing.example.mjs
+++ b/examples/src/examples/graphics/post-processing.example.mjs
@@ -219,6 +219,7 @@ assetListLoader.load(() => {
         camera: cameraEntity.camera, // camera used to render those passes
         samples: 0, // number of samples for multi-sampling
         sceneColorMap: true, // true if the scene color should be captured
+        bloomEnabled: true,
 
         // disabled TAA as it currently does not handle dynamic objects
         prepassEnabled: false,
@@ -245,8 +246,11 @@ assetListLoader.load(() => {
         // if settings require render passes to be re-created
         const noPasses = cameraEntity.camera.renderPasses.length === 0;
         const taaEnabled = data.get('data.taa.enabled');
-        if (noPasses || taaEnabled !== currentOptions.taaEnabled) {
+        const bloomEnabled = data.get('data.bloom.enabled');
+
+        if (noPasses || taaEnabled !== currentOptions.taaEnabled || bloomEnabled !== currentOptions.bloomEnabled) {
             currentOptions.taaEnabled = taaEnabled;
+            currentOptions.bloomEnabled = bloomEnabled;
             currentOptions.prepassEnabled = taaEnabled;
 
             // create new pass
@@ -280,9 +284,11 @@ assetListLoader.load(() => {
         cameraEntity.camera.jitter = taaEnabled ? data.get('data.taa.jitter') : 0;
 
         // bloom
-        composePass.bloomIntensity = pc.math.lerp(0, 0.1, data.get('data.bloom.intensity') / 100);
-        renderPassCamera.lastMipLevel = data.get('data.bloom.lastMipLevel');
-        renderPassCamera.bloomEnabled = data.get('data.bloom.enabled');
+        // renderPassCamera.bloomEnabled = data.get('data.bloom.enabled');
+        if (bloomEnabled) {
+            renderPassCamera.lastMipLevel = data.get('data.bloom.lastMipLevel');
+            composePass.bloomIntensity = pc.math.lerp(0, 0.1, data.get('data.bloom.intensity') / 100);
+        }
 
         // grading
         composePass.gradingSaturation = data.get('data.grading.saturation');
@@ -317,7 +323,7 @@ assetListLoader.load(() => {
             tonemapping: pc.TONEMAP_ACES
         },
         bloom: {
-            enabled: true,
+            enabled: currentOptions.bloomEnabled,
             intensity: 20,
             lastMipLevel: 1
         },

--- a/examples/src/examples/graphics/taa.example.mjs
+++ b/examples/src/examples/graphics/taa.example.mjs
@@ -122,6 +122,7 @@ assetListLoader.load(() => {
         samples: 0, // number of samples for multi-sampling
         // sceneColorMap: true, // true if the scene color should be captured
         sceneColorMap: false,
+        bloomEnabled: true,
 
         // enable the pre-pass to generate the depth buffer, which is needed by the TAA
         prepassEnabled: true,
@@ -154,8 +155,11 @@ assetListLoader.load(() => {
         // if settings require render passes to be re-created
         const noPasses = cameraEntity.camera.renderPasses.length === 0;
         const taaEnabled = data.get('data.taa.enabled');
-        if (noPasses || taaEnabled !== currentOptions.taaEnabled) {
+        const bloomEnabled = data.get('data.scene.bloom');
+
+        if (noPasses || taaEnabled !== currentOptions.taaEnabled || bloomEnabled !== currentOptions.bloomEnabled) {
             currentOptions.taaEnabled = taaEnabled;
+            currentOptions.bloomEnabled = bloomEnabled;
 
             // TAA has been flipped, setup sharpening appropriately
             data.set('data.scene.sharpness', taaEnabled ? 1 : 0);
@@ -167,7 +171,6 @@ assetListLoader.load(() => {
         // apply all runtime settings
         const renderPassCamera = cameraEntity.camera.renderPasses[0];
         renderPassCamera.renderTargetScale = data.get('data.scene.scale');
-        renderPassCamera.bloomEnabled = data.get('data.scene.bloom');
 
         const composePass = renderPassCamera.composePass;
         composePass.sharpness = data.get('data.scene.sharpness');

--- a/src/extras/render-passes/render-pass-camera-frame.js
+++ b/src/extras/render-passes/render-pass-camera-frame.js
@@ -117,14 +117,6 @@ class RenderPassCameraFrame extends RenderPass {
         return this._renderTargetScale;
     }
 
-    set bloomEnabled(value) {
-        if (this._bloomEnabled !== value) {
-            this._bloomEnabled = value;
-            this.composePass.bloomTexture = value ? this.bloomPass.bloomTexture : null;
-            this.bloomPass.enabled = value;
-        }
-    }
-
     get bloomEnabled() {
         return this._bloomEnabled;
     }
@@ -221,7 +213,7 @@ class RenderPassCameraFrame extends RenderPass {
         const sceneTextureWithTaa = this.setupTaaPass(options);
 
         // bloom
-        this.setupBloomPass(sceneTextureWithTaa);
+        this.setupBloomPass(options, sceneTextureWithTaa);
 
         // compose
         this.setupComposePass(options);
@@ -300,8 +292,8 @@ class RenderPassCameraFrame extends RenderPass {
         }
     }
 
-    setupBloomPass(inputTexture) {
-        if (this.bloomEnabled) {
+    setupBloomPass(options, inputTexture) {
+        if (options.bloomEnabled) {
             // create a bloom pass, which generates bloom texture based on the provided texture
             this.bloomPass = new RenderPassBloom(this.device, inputTexture, this.hdrFormat);
         }


### PR DESCRIPTION
- instead of just not using the bloom texture during the composition, rebuild render passes to avoid blooming completely