### PR TITLE
DOF - near blur is optional

### DIFF
--- a/examples/src/examples/graphics/depth-of-field.controls.mjs
+++ b/examples/src/examples/graphics/depth-of-field.controls.mjs
@@ -40,6 +40,15 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
+                { text: 'Near Blur' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.dof.nearBlur' }
+                })
+            ),
+            jsx(
+                LabelGroup,
                 { text: 'Focus Distance' },
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),

--- a/examples/src/examples/graphics/depth-of-field.example.mjs
+++ b/examples/src/examples/graphics/depth-of-field.example.mjs
@@ -149,6 +149,7 @@ assetListLoader.load(() => {
 
         // DOF
         cameraFrame.dof.enabled = data.get('data.dof.enabled');
+        cameraFrame.dof.nearBlur = data.get('data.dof.nearBlur');
         cameraFrame.dof.focusDistance = data.get('data.dof.focusDistance');
         cameraFrame.dof.focusRange = data.get('data.dof.focusRange');
         cameraFrame.dof.blurRadius = data.get('data.dof.blurRadius');
@@ -193,6 +194,7 @@ assetListLoader.load(() => {
         },
         dof: {
             enabled: true,
+            nearBlur: true,
             focusDistance: 200,
             focusRange: 100,
             blurRadius: 5,

--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -152,6 +152,7 @@ import { CameraFrameOptions, RenderPassCameraFrame } from './render-pass-camera-
  *
  * @typedef {Object} Dof
  * @property {boolean} enabled - Whether DoF is enabled. Defaults to false.
+ * @property {boolean} nearBlur - Whether the near blur is enabled. Defaults to false.
  * @property {number} focusDistance - The distance at which the focus is set. Defaults to 100.
  * @property {number} focusRange - The range around the focus distance where the focus is sharp.
  * Defaults to 10.
@@ -265,6 +266,7 @@ class CameraFrame {
      */
     dof = {
         enabled: false,
+        nearBlur: false,
         focusDistance: 100,
         focusRange: 10,
         blurRadius: 3,
@@ -367,6 +369,7 @@ class CameraFrame {
         options.ssaoBlurEnabled = ssao.blurEnabled;
         options.formats = rendering.renderFormats.slice();
         options.dofEnabled = this.dof.enabled;
+        options.dofNearBlur = this.dof.nearBlur;
         options.dofHighQuality = this.dof.highQuality;
     }
 

--- a/src/extras/render-passes/render-pass-camera-frame.js
+++ b/src/extras/render-passes/render-pass-camera-frame.js
@@ -58,6 +58,8 @@ class CameraFrameOptions {
     // DOF
     dofEnabled = false;
 
+    dofNearBlur = false;
+
     dofHighQuality = true;
 }
 
@@ -186,6 +188,7 @@ class RenderPassCameraFrame extends RenderPass {
             options.prepassEnabled !== currentOptions.prepassEnabled ||
             options.sceneColorMap !== currentOptions.sceneColorMap ||
             options.dofEnabled !== currentOptions.dofEnabled ||
+            options.dofNearBlur !== currentOptions.dofNearBlur ||
             options.dofHighQuality !== currentOptions.dofHighQuality ||
             arraysNotEqual(options.formats, currentOptions.formats);
     }
@@ -407,7 +410,7 @@ class RenderPassCameraFrame extends RenderPass {
 
     setupDofPass(options, inputTexture, inputTextureHalf) {
         if (options.dofEnabled)  {
-            this.dofPass = new RenderPassDof(this.device, this.cameraComponent, inputTexture, inputTextureHalf, options.dofHighQuality);
+            this.dofPass = new RenderPassDof(this.device, this.cameraComponent, inputTexture, inputTextureHalf, options.dofHighQuality, options.dofNearBlur);
         }
     }
 

--- a/src/extras/render-passes/render-pass-coc.js
+++ b/src/extras/render-passes/render-pass-coc.js
@@ -5,7 +5,7 @@ import { ChunkUtils } from '../../scene/shader-lib/chunk-utils.js';
 /**
  * Render pass implementation of a Circle of Confusion texture generation, used by Depth of Field.
  * This pass generates a CoC texture based on the scene's depth buffer, and focus range and distance
- * parameters. The CoC texture stores near and far CoC values in the red and green channels.
+ * parameters. The CoC texture stores far and near CoC values in the red and green channels.
  *
  * @category Graphics
  * @ignore
@@ -15,13 +15,14 @@ class RenderPassCoC extends RenderPassShaderQuad {
 
     focusRange;
 
-    constructor(device, cameraComponent) {
+    constructor(device, cameraComponent, nearBlur) {
         super(device);
         this.cameraComponent = cameraComponent;
 
         const screenDepth = ChunkUtils.getScreenDepthChunk(device, cameraComponent.shaderParams);
-        this.shader = this.createQuadShader('CocShader', /* glsl */`
+        this.shader = this.createQuadShader(`CocShader-${nearBlur}`, /* glsl */`
 
+            ${nearBlur ? '#define NEAR_BLUR' : ''}
             ${screenDepth}
             varying vec2 uv0;
             uniform vec3 params;
@@ -34,14 +35,19 @@ class RenderPassCoC extends RenderPassShaderQuad {
                 float focusDistance = params.x;
                 float focusRange = params.y;
                 float invRange = params.z;
-                float nearRange = focusDistance - focusRange * 0.5;
                 float farRange = focusDistance + focusRange * 0.5;
                 
                 // near and far CoC
-                float cocNear = min((nearRange - depth) * invRange, 1.0);
                 float cocFar = min((depth - farRange) * invRange, 1.0);
 
-                gl_FragColor = vec4(cocNear, cocFar, 0.0, 0.0);
+                #ifdef NEAR_BLUR
+                    float nearRange = focusDistance - focusRange * 0.5;
+                    float cocNear = min((nearRange - depth) * invRange, 1.0);
+                #else
+                    float cocNear = 0.0;
+                #endif
+
+                gl_FragColor = vec4(cocFar, cocNear, 0.0, 0.0);
             }`
         );
 

--- a/src/extras/render-passes/render-pass-dof-blur.js
+++ b/src/extras/render-passes/render-pass-dof-blur.js
@@ -125,7 +125,7 @@ class RenderPassDofBlur extends RenderPassShaderQuad {
                         vec3 tap = texture2DLod(farTexture, uv, 0.0).rgb;
 
                         // block out sharp objects to avoid leaking to far blur
-                        float cocThis = texture2DLod(cocTexture, uv, 0.0).g;
+                        float cocThis = texture2DLod(cocTexture, uv, 0.0).r;
                         tap *= cocThis;
                         sumCoC += cocThis;
 

--- a/src/extras/render-passes/render-pass-dof-blur.js
+++ b/src/extras/render-passes/render-pass-dof-blur.js
@@ -2,6 +2,11 @@ import { Kernel } from '../../core/math/kernel.js';
 import { RenderPassShaderQuad } from '../../scene/graphics/render-pass-shader-quad.js';
 
 /**
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ * @import { Texture } from '../../platform/graphics/texture.js'
+ */
+
+/**
  * Render pass implementation of a down-sample filter used by the Depth of Field pass. Based on
  * a texel of the CoC texture, it generates blurred version of the near or far texture.
  *
@@ -17,6 +22,12 @@ class RenderPassDofBlur extends RenderPassShaderQuad {
 
     _blurRingPoints = 3;
 
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {Texture|null} nearTexture - The near texture to blur. Skip near blur if the texture is null.
+     * @param {Texture} farTexture - The far texture to blur.
+     * @param {Texture} cocTexture - The CoC texture.
+     */
     constructor(device, nearTexture, farTexture, cocTexture) {
         super(device);
         this.nearTexture = nearTexture;
@@ -59,10 +70,16 @@ class RenderPassDofBlur extends RenderPassShaderQuad {
     createShader() {
         this.kernel = new Float32Array(Kernel.concentric(this.blurRings, this.blurRingPoints));
         const kernelCount = this.kernel.length >> 1;
+        const nearBlur = this.nearTexture !== null;
+        const shaderName = `DofBlurShader-${kernelCount}-${nearBlur ? 'nearBlur' : 'noNearBlur'}`;
 
-        this.shader = this.createQuadShader(`DofBlurShader-${kernelCount}`, /* glsl */`
+        this.shader = this.createQuadShader(shaderName, /* glsl */`
 
-            uniform sampler2D nearTexture;
+            ${nearBlur ? '#define NEAR_BLUR' : ''}
+
+            #if defined(NEAR_BLUR)
+                uniform sampler2D nearTexture;
+            #endif
             uniform sampler2D farTexture;
             uniform sampler2D cocTexture;
             uniform float blurRadiusNear;
@@ -74,27 +91,31 @@ class RenderPassDofBlur extends RenderPassShaderQuad {
             void main()
             {
                 vec2 coc = texture2D(cocTexture, uv0).rg;
-                float cocNear = coc.r;
-                float cocFar = coc.g;
+                float cocFar = coc.r;
 
                 vec3 sum = vec3(0.0, 0.0, 0.0);
 
-                // near blur
-                if (cocNear > 0.0001) {
+                #if defined(NEAR_BLUR)
+                    // near blur
+                    float cocNear = coc.g;
+                    if (cocNear > 0.0001) {
 
-                    ivec2 nearTextureSize = textureSize(nearTexture, 0);
-                    vec2 step = cocNear * blurRadiusNear / vec2(nearTextureSize);
+                        ivec2 nearTextureSize = textureSize(nearTexture, 0);
+                        vec2 step = cocNear * blurRadiusNear / vec2(nearTextureSize);
 
-                    for (int i = 0; i < ${kernelCount}; i++)
-                    {
-                        vec2 uv = uv0 + step * kernel[i];
-                        vec3 tap = texture2DLodEXT(nearTexture, uv, 0.0).rgb;
-                        sum += tap.rgb;
-                    }
+                        for (int i = 0; i < ${kernelCount}; i++)
+                        {
+                            vec2 uv = uv0 + step * kernel[i];
+                            vec3 tap = texture2DLodEXT(nearTexture, uv, 0.0).rgb;
+                            sum += tap.rgb;
+                        }
 
-                    sum *= ${1.0 / kernelCount};
+                        sum *= ${1.0 / kernelCount};
 
-                } else if (cocFar > 0.0001) { // far blur
+                    } else
+                #endif
+                    
+                    if (cocFar > 0.0001) { // far blur
 
                     ivec2 farTextureSize = textureSize(farTexture, 0);
                     vec2 step = cocFar * blurRadiusFar / vec2(farTextureSize);
@@ -106,7 +127,7 @@ class RenderPassDofBlur extends RenderPassShaderQuad {
                         vec3 tap = texture2DLodEXT(farTexture, uv, 0.0).rgb;
 
                         // block out sharp objects to avoid leaking to far blur
-                        float cocThis = texture2DLodEXT(cocTexture, uv, 0.0).g;
+                        float cocThis = texture2DLodEXT(cocTexture, uv, 0.0).r;
                         tap *= cocThis;
                         sumCoC += cocThis;
 


### PR DESCRIPTION
- made the near blur optional, to allow cheaper DOF when only the far blur is needed
- skips blurring the near part of the texture
- CoC texture is single channel instead of two channel

new public API:
```
CameraFrame.dof.nearBlur  // defaults to false
```