### PR TITLE
Delete splat-related exports now that extras is part of core engine

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,8 +82,6 @@ export { RenderPass } from './platform/graphics/render-pass.js';
 export { ScopeId } from './platform/graphics/scope-id.js';
 export { ScopeSpace } from './platform/graphics/scope-space.js';
 export { Shader } from './platform/graphics/shader.js';
-export { ShaderProcessorOptions } from './platform/graphics/shader-processor-options.js';   // used by splats in extras
-export { ShaderUtils } from './platform/graphics/shader-utils.js';  // used by splats in extras
 export { StorageBuffer } from './platform/graphics/storage-buffer.js';
 export { Texture } from './platform/graphics/texture.js';
 export { TextureUtils } from './platform/graphics/texture-utils.js';
@@ -188,13 +186,11 @@ export { RenderPassForward } from './scene/renderer/render-pass-forward.js';
 
 // SCENE / SHADER-LIB
 export { createShader, createShaderFromCode } from './scene/shader-lib/utils.js';
-export { getProgramLibrary } from './scene/shader-lib/get-program-library.js';      // used by splats in extras
 export { LitShaderOptions } from './scene/shader-lib/programs/lit-shader-options.js';
 export { ProgramLibrary } from './scene/shader-lib/program-library.js';
 export { shaderChunks } from './scene/shader-lib/chunks/chunks.js';
 export { shaderChunksLightmapper } from './scene/shader-lib/chunks/chunks-lightmapper.js';
 export { ChunkBuilder } from './scene/shader-lib/chunk-builder.js';     // used by shed
-export { ShaderGenerator } from './scene/shader-lib/programs/shader-generator.js';  // used by splats in extras
 
 // SCENE / SPLAT
 export { GSplatData } from './scene/gsplat/gsplat-data.js';


### PR DESCRIPTION
Remove the exports that were added in https://github.com/playcanvas/engine/pull/5900 since 3DGS and extras are now part of the core engine.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
