### PR TITLE
Store, use and restore any existing onPreRenderLayer function

### DIFF
--- a/src/extras/renderers/outline-renderer.js
+++ b/src/extras/renderers/outline-renderer.js
@@ -332,7 +332,7 @@ class OutlineRenderer {
 
         // store the current function before we overwrite it
         const onPreRenderLayer = sceneCameraEntity.camera.onPreRenderLayer;
-        
+
         // function called before the scene camera renders a layer
         sceneCameraEntity.camera.onPreRenderLayer = (layer, transparent) => {
 

--- a/src/extras/renderers/outline-renderer.js
+++ b/src/extras/renderers/outline-renderer.js
@@ -330,6 +330,9 @@ class OutlineRenderer {
         const sceneCamera = sceneCameraEntity.camera;
         this.updateRenderTarget(sceneCamera);
 
+        // store the current function before we overwrite it
+        const onPreRenderLayer = sceneCameraEntity.camera.onPreRenderLayer;
+        
         // function called before the scene camera renders a layer
         sceneCameraEntity.camera.onPreRenderLayer = (layer, transparent) => {
 
@@ -337,8 +340,12 @@ class OutlineRenderer {
             if (transparent === blendLayerTransparent && layer === blendLayer) {
                 this.blendOutlines();
 
-                sceneCameraEntity.camera.onPreRenderLayer = null;
+                // restore the previous function
+                sceneCameraEntity.camera.onPreRenderLayer = onPreRenderLayer;
             }
+
+            // call the current function
+            onPreRenderLayer?.(layer, transparent);
         };
 
         // copy the transform


### PR DESCRIPTION
Fixes #7150

This change fixes the reported issue by
- Storing any existing onPreRenderLayer function
- Calling that function as well as performing the function provided by the outliner
- Restoring the old function when the outliner is deactivated

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
