### PR TITLE
[BREAKING] Remove support for Layer.renderTarget and some callbacks on the Layer

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -513,16 +513,30 @@ Object.defineProperty(Scene.prototype, 'models', {
     }
 });
 
-Object.defineProperty(Layer.prototype, 'renderTarget', {
-    set: function (rt) {
-        Debug.deprecated('pc.Layer#renderTarget is deprecated. Set the render target on the camera instead.');
-        this._renderTarget = rt;
-        this._dirtyComposition = true;
-    },
-    get: function () {
-        return this._renderTarget;
-    }
-});
+// A helper function to add deprecated set and get property on a Layer
+function _removedLayerProperty(name) {
+    Object.defineProperty(Layer.prototype, name, {
+        set: function (value) {
+            Debug.errorOnce(`pc.Layer#${name} has been removed.`);
+        },
+        get: function () {
+            Debug.errorOnce(`pc.Layer#${name} has been removed.`);
+            return undefined;
+        }
+    });
+}
+
+_removedLayerProperty('renderTarget');
+_removedLayerProperty('onPreCull');
+_removedLayerProperty('onPreRender');
+_removedLayerProperty('onPreRenderOpaque');
+_removedLayerProperty('onPreRenderTransparent');
+_removedLayerProperty('onPostCull');
+_removedLayerProperty('onPostRender');
+_removedLayerProperty('onPostRenderOpaque');
+_removedLayerProperty('onPostRenderTransparent');
+_removedLayerProperty('onDrawCall');
+_removedLayerProperty('layerReference');
 
 Object.defineProperty(Batch.prototype, 'model', {
     get: function () {

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1925,8 +1925,6 @@ class AppBase extends EventHandler {
 
         this._entityIndex = {};
 
-        this.defaultLayerDepth.onPreRenderOpaque = null;
-        this.defaultLayerDepth.onPostRenderOpaque = null;
         this.defaultLayerDepth.onDisable = null;
         this.defaultLayerDepth.onEnable = null;
         this.defaultLayerDepth = null;

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -56,7 +56,7 @@ class CameraComponent extends Component {
     /**
      * Custom function that is called when postprocessing should execute.
      *
-     * @type {Function}
+     * @type {Function|null}
      * @ignore
      */
     onPostprocessing = null;
@@ -64,16 +64,30 @@ class CameraComponent extends Component {
     /**
      * Custom function that is called before the camera renders the scene.
      *
-     * @type {Function}
+     * @type {Function|null}
      */
     onPreRender = null;
 
     /**
      * Custom function that is called after the camera renders the scene.
      *
-     * @type {Function}
+     * @type {Function|null}
      */
     onPostRender = null;
+
+    /**
+     * Custom function that is called before visibility culling is performed for this camera.
+     *
+     * @type {Function|null}
+     */
+    onPreCull = null;
+
+    /**
+     * Custom function that is called after visibility culling is performed for this camera.
+     *
+     * @type {Function|null}
+     */
+    onPostCull = null;
 
     /**
      * A counter of requests of depth map rendering.

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -77,7 +77,7 @@ class LayerComposition extends EventHandler {
     subLayerEnabled = []; // more granular control on top of layer.enabled (ANDed)
 
     /**
-     * An array of {@link CameraComponent}
+     * An array of {@link CameraComponent}s.
      *
      * @type {CameraComponent[]}
      * @ignore

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -77,21 +77,12 @@ class LayerComposition extends EventHandler {
     subLayerEnabled = []; // more granular control on top of layer.enabled (ANDed)
 
     /**
-     * A read-only array of {@link CameraComponent} that can be used during rendering. e.g.
-     * Inside {@link Layer#onPreCull}, {@link Layer#onPostCull}, {@link Layer#onPreRender},
-     * {@link Layer#onPostRender}.
+     * An array of {@link CameraComponent}
      *
      * @type {CameraComponent[]}
-     */
-    cameras = [];
-
-    /**
-     * A mapping of {@link CameraComponent} to its index in {@link LayerComposition#cameras}.
-     *
-     * @type {Map<CameraComponent, number>}
      * @ignore
      */
-    camerasMap = new Map();
+    cameras = [];
 
     /**
      * The actual rendering sequence, generated based on layers and cameras
@@ -168,12 +159,6 @@ class LayerComposition extends EventHandler {
             // sort cameras by priority
             if (this.cameras.length > 1) {
                 sortPriority(this.cameras);
-            }
-
-            // update camera map
-            this.camerasMap.clear();
-            for (let i = 0; i < this.cameras.length; i++) {
-                this.camerasMap.set(this.cameras[i], i);
             }
 
             // collect a list of layers this camera renders
@@ -283,13 +268,8 @@ class LayerComposition extends EventHandler {
     // function adds new render action to a list, while trying to limit allocation and reuse already allocated objects
     addRenderAction(renderActionIndex, layer, isTransparent, camera, cameraFirstRenderAction, postProcessMarked) {
 
-        // render target from the camera takes precedence over the render target from the layer
-        let rt = layer.renderTarget;
-        if (camera && camera.renderTarget) {
-            if (layer.id !== LAYERID_DEPTH) {   // ignore depth layer
-                rt = camera.renderTarget;
-            }
-        }
+        // camera's render target, ignoring depth layer
+        let rt = layer.id !== LAYERID_DEPTH ? camera.renderTarget : null;
 
         // was camera and render target combo used already
         let used = false;

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -22,7 +22,7 @@ class RenderAction {
         this.camera = null;
 
         /**
-         * render target this render action renders to (taken from either camera or layer)
+         * render target this render action renders to
          *
          * @type {RenderTarget|null}
          */

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -22,7 +22,7 @@ class RenderAction {
         this.camera = null;
 
         /**
-         * render target this render action renders to
+         * Render target this render action renders to.
          *
          * @type {RenderTarget|null}
          */

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -276,98 +276,6 @@ class Layer {
         this._clearStencilBuffer = !!options.clearStencilBuffer;
 
         /**
-         * Custom function that is called before visibility culling is performed for this layer.
-         * Useful, for example, if you want to modify camera projection while still using the same
-         * camera and make frustum culling work correctly with it (see
-         * {@link CameraComponent#calculateTransform} and {@link CameraComponent#calculateProjection}).
-         * This function will receive camera index as the only argument. You can get the actual
-         * camera being used by looking up {@link LayerComposition#cameras} with this index.
-         *
-         * @type {Function}
-         */
-        this.onPreCull = options.onPreCull;
-
-        /**
-         * Custom function that is called before this layer is rendered. Useful, for example, for
-         * reacting on screen size changes. This function is called before the first occurrence of
-         * this layer in {@link LayerComposition}. It will receive camera index as the only
-         * argument. You can get the actual camera being used by looking up
-         * {@link LayerComposition#cameras} with this index.
-         *
-         * @type {Function}
-         */
-        this.onPreRender = options.onPreRender;
-
-        /**
-         * Custom function that is called before opaque mesh instances (not semi-transparent) in
-         * this layer are rendered. This function will receive camera index as the only argument.
-         * You can get the actual camera being used by looking up {@link LayerComposition#cameras}
-         * with this index.
-         *
-         * @type {Function}
-         */
-        this.onPreRenderOpaque = options.onPreRenderOpaque;
-
-        /**
-         * Custom function that is called before semi-transparent mesh instances in this layer are
-         * rendered. This function will receive camera index as the only argument. You can get the
-         * actual camera being used by looking up {@link LayerComposition#cameras} with this index.
-         *
-         * @type {Function}
-         */
-        this.onPreRenderTransparent = options.onPreRenderTransparent;
-
-        /**
-         * Custom function that is called after visibility culling is performed for this layer.
-         * Useful for reverting changes done in {@link Layer#onPreCull} and determining final mesh
-         * instance visibility (see {@link MeshInstance#visibleThisFrame}). This function will
-         * receive camera index as the only argument. You can get the actual camera being used by
-         * looking up {@link LayerComposition#cameras} with this index.
-         *
-         * @type {Function}
-         */
-        this.onPostCull = options.onPostCull;
-
-        /**
-         * Custom function that is called after this layer is rendered. Useful to revert changes
-         * made in {@link Layer#onPreRender}. This function is called after the last occurrence of this
-         * layer in {@link LayerComposition}. It will receive camera index as the only argument.
-         * You can get the actual camera being used by looking up {@link LayerComposition#cameras}
-         * with this index.
-         *
-         * @type {Function}
-         */
-        this.onPostRender = options.onPostRender;
-
-        /**
-         * Custom function that is called after opaque mesh instances (not semi-transparent) in
-         * this layer are rendered. This function will receive camera index as the only argument.
-         * You can get the actual camera being used by looking up {@link LayerComposition#cameras}
-         * with this index.
-         *
-         * @type {Function}
-         */
-        this.onPostRenderOpaque = options.onPostRenderOpaque;
-
-        /**
-         * Custom function that is called after semi-transparent mesh instances in this layer are
-         * rendered. This function will receive camera index as the only argument. You can get the
-         * actual camera being used by looking up {@link LayerComposition#cameras} with this index.
-         *
-         * @type {Function}
-         */
-        this.onPostRenderTransparent = options.onPostRenderTransparent;
-
-        /**
-         * Custom function that is called before every mesh instance in this layer is rendered. It
-         * is not recommended to set this function when rendering many objects every frame due to
-         * performance reasons.
-         *
-         * @type {Function}
-         */
-        this.onDrawCall = options.onDrawCall;
-
-        /**
          * Custom function that is called after the layer has been enabled. This happens when:
          *
          * - The layer is created with {@link Layer#enabled} set to true (which is the default value).
@@ -395,19 +303,11 @@ class Layer {
         }
 
         /**
-         * Make this layer render the same mesh instances that another layer does instead of having
-         * its own mesh instance list. Both layers must share cameras. Frustum culling is only
-         * performed for one layer. Useful for rendering multiple passes using different shaders.
-         *
-         * @type {Layer}
-         */
-        this.layerReference = options.layerReference; // should use the same camera
-
-        /**
          * @type {Function|null}
          * @ignore
          */
         this.customSortCallback = null;
+
         /**
          * @type {Function|null}
          * @ignore

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -225,7 +225,7 @@ class MeshInstance {
     visible = true;
 
     /**
-     * Read this value in {@link Layer#onPostCull} to determine if the object is actually going to
+     * Read this value in {@link CameraComponent#onPostCull} to determine if the object is actually going to
      * be rendered.
      *
      * @type {boolean}

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -779,7 +779,7 @@ class ForwardRenderer extends Renderer {
             visible,
             splitLights,
             shaderPass,
-            layer?.onDrawCall,
+            null,
             layer,
             flipFaces);
 


### PR DESCRIPTION
- removed Layer.renderTarget support, which has been deprecated for few years now. renderTarget can be set on the CameraComponent only now.
- this made multiple callbacks on the Layer no longer relevant, and those were removed as well: 
	- onPreRender
	- onPreRenderOpaque
	- onPreRenderTransparent
	- onPostRender
	- onPostRenderOpaque
	- onPostRenderTransparent
- two callbacks were moved from the Layer to a more appropriate place at the CameraComponent:
	- onPreCull
	- onPostCull
- Layer.layerReference has been removed, this have been unused for some time
- Layer.onDrawCall callback has been removed. This was a callback called during rendering when all render state has been setup, allowing the user to apply some overrides. With the move to render pipelines and uniform buffers, only a very limited subset of state could be change here, making it pointless. This will also further limited when we implement parallel render pipeline compilation, as even those few remining bits that can be changed currently will no longer be applicable.

Callbacks available now, all on the CameraComponent:
- onPreCull
- onPostCull
- onPreRender
- onPostRender

There will likely be additional callbacks added for the render pass architecture, but that a separate work in the future.