### PR TITLE
Move CameraFrame to the Graphics category

### DIFF
--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -169,7 +169,7 @@ import { CameraFrameOptions, RenderPassCameraFrame } from './render-pass-camera-
  * Implementation of a simple to use camera rendering pass, which supports SSAO, Bloom and
  * other rendering effects.
  *
- * @category Render Pass
+ * @category Graphics
  */
 class CameraFrame {
     /** @private */


### PR DESCRIPTION
Currently, this is living alone in its own `Render Pass` category in the API reference. Feels like it should be alongside all the other `Graphics` symbols.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
