### PR TITLE
[Fix] Update to disk/sphere area lights to avoid NaN values

### DIFF
--- a/src/scene/shader-lib/chunks/lit/frag/ltc.js
+++ b/src/scene/shader-lib/chunks/lit/frag/ltc.js
@@ -365,18 +365,26 @@ float LTC_EvaluateDisk(vec3 N, vec3 V, vec3 P, mat3 Minv, Coords points)
     return formFactor*scale;
 }
 
+// LTC_EvaluateDisk in some rare cases genereates NaN values in a or b, just before 'float c0 = a * b;'
+// Get rid of those Nan values before they propagate further, as in case of bloom / DOF blurs they
+// propagage to large areas. I didn't find the actual reason where those come from, so that is still TODO.
+// Note that only disk/sphere lights are causing it, so only handle those.
+float FixNan(float value) {
+    return isnan(value) ? 0.0 : value;
+}
+
 float getRectLightDiffuse(vec3 worldNormal, vec3 viewDir, vec3 lightDir, vec3 lightDirNorm) {
     return LTC_EvaluateRect( worldNormal, viewDir, vPositionW, mat3( 1.0 ), dLTCCoords );
 }
 
 float getDiskLightDiffuse(vec3 worldNormal, vec3 viewDir, vec3 lightDir, vec3 lightDirNorm) {
-    return LTC_EvaluateDisk( worldNormal, viewDir, vPositionW, mat3( 1.0 ), dLTCCoords );
+    return FixNan(LTC_EvaluateDisk( worldNormal, viewDir, vPositionW, mat3( 1.0 ), dLTCCoords ));
 }
 
 float getSphereLightDiffuse(vec3 worldNormal, vec3 viewDir, vec3 lightDir, vec3 lightDirNorm) {
     // NB: this could be improved further with distance based wrap lighting
     float falloff = dSphereRadius / (dot(lightDir, lightDir) + dSphereRadius);
-    return getLightDiffuse(worldNormal, viewDir, lightDirNorm) * falloff;
+    return FixNan(getLightDiffuse(worldNormal, viewDir, lightDirNorm) * falloff);
 }
 
 mat3 getLTCLightInvMat(vec2 uv)


### PR DESCRIPTION
Fixes the issue in ClusteredAreaLights example on nvidia cards (rtx 2070 test case).

The problem is that the LTC code generates Nan in occasional pixel, and further blur filtres in Bloom or DOF propagage those to large areas on the screen, depending on the blur settings (even full screen).

This avoids the Nan. The actual reason is still unknown, see the comment, but this works well as a workaround.

Possibly related to https://github.com/playcanvas/engine/issues/7492 and https://github.com/playcanvas/engine/issues/7105, but  in the fixed case this was cased by the area lights, which might not be the case in the other reported issues. Something else might be creating NaN pixel colors.