### PR TITLE
fixed: incorrect texture being marked as srgb

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -2047,6 +2047,10 @@ const applySampler = (texture, gltfSampler) => {
 
 let gltfTextureUniqueId = 0;
 
+const getTextureSource = gltfTexture => gltfTexture.extensions?.KHR_texture_basisu?.source ??
+    gltfTexture.extensions?.EXT_texture_webp?.source ??
+    gltfTexture.source;
+
 // create gltf images. returns an array of promises that resolve to texture assets.
 const createImages = (gltf, bufferViews, urlBase, registry, options) => {
     if (!gltf.images || gltf.images.length === 0) {
@@ -2077,13 +2081,15 @@ const createImages = (gltf, bufferViews, urlBase, registry, options) => {
                 if (gltfMaterial.hasOwnProperty('pbrMetallicRoughness')) {
                     const pbrData = gltfMaterial.pbrMetallicRoughness;
                     if (pbrData.hasOwnProperty('baseColorTexture')) {
-                        set.add(pbrData.baseColorTexture.index);
+                        const gltfTexture = gltf.textures[pbrData.baseColorTexture.index];
+                        set.add(getTextureSource(gltfTexture));
                     }
                 }
 
                 // emissive
                 if (gltfMaterial.hasOwnProperty('emissiveTexture')) {
-                    set.add(gltfMaterial.emissiveTexture.index);
+                    const gltfTexture = gltf.textures[gltfMaterial.emissiveTexture.index];
+                    set.add(getTextureSource(gltfTexture));
                 }
             });
         }
@@ -2224,9 +2230,7 @@ const createTextures = (gltf, images, options) => {
         promise = promise.then((gltfImageIndex) => {
             // resolve image index
             gltfImageIndex = gltfImageIndex ??
-                             gltfTexture?.extensions?.KHR_texture_basisu?.source ??
-                             gltfTexture?.extensions?.EXT_texture_webp?.source ??
-                             gltfTexture.source;
+                getTextureSource(gltfTexture);
 
             const cloneAsset = seenImages.has(gltfImageIndex);
             seenImages.add(gltfImageIndex);


### PR DESCRIPTION
Fixes #6937

Ensures that getGammaTextures sets the correct image index

![image](https://github.com/user-attachments/assets/7cdaaa46-01d7-433e-a59c-7ead32f9cc43)


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
