### PR TITLE
Example device types fixes v1

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -66,7 +66,7 @@ Examples can also contain comments which allow you to define the default configu
 // @config NO_DEVICE_SELECTOR
 // @config NO_MINISTATS
 // @config WEBGPU_DISABLED
-// @config WEBGL_DISABLED
+// @config WEBGL2_DISABLED
 // @config WEBGL1_DISABLED
 import * as pc from 'playcanvas';
 ...

--- a/examples/iframe/utils.mjs
+++ b/examples/iframe/utils.mjs
@@ -92,7 +92,7 @@ export function parseConfig(script) {
     return config;
 }
 
-const DEVICE_TYPES = ['webgpu', 'webgl2', 'webgl1'];
+const DEVICE_TYPES = ['webgpu', 'webgl2', 'webgl1', 'null'];
 export let deviceType = 'webgl2';
 
 /**

--- a/examples/iframe/utils.mjs
+++ b/examples/iframe/utils.mjs
@@ -96,7 +96,7 @@ const DEVICE_TYPES = ['webgpu', 'webgl2', 'webgl1'];
 export let deviceType = 'webgl2';
 
 /**
- * @param {{ WEBGPU_DISABLED: boolean; WEBGL_DISABLED: boolean; WEBGL1_DISABLED: boolean }} config -
+ * @param {{ WEBGPU_DISABLED: boolean; WEBGL2_DISABLED: boolean; WEBGL1_DISABLED: boolean }} config -
  * The configuration object.
  */
 export function updateDeviceType(config) {
@@ -108,13 +108,13 @@ export function updateDeviceType(config) {
         deviceType = params.deviceType;
         return;
     }
-    if (config.WEBGL1_DISABLED && config.WEBGL_DISABLED && config.WEBGPU_DISABLED) {
+    if (config.WEBGL1_DISABLED && config.WEBGL2_DISABLED && config.WEBGPU_DISABLED) {
         console.warn('WebGL 1.0, WebGL 2.0 and WebGPU are disabled. Using Null device instead.');
         deviceType = 'null';
         return;
     }
     if (config.WEBGPU_DISABLED) {
-        if (config.WEBGL_DISABLED && deviceType !== 'webgl1') {
+        if (config.WEBGL2_DISABLED && deviceType !== 'webgl1') {
             console.warn('WebGPU is disabled. Using WebGL 1.0 device instead.');
             deviceType = 'webgl1';
             return;
@@ -125,7 +125,7 @@ export function updateDeviceType(config) {
             return;
         }
     }
-    if (config.WEBGL_DISABLED) {
+    if (config.WEBGL2_DISABLED) {
         if (config.WEBGPU_DISABLED && deviceType !== 'webgl1') {
             console.warn('WebGL 2.0 is disabled. Using WebGL 1.0 device instead.');
             deviceType = 'webgl1';
@@ -143,7 +143,7 @@ export function updateDeviceType(config) {
             deviceType = 'webgl2';
             return;
         }
-        if (config.WEBGL_DISABLED && deviceType !== 'webgpu') {
+        if (config.WEBGL2_DISABLED && deviceType !== 'webgpu') {
             console.warn('WebGL 1.0 is disabled. Using WebGPU device instead.');
             deviceType = 'webgpu';
         }

--- a/examples/scripts/utils.mjs
+++ b/examples/scripts/utils.mjs
@@ -45,7 +45,7 @@ export const getDirFiles = (path) => {
  * @property {boolean} [NO_DEVICE_SELECTOR] - No device selector.
  * @property {boolean} [NO_MINISTATS] - No ministats.
  * @property {boolean} [WEBGPU_DISABLED] - If webgpu is disabled.
- * @property {boolean} [WEBGL_DISABLED] - If webgl is disabled.
+ * @property {boolean} [WEBGL2_DISABLED] - If webgl is disabled.
  */
 
 /**

--- a/examples/src/app/components/DeviceSelector.mjs
+++ b/examples/src/app/components/DeviceSelector.mjs
@@ -11,9 +11,9 @@ import {
 import '../events.js';
 
 const deviceTypeNames = {
-    [DEVICETYPE_WEBGL1]: 'WebGL 1',
-    [DEVICETYPE_WEBGL2]: 'WebGL 2',
     [DEVICETYPE_WEBGPU]: 'WebGPU',
+    [DEVICETYPE_WEBGL2]: 'WebGL 2',
+    [DEVICETYPE_WEBGL1]: 'WebGL 1',
     [DEVICETYPE_NULL]: 'Null'
 };
 
@@ -157,9 +157,9 @@ class DeviceSelector extends TypedComponent {
         return jsx(SelectInput, {
             id: 'deviceTypeSelectInput',
             options: [
-                { t: deviceTypeNames[DEVICETYPE_WEBGL1], v: DEVICETYPE_WEBGL1 },
-                { t: deviceTypeNames[DEVICETYPE_WEBGL2], v: DEVICETYPE_WEBGL2 },
                 { t: deviceTypeNames[DEVICETYPE_WEBGPU], v: DEVICETYPE_WEBGPU },
+                { t: deviceTypeNames[DEVICETYPE_WEBGL2], v: DEVICETYPE_WEBGL2 },
+                { t: deviceTypeNames[DEVICETYPE_WEBGL1], v: DEVICETYPE_WEBGL1 },
                 { t: deviceTypeNames[DEVICETYPE_NULL], v: DEVICETYPE_NULL }
             ],
             value: activeDevice,

--- a/examples/src/examples/compute/histogram.example.mjs
+++ b/examples/src/examples/compute/histogram.example.mjs
@@ -1,4 +1,5 @@
-// @config WEBGL_DISABLED
+// @config WEBGL2_DISABLED
+// @config WEBGL1_DISABLED
 import * as pc from 'playcanvas';
 import { deviceType, rootPath } from 'examples/utils';
 import files from 'examples/files';

--- a/examples/src/examples/compute/particles.example.mjs
+++ b/examples/src/examples/compute/particles.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGL_DISABLED
+// @config WEBGL2_DISABLED
 import * as pc from 'playcanvas';
 import { deviceType, rootPath } from 'examples/utils';
 import files from 'examples/files';

--- a/examples/src/examples/compute/particles.example.mjs
+++ b/examples/src/examples/compute/particles.example.mjs
@@ -1,4 +1,5 @@
 // @config WEBGL2_DISABLED
+// @config WEBGL1_DISABLED
 import * as pc from 'playcanvas';
 import { deviceType, rootPath } from 'examples/utils';
 import files from 'examples/files';

--- a/examples/src/examples/compute/texture-gen.example.mjs
+++ b/examples/src/examples/compute/texture-gen.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGL_DISABLED
+// @config WEBGL2_DISABLED
 import * as pc from 'playcanvas';
 import { deviceType, rootPath } from 'examples/utils';
 import files from 'examples/files';

--- a/examples/src/examples/compute/texture-gen.example.mjs
+++ b/examples/src/examples/compute/texture-gen.example.mjs
@@ -1,4 +1,5 @@
 // @config WEBGL2_DISABLED
+// @config WEBGL1_DISABLED
 import * as pc from 'playcanvas';
 import { deviceType, rootPath } from 'examples/utils';
 import files from 'examples/files';

--- a/examples/src/examples/compute/vertex-update.example.mjs
+++ b/examples/src/examples/compute/vertex-update.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGL_DISABLED
+// @config WEBGL2_DISABLED
 import * as pc from 'playcanvas';
 import { deviceType, rootPath } from 'examples/utils';
 import files from 'examples/files';

--- a/examples/src/examples/compute/vertex-update.example.mjs
+++ b/examples/src/examples/compute/vertex-update.example.mjs
@@ -1,4 +1,5 @@
 // @config WEBGL2_DISABLED
+// @config WEBGL1_DISABLED
 import * as pc from 'playcanvas';
 import { deviceType, rootPath } from 'examples/utils';
 import files from 'examples/files';

--- a/examples/src/examples/graphics/wgsl-shader.example.mjs
+++ b/examples/src/examples/graphics/wgsl-shader.example.mjs
@@ -1,4 +1,5 @@
 // @config WEBGL2_DISABLED
+// @config WEBGL1_DISABLED
 // @config HIDDEN
 import * as pc from 'playcanvas';
 import files from 'examples/files';

--- a/examples/src/examples/graphics/wgsl-shader.example.mjs
+++ b/examples/src/examples/graphics/wgsl-shader.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGL_DISABLED
+// @config WEBGL2_DISABLED
 // @config HIDDEN
 import * as pc from 'playcanvas';
 import files from 'examples/files';

--- a/examples/src/examples/loaders/gsplat-many.example.mjs
+++ b/examples/src/examples/loaders/gsplat-many.example.mjs
@@ -1,5 +1,4 @@
 // @config WEBGL1_DISABLED
-
 import * as pc from 'playcanvas';
 import { data } from 'examples/observer';
 import files from 'examples/files';

--- a/examples/src/examples/loaders/gsplat.example.mjs
+++ b/examples/src/examples/loaders/gsplat.example.mjs
@@ -1,5 +1,4 @@
 // @config WEBGL1_DISABLED
-
 import * as pc from 'playcanvas';
 import { deviceType, rootPath } from 'examples/utils';
 


### PR DESCRIPTION
Fixes #7087

- Fixes examples that require webgpu only
- Updated `WEBGL_DISABLED` to `WEBGL2_DISABLED`
- Fixed not being able to select NullGraphicsDevice
