### PR TITLE
Remove app#context backwards compatibility for scripts 1

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -241,15 +241,6 @@ class AppBase extends EventHandler {
         this._fillMode = FILLMODE_KEEP_ASPECT;
         this._resolutionMode = RESOLUTION_FIXED;
         this._allowResize = true;
-
-        /**
-         * For backwards compatibility with scripts 1.0.
-         *
-         * @type {AppBase}
-         * @deprecated
-         * @ignore
-         */
-        this.context = this;
     }
 
     /**


### PR DESCRIPTION
This should have gone with the legacy script component.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
