### PR TITLE
RenderPassCameraFrame exposes HDR formats

### DIFF
--- a/src/extras/render-passes/render-pass-camera-frame.js
+++ b/src/extras/render-passes/render-pass-camera-frame.js
@@ -21,6 +21,8 @@ export const SSAOTYPE_LIGHTING = 'lighting';
 export const SSAOTYPE_COMBINE = 'combine';
 
 class CameraFrameOptions {
+    formats;
+
     samples = 1;
 
     sceneColorMap = true;
@@ -120,7 +122,7 @@ class RenderPassCameraFrame extends RenderPass {
     sanitizeOptions(options) {
         options = Object.assign({}, _defaultOptions, options);
 
-        // automatically enabled prepass when required internally
+        // automatically enable prepass when required internally
         if (options.taaEnabled || options.ssaoType !== SSAOTYPE_NONE) {
             options.prepassEnabled = true;
         }
@@ -142,11 +144,20 @@ class RenderPassCameraFrame extends RenderPass {
 
     needsReset(options) {
         const currentOptions = this.options;
+
+        // helper to compare arrays
+        const arraysNotEqual = (arr1, arr2) =>
+            arr1 !== arr2 &&
+            (!(Array.isArray(arr1) && Array.isArray(arr2)) ||
+            arr1.length !== arr2.length ||
+            !arr1.every((value, index) => value === arr2[index]));
+
         return options.ssaoType !== currentOptions.ssaoType ||
             options.ssaoBlurEnabled !== currentOptions.ssaoBlurEnabled ||
             options.taaEnabled !== currentOptions.taaEnabled ||
             options.bloomEnabled !== currentOptions.bloomEnabled ||
-            options.prepassEnabled !== currentOptions.prepassEnabled;
+            options.prepassEnabled !== currentOptions.prepassEnabled ||
+            arraysNotEqual(options.formats, currentOptions.formats);
     }
 
     // manually called, applies changes
@@ -174,7 +185,7 @@ class RenderPassCameraFrame extends RenderPass {
         const cameraComponent = this.cameraComponent;
         const targetRenderTarget = cameraComponent.renderTarget;
 
-        this.hdrFormat = device.getRenderableHdrFormat() || PIXELFORMAT_RGBA8;
+        this.hdrFormat = device.getRenderableHdrFormat(options.formats) || PIXELFORMAT_RGBA8;
 
         // camera renders in HDR mode (linear output, no tonemapping)
         if (!cameraComponent.rendering) {
@@ -342,7 +353,8 @@ class RenderPassCameraFrame extends RenderPass {
     }
 
     setupBloomPass(options, inputTexture) {
-        if (options.bloomEnabled) {
+        // HDR bloom is not supported on RGBA8 format
+        if (options.bloomEnabled && this.hdrFormat !== PIXELFORMAT_RGBA8) {
             // create a bloom pass, which generates bloom texture based on the provided texture
             this.bloomPass = new RenderPassBloom(this.device, inputTexture, this.hdrFormat);
         }
@@ -399,7 +411,7 @@ class RenderPassCameraFrame extends RenderPass {
 
         // TAA history buffer is double buffered, assign the current one to the follow up passes.
         this.composePass.sceneTexture = sceneTexture;
-        if (this.options.bloomEnabled) {
+        if (this.options.bloomEnabled && this.bloomPass) {
             this.bloomPass.sourceTexture = sceneTexture;
         }
     }

--- a/src/extras/render-passes/render-pass-camera-frame.js
+++ b/src/extras/render-passes/render-pass-camera-frame.js
@@ -146,8 +146,7 @@ class RenderPassCameraFrame extends RenderPass {
         const currentOptions = this.options;
 
         // helper to compare arrays
-        const arraysNotEqual = (arr1, arr2) =>
-            arr1 !== arr2 &&
+        const arraysNotEqual = (arr1, arr2) => arr1 !== arr2 &&
             (!(Array.isArray(arr1) && Array.isArray(arr2)) ||
             arr1.length !== arr2.length ||
             !arr1.every((value, index) => value === arr2[index]));


### PR DESCRIPTION
- this allows the users to specify preference of the HDR format used for rendering
- also, when no HDR format is supported, the bloom is automatically disabled as non-supported