### PR TITLE
[BROKEN, DO NOT MERGE] - A test PR to create a chromium issue on HDR problem

### DIFF
--- a/examples/src/examples/graphics/post-processing.example.mjs
+++ b/examples/src/examples/graphics/post-processing.example.mjs
@@ -36,7 +36,6 @@ const gfxOptions = {
     antialias: false,
 
 
-
     displayFormat: pc.DISPLAYFORMAT_HDR
 };
 
@@ -100,7 +99,7 @@ assetListLoader.load(() => {
     });
 
     // add an instance of the mosquito mesh
-    //const mosquitoEntity = assets.mosquito.resource.instantiateRenderEntity();
+    // const mosquitoEntity = assets.mosquito.resource.instantiateRenderEntity();
 
 
     // use sphere instead
@@ -109,8 +108,6 @@ assetListLoader.load(() => {
         type: 'sphere',
         material: new pc.StandardMaterial()
     });
-
-
 
 
     mosquitoEntity.setLocalScale(600, 600, 600);
@@ -347,7 +344,6 @@ assetListLoader.load(() => {
         const ll = angle < 1 && angle + dt >= 1;
         pc.Tracing.set(pc.TRACEID_RENDER_PASS, ll);
         pc.Tracing.set(pc.TRACEID_RENDER_PASS_DETAIL, ll);
-
 
 
         angle += dt;

--- a/examples/src/examples/graphics/post-processing.example.mjs
+++ b/examples/src/examples/graphics/post-processing.example.mjs
@@ -33,7 +33,11 @@ const gfxOptions = {
     // The scene is rendered to an antialiased texture, so we disable antialiasing on the canvas
     // to avoid the additional cost. This is only used for the UI which renders on top of the
     // post-processed scene, and we're typically happy with some aliasing on the UI.
-    antialias: false
+    antialias: false,
+
+
+
+    displayFormat: pc.DISPLAYFORMAT_HDR
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
@@ -96,7 +100,19 @@ assetListLoader.load(() => {
     });
 
     // add an instance of the mosquito mesh
-    const mosquitoEntity = assets.mosquito.resource.instantiateRenderEntity();
+    //const mosquitoEntity = assets.mosquito.resource.instantiateRenderEntity();
+
+
+    // use sphere instead
+    const mosquitoEntity = new pc.Entity();
+    mosquitoEntity.addComponent('render', {
+        type: 'sphere',
+        material: new pc.StandardMaterial()
+    });
+
+
+
+
     mosquitoEntity.setLocalScale(600, 600, 600);
     mosquitoEntity.setLocalPosition(0, 20, 0);
     app.root.addChild(mosquitoEntity);
@@ -216,8 +232,8 @@ assetListLoader.load(() => {
     // ------ Custom render passes set up ------
 
     const currentOptions = new pc.CameraFrameOptions();
-    currentOptions.sceneColorMap = true;
-    currentOptions.bloomEnabled = true;
+    currentOptions.sceneColorMap = false; // true;
+    currentOptions.bloomEnabled = false; // true;
     currentOptions.taaEnabled = false;          // disabled TAA as it currently does not handle dynamic objects
 
     // and set up these rendering passes to be used by the camera, instead of its default rendering
@@ -229,15 +245,15 @@ assetListLoader.load(() => {
     const applySettings = () => {
 
         // update current options and apply them
-        currentOptions.taaEnabled = data.get('data.taa.enabled');
-        currentOptions.bloomEnabled = data.get('data.bloom.enabled');
+        currentOptions.taaEnabled = false; // data.get('data.taa.enabled');
+        currentOptions.bloomEnabled = false; // data.get('data.bloom.enabled');
         renderPassCamera.update(currentOptions);
 
         // apply options on the other passes
         const composePass = renderPassCamera.composePass;
 
         // SCENE
-        composePass.toneMapping = data.get('data.scene.tonemapping');
+        composePass.toneMapping = pc.TONEMAP_NONE;// data.get('data.scene.tonemapping');
         renderPassCamera.renderTargetScale = data.get('data.scene.scale');
 
         const background = data.get('data.scene.background');
@@ -326,6 +342,14 @@ assetListLoader.load(() => {
     // update things every frame
     let angle = 0;
     app.on('update', function (/** @type {number} */ dt) {
+
+
+        const ll = angle < 1 && angle + dt >= 1;
+        pc.Tracing.set(pc.TRACEID_RENDER_PASS, ll);
+        pc.Tracing.set(pc.TRACEID_RENDER_PASS_DETAIL, ll);
+
+
+
         angle += dt;
 
         // scale the boxes


### PR DESCRIPTION
related to this change: https://github.com/playcanvas/engine/pull/6980
repro: load this https://engine-g7ju2nk6c-playcanvas.vercel.app/#/graphics/post-processing on HDR screen, open dev tools and resize them. But even without them, the rendering has issues visible when rotating the camera.
Needs to be set to WebGPU mode.

LDR screen, all good:
<img width="1393" alt="ldr" src="https://github.com/user-attachments/assets/1c9b9178-d414-452d-96b8-fa1e3f194588">
<img width="1388" alt="Screenshot 2024-09-23 at 11 28 17" src="https://github.com/user-attachments/assets/75807bdb-eb8d-41bd-8eff-b53b1feaaa55">

HDR screen, all messed up:
<img width="1388" alt="Screenshot 2024-09-23 at 11 28 02" src="https://github.com/user-attachments/assets/8c0762bd-6b30-4c7a-9421-20b2c73c20ff">
<img width="1388" alt="Screenshot 2024-09-23 at 11 28 17" src="https://github.com/user-attachments/assets/7df3e3af-5a16-4030-8a3a-83665fda938f">

testing on
MacBook Pro M1 Max, Sonoma 14.6.1
Version 129.0.6668.59 (Official Build) (arm64)