### PR TITLE
Fix initialization of __attributes in ScriptType class

### DIFF
--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -10,7 +10,7 @@ import { Script } from './script.js';
  */
 class ScriptType extends Script {
     /** @private */
-    __attributes;
+    __attributes = {};
 
     /** @private */
     __attributesRaw;


### PR DESCRIPTION
Ensure's `__attributes` is initialized when using `registerScript`.

Fixes #6880 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
