### PR TITLE
[Fix] Fix albedo debug output

### DIFF
--- a/src/scene/shader-lib/chunks/lit/frag/debug-output.js
+++ b/src/scene/shader-lib/chunks/lit/frag/debug-output.js
@@ -1,6 +1,6 @@
 export default /* glsl */`
 #ifdef DEBUG_ALBEDO_PASS
-gl_FragColor = vec4(gammaCorrectOutput(litArgs_albedo), 1.0);
+gl_FragColor = vec4(gammaCorrectOutput(dAlbedo), 1.0);
 #endif
 
 #ifdef DEBUG_UV0_PASS


### PR DESCRIPTION
- when metalness is used, litArgs_albedo get modulated by inverse metalness and no longer represents the albedo. Debug output dAlbedo instead