### PR TITLE
Renamed shadow type constants, old constants are deprecated

### DIFF
--- a/examples/src/examples/animation/blend-trees-1d.example.mjs
+++ b/examples/src/examples/animation/blend-trees-1d.example.mjs
@@ -92,7 +92,7 @@ assetListLoader.load(() => {
         castShadows: true,
         intensity: 1.5,
         normalOffsetBias: 0.02,
-        shadowType: pc.SHADOW_PCF5,
+        shadowType: pc.SHADOW_PCF5_32F,
         shadowDistance: 6,
         shadowResolution: 2048,
         shadowBias: 0.02

--- a/examples/src/examples/animation/blend-trees-2d-cartesian.example.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.example.mjs
@@ -97,7 +97,7 @@ assetListLoader.load(() => {
         castShadows: true,
         intensity: 1.5,
         normalOffsetBias: 0.02,
-        shadowType: pc.SHADOW_PCF5,
+        shadowType: pc.SHADOW_PCF5_32F,
         shadowDistance: 6,
         shadowResolution: 2048,
         shadowBias: 0.02

--- a/examples/src/examples/animation/blend-trees-2d-directional.example.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-directional.example.mjs
@@ -95,7 +95,7 @@ assetListLoader.load(() => {
         castShadows: true,
         intensity: 1.5,
         normalOffsetBias: 0.02,
-        shadowType: pc.SHADOW_PCF5,
+        shadowType: pc.SHADOW_PCF5_32F,
         shadowDistance: 6,
         shadowResolution: 2048,
         shadowBias: 0.02

--- a/examples/src/examples/animation/layer-masks.example.mjs
+++ b/examples/src/examples/animation/layer-masks.example.mjs
@@ -113,7 +113,7 @@ assetListLoader.load(() => {
         castShadows: true,
         intensity: 1.5,
         normalOffsetBias: 0.02,
-        shadowType: pc.SHADOW_PCF5,
+        shadowType: pc.SHADOW_PCF5_32F,
         shadowDistance: 6,
         shadowResolution: 2048,
         shadowBias: 0.02

--- a/examples/src/examples/graphics/clustered-omni-shadows.controls.mjs
+++ b/examples/src/examples/graphics/clustered-omni-shadows.controls.mjs
@@ -17,12 +17,12 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 link: { observer, path: 'settings.shadowType' },
                 type: 'number',
                 options: [
-                    { v: pc.SHADOW_PCF1, t: 'PCF1' },
-                    { v: pc.SHADOW_PCF3, t: 'PCF3' },
-                    { v: pc.SHADOW_PCF5, t: 'PCF5' },
-                    { v: pc.SHADOW_PCF1_FLOAT16, t: 'PCF1_FLOAT16' },
-                    { v: pc.SHADOW_PCF3_FLOAT16, t: 'PCF3_FLOAT16' },
-                    { v: pc.SHADOW_PCF5_FLOAT16, t: 'PCF5_FLOAT16' }
+                    { v: pc.SHADOW_PCF1_32F, t: 'PCF1_32F' },
+                    { v: pc.SHADOW_PCF3_32F, t: 'PCF3_32F' },
+                    { v: pc.SHADOW_PCF5_32F, t: 'PCF5_32F' },
+                    { v: pc.SHADOW_PCF1_16F, t: 'PCF1_16F' },
+                    { v: pc.SHADOW_PCF3_16F, t: 'PCF3_16F' },
+                    { v: pc.SHADOW_PCF5_16F, t: 'PCF5_16F' }
                 ]
             })
         ),

--- a/examples/src/examples/graphics/clustered-omni-shadows.example.mjs
+++ b/examples/src/examples/graphics/clustered-omni-shadows.example.mjs
@@ -70,7 +70,7 @@ assetListLoader.load(() => {
 
     data.set('settings', {
         shadowAtlasResolution: 1300, // shadow map resolution storing all shadows
-        shadowType: pc.SHADOW_PCF3, // shadow filter type
+        shadowType: pc.SHADOW_PCF3_32F, // shadow filter type
         shadowsEnabled: true,
         cookiesEnabled: true
     });

--- a/examples/src/examples/graphics/clustered-spot-shadows.controls.mjs
+++ b/examples/src/examples/graphics/clustered-spot-shadows.controls.mjs
@@ -44,12 +44,12 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     link: { observer, path: 'settings.shadowType' },
                     type: 'number',
                     options: [
-                        { v: pc.SHADOW_PCF1, t: 'PCF1' },
-                        { v: pc.SHADOW_PCF3, t: 'PCF3' },
-                        { v: pc.SHADOW_PCF5, t: 'PCF5' },
-                        { v: pc.SHADOW_PCF1_FLOAT16, t: 'PCF1_FLOAT16' },
-                        { v: pc.SHADOW_PCF3_FLOAT16, t: 'PCF3_FLOAT16' },
-                        { v: pc.SHADOW_PCF5_FLOAT16, t: 'PCF5_FLOAT16' }
+                        { v: pc.SHADOW_PCF1_32F, t: 'PCF1_32F' },
+                        { v: pc.SHADOW_PCF3_32F, t: 'PCF3_32F' },
+                        { v: pc.SHADOW_PCF5_32F, t: 'PCF5_32F' },
+                        { v: pc.SHADOW_PCF1_16F, t: 'PCF1_16F' },
+                        { v: pc.SHADOW_PCF3_16F, t: 'PCF3_16F' },
+                        { v: pc.SHADOW_PCF5_16F, t: 'PCF5_16F' }
                     ]
                 })
             )

--- a/examples/src/examples/graphics/clustered-spot-shadows.example.mjs
+++ b/examples/src/examples/graphics/clustered-spot-shadows.example.mjs
@@ -61,7 +61,7 @@ assetListLoader.load(() => {
 
     data.set('settings', {
         shadowAtlasResolution: 1024, // shadow map resolution storing all shadows
-        shadowType: pc.SHADOW_PCF3, // shadow filter type
+        shadowType: pc.SHADOW_PCF3_32F, // shadow filter type
         shadowsEnabled: true,
         cookiesEnabled: true,
         shadowIntensity: 1,

--- a/examples/src/examples/graphics/contact-hardening-shadows.controls.mjs
+++ b/examples/src/examples/graphics/contact-hardening-shadows.controls.mjs
@@ -46,8 +46,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'script.area.shadowType' },
                     options: [
-                        { v: pc.SHADOW_PCSS, t: 'PCSS' },
-                        { v: pc.SHADOW_PCF5, t: 'PCF' }
+                        { v: pc.SHADOW_PCSS_32F, t: 'PCSS_32F' },
+                        { v: pc.SHADOW_PCF5_32F, t: 'PCF_32F' }
                     ]
                 })
             )
@@ -91,8 +91,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'script.point.shadowType' },
                     options: [
-                        { v: pc.SHADOW_PCSS, t: 'PCSS' },
-                        { v: pc.SHADOW_PCF5, t: 'PCF' }
+                        { v: pc.SHADOW_PCSS_32F, t: 'PCSS_32F' },
+                        { v: pc.SHADOW_PCF5_32F, t: 'PCF_32F' }
                     ]
                 })
             )
