### PR TITLE
Fix to Lightmapper’s ambient baking when clustered lighting is enabled

### DIFF
--- a/examples/src/examples/graphics/lights-baked-a-o.example.mjs
+++ b/examples/src/examples/graphics/lights-baked-a-o.example.mjs
@@ -1,4 +1,3 @@
-// @config WEBGPU_DISABLED
 import { data } from 'examples/observer';
 import { deviceType, rootPath } from 'examples/utils';
 import * as pc from 'playcanvas';

--- a/examples/src/examples/graphics/lights-baked.example.mjs
+++ b/examples/src/examples/graphics/lights-baked.example.mjs
@@ -1,4 +1,3 @@
-// @config WEBGPU_DISABLED
 import { deviceType, rootPath } from 'examples/utils';
 import * as pc from 'playcanvas';
 

--- a/src/framework/lightmapper/bake-light.js
+++ b/src/framework/lightmapper/bake-light.js
@@ -19,9 +19,9 @@ class BakeLight {
         // don't use cascades
         light.numCascades = 1;
 
-        if (this.scene.clusteredLightingEnabled) {
-            // if clustered shadows are disabled, disable them on the light
-            light.castShadows = light.bakeShadows && lightingParams.shadowsEnabled;
+        // if clustered shadows are disabled, disable them on the light
+        if (this.scene.clusteredLightingEnabled && !lightingParams.shadowsEnabled) {
+            light.castShadows = false;
         }
 
         // bounds for non-directional light


### PR DESCRIPTION
Fixes issue introduced here: https://github.com/playcanvas/engine/pull/6884
Where ambient lighting was no longer baked when clustered lighting is enabled.

The reason is the fact that `Light.castShadow` getter returns different value than set using setter (risky to refactor)

```
    set castShadows(value) {
        this._castShadows = value;
    }

    get castShadows() {
        return this._castShadows && this._mask !== MASK_BAKE && this._mask !== 0;
    }

```

avoid this problem by changing it only if strictly needed.

BEFORE:
<img width="704" alt="Screenshot 2025-03-13 at 12 34 42" src="https://github.com/user-attachments/assets/36f7be35-28b9-4335-940a-92d809e6e556" />

NOW:
<img width="709" alt="Screenshot 2025-03-13 at 12 34 49" src="https://github.com/user-attachments/assets/a5fefbdc-303d-4b31-b5be-8b84d20ec4ee" />



**Other change:** enable baking examples on WebGPU. They still don't support spot and omni shadows (debug logs warn about this), but otherwise it seems to work well, likely due to https://github.com/playcanvas/engine/pull/7407 fixing those shadow artefacts around the edges.