### PR TITLE
Do not allow gizmo rendering to use debug output

### DIFF
--- a/src/extras/gizmo/shape/shape.js
+++ b/src/extras/gizmo/shape/shape.js
@@ -296,6 +296,7 @@ class Shape {
         const material = new ShaderMaterial(shaderDesc);
         material.cull = this._cull;
         material.blendType = BLEND_NORMAL;
+        material.chunks.debugOutputPS = '';   // do not apply debug output shader code to gizmo
         material.update();
 
         const meshInstances = [];


### PR DESCRIPTION
- always renderi gizmos using standard output, and not debug output

old
<img width="550" alt="Screenshot 2024-10-07 at 10 39 19" src="https://github.com/user-attachments/assets/494df12c-3eed-4f34-a075-d0817b8abf68">

vs new
<img width="552" alt="Screenshot 2024-10-07 at 10 38 49" src="https://github.com/user-attachments/assets/18239b71-57bb-4985-83ae-8f9c5992c5a7">
