### PR TITLE
OutlineRenderer and an engine example

### DIFF
--- a/examples/src/examples/graphics/outlines-colored.example.mjs
+++ b/examples/src/examples/graphics/outlines-colored.example.mjs
@@ -1,0 +1,121 @@
+import * as pc from 'playcanvas';
+import { deviceType, rootPath, fileImport } from 'examples/utils';
+
+const { OutlineRenderer } = await fileImport(rootPath + '/static/assets/scripts/misc/outline-renderer.mjs');
+
+const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
+window.focus();
+
+// set up and load draco module, as the glb we load is draco compressed
+pc.WasmModule.setConfig('DracoDecoderModule', {
+    glueUrl: rootPath + '/static/lib/draco/draco.wasm.js',
+    wasmUrl: rootPath + '/static/lib/draco/draco.wasm.wasm',
+    fallbackUrl: rootPath + '/static/lib/draco/draco.js'
+});
+
+const assets = {
+    laboratory: new pc.Asset('statue', 'container', { url: rootPath + '/static/assets/models/laboratory.glb' }),
+    orbit: new pc.Asset('orbit', 'script', { url: rootPath + '/static/scripts/camera/orbit-camera.js' }),
+    ssao: new pc.Asset('ssao', 'script', { url: rootPath + '/static/scripts/posteffects/posteffect-ssao.js' }),
+    helipad: new pc.Asset(
+        'helipad-env-atlas',
+        'texture',
+        { url: rootPath + '/static/assets/cubemaps/helipad-env-atlas.png' },
+        { type: pc.TEXTURETYPE_RGBP, mipmaps: false }
+    )
+};
+
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    glslangUrl: rootPath + '/static/lib/glslang/glslang.js',
+    twgslUrl: rootPath + '/static/lib/twgsl/twgsl.js'
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(document.body);
+createOptions.touch = new pc.TouchDevice(document.body);
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem,
+    pc.ScriptComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.ScriptHandler,
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
+
+// Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+// Ensure canvas is resized when window changes size
+const resize = () => app.resizeCanvas();
+window.addEventListener('resize', resize);
+app.on('destroy', () => {
+    window.removeEventListener('resize', resize);
+});
+
+const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+assetListLoader.load(() => {
+    app.start();
+
+    // setup skydome
+    app.scene.envAtlas = assets.helipad.resource;
+    app.scene.skyboxMip = 2;
+    app.scene.exposure = 2.5;
+
+    // get the instance of the laboratory
+    const laboratoryEntity = assets.laboratory.resource.instantiateRenderEntity();
+    laboratoryEntity.setLocalScale(100, 100, 100);
+    app.root.addChild(laboratoryEntity);
+
+    // Create an Entity with a camera component
+    const cameraEntity = new pc.Entity('SceneCamera');
+    cameraEntity.addComponent('camera', {
+        clearColor: new pc.Color(0.4, 0.45, 0.5),
+        nearClip: 1,
+        farClip: 600
+    });
+
+    // add orbit camera script
+    cameraEntity.addComponent('script');
+    cameraEntity.script.create('orbitCamera', {
+        attributes: {
+            inertiaFactor: 0.2,
+            focusEntity: laboratoryEntity,
+            distanceMax: 300
+        }
+    });
+    cameraEntity.script.create('orbitCameraInputMouse');
+    cameraEntity.script.create('orbitCameraInputTouch');
+
+    // position the camera in the world
+    cameraEntity.setLocalPosition(-60, 30, 60);
+    app.root.addChild(cameraEntity);
+
+    // create the outline renderer
+    const outlineRenderer = new pc.OutlineRenderer(app);
+
+    // add entities to the outline renderer
+    outlineRenderer.addEntity(laboratoryEntity.findByName("Weltkugel"), pc.Color.RED);
+    outlineRenderer.addEntity(laboratoryEntity.findByName("Stuhl"), pc.Color.WHITE);
+    outlineRenderer.addEntity(laboratoryEntity.findByName("Teleskop"), pc.Color.GREEN);
+
+    app.on('update', (/** @type {number} */ dt) => {
+
+        // update the outline renderer each frame, and render the outlines inside the opaque sub-layer
+        // of the immediate layer
+        const immediateLayer = app.scene.layers.getLayerByName('Immediate');
+        outlineRenderer.frameUpdate(cameraEntity, immediateLayer, false);
+    });
+});
+
+export { app };

