### PR TITLE
WebXR - fix depth sensing on quest 3

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -477,19 +477,24 @@ class XrManager extends EventHandler {
             if (options && options.depthSensing && this.depthSensing.supported) {
                 opts.optionalFeatures.push('depth-sensing');
 
-                const usagePreference = [XRDEPTHSENSINGUSAGE_CPU];
-                const dataFormatPreference = [XRDEPTHSENSINGFORMAT_L8A8];
+                const usagePreference = [];
+                const dataFormatPreference = [];
 
-                if (options.depthSensing.usagePreference) {
-                    const ind = usagePreference.indexOf(options.depthSensing.usagePreference);
-                    if (ind !== -1) usagePreference.splice(ind, 1);
-                    usagePreference.unshift(options.depthSensing.usagePreference);
-                }
+                if (!navigator.userAgent.includes('OculusBrowser')) {
+                    usagePreference.push(XRDEPTHSENSINGUSAGE_CPU);
+                    dataFormatPreference.push(XRDEPTHSENSINGFORMAT_L8A8);
 
-                if (options.depthSensing.dataFormatPreference) {
-                    const ind = dataFormatPreference.indexOf(options.depthSensing.dataFormatPreference);
-                    if (ind !== -1) dataFormatPreference.splice(ind, 1);
-                    dataFormatPreference.unshift(options.depthSensing.dataFormatPreference);
+                    if (options.depthSensing.usagePreference) {
+                        const ind = usagePreference.indexOf(options.depthSensing.usagePreference);
+                        if (ind !== -1) usagePreference.splice(ind, 1);
+                        usagePreference.unshift(options.depthSensing.usagePreference);
+                    }
+
+                    if (options.depthSensing.dataFormatPreference) {
+                        const ind = dataFormatPreference.indexOf(options.depthSensing.dataFormatPreference);
+                        if (ind !== -1) dataFormatPreference.splice(ind, 1);
+                        dataFormatPreference.unshift(options.depthSensing.dataFormatPreference);
+                    }
                 }
 
                 opts.depthSensing = {


### PR DESCRIPTION
A recent update of OculusBrowser depth sensing implementation broke access to it.
There was an update to the WebXR Depth Sensing specs and implementation of it on Meta Quest: https://github.com/immersive-web/depth-sensing/pull/49
This PR ensures that we take that edge case into account.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
