### PR TITLE
Zero out setTimeout id

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -2090,6 +2090,8 @@ const makeTick = function (_app) {
         if (application._destroyRequested) {
             application.destroy();
         }
+
+        application.frameRequestId = null;
     };
 };
 


### PR DESCRIPTION
I have noticed that `cancelAnimationFrame` actually appears on performance captures in Chrome, but cancelling should be almost always unnecessary.

In this PR I nullify the timeout id at the end of the update loop so cancelling is skipped during the next invocation.

I can't think of negative impact or side effect of this change, can you @Maksims ?