### PR TITLE
[Postprocessing example] Scale down TAA jitter based on renderPassCamera.renderTargetScale

### DIFF
--- a/examples/src/examples/graphics/post-processing.controls.mjs
+++ b/examples/src/examples/graphics/post-processing.controls.mjs
@@ -17,7 +17,7 @@ export function controls({ observer, ReactPCUI, React, jsx, fragment }) {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'data.scene.scale' },
                     min: 0.2,
-                    max: 1,
+                    max: 2,
                     precision: 1
                 })
             ),

--- a/examples/src/examples/graphics/post-processing.example.mjs
+++ b/examples/src/examples/graphics/post-processing.example.mjs
@@ -277,7 +277,8 @@ assetListLoader.load(() => {
         });
 
         // taa - enable camera jitter if taa is enabled
-        cameraEntity.camera.jitter = taaEnabled ? data.get('data.taa.jitter') : 0;
+        const jitterResolutionScale = Math.min(Math.pow(renderPassCamera.renderTargetScale, 2.0), 1);
+        cameraEntity.camera.jitter = taaEnabled ? data.get('data.taa.jitter') * jitterResolutionScale : 0;
 
         // bloom
         composePass.bloomIntensity = pc.math.lerp(0, 0.1, data.get('data.bloom.intensity') / 100);


### PR DESCRIPTION
At a lower resolution scale, the jitter becomes very obvious. I noticed that when we scale it down by the resolution scale, and it looks a lot better. At first I tried a linear scale (`jitter * resolution`), but using a squared resolutionScale looks even better imo. I'm not sure why, though!

My question for @mvaligursky is: should `RenderPassCameraFrame` scale down the jitter for you based on the render scale? Or is this something we'd leave up to application developers?

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
