### PR TITLE
[Fix] Stop transparent meshes to be rendered in depth prepass

### DIFF
--- a/src/extras/render-passes/render-pass-prepass.js
+++ b/src/extras/render-passes/render-pass-prepass.js
@@ -116,15 +116,15 @@ class RenderPassPrepass extends RenderPass {
         for (let i = 0; i < layers.length; i++) {
             const layer = layers[i];
 
+            // only render the layers before the depth layer
+            if (layer.id === LAYERID_DEPTH) {
+                break;
+            }
+            
             if (layer.enabled && subLayerEnabled[i]) {
 
                 // if the layer is rendered by the camera
                 if (layer.camerasSet.has(camera)) {
-
-                    // only render the layers before the depth layer
-                    if (layer.id === LAYERID_DEPTH) {
-                        break;
-                    }
 
                     const culledInstances = layer.getCulledInstances(camera);
                     const meshInstances = isTransparent[i] ? culledInstances.transparent : culledInstances.opaque;


### PR DESCRIPTION
- make sure the Depth layer stops depth-prepass rendering even when it’s disabled