### PR TITLE
Improve JSDoc for Standard Material

### DIFF
--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -191,12 +191,29 @@ const STANDARD_MAT_PROPS = [
 const REPLACEMENTS = [{
     path: `${TYPES_PATH}/scene/materials/standard-material.d.ts`,
     replacement: {
-        from: 'reset(): void;',
-        to: `reset(): void;
-${STANDARD_MAT_PROPS.map(prop => `
-    set ${prop[0]}(arg: ${prop[1]});
-    get ${prop[0]}(): ${prop[1]};
-`).join('')}`,
+        transformer: (contents) => {
+
+            // Find the jsdoc block description using eg "@property {Type} {name}"
+            return contents.replace('reset(): void;', `reset(): void;
+                ${STANDARD_MAT_PROPS.map(prop => {
+                    const typeDefinition = `@property {${prop[1]}} ${prop[0]}`
+                    const typeDescriptionIndex = contents.match(typeDefinition);
+                    const typeDescription = typeDescriptionIndex ? 
+                        contents.slice(typeDescriptionIndex.index + typeDefinition.length, contents.indexOf('\n * @property', typeDescriptionIndex.index + typeDefinition.length)) 
+                        : '';
+
+                    // Strip newlines, asterisks, and tabs from the type description
+                    const cleanTypeDescription = typeDescription
+                        .trim()
+                        .replace(/[\n\t*]/g, ' ') // remove newlines, tabs, and asterisks
+                        .replace(/\s+/g, ' '); // collapse whitespace
+
+                    const jsdoc = cleanTypeDescription ? `/** ${cleanTypeDescription} */` : '';
+                    // console.log(prop[0], contents.match(`@property {${prop[1]}} ${prop[0]}`), cleanTypeDescription);
+                    return `\t${jsdoc}\n\tset ${prop[0]}(arg: ${prop[1]});\n\tget ${prop[0]}(): ${prop[1]};\n\n`;
+                }).join('')}`,
+        )
+        },
         footer: `
 import { Color } from '../../core/math/color.js';
 import { Vec2 } from '../../core/math/vec2.js';
@@ -243,9 +260,13 @@ export function typesFixup() {
         name: 'types-fixup',
         buildStart() {
             REPLACEMENTS.forEach((item) => {
-                const { from, to, footer } = item.replacement;
+                const { from, to, footer, transformer } = item.replacement;
                 let contents = fs.readFileSync(item.path, 'utf-8');
-                contents = contents.replace(from, to);
+                if (transformer) {
+                    contents = transformer(contents);
+                } else {
+                    contents = contents.replace(from, to);
+                }
                 contents += footer ?? '';
                 fs.writeFileSync(item.path, contents, 'utf-8');
                 console.log(`${GREEN_OUT}type fixed ${BOLD_OUT}${item.path}${REGULAR_OUT}`);

--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -209,7 +209,6 @@ const REPLACEMENTS = [{
         .replace(/\s+/g, ' '); // collapse whitespace
 
         const jsdoc = cleanTypeDescription ? `/** ${cleanTypeDescription} */` : '';
-        // console.log(prop[0], contents.match(`@property {${prop[1]}} ${prop[0]}`), cleanTypeDescription);
         return `\t${jsdoc}\n\tset ${prop[0]}(arg: ${prop[1]});\n\tget ${prop[0]}(): ${prop[1]};\n\n`;
     }).join('')}`
             );

--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -195,24 +195,24 @@ const REPLACEMENTS = [{
 
             // Find the jsdoc block description using eg "@property {Type} {name}"
             return contents.replace('reset(): void;', `reset(): void;
-                ${STANDARD_MAT_PROPS.map(prop => {
-                    const typeDefinition = `@property {${prop[1]}} ${prop[0]}`
-                    const typeDescriptionIndex = contents.match(typeDefinition);
-                    const typeDescription = typeDescriptionIndex ? 
-                        contents.slice(typeDescriptionIndex.index + typeDefinition.length, contents.indexOf('\n * @property', typeDescriptionIndex.index + typeDefinition.length)) 
-                        : '';
+                ${STANDARD_MAT_PROPS.map((prop) => {
+        const typeDefinition = `@property {${prop[1]}} ${prop[0]}`;
+        const typeDescriptionIndex = contents.match(typeDefinition);
+        const typeDescription = typeDescriptionIndex ?
+            contents.slice(typeDescriptionIndex.index + typeDefinition.length, contents.indexOf('\n * @property', typeDescriptionIndex.index + typeDefinition.length)) :
+            '';
 
-                    // Strip newlines, asterisks, and tabs from the type description
-                    const cleanTypeDescription = typeDescription
-                        .trim()
-                        .replace(/[\n\t*]/g, ' ') // remove newlines, tabs, and asterisks
-                        .replace(/\s+/g, ' '); // collapse whitespace
+        // Strip newlines, asterisks, and tabs from the type description
+        const cleanTypeDescription = typeDescription
+        .trim()
+        .replace(/[\n\t*]/g, ' ') // remove newlines, tabs, and asterisks
+        .replace(/\s+/g, ' '); // collapse whitespace
 
-                    const jsdoc = cleanTypeDescription ? `/** ${cleanTypeDescription} */` : '';
-                    // console.log(prop[0], contents.match(`@property {${prop[1]}} ${prop[0]}`), cleanTypeDescription);
-                    return `\t${jsdoc}\n\tset ${prop[0]}(arg: ${prop[1]});\n\tget ${prop[0]}(): ${prop[1]};\n\n`;
-                }).join('')}`,
-        )
+        const jsdoc = cleanTypeDescription ? `/** ${cleanTypeDescription} */` : '';
+        // console.log(prop[0], contents.match(`@property {${prop[1]}} ${prop[0]}`), cleanTypeDescription);
+        return `\t${jsdoc}\n\tset ${prop[0]}(arg: ${prop[1]});\n\tget ${prop[0]}(): ${prop[1]};\n\n`;
+    }).join('')}`
+            );
         },
         footer: `
 import { Color } from '../../core/math/color.js';


### PR DESCRIPTION
The PR improves the StandardMaterial types by including the Jsdoc description for each material property. This improves intellisense and dev experience.

**Before:**
```typescript
set anisotropy(arg: number);
get anisotropy(): number;
```

![image](https://github.com/user-attachments/assets/d80dd29b-8a03-4fad-94d4-fbce7f9df6a5)

**After:**
```typescript
/** The ambient color of the material. This color value is 3-component (RGB), where each component is between 0 and 1. */
set ambient(arg: Color);
get ambient(): Color;
```

![image](https://github.com/user-attachments/assets/f7f522b7-24b6-40b4-a9fd-e42843287f31)


The  [`utils/plugins/rollup-types-fixup.mjs`](diffhunk://#diff-5e98ed5845e0cbbad0440729f9f41794684c4dd165f3dd08e0b3e4344745441bL246-R269) is updated to apply a transformer function if it exists, allowing for more flexible and dynamic content replacement during the build process. This is used to inject jsdoc blocks above material properties


