### PR TITLE
[FIX] Address some TypeDoc warnings related to TextureParser

### DIFF
--- a/src/framework/parsers/texture/texture.js
+++ b/src/framework/parsers/texture/texture.js
@@ -10,12 +10,10 @@
  * of texture assets.
  */
 class TextureParser {
-    /* eslint-disable jsdoc/require-returns-check */
     /**
-     * @function
-     * @name TextureParser#load
-     * @description Load the texture from the remote URL. When loaded (or failed), use the callback
-     * to return an the raw resource data (or error).
+     * Load the texture from the remote URL. When loaded (or failed), use the callback to return an
+     * the raw resource data (or error).
+     *
      * @param {object} url - The URL of the resource to load.
      * @param {string} url.load - The URL to use for loading the resource.
      * @param {string} url.original - The original URL useful for identifying the resource type.
@@ -27,11 +25,10 @@ class TextureParser {
         throw new Error('not implemented');
     }
 
+    /* eslint-disable jsdoc/require-returns-check */
     /**
-     * @function
-     * @name TextureParser#open
-     * @description Convert raw resource data into a resource instance. E.g. Take 3D model format
-     * JSON and return a {@link Model}.
+     * Convert raw resource data into a {@link Texture}.
+     *
      * @param {string} url - The URL of the resource to open.
      * @param {*} data - The raw resource data passed by callback from {@link ResourceHandler#load}.
      * @param {GraphicsDevice} device - The graphics device.


### PR DESCRIPTION
Fixes 4 more TypeDoc warnings. 17 remaining.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
