### PR TITLE
Remove Listener velocity

### DIFF
--- a/src/platform/sound/listener.js
+++ b/src/platform/sound/listener.js
@@ -23,12 +23,6 @@ class Listener {
     position = new Vec3();
 
     /**
-     * @type {Vec3}
-     * @private
-     */
-    velocity = new Vec3();
-
-    /**
      * @type {Mat4}
      * @private
      */
@@ -69,27 +63,6 @@ class Listener {
                 listener.setPosition(position.x, position.y, position.z);
             }
         }
-    }
-
-    /**
-     * Get the velocity of the listener.
-     *
-     * @returns {Vec3} The velocity of the listener.
-     * @deprecated
-     */
-    getVelocity() {
-        Debug.warn('Listener#getVelocity is not implemented.');
-        return this.velocity;
-    }
-
-    /**
-     * Set the velocity of the listener.
-     *
-     * @param {Vec3} velocity - The new velocity of the listener.
-     * @deprecated
-     */
-    setVelocity(velocity) {
-        Debug.warn('Listener#setVelocity is not implemented.');
     }
 
     /**

--- a/src/platform/sound/listener.js
+++ b/src/platform/sound/listener.js
@@ -1,4 +1,3 @@
-import { Debug } from '../../core/debug.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { Vec3 } from '../../core/math/vec3.js';
 


### PR DESCRIPTION
Removes long deprecated internal `Listener` `set/getVelocity` API. Since internal, it's not technically a BREAKING change.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
