### PR TITLE
Shader WGSL example - split single shader into vertex and fragment

### DIFF
--- a/examples/src/examples/graphics/wgsl-shader.example.mjs
+++ b/examples/src/examples/graphics/wgsl-shader.example.mjs
@@ -46,8 +46,8 @@ app.on('destroy', () => {
 
 const material = new pc.ShaderMaterial({
     uniqueName: 'MyWGSLShader',
-    vertexCode: files['shader.wgsl'],
-    fragmentCode: files['shader.wgsl'],
+    vertexCode: files['shader.vert.wgsl'],
+    fragmentCode: files['shader.frag.wgsl'],
     shaderLanguage: pc.SHADERLANGUAGE_WGSL,
 
     // For now WGSL shaders need to provide their own bind group formats as they aren't processed.

--- a/examples/src/examples/graphics/wgsl-shader.shader.frag.wgsl
+++ b/examples/src/examples/graphics/wgsl-shader.shader.frag.wgsl
@@ -15,14 +15,6 @@ struct VertexOutput {
 @group(2) @binding(0) var<uniform> uvMesh : ub_mesh;
 @group(0) @binding(0) var<uniform> ubView : ub_view;
 
-@vertex
-fn vertexMain(@location(0) position : vec4f) -> VertexOutput {
-    var output : VertexOutput;
-    output.position = ubView.matrix_viewProjection * (uvMesh.matrix_model * position);
-    output.fragPosition = 0.5 * (position + vec4(1.0));
-    return output;
-}
-
 @fragment
 fn fragmentMain(input : VertexOutput) -> @location(0) vec4f {
     var color : vec3f = input.fragPosition.rgb;

--- a/examples/src/examples/graphics/wgsl-shader.shader.vert.wgsl
+++ b/examples/src/examples/graphics/wgsl-shader.shader.vert.wgsl
@@ -1,0 +1,28 @@
+struct ub_mesh {
+    matrix_model : mat4x4f,
+    amount : f32,
+}
+
+struct ub_view {
+    matrix_viewProjection : mat4x4f,
+}
+
+struct VertexOutput {
+    @builtin(position) position : vec4f,
+    @location(0) fragPosition: vec4f,
+}
+
+@group(2) @binding(0) var<uniform> uvMesh : ub_mesh;
+@group(0) @binding(0) var<uniform> ubView : ub_view;
+
+struct VertexInput {
+    @location(0) position : vec4f,
+}
+
+@vertex
+fn vertexMain(input : VertexInput) -> VertexOutput {
+    var output : VertexOutput;
+    output.position = ubView.matrix_viewProjection * (uvMesh.matrix_model * input.position);
+    output.fragPosition = 0.5 * (input.position + vec4(1.0));
+    return output;
+}


### PR DESCRIPTION
this is the typical way we create shaders, and will be used for prototyping of changes