### PR TITLE
Exposed Scene.sky properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -193,6 +193,9 @@ export { shaderChunks } from './scene/shader-lib/chunks/chunks.js';
 export { shaderChunksLightmapper } from './scene/shader-lib/chunks/chunks-lightmapper.js';
 export { ChunkBuilder } from './scene/shader-lib/chunk-builder.js';     // used by shed
 
+// SCENE / SKY
+export { Sky } from './scene/skybox/sky.js';
+
 // SCENE / SPLAT
 export { GSplatData } from './scene/gsplat/gsplat-data.js';
 export { GSplat } from './scene/gsplat/gsplat.js';

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -417,6 +417,9 @@ class Scene extends EventHandler {
         return this._layers;
     }
 
+    /**
+     * Gets the {@link Sky} that defines sky properties.
+     */
     get sky() {
         return this._sky;
     }

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -419,6 +419,8 @@ class Scene extends EventHandler {
 
     /**
      * Gets the {@link Sky} that defines sky properties.
+     *
+     * @type {Sky}
      */
     get sky() {
         return this._sky;

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -50,6 +50,7 @@ class Sky {
      * Constructs a new sky.
      *
      * @param {Scene} scene - The scene owning the sky.
+     * @ignore
      */
     constructor(scene) {
         this.device = scene.device;
@@ -76,9 +77,9 @@ class Sky {
      * The type of the sky. One of the SKYMESH_* constants. Defaults to {@link SKYTYPE_INFINITE}.
      * Can be:
      *
-     * {@link SKYTYPE_INFINITE}
-     * {@link SKYTYPE_BOX}
-     * {@link SKYTYPE_DOME}
+     * - {@link SKYTYPE_INFINITE}
+     * - {@link SKYTYPE_BOX}
+     * - {@link SKYTYPE_DOME}
      *
      * @type {string}
      */


### PR DESCRIPTION
Scene.sky should have been public, and this PR fixes it.

<img width="978" alt="Screenshot 2024-10-16 at 09 47 47" src="https://github.com/user-attachments/assets/c1ccd4c2-ee4f-454c-add1-eb9fcb11806a">

<img width="688" alt="Screenshot 2024-10-16 at 09 48 01" src="https://github.com/user-attachments/assets/62dcd28a-915e-462d-9250-2082970c0afe">
<img width="684" alt="Screenshot 2024-10-16 at 09 48 08" src="https://github.com/user-attachments/assets/34f7b1b2-d2b9-425c-b89b-fd36eba46c2a">
