### PR TITLE
Improvements to sRGB support by the Texture

### DIFF
--- a/src/framework/handlers/basis-worker.js
+++ b/src/framework/handlers/basis-worker.js
@@ -59,7 +59,7 @@ function BasisWorker() {
     // map of basis format to engine pixel format
     const basisToEngineMapping = (basisFormat, deviceDetails) => {
         switch (basisFormat) {
-            case BASIS_FORMAT.cTFETC1: return deviceDetails.formats.etc1 ? PIXEL_FORMAT.ETC1 : PIXEL_FORMAT.ETC2_RGB;
+            case BASIS_FORMAT.cTFETC1: return deviceDetails.formats.etc2 ? PIXEL_FORMAT.ETC2_RGB : PIXEL_FORMAT.ETC1;
             case BASIS_FORMAT.cTFETC2: return PIXEL_FORMAT.ETC2_RGBA;
             case BASIS_FORMAT.cTFBC1: return PIXEL_FORMAT.DXT1;
             case BASIS_FORMAT.cTFBC3: return PIXEL_FORMAT.DXT5;
@@ -136,7 +136,10 @@ function BasisWorker() {
                     return 'etc2';
                 }
             } else {
-                if (deviceDetails.formats.etc1 || deviceDetails.formats.etc2) {
+                if (deviceDetails.formats.etc2) {
+                    return 'etc2';
+                }
+                if (deviceDetails.formats.etc1) {
                     return 'etc1';
                 }
             }

--- a/src/framework/handlers/basis.js
+++ b/src/framework/handlers/basis.js
@@ -230,7 +230,7 @@ class BasisClient {
 
 // defaults
 const defaultNumWorkers = 1;
-const defaultRgbPriority = ['etc1', 'etc2', 'astc', 'dxt', 'pvr', 'atc'];
+const defaultRgbPriority = ['etc2', 'etc1', 'astc', 'dxt', 'pvr', 'atc'];
 const defaultRgbaPriority = ['astc', 'dxt', 'etc2', 'pvr', 'atc'];
 const defaultMaxRetries = 5;
 

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1159,6 +1159,24 @@ export const pixelFormatLinearToGamma = (format) => {
 };
 
 /**
+ * Returns the linear equivalent format for the supplied sRGB format. If it does not exist, the input
+ * format is returned. For example for {@link PIXELFORMAT_SRGBA8} the return value is
+ * {@link PIXELFORMAT_RGBA8}.
+ *
+ * @param {number} format - The texture format.
+ * @returns {number} The equivalent format without automatic sRGB conversion.
+ * @ignore
+ */
+export const pixelFormatGammaToLinear = (format) => {
+    for (const [key, value] of pixelFormatInfo) {
+        if (value.srgbFormat === format) {
+            return key;
+        }
+    }
+    return format;
+};
+
+/**
  * For a pixel format that stores color information, this function returns true if the texture
  * sample is in sRGB space and needs to be decoded to linear space.
  *

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -252,8 +252,8 @@ class WebglTexture {
                 this._glInternalFormat = device.extCompressedTextureS3TC_SRGB.COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT;
                 break;
             case PIXELFORMAT_ETC2_SRGB:
-                this._glFormat = gl.RGB;
-                this._glInternalFormat = device.extCompressedTextureETC.COMPRESSED_RGB8_ETC2;
+                this._glFormat = gl.SRGB;
+                this._glInternalFormat = device.extCompressedTextureETC.COMPRESSED_SRGB8_ETC2;
                 break;
             case PIXELFORMAT_ETC2_SRGBA:
                 this._glFormat = gl.SRGB_ALPHA;


### PR DESCRIPTION
### New API

- `Texture.srgb(boolean)` - allows the format of the texture to be switched between sRGB <-> linear. Expensive operation, intended mostly for use by the Editor, to give user an instant impact of the change. Warns of the high cost.

### Fixes

- fix to PIXELFORMAT_ETC2_SRGB format, which was not using SRGB format and so the texture was not being automatically decoded to linear format during sampling

### Other changes

- basis decoding used to prefer ETC1 format over ETC2 formats for RGB textures. This works the other way now, as support for these formats on android is 99.99% anyways, and ETC2 format has sRGB equivalent