### PR TITLE
[BREAKING] Refactor standard material chunks dealing with texture channels

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -219,18 +219,18 @@ class StandardMaterialOptionsBuilder {
 
         const equalish = (a, b) => Math.abs(a - b) < 1e-4;
 
-        options.specularTint = specularTint ? 2 : 0;
-        options.specularityFactorTint = specularityFactorTint ? 1 : 0;
-        options.metalnessTint = (stdMat.useMetalness && stdMat.metalness < 1) ? 1 : 0;
-        options.glossTint = 1;
+        options.specularTint = specularTint;
+        options.specularityFactorTint = specularityFactorTint;
+        options.metalnessTint = (stdMat.useMetalness && stdMat.metalness < 1);
+        options.glossTint = true;
         options.diffuseEncoding = stdMat.diffuseMap?.encoding;
         options.diffuseDetailEncoding = stdMat.diffuseDetailMap?.encoding;
         options.emissiveEncoding = stdMat.emissiveMap?.encoding;
         options.lightMapEncoding = stdMat.lightMap?.encoding;
         options.packedNormal = isPackedNormalMap;
-        options.refractionTint = equalish(stdMat.refraction, 1.0) ? 0 : 1;
-        options.refractionIndexTint = equalish(stdMat.refractionIndex, 1.0 / 1.5) ? 0 : 1;
-        options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness !== 1.0) ? 1 : 0;
+        options.refractionTint = equalish(stdMat.refraction, 1.0);
+        options.refractionIndexTint = equalish(stdMat.refractionIndex, 1.0 / 1.5);
+        options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness !== 1.0);
         options.specularEncoding = stdMat.specularEncoding || 'linear';
         options.sheenEncoding = stdMat.sheenEncoding || 'linear';
         options.aoMapUv = stdMat.aoUvSet; // backwards compatibility
