### PR TITLE
[Fix] Preprocessor correctly updates position for text replacement

### DIFF
--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -201,7 +201,7 @@ class Preprocessor {
                             source = source.substring(0, define.index - 1) + source.substring(DEFINE.lastIndex);
 
                             // continue processing on the next symbol
-                            KEYWORD.lastIndex = define.index;
+                            KEYWORD.lastIndex = define.index - 1;
                         }
                     }
 
@@ -233,7 +233,7 @@ class Preprocessor {
                             source = source.substring(0, undef.index - 1) + source.substring(UNDEF.lastIndex);
 
                             // continue processing on the next symbol
-                            KEYWORD.lastIndex = undef.index;
+                            KEYWORD.lastIndex = undef.index - 1;
                         }
                     }
 
@@ -367,7 +367,7 @@ class Preprocessor {
                             source = source.substring(0, include.index - 1) + includeSource + source.substring(INCLUDE.lastIndex);
 
                             // process the just included test
-                            KEYWORD.lastIndex = include.index;
+                            KEYWORD.lastIndex = include.index - 1;
                         } else {
                             console.error(`Include "${identifier}" not resolved while preprocessing ${Preprocessor.sourceName}`, { source: originalSource });
                             error = true;


### PR DESCRIPTION
in my specific test case, a file with
```
#include "A"
```
would include content of A:
```
#include "B"
```

but as index after the A replacement was not correct, B was not recognized as an include.