### PR TITLE
Undo the R8 format fix

### DIFF
--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1238,7 +1238,6 @@ export const getPixelFormatArrayType = (format) => {
         case PIXELFORMAT_RGB16F:
         case PIXELFORMAT_RGBA16F:
             return Uint16Array;
-        case PIXELFORMAT_R8:
         case PIXELFORMAT_R8I:
         case PIXELFORMAT_RG8I:
         case PIXELFORMAT_RGBA8I:


### PR DESCRIPTION
Undo fix from #7177 , as that format was already handled by the `default:` case.