### PR TITLE
Prefilter fix (engine v1)

### DIFF
--- a/src/scene/graphics/reproject-texture.js
+++ b/src/scene/graphics/reproject-texture.js
@@ -499,14 +499,8 @@ function reprojectTexture(source, target, options = {}) {
 
     const params = [
         0,
-        specularPower,
         source.fixCubemapSeams ? 1.0 / source.width : 0.0,          // source seam scale
         target.fixCubemapSeams ? 1.0 / target.width : 0.0           // target seam scale
-    ];
-
-    const params2 = [
-        target.width * target.height * (target.cubemap ? 6 : 1),
-        source.width * source.height * (source.cubemap ? 6 : 1)
     ];
 
     if (prefilterSamples) {
@@ -530,7 +524,6 @@ function reprojectTexture(source, target, options = {}) {
             });
             params[0] = f;
             constantParams.setValue(params);
-            constantParams2.setValue(params2);
 
             drawQuadWithShader(device, renderTarget, shader, options?.rect);
 

--- a/src/scene/shader-lib/chunks/common/frag/reproject.js
+++ b/src/scene/shader-lib/chunks/common/frag/reproject.js
@@ -31,23 +31,13 @@ varying vec2 vUv0;
 
 // params:
 // x - target cubemap face 0..6
-// y - specular power (when prefiltering)
-// z - source cubemap seam scale (0 to disable)
-// w - target cubemap size for seam calc (0 to disable)
-uniform vec4 params;
-
-// params2:
-// x - target image total pixels
-// y - source cubemap size
-uniform vec2 params2;
+// y - source cubemap seam scale (0 to disable)
+// z - target cubemap size for seam calc (0 to disable)
+uniform vec3 params;
 
 float targetFace() { return params.x; }
-float specularPower() { return params.y; }
-float sourceCubeSeamScale() { return params.z; }
-float targetCubeSeamScale() { return params.w; }
-
-float targetTotalPixels() { return params2.x; }
-float sourceTotalPixels() { return params2.y; }
+float sourceCubeSeamScale() { return params.y; }
+float targetCubeSeamScale() { return params.z; }
 
 float PI = 3.141592653589793;
 


### PR DESCRIPTION
Fixes:
https://forum.playcanvas.com/t/bug-prefilter-cubemap-legacy-cubemap-failure/36797
https://forum.playcanvas.com/t/chrome-128-webgl-issue-breaks-project-the-provided-float-value-is-non-finite/36794

Chrome 128 introduced a bug where specifying `undefined` as a uniform parameter causes a browser failure.

This PR fixes this case when prefiltering cubemaps.

It also removes the dead uniforms.