### PR TITLE
Check xr policy

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -669,6 +669,14 @@ class XrManager extends EventHandler {
      * @private
      */
     _sessionSupportCheck(type) {
+        const featurePolicy = document?.featurePolicy;
+        if (featurePolicy) {
+            const allowed = featurePolicy.allowsFeature('xr-spatial-tracking');
+            if (!allowed) {
+                return;
+            }
+        }
+
         navigator.xr.isSessionSupported(type).then((available) => {
             if (this._available[type] === available) {
                 return;


### PR DESCRIPTION
Fixes #6692 

Checks if the WebXR API is allowed to be used before using it (`navigator.xr.isSessionSupported`).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
