### PR TITLE
Removed references to no longer used _shader from the Material

### DIFF
--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -877,9 +877,6 @@ class BatchManager {
         }
 
         batch2.meshInstance.castShadow = batch.meshInstance.castShadow;
-        batch2.meshInstance._shader = batch.meshInstance._shader.slice();
-
-        batch2.meshInstance.castShadow = batch.meshInstance.castShadow;
 
         return batch2;
     }

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -497,7 +497,6 @@ class Material {
      */
     copy(source) {
         this.name = source.name;
-        this._shader = source._shader;
 
         // Render states
         this.alphaTest = source.alphaTest;
@@ -557,7 +556,6 @@ class Material {
      */
     update() {
         this.dirty = true;
-        if (this._shader) this._shader.failed = false;
     }
 
     // Parameter management
@@ -660,7 +658,6 @@ class Material {
      */
     destroy() {
         this.variants.clear();
-        this._shader = null;
 
         for (let i = 0; i < this.meshInstances.length; i++) {
             const meshInstance = this.meshInstances[i];


### PR DESCRIPTION
- all materials use and store shaders in variants cache, and the single _shader is no longer used