### PR TITLE
Texture array and cubemaps single slice updates

### DIFF
--- a/examples/src/examples/graphics/texture-array.example.mjs
+++ b/examples/src/examples/graphics/texture-array.example.mjs
@@ -120,11 +120,11 @@ assetListLoader.load(() => {
                 assets.aerialRocks.resource.getSource(),
                 assets.coastSand.resource.getSource()
             ]
-        ]
+        ],
+        immediate: true
     };
 
     const textureArray = new pc.Texture(app.graphicsDevice, textureArrayOptions);
-    textureArray.upload();
 
     // generate mipmaps for visualization
     const mipmaps = generateMipmaps(textureArrayOptions.width, textureArrayOptions.height);

--- a/examples/src/examples/graphics/texture-array.example.mjs
+++ b/examples/src/examples/graphics/texture-array.example.mjs
@@ -105,9 +105,10 @@ assetListLoader.load(() => {
     const textureArrayOptions = {
         name: 'textureArrayImages',
         format: pc.PIXELFORMAT_SRGBA8,
+        dimension: pc.TEXTUREDIMENSION_2D_ARRAY,
         width: 1024,
         height: 1024,
-        arrayLength: 4, // array texture with 4 textures
+        slices: 4, // array texture with 4 textures
         magFilter: pc.FILTER_NEAREST,
         minFilter: pc.FILTER_NEAREST_MIPMAP_NEAREST,
         mipmaps: true,
@@ -130,7 +131,7 @@ assetListLoader.load(() => {
     const mipmaps = generateMipmaps(textureArrayOptions.width, textureArrayOptions.height);
     const levels = mipmaps.map((data) => {
         const textures = [];
-        for (let i = 0; i < textureArrayOptions.arrayLength; i++) {
+        for (let i = 0; i < textureArrayOptions.slices; i++) {
             textures.push(data);
         }
         return textures;

--- a/examples/src/examples/graphics/texture-array.example.mjs
+++ b/examples/src/examples/graphics/texture-array.example.mjs
@@ -108,7 +108,7 @@ assetListLoader.load(() => {
         dimension: pc.TEXTUREDIMENSION_2D_ARRAY,
         width: 1024,
         height: 1024,
-        slices: 4, // array texture with 4 textures
+        layers: 4, // array texture with 4 textures
         magFilter: pc.FILTER_NEAREST,
         minFilter: pc.FILTER_NEAREST_MIPMAP_NEAREST,
         mipmaps: true,
@@ -131,7 +131,7 @@ assetListLoader.load(() => {
     const mipmaps = generateMipmaps(textureArrayOptions.width, textureArrayOptions.height);
     const levels = mipmaps.map((data) => {
         const textures = [];
-        for (let i = 0; i < textureArrayOptions.slices; i++) {
+        for (let i = 0; i < textureArrayOptions.layers; i++) {
             textures.push(data);
         }
         return textures;

--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -61,11 +61,11 @@ const _completePartialMipmapChain = function (texture) {
 
     if (!(texture._format === PIXELFORMAT_RGBA8 ||
           texture._format === PIXELFORMAT_RGBA32F) ||
-          texture._volume ||
+          texture.volume ||
           texture._compressed ||
           texture._levels.length === 1 ||
           texture._levels.length === requiredMipLevels ||
-          isHtmlElement(texture._cubemap ? texture._levels[0][0] : texture._levels[0])) {
+          isHtmlElement(texture.cubemap ? texture._levels[0][0] : texture._levels[0])) {
         return;
     }
 
@@ -99,7 +99,7 @@ const _completePartialMipmapChain = function (texture) {
     for (let level = texture._levels.length; level < requiredMipLevels; ++level) {
         const width = Math.max(1, texture._width >> (level - 1));
         const height = Math.max(1, texture._height >> (level - 1));
-        if (texture._cubemap) {
+        if (texture.cubemap) {
             const mips = [];
             for (let face = 0; face < 6; ++face) {
                 mips.push(downsample(width, height, texture._levels[level - 1][face]));
@@ -110,7 +110,7 @@ const _completePartialMipmapChain = function (texture) {
         }
     }
 
-    texture._levelsUpdated = texture._cubemap ? [[true, true, true, true, true, true]] : [true];
+    texture._levelsUpdated = texture.cubemap ? [[true, true, true, true, true, true]] : [true];
 };
 
 /**

--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -99,10 +99,10 @@ const _completePartialMipmapChain = function (texture) {
     for (let level = texture._levels.length; level < requiredMipLevels; ++level) {
         const width = Math.max(1, texture._width >> (level - 1));
         const height = Math.max(1, texture._height >> (level - 1));
-        if (texture.cubemap) {
+        if (texture.cubemap || texture.array) {
             const mips = [];
-            for (let face = 0; face < 6; ++face) {
-                mips.push(downsample(width, height, texture._levels[level - 1][face]));
+            for (let slice = 0; slice < texture.slices; ++slice) {
+                mips.push(downsample(width, height, texture._levels[level - 1][slice]));
             }
             texture._levels.push(mips);
         } else {
@@ -110,7 +110,7 @@ const _completePartialMipmapChain = function (texture) {
         }
     }
 
-    texture._levelsUpdated = texture.cubemap ? [[true, true, true, true, true, true]] : [true];
+    texture._levelsUpdated = (texture.cubemap || texture.array) ? [Array(texture.slices).fill(true)] : [true];
 };
 
 /**

--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -101,8 +101,8 @@ const _completePartialMipmapChain = function (texture) {
         const height = Math.max(1, texture._height >> (level - 1));
         if (texture.cubemap || texture.array) {
             const mips = [];
-            for (let slice = 0; slice < texture.slices; ++slice) {
-                mips.push(downsample(width, height, texture._levels[level - 1][slice]));
+            for (let layer = 0; layer < texture.layers; ++layer) {
+                mips.push(downsample(width, height, texture._levels[level - 1][layer]));
             }
             texture._levels.push(mips);
         } else {
@@ -110,7 +110,7 @@ const _completePartialMipmapChain = function (texture) {
         }
     }
 
-    texture._levelsUpdated = (texture.cubemap || texture.array) ? [Array(texture.slices).fill(true)] : [true];
+    texture._levelsUpdated = (texture.cubemap || texture.array) ? [Array(texture.layers).fill(true)] : [true];
 };
 
 /**

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -1107,6 +1107,8 @@ class Lightmapper {
 
                         } else {    // use the old path for WebGL till the render pass way above is fixed
 
+                            device._uploadDirtyTextures();
+
                             // ping-ponging output
                             this.renderer.setCamera(this.camera, tempRT, true);
 

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -172,7 +172,8 @@ class XrView extends EventHandler {
 
             this._textureDepth = new Texture(device, {
                 format: this._manager.views.depthPixelFormat,
-                arrayLength: (viewsCount === 1) ? 0 : viewsCount,
+                array: viewsCount > 1,
+                slices: viewsCount,
                 mipmaps: false,
                 addressU: ADDRESS_CLAMP_TO_EDGE,
                 addressV: ADDRESS_CLAMP_TO_EDGE,

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -173,7 +173,7 @@ class XrView extends EventHandler {
             this._textureDepth = new Texture(device, {
                 format: this._manager.views.depthPixelFormat,
                 array: viewsCount > 1,
-                slices: viewsCount,
+                layers: viewsCount,
                 mipmaps: false,
                 addressU: ADDRESS_CLAMP_TO_EDGE,
                 addressV: ADDRESS_CLAMP_TO_EDGE,

--- a/src/platform/graphics/null/null-texture.js
+++ b/src/platform/graphics/null/null-texture.js
@@ -10,6 +10,9 @@ class NullTexture {
 
     loseContext() {
     }
+
+    uploadImmediate(device, texture, immediate) {
+    }
 }
 
 export { NullTexture };

--- a/src/platform/graphics/texture-utils.js
+++ b/src/platform/graphics/texture-utils.js
@@ -26,7 +26,7 @@ class TextureUtils {
      *
      * @param {number} width - Texture's width.
      * @param {number} height - Texture's height.
-     * @param {number} [depth] - Texture's depth slices. Defaults to 1.
+     * @param {number} [depth] - Texture's depth layers. Defaults to 1.
      * @returns {number} The number of mip levels required for the texture.
      */
     static calcMipLevelsCount(width, height, depth = 1) {
@@ -38,7 +38,7 @@ class TextureUtils {
      *
      * @param {number} width - Texture's width.
      * @param {number} height - Texture's height.
-     * @param {number} depth - Texture's depth slices.
+     * @param {number} depth - Texture's depth layers.
      * @param {number} format - Texture's pixel format PIXELFORMAT_***.
      * @returns {number} The number of bytes of GPU memory required for the texture.
      */
@@ -70,15 +70,15 @@ class TextureUtils {
      *
      * @param {number} width - Texture's width.
      * @param {number} height - Texture's height.
-     * @param {number} slices - Texture's slices.
+     * @param {number} layers - Texture's layers.
      * @param {number} format - Texture's pixel format PIXELFORMAT_***.
      * @param {boolean} isVolume - True if the texture is a volume texture, false otherwise.
      * @param {boolean} mipmaps - True if the texture includes mipmaps, false otherwise.
      * @returns {number} The number of bytes of GPU memory required for the texture.
      */
-    static calcGpuSize(width, height, slices, format, isVolume, mipmaps) {
+    static calcGpuSize(width, height, layers, format, isVolume, mipmaps) {
         let result = 0;
-        let depth = isVolume ? slices : 1;
+        let depth = isVolume ? layers : 1;
 
         while (1) {
             result += TextureUtils.calcLevelGpuSize(width, height, depth, format);
@@ -92,7 +92,7 @@ class TextureUtils {
             depth = Math.max(depth >> 1, 1);
         }
 
-        return result * (isVolume ? 1 : slices);
+        return result * (isVolume ? 1 : layers);
     }
 }
 

--- a/src/platform/graphics/texture-utils.js
+++ b/src/platform/graphics/texture-utils.js
@@ -1,7 +1,8 @@
 import { Debug } from '../../core/debug.js';
 import {
     pixelFormatInfo,
-    PIXELFORMAT_PVRTC_2BPP_RGB_1, PIXELFORMAT_PVRTC_2BPP_RGBA_1
+    PIXELFORMAT_PVRTC_2BPP_RGB_1, PIXELFORMAT_PVRTC_2BPP_RGBA_1,
+    TEXTUREDIMENSION_3D
 } from './constants.js';
 
 /**
@@ -26,7 +27,7 @@ class TextureUtils {
      *
      * @param {number} width - Texture's width.
      * @param {number} height - Texture's height.
-     * @param {number} [depth] - Texture's depth. Defaults to 1.
+     * @param {number} [depth] - Texture's depth slices. Defaults to 1.
      * @returns {number} The number of mip levels required for the texture.
      */
     static calcMipLevelsCount(width, height, depth = 1) {
@@ -38,7 +39,7 @@ class TextureUtils {
      *
      * @param {number} width - Texture's width.
      * @param {number} height - Texture's height.
-     * @param {number} depth - Texture's depth.
+     * @param {number} depth - Texture's depth slices.
      * @param {number} format - Texture's pixel format PIXELFORMAT_***.
      * @returns {number} The number of bytes of GPU memory required for the texture.
      */
@@ -68,16 +69,17 @@ class TextureUtils {
     /**
      * Calculate the GPU memory required for a texture.
      *
+     * @param {string} dimension - Texture's dimension
      * @param {number} width - Texture's width.
      * @param {number} height - Texture's height.
-     * @param {number} depth - Texture's depth.
+     * @param {number} slices - Texture's slices.
      * @param {number} format - Texture's pixel format PIXELFORMAT_***.
      * @param {boolean} mipmaps - True if the texture includes mipmaps, false otherwise.
-     * @param {boolean} cubemap - True is the texture is a cubemap, false otherwise.
      * @returns {number} The number of bytes of GPU memory required for the texture.
      */
-    static calcGpuSize(width, height, depth, format, mipmaps, cubemap) {
+    static calcGpuSize(width, height, slices, format, isVolume, mipmaps) {
         let result = 0;
+        let depth = isVolume ? slices : 1;
 
         while (1) {
             result += TextureUtils.calcLevelGpuSize(width, height, depth, format);
@@ -91,7 +93,7 @@ class TextureUtils {
             depth = Math.max(depth >> 1, 1);
         }
 
-        return result * (cubemap ? 6 : 1);
+        return result * (isVolume ? 1 : slices);
     }
 }
 

--- a/src/platform/graphics/texture-utils.js
+++ b/src/platform/graphics/texture-utils.js
@@ -1,8 +1,7 @@
 import { Debug } from '../../core/debug.js';
 import {
     pixelFormatInfo,
-    PIXELFORMAT_PVRTC_2BPP_RGB_1, PIXELFORMAT_PVRTC_2BPP_RGBA_1,
-    TEXTUREDIMENSION_3D
+    PIXELFORMAT_PVRTC_2BPP_RGB_1, PIXELFORMAT_PVRTC_2BPP_RGBA_1
 } from './constants.js';
 
 /**
@@ -69,11 +68,11 @@ class TextureUtils {
     /**
      * Calculate the GPU memory required for a texture.
      *
-     * @param {string} dimension - Texture's dimension
      * @param {number} width - Texture's width.
      * @param {number} height - Texture's height.
      * @param {number} slices - Texture's slices.
      * @param {number} format - Texture's pixel format PIXELFORMAT_***.
+     * @param {boolean} isVolume - True if the texture is a volume texture, false otherwise.
      * @param {boolean} mipmaps - True if the texture includes mipmaps, false otherwise.
      * @returns {number} The number of bytes of GPU memory required for the texture.
      */

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -201,6 +201,7 @@ class Texture {
      * of Uint8Array if options.arrayLength is defined and greater than zero.
      * @param {boolean} [options.storage] - Defines if texture can be used as a storage texture by
      * a compute shader. Defaults to false.
+     * @param {boolean} [options.immediate] - If set and true, the texture will be uploaded to the GPU immediately.
      * @example
      * // Create a 8x8x24-bit texture
      * const texture = new pc.Texture(graphicsDevice, {
@@ -288,7 +289,7 @@ class Texture {
 
         this._levels = options.levels;
         if (this._levels) {
-            this.upload();
+            this.upload(options.immediate ?? false);
         } else {
             this._levels = this._cubemap ? [[null, null, null, null, null, null]] : [null];
         }
@@ -908,8 +909,9 @@ class Texture {
      * @param {number} [mipLevel] - A non-negative integer specifying the image level of detail.
      * Defaults to 0, which represents the base image source. A level value of N, that is greater
      * than 0, represents the image source for the Nth mipmap reduction level.
+     * @param {boolean} [immediate] - When set to true it forces an immediate upload upon assignment. Defaults to false.
      */
-    setSource(source, mipLevel = 0) {
+    setSource(source, mipLevel = 0, immediate = false) {
         let invalid = false;
         let width, height;
 
@@ -997,7 +999,7 @@ class Texture {
             this._invalid = invalid;
 
             // reupload
-            this.upload();
+            this.upload(immediate);
         }
     }
 
@@ -1017,15 +1019,16 @@ class Texture {
 
     /**
      * Unlocks the currently locked mip level and uploads it to VRAM.
+     * @param {boolean} [immediate] - When set to true it forces an immediate upload upon unlocking. Defaults to false.
      */
-    unlock() {
+    unlock(immediate = false) {
         if (this._lockedMode === TEXTURELOCK_NONE) {
             Debug.warn('pc.Texture#unlock: Attempting to unlock a texture that is not locked.', this);
         }
 
         // Upload the new pixel data if locked in write mode (default)
         if (this._lockedMode === TEXTURELOCK_WRITE) {
-            this.upload();
+            this.upload(immediate);
         }
         this._lockedLevel = -1;
         this._lockedMode = TEXTURELOCK_NONE;
@@ -1033,15 +1036,16 @@ class Texture {
 
     /**
      * Forces a reupload of the textures pixel data to graphics memory. Ordinarily, this function
-     * is called by internally by {@link Texture#setSource} and {@link Texture#unlock}. However, it
+     * is called internally by {@link Texture#setSource} and {@link Texture#unlock}. However, it
      * still needs to be called explicitly in the case where an HTMLVideoElement is set as the
      * source of the texture.  Normally, this is done once every frame before video textured
      * geometry is rendered.
+     * @param {boolean} [immediate] - When set to true it forces an immediate upload. Defaults to false.
      */
-    upload() {
+    upload(immediate = false) {
         this._needsUpload = true;
         this._needsMipmapsUpload = this._mipmaps;
-        this.impl.uploadImmediate?.(this.device, this);
+        this.impl.uploadImmediate(this.device, this, immediate);
     }
 
     /**

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -229,10 +229,10 @@ class Texture {
      */
     constructor(graphicsDevice, options = {}) {
         this.device = graphicsDevice;
-        Debug.assert(this.device, "Texture constructor requires a graphicsDevice to be valid");
-        Debug.assert(!options.width || Number.isInteger(options.width), "Texture width must be an integer number, got", options);
-        Debug.assert(!options.height || Number.isInteger(options.height), "Texture height must be an integer number, got", options);
-        Debug.assert(!options.layers || Number.isInteger(options.layers), "Texture layers must be an integer number, got", options);
+        Debug.assert(this.device, 'Texture constructor requires a graphicsDevice to be valid');
+        Debug.assert(!options.width || Number.isInteger(options.width), 'Texture width must be an integer number, got', options);
+        Debug.assert(!options.height || Number.isInteger(options.height), 'Texture height must be an integer number, got', options);
+        Debug.assert(!options.layers || Number.isInteger(options.layers), 'Texture layers must be an integer number, got', options);
 
         this.name = options.name ?? '';
 
@@ -246,7 +246,7 @@ class Texture {
 
         this._layers = Math.floor(options.layers ?? (this._dimension === TEXTUREDIMENSION_CUBE ? 6 : 1));
 
-        Debug.assert((this._dimension === TEXTUREDIMENSION_CUBE ? this._layers === 6 : true), "Texture cube map must have 6 layers");
+        Debug.assert((this._dimension === TEXTUREDIMENSION_CUBE ? this._layers === 6 : true), 'Texture cube map must have 6 layers');
 
         this._format = options.format ?? PIXELFORMAT_RGBA8;
         this._compressed = isCompressedPixelFormat(this._format);
@@ -970,8 +970,9 @@ class Texture {
             if (!invalid) {
                 // mark levels as updated
                 for (let i = 0; i < this._layers; i++) {
-                    if (this._levels[0][i] !== source[i])
+                    if (this._levels[0][i] !== source[i]) {
                         this._levelsUpdated[0][i] = true;
+                    }
                 }
             }
         } else {
@@ -982,8 +983,9 @@ class Texture {
 
             if (!invalid) {
                 // mark level as updated
-                if (source !== this._levels[0])
+                if (source !== this._levels[0]) {
                     this._levelsUpdated[0] = true;
+                }
 
                 if (source instanceof HTMLVideoElement) {
                     width = source.videoWidth;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1145,6 +1145,22 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.gpuProfiler.request();
     }
 
+    _uploadDirtyTextures() {
+
+        this.textures.forEach((texture) => {
+            if (texture._needsUpload || texture._needsMipmapsUpload) {
+                if (!texture.impl._glTexture) {
+                    texture.impl.initialize(this, texture);
+                }
+
+                this.bindTexture(texture);
+                texture.impl.upload(this, texture);
+                texture._needsUpload = false;
+                texture._needsMipmapsUpload = false;
+            }
+        });
+    }
+
     /**
      * Start a render pass.
      *
@@ -1152,6 +1168,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @ignore
      */
     startRenderPass(renderPass) {
+
+        this._uploadDirtyTextures();
 
         // set up render target
         const rt = renderPass.renderTarget ?? this.backBuffer;
@@ -1526,7 +1544,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             impl.initialize(this, texture);
         }
 
-        if (impl.dirtyParameterFlags > 0 || texture._needsUpload || texture._needsMipmapsUpload) {
+        if (impl.dirtyParameterFlags > 0) {
 
             // Ensure the specified texture unit is active
             this.activeTexture(textureUnit);
@@ -1537,12 +1555,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
             if (impl.dirtyParameterFlags) {
                 this.setTextureParameters(texture);
                 impl.dirtyParameterFlags = 0;
-            }
-
-            if (texture._needsUpload || texture._needsMipmapsUpload) {
-                impl.upload(this, texture);
-                texture._needsUpload = false;
-                texture._needsMipmapsUpload = false;
             }
         } else {
             // Ensure the texture is currently bound to the correct target on the specified texture unit.

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -170,7 +170,7 @@ class WebglRenderTarget {
                     gl.framebufferTexture2D(
                         gl.FRAMEBUFFER,
                         attachmentBaseConstant + i,
-                        colorBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
+                        colorBuffer.cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
                         colorBuffer.impl._glTexture,
                         target.mipLevel
                     );
@@ -197,7 +197,7 @@ class WebglRenderTarget {
 
                     // Attach
                     gl.framebufferTexture2D(gl.FRAMEBUFFER, attachmentPoint,
-                        depthBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
+                        depthBuffer.cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
                         target._depthBuffer.impl._glTexture, target.mipLevel);
 
                 } else {
@@ -348,7 +348,7 @@ class WebglRenderTarget {
             const dstFramebuffer = gl.createFramebuffer();
             device.setFramebuffer(dstFramebuffer);
             gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
-                colorBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
+                colorBuffer.cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
                 colorBuffer.impl._glTexture,
                 0
             );

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -165,6 +165,7 @@ class WebglRenderTarget {
                         colorBuffer._width = Math.min(colorBuffer.width, device.maxRenderBufferSize);
                         colorBuffer._height = Math.min(colorBuffer.height, device.maxRenderBufferSize);
                         device.setTexture(colorBuffer, 0);
+                        colorBuffer.upload(true);
                     }
                     // Attach the color buffer
                     gl.framebufferTexture2D(
@@ -193,6 +194,7 @@ class WebglRenderTarget {
                         depthBuffer._width = Math.min(depthBuffer.width, device.maxRenderBufferSize);
                         depthBuffer._height = Math.min(depthBuffer.height, device.maxRenderBufferSize);
                         device.setTexture(depthBuffer, 0);
+                        depthBuffer.upload(true);
                     }
 
                     // Attach

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -649,11 +649,12 @@ class WebglTexture {
                         this._glPixelType,
                         mipObject);
                 }
-            } else if (texture.array && typeof mipObject === "object") {
+            } else if (texture.array && typeof mipObject === 'object') {
                 if (texture._compressed) {
                     for (let index = 0; index < texture._layers; index++) {
-                        if (!texture._levelsUpdated[0][index] || !mipObject[index])
+                        if (!texture._levelsUpdated[0][index] || !mipObject[index]) {
                             continue;
+                        }
                         gl.compressedTexSubImage3D(
                             gl.TEXTURE_2D_ARRAY,
                             mipLevel,
@@ -669,8 +670,9 @@ class WebglTexture {
                     }
                 } else {
                     for (let index = 0; index < texture.layers; index++) {
-                        if (!texture._levelsUpdated[0][index] || !mipObject[index])
+                        if (!texture._levelsUpdated[0][index] || !mipObject[index]) {
                             continue;
+                        }
                         gl.texSubImage3D(
                             gl.TEXTURE_2D_ARRAY,
                             mipLevel,

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -453,6 +453,19 @@ class WebglTexture {
         this._glCreated = false;
     }
 
+    uploadImmediate(device, texture, immediate) {
+        if (immediate) {
+            if (!texture._glTexture) {
+                this.initialize(device, texture);
+            }
+
+            device.bindTexture(texture);
+            this.upload(device, texture);
+            texture._needsUpload = false;
+            texture._needsMipmapsUpload = false;
+        }
+    }
+
     /**
      * @param {WebglGraphicsDevice} device - The device.
      * @param {Texture} texture - The texture to update.

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -567,7 +567,7 @@ class WebglTexture {
                     resMult = 1 / Math.pow(2, mipLevel);
                     for (face = 0; face < texture.slices; face++) {
                         const texData = mipObject[face];
-                        if (!texture._levelsUpdated[0][face] || !texData)
+                        if (!texture._levelsUpdated[0][face])
                             continue;
                         }
 

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -488,11 +488,11 @@ class WebglTexture {
         if (texture.array && !this._glCreated) {
             // for texture arrays we reserve the space in advance
             gl.texStorage3D(gl.TEXTURE_2D_ARRAY,
-                            requiredMipLevels,
-                            this._glInternalFormat,
-                            texture._width,
-                            texture._height,
-                            texture._slices);
+                requiredMipLevels,
+                this._glInternalFormat,
+                texture._width,
+                texture._height,
+                texture._layers);
         }
 
         // Upload all existing mip levels. Initialize 0 mip anyway.
@@ -522,9 +522,9 @@ class WebglTexture {
 
                 if (device._isBrowserInterface(mipObject[0])) {
                     // Upload the image, canvas or video
-                    for (face = 0; face < texture.slices; face++) {
+                    for (face = 0; face < texture.layers; face++) {
                         let src = mipObject[face];
-                        if (!texture._levelsUpdated[0][face] || !src)
+                        if (!texture._levelsUpdated[0][face] || !src) {
                             continue;
                         }
 
@@ -565,9 +565,9 @@ class WebglTexture {
                 } else {
                     // Upload the byte array
                     resMult = 1 / Math.pow(2, mipLevel);
-                    for (face = 0; face < texture.slices; face++) {
+                    for (face = 0; face < texture.layers; face++) {
                         const texData = mipObject[face];
-                        if (!texture._levelsUpdated[0][face])
+                        if (!texture._levelsUpdated[0][face]) {
                             continue;
                         }
 
@@ -628,30 +628,30 @@ class WebglTexture {
                 // Upload the byte array
                 if (texture._compressed) {
                     gl.compressedTexImage3D(gl.TEXTURE_3D,
-                                            mipLevel,
-                                            this._glInternalFormat,
-                                            Math.max(texture._width * resMult, 1),
-                                            Math.max(texture._height * resMult, 1),
-                                            Math.max(texture._slices * resMult, 1),
-                                            0,
-                                            mipObject);
+                        mipLevel,
+                        this._glInternalFormat,
+                        Math.max(texture._width * resMult, 1),
+                        Math.max(texture._height * resMult, 1),
+                        Math.max(texture._layers * resMult, 1),
+                        0,
+                        mipObject);
                 } else {
                     device.setUnpackFlipY(false);
                     device.setUnpackPremultiplyAlpha(texture._premultiplyAlpha);
                     gl.texImage3D(gl.TEXTURE_3D,
-                                  mipLevel,
-                                  this._glInternalFormat,
-                                  Math.max(texture._width * resMult, 1),
-                                  Math.max(texture._height * resMult, 1),
-                                  Math.max(texture._slices * resMult, 1),
-                                  0,
-                                  this._glFormat,
-                                  this._glPixelType,
-                                  mipObject);
+                        mipLevel,
+                        this._glInternalFormat,
+                        Math.max(texture._width * resMult, 1),
+                        Math.max(texture._height * resMult, 1),
+                        Math.max(texture._layers * resMult, 1),
+                        0,
+                        this._glFormat,
+                        this._glPixelType,
+                        mipObject);
                 }
             } else if (texture.array && typeof mipObject === "object") {
                 if (texture._compressed) {
-                    for (let index = 0; index < texture._slices; index++) {
+                    for (let index = 0; index < texture._layers; index++) {
                         if (!texture._levelsUpdated[0][index] || !mipObject[index])
                             continue;
                         gl.compressedTexSubImage3D(
@@ -668,7 +668,7 @@ class WebglTexture {
                         );
                     }
                 } else {
-                    for (let index = 0; index < texture.slices; index++) {
+                    for (let index = 0; index < texture.layers; index++) {
                         if (!texture._levelsUpdated[0][index] || !mipObject[index])
                             continue;
                         gl.texSubImage3D(
@@ -799,7 +799,7 @@ class WebglTexture {
 
         if (texture._needsUpload) {
             if (texture.cubemap || texture.array) {
-                for (let i = 0; i < texture.slices; i++)
+                for (let i = 0; i < texture.layers; i++) {
                     texture._levelsUpdated[0][i] = false;
                 }
             } else {

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -658,7 +658,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     _uploadDirtyTextures() {
 
         this.textures.forEach((texture) => {
-            if (texture._needsUpload || texture._needsMipmaps) {
+            if (texture._needsUpload || texture._needsMipmapsUpload) {
                 texture.upload();
             }
         });

--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -110,7 +110,7 @@ class WebgpuMipmapRenderer {
         DebugHelper.setLabel(pipeline, 'RenderPipeline-MipmapRenderer');
 
         const texture = webgpuTexture.texture;
-        const numFaces = texture.cubemap ? 6 : (texture.array ? texture.arrayLength : 1);
+        const numFaces = texture.slices;
 
         const srcViews = [];
         for (let face = 0; face < numFaces; face++) {

--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -110,7 +110,7 @@ class WebgpuMipmapRenderer {
         DebugHelper.setLabel(pipeline, 'RenderPipeline-MipmapRenderer');
 
         const texture = webgpuTexture.texture;
-        const numFaces = texture.slices;
+        const numFaces = texture.layers;
 
         const srcViews = [];
         for (let face = 0; face < numFaces; face++) {

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -100,7 +100,7 @@ class WebgpuTexture {
             size: {
                 width: texture.width,
                 height: texture.height,
-                depthOrArrayLayers: texture.cubemap ? 6 : (texture.array ? texture.arrayLength : 1)
+                depthOrArrayLayers: texture.slices
             },
             format: this.format,
             mipLevelCount: numLevels,
@@ -331,15 +331,15 @@ class WebgpuTexture {
                             }
                         }
 
-                    } else if (texture._volume) {
+                    } else if (texture.volume) {
 
                         Debug.warn('Volume texture data upload is not supported yet', this.texture);
 
                     } else if (texture.array) { // texture array
 
-                        if (texture.arrayLength === mipObject.length) {
+                        if (texture.slices === mipObject.length) {
 
-                            for (let index = 0; index < texture._arrayLength; index++) {
+                            for (let index = 0; index < texture.slices; index++) {
                                 const arraySource = mipObject[index];
 
                                 if (this.isExternalImage(arraySource)) {

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -100,7 +100,7 @@ class WebgpuTexture {
             size: {
                 width: texture.width,
                 height: texture.height,
-                depthOrArrayLayers: texture.slices
+                depthOrArrayLayers: texture.layers
             },
             format: this.format,
             mipLevelCount: numLevels,
@@ -337,9 +337,9 @@ class WebgpuTexture {
 
                     } else if (texture.array) { // texture array
 
-                        if (texture.slices === mipObject.length) {
+                        if (texture.layers === mipObject.length) {
 
-                            for (let index = 0; index < texture.slices; index++) {
+                            for (let index = 0; index < texture.layers; index++) {
                                 const arraySource = mipObject[index];
 
                                 if (this.isExternalImage(arraySource)) {


### PR DESCRIPTION
Hello PC team,
this PR adds single slice updates for texture 2d arrays and cubemaps. 

Please note this is a draft, work in progress PR but I wanted to get it out so that I can get feedback early on.
Please also note that I have [another branch where I was a little more ambitious](https://github.com/playcanvas/engine/compare/main...heretique:playcanvas-engine:texture-updates-improvements) with larger internal changes for the textures but that proved to generate more chained changes because there are a lot of internal places where the engine uses the internals ("private" fields) of the textures bypassing the provided API. So after discussions on #4290 I went with the least possible changes, that I'll list bellow:

 - added a `_dimension` private field to use for identifying the "type" of the texture. `_type` is already used for something else
 - added a single `_slices` field to indicate the number of faces for a cubemap, slices/layers for a texture 2d array, depth for a 3d texture
 - removed `arrayLength`, `_volume`, `_cubemap` internal fields but based the API getters and setters on the newly introduced `_dimension` and `_slices` fields
 - added an `immediate` option at texture creation, `setSource` and `unlock` to force an immediate upload of texture data to GPU
 - this may be debatable but I removed the possibility of setting any mipmap level from `setSource`. Given the name and the fact that it is supposed to set the texture source from a "browser interface" it doesn't make much sense, plus in all the codebase only level 0 it is used. This should force users to use `lock` API which is more low level.
 - `lock` now allows you to update mip level 0 for single slices of a texture 2d array or cubemap face. Why this limitation? because of the way the `_levelsUpdated` were used before. In the first place I don't believe updating a single face using `lock` worked before because `_levelsUpdated` was not being set at all and there is a check in the `webgl` implementation that specifically checks for `_levelsUpdated[0][face]`. I decided to do a similar thing for texture 2 arrays as well and allow setting mip 0 and fixed it as well for cubemap. I believe it makes more sense as if any mip level is missing they still need to be generated using `gl.generateMipmaps` on WebGL.

This last point brings me to the big issue that I encountered, `gl.generateMipmap` does a full mipmap chain generation on all types of textures, this may make sense for 2D and 3D textures but not so much for cubemaps and even less for texure 2d arrays. It does make sense at texture creation time, but this last type can contain hundreds of textures and re-generating the full mipmap chain after a single slice upload is wasteful and can block the main loop.
The solution, implement a mipmap renderer for WebGL like the one we have for WebGPU. I already started with that, although not pushed yet because there's a big issue with that. For WebGL most of the texture data is lazily uploaded during main render loop right inside the `draw` method. By the time we reach `setTexture` a part of the GL state is already set, shaders bound, etc. If I do my own `WebglMipmapRenderere.generate` call it will probably mess up the state pretty bad as I need to bind framebuffers, shaders, etc. for rendering the mipmaps. We will probably need to upload dirty textures before entering the `draw` method and here's where I'm kindly asking for guidance/suggestions on how to do this without breaking anything 😁. I'll update the PR with the mipmaprenderer in the following days when I have some time to polish it. 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
