### PR TITLE
Refactor shader generator for Iridescence + bug fix

### DIFF
--- a/examples/src/examples/graphics/asset-viewer.example.mjs
+++ b/examples/src/examples/graphics/asset-viewer.example.mjs
@@ -122,7 +122,7 @@ assetListLoader.load(() => {
     const dish = createVisual(assets.dish.resource, new pc.Vec3(-4, -0.5, 0), 9);
     createText(
         assets.font,
-        'KHR_materials_specular\nKHR_materials_volume\nKHR_materials_ior\nKHR_materials_transmission',
+        'KHR_materials_iridescence\nKHR_materials_volume\nKHR_materials_ior\nKHR_materials_transmission',
         -4,
         2
     );

--- a/src/scene/shader-lib/chunks/lit/frag/lighting/lightEvaluation.js
+++ b/src/scene/shader-lib/chunks/lit/frag/lighting/lightEvaluation.js
@@ -1,6 +1,10 @@
 // evaluation of a light with index {i}, driven by defines
 export default /* glsl */`
 #if defined(LIGHT{i})
-    evaluateLight{i}();
+    evaluateLight{i}(
+        #if defined(LIT_IRIDESCENCE)
+            iridescenceFresnel
+        #endif
+    );
 #endif
 `;

--- a/src/scene/shader-lib/chunks/lit/frag/lighting/lightFunctionLight.js
+++ b/src/scene/shader-lib/chunks/lit/frag/lighting/lightFunctionLight.js
@@ -2,7 +2,11 @@
 export default /* glsl */`
 #if defined(LIGHT{i})
 
-void evaluateLight{i}() {
+void evaluateLight{i}(
+    #if defined(LIT_IRIDESCENCE)
+        vec3 iridescenceFresnel
+    #endif
+) {
 
     // light color
     vec3 lightColor = light{i}_color;


### PR DESCRIPTION
Refactor shader generator for Iridescence:
- use new version of IridescentDishWithOlives.glb which actually uses KHR_materials_iridescence, as opposed to KHR_materials_specular with the older model
- refactor shader generation

Fix: Fix to light evaluation when Iridescence is used, a parameter needs to be passed to light evaluation function, introduced recently

<img width="797" alt="Screenshot 2025-04-02 at 16 05 01" src="https://github.com/user-attachments/assets/78adfce2-bde8-4b21-8557-5d1f7cd61308" />
