### PR TITLE
GSplat speedup

### DIFF
--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -310,9 +310,7 @@ class PlyParser {
 
                         // reorder data
                         if (asset.data.reorder ?? true) {
-                            const start = Date.now();
                             gsplatData.reorderData();
-                            console.log(`took ${Date.now() - start}ms`);
                         }
                     }
 

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -1,5 +1,6 @@
 import { GSplatData } from '../../scene/gsplat/gsplat-data.js';
 import { GSplatResource } from './gsplat-resource.js';
+import { Mat4 } from '../../core/math/mat4.js';
 
 const magicBytes = new Uint8Array([112, 108, 121, 10]);                                                 // ply\n
 const endHeaderBytes = new Uint8Array([10, 101, 110, 100, 95, 104, 101, 97, 100, 101, 114, 10]);        // \nend_header\n
@@ -258,6 +259,8 @@ const defaultElements = [
 const defaultElementsSet = new Set(defaultElements);
 const defaultElementFilter = val => defaultElementsSet.has(val);
 
+const mat4 = new Mat4();
+
 class PlyParser {
     /** @type {import('../../platform/graphics/graphics-device.js').GraphicsDevice} */
     device;
@@ -295,10 +298,23 @@ class PlyParser {
             readPly(response.body.getReader(), asset.data.elementFilter ?? defaultElementFilter)
                 .then((response) => {
                     // construct the GSplatData object
-                    const gsplatData = new GSplatData(response, {
-                        performZScale: asset.data.performZScale,
-                        reorder: asset.data.reorder
-                    });
+                    const gsplatData = new GSplatData(response);
+
+                    if (!gsplatData.isCompressed) {
+
+                        // perform Z scale
+                        if (asset.data.performZScale ?? true) {
+                            mat4.setScale(-1, -1, 1);
+                            gsplatData.transform(mat4);
+                        }
+
+                        // reorder data
+                        if (asset.data.reorder ?? true) {
+                            const start = Date.now();
+                            gsplatData.reorderData();
+                            console.log(`took ${Date.now() - start}ms`);
+                        }
+                    }
 
                     // construct the resource
                     const resource = new GSplatResource(

--- a/src/scene/gsplat/gsplat-data.js
+++ b/src/scene/gsplat/gsplat-data.js
@@ -182,28 +182,10 @@ class GSplatData {
 
     // /**
     //  * @param {import('./ply-reader').PlyElement[]} elements - The elements.
-    //  * @param {boolean} [performZScale] - Whether to perform z scaling.
-    //  * @param {object} [options] - The options.
-    //  * @param {boolean} [options.performZScale] - Whether to perform z scaling.
-    //  * @param {boolean} [options.reorder] - Whether to reorder the data.
     //  */
-    constructor(elements, options = {}) {
+    constructor(elements) {
         this.elements = elements;
-
         this.numSplats = this.getElement('vertex').count;
-
-        if (!this.isCompressed) {
-            if (options.performZScale ?? true) {
-                mat4.setScale(-1, -1, 1);
-                this.transform(mat4);
-            }
-
-            // reorder uncompressed splats in morton order for better memory access
-            // efficiency during rendering
-            if (options.reorder ?? true) {
-                this.reorderData();
-            }
-        }
     }
 
     /**
@@ -584,10 +566,7 @@ class GSplatData {
                     storage: data[name]
                 };
             })
-        }], {
-            performZScale: false,
-            reorder: false
-        });
+        }]);
     }
 
     calcMortonOrder() {
@@ -623,32 +602,41 @@ class GSplatData {
         const { min: minY, max: maxY } = calcMinMax(y);
         const { min: minZ, max: maxZ } = calcMinMax(z);
 
-        const sizeX = 1024 / (maxX - minX);
-        const sizeY = 1024 / (maxY - minY);
-        const sizeZ = 1024 / (maxZ - minZ);
+        const sizeX = minX == maxX ? 0 : 1024 / (maxX - minX);
+        const sizeY = minY == maxY ? 0 : 1024 / (maxY - minY);
+        const sizeZ = minZ == maxZ ? 0 : 1024 / (maxZ - minZ);
 
-        const morton = new Uint32Array(this.numSplats);
+        const codes = new Map();
         for (let i = 0; i < this.numSplats; i++) {
             const ix = Math.floor((x[i] - minX) * sizeX);
             const iy = Math.floor((y[i] - minY) * sizeY);
             const iz = Math.floor((z[i] - minZ) * sizeZ);
-            morton[i] = encodeMorton3(ix, iy, iz);
+            const code = encodeMorton3(ix, iy, iz);
+
+            const val = codes.get(code);
+            if (val) {
+                val.push(i);
+            } else {
+                codes.set(code, [i]);
+            }
         }
 
-        // generate indices
+        const keys = Array.from(codes.keys()).sort((a, b) => a - b);
         const indices = new Uint32Array(this.numSplats);
-        for (let i = 0; i < this.numSplats; i++) {
-            indices[i] = i;
+        let idx = 0;
+
+        for (let i = 0; i < keys.length; ++i) {
+            const val = codes.get(keys[i]);
+            for (let j = 0; j < val.length; ++j) {
+                indices[idx++] = val[j];
+            }
         }
-        // order splats by morton code
-        indices.sort((a, b) => morton[a] - morton[b]);
 
         return indices;
     }
 
     // reorder the splat data to aid in better gpu memory access at render time
-    reorderData() {
-        const order = this.calcMortonOrder();
+    reorder(order) {
 
         const reorder = (data) => {
             const result = new data.constructor(data.length);
@@ -667,6 +655,49 @@ class GSplatData {
                 }
             });
         });
+    }
+
+    reorderFast(order) {
+        const cache = new Map();
+
+        const getStorage = (size) => {
+            if (cache.has(size)) {
+                const buffer = cache.get(size);
+                cache.delete(size);
+                return buffer;
+            }
+
+            return new ArrayBuffer(size);
+        };
+
+        const returnStorage = (buffer) => {
+            cache.set(buffer.byteLength, buffer);
+        };
+
+        const reorder = (data) => {
+            const result = new data.constructor(getStorage(data.byteLength));
+
+            for (let i = 0; i < order.length; i++) {
+                result[i] = data[order[i]];
+            }
+
+            returnStorage(data.buffer);
+
+            return result;
+        };
+
+        this.elements.forEach((element) => {
+            element.properties.forEach((property) => {
+                if (property.storage) {
+                    property.storage = reorder(property.storage);
+                }
+            });
+        });
+    }
+
+    // reorder the splat data to aid in better gpu memory access at render time
+    reorderData() {
+        this.reorderFast(this.calcMortonOrder());
     }
 }
 

--- a/src/scene/gsplat/gsplat-data.js
+++ b/src/scene/gsplat/gsplat-data.js
@@ -602,9 +602,9 @@ class GSplatData {
         const { min: minY, max: maxY } = calcMinMax(y);
         const { min: minZ, max: maxZ } = calcMinMax(z);
 
-        const sizeX = minX == maxX ? 0 : 1024 / (maxX - minX);
-        const sizeY = minY == maxY ? 0 : 1024 / (maxY - minY);
-        const sizeZ = minZ == maxZ ? 0 : 1024 / (maxZ - minZ);
+        const sizeX = minX === maxX ? 0 : 1024 / (maxX - minX);
+        const sizeY = minY === maxY ? 0 : 1024 / (maxY - minY);
+        const sizeZ = minZ === maxZ ? 0 : 1024 / (maxZ - minZ);
 
         const codes = new Map();
         for (let i = 0; i < this.numSplats; i++) {

--- a/src/scene/gsplat/gsplat-data.js
+++ b/src/scene/gsplat/gsplat-data.js
@@ -637,27 +637,6 @@ class GSplatData {
 
     // reorder the splat data to aid in better gpu memory access at render time
     reorder(order) {
-
-        const reorder = (data) => {
-            const result = new data.constructor(data.length);
-
-            for (let i = 0; i < order.length; i++) {
-                result[i] = data[order[i]];
-            }
-
-            return result;
-        };
-
-        this.elements.forEach((element) => {
-            element.properties.forEach((property) => {
-                if (property.storage) {
-                    property.storage = reorder(property.storage);
-                }
-            });
-        });
-    }
-
-    reorderFast(order) {
         const cache = new Map();
 
         const getStorage = (size) => {
@@ -697,7 +676,7 @@ class GSplatData {
 
     // reorder the splat data to aid in better gpu memory access at render time
     reorderData() {
-        this.reorderFast(this.calcMortonOrder());
+        this.reorder(this.calcMortonOrder());
     }
 }
 

--- a/src/scene/gsplat/gsplat-material.js
+++ b/src/scene/gsplat/gsplat-material.js
@@ -27,7 +27,7 @@ const splatMainFS = `
  * @property {string} [vertex] - Custom vertex shader, see SPLAT MANY example.
  * @property {string} [fragment] - Custom fragment shader, see SPLAT MANY example.
  * @property {string} [dither] - Opacity dithering enum.
- * 
+ *
  * @ignore
  */
 

--- a/src/scene/gsplat/gsplat-material.js
+++ b/src/scene/gsplat/gsplat-material.js
@@ -27,6 +27,8 @@ const splatMainFS = `
  * @property {string} [vertex] - Custom vertex shader, see SPLAT MANY example.
  * @property {string} [fragment] - Custom fragment shader, see SPLAT MANY example.
  * @property {string} [dither] - Opacity dithering enum.
+ * 
+ * @ignore
  */
 
 /**

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -142,12 +142,12 @@ const splatCoreVS = /* glsl */ `
     }
 `;
 
-const splatCoreFS = /* glsl_ */ `
+const splatCoreFS = /* glsl */ `
     varying vec2 texCoord;
     varying vec4 color;
 
     #ifndef DITHER_NONE
-    varying float id;
+        varying float id;
     #endif
 
     #ifdef PICK_PASS

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -16,7 +16,10 @@ const splatCoreVS = /* glsl */ `
 
     varying vec2 texCoord;
     varying vec4 color;
-    varying float id;
+
+    #ifndef DITHER_NONE
+        varying float id;
+    #endif
 
     uniform vec4 tex_params;
     uniform sampler2D splatColor;
@@ -86,7 +89,10 @@ const splatCoreVS = /* glsl */ `
             return vec4(0.0, 0.0, 2.0, 1.0);
         }
 
-        id = float(splatId);
+        #ifndef DITHER_NONE
+            id = float(splatId);
+        #endif
+
         color = getColor();
 
         mat3 Vrk = mat3(
@@ -139,7 +145,10 @@ const splatCoreVS = /* glsl */ `
 const splatCoreFS = /* glsl_ */ `
     varying vec2 texCoord;
     varying vec4 color;
+
+    #ifndef DITHER_NONE
     varying float id;
+    #endif
 
     #ifdef PICK_PASS
         uniform vec4 uColor;


### PR DESCRIPTION
In this PR we:
* speed up the load-time reordering of uncompressed splat data by roughly 1/3rd for large scenes
    * time to reorder the 6 million splat bicycle scene goes from 3.2s to 2.3s on Chrome Macbook M1
* simplify code slightly by moving some of the load-time logic from `GSplatData` to `PLYParser`
* small render speedup by removing the `id` varying in uncompressed shader when it's not needed