### PR TITLE
Update eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,13 +17,13 @@ export default [
                 ...globals.browser,
                 ...globals.mocha,
                 ...globals.node,
-                'Ammo': false,
-                'earcut': false,
-                'opentype': false,
-                'pc': false,
-                'TWEEN': false,
-                'twgsl': false,
-                'webkitAudioContext': false
+                'Ammo': 'readonly',
+                'earcut': 'readonly',
+                'opentype': 'readonly',
+                'pc': 'readonly',
+                'TWEEN': 'readonly',
+                'twgsl': 'readonly',
+                'webkitAudioContext': 'readonly'
             }
         },
         rules: {


### PR DESCRIPTION
Removes the use of deprecated booleans in eslint config. See Tip at the end of ['readonly'](https://eslint.org/docs/latest/use/configure/language-options#using-configuration-files) docs.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
