### PR TITLE
Renamed internal ‘descr’ symbols to ‘desc’ for consistency

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -42,7 +42,7 @@ class WebgpuBindGroupFormat {
         /** @type {WebgpuGraphicsDevice} */
         const device = bindGroupFormat.device;
 
-        const { key, descr } = this.createDescriptor(bindGroupFormat);
+        const { key, desc: desc } = this.createDescriptor(bindGroupFormat);
 
         /**
          * Unique key, used for caching
@@ -51,16 +51,16 @@ class WebgpuBindGroupFormat {
          */
         this.key = stringIds.get(key);
 
-        // keep descr in debug mode
+        // keep desc in debug mode
         Debug.call(() => {
-            this.descr = descr;
+            this.desc = desc;
         });
 
         /**
          * @type {GPUBindGroupLayout}
          * @private
          */
-        this.bindGroupLayout = device.wgpu.createBindGroupLayout(descr);
+        this.bindGroupLayout = device.wgpu.createBindGroupLayout(desc);
         DebugHelper.setLabel(this.bindGroupLayout, bindGroupFormat.name);
     }
 
@@ -211,13 +211,13 @@ class WebgpuBindGroupFormat {
         });
 
         /** @type {GPUBindGroupLayoutDescriptor} */
-        const descr = {
+        const desc = {
             entries: entries
         };
 
         return {
             key,
-            descr
+            desc
         };
     }
 }

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -42,7 +42,7 @@ class WebgpuBindGroupFormat {
         /** @type {WebgpuGraphicsDevice} */
         const device = bindGroupFormat.device;
 
-        const { key, desc: desc } = this.createDescriptor(bindGroupFormat);
+        const { key, desc } = this.createDescriptor(bindGroupFormat);
 
         /**
          * Unique key, used for caching

--- a/src/platform/graphics/webgpu/webgpu-bind-group.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group.js
@@ -23,15 +23,15 @@ class WebgpuBindGroup {
         const device = bindGroup.device;
 
         /** @type {GPUBindGroupDescriptor} */
-        const descr = this.createDescriptor(device, bindGroup);
+        const desc = this.createDescriptor(device, bindGroup);
 
         WebgpuDebug.validate(device);
 
-        this.bindGroup = device.wgpu.createBindGroup(descr);
+        this.bindGroup = device.wgpu.createBindGroup(desc);
 
         WebgpuDebug.end(device, {
             debugFormat: this.debugFormat,
-            descr: descr,
+            desc: desc,
             format: bindGroup.format,
             bindGroup: bindGroup
         });
@@ -158,14 +158,14 @@ class WebgpuBindGroup {
             });
         });
 
-        const descr = {
+        const desc = {
             layout: bindGroup.format.impl.bindGroupLayout,
             entries: entries
         };
 
-        DebugHelper.setLabel(descr, bindGroup.name);
+        DebugHelper.setLabel(desc, bindGroup.name);
 
-        return descr;
+        return desc;
     }
 }
 

