### PR TITLE
Fix GLB parser index buffer initialization

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -767,7 +767,7 @@ const createMesh = (device, gltfMesh, accessors, bufferViews, vertexBufferDict, 
                     indices = new Uint16Array(indices);
                 }
 
-                const indexBuffer = new IndexBuffer(device, indexFormat, indices.length, BUFFER_STATIC, indices);
+                const indexBuffer = new IndexBuffer(device, indexFormat, indices.length, BUFFER_STATIC, indices.buffer);
                 mesh.indexBuffer[0] = indexBuffer;
                 mesh.primitive[0].count = indices.length;
             } else {


### PR DESCRIPTION
Fixes #5869 

Fixes a bug, where GLB parser passes a typed array instead of an array buffer to the index buffer constructor.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
