### PR TITLE
Gsplat fixes

### DIFF
--- a/src/scene/gsplat/gsplat-compressed-material.js
+++ b/src/scene/gsplat/gsplat-compressed-material.js
@@ -27,11 +27,12 @@ varying vec4 color;
 #endif
 
 uniform vec2 viewport;
-uniform vec4 bufferWidths;
+uniform vec4 bufferWidths;                  // packed width, chunked width, numSplats
 uniform highp usampler2D splatOrder;
 uniform highp usampler2D packedTexture;
 uniform highp sampler2D chunkTexture;
 
+uint orderId;
 uint splatId;
 ivec2 splatUV;
 ivec2 chunkUV;
@@ -46,7 +47,7 @@ void calcUV() {
     int chunkWidth = int(bufferWidths.y);
 
     // sample order texture
-    uint orderId = vertex_id_attrib + uint(vertex_position.z);
+    orderId = vertex_id_attrib + uint(vertex_position.z);
     ivec2 orderUV = ivec2(
         int(orderId) % packedWidth,
         int(orderId) / packedWidth
@@ -197,7 +198,7 @@ vec4 evalSplat() {
     vec4 centerClip = matrix_projection * centerView;
 
     // cull behind camera
-    if (centerClip.z < -centerClip.w) {
+    if (centerClip.z < -centerClip.w || orderId >= uint(bufferWidths.z)) {
         return vec4(0.0, 0.0, 2.0, 1.0);
     }
 

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -110,7 +110,7 @@ class GSplatCompressed {
         const result = createGSplatCompressedMaterial(options);
         result.setParameter('packedTexture', this.packedTexture);
         result.setParameter('chunkTexture', this.chunkTexture);
-        result.setParameter('bufferWidths', new Float32Array([this.packedTexture.width, this.chunkTexture.width / 3, 0, 0]));
+        result.setParameter('bufferWidths', new Float32Array([this.packedTexture.width, this.chunkTexture.width / 3, this.numSplats, 0]));
         return result;
     }
 

--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -119,7 +119,9 @@ class GSplatInstance {
         this.meshInstance = new MeshInstance(this.mesh, this.material);
         this.meshInstance.setInstancing(indicesVB, true);
         this.meshInstance.gsplatInstance = this;
-        this.meshInstance.instancingCount = numSplatInstances;
+
+        // only start rendering the splat after we've received the splat order data
+        this.meshInstance.instancingCount = 0;
 
         // clone centers to allow multiple instances of sorter
         this.centers = new Float32Array(splat.centers);


### PR DESCRIPTION
Fixes: #6699 

This PR fixes two issues:
* only render the gsplat instance after we've received the sorted order data (otherwise there is a visible snap on the first frame).
* refrain from rendering out-of-bounds splats when they're compressed (similar to #6590 for uncompressed)