### PR TITLE
Renovate: Pin `devDependencies`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,14 @@
       "schedule": [
         "on monday at 10:00am"
       ]
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "rangeStrategy": "pin"
+    },
+    {
+      "matchDepTypes": ["dependencies"],
+      "rangeStrategy": "widen"
     }
   ]
 }


### PR DESCRIPTION
Pin `devDependencies` to specific (latest) versions. Leave regular `dependencies` on semver ranges so upstream packages can use the version they want.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
