### PR TITLE
Use `@template` on `ObjectPool` for actual types

### DIFF
--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -1,6 +1,7 @@
 /**
  * A pool of reusable objects of the same type. Designed to promote reuse of objects to reduce
  * garbage collection.
+ *
  * @template {new (...args: any[]) => any} T
  */
 class ObjectPool {

--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -1,6 +1,7 @@
 /**
  * A pool of reusable objects of the same type. Designed to promote reuse of objects to reduce
  * garbage collection.
+ * @template {new (...args: any[]) => any} T
  */
 class ObjectPool {
     /**
@@ -14,7 +15,7 @@ class ObjectPool {
     /**
      * Array of object instances.
      *
-     * @type {object[]}
+     * @type {InstanceType<T>[]}
      * @private
      */
     _pool = [];
@@ -28,7 +29,7 @@ class ObjectPool {
     _count = 0;
 
     /**
-     * @param {new (...args: any[]) => any} constructorFunc - The constructor function for the
+     * @param {T} constructorFunc - The constructor function for the
      * objects in the pool.
      * @param {number} size - The initial number of object instances to allocate.
      */
@@ -54,7 +55,7 @@ class ObjectPool {
      * Returns an object instance from the pool. If no instances are available, the pool will be
      * doubled in size and a new instance will be returned.
      *
-     * @returns {object} An object instance from the pool.
+     * @returns {InstanceType<T>} An object instance from the pool.
      */
     allocate() {
         if (this._count >= this._pool.length) {


### PR DESCRIPTION
This allows e.g. `ObjectPool#allocate` to return real types for better IntelliSense.

Demonstration on this method:

```js
...
            this.contactResultPool = new ObjectPool(ContactResult, 1);
...
    _createContactResult(other, contacts) {
        const result = this.contactResultPool.allocate();
        result.other = other;
        result.contacts = contacts;
        return result;
    }
```

This method is now type aware as you can hover over e.g. `result.contacts`:

![image](https://github.com/user-attachments/assets/4022214d-4f93-4e1a-943a-460eda4cca8c)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
