### PR TITLE
Update to render passes - generate scene half sized texture

### DIFF
--- a/examples/src/examples/graphics/clustered-lighting.example.mjs
+++ b/examples/src/examples/graphics/clustered-lighting.example.mjs
@@ -100,7 +100,6 @@ assetListLoader.load(() => {
     const cylinderMesh = pc.Mesh.fromGeometry(app.graphicsDevice, new pc.CylinderGeometry({ capSegments: 200 }));
     const cylinder = new pc.Entity();
     cylinder.addComponent('render', {
-        material: material,
         meshInstances: [new pc.MeshInstance(cylinderMesh, material)],
         castShadows: true
     });

--- a/src/extras/render-passes/render-pass-bloom.js
+++ b/src/extras/render-passes/render-pass-bloom.js
@@ -9,6 +9,10 @@ import { RenderPassDownsample } from './render-pass-downsample.js';
 import { RenderPassUpsample } from './render-pass-upsample.js';
 import { math } from '../../core/math/math.js';
 
+/**
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ */
+
 // based on https://learnopengl.com/Guest-Articles/2022/Phys.-Based-Bloom
 /**
  * Render pass implementation of HDR bloom effect.
@@ -27,6 +31,12 @@ class RenderPassBloom extends RenderPass {
 
     renderTargets = [];
 
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {Texture} sourceTexture - The source texture, usually at half the resolution of the
+     * render target getting blurred.
+     * @param {number} format - The texture format.
+     */
     constructor(device, sourceTexture, format) {
         super(device);
         this._sourceTexture = sourceTexture;
@@ -95,8 +105,7 @@ class RenderPassBloom extends RenderPass {
         let passSourceTexture = this._sourceTexture;
         for (let i = 0; i < numPasses; i++) {
 
-            const fast = i === 0;  // fast box downscale for the first pass
-            const pass = new RenderPassDownsample(device, passSourceTexture, fast);
+            const pass = new RenderPassDownsample(device, passSourceTexture);
             const rt = this.renderTargets[i];
             pass.init(rt, {
                 resizeSource: passSourceTexture,
@@ -128,24 +137,6 @@ class RenderPassBloom extends RenderPass {
         // release the rest
         this.destroyRenderPasses();
         this.destroyRenderTargets(1);
-    }
-
-    set sourceTexture(value) {
-        this._sourceTexture = value;
-
-        if (this.beforePasses.length > 0) {
-            const firstPass = this.beforePasses[0];
-
-            // change resize source
-            firstPass.options.resizeSource = value;
-
-            // change downsample source
-            firstPass.sourceTexture = value;
-        }
-    }
-
-    get sourceTexture() {
-        return this._sourceTexture;
     }
 
     frameUpdate() {

--- a/src/extras/render-passes/render-pass-downsample.js
+++ b/src/extras/render-passes/render-pass-downsample.js
@@ -61,6 +61,13 @@ class RenderPassDownsample extends RenderPassShaderQuad {
         this.sourceInvResolutionValue = new Float32Array(2);
     }
 
+    setSourceTexture(value) {
+        this._sourceTexture = value;
+
+        // change resize source
+        this.options.resizeSource = value;
+    }
+
     execute() {
         this.sourceTextureId.setValue(this.sourceTexture);
 

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -315,7 +315,7 @@ class RenderTarget {
         if (this.width !== width || this.height !== height) {
 
             if (this.mipLevel > 0) {
-                Debug.warn('Only render target rendering to mipLevel 0 can be resized, ignoring.', this);
+                Debug.warn('Only a render target rendering to mipLevel 0 can be resized, ignoring.', this);
                 return;
             }
 

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -312,12 +312,12 @@ class RenderTarget {
      */
     resize(width, height) {
 
-        if (this.mipLevel > 0) {
-            Debug.warn('Only render target rendering to mipLevel 0 can be resized, ignoring.', this);
-            return;
-        }
-
         if (this.width !== width || this.height !== height) {
+
+            if (this.mipLevel > 0) {
+                Debug.warn('Only render target rendering to mipLevel 0 can be resized, ignoring.', this);
+                return;
+            }
 
             // release existing
             const device = this._device;


### PR DESCRIPTION
Before: The scene gets rendered to a render target. The bloom then blurs it by downscaling and upscaling, starting at half size. The first bloom pass would just cheaply (box filter) downscale to half size. That makes the final bloom texture half size of the scene.

Now: The cheap downscale to half res is pulled out of bloom, as that is something other effects (DOF) needs as well, so lets generate it only one time. Bloom then uses it.

Small change is that the bloom texture ends up being a quarter size and not half size, so slightly cheaper, but I cannot see any difference visually, so happy with this.