### PR TITLE
Gsplat followup orientation and shader update

### DIFF
--- a/src/framework/parsers/gsplat-resource.js
+++ b/src/framework/parsers/gsplat-resource.js
@@ -66,6 +66,12 @@ class GSplatResource {
             instance: splatInstance
         });
 
+        // the ply scene data no longer gets automatically rotated on load, so do
+        // it here instead.
+        if (!this.splatData.isCompressed) {
+            entity.setLocalEulerAngles(0, 0, 180);
+        }
+
         // set custom aabb
         component.customAabb = splatInstance.splat.aabb.clone();
 

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -340,7 +340,7 @@ const readFloatPly = async (streamBuf, elements, littleEndian) => {
         streamBuf.head += toRead * inputSize;
     }
 
-    return new GSplatData(elements); 
+    return new GSplatData(elements);
 };
 
 const readGeneralPly = async (streamBuf, elements, littleEndian) => {
@@ -390,7 +390,7 @@ const readGeneralPly = async (streamBuf, elements, littleEndian) => {
 
     // console.log(elements);
 
-    return new GSplatData(elements);    
+    return new GSplatData(elements);
 };
 
 /**
@@ -490,24 +490,26 @@ const readPly = async (reader, propertyFilter = null) => {
     // load compressed PLY with fast path
     if (isCompressedPly(elements)) {
         return await readCompressedPly(streamBuf, elements, format === 'binary_little_endian');
-    } else {
-        // allocate element storage
-        elements.forEach((e) => {
-            e.properties.forEach((p) => {
-                const storageType = dataTypeMap.get(p.type);
-                if (storageType) {
-                    const storage = (!propertyFilter || propertyFilter(p.name)) ? new storageType(e.count) : null;
-                    p.storage = storage;
-                }
-            });
-        });
-
-        if (isFloatPly(elements)) {
-            return await readFloatPly(streamBuf, elements, format === 'binary_little_endian');
-        } else {
-            return await readGeneralPly(streamBuf, elements, format === 'binary_little_endian');
-        }
     }
+
+    // allocate element storage
+    elements.forEach((e) => {
+        e.properties.forEach((p) => {
+            const storageType = dataTypeMap.get(p.type);
+            if (storageType) {
+                const storage = (!propertyFilter || propertyFilter(p.name)) ? new storageType(e.count) : null;
+                p.storage = storage;
+            }
+        });
+    });
+
+    // load float32 PLY with fast path
+    if (isFloatPly(elements)) {
+        return await readFloatPly(streamBuf, elements, format === 'binary_little_endian');
+    }
+
+    // fallback, general case
+    return await readGeneralPly(streamBuf, elements, format === 'binary_little_endian');
 };
 
 // by default load everything

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -35,10 +35,10 @@ class SplatCompressedIterator {
             const m = Math.sqrt(1.0 - (a * a + b * b + c * c));
 
             switch (value >>> 30) {
-                case 0: result.set(m, a, b, c); break;
-                case 1: result.set(a, m, b, c); break;
-                case 2: result.set(a, b, m, c); break;
-                case 3: result.set(a, b, c, m); break;
+                case 0: result.set(a, b, c, m); break;
+                case 1: result.set(m, b, c, a); break;
+                case 2: result.set(b, m, c, a); break;
+                case 3: result.set(b, c, m, a); break;
             }
         };
 
@@ -222,17 +222,25 @@ class GSplatCompressedData {
 
         const iter = this.createIter(p, r, s, c);
 
+        // the compressed data is stored "right way up" so must
+        // be flipped upside down during decompression to match
+        // uncompressed orientation.
+        const q = new Quat().setFromEulerAngles(0, 0, 180);
+
         for (let i = 0; i < this.numSplats; ++i) {
             iter.read(i);
+
+            q.transformVector(p, p);
+            r.mul2(q, r);
 
             data.x[i] = p.x;
             data.y[i] = p.y;
             data.z[i] = p.z;
 
-            data.rot_0[i] = r.x;
-            data.rot_1[i] = r.y;
-            data.rot_2[i] = r.z;
-            data.rot_3[i] = r.w;
+            data.rot_1[i] = r.x;
+            data.rot_2[i] = r.y;
+            data.rot_3[i] = r.z;
+            data.rot_0[i] = r.w;
 
             data.scale_0[i] = s.x;
             data.scale_1[i] = s.y;

--- a/src/scene/gsplat/gsplat-compressed-material.js
+++ b/src/scene/gsplat/gsplat-compressed-material.js
@@ -203,9 +203,6 @@ const splatCoreVS = /* glsl */ `
 `;
 
 const splatCoreFS = /* glsl */ `
-    varying mediump vec2 texCoord;
-    varying mediump vec4 color;
-
     #ifndef DITHER_NONE
         varying float id;
     #endif
@@ -214,7 +211,7 @@ const splatCoreFS = /* glsl */ `
         uniform vec4 uColor;
     #endif
 
-    vec4 evalSplat() {
+    vec4 evalSplat(vec2 texCoord, vec4 color) {
         mediump float A = dot(texCoord, texCoord);
         if (A > 1.0) {
             discard;
@@ -226,8 +223,10 @@ const splatCoreFS = /* glsl */ `
         }
 
         #ifdef PICK_PASS
-            if (B < 0.3) discard;
-            return(uColor);
+            if (B < 0.3) {
+                discard;
+            }
+            return uColor;
         #endif
 
         #ifndef DITHER_NONE
@@ -342,9 +341,12 @@ const splatMainVS = /* glsl */ `
 `;
 
 const splatMainFS = /* glsl */ `
+    varying mediump vec2 texCoord;
+    varying mediump vec4 color;
+
     void main(void)
     {
-        gl_FragColor = evalSplat();
+        gl_FragColor = evalSplat(texCoord, color);
     }
 `;
 

--- a/src/scene/gsplat/gsplat-compressed-material.js
+++ b/src/scene/gsplat/gsplat-compressed-material.js
@@ -164,10 +164,8 @@ const splatCoreVS = /* glsl */ `
         covB = vec3(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
     }
 
-    // given the splat center (view space) and covariance A and B vectors, calculate
-    // the v1 and v2 vectors for this view.
-    vec4 calcV1V2(vec3 centerView, vec3 covA, vec3 covB, mat3 W) {
-
+    // calculate 2d covariance vectors
+    vec4 calcV1V2(in vec3 splat_cam, in vec3 covA, in vec3 covB, mat3 W) {
         mat3 Vrk = mat3(
             covA.x, covA.y, covA.z, 
             covA.y, covB.x, covB.y,
@@ -176,8 +174,8 @@ const splatCoreVS = /* glsl */ `
 
         float focal = viewport.x * matrix_projection[0][0];
 
-        float J1 = focal / centerView.z;
-        vec2 J2 = -J1 / centerView.z * centerView.xy;
+        float J1 = focal / splat_cam.z;
+        vec2 J2 = -J1 / splat_cam.z * splat_cam.xy;
         mat3 J = mat3(
             J1, 0.0, J2.x, 
             0.0, J1, J2.y, 

--- a/src/scene/gsplat/gsplat-data.js
+++ b/src/scene/gsplat/gsplat-data.js
@@ -158,35 +158,39 @@ class GSplatData {
         let mx, my, mz, Mx, My, Mz;
         let first = true;
 
-        const p = new Vec3();
-        const s = new Vec3();
-
-        const iter = this.createIter(p, null, s);
+        const x = this.getProp('x');
+        const y = this.getProp('y');
+        const z = this.getProp('z');
+        const sx = this.getProp('scale_0');
+        const sy = this.getProp('scale_1');
+        const sz = this.getProp('scale_2');
 
         for (let i = 0; i < this.numSplats; ++i) {
             if (pred && !pred(i)) {
                 continue;
             }
 
-            iter.read(i);
+            const scaleVal = 2.0 * Math.exp(Math.max(sx[i], sy[i], sz[i]));
 
-            const scaleVal = 2.0 * Math.max(s.x, s.y, s.z);
+            const px = x[i];
+            const py = y[i];
+            const pz = z[i];
 
             if (first) {
                 first = false;
-                mx = p.x - scaleVal;
-                my = p.y - scaleVal;
-                mz = p.z - scaleVal;
-                Mx = p.x + scaleVal;
-                My = p.y + scaleVal;
-                Mz = p.z + scaleVal;
+                mx = px - scaleVal;
+                my = py - scaleVal;
+                mz = pz - scaleVal;
+                Mx = px + scaleVal;
+                My = py + scaleVal;
+                Mz = pz + scaleVal;
             } else {
-                mx = Math.min(mx, p.x - scaleVal);
-                my = Math.min(my, p.y - scaleVal);
-                mz = Math.min(mz, p.z - scaleVal);
-                Mx = Math.max(Mx, p.x + scaleVal);
-                My = Math.max(My, p.y + scaleVal);
-                Mz = Math.max(Mz, p.z + scaleVal);
+                mx = Math.min(mx, px - scaleVal);
+                my = Math.min(my, py - scaleVal);
+                mz = Math.min(mz, pz - scaleVal);
+                Mx = Math.max(Mx, px + scaleVal);
+                My = Math.max(My, py + scaleVal);
+                Mz = Math.max(Mz, pz + scaleVal);
             }
         }
 
@@ -238,15 +242,14 @@ class GSplatData {
      * @param {Float32Array} result - Array containing the centers.
      */
     getCenters(result) {
-        const p = new Vec3();
-        const iter = this.createIter(p);
+        const x = this.getProp('x');
+        const y = this.getProp('y');
+        const z = this.getProp('z');
 
         for (let i = 0; i < this.numSplats; ++i) {
-            iter.read(i);
-
-            result[i * 3 + 0] = p.x;
-            result[i * 3 + 1] = p.y;
-            result[i * 3 + 2] = p.z;
+            result[i * 3 + 0] = x[i];
+            result[i * 3 + 1] = y[i];
+            result[i * 3 + 2] = z[i];
         }
     }
 
@@ -255,9 +258,12 @@ class GSplatData {
      * @param {Function} pred - Predicate given index for skipping.
      */
     calcFocalPoint(result, pred) {
-        const p = new Vec3();
-        const s = new Vec3();
-        const iter = this.createIter(p, null, s, null);
+        const x = this.getProp('x');
+        const y = this.getProp('y');
+        const z = this.getProp('z');
+        const sx = this.getProp('scale_0');
+        const sy = this.getProp('scale_1');
+        const sz = this.getProp('scale_2');
 
         result.x = 0;
         result.y = 0;
@@ -269,12 +275,10 @@ class GSplatData {
                 continue;
             }
 
-            iter.read(i);
-
-            const weight = 1.0 / (1.0 + Math.max(s.x, s.y, s.z));
-            result.x += p.x * weight;
-            result.y += p.y * weight;
-            result.z += p.z * weight;
+            const weight = 1.0 / (1.0 + Math.exp(Math.max(sx[i], sy[i], sz[i])));
+            result.x += x[i] * weight;
+            result.y += y[i] * weight;
+            result.z += z[i] * weight;
             sum += weight;
         }
         result.mulScalar(1 / sum);

--- a/src/scene/gsplat/gsplat-material.js
+++ b/src/scene/gsplat/gsplat-material.js
@@ -74,9 +74,12 @@ const splatMainVS = /* glsl */ `
 `;
 
 const splatMainFS = /* glsl */ `
+    varying mediump vec2 texCoord;
+    varying mediump vec4 color;
+
     void main(void)
     {
-        gl_FragColor = evalSplat();
+        gl_FragColor = evalSplat(texCoord, color);
     }
 `;
 

--- a/src/scene/gsplat/shader-generator-gsplat.js
+++ b/src/scene/gsplat/shader-generator-gsplat.js
@@ -84,9 +84,9 @@ const splatCoreVS = /* glsl */ `
         float J1 = focal / splat_cam.z;
         vec2 J2 = -J1 / splat_cam.z * splat_cam.xy;
         mat3 J = mat3(
-            J1, 0., J2.x, 
-            0., J1, J2.y, 
-            0., 0., 0.
+            J1, 0.0, J2.x, 
+            0.0, J1, J2.y, 
+            0.0, 0.0, 0.0
         );
 
         mat3 T = W * J;
@@ -221,9 +221,6 @@ const splatCoreVS = /* glsl */ `
 `;
 
 const splatCoreFS = /* glsl */ `
-    varying mediump vec2 texCoord;
-    varying mediump vec4 color;
-
     #ifndef DITHER_NONE
         varying float id;
     #endif
@@ -232,7 +229,7 @@ const splatCoreFS = /* glsl */ `
         uniform vec4 uColor;
     #endif
 
-    vec4 evalSplat() {
+    vec4 evalSplat(vec2 texCoord, vec4 color) {
         mediump float A = dot(texCoord, texCoord);
         if (A > 1.0) {
             discard;
@@ -244,8 +241,10 @@ const splatCoreFS = /* glsl */ `
         }
 
         #ifdef PICK_PASS
-            if (B < 0.3) discard;
-            return(uColor);
+            if (B < 0.3) {
+                discard;
+            }
+            return uColor;
         #endif
 
         #ifndef DITHER_NONE


### PR DESCRIPTION
This PR continues on from #6946 by:
* Orientating the GS scene in the instantiated gsplat resource (since we no longer reorientate splat data at load time). 
* Reorientate compressed data at load time to match uncompressed data.
* Update shaders so now uncompressed and compressed fragments are identical.

Also includes load time speedups:
* add a fast path for PLY files containing only float32 data (i.e. uncompressed GS data)
* speedup code which does packaging of transform, covariant and SH data for gpu
* implement fast path for calculating centers and focal point

These speedups result in `bicycle.ply` load time in Supersplat going from 23sec -> 9.5sec.