### PR TITLE
Support chunks to be included by VS of ShaderMaterial

### DIFF
--- a/src/scene/shader-lib/programs/shader-generator-shader.js
+++ b/src/scene/shader-lib/programs/shader-generator-shader.js
@@ -73,7 +73,10 @@ class ShaderGeneratorShader extends ShaderGenerator {
             definitionOptions.vertexCode = desc.vertexCode;
 
         } else {
-            const includes = new Map();
+            const includes = new Map(Object.entries({
+                ...shaderChunks,
+                ...options.chunks
+            }));
             const defines = new Map(options.defines);
 
             includes.set('shaderPassDefines', shaderPassInfo.shaderDefines);


### PR DESCRIPTION
- we only connected all chunks to includes of the fragment shader. This attaches them to includes of the vertex shader as well.