### PR TITLE
Improved error message when basis wasm is not loaded

### DIFF
--- a/examples/src/examples/loaders/gltf-export.example.mjs
+++ b/examples/src/examples/loaders/gltf-export.example.mjs
@@ -102,7 +102,8 @@ assetListLoader.load(() => {
 
     // a render component with a sphere and cone primitives
     const material = new pc.StandardMaterial();
-    material.diffuse = pc.Color.RED;
+    material.diffuse = pc.Color.YELLOW;
+    material.diffuseMap = assets.color.resource;
     material.update();
 
     const entity = new pc.Entity('TwoMeshInstances');

--- a/src/framework/parsers/texture/basis.js
+++ b/src/framework/parsers/texture/basis.js
@@ -29,7 +29,7 @@ class BasisParser extends TextureParser {
             );
 
             if (!basisModuleFound) {
-                callback(`Basis module not found. Asset '${asset.name}' basis texture variant will not be loaded.`);
+                callback(`Basis module not found. Asset [${asset.name}](${asset.getFileUrl()}) basis texture variant will not be loaded.`);
             }
         };
 

--- a/src/framework/parsers/texture/ktx2.js
+++ b/src/framework/parsers/texture/ktx2.js
@@ -128,7 +128,7 @@ class Ktx2Parser extends TextureParser {
             );
 
             if (!basisModuleFound) {
-                callback(`Basis module not found. Asset "${asset.name}" basis texture variant will not be loaded.`);
+                callback(`Basis module not found. Asset [${asset.name}](${asset.getFileUrl()}) basis texture variant will not be loaded.`);
             }
         } else {
             // TODO: load non-supercompressed formats


### PR DESCRIPTION
- log out url as well, not only the asset name
- also using basis textures in usdz export example (this was lost when a BasicMaterial was removed) to test basis texture export to gltf/ysdz