### PR TITLE
ShaderMaterial generator provides GAMMA and TONEMAPPING defines to VS

### DIFF
--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -607,6 +607,12 @@ export const GAMMA_NONE = 0;
  */
 export const GAMMA_SRGB = 1;
 
+// names of the gamma correction modes
+export const gammaNames = {
+    [GAMMA_NONE]: 'NONE',
+    [GAMMA_SRGB]: 'SRGB'
+};
+
 /**
  * Linear tonemapping. The colors are preserved, but the exposure is applied.
  *

--- a/src/scene/gsplat/gsplat-material.js
+++ b/src/scene/gsplat/gsplat-material.js
@@ -1,6 +1,6 @@
 import { CULLFACE_NONE, SEMANTIC_ATTR13, SEMANTIC_POSITION } from '../../platform/graphics/constants.js';
 import { ShaderProcessorOptions } from '../../platform/graphics/shader-processor-options.js';
-import { BLEND_NONE, BLEND_NORMAL, DITHER_NONE, GAMMA_NONE, GAMMA_SRGB, tonemapNames } from '../constants.js';
+import { BLEND_NONE, BLEND_NORMAL, DITHER_NONE, gammaNames, tonemapNames } from '../constants.js';
 import { ShaderMaterial } from '../materials/shader-material.js';
 import { getProgramLibrary } from '../shader-lib/get-program-library.js';
 import { getMaterialShaderDefines } from '../shader-lib/utils.js';
@@ -9,11 +9,6 @@ import { shaderChunks } from '../shader-lib/chunks/chunks.js';
 import { ShaderGenerator } from '../shader-lib/programs/shader-generator.js';
 import { ShaderPass } from '../shader-pass.js';
 import { hashCode } from '../../core/hash.js';
-
-const gammaNames = {
-    [GAMMA_NONE]: 'NONE',
-    [GAMMA_SRGB]: 'SRGB'
-};
 
 const defaultChunks = new Map(Object.entries(shaderChunks));
 

--- a/src/scene/shader-lib/programs/shader-generator-shader.js
+++ b/src/scene/shader-lib/programs/shader-generator-shader.js
@@ -1,7 +1,7 @@
 import { hashCode } from '../../../core/hash.js';
 import { SEMANTIC_ATTR15, SEMANTIC_BLENDINDICES, SEMANTIC_BLENDWEIGHT, SHADERLANGUAGE_WGSL } from '../../../platform/graphics/constants.js';
 import { ShaderUtils } from '../../../platform/graphics/shader-utils.js';
-import { tonemapNames } from '../../constants.js';
+import { gammaNames, tonemapNames } from '../../constants.js';
 import { ShaderPass } from '../../shader-pass.js';
 import { shaderChunks } from '../chunks/chunks.js';
 import { ShaderGenerator } from './shader-generator.js';
@@ -61,6 +61,10 @@ class ShaderGeneratorShader extends ShaderGenerator {
         definitionOptions.attributes = attributes;
     }
 
+    addSharedDefines(defines, options) {
+        defines.set('TONEMAP', tonemapNames[options.toneMapping]);
+        defines.set('GAMMA', gammaNames[options.gamma]);
+    }
 
     createVertexDefinition(definitionOptions, options, shaderPassInfo) {
 
@@ -78,6 +82,7 @@ class ShaderGeneratorShader extends ShaderGenerator {
                 ...options.chunks
             }));
             const defines = new Map(options.defines);
+            this.addSharedDefines(defines, options);
 
             includes.set('shaderPassDefines', shaderPassInfo.shaderDefines);
             includes.set('userCode', desc.vertexCode);
@@ -120,7 +125,7 @@ class ShaderGeneratorShader extends ShaderGenerator {
             includes.set('userCode', desc.fragmentCode);
 
             const defines = new Map(options.defines);
-            defines.set('TONEMAP', tonemapNames[options.toneMapping]);
+            this.addSharedDefines(defines, options);
 
             definitionOptions.fragmentCode = fShader;
             definitionOptions.fragmentIncludes = includes;


### PR DESCRIPTION
- in addition to fragment shader, those are added to vertex shader, allowing users to execute tonemapping / gamma correction per vertex if more performant (needed for gsplats)