### PR TITLE
WarnOnce in debug mode if material parameter is being set to undefined

### DIFF
--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -650,6 +650,13 @@ class Material {
     }
 
     _setParameterSimple(name, data) {
+
+        Debug.call(() => {
+            if (data === undefined) {
+                Debug.warnOnce(`Material#setParameter: Attempting to set undefined data for parameter "${name}", this is likely not expected.`);
+            }
+        });
+
         const param = this.parameters[name];
         if (param) {
             param.data = data;


### PR DESCRIPTION
as it's almost guaranteed to fail later when the value is needed for rendering.