### PR TITLE
Remove deprecated uniform for grab pass textures: uDepthMap and texture_grabPass

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1893,11 +1893,14 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
                 // #if _DEBUG
                 const samplerName = sampler.scopeId.name;
-                if (samplerName === 'uSceneDepthMap' || samplerName === 'uDepthMap') {
-                    Debug.warnOnce(`A sampler ${samplerName} is used by the shader but a scene depth texture is not available. Use CameraComponent.requestSceneDepthMap / enable Depth Grabpass on the Camera Component to enable it.`);
+                Debug.assert(samplerName !== 'texture_grabPass', `Engine provided texture with sampler name 'texture_grabPass' is not longer supported, use 'uSceneColorMap' instead`);
+                Debug.assert(samplerName !== 'uDepthMap', `Engine provided texture with sampler name 'uDepthMap' is not longer supported, use 'uSceneDepthMap' instead`);
+
+                if (samplerName === 'uSceneDepthMap') {
+                    Debug.warnOnce('A sampler uSceneDepthMap is used by the shader but a scene depth texture is not available. Use CameraComponent.requestSceneDepthMap / enable Depth Grabpass on the Camera Component to enable it.');
                 }
-                if (samplerName === 'uSceneColorMap' || samplerName === 'texture_grabPass') {
-                    Debug.warnOnce(`A sampler ${samplerName} is used by the shader but a scene color texture is not available. Use CameraComponent.requestSceneColorMap / enable Color Grabpass on the Camera Component to enable it.`);
+                if (samplerName === 'uSceneColorMap') {
+                    Debug.warnOnce('A sampler uSceneColorMap is used by the shader but a scene color texture is not available. Use CameraComponent.requestSceneColorMap / enable Color Grabpass on the Camera Component to enable it.');
                 }
                 // #endif
 

--- a/src/scene/graphics/render-pass-color-grab.js
+++ b/src/scene/graphics/render-pass-color-grab.js
@@ -5,7 +5,7 @@ import { RenderTarget } from "../../platform/graphics/render-target.js";
 import { Texture } from "../../platform/graphics/texture.js";
 
 // uniform names (first is current name, second one is deprecated name for compatibility)
-const _colorUniformNames = ['uSceneColorMap', 'texture_grabPass'];
+const _colorUniformName = 'uSceneColorMap';
 
 /**
  * A render pass implementing grab of a color buffer.
@@ -50,7 +50,7 @@ class RenderPassColorGrab extends RenderPass {
         // allocate texture buffer
         const mipmaps = device.isWebGL2;
         const texture = new Texture(device, {
-            name: _colorUniformNames[0],
+            name: _colorUniformName,
             format,
             width: sourceRenderTarget ? sourceRenderTarget.colorBuffer.width : device.width,
             height: sourceRenderTarget ? sourceRenderTarget.colorBuffer.height : device.height,
@@ -108,7 +108,7 @@ class RenderPassColorGrab extends RenderPass {
 
         // assign uniform
         const colorBuffer = this.colorRenderTarget.colorBuffer;
-        _colorUniformNames.forEach(name => device.scope.resolve(name).setValue(colorBuffer));
+        device.scope.resolve(_colorUniformName).setValue(colorBuffer);
     }
 
     execute() {

--- a/src/scene/graphics/render-pass-color-grab.js
+++ b/src/scene/graphics/render-pass-color-grab.js
@@ -4,7 +4,7 @@ import { RenderPass } from "../../platform/graphics/render-pass.js";
 import { RenderTarget } from "../../platform/graphics/render-target.js";
 import { Texture } from "../../platform/graphics/texture.js";
 
-// uniform names (first is current name, second one is deprecated name for compatibility)
+// uniform name
 const _colorUniformName = 'uSceneColorMap';
 
 /**

--- a/src/scene/graphics/render-pass-depth-grab.js
+++ b/src/scene/graphics/render-pass-depth-grab.js
@@ -4,7 +4,7 @@ import { RenderPass } from "../../platform/graphics/render-pass.js";
 import { RenderTarget } from "../../platform/graphics/render-target.js";
 import { Texture } from "../../platform/graphics/texture.js";
 
-// uniform names (first is current name, second one is deprecated name for compatibility)
+// uniform name
 const _depthUniformName = 'uSceneDepthMap';
 
 /**

--- a/src/scene/graphics/render-pass-depth-grab.js
+++ b/src/scene/graphics/render-pass-depth-grab.js
@@ -5,7 +5,7 @@ import { RenderTarget } from "../../platform/graphics/render-target.js";
 import { Texture } from "../../platform/graphics/texture.js";
 
 // uniform names (first is current name, second one is deprecated name for compatibility)
-const _depthUniformNames = ['uSceneDepthMap', 'uDepthMap'];
+const _depthUniformName = 'uSceneDepthMap';
 
 /**
  * A render pass implementing grab of a depth buffer, used on WebGL 2 and WebGPU devices.
@@ -39,7 +39,7 @@ class RenderPassDepthGrab extends RenderPass {
 
         // allocate texture buffer
         const texture = new Texture(device, {
-            name: _depthUniformNames[0],
+            name: _depthUniformName,
             format,
             width: sourceRenderTarget ? sourceRenderTarget.colorBuffer.width : device.width,
             height: sourceRenderTarget ? sourceRenderTarget.colorBuffer.height : device.height,
@@ -116,7 +116,7 @@ class RenderPassDepthGrab extends RenderPass {
 
         // assign uniform
         const colorBuffer = useDepthBuffer ? this.depthRenderTarget.depthBuffer : this.depthRenderTarget.colorBuffer;
-        _depthUniformNames.forEach(name => device.scope.resolve(name).setValue(colorBuffer));
+        device.scope.resolve(_depthUniformName).setValue(colorBuffer);
     }
 
     execute() {


### PR DESCRIPTION
- if the old names are still used by the user shaders, the engine asserts and prints instructions on what name to use instead.