### PR TITLE
Remove CameraComponentSystem onUpdate handler

### DIFF
--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -44,8 +44,6 @@ class CameraComponentSystem extends ComponentSystem {
 
         this.on('beforeremove', this.onBeforeRemove, this);
         this.app.on('prerender', this.onAppPrerender, this);
-
-        this.app.systems.on('update', this.onUpdate, this);
     }
 
     initializeComponentData(component, data, properties) {
@@ -153,9 +151,6 @@ class CameraComponentSystem extends ComponentSystem {
         component.onRemove();
     }
 
-    onUpdate(dt) {
-    }
-
     onAppPrerender() {
         for (let i = 0, len = this.cameras.length; i < len; i++) {
             this.cameras[i].onAppPrerender();
@@ -173,12 +168,6 @@ class CameraComponentSystem extends ComponentSystem {
             this.cameras.splice(index, 1);
             sortPriority(this.cameras);
         }
-    }
-
-    destroy() {
-        super.destroy();
-
-        this.app.systems.off('update', this.onUpdate, this);
     }
 }
 

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -171,9 +171,9 @@ class CameraComponentSystem extends ComponentSystem {
     }
 
     destroy() {
-        super.destroy();
-
         this.app.off('prerender', this.onAppPrerender, this);
+
+        super.destroy();
     }
 }
 

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -169,6 +169,12 @@ class CameraComponentSystem extends ComponentSystem {
             sortPriority(this.cameras);
         }
     }
+
+    destroy() {
+        super.destroy();
+
+        this.app.off('prerender', this.onAppPrerender, this);
+    }
 }
 
 Component._buildAccessors(CameraComponent.prototype, _schema);


### PR DESCRIPTION
* The `onUpdate` handler is empty and can be safely removed.
* It's not overridden or utilized in any way by the Editor.
* Correctly `off` the `prerender` event in `ComponentSystem#destroy`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
