### PR TITLE
[Fix] When CameraFrame is disabled, disable SSAO being applied during forward pass

### DIFF
--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -339,6 +339,9 @@ class CameraFrame {
         // no longer HDR rendering
         cameraComponent.gammaCorrection = GAMMA_SRGB;
 
+        // disable SSAO included in the lighting pass
+        cameraComponent.shaderParams.ssaoEnabled = false;
+
         this.renderPassCamera = null;
     }
 


### PR DESCRIPTION
- fix to disable lighting-time SSAO when CameraFrame is disabled, otherwise a black SSAO texture is sampled causing the scene ambient color to be black