### PR TITLE
Update to the way we strip unused MRT outputs

### DIFF
--- a/src/platform/graphics/shader-chunks/frag/gles3.js
+++ b/src/platform/graphics/shader-chunks/frag/gles3.js
@@ -4,60 +4,37 @@ export default /* glsl */`
 #define outType_0 vec4
 #endif
 
-layout(location = 0) out highp outType_0 pc_fragColor;
+layout(location = 0) out highp outType_0 pcFragColor0;
 
-#ifndef REMOVE_COLOR_ATTACHMENT_1
 #if COLOR_ATTACHMENT_1
-layout(location = 1) out highp outType_1 pc_fragColor1;
-#endif
+layout(location = 1) out highp outType_1 pcFragColor1;
 #endif
 
-#ifndef REMOVE_COLOR_ATTACHMENT_2
 #if COLOR_ATTACHMENT_2
-layout(location = 2) out highp outType_2 pc_fragColor2;
-#endif
+layout(location = 2) out highp outType_2 pcFragColor2;
 #endif
 
-#ifndef REMOVE_COLOR_ATTACHMENT_3
 #if COLOR_ATTACHMENT_3
-layout(location = 3) out highp outType_3 pc_fragColor3;
-#endif
+layout(location = 3) out highp outType_3 pcFragColor3;
 #endif
 
-#ifndef REMOVE_COLOR_ATTACHMENT_4
 #if COLOR_ATTACHMENT_4
-layout(location = 4) out highp outType_4 pc_fragColor4;
-#endif
+layout(location = 4) out highp outType_4 pcFragColor4;
 #endif
 
-#ifndef REMOVE_COLOR_ATTACHMENT_5
 #if COLOR_ATTACHMENT_5
-layout(location = 5) out highp outType_5 pc_fragColor5;
-#endif
+layout(location = 5) out highp outType_5 pcFragColor5;
 #endif
 
-#ifndef REMOVE_COLOR_ATTACHMENT_6
 #if COLOR_ATTACHMENT_6
-layout(location = 6) out highp outType_6 pc_fragColor6;
-#endif
+layout(location = 6) out highp outType_6 pcFragColor6;
 #endif
 
-#ifndef REMOVE_COLOR_ATTACHMENT_7
 #if COLOR_ATTACHMENT_7
-layout(location = 7) out highp outType_7 pc_fragColor7;
-#endif
+layout(location = 7) out highp outType_7 pcFragColor7;
 #endif
 
-#define gl_FragColor pc_fragColor
-
-#define pcFragColor0 pc_fragColor
-#define pcFragColor1 pc_fragColor1
-#define pcFragColor2 pc_fragColor2
-#define pcFragColor3 pc_fragColor3
-#define pcFragColor4 pc_fragColor4
-#define pcFragColor5 pc_fragColor5
-#define pcFragColor6 pc_fragColor6
-#define pcFragColor7 pc_fragColor7
+#define gl_FragColor pcFragColor0
 
 #define varying in
 

--- a/src/platform/graphics/shader-chunks/frag/webgpu.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu.js
@@ -28,25 +28,16 @@ export default /* glsl */`
 #define outType_7 vec4
 #endif
 
-layout(location = 0) out highp outType_0 pc_fragColor;
-layout(location = 1) out highp outType_1 pc_fragColor1;
-layout(location = 2) out highp outType_2 pc_fragColor2;
-layout(location = 3) out highp outType_3 pc_fragColor3;
-layout(location = 4) out highp outType_4 pc_fragColor4;
-layout(location = 5) out highp outType_5 pc_fragColor5;
-layout(location = 6) out highp outType_6 pc_fragColor6;
-layout(location = 7) out highp outType_7 pc_fragColor7;
+layout(location = 0) out highp outType_0 pcFragColor0;
+layout(location = 1) out highp outType_1 pcFragColor1;
+layout(location = 2) out highp outType_2 pcFragColor2;
+layout(location = 3) out highp outType_3 pcFragColor3;
+layout(location = 4) out highp outType_4 pcFragColor4;
+layout(location = 5) out highp outType_5 pcFragColor5;
+layout(location = 6) out highp outType_6 pcFragColor6;
+layout(location = 7) out highp outType_7 pcFragColor7;
 
-#define gl_FragColor pc_fragColor
-
-#define pcFragColor0 pc_fragColor
-#define pcFragColor1 pc_fragColor1
-#define pcFragColor2 pc_fragColor2
-#define pcFragColor3 pc_fragColor3
-#define pcFragColor4 pc_fragColor4
-#define pcFragColor5 pc_fragColor5
-#define pcFragColor6 pc_fragColor6
-#define pcFragColor7 pc_fragColor7
+#define gl_FragColor pcFragColor0
 
 #define texture2D(res, uv) texture(sampler2D(res, res ## _sampler), uv)
 #define texture2DBias(res, uv, bias) texture(sampler2D(res, res ## _sampler), uv, bias)

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1386,13 +1386,8 @@ class LitShader {
             backend.append('    gl_FragColor = applyMsdf(gl_FragColor);');
         }
 
-        // TODO: moving this to include bellow makes MRT example to break, as we no longer find pc_fragColor1
-        // in code during preprocessing with stripUnusedColorAttachments. We need some other soltuion for it,
-        // perhaps do this preprocessing after the incldues are inlined?
-        backend.append(chunks.outputPS);
-
         backend.append(`
-            // #include "outputPS"
+            #include "outputPS"
             #include "debugOutputPS"
         `);
 


### PR DESCRIPTION
This PR updates the way we strip unused fragment outputs (MRT related) due to an [issue on iOS 15](https://github.com/playcanvas/engine/pull/5459).

Before, the shader code was created as a single string, and we simply prepended some defines to remove unused outputs, and let out preprocessor strip them out.

Now those outputs can be used inside includes, and so we had to change the way unused outputs are defined, to be done at the end of the preprocessing step. This excludes using defines to strip them, as we don't want to run preprocessor twice just for this, and we do custom line stripping at the end instead.