### PR TITLE
Gsplat shader optimisations

### DIFF
--- a/src/scene/gsplat/gsplat-compressed-material.js
+++ b/src/scene/gsplat/gsplat-compressed-material.js
@@ -296,7 +296,7 @@ const splatMainVS = /* glsl */ `
             return;
         }
 
-        // read chunk data
+        // read chunk data and packed data
         readData();
 
         // get center

--- a/src/scene/gsplat/gsplat-compressed-material.js
+++ b/src/scene/gsplat/gsplat-compressed-material.js
@@ -25,9 +25,6 @@ const splatCoreVS = /* glsl */ `
     attribute vec3 vertex_position;
     attribute uint vertex_id_attrib;
 
-    varying vec2 texCoord;
-    varying vec4 color;
-
     #ifndef DITHER_NONE
         varying float id;
     #endif
@@ -205,8 +202,8 @@ const splatCoreVS = /* glsl */ `
 `;
 
 const splatCoreFS = /* glsl */ `
-    varying vec2 texCoord;
-    varying vec4 color;
+    varying mediump vec2 texCoord;
+    varying mediump vec4 color;
 
     #ifndef DITHER_NONE
         varying float id;
@@ -217,12 +214,12 @@ const splatCoreFS = /* glsl */ `
     #endif
 
     vec4 evalSplat() {
-        float A = dot(texCoord, texCoord);
+        mediump float A = dot(texCoord, texCoord);
         if (A > 1.0) {
             discard;
         }
 
-        float B = exp(-A * 4.0) * color.a;
+        mediump float B = exp(-A * 4.0) * color.a;
         if (B < 1.0 / 255.0) {
             discard;
         }
@@ -283,7 +280,10 @@ class GSplatCompressedShaderGenerator {
 const gsplatCompressed = new GSplatCompressedShaderGenerator();
 
 const splatMainVS = /* glsl */ `
-    vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
+    varying mediump vec2 texCoord;
+    varying mediump vec4 color;
+
+    mediump vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
 
     void main(void)
     {

--- a/src/scene/gsplat/gsplat-compressed-material.js
+++ b/src/scene/gsplat/gsplat-compressed-material.js
@@ -75,13 +75,10 @@ const splatCoreVS = /* glsl */ `
     }
 
     // read chunk and packed data from textures
-    void readChunkData() {
+    void readData() {
         chunkDataA = texelFetch(chunkTexture, chunkUV, 0);
         chunkDataB = texelFetch(chunkTexture, ivec2(chunkUV.x + 1, chunkUV.y), 0);
         chunkDataC = texelFetch(chunkTexture, ivec2(chunkUV.x + 2, chunkUV.y), 0);
-    }
-
-    void readPackedData() {
         packedData = texelFetch(packedTexture, packedUV, 0);
     }
 
@@ -152,26 +149,32 @@ const splatCoreVS = /* glsl */ `
     }
 
     // Given a rotation matrix and scale vector, compute 3d covariance A and B
-    void calcCov3d(mat3 rot, vec3 scale, out vec3 covA, out vec3 covB) {
+    void getCovariance(out vec3 covA, out vec3 covB) {
+        mat3 rot = quatToMat3(getRotation());
+        vec3 scale = getScale();
+
         // M = S * R
         mat3 M = transpose(mat3(
             scale.x * rot[0],
             scale.y * rot[1],
             scale.z * rot[2]
         ));
+
         covA = vec3(dot(M[0], M[0]), dot(M[0], M[1]), dot(M[0], M[2]));
         covB = vec3(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
     }
 
     // given the splat center (view space) and covariance A and B vectors, calculate
     // the v1 and v2 vectors for this view.
-    vec4 calcV1V2(vec3 centerView, vec3 covA, vec3 covB, mat3 W, float focal) {
+    vec4 calcV1V2(vec3 centerView, vec3 covA, vec3 covB, mat3 W) {
 
         mat3 Vrk = mat3(
             covA.x, covA.y, covA.z, 
             covA.y, covB.x, covB.y,
             covA.z, covB.y, covB.z
         );
+
+        float focal = viewport.x * matrix_projection[0][0];
 
         float J1 = focal / centerView.z;
         vec2 J2 = -J1 / centerView.z * centerView.xy;
@@ -294,17 +297,14 @@ const splatMainVS = /* glsl */ `
         }
 
         // read chunk data
-        readChunkData();
+        readData();
 
-        // read packed data
-        readPackedData();
+        // get center
+        vec3 center = getCenter();
 
-        mat4 modelView = matrix_view * matrix_model;
-
-        // transform center to camera space
-        vec4 splat_cam = modelView * vec4(getCenter(), 1.0);
-
-        // transform center to clip space
+        // handle transforms
+        mat4 model_view = matrix_view * matrix_model;
+        vec4 splat_cam = model_view * vec4(center, 1.0);
         vec4 splat_proj = matrix_projection * splat_cam;
 
         // cull behind camera
@@ -313,11 +313,11 @@ const splatMainVS = /* glsl */ `
             return;
         }
 
-        // calculate the 3d covariance vectors from rotation and scale
+        // get covariance
         vec3 covA, covB;
-        calcCov3d(quatToMat3(getRotation()), getScale(), covA, covB);
+        getCovariance(covA, covB);
 
-        vec4 v1v2 = calcV1V2(splat_cam.xyz, covA, covB, transpose(mat3(modelView)), viewport.x * matrix_projection[0][0]);
+        vec4 v1v2 = calcV1V2(splat_cam.xyz, covA, covB, transpose(mat3(model_view)));
 
         // get color
         color = getColor();

--- a/src/scene/gsplat/gsplat-material.js
+++ b/src/scene/gsplat/gsplat-material.js
@@ -8,9 +8,10 @@ import { gsplat } from './shader-generator-gsplat.js';
 const splatMainVS = /* glsl */ `
     uniform sampler2D splatColor;
 
-    varying vec4 color;
+    varying mediump vec2 texCoord;
+    varying mediump vec4 color;
 
-    vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
+    mediump vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
 
     void main(void)
     {
@@ -51,7 +52,7 @@ const splatMainVS = /* glsl */ `
         float scale = min(1.0, sqrt(-log(1.0 / 255.0 / color.a)) / 2.0);
 
         v1v2 *= scale;
-    
+
         // early out tiny splats
         if (dot(v1v2.xy, v1v2.xy) < 4.0 && dot(v1v2.zw, v1v2.zw) < 4.0) {
             gl_Position = discardVec;

--- a/src/scene/gsplat/gsplat-material.js
+++ b/src/scene/gsplat/gsplat-material.js
@@ -19,16 +19,22 @@ const splatMainVS = `
         // read data
         readData();
 
+        color = getColor();
+
+        // size the quad based on alpha
+        // float scale = 1.0;
+        // float scale = min(1.0, sqrt(-log(1.0 / 255.0 / color.a)) / 2.0);
+        float scale = sqrt(1.0 - pow(1.0 / 255.0 / color.a, 1.0 / 3.6));
+
         vec4 pos;
-        if (!evalSplat(pos)) {
+        if (!evalSplat(pos, scale)) {
             gl_Position = discardVec;
             return;
         }
 
         gl_Position = pos;
 
-        texCoord = vertex_position.xy;
-        color = getColor();
+        texCoord = vertex_position.xy * scale / 2.0;
 
         #ifndef DITHER_NONE
             id = float(splatId);

--- a/src/scene/gsplat/gsplat-material.js
+++ b/src/scene/gsplat/gsplat-material.js
@@ -21,16 +21,12 @@ const splatMainVS = /* glsl */ `
             return;
         }
 
-        // read center
-        vec3 center;
-        readCenter(center);
+        // get center
+        vec3 center = getCenter();
 
-        mat4 modelView = matrix_view * matrix_model;
-
-        // transform center to camera space
-        vec4 splat_cam = modelView * vec4(center, 1.0);
-
-        // transform center to clip space
+        // handle transforms
+        mat4 model_view = matrix_view * matrix_model;
+        vec4 splat_cam = model_view * vec4(center, 1.0);
         vec4 splat_proj = matrix_projection * splat_cam;
 
         // cull behind camera
@@ -39,13 +35,13 @@ const splatMainVS = /* glsl */ `
             return;
         }
 
-        // read covariance
+        // get covariance
         vec3 covA, covB;
-        readCovariance(covA, covB);
+        getCovariance(covA, covB);
 
-        vec4 v1v2 = calcV1V2(splat_cam.xyz, covA, covB, transpose(mat3(modelView)));
+        vec4 v1v2 = calcV1V2(splat_cam.xyz, covA, covB, transpose(mat3(model_view)));
 
-        // read color
+        // get color
         color = texelFetch(splatColor, splatUV, 0);
 
         // calculate scale based on alpha

--- a/src/scene/gsplat/gsplat-material.js
+++ b/src/scene/gsplat/gsplat-material.js
@@ -8,7 +8,7 @@ import { gsplat } from './shader-generator-gsplat.js';
 const splatMainVS = /* glsl */ `
     uniform sampler2D splatColor;
 
-    varying mediump vec4 color;
+    varying vec4 color;
 
     vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
 

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -74,7 +74,7 @@ const splatCoreVS = /* glsl */ `
     }
 
     // calculate 2d covariance vectors
-    void calcV1V2(in vec3 splat_cam, in vec3 covA, in vec3 covB, out vec2 v1, out vec2 v2) {
+    vec4 calcV1V2(in vec3 splat_cam, in vec3 covA, in vec3 covB, mat3 W) {
         mat3 Vrk = mat3(
             covA.x, covA.y, covA.z, 
             covA.y, covB.x, covB.y,
@@ -91,8 +91,6 @@ const splatCoreVS = /* glsl */ `
             0., 0., 0.
         );
 
-        mat3 W = transpose(mat3(matrix_view) * mat3(matrix_model));
-
         mat3 T = W * J;
         mat3 cov = transpose(T) * Vrk * T;
 
@@ -106,8 +104,10 @@ const splatCoreVS = /* glsl */ `
         float lambda2 = max(mid - radius, 0.1);
         vec2 diagonalVector = normalize(vec2(offDiagonal, lambda1 - diagonal1));
 
-        v1 = min(sqrt(2.0 * lambda1), 1024.0) * diagonalVector;
-        v2 = min(sqrt(2.0 * lambda2), 1024.0) * vec2(diagonalVector.y, -diagonalVector.x);
+        vec2 v1 = min(sqrt(2.0 * lambda1), 1024.0) * diagonalVector;
+        vec2 v2 = min(sqrt(2.0 * lambda2), 1024.0) * vec2(diagonalVector.y, -diagonalVector.x);
+
+        return vec4(v1, v2);
     }
 `;
 

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -15,9 +15,8 @@ const splatCoreVS = /* glsl */ `
     uniform vec4 tex_params;            // num splats, texture width
 
     uniform highp usampler2D splatOrder;
-    uniform highp sampler2D transformA;
+    uniform highp usampler2D transformA;
     uniform highp sampler2D transformB;
-    uniform highp sampler2D transformC;
 
     attribute vec3 vertex_position;
     attribute uint vertex_id_attrib;
@@ -59,19 +58,19 @@ const splatCoreVS = /* glsl */ `
         return true;
     }
 
-    vec4 tA;
+    uvec4 tA;
 
     void readCenter(out vec3 center) {
         tA = texelFetch(transformA, splatUV, 0);
-        center = tA.xyz;
+        center = uintBitsToFloat(tA.xyz);
     }
 
     void readCovariance(out vec3 covA, out vec3 covB) {
         vec4 tB = texelFetch(transformB, splatUV, 0);
-        float tC = texelFetch(transformC, splatUV, 0).x;
+        vec2 tC = unpackHalf2x16(tA.w);
 
         covA = tB.xyz;
-        covB = vec3(tA.w, tB.w, tC);
+        covB = vec3(tC.x, tC.y, tB.w);
     }
 
     // calculate 2d covariance vectors

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -19,10 +19,10 @@ const splatCoreVS = /* glsl */ `
     uniform highp sampler2D transformB;
     uniform highp sampler2D transformC;
 
-    attribute mediump vec3 vertex_position;
+    attribute vec3 vertex_position;
     attribute uint vertex_id_attrib;
 
-    varying mediump vec2 texCoord;
+    varying vec2 texCoord;
 
     #ifndef DITHER_NONE
         varying float id;
@@ -113,8 +113,8 @@ const splatCoreVS = /* glsl */ `
 `;
 
 const splatCoreFS = /* glsl */ `
-    varying mediump vec2 texCoord;
-    varying mediump vec4 color;
+    varying vec2 texCoord;
+    varying vec4 color;
 
     #ifndef DITHER_NONE
         varying float id;

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -21,8 +21,6 @@ const splatCoreVS = /* glsl */ `
     attribute vec3 vertex_position;
     attribute uint vertex_id_attrib;
 
-    varying vec2 texCoord;
-
     #ifndef DITHER_NONE
         varying float id;
     #endif
@@ -112,8 +110,8 @@ const splatCoreVS = /* glsl */ `
 `;
 
 const splatCoreFS = /* glsl */ `
-    varying vec2 texCoord;
-    varying vec4 color;
+    varying mediump vec2 texCoord;
+    varying mediump vec4 color;
 
     #ifndef DITHER_NONE
         varying float id;
@@ -124,12 +122,12 @@ const splatCoreFS = /* glsl */ `
     #endif
 
     vec4 evalSplat() {
-        float A = dot(texCoord, texCoord);
+        mediump float A = dot(texCoord, texCoord);
         if (A > 1.0) {
             discard;
         }
 
-        float B = exp(-A * 4.0) * color.a;
+        mediump float B = exp(-A * 4.0) * color.a;
         if (B < 1.0 / 255.0) {
             discard;
         }

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -58,12 +58,12 @@ const splatCoreVS = /* glsl */ `
 
     uvec4 tA;
 
-    void readCenter(out vec3 center) {
+    vec3 getCenter() {
         tA = texelFetch(transformA, splatUV, 0);
-        center = uintBitsToFloat(tA.xyz);
+        return uintBitsToFloat(tA.xyz);
     }
 
-    void readCovariance(out vec3 covA, out vec3 covB) {
+    void getCovariance(out vec3 covA, out vec3 covB) {
         vec4 tB = texelFetch(transformB, splatUV, 0);
         vec2 tC = unpackHalf2x16(tA.w);
 


### PR DESCRIPTION
This PR:
* implements a small gpu data layout improvement for uncompressed splats
* scale splat quads at runtime to exclude completely semitransparent parts
* speculatively add `mediump` precision qualifier which should help on android devices (more work to do here)
* update compressed and uncompressed shaders to be have roughly the same structure