### PR TITLE
Gizmo fixes

### DIFF
--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -374,14 +374,12 @@ class Gizmo extends EventHandler {
             return;
         }
 
-        const { offsetX, offsetY } = e;
-
-        const selection = this._getSelection(offsetX, offsetY);
+        const selection = this._getSelection(e.offsetX, e.offsetY);
         if (selection[0]) {
             e.preventDefault();
             e.stopPropagation();
         }
-        this.fire(Gizmo.EVENT_POINTERMOVE, offsetX, offsetY, selection[0]);
+        this.fire(Gizmo.EVENT_POINTERMOVE, e.offsetX, e.offsetY, selection[0]);
     }
 
     /**
@@ -564,8 +562,8 @@ class Gizmo extends EventHandler {
     destroy() {
         this.detach();
 
-        this._device.canvas.removeEventListener('pointerdown', this._onPointerDown, true);
-        this._device.canvas.removeEventListener('pointermove', this._onPointerMove, true);
+        this._device.canvas.removeEventListener('pointerdown', this._onPointerDown);
+        this._device.canvas.removeEventListener('pointermove', this._onPointerMove);
         this._device.canvas.removeEventListener('pointerup', this._onPointerUp);
 
         this.root.destroy();

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -382,6 +382,7 @@ class Gizmo extends EventHandler {
     }
 
     /**
+     * @param {PointerEvent} e - The pointer event.
      * @private
      */
     _onPointerUp(e) {

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -373,7 +373,6 @@ class Gizmo extends EventHandler {
         if (!this.root.enabled || document.pointerLockElement) {
             return;
         }
-
         const selection = this._getSelection(e.offsetX, e.offsetY);
         if (selection[0]) {
             e.preventDefault();

--- a/src/extras/gizmo/rotate-gizmo.js
+++ b/src/extras/gizmo/rotate-gizmo.js
@@ -169,7 +169,7 @@ class RotateGizmo extends TransformGizmo {
             this._nodeOffsets.clear();
         });
 
-        this._app.on('update', () => {
+        this._app.on('prerender', () => {
             this._faceAxisLookAtCamera();
             this._xyzAxisLookAtCamera();
 

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -262,7 +262,7 @@ class TransformGizmo extends Gizmo {
     constructor(camera, layer) {
         super(camera, layer);
 
-        this._app.on('update', () => {
+        this._app.on('prerender', () => {
             if (!this.root.enabled) {
                 return;
             }


### PR DESCRIPTION
This PR has various fixes for gizmo:
- render the guide lines during app `prerender` instead of `update`
    - fixes a bug when the application is rendering on-demand
- capture the pointer during gizmo drag so we don't loose events when pointer leaves the canvas area
- use normal bubble phase for events instead of capture-phase events