### PR TITLE
Gizmo features

### DIFF
--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -456,7 +456,7 @@ class Gizmo extends EventHandler {
     _getSelection(x, y) {
         const start = this._camera.entity.getPosition();
         const end = this._camera.screenToWorld(x, y, this._camera.farClip - this._camera.nearClip);
-        const dir = end.clone().sub(start).normalize();
+        const dir = tmpV1.copy(end).sub(start).normalize();
 
         const selection = [];
         for (let i = 0; i < this.intersectShapes.length; i++) {

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -461,7 +461,7 @@ class Gizmo extends EventHandler {
         const selection = [];
         for (let i = 0; i < this.intersectShapes.length; i++) {
             const shape = this.intersectShapes[i];
-            if (shape.disabled) {
+            if (shape.disabled || !shape.entity.enabled) {
                 continue;
             }
 

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -106,6 +106,13 @@ class ScaleGizmo extends TransformGizmo {
     snapIncrement = 1;
 
     /**
+     * Flips the planes to face the camera.
+     * 
+     * @type {boolean}
+     */
+    flipPlanes = true;
+
+    /**
      * Creates a new ScaleGizmo object.
      *
      * @param {CameraComponent} camera - The camera component.
@@ -137,6 +144,9 @@ class ScaleGizmo extends TransformGizmo {
         });
 
         this._app.on('update', () => {
+            if (!this.flipPlanes) {
+                return;
+            }
             this._planesLookAtCamera();
         });
     }

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -18,6 +18,9 @@ const tmpV1 = new Vec3();
 const tmpV2 = new Vec3();
 const tmpQ1 = new Quat();
 
+// constants
+const GLANCE_EPSILON = 0.98;
+
 /**
  * Scaling gizmo.
  *
@@ -144,9 +147,6 @@ class ScaleGizmo extends TransformGizmo {
         });
 
         this._app.on('update', () => {
-            if (!this.flipPlanes) {
-                return;
-            }
             this._planesLookAtCamera();
         });
     }
@@ -366,13 +366,22 @@ class ScaleGizmo extends TransformGizmo {
      */
     _planesLookAtCamera() {
         tmpV1.cross(this._camera.entity.forward, this.root.right);
-        this._shapes.yz.flipped = tmpV2.set(0, +(tmpV1.dot(this.root.forward) > 0), +(tmpV1.dot(this.root.up) > 0));
+        this._shapes.yz.entity.enabled = tmpV1.length() < GLANCE_EPSILON;
+        if (this.flipPlanes) {
+            this._shapes.yz.flipped = tmpV2.set(0, +(tmpV1.dot(this.root.forward) > 0), +(tmpV1.dot(this.root.up) > 0));
+        }
 
         tmpV1.cross(this._camera.entity.forward, this.root.forward);
-        this._shapes.xy.flipped = tmpV2.set(+(tmpV1.dot(this.root.up) > 0), +(tmpV1.dot(this.root.right) < 0), 0);
+        this._shapes.xy.entity.enabled = tmpV1.length() < GLANCE_EPSILON;
+        if (this.flipPlanes) {
+            this._shapes.xy.flipped = tmpV2.set(+(tmpV1.dot(this.root.up) > 0), +(tmpV1.dot(this.root.right) < 0), 0);
+        }
 
         tmpV1.cross(this._camera.entity.forward, this.root.up);
-        this._shapes.xz.flipped = tmpV2.set(+(tmpV1.dot(this.root.forward) < 0), 0, +(tmpV1.dot(this.root.right) < 0));
+        this._shapes.xz.entity.enabled = tmpV1.length() < GLANCE_EPSILON;
+        if (this.flipPlanes) {
+            this._shapes.xz.flipped = tmpV2.set(+(tmpV1.dot(this.root.forward) < 0), 0, +(tmpV1.dot(this.root.right) < 0));
+        }
     }
 
     /**

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -146,7 +146,7 @@ class ScaleGizmo extends TransformGizmo {
             this._nodeScales.clear();
         });
 
-        this._app.on('update', () => {
+        this._app.on('prerender', () => {
             this._planesLookAtCamera();
         });
     }

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -135,6 +135,10 @@ class ScaleGizmo extends TransformGizmo {
         this.on(TransformGizmo.EVENT_NODESDETACH, () => {
             this._nodeScales.clear();
         });
+
+        this._app.on('update', () => {
+            this._planesLookAtCamera();
+        });
     }
 
     set coordSpace(value) {
@@ -345,6 +349,20 @@ class ScaleGizmo extends TransformGizmo {
         this._shapes.yz[prop] = value;
         this._shapes.xz[prop] = value;
         this._shapes.xy[prop] = value;
+    }
+
+    /**
+     * @private
+     */
+    _planesLookAtCamera() {
+        tmpV1.cross(this._camera.entity.forward, this.root.right);
+        this._shapes.yz.flipped = tmpV2.set(0, +(tmpV1.dot(this.root.forward) > 0), +(tmpV1.dot(this.root.up) > 0));
+
+        tmpV1.cross(this._camera.entity.forward, this.root.forward);
+        this._shapes.xy.flipped = tmpV2.set(+(tmpV1.dot(this.root.up) > 0), +(tmpV1.dot(this.root.right) < 0), 0);
+
+        tmpV1.cross(this._camera.entity.forward, this.root.up);
+        this._shapes.xz.flipped = tmpV2.set(+(tmpV1.dot(this.root.forward) < 0), 0, +(tmpV1.dot(this.root.right) < 0));
     }
 
     /**

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -120,7 +120,7 @@ class ScaleGizmo extends TransformGizmo {
      *
      * @type {Vec3}
      */
-    lowerScaleBound = new Vec3(-Infinity, -Infinity, -Infinity);
+    lowerBoundScale = new Vec3(-Infinity, -Infinity, -Infinity);
 
     /**
      * Creates a new ScaleGizmo object.
@@ -412,7 +412,7 @@ class ScaleGizmo extends TransformGizmo {
             if (!scale) {
                 continue;
             }
-            node.setLocalScale(tmpV1.copy(scale).mul(pointDelta).max(this.lowerScaleBound));
+            node.setLocalScale(tmpV1.copy(scale).mul(pointDelta).max(this.lowerBoundScale));
         }
     }
 

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -116,6 +116,13 @@ class ScaleGizmo extends TransformGizmo {
     flipPlanes = true;
 
     /**
+     * The lower bound for scaling.
+     *
+     * @type {Vec3}
+     */
+    lowerScaleBound = new Vec3(-Infinity, -Infinity, -Infinity);
+
+    /**
      * Creates a new ScaleGizmo object.
      *
      * @param {CameraComponent} camera - The camera component.
@@ -405,7 +412,7 @@ class ScaleGizmo extends TransformGizmo {
             if (!scale) {
                 continue;
             }
-            node.setLocalScale(scale.clone().mul(pointDelta));
+            node.setLocalScale(tmpV1.copy(scale).mul(pointDelta).max(this.lowerScaleBound));
         }
     }
 

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -110,7 +110,7 @@ class ScaleGizmo extends TransformGizmo {
 
     /**
      * Flips the planes to face the camera.
-     * 
+     *
      * @type {boolean}
      */
     flipPlanes = true;

--- a/src/extras/gizmo/shape/plane-shape.js
+++ b/src/extras/gizmo/shape/plane-shape.js
@@ -47,9 +47,8 @@ class PlaneShape extends Shape {
         if (this._flipped.distance(value) < UPDATE_EPSILON) {
             return;
         }
-
         this._flipped.copy(value);
-        this._updateTransform();
+        this.entity.setLocalPosition(this._getPosition());
     }
 
     get flipped() {

--- a/src/extras/gizmo/shape/plane-shape.js
+++ b/src/extras/gizmo/shape/plane-shape.js
@@ -4,6 +4,8 @@ import { PlaneGeometry } from '../../../scene/geometry/plane-geometry.js';
 import { TriData } from '../tri-data.js';
 import { Shape } from './shape.js';
 
+const UPDATE_EPSILON = 1e-6;
+
 class PlaneShape extends Shape {
     _cull = CULLFACE_NONE;
 
@@ -42,6 +44,10 @@ class PlaneShape extends Shape {
     }
 
     set flipped(value) {
+        if (this._flipped.distance(value) < UPDATE_EPSILON) {
+            return;
+        }
+
         this._flipped.copy(value);
         this._updateTransform();
     }

--- a/src/extras/gizmo/shape/plane-shape.js
+++ b/src/extras/gizmo/shape/plane-shape.js
@@ -11,6 +11,8 @@ class PlaneShape extends Shape {
 
     _gap = 0.1;
 
+    _flipped = new Vec3();
+
     constructor(device, options = {}) {
         super(device, options);
 
@@ -19,21 +21,6 @@ class PlaneShape extends Shape {
         ];
 
         this._createPlane();
-    }
-
-    _getPosition() {
-        const offset = this._size / 2 + this._gap;
-        const position = new Vec3(offset, offset, offset);
-        position[this.axis] = 0;
-        return position;
-    }
-
-    _createPlane() {
-        this._createRoot('plane');
-        this._updateTransform();
-
-        // plane
-        this._addRenderMesh(this.entity, 'plane', this._shading);
     }
 
     set size(value) {
@@ -52,6 +39,34 @@ class PlaneShape extends Shape {
 
     get gap() {
         return this._gap;
+    }
+
+    set flipped(value) {
+        this._flipped.copy(value);
+        this._updateTransform();
+    }
+
+    get flipped() {
+        return this._flipped;
+    }
+
+    _getPosition() {
+        const offset = this._size / 2 + this._gap;
+        const position = new Vec3(
+            this._flipped.x ? -offset : offset,
+            this._flipped.y ? -offset : offset,
+            this._flipped.z ? -offset : offset
+        );
+        position[this.axis] = 0;
+        return position;
+    }
+
+    _createPlane() {
+        this._createRoot('plane');
+        this._updateTransform();
+
+        // plane
+        this._addRenderMesh(this.entity, 'plane', this._shading);
     }
 
     _updateTransform() {

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -24,6 +24,9 @@ const tmpV1 = new Vec3();
 const tmpV2 = new Vec3();
 const tmpQ1 = new Quat();
 
+// constants
+const GLANCE_EPSILON = 0.98;
+
 /**
  * Translation gizmo.
  *
@@ -148,9 +151,6 @@ class TranslateGizmo extends TransformGizmo {
         });
 
         this._app.on('update', () => {
-            if (!this.flipPlanes) {
-                return;
-            }
             this._planesLookAtCamera();
         });
     }
@@ -362,13 +362,22 @@ class TranslateGizmo extends TransformGizmo {
      */
     _planesLookAtCamera() {
         tmpV1.cross(this._camera.entity.forward, this.root.right);
-        this._shapes.yz.flipped = tmpV2.set(0, +(tmpV1.dot(this.root.forward) > 0), +(tmpV1.dot(this.root.up) > 0));
+        this._shapes.yz.entity.enabled = tmpV1.length() < GLANCE_EPSILON;
+        if (this.flipPlanes) {
+            this._shapes.yz.flipped = tmpV2.set(0, +(tmpV1.dot(this.root.forward) > 0), +(tmpV1.dot(this.root.up) > 0));
+        }
 
         tmpV1.cross(this._camera.entity.forward, this.root.forward);
-        this._shapes.xy.flipped = tmpV2.set(+(tmpV1.dot(this.root.up) > 0), +(tmpV1.dot(this.root.right) < 0), 0);
+        this._shapes.xy.entity.enabled = tmpV1.length() < GLANCE_EPSILON;
+        if (this.flipPlanes) {
+            this._shapes.xy.flipped = tmpV2.set(+(tmpV1.dot(this.root.up) > 0), +(tmpV1.dot(this.root.right) < 0), 0);
+        }
 
         tmpV1.cross(this._camera.entity.forward, this.root.up);
-        this._shapes.xz.flipped = tmpV2.set(+(tmpV1.dot(this.root.forward) < 0), 0, +(tmpV1.dot(this.root.right) < 0));
+        this._shapes.xz.entity.enabled = tmpV1.length() < GLANCE_EPSILON;
+        if (this.flipPlanes) {
+            this._shapes.xz.flipped = tmpV2.set(+(tmpV1.dot(this.root.forward) < 0), 0, +(tmpV1.dot(this.root.right) < 0));
+        }
     }
 
     /**

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -411,13 +411,13 @@ class TranslateGizmo extends TransformGizmo {
                 tmpV2.z = 1 / tmpV2.z;
                 tmpQ1.copy(node.getLocalRotation()).transformVector(tmpV1, tmpV1);
                 tmpV1.mul(tmpV2);
-                node.setLocalPosition(pos.clone().add(tmpV1));
+                node.setLocalPosition(tmpV1.add(pos));
             } else {
                 const pos = this._nodePositions.get(node);
                 if (!pos) {
                     continue;
                 }
-                node.setPosition(pos.clone().add(pointDelta));
+                node.setPosition(tmpV1.copy(pointDelta).add(pos));
             }
         }
 

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -141,14 +141,7 @@ class TranslateGizmo extends TransformGizmo {
         });
 
         this._app.on('update', () => {
-            tmpV1.cross(this._camera.entity.forward, this.root.right);
-            this._shapes.yz.flipped = tmpV2.set(0, +(tmpV1.z < 0), +(tmpV1.y > 0));
-
-            tmpV1.cross(tmpV2.copy(this._camera.entity.forward).mulScalar(-1), this.root.forward);
-            this._shapes.xy.flipped = tmpV2.set(+(tmpV1.y < 0), +(tmpV1.x > 0), 0);
-
-            tmpV1.cross(this._camera.entity.right, this.root.up);
-            this._shapes.xz.flipped = tmpV2.set(+(tmpV1.x < 0), 0, +(tmpV1.z < 0));
+            this._planesLookAtCamera();
         });
     }
 
@@ -352,6 +345,20 @@ class TranslateGizmo extends TransformGizmo {
         this._shapes.yz[prop] = value;
         this._shapes.xz[prop] = value;
         this._shapes.xy[prop] = value;
+    }
+
+    /**
+     * @private
+     */
+    _planesLookAtCamera() {
+        tmpV1.cross(this._camera.entity.forward, this.root.right);
+        this._shapes.yz.flipped = tmpV2.set(0, +(tmpV1.dot(this.root.forward) > 0), +(tmpV1.dot(this.root.up) > 0));
+
+        tmpV1.cross(this._camera.entity.forward, this.root.forward);
+        this._shapes.xy.flipped = tmpV2.set(+(tmpV1.dot(this.root.up) > 0), +(tmpV1.dot(this.root.right) < 0), 0);
+
+        tmpV1.cross(this._camera.entity.forward, this.root.up);
+        this._shapes.xz.flipped = tmpV2.set(+(tmpV1.dot(this.root.forward) < 0), 0, +(tmpV1.dot(this.root.right) < 0));
     }
 
     /**

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -139,6 +139,17 @@ class TranslateGizmo extends TransformGizmo {
             this._nodeLocalPositions.clear();
             this._nodePositions.clear();
         });
+
+        this._app.on('update', () => {
+            tmpV1.cross(this._camera.entity.forward, this.root.right);
+            this._shapes.yz.flipped = tmpV2.set(0, +(tmpV1.z < 0), +(tmpV1.y > 0));
+
+            tmpV1.cross(tmpV2.copy(this._camera.entity.forward).mulScalar(-1), this.root.forward);
+            this._shapes.xy.flipped = tmpV2.set(+(tmpV1.y < 0), +(tmpV1.x > 0), 0);
+
+            tmpV1.cross(this._camera.entity.right, this.root.up);
+            this._shapes.xz.flipped = tmpV2.set(+(tmpV1.x < 0), 0, +(tmpV1.z < 0));
+        });
     }
 
     /**

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -150,7 +150,7 @@ class TranslateGizmo extends TransformGizmo {
             this._nodePositions.clear();
         });
 
-        this._app.on('update', () => {
+        this._app.on('prerender', () => {
             this._planesLookAtCamera();
         });
     }

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -110,6 +110,13 @@ class TranslateGizmo extends TransformGizmo {
     snapIncrement = 1;
 
     /**
+     * Flips the planes to face the camera.
+     * 
+     * @type {boolean}
+     */
+    flipPlanes = true;
+
+    /**
      * Creates a new TranslateGizmo object.
      *
      * @param {CameraComponent} camera - The camera component.
@@ -141,6 +148,9 @@ class TranslateGizmo extends TransformGizmo {
         });
 
         this._app.on('update', () => {
+            if (!this.flipPlanes) {
+                return;
+            }
             this._planesLookAtCamera();
         });
     }

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -114,7 +114,7 @@ class TranslateGizmo extends TransformGizmo {
 
     /**
      * Flips the planes to face the camera.
-     * 
+     *
      * @type {boolean}
      */
     flipPlanes = true;


### PR DESCRIPTION
Fixes #6851

- The planes for translate and scale gizmos will now orient themselves to be nearest to the camera for easier access
- The planes are hidden at glancing angles
- Added option to set lower bound scale `lowerBoundScale: Vec3 = new Vec3(-Infinity, -Infinity, -Infinity)`
- Removed unnecessary vec cloning

### API Changes
- Adds new property to enable flipping planes `flipPlanes: boolean = true`

### Preview
**Plane orientation**
![image](https://github.com/user-attachments/assets/f5531c6f-9f0f-401b-b965-b3e85cf1d506)
![image](https://github.com/user-attachments/assets/9a3dc8fc-e678-417b-8718-7d7c7a0e0b09)

**Plane hiding**
![image](https://github.com/user-attachments/assets/12bec4e4-fb7e-4c19-9ce7-c3d7f85a5971)


