### PR TITLE
Adds `deprecated.js` to `sideEffects`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "./build/*": "./build/*",
     "./scripts/*": "./scripts/*"
   },
-  "sideEffects": false,
+  "sideEffects": ["./build/playcanvas/src/deprecated/deprecated.js"],
   "type": "module",
   "bugs": {
     "url": "https://github.com/playcanvas/engine/issues"


### PR DESCRIPTION
The engine is marked as [not having sideEffects](https://github.com/playcanvas/engine/blob/main/package.json#L49), however [deprecated.js contains numerous side effects](https://github.com/playcanvas/engine/blob/a611fe2ac0da8e89f0adb9d059c91a68a2f2f750/src/deprecated/deprecated.js#L782-L792).

This has important consequences, as most bundlers will tree-shake/remove `deprecated.js` in a production build, meaning code can behave differently in production. You can see a repro here https://stackblitz.com/edit/vitejs-vite-t6vvne?file=main.js,vite.config.js,index.html


This PR marks `deprecated.js` as a sideEffect which is a common indicator to most bundlers not to tree-shake that file.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
