### PR TITLE
Skybox shaders on WebGPU use native WGSL chunks

### DIFF
--- a/src/platform/graphics/shader-chunks/frag/webgpu-wgsl.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu-wgsl.js
@@ -1,0 +1,2 @@
+export default /* wgsl */`
+`;

--- a/src/platform/graphics/shader-chunks/vert/webgpu-wgsl.js
+++ b/src/platform/graphics/shader-chunks/vert/webgpu-wgsl.js
@@ -1,0 +1,3 @@
+export default /* wgsl */`
+#define VERTEXSHADER
+`;

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -2,7 +2,7 @@ import { TRACEID_SHADER_ALLOC } from '../../core/constants.js';
 import { Debug } from '../../core/debug.js';
 import { platform } from '../../core/platform.js';
 import { Preprocessor } from '../../core/preprocessor.js';
-import { SHADERLANGUAGE_GLSL } from './constants.js';
+import { SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL } from './constants.js';
 import { DebugGraphics } from './debug-graphics.js';
 import { ShaderUtils } from './shader-utils.js';
 
@@ -118,9 +118,12 @@ class Shader {
             Debug.assert(definition.vshader, 'No vertex shader has been specified when creating a shader.');
             Debug.assert(definition.fshader, 'No fragment shader has been specified when creating a shader.');
 
+            const wgsl = definition.shaderLanguage === SHADERLANGUAGE_WGSL;
+
             // pre-process vertex shader source
             definition.vshader = Preprocessor.run(definition.vshader, definition.vincludes, {
-                sourceName: `vertex shader for ${this.label}`
+                sourceName: `vertex shader for ${this.label}`,
+                stripDefines: wgsl
             });
 
             // if no attributes are specified, try to extract the default names after the shader has been pre-processed
@@ -136,6 +139,7 @@ class Shader {
             // pre-process fragment shader source
             definition.fshader = Preprocessor.run(definition.fshader, definition.fincludes, {
                 stripUnusedColorAttachments,
+                stripDefines: wgsl,
                 sourceName: `fragment shader for ${this.label}`
             });
         }

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -1,0 +1,417 @@
+// import alphaTestPS from './standard/frag/alphaTest.js';
+// import ambientConstantPS from './lit/frag/ambientConstant.js';
+// import ambientEnvPS from './lit/frag/ambientEnv.js';
+// import ambientSHPS from './lit/frag/ambientSH.js';
+// import aoPS from './standard/frag/ao.js';
+// import aoDetailMapPS from './standard/frag/aoDetailMap.js';
+// import aoDiffuseOccPS from './lit/frag/aoDiffuseOcc.js';
+// import aoSpecOccPS from './lit/frag/aoSpecOcc.js';
+// import aoSpecOccConstPS from './lit/frag/aoSpecOccConst.js';
+// import aoSpecOccConstSimplePS from './lit/frag/aoSpecOccConstSimple.js';
+// import aoSpecOccSimplePS from './lit/frag/aoSpecOccSimple.js';
+// import basePS from './lit/frag/base.js';
+// import baseVS from './lit/vert/base.js';
+// import baseNineSlicedPS from './lit/frag/baseNineSliced.js';
+// import baseNineSlicedVS from './lit/vert/baseNineSliced.js';
+// import baseNineSlicedTiledPS from './lit/frag/baseNineSlicedTiled.js';
+// import bayerPS from './common/frag/bayer.js';
+// import blurVSMPS from './lit/frag/blurVSM.js';
+// import clearCoatPS from './standard/frag/clearCoat.js';
+// import clearCoatGlossPS from './standard/frag/clearCoatGloss.js';
+// import clearCoatNormalPS from './standard/frag/clearCoatNormal.js';
+// import clusteredLightUtilsPS from './lit/frag/clusteredLightUtils.js';
+// import clusteredLightCookiesPS from './lit/frag/clusteredLightCookies.js';
+// import clusteredLightShadowsPS from './lit/frag/clusteredLightShadows.js';
+// import clusteredLightPS from './lit/frag/clusteredLight.js';
+// import combinePS from './lit/frag/combine.js';
+// import cookiePS from './lit/frag/cookie.js';
+// import cubeMapProjectBoxPS from './lit/frag/cubeMapProjectBox.js';
+// import cubeMapProjectNonePS from './lit/frag/cubeMapProjectNone.js';
+// import cubeMapRotatePS from './lit/frag/cubeMapRotate.js';
+// import debugOutputPS from './lit/frag/debug-output.js';
+// import debugProcessFrontendPS from './lit/frag/debug-process-frontend.js';
+import decodePS from './common/frag/decode.js';
+// import detailModesPS from './standard/frag/detailModes.js';
+// import diffusePS from './standard/frag/diffuse.js';
+// import diffuseDetailMapPS from './standard/frag/diffuseDetailMap.js';
+// import emissivePS from './standard/frag/emissive.js';
+// import encodePS from './common/frag/encode.js';
+// import endPS from './lit/frag/end.js';
+// import endVS from './lit/vert/end.js';
+import envAtlasPS from './common/frag/envAtlas.js';
+// import envConstPS from './common/frag/envConst.js';
+import envMultiplyPS from './common/frag/envMultiply.js';
+// import falloffInvSquaredPS from './lit/frag/falloffInvSquared.js';
+// import falloffLinearPS from './lit/frag/falloffLinear.js';
+// import floatUnpackingPS from './lit/frag/float-unpacking.js';
+// import floatAsUintPS from './common/frag/float-as-uint.js';
+import fogPS from './common/frag/fog.js';
+// import fresnelSchlickPS from './lit/frag/fresnelSchlick.js';
+// import fullscreenQuadPS from './common/frag/fullscreenQuad.js';
+// import fullscreenQuadVS from './common/vert/fullscreenQuad.js';
+import gammaPS from './common/frag/gamma.js';
+// import gles3PS from '../../../platform/graphics/shader-chunks/frag/gles3.js';
+// import gles3VS from '../../../platform/graphics/shader-chunks/vert/gles3.js';
+// import glossPS from './standard/frag/gloss.js';
+// import gsplatCenterVS from './gsplat/vert/gsplatCenter.js';
+// import gsplatColorVS from './gsplat/vert/gsplatColor.js';
+// import gsplatCommonVS from './gsplat/vert/gsplatCommon.js';
+// import gsplatCompressedDataVS from './gsplat/vert/gsplatCompressedData.js';
+// import gsplatCompressedSHVS from './gsplat/vert/gsplatCompressedSH.js';
+// import gsplatCornerVS from './gsplat/vert/gsplatCorner.js';
+// import gsplatDataVS from './gsplat/vert/gsplatData.js';
+// import gsplatOutputVS from './gsplat/vert/gsplatOutput.js';
+// import gsplatPS from './gsplat/frag/gsplat.js';
+// import gsplatSHVS from './gsplat/vert/gsplatSH.js';
+// import gsplatSourceVS from './gsplat/vert/gsplatSource.js';
+// import gsplatVS from './gsplat/vert/gsplat.js';
+// import iridescenceDiffractionPS from './lit/frag/iridescenceDiffraction.js';
+// import iridescencePS from './standard/frag/iridescence.js';
+// import iridescenceThicknessPS from './standard/frag/iridescenceThickness.js';
+// import iorPS from './standard/frag/ior.js';
+// import lightDiffuseLambertPS from './lit/frag/lightDiffuseLambert.js';
+// import lightDirPointPS from './lit/frag/lightDirPoint.js';
+// import lightmapAddPS from './lit/frag/lightmapAdd.js';
+// import lightmapDirAddPS from './lit/frag/lightmapDirAdd.js';
+// import lightmapDirPS from './standard/frag/lightmapDir.js';
+// import lightmapSinglePS from './standard/frag/lightmapSingle.js';
+// import lightSpecularAnisoGGXPS from './lit/frag/lightSpecularAnisoGGX.js';
+// import lightSpecularBlinnPS from './lit/frag/lightSpecularBlinn.js';
+// import lightSheenPS from './lit/frag/lightSheen.js';
+// import linearizeDepthPS from './common/frag/linearizeDepth.js';
+// import litShaderArgsPS from './standard/frag/litShaderArgs.js';
+// import ltcPS from './lit/frag/ltc.js';
+// import metalnessPS from './standard/frag/metalness.js';
+// import msdfPS from './common/frag/msdf.js';
+// import metalnessModulatePS from './lit/frag/metalnessModulate.js';
+// import msdfVS from './common/vert/msdf.js';
+// import normalVS from './lit/vert/normal.js';
+// import normalCoreVS from './common/vert/normalCore.js';
+// import normalDetailMapPS from './standard/frag/normalDetailMap.js';
+// import normalMapPS from './standard/frag/normalMap.js';
+// import normalXYPS from './standard/frag/normalXY.js';
+// import normalXYZPS from './standard/frag/normalXYZ.js';
+// import opacityPS from './standard/frag/opacity.js';
+// import opacityDitherPS from './standard/frag/opacity-dither.js';
+// import outputPS from './lit/frag/output.js';
+// import outputAlphaPS from './lit/frag/outputAlpha.js';
+// import outputAlphaOpaquePS from './lit/frag/outputAlphaOpaque.js';
+// import outputAlphaPremulPS from './lit/frag/outputAlphaPremul.js';
+// import outputTex2DPS from './common/frag/outputTex2D.js';
+// import sheenPS from './standard/frag/sheen.js';
+// import sheenGlossPS from './standard/frag/sheenGloss.js';
+// import parallaxPS from './standard/frag/parallax.js';
+// import particlePS from './particle/frag/particle.js';
+// import particleVS from './particle/vert/particle.js';
+// import particleAnimFrameClampVS from './particle/vert/particleAnimFrameClamp.js';
+// import particleAnimFrameLoopVS from './particle/vert/particleAnimFrameLoop.js';
+// import particleAnimTexVS from './particle/vert/particleAnimTex.js';
+// import particleInputFloatPS from './particle/frag/particleInputFloat.js';
+// import particleInputRgba8PS from './particle/frag/particleInputRgba8.js';
+// import particleOutputFloatPS from './particle/frag/particleOutputFloat.js';
+// import particleOutputRgba8PS from './particle/frag/particleOutputRgba8.js';
+// import particleUpdaterAABBPS from './particle/frag/particleUpdaterAABB.js';
+// import particleUpdaterEndPS from './particle/frag/particleUpdaterEnd.js';
+// import particleUpdaterInitPS from './particle/frag/particleUpdaterInit.js';
+// import particleUpdaterNoRespawnPS from './particle/frag/particleUpdaterNoRespawn.js';
+// import particleUpdaterOnStopPS from './particle/frag/particleUpdaterOnStop.js';
+// import particleUpdaterRespawnPS from './particle/frag/particleUpdaterRespawn.js';
+// import particleUpdaterSpherePS from './particle/frag/particleUpdaterSphere.js';
+// import particleUpdaterStartPS from './particle/frag/particleUpdaterStart.js';
+// import particle_billboardVS from './particle/vert/particle_billboard.js';
+// import particle_blendAddPS from './particle/frag/particle_blendAdd.js';
+// import particle_blendMultiplyPS from './particle/frag/particle_blendMultiply.js';
+// import particle_blendNormalPS from './particle/frag/particle_blendNormal.js';
+// import particle_cpuVS from './particle/vert/particle_cpu.js';
+// import particle_cpu_endVS from './particle/vert/particle_cpu_end.js';
+// import particle_customFaceVS from './particle/vert/particle_customFace.js';
+// import particle_endPS from './particle/frag/particle_end.js';
+// import particle_endVS from './particle/vert/particle_end.js';
+// import particle_halflambertPS from './particle/frag/particle_halflambert.js';
+// import particle_initVS from './particle/vert/particle_init.js';
+// import particle_lambertPS from './particle/frag/particle_lambert.js';
+// import particle_lightingPS from './particle/frag/particle_lighting.js';
+// import particle_localShiftVS from './particle/vert/particle_localShift.js';
+// import particle_meshVS from './particle/vert/particle_mesh.js';
+// import particle_normalVS from './particle/vert/particle_normal.js';
+// import particle_normalMapPS from './particle/frag/particle_normalMap.js';
+// import particle_pointAlongVS from './particle/vert/particle_pointAlong.js';
+// import particle_softPS from './particle/frag/particle_soft.js';
+// import particle_softVS from './particle/vert/particle_soft.js';
+// import particle_stretchVS from './particle/vert/particle_stretch.js';
+// import particle_TBNVS from './particle/vert/particle_TBN.js';
+// import particle_wrapVS from './particle/vert/particle_wrap.js';
+// import pickPS from './common/frag/pick.js';
+// import reflDirPS from './lit/frag/reflDir.js';
+// import reflDirAnisoPS from './lit/frag/reflDirAniso.js';
+// import reflectionCCPS from './lit/frag/reflectionCC.js';
+// import reflectionCubePS from './lit/frag/reflectionCube.js';
+// import reflectionEnvHQPS from './lit/frag/reflectionEnvHQ.js';
+// import reflectionEnvPS from './lit/frag/reflectionEnv.js';
+// import reflectionSpherePS from './lit/frag/reflectionSphere.js';
+// import reflectionSheenPS from './lit/frag/reflectionSheen.js';
+// import refractionCubePS from './lit/frag/refractionCube.js';
+// import refractionDynamicPS from './lit/frag/refractionDynamic.js';
+// import reprojectPS from './common/frag/reproject.js';
+// import sampleCatmullRomPS from './common/frag/sampleCatmullRom.js';
+// import screenDepthPS from './common/frag/screenDepth.js';
+// import shadowCascadesPS from './lit/frag/shadowCascades.js';
+// import shadowEVSMPS from './lit/frag/shadowEVSM.js';
+// import shadowEVSMnPS from './lit/frag/shadowEVSMn.js';
+// import shadowPCSSPS from './lit/frag/shadowPCSS.js';
+// import shadowSampleCoordPS from './lit/frag/shadowSampleCoord.js';
+// import shadowSoftPS from './lit/frag/shadowSoft.js';
+// import shadowStandardPS from './lit/frag/shadowStandard.js';
+// import shadowStandardGL2PS from './lit/frag/shadowStandardGL2.js';
+// import shadowVSM_commonPS from './lit/frag/shadowVSM_common.js';
+// import skinBatchVS from './common/vert/skinBatch.js';
+// import skinVS from './common/vert/skin.js';
+import skyboxPS from './skybox/frag/skybox.js';
+import skyboxVS from './skybox/vert/skybox.js';
+// import specularPS from './standard/frag/specular.js';
+import sphericalPS from './common/frag/spherical.js';
+// import specularityFactorPS from './standard/frag/specularityFactor.js';
+// import spotPS from './lit/frag/spot.js';
+// import startPS from './lit/frag/start.js';
+// import startVS from './lit/vert/start.js';
+// import startNineSlicedPS from './lit/frag/startNineSliced.js';
+// import startNineSlicedTiledPS from './lit/frag/startNineSlicedTiled.js';
+// import storeEVSMPS from './lit/frag/storeEVSM.js';
+// import tangentBinormalVS from './lit/vert/tangentBinormal.js';
+// import TBNPS from './lit/frag/TBN.js';
+// import TBNderivativePS from './lit/frag/TBNderivative.js';
+// import TBNObjectSpacePS from './lit/frag/TBNObjectSpace.js';
+// import thicknessPS from './standard/frag/thickness.js';
+import tonemappingPS from './common/frag/tonemapping/tonemapping.js';
+import tonemappingAcesPS from './common/frag/tonemapping/tonemappingAces.js';
+import tonemappingAces2PS from './common/frag/tonemapping/tonemappingAces2.js';
+import tonemappingFilmicPS from './common/frag/tonemapping/tonemappingFilmic.js';
+import tonemappingHejlPS from './common/frag/tonemapping/tonemappingHejl.js';
+import tonemappingLinearPS from './common/frag/tonemapping/tonemappingLinear.js';
+import tonemappingNeutralPS from './common/frag/tonemapping/tonemappingNeutral.js';
+import tonemappingNonePS from './common/frag/tonemapping/tonemappingNone.js';
+// import transformVS from './common/vert/transform.js';
+// import transformCoreVS from './common/vert/transformCore.js';
+// import transformInstancingVS from './common/vert/transformInstancing.js';
+// import transmissionPS from './standard/frag/transmission.js';
+// import twoSidedLightingPS from './lit/frag/twoSidedLighting.js';
+// import uv0VS from './lit/vert/uv0.js';
+// import uv1VS from './lit/vert/uv1.js';
+// import viewDirPS from './lit/frag/viewDir.js';
+// import viewNormalVS from './lit/vert/viewNormal.js';
+// import webgpuPS from '../../../platform/graphics/shader-chunks/frag/webgpu.js';
+// import webgpuVS from '../../../platform/graphics/shader-chunks/vert/webgpu.js';
+
+/**
+ * Object containing all default WGSL shader chunks used by shader generators.
+ *
+ * @type {Record<string, string>}
+ * @category Graphics
+ */
+const shaderChunksWGSL = {
+    // alphaTestPS,
+    // ambientConstantPS,
+    // ambientEnvPS,
+    // ambientSHPS,
+    // aoPS,
+    // aoDetailMapPS,
+    // aoDiffuseOccPS,
+    // aoSpecOccPS,
+    // aoSpecOccConstPS,
+    // aoSpecOccConstSimplePS,
+    // aoSpecOccSimplePS,
+    // basePS,
+    // baseVS,
+    // baseNineSlicedPS,
+    // baseNineSlicedVS,
+    // baseNineSlicedTiledPS,
+    // bayerPS,
+    // blurVSMPS,
+    // clearCoatPS,
+    // clearCoatGlossPS,
+    // clearCoatNormalPS,
+    // clusteredLightCookiesPS,
+    // clusteredLightShadowsPS,
+    // clusteredLightUtilsPS,
+    // clusteredLightPS,
+    // combinePS,
+    // cookiePS,
+    // cubeMapProjectBoxPS,
+    // cubeMapProjectNonePS,
+    // cubeMapRotatePS,
+    // debugOutputPS,
+    // debugProcessFrontendPS,
+    // detailModesPS,
+    // diffusePS,
+    // diffuseDetailMapPS,
+    decodePS,
+    // emissivePS,
+    // encodePS,
+    // endPS,
+    // endVS,
+    envAtlasPS,
+    // envConstPS,
+    envMultiplyPS,
+    // falloffInvSquaredPS,
+    // falloffLinearPS,
+    // floatUnpackingPS,
+    // floatAsUintPS,
+    fogPS,
+    // fresnelSchlickPS,
+    // fullscreenQuadPS,
+    // fullscreenQuadVS,
+    gammaPS,
+    // gles3PS,
+    // gles3VS,
+    // glossPS,
+    // gsplatCenterVS,
+    // gsplatCornerVS,
+    // gsplatColorVS,
+    // gsplatCommonVS,
+    // gsplatCompressedDataVS,
+    // gsplatCompressedSHVS,
+    // gsplatDataVS,
+    // gsplatOutputVS,
+    // gsplatPS,
+    // gsplatSHVS,
+    // gsplatSourceVS,
+    // gsplatVS,
+    // iridescenceDiffractionPS,
+    // iridescencePS,
+    // iridescenceThicknessPS,
+    // iorPS,
+    // lightDiffuseLambertPS,
+    // lightDirPointPS,
+    // lightmapAddPS,
+    // lightmapDirAddPS,
+    // lightmapDirPS,
+    // lightmapSinglePS,
+    // lightSpecularAnisoGGXPS,
+    // lightSpecularBlinnPS,
+    // lightSheenPS,
+    // linearizeDepthPS,
+    // litShaderArgsPS,
+    // ltcPS,
+    // metalnessPS,
+    // metalnessModulatePS,
+    // msdfPS,
+    // msdfVS,
+    // normalVS,
+    // normalCoreVS,
+    // normalDetailMapPS,
+    // normalMapPS,
+    // normalXYPS,
+    // normalXYZPS,
+    // opacityPS,
+    // opacityDitherPS,
+    // outputPS,
+    // outputAlphaPS,
+    // outputAlphaOpaquePS,
+    // outputAlphaPremulPS,
+    // outputTex2DPS,
+    // sheenPS,
+    // sheenGlossPS,
+    // parallaxPS,
+    // particlePS,
+    // particleVS,
+    // particleAnimFrameClampVS,
+    // particleAnimFrameLoopVS,
+    // particleAnimTexVS,
+    // particleInputFloatPS,
+    // particleInputRgba8PS,
+    // particleOutputFloatPS,
+    // particleOutputRgba8PS,
+    // particleUpdaterAABBPS,
+    // particleUpdaterEndPS,
+    // particleUpdaterInitPS,
+    // particleUpdaterNoRespawnPS,
+    // particleUpdaterOnStopPS,
+    // particleUpdaterRespawnPS,
+    // particleUpdaterSpherePS,
+    // particleUpdaterStartPS,
+    // particle_billboardVS,
+    // particle_blendAddPS,
+    // particle_blendMultiplyPS,
+    // particle_blendNormalPS,
+    // particle_cpuVS,
+    // particle_cpu_endVS,
+    // particle_customFaceVS,
+    // particle_endPS,
+    // particle_endVS,
+    // particle_halflambertPS,
+    // particle_initVS,
+    // particle_lambertPS,
+    // particle_lightingPS,
+    // particle_localShiftVS,
+    // particle_meshVS,
+    // particle_normalVS,
+    // particle_normalMapPS,
+    // particle_pointAlongVS,
+    // particle_softPS,
+    // particle_softVS,
+    // particle_stretchVS,
+    // particle_TBNVS,
+    // particle_wrapVS,
+    // pickPS,
+    // reflDirPS,
+    // reflDirAnisoPS,
+    // reflectionCCPS,
+    // reflectionCubePS,
+    // reflectionEnvHQPS,
+    // reflectionEnvPS,
+    // reflectionSpherePS,
+    // reflectionSheenPS,
+    // refractionCubePS,
+    // refractionDynamicPS,
+    // reprojectPS,
+    // sampleCatmullRomPS,
+    // screenDepthPS,
+    // shadowCascadesPS,
+    // shadowEVSMPS,
+    // shadowEVSMnPS,
+    // shadowPCSSPS,
+    // shadowSampleCoordPS,
+    // shadowSoftPS,
+    // shadowStandardPS,
+    // shadowStandardGL2PS,
+    // shadowVSM_commonPS,
+    // skinBatchVS,
+    // skinVS,
+    skyboxPS,
+    skyboxVS,
+    // specularPS,
+    sphericalPS,
+    // specularityFactorPS,
+    // spotPS,
+    // startPS,
+    // startVS,
+    // startNineSlicedPS,
+    // startNineSlicedTiledPS,
+    // storeEVSMPS,
+    // tangentBinormalVS,
+    // TBNPS,
+    // TBNderivativePS,
+    // TBNObjectSpacePS,
+    // thicknessPS,
+    tonemappingPS,
+    tonemappingAcesPS,
+    tonemappingAces2PS,
+    tonemappingFilmicPS,
+    tonemappingHejlPS,
+    tonemappingLinearPS,
+    tonemappingNeutralPS,
+    tonemappingNonePS,
+    // transformVS,
+    // transformCoreVS,
+    // transformInstancingVS,
+    // transmissionPS,
+    // twoSidedLightingPS,
+    // uv0VS,
+    // uv1VS,
+    // viewDirPS,
+    // viewNormalVS,
+    // webgpuPS,
+    // webgpuVS
+};
+
+export { shaderChunksWGSL };

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -400,7 +400,7 @@ const shaderChunksWGSL = {
     tonemappingHejlPS,
     tonemappingLinearPS,
     tonemappingNeutralPS,
-    tonemappingNonePS,
+    tonemappingNonePS
     // transformVS,
     // transformCoreVS,
     // transformInstancingVS,

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/decode.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/decode.js
@@ -1,0 +1,41 @@
+export default /* glsl */`
+
+#ifndef _DECODE_INCLUDED_
+#define _DECODE_INCLUDED_
+
+fn decodeLinear(raw: vec4f) -> vec3f {
+    return raw.rgb;
+}
+
+fn decodeGamma(raw: f32) -> f32 {
+    return pow(raw, 2.2);
+}
+
+fn decodeGammaVec3(raw: vec3f) -> vec3f {
+    return pow(raw, vec3f(2.2));
+}
+
+fn decodeGammaVec4(raw: vec4f) -> vec3f {
+    return pow(raw.xyz, vec3f(2.2));
+}
+
+fn decodeRGBM(raw: vec4f) -> vec3f {
+    let color = (8.0 * raw.a) * raw.rgb;
+    return color * color;
+}
+
+fn decodeRGBP(raw: vec4f) -> vec3f {
+    let color = raw.rgb * (-raw.a * 7.0 + 8.0);
+    return color * color;
+}
+
+fn decodeRGBE(raw: vec4f) -> vec3f {
+    return select(vec3f(0.0), raw.xyz * pow(2.0, raw.w * 255.0 - 128.0), raw.a != 0.0);
+}
+
+fn passThrough(raw: vec4f) -> vec4f {
+    return raw;
+}
+
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/envAtlas.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/envAtlas.js
@@ -1,0 +1,23 @@
+export default /* wgsl */`
+// the envAtlas is fixed at 512 pixels. every equirect is generated with 1 pixel boundary.
+const atlasSize : f32 = 512.0;
+const seamSize : f32 = 1.0 / atlasSize;
+
+// map a normalized equirect UV to the given rectangle (taking 1 pixel seam into account).
+fn mapUv(uv : vec2f, rect : vec4f) -> vec2f {
+    return vec2f(mix(rect.x + seamSize, rect.x + rect.z - seamSize, uv.x),
+                 mix(rect.y + seamSize, rect.y + rect.w - seamSize, uv.y));
+}
+
+// map a normalized equirect UV and roughness level to the correct atlas rect.
+fn mapRoughnessUv(uv : vec2f, level : f32) -> vec2f {
+    let t : f32 = 1.0 / exp2(level);
+    return mapUv(uv, vec4f(0.0, 1.0 - t, t, t * 0.5));
+}
+
+// map shiny level UV
+fn mapShinyUv(uv : vec2f, level : f32) -> vec2f {
+    let t : f32 = 1.0 / exp2(level);
+    return mapUv(uv, vec4f(1.0 - t, 1.0 - t, t, t * 0.5));
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/envMultiply.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/envMultiply.js
@@ -1,0 +1,7 @@
+export default /* wgsl */`
+uniform skyboxIntensity : f32;
+
+fn processEnvironment(color : vec3f) -> vec3f {
+    return color * uniform.skyboxIntensity;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/fog.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/fog.js
@@ -1,0 +1,44 @@
+export default /* glsl */`
+
+#if (FOG != NONE)
+    uniform fog_color : vec3f;
+    
+    #if (FOG == LINEAR)
+        uniform fog_start : f32;
+        uniform fog_end : f32;
+    #else
+        uniform fog_density : f32;
+    #endif
+#endif
+
+uniform dBlendModeFogFactor : f32;
+
+fn getFogFactor() -> f32 {
+    //let depth = gl_FragCoord.z / gl_FragCoord.w;
+    let depth = 1.0;
+
+
+
+
+
+    var fogFactor : f32 = 0.0;
+
+    #if (FOG == LINEAR)
+        fogFactor = (uniform.fog_end - depth) / (uniform.fog_end - uniform.fog_start);
+    #elif (FOG == EXP)
+        fogFactor = exp(-depth * uniform.fog_density);
+    #elif (FOG == EXP2)
+        fogFactor = exp(-depth * depth * uniform.fog_density * uniform.fog_density);
+    #endif
+
+    return clamp(fogFactor, 0.0, 1.0);
+}
+
+fn addFog(color : vec3f) -> vec3f {
+    #if (FOG != NONE)
+        return mix(uniform.fog_color * uniform.dBlendModeFogFactor, color, getFogFactor());
+    #else
+        return color;
+    #endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/fog.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/fog.js
@@ -14,12 +14,10 @@ export default /* glsl */`
 uniform dBlendModeFogFactor : f32;
 
 fn getFogFactor() -> f32 {
-    //let depth = gl_FragCoord.z / gl_FragCoord.w;
+
+    // TODO: find a way to do this in WGSL, for now the fog is not working
+    // let depth = gl_FragCoord.z / gl_FragCoord.w;
     let depth = 1.0;
-
-
-
-
 
     var fogFactor : f32 = 0.0;
 

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/gamma.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/gamma.js
@@ -1,0 +1,42 @@
+export default /* glsl */`
+
+#include "decodePS"
+
+#if (GAMMA == SRGB)
+
+    fn gammaCorrectInput(color: f32) -> f32 {
+        return decodeGamma(color);
+    }
+
+    fn gammaCorrectInputVec3(color: vec3f) -> vec3f {
+        return decodeGammaVec3(color);
+    }
+
+    fn gammaCorrectInputVec4(color: vec4f) -> vec4f {
+        return vec4f(decodeGammaVec3(color.xyz), color.w);
+    }
+
+    fn gammaCorrectOutput(color: vec3f) -> vec3f {
+        return pow(color + 0.0000001, vec3f(1.0 / 2.2));
+    }
+
+#else // NONE
+
+    fn gammaCorrectInput(color: f32) -> f32 {
+        return color;
+    }
+
+    fn gammaCorrectInputVec3(color: vec3f) -> vec3f {
+        return color;
+    }
+
+    fn gammaCorrectInputVec4(color: vec4f) -> vec4f {
+        return color;
+    }
+
+    fn gammaCorrectOutput(color: vec3f) -> vec3f {
+        return color;
+    }
+
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/spherical.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/spherical.js
@@ -1,0 +1,14 @@
+export default /* wgsl */`
+// equirectangular helper functions
+const PI : f32 = 3.141592653589793;
+
+fn toSpherical(dir: vec3f) -> vec2f {
+    let angle_xz = select(0.0, atan2(dir.x, dir.z), any(dir.xz != vec2f(0.0)));
+    return vec2f(angle_xz, asin(dir.y));
+}
+
+fn toSphericalUv(dir : vec3f) -> vec2f {
+    let uv : vec2f = toSpherical(dir) / vec2f(PI * 2.0, PI) + vec2f(0.5, 0.5);
+    return vec2f(uv.x, 1.0 - uv.y);
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemapping.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemapping.js
@@ -1,0 +1,17 @@
+export default /* glsl */`
+#if (TONEMAP == NONE)
+    #include "tonemappingNonePS"
+#elif TONEMAP == FILMIC
+    #include "tonemappingFilmicPS"
+#elif TONEMAP == LINEAR
+    #include "tonemappingLinearPS"
+#elif TONEMAP == HEJL
+    #include "tonemappingHejlPS"
+#elif TONEMAP == ACES
+    #include "tonemappingAcesPS"
+#elif TONEMAP == ACES2
+    #include "tonemappingAces2PS"
+#elif TONEMAP == NEUTRAL
+    #include "tonemappingNeutralPS"
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingAces.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingAces.js
@@ -1,0 +1,13 @@
+export default /* glsl */`
+uniform exposure: f32;
+
+fn toneMap(color: vec3f) -> vec3f {
+    let tA: f32 = 2.51;
+    let tB: f32 = 0.03;
+    let tC: f32 = 2.43;
+    let tD: f32 = 0.59;
+    let tE: f32 = 0.14;
+    let x: vec3f = color * uniform.exposure;
+    return (x * (tA * x + tB)) / (x * (tC * x + tD) + tE);
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingAces2.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingAces2.js
@@ -1,0 +1,37 @@
+export default /* glsl */`
+uniform exposure: f32;
+
+// ACES approximation by Stephen Hill
+
+// sRGB => XYZ => D65_2_D60 => AP1 => RRT_SAT
+const ACESInputMat: mat3x3f = mat3x3f(
+    vec3f(0.59719, 0.35458, 0.04823),
+    vec3f(0.07600, 0.90834, 0.01566),
+    vec3f(0.02840, 0.13383, 0.83777)
+);
+
+// ODT_SAT => XYZ => D60_2_D65 => sRGB
+const ACESOutputMat: mat3x3f = mat3x3f(
+    vec3f( 1.60475, -0.53108, -0.07367),
+    vec3f(-0.10208,  1.10813, -0.00605),
+    vec3f(-0.00327, -0.07276,  1.07602)
+);
+
+fn RRTAndODTFit(v: vec3f) -> vec3f {
+    let a: vec3f = v * (v + vec3f(0.0245786)) - vec3f(0.000090537);
+    let b: vec3f = v * (vec3f(0.983729) * v + vec3f(0.4329510)) + vec3f(0.238081);
+    return a / b;
+}
+
+fn toneMap(color: vec3f) -> vec3f {
+    var c: vec3f = color * (uniform.exposure / 0.6);
+    c = ACESInputMat * c;
+
+    // Apply RRT and ODT
+    c = RRTAndODTFit(c);
+    c = ACESOutputMat * c;
+
+    // Clamp to [0, 1]
+    return clamp(c, vec3f(0.0), vec3f(1.0));
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingFilmic.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingFilmic.js
@@ -1,0 +1,22 @@
+export default /* glsl */`
+const A: f32 = 0.15;
+const B: f32 = 0.50;
+const C: f32 = 0.10;
+const D: f32 = 0.20;
+const E: f32 = 0.02;
+const F: f32 = 0.30;
+const W: f32 = 11.2;
+
+uniform exposure: f32;
+
+fn uncharted2Tonemap(x: vec3f) -> vec3f {
+    return ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - vec3f(E / F);
+}
+
+fn toneMap(color: vec3f) -> vec3f {
+    var c: vec3f = uncharted2Tonemap(color * uniform.exposure);
+    let whiteScale: vec3f = vec3f(1.0) / uncharted2Tonemap(vec3f(W, W, W));
+    c *= whiteScale;
+    return c;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingHejl.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingHejl.js
@@ -1,0 +1,20 @@
+export default /* glsl */`
+uniform exposure: f32;
+
+fn toneMap(color: vec3f) -> vec3f {
+    let A: f32 = 0.22;
+    let B: f32 = 0.3;
+    let C: f32 = 0.1;
+    let D: f32 = 0.2;
+    let E: f32 = 0.01;
+    let F: f32 = 0.3;
+    let Scl: f32 = 1.25;
+
+    let adjusted_color = color * uniform.exposure;
+    let h = max(vec3f(0.0), adjusted_color - vec3f(0.004));
+
+    return (h * ((Scl * A) * h + Scl * vec3f(C * B)) + Scl * vec3f(D * E)) /
+           (h * (A * h + vec3f(B)) + vec3f(D * F)) -
+           Scl * vec3f(E / F);
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingLinear.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingLinear.js
@@ -1,0 +1,7 @@
+export default /* glsl */`
+uniform exposure: f32;
+
+fn toneMap(color: vec3f) -> vec3f {
+    return color * uniform.exposure;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingNeutral.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingNeutral.js
@@ -1,0 +1,27 @@
+// https://modelviewer.dev/examples/tone-mapping
+export default /* glsl */`
+uniform exposure: f32;
+
+fn toneMap(col: vec3f) -> vec3f {
+    var color = col * uniform.exposure;
+
+    let startCompression = 0.8 - 0.04;
+    let desaturation = 0.15;
+
+    let x = min(color.r, min(color.g, color.b));
+    let offset = select(0.04, x - 6.25 * x * x, x < 0.08);
+    color -= vec3f(offset);
+
+    let peak = max(color.r, max(color.g, color.b));
+    if (peak < startCompression) {
+        return color;
+    }
+
+    let d = 1.0 - startCompression;
+    let newPeak = 1.0 - d * d / (peak + d - startCompression);
+    color *= newPeak / peak;
+
+    let g = 1.0 - 1.0 / (desaturation * (peak - newPeak) + 1.0);
+    return mix(color, vec3f(newPeak), vec3f(g));
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingNone.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/tonemapping/tonemappingNone.js
@@ -1,0 +1,5 @@
+export default /* glsl */`
+fn toneMap(color: vec3f) -> vec3f {
+    return color;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/skybox/frag/skybox.js
+++ b/src/scene/shader-lib/chunks-wgsl/skybox/frag/skybox.js
@@ -1,0 +1,69 @@
+export default /* wgsl */`
+    #include "envMultiplyPS"
+    #include "gammaPS"
+    #include "tonemappingPS"
+
+    // Varying and uniform declarations
+    varying vViewDir : vec3f;
+    uniform skyboxHighlightMultiplier : f32;
+
+    #ifdef SKY_CUBEMAP
+
+        var texture_cubeMap : texture_cube<f32>;
+        var texture_cubeMap_sampler : sampler;
+
+        #ifdef SKYMESH
+            varying vWorldPos : vec3f;
+            uniform cubeMapRotationMatrix : mat3x3f;
+            uniform projectedSkydomeCenter : vec3f;
+        #endif
+
+    #else // env-atlas
+
+        #include "sphericalPS"
+        #include "envAtlasPS"
+
+        var texture_envAtlas : texture_2d<f32>;
+        var texture_envAtlas_sampler : sampler;
+
+        uniform mipLevel : f32;
+
+    #endif
+
+    @fragment
+    fn fragmentMain(input : FragmentInput) -> FragmentOutput {
+
+        var linear : vec3f;
+        var dir : vec3f;
+
+        #ifdef SKY_CUBEMAP
+
+            #ifdef SKYMESH
+                // get vector from world space pos to tripod origin
+                var envDir : vec3f = normalize(input.vWorldPos - uniform.projectedSkydomeCenter);
+                dir = envDir * uniform.cubeMapRotationMatrix;
+            #else
+                dir = input.vViewDir;
+            #endif
+
+            dir.x *= -1.0;
+            linear = __INJECT_SKYBOX_DECODE_FNC(textureSample(texture_cubeMap, texture_cubeMap_sampler, dir));
+
+        #else // env-atlas
+
+            dir = input.vViewDir * vec3f(-1.0, 1.0, 1.0);
+            let uv : vec2f = toSphericalUv(normalize(dir));
+            linear = __INJECT_SKYBOX_DECODE_FNC(textureSample(texture_envAtlas, texture_envAtlas_sampler, mapRoughnessUv(uv, uniform.mipLevel)));
+
+        #endif
+
+        // our HDR encodes values up to 64, so allow extra brightness for the clipped values
+        if (any(linear >= vec3f(64.0))) {
+            linear *= uniform.skyboxHighlightMultiplier;
+        }
+        
+        var output: FragmentOutput;
+        output.color = vec4f(gammaCorrectOutput(toneMap(processEnvironment(linear))), 1.0);
+        return output;
+    }
+`;

--- a/src/scene/shader-lib/chunks-wgsl/skybox/vert/skybox.js
+++ b/src/scene/shader-lib/chunks-wgsl/skybox/vert/skybox.js
@@ -1,0 +1,51 @@
+export default /* wgsl */`
+    // Attribute
+    attribute aPosition : vec4f;
+
+    #ifndef VIEWMATRIX
+    #define VIEWMATRIX
+    uniform matrix_view : mat4x4f;
+    #endif
+
+    uniform matrix_projectionSkybox : mat4x4f;
+    uniform cubeMapRotationMatrix : mat3x3f;
+
+    varying vViewDir : vec3f;
+
+    #ifdef SKYMESH
+        uniform matrix_model : mat4x4f;
+        varying vWorldPos : vec3f;
+    #endif
+
+    @vertex
+    fn vertexMain(input : VertexInput) -> VertexOutput {
+
+        var output : VertexOutput;
+        var view : mat4x4f = uniform.matrix_view;
+
+        #ifdef SKYMESH
+
+            var worldPos : vec4f = uniform.matrix_model * input.aPosition;
+            output.vWorldPos = worldPos.xyz;
+            output.position = uniform.matrix_projectionSkybox * (view * worldPos);
+
+        #else
+
+            view[3][0] = 0.0;
+            view[3][1] = 0.0;
+            view[3][2] = 0.0;
+            output.position = uniform.matrix_projectionSkybox * (view * input.aPosition);
+            output.vViewDir = input.aPosition.xyz * uniform.cubeMapRotationMatrix;
+
+        #endif
+
+        // Force skybox to far Z, regardless of the clip planes on the camera
+        // Subtract a tiny fudge factor to ensure floating point errors don't
+        // still push pixels beyond far Z. See:
+        // https://community.khronos.org/t/skybox-problem/61857
+
+        output.position.z = output.position.w - 1.0e-7;
+
+        return output;
+    }
+`;

--- a/src/scene/shader-lib/chunks/skybox/vert/skybox.js
+++ b/src/scene/shader-lib/chunks/skybox/vert/skybox.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-attribute vec3 aPosition;
+attribute vec4 aPosition;
 
 #ifndef VIEWMATRIX
 #define VIEWMATRIX
@@ -22,15 +22,15 @@ void main(void) {
 
     #ifdef SKYMESH
 
-        vec4 worldPos = matrix_model * vec4(aPosition, 1.0);
+        vec4 worldPos = matrix_model * aPosition;
         vWorldPos = worldPos.xyz;
-        gl_Position = matrix_projectionSkybox * view * worldPos;
+        gl_Position = matrix_projectionSkybox * (view * worldPos);
 
     #else
 
         view[3][0] = view[3][1] = view[3][2] = 0.0;
-        gl_Position = matrix_projectionSkybox * view * vec4(aPosition, 1.0);
-        vViewDir = aPosition * cubeMapRotationMatrix;
+        gl_Position = matrix_projectionSkybox * (view * aPosition);
+        vViewDir = aPosition.xyz * cubeMapRotationMatrix;
 
     #endif
 

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -1,8 +1,9 @@
-import { CULLFACE_FRONT, SEMANTIC_POSITION } from '../../platform/graphics/constants.js';
+import { CULLFACE_FRONT, SEMANTIC_POSITION, SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL } from '../../platform/graphics/constants.js';
 import { LAYERID_SKYBOX, SKYTYPE_INFINITE } from '../constants.js';
 import { ShaderMaterial } from '../materials/shader-material.js';
 import { MeshInstance } from '../mesh-instance.js';
 import { ChunkUtils } from '../shader-lib/chunk-utils.js';
+import { shaderChunksWGSL } from '../shader-lib/chunks-wgsl/chunks-wgsl.js';
 import { shaderChunks } from '../shader-lib/chunks/chunks.js';
 import { SkyGeometry } from './sky-geometry.js';
 
@@ -33,10 +34,12 @@ class SkyMesh {
      */
     constructor(device, scene, node, texture, type) {
 
+        const wgsl = device.isWebGPU;
         const material = new ShaderMaterial({
             uniqueName: 'SkyMaterial',
-            vertexCode: shaderChunks.skyboxVS,
-            fragmentCode: shaderChunks.skyboxPS,
+            vertexCode: wgsl ? shaderChunksWGSL.skyboxVS : shaderChunks.skyboxVS,
+            fragmentCode: wgsl ? shaderChunksWGSL.skyboxPS : shaderChunks.skyboxPS,
+            shaderLanguage: wgsl ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL,
             attributes: {
                 aPosition: SEMANTIC_POSITION
             }
@@ -46,7 +49,6 @@ class SkyMesh {
         material.setDefine('__INJECT_SKYBOX_DECODE_FNC', ChunkUtils.decodeFunc(texture.encoding));
         if (type !== SKYTYPE_INFINITE) material.setDefine('SKYMESH', '');
         if (texture.cubemap) material.setDefine('SKY_CUBEMAP', '');
-
 
         material.setParameter('skyboxHighlightMultiplier', scene.skyboxHighlightMultiplier);
 


### PR DESCRIPTION
- upgrade to ShaderMaterial shader generation to better support WGSL shaders
- converted skydome shaders to use native WGSL shader generation and avoid GLSL->WGSL transpilation completely

Note: Fog does not currently functions as `gl_FragCoord.z / gl_FragCoord.w` needs replacement - this are not global variables in WGSL