### PR TITLE
Small gsplat shader update

### DIFF
--- a/examples/src/examples/loaders/gsplat-many.shader.vert
+++ b/examples/src/examples/loaders/gsplat-many.shader.vert
@@ -35,13 +35,14 @@ void main(void)
     // handle transforms
     mat4 model_view = matrix_view * matrix_model;
     vec4 splat_cam = model_view * vec4(center, 1.0);
-    vec4 splat_proj = matrix_projection * splat_cam;
 
     // cull behind camera
-    if (splat_proj.z < -splat_proj.w) {
+    if (splat_cam.z > 0.0) {
         gl_Position = discardVec;
         return;
     }
+
+    vec4 splat_proj = matrix_projection * splat_cam;
 
     // get covariance
     vec3 covA, covB;

--- a/examples/src/examples/loaders/gsplat-many.shader.vert
+++ b/examples/src/examples/loaders/gsplat-many.shader.vert
@@ -44,6 +44,9 @@ void main(void)
 
     vec4 splat_proj = matrix_projection * splat_cam;
 
+    // ensure gaussians are not clipped by camera near and far
+    splat_proj.z = clamp(splat_proj.z, -abs(splat_proj.w), abs(splat_proj.w));
+
     // get covariance
     vec3 covA, covB;
     getCovariance(covA, covB);

--- a/src/scene/gsplat/gsplat-material.js
+++ b/src/scene/gsplat/gsplat-material.js
@@ -29,13 +29,17 @@ const splatMainVS = /* glsl */ `
         // handle transforms
         mat4 model_view = matrix_view * matrix_model;
         vec4 splat_cam = model_view * vec4(center, 1.0);
-        vec4 splat_proj = matrix_projection * splat_cam;
 
         // cull behind camera
-        if (splat_proj.z < -splat_proj.w) {
+        if (splat_cam.z > 0.0) {
             gl_Position = discardVec;
             return;
         }
+
+        vec4 splat_proj = matrix_projection * splat_cam;
+
+        // ensure gaussians are not clipped by camera near and far
+        splat_proj.z = clamp(splat_proj.z, -abs(splat_proj.w), abs(splat_proj.w));
 
         // get covariance
         vec3 covA, covB;


### PR DESCRIPTION
This PR changes the default gsplat shader to refrain from clipping gaussians by the near and far camera clipping planes. Depth values are clamped instead.