### PR TITLE
Small gizmo event handler fix

### DIFF
--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -512,8 +512,8 @@ class Gizmo extends EventHandler {
     destroy() {
         this.detach();
 
-        this._device.canvas.removeEventListener('pointerdown', this._onPointerDown);
-        this._device.canvas.removeEventListener('pointermove', this._onPointerMove);
+        this._device.canvas.removeEventListener('pointerdown', this._onPointerDown, true);
+        this._device.canvas.removeEventListener('pointermove', this._onPointerMove, true);
         this._device.canvas.removeEventListener('pointerup', this._onPointerUp);
 
         this.root.destroy();


### PR DESCRIPTION
Fixes a small bug where removeEventListener wasn't also specifying capture flag (in #6790)