### PR TITLE
Propsal to update deprecated and removed functionality

### DIFF
--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -26,6 +26,18 @@ class Debug {
     }
 
     /**
+     * Removed warning message.
+     *
+     * @param {string} message - The message to log.
+     */
+    static removed(message) {
+        if (!Debug._loggedMessages.has(message)) {
+            Debug._loggedMessages.add(message);
+            console.warn(`REMOVED: ${message}`);
+        }
+    }
+
+    /**
      * Assertion deprecated message. If the assertion is false, the deprecated message is written to the log.
      *
      * @param {boolean|object} assertion - The assertion to check.

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -35,7 +35,6 @@ import { Morph } from '../scene/morph.js';
 import { MeshInstance } from '../scene/mesh-instance.js';
 import { Scene } from '../scene/scene.js';
 import { StandardMaterial } from '../scene/materials/standard-material.js';
-import { Batch } from '../scene/batching/batch.js';
 import { getDefaultMaterial } from '../scene/materials/default-material.js';
 import { StandardMaterialOptions } from '../scene/materials/standard-material-options.js';
 import { LitShaderOptions } from '../scene/shader-lib/programs/lit-shader-options.js';
@@ -537,13 +536,6 @@ _removedLayerProperty('onPostRenderOpaque');
 _removedLayerProperty('onPostRenderTransparent');
 _removedLayerProperty('onDrawCall');
 _removedLayerProperty('layerReference');
-
-Object.defineProperty(Batch.prototype, 'model', {
-    get: function () {
-        Debug.deprecated('pc.Batch#model is deprecated. Use pc.Batch#meshInstance to access batched mesh instead.');
-        return null;
-    }
-});
 
 ForwardRenderer.prototype.renderComposition = function (comp) {
     Debug.deprecated('pc.ForwardRenderer#renderComposition is deprecated. Use pc.AppBase.renderComposition instead.');

--- a/src/scene/batching/batch.js
+++ b/src/scene/batching/batch.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 
 /**
@@ -91,6 +92,16 @@ class Batch {
         }
         this.meshInstance.aabb = this._aabb;
         this.meshInstance._aabbVer = 0;
+    }
+
+    /**
+     * @deprecated
+     * @private
+     * @returns {undefined}
+     */
+    get model() {
+        Debug.removed('pc.Batch#model was removed. Use pc.Batch#meshInstance to access batched mesh instead.');
+        return undefined;
     }
 }
 

--- a/src/scene/batching/batch.js
+++ b/src/scene/batching/batch.js
@@ -96,8 +96,8 @@ class Batch {
 
     /**
      * @deprecated
-     * @private
-     * @returns {undefined}
+     * @ignore
+     * @type {undefined}
      */
     get model() {
         Debug.removed('pc.Batch#model was removed. Use pc.Batch#meshInstance to access batched mesh instead.');

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -49,6 +49,7 @@ const STRIP_FUNCTIONS = [
     'Debug.errorOnce',
     'Debug.log',
     'Debug.logOnce',
+    'Debug.removed',
     'Debug.trace',
     'DebugHelper.setName',
     'DebugHelper.setLabel',


### PR DESCRIPTION
This is a proposed change, and if this gets approved, this change will be applied to most of deprecated.js.

- add `Debug.removed` for functionality that has been completely removed, vs just deprecated (which still works as before)
- move getters / setters and other bits from deprecated.js to the appropriate module:
    - as Object.defineProperty was used in the deprecated.js, this was a module with side-effects and its imports cannot be part of tree-shaking, making tree-shaking less efficient (according to @marklundin )
    - the syntax of setter and getter in a class is nicer than Object.defineProperty syntax