### PR TITLE
Cookie texture blit shaders used by clustered lighting are in WGSL

### DIFF
--- a/src/scene/renderer/render-pass-cookie-renderer.js
+++ b/src/scene/renderer/render-pass-cookie-renderer.js
@@ -1,7 +1,7 @@
 import { Debug } from '../../core/debug.js';
 import { Vec4 } from '../../core/math/vec4.js';
 import { Mat4 } from '../../core/math/mat4.js';
-import { CULLFACE_NONE } from '../../platform/graphics/constants.js';
+import { CULLFACE_NONE, SEMANTIC_POSITION, SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL } from '../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI } from '../constants.js';
 import { createShaderFromCode } from '../shader-lib/utils.js';
@@ -10,35 +10,8 @@ import { BlendState } from '../../platform/graphics/blend-state.js';
 import { QuadRender } from '../graphics/quad-render.js';
 import { DepthState } from '../../platform/graphics/depth-state.js';
 import { RenderPass } from '../../platform/graphics/render-pass.js';
-
-const textureBlitVertexShader = /* glsl */ `
-    attribute vec2 vertex_position;
-    varying vec2 uv0;
-    void main(void) {
-        gl_Position = vec4(vertex_position, 0.5, 1.0);
-        uv0 = vertex_position.xy * 0.5 + 0.5;
-        #ifndef WEBGPU
-            uv0.y = 1.0 - uv0.y;
-        #endif
-    }`;
-
-const textureBlitFragmentShader = /* glsl */ `
-    varying vec2 uv0;
-    uniform sampler2D blitTexture;
-    void main(void) {
-        gl_FragColor = texture2D(blitTexture, uv0);
-    }`;
-
-// shader runs for each face, with inViewProj matrix representing a face camera
-const textureCubeBlitFragmentShader = /* glsl */ `
-    varying vec2 uv0;
-    uniform samplerCube blitTexture;
-    uniform mat4 invViewProj;
-    void main(void) {
-        vec4 projPos = vec4(uv0 * 2.0 - 1.0, 0.5, 1.0);
-        vec4 worldPos = invViewProj * projPos;
-        gl_FragColor = textureCube(blitTexture, worldPos.xyz);
-    }`;
+import { shaderChunks } from '../shader-lib/chunks/chunks.js';
+import { shaderChunksWGSL } from '../shader-lib/chunks-wgsl/chunks-wgsl.js';
 
 const _viewport = new Vec4();
 
