### PR TITLE
Refactor Grid class initialization and set initial values

### DIFF
--- a/scripts/esm/grid.mjs
+++ b/scripts/esm/grid.mjs
@@ -184,16 +184,7 @@ class Grid extends Script {
      */
     _resolution = Grid.RESOLUTION_HIGH;
 
-    /**
-     * @param {ScriptArgs} args - The arguments.
-     */
-    constructor(args) {
-        super(args);
-        const {
-            colorX,
-            colorZ,
-            resolution
-        } = args.attributes;
+    initialize() {
 
         // ensure the entity has a render component
         if (!this.entity.render) {
@@ -220,9 +211,9 @@ class Grid extends Script {
         this.entity.render.meshInstances = [this._meshInstance];
 
         // set the initial values
-        this.colorX = colorX ?? this.colorX;
-        this.colorZ = colorZ ?? this.colorZ;
-        this.resolution = resolution ?? this.resolution;
+        this.colorX = this._colorX;
+        this.colorZ = this._colorZ;
+        this.resolution = this._resolution;
 
         // calculate half extents
         this._set('uHalfExtents', this._calcHalfExtents(tmpVa));
@@ -263,6 +254,11 @@ class Grid extends Script {
      * @private
      */
     _set(name, value) {
+
+        if (!this._material) {
+            return;
+        }
+
         if (value instanceof Color) {
             this._material.setParameter(name, [value.r, value.g, value.b]);
         }


### PR DESCRIPTION
Moves initialisation out of constructor into `initialize()`

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
