### PR TITLE
GSplat shader fixes

### DIFF
--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -200,6 +200,10 @@ class Asset extends EventHandler {
         this.tags = new Tags(this);
 
         this._preload = false;
+
+        /**
+         * @type {AssetFile | null}
+         */
         this._file = null;
         this._data = data || { };
 

--- a/src/scene/gsplat/gsplat.js
+++ b/src/scene/gsplat/gsplat.js
@@ -58,9 +58,6 @@ class GSplat {
     sh4to7Texture;
 
     /** @type {Texture | undefined} */
-    sh8Texture;
-
-    /** @type {Texture | undefined} */
     sh8to11Texture;
 
     /** @type {Texture | undefined} */
@@ -102,7 +99,7 @@ class GSplat {
                     this.sh8to11Texture = this.createTexture('splatSH_8to11', PIXELFORMAT_RGBA32U, size);
                     this.sh12to15Texture = this.createTexture('splatSH_12to15', PIXELFORMAT_RGBA32U, size);
                 } else {
-                    this.sh8Texture = this.createTexture('splatSH_8', PIXELFORMAT_R32U, size);
+                    this.sh8to11Texture = this.createTexture('splatSH_8to11', PIXELFORMAT_R32U, size);
                 }
             }
 
@@ -116,7 +113,6 @@ class GSplat {
         this.transformBTexture?.destroy();
         this.sh1to3Texture?.destroy();
         this.sh4to7Texture?.destroy();
-        this.sh8Texture?.destroy();
         this.sh8to11Texture?.destroy();
         this.sh12to15Texture?.destroy();
     }
@@ -133,7 +129,6 @@ class GSplat {
         result.setDefine('SH_BANDS', this.shBands);
         result.setParameter('splatSH_1to3', this.sh1to3Texture);
         result.setParameter('splatSH_4to7', this.sh4to7Texture);
-        result.setParameter('splatSH_8', this.sh8Texture);
         result.setParameter('splatSH_8to11', this.sh8to11Texture);
         result.setParameter('splatSH_12to15', this.sh12to15Texture);
         return result;
@@ -292,7 +287,6 @@ class GSplat {
     updateSHData(gsplatData) {
         const sh1to3Data = this.sh1to3Texture.lock();
         const sh4to7Data = this.sh4to7Texture?.lock();
-        const sh8Data = this.sh8Texture?.lock();
         const sh8to11Data = this.sh8to11Texture?.lock();
         const sh12to15Data = this.sh12to15Texture?.lock();
 
@@ -363,14 +357,13 @@ class GSplat {
                     sh12to15Data[i * 4 + 2] = c[39] << 21 | c[40] << 11 | c[41];
                     sh12to15Data[i * 4 + 3] = c[42] << 21 | c[43] << 11 | c[44];
                 } else {
-                    sh8Data[i] = c[21] << 21 | c[22] << 11 | c[23];
+                    sh8to11Data[i] = c[21] << 21 | c[22] << 11 | c[23];
                 }
             }
         }
 
         this.sh1to3Texture.unlock();
         this.sh4to7Texture?.unlock();
-        this.sh8Texture?.unlock();
         this.sh8to11Texture?.unlock();
         this.sh12to15Texture?.unlock();
     }

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplat.js
@@ -21,7 +21,7 @@ void main(void) {
     vec3 modelCenter = readCenter(source);
 
     SplatCenter center;
-    if (!initCenter(source, modelCenter, center)) {
+    if (!initCenter(modelCenter, center)) {
         gl_Position = discardVec;
         return;
     }

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatCenter.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatCenter.js
@@ -4,11 +4,11 @@ uniform mat4 matrix_view;
 uniform mat4 matrix_projection;
 
 // project the model space gaussian center to view and clip space
-bool initCenter(SplatSource source, vec3 modelCenter, out SplatCenter center) {
+bool initCenter(vec3 modelCenter, out SplatCenter center) {
     mat4 modelView = matrix_view * matrix_model;
     vec4 centerView = modelView * vec4(modelCenter, 1.0);
 
-    // early out if splat is behind the camear
+    // early out if splat is behind the camera
     if (centerView.z > 0.0) {
         return false;
     }

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatSH.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatSH.js
@@ -35,11 +35,11 @@ void fetch(in uint t, out vec3 a) {
 #elif SH_BANDS == 2
     uniform highp usampler2D splatSH_1to3;
     uniform highp usampler2D splatSH_4to7;
-    uniform highp usampler2D splatSH_8;
+    uniform highp usampler2D splatSH_8to11;
     void readSHData(in SplatSource source, out vec3 sh[8], out float scale) {
         fetchScale(texelFetch(splatSH_1to3, source.uv, 0), scale, sh[0], sh[1], sh[2]);
         fetch(texelFetch(splatSH_4to7, source.uv, 0), sh[3], sh[4], sh[5], sh[6]);
-        fetch(texelFetch(splatSH_8, source.uv, 0).x, sh[7]);
+        fetch(texelFetch(splatSH_8to11, source.uv, 0).x, sh[7]);
     }
 #else
     uniform highp usampler2D splatSH_1to3;


### PR DESCRIPTION
This shader fixes a few issues:
- use consistent texture naming between rendering  2 or 3 bands of spherical harmonics
    - having different naming is an issue when 3 bands of spherical harmonics are loaded but only 2 are used for rendering
- Fix invalid initCenter call
- Small asset type update