### PR TITLE
Remove opacityTint internal flag

### DIFF
--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -392,8 +392,6 @@ class ElementComponentSystem extends ComponentSystem {
         material.emissiveMap = this._defaultTexture;
         material.opacityMap = this._defaultTexture;
         material.opacityMapChannel = 'a';
-        material.opacityTint = true;
-        material.opacity = 0; // use non-1 opacity to compile shader correctly
         material.useLighting = false;
         material.useTonemap = false;
         material.useFog = false;

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -77,8 +77,6 @@ class SpriteComponentSystem extends ComponentSystem {
             material.emissiveMap = texture;
             material.opacityMap = texture;
             material.opacityMapChannel = 'a';
-            material.opacityTint = true;
-            material.opacity = 0; // use non-1 opacity to compile shader correctly
             material.useLighting = false;
             material.useTonemap = false;
             material.useFog = false;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -184,7 +184,6 @@ class StandardMaterialOptionsBuilder {
     }
 
     _updateMinOptions(options, stdMat, pass) {
-        options.opacityTint = stdMat.blendType !== BLEND_NONE || stdMat.opacityShadowDither !== DITHER_NONE;
 
         // pre-pass uses the same dither setting as forward pass, otherwise shadow dither
         const isPrepass = pass === SHADER_PREPASS_VELOCITY;
@@ -209,7 +208,6 @@ class StandardMaterialOptionsBuilder {
 
         const isPackedNormalMap = stdMat.normalMap ? (stdMat.normalMap.format === PIXELFORMAT_DXT5 || stdMat.normalMap.type === TEXTURETYPE_SWIZZLEGGGR) : false;
 
-        options.opacityTint = (stdMat.blendType !== BLEND_NONE || stdMat.alphaTest > 0 || stdMat.opacityDither !== DITHER_NONE) ? 1 : 0;
         options.specularTint = specularTint ? 2 : 0;
         options.specularityFactorTint = specularityFactorTint ? 1 : 0;
         options.metalnessTint = (stdMat.useMetalness && stdMat.metalness < 1) ? 1 : 0;

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -36,13 +36,6 @@ class StandardMaterialOptions {
      */
     glossTint = false;
 
-    /**
-     * Defines if {@link StandardMaterial#opacity} constant should affect opacity value.
-     *
-     * @type {boolean}
-     */
-    opacityTint = false;
-
     emissiveEncoding = 'linear';
 
     lightMapEncoding = 'linear';

--- a/src/scene/shader-lib/chunks/standard/frag/opacity.js
+++ b/src/scene/shader-lib/chunks/standard/frag/opacity.js
@@ -1,14 +1,8 @@
 export default /* glsl */`
-#ifdef MAPFLOAT
 uniform float material_opacity;
-#endif
 
 void getOpacity() {
-    dAlpha = 1.0;
-
-    #ifdef MAPFLOAT
-    dAlpha *= material_opacity;
-    #endif
+    dAlpha = material_opacity;
 
     #ifdef MAPTEXTURE
     dAlpha *= texture2DBias($SAMPLER, $UV, textureBias).$CH;


### PR DESCRIPTION
- not a breaking change as this was internal flag only, used to optimize one uniform
- this was causing a shader recompilation if alpha value change / blending mode changes, and so is removed.
