### PR TITLE
Multisampled depth buffers can be shared between render targets on WebGPU

### DIFF
--- a/src/core/ref-counted-cache.js
+++ b/src/core/ref-counted-cache.js
@@ -1,5 +1,7 @@
 /**
- * Class implementing reference counting cache for objects.
+ * Class implementing reference counting cache for objects. The objects itself is used as the key.
+ * If you need a reference counted cache for objects accessed by a key, use
+ * {@link RefCountedKeyCache}.
  */
 class RefCountedCache {
     /**

--- a/src/core/ref-counted-key-cache.js
+++ b/src/core/ref-counted-key-cache.js
@@ -1,0 +1,99 @@
+import { Debug } from "./debug.js";
+import { RefCountedObject } from "./ref-counted-object.js";
+
+/**
+ * An entry in the RefCountedKeyCache cache, which wraps the object with a reference count.
+ */
+class Entry extends RefCountedObject {
+	object;
+
+    constructor(obj) {
+        super();
+        this.object = obj;
+        this.incRefCount();
+    }
+};
+
+/**
+ * Class implementing reference counting cache for objects accessed by a key. Reference counting is
+ * separate from the stored object.
+ */
+class RefCountedKeyCache {
+	
+	/**
+     * Map storing the cache. They key is a look up key for the object, the value is an instance
+     * of the Entry class, which wraps the object with a reference count.
+     *
+     * {@type <object, Entry>}
+     * @private
+     * */
+	cache = new Map();
+
+    /**
+     * Destroy all stored objects.
+     */
+    destroy() {
+        this.cache.forEach((entry) => {
+            entry.object?.destroy();
+        });
+        this.cache.clear();
+    }
+
+    /**
+     * Clear the cache, without destroying the objects.
+     */
+    clear() {
+        this.cache.clear();
+    }
+
+    /**
+     * Get the object from the cache with the given key, while incrementing the reference count. If
+     * the object is not in the cache, returns null.
+     * 
+     * @param {object} key - The key to look up the object.
+     * @returns {object} The object, or null if not found.
+     */
+	get(key) {
+        const entry = this.cache.get(key);
+        if (entry) {
+            entry.incRefCount();
+            return entry.object;
+        }
+        return null;
+    }
+
+    /**
+     * Put the object in the cache with the given key. The object cannot be in the cache already.
+     * This sets its reference count to 1.
+     *
+     * @param {object} key - The key to store the object under.
+     * @param {object} object - The object to store.
+     */
+    set(key, object) {
+        Debug.assert(!this.cache.has(key), `RefCountedKeyCache: Trying to put object with key that already exists in the cache`, { key, object });
+        this.cache.set(key, new Entry(object));
+    }
+
+    /**
+     * Remove the object reference from the cache with the given key. If the reference count reaches
+     * zero, the object is destroyed.
+     *
+     * @param {object} key - The key to remove the object under.
+     */
+	release(key) {
+        const entry = this.cache.get(key);
+        if (entry) {
+            entry.decRefCount();
+
+            // last reference removed, destroy the object
+            if (entry.refCount === 0) {
+                this.cache.delete(key); // remove the entry from the cache
+                entry.object?.destroy(); // destroy the object
+            }
+        } else {
+            Debug.warn(`RefCountedKeyCache: Trying to release object that is not in the cache`, { key });
+        }
+	}
+};
+
+export { RefCountedKeyCache };

--- a/src/core/ref-counted-key-cache.js
+++ b/src/core/ref-counted-key-cache.js
@@ -1,33 +1,32 @@
-import { Debug } from "./debug.js";
-import { RefCountedObject } from "./ref-counted-object.js";
+import { Debug } from './debug.js';
+import { RefCountedObject } from './ref-counted-object.js';
 
 /**
  * An entry in the RefCountedKeyCache cache, which wraps the object with a reference count.
  */
 class Entry extends RefCountedObject {
-	object;
+    object;
 
     constructor(obj) {
         super();
         this.object = obj;
         this.incRefCount();
     }
-};
+}
 
 /**
  * Class implementing reference counting cache for objects accessed by a key. Reference counting is
  * separate from the stored object.
  */
 class RefCountedKeyCache {
-	
-	/**
+    /**
      * Map storing the cache. They key is a look up key for the object, the value is an instance
      * of the Entry class, which wraps the object with a reference count.
      *
      * {@type <object, Entry>}
      * @private
-     * */
-	cache = new Map();
+     */
+    cache = new Map();
 
     /**
      * Destroy all stored objects.
@@ -49,11 +48,11 @@ class RefCountedKeyCache {
     /**
      * Get the object from the cache with the given key, while incrementing the reference count. If
      * the object is not in the cache, returns null.
-     * 
+     *
      * @param {object} key - The key to look up the object.
      * @returns {object} The object, or null if not found.
      */
-	get(key) {
+    get(key) {
         const entry = this.cache.get(key);
         if (entry) {
             entry.incRefCount();
@@ -70,7 +69,7 @@ class RefCountedKeyCache {
      * @param {object} object - The object to store.
      */
     set(key, object) {
-        Debug.assert(!this.cache.has(key), `RefCountedKeyCache: Trying to put object with key that already exists in the cache`, { key, object });
+        Debug.assert(!this.cache.has(key), 'RefCountedKeyCache: Trying to put object with key that already exists in the cache', { key, object });
         this.cache.set(key, new Entry(object));
     }
 
@@ -80,7 +79,7 @@ class RefCountedKeyCache {
      *
      * @param {object} key - The key to remove the object under.
      */
-	release(key) {
+    release(key) {
         const entry = this.cache.get(key);
         if (entry) {
             entry.decRefCount();
@@ -91,9 +90,9 @@ class RefCountedKeyCache {
                 entry.object?.destroy(); // destroy the object
             }
         } else {
-            Debug.warn(`RefCountedKeyCache: Trying to release object that is not in the cache`, { key });
+            Debug.warn('RefCountedKeyCache: Trying to release object that is not in the cache', { key });
         }
-	}
-};
+    }
+}
 
 export { RefCountedKeyCache };

--- a/src/extras/render-passes/render-pass-camera-frame.js
+++ b/src/extras/render-passes/render-pass-camera-frame.js
@@ -271,7 +271,7 @@ class RenderPassCameraFrame extends RenderPass {
             const { app, device, cameraComponent } = this;
             const { scene, renderer } = app;
 
-            this.prePass = new RenderPassPrepass(device, scene, renderer, cameraComponent, this.sceneDepth, this.sceneOptions);
+            this.prePass = new RenderPassPrepass(device, scene, renderer, cameraComponent, this.sceneDepth, this.sceneOptions, options.samples);
         }
     }
 

--- a/src/extras/render-passes/render-pass-prepass.js
+++ b/src/extras/render-passes/render-pass-prepass.js
@@ -40,11 +40,12 @@ class RenderPassPrepass extends RenderPass {
     /** @type {Texture} */
     velocityTexture;
 
-    constructor(device, scene, renderer, camera, depthBuffer, options) {
+    constructor(device, scene, renderer, camera, depthBuffer, options, samples) {
         super(device);
         this.scene = scene;
         this.renderer = renderer;
         this.camera = camera;
+        this.samples = samples;
 
         this.setupRenderTarget(depthBuffer, options);
     }
@@ -84,7 +85,8 @@ class RenderPassPrepass extends RenderPass {
         const renderTarget = new RenderTarget({
             name: 'PrepassRT',
             // colorBuffer: this.velocityTexture,
-            depthBuffer: depthBuffer
+            depthBuffer: depthBuffer,
+            samples: this.samples
         });
 
         this.init(renderTarget, options);

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -360,7 +360,7 @@ class RenderTarget {
         // TODO: consider adding support for MRT to this function.
 
         if (this._device && this._samples > 1) {
-            DebugGraphics.pushGpuMarker(this._device, `RESOLVE-RT:${this.name}`);
+            DebugGraphics.pushGpuMarker(this._device, `RESOLVE-RT:${this.name}:${color ? '[color]' : ''}:${depth ? '[depth]' : ''}`);
             this.impl.resolve(this._device, this, color, depth);
             DebugGraphics.popGpuMarker(this._device);
         }


### PR DESCRIPTION
In a case where a user provided depth buffer is used for render target used by the depth pre-pass as well as render target used by the main render pass, and those render targets are multi-sampled, those need to use the same buffer under the hood. Before, each render target would allocate it's own multi-sampled depth buffer, but that would cause the depth generated by the depth-pre-pass not being used in the main pass to accelerate it.

This PR adds sharing of those buffers across render targets. Initially WebGPU only, but will be added for WebGL in a separate PR.