### PR TITLE
[Fix] Fixed manual loading of .hdr files using incorrect type / encoding

### DIFF
--- a/src/framework/parsers/texture/hdr.js
+++ b/src/framework/parsers/texture/hdr.js
@@ -25,6 +25,11 @@ class HdrParser extends TextureParser {
 
     load(url, callback, asset) {
         Asset.fetchArrayBuffer(url.load, callback, asset, this.maxRetries);
+
+        // .hdr assets should be loaded with 'rgbe' type, but historically they were not, so set a default type here
+        if (asset.data && !asset.data.type) {
+            asset.data.type = TEXTURETYPE_RGBE;
+        }
     }
 
     open(url, data, device, textureOptions = {}) {


### PR DESCRIPTION
In few engine example (Sky) we load .hdr asset like this

```
    hdri_street: new pc.Asset(
        'hdri',
        'texture',
        { url: `${rootPath}/static/assets/hdri/st-peters-square.hdr` },
        { mipmaps: false }
    )
```
note that the type (encoding) of 'rgbe' is not listed. ideally it would be loaded this way:
```
    hdri_street: new pc.Asset(
        'hdri',
        'texture',
        { url: `${rootPath}/static/assets/hdri/st-peters-square.hdr` },
        { mipmaps: false, type: 'rgbe' }
    )
```

internally. hdr.js loaded creates the texture using 'rgbe' type, but later when asset texture options are applied, this is set back to `default' due to [this PR](https://github.com/playcanvas/engine/pull/7488).

The fix here not only creates texture with 'rgbe', but also injects this type to the loading options.
