### PR TITLE
Gizmo size invariant to canvas resizing

### DIFF
--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -26,6 +26,7 @@ const tmpR1 = new Ray();
 const MIN_GIZMO_SCALE = 1e-4;
 const PERS_SCALE_RATIO = 0.3;
 const ORTHO_SCALE_RATIO = 0.32;
+const CANVAS_RATIO = 1024;
 
 /**
  * Local coordinate space.
@@ -403,6 +404,10 @@ class Gizmo extends EventHandler {
             this._scale = this._camera.orthoHeight * ORTHO_SCALE_RATIO;
         }
         this._scale = Math.max(this._scale * this._size, MIN_GIZMO_SCALE);
+
+        const bounds = this._device.canvas.getBoundingClientRect();
+        this._scale *= CANVAS_RATIO / Math.min(bounds.width, bounds.height);
+
         this.root.setLocalScale(this._scale, this._scale, this._scale);
 
         this.fire(Gizmo.EVENT_SCALEUPDATE, this._scale);


### PR DESCRIPTION
Uses the bounding css dimensions of the canvas to keep the gizmo size invariant when resizing the canvas.
