### PR TITLE
Moved zero render target checked to a better place

### DIFF
--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -150,6 +150,12 @@ class WebglRenderTarget {
 
         } else {
 
+            Debug.call(() => {
+                if (target.width <= 0 || target.height <= 0) {
+                    Debug.warnOnce(`Invalid render target size: ${target.width} x ${target.height}`, target);
+                }
+            });
+
             // ##### Create main FBO #####
             this._glFrameBuffer = gl.createFramebuffer();
             device.setFramebuffer(this._glFrameBuffer);
@@ -223,12 +229,6 @@ class WebglRenderTarget {
 
         // ##### Create MSAA FBO #####
         if (target._samples > 1) {
-
-            Debug.call(() => {
-                if (target.width <= 0 || target.height <= 0) {
-                    Debug.warnOnce(`Invalid render target size: ${target.width} x ${target.height}`, target);
-                }
-            });
 
             // Use previous FBO for resolves
             this._glResolveFrameBuffer = this._glFrameBuffer;


### PR DESCRIPTION
this is to handle single samplered RTs as well, not only multisampled

Related to https://github.com/playcanvas/engine/issues/7351

repro using engine example
<img width="790" alt="Screenshot 2025-02-14 at 16 03 46" src="https://github.com/user-attachments/assets/e9fe3a00-b5b9-4303-9ba7-c2ce53efc6b7" />

note that this is not related to CameraFrame only, but any render target rendering, even old post-effects.
