### PR TITLE
GSplat shaders can output depth during Depth Prepass

### DIFF
--- a/src/scene/shader-lib/chunks/common/frag/float-as-uint.js
+++ b/src/scene/shader-lib/chunks/common/frag/float-as-uint.js
@@ -29,5 +29,14 @@ float uint2float(vec4 value) {
     return uintBitsToFloat(intBits);
 }
 
+// store a single float value in vec4, assuming either RGBA8 or float renderable texture
+vec4 float2vec4(float value) {
+    #if defined(CAPS_TEXTURE_FLOAT_RENDERABLE)
+        return vec4(value, 1.0, 1.0, 1.0);
+    #else
+        return float2uint(value);
+    #endif
+}
+
 #endif // FLOAT_AS_UINT
 `;

--- a/src/scene/shader-lib/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/chunks/gsplat/frag/gsplat.js
@@ -10,8 +10,13 @@ export default /* glsl */`
     #include "pickPS"
 #endif
 
-#if defined(SHADOW_PASS) || defined(PICK_PASS)
+#if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
     uniform float alphaClip;
+#endif
+
+#ifdef PREPASS_PASS
+    varying float vLinearDepth;
+    #include "floatAsUintPS"
 #endif
 
 varying mediump vec2 gaussianUV;
@@ -26,17 +31,23 @@ void main(void) {
     // evaluate alpha
     mediump float alpha = exp(-A * 4.0) * gaussianColor.a;
 
-    #ifdef PICK_PASS
+    #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
         if (alpha < alphaClip) {
             discard;
         }
+    #endif
+
+    #ifdef PICK_PASS
+
         gl_FragColor = getPickOutput();
+
     #elif SHADOW_PASS
 
-        if (alpha < alphaClip) {
-            discard;
-        }
         gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+
+    #elif PREPASS_PASS
+
+        gl_FragColor = float2vec4(vLinearDepth);
 
     #else
         if (alpha < 1.0 / 255.0) {

--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplat.js
@@ -10,6 +10,10 @@ varying mediump vec4 gaussianColor;
 
 mediump vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
 
+#ifdef PREPASS_PASS
+    varying float vLinearDepth;
+#endif
+
 void main(void) {
     // read gaussian details
     SplatSource source;
@@ -52,6 +56,10 @@ void main(void) {
 
     #ifndef DITHER_NONE
         id = float(source.id);
+    #endif
+
+    #ifdef PREPASS_PASS
+        vLinearDepth = -center.view.z;
     #endif
 }
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/pass-other/litOtherMain.js
+++ b/src/scene/shader-lib/chunks/lit/frag/pass-other/litOtherMain.js
@@ -21,11 +21,7 @@ void main(void) {
     #endif
 
     #ifdef PREPASS_PASS
-        #if defined(CAPS_TEXTURE_FLOAT_RENDERABLE)
-            gl_FragColor = vec4(vLinearDepth, 1.0, 1.0, 1.0);
-        #else
-            gl_FragColor = float2uint(vLinearDepth);
-        #endif
+        gl_FragColor = float2vec4(vLinearDepth);
     #endif
 }
 `;


### PR DESCRIPTION
Updated gsplat shaders to output linear depth when rendered during a depth prepass