@@ -239,12 +239,12 @@ class StandardMaterialOptionsBuilder {
         options.normalDetail = !!stdMat.normalMap;
         options.diffuseDetailMode = stdMat.diffuseDetailMode;
         options.aoDetailMode = stdMat.aoDetailMode;
-        options.clearCoatTint = equalish(stdMat.clearCoat, 1.0) ? 0 : 1;
+        options.clearCoatTint = equalish(stdMat.clearCoat, 1.0);
         options.clearCoatGloss = !!stdMat.clearCoatGloss;
-        options.clearCoatGlossTint = (stdMat.clearCoatGloss !== 1.0) ? 1 : 0;
-        options.iorTint = equalish(stdMat.refractionIndex, 1.0 / 1.5) ? 0 : 1;
+        options.clearCoatGlossTint = (stdMat.clearCoatGloss !== 1.0);
+        options.iorTint = equalish(stdMat.refractionIndex, 1.0 / 1.5);
 
-        options.iridescenceTint = stdMat.iridescence !== 1.0 ? 1 : 0;
+        options.iridescenceTint = stdMat.iridescence !== 1.0;
 
         options.glossInvert = stdMat.glossInvert;
         options.sheenGlossInvert = stdMat.sheenGlossInvert;

--- a/src/scene/shader-lib/chunks/standard/frag/ao.js
+++ b/src/scene/shader-lib/chunks/standard/frag/ao.js
@@ -1,22 +1,22 @@
 export default /* glsl */`
 
-#if defined(STD_AO_TEXTURE_ENABLED) || defined(STD_AO_VERTEX_ENABLED)
+#if defined(STD_AO_TEXTURE) || defined(STD_AO_VERTEX)
     uniform float material_aoIntensity;
 #endif
 
 void getAO() {
     dAo = 1.0;
 
-    #ifdef STD_AO_TEXTURE_ENABLED
-        float aoBase = texture2DBias({STD_AO_TEXTURE}, {STD_AO_TEXTURE_UV}, textureBias).{STD_AO_TEXTURE_CHANNEL};
+    #ifdef STD_AO_TEXTURE
+        float aoBase = texture2DBias({STD_AO_TEXTURE_NAME}, {STD_AO_TEXTURE_UV}, textureBias).{STD_AO_TEXTURE_CHANNEL};
         dAo *= addAoDetail(aoBase);
     #endif
 
-    #ifdef STD_AO_VERTEX_ENABLED
+    #ifdef STD_AO_VERTEX
         dAo *= saturate(vVertexColor.{STD_AO_VERTEX_CHANNEL});
     #endif
 
-    #if defined(STD_AO_TEXTURE_ENABLED) || defined(STD_AO_VERTEX_ENABLED)
+    #if defined(STD_AO_TEXTURE) || defined(STD_AO_VERTEX)
         dAo = mix(1.0, dAo, material_aoIntensity);
     #endif
 }

--- a/src/scene/shader-lib/chunks/standard/frag/ao.js
+++ b/src/scene/shader-lib/chunks/standard/frag/ao.js
@@ -1,30 +1,22 @@
 export default /* glsl */`
 
-#ifdef MAPTEXTURE
-    #define AO_INTENSITY
-#endif
-
-#ifdef MAPVERTEX
-    #define AO_INTENSITY
-#endif
-
-#ifdef AO_INTENSITY
+#if defined(STD_AO_TEXTURE_ENABLED) || defined(STD_AO_VERTEX_ENABLED)
     uniform float material_aoIntensity;
 #endif
 
 void getAO() {
     dAo = 1.0;
 
-    #ifdef MAPTEXTURE
-        float aoBase = texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_AO_TEXTURE_ENABLED
+        float aoBase = texture2DBias({STD_AO_TEXTURE}, {STD_AO_TEXTURE_UV}, textureBias).{STD_AO_TEXTURE_CHANNEL};
         dAo *= addAoDetail(aoBase);
     #endif
 
-    #ifdef MAPVERTEX
-        dAo *= saturate(vVertexColor.$VC);
+    #ifdef STD_AO_VERTEX_ENABLED
+        dAo *= saturate(vVertexColor.{STD_AO_VERTEX_CHANNEL});
     #endif
 
-    #ifdef AO_INTENSITY
+    #if defined(STD_AO_TEXTURE_ENABLED) || defined(STD_AO_VERTEX_ENABLED)
         dAo = mix(1.0, dAo, material_aoIntensity);
     #endif
 }

--- a/src/scene/shader-lib/chunks/standard/frag/aoDetailMap.js
+++ b/src/scene/shader-lib/chunks/standard/frag/aoDetailMap.js
@@ -1,8 +1,8 @@
 export default /* glsl */`
 float addAoDetail(float ao) {
-#ifdef MAPTEXTURE
-    float aoDetail = texture2DBias($SAMPLER, $UV, textureBias).$CH;
-    return detailMode_$DETAILMODE(vec3(ao), vec3(aoDetail)).r;
+#ifdef STD_AODETAIL_TEXTURE_ENABLED
+    float aoDetail = texture2DBias({STD_AODETAIL_TEXTURE}, {STD_AODETAIL_TEXTURE_UV}, textureBias).{STD_AODETAIL_TEXTURE_CHANNEL};
+    return detailMode_{STD_AODETAIL_DETAILMODE}(vec3(ao), vec3(aoDetail)).r;
 #else
     return ao;
 #endif

--- a/src/scene/shader-lib/chunks/standard/frag/aoDetailMap.js
+++ b/src/scene/shader-lib/chunks/standard/frag/aoDetailMap.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 float addAoDetail(float ao) {
-#ifdef STD_AODETAIL_TEXTURE_ENABLED
-    float aoDetail = texture2DBias({STD_AODETAIL_TEXTURE}, {STD_AODETAIL_TEXTURE_UV}, textureBias).{STD_AODETAIL_TEXTURE_CHANNEL};
+#ifdef STD_AODETAIL_TEXTURE
+    float aoDetail = texture2DBias({STD_AODETAIL_TEXTURE_NAME}, {STD_AODETAIL_TEXTURE_UV}, textureBias).{STD_AODETAIL_TEXTURE_CHANNEL};
     return detailMode_{STD_AODETAIL_DETAILMODE}(vec3(ao), vec3(aoDetail)).r;
 #else
     return ao;

--- a/src/scene/shader-lib/chunks/standard/frag/clearCoat.js
+++ b/src/scene/shader-lib/chunks/standard/frag/clearCoat.js
@@ -1,20 +1,20 @@
 export default /* glsl */`
-#ifdef STD_CLEARCOAT_CONSTANT_ENABLED
+#ifdef STD_CLEARCOAT_CONSTANT
 uniform float material_clearCoat;
 #endif
 
 void getClearCoat() {
     ccSpecularity = 1.0;
 
-    #ifdef STD_CLEARCOAT_CONSTANT_ENABLED
+    #ifdef STD_CLEARCOAT_CONSTANT
     ccSpecularity *= material_clearCoat;
     #endif
 
-    #ifdef STD_CLEARCOAT_TEXTURE_ENABLED
-    ccSpecularity *= texture2DBias({STD_CLEARCOAT_TEXTURE}, {STD_CLEARCOAT_TEXTURE_UV}, textureBias).{STD_CLEARCOAT_TEXTURE_CHANNEL};
+    #ifdef STD_CLEARCOAT_TEXTURE
+    ccSpecularity *= texture2DBias({STD_CLEARCOAT_TEXTURE_NAME}, {STD_CLEARCOAT_TEXTURE_UV}, textureBias).{STD_CLEARCOAT_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_CLEARCOAT_VERTEX_ENABLED
+    #ifdef STD_CLEARCOAT_VERTEX
     ccSpecularity *= saturate(vVertexColor.{STD_CLEARCOAT_VERTEX_CHANNEL});
     #endif
 }

--- a/src/scene/shader-lib/chunks/standard/frag/clearCoat.js
+++ b/src/scene/shader-lib/chunks/standard/frag/clearCoat.js
@@ -1,21 +1,21 @@
 export default /* glsl */`
-#ifdef MAPFLOAT
+#ifdef STD_CLEARCOAT_MATERIAL_ENABLED
 uniform float material_clearCoat;
 #endif
 
 void getClearCoat() {
     ccSpecularity = 1.0;
 
-    #ifdef MAPFLOAT
+    #ifdef STD_CLEARCOAT_MATERIAL_ENABLED
     ccSpecularity *= material_clearCoat;
     #endif
 
-    #ifdef MAPTEXTURE
-    ccSpecularity *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_CLEARCOAT_TEXTURE_ENABLED
+    ccSpecularity *= texture2DBias({STD_CLEARCOAT_TEXTURE}, {STD_CLEARCOAT_TEXTURE_UV}, textureBias).{STD_CLEARCOAT_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    ccSpecularity *= saturate(vVertexColor.$VC);
+    #ifdef STD_CLEARCOAT_VERTEX_ENABLED
+    ccSpecularity *= saturate(vVertexColor.{STD_CLEARCOAT_VERTEX_CHANNEL});
     #endif
 }
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/clearCoat.js
+++ b/src/scene/shader-lib/chunks/standard/frag/clearCoat.js
@@ -1,12 +1,12 @@
 export default /* glsl */`
-#ifdef STD_CLEARCOAT_MATERIAL_ENABLED
+#ifdef STD_CLEARCOAT_CONSTANT_ENABLED
 uniform float material_clearCoat;
 #endif
 
 void getClearCoat() {
     ccSpecularity = 1.0;
 
-    #ifdef STD_CLEARCOAT_MATERIAL_ENABLED
+    #ifdef STD_CLEARCOAT_CONSTANT_ENABLED
     ccSpecularity *= material_clearCoat;
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/clearCoatGloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/clearCoatGloss.js
@@ -1,24 +1,24 @@
 export default /* glsl */`
-#ifdef MAPFLOAT
+#ifdef STD_CLEARCOATGLOSS_MATERIAL_ENABLED
 uniform float material_clearCoatGloss;
 #endif
 
 void getClearCoatGlossiness() {
     ccGlossiness = 1.0;
 
-    #ifdef MAPFLOAT
+    #ifdef STD_CLEARCOATGLOSS_MATERIAL_ENABLED
     ccGlossiness *= material_clearCoatGloss;
     #endif
 
-    #ifdef MAPTEXTURE
-    ccGlossiness *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_CLEARCOATGLOSS_TEXTURE_ENABLED
+    ccGlossiness *= texture2DBias({STD_CLEARCOATGLOSS_TEXTURE}, {STD_CLEARCOATGLOSS_TEXTURE_UV}, textureBias).{STD_CLEARCOATGLOSS_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    ccGlossiness *= saturate(vVertexColor.$VC);
+    #ifdef STD_CLEARCOATGLOSS_VERTEX_ENABLED
+    ccGlossiness *= saturate(vVertexColor.{STD_CLEARCOATGLOSS_VERTEX_CHANNEL});
     #endif
 
-    #ifdef MAPINVERT
+    #ifdef STD_CLEARCOATGLOSS_INVERT
     ccGlossiness = 1.0 - ccGlossiness;
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/clearCoatGloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/clearCoatGloss.js
@@ -1,12 +1,12 @@
 export default /* glsl */`
-#ifdef STD_CLEARCOATGLOSS_MATERIAL_ENABLED
+#ifdef STD_CLEARCOATGLOSS_CONSTANT_ENABLED
 uniform float material_clearCoatGloss;
 #endif
 
 void getClearCoatGlossiness() {
     ccGlossiness = 1.0;
 
-    #ifdef STD_CLEARCOATGLOSS_MATERIAL_ENABLED
+    #ifdef STD_CLEARCOATGLOSS_CONSTANT_ENABLED
     ccGlossiness *= material_clearCoatGloss;
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/clearCoatGloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/clearCoatGloss.js
@@ -1,20 +1,20 @@
 export default /* glsl */`
-#ifdef STD_CLEARCOATGLOSS_CONSTANT_ENABLED
+#ifdef STD_CLEARCOATGLOSS_CONSTANT
 uniform float material_clearCoatGloss;
 #endif
 
 void getClearCoatGlossiness() {
     ccGlossiness = 1.0;
 
-    #ifdef STD_CLEARCOATGLOSS_CONSTANT_ENABLED
+    #ifdef STD_CLEARCOATGLOSS_CONSTANT
     ccGlossiness *= material_clearCoatGloss;
     #endif
 
-    #ifdef STD_CLEARCOATGLOSS_TEXTURE_ENABLED
-    ccGlossiness *= texture2DBias({STD_CLEARCOATGLOSS_TEXTURE}, {STD_CLEARCOATGLOSS_TEXTURE_UV}, textureBias).{STD_CLEARCOATGLOSS_TEXTURE_CHANNEL};
+    #ifdef STD_CLEARCOATGLOSS_TEXTURE
+    ccGlossiness *= texture2DBias({STD_CLEARCOATGLOSS_TEXTURE_NAME}, {STD_CLEARCOATGLOSS_TEXTURE_UV}, textureBias).{STD_CLEARCOATGLOSS_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_CLEARCOATGLOSS_VERTEX_ENABLED
+    #ifdef STD_CLEARCOATGLOSS_VERTEX
     ccGlossiness *= saturate(vVertexColor.{STD_CLEARCOATGLOSS_VERTEX_CHANNEL});
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/clearCoatNormal.js
+++ b/src/scene/shader-lib/chunks/standard/frag/clearCoatNormal.js
@@ -1,11 +1,11 @@
 export default /* glsl */`
-#ifdef MAPTEXTURE
+#ifdef STD_CLEARCOATNORMAL_TEXTURE_ENABLED
 uniform float material_clearCoatBumpiness;
 #endif
 
 void getClearCoatNormal() {
-#ifdef MAPTEXTURE
-    vec3 normalMap = unpackNormal(texture2DBias($SAMPLER, $UV, textureBias));
+#ifdef STD_CLEARCOATNORMAL_TEXTURE_ENABLED
+    vec3 normalMap = unpackNormal(texture2DBias({STD_CLEARCOATNORMAL_TEXTURE}, {STD_CLEARCOATNORMAL_TEXTURE_UV}, textureBias));
     normalMap = mix(vec3(0.0, 0.0, 1.0), normalMap, material_clearCoatBumpiness);
     ccNormalW = normalize(dTBN * normalMap);
 #else

--- a/src/scene/shader-lib/chunks/standard/frag/clearCoatNormal.js
+++ b/src/scene/shader-lib/chunks/standard/frag/clearCoatNormal.js
@@ -1,11 +1,11 @@
 export default /* glsl */`
-#ifdef STD_CLEARCOATNORMAL_TEXTURE_ENABLED
+#ifdef STD_CLEARCOATNORMAL_TEXTURE
 uniform float material_clearCoatBumpiness;
 #endif
 
 void getClearCoatNormal() {
-#ifdef STD_CLEARCOATNORMAL_TEXTURE_ENABLED
-    vec3 normalMap = unpackNormal(texture2DBias({STD_CLEARCOATNORMAL_TEXTURE}, {STD_CLEARCOATNORMAL_TEXTURE_UV}, textureBias));
+#ifdef STD_CLEARCOATNORMAL_TEXTURE
+    vec3 normalMap = unpackNormal(texture2DBias({STD_CLEARCOATNORMAL_TEXTURE_NAME}, {STD_CLEARCOATNORMAL_TEXTURE_UV}, textureBias));
     normalMap = mix(vec3(0.0, 0.0, 1.0), normalMap, material_clearCoatBumpiness);
     ccNormalW = normalize(dTBN * normalMap);
 #else

--- a/src/scene/shader-lib/chunks/standard/frag/diffuse.js
+++ b/src/scene/shader-lib/chunks/standard/frag/diffuse.js
@@ -4,12 +4,12 @@ uniform vec3 material_diffuse;
 void getAlbedo() {
     dAlbedo = material_diffuse.rgb;
 
-#ifdef STD_DIFFUSE_TEXTURE_ENABLED
-    vec3 albedoBase = {STD_DIFFUSE_TEXTURE_DECODE}(texture2DBias({STD_DIFFUSE_TEXTURE}, {STD_DIFFUSE_TEXTURE_UV}, textureBias)).{STD_DIFFUSE_TEXTURE_CHANNEL};
+#ifdef STD_DIFFUSE_TEXTURE
+    vec3 albedoBase = {STD_DIFFUSE_TEXTURE_DECODE}(texture2DBias({STD_DIFFUSE_TEXTURE_NAME}, {STD_DIFFUSE_TEXTURE_UV}, textureBias)).{STD_DIFFUSE_TEXTURE_CHANNEL};
     dAlbedo *= addAlbedoDetail(albedoBase);
 #endif
 
-#ifdef STD_DIFFUSE_VERTEX_ENABLED
+#ifdef STD_DIFFUSE_VERTEX
     dAlbedo *= gammaCorrectInput(saturate(vVertexColor.{STD_DIFFUSE_VERTEX_CHANNEL}));
 #endif
 }

--- a/src/scene/shader-lib/chunks/standard/frag/diffuse.js
+++ b/src/scene/shader-lib/chunks/standard/frag/diffuse.js
@@ -4,13 +4,13 @@ uniform vec3 material_diffuse;
 void getAlbedo() {
     dAlbedo = material_diffuse.rgb;
 
-#ifdef MAPTEXTURE
-    vec3 albedoBase = $DECODE(texture2DBias($SAMPLER, $UV, textureBias)).$CH;
+#ifdef STD_DIFFUSE_TEXTURE_ENABLED
+    vec3 albedoBase = {STD_DIFFUSE_TEXTURE_DECODE}(texture2DBias({STD_DIFFUSE_TEXTURE}, {STD_DIFFUSE_TEXTURE_UV}, textureBias)).{STD_DIFFUSE_TEXTURE_CHANNEL};
     dAlbedo *= addAlbedoDetail(albedoBase);
 #endif
 
-#ifdef MAPVERTEX
-    dAlbedo *= gammaCorrectInput(saturate(vVertexColor.$VC));
+#ifdef STD_DIFFUSE_VERTEX_ENABLED
+    dAlbedo *= gammaCorrectInput(saturate(vVertexColor.{STD_DIFFUSE_VERTEX_CHANNEL}));
 #endif
 }
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/diffuseDetailMap.js
+++ b/src/scene/shader-lib/chunks/standard/frag/diffuseDetailMap.js
@@ -1,8 +1,8 @@
 export default /* glsl */`
 vec3 addAlbedoDetail(vec3 albedo) {
-#ifdef MAPTEXTURE
-    vec3 albedoDetail = $DECODE(texture2DBias($SAMPLER, $UV, textureBias)).$CH;
-    return detailMode_$DETAILMODE(albedo, albedoDetail);
+#ifdef STD_DIFFUSEDETAIL_TEXTURE_ENABLED
+    vec3 albedoDetail = {STD_DIFFUSEDETAIL_TEXTURE_DECODE}(texture2DBias({STD_DIFFUSEDETAIL_TEXTURE}, {STD_DIFFUSEDETAIL_TEXTURE_UV}, textureBias)).{STD_DIFFUSEDETAIL_TEXTURE_CHANNEL};
+    return detailMode_{STD_DIFFUSEDETAIL_DETAILMODE}(albedo, albedoDetail);
 #else
     return albedo;
 #endif

--- a/src/scene/shader-lib/chunks/standard/frag/diffuseDetailMap.js
+++ b/src/scene/shader-lib/chunks/standard/frag/diffuseDetailMap.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 vec3 addAlbedoDetail(vec3 albedo) {
-#ifdef STD_DIFFUSEDETAIL_TEXTURE_ENABLED
-    vec3 albedoDetail = {STD_DIFFUSEDETAIL_TEXTURE_DECODE}(texture2DBias({STD_DIFFUSEDETAIL_TEXTURE}, {STD_DIFFUSEDETAIL_TEXTURE_UV}, textureBias)).{STD_DIFFUSEDETAIL_TEXTURE_CHANNEL};
+#ifdef STD_DIFFUSEDETAIL_TEXTURE
+    vec3 albedoDetail = {STD_DIFFUSEDETAIL_TEXTURE_DECODE}(texture2DBias({STD_DIFFUSEDETAIL_TEXTURE_NAME}, {STD_DIFFUSEDETAIL_TEXTURE_UV}, textureBias)).{STD_DIFFUSEDETAIL_TEXTURE_CHANNEL};
     return detailMode_{STD_DIFFUSEDETAIL_DETAILMODE}(albedo, albedoDetail);
 #else
     return albedo;

--- a/src/scene/shader-lib/chunks/standard/frag/emissive.js
+++ b/src/scene/shader-lib/chunks/standard/frag/emissive.js
@@ -5,11 +5,11 @@ uniform float material_emissiveIntensity;
 void getEmission() {
     dEmission = material_emissive * material_emissiveIntensity;
 
-    #ifdef STD_EMISSIVE_TEXTURE_ENABLED
-    dEmission *= {STD_EMISSIVE_TEXTURE_DECODE}(texture2DBias({STD_EMISSIVE_TEXTURE}, {STD_EMISSIVE_TEXTURE_UV}, textureBias)).{STD_EMISSIVE_TEXTURE_CHANNEL};
+    #ifdef STD_EMISSIVE_TEXTURE
+    dEmission *= {STD_EMISSIVE_TEXTURE_DECODE}(texture2DBias({STD_EMISSIVE_TEXTURE_NAME}, {STD_EMISSIVE_TEXTURE_UV}, textureBias)).{STD_EMISSIVE_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_EMISSIVE_VERTEX_ENABLED
+    #ifdef STD_EMISSIVE_VERTEX
     dEmission *= gammaCorrectInput(saturate(vVertexColor.{STD_EMISSIVE_VERTEX_CHANNEL}));
     #endif
 }

--- a/src/scene/shader-lib/chunks/standard/frag/emissive.js
+++ b/src/scene/shader-lib/chunks/standard/frag/emissive.js
@@ -5,12 +5,12 @@ uniform float material_emissiveIntensity;
 void getEmission() {
     dEmission = material_emissive * material_emissiveIntensity;
 
-    #ifdef MAPTEXTURE
-    dEmission *= $DECODE(texture2DBias($SAMPLER, $UV, textureBias)).$CH;
+    #ifdef STD_EMISSIVE_TEXTURE_ENABLED
+    dEmission *= {STD_EMISSIVE_TEXTURE_DECODE}(texture2DBias({STD_EMISSIVE_TEXTURE}, {STD_EMISSIVE_TEXTURE_UV}, textureBias)).{STD_EMISSIVE_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    dEmission *= gammaCorrectInput(saturate(vVertexColor.$VC));
+    #ifdef STD_EMISSIVE_VERTEX_ENABLED
+    dEmission *= gammaCorrectInput(saturate(vVertexColor.{STD_EMISSIVE_VERTEX_CHANNEL}));
     #endif
 }
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/gloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/gloss.js
@@ -1,20 +1,20 @@
 export default /* glsl */`
-#ifdef STD_GLOSS_CONSTANT_ENABLED
+#ifdef STD_GLOSS_CONSTANT
 uniform float material_gloss;
 #endif
 
 void getGlossiness() {
     dGlossiness = 1.0;
 
-    #ifdef STD_GLOSS_CONSTANT_ENABLED
+    #ifdef STD_GLOSS_CONSTANT
     dGlossiness *= material_gloss;
     #endif
 
-    #ifdef STD_GLOSS_TEXTURE_ENABLED
-    dGlossiness *= texture2DBias({STD_GLOSS_TEXTURE}, {STD_GLOSS_TEXTURE_UV}, textureBias).{STD_GLOSS_TEXTURE_CHANNEL};
+    #ifdef STD_GLOSS_TEXTURE
+    dGlossiness *= texture2DBias({STD_GLOSS_TEXTURE_NAME}, {STD_GLOSS_TEXTURE_UV}, textureBias).{STD_GLOSS_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_GLOSS_VERTEX_ENABLED
+    #ifdef STD_GLOSS_VERTEX
     dGlossiness *= saturate(vVertexColor.{STD_GLOSS_VERTEX_CHANNEL});
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/gloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/gloss.js
@@ -1,12 +1,12 @@
 export default /* glsl */`
-#ifdef STD_GLOSS_MATERIAL_ENABLED
+#ifdef STD_GLOSS_CONSTANT_ENABLED
 uniform float material_gloss;
 #endif
 
 void getGlossiness() {
     dGlossiness = 1.0;
 
-    #ifdef STD_GLOSS_MATERIAL_ENABLED
+    #ifdef STD_GLOSS_CONSTANT_ENABLED
     dGlossiness *= material_gloss;
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/gloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/gloss.js
@@ -1,24 +1,24 @@
 export default /* glsl */`
-#ifdef MAPFLOAT
+#ifdef STD_GLOSS_MATERIAL_ENABLED
 uniform float material_gloss;
 #endif
 
 void getGlossiness() {
     dGlossiness = 1.0;
 
-    #ifdef MAPFLOAT
+    #ifdef STD_GLOSS_MATERIAL_ENABLED
     dGlossiness *= material_gloss;
     #endif
 
-    #ifdef MAPTEXTURE
-    dGlossiness *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_GLOSS_TEXTURE_ENABLED
+    dGlossiness *= texture2DBias({STD_GLOSS_TEXTURE}, {STD_GLOSS_TEXTURE_UV}, textureBias).{STD_GLOSS_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    dGlossiness *= saturate(vVertexColor.$VC);
+    #ifdef STD_GLOSS_VERTEX_ENABLED
+    dGlossiness *= saturate(vVertexColor.{STD_GLOSS_VERTEX_CHANNEL});
     #endif
 
-    #ifdef MAPINVERT
+    #ifdef STD_GLOSS_INVERT
     dGlossiness = 1.0 - dGlossiness;
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/ior.js
+++ b/src/scene/shader-lib/chunks/standard/frag/ior.js
@@ -1,10 +1,10 @@
 export default /* glsl */`
-#ifdef MAPFLOAT
+#ifdef STD_IOR_MATERIAL_ENABLED
 uniform float material_refractionIndex;
 #endif
 
 void getIor() {
-#ifdef MAPFLOAT
+#ifdef STD_IOR_MATERIAL_ENABLED
     dIor = material_refractionIndex;
 #else
     dIor = 1.0 / 1.5;

--- a/src/scene/shader-lib/chunks/standard/frag/ior.js
+++ b/src/scene/shader-lib/chunks/standard/frag/ior.js
@@ -1,10 +1,10 @@
 export default /* glsl */`
-#ifdef STD_IOR_MATERIAL_ENABLED
+#ifdef STD_IOR_CONSTANT_ENABLED
 uniform float material_refractionIndex;
 #endif
 
 void getIor() {
-#ifdef STD_IOR_MATERIAL_ENABLED
+#ifdef STD_IOR_CONSTANT_ENABLED
     dIor = material_refractionIndex;
 #else
     dIor = 1.0 / 1.5;

--- a/src/scene/shader-lib/chunks/standard/frag/ior.js
+++ b/src/scene/shader-lib/chunks/standard/frag/ior.js
@@ -1,10 +1,10 @@
 export default /* glsl */`
-#ifdef STD_IOR_CONSTANT_ENABLED
+#ifdef STD_IOR_CONSTANT
 uniform float material_refractionIndex;
 #endif
 
 void getIor() {
-#ifdef STD_IOR_CONSTANT_ENABLED
+#ifdef STD_IOR_CONSTANT
     dIor = material_refractionIndex;
 #else
     dIor = 1.0 / 1.5;

--- a/src/scene/shader-lib/chunks/standard/frag/iridescence.js
+++ b/src/scene/shader-lib/chunks/standard/frag/iridescence.js
@@ -1,17 +1,17 @@
 export default /* glsl */`
-#ifdef MAPFLOAT
+#ifdef STD_IRIDESCENCE_MATERIAL_ENABLED
 uniform float material_iridescence;
 #endif
 
 void getIridescence() {
     float iridescence = 1.0;
 
-    #ifdef MAPFLOAT
+    #ifdef STD_IRIDESCENCE_MATERIAL_ENABLED
     iridescence *= material_iridescence;
     #endif
 
-    #ifdef MAPTEXTURE
-    iridescence *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_IRIDESCENCE_TEXTURE_ENABLED
+    iridescence *= texture2DBias({STD_IRIDESCENCE_TEXTURE}, {STD_IRIDESCENCE_TEXTURE_UV}, textureBias).{STD_IRIDESCENCE_TEXTURE_CHANNEL};
     #endif
 
     dIridescence = iridescence; 

--- a/src/scene/shader-lib/chunks/standard/frag/iridescence.js
+++ b/src/scene/shader-lib/chunks/standard/frag/iridescence.js
@@ -1,17 +1,17 @@
 export default /* glsl */`
-#ifdef STD_IRIDESCENCE_CONSTANT_ENABLED
+#ifdef STD_IRIDESCENCE_CONSTANT
 uniform float material_iridescence;
 #endif
 
 void getIridescence() {
     float iridescence = 1.0;
 
-    #ifdef STD_IRIDESCENCE_CONSTANT_ENABLED
+    #ifdef STD_IRIDESCENCE_CONSTANT
     iridescence *= material_iridescence;
     #endif
 
-    #ifdef STD_IRIDESCENCE_TEXTURE_ENABLED
-    iridescence *= texture2DBias({STD_IRIDESCENCE_TEXTURE}, {STD_IRIDESCENCE_TEXTURE_UV}, textureBias).{STD_IRIDESCENCE_TEXTURE_CHANNEL};
+    #ifdef STD_IRIDESCENCE_TEXTURE
+    iridescence *= texture2DBias({STD_IRIDESCENCE_TEXTURE_NAME}, {STD_IRIDESCENCE_TEXTURE_UV}, textureBias).{STD_IRIDESCENCE_TEXTURE_CHANNEL};
     #endif
 
     dIridescence = iridescence; 

--- a/src/scene/shader-lib/chunks/standard/frag/iridescence.js
+++ b/src/scene/shader-lib/chunks/standard/frag/iridescence.js
@@ -1,12 +1,12 @@
 export default /* glsl */`
-#ifdef STD_IRIDESCENCE_MATERIAL_ENABLED
+#ifdef STD_IRIDESCENCE_CONSTANT_ENABLED
 uniform float material_iridescence;
 #endif
 
 void getIridescence() {
     float iridescence = 1.0;
 
-    #ifdef STD_IRIDESCENCE_MATERIAL_ENABLED
+    #ifdef STD_IRIDESCENCE_CONSTANT_ENABLED
     iridescence *= material_iridescence;
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/iridescenceThickness.js
+++ b/src/scene/shader-lib/chunks/standard/frag/iridescenceThickness.js
@@ -1,14 +1,14 @@
 export default /* glsl */`
 uniform float material_iridescenceThicknessMax;
 
-#ifdef STD_IRIDESCENCETHICKNESS_TEXTURE_ENABLED
+#ifdef STD_IRIDESCENCETHICKNESS_TEXTURE
 uniform float material_iridescenceThicknessMin;
 #endif
 
 void getIridescenceThickness() {
 
-    #ifdef STD_IRIDESCENCETHICKNESS_TEXTURE_ENABLED
-        float blend = texture2DBias({STD_IRIDESCENCETHICKNESS_TEXTURE}, {STD_IRIDESCENCETHICKNESS_TEXTURE_UV}, textureBias).{STD_IRIDESCENCETHICKNESS_TEXTURE_CHANNEL};
+    #ifdef STD_IRIDESCENCETHICKNESS_TEXTURE
+        float blend = texture2DBias({STD_IRIDESCENCETHICKNESS_TEXTURE_NAME}, {STD_IRIDESCENCETHICKNESS_TEXTURE_UV}, textureBias).{STD_IRIDESCENCETHICKNESS_TEXTURE_CHANNEL};
         float iridescenceThickness = mix(material_iridescenceThicknessMin, material_iridescenceThicknessMax, blend);
     #else
         float iridescenceThickness = material_iridescenceThicknessMax;

--- a/src/scene/shader-lib/chunks/standard/frag/iridescenceThickness.js
+++ b/src/scene/shader-lib/chunks/standard/frag/iridescenceThickness.js
@@ -1,17 +1,17 @@
 export default /* glsl */`
 uniform float material_iridescenceThicknessMax;
 
-#ifdef MAPTEXTURE
+#ifdef STD_IRIDESCENCETHICKNESS_TEXTURE_ENABLED
 uniform float material_iridescenceThicknessMin;
 #endif
 
 void getIridescenceThickness() {
 
-    #ifdef MAPTEXTURE
-    float blend = texture2DBias($SAMPLER, $UV, textureBias).$CH;
-    float iridescenceThickness = mix(material_iridescenceThicknessMin, material_iridescenceThicknessMax, blend);
+    #ifdef STD_IRIDESCENCETHICKNESS_TEXTURE_ENABLED
+        float blend = texture2DBias({STD_IRIDESCENCETHICKNESS_TEXTURE}, {STD_IRIDESCENCETHICKNESS_TEXTURE_UV}, textureBias).{STD_IRIDESCENCETHICKNESS_TEXTURE_CHANNEL};
+        float iridescenceThickness = mix(material_iridescenceThicknessMin, material_iridescenceThicknessMax, blend);
     #else
-    float iridescenceThickness = material_iridescenceThicknessMax;
+        float iridescenceThickness = material_iridescenceThicknessMax;
     #endif
 
     dIridescenceThickness = iridescenceThickness; 

--- a/src/scene/shader-lib/chunks/standard/frag/lightmapDir.js
+++ b/src/scene/shader-lib/chunks/standard/frag/lightmapDir.js
@@ -3,9 +3,9 @@ uniform sampler2D texture_lightMap;
 uniform sampler2D texture_dirLightMap;
 
 void getLightMap() {
-    dLightmap = $DECODE(texture2DBias(texture_lightMap, $UV, textureBias)).$CH;
+    dLightmap = {STD_LIGHT_TEXTURE_DECODE}(texture2DBias(texture_lightMap, {STD_LIGHT_TEXTURE_UV}, textureBias)).{STD_LIGHT_TEXTURE_CHANNEL};
 
-    vec3 dir = texture2DBias(texture_dirLightMap, $UV, textureBias).xyz * 2.0 - 1.0;
+    vec3 dir = texture2DBias(texture_dirLightMap, {STD_LIGHT_TEXTURE_UV}, textureBias).xyz * 2.0 - 1.0;
     float dirDot = dot(dir, dir);
     dLightmapDir = (dirDot > 0.001) ? dir / sqrt(dirDot) : vec3(0.0);
 }

--- a/src/scene/shader-lib/chunks/standard/frag/lightmapSingle.js
+++ b/src/scene/shader-lib/chunks/standard/frag/lightmapSingle.js
@@ -2,12 +2,12 @@ export default /* glsl */`
 void getLightMap() {
     dLightmap = vec3(1.0);
 
-    #ifdef MAPTEXTURE
-    dLightmap *= $DECODE(texture2DBias($SAMPLER, $UV, textureBias)).$CH;
+    #ifdef STD_LIGHT_TEXTURE_ENABLED
+    dLightmap *= {STD_LIGHT_TEXTURE_DECODE}(texture2DBias({STD_LIGHT_TEXTURE}, {STD_LIGHT_TEXTURE_UV}, textureBias)).{STD_LIGHT_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    dLightmap *= saturate(vVertexColor.$VC);
+    #ifdef STD_LIGHT_VERTEX_ENABLED
+    dLightmap *= saturate(vVertexColor.{STD_LIGHT_VERTEX_CHANNEL});
     #endif
 }
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/lightmapSingle.js
+++ b/src/scene/shader-lib/chunks/standard/frag/lightmapSingle.js
@@ -2,11 +2,11 @@ export default /* glsl */`
 void getLightMap() {
     dLightmap = vec3(1.0);
 
-    #ifdef STD_LIGHT_TEXTURE_ENABLED
-    dLightmap *= {STD_LIGHT_TEXTURE_DECODE}(texture2DBias({STD_LIGHT_TEXTURE}, {STD_LIGHT_TEXTURE_UV}, textureBias)).{STD_LIGHT_TEXTURE_CHANNEL};
+    #ifdef STD_LIGHT_TEXTURE
+    dLightmap *= {STD_LIGHT_TEXTURE_DECODE}(texture2DBias({STD_LIGHT_TEXTURE_NAME}, {STD_LIGHT_TEXTURE_UV}, textureBias)).{STD_LIGHT_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_LIGHT_VERTEX_ENABLED
+    #ifdef STD_LIGHT_VERTEX
     dLightmap *= saturate(vVertexColor.{STD_LIGHT_VERTEX_CHANNEL});
     #endif
 }

--- a/src/scene/shader-lib/chunks/standard/frag/metalness.js
+++ b/src/scene/shader-lib/chunks/standard/frag/metalness.js
@@ -1,20 +1,20 @@
 export default /* glsl */`
-#ifdef STD_METALNESS_CONSTANT_ENABLED
+#ifdef STD_METALNESS_CONSTANT
 uniform float material_metalness;
 #endif
 
 void getMetalness() {
     float metalness = 1.0;
 
-    #ifdef STD_METALNESS_CONSTANT_ENABLED
+    #ifdef STD_METALNESS_CONSTANT
     metalness *= material_metalness;
     #endif
 
-    #ifdef STD_METALNESS_TEXTURE_ENABLED
-    metalness *= texture2DBias({STD_METALNESS_TEXTURE}, {STD_METALNESS_TEXTURE_UV}, textureBias).{STD_METALNESS_TEXTURE_CHANNEL};
+    #ifdef STD_METALNESS_TEXTURE
+    metalness *= texture2DBias({STD_METALNESS_TEXTURE_NAME}, {STD_METALNESS_TEXTURE_UV}, textureBias).{STD_METALNESS_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_METALNESS_VERTEX_ENABLED
+    #ifdef STD_METALNESS_VERTEX
     metalness *= saturate(vVertexColor.{STD_METALNESS_VERTEX_CHANNEL});
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/metalness.js
+++ b/src/scene/shader-lib/chunks/standard/frag/metalness.js
@@ -1,12 +1,12 @@
 export default /* glsl */`
-#ifdef STD_METALNESS_MATERIAL_ENABLED
+#ifdef STD_METALNESS_CONSTANT_ENABLED
 uniform float material_metalness;
 #endif
 
 void getMetalness() {
     float metalness = 1.0;
 
-    #ifdef STD_METALNESS_MATERIAL_ENABLED
+    #ifdef STD_METALNESS_CONSTANT_ENABLED
     metalness *= material_metalness;
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/metalness.js
+++ b/src/scene/shader-lib/chunks/standard/frag/metalness.js
@@ -1,21 +1,21 @@
 export default /* glsl */`
-#ifdef MAPFLOAT
+#ifdef STD_METALNESS_MATERIAL_ENABLED
 uniform float material_metalness;
 #endif
 
 void getMetalness() {
     float metalness = 1.0;
 
-    #ifdef MAPFLOAT
+    #ifdef STD_METALNESS_MATERIAL_ENABLED
     metalness *= material_metalness;
     #endif
 
-    #ifdef MAPTEXTURE
-    metalness *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_METALNESS_TEXTURE_ENABLED
+    metalness *= texture2DBias({STD_METALNESS_TEXTURE}, {STD_METALNESS_TEXTURE_UV}, textureBias).{STD_METALNESS_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    metalness *= saturate(vVertexColor.$VC);
+    #ifdef STD_METALNESS_VERTEX_ENABLED
+    metalness *= saturate(vVertexColor.{STD_METALNESS_VERTEX_CHANNEL});
     #endif
 
     dMetalness = metalness;

--- a/src/scene/shader-lib/chunks/standard/frag/normalDetailMap.js
+++ b/src/scene/shader-lib/chunks/standard/frag/normalDetailMap.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#ifdef MAPTEXTURE
+#ifdef STD_NORMALDETAIL_TEXTURE_ENABLED
 uniform float material_normalDetailMapBumpiness;
 
 vec3 blendNormals(vec3 n1, vec3 n2) {
@@ -11,8 +11,8 @@ vec3 blendNormals(vec3 n1, vec3 n2) {
 #endif
 
 vec3 addNormalDetail(vec3 normalMap) {
-#ifdef MAPTEXTURE
-    vec3 normalDetailMap = unpackNormal(texture2DBias($SAMPLER, $UV, textureBias));
+#ifdef STD_NORMALDETAIL_TEXTURE_ENABLED
+    vec3 normalDetailMap = unpackNormal(texture2DBias({STD_NORMALDETAIL_TEXTURE}, {STD_NORMALDETAIL_TEXTURE_UV}, textureBias));
     normalDetailMap = mix(vec3(0.0, 0.0, 1.0), normalDetailMap, material_normalDetailMapBumpiness);
     return blendNormals(normalMap, normalDetailMap);
 #else

--- a/src/scene/shader-lib/chunks/standard/frag/normalDetailMap.js
+++ b/src/scene/shader-lib/chunks/standard/frag/normalDetailMap.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#ifdef STD_NORMALDETAIL_TEXTURE_ENABLED
+#ifdef STD_NORMALDETAIL_TEXTURE
 uniform float material_normalDetailMapBumpiness;
 
 vec3 blendNormals(vec3 n1, vec3 n2) {
@@ -11,8 +11,8 @@ vec3 blendNormals(vec3 n1, vec3 n2) {
 #endif
 
 vec3 addNormalDetail(vec3 normalMap) {
-#ifdef STD_NORMALDETAIL_TEXTURE_ENABLED
-    vec3 normalDetailMap = unpackNormal(texture2DBias({STD_NORMALDETAIL_TEXTURE}, {STD_NORMALDETAIL_TEXTURE_UV}, textureBias));
+#ifdef STD_NORMALDETAIL_TEXTURE
+    vec3 normalDetailMap = unpackNormal(texture2DBias({STD_NORMALDETAIL_TEXTURE_NAME}, {STD_NORMALDETAIL_TEXTURE_UV}, textureBias));
     normalDetailMap = mix(vec3(0.0, 0.0, 1.0), normalDetailMap, material_normalDetailMapBumpiness);
     return blendNormals(normalMap, normalDetailMap);
 #else

--- a/src/scene/shader-lib/chunks/standard/frag/normalMap.js
+++ b/src/scene/shader-lib/chunks/standard/frag/normalMap.js
@@ -1,11 +1,11 @@
 export default /* glsl */`
-#ifdef MAPTEXTURE
+#ifdef STD_NORMAL_TEXTURE_ENABLED
 uniform float material_bumpiness;
 #endif
 
 void getNormal() {
-#ifdef MAPTEXTURE
-    vec3 normalMap = unpackNormal(texture2DBias($SAMPLER, $UV, textureBias));
+#ifdef STD_NORMAL_TEXTURE_ENABLED
+    vec3 normalMap = unpackNormal(texture2DBias({STD_NORMAL_TEXTURE}, {STD_NORMAL_TEXTURE_UV}, textureBias));
     normalMap = mix(vec3(0.0, 0.0, 1.0), normalMap, material_bumpiness);
     dNormalW = normalize(dTBN * addNormalDetail(normalMap));
 #else

--- a/src/scene/shader-lib/chunks/standard/frag/normalMap.js
+++ b/src/scene/shader-lib/chunks/standard/frag/normalMap.js
@@ -1,11 +1,11 @@
 export default /* glsl */`
-#ifdef STD_NORMAL_TEXTURE_ENABLED
+#ifdef STD_NORMAL_TEXTURE
 uniform float material_bumpiness;
 #endif
 
 void getNormal() {
-#ifdef STD_NORMAL_TEXTURE_ENABLED
-    vec3 normalMap = unpackNormal(texture2DBias({STD_NORMAL_TEXTURE}, {STD_NORMAL_TEXTURE_UV}, textureBias));
+#ifdef STD_NORMAL_TEXTURE
+    vec3 normalMap = unpackNormal(texture2DBias({STD_NORMAL_TEXTURE_NAME}, {STD_NORMAL_TEXTURE_UV}, textureBias));
     normalMap = mix(vec3(0.0, 0.0, 1.0), normalMap, material_bumpiness);
     dNormalW = normalize(dTBN * addNormalDetail(normalMap));
 #else

--- a/src/scene/shader-lib/chunks/standard/frag/opacity.js
+++ b/src/scene/shader-lib/chunks/standard/frag/opacity.js
@@ -4,11 +4,11 @@ uniform float material_opacity;
 void getOpacity() {
     dAlpha = material_opacity;
 
-    #ifdef STD_OPACITY_TEXTURE_ENABLED
-    dAlpha *= texture2DBias({STD_OPACITY_TEXTURE}, {STD_OPACITY_TEXTURE_UV}, textureBias).{STD_OPACITY_TEXTURE_CHANNEL};
+    #ifdef STD_OPACITY_TEXTURE
+    dAlpha *= texture2DBias({STD_OPACITY_TEXTURE_NAME}, {STD_OPACITY_TEXTURE_UV}, textureBias).{STD_OPACITY_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_OPACITY_VERTEX_ENABLED
+    #ifdef STD_OPACITY_VERTEX
     dAlpha *= clamp(vVertexColor.{STD_OPACITY_VERTEX_CHANNEL}, 0.0, 1.0);
     #endif
 }

--- a/src/scene/shader-lib/chunks/standard/frag/opacity.js
+++ b/src/scene/shader-lib/chunks/standard/frag/opacity.js
@@ -4,12 +4,12 @@ uniform float material_opacity;
 void getOpacity() {
     dAlpha = material_opacity;
 
-    #ifdef MAPTEXTURE
-    dAlpha *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_OPACITY_TEXTURE_ENABLED
+    dAlpha *= texture2DBias({STD_OPACITY_TEXTURE}, {STD_OPACITY_TEXTURE_UV}, textureBias).{STD_OPACITY_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    dAlpha *= clamp(vVertexColor.$VC, 0.0, 1.0);
+    #ifdef STD_OPACITY_VERTEX_ENABLED
+    dAlpha *= clamp(vVertexColor.{STD_OPACITY_VERTEX_CHANNEL}, 0.0, 1.0);
     #endif
 }
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/parallax.js
+++ b/src/scene/shader-lib/chunks/standard/frag/parallax.js
@@ -4,7 +4,7 @@ uniform float material_heightMapFactor;
 void getParallax() {
     float parallaxScale = material_heightMapFactor;
 
-    float height = texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    float height = texture2DBias({STD_HEIGHT_TEXTURE}, {STD_HEIGHT_TEXTURE_UV}, textureBias).{STD_HEIGHT_TEXTURE_CHANNEL};
     height = height * parallaxScale - parallaxScale*0.5;
     vec3 viewDirT = dViewDirW * dTBN;
 

--- a/src/scene/shader-lib/chunks/standard/frag/parallax.js
+++ b/src/scene/shader-lib/chunks/standard/frag/parallax.js
@@ -4,7 +4,7 @@ uniform float material_heightMapFactor;
 void getParallax() {
     float parallaxScale = material_heightMapFactor;
 
-    float height = texture2DBias({STD_HEIGHT_TEXTURE}, {STD_HEIGHT_TEXTURE_UV}, textureBias).{STD_HEIGHT_TEXTURE_CHANNEL};
+    float height = texture2DBias({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_UV}, textureBias).{STD_HEIGHT_TEXTURE_CHANNEL};
     height = height * parallaxScale - parallaxScale*0.5;
     vec3 viewDirT = dViewDirW * dTBN;
 

--- a/src/scene/shader-lib/chunks/standard/frag/sheen.js
+++ b/src/scene/shader-lib/chunks/standard/frag/sheen.js
@@ -5,12 +5,12 @@ uniform vec3 material_sheen;
 void getSheen() {
     vec3 sheenColor = material_sheen;
 
-    #ifdef MAPTEXTURE
-    sheenColor *= $DECODE(texture2DBias($SAMPLER, $UV, textureBias)).$CH;
+    #ifdef STD_SHEEN_TEXTURE_ENABLED
+    sheenColor *= {STD_SHEEN_TEXTURE_DECODE}(texture2DBias({STD_SHEEN_TEXTURE}, {STD_SHEEN_TEXTURE_UV}, textureBias)).{STD_SHEEN_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    sheenColor *= saturate(vVertexColor.$VC);
+    #ifdef STD_SHEEN_VERTEX_ENABLED
+    sheenColor *= saturate(vVertexColor.{STD_SHEEN_VERTEX_CHANNEL});
     #endif
 
     sSpecularity = sheenColor;

--- a/src/scene/shader-lib/chunks/standard/frag/sheen.js
+++ b/src/scene/shader-lib/chunks/standard/frag/sheen.js
@@ -5,11 +5,11 @@ uniform vec3 material_sheen;
 void getSheen() {
     vec3 sheenColor = material_sheen;
 
-    #ifdef STD_SHEEN_TEXTURE_ENABLED
-    sheenColor *= {STD_SHEEN_TEXTURE_DECODE}(texture2DBias({STD_SHEEN_TEXTURE}, {STD_SHEEN_TEXTURE_UV}, textureBias)).{STD_SHEEN_TEXTURE_CHANNEL};
+    #ifdef STD_SHEEN_TEXTURE
+    sheenColor *= {STD_SHEEN_TEXTURE_DECODE}(texture2DBias({STD_SHEEN_TEXTURE_NAME}, {STD_SHEEN_TEXTURE_UV}, textureBias)).{STD_SHEEN_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_SHEEN_VERTEX_ENABLED
+    #ifdef STD_SHEEN_VERTEX
     sheenColor *= saturate(vVertexColor.{STD_SHEEN_VERTEX_CHANNEL});
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/sheenGloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/sheenGloss.js
@@ -4,19 +4,18 @@ uniform float material_sheenGloss;
 void getSheenGlossiness() {
     float sheenGlossiness = material_sheenGloss;
 
-    #ifdef MAPTEXTURE
-    sheenGlossiness *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_SHEENGLOSS_TEXTURE_ENABLED
+    sheenGlossiness *= texture2DBias({STD_SHEENGLOSS_TEXTURE}, {STD_SHEENGLOSS_TEXTURE_UV}, textureBias).{STD_SHEENGLOSS_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    sheenGlossiness *= saturate(vVertexColor.$VC);
+    #ifdef STD_SHEENGLOSS_VERTEX_ENABLED
+    sheenGlossiness *= saturate(vVertexColor.{STD_SHEENGLOSS_VERTEX_CHANNEL});
     #endif
 
-    #ifdef MAPINVERT
+    #ifdef STD_SHEENGLOSS_INVERT
     sheenGlossiness = 1.0 - sheenGlossiness;
     #endif
 
-    sheenGlossiness += 0.0000001;
-    sGlossiness = sheenGlossiness;
+    sGlossiness = sheenGlossiness + 0.0000001;
 }
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/sheenGloss.js
+++ b/src/scene/shader-lib/chunks/standard/frag/sheenGloss.js
@@ -4,11 +4,11 @@ uniform float material_sheenGloss;
 void getSheenGlossiness() {
     float sheenGlossiness = material_sheenGloss;
 
-    #ifdef STD_SHEENGLOSS_TEXTURE_ENABLED
-    sheenGlossiness *= texture2DBias({STD_SHEENGLOSS_TEXTURE}, {STD_SHEENGLOSS_TEXTURE_UV}, textureBias).{STD_SHEENGLOSS_TEXTURE_CHANNEL};
+    #ifdef STD_SHEENGLOSS_TEXTURE
+    sheenGlossiness *= texture2DBias({STD_SHEENGLOSS_TEXTURE_NAME}, {STD_SHEENGLOSS_TEXTURE_UV}, textureBias).{STD_SHEENGLOSS_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_SHEENGLOSS_VERTEX_ENABLED
+    #ifdef STD_SHEENGLOSS_VERTEX
     sheenGlossiness *= saturate(vVertexColor.{STD_SHEENGLOSS_VERTEX_CHANNEL});
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/specular.js
+++ b/src/scene/shader-lib/chunks/standard/frag/specular.js
@@ -1,22 +1,22 @@
 export default /* glsl */`
 
-#ifdef MAPCOLOR
+#ifdef STD_SPECULAR_MATERIAL_ENABLED
 uniform vec3 material_specular;
 #endif
 
 void getSpecularity() {
     vec3 specularColor = vec3(1,1,1);
 
-    #ifdef MAPCOLOR
+    #ifdef STD_SPECULAR_MATERIAL_ENABLED
     specularColor *= material_specular;
     #endif
 
-    #ifdef MAPTEXTURE
-    specularColor *= $DECODE(texture2DBias($SAMPLER, $UV, textureBias)).$CH;
+    #ifdef STD_SPECULAR_TEXTURE_ENABLED
+    specularColor *= {STD_SPECULAR_TEXTURE_DECODE}(texture2DBias({STD_SPECULAR_TEXTURE}, {STD_SPECULAR_TEXTURE_UV}, textureBias)).{STD_SPECULAR_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    specularColor *= saturate(vVertexColor.$VC);
+    #ifdef STD_SPECULAR_VERTEX_ENABLED
+    specularColor *= saturate(vVertexColor.{STD_SPECULAR_VERTEX_CHANNEL});
     #endif
 
     dSpecularity = specularColor;

--- a/src/scene/shader-lib/chunks/standard/frag/specular.js
+++ b/src/scene/shader-lib/chunks/standard/frag/specular.js
@@ -1,13 +1,13 @@
 export default /* glsl */`
 
-#ifdef STD_SPECULAR_MATERIAL_ENABLED
+#ifdef STD_SPECULAR_CONSTANT_ENABLED
 uniform vec3 material_specular;
 #endif
 
 void getSpecularity() {
     vec3 specularColor = vec3(1,1,1);
 
-    #ifdef STD_SPECULAR_MATERIAL_ENABLED
+    #ifdef STD_SPECULAR_CONSTANT_ENABLED
     specularColor *= material_specular;
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/specular.js
+++ b/src/scene/shader-lib/chunks/standard/frag/specular.js
@@ -1,21 +1,21 @@
 export default /* glsl */`
 
-#ifdef STD_SPECULAR_CONSTANT_ENABLED
+#ifdef STD_SPECULAR_CONSTANT
 uniform vec3 material_specular;
 #endif
 
 void getSpecularity() {
     vec3 specularColor = vec3(1,1,1);
 
-    #ifdef STD_SPECULAR_CONSTANT_ENABLED
+    #ifdef STD_SPECULAR_CONSTANT
     specularColor *= material_specular;
     #endif
 
-    #ifdef STD_SPECULAR_TEXTURE_ENABLED
-    specularColor *= {STD_SPECULAR_TEXTURE_DECODE}(texture2DBias({STD_SPECULAR_TEXTURE}, {STD_SPECULAR_TEXTURE_UV}, textureBias)).{STD_SPECULAR_TEXTURE_CHANNEL};
+    #ifdef STD_SPECULAR_TEXTURE
+    specularColor *= {STD_SPECULAR_TEXTURE_DECODE}(texture2DBias({STD_SPECULAR_TEXTURE_NAME}, {STD_SPECULAR_TEXTURE_UV}, textureBias)).{STD_SPECULAR_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_SPECULAR_VERTEX_ENABLED
+    #ifdef STD_SPECULAR_VERTEX
     specularColor *= saturate(vVertexColor.{STD_SPECULAR_VERTEX_CHANNEL});
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/specularityFactor.js
+++ b/src/scene/shader-lib/chunks/standard/frag/specularityFactor.js
@@ -1,13 +1,13 @@
 export default /* glsl */`
 
-#ifdef STD_SPECULARITYFACTOR_MATERIAL_ENABLED
+#ifdef STD_SPECULARITYFACTOR_CONSTANT_ENABLED
 uniform float material_specularityFactor;
 #endif
 
 void getSpecularityFactor() {
     float specularityFactor = 1.0;
 
-    #ifdef STD_SPECULARITYFACTOR_MATERIAL_ENABLED
+    #ifdef STD_SPECULARITYFACTOR_CONSTANT_ENABLED
     specularityFactor *= material_specularityFactor;
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/specularityFactor.js
+++ b/src/scene/shader-lib/chunks/standard/frag/specularityFactor.js
@@ -1,22 +1,22 @@
 export default /* glsl */`
 
-#ifdef MAPFLOAT
+#ifdef STD_SPECULARITYFACTOR_MATERIAL_ENABLED
 uniform float material_specularityFactor;
 #endif
 
 void getSpecularityFactor() {
     float specularityFactor = 1.0;
 
-    #ifdef MAPFLOAT
+    #ifdef STD_SPECULARITYFACTOR_MATERIAL_ENABLED
     specularityFactor *= material_specularityFactor;
     #endif
 
-    #ifdef MAPTEXTURE
-    specularityFactor *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_SPECULARITYFACTOR_TEXTURE_ENABLED
+    specularityFactor *= texture2DBias({STD_SPECULARITYFACTOR_TEXTURE}, {STD_SPECULARITYFACTOR_TEXTURE_UV}, textureBias).{STD_SPECULARITYFACTOR_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    specularityFactor *= saturate(vVertexColor.$VC);
+    #ifdef STD_SPECULARITYFACTOR_VERTEX_ENABLED
+    specularityFactor *= saturate(vVertexColor.{STD_SPECULARITYFACTOR_VERTEX_CHANNEL});
     #endif
 
     dSpecularityFactor = specularityFactor;

--- a/src/scene/shader-lib/chunks/standard/frag/specularityFactor.js
+++ b/src/scene/shader-lib/chunks/standard/frag/specularityFactor.js
@@ -1,21 +1,21 @@
 export default /* glsl */`
 
-#ifdef STD_SPECULARITYFACTOR_CONSTANT_ENABLED
+#ifdef STD_SPECULARITYFACTOR_CONSTANT
 uniform float material_specularityFactor;
 #endif
 
 void getSpecularityFactor() {
     float specularityFactor = 1.0;
 
-    #ifdef STD_SPECULARITYFACTOR_CONSTANT_ENABLED
+    #ifdef STD_SPECULARITYFACTOR_CONSTANT
     specularityFactor *= material_specularityFactor;
     #endif
 
-    #ifdef STD_SPECULARITYFACTOR_TEXTURE_ENABLED
-    specularityFactor *= texture2DBias({STD_SPECULARITYFACTOR_TEXTURE}, {STD_SPECULARITYFACTOR_TEXTURE_UV}, textureBias).{STD_SPECULARITYFACTOR_TEXTURE_CHANNEL};
+    #ifdef STD_SPECULARITYFACTOR_TEXTURE
+    specularityFactor *= texture2DBias({STD_SPECULARITYFACTOR_TEXTURE_NAME}, {STD_SPECULARITYFACTOR_TEXTURE_UV}, textureBias).{STD_SPECULARITYFACTOR_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_SPECULARITYFACTOR_VERTEX_ENABLED
+    #ifdef STD_SPECULARITYFACTOR_VERTEX
     specularityFactor *= saturate(vVertexColor.{STD_SPECULARITYFACTOR_VERTEX_CHANNEL});
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/thickness.js
+++ b/src/scene/shader-lib/chunks/standard/frag/thickness.js
@@ -1,21 +1,21 @@
 export default /* glsl */`
-#ifdef MAPFLOAT
+#ifdef STD_THICKNESS_MATERIAL_ENABLED
 uniform float material_thickness;
 #endif
 
 void getThickness() {
     dThickness = 1.0;
 
-    #ifdef MAPFLOAT
+    #ifdef STD_THICKNESS_MATERIAL_ENABLED
     dThickness *= material_thickness;
     #endif
 
-    #ifdef MAPTEXTURE
-    dThickness *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_THICKNESS_TEXTURE_ENABLED
+    dThickness *= texture2DBias({STD_THICKNESS_TEXTURE}, {STD_THICKNESS_TEXTURE_UV}, textureBias).{STD_THICKNESS_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    dThickness *= saturate(vVertexColor.$VC);
+    #ifdef STD_THICKNESS_VERTEX_ENABLED
+    dThickness *= saturate(vVertexColor.{STD_THICKNESS_VERTEX_CHANNEL});
     #endif
 }
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/thickness.js
+++ b/src/scene/shader-lib/chunks/standard/frag/thickness.js
@@ -1,12 +1,12 @@
 export default /* glsl */`
-#ifdef STD_THICKNESS_MATERIAL_ENABLED
+#ifdef STD_THICKNESS_CONSTANT_ENABLED
 uniform float material_thickness;
 #endif
 
 void getThickness() {
     dThickness = 1.0;
 
-    #ifdef STD_THICKNESS_MATERIAL_ENABLED
+    #ifdef STD_THICKNESS_CONSTANT_ENABLED
     dThickness *= material_thickness;
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/thickness.js
+++ b/src/scene/shader-lib/chunks/standard/frag/thickness.js
@@ -1,20 +1,20 @@
 export default /* glsl */`
-#ifdef STD_THICKNESS_CONSTANT_ENABLED
+#ifdef STD_THICKNESS_CONSTANT
 uniform float material_thickness;
 #endif
 
 void getThickness() {
     dThickness = 1.0;
 
-    #ifdef STD_THICKNESS_CONSTANT_ENABLED
+    #ifdef STD_THICKNESS_CONSTANT
     dThickness *= material_thickness;
     #endif
 
-    #ifdef STD_THICKNESS_TEXTURE_ENABLED
-    dThickness *= texture2DBias({STD_THICKNESS_TEXTURE}, {STD_THICKNESS_TEXTURE_UV}, textureBias).{STD_THICKNESS_TEXTURE_CHANNEL};
+    #ifdef STD_THICKNESS_TEXTURE
+    dThickness *= texture2DBias({STD_THICKNESS_TEXTURE_NAME}, {STD_THICKNESS_TEXTURE_UV}, textureBias).{STD_THICKNESS_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_THICKNESS_VERTEX_ENABLED
+    #ifdef STD_THICKNESS_VERTEX
     dThickness *= saturate(vVertexColor.{STD_THICKNESS_VERTEX_CHANNEL});
     #endif
 }

--- a/src/scene/shader-lib/chunks/standard/frag/transmission.js
+++ b/src/scene/shader-lib/chunks/standard/frag/transmission.js
@@ -1,22 +1,22 @@
 export default /* glsl */`
 
-#ifdef MAPFLOAT
+#ifdef STD_REFRACTION_MATERIAL_ENABLED
 uniform float material_refraction;
 #endif
 
 void getRefraction() {
     float refraction = 1.0;
 
-    #ifdef MAPFLOAT
+    #ifdef STD_REFRACTION_MATERIAL_ENABLED
     refraction = material_refraction;
     #endif
 
-    #ifdef MAPTEXTURE
-    refraction *= texture2DBias($SAMPLER, $UV, textureBias).$CH;
+    #ifdef STD_REFRACTION_TEXTURE_ENABLED
+    refraction *= texture2DBias({STD_REFRACTION_TEXTURE}, {STD_REFRACTION_TEXTURE_UV}, textureBias).{STD_REFRACTION_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef MAPVERTEX
-    refraction *= saturate(vVertexColor.$VC);
+    #ifdef STD_REFRACTION_VERTEX_ENABLED
+    refraction *= saturate(vVertexColor.{STD_REFRACTION_VERTEX_CHANNEL});
     #endif
 
     dTransmission = refraction;

--- a/src/scene/shader-lib/chunks/standard/frag/transmission.js
+++ b/src/scene/shader-lib/chunks/standard/frag/transmission.js
@@ -1,21 +1,21 @@
 export default /* glsl */`
 
-#ifdef STD_REFRACTION_CONSTANT_ENABLED
+#ifdef STD_REFRACTION_CONSTANT
 uniform float material_refraction;
 #endif
 
 void getRefraction() {
     float refraction = 1.0;
 
-    #ifdef STD_REFRACTION_CONSTANT_ENABLED
+    #ifdef STD_REFRACTION_CONSTANT
     refraction = material_refraction;
     #endif
 
-    #ifdef STD_REFRACTION_TEXTURE_ENABLED
-    refraction *= texture2DBias({STD_REFRACTION_TEXTURE}, {STD_REFRACTION_TEXTURE_UV}, textureBias).{STD_REFRACTION_TEXTURE_CHANNEL};
+    #ifdef STD_REFRACTION_TEXTURE
+    refraction *= texture2DBias({STD_REFRACTION_TEXTURE_NAME}, {STD_REFRACTION_TEXTURE_UV}, textureBias).{STD_REFRACTION_TEXTURE_CHANNEL};
     #endif
 
-    #ifdef STD_REFRACTION_VERTEX_ENABLED
+    #ifdef STD_REFRACTION_VERTEX
     refraction *= saturate(vVertexColor.{STD_REFRACTION_VERTEX_CHANNEL});
     #endif
 

--- a/src/scene/shader-lib/chunks/standard/frag/transmission.js
+++ b/src/scene/shader-lib/chunks/standard/frag/transmission.js
@@ -1,13 +1,13 @@
 export default /* glsl */`
 
-#ifdef STD_REFRACTION_MATERIAL_ENABLED
+#ifdef STD_REFRACTION_CONSTANT_ENABLED
 uniform float material_refraction;
 #endif
 
 void getRefraction() {
     float refraction = 1.0;
 
-    #ifdef STD_REFRACTION_MATERIAL_ENABLED
+    #ifdef STD_REFRACTION_CONSTANT_ENABLED
     refraction = material_refraction;
     #endif
 

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -519,10 +519,6 @@ class ShaderGeneratorStandard extends ShaderGenerator {
                 }
             }
 
-            Debug.assert(!code.code.includes('$texture2DSRGB'), 'Shader chunk macro $texture2DSRGB has been removed.', { code: code.code });
-            Debug.assert(!code.code.includes('$texture2DRGBM'), 'Shader chunk macro $texture2DRGBM has been removed.', { code: code.code });
-            Debug.assert(!code.code.includes('$texture2DRGBE'), 'Shader chunk macro $texture2DRGBE has been removed.', { code: code.code });
-
         } else {
             // all other passes require only opacity
             const opacityShadowDither = options.litOptions.opacityShadowDither;

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -112,8 +112,8 @@ class ShaderGeneratorStandard extends ShaderGenerator {
 
             // defines
             [
-                ['MAPFLOAT',   `STD_${propName}_MATERIAL_ENABLED`],
-                ['MAPCOLOR',   `STD_${propName}_MATERIAL_ENABLED`],
+                ['MAPFLOAT',   `STD_${propName}_CONSTANT_ENABLED`],
+                ['MAPCOLOR',   `STD_${propName}_CONSTANT_ENABLED`],
                 ['MAPVERTEX',  `STD_${propName}_VERTEX_ENABLED`],
                 ['MAPTEXTURE', `STD_${propName}_TEXTURE_ENABLED`],
                 ['MAPINVERT',  `STD_${propName}_INVERT`]
@@ -209,7 +209,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         }
 
         if (tintOption) {
-            fDefines.set(`STD_${propNameCaps}_MATERIAL_ENABLED`, '');
+            fDefines.set(`STD_${propNameCaps}_CONSTANT_ENABLED`, '');
         }
         if (!!(options[invertName])) {
             fDefines.set(`STD_${propNameCaps}_INVERT`, '');

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -104,7 +104,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
             [
                 ['$UV',         `{STD_${propName}_TEXTURE_UV}`],
                 ['$CH',         `{STD_${propName}_TEXTURE_CHANNEL}`],
-                ['$SAMPLER',    `{STD_${propName}_TEXTURE}`],
+                ['$SAMPLER',    `{STD_${propName}_TEXTURE_NAME}`],
                 ['$DECODE',     `{STD_${propName}_TEXTURE_DECODE}`],
                 ['$VC',         `{STD_${propName}_VERTEX_CHANNEL}`],
                 ['$DETAILMODE', `{STD_${propName}_DETAILMODE}`]
@@ -112,10 +112,10 @@ class ShaderGeneratorStandard extends ShaderGenerator {
 
             // defines
             [
-                ['MAPFLOAT',   `STD_${propName}_CONSTANT_ENABLED`],
-                ['MAPCOLOR',   `STD_${propName}_CONSTANT_ENABLED`],
-                ['MAPVERTEX',  `STD_${propName}_VERTEX_ENABLED`],
-                ['MAPTEXTURE', `STD_${propName}_TEXTURE_ENABLED`],
+                ['MAPFLOAT',   `STD_${propName}_CONSTANT`],
+                ['MAPCOLOR',   `STD_${propName}_CONSTANT`],
+                ['MAPVERTEX',  `STD_${propName}_VERTEX`],
+                ['MAPTEXTURE', `STD_${propName}_TEXTURE`],
                 ['MAPINVERT',  `STD_${propName}_INVERT`]
             ].forEach(([oldSyntax, newSyntax]) => trackChange(oldSyntax, newSyntax));
 
@@ -171,7 +171,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
 
         if (textureOption) {
 
-            fDefines.set(`STD_${propNameCaps}_TEXTURE_ENABLED`, '');
+            fDefines.set(`STD_${propNameCaps}_TEXTURE`, '');
 
             const uv = this._getUvSourceExpression(transformPropName, uVPropName, options);
 
@@ -180,7 +180,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
             fDefines.set(`{STD_${propNameCaps}_TEXTURE_CHANNEL}`, options[channelPropName]);
 
             // texture sampler define
-            const textureId = `{STD_${propNameCaps}_TEXTURE}`;
+            const textureId = `{STD_${propNameCaps}_TEXTURE_NAME}`;
             if (mapping && chunkCode.includes(textureId)) {
                 let samplerName = `texture_${mapPropName}`;
                 const alias = mapping[textureIdentifier];
@@ -200,7 +200,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         }
 
         if (vertexColorOption) {
-            fDefines.set(`STD_${propNameCaps}_VERTEX_ENABLED`, '');
+            fDefines.set(`STD_${propNameCaps}_VERTEX`, '');
             fDefines.set(`{STD_${propNameCaps}_VERTEX_CHANNEL}`, options[vertexColorChannelPropName]);
         }
 
@@ -209,7 +209,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         }
 
         if (tintOption) {
-            fDefines.set(`STD_${propNameCaps}_CONSTANT_ENABLED`, '');
+            fDefines.set(`STD_${propNameCaps}_CONSTANT`, '');
         }
         if (!!(options[invertName])) {
             fDefines.set(`STD_${propNameCaps}_INVERT`, '');

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -52,15 +52,13 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         return key;
     }
 
-    // get the value to replace $UV with in Map Shader functions
-
     /**
-     * Get the code with which to to replace '$UV' in the map shader functions.
+     * Get the code with which to to replace '*_TEXTURE_UV' in the map shader functions.
      *
      * @param {string} transformPropName - Name of the transform id in the options block. Usually "basenameTransform".
      * @param {string} uVPropName - Name of the UV channel in the options block. Usually "basenameUv".
      * @param {object} options - The options passed into createShaderDefinition.
-     * @returns {string} The code used to replace "$UV" in the shader code.
+     * @returns {string} The code used to replace '*_TEXTURE_UV' in the shader code.
      * @private
      */
     _getUvSourceExpression(transformPropName, uVPropName, options) {
@@ -90,32 +88,64 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         return expression;
     }
 
-    _addMapDef(name, enabled) {
-        return enabled ? `#define ${name}\n` : `#undef ${name}\n`;
-    }
+    _validateMapChunk(propName, chunkName, chunks) {
+        Debug.call(() => {
+            const code = chunks[chunkName];
+            const requiredChangeStrings = [];
 
-    _addMapDefs(float, color, vertex, map, invert) {
-        return this._addMapDef('MAPFLOAT', float) +
-               this._addMapDef('MAPCOLOR', color) +
-               this._addMapDef('MAPVERTEX', vertex) +
-               this._addMapDef('MAPTEXTURE', map) +
-               this._addMapDef('MAPINVERT', invert);
+            // Helper function to add a formatted change string if the old syntax is found
+            const trackChange = (oldSyntax, newSyntax) => {
+                if (code.includes(oldSyntax)) {
+                    requiredChangeStrings.push(`  ${oldSyntax} -> ${newSyntax}`);
+                }
+            };
+
+            // inject defines (with curly braces)
+            [
+                ['$UV',         `{STD_${propName}_TEXTURE_UV}`],
+                ['$CH',         `{STD_${propName}_TEXTURE_CHANNEL}`],
+                ['$SAMPLER',    `{STD_${propName}_TEXTURE}`],
+                ['$DECODE',     `{STD_${propName}_TEXTURE_DECODE}`],
+                ['$VC',         `{STD_${propName}_VERTEX_CHANNEL}`],
+                ['$DETAILMODE', `{STD_${propName}_DETAILMODE}`]
+            ].forEach(([oldSyntax, newSyntax]) => trackChange(oldSyntax, newSyntax));
+
+            // defines
+            [
+                ['MAPFLOAT',   `STD_${propName}_MATERIAL_ENABLED`],
+                ['MAPCOLOR',   `STD_${propName}_MATERIAL_ENABLED`],
+                ['MAPVERTEX',  `STD_${propName}_VERTEX_ENABLED`],
+                ['MAPTEXTURE', `STD_${propName}_TEXTURE_ENABLED`],
+                ['MAPINVERT',  `STD_${propName}_INVERT`]
+            ].forEach(([oldSyntax, newSyntax]) => trackChange(oldSyntax, newSyntax));
+
+            // custom handling
+            if (code.includes('$texture2DSAMPLE')) {
+                trackChange('$texture2DSAMPLE', '(Macro no longer supported - remove/refactor)');
+            }
+
+            if (requiredChangeStrings.length > 0) {
+                Debug.errorOnce(`Shader chunk ${chunkName} is in no longer compatible format. Please make these replacements to bring it to the current version:\n${requiredChangeStrings.join('\n')}`, { code: code });
+            }
+        });
     }
 
     /**
      * Add chunk for Map Types (used for all maps except Normal).
      *
+     * @param {Map<string, string>} fDefines - The fragment defines.
      * @param {string} propName - The base name of the map: diffuse | emissive | opacity | light | height | metalness | specular | gloss | ao.
      * @param {string} chunkName - The name of the chunk to use. Usually "basenamePS".
      * @param {object} options - The options passed into to createShaderDefinition.
      * @param {object} chunks - The set of shader chunks to choose from.
      * @param {object} mapping - The mapping between chunk and sampler
-     * @param {string} encoding - The texture's encoding
+     * @param {string|null} encoding - The texture's encoding
      * @returns {string} The shader code to support this map.
      * @private
      */
-    _addMap(propName, chunkName, options, chunks, mapping, encoding = null) {
+    _addMap(fDefines, propName, chunkName, options, chunks, mapping, encoding = null) {
         const mapPropName = `${propName}Map`;
+        const propNameCaps = propName.toUpperCase();
         const uVPropName = `${mapPropName}Uv`;
         const identifierPropName = `${mapPropName}Identifier`;
         const transformPropName = `${mapPropName}Transform`;
@@ -132,14 +162,26 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         const textureIdentifier = options[identifierPropName];
         const detailModeOption = options[detailModePropName];
 
-        let subCode = chunks[chunkName];
+        const chunkCode = chunks[chunkName];
+
+        // log errors if the chunk format is deprecated (format changed in engine 2.7)
+        Debug.call(() => {
+            this._validateMapChunk(propNameCaps, chunkName, chunks);
+        });
 
         if (textureOption) {
+
+            fDefines.set(`STD_${propNameCaps}_TEXTURE_ENABLED`, '');
+
             const uv = this._getUvSourceExpression(transformPropName, uVPropName, options);
 
-            subCode = subCode.replace(/\$UV/g, uv).replace(/\$CH/g, options[channelPropName]);
+            // chunk injection defines
+            fDefines.set(`{STD_${propNameCaps}_TEXTURE_UV}`, uv);
+            fDefines.set(`{STD_${propNameCaps}_TEXTURE_CHANNEL}`, options[channelPropName]);
 
-            if (mapping && subCode.search(/\$SAMPLER/g) !== -1) {
+            // texture sampler define
+            const textureId = `{STD_${propNameCaps}_TEXTURE}`;
+            if (mapping && chunkCode.includes(textureId)) {
                 let samplerName = `texture_${mapPropName}`;
                 const alias = mapping[textureIdentifier];
                 if (alias) {
@@ -147,46 +189,33 @@ class ShaderGeneratorStandard extends ShaderGenerator {
                 } else {
                     mapping[textureIdentifier] = samplerName;
                 }
-                subCode = subCode.replace(/\$SAMPLER/g, samplerName);
+                fDefines.set(textureId, samplerName);
             }
 
             if (encoding) {
-                if (options[channelPropName] === 'aaa') {
-                    // completely skip decoding if the user has selected the alpha channel (since alpha
-                    // is never decoded).
-                    subCode = subCode.replace(/\$DECODE/g, 'passThrough');
-                } else {
-                    subCode = subCode.replace(/\$DECODE/g, ChunkUtils.decodeFunc(encoding));
-                }
-
-                // continue to support $texture2DSAMPLE
-                if (subCode.indexOf('$texture2DSAMPLE')) {
-                    const decodeTable = {
-                        linear: 'texture2D',
-                        srgb: 'texture2DSRGB',
-                        rgbm: 'texture2DRGBM',
-                        rgbe: 'texture2DRGBE'
-                    };
-
-                    subCode = subCode.replace(/\$texture2DSAMPLE/g, decodeTable[encoding] || 'texture2D');
-                }
+                // decode function, ignored for alpha channel
+                const textureDecode = options[channelPropName] === 'aaa' ? 'passThrough' : ChunkUtils.decodeFunc(encoding);
+                fDefines.set(`{STD_${propNameCaps}_TEXTURE_DECODE}`, textureDecode);
             }
         }
 
         if (vertexColorOption) {
-            subCode = subCode.replace(/\$VC/g, options[vertexColorChannelPropName]);
+            fDefines.set(`STD_${propNameCaps}_VERTEX_ENABLED`, '');
+            fDefines.set(`{STD_${propNameCaps}_VERTEX_CHANNEL}`, options[vertexColorChannelPropName]);
         }
 
         if (detailModeOption) {
-            subCode = subCode.replace(/\$DETAILMODE/g, detailModeOption);
+            fDefines.set(`{STD_${propNameCaps}_DETAILMODE}`, detailModeOption);
         }
 
-        const isFloatTint = !!(tintOption & 1);
-        const isVecTint = !!(tintOption & 2);
-        const invertOption = !!(options[invertName]);
+        if (tintOption) {
+            fDefines.set(`STD_${propNameCaps}_MATERIAL_ENABLED`, '');
+        }
+        if (!!(options[invertName])) {
+            fDefines.set(`STD_${propNameCaps}_INVERT`, '');
+        }
 
-        subCode = this._addMapDefs(isFloatTint, isVecTint, vertexColorOption, textureOption, invertOption) + subCode;
-        return subCode.replace(/\$/g, '');
+        return chunkCode;
     }
 
     _correctChannel(p, chan, _matTex2D) {
@@ -261,6 +290,9 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         const isForwardPass = shaderPassInfo.isForward;
         const litShader = new LitShader(device, options.litOptions);
 
+        // fragment defines
+        const fDefines = litShader.fDefines;
+
         // generate vertex shader
         this.createVertexShader(litShader, options);
 
@@ -285,20 +317,15 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         if (isForwardPass) {
             // parallax
             if (options.heightMap) {
-                // if (!options.normalMap) {
-                //     const transformedHeightMapUv = this._getUvSourceExpression("heightMapTransform", "heightMapUv", options);
-                //     if (!options.hasTangents) tbn = tbn.replace(/\$UV/g, transformedHeightMapUv);
-                //     code += tbn;
-                // }
                 decl.append('vec2 dUvOffset;');
-                code.append(this._addMap('height', 'parallaxPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'height', 'parallaxPS', options, litShader.chunks, textureMapping));
                 func.append('getParallax();');
             }
 
             // opacity
             if (options.litOptions.blendType !== BLEND_NONE || options.litOptions.alphaTest || options.litOptions.alphaToCoverage || options.litOptions.opacityDither !== DITHER_NONE) {
                 decl.append('float dAlpha;');
-                code.append(this._addMap('opacity', 'opacityPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'opacity', 'opacityPS', options, litShader.chunks, textureMapping));
                 func.append('getOpacity();');
                 args.append('litArgs_opacity = dAlpha;');
 
@@ -334,8 +361,8 @@ class ShaderGeneratorStandard extends ShaderGenerator {
                 }
 
                 decl.append('vec3 dNormalW;');
-                code.append(this._addMap('normalDetail', 'normalDetailMapPS', options, litShader.chunks, textureMapping));
-                code.append(this._addMap('normal', 'normalMapPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'normalDetail', 'normalDetailMapPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'normal', 'normalMapPS', options, litShader.chunks, textureMapping));
                 func.append('getNormal();');
                 args.append('litArgs_worldNormal = dNormalW;');
             }
@@ -359,20 +386,20 @@ class ShaderGeneratorStandard extends ShaderGenerator {
             // albedo
             decl.append('vec3 dAlbedo;');
             if (options.diffuseDetail) {
-                code.append(this._addMap('diffuseDetail', 'diffuseDetailMapPS', options, litShader.chunks, textureMapping, options.diffuseDetailEncoding));
+                code.append(this._addMap(fDefines, 'diffuseDetail', 'diffuseDetailMapPS', options, litShader.chunks, textureMapping, options.diffuseDetailEncoding));
             }
-            code.append(this._addMap('diffuse', 'diffusePS', options, litShader.chunks, textureMapping, options.diffuseEncoding));
+            code.append(this._addMap(fDefines, 'diffuse', 'diffusePS', options, litShader.chunks, textureMapping, options.diffuseEncoding));
             func.append('getAlbedo();');
             args.append('litArgs_albedo = dAlbedo;');
 
             if (options.litOptions.useRefraction) {
                 decl.append('float dTransmission;');
-                code.append(this._addMap('refraction', 'transmissionPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'refraction', 'transmissionPS', options, litShader.chunks, textureMapping));
                 func.append('getRefraction();');
                 args.append('litArgs_transmission = dTransmission;');
 
                 decl.append('float dThickness;');
-                code.append(this._addMap('thickness', 'thicknessPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'thickness', 'thicknessPS', options, litShader.chunks, textureMapping));
                 func.append('getThickness();');
                 args.append('litArgs_thickness = dThickness;');
 
@@ -383,12 +410,12 @@ class ShaderGeneratorStandard extends ShaderGenerator {
 
             if (options.litOptions.useIridescence) {
                 decl.append('float dIridescence;');
-                code.append(this._addMap('iridescence', 'iridescencePS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'iridescence', 'iridescencePS', options, litShader.chunks, textureMapping));
                 func.append('getIridescence();');
                 args.append('litArgs_iridescence_intensity = dIridescence;');
 
                 decl.append('float dIridescenceThickness;');
-                code.append(this._addMap('iridescenceThickness', 'iridescenceThicknessPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'iridescenceThickness', 'iridescenceThicknessPS', options, litShader.chunks, textureMapping));
                 func.append('getIridescenceThickness();');
                 args.append('litArgs_iridescence_thickness = dIridescenceThickness;');
             }
@@ -399,38 +426,38 @@ class ShaderGeneratorStandard extends ShaderGenerator {
                 decl.append('float dGlossiness;');
                 if (options.litOptions.useSheen) {
                     decl.append('vec3 sSpecularity;');
-                    code.append(this._addMap('sheen', 'sheenPS', options, litShader.chunks, textureMapping, options.sheenEncoding));
+                    code.append(this._addMap(fDefines, 'sheen', 'sheenPS', options, litShader.chunks, textureMapping, options.sheenEncoding));
                     func.append('getSheen();');
                     args.append('litArgs_sheen_specularity = sSpecularity;');
 
                     decl.append('float sGlossiness;');
-                    code.append(this._addMap('sheenGloss', 'sheenGlossPS', options, litShader.chunks, textureMapping));
+                    code.append(this._addMap(fDefines, 'sheenGloss', 'sheenGlossPS', options, litShader.chunks, textureMapping));
                     func.append('getSheenGlossiness();');
                     args.append('litArgs_sheen_gloss = sGlossiness;');
                 }
                 if (options.litOptions.useMetalness) {
                     decl.append('float dMetalness;');
-                    code.append(this._addMap('metalness', 'metalnessPS', options, litShader.chunks, textureMapping));
+                    code.append(this._addMap(fDefines, 'metalness', 'metalnessPS', options, litShader.chunks, textureMapping));
                     func.append('getMetalness();');
                     args.append('litArgs_metalness = dMetalness;');
 
                     decl.append('float dIor;');
-                    code.append(this._addMap('ior', 'iorPS', options, litShader.chunks, textureMapping));
+                    code.append(this._addMap(fDefines, 'ior', 'iorPS', options, litShader.chunks, textureMapping));
                     func.append('getIor();');
                     args.append('litArgs_ior = dIor;');
                 }
                 if (options.litOptions.useSpecularityFactor) {
                     decl.append('float dSpecularityFactor;');
-                    code.append(this._addMap('specularityFactor', 'specularityFactorPS', options, litShader.chunks, textureMapping));
+                    code.append(this._addMap(fDefines, 'specularityFactor', 'specularityFactorPS', options, litShader.chunks, textureMapping));
                     func.append('getSpecularityFactor();');
                     args.append('litArgs_specularityFactor = dSpecularityFactor;');
                 }
                 if (options.useSpecularColor) {
-                    code.append(this._addMap('specular', 'specularPS', options, litShader.chunks, textureMapping, options.specularEncoding));
+                    code.append(this._addMap(fDefines, 'specular', 'specularPS', options, litShader.chunks, textureMapping, options.specularEncoding));
                 } else {
                     code.append('void getSpecularity() { dSpecularity = vec3(1); }');
                 }
-                code.append(this._addMap('gloss', 'glossPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'gloss', 'glossPS', options, litShader.chunks, textureMapping));
                 func.append('getGlossiness();');
                 func.append('getSpecularity();');
                 args.append('litArgs_specularity = dSpecularity;');
@@ -442,18 +469,18 @@ class ShaderGeneratorStandard extends ShaderGenerator {
 
             // ao
             if (options.aoDetail) {
-                code.append(this._addMap('aoDetail', 'aoDetailMapPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'aoDetail', 'aoDetailMapPS', options, litShader.chunks, textureMapping));
             }
             if (options.aoMap || options.aoVertexColor || options.useAO) {
                 decl.append('float dAo;');
-                code.append(this._addMap('ao', 'aoPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'ao', 'aoPS', options, litShader.chunks, textureMapping));
                 func.append('getAO();');
                 args.append('litArgs_ao = dAo;');
             }
 
             // emission
             decl.append('vec3 dEmission;');
-            code.append(this._addMap('emissive', 'emissivePS', options, litShader.chunks, textureMapping, options.emissiveEncoding));
+            code.append(this._addMap(fDefines, 'emissive', 'emissivePS', options, litShader.chunks, textureMapping, options.emissiveEncoding));
             func.append('getEmission();');
             args.append('litArgs_emission = dEmission;');
 
@@ -463,9 +490,9 @@ class ShaderGeneratorStandard extends ShaderGenerator {
                 decl.append('float ccGlossiness;');
                 decl.append('vec3 ccNormalW;');
 
-                code.append(this._addMap('clearCoat', 'clearCoatPS', options, litShader.chunks, textureMapping));
-                code.append(this._addMap('clearCoatGloss', 'clearCoatGlossPS', options, litShader.chunks, textureMapping));
-                code.append(this._addMap('clearCoatNormal', 'clearCoatNormalPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'clearCoat', 'clearCoatPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'clearCoatGloss', 'clearCoatGlossPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'clearCoatNormal', 'clearCoatNormalPS', options, litShader.chunks, textureMapping));
 
                 func.append('getClearCoat();');
                 func.append('getClearCoatGlossiness();');
@@ -484,7 +511,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
                 if (lightmapDir) {
                     decl.append('vec3 dLightmapDir;');
                 }
-                code.append(this._addMap('light', lightmapChunkPropName, options, litShader.chunks, textureMapping, options.lightMapEncoding));
+                code.append(this._addMap(fDefines, 'light', lightmapChunkPropName, options, litShader.chunks, textureMapping, options.lightMapEncoding));
                 func.append('getLightMap();');
                 args.append('litArgs_lightmap = dLightmap;');
                 if (lightmapDir) {
@@ -492,16 +519,16 @@ class ShaderGeneratorStandard extends ShaderGenerator {
                 }
             }
 
-            Debug.assert(code.code.indexOf('texture2DSRGB') === -1 &&
-                         code.code.indexOf('texture2DRGBM') === -1 &&
-                         code.code.indexOf('texture2DRGBE') === -1, 'Shader chunk macro $texture2DSAMPLE(XXX) is deprecated. Please use $DECODE(texture2D(XXX)) instead.');
+            Debug.assert(!code.code.includes('$texture2DSRGB'), 'Shader chunk macro $texture2DSRGB has been removed.', { code: code.code });
+            Debug.assert(!code.code.includes('$texture2DRGBM'), 'Shader chunk macro $texture2DRGBM has been removed.', { code: code.code });
+            Debug.assert(!code.code.includes('$texture2DRGBE'), 'Shader chunk macro $texture2DRGBE has been removed.', { code: code.code });
 
         } else {
             // all other passes require only opacity
             const opacityShadowDither = options.litOptions.opacityShadowDither;
             if (options.litOptions.alphaTest || opacityShadowDither) {
                 decl.append('float dAlpha;');
-                code.append(this._addMap('opacity', 'opacityPS', options, litShader.chunks, textureMapping));
+                code.append(this._addMap(fDefines, 'opacity', 'opacityPS', options, litShader.chunks, textureMapping));
                 func.append('getOpacity();');
                 args.append('litArgs_opacity = dAlpha;');
                 if (options.litOptions.alphaTest) {
@@ -546,7 +573,6 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         const vDefines = litShader.vDefines;
         options.defines.forEach((value, key) => vDefines.set(key, value));
 
-        const fDefines = litShader.fDefines;
         options.defines.forEach((value, key) => fDefines.set(key, value));
 
         const definition = ShaderUtils.createDefinition(device, {


### PR DESCRIPTION
If you are not overriding any of the shader chunks listed bellow, you can skip this, this has no effect on your project.

More commonly modified chunks:
```
- diffusePS
- emissivePS
- opacityPS
```
Rarely commonly modified chunks:
```
- parallaxPS
- normalDetailMapPS
- normalMapPS
- diffuseDetailMapPS
- transmissionPS
- thicknessPS
- iridescencePS
- iridescenceThicknessPS
- sheenPS
- sheenGlossPS
- metalnessPS
- iorPS
- specularityFactorPS
- specularPS
- glossPS
- aoDetailMapPS
- aoPS
- clearCoatPS
- clearCoatGlossPS
- clearCoatNormalPS
- lightmapDirPS
- lightmapSinglePS
```
All listed front end shader chunks, dealing with StandardMaterial texture sampling / vertex color access were modified. If you are overriding any of these, you need to update them to a new format.

To make the transition easier, engine in debug mode prints exactly what needs to be replaced in each chunk:
<img width="736" alt="Screenshot 2025-03-28 at 11 40 52" src="https://github.com/user-attachments/assets/d97a81d6-f62a-4831-ae2b-f8c5a2f410f8" />

The user can simply apply those changes (search and replace), the source:
<img width="773" alt="Screenshot 2025-03-28 at 11 41 59" src="https://github.com/user-attachments/assets/5b2ea69b-e4ce-4a06-a1cc-7cf985d533ce" />

the modified chunk:
<img width="803" alt="Screenshot 2025-03-28 at 11 42 07" src="https://github.com/user-attachments/assets/905bd4f1-ca60-48b0-a160-4061d241c635" />

Benefits:
- we now have global defines that drive those chunks, instead of per chunk defines
- we do NOT need to do any string replacement in javascript, but simply apply standard preprocessor to the chunk
- this allows us to simply convert chunks to WGSL and retain their functionality, and then further create an uber shader for the standard material
