### PR TITLE
Ensure ScriptType members are initialized correctly

### DIFF
--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -9,11 +9,26 @@ import { Script } from './script.js';
  * @category Script
  */
 class ScriptType extends Script {
+
     /** @private */
-    __attributes = {};
+    __attributes;
 
     /** @private */
     __attributesRaw;
+
+    /**
+     * Create a new ScriptType instance.
+     *
+     * @param {object} args - The input arguments object.
+     * @param {import('../app-base.js').AppBase} args.app - The {@link AppBase} that is running the
+     * script.
+     * @param {import('../entity.js').Entity} args.entity - The {@link Entity} that the script is
+     * attached to.
+     */
+    constructor(args) {
+        super(args);
+        this.initScriptType(args);
+    }
 
     /**
      * The interface to define attributes for Script Types. Refer to {@link ScriptAttributes}.

--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -10,7 +10,7 @@ import { Script } from './script.js';
  */
 class ScriptType extends Script {
     /** @private */
-    __attributes;
+    __attributes = {};
 
     /** @private */
     __attributesRaw;


### PR DESCRIPTION
This ensures the members are set correctly in the ScriptType constructor. As per https://github.com/playcanvas/engine/pull/6906#issuecomment-2326657879, the transpiled versions initializes and override the `__attributes`class members. Fixes #6880

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