--- a/examples/src/examples/graphics/outlines-colored.example.mjs
+++ b/examples/src/examples/graphics/outlines-colored.example.mjs
@@ -1,7 +1,5 @@
 import * as pc from 'playcanvas';
-import { deviceType, rootPath, fileImport } from 'examples/utils';
-
-const { OutlineRenderer } = await fileImport(rootPath + '/static/assets/scripts/misc/outline-renderer.mjs');
+import { deviceType, rootPath } from 'examples/utils';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();

--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -6,6 +6,9 @@
 
 export { MiniStats } from './mini-stats/mini-stats.js';
 
+// RENDERERS
+export { OutlineRenderer } from './renderers/outline-renderer.js';
+
 // EXPORTERS
 export { UsdzExporter } from './exporters/usdz-exporter.js';
 export { GltfExporter } from './exporters/gltf-exporter.js';

--- a/src/extras/renderers/outline-renderer.js
+++ b/src/extras/renderers/outline-renderer.js
@@ -294,7 +294,8 @@ class OutlineRenderer {
         // render target
         return new RenderTarget({
             colorBuffer: texture,
-            depth: depth
+            depth: depth,
+            flipY: this.app.graphicsDevice.isWebGPU
         });
     }
 

--- a/src/extras/renderers/outline-renderer.js
+++ b/src/extras/renderers/outline-renderer.js
@@ -1,20 +1,20 @@
-import { Color } from "../../core/math/color.js";
-import { Entity } from "../../framework/entity.js";
-import { BlendState } from "../../platform/graphics/blend-state.js";
+import { Color } from '../../core/math/color.js';
+import { Entity } from '../../framework/entity.js';
+import { BlendState } from '../../platform/graphics/blend-state.js';
 import {
     ADDRESS_CLAMP_TO_EDGE, BLENDEQUATION_ADD, BLENDMODE_ONE_MINUS_SRC_ALPHA, BLENDMODE_SRC_ALPHA,
     CULLFACE_NONE,
     FILTER_LINEAR, FILTER_LINEAR_MIPMAP_LINEAR, PIXELFORMAT_SRGBA8
-} from "../../platform/graphics/constants.js";
-import { DepthState } from "../../platform/graphics/depth-state.js";
-import { RenderTarget } from "../../platform/graphics/render-target.js";
-import { Texture } from "../../platform/graphics/texture.js";
-import { drawQuadWithShader } from "../../scene/graphics/quad-render-utils.js";
-import { QuadRender } from "../../scene/graphics/quad-render.js";
-import { StandardMaterialOptions } from "../../scene/materials/standard-material-options.js";
-import { StandardMaterial } from "../../scene/materials/standard-material.js";
-import { shaderChunks } from "../../scene/shader-lib/chunks/chunks.js";
-import { createShaderFromCode } from "../../scene/shader-lib/utils.js";
+} from '../../platform/graphics/constants.js';
+import { DepthState } from '../../platform/graphics/depth-state.js';
+import { RenderTarget } from '../../platform/graphics/render-target.js';
+import { Texture } from '../../platform/graphics/texture.js';
+import { drawQuadWithShader } from '../../scene/graphics/quad-render-utils.js';
+import { QuadRender } from '../../scene/graphics/quad-render.js';
+import { StandardMaterialOptions } from '../../scene/materials/standard-material-options.js';
+import { StandardMaterial } from '../../scene/materials/standard-material.js';
+import { shaderChunks } from '../../scene/shader-lib/chunks/chunks.js';
+import { createShaderFromCode } from '../../scene/shader-lib/utils.js';
 
 /**
  * @import { AppBase } from '../../framework/app-base.js'

--- a/src/extras/renderers/outline-renderer.js
+++ b/src/extras/renderers/outline-renderer.js
@@ -1,0 +1,354 @@
+import { Color } from "../../core/math/color.js";
+import { Entity } from "../../framework/entity.js";
+import { BlendState } from "../../platform/graphics/blend-state.js";
+import {
+    ADDRESS_CLAMP_TO_EDGE, BLENDEQUATION_ADD, BLENDMODE_ONE_MINUS_SRC_ALPHA, BLENDMODE_SRC_ALPHA,
+    CULLFACE_NONE,
+    FILTER_LINEAR, FILTER_LINEAR_MIPMAP_LINEAR, PIXELFORMAT_SRGBA8
+} from "../../platform/graphics/constants.js";
+import { DepthState } from "../../platform/graphics/depth-state.js";
+import { RenderTarget } from "../../platform/graphics/render-target.js";
+import { Texture } from "../../platform/graphics/texture.js";
+import { drawQuadWithShader } from "../../scene/graphics/quad-render-utils.js";
+import { QuadRender } from "../../scene/graphics/quad-render.js";
+import { StandardMaterialOptions } from "../../scene/materials/standard-material-options.js";
+import { StandardMaterial } from "../../scene/materials/standard-material.js";
+import { shaderChunks } from "../../scene/shader-lib/chunks/chunks.js";
+import { createShaderFromCode } from "../../scene/shader-lib/utils.js";
+
+/**
+ * @import { AppBase } from '../../framework/app-base.js'
+ * @import { Layer } from "../../scene/layer.js"
+ */
+
+// Fragment shader which works on a source image containing objects rendered using a constant color.
+// The shader removes the original object color and outputs outline color only.
+const shaderOutlineExtendPS = /* glsl */ `
+
+    varying vec2 vUv0;
+
+    uniform vec2 uOffset;
+    uniform float uSrcMultiplier;
+    uniform sampler2D source;
+
+    void main(void)
+    {
+        vec4 pixel;
+        vec4 texel = texture2D(source, vUv0);
+        vec4 firstTexel = texel;
+        float diff = texel.a * uSrcMultiplier;
+
+        pixel = texture2D(source, vUv0 + uOffset * -2.0);
+        texel = max(texel, pixel);
+        diff = max(diff, length(firstTexel.rgb - pixel.rgb));
+
+        pixel = texture2D(source, vUv0 + uOffset * -1.0);
+        texel = max(texel, pixel);
+        diff = max(diff, length(firstTexel.rgb - pixel.rgb));
+
+        pixel = texture2D(source, vUv0 + uOffset * 1.0);
+        texel = max(texel, pixel);
+        diff = max(diff, length(firstTexel.rgb - pixel.rgb));
+
+        pixel = texture2D(source, vUv0 + uOffset * 2.0);
+        texel = max(texel, pixel);
+        diff = max(diff, length(firstTexel.rgb - pixel.rgb));
+
+       gl_FragColor = vec4(texel.rgb, min(diff, 1.0));
+    }
+`;
+
+const _tempFloatArray = new Float32Array(2);
+const _tempColor = new Color();
+
+/**
+ * Class responsible for rendering color outlines around objects in the scene.
+ *
+ * @category Graphics
+ */
+class OutlineRenderer {
+    /**
+     * Create a new OutlineRenderer.
+     *
+     * @param {AppBase} app - The application.
+     * @param {Layer} [renderingLayer] - A layer used internally to render the outlines. If not
+     * provided, the renderer will use the 'Immediate' layer. This needs to be supplied only if the
+     * 'Immediate' layer is not present in the scene.
+     * @param {number} [priority] - The priority of the camera rendering the outlines. Should be
+     * smaller value than the priority of the scene camera, to be updated first. Defaults to -1.
+     */
+    constructor(app, renderingLayer, priority = -1) {
+        this.app = app;
+
+        this.renderingLayer = renderingLayer ?? app.scene.layers.getLayerByName('Immediate');
+
+        this.rt = this.createRenderTarget('OutlineTexture', 1, 1, true);
+
+        // camera which renders the outline texture
+        this.outlineCameraEntity = new Entity('OutlineCamera');
+        this.outlineCameraEntity.addComponent('camera', {
+            layers: [this.renderingLayer.id],
+            priority: priority,
+            clearColor: new Color(0, 0, 0, 0),
+            renderTarget: this.rt
+        });
+
+        // custom shader pass for the outline camera
+        this.outlineShaderPass = this.outlineCameraEntity.camera.setShaderPass('OutlineShaderPass');
+
+        // function called after the camera has rendered the outline objects to the texture
+        this.outlineCameraEntity.camera.onPostRender = () => {
+            this.onPostRender();
+        };
+
+        // add the camera to the scene
+        this.app.root.addChild(this.outlineCameraEntity);
+
+        // temporary render target for intermediate steps
+        this.tempRt = this.createRenderTarget('OutlineTempTexture', 1, 1, false);
+
+        this.blendState = new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_SRC_ALPHA, BLENDMODE_ONE_MINUS_SRC_ALPHA);
+
+        const device = this.app.graphicsDevice;
+        this.shaderExtend = createShaderFromCode(device, shaderChunks.fullscreenQuadVS, shaderOutlineExtendPS, 'OutlineExtendShader');
+        this.shaderBlend = createShaderFromCode(device, shaderChunks.fullscreenQuadVS, shaderChunks.outputTex2DPS, 'OutlineBlendShader');
+
+        this.quadRenderer = new QuadRender(this.shaderBlend);
+
+        this.whiteTex = new Texture(device, {
+            name: 'OutlineWhiteTexture',
+            width: 1,
+            height: 1,
+            format: PIXELFORMAT_SRGBA8,
+            mipmaps: false
+        });
+        const pixels = this.whiteTex.lock();
+        pixels.set(new Uint8Array([255, 255, 255, 255]));
+        this.whiteTex.unlock();
+    }
+
+    /**
+     * Destroy the outline renderer and its resources.
+     */
+    destroy() {
+
+        this.whiteTex.destroy();
+        this.whiteTex = null;
+
+        this.outlineCameraEntity.destroy();
+        this.outlineCameraEntity = null;
+
+        this.rt.destroyTextureBuffers();
+        this.rt.destroy();
+        this.rt = null;
+
+        this.tempRt.destroyTextureBuffers();
+        this.tempRt.destroy();
+        this.tempRt = null;
+
+        this.quadRenderer?.destroy();
+        this.quadRenderer = null;
+    }
+
+    getMeshInstances(entity, recursive) {
+        const meshInstances = [];
+
+        const renders = recursive ? entity.findComponents('render') : (entity.render ? [entity.render] : []);
+        renders.forEach((render) => {
+            meshInstances.push(...render.meshInstances);
+        });
+
+        const models = recursive ? entity.findComponents('model') : (entity.model ? [entity.model] : []);
+        models.forEach((model) => {
+            meshInstances.push(...model.meshInstances);
+        });
+
+        return meshInstances;
+    }
+
+    /**
+     * Add an entity to the outline renderer.
+     *
+     * @param {Entity} entity - The entity to add. All MeshInstance of the entity and its
+     * descendants will be added.
+     * @param {Color} color - The color of the outline.
+     * @param {boolean} [recursive] - Whether to add MeshInstances of the entity's descendants.
+     * Defaults to true.
+     */
+    addEntity(entity, color, recursive = true) {
+        const meshInstances = this.getMeshInstances(entity, recursive);
+
+        // update all materials
+        meshInstances.forEach((meshInstance) => {
+            if (meshInstance.material instanceof StandardMaterial) {
+                const outlineShaderPass = this.outlineShaderPass;
+                meshInstance.material.onUpdateShader = (options) => {
+
+                    if (options.pass === outlineShaderPass) {
+
+                        // custom shader for the outline shader pass, renders single color meshes using emissive color
+                        const opts = new StandardMaterialOptions();
+                        opts.opacityMap = options.opacityMap;
+                        opts.opacityMapUv = options.opacityMapUv;
+                        opts.opacityMapChannel = options.opacityMapChannel;
+                        opts.opacityMapTransform = options.opacityMapTransform;
+                        opts.opacityVertexColor = options.opacityVertexColor;
+                        opts.opacityVertexColorChannel = options.opacityVertexColorChannel;
+                        opts.litOptions.vertexColors = options.litOptions.vertexColors;
+                        opts.litOptions.alphaTest = options.litOptions.alphaTest;
+                        opts.litOptions.skin = options.litOptions.skin;
+                        return opts;
+                    }
+
+                    return options;
+                };
+
+                // set emissive color override for the outline shader pass only
+                _tempColor.linear(color);
+                const colArray = new Float32Array([_tempColor.r, _tempColor.g, _tempColor.b]);
+                meshInstance.setParameter('material_emissive', colArray, 1 << this.outlineShaderPass);
+                meshInstance.setParameter('texture_emissiveMap', this.whiteTex, 1 << this.outlineShaderPass);
+            }
+        });
+
+        this.renderingLayer.addMeshInstances(meshInstances, true);
+    }
+
+    /**
+     * Remove an entity from the outline renderer.
+     *
+     * @param {Entity} entity - The entity to remove.
+     * @param {boolean} [recursive] - Whether to add MeshInstances of the entity's descendants.
+     * Defaults to true.
+     */
+    removeEntity(entity, recursive = true) {
+        const meshInstances = this.getMeshInstances(entity, recursive);
+        this.renderingLayer.removeMeshInstances(meshInstances);
+
+        meshInstances.forEach((meshInstance) => {
+            if (meshInstance.material instanceof StandardMaterial) {
+                meshInstance.material.onUpdateShader = null;
+                meshInstance.deleteParameter('material_emissive');
+            }
+        });
+    }
+
+    removeAllEntities() {
+        this.renderingLayer.clearMeshInstances();
+    }
+
+    blendOutlines() {
+
+        // blend in the outlines texture on top of the rendering
+        const device = this.app.graphicsDevice;
+        device.scope.resolve('source').setValue(this.rt.colorBuffer);
+
+        device.setDepthState(DepthState.NODEPTH);
+        device.setCullMode(CULLFACE_NONE);
+        device.setBlendState(this.blendState);
+        this.quadRenderer.render();
+    }
+
+    onPostRender() {
+
+        // when the outline camera has rendered the outline objects to the texture, process the texture
+        // to generate the outline effect
+        const device = this.app.graphicsDevice;
+        const uOffset = device.scope.resolve('uOffset');
+        const uColorBuffer = device.scope.resolve('source');
+        const uSrcMultiplier = device.scope.resolve('uSrcMultiplier');
+        const { rt, tempRt, shaderExtend } = this;
+        const { width, height } = rt;
+
+        // horizontal extend pass
+        _tempFloatArray[0] = 1.0 / width / 2.0;
+        _tempFloatArray[1] = 0;
+        uOffset.setValue(_tempFloatArray);
+        uColorBuffer.setValue(rt.colorBuffer);
+        uSrcMultiplier.setValue(0.0);
+        drawQuadWithShader(device, tempRt, shaderExtend);
+
+        // vertical extend pass
+        _tempFloatArray[0] = 0;
+        _tempFloatArray[1] = 1.0 / height / 2.0;
+        uOffset.setValue(_tempFloatArray);
+        uColorBuffer.setValue(tempRt.colorBuffer);
+        uSrcMultiplier.setValue(1.0);
+        drawQuadWithShader(device, rt, shaderExtend);
+    }
+
+    createRenderTarget(name, width, height, depth) {
+        // Create texture render target with specified resolution and mipmap generation
+        const texture = new Texture(this.app.graphicsDevice, {
+            name: name,
+            width: width,
+            height: height,
+            format: PIXELFORMAT_SRGBA8,
+            mipmaps: false,
+            addressU: ADDRESS_CLAMP_TO_EDGE,
+            addressV: ADDRESS_CLAMP_TO_EDGE,
+            minFilter: FILTER_LINEAR_MIPMAP_LINEAR,
+            magFilter: FILTER_LINEAR
+        });
+
+        // render target
+        return new RenderTarget({
+            colorBuffer: texture,
+            depth: depth
+        });
+    }
+
+    updateRenderTarget(sceneCamera) {
+
+        // main camera resolution
+        const width = sceneCamera.renderTarget?.width ?? this.app.graphicsDevice.width;
+        const height = sceneCamera.renderTarget?.height ?? this.app.graphicsDevice.height;
+
+        const outlineCamera = this.outlineCameraEntity.camera;
+        if (!outlineCamera.renderTarget || outlineCamera.renderTarget.width !== width || outlineCamera.renderTarget.height !== height) {
+
+            this.rt.resize(width, height);
+            this.tempRt.resize(width, height);
+        }
+    }
+
+    /**
+     * Update the outline renderer. Should be called once per frame.
+     *
+     * @param {Entity} sceneCameraEntity - The camera used to render the scene, which is used to provide
+     * the camera properties to the outline rendering camera.
+     * @param {Layer} blendLayer - The layer in which the outlines should be rendered.
+     * @param {boolean} blendLayerTransparent - Whether the blend layer is transparent.
+     */
+    frameUpdate(sceneCameraEntity, blendLayer, blendLayerTransparent) {
+
+        const sceneCamera = sceneCameraEntity.camera;
+        this.updateRenderTarget(sceneCamera);
+
+        // function called before the scene camera renders a layer
+        sceneCameraEntity.camera.onPreRenderLayer = (layer, transparent) => {
+
+            // when specified blend layer is rendered, add outline before its rendering
+            if (transparent === blendLayerTransparent && layer === blendLayer) {
+                this.blendOutlines();
+
+                sceneCameraEntity.camera.onPreRenderLayer = null;
+            }
+        };
+
+        // copy the transform
+        this.outlineCameraEntity.setLocalPosition(sceneCameraEntity.getPosition());
+        this.outlineCameraEntity.setLocalRotation(sceneCameraEntity.getRotation());
+
+        // copy other properties from the scene camera
+        const outlineCamera = this.outlineCameraEntity.camera;
+        outlineCamera.projection = sceneCamera.projection;
+        outlineCamera.horizontalFov = sceneCamera.horizontalFov;
+        outlineCamera.fov = sceneCamera.fov;
+        outlineCamera.orthoHeight = sceneCamera.orthoHeight;
+        outlineCamera.nearClip = sceneCamera.nearClip;
+        outlineCamera.farClip = sceneCamera.farClip;
+    }
+}
+
+export { OutlineRenderer };

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -30,6 +30,14 @@ import { PostEffectQueue } from './post-effect-queue.js';
  */
 
 /**
+ * Callback used by {@link CameraComponent#onPreRenderLayer} and {@link CameraComponent#onPostRenderLayer}.
+ *
+ * @callback RenderLayerCallback
+ * @param {Layer} layer - The layer.
+ * @param {boolean} transparent - True for transparent sublayer, otherwise opaque sublayer.
+ */
+
+/**
  * The Camera Component enables an Entity to render the scene. A scene requires at least one
  * enabled camera component to be rendered. Note that multiple camera components can be enabled
  * simultaneously (for split-screen or offscreen rendering, for example).
@@ -69,11 +77,29 @@ class CameraComponent extends Component {
     onPreRender = null;
 
     /**
+     * Custom function that is called before the camera renders a layer. This is called during
+     * rendering to a render target or a default framebuffer, and additional rendering can be
+     * performed here, for example using ${@link QuadRender#render}.
+     *
+     * @type {RenderLayerCallback|null}
+     */
+    onPreRenderLayer = null;
+
+    /**
      * Custom function that is called after the camera renders the scene.
      *
      * @type {Function|null}
      */
     onPostRender = null;
