### PR TITLE
[BREAKING] Remove StandardMaterial.sheenGlossTint

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -1041,11 +1041,9 @@ const extensionSheen = (data, material, textures) => {
         material.sheenEncoding = 'srgb';
         extractTextureTransform(data.sheenColorTexture, material, ['sheen']);
     }
-    if (data.hasOwnProperty('sheenRoughnessFactor')) {
-        material.sheenGloss = data.sheenRoughnessFactor;
-    } else {
-        material.sheenGloss = 0.0;
-    }
+
+    material.sheenGloss = data.hasOwnProperty('sheenRoughnessFactor') ? data.sheenRoughnessFactor : 0.0;
+
     if (data.hasOwnProperty('sheenRoughnessTexture')) {
         material.sheenGlossMap = textures[data.sheenRoughnessTexture.index];
         material.sheenGlossMapChannel = 'a';

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -235,8 +235,6 @@ class StandardMaterialOptionsBuilder {
 
         options.iridescenceTint = stdMat.iridescence !== 1.0 ? 1 : 0;
 
-        options.sheenGlossTint = 1;
-
         options.glossInvert = stdMat.glossInvert;
         options.sheenGlossInvert = stdMat.sheenGlossInvert;
         options.clearCoatGlossInvert = stdMat.clearCoatGlossInvert;

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -65,7 +65,6 @@ const standardMaterialParameterTypes = {
     sheen: 'rgb',
     ..._textureParameter('sheen'),
     sheenGloss: 'number',
-    sheenGlossTint: 'boolean',
     sheenGlossInvert: 'boolean',
     ..._textureParameter('sheenGloss'),
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -335,8 +335,6 @@ const _tempColor = new Color();
  * This color value is a single value between 0 and 1.
  * @property {boolean} sheenGlossInvert Invert the sheen gloss component (default is false).
  * Enabling this flag results in material treating the sheen gloss members as roughness.
- * @property {boolean} sheenGlossTint Multiply sheen glossiness map and/or sheen glossiness vertex
- * value by the scalar sheen glossiness value.
  * @property {Texture|null} sheenGlossMap The sheen glossiness microstructure color map of the
  * material (default is null).
  * @property {number} sheenGlossMapUv Sheen map UV channel.
@@ -720,10 +718,7 @@ class StandardMaterial extends Material {
             }
 
             this._setParameter('material_sheen', getUniform('sheen'));
-
-            if (!this.sheenGlossMap || this.sheenGlossTint) {
-                this._setParameter('material_sheenGloss', this.sheenGloss);
-            }
+            this._setParameter('material_sheenGloss', this.sheenGloss);
 
             this._setParameter('material_refractionIndex', this.refractionIndex);
         } else {

--- a/src/scene/shader-lib/chunks/standard/frag/sheenGloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/sheenGloss.js
@@ -1,14 +1,8 @@
 export default /* glsl */`
-#ifdef MAPFLOAT
 uniform float material_sheenGloss;
-#endif
 
 void getSheenGlossiness() {
-    float sheenGlossiness = 1.0;
-
-    #ifdef MAPFLOAT
-    sheenGlossiness *= material_sheenGloss;
-    #endif
+    float sheenGlossiness = material_sheenGloss;
 
     #ifdef MAPTEXTURE
     sheenGlossiness *= texture2DBias($SAMPLER, $UV, textureBias).$CH;


### PR DESCRIPTION
marked breaking, as the behaviour has changed.

sheenGloss value defaults to 0, and when sheenGlossMap is set on the StandardMaterial, sheenGloss also needs to be set to non-zero values for the texture has an effect.

This matches https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_sheen/README.md extension as well

We'll handle Editor material conversion to avoid the impact for the Editor projects, but engie only users will need to be aware here and adjust the sheenGloss value.