### PR TITLE
[Fix] Fixed incorrect 2D texture array setup with compressed format

### DIFF
--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -632,7 +632,7 @@ class WebglTexture {
                                 Math.max(Math.floor(texture._width * resMult), 1),
                                 Math.max(Math.floor(texture._height * resMult), 1),
                                 1,
-                                this._glFormat,
+                                this._glInternalFormat,
                                 mipObject[index]
                             );
                         }


### PR DESCRIPTION
Fixes an issue mentioned here: https://forum.playcanvas.com/t/maximum-per-stage-sampled-texture-limit/39158/6