+
+    /**
+     * Custom function that is called after the camera renders a layer. This is called during
+     * rendering to a render target or a default framebuffer, and additional rendering can be
+     * performed here, for example using ${@link QuadRender#render}.
+     *
+     * @type {RenderLayerCallback|null}
+     */
+    onPostRenderLayer = null;
 
     /**
      * Custom function that is called before visibility culling is performed for this camera.

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -8,6 +8,13 @@ import { LitShaderOptions } from '../shader-lib/programs/lit-shader-options.js';
  */
 class StandardMaterialOptions {
     /**
+     * The set of defines used to generate the shader.
+     *
+     * @type {Map<string, string>}
+     */
+    defines = new Map();
+
+    /**
      * If UV1 (second set of texture coordinates) is required in the shader. Will be declared as
      * "vUv1" and passed to the fragment shader.
      *

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -1041,26 +1041,11 @@ class MeshInstance {
      * over parameter of the same name if set on Material this mesh instance uses for rendering.
      *
      * @param {string} name - The name of the parameter to set.
-     * @param {number|number[]|Texture|Float32Array} data - The
-     * value for the specified parameter.
+     * @param {number|number[]|Texture|Float32Array} data - The value for the specified parameter.
      * @param {number} [passFlags] - Mask describing which passes the material should be included
-     * in.
+     * in. Defaults to 0xFFFFFFFF (all passes).
      */
-    setParameter(name, data, passFlags = -262141) {
-
-        // note on -262141: All bits set except 2 - 19 range
-
-        if (data === undefined && typeof name === 'object') {
-            const uniformObject = name;
-            if (uniformObject.length) {
-                for (let i = 0; i < uniformObject.length; i++) {
-                    this.setParameter(uniformObject[i]);
-                }
-                return;
-            }
-            name = uniformObject.name;
-            data = uniformObject.value;
-        }
+    setParameter(name, data, passFlags = 0xFFFFFFFF) {
 
         const param = this.parameters[name];
         if (param) {

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -251,6 +251,9 @@ class RenderPassForward extends RenderPass {
 
         if (camera) {
 
+            // layer post render callback
+            camera.onPreRenderLayer?.(layer, transparent);
+
             const options = {
                 lightClusters: renderAction.lightClusters
             };
@@ -276,6 +279,9 @@ class RenderPassForward extends RenderPass {
             device.setBlendState(BlendState.NOBLEND);
             device.setStencilState(null, null);
             device.setAlphaToCoverage(false);
+
+            // layer post render callback
+            camera.onPostRenderLayer?.(layer, transparent);
         }
 
         DebugGraphics.popGpuMarker(this.device);


### PR DESCRIPTION
- Outline rendering tech extracted from the Editor and cleaned up and modernised, delivered as a module in `/extras`
- Engine example showing its use
- cleaned up `MeshInstance.setParameter` to avoid obsolete and undocumented functionality, and also to handle refactoring to shader passes, where the passes no longer have fixed numerical IDs.

## New public API

A replacement for removed callbacks on the Layer class.

```
CameraComponent.onPreRenderLayer(Layer, transparent)
CameraComponent.onPostRenderLayer(Layer, transparent)
```

<img width="581" alt="Screenshot 2024-08-29 at 13 25 50" src="https://github.com/user-attachments/assets/a25c691a-8820-4f62-8b50-5a57f7577a58">
