### PR TITLE
Compressed splat update

### DIFF
--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -39,9 +39,13 @@ const dataTypeMap = new Map([
 // helper for streaming in chunks of data in a memory efficient way
 class StreamBuf {
     reader;
+
     data;
+
     view;
+
     head = 0;
+
     tail = 0;
 
     constructor(reader) {
@@ -114,15 +118,39 @@ class StreamBuf {
         return this.tail - this.head;
     }
 
-    getInt8()    { const result = this.view.getInt8(this.head); this.head++; return result; }
-    getUint8()   { const result = this.view.getUint8(this.head); this.head++; return result; }
-    getInt16()   { const result = this.view.getInt16(this.head, true); this.head += 2; return result; }
-    getUint16()  { const result = this.view.getUint16(this.head, true); this.head += 2; return result; }
-    getInt32()   { const result = this.view.getInt32(this.head, true); this.head += 4; return result; }
-    getUint32()  { const result = this.view.getUint32(this.head, true); this.head += 4; return result; }
-    getFloat32() { const result = this.view.getFloat32(this.head, true); this.head += 4; return result; }
-    getFloat64() { const result = this.view.getFloat64(this.head, true); this.head += 8; return result; }
-};
+    // helpers for extracting data from head
+    getInt8() {
+        const result = this.view.getInt8(this.head); this.head++; return result;
+    }
+
+    getUint8() {
+        const result = this.view.getUint8(this.head); this.head++; return result;
+    }
+
+    getInt16() {
+        const result = this.view.getInt16(this.head, true); this.head += 2; return result;
+    }
+
+    getUint16() {
+        const result = this.view.getUint16(this.head, true); this.head += 2; return result;
+    }
+
+    getInt32() {
+        const result = this.view.getInt32(this.head, true); this.head += 4; return result;
+    }
+
+    getUint32() {
+        const result = this.view.getUint32(this.head, true); this.head += 4; return result;
+    }
+
+    getFloat32() {
+        const result = this.view.getFloat32(this.head, true); this.head += 4; return result;
+    }
+
+    getFloat64() {
+        const result = this.view.getFloat64(this.head, true); this.head += 8; return result;
+    }
+}
 
 // parse the ply header text and return an array of Element structures and a
 // string containing the ply format
@@ -216,6 +244,7 @@ const readCompressedPly = async (streamBuf, elements, littleEndian) => {
     let chunks = 0;
     while (chunks < numChunks) {
         while (streamBuf.remaining < chunkSize) {
+            /* eslint-disable no-await-in-loop */
             await streamBuf.read();
         }
 
@@ -241,6 +270,7 @@ const readCompressedPly = async (streamBuf, elements, littleEndian) => {
     let vertices = 0;
     while (vertices < numVertices) {
         while (streamBuf.remaining < vertexSize) {
+            /* eslint-disable no-await-in-loop */
             await streamBuf.read();
         }
 
@@ -324,6 +354,7 @@ const readPly = async (reader, propertyFilter = null) => {
 
     while (true) {
         // get the next chunk of data
+        /* eslint-disable no-await-in-loop */
         await streamBuf.read();
 
         // check magic bytes
@@ -384,6 +415,7 @@ const readPly = async (reader, propertyFilter = null) => {
 
         while (c < element.count) {
             while (streamBuf.remaining < inputSize) {
+                /* eslint-disable no-await-in-loop */
                 await streamBuf.read();
             }
 
@@ -408,7 +440,7 @@ const readPly = async (reader, propertyFilter = null) => {
                         streamBuf.head += property.byteSize;
                     }
                 }
-                c++
+                c++;
             }
         }
     }

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -1,20 +1,7 @@
 import { GSplatData } from '../../scene/gsplat/gsplat-data.js';
+import { GSplatCompressedData } from '../../scene/gsplat/gsplat-compressed-data.js';
 import { GSplatResource } from './gsplat-resource.js';
 import { Mat4 } from '../../core/math/mat4.js';
-
-const magicBytes = new Uint8Array([112, 108, 121, 10]);                                                 // ply\n
-const endHeaderBytes = new Uint8Array([10, 101, 110, 100, 95, 104, 101, 97, 100, 101, 114, 10]);        // \nend_header\n
-
-const dataTypeMap = new Map([
-    ['char', Int8Array],
-    ['uchar', Uint8Array],
-    ['short', Int16Array],
-    ['ushort', Uint16Array],
-    ['int', Int32Array],
-    ['uint', Uint32Array],
-    ['float', Float32Array],
-    ['double', Float64Array]
-]);
 
 /**
  * @typedef {Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array} DataType
@@ -35,21 +22,257 @@ const dataTypeMap = new Map([
  * @property {PlyProperty[]} properties - The properties.
  */
 
+const magicBytes = new Uint8Array([112, 108, 121, 10]);                                                 // ply\n
+const endHeaderBytes = new Uint8Array([10, 101, 110, 100, 95, 104, 101, 97, 100, 101, 114, 10]);        // \nend_header\n
+
+const dataTypeMap = new Map([
+    ['char', Int8Array],
+    ['uchar', Uint8Array],
+    ['short', Int16Array],
+    ['ushort', Uint16Array],
+    ['int', Int32Array],
+    ['uint', Uint32Array],
+    ['float', Float32Array],
+    ['double', Float64Array]
+]);
+
+// helper for streaming in chunks of data in a memory efficient way
+class StreamBuf {
+    reader;
+    data;
+    view;
+    head = 0;
+    tail = 0;
+
+    constructor(reader) {
+        this.reader = reader;
+    }
+
+    // read the next chunk of data
+    async read() {
+        const { value, done } = await this.reader.read();
+
+        if (done) {
+            throw new Error('Stream finished before end of header');
+        }
+
+        this.push(value);
+    }
+
+    // append data to the buffer
+    push(data) {
+        if (!this.data) {
+            // first buffer
+            this.data = data;
+            this.view = new DataView(this.data.buffer);
+            this.tail = data.length;
+        } else {
+            const remaining = this.tail - this.head;
+            const newSize = remaining + data.length;
+
+            if (this.data.length >= newSize) {
+                // buffer is large enough to contain combined data
+                if (this.head > 0) {
+                    // shuffle existing data to index 0 and append the new data
+                    this.data.copyWithin(0, this.head, this.tail);
+                    this.data.set(data, remaining);
+                    this.head = 0;
+                    this.tail = newSize;
+                } else {
+                    // no shuffle needed, just append new data
+                    this.data.set(data, this.tail);
+                    this.tail += data.length;
+                }
+            } else {
+                // buffer is too small and must grow
+                const tmp = new Uint8Array(newSize);
+                if (this.head > 0 || this.tail < this.data.length) {
+                    // shuffle existing data to index 0 and append the new data
+                    tmp.set(this.data.subarray(this.head, this.tail), 0);
+                } else {
+                    tmp.set(this.data, 0);
+                }
+                tmp.set(data, remaining);
+                this.data = tmp;
+                this.view = new DataView(this.data.buffer);
+                this.head = 0;
+                this.tail = newSize;
+            }
+        }
+    }
+
+    // remove the read data from the head of the buffer
+    compact() {
+        if (this.head > 0) {
+            this.data.copyWithin(0, this.head, this.tail);
+            this.tail -= this.head;
+            this.head = 0;
+        }
+    }
+
+    get remaining() {
+        return this.tail - this.head;
+    }
+
+    getInt8()    { const result = this.view.getInt8(this.head); this.head++; return result; }
+    getUint8()   { const result = this.view.getUint8(this.head); this.head++; return result; }
+    getInt16()   { const result = this.view.getInt16(this.head, true); this.head += 2; return result; }
+    getUint16()  { const result = this.view.getUint16(this.head, true); this.head += 2; return result; }
+    getInt32()   { const result = this.view.getInt32(this.head, true); this.head += 4; return result; }
+    getUint32()  { const result = this.view.getUint32(this.head, true); this.head += 4; return result; }
+    getFloat32() { const result = this.view.getFloat32(this.head, true); this.head += 4; return result; }
+    getFloat64() { const result = this.view.getFloat64(this.head, true); this.head += 8; return result; }
+};
+
+// parse the ply header text and return an array of Element structures and a
+// string containing the ply format
+const parseHeader = (lines) => {
+    const elements = [];
+    let format;
+
+    for (let i = 1; i < lines.length; ++i) {
+        const words = lines[i].split(' ');
+
+        switch (words[0]) {
+            case 'format':
+                format = words[1];
+                break;
+            case 'element':
+                elements.push({
+                    name: words[1],
+                    count: parseInt(words[2], 10),
+                    properties: []
+                });
+                break;
+            case 'property': {
+                if (!dataTypeMap.has(words[1])) {
+                    throw new Error(`Unrecognized property data type '${words[1]}' in ply header`);
+                }
+                const element = elements[elements.length - 1];
+                element.properties.push({
+                    type: words[1],
+                    name: words[2],
+                    storage: null,
+                    byteSize: dataTypeMap.get(words[1]).BYTES_PER_ELEMENT
+                });
+                break;
+            }
+            default:
+                throw new Error(`Unrecognized header value '${words[0]}' in ply header`);
+        }
+    }
+
+    return { elements, format };
+};
+
+// return true if the array of elements references a compressed ply file
+const isCompressedPly = (elements) => {
+    const chunkProperties = [
+        'min_x', 'min_y', 'min_z',
+        'max_x', 'max_y', 'max_z',
+        'min_scale_x', 'min_scale_y', 'min_scale_z',
+        'max_scale_x', 'max_scale_y', 'max_scale_z'
+    ];
+
+    const vertexProperties = [
+        'packed_position', 'packed_rotation', 'packed_scale', 'packed_color'
+    ];
+
+    return elements.length === 2 &&
+           elements[0].name === 'chunk' &&
+           elements[0].properties.every((p, i) => p.name === chunkProperties[i] && p.type === 'float') &&
+           elements[1].name === 'vertex' &&
+           elements[1].properties.every((p, i) => p.name === vertexProperties[i] && p.type === 'uint');
+};
+
+// read the data of a compressed ply file
+const readCompressedPly = async (streamBuf, elements, littleEndian) => {
+    const result = new GSplatCompressedData();
+
+    const numChunks = elements[0].count;
+    const chunkSize = 12 * 4;
+
+    const numVertices = elements[1].count;
+    const vertexSize = 4 * 4;
+
+    // evaluate the storage size for the given count (this must match the
+    // texture size calculation in GSplatCompressed).
+    const evalStorageSize = (count) => {
+        const width = Math.ceil(Math.sqrt(count));
+        const height = Math.ceil(count / width);
+        return width * height;
+    };
+
+    // allocate result
+    result.numSplats = elements[1].count;
+    result.chunkData = new Float32Array(evalStorageSize(numChunks) * 12);
+    result.vertexData = new Uint32Array(evalStorageSize(numVertices) * 4);
+
+    let uint32StreamData;
+    const uint32ChunkData = new Uint32Array(result.chunkData.buffer);
+    const uint32VertexData = result.vertexData;
+
+    // read chunks
+    let chunks = 0;
+    while (chunks < numChunks) {
+        while (streamBuf.remaining < chunkSize) {
+            await streamBuf.read();
+        }
+
+        // ensure the uint32 view is still valid
+        if (uint32StreamData?.buffer !== streamBuf.data.buffer) {
+            uint32StreamData = new Uint32Array(streamBuf.data.buffer, 0, Math.floor(streamBuf.data.buffer.byteLength / 4));
+        }
+
+        // read the next chunk of data
+        const toRead = Math.min(numChunks - chunks, Math.floor(streamBuf.remaining / chunkSize));
+
+        const dstOffset = chunks * 12;
+        const srcOffset = streamBuf.head / 4;
+        for (let i = 0; i < toRead * 12; ++i) {
+            uint32ChunkData[dstOffset + i] = uint32StreamData[srcOffset + i];
+        }
+
+        streamBuf.head += toRead * chunkSize;
+        chunks += toRead;
+    }
+
+    // read vertices
+    let vertices = 0;
+    while (vertices < numVertices) {
+        while (streamBuf.remaining < vertexSize) {
+            await streamBuf.read();
+        }
+
+        // ensure the uint32 view is still valid
+        if (uint32StreamData?.buffer !== streamBuf.data.buffer) {
+            uint32StreamData = new Uint32Array(streamBuf.data.buffer, 0, Math.floor(streamBuf.data.buffer.byteLength / 4));
+        }
+
+        // read the next chunk of data
+        const toRead = Math.min(numVertices - vertices, Math.floor(streamBuf.remaining / vertexSize));
+
+        const dstOffset = vertices * 4;
+        const srcOffset = streamBuf.head / 4;
+        for (let i = 0; i < toRead * 4; ++i) {
+            uint32VertexData[dstOffset + i] = uint32StreamData[srcOffset + i];
+        }
+
+        streamBuf.head += toRead * vertexSize;
+        vertices += toRead;
+    }
+
+    return result;
+};
+
 /**
  * asynchronously read a ply file data
  *
  * @param {ReadableStreamDefaultReader<Uint8Array>} reader - The reader.
  * @param {Function|null} propertyFilter - Function to filter properties with.
- * @returns {Promise<PlyElement[]>} The ply file data.
+ * @returns {Promise<GSplatData | GSplatCompressedData>} The ply file data.
  */
 const readPly = async (reader, propertyFilter = null) => {
-    const concat = (a, b) => {
-        const c = new Uint8Array(a.byteLength + b.byteLength);
-        c.set(a);
-        c.set(b, a.byteLength);
-        return c;
-    };
-
     /**
      * Searches for the first occurrence of a sequence within a buffer.
      * @example
@@ -96,150 +319,103 @@ const readPly = async (reader, propertyFilter = null) => {
         return true;
     };
 
-    /** @type {Uint8Array|undefined} */
-    let buf;
-    /** @type {number} */
-    let endHeaderIndex;
+    const streamBuf = new StreamBuf(reader);
+    let headerLength;
 
     while (true) {
-        // get the next chunk
-        /* eslint-disable no-await-in-loop */
-        const { value, done } = await reader.read();
-
-        if (done) {
-            throw new Error('Stream finished before end of header');
-        }
-
-        // combine new chunk with the previous
-        buf = buf ? concat(buf, value) : value;
+        // get the next chunk of data
+        await streamBuf.read();
 
         // check magic bytes
-        if (buf.length >= magicBytes.length && !startsWith(buf, magicBytes)) {
+        if (streamBuf.tail >= magicBytes.length && !startsWith(streamBuf.data, magicBytes)) {
             throw new Error('Invalid ply header');
         }
 
-        // check if we can find the end-of-header marker
-        endHeaderIndex = find(buf, endHeaderBytes);
+        // search for end-of-header marker
+        headerLength = find(streamBuf.data, endHeaderBytes);
 
-        if (endHeaderIndex !== -1) {
+        if (headerLength !== -1) {
             break;
         }
     }
 
-    // decode buffer header text
-    const headerText = new TextDecoder('ascii').decode(buf.slice(0, endHeaderIndex));
-
-    // split into lines and remove comments
-    const headerLines = headerText.split('\n')
+    // decode buffer header text and split into lines and remove comments
+    const lines = new TextDecoder('ascii')
+        .decode(streamBuf.data.subarray(0, headerLength))
+        .split('\n')
         .filter(line => !line.startsWith('comment '));
 
-    // decode header and allocate data storage
-    const elements = [];
-    for (let i = 1; i < headerLines.length; ++i) {
-        const words = headerLines[i].split(' ');
+    // decode header and build element and property list
+    const { elements, format } = parseHeader(lines);
 
-        switch (words[0]) {
-            case 'format':
-                if (words[1] !== 'binary_little_endian') {
-                    throw new Error('Unsupported ply format');
-                }
-                break;
-            case 'element':
-                elements.push({
-                    name: words[1],
-                    count: parseInt(words[2], 10),
-                    properties: []
-                });
-                break;
-            case 'property': {
-                if (!dataTypeMap.has(words[1])) {
-                    throw new Error(`Unrecognized property data type '${words[1]}' in ply header`);
-                }
-                const element = elements[elements.length - 1];
-                const storageType = dataTypeMap.get(words[1]);
-                const storage = (!propertyFilter || propertyFilter(words[2])) ? new storageType(element.count) : null;
-                element.properties.push({
-                    type: words[1],
-                    name: words[2],
-                    storage: storage,
-                    byteSize: storageType.BYTES_PER_ELEMENT
-                });
-                break;
-            }
-            default:
-                throw new Error(`Unrecognized header value '${words[0]}' in ply header`);
-        }
+    // check format is supported
+    if (format !== 'binary_little_endian' && format !== 'binary_big_endian') {
+        throw new Error('Unsupported ply format');
     }
 
-    // read data
-    let readIndex = endHeaderIndex + endHeaderBytes.length;
-    let remaining = buf.length - readIndex;
-    let dataView = new DataView(buf.buffer);
+    // skip past header and compact the chunk data so the read operations
+    // fall nicely on aligned data boundaries
+    streamBuf.head = headerLength + endHeaderBytes.length;
+    streamBuf.compact();
 
+    // load compressed PLY with fast path
+    if (isCompressedPly(elements)) {
+        return await readCompressedPly(streamBuf, elements, format === 'binary_little_endian');
+    }
+
+    // allocate element storage
+    elements.forEach((e) => {
+        e.properties.forEach((p) => {
+            const storageType = dataTypeMap.get(p.type);
+            if (storageType) {
+                const storage = (!propertyFilter || propertyFilter(p.name)) ? new storageType(e.count) : null;
+                p.storage = storage;
+            }
+        });
+    });
+
+    // read and un-interleave the data
     for (let i = 0; i < elements.length; ++i) {
         const element = elements[i];
 
-        for (let e = 0; e < element.count; ++e) {
-            for (let j = 0; j < element.properties.length; ++j) {
-                const property = element.properties[j];
+        // calculate the size of an input element record
+        const inputSize = element.properties.reduce((a, p) => a + p.byteSize, 0);
+        let c = 0;
 
-                // if we've run out of data, load the next chunk
-                while (remaining < property.byteSize) {
-                    const { value, done } = await reader.read();
+        while (c < element.count) {
+            while (streamBuf.remaining < inputSize) {
+                await streamBuf.read();
+            }
 
-                    if (done) {
-                        throw new Error('Stream finished before end of data');
-                    }
+            const toRead = Math.min(element.count - c, Math.floor(streamBuf.remaining / inputSize));
 
-                    // create buffer with left-over data from previous chunk and the new data
-                    const tmp = new Uint8Array(remaining + value.byteLength);
-                    tmp.set(buf.slice(readIndex));
-                    tmp.set(value, remaining);
+            for (let n = 0; n < toRead; ++n) {
+                for (let j = 0; j < element.properties.length; ++j) {
+                    const property = element.properties[j];
 
-                    buf = tmp;
-                    dataView = new DataView(buf.buffer);
-                    readIndex = 0;
-                    remaining = buf.length;
-                }
-
-                if (property.storage) {
-                    switch (property.type) {
-                        case 'char':
-                            property.storage[e] = dataView.getInt8(readIndex);
-                            break;
-                        case 'uchar':
-                            property.storage[e] = dataView.getUint8(readIndex);
-                            break;
-                        case 'short':
-                            property.storage[e] = dataView.getInt16(readIndex, true);
-                            break;
-                        case 'ushort':
-                            property.storage[e] = dataView.getUint16(readIndex, true);
-                            break;
-                        case 'int':
-                            property.storage[e] = dataView.getInt32(readIndex, true);
-                            break;
-                        case 'uint':
-                            property.storage[e] = dataView.getUint32(readIndex, true);
-                            break;
-                        case 'float':
-                            property.storage[e] = dataView.getFloat32(readIndex, true);
-                            break;
-                        case 'double':
-                            property.storage[e] = dataView.getFloat64(readIndex, true);
-                            break;
+                    if (property.storage) {
+                        switch (property.type) {
+                            case 'char':   property.storage[c] = streamBuf.getInt8(); break;
+                            case 'uchar':  property.storage[c] = streamBuf.getUint8(); break;
+                            case 'short':  property.storage[c] = streamBuf.getInt16(); break;
+                            case 'ushort': property.storage[c] = streamBuf.getUint16(); break;
+                            case 'int':    property.storage[c] = streamBuf.getInt32(); break;
+                            case 'uint':   property.storage[c] = streamBuf.getUint32(); break;
+                            case 'float':  property.storage[c] = streamBuf.getFloat32(); break;
+                            case 'double': property.storage[c] = streamBuf.getFloat64(); break;
+                        }
+                    } else {
+                        streamBuf.head += property.byteSize;
                     }
                 }
-
-                readIndex += property.byteSize;
-                remaining -= property.byteSize;
+                c++
             }
         }
     }
 
     // console.log(elements);
 
-    return elements;
+    return new GSplatData(elements);
 };
 
 // filter out element data we're not going to use
@@ -296,10 +472,7 @@ class PlyParser {
             callback("Error loading resource", null);
         } else {
             readPly(response.body.getReader(), asset.data.elementFilter ?? defaultElementFilter)
-                .then((response) => {
-                    // construct the GSplatData object
-                    const gsplatData = new GSplatData(response);
-
+                .then((gsplatData) => {
                     if (!gsplatData.isCompressed) {
 
                         // perform Z scale

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -1,0 +1,257 @@
+import { Quat } from '../../core/math/quat.js';
+import { Vec3 } from '../../core/math/vec3.js';
+import { Vec4 } from '../../core/math/vec4.js';
+import { BoundingBox } from '../../core/shape/bounding-box.js';
+import { GSplatData } from './gsplat-data.js';
+
+const SH_C0 = 0.28209479177387814;
+
+// iterator for accessing compressed splat data
+class SplatCompressedIterator {
+    constructor(gsplatData, p, r, s, c) {
+        const unpackUnorm = (value, bits) => {
+            const t = (1 << bits) - 1;
+            return (value & t) / t;
+        };
+
+        const unpack111011 = (result, value) => {
+            result.x = unpackUnorm(value >>> 21, 11);
+            result.y = unpackUnorm(value >>> 11, 10);
+            result.z = unpackUnorm(value, 11);
+        };
+
+        const unpack8888 = (result, value) => {
+            result.x = unpackUnorm(value >>> 24, 8);
+            result.y = unpackUnorm(value >>> 16, 8);
+            result.z = unpackUnorm(value >>> 8, 8);
+            result.w = unpackUnorm(value, 8);
+        };
+
+        // unpack quaternion with 2,10,10,10 format (largest element, 3x10bit element)
+        const unpackRot = (result, value) => {
+            const norm = 1.0 / (Math.sqrt(2) * 0.5);
+            const a = (unpackUnorm(value >>> 20, 10) - 0.5) * norm;
+            const b = (unpackUnorm(value >>> 10, 10) - 0.5) * norm;
+            const c = (unpackUnorm(value, 10) - 0.5) * norm;
+            const m = Math.sqrt(1.0 - (a * a + b * b + c * c));
+
+            switch (value >>> 30) {
+                case 0: result.set(m, a, b, c); break;
+                case 1: result.set(a, m, b, c); break;
+                case 2: result.set(a, b, m, c); break;
+                case 3: result.set(a, b, c, m); break;
+            }
+        };
+
+        const lerp = (a, b, t) => a * (1 - t) + b * t;
+
+        const chunkData = gsplatData.chunkData;
+        const vertexData = gsplatData.vertexData;
+
+        this.read = (i) => {
+            const ci = Math.floor(i / 256) * 12;
+
+            if (p) {
+                unpack111011(p, vertexData[i * 4 + 0]);
+                p.x = lerp(chunkData[ci + 0], chunkData[ci + 3], p.x);
+                p.y = lerp(chunkData[ci + 1], chunkData[ci + 4], p.y);
+                p.z = lerp(chunkData[ci + 2], chunkData[ci + 5], p.z);
+            }
+
+            if (r) {
+                unpackRot(r, vertexData[i * 4 + 1]);
+            }
+
+            if (s) {
+                unpack111011(s, vertexData[i * 4 + 2]);
+                s.x = lerp(chunkData[ci + 6], chunkData[ci + 9], s.x);
+                s.y = lerp(chunkData[ci + 7], chunkData[ci + 10], s.y);
+                s.z = lerp(chunkData[ci + 8], chunkData[ci + 11], s.z);
+            }
+
+            if (c) {
+                unpack8888(c, vertexData[i * 4 + 3]);
+            }
+        };
+    }
+}
+
+class GSplatCompressedData {
+    numSplats;
+
+    // contains 12 floats per chunk:
+    //   min_x, min_y, min_z,
+    //   max_x, max_y, max_z,
+    //   min_scale_x, min_scale_y, min_scale_z,
+    //   max_scale_x, max_scale_y, max_scale_z
+    /* @type {Float32Array} */
+    chunkData;
+
+    // contains 4 uint32 per vertex:
+    //   packed_position, packed_rotation, packed_scale, packed_color
+    /* @type {Uint32Array} */
+    vertexData;
+
+    /**
+     * Create an iterator for accessing splat data
+     *
+     * @param {Vec3|null} [p] - the vector to receive splat position
+     * @param {Quat|null} [r] - the quaternion to receive splat rotation
+     * @param {Vec3|null} [s] - the vector to receive splat scale
+     * @param {Vec4|null} [c] - the vector to receive splat color
+     * @returns {SplatCompressedIterator} - The iterator
+     */
+    createIter(p, r, s, c) {
+        return new SplatCompressedIterator(this, p, r, s, c);
+    }
+
+    /**
+     * Calculate pessimistic scene aabb taking into account splat size. This is faster than
+     * calculating an exact aabb.
+     *
+     * @param {BoundingBox} result - Where to store the resulting bounding box.
+     * @returns {boolean} - Whether the calculation was successful.
+     */
+    calcAabb(result) {
+        let mx, my, mz, Mx, My, Mz;
+
+        // fast bounds calc using chunk data
+        const numChunks = Math.ceil(this.numSplats / 256);
+
+        const chunkData = this.chunkData;
+
+        let s = Math.exp(Math.max(chunkData[9], chunkData[10], chunkData[11]));
+        mx = chunkData[0] - s;
+        my = chunkData[1] - s;
+        mz = chunkData[2] - s;
+        Mx = chunkData[3] + s;
+        My = chunkData[4] + s;
+        Mz = chunkData[5] + s;
+
+        for (let i = 1; i < numChunks; ++i) {
+            s = Math.exp(Math.max(chunkData[i * 12 + 9], chunkData[i * 12 + 10], chunkData[i * 12 + 11]));
+            mx = Math.min(mx, chunkData[i * 12 + 0] - s);
+            my = Math.min(my, chunkData[i * 12 + 1] - s);
+            mz = Math.min(mz, chunkData[i * 12 + 2] - s);
+            Mx = Math.max(Mx, chunkData[i * 12 + 3] + s);
+            My = Math.max(My, chunkData[i * 12 + 4] + s);
+            Mz = Math.max(Mz, chunkData[i * 12 + 5] + s);
+        }
+
+        result.center.set((mx + Mx) * 0.5, (my + My) * 0.5, (mz + Mz) * 0.5);
+        result.halfExtents.set((Mx - mx) * 0.5, (My - my) * 0.5, (Mz - mz) * 0.5);
+
+        return true;
+    }
+
+    /**
+     * @param {Float32Array} result - Array containing the centers.
+     */
+    getCenters(result) {
+        const chunkData = this.chunkData;
+        const vertexData = this.vertexData;
+
+        const numChunks = Math.ceil(this.numSplats / 256);
+
+        let mx, my, mz, Mx, My, Mz;
+
+        for (let c = 0; c < numChunks; ++c) {
+            mx = chunkData[c * 12 + 0];
+            my = chunkData[c * 12 + 1];
+            mz = chunkData[c * 12 + 2];
+            Mx = chunkData[c * 12 + 3];
+            My = chunkData[c * 12 + 4];
+            Mz = chunkData[c * 12 + 5];
+
+            const end = Math.min(this.numSplats, (c + 1) * 256);
+            for (let i = c * 256; i < end; ++i) {
+                const p = vertexData[i * 4];
+                const px = (p >>> 21) / 2047;
+                const py = ((p >>> 11) & 0x3ff) / 1023;
+                const pz = (p & 0x7ff) / 2047;
+                result[i * 3 + 0] = (1 - px) * mx + px * Mx;
+                result[i * 3 + 1] = (1 - py) * my + py * My;
+                result[i * 3 + 2] = (1 - pz) * mz + pz * Mz;
+            }
+        }
+    }
+
+    /**
+     * @param {Vec3} result - The result.
+     */
+    calcFocalPoint(result) {
+        const chunkData = this.chunkData;
+        const numChunks = Math.ceil(this.numSplats / 256);
+
+        result.x = 0;
+        result.y = 0;
+        result.z = 0;
+
+        for (let i = 0; i < numChunks; ++i) {
+            result.x += chunkData[i * 12 + 0] + chunkData[i * 12 + 3];
+            result.y += chunkData[i * 12 + 1] + chunkData[i * 12 + 4];
+            result.z += chunkData[i * 12 + 2] + chunkData[i * 12 + 5];
+        }
+        result.mulScalar(0.5 / numChunks);
+    }
+
+    get isCompressed() {
+        return true;
+    }
+
+    // decompress into GSplatData
+    decompress() {
+        const members = ['x', 'y', 'z', 'f_dc_0', 'f_dc_1', 'f_dc_2', 'opacity', 'rot_0', 'rot_1', 'rot_2', 'rot_3', 'scale_0', 'scale_1', 'scale_2'];
+
+        // allocate uncompressed data
+        const data = {};
+        members.forEach((name) => {
+            data[name] = new Float32Array(this.numSplats);
+        });
+
+        const p = new Vec3();
+        const r = new Quat();
+        const s = new Vec3();
+        const c = new Vec4();
+
+        const iter = this.createIter(p, r, s, c);
+
+        for (let i = 0; i < this.numSplats; ++i) {
+            iter.read(i);
+
+            data.x[i] = p.x;
+            data.y[i] = p.y;
+            data.z[i] = p.z;
+
+            data.rot_0[i] = r.x;
+            data.rot_1[i] = r.y;
+            data.rot_2[i] = r.z;
+            data.rot_3[i] = r.w;
+
+            data.scale_0[i] = s.x;
+            data.scale_1[i] = s.y;
+            data.scale_2[i] = s.z;
+
+            data.f_dc_0[i] = (c.x - 0.5) / SH_C0;
+            data.f_dc_1[i] = (c.y - 0.5) / SH_C0;
+            data.f_dc_2[i] = (c.z - 0.5) / SH_C0;
+            // convert opacity to log sigmoid taking into account infinities at 0 and 1
+            data.opacity[i] = (c.w <= 0) ? -40 : (c.w >= 1) ? 40 : -Math.log(1 / c.w - 1);
+        }
+
+        return new GSplatData([{
+            name: 'vertex',
+            count: this.numSplats,
+            properties: members.map((name) => {
+                return {
+                    name: name,
+                    type: 'float',
+                    byteSize: 4,
+                    storage: data[name]
+                };
+            })
+        }]);
+    }
+};
+
+export { GSplatCompressedData };

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -1,7 +1,6 @@
 import { Quat } from '../../core/math/quat.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Vec4 } from '../../core/math/vec4.js';
-import { BoundingBox } from '../../core/shape/bounding-box.js';
 import { GSplatData } from './gsplat-data.js';
 
 const SH_C0 = 0.28209479177387814;
@@ -79,17 +78,24 @@ class SplatCompressedIterator {
 class GSplatCompressedData {
     numSplats;
 
-    // contains 12 floats per chunk:
-    //   min_x, min_y, min_z,
-    //   max_x, max_y, max_z,
-    //   min_scale_x, min_scale_y, min_scale_z,
-    //   max_scale_x, max_scale_y, max_scale_z
-    /* @type {Float32Array} */
+    /**
+     * Contains 12 floats per chunk:
+     *      min_x, min_y, min_z,
+     *      max_x, max_y, max_z,
+     *      min_scale_x, min_scale_y, min_scale_z,
+     *      max_scale_x, max_scale_y, max_scale_z
+     * @type {Float32Array}
+     */
     chunkData;
 
-    // contains 4 uint32 per vertex:
-    //   packed_position, packed_rotation, packed_scale, packed_color
-    /* @type {Uint32Array} */
+    /**
+     * Contains 4 uint32 per vertex:
+     *      packed_position
+     *      packed_rotation
+     *      packed_scale
+     *      packed_color
+     * @type {Uint32Array}
+     */
     vertexData;
 
     /**
@@ -109,7 +115,7 @@ class GSplatCompressedData {
      * Calculate pessimistic scene aabb taking into account splat size. This is faster than
      * calculating an exact aabb.
      *
-     * @param {BoundingBox} result - Where to store the resulting bounding box.
+     * @param {import('../../core/shape/bounding-box.js').BoundingBox} result - Where to store the resulting bounding box.
      * @returns {boolean} - Whether the calculation was successful.
      */
     calcAabb(result) {
@@ -252,6 +258,6 @@ class GSplatCompressedData {
             })
         }]);
     }
-};
+}
 
 export { GSplatCompressedData };

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -104,7 +104,7 @@ class GSplatCompressed {
             magFilter: FILTER_NEAREST,
             addressU: ADDRESS_CLAMP_TO_EDGE,
             addressV: ADDRESS_CLAMP_TO_EDGE,
-            ... data ? { levels: [data] } : { }
+            ...(data ? { levels: [data] } : { })
         });
     }
 }

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -45,18 +45,12 @@ class GSplatCompressed {
 
         // initialize packed data
         this.packedTexture = this.createTexture('packedData', PIXELFORMAT_RGBA32U, this.evalTextureSize(numSplats), gsplatData.vertexData);
-        // const packedData = this.packedTexture.lock();
-        // packedData.set(gsplatData.vertexData);
-        // this.packedTexture.unlock();
 
         // initialize chunk data
         const chunkSize = this.evalTextureSize(numChunks);
         chunkSize.x *= 3;
 
         this.chunkTexture = this.createTexture('chunkData', PIXELFORMAT_RGBA32F, chunkSize, gsplatData.chunkData);
-        // const chunkData = this.chunkTexture.lock();
-        // chunkData.set(gsplatData.chunkData);
-        // this.chunkTexture.unlock();
     }
 
     destroy() {

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -26,7 +26,7 @@ class GSplatCompressed {
 
     /**
      * @param {import('../../platform/graphics/graphics-device.js').GraphicsDevice} device - The graphics device.
-     * @param {import('./gsplat-data.js').GSplatData} gsplatData - The splat data.
+     * @param {import('./gsplat-compressed-data.js').GSplatCompressedData} gsplatData - The splat data.
      */
     constructor(device, gsplatData) {
         const numSplats = gsplatData.numSplats;
@@ -44,57 +44,19 @@ class GSplatCompressed {
         gsplatData.getCenters(this.centers);
 
         // initialize packed data
-        this.packedTexture = this.createTexture('packedData', PIXELFORMAT_RGBA32U, this.evalTextureSize(numSplats));
-
-        const position = gsplatData.getProp('packed_position');
-        const rotation = gsplatData.getProp('packed_rotation');
-        const scale = gsplatData.getProp('packed_scale');
-        const color = gsplatData.getProp('packed_color');
-
-        const packedData = this.packedTexture.lock();
-        for (let i = 0; i < numSplats; ++i) {
-            packedData[i * 4 + 0] = position[i];
-            packedData[i * 4 + 1] = rotation[i];
-            packedData[i * 4 + 2] = scale[i];
-            packedData[i * 4 + 3] = color[i];
-        }
-        this.packedTexture.unlock();
+        this.packedTexture = this.createTexture('packedData', PIXELFORMAT_RGBA32U, this.evalTextureSize(numSplats), gsplatData.vertexData);
+        // const packedData = this.packedTexture.lock();
+        // packedData.set(gsplatData.vertexData);
+        // this.packedTexture.unlock();
 
         // initialize chunk data
         const chunkSize = this.evalTextureSize(numChunks);
         chunkSize.x *= 3;
 
-        this.chunkTexture = this.createTexture('chunkData', PIXELFORMAT_RGBA32F, chunkSize);
-
-        const minX = gsplatData.getProp('min_x', 'chunk');
-        const minY = gsplatData.getProp('min_y', 'chunk');
-        const minZ = gsplatData.getProp('min_z', 'chunk');
-        const maxX = gsplatData.getProp('max_x', 'chunk');
-        const maxY = gsplatData.getProp('max_y', 'chunk');
-        const maxZ = gsplatData.getProp('max_z', 'chunk');
-        const minScaleX = gsplatData.getProp('min_scale_x', 'chunk');
-        const minScaleY = gsplatData.getProp('min_scale_y', 'chunk');
-        const minScaleZ = gsplatData.getProp('min_scale_z', 'chunk');
-        const maxScaleX = gsplatData.getProp('max_scale_x', 'chunk');
-        const maxScaleY = gsplatData.getProp('max_scale_y', 'chunk');
-        const maxScaleZ = gsplatData.getProp('max_scale_z', 'chunk');
-
-        const chunkData = this.chunkTexture.lock();
-        for (let i = 0; i < numChunks; ++i) {
-            chunkData[i * 12 + 0] = minX[i];
-            chunkData[i * 12 + 1] = minY[i];
-            chunkData[i * 12 + 2] = minZ[i];
-            chunkData[i * 12 + 3] = maxX[i];
-            chunkData[i * 12 + 4] = maxY[i];
-            chunkData[i * 12 + 5] = maxZ[i];
-            chunkData[i * 12 + 6] = minScaleX[i];
-            chunkData[i * 12 + 7] = minScaleY[i];
-            chunkData[i * 12 + 8] = minScaleZ[i];
-            chunkData[i * 12 + 9] = maxScaleX[i];
-            chunkData[i * 12 + 10] = maxScaleY[i];
-            chunkData[i * 12 + 11] = maxScaleZ[i];
-        }
-        this.chunkTexture.unlock();
+        this.chunkTexture = this.createTexture('chunkData', PIXELFORMAT_RGBA32F, chunkSize, gsplatData.chunkData);
+        // const chunkData = this.chunkTexture.lock();
+        // chunkData.set(gsplatData.chunkData);
+        // this.chunkTexture.unlock();
     }
 
     destroy() {
@@ -136,7 +98,7 @@ class GSplatCompressed {
      * @param {Vec2} size - The width and height of the texture.
      * @returns {Texture} The created texture instance.
      */
-    createTexture(name, format, size) {
+    createTexture(name, format, size, data) {
         return new Texture(this.device, {
             name: name,
             width: size.x,
@@ -147,7 +109,8 @@ class GSplatCompressed {
             minFilter: FILTER_NEAREST,
             magFilter: FILTER_NEAREST,
             addressU: ADDRESS_CLAMP_TO_EDGE,
-            addressV: ADDRESS_CLAMP_TO_EDGE
+            addressV: ADDRESS_CLAMP_TO_EDGE,
+            ... data ? { levels: [data] } : { }
         });
     }
 }

--- a/src/scene/gsplat/gsplat-data.js
+++ b/src/scene/gsplat/gsplat-data.js
@@ -2,7 +2,6 @@ import { Color } from '../../core/math/color.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { Quat } from '../../core/math/quat.js';
 import { Vec3 } from '../../core/math/vec3.js';
-import { Vec4 } from '../../core/math/vec4.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 
 const vec3 = new Vec3();
@@ -178,7 +177,7 @@ class GSplatData {
      * @param {Vec3|null} [p] - the vector to receive splat position
      * @param {Quat|null} [r] - the quaternion to receive splat rotation
      * @param {Vec3|null} [s] - the vector to receive splat scale
-     * @param {Vec4|null} [c] - the vector to receive splat color
+     * @param {import('../../core/math/vec4.js').Vec4|null} [c] - the vector to receive splat color
      * @returns {SplatIterator} - The iterator
      */
     createIter(p, r, s, c) {


### PR DESCRIPTION
This PR:
- extracts compressed data functionality from `GSplatData` and places it into `GSplatCompressedData`
- adds a fast path for loading compressed data and calculating the focal point
- uses less memory when loading compressed data by allocating the required size and using it directly for texture upload (instead of duplicating the data as we did before)
- implements better memory usage when reading the input data stream

Large compressed scenes load roughly 4x faster (and nearly 10x faster when also calculating the focal point).

Load time for a 476MB compressed scene with 29M splats goes from:
5.1s (2.6s for focal point) to 556ms (2ms for focal point).

Uncompressed load time has also improved by about 10-20% due to streaming improvements.