@@ -139,7 +112,13 @@ class RenderPassCookieRenderer extends RenderPass {
 
     get quadRenderer2D() {
         if (!this._quadRenderer2D) {
-            const shader = createShaderFromCode(this.device, textureBlitVertexShader, textureBlitFragmentShader, 'cookieRenderer2d');
+            const wgsl = this.device.isWebGPU;
+            const chunks = wgsl ? shaderChunksWGSL : shaderChunks;
+            const shader = createShaderFromCode(this.device, chunks.cookieBlitVS, chunks.cookieBlit2DPS, 'cookieRenderer2d', {
+                vertex_position: SEMANTIC_POSITION
+            }, {
+                shaderLanguage: wgsl ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL
+            });
             this._quadRenderer2D = new QuadRender(shader);
         }
         return this._quadRenderer2D;
@@ -147,7 +126,13 @@ class RenderPassCookieRenderer extends RenderPass {
 
     get quadRendererCube() {
         if (!this._quadRendererCube) {
-            const shader = createShaderFromCode(this.device, textureBlitVertexShader, textureCubeBlitFragmentShader, 'cookieRendererCube');
+            const wgsl = this.device.isWebGPU;
+            const chunks = wgsl ? shaderChunksWGSL : shaderChunks;
+            const shader = createShaderFromCode(this.device, chunks.cookieBlitVS, chunks.cookieBlitCubePS, 'cookieRendererCube', {
+                vertex_position: SEMANTIC_POSITION
+            }, {
+                shaderLanguage: wgsl ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL
+            });
             this._quadRendererCube = new QuadRender(shader);
         }
         return this._quadRendererCube;

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -16,6 +16,9 @@
 // import clusteredLightShadowsPS from './lit/frag/clusteredLightShadows.js';
 // import clusteredLightPS from './lit/frag/clusteredLight.js';
 // import combinePS from './lit/frag/combine.js';
+import cookieBlit2DPS from './internal/frag/cookie-blit-2d.js';
+import cookieBlitCubePS from './internal/frag/cookie-blit-cube.js';
+import cookieBlitVS from './internal/vert/cookie-blit.js';
 // import cookiePS from './lit/frag/cookie.js';
 // import cubeMapProjectPS from './lit/frag/cubeMapProject.js';
 // import cubeMapRotatePS from './lit/frag/cubeMapRotate.js';
@@ -226,6 +229,9 @@ const shaderChunksWGSL = {
     // clusteredLightUtilsPS,
     // clusteredLightPS,
     // combinePS,
+    cookieBlit2DPS,
+    cookieBlitCubePS,
+    cookieBlitVS,
     // cookiePS,
     // cubeMapProjectPS,
     // cubeMapRotatePS,

--- a/src/scene/shader-lib/chunks-wgsl/internal/frag/cookie-blit-2d.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/frag/cookie-blit-2d.js
@@ -1,0 +1,13 @@
+export default /* wgsl */`
+    varying uv0: vec2f;
+
+    var blitTexture: texture_2d<f32>;
+    var blitTextureSampler : sampler;
+
+    @fragment
+    fn fragmentMain(input : FragmentInput) -> FragmentOutput {
+        var output: FragmentOutput;
+        output.color = textureSample(blitTexture, blitTextureSampler, input.uv0);
+        return output;
+    }
+`;

--- a/src/scene/shader-lib/chunks-wgsl/internal/frag/cookie-blit-cube.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/frag/cookie-blit-cube.js
@@ -1,0 +1,15 @@
+export default /* wgsl */`
+    varying uv0: vec2f;
+    uniform invViewProj: mat4x4<f32>;
+    var blitTexture: texture_cube<f32>;
+    var blitTextureSampler : sampler;
+
+    @fragment
+    fn fragmentMain(input : FragmentInput) -> FragmentOutput {
+        var output: FragmentOutput;
+        var projPos = vec4f(input.uv0 * 2.0 - 1.0, 0.5, 1.0);
+        var worldPos = uniform.invViewProj * projPos;
+        output.color = textureSample(blitTexture, blitTextureSampler, worldPos.xyz);
+        return output;
+    }
+`;

--- a/src/scene/shader-lib/chunks-wgsl/internal/vert/cookie-blit.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/vert/cookie-blit.js
@@ -1,0 +1,13 @@
+export default /* wgsl */`
+    attribute vertex_position: vec2f;
+    varying uv0: vec2f;
+
+    @vertex
+    fn vertexMain(input: VertexInput) -> VertexOutput {
+        var output: VertexOutput;
+        output.position = vec4f(input.vertex_position, 0.5, 1.0);
+        output.uv0 = input.vertex_position * 0.5 + vec2f(0.5, 0.5);
+        output.uv0.y = 1.0 - output.uv0.y;
+        return output;
+    }
+`;

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -16,6 +16,9 @@ import clusteredLightCookiesPS from './lit/frag/clusteredLightCookies.js';
 import clusteredLightShadowsPS from './lit/frag/clusteredLightShadows.js';
 import clusteredLightPS from './lit/frag/clusteredLight.js';
 import combinePS from './lit/frag/combine.js';
+import cookieBlit2DPS from './internal/frag/cookie-blit-2d.js';
+import cookieBlitCubePS from './internal/frag/cookie-blit-cube.js';
+import cookieBlitVS from './internal/vert/cookie-blit.js';
 import cookiePS from './lit/frag/cookie.js';
 import cubeMapProjectPS from './lit/frag/cubeMapProject.js';
 import cubeMapRotatePS from './lit/frag/cubeMapRotate.js';
@@ -229,6 +232,9 @@ const shaderChunks = {
     clusteredLightUtilsPS,
     clusteredLightPS,
     combinePS,
+    cookieBlit2DPS,
+    cookieBlitCubePS,
+    cookieBlitVS,
     cookiePS,
     cubeMapProjectPS,
     cubeMapRotatePS,

--- a/src/scene/shader-lib/chunks/internal/frag/cookie-blit-2d.js
+++ b/src/scene/shader-lib/chunks/internal/frag/cookie-blit-2d.js
@@ -1,0 +1,7 @@
+export default /* glsl */`
+    varying vec2 uv0;
+    uniform sampler2D blitTexture;
+    void main(void) {
+        gl_FragColor = texture2D(blitTexture, uv0);
+    }
+`;

--- a/src/scene/shader-lib/chunks/internal/frag/cookie-blit-cube.js
+++ b/src/scene/shader-lib/chunks/internal/frag/cookie-blit-cube.js
@@ -1,0 +1,10 @@
+export default /* glsl */`
+    varying vec2 uv0;
+    uniform samplerCube blitTexture;
+    uniform mat4 invViewProj;
+    void main(void) {
+        vec4 projPos = vec4(uv0 * 2.0 - 1.0, 0.5, 1.0);
+        vec4 worldPos = invViewProj * projPos;
+        gl_FragColor = textureCube(blitTexture, worldPos.xyz);
+    }
+`;

--- a/src/scene/shader-lib/chunks/internal/vert/cookie-blit.js
+++ b/src/scene/shader-lib/chunks/internal/vert/cookie-blit.js
@@ -1,0 +1,11 @@
+export default /* glsl */`
+    attribute vec2 vertex_position;
+    varying vec2 uv0;
+    void main(void) {
+        gl_Position = vec4(vertex_position, 0.5, 1.0);
+        uv0 = vertex_position.xy * 0.5 + 0.5;
+        #ifndef WEBGPU
+            uv0.y = 1.0 - uv0.y;
+        #endif
+    }
+`;


### PR DESCRIPTION
- shader chunks that the cookie renderer uses when copied cookie textures to atlas are now stored as chunks, both GLSL and WGSL