### PR TITLE
Make camera controls more sensitive to trackpad pinch

### DIFF
--- a/scripts/esm/camera-controls.mjs
+++ b/scripts/esm/camera-controls.mjs
@@ -710,7 +710,9 @@ class CameraControls extends Script {
      */
     _onWheel(event) {
         event.preventDefault();
-        this._zoom(event.deltaY);
+        let delta = event.deltaY;
+        delta = Math.abs(delta) > 25 ? delta : delta * 10;
+        this._zoom(delta);
     }
 
     /**


### PR DESCRIPTION
On browsers unfortunately trackpad pinch-zoom is sent over as a wheel event. However, the magnitude of these events are decidedly smaller in practice, leading to very unsatisfying pinch zooming. Multiplying deltas by 10 when they are less than 25 in my testing is an effective fix for this.

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
