### PR TITLE
LitShader generator refactoring - the main is a single string now

### DIFF
--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -906,6 +906,12 @@ export const SPRITE_RENDERMODE_SLICED = 1;
  */
 export const SPRITE_RENDERMODE_TILED = 2;
 
+export const spriteRenderModeNames = {
+    [SPRITE_RENDERMODE_SIMPLE]: 'SIMPLE',
+    [SPRITE_RENDERMODE_SLICED]: 'SLICED',
+    [SPRITE_RENDERMODE_TILED]: 'TILED'
+};
+
 /**
  * Single color lightmap.
  *

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -172,7 +172,6 @@ import skyboxVS from './skybox/vert/skybox.js';
 import sphericalPS from './common/frag/spherical.js';
 // import specularityFactorPS from './standard/frag/specularityFactor.js';
 // import spotPS from './lit/frag/spot.js';
-// import startPS from './lit/frag/start.js';
 // import startNineSlicedPS from './lit/frag/startNineSliced.js';
 // import startNineSlicedTiledPS from './lit/frag/startNineSlicedTiled.js';
 // import tangentBinormalVS from './lit/vert/tangentBinormal.js';
@@ -381,7 +380,6 @@ const shaderChunksWGSL = {
     sphericalPS,
     // specularityFactorPS,
     // spotPS,
-    // startPS,
     // startNineSlicedPS,
     // startNineSlicedTiledPS,
     // tangentBinormalVS,

--- a/src/scene/shader-lib/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/chunks/chunk-validation.js
@@ -31,7 +31,6 @@ const chunkVersions = {
 
     // backend
     normalVertexPS: CHUNKAPI_1_55,
-    startPS: CHUNKAPI_1_55,
 
     ambientConstantPS: CHUNKAPI_1_62,
     ambientEnvPS: CHUNKAPI_1_62,
@@ -120,7 +119,8 @@ const removedChunks = {
     viewNormalVS: CHUNKAPI_2_6,
     lightmapDirAddPS: CHUNKAPI_2_6,
     TBNObjectSpacePS: CHUNKAPI_2_6,
-    TBNderivativePS: CHUNKAPI_2_6
+    TBNderivativePS: CHUNKAPI_2_6,
+    startPS: CHUNKAPI_2_6
 };
 
 // compare two "major.minor" semantic version strings and return true if a is a smaller version than b.

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -172,7 +172,6 @@ import specularPS from './standard/frag/specular.js';
 import sphericalPS from './common/frag/spherical.js';
 import specularityFactorPS from './standard/frag/specularityFactor.js';
 import spotPS from './lit/frag/spot.js';
-import startPS from './lit/frag/start.js';
 import startNineSlicedPS from './lit/frag/startNineSliced.js';
 import startNineSlicedTiledPS from './lit/frag/startNineSlicedTiled.js';
 import tangentBinormalVS from './lit/vert/tangentBinormal.js';
@@ -381,7 +380,6 @@ const shaderChunks = {
     sphericalPS,
     specularityFactorPS,
     spotPS,
-    startPS,
     startNineSlicedPS,
     startNineSlicedTiledPS,
     tangentBinormalVS,

--- a/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
+++ b/src/scene/shader-lib/chunks/lit/frag/refractionDynamic.js
@@ -48,7 +48,7 @@ void addRefraction(
     vec3 refractionVector = normalize(refract(-viewDir, worldNormal, refractionIndex)) * scale;
     vec3 refraction = evalRefractionColor(refractionVector, gloss, refractionIndex);
 
-    #ifdef DISPERSION
+    #ifdef LIT_DISPERSION
         // based on the dispersion material property, calculate modified refraction index values
         // for R and B channels and evaluate the refraction color for them.
         float halfSpread = (1.0 / refractionIndex - 1.0) * 0.025 * dispersion;

--- a/src/scene/shader-lib/chunks/lit/frag/start.js
+++ b/src/scene/shader-lib/chunks/lit/frag/start.js
@@ -1,9 +1,0 @@
-export default /* glsl */`
-void main(void) {
-    dReflection = vec4(0);
-
-    #ifdef LIT_CLEARCOAT
-    ccSpecularLight = vec3(0);
-    ccReflection = vec3(0);
-    #endif
-`;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -794,8 +794,8 @@ class LitShader {
                 dReflection = vec4(0);
 
                 #ifdef LIT_CLEARCOAT
-                ccSpecularLight = vec3(0);
-                ccReflection = vec3(0);
+                    ccSpecularLight = vec3(0);
+                    ccReflection = vec3(0);
                 #endif
 
                 #if LIT_NONE_SLICE_MODE == SLICED

--- a/src/scene/shader-lib/programs/shader-generator.js
+++ b/src/scene/shader-lib/programs/shader-generator.js
@@ -1,10 +1,6 @@
 import { hashCode } from '../../../core/hash.js';
 
 class ShaderGenerator {
-    static end() {
-        return '}\n';
-    }
-
     /**
      * @param {Map<string, string>} defines - the set of defines to be used in the shader.
      * @returns {number} the hash code of the defines.

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -520,7 +520,12 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         }
 
         decl.append(litShader.chunks.litShaderArgsPS);
-        code.append(`void evaluateFrontend() { \n${func.code}\n${args.code}\n }\n`);
+        code.append(`
+            void evaluateFrontend() {
+                ${func.code}
+                ${args.code}
+            }
+        `);
 
         for (const texture in textureMapping) {
             decl.append(`uniform sampler2D ${textureMapping[texture]};`);


### PR DESCRIPTION
- further lit-shader refactoring. `main` function of it is a single string now, and will be moved to a chunk in the future. This will be so much easier to read what is going on.

<img width="559" alt="Screenshot 2025-02-27 at 17 21 47" src="https://github.com/user-attachments/assets/b1eb0892-94ac-4b4d-a517-c3df25009e49" />

removed chunks:
```
startPS
```
