### PR TITLE
Refactor first-person controller script

### DIFF
--- a/examples/src/examples/camera/first-person.example.mjs
+++ b/examples/src/examples/camera/first-person.example.mjs
@@ -114,7 +114,7 @@ function createCharacterController(camera) {
     });
     entity.addComponent('script');
     entity.script.create(FirstPersonController, {
-        attributes: {
+        properties: {
             camera,
             jumpForce: 850
         }

--- a/scripts/esm/first-person-controller.mjs
+++ b/scripts/esm/first-person-controller.mjs
@@ -713,7 +713,6 @@ class FirstPersonController extends Script {
      */
     _gamePadInput;
 
-
     /**
      * @type {number}
      * @private
@@ -811,12 +810,7 @@ class FirstPersonController extends Script {
      */
     jumpForce = 600;
 
-    /**
-     * @param {object} args - The script arguments.
-     */
-    constructor(args) {
-        super(args);
-
+    initialize() {
         // input
         this._keyboardMouseInput = new KeyboardMouseInput(this.app);
         this._mobileInput = new MobileInput(this.app);
@@ -833,25 +827,7 @@ class FirstPersonController extends Script {
             this._gamePadInput.enabled = false;
         });
 
-        const {
-            camera,
-            lookSens,
-            speedGround,
-            speedAir,
-            sprintMult,
-            velocityDampingGround,
-            velocityDampingAir,
-            jumpForce,
-            mobileDeadZone,
-            mobileTurnSpeed,
-            mobileRadius,
-            mobileDoubleTapInterval,
-            gamePadDeadZoneLow,
-            gamePadDeadZoneHigh,
-            gamePadTurnSpeed
-        } = args.attributes;
-
-        if (!camera) {
+        if (!this.camera) {
             throw new Error('No camera entity found');
         }
         if (!this.entity.rigidbody) {
@@ -859,21 +835,11 @@ class FirstPersonController extends Script {
         }
         this._rigidbody = this.entity.rigidbody;
 
-        this.camera = camera;
-        this.lookSens = lookSens ?? this.lookSens;
-        this.speedGround = speedGround ?? this.speedGround;
-        this.speedAir = speedAir ?? this.speedAir;
-        this.sprintMult = sprintMult ?? this.sprintMult;
-        this.velocityDampingGround = velocityDampingGround ?? this.velocityDampingGround;
-        this.velocityDampingAir = velocityDampingAir ?? this.velocityDampingAir;
-        this.jumpForce = jumpForce ?? this.jumpForce;
-        this.mobileDeadZone = mobileDeadZone ?? this.mobileDeadZone;
-        this.mobileTurnSpeed = mobileTurnSpeed ?? this.mobileTurnSpeed;
-        this.mobileRadius = mobileRadius ?? this.mobileRadius;
-        this.mobileDoubleTapInterval = mobileDoubleTapInterval ?? this.mobileDoubleTapInterval;
-        this.gamePadDeadZoneLow = gamePadDeadZoneLow ?? this.gamePadDeadZoneLow;
-        this.gamePadDeadZoneHigh = gamePadDeadZoneHigh ?? this.gamePadDeadZoneHigh;
-        this.gamePadTurnSpeed = gamePadTurnSpeed ?? this.gamePadTurnSpeed;
+        this.mobileDeadZone = this._mobileDeadZone;
+        this.mobileTurnSpeed = this._mobileTurnSpeed;
+        this.gamePadDeadZoneLow = this._gamePadDeadZoneLow;
+        this.gamePadDeadZoneHigh = this._gamePadDeadZoneHigh;
+        this.gamePadTurnSpeed = this._gamePadTurnSpeed;
 
         this.app.on('cc:look', (movX, movY) => {
             this.look.x = math.clamp(this.look.x - movY * this.lookSens, -LOOK_MAX_ANGLE, LOOK_MAX_ANGLE);
@@ -907,11 +873,10 @@ class FirstPersonController extends Script {
      * @range [0, 0.4]
      */
     set mobileDeadZone(value) {
-        if (value === this._mobileDeadZone) {
-            return;
-        }
         this._mobileDeadZone = value;
-        this._mobileInput.deadZone = value;
+        if (this._mobileInput) {
+            this._mobileInput.deadZone = value;
+        }
     }
 
     get mobileDeadZone() {
@@ -925,11 +890,10 @@ class FirstPersonController extends Script {
      * @type {number}
      */
     set mobileTurnSpeed(value) {
-        if (value === this._mobileTurnSpeed) {
-            return;
-        }
         this._mobileTurnSpeed = value;
-        this._mobileInput.turnSpeed = value;
+        if (this._mobileInput) {
+            this._mobileInput.turnSpeed = value;
+        }
     }
 
     get mobileTurnSpeed() {
@@ -978,11 +942,10 @@ class FirstPersonController extends Script {
      * @range [0, 0.4]
      */
     set gamePadDeadZoneLow(value) {
-        if (value === this._gamePadDeadZoneLow) {
-            return;
-        }
         this._gamePadDeadZoneLow = value;
-        this._gamePadInput.deadZoneLow = value;
+        if (this._gamePadInput) {
+            this._gamePadInput.deadZoneLow = value;
+        }
     }
 
     get gamePadDeadZoneLow() {
@@ -997,11 +960,10 @@ class FirstPersonController extends Script {
      * @range [0, 0.4]
      */
     set gamePadDeadZoneHigh(value) {
-        if (value === this._gamePadDeadZoneHigh) {
-            return;
-        }
         this._gamePadDeadZoneHigh = value;
-        this._gamePadInput.deadZoneHigh = value;
+        if (this._gamePadInput) {
+            this._gamePadInput.deadZoneHigh = value;
+        }
     }
 
     get gamePadDeadZoneHigh() {
@@ -1015,11 +977,10 @@ class FirstPersonController extends Script {
      * @type {number}
      */
     set gamePadTurnSpeed(value) {
-        if (value === this._gamePadTurnSpeed) {
-            return;
-        }
         this._gamePadTurnSpeed = value;
-        this._gamePadInput.turnSpeed = value;
+        if (this._gamePadInput) {
+            this._gamePadInput.turnSpeed = value;
+        }
     }
 
     get gamePadTurnSpeed() {

--- a/scripts/esm/first-person-controller.mjs
+++ b/scripts/esm/first-person-controller.mjs
@@ -68,9 +68,9 @@ class KeyboardMouseInput {
         if (value === this._enabled) {
             return;
         }
-        this._enabled = value;
+        this._enabled = value ?? this._enabled;
 
-        if (value) {
+        if (this._enabled) {
             this._bind();
         } else {
             this._unbind();
@@ -300,9 +300,9 @@ class MobileInput {
         if (value === this._enabled) {
             return;
         }
-        this._enabled = value;
+        this._enabled = value ?? this._enabled;
 
-        if (value) {
+        if (this._enabled) {
             this._bind();
         } else {
             this._unbind();
@@ -575,7 +575,7 @@ class GamePadInput {
         if (value === this._enabled) {
             return;
         }
-        this._enabled = value;
+        this._enabled = value ?? this._enabled;
     }
 
     get enabled() {
@@ -894,7 +894,7 @@ class FirstPersonController extends Script {
     set mobileDeadZone(value) {
         this._mobileDeadZone = value ?? this._mobileDeadZone;
         if (this._mobileInput) {
-            this._mobileInput.deadZone = value;
+            this._mobileInput.deadZone = this._mobileDeadZone;
         }
     }
 
@@ -911,7 +911,7 @@ class FirstPersonController extends Script {
     set mobileTurnSpeed(value) {
         this._mobileTurnSpeed = value ?? this._mobileTurnSpeed;
         if (this._mobileInput) {
-            this._mobileInput.turnSpeed = value;
+            this._mobileInput.turnSpeed = this._mobileTurnSpeed;
         }
     }
 
@@ -957,7 +957,7 @@ class FirstPersonController extends Script {
     set gamePadDeadZoneLow(value) {
         this._gamePadDeadZoneLow = value ?? this._gamePadDeadZoneLow;
         if (this._gamePadInput) {
-            this._gamePadInput.deadZoneLow = value;
+            this._gamePadInput.deadZoneLow = this._gamePadDeadZoneLow;
         }
     }
 
@@ -975,7 +975,7 @@ class FirstPersonController extends Script {
     set gamePadDeadZoneHigh(value) {
         this._gamePadDeadZoneHigh = value ?? this._gamePadDeadZoneHigh;
         if (this._gamePadInput) {
-            this._gamePadInput.deadZoneHigh = value;
+            this._gamePadInput.deadZoneHigh = this._gamePadDeadZoneHigh;
         }
     }
 
@@ -992,7 +992,7 @@ class FirstPersonController extends Script {
     set gamePadTurnSpeed(value) {
         this._gamePadTurnSpeed = value ?? this._gamePadTurnSpeed;
         if (this._gamePadInput) {
-            this._gamePadInput.turnSpeed = value;
+            this._gamePadInput.turnSpeed = this._gamePadTurnSpeed;
         }
     }
 

--- a/scripts/esm/first-person-controller.mjs
+++ b/scripts/esm/first-person-controller.mjs
@@ -828,10 +828,29 @@ class FirstPersonController extends Script {
         });
 
         if (!this.camera) {
-            throw new Error('No camera entity found');
+            this.camera = this.entity.findComponent('camera').entity;
+            if (!this.camera) {
+                throw new Error('FirstPersonController expects a camera entity');
+            }
+        }
+        if (!this.entity.collision) {
+            this.entity.addComponent('collision', {
+                type: 'capsule',
+                radius: 0.5,
+                height: 2
+            });
         }
         if (!this.entity.rigidbody) {
-            throw new Error('No rigidbody component found');
+            this.entity.addComponent('rigidbody', {
+                type: 'dynamic',
+                mass: 100,
+                linearDamping: 0,
+                angularDamping: 0,
+                linearFactor: Vec3.ONE,
+                angularFactor: Vec3.ZERO,
+                friction: 0.5,
+                restitution: 0
+            });
         }
         this._rigidbody = this.entity.rigidbody;
 
@@ -873,7 +892,7 @@ class FirstPersonController extends Script {
      * @range [0, 0.4]
      */
     set mobileDeadZone(value) {
-        this._mobileDeadZone = value;
+        this._mobileDeadZone = value ?? this._mobileDeadZone;
         if (this._mobileInput) {
             this._mobileInput.deadZone = value;
         }
@@ -890,7 +909,7 @@ class FirstPersonController extends Script {
      * @type {number}
      */
     set mobileTurnSpeed(value) {
-        this._mobileTurnSpeed = value;
+        this._mobileTurnSpeed = value ?? this._mobileTurnSpeed;
         if (this._mobileInput) {
             this._mobileInput.turnSpeed = value;
         }
@@ -907,10 +926,7 @@ class FirstPersonController extends Script {
      * @type {number}
      */
     set mobileRadius(value) {
-        if (value === this._mobileRadius) {
-            return;
-        }
-        this._mobileRadius = value;
+        this._mobileRadius = value ?? this._mobileRadius;
     }
 
     get mobileRadius() {
@@ -924,10 +940,7 @@ class FirstPersonController extends Script {
      * @type {number}
      */
     set mobileDoubleTapInterval(value) {
-        if (value === this._mobileDoubleTapInterval) {
-            return;
-        }
-        this._mobileDoubleTapInterval = value;
+        this._mobileDoubleTapInterval = value ?? this._mobileDoubleTapInterval;
     }
 
     get mobileDoubleTapInterval() {
@@ -942,7 +955,7 @@ class FirstPersonController extends Script {
      * @range [0, 0.4]
      */
     set gamePadDeadZoneLow(value) {
-        this._gamePadDeadZoneLow = value;
+        this._gamePadDeadZoneLow = value ?? this._gamePadDeadZoneLow;
         if (this._gamePadInput) {
             this._gamePadInput.deadZoneLow = value;
         }
@@ -960,7 +973,7 @@ class FirstPersonController extends Script {
      * @range [0, 0.4]
      */
     set gamePadDeadZoneHigh(value) {
-        this._gamePadDeadZoneHigh = value;
+        this._gamePadDeadZoneHigh = value ?? this._gamePadDeadZoneHigh;
         if (this._gamePadInput) {
             this._gamePadInput.deadZoneHigh = value;
         }
@@ -977,7 +990,7 @@ class FirstPersonController extends Script {
      * @type {number}
      */
     set gamePadTurnSpeed(value) {
-        this._gamePadTurnSpeed = value;
+        this._gamePadTurnSpeed = value ?? this._gamePadTurnSpeed;
         if (this._gamePadInput) {
             this._gamePadInput.turnSpeed = value;
         }


### PR DESCRIPTION
Refactors First Person Controller script to use `initialize()` instead of the constructor

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
