### PR TITLE
Preprocessor handles || and && in the expressions

### DIFF
--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -3,15 +3,6 @@ uniform highp sampler2D clusterWorldTexture;
 uniform highp sampler2D lightsTexture8;
 uniform highp sampler2D lightsTextureFloat;
 
-// complex ifdef expression are not supported, handle it here
-// defined(CLUSTER_COOKIES) || defined(CLUSTER_SHADOWS)
-#if defined(CLUSTER_COOKIES)
-    #define CLUSTER_COOKIES_OR_SHADOWS
-#endif
-#if defined(CLUSTER_SHADOWS)
-    #define CLUSTER_COOKIES_OR_SHADOWS
-#endif
-
 #ifdef CLUSTER_SHADOWS
     // TODO: when VSM shadow is supported, it needs to use sampler2D in webgl2
     uniform sampler2DShadow shadowAtlasTexture;
@@ -309,7 +300,7 @@ void evaluateLight(
             falloffAttenuation *= getSpotEffect(light.direction, light.innerConeAngleCos, light.outerConeAngleCos, dLightDirNormW);
         }
 
-        #if defined(CLUSTER_COOKIES_OR_SHADOWS)
+        #if defined(CLUSTER_COOKIES) || defined(CLUSTER_SHADOWS)
 
         if (falloffAttenuation > 0.00001) {
 

--- a/test/core/preprocessor.test.mjs
+++ b/test/core/preprocessor.test.mjs
@@ -22,8 +22,32 @@ describe('Preprocessor', function () {
         #define __INJECT_STRING hello
         #define FEATURE1
         #define FEATURE2
+        #define AND1
+        #define AND2
+        #define OR1
+        #define OR2
 
         #include "incLoop, LOOP_COUNT"
+
+        #if (defined(AND1) && defined(AND2))
+            ANDS1
+        #endif
+
+        #if (defined(UNDEFINED) && defined(AND2))
+            ANDS2
+        #endif
+
+        #if (defined(OR1) || defined(OR2))
+            ORS1
+        #endif
+
+        #if (defined(UNDEFINED) || defined(OR2))
+            ORS2
+        #endif
+
+        #if (defined(UNDEFINED) || defined(UNDEFINED2) || defined(OR2))
+            ORS3
+        #endif
 
         #ifdef FEATURE1
             TEST1
@@ -225,4 +249,23 @@ describe('Preprocessor', function () {
         expect(Preprocessor.run(srcData, includes).includes('inserted3')).to.equal(false);
     });
 
+    it('returns true for ANDS1', function () {
+        expect(Preprocessor.run(srcData, includes).includes('ANDS1')).to.equal(true);
+    });
+
+    it('returns false for ANDS2', function () {
+        expect(Preprocessor.run(srcData, includes).includes('ANDS2')).to.equal(false);
+    });
+
+    it('returns true for ORS1', function () {
+        expect(Preprocessor.run(srcData, includes).includes('ORS1')).to.equal(true);
+    });
+
+    it('returns true for ORS2', function () {
+        expect(Preprocessor.run(srcData, includes).includes('ORS2')).to.equal(true);
+    });
+
+    it('returns true for ORS3', function () {
+        expect(Preprocessor.run(srcData, includes).includes('ORS3')).to.equal(true);
+    });
 });


### PR DESCRIPTION
preprocessor now handles cases with && and ||, for example
```
#if defined(A) || B == 3
#if A > 2 && A < 4 || SHADOWS
```