### PR TITLE
[BREAKING] Remove `pc.type`

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -38,10 +38,10 @@ function extend(target, ex) {
     for (const prop in ex) {
         const copy = ex[prop];
 
-        if (copy && typeof copy === 'object' && !Array.isArray(copy)) {
-            target[prop] = extend({}, copy);
-        } else if (Array.isArray(copy)) {
+        if (Array.isArray(copy)) {
             target[prop] = extend([], copy);
+        } else if (copy && typeof copy === 'object') {
+            target[prop] = extend({}, copy);
         } else {
             target[prop] = copy;
         }

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -9,36 +9,6 @@ const version = '$_CURRENT_SDK_VERSION';
  */
 const revision = '$_CURRENT_SDK_REVISION';
 
-const typeofs = ['undefined', 'number', 'string', 'boolean'];
-const objectTypes = {
-    '[object Array]': 'array',
-    '[object Object]': 'object',
-    '[object Function]': 'function',
-    '[object Date]': 'date',
-    '[object RegExp]': 'regexp',
-    '[object Float32Array]': 'float32array'
-};
-
-/**
- * Extended typeof() function, returns the type of the object.
- *
- * @param {object} obj - The object to get the type of.
- * @returns {string} The type string: "null", "undefined", "number", "string", "boolean", "array", "object", "function", "date", "regexp" or "float32array".
- * @ignore
- */
-function type(obj) {
-    if (obj === null) {
-        return 'null';
-    }
-
-    const typeString = typeof obj;
-    if (typeofs.includes(typeString)) {
-        return typeString;
-    }
-
-    return objectTypes[Object.prototype.toString.call(obj)];
-}
-
 /**
  * Merge the contents of two objects into a single object.
  *
@@ -57,7 +27,7 @@ function type(obj) {
  *     }
  * };
  *
- * pc.extend(A, B);
+ * extend(A, B);
  * A.a();
  * // logs "a"
  * A.b();
@@ -68,9 +38,9 @@ function extend(target, ex) {
     for (const prop in ex) {
         const copy = ex[prop];
 
-        if (type(copy) === 'object') {
+        if (copy && typeof copy === 'object' && !Array.isArray(copy)) {
             target[prop] = extend({}, copy);
-        } else if (type(copy) === 'array') {
+        } else if (Array.isArray(copy)) {
             target[prop] = extend([], copy);
         } else {
             target[prop] = copy;
@@ -80,4 +50,4 @@ function extend(target, ex) {
     return target;
 }
 
-export { extend, revision, type, version };
+export { extend, revision, version };

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ import './polyfill/typedarray-fill.js';
 
 // CORE
 export * from './core/constants.js';
-export { extend, revision, type, version } from './core/core.js';
+export { extend, revision, version } from './core/core.js';
 export { guid } from './core/guid.js';
 export { path } from './core/path.js';
 export { platform } from './core/platform.js';

--- a/src/platform/input/controller.js
+++ b/src/platform/input/controller.js
@@ -1,4 +1,3 @@
-import { type } from '../../core/core.js';
 import {
     ACTION_GAMEPAD, ACTION_KEYBOARD, ACTION_MOUSE,
     EVENT_MOUSEMOVE,
@@ -392,7 +391,7 @@ class Controller {
         if (this._axes[name]) {
             const len = this._axes[name].length;
             for (let i = 0; i < len; i++) {
-                if (type(this._axes[name][i]) === 'function') {
+                if (typeof this._axes[name][i] === 'function') {
                     const v = this._axes[name][i]();
                     if (Math.abs(v) > Math.abs(value)) {
                         value = v;

--- a/test/core/core.test.mjs
+++ b/test/core/core.test.mjs
@@ -1,41 +1,8 @@
-import { extend, type } from '../../src/core/core.js';
+import { extend } from '../../src/core/core.js';
 
 import { expect } from 'chai';
 
 describe('core', function () {
-
-    describe('#type', function () {
-
-        it('returns the correct types', function () {
-            const types = [
-                null,
-                1,
-                'a',
-                true,
-                {},
-                [],
-                function () {},
-                new Date(),
-                new RegExp()
-            ];
-            const expected = [
-                'null',
-                'number',
-                'string',
-                'boolean',
-                'object',
-                'array',
-                'function',
-                'date',
-                'regexp'
-            ];
-
-            for (let i = 0; i < types.length; i++) {
-                expect(type(types[i])).to.equal(expected[i]);
-            }
-        });
-
-    });
 
     describe('#extend', function () {
 


### PR DESCRIPTION
Another function that has been publicly exported since the dawn of time. But it doesn't offer any real value.

Note that it is not public API (and doesn't appear in the API reference) so it's not technically breaking.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
