### PR TITLE
[Fix] Change gloss default value to 1

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -1125,7 +1125,7 @@ const createMaterial = (gltfMaterial, textures) => {
 
     // Set glTF spec defaults
     material.specular.set(1, 1, 1);
-    material.gloss = 0;
+    material.gloss = 1;
     material.glossInvert = true;
     material.useMetalness = true;
 


### PR DESCRIPTION
it seems my suggestion here was not correct: https://github.com/playcanvas/engine/pull/7198#discussion_r1889896613

as a result, few engine examples rendered like this:
![Screenshot 2024-12-19 at 15 54 03](https://github.com/user-attachments/assets/6f80cc3e-1974-438c-947a-682b1f87cc04)
