### PR TITLE
Easier to override render pass used by the CameraFrame

### DIFF
--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -22,6 +22,7 @@ export { RenderPassDof } from './render-passes/render-pass-dof.js';
 export { RenderPassDownsample } from './render-passes/render-pass-downsample.js';
 export { RenderPassUpsample } from './render-passes/render-pass-upsample.js';
 export { RenderPassBloom } from './render-passes/render-pass-bloom.js';
+export { RenderPassPrepass } from './render-passes/render-pass-prepass.js';
 export { RenderPassSsao } from './render-passes/render-pass-ssao.js';
 export { RenderPassTAA } from './render-passes/render-pass-taa.js';
 export { CameraFrame } from './render-passes/camera-frame.js';

--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -320,7 +320,7 @@ class CameraFrame {
         Debug.assert(!this.renderPassCamera);
 
         const cameraComponent = this.cameraComponent;
-        this.renderPassCamera = new RenderPassCameraFrame(this.app, cameraComponent, this.options);
+        this.renderPassCamera = this.createRenderPass(this.app, cameraComponent);
         cameraComponent.renderPasses = [this.renderPassCamera];
     }
 
@@ -340,6 +340,18 @@ class CameraFrame {
         cameraComponent.gammaCorrection = GAMMA_SRGB;
 
         this.renderPassCamera = null;
+    }
+
+    /**
+     * Creates a render pass for the camera frame. Override this method to utilize a custom render
+     * pass, typically one that extends {@link RenderPassCameraFrame}.
+     *
+     * @param {AppBase} app - The application.
+     * @param {CameraComponent} cameraComponent - The camera component.
+     * @returns {RenderPassCameraFrame} - The render pass.
+     */
+    createRenderPass(app, cameraComponent) {
+        return new RenderPassCameraFrame(app, cameraComponent, this.options);
     }
 
     /**

--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -319,9 +319,8 @@ class CameraFrame {
     enable() {
         Debug.assert(!this.renderPassCamera);
 
-        const cameraComponent = this.cameraComponent;
-        this.renderPassCamera = this.createRenderPass(this.app, cameraComponent);
-        cameraComponent.renderPasses = [this.renderPassCamera];
+        this.renderPassCamera = this.createRenderPass();
+        this.cameraComponent.renderPasses = [this.renderPassCamera];
     }
 
     disable() {
@@ -346,12 +345,10 @@ class CameraFrame {
      * Creates a render pass for the camera frame. Override this method to utilize a custom render
      * pass, typically one that extends {@link RenderPassCameraFrame}.
      *
-     * @param {AppBase} app - The application.
-     * @param {CameraComponent} cameraComponent - The camera component.
      * @returns {RenderPassCameraFrame} - The render pass.
      */
-    createRenderPass(app, cameraComponent) {
-        return new RenderPassCameraFrame(app, cameraComponent, this.options);
+    createRenderPass() {
+        return new RenderPassCameraFrame(this.app, this.cameraComponent, this.options);
     }
 
     /**


### PR DESCRIPTION
- simplified a way for the user to use render pass based on the RenderPassCameraFrame, by allowing them to override the create render pass function
- also exposed the RenderPassPrepass as that can be useful for depth only rendering