### PR TITLE
Restore missing StandardMaterial properties from API reference

### DIFF
--- a/utils/typedoc/typedoc-plugin.mjs
+++ b/utils/typedoc/typedoc-plugin.mjs
@@ -132,7 +132,7 @@ function load(app) {
                 if (!reflection.children) {
                     reflection.children = [];
                 }
-                reflection.children.push(newProperty);
+                reflection.addChild(newProperty);
             }
         });
     });


### PR DESCRIPTION
Presumably the TypeDoc API has changed, which caused the TypeDoc plugin for adding `StandardMaterial` properties to fail.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
