### PR TITLE
Leverage WebXR types in public API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.71.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@types/webxr": "^0.5.15",
+        "@types/webxr": "^0.5.16",
         "@webgpu/types": "^0.1.40"
       },
       "devDependencies": {
@@ -46,6 +46,9 @@
         "typedoc-plugin-mdn-links": "^3.1.22",
         "typescript": "^5.4.5",
         "xhr2": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2488,9 +2491,9 @@
       "dev": true
     },
     "node_modules/@types/webxr": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.15.tgz",
-      "integrity": "sha512-nC9116Gd4N+CqTxqo6gvCfhAMAzgRcfS8ZsciNodHq8uwW4JCVKwhagw8yN0XmC7mHrLnWqniJpoVEiR+72Drw=="
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.16.tgz",
+      "integrity": "sha512-0E0Cl84FECtzrB4qG19TNTqpunw0F1YF0QZZnFMF6pDw1kNKJtrlTKlVB34stGIsHbZsYQ7H0tNjPfZftkHHoA=="
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "README*.md"
   ],
   "dependencies": {
-    "@types/webxr": "^0.5.15",
+    "@types/webxr": "^0.5.16",
     "@webgpu/types": "^0.1.40"
   },
   "devDependencies": {

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -129,7 +129,7 @@ class AppBase extends EventHandler {
      *
      * @callback MakeTickCallback
      * @param {number} [timestamp] - The timestamp supplied by requestAnimationFrame.
-     * @param {*} [frame] - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} [frame] - XRFrame from requestAnimationFrame callback.
      * @returns {void}
      */
 
@@ -2036,7 +2036,7 @@ const makeTick = function (_app) {
     const application = _app;
     /**
      * @param {number} [timestamp] - The timestamp supplied by requestAnimationFrame.
-     * @param {*} [frame] - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} [frame] - XRFrame from requestAnimationFrame callback.
      */
     return function (timestamp, frame) {
         if (!application.graphicsDevice)

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -313,7 +313,7 @@ class ElementSelectEvent extends ElementInputEvent {
     /**
      * Create an instance of a ElementSelectEvent.
      *
-     * @param {object} event - The XRInputSourceEvent that was originally raised.
+     * @param {XRInputSourceEvent} event - The XRInputSourceEvent that was originally raised.
      * @param {import('../components/element/component.js').ElementComponent} element - The
      * ElementComponent that this event was originally raised on.
      * @param {import('../components/camera/component.js').CameraComponent} camera - The

--- a/src/framework/xr/xr-anchor.js
+++ b/src/framework/xr/xr-anchor.js
@@ -127,7 +127,7 @@ class XrAnchor extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-anchors.js
+++ b/src/framework/xr/xr-anchors.js
@@ -382,7 +382,7 @@ class XrAnchors extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-hand.js
+++ b/src/framework/xr/xr-hand.js
@@ -147,7 +147,7 @@ class XrHand extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -89,7 +89,7 @@ class XrHitTestSource extends EventHandler {
      * Create a new XrHitTestSource instance.
      *
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @param {*} xrHitTestSource - XRHitTestSource object that is created by WebXR API.
+     * @param {XRHitTestSource} xrHitTestSource - XRHitTestSource object that is created by WebXR API.
      * @param {boolean} transient - True if XRHitTestSource created for input source profile.
      * @param {null|import('./xr-input-source.js').XrInputSource} inputSource - Input Source for which hit test is created for, or null.
      * @ignore
@@ -127,7 +127,7 @@ class XrHitTestSource extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -337,7 +337,7 @@ class XrHitTest extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-image-tracking.js
+++ b/src/framework/xr/xr-image-tracking.js
@@ -157,7 +157,7 @@ class XrImageTracking extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -299,8 +299,7 @@ class XrInputSource extends EventHandler {
      * Create a new XrInputSource instance.
      *
      * @param {import('./xr-manager.js').XrManager} manager - WebXR Manager.
-     * @param {*} xrInputSource - [XRInputSource](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSource)
-     * object that is created by WebXR API.
+     * @param {XRInputSource} xrInputSource - A WebXR input source.
      * @ignore
      */
     constructor(manager, xrInputSource) {
@@ -328,7 +327,7 @@ class XrInputSource extends EventHandler {
     /**
      * XRInputSource object that is associated with this input source.
      *
-     * @type {object}
+     * @type {XRInputSource}
      */
     get inputSource() {
         return this._xrInputSource;
@@ -469,7 +468,7 @@ class XrInputSource extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -303,7 +303,7 @@ class XrInput extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-joint.js
+++ b/src/framework/xr/xr-joint.js
@@ -127,7 +127,7 @@ class XrJoint {
     }
 
     /**
-     * @param {*} pose - XRJointPose of this joint.
+     * @param {XRJointPose} pose - XRJointPose of this joint.
      * @ignore
      */
     update(pose) {

--- a/src/framework/xr/xr-light-estimation.js
+++ b/src/framework/xr/xr-light-estimation.js
@@ -191,7 +191,7 @@ class XrLightEstimation extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -849,7 +849,7 @@ class XrManager extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      *
      * @returns {boolean} True if update was successful, false otherwise.
      * @ignore

--- a/src/framework/xr/xr-plane-detection.js
+++ b/src/framework/xr/xr-plane-detection.js
@@ -143,7 +143,7 @@ class XrPlaneDetection extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-plane.js
+++ b/src/framework/xr/xr-plane.js
@@ -102,7 +102,7 @@ class XrPlane extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @ignore
      */
     update(frame) {

--- a/src/framework/xr/xr-tracked-image.js
+++ b/src/framework/xr/xr-tracked-image.js
@@ -75,7 +75,7 @@ class XrTrackedImage extends EventHandler {
     _emulated = false;
 
     /**
-     * @type {*}
+     * @type {XRPose|null}
      * @ignore
      */
     _pose = null;

--- a/src/framework/xr/xr-views.js
+++ b/src/framework/xr/xr-views.js
@@ -204,7 +204,7 @@ class XrViews extends EventHandler {
     }
 
     /**
-     * @param {*} frame - XRFrame from requestAnimationFrame callback.
+     * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @param {XRView} xrView - XRView from WebXR API.
      * @ignore
      */


### PR DESCRIPTION
Tighten up the areas of the API (both internal and external) that use WebXR types. The Engine has a dependency on `@types/webxr` now so these types are now available.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
