### PR TITLE
Add support for Chrome HDR mode for WebGPU

### DIFF
--- a/examples/src/examples/graphics/mesh-decals.example.mjs
+++ b/examples/src/examples/graphics/mesh-decals.example.mjs
@@ -11,7 +11,10 @@ const assets = {
 const gfxOptions = {
     deviceTypes: [deviceType],
     glslangUrl: rootPath + '/static/lib/glslang/glslang.js',
-    twgslUrl: rootPath + '/static/lib/twgsl/twgsl.js'
+    twgslUrl: rootPath + '/static/lib/twgsl/twgsl.js',
+
+    // enable HDR rendering if supported
+    displayFormat: pc.DISPLAYFORMAT_HDR
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
@@ -42,6 +45,10 @@ assetListLoader.load(() => {
     app.start();
 
     app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
+
+    // if the device renders in HDR mode, disable tone mapping to output HDR values without any processing
+    app.scene.rendering.toneMapping = device.isHdr ? pc.TONEMAP_NONE : pc.TONEMAP_ACES;
+    app.scene.rendering.gammaCorrection = pc.GAMMA_SRGB;
 
     // create material for the plane
     const planeMaterial = new pc.StandardMaterial();
@@ -201,6 +208,7 @@ assetListLoader.load(() => {
     material.depthWrite = false; // optimization - no need to write to depth buffer, as decals are part of the ground plane
     material.emissiveMap = assets.heart.resource;
     material.emissive = pc.Color.WHITE;
+    material.emissiveIntensity = 10;    // bright emissive to make it really bright on HDR displays
     material.opacityMap = assets.heart.resource;
     material.depthBias = -0.1; // depth biases to avoid z-fighting with ground plane
     material.slopeDepthBias = -0.1;

--- a/examples/src/examples/graphics/shader-burn.example.mjs
+++ b/examples/src/examples/graphics/shader-burn.example.mjs
@@ -13,7 +13,10 @@ const assets = {
 const gfxOptions = {
     deviceTypes: [deviceType],
     glslangUrl: rootPath + '/static/lib/glslang/glslang.js',
-    twgslUrl: rootPath + '/static/lib/twgsl/twgsl.js'
+    twgslUrl: rootPath + '/static/lib/twgsl/twgsl.js',
+
+    // Enable HDR rendering if supported
+    displayFormat: pc.DISPLAYFORMAT_HDR
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);

--- a/examples/src/examples/graphics/shader-burn.shader.frag
+++ b/examples/src/examples/graphics/shader-burn.shader.frag
@@ -15,7 +15,7 @@ void main(void)
         discard;
     }
     if (height < (uTime + uTime * 0.1)) {
-        linearColor = vec4(1.0, 0.02, 0.0, 1.0);
+        linearColor = vec4(5.0, 0.02, 0.0, 1.0);
     }
     gl_FragColor.rgb = gammaCorrectOutput(linearColor.rgb);
     gl_FragColor.a = 1.0;

--- a/examples/src/examples/graphics/sky.example.mjs
+++ b/examples/src/examples/graphics/sky.example.mjs
@@ -25,7 +25,10 @@ const assets = {
 const gfxOptions = {
     deviceTypes: [deviceType],
     glslangUrl: rootPath + '/static/lib/glslang/glslang.js',
-    twgslUrl: rootPath + '/static/lib/twgsl/twgsl.js'
+    twgslUrl: rootPath + '/static/lib/twgsl/twgsl.js',
+
+    // enable HDR rendering if supported
+    displayFormat: pc.DISPLAYFORMAT_HDR
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
@@ -57,7 +60,9 @@ const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets
 assetListLoader.load(() => {
     app.start();
 
-    app.scene.rendering.toneMapping = pc.TONEMAP_ACES;
+    // if the device renders in HDR mode, disable tone mapping to output HDR values without any processing
+    app.scene.rendering.toneMapping = device.isHdr ? pc.TONEMAP_NONE : pc.TONEMAP_ACES;
+    app.scene.rendering.gammaCorrection = pc.GAMMA_SRGB;
 
     // add an instance of the statue
     const statueEntity = assets.statue.resource.instantiateRenderEntity();

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -2215,11 +2215,13 @@ export const DISPLAYFORMAT_LDR_SRGB = 'ldr_srgb';
 
 /**
  * Display format for high dynamic range data, using 16bit floating point values.
- * Note: This is not implemented yet, but is added to indicate the intended API.
+ * Note: This is supported on WebGPU platform only, and ignored on other platforms. On displays
+ * without HDR support, it silently falls back to {@link DISPLAYFORMAT_LDR}. Use
+ * {@link GraphicsDevice.isHdr} to see if the HDR format is used. When it is, it's recommended to
+ * use {@link TONEMAP_NONE} for the tonemapping mode, to avoid it clipping the high dynamic range.
  *
  * @type {string}
  * @category Graphics
- * @ignore
  */
 export const DISPLAYFORMAT_HDR = 'hdr';
 

--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -21,6 +21,7 @@ import { NullGraphicsDevice } from './null/null-graphics-device.js';
  *
  * - {@link DISPLAYFORMAT_LDR}
  * - {@link DISPLAYFORMAT_LDR_SRGB}
+ * - {@link DISPLAYFORMAT_HDR}
  *
  * @param {boolean} [options.depth] - Boolean that indicates that the drawing buffer is
  * requested to have a depth buffer of at least 16 bits. Defaults to true.

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -105,6 +105,14 @@ class GraphicsDevice extends EventHandler {
     isWebGL2 = false;
 
     /**
+     * True if the back-buffer is using HDR format, which means that the browser will display the
+     * rendered images in high dynamic range mode. This is true if the displayFormat is set to
+     * {@link DISPLAYFORMAT_HDR} when creating the graphics device, and HDR is supported by the
+     * device.
+     */
+    isHdr = false;
+
+    /**
      * The scope namespace for shader attributes and variables.
      *
      * @type {ScopeSpace}

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -106,9 +106,9 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * True if the back-buffer is using HDR format, which means that the browser will display the
-     * rendered images in high dynamic range mode. This is true if the displayFormat is set to
-     * {@link DISPLAYFORMAT_HDR} when creating the graphics device, and HDR is supported by the
-     * device.
+     * rendered images in high dynamic range mode. This is true if the options.displayFormat is set
+     * to {@link DISPLAYFORMAT_HDR} when creating the graphics device using
+     * {@link createGraphicsDevice}, and HDR is supported by the device.
      */
     isHdr = false;
 

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -2,6 +2,7 @@ import { Debug } from '../../core/debug.js';
 import { Tracing } from '../../core/tracing.js';
 import { Color } from '../../core/math/color.js';
 import { TRACEID_RENDER_PASS, TRACEID_RENDER_PASS_DETAIL } from '../../core/constants.js';
+import { pixelFormatInfo } from './constants.js';
 
 /**
  * @import { GraphicsDevice } from '../graphics/graphics-device.js'
@@ -453,26 +454,32 @@ class RenderPass {
 
             for (let i = 0; i < numColor; i++) {
                 const colorOps = this.colorArrayOps[i];
+                const colorFormat = pixelFormatInfo.get(isBackBuffer ? device.backBufferFormat : rt.getColorBuffer(i).format)?.name;
                 Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    color[${i}]: ` +
                             `${colorOps.clear ? 'clear' : 'load'}->` +
                             `${colorOps.store ? 'store' : 'discard'} ` +
                             `${colorOps.resolve ? 'resolve ' : ''}` +
-                            `${colorOps.mipmaps ? 'mipmaps ' : ''}`);
+                            `${colorOps.mipmaps ? 'mipmaps ' : ''}` +
+                            ` [format: ${colorFormat}]`);
             }
 
             if (this.depthStencilOps) {
+
+                const depthFormat = `${rt.depthBuffer ?  ' [format: ' + pixelFormatInfo.get(rt.depthBuffer.format)?.name + ']' : ''}`
 
                 if (hasDepth) {
                     Debug.trace(TRACEID_RENDER_PASS_DETAIL, '    depthOps: ' +
                                 `${this.depthStencilOps.clearDepth ? 'clear' : 'load'}->` +
                                 `${this.depthStencilOps.storeDepth ? 'store' : 'discard'}` +
-                                `${this.depthStencilOps.resolveDepth ? ' resolve' : ''}`);
+                                `${this.depthStencilOps.resolveDepth ? ' resolve' : ''}` +
+                                `${depthFormat}`);
                 }
 
                 if (hasStencil) {
                     Debug.trace(TRACEID_RENDER_PASS_DETAIL, '    stencOps: ' +
                                 `${this.depthStencilOps.clearStencil ? 'clear' : 'load'}->` +
-                                `${this.depthStencilOps.storeStencil ? 'store' : 'discard'}`);
+                                `${this.depthStencilOps.storeStencil ? 'store' : 'discard'}` +
+                                `${depthFormat}`);
                 }
             }
         }

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -465,7 +465,7 @@ class RenderPass {
 
             if (this.depthStencilOps) {
 
-                const depthFormat = `${rt.depthBuffer ?  ' [format: ' + pixelFormatInfo.get(rt.depthBuffer.format)?.name + ']' : ''}`
+                const depthFormat = `${rt.depthBuffer ? ` [format: ${pixelFormatInfo.get(rt.depthBuffer.format)?.name}]` : ''}`;
 
                 if (hasDepth) {
                     Debug.trace(TRACEID_RENDER_PASS_DETAIL, '    depthOps: ' +

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -3,7 +3,8 @@ import { Debug, DebugHelper } from '../../../core/debug.js';
 import {
     PIXELFORMAT_RGBA8, PIXELFORMAT_BGRA8, DEVICETYPE_WEBGPU,
     BUFFERUSAGE_READ, BUFFERUSAGE_COPY_DST, semanticToLocation,
-    PIXELFORMAT_SRGBA8, DISPLAYFORMAT_LDR_SRGB, PIXELFORMAT_SBGRA8
+    PIXELFORMAT_SRGBA8, DISPLAYFORMAT_LDR_SRGB, PIXELFORMAT_SBGRA8, DISPLAYFORMAT_HDR,
+    PIXELFORMAT_RGBA16F
 } from '../constants.js';
 import { BindGroupFormat } from '../bind-group-format.js';
 import { BindGroup } from '../bind-group.js';
@@ -268,8 +269,11 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
         this.gpuContext = this.canvas.getContext('webgpu');
 
+        // tonemapping, used when the backbuffer is HDR
+        let canvasToneMapping = 'standard';
+
         // pixel format of the framebuffer that is the most efficient one on the system
-        const preferredCanvasFormat = navigator.gpu.getPreferredCanvasFormat();
+        let preferredCanvasFormat = navigator.gpu.getPreferredCanvasFormat();
 
         // display format the user asked for
         const displayFormat = this.initOptions.displayFormat;
@@ -282,6 +286,24 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // view format for the backbuffer. Backbuffer is always allocated without srgb conversion, and
         // the view we create specifies srgb is needed to handle the conversion.
         this.backBufferViewFormat = displayFormat === DISPLAYFORMAT_LDR_SRGB ? `${preferredCanvasFormat}-srgb` : preferredCanvasFormat;
+
+        // optional HDR display format
+        if (displayFormat === DISPLAYFORMAT_HDR && this.textureFloatFilterable) {
+
+            // if supported by the system
+            const hdrMediaQuery = window.matchMedia('(dynamic-range: high)');
+            if (hdrMediaQuery?.matches) {
+
+                // configure the backbuffer to be 16 bit float
+                this.backBufferFormat = PIXELFORMAT_RGBA16F;
+                this.backBufferViewFormat = 'rgba16float';
+                preferredCanvasFormat = 'rgba16float';
+                this.isHdr = true;
+
+                // use extended tonemapping for HDR to avoid clipping
+                canvasToneMapping = 'extended';
+            }
+        }
 
         /**
          * Configuration of the main colorframebuffer we obtain using getCurrentTexture
@@ -296,6 +318,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
             // use preferred format for optimal performance on mobile
             format: preferredCanvasFormat,
+
+            toneMapping: { mode: canvasToneMapping },
 
             // RENDER_ATTACHMENT is required, COPY_SRC allows scene grab to copy out from it
             usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/6975

This adds support for HDR displays for WebGPU (new in Chrome 129). 

There is a new public constant that can be used to request HDR mode:
`DISPLAYFORMAT_HDR` // this is now public

also, new API to test if HDR is active:
`GraphicsDevice.isHdr`

Notes:
- few examples were updated to test this.
- old bloom was removed from the example as that is LDR implementation
- WebGPU implements single non-specific tonemapping, so it does not exactly match our tonemapping options. They plan to expose additional options in the future.
- there is an issue with some more advanced examples, I'll investigate more and likely open chromium issue, as the browser rendering gets broken in those cases.