### PR TITLE
[Fix] The material loading do not print validation warnings for few unsupported properties

### DIFF
--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -182,7 +182,13 @@ const standardMaterialRemovedParameters = {
     opacityMapVertexColor: 'boolean',
     specularAntialias: 'boolean',
     specularMapTint: 'boolean',
-    specularMapVertexColor: 'boolean'
+    specularMapVertexColor: 'boolean',
+    ambientTint: 'boolean',
+    emissiveTint: 'boolean',
+    diffuseTint: 'boolean',
+    sheenTint: 'boolean',
+    conserveEnergy: 'boolean',
+    useGamma: 'boolean'
 };
 
 export {


### PR DESCRIPTION
tints that are no longer supported, and few other similarly removed properties