### PR TITLE
Hide component constructors

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -13,39 +13,50 @@ import {
 import { AnimTrack } from '../../anim/evaluator/anim-track.js';
 
 /**
- * @import { AnimComponentSystem } from './system.js'
- */
-
-/**
  * The Anim Component allows an Entity to playback animations on models and entity properties.
  *
+ * @hideconstructor
  * @category Animation
  */
 class AnimComponent extends Component {
-    /**
-     * Create a new AnimComponent instance.
-     *
-     * @param {AnimComponentSystem} system - The {@link ComponentSystem} that created this Component.
-     * @param {Entity} entity - The Entity that this Component is attached to.
-     */
-    constructor(system, entity) {
-        super(system, entity);
+    /** @private */
+    _stateGraphAsset = null;
 
-        this._stateGraphAsset = null;
-        this._animationAssets = {};
-        this._speed = 1.0;
-        this._activate = true;
-        this._playing = false;
-        this._rootBone = null;
-        this._stateGraph = null;
-        this._layers = [];
-        this._layerIndices = {};
-        this._parameters = {};
-        // a collection of animated property targets
-        this._targets = {};
-        this._consumedTriggers = new Set();
-        this._normalizeWeights = false;
-    }
+    /** @private */
+    _animationAssets = {};
+
+    /** @private */
+    _speed = 1;
+
+    /** @private */
+    _activate = true;
+
+    /** @private */
+    _playing = false;
+
+    /** @private */
+    _rootBone = null;
+
+    /** @private */
+    _stateGraph = null;
+
+    /** @private */
+    _layers = [];
+
+    /** @private */
+    _layerIndices = {};
+
+    /** @private */
+    _parameters = {};
+
+    /** @private */
+    _targets = {};
+
+    /** @private */
+    _consumedTriggers = new Set();
+
+    /** @private */
+    _normalizeWeights = false;
 
     set stateGraphAsset(value) {
         if (value === null) {

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -9,14 +9,13 @@ import { Component } from '../component.js';
 
 /**
  * @import { Animation } from '../../../scene/animation/animation.js'
- * @import { AnimationComponentSystem } from './system.js'
- * @import { Entity } from '../../entity.js'
  * @import { Model } from '../../../scene/model.js'
  */
 
 /**
  * The Animation Component allows an Entity to playback animations on models.
  *
+ * @hideconstructor
  * @category Animation
  */
 class AnimationComponent extends Component {
@@ -108,17 +107,6 @@ class AnimationComponent extends Component {
      * @type {number}
      */
     speed = 1;
-
-    /**
-     * Create a new AnimationComponent instance.
-     *
-     * @param {AnimationComponentSystem} system - The {@link ComponentSystem} that created this
-     * component.
-     * @param {Entity} entity - The Entity that this component is attached to.
-     */
-    constructor(system, entity) { // eslint-disable-line no-useless-constructor
-        super(system, entity);
-    }
 
     /**
      * Sets the dictionary of animations by name.

--- a/src/framework/components/audio-listener/component.js
+++ b/src/framework/components/audio-listener/component.js
@@ -1,27 +1,13 @@
 import { Component } from '../component.js';
 
 /**
- * @import { AudioListenerComponentSystem } from './system.js'
- * @import { Entity } from '../../entity.js'
- */
-
-/**
  * Represents the audio listener in the 3D world, so that 3D positioned audio sources are heard
  * correctly.
  *
+ * @hideconstructor
  * @category Sound
  */
 class AudioListenerComponent extends Component {
-    /**
-     * Create a new AudioListenerComponent instance.
-     *
-     * @param {AudioListenerComponentSystem} system - The ComponentSystem that created this component.
-     * @param {Entity} entity - The Entity that this component is attached to.
-     */
-    constructor(system, entity) { // eslint-disable-line no-useless-constructor
-        super(system, entity);
-    }
-
     setCurrentListener() {
         if (this.enabled && this.entity.audiolistener && this.entity.enabled) {
             this.system.current = this.entity;

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -43,6 +43,7 @@ STATES_TO_SPRITE_FRAME_NAMES[VisualState.INACTIVE] = 'inactiveSpriteFrame';
  * A ButtonComponent enables a group of entities to behave like a button, with different visual
  * states for hover and press interactions.
  *
+ * @hideconstructor
  * @category User Interface
  */
 class ButtonComponent extends Component {
@@ -243,6 +244,27 @@ class ButtonComponent extends Component {
      */
     static EVENT_PRESSEDEND = 'pressedend';
 
+    /** @private */
+    _visualState = VisualState.DEFAULT;
+
+    /** @private */
+    _isHovering = false;
+
+    /** @private */
+    _hoveringCounter = 0;
+
+    /** @private */
+    _isPressed = false;
+
+    /** @private */
+    _defaultTint = new Color(1, 1, 1, 1);
+
+    /** @private */
+    _defaultSpriteAsset = null;
+
+    /** @private */
+    _defaultSpriteFrame = 0;
+
     /**
      * Create a new ButtonComponent instance.
      *
@@ -251,15 +273,6 @@ class ButtonComponent extends Component {
      */
     constructor(system, entity) {
         super(system, entity);
-
-        this._visualState = VisualState.DEFAULT;
-        this._isHovering = false;
-        this._hoveringCounter = 0;
-        this._isPressed = false;
-
-        this._defaultTint = new Color(1, 1, 1, 1);
-        this._defaultSpriteAsset = null;
-        this._defaultSpriteFrame = 0;
 
         this._imageReference = new EntityReference(this, 'imageEntity', {
             'element#gain': this._onImageElementGain,

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -50,6 +50,7 @@ import { PostEffectQueue } from './post-effect-queue.js';
  * entity.camera.nearClip = 2;
  * ```
  *
+ * @hideconstructor
  * @category Graphics
  */
 class CameraComponent extends Component {

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -30,6 +30,7 @@ const _quat = new Quat();
  * | **Rigid Body (Dynamic or Kinematic)** | <ul><li>contact</li><li>collisionstart</li><li>collisionend</li></ul> | <ul><li>contact</li><li>collisionstart</li><li>collisionend</li></ul> | <ul><li>triggerenter</li><li>triggerleave</li></ul> |
  * | **Trigger Volume**                    |                                                                       | <ul><li>triggerenter</li><li>triggerleave</li></ul>                   |                                                     |
  *
+ * @hideconstructor
  * @category Physics
  */
 class CollisionComponent extends Component {
@@ -94,6 +95,12 @@ class CollisionComponent extends Component {
      */
     static EVENT_TRIGGERLEAVE = 'triggerleave';
 
+    /** @private */
+    _compoundParent = null;
+
+    /** @private */
+    _hasOffset = false;
+
     /**
      * Create a new CollisionComponent.
      *
@@ -102,10 +109,6 @@ class CollisionComponent extends Component {
      */
     constructor(system, entity) {
         super(system, entity);
-
-        /** @private */
-        this._compoundParent = null;
-        this._hasOffset = false;
 
         this.entity.on('insert', this._onInsert, this);
 

--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -8,6 +8,8 @@ import { EventHandler } from '../../core/event-handler.js';
 /**
  * Components are used to attach functionality on a {@link Entity}. Components can receive update
  * events each frame, and expose properties to the PlayCanvas Editor.
+ *
+ * @hideconstructor
  */
 class Component extends EventHandler {
     /**

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -82,6 +82,7 @@ const matD = new Mat4();
  * - [Text localization](https://playcanvas.github.io/#/user-interface/text-localization)
  * - [Typewriter text](https://playcanvas.github.io/#/user-interface/text-typewriter)
  *
+ * @hideconstructor
  * @category User Interface
  */
 class ElementComponent extends Component {

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -22,6 +22,7 @@ import { Component } from '../component.js';
  * - [Loading a Splat](https://playcanvas.github.io/#/loaders/gsplat)
  * - [Custom Splat Shaders](https://playcanvas.github.io/#/loaders/gsplat-many)
  *
+ * @hideconstructor
  * @category Graphics
  */
 class GSplatComponent extends Component {

--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -1,41 +1,33 @@
 import { Component } from '../component.js';
 
 /**
- * @import { Entity } from '../../entity.js'
- * @import { LayoutChildComponentSystem } from './system.js'
- */
-
-/**
  * A LayoutChildComponent enables the Entity to control the sizing applied to it by its parent
  * {@link LayoutGroupComponent}.
  *
+ * @hideconstructor
  * @category User Interface
  */
 class LayoutChildComponent extends Component {
-    /**
-     * Create a new LayoutChildComponent.
-     *
-     * @param {LayoutChildComponentSystem} system - The ComponentSystem that created this Component.
-     * @param {Entity} entity - The Entity that this Component is attached to.
-     */
-    constructor(system, entity) {
-        super(system, entity);
+    /** @private */
+    _minWidth = 0;
 
-        /** @private */
-        this._minWidth = 0;
-        /** @private */
-        this._minHeight = 0;
-        /** @private */
-        this._maxWidth = null;
-        /** @private */
-        this._maxHeight = null;
-        /** @private */
-        this._fitWidthProportion = 0;
-        /** @private */
-        this._fitHeightProportion = 0;
-        /** @private */
-        this._excludeFromLayout = false;
-    }
+    /** @private */
+    _minHeight = 0;
+
+    /** @private */
+    _maxWidth = null;
+
+    /** @private */
+    _maxHeight = null;
+
+    /** @private */
+    _fitWidthProportion = 0;
+
+    /** @private */
+    _fitHeightProportion = 0;
+
+    /** @private */
+    _excludeFromLayout = false;
 
     /**
      * Sets the minimum width the element should be rendered at.

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -23,9 +23,40 @@ function isEnabledAndHasEnabledElement(entity) {
  * A LayoutGroupComponent enables the Entity to position and scale child {@link ElementComponent}s
  * according to configurable layout rules.
  *
+ * @hideconstructor
  * @category User Interface
  */
 class LayoutGroupComponent extends Component {
+    /** @private */
+    _orientation = ORIENTATION_HORIZONTAL;
+
+    /** @private */
+    _reverseX = false;
+
+    /** @private */
+    _reverseY = true;
+
+    /** @private */
+    _alignment = new Vec2(0, 1);
+
+    /** @private */
+    _padding = new Vec4();
+
+    /** @private */
+    _spacing = new Vec2();
+
+    /** @private */
+    _widthFitting = FITTING_NONE;
+
+    /** @private */
+    _heightFitting = FITTING_NONE;
+
+    /** @private */
+    _wrap = false;
+
+    /** @private */
+    _layoutCalculator = new LayoutCalculator();
+
     /**
      * Create a new LayoutGroupComponent instance.
      *
@@ -34,27 +65,6 @@ class LayoutGroupComponent extends Component {
      */
     constructor(system, entity) {
         super(system, entity);
-
-        /** @private */
-        this._orientation = ORIENTATION_HORIZONTAL;
-        /** @private */
-        this._reverseX = false;
-        /** @private */
-        this._reverseY = true;
-        /** @private */
-        this._alignment = new Vec2(0, 1);
-        /** @private */
-        this._padding = new Vec4();
-        /** @private */
-        this._spacing = new Vec2();
-        /** @private */
-        this._widthFitting = FITTING_NONE;
-        /** @private */
-        this._heightFitting = FITTING_NONE;
-        /** @private */
-        this._wrap = false;
-        /** @private */
-        this._layoutCalculator = new LayoutCalculator();
 
         // Listen for the group container being resized
         this._listenForReflowEvents(this.entity, 'on');

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -7,9 +7,7 @@ import { properties } from './data.js';
 
 /**
  * @import { Color } from '../../../core/math/color.js'
- * @import { Entity } from '../../entity.js'
  * @import { LightComponentData } from './data.js'
- * @import { LightComponentSystem } from './system.js'
  * @import { Light } from '../../../scene/light.js'
  * @import { Texture } from '../../../platform/graphics/texture.js'
  * @import { Vec2 } from '../../../core/math/vec2.js'
@@ -39,6 +37,7 @@ import { properties } from './data.js';
  * entity.light.range = 20;
  * ```
  *
+ * @hideconstructor
  * @category Graphics
  */
 class LightComponent extends Component {
@@ -60,20 +59,17 @@ class LightComponent extends Component {
      */
     _evtLayerRemoved = null;
 
-    /**
-     * Creates a new LightComponent instance.
-     *
-     * @param {LightComponentSystem} system - The ComponentSystem that created this Component.
-     * @param {Entity} entity - The Entity that this Component is attached to.
-     */
-    constructor(system, entity) {
-        super(system, entity);
+    /** @private */
+    _cookieAsset = null;
 
-        this._cookieAsset = null;
-        this._cookieAssetId = null;
-        this._cookieAssetAdd = false;
-        this._cookieMatrix = null;
-    }
+    /** @private */
+    _cookieAssetId = null;
+
+    /** @private */
+    _cookieAssetAdd = false;
+
+    /** @private */
+    _cookieMatrix = null;
 
     // TODO: Remove this override in upgrading component
     /**

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -21,6 +21,7 @@ import { Component } from '../component.js';
  * Enables an Entity to render a model or a primitive shape. This Component attaches additional
  * model geometry in to the scene graph below the Entity.
  *
+ * @hideconstructor
  * @category Graphics
  */
 class ModelComponent extends Component {

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -103,6 +103,7 @@ let depthLayer;
  * time. Most of the curve parameters can also be specified by 2 minimum/maximum curves, this way
  * each particle will pick a random value in-between.
  *
+ * @hideconstructor
  * @category Graphics
  */
 class ParticleSystemComponent extends Component {

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -61,6 +61,7 @@ import { EntityReference } from '../../utils/entity-reference.js';
  * @property {Entity} rootBone A reference to the entity to be used as the root bone for any
  * skinned meshes that are rendered by this component.
  *
+ * @hideconstructor
  * @category Graphics
  */
 class RenderComponent extends Component {

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -55,6 +55,7 @@ const _vec3 = new Vec3();
  * - [Falling shapes](https://playcanvas.github.io/#/physics/falling-shapes)
  * - [Vehicle physics](https://playcanvas.github.io/#/physics/vehicle)
  *
+ * @hideconstructor
  * @category Physics
  */
 class RigidBodyComponent extends Component {
@@ -164,16 +165,6 @@ class RigidBodyComponent extends Component {
 
     /** @private */
     _type = BODYTYPE_STATIC;
-
-    /**
-     * Create a new RigidBodyComponent instance.
-     *
-     * @param {RigidBodyComponentSystem} system - The ComponentSystem that created this component.
-     * @param {Entity} entity - The entity this component is attached to.
-     */
-    constructor(system, entity) { // eslint-disable-line no-useless-constructor
-        super(system, entity);
-    }
 
     /** @ignore */
     static onLibraryLoaded() {

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -15,6 +15,7 @@ const _transform = new Mat4();
  * A ScreenComponent enables the Entity to render child {@link ElementComponent}s using anchors and
  * positions in the ScreenComponent's space.
  *
+ * @hideconstructor
  * @category User Interface
  */
 class ScreenComponent extends Component {

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -22,6 +22,7 @@ const toLowerCamelCase = str => str[0].toLowerCase() + str.substring(1);
  * Script Types defined in JavaScript files to be executed with access to the Entity. For more
  * details on scripting see [Scripting](https://developer.playcanvas.com/user-manual/scripting/).
  *
+ * @hideconstructor
  * @category Script
  */
 class ScriptComponent extends Component {

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -21,6 +21,7 @@ const _tempScrollValue = new Vec2();
  * A ScrollViewComponent enables a group of entities to behave like a masked scrolling area, with
  * optional horizontal and vertical scroll bars.
  *
+ * @hideconstructor
  * @category User Interface
  */
 class ScrollViewComponent extends Component {

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -13,6 +13,7 @@ import { EntityReference } from '../../utils/entity-reference.js';
 /**
  * A ScrollbarComponent enables a group of entities to behave like a draggable scrollbar.
  *
+ * @hideconstructor
  * @category User Interface
  */
 class ScrollbarComponent extends Component {

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -53,6 +53,7 @@ import { SoundSlot } from './slot.js';
  *
  * - [Positional Sound](https://playcanvas.github.io/#/sound/positional)
  *
+ * @hideconstructor
  * @category Sound
  */
 class SoundComponent extends Component {
@@ -116,39 +117,36 @@ class SoundComponent extends Component {
      */
     static EVENT_END = 'end';
 
+    /** @private */
+    _volume = 1;
+
+    /** @private */
+    _pitch = 1;
+
+    /** @private */
+    _positional = true;
+
+    /** @private */
+    _refDistance = 1;
+
+    /** @private */
+    _maxDistance = 10000;
+
+    /** @private */
+    _rollOffFactor = 1;
+
+    /** @private */
+    _distanceModel = DISTANCE_LINEAR;
+
     /**
-     * Create a new Sound Component.
-     *
-     * @param {SoundComponentSystem} system - The ComponentSystem that created this component.
-     * @param {Entity} entity - The entity that the Component is attached to.
+     * @type {Object<string, SoundSlot>}
+     * @private
      */
-    constructor(system, entity) {
-        super(system, entity);
+    _slots = {};
 
-        /** @private */
-        this._volume = 1;
-        /** @private */
-        this._pitch = 1;
-        /** @private */
-        this._positional = true;
-        /** @private */
-        this._refDistance = 1;
-        /** @private */
-        this._maxDistance = 10000;
-        /** @private */
-        this._rollOffFactor = 1;
-        /** @private */
-        this._distanceModel = DISTANCE_LINEAR;
+    /** @private */
+    _playingBeforeDisable = {};
 
-        /**
-         * @type {Object<string, SoundSlot>}
-         * @private
-         */
-        this._slots = {};
-
-        /** @private */
-        this._playingBeforeDisable = {};
-    }
 
     /**
      * Update the specified property on all sound instances.

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -33,6 +33,7 @@ const PARAM_ATLAS_RECT = 'atlasRect';
 /**
  * Enables an Entity to render a simple static sprite or sprite animations.
  *
+ * @hideconstructor
  * @category Graphics
  */
 class SpriteComponent extends Component {


### PR DESCRIPTION
* Hide all component constructors for the docs (since you should never create components via constructor and use `addComponent` instead).
* Delete a few 'useless' constructors.
* Convert some more properties to class fields.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
