### PR TITLE
Improvements to Preprocessor - spaces after #else, comments in #include blocks

### DIFF
--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -22,7 +22,7 @@ const UNDEF = /undef[ \t]+([^\n]+)\r?(?:\n|$)/g;
 const IF = /(ifdef|ifndef|if)[ \t]*([^\r\n]+)\r?\n/g;
 
 // #endif/#else or #elif EXPRESSION
-const ENDIF = /(endif|else|elif)([ \t][^\r\n]+)?\r?(?:\n|$)/g;
+const ENDIF = /(endif|else|elif)(?:[ \t]+([^\r\n]*))?\r?\n?/g;
 
 // identifier
 const IDENTIFIER = /([\w-]+)/;
@@ -401,6 +401,8 @@ class Preprocessor {
                         // cut out the include line and replace it with the included string
                         let includeSource = includes?.get(identifier);
                         if (includeSource !== undefined) {
+
+                            includeSource = this.stripComments(includeSource);
 
                             // handle second identifier specifying loop count
                             if (countIdentifier) {

--- a/src/extras/render-passes/render-pass-compose.js
+++ b/src/extras/render-passes/render-pass-compose.js
@@ -13,7 +13,6 @@ import { GAMMA_NONE, GAMMA_SRGB, gammaNames, TONEMAP_LINEAR, tonemapNames } from
 const fragmentShader = /* glsl */ `
 
     #include "tonemappingPS"
-    #include "decodePS"
     #include "gammaPS"
 
     varying vec2 uv0;


### PR DESCRIPTION
- skip spaces after `#else` and similar, to match the `else` keyword, which was failing with trailing white spaces
- strip comments from included blocks