### PR TITLE
[Fix] Fixed hanling of texture.type

### DIFF
--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -225,6 +225,7 @@ class TextureHandler extends ResourceHandler {
             }
 
             // extract asset type (this is bit of a mess)
+            options.type = TEXTURETYPE_DEFAULT;
             if (assetData.hasOwnProperty('type')) {
                 options.type = JSON_TEXTURE_TYPE[assetData.type];
             } else if (assetData.hasOwnProperty('rgbm') && assetData.rgbm) {

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -266,7 +266,7 @@ class Texture {
         this._compareOnRead = options.compareOnRead ?? false;
         this._compareFunc = options.compareFunc ?? FUNC_LESS;
 
-        this.type = options.hasOwnProperty('type') ? options.type : TEXTURETYPE_DEFAULT;
+        this._type = options.hasOwnProperty('type') ? options.type : TEXTURETYPE_DEFAULT;
         Debug.assert(!options.hasOwnProperty('rgbm'), 'Use options.type.');
         Debug.assert(!options.hasOwnProperty('swizzleGGGR'), 'Use options.type.');
 
@@ -792,6 +792,31 @@ class Texture {
      */
     get volume() {
         return this._volume;
+    }
+
+    /**
+     * Sets the texture type.
+     *
+     * @type {number}
+     * @ignore
+     */
+    set type(value) {
+        if (this._type !== value) {
+            this._type = value;
+
+            // update all shaders to respect the encoding of the texture (needed by the standard material)
+            this.device._shadersDirty = true;
+        }
+    }
+
+    /**
+     * Gets the texture type.
+     *
+     * @type {number}
+     * @ignore
+     */
+    get type() {
+        return this._type;
     }
 
     /**


### PR DESCRIPTION
- when the Editor changes texture properties, the type had no default value, and so the engine would be only notified if flag (for example rgbm) was turned on, but not when off.
- texture class handles the type change by rebuilding shaders, to reflect the new decoding the texture requires
