### PR TITLE
Set ‘data-engine’ parameter of the canvas to PlayCanvas

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -1,3 +1,4 @@
+import { version } from '../../core/core.js';
 import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
 import { platform } from '../../core/platform.js';
@@ -418,6 +419,9 @@ class GraphicsDevice extends EventHandler {
         super();
 
         this.canvas = canvas;
+        if ('setAttribute' in canvas) {
+            canvas.setAttribute('data-engine', `PlayCanvas ${version}`);
+        }
 
         // copy options and handle defaults
         this.initOptions = { ...options };


### PR DESCRIPTION
to allow easy identification in the inspector