### PR TITLE
[Fix] Fix reversed face culling when rendering shadows on WebGPU

### DIFF
--- a/examples/src/examples/graphics/lights.example.mjs
+++ b/examples/src/examples/graphics/lights.example.mjs
@@ -16,6 +16,7 @@ function createMaterial(colors) {
 
 const assets = {
     statue: new pc.Asset('statue', 'container', { url: `${rootPath}/static/assets/models/statue.glb` }),
+    orbit: new pc.Asset('script', 'script', { url: `${rootPath}/static/scripts/camera/orbit-camera.js` }),
     heart: new pc.Asset('heart', 'texture', { url: `${rootPath}/static/assets/textures/heart.png` }),
     xmas_negx: new pc.Asset('xmas_negx', 'texture', {
         url: `${rootPath}/static/assets/cubemaps/xmas_faces/xmas_negx.png`
@@ -49,9 +50,11 @@ device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.keyboard = new pc.Keyboard(document.body);
+createOptions.mouse = new pc.Mouse(document.body);
+createOptions.touch = new pc.TouchDevice(document.body);
 
-createOptions.componentSystems = [pc.RenderComponentSystem, pc.CameraComponentSystem, pc.LightComponentSystem];
-createOptions.resourceHandlers = [pc.TextureHandler, pc.ContainerHandler, pc.CubemapHandler];
+createOptions.componentSystems = [pc.RenderComponentSystem, pc.CameraComponentSystem, pc.LightComponentSystem, pc.ScriptComponentSystem];
+createOptions.resourceHandlers = [pc.TextureHandler, pc.ContainerHandler, pc.CubemapHandler, pc.ScriptHandler];
 
 const app = new pc.AppBase(canvas);
 app.init(createOptions);
@@ -90,6 +93,17 @@ assetListLoader.load(() => {
     camera.translate(0, 15, 35);
     camera.rotate(-14, 0, 0);
     app.root.addChild(camera);
+
+    camera.addComponent('script');
+    camera.script.create('orbitCamera', {
+        attributes: {
+            inertiaFactor: 0.2,
+            frameOnStart: false,
+            distanceMax: 500
+        }
+    });
+    camera.script.create('orbitCameraInputMouse');
+    camera.script.create('orbitCameraInputTouch');
 
     // ground material
     const material = createMaterial({

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -300,7 +300,8 @@ class ShadowRenderer {
                 material.dirty = false;
             }
 
-            renderer.setupCullMode(true, 1, meshInstance);
+            // reverse face culling on WebGPU - shadow maps have flipY set to true on WebGPU and so the winding order is reversed
+            renderer.setupCullMode(true, device.isWebGPU ? -1 : 1, meshInstance);
 
             // Uniforms I (shadow): material
             material.setParameters(device);

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -280,6 +280,9 @@ class ShadowRenderer {
         const shadowPass = this.getShadowPass(light);
         const cameraShaderParams = camera.shaderParams;
 
+        // reverse face culling when shadow map has flipY set to true which cases reversed winding order
+        const flipFactor = camera.renderTarget.flipY ? -1 : 1;
+
         // Render
         const count = visibleCasters.length;
         for (let i = 0; i < count; i++) {
@@ -300,8 +303,7 @@ class ShadowRenderer {
                 material.dirty = false;
             }
 
-            // reverse face culling on WebGPU - shadow maps have flipY set to true on WebGPU and so the winding order is reversed
-            renderer.setupCullMode(true, device.isWebGPU ? -1 : 1, meshInstance);
+            renderer.setupCullMode(true, flipFactor, meshInstance);
 
             // Uniforms I (shadow): material
             material.setParameters(device);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/7397#issuecomment-2697957479

due to flipped shadow map, face winding order was reversed and shadow map rendering had issues. This also fixes issues (gaps) in few other engine examples, for example

<img width="264" alt="Screenshot 2025-03-05 at 11 09 58" src="https://github.com/user-attachments/assets/fa2770a3-ac4d-4d09-868a-31e69af547d2" />
<img width="251" alt="Screenshot 2025-03-05 at 11 10 17" src="https://github.com/user-attachments/assets/82c96560-fbc0-4fc6-a761-580de49f92ea" />

<img width="300" alt="Screenshot 2025-03-05 at 11 09 29" src="https://github.com/user-attachments/assets/777b149f-5dba-4c1c-98fb-9ea175734df7" />
<img width="325" alt="Screenshot 2025-03-05 at 11 09 39" src="https://github.com/user-attachments/assets/60c56cc1-3e69-496c-9765-d4556a64cc66" />

- also added orbit camera to Lights example

