### PR TITLE
Adjusted syntax of variables the preprocessor uses for injection

### DIFF
--- a/src/scene/shader-lib/chunks-wgsl/skybox/frag/skybox.js
+++ b/src/scene/shader-lib/chunks-wgsl/skybox/frag/skybox.js
@@ -47,13 +47,13 @@ export default /* wgsl */`
             #endif
 
             dir.x *= -1.0;
-            linear = _INJECT_SKYBOX_DECODE_FNC(textureSample(texture_cubeMap, texture_cubeMap_sampler, dir));
+            linear = {SKYBOX_DECODE_FNC}(textureSample(texture_cubeMap, texture_cubeMap_sampler, dir));
 
         #else // env-atlas
 
             dir = input.vViewDir * vec3f(-1.0, 1.0, 1.0);
             let uv : vec2f = toSphericalUv(normalize(dir));
-            linear = _INJECT_SKYBOX_DECODE_FNC(textureSample(texture_envAtlas, texture_envAtlas_sampler, mapRoughnessUv(uv, uniform.mipLevel)));
+            linear = {SKYBOX_DECODE_FNC}(textureSample(texture_envAtlas, texture_envAtlas_sampler, mapRoughnessUv(uv, uniform.mipLevel)));
 
         #endif
 

--- a/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/clusteredLight.js
@@ -98,25 +98,51 @@ struct ClusterLightData {
 mat4 lightProjectionMatrix;
 
 // macros for light properties
-#define isClusteredLightCastShadow(light) ( light.shadowIntensity > 0.0 )
-#define isClusteredLightCookie(light) (light.cookie > 0.5 )
-#define isClusteredLightCookieRgb(light) (light.cookieRgb > 0.5 )
-#define isClusteredLightSpot(light) ( light.lightType > 0.5 )
-#define isClusteredLightFalloffLinear(light) ( light.falloffMode < 0.5 )
+bool isClusteredLightCastShadow(in ClusterLightData light) {
+  return light.shadowIntensity > 0.0;
+}
+
+bool isClusteredLightCookie(in ClusterLightData light) {
+  return light.cookie > 0.5;
+}
+
+bool isClusteredLightCookieRgb(in ClusterLightData light) {
+  return light.cookieRgb > 0.5;
+}
+
+bool isClusteredLightSpot(in ClusterLightData light) {
+  return light.lightType > 0.5;
+}
+
+bool isClusteredLightFalloffLinear(in ClusterLightData light) {
+  return light.falloffMode < 0.5;
+}
 
 // macros to test light shape
 // Note: Following functions need to be called serially in listed order as they do not test both '>' and '<'
-#define isClusteredLightArea(light) ( light.shape > 0.1 )
-#define isClusteredLightRect(light) ( light.shape < 0.3 )
-#define isClusteredLightDisk(light) ( light.shape < 0.6 )
+bool isClusteredLightArea(in ClusterLightData light) {
+  return light.shape > 0.1;
+}
+
+bool isClusteredLightRect(in ClusterLightData light) {
+  return light.shape < 0.3;
+}
+
+bool isClusteredLightDisk(in ClusterLightData light) {
+  return light.shape < 0.6;
+}
 
 // macro to test light mask (mesh accepts dynamic vs lightmapped lights)
 #ifdef CLUSTER_MESH_DYNAMIC_LIGHTS
     // accept lights marked as dynamic or both dynamic and lightmapped
-    #define acceptLightMask(light) ( light.mask < 0.75)
+    bool acceptLightMask(in ClusterLightData light) {
+        return light.mask < 0.75;
+    }
 #else
     // accept lights marked as lightmapped or both dynamic and lightmapped
-    #define acceptLightMask(light) ( light.mask > 0.25)
+    bool acceptLightMask(in ClusterLightData light) {
+        return light.mask > 0.25;
+    }
 #endif
 
 vec4 decodeClusterLowRange4Vec4(vec4 d0, vec4 d1, vec4 d2, vec4 d3) {

--- a/src/scene/shader-lib/chunks/lit/vert/uvTransform.js
+++ b/src/scene/shader-lib/chunks/lit/vert/uvTransform.js
@@ -1,7 +1,7 @@
 // chunk that generates uv coordinate transformed by uv transform matrix
 export default /* glsl */`
