### PR TITLE
DOF support for WebGPU

### DIFF
--- a/examples/src/examples/graphics/depth-of-field.example.mjs
+++ b/examples/src/examples/graphics/depth-of-field.example.mjs
@@ -1,4 +1,3 @@
-// @config WEBGPU_DISABLED
 import { data } from 'examples/observer';
 import { deviceType, rootPath } from 'examples/utils';
 import * as pc from 'playcanvas';

--- a/src/extras/render-passes/render-pass-dof-blur.js
+++ b/src/extras/render-passes/render-pass-dof-blur.js
@@ -88,7 +88,7 @@ class RenderPassDofBlur extends RenderPassShaderQuad {
                     for (int i = 0; i < ${kernelCount}; i++)
                     {
                         vec2 uv = uv0 + step * kernel[i];
-                        vec3 tap = texture2D(nearTexture, uv).rgb;
+                        vec3 tap = texture2DLodEXT(nearTexture, uv, 0.0).rgb;
                         sum += tap.rgb;
                     }
 
@@ -103,10 +103,10 @@ class RenderPassDofBlur extends RenderPassShaderQuad {
                     for (int i = 0; i < ${kernelCount}; i++)
                     {
                         vec2 uv = uv0 + step * kernel[i];
-                        vec3 tap = texture2D(farTexture, uv).rgb;
+                        vec3 tap = texture2DLodEXT(farTexture, uv, 0.0).rgb;
 
                         // block out sharp objects to avoid leaking to far blur
-                        float cocThis = texture2D(cocTexture, uv).g;
+                        float cocThis = texture2DLodEXT(cocTexture, uv, 0.0).g;
                         tap *= cocThis;
                         sumCoC += cocThis;
 


### PR DESCRIPTION
- turns out the incorrect shader generation was due to uniform control flow warning due to not using LOD sampling instructions.