### PR TITLE
Rendering to a single mip level of RenderTarget (WebGPU only)

### DIFF
--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -51,7 +51,7 @@ class ColorAttachmentOps {
      *
      * @type {boolean}
      */
-    mipmaps = false;
+    genMipmaps = false;
 }
 
 class DepthStencilAttachmentOps {
@@ -315,8 +315,8 @@ class RenderPass {
             }
 
             // if render target needs mipmaps
-            if (this.renderTarget?._colorBuffers?.[i].mipmaps) {
-                colorOps.mipmaps = true;
+            if (this.renderTarget?.mipmaps && this.renderTarget?._colorBuffers?.[i].mipmaps) {
+                colorOps.genMipmaps = true;
             }
         }
     }
@@ -458,12 +458,14 @@ class RenderPass {
             const numColor = rt?._colorBuffers?.length ?? (isBackBuffer ? 1 : 0);
             const hasDepth = rt?.depth;
             const hasStencil = rt?.stencil;
+            const mipLevel = rt?.mipLevel;
             const rtInfo = !rt ? '' : ` RT: ${(rt ? rt.name : 'NULL')} ` +
                 `${numColor > 0 ? `[Color${numColor > 1 ? ` x ${numColor}` : ''}]` : ''}` +
                 `${hasDepth ? '[Depth]' : ''}` +
                 `${hasStencil ? '[Stencil]' : ''}` +
                 ` ${rt.width} x ${rt.height}` +
-                `${(this.samples > 0 ? ` samples: ${this.samples}` : '')}`;
+                `${(this.samples > 0 ? ` samples: ${this.samples}` : '')}` +
+                `${mipLevel > 0 ? ` mipLevel: ${mipLevel}` : ''}`;
 
             const indexString = this._skipStart ? '++' : index.toString().padEnd(2, ' ');
             Debug.trace(TRACEID_RENDER_PASS,
@@ -478,7 +480,7 @@ class RenderPass {
                             `${colorOps.clear ? 'clear' : 'load'}->` +
                             `${colorOps.store ? 'store' : 'discard'} ` +
                             `${colorOps.resolve ? 'resolve ' : ''}` +
-                            `${colorOps.mipmaps ? 'mipmaps ' : ''}` +
+                            `${colorOps.genMipmaps ? 'mipmaps ' : ''}` +
                             ` [format: ${colorFormat}]`);
             }
 

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -82,7 +82,7 @@ class RenderTarget {
     _mipLevel;
 
     /**
-     * True if the mipmaps should b automatically generated for the color buffer(s) if it contains
+     * True if the mipmaps should be automatically generated for the color buffer(s) if it contains
      * a mip chain.
      *
      * @type {boolean}

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -327,7 +327,7 @@ class RenderTarget {
     resize(width, height) {
 
         if (this.mipLevel > 0) {
-            Debug.warn(`Only render target rendering to mipLevel 0 can be resized, ignoring.`, this);
+            Debug.warn('Only render target rendering to mipLevel 0 can be resized, ignoring.', this);
             return;
         }
 

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -3,6 +3,7 @@ import { TRACEID_RENDER_TARGET_ALLOC } from '../../core/constants.js';
 import { PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_R32F, isSrgbPixelFormat } from './constants.js';
 import { DebugGraphics } from './debug-graphics.js';
 import { GraphicsDevice } from './graphics-device.js';
+import { TextureUtils } from './texture-utils.js';
 
 /**
  * @import { Texture } from './texture.js'
@@ -74,6 +75,33 @@ class RenderTarget {
      */
     _face;
 
+    /**
+     * @type {number}
+     * @private
+     */
+    _mipLevel;
+
+    /**
+     * True if the mipmaps should b automatically generated for the color buffer(s) if it contains
+     * a mip chain.
+     *
+     * @type {boolean}
+     * @private
+     */
+    _mipmaps;
+
+    /**
+     * @type {number}
+     * @private
+     */
+    _width;
+
+    /**
+     * @type {number}
+     * @private
+     */
+    _height;
+
     /** @type {boolean} */
     flipY;
 
@@ -93,6 +121,9 @@ class RenderTarget {
      * depth/stencil surface (WebGL2 only). If set, the 'depth' and 'stencil' properties are
      * ignored. Texture must have {@link PIXELFORMAT_DEPTH} or {@link PIXELFORMAT_DEPTHSTENCIL}
      * format.
+     * @param {number} [options.mipLevel] - If set to a number greater than 0, the render target
+     * will render to the specified mip level of the color buffer. Defaults to 0. Currently only
+     * supported on WebGPU.
      * @param {number} [options.face] - If the colorBuffer parameter is a cubemap, use this option
      * to specify the face of the cubemap to render to. Can be:
      *
@@ -210,6 +241,19 @@ class RenderTarget {
         // render image flipped in Y
         this.flipY = options.flipY ?? false;
 
+        this._mipLevel = options.mipLevel ?? 0;
+        if (this._mipLevel > 0 && this._depth) {
+            Debug.error(`Rendering to a mipLevel is not supported when render target uses a depth buffer. Ignoring mipLevel ${this._mipLevel} for render target ${this.name}`, {
+                renderTarget: this,
+                options
+            });
+            this._mipLevel = 0;
+        }
+
+        // if we render to a specific mipmap (even 0), do not generate mipmaps
+        this._mipmaps = options.mipLevel === undefined;
+
+        this.updateDimensions();
         this.validateMrt();
 
         // device specific implementation
@@ -282,6 +326,11 @@ class RenderTarget {
      */
     resize(width, height) {
 
+        if (this.mipLevel > 0) {
+            Debug.warn(`Only render target rendering to mipLevel 0 can be resized, ignoring.`, this);
+            return;
+        }
+
         if (this.width !== width || this.height !== height) {
 
             // release existing
@@ -300,6 +349,8 @@ class RenderTarget {
             // initialize again
             this.validateMrt();
             this.impl = device.createRenderTargetImpl(this);
+
+            this.updateDimensions();
         }
     }
 
@@ -474,12 +525,31 @@ class RenderTarget {
     }
 
     /**
+     * Mip level of the render target.
+     *
+     * @type {number}
+     */
+    get mipLevel() {
+        return this._mipLevel;
+    }
+
+    /**
+     * True if the mipmaps are automatically generated for the color buffer(s) if it contains
+     * a mip chain.
+     *
+     * @type {boolean}
+     */
+    get mipmaps() {
+        return this._mipmaps;
+    }
+
+    /**
      * Width of the render target in pixels.
      *
      * @type {number}
      */
     get width() {
-        return this._colorBuffer?.width || this._depthBuffer?.width || this._device.width;
+        return this._width ?? this._device.width;
     }
 
     /**
@@ -488,7 +558,17 @@ class RenderTarget {
      * @type {number}
      */
     get height() {
-        return this._colorBuffer?.height || this._depthBuffer?.height || this._device.height;
+        return this._height ?? this._device.height;
+    }
+
+    updateDimensions() {
+        this._width = this._colorBuffer?.width ?? this._depthBuffer?.width;
+        this._height = this._colorBuffer?.height ?? this._depthBuffer?.height;
+
+        if (this._mipLevel > 0 && this._width && this._height) {
+            this._width = TextureUtils.calcLevelDimension(this._width, this._mipLevel);
+            this._height = TextureUtils.calcLevelDimension(this._height, this._mipLevel);
+        }
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1270,7 +1270,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             // generate mipmaps
             for (let i = 0; i < colorBufferCount; i++) {
                 const colorOps = renderPass.colorArrayOps[i];
-                if (colorOps.mipmaps) {
+                if (colorOps.genMipmaps) {
                     const colorBuffer = target._colorBuffers[i];
                     if (colorBuffer && colorBuffer.impl._glTexture && colorBuffer.mipmaps) {
 

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -175,8 +175,6 @@ class WebglRenderTarget {
                         target.mipLevel
                     );
 
-                    console.log(target.name, " level ", target.mipLevel);
-
                     buffers.push(attachmentBaseConstant + i);
                 }
             }

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -172,8 +172,10 @@ class WebglRenderTarget {
                         attachmentBaseConstant + i,
                         colorBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
                         colorBuffer.impl._glTexture,
-                        0
+                        target.mipLevel
                     );
+
+                    console.log(target.name, " level ", target.mipLevel);
 
                     buffers.push(attachmentBaseConstant + i);
                 }
@@ -198,7 +200,7 @@ class WebglRenderTarget {
                     // Attach
                     gl.framebufferTexture2D(gl.FRAMEBUFFER, attachmentPoint,
                         depthBuffer._cubemap ? gl.TEXTURE_CUBE_MAP_POSITIVE_X + target._face : gl.TEXTURE_2D,
-                        target._depthBuffer.impl._glTexture, 0);
+                        target._depthBuffer.impl._glTexture, target.mipLevel);
 
                 } else {
                     // --- Init a new depth/stencil buffer (optional) ---

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -774,7 +774,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // generate mipmaps using the same command buffer encoder
         for (let i = 0; i < renderPass.colorArrayOps.length; i++) {
             const colorOps = renderPass.colorArrayOps[i];
-            if (colorOps.mipmaps) {
+            if (colorOps.genMipmaps) {
                 this.mipmapRenderer.generate(renderPass.renderTarget._colorBuffers[i].impl);
             }
         }

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -404,14 +404,14 @@ class WebgpuRenderTarget {
         /** @type {GPURenderPassColorAttachment} */
         const colorAttachment = {};
 
-        const { samples, width, height } = renderTarget;
+        const { samples, width, height, mipLevel } = renderTarget;
         const colorBuffer = renderTarget.getColorBuffer(index);
 
         // view used to write to the color buffer (either by rendering to it, or resolving to it)
         let colorView = null;
         if (colorBuffer) {
 
-            // render to top mip level in case of mip-mapped buffer
+            // render to a single mip level
             const mipLevelCount = 1;
 
             // cubemap face view - face is a single 2d array layer in order [+X, -X, +Y, -Y, +Z, -Z]
@@ -420,11 +420,13 @@ class WebgpuRenderTarget {
                     dimension: '2d',
                     baseArrayLayer: renderTarget.face,
                     arrayLayerCount: 1,
-                    mipLevelCount
+                    mipLevelCount,
+                    baseMipLevel: mipLevel
                 });
             } else {
                 colorView = colorBuffer.impl.createView({
-                    mipLevelCount
+                    mipLevelCount,
+                    baseMipLevel: mipLevel
                 });
             }
         }


### PR DESCRIPTION
- added support for rendering to a mipLevel of a texture
- due to some complications on WebGL (could not get it to work), this is currently supported on WebGPU only
- changes to the way RT evaluates its width and height to take this into account, and return size of a rendered mip level to handle viewport set up for it

test screenshot - rendering to mipLevel 1 of the render target, the others are untouched (black)
![Screenshot 2024-10-21 at 12 25 54](https://github.com/user-attachments/assets/ea873da9-a721-4b07-8ff6-27bbc1cd350f)
