### PR TITLE
Refactor the way shaders get created for particle systems

### DIFF
--- a/examples/src/examples/graphics/particles-mesh.controls.mjs
+++ b/examples/src/examples/graphics/particles-mesh.controls.mjs
@@ -1,0 +1,64 @@
+import * as pc from 'playcanvas';
+
+/**
+ * @param {import('../../app/components/Example.mjs').ControlOptions} options - The options.
+ * @returns {JSX.Element} The returned JSX Element.
+ */
+export function controls({ observer, ReactPCUI, React, jsx, fragment }) {
+    const { BindingTwoWay, LabelGroup, Panel, SliderInput, BooleanInput, SelectInput } = ReactPCUI;
+    return fragment(
+        jsx(
+            Panel,
+            { headerText: 'Settings' },
+            jsx(
+                LabelGroup,
+                { text: 'Lifetime' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'settings.lifetime' },
+                    min: 0,
+                    max: 5,
+                    precision: 1
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Num Particles' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'settings.numParticles' },
+                    min: 1,
+                    max: 1000,
+                    precision: 0
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Enabled' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'settings.enabled' }
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Lighting' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'settings.lighting' }
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Align To Motion' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'settings.alignToMotion' }
+                })
+            )
+        )
+    );
+}

--- a/examples/src/examples/graphics/particles-mesh.controls.mjs
+++ b/examples/src/examples/graphics/particles-mesh.controls.mjs
@@ -1,11 +1,9 @@
-import * as pc from 'playcanvas';
-
 /**
  * @param {import('../../app/components/Example.mjs').ControlOptions} options - The options.
  * @returns {JSX.Element} The returned JSX Element.
  */
 export function controls({ observer, ReactPCUI, React, jsx, fragment }) {
-    const { BindingTwoWay, LabelGroup, Panel, SliderInput, BooleanInput, SelectInput } = ReactPCUI;
+    const { BindingTwoWay, LabelGroup, Panel, SliderInput, BooleanInput } = ReactPCUI;
     return fragment(
         jsx(
             Panel,

--- a/examples/src/examples/graphics/particles-mesh.example.mjs
+++ b/examples/src/examples/graphics/particles-mesh.example.mjs
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import { data } from 'examples/observer';
 import { deviceType, rootPath } from 'examples/utils';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -162,6 +163,19 @@ assetListLoader.load(() => {
         lighting: true,
         halfLambert: true,
         alignToMotion: true
+    });
+
+    data.set('settings', {
+        lifetime: 1,
+        numParticles: 150,
+        lighting: true,
+        alignToMotion: true,
+        enabled: true
+    });
+
+    data.on('*:set', (/** @type {string} */ path, value) => {
+        const propertyName = path.split('.')[1];
+        entity.particlesystem[propertyName] = value;
     });
 });
 

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -2070,6 +2070,19 @@ class ParticleSystemComponent extends Component {
     }
 
     /**
+     * Called by the Editor when the component is selected, to allow custom in Editor behavior.
+     *
+     * @private
+     */
+    setInTools() {
+        const { emitter } = this;
+        if (emitter && !emitter.inTools) {
+            emitter.inTools = true;
+            this.rebuild();
+        }
+    }
+
+    /**
      * Rebuilds all data used by this particle system.
      *
      * @private
@@ -2079,7 +2092,6 @@ class ParticleSystemComponent extends Component {
         this.enabled = false;
         if (this.emitter) {
             this.emitter.rebuild(); // worst case: required to rebuild buffers/shaders
-            this.emitter.meshInstance.node = this.entity;
         }
         this.enabled = enabled;
     }

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -47,6 +47,7 @@ import { shaderChunks } from '../shader-lib/chunks/chunks.js';
 import { particle } from '../shader-lib/programs/particle.js';
 import { ParticleCPUUpdater } from './cpu-updater.js';
 import { ParticleGPUUpdater } from './gpu-updater.js';
+import { ParticleMaterial } from './particle-material.js';
 
 const particleVerts = [
     [-1, -1],
@@ -221,6 +222,21 @@ function divGraphFrom2Curves(curve1, curve2, outUMax) {
 const particleEmitterDeviceCache = new DeviceCache();
 
 class ParticleEmitter {
+    /** @type {ParticleMaterial|null} */
+    material = null;
+
+    /** @type {Texture|null} */
+    internalTex0 = null;
+
+    /** @type {Texture|null} */
+    internalTex1 = null;
+
+    /** @type {Texture|null} */
+    internalTex2 = null;
+
+    /** @type {Texture|null} */
+    colorParam = null;
+
     constructor(graphicsDevice, options) {
         this.graphicsDevice = graphicsDevice;
         const gd = graphicsDevice;
@@ -320,11 +336,6 @@ class ParticleEmitter {
         this.animParams = new Float32Array(4);
         this.animIndexParams = new Float32Array(2);
 
-        this.internalTex0 = null;
-        this.internalTex1 = null;
-        this.internalTex2 = null;
-        this.colorParam = null;
-
         this.vbToSort = null;
         this.vbOld = null;
         this.particleDistance = null;
@@ -404,7 +415,6 @@ class ParticleEmitter {
     }
 
     onChangeCamera() {
-        this.regenShader();
         this.resetMaterial();
     }
 
@@ -678,16 +688,8 @@ class ParticleEmitter {
         mesh.primitive[0].count = (this.numParticles * this.numParticleIndices);
         mesh.primitive[0].indexed = true;
 
-        this.material = new Material();
-        this.material.name = this.node.name;
-        this.material.cull = CULLFACE_NONE;
-        this.material.alphaWrite = false;
-        this.material.blendType = this.blendType;
+        this.material = this._createMaterial();
 
-        this.material.depthWrite = this.depthWrite;
-        this.material.emitter = this;
-
-        this.regenShader();
         this.resetMaterial();
 
         const wasVisible = this.meshInstance ? this.meshInstance.visible : true;
@@ -808,69 +810,16 @@ class ParticleEmitter {
         }
     }
 
-    regenShader() {
-        const programLib = getProgramLibrary(this.graphicsDevice);
-        programLib.register('particle', particle);
+    _createMaterial() {
 
-        const hasNormal = (this.normalMap !== null);
-        this.normalOption = 0;
-        if (this.lighting) {
-            this.normalOption = hasNormal ? 2 : 1;
-        }
-        // getShaderVariant is also called by pc.Scene when all shaders need to be updated
-        this.material.getShaderVariant = function (dev, sc, defs, renderParams, pass, sortedLights, viewUniformFormat, viewBindGroupFormat) {
+        const material = new ParticleMaterial(this);
+        material.name = `EmitterMaterial:${this.node.name}`;
+        material.cull = CULLFACE_NONE;
+        material.alphaWrite = false;
+        material.blendType = this.blendType;
+        material.depthWrite = this.depthWrite;
 
-            // The app works like this:
-            // 1. Emitter init
-            // 2. Update. No camera is assigned to emitters
-            // 3. Render; activeCamera = camera; shader init
-            // 4. Update. activeCamera is set to emitters
-            // -----
-            // The problem with 1st frame render is that we init the shader without having any camera set to emitter -
-            // so wrong shader is being compiled.
-            // To fix it, we need to check activeCamera!=emitter.camera in shader init too
-            if (this.emitter.scene) {
-                if (this.emitter.camera !== this.emitter.scene._activeCamera) {
-                    this.emitter.camera = this.emitter.scene._activeCamera;
-                    this.emitter.onChangeCamera();
-                }
-            }
-
-            // set by Editor if running inside editor
-            const inTools = this.emitter.inTools;
-            const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat);
-
-            // renderParams and other parametesr should be passed in, but they are not so work around it
-            renderParams = renderParams ?? this.emitter.camera?.renderingParams ?? this.emitter.scene?.rendering;
-
-            const shader = programLib.getProgram('particle', {
-                pass: SHADER_FORWARD,
-                useCpu: this.emitter.useCpu,
-                normal: this.emitter.normalOption,
-                halflambert: this.emitter.halfLambert,
-                stretch: this.emitter.stretch,
-                alignToMotion: this.emitter.alignToMotion,
-                soft: this.emitter.depthSoftening,
-                mesh: this.emitter.useMesh,
-                gamma: renderParams?.shaderOutputGamma ?? GAMMA_NONE,
-                toneMap: renderParams?.toneMapping ?? TONEMAP_LINEAR,
-                fog: (this.emitter.scene && !this.emitter.noFog) ? this.emitter.scene.fog : 'none',
-                wrap: this.emitter.wrap && this.emitter.wrapBounds,
-                localSpace: this.emitter.localSpace,
-
-                // in Editor, screen space particles (children of 2D Screen) are still rendered in 3d space
-                screenSpace: inTools ? false : this.emitter.screenSpace,
-
-                blend: this.blendType,
-                animTex: this.emitter._isAnimated(),
-                animTexLoop: this.emitter.animLoop,
-                pack8: this.emitter.pack8,
-                customFace: this.emitter.orientation !== PARTICLEORIENTATION_SCREEN
-            }, processingOptions);
-
-            return shader;
-        };
-        this.material.shader = this.material.getShaderVariant();
+        return material;
     }
 
     resetMaterial() {
@@ -968,13 +917,14 @@ class ParticleEmitter {
 
         if ((this.vertexBuffer === undefined) || (this.vertexBuffer.getNumVertices() !== psysVertCount)) {
             // Create the particle vertex format
+            const elements = [];
             if (!this.useCpu) {
                 // GPU: XYZ = quad vertex position; W = INT: particle ID, FRAC: random factor
-                const elements = [{
+                elements.push({
                     semantic: SEMANTIC_ATTR0,
                     components: 4,
                     type: TYPE_FLOAT32
-                }];
+                });
                 if (this.useMesh) {
                     elements.push({
                         semantic: SEMANTIC_ATTR1,
@@ -982,14 +932,8 @@ class ParticleEmitter {
                         type: TYPE_FLOAT32
                     });
                 }
-                const particleFormat = new VertexFormat(this.graphicsDevice, elements);
-
-                this.vertexBuffer = new VertexBuffer(this.graphicsDevice, particleFormat, psysVertCount, {
-                    usage: BUFFER_DYNAMIC
-                });
-                this.indexBuffer = new IndexBuffer(this.graphicsDevice, INDEXFORMAT_UINT32, psysIndexCount);
             } else {
-                const elements = [{
+                elements.push({
                     semantic: SEMANTIC_ATTR0,
                     components: 4,
                     type: TYPE_FLOAT32
@@ -1009,14 +953,15 @@ class ParticleEmitter {
                     semantic: SEMANTIC_ATTR4,
                     components: this.useMesh ? 4 : 2,
                     type: TYPE_FLOAT32
-                }];
-                const particleFormat = new VertexFormat(this.graphicsDevice, elements);
-
-                this.vertexBuffer = new VertexBuffer(this.graphicsDevice, particleFormat, psysVertCount, {
-                    usage: BUFFER_DYNAMIC
                 });
-                this.indexBuffer = new IndexBuffer(this.graphicsDevice, INDEXFORMAT_UINT32, psysIndexCount);
             }
+
+            const vertexFormat = new VertexFormat(this.graphicsDevice, elements);
+
+            this.vertexBuffer = new VertexBuffer(this.graphicsDevice, vertexFormat, psysVertCount, {
+                usage: BUFFER_DYNAMIC
+            });
+            this.indexBuffer = new IndexBuffer(this.graphicsDevice, INDEXFORMAT_UINT32, psysIndexCount);
 
             // Fill the vertex buffer
             const data = new Float32Array(this.vertexBuffer.lock());
@@ -1214,70 +1159,46 @@ class ParticleEmitter {
     }
 
     _destroyResources() {
-        if (this.particleTexIN) {
-            this.particleTexIN.destroy();
-            this.particleTexIN = null;
-        }
+        this.particleTexIN?.destroy();
+        this.particleTexIN = null;
 
-        if (this.particleTexOUT) {
-            this.particleTexOUT.destroy();
-            this.particleTexOUT = null;
-        }
+        this.particleTexOUT?.destroy();
+        this.particleTexOUT = null;
 
         if (this.particleTexStart && this.particleTexStart.destroy) {
             this.particleTexStart.destroy();
             this.particleTexStart = null;
         }
 
-        if (this.rtParticleTexIN) {
-            this.rtParticleTexIN.destroy();
-            this.rtParticleTexIN = null;
-        }
+        this.rtParticleTexIN?.destroy();
+        this.rtParticleTexIN = null;
 
-        if (this.rtParticleTexOUT) {
-            this.rtParticleTexOUT.destroy();
-            this.rtParticleTexOUT = null;
-        }
+        this.rtParticleTexOUT?.destroy();
+        this.rtParticleTexOUT = null;
 
-        if (this.internalTex0) {
-            this.internalTex0.destroy();
-            this.internalTex0 = null;
-        }
+        this.internalTex0?.destroy();
+        this.internalTex0 = null;
 
-        if (this.internalTex1) {
-            this.internalTex1.destroy();
-            this.internalTex1 = null;
-        }
+        this.internalTex1?.destroy();
+        this.internalTex1 = null;
 
-        if (this.internalTex2) {
-            this.internalTex2.destroy();
-            this.internalTex2 = null;
-        }
+        this.internalTex2?.destroy();
+        this.internalTex2 = null;
 
-        if (this.internalTex3) {
-            this.internalTex3.destroy();
-            this.internalTex3 = null;
-        }
+        this.internalTex3?.destroy();
+        this.internalTex3 = null;
 
-        if (this.colorParam) {
-            this.colorParam.destroy();
-            this.colorParam = null;
-        }
+        this.colorParam?.destroy();
+        this.colorParam = null;
 
-        if (this.vertexBuffer) {
-            this.vertexBuffer.destroy();
-            this.vertexBuffer = undefined; // we are testing if vb is undefined in some code, no idea why
-        }
+        this.vertexBuffer?.destroy();
+        this.vertexBuffer = undefined; // we are testing if vb is undefined in some code, no idea why
 
-        if (this.indexBuffer) {
-            this.indexBuffer.destroy();
-            this.indexBuffer = undefined;
-        }
+        this.indexBuffer?.destroy();
+        this.indexBuffer = undefined;
 
-        if (this.material) {
-            this.material.destroy();
-            this.material = null;
-        }
+        this.material?.destroy();
+        this.material = null;
 
         // note: shaders should not be destroyed as they could be shared between emitters
     }

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -26,25 +26,18 @@ import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { Texture } from '../../platform/graphics/texture.js';
 import { VertexBuffer } from '../../platform/graphics/vertex-buffer.js';
 import { VertexFormat } from '../../platform/graphics/vertex-format.js';
-import { ShaderProcessorOptions } from '../../platform/graphics/shader-processor-options.js';
 
 import {
     BLEND_NORMAL,
     EMITTERSHAPE_BOX,
-    GAMMA_NONE,
     PARTICLEMODE_GPU,
     PARTICLEORIENTATION_SCREEN, PARTICLEORIENTATION_WORLD,
-    PARTICLESORT_NONE,
-    SHADER_FORWARD,
-    TONEMAP_LINEAR
+    PARTICLESORT_NONE
 } from '../constants.js';
 import { Mesh } from '../mesh.js';
 import { MeshInstance } from '../mesh-instance.js';
-import { Material } from '../materials/material.js';
-import { getProgramLibrary } from '../shader-lib/get-program-library.js';
 import { createShaderFromCode } from '../shader-lib/utils.js';
 import { shaderChunks } from '../shader-lib/chunks/chunks.js';
-import { particle } from '../shader-lib/programs/particle.js';
 import { ParticleCPUUpdater } from './cpu-updater.js';
 import { ParticleGPUUpdater } from './gpu-updater.js';
 import { ParticleMaterial } from './particle-material.js';

--- a/src/scene/particle-system/particle-material.js
+++ b/src/scene/particle-system/particle-material.js
@@ -1,0 +1,74 @@
+import { Debug } from '../../core/debug.js';
+import { ShaderProcessorOptions } from '../../platform/graphics/shader-processor-options.js';
+import {
+    GAMMA_NONE,
+    PARTICLEORIENTATION_SCREEN,
+    SHADER_FORWARD,
+    TONEMAP_LINEAR
+} from '../constants.js';
+import { getProgramLibrary } from '../shader-lib/get-program-library.js';
+import { Material } from '../materials/material.js'
+import { particle } from '../shader-lib/programs/particle.js';
+
+/**
+ * @import { ParticleEmitter } from './particle-emitter.js'
+ */
+
+/**
+ * A material for rendering particle geometry by the particle emitter.
+ *
+ * @category Graphics
+ */
+class ParticleMaterial extends Material {
+    /**
+     * The color of the particles.
+     *
+     * @type {ParticleEmitter}
+     */
+    emitter = null;
+
+    constructor(emitter) {
+        super();
+
+        this.emitter = emitter;
+        Debug.assert(emitter);
+    }
+
+    getShaderVariant(device, scene, objDefs, renderParams, pass, sortedLights, viewUniformFormat, viewBindGroupFormat, vertexFormat) {
+
+        const { emitter } = this;
+        const options = {
+            pass: SHADER_FORWARD,
+            useCpu: this.emitter.useCpu,
+            normal: emitter.lighting ? ((emitter.normalMap !== null) ? 2 : 1) : 0,
+            halflambert: this.emitter.halfLambert,
+            stretch: this.emitter.stretch,
+            alignToMotion: this.emitter.alignToMotion,
+            soft: this.emitter.depthSoftening,
+            mesh: this.emitter.useMesh,
+            gamma: renderParams?.shaderOutputGamma ?? GAMMA_NONE,
+            toneMap: renderParams?.toneMapping ?? TONEMAP_LINEAR,
+            fog: (this.emitter.scene && !this.emitter.noFog) ? this.emitter.scene.fog : 'none',
+            wrap: this.emitter.wrap && this.emitter.wrapBounds,
+            localSpace: this.emitter.localSpace,
+
+            // in Editor, screen space particles (children of 2D Screen) are still rendered in 3d space
+            screenSpace: emitter.inTools ? false : this.emitter.screenSpace,
+
+            blend: this.blendType,
+            animTex: this.emitter._isAnimated(),
+            animTexLoop: this.emitter.animLoop,
+            pack8: this.emitter.pack8,
+            customFace: this.emitter.orientation !== PARTICLEORIENTATION_SCREEN
+        };
+
+        const processingOptions = new ShaderProcessorOptions(viewUniformFormat, viewBindGroupFormat, vertexFormat);
+
+        const library = getProgramLibrary(device);
+        library.register('particle', particle);
+
+        return library.getProgram('particle', options, processingOptions, this.userId);
+    }
+}
+
+export { ParticleMaterial };

--- a/src/scene/particle-system/particle-material.js
+++ b/src/scene/particle-system/particle-material.js
@@ -7,7 +7,7 @@ import {
     TONEMAP_LINEAR
 } from '../constants.js';
 import { getProgramLibrary } from '../shader-lib/get-program-library.js';
-import { Material } from '../materials/material.js'
+import { Material } from '../materials/material.js';
 import { particle } from '../shader-lib/programs/particle.js';
 
 /**


### PR DESCRIPTION
- remove manual handling of shader creation, where shaders would need to be recreated when the camera was supplied on the second frame
- instead, use the same system as other material / shader types and create shader when needed by the renderer, using it's supplied parameters - new internal `ParticleMatrial` class handles it
- slight clean up to the way Editor triggers a custom mode for 2D particles

- exposed few parameters to the engine example to allow for testing
<img width="806" alt="Screenshot 2024-07-11 at 10 51 58" src="https://github.com/playcanvas/engine/assets/59932779/a5706063-6900-4220-bc80-2a6458f873de">
