### PR TITLE
Remove redundant StandardMaterial.shadingModel

### DIFF
--- a/examples/src/examples/graphics/lit-material.example.mjs
+++ b/examples/src/examples/graphics/lit-material.example.mjs
@@ -107,7 +107,6 @@ assetListLoader.load(() => {
     material.setParameter('texture_diffuseMap', assets.color.resource);
     material.setParameter('texture_glossMap', assets.gloss.resource);
     material.setParameter('texture_normalMap', assets.normal.resource);
-    material.shadingModel = pc.SPECULAR_BLINN;
     material.useSkybox = true;
     material.hasSpecular = true;
     material.hasSpecularityFactor = true;

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -21,7 +21,7 @@ import { http } from '../platform/net/http.js';
 
 import {
     LAYERID_DEPTH, LAYERID_IMMEDIATE, LAYERID_SKYBOX, LAYERID_UI, LAYERID_WORLD,
-    SORTMODE_NONE, SORTMODE_MANUAL, SPECULAR_BLINN
+    SORTMODE_NONE, SORTMODE_MANUAL
 } from '../scene/constants.js';
 import { setProgramLibrary } from '../scene/shader-lib/get-program-library.js';
 import { ProgramLibrary } from '../scene/shader-lib/program-library.js';
@@ -590,7 +590,6 @@ class AppBase extends EventHandler {
     _initDefaultMaterial() {
         const material = new StandardMaterial();
         material.name = "Default Material";
-        material.shadingModel = SPECULAR_BLINN;
         setDefaultMaterial(this.graphicsDevice, material);
     }
 

--- a/src/framework/parsers/material/json-standard-material.js
+++ b/src/framework/parsers/material/json-standard-material.js
@@ -6,8 +6,6 @@ import { Texture } from '../../../platform/graphics/texture.js';
 
 import { BoundingBox } from '../../../core/shape/bounding-box.js';
 
-import { SPECULAR_BLINN } from '../../../scene/constants.js';
-
 import { StandardMaterial } from '../../../scene/materials/standard-material.js';
 import { StandardMaterialValidator } from '../../../scene/materials/standard-material-validator.js';
 import { standardMaterialParameterTypes } from '../../../scene/materials/standard-material-parameters.js';
@@ -96,10 +94,6 @@ class JsonStandardMaterialParser {
     // convert any properties that are out of date
     // or from old versions into current version
     migrate(data) {
-        // replace old shader property with new shadingModel property
-        if (data.shadingModel === undefined) {
-            data.shadingModel = SPECULAR_BLINN;
-        }
         if (data.shader) delete data.shader;
 
         // make JS style

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -498,14 +498,6 @@ export const CUBEPROJ_NONE = 0;
 export const CUBEPROJ_BOX = 1;
 
 /**
- * Energy-conserving Blinn-Phong.
- *
- * @type {number}
- * @category Graphics
- */
-export const SPECULAR_BLINN = 1;
-
-/**
  * Multiply together the primary and secondary colors.
  *
  * @type {string}

--- a/src/scene/materials/lit-material-options-builder.js
+++ b/src/scene/materials/lit-material-options-builder.js
@@ -50,7 +50,6 @@ class LitMaterialOptionsBuilder {
         litOptions.customFragmentShader = null;
         litOptions.pixelSnap = material.pixelSnap;
 
-        litOptions.shadingModel = material.shadingModel;
         litOptions.ambientSH = material.ambientSH;
         litOptions.fastTbn = material.fastTbn;
         litOptions.twoSidedLighting = material.twoSidedLighting;

--- a/src/scene/materials/lit-material.js
+++ b/src/scene/materials/lit-material.js
@@ -1,5 +1,5 @@
 import { ShaderProcessorOptions } from '../../platform/graphics/shader-processor-options.js';
-import { DITHER_NONE, FRESNEL_SCHLICK, SPECOCC_AO, SPECULAR_BLINN } from "../constants.js";
+import { DITHER_NONE, FRESNEL_SCHLICK, SPECOCC_AO } from "../constants.js";
 import { Material } from './material.js';
 import { LitMaterialOptions } from './lit-material-options.js';
 import { LitMaterialOptionsBuilder } from './lit-material-options-builder.js';
@@ -32,8 +32,6 @@ class LitMaterial extends Material {
     useTonemap = true;
 
     useSkybox = true;
-
-    shadingModel = SPECULAR_BLINN;
 
     ambientSH = null;
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -259,7 +259,6 @@ class StandardMaterialOptionsBuilder {
         options.litOptions.customFragmentShader = stdMat.customFragmentShader;
         options.litOptions.pixelSnap = stdMat.pixelSnap;
 
-        options.litOptions.shadingModel = stdMat.shadingModel;
         options.litOptions.ambientSH = !!stdMat.ambientSH;
         options.litOptions.fastTbn = stdMat.fastTbn;
         options.litOptions.twoSidedLighting = stdMat.twoSidedLighting;

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -134,7 +134,6 @@ const standardMaterialParameterTypes = {
 
     cull: 'enum:cull',
     blendType: 'enum:blendType',
-    shadingModel: 'enum:shadingModel',
 
     useFog: 'boolean',
     useLighting: 'boolean',

--- a/src/scene/materials/standard-material-validator.js
+++ b/src/scene/materials/standard-material-validator.js
@@ -10,8 +10,7 @@ import {
     SPECOCC_AO, SPECOCC_GLOSSDEPENDENT, SPECOCC_NONE,
     BLEND_SUBTRACTIVE, BLEND_ADDITIVE, BLEND_NORMAL, BLEND_NONE, BLEND_PREMULTIPLIED,
     BLEND_MULTIPLICATIVE, BLEND_ADDITIVEALPHA, BLEND_MULTIPLICATIVE2X, BLEND_SCREEN,
-    BLEND_MIN, BLEND_MAX,
-    SPECULAR_BLINN
+    BLEND_MIN, BLEND_MAX
 } from '../constants.js';
 
 import { standardMaterialParameterTypes, standardMaterialRemovedParameters } from './standard-material-parameters.js';
@@ -56,9 +55,6 @@ class StandardMaterialValidator {
                 FUNC_NOTEQUAL,
                 FUNC_GREATEREQUAL,
                 FUNC_ALWAYS
-            ]),
-            shadingModel: this._createEnumValidator([
-                SPECULAR_BLINN
             ])
         };
     }

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -12,8 +12,7 @@ import {
     FRESNEL_SCHLICK,
     SHADER_DEPTH, SHADER_PICK,
     SHADER_PREPASS_VELOCITY,
-    SPECOCC_AO,
-    SPECULAR_BLINN
+    SPECOCC_AO
 } from '../constants.js';
 import { ShaderPass } from '../shader-pass.js';
 import { EnvLighting } from '../graphics/env-lighting.js';
@@ -519,8 +518,6 @@ const _tempColor = new Color();
  * @property {number} occludeSpecularIntensity Controls visibility of specular occlusion.
  * @property {boolean} occludeDirect Tells if AO should darken directional lighting. Defaults to
  * false.
- * @property {number} shadingModel Defines the shading model.
- * - {@link SPECULAR_BLINN}: Energy-conserving Blinn-Phong.
  * @property {number} fresnelModel Defines the formula used for Fresnel effect.
  * As a side-effect, enabling any Fresnel model changes the way diffuse and reflection components
  * are combined. When Fresnel is off, legacy non energy-conserving combining is used. When it is
@@ -1217,7 +1214,6 @@ function _defineMaterialProps() {
     _defineFlag('normalizeNormalMap', true);
     _defineFlag('opacityFadesSpecular', true);
     _defineFlag('occludeSpecular', SPECOCC_AO);
-    _defineFlag('shadingModel', SPECULAR_BLINN);
     _defineFlag('fresnelModel', FRESNEL_SCHLICK); // NOTE: this has been made to match the default shading model (to fix a bug)
     _defineFlag('useDynamicRefraction', false);
     _defineFlag('cubeMapProjection', CUBEPROJ_NONE);

--- a/src/scene/shader-lib/programs/lit-shader-options.js
+++ b/src/scene/shader-lib/programs/lit-shader-options.js
@@ -103,13 +103,6 @@ class LitShaderOptions {
     pixelSnap = false;
 
     /**
-     * The value of {@link StandardMaterial#shadingModel}.
-     *
-     * @type {number}
-     */
-    shadingModel = 0;
-
-    /**
      * If ambient spherical harmonics are used. Ambient SH replace prefiltered cubemap ambient on
      * certain platforms (mostly Android) for performance reasons.
      *

--- a/test/scene/materials/standard-material.test.mjs
+++ b/test/scene/materials/standard-material.test.mjs
@@ -1,4 +1,4 @@
-import { CUBEPROJ_NONE, DETAILMODE_MUL, DITHER_NONE, FRESNEL_SCHLICK, SPECOCC_AO, SPECULAR_BLINN } from '../../../src/scene/constants.js';
+import { CUBEPROJ_NONE, DETAILMODE_MUL, DITHER_NONE, FRESNEL_SCHLICK, SPECOCC_AO } from '../../../src/scene/constants.js';
 import { Color } from '../../../src/core/math/color.js';
 import { Material } from '../../../src/scene/materials/material.js';
 import { StandardMaterial } from '../../../src/scene/materials/standard-material.js';
@@ -240,7 +240,6 @@ describe('StandardMaterial', function () {
         expect(material.refraction).to.equal(0);
         expect(material.refractionIndex).to.equal(1.0 / 1.5);
         expect(material.dispersion).to.equal(0);
-        expect(material.shadingModel).to.equal(SPECULAR_BLINN);
 
         expect(material.specular).to.be.instanceof(Color);
         expect(material.specular.r).to.equal(0);

--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -152,7 +152,6 @@ const STANDARD_MAT_PROPS = [
     ['refraction', 'number'],
     ['refractionIndex', 'number'],
     ['dispersion', 'number'],
-    ['shadingModel', 'number'],
     ['specular', 'Color'],
     ['specularMap', 'Texture|null'],
     ['specularMapChannel', 'string'],


### PR DESCRIPTION
- Now that the Phong model has been removed, this parameter is hardcoded to BlinnPhong and that is never used during the shader generation or elsewhere, and so can be safely removed.
- SPECULAR_BLINN is also removed