### PR TITLE
#7004 Ensure outliner only adds enabled render components

### DIFF
--- a/src/extras/renderers/outline-renderer.js
+++ b/src/extras/renderers/outline-renderer.js
@@ -155,12 +155,16 @@ class OutlineRenderer {
 
         const renders = recursive ? entity.findComponents('render') : (entity.render ? [entity.render] : []);
         renders.forEach((render) => {
-            meshInstances.push(...render.meshInstances);
+            if (render.entity.enabled && render.enabled) {
+                meshInstances.push(...render.meshInstances);
+            }
         });
 
         const models = recursive ? entity.findComponents('model') : (entity.model ? [entity.model] : []);
         models.forEach((model) => {
-            meshInstances.push(...model.meshInstances);
+            if (model.entity.enabled && model.enabled) {
+                meshInstances.push(...model.meshInstances);
+            }
         });
 
         return meshInstances;


### PR DESCRIPTION
Fixes #7004 

Ensure only enabled rendercomponents have their meshcomponents added to the layer

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
