### PR TITLE
[Fix] Clear index buffer when the draw call is skipped

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -724,6 +724,15 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
+     * Clears the index buffer set on the graphics device. This is called automatically by the
+     * renderer.
+     * @ignore
+     */
+    clearIndexBuffer() {
+        this.indexBuffer = null;
+    }
+
+    /**
      * Queries the currently set render target on the device.
      *
      * @returns {RenderTarget} The current render target.

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -554,7 +554,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             // vertex buffers
             const vb0 = this.vertexBuffers[0];
             const vb1 = this.vertexBuffers[1];
-            this.vertexBuffers.length = 0;
 
             if (vb0) {
                 const vbSlot = this.submitVertexBuffer(vb0, 0);
@@ -580,7 +579,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             // draw
             const ib = this.indexBuffer;
             if (ib) {
-                this.indexBuffer = null;
                 passEncoder.setIndexBuffer(ib.impl.buffer, ib.impl.format);
                 passEncoder.drawIndexed(primitive.count, numInstances, primitive.base, 0, 0);
             } else {
@@ -596,6 +594,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
                 pipeline
             });
         }
+
+        this.vertexBuffers.length = 0;
+        this.indexBuffer = null;
     }
 
     setShader(shader, asyncCompile = false) {

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -824,6 +824,7 @@ class Renderer {
                 device.draw(mesh.primitive[style], instancingData.count);
             } else {
                 device.clearVertexBuffer();
+                device.clearIndexBuffer();
             }
         } else {
             device.draw(mesh.primitive[style]);
@@ -840,6 +841,7 @@ class Renderer {
                 device.draw(mesh.primitive[style], instancingData.count, true);
             } else {
                 device.clearVertexBuffer();
+                device.clearIndexBuffer();
             }
         } else {
             // matrices are already set


### PR DESCRIPTION
- when instanced indexed rendering is skipped due to 0 instances, we need to clear the index buffer to not affect the following draw call
- reproducible in the scenes with large gsplats on first frame before sorting is done, and 0 instances are rendered.