### PR TITLE
[BREAKING] Remove CURVE_CATMULL and CURVE_CARDINAL

### DIFF
--- a/src/core/math/constants.js
+++ b/src/core/math/constants.js
@@ -15,27 +15,7 @@ export const CURVE_LINEAR = 0;
 export const CURVE_SMOOTHSTEP = 1;
 
 /**
- * A Catmull-Rom spline interpolation scheme. This interpolation scheme is deprecated. Use
- * CURVE_SPLINE instead.
- *
- * @type {number}
- * @deprecated
- * @ignore
- */
-export const CURVE_CATMULL = 2;
-
-/**
- * A cardinal spline interpolation scheme. This interpolation scheme is deprecated. Use
- * CURVE_SPLINE instead.
- *
- * @type {number}
- * @deprecated
- * @ignore
- */
-export const CURVE_CARDINAL = 3;
-
-/**
- * Cardinal spline interpolation scheme. For Catmull-Rom, specify curve tension 0.5.
+ * Cardinal spline interpolation scheme. For a Catmull-Rom spline, specify a curve tension of 0.5.
  *
  * @type {number}
  * @category Math
@@ -43,7 +23,7 @@ export const CURVE_CARDINAL = 3;
 export const CURVE_SPLINE = 4;
 
 /**
- * A stepped interpolator, free from the shackles of blending.
+ * A stepped interpolator that does not perform any blending.
  *
  * @type {number}
  * @category Math

--- a/src/core/math/curve-evaluator.js
+++ b/src/core/math/curve-evaluator.js
@@ -1,4 +1,4 @@
-import { CURVE_CARDINAL, CURVE_CATMULL, CURVE_LINEAR, CURVE_SMOOTHSTEP, CURVE_SPLINE, CURVE_STEP } from './constants.js';
+import { CURVE_LINEAR, CURVE_SMOOTHSTEP, CURVE_SPLINE, CURVE_STEP } from './constants.js';
 import { math } from './math.js';
 
 /**
@@ -126,23 +126,11 @@ class CurveEvaluator {
                 this._recip = (isFinite(diff) ? diff : 0);
                 this._p0 = keys[index][1];
                 this._p1 = keys[index + 1][1];
-                if (this._isHermite()) {
+                if (this._curve.type === CURVE_SPLINE) {
                     this._calcTangents(keys, index);
                 }
             }
         }
-    }
-
-    /**
-     * Returns whether the curve is a hermite.
-     *
-     * @returns {boolean} True if the curve is a hermite and false otherwise.
-     * @private
-     */
-    _isHermite() {
-        return this._curve.type === CURVE_CATMULL ||
-               this._curve.type === CURVE_CARDINAL ||
-               this._curve.type === CURVE_SPLINE;
     }
 
     /**
@@ -187,7 +175,7 @@ class CurveEvaluator {
             const a_ = b[1] + (a[1] - b[1]) * (isFinite(s1) ? s1 : 0);
             const d_ = c[1] + (d[1] - c[1]) * (isFinite(s2) ? s2 : 0);
 
-            const tension = (this._curve.type === CURVE_CATMULL) ? 0.5 : this._curve.tension;
+            const tension = this._curve.tension;
 
             this._m0 = tension * (c[1] - a_);
             this._m1 = tension * (d_ - b[1]);

--- a/src/core/math/curve.js
+++ b/src/core/math/curve.js
@@ -29,7 +29,7 @@ class Curve {
     /**
      * Controls how {@link CURVE_SPLINE} tangents are calculated. Valid range is between 0 and 1
      * where 0 results in a non-smooth curve (equivalent to linear interpolation) and 1 results in
-     * a very smooth curve. Use 0.5 for a Catmull-rom spline.
+     * a very smooth curve. Use 0.5 for a Catmull-Rom spline.
      *
      * @type {number}
      */


### PR DESCRIPTION
These were deprecated and hidden from the public API in 2019 by @slimbuck: https://github.com/playcanvas/engine/commit/461fa6e116b02b8d7b2c72baa7a0be3a79087e3b

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
