### PR TITLE
Unify gsplat shaders

### DIFF
--- a/src/scene/gsplat/gsplat-compressed-material.js
+++ b/src/scene/gsplat/gsplat-compressed-material.js
@@ -11,255 +11,260 @@ import { ShaderGenerator } from "../shader-lib/programs/shader-generator.js";
 import { ShaderPass } from "../shader-pass.js";
 
 const splatCoreVS = /* glsl */ `
+    uniform mat4 matrix_model;
+    uniform mat4 matrix_view;
+    uniform mat4 matrix_projection;
 
-uniform mat4 matrix_model;
-uniform mat4 matrix_view;
-uniform mat4 matrix_projection;
+    uniform vec2 viewport;
+    uniform vec4 tex_params;                  // num splats, packed width, chunked width
 
-attribute vec3 vertex_position;
-attribute uint vertex_id_attrib;
+    uniform highp usampler2D splatOrder;
+    uniform highp usampler2D packedTexture;
+    uniform highp sampler2D chunkTexture;
 
-varying vec2 texCoord;
-varying vec4 color;
+    attribute vec3 vertex_position;
+    attribute uint vertex_id_attrib;
 
-#ifndef DITHER_NONE
-    varying float id;
-#endif
-
-uniform vec2 viewport;
-uniform vec4 bufferWidths;                  // packed width, chunked width, numSplats
-uniform highp usampler2D splatOrder;
-uniform highp usampler2D packedTexture;
-uniform highp sampler2D chunkTexture;
-
-uint orderId;
-uint splatId;
-ivec2 splatUV;
-ivec2 chunkUV;
-
-uvec4 packedData;
-vec4 chunkDataA;
-vec4 chunkDataB;
-vec4 chunkDataC;
-
-void calcUV() {
-    int packedWidth = int(bufferWidths.x);
-    int chunkWidth = int(bufferWidths.y);
-
-    // sample order texture
-    orderId = vertex_id_attrib + uint(vertex_position.z);
-    ivec2 orderUV = ivec2(
-        int(orderId) % packedWidth,
-        int(orderId) / packedWidth
-    );
-
-    // calculate splatUV
-    splatId = texelFetch(splatOrder, orderUV, 0).r;
-    splatUV = ivec2(
-        int(splatId) % packedWidth,
-        int(splatId) / packedWidth
-    );
-
-    // calculate chunkUV
-    int chunkId = int(splatId / 256u);
-    chunkUV = ivec2(
-        (chunkId % chunkWidth) * 3,
-        chunkId / chunkWidth
-    );
-}
-
-vec3 unpack111011(uint bits) {
-    return vec3(
-        float(bits >> 21u) / 2047.0,
-        float((bits >> 11u) & 0x3ffu) / 1023.0,
-        float(bits & 0x7ffu) / 2047.0
-    );
-}
-
-vec4 unpack8888(uint bits) {
-    return vec4(
-        float(bits >> 24u) / 255.0,
-        float((bits >> 16u) & 0xffu) / 255.0,
-        float((bits >> 8u) & 0xffu) / 255.0,
-        float(bits & 0xffu) / 255.0
-    );
-}
-
-float norm = 1.0 / (sqrt(2.0) * 0.5);
-
-vec4 unpackRotation(uint bits) {
-    float a = (float((bits >> 20u) & 0x3ffu) / 1023.0 - 0.5) * norm;
-    float b = (float((bits >> 10u) & 0x3ffu) / 1023.0 - 0.5) * norm;
-    float c = (float(bits & 0x3ffu) / 1023.0 - 0.5) * norm;
-    float m = sqrt(1.0 - (a * a + b * b + c * c));
-
-    uint mode = bits >> 30u;
-    if (mode == 0u) return vec4(m, a, b, c);
-    if (mode == 1u) return vec4(a, m, b, c);
-    if (mode == 2u) return vec4(a, b, m, c);
-    return vec4(a, b, c, m);
-}
-
-vec3 getPosition() {
-    return mix(chunkDataA.xyz, vec3(chunkDataA.w, chunkDataB.xy), unpack111011(packedData.x));
-}
-
-vec4 getRotation() {
-    return unpackRotation(packedData.y);
-}
-
-vec3 getScale() {
-    return exp(mix(vec3(chunkDataB.zw, chunkDataC.x), chunkDataC.yzw, unpack111011(packedData.z)));
-}
-
-vec4 getColor() {
-    return unpack8888(packedData.w);
-}
-
-mat3 quatToMat3(vec4 R) {
-    float x = R.x;
-    float y = R.y;
-    float z = R.z;
-    float w = R.w;
-    return mat3(
-        1.0 - 2.0 * (z * z + w * w),
-              2.0 * (y * z + x * w),
-              2.0 * (y * w - x * z),
-              2.0 * (y * z - x * w),
-        1.0 - 2.0 * (y * y + w * w),
-              2.0 * (z * w + x * y),
-              2.0 * (y * w + x * z),
-              2.0 * (z * w - x * y),
-        1.0 - 2.0 * (y * y + z * z)
-    );
-}
-
-// Given a rotation matrix and scale vector, compute 3d covariance A and B
-void calcCov3d(mat3 rot, vec3 scale, out vec3 covA, out vec3 covB) {
-    // M = S * R
-    mat3 M = transpose(mat3(
-        scale.x * rot[0],
-        scale.y * rot[1],
-        scale.z * rot[2]
-    ));
-    covA = vec3(dot(M[0], M[0]), dot(M[0], M[1]), dot(M[0], M[2]));
-    covB = vec3(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
-}
-
-// given the splat center (view space) and covariance A and B vectors, calculate
-// the v1 and v2 vectors for this view.
-vec4 calcV1V2(vec3 centerView, vec3 covA, vec3 covB, float focal, mat3 W) {
-
-    mat3 Vrk = mat3(
-        covA.x, covA.y, covA.z, 
-        covA.y, covB.x, covB.y,
-        covA.z, covB.y, covB.z
-    );
-
-    float J1 = focal / centerView.z;
-    vec2 J2 = -J1 / centerView.z * centerView.xy;
-    mat3 J = mat3(
-        J1, 0.0, J2.x, 
-        0.0, J1, J2.y, 
-        0.0, 0.0, 0.0
-    );
-
-    mat3 T = W * J;
-    mat3 cov = transpose(T) * Vrk * T;
-
-    float diagonal1 = cov[0][0] + 0.3;
-    float offDiagonal = cov[0][1];
-    float diagonal2 = cov[1][1] + 0.3;
-
-    float mid = 0.5 * (diagonal1 + diagonal2);
-    float radius = length(vec2((diagonal1 - diagonal2) / 2.0, offDiagonal));
-    float lambda1 = mid + radius;
-    float lambda2 = max(mid - radius, 0.1);
-    vec2 diagonalVector = normalize(vec2(offDiagonal, lambda1 - diagonal1));
-
-    vec2 v1 = min(sqrt(2.0 * lambda1), 1024.0) * diagonalVector;
-    vec2 v2 = min(sqrt(2.0 * lambda2), 1024.0) * vec2(diagonalVector.y, -diagonalVector.x);
-
-    return vec4(v1, v2);
-}
-
-vec4 evalSplat() {
-    // calculate source UVs
-    calcUV();
-
-    // read raw data
-    packedData = texelFetch(packedTexture, splatUV, 0);
-    chunkDataA = texelFetch(chunkTexture, chunkUV, 0);
-    chunkDataB = texelFetch(chunkTexture, ivec2(chunkUV.x + 1, chunkUV.y), 0);
-    chunkDataC = texelFetch(chunkTexture, ivec2(chunkUV.x + 2, chunkUV.y), 0);
-
-    mat4 modelView = matrix_view * matrix_model;
-    vec4 centerView = modelView * vec4(getPosition(), 1.0);
-    vec4 centerClip = matrix_projection * centerView;
-
-    // cull behind camera
-    if (centerClip.z < -centerClip.w || orderId >= uint(bufferWidths.z)) {
-        return vec4(0.0, 0.0, 2.0, 1.0);
-    }
-
-    // calculate the 3d covariance vectors from rotation and scale
-    vec3 covA, covB;
-    calcCov3d(quatToMat3(getRotation()), getScale(), covA, covB);
-
-    vec4 v1v2 = calcV1V2(centerView.xyz, covA, covB, viewport.x * matrix_projection[0][0], transpose(mat3(modelView)));
-
-    // early out tiny splats
-    // TODO: figure out length units and expose as uniform parameter
-    // TODO: perhaps make this a shader compile-time option
-    if (dot(v1v2.xy, v1v2.xy) < 4.0 && dot(v1v2.zw, v1v2.zw) < 4.0) {
-        return vec4(0.0, 0.0, 2.0, 1.0);
-    }
-
-    texCoord = vertex_position.xy;
-    color = getColor();
+    varying vec2 texCoord;
+    varying vec4 color;
 
     #ifndef DITHER_NONE
-        id = float(splatId);
+        varying float id;
     #endif
 
-    return centerClip + vec4((texCoord.x * v1v2.xy + texCoord.y * v1v2.zw) / viewport * centerClip.w, 0, 0);
-}
+    uint orderId;
+    uint splatId;
+    ivec2 packedUV;
+    ivec2 chunkUV;
+
+    vec4 chunkDataA;    // x: min_x, y: min_y, z: min_z, w: max_x
+    vec4 chunkDataB;    // x: max_y, y: max_z, z: scale_min_x, w: scale_min_y
+    vec4 chunkDataC;    // x: scale_min_z, y: scale_max_x, z: scale_max_y, w: scale_max_z
+    uvec4 packedData;   // x: position bits, y: rotation bits, z: scale bits, w: color bits
+
+    // calculate the current splat index and uvs
+    bool calcSplatUV() {
+        uint numSplats = uint(tex_params.x);
+        uint packedWidth = uint(tex_params.y);
+        uint chunkWidth = uint(tex_params.z);
+
+        // calculate splat index
+        orderId = vertex_id_attrib + uint(vertex_position.z);
+
+        // checkout for out of bounds
+        if (orderId >= numSplats) {
+            return false;
+        }
+
+        // calculate packedUV
+        ivec2 orderUV = ivec2(
+            int(orderId % packedWidth),
+            int(orderId / packedWidth)
+        );
+        splatId = texelFetch(splatOrder, orderUV, 0).r;
+        packedUV = ivec2(
+            int(splatId % packedWidth),
+            int(splatId / packedWidth)
+        );
+
+        // calculate chunkUV
+        uint chunkId = splatId / 256u;
+        chunkUV = ivec2(
+            int((chunkId % chunkWidth) * 3u),
+            int(chunkId / chunkWidth)
+        );
+
+        return true;
+    }
+
+    // read chunk and packed data from textures
+    void readData() {
+        chunkDataA = texelFetch(chunkTexture, chunkUV, 0);
+        chunkDataB = texelFetch(chunkTexture, ivec2(chunkUV.x + 1, chunkUV.y), 0);
+        chunkDataC = texelFetch(chunkTexture, ivec2(chunkUV.x + 2, chunkUV.y), 0);
+
+        // TODO: early out based on chunk data (before reading the huge packed data)
+
+        packedData = texelFetch(packedTexture, packedUV, 0);
+    }
+
+    vec3 unpack111011(uint bits) {
+        return vec3(
+            float(bits >> 21u) / 2047.0,
+            float((bits >> 11u) & 0x3ffu) / 1023.0,
+            float(bits & 0x7ffu) / 2047.0
+        );
+    }
+
+    vec4 unpack8888(uint bits) {
+        return vec4(
+            float(bits >> 24u) / 255.0,
+            float((bits >> 16u) & 0xffu) / 255.0,
+            float((bits >> 8u) & 0xffu) / 255.0,
+            float(bits & 0xffu) / 255.0
+        );
+    }
+
+    float norm = 1.0 / (sqrt(2.0) * 0.5);
+
+    vec4 unpackRotation(uint bits) {
+        float a = (float((bits >> 20u) & 0x3ffu) / 1023.0 - 0.5) * norm;
+        float b = (float((bits >> 10u) & 0x3ffu) / 1023.0 - 0.5) * norm;
+        float c = (float(bits & 0x3ffu) / 1023.0 - 0.5) * norm;
+        float m = sqrt(1.0 - (a * a + b * b + c * c));
+
+        uint mode = bits >> 30u;
+        if (mode == 0u) return vec4(m, a, b, c);
+        if (mode == 1u) return vec4(a, m, b, c);
+        if (mode == 2u) return vec4(a, b, m, c);
+        return vec4(a, b, c, m);
+    }
+
+    vec3 getPosition() {
+        return mix(chunkDataA.xyz, vec3(chunkDataA.w, chunkDataB.xy), unpack111011(packedData.x));
+    }
+
+    vec4 getRotation() {
+        return unpackRotation(packedData.y);
+    }
+
+    vec3 getScale() {
+        return exp(mix(vec3(chunkDataB.zw, chunkDataC.x), chunkDataC.yzw, unpack111011(packedData.z)));
+    }
+
+    vec4 getColor() {
+        return unpack8888(packedData.w);
+    }
+
+    mat3 quatToMat3(vec4 R) {
+        float x = R.x;
+        float y = R.y;
+        float z = R.z;
+        float w = R.w;
+        return mat3(
+            1.0 - 2.0 * (z * z + w * w),
+                2.0 * (y * z + x * w),
+                2.0 * (y * w - x * z),
+                2.0 * (y * z - x * w),
+            1.0 - 2.0 * (y * y + w * w),
+                2.0 * (z * w + x * y),
+                2.0 * (y * w + x * z),
+                2.0 * (z * w - x * y),
+            1.0 - 2.0 * (y * y + z * z)
+        );
+    }
+
+    // Given a rotation matrix and scale vector, compute 3d covariance A and B
+    void calcCov3d(mat3 rot, vec3 scale, out vec3 covA, out vec3 covB) {
+        // M = S * R
+        mat3 M = transpose(mat3(
+            scale.x * rot[0],
+            scale.y * rot[1],
+            scale.z * rot[2]
+        ));
+        covA = vec3(dot(M[0], M[0]), dot(M[0], M[1]), dot(M[0], M[2]));
+        covB = vec3(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
+    }
+
+    // given the splat center (view space) and covariance A and B vectors, calculate
+    // the v1 and v2 vectors for this view.
+    vec4 calcV1V2(vec3 centerView, vec3 covA, vec3 covB, float focal, mat3 W) {
+
+        mat3 Vrk = mat3(
+            covA.x, covA.y, covA.z, 
+            covA.y, covB.x, covB.y,
+            covA.z, covB.y, covB.z
+        );
+
+        float J1 = focal / centerView.z;
+        vec2 J2 = -J1 / centerView.z * centerView.xy;
+        mat3 J = mat3(
+            J1, 0.0, J2.x, 
+            0.0, J1, J2.y, 
+            0.0, 0.0, 0.0
+        );
+
+        mat3 T = W * J;
+        mat3 cov = transpose(T) * Vrk * T;
+
+        float diagonal1 = cov[0][0] + 0.3;
+        float offDiagonal = cov[0][1];
+        float diagonal2 = cov[1][1] + 0.3;
+
+        float mid = 0.5 * (diagonal1 + diagonal2);
+        float radius = length(vec2((diagonal1 - diagonal2) / 2.0, offDiagonal));
+        float lambda1 = mid + radius;
+        float lambda2 = max(mid - radius, 0.1);
+        vec2 diagonalVector = normalize(vec2(offDiagonal, lambda1 - diagonal1));
+
+        vec2 v1 = min(sqrt(2.0 * lambda1), 1024.0) * diagonalVector;
+        vec2 v2 = min(sqrt(2.0 * lambda2), 1024.0) * vec2(diagonalVector.y, -diagonalVector.x);
+
+        return vec4(v1, v2);
+    }
+
+    // evaluate the splat position
+    bool evalSplat(out vec4 result) {
+        mat4 modelView = matrix_view * matrix_model;
+        vec4 centerView = modelView * vec4(getPosition(), 1.0);
+        vec4 centerClip = matrix_projection * centerView;
+
+        // cull behind camera
+        if (centerClip.z < -centerClip.w) {
+            return false;
+        }
+
+        // calculate the 3d covariance vectors from rotation and scale
+        vec3 covA, covB;
+        calcCov3d(quatToMat3(getRotation()), getScale(), covA, covB);
+
+        vec4 v1v2 = calcV1V2(centerView.xyz, covA, covB, viewport.x * matrix_projection[0][0], transpose(mat3(modelView)));
+
+        // early out tiny splats
+        // TODO: figure out length units and expose as uniform parameter
+        // TODO: perhaps make this a shader compile-time option
+        if (dot(v1v2.xy, v1v2.xy) < 4.0 && dot(v1v2.zw, v1v2.zw) < 4.0) {
+            return false;
+        }
+
+        result = centerClip + vec4((vertex_position.x * v1v2.xy + vertex_position.y * v1v2.zw) / viewport * centerClip.w, 0, 0);
+
+        return true;
+    }
 `;
 
 const splatCoreFS = /* glsl */ `
-
-varying vec2 texCoord;
-varying vec4 color;
-
-#ifndef DITHER_NONE
-    varying float id;
-#endif
-
-#ifdef PICK_PASS
-    uniform vec4 uColor;
-#endif
-
-vec4 evalSplat() {
-
-    float A = -dot(texCoord, texCoord);
-    if (A < -4.0) discard;
-    float B = exp(A) * color.a;
-
-    #ifdef PICK_PASS
-        if (B < 0.3) discard;
-        return(uColor);
-    #endif
+    varying vec2 texCoord;
+    varying vec4 color;
 
     #ifndef DITHER_NONE
-        opacityDither(B, id * 0.013);
+        varying float id;
     #endif
 
-    #ifdef TONEMAP_ENABLED
-        return vec4(gammaCorrectOutput(toneMap(decodeGamma(color.rgb))), B);
-    #else
-        return vec4(color.rgb, B);
+    #ifdef PICK_PASS
+        uniform vec4 uColor;
     #endif
-}
+
+    vec4 evalSplat() {
+        float A = -dot(texCoord, texCoord);
+        if (A < -4.0) discard;
+        float B = exp(A) * color.a;
+
+        #ifdef PICK_PASS
+            if (B < 0.3) discard;
+            return(uColor);
+        #endif
+
+        #ifndef DITHER_NONE
+            opacityDither(B, id * 0.013);
+        #endif
+
+        #ifdef TONEMAP_ENABLED
+            return vec4(gammaCorrectOutput(toneMap(decodeGamma(color.rgb))), B);
+        #else
+            return vec4(color.rgb, B);
+        #endif
+    }
 `;
 
 class GSplatCompressedShaderGenerator {
@@ -301,9 +306,33 @@ class GSplatCompressedShaderGenerator {
 const gsplatCompressed = new GSplatCompressedShaderGenerator();
 
 const splatMainVS = `
+    vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
+
     void main(void)
     {
-        gl_Position = evalSplat();
+        // calculate splat uv
+        if (!calcSplatUV()) {
+            gl_Position = discardVec;
+            return;
+        }
+
+        // read data
+        readData();
+
+        vec4 pos;
+        if (!evalSplat(pos)) {
+            gl_Position = discardVec;
+            return;
+        }
+
+        gl_Position = pos;
+
+        texCoord = vertex_position.xy;
+        color = getColor();
+
+        #ifndef DITHER_NONE
+            id = float(splatId);
+        #endif
     }
 `;
 

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -66,7 +66,7 @@ class GSplatCompressed {
         const result = createGSplatCompressedMaterial(options);
         result.setParameter('packedTexture', this.packedTexture);
         result.setParameter('chunkTexture', this.chunkTexture);
-        result.setParameter('bufferWidths', new Float32Array([this.packedTexture.width, this.chunkTexture.width / 3, this.numSplats, 0]));
+        result.setParameter('tex_params', new Float32Array([this.numSplats, this.packedTexture.width, this.chunkTexture.width / 3, 0]));
         return result;
     }
 

--- a/src/scene/gsplat/gsplat-material.js
+++ b/src/scene/gsplat/gsplat-material.js
@@ -6,12 +6,33 @@ import { getProgramLibrary } from "../shader-lib/get-program-library.js";
 import { gsplat } from "./shader-generator-gsplat.js";
 
 const splatMainVS = `
+    vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
+
     void main(void)
     {
-        vec3 centerLocal = evalCenter();
-        vec4 centerWorld = matrix_model * vec4(centerLocal, 1.0);
+        // calculate splat uv
+        if (!calcSplatUV()) {
+            gl_Position = discardVec;
+            return;
+        }
 
-        gl_Position = evalSplat(centerWorld);
+        // read data
+        readData();
+
+        vec4 pos;
+        if (!evalSplat(pos)) {
+            gl_Position = discardVec;
+            return;
+        }
+
+        gl_Position = pos;
+
+        texCoord = vertex_position.xy;
+        color = getColor();
+
+        #ifndef DITHER_NONE
+            id = float(splatId);
+        #endif
     }
 `;
 

--- a/src/scene/gsplat/gsplat.js
+++ b/src/scene/gsplat/gsplat.js
@@ -88,9 +88,7 @@ class GSplat {
         result.setParameter('transformA', this.transformATexture);
         result.setParameter('transformB', this.transformBTexture);
         result.setParameter('transformC', this.transformCTexture);
-
-        const { width, height } = this.colorTexture;
-        result.setParameter('tex_params', new Float32Array([width, height, 1 / width, 1 / height]));
+        result.setParameter('tex_params', new Float32Array([this.numSplats, this.colorTexture.width, 0, 0]));
         return result;
     }
 


### PR DESCRIPTION
This PR aligns the compressed and uncompressed versions of gsplat shaders as far as possible.

This is done so users can customise both in a similar way.

It's not obvious from the PR diff, but now:
* both materials have the same `mainVS`, `mainFS` and `splatCoreFS` chunks
* functions and uniform names are shared when possible

A followup PR will further break the chunks for easier user customisation, most likely in engine v2 only.