-vUV_INJECT_TRANSFORM_UV_{i}__INJECT_TRANSFORM_ID_{i} = vec2(
-    dot(vec3(uv_INJECT_TRANSFORM_UV_{i}, 1), _INJECT_TRANSFORM_NAME_{i}0),
-    dot(vec3(uv_INJECT_TRANSFORM_UV_{i}, 1), _INJECT_TRANSFORM_NAME_{i}1)
+vUV{TRANSFORM_UV_{i}}_{TRANSFORM_ID_{i}} = vec2(
+    dot(vec3(uv{TRANSFORM_UV_{i}}, 1), {TRANSFORM_NAME_{i}}0),
+    dot(vec3(uv{TRANSFORM_UV_{i}}, 1), {TRANSFORM_NAME_{i}}1)
 );
 `;

--- a/src/scene/shader-lib/chunks/lit/vert/uvTransformUniforms.js
+++ b/src/scene/shader-lib/chunks/lit/vert/uvTransformUniforms.js
@@ -1,5 +1,5 @@
 // uniform declaration for uv transform matrix, 3x2 matrix
 export default /* glsl */`
-    uniform vec3 _INJECT_TRANSFORM_NAME_{i}0;
-    uniform vec3 _INJECT_TRANSFORM_NAME_{i}1;
+    uniform vec3 {TRANSFORM_NAME_{i}}0;
+    uniform vec3 {TRANSFORM_NAME_{i}}1;
 `;

--- a/src/scene/shader-lib/chunks/skybox/frag/skybox.js
+++ b/src/scene/shader-lib/chunks/skybox/frag/skybox.js
@@ -43,14 +43,14 @@ export default /* glsl */`
             #endif
 
             dir.x *= -1.0;
-            vec3 linear = _INJECT_SKYBOX_DECODE_FNC(textureCube(texture_cubeMap, dir));
+            vec3 linear = {SKYBOX_DECODE_FNC}(textureCube(texture_cubeMap, dir));
 
         #else // env-atlas
 
             vec3 dir = vViewDir * vec3(-1.0, 1.0, 1.0);
             vec2 uv = toSphericalUv(normalize(dir));
 
-            vec3 linear = _INJECT_SKYBOX_DECODE_FNC(texture2D(texture_envAtlas, mapRoughnessUv(uv, mipLevel)));
+            vec3 linear = {SKYBOX_DECODE_FNC}(texture2D(texture_envAtlas, mapRoughnessUv(uv, mipLevel)));
 
         #endif
 

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -256,9 +256,9 @@ class LitShader {
 
                 // defines used by the included chunks
                 const varName = `texture_${name}MapTransform`;
-                vDefines.set(`_INJECT_TRANSFORM_NAME_${numTransforms}`, varName);
-                vDefines.set(`_INJECT_TRANSFORM_UV_${numTransforms}`, uv);
-                vDefines.set(`_INJECT_TRANSFORM_ID_${numTransforms}`, id);
+                vDefines.set(`{TRANSFORM_NAME_${numTransforms}}`, varName);
+                vDefines.set(`{TRANSFORM_UV_${numTransforms}}`, uv);
+                vDefines.set(`{TRANSFORM_ID_${numTransforms}}`, id);
 
                 numTransforms++;
             }

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -46,7 +46,7 @@ class SkyMesh {
         });
 
         // defines
-        material.setDefine('_INJECT_SKYBOX_DECODE_FNC', ChunkUtils.decodeFunc(texture.encoding));
+        material.setDefine('{SKYBOX_DECODE_FNC}', ChunkUtils.decodeFunc(texture.encoding));
         if (type !== SKYTYPE_INFINITE) material.setDefine('SKYMESH', '');
         if (texture.cubemap) material.setDefine('SKY_CUBEMAP', '');
 

--- a/test/core/preprocessor.test.mjs
+++ b/test/core/preprocessor.test.mjs
@@ -18,8 +18,8 @@ describe('Preprocessor', function () {
     const srcData = `
         
         #define LOOP_COUNT 3
-        #define _INJECT_COUNT 2
-        #define _INJECT_STRING hello
+        #define {COUNT} 2
+        #define {STRING} hello
         #define FEATURE1
         #define FEATURE2
         #define AND1
@@ -126,8 +126,8 @@ describe('Preprocessor', function () {
             CMP5
         #endif
 
-        TESTINJECTION _INJECT_COUNT
-        INJECTSTRING _INJECT_STRING(x)
+        TESTINJECTION {COUNT}
+        INJECTSTRING {STRING}(x)
     `;
 
     it('returns false for MORPH_A', function () {


### PR DESCRIPTION
use curly brackets around the define variable name to mark it for injection into shader code (we resolve it before passing it to platform compilers)

Before, the define had to be named
```
define _INJECT_COUNT 4
```
and the code using it would be 
```
for (int i = 0; i < _INJECT_COUNT; i++)
```

now we have
```
define {COUNT} 4
```
and the code using it would be 
```
for (int i = 0; i < {COUNT}; i++)
```