### PR TITLE
Small bloom render pass optimization

### DIFF
--- a/src/extras/render-passes/render-pass-bloom.js
+++ b/src/extras/render-passes/render-pass-bloom.js
@@ -94,7 +94,8 @@ class RenderPassBloom extends RenderPass {
         let passSourceTexture = this._sourceTexture;
         for (let i = 0; i < numPasses; i++) {
 
-            const pass = new RenderPassDownsample(device, passSourceTexture);
+            const fast = i === 0;  // fast box downscale for the first pass
+            const pass = new RenderPassDownsample(device, passSourceTexture, fast);
             const rt = this.renderTargets[i];
             pass.init(rt, {
                 resizeSource: passSourceTexture,

--- a/src/extras/render-passes/render-pass-downsample.js
+++ b/src/extras/render-passes/render-pass-downsample.js
@@ -7,10 +7,12 @@ import { RenderPassShaderQuad } from '../../scene/graphics/render-pass-shader-qu
  * @ignore
  */
 class RenderPassDownsample extends RenderPassShaderQuad {
-    constructor(device, sourceTexture) {
+    constructor(device, sourceTexture, fast = false) {
         super(device);
         this.sourceTexture = sourceTexture;
-        this.shader = this.createQuadShader('DownSampleShader', /* glsl */`
+        this.shader = this.createQuadShader(`DownSampleShader${fast ? 'Fast' : ''}`, /* glsl */`
+
+            ${fast ? '#define FAST' : ''}
 
             uniform sampler2D sourceTexture;
             uniform vec2 sourceInvResolution;
@@ -18,30 +20,37 @@ class RenderPassDownsample extends RenderPassShaderQuad {
 
             void main()
             {
-                float x = sourceInvResolution.x;
-                float y = sourceInvResolution.y;
+                vec3 e = texture2D (sourceTexture, vec2 (uv0.x, uv0.y)).rgb;
 
-                vec3 a = texture2D (sourceTexture, vec2 (uv0.x - 2.0 * x, uv0.y + 2.0 * y)).rgb;
-                vec3 b = texture2D (sourceTexture, vec2 (uv0.x,           uv0.y + 2.0 * y)).rgb;
-                vec3 c = texture2D (sourceTexture, vec2 (uv0.x + 2.0 * x, uv0.y + 2.0 * y)).rgb;
+                #ifdef FAST
+                    vec3 value = e;
+                #else
 
-                vec3 d = texture2D (sourceTexture, vec2 (uv0.x - 2.0 * x, uv0.y)).rgb;
-                vec3 e = texture2D (sourceTexture, vec2 (uv0.x,           uv0.y)).rgb;
-                vec3 f = texture2D (sourceTexture, vec2 (uv0.x + 2.0 * x, uv0.y)).rgb;
+                    float x = sourceInvResolution.x;
+                    float y = sourceInvResolution.y;
 
-                vec3 g = texture2D (sourceTexture, vec2 (uv0.x - 2.0 * x, uv0.y - 2.0 * y)).rgb;
-                vec3 h = texture2D (sourceTexture, vec2 (uv0.x,           uv0.y - 2.0 * y)).rgb;
-                vec3 i = texture2D (sourceTexture, vec2 (uv0.x + 2.0 * x, uv0.y - 2.0 * y)).rgb;
+                    vec3 a = texture2D (sourceTexture, vec2 (uv0.x - 2.0 * x, uv0.y + 2.0 * y)).rgb;
+                    vec3 b = texture2D (sourceTexture, vec2 (uv0.x,           uv0.y + 2.0 * y)).rgb;
+                    vec3 c = texture2D (sourceTexture, vec2 (uv0.x + 2.0 * x, uv0.y + 2.0 * y)).rgb;
 
-                vec3 j = texture2D (sourceTexture, vec2 (uv0.x - x, uv0.y + y)).rgb;
-                vec3 k = texture2D (sourceTexture, vec2 (uv0.x + x, uv0.y + y)).rgb;
-                vec3 l = texture2D (sourceTexture, vec2 (uv0.x - x, uv0.y - y)).rgb;
-                vec3 m = texture2D (sourceTexture, vec2 (uv0.x + x, uv0.y - y)).rgb;
+                    vec3 d = texture2D (sourceTexture, vec2 (uv0.x - 2.0 * x, uv0.y)).rgb;
+                    vec3 f = texture2D (sourceTexture, vec2 (uv0.x + 2.0 * x, uv0.y)).rgb;
 
-                vec3 value = e * 0.125;
-                value += (a + c + g + i) * 0.03125;
-                value += (b + d + f + h) * 0.0625;
-                value += (j + k + l + m) * 0.125;
+                    vec3 g = texture2D (sourceTexture, vec2 (uv0.x - 2.0 * x, uv0.y - 2.0 * y)).rgb;
+                    vec3 h = texture2D (sourceTexture, vec2 (uv0.x,           uv0.y - 2.0 * y)).rgb;
+                    vec3 i = texture2D (sourceTexture, vec2 (uv0.x + 2.0 * x, uv0.y - 2.0 * y)).rgb;
+
+                    vec3 j = texture2D (sourceTexture, vec2 (uv0.x - x, uv0.y + y)).rgb;
+                    vec3 k = texture2D (sourceTexture, vec2 (uv0.x + x, uv0.y + y)).rgb;
+                    vec3 l = texture2D (sourceTexture, vec2 (uv0.x - x, uv0.y - y)).rgb;
+                    vec3 m = texture2D (sourceTexture, vec2 (uv0.x + x, uv0.y - y)).rgb;
+
+
+                    vec3 value = e * 0.125;
+                    value += (a + c + g + i) * 0.03125;
+                    value += (b + d + f + h) * 0.0625;
+                    value += (j + k + l + m) * 0.125;
+                #endif
 
                 gl_FragColor = vec4(value, 1.0);
             }`


### PR DESCRIPTION
The bloom uses a series of downscaling and upscaling render passes to blur.
Instead of executing more costly 13-samples downscaling at all time, use just a single sample box filter for downscaling from full to half res, which is the most costly pass. No visible difference to the quality.

Cost of 4k rendering of Post-Processing example on apple m1 max:
before: 4.4ms
now: 4.2ms