### PR TITLE
[Fix] Fixed part of the image being upside down on WebGPU with DOF and TAA

### DIFF
--- a/src/extras/render-passes/render-pass-compose.js
+++ b/src/extras/render-passes/render-pass-compose.js
@@ -200,7 +200,7 @@ const fragmentShader = /* glsl */ `
 
         #ifdef DOF
             vec2 coc;
-            vec3 blur = dofBlur(uv, coc);
+            vec3 blur = dofBlur(uv0, coc);
             result = mix(result, blur, coc.r + coc.g);
         #endif
 


### PR DESCRIPTION
repro in the DOF engine example