### PR TITLE
Allow per camera fog settings

### DIFF
--- a/examples/src/examples/graphics/shader-hatch.example.mjs
+++ b/examples/src/examples/graphics/shader-hatch.example.mjs
@@ -208,7 +208,7 @@ assetListLoader.load(() => {
         }
         if (propertyName === 'fog') {
             // turn on/off fog and set up its properties
-            app.scene.fog = value ? pc.FOG_LINEAR : pc.FOG_NONE;
+            app.scene.rendering.fog = value ? pc.FOG_LINEAR : pc.FOG_NONE;
             app.scene.fogColor = new pc.Color(0.8, 0.8, 0.8);
             app.scene.fogStart = 100;
             app.scene.fogEnd = 300;

--- a/examples/src/examples/graphics/shader-hatch.example.mjs
+++ b/examples/src/examples/graphics/shader-hatch.example.mjs
@@ -209,9 +209,9 @@ assetListLoader.load(() => {
         if (propertyName === 'fog') {
             // turn on/off fog and set up its properties
             app.scene.rendering.fog = value ? pc.FOG_LINEAR : pc.FOG_NONE;
-            app.scene.fogColor = new pc.Color(0.8, 0.8, 0.8);
-            app.scene.fogStart = 100;
-            app.scene.fogEnd = 300;
+            app.scene.rendering.fogColor = new pc.Color(0.8, 0.8, 0.8);
+            app.scene.rendering.fogStart = 100;
+            app.scene.rendering.fogEnd = 300;
         }
         if (propertyName === 'metalness') {
             materials.forEach((mat) => {

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -453,6 +453,17 @@ Object.defineProperty(Scene.prototype, 'defaultMaterial', {
     }
 });
 
+Object.defineProperty(Scene.prototype, 'fog', {
+    set: function (value) {
+        Debug.deprecated('Scene#fog is deprecated. Use Scene#rendering.fog instead.');
+        this.rendering.fog = value;
+    },
+    get: function () {
+        Debug.deprecated('Scene#fog is deprecated. Use Scene#rendering.fog instead.');
+        return this.rendering.fog;
+    }
+});
+
 Object.defineProperty(Scene.prototype, 'toneMapping', {
     set: function (value) {
         Debug.deprecated('Scene#toneMapping is deprecated. Use Scene#rendering.toneMapping instead.');

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -464,6 +464,50 @@ Object.defineProperty(Scene.prototype, 'fog', {
     }
 });
 
+Object.defineProperty(Scene.prototype, 'fogColor', {
+    set: function (value) {
+        Debug.deprecated('Scene#fogColor is deprecated. Use Scene#rendering.fogColor instead.');
+        this.rendering.fogColor = value;
+    },
+    get: function () {
+        Debug.deprecated('Scene#fogColor is deprecated. Use Scene#rendering.fogColor instead.');
+        return this.rendering.fogColor;
+    }
+});
+
+Object.defineProperty(Scene.prototype, 'fogEnd', {
+    set: function (value) {
+        Debug.deprecated('Scene#fogEnd is deprecated. Use Scene#rendering.fogEnd instead.');
+        this.rendering.fogEnd = value;
+    },
+    get: function () {
+        Debug.deprecated('Scene#fogEnd is deprecated. Use Scene#rendering.fogEnd instead.');
+        return this.rendering.fogEnd;
+    }
+});
+
+Object.defineProperty(Scene.prototype, 'fogStart', {
+    set: function (value) {
+        Debug.deprecated('Scene#fogStart is deprecated. Use Scene#rendering.fogStart instead.');
+        this.rendering.fogStart = value;
+    },
+    get: function () {
+        Debug.deprecated('Scene#fogStart is deprecated. Use Scene#rendering.fogStart instead.');
+        return this.rendering.fogStart;
+    }
+});
+
+Object.defineProperty(Scene.prototype, 'fogDensity', {
+    set: function (value) {
+        Debug.deprecated('Scene#fogDensity is deprecated. Use Scene#rendering.fogDensity instead.');
+        this.rendering.fogDensity = value;
+    },
+    get: function () {
+        Debug.deprecated('Scene#fogDensity is deprecated. Use Scene#rendering.fogDensity instead.');
+        return this.rendering.fogDensity;
+    }
+});
+
 Object.defineProperty(Scene.prototype, 'toneMapping', {
     set: function (value) {
         Debug.deprecated('Scene#toneMapping is deprecated. Use Scene#rendering.toneMapping instead.');

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -684,11 +684,11 @@ class Lightmapper {
     setupScene() {
 
         // backup
-        this.fog = this.scene.fog;
+        this.fog = this.scene.rendering.fog;
         this.ambientLight.copy(this.scene.ambientLight);
 
         // set up scene
-        this.scene.fog = FOG_NONE;
+        this.scene.rendering.fog = FOG_NONE;
 
         // if not baking ambient, set it to black
         if (!this.scene.ambientBake) {
@@ -701,7 +701,7 @@ class Lightmapper {
 
     restoreScene() {
 
-        this.scene.fog = this.fog;
+        this.scene.rendering.fog = this.fog;
         this.scene.ambientLight.copy(this.ambientLight);
     }
 

--- a/src/scene/materials/lit-material-options-builder.js
+++ b/src/scene/materials/lit-material-options-builder.js
@@ -89,7 +89,7 @@ class LitMaterialOptionsBuilder {
     }
 
     static updateEnvOptions(litOptions, material, scene, renderParams) {
-        litOptions.fog = material.useFog ? scene.fog : FOG_NONE;
+        litOptions.fog = material.useFog ? renderParams.fog : FOG_NONE;
         litOptions.gamma = renderParams.shaderOutputGamma;
         litOptions.toneMap = material.useTonemap ? renderParams.toneMapping : TONEMAP_NONE;
 

--- a/src/scene/materials/shader-material.js
+++ b/src/scene/materials/shader-material.js
@@ -108,7 +108,7 @@ class ShaderMaterial extends Material {
             pass: params.pass,
             gamma: params.renderParams.shaderOutputGamma,
             toneMapping: params.renderParams.toneMapping,
-            fog: params.scene.fog,
+            fog: params.renderParams.fog,
             shaderDesc: this.shaderDesc
         };
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -277,7 +277,7 @@ class StandardMaterialOptionsBuilder {
     }
 
     _updateEnvOptions(options, stdMat, scene, renderParams) {
-        options.litOptions.fog = stdMat.useFog ? scene.fog : FOG_NONE;
+        options.litOptions.fog = stdMat.useFog ? renderParams.fog : FOG_NONE;
         options.litOptions.gamma = renderParams.shaderOutputGamma;
         options.litOptions.toneMap = stdMat.useTonemap ? renderParams.toneMapping : TONEMAP_NONE;
 

--- a/src/scene/particle-system/particle-material.js
+++ b/src/scene/particle-system/particle-material.js
@@ -50,7 +50,7 @@ class ParticleMaterial extends Material {
             mesh: this.emitter.useMesh,
             gamma: renderParams?.shaderOutputGamma ?? GAMMA_NONE,
             toneMap: renderParams?.toneMapping ?? TONEMAP_LINEAR,
-            fog: (scene && !this.emitter.noFog) ? scene.fog : 'none',
+            fog: (scene && !this.emitter.noFog) ? scene.rendering.fog : 'none',
             wrap: this.emitter.wrap && this.emitter.wrapBounds,
             localSpace: this.emitter.localSpace,
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -757,6 +757,8 @@ class ForwardRenderer extends Renderer {
         // Set the not very clever global variable which is only useful when there's just one camera
         scene._activeCamera = camera;
 
+        const renderParams = camera.renderingParams ?? scene.rendering;
+        this.setFogConstants(renderParams);
         const viewCount = this.setCameraUniforms(camera, renderTarget);
         if (device.supportsUniformBuffers) {
             this.setupViewUniformBuffers(viewBindGroups, this.viewUniformFormat, this.viewBindGroupFormat, viewCount);
@@ -788,14 +790,11 @@ class ForwardRenderer extends Renderer {
         }
     }
 
-    setSceneConstants() {
-        const scene = this.scene;
+    setFogConstants(renderParams) {
 
-        // Set up ambient/exposure
-        this.dispatchGlobalLights(scene);
+        if (renderParams.fog !== FOG_NONE) {
 
-        // Set up the fog
-        if (scene.fog !== FOG_NONE) {
+            const scene = this.scene;
 
             // color in linear space
             tmpColor.linear(scene.fogColor);
@@ -805,13 +804,20 @@ class ForwardRenderer extends Renderer {
             fogUniform[2] = tmpColor.b;
             this.fogColorId.setValue(fogUniform);
 
-            if (scene.fog === FOG_LINEAR) {
+            if (renderParams.fog === FOG_LINEAR) {
                 this.fogStartId.setValue(scene.fogStart);
                 this.fogEndId.setValue(scene.fogEnd);
             } else {
                 this.fogDensityId.setValue(scene.fogDensity);
             }
         }
+    }
+
+    setSceneConstants() {
+        const scene = this.scene;
+
+        // Set up ambient/exposure
+        this.dispatchGlobalLights(scene);
 
         // Set up screen size // should be RT size?
         const device = this.device;

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -797,7 +797,7 @@ class ForwardRenderer extends Renderer {
             const scene = this.scene;
 
             // color in linear space
-            tmpColor.linear(scene.fogColor);
+            tmpColor.linear(scene?.rendering.fogColor);
             const fogUniform = this.fogColor;
             fogUniform[0] = tmpColor.r;
             fogUniform[1] = tmpColor.g;
@@ -805,10 +805,10 @@ class ForwardRenderer extends Renderer {
             this.fogColorId.setValue(fogUniform);
 
             if (renderParams.fog === FOG_LINEAR) {
-                this.fogStartId.setValue(scene.fogStart);
-                this.fogEndId.setValue(scene.fogEnd);
+                this.fogStartId.setValue(scene.rendering.fogStart);
+                this.fogEndId.setValue(scene.rendering.fogEnd);
             } else {
-                this.fogDensityId.setValue(scene.fogDensity);
+                this.fogDensityId.setValue(scene.rendering.fogDensity);
             }
         }
     }

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -251,7 +251,7 @@ class RenderPassForward extends RenderPass {
 
         if (camera) {
 
-            // layer post render callback
+            // layer pre render callback
             camera.onPreRenderLayer?.(layer, transparent);
 
             const options = {

--- a/src/scene/renderer/rendering-params.js
+++ b/src/scene/renderer/rendering-params.js
@@ -1,5 +1,5 @@
 import { hashCode } from '../../core/hash.js';
-import { GAMMA_NONE, GAMMA_SRGB, TONEMAP_LINEAR } from '../constants.js';
+import { FOG_NONE, GAMMA_NONE, GAMMA_SRGB, TONEMAP_LINEAR } from '../constants.js';
 
 /**
  * Rendering parameters, allow configuration of the rendering parameters.
@@ -15,6 +15,9 @@ class RenderingParams {
 
     /** @private */
     _srgbRenderTarget = false;
+
+    /** @private */
+    _fog = FOG_NONE;
 
     /**
      * The hash of the rendering parameters, or undefined if the hash has not been computed yet.
@@ -32,7 +35,7 @@ class RenderingParams {
      */
     get hash() {
         if (this._hash === undefined) {
-            const key = `${this.gammaCorrection}_${this.toneMapping}_${this.srgbRenderTarget}`;
+            const key = `${this.gammaCorrection}_${this.toneMapping}_${this.srgbRenderTarget}_${this.fog}`;
             this._hash = hashCode(key);
         }
         return this._hash;
@@ -40,6 +43,34 @@ class RenderingParams {
 
     markDirty() {
         this._hash = undefined;
+    }
+
+    /**
+     * Sets the type of fog used by the scene. Can be:
+     *
+     * - {@link FOG_NONE}
+     * - {@link FOG_LINEAR}
+     * - {@link FOG_EXP}
+     * - {@link FOG_EXP2}
+     *
+     * Defaults to {@link FOG_NONE}.
+     *
+     * @type {string}
+     */
+    set fog(type) {
+        if (this._fog !== type) {
+            this._fog = type;
+            this.markDirty();
+        }
+    }
+
+    /**
+     * Gets the type of fog used by the scene.
+     *
+     * @type {string}
+     */
+    get fog() {
+        return this._fog;
     }
 
     /**

--- a/src/scene/renderer/rendering-params.js
+++ b/src/scene/renderer/rendering-params.js
@@ -1,4 +1,5 @@
 import { hashCode } from '../../core/hash.js';
+import { Color } from '../../core/math/color.js';
 import { FOG_NONE, GAMMA_NONE, GAMMA_SRGB, TONEMAP_LINEAR } from '../constants.js';
 
 /**
@@ -18,6 +19,37 @@ class RenderingParams {
 
     /** @private */
     _fog = FOG_NONE;
+
+    /**
+     * The color of the fog (if enabled), specified in sRGB color space. Defaults to black (0, 0, 0).
+     *
+     * @type {Color}
+     */
+    fogColor = new Color(0, 0, 0);
+
+    /**
+     * The density of the fog (if enabled). This property is only valid if the fog property is set
+     * to {@link FOG_EXP} or {@link FOG_EXP2}. Defaults to 0.
+     *
+     * @type {number}
+     */
+    fogDensity = 0;
+
+    /**
+     * The distance from the viewpoint where linear fog reaches its maximum. This property is only
+     * valid if the fog property is set to {@link FOG_LINEAR}. Defaults to 1000.
+     *
+     * @type {number}
+     */
+    fogEnd = 1000;
+
+    /**
+     * The distance from the viewpoint where linear fog begins. This property is only valid if the
+     * fog property is set to {@link FOG_LINEAR}. Defaults to 1.
+     *
+     * @type {number}
+     */
+    fogStart = 1;
 
     /**
      * The hash of the rendering parameters, or undefined if the hash has not been computed yet.

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -249,8 +249,6 @@ class Scene extends EventHandler {
          */
         this._layers = null;
 
-        this._fog = FOG_NONE;
-
         /**
          * Array of 6 prefiltered lighting data cubemaps.
          *
@@ -427,34 +425,6 @@ class Scene extends EventHandler {
      */
     get envAtlas() {
         return this._envAtlas;
-    }
-
-    /**
-     * Sets the type of fog used by the scene. Can be:
-     *
-     * - {@link FOG_NONE}
-     * - {@link FOG_LINEAR}
-     * - {@link FOG_EXP}
-     * - {@link FOG_EXP2}
-     *
-     * Defaults to {@link FOG_NONE}.
-     *
-     * @type {string}
-     */
-    set fog(type) {
-        if (type !== this._fog) {
-            this._fog = type;
-            this.updateShaders = true;
-        }
-    }
-
-    /**
-     * Gets the type of fog used by the scene.
-     *
-     * @type {string}
-     */
-    get fog() {
-        return this._fog;
     }
 
     /**
@@ -730,7 +700,7 @@ class Scene extends EventHandler {
         this._gravity.set(physics.gravity[0], physics.gravity[1], physics.gravity[2]);
         this.ambientLight.set(render.global_ambient[0], render.global_ambient[1], render.global_ambient[2]);
         this.ambientLuminance = render.ambientLuminance;
-        this._fog = render.fog;
+        this._renderingParams.fog = render.fog;
         this.fogColor.set(render.fog_color[0], render.fog_color[1], render.fog_color[2]);
         this.fogStart = render.fog_start;
         this.fogEnd = render.fog_end;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -114,37 +114,6 @@ class Scene extends EventHandler {
     exposure = 1;
 
     /**
-     * The color of the fog (if enabled), specified in sRGB color space. Defaults to black (0, 0, 0).
-     *
-     * @type {Color}
-     */
-    fogColor = new Color(0, 0, 0);
-
-    /**
-     * The density of the fog (if enabled). This property is only valid if the fog property is set
-     * to {@link FOG_EXP} or {@link FOG_EXP2}. Defaults to 0.
-     *
-     * @type {number}
-     */
-    fogDensity = 0;
-
-    /**
-     * The distance from the viewpoint where linear fog reaches its maximum. This property is only
-     * valid if the fog property is set to {@link FOG_LINEAR}. Defaults to 1000.
-     *
-     * @type {number}
-     */
-    fogEnd = 1000;
-
-    /**
-     * The distance from the viewpoint where linear fog begins. This property is only valid if the
-     * fog property is set to {@link FOG_LINEAR}. Defaults to 1.
-     *
-     * @type {number}
-     */
-    fogStart = 1;
-
-    /**
      * The lightmap resolution multiplier. Defaults to 1.
      *
      * @type {number}
@@ -701,10 +670,10 @@ class Scene extends EventHandler {
         this.ambientLight.set(render.global_ambient[0], render.global_ambient[1], render.global_ambient[2]);
         this.ambientLuminance = render.ambientLuminance;
         this._renderingParams.fog = render.fog;
-        this.fogColor.set(render.fog_color[0], render.fog_color[1], render.fog_color[2]);
-        this.fogStart = render.fog_start;
-        this.fogEnd = render.fog_end;
-        this.fogDensity = render.fog_density;
+        this._renderingParams.fogColor.set(render.fog_color[0], render.fog_color[1], render.fog_color[2]);
+        this._renderingParams.fogStart = render.fog_start;
+        this._renderingParams.fogEnd = render.fog_end;
+        this._renderingParams.fogDensity = render.fog_density;
         this._renderingParams.gammaCorrection = render.gamma_correction;
         this._renderingParams.toneMapping = render.tonemapping;
         this.lightmapSizeMultiplier = render.lightmapSizeMultiplier;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -7,7 +7,7 @@ import { math } from '../core/math/math.js';
 import { Mat3 } from '../core/math/mat3.js';
 import { Mat4 } from '../core/math/mat4.js';
 import { PIXELFORMAT_RGBA8, ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR } from '../platform/graphics/constants.js';
-import { BAKE_COLORDIR, FOG_NONE, LAYERID_IMMEDIATE } from './constants.js';
+import { BAKE_COLORDIR, LAYERID_IMMEDIATE } from './constants.js';
 import { LightingParams } from './lighting/lighting-params.js';
 import { Sky } from './skybox/sky.js';
 import { Immediate } from './immediate/immediate.js';


### PR DESCRIPTION
- before, a fog parameters were a scene settings that all cameras were using
- these have now been moved to scene.rendering which can be overwritten on a camera, allowing per camera control
- this is a non-breaking change as existing Scene.fog settings is only deprecated

Old API
```
Scene.fog
Scece.fogColor
Scene.fogStart
Scene.fogEnd
Scene.fogDensity
```

New API
```
Scene.rendering.fog
Scece.rendering.fogColor
Scene.rendering.fogStart
Scene.rendering.fogEnd
Scene.rendering.fogDensity
```