### PR TITLE
Batcher buffers merging optimization

### DIFF
--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -706,24 +706,33 @@ class BatchManager {
                         // transform position, normal and tangent to world space
                         if (!dynamic && stream.numComponents >= 3) {
                             if (semantic === SEMANTIC_POSITION) {
+                                const m = transform.data;
+                                let x, y, z;
+
                                 for (let j = 0; j < totalComponents; j += stream.numComponents) {
-                                    vec.set(subarray[j], subarray[j + 1], subarray[j + 2]);
-                                    transform.transformPoint(vec, vec);
-                                    subarray[j] = vec.x;
-                                    subarray[j + 1] = vec.y;
-                                    subarray[j + 2] = vec.z;
+                                    x = subarray[j];
+                                    y = subarray[j + 1];
+                                    z = subarray[j + 2];
+
+                                    subarray[j] = x * m[0] + y * m[4] + z * m[8] + m[12];
+                                    subarray[j + 1] = x * m[1] + y * m[5] + z * m[9] + m[13];
+                                    subarray[j + 2] = x * m[2] + y * m[6] + z * m[10] + m[14];
                                 }
                             } else if (semantic === SEMANTIC_NORMAL || semantic === SEMANTIC_TANGENT) {
-
                                 // handle non-uniform scale by using transposed inverse matrix to transform vectors
                                 mat3.invertMat4(transform).transpose();
 
+                                const m = mat3.data;
+                                let x, y, z;
+
                                 for (let j = 0; j < totalComponents; j += stream.numComponents) {
-                                    vec.set(subarray[j], subarray[j + 1], subarray[j + 2]);
-                                    mat3.transformVector(vec, vec);
-                                    subarray[j] = vec.x;
-                                    subarray[j + 1] = vec.y;
-                                    subarray[j + 2] = vec.z;
+                                    x = subarray[j];
+                                    y = subarray[j + 1];
+                                    z = subarray[j + 2];
+
+                                    subarray[j] = x * m[0] + y * m[3] + z * m[6];
+                                    subarray[j + 1] = x * m[1] + y * m[4] + z * m[7];
+                                    subarray[j + 2] = x * m[2] + y * m[5] + z * m[8];
                                 }
                             }
                         }

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -706,6 +706,7 @@ class BatchManager {
                         if (!dynamic && stream.numComponents >= 3) {
                             if (semantic === SEMANTIC_POSITION) {
                                 const m = transform.data;
+                                const [ m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14 ] = m;
                                 let x, y, z;
 
                                 for (let j = 0; j < totalComponents; j += stream.numComponents) {
@@ -714,15 +715,16 @@ class BatchManager {
                                     z = subarray[j + 2];
 
                                     // mat4.transformVector
-                                    subarray[j] = x * m[0] + y * m[4] + z * m[8] + m[12];
-                                    subarray[j + 1] = x * m[1] + y * m[5] + z * m[9] + m[13];
-                                    subarray[j + 2] = x * m[2] + y * m[6] + z * m[10] + m[14];
+                                    subarray[j] = x * m0 + y * m4 + z * m8 + m12;
+                                    subarray[j + 1] = x * m1 + y * m5 + z * m9 + m13;
+                                    subarray[j + 2] = x * m2 + y * m6 + z * m10 + m14;
                                 }
                             } else if (semantic === SEMANTIC_NORMAL || semantic === SEMANTIC_TANGENT) {
                                 // handle non-uniform scale by using transposed inverse matrix to transform vectors
                                 mat3.invertMat4(transform).transpose();
 
                                 const m = mat3.data;
+                                const [ m0, m1, m2, m3, m4, m5, m6, m7, m8 ] = m;
                                 let x, y, z;
 
                                 for (let j = 0; j < totalComponents; j += stream.numComponents) {
@@ -731,9 +733,9 @@ class BatchManager {
                                     z = subarray[j + 2];
 
                                     // mat3.transformVector
-                                    subarray[j] = x * m[0] + y * m[3] + z * m[6];
-                                    subarray[j + 1] = x * m[1] + y * m[4] + z * m[7];
-                                    subarray[j + 2] = x * m[2] + y * m[5] + z * m[8];
+                                    subarray[j] = x * m0 + y * m3 + z * m6;
+                                    subarray[j + 1] = x * m1 + y * m4 + z * m7;
+                                    subarray[j + 2] = x * m2 + y * m5 + z * m8;
                                 }
                             }
                         }

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -1,7 +1,6 @@
 import { Debug } from '../../core/debug.js';
 import { now } from '../../core/time.js';
 import { Mat3 } from '../../core/math/mat3.js';
-import { Vec3 } from '../../core/math/vec3.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 
 import {
@@ -706,7 +705,19 @@ class BatchManager {
                         if (!dynamic && stream.numComponents >= 3) {
                             if (semantic === SEMANTIC_POSITION) {
                                 const m = transform.data;
-                                const [ m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14 ] = m;
+                                const m0 = m[0];
+                                const m1 = m[1];
+                                const m2 = m[2];
+                                const m4 = m[4];
+                                const m5 = m[5];
+                                const m6 = m[6];
+                                const m8 = m[8];
+                                const m9 = m[9];
+                                const m10 = m[10];
+                                const m12 = m[12];
+                                const m13 = m[13];
+                                const m14 = m[14];
+
                                 let x, y, z;
 
                                 for (let j = 0; j < totalComponents; j += stream.numComponents) {
@@ -723,8 +734,7 @@ class BatchManager {
                                 // handle non-uniform scale by using transposed inverse matrix to transform vectors
                                 mat3.invertMat4(transform).transpose();
 
-                                const m = mat3.data;
-                                const [ m0, m1, m2, m3, m4, m5, m6, m7, m8 ] = m;
+                                const [m0, m1, m2, m3, m4, m5, m6, m7, m8] = mat3.data;
                                 let x, y, z;
 
                                 for (let j = 0; j < totalComponents; j += stream.numComponents) {

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -666,7 +666,6 @@ class BatchManager {
             let verticesOffset = 0;
             let indexOffset = 0;
             let transform;
-            const vec = new Vec3();
 
             // allocate indices
             const indexArrayType = batchNumVerts <= 0xffff ? Uint16Array : Uint32Array;
@@ -714,6 +713,7 @@ class BatchManager {
                                     y = subarray[j + 1];
                                     z = subarray[j + 2];
 
+                                    // mat4.transformVector
                                     subarray[j] = x * m[0] + y * m[4] + z * m[8] + m[12];
                                     subarray[j + 1] = x * m[1] + y * m[5] + z * m[9] + m[13];
                                     subarray[j + 2] = x * m[2] + y * m[6] + z * m[10] + m[14];
@@ -730,6 +730,7 @@ class BatchManager {
                                     y = subarray[j + 1];
                                     z = subarray[j + 2];
 
+                                    // mat3.transformVector
                                     subarray[j] = x * m[0] + y * m[3] + z * m[6];
                                     subarray[j + 1] = x * m[1] + y * m[4] + z * m[7];
                                     subarray[j + 2] = x * m[2] + y * m[5] + z * m[8];


### PR DESCRIPTION
Batcher consists of multiple parts:
1. Collecting information on batch groups.
2. Figuring out individual batches based on mesh differences.
3. Merging meshes buffers with additional transformation.

This PR focuses on the third case by decomposing some math functions that are called frequently, which results in significant performance gains in some of our tests.

In a scene with 749 batches, on test machine currently it takes:
~1658ms to apply position transformations and 612ms on normals transformations.

With this PR these numbers become:
~216ms to apply position transformations and 155ms on normals transformations.

In this specific case we have **x7.7 time speed up** on positions and **x3.9 times speed up** on normals.
We've tested multiple cases, and gains can vary from x1.5 to x10, depending on number of meshes per batch and how large these meshes are.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
