### PR TITLE
Gizmo resize editor example fix

### DIFF
--- a/examples/src/examples/misc/editor.controls.mjs
+++ b/examples/src/examples/misc/editor.controls.mjs
@@ -54,7 +54,7 @@ export function controls({ observer, ReactPCUI, React, jsx, fragment }) {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'gizmo.size' },
                     min: 0.1,
-                    max: 2.0
+                    max: 10.0
                 })
             ),
             jsx(

--- a/examples/src/examples/misc/editor.example.mjs
+++ b/examples/src/examples/misc/editor.example.mjs
@@ -157,7 +157,8 @@ const resize = () => {
     app.resizeCanvas();
     const bounds = canvas.getBoundingClientRect();
     const dim = camera.camera.horizontalFov ? bounds.width : bounds.height;
-    gizmoHandler.gizmo.size = 1024 / dim;
+    gizmoHandler.size = 1024 / dim;
+    data.set('gizmo.size', gizmoHandler.size);
 };
 window.addEventListener('resize', resize);
 resize();

--- a/examples/src/examples/misc/editor.gizmo-handler.mjs
+++ b/examples/src/examples/misc/editor.gizmo-handler.mjs
@@ -80,6 +80,16 @@ class GizmoHandler {
         return this._skipSetFire;
     }
 
+    set size(value) {
+        for (const type in this._gizmos) {
+            this._gizmos[type].size = value;
+        }
+    }
+
+    get size() {
+        return this.gizmo.size;
+    }
+
     /**
      * @param {string} type - The transform gizmo type.
      */


### PR DESCRIPTION
Applies gizmo sizing to all gizmos in editor example and updates controls UI 
