### PR TITLE
Support compressed.ply spherical harmonics

### DIFF
--- a/src/core/math/float-packing.js
+++ b/src/core/math/float-packing.js
@@ -5,6 +5,17 @@ const oneDiv255 = 1 / 255;
 const floatView = new Float32Array(1);
 const int32View = new Int32Array(floatView.buffer);
 
+const f32 = new Float32Array(1);
+const magicF = new Float32Array(1);
+const wasInfNanF = new Float32Array(1);
+
+const u32 = new Uint32Array(f32.buffer);
+const magicU = new Uint32Array(magicF.buffer);
+const wasInfNanU = new Uint32Array(wasInfNanF.buffer);
+
+magicU[0] = (254 - 15) << 23;
+wasInfNanU[0] = (127 + 16) << 23;
+
 /**
  * Utility static class providing functionality to pack float values to various storage
  * representations.
@@ -119,6 +130,24 @@ class FloatPacking {
         value = math.clamp((value - min) / (max - min), 0, 1);
         FloatPacking.float2Bytes(value, array, offset, numBytes);
     }
+
+    /**
+     * Unpacks a 16 bit half floating point value to a float.
+     * 
+     * Based on https://fgiesen.wordpress.com/2012/03/28/half-to-float-done-quic/
+     *
+     * @param {number} value - The half value to pack as a uint16.
+     * @returns {number} The packed value.
+     */
+    static half2Float(value) {
+        u32[0] = (value & 0x7fff) << 13;
+        f32[0] *= magicF[0];
+        if (f32[0] >= wasInfNanF[0]) {
+            u32[0] |= 255 << 23;
+        }
+        u32[0] |= (value & 0x8000) << 16;
+        return f32[0];
+    };
 
     /**
      * Packs a float into specified number of bytes, using 1 byte for exponent and the remaining

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -271,6 +271,7 @@ const readCompressedPly = async (streamBuf, elements, littleEndian) => {
 
         while (cursor < length) {
             while (streamBuf.remaining === 0) {
+                /* eslint-disable no-await-in-loop */
                 await streamBuf.read();
             }
 

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -186,7 +186,7 @@ class Texture {
      * - {@link FUNC_NOTEQUAL}
      *
      * Defaults to {@link FUNC_LESS}.
-     * @param {Uint8Array[]|HTMLCanvasElement[]|HTMLImageElement[]|HTMLVideoElement[]|Uint8Array[][]} [options.levels]
+     * @param {Uint8Array[]|Uint16Array[]|Uint32Array|HTMLCanvasElement[]|HTMLImageElement[]|HTMLVideoElement[]|Uint8Array[][]} [options.levels]
      * - Array of Uint8Array or other supported browser interface; or a two-dimensional array
      * of Uint8Array if options.arrayLength is defined and greater than zero.
      * @param {boolean} [options.storage] - Defines if texture can be used as a storage texture by

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -186,7 +186,7 @@ class Texture {
      * - {@link FUNC_NOTEQUAL}
      *
      * Defaults to {@link FUNC_LESS}.
-     * @param {Uint8Array[]|Uint16Array[]|Uint32Array|HTMLCanvasElement[]|HTMLImageElement[]|HTMLVideoElement[]|Uint8Array[][]} [options.levels]
+     * @param {Uint8Array[]|Uint16Array[]|Uint32Array[]|Float32Array[]|HTMLCanvasElement[]|HTMLImageElement[]|HTMLVideoElement[]|Uint8Array[][]} [options.levels]
      * - Array of Uint8Array or other supported browser interface; or a two-dimensional array
      * of Uint8Array if options.arrayLength is defined and greater than zero.
      * @param {boolean} [options.storage] - Defines if texture can be used as a storage texture by

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -126,21 +126,26 @@ class SplatCompressedIterator {
                 ];
 
                 for (let i = 0; i < 3; ++i) {
-                    sh[i * 15 + 0] = halfToFloat(band1Data[b1[i] * 3 + 0]);
-                    sh[i * 15 + 1] = halfToFloat(band1Data[b1[i] * 3 + 1]);
-                    sh[i * 15 + 2] = halfToFloat(band1Data[b1[i] * 3 + 2]);
-                    sh[i * 15 + 3] = halfToFloat(band2Data[b2[i] * 5 + 0]);
-                    sh[i * 15 + 4] = halfToFloat(band2Data[b2[i] * 5 + 1]);
-                    sh[i * 15 + 5] = halfToFloat(band2Data[b2[i] * 5 + 2]);
-                    sh[i * 15 + 6] = halfToFloat(band2Data[b2[i] * 5 + 3]);
-                    sh[i * 15 + 7] = halfToFloat(band2Data[b2[i] * 5 + 4]);
-                    sh[i * 15 + 8] = halfToFloat(band3Data[b3[i] * 7 + 0]);
-                    sh[i * 15 + 9] = halfToFloat(band3Data[b3[i] * 7 + 1]);
-                    sh[i * 15 + 10] = halfToFloat(band3Data[b3[i] * 7 + 2]);
-                    sh[i * 15 + 11] = halfToFloat(band3Data[b3[i] * 7 + 3]);
-                    sh[i * 15 + 12] = halfToFloat(band3Data[b3[i] * 7 + 4]);
-                    sh[i * 15 + 13] = halfToFloat(band3Data[b3[i] * 7 + 5]);
-                    sh[i * 15 + 14] = halfToFloat(band3Data[b3[i] * 7 + 6]);
+                    const i1 = b1[i] * 3;
+                    sh[i * 15 + 0] = halfToFloat(band1Data[i1 + 0]);
+                    sh[i * 15 + 1] = halfToFloat(band1Data[i1 + 1]);
+                    sh[i * 15 + 2] = halfToFloat(band1Data[i1 + 2]);
+
+                    const i2 = b2[i] * 5;
+                    sh[i * 15 + 3] = halfToFloat(band2Data[i2 + 0]);
+                    sh[i * 15 + 4] = halfToFloat(band2Data[i2 + 1]);
+                    sh[i * 15 + 5] = halfToFloat(band2Data[i2 + 2]);
+                    sh[i * 15 + 6] = halfToFloat(band2Data[i2 + 3]);
+                    sh[i * 15 + 7] = halfToFloat(band2Data[i2 + 4]);
+
+                    const i3 = b3[i] * 7;
+                    sh[i * 15 + 8] = halfToFloat(band3Data[i3 + 0]);
+                    sh[i * 15 + 9] = halfToFloat(band3Data[i3 + 1]);
+                    sh[i * 15 + 10] = halfToFloat(band3Data[i3 + 2]);
+                    sh[i * 15 + 11] = halfToFloat(band3Data[i3 + 3]);
+                    sh[i * 15 + 12] = halfToFloat(band3Data[i3 + 4]);
+                    sh[i * 15 + 13] = halfToFloat(band3Data[i3 + 5]);
+                    sh[i * 15 + 14] = halfToFloat(band3Data[i3 + 6]);
                 }
             }
         };

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -102,6 +102,36 @@ class GSplatCompressedData {
      */
     vertexData;
 
+    // optional spherical harmonics data
+
+    /**
+     * Contains 3 half values per band 1 palette entry
+     * @type {Uint16Array}
+     */
+    band1Data;
+
+    /**
+     * Contains 5 half values per band 2 palette entry
+     * @type {Uint16Array}
+     */
+    band2Data;
+
+    /**
+     * Contains 7 half values per band 3 palette entry
+     * @type {Uint16Array}
+     */
+    band3Data;
+
+    /**
+     * Contains 4 uint32 per vertex with packed bits referencing the SH palette:
+     *      packed_sh_0
+     *      packed_sh_1
+     *      packed_sh_2
+     *      packed_sh_3
+     * @type {Uint32Array}
+     */
+    packedSHData;
+
     /**
      * Create an iterator for accessing splat data
      *
@@ -207,6 +237,10 @@ class GSplatCompressedData {
 
     get isCompressed() {
         return true;
+    }
+
+    get hasSHData() {
+        return !!this.packedSHData;
     }
 
     // decompress into GSplatData

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -1,4 +1,3 @@
-import { FloatPacking } from '../../core/math/float-packing.js';
 import { Quat } from '../../core/math/quat.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Vec4 } from '../../core/math/vec4.js';

--- a/src/scene/gsplat/gsplat-compressed-material.js
+++ b/src/scene/gsplat/gsplat-compressed-material.js
@@ -200,6 +200,141 @@ const splatCoreVS = /* glsl */ `
 
         return vec4(v1, v2);
     }
+
+#if defined(USE_SH)
+    #define SH_C1 0.4886025119029199f
+
+    #define SH_C2_0 1.0925484305920792f
+    #define SH_C2_1 -1.0925484305920792f
+    #define SH_C2_2 0.31539156525252005f
+    #define SH_C2_3 -1.0925484305920792f
+    #define SH_C2_4 0.5462742152960396f
+
+    #define SH_C3_0 -0.5900435899266435f
+    #define SH_C3_1 2.890611442640554f
+    #define SH_C3_2 -0.4570457994644658f
+    #define SH_C3_3 0.3731763325901154f
+    #define SH_C3_4 -0.4570457994644658f
+    #define SH_C3_5 1.445305721320277f
+    #define SH_C3_6 -0.5900435899266435f
+
+    uniform highp sampler2D band1Texture;
+    uniform highp sampler2D band2Texture;
+    uniform highp sampler2D band3Texture;
+    uniform highp usampler2D packedSHTexture;
+
+    ivec2 shUV(uint index) {
+        return ivec2(int(index & 1023u) * 2, int(index / 1024u));
+    }
+
+    void readSHData(out vec3 sh[15]) {
+        // read the splat indices
+        uvec4 packedSHData = texelFetch(packedSHTexture, packedUV, 0);
+
+        // generate palette uvs from packed bits
+
+        // 11, 11, 10
+        ivec2 band1r = ivec2(int(packedSHData.x >> 21u), 0);
+        ivec2 band1g = ivec2(int((packedSHData.x >> 10u) & 0x7ffu), 0);
+        ivec2 band1b = ivec2(int(packedSHData.x & 0x3ffu), 0);
+
+        // 15, 15, 15
+        ivec2 band2r = shUV((packedSHData.y >> 17u) & 0x7fffu);
+        ivec2 band2g = shUV((packedSHData.y >> 2u) & 0x7fffu);
+        ivec2 band2b = shUV(((packedSHData.y << 13u) | (packedSHData.z >> 19u)) & 0x7fffu);
+
+        // 17, 17, 17
+        ivec2 band3r = shUV((packedSHData.z >> 2u) & 0x1ffffu);
+        ivec2 band3g = shUV(((packedSHData.z << 15u) | (packedSHData.w >> 17u)) & 0x1ffffu);
+        ivec2 band3b = shUV(packedSHData.w & 0x1ffffu);
+
+        // sample palette coefficients
+
+        // band 1
+        vec3 a = texelFetch(band1Texture, band1r, 0).xyz;
+        vec3 b = texelFetch(band1Texture, band1g, 0).xyz;
+        vec3 c = texelFetch(band1Texture, band1b, 0).xyz;
+
+        // band 2
+        vec4 d = texelFetch(band2Texture, band2r, 0);
+        float e = texelFetch(band2Texture, band2r + ivec2(1, 0), 0).x;
+        vec4 f = texelFetch(band2Texture, band2g, 0);
+        float g = texelFetch(band2Texture, band2g + ivec2(1, 0), 0).x;
+        vec4 h = texelFetch(band2Texture, band2b, 0);
+        float i = texelFetch(band2Texture, band2b + ivec2(1, 0), 0).x;
+
+        // band 3
+        vec4 j = texelFetch(band3Texture, band3r, 0);
+        vec3 k = texelFetch(band3Texture, band3r + ivec2(1, 0), 0).xyz;
+        vec4 l = texelFetch(band3Texture, band3g, 0);
+        vec3 m = texelFetch(band3Texture, band3g + ivec2(1, 0), 0).xyz;
+        vec4 n = texelFetch(band3Texture, band3b, 0);
+        vec3 o = texelFetch(band3Texture, band3b + ivec2(1, 0), 0).xyz;
+
+        sh[0] = vec3(a.x, b.x, c.x);
+        sh[1] = vec3(a.y, b.y, c.y);
+        sh[2] = vec3(a.z, b.z, c.z);
+        sh[3] = vec3(d.x, f.x, h.x);
+        sh[4] = vec3(d.y, f.y, h.y);
+        sh[5] = vec3(d.z, f.z, h.z);
+        sh[6] = vec3(d.w, f.w, h.w);
+        sh[7] = vec3(e, g, i);
+        sh[8] = vec3(j.x, l.x, n.x);
+        sh[9] = vec3(j.y, l.y, n.y);
+        sh[10] = vec3(j.z, l.z, n.z);
+        sh[11] = vec3(j.w, l.w, n.w);
+        sh[12] = vec3(k.x, m.x, o.x);
+        sh[13] = vec3(k.y, m.y, o.y);
+        sh[14] = vec3(k.z, m.z, o.z);
+    }
+
+    // see https://github.com/graphdeco-inria/gaussian-splatting/blob/main/utils/sh_utils.py
+    vec3 evalSH(in vec3 dir) {
+
+        vec3 sh[15];
+        readSHData(sh);
+
+        vec3 result = vec3(0.0);
+
+        // 1st degree
+        float x = dir.x;
+        float y = dir.y;
+        float z = dir.z;
+
+        result += SH_C1 * (-sh[0] * y + sh[1] * z - sh[2] * x);
+
+        // 2nd degree
+        float xx = x * x;
+        float yy = y * y;
+        float zz = z * z;
+        float xy = x * y;
+        float yz = y * z;
+        float xz = x * z;
+
+        result +=
+            sh[3] * (SH_C2_0 * xy) *  +
+            sh[4] * (SH_C2_1 * yz) +
+            sh[5] * (SH_C2_2 * (2.0 * zz - xx - yy)) +
+            sh[6] * (SH_C2_3 * xz) +
+            sh[7] * (SH_C2_4 * (xx - yy));
+
+        // 3rd degree
+        result +=
+            sh[8]  * (SH_C3_0 * y * (3.0 * xx - yy)) +
+            sh[9]  * (SH_C3_1 * xy * z) +
+            sh[10] * (SH_C3_2 * y * (4.0 * zz - xx - yy)) +
+            sh[11] * (SH_C3_3 * z * (2.0 * zz - 3.0 * xx - 3.0 * yy)) +
+            sh[12] * (SH_C3_4 * x * (4.0 * zz - xx - yy)) +
+            sh[13] * (SH_C3_5 * z * (xx - yy)) +
+            sh[14] * (SH_C3_6 * x * (xx - 3.0 * yy));
+
+        return result;
+    }
+#else
+    vec3 evalSH(in vec3 dir) {
+        return vec3(0.0);
+    }
+#endif
 `;
 
 const splatCoreFS = /* glsl */ `
@@ -255,8 +390,8 @@ class GSplatCompressedShaderGenerator {
         const shaderPassDefines = shaderPassInfo.shaderDefines;
 
         const defines =
-            `${shaderPassDefines
-            }#define DITHER_${options.dither.toUpperCase()}\n` +
+            `${shaderPassDefines}\n` +
+            `#define DITHER_${options.dither.toUpperCase()}\n` +
             `#define TONEMAP_${options.toneMapping === TONEMAP_LINEAR ? 'DISABLED' : 'ENABLED'}\n`;
 
         const vs = defines + splatCoreVS + options.vertex;
@@ -267,7 +402,9 @@ class GSplatCompressedShaderGenerator {
             splatCoreFS + options.fragment;
 
         const defineMap = new Map();
-        options.defines.forEach(value => defineMap.set(value, true));
+        options.defines.forEach((value, key) => {
+            defineMap.set(key, value);
+        });
 
         return ShaderUtils.createDefinition(device, {
             name: 'SplatShader',
@@ -288,6 +425,8 @@ const gsplatCompressed = new GSplatCompressedShaderGenerator();
 const splatMainVS = /* glsl */ `
     varying mediump vec2 texCoord;
     varying mediump vec4 color;
+
+    uniform vec3 view_position;
 
     mediump vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
 
@@ -339,6 +478,12 @@ const splatMainVS = /* glsl */ `
         gl_Position = splat_proj + vec4((vertex_position.x * v1v2.xy + vertex_position.y * v1v2.zw) / viewport * splat_proj.w, 0, 0);
 
         texCoord = vertex_position.xy * scale / 2.0;
+
+        #ifdef USE_SH
+            vec4 worldCenter = matrix_model * vec4(center, 1.0);
+            vec3 viewDir = normalize((worldCenter.xyz / worldCenter.w - view_position) * mat3(matrix_model));
+            color.xyz = max(color.xyz + evalSH(viewDir), 0.0);
+        #endif
 
         #ifndef DITHER_NONE
             id = float(splatId);

--- a/src/scene/gsplat/gsplat-compressed-material.js
+++ b/src/scene/gsplat/gsplat-compressed-material.js
@@ -37,6 +37,8 @@ const splatCoreVS = /* glsl */ `
     vec4 chunkDataA;    // x: min_x, y: min_y, z: min_z, w: max_x
     vec4 chunkDataB;    // x: max_y, y: max_z, z: scale_min_x, w: scale_min_y
     vec4 chunkDataC;    // x: scale_min_z, y: scale_max_x, z: scale_max_y, w: scale_max_z
+    vec4 chunkDataD;    // x: min_r, y: min_g, z: min_b, w: max_r
+    vec4 chunkDataE;    // x: max_g, y: max_b, z: unused, w: unused
     uvec4 packedData;   // x: position bits, y: rotation bits, z: scale bits, w: color bits
 
     // calculate the current splat index and uvs
@@ -67,7 +69,7 @@ const splatCoreVS = /* glsl */ `
         // calculate chunkUV
         uint chunkId = splatId / 256u;
         chunkUV = ivec2(
-            int((chunkId % chunkWidth) * 3u),
+            int((chunkId % chunkWidth) * 5u),
             int(chunkId / chunkWidth)
         );
 
@@ -79,6 +81,8 @@ const splatCoreVS = /* glsl */ `
         chunkDataA = texelFetch(chunkTexture, chunkUV, 0);
         chunkDataB = texelFetch(chunkTexture, ivec2(chunkUV.x + 1, chunkUV.y), 0);
         chunkDataC = texelFetch(chunkTexture, ivec2(chunkUV.x + 2, chunkUV.y), 0);
+        chunkDataD = texelFetch(chunkTexture, ivec2(chunkUV.x + 3, chunkUV.y), 0);
+        chunkDataE = texelFetch(chunkTexture, ivec2(chunkUV.x + 4, chunkUV.y), 0);
         packedData = texelFetch(packedTexture, packedUV, 0);
     }
 
@@ -127,7 +131,8 @@ const splatCoreVS = /* glsl */ `
     }
 
     vec4 getColor() {
-        return unpack8888(packedData.w);
+        vec4 r = unpack8888(packedData.w);
+        return vec4(mix(chunkDataD.xyz, vec3(chunkDataD.w, chunkDataE.xy), r.rgb), r.w);
     }
 
     mat3 quatToMat3(vec4 R) {

--- a/src/scene/gsplat/gsplat-compressed-material.js
+++ b/src/scene/gsplat/gsplat-compressed-material.js
@@ -239,7 +239,7 @@ const splatCoreVS = /* glsl */ `
         ivec2 band1b = ivec2(int(packedSHData.x & 0x3ffu), 0);
 
         // 15, 15, 15
-        ivec2 band2r = shUV((packedSHData.y >> 17u) & 0x7fffu);
+        ivec2 band2r = shUV(packedSHData.y >> 17u);
         ivec2 band2g = shUV((packedSHData.y >> 2u) & 0x7fffu);
         ivec2 band2b = shUV(((packedSHData.y << 13u) | (packedSHData.z >> 19u)) & 0x7fffu);
 

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -2,7 +2,7 @@ import { Vec2 } from '../../core/math/vec2.js';
 import { Texture } from '../../platform/graphics/texture.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import {
-    ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_RGBA32F, PIXELFORMAT_RGBA32U
+    ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F, PIXELFORMAT_RGBA32U
 } from '../../platform/graphics/constants.js';
 import { createGSplatCompressedMaterial } from './gsplat-compressed-material.js';
 
@@ -31,6 +31,18 @@ class GSplatCompressed {
     /** @type {Texture} */
     chunkTexture;
 
+    /** @type {Texture?} */
+    band1Texture;
+
+    /** @type {Texture?} */
+    band2Texture;
+
+    /** @type {Texture?} */
+    band3Texture;
+
+    /** @type {Texture?} */
+    packedSHTexture;
+
     /**
      * @param {GraphicsDevice} device - The graphics device.
      * @param {GSplatCompressedData} gsplatData - The splat data.
@@ -58,6 +70,52 @@ class GSplatCompressed {
         chunkSize.x *= 3;
 
         this.chunkTexture = this.createTexture('chunkData', PIXELFORMAT_RGBA32F, chunkSize, gsplatData.chunkData);
+
+        if (gsplatData.hasSHData) {
+            const { band1Data, band2Data, band3Data, packedSHData } = gsplatData;
+
+            const calcDim = (numEntries) => {
+                return new Vec2(2048, Math.ceil(numEntries / 1024));
+            };
+
+            // pad ushort data with zeros
+            const padUint16 = (target, targetStride, src, srcStride, numEntries) => {
+                for (let i = 0; i < numEntries; ++i) {
+                    for (let j = 0; j < srcStride; ++j) {
+                        target[i * targetStride + j] = src[i * srcStride + j];
+                    }
+                }
+            };
+
+            // unpack the palette coefficients to align nicely to RGBA16F boundaries for ease of reading on gpu
+
+            // band1 has max 2k entries, 3 coefficients each, 1 pixel per entry.
+            const band1Size = band1Data.length / 3;
+            this.band1Texture = this.createTexture('band1Palette', PIXELFORMAT_RGBA16F, new Vec2(band1Size, 1));
+            padUint16(this.band1Texture.lock(), 4, band1Data, 3, band1Size);
+
+            // band2 has max 32k entries, 5 coefficients each, 2 pixels per entry.
+            const band2Size = band2Data.length / 5;
+            this.band2Texture = this.createTexture('band2Palette', PIXELFORMAT_RGBA16F, calcDim(band2Size));
+            padUint16(this.band2Texture.lock(), 8, band2Data, 5, band2Size);
+
+            // band3 has max 128k entries, 7 coefficients each, 2 pixels per entry.
+            const band3Size = band3Data.length / 7;
+            this.band3Texture = this.createTexture('band3Palette', PIXELFORMAT_RGBA16F, calcDim(band3Size));
+            padUint16(this.band3Texture.lock(), 8, band3Data, 7, band3Size);
+
+            // packed SH data is loaded directly
+            this.packedSHTexture = this.createTexture('packedSHData', PIXELFORMAT_RGBA32U, this.evalTextureSize(numSplats), packedSHData);
+
+            this.band1Texture.unlock();
+            this.band2Texture.unlock();
+            this.band3Texture.unlock();
+        } else {
+            this.band1Texture = null;
+            this.band2Texture = null;
+            this.band3Texture = null;
+            this.packedSHTexture = null;
+        }
     }
 
     destroy() {
@@ -74,6 +132,13 @@ class GSplatCompressed {
         result.setParameter('packedTexture', this.packedTexture);
         result.setParameter('chunkTexture', this.chunkTexture);
         result.setParameter('tex_params', new Float32Array([this.numSplats, this.packedTexture.width, this.chunkTexture.width / 3, 0]));
+        if (this.packedSHTexture) {
+            result.setDefine('USE_SH', true);
+            result.setParameter('band1Texture', this.band1Texture);
+            result.setParameter('band2Texture', this.band2Texture);
+            result.setParameter('band3Texture', this.band3Texture);
+            result.setParameter('packedSHTexture', this.packedSHTexture);
+        }
         return result;
     }
 
@@ -97,7 +162,7 @@ class GSplatCompressed {
      * @param {string} name - The name of the texture to be created.
      * @param {number} format - The pixel format of the texture.
      * @param {Vec2} size - The width and height of the texture.
-     * @param {Uint8Array} [data] - The initial data to fill the texture with.
+     * @param {Uint8Array|Uint16Array|Uint32Array} [data] - The initial data to fill the texture with.
      * @returns {Texture} The created texture instance.
      */
     createTexture(name, format, size, data) {

--- a/src/scene/gsplat/gsplat-data.js
+++ b/src/scene/gsplat/gsplat-data.js
@@ -322,6 +322,15 @@ class GSplatData {
         return false;
     }
 
+    get hasSHData() {
+        for (let i = 0; i < 45; ++i) {
+            if (!this.getProp(`f_rest_${i}`)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     calcMortonOrder() {
         const calcMinMax = (arr) => {
             let min = arr[0];

--- a/src/scene/gsplat/gsplat.js
+++ b/src/scene/gsplat/gsplat.js
@@ -87,7 +87,7 @@ class GSplat {
         this.updateTransformData(gsplatData);
 
         // initialize SH data
-        this.hasSH = getSHData(gsplatData).every(x => x);
+        this.hasSH = gsplatData.hasSHData;
         if (this.hasSH) {
             this.sh1to3Texture = this.createTexture('splatSH_1to3', PIXELFORMAT_RGBA32U, size);
             this.sh4to7Texture = this.createTexture('splatSH_4to7', PIXELFORMAT_RGBA32U, size);


### PR DESCRIPTION
This PR:
- adds support for loading and rendering compressed spherical harmonic data in `compressed.ply` files
- the details of the format will be described elsewhere with the release in SuperSplat, but in summary:
    - 3 palettes of spherical harmonics coefficients are stored per file (one for each sh band)
    - each splat stores 9 indices into this data (r,g,b indices for band 1, 2, 3), totalling 128bits
- this results in compressed files being roughly twice the size with 3 bands of spherical harmonics
- small type fix for specifying texture data

Notes:
- we are adding support here for 0 or 3 bands of spherical harmonics, but may add explicit support for 1 and 2 bands in future
- the palette data is stored in halfs for the space savings, but it might be preferable to use floats