### PR TITLE
[Fix] Create a dummy framebuffer on NullDevice to avoid undefined access

### DIFF
--- a/src/platform/graphics/null/null-graphics-device.js
+++ b/src/platform/graphics/null/null-graphics-device.js
@@ -2,6 +2,7 @@ import {
     DEVICETYPE_NULL
 } from '../constants.js';
 import { GraphicsDevice } from '../graphics-device.js';
+import { RenderTarget } from '../render-target.js';
 
 import { NullIndexBuffer } from './null-index-buffer.js';
 import { NullRenderTarget } from './null-render-target.js';
@@ -17,6 +18,14 @@ class NullGraphicsDevice extends GraphicsDevice {
         this.isNull = true;
         this._deviceType = DEVICETYPE_NULL;
         this.samples = 1;
+
+        this.backBuffer = new RenderTarget({
+            name: 'Framebuffer',
+            graphicsDevice: this,
+            depth: this.initOptions.depth,
+            stencil: this.supportsStencil,
+            samples: this.samples
+        });
     }
 
     destroy() {


### PR DESCRIPTION
it’s required by few functions in the engine, so create a dummy RT for this purpose