### PR TITLE
Fix an issue with light baking if the clustered lighting has shadows disabled

### DIFF
--- a/src/framework/lightmapper/bake-light-ambient.js
+++ b/src/framework/lightmapper/bake-light-ambient.js
@@ -9,8 +9,9 @@ const _tempPoint = new Vec3();
 
 // bake light representing an ambient light (cubemap or constant)
 class BakeLightAmbient extends BakeLight {
-    constructor(scene) {
+    constructor(lightmapper) {
 
+        const scene = lightmapper.scene;
         const lightEntity = new Entity('AmbientLight');
         lightEntity.addComponent('light', {
             type: 'directional',
@@ -29,7 +30,7 @@ class BakeLightAmbient extends BakeLight {
             bakeDir: false
         });
 
-        super(scene, lightEntity.light.light);
+        super(scene, lightEntity.light.light, lightmapper.lightingParams);
     }
 
     get numVirtualLights() {

--- a/src/framework/lightmapper/bake-light-simple.js
+++ b/src/framework/lightmapper/bake-light-simple.js
@@ -7,6 +7,10 @@ const _tempPoint = new Vec2();
 
 // a bake light representing a directional, omni or spot type of light
 class BakeLightSimple extends BakeLight {
+    constructor(lightmapper, light) {
+        super(lightmapper.scene, light, lightmapper.lightingParams);
+    }
+
     get numVirtualLights() {
         // only directional lights support multiple samples
         if (this.light.type === LIGHTTYPE_DIRECTIONAL) {

--- a/src/framework/lightmapper/bake-light.js
+++ b/src/framework/lightmapper/bake-light.js
@@ -6,7 +6,7 @@ const tempSphere = new BoundingSphere();
 
 // helper class to store all lights including their original state
 class BakeLight {
-    constructor(scene, light) {
+    constructor(scene, light, lightingParams) {
 
         this.scene = scene;
 
@@ -18,6 +18,11 @@ class BakeLight {
 
         // don't use cascades
         light.numCascades = 1;
+
+        if (this.scene.clusteredLightingEnabled) {
+            // if clustered shadows are disabled, disable them on the light
+            light.castShadows = light.castShadows && lightingParams.shadowsEnabled;
+        }
 
         // bounds for non-directional light
         if (light.type !== LIGHTTYPE_DIRECTIONAL) {
@@ -40,6 +45,7 @@ class BakeLight {
         this.intensity = this.light.intensity;
         this.rotation = this.light._node.getLocalRotation().clone();
         this.numCascades = this.light.numCascades;
+        this.castShadows = this.light.castShadows;
     }
 
     restore() {
@@ -50,6 +56,7 @@ class BakeLight {
         light.intensity = this.intensity;
         light._node.setLocalRotation(this.rotation);
         light.numCascades = this.numCascades;
+        light.castShadows = this.castShadows;
     }
 
     startBake() {

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -637,11 +637,11 @@ class Lightmapper {
         }
     }
 
-    prepareLightsToBake(layerComposition, allLights, bakeLights) {
+    prepareLightsToBake(allLights, bakeLights) {
 
         // ambient light
         if (this.scene.ambientBake) {
-            const ambientLight = new BakeLightAmbient(this.scene);
+            const ambientLight = new BakeLightAmbient(this);
             bakeLights.push(ambientLight);
         }
 
@@ -651,7 +651,7 @@ class Lightmapper {
             const light = sceneLights[i];
 
             // store all lights and their original settings we need to temporarily modify
-            const bakeLight = new BakeLightSimple(this.scene, light);
+            const bakeLight = new BakeLightSimple(this, light);
             allLights.push(bakeLight);
 
             // bake light
@@ -941,7 +941,7 @@ class Lightmapper {
         // Collect bakeable lights, and also keep allLights along with their properties we change to restore them later
         this.renderer.collectLights(comp);
         const allLights = [], bakeLights = [];
-        this.prepareLightsToBake(comp, allLights, bakeLights);
+        this.prepareLightsToBake(allLights, bakeLights);
 
         // update transforms
         this.updateTransforms(allNodes);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -257,8 +257,11 @@ class ForwardRenderer extends Renderer {
                 this.lightShadowIntensity[cnt].setValue(directional.shadowIntensity);
 
                 const projectionCompensation = (50.0 / lightRenderData.projectionCompensation);
-                const pixelsPerMeter = directional.penumbraSize / lightRenderData.shadowCamera.renderTarget.width;
-                this.lightShadowSearchAreaId[cnt].setValue(pixelsPerMeter * projectionCompensation);
+                const shadowRT = lightRenderData.shadowCamera.renderTarget;
+                if (shadowRT) {
+                    const pixelsPerMeter = directional.penumbraSize / shadowRT.width;
+                    this.lightShadowSearchAreaId[cnt].setValue(pixelsPerMeter * projectionCompensation);
+                }
 
                 const cameraParams = directional._shadowCameraParams;
                 cameraParams.length = 4;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/6842

When clustered lighting is enabled, but it's shadows are disabled, temporarily disable shadow baking as well