### PR TITLE
[BREAKING] Adjusted the alpha part of the normal blend used by the Materials

### DIFF
--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -34,7 +34,7 @@ import { getDefaultMaterial } from './default-material.js';
 const blendModes = [];
 blendModes[BLEND_SUBTRACTIVE] = { src: BLENDMODE_ONE, dst: BLENDMODE_ONE, op: BLENDEQUATION_REVERSE_SUBTRACT };
 blendModes[BLEND_NONE] = { src: BLENDMODE_ONE, dst: BLENDMODE_ZERO, op: BLENDEQUATION_ADD };
-blendModes[BLEND_NORMAL] = { src: BLENDMODE_SRC_ALPHA, dst: BLENDMODE_ONE_MINUS_SRC_ALPHA, op: BLENDEQUATION_ADD };
+blendModes[BLEND_NORMAL] = { src: BLENDMODE_SRC_ALPHA, dst: BLENDMODE_ONE_MINUS_SRC_ALPHA, op: BLENDEQUATION_ADD, alphaSrc: BLENDMODE_ONE };
 blendModes[BLEND_PREMULTIPLIED] = { src: BLENDMODE_ONE, dst: BLENDMODE_ONE_MINUS_SRC_ALPHA, op: BLENDEQUATION_ADD };
 blendModes[BLEND_ADDITIVE] = { src: BLENDMODE_ONE, dst: BLENDMODE_ONE, op: BLENDEQUATION_ADD };
 blendModes[BLEND_ADDITIVEALPHA] = { src: BLENDMODE_SRC_ALPHA, dst: BLENDMODE_ONE, op: BLENDEQUATION_ADD };
@@ -376,7 +376,7 @@ class Material {
         const blendMode = blendModes[type];
         Debug.assert(blendMode, `Unknown blend mode ${type}`);
         this._blendState.setColorBlend(blendMode.op, blendMode.src, blendMode.dst);
-        this._blendState.setAlphaBlend(blendMode.op, blendMode.src, blendMode.dst);
+        this._blendState.setAlphaBlend(blendMode.alphaOp ?? blendMode.op, blendMode.alphaSrc ?? blendMode.src, blendMode.alphaDst ?? blendMode.dst);
 
         const blend = type !== BLEND_NONE;
         if (this._blendState.blend !== blend) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5340

The alpha part of the Normal blend mode has been changed to preserve opaque objects when a transparent object renders on top.

This has no impact for projects that do not use destination alpha, and should only improve the AR and similar applications, but marking this as a Breaking as it has a potential for a change, even though mostly for the better.

One example is splat rendering. Before the splat was see-through
![Screenshot 2024-08-21 at 15 18 14](https://github.com/user-attachments/assets/47088034-361d-4119-866a-0cfafdabb913)

But this is no longer a problem
<img width="266" alt="Screenshot 2024-08-21 at 15 18 44" src="https://github.com/user-attachments/assets/aeff7ad5-e8aa-4b48-9c79-a08c27aaa501">
