### PR TITLE
Remove float rendering precision test for old WebGL devices

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -310,6 +310,13 @@ Object.defineProperty(GraphicsDevice.prototype, 'webgl2', {
     }
 });
 
+Object.defineProperty(GraphicsDevice.prototype, 'textureFloatHighPrecision', {
+    get: function () {
+        Debug.deprecated('pc.GraphicsDevice#textureFloatHighPrecision is deprecated and always returns true.');
+        return true;
+    }
+});
+
 Object.defineProperty(GraphicsDevice.prototype, 'extBlendMinmax', {
     get: function () {
         Debug.deprecated('pc.GraphicsDevice#extBlendMinmax is deprecated as it is always true.');

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -426,11 +426,7 @@ class LitShader {
         let code = this._fsGetBeginCode();
 
         if (shadowType === SHADOW_VSM32) {
-            if (device.textureFloatHighPrecision) {
-                code += '#define VSM_EXPONENT 15.0\n\n';
-            } else {
-                code += '#define VSM_EXPONENT 5.54\n\n';
-            }
+            code += '#define VSM_EXPONENT 15.0\n\n';
         } else if (shadowType === SHADOW_VSM16) {
             code += '#define VSM_EXPONENT 5.54\n\n';
         }
@@ -1157,11 +1153,7 @@ class LitShader {
                             break;
                         case SHADOW_VSM32:
                             shadowReadMode = "VSM32";
-                            if (device.textureFloatHighPrecision) {
-                                evsmExp = "15.0";
-                            } else {
-                                evsmExp = "5.54";
-                            }
+                            evsmExp = "15.0";
                             break;
                         case SHADOW_PCF1:
                             shadowReadMode = "PCF1x1";

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -408,7 +408,6 @@ class LitShader {
     }
 
     _fsGetShadowPassCode() {
-        const device = this.device;
         const options = this.options;
         const chunks = this.chunks;
         const varyings = this.varyings;


### PR DESCRIPTION
This is relevant for GPU chips introduced 12 years ago - like PowerVR SGX543 (iPhone 4s), Intel HD Graphics 4000, Adreno 305.
This precision test was only used for empirical exponent constants for VSM32 shadows to slightly improve it's quality.

I think it's time to remove it for engine v2.

Also remove a WebGL1 path in one function.

Suggestion: diff it with white spaces differences hidden