### PR TITLE
Ply fetch

### DIFF
--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -591,6 +591,7 @@ class PlyParser {
      */
     async load(url, callback, asset) {
         try {
+            // either use the fetch request passed in by the application or initiate it ourselves
             const response = await (asset.file?.contents ?? fetch(url.load));
             if (!response || !response.body) {
                 callback('Error loading resource', null);

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -591,7 +591,7 @@ class PlyParser {
      */
     async load(url, callback, asset) {
         try {
-            const response = await fetch(url.load);
+            const response = await (asset.file?.contents ?? fetch(url.load));
             if (!response || !response.body) {
                 callback('Error loading resource', null);
             } else {


### PR DESCRIPTION
This PR allows the application to provide fetch request when loading PLY asset.

Initiating the fetch request as soon as possible, even before the engine is initialized can save 100's of milliseconds at startup.

This new field is left undocumented, so for now this feature is considered internal.

## Notes
- actually it would be great if the application had access to the fetch request when initiated by the asset system