### PR TITLE
Multicam API updates

### DIFF
--- a/examples/src/examples/camera/multi.controls.mjs
+++ b/examples/src/examples/camera/multi.controls.mjs
@@ -72,8 +72,9 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'attr.lookDamping' },
                     min: 0,
-                    max: 0.99,
-                    step: 0.01
+                    max: 0.999,
+                    step: 0.001,
+                    precision: 3
                 })
             ),
             jsx(
@@ -83,8 +84,9 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'attr.moveDamping' },
                     min: 0,
-                    max: 0.99,
-                    step: 0.01
+                    max: 0.999,
+                    step: 0.001,
+                    precision: 3
                 })
             ),
             jsx(
@@ -125,9 +127,10 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'attr.wheelSpeed' },
-                    min: 0.001,
-                    max: 0.01,
-                    step: 0.001
+                    min: 0,
+                    max: 10,
+                    step: 0.001,
+                    precision: 3
                 })
             ),
             jsx(
@@ -136,9 +139,10 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'attr.zoomMin' },
-                    min: 0.001,
-                    max: 0.01,
-                    step: 0.001
+                    min: 0,
+                    max: 10,
+                    step: 0.001,
+                    precision: 3
                 })
             ),
             jsx(
@@ -147,8 +151,10 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'attr.zoomMax' },
-                    min: 1,
-                    max: 10
+                    min: 0,
+                    max: 10,
+                    step: 0.001,
+                    precision: 3
                 })
             ),
             jsx(
@@ -157,9 +163,10 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'attr.zoomScaleMin' },
-                    min: 0.001,
-                    max: 0.01,
-                    step: 0.001
+                    min: 0,
+                    max: 1,
+                    step: 0.001,
+                    precision: 3
                 })
             ),
             jsx(

--- a/examples/src/examples/camera/multi.controls.mjs
+++ b/examples/src/examples/camera/multi.controls.mjs
@@ -20,12 +20,29 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             { headerText: 'Attributes' },
             jsx(
                 LabelGroup,
-                { text: 'Focus FOV' },
-                jsx(SliderInput, {
+                { text: 'Enable Orbit' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
                     binding: new BindingTwoWay(),
-                    link: { observer, path: 'attr.focusFov' },
-                    min: 30,
-                    max: 120
+                    link: { observer, path: 'attr.enableOrbit' }
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Enable Pan' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'attr.enablePan' }
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Enable Fly' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'attr.enableFly' }
                 })
             ),
             jsx(

--- a/examples/src/examples/camera/multi.controls.mjs
+++ b/examples/src/examples/camera/multi.controls.mjs
@@ -89,6 +89,28 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
+                { text: 'Pitch min' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'attr.pitchMin' },
+                    min: -90,
+                    max: 90,
+                    step: 1
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Pitch max' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'attr.pitchMax' },
+                    min: -90,
+                    max: 90,
+                    step: 1
+                })
+            ),
+            jsx(
+                LabelGroup,
                 { text: 'Pinch speed' },
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),

