### PR TITLE
Optimized the creation of CommandEncoders on WebGPU

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -858,7 +858,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
             const cb = commandEncoder.finish();
             DebugHelper.setLabel(cb, 'CommandBuffer-Shared');
-            
+
             this.addCommandBuffer(cb);
             this.commandEncoder = null;
         }

--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -123,8 +123,7 @@ class WebgpuMipmapRenderer {
         }
 
         // loop through each mip level and render the previous level's contents into it.
-        const commandEncoder = device.commandEncoder ?? wgpu.createCommandEncoder();
-        DebugHelper.setLabel(commandEncoder, 'MipmapRendererEncoder');
+        const commandEncoder = device.getCommandEncoder();
 
         DebugGraphics.pushGpuMarker(device, 'MIPMAP-RENDERER');
 
@@ -170,14 +169,6 @@ class WebgpuMipmapRenderer {
         }
 
         DebugGraphics.popGpuMarker(device);
-
-        // submit the encoded commands if we created the encoder
-        if (!device.commandEncoder) {
-
-            const cb = commandEncoder.finish();
-            DebugHelper.setLabel(cb, 'MipmapRenderer-CommandBuffer');
-            device.addCommandBuffer(cb);
-        }
 
         // clear invalidated state
         device.pipeline = null;

--- a/src/platform/graphics/webgpu/webgpu-query-set.js
+++ b/src/platform/graphics/webgpu/webgpu-query-set.js
@@ -68,8 +68,7 @@ class WebgpuQuerySet {
 
     resolve(count) {
         const device = this.device;
-        const commandEncoder = device.wgpu.createCommandEncoder();
-        DebugHelper.setLabel(commandEncoder, 'ResolveQuerySet-Encoder');
+        const commandEncoder = device.getCommandEncoder();
 
         // copy times to the gpu buffer
         commandEncoder.resolveQuerySet(this.querySet, 0, count, this.queryBuffer, 0);
@@ -79,10 +78,6 @@ class WebgpuQuerySet {
         this.activeStagingBuffer = activeStagingBuffer;
 
         commandEncoder.copyBufferToBuffer(this.queryBuffer, 0, activeStagingBuffer, 0, this.bytesPerSlot * count);
-
-        const cb = commandEncoder.finish();
-        DebugHelper.setLabel(cb, 'ResolveQuerySet');
-        device.addCommandBuffer(cb);
     }
 
     request(count, renderVersion) {

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -526,9 +526,6 @@ class WebgpuTexture {
         const stagingBuffer = device.createBufferImpl(BUFFERUSAGE_READ | BUFFERUSAGE_COPY_DST);
         stagingBuffer.allocate(device, size);
 
-        // use existing or create new encoder
-        const commandEncoder = device.commandEncoder ?? device.wgpu.createCommandEncoder();
-
         const src = {
             texture: this.gpuTexture,
             mipLevel: mipLevel,
@@ -548,15 +545,8 @@ class WebgpuTexture {
         };
 
         // copy the GPU texture to the staging buffer
+        const commandEncoder = device.getCommandEncoder();
         commandEncoder.copyTextureToBuffer(src, dst, copySize);
-
-        // if we created new encoder
-        if (!device.commandEncoder) {
-            DebugHelper.setLabel(commandEncoder, 'copyTextureToBuffer-Encoder');
-            const cb = commandEncoder.finish();
-            DebugHelper.setLabel(cb, 'copyTextureToBuffer-CommandBuffer');
-            device.addCommandBuffer(cb);
-        }
 
         // async read data from the staging buffer to a temporary array
         return device.readBuffer(stagingBuffer, size, null, immediate).then((temp) => {


### PR DESCRIPTION
The rendering on WebGPU used to create a new command encoder for each render pass, and also for other operations between the passes, like buffer upload / download, query resolves and similar.

Now this has been minimized to 2-3 a frame, depending on how the scheduling of dynamic buffer uploads needs to execute.

The hope is that this will minimize the gaps on the gpu between render passes, which this likely contributes to, at least on Apple HW. Follows this advice from Apple engineer: 

```
Each command encoder creates a MTLCommandBuffer and MTLCommandBuffer requires synchronization
back to the unified memory on Apple Silicon and iOS. So this is much much slower in general than using
a single MTLCommandBuffer (1 GPUCommandEncoder) and creating several render or compute passes.
```

This is the before capture, where the gaps can be observed. It seems the hea dof mini-browser is broken at the moment, and so I cannot capture after screenshot currently :(

Note especially the gaps between those tiny bloom blur passes, where the gaps are significantly larger than the passes themselves.
![image](https://github.com/user-attachments/assets/a54a89a9-75af-4c00-b0f7-f7a44f2feb26)
