### PR TITLE
Ammo pointer fix

### DIFF
--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -626,13 +626,13 @@ class CollisionComponent extends Component {
      * @returns {number|null} The shape's index in the child array of the compound shape.
      * @private
      */
-    _getCompoundChildShapeIndex(shape) {
+    getCompoundChildShapeIndex(shape) {
         const compound = this.data.shape;
         const shapes = compound.getNumChildShapes();
 
         for (let i = 0; i < shapes; i++) {
             const childShape = compound.getChildShape(i);
-            if (childShape.ptr === shape.ptr) {
+            if (Ammo.getPointer(childShape) === Ammo.getPointer(shape)) {
                 return i;
             }
         }

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -818,7 +818,7 @@ class CollisionComponentSystem extends ComponentSystem {
 
         if (entity.enabled && entity.collision.enabled && (entity._dirtyLocal || forceUpdate)) {
             const transform = this._getNodeTransform(entity, parentComponent.entity);
-            const idx = parentComponent._getCompoundChildShapeIndex(entity.collision.shape);
+            const idx = parentComponent.getCompoundChildShapeIndex(entity.collision.shape);
             if (idx === null) {
                 parentComponent.shape.addChildShape(transform, entity.collision.data.shape);
             } else {
@@ -836,7 +836,7 @@ class CollisionComponentSystem extends ComponentSystem {
         if (collision.shape.removeChildShape) {
             collision.shape.removeChildShape(shape);
         } else {
-            const ind = collision._getCompoundChildShapeIndex(shape);
+            const ind = collision.getCompoundChildShapeIndex(shape);
             if (ind !== null) {
                 collision.shape.removeChildShapeByIndex(ind);
             }


### PR DESCRIPTION
Fixes #7036 

Correct way to get a pointer in Emscripten now is via a `.getPointer(object)` method. Reading `.ptr` property is not, which can be `undefined`, which made the `undefined === undefined` test return the same first child shape.

Also removed the underscore from the class method, as it is used by another class.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
