### PR TITLE
[Fix] Texture created by TextureAtlas respects its initial settings

### DIFF
--- a/src/framework/handlers/texture-atlas.js
+++ b/src/framework/handlers/texture-atlas.js
@@ -91,14 +91,14 @@ class TextureAtlasHandler extends ResourceHandler {
     }
 
     // Create texture atlas resource using the texture from the texture loader
-    open(url, data) {
+    open(url, data, asset) {
         const resource = new TextureAtlas();
         if (data.texture && data.data) {
             resource.texture = data.texture;
             resource.__data = data.data; // store data temporarily to be copied into asset
         } else {
             const handler = this._loader.getHandler('texture');
-            const texture = handler.open(url, data);
+            const texture = handler.open(url, data, asset);
             if (!texture) return null;
             resource.texture = texture;
         }


### PR DESCRIPTION
TextureAtlas under the hood creates a Texture by calling Open on its handler. We now pass an asset instance to it, allowing it to create the texture using initial settings, instead of depending on those settings to be set on Texture after the creation, which is currently not supported on WebGPU.

Fixes a warning during loading of  https://playcanvas.com/project/1295667/overview/webgpu-mips-warning

![Screenshot 2025-01-20 at 14 46 44](https://github.com/user-attachments/assets/9e6b51f8-e2d2-480d-b337-71fe3343e60c)
