### PR TITLE
Updated HDR example to not allow control for UI tonemapping

### DIFF
--- a/examples/src/examples/graphics/hdr.controls.mjs
+++ b/examples/src/examples/graphics/hdr.controls.mjs
@@ -36,23 +36,6 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: pc.TONEMAP_NEUTRAL, t: 'NEUTRAL' }
                 ]
             })
-        ),
-        jsx(
-            LabelGroup,
-            { text: 'UI Tonemap' },
-            jsx(SelectInput, {
-                binding: new BindingTwoWay(),
-                link: { observer, path: 'data.uiTonemapping' },
-                type: 'number',
-                options: [
-                    { v: pc.TONEMAP_NONE, t: 'NONE' },
-                    { v: pc.TONEMAP_FILMIC, t: 'FILMIC' },
-                    { v: pc.TONEMAP_HEJL, t: 'HEJL' },
-                    { v: pc.TONEMAP_ACES, t: 'ACES' },
-                    { v: pc.TONEMAP_ACES2, t: 'ACES2' },
-                    { v: pc.TONEMAP_NEUTRAL, t: 'NEUTRAL' }
-                ]
-            })
         )
     );
 };

--- a/examples/src/examples/graphics/hdr.example.mjs
+++ b/examples/src/examples/graphics/hdr.example.mjs
@@ -178,18 +178,12 @@ assetListLoader.load(() => {
             cameraFrame.rendering.toneMapping = value;
             cameraFrame.update();
         }
-
-        if (path === 'data.uiTonemapping') {
-            // camera tone mapping is applied to the UI
-            cameraEntity.camera.toneMapping = value;
-        }
     });
 
     // set initial values
     data.set('data', {
         hdr: true,
-        sceneTonemapping: pc.TONEMAP_ACES,
-        uiTonemapping: pc.TONEMAP_NONE
+        sceneTonemapping: pc.TONEMAP_ACES
     });
 });
 


### PR DESCRIPTION
- When CameraFrame is used, UI tonemapping could be controlled, and this was added to the example.
- now that [this issue](https://github.com/playcanvas/engine/pull/7405) has been fixed, this is no longer possible, as UI material's are set to 'useTonemap = false`.
- hence removing this from the example. To get it to work, we'd need to expose `useTonemap` setting for UI materials, which is not easy at this point, for a feature not likely needed.

Conclusion: tonemapping for UI cannot be controlled, but as the example demonstrates, the tonamapping control for the scene (in the default case, or CameraFrame case) does not affect the UI, which is always not tonemapped.