### PR TITLE
Avoid using __ in defines to avoid GLSL warning

### DIFF
--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -105,10 +105,10 @@ class Preprocessor {
             }
         });
 
-        // extract defines with name starting with __INJECT_
+        // extract defines with name starting with _INJECT_
         const injectDefines = new Map();
         defines.forEach((value, key) => {
-            if (key.startsWith('__INJECT_')) {
+            if (key.startsWith('_INJECT_')) {
                 injectDefines.set(key, value);
             }
         });

--- a/src/scene/shader-lib/chunks-wgsl/skybox/frag/skybox.js
+++ b/src/scene/shader-lib/chunks-wgsl/skybox/frag/skybox.js
@@ -47,13 +47,13 @@ export default /* wgsl */`
             #endif
 
             dir.x *= -1.0;
-            linear = __INJECT_SKYBOX_DECODE_FNC(textureSample(texture_cubeMap, texture_cubeMap_sampler, dir));
+            linear = _INJECT_SKYBOX_DECODE_FNC(textureSample(texture_cubeMap, texture_cubeMap_sampler, dir));
 
         #else // env-atlas
 
             dir = input.vViewDir * vec3f(-1.0, 1.0, 1.0);
             let uv : vec2f = toSphericalUv(normalize(dir));
-            linear = __INJECT_SKYBOX_DECODE_FNC(textureSample(texture_envAtlas, texture_envAtlas_sampler, mapRoughnessUv(uv, uniform.mipLevel)));
+            linear = _INJECT_SKYBOX_DECODE_FNC(textureSample(texture_envAtlas, texture_envAtlas_sampler, mapRoughnessUv(uv, uniform.mipLevel)));
 
         #endif
 

--- a/src/scene/shader-lib/chunks/skybox/frag/skybox.js
+++ b/src/scene/shader-lib/chunks/skybox/frag/skybox.js
@@ -43,14 +43,14 @@ export default /* glsl */`
             #endif
 
             dir.x *= -1.0;
-            vec3 linear = __INJECT_SKYBOX_DECODE_FNC(textureCube(texture_cubeMap, dir));
+            vec3 linear = _INJECT_SKYBOX_DECODE_FNC(textureCube(texture_cubeMap, dir));
 
         #else // env-atlas
 
             vec3 dir = vViewDir * vec3(-1.0, 1.0, 1.0);
             vec2 uv = toSphericalUv(normalize(dir));
 
-            vec3 linear = __INJECT_SKYBOX_DECODE_FNC(texture2D(texture_envAtlas, mapRoughnessUv(uv, mipLevel)));
+            vec3 linear = _INJECT_SKYBOX_DECODE_FNC(texture2D(texture_envAtlas, mapRoughnessUv(uv, mipLevel)));
 
         #endif
 

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -46,7 +46,7 @@ class SkyMesh {
         });
 
         // defines
-        material.setDefine('__INJECT_SKYBOX_DECODE_FNC', ChunkUtils.decodeFunc(texture.encoding));
+        material.setDefine('_INJECT_SKYBOX_DECODE_FNC', ChunkUtils.decodeFunc(texture.encoding));
         if (type !== SKYTYPE_INFINITE) material.setDefine('SKYMESH', '');
         if (texture.cubemap) material.setDefine('SKY_CUBEMAP', '');
 

--- a/test/core/preprocessor.test.mjs
+++ b/test/core/preprocessor.test.mjs
@@ -18,8 +18,8 @@ describe('Preprocessor', function () {
     const srcData = `
         
         #define LOOP_COUNT 3
-        #define __INJECT_COUNT 2
-        #define __INJECT_STRING hello
+        #define _INJECT_COUNT 2
+        #define _INJECT_STRING hello
         #define FEATURE1
         #define FEATURE2
         #define AND1
@@ -126,8 +126,8 @@ describe('Preprocessor', function () {
             CMP5
         #endif
 
-        TESTINJECTION __INJECT_COUNT
-        INJECTSTRING __INJECT_STRING(x)
+        TESTINJECTION _INJECT_COUNT
+        INJECTSTRING _INJECT_STRING(x)
     `;
 
     it('returns false for MORPH_A', function () {


### PR DESCRIPTION
Avoid using defines with double underscore to avoid possible issues. 
GLSL compiler warning: `WARNING: 0:71: '__INJECT_SKYBOX_DECODE_FNC' : macro name with a double underscore is reserved - unintented behavior is possible`