### PR TITLE
Removes deprecated `.wheel` in OrbitCamera

### DIFF
--- a/scripts/camera/orbit-camera.js
+++ b/scripts/camera/orbit-camera.js
@@ -494,9 +494,9 @@ OrbitCameraInputMouse.prototype.onMouseMove = function (event) {
 
 OrbitCameraInputMouse.prototype.onMouseWheel = function (event) {
     if (this.entity.camera.projection === pc.PROJECTION_PERSPECTIVE) {
-        this.orbitCamera.distance -= event.wheel * this.distanceSensitivity * (this.orbitCamera.distance * 0.1);
+        this.orbitCamera.distance -= event.wheelDelta * -2 * this.distanceSensitivity * (this.orbitCamera.distance * 0.1);
     } else {
-        this.orbitCamera.orthoHeight -= event.wheel * this.distanceSensitivity;
+        this.orbitCamera.orthoHeight -= event.wheelDelta * -2 * this.distanceSensitivity;
     }
     event.event.preventDefault();
 };


### PR DESCRIPTION
Removes the deprecated `.wheel` property in the OrbitCamera, which was breaking projects in production. See https://github.com/playcanvas/engine/pull/7114

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
