### PR TITLE
Use less memory loading compressed.ply

### DIFF
--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -323,7 +323,7 @@ const readCompressedPly = async (streamBuf, elements) => {
                         shData0[tidx] = tmpBuf[(j * 3 + 0) * srcCoeffs + k];
                         shData1[tidx] = tmpBuf[(j * 3 + 1) * srcCoeffs + k];
                         shData2[tidx] = tmpBuf[(j * 3 + 2) * srcCoeffs + k];
-                    } else {srcCoeffs
+                    } else {
                         shData0[tidx] = 127;
                         shData1[tidx] = 127;
                         shData2[tidx] = 127;

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -262,10 +262,12 @@ const readCompressedPly = async (streamBuf, elements) => {
         return width * height;
     };
 
+    const storageSize = evalStorageSize(numVertices);
+
     // allocate result
     result.numSplats = numVertices;
     result.chunkData = new Float32Array(numChunks * numChunkProperties);
-    result.vertexData = new Uint32Array(evalStorageSize(numVertices) * 4);
+    result.vertexData = new Uint32Array(storageSize * 4);
 
     // read length bytes of data into buffer
     const read = async (buffer, length) => {
@@ -294,8 +296,48 @@ const readCompressedPly = async (streamBuf, elements) => {
 
     // read sh data
     if (elements.length === 3) {
-        result.shData = new Uint8Array(elements[2].count * elements[2].properties.length);
-        await read(result.shData.buffer, result.shData.byteLength);
+        // allocate memory for 48 coefficients per gaussian
+        const texStorageSize = storageSize * 16;            // RGBA32U per texel
+        const shData0 = new Uint8Array(texStorageSize);
+        const shData1 = new Uint8Array(texStorageSize);
+        const shData2 = new Uint8Array(texStorageSize);
+
+        // the file contains 1, 2 or 3 bands of SH data (with 9, 24 or 45 coefficients respectively)
+        // we must load the data and pad it for GPU
+        const chunkSize = 1024;
+        const srcCoeffs = elements[2].properties.length / 3;
+        const tmpBuf = new Uint8Array(chunkSize * srcCoeffs * 3);
+
+        // read in chunks of 1k gaussians and write to the padded texture data
+        for (let i = 0; i < result.numSplats; i += chunkSize) {
+            const toRead = Math.min(chunkSize, result.numSplats - i);
+
+            // read the next chunk of data
+            await read(tmpBuf.buffer, toRead * srcCoeffs * 3);
+
+            // pad the data
+            for (let j = 0; j < toRead; ++j) {
+                for (let k = 0; k < 15; ++k) {
+                    const tidx = (i + j) * 16 + k;
+                    if (k < srcCoeffs) {
+                        shData0[tidx] = tmpBuf[(j * 3 + 0) * srcCoeffs + k];
+                        shData1[tidx] = tmpBuf[(j * 3 + 1) * srcCoeffs + k];
+                        shData2[tidx] = tmpBuf[(j * 3 + 2) * srcCoeffs + k];
+                    } else {srcCoeffs
+                        shData0[tidx] = 127;
+                        shData1[tidx] = 127;
+                        shData2[tidx] = 127;
+                    }
+                }
+            }
+        }
+
+        result.shData0 = shData0;
+        result.shData1 = shData1;
+        result.shData2 = shData2;
+        result.shBands = { 3: 1, 8: 2, 15: 3 }[srcCoeffs];
+    } else {
+        result.shBands = 0;
     }
 
     return result;

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -48,7 +48,7 @@ class SplatCompressedIterator {
 
         const lerp = (a, b, t) => a * (1 - t) + b * t;
 
-        const { chunkData, chunkSize, vertexData, shData, shBands } = gsplatData;
+        const { chunkData, chunkSize, vertexData, shData0, shData1, shData2, shBands } = gsplatData;
         const shCoeffs = [3, 8, 15][shBands - 1];
 
         this.read = (i) => {
@@ -82,9 +82,10 @@ class SplatCompressedIterator {
             }
 
             if (sh && shBands > 0) {
+                const shData = [shData0, shData1, shData2];
                 for (let j = 0; j < 3; ++j) {
                     for (let k = 0; k < 15; ++k) {
-                        sh[j * 15 + k] = (k < shCoeffs) ? (shData[(i * 3 + j) * shCoeffs + k] * (8 / 255) - 4) : 0;
+                        sh[j * 15 + k] = (k < shCoeffs) ? (shData[j][i * 3 * shCoeffs + k] * (8 / 255) - 4) : 0;
                     }
                 }
             }
@@ -121,7 +122,12 @@ class GSplatCompressedData {
      * Contains optional quantized spherical harmonic data for up to 3 bands.
      * @type {Uint8Array}
      */
-    shData;
+    shData0;
+    shData1;
+    shData2;
+
+    // number of bands
+    shBands;
 
     /**
      * Create an iterator for accessing splat data
@@ -231,15 +237,6 @@ class GSplatCompressedData {
 
     get chunkSize() {
         return this.chunkData.length / this.numChunks;
-    }
-
-    get shBands() {
-        const sizes = {
-            3: 1,
-            8: 2,
-            15: 3
-        };
-        return sizes[this.shData?.length / this.numSplats / 3] ?? 0;
     }
 
     // decompress into GSplatData

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -119,14 +119,27 @@ class GSplatCompressedData {
     vertexData;
 
     /**
-     * Contains optional quantized spherical harmonic data for up to 3 bands.
+     * Contains optional quantized spherical harmonic data.
      * @type {Uint8Array}
      */
     shData0;
+
+    /**
+     * Contains optional quantized spherical harmonic data.
+     * @type {Uint8Array}
+     */
     shData1;
+
+    /**
+     * Contains optional quantized spherical harmonic data.
+     * @type {Uint8Array}
+     */
     shData2;
 
-    // number of bands
+    /**
+     * Contains the number of bands of spherical harmonics data.
+     * @type {number}
+     */
     shBands;
 
     /**

--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -85,7 +85,7 @@ class SplatCompressedIterator {
                 const shData = [shData0, shData1, shData2];
                 for (let j = 0; j < 3; ++j) {
                     for (let k = 0; k < 15; ++k) {
-                        sh[j * 15 + k] = (k < shCoeffs) ? (shData[j][i * 3 * shCoeffs + k] * (8 / 255) - 4) : 0;
+                        sh[j * 15 + k] = (k < shCoeffs) ? (shData[j][i * 16 + k] * (8 / 255) - 4) : 0;
                     }
                 }
             }

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -93,39 +93,10 @@ class GSplatCompressed {
 
         // load optional spherical harmonics data
         if (shBands > 0) {
-            const { shData } = gsplatData;
-
             const size = this.evalTextureSize(numSplats);
-
-            const texture0 = this.createTexture('shTexture0', PIXELFORMAT_RGBA32U, size);
-            const texture1 = this.createTexture('shTexture1', PIXELFORMAT_RGBA32U, size);
-            const texture2 = this.createTexture('shTexture2', PIXELFORMAT_RGBA32U, size);
-
-            const data0 = texture0.lock();
-            const data1 = texture1.lock();
-            const data2 = texture2.lock();
-
-            const target0 = new Uint8Array(data0.buffer);
-            const target1 = new Uint8Array(data1.buffer);
-            const target2 = new Uint8Array(data2.buffer);
-
-            const srcCoeffs = [3, 8, 15][shBands - 1];
-
-            for (let i = 0; i < numSplats; ++i) {
-                for (let j = 0; j < 15; ++j) {
-                    target0[i * 16 + j] = j < srcCoeffs ? shData[(i * 3 + 0) * srcCoeffs + j] : 127;
-                    target1[i * 16 + j] = j < srcCoeffs ? shData[(i * 3 + 1) * srcCoeffs + j] : 127;
-                    target2[i * 16 + j] = j < srcCoeffs ? shData[(i * 3 + 2) * srcCoeffs + j] : 127;
-                }
-            }
-
-            texture0.unlock();
-            texture1.unlock();
-            texture2.unlock();
-
-            this.shTexture0 = texture0;
-            this.shTexture1 = texture1;
-            this.shTexture2 = texture2;
+            this.shTexture0 =this.createTexture('shTexture0', PIXELFORMAT_RGBA32U, size, new Uint32Array(gsplatData.shData0.buffer));
+            this.shTexture1 =this.createTexture('shTexture1', PIXELFORMAT_RGBA32U, size, new Uint32Array(gsplatData.shData1.buffer));
+            this.shTexture2 =this.createTexture('shTexture2', PIXELFORMAT_RGBA32U, size, new Uint32Array(gsplatData.shData2.buffer));
         } else {
             this.shTexture0 = null;
             this.shTexture1 = null;

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -32,9 +32,6 @@ class GSplatCompressed {
     /** @type {BoundingBox} */
     aabb;
 
-    /** @type {Float32Array} */
-    centers;
-
     /** @type {Texture} */
     packedTexture;
 
@@ -65,10 +62,6 @@ class GSplatCompressed {
         this.aabb = new BoundingBox();
         gsplatData.calcAabb(this.aabb);
 
-        // initialize centers
-        this.centers = new Float32Array(numSplats * 3);
-        gsplatData.getCenters(this.centers);
-
         // initialize packed data
         this.packedTexture = this.createTexture('packedData', PIXELFORMAT_RGBA32U, this.evalTextureSize(numSplats), vertexData);
 
@@ -94,9 +87,9 @@ class GSplatCompressed {
         // load optional spherical harmonics data
         if (shBands > 0) {
             const size = this.evalTextureSize(numSplats);
-            this.shTexture0 =this.createTexture('shTexture0', PIXELFORMAT_RGBA32U, size, new Uint32Array(gsplatData.shData0.buffer));
-            this.shTexture1 =this.createTexture('shTexture1', PIXELFORMAT_RGBA32U, size, new Uint32Array(gsplatData.shData1.buffer));
-            this.shTexture2 =this.createTexture('shTexture2', PIXELFORMAT_RGBA32U, size, new Uint32Array(gsplatData.shData2.buffer));
+            this.shTexture0 = this.createTexture('shTexture0', PIXELFORMAT_RGBA32U, size, new Uint32Array(gsplatData.shData0.buffer));
+            this.shTexture1 = this.createTexture('shTexture1', PIXELFORMAT_RGBA32U, size, new Uint32Array(gsplatData.shData1.buffer));
+            this.shTexture2 = this.createTexture('shTexture2', PIXELFORMAT_RGBA32U, size, new Uint32Array(gsplatData.shData2.buffer));
         } else {
             this.shTexture0 = null;
             this.shTexture1 = null;

--- a/src/scene/gsplat/gsplat.js
+++ b/src/scene/gsplat/gsplat.js
@@ -31,9 +31,6 @@ class GSplat {
 
     numSplatsVisible;
 
-    /** @type {Float32Array} */
-    centers;
-
     /** @type {BoundingBox} */
     aabb;
 
@@ -71,9 +68,6 @@ class GSplat {
         this.device = device;
         this.numSplats = numSplats;
         this.numSplatsVisible = numSplats;
-
-        this.centers = new Float32Array(gsplatData.numSplats * 3);
-        gsplatData.getCenters(this.centers);
 
         this.aabb = new BoundingBox();
         gsplatData.calcAabb(this.aabb);


### PR DESCRIPTION
This PR updates the loading code for compressed.ply files that contain spherical harmonics.

The PLY load was reading the raw spherical harmonic data and then `GsplatCompressedData` was packing the data for GPU.

This resulted in almost double the memory requirement for spherical harmonic data at load time.

This PR changes PLY reader to stream in and pack the data in one step, thereby almost halving the memory allocation at load time.

From a quick chrome devtools memory snapshot, loading the 375MB compress.ply bicycle scene has gone from allocating 854MB to 515MB.

## Notes
- we can get further savings by storing fewer copies of unneccessary centers buffers, this will be done separately because the change will require structural changes in the engine