### PR TITLE
[FIX] [WebGL2] Use correct internal format for WebGL 565/5551/RGBA4 formats

### DIFF
--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -142,17 +142,17 @@ class WebglTexture {
                 break;
             case PIXELFORMAT_RGB565:
                 this._glFormat = gl.RGB;
-                this._glInternalFormat = gl.RGB;
+                this._glInternalFormat = gl.RGB565;
                 this._glPixelType = gl.UNSIGNED_SHORT_5_6_5;
                 break;
             case PIXELFORMAT_RGBA5551:
                 this._glFormat = gl.RGBA;
-                this._glInternalFormat = gl.RGBA;
+                this._glInternalFormat = gl.RGB5_A1;
                 this._glPixelType = gl.UNSIGNED_SHORT_5_5_5_1;
                 break;
             case PIXELFORMAT_RGBA4:
                 this._glFormat = gl.RGBA;
-                this._glInternalFormat = gl.RGBA;
+                this._glInternalFormat = gl.RGBA4;
                 this._glPixelType = gl.UNSIGNED_SHORT_4_4_4_4;
                 break;
             case PIXELFORMAT_RGB8:


### PR DESCRIPTION
I ran into some issues creating textures with these formats and found I had to change the internal format. WebGL2 accepts the sized internal formats while WebGL1 doesn't.

I'm not sure how we're handling WebGL1/2 differences now with the ongoing WebGL1 branch - is it OK to open PRs that assume WebGL2?

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
