### PR TITLE
ShaderMaterial supports PICK shader pass

### DIFF
--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -133,6 +133,7 @@ import particle_softVS from './particle/vert/particle_soft.js';
 import particle_stretchVS from './particle/vert/particle_stretch.js';
 import particle_TBNVS from './particle/vert/particle_TBN.js';
 import particle_wrapVS from './particle/vert/particle_wrap.js';
+import pickPS from './common/frag/pick.js';
 import reflDirPS from './lit/frag/reflDir.js';
 import reflDirAnisoPS from './lit/frag/reflDirAniso.js';
 import reflectionCCPS from './lit/frag/reflectionCC.js';
@@ -335,6 +336,7 @@ const shaderChunks = {
     particle_stretchVS,
     particle_TBNVS,
     particle_wrapVS,
+    pickPS,
     reflDirPS,
     reflDirAnisoPS,
     reflectionCCPS,

--- a/src/scene/shader-lib/chunks/common/frag/pick.js
+++ b/src/scene/shader-lib/chunks/common/frag/pick.js
@@ -1,0 +1,10 @@
+export default /* glsl */`
+uniform uint meshInstanceId;
+
+vec4 getPickOutput() {
+    const vec4 inv = vec4(1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0);
+    const uvec4 shifts = uvec4(16, 8, 0, 24);
+    uvec4 col = (uvec4(meshInstanceId) >> shifts) & uvec4(0xff);
+    return vec4(col) * inv;
+}
+`;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -369,15 +369,11 @@ class LitShader {
             ${this.varyingDefines}
             ${this.frontendDecl}
             ${this.frontendCode}
-            uniform uint meshInstanceId;
+            ${this.chunks.pickPS}
 
             void main(void) {
                 ${this.frontendFunc}
-                
-                const vec4 inv = vec4(1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0);
-                const uvec4 shifts = uvec4(16, 8, 0, 24);
-                uvec4 col = (uvec4(meshInstanceId) >> shifts) & uvec4(0xff);
-                gl_FragColor = vec4(col) * inv;
+                gl_FragColor = getPickOutput();
             }
         `;
     }

--- a/src/scene/shader-lib/programs/shader-generator-shader.js
+++ b/src/scene/shader-lib/programs/shader-generator-shader.js
@@ -115,6 +115,7 @@ class ShaderGeneratorShader extends ShaderGenerator {
             includes.set('tonemapping', ShaderGenerator.tonemapCode(options.toneMapping));
             includes.set('fog', ShaderGenerator.fogCode(options.fog));
             includes.set('userCode', desc.fragmentCode);
+            includes.set('pick', shaderChunks.pickPS);
 
             definitionOptions.fragmentCode = fShader;
             definitionOptions.fragmentIncludes = includes;


### PR DESCRIPTION
- shaders used by ShaderMaterial can easily add support for pick shader pass used by the Picker.

Example of fragment shader:
```
#ifdef PICK_PASS
    #include "pick"
#endif

void main(void)
{
    #ifdef PICK_PASS
        gl_FragColor = getPickOutput();	// picker pass rendering
    #else
        gl_FragColor = vec4(1.0);	// default color rendering
    #endif
}

```
