### PR TITLE
Adds LTS tag to NPM publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,6 +29,6 @@ jobs:
         run: npm run publint
       
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --tag lts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds the LTS (Long Term Support) tag to the npm publish workflow so as not to override the default `latest` tag, which should be reserved for `2.x` releases. Allows users to install/link via `npm install playcanvas@lts ` or `https://esm.sh/playcanvas@lts` which defaults to the latest 1.x release.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
