### PR TITLE
RenderPass based SSAO works with multisampling

### DIFF
--- a/src/extras/render-passes/render-pass-camera-frame.js
+++ b/src/extras/render-passes/render-pass-camera-frame.js
@@ -271,7 +271,10 @@ class RenderPassCameraFrame extends RenderPass {
             const { app, device, cameraComponent } = this;
             const { scene, renderer } = app;
 
-            this.prePass = new RenderPassPrepass(device, scene, renderer, cameraComponent, this.sceneDepth, this.sceneOptions, options.samples);
+            // ssao needs resolved depth
+            const resolveDepth = this.options.ssaoType !== SSAOTYPE_NONE;
+
+            this.prePass = new RenderPassPrepass(device, scene, renderer, cameraComponent, this.sceneDepth, resolveDepth, this.sceneOptions, options.samples);
         }
     }
 

--- a/src/extras/render-passes/render-pass-prepass.js
+++ b/src/extras/render-passes/render-pass-prepass.js
@@ -40,14 +40,14 @@ class RenderPassPrepass extends RenderPass {
     /** @type {Texture} */
     velocityTexture;
 
-    constructor(device, scene, renderer, camera, depthBuffer, options, samples) {
+    constructor(device, scene, renderer, camera, depthBuffer, resolveDepth, options, samples) {
         super(device);
         this.scene = scene;
         this.renderer = renderer;
         this.camera = camera;
         this.samples = samples;
 
-        this.setupRenderTarget(depthBuffer, options);
+        this.setupRenderTarget(depthBuffer, resolveDepth, options);
     }
 
     destroy() {
@@ -64,7 +64,7 @@ class RenderPassPrepass extends RenderPass {
         this.viewBindGroups.length = 0;
     }
 
-    setupRenderTarget(depthBuffer, options) {
+    setupRenderTarget(depthBuffer, resolveDepth, options) {
 
         const { device } = this;
 
@@ -91,6 +91,10 @@ class RenderPassPrepass extends RenderPass {
 
         this.init(renderTarget, options);
         this.depthStencilOps.storeDepth = true;
+
+        if (resolveDepth) {
+            this.depthStencilOps.resolveDepth = true;
+        }
     }
 
     after() {

--- a/src/extras/render-passes/render-pass-ssao.js
+++ b/src/extras/render-passes/render-pass-ssao.js
@@ -1,3 +1,4 @@
+import { Color } from '../../core/math/color.js';
 import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_R8 } from '../../platform/graphics/constants.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { Texture } from '../../platform/graphics/texture.js';
@@ -259,6 +260,10 @@ class RenderPassSsao extends RenderPassShaderQuad {
             resizeSource: this.sourceTexture
         });
 
+        // clear the color to avoid load op
+        const clearColor = new Color(0, 0, 0, 0);
+        this.setClearColor(clearColor);
+
         // optional blur passes
         if (blurEnabled) {
 
@@ -268,11 +273,13 @@ class RenderPassSsao extends RenderPassShaderQuad {
             blurPassHorizontal.init(blurRT, {
                 resizeSource: rt.colorBuffer
             });
+            blurPassHorizontal.setClearColor(clearColor);
 
             const blurPassVertical = new RenderPassDepthAwareBlur(device, blurRT.colorBuffer, false);
             blurPassVertical.init(rt, {
                 resizeSource: rt.colorBuffer
             });
+            blurPassVertical.setClearColor(clearColor);
 
             this.afterPasses.push(blurPassHorizontal);
             this.afterPasses.push(blurPassVertical);

--- a/src/platform/graphics/multi-sampled-texture-cache.js
+++ b/src/platform/graphics/multi-sampled-texture-cache.js
@@ -4,7 +4,7 @@ import { DeviceCache } from './device-cache.js';
 /**
  * Reference counted cache storing multi-sampled versions of depth buffers, which are reference
  * counted and shared between render targets using the same user-specified depth-buffer. This is
- * needed for in cases where the user provided depth buffer is used for depth-pre-pass and then
+ * needed for the cases where the user provided depth buffer is used for depth-pre-pass and then
  * the main render pass - those need to share the same multi-sampled depth buffer.
  */
 class MultisampledTextureCache extends RefCountedKeyCache {

--- a/src/platform/graphics/multi-sampled-texture-cache.js
+++ b/src/platform/graphics/multi-sampled-texture-cache.js
@@ -1,0 +1,25 @@
+import { RefCountedKeyCache } from "../../core/ref-counted-key-cache.js";
+import { DeviceCache } from "./device-cache.js";
+
+/**
+ * Reference counted cache storing multi-sampled versions of depth buffers, which are reference
+ * counted and shared between render targets using the same user-specified depth-buffer. This is
+ * needed for in cases where the user provided depth buffer is used for depth-pre-pass and then
+ * the main render pass - those need to share the same multi-sampled depth buffer.
+ */
+class MultisampledTextureCache extends RefCountedKeyCache {
+    loseContext(device) {
+        this.clear(); // just clear the cache when the context is lost
+    }
+}
+
+// a device cache storing per device instance of MultisampledTextureCache
+const multisampledTextureCache = new DeviceCache();
+
+const getMultisampledTextureCache = (device) => {
+    return multisampledTextureCache.get(device, () => {
+        return new MultisampledTextureCache();
+    });
+};
+
+export { getMultisampledTextureCache };

--- a/src/platform/graphics/multi-sampled-texture-cache.js
+++ b/src/platform/graphics/multi-sampled-texture-cache.js
@@ -1,5 +1,5 @@
-import { RefCountedKeyCache } from "../../core/ref-counted-key-cache.js";
-import { DeviceCache } from "./device-cache.js";
+import { RefCountedKeyCache } from '../../core/ref-counted-key-cache.js';
+import { DeviceCache } from './device-cache.js';
 
 /**
  * Reference counted cache storing multi-sampled versions of depth buffers, which are reference

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -85,6 +85,13 @@ class DepthStencilAttachmentOps {
     storeDepth = false;
 
     /**
+     * True if the depth attachment needs to be resolved.
+     *
+     * @type {boolean}
+     */
+    resolveDepth = false;
+
+    /**
      * True if the stencil attachment needs to be stored after the render pass. False
      * if it can be discarded.
      *
@@ -458,7 +465,8 @@ class RenderPass {
                 if (hasDepth) {
                     Debug.trace(TRACEID_RENDER_PASS_DETAIL, '    depthOps: ' +
                                 `${this.depthStencilOps.clearDepth ? 'clear' : 'load'}->` +
-                                `${this.depthStencilOps.storeDepth ? 'store' : 'discard'}`);
+                                `${this.depthStencilOps.storeDepth ? 'store' : 'discard'}` +
+                                `${this.depthStencilOps.resolveDepth ? ' resolve' : ''}`);
                 }
 
                 if (hasStencil) {

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1258,6 +1258,13 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 }
             }
 
+            // resolve depth/stencil buffer
+            if (target.depthBuffer && renderPass.depthStencilOps.resolveDepth) {
+                if (renderPass.samples > 1 && target.autoResolve) {
+                    target.resolve(false, true);
+                }
+            }
+
             // generate mipmaps
             for (let i = 0; i < colorBufferCount; i++) {
                 const colorOps = renderPass.colorArrayOps[i];

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -124,8 +124,9 @@ class WebglRenderTarget {
             this._glMsaaDepthBuffer = null;
 
             // release reference to the texture, as its ref-counted
-            if (this.msaaDepthBufferKey)
+            if (this.msaaDepthBufferKey) {
                 getMultisampledTextureCache(device).release(this.msaaDepthBufferKey);
+            }
         }
 
         this.suppliedColorFramebuffer = undefined;
@@ -292,7 +293,7 @@ class WebglRenderTarget {
                     gl.renderbufferStorageMultisample(gl.RENDERBUFFER, target._samples, internalFormat, target.width, target.height);
 
                     // add 'destroy' method to the renderbuffer, allowing it to be destroyed by the cache
-                    this._glMsaaDepthBuffer.destroy = function() {
+                    this._glMsaaDepthBuffer.destroy = function () {
                         gl.deleteRenderbuffer(this);
                     };
 

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -286,9 +286,6 @@ class WebglRenderTarget {
                     if (depthBuffer) {
                         getMultisampledTextureCache(device).set(key, this._glMsaaDepthBuffer);
                     }
-                } else {
-
-                    this._glMsaaDepthBuffer = this._glMsaaDepthBuffer;
                 }
 
                 // add the depth buffer to the FBO

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -96,13 +96,8 @@ class DepthAttachment {
 
             this.multisampledDepthBuffer = null;
 
-            // cache its stored in
-            const msTextures = multisampledTextureCache.get(device, () => {
-                return null;
-            });
-
             // release reference to the texture, as its ref-counted
-            msTextures.release(this.multisampledDepthBufferKey);
+            getMultisampledTextureCache(device).release(this.multisampledDepthBufferKey);
         }
     }
 }

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -1,7 +1,6 @@
 import { Debug, DebugHelper } from '../../../core/debug.js';
-import { RefCountedKeyCache } from '../../../core/ref-counted-key-cache.js';
 import { StringIds } from '../../../core/string-ids.js';
-import { DeviceCache } from '../device-cache.js';
+import { getMultisampledTextureCache } from '../multi-sampled-texture-cache.js';
 import { WebgpuDebug } from './webgpu-debug.js';
 
 /**
@@ -11,21 +10,6 @@ import { WebgpuDebug } from './webgpu-debug.js';
  */
 
 const stringIds = new StringIds();
-
-/**
- * Reference counted cache storing multi-sampled versions of depth buffers, which are reference
- * counted and shared between render targets using the same user-specified depth-buffer. This is
- * needed for in cases where the user provided depth buffer is used for depth-pre-pass and then
- * the main render pass - those need to share the same multi-sampled depth buffer.
- */
-class MultisampledTextureCache extends RefCountedKeyCache {
-    loseContext(device) {
-        this.clear(); // just clear the cache when the context is lost
-    }
-}
-
-// a device cache storing per device instance of MultisampledTextureCache
-const _multisampledTextureCache = new DeviceCache();
 
 /**
  * Private class storing info about color buffer.
@@ -113,7 +97,7 @@ class DepthAttachment {
             this.multisampledDepthBuffer = null;
 
             // cache its stored in
-            const msTextures = _multisampledTextureCache.get(device, () => {
+            const msTextures = multisampledTextureCache.get(device, () => {
                 return null;
             });
 
@@ -354,12 +338,8 @@ class WebgpuRenderTarget {
                     // key for matching multi-sampled depth buffer
                     const key = `${depthBuffer.id}:${width}:${height}:${samples}:${depthBuffer.impl.format}`;
 
-                    // cache for the device
-                    const msTextures = _multisampledTextureCache.get(device, () => {
-                        return new MultisampledTextureCache();
-                    });
-
                     // check if we have already allocated a multi-sampled depth buffer for the depth buffer
+                    const msTextures = getMultisampledTextureCache(device);
                     let msDepthTexture = msTextures.get(key); // this incRefs it if found
                     if (!msDepthTexture) {
 


### PR DESCRIPTION
When render pass based ssao is enabled, and the samples > 1:
- share multisampled depth buffer with main scene, similar to how it was done on WebGPU in https://github.com/playcanvas/engine/pull/6932
- when prepass rendering is done, resolve the depth buffer, as that resolved depth is used by SSAO

Other changes
- skip few load ops on render targets and do clear when we don't need original data
- extracted multisampled texture cache to a separate module, as that is shared between webgl and webgpu