--- a/examples/src/examples/camera/multi.controls.mjs
+++ b/examples/src/examples/camera/multi.controls.mjs
@@ -16,6 +16,15 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             })
         ),
         jsx(
+            LabelGroup,
+            { text: 'Smoothed focus' },
+            jsx(BooleanInput, {
+                type: 'toggle',
+                binding: new BindingTwoWay(),
+                link: { observer, path: 'example.smoothedFocus' }
+            })
+        ),
+        jsx(
             Panel,
             { headerText: 'Attributes' },
             jsx(

--- a/examples/src/examples/camera/multi.example.mjs
+++ b/examples/src/examples/camera/multi.example.mjs
@@ -144,24 +144,28 @@ data.set('example', {
     zoomReset: true,
     smoothedFocus: true
 });
-data.set('attr', {
-    enableOrbit: multiCameraScript.enableOrbit,
-    enablePan: multiCameraScript.enablePan,
-    enableFly: multiCameraScript.enableFly,
-    lookSensitivity: 0.2,
-    lookDamping: 0.97,
-    moveDamping: 0.98,
-    pitchMin: multiCameraScript.pitchMin,
-    pitchMax: multiCameraScript.pitchMax,
-    pinchSpeed: 5,
-    wheelSpeed: 0.005,
-    zoomMin: 0.001,
-    zoomMax: 10,
-    zoomScaleMin: 0.01,
-    moveSpeed: 2,
-    sprintSpeed: 4,
-    crouchSpeed: 1
-});
+
+data.set('attr', [
+    'enableOrbit',
+    'enablePan',
+    'enableFly',
+    'lookSensitivity',
+    'lookDamping',
+    'moveDamping',
+    'pitchMin',
+    'pitchMax',
+    'pinchSpeed',
+    'wheelSpeed',
+    'zoomMin',
+    'zoomMax',
+    'zoomScaleMin',
+    'moveSpeed',
+    'sprintSpeed',
+    'crouchSpeed'
+].reduce((/** @type {Record<string, any>} */ obj, key) => {
+    obj[key] = multiCameraScript[key];
+    return obj;
+}, {}));
 data.on('*:set', (/** @type {string} */ path, /** @type {any} */ value) => {
     const [category, key] = path.split('.');
     if (category !== 'attr') {

--- a/examples/src/examples/camera/multi.example.mjs
+++ b/examples/src/examples/camera/multi.example.mjs
@@ -1,4 +1,4 @@
-// @config DESCRIPTION <div style='text-align:center'><div>(<b>WASDQE</b>) Move (Fly enabled)</div><div>(<b>LMB</b>) Orbit, (<b>LMB </b>(Orbit disabled)<b> / RMB</b>) Fly</div><div>(<b>Hold Shift / MMB / RMB </b>(Fly or Orbit disabled)) Pan</div><div>(<b>Scroll Wheel</b>) zoom</div><div>(<b>F</b>) Focus</div></div>
+// @config DESCRIPTION <div style='text-align:center'><div>(<b>WASDQE</b>) Move (Fly enabled)</div><div>(<b>LMB</b>) Orbit, (<b>LMB </b>(Orbit disabled)<b> / RMB</b>) Fly</div><div>(<b>Hold Shift / MMB / RMB </b>(Fly or Orbit disabled)) Pan</div><div>(<b>Scroll Wheel</b> (Orbit or Pan enabled)) zoom</div><div>(<b>F</b>) Focus</div></div>
 // @config HIDDEN
 import * as pc from 'playcanvas';
 import { data } from 'examples/observer';

--- a/examples/src/examples/camera/multi.example.mjs
+++ b/examples/src/examples/camera/multi.example.mjs
@@ -115,7 +115,7 @@ const createMultiCamera = (focus) => {
     // wait until after canvas resized to focus on entity
     const resize = new ResizeObserver(() => {
         resize.disconnect();
-        script.focus(bbox.center, start);
+        script.focus(bbox.center, start, false);
     });
     resize.observe(canvas);
 

--- a/examples/src/examples/camera/multi.example.mjs
+++ b/examples/src/examples/camera/multi.example.mjs
@@ -1,4 +1,4 @@
-// @config DESCRIPTION <div style='text-align:center'><div>(<b>WASDQE</b>) Move</div><div>(<b>LMB</b>) Orbit, (<b>RMB</b>) Fly</div><div>(<b>Scroll Wheel</b>) zoom</div><div>(<b>MMB / Hold Shift</b>) Pan</div><div>(<b>F</b>) Focus</div></div>
+// @config DESCRIPTION <div style='text-align:center'><div>(<b>WASDQE</b>) Move (Fly enabled)</div><div>(<b>LMB</b>) Orbit, (<b>LMB </b>(Orbit disabled)<b> / RMB</b>) Fly</div><div>(<b>Hold Shift / MMB / RMB </b>(Fly or Orbit disabled)) Pan</div><div>(<b>Scroll Wheel</b>) zoom</div><div>(<b>F</b>) Focus</div></div>
 // @config HIDDEN
 import * as pc from 'playcanvas';
 import { data } from 'examples/observer';

--- a/examples/src/examples/camera/multi.example.mjs
+++ b/examples/src/examples/camera/multi.example.mjs
@@ -147,7 +147,9 @@ data.set('example', {
     zoomReset: true
 });
 data.set('attr', {
-    focusFov: 75,
+    enableOrbit: multiCameraScript.enableOrbit,
+    enablePan: multiCameraScript.enablePan,
+    enableFly: multiCameraScript.enableFly,
     lookSensitivity: 0.2,
     lookDamping: 0.97,
     moveDamping: 0.98,

--- a/examples/src/examples/camera/multi.example.mjs
+++ b/examples/src/examples/camera/multi.example.mjs
@@ -101,10 +101,11 @@ const createMultiCamera = (focus) => {
     // focus on entity when 'f' key is pressed
     const onKeyDown = (/** @type {KeyboardEvent} */ e) => {
         if (e.key === 'f') {
+            const smoothed = data.get('example.smoothedFocus');
             if (data.get('example.zoomReset')) {
-                script.resetZoom(cameraDist);
+                script.resetZoom(cameraDist, smoothed);
             }
-            script.focus(bbox.center);
+            script.focus(bbox.center, null, smoothed);
         }
     };
     window.addEventListener('keydown', onKeyDown);
@@ -144,7 +145,8 @@ const multiCameraScript = createMultiCamera(statue);
 
 // Bind controls to camera attributes
 data.set('example', {
-    zoomReset: true
+    zoomReset: true,
+    smoothedFocus: true
 });
 data.set('attr', {
     enableOrbit: multiCameraScript.enableOrbit,

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -337,7 +337,7 @@ body {
     position: absolute;
     right: 8px;
     top: 8px;
-    width: 250px;
+    width: 280px;
     z-index: 9999;
     background-color: rgba(54, 67, 70, 0.64);
     backdrop-filter: blur(32px);

--- a/scripts/camera/base-camera.mjs
+++ b/scripts/camera/base-camera.mjs
@@ -39,36 +39,48 @@ class BaseCamera extends Script {
     root;
 
     /**
+     * The scene size.
+     *
      * @attribute
      * @type {number}
      */
     sceneSize = 100;
 
     /**
+     * The look sensitivity.
+     *
      * @attribute
      * @type {number}
      */
     lookSensitivity = 0.2;
 
     /**
+     * The look damping.
+     *
      * @attribute
      * @type {number}
      */
     lookDamping = 0.97;
 
     /**
+     * The move damping.
+     *
      * @attribute
      * @type {number}
      */
     moveDamping = 0.98;
 
     /**
+     * The minimum camera pitch angle.
+     *
      * @attribute
      * @type {number}
      */
     pitchMin = -90;
 
     /**
+     * The maximum camera pitch angle.
+     *
      * @attribute
      * @type {number}
      */

--- a/scripts/camera/base-camera.mjs
+++ b/scripts/camera/base-camera.mjs
@@ -65,17 +65,31 @@ class BaseCamera extends Script {
     moveDamping = 0.98;
 
     /**
+     * @attribute
+     * @type {number}
+     */
+    pitchMin = -90;
+
+    /**
+     * @attribute
+     * @type {number}
+     */
+    pitchMax = 90;
+
+    /**
      * @param {object} args - The script arguments.
      */
     constructor(args) {
         super(args);
-        const { name, sceneSize, lookSensitivity, lookDamping, moveDamping } = args.attributes;
+        const { name, sceneSize, lookSensitivity, lookDamping, moveDamping, pitchMin, pitchMax } = args.attributes;
 
         this.root = new Entity(name ?? 'base-camera');
         this.sceneSize = sceneSize ?? this.sceneSize;
         this.lookSensitivity = lookSensitivity ?? this.lookSensitivity;
         this.lookDamping = lookDamping ?? this.lookDamping;
         this.moveDamping = moveDamping ?? this.moveDamping;
+        this.pitchMin = pitchMin ?? this.pitchMin;
+        this.pitchMax = pitchMax ?? this.pitchMax;
 
         this._onPointerDown = this._onPointerDown.bind(this);
         this._onPointerMove = this._onPointerMove.bind(this);
@@ -149,7 +163,7 @@ class BaseCamera extends Script {
         }
         const movementX = event.movementX || 0;
         const movementY = event.movementY || 0;
-        this._dir.x = math.clamp(this._dir.x - movementY * this.lookSensitivity, -LOOK_MAX_ANGLE, LOOK_MAX_ANGLE);
+        this._dir.x = math.clamp(this._dir.x - movementY * this.lookSensitivity, this.pitchMin, this.pitchMax);
         this._dir.y -= movementX * this.lookSensitivity;
     }
 

--- a/scripts/camera/base-camera.mjs
+++ b/scripts/camera/base-camera.mjs
@@ -2,8 +2,6 @@ import { Entity, Script, Vec3, Vec2, math } from 'playcanvas';
 
 /** @import { CameraComponent } from 'playcanvas' */
 
-const LOOK_MAX_ANGLE = 90;
-
 class BaseCamera extends Script {
     /**
      * @type {CameraComponent}

--- a/scripts/camera/multi-camera.mjs
+++ b/scripts/camera/multi-camera.mjs
@@ -607,7 +607,7 @@ class MultiCamera extends BaseCamera {
             this._camera.entity.setLocalPosition(0, 0, this._cameraDist);
         }
 
-        if (this._flying) {
+        if (this.enableFly) {
             this._move(dt);
         }
 

--- a/scripts/camera/multi-camera.mjs
+++ b/scripts/camera/multi-camera.mjs
@@ -478,13 +478,17 @@ class MultiCamera extends BaseCamera {
     /**
      * @param {Vec3} point - The point.
      * @param {Vec3} [start] - The start.
+     * @param {boolean} [smoothing] - Whether to smooth the focus.
      */
-    focus(point, start) {
+    focus(point, start, smoothing = true) {
         if (!this._camera) {
             return;
         }
         if (!start) {
             this._origin.copy(point);
+            if (!smoothing) {
+                this._position.copy(point);
+            }
             return;
         }
 
@@ -498,6 +502,12 @@ class MultiCamera extends BaseCamera {
         this._camera.entity.setLocalEulerAngles(0, 0, 0);
 
         this._zoomDist = tmpV1.length();
+
+        if (!smoothing) {
+            this._angles.set(this._dir.x, this._dir.y, 0);
+            this._position.copy(point);
+            this._cameraDist = this._zoomDist;
+        }
     }
 
     /**

--- a/scripts/camera/multi-camera.mjs
+++ b/scripts/camera/multi-camera.mjs
@@ -568,9 +568,13 @@ class MultiCamera extends BaseCamera {
 
     /**
      * @param {number} [zoomDist] - The zoom distance.
+     * @param {boolean} [smoothing] - Whether to smooth the zoom.
      */
-    resetZoom(zoomDist = 0) {
+    resetZoom(zoomDist = 0, smoothing = true) {
         this._zoomDist = zoomDist;
+        if (!smoothing) {
+            this._cameraDist = zoomDist;
+        }
     }
 
     /**

--- a/scripts/camera/multi-camera.mjs
+++ b/scripts/camera/multi-camera.mjs
@@ -607,7 +607,9 @@ class MultiCamera extends BaseCamera {
             this._camera.entity.setLocalPosition(0, 0, this._cameraDist);
         }
 
-        this._move(dt);
+        if (this._flying) {
+            this._move(dt);
+        }
 
         super.update(dt);
     }

--- a/scripts/camera/multi-camera.mjs
+++ b/scripts/camera/multi-camera.mjs
@@ -165,7 +165,16 @@ class MultiCamera extends BaseCamera {
      */
     constructor(args) {
         super(args);
-        const { pinchSpeed, wheelSpeed, zoomMin, zoomMax, moveSpeed, sprintSpeed, crouchSpeed } = args.attributes;
+        const {
+            focus: point = Vec3.ZERO,
+            pinchSpeed,
+            wheelSpeed,
+            zoomMin,
+            zoomMax,
+            moveSpeed,
+            sprintSpeed,
+            crouchSpeed
+        } = args.attributes;
 
         this.pinchSpeed = pinchSpeed ?? this.pinchSpeed;
         this.wheelSpeed = wheelSpeed ?? this.wheelSpeed;
@@ -183,6 +192,8 @@ class MultiCamera extends BaseCamera {
             throw new Error('MultiCamera script requires a camera component');
         }
         this.attach(this.entity.camera);
+
+        this.focus(point, this.entity.getPosition(), false);
     }
 
     /**
@@ -532,6 +543,8 @@ class MultiCamera extends BaseCamera {
     }
 
     /**
+     * Focus the camera on a point.
+     *
      * @param {Vec3} point - The point.
      * @param {Vec3} [start] - The start.
      * @param {boolean} [smoothing] - Whether to smooth the focus.
@@ -567,6 +580,8 @@ class MultiCamera extends BaseCamera {
     }
 
     /**
+     * Reset the zoom. For orbit and panning only.
+     *
      * @param {number} [zoomDist] - The zoom distance.
      * @param {boolean} [smoothing] - Whether to smooth the zoom.
      */
@@ -575,6 +590,21 @@ class MultiCamera extends BaseCamera {
         if (!smoothing) {
             this._cameraDist = zoomDist;
         }
+    }
+
+    /**
+     * Refocus the camera.
+     *
+     * @param {Vec3} point - The point.
+     * @param {Vec3} [start] - The start.
+     * @param {number} [zoomDist] - The zoom distance.
+     * @param {boolean} [smoothing] - Whether to smooth the refocus.
+     */
+    refocus(point, start = null, zoomDist = null, smoothing = true) {
+        if (zoomDist !== null) {
+            this.resetZoom(zoomDist, smoothing);
+        }
+        this.focus(point, start, smoothing);
     }
 
     /**

--- a/scripts/camera/multi-camera.mjs
+++ b/scripts/camera/multi-camera.mjs
@@ -187,6 +187,60 @@ class MultiCamera extends BaseCamera {
 
     /**
      * @param {PointerEvent} event - The pointer event.
+     * @private
+     * @returns {boolean} Whether the mouse pan should start.
+     */
+    _isStartMousePan(event) {
+        if (!this.enablePan) {
+            return false;
+        }
+        if (event.shiftKey) {
+            return true;
+        }
+        if (!this.enableOrbit && !this.enableFly) {
+            return event.button === 0 || event.button === 1 || event.button === 2;
+        }
+        if (!this.enableOrbit || !this.enableFly) {
+            return event.button === 1 || event.button === 2;
+        }
+        return event.button === 1;
+    }
+
+    /**
+     * @param {PointerEvent} event - The pointer event.
+     * @returns {boolean} Whether the fly should start.
+     * @private
+     */
+    _isStartFly(event) {
+        if (!this.enableFly) {
+            return false;
+        }
+        if (!this.enableOrbit && !this.enablePan) {
+            return event.button === 0 || event.button === 1 || event.button === 2;
+        }
+        if (!this.enableOrbit) {
+            return event.button === 0;
+        }
+        return event.button === 2;
+    }
+
+    /**
+     * @param {PointerEvent} event - The pointer event.
+     * @returns {boolean} Whether the orbit should start.
+     * @private
+     */
+    _isStartOrbit(event) {
+        if (!this.enableOrbit) {
+            return false;
+        }
+        if (!this.enableFly && !this.enablePan) {
+            return event.button === 0 || event.button === 1 || event.button === 2;
+        }
+        return event.button === 0;
+    }
+
+    /**
+     * @param {PointerEvent} event - The pointer event.
      * @protected
      */
     _onPointerDown(event) {
@@ -196,20 +250,10 @@ class MultiCamera extends BaseCamera {
         this._pointerEvents.set(event.pointerId, event);
 
         const startTouchPan = this.enablePan && this._pointerEvents.size === 2;
-        const startMousePan = this.enablePan && (
-            event.shiftKey ||
-            event.button === 1 ||
-            ((!this.enableFly || !this.enableOrbit) && event.button === 2) ||
-            ((!this.enableFly && !this.enableOrbit) && event.button === 0)
-        );
-        const startFly = this.enableFly && (
-            (this.enableOrbit && event.button === 2) ||
-            (!this.enableOrbit && event.button === 0)
-        );
-        const startOrbit = this.enableOrbit && (
-            (this.enableFly && event.button === 0) ||
-            (!this.enableFly && event.button === 0)
-        );
+        const startMousePan = this._isStartMousePan(event);
+        const startFly = this._isStartFly(event);
+        const startOrbit = this._isStartOrbit(event);
+
         if (startTouchPan) {
             // start touch pan
             this._lastPinchDist = this._getPinchDist();

--- a/scripts/camera/multi-camera.mjs
+++ b/scripts/camera/multi-camera.mjs
@@ -77,84 +77,104 @@ class MultiCamera extends BaseCamera {
     };
 
     /**
+     * Enable orbit camera movement.
+     *
      * @attribute
      * @type {boolean}
      */
     enableOrbit = true;
 
     /**
+     * Enable panning the camera.
+     *
      * @attribute
      * @type {boolean
      */
     enablePan = true;
 
     /**
+     * Enable flying the camera.
+     *
      * @attribute
      * @type {boolean}
      */
     enableFly = true;
 
     /**
-     * @attribute
-     * @type {number}
-     */
-    lookSensitivity = 0.2;
-
-    /**
-     * @attribute
-     * @type {number}
-     */
-    lookDamping = 0.97;
-
-    /**
-     * @attribute
-     * @type {number}
-     */
-    moveDamping = 0.98;
-
-    /**
+     * The touch pinch speed.
+     *
      * @attribute
      * @type {number}
      */
     pinchSpeed = 5;
 
     /**
+     * The mouse wheel speed.
+     *
      * @attribute
      * @type {number}
      */
     wheelSpeed = 0.005;
 
     /**
+     * The minimum zoom distance relative to the scene size.
+     *
      * @attribute
      * @type {number}
      */
     zoomMin = 0.001;
 
     /**
+     * The maximum zoom distance relative to the scene size.
+     *
      * @attribute
      * @type {number}
      */
     zoomMax = 10;
 
     /**
+     * The minimum distance the camera can zoom. This will override zoomMin.
+     *
+     * @attribute
+     * @type {number}
+     */
+    zoomDistMin = 0;
+
+    /**
+     * The maximum distance the camera can zoom. This will override zoomMax.
+     *
+     * @attribute
+     * @type {number}
+     */
+    zoomDistMax = Infinity;
+
+    /**
+     * The minimum scale the camera can zoom.
+     *
      * @attribute
      * @type {number}
      */
     zoomScaleMin = 0.01;
 
     /**
+     * The fly move speed.
+     *
      * @attribute
      * @type {number}
      */
     moveSpeed = 2;
 
     /**
+     * The fly sprint speed.
+     *
      * @attribute
      * @type {number}
      */
     sprintSpeed = 4;
 
     /**
+     * The fly crouch speed.
+     *
      * @attribute
      * @type {number}
      */
@@ -171,6 +191,8 @@ class MultiCamera extends BaseCamera {
             wheelSpeed,
             zoomMin,
             zoomMax,
+            zoomDistMin,
+            zoomDistMax,
             moveSpeed,
             sprintSpeed,
             crouchSpeed
@@ -180,6 +202,9 @@ class MultiCamera extends BaseCamera {
         this.wheelSpeed = wheelSpeed ?? this.wheelSpeed;
         this.zoomMin = zoomMin ?? this.zoomMin;
         this.zoomMax = zoomMax ?? this.zoomMax;
+        this.zoomDistMin = zoomDistMin ?? this.zoomDistMin;
+        this.zoomDistMax = zoomDistMax ?? this.zoomDistMax;
+
         this.moveSpeed = moveSpeed ?? this.moveSpeed;
         this.sprintSpeed = sprintSpeed ?? this.sprintSpeed;
         this.crouchSpeed = crouchSpeed ?? this.crouchSpeed;
@@ -540,6 +565,7 @@ class MultiCamera extends BaseCamera {
         const scale = math.clamp(this._zoomDist / (max - min), this.zoomScaleMin, 1);
         this._zoomDist += (delta * this.wheelSpeed * this.sceneSize * scale);
         this._zoomDist = math.clamp(this._zoomDist, min, max);
+        this._zoomDist = math.clamp(this._zoomDist, this.zoomDistMin, this.zoomDistMax);
     }
 
     /**

--- a/scripts/camera/multi-camera.mjs
+++ b/scripts/camera/multi-camera.mjs
@@ -420,6 +420,10 @@ class MultiCamera extends BaseCamera {
      * @param {number} dt - The delta time.
      */
     _move(dt) {
+        if (!this.enableFly) {
+            return;
+        }
+
         tmpV1.set(0, 0, 0);
         if (this._key.forward) {
             tmpV1.add(this.root.forward);
@@ -492,6 +496,10 @@ class MultiCamera extends BaseCamera {
      * @private
      */
     _pan(pos) {
+        if (!this.enablePan) {
+            return;
+        }
+
         const start = new Vec3();
         const end = new Vec3();
 
@@ -509,6 +517,10 @@ class MultiCamera extends BaseCamera {
      * @private
      */
     _zoom(delta) {
+        if (!this.enableOrbit && !this.enablePan) {
+            return;
+        }
+
         if (!this._camera) {
             return;
         }
@@ -607,9 +619,7 @@ class MultiCamera extends BaseCamera {
             this._camera.entity.setLocalPosition(0, 0, this._cameraDist);
         }
 
-        if (this.enableFly) {
-            this._move(dt);
-        }
+        this._move(dt);
 
         super.update(dt);
     }


### PR DESCRIPTION
- Added attributes to enable orbit/fly/pan controls `enableOrbit: boolean; enablePan: boolean; enableFly: boolean`
- Set default focus to use camera position as start and origin as focus point
- Added smoothing parameter to `focus` and `resetZoom`
- Added `refocus` method for simpler focusing API `refocus(point: Vec3, start?: Vec3 | null = null, zoomDist?: number | null = null, smoothing: boolean = true)`
- Added attributes `pitchMin: number` and `pitchMax: number` for constraining the pitch angles
- Added attributes `zoomDistMin: number` and `zoomDistMax: number` for constraining the absolute zoom distance 

### Preview
![image](https://github.com/user-attachments/assets/82b01ff7-7ab6-4e63-ab28-f1fc3c225542)

