### PR TITLE
Refactor shader cache implementation for the mesh instance

### DIFF
--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -83,7 +83,7 @@ class Material {
      * The cache of shader variants generated for this material. The key represents the unique
      * variant, the value is the shader.
      *
-     * @type {Map<string, import('../../platform/graphics/shader.js').Shader>}
+     * @type {Map<number, import('../../platform/graphics/shader.js').Shader>}
      * @ignore
      */
     variants = new Map();


### PR DESCRIPTION
- before, we had the string based shader key. As we only had two values to construct the string, and in order to avoid the string construction every draw call, a two level look up was implemented
- as this is not scalable to more than 2 keys we need in the follow up PRs, this has been changed to a hash key, similarly to the way the render pipeline cache is implemented
- as the content of this cache is very small (few shaders), a simpler solution was done without handling the hash collisions, which are very unlikely in this case. This is tested and reported in the debug mode, which will allow to avoid it fi this actually takes place.