### PR TITLE
[WebglGraphicsDevice] Catch and return async error in readTextureAsync

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2059,7 +2059,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
                     renderTarget.destroy();
                 }
                 resolve(data);
-            });
+            }).catch(reject);
         });
     }
 


### PR DESCRIPTION
Very small change to `WebglGraphicsDevice` which catches and calls `reject` when `readPixelsAsync` fails.

We saw this failure while attempting a readback during WebGL context loss, or if a context loss occurs while async reading is in progress.

Without this change, the method throws an uncaught exception that cannot be caught in any downstream APIs, for example:
```
myTexture
    .read(0, 0, myTexture.width, myTexture.height, { mipLevel: 0 })
    .then((pixels) => {
        // All is well
    }).catch((err) -> {
        // Will never be called on error
    });
```

With this change, the code above will work as expected and allow the developer to handle any readback errors as they see fit.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
