### PR TITLE
[Examples/Vehicle] Fix Ammo null function error on restart

### DIFF
--- a/examples/src/examples/physics/vehicle.example.mjs
+++ b/examples/src/examples/physics/vehicle.example.mjs
@@ -89,17 +89,12 @@ assetListLoader.load(() => {
     app.root.addChild(ground);
 
     // Create 4 wheels for our vehicle
-    /**
-     * @todo use .map ...
-     * @type {pc.Entity[]}
-     */
-    const wheels = [];
-    [
+    const wheels = [
         { name: 'Front Left Wheel', pos: new pc.Vec3(0.8, 0.4, 1.2), front: true },
         { name: 'Front Right Wheel', pos: new pc.Vec3(-0.8, 0.4, 1.2), front: true },
         { name: 'Back Left Wheel', pos: new pc.Vec3(0.8, 0.4, -1.2), front: false },
         { name: 'Back Right Wheel', pos: new pc.Vec3(-0.8, 0.4, -1.2), front: false }
-    ].forEach(function (wheelDef) {
+    ].map(function (wheelDef) {
         // Create a wheel
         const wheel = new pc.Entity(wheelDef.name);
         wheel.addComponent('script');
@@ -110,7 +105,7 @@ assetListLoader.load(() => {
             }
         });
         wheel.setLocalPosition(wheelDef.pos);
-        wheels.push(wheel);
+        return wheel;
     });
 
     // Create a physical vehicle

--- a/examples/src/examples/physics/vehicle.example.mjs
+++ b/examples/src/examples/physics/vehicle.example.mjs
@@ -94,7 +94,7 @@ assetListLoader.load(() => {
         { name: 'Front Right Wheel', pos: new pc.Vec3(-0.8, 0.4, 1.2), front: true },
         { name: 'Back Left Wheel', pos: new pc.Vec3(0.8, 0.4, -1.2), front: false },
         { name: 'Back Right Wheel', pos: new pc.Vec3(-0.8, 0.4, -1.2), front: false }
-    ].map(function (wheelDef) {
+    ].map((wheelDef) => {
         // Create a wheel
         const wheel = new pc.Entity(wheelDef.name);
         wheel.addComponent('script');

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -910,7 +910,6 @@ class CollisionComponentSystem extends ComponentSystem {
 
         transform.setRotation(ammoQuat);
         Ammo.destroy(ammoQuat);
-        Ammo.destroy(origin);
 
         return transform;
     }

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -186,6 +186,18 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    /** @ignore */
+    static onAppDestroy() {
+        Ammo.destroy(_ammoTransform);
+        Ammo.destroy(_ammoVec1);
+        Ammo.destroy(_ammoVec2);
+        Ammo.destroy(_ammoQuat);
+        _ammoTransform = null;
+        _ammoVec1 = null;
+        _ammoVec2 = null;
+        _ammoQuat = null;
+    }
+
     /**
      * Sets the rate at which a body loses angular velocity over time.
      *

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -1045,11 +1045,16 @@ class RigidBodyComponentSystem extends ComponentSystem {
             Ammo.destroy(this.overlappingPairCache);
             Ammo.destroy(this.dispatcher);
             Ammo.destroy(this.collisionConfiguration);
+            Ammo.destroy(ammoRayStart);
+            Ammo.destroy(ammoRayEnd);
             this.dynamicsWorld = null;
             this.solver = null;
             this.overlappingPairCache = null;
             this.dispatcher = null;
             this.collisionConfiguration = null;
+            ammoRayStart = null;
+            ammoRayEnd = null;
+            RigidBodyComponent.onAppDestroy();
         }
     }
 }


### PR DESCRIPTION
Fixes #6724 

These are just my current findings, the engine still seems to leak rigidbody Ammo objects/pointers... but at least this makes an Example refresh work in the first place. This allows for further fixes without just crashing like it currently does here: https://playcanvas.vercel.app/#/physics/vehicle

About https://github.com/playcanvas/engine/commit/7b0c745cbe480e8dde1d4e82e62fc278562cc30c / Removing `Ammo.destroy(origin);`:

The origin is part of `btTransform`:

https://github.com/kripken/ammo.js/blob/1ed8b58c7058a5f697f2642ceef8ee20fdd55e10/bullet/src/LinearMath/btTransform.h#L32-L41

You don't just get that pointer and call `free` on it - at least it doesn't make sense to me. Probably at best nothing happens and worst case is messing up internal allocation structures while causing other subtle bugs. Any other opinions on this?

Feedback about all this highly welcome and some testing.

I can't even logically explain why the `null function error` occurs, since why should it matter if we reuse some old allocated pointers or free them and recreate those anew - it feels like a black box. :see_no_evil:

Vercel quick link: https://engine-r0b3y912i-playcanvas.vercel.app/#/physics/vehicle

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
