### PR TITLE
Add @typedef AnimCurveTarget

### DIFF
--- a/src/framework/anim/evaluator/anim-curve.js
+++ b/src/framework/anim/evaluator/anim-curve.js
@@ -1,4 +1,25 @@
 /**
+ * @example
+ * [
+ *     {
+ *         "entityPath": [
+ *             "RootNode",
+ *             "AVATAR",
+ *             "C_spine0001_bind_JNT"
+ *         ],
+ *         "component": "graph",
+ *         "propertyPath": [
+ *             "localPosition"
+ *         ]
+ *     }
+ * ]
+ * @typedef {object} AnimCurveTarget
+ * @property {string[]} entityPath - The path to the entity.
+ * @property {string} component - The component name.
+ * @property {string[]} propertyPath - The path to the property.
+ */
+
+/**
  * Animation curve links an input data set to an output data set and defines the interpolation
  * method to use.
  *
@@ -8,7 +29,7 @@ class AnimCurve {
     /**
      * Create a new animation curve.
      *
-     * @param {string[]} paths - Array of path strings identifying the targets of this curve, for
+     * @param {(string|AnimCurveTarget)[]} paths - Array of path strings identifying the targets of this curve, for
      * example "rootNode.translation".
      * @param {number} input - Index of the curve which specifies the key data.
      * @param {number} output - Index of the curve which specifies the value data.
@@ -28,7 +49,7 @@ class AnimCurve {
     /**
      * The list of paths which identify targets of this curve.
      *
-     * @type {string[]}
+     * @type {(string|AnimCurveTarget)[]}
      */
     get paths() {
         return this._paths;


### PR DESCRIPTION
The file hasn't been updated in two years and the usage seems to have changed. You can test that e.g. in https://playcanvas.vercel.app/#/animation/blend-trees-1d and put a breakpoint on `pc.AnimCurve`:

![image](https://github.com/user-attachments/assets/950a4971-19ae-476b-8c66-9b5a8dc907a8)

Stack:

![image](https://github.com/user-attachments/assets/895efe51-2b5c-424e-9265-a7950778c998)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
