### PR TITLE
Back out arrow functions for Mocha tests

### DIFF
--- a/test/core/core.test.mjs
+++ b/test/core/core.test.mjs
@@ -2,11 +2,11 @@ import { extend } from '../../src/core/core.js';
 
 import { expect } from 'chai';
 
-describe('core', () => {
+describe('core', function () {
 
-    describe('#extend', () => {
+    describe('#extend', function () {
 
-        it('combines two objects', () => {
+        it('combines two objects', function () {
             const o1 = {
                 a: 'a',
                 b: 'b'
@@ -24,7 +24,7 @@ describe('core', () => {
             expect(o3.d).to.equal('d');
         });
 
-        it('combines two arrays', () => {
+        it('combines two arrays', function () {
             const a1 = [1, 2, 3];
             const a2 = [4, 5, 6];
 
@@ -35,7 +35,7 @@ describe('core', () => {
             expect(a3[2]).to.equal(a2[2]);
         });
 
-        it('combines and object and an array', () => {
+        it('combines and object and an array', function () {
             const o1 = { a: 'a' };
             const a1 = [1, 2];
 
@@ -45,7 +45,7 @@ describe('core', () => {
             expect(o2[1]).to.equal(2);
         });
 
-        it('deep combines two objects', () => {
+        it('deep combines two objects', function () {
             const o1 = {
                 A: 'A'
             };
@@ -62,7 +62,7 @@ describe('core', () => {
             expect(o3.A).to.equal('A');
         });
 
-        it('deep combines two objects and does not copy references', () => {
+        it('deep combines two objects and does not copy references', function () {
             const o1 = {
                 A: 'A'
             };

--- a/test/core/event-handler.test.mjs
+++ b/test/core/event-handler.test.mjs
@@ -2,37 +2,37 @@ import { EventHandler } from '../../src/core/event-handler.js';
 
 import { expect } from 'chai';
 
-describe('EventHandler', () => {
+describe('EventHandler', function () {
 
-    describe('#hasEvent', () => {
+    describe('#hasEvent', function () {
 
-        it('returns true if the event is registered', () => {
+        it('returns true if the event is registered', function () {
             const e = new EventHandler();
-            e.on('test', () => { });
+            e.on('test', function () { });
             expect(e.hasEvent('test')).to.be.true;
         });
 
-        it('returns false if the event is not registered', () => {
+        it('returns false if the event is not registered', function () {
             const e = new EventHandler();
-            e.on('test', () => { });
+            e.on('test', function () { });
             expect(e.hasEvent('hello')).to.be.false;
         });
 
     });
 
-    describe('#on', () => {
+    describe('#on', function () {
 
-        it('calls handler on fire', () => {
+        it('calls handler on fire', function () {
             const e = new EventHandler();
             let called = false;
-            e.on('test', () => {
+            e.on('test', function () {
                 called = true;
             });
             e.fire('test');
             expect(called).to.be.true;
         });
 
-        it('calls handler with up to 8 arguments on fire', () => {
+        it('calls handler with up to 8 arguments on fire', function () {
             const e = new EventHandler();
             let called = false;
             e.on('test', (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) => {
@@ -53,12 +53,12 @@ describe('EventHandler', () => {
 
     });
 
-    describe('#once', () => {
+    describe('#once', function () {
 
-        it('unregisters itself after the first fire', () => {
+        it('unregisters itself after the first fire', function () {
             const e = new EventHandler();
             let count = 0;
-            e.once('test', () => {
+            e.once('test', function () {
                 count++;
             });
             expect(e.hasEvent('test')).to.be.true;
@@ -70,7 +70,7 @@ describe('EventHandler', () => {
 
     });
 
-    describe('#off', () => {
+    describe('#off', function () {
 
         it('unregisters event handler with specified callback and scope', function () {
             const e = new EventHandler();
@@ -86,7 +86,7 @@ describe('EventHandler', () => {
             expect(called).to.be.false;
         });
 
-        it('unregisters event handler with specified callback', () => {
+        it('unregisters event handler with specified callback', function () {
             const e = new EventHandler();
             let called = false;
             const callback = function () {
@@ -100,10 +100,10 @@ describe('EventHandler', () => {
             expect(called).to.be.false;
         });
 
-        it('unregisters all event handlers', () => {
+        it('unregisters all event handlers', function () {
             const e = new EventHandler();
             let called = false;
-            e.on('test', () => {
+            e.on('test', function () {
                 called = true;
             });
             expect(e.hasEvent('test')).to.be.true;

--- a/test/core/guid.test.mjs
+++ b/test/core/guid.test.mjs
@@ -2,19 +2,19 @@ import { guid } from '../../src/core/guid.js';
 
 import { expect } from 'chai';
 
-describe('guid', () => {
+describe('guid', function () {
 
-    describe('#create', () => {
+    describe('#create', function () {
 
-        it('returns a string', () => {
+        it('returns a string', function () {
             expect(guid.create()).to.be.a('string');
         });
 
-        it('returns a string of length 36', () => {
+        it('returns a string of length 36', function () {
             expect(guid.create()).to.have.length(36);
         });
 
-        it('returns different values each time', () => {
+        it('returns different values each time', function () {
             expect(guid.create()).to.not.equal(guid.create());
         });
 

--- a/test/core/hash.test.mjs
+++ b/test/core/hash.test.mjs
@@ -2,29 +2,29 @@ import { hashCode, hash32Fnv1a } from '../../src/core/hash.js';
 
 import { expect } from 'chai';
 
-describe('hashCode', () => {
+describe('hashCode', function () {
 
-    it('returns 0 for the empty string', () => {
+    it('returns 0 for the empty string', function () {
         expect(hashCode('')).to.equal(0);
     });
 
-    it('returns the same hash for the same string', () => {
+    it('returns the same hash for the same string', function () {
         expect(hashCode('abc')).to.equal(hashCode('abc'));
     });
 
-    it('returns different hashes for different strings', () => {
+    it('returns different hashes for different strings', function () {
         expect(hashCode('abc')).to.not.equal(hashCode('def'));
     });
 
 });
 
-describe('[1, 2, 3]', () => {
+describe('[1, 2, 3]', function () {
 
-    it('returns the same hash for the same arrays', () => {
+    it('returns the same hash for the same arrays', function () {
         expect(hash32Fnv1a([1, 2, 3])).to.equal(hash32Fnv1a([1, 2, 3]));
     });
 
-    it('returns different hashes for different arrays', () => {
+    it('returns different hashes for different arrays', function () {
         expect(hash32Fnv1a([1, 2, 3])).to.not.equal(hash32Fnv1a([3, 2, 1]));
     });
 

--- a/test/core/indexed-list.test.mjs
+++ b/test/core/indexed-list.test.mjs
@@ -2,11 +2,11 @@ import { IndexedList } from '../../src/core/indexed-list.js';
 
 import { expect } from 'chai';
 
-describe('IndexedList', () => {
+describe('IndexedList', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('creates an empty list', () => {
+        it('creates an empty list', function () {
             const list = new IndexedList();
 
             expect(list.list().length).to.equal(0);
@@ -14,9 +14,9 @@ describe('IndexedList', () => {
 
     });
 
-    describe('#clear', () => {
+    describe('#clear', function () {
 
-        it('removes all values', () => {
+        it('removes all values', function () {
             const list = new IndexedList();
 
             const key1 = 'key1';
@@ -58,9 +58,9 @@ describe('IndexedList', () => {
 
     });
 
-    describe('#has', () => {
+    describe('#has', function () {
 
-        it('returns true if the key exists', () => {
+        it('returns true if the key exists', function () {
             const list = new IndexedList();
 
             const key1 = 'key1';
@@ -88,7 +88,7 @@ describe('IndexedList', () => {
             expect(list.has(key5)).to.equal(true);
         });
 
-        it('returns false if the key does not exist', () => {
+        it('returns false if the key does not exist', function () {
             const list = new IndexedList();
 
             const key1 = 'key1';
@@ -118,9 +118,9 @@ describe('IndexedList', () => {
 
     });
 
-    describe('#push', () => {
+    describe('#push', function () {
 
-        it('adds an key-value pair to the list', () => {
+        it('adds an key-value pair to the list', function () {
             const list = new IndexedList();
 
             const key = 'key';
@@ -136,9 +136,9 @@ describe('IndexedList', () => {
 
     });
 
-    describe('#get', () => {
+    describe('#get', function () {
 
-        it('returns the value for the key', () => {
+        it('returns the value for the key', function () {
             const list = new IndexedList();
 
             const key = 'key';
@@ -149,7 +149,7 @@ describe('IndexedList', () => {
             expect(list.get(key)).to.equal(value);
         });
 
-        it('returns null if the key does not exist', () => {
+        it('returns null if the key does not exist', function () {
             const list = new IndexedList();
 
             const key = 'key';
@@ -163,9 +163,9 @@ describe('IndexedList', () => {
 
     });
 
-    describe('#list', () => {
+    describe('#list', function () {
 
-        it('returns list in order', () => {
+        it('returns list in order', function () {
             const list = new IndexedList();
 
             const key1 = 'key1';
@@ -197,9 +197,9 @@ describe('IndexedList', () => {
 
     });
 
-    describe('#remove', () => {
+    describe('#remove', function () {
 
-        it('removes the key', () => {
+        it('removes the key', function () {
             const list = new IndexedList();
 
             const key = 'key';
@@ -213,7 +213,7 @@ describe('IndexedList', () => {
         });
 
 
-        it('does not affect surrounding keys', () => {
+        it('does not affect surrounding keys', function () {
             const list = new IndexedList();
 
             const key1 = 'key1';

--- a/test/core/math/bit-packing.test.mjs
+++ b/test/core/math/bit-packing.test.mjs
@@ -2,11 +2,11 @@ import { BitPacking } from '../../../src/core/math/bit-packing.js';
 
 import { expect } from 'chai';
 
-describe('BitPacking', () => {
+describe('BitPacking', function () {
 
-    describe('#set', () => {
+    describe('#set', function () {
 
-        it('sets bits', () => {
+        it('sets bits', function () {
 
             let d = 0;
             d = BitPacking.set(d, 0b11, 1, 0b11);
@@ -18,8 +18,8 @@ describe('BitPacking', () => {
         });
     });
 
-    describe('#get', () => {
-        it('gets bits', () => {
+    describe('#get', function () {
+        it('gets bits', function () {
 
             const d = 0b110011;
             expect(BitPacking.get(d, 0, 0b111111)).to.equal(d);
@@ -29,8 +29,8 @@ describe('BitPacking', () => {
         });
     });
 
-    describe('#any', () => {
-        it('any', () => {
+    describe('#any', function () {
+        it('any', function () {
 
             const d = 0b110011;
             expect(BitPacking.any(d, 0, 0b111111)).to.equal(true);
@@ -39,8 +39,8 @@ describe('BitPacking', () => {
         });
     });
 
-    describe('#all', () => {
-        it('all', () => {
+    describe('#all', function () {
+        it('all', function () {
 
             const d = 0b110011;
             expect(BitPacking.all(d, 0, 0b111111)).to.equal(false);

--- a/test/core/math/color.test.mjs
+++ b/test/core/math/color.test.mjs
@@ -2,11 +2,11 @@ import { Color } from '../../../src/core/math/color.js';
 
 import { expect } from 'chai';
 
-describe('Color', () => {
+describe('Color', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('supports zero arguments', () => {
+        it('supports zero arguments', function () {
             const c = new Color();
             expect(c.r).to.equal(0);
             expect(c.g).to.equal(0);
@@ -14,7 +14,7 @@ describe('Color', () => {
             expect(c.a).to.equal(1);
         });
 
-        it('supports number arguments', () => {
+        it('supports number arguments', function () {
             const c = new Color(0.1, 0.2, 0.3, 0.4);
             expect(c.r).to.equal(0.1);
             expect(c.g).to.equal(0.2);
@@ -22,7 +22,7 @@ describe('Color', () => {
             expect(c.a).to.equal(0.4);
         });
 
-        it('supports a 3 element array argument', () => {
+        it('supports a 3 element array argument', function () {
             const c = new Color([0.1, 0.2, 0.3]);
             expect(c.r).to.equal(0.1);
             expect(c.g).to.equal(0.2);
@@ -30,7 +30,7 @@ describe('Color', () => {
             expect(c.a).to.equal(1);
         });
 
-        it('supports a 4 element array argument', () => {
+        it('supports a 4 element array argument', function () {
             const c = new Color([0.1, 0.2, 0.3, 0.4]);
             expect(c.r).to.equal(0.1);
             expect(c.g).to.equal(0.2);
@@ -40,9 +40,9 @@ describe('Color', () => {
 
     });
 
-    describe('#clone', () => {
+    describe('#clone', function () {
 
-        it('clones a color', () => {
+        it('clones a color', function () {
             const c1 = new Color(0.1, 0.2, 0.3, 0.4);
             const c2 = c1.clone();
             expect(c2).to.not.equal(c1);
@@ -52,7 +52,7 @@ describe('Color', () => {
             expect(c2.a).to.equal(0.4);
         });
 
-        it('ensures that an instance of a subclass keeps its class prototype', () => {
+        it('ensures that an instance of a subclass keeps its class prototype', function () {
             class UserColor extends Color {}
             const a = new UserColor();
             const b = a.clone();
@@ -61,9 +61,9 @@ describe('Color', () => {
 
     });
 
-    describe('#copy', () => {
+    describe('#copy', function () {
 
-        it('copies a color', () => {
+        it('copies a color', function () {
             const c1 = new Color(0.1, 0.2, 0.3, 0.4);
             const c2 = new Color();
             c2.copy(c1);
@@ -76,15 +76,15 @@ describe('Color', () => {
 
     });
 
-    describe('#equals', () => {
+    describe('#equals', function () {
 
-        it('returns true if colors are equal', () => {
+        it('returns true if colors are equal', function () {
             const c1 = new Color(0.1, 0.2, 0.3, 0.4);
             const c2 = new Color(0.1, 0.2, 0.3, 0.4);
             expect(c1.equals(c2)).to.be.true;
         });
 
-        it('returns false if colors are not equal', () => {
+        it('returns false if colors are not equal', function () {
             const c1 = new Color(0.1, 0.2, 0.3, 0.4);
             const c2 = new Color(0.5, 0.6, 0.7, 0.8);
             expect(c1.equals(c2)).to.be.false;
@@ -92,9 +92,9 @@ describe('Color', () => {
 
     });
 
-    describe('#fromString', () => {
+    describe('#fromString', function () {
 
-        it('parses a lower case hex string', () => {
+        it('parses a lower case hex string', function () {
             const c = new Color();
             c.fromString('#ff00ff');
             expect(c.r).to.equal(1);
@@ -103,7 +103,7 @@ describe('Color', () => {
             expect(c.a).to.equal(1);
         });
 
-        it('parses a lower case hex string with alpha', () => {
+        it('parses a lower case hex string with alpha', function () {
             const c = new Color();
             c.fromString('#ff00ff80');
             expect(c.r).to.equal(1);
@@ -112,7 +112,7 @@ describe('Color', () => {
             expect(c.a).to.closeTo(0.5019607843137255, 0.0001);
         });
 
-        it('parses a upper case hex string with alpha', () => {
+        it('parses a upper case hex string with alpha', function () {
             const c = new Color();
             c.fromString('#FF00FF80');
             expect(c.r).to.equal(1);
@@ -123,9 +123,9 @@ describe('Color', () => {
 
     });
 
-    describe('#lerp', () => {
+    describe('#lerp', function () {
 
-        it('linearly interpolates between two colors with alpha of 0', () => {
+        it('linearly interpolates between two colors with alpha of 0', function () {
             const c1 = new Color(0.1, 0.2, 0.3, 0.4);
             const c2 = new Color(0.5, 0.6, 0.7, 0.8);
             const c3 = new Color();
@@ -136,7 +136,7 @@ describe('Color', () => {
             expect(c3.a).to.equal(0.4);
         });
 
-        it('linearly interpolates between two colors with alpha of 0.5', () => {
+        it('linearly interpolates between two colors with alpha of 0.5', function () {
             const c1 = new Color(0.1, 0.2, 0.3, 0.4);
             const c2 = new Color(0.5, 0.6, 0.7, 0.8);
             const c3 = new Color();
@@ -147,7 +147,7 @@ describe('Color', () => {
             expect(c3.a).to.be.closeTo(0.6, 0.0001);
         });
 
-        it('linearly interpolates between two colors with alpha of 1', () => {
+        it('linearly interpolates between two colors with alpha of 1', function () {
             const c1 = new Color(0.1, 0.2, 0.3, 0.4);
             const c2 = new Color(0.5, 0.6, 0.7, 0.8);
             const c3 = new Color();
@@ -160,9 +160,9 @@ describe('Color', () => {
 
     });
 
-    describe('#set', () => {
+    describe('#set', function () {
 
-        it('sets a color', () => {
+        it('sets a color', function () {
             const c = new Color();
             c.set(0.1, 0.2, 0.3, 0.4);
             expect(c.r).to.equal(0.1);
@@ -173,27 +173,27 @@ describe('Color', () => {
 
     });
 
-    describe('#toString', () => {
+    describe('#toString', function () {
 
-        it('returns a string representation of black (no alpha)', () => {
+        it('returns a string representation of black (no alpha)', function () {
             expect(Color.BLACK.toString()).to.equal('#000000');
         });
 
-        it('returns a string representation of white (no alpha)', () => {
+        it('returns a string representation of white (no alpha)', function () {
             expect(Color.WHITE.toString()).to.equal('#ffffff');
         });
 
-        it('returns a string representation of an arbitrary color (no alpha)', () => {
+        it('returns a string representation of an arbitrary color (no alpha)', function () {
             const c = new Color(0.1, 0.2, 0.3, 0.4);
             expect(c.toString()).to.equal('#1a334d');
         });
 
-        it('returns a string representation of an arbitrary color (with single digit alpha)', () => {
+        it('returns a string representation of an arbitrary color (with single digit alpha)', function () {
             const c = new Color(0.1, 0.2, 0.3, 0.05);
             expect(c.toString(true)).to.equal('#1a334d0d');
         });
 
-        it('returns a string representation of an arbitrary color (with double digit alpha)', () => {
+        it('returns a string representation of an arbitrary color (with double digit alpha)', function () {
             const c = new Color(0.1, 0.2, 0.3, 0.4);
             expect(c.toString(true)).to.equal('#1a334d66');
         });

--- a/test/core/math/curve-set.test.mjs
+++ b/test/core/math/curve-set.test.mjs
@@ -3,25 +3,25 @@ import { CurveSet } from '../../../src/core/math/curve-set.js';
 
 import { expect } from 'chai';
 
-describe('CurveSet', () => {
+describe('CurveSet', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('supports zero arguments', () => {
+        it('supports zero arguments', function () {
             const curveSet = new CurveSet();
 
             expect(curveSet.length).to.equal(1);
             expect(curveSet.type).to.equal(CURVE_SMOOTHSTEP);
         });
 
-        it('supports one number argument', () => {
+        it('supports one number argument', function () {
             const curveSet = new CurveSet(3);
 
             expect(curveSet.length).to.equal(3);
             expect(curveSet.type).to.equal(CURVE_SMOOTHSTEP);
         });
 
-        it('supports one array argument', () => {
+        it('supports one array argument', function () {
             const curveSet = new CurveSet([
                 [
                     0, 0,        // At 0 time, value of 0
@@ -43,15 +43,15 @@ describe('CurveSet', () => {
 
     });
 
-    describe('#type', () => {
+    describe('#type', function () {
 
-        it('is CURVE_SMOOTHSTEP by default', () => {
+        it('is CURVE_SMOOTHSTEP by default', function () {
             const curveSet = new CurveSet();
 
             expect(curveSet.type).to.equal(CURVE_SMOOTHSTEP);
         });
 
-        it('can be set to CURVE_LINEAR', () => {
+        it('can be set to CURVE_LINEAR', function () {
             const curveSet = new CurveSet();
 
             curveSet.type = CURVE_LINEAR;
@@ -59,7 +59,7 @@ describe('CurveSet', () => {
             expect(curveSet.type).to.equal(CURVE_LINEAR);
         });
 
-        it('can be set to CURVE_SMOOTHSTEP', () => {
+        it('can be set to CURVE_SMOOTHSTEP', function () {
             const curveSet = new CurveSet();
 
             curveSet.type = CURVE_SMOOTHSTEP;
@@ -67,7 +67,7 @@ describe('CurveSet', () => {
             expect(curveSet.type).to.equal(CURVE_SMOOTHSTEP);
         });
 
-        it('can be set to CURVE_SPLINE', () => {
+        it('can be set to CURVE_SPLINE', function () {
             const curveSet = new CurveSet();
 
             curveSet.type = CURVE_SPLINE;
@@ -75,7 +75,7 @@ describe('CurveSet', () => {
             expect(curveSet.type).to.equal(CURVE_SPLINE);
         });
 
-        it('can be set to CURVE_STEP', () => {
+        it('can be set to CURVE_STEP', function () {
             const curveSet = new CurveSet();
 
             curveSet.type = CURVE_STEP;
@@ -83,7 +83,7 @@ describe('CurveSet', () => {
             expect(curveSet.type).to.equal(CURVE_STEP);
         });
 
-        it('sets the type property of all curves in the curve set', () => {
+        it('sets the type property of all curves in the curve set', function () {
             const curveSet = new CurveSet([
                 [
                     0, 0,        // At 0 time, value of 0
@@ -130,9 +130,9 @@ describe('CurveSet', () => {
 
     });
 
-    describe('#clone()', () => {
+    describe('#clone()', function () {
 
-        it('clones a simple curve set', () => {
+        it('clones a simple curve set', function () {
             const curveSet = new CurveSet();
             const clone = curveSet.clone();
 
@@ -141,7 +141,7 @@ describe('CurveSet', () => {
             expect(clone.type).to.equal(curveSet.type);
         });
 
-        it('clones a complex curve set', () => {
+        it('clones a complex curve set', function () {
             const curveSet = new CurveSet([
                 [
                     0, 0,        // At 0 time, value of 0
@@ -181,7 +181,7 @@ describe('CurveSet', () => {
             }
         });
 
-        it('ensures that an instance of a subclass keeps its class prototype', () => {
+        it('ensures that an instance of a subclass keeps its class prototype', function () {
             class UserCurveSet extends CurveSet {}
             const a = new UserCurveSet();
             const b = a.clone();
@@ -189,9 +189,9 @@ describe('CurveSet', () => {
         });
     });
 
-    describe('#get()', () => {
+    describe('#get()', function () {
 
-        it('returns the curve at the given index', () => {
+        it('returns the curve at the given index', function () {
             const curveSet = new CurveSet([
                 [
                     0, 0,        // At 0 time, value of 0
@@ -225,9 +225,9 @@ describe('CurveSet', () => {
 
     });
 
-    describe('#value()', () => {
+    describe('#value()', function () {
 
-        it('returns the optional array parameter', () => {
+        it('returns the optional array parameter', function () {
             const curveSet = new CurveSet([
                 [
                     0, 0,
@@ -246,7 +246,7 @@ describe('CurveSet', () => {
             expect(input).to.equal(output);
         });
 
-        it('fills a supplied array with interpolated values based on the specified time (linear)', () => {
+        it('fills a supplied array with interpolated values based on the specified time (linear)', function () {
             const curveSet = new CurveSet([
                 [
                     0, 0,
@@ -279,7 +279,7 @@ describe('CurveSet', () => {
             expect(result).to.deep.equal([0, 1]);
         });
 
-        it('fills a supplied array with interpolated values based on the specified time (smoothstep)', () => {
+        it('fills a supplied array with interpolated values based on the specified time (smoothstep)', function () {
             const curveSet = new CurveSet([
                 [
                     0, 0,
@@ -308,7 +308,7 @@ describe('CurveSet', () => {
             expect(result).to.deep.equal([0.5, 0.5]);
         });
 
-        it('fills a supplied array with interpolated values based on the specified time (spline)', () => {
+        it('fills a supplied array with interpolated values based on the specified time (spline)', function () {
             const curveSet = new CurveSet([
                 [
                     0, 0,
@@ -341,7 +341,7 @@ describe('CurveSet', () => {
             expect(result).to.deep.equal([0, 1]);
         });
 
-        it('fills a supplied array with interpolated values based on the specified time (step)', () => {
+        it('fills a supplied array with interpolated values based on the specified time (step)', function () {
             const curveSet = new CurveSet([
                 [
                     0, 0,

--- a/test/core/math/curve.test.mjs
+++ b/test/core/math/curve.test.mjs
@@ -3,16 +3,16 @@ import { Curve } from '../../../src/core/math/curve.js';
 
 import { expect } from 'chai';
 
-describe('Curve', () => {
+describe('Curve', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('supports zero arguments', () => {
+        it('supports zero arguments', function () {
             const c = new Curve();
             expect(c.keys.length).to.equal(0);
         });
 
-        it('supports array argument already sorted by time', () => {
+        it('supports array argument already sorted by time', function () {
             const c = new Curve([
                 0, 0,        // At 0 time, value of 0
                 0.33, 2,     // At 0.33 time, value of 2
@@ -32,7 +32,7 @@ describe('Curve', () => {
             expect(c.keys[3][1]).to.equal(3);
         });
 
-        it('supports array argument not sorted by time', () => {
+        it('supports array argument not sorted by time', function () {
             const c = new Curve([
                 0, 0,        // At 0 time, value of 0
                 0.33, 2,     // At 0.33 time, value of 2
@@ -54,9 +54,9 @@ describe('Curve', () => {
 
     });
 
-    describe('#add', () => {
+    describe('#add', function () {
 
-        it('adds a new key to an empty curve', () => {
+        it('adds a new key to an empty curve', function () {
             const c = new Curve();
             c.add(0.5, 1);
             expect(c.length).to.equal(1);
@@ -64,7 +64,7 @@ describe('Curve', () => {
             expect(c.keys[0][1]).to.equal(1);
         });
 
-        it('inserts a new key to a curve with existing keys at the correct index', () => {
+        it('inserts a new key to a curve with existing keys at the correct index', function () {
             const c = new Curve([
                 0, 0,        // At 0 time, value of 0
                 0.33, 2,     // At 0.33 time, value of 2
@@ -87,9 +87,9 @@ describe('Curve', () => {
 
     });
 
-    describe('#clone', () => {
+    describe('#clone', function () {
 
-        it('clones an empty curve', () => {
+        it('clones an empty curve', function () {
             const c = new Curve();
             const clone = c.clone();
             expect(clone.length).to.equal(c.length);
@@ -97,7 +97,7 @@ describe('Curve', () => {
             expect(clone.tension).to.equal(c.tension);
         });
 
-        it('clones a curve with keys', () => {
+        it('clones a curve with keys', function () {
             const c = new Curve([
                 0, 0,        // At 0 time, value of 0
                 0.33, 2,     // At 0.33 time, value of 2
@@ -113,7 +113,7 @@ describe('Curve', () => {
             }
         });
 
-        it('ensures that an instance of a subclass keeps its class prototype', () => {
+        it('ensures that an instance of a subclass keeps its class prototype', function () {
             class UserCurve extends Curve {}
             const a = new UserCurve();
             const b = a.clone();
@@ -122,9 +122,9 @@ describe('Curve', () => {
 
     });
 
-    describe('#get', () => {
+    describe('#get', function () {
 
-        it('returns the key at the given index', () => {
+        it('returns the key at the given index', function () {
             const c = new Curve([
                 0, 0,        // At 0 time, value of 0
                 0.33, 2,     // At 0.33 time, value of 2
@@ -138,7 +138,7 @@ describe('Curve', () => {
             expect(c.get(3)).to.deep.equal([1, 3]);
         });
 
-        it('returns undefined if the index is out of range', () => {
+        it('returns undefined if the index is out of range', function () {
             const c = new Curve([
                 0, 0,        // At 0 time, value of 0
                 0.33, 2,     // At 0.33 time, value of 2
@@ -152,9 +152,9 @@ describe('Curve', () => {
 
     });
 
-    describe('#quantize', () => {
+    describe('#quantize', function () {
 
-        it('returns the interpolated values at the given intervals (CURVE_LINEAR)', () => {
+        it('returns the interpolated values at the given intervals (CURVE_LINEAR)', function () {
             const c = new Curve([
                 0, 0,
                 0.25, 1,
@@ -178,7 +178,7 @@ describe('Curve', () => {
             expect(values[10]).to.be.closeTo(0, 0.00001);
         });
 
-        it('returns the interpolated values at the given intervals (CURVE_SMOOTHSTEP)', () => {
+        it('returns the interpolated values at the given intervals (CURVE_SMOOTHSTEP)', function () {
             const c = new Curve([
                 0, 0,
                 0.25, 1,
@@ -201,7 +201,7 @@ describe('Curve', () => {
             expect(values[10]).to.be.closeTo(0, 0.00001);
         });
 
-        it('returns the interpolated values at the given intervals (CURVE_SPLINE})', () => {
+        it('returns the interpolated values at the given intervals (CURVE_SPLINE})', function () {
             const c = new Curve([
                 0, 0,
                 0.25, 1,
@@ -225,7 +225,7 @@ describe('Curve', () => {
             expect(values[10]).to.be.closeTo(0, 0.00001);
         });
 
-        it('returns the interpolated values at the given intervals (CURVE_STEP)', () => {
+        it('returns the interpolated values at the given intervals (CURVE_STEP)', function () {
             const c = new Curve([
                 0, 0,
                 0.25, 1,
@@ -251,9 +251,9 @@ describe('Curve', () => {
 
     });
 
-    describe('#value', () => {
+    describe('#value', function () {
 
-        it('returns the interpolated value at the given time (CURVE_LINEAR)', () => {
+        it('returns the interpolated value at the given time (CURVE_LINEAR)', function () {
             const c = new Curve([
                 0, 0,
                 0.25, 1,
@@ -275,7 +275,7 @@ describe('Curve', () => {
             expect(c.value(1)).to.be.closeTo(0, 0.00001);
         });
 
-        it('returns the interpolated value at the given time (CURVE_SMOOTHSTEP)', () => {
+        it('returns the interpolated value at the given time (CURVE_SMOOTHSTEP)', function () {
             const c = new Curve([
                 0, 0,
                 0.25, 1,
@@ -296,7 +296,7 @@ describe('Curve', () => {
             expect(c.value(1)).to.be.closeTo(0, 0.00001);
         });
 
-        it('returns the interpolated value at the given time (CURVE_SPLINE})', () => {
+        it('returns the interpolated value at the given time (CURVE_SPLINE})', function () {
             const c = new Curve([
                 0, 0,
                 0.25, 1,
@@ -318,7 +318,7 @@ describe('Curve', () => {
             expect(c.value(1)).to.be.closeTo(0, 0.00001);
         });
 
-        it('returns the interpolated value at the given time (CURVE_STEP)', () => {
+        it('returns the interpolated value at the given time (CURVE_STEP)', function () {
             const c = new Curve([
                 0, 0,
                 0.25, 1,

--- a/test/core/math/mat3.test.mjs
+++ b/test/core/math/mat3.test.mjs
@@ -11,24 +11,24 @@ const increasingTransposed = [1, 4, 7, 2, 5, 8, 3, 6, 9];
 
 const increasingMat4 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
-describe('Mat3', () => {
+describe('Mat3', function () {
 
-    describe('#data', () => {
-        it('is a Float32Array of length 9', () => {
+    describe('#data', function () {
+        it('is a Float32Array of length 9', function () {
             const m = new Mat3();
             expect(m.data).to.be.an.instanceof(Float32Array);
             expect(m.data).to.have.length(9);
         });
 
-        it('is initialized to the identity matrix', () => {
+        it('is initialized to the identity matrix', function () {
             const m = new Mat3();
             expect(m.data).to.deep.equal(new Float32Array(identity));
         });
     });
 
-    describe('#equals', () => {
+    describe('#equals', function () {
 
-        it('returns true for the same matrix', () => {
+        it('returns true for the same matrix', function () {
             const m = new Mat3();
             m.data.set(increasing);
             const n = new Mat3();
@@ -36,7 +36,7 @@ describe('Mat3', () => {
             expect(m.equals(n)).to.be.true;
         });
 
-        it('returns false for different matrices', () => {
+        it('returns false for different matrices', function () {
             const m = new Mat3();
             m.data.set(increasing);
             const n = new Mat3();
@@ -46,8 +46,8 @@ describe('Mat3', () => {
 
     });
 
-    describe('#clone', () => {
-        it('clones correctly', () => {
+    describe('#clone', function () {
+        it('clones correctly', function () {
             const m = new Mat3();
             m.data.set(increasing);
             const n = m.clone();
@@ -55,8 +55,8 @@ describe('Mat3', () => {
         });
     });
 
-    describe('#copy', () => {
-        it('copies correctly', () => {
+    describe('#copy', function () {
+        it('copies correctly', function () {
             const m = new Mat3();
             m.data.set(increasing);
             const n = new Mat3();
@@ -65,8 +65,8 @@ describe('Mat3', () => {
         });
     });
 
-    describe('#set', () => {
-        it('sets the matrix correctly', () => {
+    describe('#set', function () {
+        it('sets the matrix correctly', function () {
             const m = new Mat3();
             m.set(increasing);
             const n = new Mat3();
@@ -75,21 +75,21 @@ describe('Mat3', () => {
         });
     });
 
-    describe('#isIdentity', () => {
-        it('is true for the identity matrix', () => {
+    describe('#isIdentity', function () {
+        it('is true for the identity matrix', function () {
             const m = new Mat3();
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('is false for a non-identity matrix', () => {
+        it('is false for a non-identity matrix', function () {
             const m = new Mat3();
             m.data.set([1, 2, 3, 4, 5, 6, 7, 8, 9]);
             expect(m.isIdentity()).to.be.false;
         });
     });
 
-    describe('#setIdentity', () => {
-        it('sets the matrix to the identity matrix', () => {
+    describe('#setIdentity', function () {
+        it('sets the matrix to the identity matrix', function () {
             const m = new Mat3();
             m.set(increasing);
             expect(m.isIdentity()).to.be.false;
@@ -98,15 +98,15 @@ describe('Mat3', () => {
         });
     });
 
-    describe('#transpose', () => {
+    describe('#transpose', function () {
 
-        it('transposes the identity matrix to the identity matrix', () => {
+        it('transposes the identity matrix to the identity matrix', function () {
             const m = new Mat3();
             m.transpose();
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('transposes a non-identity matrix correctly', () => {
+        it('transposes a non-identity matrix correctly', function () {
             const m = new Mat3();
             m.set(increasing);
             m.transpose();
@@ -114,7 +114,7 @@ describe('Mat3', () => {
             expect(m.data).to.deep.equal(new Float32Array(increasingTransposed));
         });
 
-        it('transposes a non-identity matrix correctly given a source matrix', () => {
+        it('transposes a non-identity matrix correctly given a source matrix', function () {
             const m = new Mat3();
             m.set(increasing);
             const n = new Mat3();
@@ -123,8 +123,8 @@ describe('Mat3', () => {
         });
     });
 
-    describe('#setFromMat4', () => {
-        it('sets the matrix correctly', () => {
+    describe('#setFromMat4', function () {
+        it('sets the matrix correctly', function () {
             const m = new Mat4();
             m.set(increasingMat4);
 
@@ -135,8 +135,8 @@ describe('Mat3', () => {
         });
     });
 
-    describe('#invertMat4', () => {
-        it('inverts the matrix correctly', () => {
+    describe('#invertMat4', function () {
+        it('inverts the matrix correctly', function () {
             const m = new Mat4();
             m.set([2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1]);
 
@@ -147,8 +147,8 @@ describe('Mat3', () => {
         });
     });
 
-    describe('#transformVector', () => {
-        it('transforms a vector correctly', () => {
+    describe('#transformVector', function () {
+        it('transforms a vector correctly', function () {
             const m = new Mat4();
             m.setScale(2, 2, 2);
 

--- a/test/core/math/mat4.test.mjs
+++ b/test/core/math/mat4.test.mjs
@@ -5,11 +5,11 @@ import { Vec4 } from '../../../src/core/math/vec4.js';
 
 import { expect } from 'chai';
 
-describe('Mat4', () => {
+describe('Mat4', function () {
 
-    describe('#data', () => {
+    describe('#data', function () {
 
-        it('is a Float32Array of length 16', () => {
+        it('is a Float32Array of length 16', function () {
             const m = new Mat4();
             expect(m.data).to.be.an.instanceof(Float32Array);
             expect(m.data).to.have.length(16);
@@ -17,9 +17,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#constructor()', () => {
+    describe('#constructor()', function () {
 
-        it('creates an identity matrix', () => {
+        it('creates an identity matrix', function () {
             const m = new Mat4();
             const identity = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
             expect(m.data).to.deep.equal(identity);
@@ -27,9 +27,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#add()', () => {
+    describe('#add()', function () {
 
-        it('adds one matrix to another in place', () => {
+        it('adds one matrix to another in place', function () {
             const m1 = new Mat4();
             m1.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const m2 = new Mat4();
@@ -39,7 +39,7 @@ describe('Mat4', () => {
             expect(m1.data).to.deep.equal(result);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             expect(m1.add(m2)).to.equal(m1);
@@ -47,9 +47,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#add2()', () => {
+    describe('#add2()', function () {
 
-        it('adds two matrices together and writes result to a third matrix', () => {
+        it('adds two matrices together and writes result to a third matrix', function () {
             const m1 = new Mat4();
             m1.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const m2 = new Mat4();
@@ -60,7 +60,7 @@ describe('Mat4', () => {
             expect(m3.data).to.deep.equal(result);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             const m3 = new Mat4();
@@ -69,16 +69,16 @@ describe('Mat4', () => {
 
     });
 
-    describe('#clone()', () => {
+    describe('#clone()', function () {
 
-        it('clones a matrix', () => {
+        it('clones a matrix', function () {
             const m1 = new Mat4();
             m1.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const m2 = m1.clone();
             expect(m2.data).to.deep.equal(m1.data);
         });
 
-        it('ensures that an instance of a subclass keeps its class prototype', () => {
+        it('ensures that an instance of a subclass keeps its class prototype', function () {
             class UserMat4 extends Mat4 {}
             const a = new UserMat4();
             const b = a.clone();
@@ -87,9 +87,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#copy()', () => {
+    describe('#copy()', function () {
 
-        it('copies a matrix', () => {
+        it('copies a matrix', function () {
             const m1 = new Mat4();
             m1.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const m2 = new Mat4();
@@ -97,7 +97,7 @@ describe('Mat4', () => {
             expect(m2.data).to.deep.equal(m1.data);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             expect(m2.copy(m1)).to.equal(m2);
@@ -105,9 +105,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#equals()', () => {
+    describe('#equals()', function () {
 
-        it('checks for equality', () => {
+        it('checks for equality', function () {
             const m1 = new Mat4();
             m1.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const m2 = new Mat4();
@@ -120,9 +120,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#getEulerAngles()', () => {
+    describe('#getEulerAngles()', function () {
 
-        it('gets euler angles from an identity matrix', () => {
+        it('gets euler angles from an identity matrix', function () {
             const m = new Mat4();
             const angles = m.getEulerAngles();
             expect(angles.x).to.equal(0);
@@ -130,7 +130,7 @@ describe('Mat4', () => {
             expect(angles.z).to.equal(0);
         });
 
-        it('gets euler angles from an identity matrix (no allocation)', () => {
+        it('gets euler angles from an identity matrix (no allocation)', function () {
             const m = new Mat4();
             const angles = new Vec3();
             m.getEulerAngles(angles);
@@ -139,7 +139,7 @@ describe('Mat4', () => {
             expect(angles.z).to.equal(0);
         });
 
-        it('gets a 90 rotation around x', () => {
+        it('gets a 90 rotation around x', function () {
             const m = new Mat4();
             m.set([1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1]);
             const angles = m.getEulerAngles();
@@ -148,7 +148,7 @@ describe('Mat4', () => {
             expect(angles.z).to.equal(0);
         });
 
-        it('gets a -45 rotation around x', () => {
+        it('gets a -45 rotation around x', function () {
             const m = new Mat4();
             m.set([1, 0, 0, 0, 0, 0.7071067811865476, -0.7071067811865476, 0, 0, 0.7071067811865476, 0.7071067811865476, 0, 0, 0, 0, 1]);
             const angles = m.getEulerAngles();
@@ -157,7 +157,7 @@ describe('Mat4', () => {
             expect(angles.z).to.be.closeTo(0, 0.00001);
         });
 
-        it('gets a -45 rotation around y', () => {
+        it('gets a -45 rotation around y', function () {
             const m = new Mat4();
             m.set([0.7071067811865476, 0, 0.7071067811865476, 0, 0, 1, 0, 0, -0.7071067811865476, 0, 0.7071067811865476, 0, 0, 0, 0, 1]);
             const angles = m.getEulerAngles();
@@ -166,7 +166,7 @@ describe('Mat4', () => {
             expect(angles.z).to.be.closeTo(0, 0.00001);
         });
 
-        it('gets a -45 rotation around z', () => {
+        it('gets a -45 rotation around z', function () {
             const m = new Mat4();
             m.set([0.7071067811865476, -0.7071067811865476, 0, 0, 0.7071067811865476, 0.7071067811865476, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
             const angles = m.getEulerAngles();
@@ -177,9 +177,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#getScale()', () => {
+    describe('#getScale()', function () {
 
-        it('gets scale from an identity matrix', () => {
+        it('gets scale from an identity matrix', function () {
             const m = new Mat4();
             const scale = m.getScale();
             expect(scale.x).to.equal(1);
@@ -187,7 +187,7 @@ describe('Mat4', () => {
             expect(scale.z).to.equal(1);
         });
 
-        it('gets scale from an identity matrix (no allocation)', () => {
+        it('gets scale from an identity matrix (no allocation)', function () {
             const m = new Mat4();
             const scale = new Vec3();
             m.getScale(scale);
@@ -196,7 +196,7 @@ describe('Mat4', () => {
             expect(scale.z).to.equal(1);
         });
 
-        it('gets scale from a scaled matrix', () => {
+        it('gets scale from a scaled matrix', function () {
             const m = new Mat4();
             m.set([2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1]);
             const scale = m.getScale();
@@ -205,7 +205,7 @@ describe('Mat4', () => {
             expect(scale.z).to.equal(2);
         });
 
-        it('gets scale from a scaled matrix (no allocation)', () => {
+        it('gets scale from a scaled matrix (no allocation)', function () {
             const m = new Mat4();
             m.set([2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1]);
             const scale = new Vec3();
@@ -217,9 +217,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#getTranslation()', () => {
+    describe('#getTranslation()', function () {
 
-        it('gets translation from an identity matrix', () => {
+        it('gets translation from an identity matrix', function () {
             const m = new Mat4();
             const translation = m.getTranslation();
             expect(translation.x).to.equal(0);
@@ -227,7 +227,7 @@ describe('Mat4', () => {
             expect(translation.z).to.equal(0);
         });
 
-        it('gets translation from an identity matrix (no allocation)', () => {
+        it('gets translation from an identity matrix (no allocation)', function () {
             const m = new Mat4();
             const translation = new Vec3();
             m.getTranslation(translation);
@@ -236,7 +236,7 @@ describe('Mat4', () => {
             expect(translation.z).to.equal(0);
         });
 
-        it('gets translation from a translated matrix', () => {
+        it('gets translation from a translated matrix', function () {
             const m = new Mat4();
             m.set([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1]);
             const translation = m.getTranslation();
@@ -245,7 +245,7 @@ describe('Mat4', () => {
             expect(translation.z).to.equal(30);
         });
 
-        it('gets translation from a translated matrix (no allocation)', () => {
+        it('gets translation from a translated matrix (no allocation)', function () {
             const m = new Mat4();
             m.set([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1]);
             const translation = new Vec3();
@@ -257,9 +257,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#getX()', () => {
+    describe('#getX()', function () {
 
-        it('gets x axis from a matrix', () => {
+        it('gets x axis from a matrix', function () {
             const m = new Mat4();
             m.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const axis = m.getX();
@@ -268,7 +268,7 @@ describe('Mat4', () => {
             expect(axis.z).to.equal(2);
         });
 
-        it('gets x axis from a matrix (no allocation)', () => {
+        it('gets x axis from a matrix (no allocation)', function () {
             const m = new Mat4();
             m.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const axis = new Vec3();
@@ -280,9 +280,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#getY()', () => {
+    describe('#getY()', function () {
 
-        it('gets y axis from a matrix', () => {
+        it('gets y axis from a matrix', function () {
             const m = new Mat4();
             m.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const axis = m.getY();
@@ -291,7 +291,7 @@ describe('Mat4', () => {
             expect(axis.z).to.equal(6);
         });
 
-        it('gets y axis from a matrix (no allocation)', () => {
+        it('gets y axis from a matrix (no allocation)', function () {
             const m = new Mat4();
             m.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const axis = new Vec3();
@@ -303,9 +303,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#getZ()', () => {
+    describe('#getZ()', function () {
 
-        it('gets z axis from a matrix', () => {
+        it('gets z axis from a matrix', function () {
             const m = new Mat4();
             m.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const axis = m.getZ();
@@ -314,7 +314,7 @@ describe('Mat4', () => {
             expect(axis.z).to.equal(10);
         });
 
-        it('gets z axis from a matrix (no allocation)', () => {
+        it('gets z axis from a matrix (no allocation)', function () {
             const m = new Mat4();
             m.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             const axis = new Vec3();
@@ -326,15 +326,15 @@ describe('Mat4', () => {
 
     });
 
-    describe('#invert()', () => {
+    describe('#invert()', function () {
 
-        it('inverts an identity matrix to the identity matrix', () => {
+        it('inverts an identity matrix to the identity matrix', function () {
             const m = new Mat4();
             m.invert();
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('inverts a translation matrix to the inverse translation matrix', () => {
+        it('inverts a translation matrix to the inverse translation matrix', function () {
             const m = new Mat4();
             m.set([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1]);
             m.invert();
@@ -343,7 +343,7 @@ describe('Mat4', () => {
             expect(m.data).to.deep.equal(new Float32Array(result));
         });
 
-        it('inverts a translation matrix to the inverse translation matrix given a source matrix', () => {
+        it('inverts a translation matrix to the inverse translation matrix given a source matrix', function () {
             const m = new Mat4();
             m.set([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1]);
 
@@ -354,21 +354,21 @@ describe('Mat4', () => {
             expect(n.data).to.deep.equal(new Float32Array(result));
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m = new Mat4();
             expect(m.invert()).to.equal(m);
         });
 
     });
 
-    describe('#isIdentity()', () => {
+    describe('#isIdentity()', function () {
 
-        it('returns true for an identity matrix', () => {
+        it('returns true for an identity matrix', function () {
             const m = new Mat4();
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('returns false for a non-identity matrix', () => {
+        it('returns false for a non-identity matrix', function () {
             const m = new Mat4();
             m.set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
             expect(m.isIdentity()).to.be.false;
@@ -376,16 +376,16 @@ describe('Mat4', () => {
 
     });
 
-    describe('#mul()', () => {
+    describe('#mul()', function () {
 
-        it('sets the identity when multiplying the identity by the identity (I * I = I)', () => {
+        it('sets the identity when multiplying the identity by the identity (I * I = I)', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             m1.mul(m2);
             expect(m1.isIdentity()).to.be.true;
         });
 
-        it('leaves matrix unchanged when multiplying by the identity ( A * I = A )', () => {
+        it('leaves matrix unchanged when multiplying by the identity ( A * I = A )', function () {
             const m1 = new Mat4();
             const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
             m1.set(data);
@@ -394,7 +394,7 @@ describe('Mat4', () => {
             expect(m1.data).to.deep.equal(new Float32Array(data));
         });
 
-        it('sets a matrix to the right hand side when left hand side is identity ( I * A = A )', () => {
+        it('sets a matrix to the right hand side when left hand side is identity ( I * A = A )', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
@@ -403,7 +403,7 @@ describe('Mat4', () => {
             expect(m1.data).to.deep.equal(new Float32Array(data));
         });
 
-        it('multiplies an arbitrary matrix with another in place', () => {
+        it('multiplies an arbitrary matrix with another in place', function () {
             const m1 = new Mat4();
             m1.set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
             const m2 = new Mat4();
@@ -413,7 +413,7 @@ describe('Mat4', () => {
             expect(m1.data).to.deep.equal(new Float32Array(result));
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             expect(m1.mul(m2)).to.equal(m1);
@@ -421,9 +421,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#mul2()', () => {
+    describe('#mul2()', function () {
 
-        it('sets the identity when multiplying the identity by the identity (I * I = I)', () => {
+        it('sets the identity when multiplying the identity by the identity (I * I = I)', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             const m3 = new Mat4();
@@ -431,7 +431,7 @@ describe('Mat4', () => {
             expect(m1.isIdentity()).to.be.true;
         });
 
-        it('leaves matrix unchanged when multiplying by the identity ( A * I = A )', () => {
+        it('leaves matrix unchanged when multiplying by the identity ( A * I = A )', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
@@ -441,7 +441,7 @@ describe('Mat4', () => {
             expect(m1.data).to.deep.equal(new Float32Array(data));
         });
 
-        it('sets a matrix to the right hand side when left hand side is identity ( I * A = A )', () => {
+        it('sets a matrix to the right hand side when left hand side is identity ( I * A = A )', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             const m3 = new Mat4();
@@ -451,7 +451,7 @@ describe('Mat4', () => {
             expect(m1.data).to.deep.equal(new Float32Array(data));
         });
 
-        it('multiplies two arbitrary matrices together and writes result to a third', () => {
+        it('multiplies two arbitrary matrices together and writes result to a third', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             m2.set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
@@ -462,7 +462,7 @@ describe('Mat4', () => {
             expect(m1.data).to.deep.equal(new Float32Array(result));
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             const m3 = new Mat4();
@@ -471,9 +471,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#mulAffine2()', () => {
+    describe('#mulAffine2()', function () {
 
-        it('sets the identity when multiplying the identity by the identity (I * I = I)', () => {
+        it('sets the identity when multiplying the identity by the identity (I * I = I)', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             const m3 = new Mat4();
@@ -481,7 +481,7 @@ describe('Mat4', () => {
             expect(m1.isIdentity()).to.be.true;
         });
 
-        it('leaves matrix unchanged when multiplying by the identity ( A * I = A )', () => {
+        it('leaves matrix unchanged when multiplying by the identity ( A * I = A )', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             const data = [1, 2, 3, 0, 5, 6, 7, 0, 9, 10, 11, 0, 13, 14, 15, 1];
@@ -491,7 +491,7 @@ describe('Mat4', () => {
             expect(m1.data).to.deep.equal(new Float32Array(data));
         });
 
-        it('sets a matrix to the right hand side when left hand side is identity ( I * A = A )', () => {
+        it('sets a matrix to the right hand side when left hand side is identity ( I * A = A )', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             const m3 = new Mat4();
@@ -501,7 +501,7 @@ describe('Mat4', () => {
             expect(m1.data).to.deep.equal(new Float32Array(data));
         });
 
-        it('multiplies two arbitrary matrices together and writes result to a third', () => {
+        it('multiplies two arbitrary matrices together and writes result to a third', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             m2.set([1, 2, 3, 0, 5, 6, 7, 0, 9, 10, 11, 0, 13, 14, 15, 1]);
@@ -512,7 +512,7 @@ describe('Mat4', () => {
             expect(m1.data).to.deep.equal(new Float32Array(result));
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m1 = new Mat4();
             const m2 = new Mat4();
             const m3 = new Mat4();
@@ -521,16 +521,16 @@ describe('Mat4', () => {
 
     });
 
-    describe('#set()', () => {
+    describe('#set()', function () {
 
-        it('sets a matrix', () => {
+        it('sets a matrix', function () {
             const m = new Mat4();
             const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
             m.set(data);
             expect(m.data).to.deep.equal(new Float32Array(data));
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m = new Mat4();
             const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
             expect(m.set(data)).to.equal(m);
@@ -538,15 +538,15 @@ describe('Mat4', () => {
 
     });
 
-    describe('#setFromAxisAngle()', () => {
+    describe('#setFromAxisAngle()', function () {
 
-        it('sets the identity matrix when passing a zero angle', () => {
+        it('sets the identity matrix when passing a zero angle', function () {
             const m = new Mat4();
             m.setFromAxisAngle(Vec3.UP, 0);
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('sets an approximation of the identity matrix when passing a multiple of 360', () => {
+        it('sets an approximation of the identity matrix when passing a multiple of 360', function () {
             const m = new Mat4();
             m.setFromAxisAngle(Vec3.UP, 360);
             expect(m.data[0]).to.be.closeTo(1, 0.001);
@@ -567,7 +567,7 @@ describe('Mat4', () => {
             expect(m.data[15]).to.be.closeTo(1, 0.001);
         });
 
-        it('set a rotation matrix of 90 around the x axis', () => {
+        it('set a rotation matrix of 90 around the x axis', function () {
             const m = new Mat4();
             m.setFromAxisAngle(Vec3.RIGHT, 90);
             expect(m.data[0]).to.be.closeTo(1, 0.001);
@@ -588,22 +588,22 @@ describe('Mat4', () => {
             expect(m.data[15]).to.be.closeTo(1, 0.001);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m = new Mat4();
             expect(m.setFromAxisAngle(Vec3.UP, 0)).to.equal(m);
         });
 
     });
 
-    describe('#setFromEulerAngles()', () => {
+    describe('#setFromEulerAngles()', function () {
 
-        it('sets the identity matrix when zeros are passed', () => {
+        it('sets the identity matrix when zeros are passed', function () {
             const m = new Mat4();
             m.setFromEulerAngles(0, 0, 0);
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('set a rotation matrix from arbitrary euler angles', () => {
+        it('set a rotation matrix from arbitrary euler angles', function () {
             const m = new Mat4();
             m.setFromEulerAngles(10, 20, 30);
             expect(m.data[0]).to.be.closeTo(0.813797652721405, 0.00001);
@@ -624,16 +624,16 @@ describe('Mat4', () => {
             expect(m.data[15]).to.equal(1);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m = new Mat4();
             expect(m.setFromEulerAngles(0, 0, 0)).to.equal(m);
         });
 
     });
 
-    describe('#setIdentity()', () => {
+    describe('#setIdentity()', function () {
 
-        it('sets an identity matrix', () => {
+        it('sets an identity matrix', function () {
             const m = new Mat4();
             m.setIdentity();
 
@@ -641,22 +641,22 @@ describe('Mat4', () => {
             expect(m.data).to.deep.equal(identity);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m = new Mat4();
             expect(m.setIdentity()).to.equal(m);
         });
 
     });
 
-    describe('#setLookAt()', () => {
+    describe('#setLookAt()', function () {
 
-        it('sets the identity matrix when eye is at origin looking down negative z', () => {
+        it('sets the identity matrix when eye is at origin looking down negative z', function () {
             const m = new Mat4();
             m.setLookAt(Vec3.ZERO, Vec3.FORWARD, Vec3.UP);
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('sets matrix translation to eye position', () => {
+        it('sets matrix translation to eye position', function () {
             const m = new Mat4();
             m.setLookAt(new Vec3(10, 20, 30), Vec3.FORWARD, Vec3.UP);
             expect(m.data[12]).to.equal(10);
@@ -664,7 +664,7 @@ describe('Mat4', () => {
             expect(m.data[14]).to.equal(30);
         });
 
-        it('sets matrix from arbitrary inputs', () => {
+        it('sets matrix from arbitrary inputs', function () {
             const m = new Mat4();
             m.setLookAt(new Vec3(10, 20, 30), new Vec3(40, 50, 60), Vec3.RIGHT);
             expect(m.data[0]).to.equal(0);
@@ -685,22 +685,22 @@ describe('Mat4', () => {
             expect(m.data[15]).to.equal(1);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m = new Mat4();
             expect(m.setLookAt(Vec3.ZERO, Vec3.FORWARD, Vec3.UP)).to.equal(m);
         });
 
     });
 
-    describe('#setOrtho()', () => {
+    describe('#setOrtho()', function () {
 
-        it('sets a normalized orthographic matrix', () => {
+        it('sets a normalized orthographic matrix', function () {
             const m = new Mat4();
             m.setOrtho(-1, 1, -1, 1, 1, -1);
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('sets a non-normalized orthographic matrix', () => {
+        it('sets a non-normalized orthographic matrix', function () {
             const m = new Mat4();
             m.setOrtho(-10, 10, -5, 5, 2, -2);
             expect(m.data[0]).to.be.closeTo(0.1, 0.001);
@@ -723,9 +723,9 @@ describe('Mat4', () => {
 
     });
 
-    describe('#setPerspective()', () => {
+    describe('#setPerspective()', function () {
 
-        it('sets a perspective matrix', () => {
+        it('sets a perspective matrix', function () {
             const m = new Mat4();
             m.setPerspective(90, 1, 1, 10);
             expect(m.data[0]).to.equal(1);
@@ -748,15 +748,15 @@ describe('Mat4', () => {
 
     });
 
-    describe('#setScale()', () => {
+    describe('#setScale()', function () {
 
-        it('sets an identity matrix when ones are passed in', () => {
+        it('sets an identity matrix when ones are passed in', function () {
             const m = new Mat4();
             m.setScale(1, 1, 1);
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('sets a scale matrix', () => {
+        it('sets a scale matrix', function () {
             const m = new Mat4();
             m.setScale(10, 20, 30);
 
@@ -764,22 +764,22 @@ describe('Mat4', () => {
             expect(m.data).to.deep.equal(result);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m = new Mat4();
             expect(m.setScale(1, 2, 3)).to.equal(m);
         });
 
     });
 
-    describe('#setTranslate()', () => {
+    describe('#setTranslate()', function () {
 
-        it('sets an identity matrix when zeros are passed in', () => {
+        it('sets an identity matrix when zeros are passed in', function () {
             const m = new Mat4();
             m.setTranslate(0, 0, 0);
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('sets a translation matrix', () => {
+        it('sets a translation matrix', function () {
             const m = new Mat4();
             m.setTranslate(1, 2, 3);
 
@@ -787,22 +787,22 @@ describe('Mat4', () => {
             expect(m.data).to.deep.equal(result);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m = new Mat4();
             expect(m.setTranslate(1, 2, 3)).to.equal(m);
         });
 
     });
 
-    describe('#setTRS()', () => {
+    describe('#setTRS()', function () {
 
-        it('sets a matrix from identity translation, rotation and scale', () => {
+        it('sets a matrix from identity translation, rotation and scale', function () {
             const m = new Mat4();
             m.setTRS(Vec3.ZERO, Quat.IDENTITY, Vec3.ONE);
             expect(m.equals(Mat4.IDENTITY)).to.be.true;
         });
 
-        it('sets a matrix from translation, rotation and scale', () => {
+        it('sets a matrix from translation, rotation and scale', function () {
             const m = new Mat4();
             const t = new Vec3(1, 2, 3);
             const r = new Quat().setFromEulerAngles(10, 20, 30);
@@ -826,32 +826,32 @@ describe('Mat4', () => {
             expect(m.data[15]).to.equal(1);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m = new Mat4();
             expect(m.setTRS(Vec3.ZERO, Quat.IDENTITY, Vec3.ONE)).to.equal(m);
         });
 
     });
 
-    describe('#toString()', () => {
+    describe('#toString()', function () {
 
-        it('returns a string representation of a matrix', () => {
+        it('returns a string representation of a matrix', function () {
             const m = new Mat4();
             expect(m.toString()).to.equal('[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]');
         });
 
     });
 
-    describe('#transformPoint()', () => {
+    describe('#transformPoint()', function () {
 
-        it('leaves point unchanged when transforming by the identity matrix', () => {
+        it('leaves point unchanged when transforming by the identity matrix', function () {
             const p = new Vec3(1, 2, 3);
             const m = new Mat4();
             const r = m.transformPoint(p);
             expect(p.equals(r)).to.be.true;
         });
 
-        it('leaves point unchanged when transforming by the identity matrix (no allocation)', () => {
+        it('leaves point unchanged when transforming by the identity matrix (no allocation)', function () {
             const p = new Vec3(1, 2, 3);
             const m = new Mat4();
             const r = new Vec3();
@@ -859,7 +859,7 @@ describe('Mat4', () => {
             expect(p.equals(r)).to.be.true;
         });
 
-        it('transforms a point by a 90 degree rotation around the z axis', () => {
+        it('transforms a point by a 90 degree rotation around the z axis', function () {
             const p = new Vec3(1, 0, 0);
             const m = new Mat4();
             const r = new Vec3();
@@ -872,7 +872,7 @@ describe('Mat4', () => {
             expect(r.z).to.be.closeTo(0, 0.00001);
         });
 
-        it('transforms a point by a 90 degree rotation around the z axis (input and output vectors are the same)', () => {
+        it('transforms a point by a 90 degree rotation around the z axis (input and output vectors are the same)', function () {
             const p = new Vec3(1, 0, 0);
             const m = new Mat4();
 
@@ -884,7 +884,7 @@ describe('Mat4', () => {
             expect(p.z).to.be.closeTo(0, 0.00001);
         });
 
-        it('takes translation component of a matrix into account', () => {
+        it('takes translation component of a matrix into account', function () {
             const p = new Vec3(1, 2, 3);
             const m = new Mat4();
             m.setTranslate(10, 20, 30);
@@ -896,16 +896,16 @@ describe('Mat4', () => {
 
     });
 
-    describe('#transformVec4()', () => {
+    describe('#transformVec4()', function () {
 
-        it('leaves vector unchanged when transforming by the identity matrix', () => {
+        it('leaves vector unchanged when transforming by the identity matrix', function () {
             const v = new Vec4(1, 2, 3, 4);
             const m = new Mat4();
             const r = m.transformVec4(v);
             expect(v.equals(r)).to.be.true;
         });
 
-        it('leaves vector unchanged when transforming by the identity matrix (no allocation)', () => {
+        it('leaves vector unchanged when transforming by the identity matrix (no allocation)', function () {
             const v = new Vec4(1, 2, 3, 4);
             const m = new Mat4();
             const r = new Vec4();
@@ -913,7 +913,7 @@ describe('Mat4', () => {
             expect(v.equals(r)).to.be.true;
         });
 
-        it('transforms a vector by a 90 degree rotation around the z axis', () => {
+        it('transforms a vector by a 90 degree rotation around the z axis', function () {
             const v = new Vec4(1, 0, 0, 0);
             const m = new Mat4();
             const r = new Vec4();
@@ -927,7 +927,7 @@ describe('Mat4', () => {
             expect(r.w).to.equal(0);
         });
 
-        it('transforms a vector by a 90 degree rotation around the z axis (input and output vectors are the same)', () => {
+        it('transforms a vector by a 90 degree rotation around the z axis (input and output vectors are the same)', function () {
             const v = new Vec4(1, 0, 0, 0);
             const m = new Mat4();
 
@@ -942,16 +942,16 @@ describe('Mat4', () => {
 
     });
 
-    describe('#transformVector()', () => {
+    describe('#transformVector()', function () {
 
-        it('leaves vector unchanged when transforming by the identity matrix', () => {
+        it('leaves vector unchanged when transforming by the identity matrix', function () {
             const v = new Vec3(1, 2, 3);
             const m = new Mat4();
             const r = m.transformVector(v);
             expect(v.equals(r)).to.be.true;
         });
 
-        it('leaves vector unchanged when transforming by the identity matrix (no allocation)', () => {
+        it('leaves vector unchanged when transforming by the identity matrix (no allocation)', function () {
             const v = new Vec3(1, 2, 3);
             const m = new Mat4();
             const r = new Vec3();
@@ -959,7 +959,7 @@ describe('Mat4', () => {
             expect(v.equals(r)).to.be.true;
         });
 
-        it('transforms a vector by a 90 degree rotation around the z axis', () => {
+        it('transforms a vector by a 90 degree rotation around the z axis', function () {
             const v = new Vec3(1, 0, 0);
             const m = new Mat4();
             const r = new Vec3();
@@ -972,7 +972,7 @@ describe('Mat4', () => {
             expect(r.z).to.be.closeTo(0, 0.00001);
         });
 
-        it('transforms a vector by a 90 degree rotation around the z axis (input and output vectors are the same)', () => {
+        it('transforms a vector by a 90 degree rotation around the z axis (input and output vectors are the same)', function () {
             const v = new Vec3(1, 0, 0);
             const m = new Mat4();
 
@@ -984,7 +984,7 @@ describe('Mat4', () => {
             expect(v.z).to.be.closeTo(0, 0.00001);
         });
 
-        it('ignores the translation component of a matrix', () => {
+        it('ignores the translation component of a matrix', function () {
             const v = new Vec3(1, 2, 3);
             const m = new Mat4();
             m.setTranslate(10, 20, 30);
@@ -994,15 +994,15 @@ describe('Mat4', () => {
 
     });
 
-    describe('#transpose()', () => {
+    describe('#transpose()', function () {
 
-        it('transposes the identity matrix to the identity matrix', () => {
+        it('transposes the identity matrix to the identity matrix', function () {
             const m = new Mat4();
             m.transpose();
             expect(m.isIdentity()).to.be.true;
         });
 
-        it('flips a matrix along its top-left to bottom-right diagonal', () => {
+        it('flips a matrix along its top-left to bottom-right diagonal', function () {
             const m = new Mat4();
             m.set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
             m.transpose();
@@ -1010,7 +1010,7 @@ describe('Mat4', () => {
             expect(m.data).to.deep.equal(new Float32Array(result));
         });
 
-        it('flips a matrix along its top-left to bottom-right diagonal given a source matrix', () => {
+        it('flips a matrix along its top-left to bottom-right diagonal given a source matrix', function () {
             const m = new Mat4();
             m.set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 
@@ -1021,7 +1021,7 @@ describe('Mat4', () => {
             expect(n.data).to.deep.equal(new Float32Array(result));
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const m = new Mat4();
             expect(m.transpose()).to.equal(m);
         });

--- a/test/core/math/math.test.mjs
+++ b/test/core/math/math.test.mjs
@@ -2,118 +2,118 @@ import { math } from '../../../src/core/math/math.js';
 
 import { expect } from 'chai';
 
-describe('math', () => {
+describe('math', function () {
 
-    describe('#DEG_TO_RAD', () => {
+    describe('#DEG_TO_RAD', function () {
 
-        it('converts degrees to radians', () => {
+        it('converts degrees to radians', function () {
             const deg = 180;
             expect(deg * math.DEG_TO_RAD).to.equal(Math.PI);
         });
 
     });
 
-    describe('#RAD_TO_DEG', () => {
+    describe('#RAD_TO_DEG', function () {
 
-        it('converts radians to degrees', () => {
+        it('converts radians to degrees', function () {
             const rad = Math.PI;
             expect(rad * math.RAD_TO_DEG).to.equal(180);
         });
 
     });
 
-    describe('#between', () => {
+    describe('#between', function () {
 
-        it('returns true if value is between min and max inclusive', () => {
+        it('returns true if value is between min and max inclusive', function () {
             expect(math.between(0, 0, 1, true)).to.be.true;
             expect(math.between(0.5, 0, 1, true)).to.be.true;
             expect(math.between(1, 0, 1, true)).to.be.true;
         });
 
-        it('returns false if value is not between min and max inclusive', () => {
+        it('returns false if value is not between min and max inclusive', function () {
             expect(math.between(-1, 0, 1, true)).to.be.false;
             expect(math.between(2, 0, 1, true)).to.be.false;
         });
 
-        it('returns false if value is between min and max exclusive', () => {
+        it('returns false if value is between min and max exclusive', function () {
             expect(math.between(0, 0, 1, false)).to.be.false;
             expect(math.between(1, 0, 1, false)).to.be.false;
         });
 
-        it('returns false if value is not between min and max exclusive', () => {
+        it('returns false if value is not between min and max exclusive', function () {
             expect(math.between(-1, 0, 1, false)).to.be.false;
             expect(math.between(2, 0, 1, false)).to.be.false;
         });
 
     });
 
-    describe('#bytesToInt24', () => {
+    describe('#bytesToInt24', function () {
 
-        it('packs 3 unsigned bytes into a 24-bit unsigned int', () => {
+        it('packs 3 unsigned bytes into a 24-bit unsigned int', function () {
             const uint24 = math.bytesToInt24(0xaa, 0xbb, 0xcc);
             expect(uint24).to.equal(0xaabbcc);
         });
 
-        it('packs an array of 3 unsigned bytes into a 24-bit unsigned int', () => {
+        it('packs an array of 3 unsigned bytes into a 24-bit unsigned int', function () {
             const uint24 = math.bytesToInt24([0xaa, 0xbb, 0xcc]);
             expect(uint24).to.equal(0xaabbcc);
         });
 
-        it('returns 0 when all supplied bytes are 0', () => {
+        it('returns 0 when all supplied bytes are 0', function () {
             const uint24 = math.bytesToInt24(0, 0, 0);
             expect(uint24).to.equal(0);
         });
 
-        it('returns 2 ^ 24 - 1 when all supplied bytes are 255', () => {
+        it('returns 2 ^ 24 - 1 when all supplied bytes are 255', function () {
             const uint24 = math.bytesToInt24(255, 255, 255);
             expect(uint24).to.equal(Math.pow(2, 24) - 1);
         });
 
     });
 
-    describe('#bytesToInt32', () => {
+    describe('#bytesToInt32', function () {
 
-        it('packs 4 unsigned bytes into a 32-bit unsigned int', () => {
+        it('packs 4 unsigned bytes into a 32-bit unsigned int', function () {
             const uint32 = math.bytesToInt32(0xaa, 0xbb, 0xcc, 0xdd);
             expect(uint32).to.equal(0xaabbccdd);
         });
 
-        it('packs an array of 4 unsigned bytes into a 32-bit unsigned int', () => {
+        it('packs an array of 4 unsigned bytes into a 32-bit unsigned int', function () {
             const uint32 = math.bytesToInt32([0xaa, 0xbb, 0xcc, 0xdd]);
             expect(uint32).to.equal(0xaabbccdd);
         });
 
-        it('returns 0 when all supplied bytes are 0', () => {
+        it('returns 0 when all supplied bytes are 0', function () {
             const uint32 = math.bytesToInt32(0, 0, 0, 0);
             expect(uint32).to.equal(0);
         });
 
-        it('returns 2 ^ 32 - 1 when all supplied bytes are 255', () => {
+        it('returns 2 ^ 32 - 1 when all supplied bytes are 255', function () {
             const uint32 = math.bytesToInt32(255, 255, 255, 255);
             expect(uint32).to.equal(Math.pow(2, 32) - 1);
         });
 
     });
 
-    describe('#clamp', () => {
+    describe('#clamp', function () {
 
-        it('returns the value when it is between min and max', () => {
+        it('returns the value when it is between min and max', function () {
             expect(math.clamp(5, 0, 10)).to.equal(5);
         });
 
-        it('returns the minimum value when it is less than min', () => {
+        it('returns the minimum value when it is less than min', function () {
             expect(math.clamp(-5, 0, 10)).to.equal(0);
         });
 
-        it('returns the maximum value when it is greater than max', () => {
+        it('returns the maximum value when it is greater than max', function () {
             expect(math.clamp(15, 0, 10)).to.equal(10);
         });
 
     });
 
-    describe('#intToBytes24', () => {
+    describe('#intToBytes24', function () {
 
-        it('converts an integer to a 3-element byte array', () => {
+        it('converts an integer to a 3-element byte array', function () {
             const i = 0x112233;
             const b = math.intToBytes24(i);
             expect(b[0]).to.equal(0x11);
@@ -123,9 +123,9 @@ describe('math', () => {
 
     });
 
-    describe('#intToBytes32', () => {
+    describe('#intToBytes32', function () {
 
-        it('converts an integer to a 4-element byte array', () => {
+        it('converts an integer to a 4-element byte array', function () {
             const i = 0x11223344;
             const b = math.intToBytes32(i);
             expect(b[0]).to.equal(0x11);
@@ -136,57 +136,57 @@ describe('math', () => {
 
     });
 
-    describe('#lerp', () => {
+    describe('#lerp', function () {
 
-        it('returns a when alpha is 0', () => {
+        it('returns a when alpha is 0', function () {
             expect(math.lerp(0, 1, 0)).to.equal(0);
         });
 
-        it('returns b when alpha is 1', () => {
+        it('returns b when alpha is 1', function () {
             expect(math.lerp(0, 1, 1)).to.equal(1);
         });
 
-        it('returns a + alpha * (b - a) when alpha is 0.5', () => {
+        it('returns a + alpha * (b - a) when alpha is 0.5', function () {
             expect(math.lerp(0, 1, 0.5)).to.equal(0.5);
         });
 
     });
 
-    describe('#lerpAngle', () => {
+    describe('#lerpAngle', function () {
 
-        it('returns 0 when a is 0 and b is 360 and alpha is 0', () => {
+        it('returns 0 when a is 0 and b is 360 and alpha is 0', function () {
             expect(math.lerpAngle(0, 360, 0)).to.equal(0);
         });
 
-        it('returns 0 when a is 0 and b is 360 and alpha is 0.5', () => {
+        it('returns 0 when a is 0 and b is 360 and alpha is 0.5', function () {
             expect(math.lerpAngle(0, 360, 0.5)).to.equal(0);
         });
 
-        it('returns 0 when a is 0 and b is 360 and alpha is 1', () => {
+        it('returns 0 when a is 0 and b is 360 and alpha is 1', function () {
             expect(math.lerpAngle(0, 360, 1)).to.equal(0);
         });
 
-        it('returns 0 when a is -90 and b is 90 and alpha is 0.5', () => {
+        it('returns 0 when a is -90 and b is 90 and alpha is 0.5', function () {
             expect(math.lerpAngle(-90, 90, 0.5)).to.equal(0);
         });
 
-        it('returns 180 when a is 90 and b is2790 and alpha is 0.5', () => {
+        it('returns 180 when a is 90 and b is2790 and alpha is 0.5', function () {
             expect(math.lerpAngle(90, 270, 0.5)).to.equal(180);
         });
 
-        it('crosses the 360 to 0 degree boundary correctly (anticlockwise)', () => {
+        it('crosses the 360 to 0 degree boundary correctly (anticlockwise)', function () {
             expect(math.lerpAngle(10, 350, 0.75)).to.equal(-5);
         });
 
-        it('crosses the 360 to 0 degree boundary correctly (clockwise)', () => {
+        it('crosses the 360 to 0 degree boundary correctly (clockwise)', function () {
             expect(math.lerpAngle(350, 10, 0.75)).to.equal(365);
         });
 
     });
 
-    describe('#nextPowerOfTwo', () => {
+    describe('#nextPowerOfTwo', function () {
 
-        it('returns the next power of two', () => {
+        it('returns the next power of two', function () {
             expect(math.nextPowerOfTwo(0)).to.equal(0);
             expect(math.nextPowerOfTwo(1)).to.equal(1);
             expect(math.nextPowerOfTwo(2)).to.equal(2);
@@ -201,9 +201,9 @@ describe('math', () => {
 
     });
 
-    describe('#nearestPowerOfTwo', () => {
+    describe('#nearestPowerOfTwo', function () {
 
-        it('returns the nearest power of two', () => {
+        it('returns the nearest power of two', function () {
             expect(math.nearestPowerOfTwo(0)).to.equal(0);
             expect(math.nearestPowerOfTwo(1)).to.equal(1);
             expect(math.nearestPowerOfTwo(2)).to.equal(2);
@@ -218,9 +218,9 @@ describe('math', () => {
 
     });
 
-    describe('#powerOfTwo', () => {
+    describe('#powerOfTwo', function () {
 
-        it('returns true when the value is a power of two', () => {
+        it('returns true when the value is a power of two', function () {
             expect(math.powerOfTwo(1)).to.be.true;
             expect(math.powerOfTwo(2)).to.be.true;
             expect(math.powerOfTwo(4)).to.be.true;
@@ -233,7 +233,7 @@ describe('math', () => {
             expect(math.powerOfTwo(512)).to.be.true;
         });
 
-        it('returns false when the value is not a power of two', () => {
+        it('returns false when the value is not a power of two', function () {
             expect(math.powerOfTwo(0)).to.be.false;
             expect(math.powerOfTwo(3)).to.be.false;
             expect(math.powerOfTwo(5)).to.be.false;
@@ -248,9 +248,9 @@ describe('math', () => {
 
     });
 
-    describe('#random', () => {
+    describe('#random', function () {
 
-        it('returns a random number between 0 and 1', () => {
+        it('returns a random number between 0 and 1', function () {
             const r = math.random(100, 101);
             expect(r).to.be.at.least(100);
             expect(r).to.be.at.most(101);
@@ -258,9 +258,9 @@ describe('math', () => {
 
     });
 
-    describe('#roundUp', () => {
+    describe('#roundUp', function () {
 
-        it('rounds a number up to the nearest multiple', () => {
+        it('rounds a number up to the nearest multiple', function () {
             expect(math.roundUp(0, 2)).to.equal(0);
             expect(math.roundUp(0.5, 2)).to.equal(2);
             expect(math.roundUp(1, 2)).to.equal(2);
@@ -272,7 +272,7 @@ describe('math', () => {
             expect(math.roundUp(4, 2)).to.equal(4);
         });
 
-        it('returns number unchanged for multiples of 0', () => {
+        it('returns number unchanged for multiples of 0', function () {
             expect(math.roundUp(0, 0)).to.equal(0);
             expect(math.roundUp(0.5, 0)).to.equal(0.5);
             expect(math.roundUp(1, 0)).to.equal(1);
@@ -286,33 +286,33 @@ describe('math', () => {
 
     });
 
-    describe('#smootherstep', () => {
+    describe('#smootherstep', function () {
 
-        it('returns 0 when x equals min', () => {
+        it('returns 0 when x equals min', function () {
             expect(math.smootherstep(0, 10, 0)).to.equal(0);
         });
 
-        it('returns 0.5 when x is midway between min and max', () => {
+        it('returns 0.5 when x is midway between min and max', function () {
             expect(math.smootherstep(0, 10, 5)).to.equal(0.5);
         });
 
-        it('returns 1 when x equals max', () => {
+        it('returns 1 when x equals max', function () {
             expect(math.smootherstep(0, 10, 10)).to.equal(1);
         });
 
     });
 
-    describe('#smoothstep', () => {
+    describe('#smoothstep', function () {
 
-        it('returns 0 when x equals a', () => {
+        it('returns 0 when x equals a', function () {
             expect(math.smoothstep(0, 10, 0)).to.equal(0);
         });
 
-        it('returns 0.5 when x is midway between a and b', () => {
+        it('returns 0.5 when x is midway between a and b', function () {
             expect(math.smoothstep(0, 10, 5)).to.equal(0.5);
         });
 
-        it('returns 1 when x equals b', () => {
+        it('returns 1 when x equals b', function () {
             expect(math.smoothstep(0, 10, 10)).to.equal(1);
         });
 

--- a/test/core/math/quat.test.mjs
+++ b/test/core/math/quat.test.mjs
@@ -4,11 +4,11 @@ import { Vec3 } from '../../../src/core/math/vec3.js';
 
 import { expect } from 'chai';
 
-describe('Quat', () => {
+describe('Quat', function () {
 
-    describe('#constructor()', () => {
+    describe('#constructor()', function () {
 
-        it('supports zero arguments', () => {
+        it('supports zero arguments', function () {
             const q = new Quat();
             expect(q.x).to.equal(0);
             expect(q.y).to.equal(0);
@@ -16,7 +16,7 @@ describe('Quat', () => {
             expect(q.w).to.equal(1);
         });
 
-        it('supports number arguments', () => {
+        it('supports number arguments', function () {
             const q = new Quat(0.1, 0.2, 0.3, 0.4);
             expect(q.x).to.equal(0.1);
             expect(q.y).to.equal(0.2);
@@ -24,7 +24,7 @@ describe('Quat', () => {
             expect(q.w).to.equal(0.4);
         });
 
-        it('supports a 4 element array argument', () => {
+        it('supports a 4 element array argument', function () {
             const q = new Quat([0.1, 0.2, 0.3, 0.4]);
             expect(q.x).to.equal(0.1);
             expect(q.y).to.equal(0.2);
@@ -34,9 +34,9 @@ describe('Quat', () => {
 
     });
 
-    describe('#clone()', () => {
+    describe('#clone()', function () {
 
-        it('clones a quaternion', () => {
+        it('clones a quaternion', function () {
             const q1 = new Quat(0.1, 0.2, 0.3, 0.4);
             const q2 = q1.clone();
             expect(q2).to.not.equal(q1);
@@ -46,7 +46,7 @@ describe('Quat', () => {
             expect(q2.w).to.equal(0.4);
         });
 
-        it('ensures that an instance of a subclass keeps its class prototype', () => {
+        it('ensures that an instance of a subclass keeps its class prototype', function () {
             class UserQuat extends Quat {}
             const a = new UserQuat();
             const b = a.clone();
@@ -55,9 +55,9 @@ describe('Quat', () => {
 
     });
 
-    describe('#copy()', () => {
+    describe('#copy()', function () {
 
-        it('copies a quaternion', () => {
+        it('copies a quaternion', function () {
             const q1 = new Quat(0.1, 0.2, 0.3, 0.4);
             const q2 = new Quat();
             q2.copy(q1);
@@ -68,7 +68,7 @@ describe('Quat', () => {
             expect(q2.w).to.equal(0.4);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             expect(q1.copy(q2)).to.equal(q1);
@@ -76,26 +76,26 @@ describe('Quat', () => {
 
     });
 
-    describe('#equals()', () => {
+    describe('#equals()', function () {
 
-        it('checks for equality of the same quaternion', () => {
+        it('checks for equality of the same quaternion', function () {
             const q = new Quat(0.1, 0.2, 0.3, 0.4);
             expect(q.equals(q)).to.be.true;
         });
 
-        it('checks for equality of two different quaternions with the same values', () => {
+        it('checks for equality of two different quaternions with the same values', function () {
             const q1 = new Quat(0.1, 0.2, 0.3, 0.4);
             const q2 = new Quat(0.1, 0.2, 0.3, 0.4);
             expect(q1.equals(q2)).to.be.true;
         });
 
-        it('checks for equality of two different quaternions with different values', () => {
+        it('checks for equality of two different quaternions with different values', function () {
             const q1 = new Quat(0.1, 0.2, 0.3, 0.4);
             const q2 = new Quat(0.5, 0.6, 0.7, 0.8);
             expect(q1.equals(q2)).to.be.false;
         });
 
-        it('checks for equality of different quaternions that are close enough', () => {
+        it('checks for equality of different quaternions that are close enough', function () {
             const q1 = new Quat(0.1, 0.2, 0.3, 0.4);
             const q2 = new Quat(0.10000000000000001, 0.2, 0.3, 0.4);
             const epsilon = 0.000001;
@@ -111,9 +111,9 @@ describe('Quat', () => {
 
     });
 
-    describe('#getAxisAngle()', () => {
+    describe('#getAxisAngle()', function () {
 
-        it('returns the x axis and 0 angle for an identity quaternion', () => {
+        it('returns the x axis and 0 angle for an identity quaternion', function () {
             const q = new Quat();
             const axis = new Vec3();
             const angle = q.getAxisAngle(axis);
@@ -123,7 +123,7 @@ describe('Quat', () => {
             expect(axis.z).to.equal(0);
         });
 
-        it('returns what is set with setFromAxisAngle', () => {
+        it('returns what is set with setFromAxisAngle', function () {
             const q = new Quat();
             q.setFromAxisAngle(Vec3.UP, Math.PI / 2);
             const axis = new Vec3();
@@ -136,9 +136,9 @@ describe('Quat', () => {
 
     });
 
-    describe('#getEulerAngles()', () => {
+    describe('#getEulerAngles()', function () {
 
-        it('returns zeroes for an identity quaternion', () => {
+        it('returns zeroes for an identity quaternion', function () {
             const q = new Quat();
             const eulers = q.getEulerAngles();
             expect(eulers.x).to.equal(0);
@@ -146,7 +146,7 @@ describe('Quat', () => {
             expect(eulers.z).to.equal(0);
         });
 
-        it('returns zeroes for an identity quaternion (no allocation)', () => {
+        it('returns zeroes for an identity quaternion (no allocation)', function () {
             const q = new Quat();
             const eulers = new Vec3();
             q.getEulerAngles(eulers);
@@ -155,7 +155,7 @@ describe('Quat', () => {
             expect(eulers.z).to.equal(0);
         });
 
-        it('extracts a 180° turn around x axis', () => {
+        it('extracts a 180° turn around x axis', function () {
             const q = new Quat(1, 0, 0, 0);
             const eulers = new Vec3();
             q.getEulerAngles(eulers);
@@ -164,7 +164,7 @@ describe('Quat', () => {
             expect(eulers.z).to.equal(0);
         });
 
-        it('extracts a 180° turn around y axis', () => {
+        it('extracts a 180° turn around y axis', function () {
             const q = new Quat(0, 1, 0, 0);
             const eulers = new Vec3();
             q.getEulerAngles(eulers);
@@ -174,7 +174,7 @@ describe('Quat', () => {
             expect(eulers.z).to.equal(180);
         });
 
-        it('extracts a 180° turn around z axis', () => {
+        it('extracts a 180° turn around z axis', function () {
             const q = new Quat(0, 0, 1, 0);
             const eulers = new Vec3();
             q.getEulerAngles(eulers);
@@ -183,7 +183,7 @@ describe('Quat', () => {
             expect(eulers.z).to.equal(180);
         });
 
-        it('extracts a 90° turn around z axis', () => {
+        it('extracts a 90° turn around z axis', function () {
             const q = new Quat(Math.sqrt(0.5), 0, 0, Math.sqrt(0.5));
             const eulers = new Vec3();
             q.getEulerAngles(eulers);
@@ -192,7 +192,7 @@ describe('Quat', () => {
             expect(eulers.z).to.equal(0);
         });
 
-        it('extracts a 90° turn around y axis', () => {
+        it('extracts a 90° turn around y axis', function () {
             const q = new Quat(0, Math.sqrt(0.5), 0, Math.sqrt(0.5));
             const eulers = new Vec3();
             q.getEulerAngles(eulers);
@@ -201,7 +201,7 @@ describe('Quat', () => {
             expect(eulers.z).to.equal(0);
         });
 
-        it('extracts a 90° turn around z axis', () => {
+        it('extracts a 90° turn around z axis', function () {
             const q = new Quat(0, 0, Math.sqrt(0.5), Math.sqrt(0.5));
             const eulers = new Vec3();
             q.getEulerAngles(eulers);
@@ -210,7 +210,7 @@ describe('Quat', () => {
             expect(eulers.z).to.be.closeTo(90, 0.00001);
         });
 
-        it('extracts a -90° turn around x axis', () => {
+        it('extracts a -90° turn around x axis', function () {
             const q = new Quat(-Math.sqrt(0.5), 0, 0, Math.sqrt(0.5));
             const eulers = new Vec3();
             q.getEulerAngles(eulers);
@@ -219,7 +219,7 @@ describe('Quat', () => {
             expect(eulers.z).to.equal(0);
         });
 
-        it('extracts a -90° turn around y axis', () => {
+        it('extracts a -90° turn around y axis', function () {
             const q = new Quat(0, -Math.sqrt(0.5), 0, Math.sqrt(0.5));
             const eulers = new Vec3();
             q.getEulerAngles(eulers);
@@ -228,7 +228,7 @@ describe('Quat', () => {
             expect(eulers.z).to.equal(0);
         });
 
-        it('extracts a -90° turn around z axis', () => {
+        it('extracts a -90° turn around z axis', function () {
             const q = new Quat(0, 0, -Math.sqrt(0.5), Math.sqrt(0.5));
             const eulers = new Vec3();
             q.getEulerAngles(eulers);
@@ -239,15 +239,15 @@ describe('Quat', () => {
 
     });
 
-    describe('#invert()', () => {
+    describe('#invert()', function () {
 
-        it('leaves the identity quaternion unchanged', () => {
+        it('leaves the identity quaternion unchanged', function () {
             const q = new Quat();
             q.invert();
             expect(q.equals(Quat.IDENTITY)).to.be.true;
         });
 
-        it('leaves the quaternion unchanged if applied twice', () => {
+        it('leaves the quaternion unchanged if applied twice', function () {
             const q = new Quat();
             q.setFromEulerAngles(10, 20, 30);
             const original = q.clone();
@@ -256,51 +256,51 @@ describe('Quat', () => {
             expect(q.equals(original)).to.be.true;
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q = new Quat();
             expect(q.invert()).to.equal(q);
         });
 
     });
 
-    describe('#length()', () => {
+    describe('#length()', function () {
 
-        it('returns 1 for the identity quaternion', () => {
+        it('returns 1 for the identity quaternion', function () {
             const q = new Quat();
             expect(q.length()).to.equal(1);
         });
 
-        it('returns the correct length for a non-identity quaternion', () => {
+        it('returns the correct length for a non-identity quaternion', function () {
             const q = new Quat(1, 2, 3, 4);
             expect(q.length()).to.equal(Math.sqrt(30));
         });
 
     });
 
-    describe('#lengthSq()', () => {
+    describe('#lengthSq()', function () {
 
-        it('returns 1 for the identity quaternion', () => {
+        it('returns 1 for the identity quaternion', function () {
             const q = new Quat();
             expect(q.lengthSq()).to.equal(1);
         });
 
-        it('returns the correct squared length for a non-identity quaternion', () => {
+        it('returns the correct squared length for a non-identity quaternion', function () {
             const q = new Quat(1, 2, 3, 4);
             expect(q.lengthSq()).to.equal(30);
         });
 
     });
 
-    describe('#mul()', () => {
+    describe('#mul()', function () {
 
-        it('sets the identity when multiplying the identity by the identity (I * I = I)', () => {
+        it('sets the identity when multiplying the identity by the identity (I * I = I)', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             q1.mul(q2);
             expect(q1.equals(Quat.IDENTITY)).to.be.true;
         });
 
-        it('leaves matrix unchanged when multiplying by the identity ( A * I = A )', () => {
+        it('leaves matrix unchanged when multiplying by the identity ( A * I = A )', function () {
             const q1 = new Quat();
             q1.setFromEulerAngles(10, 20, 30);
             const q2 = new Quat();
@@ -311,7 +311,7 @@ describe('Quat', () => {
             expect(eulers.z).to.be.closeTo(30, 0.00001);
         });
 
-        it('sets a quaternion to the right hand side when left hand side is identity ( I * A = A )', () => {
+        it('sets a quaternion to the right hand side when left hand side is identity ( I * A = A )', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             q2.setFromEulerAngles(10, 20, 30);
@@ -322,7 +322,7 @@ describe('Quat', () => {
             expect(eulers.z).to.be.closeTo(30, 0.00001);
         });
 
-        it('multiplies an arbitrary quaternion with another in place', () => {
+        it('multiplies an arbitrary quaternion with another in place', function () {
             const q1 = new Quat();
             q1.setFromEulerAngles(10, 20, 30);
             const q2 = new Quat();
@@ -334,7 +334,7 @@ describe('Quat', () => {
             expect(eulers.z).to.be.closeTo(113.547040698283, 0.00001);
         });
 
-        it('sets the identity quaternion when multiplying by the inverse', () => {
+        it('sets the identity quaternion when multiplying by the inverse', function () {
             const q1 = new Quat();
             q1.setFromEulerAngles(10, 20, 30);
             const q2 = q1.clone().invert();
@@ -345,7 +345,7 @@ describe('Quat', () => {
             expect(q1.w).to.be.closeTo(1, 0.00001);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             expect(q1.mul(q2)).to.equal(q1);
@@ -353,9 +353,9 @@ describe('Quat', () => {
 
     });
 
-    describe('#mul2()', () => {
+    describe('#mul2()', function () {
 
-        it('sets the identity when multiplying the identity by the identity (I * I = I)', () => {
+        it('sets the identity when multiplying the identity by the identity (I * I = I)', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             const q3 = new Quat();
@@ -363,7 +363,7 @@ describe('Quat', () => {
             expect(q1.equals(Quat.IDENTITY)).to.be.true;
         });
 
-        it('leaves matrix unchanged when multiplying by the identity ( A * I = A )', () => {
+        it('leaves matrix unchanged when multiplying by the identity ( A * I = A )', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             q2.setFromEulerAngles(10, 20, 30);
@@ -375,7 +375,7 @@ describe('Quat', () => {
             expect(eulers.z).to.be.closeTo(30, 0.00001);
         });
 
-        it('sets a quaternion to the right hand side when left hand side is identity ( I * A = A )', () => {
+        it('sets a quaternion to the right hand side when left hand side is identity ( I * A = A )', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             const q3 = new Quat();
@@ -387,7 +387,7 @@ describe('Quat', () => {
             expect(eulers.z).to.be.closeTo(30, 0.00001);
         });
 
-        it('multiplies an arbitrary quaternion with another in place', () => {
+        it('multiplies an arbitrary quaternion with another in place', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             q2.setFromEulerAngles(10, 20, 30);
@@ -400,7 +400,7 @@ describe('Quat', () => {
             expect(eulers.z).to.be.closeTo(113.547040698283, 0.00001);
         });
 
-        it('sets the identity quaternion when multiplying by the inverse', () => {
+        it('sets the identity quaternion when multiplying by the inverse', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             q2.setFromEulerAngles(10, 20, 30);
@@ -412,7 +412,7 @@ describe('Quat', () => {
             expect(q1.w).to.be.closeTo(1, 0.00001);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             const q3 = new Quat();
@@ -421,30 +421,30 @@ describe('Quat', () => {
 
     });
 
-    describe('#normalize()', () => {
+    describe('#normalize()', function () {
 
-        it('leaves the identity quaternion unchanged', () => {
+        it('leaves the identity quaternion unchanged', function () {
             const q = new Quat();
             q.normalize();
             expect(q.equals(Quat.IDENTITY)).to.be.true;
         });
 
-        it('makes an arbitrary quaternion have length 1', () => {
+        it('makes an arbitrary quaternion have length 1', function () {
             const q = new Quat(1, 2, 3, 4);
             q.normalize();
             expect(q.length()).to.be.closeTo(1, 0.00001);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q = new Quat();
             expect(q.normalize()).to.equal(q);
         });
 
     });
 
-    describe('#set()', () => {
+    describe('#set()', function () {
 
-        it('sets the quaternion', () => {
+        it('sets the quaternion', function () {
             const q = new Quat();
             q.set(0.1, 0.2, 0.3, 0.4);
             expect(q.x).to.equal(0.1);
@@ -453,22 +453,22 @@ describe('Quat', () => {
             expect(q.w).to.equal(0.4);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q = new Quat();
             expect(q.set(0.1, 0.2, 0.3, 0.4)).to.equal(q);
         });
 
     });
 
-    describe('#setFromAxisAngle()', () => {
+    describe('#setFromAxisAngle()', function () {
 
-        it('sets the identity quaternion when passing a zero angle', () => {
+        it('sets the identity quaternion when passing a zero angle', function () {
             const q = new Quat();
             q.setFromAxisAngle(Vec3.UP, 0);
             expect(q.equals(Quat.IDENTITY)).to.be.true;
         });
 
-        it('sets an approximation of the identity quaternion when passing a multiple of 360', () => {
+        it('sets an approximation of the identity quaternion when passing a multiple of 360', function () {
             const q = new Quat();
             q.setFromAxisAngle(Vec3.UP, 720);
             expect(q.x).to.be.closeTo(0, 0.00001);
@@ -477,7 +477,7 @@ describe('Quat', () => {
             expect(q.w).to.be.closeTo(1, 0.00001);
         });
 
-        it('set a quaternion of 90 around the x axis', () => {
+        it('set a quaternion of 90 around the x axis', function () {
             const q = new Quat();
             q.setFromAxisAngle(Vec3.RIGHT, 90);
             expect(q.x).to.be.closeTo(0.7071067811865475, 0.00001);
@@ -486,14 +486,14 @@ describe('Quat', () => {
             expect(q.w).to.be.closeTo(0.7071067811865476, 0.00001);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q = new Quat();
             expect(q.setFromAxisAngle(Vec3.UP, 0)).to.equal(q);
         });
 
     });
 
-    describe('#setFromEulerAngles()', () => {
+    describe('#setFromEulerAngles()', function () {
 
         [
             [0, 0, 0],
@@ -527,16 +527,16 @@ describe('Quat', () => {
             });
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q = new Quat();
             expect(q.setFromEulerAngles(0, 0, 0)).to.equal(q);
         });
 
     });
 
-    describe('#setFromMat4()', () => {
+    describe('#setFromMat4()', function () {
 
-        it('set the identity quaternion from an identity matrix', () => {
+        it('set the identity quaternion from an identity matrix', function () {
             const q = new Quat();
             const m = new Mat4();
             q.setFromMat4(m);
@@ -569,7 +569,7 @@ describe('Quat', () => {
             return result;
         };
 
-        it('set the quaternion from a non-identity matrix', () => {
+        it('set the quaternion from a non-identity matrix', function () {
             const q = new Quat();
             const m = new Mat4();
             m.setFromEulerAngles(10, 20, 30);
@@ -580,14 +580,14 @@ describe('Quat', () => {
             expect(eulers.z).to.be.closeTo(30, 0.00001);
         });
 
-        it('converts rot180', () => {
+        it('converts rot180', function () {
             expect(quatToMatToQuat(1, 0, 0, 0)).to.be.true;
             expect(quatToMatToQuat(0, 1, 0, 0)).to.be.true;
             expect(quatToMatToQuat(0, 0, 1, 0)).to.be.true;
             expect(quatToMatToQuat(0, 0, 0, 1)).to.be.true;
         });
 
-        it('converts rot180n', () => {
+        it('converts rot180n', function () {
             expect(quatToMatToQuat(-1, 0, 0, 0)).to.be.true;
             expect(quatToMatToQuat(-1e-20, -1, 0, 0)).to.be.true;
             expect(quatToMatToQuat(-1e-20, 0, -1, 0)).to.be.true;
@@ -596,7 +596,7 @@ describe('Quat', () => {
 
         const s2 = 1 / Math.sqrt(2);
 
-        it('converts rot90', () => {
+        it('converts rot90', function () {
             expect(quatToMatToQuat(s2, s2, 0, 0)).to.be.true;
             expect(quatToMatToQuat(s2, -s2, 0, 0)).to.be.true;
             expect(quatToMatToQuat(s2, 0, s2, 0)).to.be.true;
@@ -605,7 +605,7 @@ describe('Quat', () => {
             expect(quatToMatToQuat(s2, 0, 0, -s2)).to.be.true;
         });
 
-        it('converts rot90n', () => {
+        it('converts rot90n', function () {
             expect(quatToMatToQuat(-s2, s2, 0, 0)).to.be.true;
             expect(quatToMatToQuat(-s2, -s2, 0, 0)).to.be.true;
             expect(quatToMatToQuat(-s2, 0, s2, 0)).to.be.true;
@@ -614,7 +614,7 @@ describe('Quat', () => {
             expect(quatToMatToQuat(-s2, 0, 0, -s2)).to.be.true;
         });
 
-        it('converts suit', () => {
+        it('converts suit', function () {
             const vals = [0.9999, -0.002, -0.999, 0.01, 0, 1];
 
             vals.forEach((x) => {
@@ -628,7 +628,7 @@ describe('Quat', () => {
             });
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q = new Quat();
             const m = new Mat4();
             expect(q.setFromMat4(m)).to.equal(q);
@@ -636,9 +636,9 @@ describe('Quat', () => {
 
     });
 
-    describe('#setFromDirections()', () => {
+    describe('#setFromDirections()', function () {
 
-        it('set the identity quaternion from equal directions', () => {
+        it('set the identity quaternion from equal directions', function () {
             const v1 = new Vec3(1, 0, 0);
             const v2 = new Vec3(1, 0, 0);
 
@@ -653,7 +653,7 @@ describe('Quat', () => {
             expect(q2.equals(Quat.IDENTITY)).to.be.true;
         });
 
-        it('set a quaternion from different directions', () => {
+        it('set a quaternion from different directions', function () {
             const v1 = new Vec3(1, 0, 0);
             const v2 = new Vec3(0, 1, 0);
 
@@ -675,7 +675,7 @@ describe('Quat', () => {
 
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q = new Quat();
             const v1 = new Vec3();
             const v2 = new Vec3();
@@ -684,9 +684,9 @@ describe('Quat', () => {
 
     });
 
-    describe('#slerp()', () => {
+    describe('#slerp()', function () {
 
-        it('return first quaternion when alpha is 0', () => {
+        it('return first quaternion when alpha is 0', function () {
             const q1 = new Quat();
             q1.setFromEulerAngles(10, 20, 30);
             const q2 = new Quat();
@@ -699,7 +699,7 @@ describe('Quat', () => {
             expect(q.w).to.be.closeTo(q1.w, 0.00001);
         });
 
-        it('return second quaternion when alpha is 1', () => {
+        it('return second quaternion when alpha is 1', function () {
             const q1 = new Quat();
             q1.setFromEulerAngles(10, 20, 30);
             const q2 = new Quat();
@@ -712,7 +712,7 @@ describe('Quat', () => {
             expect(q.w).to.be.closeTo(q2.w, 0.00001);
         });
 
-        it('returns the correct quaternion when alpha is 0.5', () => {
+        it('returns the correct quaternion when alpha is 0.5', function () {
             const q1 = new Quat();
             q1.setFromEulerAngles(0, 0, 10);
             const q2 = new Quat();
@@ -725,7 +725,7 @@ describe('Quat', () => {
             expect(eulers.z).to.be.closeTo(15, 0.00001);
         });
 
-        it('returns this', () => {
+        it('returns this', function () {
             const q1 = new Quat();
             const q2 = new Quat();
             const q = new Quat();
@@ -734,25 +734,25 @@ describe('Quat', () => {
 
     });
 
-    describe('#toString()', () => {
+    describe('#toString()', function () {
 
-        it('returns a string representation of the quaternion', () => {
+        it('returns a string representation of the quaternion', function () {
             const q = new Quat(0.1, 0.2, 0.3, 0.4);
             expect(q.toString()).to.equal('[0.1, 0.2, 0.3, 0.4]');
         });
 
     });
 
-    describe('#transformVector()', () => {
+    describe('#transformVector()', function () {
 
-        it('leaves vector unchanged when transforming by the identity quaternion', () => {
+        it('leaves vector unchanged when transforming by the identity quaternion', function () {
             const v = new Vec3(1, 2, 3);
             const q = new Quat();
             const r = q.transformVector(v);
             expect(v.equals(r)).to.be.true;
         });
 
-        it('leaves vector unchanged when transforming by the identity quaternion (no allocation)', () => {
+        it('leaves vector unchanged when transforming by the identity quaternion (no allocation)', function () {
             const v = new Vec3(1, 2, 3);
             const q = new Quat();
             const r = new Vec3();
@@ -760,7 +760,7 @@ describe('Quat', () => {
             expect(v.equals(r)).to.be.true;
         });
 
-        it('transforms a vector by a 90 degree rotation around the z axis', () => {
+        it('transforms a vector by a 90 degree rotation around the z axis', function () {
             const v = new Vec3(1, 0, 0);
             const q = new Quat();
             const r = new Vec3();
@@ -773,7 +773,7 @@ describe('Quat', () => {
             expect(r.z).to.be.closeTo(0, 0.00001);
         });
 
-        it('transforms a vector by a 90 degree rotation around the z axis (input and output vectors are the same)', () => {
+        it('transforms a vector by a 90 degree rotation around the z axis (input and output vectors are the same)', function () {
             const v = new Vec3(1, 0, 0);
             const q = new Quat();
 

--- a/test/core/math/vec2.test.mjs
+++ b/test/core/math/vec2.test.mjs
@@ -2,23 +2,23 @@ import { Vec2 } from '../../../src/core/math/vec2.js';
 
 import { expect } from 'chai';
 
-describe('Vec2', () => {
+describe('Vec2', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('supports zero arguments', () => {
+        it('supports zero arguments', function () {
             const v = new Vec2();
             expect(v.x).to.equal(0);
             expect(v.y).to.equal(0);
         });
 
-        it('supports number arguments', () => {
+        it('supports number arguments', function () {
             const v = new Vec2(1, 2);
             expect(v.x).to.equal(1);
             expect(v.y).to.equal(2);
         });
 
-        it('supports an array argument', () => {
+        it('supports an array argument', function () {
             const v = new Vec2([1, 2]);
             expect(v.x).to.equal(1);
             expect(v.y).to.equal(2);
@@ -26,9 +26,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#add', () => {
+    describe('#add', function () {
 
-        it('adds a vector to another in place', () => {
+        it('adds a vector to another in place', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             v1.add(v2);
@@ -36,7 +36,7 @@ describe('Vec2', () => {
             expect(v1.y).to.equal(6);
         });
 
-        it('adds a vector to itself in place', () => {
+        it('adds a vector to itself in place', function () {
             const v1 = new Vec2(1, 2);
             v1.add(v1);
             expect(v1.x).to.equal(2);
@@ -45,9 +45,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#add2', () => {
+    describe('#add2', function () {
 
-        it('adds two vectors together and writes result to a third vector', () => {
+        it('adds two vectors together and writes result to a third vector', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             const v3 = new Vec2();
@@ -56,7 +56,7 @@ describe('Vec2', () => {
             expect(v3.y).to.equal(6);
         });
 
-        it('adds a vector to itself and writes result to itself', () => {
+        it('adds a vector to itself and writes result to itself', function () {
             const v1 = new Vec2(1, 2);
             v1.add2(v1, v1);
             expect(v1.x).to.equal(2);
@@ -65,9 +65,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#addScalar', () => {
+    describe('#addScalar', function () {
 
-        it('adds a scalar in place', () => {
+        it('adds a scalar in place', function () {
             const v = new Vec2(1, 2);
             v.addScalar(2);
             expect(v.x).to.equal(3);
@@ -76,9 +76,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#addScaled', () => {
+    describe('#addScaled', function () {
 
-        it('adds a scaled vector', () => {
+        it('adds a scaled vector', function () {
             const v = new Vec2(1, 2);
             v.addScaled(Vec2.UP, 2);
             expect(v.x).to.equal(1);
@@ -87,16 +87,16 @@ describe('Vec2', () => {
 
     });
 
-    describe('#ceil', () => {
+    describe('#ceil', function () {
 
-        it('leaves integers unchanged', () => {
+        it('leaves integers unchanged', function () {
             const v = new Vec2(1, 2);
             v.ceil();
             expect(v.x).to.equal(1);
             expect(v.y).to.equal(2);
         });
 
-        it('calculates the ceil of all components', () => {
+        it('calculates the ceil of all components', function () {
             const v = new Vec2(1.1, 2.2);
             v.ceil();
             expect(v.x).to.equal(2);
@@ -105,9 +105,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#clone', () => {
+    describe('#clone', function () {
 
-        it('clones a vector', () => {
+        it('clones a vector', function () {
             const v1 = new Vec2(1, 2);
             const v2 = v1.clone();
             expect(v2).to.be.instanceof(Vec2);
@@ -115,7 +115,7 @@ describe('Vec2', () => {
             expect(v2.y).to.equal(2);
         });
 
-        it('ensures that an instance of a subclass keeps its class prototype', () => {
+        it('ensures that an instance of a subclass keeps its class prototype', function () {
             class UserVec2 extends Vec2 {}
             const a = new UserVec2();
             const b = a.clone();
@@ -124,9 +124,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#copy', () => {
+    describe('#copy', function () {
 
-        it('copies a vector', () => {
+        it('copies a vector', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2();
             v2.copy(v1);
@@ -136,9 +136,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#cross', () => {
+    describe('#cross', function () {
 
-        it('calculates cross product of two vectors', () => {
+        it('calculates cross product of two vectors', function () {
             const v1 = new Vec2(1, 0);
             const v2 = new Vec2(0, 1);
             expect(v1.cross(v2)).to.equal(1);
@@ -146,16 +146,16 @@ describe('Vec2', () => {
 
     });
 
-    describe('#distance', () => {
+    describe('#distance', function () {
 
-        it('calculates the distance between two vectors', () => {
+        it('calculates the distance between two vectors', function () {
             const v1 = new Vec2();
             const v2 = new Vec2(10, 0);
             const distance = v1.distance(v2);
             expect(distance).to.equal(10);
         });
 
-        it('returns zero for the distance between the same vector', () => {
+        it('returns zero for the distance between the same vector', function () {
             const v1 = new Vec2(10, 0);
             const distance = v1.distance(v1);
             expect(distance).to.equal(0);
@@ -163,9 +163,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#div', () => {
+    describe('#div', function () {
 
-        it('divides a vector by another in place', () => {
+        it('divides a vector by another in place', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             v1.div(v2);
@@ -173,7 +173,7 @@ describe('Vec2', () => {
             expect(v1.y).to.equal(0.5);
         });
 
-        it('divides a vector by itself in place', () => {
+        it('divides a vector by itself in place', function () {
             const v1 = new Vec2(1, 2);
             v1.div(v1);
             expect(v1.x).to.equal(1);
@@ -182,9 +182,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#div2', () => {
+    describe('#div2', function () {
 
-        it('divides a vector by another vector and writes the result to a third vector', () => {
+        it('divides a vector by another vector and writes the result to a third vector', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             const v3 = new Vec2();
@@ -193,7 +193,7 @@ describe('Vec2', () => {
             expect(v3.y).to.equal(0.5);
         });
 
-        it('divides a vector by itself and writes the result to itself', () => {
+        it('divides a vector by itself and writes the result to itself', function () {
             const v1 = new Vec2(1, 2);
             v1.div2(v1, v1);
             expect(v1.x).to.equal(1);
@@ -202,9 +202,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#divScalar', () => {
+    describe('#divScalar', function () {
 
-        it('divides a vector by a scalar in place', () => {
+        it('divides a vector by a scalar in place', function () {
             const v = new Vec2(1, 2);
             v.divScalar(2);
             expect(v.x).to.equal(0.5);
@@ -213,21 +213,21 @@ describe('Vec2', () => {
 
     });
 
-    describe('#dot', () => {
+    describe('#dot', function () {
 
-        it('calculates dot product of two arbitrary non-unit vectors', () => {
+        it('calculates dot product of two arbitrary non-unit vectors', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             expect(v1.dot(v2)).to.equal(11);
         });
 
-        it('calculates dot product of two parallel unit vectors', () => {
+        it('calculates dot product of two parallel unit vectors', function () {
             const v1 = new Vec2(1, 0);
             const v2 = new Vec2(1, 0);
             expect(v1.dot(v2)).to.equal(1);
         });
 
-        it('calculates dot product of two perpendicular unit vectors', () => {
+        it('calculates dot product of two perpendicular unit vectors', function () {
             const v1 = new Vec2(1, 0);
             const v2 = new Vec2(0, 1);
             expect(v1.dot(v2)).to.equal(0);
@@ -235,26 +235,26 @@ describe('Vec2', () => {
 
     });
 
-    describe('#equals', () => {
+    describe('#equals', function () {
 
-        it('checks for equality of the same vector', () => {
+        it('checks for equality of the same vector', function () {
             const v = new Vec2(1, 2);
             expect(v.equals(v)).to.be.true;
         });
 
-        it('checks for equality of two different vectors with the same values', () => {
+        it('checks for equality of two different vectors with the same values', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(1, 2);
             expect(v1.equals(v2)).to.be.true;
         });
 
-        it('checks for equality of two different vectors with different values', () => {
+        it('checks for equality of two different vectors with different values', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             expect(v1.equals(v2)).to.be.false;
         });
 
-        it('checks for equality of different vectors that are close enough', () => {
+        it('checks for equality of different vectors that are close enough', function () {
             const v1 = new Vec2(0.1, 0.2);
             const v2 = new Vec2(0.10000000000000001, 0.2);
             const epsilon = 0.000001;
@@ -270,16 +270,16 @@ describe('Vec2', () => {
 
     });
 
-    describe('#floor', () => {
+    describe('#floor', function () {
 
-        it('leaves integers unchanged', () => {
+        it('leaves integers unchanged', function () {
             const v = new Vec2(1, 2);
             v.floor();
             expect(v.x).to.equal(1);
             expect(v.y).to.equal(2);
         });
 
-        it('rounds down floating point numbers', () => {
+        it('rounds down floating point numbers', function () {
             const v = new Vec2(1.1, 2.2);
             v.floor();
             expect(v.x).to.equal(1);
@@ -288,37 +288,37 @@ describe('Vec2', () => {
 
     });
 
-    describe('#length', () => {
+    describe('#length', function () {
 
-        it('calculates the length of a zero length vector', () => {
+        it('calculates the length of a zero length vector', function () {
             const v = new Vec2();
             expect(v.length()).to.equal(0);
         });
 
-        it('calculates the length of a vector', () => {
+        it('calculates the length of a vector', function () {
             const v = new Vec2(3, 4);
             expect(v.length()).to.equal(5);
         });
 
     });
 
-    describe('#lengthSq', () => {
+    describe('#lengthSq', function () {
 
-        it('calculates the length squared of a zero length vector', () => {
+        it('calculates the length squared of a zero length vector', function () {
             const v = new Vec2();
             expect(v.length()).to.equal(0);
         });
 
-        it('calculates the length squared of a vector', () => {
+        it('calculates the length squared of a vector', function () {
             const v = new Vec2(3, 4);
             expect(v.lengthSq()).to.equal(25);
         });
 
     });
 
-    describe('#lerp', () => {
+    describe('#lerp', function () {
 
-        it('linearly interpolates between two vectors with alpha of 0', () => {
+        it('linearly interpolates between two vectors with alpha of 0', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             const v3 = new Vec2();
@@ -327,7 +327,7 @@ describe('Vec2', () => {
             expect(v3.y).to.equal(2);
         });
 
-        it('linearly interpolates between two vectors with alpha of 0.5', () => {
+        it('linearly interpolates between two vectors with alpha of 0.5', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             const v3 = new Vec2();
@@ -336,7 +336,7 @@ describe('Vec2', () => {
             expect(v3.y).to.equal(3);
         });
 
-        it('linearly interpolates between two vectors with alpha of 1', () => {
+        it('linearly interpolates between two vectors with alpha of 1', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             const v3 = new Vec2();
@@ -347,9 +347,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#max', () => {
+    describe('#max', function () {
 
-        it('handles left hand larger than right hand', () => {
+        it('handles left hand larger than right hand', function () {
             const v1 = new Vec2(3, 4);
             const v2 = new Vec2(1, 2);
             v1.max(v2);
@@ -357,7 +357,7 @@ describe('Vec2', () => {
             expect(v1.y).to.equal(4);
         });
 
-        it('handles right hand larger than left hand', () => {
+        it('handles right hand larger than left hand', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             v1.max(v2);
@@ -367,9 +367,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#min', () => {
+    describe('#min', function () {
 
-        it('handles left hand larger than right hand', () => {
+        it('handles left hand larger than right hand', function () {
             const v1 = new Vec2(3, 4);
             const v2 = new Vec2(1, 2);
             v1.min(v2);
@@ -377,7 +377,7 @@ describe('Vec2', () => {
             expect(v1.y).to.equal(2);
         });
 
-        it('handles right hand larger than left hand', () => {
+        it('handles right hand larger than left hand', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             v1.min(v2);
@@ -387,9 +387,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#mul', () => {
+    describe('#mul', function () {
 
-        it('multiplies a vector by another in place', () => {
+        it('multiplies a vector by another in place', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             v1.mul(v2);
@@ -397,7 +397,7 @@ describe('Vec2', () => {
             expect(v1.y).to.equal(8);
         });
 
-        it('multiplies a vector by itself in place', () => {
+        it('multiplies a vector by itself in place', function () {
             const v1 = new Vec2(1, 2);
             v1.mul(v1);
             expect(v1.x).to.equal(1);
@@ -406,9 +406,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#mul2', () => {
+    describe('#mul2', function () {
 
-        it('multiplies a vector by another vector and writes the result to a third vector', () => {
+        it('multiplies a vector by another vector and writes the result to a third vector', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             const v3 = new Vec2();
@@ -417,7 +417,7 @@ describe('Vec2', () => {
             expect(v3.y).to.equal(8);
         });
 
-        it('multiplies a vector by itself and writes the result to itself', () => {
+        it('multiplies a vector by itself and writes the result to itself', function () {
             const v1 = new Vec2(1, 2);
             v1.mul2(v1, v1);
             expect(v1.x).to.equal(1);
@@ -426,9 +426,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#mulScalar', () => {
+    describe('#mulScalar', function () {
 
-        it('multiplies a vector by a scalar in place', () => {
+        it('multiplies a vector by a scalar in place', function () {
             const v = new Vec2(1, 2);
             v.mulScalar(2);
             expect(v.x).to.equal(2);
@@ -437,16 +437,16 @@ describe('Vec2', () => {
 
     });
 
-    describe('#normalize', () => {
+    describe('#normalize', function () {
 
-        it('handles a zero length vector', () => {
+        it('handles a zero length vector', function () {
             const v = new Vec2();
             v.normalize();
             expect(v.x).to.equal(0);
             expect(v.y).to.equal(0);
         });
 
-        it('handles a non-zero length vector', () => {
+        it('handles a non-zero length vector', function () {
             const v = new Vec2(1, 2);
             v.normalize();
             expect(v.length()).to.be.closeTo(1, 0.00001);
@@ -454,16 +454,16 @@ describe('Vec2', () => {
 
     });
 
-    describe('#round', () => {
+    describe('#round', function () {
 
-        it('leaves integers unchanged', () => {
+        it('leaves integers unchanged', function () {
             const v = new Vec2(1, 2);
             v.round();
             expect(v.x).to.equal(1);
             expect(v.y).to.equal(2);
         });
 
-        it('rounds floating point numbers to the nearest integer', () => {
+        it('rounds floating point numbers to the nearest integer', function () {
             const v = new Vec2(1.1, 2.2);
             v.round();
             expect(v.x).to.equal(1);
@@ -472,9 +472,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#set', () => {
+    describe('#set', function () {
 
-        it('sets a vector to number values', () => {
+        it('sets a vector to number values', function () {
             const v = new Vec2();
             v.set(1, 2);
             expect(v.x).to.equal(1);
@@ -483,9 +483,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#sub', () => {
+    describe('#sub', function () {
 
-        it('subtracts a vector from another in place', () => {
+        it('subtracts a vector from another in place', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             v1.sub(v2);
@@ -493,7 +493,7 @@ describe('Vec2', () => {
             expect(v1.y).to.equal(-2);
         });
 
-        it('subtracts a vector from itself in place', () => {
+        it('subtracts a vector from itself in place', function () {
             const v1 = new Vec2(1, 2);
             v1.sub(v1);
             expect(v1.x).to.equal(0);
@@ -502,9 +502,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#sub2', () => {
+    describe('#sub2', function () {
 
-        it('subtracts a vector from another vector and writes the result to a third vector', () => {
+        it('subtracts a vector from another vector and writes the result to a third vector', function () {
             const v1 = new Vec2(1, 2);
             const v2 = new Vec2(3, 4);
             const v3 = new Vec2();
@@ -513,7 +513,7 @@ describe('Vec2', () => {
             expect(v3.y).to.equal(-2);
         });
 
-        it('subtracts a vector from itself and writes the result to itself', () => {
+        it('subtracts a vector from itself and writes the result to itself', function () {
             const v1 = new Vec2(1, 2);
             v1.sub2(v1, v1);
             expect(v1.x).to.equal(0);
@@ -522,9 +522,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#subScalar', () => {
+    describe('#subScalar', function () {
 
-        it('subtracts a scalar from a vector in place', () => {
+        it('subtracts a scalar from a vector in place', function () {
             const v = new Vec2(1, 2);
             v.subScalar(2);
             expect(v.x).to.equal(-1);
@@ -533,9 +533,9 @@ describe('Vec2', () => {
 
     });
 
-    describe('#toString', () => {
+    describe('#toString', function () {
 
-        it('returns a string representation of a vector', () => {
+        it('returns a string representation of a vector', function () {
             const v = new Vec2(1, 2);
             expect(v.toString()).to.equal('[1, 2]');
         });

--- a/test/core/math/vec3.test.mjs
+++ b/test/core/math/vec3.test.mjs
@@ -2,25 +2,25 @@ import { Vec3 } from '../../../src/core/math/vec3.js';
 
 import { expect } from 'chai';
 
-describe('Vec3', () => {
+describe('Vec3', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('supports zero arguments', () => {
+        it('supports zero arguments', function () {
             const v = new Vec3();
             expect(v.x).to.equal(0);
             expect(v.y).to.equal(0);
             expect(v.z).to.equal(0);
         });
 
-        it('supports number arguments', () => {
+        it('supports number arguments', function () {
             const v = new Vec3(1, 2, 3);
             expect(v.x).to.equal(1);
             expect(v.y).to.equal(2);
             expect(v.z).to.equal(3);
         });
 
-        it('supports an array argument', () => {
+        it('supports an array argument', function () {
             const v = new Vec3([1, 2, 3]);
             expect(v.x).to.equal(1);
             expect(v.y).to.equal(2);
@@ -29,9 +29,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#add', () => {
+    describe('#add', function () {
 
-        it('adds a vector to another in place', () => {
+        it('adds a vector to another in place', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             v1.add(v2);
@@ -40,7 +40,7 @@ describe('Vec3', () => {
             expect(v1.z).to.equal(9);
         });
 
-        it('adds a vector to itself in place', () => {
+        it('adds a vector to itself in place', function () {
             const v1 = new Vec3(1, 2, 3);
             v1.add(v1);
             expect(v1.x).to.equal(2);
@@ -50,9 +50,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#add2', () => {
+    describe('#add2', function () {
 
-        it('adds two vectors together and writes result to a third vector', () => {
+        it('adds two vectors together and writes result to a third vector', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             const v3 = new Vec3();
@@ -62,7 +62,7 @@ describe('Vec3', () => {
             expect(v3.z).to.equal(9);
         });
 
-        it('adds a vector to itself and writes result to itself', () => {
+        it('adds a vector to itself and writes result to itself', function () {
             const v1 = new Vec3(1, 2, 3);
             v1.add2(v1, v1);
             expect(v1.x).to.equal(2);
@@ -72,9 +72,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#addScalar', () => {
+    describe('#addScalar', function () {
 
-        it('adds a scalar in place', () => {
+        it('adds a scalar in place', function () {
             const v = new Vec3(1, 2, 3);
             v.addScalar(2);
             expect(v.x).to.equal(3);
@@ -84,9 +84,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#addScaled', () => {
+    describe('#addScaled', function () {
 
-        it('adds a scaled vector', () => {
+        it('adds a scaled vector', function () {
             const v = new Vec3(1, 2, 3);
             v.addScaled(Vec3.UP, 2);
             expect(v.x).to.equal(1);
@@ -96,9 +96,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#ceil', () => {
+    describe('#ceil', function () {
 
-        it('leaves integers unchanged', () => {
+        it('leaves integers unchanged', function () {
             const v = new Vec3(1, 2, 3);
             v.ceil();
             expect(v.x).to.equal(1);
@@ -106,7 +106,7 @@ describe('Vec3', () => {
             expect(v.z).to.equal(3);
         });
 
-        it('calculates the ceil of all components', () => {
+        it('calculates the ceil of all components', function () {
             const v = new Vec3(1.1, 2.2, 3.3);
             v.ceil();
             expect(v.x).to.equal(2);
@@ -116,9 +116,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#clone', () => {
+    describe('#clone', function () {
 
-        it('clones a vector', () => {
+        it('clones a vector', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = v1.clone();
             expect(v2).to.be.instanceof(Vec3);
@@ -127,7 +127,7 @@ describe('Vec3', () => {
             expect(v2.z).to.equal(3);
         });
 
-        it('ensures that an instance of a subclass keeps its class prototype', () => {
+        it('ensures that an instance of a subclass keeps its class prototype', function () {
             class UserVec3 extends Vec3 {}
             const a = new UserVec3();
             const b = a.clone();
@@ -136,9 +136,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#copy', () => {
+    describe('#copy', function () {
 
-        it('copies a vector', () => {
+        it('copies a vector', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3();
             v2.copy(v1);
@@ -149,9 +149,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#cross', () => {
+    describe('#cross', function () {
 
-        it('calculates cross product of two vectors', () => {
+        it('calculates cross product of two vectors', function () {
             const v1 = new Vec3(1, 0, 0);
             const v2 = new Vec3(0, 1, 0);
             const v3 = new Vec3();
@@ -161,7 +161,7 @@ describe('Vec3', () => {
             expect(v3.z).to.equal(1);
         });
 
-        it('handles first vector also as the result', () => {
+        it('handles first vector also as the result', function () {
             const v1 = new Vec3(1, 0, 0);
             const v2 = new Vec3(0, 1, 0);
             v1.cross(v1, v2);
@@ -170,7 +170,7 @@ describe('Vec3', () => {
             expect(v1.z).to.equal(1);
         });
 
-        it('handles second vector also as the result', () => {
+        it('handles second vector also as the result', function () {
             const v1 = new Vec3(1, 0, 0);
             const v2 = new Vec3(0, 1, 0);
             v2.cross(v1, v2);
@@ -181,16 +181,16 @@ describe('Vec3', () => {
 
     });
 
-    describe('#distance', () => {
+    describe('#distance', function () {
 
-        it('calculates the distance between two vectors', () => {
+        it('calculates the distance between two vectors', function () {
             const v1 = new Vec3();
             const v2 = new Vec3(10, 0, 0);
             const distance = v1.distance(v2);
             expect(distance).to.equal(10);
         });
 
-        it('returns zero for the distance between the same vector', () => {
+        it('returns zero for the distance between the same vector', function () {
             const v1 = new Vec3(10, 0, 0);
             const distance = v1.distance(v1);
             expect(distance).to.equal(0);
@@ -198,9 +198,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#div', () => {
+    describe('#div', function () {
 
-        it('divides a vector by another in place', () => {
+        it('divides a vector by another in place', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             v1.div(v2);
@@ -209,7 +209,7 @@ describe('Vec3', () => {
             expect(v1.z).to.equal(0.5);
         });
 
-        it('divides a vector by itself in place', () => {
+        it('divides a vector by itself in place', function () {
             const v1 = new Vec3(1, 2, 3);
             v1.div(v1);
             expect(v1.x).to.equal(1);
@@ -219,9 +219,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#div2', () => {
+    describe('#div2', function () {
 
-        it('divides a vector by another vector and writes the result to a third vector', () => {
+        it('divides a vector by another vector and writes the result to a third vector', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             const v3 = new Vec3();
@@ -231,7 +231,7 @@ describe('Vec3', () => {
             expect(v3.z).to.equal(0.5);
         });
 
-        it('divides a vector by itself and writes the result to itself', () => {
+        it('divides a vector by itself and writes the result to itself', function () {
             const v1 = new Vec3(1, 2, 3);
             v1.div2(v1, v1);
             expect(v1.x).to.equal(1);
@@ -241,9 +241,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#divScalar', () => {
+    describe('#divScalar', function () {
 
-        it('divides a vector by a scalar in place', () => {
+        it('divides a vector by a scalar in place', function () {
             const v = new Vec3(1, 2, 3);
             v.divScalar(2);
             expect(v.x).to.equal(0.5);
@@ -253,21 +253,21 @@ describe('Vec3', () => {
 
     });
 
-    describe('#dot', () => {
+    describe('#dot', function () {
 
-        it('calculates dot product of two arbitrary non-unit vectors', () => {
+        it('calculates dot product of two arbitrary non-unit vectors', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             expect(v1.dot(v2)).to.equal(32);
         });
 
-        it('calculates dot product of two parallel unit vectors', () => {
+        it('calculates dot product of two parallel unit vectors', function () {
             const v1 = new Vec3(1, 0, 0);
             const v2 = new Vec3(1, 0, 0);
             expect(v1.dot(v2)).to.equal(1);
         });
 
-        it('calculates dot product of two perpendicular unit vectors', () => {
+        it('calculates dot product of two perpendicular unit vectors', function () {
             const v1 = new Vec3(0, 1, 0);
             const v2 = new Vec3(0, 0, 1);
             expect(v1.dot(v2)).to.equal(0);
@@ -275,26 +275,26 @@ describe('Vec3', () => {
 
     });
 
-    describe('#equals', () => {
+    describe('#equals', function () {
 
-        it('checks for equality of the same vector', () => {
+        it('checks for equality of the same vector', function () {
             const v = new Vec3(1, 2, 3);
             expect(v.equals(v)).to.be.true;
         });
 
-        it('checks for equality of two different vectors with the same values', () => {
+        it('checks for equality of two different vectors with the same values', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(1, 2, 3);
             expect(v1.equals(v2)).to.be.true;
         });
 
-        it('checks for equality of two different vectors with different values', () => {
+        it('checks for equality of two different vectors with different values', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             expect(v1.equals(v2)).to.be.false;
         });
 
-        it('checks for equality of different vectors that are close enough', () => {
+        it('checks for equality of different vectors that are close enough', function () {
             const v1 = new Vec3(0.1, 0.2, 0.3);
             const v2 = new Vec3(0.10000000000000001, 0.2, 0.3);
             const epsilon = 0.000001;
@@ -310,9 +310,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#floor', () => {
+    describe('#floor', function () {
 
-        it('leaves integers unchanged', () => {
+        it('leaves integers unchanged', function () {
             const v = new Vec3(1, 2, 3);
             v.floor();
             expect(v.x).to.equal(1);
@@ -320,7 +320,7 @@ describe('Vec3', () => {
             expect(v.z).to.equal(3);
         });
 
-        it('rounds down floating point numbers', () => {
+        it('rounds down floating point numbers', function () {
             const v = new Vec3(1.1, 2.2, 3.3);
             v.floor();
             expect(v.x).to.equal(1);
@@ -330,37 +330,37 @@ describe('Vec3', () => {
 
     });
 
-    describe('#length', () => {
+    describe('#length', function () {
 
-        it('calculates the length of a zero length vector', () => {
+        it('calculates the length of a zero length vector', function () {
             const v = new Vec3();
             expect(v.length()).to.equal(0);
         });
 
-        it('calculates the length of a vector', () => {
+        it('calculates the length of a vector', function () {
             const v = new Vec3(0, 3, 4);
             expect(v.length()).to.equal(5);
         });
 
     });
 
-    describe('#lengthSq', () => {
+    describe('#lengthSq', function () {
 
-        it('calculates the length squared of a zero length vector', () => {
+        it('calculates the length squared of a zero length vector', function () {
             const v = new Vec3();
             expect(v.lengthSq()).to.equal(0);
         });
 
-        it('calculates the length squared of a vector', () => {
+        it('calculates the length squared of a vector', function () {
             const v = new Vec3(0, 3, 4);
             expect(v.lengthSq()).to.equal(25);
         });
 
     });
 
-    describe('#lerp', () => {
+    describe('#lerp', function () {
 
-        it('linearly interpolates between two vectors with alpha of 0', () => {
+        it('linearly interpolates between two vectors with alpha of 0', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             const v3 = new Vec3();
@@ -370,7 +370,7 @@ describe('Vec3', () => {
             expect(v3.z).to.equal(3);
         });
 
-        it('linearly interpolates between two vectors with alpha of 0.5', () => {
+        it('linearly interpolates between two vectors with alpha of 0.5', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             const v3 = new Vec3();
@@ -380,7 +380,7 @@ describe('Vec3', () => {
             expect(v3.z).to.equal(4.5);
         });
 
-        it('linearly interpolates between two vectors with alpha of 1', () => {
+        it('linearly interpolates between two vectors with alpha of 1', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             const v3 = new Vec3();
@@ -392,9 +392,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#max', () => {
+    describe('#max', function () {
 
-        it('handles left hand larger than right hand', () => {
+        it('handles left hand larger than right hand', function () {
             const v1 = new Vec3(4, 5, 6);
             const v2 = new Vec3(1, 2, 3);
             v1.max(v2);
@@ -403,7 +403,7 @@ describe('Vec3', () => {
             expect(v1.z).to.equal(6);
         });
 
-        it('handles right hand larger than left hand', () => {
+        it('handles right hand larger than left hand', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             v1.max(v2);
@@ -414,9 +414,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#min', () => {
+    describe('#min', function () {
 
-        it('handles left hand larger than right hand', () => {
+        it('handles left hand larger than right hand', function () {
             const v1 = new Vec3(4, 5, 6);
             const v2 = new Vec3(1, 2, 3);
             v1.min(v2);
@@ -425,7 +425,7 @@ describe('Vec3', () => {
             expect(v1.z).to.equal(3);
         });
 
-        it('handles right hand larger than left hand', () => {
+        it('handles right hand larger than left hand', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             v1.min(v2);
@@ -436,9 +436,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#mul', () => {
+    describe('#mul', function () {
 
-        it('multiplies a vector by another in place', () => {
+        it('multiplies a vector by another in place', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             v1.mul(v2);
@@ -447,7 +447,7 @@ describe('Vec3', () => {
             expect(v1.z).to.equal(18);
         });
 
-        it('multiplies a vector by itself in place', () => {
+        it('multiplies a vector by itself in place', function () {
             const v1 = new Vec3(1, 2, 3);
             v1.mul(v1);
             expect(v1.x).to.equal(1);
@@ -457,9 +457,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#mul2', () => {
+    describe('#mul2', function () {
 
-        it('multiplies a vector by another vector and writes the result to a third vector', () => {
+        it('multiplies a vector by another vector and writes the result to a third vector', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             const v3 = new Vec3();
@@ -469,7 +469,7 @@ describe('Vec3', () => {
             expect(v3.z).to.equal(18);
         });
 
-        it('multiplies a vector by itself and writes the result to itself', () => {
+        it('multiplies a vector by itself and writes the result to itself', function () {
             const v1 = new Vec3(1, 2, 3);
             v1.mul2(v1, v1);
             expect(v1.x).to.equal(1);
@@ -479,9 +479,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#mulScalar', () => {
+    describe('#mulScalar', function () {
 
-        it('multiplies a vector by a scalar in place', () => {
+        it('multiplies a vector by a scalar in place', function () {
             const v = new Vec3(1, 2, 3);
             v.mulScalar(2);
             expect(v.x).to.equal(2);
@@ -491,9 +491,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#normalize', () => {
+    describe('#normalize', function () {
 
-        it('handles a zero length vector', () => {
+        it('handles a zero length vector', function () {
             const v = new Vec3();
             v.normalize();
             expect(v.x).to.equal(0);
@@ -501,7 +501,7 @@ describe('Vec3', () => {
             expect(v.z).to.equal(0);
         });
 
-        it('handles a non-zero length vector', () => {
+        it('handles a non-zero length vector', function () {
             const v = new Vec3(1, 2, 3);
             v.normalize();
             expect(v.length()).to.equal(1);
@@ -509,9 +509,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#project', () => {
+    describe('#project', function () {
 
-        it('projects a vector onto another vector', () => {
+        it('projects a vector onto another vector', function () {
             const v1 = new Vec3(5, 5, 5);
             const v2 = new Vec3(1, 0, 0);
             v1.project(v2);
@@ -522,9 +522,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#round', () => {
+    describe('#round', function () {
 
-        it('leaves integers unchanged', () => {
+        it('leaves integers unchanged', function () {
             const v = new Vec3(1, 2, 3);
             v.round();
             expect(v.x).to.equal(1);
@@ -532,7 +532,7 @@ describe('Vec3', () => {
             expect(v.z).to.equal(3);
         });
 
-        it('rounds floating point numbers to the nearest integer', () => {
+        it('rounds floating point numbers to the nearest integer', function () {
             const v = new Vec3(1.1, 2.2, 3.3);
             v.round();
             expect(v.x).to.equal(1);
@@ -542,9 +542,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#set', () => {
+    describe('#set', function () {
 
-        it('sets a vector to number values', () => {
+        it('sets a vector to number values', function () {
             const v = new Vec3();
             v.set(1, 2, 3);
             expect(v.x).to.equal(1);
@@ -554,9 +554,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#sub', () => {
+    describe('#sub', function () {
 
-        it('subtracts a vector from another in place', () => {
+        it('subtracts a vector from another in place', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             v1.sub(v2);
@@ -565,7 +565,7 @@ describe('Vec3', () => {
             expect(v1.z).to.equal(-3);
         });
 
-        it('subtracts a vector from itself in place', () => {
+        it('subtracts a vector from itself in place', function () {
             const v1 = new Vec3(1, 2, 3);
             v1.sub(v1);
             expect(v1.x).to.equal(0);
@@ -575,9 +575,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#sub2', () => {
+    describe('#sub2', function () {
 
-        it('subtracts a vector from another vector and writes the result to a third vector', () => {
+        it('subtracts a vector from another vector and writes the result to a third vector', function () {
             const v1 = new Vec3(1, 2, 3);
             const v2 = new Vec3(4, 5, 6);
             const v3 = new Vec3();
@@ -587,7 +587,7 @@ describe('Vec3', () => {
             expect(v3.z).to.equal(-3);
         });
 
-        it('subtracts a vector from itself and writes the result to itself', () => {
+        it('subtracts a vector from itself and writes the result to itself', function () {
             const v1 = new Vec3(1, 2, 3);
             v1.sub2(v1, v1);
             expect(v1.x).to.equal(0);
@@ -597,9 +597,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#subScalar', () => {
+    describe('#subScalar', function () {
 
-        it('subtracts a scalar from a vector in place', () => {
+        it('subtracts a scalar from a vector in place', function () {
             const v = new Vec3(1, 2, 3);
             v.subScalar(2);
             expect(v.x).to.equal(-1);
@@ -609,9 +609,9 @@ describe('Vec3', () => {
 
     });
 
-    describe('#toString', () => {
+    describe('#toString', function () {
 
-        it('returns a string representation of a vector', () => {
+        it('returns a string representation of a vector', function () {
             const v = new Vec3(1, 2, 3);
             expect(v.toString()).to.equal('[1, 2, 3]');
         });

--- a/test/core/math/vec4.test.mjs
+++ b/test/core/math/vec4.test.mjs
@@ -2,11 +2,11 @@ import { Vec4 } from '../../../src/core/math/vec4.js';
 
 import { expect } from 'chai';
 
-describe('Vec4', () => {
+describe('Vec4', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('supports zero arguments', () => {
+        it('supports zero arguments', function () {
             const v = new Vec4();
             expect(v.x).to.equal(0);
             expect(v.y).to.equal(0);
@@ -14,7 +14,7 @@ describe('Vec4', () => {
             expect(v.w).to.equal(0);
         });
 
-        it('supports number arguments', () => {
+        it('supports number arguments', function () {
             const v = new Vec4(1, 2, 3, 4);
             expect(v.x).to.equal(1);
             expect(v.y).to.equal(2);
@@ -22,7 +22,7 @@ describe('Vec4', () => {
             expect(v.w).to.equal(4);
         });
 
-        it('supports an array argument', () => {
+        it('supports an array argument', function () {
             const v = new Vec4([1, 2, 3, 4]);
             expect(v.x).to.equal(1);
             expect(v.y).to.equal(2);
@@ -32,9 +32,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#add', () => {
+    describe('#add', function () {
 
-        it('adds a vector to another in place', () => {
+        it('adds a vector to another in place', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             v1.add(v2);
@@ -44,7 +44,7 @@ describe('Vec4', () => {
             expect(v1.w).to.equal(12);
         });
 
-        it('adds a vector to itself in place', () => {
+        it('adds a vector to itself in place', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             v1.add(v1);
             expect(v1.x).to.equal(2);
@@ -55,9 +55,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#add2', () => {
+    describe('#add2', function () {
 
-        it('adds two vectors together and writes result to a third vector', () => {
+        it('adds two vectors together and writes result to a third vector', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             const v3 = new Vec4();
@@ -68,7 +68,7 @@ describe('Vec4', () => {
             expect(v3.w).to.equal(12);
         });
 
-        it('adds a vector to itself and writes result to itself', () => {
+        it('adds a vector to itself and writes result to itself', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             v1.add2(v1, v1);
             expect(v1.x).to.equal(2);
@@ -79,9 +79,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#addScalar', () => {
+    describe('#addScalar', function () {
 
-        it('adds a scalar in place', () => {
+        it('adds a scalar in place', function () {
             const v = new Vec4(1, 2, 3, 4);
             v.addScalar(2);
             expect(v.x).to.equal(3);
@@ -92,9 +92,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#addScaled', () => {
+    describe('#addScaled', function () {
 
-        it('adds a scaled vector', () => {
+        it('adds a scaled vector', function () {
             const v = new Vec4(1, 2, 3, 4);
             v.addScaled(Vec4.ONE, 2);
             expect(v.x).to.equal(3);
@@ -105,9 +105,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#ceil', () => {
+    describe('#ceil', function () {
 
-        it('leaves integers unchanged', () => {
+        it('leaves integers unchanged', function () {
             const v = new Vec4(1, 2, 3, 4);
             v.ceil();
             expect(v.x).to.equal(1);
@@ -116,7 +116,7 @@ describe('Vec4', () => {
             expect(v.w).to.equal(4);
         });
 
-        it('calculates the ceil of all components', () => {
+        it('calculates the ceil of all components', function () {
             const v = new Vec4(1.1, 2.2, 3.3, 4.4);
             v.ceil();
             expect(v.x).to.equal(2);
@@ -127,9 +127,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#clone', () => {
+    describe('#clone', function () {
 
-        it('clones a vector', () => {
+        it('clones a vector', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = v1.clone();
             expect(v2).to.be.instanceof(Vec4);
@@ -139,7 +139,7 @@ describe('Vec4', () => {
             expect(v2.w).to.equal(4);
         });
 
-        it('ensures that an instance of a subclass keeps its class prototype', () => {
+        it('ensures that an instance of a subclass keeps its class prototype', function () {
             class UserVec4 extends Vec4 {}
             const a = new UserVec4();
             const b = a.clone();
@@ -148,9 +148,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#copy', () => {
+    describe('#copy', function () {
 
-        it('copies a vector', () => {
+        it('copies a vector', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4();
             v2.copy(v1);
@@ -162,9 +162,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#div', () => {
+    describe('#div', function () {
 
-        it('divides a vector by another in place', () => {
+        it('divides a vector by another in place', function () {
             const v1 = new Vec4(12, 12, 12, 12);
             const v2 = new Vec4(4, 3, 2, 1);
             v1.div(v2);
@@ -174,7 +174,7 @@ describe('Vec4', () => {
             expect(v1.w).to.equal(12);
         });
 
-        it('divides a vector by itself in place', () => {
+        it('divides a vector by itself in place', function () {
             const v1 = new Vec4(12, 12, 12, 12);
             v1.div(v1);
             expect(v1.x).to.equal(1);
@@ -185,9 +185,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#div2', () => {
+    describe('#div2', function () {
 
-        it('divides a vector by another vector and writes the result to a third vector', () => {
+        it('divides a vector by another vector and writes the result to a third vector', function () {
             const v1 = new Vec4(12, 12, 12, 12);
             const v2 = new Vec4(4, 3, 2, 1);
             const v3 = new Vec4();
@@ -198,7 +198,7 @@ describe('Vec4', () => {
             expect(v3.w).to.equal(12);
         });
 
-        it('divides a vector by itself and writes the result to itself', () => {
+        it('divides a vector by itself and writes the result to itself', function () {
             const v1 = new Vec4(12, 12, 12, 12);
             v1.div2(v1, v1);
             expect(v1.x).to.equal(1);
@@ -209,9 +209,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#divScalar', () => {
+    describe('#divScalar', function () {
 
-        it('divides a vector by a scalar in place', () => {
+        it('divides a vector by a scalar in place', function () {
             const v = new Vec4(1, 2, 3, 4);
             v.divScalar(2);
             expect(v.x).to.equal(0.5);
@@ -222,23 +222,23 @@ describe('Vec4', () => {
 
     });
 
-    describe('#dot', () => {
+    describe('#dot', function () {
 
-        it('calculates dot product of two arbitrary non-unit vectors', () => {
+        it('calculates dot product of two arbitrary non-unit vectors', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             const dot = v1.dot(v2);
             expect(dot).to.equal(70);
         });
 
-        it('calculates dot product of two parallel unit vectors', () => {
+        it('calculates dot product of two parallel unit vectors', function () {
             const v1 = new Vec4(1, 0, 0, 0);
             const v2 = new Vec4(1, 0, 0, 0);
             const dot = v1.dot(v2);
             expect(dot).to.equal(1);
         });
 
-        it('calculates dot product of two perpendicular unit vectors', () => {
+        it('calculates dot product of two perpendicular unit vectors', function () {
             const v1 = new Vec4(0, 1, 0, 0);
             const v2 = new Vec4(0, 0, 1, 0);
             expect(v1.dot(v2)).to.equal(0);
@@ -246,26 +246,26 @@ describe('Vec4', () => {
 
     });
 
-    describe('#equals', () => {
+    describe('#equals', function () {
 
-        it('checks for equality of the same vector', () => {
+        it('checks for equality of the same vector', function () {
             const v = new Vec4(1, 2, 3, 4);
             expect(v.equals(v)).to.be.true;
         });
 
-        it('checks for equality of two different vectors with the same values', () => {
+        it('checks for equality of two different vectors with the same values', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(1, 2, 3, 4);
             expect(v1.equals(v2)).to.be.true;
         });
 
-        it('checks for equality of two different vectors with different values', () => {
+        it('checks for equality of two different vectors with different values', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             expect(v1.equals(v2)).to.be.false;
         });
 
-        it('checks for equality of different vectors that are close enough', () => {
+        it('checks for equality of different vectors that are close enough', function () {
             const v1 = new Vec4(0.1, 0.2, 0.3, 0.4);
             const v2 = new Vec4(0.10000000000000001, 0.2, 0.3, 0.4);
             const epsilon = 0.000001;
@@ -281,9 +281,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#floor', () => {
+    describe('#floor', function () {
 
-        it('leaves integers unchanged', () => {
+        it('leaves integers unchanged', function () {
             const v = new Vec4(1, 2, 3, 4);
             v.floor();
             expect(v.x).to.equal(1);
@@ -292,7 +292,7 @@ describe('Vec4', () => {
             expect(v.w).to.equal(4);
         });
 
-        it('rounds down floating point numbers', () => {
+        it('rounds down floating point numbers', function () {
             const v = new Vec4(1.1, 2.2, 3.3, 4.4);
             v.floor();
             expect(v.x).to.equal(1);
@@ -303,37 +303,37 @@ describe('Vec4', () => {
 
     });
 
-    describe('#length', () => {
+    describe('#length', function () {
 
-        it('calculates the length of a zero length vector', () => {
+        it('calculates the length of a zero length vector', function () {
             const v = new Vec4();
             expect(v.length()).to.equal(0);
         });
 
-        it('calculates the length of a vector', () => {
+        it('calculates the length of a vector', function () {
             const v = new Vec4(0, 3, 4, 0);
             expect(v.length()).to.equal(5);
         });
 
     });
 
-    describe('#lengthSq', () => {
+    describe('#lengthSq', function () {
 
-        it('calculates the length squared of a zero length vector', () => {
+        it('calculates the length squared of a zero length vector', function () {
             const v = new Vec4();
             expect(v.length()).to.equal(0);
         });
 
-        it('calculates the length squared of a vector', () => {
+        it('calculates the length squared of a vector', function () {
             const v = new Vec4(0, 3, 4, 0);
             expect(v.lengthSq()).to.equal(25);
         });
 
     });
 
-    describe('#lerp', () => {
+    describe('#lerp', function () {
 
-        it('linearly interpolates between two vectors with alpha of 0', () => {
+        it('linearly interpolates between two vectors with alpha of 0', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             const v3 = new Vec4();
@@ -344,7 +344,7 @@ describe('Vec4', () => {
             expect(v3.w).to.equal(4);
         });
 
-        it('linearly interpolates between two vectors with alpha of 0.5', () => {
+        it('linearly interpolates between two vectors with alpha of 0.5', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             const v3 = new Vec4();
@@ -355,7 +355,7 @@ describe('Vec4', () => {
             expect(v3.w).to.equal(6);
         });
 
-        it('linearly interpolates between two vectors with alpha of 1', () => {
+        it('linearly interpolates between two vectors with alpha of 1', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             const v3 = new Vec4();
@@ -368,9 +368,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#max', () => {
+    describe('#max', function () {
 
-        it('handles left hand larger than right hand', () => {
+        it('handles left hand larger than right hand', function () {
             const v1 = new Vec4(5, 6, 7, 8);
             const v2 = new Vec4(1, 2, 3, 4);
             v1.max(v2);
@@ -380,7 +380,7 @@ describe('Vec4', () => {
             expect(v1.w).to.equal(8);
         });
 
-        it('handles right hand larger than left hand', () => {
+        it('handles right hand larger than left hand', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             v1.max(v2);
@@ -392,9 +392,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#min', () => {
+    describe('#min', function () {
 
-        it('handles left hand larger than right hand', () => {
+        it('handles left hand larger than right hand', function () {
             const v1 = new Vec4(5, 6, 7, 8);
             const v2 = new Vec4(1, 2, 3, 4);
             v1.min(v2);
@@ -404,7 +404,7 @@ describe('Vec4', () => {
             expect(v1.w).to.equal(4);
         });
 
-        it('handles right hand larger than left hand', () => {
+        it('handles right hand larger than left hand', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             v1.min(v2);
@@ -416,9 +416,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#mul', () => {
+    describe('#mul', function () {
 
-        it('multiplies a vector by another in place', () => {
+        it('multiplies a vector by another in place', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             v1.mul(v2);
@@ -428,7 +428,7 @@ describe('Vec4', () => {
             expect(v1.w).to.equal(32);
         });
 
-        it('multiplies a vector by itself in place', () => {
+        it('multiplies a vector by itself in place', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             v1.mul(v1);
             expect(v1.x).to.equal(1);
@@ -439,9 +439,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#mul2', () => {
+    describe('#mul2', function () {
 
-        it('multiplies a vector by another vector and writes the result to a third vector', () => {
+        it('multiplies a vector by another vector and writes the result to a third vector', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             const v3 = new Vec4();
@@ -452,7 +452,7 @@ describe('Vec4', () => {
             expect(v3.w).to.equal(32);
         });
 
-        it('multiplies a vector by itself and writes the result to itself', () => {
+        it('multiplies a vector by itself and writes the result to itself', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             v1.mul2(v1, v1);
             expect(v1.x).to.equal(1);
@@ -463,9 +463,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#mulScalar', () => {
+    describe('#mulScalar', function () {
 
-        it('multiplies a vector by a scalar in place', () => {
+        it('multiplies a vector by a scalar in place', function () {
             const v = new Vec4(1, 2, 3, 4);
             v.mulScalar(2);
             expect(v.x).to.equal(2);
@@ -476,9 +476,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#normalize', () => {
+    describe('#normalize', function () {
 
-        it('handles a zero length vector', () => {
+        it('handles a zero length vector', function () {
             const v = new Vec4();
             v.normalize();
             expect(v.x).to.equal(0);
@@ -487,7 +487,7 @@ describe('Vec4', () => {
             expect(v.w).to.equal(0);
         });
 
-        it('handles a non-zero length vector', () => {
+        it('handles a non-zero length vector', function () {
             const v = new Vec4(1, 2, 3, 4);
             v.normalize();
             expect(v.length()).to.be.closeTo(1, 0.00001);
@@ -495,9 +495,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#round', () => {
+    describe('#round', function () {
 
-        it('leaves integers unchanged', () => {
+        it('leaves integers unchanged', function () {
             const v = new Vec4(1, 2, 3, 4);
             v.round();
             expect(v.x).to.equal(1);
@@ -506,7 +506,7 @@ describe('Vec4', () => {
             expect(v.w).to.equal(4);
         });
 
-        it('rounds floating point numbers to the nearest integer', () => {
+        it('rounds floating point numbers to the nearest integer', function () {
             const v = new Vec4(1.1, 2.2, 3.3, 4.4);
             v.round();
             expect(v.x).to.equal(1);
@@ -517,9 +517,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#set', () => {
+    describe('#set', function () {
 
-        it('sets a vector to number values', () => {
+        it('sets a vector to number values', function () {
             const v = new Vec4();
             v.set(1, 2, 3, 4);
             expect(v.x).to.equal(1);
@@ -530,9 +530,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#sub', () => {
+    describe('#sub', function () {
 
-        it('subtracts a vector from another in place', () => {
+        it('subtracts a vector from another in place', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             v1.sub(v2);
@@ -542,7 +542,7 @@ describe('Vec4', () => {
             expect(v1.w).to.equal(-4);
         });
 
-        it('subtracts a vector from itself in place', () => {
+        it('subtracts a vector from itself in place', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             v1.sub(v1);
             expect(v1.x).to.equal(0);
@@ -553,9 +553,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#sub2', () => {
+    describe('#sub2', function () {
 
-        it('subtracts a vector from another vector and writes the result to a third vector', () => {
+        it('subtracts a vector from another vector and writes the result to a third vector', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             const v2 = new Vec4(5, 6, 7, 8);
             const v3 = new Vec4();
@@ -566,7 +566,7 @@ describe('Vec4', () => {
             expect(v3.w).to.equal(-4);
         });
 
-        it('subtracts a vector from itself and writes the result to itself', () => {
+        it('subtracts a vector from itself and writes the result to itself', function () {
             const v1 = new Vec4(1, 2, 3, 4);
             v1.sub2(v1, v1);
             expect(v1.x).to.equal(0);
@@ -577,9 +577,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#subScalar', () => {
+    describe('#subScalar', function () {
 
-        it('subtracts a scalar from a vector in place', () => {
+        it('subtracts a scalar from a vector in place', function () {
             const v = new Vec4(1, 2, 3, 4);
             v.subScalar(2);
             expect(v.x).to.equal(-1);
@@ -590,9 +590,9 @@ describe('Vec4', () => {
 
     });
 
-    describe('#toString', () => {
+    describe('#toString', function () {
 
-        it('returns a string representation of a vector', () => {
+        it('returns a string representation of a vector', function () {
             const v = new Vec4(1, 2, 3, 4);
             expect(v.toString()).to.equal('[1, 2, 3, 4]');
         });

--- a/test/core/path.test.mjs
+++ b/test/core/path.test.mjs
@@ -2,11 +2,11 @@ import { path } from '../../src/core/path.js';
 
 import { expect } from 'chai';
 
-describe('path', () => {
+describe('path', function () {
 
-    describe('#extractPath', () => {
+    describe('#extractPath', function () {
 
-        it('removes from filename from paths', () => {
+        it('removes from filename from paths', function () {
             expect(path.extractPath('path/to/file')).to.equal('./path/to');
             expect(path.extractPath('./path/to/file')).to.equal('./path/to');
             expect(path.extractPath('../path/to/file')).to.equal('../path/to');
@@ -16,9 +16,9 @@ describe('path', () => {
 
     });
 
-    describe('#getBasename', () => {
+    describe('#getBasename', function () {
 
-        it('returns basename from filename', () => {
+        it('returns basename from filename', function () {
 
             expect(path.getBasename('path/to/file.txt')).to.equal('file.txt');
             expect(path.getBasename('path/to/directory')).to.equal('directory');
@@ -27,9 +27,9 @@ describe('path', () => {
 
     });
 
-    describe('#getDirectory', () => {
+    describe('#getDirectory', function () {
 
-        it('handles various paths', () => {
+        it('handles various paths', function () {
             expect(path.getDirectory('folder/file.txt')).to.equal('folder');
             expect(path.getDirectory('folder/another')).to.equal('folder');
             expect(path.getDirectory('folder/another/')).to.equal('folder/another');
@@ -40,45 +40,45 @@ describe('path', () => {
     });
 
 
-    describe('#getExtension', () => {
+    describe('#getExtension', function () {
 
-        it('returns the extension of a file', () => {
+        it('returns the extension of a file', function () {
             expect(path.getExtension('file.txt')).to.equal('.txt');
         });
 
-        it('returns the extension of a file with a path', () => {
+        it('returns the extension of a file with a path', function () {
             expect(path.getExtension('path/to/file.txt')).to.equal('.txt');
         });
 
-        it('returns the extension of a file with a path and query string', () => {
+        it('returns the extension of a file with a path and query string', function () {
             expect(path.getExtension('path/to/file.txt?query=string')).to.equal('.txt');
         });
 
-        it('returns the empty string if the file has no extension', () => {
+        it('returns the empty string if the file has no extension', function () {
             expect(path.getExtension('file')).to.equal('');
         });
 
     });
 
-    describe('#isRelativePath', () => {
+    describe('#isRelativePath', function () {
 
-        it('returns true for relative paths', () => {
+        it('returns true for relative paths', function () {
             expect(path.isRelativePath('path/to/file')).to.be.true;
             expect(path.isRelativePath('./path/to/file')).to.be.true;
             expect(path.isRelativePath('../path/to/file')).to.be.true;
             expect(path.isRelativePath('path/../path/to/file.txt')).to.be.true;
         });
 
-        it('returns false for absolute paths', () => {
+        it('returns false for absolute paths', function () {
             expect(path.isRelativePath('/path/to/file')).to.be.false;
             expect(path.isRelativePath('/path/../path/to/file.txt')).to.be.false;
         });
 
     });
 
-    describe('#join', () => {
+    describe('#join', function () {
 
-        it('handles two path sections', () => {
+        it('handles two path sections', function () {
             expect(path.join('a', 'b')).to.equal('a/b');
             expect(path.join('a', '/b')).to.equal('/b');
             expect(path.join('/a', 'b')).to.equal('/a/b');
@@ -92,7 +92,7 @@ describe('path', () => {
             expect(path.join('a/b', '')).to.equal('a/b');
         });
 
-        it('handles more than two path sections', () => {
+        it('handles more than two path sections', function () {
             expect(path.join('a', 'b', 'c')).to.equal('a/b/c');
             expect(path.join('a', '/b', 'c')).to.equal('/b/c');
             expect(path.join('/a', 'b', 'c')).to.equal('/a/b/c');
@@ -108,7 +108,7 @@ describe('path', () => {
             expect(path.join('a', 'b', 'c', 'd')).to.equal('a/b/c/d');
         });
 
-        it('handles invalid values', () => {
+        it('handles invalid values', function () {
             expect(() => {
                 path.join('a', undefined);
             }).to.throw();
@@ -116,9 +116,9 @@ describe('path', () => {
 
     });
 
-    describe('#normalize', () => {
+    describe('#normalize', function () {
 
-        it('normalizes any path', () => {
+        it('normalizes any path', function () {
             expect(path.normalize('a/b/c')).to.equal('a/b/c');
             expect(path.normalize('/a/b/c')).to.equal('/a/b/c');
             expect(path.normalize('a//b/c')).to.equal('a/b/c');
@@ -139,9 +139,9 @@ describe('path', () => {
 
     });
 
-    describe('#split', () => {
+    describe('#split', function () {
 
-        it('splits a path into path and filename', () => {
+        it('splits a path into path and filename', function () {
             expect(path.split('path/to/file.txt')).to.deep.equal(['path/to', 'file.txt']);
         });
 

--- a/test/core/preprocessor.test.mjs
+++ b/test/core/preprocessor.test.mjs
@@ -2,7 +2,7 @@ import { Preprocessor } from '../../src/core/preprocessor.js';
 
 import { expect } from 'chai';
 
-describe('Preprocessor', () => {
+describe('Preprocessor', function () {
 
     const includes = new Map([
         ['inc1', `
@@ -75,83 +75,83 @@ describe('Preprocessor', () => {
         #endif
     `;
 
-    it('returns false for MORPH_A', () => {
+    it('returns false for MORPH_A', function () {
         expect(Preprocessor.run(srcData, includes).includes('MORPH_A')).to.equal(false);
     });
 
-    it('returns false for MORPH_B', () => {
+    it('returns false for MORPH_B', function () {
         expect(Preprocessor.run(srcData, includes).includes('MORPH_B')).to.equal(false);
     });
 
-    it('returns true for $', () => {
+    it('returns true for $', function () {
         expect(Preprocessor.run(srcData, includes).includes('$')).to.equal(true);
     });
 
-    it('returns true for TEST1', () => {
+    it('returns true for TEST1', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST1')).to.equal(true);
     });
 
-    it('returns true for TEST2', () => {
+    it('returns true for TEST2', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST2')).to.equal(true);
     });
 
-    it('returns true for TEST3', () => {
+    it('returns true for TEST3', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST3')).to.equal(true);
     });
 
-    it('returns true for TEST4', () => {
+    it('returns true for TEST4', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST4')).to.equal(true);
     });
 
-    it('returns false for TEST5', () => {
+    it('returns false for TEST5', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST5')).to.equal(false);
     });
 
-    it('returns true for TEST6', () => {
+    it('returns true for TEST6', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST6')).to.equal(true);
     });
 
-    it('returns false for TEST7', () => {
+    it('returns false for TEST7', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST7')).to.equal(false);
     });
 
-    it('returns false for TEST8', () => {
+    it('returns false for TEST8', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST8')).to.equal(false);
     });
 
-    it('returns false for TEST9', () => {
+    it('returns false for TEST9', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST9')).to.equal(false);
     });
 
-    it('returns true for TEST10', () => {
+    it('returns true for TEST10', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST10')).to.equal(true);
     });
 
-    it('returns false for TEST11', () => {
+    it('returns false for TEST11', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST11')).to.equal(false);
     });
 
-    it('returns false for TEST12', () => {
+    it('returns false for TEST12', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST12')).to.equal(false);
     });
 
-    it('returns true for TEST13', () => {
+    it('returns true for TEST13', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST13')).to.equal(true);
     });
 
-    it('returns false for TEST14', () => {
+    it('returns false for TEST14', function () {
         expect(Preprocessor.run(srcData, includes).includes('TEST14')).to.equal(false);
     });
 
-    it('returns true for INC1', () => {
+    it('returns true for INC1', function () {
         expect(Preprocessor.run(srcData, includes).includes('block1')).to.equal(true);
     });
 
-    it('returns false for INC2', () => {
+    it('returns false for INC2', function () {
         expect(Preprocessor.run(srcData, includes).includes('block2')).to.equal(false);
     });
 
-    it('returns true for nested', () => {
+    it('returns true for nested', function () {
         expect(Preprocessor.run(srcData, includes).includes('nested')).to.equal(true);
     });
 });

--- a/test/core/shape/plane.test.mjs
+++ b/test/core/shape/plane.test.mjs
@@ -3,11 +3,11 @@ import { Vec3 } from '../../../src/core/math/vec3.js';
 
 import { expect } from 'chai';
 
-describe('Plane', () => {
+describe('Plane', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('supports zero arguments', () => {
+        it('supports zero arguments', function () {
             const p = new Plane();
             expect(p.normal.x).to.equal(Vec3.UP.x);
             expect(p.normal.y).to.equal(Vec3.UP.y);
@@ -15,7 +15,7 @@ describe('Plane', () => {
             expect(p.distance).to.equal(0);
         });
 
-        it('supports arguments', () => {
+        it('supports arguments', function () {
             const p = new Plane(Vec3.UP, 5);
             expect(p.normal.x).to.equal(0);
             expect(p.normal.y).to.equal(1);
@@ -25,7 +25,7 @@ describe('Plane', () => {
 
     });
 
-    describe('#setFromPointNormal', () => {
+    describe('#setFromPointNormal', function () {
 
         const p = new Plane();
         p.setFromPointNormal(new Vec3(1, 2, 3), Vec3.UP);
@@ -36,7 +36,7 @@ describe('Plane', () => {
 
     });
 
-    describe('#intersectsLine', () => {
+    describe('#intersectsLine', function () {
 
         const p = new Plane();
         p.setFromPointNormal(new Vec3(0, 5, 0), Vec3.UP);

--- a/test/core/sorted-loop-array.test.mjs
+++ b/test/core/sorted-loop-array.test.mjs
@@ -2,11 +2,11 @@ import { SortedLoopArray } from '../../src/core/sorted-loop-array.js';
 
 import { expect } from 'chai';
 
-describe('SortedLoopArray', () => {
+describe('SortedLoopArray', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('creates a new sorted loop array', () => {
+        it('creates a new sorted loop array', function () {
             const array = new SortedLoopArray({
                 sortBy: 'priority'
             });
@@ -17,9 +17,9 @@ describe('SortedLoopArray', () => {
 
     });
 
-    describe('#append()', () => {
+    describe('#append()', function () {
 
-        it('adds item to array', () => {
+        it('adds item to array', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             expect(arr.items.length).to.equal(0);
 
@@ -32,14 +32,14 @@ describe('SortedLoopArray', () => {
             expect(arr.items[0]).to.equal(item);
         });
 
-        it('increases length', () => {
+        it('increases length', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             expect(arr.length).to.equal(0);
             arr.append({ priority: 1 });
             expect(arr.length).to.equal(1);
         });
 
-        it('does not modify loopIndex', () => {
+        it('does not modify loopIndex', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -59,7 +59,7 @@ describe('SortedLoopArray', () => {
             expect(arr.loopIndex).to.equal(1);
         });
 
-        it('always adds item to the end', () => {
+        it('always adds item to the end', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -82,9 +82,9 @@ describe('SortedLoopArray', () => {
 
     });
 
-    describe('#insert()', () => {
+    describe('#insert()', function () {
 
-        it('adds item to array', () => {
+        it('adds item to array', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             expect(arr.items.length).to.equal(0);
 
@@ -97,7 +97,7 @@ describe('SortedLoopArray', () => {
             expect(arr.items[0]).to.equal(item);
         });
 
-        it('adds item after items with lower priority', () => {
+        it('adds item after items with lower priority', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -113,7 +113,7 @@ describe('SortedLoopArray', () => {
             expect(arr.items[1]).to.equal(b);
         });
 
-        it('adds item after items with equal priority', () => {
+        it('adds item after items with equal priority', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -129,7 +129,7 @@ describe('SortedLoopArray', () => {
             expect(arr.items[1]).to.equal(b);
         });
 
-        it('adds item between items with lower and higher priority', () => {
+        it('adds item between items with lower and higher priority', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -150,7 +150,7 @@ describe('SortedLoopArray', () => {
             expect(arr.items[2]).to.equal(c);
         });
 
-        it('adds item after items with lower and equal priority', () => {
+        it('adds item after items with lower and equal priority', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -171,7 +171,7 @@ describe('SortedLoopArray', () => {
             expect(arr.items[2]).to.equal(c);
         });
 
-        it('adds item before items with higher priority', () => {
+        it('adds item before items with higher priority', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -192,7 +192,7 @@ describe('SortedLoopArray', () => {
             expect(arr.items[2]).to.equal(c);
         });
 
-        it('does not modify loopIndex for item added after it', () => {
+        it('does not modify loopIndex for item added after it', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -212,7 +212,7 @@ describe('SortedLoopArray', () => {
             expect(arr.loopIndex).to.equal(1);
         });
 
-        it('modifies loopIndex for item added before it', () => {
+        it('modifies loopIndex for item added before it', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -232,7 +232,7 @@ describe('SortedLoopArray', () => {
             expect(arr.loopIndex).to.equal(2);
         });
 
-        it('modifies loopIndex for item added on the same slot', () => {
+        it('modifies loopIndex for item added on the same slot', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -252,7 +252,7 @@ describe('SortedLoopArray', () => {
             expect(arr.loopIndex).to.equal(1);
         });
 
-        it('increases length', () => {
+        it('increases length', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             expect(arr.length).to.equal(0);
             arr.insert({ priority: 1 });
@@ -261,9 +261,9 @@ describe('SortedLoopArray', () => {
 
     });
 
-    describe('#remove()', () => {
+    describe('#remove()', function () {
 
-        it('removes item from array', () => {
+        it('removes item from array', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             expect(arr.items.length).to.equal(0);
 
@@ -280,7 +280,7 @@ describe('SortedLoopArray', () => {
             expect(arr.items.length).to.equal(0);
         });
 
-        it('decreases length', () => {
+        it('decreases length', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const item = { priority: 1 };
             expect(arr.length).to.equal(0);
@@ -294,7 +294,7 @@ describe('SortedLoopArray', () => {
             expect(arr.length).to.equal(0);
         });
 
-        it('does not modify loopIndex for item removed after it', () => {
+        it('does not modify loopIndex for item removed after it', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -315,7 +315,7 @@ describe('SortedLoopArray', () => {
             expect(arr.loopIndex).to.equal(1);
         });
 
-        it('modifies loopIndex for item removed before it', () => {
+        it('modifies loopIndex for item removed before it', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -336,7 +336,7 @@ describe('SortedLoopArray', () => {
             expect(arr.loopIndex).to.equal(0);
         });
 
-        it('modifies loopIndex when item it points to was removed', () => {
+        it('modifies loopIndex when item it points to was removed', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -357,7 +357,7 @@ describe('SortedLoopArray', () => {
             expect(arr.loopIndex).to.equal(0);
         });
 
-        it('does not modify loopIndex if element does not exist', () => {
+        it('does not modify loopIndex if element does not exist', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -379,9 +379,9 @@ describe('SortedLoopArray', () => {
 
     });
 
-    describe('#sort', () => {
+    describe('#sort', function () {
 
-        it('sorts items', () => {
+        it('sorts items', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -401,7 +401,7 @@ describe('SortedLoopArray', () => {
             expect(arr.items[2]).to.equal(c);
         });
 
-        it('updates loopIndex', () => {
+        it('updates loopIndex', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1
@@ -419,7 +419,7 @@ describe('SortedLoopArray', () => {
             expect(arr.loopIndex).to.equal(2);
         });
 
-        it('does not update loopIndex if it cannot find element it\'s pointing to', () => {
+        it('does not update loopIndex if it cannot find element it\'s pointing to', function () {
             const arr = new SortedLoopArray({ sortBy: 'priority' });
             const a = {
                 priority: 1

--- a/test/core/string.test.mjs
+++ b/test/core/string.test.mjs
@@ -2,25 +2,25 @@ import { string } from '../../src/core/string.js';
 
 import { expect } from 'chai';
 
-describe('string', () => {
+describe('string', function () {
 
-    describe('#format', () => {
+    describe('#format', function () {
 
-        it('handles no args', () => {
+        it('handles no args', function () {
             const src = 'a string';
             const result = string.format(src);
 
             expect(result).to.equal('a string');
         });
 
-        it('handles one arg', () => {
+        it('handles one arg', function () {
             const src = 'a string {0}';
             const result = string.format(src, 'abc');
 
             expect(result).to.equal('a string abc');
         });
 
-        it('handles two args', () => {
+        it('handles two args', function () {
             const src = '{0} a string {1}';
             const result = string.format(src, 'abc', 'def');
 
@@ -29,9 +29,9 @@ describe('string', () => {
 
     });
 
-    describe('#getSymbols', () => {
+    describe('#getSymbols', function () {
 
-        it('returns an array of the expected length', () => {
+        it('returns an array of the expected length', function () {
             expect(string.getSymbols('ABC').length).to.equal(3);
             expect(string.getSymbols('A🇺🇸').length).to.equal(2);
             expect(string.getSymbols('👨🏿').length).to.equal(1);

--- a/test/core/uri.test.mjs
+++ b/test/core/uri.test.mjs
@@ -2,11 +2,11 @@ import { createURI, URI } from '../../src/core/uri.js';
 
 import { expect } from 'chai';
 
-describe('URI', () => {
+describe('URI', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('handles all sections', () => {
+        it('handles all sections', function () {
             const s = 'http://a/b/c/d;p?q=r#l';
 
             const uri = new URI(s);
@@ -18,7 +18,7 @@ describe('URI', () => {
             expect(uri.fragment).to.equal('l');
         });
 
-        it('handles no scheme', () => {
+        it('handles no scheme', function () {
             const s = '//a/b/c/d;p?q=r#l';
             const uri = new URI(s);
 
@@ -29,7 +29,7 @@ describe('URI', () => {
             expect(uri.fragment).to.equal('l');
         });
 
-        it('handles no authority', () => {
+        it('handles no authority', function () {
             const s = '/b/c/d;p?q=r#l';
             const uri = new URI(s);
 
@@ -40,7 +40,7 @@ describe('URI', () => {
             expect(uri.fragment).to.equal('l');
         });
 
-        it('handles no query', () => {
+        it('handles no query', function () {
             const s = 'http://a/b/c/d;p#l';
             const uri = new URI(s);
 
@@ -51,7 +51,7 @@ describe('URI', () => {
             expect(uri.fragment).to.equal('l');
         });
 
-        it('handles no fragment', () => {
+        it('handles no fragment', function () {
             const s = 'http://a/b/c/d;p?q=r';
             const uri = new URI(s);
 
@@ -64,9 +64,9 @@ describe('URI', () => {
 
     });
 
-    describe('#toString', () => {
+    describe('#toString', function () {
 
-        it('matches the URI passed to the constructor', () => {
+        it('matches the URI passed to the constructor', function () {
             const s = 'http://a/b/c/d;p?q=r#l';
             const uri = new URI(s);
             const r = uri.toString();
@@ -74,7 +74,7 @@ describe('URI', () => {
             expect(s).to.equal(r);
         });
 
-        it('handles an edit to the query', () => {
+        it('handles an edit to the query', function () {
             const s = 'http://example.com';
             const uri = new URI(s);
             uri.query = 'q=abc';
@@ -87,9 +87,9 @@ describe('URI', () => {
 
     });
 
-    describe('#getQuery', () => {
+    describe('#getQuery', function () {
 
-        it('correctly parses the query string', () => {
+        it('correctly parses the query string', function () {
             const s = 'http://example.com/test?a=1&b=string&c=something%20spaced';
             const uri = new URI(s);
 
@@ -100,7 +100,7 @@ describe('URI', () => {
             expect(q.c).to.equal('something spaced');
         });
 
-        it('handles an empty query string', () => {
+        it('handles an empty query string', function () {
             const s = 'http://example.com/test';
             const uri = new URI(s);
 
@@ -111,9 +111,9 @@ describe('URI', () => {
 
     });
 
-    describe('#setQuery', () => {
+    describe('#setQuery', function () {
 
-        it('adds a query string', () => {
+        it('adds a query string', function () {
             const uri = new URI('http://example.com/test');
             const q = {
                 key: 'value'
@@ -124,7 +124,7 @@ describe('URI', () => {
         });
 
 
-        it('adds a query string with spaces and quotes', () => {
+        it('adds a query string with spaces and quotes', function () {
             const uri = new URI('http://example.com/test');
             const q = {
                 'key': 'value',
@@ -138,9 +138,9 @@ describe('URI', () => {
 
 });
 
-describe('createURI', () => {
+describe('createURI', function () {
 
-    it('correctly constructs URIs', () => {
+    it('correctly constructs URIs', function () {
         let uri;
 
         uri = createURI({
@@ -170,7 +170,7 @@ describe('createURI', () => {
 
     });
 
-    it('throws exceptions', () => {
+    it('throws exceptions', function () {
         expect(() => {
             createURI({
                 scheme: 'http',

--- a/test/framework/anim/controller/anim-blend-tree.test.mjs
+++ b/test/framework/anim/controller/anim-blend-tree.test.mjs
@@ -6,7 +6,7 @@ import { AnimBlendTreeDirectional2D } from '../../../../src/framework/anim/contr
 import { AnimState } from '../../../../src/framework/anim/controller/anim-state.js';
 import { expect } from 'chai';
 
-describe('AnimBlendTree', () => {
+describe('AnimBlendTree', function () {
     const findParameter = () => {};
     const animState = new AnimState({ findParameter }, 'state', 1, true, null);
     const animBlendTree = new AnimBlendTree(animState, null, 'blendTree', 1, ['blendParam'], [
@@ -20,38 +20,38 @@ describe('AnimBlendTree', () => {
         }
     ], false, animState._createTree, findParameter);
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             expect(animBlendTree).to.be.ok;
         });
 
     });
 
-    describe('#getChild', () => {
+    describe('#getChild', function () {
 
-        it('can retrieve a child by name', () => {
+        it('can retrieve a child by name', function () {
             expect(animBlendTree.getChild('child1').name).to.equal('child1');
             expect(animBlendTree.getChild('child2').name).to.equal('child2');
         });
 
-        it('returns null when a child is not found', () => {
+        it('returns null when a child is not found', function () {
             expect(animBlendTree.getChild('child3')).to.equal(null);
         });
 
     });
 
-    describe('#getNodeCount', () => {
+    describe('#getNodeCount', function () {
 
-        it('returns the count of children in the blend tree', () => {
+        it('returns the count of children in the blend tree', function () {
             expect(animBlendTree.getNodeCount()).to.equal(2);
         });
 
     });
 
-    describe('#updateParameterValues', () => {
+    describe('#updateParameterValues', function () {
 
-        it('parameters are not set before it is called', () => {
+        it('parameters are not set before it is called', function () {
             const params = {
                 'param1': {
                     value: 'value1'
@@ -70,7 +70,7 @@ describe('AnimBlendTree', () => {
             expect(animBlendTree._parameterValues[1]).to.not.be.equal('value2');
         });
 
-        it('can set any updated parameters in the blend tree', () => {
+        it('can set any updated parameters in the blend tree', function () {
             const params = {
                 'param1': {
                     value: 'value1'
@@ -93,7 +93,7 @@ describe('AnimBlendTree', () => {
             expect(animBlendTree._parameterValues[1]).to.equal('value3');
         });
 
-        it('returns false when stored parameters are already up to date', () => {
+        it('returns false when stored parameters are already up to date', function () {
             const params = {
                 'param1': {
                     value: 'value1'
@@ -112,7 +112,7 @@ describe('AnimBlendTree', () => {
             expect(result).to.equal(false);
         });
 
-        it('returns true when stored parameters are already up to date', () => {
+        it('returns true when stored parameters are already up to date', function () {
             const params = {
                 'param1': {
                     value: 'value1'
@@ -137,7 +137,7 @@ describe('AnimBlendTree', () => {
 
 });
 
-describe('AnimBlendTree1D', () => {
+describe('AnimBlendTree1D', function () {
     const params = {
         'blendParam': {
             value: 0.5
@@ -158,22 +158,22 @@ describe('AnimBlendTree1D', () => {
         }
     ], false, animState._createTree, findParameter);
 
-    describe('#calculateWeights', () => {
+    describe('#calculateWeights', function () {
 
-        it('produces equal weights when the parameter is at the midpoint of both children', () => {
+        it('produces equal weights when the parameter is at the midpoint of both children', function () {
             animBlendTree.calculateWeights();
             expect(animBlendTree.getChild('child1').weight).to.equal(0.5);
             expect(animBlendTree.getChild('child2').weight).to.equal(0.5);
         });
 
-        it('produces unequal weights when the parameter is not the midpoint of both children', () => {
+        it('produces unequal weights when the parameter is not the midpoint of both children', function () {
             params.blendParam.value = 0.25;
             animBlendTree.calculateWeights();
             expect(animBlendTree.getChild('child1').weight).to.equal(0.75);
             expect(animBlendTree.getChild('child2').weight).to.equal(0.25);
         });
 
-        it('produces correct results when a parameter is the same as a childs point', () => {
+        it('produces correct results when a parameter is the same as a childs point', function () {
             params.blendParam.value = 1;
             animBlendTree.calculateWeights();
             expect(animBlendTree.getChild('child1').weight).to.equal(0);
@@ -183,7 +183,7 @@ describe('AnimBlendTree1D', () => {
     });
 });
 
-describe('AnimBlendTreeDirect', () => {
+describe('AnimBlendTreeDirect', function () {
     const params = {
         'blendParam1': {
             value: 0.5
@@ -205,15 +205,15 @@ describe('AnimBlendTreeDirect', () => {
         }
     ], false, animState._createTree, findParameter);
 
-    describe('#calculateWeights', () => {
+    describe('#calculateWeights', function () {
 
-        it('produces equal weights when the parameters are equal', () => {
+        it('produces equal weights when the parameters are equal', function () {
             animBlendTree.calculateWeights();
             expect(animBlendTree.getChild('child1').weight).to.equal(0.5);
             expect(animBlendTree.getChild('child2').weight).to.equal(0.5);
         });
 
-        it('produces unequal weights when the parameters are not equal', () => {
+        it('produces unequal weights when the parameters are not equal', function () {
             params.blendParam1.value = 0.75;
             params.blendParam2.value = 0.25;
             animBlendTree.calculateWeights();
@@ -221,7 +221,7 @@ describe('AnimBlendTreeDirect', () => {
             expect(animBlendTree.getChild('child2').weight).to.equal(0.25);
         });
 
-        it('produces a zero weight for single parameters that are zero', () => {
+        it('produces a zero weight for single parameters that are zero', function () {
             params.blendParam1.value = 1;
             params.blendParam2.value = 0;
             animBlendTree.calculateWeights();
@@ -229,7 +229,7 @@ describe('AnimBlendTreeDirect', () => {
             expect(animBlendTree.getChild('child2').weight).to.equal(0);
         });
 
-        it('produces zero weights when all parameters are zero', () => {
+        it('produces zero weights when all parameters are zero', function () {
             params.blendParam1.value = 0;
             params.blendParam2.value = 0;
             animBlendTree.calculateWeights();
@@ -241,7 +241,7 @@ describe('AnimBlendTreeDirect', () => {
 
 });
 
-describe('AnimBlendTreeCartesian2D', () => {
+describe('AnimBlendTreeCartesian2D', function () {
     const params = {
         'blendParam1': {
             value: 0
@@ -265,29 +265,29 @@ describe('AnimBlendTreeCartesian2D', () => {
         }
     ], false, animState._createTree, findParameter);
 
-    describe('#calculateWeights', () => {
+    describe('#calculateWeights', function () {
 
-        it('produces equal weights when the parameters are equal', () => {
+        it('produces equal weights when the parameters are equal', function () {
             animBlendTree.calculateWeights();
             expect(animBlendTree.getChild('child1').weight).to.equal(0.5);
             expect(animBlendTree.getChild('child2').weight).to.equal(0.5);
         });
 
-        it('produces unequal weights when the parameters are not equal', () => {
+        it('produces unequal weights when the parameters are not equal', function () {
             params.blendParam2.value = 0.5;
             animBlendTree.calculateWeights();
             expect(animBlendTree.getChild('child1').weight).to.equal(0.75);
             expect(animBlendTree.getChild('child2').weight).to.equal(0.25);
         });
 
-        it('produces a zero weight for single parameters that are zero', () => {
+        it('produces a zero weight for single parameters that are zero', function () {
             params.blendParam2.value = 1;
             animBlendTree.calculateWeights();
             expect(animBlendTree.getChild('child1').weight).to.equal(1);
             expect(animBlendTree.getChild('child2').weight).to.equal(0);
         });
 
-        it('produces a zero weights when all parameters are zero', () => {
+        it('produces a zero weights when all parameters are zero', function () {
             params.blendParam1.value = 0;
             params.blendParam2.value = 0;
             animBlendTree._children[0]._point = [0, 0];
@@ -301,7 +301,7 @@ describe('AnimBlendTreeCartesian2D', () => {
 
 });
 
-describe('AnimBlendTreeDirectional2D', () => {
+describe('AnimBlendTreeDirectional2D', function () {
     const params = {
         'blendParam1': {
             value: 0
@@ -325,29 +325,29 @@ describe('AnimBlendTreeDirectional2D', () => {
         }
     ], false, animState._createTree, findParameter);
 
-    describe('#calculateWeights', () => {
+    describe('#calculateWeights', function () {
 
-        it('produces equal weights when the parameters are equal', () => {
+        it('produces equal weights when the parameters are equal', function () {
             animBlendTree.calculateWeights();
             expect(animBlendTree.getChild('child1').weight).to.equal(0.5);
             expect(animBlendTree.getChild('child2').weight).to.equal(0.5);
         });
 
-        it('produces unequal weights when the parameters are not equal', () => {
+        it('produces unequal weights when the parameters are not equal', function () {
             params.blendParam2.value = 0.5;
             animBlendTree.calculateWeights();
             expect(animBlendTree.getChild('child1').weight).to.equal(1);
             expect(animBlendTree.getChild('child2').weight).to.equal(0);
         });
 
-        it('produces a zero weight for single parameters that are zero', () => {
+        it('produces a zero weight for single parameters that are zero', function () {
             params.blendParam2.value = 1;
             animBlendTree.calculateWeights();
             expect(animBlendTree.getChild('child1').weight).to.equal(1);
             expect(animBlendTree.getChild('child2').weight).to.equal(0);
         });
 
-        it('produces a zero weights when all parameters are zero', () => {
+        it('produces a zero weights when all parameters are zero', function () {
             params.blendParam1.value = 0;
             params.blendParam2.value = 0;
             animBlendTree._children[0]._point = [0, 0];

--- a/test/framework/anim/controller/anim-controller.test.mjs
+++ b/test/framework/anim/controller/anim-controller.test.mjs
@@ -12,7 +12,7 @@ import { NullGraphicsDevice } from '../../../../src/platform/graphics/null/null-
 import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 import { expect } from 'chai';
 
-describe('AnimController', () => {
+describe('AnimController', function () {
 
     let app;
     let controller;
@@ -103,60 +103,60 @@ describe('AnimController', () => {
         app.destroy();
     });
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             expect(controller).to.be.ok;
         });
 
     });
 
-    describe('#_getActiveStateProgressForTime', () => {
+    describe('#_getActiveStateProgressForTime', function () {
 
-        it('returns 1 when the controller is in the START state', () => {
+        it('returns 1 when the controller is in the START state', function () {
             controller.activeState = 'START';
             expect(controller._getActiveStateProgressForTime(0)).to.equal(1);
         });
 
-        it('returns 1 when the controller is in the ANY state', () => {
+        it('returns 1 when the controller is in the ANY state', function () {
             controller.activeState = 'ANY';
             expect(controller._getActiveStateProgressForTime(0)).to.equal(1);
         });
 
-        it('returns 1 when the controller is in the END state', () => {
+        it('returns 1 when the controller is in the END state', function () {
             controller.activeState = 'END';
             expect(controller._getActiveStateProgressForTime(0)).to.equal(1);
         });
 
-        it('returns a progress of 0 when the controller is at the start of a states timeline', () => {
+        it('returns a progress of 0 when the controller is at the start of a states timeline', function () {
             controller.update(0);
             expect(controller._getActiveStateProgressForTime(0)).to.equal(0);
         });
 
-        it('returns a progress of 0.5 when the controller is halfway through a states duration', () => {
+        it('returns a progress of 0.5 when the controller is halfway through a states duration', function () {
             controller.update(0);
             expect(controller._getActiveStateProgressForTime(2)).to.equal(0.5);
         });
 
-        it('returns a progress of 1 when the controller is at the end of a states timeline', () => {
+        it('returns a progress of 1 when the controller is at the end of a states timeline', function () {
             controller.update(0);
             expect(controller._getActiveStateProgressForTime(4)).to.equal(1);
         });
 
     });
 
-    describe('#_findTransitionsFromState', () => {
+    describe('#_findTransitionsFromState', function () {
 
-        it('returns the transitions for a given state', () => {
+        it('returns the transitions for a given state', function () {
             expect(controller._findTransitionsFromState('START').length).to.equal(1);
             expect(controller._findTransitionsFromState('START')[0].to).to.equal('Initial State');
         });
 
-        it('returns an empty array when a state has no transitions', () => {
+        it('returns an empty array when a state has no transitions', function () {
             expect(controller._findTransitionsFromState('Initial State').length).to.equal(0);
         });
 
-        it('returns transitions sorted by priority', () => {
+        it('returns transitions sorted by priority', function () {
             expect(controller._findTransitionsFromState('Other State 1').length).to.equal(2);
             expect(controller._findTransitionsFromState('Other State 1')[0].priority).to.equal(1);
             expect(controller._findTransitionsFromState('Other State 1')[1].priority).to.equal(2);
@@ -164,13 +164,13 @@ describe('AnimController', () => {
 
     });
 
-    describe('#_findTransitionsBetweenStates', () => {
+    describe('#_findTransitionsBetweenStates', function () {
 
-        it('returns the transitions between two states', () => {
+        it('returns the transitions between two states', function () {
             expect(controller._findTransitionsBetweenStates('Other State 1', 'Other State 2').length).to.equal(2);
         });
 
-        it('returns transitions sorted by priority', () => {
+        it('returns transitions sorted by priority', function () {
             expect(controller._findTransitionsBetweenStates('Other State 1', 'Other State 2').length).to.equal(2);
             expect(controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0].priority).to.equal(1);
             expect(controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[1].priority).to.equal(2);
@@ -178,46 +178,46 @@ describe('AnimController', () => {
 
     });
 
-    describe('#_transitionHasConditionsMet', () => {
+    describe('#_transitionHasConditionsMet', function () {
 
-        it('returns true when no conditions are present', () => {
+        it('returns true when no conditions are present', function () {
             expect(controller._transitionHasConditionsMet(controller._findTransitionsBetweenStates('START', 'Initial State')[0])).to.equal(true);
         });
 
-        it('returns true when a condition is present and met', () => {
+        it('returns true when a condition is present and met', function () {
             expect(controller._transitionHasConditionsMet(controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[1])).to.equal(true);
         });
 
-        it('returns false when a condition is present but not met', () => {
+        it('returns false when a condition is present but not met', function () {
             expect(controller._transitionHasConditionsMet(controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0])).to.equal(false);
         });
 
     });
 
-    describe('#_findTransition', () => {
+    describe('#_findTransition', function () {
 
-        it('returns a transition with the correct from state when from and to are supplied', () => {
+        it('returns a transition with the correct from state when from and to are supplied', function () {
             const transition = controller._findTransition('START', 'Initial State');
             expect(transition.from).to.equal('START');
         });
 
-        it('returns a transition with the correct source state when from and to are supplied', () => {
+        it('returns a transition with the correct source state when from and to are supplied', function () {
             const transition = controller._findTransition('START', 'Initial State');
             expect(transition.from).to.equal('START');
         });
 
-        it('returns a transition with the correct destination state when from and to are supplied', () => {
+        it('returns a transition with the correct destination state when from and to are supplied', function () {
             const transition = controller._findTransition('START', 'Initial State');
             expect(transition.to).to.equal('Initial State');
         });
 
-        it('returns a transition when the from param is given and the controller is not transitioning', () => {
+        it('returns a transition when the from param is given and the controller is not transitioning', function () {
             expect(controller._isTransitioning).to.equal(false);
             const transition = controller._findTransition('START');
             expect(transition.from).to.equal('START');
         });
 
-        it('returns null when controller is transitioning and the interruption source is "none"', () => {
+        it('returns null when controller is transitioning and the interruption source is "none"', function () {
             controller._isTransitioning = true;
             expect(controller._isTransitioning).to.equal(true);
             expect(controller._transitionInterruptionSource).to.equal('NONE');
@@ -225,7 +225,7 @@ describe('AnimController', () => {
             expect(transition).to.equal(null);
         });
 
-        it('returns null when controller is transitioning and the interruption source is "none"', () => {
+        it('returns null when controller is transitioning and the interruption source is "none"', function () {
             controller._isTransitioning = true;
             expect(controller._isTransitioning).to.equal(true);
             expect(controller._transitionInterruptionSource).to.equal('NONE');
@@ -233,7 +233,7 @@ describe('AnimController', () => {
             expect(transition).to.equal(null);
         });
 
-        it('returns a transition from the previous state when controller is transitioning and the interruption source is "PREV_STATE"', () => {
+        it('returns a transition from the previous state when controller is transitioning and the interruption source is "PREV_STATE"', function () {
             controller._isTransitioning = true;
             controller._transitionInterruptionSource = 'PREV_STATE';
             controller._previousStateName = 'Other State 1';
@@ -243,7 +243,7 @@ describe('AnimController', () => {
             expect(transition.from).to.equal('Other State 1');
         });
 
-        it('returns a transition from the ANY state when controller is transitioning and the interruption source is "PREV_STATE" with no matching previous state', () => {
+        it('returns a transition from the ANY state when controller is transitioning and the interruption source is "PREV_STATE" with no matching previous state', function () {
             controller._isTransitioning = true;
             controller._transitionInterruptionSource = 'PREV_STATE';
             expect(controller._isTransitioning).to.equal(true);
@@ -252,7 +252,7 @@ describe('AnimController', () => {
             expect(transition.from).to.equal('ANY');
         });
 
-        it('returns a transition from the next state when controller is transitioning and the interruption source is "NEXT_STATE"', () => {
+        it('returns a transition from the next state when controller is transitioning and the interruption source is "NEXT_STATE"', function () {
             controller._isTransitioning = true;
             controller._transitionInterruptionSource = 'NEXT_STATE';
             controller._activeStateName = 'Other State 1';
@@ -262,7 +262,7 @@ describe('AnimController', () => {
             expect(transition.from).to.equal('Other State 1');
         });
 
-        it('returns a transition from the ANY state when controller is transitioning and the interruption source is "NEXT_STATE" with no matching next state', () => {
+        it('returns a transition from the ANY state when controller is transitioning and the interruption source is "NEXT_STATE" with no matching next state', function () {
             controller.update(0);
             controller._isTransitioning = true;
             controller._transitionInterruptionSource = 'NEXT_STATE';
@@ -272,7 +272,7 @@ describe('AnimController', () => {
             expect(transition.from).to.equal('ANY');
         });
 
-        it('returns a transition from the next state when controller is transitioning and the interruption source is "PREV_STATE_NEXT_STATE"', () => {
+        it('returns a transition from the next state when controller is transitioning and the interruption source is "PREV_STATE_NEXT_STATE"', function () {
             controller._isTransitioning = true;
             controller._transitionInterruptionSource = 'PREV_STATE_NEXT_STATE';
             controller._activeStateName = 'Other State 1';
@@ -282,7 +282,7 @@ describe('AnimController', () => {
             expect(transition.from).to.equal('Other State 1');
         });
 
-        it('returns a transition from the previous state when controller is transitioning and the interruption source is "PREV_STATE_NEXT_STATE"', () => {
+        it('returns a transition from the previous state when controller is transitioning and the interruption source is "PREV_STATE_NEXT_STATE"', function () {
             controller._isTransitioning = true;
             controller._transitionInterruptionSource = 'PREV_STATE_NEXT_STATE';
             controller._previousStateName = 'Other State 1';
@@ -292,7 +292,7 @@ describe('AnimController', () => {
             expect(transition.from).to.equal('Other State 1');
         });
 
-        it('returns a transition from the ANY state when controller is transitioning and the interruption source is "PREV_STATE_NEXT_STATE"', () => {
+        it('returns a transition from the ANY state when controller is transitioning and the interruption source is "PREV_STATE_NEXT_STATE"', function () {
             controller.update(0);
             controller._isTransitioning = true;
             controller._transitionInterruptionSource = 'PREV_STATE_NEXT_STATE';
@@ -302,7 +302,7 @@ describe('AnimController', () => {
             expect(transition.from).to.equal('ANY');
         });
 
-        it('returns a transition from the next state when controller is transitioning and the interruption source is "NEXT_STATE_PREV_STATE"', () => {
+        it('returns a transition from the next state when controller is transitioning and the interruption source is "NEXT_STATE_PREV_STATE"', function () {
             controller._isTransitioning = true;
             controller._transitionInterruptionSource = 'NEXT_STATE_PREV_STATE';
             controller._activeStateName = 'Other State 1';
@@ -312,7 +312,7 @@ describe('AnimController', () => {
             expect(transition.from).to.equal('Other State 1');
         });
 
-        it('returns a transition from the previous state when controller is transitioning and the interruption source is "NEXT_STATE_PREV_STATE"', () => {
+        it('returns a transition from the previous state when controller is transitioning and the interruption source is "NEXT_STATE_PREV_STATE"', function () {
             controller._isTransitioning = true;
             controller._transitionInterruptionSource = 'NEXT_STATE_PREV_STATE';
             controller._previousStateName = 'Other State 1';
@@ -323,7 +323,7 @@ describe('AnimController', () => {
             expect(transition.from).to.equal('Other State 1');
         });
 
-        it('returns a transition from the ANY state when controller is transitioning and the interruption source is "NEXT_STATE_PREV_STATE"', () => {
+        it('returns a transition from the ANY state when controller is transitioning and the interruption source is "NEXT_STATE_PREV_STATE"', function () {
             controller.update(0);
             controller._isTransitioning = true;
             controller._transitionInterruptionSource = 'NEXT_STATE_PREV_STATE';
@@ -335,62 +335,62 @@ describe('AnimController', () => {
 
     });
 
-    describe('#updateStateFromTransition', () => {
+    describe('#updateStateFromTransition', function () {
 
-        it('begins transitions to the destination state', () => {
+        it('begins transitions to the destination state', function () {
             const transition = controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0];
             controller.updateStateFromTransition(transition);
             expect(controller.activeStateName).to.equal('Other State 2');
         });
 
-        it('sets the currently active state as the previous state', () => {
+        it('sets the currently active state as the previous state', function () {
             const previousActiveState = controller.activeStateName;
             const transition = controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0];
             controller.updateStateFromTransition(transition);
             expect(controller.previousStateName).to.equal(previousActiveState);
         });
 
-        it('adds a new clip for the newly active state to the evaluator', () => {
+        it('adds a new clip for the newly active state to the evaluator', function () {
             const transition = controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0];
             controller.updateStateFromTransition(transition);
             expect(controller._animEvaluator.clips[0].track.name).to.equal('otherState2Track');
         });
 
-        it('sets the controller _isTransitoning property to true', () => {
+        it('sets the controller _isTransitoning property to true', function () {
             const transition = controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0];
             expect(controller._isTransitioning).to.equal(false);
             controller.updateStateFromTransition(transition);
             expect(controller._isTransitioning).to.equal(true);
         });
 
-        it('sets the current transition time to 0', () => {
+        it('sets the current transition time to 0', function () {
             const transition = controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0];
             controller.updateStateFromTransition(transition);
             expect(controller._currTransitionTime).to.equal(0);
         });
 
-        it('sets the time in state correctly if a transition offset is supplied', () => {
+        it('sets the time in state correctly if a transition offset is supplied', function () {
             const transition = controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0];
             transition._transitionOffset = 0.5;
             controller.updateStateFromTransition(transition);
             expect(controller._timeInState).to.equal(2);
         });
 
-        it('sets the time in state before correctly if a transition offset is supplied', () => {
+        it('sets the time in state before correctly if a transition offset is supplied', function () {
             const transition = controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0];
             transition._transitionOffset = 0.5;
             controller.updateStateFromTransition(transition);
             expect(controller._timeInStateBefore).to.equal(2);
         });
 
-        it('sets the new clips time correctly if a transition offset is supplied', () => {
+        it('sets the new clips time correctly if a transition offset is supplied', function () {
             const transition = controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0];
             transition._transitionOffset = 0.5;
             controller.updateStateFromTransition(transition);
             expect(controller._animEvaluator.clips[0].time).to.equal(2);
         });
 
-        it('sets the new clips time correctly if a transition offset is not supplied', () => {
+        it('sets the new clips time correctly if a transition offset is not supplied', function () {
             const transition = controller._findTransitionsBetweenStates('Other State 1', 'Other State 2')[0];
             controller.updateStateFromTransition(transition);
             expect(controller._animEvaluator.clips[0].time).to.equal(0);

--- a/test/framework/anim/controller/anim-node.test.mjs
+++ b/test/framework/anim/controller/anim-node.test.mjs
@@ -2,11 +2,11 @@ import { AnimNode } from '../../../../src/framework/anim/controller/anim-node.js
 import { AnimState } from '../../../../src/framework/anim/controller/anim-state.js';
 import { expect } from 'chai';
 
-describe('AnimNode', () => {
+describe('AnimNode', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', 1);
             expect(animNode).to.be.ok;
@@ -14,9 +14,9 @@ describe('AnimNode', () => {
 
     });
 
-    describe('#name', () => {
+    describe('#name', function () {
 
-        it('returns the name of the AnimNode', () => {
+        it('returns the name of the AnimNode', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', 1);
             expect(animNode.name).to.equal('node');
@@ -24,9 +24,9 @@ describe('AnimNode', () => {
 
     });
 
-    describe('#parent', () => {
+    describe('#parent', function () {
 
-        it('returns the parent of the AnimNode', () => {
+        it('returns the parent of the AnimNode', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNodeParent = new AnimNode(animState, null, 'parent', 1);
             const animNode = new AnimNode(animState, animNodeParent, 'node', 1);
@@ -35,15 +35,15 @@ describe('AnimNode', () => {
 
     });
 
-    describe('#path', () => {
+    describe('#path', function () {
 
-        it('returns the name of the AnimNode when it has no parent', () => {
+        it('returns the name of the AnimNode when it has no parent', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', 1);
             expect(animNode.path).to.equal('node');
         });
 
-        it('returns a path representing a node and its hierarchy', () => {
+        it('returns a path representing a node and its hierarchy', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNodeParent = new AnimNode(animState, null, 'parent', 1);
             const animNode = new AnimNode(animState, animNodeParent, 'node', 1);
@@ -52,15 +52,15 @@ describe('AnimNode', () => {
 
     });
 
-    describe('#pointLength', () => {
+    describe('#pointLength', function () {
 
-        it('returns the correct point length when the point is 1 dimensional', () => {
+        it('returns the correct point length when the point is 1 dimensional', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', 1);
             expect(animNode.pointLength).to.equal(1);
         });
 
-        it('returns the correct point length when the point is 2 dimensional', () => {
+        it('returns the correct point length when the point is 2 dimensional', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', [5, 2]);
             expect(animNode.pointLength).to.equal(Math.sqrt(5 * 5 + 2 * 2));
@@ -68,23 +68,23 @@ describe('AnimNode', () => {
 
     });
 
-    describe('#weight', () => {
+    describe('#weight', function () {
 
-        it('can set the weight of the AnimNode', () => {
+        it('can set the weight of the AnimNode', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', 1);
             animNode.weight = 0.5;
             expect(animNode._weight).to.equal(0.5);
         });
 
-        it('can get the weight of the AnimNode when no parent is present', () => {
+        it('can get the weight of the AnimNode when no parent is present', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', 1);
             expect(animNode.parent).to.equal(null);
             expect(animNode.weight).to.equal(1.0);
         });
 
-        it('can get the correct weight of the AnimNode when a parent is present', () => {
+        it('can get the correct weight of the AnimNode when a parent is present', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNodeParent = new AnimNode(animState, null, 'parent', 1);
             animNodeParent.weight = 0.5;
@@ -96,9 +96,9 @@ describe('AnimNode', () => {
 
     });
 
-    describe('#normalizedWeight', () => {
+    describe('#normalizedWeight', function () {
 
-        it('can get the normalized weight when the AnimNode\'s state total weight is non zero', () => {
+        it('can get the normalized weight when the AnimNode\'s state total weight is non zero', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             animState.animations = [
                 {
@@ -115,7 +115,7 @@ describe('AnimNode', () => {
             expect(animNode.normalizedWeight).to.equal(0.5);
         });
 
-        it('can get the normalized weight when the AnimNode\'s state total weight is zero', () => {
+        it('can get the normalized weight when the AnimNode\'s state total weight is zero', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', 1);
             animNode.weight = 2.5;
@@ -124,16 +124,16 @@ describe('AnimNode', () => {
 
     });
 
-    describe('#absoluteSpeed', () => {
+    describe('#absoluteSpeed', function () {
 
-        it('returns an absolue speed when speed is negative', () => {
+        it('returns an absolue speed when speed is negative', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', 1, -5);
             expect(animNode.speed).to.equal(-5);
             expect(animNode.absoluteSpeed).to.equal(5);
         });
 
-        it('returns an absolue speed when speed is positive', () => {
+        it('returns an absolue speed when speed is positive', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', 1, 5);
             expect(animNode.speed).to.equal(5);
@@ -142,9 +142,9 @@ describe('AnimNode', () => {
 
     });
 
-    describe('#speed', () => {
+    describe('#speed', function () {
 
-        it('returns a speed value thats weighted by the weightedSpeed value', () => {
+        it('returns a speed value thats weighted by the weightedSpeed value', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             const animNode = new AnimNode(animState, null, 'node', 1, 0.5);
             animNode.weightedSpeed = 0.5;

--- a/test/framework/anim/controller/anim-state.test.mjs
+++ b/test/framework/anim/controller/anim-state.test.mjs
@@ -6,18 +6,18 @@ import { AnimCurve } from '../../../../src/framework/anim/evaluator/anim-curve.j
 import { AnimData } from '../../../../src/framework/anim/evaluator/anim-data.js';
 import { AnimTrack } from '../../../../src/framework/anim/evaluator/anim-track.js';
 
-describe('AnimState', () => {
+describe('AnimState', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, null);
             expect(animState).to.be.ok;
             expect(animState.name).to.equal('state');
             expect(animState.nodeCount).to.equal(1);
         });
 
-        it('instansiates correctly with a blend tree', () => {
+        it('instansiates correctly with a blend tree', function () {
             const animState = new AnimState({ findParameter: () => {} }, 'state', 1, true, {
                 type: ANIM_BLEND_1D,
                 parameter: 'param',
@@ -30,9 +30,9 @@ describe('AnimState', () => {
 
     });
 
-    describe('#addAnimation', () => {
+    describe('#addAnimation', function () {
 
-        it('can add an animation to the AnimState instance', () => {
+        it('can add an animation to the AnimState instance', function () {
 
             const curves = [new AnimCurve(['path/to/entity'], 0, 0, INTERPOLATION_LINEAR)];
             const inputs = [new AnimData(1, [0, 1, 2])];

--- a/test/framework/anim/controller/anim-transition.test.mjs
+++ b/test/framework/anim/controller/anim-transition.test.mjs
@@ -1,11 +1,11 @@
 import { AnimTransition } from '../../../../src/framework/anim/controller/anim-transition.js';
 import { expect } from 'chai';
 
-describe('AnimTransition', () => {
+describe('AnimTransition', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             const animTransition = new AnimTransition({
                 from: 'fromState',
                 to: 'toState'

--- a/test/framework/anim/evaluator/anim-cache.test.mjs
+++ b/test/framework/anim/evaluator/anim-cache.test.mjs
@@ -3,31 +3,31 @@ import { AnimData } from '../../../../src/framework/anim/evaluator/anim-data.js'
 import { INTERPOLATION_STEP, INTERPOLATION_LINEAR } from '../../../../src/framework/anim/constants.js';
 import { expect } from 'chai';
 
-describe('AnimCache', () => {
+describe('AnimCache', function () {
     const animCache = new AnimCache();
     const input = new AnimData(1, [0, 1, 2]);
     const output = new AnimData(3, [0, 0, 0, 1, 2, 3, 2, 4, 6]);
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             expect(animCache).to.be.ok;
         });
 
     });
 
-    describe('#update', () => {
+    describe('#update', function () {
 
-        it('can update the normalized time of the cache', () => {
+        it('can update the normalized time of the cache', function () {
             animCache.update(1.25, input.data);
             expect(animCache._t).to.equal(0.25);
         });
 
     });
 
-    describe('#eval', () => {
+    describe('#eval', function () {
 
-        it('can retrieve the step output keyframe value for a given input key', () => {
+        it('can retrieve the step output keyframe value for a given input key', function () {
             const result = [0, 0, 0];
             animCache.update(0, input.data);
             animCache.eval(result, INTERPOLATION_STEP, output);
@@ -43,7 +43,7 @@ describe('AnimCache', () => {
             expect(result).to.deep.equal([1, 2, 3]);
         });
 
-        it('can retrieve the linear output keyframe value for a given input key', () => {
+        it('can retrieve the linear output keyframe value for a given input key', function () {
             const result = [0, 0, 0];
             animCache.update(0, input.data);
             animCache.eval(result, INTERPOLATION_LINEAR, output);

--- a/test/framework/anim/evaluator/anim-clip.test.mjs
+++ b/test/framework/anim/evaluator/anim-clip.test.mjs
@@ -6,7 +6,7 @@ import { AnimEvents } from '../../../../src/framework/anim/evaluator/anim-events
 import { INTERPOLATION_LINEAR } from '../../../../src/framework/anim/constants.js';
 import { expect } from 'chai';
 
-describe('AnimClip', () => {
+describe('AnimClip', function () {
     let animClip;
 
     beforeEach(() => {
@@ -24,9 +24,9 @@ describe('AnimClip', () => {
         });
     });
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             expect(animClip).to.be.ok;
             expect(animClip.name).to.equal('track');
             expect(animClip.track.name).to.equal('track');
@@ -38,18 +38,18 @@ describe('AnimClip', () => {
 
     });
 
-    describe('#_update', () => {
+    describe('#_update', function () {
 
-        it('can update the clip\'s snapshot by a given deltaTime', () => {
+        it('can update the clip\'s snapshot by a given deltaTime', function () {
             animClip._update(0.5);
             expect(animClip.snapshot._results[0]).to.deep.equal([0.5, 1, 1.5]);
         });
 
     });
 
-    describe('#pause', () => {
+    describe('#pause', function () {
 
-        it('can stop the clip from updating', () => {
+        it('can stop the clip from updating', function () {
             animClip.pause();
             animClip._update(0.5);
             expect(animClip.snapshot._results[0]).to.deep.equal([0, 0, 0]);
@@ -57,9 +57,9 @@ describe('AnimClip', () => {
 
     });
 
-    describe('#stop', () => {
+    describe('#stop', function () {
 
-        it('pauses the clip and moves the cursor to the start', () => {
+        it('pauses the clip and moves the cursor to the start', function () {
             animClip._update(0.5);
             animClip.stop();
             animClip._update(0.5);
@@ -68,9 +68,9 @@ describe('AnimClip', () => {
 
     });
 
-    describe('#reset', () => {
+    describe('#reset', function () {
 
-        it('moves the cursor to the start', () => {
+        it('moves the cursor to the start', function () {
             animClip._update(0.5);
             animClip.reset();
             animClip._update(0);
@@ -79,9 +79,9 @@ describe('AnimClip', () => {
 
     });
 
-    describe('#resume', () => {
+    describe('#resume', function () {
 
-        it('moves the cursor to the start', () => {
+        it('moves the cursor to the start', function () {
             animClip.pause();
             animClip.resume();
             animClip._update(0.5);
@@ -90,9 +90,9 @@ describe('AnimClip', () => {
 
     });
 
-    describe('#play', () => {
+    describe('#play', function () {
 
-        it('plays the clip from the beginning', () => {
+        it('plays the clip from the beginning', function () {
             animClip._update(0.5);
             animClip.pause();
             animClip.play();
@@ -102,9 +102,9 @@ describe('AnimClip', () => {
 
     });
 
-    describe('#time', () => {
+    describe('#time', function () {
 
-        it('aligns the clips eventCursor property when setting the time', () => {
+        it('aligns the clips eventCursor property when setting the time', function () {
             expect(animClip.eventCursor).to.equal(0);
             animClip.time = 1.1;
             expect(animClip.eventCursor).to.equal(2);
@@ -114,7 +114,7 @@ describe('AnimClip', () => {
             expect(animClip.eventCursor).to.equal(0);
         });
 
-        it('updates the clips eventCursor property as the clip updates forwards', () => {
+        it('updates the clips eventCursor property as the clip updates forwards', function () {
             expect(animClip.time).to.equal(0);
             expect(animClip.eventCursor).to.equal(0);
             animClip._update(0.55);
@@ -131,7 +131,7 @@ describe('AnimClip', () => {
             expect(animClip.eventCursor).to.equal(0);
         });
 
-        it('updates the clips eventCursor property as the clip updates backwards', () => {
+        it('updates the clips eventCursor property as the clip updates backwards', function () {
             animClip.speed = -1;
             animClip.time = 2;
             expect(animClip.time).to.equal(2);

--- a/test/framework/anim/evaluator/anim-curve.test.mjs
+++ b/test/framework/anim/evaluator/anim-curve.test.mjs
@@ -2,7 +2,7 @@ import { AnimCurve } from '../../../../src/framework/anim/evaluator/anim-curve.j
 import { INTERPOLATION_CUBIC } from '../../../../src/framework/anim/constants.js';
 import { expect } from 'chai';
 
-describe('AnimCurve', () => {
+describe('AnimCurve', function () {
     const animCurve = new AnimCurve(
         ['path/to/entity1', 'path/to/entity2'],
         1,
@@ -10,42 +10,42 @@ describe('AnimCurve', () => {
         INTERPOLATION_CUBIC
     );
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             expect(animCurve).to.be.ok;
         });
 
     });
 
-    describe('#paths', () => {
+    describe('#paths', function () {
 
-        it('can retrieve the curve paths', () => {
+        it('can retrieve the curve paths', function () {
             expect(animCurve.paths.length).to.equal(2);
             expect(animCurve.paths).to.deep.equal(['path/to/entity1', 'path/to/entity2']);
         });
 
     });
 
-    describe('#input', () => {
+    describe('#input', function () {
 
-        it('can retrieve the input value', () => {
+        it('can retrieve the input value', function () {
             expect(animCurve.input).to.equal(1);
         });
 
     });
 
-    describe('#output', () => {
+    describe('#output', function () {
 
-        it('can retrieve the output value', () => {
+        it('can retrieve the output value', function () {
             expect(animCurve.output).to.equal(2);
         });
 
     });
 
-    describe('#interpolation', () => {
+    describe('#interpolation', function () {
 
-        it('can retrieve the interpolation value', () => {
+        it('can retrieve the interpolation value', function () {
             expect(animCurve.interpolation).to.equal(INTERPOLATION_CUBIC);
         });
 

--- a/test/framework/anim/evaluator/anim-data.test.mjs
+++ b/test/framework/anim/evaluator/anim-data.test.mjs
@@ -1,30 +1,30 @@
 import { AnimData } from '../../../../src/framework/anim/evaluator/anim-data.js';
 import { expect } from 'chai';
 
-describe('AnimData', () => {
+describe('AnimData', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
         const animData = new AnimData(1, [0, 1, 2]);
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             expect(animData).to.be.ok;
         });
 
     });
 
-    describe('#components', () => {
+    describe('#components', function () {
         const animData = new AnimData(1, [0, 1, 2]);
 
-        it('can retrieve the number of components', () => {
+        it('can retrieve the number of components', function () {
             expect(animData.components).to.equal(1);
         });
 
     });
 
-    describe('#data', () => {
+    describe('#data', function () {
         const animData = new AnimData(1, [0, 1, 2]);
 
-        it('can retrieve the number of components', () => {
+        it('can retrieve the number of components', function () {
             expect(animData.data.length).to.equal(3);
             expect(animData.data).to.deep.equal([0, 1, 2]);
         });

--- a/test/framework/anim/evaluator/anim-evaluator.test.mjs
+++ b/test/framework/anim/evaluator/anim-evaluator.test.mjs
@@ -14,9 +14,9 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe('AnimEvaluator', () => {
+describe('AnimEvaluator', function () {
 
-    it('AnimEvaluator: update with clip blending', () => {
+    it('AnimEvaluator: update with clip blending', function () {
         const canvas = new HTMLCanvasElement(500, 500);
         const app = new Application(canvas, { graphicsDevice: new NullGraphicsDevice(canvas) });
 
@@ -89,7 +89,7 @@ describe('AnimEvaluator', () => {
         expect(child1.localPosition.z).to.equal(0);
     });
 
-    it('AnimEvaluator: update without clip blending', () => {
+    it('AnimEvaluator: update without clip blending', function () {
         const canvas = new HTMLCanvasElement(500, 500);
         const app = new Application(canvas, { graphicsDevice: new NullGraphicsDevice(canvas) });
 

--- a/test/framework/anim/evaluator/anim-events.test.mjs
+++ b/test/framework/anim/evaluator/anim-events.test.mjs
@@ -1,7 +1,7 @@
 import { AnimEvents } from '../../../../src/framework/anim/evaluator/anim-events.js';
 import { expect } from 'chai';
 
-describe('AnimEvents', () => {
+describe('AnimEvents', function () {
     const animEvents = new AnimEvents([
         {
             name: 'event2',
@@ -15,26 +15,26 @@ describe('AnimEvents', () => {
         }
     ]);
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             expect(animEvents).to.be.ok;
         });
 
     });
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('sorts the events', () => {
+        it('sorts the events', function () {
             expect(animEvents.events[0].name).to.equal('event1');
             expect(animEvents.events[1].name).to.equal('event2');
         });
 
     });
 
-    describe('#events', () => {
+    describe('#events', function () {
 
-        it('returns the events stored in the instance', () => {
+        it('returns the events stored in the instance', function () {
             expect(animEvents.events[0].name).to.equal('event1');
             expect(animEvents.events[0].time).to.equal(0.5);
             expect(animEvents.events[0].property).to.equal(false);

--- a/test/framework/anim/evaluator/anim-snapshot.test.mjs
+++ b/test/framework/anim/evaluator/anim-snapshot.test.mjs
@@ -5,16 +5,16 @@ import { AnimSnapshot } from '../../../../src/framework/anim/evaluator/anim-snap
 import { INTERPOLATION_LINEAR } from '../../../../src/framework/anim/constants.js';
 import { expect } from 'chai';
 
-describe('AnimSnapshot', () => {
+describe('AnimSnapshot', function () {
     const curves = [new AnimCurve(['path/to/entity'], 0, 0, INTERPOLATION_LINEAR)];
     const inputs = [new AnimData(1, [0, 1, 2])];
     const outputs = [new AnimData(3, [0, 0, 0, 1, 2, 3, 2, 4, 6])];
     const animTrack = new AnimTrack('track', 2, inputs, outputs, curves);
     const animSnapshot = new AnimSnapshot(animTrack);
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             expect(animSnapshot).to.be.ok;
             expect(animSnapshot._name).to.equal('trackSnapshot');
             expect(animSnapshot._time).to.equal(-1);

--- a/test/framework/anim/evaluator/anim-target-value.test.mjs
+++ b/test/framework/anim/evaluator/anim-target-value.test.mjs
@@ -2,11 +2,11 @@ import { AnimTargetValue } from '../../../../src/framework/anim/evaluator/anim-t
 import { ANIM_LAYER_ADDITIVE, ANIM_LAYER_OVERWRITE } from '../../../../src/framework/anim/controller/constants.js';
 import { expect } from 'chai';
 
-describe('AnimTargetValue', () => {
+describe('AnimTargetValue', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly with an object', () => {
+        it('instantiates correctly with an object', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -25,9 +25,9 @@ describe('AnimTargetValue', () => {
 
     });
 
-    describe('#setMask', () => {
+    describe('#setMask', function () {
 
-        it('sets dirty to true if normalizeWeights is true', () => {
+        it('sets dirty to true if normalizeWeights is true', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -47,7 +47,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.dirty).to.equal(true);
         });
 
-        it('doesn\'t set dirty to true if normalizeWeights is false', () => {
+        it('doesn\'t set dirty to true if normalizeWeights is false', function () {
             const mockComponent = {
                 normalizeWeights: false,
                 layers: [
@@ -67,7 +67,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.dirty).to.equal(false);
         });
 
-        it('sets the indexed mask value to the given value', () => {
+        it('sets the indexed mask value to the given value', function () {
             const mockComponent = {
                 normalizeWeights: false,
                 layers: [
@@ -87,7 +87,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.mask[0]).to.equal(1);
         });
 
-        it('sets the previous mask values to 0 if normalizeWeights is true and the layers blend type is overwrite', () => {
+        it('sets the previous mask values to 0 if normalizeWeights is true and the layers blend type is overwrite', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -107,7 +107,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.mask[0]).to.equal(0);
         });
 
-        it('doesn\'t set the previous mask value to 0 if normalizeWeights is true and the layers blend type is additive', () => {
+        it('doesn\'t set the previous mask value to 0 if normalizeWeights is true and the layers blend type is additive', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -127,7 +127,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.mask[0]).to.equal(1);
         });
 
-        it('doesn\'t set the previous mask value to 0 if normalizeWeights is false and the layers blend type is overwrite', () => {
+        it('doesn\'t set the previous mask value to 0 if normalizeWeights is false and the layers blend type is overwrite', function () {
             const mockComponent = {
                 normalizeWeights: false,
                 layers: [
@@ -147,7 +147,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.mask[0]).to.equal(1);
         });
 
-        it('doesn\'t set the previous mask value to 0 if normalizeWeights is false and the layers blend type is additive', () => {
+        it('doesn\'t set the previous mask value to 0 if normalizeWeights is false and the layers blend type is additive', function () {
             const mockComponent = {
                 normalizeWeights: false,
                 layers: [
@@ -169,9 +169,9 @@ describe('AnimTargetValue', () => {
 
     });
 
-    describe('#updateWeights', () => {
+    describe('#updateWeights', function () {
 
-        it('sets the instances weights to that of the component\'s layers weights', () => {
+        it('sets the instances weights to that of the component\'s layers weights', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -190,7 +190,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.weights).to.deep.equal(new Float32Array([1, 2]));
         });
 
-        it('sets the total weight to the sum of all the component\'s layers weights and their masks', () => {
+        it('sets the total weight to the sum of all the component\'s layers weights and their masks', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -215,9 +215,9 @@ describe('AnimTargetValue', () => {
 
     });
 
-    describe('#getWeight', () => {
+    describe('#getWeight', function () {
 
-        it('calls updateWeights if dirty is true', () => {
+        it('calls updateWeights if dirty is true', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -240,7 +240,7 @@ describe('AnimTargetValue', () => {
             expect(updateWeightsCalled).to.equal(true);
         });
 
-        it('does not call updateWeights if dirty is false', () => {
+        it('does not call updateWeights if dirty is false', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -263,7 +263,7 @@ describe('AnimTargetValue', () => {
             expect(updateWeightsCalled).to.equal(false);
         });
 
-        it('returns 0 when the indexed mask is 0', () => {
+        it('returns 0 when the indexed mask is 0', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -281,7 +281,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.getWeight(0)).to.equal(0);
         });
 
-        it('returns 1 when the indexed mask is 1', () => {
+        it('returns 1 when the indexed mask is 1', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -300,7 +300,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.getWeight(0)).to.equal(1);
         });
 
-        it('returns 0 when normalizeWeights is true and totalWeight is 0', () => {
+        it('returns 0 when normalizeWeights is true and totalWeight is 0', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -322,7 +322,7 @@ describe('AnimTargetValue', () => {
             expect(weight).to.equal(0);
         });
 
-        it('returns a normalized weight when normalizeWeights is true and totalWeight is non 0', () => {
+        it('returns a normalized weight when normalizeWeights is true and totalWeight is non 0', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -344,7 +344,7 @@ describe('AnimTargetValue', () => {
             expect(weight).to.equal(0.2);
         });
 
-        it('returns a weight when normalizeWeights is false and totalWeight is non 0', () => {
+        it('returns a weight when normalizeWeights is false and totalWeight is non 0', function () {
             const mockComponent = {
                 normalizeWeights: false,
                 layers: [
@@ -368,9 +368,9 @@ describe('AnimTargetValue', () => {
 
     });
 
-    describe('#updateValue', () => {
+    describe('#updateValue', function () {
 
-        it('can set a vector', () => {
+        it('can set a vector', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -386,7 +386,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([1, 1, 1]);
         });
 
-        it('can set a normalized vector', () => {
+        it('can set a normalized vector', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -403,7 +403,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([1, 1, 1]);
         });
 
-        it('can set a quat', () => {
+        it('can set a quat', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -419,7 +419,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([1, 0, 0, 0]);
         });
 
-        it('can set a normalized quat', () => {
+        it('can set a normalized quat', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -436,7 +436,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([1, 0, 0, 0]);
         });
 
-        it('can blend two additive vectors together', () => {
+        it('can blend two additive vectors together', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -459,7 +459,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([3, 3, 3]);
         });
 
-        it('can blend two additive vectors together with normalized weights', () => {
+        it('can blend two additive vectors together with normalized weights', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -483,7 +483,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([1.25, 1.25, 1.25]);
         });
 
-        it('can blend two additive quats together', () => {
+        it('can blend two additive quats together', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -506,7 +506,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([0, 0, 1, 0]);
         });
 
-        it('can blend two additive quats together with normalized weights', () => {
+        it('can blend two additive quats together with normalized weights', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -536,7 +536,7 @@ describe('AnimTargetValue', () => {
         });
 
 
-        it('can blend two overwrite vectors together', () => {
+        it('can blend two overwrite vectors together', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -559,7 +559,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([2, 2, 2]);
         });
 
-        it('can blend two overwrite vectors together with normalized weights', () => {
+        it('can blend two overwrite vectors together with normalized weights', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -583,7 +583,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([2, 2, 2]);
         });
 
-        it('can blend two overwrite quats together', () => {
+        it('can blend two overwrite quats together', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -606,7 +606,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([0, 1, 0, 0]);
         });
 
-        it('can blend two overwrite quats together with normalized weights', () => {
+        it('can blend two overwrite quats together with normalized weights', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -630,7 +630,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([0, 1, 0, 0]);
         });
 
-        it('can blend one additive and one overwrite vector together', () => {
+        it('can blend one additive and one overwrite vector together', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -653,7 +653,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([2, 2, 2]);
         });
 
-        it('can blend one additive and one overwrite vector together', () => {
+        it('can blend one additive and one overwrite vector together', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -676,7 +676,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([2, 2, 2]);
         });
 
-        it('can blend one additive and one overwrite vector together with normalized weights', () => {
+        it('can blend one additive and one overwrite vector together with normalized weights', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -700,7 +700,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([2, 2, 2]);
         });
 
-        it('can blend one additive and one overwrite quat together', () => {
+        it('can blend one additive and one overwrite quat together', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -723,7 +723,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([0, 1, 0, 0]);
         });
 
-        it('can blend one additive and one overwrite quat together with normalized weights', () => {
+        it('can blend one additive and one overwrite quat together with normalized weights', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -747,7 +747,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([0, 1, 0, 0]);
         });
 
-        it('can blend one overwrite and one additive vector together', () => {
+        it('can blend one overwrite and one additive vector together', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -770,7 +770,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([3, 3, 3]);
         });
 
-        it('can blend one overwrite and one additive vector together with normalized weights', () => {
+        it('can blend one overwrite and one additive vector together with normalized weights', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [
@@ -794,7 +794,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([1.25, 1.25, 1.25]);
         });
 
-        it('can blend one overwrite and one additive quat together', () => {
+        it('can blend one overwrite and one additive quat together', function () {
             const mockComponent = {
                 layers: [
                     {
@@ -817,7 +817,7 @@ describe('AnimTargetValue', () => {
             expect(animTargetValue.value).to.deep.equal([0, 0, 1, 0]);
         });
 
-        it('can blend one overwrite and one additive quat together with normalized weights', () => {
+        it('can blend one overwrite and one additive quat together with normalized weights', function () {
             const mockComponent = {
                 normalizeWeights: true,
                 layers: [

--- a/test/framework/anim/evaluator/anim-target.test.mjs
+++ b/test/framework/anim/evaluator/anim-target.test.mjs
@@ -1,11 +1,11 @@
 import { AnimTarget } from '../../../../src/framework/anim/evaluator/anim-target.js';
 import { expect } from 'chai';
 
-describe('AnimTarget', () => {
+describe('AnimTarget', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly with an object', () => {
+        it('instantiates correctly with an object', function () {
             const func = {
                 set: 'set',
                 get: 'get'
@@ -21,7 +21,7 @@ describe('AnimTarget', () => {
             expect(animTarget.isTransform).to.equal(false);
         });
 
-        it('instantiates correctly with a function', () => {
+        it('instantiates correctly with a function', function () {
             const func = () => {};
             const animTarget = new AnimTarget(func, 'vector', 3, 'path/to/entity');
 
@@ -34,7 +34,7 @@ describe('AnimTarget', () => {
             expect(animTarget.isTransform).to.equal(false);
         });
 
-        it('instantiates correctly with a transform path', () => {
+        it('instantiates correctly with a transform path', function () {
             const func = () => {};
             const animTarget = new AnimTarget(func, 'vector', 3, 'path/to/entity/localScale');
 

--- a/test/framework/anim/evaluator/anim-track.test.mjs
+++ b/test/framework/anim/evaluator/anim-track.test.mjs
@@ -5,15 +5,15 @@ import { AnimSnapshot } from '../../../../src/framework/anim/evaluator/anim-snap
 import { INTERPOLATION_LINEAR } from '../../../../src/framework/anim/constants.js';
 import { expect } from 'chai';
 
-describe('AnimTrack', () => {
+describe('AnimTrack', function () {
     const curves = [new AnimCurve(['path/to/entity'], 0, 0, INTERPOLATION_LINEAR)];
     const inputs = [new AnimData(1, [0, 1, 2])];
     const outputs = [new AnimData(3, [0, 0, 0, 1, 2, 3, 2, 4, 6])];
     const animTrack = new AnimTrack('track', 2, inputs, outputs, curves);
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             expect(animTrack).to.be.ok;
             expect(animTrack.name).to.equal('track');
             expect(animTrack.duration).to.equal(2);
@@ -24,9 +24,9 @@ describe('AnimTrack', () => {
 
     });
 
-    describe('#eval', () => {
+    describe('#eval', function () {
 
-        it('correctly updates a given snapshot', () => {
+        it('correctly updates a given snapshot', function () {
             const snapshot = new AnimSnapshot(animTrack);
             animTrack.eval(0, snapshot);
             expect(snapshot._results[0]).to.deep.equal([0, 0, 0]);
@@ -40,12 +40,12 @@ describe('AnimTrack', () => {
 
 });
 
-describe('EmptyAnimTrack', () => {
+describe('EmptyAnimTrack', function () {
     const emptyAnimTrack = AnimTrack.EMPTY;
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             expect(emptyAnimTrack).to.be.ok;
             expect(emptyAnimTrack.name).to.equal('empty');
             expect(emptyAnimTrack.duration).to.equal(Number.MAX_VALUE);

--- a/test/framework/anim/state-graph/anim-state-graph.test.mjs
+++ b/test/framework/anim/state-graph/anim-state-graph.test.mjs
@@ -1,11 +1,11 @@
 import { AnimStateGraph } from '../../../../src/framework/anim/state-graph/anim-state-graph.js';
 import { expect } from 'chai';
 
-describe('AnimStateGraph', () => {
+describe('AnimStateGraph', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly with data layers as an object', () => {
+        it('instantiates correctly with data layers as an object', function () {
             const data = {
                 'layers': {
                     '0': {
@@ -42,7 +42,7 @@ describe('AnimStateGraph', () => {
             expect(animStateGraph.layers[0].states[1].name).to.equal('New State');
         });
 
-        it('instantiates correctly with data layers as an array', () => {
+        it('instantiates correctly with data layers as an array', function () {
             const data = {
                 'layers': [
                     {

--- a/test/framework/application.test.mjs
+++ b/test/framework/application.test.mjs
@@ -18,11 +18,11 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe('Application', () => {
+describe('Application', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('support no options', () => {
+        it('support no options', function () {
             const canvas = new HTMLCanvasElement(500, 500);
             const app = new Application(canvas, { graphicsDevice: new NullGraphicsDevice(canvas) });
 
@@ -53,9 +53,9 @@ describe('Application', () => {
 
     });
 
-    describe('#destroy', () => {
+    describe('#destroy', function () {
 
-        it('destroys the application', () => {
+        it('destroys the application', function () {
             const canvas = new HTMLCanvasElement(500, 500);
             const app = new Application(canvas, { graphicsDevice: new NullGraphicsDevice(canvas) });
 

--- a/test/framework/asset/asset-list-loader.test.mjs
+++ b/test/framework/asset/asset-list-loader.test.mjs
@@ -7,7 +7,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe('AssetListLoader', () => {
+describe('AssetListLoader', function () {
 
     let app;
     const assetPath = 'http://localhost:3000/test/test-assets/';
@@ -21,14 +21,14 @@ describe('AssetListLoader', () => {
         app.destroy();
     });
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             const assetListLoader = new AssetListLoader([], app.assets);
             expect(assetListLoader).to.be.ok;
         });
 
-        it('stores a single asset', () => {
+        it('stores a single asset', function () {
             const assets = [
                 new Asset('model', 'container', { url: `${assetPath}test.glb` })
             ];
@@ -36,7 +36,7 @@ describe('AssetListLoader', () => {
             expect(assetListLoader._assets.has(assets[0])).to.equal(true);
         });
 
-        it('stores multiple assets', () => {
+        it('stores multiple assets', function () {
             const assets = [
                 new Asset('model', 'container', { url: `${assetPath}test.glb` }),
                 new Asset('styling', 'css', { url: `${assetPath}test.css` })
@@ -46,7 +46,7 @@ describe('AssetListLoader', () => {
             expect(assetListLoader._assets.has(assets[1])).to.equal(true);
         });
 
-        it('stores single copies of duplicated assets', () => {
+        it('stores single copies of duplicated assets', function () {
             const assets = [
                 new Asset('model', 'container', { url: `${assetPath}test.glb` })
             ];
@@ -54,7 +54,7 @@ describe('AssetListLoader', () => {
             expect(assetListLoader._assets.size).to.equal(1);
         });
 
-        it('adds the supplied registry to any assets that do not have one', () => {
+        it('adds the supplied registry to any assets that do not have one', function () {
             const assets = [
                 new Asset('model', 'container', { url: `${assetPath}test.glb` })
             ];
@@ -67,7 +67,7 @@ describe('AssetListLoader', () => {
 
     });
 
-    describe('#ready', () => {
+    describe('#ready', function () {
 
         it('can return a single loaded asset', (done) => {
             const asset = new Asset('model', 'container', { url: `${assetPath}test.glb` });
@@ -112,7 +112,7 @@ describe('AssetListLoader', () => {
 
     });
 
-    describe('#load', () => {
+    describe('#load', function () {
 
         it('can call the ready callback if an asset is already loaded', (done) => {
             const asset = new Asset('model', 'container', { url: `${assetPath}test.glb` });

--- a/test/framework/asset/asset-localized.test.mjs
+++ b/test/framework/asset/asset-localized.test.mjs
@@ -7,7 +7,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe('LocalizedAsset', () => {
+describe('LocalizedAsset', function () {
 
     let app;
 
@@ -20,7 +20,7 @@ describe('LocalizedAsset', () => {
         app.destroy();
     });
 
-    it('sets defaultAsset and localizedAsset to the same id if defaultAsset has no localization', () => {
+    it('sets defaultAsset and localizedAsset to the same id if defaultAsset has no localization', function () {
         const asset = new Asset('Default Asset', 'texture');
 
         app.assets.add(asset);
@@ -32,7 +32,7 @@ describe('LocalizedAsset', () => {
         expect(la.localizedAsset).to.equal(asset.id);
     });
 
-    it('does not add load and change events to the asset when autoLoad is false', () => {
+    it('does not add load and change events to the asset when autoLoad is false', function () {
         const asset = new Asset('Default Asset', 'texture');
 
         app.assets.add(asset);
@@ -44,7 +44,7 @@ describe('LocalizedAsset', () => {
         expect(asset.hasEvent('change')).to.equal(false);
     });
 
-    it('adds load, change and remove events to the asset when autoLoad is true', () => {
+    it('adds load, change and remove events to the asset when autoLoad is true', function () {
         const asset = new Asset('Default Asset', 'texture');
 
         app.assets.add(asset);
@@ -58,7 +58,7 @@ describe('LocalizedAsset', () => {
         expect(asset.hasEvent('remove')).to.equal(true);
     });
 
-    it('adds events to the asset when autoLoad becomes true later', () => {
+    it('adds events to the asset when autoLoad becomes true later', function () {
         const asset = new Asset('Default Asset', 'texture');
 
         app.assets.add(asset);
@@ -73,7 +73,7 @@ describe('LocalizedAsset', () => {
         expect(asset.hasEvent('remove')).to.equal(true);
     });
 
-    it('picks the correct localizedAsset when the locale is already different', () => {
+    it('picks the correct localizedAsset when the locale is already different', function () {
         const asset = new Asset('Default Asset', 'texture');
         const asset2 = new Asset('Localized Asset', 'texture');
 
@@ -91,7 +91,7 @@ describe('LocalizedAsset', () => {
         expect(la.localizedAsset).to.equal(asset2.id);
     });
 
-    it('changes the localized asset after defaultAsset and then the locale change', () => {
+    it('changes the localized asset after defaultAsset and then the locale change', function () {
         const asset = new Asset('Default Asset', 'texture');
         const asset2 = new Asset('Localized Asset', 'texture');
 
@@ -110,7 +110,7 @@ describe('LocalizedAsset', () => {
         expect(la.localizedAsset).to.equal(asset2.id);
     });
 
-    it('removes events from the defaultAsset and localizedAsset is changed', () => {
+    it('removes events from the defaultAsset and localizedAsset is changed', function () {
         const asset = new Asset('Default Asset', 'texture');
         const asset2 = new Asset('Localized Asset', 'texture');
 
@@ -142,7 +142,7 @@ describe('LocalizedAsset', () => {
         expect(asset2.hasEvent('remove')).to.equal(true);
     });
 
-    it('propagates asset events to LocalizedAsset', () => {
+    it('propagates asset events to LocalizedAsset', function () {
         const asset = new Asset('Default Asset', 'texture');
 
         app.assets.add(asset);
@@ -155,15 +155,15 @@ describe('LocalizedAsset', () => {
         let changeFired = false;
         let removeFired = false;
 
-        la.on('load', () => {
+        la.on('load', function () {
             loadFired = true;
         });
 
-        la.on('change', () => {
+        la.on('change', function () {
             changeFired = true;
         });
 
-        la.on('remove', () => {
+        la.on('remove', function () {
             removeFired = true;
         });
 
@@ -176,7 +176,7 @@ describe('LocalizedAsset', () => {
         expect(removeFired).to.equal(true);
     });
 
-    it('uses only the defaultAsset when disableLocalization is true', () => {
+    it('uses only the defaultAsset when disableLocalization is true', function () {
         const asset = new Asset('Default Asset', 'texture');
         const asset2 = new Asset('Localized Asset', 'texture');
 
@@ -195,7 +195,7 @@ describe('LocalizedAsset', () => {
         expect(la.localizedAsset).to.equal(asset.id);
     });
 
-    it('falls back to defaultAsset when a null asset is set for a locale', () => {
+    it('falls back to defaultAsset when a null asset is set for a locale', function () {
         const asset = new Asset('Default Asset', 'texture');
         const asset2 = new Asset('Localized Asset', 'texture');
 
@@ -241,7 +241,7 @@ describe('LocalizedAsset', () => {
         asset.removeLocalizedAssetId('fr');
     });
 
-    it('updates the localizedAsset on setting a localized asset for the current locale', () => {
+    it('updates the localizedAsset on setting a localized asset for the current locale', function () {
         const asset = new Asset('Default Asset', 'texture');
         app.assets.add(asset);
         const asset2 = new Asset('Localized Asset', 'texture');
@@ -256,7 +256,7 @@ describe('LocalizedAsset', () => {
         expect(la.localizedAsset).to.equal(asset2.id);
     });
 
-    it('updates the localizedAsset to the defaultAsset on removing a localized asset for the current locale', () => {
+    it('updates the localizedAsset to the defaultAsset on removing a localized asset for the current locale', function () {
         const asset = new Asset('Default Asset', 'texture');
         app.assets.add(asset);
         const asset2 = new Asset('Localized Asset', 'texture');
@@ -273,7 +273,7 @@ describe('LocalizedAsset', () => {
         expect(la.localizedAsset).to.equal(asset.id);
     });
 
-    it('updates the localizedAsset on setting a localized asset for the current locale even if defaultAsset is added to the registry later', () => {
+    it('updates the localizedAsset on setting a localized asset for the current locale even if defaultAsset is added to the registry later', function () {
         const asset = new Asset('Default Asset', 'texture');
         const asset2 = new Asset('Localized Asset', 'texture');
         app.assets.add(asset2);
@@ -290,7 +290,7 @@ describe('LocalizedAsset', () => {
     });
 
 
-    it('switches LocalizedAsset to the defaultAsset by removing a localized asset from the registry', () => {
+    it('switches LocalizedAsset to the defaultAsset by removing a localized asset from the registry', function () {
         const asset = new Asset('Default Asset', 'texture');
         app.assets.add(asset);
         const asset2 = new Asset('Localized Asset', 'texture');
@@ -308,7 +308,7 @@ describe('LocalizedAsset', () => {
         expect(la.localizedAsset).to.equal(asset.id);
     });
 
-    it('keeps same localizedAsset and adds "add" event handler on removing the defaultAsset from the registry', () => {
+    it('keeps same localizedAsset and adds "add" event handler on removing the defaultAsset from the registry', function () {
         const asset = new Asset('Default Asset', 'texture');
         app.assets.add(asset);
         const asset2 = new Asset('Localized Asset', 'texture');
@@ -330,17 +330,17 @@ describe('LocalizedAsset', () => {
         expect(app.assets.hasEvent(`add:${asset.id}`)).to.equal(true);
     });
 
-    describe('#destroy', () => {
+    describe('#destroy', function () {
 
-        it('removes asset references and events', () => {
+        it('removes asset references and events', function () {
             const asset = new Asset('Default Asset', 'texture');
 
             const la = new LocalizedAsset(app);
             la.defaultAsset = asset.id;
 
-            la.on('load', () => {});
-            la.on('change', () => {});
-            la.on('remove', () => {});
+            la.on('load', function () {});
+            la.on('change', function () {});
+            la.on('remove', function () {});
 
             expect(app.assets.hasEvent(`add:${asset.id}`)).to.equal(true);
             expect(la.hasEvent('load')).to.equal(true);

--- a/test/framework/asset/asset-registry.test.mjs
+++ b/test/framework/asset/asset-registry.test.mjs
@@ -11,7 +11,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 import { expect } from 'chai';
 import { restore, spy } from 'sinon';
 
-describe('AssetRegistry', () => {
+describe('AssetRegistry', function () {
 
     let app;
     let retryDelay;
@@ -29,9 +29,9 @@ describe('AssetRegistry', () => {
         restore();
     });
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('instantiates correctly', () => {
+        it('instantiates correctly', function () {
             const resourceLoader = new ResourceLoader(app);
             const assetRegistry = new AssetRegistry(resourceLoader);
 
@@ -40,9 +40,9 @@ describe('AssetRegistry', () => {
 
     });
 
-    describe('#add', () => {
+    describe('#add', function () {
 
-        it('adds an asset', () => {
+        it('adds an asset', function () {
             const asset = new Asset('Test Asset', 'text', {
                 url: 'fake/url/file.txt'
             });
@@ -55,9 +55,9 @@ describe('AssetRegistry', () => {
 
     });
 
-    describe('#find', () => {
+    describe('#find', function () {
 
-        it('works after removing an asset', () => {
+        it('works after removing an asset', function () {
             const asset1 = new Asset('Asset 1', 'text', {
                 url: 'fake/one/file.txt'
             });
@@ -81,9 +81,9 @@ describe('AssetRegistry', () => {
 
     });
 
-    describe('#find + rename', () => {
+    describe('#find + rename', function () {
 
-        it('works after renaming an asset', () => {
+        it('works after renaming an asset', function () {
             const asset1 = new Asset('Asset 1', 'text', {
                 url: 'fake/one/file.txt'
             });
@@ -105,9 +105,9 @@ describe('AssetRegistry', () => {
 
     });
 
-    describe('#find + type', () => {
+    describe('#find + type', function () {
 
-        it('finds assets by name filtered by type', () => {
+        it('finds assets by name filtered by type', function () {
             const asset1 = new Asset('Asset 1', 'text', {
                 url: 'fake/one/file.txt'
             });
@@ -124,9 +124,9 @@ describe('AssetRegistry', () => {
 
     });
 
-    describe('#findAll + type', () => {
+    describe('#findAll + type', function () {
 
-        it('finds all assets by name filtered by type', () => {
+        it('finds all assets by name filtered by type', function () {
             const asset1 = new Asset('Asset 1', 'text', {
                 url: 'fake/one/file.txt'
             });
@@ -156,9 +156,9 @@ describe('AssetRegistry', () => {
 
     });
 
-    describe('#get', () => {
+    describe('#get', function () {
 
-        it('retrieves an asset by id', () => {
+        it('retrieves an asset by id', function () {
             const asset = new Asset('Test Asset', 'text', {
                 url: 'fake/url/file.txt'
             });
@@ -171,9 +171,9 @@ describe('AssetRegistry', () => {
 
     });
 
-    describe('#getByUrl', () => {
+    describe('#getByUrl', function () {
 
-        it('retrieves an asset by url', () => {
+        it('retrieves an asset by url', function () {
             const asset = new Asset('Test Asset', 'text', {
                 url: 'fake/url/file.txt'
             });
@@ -184,7 +184,7 @@ describe('AssetRegistry', () => {
             expect(asset).to.equal(assetFromRegistry);
         });
 
-        it('works after removing an asset', () => {
+        it('works after removing an asset', function () {
             const asset1 = new Asset('Asset 1', 'text', {
                 url: 'fake/one/file.txt'
             });
@@ -208,9 +208,9 @@ describe('AssetRegistry', () => {
 
     });
 
-    describe('#list', () => {
+    describe('#list', function () {
 
-        it('lists all assets', () => {
+        it('lists all assets', function () {
             const asset1 = new Asset('Asset 1', 'text', {
                 url: 'fake/one/file.txt'
             });
@@ -234,7 +234,7 @@ describe('AssetRegistry', () => {
 
     });
 
-    describe('#loadFromUrl', () => {
+    describe('#loadFromUrl', function () {
 
         const assetPath = 'http://localhost:3000/test/test-assets/';
 
@@ -322,9 +322,9 @@ describe('AssetRegistry', () => {
 
     });
 
-    describe('#remove', () => {
+    describe('#remove', function () {
 
-        it('removes by id', () => {
+        it('removes by id', function () {
             const asset1 = new Asset('Asset 1', 'text', {
                 url: 'fake/one/file.txt'
             });

--- a/test/framework/asset/asset.test.mjs
+++ b/test/framework/asset/asset.test.mjs
@@ -6,7 +6,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe('Asset', () => {
+describe('Asset', function () {
 
     let app;
 
@@ -30,15 +30,15 @@ describe('Asset', () => {
         'ja': 'ja-JP'
     };
 
-    describe('#getLocalizedAssetId', () => {
+    describe('#getLocalizedAssetId', function () {
 
-        it('should return null if no localizations exist', () => {
+        it('should return null if no localizations exist', function () {
             const asset = new Asset('asset', 'font');
             asset.id = 1000;
             expect(asset.getLocalizedAssetId('en')).to.equal(null);
         });
 
-        it('should return fallback language if available', () => {
+        it('should return fallback language if available', function () {
             const asset = new Asset('asset', 'font');
 
             let id = 1000;
@@ -54,7 +54,7 @@ describe('Asset', () => {
             }
         });
 
-        it('should return fallback language if available', () => {
+        it('should return fallback language if available', function () {
             const asset = new Asset('asset', 'font');
 
             let id = 1000;
@@ -70,7 +70,7 @@ describe('Asset', () => {
             }
         });
 
-        it('should return fallback language if available', () => {
+        it('should return fallback language if available', function () {
             const asset = new Asset('asset', 'font');
 
             let id = 1;
@@ -87,7 +87,7 @@ describe('Asset', () => {
             }
         });
 
-        it('zh-HK should return zh-HK if it exists', () => {
+        it('zh-HK should return zh-HK if it exists', function () {
             const asset = new Asset('asset', 'font');
 
             asset.addLocalizedAssetId('zh-CN', 1);
@@ -97,7 +97,7 @@ describe('Asset', () => {
             expect(asset.getLocalizedAssetId('zh-HK')).to.equal(2);
         });
 
-        it('zh-HK should fallback to zh-TW', () => {
+        it('zh-HK should fallback to zh-TW', function () {
             const asset = new Asset('asset', 'font');
 
             asset.addLocalizedAssetId('zh-CN', 1);
@@ -106,7 +106,7 @@ describe('Asset', () => {
             expect(asset.getLocalizedAssetId('zh-HK')).to.equal(2);
         });
 
-        it('zh-TW should fallback to zh-HK', () => {
+        it('zh-TW should fallback to zh-HK', function () {
             const asset = new Asset('asset', 'font');
 
             asset.addLocalizedAssetId('zh-CN', 1);
@@ -115,7 +115,7 @@ describe('Asset', () => {
             expect(asset.getLocalizedAssetId('zh-TW')).to.equal(2);
         });
 
-        it('zh-SG should fallback to zh-CN', () => {
+        it('zh-SG should fallback to zh-CN', function () {
             const asset = new Asset('asset', 'font');
 
             asset.addLocalizedAssetId('zh-HK', 1);

--- a/test/framework/components/element/component.test.mjs
+++ b/test/framework/components/element/component.test.mjs
@@ -7,7 +7,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe('ElementComponent', () => {
+describe('ElementComponent', function () {
     let app;
 
     beforeEach(() => {
@@ -19,9 +19,9 @@ describe('ElementComponent', () => {
         app.destroy();
     });
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('creates a default element component', () => {
+        it('creates a default element component', function () {
             const e = new Entity();
             e.addComponent('element');
 
@@ -123,7 +123,7 @@ describe('ElementComponent', () => {
 
     });
 
-    it('unbinds screen component on reparent', () => {
+    it('unbinds screen component on reparent', function () {
         const screen = new Entity();
         screen.addComponent('screen');
         app.root.addChild(screen);
@@ -140,7 +140,7 @@ describe('ElementComponent', () => {
         expect(screen.screen._elements).to.not.include(e.element);
     });
 
-    it('unbinds screen component on destroy', () => {
+    it('unbinds screen component on destroy', function () {
         const screen = new Entity();
         screen.addComponent('screen');
         app.root.addChild(screen);

--- a/test/framework/components/layout-group/component.test.mjs
+++ b/test/framework/components/layout-group/component.test.mjs
@@ -10,7 +10,7 @@ import { restore, spy, stub } from 'sinon';
 
 /** @typedef {import('../../../../src/framework/components/layout-group/system.js').LayoutGroupComponentSystem} LayoutGroupComponentSystem */
 
-describe('LayoutGroupComponent', () => {
+describe('LayoutGroupComponent', function () {
     /** @type {Application} */
     let app;
     /** @type {LayoutGroupComponentSystem} */
@@ -56,7 +56,7 @@ describe('LayoutGroupComponent', () => {
         app.destroy();
     });
 
-    it('reflows in ascending order of graph depth', () => {
+    it('reflows in ascending order of graph depth', function () {
         system.scheduleReflow(entity0_0.layoutgroup);
         system.scheduleReflow(entity0.layoutgroup);
         system.scheduleReflow(entity0_0_0.layoutgroup);
@@ -71,7 +71,7 @@ describe('LayoutGroupComponent', () => {
         expect(entity0_0.layoutgroup.reflow.calledBefore(entity0_0_0.layoutgroup.reflow)).to.be.true;
     });
 
-    it('reflows additional groups that are pushed during the reflow', () => {
+    it('reflows additional groups that are pushed during the reflow', function () {
         system.scheduleReflow(entity0.layoutgroup);
 
         let done = false;
@@ -95,7 +95,7 @@ describe('LayoutGroupComponent', () => {
         expect(entity0_0.layoutgroup.reflow.calledBefore(entity0_0_0.layoutgroup.reflow)).to.be.true;
     });
 
-    it('does not allow the same group to be pushed to the queue twice', () => {
+    it('does not allow the same group to be pushed to the queue twice', function () {
         system.scheduleReflow(entity0.layoutgroup);
         system.scheduleReflow(entity0.layoutgroup);
 
@@ -104,7 +104,7 @@ describe('LayoutGroupComponent', () => {
         expect(entity0.layoutgroup.reflow.callCount).to.equal(1);
     });
 
-    it('bails if the maximum iteration count is reached', () => {
+    it('bails if the maximum iteration count is reached', function () {
         stub(console, 'warn');
 
         system.scheduleReflow(entity0.layoutgroup);

--- a/test/framework/components/layout-group/layout-calculator.test.mjs
+++ b/test/framework/components/layout-group/layout-calculator.test.mjs
@@ -14,7 +14,7 @@ import { expect } from 'chai';
 
 /** @typedef {import('../../../../src/framework/components/element/component.js').ElementComponent} ElementComponent */
 
-describe('LayoutCalculator', () => {
+describe('LayoutCalculator', function () {
     /** @type {Application} */
     let app;
     /** @type {LayoutCalculator} */
@@ -269,7 +269,7 @@ describe('LayoutCalculator', () => {
         });
     };
 
-    it('throws an error if provided with an unrecognized orientation', () => {
+    it('throws an error if provided with an unrecognized orientation', function () {
         expect(() => {
             elements = mixedWidthElements;
             options.orientation = 42;
@@ -277,7 +277,7 @@ describe('LayoutCalculator', () => {
         }).to.throw('Unrecognized orientation value: 42');
     });
 
-    it('lays children out horizontally when orientation is ORIENTATION_HORIZONTAL', () => {
+    it('lays children out horizontally when orientation is ORIENTATION_HORIZONTAL', function () {
         elements = mixedWidthElements;
         options.orientation = ORIENTATION_HORIZONTAL;
 
@@ -287,7 +287,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [0,   0,   0,   0,   0]);
     });
 
-    it('lays children out vertically when orientation is ORIENTATION_VERTICAL', () => {
+    it('lays children out vertically when orientation is ORIENTATION_VERTICAL', function () {
         elements = mixedHeightElements;
         options.orientation = ORIENTATION_VERTICAL;
 
@@ -297,7 +297,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [0, 100, 150, 250, 270]);
     });
 
-    it('takes into account each element\'s pivot when calculating horizontal positions', () => {
+    it('takes into account each element\'s pivot when calculating horizontal positions', function () {
         elements = mixedWidthElements;
         options.orientation = ORIENTATION_HORIZONTAL;
 
@@ -310,7 +310,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [10,  10,   0,   0,   0], { approx: true });
     });
 
-    it('takes into account each element\'s pivot when calculating vertical positions', () => {
+    it('takes into account each element\'s pivot when calculating vertical positions', function () {
         elements = mixedHeightElements;
         options.orientation = ORIENTATION_VERTICAL;
 
@@ -323,7 +323,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [50, 110, 150, 250, 270], { approx: true });
     });
 
-    it('returns a layoutInfo object containing the layout bounds', () => {
+    it('returns a layoutInfo object containing the layout bounds', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -363,7 +363,7 @@ describe('LayoutCalculator', () => {
         expect(layoutInfo.bounds.w).to.equal(100);
     });
 
-    it('{ wrap: false } FITTING_NONE does not adjust the size or position of elements to match the container size', () => {
+    it('{ wrap: false } FITTING_NONE does not adjust the size or position of elements to match the container size', function () {
         elements = mixedWidthElements;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_NONE;
@@ -377,7 +377,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it('{ wrap: false } FITTING_STRETCH uses natural widths when total is larger than container size', () => {
+    it('{ wrap: false } FITTING_STRETCH uses natural widths when total is larger than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_STRETCH;
@@ -392,7 +392,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it('{ wrap: false } FITTING_STRETCH stretches elements proportionally when natural widths are less than container size', () => {
+    it('{ wrap: false } FITTING_STRETCH stretches elements proportionally when natural widths are less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_STRETCH;
@@ -407,7 +407,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it('{ wrap: false } FITTING_STRETCH does not make any elements wider than their maxWidth when increasing widths', () => {
+    it('{ wrap: false } FITTING_STRETCH does not make any elements wider than their maxWidth when increasing widths', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_STRETCH;
@@ -422,7 +422,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it('{ wrap: false } FITTING_STRETCH distributes additional space among remaining elements when one element\'s maxWidth is very small', () => {
+    it('{ wrap: false } FITTING_STRETCH distributes additional space among remaining elements when one element\'s maxWidth is very small', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_STRETCH;
@@ -444,7 +444,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100,     100,     100]);
     });
 
-    it('{ wrap: false } FITTING_STRETCH includes spacing and padding in calculations', () => {
+    it('{ wrap: false } FITTING_STRETCH includes spacing and padding in calculations', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_STRETCH;
@@ -462,7 +462,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100,     100, 100, 100]);
     });
 
-    it('{ wrap: false } FITTING_SHRINK uses natural widths when total is less than container size', () => {
+    it('{ wrap: false } FITTING_SHRINK uses natural widths when total is less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_SHRINK;
@@ -477,7 +477,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it('{ wrap: false } FITTING_SHRINK shrinks elements proportionally when natural widths are greater than than container size', () => {
+    it('{ wrap: false } FITTING_SHRINK shrinks elements proportionally when natural widths are greater than than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_SHRINK;
@@ -492,7 +492,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100,  100,   100,   100, 100]);
     });
 
-    it('{ wrap: false } FITTING_SHRINK does not make any elements smaller than their minWidth when reducing widths', () => {
+    it('{ wrap: false } FITTING_SHRINK does not make any elements smaller than their minWidth when reducing widths', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_SHRINK;
@@ -507,7 +507,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it('{ wrap: false } FITTING_SHRINK distributes additional size reduction among remaining elements when one element\'s minWidth is very large', () => {
+    it('{ wrap: false } FITTING_SHRINK distributes additional size reduction among remaining elements when one element\'s minWidth is very large', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_SHRINK;
@@ -528,7 +528,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100,    100, 100, 100, 100]);
     });
 
-    it('{ wrap: false } FITTING_SHRINK includes spacing and padding in calculations', () => {
+    it('{ wrap: false } FITTING_SHRINK includes spacing and padding in calculations', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_SHRINK;
@@ -546,7 +546,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100,  100, 100, 100]);
     });
 
-    it('{ wrap: false } FITTING_BOTH stretches elements proportionally when natural widths are less than container size', () => {
+    it('{ wrap: false } FITTING_BOTH stretches elements proportionally when natural widths are less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_BOTH;
@@ -561,7 +561,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it('{ wrap: false } FITTING_BOTH shrinks elements proportionally when natural widths are greater than than container size', () => {
+    it('{ wrap: false } FITTING_BOTH shrinks elements proportionally when natural widths are greater than than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_BOTH;
@@ -576,7 +576,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100,  100,   100,   100, 100]);
     });
 
-    it('{ wrap: false } can reverse elements on the x axis', () => {
+    it('{ wrap: false } can reverse elements on the x axis', function () {
         elements = mixedWidthElements;
         options.reverseX = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -589,7 +589,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [0,     0,  0,  0, 0]);
     });
 
-    it('{ wrap: false } can reverse elements on the y axis', () => {
+    it('{ wrap: false } can reverse elements on the y axis', function () {
         elements = mixedHeightElements;
         options.reverseY = true;
         options.orientation = ORIENTATION_VERTICAL;
@@ -602,7 +602,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [200, 150, 50, 30, 0]);
     });
 
-    it('{ wrap: false } can align to [1, 0.5]', () => {
+    it('{ wrap: false } can align to [1, 0.5]', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_NONE;
@@ -617,7 +617,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [150, 150, 150, 150, 150]);
     });
 
-    it('{ wrap: false } can align to [0.5, 1]', () => {
+    it('{ wrap: false } can align to [0.5, 1]', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
         options.widthFitting = FITTING_NONE;
@@ -632,7 +632,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [300, 300, 300, 300, 300]);
     });
 
-    it('{ wrap: false } can exclude elements from the layout', () => {
+    it('{ wrap: false } can exclude elements from the layout', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.orientation = ORIENTATION_HORIZONTAL;
 
@@ -644,7 +644,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [0, 0,   0,   0,   0]);
     });
 
-    it('{ wrap: true } FITTING_NONE does not adjust the size or position of elements to match the container size', () => {
+    it('{ wrap: true } FITTING_NONE does not adjust the size or position of elements to match the container size', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -660,7 +660,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it('{ wrap: true } FITTING_NONE calculates line positions based on the largest element on the line', () => {
+    it('{ wrap: true } FITTING_NONE calculates line positions based on the largest element on the line', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -678,7 +678,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 200, 100, 100]);
     });
 
-    it('{ wrap: true } FITTING_NONE does not adjust the size or position of elements to match the container size', () => {
+    it('{ wrap: true } FITTING_NONE does not adjust the size or position of elements to match the container size', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -694,7 +694,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it('{ wrap: true } FITTING_NONE includes spacing and padding in calculations', () => {
+    it('{ wrap: true } FITTING_NONE includes spacing and padding in calculations', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -714,7 +714,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100, 100, 100, 100, 100]);
     });
 
-    it('{ wrap: true } FITTING_NONE includes spacing when calculating line breaks', () => {
+    it('{ wrap: true } FITTING_NONE includes spacing when calculating line breaks', function () {
         elements = mixedWidthElements;
         elements[0].width = 100;
         elements[1].width = 100;
@@ -734,7 +734,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [0,    0,  0,   0, 100]);
     });
 
-    it('{ wrap: true } FITTING_STRETCH stretches elements proportionally when natural widths are less than container size', () => {
+    it('{ wrap: true } FITTING_STRETCH stretches elements proportionally when natural widths are less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -750,7 +750,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100,    100,     100, 100, 100]);
     });
 
-    it('{ wrap: true } FITTING_SHRINK stretches elements proportionally when natural widths are less than container size', () => {
+    it('{ wrap: true } FITTING_SHRINK stretches elements proportionally when natural widths are less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -766,7 +766,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100,    100,    100,    100, 100]);
     });
 
-    it('{ wrap: true } FITTING_BOTH stretches elements proportionally when natural widths are less than container size', () => {
+    it('{ wrap: true } FITTING_BOTH stretches elements proportionally when natural widths are less than container size', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -782,7 +782,7 @@ describe('LayoutCalculator', () => {
         assertValues('calculatedHeight', [100,    100,     100, 100, 100]);
     });
 
-    it('{ wrap: true } can reverse elements on the x axis', () => {
+    it('{ wrap: true } can reverse elements on the x axis', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.reverseX = true;
@@ -796,7 +796,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [0,   0,  0, 100, 100]);
     });
 
-    it('{ wrap: true } can reverse elements on the y axis', () => {
+    it('{ wrap: true } can reverse elements on the y axis', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.reverseY = true;
@@ -810,7 +810,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [100, 100, 100, 0, 0]);
     });
 
-    it('{ wrap: true } can reverse elements both axes', () => {
+    it('{ wrap: true } can reverse elements both axes', function () {
         elements = mixedWidthElements;
         options.wrap = true;
         options.reverseX = true;
@@ -825,7 +825,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [100, 100, 100,  0, 0]);
     });
 
-    it('{ wrap: true } can align to [1, 0.5]', () => {
+    it('{ wrap: true } can align to [1, 0.5]', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -842,7 +842,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [100, 100, 100, 200, 200]);
     });
 
-    it('{ wrap: true } can align to [0.5, 1]', () => {
+    it('{ wrap: true } can align to [0.5, 1]', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;
@@ -859,7 +859,7 @@ describe('LayoutCalculator', () => {
         assertValues('y', [200, 200, 200, 300, 300]);
     });
 
-    it('{ wrap: false } can exclude elements from the layout', () => {
+    it('{ wrap: false } can exclude elements from the layout', function () {
         elements = mixedWidthElementsWithLayoutChildComponents;
         options.wrap = true;
         options.orientation = ORIENTATION_HORIZONTAL;

--- a/test/framework/components/model/component.test.mjs
+++ b/test/framework/components/model/component.test.mjs
@@ -8,7 +8,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe('ModelComponent', () => {
+describe('ModelComponent', function () {
     let app;
     let assets = {};
 
@@ -60,7 +60,7 @@ describe('ModelComponent', () => {
         assets = {};
     });
 
-    it('Create default model component', () => {
+    it('Create default model component', function () {
         const e = new Entity();
         e.addComponent('model');
 
@@ -79,7 +79,7 @@ describe('ModelComponent', () => {
 
     });
 
-    it('Set modelAsset and model', () => {
+    it('Set modelAsset and model', function () {
         const e = new Entity();
         e.addComponent('model', {
             asset: assets.model
@@ -91,7 +91,7 @@ describe('ModelComponent', () => {
         expect(e.model.model).to.not.be.null;
     });
 
-    it('Default cloned model component is identical', () => {
+    it('Default cloned model component is identical', function () {
         const e = new Entity();
         e.addComponent('model', {
             asset: assets.model
@@ -115,7 +115,7 @@ describe('ModelComponent', () => {
     });
 
 
-    it('Cloned model component with flags set has correct meshinstance flags', () => {
+    it('Cloned model component with flags set has correct meshinstance flags', function () {
         const e = new Entity();
         e.addComponent('model', {
             asset: assets.model,
@@ -144,7 +144,7 @@ describe('ModelComponent', () => {
     });
 
 
-    it('Cloned model component with flags set directly on mesh instance is identical', () => {
+    it('Cloned model component with flags set directly on mesh instance is identical', function () {
         const e = new Entity();
         e.addComponent('model', {
             asset: assets.model
@@ -173,7 +173,7 @@ describe('ModelComponent', () => {
         }
     });
 
-    it('ModelAsset unbinds on destroy', () => {
+    it('ModelAsset unbinds on destroy', function () {
         const e = new Entity();
         app.root.addChild(e);
         e.addComponent('model', {
@@ -193,7 +193,7 @@ describe('ModelComponent', () => {
         expect(assets.model.hasEvent('unload')).to.be.false;
     });
 
-    it('ModelAsset unbinds on reset', () => {
+    it('ModelAsset unbinds on reset', function () {
         const e = new Entity();
         app.root.addChild(e);
         e.addComponent('model', {
@@ -213,7 +213,7 @@ describe('ModelComponent', () => {
         expect(assets.model.hasEvent('unload')).to.be.false;
     });
 
-    it('Material Asset unbinds on destroy', () => {
+    it('Material Asset unbinds on destroy', function () {
         const e = new Entity();
         app.root.addChild(e);
         e.addComponent('model', {
@@ -234,7 +234,7 @@ describe('ModelComponent', () => {
         expect(assets.material.hasEvent('remove')).to.be.false;
     });
 
-    it('Material Asset unbinds on reset', () => {
+    it('Material Asset unbinds on reset', function () {
         const e = new Entity();
         app.root.addChild(e);
         e.addComponent('model', {
@@ -276,7 +276,7 @@ describe('ModelComponent', () => {
 
         app.assets.load(boxAsset);
 
-        boxAsset.on('load', () => {
+        boxAsset.on('load', function () {
             const e = new Entity();
             e.addComponent('model', {
                 asset: boxAsset
@@ -301,7 +301,7 @@ describe('ModelComponent', () => {
         app.assets.add(boxAsset);
         app.assets.load(boxAsset);
 
-        boxAsset.on('load', () => {
+        boxAsset.on('load', function () {
             const e = new Entity();
             e.addComponent('model', {
                 asset: boxAsset
@@ -311,7 +311,7 @@ describe('ModelComponent', () => {
 
             expect(app.assets.hasEvent(`add:${materialAsset.id}`)).to.be.true;
 
-            materialAsset.on('load', () => {
+            materialAsset.on('load', function () {
                 // do checks after the 'load' handler on the asset has been executed
                 // by other engine event handlers
                 setTimeout(() => {
@@ -338,7 +338,7 @@ describe('ModelComponent', () => {
         app.assets.add(boxAsset);
         app.assets.load(boxAsset);
 
-        boxAsset.on('load', () => {
+        boxAsset.on('load', function () {
             const e = new Entity();
             e.addComponent('model', {
                 asset: boxAsset
@@ -358,7 +358,7 @@ describe('ModelComponent', () => {
         });
     });
 
-    it('Layers are initialized before model is set', () => {
+    it('Layers are initialized before model is set', function () {
         const e = new Entity();
         e.addComponent('model', {
             layers: [LAYERID_UI]

--- a/test/framework/components/system.test.mjs
+++ b/test/framework/components/system.test.mjs
@@ -10,7 +10,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe('ComponentSystem', () => {
+describe('ComponentSystem', function () {
     /** @type {Application} */
     let app;
     /** @type {ComponentSystem} */
@@ -27,9 +27,9 @@ describe('ComponentSystem', () => {
         app.destroy();
     });
 
-    describe('#initializeComponentData()', () => {
+    describe('#initializeComponentData()', function () {
 
-        it('works with a flat list of property names', () => {
+        it('works with a flat list of property names', function () {
             const component = {};
             const data = {
                 foo: 42,
@@ -43,7 +43,7 @@ describe('ComponentSystem', () => {
             expect(component.bar).to.equal(84);
         });
 
-        it('works with a list of property descriptor objects', () => {
+        it('works with a list of property descriptor objects', function () {
             const component = {};
             const data = {
                 rgbProperty: new Color(1, 2, 3),
@@ -102,7 +102,7 @@ describe('ComponentSystem', () => {
             expect(component.entityProperty).to.equal('abcde-12345');
         });
 
-        it('handles nulls', () => {
+        it('handles nulls', function () {
             const component = {};
             const data = {
                 rgbProperty: null,
@@ -140,7 +140,7 @@ describe('ComponentSystem', () => {
             expect(component.entityProperty).to.be.null;
         });
 
-        it('handles vec values being delivered as arrays', () => {
+        it('handles vec values being delivered as arrays', function () {
             const component = {};
             const data = {
                 rgbProperty: [1, 2, 3],
@@ -165,7 +165,7 @@ describe('ComponentSystem', () => {
             expect(component.vec4Property).to.not.equal(data.vec4Property);
         });
 
-        it('works if a normal value comes after an object value', () => {
+        it('works if a normal value comes after an object value', function () {
             const component = {};
             const data = {
                 vec: [1, 2, 3, 4],
@@ -185,7 +185,7 @@ describe('ComponentSystem', () => {
             expect(component.num).to.equal(42);
         });
 
-        it('throws if provided an unknown type', () => {
+        it('throws if provided an unknown type', function () {
             const component = {};
             const data = {
                 foo: 42
@@ -201,9 +201,9 @@ describe('ComponentSystem', () => {
 
     });
 
-    describe('#getPropertiesOfType()', () => {
+    describe('#getPropertiesOfType()', function () {
 
-        it('returns properties of the specified type', () => {
+        it('returns properties of the specified type', function () {
             system.schema = [
                 { name: 'foo', type: 'typeA' },
                 { name: 'bar', type: 'typeA' },
@@ -217,7 +217,7 @@ describe('ComponentSystem', () => {
             ]);
         });
 
-        it('returns an empty array if no properties match the specified type', () => {
+        it('returns an empty array if no properties match the specified type', function () {
             system.schema = [
                 { name: 'foo', type: 'typeA' },
                 { name: 'bar', type: 'typeA' },
@@ -228,7 +228,7 @@ describe('ComponentSystem', () => {
             expect(system.getPropertiesOfType('typeC')).to.deep.equal([]);
         });
 
-        it('doesn\'t throw an error if the system doesn\'t have a schema', () => {
+        it('doesn\'t throw an error if the system doesn\'t have a schema', function () {
             system.schema = null;
 
             expect(system.getPropertiesOfType('typeA')).to.deep.equal([]);

--- a/test/framework/entity.test.mjs
+++ b/test/framework/entity.test.mjs
@@ -34,7 +34,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 import { expect } from 'chai';
 import { stub } from 'sinon';
 
-describe('Entity', () => {
+describe('Entity', function () {
 
     let app;
 
@@ -74,21 +74,21 @@ describe('Entity', () => {
         zone: ZoneComponent
     };
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('supports zero arguments', () => {
+        it('supports zero arguments', function () {
             const entity = new Entity();
             expect(entity).to.be.an.instanceof(Entity);
             expect(entity.name).to.equal('Untitled');
         });
 
-        it('supports one argument', () => {
+        it('supports one argument', function () {
             const entity = new Entity('Test');
             expect(entity).to.be.an.instanceof(Entity);
             expect(entity.name).to.equal('Test');
         });
 
-        it('supports two arguments', () => {
+        it('supports two arguments', function () {
             const entity = new Entity('Test', app);
             expect(entity).to.be.an.instanceof(Entity);
             expect(entity.name).to.equal('Test');
@@ -96,7 +96,7 @@ describe('Entity', () => {
 
     });
 
-    describe('#addComponent', () => {
+    describe('#addComponent', function () {
 
         for (const name in components) {
             it(`adds a ${name} component`, () => {
@@ -122,7 +122,7 @@ describe('Entity', () => {
             });
         }
 
-        it('respects components order on disable', () => {
+        it('respects components order on disable', function () {
             const entity = new Entity();
             entity.enabled = true;
 
@@ -150,7 +150,7 @@ describe('Entity', () => {
             entity.destroy();
         });
 
-        it('respects components order on enable', () => {
+        it('respects components order on enable', function () {
             const entity = new Entity('Child');
             const parent = new Entity('Parent');
 
@@ -233,9 +233,9 @@ describe('Entity', () => {
         };
     };
 
-    describe('#clone', () => {
+    describe('#clone', function () {
 
-        it('clones an entity', () => {
+        it('clones an entity', function () {
             const entity = new Entity('Test');
             for (const name in components) {
                 entity.addComponent(name);
@@ -250,7 +250,7 @@ describe('Entity', () => {
             }
         });
 
-        it('clones an entity hierarchy', () => {
+        it('clones an entity hierarchy', function () {
             const root = new Entity('Test');
             const child = new Entity('Child');
             root.addChild(child);
@@ -277,7 +277,7 @@ describe('Entity', () => {
             root.destroy();
         });
 
-        it('returns a deep clone of the entity\'s subtree, including all components', () => {
+        it('returns a deep clone of the entity\'s subtree, including all components', function () {
             const subtree1 = createSubtree();
             const subtree2 = cloneSubtree(subtree1);
 
@@ -332,7 +332,7 @@ describe('Entity', () => {
             expect(subtree1.a_a_b.getGuid()).to.not.equal(subtree2.a_a_b.getGuid());
         });
 
-        it('resolves entity property references that refer to entities within the duplicated subtree', () => {
+        it('resolves entity property references that refer to entities within the duplicated subtree', function () {
             const subtree1 = createSubtree();
             subtree1.a.addComponent('dummy', { myEntity1: subtree1.a_a.getGuid(), myEntity2: subtree1.a_a_b.getGuid() });
             subtree1.a_a_a.addComponent('dummy', { myEntity1: subtree1.a.getGuid(), myEntity2: subtree1.a_b.getGuid() });
@@ -344,7 +344,7 @@ describe('Entity', () => {
             expect(subtree2.a_a_a.dummy.myEntity2).to.equal(subtree2.a_b.getGuid());
         });
 
-        it('resolves entity property references that refer to the cloned entity itself', () => {
+        it('resolves entity property references that refer to the cloned entity itself', function () {
             const subtree1 = createSubtree();
             subtree1.a.addComponent('dummy', { myEntity1: subtree1.a.getGuid() });
             subtree1.a_a_a.addComponent('dummy', { myEntity1: subtree1.a_a_a.getGuid() });
@@ -354,7 +354,7 @@ describe('Entity', () => {
             expect(subtree2.a_a_a.dummy.myEntity1).to.equal(subtree2.a_a_a.getGuid());
         });
 
-        it('does not attempt to resolve entity property references that refer to entities outside of the duplicated subtree', () => {
+        it('does not attempt to resolve entity property references that refer to entities outside of the duplicated subtree', function () {
             const root = new Entity('root', app);
             const sibling = new Entity('sibling', app);
 
@@ -369,7 +369,7 @@ describe('Entity', () => {
             expect(subtree2.a.dummy.myEntity2).to.equal(sibling.getGuid());
         });
 
-        it('ignores null and undefined entity property references', () => {
+        it('ignores null and undefined entity property references', function () {
             const subtree1 = createSubtree();
             subtree1.a.addComponent('dummy', { myEntity1: null, myEntity2: undefined });
 
@@ -378,7 +378,7 @@ describe('Entity', () => {
             expect(subtree2.a.dummy.myEntity2).to.be.undefined;
         });
 
-        it('resolves entity script attributes that refer to entities within the duplicated subtree', () => {
+        it('resolves entity script attributes that refer to entities within the duplicated subtree', function () {
             const TestScript = createScript('test');
             TestScript.attributes.add('entityAttr', { type: 'entity' });
             TestScript.attributes.add('entityArrayAttr', { type: 'entity', array: true });
@@ -425,7 +425,7 @@ describe('Entity', () => {
             expect(subtree2.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(subtree2.a_a_a.getGuid());
         });
 
-        it('resolves entity script attributes that refer to entities within the duplicated subtree after preloading has finished', () => {
+        it('resolves entity script attributes that refer to entities within the duplicated subtree after preloading has finished', function () {
             const TestScript = createScript('test');
             TestScript.attributes.add('entityAttr', { type: 'entity' });
             TestScript.attributes.add('entityArrayAttr', { type: 'entity', array: true });
@@ -475,7 +475,7 @@ describe('Entity', () => {
             expect(subtree2.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(subtree2.a_a_a.getGuid());
         });
 
-        it('does not attempt to resolve entity script attributes that refer to entities outside of the duplicated subtree', () => {
+        it('does not attempt to resolve entity script attributes that refer to entities outside of the duplicated subtree', function () {
             const TestScript = createScript('test');
             TestScript.attributes.add('entityAttr', { type: 'entity' });
             TestScript.attributes.add('entityArrayAttr', { type: 'entity', array: true });
@@ -506,7 +506,7 @@ describe('Entity', () => {
             expect(subtree2.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(app.root.getGuid());
         });
 
-        it('ensures that an instance of a subclass keeps its class prototype', () => {
+        it('ensures that an instance of a subclass keeps its class prototype', function () {
             class UserEntity extends Entity {}
             const a = new UserEntity();
             const b = a.clone();
@@ -514,13 +514,13 @@ describe('Entity', () => {
         });
     });
 
-    describe('#destroy', () => {
+    describe('#destroy', function () {
 
-        it('destroys the entity', () => {
+        it('destroys the entity', function () {
             const entity = new Entity();
 
             let destroyed = false;
-            entity.on('destroy', () => {
+            entity.on('destroy', function () {
                 destroyed = true;
             });
             entity.destroy();
@@ -530,21 +530,21 @@ describe('Entity', () => {
 
     });
 
-    describe('#findByGuid', () => {
+    describe('#findByGuid', function () {
 
-        it('returns same entity', () => {
+        it('returns same entity', function () {
             const e = new Entity();
             expect(e.findByGuid(e.getGuid())).to.equal(e);
         });
 
-        it('returns direct child entity', () => {
+        it('returns direct child entity', function () {
             const e = new Entity();
             const c = new Entity();
             e.addChild(c);
             expect(e.findByGuid(c.getGuid())).to.equal(c);
         });
 
-        it('returns child of child entity', () => {
+        it('returns child of child entity', function () {
             const e = new Entity();
             const c = new Entity();
             const c2 = new Entity();
@@ -553,14 +553,14 @@ describe('Entity', () => {
             expect(e.findByGuid(c2.getGuid())).to.equal(c2);
         });
 
-        it('does not return parent', () => {
+        it('does not return parent', function () {
             const e = new Entity();
             const c = new Entity();
             e.addChild(c);
             expect(c.findByGuid(e.getGuid())).to.equal(null);
         });
 
-        it('does not return destroyed entity', () => {
+        it('does not return destroyed entity', function () {
             const e = new Entity();
             const c = new Entity();
             e.addChild(c);
@@ -568,7 +568,7 @@ describe('Entity', () => {
             expect(e.findByGuid(c.getGuid())).to.equal(null);
         });
 
-        it('does not return entity that was removed from hierarchy', () => {
+        it('does not return entity that was removed from hierarchy', function () {
             const e = new Entity();
             const c = new Entity();
             e.addChild(c);
@@ -576,29 +576,29 @@ describe('Entity', () => {
             expect(e.findByGuid(c.getGuid())).to.equal(null);
         });
 
-        it('does not return entity that does not exist', () => {
+        it('does not return entity that does not exist', function () {
             expect(app.root.findByGuid('missing')).to.equal(null);
         });
 
     });
 
-    describe('#findComponent', () => {
+    describe('#findComponent', function () {
 
-        it('finds component on single entity', () => {
+        it('finds component on single entity', function () {
             const e = new Entity();
             e.addComponent('anim');
             const component = e.findComponent('anim');
             expect(component).to.be.an.instanceof(AnimComponent);
         });
 
-        it('returns null when component is not found', () => {
+        it('returns null when component is not found', function () {
             const e = new Entity();
             e.addComponent('anim');
             const component = e.findComponent('render');
             expect(component).to.be.null;
         });
 
-        it('finds component on child entity', () => {
+        it('finds component on child entity', function () {
             const root = new Entity();
             const child = new Entity();
             root.addChild(child);
@@ -607,7 +607,7 @@ describe('Entity', () => {
             expect(component).to.be.an.instanceof(AnimComponent);
         });
 
-        it('finds component on grandchild entity', () => {
+        it('finds component on grandchild entity', function () {
             const root = new Entity();
             const child = new Entity();
             const grandchild = new Entity();
@@ -618,7 +618,7 @@ describe('Entity', () => {
             expect(component).to.be.an.instanceof(AnimComponent);
         });
 
-        it('does not find component on parent entity', () => {
+        it('does not find component on parent entity', function () {
             const root = new Entity();
             const child = new Entity();
             root.addChild(child);
@@ -629,9 +629,9 @@ describe('Entity', () => {
 
     });
 
-    describe('#findComponents', () => {
+    describe('#findComponents', function () {
 
-        it('finds components on single entity', () => {
+        it('finds components on single entity', function () {
             const e = new Entity();
             e.addComponent('anim');
             const components = e.findComponents('anim');
@@ -640,7 +640,7 @@ describe('Entity', () => {
             expect(components[0]).to.be.an.instanceof(AnimComponent);
         });
 
-        it('returns empty array when no components are found', () => {
+        it('returns empty array when no components are found', function () {
             const e = new Entity();
             e.addComponent('anim');
             const components = e.findComponents('render');
@@ -648,7 +648,7 @@ describe('Entity', () => {
             expect(components.length).to.equal(0);
         });
 
-        it('finds components on child entity', () => {
+        it('finds components on child entity', function () {
             const root = new Entity();
             const child = new Entity();
             root.addChild(child);
@@ -659,7 +659,7 @@ describe('Entity', () => {
             expect(components[0]).to.be.an.instanceof(AnimComponent);
         });
 
-        it('finds components on 3 entity hierarchy', () => {
+        it('finds components on 3 entity hierarchy', function () {
             const root = new Entity();
             const child = new Entity();
             const grandchild = new Entity();
@@ -676,7 +676,7 @@ describe('Entity', () => {
             expect(components[2]).to.be.an.instanceof(AnimComponent);
         });
 
-        it('does not find components on parent entity', () => {
+        it('does not find components on parent entity', function () {
             const root = new Entity();
             const child = new Entity();
             root.addChild(child);
@@ -688,9 +688,9 @@ describe('Entity', () => {
 
     });
 
-    describe('#findScript', () => {
+    describe('#findScript', function () {
 
-        it('finds script on single entity', () => {
+        it('finds script on single entity', function () {
             const MyScript = createScript('myScript');
             const e = new Entity();
             e.addComponent('script');
@@ -699,7 +699,7 @@ describe('Entity', () => {
             expect(script).to.be.an.instanceof(MyScript);
         });
 
-        it('returns undefined when script is not found', () => {
+        it('returns undefined when script is not found', function () {
             const root = new Entity();
             const child = new Entity();
             root.addChild(child);
@@ -708,7 +708,7 @@ describe('Entity', () => {
             expect(script).to.be.undefined;
         });
 
-        it('returns undefined when script component is not found', () => {
+        it('returns undefined when script component is not found', function () {
             const root = new Entity();
             const child = new Entity();
             root.addChild(child);
@@ -716,7 +716,7 @@ describe('Entity', () => {
             expect(script).to.be.undefined;
         });
 
-        it('finds script on child entity', () => {
+        it('finds script on child entity', function () {
             const MyScript = createScript('myScript');
             const root = new Entity();
             const child = new Entity();
@@ -727,7 +727,7 @@ describe('Entity', () => {
             expect(script).to.be.an.instanceof(MyScript);
         });
 
-        it('finds script on grandchild entity', () => {
+        it('finds script on grandchild entity', function () {
             const MyScript = createScript('myScript');
             const root = new Entity();
             const child = new Entity();
@@ -740,7 +740,7 @@ describe('Entity', () => {
             expect(script).to.be.an.instanceof(MyScript);
         });
 
-        it('does not find script on parent entity', () => {
+        it('does not find script on parent entity', function () {
             createScript('myScript');
             const root = new Entity();
             const child = new Entity();
@@ -753,9 +753,9 @@ describe('Entity', () => {
 
     });
 
-    describe('#findScripts', () => {
+    describe('#findScripts', function () {
 
-        it('finds scripts on single entity', () => {
+        it('finds scripts on single entity', function () {
             const MyScript = createScript('myScript');
             const e = new Entity();
             e.addComponent('script');
@@ -766,7 +766,7 @@ describe('Entity', () => {
             expect(scripts[0]).to.be.an.instanceof(MyScript);
         });
 
-        it('returns empty array when no scripts are found', () => {
+        it('returns empty array when no scripts are found', function () {
             const root = new Entity();
             const child = new Entity();
             root.addChild(child);
@@ -776,7 +776,7 @@ describe('Entity', () => {
             expect(scripts.length).to.equal(0);
         });
 
-        it('returns empty array when no script component are found', () => {
+        it('returns empty array when no script component are found', function () {
             const root = new Entity();
             const child = new Entity();
             root.addChild(child);
@@ -785,7 +785,7 @@ describe('Entity', () => {
             expect(scripts.length).to.equal(0);
         });
 
-        it('finds scripts on child entity', () => {
+        it('finds scripts on child entity', function () {
             const MyScript = createScript('myScript');
             const root = new Entity();
             const child = new Entity();
@@ -798,7 +798,7 @@ describe('Entity', () => {
             expect(scripts[0]).to.be.an.instanceof(MyScript);
         });
 
-        it('finds scripts on 3 entity hierarchy', () => {
+        it('finds scripts on 3 entity hierarchy', function () {
             const MyScript = createScript('myScript');
             const root = new Entity();
             const child = new Entity();
@@ -819,7 +819,7 @@ describe('Entity', () => {
             expect(scripts[2]).to.be.an.instanceof(MyScript);
         });
 
-        it('does not find scripts on parent entity', () => {
+        it('does not find scripts on parent entity', function () {
             createScript('myScript');
             const root = new Entity();
             const child = new Entity();
@@ -833,9 +833,9 @@ describe('Entity', () => {
 
     });
 
-    describe('#removeComponent', () => {
+    describe('#removeComponent', function () {
 
-        it('removes a component from the entity', () => {
+        it('removes a component from the entity', function () {
             const entity = new Entity();
             expect(entity.anim).to.be.undefined;
             entity.addComponent('anim');

--- a/test/framework/i18n/i18n.test.mjs
+++ b/test/framework/i18n/i18n.test.mjs
@@ -8,7 +8,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 import { expect } from 'chai';
 import { restore, stub } from 'sinon';
 
-describe('I18n', () => {
+describe('I18n', function () {
 
     let app;
 
@@ -60,21 +60,21 @@ describe('I18n', () => {
         return data;
     };
 
-    describe('#assets', () => {
+    describe('#assets', function () {
 
-        it('returns same ids for assets after setting array of asset ids', () => {
+        it('returns same ids for assets after setting array of asset ids', function () {
             app.i18n.assets = [1, 2];
             expect(app.i18n.assets).to.deep.equal([1, 2]);
         });
 
-        it('returns same ids for assets after setting array of assets', () => {
+        it('returns same ids for assets after setting array of assets', function () {
             const a1 = new Asset('a1', 'json');
             const a2 = new Asset('a2', 'json');
             app.i18n.assets = [a1, a2];
             expect(app.i18n.assets).to.deep.equal([a1.id, a2.id]);
         });
 
-        it('removes old assets when setting new array', () => {
+        it('removes old assets when setting new array', function () {
             app.i18n.assets = [1, 2];
             app.i18n.assets = [2, 3];
             expect(app.i18n.assets).to.deep.equal([2, 3]);
@@ -82,61 +82,61 @@ describe('I18n', () => {
 
     });
 
-    describe('#findAvailableLocale', () => {
+    describe('#findAvailableLocale', function () {
 
-        it('should find locale if translations have been provided for it', () => {
+        it('should find locale if translations have been provided for it', function () {
             addText('no-IT', 'key', 'norwegian');
             expect(app.i18n.findAvailableLocale('no-IT')).to.equal('no-IT');
         });
 
-        it('should fallback to en-US if translations have not been provided for the desired locale', () => {
+        it('should fallback to en-US if translations have not been provided for the desired locale', function () {
             addText('no-IT', 'key', 'norwegian');
             expect(app.i18n.findAvailableLocale('de-DE')).to.equal('en-US');
         });
 
-        it('should fallback to zh-CN if translations are provided and zh-SG is the desired locale', () => {
+        it('should fallback to zh-CN if translations are provided and zh-SG is the desired locale', function () {
             addText('zh-CN', 'key', 'Chinese');
             expect(app.i18n.findAvailableLocale('zh-SG')).to.equal('zh-CN');
         });
 
-        it('should fallback to en-GB if translations are provided and en-US is the desired locale', () => {
+        it('should fallback to en-GB if translations are provided and en-US is the desired locale', function () {
             addText('en-GB', 'key', 'British');
             expect(app.i18n.findAvailableLocale('en-US')).to.equal('en-GB');
         });
 
     });
 
-    describe('#getPluralText', () => {
+    describe('#getPluralText', function () {
 
-        it('should return key when no translations exist for that locale', () => {
+        it('should return key when no translations exist for that locale', function () {
             expect(app.i18n.getPluralText('key')).to.equal('key');
 
             addText('no-NO', 'key', ['translated']);
             expect(app.i18n.getPluralText('key')).to.equal('key');
         });
 
-        it('should return key if the desired locale has other translations but not that key', () => {
+        it('should return key if the desired locale has other translations but not that key', function () {
             addText('no-NO', 'key', ['norwegian']);
             expect(app.i18n.getPluralText('key2', 'no-NO')).to.equal('key2');
             app.i18n.locale = 'no-NO';
             expect(app.i18n.getPluralText('key2')).to.equal('key2');
         });
 
-        it('should return en-US translation if the desired locale has no translations', () => {
+        it('should return en-US translation if the desired locale has no translations', function () {
             addText('en-US', 'key', ['english one', 'english other']);
             expect(app.i18n.getPluralText('key', 1, 'no-NO')).to.equal('english one');
             app.i18n.locale = 'no-NO';
             expect(app.i18n.getPluralText('key', 1)).to.equal('english one');
         });
 
-        it('should return en-US plural form if the desired locale does not exist', () => {
+        it('should return en-US plural form if the desired locale does not exist', function () {
             addText('en-US', 'key', ['english one', 'english other']);
             expect(app.i18n.getPluralText('key', 1, 'ar')).to.equal('english one');
             app.i18n.locale = 'ar';
             expect(app.i18n.getPluralText('key', 1)).to.equal('english one');
         });
 
-        it('returns empty string if the empty string is a valid translation', () => {
+        it('returns empty string if the empty string is a valid translation', function () {
             addText('en-US', 'key', ['', '']);
             expect(app.i18n.getPluralText('key', 0)).to.equal('');
             expect(app.i18n.getPluralText('key', 1)).to.equal('');
@@ -159,7 +159,7 @@ describe('I18n', () => {
             });
         });
 
-        it('returns key is translation is null', () => {
+        it('returns key is translation is null', function () {
             addText('en-US', 'key', [null, null]);
             expect(app.i18n.getPluralText('key', 0)).to.equal('key');
             expect(app.i18n.getPluralText('key', 1)).to.equal('key');
@@ -185,7 +185,7 @@ describe('I18n', () => {
             expect(app.i18n.getPluralText('key', 2, 'es-ES')).to.equal('key');
         });
 
-        it('should fall back to default locale for that language if the specific locale does not exist', () => {
+        it('should fall back to default locale for that language if the specific locale does not exist', function () {
             for (const lang in DEFAULT_LOCALE_FALLBACKS) {
                 addText(DEFAULT_LOCALE_FALLBACKS[lang], 'key', [`language ${lang}`]);
             }
@@ -203,7 +203,7 @@ describe('I18n', () => {
 
         });
 
-        it('should fall back to default locale for that language if you just pass the language', () => {
+        it('should fall back to default locale for that language if you just pass the language', function () {
             for (const lang in DEFAULT_LOCALE_FALLBACKS) {
                 addText(DEFAULT_LOCALE_FALLBACKS[lang], 'key', [`language ${lang}`]);
             }
@@ -220,14 +220,14 @@ describe('I18n', () => {
             expect(app.i18n.getPluralText('key', 1)).to.equal('language no');
         });
 
-        it('should fall back to first available locale for that language if no default fallback exists', () => {
+        it('should fall back to first available locale for that language if no default fallback exists', function () {
             addText('no-IT', 'key', ['norwegian']);
             expect(app.i18n.getPluralText('key', 1, 'no-NO')).to.equal('norwegian');
             app.i18n.locale = 'no-NO';
             expect(app.i18n.getPluralText('key', 1)).to.equal('norwegian');
         });
 
-        it('should return correct plural forms for \"ja, ko, th, vi, zh\"', () => {
+        it('should return correct plural forms for \"ja, ko, th, vi, zh\"', function () {
             const locales = ['ja-JP', 'ko-KO', 'th-TH', 'vi-VI', 'zh-ZH'];
             locales.forEach((locale) => {
                 addText(locale, 'key', ['other']);
@@ -243,7 +243,7 @@ describe('I18n', () => {
             });
         });
 
-        it('should return correct plural forms for \"fa, hi\"', () => {
+        it('should return correct plural forms for \"fa, hi\"', function () {
             const locales = ['fa-FA', 'hi-HI'];
             locales.forEach((locale) => {
                 addText(locale, 'key', ['one', 'other']);
@@ -265,7 +265,7 @@ describe('I18n', () => {
             });
         });
 
-        it('should return correct plural forms for \"fr\"', () => {
+        it('should return correct plural forms for \"fr\"', function () {
             const locales = ['fr-FR'];
             locales.forEach((locale) => {
                 addText(locale, 'key', ['one', 'other']);
@@ -287,7 +287,7 @@ describe('I18n', () => {
         });
 
 
-        it('should return correct plural forms for \"en, de, it, el, es, tr\"', () => {
+        it('should return correct plural forms for \"en, de, it, el, es, tr\"', function () {
             const locales = ['en-US', 'en-GB', 'de-DE', 'it-IT', 'el-GR', 'es-ES', 'tr-TR'];
             locales.forEach((locale) => {
                 addText(locale, 'key', ['one', 'other']);
@@ -308,7 +308,7 @@ describe('I18n', () => {
             });
         });
 
-        it('should return correct plural forms for \"ru, uk\"', () => {
+        it('should return correct plural forms for \"ru, uk\"', function () {
             const locales = ['ru-RU', 'uk-UK'];
             locales.forEach((locale) => {
                 addText(locale, 'key', ['one', 'few', 'many', 'other']);
@@ -347,7 +347,7 @@ describe('I18n', () => {
             });
         });
 
-        it('should return correct plural forms for \"ar\"', () => {
+        it('should return correct plural forms for \"ar\"', function () {
             const locales = ['ar-AR'];
             locales.forEach((locale) => {
                 addText(locale, 'key', ['zero', 'one', 'two', 'few', 'many', 'other']);
@@ -386,7 +386,7 @@ describe('I18n', () => {
             });
         });
 
-        it('zh-HK should use zh-HK if it exists', () => {
+        it('zh-HK should use zh-HK if it exists', function () {
             addText('zh-CN', 'key', ['cn']);
             addText('zh-HK', 'key', ['hk']);
             addText('zh-TW', 'key', ['tw']);
@@ -394,21 +394,21 @@ describe('I18n', () => {
             expect(app.i18n.getPluralText('key')).to.equal('hk');
         });
 
-        it('zh-HK should fall back to zh-TW', () => {
+        it('zh-HK should fall back to zh-TW', function () {
             addText('zh-CN', 'key', ['cn']);
             addText('zh-TW', 'key', ['hk']);
             app.i18n.locale = 'zh-HK';
             expect(app.i18n.getPluralText('key')).to.equal('hk');
         });
 
-        it('zh-TW should fall back to zh-HK', () => {
+        it('zh-TW should fall back to zh-HK', function () {
             addText('zh-CN', 'key', ['cn']);
             addText('zh-HK', 'key', ['tw']);
             app.i18n.locale = 'zh-TW';
             expect(app.i18n.getPluralText('key')).to.equal('tw');
         });
 
-        it('zh-SG should fall back to zh-CN', () => {
+        it('zh-SG should fall back to zh-CN', function () {
             addText('zh-HK', 'key', ['hk']);
             addText('zh-CN', 'key', ['cn']);
             addText('zh-TW', 'key', ['tw']);
@@ -418,23 +418,23 @@ describe('I18n', () => {
 
     });
 
-    describe('#getText', () => {
+    describe('#getText', function () {
 
-        it('should return key when no translations exist for that locale', () => {
+        it('should return key when no translations exist for that locale', function () {
             expect(app.i18n.getText('key')).to.equal('key');
 
             addText('no-NO', 'key', 'translated');
             expect(app.i18n.getText('key')).to.equal('key');
         });
 
-        it('should return localized text when translation exists', () => {
+        it('should return localized text when translation exists', function () {
             addText('no-NO', 'key', 'translated');
             expect(app.i18n.getText('key', 'no-NO')).to.equal('translated');
             app.i18n.locale = 'no-NO';
             expect(app.i18n.getText('key')).to.equal('translated');
         });
 
-        it('should return en-US translation if the desired locale has no translations', () => {
+        it('should return en-US translation if the desired locale has no translations', function () {
             addText('en-US', 'key', 'english');
             expect(app.i18n.getText('key', 'no-NO')).to.equal('english');
             app.i18n.locale = 'no-NO';
@@ -445,42 +445,42 @@ describe('I18n', () => {
             expect(app.i18n.getText('key')).to.equal('norwegian');
         });
 
-        it('should return key if the desired locale has other translations but not that key', () => {
+        it('should return key if the desired locale has other translations but not that key', function () {
             addText('no-NO', 'key', 'norwegian');
             expect(app.i18n.getText('key2', 'no-NO')).to.equal('key2');
             app.i18n.locale = 'no-NO';
             expect(app.i18n.getText('key2')).to.equal('key2');
         });
 
-        it('should fall back to default locale for that language if the specific locale does not exist', () => {
+        it('should fall back to default locale for that language if the specific locale does not exist', function () {
             addText('no-NO', 'key', 'norwegian');
             expect(app.i18n.getText('key', 'no-IT')).to.equal('norwegian');
             app.i18n.locale = 'no-IT';
             expect(app.i18n.getText('key')).to.equal('norwegian');
         });
 
-        it('should fall back to default locale for that language if you just pass the language', () => {
+        it('should fall back to default locale for that language if you just pass the language', function () {
             addText('no-NO', 'key', 'norwegian');
             expect(app.i18n.getText('key', 'no')).to.equal('norwegian');
             app.i18n.locale = 'no';
             expect(app.i18n.getText('key')).to.equal('norwegian');
         });
 
-        it('should fall back to first available locale for that language if no default fallback exists', () => {
+        it('should fall back to first available locale for that language if no default fallback exists', function () {
             addText('no-IT', 'key', 'norwegian');
             expect(app.i18n.getText('key', 'no-NO')).to.equal('norwegian');
             app.i18n.locale = 'no-NO';
             expect(app.i18n.getText('key')).to.equal('norwegian');
         });
 
-        it('when called on plural key should return the first entry', () => {
+        it('when called on plural key should return the first entry', function () {
             addText('no-IT', 'key', ['one', 'other']);
             expect(app.i18n.getText('key', 'no-NO')).to.equal('one');
             app.i18n.locale = 'no-NO';
             expect(app.i18n.getText('key')).to.equal('one');
         });
 
-        it('returns empty string if the empty string is a valid translation', () => {
+        it('returns empty string if the empty string is a valid translation', function () {
             addText('en-US', 'key', '');
             expect(app.i18n.getText('key')).to.equal('');
             expect(app.i18n.getText('key', 'no-NO')).to.equal('');
@@ -488,7 +488,7 @@ describe('I18n', () => {
             expect(app.i18n.getText('key')).to.equal('');
         });
 
-        it('returns key if the translation is null', () => {
+        it('returns key if the translation is null', function () {
             addText('en-US', 'key', null);
             expect(app.i18n.getText('key')).to.equal('key');
             expect(app.i18n.getText('key', 'no-NO')).to.equal('key');
@@ -496,7 +496,7 @@ describe('I18n', () => {
             expect(app.i18n.getText('key')).to.equal('key');
         });
 
-        it('zh-HK should use zh-HK if it exists', () => {
+        it('zh-HK should use zh-HK if it exists', function () {
             addText('zh-CN', 'key', 'cn');
             addText('zh-HK', 'key', 'hk');
             addText('zh-TW', 'key', 'tw');
@@ -504,21 +504,21 @@ describe('I18n', () => {
             expect(app.i18n.getText('key')).to.equal('hk');
         });
 
-        it('zh-HK should fall back to zh-TW', () => {
+        it('zh-HK should fall back to zh-TW', function () {
             addText('zh-CN', 'key', 'cn');
             addText('zh-TW', 'key', 'hk');
             app.i18n.locale = 'zh-HK';
             expect(app.i18n.getText('key')).to.equal('hk');
         });
 
-        it('zh-TW should fall back to zh-HK', () => {
+        it('zh-TW should fall back to zh-HK', function () {
             addText('zh-CN', 'key', 'cn');
             addText('zh-HK', 'key', 'tw');
             app.i18n.locale = 'zh-TW';
             expect(app.i18n.getText('key')).to.equal('tw');
         });
 
-        it('zh-SG should fall back to zh-CN', () => {
+        it('zh-SG should fall back to zh-CN', function () {
             addText('zh-HK', 'key', 'hk');
             addText('zh-CN', 'key', 'cn');
             addText('zh-TW', 'key', 'tw');
@@ -528,9 +528,9 @@ describe('I18n', () => {
 
     });
 
-    describe('#locale', () => {
+    describe('#locale', function () {
 
-        it('ensures locale for Indonesian always starts with "id"', () => {
+        it('ensures locale for Indonesian always starts with "id"', function () {
             app.i18n.locale = 'id';
             expect(app.i18n.locale).to.equal('id');
 
@@ -553,9 +553,9 @@ describe('I18n', () => {
 
     });
 
-    describe('removeData', () => {
+    describe('removeData', function () {
 
-        it('removes all data correctly', () => {
+        it('removes all data correctly', function () {
             const data1 = addText('en-US', 'key', 'translation');
             const data2 = addText('en-US', 'key2', 'translation2');
             const data3 = addText('no-IT', 'key3', 'translation3');
@@ -591,7 +591,7 @@ describe('I18n', () => {
         const asset = new Asset('a1', 'json', { url: '/fake/url.json' });
         app.i18n.assets = [asset];
 
-        app.i18n.on('data:add', () => {
+        app.i18n.on('data:add', function () {
             expect(app.i18n.getText('key')).to.equal('translation');
             done();
         });
@@ -610,7 +610,7 @@ describe('I18n', () => {
 
         app.i18n.assets = [asset];
 
-        app.i18n.on('data:add', () => {
+        app.i18n.on('data:add', function () {
             expect(app.i18n.getText('key')).to.equal('translation');
             done();
         });
@@ -623,13 +623,13 @@ describe('I18n', () => {
             callback(null, createTranslation('en-US', 'key', 'translation'));
         });
 
-        app.i18n.on('data:add', () => {
+        app.i18n.on('data:add', function () {
             expect(app.i18n.getText('key')).to.equal('translation');
             done();
         });
 
         const asset = new Asset('a1', 'json', { url: '/fake/url.json' });
-        asset.on('load', () => {
+        asset.on('load', function () {
             app.i18n.assets = [asset];
         });
 
@@ -644,13 +644,13 @@ describe('I18n', () => {
 
         const asset = new Asset('a1', 'json', { url: '/fake/url.json' });
 
-        app.i18n.on('data:add', () => {
+        app.i18n.on('data:add', function () {
             asset.unload();
             expect(app.i18n.getText('key')).to.equal('key');
             done();
         });
 
-        asset.on('load', () => {
+        asset.on('load', function () {
             app.i18n.assets = [asset];
         });
 
@@ -665,13 +665,13 @@ describe('I18n', () => {
 
         const asset = new Asset('a1', 'json', { url: '/fake/url.json' });
 
-        app.i18n.on('data:add', () => {
+        app.i18n.on('data:add', function () {
             app.assets.remove(asset);
             expect(app.i18n.getText('key')).to.equal('key');
             done();
         });
 
-        asset.on('load', () => {
+        asset.on('load', function () {
             app.i18n.assets = [asset];
         });
 
@@ -686,7 +686,7 @@ describe('I18n', () => {
 
         const asset = new Asset('a1', 'json', { url: '/fake/url.json' });
 
-        app.i18n.once('data:add', () => {
+        app.i18n.once('data:add', function () {
             app.assets.remove(asset);
 
             setTimeout(() => {
@@ -696,7 +696,7 @@ describe('I18n', () => {
             });
         });
 
-        asset.once('load', () => {
+        asset.once('load', function () {
             app.i18n.assets = [asset];
         });
 
@@ -711,11 +711,11 @@ describe('I18n', () => {
 
         const asset = new Asset('a1', 'json', { url: '/fake/url.json' });
 
-        app.i18n.once('data:add', () => {
+        app.i18n.once('data:add', function () {
             expect(app.i18n.getText('key')).to.equal('translation');
 
             setTimeout(() => {
-                app.i18n.once('data:add', () => {
+                app.i18n.once('data:add', function () {
                     expect(app.i18n.getText('key')).to.equal('changed');
                     done();
                 });
@@ -724,7 +724,7 @@ describe('I18n', () => {
             });
         });
 
-        asset.once('load', () => {
+        asset.once('load', function () {
             app.i18n.assets = [asset];
         });
 

--- a/test/framework/scene-registry.test.mjs
+++ b/test/framework/scene-registry.test.mjs
@@ -6,7 +6,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe('SceneRegistry', () => {
+describe('SceneRegistry', function () {
 
     let app;
 
@@ -19,9 +19,9 @@ describe('SceneRegistry', () => {
         app.destroy();
     });
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('creates a new scene registry', () => {
+        it('creates a new scene registry', function () {
             const registry = new SceneRegistry(app);
 
             expect(registry.list().length).to.equal(0);
@@ -29,9 +29,9 @@ describe('SceneRegistry', () => {
 
     });
 
-    describe('#add', () => {
+    describe('#add', function () {
 
-        it('adds a single scene to the registry', () => {
+        it('adds a single scene to the registry', function () {
             const registry = new SceneRegistry(app);
 
             registry.add('New Scene', '/test.json');
@@ -39,7 +39,7 @@ describe('SceneRegistry', () => {
             expect(registry.list().length).to.equal(1);
         });
 
-        it('adds multiple scenes to the registry', () => {
+        it('adds multiple scenes to the registry', function () {
             const registry = new SceneRegistry(app);
             registry.add('New Scene 1', '/test1.json');
             registry.add('New Scene 2', '/test2.json');
@@ -57,9 +57,9 @@ describe('SceneRegistry', () => {
 
     });
 
-    describe('#find', () => {
+    describe('#find', function () {
 
-        it('find', () => {
+        it('find', function () {
             const registry = new SceneRegistry(app);
             registry.add('New Scene', '/test.json');
 
@@ -71,9 +71,9 @@ describe('SceneRegistry', () => {
 
     });
 
-    describe('#findByUrl', () => {
+    describe('#findByUrl', function () {
 
-        it('url index', () => {
+        it('url index', function () {
             const registry = new SceneRegistry(app);
             registry.add('New Scene 1', '/test1.json');
 
@@ -84,9 +84,9 @@ describe('SceneRegistry', () => {
 
     });
 
-    describe('#list', () => {
+    describe('#list', function () {
 
-        it('lists the scenes in the registry', () => {
+        it('lists the scenes in the registry', function () {
             const registry = new SceneRegistry(app);
             registry.add('New Scene 1', '/test1.json');
             registry.add('New Scene 2', '/test2.json');
@@ -112,7 +112,7 @@ describe('SceneRegistry', () => {
         });
     };
 
-    describe('#loadSceneData', () => {
+    describe('#loadSceneData', function () {
 
         const assetPath = 'http://localhost:3000/test/test-assets/';
 
@@ -170,9 +170,9 @@ describe('SceneRegistry', () => {
         });
     });
 
-    describe('#remove', () => {
+    describe('#remove', function () {
 
-        it('remove', () => {
+        it('remove', function () {
             const registry = new SceneRegistry(app);
             registry.add('New Scene', '/test.json');
 
@@ -182,7 +182,7 @@ describe('SceneRegistry', () => {
             expect(registry.find('New Scene')).to.equal(null);
         });
 
-        it('remove middle value', () => {
+        it('remove middle value', function () {
             const registry = new SceneRegistry(app);
             registry.add('New Scene 1', '/test1.json');
             registry.add('New Scene 2', '/test2.json');
@@ -198,7 +198,7 @@ describe('SceneRegistry', () => {
             expect(registry.find('New Scene 3').url).to.equal('/test3.json');
         });
 
-        it('remove middle, url index', () => {
+        it('remove middle, url index', function () {
             const registry = new SceneRegistry(app);
             registry.add('New Scene 1', '/test1.json');
             registry.add('New Scene 2', '/test2.json');

--- a/test/framework/utils/entity-reference.test.mjs
+++ b/test/framework/utils/entity-reference.test.mjs
@@ -12,7 +12,7 @@ import { restore, spy, stub } from 'sinon';
 
 /** @typedef {import('../../../../src/framework/components/component.js').Component} Component */
 
-describe('EntityReference', () => {
+describe('EntityReference', function () {
     /** @type {Application} */
     let app;
     /** @type {Entity} */
@@ -67,7 +67,7 @@ describe('EntityReference', () => {
         return entity._callbacks.get(eventName)?.length || 0;
     }
 
-    it('provides a reference to the entity once the guid is populated', () => {
+    it('provides a reference to the entity once the guid is populated', function () {
         const reference = new EntityReference(testComponent, 'myEntity1');
         expect(reference.entity).to.equal(null);
 
@@ -75,7 +75,7 @@ describe('EntityReference', () => {
         expect(reference.entity).to.equal(otherEntity1);
     });
 
-    it('does not attempt to resolve the entity reference if the parent component is not on the scene graph yet', () => {
+    it('does not attempt to resolve the entity reference if the parent component is not on the scene graph yet', function () {
         app.root.removeChild(testEntity);
 
         spy(app.root, 'findByGuid');
@@ -87,7 +87,7 @@ describe('EntityReference', () => {
         expect(app.root.findByGuid.callCount).to.equal(0);
     });
 
-    it('resolves the entity reference when onParentComponentEnable() is called', () => {
+    it('resolves the entity reference when onParentComponentEnable() is called', function () {
         app.root.removeChild(testEntity);
 
         const reference = new EntityReference(testComponent, 'myEntity1');
@@ -100,7 +100,7 @@ describe('EntityReference', () => {
         expect(reference.entity).to.equal(otherEntity1);
     });
 
-    it('nullifies the reference when the guid is nullified', () => {
+    it('nullifies the reference when the guid is nullified', function () {
         const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1.getGuid();
         expect(reference.entity).to.equal(otherEntity1);
@@ -109,7 +109,7 @@ describe('EntityReference', () => {
         expect(reference.entity).to.equal(null);
     });
 
-    it('nullifies the reference when the referenced entity is destroyed', () => {
+    it('nullifies the reference when the referenced entity is destroyed', function () {
         const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1.getGuid();
         expect(reference.entity).to.equal(otherEntity1);
@@ -118,7 +118,7 @@ describe('EntityReference', () => {
         expect(reference.entity).to.equal(null);
     });
 
-    it('removes all entity and component listeners when the guid is reassigned', () => {
+    it('removes all entity and component listeners when the guid is reassigned', function () {
         const reference = new EntityReference(testComponent, 'myEntity1', {
             'entity#foo': stub(),
             'dummy#bar': stub()
@@ -134,7 +134,7 @@ describe('EntityReference', () => {
         expect(getNumListenersForEvent(otherEntity1.dummy, 'bar')).to.equal(0);
     });
 
-    it('removes all entity and component listeners when the parent component is removed', () => {
+    it('removes all entity and component listeners when the parent component is removed', function () {
         const reference = new EntityReference(testComponent, 'myEntity1', {
             'entity#foo': stub(),
             'dummy#bar': stub()
@@ -154,7 +154,7 @@ describe('EntityReference', () => {
         expect(getNumListenersForEvent(app.systems.dummy, 'beforeremove')).to.equal(0);
     });
 
-    it('removes all entity and component listeners when the parent component\'s entity is destroyed', () => {
+    it('removes all entity and component listeners when the parent component\'s entity is destroyed', function () {
         const reference = new EntityReference(testComponent, 'myEntity1', {
             'entity#foo': stub(),
             'dummy#bar': stub()
@@ -174,7 +174,7 @@ describe('EntityReference', () => {
         expect(getNumListenersForEvent(app.systems.dummy, 'beforeremove')).to.equal(0);
     });
 
-    it('fires component gain events when a guid is first assigned, if the referenced entity already has the component', () => {
+    it('fires component gain events when a guid is first assigned, if the referenced entity already has the component', function () {
         const gainListener = stub();
 
         const reference = new EntityReference(testComponent, 'myEntity1', {
@@ -187,7 +187,7 @@ describe('EntityReference', () => {
         expect(gainListener.callCount).to.equal(1);
     });
 
-    it('fires component gain events once a component is added', () => {
+    it('fires component gain events once a component is added', function () {
         const gainListener = stub();
 
         const reference = new EntityReference(testComponent, 'myEntity2', {
@@ -204,7 +204,7 @@ describe('EntityReference', () => {
         expect(gainListener.callCount).to.equal(1);
     });
 
-    it('fires component lose and gain events when a component is removed and re-added', () => {
+    it('fires component lose and gain events when a component is removed and re-added', function () {
         const gainListener = stub();
         const loseListener = stub();
 
@@ -230,7 +230,7 @@ describe('EntityReference', () => {
         expect(loseListener.callCount).to.equal(1);
     });
 
-    it('fires component lose events when the guid is reassigned, but only for component types that the entity had', () => {
+    it('fires component lose events when the guid is reassigned, but only for component types that the entity had', function () {
         const dummyLoseListener = stub();
         const lightLoseListener = stub();
 
@@ -251,7 +251,7 @@ describe('EntityReference', () => {
         expect(lightLoseListener.callCount).to.equal(0);
     });
 
-    it('forwards any events dispatched by a component', () => {
+    it('forwards any events dispatched by a component', function () {
         const fooListener = stub();
         const barListener = stub();
 
@@ -276,7 +276,7 @@ describe('EntityReference', () => {
         expect(barListener.getCall(0).args[1]).to.equal('d');
     });
 
-    it('correctly handles component event forwarding across component removal and subsequent re-addition', () => {
+    it('correctly handles component event forwarding across component removal and subsequent re-addition', function () {
         const fooListener = stub();
         const barListener = stub();
 
@@ -305,7 +305,7 @@ describe('EntityReference', () => {
         expect(barListener.callCount).to.equal(1);
     });
 
-    it('forwards any events dispatched by the entity', () => {
+    it('forwards any events dispatched by the entity', function () {
         const fooListener = stub();
         const barListener = stub();
 
@@ -330,7 +330,7 @@ describe('EntityReference', () => {
         expect(barListener.getCall(0).args[1]).to.equal('d');
     });
 
-    it('correctly handles entity event forwarding across entity nullification and subsequent reassignment', () => {
+    it('correctly handles entity event forwarding across entity nullification and subsequent reassignment', function () {
         const fooListener = stub();
         const barListener = stub();
 
@@ -357,7 +357,7 @@ describe('EntityReference', () => {
         expect(barListener.callCount).to.equal(1);
     });
 
-    it('validates the event map', () => {
+    it('validates the event map', function () {
         function testEventMap(eventMap) {
             const reference = new EntityReference(testComponent, 'myEntity1', eventMap);
             expect(reference).to.be.ok;
@@ -382,7 +382,7 @@ describe('EntityReference', () => {
         }).to.throw('Invalid or missing callback for event listener `foo#bar`');
     });
 
-    it('logs a warning if the entity property is set to anything other than a string, undefined or null', () => {
+    it('logs a warning if the entity property is set to anything other than a string, undefined or null', function () {
         stub(console, 'warn');
 
         const reference = new EntityReference(testComponent, 'myEntity1');
@@ -400,7 +400,7 @@ describe('EntityReference', () => {
         expect(console.warn.getCall(0).args[0]).to.equal('Entity field `myEntity1` was set to unexpected type \'object\'');
     });
 
-    it('set reference to a Entity instead of guid, converts property to guid', () => {
+    it('set reference to a Entity instead of guid, converts property to guid', function () {
         const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1;
 
@@ -408,7 +408,7 @@ describe('EntityReference', () => {
         expect(reference.entity).to.equal(otherEntity1);
     });
 
-    it('set reference to a Entity that is not in hierarchy, converts property to guid', () => {
+    it('set reference to a Entity that is not in hierarchy, converts property to guid', function () {
         const reference = new EntityReference(testComponent, 'myEntity1');
         const entity = new Entity();
         testComponent.myEntity1 = entity;
@@ -417,13 +417,13 @@ describe('EntityReference', () => {
         expect(reference.entity).to.equal(entity);
     });
 
-    it('hasComponent() returns false if the entity is not present', () => {
+    it('hasComponent() returns false if the entity is not present', function () {
         const reference = new EntityReference(testComponent, 'myEntity1');
 
         expect(reference.hasComponent('dummy')).to.equal(false);
     });
 
-    it('hasComponent() returns false if the entity is present but does not have a component of the provided type', () => {
+    it('hasComponent() returns false if the entity is present but does not have a component of the provided type', function () {
         const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1.getGuid();
         otherEntity1.removeComponent('dummy');
@@ -431,7 +431,7 @@ describe('EntityReference', () => {
         expect(reference.hasComponent('dummy')).to.equal(false);
     });
 
-    it('hasComponent() returns true if the entity is present and has a component of the provided type', () => {
+    it('hasComponent() returns true if the entity is present and has a component of the provided type', function () {
         const reference = new EntityReference(testComponent, 'myEntity1');
         testComponent.myEntity1 = otherEntity1.getGuid();
 

--- a/test/platform/graphics/blend-state.test.mjs
+++ b/test/platform/graphics/blend-state.test.mjs
@@ -6,11 +6,11 @@ import {
 
 import { expect } from 'chai';
 
-describe('BlendState', () => {
+describe('BlendState', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('empty', () => {
+        it('empty', function () {
             const bs = new BlendState();
             expect(bs.blend).to.equal(false);
             expect(bs.colorOp).to.equal(BLENDEQUATION_ADD);
@@ -25,7 +25,7 @@ describe('BlendState', () => {
             expect(bs.alphaWrite).to.equal(true);
         });
 
-        it('minimal parameters', () => {
+        it('minimal parameters', function () {
             const bs = new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ZERO);
             expect(bs.blend).to.equal(true);
             expect(bs.colorOp).to.equal(BLENDEQUATION_ADD);
@@ -40,7 +40,7 @@ describe('BlendState', () => {
             expect(bs.alphaWrite).to.equal(true);
         });
 
-        it('full parameters', () => {
+        it('full parameters', function () {
             const bs = new BlendState(true, BLENDEQUATION_MIN, BLENDMODE_ONE, BLENDMODE_ZERO,
                 BLENDEQUATION_MAX, BLENDMODE_ONE_MINUS_DST_COLOR, BLENDMODE_SRC_ALPHA_SATURATE,
                 false, false, false, false);

--- a/test/platform/graphics/depth-state.test.mjs
+++ b/test/platform/graphics/depth-state.test.mjs
@@ -5,17 +5,17 @@ import {
 
 import { expect } from 'chai';
 
-describe('DepthState', () => {
+describe('DepthState', function () {
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('empty', () => {
+        it('empty', function () {
             const ds = new DepthState();
             expect(ds.func).to.equal(FUNC_LESSEQUAL);
             expect(ds.write).to.equal(true);
         });
 
-        it('full parameters', () => {
+        it('full parameters', function () {
             const ds = new DepthState(FUNC_NOTEQUAL, false);
             expect(ds.func).to.equal(FUNC_NOTEQUAL);
             expect(ds.write).to.equal(false);
@@ -23,16 +23,16 @@ describe('DepthState', () => {
 
     });
 
-    describe('#test property', () => {
+    describe('#test property', function () {
 
-        it('test enabled', () => {
+        it('test enabled', function () {
             const ds = new DepthState();
             ds.test = true;
             expect(ds.func).to.equal(FUNC_LESSEQUAL);
             expect(ds.test).to.equal(true);
         });
 
-        it('test disabled', () => {
+        it('test disabled', function () {
             const ds = new DepthState();
             ds.test = false;
             expect(ds.func).to.equal(FUNC_ALWAYS);

--- a/test/platform/input/keyboard.test.mjs
+++ b/test/platform/input/keyboard.test.mjs
@@ -3,7 +3,7 @@ import { EVENT_KEYDOWN, EVENT_KEYUP, KEY_UP } from '../../../src/platform/input/
 
 import { expect } from 'chai';
 
-describe('Keyboard', () => {
+describe('Keyboard', function () {
 
     /** @type { Keyboard } */
     let keyboard;
@@ -17,21 +17,21 @@ describe('Keyboard', () => {
         keyboard.detach();
     });
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('should create a new instance', () => {
+        it('should create a new instance', function () {
             expect(keyboard).to.be.an.instanceOf(Keyboard);
         });
 
     });
 
-    describe('#isPressed', () => {
+    describe('#isPressed', function () {
 
-        it('should return false for a key that is not pressed', () => {
+        it('should return false for a key that is not pressed', function () {
             expect(keyboard.isPressed(KEY_UP)).to.be.false;
         });
 
-        it('should return true for a key that is pressed', () => {
+        it('should return true for a key that is pressed', function () {
             const keyDownEvent = new KeyboardEvent('keydown', {
                 keyCode: 38 // Up arrow
             });
@@ -53,7 +53,7 @@ describe('Keyboard', () => {
 
     });
 
-    describe('#on', () => {
+    describe('#on', function () {
 
         it('should handle keydown events', (done) => {
             keyboard.on(EVENT_KEYDOWN, (event) => {
@@ -87,13 +87,13 @@ describe('Keyboard', () => {
 
     });
 
-    describe('#wasPressed', () => {
+    describe('#wasPressed', function () {
 
-        it('should return false for a key that was not pressed', () => {
+        it('should return false for a key that was not pressed', function () {
             expect(keyboard.wasPressed(KEY_UP)).to.be.false;
         });
 
-        it('should return true for a key that was pressed since the last update', () => {
+        it('should return true for a key that was pressed since the last update', function () {
             const keyDownEvent = new KeyboardEvent('keydown', {
                 keyCode: 38 // Up arrow
             });
@@ -108,13 +108,13 @@ describe('Keyboard', () => {
 
     });
 
-    describe('#wasReleased', () => {
+    describe('#wasReleased', function () {
 
-        it('should return false for a key that was not released', () => {
+        it('should return false for a key that was not released', function () {
             expect(keyboard.wasReleased(KEY_UP)).to.be.false;
         });
 
-        it('should return true for a key that was released since the last update', () => {
+        it('should return true for a key that was released since the last update', function () {
             const keyDownEvent = new KeyboardEvent('keydown', {
                 keyCode: 38 // Up arrow
             });

--- a/test/platform/input/mouse.test.mjs
+++ b/test/platform/input/mouse.test.mjs
@@ -13,7 +13,7 @@ Mouse.prototype._getTargetCoords = function (event) {
     return { x: 0, y: 0 };
 };
 
-describe('Mouse', () => {
+describe('Mouse', function () {
 
     /** @type { Mouse } */
     let mouse;
@@ -26,23 +26,23 @@ describe('Mouse', () => {
         mouse.detach();
     });
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
-        it('should create a new instance', () => {
+        it('should create a new instance', function () {
             expect(mouse).to.be.an.instanceOf(Mouse);
         });
 
     });
 
-    describe('#isPressed', () => {
+    describe('#isPressed', function () {
 
-        it('should return false for all buttons by default', () => {
+        it('should return false for all buttons by default', function () {
             for (const button of buttons) {
                 expect(mouse.isPressed(button)).to.be.false;
             }
         });
 
-        it('should return true for a mouse button that is pressed', () => {
+        it('should return true for a mouse button that is pressed', function () {
             for (const button of buttons) {
                 const mouseDownEvent = new MouseEvent('mousedown', { button });
                 window.dispatchEvent(mouseDownEvent);
@@ -58,7 +58,7 @@ describe('Mouse', () => {
 
     });
 
-    describe('#on', () => {
+    describe('#on', function () {
 
         it('should handle mousedown events', (done) => {
             mouse.on(EVENT_MOUSEDOWN, (event) => {
@@ -86,15 +86,15 @@ describe('Mouse', () => {
 
     });
 
-    describe('#wasPressed', () => {
+    describe('#wasPressed', function () {
 
-        it('should return false for all buttons by default', () => {
+        it('should return false for all buttons by default', function () {
             for (const button of buttons) {
                 expect(mouse.wasPressed(button)).to.be.false;
             }
         });
 
-        it('should return true for a mouse button that was pressed', () => {
+        it('should return true for a mouse button that was pressed', function () {
             for (const button of buttons) {
                 const mouseDownEvent = new MouseEvent('mousedown', { button });
                 window.dispatchEvent(mouseDownEvent);
@@ -109,15 +109,15 @@ describe('Mouse', () => {
 
     });
 
-    describe('#wasReleased', () => {
+    describe('#wasReleased', function () {
 
-        it('should return false for all buttons by default', () => {
+        it('should return false for all buttons by default', function () {
             for (const button of buttons) {
                 expect(mouse.wasReleased(button)).to.be.false;
             }
         });
 
-        it('should return true for a mouse button that was released', () => {
+        it('should return true for a mouse button that was released', function () {
             for (const button of buttons) {
                 const mouseDownEvent = new MouseEvent('mousedown', { button });
                 window.dispatchEvent(mouseDownEvent);

--- a/test/platform/net/http.test.mjs
+++ b/test/platform/net/http.test.mjs
@@ -3,7 +3,7 @@ import { http, Http } from '../../../src/platform/net/http.js';
 import { expect } from 'chai';
 import { restore, spy } from 'sinon';
 
-describe('Http', () => {
+describe('Http', function () {
     let retryDelay;
 
     beforeEach(() => {
@@ -16,7 +16,7 @@ describe('Http', () => {
         restore();
     });
 
-    describe('#get()', () => {
+    describe('#get()', function () {
 
         it('returns resource', (done) => {
             http.get('http://localhost:3000/test/test-assets/test.json', (err, data) => {

--- a/test/scene/batching/batch-manager.test.mjs
+++ b/test/scene/batching/batch-manager.test.mjs
@@ -7,7 +7,7 @@ import { HTMLCanvasElement } from '@playcanvas/canvas-mock';
 
 import { expect } from 'chai';
 
-describe('BatchManager', () => {
+describe('BatchManager', function () {
 
     beforeEach(function () {
         const canvas = new HTMLCanvasElement(500, 500);

--- a/test/scene/composition/layer-composition.test.mjs
+++ b/test/scene/composition/layer-composition.test.mjs
@@ -18,7 +18,7 @@ describe('LayerComposition', function () {
         this.composition = null;
     });
 
-    describe('#constructor', () => {
+    describe('#constructor', function () {
 
         it('creates a new LayerComposition', function () {
             expect(this.composition).to.be.an.instanceof(LayerComposition);
@@ -26,7 +26,7 @@ describe('LayerComposition', function () {
 
     });
 
-    describe('#getLayerById', () => {
+    describe('#getLayerById', function () {
 
         it('should work after push()', function () {
             this.composition.push(this.layer);
@@ -78,7 +78,7 @@ describe('LayerComposition', function () {
 
     });
 
-    describe('#getOpaqueIndex', () => {
+    describe('#getOpaqueIndex', function () {
 
         it('should return correct index after push()', function () {
             this.composition.push(this.layer);
@@ -103,7 +103,7 @@ describe('LayerComposition', function () {
 
     });
 
-    describe('#getTransparentIndex', () => {
+    describe('#getTransparentIndex', function () {
 
         it('should return correct index after push()', function () {
             this.composition.push(this.layer);
@@ -128,7 +128,7 @@ describe('LayerComposition', function () {
 
     });
 
-    describe('#getLayerByName', () => {
+    describe('#getLayerByName', function () {
 
         it('should return layer', function () {
             this.composition.push(this.layer);
@@ -141,7 +141,7 @@ describe('LayerComposition', function () {
 
     });
 
-    describe('#sortTransparentLayers', () => {
+    describe('#sortTransparentLayers', function () {
 
         it('should return negative if the first layers are on top of the second layers', function () {
             const layerFront = new Layer({ id: 2 });
@@ -259,7 +259,7 @@ describe('LayerComposition', function () {
 
     });
 
-    describe('#sortOpaqueLayers', () => {
+    describe('#sortOpaqueLayers', function () {
 
         it('should return negative if the first layers are on top of the second layers', function () {
             const layerFront = new Layer({ id: 2 });

--- a/test/scene/graph-node.test.mjs
+++ b/test/scene/graph-node.test.mjs
@@ -6,17 +6,17 @@ import { Vec3 } from '../../src/core/math/vec3.js';
 
 import { expect } from 'chai';
 
-describe('GraphNode', () => {
+describe('GraphNode', function () {
 
-    describe('#children', () => {
+    describe('#children', function () {
 
-        it('should be an empty array by default', () => {
+        it('should be an empty array by default', function () {
             const root = new GraphNode();
             expect(root.children).to.be.an('array');
             expect(root.children).to.be.empty;
         });
 
-        it('should be an array of GraphNode', () => {
+        it('should be an array of GraphNode', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.addChild(child);
@@ -26,30 +26,30 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#enabled', () => {
+    describe('#enabled', function () {
 
-        it('should be false by default', () => {
+        it('should be false by default', function () {
             const root = new GraphNode();
             expect(root.enabled).to.be.false;
         });
 
     });
 
-    describe('#graphDepth', () => {
+    describe('#graphDepth', function () {
 
-        it('should be 0 by default', () => {
+        it('should be 0 by default', function () {
             const root = new GraphNode();
             expect(root.graphDepth).to.equal(0);
         });
 
-        it('should be 1 if the node is a child', () => {
+        it('should be 1 if the node is a child', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.addChild(child);
             expect(child.graphDepth).to.equal(1);
         });
 
-        it('should be 2 if the node is a grandchild', () => {
+        it('should be 2 if the node is a grandchild', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             const grandChild = new GraphNode();
@@ -60,14 +60,14 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#parent', () => {
+    describe('#parent', function () {
 
-        it('should be null by default', () => {
+        it('should be null by default', function () {
             const node = new GraphNode();
             expect(node.parent).to.be.null;
         });
 
-        it('should be set to the parent node', () => {
+        it('should be set to the parent node', function () {
             const parent = new GraphNode();
             const child = new GraphNode();
             parent.addChild(child);
@@ -76,19 +76,19 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#name', () => {
+    describe('#name', function () {
 
-        it('should be an \'Untitled\' by default', () => {
+        it('should be an \'Untitled\' by default', function () {
             const node = new GraphNode();
             expect(node.name).to.equal('Untitled');
         });
 
-        it('can be set via the constructor', () => {
+        it('can be set via the constructor', function () {
             const node = new GraphNode('root');
             expect(node.name).to.equal('root');
         });
 
-        it('can be set to a new name', () => {
+        it('can be set to a new name', function () {
             const node = new GraphNode('node');
             node.name = 'root';
             expect(node.name).to.equal('root');
@@ -96,21 +96,21 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#path', () => {
+    describe('#path', function () {
 
-        it('returns empty string for root node', () => {
+        it('returns empty string for root node', function () {
             const root = new GraphNode('root');
             expect(root.path).to.equal('');
         });
 
-        it('returns path to child node', () => {
+        it('returns path to child node', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);
             expect(child.path).to.equal('child');
         });
 
-        it('returns path to grandchild node', () => {
+        it('returns path to grandchild node', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             const grandchild = new GraphNode('grandchild');
@@ -121,21 +121,21 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#root', () => {
+    describe('#root', function () {
 
-        it('returns itself for root node', () => {
+        it('returns itself for root node', function () {
             const root = new GraphNode('root');
             expect(root.root).to.equal(root);
         });
 
-        it('returns root node for child node', () => {
+        it('returns root node for child node', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);
             expect(child.root).to.equal(root);
         });
 
-        it('returns root node for grandchild node', () => {
+        it('returns root node for grandchild node', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             const grandchild = new GraphNode('grandchild');
@@ -146,9 +146,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#tags', () => {
+    describe('#tags', function () {
 
-        it('should be empty by default', () => {
+        it('should be empty by default', function () {
             const node = new GraphNode();
             expect(node.tags).to.be.an.instanceof(Tags);
             expect(node.tags.size).to.equal(0);
@@ -156,9 +156,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#constructor()', () => {
+    describe('#constructor()', function () {
 
-        it('supports zero arguments', () => {
+        it('supports zero arguments', function () {
             const node = new GraphNode();
             expect(node.children).to.be.an('array').with.lengthOf(0);
             expect(node.enabled).to.equal(false);
@@ -171,7 +171,7 @@ describe('GraphNode', () => {
             expect(node.up).to.be.an.instanceof(Vec3);
         });
 
-        it('supports one argument', () => {
+        it('supports one argument', function () {
             const node = new GraphNode('root');
             expect(node.children).to.be.an('array').with.lengthOf(0);
             expect(node.enabled).to.equal(false);
@@ -185,9 +185,9 @@ describe('GraphNode', () => {
         });
     });
 
-    describe('#addChild()', () => {
+    describe('#addChild()', function () {
 
-        it('adds a child node', () => {
+        it('adds a child node', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.addChild(child);
@@ -198,8 +198,8 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#clone', () => {
-        it('ensures that an instance of a subclass keeps its class prototype', () => {
+    describe('#clone', function () {
+        it('ensures that an instance of a subclass keeps its class prototype', function () {
             class UserGraphNode extends GraphNode {}
             const a = new UserGraphNode();
             const b = a.clone();
@@ -207,9 +207,9 @@ describe('GraphNode', () => {
         });
     });
 
-    describe('#find()', () => {
+    describe('#find()', function () {
 
-        it('finds a node by property', () => {
+        it('finds a node by property', function () {
             const root = new GraphNode();
             const child = new GraphNode('Child');
             root.addChild(child);
@@ -227,7 +227,7 @@ describe('GraphNode', () => {
             expect(res).to.be.an('array').with.lengthOf(0);
         });
 
-        it('finds a node by filter function', () => {
+        it('finds a node by filter function', function () {
             const root = new GraphNode();
             const child = new GraphNode('Child');
             root.addChild(child);
@@ -253,23 +253,23 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#findByName()', () => {
+    describe('#findByName()', function () {
 
-        it('finds root by name', () => {
+        it('finds root by name', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);
             expect(root.findByName('root')).to.equal(root);
         });
 
-        it('finds child by name', () => {
+        it('finds child by name', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);
             expect(root.findByName('child')).to.equal(child);
         });
 
-        it('returns null if no node is found', () => {
+        it('returns null if no node is found', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);
@@ -278,16 +278,16 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#findByPath()', () => {
+    describe('#findByPath()', function () {
 
-        it('finds a child by path', () => {
+        it('finds a child by path', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);
             expect(root.findByPath('child')).to.equal(child);
         });
 
-        it('finds a grandchild by path (string argument)', () => {
+        it('finds a grandchild by path (string argument)', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             const grandchild = new GraphNode('grandchild');
@@ -296,7 +296,7 @@ describe('GraphNode', () => {
             expect(root.findByPath('child/grandchild')).to.equal(grandchild);
         });
 
-        it('finds a grandchild by path (array argument)', () => {
+        it('finds a grandchild by path (array argument)', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             const grandchild = new GraphNode('grandchild');
@@ -305,7 +305,7 @@ describe('GraphNode', () => {
             expect(root.findByPath(['child', 'grandchild'])).to.equal(grandchild);
         });
 
-        it('returns null if no node is found', () => {
+        it('returns null if no node is found', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);
@@ -314,16 +314,16 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#findByTag()', () => {
+    describe('#findByTag()', function () {
 
-        it('does not search the root node', () => {
+        it('does not search the root node', function () {
             const root = new GraphNode('root');
             root.tags.add('tag');
             const result = root.findByTag('tag');
             expect(result).to.be.an('array').with.lengthOf(0);
         });
 
-        it('returns an array of nodes that have the query tag', () => {
+        it('returns an array of nodes that have the query tag', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);
@@ -333,7 +333,7 @@ describe('GraphNode', () => {
             expect(result[0]).to.equal(child);
         });
 
-        it('returns an array of nodes that have at least one of the query tags', () => {
+        it('returns an array of nodes that have at least one of the query tags', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             const grandchild = new GraphNode('grandchild');
@@ -347,7 +347,7 @@ describe('GraphNode', () => {
             expect(result[0]).to.equal(grandchild);
         });
 
-        it('returns an array of nodes that have all of the supplied tags', () => {
+        it('returns an array of nodes that have all of the supplied tags', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             const grandchild = new GraphNode('grandchild');
@@ -361,7 +361,7 @@ describe('GraphNode', () => {
             expect(result[0]).to.equal(grandchild);
         });
 
-        it('returns an empty array if the search fails', () => {
+        it('returns an empty array if the search fails', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);
@@ -371,9 +371,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#findOne()', () => {
+    describe('#findOne()', function () {
 
-        it('finds a node by property', () => {
+        it('finds a node by property', function () {
             const root = new GraphNode();
             const child = new GraphNode('Child');
             root.addChild(child);
@@ -389,7 +389,7 @@ describe('GraphNode', () => {
             expect(res).to.be.null;
         });
 
-        it('finds a node by filter function', () => {
+        it('finds a node by filter function', function () {
             const root = new GraphNode();
             const child = new GraphNode('Child');
             root.addChild(child);
@@ -413,9 +413,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#forEach()', () => {
+    describe('#forEach()', function () {
 
-        it('iterates over all nodes', () => {
+        it('iterates over all nodes', function () {
             const root = new GraphNode();
             const child1 = new GraphNode();
             const child2 = new GraphNode();
@@ -433,9 +433,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#getEulerAngles()', () => {
+    describe('#getEulerAngles()', function () {
 
-        it('returns the euler angles', () => {
+        it('returns the euler angles', function () {
             const node = new GraphNode();
             const angles = node.getEulerAngles();
             expect(angles).to.be.an.instanceof(Vec3);
@@ -446,9 +446,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#getLocalScale()', () => {
+    describe('#getLocalScale()', function () {
 
-        it('returns the default local scale of a node', () => {
+        it('returns the default local scale of a node', function () {
             const node = new GraphNode();
             const scale = node.getLocalScale();
             expect(scale).to.be.an.instanceof(Vec3);
@@ -457,7 +457,7 @@ describe('GraphNode', () => {
             expect(scale.z).to.equal(1);
         });
 
-        it('returns the local scale last set on a node', () => {
+        it('returns the local scale last set on a node', function () {
             const node = new GraphNode();
             node.setLocalScale(2, 3, 4);
             const scale = node.getLocalScale();
@@ -469,16 +469,16 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#getLocalTransform()', () => {
+    describe('#getLocalTransform()', function () {
 
-        it('returns an identity matrix for a newly created node', () => {
+        it('returns an identity matrix for a newly created node', function () {
             const node = new GraphNode();
             const transform = node.getLocalTransform();
             expect(transform).to.be.an.instanceof(Mat4);
             expect(transform.equals(Mat4.IDENTITY)).to.be.true;
         });
 
-        it('returns the local transform matrix of a transformed node', () => {
+        it('returns the local transform matrix of a transformed node', function () {
             const node = new GraphNode();
             node.setLocalPosition(1, 2, 3);
             node.setLocalScale(4, 5, 6);
@@ -489,16 +489,16 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#getWorldTransform()', () => {
+    describe('#getWorldTransform()', function () {
 
-        it('returns an identity matrix for a newly created node', () => {
+        it('returns an identity matrix for a newly created node', function () {
             const node = new GraphNode();
             const transform = node.getWorldTransform();
             expect(transform).to.be.an.instanceof(Mat4);
             expect(transform.equals(Mat4.IDENTITY)).to.be.true;
         });
 
-        it('returns the world transform matrix of a transformed node', () => {
+        it('returns the world transform matrix of a transformed node', function () {
             const node = new GraphNode();
             node.setLocalPosition(1, 2, 3);
             node.setLocalScale(4, 5, 6);
@@ -507,7 +507,7 @@ describe('GraphNode', () => {
             expect(transform.data).to.deep.equal(expected);
         });
 
-        it('returns the world transform matrix of a transformed child node', () => {
+        it('returns the world transform matrix of a transformed child node', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.addChild(child);
@@ -533,9 +533,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#insertChild()', () => {
+    describe('#insertChild()', function () {
 
-        it('inserts a single child node', () => {
+        it('inserts a single child node', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.insertChild(child, 0);
@@ -544,7 +544,7 @@ describe('GraphNode', () => {
             expect(child.parent).to.equal(root);
         });
 
-        it('inserts a child node at the beginning', () => {
+        it('inserts a child node at the beginning', function () {
             const root = new GraphNode();
             const child1 = new GraphNode();
             const child2 = new GraphNode();
@@ -557,7 +557,7 @@ describe('GraphNode', () => {
             expect(child2.parent).to.equal(root);
         });
 
-        it('inserts a child node at the end', () => {
+        it('inserts a child node at the end', function () {
             const root = new GraphNode();
             const child1 = new GraphNode();
             const child2 = new GraphNode();
@@ -572,16 +572,16 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#isAncestorOf()', () => {
+    describe('#isAncestorOf()', function () {
 
-        it('returns true if a parent node is an ancestor of a child node', () => {
+        it('returns true if a parent node is an ancestor of a child node', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.addChild(child);
             expect(root.isAncestorOf(child)).to.be.true;
         });
 
-        it('returns true if a grandparent node is an ancestor of a grandchild node', () => {
+        it('returns true if a grandparent node is an ancestor of a grandchild node', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             const grandchild = new GraphNode();
@@ -590,29 +590,29 @@ describe('GraphNode', () => {
             expect(root.isAncestorOf(grandchild)).to.be.true;
         });
 
-        it('returns false if a node is not an ancestor of another node', () => {
+        it('returns false if a node is not an ancestor of another node', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             expect(root.isAncestorOf(child)).to.be.false;
         });
 
-        it('asserts that nodes are not ancestors of themselves', () => {
+        it('asserts that nodes are not ancestors of themselves', function () {
             const node = new GraphNode();
             expect(node.isAncestorOf(node)).to.be.false;
         });
 
     });
 
-    describe('#isDescendantOf()', () => {
+    describe('#isDescendantOf()', function () {
 
-        it('returns true if a child node is a descendant of a parent node', () => {
+        it('returns true if a child node is a descendant of a parent node', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.addChild(child);
             expect(child.isDescendantOf(root)).to.be.true;
         });
 
-        it('returns true if a grandchild node is an descendant of a grandparent node', () => {
+        it('returns true if a grandchild node is an descendant of a grandparent node', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             const grandchild = new GraphNode();
@@ -621,22 +621,22 @@ describe('GraphNode', () => {
             expect(grandchild.isDescendantOf(root)).to.be.true;
         });
 
-        it('returns false if a node is not a descendant of another node', () => {
+        it('returns false if a node is not a descendant of another node', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             expect(child.isDescendantOf(root)).to.be.false;
         });
 
-        it('asserts that nodes are not descendants of themselves', () => {
+        it('asserts that nodes are not descendants of themselves', function () {
             const node = new GraphNode();
             expect(node.isDescendantOf(node)).to.be.false;
         });
 
     });
 
-    describe('#remove', () => {
+    describe('#remove', function () {
 
-        it('removes the node from its parent, unparenting it', () => {
+        it('removes the node from its parent, unparenting it', function () {
             const node = new GraphNode();
             const child = new GraphNode();
             node.addChild(child);
@@ -647,9 +647,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#removeChild()', () => {
+    describe('#removeChild()', function () {
 
-        it('removes a child node', () => {
+        it('removes a child node', function () {
             const node = new GraphNode();
             const child = new GraphNode();
             node.addChild(child);
@@ -660,9 +660,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#reparent()', () => {
+    describe('#reparent()', function () {
 
-        it('reparents a child node', () => {
+        it('reparents a child node', function () {
             const node = new GraphNode();
             const child = new GraphNode();
             node.addChild(child);
@@ -676,9 +676,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#rotate()', () => {
+    describe('#rotate()', function () {
 
-        it('leaves rotation unchanged for a zero rotation (number inputs)', () => {
+        it('leaves rotation unchanged for a zero rotation (number inputs)', function () {
             const node = new GraphNode();
             const anglesPre = node.getEulerAngles().clone();
             node.rotate(0, 0, 0);
@@ -686,7 +686,7 @@ describe('GraphNode', () => {
             expect(anglesPre.equals(anglesPost)).to.be.true;
         });
 
-        it('leaves rotation unchanged for a zero rotation (vector input)', () => {
+        it('leaves rotation unchanged for a zero rotation (vector input)', function () {
             const node = new GraphNode();
             const anglesPre = node.getEulerAngles().clone();
             node.rotate(Vec3.ZERO);
@@ -694,7 +694,7 @@ describe('GraphNode', () => {
             expect(anglesPre.equals(anglesPost)).to.be.true;
         });
 
-        it('accumulates rotations in a node', () => {
+        it('accumulates rotations in a node', function () {
             const node = new GraphNode();
             node.rotate(1, 0, 0);
             node.rotate(2, 0, 0);
@@ -706,7 +706,7 @@ describe('GraphNode', () => {
             expect(angles.z).to.be.closeTo(0, 0.00001);
         });
 
-        it('accumulates rotations in a hierarchy', () => {
+        it('accumulates rotations in a hierarchy', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.addChild(child);
@@ -727,9 +727,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#rotateLocal()', () => {
+    describe('#rotateLocal()', function () {
 
-        it('leaves rotation unchanged for a zero rotation (number inputs)', () => {
+        it('leaves rotation unchanged for a zero rotation (number inputs)', function () {
             const node = new GraphNode();
             const anglesPre = node.getEulerAngles().clone();
             node.rotateLocal(0, 0, 0);
@@ -737,7 +737,7 @@ describe('GraphNode', () => {
             expect(anglesPre.equals(anglesPost)).to.be.true;
         });
 
-        it('leaves rotation unchanged for a zero rotation (vector input)', () => {
+        it('leaves rotation unchanged for a zero rotation (vector input)', function () {
             const node = new GraphNode();
             const anglesPre = node.getEulerAngles().clone();
             node.rotateLocal(Vec3.ZERO);
@@ -745,7 +745,7 @@ describe('GraphNode', () => {
             expect(anglesPre.equals(anglesPost)).to.be.true;
         });
 
-        it('accumulates rotations in a node', () => {
+        it('accumulates rotations in a node', function () {
             const node = new GraphNode();
             node.rotateLocal(1, 0, 0);
             node.rotateLocal(2, 0, 0);
@@ -757,7 +757,7 @@ describe('GraphNode', () => {
             expect(angles.z).to.be.closeTo(0, 0.00001);
         });
 
-        it('accumulates rotations in a hierarchy', () => {
+        it('accumulates rotations in a hierarchy', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.addChild(child);
@@ -778,9 +778,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#translate()', () => {
+    describe('#translate()', function () {
 
-        it('translates hierarchical nodes with number arguments', () => {
+        it('translates hierarchical nodes with number arguments', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.addChild(child);
@@ -802,7 +802,7 @@ describe('GraphNode', () => {
             expect(pos.z).to.equal(9);
         });
 
-        it('translates hierarchical nodes with a vector argument', () => {
+        it('translates hierarchical nodes with a vector argument', function () {
             const root = new GraphNode();
             const child = new GraphNode();
             root.addChild(child);
@@ -826,9 +826,9 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#translateLocal()', () => {
+    describe('#translateLocal()', function () {
 
-        it('GraphNode: translateLocal in hierarchy', () => {
+        it('GraphNode: translateLocal in hierarchy', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);
@@ -851,8 +851,8 @@ describe('GraphNode', () => {
 
     });
 
-    describe('#setPositionAndRotation()', () => {
-        it('setPositionAndRotation is the same as setPosition and setRotation', () => {
+    describe('#setPositionAndRotation()', function () {
+        it('setPositionAndRotation is the same as setPosition and setRotation', function () {
             const root = new GraphNode('root');
             const child = new GraphNode('child');
             root.addChild(child);

--- a/test/scene/materials/shader-material.test.mjs
+++ b/test/scene/materials/shader-material.test.mjs
@@ -4,7 +4,7 @@ import { ShaderMaterial } from '../../../src/scene/materials/shader-material.js'
 
 import { expect } from 'chai';
 
-describe('Material', () => {
+describe('Material', function () {
 
     function checkDefaultMaterial(material) {
         expect(material).to.be.an.instanceof(ShaderMaterial);
@@ -26,18 +26,18 @@ describe('Material', () => {
         expect(material.stencilFront).to.not.exist;
     }
 
-    describe('#constructor()', () => {
+    describe('#constructor()', function () {
 
-        it('should create a new instance', () => {
+        it('should create a new instance', function () {
             const material = new ShaderMaterial();
             checkDefaultMaterial(material);
         });
 
     });
 
-    describe('#clone()', () => {
+    describe('#clone()', function () {
 
-        it('should clone a material', () => {
+        it('should clone a material', function () {
             const material = new ShaderMaterial();
             const clone = material.clone();
             checkDefaultMaterial(clone);
@@ -45,9 +45,9 @@ describe('Material', () => {
 
     });
 
-    describe('#copy()', () => {
+    describe('#copy()', function () {
 
-        it('should copy a material', () => {
+        it('should copy a material', function () {
             const src = new ShaderMaterial();
             const dst = new ShaderMaterial();
             dst.copy(src);

--- a/test/scene/materials/standard-material.test.mjs
+++ b/test/scene/materials/standard-material.test.mjs
@@ -6,7 +6,7 @@ import { Vec2 } from '../../../src/core/math/vec2.js';
 
 import { expect } from 'chai';
 
-describe('StandardMaterial', () => {
+describe('StandardMaterial', function () {
 
     function checkDefaultMaterial(material) {
         expect(material).to.be.an.instanceof(StandardMaterial);
@@ -282,18 +282,18 @@ describe('StandardMaterial', () => {
         expect(material.useSkybox).to.equal(true);
     }
 
-    describe('#constructor()', () => {
+    describe('#constructor()', function () {
 
-        it('should create a new instance', () => {
+        it('should create a new instance', function () {
             const material = new StandardMaterial();
             checkDefaultMaterial(material);
         });
 
     });
 
-    describe('#clone()', () => {
+    describe('#clone()', function () {
 
-        it('should clone a material', () => {
+        it('should clone a material', function () {
             const material = new StandardMaterial();
             const clone = material.clone();
             checkDefaultMaterial(clone);
@@ -301,9 +301,9 @@ describe('StandardMaterial', () => {
 
     });
 
-    describe('#copy()', () => {
+    describe('#copy()', function () {
 
-        it('should copy a material', () => {
+        it('should copy a material', function () {
             const src = new StandardMaterial();
             const dst = new StandardMaterial();
             dst.copy(src);


### PR DESCRIPTION
Recently, @kpal81xd [updated our ESLint config](https://github.com/playcanvas/engine/pull/6877) to enforce arrow functions. However, Mocha [advises against using arrow functions](https://mochajs.org/#arrow-functions). This PR restores them.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
