### PR TITLE
Invoke stopPropagation on pointer events handled by gizmo.

### DIFF
--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -322,6 +322,7 @@ class Gizmo extends EventHandler {
         const selection = this._getSelection(e.offsetX, e.offsetY);
         if (selection[0]) {
             e.preventDefault();
+            e.stopPropagation();
         }
         this.fire(Gizmo.EVENT_POINTERDOWN, e.offsetX, e.offsetY, selection[0]);
     }
@@ -337,6 +338,7 @@ class Gizmo extends EventHandler {
         const selection = this._getSelection(e.offsetX, e.offsetY);
         if (selection[0]) {
             e.preventDefault();
+            e.stopPropagation();
         }
         this.fire(Gizmo.EVENT_POINTERMOVE, e.offsetX, e.offsetY, selection[0]);
     }


### PR DESCRIPTION
When handling a pointer event also invoke `stopPropagation`. Otherwise other pointer event handlers still get called.