### PR TITLE
Remove private StandardMaterial.tbnFast option support

### DIFF
--- a/src/scene/materials/lit-material-options-builder.js
+++ b/src/scene/materials/lit-material-options-builder.js
@@ -52,7 +52,6 @@ class LitMaterialOptionsBuilder {
         litOptions.pixelSnap = material.pixelSnap;
 
         litOptions.ambientSH = material.ambientSH;
-        litOptions.fastTbn = material.fastTbn;
         litOptions.twoSidedLighting = material.twoSidedLighting;
         litOptions.occludeDirect = material.occludeDirect;
         litOptions.occludeSpecular = material.occludeSpecular;

--- a/src/scene/materials/lit-material.js
+++ b/src/scene/materials/lit-material.js
@@ -39,8 +39,6 @@ class LitMaterial extends Material {
 
     nineSlicedMode = null;
 
-    fastTbn = false;
-
     twoSidedLighting = false;
 
     occludeDirect = false;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -254,7 +254,6 @@ class StandardMaterialOptionsBuilder {
         options.litOptions.pixelSnap = stdMat.pixelSnap;
 
         options.litOptions.ambientSH = !!stdMat.ambientSH;
-        options.litOptions.fastTbn = stdMat.fastTbn;
         options.litOptions.twoSidedLighting = stdMat.twoSidedLighting;
         options.litOptions.occludeSpecular = stdMat.occludeSpecular;
         options.litOptions.occludeSpecularFloat = (stdMat.occludeSpecularIntensity !== 1.0);

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -147,7 +147,6 @@ const standardMaterialParameterTypes = {
     // forceUv1
     // occludeDirect
     // occludeSpecularIntensity
-    // fastTbn
     // normalizeNormalMap
 
     // msdfMap

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1188,7 +1188,6 @@ function _defineMaterialProps() {
     _defineFlag('sheenTint', false);
     _defineFlag('specularTint', false);
     _defineFlag('specularityFactorTint', false);
-    _defineFlag('fastTbn', false);
     _defineFlag('useMetalness', false);
     _defineFlag('useMetalnessSpecularColor', false);
     _defineFlag('useSheen', false);

--- a/src/scene/shader-lib/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/chunks/chunk-validation.js
@@ -68,7 +68,6 @@ const chunkVersions = {
     TBNPS: CHUNKAPI_1_62,
     TBNObjectSpacePS: CHUNKAPI_1_62,
     TBNderivativePS: CHUNKAPI_1_62,
-    TBNfastPS: CHUNKAPI_1_62,
 
     endPS: CHUNKAPI_1_65,
     metalnessModulatePS: CHUNKAPI_1_65,

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -174,7 +174,6 @@ import storeEVSMPS from './lit/frag/storeEVSM.js';
 import tangentBinormalVS from './lit/vert/tangentBinormal.js';
 import TBNPS from './lit/frag/TBN.js';
 import TBNderivativePS from './lit/frag/TBNderivative.js';
-import TBNfastPS from './lit/frag/TBNfast.js';
 import TBNObjectSpacePS from './lit/frag/TBNObjectSpace.js';
 import thicknessPS from './standard/frag/thickness.js';
 import tonemappingAcesPS from './common/frag/tonemappingAces.js';
@@ -378,7 +377,6 @@ const shaderChunks = {
     tangentBinormalVS,
     TBNPS,
     TBNderivativePS,
-    TBNfastPS,
     TBNObjectSpacePS,
     thicknessPS,
     tonemappingAcesPS,

--- a/src/scene/shader-lib/chunks/lit/frag/TBNfast.js
+++ b/src/scene/shader-lib/chunks/lit/frag/TBNfast.js
@@ -1,5 +1,0 @@
-export default /* glsl */`
-void getTBN(vec3 tangent, vec3 binormal, vec3 normal) {
-    dTBN = mat3(tangent, binormal, normal);
-}
-`;

--- a/src/scene/shader-lib/programs/lit-shader-options.js
+++ b/src/scene/shader-lib/programs/lit-shader-options.js
@@ -111,14 +111,6 @@ class LitShaderOptions {
     ambientSH = false;
 
     /**
-     * Use slightly cheaper normal mapping code (skip tangent space normalization). Can look buggy
-     * sometimes.
-     *
-     * @type {boolean}
-     */
-    fastTbn = false;
-
-    /**
      * The value of {@link StandardMaterial#twoSidedLighting}.
      *
      * @type {boolean}

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -663,7 +663,7 @@ class LitShader {
 
         if (hasTBN) {
             if (options.hasTangents) {
-                func.append(options.fastTbn ? chunks.TBNfastPS : chunks.TBNPS);
+                func.append(chunks.TBNPS);
             } else {
                 if (options.useNormals || options.useClearCoatNormals) {
                     func.append(chunks.TBNderivativePS.replace(/\$UV/g, this.lightingUv));


### PR DESCRIPTION
- this option uses slightly faster TBN generation from TBN vectors by avoiding normalization, which could create incorrect results in some cases. Removed.