### PR TITLE
[Fix] Fix frequent shader variant invalidation

### DIFF
--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -179,6 +179,8 @@ class Material {
      */
     _chunks = { };
 
+    _dirtyShader = true;
+
     /** @protected */
     constructor() {
         if (new.target === Material) {
@@ -192,7 +194,7 @@ class Material {
      * @type {Object<string, string>}
      */
     set chunks(value) {
-        this.clearVariants();
+        this._dirtyShader = true;
         this._chunks = value;
     }
 
@@ -202,7 +204,7 @@ class Material {
      * @type {Object<string, string>}
      */
     get chunks() {
-        this.clearVariants();
+        this._dirtyShader = true;
         return this._chunks;
     }
 
@@ -589,6 +591,9 @@ class Material {
     }
 
     updateUniforms(device, scene) {
+        if (this._dirtyShader) {
+            this.clearVariants();
+        }
     }
 
     /**

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -569,8 +569,6 @@ class StandardMaterial extends Material {
     constructor() {
         super();
 
-        this._dirtyShader = true;
-
         // storage for texture and cubemap asset references
         this._assetReferences = {};
 
@@ -800,9 +798,7 @@ class StandardMaterial extends Material {
         // remove unused params
         this._processParameters('_activeParams');
 
-        if (this._dirtyShader) {
-            this.clearVariants();
-        }
+        super.updateUniforms(device, scene);
     }
 
     updateEnvUniforms(device, scene) {

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -300,16 +300,13 @@ class ShadowRenderer {
                 material.dirty = false;
             }
 
-            if (material.chunks) {
+            renderer.setupCullMode(true, 1, meshInstance);
 
-                renderer.setupCullMode(true, 1, meshInstance);
+            // Uniforms I (shadow): material
+            material.setParameters(device);
 
-                // Uniforms I (shadow): material
-                material.setParameters(device);
-
-                // Uniforms II (shadow): meshInstance overrides
-                meshInstance.setParameters(device, passFlags);
-            }
+            // Uniforms II (shadow): meshInstance overrides
+            meshInstance.setParameters(device, passFlags);
 
             const shaderInstance = meshInstance.getShaderInstance(shadowPass, 0, scene, cameraShaderParams, this.viewUniformFormat, this.viewBindGroupFormat);
             const shadowShader = shaderInstance.shader;


### PR DESCRIPTION
Fix long term problem made worse in #7284

Basically:
- Material.chunks getter marks material as dirty, not only setter, as we don't know if chunks will be modified even then
- ShadowRenderer calls this getter, even though it only tests for its existence, invalidating variants
- now that all materials have chunks, this test can be removed