### PR TITLE
Fix Script schema retrieval in ScriptHandler

### DIFF
--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -139,7 +139,7 @@ class ScriptHandler extends ResourceHandler {
         import(importUrl.toString()).then((module) => {
 
             const filename = importUrl.pathname.split('/').pop();
-            const scriptSchema = this._app.assets.find(filename, 'script').data.scripts;
+            const scriptSchema = this._app.assets.find(filename, 'script')?.data?.scripts;
 
             for (const key in module) {
                 const scriptClass = module[key];
@@ -153,7 +153,7 @@ class ScriptHandler extends ResourceHandler {
                     registerScript(scriptClass, scriptName);
 
                     // Store any schema associated with the script
-                    this._app.scripts.addSchema(scriptName, scriptSchema[scriptName]);
+                    if (scriptSchema) this._app.scripts.addSchema(scriptName, scriptSchema[scriptName]);
                 }
             }
 


### PR DESCRIPTION
Fixes an issue in the script handler for engine only users. Ensures the script schema exists before attempting to add it

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
