### PR TITLE
EventHandle.off - performance improvements

### DIFF
--- a/src/core/event-handle.js
+++ b/src/core/event-handle.js
@@ -32,7 +32,7 @@ class EventHandle {
 
     /**
      * @type {string}
-     * @private
+     * @ignore
      */
     name;
 
@@ -81,7 +81,7 @@ class EventHandle {
      */
     off() {
         if (this._removed) return;
-        this.handler.off(this.name, this.callback, this.scope);
+        this.handler.offByHandle(this);
     }
 
     on(name, callback, scope = this) {

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -223,6 +223,40 @@ class EventHandler {
     }
 
     /**
+     * Detach an event handler from an event using EventHandle instance. More optimal remove
+     * as it does not have to scan callbacks array.
+     *
+     * @param {EventHandle} handle - Handle of event.
+     * @ignore
+     */
+    offByHandle(handle) {
+        const name = handle.name;
+        handle.removed = true;
+
+        // if we are removing a callback from the list that is executing right now
+        // ensure we preserve initial list before modifications
+        if (this._callbackActive.has(name) && this._callbackActive.get(name) === this._callbacks.get(name)) {
+            this._callbackActive.set(name, this._callbackActive.get(name).slice());
+        }
+
+        const callbacks = this._callbacks.get(name);
+        if (!callbacks) {
+            return this;
+        }
+
+        const ind = callbacks.indexOf(handle);
+        if (ind !== -1) {
+            callbacks.splice(ind, 1);
+
+            if (callbacks.length === 0) {
+                this._callbacks.delete(name);
+            }
+        }
+
+        return this;
+    }
+
+    /**
      * Fire an event, all additional arguments are passed on to the event listener.
      *
      * @param {string} name - Name of event to fire.


### PR DESCRIPTION
No logic changes.

Since EventHandle was implemented, developer lives for events management have been simplified. At the same time there is a new opportunity for optimization. This PR does just that, when using EventHandle.off, instead of scanning callbacks and comparing `name`, `callback` and `scope`, now it uses EventHandle itself and checks if it is in array, if so, removes it.

This leads to massive performance improvements when .off is called on EventHandle vs .off on EventHandler.

One of these cases is [onDisable](https://github.com/playcanvas/engine/blob/079caff78cf969825445f0f367b8117f0816c49f/src/framework/components/render/component.js#L827-L830) on RenderComponent (and similar components). On large scenes with a lot of render components `scene._callbacks['set:layers']` - becomes a very large array, the same applies to `app.layers._callbacks`.

In some of our projects, disabling render components leads to a massive lag spike, in one specific project disabling big chunk of a scene takes ~3500ms, with this optimization time is reduces to ~900ms.

To benefit from this optimization, we need to use EventHandle within engine as much as possible, instead of a `off` on EventHandler's.

PR's with EventHandle.off in critical places coming after this one.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
