### PR TITLE
Improved missing texture uniform error handling

### DIFF
--- a/src/extras/render-passes/render-pass-camera-frame.js
+++ b/src/extras/render-passes/render-pass-camera-frame.js
@@ -25,7 +25,7 @@ class CameraFrameOptions {
 
     samples = 1;
 
-    sceneColorMap = true;
+    sceneColorMap = false;
 
     // skybox is the last layer rendered before the grab passes
     lastGrabLayerId = LAYERID_SKYBOX;
@@ -154,6 +154,7 @@ class RenderPassCameraFrame extends RenderPass {
         return options.ssaoType !== currentOptions.ssaoType ||
             options.ssaoBlurEnabled !== currentOptions.ssaoBlurEnabled ||
             options.taaEnabled !== currentOptions.taaEnabled ||
+            options.samples !== currentOptions.samples ||
             options.bloomEnabled !== currentOptions.bloomEnabled ||
             options.prepassEnabled !== currentOptions.prepassEnabled ||
             arraysNotEqual(options.formats, currentOptions.formats);

--- a/src/platform/graphics/built-in-textures.js
+++ b/src/platform/graphics/built-in-textures.js
@@ -7,7 +7,8 @@ const textureData = {
     white: [255, 255, 255, 255],
     gray: [128, 128, 128, 255],
     black: [0, 0, 0, 255],
-    normal: [128, 128, 255, 255]
+    normal: [128, 128, 255, 255],
+    pink: [255, 128, 255, 255]
 };
 
 // class used to hold LUT textures in the device cache

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -893,7 +893,7 @@ class ForwardRenderer extends Renderer {
 
                 // info about the next render action
                 const nextRenderAction = renderActions[i + 1];
-                const isNextLayerDepth = nextRenderAction ? nextRenderAction.layer.id === LAYERID_DEPTH : false;
+                const isNextLayerDepth = nextRenderAction ? (!nextRenderAction.useCameraPasses && nextRenderAction.layer.id === LAYERID_DEPTH) : false;
                 const isNextLayerGrabPass = isNextLayerDepth && (camera.renderSceneColorMap || camera.renderSceneDepthMap);
                 const nextNeedDirShadows = nextRenderAction ? (nextRenderAction.firstCameraUse && this.cameraDirShadowLights.has(nextRenderAction.camera.camera)) : false;
 


### PR DESCRIPTION
WebGPU does not support rendering with unassigned texture to a bind group .. this resulted in broken rendering and endless stream of errors. Engine now uses pink texture under the hood to provide some texture, and handles error reporting with more detail.