### PR TITLE
WGSL shaders expose inputs as globals + fog fix

### DIFF
--- a/src/scene/shader-lib/chunks-wgsl/common/frag/fog.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/fog.js
@@ -1,5 +1,7 @@
 export default /* wgsl */`
 
+var<private> dBlendModeFogFactor : f32 = 1.0;
+
 #if (FOG != NONE)
     uniform fog_color : vec3f;
     
@@ -11,13 +13,9 @@ export default /* wgsl */`
     #endif
 #endif
 
-uniform dBlendModeFogFactor : f32;
-
 fn getFogFactor() -> f32 {
 
-    // TODO: find a way to do this in WGSL, for now the fog is not working
-    // let depth = gl_FragCoord.z / gl_FragCoord.w;
-    let depth = 1.0;
+    let depth = pcPosition.z / pcPosition.w;
 
     var fogFactor : f32 = 0.0;
 
@@ -34,7 +32,7 @@ fn getFogFactor() -> f32 {
 
 fn addFog(color : vec3f) -> vec3f {
     #if (FOG != NONE)
-        return mix(uniform.fog_color * uniform.dBlendModeFogFactor, color, getFogFactor());
+        return mix(uniform.fog_color * dBlendModeFogFactor, color, getFogFactor());
     #else
         return color;
     #endif


### PR DESCRIPTION
- Finished the work on exposing shader inputs to globals during WGSL shader processing, to make it more similar to GLSL shaders and allow simpler shader porting.
- Also with this now in place, fixed the fog WGSL chunk, which is now fully functional

What this means for WGSL shaders:

WGSL vertex shader:
```
// if the vertex shader has an attribute, which is normally accessible as part of input struct
attribute vertex_position: vec4f;

// this is now automatically available as a global variable:
var<private> vertex_position: vec4f;

// there are additionally these build in globals available:
var<private> pcVertexIndex: u32; // @builtin(vertex_index)
var<private> pcInstanceIndex: u32; // @builtin(instance_index)
```

WGSL fragment shader:
```
// if the fragment shader has an varying (input from VS)
varying data: vec2f;

// this is now available as global
var<private> data: vec2f;

// there are additionally these build in globals available:
var<private> pcPosition: vec4f;     // @builtin(position), equivalent to gl_FragCoord in GLSL
var<private> pcFrontFacing: bool; // @builtin(front_facing)
var<private> pcSampleIndex: u32; //  @builtin(sample_index)
```
All these globals are provided for convenience, but can be still accessed using the input structures passed to main entry points, as before.
```
@vertex fn vertexMain(input: VertexInput) -> VertexOutput
@fragment fn fragmentMain(input: FragmentInput) -> FragmentOutput
```