### PR TITLE
ESM Script clone fix

### DIFF
--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -109,7 +109,7 @@ class ScriptComponentSystem extends ComponentSystem {
             const scriptName = scriptInstance.__scriptType.__name;
             order.push(scriptName);
 
-            const attributes = { };
+            const attributes = entity.script._attributeDataMap?.get(scriptName) || { };
             for (const key in scriptInstance.__attributes) {
                 attributes[key] = scriptInstance.__attributes[key];
             }


### PR DESCRIPTION
This PR fixes an issue [reported on Discord](https://discord.com/channels/408617316415307776/1242436398678671401/1324374717758701599) where a cloned entity with an ESM Script would not acquire the correct attributes from the source.

There is a [test case here](https://playcanvas.com/editor/scene/2147547) and [editor project here](https://playcanvas.com/editor/scene/2147547)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
