### PR TITLE
Restore @ignore tags for classes that should not be in the API reference

### DIFF
--- a/src/core/math/blue-noise.js
+++ b/src/core/math/blue-noise.js
@@ -21,6 +21,8 @@ const blueNoiseData = () => {
 
 /**
  * Blue noise based random numbers API.
+ *
+ * @ignore
  */
 class BlueNoise {
     seed = 0;

--- a/src/core/math/curve-evaluator.js
+++ b/src/core/math/curve-evaluator.js
@@ -7,6 +7,8 @@ import { math } from './math.js';
 
 /**
  * A class for evaluating a curve at a specific time.
+ *
+ * @ignore
  */
 class CurveEvaluator {
     /** @private */

--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -3,6 +3,7 @@
  * garbage collection.
  *
  * @template {new (...args: any[]) => any} T
+ * @ignore
  */
 class ObjectPool {
     /**

--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -17,6 +17,8 @@ let id = 0;
 /**
  * Data structure to hold a bind group and its offsets. This is used by {@link UniformBuffer#update}
  * to return a dynamic bind group and offset for the uniform buffer.
+ *
+ * @ignore
  */
 class DynamicBindGroup {
     bindGroup;
@@ -27,6 +29,8 @@ class DynamicBindGroup {
 /**
  * A bind group represents a collection of {@link UniformBuffer}, {@link Texture} and
  * {@link StorageBuffer} instanced, which can be bind on a GPU for rendering.
+ *
+ * @ignore
  */
 class BindGroup {
     /**

--- a/src/platform/graphics/dynamic-buffer.js
+++ b/src/platform/graphics/dynamic-buffer.js
@@ -9,6 +9,8 @@ import { SHADERSTAGE_FRAGMENT, SHADERSTAGE_VERTEX, UNIFORM_BUFFER_DEFAULT_SLOT_N
 
 /**
  * A base class representing a single per platform buffer.
+ *
+ * @ignore
  */
 class DynamicBuffer {
     /** @type {GraphicsDevice} */

--- a/src/platform/graphics/dynamic-buffers.js
+++ b/src/platform/graphics/dynamic-buffers.js
@@ -8,6 +8,8 @@ import { math } from '../../core/math/math.js';
 
 /**
  * A container for storing the used areas of a pair of staging and gpu buffers.
+ *
+ * @ignore
  */
 class UsedBuffer {
     /** @type {DynamicBuffer} */
@@ -34,6 +36,8 @@ class UsedBuffer {
 
 /**
  * A container for storing the return values of an allocation function.
+ *
+ * @ignore
  */
 class DynamicBufferAllocation {
     /**
@@ -66,6 +70,8 @@ class DynamicBufferAllocation {
  * command buffers that require these buffers, the system automatically uploads the data to the GPU
  * buffers. This approach ensures efficient memory management and smooth data transfer between the
  * CPU and GPU.
+ *
+ * @ignore
  */
 class DynamicBuffers {
     /**

--- a/src/platform/graphics/gpu-profiler.js
+++ b/src/platform/graphics/gpu-profiler.js
@@ -4,6 +4,8 @@ import { Tracing } from '../../core/tracing.js';
 
 /**
  * Base class of a simple GPU profiler.
+ *
+ * @ignore
  */
 class GpuProfiler {
     /**
@@ -23,8 +25,9 @@ class GpuProfiler {
     pastFrameAllocations = new Map();
 
     /**
-     * The if enabled in the current frame.
-     * @ignore
+     * True if enabled in the current frame.
+     *
+     * @private
      */
     _enabled = false;
 

--- a/src/platform/graphics/null/null-index-buffer.js
+++ b/src/platform/graphics/null/null-index-buffer.js
@@ -1,5 +1,7 @@
 /**
  * A Null implementation of the IndexBuffer.
+ *
+ * @ignore
  */
 class NullIndexBuffer {
     unlock(indexBuffer) {

--- a/src/platform/graphics/null/null-render-target.js
+++ b/src/platform/graphics/null/null-render-target.js
@@ -1,5 +1,7 @@
 /**
  * A Null implementation of the RenderTarget.
+ *
+ * @ignore
  */
 class NullRenderTarget {
     destroy(device) {

--- a/src/platform/graphics/null/null-shader.js
+++ b/src/platform/graphics/null/null-shader.js
@@ -1,5 +1,7 @@
 /**
  * A Null implementation of the Shader.
+ *
+ * @ignore
  */
 class NullShader {
     destroy(shader) {

--- a/src/platform/graphics/null/null-texture.js
+++ b/src/platform/graphics/null/null-texture.js
@@ -1,5 +1,7 @@
 /**
  * A Null implementation of the Texture.
+ *
+ * @ignore
  */
 class NullTexture {
     destroy(device) {

--- a/src/platform/graphics/null/null-vertex-buffer.js
+++ b/src/platform/graphics/null/null-vertex-buffer.js
@@ -1,5 +1,7 @@
 /**
  * A Null implementation of the VertexBuffer.
+ *
+ * @ignore
  */
 class NullVertexBuffer {
     destroy(device) {

--- a/src/platform/graphics/uniform-buffer.js
+++ b/src/platform/graphics/uniform-buffer.js
@@ -204,6 +204,8 @@ _updateFunctions[UNIFORMTYPE_UVEC3ARRAY] = (uniformBuffer, value, offset, count)
 
 /**
  * A uniform buffer represents a GPU memory buffer storing the uniforms.
+ *
+ * @ignore
  */
 class UniformBuffer {
     device;

--- a/src/platform/graphics/vertex-iterator.js
+++ b/src/platform/graphics/vertex-iterator.js
@@ -77,6 +77,7 @@ function arrayGet4(offset, outputArray, outputIndex) {
  * Helps with accessing a specific vertex attribute.
  *
  * @category Graphics
+ * @ignore
  */
 class VertexIteratorAccessor {
     /**

--- a/src/platform/graphics/webgl/webgl-buffer.js
+++ b/src/platform/graphics/webgl/webgl-buffer.js
@@ -2,6 +2,8 @@ import { BUFFER_DYNAMIC, BUFFER_GPUDYNAMIC, BUFFER_STATIC, BUFFER_STREAM } from 
 
 /**
  * A WebGL implementation of the Buffer.
+ *
+ * @ignore
  */
 class WebglBuffer {
     bufferId = null;

--- a/src/platform/graphics/webgl/webgl-index-buffer.js
+++ b/src/platform/graphics/webgl/webgl-index-buffer.js
@@ -3,6 +3,8 @@ import { WebglBuffer } from './webgl-buffer.js';
 
 /**
  * A WebGL implementation of the IndexBuffer.
+ *
+ * @ignore
  */
 class WebglIndexBuffer extends WebglBuffer {
     constructor(indexBuffer) {

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -10,6 +10,8 @@ import { getMultisampledTextureCache } from '../multi-sampled-texture-cache.js';
 
 /**
  * A private class representing a pair of framebuffers, when MSAA is used.
+ *
+ * @ignore
  */
 class FramebufferPair {
     /**
@@ -53,6 +55,8 @@ class FramebufferPair {
 
 /**
  * A WebGL implementation of the RenderTarget.
+ *
+ * @ignore
  */
 class WebglRenderTarget {
     _glFrameBuffer = null;

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -44,6 +44,8 @@ const _fragmentShaderCache = new DeviceCache();
 
 /**
  * A WebGL implementation of the Shader.
+ *
+ * @ignore
  */
 class WebglShader {
     compileDuration = 0;

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -55,6 +55,8 @@ function downsampleImage(image, size) {
 
 /**
  * A WebGL implementation of the Texture.
+ *
+ * @ignore
  */
 class WebglTexture {
     _glTexture = null;

--- a/src/platform/graphics/webgl/webgl-vertex-buffer.js
+++ b/src/platform/graphics/webgl/webgl-vertex-buffer.js
@@ -2,6 +2,8 @@ import { WebglBuffer } from './webgl-buffer.js';
 
 /**
  * A WebGL implementation of the VertexBuffer.
+ *
+ * @ignore
  */
 class WebglVertexBuffer extends WebglBuffer {
     // vertex array object

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -32,6 +32,8 @@ const stringIds = new StringIds();
 
 /**
  * A WebGPU implementation of the BindGroupFormat, which is a wrapper over GPUBindGroupLayout.
+ *
+ * @ignore
  */
 class WebgpuBindGroupFormat {
     /**

--- a/src/platform/graphics/webgpu/webgpu-bind-group.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group.js
@@ -9,6 +9,8 @@ import { WebgpuDebug } from './webgpu-debug.js';
 
 /**
  * A WebGPU implementation of the BindGroup, which is a wrapper over GPUBindGroup.
+ *
+ * @ignore
  */
 class WebgpuBindGroup {
     /**

--- a/src/platform/graphics/webgpu/webgpu-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-buffer.js
@@ -7,6 +7,8 @@ import { Debug, DebugHelper } from '../../../core/debug.js';
 
 /**
  * A WebGPU implementation of the Buffer.
+ *
+ * @ignore
  */
 class WebgpuBuffer {
     /**

--- a/src/platform/graphics/webgpu/webgpu-clear-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-clear-renderer.js
@@ -26,6 +26,8 @@ const primitive = {
  * it needs to be cleared later during the rendering, this need to be achieved by rendering a quad.
  * This class renders a full-screen quad, and expects the viewport / scissor to be set up to clip
  * it to only required area.
+ *
+ * @ignore
  */
 class WebgpuClearRenderer {
     constructor(device) {

--- a/src/platform/graphics/webgpu/webgpu-compute.js
+++ b/src/platform/graphics/webgpu/webgpu-compute.js
@@ -5,6 +5,8 @@ import { UniformBuffer } from '../uniform-buffer.js';
 
 /**
  * A WebGPU implementation of the Compute.
+ *
+ * @ignore
  */
 class WebgpuCompute {
     /** @type {UniformBuffer[]} */

--- a/src/platform/graphics/webgpu/webgpu-index-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-index-buffer.js
@@ -4,6 +4,8 @@ import { WebgpuBuffer } from './webgpu-buffer.js';
 
 /**
  * A WebGPU implementation of the IndexBuffer.
+ *
+ * @ignore
  */
 class WebgpuIndexBuffer extends WebgpuBuffer {
     format = null;

--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -11,6 +11,8 @@ import { DebugGraphics } from '../debug-graphics.js';
 
 /**
  * A WebGPU helper class implementing texture mipmap generation.
+ *
+ * @ignore
  */
 class WebgpuMipmapRenderer {
     /** @type {WebgpuGraphicsDevice} */

--- a/src/platform/graphics/webgpu/webgpu-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-pipeline.js
@@ -10,6 +10,8 @@ let _layoutId = 0;
 
 /**
  * Base class for render and compute pipelines.
+ *
+ * @ignore
  */
 class WebgpuPipeline {
     constructor(device) {

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -104,6 +104,8 @@ class DepthAttachment {
 
 /**
  * A WebGPU implementation of the RenderTarget.
+ *
+ * @ignore
  */
 class WebgpuRenderTarget {
     /** @type {boolean} */

--- a/src/platform/graphics/webgpu/webgpu-resolver.js
+++ b/src/platform/graphics/webgpu/webgpu-resolver.js
@@ -10,6 +10,8 @@ import { DebugGraphics } from '../debug-graphics.js';
 
 /**
  * A WebGPU helper class implementing custom resolve of multi-sampled textures.
+ *
+ * @ignore
  */
 class WebgpuResolver {
     /** @type {WebgpuGraphicsDevice} */

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -12,6 +12,8 @@ import { WebgpuShaderProcessorWGSL } from './webgpu-shader-processor-wgsl.js';
 
 /**
  * A WebGPU implementation of the Shader.
+ *
+ * @ignore
  */
 class WebgpuShader {
     /**

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -41,6 +41,8 @@ const dummyUse = (thingOne) => {
 
 /**
  * A WebGPU implementation of the Texture.
+ *
+ * @ignore
  */
 class WebgpuTexture {
     /**

--- a/src/platform/graphics/webgpu/webgpu-uniform-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-uniform-buffer.js
@@ -3,6 +3,8 @@ import { WebgpuBuffer } from './webgpu-buffer.js';
 
 /**
  * A WebGPU implementation of the UniformBuffer.
+ *
+ * @ignore
  */
 class WebgpuUniformBuffer extends WebgpuBuffer {
     constructor(uniformBuffer) {

--- a/src/platform/graphics/webgpu/webgpu-vertex-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-vertex-buffer.js
@@ -3,6 +3,8 @@ import { WebgpuBuffer } from './webgpu-buffer.js';
 
 /**
  * A WebGPU implementation of the VertexBuffer.
+ *
+ * @ignore
  */
 class WebgpuVertexBuffer extends WebgpuBuffer {
     constructor(vertexBuffer, format, options) {

--- a/src/platform/sound/listener.js
+++ b/src/platform/sound/listener.js
@@ -7,6 +7,8 @@ import { Vec3 } from '../../core/math/vec3.js';
 
 /**
  * Represents an audio listener - used internally.
+ *
+ * @ignore
  */
 class Listener {
     /**

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -7,6 +7,8 @@
 /**
  * Class representing an entry in the final order of rendering of cameras and layers in the engine
  * this is populated at runtime based on LayerComposition
+ *
+ * @ignore
  */
 class RenderAction {
     // {CameraComponent|null}

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -8,6 +8,8 @@ import { Debug } from '../core/debug.js';
 
 /**
  * A frame graph represents a single rendering frame as a sequence of render passes.
+ *
+ * @ignore
  */
 class FrameGraph {
     /** @type {RenderPass[]} */

--- a/src/scene/graphics/light-cube.js
+++ b/src/scene/graphics/light-cube.js
@@ -13,6 +13,8 @@ const lightCubeDir = [
 /**
  * A lighting cube represented by 6 colors, one per cube direction. Use for simple lighting on the
  * particle system.
+ *
+ * @ignore
  */
 class LightCube {
     colors = new Float32Array(6 * 3);

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -51,6 +51,8 @@ const lookupHashes = new Uint32Array(4);
 
 /**
  * Internal data structure used to store data used by hardware instancing.
+ *
+ * @ignore
  */
 class InstancingData {
     /** @type {VertexBuffer|null} */
@@ -80,6 +82,8 @@ class InstancingData {
 
 /**
  * Internal helper class for storing the shader and related mesh bind group in the shader cache.
+ *
+ * @ignore
  */
 class ShaderInstance {
     /**

--- a/src/scene/render.js
+++ b/src/scene/render.js
@@ -9,6 +9,8 @@ import { EventHandler } from '../core/event-handler.js';
  * scene, and are accessible using the {@link ContainerResource#renders} property. A `Render` is
  * the resource of a Render Asset. They are usually created by the GLB loader and not created by
  * hand.
+ *
+ * @ignore
  */
 class Render extends EventHandler {
     /**

--- a/src/scene/renderer/render-pass-cookie-renderer.js
+++ b/src/scene/renderer/render-pass-cookie-renderer.js
@@ -47,6 +47,8 @@ const _invViewProjMatrices = [];
 
 /**
  * A render pass used to render cookie textures (both 2D and Cubemap) into the texture atlas.
+ *
+ * @ignore
  */
 class RenderPassCookieRenderer extends RenderPass {
     /** @type {QuadRender|null} */

--- a/src/scene/renderer/render-pass-shadow-directional.js
+++ b/src/scene/renderer/render-pass-shadow-directional.js
@@ -4,6 +4,8 @@ import { SHADOWUPDATE_NONE, SHADOWUPDATE_THISFRAME } from '../constants.js';
 
 /**
  * A render pass used to render directional shadows.
+ *
+ * @ignore
  */
 class RenderPassShadowDirectional extends RenderPass {
     constructor(device, shadowRenderer, light, camera, allCascadesRendering) {

--- a/src/scene/renderer/render-pass-shadow-local-clustered.js
+++ b/src/scene/renderer/render-pass-shadow-local-clustered.js
@@ -3,6 +3,8 @@ import { RenderPass } from '../../platform/graphics/render-pass.js';
 /**
  * A render pass used to render local clustered shadows. This is done inside a single render pass,
  * as all shadows are part of a single render target atlas.
+ *
+ * @ignore
  */
 class RenderPassShadowLocalClustered extends RenderPass {
     constructor(device, shadowRenderer, shadowRendererLocal) {

--- a/src/scene/renderer/render-pass-update-clustered.js
+++ b/src/scene/renderer/render-pass-update-clustered.js
@@ -5,6 +5,8 @@ import { RenderPassShadowLocalClustered } from './render-pass-shadow-local-clust
 
 /**
  * A render pass used to update clustered lighting data - shadows, cookies, world clusters.
+ *
+ * @ignore
  */
 class RenderPassUpdateClustered extends RenderPass {
     constructor(device, renderer, shadowRenderer, shadowRendererLocal, lightTextureAtlas) {

--- a/src/scene/renderer/world-clusters-allocator.js
+++ b/src/scene/renderer/world-clusters-allocator.js
@@ -11,6 +11,8 @@ const tempClusterArray = [];
 /**
  * A class managing instances of world clusters used by the renderer for layers with
  * unique sets of clustered lights.
+ *
+ * @ignore
  */
 class WorldClustersAllocator {
     /**

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -15,6 +15,8 @@ const shaderPassDeviceCache = new DeviceCache();
  * Info about a shader pass. Shader pass is represented by a unique index and a name, and the
  * index is used to access the shader required for the pass, from an array stored in the
  * material or mesh instance.
+ *
+ * @ignore
  */
 class ShaderPassInfo {
     /** @type {number} */

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -16,6 +16,8 @@ import { SkyGeometry } from './sky-geometry.js';
 
 /**
  * A visual representation of the sky.
+ *
+ * @ignore
  */
 class SkyMesh {
     /**


### PR DESCRIPTION
[This PR](https://github.com/playcanvas/engine/pull/6782) overzealously removed `@ignore` tags from certain classes. This PR restores them for classes we probably do not want to be public.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