--- a/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
@@ -29,7 +29,7 @@ class WebgpuComputePipeline extends WebgpuPipeline {
         const webgpuShader = shader.impl;
 
         /** @type {GPUComputePipelineDescriptor} */
-        const descr = {
+        const desc = {
             compute: {
                 module: webgpuShader.getComputeShaderModule(),
                 entryPoint: webgpuShader.computeEntryPoint
@@ -42,16 +42,16 @@ class WebgpuComputePipeline extends WebgpuPipeline {
         WebgpuDebug.validate(this.device);
 
         _pipelineId++;
-        DebugHelper.setLabel(descr, `ComputePipelineDescr-${_pipelineId}`);
+        DebugHelper.setLabel(desc, `ComputePipelineDescr-${_pipelineId}`);
 
-        const pipeline = wgpu.createComputePipeline(descr);
+        const pipeline = wgpu.createComputePipeline(desc);
 
         DebugHelper.setLabel(pipeline, `ComputePipeline-${_pipelineId}`);
-        Debug.trace(TRACEID_COMPUTEPIPELINE_ALLOC, `Alloc: Id ${_pipelineId}`, descr);
+        Debug.trace(TRACEID_COMPUTEPIPELINE_ALLOC, `Alloc: Id ${_pipelineId}`, desc);
 
         WebgpuDebug.end(this.device, {
             computePipeline: this,
-            descr,
+            desc: desc,
             shader
         });
 

--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -73,7 +73,7 @@ class WebgpuMipmapRenderer {
     generate(webgpuTexture) {
 
         // ignore texture with no mipmaps
-        const textureDescr = webgpuTexture.descr;
+        const textureDescr = webgpuTexture.desc;
         if (textureDescr.mipLevelCount <= 1) {
             return;
         }

--- a/src/platform/graphics/webgpu/webgpu-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-pipeline.js
@@ -30,18 +30,18 @@ class WebgpuPipeline {
             bindGroupLayouts.push(format.bindGroupLayout);
         });
 
-        const descr = {
+        const desc = {
             bindGroupLayouts: bindGroupLayouts
         };
 
         _layoutId++;
-        DebugHelper.setLabel(descr, `PipelineLayoutDescr-${_layoutId}`);
+        DebugHelper.setLabel(desc, `PipelineLayoutDescr-${_layoutId}`);
 
         /** @type {GPUPipelineLayout} */
-        const pipelineLayout = this.device.wgpu.createPipelineLayout(descr);
+        const pipelineLayout = this.device.wgpu.createPipelineLayout(desc);
         DebugHelper.setLabel(pipelineLayout, `PipelineLayout-${_layoutId}`);
         Debug.trace(TRACEID_PIPELINELAYOUT_ALLOC, `Alloc: Id ${_layoutId}`, {
-            descr,
+            desc: desc,
             bindGroupFormats
         });
 

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -304,7 +304,7 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
         const webgpuShader = shader.impl;
 
         /** @type {GPURenderPipelineDescriptor} */
-        const descr = {
+        const desc = {
             vertex: {
                 module: webgpuShader.getVertexShaderModule(),
                 entryPoint: webgpuShader.vertexEntryPoint,
@@ -327,7 +327,7 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
             layout: pipelineLayout
         };
 
-        descr.fragment = {
+        desc.fragment = {
             module: webgpuShader.getFragmentShaderModule(),
             entryPoint: webgpuShader.fragmentEntryPoint,
             targets: []
@@ -347,7 +347,7 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
             const blend = this.getBlend(blendState);
 
             colorAttachments.forEach((attachment) => {
-                descr.fragment.targets.push({
+                desc.fragment.targets.push({
                     format: attachment.format,
                     writeMask: writeMask,
                     blend: blend
@@ -358,16 +358,16 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
         WebgpuDebug.validate(this.device);
 
         _pipelineId++;
-        DebugHelper.setLabel(descr, `RenderPipelineDescr-${_pipelineId}`);
+        DebugHelper.setLabel(desc, `RenderPipelineDescr-${_pipelineId}`);
 
-        const pipeline = wgpu.createRenderPipeline(descr);
+        const pipeline = wgpu.createRenderPipeline(desc);
 
         DebugHelper.setLabel(pipeline, `RenderPipeline-${_pipelineId}`);
-        Debug.trace(TRACEID_RENDERPIPELINE_ALLOC, `Alloc: Id ${_pipelineId}, stack: ${DebugGraphics.toString()}`, descr);
+        Debug.trace(TRACEID_RENDERPIPELINE_ALLOC, `Alloc: Id ${_pipelineId}, stack: ${DebugGraphics.toString()}`, desc);
 
         WebgpuDebug.end(this.device, {
             renderPipeline: this,
-            descr,
+            desc: desc,
             shader
         });
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -70,7 +70,7 @@ class WebgpuTexture {
      * @type {GPUTextureDescriptor}
      * @private
      */
-    descr;
+    desc;
 
     /**
      * @type {GPUTextureFormat}
@@ -96,7 +96,7 @@ class WebgpuTexture {
 
         Debug.assert(texture.width > 0 && texture.height > 0, `Invalid texture dimensions ${texture.width}x${texture.height} for texture ${texture.name}`, texture);
 
-        this.descr = {
+        this.desc = {
             size: {
                 width: texture.width,
                 height: texture.height,
@@ -117,11 +117,11 @@ class WebgpuTexture {
 
         WebgpuDebug.validate(device);
 
-        this.gpuTexture = wgpu.createTexture(this.descr);
+        this.gpuTexture = wgpu.createTexture(this.desc);
         DebugHelper.setLabel(this.gpuTexture, `${texture.name}${texture.cubemap ? '[cubemap]' : ''}${texture.volume ? '[3d]' : ''}`);
 
         WebgpuDebug.end(device, {
-            descr: this.descr,
+            desc: this.desc,
             texture
         });
 
@@ -163,7 +163,7 @@ class WebgpuTexture {
     createView(viewDescr) {
 
         const options = viewDescr ?? {};
-        const textureDescr = this.descr;
+        const textureDescr = this.desc;
         const texture = this.texture;
 
         // '1d', '2d', '2d-array', 'cube', 'cube-array', '3d'
@@ -175,7 +175,7 @@ class WebgpuTexture {
         };
 
         /** @type {GPUTextureViewDescriptor} */
-        const descr = {
+        const desc = {
             format: options.format ?? textureDescr.format,
             dimension: options.dimension ?? defaultViewDimension(),
             aspect: options.aspect ?? 'all',
@@ -185,7 +185,7 @@ class WebgpuTexture {
             arrayLayerCount: options.arrayLayerCount ?? textureDescr.depthOrArrayLayers
         };
 
-        const view = this.gpuTexture.createView(descr);
+        const view = this.gpuTexture.createView(desc);
         DebugHelper.setLabel(view, `${viewDescr ? `CustomView${JSON.stringify(viewDescr)}` : 'DefaultView'}:${this.texture.name}`);
 
         return view;
@@ -208,7 +208,7 @@ class WebgpuTexture {
             let label;
 
             /** @type GPUSamplerDescriptor */
-            const descr = {
+            const desc = {
                 addressModeU: gpuAddressModes[texture.addressU],
                 addressModeV: gpuAddressModes[texture.addressV],
                 addressModeW: gpuAddressModes[texture.addressW]
@@ -222,16 +222,16 @@ class WebgpuTexture {
             if (sampleType === SAMPLETYPE_DEPTH || sampleType === SAMPLETYPE_INT || sampleType === SAMPLETYPE_UINT) {
 
                 // depth compare sampling
-                descr.compare = 'less';
-                descr.magFilter = 'linear';
-                descr.minFilter = 'linear';
+                desc.compare = 'less';
+                desc.magFilter = 'linear';
+                desc.minFilter = 'linear';
                 label = 'Compare';
 
             } else if (sampleType === SAMPLETYPE_UNFILTERABLE_FLOAT) {
 
-                descr.magFilter = 'nearest';
-                descr.minFilter = 'nearest';
-                descr.mipmapFilter = 'nearest';
+                desc.magFilter = 'nearest';
+                desc.minFilter = 'nearest';
+                desc.mipmapFilter = 'nearest';
                 label = 'Unfilterable';
 
             } else {
@@ -240,30 +240,30 @@ class WebgpuTexture {
                 const forceNearest = !device.textureFloatFilterable && (texture.format === PIXELFORMAT_RGBA32F || texture.format === PIXELFORMAT_RGBA16F);
 
                 if (forceNearest || this.texture.format === PIXELFORMAT_DEPTHSTENCIL || isIntegerPixelFormat(this.texture.format)) {
-                    descr.magFilter = 'nearest';
-                    descr.minFilter = 'nearest';
-                    descr.mipmapFilter = 'nearest';
+                    desc.magFilter = 'nearest';
+                    desc.minFilter = 'nearest';
+                    desc.mipmapFilter = 'nearest';
                     label = 'Nearest';
                 } else {
-                    descr.magFilter = gpuFilterModes[texture.magFilter].level;
-                    descr.minFilter = gpuFilterModes[texture.minFilter].level;
-                    descr.mipmapFilter = gpuFilterModes[texture.minFilter].mip;
+                    desc.magFilter = gpuFilterModes[texture.magFilter].level;
+                    desc.minFilter = gpuFilterModes[texture.minFilter].level;
+                    desc.mipmapFilter = gpuFilterModes[texture.minFilter].mip;
                     Debug.call(() => {
-                        label = `Texture:${texture.magFilter}-${texture.minFilter}-${descr.mipmapFilter}`;
+                        label = `Texture:${texture.magFilter}-${texture.minFilter}-${desc.mipmapFilter}`;
                     });
                 }
             }
 
             // ensure anisotropic filtering is only set when filtering is correctly
             // set up
-            const allLinear = (descr.minFilter === 'linear' &&
-                               descr.magFilter === 'linear' &&
-                               descr.mipmapFilter === 'linear');
-            descr.maxAnisotropy = allLinear ?
+            const allLinear = (desc.minFilter === 'linear' &&
+                               desc.magFilter === 'linear' &&
+                               desc.mipmapFilter === 'linear');
+            desc.maxAnisotropy = allLinear ?
                 math.clamp(Math.round(texture._anisotropy), 1, device.maxTextureAnisotropy) :
                 1;
 
-            sampler = device.wgpu.createSampler(descr);
+            sampler = device.wgpu.createSampler(desc);
             DebugHelper.setLabel(sampler, label);
             this.samplers[sampleType] = sampler;
         }
@@ -407,7 +407,7 @@ class WebgpuTexture {
 
     uploadExternalImage(device, image, mipLevel, index) {
 
-        Debug.assert(mipLevel < this.descr.mipLevelCount, `Accessing mip level ${mipLevel} of texture with ${this.descr.mipLevelCount} mip levels`, this);
+        Debug.assert(mipLevel < this.desc.mipLevelCount, `Accessing mip level ${mipLevel} of texture with ${this.desc.mipLevelCount} mip levels`, this);
 
         const src = {
             source: image,
@@ -423,8 +423,8 @@ class WebgpuTexture {
         };
 
         const copySize = {
-            width: this.descr.size.width,
-            height: this.descr.size.height,
+            width: this.desc.size.width,
+            height: this.desc.size.height,
             depthOrArrayLayers: 1   // single layer
         };
 


### PR DESCRIPTION
simple rename, no functional change