@@ -136,8 +136,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'script.directional.shadowType' },
                     options: [
-                        { v: pc.SHADOW_PCSS, t: 'PCSS' },
-                        { v: pc.SHADOW_PCF5, t: 'PCF' }
+                        { v: pc.SHADOW_PCSS_32F, t: 'PCSS_32F' },
+                        { v: pc.SHADOW_PCF5_32F, t: 'PCF_32F' }
                     ]
                 })
             )

--- a/examples/src/examples/graphics/contact-hardening-shadows.example.mjs
+++ b/examples/src/examples/graphics/contact-hardening-shadows.example.mjs
@@ -113,19 +113,19 @@ assetListLoader.load(() => {
             enabled: true,
             intensity: 16.0,
             size: 2,
-            shadowType: pc.SHADOW_PCSS
+            shadowType: pc.SHADOW_PCSS_32F
         },
         point: {
             enabled: true,
             intensity: 4.0,
             size: 2,
-            shadowType: pc.SHADOW_PCSS
+            shadowType: pc.SHADOW_PCSS_32F
         },
         directional: {
             enabled: true,
             intensity: 2.0,
             size: 1,
-            shadowType: pc.SHADOW_PCSS
+            shadowType: pc.SHADOW_PCSS_32F
         }
     });
 

--- a/examples/src/examples/graphics/dithered-transparency.example.mjs
+++ b/examples/src/examples/graphics/dithered-transparency.example.mjs
@@ -126,7 +126,7 @@ assetListLoader.load(() => {
         range: 200,
         castShadows: true,
         shadowResolution: 2048,
-        shadowType: pc.SHADOW_VSM16,
+        shadowType: pc.SHADOW_VSM_16F,
         vsmBlurSize: 20,
         shadowBias: 0.1,
         normalOffsetBias: 0.1

--- a/examples/src/examples/graphics/ground-fog.example.mjs
+++ b/examples/src/examples/graphics/ground-fog.example.mjs
@@ -119,7 +119,7 @@ assetListLoader.load(() => {
         castShadows: true,
         shadowDistance: 1000,
         shadowResolution: 2048,
-        shadowType: pc.SHADOW_PCF3
+        shadowType: pc.SHADOW_PCF3_32F
     });
     app.root.addChild(dirLight);
     dirLight.setLocalEulerAngles(45, 350, 20);

--- a/examples/src/examples/graphics/lights-baked-a-o.example.mjs
+++ b/examples/src/examples/graphics/lights-baked-a-o.example.mjs
@@ -96,7 +96,7 @@ assetListLoader.load(() => {
         shadowBias: 0.2,
         shadowDistance: 100,
         shadowResolution: 2048,
-        shadowType: pc.SHADOW_PCF3,
+        shadowType: pc.SHADOW_PCF3_32F,
         color: new pc.Color(0.7, 0.7, 0.5),
         intensity: 1.6
     });
@@ -115,7 +115,7 @@ assetListLoader.load(() => {
         shadowBias: 0.2,
         shadowDistance: 25,
         shadowResolution: 512,
-        shadowType: pc.SHADOW_PCF3,
+        shadowType: pc.SHADOW_PCF3_32F,
         color: pc.Color.YELLOW,
         range: 25,
         intensity: 0.9
@@ -135,7 +135,7 @@ assetListLoader.load(() => {
         shadowBias: 0.2,
         shadowDistance: 50,
         shadowResolution: 512,
-        shadowType: pc.SHADOW_PCF3,
+        shadowType: pc.SHADOW_PCF3_32F,
         color: pc.Color.RED,
         range: 10,
         intensity: 2.5

--- a/examples/src/examples/graphics/lights-baked.example.mjs
+++ b/examples/src/examples/graphics/lights-baked.example.mjs
@@ -87,7 +87,7 @@ light.addComponent('light', {
     shadowBias: 0.2,
     shadowDistance: 50,
     shadowResolution: 2048,
-    shadowType: pc.SHADOW_PCF3,
+    shadowType: pc.SHADOW_PCF3_32F,
     color: pc.Color.GREEN,
     type: 'directional'
 });
@@ -105,7 +105,7 @@ lightPoint.addComponent('light', {
     shadowBias: 0.2,
     shadowDistance: 50,
     shadowResolution: 512,
-    shadowType: pc.SHADOW_PCF3,
+    shadowType: pc.SHADOW_PCF3_32F,
     color: pc.Color.RED,
     range: 100,
     type: 'point'

--- a/examples/src/examples/graphics/lights.example.mjs
+++ b/examples/src/examples/graphics/lights.example.mjs
@@ -184,7 +184,7 @@ assetListLoader.load(() => {
             castShadows: true,
             shadowBias: 0.05,
             normalOffsetBias: 0.03,
-            shadowType: pc.SHADOW_PCF3,
+            shadowType: pc.SHADOW_PCF3_32F,
             shadowResolution: 256,
             range: 111,
             cookieAsset: cubemapAsset,

--- a/examples/src/examples/graphics/shadow-cascades.controls.mjs
+++ b/examples/src/examples/graphics/shadow-cascades.controls.mjs
@@ -18,15 +18,15 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     link: { observer, path: 'settings.light.shadowType' },
                     type: 'number',
                     options: [
-                        { v: pc.SHADOW_PCF1, t: 'PCF1' },
-                        { v: pc.SHADOW_PCF3, t: 'PCF3' },
-                        { v: pc.SHADOW_PCF5, t: 'PCF5' },
-                        { v: pc.SHADOW_PCF1_FLOAT16, t: 'PCF1_FLOAT16' },
-                        { v: pc.SHADOW_PCF3_FLOAT16, t: 'PCF3_FLOAT16' },
-                        { v: pc.SHADOW_PCF5_FLOAT16, t: 'PCF5_FLOAT16' },
+                        { v: pc.SHADOW_PCF1_32F, t: 'PCF1_32F' },
+                        { v: pc.SHADOW_PCF3_32F, t: 'PCF3_32F' },
+                        { v: pc.SHADOW_PCF5_32F, t: 'PCF5_32F' },
+                        { v: pc.SHADOW_PCF1_16F, t: 'PCF1_16F' },
+                        { v: pc.SHADOW_PCF3_16F, t: 'PCF3_16F' },
+                        { v: pc.SHADOW_PCF5_16F, t: 'PCF5_16F' },
                         { v: pc.SHADOW_VSM8, t: 'VSM8' },
-                        { v: pc.SHADOW_VSM16, t: 'VSM16' },
-                        { v: pc.SHADOW_VSM32, t: 'VSM32' }
+                        { v: pc.SHADOW_VSM_16F, t: 'VSM_16F' },
+                        { v: pc.SHADOW_VSM_32F, t: 'VSM_32F' }
                     ]
                 })
             ),

--- a/examples/src/examples/graphics/shadow-cascades.example.mjs
+++ b/examples/src/examples/graphics/shadow-cascades.example.mjs
@@ -54,7 +54,7 @@ assetListLoader.load(() => {
             numCascades: 4, // number of cascades
             shadowResolution: 2048, // shadow map resolution storing 4 cascades
             cascadeDistribution: 0.5, // distribution of cascade distances to prefer sharpness closer to the camera
-            shadowType: pc.SHADOW_PCF3, // shadow filter type
+            shadowType: pc.SHADOW_PCF3_32F, // shadow filter type
             vsmBlurSize: 11, // shader filter blur size for VSM shadows
             everyFrame: true // true if all cascades update every frame
         }

--- a/examples/src/examples/physics/offset-collision.example.mjs
+++ b/examples/src/examples/physics/offset-collision.example.mjs
@@ -83,7 +83,7 @@ assetListLoader.load(() => {
         castShadows: true,
         intensity: 1.5,
         normalOffsetBias: 0.2,
-        shadowType: pc.SHADOW_PCF5,
+        shadowType: pc.SHADOW_PCF5_32F,
         shadowDistance: 12,
         shadowResolution: 4096,
         shadowBias: 0.2

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1416,9 +1416,12 @@ class AppBase extends EventHandler {
      * @param {number} settings.render.lightingMaxLightsPerCell - Maximum number of lights a cell can store.
      * @param {number} settings.render.lightingShadowType - The type of shadow filtering used by all shadows. Can be:
      *
-     * - {@link SHADOW_PCF1}: PCF 1x1 sampling.
-     * - {@link SHADOW_PCF3}: PCF 3x3 sampling.
-     * - {@link SHADOW_PCF5}: PCF 5x5 sampling.
+     * - {@link SHADOW_PCF1_32F}
+     * - {@link SHADOW_PCF3_32F}
+     * - {@link SHADOW_PCF5_32F}
+     * - {@link SHADOW_PCF1_16F}
+     * - {@link SHADOW_PCF3_16F}
+     * - {@link SHADOW_PCF5_16F}
      *
      * @param {Vec3} settings.render.lightingCells - Number of cells along each world space axis the space containing lights
      * is subdivided into.

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -547,16 +547,16 @@ class LightComponent extends Component {
     /**
      * Sets the type of shadows being rendered by this light. Can be:
      *
-     * - {@link SHADOW_PCF1}
-     * - {@link SHADOW_PCF3}
-     * - {@link SHADOW_PCF5}
-     * - {@link SHADOW_PCF1_FLOAT16}
-     * - {@link SHADOW_PCF3_FLOAT16}
-     * - {@link SHADOW_PCF5_FLOAT16}
+     * - {@link SHADOW_PCF1_32F}
+     * - {@link SHADOW_PCF3_32F}
+     * - {@link SHADOW_PCF5_32F}
+     * - {@link SHADOW_PCF1_16F}
+     * - {@link SHADOW_PCF3_16F}
+     * - {@link SHADOW_PCF5_16F}
      * - {@link SHADOW_VSM8}
-     * - {@link SHADOW_VSM16}
-     * - {@link SHADOW_VSM32}
-     * - {@link SHADOW_PCSS}
+     * - {@link SHADOW_VSM_16F}
+     * - {@link SHADOW_VSM_32F}
+     * - {@link SHADOW_PCSS_32F}
      *
      * @type {number}
      */

--- a/src/framework/components/light/data.js
+++ b/src/framework/components/light/data.js
@@ -4,7 +4,7 @@ import {
     LAYERID_WORLD,
     LIGHTSHAPE_PUNCTUAL,
     LIGHTFALLOFF_LINEAR,
-    SHADOW_PCF3,
+    SHADOW_PCF3_32F,
     SHADOWUPDATE_REALTIME
 } from '../../../scene/constants.js';
 
@@ -58,7 +58,7 @@ class LightComponentData {
 
     falloffMode = LIGHTFALLOFF_LINEAR;
 
-    shadowType = SHADOW_PCF3;
+    shadowType = SHADOW_PCF3_32F;
 
     vsmBlurSize = 11;
 

--- a/src/framework/lightmapper/bake-light-ambient.js
+++ b/src/framework/lightmapper/bake-light-ambient.js
@@ -2,7 +2,7 @@ import { Vec3 } from '../../core/math/vec3.js';
 import { random } from '../../core/math/random.js';
 import { Color } from '../../core/math/color.js';
 import { Entity } from '../entity.js';
-import { SHADOW_PCF3 } from '../../scene/constants.js';
+import { SHADOW_PCF3_32F } from '../../scene/constants.js';
 import { BakeLight } from './bake-light.js';
 
 const _tempPoint = new Vec3();
@@ -24,7 +24,7 @@ class BakeLightAmbient extends BakeLight {
             shadowBias: 0.2,
             shadowDistance: 1,  // this is updated during shadow map rendering
             shadowResolution: 2048,
-            shadowType: SHADOW_PCF3,
+            shadowType: SHADOW_PCF3_32F,
             color: Color.WHITE,
             intensity: 1,
             bakeDir: false

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -281,8 +281,10 @@ export const LIGHTFALLOFF_INVERSESQUARED = 1;
  * @type {number}
  * @category Graphics
  */
-export const SHADOW_PCF3 = 0;
-export const SHADOW_DEPTH = 0; // alias for SHADOW_PCF3 for backwards compatibility
+export const SHADOW_PCF3_32F = 0;
+
+/** @deprecated */
+export const SHADOW_PCF3 = 0; // alias for SHADOW_PCF3_32F for backwards compatibility
 
 /**
  * A shadow sampling technique using a 16-bit exponential variance shadow map packed into
@@ -303,18 +305,24 @@ export const SHADOW_VSM8 = 1;
  * @type {number}
  * @category Graphics
  */
-export const SHADOW_VSM16 = 2;
+export const SHADOW_VSM_16F = 2;
+
+/** @deprecated */
+export const SHADOW_VSM16 = 2; // alias for SHADOW_VSM_16F for backwards compatibility
 
 /**
  * A shadow sampling technique using a 32-bit exponential variance shadow map that leverages
  * variance to approximate shadow boundaries, enabling soft shadows. Only supported when
- * {@link GraphicsDevice#textureFloatRenderable} is true. Falls back to {@link SHADOW_VSM16}, if not
- * supported.
+ * {@link GraphicsDevice#textureFloatRenderable} is true. Falls back to {@link SHADOW_VSM_16F}, if
+ * not supported.
  *
  * @type {number}
  * @category Graphics
  */
-export const SHADOW_VSM32 = 3;
+export const SHADOW_VSM_32F = 3;
+
+/** @deprecated */
+export const SHADOW_VSM32 = 3; // alias for SHADOW_VSM_32F for backwards compatibility
 
 /**
  * A shadow sampling technique using 32bit shadow map that averages depth comparisons from a 5x5
@@ -323,7 +331,10 @@ export const SHADOW_VSM32 = 3;
  * @type {number}
  * @category Graphics
  */
-export const SHADOW_PCF5 = 4;
+export const SHADOW_PCF5_32F = 4;
+
+/** @deprecated */
+export const SHADOW_PCF5 = 4;  // alias for SHADOW_PCF5_32F for backwards compatibility
 
 /**
  * A shadow sampling technique using a 32-bit shadow map that performs a single depth comparison for
@@ -332,7 +343,10 @@ export const SHADOW_PCF5 = 4;
  * @type {number}
  * @category Graphics
  */
-export const SHADOW_PCF1 = 5;
+export const SHADOW_PCF1_32F = 5;
+
+/** @deprecated */
+export const SHADOW_PCF1 = 5;  // alias for SHADOW_PCF1_32F for backwards compatibility
 
 /**
  * A shadow sampling technique using a 32-bit shadow map that adjusts filter size based on blocker
@@ -341,7 +355,7 @@ export const SHADOW_PCF1 = 5;
  * @type {number}
  * @category Graphics
  */
-export const SHADOW_PCSS = 6;
+export const SHADOW_PCSS_32F = 6;
 
 /**
  * A shadow sampling technique using a 16-bit shadow map that performs a single depth comparison for
@@ -350,7 +364,7 @@ export const SHADOW_PCSS = 6;
  * @type {number}
  * @category Graphics
  */
-export const SHADOW_PCF1_FLOAT16 = 7;
+export const SHADOW_PCF1_16F = 7;
 
 /**
  * A shadow sampling technique using 16-bit shadow map that averages depth comparisons from a 3x3
@@ -359,7 +373,7 @@ export const SHADOW_PCF1_FLOAT16 = 7;
  * @type {number}
  * @category Graphics
  */
-export const SHADOW_PCF3_FLOAT16 = 8;
+export const SHADOW_PCF3_16F = 8;
 
 /**
  * A shadow sampling technique using 16-bit shadow map that averages depth comparisons from a 3x3
@@ -368,7 +382,7 @@ export const SHADOW_PCF3_FLOAT16 = 8;
  * @type {number}
  * @category Graphics
  */
-export const SHADOW_PCF5_FLOAT16 = 9;
+export const SHADOW_PCF5_16F = 9;
 
 /**
  * Information about shadow types.
@@ -377,16 +391,16 @@ export const SHADOW_PCF5_FLOAT16 = 9;
  * @ignore
  */
 export const shadowTypeInfo = new Map([
-    [SHADOW_PCF1,            { name: 'PCF1', format: PIXELFORMAT_DEPTH, pcf: true }],
-    [SHADOW_PCF3,            { name: 'PCF3', format: PIXELFORMAT_DEPTH, pcf: true }],
-    [SHADOW_PCF5,            { name: 'PCF5', format: PIXELFORMAT_DEPTH, pcf: true }],
-    [SHADOW_PCF1_FLOAT16,    { name: 'PCF1_FLOAT16', format: PIXELFORMAT_DEPTH16, pcf: true }],
-    [SHADOW_PCF3_FLOAT16,    { name: 'PCF3_FLOAT16', format: PIXELFORMAT_DEPTH16, pcf: true }],
-    [SHADOW_PCF5_FLOAT16,    { name: 'PCF5_FLOAT16', format: PIXELFORMAT_DEPTH16, pcf: true }],
+    [SHADOW_PCF1_32F,    { name: 'PCF1_32F', format: PIXELFORMAT_DEPTH, pcf: true }],
+    [SHADOW_PCF3_32F,    { name: 'PCF3_32F', format: PIXELFORMAT_DEPTH, pcf: true }],
+    [SHADOW_PCF5_32F,    { name: 'PCF5_32F', format: PIXELFORMAT_DEPTH, pcf: true }],
+    [SHADOW_PCF1_16F,    { name: 'PCF1_16F', format: PIXELFORMAT_DEPTH16, pcf: true }],
+    [SHADOW_PCF3_16F,    { name: 'PCF3_16F', format: PIXELFORMAT_DEPTH16, pcf: true }],
+    [SHADOW_PCF5_16F,    { name: 'PCF5_16F', format: PIXELFORMAT_DEPTH16, pcf: true }],
     [SHADOW_VSM8,            { name: 'VSM8', format: PIXELFORMAT_RGBA8, vsm: true }],
-    [SHADOW_VSM16,           { name: 'VSM16', format: PIXELFORMAT_RGBA16F, vsm: true }],
-    [SHADOW_VSM32,           { name: 'VSM32', format: PIXELFORMAT_RGBA32F, vsm: true }],
-    [SHADOW_PCSS,            { name: 'PCSS', format: PIXELFORMAT_R32F }]
+    [SHADOW_VSM_16F,     { name: 'VSM_16F', format: PIXELFORMAT_RGBA16F, vsm: true }],
+    [SHADOW_VSM_32F,     { name: 'VSM_32F', format: PIXELFORMAT_RGBA32F, vsm: true }],
+    [SHADOW_PCSS_32F,    { name: 'PCSS_32F', format: PIXELFORMAT_R32F }]
 ]);
 
 /**

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -8,12 +8,11 @@ import {
     BLUR_GAUSSIAN,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
     MASK_BAKE, MASK_AFFECT_DYNAMIC,
-    SHADOW_PCF1, SHADOW_PCF3, SHADOW_VSM8, SHADOW_VSM16, SHADOW_VSM32, SHADOW_PCSS,
+    SHADOW_PCF1_32F, SHADOW_PCF3_32F, SHADOW_VSM8, SHADOW_VSM_16F, SHADOW_VSM_32F, SHADOW_PCSS_32F,
     SHADOWUPDATE_NONE, SHADOWUPDATE_REALTIME, SHADOWUPDATE_THISFRAME,
     LIGHTSHAPE_PUNCTUAL, LIGHTFALLOFF_LINEAR,
     shadowTypeInfo,
-    SHADOW_PCF1_FLOAT16,
-    SHADOW_PCF3_FLOAT16
+    SHADOW_PCF1_16F, SHADOW_PCF3_16F
 } from './constants.js';
 import { ShadowRenderer } from './renderer/shadow-renderer.js';
 import { DepthState } from '../platform/graphics/depth-state.js';
@@ -165,7 +164,7 @@ class Light {
         this.attenuationStart = 10;
         this.attenuationEnd = 10;
         this._falloffMode = LIGHTFALLOFF_LINEAR;
-        this._shadowType = SHADOW_PCF3;
+        this._shadowType = SHADOW_PCF3_32F;
         this._vsmBlurSize = 11;
         this.vsmBlurMode = BLUR_GAUSSIAN;
         this.vsmBias = 0.01 * 0.25;
@@ -389,18 +388,18 @@ class Light {
         const device = this.device;
 
         // omni light supports PCF1, PCF3 and PCSS only
-        if (this._type === LIGHTTYPE_OMNI && value !== SHADOW_PCF1 && value !== SHADOW_PCF3 &&
-            value !== SHADOW_PCF1_FLOAT16 && value !== SHADOW_PCF3_FLOAT16 && value !== SHADOW_PCSS) {
-            value = SHADOW_PCF3;
+        if (this._type === LIGHTTYPE_OMNI && value !== SHADOW_PCF1_32F && value !== SHADOW_PCF3_32F &&
+            value !== SHADOW_PCF1_16F && value !== SHADOW_PCF3_16F && value !== SHADOW_PCSS_32F) {
+            value = SHADOW_PCF3_32F;
         }
 
         // fallback from vsm32 to vsm16
-        if (value === SHADOW_VSM32 && (!device.textureFloatRenderable || !device.textureFloatFilterable)) {
-            value = SHADOW_VSM16;
+        if (value === SHADOW_VSM_32F && (!device.textureFloatRenderable || !device.textureFloatFilterable)) {
+            value = SHADOW_VSM_16F;
         }
 
         // fallback from vsm16 to vsm8
-        if (value === SHADOW_VSM16 && !device.textureHalfFloatRenderable) {
+        if (value === SHADOW_VSM_16F && !device.textureHalfFloatRenderable) {
             value = SHADOW_VSM8;
         }
 

--- a/src/scene/lighting/light-texture-atlas.js
+++ b/src/scene/lighting/light-texture-atlas.js
@@ -5,7 +5,7 @@ import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_RGBA8 } from '../../
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { Texture } from '../../platform/graphics/texture.js';
 
-import { LIGHTTYPE_OMNI, LIGHTTYPE_SPOT, SHADOW_PCF3, shadowTypeInfo } from '../constants.js';
+import { LIGHTTYPE_OMNI, LIGHTTYPE_SPOT, SHADOW_PCF3_32F, shadowTypeInfo } from '../constants.js';
 import { ShadowMap } from '../renderer/shadow-map.js';
 
 const _tempArray = [];
@@ -98,7 +98,7 @@ class LightTextureAtlas {
         this.cookieRenderTarget = null;
     }
 
-    allocateShadowAtlas(resolution, shadowType = SHADOW_PCF3) {
+    allocateShadowAtlas(resolution, shadowType = SHADOW_PCF3_32F) {
 
         const existingFormat = this.shadowAtlas?.texture.format;
         const requiredFormat = shadowTypeInfo.get(shadowType).format;

--- a/src/scene/lighting/lighting-params.js
+++ b/src/scene/lighting/lighting-params.js
@@ -1,6 +1,6 @@
 import { math } from '../../core/math/math.js';
 import { Vec3 } from '../../core/math/vec3.js';
-import { SHADOW_PCF3 } from '../constants.js';
+import { SHADOW_PCF3_32F } from '../constants.js';
 
 /**
  * Lighting parameters, allow configuration of the global lighting parameters. For details see
@@ -22,7 +22,7 @@ class LightingParams {
     _shadowsEnabled = true;
 
     /** @private */
-    _shadowType = SHADOW_PCF3;
+    _shadowType = SHADOW_PCF3_32F;
 
     /** @private */
     _shadowAtlasResolution = 2048;
@@ -154,14 +154,14 @@ class LightingParams {
     /**
      * Sets the type of shadow filtering used by all shadows. Can be:
      *
-     * - {@link SHADOW_PCF1}
-     * - {@link SHADOW_PCF3}
-     * - {@link SHADOW_PCF5}
-     * - {@link SHADOW_PCF1_FLOAT16}
-     * - {@link SHADOW_PCF3_FLOAT16}
-     * - {@link SHADOW_PCF5_FLOAT16}
+     * - {@link SHADOW_PCF1_32F}
+     * - {@link SHADOW_PCF3_32F}
+     * - {@link SHADOW_PCF5_32F}
+     * - {@link SHADOW_PCF1_16F}
+     * - {@link SHADOW_PCF3_16F}
+     * - {@link SHADOW_PCF5_16F}
      *
-     * Defaults to {@link SHADOW_PCF3}
+     * Defaults to {@link SHADOW_PCF3_32F}
      *
      * @type {number}
      */

--- a/src/scene/renderer/shadow-map.js
+++ b/src/scene/renderer/shadow-map.js
@@ -11,7 +11,7 @@ import { Texture } from '../../platform/graphics/texture.js';
 
 import {
     LIGHTTYPE_OMNI,
-    SHADOW_VSM32, SHADOW_PCSS,
+    SHADOW_VSM_32F, SHADOW_PCSS_32F,
     shadowTypeInfo
 } from '../constants.js';
 
@@ -47,7 +47,7 @@ class ShadowMap {
     }
 
     static getShadowFiltering(device, shadowType) {
-        if (shadowType === SHADOW_VSM32) {
+        if (shadowType === SHADOW_VSM_32F) {
             return device.extTextureFloatLinear ? FILTER_LINEAR : FILTER_NEAREST;
         }
         return FILTER_LINEAR;
@@ -133,7 +133,7 @@ class ShadowMap {
         const shadowInfo = shadowTypeInfo.get(shadowType);
         Debug.assert(shadowInfo);
         const formatName = pixelFormatInfo.get(shadowInfo.format)?.name;
-        const isPcss = shadowType === SHADOW_PCSS;
+        const isPcss = shadowType === SHADOW_PCSS_32F;
         const filter = isPcss ? FILTER_NEAREST : FILTER_LINEAR;
 
         const cubemap = new Texture(device, {

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -11,7 +11,7 @@ import {
     BLUR_GAUSSIAN,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI,
     SHADER_SHADOW,
-    SHADOW_VSM8, SHADOW_VSM32,
+    SHADOW_VSM8, SHADOW_VSM_32F,
     SHADOWUPDATE_NONE, SHADOWUPDATE_THISFRAME,
     SORTKEY_DEPTH,
     shadowTypeInfo
@@ -119,7 +119,7 @@ class ShadowRenderer {
         const shadowCam = LightCamera.create('ShadowCamera', type, face);
 
         // don't clear the color buffer if rendering a depth map
-        if (shadowType >= SHADOW_VSM8 && shadowType <= SHADOW_VSM32) {
+        if (shadowType >= SHADOW_VSM8 && shadowType <= SHADOW_VSM_32F) {
             shadowCam.clearColor = new Color(0, 0, 0, 0);
         } else {
             shadowCam.clearColor = new Color(1, 1, 1, 1);

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -11,12 +11,10 @@ import {
     LIGHTSHAPE_PUNCTUAL, LIGHTSHAPE_RECT, LIGHTSHAPE_DISK, LIGHTSHAPE_SPHERE,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
     SHADER_DEPTH, SHADER_PICK,
-    SHADOW_PCF1, SHADOW_PCF3, SHADOW_PCF5, SHADOW_VSM8, SHADOW_VSM16, SHADOW_VSM32, SHADOW_PCSS,
+    SHADOW_PCF1_32F, SHADOW_PCF3_32F, SHADOW_PCF5_32F, SHADOW_VSM8, SHADOW_VSM_16F, SHADOW_VSM_32F, SHADOW_PCSS_32F,
     SPECOCC_AO, SPECOCC_GLOSSDEPENDENT,
     SPRITE_RENDERMODE_SLICED, SPRITE_RENDERMODE_TILED, shadowTypeInfo, SHADER_PREPASS,
-    SHADOW_PCF1_FLOAT16,
-    SHADOW_PCF5_FLOAT16,
-    SHADOW_PCF3_FLOAT16
+    SHADOW_PCF1_16F, SHADOW_PCF5_16F, SHADOW_PCF3_16F
 } from '../../constants.js';
 import { shaderChunks } from '../chunks/chunks.js';
 import { ChunkUtils } from '../chunk-utils.js';
@@ -435,16 +433,16 @@ class LitShader {
 
         // If not a directional light and using clustered, fall back to using PCF3x3 if shadow type isn't supported
         if (lightType !== LIGHTTYPE_DIRECTIONAL && options.clusteredLightingEnabled) {
-            if (shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32 || shadowType === SHADOW_PCSS) {
-                shadowType = SHADOW_PCF3;
+            if (shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM_16F || shadowType === SHADOW_VSM_32F || shadowType === SHADOW_PCSS_32F) {
+                shadowType = SHADOW_PCF3_32F;
             }
         }
 
         let code = this._fsGetBeginCode();
 
-        if (shadowType === SHADOW_VSM32) {
+        if (shadowType === SHADOW_VSM_32F) {
             code += '#define VSM_EXPONENT 15.0\n\n';
-        } else if (shadowType === SHADOW_VSM16) {
+        } else if (shadowType === SHADOW_VSM_16F) {
             code += '#define VSM_EXPONENT 5.54\n\n';
         }
 
@@ -467,7 +465,7 @@ class LitShader {
             code += '}\n\n';
         }
 
-        if (shadowType === SHADOW_PCSS) {
+        if (shadowType === SHADOW_PCSS_32F) {
             code += shaderChunks.linearizeDepthPS;
         }
 
@@ -475,7 +473,7 @@ class LitShader {
 
         code += this.frontendFunc;
 
-        const isVsm = shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM16 || shadowType === SHADOW_VSM32;
+        const isVsm = shadowType === SHADOW_VSM8 || shadowType === SHADOW_VSM_16F || shadowType === SHADOW_VSM_32F;
 
         // Use perspective depth for:
         // Directional: Always since light has no position
@@ -493,7 +491,7 @@ class LitShader {
         }
 
         if (!isVsm) {
-            const exportR32 = shadowType === SHADOW_PCSS;
+            const exportR32 = shadowType === SHADOW_PCSS_32F;
 
             if (exportR32) {
                 code += '    gl_FragColor.r = depth;\n';
@@ -591,7 +589,7 @@ class LitShader {
 
             decl.append(`uniform vec3 light${i}_color;`);
 
-            if (light._shadowType === SHADOW_PCSS && light.castShadows && !options.noShadow) {
+            if (light._shadowType === SHADOW_PCSS_32F && light.castShadows && !options.noShadow) {
                 decl.append(`uniform float light${i}_shadowSearchArea;`);
                 decl.append(`uniform vec4 light${i}_cameraParams;`);
             }
@@ -636,7 +634,7 @@ class LitShader {
                 numShadowLights++;
                 shadowTypeUsed[light._shadowType] = true;
                 if (light._isVsm) useVsm = true;
-                if (light._shadowType === SHADOW_PCSS) usePcss = true;
+                if (light._shadowType === SHADOW_PCSS_32F) usePcss = true;
             }
             if (light._cookie) {
                 if (light._cookie._cubemap) {
@@ -780,9 +778,9 @@ class LitShader {
 
             // include shadow chunks clustered lights support
             if (options.clusteredLightingShadowsEnabled && !options.noShadow) {
-                shadowTypeUsed[SHADOW_PCF3] = true;
-                shadowTypeUsed[SHADOW_PCF5] = true;
-                shadowTypeUsed[SHADOW_PCSS] = true;
+                shadowTypeUsed[SHADOW_PCF3_32F] = true;
+                shadowTypeUsed[SHADOW_PCF5_32F] = true;
+                shadowTypeUsed[SHADOW_PCSS_32F] = true;
             }
         }
 
@@ -790,10 +788,10 @@ class LitShader {
             if (shadowedDirectionalLightUsed) {
                 func.append(chunks.shadowCascadesPS);
             }
-            if (shadowTypeUsed[SHADOW_PCF1] || shadowTypeUsed[SHADOW_PCF3] || shadowTypeUsed[SHADOW_PCF1_FLOAT16] || shadowTypeUsed[SHADOW_PCF3_FLOAT16]) {
+            if (shadowTypeUsed[SHADOW_PCF1_32F] || shadowTypeUsed[SHADOW_PCF3_32F] || shadowTypeUsed[SHADOW_PCF1_16F] || shadowTypeUsed[SHADOW_PCF3_16F]) {
                 func.append(chunks.shadowStandardPS);
             }
-            if (shadowTypeUsed[SHADOW_PCF5] || shadowTypeUsed[SHADOW_PCF5_FLOAT16]) {
+            if (shadowTypeUsed[SHADOW_PCF5_32F] || shadowTypeUsed[SHADOW_PCF5_16F]) {
                 func.append(chunks.shadowStandardGL2PS);
             }
             if (useVsm) {
@@ -801,10 +799,10 @@ class LitShader {
                 if (shadowTypeUsed[SHADOW_VSM8]) {
                     func.append(chunks.shadowVSM8PS);
                 }
-                if (shadowTypeUsed[SHADOW_VSM16]) {
+                if (shadowTypeUsed[SHADOW_VSM_16F]) {
                     func.append(chunks.shadowEVSMPS.replace(/\$/g, '16'));
                 }
-                if (shadowTypeUsed[SHADOW_VSM32]) {
+                if (shadowTypeUsed[SHADOW_VSM_32F]) {
                     func.append(device.extTextureFloatLinear ? chunks.shadowEVSMPS.replace(/\$/g, '32') : chunks.shadowEVSMnPS.replace(/\$/g, '32'));
                 }
             }
@@ -1165,7 +1163,7 @@ class LitShader {
                     const shadowInfo = shadowTypeInfo.get(light._shadowType);
                     Debug.assert(shadowInfo);
 
-                    const pcssShadows = light._shadowType === SHADOW_PCSS;
+                    const pcssShadows = light._shadowType === SHADOW_PCSS_32F;
                     const vsmShadows = shadowInfo?.vsm;
                     const pcfShadows = shadowInfo?.pcf;
                     let shadowReadMode = null;
@@ -1175,27 +1173,27 @@ class LitShader {
                             shadowReadMode = 'VSM8';
                             evsmExp = '0.0';
                             break;
-                        case SHADOW_VSM16:
+                        case SHADOW_VSM_16F:
                             shadowReadMode = 'VSM16';
                             evsmExp = '5.54';
                             break;
-                        case SHADOW_VSM32:
+                        case SHADOW_VSM_32F:
                             shadowReadMode = 'VSM32';
                             evsmExp = '15.0';
                             break;
-                        case SHADOW_PCF1:
-                        case SHADOW_PCF1_FLOAT16:
+                        case SHADOW_PCF1_32F:
+                        case SHADOW_PCF1_16F:
                             shadowReadMode = 'PCF1x1';
                             break;
-                        case SHADOW_PCF5:
-                        case SHADOW_PCF5_FLOAT16:
+                        case SHADOW_PCF5_32F:
+                        case SHADOW_PCF5_16F:
                             shadowReadMode = 'PCF5x5';
                             break;
-                        case SHADOW_PCSS:
+                        case SHADOW_PCSS_32F:
                             shadowReadMode = 'PCSS';
                             break;
-                        case SHADOW_PCF3:
-                        case SHADOW_PCF3_FLOAT16:
+                        case SHADOW_PCF3_32F:
+                        case SHADOW_PCF3_16F:
                         default:
                             shadowReadMode = 'PCF3x3';
                             break;

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -34,7 +34,7 @@ class ShaderPassInfo {
      * @param {boolean} [options.isForward] - Whether the pass is forward.
      * @param {boolean} [options.isShadow] - Whether the pass is shadow.
      * @param {boolean} [options.lightType] - Type of light, for example `pc.LIGHTTYPE_DIRECTIONAL`.
-     * @param {boolean} [options.shadowType] - Type of shadow, for example `pc.SHADOW_PCF3`.
+     * @param {boolean} [options.shadowType] - Type of shadow, for example `pc.SHADOW_PCF3_32F`.
      */
     constructor(name, index, options = {}) {
 


### PR DESCRIPTION
Not marking this as breaking, as old constants are still working fine, just marked as deprecated.

renames done:
```
SHADOW_PCF1_FLOAT16 -> SHADOW_PCF1_16F
SHADOW_PCF3_FLOAT16 -> SHADOW_PCF3_16F
SHADOW_PCF5_FLOAT16 -> SHADOW_PCF5_16F
SHADOW_PCSS -> SHADOW_PCSS_32F
SHADOW_PCF1 -> SHADOW_PCF1_32F
SHADOW_PCF3 -> SHADOW_PCF3_32F
SHADOW_PCF5 -> SHADOW_PCF5_32F
SHADOW_VSM16 -> SHADOW_VSM_16F
SHADOW_VSM32 -> SHADOW_VSM_32F
```

SHADOW_VSM8 is unmodified and will be completely removed in following PR.
