### PR TITLE
Option to apply SSAO during lighting instead of during postprocessing

### DIFF
--- a/examples/src/examples/graphics/ambient-occlusion.controls.mjs
+++ b/examples/src/examples/graphics/ambient-occlusion.controls.mjs
@@ -10,11 +10,16 @@ export function controls({ observer, ReactPCUI, React, jsx, fragment }) {
             { headerText: 'Ambient Occlusion' },
             jsx(
                 LabelGroup,
-                { text: 'enabled' },
-                jsx(BooleanInput, {
-                    type: 'toggle',
+                { text: 'Type' },
+                jsx(SelectInput, {
                     binding: new BindingTwoWay(),
-                    link: { observer, path: 'data.ssao.enabled' }
+                    link: { observer, path: 'data.ssao.type' },
+                    type: 'string',
+                    options: [
+                        { v: pc.SSAOTYPE_NONE, t: 'None' },
+                        { v: pc.SSAOTYPE_LIGHTING, t: 'Lighting' },
+                        { v: pc.SSAOTYPE_COMBINE, t: 'Combine' }
+                    ]
                 })
             ),
             jsx(

--- a/examples/src/examples/graphics/ambient-occlusion.controls.mjs
+++ b/examples/src/examples/graphics/ambient-occlusion.controls.mjs
@@ -1,3 +1,5 @@
+import * as pc from 'playcanvas';
+
 /**
  * @param {import('../../app/components/Example.mjs').ControlOptions} options - The options.
  * @returns {JSX.Element} The returned JSX Element.

--- a/examples/src/examples/graphics/ambient-occlusion.example.mjs
+++ b/examples/src/examples/graphics/ambient-occlusion.example.mjs
@@ -179,7 +179,7 @@ assetListLoader.load(() => {
         // enable temporal anti-aliasing
         taaEnabled: false,
 
-        ssaoEnabled: true,
+        ssaoType: pc.SSAOTYPE_LIGHTING,
         ssaoBlurEnabled: true
     };
 
@@ -193,7 +193,7 @@ assetListLoader.load(() => {
         // Internally this sets up additional passes it needs, based on the options passed to it.
         const renderPassCamera = new pc.RenderPassCameraFrame(app, currentOptions);
 
-        renderPassCamera.ssaoEnabled = currentOptions.ssaoEnabled;
+        renderPassCamera.ssaoType = currentOptions.ssaoType;
 
         const composePass = renderPassCamera.composePass;
         composePass.sharpness = 0;
@@ -206,12 +206,14 @@ assetListLoader.load(() => {
     };
 
     const applySettings = () => {
+
+        const ssaoType = data.get('data.ssao.type');
+
         // if settings require render passes to be re-created
         const noPasses = cameraEntity.camera.renderPasses.length === 0;
-        const ssaoEnabled = data.get('data.ssao.enabled');
         const blurEnabled = data.get('data.ssao.blurEnabled');
-        if (noPasses || ssaoEnabled !== currentOptions.ssaoEnabled || blurEnabled !== currentOptions.ssaoBlurEnabled) {
-            currentOptions.ssaoEnabled = ssaoEnabled;
+        if (noPasses || ssaoType !== currentOptions.ssaoType || blurEnabled !== currentOptions.ssaoBlurEnabled) {
+            currentOptions.ssaoType = ssaoType;
             currentOptions.ssaoBlurEnabled = blurEnabled;
 
             // create new pass
@@ -254,7 +256,7 @@ assetListLoader.load(() => {
     // initial settings
     data.set('data', {
         ssao: {
-            enabled: true,
+            type: pc.SSAOTYPE_LIGHTING,
             blurEnabled: true,
             radius: 30,
             samples: 12,

--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -14,6 +14,7 @@ export { UsdzExporter } from './exporters/usdz-exporter.js';
 export { GltfExporter } from './exporters/gltf-exporter.js';
 
 // RENDER PASSES
+export { SSAOTYPE_NONE, SSAOTYPE_LIGHTING, SSAOTYPE_COMBINE } from './render-passes/render-pass-camera-frame.js';
 export { RenderPassCameraFrame } from './render-passes/render-pass-camera-frame.js';
 export { RenderPassCompose } from './render-passes/render-pass-compose.js';
 export { RenderPassDepthAwareBlur } from './render-passes/render-pass-depth-aware-blur.js';

--- a/src/extras/render-passes/render-pass-ssao.js
+++ b/src/extras/render-passes/render-pass-ssao.js
@@ -279,6 +279,7 @@ class RenderPassSsao extends RenderPassShaderQuad {
         }
 
         this.ssaoTextureId = device.scope.resolve('ssaoTexture');
+        this.ssaoTextureSizeInvId = device.scope.resolve('ssaoTextureSizeInv');
     }
 
     destroy() {
@@ -367,6 +368,9 @@ class RenderPassSsao extends RenderPassShaderQuad {
 
     after() {
         this.ssaoTextureId.setValue(this.ssaoTexture);
+
+        const srcTexture = this.sourceTexture;
+        this.ssaoTextureSizeInvId.setValue([1.0 / srcTexture.width, 1.0 / srcTexture.height]);
     }
 }
 

--- a/src/extras/render-passes/render-pass-ssao.js
+++ b/src/extras/render-passes/render-pass-ssao.js
@@ -277,6 +277,8 @@ class RenderPassSsao extends RenderPassShaderQuad {
             this.afterPasses.push(blurPassHorizontal);
             this.afterPasses.push(blurPassVertical);
         }
+
+        this.ssaoTextureId = device.scope.resolve('ssaoTexture');
     }
 
     destroy() {
@@ -361,6 +363,10 @@ class RenderPassSsao extends RenderPassShaderQuad {
         scope.resolve('uProjectionScaleRadius').setValue(projectionScale * radius);
 
         super.execute();
+    }
+
+    after() {
+        this.ssaoTextureId.setValue(this.ssaoTexture);
     }
 }
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -115,8 +115,9 @@ class StandardMaterialOptionsBuilder {
         }
         this._mapXForms = null;
 
-        // true if ssao is applied directly in the forward shaders
-        options.ssao = renderParams?.ssaoEnabled;
+        // true if ssao is applied directly in the lit shaders. Also ensure the AO part is generated in the front end
+        options.litOptions.ssao = renderParams?.ssaoEnabled;
+        options.useAO = true;
 
         // All texture related lit options
         options.litOptions.lightMapEnabled = options.lightMap;
@@ -124,7 +125,7 @@ class StandardMaterialOptionsBuilder {
         options.litOptions.useHeights = options.heightMap;
         options.litOptions.useNormals = options.normalMap;
         options.litOptions.useClearCoatNormals = options.clearCoatNormalMap;
-        options.litOptions.useAo = options.aoMap || options.aoVertexColor || options.ssao;
+        options.litOptions.useAo = options.aoMap || options.aoVertexColor || options.litOptions.ssao;
         options.litOptions.diffuseMapEnabled = options.diffuseMap;
     }
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -55,7 +55,7 @@ class StandardMaterialOptionsBuilder {
         this._updateMaterialOptions(options, stdMat);
         options.litOptions.hasTangents = objDefs && ((objDefs & SHADERDEF_TANGENTS) !== 0);
         this._updateLightOptions(options, scene, stdMat, objDefs, sortedLights);
-        this._updateUVOptions(options, stdMat, objDefs, false);
+        this._updateUVOptions(options, stdMat, objDefs, false, renderParams);
     }
 
     _updateSharedOptions(options, scene, stdMat, objDefs, pass) {
@@ -96,7 +96,7 @@ class StandardMaterialOptionsBuilder {
         }
     }
 
-    _updateUVOptions(options, stdMat, objDefs, minimalOptions) {
+    _updateUVOptions(options, stdMat, objDefs, minimalOptions, renderParams) {
         let hasUv0 = false;
         let hasUv1 = false;
         let hasVcolor = false;
@@ -115,13 +115,16 @@ class StandardMaterialOptionsBuilder {
         }
         this._mapXForms = null;
 
+        // true if ssao is applied directly in the forward shaders
+        options.ssao = renderParams?.ssaoEnabled;
+
         // All texture related lit options
         options.litOptions.lightMapEnabled = options.lightMap;
         options.litOptions.dirLightMapEnabled = options.dirLightMap;
         options.litOptions.useHeights = options.heightMap;
         options.litOptions.useNormals = options.normalMap;
         options.litOptions.useClearCoatNormals = options.clearCoatNormalMap;
-        options.litOptions.useAo = options.aoMap || options.aoVertexColor;
+        options.litOptions.useAo = options.aoMap || options.aoVertexColor || options.ssao;
         options.litOptions.diffuseMapEnabled = options.diffuseMap;
     }
 

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -76,6 +76,13 @@ class StandardMaterialOptions {
     clearCoatGlossInvert = false;
 
     /**
+     * Apply SSAO during the lighting.
+     *
+     * @type {boolean}
+     */
+    ssao = false;
+
+    /**
      * Storage for the options for lit the shader and material.
      *
      * @type {LitShaderOptions}

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -76,11 +76,11 @@ class StandardMaterialOptions {
     clearCoatGlossInvert = false;
 
     /**
-     * Apply SSAO during the lighting.
+     * True to include AO variables even if AO is not used, which allows SSAO to be used in the lit shader.
      *
      * @type {boolean}
      */
-    ssao = false;
+    useAO = false;
 
     /**
      * Storage for the options for lit the shader and material.

--- a/src/scene/renderer/rendering-params.js
+++ b/src/scene/renderer/rendering-params.js
@@ -18,6 +18,9 @@ class RenderingParams {
     _srgbRenderTarget = false;
 
     /** @private */
+    _ssaoEnabled = true;
+
+    /** @private */
     _fog = FOG_NONE;
 
     /**
@@ -67,7 +70,7 @@ class RenderingParams {
      */
     get hash() {
         if (this._hash === undefined) {
-            const key = `${this.gammaCorrection}_${this.toneMapping}_${this.srgbRenderTarget}_${this.fog}`;
+            const key = `${this.gammaCorrection}_${this.toneMapping}_${this.srgbRenderTarget}_${this.fog}_${this.ssaoEnabled}`;
             this._hash = hashCode(key);
         }
         return this._hash;
@@ -103,6 +106,17 @@ class RenderingParams {
      */
     get fog() {
         return this._fog;
+    }
+
+    set ssaoEnabled(value) {
+        if (this._ssaoEnabled !== value) {
+            this._ssaoEnabled = value;
+            this.markDirty();
+        }
+    }
+
+    get ssaoEnabled() {
+        return this._ssaoEnabled;
     }
 
     /**

--- a/src/scene/shader-lib/chunks/standard/frag/ao.js
+++ b/src/scene/shader-lib/chunks/standard/frag/ao.js
@@ -1,27 +1,31 @@
 export default /* glsl */`
-uniform float material_aoIntensity;
 
-#ifdef MAPSSAO
-    uniform sampler2D ssaoTexture;
+#ifdef MAPTEXTURE
+    #define AO_INTENSITY
+#endif
+
+#ifdef MAPVERTEX
+    #define AO_INTENSITY
+#endif
+
+#ifdef AO_INTENSITY
+    uniform float material_aoIntensity;
 #endif
 
 void getAO() {
     dAo = 1.0;
 
-    #ifdef MAPSSAO
-    vec2 ssaoTextureSize = vec2(textureSize(ssaoTexture, 0));
-    dAo *= texture2DLodEXT(ssaoTexture, gl_FragCoord.xy / ssaoTextureSize, 0.0).r;
-    #endif
-
     #ifdef MAPTEXTURE
-    float aoBase = texture2DBias($SAMPLER, $UV, textureBias).$CH;
-    dAo *= addAoDetail(aoBase);
+        float aoBase = texture2DBias($SAMPLER, $UV, textureBias).$CH;
+        dAo *= addAoDetail(aoBase);
     #endif
 
     #ifdef MAPVERTEX
-    dAo *= saturate(vVertexColor.$VC);
+        dAo *= saturate(vVertexColor.$VC);
     #endif
 
-    dAo = mix(1.0, dAo, material_aoIntensity);
+    #ifdef AO_INTENSITY
+        dAo = mix(1.0, dAo, material_aoIntensity);
+    #endif
 }
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/ao.js
+++ b/src/scene/shader-lib/chunks/standard/frag/ao.js
@@ -1,8 +1,17 @@
 export default /* glsl */`
 uniform float material_aoIntensity;
 
+#ifdef MAPSSAO
+    uniform sampler2D ssaoTexture;
+#endif
+
 void getAO() {
     dAo = 1.0;
+
+    #ifdef MAPSSAO
+    vec2 ssaoTextureSize = vec2(textureSize(ssaoTexture, 0));
+    dAo *= texture2DLodEXT(ssaoTexture, gl_FragCoord.xy / ssaoTextureSize, 0.0).r;
+    #endif
 
     #ifdef MAPTEXTURE
     float aoBase = texture2DBias($SAMPLER, $UV, textureBias).$CH;

--- a/src/scene/shader-lib/programs/lit-shader-options.js
+++ b/src/scene/shader-lib/programs/lit-shader-options.js
@@ -111,6 +111,13 @@ class LitShaderOptions {
     ambientSH = false;
 
     /**
+     * Apply SSAO during the lighting.
+     *
+     * @type {boolean}
+     */
+    ssao = false;
+
+    /**
      * The value of {@link StandardMaterial#twoSidedLighting}.
      *
      * @type {boolean}

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -934,6 +934,15 @@ class LitShader {
         // invoke frontend functions
         code.append(this.frontendFunc);
 
+        // apply SSAO
+        if (options.ssao) {
+            func.append(`
+                    uniform sampler2D ssaoTexture;
+                    uniform vec2 ssaoTextureSizeInv;
+                `);
+            backend.append('litArgs_ao *= texture2DLodEXT(ssaoTexture, gl_FragCoord.xy * ssaoTextureSizeInv, 0.0).r;');
+        }
+
         // transform tangent space normals to world space
         if (this.needsNormal) {
             if (options.useSpecular) {

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -436,8 +436,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
             if (options.aoDetail) {
                 code.append(this._addMap('aoDetail', 'aoDetailMapPS', options, litShader.chunks, textureMapping));
             }
-            if (options.aoMap || options.aoVertexColor || options.ssao) {
-                if (options.ssao) code.append('#define MAPSSAO');
+            if (options.aoMap || options.aoVertexColor || options.useAO) {
                 decl.append('float dAo;');
                 code.append(this._addMap('ao', 'aoPS', options, litShader.chunks, textureMapping));
                 func.append('getAO();');

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -436,7 +436,8 @@ class ShaderGeneratorStandard extends ShaderGenerator {
             if (options.aoDetail) {
                 code.append(this._addMap('aoDetail', 'aoDetailMapPS', options, litShader.chunks, textureMapping));
             }
-            if (options.aoMap || options.aoVertexColor) {
+            if (options.aoMap || options.aoVertexColor || options.ssao) {
+                if (options.ssao) code.append('#define MAPSSAO');
                 decl.append('float dAo;');
                 code.append(this._addMap('ao', 'aoPS', options, litShader.chunks, textureMapping));
                 func.append('getAO();');


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/4844
Try it here: https://engine-hx2mdhbb7-playcanvas.vercel.app/#/graphics/ambient-occlusion

Until now, the SSAO was applied as a post-processing effect. The problem is that the ambient occlusion then incorrectly darkens even the areas hit by lights.

For the render pass architecture, an option to apply AO during lighting in forward passes has been added.

Before - notice how uniformly the SSAO looks
<img width="1154" alt="Screenshot 2024-09-03 at 15 23 34" src="https://github.com/user-attachments/assets/485299aa-e648-4ac2-a728-8b2df4105101">

Now - almost no AO is visible in the lit areas, but ambient areas receive AO as before
<img width="1155" alt="Screenshot 2024-09-03 at 15 23 48" src="https://github.com/user-attachments/assets/f92d316a-d0d9-4462-a6dd-66402cd16ab6">

Detail before
<img width="762" alt="Screenshot 2024-09-03 at 15 32 37" src="https://github.com/user-attachments/assets/c459e775-9216-41e9-b6a5-7f9021e5f17b">

and now
<img width="780" alt="Screenshot 2024-09-03 at 15 32 53" src="https://github.com/user-attachments/assets/6f371d29-6f46-4c41-9dc3-71d3352b3486">

Detail before
<img width="1005" alt="Screenshot 2024-09-03 at 15 34 53" src="https://github.com/user-attachments/assets/9669f3d3-a1b8-49d7-b532-b825f775abf0">

and now
<img width="999" alt="Screenshot 2024-09-03 at 15 35 04" src="https://github.com/user-attachments/assets/78bf6d26-ddc0-4551-9c8f-f4d051924448">
