### PR TITLE
WGSL versions of code vertex shader funcionality

### DIFF
--- a/examples/assets/scripts/misc/gooch-material.mjs
+++ b/examples/assets/scripts/misc/gooch-material.mjs
@@ -13,7 +13,128 @@ const createGoochMaterial = (texture, color) => {
     // create a new material with a custom shader
     const material = new ShaderMaterial({
         uniqueName: 'GoochShader',
-        vertexCode: /* glsl */ `
+
+        vertexWGSL: /* wgsl */ `
+
+            // include code transform shader functionality provided by the engine. It automatically
+            // declares vertex_position attribute, and handles skinning and morphing if necessary.
+            // It also adds uniforms: matrix_viewProjection, matrix_model, matrix_normal.
+            // Functions added: getModelMatrix, getLocalPosition
+            #include "transformCoreVS"
+
+            // include code for normal shader functionality provided by the engine. It automatically
+            // declares vertex_normal attribute, and handles skinning and morphing if necessary.
+            // Functions added: getNormalMatrix, getLocalNormal
+            #include "normalCoreVS"
+
+            // add additional attributes we need
+            attribute aUv0: vec2f;
+
+            // out custom uniforms
+            uniform uLightDir: vec3f;
+
+            // variables we pass to the fragment shader
+            varying uv0: vec2f;
+            varying brightness: f32;
+
+            // use instancing if required
+            #if INSTANCING
+
+                // add instancing attributes we need for our case - here we have position and scale
+                attribute aInstPosition: vec3f;
+                attribute aInstScale: f32;
+
+                // instancing needs to provide a model matrix, the rest is handled by the engine when using transformCore
+                fn getModelMatrix() -> mat4x4f {
+                    return mat4x4f(
+                        vec4f(aInstScale, 0.0, 0.0, 0.0),
+                        vec4f(0.0, aInstScale, 0.0, 0.0),
+                        vec4f(0.0, 0.0, aInstScale, 0.0),
+                        vec4f(aInstPosition, 1.0)
+                    );
+                }
+
+            #endif
+
+            @vertex
+            fn vertexMain(input: VertexInput) -> VertexOutput {
+                var output: VertexOutput;
+
+                // use functionality from transformCore to get a world position, which includes skinning, morphing or instancing as needed
+                let modelMatrix: mat4x4f = getModelMatrix();
+                let localPos: vec3f = getLocalPosition(input.vertex_position.xyz);
+                let worldPos: vec4f = modelMatrix * vec4f(localPos, 1.0);
+
+                // use functionality from normalCore to get the world normal, which includes skinning, morphing or instancing as needed
+                let normalMatrix: mat3x3f = getNormalMatrix(modelMatrix);
+                let localNormal: vec3f = getLocalNormal(input.vertex_normal);
+                let worldNormal: vec3f = normalize(normalMatrix * localNormal);
+
+                // wrap-around diffuse lighting
+                output.brightness = (dot(worldNormal, uniform.uLightDir) + 1.0) * 0.5;
+
+                // Pass the texture coordinates
+                output.uv0 = input.aUv0;
+
+                // Transform the geometry
+                output.position = uniform.matrix_viewProjection * worldPos;
+
+                return output;
+            }
+        `,
+
+        fragmentWGSL: /* wgsl */ `
+
+            #include "gammaPS"
+            #include "tonemappingPS"
+            #include "fogPS"
+
+            varying brightness: f32;
+            varying uv0: vec2f;
+
+            uniform uColor: vec3f;
+            #ifdef DIFFUSE_MAP
+                var uDiffuseMap: texture_2d<f32>;
+                var uDiffuseMapSampler: sampler;
+            #endif
+
+            // Gooch shading constants - could be exposed as uniforms instead
+            const diffuseCool: f32 = 0.4;
+            const diffuseWarm: f32 = 0.4;
+            const cool: vec3f = vec3f(0.0, 0.0, 0.6);
+            const warm: vec3f = vec3f(0.6, 0.0, 0.0);
+
+            @fragment
+            fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+                var output: FragmentOutput;
+
+                var alpha: f32 = 1.0;
+                var colorLinear: vec3f = uniform.uColor;
+
+                // shader variant using a diffuse texture
+                #ifdef DIFFUSE_MAP
+                    let diffuseLinear: vec4f = textureSample(uDiffuseMap, uDiffuseMapSampler, input.uv0);
+                    colorLinear = colorLinear * diffuseLinear.rgb;
+                    alpha = diffuseLinear.a;
+                #endif
+
+                // simple Gooch shading that highlights structural and contextual data
+                let kCool: vec3f = min(cool + diffuseCool * colorLinear, vec3f(1.0));
+                let kWarm: vec3f = min(warm + diffuseWarm * colorLinear, vec3f(1.0));
+                colorLinear = mix(kCool, kWarm, input.brightness);
+
+                // handle standard color processing - the called functions are automatically attached to the
+                // shader based on the current fog / tone-mapping / gamma settings
+                let fogged: vec3f = addFog(colorLinear);
+                let toneMapped: vec3f = toneMap(fogged);
+                let final_rgb: vec3f = gammaCorrectOutput(toneMapped);
+                output.color = vec4f(final_rgb, alpha);
+
+                return output;
+            }        
+        `,
+
+        vertexGLSL: /* glsl */ `
 
             // include code transform shader functionality provided by the engine. It automatically
             // declares vertex_position attribute, and handles skinning and morphing if necessary.
@@ -29,12 +150,8 @@ const createGoochMaterial = (texture, color) => {
             // add additional attributes we need
             attribute vec2 aUv0;
 
-            // engine supplied uniforms
-            uniform vec3 view_position;
-
             // out custom uniforms
             uniform vec3 uLightDir;
-            uniform float uMetalness;
 
             // variables we pass to the fragment shader
             varying vec2 uv0;
@@ -81,7 +198,7 @@ const createGoochMaterial = (texture, color) => {
                 gl_Position = matrix_viewProjection * worldPos;
             }
         `,
-        fragmentCode: /* glsl */ `
+        fragmentGLSL: /* glsl */ `
             #include "gammaPS"
             #include "tonemappingPS"
             #include "fogPS"

--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -12,7 +12,12 @@ import {
     TEXTUREDIMENSION_1D,
     TEXTUREDIMENSION_CUBE_ARRAY,
     UNIFORMTYPE_FLOAT,
-    UNUSED_UNIFORM_NAME
+    UNUSED_UNIFORM_NAME,
+    TYPE_FLOAT32,
+    TYPE_FLOAT16,
+    TYPE_INT8,
+    TYPE_INT16,
+    TYPE_INT32
 } from '../constants.js';
 import { UniformFormat, UniformBufferFormat } from '../uniform-buffer-format.js';
 import { BindGroupFormat, BindStorageBufferFormat, BindTextureFormat } from '../bind-group-format.js';
@@ -40,6 +45,9 @@ const VARYING = /(?:@interpolate\([^)]*\)\s*)?([\w]+)\s*:/;
 
 // marker for a place in the source code to be replaced by code
 const MARKER = '@@@';
+
+// matches vertex of fragment entry function, extracts the input name. Ends at the start of the function body '{'.
+const ENTRY_FUNCTION = /(@vertex|@fragment)\s*fn\s+\w+\s*\(\s*(\w+)\s*:[\s\S]*?\{/;
 
 const getTextureDimension = (textureType, isArray) => {
     if (isArray) {
@@ -315,6 +323,9 @@ class WebgpuShaderProcessorWGSL {
 
         // generate fragment output struct
         const fOutput = WebgpuShaderProcessorWGSL.generateFragmentOutputStruct(fragmentExtracted.src, device.maxColorAttachments);
+
+        // VS - inject input copy to globals
+        vertexExtracted.src = WebgpuShaderProcessorWGSL.copyInputs(vertexExtracted.src, shader);
 
         // VS - insert the blocks to the source
         const vBlock = `${attributesBlock}\n${vertexVaryingsBlock}\n${uniformsData.code}\n${resourcesData.code}\n`;
@@ -671,12 +682,40 @@ class WebgpuShaderProcessorWGSL {
         return `${structCode}};\n`;
     }
 
+    // convert a float attribute type to matching signed or unsigned int type
+    // for example: vec4f -> vec4u, f32 -> u32
+    static floatAttributeToInt(type, signed) {
+
+        // convert any long-form type to short-form
+        const longToShortMap = {
+            'f32': 'f32',
+            'vec2<f32>': 'vec2f',
+            'vec3<f32>': 'vec3f',
+            'vec4<f32>': 'vec4f'
+        };
+        const shortType = longToShortMap[type] || type;
+
+        // map from float short type to int short type
+        const floatToIntShort = {
+            'f32': signed ? 'i32' : 'u32',
+            'vec2f': signed ? 'vec2i' : 'vec2u',
+            'vec3f': signed ? 'vec3i' : 'vec3u',
+            'vec4f': signed ? 'vec4i' : 'vec4u'
+        };
+
+        return floatToIntShort[shortType] || null;
+    }
+
     static processAttributes(attributeLines, shaderDefinitionAttributes = {}, attributesMap, processingOptions) {
-        let block = '';
+        let blockAttributes = '';
+        let blockPrivates = '';
+        let blockCopy = '';
         const usedLocations = {};
         attributeLines.forEach((line) => {
             const words = splitToWords(line);
             const name = words[0];
+            let type = words[1];
+            const originalType = type;
 
             if (shaderDefinitionAttributes.hasOwnProperty(name)) {
                 const semantic = shaderDefinitionAttributes[name];
@@ -690,18 +729,78 @@ class WebgpuShaderProcessorWGSL {
                 // build a map of used attributes
                 attributesMap.set(location, name);
 
+                // if vertex format for this attribute is not of a float type, but shader specifies float type, convert the shader type
+                // to match the vertex format type, for example: vec4f -> vec4u
+                // Note that we skip normalized elements, as shader receives them as floats already.
+                const element = processingOptions.getVertexElement(semantic);
+                if (element) {
+                    const dataType = element.dataType;
+                    if (dataType !== TYPE_FLOAT32 && dataType !== TYPE_FLOAT16 && !element.normalize && !element.asInt) {
+
+                        // new attribute type, based on the vertex format element type
+                        const isSignedType = dataType === TYPE_INT8 || dataType === TYPE_INT16 || dataType === TYPE_INT32;
+                        type = WebgpuShaderProcessorWGSL.floatAttributeToInt(type, isSignedType);
+                        Debug.assert(type !== null, `Attribute ${name} has a type that cannot be converted to int: ${dataType}`);
+                    }
+                }
+
                 // generates: @location(0) position : vec4f
-                block += `    @location(${location}) ${line},\n`;
+                blockAttributes += `    @location(${location}) ${name}: ${type},\n`;
+
+                // private global variable - this uses the original type
+                blockPrivates += `    var<private> ${line};\n`;
+
+                // copy input variable to the private variable - convert type if needed
+                blockCopy += `    ${name} = ${originalType}(input.${name});\n`;
             } else {
                 Debug.error(`Attribute ${name} is not defined in the shader definition.`, shaderDefinitionAttributes);
             }
         });
 
         // add built-in attributes
-        block += '    @builtin(vertex_index) vertexIndex : u32,\n';     // vertex index
-        block += '    @builtin(instance_index) instanceIndex : u32\n';  // instance index
+        blockAttributes += '    @builtin(vertex_index) vertexIndex : u32,\n';     // vertex index
+        blockAttributes += '    @builtin(instance_index) instanceIndex : u32\n';  // instance index
 
-        return `struct VertexInput {\n${block}};\n`;
+        return `
+            struct VertexInput {
+                ${blockAttributes}
+            };
+
+            ${blockPrivates}
+
+            fn _copyInputs_(input: VertexInput) {
+                ${blockCopy}
+            }
+        `;
+    }
+
+    /**
+     * Injects a call to _copyInputs_ with the function's input parameter right after the opening
+     * brace of a WGSL function marked with `@vertex` or `@fragment`.
+     *
+     * @param {string} src - The source string containing the WGSL code.
+     * @param {Shader} shader - The shader.
+     * @returns {string} - The modified source string.
+     */
+    static copyInputs(src, shader) {
+        // find @vertex or @fragment followed by the function signature and capture the input parameter name
+        const match = src.match(ENTRY_FUNCTION);
+
+        // check if match exists AND the parameter name (Group 2) was captured
+        if (!match || !match[2]) {
+            Debug.warn('No entry function found or input parameter name not captured.', shader);
+            return src;
+        }
+
+        const inputName = match[2];
+        const braceIndex = match.index + match[0].length - 1; // Calculate the index of the '{'
+
+        // inject the line right after the opening brace
+        const beginning = src.slice(0, braceIndex + 1);
+        const end = src.slice(braceIndex + 1);
+
+        const lineToInject = `\n    _copyInputs_(${inputName});`;
+        return beginning + lineToInject + end;
     }
 
     static cutOut(src, start, end, replacement) {

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -208,7 +208,6 @@ class Renderer {
         // Uniforms
         const scope = graphicsDevice.scope;
         this.boneTextureId = scope.resolve('texture_poseMap');
-        this.boneTextureSizeId = scope.resolve('texture_poseMapSize');
 
         this.modelMatrixId = scope.resolve('matrix_model');
         this.normalMatrixId = scope.resolve('matrix_normal');
@@ -697,7 +696,6 @@ class Renderer {
 
             const boneTexture = skinInstance.boneTexture;
             this.boneTextureId.setValue(boneTexture);
-            this.boneTextureSizeId.setValue(skinInstance.boneTextureSize);
         }
     }
 

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -407,7 +407,7 @@ const shaderChunksWGSL = {
     tonemappingNeutralPS,
     tonemappingNonePS,
     // transformVS,
-    transformCoreVS,
+    transformCoreVS
     // transformInstancingVS,
     // transmissionPS,
     // twoSidedLightingPS,

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -3,7 +3,7 @@
 // import aoPS from './standard/frag/ao.js';
 // import aoDiffuseOccPS from './lit/frag/aoDiffuseOcc.js';
 // import aoSpecOccPS from './lit/frag/aoSpecOcc.js';
-// import basePS from './lit/frag/base.js';
+import basePS from './lit/frag/base.js';
 // import baseNineSlicedPS from './lit/frag/baseNineSliced.js';
 // import baseNineSlicedTiledPS from './lit/frag/baseNineSlicedTiled.js';
 // import bayerPS from './common/frag/bayer.js';
@@ -81,7 +81,7 @@ import immediateLineVS from './internal/vert/immediateLine.js';
 // import litForwardPreCodePS from './lit/frag/main-forward/litForwardPreCode.js';
 // import litMainVS from './lit/vert/litMain.js';
 // import litOtherMainPS from './lit/frag/pass-other/litOtherMain.js';
-// import litShaderArgsPS from './standard/frag/litShaderArgs.js';
+import litShaderArgsPS from './standard/frag/litShaderArgs.js';
 // import litShadowMainPS from './lit/frag/pass-shadow/litShadowMain.js';
 // import ltcPS from './lit/frag/ltc.js';
 // import metalnessPS from './standard/frag/metalness.js';
@@ -93,7 +93,7 @@ import morphPS from './internal/morph/frag/morph.js';
 import morphVS from './internal/morph/vert/morph.js';
 // import msdfVS from './common/vert/msdf.js';
 // import normalVS from './lit/vert/normal.js';
-// import normalCoreVS from './common/vert/normalCore.js';
+import normalCoreVS from './common/vert/normalCore.js';
 // import normalMapPS from './standard/frag/normalMap.js';
 // import opacityPS from './standard/frag/opacity.js';
 // import opacityDitherPS from './standard/frag/opacity-dither.js';
@@ -169,7 +169,7 @@ import reprojectVS from './internal/vert/reproject.js';
 // import shadowPCSSPS from './lit/frag/shadowPCSS.js';
 // import shadowSoftPS from './lit/frag/shadowSoft.js';
 // import skinBatchVS from './common/vert/skinBatch.js';
-// import skinVS from './common/vert/skin.js';
+import skinVS from './common/vert/skin.js';
 import skyboxPS from './skybox/frag/skybox.js';
 import skyboxVS from './skybox/vert/skybox.js';
 // import specularPS from './standard/frag/specular.js';
@@ -192,7 +192,7 @@ import tonemappingLinearPS from './common/frag/tonemapping/tonemappingLinear.js'
 import tonemappingNeutralPS from './common/frag/tonemapping/tonemappingNeutral.js';
 import tonemappingNonePS from './common/frag/tonemapping/tonemappingNone.js';
 // import transformVS from './common/vert/transform.js';
-// import transformCoreVS from './common/vert/transformCore.js';
+import transformCoreVS from './common/vert/transformCore.js';
 // import transformInstancingVS from './common/vert/transformInstancing.js';
 // import transmissionPS from './standard/frag/transmission.js';
 // import twoSidedLightingPS from './lit/frag/twoSidedLighting.js';
@@ -216,7 +216,7 @@ const shaderChunksWGSL = {
     // aoPS,
     // aoDiffuseOccPS,
     // aoSpecOccPS,
-    // basePS,
+    basePS,
     // baseNineSlicedPS,
     // baseNineSlicedTiledPS,
     // bayerPS,
@@ -296,7 +296,7 @@ const shaderChunksWGSL = {
     // litForwardPreCodePS,
     // litMainVS,
     // litOtherMainPS,
-    // litShaderArgsPS,
+    litShaderArgsPS,
     // litShadowMainPS,
     // ltcPS,
     // metalnessPS,
@@ -308,7 +308,7 @@ const shaderChunksWGSL = {
     // msdfPS,
     // msdfVS,
     // normalVS,
-    // normalCoreVS,
+    normalCoreVS,
     // normalMapPS,
     // opacityPS,
     // opacityDitherPS,
@@ -384,7 +384,7 @@ const shaderChunksWGSL = {
     // shadowPCSSPS,
     // shadowSoftPS,
     // skinBatchVS,
-    // skinVS,
+    skinVS,
     skyboxPS,
     skyboxVS,
     // specularPS,
@@ -405,9 +405,9 @@ const shaderChunksWGSL = {
     tonemappingHejlPS,
     tonemappingLinearPS,
     tonemappingNeutralPS,
-    tonemappingNonePS
+    tonemappingNonePS,
     // transformVS,
-    // transformCoreVS,
+    transformCoreVS,
     // transformInstancingVS,
     // transmissionPS,
     // twoSidedLightingPS,

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/decode.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/decode.js
@@ -37,5 +37,14 @@ fn passThrough(raw: vec4f) -> vec4f {
     return raw;
 }
 
+fn unpackNormalXYZ(nmap: vec4f) -> vec3f {
+    return nmap.xyz * 2.0 - 1.0;
+}
+
+fn unpackNormalXY(nmap: vec4f) -> vec3f {
+    var xy = nmap.wy * 2.0 - 1.0;
+    return vec3f(xy, sqrt(1.0 - clamp(dot(xy, xy), 0.0, 1.0)));
+}
+
 #endif
 `;

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/spherical.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/spherical.js
@@ -1,6 +1,4 @@
 export default /* wgsl */`
-// equirectangular helper functions
-const PI : f32 = 3.141592653589793;
 
 fn toSpherical(dir: vec3f) -> vec2f {
     let angle_xz = select(0.0, atan2(dir.x, dir.z), any(dir.xz != vec2f(0.0)));
@@ -8,6 +6,7 @@ fn toSpherical(dir: vec3f) -> vec2f {
 }
 
 fn toSphericalUv(dir : vec3f) -> vec2f {
+    const PI : f32 = 3.141592653589793;
     let uv : vec2f = toSpherical(dir) / vec2f(PI * 2.0, PI) + vec2f(0.5, 0.5);
     return vec2f(uv.x, 1.0 - uv.y);
 }

--- a/src/scene/shader-lib/chunks-wgsl/common/vert/normalCore.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/vert/normalCore.js
@@ -1,0 +1,57 @@
+export default /* glsl */`
+
+attribute vertex_normal: vec3f;
+
+#ifdef MORPHING_NORMAL
+    #ifdef MORPHING_INT
+        uniform morphNormalTex: texture_2d<u32>;
+        uniform morphNormalTexSampler: sampler;
+    #else
+        uniform morphNormalTex: texture_2d<f32>;
+        uniform morphNormalTexSampler: sampler;
+    #endif
+#endif
+
+fn getLocalNormal(vertexNormal: vec3f) -> vec3f {
+
+    var localNormal: vec3f = vertexNormal;
+
+    #ifdef MORPHING_NORMAL
+
+        // Assuming getTextureMorphCoords() returns vec2i
+        let morphUV: vec2i = getTextureMorphCoords();
+
+        #ifdef MORPHING_INT
+            // Use textureLoad (texelFetch equivalent), requires integer coordinates and returns vec4u
+            let morphNormalInt: vec4u = textureLoad(morphNormalTex, morphUV, 0);
+            // Convert unsigned int vector components to float vector for calculations
+            let morphNormalF: vec3f = vec3f(morphNormalInt.xyz) / 65535.0 * 2.0 - 1.0;
+            localNormal = localNormal + morphNormalF; // Expand +=
+        #else
+            // Use textureLoad, requires integer coordinates and returns vec4f
+            let morphNormal: vec3f = textureLoad(morphNormalTex, morphUV, 0).xyz;
+            localNormal = localNormal + morphNormal; // Expand +=
+        #endif
+
+    #endif
+
+    return localNormal;
+}
+
+#ifdef SKIN
+    fn getNormalMatrix(modelMatrix: mat4x4f) -> mat3x3f {
+        // Construct mat3x3f from columns' xyz components
+        return mat3x3f(modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz);
+    }
+#elif defined(INSTANCING)
+    fn getNormalMatrix(modelMatrix: mat4x4f) -> mat3x3f {
+        // Construct mat3x3f from columns' xyz components
+        return mat3x3f(modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz);
+    }
+#else
+    fn getNormalMatrix(modelMatrix: mat4x4f) -> mat3x3f {
+        // Access uniform via uniform.<name>
+        return uniform.matrix_normal;
+    }
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/vert/skin.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/vert/skin.js
@@ -1,0 +1,51 @@
+export default /* wgsl */`
+
+attribute vertex_boneWeights: vec4f;
+attribute vertex_boneIndices: vec4f;
+
+var texture_poseMap: texture_2d<f32>;
+
+struct BoneMatrix {
+    v1: vec4f,
+    v2: vec4f,
+    v3: vec4f,
+}
+
+fn getBoneMatrix(width: i32, index: i32) -> BoneMatrix {
+
+    let v = index / width;
+    let u = index % width;
+
+    var result: BoneMatrix;
+    result.v1 = textureLoad(texture_poseMap, vec2i(u + 0, v), 0);
+    result.v2 = textureLoad(texture_poseMap, vec2i(u + 1, v), 0);
+    result.v3 = textureLoad(texture_poseMap, vec2i(u + 2, v), 0);
+    return result;
+}
+
+fn getSkinMatrix(indicesFloat: vec4f, weights: vec4f) -> mat4x4f {
+
+    let width = i32(textureDimensions(texture_poseMap).x);
+    var indices = vec4i(indicesFloat + 0.5) * 3;
+
+    let boneA = getBoneMatrix(width, indices.x);
+    let boneB = getBoneMatrix(width, indices.y);
+    let boneC = getBoneMatrix(width, indices.z);
+    let boneD = getBoneMatrix(width, indices.w);
+
+    // ... rest of getSkinMatrix remains the same ...
+    let v1 = boneA.v1 * weights.x + boneB.v1 * weights.y + boneC.v1 * weights.z + boneD.v1 * weights.w;
+    let v2 = boneA.v2 * weights.x + boneB.v2 * weights.y + boneC.v2 * weights.z + boneD.v2 * weights.w;
+    let v3 = boneA.v3 * weights.x + boneB.v3 * weights.y + boneC.v3 * weights.z + boneD.v3 * weights.w;
+
+    let one = dot(weights, vec4f(1.0, 1.0, 1.0, 1.0));
+
+    // transpose to 4x4 matrix
+    return mat4x4f(
+        v1.x, v2.x, v3.x, 0,
+        v1.y, v2.y, v3.y, 0,
+        v1.z, v2.z, v3.z, 0,
+        v1.w, v2.w, v3.w, one
+    );
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/common/vert/transformCore.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/vert/transformCore.js
@@ -1,0 +1,84 @@
+export default /* wgsl */`
+
+    attribute vertex_position: vec4f;
+
+    uniform matrix_viewProjection: mat4x4f;
+    uniform matrix_model: mat4x4f;
+    uniform matrix_normal: mat3x3f;
+
+    #ifdef MORPHING
+
+        uniform morph_tex_params: vec2f;
+        attribute morph_vertex_id: u32;
+
+        fn getTextureMorphCoords() -> vec2i {
+
+            // turn morph_vertex_id into int grid coordinates
+            var textureSize: vec2i = vec2i(uniform.morph_tex_params);
+            var morphGridV: i32 = i32(morph_vertex_id) / textureSize.x;
+            var morphGridU: i32 = i32(morph_vertex_id) - (morphGridV * textureSize.x);
+            morphGridV = textureSize.y - morphGridV - 1;
+            return vec2i(morphGridU, morphGridV);
+        }
+
+        #ifdef MORPHING_POSITION
+            #ifdef MORPHING_INT
+                uniform aabbSize: vec3f;
+                uniform aabbMin: vec3f;
+                var morphPositionTex: texture_2d<u32>;
+            #else
+                var morphPositionTex: texture_2d<f32>;
+            #endif
+        #endif
+    #endif
+
+    #ifdef defined(BATCH)
+        #include "skinBatchVS"
+
+        fn getModelMatrix() -> mat4x4f {
+            return getBoneMatrix(vertex_boneIndices);
+        }
+
+    #elif defined(SKIN)
+        #include "skinVS"
+        fn getModelMatrix() -> mat4x4f {
+            return uniform.matrix_model * getSkinMatrix(vertex_boneIndices, vertex_boneWeights);
+        }
+
+    #elif defined(INSTANCING)
+
+        #include "transformInstancingVS"
+
+    #else
+
+        fn getModelMatrix() -> mat4x4f {
+            return uniform.matrix_model;
+        }
+
+    #endif
+
+    fn getLocalPosition(vertexPosition: vec3f) -> vec3f {
+
+        var localPos: vec3f = vertexPosition;
+
+        #ifdef MORPHING_POSITION
+
+            var morphUV: vec2i = getTextureMorphCoords();
+
+            #ifdef MORPHING_INT
+                // Use textureLoad instead of texelFetch. Coordinates must be integer type (vec2i).
+                // WGSL requires explicit type conversion for vectors.
+                // Division by float literal ensures floating point division.
+                var morphPos: vec3f = vec3f(textureLoad(morphPositionTex, morphUV, 0).xyz) / 65535.0 * uniform.aabbSize + uniform.aabbMin;
+            #else
+                // Use textureLoad instead of texelFetch. Coordinates must be integer type (vec2i).
+                var morphPos: vec3f = textureLoad(morphPositionTex, morphUV, 0).xyz;
+            #endif
+
+            localPos += morphPos;
+
+        #endif
+
+        return localPos;
+    }
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/base.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/base.js
@@ -1,0 +1,17 @@
+export default /* wgsl */`
+uniform view_position: vec3f;
+
+uniform light_globalAmbient: vec3f;
+
+fn square(x: f32) -> f32 {
+    return x*x;
+}
+
+fn saturate(x: f32) -> f32 {
+    return clamp(x, 0.0, 1.0);
+}
+
+fn saturate(x: vec3f) -> vec3f {
+    return clamp(x, vec3f(0.0), vec3f(1.0));
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/litShaderArgs.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/litShaderArgs.js
@@ -1,0 +1,69 @@
+export default /* wgsl */`
+
+// Surface albedo absorbance
+var litArgs_albedo: vec3f;
+
+// Transparency
+var litArgs_opacity: f32;
+
+// Emission color
+var litArgs_emission: vec3f;
+
+// Normal direction in world space
+var litArgs_worldNormal: vec3f;
+
+// Ambient occlusion amount, range [0..1]
+var litArgs_ao: f32;
+
+// Light map color
+var litArgs_lightmap: vec3f;
+
+// Light map direction
+var litArgs_lightmapDir: vec3f;
+
+// Surface metalness factor, range [0..1]
+var litArgs_metalness: f32;
+
+// The f0 specularity factor
+var litArgs_specularity: vec3f;
+
+// Specularity intensity factor, range [0..1]
+var litArgs_specularityFactor: f32;
+
+// The microfacet glossiness factor, range [0..1]
+var litArgs_gloss: f32;
+
+// Glossiness of the sheen layer, range [0..1]
+var litArgs_sheen_gloss: f32;
+
+// The color of the f0 specularity factor for the sheen layer
+var litArgs_sheen_specularity: vec3f;
+
+// Transmission factor (refraction), range [0..1]
+var litArgs_transmission: f32;
+
+// Uniform thickness of medium, used by transmission, range [0..inf]
+var litArgs_thickness: f32;
+
+// Index of refraction
+var litArgs_ior: f32;
+
+// Dispersion, range [0..1] typically, but can be higher
+var litArgs_dispersion: f32;
+
+// Iridescence effect intensity, range [0..1]
+var litArgs_iridescence_intensity: f32;
+
+// Thickness of the iridescent microfilm layer, value is in nanometers, range [0..1000]
+var litArgs_iridescence_thickness: f32;
+
+// The normal used for the clearcoat layer
+var litArgs_clearcoat_worldNormal: vec3f;
+
+// Intensity of the clearcoat layer, range [0..1]
+var litArgs_clearcoat_specularity: f32;
+
+// Glossiness of clearcoat layer, range [0..1]
+var litArgs_clearcoat_gloss: f32;
+
+`;

--- a/src/scene/shader-lib/chunks/common/vert/skin.js
+++ b/src/scene/shader-lib/chunks/common/vert/skin.js
@@ -4,38 +4,34 @@ attribute vec4 vertex_boneWeights;
 attribute vec4 vertex_boneIndices;
 
 uniform highp sampler2D texture_poseMap;
-uniform vec4 texture_poseMapSize;
 
-void getBoneMatrix(const in float index, out vec4 v1, out vec4 v2, out vec4 v3) {
+void getBoneMatrix(const in int width, const in int index, out vec4 v1, out vec4 v2, out vec4 v3) {
 
-    float i = float(index);
-    float j = i * 3.0;
-    float dx = texture_poseMapSize.z;
-    float dy = texture_poseMapSize.w;
-    
-    float y = floor(j * dx);
-    float x = j - (y * texture_poseMapSize.x);
-    y = dy * (y + 0.5);
+    int v = index / width;
+    int u = index % width;
 
-    // read elements of 4x3 matrix
-    v1 = texture2D(texture_poseMap, vec2(dx * (x + 0.5), y));
-    v2 = texture2D(texture_poseMap, vec2(dx * (x + 1.5), y));
-    v3 = texture2D(texture_poseMap, vec2(dx * (x + 2.5), y));
+    v1 = texelFetch(texture_poseMap, ivec2(u + 0, v), 0);
+    v2 = texelFetch(texture_poseMap, ivec2(u + 1, v), 0);
+    v3 = texelFetch(texture_poseMap, ivec2(u + 2, v), 0);
 }
 
-mat4 getSkinMatrix(const in vec4 indices, const in vec4 weights) {
+mat4 getSkinMatrix(const in vec4 indicesFloat, const in vec4 weights) {
+
+    int width = textureSize(texture_poseMap, 0).x;
+    ivec4 indices = ivec4(indicesFloat + 0.5) * 3;
+
     // get 4 bone matrices
     vec4 a1, a2, a3;
-    getBoneMatrix(indices.x, a1, a2, a3);
+    getBoneMatrix(width, indices.x, a1, a2, a3);
 
     vec4 b1, b2, b3;
-    getBoneMatrix(indices.y, b1, b2, b3);
+    getBoneMatrix(width, indices.y, b1, b2, b3);
 
     vec4 c1, c2, c3;
-    getBoneMatrix(indices.z, c1, c2, c3);
+    getBoneMatrix(width, indices.z, c1, c2, c3);
 
     vec4 d1, d2, d3;
-    getBoneMatrix(indices.w, d1, d2, d3);
+    getBoneMatrix(width, indices.w, d1, d2, d3);
 
     // multiply them by weights and add up to get final 4x3 matrix
     vec4 v1 = a1 * weights.x + b1 * weights.y + c1 * weights.z + d1 * weights.w;

--- a/src/scene/shader-lib/chunks/common/vert/skinBatch.js
+++ b/src/scene/shader-lib/chunks/common/vert/skinBatch.js
@@ -2,21 +2,18 @@ export default /* glsl */`
 attribute float vertex_boneIndices;
 
 uniform highp sampler2D texture_poseMap;
-uniform vec4 texture_poseMapSize;
 
-mat4 getBoneMatrix(const in float i) {
-    float j = i * 3.0;
-    float dx = texture_poseMapSize.z;
-    float dy = texture_poseMapSize.w;
+mat4 getBoneMatrix(const in float indexFloat) {
 
-    float y = floor(j * dx);
-    float x = j - (y * texture_poseMapSize.x);
-    y = dy * (y + 0.5);
+    int width = textureSize(texture_poseMap, 0).x;
+    int index = int(indexFloat + 0.5) * 3;
+    int iy = index / width;
+    int ix = index % width;
 
     // read elements of 4x3 matrix
-    vec4 v1 = texture2D(texture_poseMap, vec2(dx * (x + 0.5), y));
-    vec4 v2 = texture2D(texture_poseMap, vec2(dx * (x + 1.5), y));
-    vec4 v3 = texture2D(texture_poseMap, vec2(dx * (x + 2.5), y));
+    vec4 v1 = texelFetch(texture_poseMap, ivec2(ix + 0, iy), 0);
+    vec4 v2 = texelFetch(texture_poseMap, ivec2(ix + 1, iy), 0);
+    vec4 v3 = texelFetch(texture_poseMap, ivec2(ix + 2, iy), 0);
 
     // transpose to 4x4 matrix
     return mat4(

--- a/src/scene/skin-instance.js
+++ b/src/scene/skin-instance.js
@@ -26,8 +26,6 @@ class SkinInstance {
      */
     bones;
 
-    boneTextureSize;
-
     /**
      * Create a new SkinInstance instance.
      *
@@ -76,8 +74,6 @@ class SkinInstance {
             magFilter: FILTER_NEAREST,
             name: 'skin'
         });
-
-        this.boneTextureSize = [width, height, 1.0 / width, 1.0 / height];
 
         this.matrixPalette = this.boneTexture.lock({ mode: TEXTURELOCK_READ });
         this.boneTexture.unlock();


### PR DESCRIPTION
- converted GLSL version of skinning and batching vertex chunks to use texelFetch and simpler integer match, instead of WebGL1 compatible texture2D and float math
- updated ShaderProcessorWGSL to handle the shader modification in case shader expects float type and vertex buffer supplies (u)int data. This is similar solution to ShaderProcessorGLSL where GLSL code was being prepared for transcoding. Often used for skin indices, but also draco compressed vertex data often stored using ints.
- upgraded gooch shader / example to use native WGSL shaders, including skinning, morphing and instancing, all those WGSL chunks are now functional.