### PR TITLE
Add option to GltfExporter to strip unused attributes

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -583,6 +583,8 @@ class GltfExporter extends CoreExporter {
 
             // Position accessor also requires min and max properties
             if (element.name === SEMANTIC_POSITION) {
+                // compute min and max from positions, as the BoundingBox stores center and extents,
+                // and we get precision warnings from gltf validator
                 const positions = [];
                 mesh.getPositions(positions);
                 const min = new Vec3();

--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -531,9 +531,9 @@ class GltfExporter extends CoreExporter {
 
                 // Check texture coordinates
                 if (semantic.startsWith('TEXCOORD_')) {
-                    const texCoordIndex = parseInt(semantic.split('_')[1]);
-                    isUsed = resources.materials.some(material => {
-                        return textureSemantics.some(texSemantic => {
+                    const texCoordIndex = parseInt(semantic.split('_')[1], 10);
+                    isUsed = resources.materials.some((material) => {
+                        return textureSemantics.some((texSemantic) => {
                             const texture = material[texSemantic];
                             // Most materials use UV0 by default, so keep TEXCOORD_0 unless explicitly using a different UV set
                             return texture && (texCoordIndex === 0 || material[`${texSemantic}Tiling`]?.uv === texCoordIndex);
@@ -553,8 +553,7 @@ class GltfExporter extends CoreExporter {
 
                 // Check skinning attributes
                 if (semantic === 'JOINTS_0' || semantic === 'WEIGHTS_0') {
-                    isUsed = resources.entityMeshInstances.some(emi => 
-                        emi.meshInstances.some(mi => mi.mesh.skin));
+                    isUsed = resources.entityMeshInstances.some(emi => emi.meshInstances.some(mi => mi.mesh.skin));
                 }
 
                 if (!isUsed) {


### PR DESCRIPTION
Adds `options.stripUnusedAttributes` to `GltfExporter` which strips out any unreferenced vertex attributes. Defaults to false.

Partially addresses #7144 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
