### PR TITLE
Convert internal morph target blending shader to WGSL on WebGPU

### DIFF
--- a/src/platform/graphics/shader-chunks/frag/shared-wgsl.js
+++ b/src/platform/graphics/shader-chunks/frag/shared-wgsl.js
@@ -16,10 +16,10 @@ fn getImageEffectUV(uv: vec2<f32>) -> vec2<f32> {
 }
 
 // types wrapped in size aligned structures to ensure correct alignment in uniform buffer arrays
-struct WrappedF32 { @size(16) x: f32 }
-struct WrappedI32 { @size(16) x: i32 }
-struct WrappedU32 { @size(16) x: u32 }
-struct WrappedVec2F { @size(16) x: f32, y: f32 }
-struct WrappedVec2I { @size(16) x: i32, y: i32 }
-struct WrappedVec2U { @size(16) x: u32, y: u32 }
+struct WrappedF32 { @size(16) element: f32 }
+struct WrappedI32 { @size(16) element: i32 }
+struct WrappedU32 { @size(16) element: u32 }
+struct WrappedVec2F { @size(16) element: vec2f }
+struct WrappedVec2I { @size(16) element: vec2i }
+struct WrappedVec2U { @size(16) element: vec2u }
 `;

--- a/src/platform/graphics/shader-chunks/frag/shared-wgsl.js
+++ b/src/platform/graphics/shader-chunks/frag/shared-wgsl.js
@@ -14,4 +14,12 @@ fn getImageEffectUV(uv: vec2<f32>) -> vec2<f32> {
     modifiedUV.y = 1.0 - modifiedUV.y;
     return modifiedUV;
 }
+
+// types wrapped in size aligned structures to ensure correct alignment in uniform buffer arrays
+struct WrappedF32 { @size(16) x: f32 }
+struct WrappedI32 { @size(16) x: i32 }
+struct WrappedU32 { @size(16) x: u32 }
+struct WrappedVec2F { @size(16) x: f32, y: f32 }
+struct WrappedVec2I { @size(16) x: i32, y: i32 }
+struct WrappedVec2U { @size(16) x: u32, y: u32 }
 `;

