### PR TITLE
[Breaking] few shader chunks available to ShaderMaterial use their original names

### DIFF
--- a/examples/assets/scripts/misc/gooch-material.mjs
+++ b/examples/assets/scripts/misc/gooch-material.mjs
@@ -19,12 +19,12 @@ const createGoochMaterial = (texture, color) => {
             // declares vertex_position attribute, and handles skinning and morphing if necessary.
             // It also adds uniforms: matrix_viewProjection, matrix_model, matrix_normal.
             // Functions added: getModelMatrix, getLocalPosition
-            #include "transformCore"
+            #include "transformCoreVS"
 
             // include code for normal shader functionality provided by the engine. It automatically
             // declares vertex_normal attribute, and handles skinning and morphing if necessary.
             // Functions added: getNormalMatrix, getLocalNormal
-            #include "normalCore"
+            #include "normalCoreVS"
 
             // add additional attributes we need
             attribute vec2 aUv0;

--- a/examples/assets/scripts/misc/hatch-material.mjs
+++ b/examples/assets/scripts/misc/hatch-material.mjs
@@ -39,12 +39,12 @@ const createHatchMaterial = (device, textures) => {
             // declares vertex_position attribute, and handles skinning and morphing if necessary.
             // It also adds uniforms: matrix_viewProjection, matrix_model, matrix_normal.
             // Functions added: getModelMatrix, getLocalPosition
-            #include "transformCore"
+            #include "transformCoreVS"
 
             // include code for normal shader functionality provided by the engine. It automatically
             // declares vertex_normal attribute, and handles skinning and morphing if necessary.
             // Functions added: getNormalMatrix, getLocalNormal
-            #include "normalCore"
+            #include "normalCoreVS"
 
             // add additional attributes we need
             attribute vec2 aUv0;

--- a/src/scene/shader-lib/chunks/common/vert/transformCore.js
+++ b/src/scene/shader-lib/chunks/common/vert/transformCore.js
@@ -50,7 +50,7 @@ uniform mat3 matrix_normal;
 
 #elif defined(INSTANCING)
 
-    #include "transformInstancing"
+    #include "transformInstancingVS"
 
 #else
 

--- a/src/scene/shader-lib/chunks/lit/vert/base.js
+++ b/src/scene/shader-lib/chunks/lit/vert/base.js
@@ -7,5 +7,5 @@ attribute vec4 vertex_color;
 vec3 dPositionW;
 mat4 dModelMatrix;
 
-#include "transformCore"
+#include "transformCoreVS"
 `;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1537,8 +1537,8 @@ class LitShader {
     getDefinition(options) {
 
         const vIncludes = new Map();
-        vIncludes.set('transformCore', this.chunks.transformCoreVS);
-        vIncludes.set('transformInstancing', this.chunks.transformInstancingVS);
+        vIncludes.set('transformCoreVS', this.chunks.transformCoreVS);
+        vIncludes.set('transformInstancingVS', this.chunks.transformInstancingVS);
         vIncludes.set('skinTexVS', this.chunks.skinTexVS);
         vIncludes.set('skinBatchTexVS', this.chunks.skinBatchTexVS);
 

--- a/src/scene/shader-lib/programs/shader-generator-shader.js
+++ b/src/scene/shader-lib/programs/shader-generator-shader.js
@@ -81,10 +81,9 @@ class ShaderGeneratorShader extends ShaderGenerator {
 
             includes.set('shaderPassDefines', shaderPassInfo.shaderDefines);
             includes.set('userCode', desc.vertexCode);
-            includes.set('transformCore', shaderChunks.transformCoreVS);
-            includes.set('transformInstancing', ''); // no default instancing, needs to be implemented in the user shader
-            includes.set('normalCore', shaderChunks.normalCoreVS);
-            includes.set('skinCode', shaderChunks.skinTexVS);
+            includes.set('transformCoreVS', shaderChunks.transformCoreVS);
+            includes.set('transformInstancingVS', ''); // no default instancing, needs to be implemented in the user shader
+            includes.set('normalCoreVS', shaderChunks.normalCoreVS);
             includes.set('skinTexVS', shaderChunks.skinTexVS);
 
             if (options.skin) defines.set('SKIN', true);


### PR DESCRIPTION
- this is to avoid custom names in few places, as the Stadard/Lit material and others all use standard names.