### PR TITLE
[Fix] Color and Depth Grab Pass would in some cases ignore being enabled

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -994,6 +994,7 @@ class CameraComponent extends Component {
         }
 
         this.camera._enableRenderPassColorGrab(this.system.app.graphicsDevice, this.renderSceneColorMap);
+        this.system.app.scene.layers.markDirty();
     }
 
     /**
@@ -1012,6 +1013,7 @@ class CameraComponent extends Component {
         }
 
         this.camera._enableRenderPassDepthGrab(this.system.app.graphicsDevice, this.system.app.renderer, this.renderSceneDepthMap);
+        this.system.app.scene.layers.markDirty();
     }
 
     dirtyLayerCompositionCameras() {

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -123,6 +123,10 @@ class LayerComposition extends EventHandler {
         this._renderActions.length = 0;
     }
 
+    markDirty() {
+        this._dirty = true;
+    }
+
     _update() {
         const len = this.layerList.length;
 


### PR DESCRIPTION
If those were enabled on frames when no changes to cameras / layers were done, the composition would not be adjusted.
It worked well when enabled on start up, as typically some things make the composition dirty, but not on other frames.