### PR TITLE
Gizmo disabled hover fix

### DIFF
--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -16,7 +16,7 @@ import { GIZMOSPACE_LOCAL, GIZMOSPACE_WORLD } from './constants.js';
  * @import { GraphNode } from '../../scene/graph-node.js'
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { MeshInstance } from '../../scene/mesh-instance.js'
- * @import { TriData } from './tri-data.js'
+ * @import { Shape } from './shape/shape.js'
  */
 
 // temporary variables
@@ -217,18 +217,11 @@ class Gizmo extends EventHandler {
     root;
 
     /**
-     * @typedef IntersectData
-     * @property {TriData[]} triData - The array of {@link TriData}.
-     * @property {GraphNode} parent - The mesh parent node.
-     * @property {MeshInstance[]} meshInstances - Array of mesh instances for rendering.
-     */
-
-    /**
-     * The intersection data object.
+     * The intersection shapes for the gizmo.
      *
-     * @type {IntersectData[]}
+     * @type {Shape[]}
      */
-    intersectData = [];
+    intersectShapes = [];
 
     /**
      * Creates a new gizmo layer and adds it to the scene.
@@ -466,9 +459,9 @@ class Gizmo extends EventHandler {
         const dir = end.clone().sub(start).normalize();
 
         const selection = [];
-        for (let i = 0; i < this.intersectData.length; i++) {
-            const { triData, parent, meshInstances } = this.intersectData[i];
-            const parentTM = parent.getWorldTransform();
+        for (let i = 0; i < this.intersectShapes.length; i++) {
+            const { triData, entity, meshInstances } = this.intersectShapes[i];
+            const parentTM = entity.getWorldTransform();
             for (let j = 0; j < triData.length; j++) {
                 const { tris, transform, priority } = triData[j];
 

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -461,6 +461,10 @@ class Gizmo extends EventHandler {
         const selection = [];
         for (let i = 0; i < this.intersectShapes.length; i++) {
             const shape = this.intersectShapes[i];
+            if (shape.disabled) {
+                continue;
+            }
+
             const parentTM = shape.entity.getWorldTransform();
             for (let j = 0; j < shape.triData.length; j++) {
                 const { tris, transform, priority } = shape.triData[j];

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -460,10 +460,10 @@ class Gizmo extends EventHandler {
 
         const selection = [];
         for (let i = 0; i < this.intersectShapes.length; i++) {
-            const { triData, entity, meshInstances } = this.intersectShapes[i];
-            const parentTM = entity.getWorldTransform();
-            for (let j = 0; j < triData.length; j++) {
-                const { tris, transform, priority } = triData[j];
+            const shape = this.intersectShapes[i];
+            const parentTM = shape.entity.getWorldTransform();
+            for (let j = 0; j < shape.triData.length; j++) {
+                const { tris, transform, priority } = shape.triData[j];
 
                 // combine node world transform with transform of tri relative to parent
                 const triWTM = tmpM1.copy(parentTM).mul(transform);
@@ -478,7 +478,7 @@ class Gizmo extends EventHandler {
                     if (tris[k].intersectsRay(ray, tmpV1)) {
                         selection.push({
                             dist: triWTM.transformPoint(tmpV1).sub(start).length(),
-                            meshInstances: meshInstances,
+                            meshInstances: shape.meshInstances,
                             priority: priority
                         });
                     }

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -676,11 +676,7 @@ class TransformGizmo extends Gizmo {
         for (const key in this._shapes) {
             const shape = this._shapes[key];
             this.root.addChild(shape.entity);
-            this.intersectData.push({
-                triData: shape.triData,
-                parent: shape.entity,
-                meshInstances: shape.meshInstances
-            });
+            this.intersectShapes.push(shape);
             for (let i = 0; i < shape.meshInstances.length; i++) {
                 this._shapeMap.set(shape.meshInstances[i], shape);
             }


### PR DESCRIPTION
Gizmo ignores triangles from shapes that are disabled correctly to stop drag interference

### API changes
- Removes `IntersectData` type