### PR TITLE
Fix to msdf chunk to handle gamma space correctly

### DIFF
--- a/src/scene/shader-lib/chunks/common/frag/msdf.js
+++ b/src/scene/shader-lib/chunks/common/frag/msdf.js
@@ -26,6 +26,12 @@ varying vec2 shadow_offset;
 #endif
 
 vec4 applyMsdf(vec4 color) {
+
+    // Convert to linear space before processing
+    // TODO: ideally this would received the color in linear space, but that would require larger changes
+    // on the engine side, with the way premultiplied alpha is handled as well.
+    color.rgb = gammaCorrectInput(color.rgb);
+
     // sample the field
     vec3 tsample = texture2D(texture_msdfMap, vUv0).rgb;
     vec2 uvShdw = vUv0 - shadow_offset;
@@ -61,6 +67,9 @@ vec4 applyMsdf(vec4 color) {
 
     vec4 scolor = (shadow > outline) ? shadow * vec4(shadow_color.a * shadow_color.rgb, shadow_color.a) : tcolor;
     tcolor = mix(scolor, tcolor, outline);
+
+    // Convert back to gamma space before returning
+    tcolor.rgb = gammaCorrectOutput(tcolor.rgb);
     
     return tcolor;
 }

--- a/src/scene/shader-lib/chunks/common/frag/msdf.js
+++ b/src/scene/shader-lib/chunks/common/frag/msdf.js
@@ -28,7 +28,7 @@ varying vec2 shadow_offset;
 vec4 applyMsdf(vec4 color) {
 
     // Convert to linear space before processing
-    // TODO: ideally this would received the color in linear space, but that would require larger changes
+    // TODO: ideally this would receive the color in linear space, but that would require larger changes
     // on the engine side, with the way premultiplied alpha is handled as well.
     color.rgb = gammaCorrectInput(color.rgb);
 


### PR DESCRIPTION
related to change where UI shader is in linear space: https://github.com/playcanvas/engine/pull/6714
and this forum reported issue: https://forum.playcanvas.com/t/textelement-outline-appears-darker-in-engine-v2/38945

This fixes the applyMsdf to operate in linear space as well