### PR TITLE
Fixed ESM `swap()`

### DIFF
--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -69,7 +69,8 @@ class ScriptHandler extends ResourceHandler {
                 callback(null, obj, extra);
 
                 // no cache for scripts
-                delete self._loader._cache[ResourceLoader.makeKey(url, 'script')];
+                const urlWithoutEndHash = url.split('&hash=')[0];
+                delete self._loader._cache[ResourceLoader.makeKey(urlWithoutEndHash, 'script')];
             } else {
                 callback(err);
             }


### PR DESCRIPTION
Fixes an issue that was preventing `swap` being called on ESM scripts. ESM Scripts are now correctly remove from the cache inline with classic scripts.  See https://github.com/playcanvas/editor/issues/1115#issuecomment-2466214508

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
