### PR TITLE
Fix for -Infinity compressed GS data

### DIFF
--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -43,6 +43,7 @@ class SplatCompressedIterator {
         };
 
         const lerp = (a, b, t) => {
+            // choose a when a === b so we don't do math on -Infinity
             return (a === b) ? a : a * (1 - t) + b * t;
         };
 

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -42,7 +42,9 @@ class SplatCompressedIterator {
             }
         };
 
-        const lerp = (a, b, t) => a === b ? a : a * (1 - t) + b * t;
+        const lerp = (a, b, t) => {
+            return (a === b) ? a : a * (1 - t) + b * t;
+        };
 
         const chunkData = gsplatData.chunkData;
         const vertexData = gsplatData.vertexData;

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -42,7 +42,7 @@ class SplatCompressedIterator {
             }
         };
 
-        const lerp = (a, b, t) => a * (1 - t) + b * t;
+        const lerp = (a, b, t) => a === b ? a : a * (1 - t) + b * t;
 
         const chunkData = gsplatData.chunkData;
         const vertexData = gsplatData.vertexData;


### PR DESCRIPTION
This PR implements a workaround for https://github.com/playcanvas/supersplat/issues/189.

In cases with infinity scales, chunk a and b values are equal and we can just take a.