--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -553,7 +553,7 @@ class WebgpuShaderProcessorWGSL {
             // array uniforms
             if (uniform.count > 0) {
 
-                // if the type is one of the onces that are not by default 16byte aligned, which is
+                // if the type is one of the ones that are not by default 16byte aligned, which is
                 // a requirement for uniform buffers, we need to wrap them in a struct
                 // for example: array<f32, 5> becomes  array<WrappedF32, 5>
                 if (wrappedArrayTypes.hasOwnProperty(typeString)) {

--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -73,6 +73,15 @@ const textureFormat2SampleType = {
     'u32': SAMPLETYPE_UINT
 };
 
+const wrappedArrayTypes = {
+    'f32': 'WrappedF32',
+    'i32': 'WrappedI32',
+    'u32': 'WrappedU32',
+    'vec2f': 'WrappedVec2F',
+    'vec2i': 'WrappedVec2I',
+    'vec2u': 'WrappedVec2U'
+};
+
 const splitToWords = (line) => {
     // remove any double spaces
     line = line.replace(/\s+/g, ' ').trim();
@@ -81,6 +90,10 @@ const splitToWords = (line) => {
     return line.split(/[\s:]+/);
 };
 
+// matches: array<f32, 4>;
+// eslint-disable-next-line
+const UNIFORM_ARRAY_REGEX = /array<([^,]+),\s*([^>]+)>/;
+
 class UniformLine {
     /**
      * A name of the ub buffer which this uniform is assigned to.
@@ -88,6 +101,8 @@ class UniformLine {
      * @type {string|null}
      */
     ubName = null;
+
+    arraySize = 0;
 
     constructor(line, shader) {
         // Save the raw line
@@ -105,6 +120,22 @@ class UniformLine {
         // Extract the name and type
         this.name = parts[0];
         this.type = parts.slice(1).join(' ');
+
+        // array of uniforms (e.g. array<f32, 5>)
+        if (this.type.includes('array<')) {
+
+            const match = UNIFORM_ARRAY_REGEX.exec(this.type);
+            Debug.assert(match, `Array type on line [${line}] is not supported.`);
+
+            // array type
+            this.type = match[1].trim();
+
+            this.arraySize = Number(match[2]);
+            if (isNaN(this.arraySize)) {
+                shader.failed = true;
+                Debug.error(`Only numerically specified uniform array sizes are supported, this uniform is not supported: '${line}'`, shader);
+            }
+        }
     }
 }
 
@@ -354,12 +385,11 @@ class WebgpuShaderProcessorWGSL {
     }
 
     /**
-     * Process the lines with uniforms. The function receives the lines containing all uniforms,
-     * both numerical as well as textures/samplers. The function also receives the format of uniform
-     * buffers (numerical) and bind groups (textures) for view and material level. All uniforms that
-     * match any of those are ignored, as those would be supplied by view / material level buffers.
-     * All leftover uniforms create uniform buffer and bind group for the mesh itself, containing
-     * uniforms that change on the level of the mesh.
+     * Process the lines with uniforms. The function receives the lines containing all numerical
+     * uniforms. The function also receives the format of uniform buffers for view and material
+     * level. All uniforms that match any of those are ignored, as those would be supplied by view /
+     * material level buffers. All leftover uniforms create uniform buffer and bind group for the
+     * mesh itself, containing uniforms that change on the level of the mesh.
      *
      * @param {GraphicsDevice} device - The graphics device.
      * @param {Array<UniformLine>} uniforms - Lines containing uniforms.
@@ -517,9 +547,25 @@ class WebgpuShaderProcessorWGSL {
         let code = `struct ${structName} {\n`;
 
         ubFormat.uniforms.forEach((uniform) => {
-            const typeString = uniformTypeToNameWGSL[uniform.type][0];
+            let typeString = uniformTypeToNameWGSL[uniform.type][0];
             Debug.assert(typeString !== undefined, `Uniform type ${uniform.type} is not handled.`);
-            code += `    ${uniform.name}: ${typeString}${uniform.count ? `[${uniform.count}]` : ''},\n`;
+
+            // array uniforms
+            if (uniform.count > 0) {
+
+                // if the type is one of the onces that are not by default 16byte aligned, which is
+                // a requirement for uniform buffers, we need to wrap them in a struct
+                // for example: array<f32, 5> becomes  array<WrappedF32, 5>
+                if (wrappedArrayTypes.hasOwnProperty(typeString)) {
+                    typeString = wrappedArrayTypes[typeString];
+                }
+
+                code += `    ${uniform.shortName}: array<${typeString}, ${uniform.count}>,\n`;
+
+            } else { // not arrays
+
+                code += `    ${uniform.shortName}: ${typeString},\n`;
+            }
         });
 
         code += '};\n';

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -47,15 +47,13 @@ class Morph extends RefCountedObject {
 
         Debug.assert(graphicsDevice, 'Morph constructor takes a GraphicsDevice as a parameter, and it was not provided.');
         this.device = graphicsDevice;
+        const device = graphicsDevice;
 
         this.preferHighPrecision = preferHighPrecision;
 
         // validation
         Debug.assert(targets.every(target => !target.used), 'A specified target has already been used to create a Morph, use its clone instead.');
         this._targets = targets.slice();
-
-        // default to texture based morphing if available
-        const device = this.device;
 
         // renderable format
         const renderableHalf = device.textureHalfFloatRenderable ? PIXELFORMAT_RGBA16F : undefined;

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -88,6 +88,10 @@ import immediateLineVS from './internal/vert/immediateLine.js';
 // import metalnessPS from './standard/frag/metalness.js';
 // import msdfPS from './common/frag/msdf.js';
 // import metalnessModulatePS from './lit/frag/metalnessModulate.js';
+import morphEvaluationPS from './internal/morph/frag/morphEvaluation.js';
+import morphDeclarationPS from './internal/morph/frag/morphDeclaration.js';
+import morphPS from './internal/morph/frag/morph.js';
+import morphVS from './internal/morph/vert/morph.js';
 // import msdfVS from './common/vert/msdf.js';
 // import normalVS from './lit/vert/normal.js';
 // import normalCoreVS from './common/vert/normalCore.js';
@@ -297,6 +301,10 @@ const shaderChunksWGSL = {
     // ltcPS,
     // metalnessPS,
     // metalnessModulatePS,
+    morphEvaluationPS,
+    morphDeclarationPS,
+    morphPS,
+    morphVS,
     // msdfPS,
     // msdfVS,
     // normalVS,

--- a/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morph.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morph.js
@@ -1,0 +1,26 @@
+// fragment shader internally used to apply morph targets in textures into a final texture containing
+// blended morph targets
+export default /* wgsl */`
+
+    varying uv0: vec2f;
+
+    // LOOP - source morph target textures
+    #include "morphDeclarationPS, MORPH_TEXTURE_COUNT"
+
+    #if MORPH_TEXTURE_COUNT > 0
+        uniform morphFactor: array<f32, {MORPH_TEXTURE_COUNT}>;
+    #endif
+
+    @fragment
+    fn fragmentMain(input : FragmentInput) -> FragmentOutput {
+        var output: FragmentOutput;
+
+        var color = vec3f(0, 0, 0);
+
+        // LOOP - source morph target textures
+        #include "morphEvaluationPS, MORPH_TEXTURE_COUNT"
+
+        output.color = vec4f(color, 1.0);
+        return output;
+    }
+`;

--- a/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphDeclaration.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphDeclaration.js
@@ -1,0 +1,4 @@
+export default /* wgsl */`
+    var morphBlendTex{i}: texture_2d<f32>;
+    var morphBlendTex{i}Sampler : sampler;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphEvaluation.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphEvaluation.js
@@ -1,3 +1,3 @@
 export default /* wgsl */`
-    color += uniform.morphFactor[{i}].x * textureSample(morphBlendTex{i}, morphBlendTex{i}Sampler, input.uv0).xyz;
+    color += uniform.morphFactor[{i}].element * textureSample(morphBlendTex{i}, morphBlendTex{i}Sampler, input.uv0).xyz;
 `;

--- a/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphEvaluation.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphEvaluation.js
@@ -1,0 +1,3 @@
+export default /* wgsl */`
+    color += uniform.morphFactor[{i}].x * textureSample(morphBlendTex{i}, morphBlendTex{i}Sampler, input.uv0).xyz;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/internal/morph/vert/morph.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/morph/vert/morph.js
@@ -1,0 +1,14 @@
+// vertex shader internally used to apply morph targets in textures into a final texture containing
+// blended morph targets
+export default /* wgsl */`
+    attribute vertex_position: vec2f;
+    varying uv0: vec2f;
+
+    @vertex
+    fn vertexMain(input: VertexInput) -> VertexOutput {
+      var output: VertexOutput;
+      output.position = vec4f(input.vertex_position, 0.5, 1.0);
+      output.uv0 = input.vertex_position * 0.5 + vec2f(0.5, 0.5);
+      return output;
+    }
+`;

--- a/src/scene/shader-lib/chunks-wgsl/internal/morph/vert/morph.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/morph/vert/morph.js
@@ -6,9 +6,9 @@ export default /* wgsl */`
 
     @vertex
     fn vertexMain(input: VertexInput) -> VertexOutput {
-      var output: VertexOutput;
-      output.position = vec4f(input.vertex_position, 0.5, 1.0);
-      output.uv0 = input.vertex_position * 0.5 + vec2f(0.5, 0.5);
-      return output;
+        var output: VertexOutput;
+        output.position = vec4f(input.vertex_position, 0.5, 1.0);
+        output.uv0 = input.vertex_position * 0.5 + vec2f(0.5, 0.5);
+        return output;
     }
 `;

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -88,6 +88,10 @@ import ltcPS from './lit/frag/ltc.js';
 import metalnessPS from './standard/frag/metalness.js';
 import msdfPS from './common/frag/msdf.js';
 import metalnessModulatePS from './lit/frag/metalnessModulate.js';
+import morphEvaluationPS from './internal/morph/frag/morphEvaluation.js';
+import morphDeclarationPS from './internal/morph/frag/morphDeclaration.js';
+import morphPS from './internal/morph/frag/morph.js';
+import morphVS from './internal/morph/vert/morph.js';
 import msdfVS from './common/vert/msdf.js';
 import normalVS from './lit/vert/normal.js';
 import normalCoreVS from './common/vert/normalCore.js';
@@ -296,6 +300,10 @@ const shaderChunks = {
     ltcPS,
     metalnessPS,
     metalnessModulatePS,
+    morphEvaluationPS,
+    morphDeclarationPS,
+    morphPS,
+    morphVS,
     msdfPS,
     msdfVS,
     normalVS,

--- a/src/scene/shader-lib/chunks/internal/morph/frag/morph.js
+++ b/src/scene/shader-lib/chunks/internal/morph/frag/morph.js
@@ -1,0 +1,32 @@
+// fragment shader internally used to apply morph targets in textures into a final texture containing
+// blended morph targets
+export default /* glsl */`
+
+    varying vec2 uv0;
+
+    // LOOP - source morph target textures
+    #include "morphDeclarationPS, MORPH_TEXTURE_COUNT"
+
+    #if MORPH_TEXTURE_COUNT > 0
+        uniform highp float morphFactor[{MORPH_TEXTURE_COUNT}];
+    #endif
+
+    #ifdef MORPH_INT
+        uniform vec3 aabbSize;
+        uniform vec3 aabbMin;
+    #endif
+
+    void main (void) {
+        highp vec4 color = vec4(0, 0, 0, 1);
+
+        // LOOP - source morph target textures
+        #include "morphEvaluationPS, MORPH_TEXTURE_COUNT"
+
+        #ifdef MORPH_INT
+            color.xyz = (color.xyz - aabbMin) / aabbSize * 65535.0;
+            gl_FragColor = uvec4(color);
+        #else
+            gl_FragColor = color;
+        #endif
+    }
+`;

--- a/src/scene/shader-lib/chunks/internal/morph/frag/morphDeclaration.js
+++ b/src/scene/shader-lib/chunks/internal/morph/frag/morphDeclaration.js
@@ -1,0 +1,3 @@
+export default /* glsl */`
+    uniform highp sampler2D morphBlendTex{i};
+`;

--- a/src/scene/shader-lib/chunks/internal/morph/frag/morphEvaluation.js
+++ b/src/scene/shader-lib/chunks/internal/morph/frag/morphEvaluation.js
@@ -1,0 +1,3 @@
+export default /* glsl */`
+    color.xyz += morphFactor[{i}] * texture2D(morphBlendTex{i}, uv0).xyz;
+`;

--- a/src/scene/shader-lib/chunks/internal/morph/vert/morph.js
+++ b/src/scene/shader-lib/chunks/internal/morph/vert/morph.js
@@ -1,0 +1,10 @@
+// vertex shader internally used to apply morph targets in textures into a final texture containing
+// blended morph targets
+export default /* glsl */`
+    attribute vec2 vertex_position;
+    varying vec2 uv0;
+    void main(void) {
+        gl_Position = vec4(vertex_position, 0.5, 1.0);
+        uv0 = vertex_position.xy * 0.5 + 0.5;
+    }
+`;


### PR DESCRIPTION
## Morph changes

- morph target blending shader was generated using GLSL and string concatenation, then transpiled to WGSL.
- now the shader has been converted to chunks, and the final shader (for the required number of weights) gets generated using defines.
- these newly created chunks were also converted to WGSL to avoid GLSL transpilation on WebGPU

## Other changes

Support for uniform arrays had been added to WGSL parsing / processing to support morphing. There are some WGSL limitation / requirements regarding uniform arrays: the elements in the array need to be 16byte aligned. This is by default not satisfied for f32 and Vec2f types and their integer variants, and so those types are internally wrapped in structs that are aligned.

Example:
```
uniform a: array<vec2f, 10>
var data = a[3];
```

gets internally transformed to
```
struct WrappedVec2F { @size(16) element: vec2f }
uniform a: array<WrappedVec2F, 10>
var data = a[3].element;
```

by the way, this is what our transpilation pipeline does as well / it's the recommended way to transfer GLSL arrays to WGSL, the only thing to be away of is that access is done using `.element`. The transpilation would handle this bit as well.