### PR TITLE
Automatically store depth if RT is used with a user supplied depth buffer

### DIFF
--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -255,11 +255,28 @@ class RenderPass {
         // defaults depend on multisampling
         this.samples = Math.max(this.renderTarget ? this.renderTarget.samples : this.device.samples, 1);
 
-        // allocate ops only when render target is used
+        // allocate ops only when render target is used (when this function was called)
+        this.allocateAttachments();
+
+        // allow for post-init setup
+        this.postInit();
+    }
+
+    allocateAttachments() {
+
+        const rt = this.renderTarget;
+
+        // depth
         this.depthStencilOps = new DepthStencilAttachmentOps();
 
-        const numColorOps = renderTarget ? renderTarget._colorBuffers?.length : 1;
+        // if a RT is used (so not a backbuffer) that was created with a user supplied depth buffer,
+        // assume the user wants to use its content, and so store it by default
+        if (rt?.depthBuffer) {
+            this.depthStencilOps.storeDepth = true;
+        }
 
+        // color
+        const numColorOps = rt?._colorBuffers?.length ?? 1;
         this.colorArrayOps.length = 0;
         for (let i = 0; i < numColorOps; i++) {
             const colorOps = new ColorAttachmentOps();
@@ -276,8 +293,6 @@ class RenderPass {
                 colorOps.mipmaps = true;
             }
         }
-
-        this.postInit();
     }
 
     destroy() {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/5823

When a RenderTarget is created and its depth buffer is specified by the user (vs auto-created), assume the user actually needs to depth to be stored in it, and do not discard it at the end of the pass.

(WebGPU specific, WebGL always stores)
