### PR TITLE
Expose PLY load progress

### DIFF
--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -112,7 +112,7 @@ class Asset extends EventHandler {
      * Please note:
      * - only gsplat assets current emit this event
      * - totalBytes may not be reliable as it is based on the content-length header of the response
-     * 
+     *
      * @event
      * @example
      * asset.on('progress', (receivedBytes, totalBytes) => {

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -107,6 +107,21 @@ class Asset extends EventHandler {
     static EVENT_CHANGE = 'change';
 
     /**
+     * Fired when the asset's stream download progresses.
+     *
+     * Please note:
+     * - only gsplat assets current emit this event
+     * - totalBytes may not be reliable as it is based on the content-length header of the response
+     * 
+     * @event
+     * @example
+     * asset.on('progress', (receivedBytes, totalBytes) => {
+     *    console.log(`Asset ${asset.name} progress ${readBytes / totalBytes}`);
+     * });
+     */
+    static EVENT_PROGRESS = 'progress';
+
+    /**
      * Fired when we add a new localized asset id to the asset.
      *
      * @event

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -558,7 +558,7 @@ class PlyParser {
             if (!response || !response.body) {
                 callback('Error loading resource', null);
             } else {
-                const totalLength = parseInt(response.headers.get('content-length') ?? '0');
+                const totalLength = parseInt(response.headers.get('content-length') ?? '0', 10);
                 let totalReceived = 0;
 
                 const { data, comments } = await readPly(

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -572,10 +572,6 @@ class PlyParser {
                     }
                 );
 
-                if (totalReceived !== totalLength) {
-                    asset.fire('progress', totalReceived, totalReceived);
-                }
-
                 // reorder data
                 if (!data.isCompressed) {
                     if (asset.data.reorder ?? true) {


### PR DESCRIPTION
This PR addresses the issue in https://forum.playcanvas.com/t/gsplat-loading-progress/38451

The PLY loader is updated to fire `progress` events during loading.

## Notes:
- in practise the `content-length` response header is not always correct:
   - it can be missing from the response header entirely if server doesn't provide it, and also in some cors situations
   - the size represents the gzipped size of the resource, while the streaming byte sizes are uncompressed bytes (i.e. readBytes can be larger than totalBytes)