### PR TITLE
Image files can be loaded into sRGB textures

### DIFF
--- a/examples/src/examples/graphics/paint-mesh.example.mjs
+++ b/examples/src/examples/graphics/paint-mesh.example.mjs
@@ -13,8 +13,8 @@ const assets = {
         { url: rootPath + '/static/assets/cubemaps/helipad-env-atlas.png' },
         { type: pc.TEXTURETYPE_RGBP, mipmaps: false }
     ),
-    color: new pc.Asset('color', 'texture', { url: rootPath + '/static/assets/textures/seaside-rocks01-color.jpg' }, { encoding: 'srgb' }),
-    decal: new pc.Asset('color', 'texture', { url: rootPath + '/static/assets/textures/heart.png' }, { encoding: 'srgb' })
+    color: new pc.Asset('color', 'texture', { url: rootPath + '/static/assets/textures/seaside-rocks01-color.jpg' }, { srgb: true }),
+    decal: new pc.Asset('color', 'texture', { url: rootPath + '/static/assets/textures/heart.png' }, { srgb: true })
 };
 
 const gfxOptions = {

--- a/examples/src/examples/graphics/paint-mesh.example.mjs
+++ b/examples/src/examples/graphics/paint-mesh.example.mjs
@@ -8,13 +8,13 @@ window.focus();
 // load the textures
 const assets = {
     helipad: new pc.Asset(
-        'helipad.dds',
-        'cubemap',
-        { url: rootPath + '/static/assets/cubemaps/helipad.dds' },
-        { type: pc.TEXTURETYPE_RGBM }
+        'helipad-env-atlas',
+        'texture',
+        { url: rootPath + '/static/assets/cubemaps/helipad-env-atlas.png' },
+        { type: pc.TEXTURETYPE_RGBP, mipmaps: false }
     ),
-    color: new pc.Asset('color', 'texture', { url: rootPath + '/static/assets/textures/seaside-rocks01-color.jpg' }),
-    decal: new pc.Asset('color', 'texture', { url: rootPath + '/static/assets/textures/heart.png' })
+    color: new pc.Asset('color', 'texture', { url: rootPath + '/static/assets/textures/seaside-rocks01-color.jpg' }, { encoding: 'srgb' }),
+    decal: new pc.Asset('color', 'texture', { url: rootPath + '/static/assets/textures/heart.png' }, { encoding: 'srgb' })
 };
 
 const gfxOptions = {
@@ -50,7 +50,7 @@ const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets
 assetListLoader.load(() => {
     app.start();
 
-    app.scene.setSkybox(assets.helipad.resources);
+    app.scene.envAtlas = assets.helipad.resource;
     app.scene.rendering.toneMapping = pc.TONEMAP_ACES;
     app.scene.skyboxIntensity = 1;
     app.scene.skyboxMip = 2;

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1816,7 +1816,7 @@ class AppBase extends EventHandler {
             material = new Material();
             material.cull = CULLFACE_NONE;
             material.setParameter("colorMap", texture);
-            material.shader = filterable ? this.scene.immediate.getTextureShader() : this.scene.immediate.getUnfilterableTextureShader();
+            material.shader = filterable ? this.scene.immediate.getTextureShader(texture.encoding) : this.scene.immediate.getUnfilterableTextureShader();
             material.update();
         }
 

--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -219,8 +219,8 @@ class TextureHandler extends ResourceHandler {
                 options.flipY = !!assetData.flipY;
             }
 
-            if (assetData.hasOwnProperty('encoding')) {
-                options.srgb = assetData.encoding === 'srgb';
+            if (assetData.hasOwnProperty('srgb')) {
+                options.srgb = !!assetData.srgb;
             }
 
             // extract asset type (this is bit of a mess)

--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -219,6 +219,10 @@ class TextureHandler extends ResourceHandler {
                 options.flipY = !!assetData.flipY;
             }
 
+            if (assetData.hasOwnProperty('encoding')) {
+                options.srgb = assetData.encoding === 'srgb';
+            }
+
             // extract asset type (this is bit of a mess)
             if (assetData.hasOwnProperty('type')) {
                 options.type = JSON_TEXTURE_TYPE[assetData.type];

--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -1,5 +1,5 @@
 import {
-    PIXELFORMAT_RGBA8, TEXHINT_ASSET
+    PIXELFORMAT_RGBA8, PIXELFORMAT_SRGBA8, TEXHINT_ASSET
 } from '../../../platform/graphics/constants.js';
 import { Texture } from '../../../platform/graphics/texture.js';
 import { http } from '../../../platform/net/http.js';
@@ -77,7 +77,7 @@ class ImgParser extends TextureParser {
             // #endif
             width: data.width,
             height: data.height,
-            format: PIXELFORMAT_RGBA8,
+            format: textureOptions.srgb ? PIXELFORMAT_SRGBA8 : PIXELFORMAT_RGBA8,
 
             ...textureOptions
         });

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -10,6 +10,7 @@ import { shaderChunks } from '../shader-lib/chunks/chunks.js';
 import { ImmediateBatches } from './immediate-batches.js';
 
 import { Vec3 } from '../../core/math/vec3.js';
+import { ChunkUtils } from '../shader-lib/chunk-utils.js';
 
 const tempPoints = [];
 const vec = new Vec3();
@@ -103,12 +104,15 @@ class Immediate {
     }
 
     // shader used to display texture
-    getTextureShader() {
-        return this.getShader('textureShader', /* glsl */ `
+    getTextureShader(encoding) {
+        const decodeFunc = ChunkUtils.decodeFunc(encoding);
+        return this.getShader(`textureShader-${encoding}`, shaderChunks.decodePS + shaderChunks.gamma2_2PS +
+        /* glsl */ `
             varying vec2 uv0;
             uniform sampler2D colorMap;
             void main (void) {
-                gl_FragColor = vec4(texture2D(colorMap, uv0).xyz, 1);
+                vec3 linearColor = ${decodeFunc}(texture2D(colorMap, uv0));
+                gl_FragColor = vec4(gammaCorrectOutput(linearColor), 1);
             }
         `);
     }


### PR DESCRIPTION
A texture asset can have `encoding: 'srgb'` option specified, which will cause it to be loaded into sRGBA8 format instead of RGBA8, with a free conversion to linear space inside a shader.

example:
```
new pc.Asset(
    'color',
    'texture',
    { url: 'heart.png' },
    { encoding: 'srgb' })
```

also updated `app.drawTexture` to work in the linear space and handle sRGB correctly