### PR TITLE
Add `Vec2.HALF`, `Vec3.HALF` and `Vec4.HALF`

### DIFF
--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -676,6 +676,14 @@ class Vec2 {
     static ZERO = Object.freeze(new Vec2(0, 0));
 
     /**
+     * A constant vector set to [0.5, 0.5].
+     *
+     * @type {Vec2}
+     * @readonly
+     */
+    static HALF = Object.freeze(new Vec2(0.5, 0.5));
+
+    /**
      * A constant vector set to [1, 1].
      *
      * @type {Vec2}

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -681,6 +681,14 @@ class Vec3 {
     static ZERO = Object.freeze(new Vec3(0, 0, 0));
 
     /**
+     * A constant vector set to [0.5, 0.5, 0.5].
+     *
+     * @type {Vec3}
+     * @readonly
+     */
+    static HALF = Object.freeze(new Vec3(0.5, 0.5, 0.5));
+
+    /**
      * A constant vector set to [1, 1, 1].
      *
      * @type {Vec3}

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -644,6 +644,14 @@ class Vec4 {
     static ZERO = Object.freeze(new Vec4(0, 0, 0, 0));
 
     /**
+     * A constant vector set to [0.5, 0.5, 0.5, 0.5].
+     *
+     * @type {Vec4}
+     * @readonly
+     */
+    static HALF = Object.freeze(new Vec4(0.5, 0.5, 0.5, 0.5));
+
+    /**
      * A constant vector set to [1, 1, 1, 1].
      *
      * @type {Vec4}


### PR DESCRIPTION
Fixes #6936 

Since we don't order those static properties alphabetically, I sorted them semantically like: `ZERO`, `HALF`, `ONE`

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
