### PR TITLE
Gizmo orthographic fix

### DIFF
--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -454,7 +454,7 @@ class Gizmo extends EventHandler {
      * @private
      */
     _getSelection(x, y) {
-        const start = this._camera.entity.getPosition();
+        const start = this._camera.screenToWorld(x, y, 0);
         const end = this._camera.screenToWorld(x, y, this._camera.farClip - this._camera.nearClip);
         const dir = tmpV1.copy(end).sub(start).normalize();
 


### PR DESCRIPTION
Revert start selection point to use z = 0 for correct ray position for orthographic