### PR TITLE
[Fix] Stencil clearing was not setting up the mask correctly

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2314,6 +2314,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
                     this.gl.clearStencil(stencil);
                     this.clearStencil = stencil;
                 }
+
+                gl.stencilMask(0xFF);
+                this.stencilWriteMaskFront = 0xFF;
+                this.stencilWriteMaskBack = 0xFF;
             }
 
             // Clear the frame buffer


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/6776

- it sets it up now to not depend on the state from before.