### PR TITLE
Small gsplat init update

### DIFF
--- a/src/scene/gsplat/gsplat-sorter.js
+++ b/src/scene/gsplat/gsplat-sorter.js
@@ -251,6 +251,12 @@ class GSplatSorter extends EventHandler {
         const orderBuffer = this.orderTexture.lock({
             mode: TEXTURELOCK_READ
         }).buffer.slice();
+
+        // initialize order data
+        for (let i = 0; i < orderBuffer.length; ++i) {
+            orderBuffer[i] = i;
+        }
+
         this.orderTexture.unlock();
 
         // send the initial buffer to worker


### PR DESCRIPTION
This PR initialises the gsplat sorting buffer.

Without this initialisation, scenes can be rendered with the uninitialised order buffer (filled with 0's). This results in gaussian 0 being rendered millions of times. In some cases this can result in extremely slow rendering frames and even PC restarts.