### PR TITLE
[BREAKING] Deprecate WebGL1 based texture sampling names with _EXT

### DIFF
--- a/examples/src/examples/graphics/grab-pass.shader.frag
+++ b/examples/src/examples/graphics/grab-pass.shader.frag
@@ -34,7 +34,7 @@ void main(void)
     float mipmap = roughness * 5.0;
 
     // get background pixel color with distorted offset
-    vec3 grabColor = texture2DLodEXT(uSceneColorMap, grabUv + offset, mipmap).rgb;
+    vec3 grabColor = texture2DLod(uSceneColorMap, grabUv + offset, mipmap).rgb;
 
     // tint the material based on mipmap
     float tintIndex = clamp(mipmap, 0.0, 3.0);

--- a/scripts/posteffects/posteffect-outline.js
+++ b/scripts/posteffects/posteffect-outline.js
@@ -34,7 +34,7 @@ function OutlineEffect(graphicsDevice, thickness) {
         '        {',
         '            for (int y=-THICKNESS;y<=THICKNESS;y++)',
         '            {    ',
-        '                float tex=texture2DLodEXT(uOutlineTex, vUv0 + vec2(float(x)/uWidth, float(y)/uHeight), 0.0).a;',
+        '                float tex=texture2DLod(uOutlineTex, vUv0 + vec2(float(x)/uWidth, float(y)/uHeight), 0.0).a;',
         '                if (tex>0.0)',
         '                {',
         '                    outline=1.0;',

--- a/src/extras/render-passes/render-pass-compose.js
+++ b/src/extras/render-passes/render-pass-compose.js
@@ -32,7 +32,7 @@ const fragmentShader = /* glsl */ `
         // Samples the DOF blur and CoC textures. When the blur texture was generated at lower resolution,
         // upscale it to the full resolution using bilinear interpolation to hide the blockiness along COC edges.
         vec3 dofBlur(vec2 uv, out vec2 coc) {
-            coc = texture2DLodEXT(cocTexture, uv, 0.0).rg;
+            coc = texture2DLod(cocTexture, uv, 0.0).rg;
 
             #if DOF_UPSCALE
                 vec2 blurTexelSize = 1.0 / vec2(textureSize(blurTexture, 0));
@@ -43,8 +43,8 @@ const fragmentShader = /* glsl */ `
                 for (int i = -1; i <= 1; i++) {
                     for (int j = -1; j <= 1; j++) {
                         vec2 offset = vec2(i, j) * blurTexelSize;
-                        vec2 cocSample = texture2DLodEXT(cocTexture, uv + offset, 0.0).rg;
-                        vec3 blurSample = texture2DLodEXT(blurTexture, uv + offset, 0.0).rgb;
+                        vec2 cocSample = texture2DLod(cocTexture, uv + offset, 0.0).rg;
+                        vec3 blurSample = texture2DLod(blurTexture, uv + offset, 0.0).rgb;
 
                         // Accumulate the weighted blur sample
                         float cocWeight = clamp(cocSample.r + cocSample.g, 0.0, 1.0);
@@ -61,7 +61,7 @@ const fragmentShader = /* glsl */ `
                 return bilinearBlur;
             #else
                 // when blurTexture is full resolution, just sample it, no upsampling
-                return texture2DLodEXT(blurTexture, uv, 0.0).rgb;
+                return texture2DLod(blurTexture, uv, 0.0).rgb;
             #endif
         }
 
@@ -159,11 +159,11 @@ const fragmentShader = /* glsl */ `
             float y = sceneTextureInvRes.y;
 
             // sample 4 neighbors around the already sampled pixel, and convert it to SDR
-            vec3 a = toSDR(texture2DLodEXT(sceneTexture, uv + vec2(0.0, -y), 0.0).rgb);
-            vec3 b = toSDR(texture2DLodEXT(sceneTexture, uv + vec2(-x, 0.0), 0.0).rgb);
+            vec3 a = toSDR(texture2DLod(sceneTexture, uv + vec2(0.0, -y), 0.0).rgb);
+            vec3 b = toSDR(texture2DLod(sceneTexture, uv + vec2(-x, 0.0), 0.0).rgb);
             vec3 c = toSDR(color.rgb);
-            vec3 d = toSDR(texture2DLodEXT(sceneTexture, uv + vec2(x, 0.0), 0.0).rgb);
-            vec3 e = toSDR(texture2DLodEXT(sceneTexture, uv + vec2(0.0, y), 0.0).rgb);
+            vec3 d = toSDR(texture2DLod(sceneTexture, uv + vec2(x, 0.0), 0.0).rgb);
+            vec3 e = toSDR(texture2DLod(sceneTexture, uv + vec2(0.0, y), 0.0).rgb);
 
             // apply the sharpening
             float min_g = min(a.g, min(b.g, min(c.g, min(d.g, e.g))));
@@ -192,7 +192,7 @@ const fragmentShader = /* glsl */ `
         #endif
         #endif
 
-        vec4 scene = texture2DLodEXT(sceneTexture, uv, 0.0);
+        vec4 scene = texture2DLod(sceneTexture, uv, 0.0);
         vec3 result = scene.rgb;
 
         #ifdef CAS
@@ -206,7 +206,7 @@ const fragmentShader = /* glsl */ `
         #endif
 
         #ifdef SSAO_TEXTURE
-            mediump float ssao = texture2DLodEXT(ssaoTexture, uv0, 0.0).r;
+            mediump float ssao = texture2DLod(ssaoTexture, uv0, 0.0).r;
         #endif
 
         #ifdef SSAO
@@ -218,7 +218,7 @@ const fragmentShader = /* glsl */ `
         #endif
 
         #ifdef BLOOM
-            vec3 bloom = texture2DLodEXT(bloomTexture, uv, 0.0).rgb;
+            vec3 bloom = texture2DLod(bloomTexture, uv, 0.0).rgb;
             result += bloom * bloomIntensity;
         #endif
 

--- a/src/extras/render-passes/render-pass-dof-blur.js
+++ b/src/extras/render-passes/render-pass-dof-blur.js
@@ -88,7 +88,7 @@ class RenderPassDofBlur extends RenderPassShaderQuad {
                     for (int i = 0; i < ${kernelCount}; i++)
                     {
                         vec2 uv = uv0 + step * kernel[i];
-                        vec3 tap = texture2DLodEXT(nearTexture, uv, 0.0).rgb;
+                        vec3 tap = texture2DLod(nearTexture, uv, 0.0).rgb;
                         sum += tap.rgb;
                     }
 
@@ -103,10 +103,10 @@ class RenderPassDofBlur extends RenderPassShaderQuad {
                     for (int i = 0; i < ${kernelCount}; i++)
                     {
                         vec2 uv = uv0 + step * kernel[i];
-                        vec3 tap = texture2DLodEXT(farTexture, uv, 0.0).rgb;
+                        vec3 tap = texture2DLod(farTexture, uv, 0.0).rgb;
 
                         // block out sharp objects to avoid leaking to far blur
-                        float cocThis = texture2DLodEXT(cocTexture, uv, 0.0).g;
+                        float cocThis = texture2DLod(cocTexture, uv, 0.0).g;
                         tap *= cocThis;
                         sumCoC += cocThis;
 

--- a/src/platform/graphics/shader-chunks/frag/gles3.js
+++ b/src/platform/graphics/shader-chunks/frag/gles3.js
@@ -65,14 +65,22 @@ layout(location = 7) out highp outType_7 pc_fragColor7;
 #define texture2DBias texture
 #define textureCube texture
 #define texture2DProj textureProj
-#define texture2DLodEXT textureLod
-#define texture2DProjLodEXT textureProjLod
-#define textureCubeLodEXT textureLod
-#define texture2DGradEXT textureGrad
-#define texture2DProjGradEXT textureProjGrad
-#define textureCubeGradEXT textureGrad
+#define texture2DLod textureLod
+#define texture2DProjLod textureProjLod
+#define textureCubeLod textureLod
+#define texture2DGrad textureGrad
+#define texture2DProjGrad textureProjGrad
+#define textureCubeGrad textureGrad
 #define utexture2D texture
 #define itexture2D texture
+
+// deprecated defines
+#define texture2DLodEXT texture2DLodEXT_is_no_longer_supported_use_texture2DLod_instead
+#define texture2DProjLodEXT texture2DProjLodEXT_is_no_longer_supported_use_texture2DProjLod
+#define textureCubeLodEXT textureCubeLodEXT_is_no_longer_supported_use_textureCubeLod_instead
+#define texture2DGradEXT texture2DGradEXT_is_no_longer_supported_use_texture2DGrad_instead
+#define texture2DProjGradEXT texture2DProjGradEXT_is_no_longer_supported_use_texture2DProjGrad_instead
+#define textureCubeGradEXT textureCubeGradEXT_is_no_longer_supported_use_textureCubeGrad_instead
 
 // sample shadows using textureGrad to remove derivatives in the dynamic loops (which are used by
 // clustered lighting) - as DirectX shader compiler tries to unroll the loops and takes long time

--- a/src/platform/graphics/shader-chunks/frag/webgpu.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu.js
@@ -50,19 +50,27 @@ layout(location = 7) out highp outType_7 pc_fragColor7;
 
 #define texture2D(res, uv) texture(sampler2D(res, res ## _sampler), uv)
 #define texture2DBias(res, uv, bias) texture(sampler2D(res, res ## _sampler), uv, bias)
-#define texture2DLodEXT(res, uv, lod) textureLod(sampler2D(res, res ## _sampler), uv, lod)
+#define texture2DLod(res, uv, lod) textureLod(sampler2D(res, res ## _sampler), uv, lod)
 #define textureCube(res, uv) texture(samplerCube(res, res ## _sampler), uv)
-#define textureCubeLodEXT(res, uv, lod) textureLod(samplerCube(res, res ## _sampler), uv, lod)
+#define textureCubeLod(res, uv, lod) textureLod(samplerCube(res, res ## _sampler), uv, lod)
 #define textureShadow(res, uv) textureLod(sampler2DShadow(res, res ## _sampler), uv, 0.0)
 #define itexture2D(res, uv) texture(isampler2D(res, res ## _sampler), uv)
 #define utexture2D(res, uv) texture(usampler2D(res, res ## _sampler), uv)
 
+// deprecated defines
+#define texture2DLodEXT texture2DLodEXT_is_no_longer_supported_use_texture2DLod_instead
+#define texture2DProjLodEXT texture2DProjLodEXT_is_no_longer_supported_use_texture2DProjLod
+#define textureCubeLodEXT textureCubeLodEXT_is_no_longer_supported_use_textureCubeLod_instead
+#define texture2DGradEXT texture2DGradEXT_is_no_longer_supported_use_texture2DGrad_instead
+#define texture2DProjGradEXT texture2DProjGradEXT_is_no_longer_supported_use_texture2DProjGrad_instead
+#define textureCubeGradEXT textureCubeGradEXT_is_no_longer_supported_use_textureCubeGrad_instead
+
 // TODO: implement other texture sampling macros
 // #define texture2DProj textureProj
-// #define texture2DProjLodEXT textureProjLod
-// #define texture2DGradEXT textureGrad
-// #define texture2DProjGradEXT textureProjGrad
-// #define textureCubeGradEXT textureGrad
+// #define texture2DProjLod textureProjLod
+// #define texture2DGrad textureGrad
+// #define texture2DProjGrad textureProjGrad
+// #define textureCubeGrad textureGrad
 
 // pass / accept shadow map as a function parameter, passes both the texture as well as sampler
 // as the combined sampler can be only created at a point of use

--- a/src/scene/shader-lib/chunks/common/frag/reproject.js
+++ b/src/scene/shader-lib/chunks/common/frag/reproject.js
@@ -120,7 +120,7 @@ vec2 octEncode(in vec3 v) {
 }
 
     vec4 sampleCubemap(vec3 dir, float mipLevel) {
-        return textureCubeLodEXT(sourceCube, modifySeams(dir, 1.0), mipLevel);
+        return textureCubeLod(sourceCube, modifySeams(dir, 1.0), mipLevel);
     }
 
     vec4 sampleCubemap(vec2 sph, float mipLevel) {
@@ -139,7 +139,7 @@ vec2 octEncode(in vec3 v) {
 
     vec4 sampleEquirect(vec2 sph, float mipLevel) {
         vec2 uv = sph / vec2(PI * 2.0, PI) + 0.5;
-        return texture2DLodEXT(sourceTex, vec2(uv.x, 1.0 - uv.y), mipLevel);
+        return texture2DLod(sourceTex, vec2(uv.x, 1.0 - uv.y), mipLevel);
     }
 
     vec4 sampleEquirect(vec3 dir, float mipLevel) {
@@ -157,7 +157,7 @@ vec2 octEncode(in vec3 v) {
 
     vec4 sampleOctahedral(vec3 dir, float mipLevel) {
         vec2 uv = octEncode(dir) * 0.5 + 0.5;
-        return texture2DLodEXT(sourceTex, vec2(uv.x, 1.0 - uv.y), mipLevel);
+        return texture2DLod(sourceTex, vec2(uv.x, 1.0 - uv.y), mipLevel);
     }
 
     vec4 sampleOctahedral(vec2 sph, float mipLevel) {

--- a/src/scene/shader-lib/chunks/common/frag/sampleCatmullRom.js
+++ b/src/scene/shader-lib/chunks/common/frag/sampleCatmullRom.js
@@ -33,17 +33,17 @@ vec4 SampleTextureCatmullRom(TEXTURE_ACCEPT(tex), vec2 uv, vec2 texSize) {
     vec2 texPos12 = (texPos1 + offset12) / texSize;
 
     vec4 result = vec4(0.0);
-    result += texture2DLodEXT(tex, vec2(texPos0.x, texPos0.y), 0.0) * w0.x * w0.y;
-    result += texture2DLodEXT(tex, vec2(texPos12.x, texPos0.y), 0.0) * w12.x * w0.y;
-    result += texture2DLodEXT(tex, vec2(texPos3.x, texPos0.y), 0.0) * w3.x * w0.y;
+    result += texture2DLod(tex, vec2(texPos0.x, texPos0.y), 0.0) * w0.x * w0.y;
+    result += texture2DLod(tex, vec2(texPos12.x, texPos0.y), 0.0) * w12.x * w0.y;
+    result += texture2DLod(tex, vec2(texPos3.x, texPos0.y), 0.0) * w3.x * w0.y;
 
-    result += texture2DLodEXT(tex, vec2(texPos0.x, texPos12.y), 0.0) * w0.x * w12.y;
-    result += texture2DLodEXT(tex, vec2(texPos12.x, texPos12.y), 0.0) * w12.x * w12.y;
-    result += texture2DLodEXT(tex, vec2(texPos3.x, texPos12.y), 0.0) * w3.x * w12.y;
+    result += texture2DLod(tex, vec2(texPos0.x, texPos12.y), 0.0) * w0.x * w12.y;
+    result += texture2DLod(tex, vec2(texPos12.x, texPos12.y), 0.0) * w12.x * w12.y;
+    result += texture2DLod(tex, vec2(texPos3.x, texPos12.y), 0.0) * w3.x * w12.y;
 
-    result += texture2DLodEXT(tex, vec2(texPos0.x, texPos3.y), 0.0) * w0.x * w3.y;
-    result += texture2DLodEXT(tex, vec2(texPos12.x, texPos3.y), 0.0) * w12.x * w3.y;
-    result += texture2DLodEXT(tex, vec2(texPos3.x, texPos3.y), 0.0) * w3.x * w3.y;
+    result += texture2DLod(tex, vec2(texPos0.x, texPos3.y), 0.0) * w0.x * w3.y;
+    result += texture2DLod(tex, vec2(texPos12.x, texPos3.y), 0.0) * w12.x * w3.y;
+    result += texture2DLod(tex, vec2(texPos3.x, texPos3.y), 0.0) * w3.x * w3.y;
 
     return result;
 }

--- a/src/scene/shader-lib/chunks/lightmapper/frag/bilateralDeNoise.js
+++ b/src/scene/shader-lib/chunks/lightmapper/frag/bilateralDeNoise.js
@@ -45,7 +45,7 @@ uniform float kernel[MSIZE];
 
 void main(void) {
     
-    vec4 pixelRgbm = texture2DLodEXT(source, vUv0, 0.0);
+    vec4 pixelRgbm = texture2DLod(source, vUv0, 0.0);
 
     // lightmap specific optimization - skip pixels that were not baked
     // this also allows dilate filter that work on the output of this to work correctly, as it depends on .a being zero
@@ -72,7 +72,7 @@ void main(void) {
             
             // sample the pixel with offset
             vec2 coord = vUv0 + vec2(float(i), float(j)) * pixelOffset;
-            vec4 rgbm = texture2DLodEXT(source, coord, 0.0);
+            vec4 rgbm = texture2DLod(source, coord, 0.0);
 
             // lightmap - only use baked pixels
             if (rgbm.a > 0.0) {

--- a/src/scene/shader-lib/chunks/lightmapper/frag/dilate.js
+++ b/src/scene/shader-lib/chunks/lightmapper/frag/dilate.js
@@ -6,15 +6,15 @@ uniform sampler2D source;
 uniform vec2 pixelOffset;
 
 void main(void) {
-    vec4 c = texture2DLodEXT(source, vUv0, 0.0);
-    c = c.a>0.0? c : texture2DLodEXT(source, vUv0 - pixelOffset, 0.0);
-    c = c.a>0.0? c : texture2DLodEXT(source, vUv0 + vec2(0, -pixelOffset.y), 0.0);
-    c = c.a>0.0? c : texture2DLodEXT(source, vUv0 + vec2(pixelOffset.x, -pixelOffset.y), 0.0);
-    c = c.a>0.0? c : texture2DLodEXT(source, vUv0 + vec2(-pixelOffset.x, 0), 0.0);
-    c = c.a>0.0? c : texture2DLodEXT(source, vUv0 + vec2(pixelOffset.x, 0), 0.0);
-    c = c.a>0.0? c : texture2DLodEXT(source, vUv0 + vec2(-pixelOffset.x, pixelOffset.y), 0.0);
-    c = c.a>0.0? c : texture2DLodEXT(source, vUv0 + vec2(0, pixelOffset.y), 0.0);
-    c = c.a>0.0? c : texture2DLodEXT(source, vUv0 + pixelOffset, 0.0);
+    vec4 c = texture2DLod(source, vUv0, 0.0);
+    c = c.a>0.0? c : texture2DLod(source, vUv0 - pixelOffset, 0.0);
+    c = c.a>0.0? c : texture2DLod(source, vUv0 + vec2(0, -pixelOffset.y), 0.0);
+    c = c.a>0.0? c : texture2DLod(source, vUv0 + vec2(pixelOffset.x, -pixelOffset.y), 0.0);
+    c = c.a>0.0? c : texture2DLod(source, vUv0 + vec2(-pixelOffset.x, 0), 0.0);
+    c = c.a>0.0? c : texture2DLod(source, vUv0 + vec2(pixelOffset.x, 0), 0.0);
+    c = c.a>0.0? c : texture2DLod(source, vUv0 + vec2(-pixelOffset.x, pixelOffset.y), 0.0);
+    c = c.a>0.0? c : texture2DLod(source, vUv0 + vec2(0, pixelOffset.y), 0.0);
+    c = c.a>0.0? c : texture2DLod(source, vUv0 + pixelOffset, 0.0);
     gl_FragColor = c;
 }
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLightCookies.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLightCookies.js
@@ -1,6 +1,6 @@
 export default /* glsl */`
 vec3 _getCookieClustered(TEXTURE_ACCEPT(tex), vec2 uv, float intensity, bool isRgb, vec4 cookieChannel) {
-    vec4 pixel = mix(vec4(1.0), texture2DLodEXT(tex, uv, 0.0), intensity);
+    vec4 pixel = mix(vec4(1.0), texture2DLod(tex, uv, 0.0), intensity);
     return isRgb == true ? pixel.rgb : vec3(dot(pixel, cookieChannel));
 }
 

--- a/src/scene/shader-lib/chunks/lit/frag/ltc.js
+++ b/src/scene/shader-lib/chunks/lit/frag/ltc.js
@@ -128,7 +128,7 @@ vec3 ccLTCSpecFres;
 #endif
 vec3 getLTCLightSpecFres(vec2 uv, vec3 specularity)
 {
-    vec4 t2 = texture2DLodEXT(areaLightsLutTex2, uv, 0.0);
+    vec4 t2 = texture2DLod(areaLightsLutTex2, uv, 0.0);
     return specularity * t2.x + ( vec3( 1.0 ) - specularity) * t2.y;
 }
 
@@ -360,7 +360,7 @@ float LTC_EvaluateDisk(vec3 N, vec3 V, vec3 P, mat3 Minv, Coords points)
     vec2 uv = vec2(avgDir.z * 0.5 + 0.5, formFactor);
     uv = uv*LUT_SCALE + LUT_BIAS;
 
-    float scale = texture2DLodEXT(areaLightsLutTex2, uv, 0.0).w;
+    float scale = texture2DLod(areaLightsLutTex2, uv, 0.0).w;
 
     return formFactor*scale;
 }
@@ -381,7 +381,7 @@ float getSphereLightDiffuse(vec3 worldNormal, vec3 viewDir, vec3 lightDir, vec3 
 
 mat3 getLTCLightInvMat(vec2 uv)
 {
-    vec4 t1 = texture2DLodEXT(areaLightsLutTex1, uv, 0.0);
+    vec4 t1 = texture2DLod(areaLightsLutTex1, uv, 0.0);
 
     return mat3(
         vec3( t1.x, 0, t1.y ),

--- a/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
+++ b/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
@@ -16,7 +16,7 @@ vec3 evalRefractionColor(vec3 refractionVector, float gloss, float refractionInd
     // Use IOR and roughness to select mip
     float iorToRoughness = (1.0 - gloss) * clamp((1.0 / refractionIndex) * 2.0 - 2.0, 0.0, 1.0);
     float refractionLod = log2(uScreenSize.x) * iorToRoughness;
-    vec3 refraction = texture2DLodEXT(uSceneColorMap, uv, refractionLod).rgb;
+    vec3 refraction = texture2DLod(uSceneColorMap, uv, refractionLod).rgb;
 
     return refraction;
 }

--- a/src/scene/shader-lib/chunks/lit/frag/shadowPCSS.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowPCSS.js
@@ -96,7 +96,7 @@ float PCSSCubeBlockerDistance(samplerCube shadowMap, vec3 lightDirNorm, vec3 sam
         vec3 sampleDir = lightDirNorm + samplePoints[i] * shadowSearchArea;
         sampleDir = normalize(sampleDir);
 
-        float blocker = textureCubeLodEXT(shadowMap, sampleDir, 0.0).r;
+        float blocker = textureCubeLod(shadowMap, sampleDir, 0.0).r;
         float isBlocking = step(blocker, z);
         blockers += isBlocking;
         averageBlocker += blocker * isBlocking;
@@ -133,7 +133,7 @@ float PCSSCube(samplerCube shadowMap, vec4 shadowParams, vec3 shadowCoords, vec4
             vec3 sampleDir = lightDirNorm + offset;
             sampleDir = normalize(sampleDir);
 
-            float depth = textureCubeLodEXT(shadowMap, sampleDir, 0.0).r;
+            float depth = textureCubeLod(shadowMap, sampleDir, 0.0).r;
             shadow += step(receiverDepth, depth);
         }
         return shadow / float(PCSS_SAMPLE_COUNT);

--- a/src/scene/shader-lib/chunks/standard/frag/opacity-dither.js
+++ b/src/scene/shader-lib/chunks/standard/frag/opacity-dither.js
@@ -15,7 +15,7 @@ void opacityDither(float alpha, float id) {
 
         #ifdef DITHER_BLUENOISE
             vec2 uv = fract(gl_FragCoord.xy / 32.0 + blueNoiseJitter.xy + id);
-            float noise = texture2DLodEXT(blueNoiseTex32, uv, 0.0).y;
+            float noise = texture2DLod(blueNoiseTex32, uv, 0.0).y;
         #endif
 
         #ifdef DITHER_IGNNOISE

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -938,7 +938,7 @@ class LitShader {
                     uniform sampler2D ssaoTexture;
                     uniform vec2 ssaoTextureSizeInv;
                 `);
-            backend.append('litArgs_ao *= texture2DLodEXT(ssaoTexture, gl_FragCoord.xy * ssaoTextureSizeInv, 0.0).r;');
+            backend.append('litArgs_ao *= texture2DLod(ssaoTexture, gl_FragCoord.xy * ssaoTextureSizeInv, 0.0).r;');
         }
 
         // transform tangent space normals to world space


### PR DESCRIPTION
Marked as [BREAKING] as if the user code uses these macros in the shaders, they need to be renamed (EXT letters removed)

- the deprecated texture sampling are no longer an extension, but are core functionality, so rename the marcos
- keep old macros in a deprecated format to get useful shader compilation errors

See red lines with the old naming containing EXT, and green lines bellow with new names
<img width="330" alt="Screenshot 2024-12-20 at 12 07 06" src="https://github.com/user-attachments/assets/e09ad460-0c86-4cec-b3b3-6cbc82c5e825" />
