### PR TITLE
Improve API docs for ModelComponent and RenderComponent

### DIFF
--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -19,15 +19,39 @@ import { Component } from '../component.js';
  */
 
 /**
- * Enables an Entity to render a model or a primitive shape. This Component attaches additional
- * model geometry in to the scene graph below the Entity.
+ * The ModelComponent enables an {@link Entity} to render 3D models. The {@link type} property can
+ * be set to one of several predefined shapes (such as `box`, `sphere`, `cone` and so on).
+ * Alternatively, the component can be configured to manage an arbitrary {@link Model}. This can
+ * either be created programmatically or loaded from an {@link Asset}.
  *
- * @hideconstructor
+ * The {@link Model} managed by this component is positioned, rotated, and scaled in world space by
+ * the world transformation matrix of the owner {@link Entity}. This world matrix is derived by
+ * combining the entity's local transformation (position, rotation, and scale) with the world
+ * transformation matrix of its parent entity in the scene hierarchy.
+ *
+ * You should never need to use the ModelComponent constructor directly. To add a ModelComponent
+ * to an Entity, use {@link Entity#addComponent}:
+ *
+ * ```javascript
+ * const entity = new pc.Entity();
+ * entity.addComponent('model', {
+ *     type: 'box'
+ * });
+ * ```
+ *
+ * Once the ModelComponent is added to the entity, you can access it via the `model` property:
+ *
+ * ```javascript
+ * entity.model.type = 'capsule';  // Set the model component's type
+ *
+ * console.log(entity.model.type); // Get the model component's type and print it
+ * ```
+ *
  * @category Graphics
  */
 class ModelComponent extends Component {
     /**
-     * @type {string}
+     * @type {'asset'|'box'|'capsule'|'cone'|'cylinder'|'plane'|'sphere'|'torus'}
      * @private
      */
     _type = 'asset';
@@ -226,18 +250,36 @@ class ModelComponent extends Component {
     }
 
     /**
-     * Sets the type of the component. Can be one of the following:
+     * Sets the type of the component, determining the source of the geometry to be rendered.
+     * The geometry, whether it's a primitive shape or originates from an asset, is rendered
+     * using the owning entity's final world transform. This world transform is calculated by
+     * concatenating (multiplying) the local transforms (position, rotation, scale) of the
+     * entity and all its ancestors in the scene hierarchy. This process positions, orientates,
+     * and scales the geometry in world space.
      *
-     * - "asset": The component will render a model asset
-     * - "box": The component will render a box (1 unit in each dimension)
-     * - "capsule": The component will render a capsule (radius 0.5, height 2)
-     * - "cone": The component will render a cone (radius 0.5, height 1)
-     * - "cylinder": The component will render a cylinder (radius 0.5, height 1)
-     * - "plane": The component will render a plane (1 unit in each dimension)
-     * - "sphere": The component will render a sphere (radius 0.5)
-     * - "torus": The component will render a torus (tubeRadius: 0.2, ringRadius: 0.3)
+     * Can be one of the following values:
      *
-     * @type {string}
+     * - **"asset"**: Renders geometry defined in an {@link Asset} of type `model`. This asset,
+     *   assigned to the {@link asset} property, contains a {@link Model}. Alternatively,
+     *   {@link model} can be set programmatically.
+     * - **"box"**: A unit cube (sides of length 1) centered at the local space origin.
+     * - **"capsule"**: A shape composed of a cylinder and two hemispherical caps that is aligned
+     *   with the local Y-axis. It is centered at the local space origin and has an unscaled height
+     *   of 2 and a radius of 0.5.
+     * - **"cone"**: A cone aligned with the local Y-axis. It is centered at the local space
+     *   origin, with its base in the local XZ plane at Y = -0.5 and its tip at Y = +0.5. It has
+     *   an unscaled height of 1 and a base radius of 0.5.
+     * - **"cylinder"**: A cylinder aligned with the local Y-axis. It is centered at the local
+     *   space origin with an unscaled height of 1 and a radius of 0.5.
+     * - **"plane"**: A flat plane in the local XZ plane at Y = 0 (normal along +Y). It is
+     *   centered at the local space origin with unscaled dimensions of 1x1 units along local X and
+     *   Z axes.
+     * - **"sphere"**: A sphere with a radius of 0.5. It is centered at the local space origin and
+     *   has poles at Y = -0.5 and Y = +0.5.
+     * - **"torus"**: A doughnut shape lying in the local XZ plane at Y = 0. It is centered at
+     *   the local space origin with a tube radius of 0.2 and a ring radius of 0.3.
+     *
+     * @type {'asset'|'box'|'capsule'|'cone'|'cylinder'|'plane'|'sphere'|'torus'}
      */
     set type(value) {
         if (this._type === value) return;
@@ -273,7 +315,7 @@ class ModelComponent extends Component {
     /**
      * Gets the type of the component.
      *
-     * @type {string}
+     * @type {'asset'|'box'|'capsule'|'cone'|'cylinder'|'plane'|'sphere'|'torus'}
      */
     get type() {
         return this._type;

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -25,6 +25,11 @@ import { Component } from '../component.js';
  * {@link MeshInstance}s. These can either be created programmatically or loaded from an
  * {@link Asset}.
  *
+ * The {@link MeshInstance}s managed by this component are positioned, rotated, and scaled in world
+ * space by the world transformation matrix of the owner {@link Entity}. This world matrix is
+ * derived by combining the entity's local transformation (position, rotation, and scale) with the
+ * world transformation matrix of its parent entity in the scene hierarchy.
+ *
  * You should never need to use the RenderComponent constructor directly. To add a RenderComponent
  * to an Entity, use {@link Entity#addComponent}:
  *
@@ -52,7 +57,10 @@ import { Component } from '../component.js';
  * @category Graphics
  */
 class RenderComponent extends Component {
-    /** @private */
+    /**
+     * @type {'asset'|'box'|'capsule'|'cone'|'cylinder'|'plane'|'sphere'|'torus'}
+     * @private
+     */
     _type = 'asset';
 
     /** @private */
@@ -252,18 +260,36 @@ class RenderComponent extends Component {
     }
 
     /**
-     * Sets the type of the component. Can be one of the following:
+     * Sets the type of the component, determining the source of the geometry to be rendered.
+     * The geometry, whether it's a primitive shape or originates from an asset, is rendered
+     * using the owning entity's final world transform. This world transform is calculated by
+     * concatenating (multiplying) the local transforms (position, rotation, scale) of the
+     * entity and all its ancestors in the scene hierarchy. This process positions, orientates,
+     * and scales the geometry in world space.
      *
-     * - "asset": The component will render a render asset
-     * - "box": The component will render a box (1 unit in each dimension)
-     * - "capsule": The component will render a capsule (radius 0.5, height 2)
-     * - "cone": The component will render a cone (radius 0.5, height 1)
-     * - "cylinder": The component will render a cylinder (radius 0.5, height 1)
-     * - "plane": The component will render a plane (1 unit in each dimension)
-     * - "sphere": The component will render a sphere (radius 0.5)
-     * - "torus": The component will render a torus (tubeRadius: 0.2, ringRadius: 0.3)
+     * Can be one of the following values:
      *
-     * @type {string}
+     * - **"asset"**: Renders geometry defined in an {@link Asset} of type `render`. This asset,
+     *   assigned to the {@link asset} property, contains one or more {@link MeshInstance}s.
+     *   Alternatively, {@link meshInstances} can be set programmatically.
+     * - **"box"**: A unit cube (sides of length 1) centered at the local space origin.
+     * - **"capsule"**: A shape composed of a cylinder and two hemispherical caps that is aligned
+     *   with the local Y-axis. It is centered at the local space origin and has an unscaled height
+     *   of 2 and a radius of 0.5.
+     * - **"cone"**: A cone aligned with the local Y-axis. It is centered at the local space
+     *   origin, with its base in the local XZ plane at Y = -0.5 and its tip at Y = +0.5. It has
+     *   an unscaled height of 1 and a base radius of 0.5.
+     * - **"cylinder"**: A cylinder aligned with the local Y-axis. It is centered at the local
+     *   space origin with an unscaled height of 1 and a radius of 0.5.
+     * - **"plane"**: A flat plane in the local XZ plane at Y = 0 (normal along +Y). It is
+     *   centered at the local space origin with unscaled dimensions of 1x1 units along local X and
+     *   Z axes.
+     * - **"sphere"**: A sphere with a radius of 0.5. It is centered at the local space origin and
+     *   has poles at Y = -0.5 and Y = +0.5.
+     * - **"torus"**: A doughnut shape lying in the local XZ plane at Y = 0. It is centered at
+     *   the local space origin with a tube radius of 0.2 and a ring radius of 0.3.
+     *
+     * @type {'asset'|'box'|'capsule'|'cone'|'cylinder'|'plane'|'sphere'|'torus'}
      */
     set type(value) {
         if (this._type !== value) {
@@ -290,7 +316,7 @@ class RenderComponent extends Component {
     /**
      * Gets the type of the component.
      *
-     * @type {string}
+     * @type {'asset'|'box'|'capsule'|'cone'|'cylinder'|'plane'|'sphere'|'torus'}
      */
     get type() {
         return this._type;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -87,15 +87,29 @@ function findNode(node, test) {
  */
 
 /**
- * The `GraphNode` class represents a node within a hierarchical scene graph. Each `GraphNode` can
- * reference a array of child nodes. This creates a tree-like structure that is fundamental for
- * organizing and managing the spatial relationships between objects in a 3D scene. This class
+ * The GraphNode class represents a node within a hierarchical scene graph. Each GraphNode can
+ * reference an array of {@link children}. This creates a tree-like structure that is fundamental
+ * for organizing and managing the spatial relationships between objects in a 3D scene. This class
  * provides a comprehensive API for manipulating the position, rotation, and scale of nodes both
- * locally and in world space.
+ * locally (relative to the {@link parent}) and in world space (relative to the {@link Scene}
+ * origin).
  *
- * `GraphNode` is the superclass of {@link Entity}, which is the primary class for creating objects
- * in a PlayCanvas application. For this reason, `GraphNode` is rarely used directly, but it provides
- * a powerful set of features that are leveraged by the `Entity` class.
+ * During the application's (see {@link AppBase}) main update loop, the engine automatically
+ * synchronizes the entire GraphNode hierarchy each frame. This process ensures that the world
+ * transformation matrices for all nodes are up-to-date. A node's world transformation matrix is
+ * calculated by combining its local transformation matrix (derived from its local position,
+ * rotation, and scale) with the world transformation matrix of its parent node. For the scene
+ * graph's {@link root} node (which has no parent), its world matrix is simply its local matrix.
+ * This hierarchical update mechanism ensures that changes made to a parent node's transform
+ * correctly propagate down to all its children and descendants, accurately reflecting their final
+ * position, orientation, and scale in the world. This synchronized world transform is essential
+ * for systems like rendering and physics.
+ *
+ * GraphNode is the superclass of {@link Entity}, which is the primary class for creating objects
+ * in a PlayCanvas application. For this reason, developers typically interact with the scene
+ * hierarchy and transformations through the Entity interface rather than using GraphNode directly.
+ * However, GraphNode provides the underlying powerful set of features for hierarchical
+ * transformations that Entity leverages.
  */
 class GraphNode extends EventHandler {
     /**


### PR DESCRIPTION
* Tighten up typings for `ModelComponent#type` and `RenderComponent#type`.
* Improve API ref docs for both classes.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
