### PR TITLE
Fix trigger crash

### DIFF
--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -119,9 +119,13 @@ class Trigger {
         const body = this.body;
         if (!body) return;
 
-        const systems = this.app.systems;
-        systems.rigidbody.addBody(body, BODYGROUP_TRIGGER, BODYMASK_NOT_STATIC ^ BODYGROUP_TRIGGER);
-        systems.rigidbody._triggers.push(this);
+        const system = this.app.systems.rigidbody;
+        const exists = system._triggers.find(trigger => trigger === this);
+
+        if (!exists) {
+            system.addBody(body, BODYGROUP_TRIGGER, BODYMASK_NOT_STATIC ^ BODYGROUP_TRIGGER);
+            system._triggers.push(this);
+        }
 
         // set the body's activation state to active so that it is
         // simulated properly again


### PR DESCRIPTION
Fixes #2572 

Prevents adding a trigger to the dynamics world, if it is already there.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
