### PR TITLE
[Fix] Fixes handling uf (u/i)sampler2DArray shader translation for WebGPU

### DIFF
--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -354,19 +354,17 @@ class BindGroupFormat {
 
             let textureType = textureDimensionInfo[format.textureDimension];
             Debug.assert(textureType, 'Unsupported texture type', format.textureDimension);
+            const isArray = textureType === 'texture2DArray';
+
+            const sampleTypePrefix = format.sampleType === SAMPLETYPE_UINT ? 'u' : (format.sampleType === SAMPLETYPE_INT ? 'i' : '');
+            textureType = `${sampleTypePrefix}${textureType}`;
 
             // handle texture2DArray by renaming the texture object and defining a replacement macro
             let namePostfix = '';
             let extraCode = '';
-            if (textureType === 'texture2DArray') {
+            if (isArray) {
                 namePostfix = '_texture';
-                extraCode = `#define ${format.name} sampler2DArray(${format.name}${namePostfix}, ${format.name}_sampler)\n`;
-            }
-
-            if (format.sampleType === SAMPLETYPE_INT) {
-                textureType = `i${textureType}`;
-            } else if (format.sampleType === SAMPLETYPE_UINT) {
-                textureType = `u${textureType}`;
+                extraCode = `#define ${format.name} ${sampleTypePrefix}sampler2DArray(${format.name}${namePostfix}, ${format.name}_sampler)\n`;
             }
 
             code += `layout(set = ${bindGroup}, binding = ${format.slot}) uniform ${textureType} ${format.name}${namePostfix};\n`;


### PR DESCRIPTION
the `u` or `i` prefix needs to be added to the line where we define a sampler

example, instead of this: 
`#define uTmpTexture sampler2DArray(uTmpTexture_texture, uTmpTexture_sampler)`
we generate this
`#define uTmpTexture usampler2DArray(uTmpTexture_texture, uTmpTexture_sampler)`

related to https://forum.playcanvas.com/t/is-usampler2darray-available-in-webgpu/38289