### PR TITLE
[Fix] Remove dimensions caching from RT

### DIFF
--- a/examples/src/examples/graphics/render-to-texture.example.mjs
+++ b/examples/src/examples/graphics/render-to-texture.example.mjs
@@ -144,8 +144,6 @@ assetListLoader.load(() => {
         height: 256,
         format: pc.PIXELFORMAT_SRGBA8,
         mipmaps: true,
-        minFilter: pc.FILTER_LINEAR,
-        magFilter: pc.FILTER_LINEAR,
         addressU: pc.ADDRESS_CLAMP_TO_EDGE,
         addressV: pc.ADDRESS_CLAMP_TO_EDGE
     });

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -90,18 +90,6 @@ class RenderTarget {
      */
     _mipmaps;
 
-    /**
-     * @type {number}
-     * @private
-     */
-    _width;
-
-    /**
-     * @type {number}
-     * @private
-     */
-    _height;
-
     /** @type {boolean} */
     flipY;
 
@@ -252,7 +240,6 @@ class RenderTarget {
         // if we render to a specific mipmap (even 0), do not generate mipmaps
         this._mipmaps = options.mipLevel === undefined;
 
-        this.updateDimensions();
         this.validateMrt();
 
         // device specific implementation
@@ -348,8 +335,6 @@ class RenderTarget {
             // initialize again
             this.validateMrt();
             this.impl = device.createRenderTargetImpl(this);
-
-            this.updateDimensions();
         }
     }
 
@@ -548,7 +533,11 @@ class RenderTarget {
      * @type {number}
      */
     get width() {
-        return this._width ?? this._device.width;
+        let width = this._colorBuffer?.width || this._depthBuffer?.width || this._device.width;
+        if (this._mipLevel > 0) {
+            width = TextureUtils.calcLevelDimension(width, this._mipLevel);
+        }
+        return width;
     }
 
     /**
@@ -557,17 +546,11 @@ class RenderTarget {
      * @type {number}
      */
     get height() {
-        return this._height ?? this._device.height;
-    }
-
-    updateDimensions() {
-        this._width = this._colorBuffer?.width ?? this._depthBuffer?.width;
-        this._height = this._colorBuffer?.height ?? this._depthBuffer?.height;
-
-        if (this._mipLevel > 0 && this._width && this._height) {
-            this._width = TextureUtils.calcLevelDimension(this._width, this._mipLevel);
-            this._height = TextureUtils.calcLevelDimension(this._height, this._mipLevel);
+        let height = this._colorBuffer?.height || this._depthBuffer?.height || this._device.height;
+        if (this._mipLevel > 0) {
+            height = TextureUtils.calcLevelDimension(height, this._mipLevel);
         }
+        return height;
     }
 
     /**


### PR DESCRIPTION
Removed dimensions caching introduced in https://github.com/playcanvas/engine/pull/7051, as it's not working in some cases. Specifically, engine examples using post-effects could not be correctly resized.