### PR TITLE
Improve ply parsing performance

### DIFF
--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -418,6 +418,25 @@ const readPly = async (reader, propertyFilter = null) => {
 
         // calculate the size of an input element record
         const inputSize = element.properties.reduce((a, p) => a + p.byteSize, 0);
+        const propertyParsingFunctions = element.properties.map((p) => {
+            /* eslint-disable brace-style */
+            if (p.storage) {
+                switch (p.type) {
+                    case 'char':   return (streamBuf, c) => { p.storage[c] = streamBuf.getInt8(); };
+                    case 'uchar':  return (streamBuf, c) => { p.storage[c] = streamBuf.getUint8(); };
+                    case 'short':  return (streamBuf, c) => { p.storage[c] = streamBuf.getInt16(); };
+                    case 'ushort': return (streamBuf, c) => { p.storage[c] = streamBuf.getUint16(); };
+                    case 'int':    return (streamBuf, c) => { p.storage[c] = streamBuf.getInt32(); };
+                    case 'uint':   return (streamBuf, c) => { p.storage[c] = streamBuf.getUint32(); };
+                    case 'float':  return (streamBuf, c) => { p.storage[c] = streamBuf.getFloat32(); };
+                    case 'double': return (streamBuf, c) => { p.storage[c] = streamBuf.getFloat64(); };
+                    default: throw new Error(`Unsupported property data type '${p.type}' in ply header`);
+                }
+            } else {
+                return (streamBuf) => { streamBuf.head += p.byteSize; };
+            }
+            /* eslint-enable brace-style */
+        });
         let c = 0;
 
         while (c < element.count) {
@@ -430,22 +449,7 @@ const readPly = async (reader, propertyFilter = null) => {
 
             for (let n = 0; n < toRead; ++n) {
                 for (let j = 0; j < element.properties.length; ++j) {
-                    const property = element.properties[j];
-
-                    if (property.storage) {
-                        switch (property.type) {
-                            case 'char':   property.storage[c] = streamBuf.getInt8(); break;
-                            case 'uchar':  property.storage[c] = streamBuf.getUint8(); break;
-                            case 'short':  property.storage[c] = streamBuf.getInt16(); break;
-                            case 'ushort': property.storage[c] = streamBuf.getUint16(); break;
-                            case 'int':    property.storage[c] = streamBuf.getInt32(); break;
-                            case 'uint':   property.storage[c] = streamBuf.getUint32(); break;
-                            case 'float':  property.storage[c] = streamBuf.getFloat32(); break;
-                            case 'double': property.storage[c] = streamBuf.getFloat64(); break;
-                        }
-                    } else {
-                        streamBuf.head += property.byteSize;
-                    }
+                    propertyParsingFunctions[j](streamBuf, c);
                 }
                 c++;
             }


### PR DESCRIPTION
This PR improves the PLY parsing speed by about 63% for the guitar scene. **The parsing time goes from 21.02 ms to 7.84 ms** (tested on an M1 MacBook Air). And the benchmark script can be found [here](https://github.com/kemchenj/engine/blob/cd90840bc763195aab98d91b6bb328b8764da4c2/ply-benchmark.js).

This optimization reduces string comparison overhead during ply parsing. Instead of comparing strings for each property of each splat, I try to do the comparison at once and made a temporary `read` function for each property. This approach reduces the number of string comparisons, resulting in faster parsing.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).