### PR TITLE
CameraFrame script, to expose a simple to use version for the engine and the Editor

### DIFF
--- a/examples/assets/scripts/misc/camera-frame.mjs
+++ b/examples/assets/scripts/misc/camera-frame.mjs
@@ -5,17 +5,16 @@ import {
     RenderingParams,
     CameraFrameOptions,
     RenderPassCameraFrame,
-    FOG_NONE, FOG_LINEAR, FOG_EXP, FOG_EXP2,
-    SSAOTYPE_NONE, SSAOTYPE_LIGHTING, SSAOTYPE_COMBINE,
-    PIXELFORMAT_RGBA8, PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F
+    FOG_NONE,
+    SSAOTYPE_NONE
 } from 'playcanvas';
 
-/** @enum {number} */
+/** @enum {string} */
 const FogType = {
-    OFF: 0,
-    LINEAR: 1,
-    EXP: 2,
-    EXP2: 3
+    NONE: 'none',      // FOG_NONE
+    LINEAR: 'linear',  // FOG_LINEAR
+    EXP: 'exp',        // FOG_EXP
+    EXP2: 'exp2'       // FOG_EXP2
 };
 
 /** @enum {number} */
@@ -28,23 +27,19 @@ const ToneMapping = {
     TONEMAP_NEUTRAL: 5
 };
 
-/** @enum {number} */
+/** @enum {string} */
 const SsaoType = {
-    NONE: 0,
-    LIGHTING: 1,
-    COMBINE: 2
+    NONE: 'none',           // SSAOTYPE_NONE
+    LIGHTING: 'lighting',   // SSAOTYPE_LIGHTING
+    COMBINE: 'combine'      // SSAOTYPE_COMBINE
 };
 
 /** @enum {number} */
 const RenderFormat = {
-    // RGBA8: PIXELFORMAT_RGBA8,
-    // RG11B10: PIXELFORMAT_111110F,
-    // RGBA16: PIXELFORMAT_RGBA16F,
-    // RGBA32: PIXELFORMAT_RGBA32F
-    RGBA8: 0,
-    RG11B10: 1,
-    RGBA16: 2,
-    RGBA32: 3
+    RGBA8: 7,       // PIXELFORMAT_RGBA8
+    RG11B10: 18,    // PIXELFORMAT_111110F
+    RGBA16: 12,     // PIXELFORMAT_RGBA16F
+    RGBA32: 14      // PIXELFORMAT_RGBA32F
 };
 
 /** @interface */
