### PR TITLE
[BREAKING] BoundingBox and OrientedBox copy parameters in the constructor

### DIFF
--- a/src/core/shape/bounding-box.js
+++ b/src/core/shape/bounding-box.js
@@ -1,4 +1,3 @@
-import { Debug } from '../debug.js';
 import { Vec3 } from '../math/vec3.js';
 
 const tmpVecA = new Vec3();
@@ -18,14 +17,14 @@ class BoundingBox {
      *
      * @type {Vec3}
      */
-    center;
+    center = new Vec3();
 
     /**
      * Half the distance across the box in each axis.
      *
      * @type {Vec3}
      */
-    halfExtents;
+    halfExtents = new Vec3(0.5, 0.5, 0.5);
 
     /**
      * @type {Vec3}
@@ -43,15 +42,17 @@ class BoundingBox {
      * Create a new BoundingBox instance. The bounding box is axis-aligned.
      *
      * @param {Vec3} [center] - Center of box. The constructor takes a reference of this parameter.
+     * Defaults to (0, 0, 0).
      * @param {Vec3} [halfExtents] - Half the distance across the box in each axis. The constructor
-     * takes a reference of this parameter. Defaults to 0.5 on each axis.
+     * takes a reference of this parameter. Defaults to (0.5, 0.5, 0.5).
      */
-    constructor(center = new Vec3(), halfExtents = new Vec3(0.5, 0.5, 0.5)) {
-        Debug.assert(!Object.isFrozen(center), 'The constructor of \'BoundingBox\' does not accept a constant (frozen) object as a \'center\' parameter');
-        Debug.assert(!Object.isFrozen(halfExtents), 'The constructor of \'BoundingBox\' does not accept a constant (frozen) object as a \'halfExtents\' parameter');
-
-        this.center = center;
-        this.halfExtents = halfExtents;
+    constructor(center, halfExtents) {
+        if (center) {
+            this.center.copy(center);
+        }
+        if (halfExtents) {
+            this.halfExtents.copy(halfExtents);
+        }
     }
 
     /**
@@ -121,7 +122,7 @@ class BoundingBox {
      * @returns {BoundingBox} A duplicate AABB.
      */
     clone() {
-        return new BoundingBox(this.center.clone(), this.halfExtents.clone());
+        return new BoundingBox(this.center, this.halfExtents);
     }
 
     /**

--- a/src/core/shape/bounding-box.js
+++ b/src/core/shape/bounding-box.js
@@ -16,6 +16,7 @@ class BoundingBox {
      * Center of box.
      *
      * @type {Vec3}
+     * @readonly
      */
     center = new Vec3();
 
@@ -23,6 +24,7 @@ class BoundingBox {
      * Half the distance across the box in each axis.
      *
      * @type {Vec3}
+     * @readonly
      */
     halfExtents = new Vec3(0.5, 0.5, 0.5);
 

--- a/src/core/shape/bounding-sphere.js
+++ b/src/core/shape/bounding-sphere.js
@@ -14,6 +14,7 @@ class BoundingSphere {
      * Center of sphere.
      *
      * @type {Vec3}
+     * @readonly
      */
     center;
 

--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -34,23 +34,26 @@ class Frustum {
      * frustum.setFromMat4(projMat);
      */
     setFromMat4(matrix) {
-        const vpm = matrix.data;
 
-        let plane;
+        const normalize = (plane) => {
+            const t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
+            const invT = 1 / t;
+            plane[0] *= invT;
+            plane[1] *= invT;
+            plane[2] *= invT;
+            plane[3] *= invT;
+        };
+
+        const vpm = matrix.data;
         const planes = this.planes;
 
         // Extract the numbers for the RIGHT plane
-        plane = planes[0];
+        let plane = planes[0];
         plane[0] = vpm[3] - vpm[0];
         plane[1] = vpm[7] - vpm[4];
         plane[2] = vpm[11] - vpm[8];
         plane[3] = vpm[15] - vpm[12];
-        // Normalize the result
-        let t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
-        plane[0] /= t;
-        plane[1] /= t;
-        plane[2] /= t;
-        plane[3] /= t;
+        normalize(plane);
 
         // Extract the numbers for the LEFT plane
         plane = planes[1];
@@ -58,12 +61,7 @@ class Frustum {
         plane[1] = vpm[7] + vpm[4];
         plane[2] = vpm[11] + vpm[8];
         plane[3] = vpm[15] + vpm[12];
-        // Normalize the result
-        t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
-        plane[0] /= t;
-        plane[1] /= t;
-        plane[2] /= t;
-        plane[3] /= t;
+        normalize(plane);
 
         // Extract the BOTTOM plane
         plane = planes[2];
@@ -71,12 +69,7 @@ class Frustum {
         plane[1] = vpm[7] + vpm[5];
         plane[2] = vpm[11] + vpm[9];
         plane[3] = vpm[15] + vpm[13];
-        // Normalize the result
-        t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
-        plane[0] /= t;
-        plane[1] /= t;
-        plane[2] /= t;
-        plane[3] /= t;
+        normalize(plane);
 
         // Extract the TOP plane
         plane = planes[3];
@@ -84,12 +77,7 @@ class Frustum {
         plane[1] = vpm[7] - vpm[5];
         plane[2] = vpm[11] - vpm[9];
         plane[3] = vpm[15] - vpm[13];
-        // Normalize the result
-        t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
-        plane[0] /= t;
-        plane[1] /= t;
-        plane[2] /= t;
-        plane[3] /= t;
+        normalize(plane);
 
         // Extract the FAR plane
         plane = planes[4];
@@ -97,12 +85,7 @@ class Frustum {
         plane[1] = vpm[7] - vpm[6];
         plane[2] = vpm[11] - vpm[10];
         plane[3] = vpm[15] - vpm[14];
-        // Normalize the result
-        t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
-        plane[0] /= t;
-        plane[1] /= t;
-        plane[2] /= t;
-        plane[3] /= t;
+        normalize(plane);
 
         // Extract the NEAR plane
         plane = planes[5];
@@ -110,12 +93,7 @@ class Frustum {
         plane[1] = vpm[7] + vpm[6];
         plane[2] = vpm[11] + vpm[10];
         plane[3] = vpm[15] + vpm[14];
-        // Normalize the result
-        t = Math.sqrt(plane[0] * plane[0] + plane[1] * plane[1] + plane[2] * plane[2]);
-        plane[0] /= t;
-        plane[1] /= t;
-        plane[2] /= t;
-        plane[3] /= t;
+        normalize(plane);
     }
 
     /**
@@ -126,9 +104,8 @@ class Frustum {
      * @returns {boolean} True if the point is inside the frustum, false otherwise.
      */
     containsPoint(point) {
-        let p, plane;
-        for (p = 0; p < 6; p++) {
-            plane = this.planes[p];
+        for (let p = 0; p < 6; p++) {
+            const plane = this.planes[p];
             if (plane[0] * point.x + plane[1] * point.y + plane[2] * point.z + plane[3] <= 0) {
                 return false;
             }
@@ -147,9 +124,6 @@ class Frustum {
      * frustum and 2 if it is contained by the frustum.
      */
     containsSphere(sphere) {
-        let c = 0;
-        let d;
-        let p;
 
         const sr = sphere.radius;
         const sc = sphere.center;
@@ -157,11 +131,11 @@ class Frustum {
         const scy = sc.y;
         const scz = sc.z;
         const planes = this.planes;
-        let plane;
 
-        for (p = 0; p < 6; p++) {
-            plane = planes[p];
-            d = plane[0] * scx + plane[1] * scy + plane[2] * scz + plane[3];
+        let c = 0;
+        for (let p = 0; p < 6; p++) {
+            const plane = planes[p];
+            const d = plane[0] * scx + plane[1] * scy + plane[2] * scz + plane[3];
             if (d <= -sr)
                 return 0;
             if (d > sr)

--- a/src/core/shape/oriented-box.js
+++ b/src/core/shape/oriented-box.js
@@ -1,4 +1,3 @@
-import { Debug } from '../debug.js';
 import { Mat4 } from '../math/mat4.js';
 import { Vec3 } from '../math/vec3.js';
 
@@ -17,7 +16,11 @@ const tmpMat4 = new Mat4();
  * @category Math
  */
 class OrientedBox {
-    halfExtents;
+    /**
+     * @type {Vec3}
+     * @private
+     */
+    halfExtents = new Vec3(0.5, 0.5, 0.5);
 
     /**
      * @type {Mat4}
@@ -41,15 +44,15 @@ class OrientedBox {
      * Create a new OrientedBox instance.
      *
      * @param {Mat4} [worldTransform] - Transform that has the orientation and position of the box.
-     * Scale is assumed to be one.
-     * @param {Vec3} [halfExtents] - Half the distance across the box in each local axis. The
-     * constructor takes a reference of this parameter.
+     * Scale is assumed to be one. Defaults to identity matrix.
+     * @param {Vec3} [halfExtents] - Half the distance across the box in each local axis. Defaults
+     * to (0.5, 0.5, 0.5).
      */
-    constructor(worldTransform = new Mat4(), halfExtents = new Vec3(0.5, 0.5, 0.5)) {
-        Debug.assert(!Object.isFrozen(worldTransform), 'The constructor of \'OrientedBox\' does not accept a constant (frozen) object as a \'worldTransform\' parameter');
-        Debug.assert(!Object.isFrozen(halfExtents), 'The constructor of \'OrientedBox\' does not accept a constant (frozen) object as a \'halfExtents\' parameter');
+    constructor(worldTransform = new Mat4(), halfExtents) {
 
-        this.halfExtents = halfExtents;
+        if (halfExtents) {
+            this.halfExtents.copy(halfExtents);
+        }
 
         this._modelTransform = worldTransform.clone().invert();
         this._worldTransform = worldTransform.clone();

--- a/src/core/shape/plane.js
+++ b/src/core/shape/plane.js
@@ -11,6 +11,7 @@ class Plane {
      * The normal of the plane.
      *
      * @type {Vec3}
+     * @readonly
      */
     normal = new Vec3();
 

--- a/src/core/shape/tri.js
+++ b/src/core/shape/tri.js
@@ -18,6 +18,7 @@ class Tri {
     /**
      * The first 3-dimensional vector of the triangle.
      *
+     * @readonly
      * @type {Vec3}
      */
     v0 = new Vec3();
@@ -26,6 +27,7 @@ class Tri {
      * The second 3-dimensional vector of the triangle.
      *
      * @type {Vec3}
+     * @readonly
      */
     v1 = new Vec3();
 
@@ -33,6 +35,7 @@ class Tri {
      * The third 3-dimensional vector of the triangle.
      *
      * @type {Vec3}
+     * @readonly
      */
     v2 = new Vec3();
 


### PR DESCRIPTION
related to https://github.com/playcanvas/engine/pull/2088

BoundingBox and OrientedBox no longer reference arguments passed into their constructors, but clone those, to avoid hard to find issues.

Search of the engine and editor code base reveals no internal issues with this, the problematic cases were refactored out  already.

Marked as `BREAKING` as this might affect user code if not used correctly.