### PR TITLE
Updates to material chunks override functionality

### DIFF
--- a/src/scene/materials/lit-material.js
+++ b/src/scene/materials/lit-material.js
@@ -24,8 +24,6 @@ class LitMaterial extends Material {
 
     shaderChunk = 'void evaluateFrontend() {}\n';
 
-    chunks = null;
-
     useLighting = true;
 
     useFog = true;

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -173,6 +173,12 @@ class Material {
      */
     stencilBack = null;
 
+    /**
+     * @type {Object<string, string>}
+     * @private
+     */
+    _chunks = { };
+
     /** @protected */
     constructor() {
         if (new.target === Material) {
@@ -180,6 +186,26 @@ class Material {
         }
     }
 
+    /**
+     * Sets the object containing custom shader chunks that will replace default ones.
+     *
+     * @type {Object<string, string>}
+     */
+    set chunks(value) {
+        this.clearVariants();
+        this._chunks = value;
+    }
+
+    /**
+     * Gets the object containing custom shader chunks.
+     *
+     * @type {Object<string, string>}
+     */
+    get chunks() {
+        this.clearVariants();
+        return this._chunks;
+    }
+    
     /**
      * Sets the offset for the output depth buffer value. Useful for decals to prevent z-fighting.
      * Typically a small negative value (-0.1) is used to render the mesh slightly closer to the
@@ -534,6 +560,14 @@ class Material {
         this.defines.clear();
         source.defines.forEach((value, key) => this.defines.set(key, value));
 
+        // chunks
+        const srcChunks = source._chunks;
+        for (const p in srcChunks) {
+            if (srcChunks.hasOwnProperty(p)) {
+                this._chunks[p] = srcChunks[p];
+            }
+        }
+        
         return this;
     }
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -205,7 +205,7 @@ class Material {
         this.clearVariants();
         return this._chunks;
     }
-    
+
     /**
      * Sets the offset for the output depth buffer value. Useful for decals to prevent z-fighting.
      * Typically a small negative value (-0.1) is used to render the mesh slightly closer to the
@@ -567,7 +567,7 @@ class Material {
                 this._chunks[p] = srcChunks[p];
             }
         }
-        
+
         return this;
     }
 

--- a/src/scene/materials/shader-material.js
+++ b/src/scene/materials/shader-material.js
@@ -110,7 +110,8 @@ class ShaderMaterial extends Material {
             gamma: params.cameraShaderParams.shaderOutputGamma,
             toneMapping: params.cameraShaderParams.toneMapping,
             fog: params.cameraShaderParams.fog,
-            shaderDesc: this.shaderDesc
+            shaderDesc: this.shaderDesc,
+            chunks: this.chunks ?? {} // override chunks from the material
         };
 
         const processingOptions = new ShaderProcessorOptions(params.viewUniformFormat, params.viewBindGroupFormat, params.vertexFormat);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -588,27 +588,7 @@ class StandardMaterial extends Material {
             this[`_${name}`] = _props[name].value();
         });
 
-        /**
-         * @type {Object<string, string>}
-         * @private
-         */
-        this._chunks = { };
         this._uniformCache = { };
-    }
-
-    /**
-     * Object containing custom shader chunks that will replace default ones.
-     *
-     * @type {Object<string, string>}
-     */
-    set chunks(value) {
-        this._dirtyShader = true;
-        this._chunks = value;
-    }
-
-    get chunks() {
-        this._dirtyShader = true;
-        return this._chunks;
     }
 
     /**
@@ -624,13 +604,6 @@ class StandardMaterial extends Material {
         Object.keys(_props).forEach((k) => {
             this[k] = source[k];
         });
-
-        // clone chunks
-        for (const p in source._chunks) {
-            if (source._chunks.hasOwnProperty(p)) {
-                this._chunks[p] = source._chunks[p];
-            }
-        }
 
         // clone user attributes
         this.userAttributes = new Map(source.userAttributes);

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1,8 +1,7 @@
 import {
     SEMANTIC_ATTR8, SEMANTIC_ATTR9, SEMANTIC_ATTR12, SEMANTIC_ATTR13, SEMANTIC_ATTR14, SEMANTIC_ATTR15,
     SEMANTIC_BLENDINDICES, SEMANTIC_BLENDWEIGHT, SEMANTIC_COLOR, SEMANTIC_NORMAL, SEMANTIC_POSITION, SEMANTIC_TANGENT,
-    SEMANTIC_TEXCOORD0, SEMANTIC_TEXCOORD1,
-    SHADERTAG_MATERIAL
+    SEMANTIC_TEXCOORD0, SEMANTIC_TEXCOORD1
 } from '../../../platform/graphics/constants.js';
 import {
     BLEND_ADDITIVEALPHA, BLEND_NORMAL, BLEND_PREMULTIPLIED,
@@ -21,7 +20,6 @@ import { ChunkUtils } from '../chunk-utils.js';
 import { LightsBuffer } from '../../lighting/lights-buffer.js';
 import { ShaderPass } from '../../shader-pass.js';
 import { validateUserChunks } from '../chunks/chunk-validation.js';
-import { ShaderUtils } from '../../../platform/graphics/shader-utils.js';
 import { ChunkBuilder } from '../chunk-builder.js';
 import { ShaderGenerator } from './shader-generator.js';
 import { Debug } from '../../../core/debug.js';
@@ -1530,33 +1528,6 @@ class LitShader {
         }
 
         Debug.assert(!this.fshader.includes('litShaderArgs'), 'Automatic compatibility with shaders using litShaderArgs has been removed. Please update the shader to use the new system.');
-    }
-
-    getDefinition(options) {
-
-        const vIncludes = new Map();
-        vIncludes.set('transformCoreVS', this.chunks.transformCoreVS);
-        vIncludes.set('transformInstancingVS', this.chunks.transformInstancingVS);
-        vIncludes.set('skinVS', this.chunks.skinVS);
-        vIncludes.set('skinBatchVS', this.chunks.skinBatchVS);
-
-        const defines = new Map(options.defines);
-
-        const definition = ShaderUtils.createDefinition(this.device, {
-            name: 'LitShader',
-            attributes: this.attributes,
-            vertexCode: this.vshader,
-            fragmentCode: this.fshader,
-            vertexIncludes: vIncludes,
-            fragmentDefines: defines,
-            vertexDefines: defines
-        });
-
-        if (this.shaderPassInfo.isForward) {
-            definition.tag = SHADERTAG_MATERIAL;
-        }
-
-        return definition;
     }
 }
 

--- a/src/scene/shader-lib/programs/lit.js
+++ b/src/scene/shader-lib/programs/lit.js
@@ -2,9 +2,12 @@ import { ChunkBuilder } from '../chunk-builder.js';
 import { LitShader } from './lit-shader.js';
 import { LitOptionsUtils } from './lit-options-utils.js';
 import { ShaderGenerator } from './shader-generator.js';
+import { SHADERTAG_MATERIAL } from '../../../platform/graphics/constants.js';
+import { ShaderUtils } from '../../../platform/graphics/shader-utils.js';
 
 /**
  * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
+ * @import { LitMaterialOptions } from '../../materials/lit-material-options.js'
  */
 
 const dummyUvs = [0, 1, 2, 3, 4, 5, 6, 7];
@@ -24,7 +27,7 @@ class ShaderGeneratorLit extends ShaderGenerator {
 
     /**
      * @param {GraphicsDevice} device - The graphics device.
-     * @param {object} options - The options to be passed to the backend.
+     * @param {LitMaterialOptions} options - The options to be passed to the backend.
      * @returns {object} Returns the created shader definition.
      */
     createShaderDefinition(device, options) {
@@ -47,7 +50,29 @@ class ShaderGeneratorLit extends ShaderGenerator {
         litShader.generateVertexShader(usedUvSets, usedUvSets, mapTransforms);
         litShader.generateFragmentShader(decl.code, code.code, func.code, 'vUv0');
 
-        return litShader.getDefinition(options);
+        const vIncludes = new Map(Object.entries({
+            ...Object.getPrototypeOf(litShader.chunks), // the prototype stores the default chunks
+            ...litShader.chunks,  // user overrides are supplied as instance properties
+            ...options.litOptions.chunks
+        }));
+
+        const defines = new Map(options.defines);
+
+        const definition = ShaderUtils.createDefinition(device, {
+            name: 'LitShader',
+            attributes: litShader.attributes,
+            vertexCode: litShader.vshader,
+            fragmentCode: litShader.fshader,
+            vertexIncludes: vIncludes,
+            fragmentDefines: defines,
+            vertexDefines: defines
+        });
+
+        if (litShader.shaderPassInfo.isForward) {
+            definition.tag = SHADERTAG_MATERIAL;
+        }
+
+        return definition;
     }
 }
 

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -11,6 +11,8 @@ import { ChunkUtils } from '../chunk-utils.js';
 import { StandardMaterialOptions } from '../../materials/standard-material-options.js';
 import { LitOptionsUtils } from './lit-options-utils.js';
 import { ShaderGenerator } from './shader-generator.js';
+import { ShaderUtils } from '../../../platform/graphics/shader-utils.js';
+import { SHADERTAG_MATERIAL } from '../../../platform/graphics/constants.js';
 
 /**
  * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
@@ -528,7 +530,29 @@ class ShaderGeneratorStandard extends ShaderGenerator {
 
         litShader.generateFragmentShader(decl.code, code.code, func.code, lightingUv);
 
-        return litShader.getDefinition(options);
+        const vIncludes = new Map(Object.entries({
+            ...Object.getPrototypeOf(litShader.chunks), // the prototype stores the default chunks
+            ...litShader.chunks,  // user overrides are supplied as instance properties
+            ...options.litOptions.chunks
+        }));
+
+        const defines = new Map(options.defines);
+
+        const definition = ShaderUtils.createDefinition(device, {
+            name: 'StandardShader',
+            attributes: litShader.attributes,
+            vertexCode: litShader.vshader,
+            fragmentCode: litShader.fshader,
+            vertexIncludes: vIncludes,
+            fragmentDefines: defines,
+            vertexDefines: defines
+        });
+
+        if (litShader.shaderPassInfo.isForward) {
+            definition.tag = SHADERTAG_MATERIAL;
+        }
+
+        return definition;
     }
 }
 


### PR DESCRIPTION
- moved `StandardMaterial.chunks` API from StandardMaterial to Material class, to make it available for all material types
- adjusted shader generators to use those in StandardMaterial, LitMaterial and ShaderMaterial, as those are based on chunks. All chunks, including material overrides are now available for the `#include` in the shader