### PR TITLE
[BREAKING] ShaderMaterial no longer auto includes gamma, tonemapping and fog code

### DIFF
--- a/examples/assets/scripts/misc/gooch-material.mjs
+++ b/examples/assets/scripts/misc/gooch-material.mjs
@@ -82,6 +82,10 @@ const createGoochMaterial = (texture, color) => {
             }
         `,
         fragmentCode: /* glsl */ `
+            #include "gammaPS"
+            #include "tonemappingPS"
+            #include "fogPS"
+
             varying float brightness;
             varying vec2 uv0;
 

--- a/examples/assets/scripts/misc/hatch-material.mjs
+++ b/examples/assets/scripts/misc/hatch-material.mjs
@@ -91,6 +91,15 @@ const createHatchMaterial = (device, textures) => {
             }
         `,
         fragmentCode: /* glsl */ `
+            // this gives us gamma correction functions, such as gammaCorrectOutput
+            #include "gammaPS"
+
+            // this give us tonemapping functionality: toneMap
+            #include "tonemappingPS"
+
+            // this gives us for functionality: addFog
+            #include "fogPS"
+
             varying float brightness;
             varying vec2 uv0;
 

--- a/examples/src/examples/graphics/reflection-planar.shader.frag
+++ b/examples/src/examples/graphics/reflection-planar.shader.frag
@@ -1,3 +1,5 @@
+#include "gammaPS"
+
 // engine built-in constant storing render target size in .xy and inverse size in .zw
 uniform vec4 uScreenSize;
 

--- a/examples/src/examples/graphics/shader-burn.shader.frag
+++ b/examples/src/examples/graphics/shader-burn.shader.frag
@@ -1,5 +1,4 @@
-
-precision mediump float;
+#include "gammaPS"
 
 varying vec2 vUv0;
 

--- a/examples/src/examples/graphics/shader-toon.shader.frag
+++ b/examples/src/examples/graphics/shader-toon.shader.frag
@@ -1,3 +1,4 @@
+#include "gammaPS"
 
 precision mediump float;
 varying float vertOutTexCoord;

--- a/examples/src/examples/graphics/shader-wobble.shader.frag
+++ b/examples/src/examples/graphics/shader-wobble.shader.frag
@@ -1,5 +1,4 @@
-
-precision mediump float;
+#include "gammaPS"
 
 uniform sampler2D uDiffuseMap;
 

--- a/examples/src/examples/graphics/shader-wobble.shader.vert
+++ b/examples/src/examples/graphics/shader-wobble.shader.vert
@@ -1,4 +1,3 @@
-
 attribute vec3 aPosition;
 attribute vec2 aUv0;
 

--- a/examples/src/examples/graphics/texture-array.ground.frag
+++ b/examples/src/examples/graphics/texture-array.ground.frag
@@ -1,3 +1,5 @@
+#include "gammaPS"
+
 varying vec2 vUv0;
 varying vec3 worldNormal;
 

--- a/examples/src/examples/graphics/texture-array.shader.frag
+++ b/examples/src/examples/graphics/texture-array.shader.frag
@@ -1,3 +1,5 @@
+#include "gammaPS"
+
 varying vec2 vUv0;
 varying vec3 worldNormal;
 uniform float uTime;

--- a/src/extras/gizmo/shape/shape.js
+++ b/src/extras/gizmo/shape/shape.js
@@ -56,6 +56,7 @@ const shaderDesc = {
         }
     `,
     fragmentCode: /* glsl */`
