### PR TITLE
[Fix] Splat shader didn’t have gamma decode functions when gamma output is disabled

### DIFF
--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatOutput.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatOutput.js
@@ -1,10 +1,10 @@
 export default /* glsl */`
 
 #include "tonemappingPS"
+#include "decodePS"
 
 #if TONEMAP != NONE
     #if GAMMA == SRGB
-        #include "decodePS"
         #include "gamma2_2PS"
     #else
         #include "gamma1_0PS"


### PR DESCRIPTION
- with gamma disabled, shader would fail to compile