### PR TITLE
Animation component asset null fix

### DIFF
--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -68,7 +68,8 @@ class AnimComponentSystem extends ComponentSystem {
                     });
                 });
             });
-        } else if (data.animationAssets) {
+        }
+        if (data.animationAssets) {
             component.animationAssets = Object.assign(component.animationAssets, data.animationAssets);
         }
 


### PR DESCRIPTION
Fixes #6860

Always add the animation asset ids to new components
