### PR TITLE
Small improvement to saturation control in compose pass to avoid clipping

### DIFF
--- a/examples/src/examples/graphics/post-processing.controls.mjs
+++ b/examples/src/examples/graphics/post-processing.controls.mjs
@@ -115,7 +115,7 @@ export function controls({ observer, ReactPCUI, React, jsx, fragment }) {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'data.grading.saturation' },
                     min: 0,
-                    max: 3,
+                    max: 2,
                     precision: 2
                 })
             ),
@@ -136,8 +136,8 @@ export function controls({ observer, ReactPCUI, React, jsx, fragment }) {
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'data.grading.contrast' },
-                    min: 0,
-                    max: 3,
+                    min: 0.5,
+                    max: 1.5,
                     precision: 2
                 })
             )


### PR DESCRIPTION
small improvement to remove black pixels caused by the clipping. Note that the saturation effects is just a cheap effect that does not work terrible well in HDR, and a lot more expensive HSL based adjustment could be used instead