### PR TITLE
Shadow cascades can be cross-blended using dithering

### DIFF
--- a/examples/src/examples/graphics/shadow-cascades.controls.mjs
+++ b/examples/src/examples/graphics/shadow-cascades.controls.mjs
@@ -74,6 +74,17 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
+                { text: 'Blend' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'settings.light.cascadeBlend' },
+                    min: 0,
+                    max: 0.2,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
                 { text: 'VSM Blur' },
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),

--- a/examples/src/examples/graphics/shadow-cascades.example.mjs
+++ b/examples/src/examples/graphics/shadow-cascades.example.mjs
@@ -54,6 +54,7 @@ assetListLoader.load(() => {
             numCascades: 4, // number of cascades
             shadowResolution: 2048, // shadow map resolution storing 4 cascades
             cascadeDistribution: 0.5, // distribution of cascade distances to prefer sharpness closer to the camera
+            cascadeBlend: 0.1, // blend between cascades
             shadowType: pc.SHADOW_PCF3_32F, // shadow filter type
             vsmBlurSize: 11, // shader filter blur size for VSM shadows
             everyFrame: true // true if all cascades update every frame
@@ -141,7 +142,7 @@ assetListLoader.load(() => {
     app.root.addChild(camera);
 
     // Create a directional light casting cascaded shadows
-    const dirLight = new pc.Entity();
+    const dirLight = new pc.Entity('Cascaded Light');
     dirLight.addComponent('light', {
         ...{
             type: 'directional',

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -386,6 +386,28 @@ class LightComponent extends Component {
     }
 
     /**
+     * Sets the blend factor for cascaded shadow maps, defining the fraction of each cascade level
+     * used for blending between adjacent cascades. The value should be between 0 and 1, with
+     * a default of 0, which disables blending between cascades.
+     *
+     * @type {number}
+     */
+    set cascadeBlend(value) {
+        this._setValue('cascadeBlend', value, function (newValue, oldValue) {
+            this.light.cascadeBlend = math.clamp(newValue, 0, 1);
+        });
+    }
+
+    /**
+     * Gets the blend factor for cascaded shadow maps.
+     *
+     * @type {number}
+     */
+    get cascadeBlend() {
+        return this.data.cascadeBlend;
+    }
+
+    /**
      * Sets the number of samples used to bake this light into the lightmap. Defaults to 1. Maximum
      * value is 255.
      *

--- a/src/framework/components/light/data.js
+++ b/src/framework/components/light/data.js
@@ -42,6 +42,8 @@ class LightComponentData {
 
     numCascades = 1;
 
+    cascadeBlend = 0;
+
     bakeNumSamples = 1;
 
     bakeArea = 0;

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -618,6 +618,10 @@ class Layer {
         this._splitLightsDirty = true;
     }
 
+    hasLight(light) {
+        return this._lightsSet.has(light);
+    }
+
     /**
      * Adds a light to this layer.
      *

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -18,6 +18,10 @@ import { ShadowRenderer } from './renderer/shadow-renderer.js';
 import { DepthState } from '../platform/graphics/depth-state.js';
 
 /**
+ * @import { GraphicsDevice } from '../platform/graphics/graphics-device.js'
+ */
+
+/**
  * @import { BindGroup } from '../platform/graphics/bind-group.js'
  * @import { Layer } from './layer.js'
  */
@@ -140,6 +144,10 @@ class Light {
      */
     shadowDepthState = DepthState.DEFAULT.clone();
 
+    /**
+     * @param {GraphicsDevice} graphicsDevice - The graphics device.
+     * @param {boolean} clusteredLighting - True if the clustered lighting is enabled.
+     */
     constructor(graphicsDevice, clusteredLighting) {
         this.device = graphicsDevice;
         this.clusteredLighting = clusteredLighting;
@@ -188,6 +196,7 @@ class Light {
         this._shadowMatrixPalette = null;   // a float array, 16 floats per cascade
         this._shadowCascadeDistances = null;
         this.numCascades = 1;
+        this._cascadeBlend = 0;
         this.cascadeDistribution = 0.5;
 
         // Light source shape properties
@@ -295,6 +304,17 @@ class Light {
 
     get numCascades() {
         return this.cascades.length;
+    }
+
+    set cascadeBlend(value) {
+        if (this._cascadeBlend !== value) {
+            this._cascadeBlend = value;
+            this.updateKey();
+        }
+    }
+
+    get cascadeBlend() {
+        return this._cascadeBlend;
     }
 
     set shadowMap(shadowMap) {
@@ -474,14 +494,14 @@ class Light {
     }
 
     set normalOffsetBias(value) {
-        if (this._normalOffsetBias === value) {
-            return;
-        }
+        if (this._normalOffsetBias !== value) {
+            const dirty = (!this._normalOffsetBias && value) || (this._normalOffsetBias && !value);
+            this._normalOffsetBias = value;
 
-        if ((!this._normalOffsetBias && value) || (this._normalOffsetBias && !value)) {
-            this.updateKey();
+            if (dirty) {
+                this.updateKey();
+            }
         }
-        this._normalOffsetBias = value;
     }
 
     get normalOffsetBias() {
@@ -773,6 +793,7 @@ class Light {
         // Directional properties
         clone.numCascades = this.numCascades;
         clone.cascadeDistribution = this.cascadeDistribution;
+        clone.cascadeBlend = this._cascadeBlend;
 
         // shape properties
         clone.shape = this._shape;
@@ -953,7 +974,9 @@ class Light {
 
     layersDirty() {
         this.layers.forEach((layer) => {
-            layer.markLightsDirty();
+            if (layer.hasLight(this)) {
+                layer.markLightsDirty();
+            }
         });
     }
 
@@ -977,7 +1000,8 @@ class Light {
         // 14 - 15 : cookie channel B
         // 12      : cookie transform
         // 10 - 11 : light source shape
-        //  8 -  9 : light num cascades
+        //  9      : use cascades
+        //  8      : cascade blend
         //  7      : disable specular
         //  6 -  4 : mask
         //  3      : cast shadows
@@ -991,7 +1015,8 @@ class Light {
                (chanId[this._cookieChannel.charAt(0)]     << 18) |
                ((this._cookieTransform ? 1 : 0)           << 12) |
                ((this._shape)                             << 10) |
-               ((this.numCascades - 1)                    <<  8) |
+               ((this.numCascades > 0 ? 1 : 0)            <<  9) |
+               ((this._cascadeBlend > 0 ? 1 : 0)          <<  8) |
                ((this.affectSpecularity ? 1 : 0)          <<  7) |
                ((this.mask)                               <<  6) |
                ((this._castShadows ? 1 : 0)               <<  3);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -126,6 +126,7 @@ class ForwardRenderer extends Renderer {
         this.shadowMatrixPaletteId = [];
         this.shadowCascadeDistancesId = [];
         this.shadowCascadeCountId = [];
+        this.shadowCascadeBlendId = [];
 
         this.screenSizeId = scope.resolve('uScreenSize');
         this._screenSize = new Float32Array(4);
@@ -202,6 +203,7 @@ class ForwardRenderer extends Renderer {
         this.shadowMatrixPaletteId[i] = scope.resolve(`${light}_shadowMatrixPalette[0]`);
         this.shadowCascadeDistancesId[i] = scope.resolve(`${light}_shadowCascadeDistances`);
         this.shadowCascadeCountId[i] = scope.resolve(`${light}_shadowCascadeCount`);
+        this.shadowCascadeBlendId[i] = scope.resolve(`${light}_shadowCascadeBlend`);
     }
 
     setLTCDirectionalLight(wtm, cnt, dir, campos, far) {
@@ -264,6 +266,7 @@ class ForwardRenderer extends Renderer {
                 this.shadowMatrixPaletteId[cnt].setValue(directional._shadowMatrixPalette);
                 this.shadowCascadeDistancesId[cnt].setValue(directional._shadowCascadeDistances);
                 this.shadowCascadeCountId[cnt].setValue(directional.numCascades);
+                this.shadowCascadeBlendId[cnt].setValue(1 - directional.cascadeBlend);
                 this.lightShadowIntensity[cnt].setValue(directional.shadowIntensity);
 
                 const projectionCompensation = (50.0 / lightRenderData.projectionCompensation);

--- a/src/scene/shader-lib/chunks/lit/frag/shadowCascades.js
+++ b/src/scene/shader-lib/chunks/lit/frag/shadowCascades.js
@@ -1,11 +1,7 @@
 export default /* glsl */`
-const float maxCascades = 4.0;
 
-// shadow matrix for selected cascade
-mat4 cascadeShadowMat;
-
-// function which selects a shadow projection matrix based on cascade distances 
-void getShadowCascadeMatrix(mat4 shadowMatrixPalette[4], vec4 shadowCascadeDistances, float shadowCascadeCount) {
+// function which selects a shadow projection matrix index based on cascade distances 
+int getShadowCascadeIndex(vec4 shadowCascadeDistances, int shadowCascadeCount) {
 
     // depth in 0 .. far plane range
     float depth = 1.0 / gl_FragCoord.w;
@@ -14,13 +10,34 @@ void getShadowCascadeMatrix(mat4 shadowMatrixPalette[4], vec4 shadowCascadeDista
     vec4 comparisons = step(shadowCascadeDistances, vec4(depth));
 
     // sum is the index
-    float cascadeIndex = dot(comparisons, vec4(1.0));
+    int cascadeIndex = int(dot(comparisons, vec4(1.0)));
 
     // limit to actual number of used cascades
-    cascadeIndex = min(cascadeIndex, shadowCascadeCount - 1.0);
+    return min(cascadeIndex, shadowCascadeCount - 1);
+}
 
-    // pick shadow matrix
-    cascadeShadowMat = shadowMatrixPalette[int(cascadeIndex)];
+// function which modifies cascade index to dither between cascades
+int ditherShadowCascadeIndex(int cascadeIndex, vec4 shadowCascadeDistances, int shadowCascadeCount, float blendFactor) {
+ 
+    if (cascadeIndex < shadowCascadeCount - 1) {
+        float currentRangeEnd = shadowCascadeDistances[cascadeIndex];
+        float transitionStart = blendFactor * currentRangeEnd; // Start overlap factor away from the end distance
+        float depth = 1.0 / gl_FragCoord.w;
+
+        if (depth > transitionStart) {
+            // Calculate a transition factor (0.0 to 1.0) within the overlap range
+            float transitionFactor = smoothstep(transitionStart, currentRangeEnd, depth);
+
+            // Add pseudo-random dithering
+            // TODO: replace by user selectable dithering method
+            float dither = fract(sin(dot(gl_FragCoord.xy, vec2(12.9898, 78.233))) * 43758.5453);
+            if (dither < transitionFactor) {
+                cascadeIndex += 1;
+            }
+        }
+    }
+
+    return cascadeIndex;
 }
 
 void fadeShadow(vec4 shadowCascadeDistances) {                  


### PR DESCRIPTION
## Feature

Directional light shadow cascades can be cross blended using dithering, instead of being a hard line switch. This looks relatively fine with textured objects, but it is an improvement even without it, where dithering is more obvious.

### new public API:
```
LightComponent.cascadeBlend - value between 0 and 1, defaults to 0
```

without dithering:
![Screenshot 2024-12-23 at 14 44 57](https://github.com/user-attachments/assets/fec723cf-453c-4590-a433-25e454b6e521)

with dithering:
![Screenshot 2024-12-23 at 14 41 47](https://github.com/user-attachments/assets/2b62e9c4-4f1b-4e9d-b29f-8bcd737f228e)

In the future we can further improve this. When TAA is enabled, we can use moving blue noise to have per frame randomized dithering, which TAA would renoise. Added [here](https://github.com/playcanvas/engine/issues/3193)

## Fixes
Fixes to issues where additional / incorrect shaders were being compiled when changing light properties:
- internally shader generation options clone lights, and those lights were invalidating layers and generating new shaders. Now layer is invalidated only by a light assigned to it.
- normalOffsetBias has updating the key before modifying the value, so the keys were not correct, and would cause another shader generation of the next property update.
