### PR TITLE
[BREAKING] Remove StandardMaterial.sheenTint

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -688,6 +688,7 @@ function _deprecateTint(name) {
     });
 }
 
+_deprecateTint('sheenTint');
 _deprecateTint('diffuseTint');
 _deprecateTint('emissiveTint');
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -238,7 +238,6 @@ class StandardMaterialOptionsBuilder {
 
         options.iridescenceTint = stdMat.iridescence !== 1.0 ? 1 : 0;
 
-        options.sheenTint = (stdMat.useSheen && notWhite(stdMat.sheen)) ? 2 : 0;
         options.sheenGlossTint = 1;
 
         options.glossInvert = stdMat.glossInvert;

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -64,7 +64,6 @@ const standardMaterialParameterTypes = {
 
     useSheen: 'boolean',
     sheen: 'rgb',
-    sheenTint: 'boolean',
     ..._textureParameter('sheen'),
     sheenGloss: 'number',
     sheenGlossTint: 'boolean',

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -319,8 +319,6 @@ const _tempColor = new Color();
  * @property {boolean} useSheen Toggle sheen specular effect on/off.
  * @property {Color} sheen The specular color of the sheen (fabric) microfiber structure.
  * This color value is 3-component (RGB), where each component is between 0 and 1.
- * @property {boolean} sheenTint Multiply sheen map and/or sheen vertex color by the constant
- * sheen value.
  * @property {Texture|null} sheenMap The sheen microstructure color map of the material (default is
  * null).
  * @property {number} sheenMapUv Sheen map UV channel.
@@ -730,9 +728,9 @@ class StandardMaterial extends Material {
             if (!this.specularityFactorMap || this.specularityFactorTint) {
                 this._setParameter('material_specularityFactor', this.specularityFactor);
             }
-            if (!this.sheenMap || this.sheenTint) {
-                this._setParameter('material_sheen', getUniform('sheen'));
-            }
+
+            this._setParameter('material_sheen', getUniform('sheen'));
+
             if (!this.sheenGlossMap || this.sheenGlossTint) {
                 this._setParameter('material_sheenGloss', this.sheenGloss);
             }
@@ -1185,7 +1183,6 @@ function _defineMaterialProps() {
     });
 
     _defineFlag('ambientTint', false);
-    _defineFlag('sheenTint', false);
     _defineFlag('specularTint', false);
     _defineFlag('specularityFactorTint', false);
     _defineFlag('useMetalness', false);

--- a/src/scene/shader-lib/chunks/standard/frag/sheen.js
+++ b/src/scene/shader-lib/chunks/standard/frag/sheen.js
@@ -1,15 +1,9 @@
 export default /* glsl */`
 
-#ifdef MAPCOLOR
 uniform vec3 material_sheen;
-#endif
 
 void getSheen() {
-    vec3 sheenColor = vec3(1, 1, 1);
-
-    #ifdef MAPCOLOR
-    sheenColor *= material_sheen;
-    #endif
+    vec3 sheenColor = material_sheen;
 
     #ifdef MAPTEXTURE
     sheenColor *= $DECODE(texture2DBias($SAMPLER, $UV, textureBias)).$CH;

--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -175,7 +175,6 @@ const STANDARD_MAT_PROPS = [
     ['sheenMapRotation', 'number'],
     ['sheenMapTiling', 'Vec2'],
     ['sheenMapUv', 'number'],
-    ['sheenTint', 'boolean'],
     ['sheenVertexColor', 'boolean'],
     ['sheenVertexColorChannel', 'string'],
     ['sphereMap', 'Texture|null'],


### PR DESCRIPTION
Removed the material property sheenTint, and it's assumed to be always true:
- it used to default to white color, and so it has no effect with the multiply unless the color has been changed.
- this is breaking in only a small number of cases, where `sheen` color has been changed, but `sheenTint` left as false
- we'll handle the correction inside the Editor projects