### PR TITLE
Remove redundant @ignore tags

### DIFF
--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -1,10 +1,8 @@
 import { Tracing } from "./tracing.js";
 
 /**
- * Engine debug log system. Note that the logging only executes in the
- * debug build of the engine, and is stripped out in other builds.
- *
- * @ignore
+ * Engine debug log system. Note that the logging only executes in the debug build of the engine,
+ * and is stripped out in other builds.
  */
 class Debug {
     /**
@@ -161,8 +159,6 @@ class Debug {
 
 /**
  * A helper debug functionality.
- *
- * @ignore
  */
 class DebugHelper {
     /**

--- a/src/core/event-handle.js
+++ b/src/core/event-handle.js
@@ -1,7 +1,9 @@
 import { Debug } from '../core/debug.js';
 
 /**
- * Event Handle that is created by {@link EventHandler} and can be used for easier event removal and management.
+ * Event Handle that is created by {@link EventHandler} and can be used for easier event removal
+ * and management.
+ *
  * @example
  * const evt = obj.on('test', (a, b) => {
  *     console.log(a + b);

--- a/src/core/event-handle.js
+++ b/src/core/event-handle.js
@@ -14,16 +14,16 @@ import { Debug } from '../core/debug.js';
  * obj.fire('test'); // this will not trigger an event
  * @example
  * // store an array of event handles
- * let events = [ ];
+ * let events = [];
  *
- * events.push(objA.on('testA', () => { }));
- * events.push(objB.on('testB', () => { }));
+ * events.push(objA.on('testA', () => {}));
+ * events.push(objB.on('testB', () => {}));
  *
  * // when needed, remove all events
  * events.forEach((evt) => {
  *     evt.off();
  * });
- * events = [ ];
+ * events = [];
  */
 class EventHandle {
     /**

--- a/src/core/event-handle.js
+++ b/src/core/event-handle.js
@@ -96,6 +96,7 @@ class EventHandle {
 
     /**
      * Mark if event has been removed.
+     *
      * @type {boolean}
      * @ignore
      */
@@ -106,7 +107,9 @@ class EventHandle {
 
     /**
      * True if event has been removed.
+     *
      * @type {boolean}
+     * @ignore
      */
     get removed() {
         return this._removed;

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -21,7 +21,7 @@ import { EventHandle } from './event-handle.js';
  * const obj = new EventHandlerSubclass();
  *
  * // subscribe to an event
- * obj.on('hello', function (str) {
+ * obj.on('hello', (str) => {
  *     console.log('event hello is fired', str);
  * });
  *
@@ -96,12 +96,12 @@ class EventHandler {
      * current this.
      * @returns {EventHandle} Can be used for removing event in the future.
      * @example
-     * obj.on('test', function (a, b) {
+     * obj.on('test', (a, b) => {
      *     console.log(a + b);
      * });
      * obj.fire('test', 1, 2); // prints 3 to the console
      * @example
-     * const evt = obj.on('test', function (a, b) {
+     * const evt = obj.on('test', (a, b) => {
      *     console.log(a + b);
      * });
      * // some time later
@@ -121,7 +121,7 @@ class EventHandler {
      * current this.
      * @returns {EventHandle} - can be used for removing event in the future.
      * @example
-     * obj.once('test', function (a, b) {
+     * obj.once('test', (a, b) => {
      *     console.log(a + b);
      * });
      * obj.fire('test', 1, 2); // prints 3 to the console
@@ -141,8 +141,7 @@ class EventHandler {
      * @param {object} [scope] - Scope that was used as the this when the event is fired.
      * @returns {EventHandler} Self for chaining.
      * @example
-     * const handler = function () {
-     * };
+     * const handler = () => {};
      * obj.on('test', handler);
      *
      * obj.off(); // Removes all events
@@ -288,7 +287,7 @@ class EventHandler {
      * @param {string} name - The name of the event to test.
      * @returns {boolean} True if the object has handlers bound to the specified event name.
      * @example
-     * obj.on('test', function () { }); // bind an event to 'test'
+     * obj.on('test', () => {}); // bind an event to 'test'
      * obj.hasEvent('test'); // returns true
      * obj.hasEvent('hello'); // returns false
      */

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -3,7 +3,6 @@
  *
  * @param {string} str - String.
  * @returns {number} Hash value.
- * @ignore
  */
 function hashCode(str) {
     let hash = 0;
@@ -22,7 +21,6 @@ function hashCode(str) {
  *.
  * @param {number[]|Uint32Array} array - Array of 32bit integer numbers to hash.
  * @returns {number} 32bit unsigned integer hash value.
- * @ignore
  */
 function hash32Fnv1a(array) {
     const prime = 16777619;

--- a/src/core/math/bit-packing.js
+++ b/src/core/math/bit-packing.js
@@ -2,7 +2,6 @@
  * BitPacking API - functionality for operating on values stored as bits in a number.
  *
  * @namespace
- * @ignore
  */
 const BitPacking = {
 

--- a/src/core/math/blue-noise.js
+++ b/src/core/math/blue-noise.js
@@ -21,8 +21,6 @@ const blueNoiseData = () => {
 
 /**
  * Blue noise based random numbers API.
- *
- * @ignore
  */
 class BlueNoise {
     seed = 0;

--- a/src/core/math/curve-evaluator.js
+++ b/src/core/math/curve-evaluator.js
@@ -3,8 +3,6 @@ import { math } from './math.js';
 
 /**
  * A class for evaluating a curve at a specific time.
- *
- * @ignore
  */
 class CurveEvaluator {
     /** @private */

--- a/src/core/math/random.js
+++ b/src/core/math/random.js
@@ -7,14 +7,12 @@ const _goldenAngle = 2.399963229728653;
  * Random API.
  *
  * @namespace
- * @ignore
  */
 const random = {
     /**
      * Return a pseudo-random 2D point inside a unit circle with uniform distribution.
      *
      * @param {import('./vec2.js').Vec2} point - The returned generated point.
-     * @ignore
      */
     circlePoint(point) {
         const r = Math.sqrt(Math.random());
@@ -30,7 +28,6 @@ const random = {
      * @param {import('./vec2.js').Vec2} point - The returned generated point.
      * @param {number} index - Index of the point to generate, in the range from 0 to numPoints - 1.
      * @param {number} numPoints - The total number of points of the set.
-     * @ignore
      */
     circlePointDeterministic(point, index, numPoints) {
         const theta = index * _goldenAngle;
@@ -54,7 +51,6 @@ const random = {
      * of 0 and 1. Defaults to 0.
      * @param {number} [end] - Part on the sphere along y axis to stop the points, in the range of
      * 0 and 1. Defaults to 1.
-     * @ignore
      */
     spherePointDeterministic(point, index, numPoints, start = 0, end = 1) {
 
@@ -81,7 +77,6 @@ const random = {
      *
      * @param {number} i - The index in the sequence to return.
      * @returns {number} The pseudo-random value.
-     * @ignore
      */
     radicalInverse(i) {
         let bits = ((i << 16) | (i >>> 16)) >>> 0;

--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -1,8 +1,6 @@
 /**
  * A pool of reusable objects of the same type. Designed to promote reuse of objects to reduce
  * garbage collection.
- *
- * @ignore
  */
 class ObjectPool {
     /**

--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -359,12 +359,18 @@ class Preprocessor {
 
     /**
      * Very simple expression evaluation, handles cases:
-     * expression
-     * defined(expression)
-     * !defined(expression)
+     *
+     * - expression
+     * - defined(expression)
+     * - !defined(expression)
      *
      * But does not handle more complex cases, which would require more complex system:
-     * defined(A) || defined(B)
+     *
+     * - defined(A) || defined(B)
+     *
+     * @param {string} expression - The expression to evaluate.
+     * @param {Map<string, string>} defines - A map containing key-value pairs of defines.
+     * @returns {object} Returns an object containing the result of the evaluation and an error flag.
      */
     static evaluate(expression, defines) {
 

--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -36,8 +36,6 @@ const INCLUDE = /include[ \t]+"([\w-]+)"\r?(?:\n|$)/g;
 /**
  * Pure static class implementing subset of C-style preprocessor.
  * inspired by: https://github.com/dcodeIO/Preprocessor.js
- *
- * @ignore
  */
 class Preprocessor {
     /**

--- a/src/core/ref-counted-cache.js
+++ b/src/core/ref-counted-cache.js
@@ -1,7 +1,5 @@
 /**
  * Class implementing reference counting cache for objects.
- *
- * @ignore
  */
 class RefCountedCache {
     /**

--- a/src/core/sort.js
+++ b/src/core/sort.js
@@ -2,7 +2,6 @@
  * @param {{priority: number}} a - First object with priority property.
  * @param {{priority: number}} b - Second object with priority property.
  * @returns {number} A number indicating the relative position.
- * @ignore
  */
 const cmpPriority = (a, b) => a.priority - b.priority;
 
@@ -10,6 +9,5 @@ const cmpPriority = (a, b) => a.priority - b.priority;
  * @param {Array<{priority: number}>} arr - Array to be sorted in place where each element contains
  * an object with at least a priority property.
  * @returns {Array<{priority: number}>} In place sorted array.
- * @ignore
  */
 export const sortPriority = arr => arr.sort(cmpPriority);

--- a/src/core/string-ids.js
+++ b/src/core/string-ids.js
@@ -1,7 +1,5 @@
 /**
  * A cache for assigning unique numerical ids to strings.
- *
- * @ignore
  */
 class StringIds {
     /** @type {Map<string, number>} */

--- a/src/framework/anim/controller/anim-blend-tree-1d.js
+++ b/src/framework/anim/controller/anim-blend-tree-1d.js
@@ -5,8 +5,6 @@ import { AnimBlendTree } from './anim-blend-tree.js';
 /**
  * An AnimBlendTree that calculates its weights using a 1D algorithm based on the thesis
  * http://runevision.com/thesis/rune_skovbo_johansen_thesis.pdf Chapter 6.
- *
- * @ignore
  */
 class AnimBlendTree1D extends AnimBlendTree {
     /**

--- a/src/framework/anim/controller/anim-blend-tree-2d-cartesian.js
+++ b/src/framework/anim/controller/anim-blend-tree-2d-cartesian.js
@@ -6,8 +6,6 @@ import { AnimBlendTree } from './anim-blend-tree.js';
 /**
  * An AnimBlendTree that calculates its weights using a 2D Cartesian algorithm based on the thesis
  * http://runevision.com/thesis/rune_skovbo_johansen_thesis.pdf Chapter 6 Section 3.
- *
- * @ignore
  */
 class AnimBlendTreeCartesian2D extends AnimBlendTree {
     static _p = new Vec2();

--- a/src/framework/anim/controller/anim-blend-tree-2d-directional.js
+++ b/src/framework/anim/controller/anim-blend-tree-2d-directional.js
@@ -6,8 +6,6 @@ import { AnimBlendTree } from './anim-blend-tree.js';
 /**
  * An AnimBlendTree that calculates its weights using a 2D directional algorithm based on the thesis
  * http://runevision.com/thesis/rune_skovbo_johansen_thesis.pdf Chapter 6.
- *
- * @ignore
  */
 class AnimBlendTreeDirectional2D extends AnimBlendTree {
     static _p = new Vec2();

--- a/src/framework/anim/controller/anim-blend-tree-direct.js
+++ b/src/framework/anim/controller/anim-blend-tree-direct.js
@@ -2,8 +2,6 @@ import { AnimBlendTree } from './anim-blend-tree.js';
 
 /**
  * An AnimBlendTree that calculates normalized weight values based on the total weight.
- *
- * @ignore
  */
 class AnimBlendTreeDirect extends AnimBlendTree {
     calculateWeights() {

--- a/src/framework/anim/controller/anim-blend-tree.js
+++ b/src/framework/anim/controller/anim-blend-tree.js
@@ -5,8 +5,6 @@ import { AnimNode } from './anim-node.js';
  * of other AnimBlendTrees, in order to create a hierarchy of AnimNodes. It takes a blend type as
  * an argument which defines which function should be used to determine the weights of each of its
  * children, based on the current parameter value.
- *
- * @ignore
  */
 class AnimBlendTree extends AnimNode {
     /**

--- a/src/framework/anim/controller/anim-node.js
+++ b/src/framework/anim/controller/anim-node.js
@@ -4,8 +4,6 @@ import { Vec2 } from '../../../core/math/vec2.js';
  * AnimNodes are used to represent a single animation track in the current state. Each state can
  * contain multiple AnimNodes, in which case they are stored in a BlendTree hierarchy, which will
  * control the weight (contribution to the states final animation) of its child AnimNodes.
- *
- * @ignore
  */
 class AnimNode {
     /**

--- a/src/framework/anim/controller/anim-state.js
+++ b/src/framework/anim/controller/anim-state.js
@@ -15,8 +15,6 @@ import {
  * AnimNode or a AnimBlendTree of multiple AnimNodes, which will be used to animate the Entity
  * while the state is active. An AnimState will stay active and play as long as there is no
  * AnimTransition with its conditions met that has that AnimState as its source state.
- *
- * @ignore
  */
 class AnimState {
     /** @private */

--- a/src/framework/anim/controller/anim-transition.js
+++ b/src/framework/anim/controller/anim-transition.js
@@ -7,8 +7,6 @@ import {
  * each frame, the controller tests to see if any of the AnimTransitions have the current AnimState
  * as their source (from) state. If so and the AnimTransitions parameter based conditions are met,
  * the controller will transition to the destination state.
- *
- * @ignore
  */
 class AnimTransition {
     /**

--- a/src/framework/anim/evaluator/anim-cache.js
+++ b/src/framework/anim/evaluator/anim-cache.js
@@ -4,8 +4,6 @@ import { INTERPOLATION_CUBIC, INTERPOLATION_LINEAR, INTERPOLATION_STEP } from '.
 
 /**
  * Internal cache data for the evaluation of a single curve timeline.
- *
- * @ignore
  */
 class AnimCache {
     /**

--- a/src/framework/anim/evaluator/anim-target-value.js
+++ b/src/framework/anim/evaluator/anim-target-value.js
@@ -6,8 +6,6 @@ import { math } from '../../../core/math/math.js';
 /**
  * Used to store and update the value of an animation target. This combines the values of multiple
  * layer targets into a single value.
- *
- * @ignore
  */
 class AnimTargetValue {
     static TYPE_QUAT = 'quaternion';

--- a/src/framework/asset/asset-file.js
+++ b/src/framework/asset/asset-file.js
@@ -1,7 +1,5 @@
 /**
  * Wraps a source of asset data.
- *
- * @ignore
  */
 class AssetFile {
     constructor(url = '', filename = '', hash = null, size = null, opt = null, contents = null) {

--- a/src/framework/components/audio-listener/system.js
+++ b/src/framework/components/audio-listener/system.js
@@ -31,7 +31,7 @@ class AudioListenerComponentSystem extends ComponentSystem {
         this.schema = _schema;
 
         this.manager = app.soundManager;
-        Debug.assert(this.manager, "AudioListenerComponentSystem cannot be created witout sound manager");
+        Debug.assert(this.manager, "AudioListenerComponentSystem cannot be created without sound manager");
 
         this.current = null;
 

--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -5,8 +5,6 @@ let _ammoVec1, _ammoQuat, _ammoTransform;
 /**
  * Creates a trigger object used to create internal physics objects that interact with rigid bodies
  * and trigger collision events with no collision response.
- *
- * @ignore
  */
 class Trigger {
     /**

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -13,7 +13,6 @@ import { getApplication } from './globals.js';
  * @param {Component} a - First object with `order` property.
  * @param {Component} b - Second object with `order` property.
  * @returns {number} A number indicating the relative position.
- * @ignore
  */
 const cmpStaticOrder = (a, b) => a.constructor.order - b.constructor.order;
 
@@ -21,19 +20,16 @@ const cmpStaticOrder = (a, b) => a.constructor.order - b.constructor.order;
  * @param {Array<Component>} arr - Array to be sorted in place where each element contains
  * an object with a static `order` property.
  * @returns {Array<Component>} In place sorted array.
- * @ignore
  */
 const sortStaticOrder = arr => arr.sort(cmpStaticOrder);
 
 /**
  * @type {GraphNode[]}
- * @ignore
  */
 const _enableList = [];
 
 /**
  * @type {Array<Array<Component>>}
- * @ignore
  */
 const tmpPool = [];
 
@@ -43,7 +39,6 @@ const getTempArray = () => {
 
 /**
  * @param {Array<Component>} a - Array to return back to pool.
- * @ignore
  */
 const releaseTempArray = (a) => {
     a.length = 0;
@@ -496,7 +491,7 @@ class Entity extends GraphNode {
     /**
      * @param {GraphNode} node - The node to update.
      * @param {boolean} enabled - Enable or disable the node.
-     * @private
+     * @protected
      */
     _notifyHierarchyStateChanged(node, enabled) {
         let enableFirst = false;
@@ -530,7 +525,7 @@ class Entity extends GraphNode {
 
     /**
      * @param {boolean} enabled - Enable or disable the node.
-     * @private
+     * @protected
      */
     _onHierarchyStateChanged(enabled) {
         super._onHierarchyStateChanged(enabled);

--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -9,8 +9,6 @@ const lights = [[], [], []];
 
 /**
  * A render pass implementing rendering of mesh instances into a pick buffer.
- *
- * @ignore
  */
 class RenderPassPicker extends RenderPass {
     /** @type {import('../../platform/graphics/bind-group.js').BindGroup[]} */

--- a/src/framework/handlers/untar.js
+++ b/src/framework/handlers/untar.js
@@ -3,8 +3,6 @@ import { EventHandler } from '../../core/event-handler.js';
 /**
  * A utility class for untaring archives from a fetch request. It processes files from a tar file
  * in a streamed manner, so asset parsing can happen in parallel instead of all at once at the end.
- *
- * @ignore
  */
 class Untar extends EventHandler {
     /**
@@ -90,7 +88,6 @@ class Untar extends EventHandler {
      *
      * @param {Promise} fetchPromise - A Promise object returned from a fetch request.
      * @param {string} assetsPrefix - Assets registry files prefix.
-     * @ignore
      */
     constructor(fetchPromise, assetsPrefix = '') {
         super();
@@ -110,7 +107,6 @@ class Untar extends EventHandler {
      * @param {boolean} done - True when reading data is complete.
      * @param {Uint8Array} value - Chunk of data read from a stream.
      * @returns {Promise|null} Return new pump Promise or null when no more data is available.
-     * @ignore
      */
     pump(done, value) {
         if (done) {
@@ -139,7 +135,6 @@ class Untar extends EventHandler {
      *
      * @returns {boolean} True if file was successfully read and more data is potentially available for
      * processing.
-     * @ignore
      */
     readFile() {
         if (!this.headerRead && this.bytesReceived > (this.bytesRead + this.headerSize)) {

--- a/src/framework/lightmapper/render-pass-lightmapper.js
+++ b/src/framework/lightmapper/render-pass-lightmapper.js
@@ -4,8 +4,6 @@ import { SHADER_FORWARD } from '../../scene/constants.js';
 
 /**
  * A render pass implementing rendering of mesh instance receivers for light-mapper.
- *
- * @ignore
  */
 class RenderPassLightmapper extends RenderPass {
     /** @type {import('../../platform/graphics/bind-group.js').BindGroup[]} */

--- a/src/framework/parsers/draco-decoder.js
+++ b/src/framework/parsers/draco-decoder.js
@@ -231,7 +231,6 @@ const dracoInitialize = (config) => {
  * @param {ArrayBuffer} buffer - The draco data to decode.
  * @param {Function} callback - Callback function to receive decoded result.
  * @returns {boolean} True if the draco worker was initialized and false otherwise.
- * @ignore
  */
 const dracoDecode = (buffer, callback) => {
     if (!initializeWorkers()) {

--- a/src/framework/parsers/texture/basis.js
+++ b/src/framework/parsers/texture/basis.js
@@ -8,8 +8,6 @@ import { TextureParser } from './texture.js';
 
 /**
  * Parser for basis files.
- *
- * @ignore
  */
 class BasisParser extends TextureParser {
     constructor(registry, device) {

--- a/src/framework/parsers/texture/dds.js
+++ b/src/framework/parsers/texture/dds.js
@@ -17,8 +17,6 @@ import { TextureParser } from './texture.js';
 
 /**
  * Legacy texture parser for dds files.
- *
- * @ignore
  */
 class DdsParser extends TextureParser {
     constructor(registry) {

--- a/src/framework/parsers/texture/hdr.js
+++ b/src/framework/parsers/texture/hdr.js
@@ -16,8 +16,6 @@ import { TextureParser } from './texture.js';
 
 /**
  * Texture parser for hdr files.
- *
- * @ignore
  */
 class HdrParser extends TextureParser {
     constructor(registry) {

--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -14,8 +14,6 @@ import { TextureParser } from './texture.js';
 
 /**
  * Parser for browser-supported image formats.
- *
- * @ignore
  */
 class ImgParser extends TextureParser {
     constructor(registry, device) {

--- a/src/framework/parsers/texture/ktx.js
+++ b/src/framework/parsers/texture/ktx.js
@@ -50,8 +50,6 @@ function createContainer(pixelFormat, buffer, byteOffset, byteSize) {
 
 /**
  * Texture parser for ktx files.
- *
- * @ignore
  */
 class KtxParser extends TextureParser {
     constructor(registry) {

--- a/src/framework/parsers/texture/ktx2.js
+++ b/src/framework/parsers/texture/ktx2.js
@@ -16,8 +16,6 @@ const KHRConstants = {
 
 /**
  * Texture parser for ktx2 files.
- *
- * @ignore
  */
 class Ktx2Parser extends TextureParser {
     constructor(registry, device) {

--- a/src/framework/parsers/texture/texture.js
+++ b/src/framework/parsers/texture/texture.js
@@ -1,8 +1,6 @@
 /**
  * Interface to a texture parser. Implementations of this interface handle the loading
  * and opening of texture assets.
- *
- * @ignore
  */
 class TextureParser {
     /* eslint-disable jsdoc/require-returns-check */

--- a/src/framework/stats.js
+++ b/src/framework/stats.js
@@ -2,8 +2,6 @@ import { getApplication } from './globals.js';
 
 /**
  * Records performance-related statistics related to the application.
- *
- * @ignore
  */
 class ApplicationStats {
     /**

--- a/src/framework/xr/xr-hand.js
+++ b/src/framework/xr/xr-hand.js
@@ -9,7 +9,6 @@ import { XrJoint } from './xr-joint.js';
 
 /**
  * @type {string[][]}
- * @ignore
  */
 let fingerJointIds = [];
 

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -4,13 +4,11 @@ import { Vec3 } from '../../core/math/vec3.js';
 
 /**
  * @type {Vec3[]}
- * @ignore
  */
 const poolVec3 = [];
 
 /**
  * @type {Quat[]}
- * @ignore
  */
 const poolQuat = [];
 

--- a/src/platform/audio/capabilities.js
+++ b/src/platform/audio/capabilities.js
@@ -2,7 +2,6 @@
  * Reports whether this device supports the Web Audio API.
  *
  * @returns {boolean} True if Web Audio is supported and false otherwise.
- * @ignore
  */
 function hasAudioContext() {
     return !!(typeof AudioContext !== 'undefined' || typeof webkitAudioContext !== 'undefined');

--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -8,8 +8,6 @@ let id = 0;
 /**
  * Data structure to hold a bind group and its offsets. This is used by {@link UniformBuffer#update}
  * to return a dynamic bind group and offset for the uniform buffer.
- *
- * @ignore
  */
 class DynamicBindGroup {
     bindGroup;
@@ -20,15 +18,13 @@ class DynamicBindGroup {
 /**
  * A bind group represents a collection of {@link UniformBuffer}, {@link Texture} and
  * {@link StorageBuffer} instanced, which can be bind on a GPU for rendering.
- *
- * @ignore
  */
 class BindGroup {
     /**
      * A render version the bind group was last updated on.
      *
      * @type {number}
-     * @ignore
+     * @private
      */
     renderVersionUpdated = -1;
 

--- a/src/platform/graphics/debug-graphics.js
+++ b/src/platform/graphics/debug-graphics.js
@@ -1,8 +1,6 @@
 /**
- * Internal graphics debug system - gpu markers and similar. Note that the functions only execute in the
- * debug build, and are stripped out in other builds.
- *
- * @ignore
+ * Internal graphics debug system - gpu markers and similar. Note that the functions only execute
+ * in the debug build, and are stripped out in other builds.
  */
 class DebugGraphics {
     /**

--- a/src/platform/graphics/device-cache.js
+++ b/src/platform/graphics/device-cache.js
@@ -14,6 +14,7 @@ class DeviceCache {
      * Returns the resources for the supplied device.
      *
      * @param {import('./graphics-device.js').GraphicsDevice} device - The graphics device.
+     * @param {() => any} onCreate - A function that creates the resource for the device.
      * @returns {any} The resource for the device.
      */
     get(device, onCreate) {

--- a/src/platform/graphics/device-cache.js
+++ b/src/platform/graphics/device-cache.js
@@ -1,8 +1,6 @@
 /**
  * A cache storing shared resources associated with a device. The resources are removed
  * from the cache when the device is destroyed.
- *
- * @ignore
  */
 class DeviceCache {
     /**

--- a/src/platform/graphics/dynamic-buffer.js
+++ b/src/platform/graphics/dynamic-buffer.js
@@ -5,8 +5,6 @@ import { SHADERSTAGE_FRAGMENT, SHADERSTAGE_VERTEX, UNIFORM_BUFFER_DEFAULT_SLOT_N
 
 /**
  * A base class representing a single per platform buffer.
- *
- * @ignore
  */
 class DynamicBuffer {
     /** @type {import('./graphics-device.js').GraphicsDevice} */

--- a/src/platform/graphics/dynamic-buffers.js
+++ b/src/platform/graphics/dynamic-buffers.js
@@ -3,8 +3,6 @@ import { math } from '../../core/math/math.js';
 
 /**
  * A container for storing the used areas of a pair of staging and gpu buffers.
- *
- * @ignore
  */
 class UsedBuffer {
     /** @type {import('./dynamic-buffer.js').DynamicBuffer} */
@@ -31,8 +29,6 @@ class UsedBuffer {
 
 /**
  * A container for storing the return values of an allocation function.
- *
- * @ignore
  */
 class DynamicBufferAllocation {
     /**
@@ -65,8 +61,6 @@ class DynamicBufferAllocation {
  * command buffers that require these buffers, the system automatically uploads the data to the GPU
  * buffers. This approach ensures efficient memory management and smooth data transfer between the
  * CPU and GPU.
- *
- * @ignore
  */
 class DynamicBuffers {
     /**
@@ -96,7 +90,7 @@ class DynamicBuffers {
     usedBuffers = [];
 
     /**
-     * @type {UsedBuffer}
+     * @type {UsedBuffer|null}
      */
     activeBuffer = null;
 

--- a/src/platform/graphics/gpu-profiler.js
+++ b/src/platform/graphics/gpu-profiler.js
@@ -4,8 +4,6 @@ import { Tracing } from "../../core/tracing.js";
 
 /**
  * Base class of a simple GPU profiler.
- *
- * @ignore
  */
 class GpuProfiler {
     /**
@@ -32,13 +30,15 @@ class GpuProfiler {
 
     /**
      * The enable request for the next frame.
-     * @ignore
+     *
+     * @private
      */
     _enableRequest = false;
 
     /**
-     * The time it took to render the last frame on GPU, or 0 if the profiler is not enabled
-     * @ignore
+     * The time it took to render the last frame on GPU, or 0 if the profiler is not enabled.
+     *
+     * @private
      */
     _frameTime = 0;
 
@@ -100,6 +100,7 @@ class GpuProfiler {
     /**
      * Allocate a slot for GPU timing during the frame. This slot is valid only for the current
      * frame. This allows multiple timers to be used during the frame, each with a unique name.
+     *
      * @param {string} name - The name of the slot.
      * @returns {number} The assigned slot index.
      * @ignore

--- a/src/platform/graphics/null/null-index-buffer.js
+++ b/src/platform/graphics/null/null-index-buffer.js
@@ -1,7 +1,5 @@
 /**
  * A Null implementation of the IndexBuffer.
- *
- * @ignore
  */
 class NullIndexBuffer {
     unlock(indexBuffer) {

--- a/src/platform/graphics/null/null-render-target.js
+++ b/src/platform/graphics/null/null-render-target.js
@@ -1,7 +1,5 @@
 /**
  * A Null implementation of the RenderTarget.
- *
- * @ignore
  */
 class NullRenderTarget {
     destroy(device) {

--- a/src/platform/graphics/null/null-shader.js
+++ b/src/platform/graphics/null/null-shader.js
@@ -1,7 +1,5 @@
 /**
  * A Null implementation of the Shader.
- *
- * @ignore
  */
 class NullShader {
     destroy(shader) {

--- a/src/platform/graphics/null/null-texture.js
+++ b/src/platform/graphics/null/null-texture.js
@@ -1,7 +1,5 @@
 /**
- * A NULL implementation of the Texture.
- *
- * @ignore
+ * A Null implementation of the Texture.
  */
 class NullTexture {
     destroy(device) {

--- a/src/platform/graphics/null/null-vertex-buffer.js
+++ b/src/platform/graphics/null/null-vertex-buffer.js
@@ -1,7 +1,5 @@
 /**
  * A Null implementation of the VertexBuffer.
- *
- * @ignore
  */
 class NullVertexBuffer {
     destroy(device) {

--- a/src/platform/graphics/shader-processor.js
+++ b/src/platform/graphics/shader-processor.js
@@ -95,8 +95,6 @@ class UniformLine {
 /**
  * Pure static class implementing processing of GLSL shaders. It allocates fixed locations for
  * attributes, and handles conversion of uniforms to uniform buffers.
- *
- * @ignore
  */
 class ShaderProcessor {
     /**

--- a/src/platform/graphics/texture-utils.js
+++ b/src/platform/graphics/texture-utils.js
@@ -41,7 +41,6 @@ class TextureUtils {
      * @param {number} depth - Texture's depth.
      * @param {number} format - Texture's pixel format PIXELFORMAT_***.
      * @returns {number} The number of bytes of GPU memory required for the texture.
-     * @ignore
      */
     static calcLevelGpuSize(width, height, depth, format) {
 
@@ -76,7 +75,6 @@ class TextureUtils {
      * @param {boolean} mipmaps - True if the texture includes mipmaps, false otherwise.
      * @param {boolean} cubemap - True is the texture is a cubemap, false otherwise.
      * @returns {number} The number of bytes of GPU memory required for the texture.
-     * @ignore
      */
     static calcGpuSize(width, height, depth, format, mipmaps, cubemap) {
         let result = 0;

--- a/src/platform/graphics/uniform-buffer.js
+++ b/src/platform/graphics/uniform-buffer.js
@@ -197,8 +197,6 @@ _updateFunctions[UNIFORMTYPE_UVEC3ARRAY] = (uniformBuffer, value, offset, count)
 
 /**
  * A uniform buffer represents a GPU memory buffer storing the uniforms.
- *
- * @ignore
  */
 class UniformBuffer {
     device;
@@ -291,8 +289,6 @@ class UniformBuffer {
 
     /**
      * Called when the rendering context was lost. It releases all context related resources.
-     *
-     * @ignore
      */
     loseContext() {
         this.impl?.loseContext();

--- a/src/platform/graphics/vertex-iterator.js
+++ b/src/platform/graphics/vertex-iterator.js
@@ -71,7 +71,6 @@ function arrayGet4(offset, outputArray, outputIndex) {
  * Helps with accessing a specific vertex attribute.
  *
  * @category Graphics
- * @ignore
  */
 class VertexIteratorAccessor {
     /**

--- a/src/platform/graphics/webgl/webgl-buffer.js
+++ b/src/platform/graphics/webgl/webgl-buffer.js
@@ -2,8 +2,6 @@ import { BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM } from 
 
 /**
  * A WebGL implementation of the Buffer.
- *
- * @ignore
  */
 class WebglBuffer {
     bufferId = null;

--- a/src/platform/graphics/webgl/webgl-gpu-profiler.js
+++ b/src/platform/graphics/webgl/webgl-gpu-profiler.js
@@ -2,8 +2,6 @@ import { GpuProfiler } from "../gpu-profiler.js";
 
 /**
  * Class holding information about the queries for a single frame.
- *
- * @ignore
  */
 class FrameQueriesInfo {
     /**
@@ -26,9 +24,6 @@ class FrameQueriesInfo {
     }
 }
 
-/**
- * @ignore
- */
 class WebglGpuProfiler extends GpuProfiler {
     device;
 
@@ -78,8 +73,6 @@ class WebglGpuProfiler extends GpuProfiler {
 
     /**
      * Called when the WebGL context was lost. It releases all context related resources.
-     *
-     * @ignore
      */
     loseContext() {
         super.loseContext();

--- a/src/platform/graphics/webgl/webgl-index-buffer.js
+++ b/src/platform/graphics/webgl/webgl-index-buffer.js
@@ -3,8 +3,6 @@ import { WebglBuffer } from "./webgl-buffer.js";
 
 /**
  * A WebGL implementation of the IndexBuffer.
- *
- * @ignore
  */
 class WebglIndexBuffer extends WebglBuffer {
     constructor(indexBuffer) {

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -4,8 +4,6 @@ import { DebugGraphics } from "../debug-graphics.js";
 
 /**
  * A private class representing a pair of framebuffers, when MSAA is used.
- *
- * @ignore
  */
 class FramebufferPair {
     /** Multi-sampled rendering framebuffer */
@@ -34,8 +32,6 @@ class FramebufferPair {
 
 /**
  * A WebGL implementation of the RenderTarget.
- *
- * @ignore
  */
 class WebglRenderTarget {
     _glFrameBuffer = null;

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -6,17 +6,32 @@ import { DebugGraphics } from "../debug-graphics.js";
  * A private class representing a pair of framebuffers, when MSAA is used.
  */
 class FramebufferPair {
-    /** Multi-sampled rendering framebuffer */
+    /**
+     * Multi-sampled rendering framebuffer.
+     *
+     * @type {WebGLFramebuffer|null}
+     */
     msaaFB;
 
-    /** Single-sampled resolve framebuffer */
+    /**
+     * Single-sampled resolve framebuffer.
+     *
+     * @type {WebGLFramebuffer|null}
+     */
     resolveFB;
 
+    /**
+     * @param {WebGLFramebuffer} msaaFB - Multi-sampled rendering framebuffer.
+     * @param {WebGLFramebuffer} resolveFB - Single-sampled resolve framebuffer.
+     */
     constructor(msaaFB, resolveFB) {
         this.msaaFB = msaaFB;
         this.resolveFB = resolveFB;
     }
 
+    /**
+     * @param {WebGLRenderingContext} gl - The WebGL rendering context.
+     */
     destroy(gl) {
         if (this.msaaFB) {
             gl.deleteRenderbuffer(this.msaaFB);
@@ -301,6 +316,9 @@ class WebglRenderTarget {
     /**
      * Checks the completeness status of the currently bound WebGLFramebuffer object.
      *
+     * @param {import('./webgl-graphics-device.js').WebglGraphicsDevice} device - The graphics device.
+     * @param {import('../render-target.js').RenderTarget} target - The render target.
+     * @param {string} [type] - An optional type string to append to the error message.
      * @private
      */
     _checkFbo(device, target, type = '') {

--- a/src/platform/graphics/webgl/webgl-shader-input.js
+++ b/src/platform/graphics/webgl/webgl-shader-input.js
@@ -4,8 +4,6 @@ import { Version } from '../version.js';
 
 /**
  * Representation of a shader uniform.
- *
- * @ignore
  */
 class WebglShaderInput {
     /**

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -40,8 +40,6 @@ const _fragmentShaderCache = new DeviceCache();
 
 /**
  * A WebGL implementation of the Shader.
- *
- * @ignore
  */
 class WebglShader {
     compileDuration = 0;

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -23,7 +23,6 @@ import {
  * @param {HTMLImageElement} image - The image to downsample.
  * @param {number} size - The maximum allowed size of the image.
  * @returns {HTMLImageElement|HTMLCanvasElement} The downsampled image.
- * @ignore
  */
 function downsampleImage(image, size) {
     const srcW = image.width;
@@ -51,8 +50,6 @@ function downsampleImage(image, size) {
 
 /**
  * A WebGL implementation of the Texture.
- *
- * @ignore
  */
 class WebglTexture {
     _glTexture = null;

--- a/src/platform/graphics/webgl/webgl-vertex-buffer.js
+++ b/src/platform/graphics/webgl/webgl-vertex-buffer.js
@@ -2,8 +2,6 @@ import { WebglBuffer } from "./webgl-buffer.js";
 
 /**
  * A WebGL implementation of the VertexBuffer.
- *
- * @ignore
  */
 class WebglVertexBuffer extends WebglBuffer {
     // vertex array object

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -28,8 +28,6 @@ const stringIds = new StringIds();
 
 /**
  * A WebGPU implementation of the BindGroupFormat, which is a wrapper over GPUBindGroupLayout.
- *
- * @ignore
  */
 class WebgpuBindGroupFormat {
     /**

--- a/src/platform/graphics/webgpu/webgpu-bind-group.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group.js
@@ -3,8 +3,6 @@ import { WebgpuDebug } from './webgpu-debug.js';
 
 /**
  * A WebGPU implementation of the BindGroup, which is a wrapper over GPUBindGroup.
- *
- * @ignore
  */
 class WebgpuBindGroup {
     /**

--- a/src/platform/graphics/webgpu/webgpu-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-buffer.js
@@ -3,8 +3,6 @@ import { Debug, DebugHelper } from '../../../core/debug.js';
 
 /**
  * A WebGPU implementation of the Buffer.
- *
- * @ignore
  */
 class WebgpuBuffer {
     /**

--- a/src/platform/graphics/webgpu/webgpu-clear-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-clear-renderer.js
@@ -23,11 +23,9 @@ const primitive = {
 /**
  * A WebGPU helper class implementing a viewport clear operation. When rendering to a texture,
  * the whole surface can be cleared using loadOp, but if only a viewport needs to be cleared, or if
- * it needs to be cleared later during the rendering, this need to be archieved by rendering a quad.
+ * it needs to be cleared later during the rendering, this need to be achieved by rendering a quad.
  * This class renders a full-screen quad, and expects the viewport / scissor to be set up to clip
  * it to only required area.
- *
- * @ignore
  */
 class WebgpuClearRenderer {
     constructor(device) {

--- a/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
@@ -6,7 +6,6 @@ import { WebgpuPipeline } from "./webgpu-pipeline.js";
 let _pipelineId = 0;
 
 class WebgpuComputePipeline extends WebgpuPipeline {
-    /** @private */
     get(shader, bindGroupFormat) {
 
         // pipeline layout

--- a/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
@@ -5,9 +5,6 @@ import { WebgpuPipeline } from "./webgpu-pipeline.js";
 
 let _pipelineId = 0;
 
-/**
- * @ignore
- */
 class WebgpuComputePipeline extends WebgpuPipeline {
     /** @private */
     get(shader, bindGroupFormat) {

--- a/src/platform/graphics/webgpu/webgpu-compute.js
+++ b/src/platform/graphics/webgpu/webgpu-compute.js
@@ -5,8 +5,6 @@ import { UniformBuffer } from "../uniform-buffer.js";
 
 /**
  * A WebGPU implementation of the Compute.
- *
- * @ignore
  */
 class WebgpuCompute {
     /** @type {UniformBuffer[]} */

--- a/src/platform/graphics/webgpu/webgpu-debug.js
+++ b/src/platform/graphics/webgpu/webgpu-debug.js
@@ -7,8 +7,6 @@ const MAX_DUPLICATES = 5;
 /**
  * Internal WebGPU debug system. Note that the functions only execute in the debug build, and are
  * stripped out in other builds.
- *
- * @ignore
  */
 class WebgpuDebug {
     static _scopes = [];

--- a/src/platform/graphics/webgpu/webgpu-dynamic-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-dynamic-buffer.js
@@ -1,9 +1,6 @@
 import { DebugHelper } from "../../../core/debug.js";
 import { DynamicBuffer } from "../dynamic-buffer.js";
 
-/**
- * @ignore
- */
 class WebgpuDynamicBuffer extends DynamicBuffer {
     /**
      * @type {GPUBuffer}

--- a/src/platform/graphics/webgpu/webgpu-index-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-index-buffer.js
@@ -4,8 +4,6 @@ import { WebgpuBuffer } from "./webgpu-buffer.js";
 
 /**
  * A WebGPU implementation of the IndexBuffer.
- *
- * @ignore
  */
 class WebgpuIndexBuffer extends WebgpuBuffer {
     format = null;

--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -5,8 +5,6 @@ import { DebugGraphics } from "../debug-graphics.js";
 
 /**
  * A WebGPU helper class implementing texture mipmap generation.
- *
- * @ignore
  */
 class WebgpuMipmapRenderer {
     /** @type {import('./webgpu-graphics-device.js').WebgpuGraphicsDevice} */

--- a/src/platform/graphics/webgpu/webgpu-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-pipeline.js
@@ -5,8 +5,6 @@ let _layoutId = 0;
 
 /**
  * Base class for render and compute pipelines.
- *
- * @ignore
  */
 class WebgpuPipeline {
     constructor(device) {

--- a/src/platform/graphics/webgpu/webgpu-query-set.js
+++ b/src/platform/graphics/webgpu/webgpu-query-set.js
@@ -3,8 +3,6 @@ import { DebugHelper } from "../../../core/debug.js";
 /**
  * A wrapper over the GpuQuerySet object, allowing timestamp and occlusion queries. The results
  * are copied back using staging buffers to avoid blocking.
- *
- * @ignore
  */
 class WebgpuQuerySet {
     /**

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -73,7 +73,6 @@ const _stencilOps = [
     'invert'                // STENCILOP_INVERT
 ];
 
-/** @ignore */
 class CacheEntry {
     /**
      * Render pipeline
@@ -91,9 +90,6 @@ class CacheEntry {
     hashes;
 }
 
-/**
- * @ignore
- */
 class WebgpuRenderPipeline extends WebgpuPipeline {
     lookupHashes = new Uint32Array(13);
 

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -111,6 +111,25 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
         this.cache = new Map();
     }
 
+    /**
+     * @param {object} primitive - The primitive.
+     * @param {import('../vertex-format.js').VertexFormat} vertexFormat0 - The first vertex format.
+     * @param {import('../vertex-format.js').VertexFormat} vertexFormat1 - The second vertex format.
+     * @param {import('../shader.js').Shader} shader - The shader.
+     * @param {import('../render-target.js').RenderTarget} renderTarget - The render target.
+     * @param {import('../bind-group-format.js').BindGroupFormat[]} bindGroupFormats - An array of
+     * bind group formats.
+     * @param {import('../blend-state.js').BlendState} blendState - The blend state.
+     * @param {import('../depth-state.js').DepthState} depthState - The depth state.
+     * @param {number} cullMode - The cull mode.
+     * @param {boolean} stencilEnabled - Whether stencil is enabled.
+     * @param {import('../stencil-parameters.js').StencilParameters} stencilFront - The stencil
+     * state for front faces.
+     * @param {import('../stencil-parameters.js').StencilParameters} stencilBack - The stencil
+     * state for back faces.
+     * @returns {GPURenderPipeline} Returns the render pipeline.
+     * @private
+     */
     get(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats, blendState,
         depthState, cullMode, stencilEnabled, stencilFront, stencilBack) {
 
@@ -210,6 +229,17 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
         return blend;
     }
 
+    /**
+     * @param {import('../depth-state.js').DepthState} depthState - The depth state.
+     * @param {import('../render-target.js').RenderTarget} renderTarget - The render target.
+     * @param {boolean} stencilEnabled - Whether stencil is enabled.
+     * @param {import('../stencil-parameters.js').StencilParameters} stencilFront - The stencil
+     * state for front faces.
+     * @param {import('../stencil-parameters.js').StencilParameters} stencilBack - The stencil
+     * state for back faces.
+     * @returns {object} Returns the depth stencil state.
+     * @private
+     */
     getDepthStencil(depthState, renderTarget, stencilEnabled, stencilFront, stencilBack) {
 
         /** @type {GPUDepthStencilState} */

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -111,7 +111,6 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
         this.cache = new Map();
     }
 
-    /** @private */
     get(primitive, vertexFormat0, vertexFormat1, shader, renderTarget, bindGroupFormats, blendState,
         depthState, cullMode, stencilEnabled, stencilFront, stencilBack) {
 
@@ -211,7 +210,6 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
         return blend;
     }
 
-    /** @private */
     getDepthStencil(depthState, renderTarget, stencilEnabled, stencilFront, stencilBack) {
 
         /** @type {GPUDepthStencilState} */

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -6,8 +6,6 @@ const stringIds = new StringIds();
 
 /**
  * Private class storing info about color buffer.
- *
- * @ignore
  */
 class ColorAttachment {
     /**
@@ -30,8 +28,6 @@ class ColorAttachment {
 
 /**
  * A WebGPU implementation of the RenderTarget.
- *
- * @ignore
  */
 class WebgpuRenderTarget {
     /** @type {boolean} */

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -277,6 +277,10 @@ class WebgpuRenderTarget {
     }
 
     /**
+     * @param {GPUDevice} wgpu - The WebGPU device.
+     * @param {import('../render-target.js').RenderTarget} renderTarget - The render target.
+     * @param {number} index - The color buffer index.
+     * @returns {GPURenderPassColorAttachment} The color attachment.
      * @private
      */
     initColor(wgpu, renderTarget, index) {

--- a/src/platform/graphics/webgpu/webgpu-resolver.js
+++ b/src/platform/graphics/webgpu/webgpu-resolver.js
@@ -64,7 +64,11 @@ class WebgpuResolver {
         this.pipelineCache = null;
     }
 
-    /** @private */
+    /**
+     * @param {GPUTextureFormat} format - Texture format.
+     * @returns {GPURenderPipeline} Pipeline for the given format.
+     * @private
+     */
     getPipeline(format) {
         let pipeline = this.pipelineCache.get(format);
         if (!pipeline) {
@@ -74,7 +78,11 @@ class WebgpuResolver {
         return pipeline;
     }
 
-    /** @private */
+    /**
+     * @param {GPUTextureFormat} format - Texture format.
+     * @returns {GPURenderPipeline} Pipeline for the given format.
+     * @private
+     */
     createPipeline(format) {
 
         /** @type {import('./webgpu-shader.js').WebgpuShader} */

--- a/src/platform/graphics/webgpu/webgpu-resolver.js
+++ b/src/platform/graphics/webgpu/webgpu-resolver.js
@@ -5,8 +5,6 @@ import { DebugGraphics } from "../debug-graphics.js";
 
 /**
  * A WebGPU helper class implementing custom resolve of multi-sampled textures.
- *
- * @ignore
  */
 class WebgpuResolver {
     /** @type {import('./webgpu-graphics-device.js').WebgpuGraphicsDevice} */

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -7,8 +7,6 @@ import { WebgpuDebug } from './webgpu-debug.js';
 
 /**
  * A WebGPU implementation of the Shader.
- *
- * @ignore
  */
 class WebgpuShader {
     /**

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -37,8 +37,6 @@ const dummyUse = (thingOne) => {
 
 /**
  * A WebGPU implementation of the Texture.
- *
- * @ignore
  */
 class WebgpuTexture {
     /**

--- a/src/platform/graphics/webgpu/webgpu-uniform-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-uniform-buffer.js
@@ -3,8 +3,6 @@ import { WebgpuBuffer } from "./webgpu-buffer.js";
 
 /**
  * A WebGPU implementation of the UniformBuffer.
- *
- * @ignore
  */
 class WebgpuUniformBuffer extends WebgpuBuffer {
     constructor(uniformBuffer) {

--- a/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
+++ b/src/platform/graphics/webgpu/webgpu-vertex-buffer-layout.js
@@ -24,9 +24,6 @@ gpuVertexFormatsNormalized[TYPE_UINT32] = 'uint32';    // there is no 32bit norm
 gpuVertexFormatsNormalized[TYPE_FLOAT32] = 'float32';  // there is no 32bit normalized float
 gpuVertexFormatsNormalized[TYPE_FLOAT16] = 'float16';  // there is no 16bit normalized half-float
 
-/**
- * @ignore
- */
 class WebgpuVertexBufferLayout {
     /**
      * @type {Map<string, GPUVertexBufferLayout[]>}

--- a/src/platform/graphics/webgpu/webgpu-vertex-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-vertex-buffer.js
@@ -3,8 +3,6 @@ import { WebgpuBuffer } from "./webgpu-buffer.js";
 
 /**
  * A WebGPU implementation of the VertexBuffer.
- *
- * @ignore
  */
 class WebgpuVertexBuffer extends WebgpuBuffer {
     constructor(vertexBuffer, format, options) {

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -10,7 +10,6 @@ const dummyArray = Object.freeze([]);
  *
  * @type {Function}
  * @returns {Gamepad[]} Retrieved gamepads from the device.
- * @ignore
  */
 let getGamepads = function () {
     return dummyArray;
@@ -216,7 +215,6 @@ const custom_maps = {};
  *
  * @param {Gamepad} pad - The HTML5 Gamepad object.
  * @returns {object} Object defining the order of buttons and axes for given HTML5 Gamepad.
- * @ignore
  */
 function getMap(pad) {
     const custom = custom_maps[pad.id];
@@ -255,7 +253,6 @@ let deadZone = 0.25;
 /**
  * @param {number} ms - Number of milliseconds to sleep for.
  * @returns {Promise<void>}
- * @ignore
  */
 function sleep(ms) {
     return new Promise((resolve) => {
@@ -407,7 +404,7 @@ class GamePad {
          * The buttons present on the GamePad. Order is provided by API, use GamePad#buttons instead.
          *
          * @type {GamePadButton[]}
-         * @ignore
+         * @private
          */
         this._buttons = gamepad.buttons.map(b => new GamePadButton(b));
 
@@ -415,7 +412,7 @@ class GamePad {
          * The axes values from the GamePad. Order is provided by API, use GamePad#axes instead.
          *
          * @type {number[]}
-         * @ignore
+         * @private
          */
         this._axes = [...gamepad.axes];
 
@@ -423,7 +420,7 @@ class GamePad {
          * Previous value for the analog axes present on the gamepad. Values are between -1 and 1.
          *
          * @type {number[]}
-         * @ignore
+         * @private
          */
         this._previousAxes = [...gamepad.axes];
 
@@ -830,7 +827,7 @@ class GamePads extends EventHandler {
          * The list of previous buttons states
          *
          * @type {boolean[][]}
-         * @ignore
+         * @private
          */
         this._previous = [];
 

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -11,7 +11,6 @@ const _keyboardEvent = new KeyboardEvent();
  *
  * @param {globalThis.KeyboardEvent} event - A browser keyboard event.
  * @returns {KeyboardEvent} A PlayCanvas keyboard event.
- * @ignore
  */
 function makeKeyboardEvent(event) {
     _keyboardEvent.key = event.keyCode;
@@ -25,7 +24,6 @@ function makeKeyboardEvent(event) {
  *
  * @param {string|number} s - Either a character code or the key character.
  * @returns {number} The character code.
- * @ignore
  */
 function toKeyCode(s) {
     if (typeof s === 'string') {

--- a/src/platform/input/mouse-event.js
+++ b/src/platform/input/mouse-event.js
@@ -4,7 +4,6 @@ import { MOUSEBUTTON_NONE } from './constants.js';
  * Returns true if pointer lock is currently enabled.
  *
  * @returns {boolean} True if pointer lock is currently enabled.
- * @ignore
  */
 function isMousePointerLocked() {
     return !!(document.pointerLockElement || document.mozPointerLockElement || document.webkitPointerLockElement);

--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -14,7 +14,6 @@ const STATE_STOPPED = 2;
  * @param {number} time - The time.
  * @param {number} duration - The duration.
  * @returns {number} The time % duration.
- * @ignore
  */
 function capTime(time, duration) {
     return (time % duration) || 0;

--- a/src/platform/sound/listener.js
+++ b/src/platform/sound/listener.js
@@ -4,8 +4,6 @@ import { Vec3 } from '../../core/math/vec3.js';
 
 /**
  * Represents an audio listener - used internally.
- *
- * @ignore
  */
 class Listener {
     /**

--- a/src/platform/sound/manager.js
+++ b/src/platform/sound/manager.js
@@ -27,7 +27,6 @@ const USER_INPUT_EVENTS = [
 class SoundManager extends EventHandler {
     /**
      * Create a new SoundManager instance.
-     *
      */
     constructor() {
         super();

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -1,8 +1,6 @@
 /**
  * Class representing an entry in the final order of rendering of cameras and layers in the engine
  * this is populated at runtime based on LayerComposition
- *
- * @ignore
  */
 class RenderAction {
     constructor() {

--- a/src/scene/compress/decompress.js
+++ b/src/scene/compress/decompress.js
@@ -2,8 +2,6 @@ import { CompressUtils } from './compress-utils.js';
 
 /**
  * Reconstruct original object field names in a compressed scene.
- *
- * @ignore
  */
 class Decompress {
     /**

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -2,8 +2,6 @@ import { Debug } from '../core/debug.js';
 
 /**
  * A frame graph represents a single rendering frame as a sequence of render passes.
- *
- * @ignore
  */
 class FrameGraph {
     /** @type {import('../platform/graphics/render-pass.js').RenderPass[]} */

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -29,7 +29,6 @@ const up = new Vec3();
  * @param {FindNodeCallback|string} attr - Attribute or lambda.
  * @param {*} [value] - Optional value in case of `attr` being a `string`
  * @returns {FindNodeCallback} Test function that receives a GraphNode and returns a boolean.
- * @ignore
  */
 function createTest(attr, value) {
     if (attr instanceof Function) {
@@ -51,7 +50,6 @@ function createTest(attr, value) {
  * @param {FindNodeCallback} test - Test function.
  * @returns {GraphNode|null} A graph node that matches the search criteria. Returns null if no
  * node is found.
- * @ignore
  */
 function findNode(node, test) {
     if (test(node))
@@ -445,7 +443,7 @@ class GraphNode extends EventHandler {
     /**
      * @param {GraphNode} node - Graph node to update.
      * @param {boolean} enabled - True if enabled in the hierarchy, false if disabled.
-     * @private
+     * @protected
      */
     _notifyHierarchyStateChanged(node, enabled) {
         node._onHierarchyStateChanged(enabled);
@@ -461,7 +459,7 @@ class GraphNode extends EventHandler {
      * Called when the enabled flag of the entity or one of its parents changes.
      *
      * @param {boolean} enabled - True if enabled in the hierarchy, false if disabled.
-     * @private
+     * @protected
      */
     _onHierarchyStateChanged(enabled) {
         // Override in derived classes

--- a/src/scene/graphics/light-cube.js
+++ b/src/scene/graphics/light-cube.js
@@ -13,8 +13,6 @@ const lightCubeDir = [
 /**
  * A lighting cube represented by 6 colors, one per cube direction. Use for simple lighting on the
  * particle system.
- *
- * @ignore
  */
 class LightCube {
     colors = new Float32Array(6 * 3);

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -15,10 +15,10 @@ const _tempRect = new Vec4();
  * target. If undefined, target is the frame buffer.
  * @param {import('../../platform/graphics/shader.js').Shader} shader - The shader used for rendering the quad. Vertex
  * shader should contain `attribute vec2 vertex_position`.
- * @param {import('../../core/math/vec4.js').Vec4} [rect] - The viewport rectangle of the quad, in
- * pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
- * @param {import('../../core/math/vec4.js').Vec4} [scissorRect] - The scissor rectangle of the
- * quad, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
+ * @param {Vec4} [rect] - The viewport rectangle of the quad, in pixels. Defaults to fullscreen:
+ * `[0, 0, target.width, target.height]`.
+ * @param {Vec4} [scissorRect] - The scissor rectangle of the quad, in pixels. Defaults to fullscreen:
+ * `[0, 0, target.width, target.height]`.
  * @category Graphics
  */
 function drawQuadWithShader(device, target, shader, rect, scissorRect) {
@@ -74,11 +74,12 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
  * `uniform sampler2D * source` in shader.
  * @param {import('../../platform/graphics/render-target.js').RenderTarget} [target] - The destination render target.
  * Defaults to the frame buffer.
- * @param {import('../../platform/graphics/shader.js').Shader} [shader] - The optional custom shader used for rendering the texture.
- * @param {import('../../core/math/vec4.js').Vec4} [rect] - The viewport rectangle to use for the
- * texture, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
- * @param {import('../../core/math/vec4.js').Vec4} [scissorRect] - The scissor rectangle to use for
- * the texture, in pixels. Defaults to fullscreen (`0, 0, target.width, target.height`).
+ * @param {import('../../platform/graphics/shader.js').Shader} [shader] - The optional custom
+ * shader used for rendering the texture.
+ * @param {Vec4} [rect] - The viewport rectangle to use for the texture, in pixels. Defaults to
+ * fullscreen: `[0, 0, target.width, target.height]`.
+ * @param {Vec4} [scissorRect] - The scissor rectangle to use for the texture, in pixels. Defaults
+ * to fullscreen `[0, 0, target.width, target.height]`.
  * @category Graphics
  */
 function drawTexture(device, texture, target, shader, rect, scissorRect) {

--- a/src/scene/graphics/render-pass-quad.js
+++ b/src/scene/graphics/render-pass-quad.js
@@ -5,8 +5,6 @@ import { RenderPass } from "../../platform/graphics/render-pass.js";
 
 /**
  * A render pass implementing rendering of a QuadRender.
- *
- * @ignore
  */
 class RenderPassQuad extends RenderPass {
     constructor(device, quad, rect, scissorRect) {

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -6,7 +6,6 @@ import { Texture } from '../../platform/graphics/texture.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import { createGSplatCompressedMaterial } from './gsplat-compressed-material.js';
 
-/** @ignore */
 class GSplatCompressed {
     device;
 

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -58,6 +58,7 @@ class GSplatCompressed {
     }
 
     /**
+     * @param {import('./gsplat-material.js').SplatMaterialOptions} options - The splat material options.
      * @returns {import('../materials/material.js').Material} material - The material to set up for
      * the splat rendering.
      */
@@ -89,6 +90,7 @@ class GSplatCompressed {
      * @param {string} name - The name of the texture to be created.
      * @param {number} format - The pixel format of the texture.
      * @param {Vec2} size - The width and height of the texture.
+     * @param {Uint8Array} [data] - The initial data to fill the texture with.
      * @returns {Texture} The created texture instance.
      */
     createTexture(name, format, size, data) {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -44,8 +44,6 @@ let id = 0;
 
 /**
  * Class storing shadow rendering related private information
- *
- * @ignore
  */
 class LightRenderData {
     constructor(device, camera, face, light) {

--- a/src/scene/materials/basic-material.js
+++ b/src/scene/materials/basic-material.js
@@ -37,7 +37,7 @@ class BasicMaterial extends Material {
      */
     color = new Color(1, 1, 1, 1);
 
-    /** @ignore */
+    /** @private */
     colorUniform = new Float32Array(4);
 
     /**

--- a/src/scene/materials/default-material.js
+++ b/src/scene/materials/default-material.js
@@ -12,7 +12,6 @@ const defaultMaterialDeviceCache = new DeviceCache();
  * graphics device used to own the material.
  * @returns {import('./standard-material.js').StandardMaterial} The default instance of
  * {@link StandardMaterial}.
- * @ignore
  */
 function getDefaultMaterial(device) {
     const material = defaultMaterialDeviceCache.get(device);
@@ -27,7 +26,6 @@ function getDefaultMaterial(device) {
  * graphics device used to own the material.
  * @param {import('./standard-material.js').StandardMaterial} material - The instance of
  * {@link StandardMaterial}.
- * @ignore
  */
 function setDefaultMaterial(device, material) {
     Debug.assert(material);

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -38,8 +38,6 @@ const lookupHashes = new Uint32Array(4);
 
 /**
  * Internal data structure used to store data used by hardware instancing.
- *
- * @ignore
  */
 class InstancingData {
     /** @type {import('../platform/graphics/vertex-buffer.js').VertexBuffer|null} */
@@ -55,8 +53,6 @@ class InstancingData {
 
 /**
  * Internal helper class for storing the shader and related mesh bind group in the shader cache.
- *
- * @ignore
  */
 class ShaderInstance {
     /**

--- a/src/scene/render.js
+++ b/src/scene/render.js
@@ -5,8 +5,6 @@ import { EventHandler } from '../core/event-handler.js';
  * scene, and are accessible using the {@link ContainerResource#renders} property. A `Render` is
  * the resource of a Render Asset. They are usually created by the GLB loader and not created by
  * hand.
- *
- * @ignore
  */
 class Render extends EventHandler {
     /**

--- a/src/scene/renderer/render-pass-cookie-renderer.js
+++ b/src/scene/renderer/render-pass-cookie-renderer.js
@@ -47,8 +47,6 @@ const _invViewProjMatrices = [];
 
 /**
  * A render pass used to render cookie textures (both 2D and Cubemap) into the texture atlas.
- *
- * @ignore
  */
 class RenderPassCookieRenderer extends RenderPass {
     /** @type {QuadRender|null} */

--- a/src/scene/renderer/render-pass-postprocessing.js
+++ b/src/scene/renderer/render-pass-postprocessing.js
@@ -3,8 +3,6 @@ import { RenderPass } from "../../platform/graphics/render-pass.js";
 
 /**
  * A render pass used to render post-effects.
- *
- * @ignore
  */
 class RenderPassPostprocessing extends RenderPass {
     constructor(device, renderer, renderAction) {

--- a/src/scene/renderer/render-pass-shadow-directional.js
+++ b/src/scene/renderer/render-pass-shadow-directional.js
@@ -4,8 +4,6 @@ import { SHADOWUPDATE_NONE, SHADOWUPDATE_THISFRAME } from "../constants.js";
 
 /**
  * A render pass used to render directional shadows.
- *
- * @ignore
  */
 class RenderPassShadowDirectional extends RenderPass {
     constructor(device, shadowRenderer, light, camera, allCascadesRendering) {

--- a/src/scene/renderer/render-pass-shadow-local-clustered.js
+++ b/src/scene/renderer/render-pass-shadow-local-clustered.js
@@ -3,8 +3,6 @@ import { RenderPass } from "../../platform/graphics/render-pass.js";
 /**
  * A render pass used to render local clustered shadows. This is done inside a single render pass,
  * as all shadows are part of a single render target atlas.
- *
- * @ignore
  */
 class RenderPassShadowLocalClustered extends RenderPass {
     constructor(device, shadowRenderer, shadowRendererLocal) {

--- a/src/scene/renderer/render-pass-shadow-local-non-clustered.js
+++ b/src/scene/renderer/render-pass-shadow-local-non-clustered.js
@@ -4,8 +4,6 @@ import { RenderPass } from "../../platform/graphics/render-pass.js";
 /**
  * A render pass used to render local non-clustered shadows. It represents rendering to a single
  * face of shadow map, as each face is a separate render target.
- *
- * @ignore
  */
 class RenderPassShadowLocalNonClustered extends RenderPass {
     constructor(device, shadowRenderer, light, face, applyVsm) {

--- a/src/scene/renderer/render-pass-update-clustered.js
+++ b/src/scene/renderer/render-pass-update-clustered.js
@@ -5,8 +5,6 @@ import { RenderPassShadowLocalClustered } from "./render-pass-shadow-local-clust
 
 /**
  * A render pass used to update clustered lighting data - shadows, cookies, world clusters.
- *
- * @ignore
  */
 class RenderPassUpdateClustered extends RenderPass {
     constructor(device, renderer, shadowRenderer, shadowRendererLocal, lightTextureAtlas) {

--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -45,9 +45,6 @@ function getDepthRange(cameraViewMatrix, aabbMin, aabbMax) {
     return _depthRange;
 }
 
-/**
- * @ignore
- */
 class ShadowRendererDirectional {
     /** @type {import('./renderer.js').Renderer} */
     renderer;

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -7,9 +7,6 @@ import {
 
 import { RenderPassShadowLocalNonClustered } from './render-pass-shadow-local-non-clustered.js';
 
-/**
- * @ignore
- */
 class ShadowRendererLocal {
     // temporary list to collect lights to render shadows for
     shadowLights = [];

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -107,6 +107,9 @@ class ShadowRendererLocal {
     /**
      * Prepare render passes for rendering of shadows for local non-clustered lights. Each shadow face
      * is a separate render pass as it renders to a separate render target.
+     *
+     * @param {import('../../scene/frame-graph.js').FrameGraph} frameGraph - The frame graph.
+     * @param {import('../../scene/light.js').Light[]} localLights - The list of local lights.
      */
     buildNonClusteredRenderPasses(frameGraph, localLights) {
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -54,9 +54,6 @@ const pixelOffset = new Float32Array(2);
 const blurScissorRect = new Vec4(1, 1, 0, 0);
 const viewportMatrix = new Mat4();
 
-/**
- * @ignore
- */
 class ShadowRenderer {
     /**
      * A cache of shadow passes. First index is looked up by light type, second by shadow type.
@@ -168,7 +165,6 @@ class ShadowRenderer {
      * @param {import('../camera.js').Camera} camera - The camera.
      * @param {import('../mesh-instance.js').MeshInstance[]} [casters] - Optional array of mesh
      * instances to use as casters.
-     * @ignore
      */
     cullShadowCasters(comp, light, visible, camera, casters) {
 

--- a/src/scene/renderer/world-clusters-allocator.js
+++ b/src/scene/renderer/world-clusters-allocator.js
@@ -6,8 +6,6 @@ const tempClusterArray = [];
 /**
  * A class managing instances of world clusters used by the renderer for layers with
  * unique sets of clustered lights.
- *
- * @ignore
  */
 class WorldClustersAllocator {
     /**

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -50,14 +50,13 @@ const builtinVaryings = {
 };
 
 class LitShader {
+    /**
+     * @param {import('../../../platform/graphics/graphics-device.js').GraphicsDevice} device - The
+     * graphics device.
+     * @param {import('./lit-shader-options.js').LitShaderOptions} options - The
+     * lit options.
+     */
     constructor(device, options) {
-        /**
-         * @param {import('../../../platform/graphics/graphics-device.js').GraphicsDevice} device - The
-         * graphics device.
-         * @param {import('./lit-shader-options.js').LitShaderOptions} options - The
-         * lit options.
-         * @ignore
-         */
         this.device = device;
         this.options = options;
 
@@ -1489,7 +1488,6 @@ class LitShader {
      * @param {string} frontendCode - Frontend code containing `getOpacity()` etc.
      * @param {string} frontendFunc - E.g. `evaluateFrontend();`
      * @param {string} lightingUv - E.g. `vUv0`
-     * @ignore
      */
     generateFragmentShader(frontendDecl, frontendCode, frontendFunc, lightingUv) {
         const options = this.options;

--- a/src/scene/shader-lib/programs/lit.js
+++ b/src/scene/shader-lib/programs/lit.js
@@ -22,7 +22,6 @@ class ShaderGeneratorLit extends ShaderGenerator {
      * graphics device.
      * @param {object} options - The options to be passed to the backend.
      * @returns {object} Returns the created shader definition.
-     * @ignore
      */
     createShaderDefinition(device, options) {
         const litShader = new LitShader(device, options.litOptions);

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -203,7 +203,6 @@ class ShaderGeneratorStandard extends ShaderGenerator {
      * graphics device.
      * @param {StandardMaterialOptions} options - The create options.
      * @returns {object} Returns the created shader definition.
-     * @ignore
      */
     createShaderDefinition(device, options) {
 

--- a/src/scene/shader-lib/utils.js
+++ b/src/scene/shader-lib/utils.js
@@ -127,7 +127,6 @@ class ShaderGeneratorPassThrough extends ShaderGenerator {
  * @param {import('../../platform/graphics/shader-processor-options.js').ShaderProcessorOptions} processingOptions -
  * The shader processing options.
  * @returns {Shader} The processed shader.
- * @ignore
  */
 function processShader(shader, processingOptions) {
 

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -12,8 +12,6 @@ const shaderPassDeviceCache = new DeviceCache();
  * Info about a shader pass. Shader pass is represented by a unique index and a name, and the
  * index is used to access the shader required for the pass, from an array stored in the
  * material or mesh instance.
- *
- * @ignore
  */
 class ShaderPassInfo {
     /** @type {number} */

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -23,6 +23,7 @@ class SkyMesh {
      * @param {import('../../platform/graphics/graphics-device.js').GraphicsDevice} device - The
      * graphics device.
      * @param {import('../scene.js').Scene} scene - The scene owning the sky.
+     * @param {import('../graph-node.js').GraphNode} node - The graph node of the sky mesh instance.
      * @param {import('../../platform/graphics/texture.js').Texture} texture - The texture of the sky.
      * @param {string} type - The type of the sky. One of the SKYMESH_* constants.
      */

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -10,8 +10,6 @@ import { SkyGeometry } from './sky-geometry.js';
 
 /**
  * A visual representation of the sky.
- *
- * @ignore
  */
 class SkyMesh {
     /**

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -7,7 +7,6 @@ import { SkyMesh } from "./sky-mesh.js";
  * Implementation of the sky.
  *
  * @category Graphics
- * @ignore
  */
 class Sky {
     /**
@@ -47,7 +46,6 @@ class Sky {
      * Constructs a new sky.
      *
      * @param {import('../scene.js').Scene} scene - The scene owning the sky.
-     * @ignore
      */
     constructor(scene) {
         this.device = scene.device;


### PR DESCRIPTION
The `@ignore` JSDoc tag will prevent a symbol from being added to the TypeDoc API reference. However, if the symbol is not exported in the root `index.js`, it will not appear in the API reference anyway. So this PR removes redundant `@ignore` tags for symbols that are not exported.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
