### PR TITLE
[Fix] Fix the high quality morph option on WebGPU

### DIFF
--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -5,7 +5,7 @@ import { FloatPacking } from '../core/math/float-packing.js';
 import { BoundingBox } from '../core/shape/bounding-box.js';
 import {
     TYPE_UINT32, SEMANTIC_ATTR15, ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST,
-    PIXELFORMAT_RGBA16F, PIXELFORMAT_RGB32F, PIXELFORMAT_RGBA32F, PIXELFORMAT_RGBA16U,
+    PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F, PIXELFORMAT_RGBA16U,
     isIntegerPixelFormat
 } from '../platform/graphics/constants.js';
 import { Texture } from '../platform/graphics/texture.js';
@@ -66,7 +66,7 @@ class Morph extends RefCountedObject {
         this.intRenderFormat = isIntegerPixelFormat(this._renderTextureFormat);
 
         // source texture format - both are always supported
-        this._textureFormat = this.preferHighPrecision ? PIXELFORMAT_RGB32F : PIXELFORMAT_RGBA16F;
+        this._textureFormat = this.preferHighPrecision ? PIXELFORMAT_RGBA32F : PIXELFORMAT_RGBA16F;
 
         this._init();
         this._updateMorphFlags();
@@ -181,11 +181,9 @@ class Morph extends RefCountedObject {
 
         // texture format based vars
         let halfFloat = false;
-        let numComponents = 3;  // RGB32 is used
         const float2Half = FloatPacking.float2Half;
         if (this._textureFormat === PIXELFORMAT_RGBA16F) {
             halfFloat = true;
-            numComponents = 4;  // RGBA16 is used, RGB16 does not work
         }
 
         // create textures
@@ -205,7 +203,7 @@ class Morph extends RefCountedObject {
 
                 for (let v = 0; v < usedDataIndices.length; v++) {
                     const index = usedDataIndices[v] * 3;
-                    const dstIndex = v * numComponents + numComponents;
+                    const dstIndex = v * 4 + 4;
                     textureData[dstIndex] = float2Half(data[index]);
                     textureData[dstIndex + 1] = float2Half(data[index + 1]);
                     textureData[dstIndex + 2] = float2Half(data[index + 2]);
@@ -215,7 +213,7 @@ class Morph extends RefCountedObject {
 
                 for (let v = 0; v < usedDataIndices.length; v++) {
                     const index = usedDataIndices[v] * 3;
-                    const dstIndex = v * numComponents + numComponents;
+                    const dstIndex = v * 4 + 4;
                     textureData[dstIndex] = data[index];
                     textureData[dstIndex + 1] = data[index + 1];
                     textureData[dstIndex + 2] = data[index + 2];

--- a/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphEvaluation.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphEvaluation.js
@@ -1,3 +1,3 @@
 export default /* wgsl */`
-    color += uniform.morphFactor[{i}].element * textureSample(morphBlendTex{i}, morphBlendTex{i}Sampler, input.uv0).xyz;
+    color += uniform.morphFactor[{i}].element * textureSampleLevel(morphBlendTex{i}, morphBlendTex{i}Sampler, input.uv0, 0).xyz;
 `;

--- a/src/scene/shader-lib/chunks/internal/morph/frag/morphEvaluation.js
+++ b/src/scene/shader-lib/chunks/internal/morph/frag/morphEvaluation.js
@@ -1,3 +1,3 @@
 export default /* glsl */`
-    color.xyz += morphFactor[{i}] * texture2D(morphBlendTex{i}, uv0).xyz;
+    color.xyz += morphFactor[{i}] * texture2DLod(morphBlendTex{i}, uv0, 0.0).xyz;
 `;


### PR DESCRIPTION
- WebGPU does not support RGB32F format, use RGBA32F
- do the same for WebGL, as the RGB is possibly simulated anyways
- (no effect) switch sampling to LOD, might be slightly more efficient, as we don't use mipmaps anyways here