### PR TITLE
[BREAKING] Remove no longer needed shader defines: SUPPORTS_TEXLOD and SUPPORTS_MRT

### DIFF
--- a/src/platform/graphics/shader-chunks/frag/gles3.js
+++ b/src/platform/graphics/shader-chunks/frag/gles3.js
@@ -89,6 +89,4 @@ layout(location = 7) out highp outType_7 pc_fragColor7;
 #define TEXTURE_ACCEPT_HIGHP(name) highp sampler2D name
 
 #define GL2
-#define SUPPORTS_TEXLOD
-#define SUPPORTS_MRT
 `;

--- a/src/platform/graphics/shader-chunks/frag/webgpu.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu.js
@@ -74,6 +74,4 @@ layout(location = 7) out highp outType_7 pc_fragColor7;
 
 #define GL2
 #define WEBGPU
-#define SUPPORTS_TEXLOD
-#define SUPPORTS_MRT
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
+++ b/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
@@ -13,14 +13,10 @@ vec3 evalRefractionColor(vec3 refractionVector, float gloss, float refractionInd
     // use built-in getGrabScreenPos function to convert screen position to grab texture uv coords
     vec2 uv = getGrabScreenPos(projectionPoint);
 
-    #ifdef SUPPORTS_TEXLOD
-        // Use IOR and roughness to select mip
-        float iorToRoughness = (1.0 - gloss) * clamp((1.0 / refractionIndex) * 2.0 - 2.0, 0.0, 1.0);
-        float refractionLod = log2(uScreenSize.x) * iorToRoughness;
-        vec3 refraction = texture2DLodEXT(uSceneColorMap, uv, refractionLod).rgb;
-    #else
-        vec3 refraction = texture2D(uSceneColorMap, uv).rgb;
-    #endif
+    // Use IOR and roughness to select mip
+    float iorToRoughness = (1.0 - gloss) * clamp((1.0 / refractionIndex) * 2.0 - 2.0, 0.0, 1.0);
+    float refractionLod = log2(uScreenSize.x) * iorToRoughness;
+    vec3 refraction = texture2DLodEXT(uSceneColorMap, uv, refractionLod).rgb;
 
     return refraction;
 }


### PR DESCRIPTION
- possibly a breaking change in the unlikely case some user shader override chunk depends on this
- both of these are always defined (WebGL1 legacy)
- internally we have a single use left and this is removed in this PR as well