### PR TITLE
WebGPU support for indexed rendering using triangle or line strips

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -565,8 +565,10 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
             Debug.call(() => this.validateAttributes(this.shader, vb0?.format, vb1?.format));
 
+            const ib = this.indexBuffer;
+
             // render pipeline
-            const pipeline = this.renderPipeline.get(primitive, vb0?.format, vb1?.format, this.shader, this.renderTarget,
+            const pipeline = this.renderPipeline.get(primitive, vb0?.format, vb1?.format, ib?.format, this.shader, this.renderTarget,
                 this.bindGroupFormats, this.blendState, this.depthState, this.cullMode,
                 this.stencilEnabled, this.stencilFront, this.stencilBack);
             Debug.assert(pipeline);
@@ -577,7 +579,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             }
 
             // draw
-            const ib = this.indexBuffer;
             if (ib) {
                 passEncoder.setIndexBuffer(ib.impl.buffer, ib.impl.format);
                 passEncoder.drawIndexed(primitive.count, numInstances, primitive.base, 0, 0);


### PR DESCRIPTION
when indexed rendering with tri-strip or line-strip is used on WebGPU, the render pipeline needs to have `primitive.stripIndexFormat` specified so that the primitive restart value that will be used is known at pipeline creation time.