### PR TITLE
Do not log warning when material data contains sheenGlossTint, which was removed

### DIFF
--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -188,7 +188,8 @@ const standardMaterialRemovedParameters = {
     diffuseTint: 'boolean',
     sheenTint: 'boolean',
     conserveEnergy: 'boolean',
-    useGamma: 'boolean'
+    useGamma: 'boolean',
+    sheenGlossTint: 'boolean'
 };
 
 export {

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -189,6 +189,7 @@ const standardMaterialRemovedParameters = {
     sheenTint: 'boolean',
     conserveEnergy: 'boolean',
     useGamma: 'boolean',
+    useGammaTonemap: 'boolean',
     sheenGlossTint: 'boolean'
 };
 


### PR DESCRIPTION
remove one of the warnings

![image](https://github.com/user-attachments/assets/ec2e7364-8cb0-4965-a919-e2f7d354d0d3)
