### PR TITLE
Compressed ply orientation fix

### DIFF
--- a/src/framework/parsers/gsplat-resource.js
+++ b/src/framework/parsers/gsplat-resource.js
@@ -68,9 +68,7 @@ class GSplatResource {
 
         // the ply scene data no longer gets automatically rotated on load, so do
         // it here instead.
-        if (!this.splatData.isCompressed) {
-            entity.setLocalEulerAngles(0, 0, 180);
-        }
+        entity.setLocalEulerAngles(0, 0, 180);
 
         // set custom aabb
         component.customAabb = splatInstance.splat.aabb.clone();

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -225,16 +225,8 @@ class GSplatCompressedData {
 
         const iter = this.createIter(p, r, s, c);
 
-        // the compressed data is stored "right way up" so must
-        // be flipped upside down during decompression to match
-        // uncompressed orientation.
-        const q = new Quat().setFromEulerAngles(0, 0, 180);
-
         for (let i = 0; i < this.numSplats; ++i) {
             iter.read(i);
-
-            q.transformVector(p, p);
-            r.mul2(q, r);
 
             data.x[i] = p.x;
             data.y[i] = p.y;


### PR DESCRIPTION
Compressed PLY files used to store the scene the "right way up" while uncompressed PLY stores the scene upside-down.

We have since changed the compressed format to store the scene with the same orientation as the uncompressed format.

This PR fixes the orientation handling to have compressed format be consistent on load. 

(Though some files may require re-compressing).