### PR TITLE
Clear references of temporary array when no longer needed

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -521,6 +521,8 @@ class Entity extends GraphNode {
                 }
             }
         }
+
+        components.length = 0;
     }
 
     /** @private */
@@ -530,6 +532,8 @@ class Entity extends GraphNode {
         for (let i = 0; i < components.length; i++) {
             components[i].onPostStateChange();
         }
+
+        components.length = 0;
     }
 
     /**
@@ -605,8 +609,6 @@ class Entity extends GraphNode {
     }
 
     _getSortedComponents() {
-        _sortedArray.length = 0;
-
         const components = this.c;
         let needSort = 0;
         for (const type in components) {

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -609,6 +609,8 @@ class Entity extends GraphNode {
     }
 
     _getSortedComponents() {
+        Debug.assert(_sortedArray.length === 0);
+
         const components = this.c;
         let needSort = 0;
         for (const type in components) {


### PR DESCRIPTION
Follow up on #6647

I think it would be better to clear the temp array of old references immediately after consuming, so we don't keep them forever.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