@@ -53,19 +48,19 @@ class Rendering {
      * @attribute
      * @type {RenderFormat}
      */
-    renderFormat = 1;
+    renderFormat = RenderFormat.RG11B10;
 
     /**
      * @attribute
      * @type {RenderFormat}
      */
-    renderFormatFallback0 = 2;
+    renderFormatFallback0 = RenderFormat.RGBA16;
 
     /**
      * @attribute
      * @type {RenderFormat}
      */
-    renderFormatFallback1 = 3;
+    renderFormatFallback1 = RenderFormat.RGBA32;
 
     /**
      * @attribute
@@ -91,7 +86,7 @@ class Rendering {
      * @attribute
      * @type {ToneMapping}
      */
-    toneMapping = 0; // ToneMapping.LINEAR;
+    toneMapping = ToneMapping.LINEAR;
 
     /**
      * @range [0, 1]
@@ -104,7 +99,7 @@ class Rendering {
      * @attribute
      * @type {FogType}
      */
-    fog = 0; // FogType.OFF;
+    fog = FogType.NONE;
 
     /**
      * @attribute
@@ -133,7 +128,7 @@ class Ssao {
      * @attribute
      * @type {SsaoType}
      */
-    type = 0; // SsaoType.NONE;
+    type = SsaoType.NONE;
 
     blurEnabled = true;
 
@@ -372,35 +367,6 @@ class CameraFrame extends Script {
         cameraComponent.jitter = 0;
     }
 
-    // remove this when the enum can be of a string type
-    getFogType(value) {
-        switch (value) {
-            case 1: return FOG_LINEAR;
-            case 2: return FOG_EXP;
-            case 3: return FOG_EXP2;
-        }
-        return FOG_NONE;
-    }
-
-    // remove this when the enum can be of a string type
-    getSsaoType(value) {
-        switch (value) {
-            case 1: return SSAOTYPE_LIGHTING;
-            case 2: return SSAOTYPE_COMBINE;
-        }
-        return SSAOTYPE_NONE;
-    }
-
-    // remove this when the enum can have numerical values assigned to it
-    getFormat(value) {
-        switch (value) {
-            case 1: return PIXELFORMAT_111110F;
-            case 2: return PIXELFORMAT_RGBA16F;
-            case 3: return PIXELFORMAT_RGBA32F;
-        }
-        return PIXELFORMAT_RGBA8;
-    }
-
     updateOptions() {
 
         const { options, rendering, bloom, taa, ssao } = this;
@@ -409,13 +375,9 @@ class CameraFrame extends Script {
         options.prepassEnabled = rendering.sceneDepthMap;
         options.bloomEnabled = bloom.enabled;
         options.taaEnabled = taa.enabled;
-        options.ssaoType = this.getSsaoType(ssao.type);
+        options.ssaoType = ssao.type;
         options.ssaoBlurEnabled = ssao.blurEnabled;
-        options.formats = [
-            this.getFormat(rendering.renderFormat),
-            this.getFormat(rendering.renderFormatFallback0),
-            this.getFormat(rendering.renderFormatFallback1)
-        ];
+        options.formats = [rendering.renderFormat, rendering.renderFormatFallback0, rendering.renderFormatFallback1];
     }
 
     postUpdate(dt) {
@@ -428,7 +390,7 @@ class CameraFrame extends Script {
         renderPassCamera.update(options);
 
         // renderingParams
-        renderingParams.fog = this.getFogType(rendering.fog);
+        renderingParams.fog = rendering.fog;
         if (renderingParams.fog !== FOG_NONE) {
             renderingParams.fogColor.copy(rendering.fogColor);
             renderingParams.fogStart = rendering.fogStart;

--- a/examples/assets/scripts/misc/camera-frame.mjs
+++ b/examples/assets/scripts/misc/camera-frame.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable jsdoc/check-tag-names */
+
 import {
     Script,
     Color,

--- a/examples/assets/scripts/misc/camera-frame.mjs
+++ b/examples/assets/scripts/misc/camera-frame.mjs
@@ -1,0 +1,486 @@
+import {
+    Script,
+    Color,
+    math,
+    RenderingParams,
+    CameraFrameOptions,
+    RenderPassCameraFrame,
+    FOG_NONE, FOG_LINEAR, FOG_EXP, FOG_EXP2,
+    SSAOTYPE_NONE, SSAOTYPE_LIGHTING, SSAOTYPE_COMBINE,
+    PIXELFORMAT_RGBA8, PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F
+} from 'playcanvas';
+
+/** @enum {number} */
+const FogType = {
+    OFF: 0,
+    LINEAR: 1,
+    EXP: 2,
+    EXP2: 3
+};
+
+/** @enum {number} */
+const ToneMapping = {
+    TONEMAP_LINEAR: 0,
+    TONEMAP_FILMIC: 1,
+    TONEMAP_HEJL: 2,
+    TONEMAP_ACES: 3,
+    TONEMAP_ACES2: 4,
+    TONEMAP_NEUTRAL: 5
+};
+
+/** @enum {number} */
+const SsaoType = {
+    NONE: 0,
+    LIGHTING: 1,
+    COMBINE: 2
+};
+
+/** @enum {number} */
+const RenderFormat = {
+    // RGBA8: PIXELFORMAT_RGBA8,
+    // RG11B10: PIXELFORMAT_111110F,
+    // RGBA16: PIXELFORMAT_RGBA16F,
+    // RGBA32: PIXELFORMAT_RGBA32F
+    RGBA8: 0,
+    RG11B10: 1,
+    RGBA16: 2,
+    RGBA32: 3
+};
+
+/** @interface */
+class Rendering {
+    /**
+     * @attribute
+     * @type {RenderFormat}
+     */
+    renderFormat = 1;
+
+    /**
+     * @attribute
+     * @type {RenderFormat}
+     */
+    renderFormatFallback0 = 2;
+
+    /**
+     * @attribute
+     * @type {RenderFormat}
+     */
+    renderFormatFallback1 = 3;
+
+    /**
+     * @attribute
+     * @range [0.1, 1]
+     * @precision 2
+     * @step 0.01
+     */
+    renderTargetScale = 1.0;
+
+    /**
+     * @attribute
+     * @range [1, 4]
+     * @precision 0
+     * @step 1
+     */
+    samples = 1;
+
+    sceneColorMap = false;
+
+    sceneDepthMap = false;
+
+    /**
+     * @attribute
+     * @type {ToneMapping}
+     */
+    toneMapping = 0; // ToneMapping.LINEAR;
+
+    /**
+     * @range [0, 1]
+     * @precision 3
+     * @step 0.001
+     */
+    sharpness = 0.0;
+
+    /**
+     * @attribute
+     * @type {FogType}
+     */
+    fog = 0; // FogType.OFF;
+
+    /**
+     * @attribute
+     */
+    fogColor = new Color(1, 1, 1, 1);
+
+    /**
+     * @attribute
+     */
+    fogStart = 0;
+
+    /**
+     * @attribute
+     */
+    fogEnd = 100;
+
+    /**
+     * @attribute
+     */
+    fogDensity = 0.01;
+}
+
+/** @interface */
+class Ssao {
+    /**
+     * @attribute
+     * @type {SsaoType}
+     */
+    type = 0; // SsaoType.NONE;
+
+    blurEnabled = true;
+
+    /**
+     * @range [0, 1]
+     * @precision 3
+     * @step 0.001
+     */
+    intensity = 0.5;
+
+    /**
+     * @range [0, 100]
+     * @precision 3
+     * @step 0.001
+     */
+    radius = 30;
+
+    /**
+     * @range [1, 64]
+     * @precision 0
+     * @step 1
+     */
+    samples = 12;
+
+    /**
+     * @range [0.1, 10]
+     * @precision 3
+     * @step 0.001
+     */
+    power = 6;
+
+    /**
+     * @range [1, 90]
+     * @precision 1
+     * @step 1
+     */
+    minAngle = 10;
+
+    /**
+     * @range [0.5, 1]
+     * @precision 3
+     * @step 0.001
+     */
+    scale = 1;
+}
+
+/** @interface */
+class Bloom {
+    enabled = false;
+
+    /**
+     * @range [0, 0.1]
+     * @precision 3
+     * @step 0.001
+     */
+    intensity = 0.01;
+
+    /**
+     * @attribute
+     * @range [0, 12]
+     * @precision 0
+     * @step 0
+     */
+    lastMipLevel = 1;
+}
+
+/** @interface */
+class Grading {
+    enabled = false;
+
+    /**
+     * @range [0, 3]
+     * @precision 3
+     * @step 0.001
+     */
+    brightness = 1;
+
+    /**
+     * @range [0.5, 1.5]
+     * @precision 3
+     * @step 0.001
+     */
+    contrast = 1;
+
+    /**
+     * @range [0, 2]
+     * @precision 3
+     * @step 0.001
+     */
+    saturation = 1;
+
+    /**
+     * @attribute
+     */
+    tint = new Color(1, 1, 1, 1);
+}
+
+/** @interface */
+class Vignette {
+    enabled = false;
+
+    /**
+     * @range [0, 1]
+     * @precision 3
+     * @step 0.001
+     */
+    intensity = 0.5;
+
+    /**
+     * @range [0, 3]
+     * @precision 3
+     * @step 0.001
+     */
+    inner = 0.5;
+
+    /**
+     * @range [0, 3]
+     * @precision 3
+     * @step 0.001
+     */
+    outer = 1;
+
+    /**
+     * @range [0.01, 10]
+     * @precision 3
+     * @step 0.001
+     */
+    curvature = 0.5;
+}
+
+/** @interface */
+class Fringing {
+    enabled = false;
+
+    /**
+     * @range [0, 100]
+     * @precision 1
+     * @step 0.1
+     */
+    intensity = 50;
+}
+
+/** @interface */
+class Taa {
+    enabled = false;
+
+    /**
+     * @range [0, 1]
+     * @precision 2
+     * @step 0.1
+     */
+    jitter = 1;
+}
+
+class CameraFrame extends Script {
+    /**
+     * @attribute
+     * @type {Rendering}
+     */
+    rendering = new Rendering();
+
+    /**
+     * @attribute
+     * @type {Ssao}
+     */
+    ssao = new Ssao();
+
+    /**
+     * @attribute
+     * @type {Bloom}
+     */
+    bloom = new Bloom();
+
+    /**
+     * @attribute
+     * @type {Grading}
+     */
+    grading = new Grading();
+
+    /**
+     * @attribute
+     * @type {Vignette}
+     */
+    vignette = new Vignette();
+
+    /**
+     * @attribute
+     * @type {Taa}
+     */
+    taa = new Taa();
+
+    /**
+     * @attribute
+     * @type {Fringing}
+     */
+    fringing = new Fringing();
+
+    options = new CameraFrameOptions();
+
+    renderingParams = new RenderingParams();
+
+    initialize() {
+
+        this.updateOptions();
+        this.createRenderPass();
+
+        this.on('enable', () => {
+            this.createRenderPass();
+        });
+
+        this.on('disable', () => {
+            this.destroyRenderPass();
+        });
+
+        this.on('destroy', () => {
+            this.destroyRenderPass();
+        });
+    }
+
+    createRenderPass() {
+        const cameraComponent = this.entity.camera;
+        cameraComponent.rendering = this.renderingParams;
+
+        this.renderPassCamera = new RenderPassCameraFrame(this.app, cameraComponent, this.options);
+        cameraComponent.renderPasses = [this.renderPassCamera];
+    }
+
+    destroyRenderPass() {
+        const cameraComponent = this.entity.camera;
+        cameraComponent.renderPasses?.forEach((renderPass) => {
+            renderPass.destroy();
+        });
+        cameraComponent.renderPasses = [];
+        cameraComponent.rendering = null;
+
+        cameraComponent.jitter = 0;
+    }
+
+    // remove this when the enum can be of a string type
+    getFogType(value) {
+        switch (value) {
+            case 1: return FOG_LINEAR;
+            case 2: return FOG_EXP;
+            case 3: return FOG_EXP2;
+        }
+        return FOG_NONE;
+    }
+
+    // remove this when the enum can be of a string type
+    getSsaoType(value) {
+        switch (value) {
+            case 1: return SSAOTYPE_LIGHTING;
+            case 2: return SSAOTYPE_COMBINE;
+        }
+        return SSAOTYPE_NONE;
+    }
+
+    // remove this when the enum can have numerical values assigned to it
+    getFormat(value) {
+        switch (value) {
+            case 1: return PIXELFORMAT_111110F;
+            case 2: return PIXELFORMAT_RGBA16F;
+            case 3: return PIXELFORMAT_RGBA32F;
+        }
+        return PIXELFORMAT_RGBA8;
+    }
+
+    updateOptions() {
+
+        const { options, rendering, bloom, taa, ssao } = this;
+        options.samples = rendering.samples;
+        options.sceneColorMap = rendering.sceneColorMap;
+        options.prepassEnabled = rendering.sceneDepthMap;
+        options.bloomEnabled = bloom.enabled;
+        options.taaEnabled = taa.enabled;
+        options.ssaoType = this.getSsaoType(ssao.type);
+        options.ssaoBlurEnabled = ssao.blurEnabled;
+        options.formats = [
+            this.getFormat(rendering.renderFormat),
+            this.getFormat(rendering.renderFormatFallback0),
+            this.getFormat(rendering.renderFormatFallback1)
+        ];
+    }
+
+    postUpdate(dt) {
+
+        const cameraComponent = this.entity.camera;
+        const { options, renderPassCamera, renderingParams, rendering, bloom, grading, vignette, fringing, taa, ssao } = this;
+
+        // options that can cause the passes to be re-created
+        this.updateOptions();
+        renderPassCamera.update(options);
+
+        // renderingParams
+        renderingParams.fog = this.getFogType(rendering.fog);
+        if (renderingParams.fog !== FOG_NONE) {
+            renderingParams.fogColor.copy(rendering.fogColor);
+            renderingParams.fogStart = rendering.fogStart;
+            renderingParams.fogEnd = rendering.fogEnd;
+            renderingParams.fogDensity = rendering.fogDensity;
+        }
+
+        // update parameters of individual render passes
+        const { composePass, bloomPass, ssaoPass } = renderPassCamera;
+
+        renderPassCamera.renderTargetScale = math.clamp(rendering.renderTargetScale, 0.1, 1);
+        composePass.toneMapping = rendering.toneMapping;
+        composePass.sharpness = rendering.sharpness;
+
+        if (options.bloomEnabled && bloomPass) {
+            composePass.bloomIntensity = bloom.intensity;
+            bloomPass.lastMipLevel = bloom.lastMipLevel;
+        }
+
+        if (options.ssaoType !== SSAOTYPE_NONE) {
+            ssaoPass.intensity = ssao.intensity;
+            ssaoPass.power = ssao.power;
+            ssaoPass.radius = ssao.radius;
+            ssaoPass.sampleCount = ssao.samples;
+            ssaoPass.minAngle = ssao.minAngle;
+            ssaoPass.scale = ssao.scale;
+        }
+
+        composePass.gradingEnabled = grading.enabled;
+        if (grading.enabled) {
+            composePass.gradingSaturation = grading.saturation;
+            composePass.gradingBrightness = grading.brightness;
+            composePass.gradingContrast = grading.contrast;
+            composePass.gradingTint = grading.tint;
+        }
+
+        composePass.vignetteEnabled = vignette.enabled;
+        if (vignette.enabled) {
+            composePass.vignetteInner = vignette.inner;
+            composePass.vignetteOuter = vignette.outer;
+            composePass.vignetteCurvature = vignette.curvature;
+            composePass.vignetteIntensity = vignette.intensity;
+        }
+
+        composePass.fringingEnabled = fringing.enabled;
+        if (fringing.enabled) {
+            composePass.fringingIntensity = fringing.intensity;
+        }
+
+        // enable camera jitter if taa is enabled
+        cameraComponent.jitter = taa.enabled ? taa.jitter : 0;
+    }
+}
+
+export { CameraFrame };

--- a/examples/assets/scripts/misc/camera-frame.mjs
+++ b/examples/assets/scripts/misc/camera-frame.mjs
@@ -21,12 +21,12 @@ const FogType = {
 
 /** @enum {number} */
 const ToneMapping = {
-    TONEMAP_LINEAR: 0,
-    TONEMAP_FILMIC: 1,
-    TONEMAP_HEJL: 2,
-    TONEMAP_ACES: 3,
-    TONEMAP_ACES2: 4,
-    TONEMAP_NEUTRAL: 5
+    LINEAR: 0,  // TONEMAP_LINEAR
+    FILMIC: 1,  // TONEMAP_FILMIC
+    HEJL: 2,    // TONEMAP_HEJL
+    ACES: 3,    // TONEMAP_ACES
+    ACES2: 4,   // TONEMAP_ACES2
+    NEUTRAL: 5  // TONEMAP_NEUTRAL
 };
 
 /** @enum {string} */

--- a/examples/src/examples/camera/first-person.example.mjs
+++ b/examples/src/examples/camera/first-person.example.mjs
@@ -141,7 +141,6 @@ app.systems.rigidbody?.gravity.set(0, -18, 0);
 
 const cameraEntity = new pc.Entity();
 cameraEntity.addComponent('camera', {
-    clearColor: new pc.Color().fromString('#DEF5FF'),
     farClip: 100,
     fov: 90
 });
@@ -150,6 +149,7 @@ cameraEntity.setLocalPosition(0, 0.5, 0);
 // ------ Custom render passes set up ------
 
 cameraEntity.addComponent('script');
+/** @type { CameraFrame } */
 const cameraFrame = cameraEntity.script.create(CameraFrame);
 
 cameraFrame.rendering.samples = 4;

--- a/examples/src/examples/camera/first-person.example.mjs
+++ b/examples/src/examples/camera/first-person.example.mjs
@@ -1,6 +1,8 @@
 // @config DESCRIPTION <div style='text-align:center'><div>(<b>WASD</b>) Move</div><div>(<b>Space</b>) Jump</div><div>(<b>Mouse</b>) Look</div></div>
 import * as pc from 'playcanvas';
-import { deviceType, rootPath } from 'examples/utils';
+import { deviceType, rootPath, fileImport } from 'examples/utils';
+
+const { CameraFrame } = await fileImport(rootPath + '/static/assets/scripts/misc/camera-frame.mjs');
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();
@@ -147,18 +149,14 @@ cameraEntity.setLocalPosition(0, 0.5, 0);
 
 // ------ Custom render passes set up ------
 
-const currentOptions = new pc.CameraFrameOptions();
-currentOptions.samples = 4;
-currentOptions.sceneColorMap = false;
-currentOptions.bloomEnabled = true;
+cameraEntity.addComponent('script');
+const cameraFrame = cameraEntity.script.create(CameraFrame);
 
-// and set up these rendering passes to be used by the camera, instead of its default rendering
-const renderPassCamera = new pc.RenderPassCameraFrame(app, cameraEntity.camera, currentOptions);
-cameraEntity.camera.renderPasses = [renderPassCamera];
+cameraFrame.rendering.samples = 4;
+cameraFrame.rendering.toneMapping = pc.TONEMAP_ACES2;
 
-const composePass = renderPassCamera.composePass;
-composePass.toneMapping = pc.TONEMAP_ACES2;
-composePass.bloomIntensity = 0.01;
+cameraFrame.bloom.enabled = true;
+cameraFrame.bloom.intensity = 0.01;
 
 // ------------------------------------------
 

--- a/examples/src/examples/graphics/ambient-occlusion.example.mjs
+++ b/examples/src/examples/graphics/ambient-occlusion.example.mjs
@@ -1,6 +1,7 @@
 import * as pc from 'playcanvas';
 import { data } from 'examples/observer';
-import { deviceType, rootPath } from 'examples/utils';
+import { deviceType, rootPath, fileImport } from 'examples/utils';
+const { CameraFrame } = await fileImport(rootPath + '/static/assets/scripts/misc/camera-frame.mjs');
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();
@@ -167,34 +168,22 @@ assetListLoader.load(() => {
 
     // ------ Custom render passes set up ------
 
-    const currentOptions = new pc.CameraFrameOptions();
-    currentOptions.samples = 4;
-    currentOptions.sceneColorMap = false;
-    currentOptions.ssaoType = pc.SSAOTYPE_LIGHTING;
-    currentOptions.ssaoBlurEnabled = true;
-
-    // and set up these rendering passes to be used by the camera, instead of its default rendering
-    const renderPassCamera = new pc.RenderPassCameraFrame(app, cameraEntity.camera, currentOptions);
-    cameraEntity.camera.renderPasses = [renderPassCamera];
+    // cameraEntity.addComponent('script');
+    /** @type { CameraFrame } */
+    const cameraFrame = cameraEntity.script.create(CameraFrame);
+    cameraFrame.rendering.samples = 4;
+    cameraFrame.rendering.toneMapping = pc.TONEMAP_NEUTRAL;
 
     const applySettings = () => {
 
-        // update current options and apply them
-        currentOptions.ssaoType = data.get('data.ssao.type');
-        currentOptions.ssaoBlurEnabled = data.get('data.ssao.blurEnabled');
-        renderPassCamera.update(currentOptions);
-
-        // apply options on the other passes
-        const ssaoPass = renderPassCamera.ssaoPass;
-        if (ssaoPass) {
-
-            ssaoPass.intensity = data.get('data.ssao.intensity');
-            ssaoPass.power = data.get('data.ssao.power');
-            ssaoPass.radius = data.get('data.ssao.radius');
-            ssaoPass.sampleCount = data.get('data.ssao.samples');
-            ssaoPass.minAngle = data.get('data.ssao.minAngle');
-            ssaoPass.scale = data.get('data.ssao.scale');
-        }
+        cameraFrame.ssao.type = data.get('data.ssao.type');
+        cameraFrame.ssao.blurEnabled = data.get('data.ssao.blurEnabled');
+        cameraFrame.ssao.intensity = data.get('data.ssao.intensity');
+        cameraFrame.ssao.power = data.get('data.ssao.power');
+        cameraFrame.ssao.radius = data.get('data.ssao.radius');
+        cameraFrame.ssao.samples = data.get('data.ssao.samples');
+        cameraFrame.ssao.minAngle = data.get('data.ssao.minAngle');
+        cameraFrame.ssao.scale = data.get('data.ssao.scale');
     };
 
     // apply UI changes

--- a/examples/src/examples/graphics/ambient-occlusion.example.mjs
+++ b/examples/src/examples/graphics/ambient-occlusion.example.mjs
@@ -168,7 +168,6 @@ assetListLoader.load(() => {
 
     // ------ Custom render passes set up ------
 
-    // cameraEntity.addComponent('script');
     /** @type { CameraFrame } */
     const cameraFrame = cameraEntity.script.create(CameraFrame);
     cameraFrame.rendering.samples = 4;

--- a/examples/src/examples/graphics/clustered-area-lights.example.mjs
+++ b/examples/src/examples/graphics/clustered-area-lights.example.mjs
@@ -218,7 +218,6 @@ assetListLoader.load(() => {
     camera.script.create('orbitCamera', {
         attributes: {
             inertiaFactor: 0.2,
-            inertiaFactor: 0,
             focusEntity: ground,
             distanceMax: 60,
             frameOnStart: false

--- a/examples/src/examples/graphics/post-processing.controls.mjs
+++ b/examples/src/examples/graphics/post-processing.controls.mjs
@@ -242,7 +242,7 @@ export function controls({ observer, ReactPCUI, React, jsx, fragment }) {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'data.taa.jitter' },
                     min: 0,
-                    max: 5,
+                    max: 1,
                     precision: 2
                 })
             )

--- a/examples/src/examples/graphics/taa.example.mjs
+++ b/examples/src/examples/graphics/taa.example.mjs
@@ -1,6 +1,7 @@
 import * as pc from 'playcanvas';
 import { data } from 'examples/observer';
-import { deviceType, rootPath } from 'examples/utils';
+import { deviceType, rootPath, fileImport } from 'examples/utils';
+const { CameraFrame } = await fileImport(rootPath + '/static/assets/scripts/misc/camera-frame.mjs');
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();
@@ -112,35 +113,20 @@ assetListLoader.load(() => {
 
     // ------ Custom render passes set up ------
 
-    const currentOptions = new pc.CameraFrameOptions();
-    currentOptions.sceneColorMap = false;
-    currentOptions.bloomEnabled = true;
-    currentOptions.taaEnabled = true;
-
-    // and set up these rendering passes to be used by the camera, instead of its default rendering
-    const renderPassCamera = new pc.RenderPassCameraFrame(app, cameraEntity.camera, currentOptions);
-    cameraEntity.camera.renderPasses = [renderPassCamera];
+    /** @type { CameraFrame } */
+    const cameraFrame = cameraEntity.script.create(CameraFrame);
+    cameraFrame.rendering.toneMapping = pc.TONEMAP_ACES;
+    cameraFrame.bloom.intensity = 0.02;
 
     // ------
 
     const applySettings = () => {
 
-        // update current options and apply them
-        currentOptions.taaEnabled = data.get('data.taa.enabled');
-        currentOptions.bloomEnabled = data.get('data.scene.bloom');
-        renderPassCamera.update(currentOptions);
-
-        // apply options on the other passes
-        const composePass = renderPassCamera.composePass;
-        composePass.sharpness = data.get('data.scene.sharpness');
-        composePass.bloomIntensity = 0.02;
-        composePass.toneMapping = pc.TONEMAP_ACES;
-
-        // taa - enable camera jitter if taa is enabled
-        cameraEntity.camera.jitter = currentOptions.taaEnabled ? data.get('data.taa.jitter') : 0;
-
-        // render target scale
-        renderPassCamera.renderTargetScale = data.get('data.scene.scale');
+        cameraFrame.bloom.enabled = data.get('data.scene.bloom');
+        cameraFrame.taa.enabled = data.get('data.taa.enabled');
+        cameraFrame.taa.jitter = data.get('data.taa.jitter');
+        cameraFrame.rendering.renderTargetScale = data.get('data.scene.scale');
+        cameraFrame.rendering.sharpness = data.get('data.scene.sharpness');
     };
 
     // apply UI changes
@@ -162,7 +148,7 @@ assetListLoader.load(() => {
             sharpness: 0.5
         },
         taa: {
-            enabled: currentOptions.taaEnabled,
+            enabled: true,
             jitter: 1
         }
     });

--- a/src/extras/render-passes/render-pass-camera-frame.js
+++ b/src/extras/render-passes/render-pass-camera-frame.js
@@ -185,7 +185,7 @@ class RenderPassCameraFrame extends RenderPass {
         const cameraComponent = this.cameraComponent;
         const targetRenderTarget = cameraComponent.renderTarget;
 
-        this.hdrFormat = device.getRenderableHdrFormat(options.formats) || PIXELFORMAT_RGBA8;
+        this.hdrFormat = device.getRenderableHdrFormat(options.formats, true, options.samples) || PIXELFORMAT_RGBA8;
 
         // camera renders in HDR mode (linear output, no tonemapping)
         if (!cameraComponent.rendering) {

--- a/src/extras/render-passes/render-pass-camera-frame.js
+++ b/src/extras/render-passes/render-pass-camera-frame.js
@@ -157,6 +157,7 @@ class RenderPassCameraFrame extends RenderPass {
             options.samples !== currentOptions.samples ||
             options.bloomEnabled !== currentOptions.bloomEnabled ||
             options.prepassEnabled !== currentOptions.prepassEnabled ||
+            options.sceneColorMap !== currentOptions.sceneColorMap ||
             arraysNotEqual(options.formats, currentOptions.formats);
     }
 

--- a/src/extras/render-passes/render-pass-camera-frame.js
+++ b/src/extras/render-passes/render-pass-camera-frame.js
@@ -113,10 +113,13 @@ class RenderPassCameraFrame extends RenderPass {
 
         this.prePass = null;
         this.scenePass = null;
+        this.scenePassTransparent = null;
+        this.colorGrabPass = null;
         this.composePass = null;
         this.bloomPass = null;
         this.ssaoPass = null;
         this.taaPass = null;
+        this.afterPass = null;
     }
 
     sanitizeOptions(options) {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -953,7 +953,8 @@ class CameraComponent extends Component {
 
     /**
      * Request the scene to generate a texture containing the scene color map. Note that this call
-     * is accumulative, and for each enable request, a disable request need to be called.
+     * is accumulative, and for each enable request, a disable request need to be called. Note that
+     * this setting is ignored when the {@link CameraComponent#renderPasses} is used.
      *
      * @param {boolean} enabled - True to request the generation, false to disable it.
      */
@@ -970,7 +971,8 @@ class CameraComponent extends Component {
 
     /**
      * Request the scene to generate a texture containing the scene depth map. Note that this call
-     * is accumulative, and for each enable request, a disable request need to be called.
+     * is accumulative, and for each enable request, a disable request need to be called. Note that
+     * this setting is ignored when the {@link CameraComponent#renderPasses} is used.
      *
      * @param {boolean} enabled - True to request the generation, false to disable it.
      */

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -927,10 +927,13 @@ class GraphicsDevice extends EventHandler {
      *
      * @param {boolean} [filterable] - If true, the format also needs to be filterable. Defaults to
      * true.
+     * @param {number} [samples] - The number of samples to check for. Some formats are not
+     * compatible with multi-sampling, for example {@link PIXELFORMAT_RGBA32F} on WebGPU platform.
+     * Defaults to 1.
      * @returns {number|undefined} The first supported renderable HDR format or undefined if none is
      * supported.
      */
-    getRenderableHdrFormat(formats = [PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F], filterable = true) {
+    getRenderableHdrFormat(formats = [PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F], filterable = true, samples = 1) {
         for (let i = 0; i < formats.length; i++) {
             const format = formats[i];
             switch (format) {
@@ -949,6 +952,12 @@ class GraphicsDevice extends EventHandler {
                     break;
 
                 case PIXELFORMAT_RGBA32F:
+                    
+                    // on WebGPU platform, RGBA32F is not compatible with multi-sampling
+                    if (this.isWebGPU && samples > 1) {
+                        continue;
+                    }
+
                     if (this.textureFloatRenderable && (!filterable || this.textureFloatFilterable)) {
                         return format;
                     }

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -952,7 +952,7 @@ class GraphicsDevice extends EventHandler {
                     break;
 
                 case PIXELFORMAT_RGBA32F:
-                    
+
                     // on WebGPU platform, RGBA32F is not compatible with multi-sampling
                     if (this.isWebGPU && samples > 1) {
                         continue;


### PR DESCRIPTION
- created a `CameraFrame.mjs` script that exposes `RenderPassCameraFrame` to the users in the simple to use way.
- this can be used by both the engine only code, as well as in the Editor which exposes it in the Inspector when the script is added on the Camera.
- updated engine examples to use it, instead of directly setting up the render pass, which has a more complicated direct API

I've create a script CamerFrame.mjs, which hooks up the render passes to an entity with the CameraComponent. This script will be a public API (for now anyways, later I might expose the render passes themselves for more advanced users) for how users can use this new tech. https://github.com/playcanvas/engine/pull/7011 I also updated few examples to use it.
@willeastcott - you were keen to review the public API here, please do it in this PR when you can. In general, this is what people will use from scripts:
```
    camera.addComponent('script');
    const cameraFrame = camera.script.create(CameraFrame);
    cameraFrame.rendering.samples = 4;
    cameraFrame.bloom.enabled = true;
    cameraFrame.bloom.intensity = 0.01;
    cameraFrame.rendering.toneMapping = pc.TONEMAP_NEUTRAL;
    cameraFrame.grading.enabled = true;
    cameraFrame.grading.brightness = 0.5;
```

<img width="501" alt="Screenshot 2024-10-08 at 12 55 17" src="https://github.com/user-attachments/assets/ef63f0b0-6446-48c5-a0fc-347239f14562">
<img width="499" alt="Screenshot 2024-10-08 at 12 55 27" src="https://github.com/user-attachments/assets/5af00ca4-a792-49cb-87ad-8a3ec81e0b15">
