### PR TITLE
Shader allocation tracing now logs the language used (GLSL / WGSL)

### DIFF
--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -163,7 +163,7 @@ class Shader {
 
     /** @ignore */
     get label() {
-        return `Shader Id ${this.id} ${this.name}`;
+        return `Shader Id ${this.id} (${this.definition.shaderLanguage === SHADERLANGUAGE_WGSL ? 'WGSL' : 'GLSL'}) ${this.name}`;
     }
 
     /**


### PR DESCRIPTION
![Screenshot 2025-02-24 at 13 04 09](https://github.com/user-attachments/assets/7f96c206-505c-42a7-a0ac-af687f130f75)