+        #include "gammaPS"
         precision highp float;
         varying vec4 vColor;
         void main(void) {

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -28,6 +28,7 @@ const lineShaderDesc = {
         }
     `,
     fragmentCode: /* glsl */ `
+        #include "gammaPS"
         varying vec4 color;
         void main(void) {
             gl_FragColor = vec4(gammaCorrectOutput(decodeGamma(color.rgb)), color.a);
@@ -137,6 +138,7 @@ class Immediate {
     getTextureShaderDesc(encoding) {
         const decodeFunc = ChunkUtils.decodeFunc(encoding);
         return this.getShaderDesc(`textureShader-${encoding}`, /* glsl */ `
+            #include "gammaPS"
             varying vec2 uv0;
             uniform sampler2D colorMap;
             void main (void) {
@@ -162,6 +164,7 @@ class Immediate {
     getDepthTextureShaderDesc() {
         return this.getShaderDesc('depthTextureShader', /* glsl */ `
             ${shaderChunks.screenDepthPS}
+            #include "gammaPS"
             varying vec2 uv0;
             void main() {
                 float depth = getLinearScreenDepth(getImageEffectUV(uv0)) * camera_params.x;

--- a/src/scene/materials/shader-material.js
+++ b/src/scene/materials/shader-material.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../core/debug.js';
 import { ShaderProcessorOptions } from '../../platform/graphics/shader-processor-options.js';
 import { SHADERDEF_INSTANCING, SHADERDEF_MORPH_NORMAL, SHADERDEF_MORPH_POSITION, SHADERDEF_MORPH_TEXTURE_BASED_INT, SHADERDEF_SKIN } from '../constants.js';
 import { getProgramLibrary } from '../shader-lib/get-program-library.js';
@@ -74,6 +75,11 @@ class ShaderMaterial extends Material {
      * @type {ShaderDesc|undefined}
      */
     set shaderDesc(value) {
+
+        if (value) {
+            Debug.assert(value.vertexCode, 'ShaderMaterial: shaderDesc must contain vertexCode');
+            Debug.assert(value.fragmentCode, 'ShaderMaterial: shaderDesc must contain fragmentCode');
+        }
 
         // shallow clone the object
         this._shaderDesc = value ? { ...value } : undefined;

--- a/src/scene/shader-lib/chunks/common/frag/decode.js
+++ b/src/scene/shader-lib/chunks/common/frag/decode.js
@@ -1,4 +1,8 @@
 export default /* glsl */`
+
+#ifndef _DECODE_INCLUDED_
+#define _DECODE_INCLUDED_
+
 vec3 decodeLinear(vec4 raw) {
     return raw.rgb;
 }
@@ -36,4 +40,6 @@ vec3 decodeRGBE(vec4 raw) {
 vec4 passThrough(vec4 raw) {
     return raw;
 }
+
+#endif
 `;

--- a/src/scene/shader-lib/chunks/common/frag/gamma.js
+++ b/src/scene/shader-lib/chunks/common/frag/gamma.js
@@ -1,4 +1,7 @@
 export default /* glsl */`
+
+#include "decodePS"
+
 #if (GAMMA == SRGB)
 
     float gammaCorrectInput(float color) {

--- a/src/scene/shader-lib/chunks/skybox/frag/skybox.js
+++ b/src/scene/shader-lib/chunks/skybox/frag/skybox.js
@@ -1,5 +1,7 @@
 export default /* glsl */`
     #include "envMultiplyPS"
+    #include "gammaPS"
+    #include "tonemappingPS"
 
     varying vec3 vViewDir;
     uniform float skyboxHighlightMultiplier;

--- a/src/scene/shader-lib/programs/shader-generator-shader.js
+++ b/src/scene/shader-lib/programs/shader-generator-shader.js
@@ -4,18 +4,6 @@ import { ShaderUtils } from '../../../platform/graphics/shader-utils.js';
 import { shaderChunks } from '../chunks/chunks.js';
 import { ShaderGenerator } from './shader-generator.js';
 
-const vShader = `
-    #include "userCode"
-`;
-
-const fShader = `
-    #include "decodePS"
-    #include "gammaPS"
-    #include "tonemappingPS"
-    #include "fogPS"
-    #include "userCode"
-`;
-
 class ShaderGeneratorShader extends ShaderGenerator {
     generateKey(options) {
 
@@ -71,7 +59,6 @@ class ShaderGeneratorShader extends ShaderGenerator {
             const includes = new Map(sharedIncludes);
             const defines = new Map(options.defines);
 
-            includes.set('userCode', desc.vertexCode);
             includes.set('transformInstancingVS', ''); // no default instancing, needs to be implemented in the user shader
 
             if (options.skin) defines.set('SKIN', true);
@@ -83,7 +70,7 @@ class ShaderGeneratorShader extends ShaderGenerator {
                 if (options.useMorphNormal) defines.set('MORPHING_NORMAL', true);
             }
 
-            definitionOptions.vertexCode = vShader;
+            definitionOptions.vertexCode = desc.vertexCode;
             definitionOptions.vertexIncludes = includes;
             definitionOptions.vertexDefines = defines;
         }
@@ -101,11 +88,9 @@ class ShaderGeneratorShader extends ShaderGenerator {
 
         } else {
             const includes = new Map(sharedIncludes);
-            includes.set('userCode', desc.fragmentCode);
-
             const defines = new Map(options.defines);
 
-            definitionOptions.fragmentCode = fShader;
+            definitionOptions.fragmentCode = desc.fragmentCode;
             definitionOptions.fragmentIncludes = includes;
             definitionOptions.fragmentDefines = defines;
         }


### PR DESCRIPTION
ShaderMaterial used to automatically include the mentioned chunks, equivalent to:
```
            #include "gammaPS"
            #include "tonemappingPS"
            #include "fogPS"
```

Now that ShaderMaterial has grown into a more general system that initially intended, this has been removed.

If the user uses relevant code functions:
```
      vec3 fogged = addFog(colorLinear);
      vec3 toneMapped = toneMap(fogged);
      gl_FragColor.rgb = gammaCorrectOutput(toneMapped);
```

they need to include the relevant functionality into their shader