### PR TITLE
Improve the performance of certain GraphNode methods and avoid recalculating the AABB multiple times during rendering.

### DIFF
--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -64,8 +64,7 @@ class ObjectPool {
 
     /**
      * Attempts to free the given object back into the pool. This only works if the object
-     * was previously allocated (i.e. it exists in `_objToIndexMap`) and is still in use
-     * (i.e., its index is below `_count`).
+     * was previously allocated and is still in use.
      *
      * @param {InstanceType<T>} obj - The object instance to be freed back into the pool.
      * @returns {boolean} Whether freeing succeeded.

--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -67,7 +67,7 @@ class ObjectPool {
      * was previously allocated (i.e. it exists in `_objToIndexMap`) and is still in use
      * (i.e., its index is below `_count`).
      *
-     * @param {InstanceType<T>} obj
+     * @param {InstanceType<T>} obj - The object instance to be freed back into the pool.
      * @returns {boolean} Whether freeing succeeded.
      */
     free(obj) {

--- a/src/core/queue.js
+++ b/src/core/queue.js
@@ -1,0 +1,102 @@
+
+/**
+ * A circular queue that automatically extends its capacity when full.
+ * This implementation uses a fixed-size array to store elements and
+ * supports efficient enqueue and dequeue operations.
+ * It is recommended to use `initialCapacity` that is close to **real-world** usage.
+ */
+class Queue {
+    constructor(initialCapacity = 8) {
+        this._storage = new Array(initialCapacity);
+
+        this._capacity = initialCapacity;
+
+        this._head = 0;
+
+        this._size = 0;
+    }
+
+    /**
+     * Enqueue (push) a value to the back of the queue.
+     * Automatically extends capacity if the queue is full.
+     * @param {*} value The value to enqueue.
+     */
+    enqueue(value) {
+        if (this._size === this._capacity) {
+            this.resize(this._capacity * 2);
+        }
+
+        const tailIndex = (this._head + this._size) % this._capacity;
+        this._storage[tailIndex] = value;
+        this._size++;
+    }
+
+    /**
+     * Dequeue (pop) a value from the front of the queue.
+     * Returns undefined if the queue is empty.
+     * @returns {*}
+     */
+    dequeue() {
+        if (this.isEmpty()) {
+            return undefined;
+        }
+
+        const value = this._storage[this._head];
+        this._storage[this._head] = undefined;
+        this._head = (this._head + 1) % this._capacity;
+        this._size--;
+
+        return value;
+    }
+
+    /**
+     * Return the front element without removing it.
+     * @returns {*}
+     */
+    peek() {
+        if (this.isEmpty()) {
+            return undefined;
+        }
+
+        return this._storage[this._head];
+    }
+
+    /**
+     * The current number of elements in the queue.
+     * @returns {number}
+     */
+    size() {
+        return this._size;
+    }
+
+    /**
+     * Check if the queue is empty.
+     * @returns {boolean}
+     */
+    isEmpty() {
+        return this._size === 0;
+    }
+
+    /**
+     * Internal method to resize the underlying storage.
+     * @param {number} size The new capacity for the queue.
+     */
+    resize(size) {
+        if (size <= this._size) {
+            return;
+        }
+
+        const newStorage = new Array(size);
+
+        for (let i = 0; i < this._size; i++) {
+            const index = (this._head + i) % this._capacity;
+            newStorage[i] = this._storage[index];
+        }
+
+        this._head = 0;
+        this._capacity = size;
+        this._storage = newStorage;
+    }
+}
+
+export { Queue };

--- a/src/core/queue.js
+++ b/src/core/queue.js
@@ -3,36 +3,97 @@
  * This implementation uses a fixed-size array to store elements and
  * supports efficient enqueue and dequeue operations.
  * It is recommended to use `initialCapacity` that is close to **real-world** usage.
+ * @template T
  */
 class Queue {
+    /**
+     * Create a new queue.
+     * @param {number} [initialCapacity=8] - The initial capacity of the queue.
+     */
     constructor(initialCapacity = 8) {
+        /**
+         * Underlying storage for the queue.
+         * @type {Array<T|undefined>}
+         * @private
+         */
         this._storage = new Array(initialCapacity);
 
-        this._capacity = initialCapacity;
-
+        /**
+         * The head (front) index.
+         * @type {number}
+         * @private
+         */
         this._head = 0;
 
-        this._size = 0;
+        /**
+         * The current number of elements in the queue.
+         * @type {number}
+         * @private
+         */
+        this._length = 0;
+    }
+
+    /**
+     * The current number of elements in the queue.
+     * @type {number}
+     * @readonly
+     */
+    get length() {
+        return this._length;
+    }
+
+    /**
+     * The capacity of the queue.
+     * @type {number}
+     * @readonly
+     */
+    get capacity() {
+        return this._storage.length;
+    }
+
+    /**
+     * Change the capacity of the underlying storage.
+     * Does not shrink capacity if new capacity is less than or equal to the current length.
+     * @param {number} capacity - The new capacity for the queue.
+     */
+    set capacity(capacity) {
+        if (capacity <= this._length) {
+            return;
+        }
+
+        const oldCapacity = this._storage.length;
+        this._storage.length = capacity;
+
+        // Handle wrap-around scenario by moving elements.
+        if (this._head + this._length > oldCapacity) {
+            const endLength = oldCapacity - this._head;
+            for (let i = 0; i < endLength; i++) {
+                this._storage[capacity - endLength + i] = this._storage[this._head + i];
+            }
+            this._head = capacity - endLength;
+        }
     }
 
     /**
      * Enqueue (push) a value to the back of the queue.
      * Automatically extends capacity if the queue is full.
-     * @param {*} value - The value to enqueue.
+     * @param {T} value - The value to enqueue.
+     * @returns {number} The new length of the queue.
      */
     enqueue(value) {
-        if (this._size === this._capacity) {
-            this.resize(this._capacity * 2);
+        if (this._length === this._storage.length) {
+            this.capacity = this._storage.length * 2;
         }
 
-        const tailIndex = (this._head + this._size) % this._capacity;
+        const tailIndex = (this._head + this._length) % this._storage.length;
         this._storage[tailIndex] = value;
-        this._size++;
+        this._length++;
+        return this._length;
     }
 
     /**
-     * @returns {*} The value at the front of the queue after dequeuing,
-     * or undefined if the queue is empty.
+     * Dequeue (pop) a value from the front of the queue.
+     * @returns {T|undefined} The dequeued value, or `undefined` if the queue is empty.
      */
     dequeue() {
         if (this.isEmpty()) {
@@ -41,56 +102,29 @@ class Queue {
 
         const value = this._storage[this._head];
         this._storage[this._head] = undefined;
-        this._head = (this._head + 1) % this._capacity;
-        this._size--;
+        this._head = (this._head + 1) % this._storage.length;
+        this._length--;
 
         return value;
     }
 
     /**
-     * @returns {*} The value at the front of the queue without dequeuing it.
+     * Returns the value at the front of the queue without removing it.
+     * @returns {T|undefined} The front value, or `undefined` if the queue is empty.
      */
     peek() {
         if (this.isEmpty()) {
             return undefined;
         }
-
         return this._storage[this._head];
     }
 
     /**
-     * @returns {number} The current number of elements in the queue.
-     */
-    size() {
-        return this._size;
-    }
-
-    /**
+     * Determines whether the queue is empty.
      * @returns {boolean} True if the queue is empty, false otherwise.
      */
     isEmpty() {
-        return this._size === 0;
-    }
-
-    /**
-     * Internal method to resize the underlying storage.
-     * @param {number} size - The new capacity for the queue.
-     */
-    resize(size) {
-        if (size <= this._size) {
-            return;
-        }
-
-        const newStorage = new Array(size);
-
-        for (let i = 0; i < this._size; i++) {
-            const index = (this._head + i) % this._capacity;
-            newStorage[i] = this._storage[index];
-        }
-
-        this._head = 0;
-        this._capacity = size;
-        this._storage = newStorage;
+        return this._length === 0;
     }
 }
 

--- a/src/core/queue.js
+++ b/src/core/queue.js
@@ -8,7 +8,7 @@
 class Queue {
     /**
      * Create a new queue.
-     * @param {number} [initialCapacity=8] - The initial capacity of the queue.
+     * @param {number} [initialCapacity] - The initial capacity of the queue.
      */
     constructor(initialCapacity = 8) {
         /**
@@ -43,15 +43,6 @@ class Queue {
     }
 
     /**
-     * The capacity of the queue.
-     * @type {number}
-     * @readonly
-     */
-    get capacity() {
-        return this._storage.length;
-    }
-
-    /**
      * Change the capacity of the underlying storage.
      * Does not shrink capacity if new capacity is less than or equal to the current length.
      * @param {number} capacity - The new capacity for the queue.
@@ -72,6 +63,15 @@ class Queue {
             }
             this._head = capacity - endLength;
         }
+    }
+
+    /**
+     * The capacity of the queue.
+     * @type {number}
+     * @readonly
+     */
+    get capacity() {
+        return this._storage.length;
     }
 
     /**

--- a/src/core/queue.js
+++ b/src/core/queue.js
@@ -1,4 +1,3 @@
-
 /**
  * A circular queue that automatically extends its capacity when full.
  * This implementation uses a fixed-size array to store elements and
@@ -19,7 +18,7 @@ class Queue {
     /**
      * Enqueue (push) a value to the back of the queue.
      * Automatically extends capacity if the queue is full.
-     * @param {*} value The value to enqueue.
+     * @param {*} value - The value to enqueue.
      */
     enqueue(value) {
         if (this._size === this._capacity) {
@@ -32,9 +31,8 @@ class Queue {
     }
 
     /**
-     * Dequeue (pop) a value from the front of the queue.
-     * Returns undefined if the queue is empty.
-     * @returns {*}
+     * @returns {*} The value at the front of the queue after dequeuing,
+     * or undefined if the queue is empty.
      */
     dequeue() {
         if (this.isEmpty()) {
@@ -50,8 +48,7 @@ class Queue {
     }
 
     /**
-     * Return the front element without removing it.
-     * @returns {*}
+     * @returns {*} The value at the front of the queue without dequeuing it.
      */
     peek() {
         if (this.isEmpty()) {
@@ -62,16 +59,14 @@ class Queue {
     }
 
     /**
-     * The current number of elements in the queue.
-     * @returns {number}
+     * @returns {number} The current number of elements in the queue.
      */
     size() {
         return this._size;
     }
 
     /**
-     * Check if the queue is empty.
-     * @returns {boolean}
+     * @returns {boolean} True if the queue is empty, false otherwise.
      */
     isEmpty() {
         return this._size === 0;
@@ -79,7 +74,7 @@ class Queue {
 
     /**
      * Internal method to resize the underlying storage.
-     * @param {number} size The new capacity for the queue.
+     * @param {number} size - The new capacity for the queue.
      */
     resize(size) {
         if (size <= this._size) {

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -811,7 +811,7 @@ class Lightmapper {
 
             const meshInstances = bakeNode.meshInstances;
             for (let i = 0; i < meshInstances.length; i++) {
-                if (meshInstances[i]._isVisible(shadowCam)) {
+                if (meshInstances[i]._isVisible(shadowCam, this.renderer._aabbUpdateIndex)) {
                     nodeVisible = true;
                     break;
                 }

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -647,7 +647,7 @@ class GraphNode extends EventHandler {
 
             const children = node._children;
             const length = children.length;
-            for (let i = length - 1; i >= 0; --i) {
+            for (let i = 0; i < length; ++i) {
                 stack[size++] = children[i];
             }
         }
@@ -696,7 +696,7 @@ class GraphNode extends EventHandler {
 
             const children = node._children;
             const length = children.length;
-            for (let i = length - 1; i >= 0; --i) {
+            for (let i = 0; i < length; ++i) {
                 stack[size++] = children[i];
             }
         }
@@ -1409,7 +1409,7 @@ class GraphNode extends EventHandler {
 
             const children = node._children;
             const length = children.length;
-            for (let i = length - 1; i >= 0; --i) {
+            for (let i = 0; i < length; ++i) {
                 stack[size++] = children[i];
             }
         }
@@ -1472,7 +1472,7 @@ class GraphNode extends EventHandler {
 
             const children = node._children;
             const length = children.length;
-            for (let i = length - 1; i >= 0; --i) {
+            for (let i = 0; i < length; ++i) {
                 stack[size++] = children[i];
             }
         }
@@ -1602,7 +1602,7 @@ class GraphNode extends EventHandler {
 
             const children = node._children;
             const length = children.length;
-            for (let i = length - 1; i >= 0; --i) {
+            for (let i = 0; i < length; ++i) {
                 stack[size++] = children[i];
             }
         }

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -75,7 +75,7 @@ function createTest(attr, value) {
 class GraphNode extends EventHandler {
     /**
      * @type {GraphNode[]}
-     * @ignore
+     * @private
      */
     static _stack = [];
 

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -596,7 +596,7 @@ class GraphNode extends EventHandler {
         const results = [];
         const test = createTest(attr, value);
 
-        this.forEach(node => {
+        this.forEach((node) => {
             if (test(node)) {
                 results.push(node);
             }
@@ -681,8 +681,11 @@ class GraphNode extends EventHandler {
     findByTag(...query) {
         const results = [];
         const stack = GraphNode._stackPool.allocate();
-        Array.prototype.push.apply(stack, this._children);
-        let size = stack.length;
+
+        let size = 0;
+        for (let i = 0; i < this._children.length; ++i) {
+            stack[size++] = this._children[i];
+        }
 
         while (size > 0) {
             const node = stack[--size];

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -645,8 +645,9 @@ class GraphNode extends EventHandler {
 
         while (stack.length) {
             const current = stack.pop();
-            if (test(current))
+            if (test(current)) {
                 return current;
+            }
 
             const children = current._children;
             for (let i = 0; i < children.length; i++) {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1586,22 +1586,24 @@ class GraphNode extends EventHandler {
             return;
         }
 
-        this._frozen = true;
-
         const stack = GraphNode._tmpGraphNodeStack;
         stack.push(this);
 
-        while (stack.length > 0) {
+        while (stack.length) {
             const node = stack.pop();
+
             if (!node._enabled || node._frozen) {
                 continue;
             }
+
+            node._frozen = true;
 
             if (node._dirtyLocal || node._dirtyWorld) {
                 node._sync();
             }
 
             const children = node._children;
+
             for (let i = children.length - 1; i >= 0; i--) {
                 stack.push(children[i]);
             }

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -783,7 +783,7 @@ class GraphNode extends EventHandler {
         queue.enqueue(this);
 
         while (queue.size()) {
-            const current = queue.dequeue()
+            const current = queue.dequeue();
             callback(current);
             const children = current.children;
             for (let i = 0; i < children.length; i++) {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -77,7 +77,7 @@ class GraphNode extends EventHandler {
      * @type {GraphNode[]}
      * @ignore
      */
-    static _tmpGraphNodeStack = [];
+    static _stack = [];
 
     /**
      * The non-unique name of a graph node. Defaults to 'Untitled'.
@@ -430,7 +430,7 @@ class GraphNode extends EventHandler {
      */
     _notifyHierarchyStateChanged(node, enabled) {
         /**
-         * NOTE: GraphNode._tmpGraphNodeStack is not used here because _notifyHierarchyStateChanged can be called
+         * NOTE: GraphNode._stack is not used here because _notifyHierarchyStateChanged can be called
          * while other _notifyHierarchyStateChanged is still running because of _onHierarchyStateChanged
          *
          * @type {GraphNode[]}
@@ -593,7 +593,7 @@ class GraphNode extends EventHandler {
         const results = [];
         const test = createTest(attr, value);
 
-        const stack = GraphNode._tmpGraphNodeStack;
+        const stack = GraphNode._stack;
         stack.push(this);
 
         while (stack.length) {
@@ -640,7 +640,7 @@ class GraphNode extends EventHandler {
     findOne(attr, value) {
         const test = createTest(attr, value);
 
-        const stack = GraphNode._tmpGraphNodeStack;
+        const stack = GraphNode._stack;
         stack.push(this);
 
         while (stack.length) {
@@ -681,7 +681,7 @@ class GraphNode extends EventHandler {
      */
     findByTag(...query) {
         const results = [];
-        const stack = GraphNode._tmpGraphNodeStack;
+        const stack = GraphNode._stack;
 
         const children = this._children;
         for (let i = 0; i < children.length; i++) {
@@ -760,7 +760,7 @@ class GraphNode extends EventHandler {
      */
     forEach(callback, thisArg) {
         /**
-         * NOTE: GraphNode._tmpGraphNodeStack is not used here because forEach can be called within the callback
+         * NOTE: GraphNode._stack is not used here because forEach can be called within the callback
          *
          * @type {GraphNode[]}
          */
@@ -1160,7 +1160,7 @@ class GraphNode extends EventHandler {
 
     /** @private */
     _dirtifyWorldInternal() {
-        const stack = GraphNode._tmpGraphNodeStack;
+        const stack = GraphNode._stack;
         stack.push(this);
 
         while (stack.length > 0) {
@@ -1402,7 +1402,7 @@ class GraphNode extends EventHandler {
         this.fire(name, parent);
 
         /**
-         * NOTE: GraphNode._tmpGraphNodeStack is not used here because _fireOnHierarchy can be called
+         * NOTE: GraphNode._stack is not used here because _fireOnHierarchy can be called
          * while other _fireOnHierarchy is still running
          *
          * @type {GraphNode[]}
@@ -1470,7 +1470,7 @@ class GraphNode extends EventHandler {
      * @private
      */
     _updateGraphDepth() {
-        const stack = GraphNode._tmpGraphNodeStack;
+        const stack = GraphNode._stack;
         stack.push(this);
 
         while (stack.length) {
@@ -1586,7 +1586,7 @@ class GraphNode extends EventHandler {
             return;
         }
 
-        const stack = GraphNode._tmpGraphNodeStack;
+        const stack = GraphNode._stack;
         stack.push(this);
 
         while (stack.length) {

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -956,7 +956,7 @@ class MeshInstance {
                 return this.isVisibleFunc(camera);
             }
 
-            const aabb = this._aabbUpdateIndex === aabbUpdateIndex ? this._aabb: this.aabb; // this line evaluates aabb
+            const aabb = this._aabbUpdateIndex === aabbUpdateIndex ? this._aabb : this.aabb; // this line evaluates aabb
             this._aabbUpdateIndex = aabbUpdateIndex;
 
             _tempSphere.center = aabb.center;

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -277,6 +277,8 @@ class MeshInstance {
      */
     pick = true;
 
+    _aabbUpdateIndex = NaN;
+
     /**
      * The stencil parameters for front faces or null if no stencil is enabled.
      *
@@ -945,7 +947,7 @@ class MeshInstance {
      * @returns {boolean} - True if the mesh instance is visible by the camera, false otherwise.
      * @ignore
      */
-    _isVisible(camera) {
+    _isVisible(camera, aabbUpdateIndex) {
 
         if (this.visible) {
 
@@ -954,8 +956,11 @@ class MeshInstance {
                 return this.isVisibleFunc(camera);
             }
 
-            _tempSphere.center = this.aabb.center;  // this line evaluates aabb
-            _tempSphere.radius = this._aabb.halfExtents.length();
+            const aabb = this._aabbUpdateIndex === aabbUpdateIndex && this._aabb || this.aabb;
+            this._aabbUpdateIndex = aabbUpdateIndex;
+
+            _tempSphere.center = aabb.center;  // this line evaluates aabb
+            _tempSphere.radius = aabb.halfExtents.length();
 
             return camera.frustum.containsSphere(_tempSphere) > 0;
         }

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -956,9 +956,7 @@ class MeshInstance {
                 return this.isVisibleFunc(camera);
             }
 
-            const aabb = this._aabbUpdateIndex === aabbUpdateIndex
-                ? this._aabb
-                : this.aabb; // this line evaluates aabb
+            const aabb = this._aabbUpdateIndex === aabbUpdateIndex ? this._aabb: this.aabb; // this line evaluates aabb
             this._aabbUpdateIndex = aabbUpdateIndex;
 
             _tempSphere.center = aabb.center;

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -956,10 +956,12 @@ class MeshInstance {
                 return this.isVisibleFunc(camera);
             }
 
-            const aabb = this._aabbUpdateIndex === aabbUpdateIndex && this._aabb || this.aabb;
+            const aabb = this._aabbUpdateIndex === aabbUpdateIndex
+                ? this._aabb
+                : this.aabb; // this line evaluates aabb
             this._aabbUpdateIndex = aabbUpdateIndex;
 
-            _tempSphere.center = aabb.center;  // this line evaluates aabb
+            _tempSphere.center = aabb.center;
             _tempSphere.radius = aabb.halfExtents.length();
 
             return camera.frustum.containsSphere(_tempSphere) > 0;

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -158,6 +158,8 @@ class Renderer {
 
     blueNoise = new BlueNoise(123);
 
+    _aabbUpdateIndex = 0;
+
     /**
      * Create a new instance.
      *
@@ -916,7 +918,7 @@ class Renderer {
             const drawCall = drawCalls[i];
             if (drawCall.visible) {
 
-                const visible = !doCull || !drawCall.cull || drawCall._isVisible(camera);
+                const visible = !doCull || !drawCall.cull || drawCall._isVisible(camera, this._aabbUpdateIndex);
                 if (visible) {
                     drawCall.visibleThisFrame = true;
 
@@ -1127,6 +1129,7 @@ class Renderer {
      */
     cullComposition(comp) {
 
+        this._aabbUpdateIndex++;
         // #if _PROFILER
         const cullTime = now();
         // #endif

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -142,7 +142,7 @@ class ShadowRenderer {
             const meshInstance = meshInstances[i];
 
             if (meshInstance.castShadow) {
-                if (!meshInstance.cull || meshInstance._isVisible(camera)) {
+                if (!meshInstance.cull || meshInstance._isVisible(camera, this.renderer._aabbUpdateIndex)) {
                     meshInstance.visibleThisFrame = true;
                     visible.push(meshInstance);
                 }

--- a/test/core/object-pool.test.mjs
+++ b/test/core/object-pool.test.mjs
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+
+import { ObjectPool } from '../../src/core/object-pool.js';
+
+class SampleObject {
+    constructor() {
+        this.value = 0;
+    }
+}
+
+describe('ObjectPool', function () {
+    let pool;
+
+    beforeEach(function () {
+        pool = new ObjectPool(SampleObject, 2);
+    });
+
+    it('should allocate an object from the pool', function () {
+        const obj = pool.allocate();
+        expect(obj).to.be.an.instanceof(SampleObject);
+    });
+
+    it('should resize the pool when allocation exceeds size', function () {
+        const obj1 = pool.allocate();
+        const obj2 = pool.allocate();
+        const obj3 = pool.allocate();
+        expect(obj3).to.be.an.instanceof(SampleObject);
+    });
+
+    it('should free an allocated object back to the pool', function () {
+        const obj = pool.allocate();
+        const success = pool.free(obj);
+        expect(success).to.be.true;
+    });
+
+    it('should not free an object not allocated from the pool', function () {
+        const obj = new SampleObject();
+        const success = pool.free(obj);
+        expect(success).to.be.false;
+    });
+
+    it('should free all allocated objects', function () {
+        pool.allocate();
+        pool.allocate();
+        pool.freeAll();
+        const obj = pool.allocate();
+        expect(obj).to.be.an.instanceof(SampleObject);
+    });
+});

--- a/test/core/object-pool.test.mjs
+++ b/test/core/object-pool.test.mjs
@@ -21,10 +21,10 @@ describe('ObjectPool', function () {
     });
 
     it('should resize the pool when allocation exceeds size', function () {
-        const obj1 = pool.allocate();
-        const obj2 = pool.allocate();
-        const obj3 = pool.allocate();
-        expect(obj3).to.be.an.instanceof(SampleObject);
+        pool.allocate();
+        pool.allocate();
+        const obj = pool.allocate();
+        expect(obj).to.be.an.instanceof(SampleObject);
     });
 
     it('should free an allocated object back to the pool', function () {

--- a/test/core/queue.test.mjs
+++ b/test/core/queue.test.mjs
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+
+import { Queue } from '../../src/core/queue.js';
+
+describe('Queue', function () {
+    let queue;
+
+    beforeEach(function () {
+        queue = new Queue(2);
+    });
+
+    it('should initialize as empty', function () {
+        expect(queue.isEmpty()).to.be.true;
+        expect(queue.size()).to.equal(0);
+    });
+
+    it('should enqueue elements into the queue', function () {
+        queue.enqueue(1);
+        expect(queue.isEmpty()).to.be.false;
+        expect(queue.size()).to.equal(1);
+        expect(queue.peek()).to.equal(1);
+    });
+
+    it('should dequeue elements from the queue', function () {
+        queue.enqueue(1);
+        queue.enqueue(2);
+        const dequeued = queue.dequeue();
+        expect(dequeued).to.equal(1);
+        expect(queue.size()).to.equal(1);
+        expect(queue.peek()).to.equal(2);
+    });
+
+    it('should return undefined when dequeuing from an empty queue', function () {
+        const dequeued = queue.dequeue();
+        expect(dequeued).to.be.undefined;
+        expect(queue.isEmpty()).to.be.true;
+    });
+
+    it('should peek at the front element without dequeuing it', function () {
+        queue.enqueue(1);
+        const front = queue.peek();
+        expect(front).to.equal(1);
+        expect(queue.size()).to.equal(1);
+    });
+
+    it('should resize when capacity is exceeded', function () {
+        queue.enqueue(1);
+        queue.enqueue(2);
+        queue.enqueue(3); // This should trigger a resize
+        expect(queue.size()).to.equal(3);
+        expect(queue.peek()).to.equal(1);
+    });
+
+    it('should maintain order after resizing', function () {
+        queue.enqueue(1);
+        queue.enqueue(2);
+        queue.enqueue(3);
+        expect(queue.dequeue()).to.equal(1);
+        expect(queue.dequeue()).to.equal(2);
+        expect(queue.dequeue()).to.equal(3);
+    });
+
+    it('should correctly report if the queue is empty', function () {
+        expect(queue.isEmpty()).to.be.true;
+        queue.enqueue(1);
+        expect(queue.isEmpty()).to.be.false;
+        queue.dequeue();
+        expect(queue.isEmpty()).to.be.true;
+    });
+
+    it('should correctly report the size of the queue', function () {
+        expect(queue.size()).to.equal(0);
+        queue.enqueue(1);
+        expect(queue.size()).to.equal(1);
+        queue.enqueue(2);
+        expect(queue.size()).to.equal(2);
+        queue.dequeue();
+        expect(queue.size()).to.equal(1);
+    });
+});

--- a/test/core/queue.test.mjs
+++ b/test/core/queue.test.mjs
@@ -9,72 +9,207 @@ describe('Queue', function () {
         queue = new Queue(2);
     });
 
-    it('should initialize as empty', function () {
-        expect(queue.isEmpty()).to.be.true;
-        expect(queue.size()).to.equal(0);
+    describe('#constructor', function () {
+        it('should initialize as empty', function () {
+            expect(queue.isEmpty()).to.be.true;
+            expect(queue.length).to.equal(0);
+        });
+
+        it('should return the initial capacity from the constructor', function () {
+            expect(queue.capacity).to.equal(2);
+
+            const customQueue = new Queue(5);
+            expect(customQueue.capacity).to.equal(5);
+        });
     });
 
-    it('should enqueue elements into the queue', function () {
-        queue.enqueue(1);
-        expect(queue.isEmpty()).to.be.false;
-        expect(queue.size()).to.equal(1);
-        expect(queue.peek()).to.equal(1);
+    describe('#enqueue()/#dequeue()', function () {
+        it('should enqueue elements into the queue', function () {
+            queue.enqueue(1);
+            expect(queue.isEmpty()).to.be.false;
+            expect(queue.length).to.equal(1);
+            expect(queue.peek()).to.equal(1);
+        });
+
+        it('should dequeue elements from the queue', function () {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            const dequeued = queue.dequeue();
+            expect(dequeued).to.equal(1);
+            expect(queue.length).to.equal(1);
+            expect(queue.peek()).to.equal(2);
+        });
+
+        it('should return undefined when dequeuing from an empty queue', function () {
+            const dequeued = queue.dequeue();
+            expect(dequeued).to.be.undefined;
+            expect(queue.isEmpty()).to.be.true;
+        });
+
+        it('should resize when capacity is exceeded', function () {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            queue.enqueue(3); // This should trigger a resize
+            expect(queue.length).to.equal(3);
+            expect(queue.peek()).to.equal(1);
+        });
+
+        it('should maintain order after resizing', function () {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            queue.enqueue(3);
+            expect(queue.dequeue()).to.equal(1);
+            expect(queue.dequeue()).to.equal(2);
+            expect(queue.dequeue()).to.equal(3);
+        });
+
+        it('should correctly report if the queue is empty', function () {
+            expect(queue.isEmpty()).to.be.true;
+            queue.enqueue(1);
+            expect(queue.isEmpty()).to.be.false;
+            queue.dequeue();
+            expect(queue.isEmpty()).to.be.true;
+        });
+
+        it('should correctly report the size of the queue', function () {
+            expect(queue.length).to.equal(0);
+            queue.enqueue(1);
+            expect(queue.length).to.equal(1);
+            queue.enqueue(2);
+            expect(queue.length).to.equal(2);
+            queue.dequeue();
+            expect(queue.length).to.equal(1);
+        });
+
+        it('should handle multiple resizes', function () {
+            for (let i = 1; i <= 5; i++) {
+                queue.enqueue(i);
+            }
+
+            expect(queue.capacity).to.be.at.least(4);
+            expect(queue.length).to.equal(5);
+
+            expect(queue.dequeue()).to.equal(1);
+            expect(queue.dequeue()).to.equal(2);
+            expect(queue.dequeue()).to.equal(3);
+            expect(queue.dequeue()).to.equal(4);
+            expect(queue.dequeue()).to.equal(5);
+        });
+
+        it('should allow enqueuing after manually setting a larger capacity', function () {
+            expect(queue.capacity).to.equal(2);
+            queue.capacity = 10;
+            expect(queue.capacity).to.equal(10);
+
+            for (let i = 0; i < 10; i++) {
+                queue.enqueue(i);
+            }
+            expect(queue.length).to.equal(10);
+            expect(queue.capacity).to.equal(10);
+        });
     });
 
-    it('should dequeue elements from the queue', function () {
-        queue.enqueue(1);
-        queue.enqueue(2);
-        const dequeued = queue.dequeue();
-        expect(dequeued).to.equal(1);
-        expect(queue.size()).to.equal(1);
-        expect(queue.peek()).to.equal(2);
+    describe('#capacity', function () {
+        it('should not reduce capacity if new capacity is smaller or equal to current length', function () {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            expect(queue.length).to.equal(2);
+
+            queue.capacity = 1;
+            expect(queue.capacity).to.equal(2);
+
+            expect(queue.dequeue()).to.equal(1);
+            expect(queue.dequeue()).to.equal(2);
+            expect(queue.isEmpty()).to.be.true;
+        });
+
+        it('should set a larger capacity if new capacity is bigger than current size', function () {
+            expect(queue.capacity).to.equal(2);
+            queue.enqueue(1);
+
+            queue.capacity = 5;
+            expect(queue.capacity).to.equal(5);
+            expect(queue.length).to.equal(1);
+            expect(queue.dequeue()).to.equal(1);
+        });
+
+        it('should handle wrap-around when manually setting capacity', function () {
+            queue.enqueue(1);
+            queue.enqueue(2);
+
+            const first = queue.dequeue();
+            expect(first).to.equal(1);
+
+            queue.enqueue(3);
+
+            queue.capacity = 4;
+            expect(queue.capacity).to.equal(4);
+
+            expect(queue.dequeue()).to.equal(2);
+            expect(queue.dequeue()).to.equal(3);
+            expect(queue.isEmpty()).to.be.true;
+        });
     });
 
-    it('should return undefined when dequeuing from an empty queue', function () {
-        const dequeued = queue.dequeue();
-        expect(dequeued).to.be.undefined;
-        expect(queue.isEmpty()).to.be.true;
+    describe('#length', function () {
+        it('should accurately reflect the number of items in the queue', function () {
+            expect(queue.length).to.equal(0);
+
+            queue.enqueue(10);
+            queue.enqueue(20);
+            expect(queue.length).to.equal(2);
+
+            queue.dequeue();
+            expect(queue.length).to.equal(1);
+
+            queue.enqueue(30);
+            expect(queue.length).to.equal(2);
+
+            queue.dequeue();
+            queue.dequeue();
+            expect(queue.length).to.equal(0);
+            expect(queue.isEmpty()).to.be.true;
+        });
     });
 
-    it('should peek at the front element without dequeuing it', function () {
-        queue.enqueue(1);
-        const front = queue.peek();
-        expect(front).to.equal(1);
-        expect(queue.size()).to.equal(1);
+    describe('#isEmpty()', function () {
+        it('should return true when queue is newly created', function () {
+            expect(queue.isEmpty()).to.be.true;
+        });
+
+        it('should return false when at least one item is enqueued', function () {
+            queue.enqueue('test');
+            expect(queue.isEmpty()).to.be.false;
+        });
+
+        it('should return true after enqueuing and then dequeuing the same number of items', function () {
+            queue.enqueue('a');
+            queue.enqueue('b');
+            queue.dequeue();
+            queue.dequeue();
+            expect(queue.isEmpty()).to.be.true;
+        });
     });
 
-    it('should resize when capacity is exceeded', function () {
-        queue.enqueue(1);
-        queue.enqueue(2);
-        queue.enqueue(3); // This should trigger a resize
-        expect(queue.size()).to.equal(3);
-        expect(queue.peek()).to.equal(1);
-    });
+    describe('#peek()', function () {
+        it('should return undefined if the queue is empty', function () {
+            expect(queue.peek()).to.be.undefined;
+        });
 
-    it('should maintain order after resizing', function () {
-        queue.enqueue(1);
-        queue.enqueue(2);
-        queue.enqueue(3);
-        expect(queue.dequeue()).to.equal(1);
-        expect(queue.dequeue()).to.equal(2);
-        expect(queue.dequeue()).to.equal(3);
-    });
+        it('should peek at the front element without dequeuing it', function () {
+            queue.enqueue(1);
+            const front = queue.peek();
+            expect(front).to.equal(1);
+            expect(queue.length).to.equal(1);
+        });
 
-    it('should correctly report if the queue is empty', function () {
-        expect(queue.isEmpty()).to.be.true;
-        queue.enqueue(1);
-        expect(queue.isEmpty()).to.be.false;
-        queue.dequeue();
-        expect(queue.isEmpty()).to.be.true;
-    });
+        it('should return the front element after multiple enqueues/dequeues', function () {
+            queue.enqueue(1);
+            queue.enqueue(2);
+            queue.enqueue(3);
+            queue.dequeue();
 
-    it('should correctly report the size of the queue', function () {
-        expect(queue.size()).to.equal(0);
-        queue.enqueue(1);
-        expect(queue.size()).to.equal(1);
-        queue.enqueue(2);
-        expect(queue.size()).to.equal(2);
-        queue.dequeue();
-        expect(queue.size()).to.equal(1);
+            expect(queue.peek()).to.equal(2);
+        });
     });
 });


### PR DESCRIPTION
I experimented with placing multiple animated skinned meshes in Playcanvas and Unity 6.1, which is going to support WebGPU to address huge performance issues with skinned meshes. 

I understand that it's best to bake animations for skinned meshes instead of using the Anim component when dealing with high number of animated skinned meshes. But still... 

The PR proposes replacing the recursive implementation of core GraphNode methods with an iterative approach and avoid recalculating the AABB multiple times during rendering to improve performance of skinned meshes.

Here are my results:

| Main branch | PR |
|-------------|----|
| <img width="197" alt="Screenshot 2025-01-03 at 11 31 08" src="https://github.com/user-attachments/assets/f11f8822-ae10-4db3-be42-1e3fefbaa96f" /> | <img width="197" alt="Screenshot 2025-01-03 at 12 52 36" src="https://github.com/user-attachments/assets/ab543fcc-5d86-4699-b7d4-4345c1c911f4" /> |

