### PR TITLE
Optimize RenderComponent destroy

### DIFF
--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -172,8 +172,7 @@ class RenderComponent extends Component {
      *
      * @param {import('./system.js').RenderComponentSystem} system - The ComponentSystem that
      * created this Component.
-     * @param {Entity} entity - The Entity that this Component is
-     * attached to.
+     * @param {Entity} entity - The Entity that this Component is attached to.
      */
     constructor(system, entity) {
         super(system, entity);

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -719,6 +719,7 @@ class RenderComponent extends Component {
                 this._rootBone = value;
             } else if (isString) {
                 this._rootBone = this.system.app.getEntityFromIndex(value) || null;
+                Debug.assert(this._rootBone, 'Failed to find rootBone Entity by GUID');
             } else {
                 this._rootBone = null;
             }

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -12,8 +12,6 @@ import { AssetReference } from '../../asset/asset-reference.js';
 
 import { Component } from '../component.js';
 
-import { EntityReference } from '../../utils/entity-reference.js';
-
 /**
  * The RenderComponent enables an {@link Entity} to render 3D meshes. The {@link RenderComponent#type}
  * property can be set to one of several predefined shape types (such as `box`, `sphere`, `cone`
@@ -53,9 +51,6 @@ import { EntityReference } from '../../utils/entity-reference.js';
  * - [Spinning Cube](https://playcanvas.github.io/#/misc/hello-world)
  * - [Primitive Shapes](https://playcanvas.github.io/#/graphics/shapes)
  * - [Loading Render Assets](https://playcanvas.github.io/#/graphics/render-asset)
- *
- * @property {import('../../entity.js').Entity} rootBone A reference to the entity to be used as
- * the root bone for any skinned meshes that are rendered by this component.
  *
  * @category Graphics
  */
@@ -136,10 +131,12 @@ class RenderComponent extends Component {
     _material;
 
     /**
-     * @type {EntityReference}
-     * @private
+     * A reference to the entity to be used as the root bone for any skinned meshes that
+     * are rendered by this component.
+     *
+     * @type {import('../../entity.js').Entity|null}
      */
-    _rootBone;
+    _rootBone = null;
 
     /**
      * @type {import('../../../core/event-handle.js').EventHandle|null}
@@ -177,8 +174,6 @@ class RenderComponent extends Component {
         super(system, entity);
 
         // the entity that represents the root bone if this render component has skinned meshes
-        this._rootBone = new EntityReference(this, 'rootBone');
-        this._rootBone.on('set:entity', this._onSetRootBone, this);
 
         // render asset reference
         this._assetReference = new AssetReference(
@@ -275,7 +270,6 @@ class RenderComponent extends Component {
      * @type {string}
      */
     set type(value) {
-
         if (this._type !== value) {
             this._area = null;
             this._type = value;
@@ -312,7 +306,6 @@ class RenderComponent extends Component {
      * @type {MeshInstance[]}
      */
     set meshInstances(value) {
-
         Debug.assert(Array.isArray(value), 'MeshInstances set to a Render component must be an array.');
         this.destroyMeshInstances();
 
@@ -702,28 +695,37 @@ class RenderComponent extends Component {
         this._assetReference.id = id;
     }
 
-    /**
-     * @param {import('../../entity.js').Entity} entity - The entity set as the root bone.
-     * @private
-     */
-    _onSetRootBone(entity) {
-        if (entity) {
-            this._onRootBoneChanged();
+    set rootBone(value) {
+        if (this._rootBone !== value) {
+            const isString = typeof (value) === 'string';
+            if (this._rootBone && isString && this._rootBone.getGuid() === value) {
+                return;
+            }
+
+            if (this._rootBone) {
+                this._clearSkinInstances();
+            }
+
+            if (value instanceof GraphNode) {
+                this._rootBone = value;
+            } else if (isString) {
+                this._rootBone = this.system.app.getEntityFromIndex(value) || null;
+            } else {
+                this._rootBone = null;
+            }
+
+            if (this._rootBone) {
+                this._cloneSkinInstances();
+            }
         }
     }
 
-    /** @private */
-    _onRootBoneChanged() {
-        // remove existing skin instances and create new ones, connected to new root bone
-        this._clearSkinInstances();
-        if (this.enabled && this.entity.enabled) {
-            this._cloneSkinInstances();
-        }
+    get rootBone() {
+        return this._rootBone;
     }
 
     /** @private */
     destroyMeshInstances() {
-
         const meshInstances = this._meshInstances;
         if (meshInstances) {
             this.removeFromLayers();
@@ -814,9 +816,9 @@ class RenderComponent extends Component {
         const scene = app.scene;
         const layers = scene.layers;
 
-        this._rootBone.onParentComponentEnable();
-
-        this._cloneSkinInstances();
+        if (this._rootBone) {
+            this._cloneSkinInstances();
+        }
 
         this._evtLayersChanged = scene.on('set:layers', this.onLayersChanged, this);
 
@@ -851,6 +853,10 @@ class RenderComponent extends Component {
 
         this._evtLayersChanged?.off();
         this._evtLayersChanged = null;
+
+        if (this._rootBone) {
+            this._clearSkinInstances();
+        }
 
         if (layers) {
             this._evtLayerAdded?.off();
@@ -904,7 +910,6 @@ class RenderComponent extends Component {
     }
 
     _onRenderAssetLoad() {
-
         // remove existing instances
         this.destroyMeshInstances();
 
@@ -923,7 +928,6 @@ class RenderComponent extends Component {
     }
 
     _clearSkinInstances() {
-
         for (let i = 0; i < this._meshInstances.length; i++) {
             const meshInstance = this._meshInstances[i];
 
@@ -934,23 +938,20 @@ class RenderComponent extends Component {
     }
 
     _cloneSkinInstances() {
-
-        if (this._meshInstances.length && this._rootBone.entity instanceof GraphNode) {
-
+        if (this._meshInstances.length && this._rootBone instanceof GraphNode) {
             for (let i = 0; i < this._meshInstances.length; i++) {
                 const meshInstance = this._meshInstances[i];
                 const mesh = meshInstance.mesh;
 
                 // if skinned but does not have instance created yet
                 if (mesh.skin && !meshInstance.skinInstance) {
-                    meshInstance.skinInstance = SkinInstanceCache.createCachedSkinInstance(mesh.skin, this._rootBone.entity, this.entity);
+                    meshInstance.skinInstance = SkinInstanceCache.createCachedSkinInstance(mesh.skin, this._rootBone, this.entity);
                 }
             }
         }
     }
 
     _cloneMeshes(meshes) {
-
         if (meshes && meshes.length) {
 
             // cloned mesh instances
@@ -1031,10 +1032,9 @@ class RenderComponent extends Component {
     }
 
     resolveDuplicatedEntityReferenceProperties(oldRender, duplicatedIdsMap) {
-        if (oldRender.rootBone && duplicatedIdsMap[oldRender.rootBone]) {
-            this.rootBone = duplicatedIdsMap[oldRender.rootBone];
+        if (oldRender.rootBone) {
+            this.rootBone = duplicatedIdsMap[oldRender.rootBone.getGuid()];
         }
-        this._clearSkinInstances();
     }
 }
 

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -13,6 +13,10 @@ import { AssetReference } from '../../asset/asset-reference.js';
 import { Component } from '../component.js';
 
 /**
+ * @import { Entity } from '../../entity.js'
+ */
+
+/**
  * The RenderComponent enables an {@link Entity} to render 3D meshes. The {@link RenderComponent#type}
  * property can be set to one of several predefined shape types (such as `box`, `sphere`, `cone`
  * and so on). Alternatively, the component can be configured to manage an arbitrary array of
@@ -134,7 +138,7 @@ class RenderComponent extends Component {
      * A reference to the entity to be used as the root bone for any skinned meshes that
      * are rendered by this component.
      *
-     * @type {import('../../entity.js').Entity|null}
+     * @type {Entity|null}
      * @private
      */
     _rootBone = null;
@@ -168,7 +172,7 @@ class RenderComponent extends Component {
      *
      * @param {import('./system.js').RenderComponentSystem} system - The ComponentSystem that
      * created this Component.
-     * @param {import('../../entity.js').Entity} entity - The Entity that this Component is
+     * @param {Entity} entity - The Entity that this Component is
      * attached to.
      */
     constructor(system, entity) {
@@ -699,7 +703,7 @@ class RenderComponent extends Component {
     /**
      * Sets the root bone entity (or entity guid) for the render component.
      *
-     * @type {import('../../entity.js').Entity|string|null}
+     * @type {Entity|string|null}
      */
     set rootBone(value) {
         if (this._rootBone !== value) {
@@ -729,7 +733,7 @@ class RenderComponent extends Component {
     /**
      * Gets the root bone entity for the render component.
      *
-     * @type {import('../../entity.js').Entity|null}
+     * @type {Entity|null}
      */
     get rootBone() {
         return this._rootBone;

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -135,6 +135,7 @@ class RenderComponent extends Component {
      * are rendered by this component.
      *
      * @type {import('../../entity.js').Entity|null}
+     * @private
      */
     _rootBone = null;
 
@@ -695,6 +696,11 @@ class RenderComponent extends Component {
         this._assetReference.id = id;
     }
 
+    /**
+     * Sets the root bone entity (or entity guid) for the render component.
+     *
+     * @type {import('../../entity.js').Entity|string|null}
+     */
     set rootBone(value) {
         if (this._rootBone !== value) {
             const isString = typeof (value) === 'string';
@@ -720,6 +726,11 @@ class RenderComponent extends Component {
         }
     }
 
+    /**
+     * Gets the root bone entity for the render component.
+     *
+     * @type {import('../../entity.js').Entity|null}
+     */
     get rootBone() {
         return this._rootBone;
     }

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -719,7 +719,9 @@ class RenderComponent extends Component {
                 this._rootBone = value;
             } else if (isString) {
                 this._rootBone = this.system.app.getEntityFromIndex(value) || null;
-                Debug.assert(this._rootBone, 'Failed to find rootBone Entity by GUID');
+                if (!this._rootBone) {
+                    Debug.warn('Failed to find rootBone Entity by GUID');
+                }
             } else {
                 this._rootBone = null;
             }

--- a/src/framework/components/render/data.js
+++ b/src/framework/components/render/data.js
@@ -1,7 +1,6 @@
 class RenderComponentData {
     constructor() {
         this.enabled = true;
-        this.rootBone = null;
     }
 }
 

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -11,7 +11,6 @@ import { RenderComponent } from './component.js';
 import { RenderComponentData } from './data.js';
 
 const _schema = [
-    { name: 'rootBone', type: 'entity' },
     'enabled'
 ];
 
@@ -30,7 +29,8 @@ const _properties = [
     'type',
     'layers',
     'isStatic',
-    'batchGroupId'
+    'batchGroupId',
+    'rootBone'
 ];
 
 /**


### PR DESCRIPTION
RenderComponent has a property `rootBone`, which is just a reference to an entity, that is used for skinning. Currently, it uses overcomplex EntityReference which creates a number of event handlers in various systems, which is extremely inefficient. `rootBone` - is a simple property that just is either `null` or some Entity.
When creating/destroying entities, EntityReference has to subscribe and unsubscribe to a number of events, which leads to an unnecessary workload.

So this PR just simplifies `rootBone` property, which does not change any behaviours. While optimising destruction of all RenderComponents (not skinned especially!!).

### Here are test results, of destroying 4706 entities with RenderComponents (not skinned, primitive cubes):
**Before: 640ms**
**After: 84ms**

# This is ~7.5 times speedup, or ~87% improvement.

In our use case, we need to parametrically create a lot of entities, and remove them on user interaction, so any lag spike is extremely noticeable. I've also noticed that changing rootBone when an entity is disabled, will not be taken in account when an entity is enabled, but this is an existing current problem and should be fixed in a separate PR.

Also, a lot of other components use EntityReference, which is best to go. It is unnecessarily complex and inefficient.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
