### PR TITLE
When Texture.srgb is changed, shaders are reevaluated to be recreated

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -392,6 +392,14 @@ class GraphicsDevice extends EventHandler {
         height: 0
     };
 
+    /**
+     * A very heavy handed way to force all shaders to be rebuilt. Avoid using as much as possible.
+     *
+     * @type {boolean}
+     * @ignore
+     */
+    _shadersDirty = false;
+
     static EVENT_RESIZE = 'resizecanvas';
 
     constructor(canvas, options) {

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -797,8 +797,11 @@ class Texture {
      * property recreates the texture on the GPU, which is an expensive operation, so it is
      * preferable to create the texture with the correct format from the start. If the texture
      * format has no sRGB variant, this operation is ignored.
+     * This is not a public API and is used by Editor only to update rendering when the sRGB
+     * property is changed in the inspector. The higher cost is acceptable in this case.
      *
      * @type {boolean}
+     * @ignore
      */
     set srgb(value) {
         const currentSrgb = isSrgbPixelFormat(this.format);
@@ -812,6 +815,9 @@ class Texture {
                     Debug.warn(`Switching format of texture '${this.name}' to sRGB equivalent: ${pixelFormatInfo.get(this.format)?.name} -> ${pixelFormatInfo.get(srgbFormat)?.name}. This is an expensive operation, and the texture should be created using the right format to avoid this.`, this);
                     this._format = srgbFormat;
                     this.recreateImpl();
+
+                    // update all shaders to respect the encoding of the texture (needed by the standard material)
+                    this.device._shadersDirty = true;
                 }
 
             } else {
@@ -822,6 +828,9 @@ class Texture {
                     Debug.warn(`Switching format of texture '${this.name}' to linear equivalent: ${pixelFormatInfo.get(this.format)?.name} -> ${pixelFormatInfo.get(linearFormat)?.name}. This is an expensive operation, and the texture should be created using the right format to avoid this.`, this);
                     this._format = linearFormat;
                     this.recreateImpl();
+
+                    // update all shaders to respect the encoding of the texture (needed by the standard material)
+                    this.device._shadersDirty = true;
                 }
             }
         }

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1229,7 +1229,7 @@ class Renderer {
     beginFrame(comp) {
 
         const scene = this.scene;
-        const updateShaders = scene.updateShaders;
+        const updateShaders = scene.updateShaders || this.device._shadersDirty;
 
         let totalMeshInstances = 0;
         const layers = comp.layerList;
@@ -1266,9 +1266,10 @@ class Renderer {
 
         // update shaders if needed
         if (updateShaders) {
-            const onlyLitShaders = !scene.updateShaders;
+            const onlyLitShaders = !scene.updateShaders || !this.device._shadersDirty;
             this.updateShaders(_tempMeshInstances, onlyLitShaders);
             scene.updateShaders = false;
+            this.device._shadersDirty = false;
             scene._shaderVersion++;
         }
 


### PR DESCRIPTION
- this is depended on by the Editor’s inspector, when the srgb property of the texture changes. Shaders need to be updated to respect new texture encoding.