### PR TITLE
Gizmo material chunks shader fix

### DIFF
--- a/src/extras/gizmo/shape/shape.js
+++ b/src/extras/gizmo/shape/shape.js
@@ -301,7 +301,9 @@ class Shape {
         material.shader = shader;
         material.cull = this._cull;
         material.blendType = BLEND_NORMAL;
-        material.chunks.debugOutputPS = '';   // do not apply debug output shader code to gizmo
+        if (material.chunks) {
+            material.chunks.debugOutputPS = '';   // do not apply debug output shader code to gizmo
+        }
         material.update();
 
         const meshInstances = [];


### PR DESCRIPTION
Fixed issue listed in https://github.com/playcanvas/engine/pull/7009 regarding ensuring debug output is not used for gizmos