### PR TITLE
Gsplat sorting update

### DIFF
--- a/src/scene/gsplat/gsplat-compressed-data.js
+++ b/src/scene/gsplat/gsplat-compressed-data.js
@@ -221,6 +221,29 @@ class GSplatCompressedData {
         }
     }
 
+    getChunks(result) {
+        const { chunkData, numChunks, chunkSize } = this;
+
+        let mx, my, mz, Mx, My, Mz;
+
+        for (let c = 0; c < numChunks; ++c) {
+            const off = c * chunkSize;
+            mx = chunkData[off + 0];
+            my = chunkData[off + 1];
+            mz = chunkData[off + 2];
+            Mx = chunkData[off + 3];
+            My = chunkData[off + 4];
+            Mz = chunkData[off + 5];
+
+            result[c * 6 + 0] = mx;
+            result[c * 6 + 1] = my;
+            result[c * 6 + 2] = mz;
+            result[c * 6 + 3] = Mx;
+            result[c * 6 + 4] = My;
+            result[c * 6 + 5] = Mz;
+        }
+    }
+
     /**
      * @param {Vec3} result - The result.
      */

--- a/src/scene/gsplat/gsplat-compressed.js
+++ b/src/scene/gsplat/gsplat-compressed.js
@@ -69,6 +69,9 @@ class GSplatCompressed {
         this.centers = new Float32Array(numSplats * 3);
         gsplatData.getCenters(this.centers);
 
+        this.chunks = new Float32Array(numChunks * 6);
+        gsplatData.getChunks(this.chunks);
+
         // initialize packed data
         this.packedTexture = this.createTexture('packedData', PIXELFORMAT_RGBA32U, this.evalTextureSize(numSplats), vertexData);
 

--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -132,12 +132,13 @@ class GSplatInstance {
         this.meshInstance.instancingCount = 0;
 
         // clone centers to allow multiple instances of sorter
-        this.centers = new Float32Array(splat.centers);
+        const centers = splat.centers.slice();
+        const chunks = splat.chunks?.slice();
 
         // create sorter
         if (!options.dither || options.dither === DITHER_NONE) {
             this.sorter = new GSplatSorter();
-            this.sorter.init(this.orderTexture, this.centers);
+            this.sorter.init(this.orderTexture, centers, chunks);
             this.sorter.on('updated', (count) => {
                 // limit splat render count to exclude those behind the camera
                 this.meshInstance.instancingCount = Math.ceil(count / splatInstanceSize);

--- a/src/scene/gsplat/gsplat-sorter.js
+++ b/src/scene/gsplat/gsplat-sorter.js
@@ -5,6 +5,7 @@ import { TEXTURELOCK_READ } from '../../platform/graphics/constants.js';
 function SortWorker() {
     let order;
     let centers;
+    let chunks;
     let mapping;
     let cameraPosition;
     let cameraDirection;
@@ -19,6 +20,11 @@ function SortWorker() {
 
     let distances;
     let countBuffer;
+
+    const numBins = 16;
+    const binCount = new Array(numBins).fill(0);
+    const binBase = new Array(numBins).fill(0);
+    const binDivider = new Array(numBins).fill(0);
 
     const binarySearch = (m, n, compare_fn) => {
         while (m <= n) {
@@ -99,16 +105,59 @@ function SortWorker() {
             countBuffer.fill(0);
         }
 
-        // generate per vertex distance to camera
         const range = maxDist - minDist;
-        const divider = (range < 1e-6) ? 0 : 1 / range * (2 ** compareBits);
+
+        // accumulate chunks into bins
+        if (chunks) {
+            const numChunks = chunks.length / 6;
+
+            // reset counts
+            binCount.fill(0);
+
+            for (let i = 0; i < numChunks; ++i) {
+                const x = chunks[i * 6 + 0];
+                const y = chunks[i * 6 + 1];
+                const z = chunks[i * 6 + 2];
+                const r = chunks[i * 6 + 3];
+                const d = x * dx + y * dy + z * dz - minDist;
+
+                const binMin = Math.max(0, Math.floor((d - r) * numBins / range));
+                const binMax = Math.min(numBins, Math.ceil((d + r) * numBins / range));
+
+                for (let j = binMin; j < binMax; ++j) {
+                    binCount[j]++;
+                }
+            }
+
+            // count total number of bin entries
+            const binTotal = binCount.reduce((a, b) => a + b, 0);
+
+            // calculate per-bin base and divider
+            for (let i = 0; i < numBins; ++i) {
+                binDivider[i] = Math.ceil(binCount[i] / binTotal * bucketCount);
+            }
+            for (let i = 0; i < numBins; ++i) {
+                binBase[i] = i === 0 ? 0 : binBase[i - 1] + binDivider[i - 1];
+            }
+        }
+
+        // generate per vertex distance to camera
+        const divider = (range < 1e-6) ? 0 : (2 ** compareBits) / range;
+        const binRange = range / numBins;
         for (let i = 0; i < numVertices; ++i) {
             const istride = i * 3;
             const x = centers[istride + 0];
             const y = centers[istride + 1];
             const z = centers[istride + 2];
-            const d = x * dx + y * dy + z * dz;
-            const sortKey = Math.floor((d - minDist) * divider);
+            const d = (x * dx + y * dy + z * dz - minDist) / binRange;
+
+            const bin = Math.floor(d);
+            const sortKey = Math.floor(binBase[bin] + binDivider[bin] * (d % 1));
+
+            // TMP
+            if (sortKey < 0 || sortKey >= bucketCount) {
+                console.log(`i=${i} d=${d} bin=${bin} sortKey=${sortKey} bucketCount=${bucketCount}`);
+            }
 
             distances[i] = sortKey;
 
@@ -129,13 +178,15 @@ function SortWorker() {
         }
 
         // find splat with distance 0 to limit rendering behind the camera
-        const tmp = -px * dx - py * dy - pz * dz;
-        const dist = i => distances[order[i]] / divider + minDist + tmp;
+        const tmp = px * dx + py * dy + pz * dz - minDist;
+        const dist = i => distances[order[i]] / divider - tmp;
         const findZero = () => {
             const result = binarySearch(0, numVertices - 1, i => -dist(i));
             return Math.min(numVertices, Math.abs(result));
         };
-        const count = dist(numVertices - 1) >= 0 ? findZero() : numVertices;
+
+        // TOOD: find 0 distance splat
+        const count = numVertices; // dist(numVertices - 1) >= 0 ? findZero() : numVertices;
 
         // apply mapping
         if (mapping) {
@@ -159,6 +210,7 @@ function SortWorker() {
         }
         if (message.data.centers) {
             centers = new Float32Array(message.data.centers);
+            forceUpdate = true;
 
             // calculate bounds
             let initialized = false;
@@ -196,8 +248,25 @@ function SortWorker() {
             if (!initialized) {
                 boundMin.x = boundMax.x = boundMin.y = boundMax.y = boundMin.z = boundMax.z = 0;
             }
-
+        }
+        if (message.data.chunks) {
+            chunks = new Float32Array(message.data.chunks);
             forceUpdate = true;
+
+            // convert chunk min/max to center/radius
+            for (let i = 0; i < chunks.length / 6; ++i) {
+                const mx = chunks[i * 6 + 0];
+                const my = chunks[i * 6 + 1];
+                const mz = chunks[i * 6 + 2];
+                const Mx = chunks[i * 6 + 3];
+                const My = chunks[i * 6 + 4];
+                const Mz = chunks[i * 6 + 5];
+
+                chunks[i * 6 + 0] = (mx + Mx) * 0.5;
+                chunks[i * 6 + 1] = (my + My) * 0.5;
+                chunks[i * 6 + 2] = (mz + Mz) * 0.5;
+                chunks[i * 6 + 3] = Math.sqrt((Mx - mx) ** 2 + (My - my) ** 2 + (Mz - mz) ** 2) * 0.5;
+            }
         }
         if (message.data.hasOwnProperty('mapping')) {
             mapping = message.data.mapping ? new Uint32Array(message.data.mapping) : null;
@@ -247,7 +316,7 @@ class GSplatSorter extends EventHandler {
         this.worker = null;
     }
 
-    init(orderTexture, centers) {
+    init(orderTexture, centers, chunks) {
         this.orderTexture = orderTexture;
         this.centers = centers.slice();
 
@@ -266,8 +335,9 @@ class GSplatSorter extends EventHandler {
         // send the initial buffer to worker
         this.worker.postMessage({
             order: orderBuffer,
-            centers: centers.buffer
-        }, [orderBuffer, centers.buffer]);
+            centers: centers.buffer,
+            chunks: chunks?.buffer
+        }, [orderBuffer, centers.buffer, chunks?.buffer]);
     }
 
     setMapping(mapping) {


### PR DESCRIPTION
This PR updates the gsplat sorter when rendering compressed data:
- send the compressed chunk min/max bound to sort worker
- use chunk bounds to calculate a per-frame histogram of chunks based on distance-to-camera
- use the histogram to allocate counting sort key bits

This results in much more stable rendering of our most challenging (especially MCMC) scenes, but also (unexpectedly) better rendering on many others.

The uncompressed sort is sped up slightly, but otherwise remains unchanged.

Cost:
- cpu sort seems to be around 20% slower
- additional memory storage requires 6 x float32 per 256 gaussians (which practically very small)

Before:

https://github.com/user-attachments/assets/629a0bd8-741c-4338-8eb2-e3def83c0ada

After:

https://github.com/user-attachments/assets/1b27ed88-f677-449b-8e5b-e4d4d779d453

Before:

https://github.com/user-attachments/assets/9530757a-ebfa-4859-a5c5-296f8a6ab267

After:

https://github.com/user-attachments/assets/785d62f3-049e-4645-bc44-445326e1970e

Before:

https://github.com/user-attachments/assets/03fcd17c-5500-456e-aabe-34dd93616a56

After:

https://github.com/user-attachments/assets/d63bba81-bf44-490f-8d69-d4d73067d1c4

## Notes

- default histogram size is arbitrarily set to 32. More buckets just seem to result in more stable sorting, but cost more CPU time.
- would be nice to support this approach for uncompressed format, but without chunks it would probably run twice as slowly

Fixes #6817