### PR TITLE
Shadow casting support for gsplat

### DIFF
--- a/examples/src/examples/loaders/gsplat.example.mjs
+++ b/examples/src/examples/loaders/gsplat.example.mjs
@@ -53,23 +53,27 @@ const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets
 assetListLoader.load(() => {
     app.start();
 
+    // create a splat entity and place it in the world
+    const biker = new pc.Entity();
+    biker.addComponent('gsplat', {
+        asset: assets.biker,
+        castShadows: true
+    });
+    biker.setLocalPosition(-1.5, 0.05, 0);
+    biker.setLocalEulerAngles(180, 90, 0);
+    biker.setLocalScale(0.7, 0.7, 0.7);
+    app.root.addChild(biker);
+
+    // set alpha clip value, used by shadows and picking
+    biker.gsplat.material.setParameter('alphaClip', 0.4);
+
     // Create an Entity with a camera component
     const camera = new pc.Entity();
     camera.addComponent('camera', {
         clearColor: new pc.Color(0.2, 0.2, 0.2),
         toneMapping: pc.TONEMAP_ACES
     });
-    camera.setLocalPosition(2, 1, 1);
-
-    // create a splat entity and place it in the world
-    const biker = new pc.Entity();
-    biker.addComponent('gsplat', {
-        asset: assets.biker
-    });
-    biker.setLocalPosition(-1.5, 0.05, 0);
-    biker.setLocalEulerAngles(180, 90, 0);
-    biker.setLocalScale(0.7, 0.7, 0.7);
-    app.root.addChild(biker);
+    camera.setLocalPosition(-0.8, 2, 3);
 
     // add orbit camera script with a mouse and a touch support
     camera.addComponent('script');
@@ -84,6 +88,46 @@ assetListLoader.load(() => {
     camera.script.create('orbitCameraInputMouse');
     camera.script.create('orbitCameraInputTouch');
     app.root.addChild(camera);
+
+    // create ground to receive shadows
+    const material = new pc.StandardMaterial();
+    material.diffuse = new pc.Color(0.5, 0.5, 0.4);
+    material.gloss = 0.2;
+    material.metalness = 0.5;
+    material.useMetalness = true;
+    material.update();
+
+    const ground = new pc.Entity();
+    ground.addComponent('render', {
+        type: 'box',
+        material: material,
+        castShadows: false
+    });
+    ground.setLocalScale(10, 1, 10);
+    ground.setLocalPosition(0, -0.45, 0);
+    app.root.addChild(ground);
+
+    // shadow casting directional light
+    // Note: it does not affect gsplat, as lighting is not supported there currently
+    const directionalLight = new pc.Entity();
+    directionalLight.addComponent('light', {
+        type: 'directional',
+        color: pc.Color.WHITE,
+        castShadows: true,
+        intensity: 1,
+        shadowBias: 0.2,
+        normalOffsetBias: 0.05,
+        shadowDistance: 10,
+        shadowIntensity: 0.5,
+        shadowResolution: 2048,
+        shadowType: pc.SHADOW_PCSS_32F,
+        penumbraSize: 10,
+        penumbraFalloff: 4,
+        shadowSamples: 16,
+        shadowBlockerSamples: 16
+    });
+    directionalLight.setEulerAngles(55, 0, 20);
+    app.root.addChild(directionalLight);
 });
 
 export { app };

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -72,6 +72,9 @@ class GSplatComponent extends Component {
      */
     _evtLayerRemoved = null;
 
+    /** @private */
+    _castShadows = false;
+
     /**
      * Create a new GSplatComponent.
      *
@@ -144,6 +147,7 @@ class GSplatComponent extends Component {
                 mi.node = this.entity;
             }
 
+            mi.castShadow = this._castShadows;
             mi.setCustomAabb(this._customAabb);
 
             // if we have custom shader options, apply them
@@ -187,6 +191,55 @@ class GSplatComponent extends Component {
      */
     get material() {
         return this._instance?.material;
+    }
+
+    /**
+     * Sets whether gsplat will cast shadows for lights that have shadow casting enabled. Defaults
+     * to false.
+     *
+     * @type {boolean}
+     */
+    set castShadows(value) {
+
+        if (this._castShadows !== value) {
+
+            const mi = this.instance?.meshInstance;
+
+            if (mi) {
+                const layers = this.layers;
+                const scene = this.system.app.scene;
+                if (this._castShadows && !value) {
+                    for (let i = 0; i < layers.length; i++) {
+                        const layer = scene.layers.getLayerById(this.layers[i]);
+                        if (layer) {
+                            layer.removeShadowCasters([mi]);
+                        }
+                    }
+                }
+
+                mi.castShadow = value;
+
+                if (!this._castShadows && value) {
+                    for (let i = 0; i < layers.length; i++) {
+                        const layer = scene.layers.getLayerById(layers[i]);
+                        if (layer) {
+                            layer.addShadowCasters([mi]);
+                        }
+                    }
+                }
+            }
+
+            this._castShadows = value;
+        }
+    }
+
+    /**
+     * Gets whether gsplat will cast shadows for lights that have shadow casting enabled.
+     *
+     * @type {boolean}
+     */
+    get castShadows() {
+        return this._castShadows;
     }
 
     /**

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -15,6 +15,7 @@ const _schema = [
 
 // order matters here
 const _properties = [
+    'castShadows',
     'instance',
     'asset',
     'layers'

--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -161,6 +161,7 @@ class GSplatInstance {
     createMaterial(options) {
         this.material = this.splat.createMaterial(options);
         this.material.setParameter('splatOrder', this.orderTexture);
+        this.material.setParameter('alphaClip', 0.3);
         if (this.meshInstance) {
             this.meshInstance.material = this.material;
         }

--- a/src/scene/shader-lib/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/chunks/gsplat/frag/gsplat.js
@@ -7,7 +7,11 @@ export default /* glsl */`
 #endif
 
 #ifdef PICK_PASS
-    uniform vec4 uColor;
+    #include "pickPS"
+#endif
+
+#if defined(SHADOW_PASS) || defined(PICK_PASS)
+    uniform float alphaClip;
 #endif
 
 varying mediump vec2 gaussianUV;
@@ -23,10 +27,17 @@ void main(void) {
     mediump float alpha = exp(-A * 4.0) * gaussianColor.a;
 
     #ifdef PICK_PASS
-        if (alpha < 0.3) {
+        if (alpha < alphaClip) {
             discard;
         }
-        gl_FragColor = uColor;
+        gl_FragColor = getPickOutput();
+    #elif SHADOW_PASS
+
+        if (alpha < alphaClip) {
+            discard;
+        }
+        gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+
     #else
         if (alpha < 1.0 / 255.0) {
             discard;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/6974 - the splat shader is now compatible with the picker.

Added support for shadow casting by gsplats.
**New API**

```
// similar to render / model coponent
GsplatComponent.castShadows = true;  // defaults to false

// create splat like this:
    const biker = new pc.Entity();
    biker.addComponent('gsplat', {
        asset: assets.biker,
        castShadows: true
    });
```

Updated example:
<img width="1057" alt="Screenshot 2025-03-21 at 12 04 17" src="https://github.com/user-attachments/assets/89d42aa9-9660-4b1c-bf3d-16606773ff09" />

It's also compatible with shadow catcher script:
<img width="1079" alt="Screenshot 2025-03-21 at 11 24 06" src="https://github.com/user-attachments/assets/36065c7d-f3f0-452d-8f4f-1e1c137bad3c" />

Also fixed compatibility with the picker, and so the splats can be picked (not individual splats, the the whole object)
picker buffer:
<img width="525" alt="Screenshot 2025-03-21 at 12 00 17" src="https://github.com/user-attachments/assets/ac8c74ed-3208-43f2-b404-c27625c0f81f" />
