### PR TITLE
[Fix] Fix Entity.findComponent(s) functions

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -427,7 +427,7 @@ class Entity extends GraphNode {
      * const light = entity.findComponent("light");
      */
     findComponent(type) {
-        const entity = this.findOne(entity => entity?.c[type]);
+        const entity = this.findOne(entity => entity.c?.[type]);
         return entity && entity.c[type];
     }
 
@@ -442,7 +442,7 @@ class Entity extends GraphNode {
      * const lights = entity.findComponents("light");
      */
     findComponents(type) {
-        return this.find(entity => entity?.c[type]).map(entity => entity.c[type]);
+        return this.find(entity => entity.c?.[type]).map(entity => entity.c[type]);
     }
 
     /**


### PR DESCRIPTION
- Fix an issue introduced here: https://github.com/playcanvas/engine/pull/6767 where the ? wasn't in the correct place compared to the original code
- this was causing exception in engine example asset-viewer