### PR TITLE
Gsplat shader chunk updates

### DIFF
--- a/examples/src/examples/loaders/gsplat-many.shader.vert
+++ b/examples/src/examples/loaders/gsplat-many.shader.vert
@@ -41,16 +41,16 @@ vec4 animateColor(float height, vec4 clr) {
 void main(void) {
     // read gaussian center
     SplatState state;
-    if (!readCenter(state)) {
+    if (!initState(state)) {
         gl_Position = discardVec;
         return;
     }
 
-    state.center = animatePosition(state.center);
+    vec3 center = animatePosition(readCenter(state));
 
     // project center to screen space
     ProjectedState projState;
-    if (!projectCenter(state, projState)) {
+    if (!projectCenter(state, center, projState)) {
         gl_Position = discardVec;
         return;
     }
@@ -63,7 +63,7 @@ void main(void) {
         clr.xyz = max(clr.xyz + evalSH(state, projState), 0.0);
     #endif
 
-    clr = animateColor(state.center.y, clr);
+    clr = animateColor(center.y, clr);
 
     applyClipping(projState, clr.w);
 

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplat.js
@@ -13,14 +13,16 @@ mediump vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
 void main(void) {
     // read gaussian details
     SplatState state;
-    if (!readCenter(state)) {
+    if (!initState(state)) {
         gl_Position = discardVec;
         return;
     }
 
+    vec3 center = readCenter(state);
+
     // project center to screen space
     ProjectedState projState;
-    if (!projectCenter(state, projState)) {
+    if (!projectCenter(state, center, projState)) {
         gl_Position = discardVec;
         return;
     }

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatCommon.js
@@ -121,7 +121,7 @@ bool projectCenter(SplatState state, vec3 center, out ProjectedState projState) 
     }
 
     // perform clipping test against x/y
-    if (any(greaterThan(abs(centerProj.xy) - vec2(l1, l2) / viewport * centerProj.w * 0.5, centerProj.ww))) {
+    if (any(greaterThan(abs(centerProj.xy) - vec2(l1, l2) / viewport * centerProj.w, centerProj.ww))) {
         return false;
     }
 

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatCommon.js
@@ -5,10 +5,10 @@ struct SplatState {
     uint id;            // splat id
     ivec2 uv;           // splat uv
     vec2 cornerUV;      // corner coordinates for this vertex of the gaussian (-1, -1)..(1, 1)
-    vec3 center;        // model space center  
 };
 
 struct ProjectedState {
+    mat4 modelView;     // model-view matrix
     vec3 centerCam;     // center in camera space
     vec4 centerProj;    // center in clip space
 
@@ -42,12 +42,37 @@ uniform mat4 matrix_model;
 uniform mat4 matrix_view;
 uniform mat4 matrix_projection;
 uniform vec2 viewport;                  // viewport dimensions
+uniform vec4 camera_params;             // 1 / far, far, near, isOrtho
+
+// initialize the splat state structure
+bool initState(out SplatState state) {
+    // calculate splat order
+    state.order = vertex_id_attrib + uint(vertex_position.z);
+
+    // return if out of range (since the last block of splats may be partially full)
+    if (state.order >= tex_params.x) {
+        return false;
+    }
+
+    ivec2 orderUV = ivec2(state.order % tex_params.y, state.order / tex_params.y);
+
+    // read splat id
+    state.id = texelFetch(splatOrder, orderUV, 0).r;
+
+    // map id to uv
+    state.uv = ivec2(state.id % tex_params.y, state.id / tex_params.y);
+
+    // get the corner
+    state.cornerUV = vertex_position.xy;
+
+    return true;
+}
 
 // calculate 2d covariance vectors
-bool projectCenter(in SplatState state, out ProjectedState projState) {
+bool projectCenter(SplatState state, vec3 center, out ProjectedState projState) {
     // project center to screen space
     mat4 model_view = matrix_view * matrix_model;
-    vec4 centerCam = model_view * vec4(state.center, 1.0);
+    vec4 centerCam = model_view * vec4(center, 1.0);
     vec4 centerProj = matrix_projection * centerCam;
     if (centerProj.z < -centerProj.w) {
         return false;
@@ -65,8 +90,9 @@ bool projectCenter(in SplatState state, out ProjectedState projState) {
 
     float focal = viewport.x * matrix_projection[0][0];
 
-    float J1 = focal / centerCam.z;
-    vec2 J2 = -J1 / centerCam.z * centerCam.xy;
+    vec3 v = camera_params.w == 1.0 ? vec3(0.0, 0.0, 1.0) : centerCam.xyz;
+    float J1 = focal / v.z;
+    vec2 J2 = -J1 / v.z * v.xy;
     mat3 J = mat3(
         J1, 0.0, J2.x, 
         0.0, J1, J2.y, 
@@ -90,22 +116,23 @@ bool projectCenter(in SplatState state, out ProjectedState projState) {
     float l2 = 2.0 * min(sqrt(2.0 * lambda2), 1024.0);
 
     // early-out gaussians smaller than 2 pixels
-    if (l1 < 4.0 && l2 < 4.0) {
+    if (l1 < 2.0 && l2 < 2.0) {
         return false;
     }
 
     // perform clipping test against x/y
-    if (any(greaterThan(abs(centerProj.xy) - (l1 + l2) / viewport * centerProj.w, centerProj.ww))) {
+    if (any(greaterThan(abs(centerProj.xy) - vec2(l1, l2) / viewport * centerProj.w * 0.5, centerProj.ww))) {
         return false;
     }
 
-    vec2 diagonalVector = normalize(vec2(offDiagonal, lambda1 - diagonal1)) / viewport;
+    vec2 diagonalVector = normalize(vec2(offDiagonal, lambda1 - diagonal1));
     vec2 v1 = l1 * diagonalVector;
     vec2 v2 = l2 * vec2(diagonalVector.y, -diagonalVector.x);
 
+    projState.modelView = model_view;
     projState.centerCam = centerCam.xyz;
     projState.centerProj = centerProj;
-    projState.cornerOffset = (state.cornerUV.x * v1 + state.cornerUV.y * v2) * centerProj.w;
+    projState.cornerOffset = (state.cornerUV.x * v1 + state.cornerUV.y * v2) / viewport * centerProj.w;
     projState.cornerProj = centerProj + vec4(projState.cornerOffset, 0.0, 0.0);
     projState.cornerUV = state.cornerUV;
 
@@ -152,7 +179,7 @@ vec3 evalSH(in SplatState state, in ProjectedState projState) {
     readSHData(state, sh);
 
     // calculate the model-space view direction
-    vec3 dir = normalize(projState.centerCam * mat3(matrix_view) * mat3(matrix_model));
+    vec3 dir = normalize(projState.centerCam * mat3(projState.modelView));
 
     float x = dir.x;
     float y = dir.y;

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatCommon.js
@@ -176,7 +176,8 @@ vec3 evalSH(in SplatState state, in ProjectedState projState) {
 
     // read sh coefficients
     vec3 sh[SH_COEFFS];
-    readSHData(state, sh);
+    float scale;
+    readSHData(state, sh, scale);
 
     // calculate the model-space view direction
     vec3 dir = normalize(projState.centerCam * mat3(projState.modelView));
@@ -217,7 +218,7 @@ vec3 evalSH(in SplatState state, in ProjectedState projState) {
         sh[14] * (SH_C3_6 * x * (xx - 3.0 * yy));
 #endif
 
-    return result;
+    return result * scale;
 }
 #endif
 `;

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatCompressedSH.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatCompressedSH.js
@@ -5,30 +5,30 @@ uniform highp usampler2D shTexture0;
 uniform highp usampler2D shTexture1;
 uniform highp usampler2D shTexture2;
 
-vec4 sunpack8888(in uint bits) {
+vec4 unpack8888s(in uint bits) {
     return vec4((uvec4(bits) >> uvec4(0u, 8u, 16u, 24u)) & 0xffu) * (8.0 / 255.0) - 4.0;
 }
 
-void readSHData(in SplatState state, out vec3 sh[15]) {
+void readSHData(in SplatState state, out vec3 sh[15], out float scale) {
     // read the sh coefficients
     uvec4 shData0 = texelFetch(shTexture0, state.uv, 0);
     uvec4 shData1 = texelFetch(shTexture1, state.uv, 0);
     uvec4 shData2 = texelFetch(shTexture2, state.uv, 0);
 
-    vec4 r0 = sunpack8888(shData0.x);
-    vec4 r1 = sunpack8888(shData0.y);
-    vec4 r2 = sunpack8888(shData0.z);
-    vec4 r3 = sunpack8888(shData0.w);
+    vec4 r0 = unpack8888s(shData0.x);
+    vec4 r1 = unpack8888s(shData0.y);
+    vec4 r2 = unpack8888s(shData0.z);
+    vec4 r3 = unpack8888s(shData0.w);
 
-    vec4 g0 = sunpack8888(shData1.x);
-    vec4 g1 = sunpack8888(shData1.y);
-    vec4 g2 = sunpack8888(shData1.z);
-    vec4 g3 = sunpack8888(shData1.w);
+    vec4 g0 = unpack8888s(shData1.x);
+    vec4 g1 = unpack8888s(shData1.y);
+    vec4 g2 = unpack8888s(shData1.z);
+    vec4 g3 = unpack8888s(shData1.w);
 
-    vec4 b0 = sunpack8888(shData2.x);
-    vec4 b1 = sunpack8888(shData2.y);
-    vec4 b2 = sunpack8888(shData2.z);
-    vec4 b3 = sunpack8888(shData2.w);
+    vec4 b0 = unpack8888s(shData2.x);
+    vec4 b1 = unpack8888s(shData2.y);
+    vec4 b2 = unpack8888s(shData2.z);
+    vec4 b3 = unpack8888s(shData2.w);
 
     sh[0] =  vec3(r0.x, g0.x, b0.x);
     sh[1] =  vec3(r0.y, g0.y, b0.y);
@@ -45,6 +45,8 @@ void readSHData(in SplatState state, out vec3 sh[15]) {
     sh[12] = vec3(r3.x, g3.x, b3.x);
     sh[13] = vec3(r3.y, g3.y, b3.y);
     sh[14] = vec3(r3.z, g3.z, b3.z);
+
+    scale = 1.0;
 }
 
 #endif

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatData.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatData.js
@@ -11,31 +11,11 @@ uniform highp sampler2D transformB;
 uint tAw;
 
 // read the model-space center of the gaussian
-bool readCenter(out SplatState state) {
-    // calculate splat order
-    state.order = vertex_id_attrib + uint(vertex_position.z);
-
-    // return if out of range (since the last block of splats may be partially full)
-    if (state.order >= tex_params.x) {
-        return false;
-    }
-
-    ivec2 orderUV = ivec2(state.order % tex_params.y, state.order / tex_params.y);
-
-    // read splat id
-    state.id = texelFetch(splatOrder, orderUV, 0).r;
-
-    // map id to uv
-    state.uv = ivec2(state.id % tex_params.y, state.id / tex_params.y);
-
+vec3 readCenter(SplatState state) {
     // read transform data
     uvec4 tA = texelFetch(transformA, state.uv, 0);
     tAw = tA.w;
-
-    state.cornerUV = vertex_position.xy;
-    state.center = uintBitsToFloat(tA.xyz);
-
-    return true;
+    return uintBitsToFloat(tA.xyz);
 }
 
 // sample covariance vectors

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatSH.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatSH.js
@@ -2,70 +2,55 @@ export default /* glsl */`
 
 #if SH_BANDS > 0
 
-vec3 unpack111011(uint bits) {
-    return vec3(
-        float(bits >> 21u) / 2047.0,
-        float((bits >> 11u) & 0x3ffu) / 1023.0,
-        float(bits & 0x7ffu) / 2047.0
-    );
+// unpack signed 11 10 11 bits
+vec3 unpack111011s(uint bits) {
+    return vec3((uvec3(bits) >> uvec3(21u, 11u, 0u)) & uvec3(0x7ffu, 0x3ffu, 0x7ffu)) / vec3(2047.0, 1023.0, 2047.0) * 2.0 - 1.0;
 }
 
 // fetch quantized spherical harmonic coefficients
 void fetchScale(in uvec4 t, out float scale, out vec3 a, out vec3 b, out vec3 c) {
     scale = uintBitsToFloat(t.x);
-    a = unpack111011(t.y) * 2.0 - 1.0;
-    b = unpack111011(t.z) * 2.0 - 1.0;
-    c = unpack111011(t.w) * 2.0 - 1.0;
+    a = unpack111011s(t.y);
+    b = unpack111011s(t.z);
+    c = unpack111011s(t.w);
 }
 
 // fetch quantized spherical harmonic coefficients
 void fetch(in uvec4 t, out vec3 a, out vec3 b, out vec3 c, out vec3 d) {
-    a = unpack111011(t.x) * 2.0 - 1.0;
-    b = unpack111011(t.y) * 2.0 - 1.0;
-    c = unpack111011(t.z) * 2.0 - 1.0;
-    d = unpack111011(t.w) * 2.0 - 1.0;
+    a = unpack111011s(t.x);
+    b = unpack111011s(t.y);
+    c = unpack111011s(t.z);
+    d = unpack111011s(t.w);
 }
 
 void fetch(in uint t, out vec3 a) {
-    a = unpack111011(t) * 2.0 - 1.0;
+    a = unpack111011s(t);
 }
 
 #if SH_BANDS == 1
     uniform highp usampler2D splatSH_1to3;
-    void readSHData(in SplatState state, out vec3 sh[3]) {
-        float scale;
+    void readSHData(in SplatState state, out vec3 sh[3], out float scale) {
         fetchScale(texelFetch(splatSH_1to3, state.uv, 0), scale, sh[0], sh[1], sh[2]);
-        for (int i = 0; i < 3; i++) {
-            sh[i] *= scale;
-        }
     }
 #elif SH_BANDS == 2
     uniform highp usampler2D splatSH_1to3;
     uniform highp usampler2D splatSH_4to7;
     uniform highp usampler2D splatSH_8to11;
-    void readSHData(in SplatState state, out vec3 sh[8]) {
-        float scale;
+    void readSHData(in SplatState state, out vec3 sh[8], out float scale) {
         fetchScale(texelFetch(splatSH_1to3, state.uv, 0), scale, sh[0], sh[1], sh[2]);
         fetch(texelFetch(splatSH_4to7, state.uv, 0), sh[3], sh[4], sh[5], sh[6]);
         fetch(texelFetch(splatSH_8to11, state.uv, 0).x, sh[7]);
-        for (int i = 0; i < 8; i++) {
-            sh[i] *= scale;
-        }
     }
 #else
     uniform highp usampler2D splatSH_1to3;
     uniform highp usampler2D splatSH_4to7;
     uniform highp usampler2D splatSH_8to11;
     uniform highp usampler2D splatSH_12to15;
-    void readSHData(in SplatState state, out vec3 sh[15]) {
-        float scale;
+    void readSHData(in SplatState state, out vec3 sh[15], out float scale) {
         fetchScale(texelFetch(splatSH_1to3, state.uv, 0), scale, sh[0], sh[1], sh[2]);
         fetch(texelFetch(splatSH_4to7, state.uv, 0), sh[3], sh[4], sh[5], sh[6]);
         fetch(texelFetch(splatSH_8to11, state.uv, 0), sh[7], sh[8], sh[9], sh[10]);
         fetch(texelFetch(splatSH_12to15, state.uv, 0), sh[11], sh[12], sh[13], sh[14]);
-        for (int i = 0; i < 15; i++) {
-            sh[i] *= scale;
-        }
     }
 #endif
 


### PR DESCRIPTION
 This PR is a followup to #7164. The following shader changes are made:
- bugfix for blurry gaussians when viewport isn't square
- split `readCenter` into two functions, `initState` and `readCenter` (allows early-out optimisation in SuperSplat)
- directly support ortho camera (also required for SuperSplat)
- spherical harmonic eval optimisations