### PR TITLE
Update alpha publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,22 +12,13 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      
+
       - name: Set up Node.js 18.x
         uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org/'
-
-      - name: Install Dependencies
-        run: npm install
-      
-      - name: Build PlayCanvas
-        run: npm run build
-
-      - name: Run Publint
-        run: npm run publint
 
       - name: Determine pre-release tag
         id: release-tag
@@ -36,10 +27,20 @@ jobs:
           echo "Detected tag: $TAG_NAME"
           if [[ "$TAG_NAME" == *-alpha.* ]]; then
             echo "tag=alpha" >> $GITHUB_ENV
+            npm version --no-git-tag-version $TAG_NAME
           else
             echo "tag=latest" >> $GITHUB_ENV
           fi
-      
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build PlayCanvas
+        run: npm run build
+
+      - name: Run Publint
+        run: npm run publint
+
       - name: Publish to npm
         run: npm publish --tag ${{ env.tag }}
         env:


### PR DESCRIPTION
This PR updates the version in package.json to match the tag when publishing an alpha build to npm.

This simplifies the process of creating an alpha build by requiring just a tag being pushed to the repo.