### PR TITLE
Improved validation of vertex attributes required by the shader

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -10,7 +10,8 @@ import {
     CULLFACE_BACK,
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH,
     PRIMITIVE_POINTS, PRIMITIVE_TRIFAN, SEMANTIC_POSITION, TYPE_FLOAT32, PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F,
-    DISPLAYFORMAT_LDR
+    DISPLAYFORMAT_LDR,
+    semanticToLocation
 } from './constants.js';
 import { BlendState } from './blend-state.js';
 import { DepthState } from './depth-state.js';
@@ -1027,17 +1028,16 @@ class GraphicsDevice extends EventHandler {
     validateAttributes(shader, vb0Format, vb1Format) {
 
         Debug.call(() => {
-            // add all attribute names from vertex formats to the set
-            _tempSet.clear();
-            vb0Format?.elements.forEach(element => _tempSet.add(element.name));
-            vb1Format?.elements.forEach(element => _tempSet.add(element.name));
 
-            // this is an object, we need to iterator over keys and make sure the value is in the temp set
-            const attributes = shader.definition.attributes;
-            for (const name in attributes) {
-                const value = attributes[name];
-                if (!_tempSet.has(value)) {
-                    Debug.errorOnce(`Attribute [${name}: ${value}] required by the shader is not present in the currently assigned vertex buffers, while rendering [${DebugGraphics.toString()}]`, {
+            // add all attribute locations from vertex formats to the set
+            _tempSet.clear();
+            vb0Format?.elements.forEach(element => _tempSet.add(semanticToLocation[element.name]));
+            vb1Format?.elements.forEach(element => _tempSet.add(semanticToLocation[element.name]));
+
+            // every location shader needs must be in the vertex buffer
+            for (const [location, name] of shader.attributes) {
+                if (!_tempSet.has(location)) {
+                    Debug.errorOnce(`Vertex attribute [${name}] at location ${location} required by the shader is not present in the currently assigned vertex buffers, while rendering [${DebugGraphics.toString()}]`, {
                         shader,
                         vb0Format,
                         vb1Format

--- a/src/platform/graphics/shader-processor-glsl.js
+++ b/src/platform/graphics/shader-processor-glsl.js
@@ -132,7 +132,8 @@ class ShaderProcessorGLSL {
         const fragmentExtracted = ShaderProcessorGLSL.extract(shaderDefinition.fshader);
 
         // VS - convert a list of attributes to a shader block with fixed locations
-        const attributesBlock = ShaderProcessorGLSL.processAttributes(vertexExtracted.attributes, shaderDefinition.attributes, shaderDefinition.processingOptions);
+        const attributesMap = new Map();
+        const attributesBlock = ShaderProcessorGLSL.processAttributes(vertexExtracted.attributes, shaderDefinition.attributes, attributesMap, shaderDefinition.processingOptions);
 
         // VS - convert a list of varyings to a shader block
         const vertexVaryingsBlock = ShaderProcessorGLSL.processVaryings(vertexExtracted.varyings, varyingMap, true);
@@ -173,6 +174,7 @@ class ShaderProcessorGLSL {
         return {
             vshader: vshader,
             fshader: fshader,
+            attributes: attributesMap,
             meshUniformBufferFormat: uniformsData.meshUniformBufferFormat,
             meshBindGroupFormat: uniformsData.meshBindGroupFormat
         };
@@ -393,7 +395,7 @@ class ShaderProcessorGLSL {
         return isNaN(num) ? 1 : num;
     }
 
-    static processAttributes(attributeLines, shaderDefinitionAttributes, processingOptions) {
+    static processAttributes(attributeLines, shaderDefinitionAttributes, attributesMap, processingOptions) {
         let block = '';
         const usedLocations = {};
         attributeLines.forEach((line) => {
@@ -409,6 +411,9 @@ class ShaderProcessorGLSL {
                 Debug.assert(!usedLocations.hasOwnProperty(location),
                     `WARNING: Two vertex attributes are mapped to the same location in a shader: ${usedLocations[location]} and ${semantic}`);
                 usedLocations[location] = semantic;
+
+                // build a map of used attributes
+                attributesMap.set(location, name);
 
                 // if vertex format for this attribute is not of a float type, we need to adjust the attribute format, for example we convert
                 //      attribute vec4 vertex_position;

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -42,7 +42,7 @@ class Shader {
     meshBindGroupFormat;
 
     /**
-     * The attributes that this shader code uses, the location is the key, the value is the name.
+     * The attributes that this shader code uses. The location is the key, the value is the name.
      * These attributes are queried / extracted from the final shader.
      *
      * @type {Map<number, string>}

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -42,6 +42,15 @@ class Shader {
     meshBindGroupFormat;
 
     /**
+     * The attributes that this shader code uses, the location is the key, the value is the name.
+     * These attributes are queried / extracted from the final shader.
+     *
+     * @type {Map<number, string>}
+     * @ignore
+     */
+    attributes = new Map();
+
+    /**
      * Creates a new Shader instance.
      *
      * Consider {@link createShaderFromCode} as a simpler and more powerful way to create

--- a/src/platform/graphics/webgl/webgl-shader-input.js
+++ b/src/platform/graphics/webgl/webgl-shader-input.js
@@ -27,10 +27,10 @@ class WebglShaderInput {
      * @param {number | WebGLUniformLocation} locationId - The location id of the shader input.
      */
     constructor(graphicsDevice, name, type, locationId) {
-        // Set the shader attribute location
+        // Set the shader uniform location
         this.locationId = locationId;
 
-        // Resolve the ScopeId for the attribute name
+        // Resolve the ScopeId for the uniform name
         this.scopeId = graphicsDevice.scope.resolve(name);
 
         // Create the version

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -311,6 +311,7 @@ class WebglShader {
 
         // Query the program for each vertex buffer input (GLSL 'attribute')
         const numAttributes = gl.getProgramParameter(glProgram, gl.ACTIVE_ATTRIBUTES);
+        shader.attributes.clear();
         for (let i = 0; i < numAttributes; i++) {
             const info = gl.getActiveAttrib(glProgram, i);
             const location = gl.getAttribLocation(glProgram, info.name);
@@ -325,8 +326,7 @@ class WebglShader {
                 console.error(`Vertex shader attribute "${info.name}" is not mapped to a semantic in shader definition, shader [${shader.label}]`, shader);
                 shader.failed = true;
             } else {
-                const shaderInput = new WebglShaderInput(device, definition.attributes[info.name], device.pcUniformType[info.type], location);
-                this.attributes.push(shaderInput);
+                shader.attributes.set(location, info.name);
             }
         }
 

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -161,6 +161,7 @@ class WebgpuShader {
 
         shader.meshUniformBufferFormat = processed.meshUniformBufferFormat;
         shader.meshBindGroupFormat = processed.meshBindGroupFormat;
+        shader.attributes = processed.attributes;
     }
 
     processWGSL() {
@@ -179,6 +180,7 @@ class WebgpuShader {
 
         shader.meshUniformBufferFormat = processed.meshUniformBufferFormat;
         shader.meshBindGroupFormat = processed.meshBindGroupFormat;
+        shader.attributes = processed.attributes;
     }
 
     transpile(src, shaderType, originalSrc) {


### PR DESCRIPTION
Validation introduced in https://github.com/playcanvas/engine/pull/7431 had false positives in case the user requested additional attributes on the Material, but those were not used in all variants (for example an instancing-capable shader used on non-instanced mesh)

This PR fixes it. We validate attributes from VertexBuffers not against all attributes shader has available, but against the list of those extracted from the final shader. For WebGL those are extracted using `getActiveAttrib`, for WebGPU from one of our shader processors (GLSL or WGSL)