### PR TITLE
MacBook Pro M1 Max, Sonoma 14.6.1 Version 129.0.6668.59 (Official Build) (arm64)

### DIFF
--- a/src/scene/graphics/render-pass-shader-quad.js
+++ b/src/scene/graphics/render-pass-shader-quad.js
@@ -82,7 +82,6 @@ class RenderPassShaderQuad extends RenderPass {
         // destroy old
         this.quadRender?.destroy();
         this.quadRender = null;
-        this._shader?.destroy();
 
         // handle new
         this._shader = shader;
@@ -118,11 +117,6 @@ class RenderPassShaderQuad extends RenderPass {
             { aPosition: SEMANTIC_POSITION },
             shaderDefinitionOptions
         );
-    }
-
-    destroy() {
-        this.shader?.destroy();
-        this.shader = null;
     }
 
     execute() {


### PR DESCRIPTION
The shader should not be destroyed:
-  the render pass does not own it, and the caller should manage its lifetime
- in general we don't destroy shaders to keep them compiled should they are needed again
- the specific issue is the hdr bloom rendering using upscaling and downscaling shaders, this stops them being compiled again each time render passes are recreated