### PR TITLE
[BREAKING] Remove no longer needed drawTexture

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ export { SoundInstance3d } from './platform/sound/instance3d.js';
 
 // SCENE
 export * from './scene/constants.js';
-export { drawQuadWithShader, drawTexture } from './scene/graphics/quad-render-utils.js';
+export { drawQuadWithShader } from './scene/graphics/quad-render-utils.js';
 export { Batch } from './scene/batching/batch.js';
 export { BatchGroup } from './scene/batching/batch-group.js';
 export { SkinBatchInstance } from './scene/batching/skin-batch-instance.js';

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -43,6 +43,7 @@ import { TextureUtils } from '../texture-utils.js';
 
 /**
  * @import { RenderPass } from '../render-pass.js'
+ * @import { Shader } from '../shader.js'
  * @import { VertexBuffer } from '../vertex-buffer.js'
  */
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -35,8 +35,6 @@ import { WebglIndexBuffer } from './webgl-index-buffer.js';
 import { WebglShader } from './webgl-shader.js';
 import { WebglTexture } from './webgl-texture.js';
 import { WebglRenderTarget } from './webgl-render-target.js';
-import { ShaderUtils } from '../shader-utils.js';
-import { Shader } from '../shader.js';
 import { BlendState } from '../blend-state.js';
 import { DepthState } from '../depth-state.js';
 import { StencilParameters } from '../stencil-parameters.js';
@@ -1114,9 +1112,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         const h = source ? source.height : dest ? dest.height : this.height;
 
         gl.blitFramebuffer(0, 0, w, h,
-                           0, 0, w, h,
-                           (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0),
-                           gl.NEAREST);
+            0, 0, w, h,
+            (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0),
+            gl.NEAREST);
 
         // TODO: not sure we need to restore the prev target, as this only should run in-between render passes
         this.renderTarget = prevRt;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1114,9 +1114,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         const h = source ? source.height : dest ? dest.height : this.height;
 
         gl.blitFramebuffer(0, 0, w, h,
-            0, 0, w, h,
-            (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0),
-            gl.NEAREST);
+                           0, 0, w, h,
+                           (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0),
+                           gl.NEAREST);
 
         // TODO: not sure we need to restore the prev target, as this only should run in-between render passes
         this.renderTarget = prevRt;
@@ -1125,38 +1125,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         DebugGraphics.popGpuMarker(this);
 
         return true;
-    }
-
-    /**
-     * Get copy shader for efficient rendering of fullscreen-quad with texture.
-     *
-     * @returns {Shader} The copy shader (based on `fullscreenQuadVS` and `outputTex2DPS` in
-     * `shaderChunks`).
-     * @ignore
-     */
-    getCopyShader() {
-        if (!this._copyShader) {
-            this._copyShader = new Shader(this, ShaderUtils.createDefinition(this, {
-                name: 'outputTex2D',
-                vertexCode: /* glsl */`
-                    attribute vec2 vertex_position;
-                    varying vec2 vUv0;
-                    void main(void)
-                    {
-                        gl_Position = vec4(vertex_position, 0.5, 1.0);
-                        vUv0 = vertex_position.xy*0.5+0.5;
-                    }
-                `,
-                fragmentCode: /* glsl */`
-                    varying vec2 vUv0;
-                    uniform sampler2D source;
-                    void main(void) {
-                        gl_FragColor = texture2D(source, vUv0);
-                    }
-                `
-            }));
-        }
-        return this._copyShader;
     }
 
     frameStart() {

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -70,33 +70,4 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
     quad.destroy();
 }
 
-/**
- * Draws a texture in screen-space. Mostly used by post-effects.
- *
- * @param {GraphicsDevice} device - The graphics device used to draw the texture.
- * @param {Texture} texture - The source texture to be drawn. Accessible as
- * `uniform sampler2D * source` in shader.
- * @param {RenderTarget} [target] - The destination render target. Defaults to the frame buffer.
- * @param {Shader} [shader] - The optional custom shader used for rendering the texture.
- * @param {Vec4} [rect] - The viewport rectangle to use for the texture, in pixels. Defaults to
- * fullscreen: `[0, 0, target.width, target.height]`.
- * @param {Vec4} [scissorRect] - The scissor rectangle to use for the texture, in pixels. Defaults
- * to fullscreen `[0, 0, target.width, target.height]`.
- * @category Graphics
- */
-function drawTexture(device, texture, target, shader, rect, scissorRect) {
-    Debug.assert(!device.isWebGPU, 'pc.drawTexture is not currently supported on WebGPU platform.');
-
-    const useBlend = arguments[6];
-    Debug.call(() => {
-        if (useBlend !== undefined) {
-            Debug.warnOnce('pc.drawTexture no longer accepts useBlend parameter, and blending state needs to be set up using GraphicsDevice.setBlendState.');
-        }
-    });
-
-    shader = shader || device.getCopyShader();
-    device.constantTexSource.setValue(texture);
-    drawQuadWithShader(device, target, shader, rect, scissorRect);
-}
-
-export { drawQuadWithShader, drawTexture };
+export { drawQuadWithShader };


### PR DESCRIPTION
- removed global WebGL only drawTexture call that was public. It was used by the post-effects only, and that has been replaced a long time ago.
- marking as BREAKING in case somebody was using this function for other purpose. The workaround is to use drawQuadWithShader with a simple shader.