### PR TITLE
Updated lint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,39 @@
+import playcanvasConfig from '@playcanvas/eslint-config';
+import babelParser from '@babel/eslint-parser';
+
+export default [
+  ...playcanvasConfig,
+  {
+    files: ['**/*.js', '**/*.mjs'],
+    globals: {
+      Ammo: 'readonly',
+      earcut: 'readonly',
+      glslang: 'readonly',
+      GPUBufferUsage: 'readonly',
+      GPUColorWrite: 'readonly',
+      GPUMapMode: 'readonly',
+      GPUShaderStage: 'readonly',
+      GPUTextureUsage: 'readonly',
+      opentype: 'readonly',
+      pc: 'readonly',
+      TWEEN: 'readonly',
+      twgsl: 'readonly',
+      webkitAudioContext: 'readonly',
+      XRRay: 'readonly',
+      XRRigidTransform: 'readonly',
+      XRWebGLLayer: 'readonly'
+    },
+    parser: babelParser,
+    parserOptions: {
+      requireConfigFile: false
+    },
+    rules: {
+      'jsdoc/check-tag-names': [
+        'error',
+        {
+          definedTags: ['attribute', 'category', 'import']
+        }
+      ]
+    }
+  }
+];

--- a/package.json
+++ b/package.json
@@ -48,43 +48,6 @@
     "type": "git",
     "url": "https://github.com/playcanvas/engine.git"
   },
-  "eslintConfig": {
-    "extends": "@playcanvas/eslint-config",
-    "globals": {
-      "Ammo": "readonly",
-      "earcut": "readonly",
-      "glslang": "readonly",
-      "GPUBufferUsage": "readonly",
-      "GPUColorWrite": "readonly",
-      "GPUMapMode": "readonly",
-      "GPUShaderStage": "readonly",
-      "GPUTextureUsage": "readonly",
-      "opentype": "readonly",
-      "pc": "readonly",
-      "TWEEN": "readonly",
-      "twgsl": "readonly",
-      "webkitAudioContext": "readonly",
-      "XRRay": "readonly",
-      "XRRigidTransform": "readonly",
-      "XRWebGLLayer": "readonly"
-    },
-    "parser": "@babel/eslint-parser",
-    "parserOptions": {
-      "requireConfigFile": false
-    },
-    "rules": {
-      "jsdoc/check-tag-names": [
-        "error",
-        {
-          "definedTags": [
-            "attribute",
-            "category",
-            "import"
-          ]
-        }
-      ]
-    }
-  },
   "eslintIgnore": [
     "examples/lib/*",
     "scripts/textmesh/earcut.min.js",
@@ -161,7 +124,7 @@
     "watch:esm:release": "npm run build target:esm:release -- -w",
     "watch:esm:debug": "npm run build target:esm:debug -- -w",
     "docs": "typedoc",
-    "lint": "eslint --ext .js,.mjs scripts src test utils rollup.config.mjs",
+    "lint": "eslint scripts src test utils rollup.config.mjs",
     "publint": "publint --level error",
     "serve": "serve build -l 51000 --cors",
     "test": "mocha --recursive --require test/fixtures.mjs",


### PR DESCRIPTION
When I updated dependencies here: https://github.com/playcanvas/engine/commit/3e9547e8b08c68adf22ea0d4c305964e02fb95f9

We got error that the lint no longer supports `--ext` option.

The solution is to move it to the config. The npm config does not support this, and so an external config needs to be used.