### PR TITLE
Remove redundant @type tags from constants

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -1,7 +1,6 @@
 /**
  * Logs a frame number.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_RENDER_FRAME = 'RenderFrame';
@@ -9,7 +8,6 @@ export const TRACEID_RENDER_FRAME = 'RenderFrame';
 /**
  * Logs a frame time.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_RENDER_FRAME_TIME = 'RenderFrameTime';
@@ -17,7 +15,6 @@ export const TRACEID_RENDER_FRAME_TIME = 'RenderFrameTime';
 /**
  * Logs basic information about generated render passes.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_RENDER_PASS = 'RenderPass';
@@ -25,7 +22,6 @@ export const TRACEID_RENDER_PASS = 'RenderPass';
 /**
  * Logs additional detail for render passes.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_RENDER_PASS_DETAIL = 'RenderPassDetail';
@@ -34,7 +30,6 @@ export const TRACEID_RENDER_PASS_DETAIL = 'RenderPassDetail';
  * Logs render actions created by the layer composition. Only executes when the
  * layer composition changes.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_RENDER_ACTION = 'RenderAction';
@@ -42,7 +37,6 @@ export const TRACEID_RENDER_ACTION = 'RenderAction';
 /**
  * Logs the allocation of render targets.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_RENDER_TARGET_ALLOC = 'RenderTargetAlloc';
@@ -50,7 +44,6 @@ export const TRACEID_RENDER_TARGET_ALLOC = 'RenderTargetAlloc';
 /**
  * Logs the allocation of textures.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_TEXTURE_ALLOC = 'TextureAlloc';
@@ -58,7 +51,6 @@ export const TRACEID_TEXTURE_ALLOC = 'TextureAlloc';
 /**
  * Logs the creation of shaders.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_SHADER_ALLOC = 'ShaderAlloc';
@@ -66,7 +58,6 @@ export const TRACEID_SHADER_ALLOC = 'ShaderAlloc';
 /**
  * Logs the compilation time of shaders.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_SHADER_COMPILE = 'ShaderCompile';
@@ -74,7 +65,6 @@ export const TRACEID_SHADER_COMPILE = 'ShaderCompile';
 /**
  * Logs the vram use by the textures.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_VRAM_TEXTURE = 'VRAM.Texture';
@@ -82,7 +72,6 @@ export const TRACEID_VRAM_TEXTURE = 'VRAM.Texture';
 /**
  * Logs the vram use by the vertex buffers.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_VRAM_VB = 'VRAM.Vb';
@@ -90,7 +79,6 @@ export const TRACEID_VRAM_VB = 'VRAM.Vb';
 /**
  * Logs the vram use by the index buffers.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_VRAM_IB = 'VRAM.Ib';
@@ -98,7 +86,6 @@ export const TRACEID_VRAM_IB = 'VRAM.Ib';
 /**
  * Logs the vram use by the storage buffers.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_VRAM_SB = 'VRAM.Sb';
@@ -106,7 +93,6 @@ export const TRACEID_VRAM_SB = 'VRAM.Sb';
 /**
  * Logs the creation of bind groups.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_BINDGROUP_ALLOC = 'BindGroupAlloc';
@@ -114,7 +100,6 @@ export const TRACEID_BINDGROUP_ALLOC = 'BindGroupAlloc';
 /**
  * Logs the creation of bind group formats.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_BINDGROUPFORMAT_ALLOC = 'BindGroupFormatAlloc';
@@ -122,7 +107,6 @@ export const TRACEID_BINDGROUPFORMAT_ALLOC = 'BindGroupFormatAlloc';
 /**
  * Logs the creation of render pipelines. WebBPU only.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_RENDERPIPELINE_ALLOC = 'RenderPipelineAlloc';
@@ -130,7 +114,6 @@ export const TRACEID_RENDERPIPELINE_ALLOC = 'RenderPipelineAlloc';
 /**
  * Logs the creation of compute pipelines. WebGPU only.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_COMPUTEPIPELINE_ALLOC = 'ComputePipelineAlloc';
@@ -138,7 +121,6 @@ export const TRACEID_COMPUTEPIPELINE_ALLOC = 'ComputePipelineAlloc';
 /**
  * Logs the creation of pipeline layouts. WebBPU only.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_PIPELINELAYOUT_ALLOC = 'PipelineLayoutAlloc';
@@ -146,7 +128,6 @@ export const TRACEID_PIPELINELAYOUT_ALLOC = 'PipelineLayoutAlloc';
 /**
  * Logs the internal debug information for Elements.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACE_ID_ELEMENT = 'Element';
@@ -154,7 +135,6 @@ export const TRACE_ID_ELEMENT = 'Element';
 /**
  * Logs the vram use by all textures in memory.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_TEXTURES = 'Textures';
@@ -162,7 +142,6 @@ export const TRACEID_TEXTURES = 'Textures';
 /**
  * Logs the render queue commands.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_RENDER_QUEUE = 'RenderQueue';
@@ -170,7 +149,6 @@ export const TRACEID_RENDER_QUEUE = 'RenderQueue';
 /**
  * Logs the GPU timings.
  *
- * @type {string}
  * @category Debug
  */
 export const TRACEID_GPU_TIMINGS = 'GpuTimings';

--- a/src/core/math/constants.js
+++ b/src/core/math/constants.js
@@ -1,7 +1,6 @@
 /**
  * A linear interpolation scheme.
  *
- * @type {number}
  * @category Math
  */
 export const CURVE_LINEAR = 0;
@@ -9,7 +8,6 @@ export const CURVE_LINEAR = 0;
 /**
  * A smooth step interpolation scheme.
  *
- * @type {number}
  * @category Math
  */
 export const CURVE_SMOOTHSTEP = 1;
@@ -17,7 +15,6 @@ export const CURVE_SMOOTHSTEP = 1;
 /**
  * Cardinal spline interpolation scheme. For a Catmull-Rom spline, specify a curve tension of 0.5.
  *
- * @type {number}
  * @category Math
  */
 export const CURVE_SPLINE = 4;
@@ -25,7 +22,6 @@ export const CURVE_SPLINE = 4;
 /**
  * A stepped interpolator that does not perform any blending.
  *
- * @type {number}
  * @category Math
  */
 export const CURVE_STEP = 5;

--- a/src/extras/gizmo/constants.js
+++ b/src/extras/gizmo/constants.js
@@ -1,7 +1,6 @@
 /**
  * Local coordinate space.
  *
- * @type {string}
  * @category Gizmo
  */
 export const GIZMOSPACE_LOCAL = 'local';
@@ -9,7 +8,6 @@ export const GIZMOSPACE_LOCAL = 'local';
 /**
  * World coordinate space.
  *
- * @type {string}
  * @category Gizmo
  */
 export const GIZMOSPACE_WORLD = 'world';
@@ -17,7 +15,6 @@ export const GIZMOSPACE_WORLD = 'world';
 /**
  * Gizmo axis for the line X.
  *
- * @type {string}
  * @category Gizmo
  */
 export const GIZMOAXIS_X = 'x';
@@ -25,7 +22,6 @@ export const GIZMOAXIS_X = 'x';
 /**
  * Gizmo axis for the line Y.
  *
- * @type {string}
  * @category Gizmo
  */
 export const GIZMOAXIS_Y = 'y';
@@ -33,7 +29,6 @@ export const GIZMOAXIS_Y = 'y';
 /**
  * Gizmo axis for the line Z.
  *
- * @type {string}
  * @category Gizmo
  */
 export const GIZMOAXIS_Z = 'z';
@@ -41,7 +36,6 @@ export const GIZMOAXIS_Z = 'z';
 /**
  * Gizmo axis for the plane YZ.
  *
- * @type {string}
  * @category Gizmo
  */
 export const GIZMOAXIS_YZ = 'yz';
@@ -49,7 +43,6 @@ export const GIZMOAXIS_YZ = 'yz';
 /**
  * Gizmo axis for the plane XZ.
  *
- * @type {string}
  * @category Gizmo
  */
 export const GIZMOAXIS_XZ = 'xz';
@@ -57,7 +50,6 @@ export const GIZMOAXIS_XZ = 'xz';
 /**
  * Gizmo axis for the plane XY.
  *
- * @type {string}
  * @category Gizmo
  */
 export const GIZMOAXIS_XY = 'xy';
@@ -65,7 +57,6 @@ export const GIZMOAXIS_XY = 'xy';
 /**
  * Gizmo axis for all directions XYZ.
  *
- * @type {string}
  * @category Gizmo
  */
 export const GIZMOAXIS_XYZ = 'xyz';
@@ -73,7 +64,6 @@ export const GIZMOAXIS_XYZ = 'xyz';
 /**
  * Gizmo axis for facing the camera (facing the camera).
  *
- * @type {string}
  * @category Gizmo
  */
 export const GIZMOAXIS_FACE = 'face';

--- a/src/extras/render-passes/constants.js
+++ b/src/extras/render-passes/constants.js
@@ -1,7 +1,6 @@
 /**
  * SSAO is disabled.
  *
- * @type {string}
  * @category Graphics
  */
 export const SSAOTYPE_NONE = 'none';
@@ -11,7 +10,6 @@ export const SSAOTYPE_NONE = 'none';
  * lighting. This results in ambient occlusion being more pronounced in areas where direct light is
  * obstructed, enhancing realism.
  *
- * @type {string}
  * @category Graphics
  */
 export const SSAOTYPE_LIGHTING = 'lighting';
@@ -21,7 +19,6 @@ export const SSAOTYPE_LIGHTING = 'lighting';
  * overlays ambient occlusion across the image, disregarding direct lighting interactions. While
  * this may sacrifice some realism, it can be advantageous for achieving specific artistic styles.
  *
- * @type {string}
  * @category Graphics
  */
 export const SSAOTYPE_COMBINE = 'combine';

--- a/src/framework/anim/constants.js
+++ b/src/framework/anim/constants.js
@@ -1,7 +1,6 @@
 /**
  * A stepped interpolation scheme.
  *
- * @type {number}
  * @category Animation
  */
 export const INTERPOLATION_STEP = 0;
@@ -9,7 +8,6 @@ export const INTERPOLATION_STEP = 0;
 /**
  * A linear interpolation scheme.
  *
- * @type {number}
  * @category Animation
  */
 export const INTERPOLATION_LINEAR = 1;
@@ -17,7 +15,6 @@ export const INTERPOLATION_LINEAR = 1;
 /**
  * A cubic spline interpolation scheme.
  *
- * @type {number}
  * @category Animation
  */
 export const INTERPOLATION_CUBIC = 2;

--- a/src/framework/anim/controller/constants.js
+++ b/src/framework/anim/controller/constants.js
@@ -1,7 +1,6 @@
 /**
  * Used to set the anim state graph transition interruption source to no state.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_INTERRUPTION_NONE = 'NONE';
@@ -9,7 +8,6 @@ export const ANIM_INTERRUPTION_NONE = 'NONE';
 /**
  * Used to set the anim state graph transition interruption source as the previous state only.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_INTERRUPTION_PREV = 'PREV_STATE';
@@ -17,7 +15,6 @@ export const ANIM_INTERRUPTION_PREV = 'PREV_STATE';
 /**
  * Used to set the anim state graph transition interruption source as the next state only.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_INTERRUPTION_NEXT = 'NEXT_STATE';
@@ -26,7 +23,6 @@ export const ANIM_INTERRUPTION_NEXT = 'NEXT_STATE';
  * Used to set the anim state graph transition interruption sources as the previous state followed
  * by the next state.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_INTERRUPTION_PREV_NEXT = 'PREV_STATE_NEXT_STATE';
@@ -35,7 +31,6 @@ export const ANIM_INTERRUPTION_PREV_NEXT = 'PREV_STATE_NEXT_STATE';
  * Used to set the anim state graph transition interruption sources as the next state followed by
  * the previous state.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_INTERRUPTION_NEXT_PREV = 'NEXT_STATE_PREV_STATE';
@@ -43,7 +38,6 @@ export const ANIM_INTERRUPTION_NEXT_PREV = 'NEXT_STATE_PREV_STATE';
 /**
  * Used to set an anim state graph transition condition predicate as '>'.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_GREATER_THAN = 'GREATER_THAN';
@@ -51,7 +45,6 @@ export const ANIM_GREATER_THAN = 'GREATER_THAN';
 /**
  * Used to set an anim state graph transition condition predicate as '<'.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_LESS_THAN = 'LESS_THAN';
@@ -59,7 +52,6 @@ export const ANIM_LESS_THAN = 'LESS_THAN';
 /**
  * Used to set an anim state graph transition condition predicate as '>='.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_GREATER_THAN_EQUAL_TO = 'GREATER_THAN_EQUAL_TO';
@@ -67,7 +59,6 @@ export const ANIM_GREATER_THAN_EQUAL_TO = 'GREATER_THAN_EQUAL_TO';
 /**
  * Used to set an anim state graph transition condition predicate as '<='.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_LESS_THAN_EQUAL_TO = 'LESS_THAN_EQUAL_TO';
@@ -75,7 +66,6 @@ export const ANIM_LESS_THAN_EQUAL_TO = 'LESS_THAN_EQUAL_TO';
 /**
  * Used to set an anim state graph transition condition predicate as '==='.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_EQUAL_TO = 'EQUAL_TO';
@@ -83,7 +73,6 @@ export const ANIM_EQUAL_TO = 'EQUAL_TO';
 /**
  * Used to set an anim state graph transition condition predicate as '!=='.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_NOT_EQUAL_TO = 'NOT_EQUAL_TO';
@@ -91,7 +80,6 @@ export const ANIM_NOT_EQUAL_TO = 'NOT_EQUAL_TO';
 /**
  * Used to set an anim state graph parameter as type integer.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_PARAMETER_INTEGER = 'INTEGER';
@@ -99,7 +87,6 @@ export const ANIM_PARAMETER_INTEGER = 'INTEGER';
 /**
  * Used to set an anim state graph parameter as type float.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_PARAMETER_FLOAT = 'FLOAT';
@@ -107,7 +94,6 @@ export const ANIM_PARAMETER_FLOAT = 'FLOAT';
 /**
  * Used to set an anim state graph parameter as type boolean.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_PARAMETER_BOOLEAN = 'BOOLEAN';
@@ -115,7 +101,6 @@ export const ANIM_PARAMETER_BOOLEAN = 'BOOLEAN';
 /**
  * Used to set an anim state graph parameter as type trigger.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_PARAMETER_TRIGGER = 'TRIGGER';
@@ -147,7 +132,6 @@ export const ANIM_BLEND_DIRECT = 'DIRECT';
 /**
  * The starting state in an anim state graph layer.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_STATE_START = 'START';
@@ -155,7 +139,6 @@ export const ANIM_STATE_START = 'START';
 /**
  * The ending state in an anim state graph layer.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_STATE_END = 'END';
@@ -163,7 +146,6 @@ export const ANIM_STATE_END = 'END';
 /**
  * Used to indicate any state in an anim state graph layer.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_STATE_ANY = 'ANY';
@@ -173,7 +155,6 @@ export const ANIM_CONTROL_STATES = [ANIM_STATE_START, ANIM_STATE_END, ANIM_STATE
 /**
  * Used to indicate that a layers animations should overwrite all previous layers.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_LAYER_OVERWRITE = 'OVERWRITE';
@@ -181,7 +162,6 @@ export const ANIM_LAYER_OVERWRITE = 'OVERWRITE';
 /**
  * Used to indicate that a layers animations should blend additively with previous layers.
  *
- * @type {string}
  * @category Animation
  */
 export const ANIM_LAYER_ADDITIVE = 'ADDITIVE';

--- a/src/framework/asset/constants.js
+++ b/src/framework/asset/constants.js
@@ -24,7 +24,6 @@ export const ABSOLUTE_URL = new RegExp(
 /**
  * Asset type name for animation.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_ANIMATION = 'animation';
@@ -32,7 +31,6 @@ export const ASSET_ANIMATION = 'animation';
 /**
  * Asset type name for audio.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_AUDIO = 'audio';
@@ -40,7 +38,6 @@ export const ASSET_AUDIO = 'audio';
 /**
  * Asset type name for image.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_IMAGE = 'image';
@@ -48,7 +45,6 @@ export const ASSET_IMAGE = 'image';
 /**
  * Asset type name for json.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_JSON = 'json';
@@ -56,7 +52,6 @@ export const ASSET_JSON = 'json';
 /**
  * Asset type name for model.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_MODEL = 'model';
@@ -64,7 +59,6 @@ export const ASSET_MODEL = 'model';
 /**
  * Asset type name for material.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_MATERIAL = 'material';
@@ -72,7 +66,6 @@ export const ASSET_MATERIAL = 'material';
 /**
  * Asset type name for text.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_TEXT = 'text';
@@ -80,7 +73,6 @@ export const ASSET_TEXT = 'text';
 /**
  * Asset type name for texture.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_TEXTURE = 'texture';
@@ -88,7 +80,6 @@ export const ASSET_TEXTURE = 'texture';
 /**
  * Asset type name for textureatlas.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_TEXTUREATLAS = 'textureatlas';
@@ -96,7 +87,6 @@ export const ASSET_TEXTUREATLAS = 'textureatlas';
 /**
  * Asset type name for cubemap.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_CUBEMAP = 'cubemap';
@@ -104,7 +94,6 @@ export const ASSET_CUBEMAP = 'cubemap';
 /**
  * Asset type name for shader.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_SHADER = 'shader';
@@ -112,7 +101,6 @@ export const ASSET_SHADER = 'shader';
 /**
  * Asset type name for CSS.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_CSS = 'css';
@@ -120,7 +108,6 @@ export const ASSET_CSS = 'css';
 /**
  * Asset type name for HTML.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_HTML = 'html';
@@ -128,7 +115,6 @@ export const ASSET_HTML = 'html';
 /**
  * Asset type name for script.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_SCRIPT = 'script';
@@ -136,7 +122,6 @@ export const ASSET_SCRIPT = 'script';
 /**
  * Asset type name for a container.
  *
- * @type {string}
  * @category Asset
  */
 export const ASSET_CONTAINER = 'container';

--- a/src/framework/components/button/constants.js
+++ b/src/framework/components/button/constants.js
@@ -1,7 +1,6 @@
 /**
  * Specifies different color tints for the hover, pressed and inactive states.
  *
- * @type {number}
  * @category User Interface
  */
 export const BUTTON_TRANSITION_MODE_TINT = 0;
@@ -9,7 +8,6 @@ export const BUTTON_TRANSITION_MODE_TINT = 0;
 /**
  * Specifies different sprites for the hover, pressed and inactive states.
  *
- * @type {number}
  * @category User Interface
  */
 export const BUTTON_TRANSITION_MODE_SPRITE_CHANGE = 1;

--- a/src/framework/components/element/constants.js
+++ b/src/framework/components/element/constants.js
@@ -1,7 +1,6 @@
 /**
  * A {@link ElementComponent} that contains child {@link ElementComponent}s.
  *
- * @type {string}
  * @category User Interface
  */
 export const ELEMENTTYPE_GROUP = 'group';
@@ -9,7 +8,6 @@ export const ELEMENTTYPE_GROUP = 'group';
 /**
  * A {@link ElementComponent} that displays an image.
  *
- * @type {string}
  * @category User Interface
  */
 export const ELEMENTTYPE_IMAGE = 'image';
@@ -17,7 +15,6 @@ export const ELEMENTTYPE_IMAGE = 'image';
 /**
  * A {@link ElementComponent} that displays text.
  *
- * @type {string}
  * @category User Interface
  */
 export const ELEMENTTYPE_TEXT = 'text';
@@ -25,7 +22,6 @@ export const ELEMENTTYPE_TEXT = 'text';
 /**
  * Fit the content exactly to Element's bounding box.
  *
- * @type {string}
  * @category User Interface
  */
 export const FITMODE_STRETCH = 'stretch';
@@ -33,7 +29,6 @@ export const FITMODE_STRETCH = 'stretch';
 /**
  * Fit the content within the Element's bounding box while preserving its Aspect Ratio.
  *
- * @type {string}
  * @category User Interface
  */
 export const FITMODE_CONTAIN = 'contain';
@@ -41,7 +36,6 @@ export const FITMODE_CONTAIN = 'contain';
 /**
  * Fit the content to cover the entire Element's bounding box while preserving its Aspect Ratio.
  *
- * @type {string}
  * @category User Interface
  */
 export const FITMODE_COVER = 'cover';

--- a/src/framework/components/joint/constants.js
+++ b/src/framework/components/joint/constants.js
@@ -1,7 +1,6 @@
 /**
  * Specified degree of freedom has free movement.
  *
- * @type {string}
  * @ignore
  */
 export const MOTION_FREE = 'free';
@@ -9,7 +8,6 @@ export const MOTION_FREE = 'free';
 /**
  * Specified degree of freedom has limited movement.
  *
- * @type {string}
  * @ignore
  */
 export const MOTION_LIMITED = 'limited';
@@ -17,7 +15,6 @@ export const MOTION_LIMITED = 'limited';
 /**
  * Specified degree of freedom is locked and allows no movement.
  *
- * @type {string}
  * @ignore
  */
 export const MOTION_LOCKED = 'locked';

--- a/src/framework/components/layout-group/constants.js
+++ b/src/framework/components/layout-group/constants.js
@@ -1,7 +1,6 @@
 /**
  * Disable all fitting logic.
  *
- * @type {number}
  * @category User Interface
  */
 export const FITTING_NONE = 0;
@@ -9,7 +8,6 @@ export const FITTING_NONE = 0;
 /**
  * Stretch child elements to fit the parent container.
  *
- * @type {number}
  * @category User Interface
  */
 export const FITTING_STRETCH = 1;
@@ -17,7 +15,6 @@ export const FITTING_STRETCH = 1;
 /**
  * Shrink child elements to fit the parent container.
  *
- * @type {number}
  * @category User Interface
  */
 export const FITTING_SHRINK = 2;
@@ -25,7 +22,6 @@ export const FITTING_SHRINK = 2;
 /**
  * Apply both STRETCH and SHRINK fitting logic where applicable.
  *
- * @type {number}
  * @category User Interface
  */
 export const FITTING_BOTH = 3;

--- a/src/framework/components/rigid-body/constants.js
+++ b/src/framework/components/rigid-body/constants.js
@@ -1,7 +1,6 @@
 /**
  * Rigid body has infinite mass and cannot move.
  *
- * @type {string}
  * @category Physics
  */
 export const BODYTYPE_STATIC = 'static';
@@ -9,7 +8,6 @@ export const BODYTYPE_STATIC = 'static';
 /**
  * Rigid body is simulated according to applied forces.
  *
- * @type {string}
  * @category Physics
  */
 export const BODYTYPE_DYNAMIC = 'dynamic';
@@ -18,7 +16,6 @@ export const BODYTYPE_DYNAMIC = 'dynamic';
  * Rigid body has infinite mass and does not respond to forces but can still be moved by setting
  * their velocity or position.
  *
- * @type {string}
  * @category Physics
  */
 export const BODYTYPE_KINEMATIC = 'kinematic';

--- a/src/framework/components/screen/constants.js
+++ b/src/framework/components/screen/constants.js
@@ -1,7 +1,6 @@
 /**
  * Always use the application's resolution as the resolution for the {@link ScreenComponent}.
  *
- * @type {string}
  * @category User Interface
  */
 export const SCALEMODE_NONE = 'none';
@@ -10,7 +9,6 @@ export const SCALEMODE_NONE = 'none';
  * Scale the {@link ScreenComponent} when the application's resolution is different than the
  * ScreenComponent's referenceResolution.
  *
- * @type {string}
  * @category User Interface
  */
 export const SCALEMODE_BLEND = 'blend';

--- a/src/framework/components/scroll-view/constants.js
+++ b/src/framework/components/scroll-view/constants.js
@@ -1,7 +1,6 @@
 /**
  * Content does not scroll any further than its bounds.
  *
- * @type {number}
  * @category User Interface
  */
 export const SCROLL_MODE_CLAMP = 0;
@@ -9,7 +8,6 @@ export const SCROLL_MODE_CLAMP = 0;
 /**
  * Content scrolls past its bounds and then gently bounces back.
  *
- * @type {number}
  * @category User Interface
  */
 export const SCROLL_MODE_BOUNCE = 1;
@@ -17,7 +15,6 @@ export const SCROLL_MODE_BOUNCE = 1;
 /**
  * Content can scroll forever.
  *
- * @type {number}
  * @category User Interface
  */
 export const SCROLL_MODE_INFINITE = 2;
@@ -25,7 +22,6 @@ export const SCROLL_MODE_INFINITE = 2;
 /**
  * The scrollbar will be visible all the time.
  *
- * @type {number}
  * @category User Interface
  */
 export const SCROLLBAR_VISIBILITY_SHOW_ALWAYS = 0;
@@ -33,7 +29,6 @@ export const SCROLLBAR_VISIBILITY_SHOW_ALWAYS = 0;
 /**
  * The scrollbar will be visible only when content exceeds the size of the viewport.
  *
- * @type {number}
  * @category User Interface
  */
 export const SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED = 1;

--- a/src/framework/components/sprite/constants.js
+++ b/src/framework/components/sprite/constants.js
@@ -1,7 +1,6 @@
 /**
  * A {@link SpriteComponent} that displays a single frame from a sprite asset.
  *
- * @type {string}
  * @category Graphics
  */
 export const SPRITETYPE_SIMPLE = 'simple';
@@ -9,7 +8,6 @@ export const SPRITETYPE_SIMPLE = 'simple';
 /**
  * A {@link SpriteComponent} that renders sprite animations.
  *
- * @type {string}
  * @category Graphics
  */
 export const SPRITETYPE_ANIMATED = 'animated';

--- a/src/framework/constants.js
+++ b/src/framework/constants.js
@@ -1,14 +1,12 @@
 /**
  * When resizing the window the size of the canvas will not change.
  *
- * @type {string}
  */
 export const FILLMODE_NONE = 'NONE';
 
 /**
  * When resizing the window the size of the canvas will change to fill the window exactly.
  *
- * @type {string}
  */
 export const FILLMODE_FILL_WINDOW = 'FILL_WINDOW';
 
@@ -16,7 +14,6 @@ export const FILLMODE_FILL_WINDOW = 'FILL_WINDOW';
  * When resizing the window the size of the canvas will change to fill the window as best it can,
  * while maintaining the same aspect ratio.
  *
- * @type {string}
  */
 export const FILLMODE_KEEP_ASPECT = 'KEEP_ASPECT';
 
@@ -24,7 +21,6 @@ export const FILLMODE_KEEP_ASPECT = 'KEEP_ASPECT';
  * When the canvas is resized the resolution of the canvas will change to match the size of the
  * canvas.
  *
- * @type {string}
  */
 export const RESOLUTION_AUTO = 'AUTO';
 
@@ -32,6 +28,5 @@ export const RESOLUTION_AUTO = 'AUTO';
  * When the canvas is resized the resolution of the canvas will remain at the same value and the
  * output will just be scaled to fit the canvas.
  *
- * @type {string}
  */
 export const RESOLUTION_FIXED = 'FIXED';

--- a/src/framework/constants.js
+++ b/src/framework/constants.js
@@ -1,32 +1,27 @@
 /**
  * When resizing the window the size of the canvas will not change.
- *
  */
 export const FILLMODE_NONE = 'NONE';
 
 /**
  * When resizing the window the size of the canvas will change to fill the window exactly.
- *
  */
 export const FILLMODE_FILL_WINDOW = 'FILL_WINDOW';
 
 /**
  * When resizing the window the size of the canvas will change to fill the window as best it can,
  * while maintaining the same aspect ratio.
- *
  */
 export const FILLMODE_KEEP_ASPECT = 'KEEP_ASPECT';
 
 /**
  * When the canvas is resized the resolution of the canvas will change to match the size of the
  * canvas.
- *
  */
 export const RESOLUTION_AUTO = 'AUTO';
 
 /**
  * When the canvas is resized the resolution of the canvas will remain at the same value and the
  * output will just be scaled to fit the canvas.
- *
  */
 export const RESOLUTION_FIXED = 'FIXED';

--- a/src/framework/xr/constants.js
+++ b/src/framework/xr/constants.js
@@ -2,7 +2,6 @@
  * Inline - always available type of session. It has limited features availability and is rendered
  * into HTML element.
  *
- * @type {string}
  * @category XR
  */
 export const XRTYPE_INLINE = 'inline';
@@ -11,7 +10,6 @@ export const XRTYPE_INLINE = 'inline';
  * Immersive VR - session that provides exclusive access to VR device with best available tracking
  * features.
  *
- * @type {string}
  * @category XR
  */
 export const XRTYPE_VR = 'immersive-vr';
@@ -20,7 +18,6 @@ export const XRTYPE_VR = 'immersive-vr';
  * Immersive AR - session that provides exclusive access to VR/AR device that is intended to be
  * blended with real-world environment.
  *
- * @type {string}
  * @category XR
  */
 export const XRTYPE_AR = 'immersive-ar';
@@ -28,7 +25,6 @@ export const XRTYPE_AR = 'immersive-ar';
 /**
  * Viewer - always supported space with some basic tracking capabilities.
  *
- * @type {string}
  * @category XR
  */
 export const XRSPACE_VIEWER = 'viewer';
@@ -41,7 +37,6 @@ export const XRSPACE_VIEWER = 'viewer';
  * with 6DoF tracking, local reference spaces should emphasize keeping the origin stable relative
  * to the user's environment.
  *
- * @type {string}
  * @category XR
  */
 export const XRSPACE_LOCAL = 'local';
@@ -55,7 +50,6 @@ export const XRSPACE_LOCAL = 'local';
  * that purpose. For devices with 6DoF tracking, local-floor reference spaces should emphasize
  * keeping the origin stable relative to the user's environment.
  *
- * @type {string}
  * @category XR
  */
 export const XRSPACE_LOCALFLOOR = 'local-floor';
@@ -66,7 +60,6 @@ export const XRSPACE_LOCALFLOOR = 'local-floor';
  * space is optimized for keeping the native origin and bounds geometry stable relative to the
  * user's environment.
  *
- * @type {string}
  * @category XR
  */
 export const XRSPACE_BOUNDEDFLOOR = 'bounded-floor';
@@ -77,7 +70,6 @@ export const XRSPACE_BOUNDEDFLOOR = 'bounded-floor';
  * reference space is optimized for stability around the user's current position, and as such the
  * native origin may drift over time.
  *
- * @type {string}
  * @category XR
  */
 export const XRSPACE_UNBOUNDED = 'unbounded';
@@ -87,7 +79,6 @@ export const XRSPACE_UNBOUNDED = 'unbounded';
  * facing. This is commonly referred to as a "gaze input" device in the context of head-mounted
  * displays.
  *
- * @type {string}
  * @category XR
  */
 export const XRTARGETRAY_GAZE = 'gaze';
@@ -96,7 +87,6 @@ export const XRTARGETRAY_GAZE = 'gaze';
  * Screen - indicates that the input source was an interaction with the canvas element associated
  * with an inline session's output context, such as a mouse click or touch event.
  *
- * @type {string}
  * @category XR
  */
 export const XRTARGETRAY_SCREEN = 'screen';
@@ -106,7 +96,6 @@ export const XRTARGETRAY_SCREEN = 'screen';
  * other hand-tracking mechanism and represents that the user is using their hands or the held
  * device for pointing.
  *
- * @type {string}
  * @category XR
  */
 export const XRTARGETRAY_POINTER = 'tracked-pointer';
@@ -114,7 +103,6 @@ export const XRTARGETRAY_POINTER = 'tracked-pointer';
 /**
  * None - view associated with a monoscopic screen, such as mobile phone screens.
  *
- * @type {string}
  * @category XR
  */
 export const XREYE_NONE = 'none';
@@ -122,7 +110,6 @@ export const XREYE_NONE = 'none';
 /**
  * Left - view associated with left eye.
  *
- * @type {string}
  * @category XR
  */
 export const XREYE_LEFT = 'left';
@@ -130,7 +117,6 @@ export const XREYE_LEFT = 'left';
 /**
  * Right - view associated with right eye.
  *
- * @type {string}
  * @category XR
  */
 export const XREYE_RIGHT = 'right';
@@ -138,7 +124,6 @@ export const XREYE_RIGHT = 'right';
 /**
  * None - input source is not meant to be held in hands.
  *
- * @type {string}
  * @category XR
  */
 export const XRHAND_NONE = 'none';
@@ -146,7 +131,6 @@ export const XRHAND_NONE = 'none';
 /**
  * Left - indicates that input source is meant to be held in left hand.
  *
- * @type {string}
  * @category XR
  */
 export const XRHAND_LEFT = 'left';
@@ -154,7 +138,6 @@ export const XRHAND_LEFT = 'left';
 /**
  * Right - indicates that input source is meant to be held in right hand.
  *
- * @type {string}
  * @category XR
  */
 export const XRHAND_RIGHT = 'right';
@@ -163,7 +146,6 @@ export const XRHAND_RIGHT = 'right';
  * Point - indicates that the hit test results will be computed based on the feature points
  * detected by the underlying Augmented Reality system.
  *
- * @type {string}
  * @category XR
  */
 export const XRTRACKABLE_POINT = 'point';
@@ -172,7 +154,6 @@ export const XRTRACKABLE_POINT = 'point';
  * Plane - indicates that the hit test results will be computed based on the planes detected by the
  * underlying Augmented Reality system.
  *
- * @type {string}
  * @category XR
  */
 export const XRTRACKABLE_PLANE = 'plane';
@@ -181,7 +162,6 @@ export const XRTRACKABLE_PLANE = 'plane';
  * Mesh - indicates that the hit test results will be computed based on the meshes detected by the
  * underlying Augmented Reality system.
  *
- * @type {string}
  * @category XR
  */
 export const XRTRACKABLE_MESH = 'mesh';
@@ -190,7 +170,6 @@ export const XRTRACKABLE_MESH = 'mesh';
  * CPU - indicates that depth sensing preferred usage is CPU. This usage path is guaranteed to be
  * supported.
  *
- * @type {string}
  * @category XR
  */
 export const XRDEPTHSENSINGUSAGE_CPU = 'cpu-optimized';
@@ -198,7 +177,6 @@ export const XRDEPTHSENSINGUSAGE_CPU = 'cpu-optimized';
 /**
  * GPU - indicates that depth sensing preferred usage is GPU.
  *
- * @type {string}
  * @category XR
  */
 export const XRDEPTHSENSINGUSAGE_GPU = 'gpu-optimized';
@@ -207,7 +185,6 @@ export const XRDEPTHSENSINGUSAGE_GPU = 'gpu-optimized';
  * Luminance Alpha - indicates that depth sensing preferred raw data format is Luminance Alpha (8bit + 8bit).
  * This format is guaranteed to be supported.
  *
- * @type {string}
  * @category XR
  */
 export const XRDEPTHSENSINGFORMAT_L8A8 = 'luminance-alpha';
@@ -215,7 +192,6 @@ export const XRDEPTHSENSINGFORMAT_L8A8 = 'luminance-alpha';
 /**
  * Unsigned Short - indicates that depth sensing preferred raw data format is Unsigned Short (16 bit).
  *
- * @type {string}
  * @category XR
  */
 export const XRDEPTHSENSINGFORMAT_R16U = 'unsigned-short';
@@ -223,7 +199,6 @@ export const XRDEPTHSENSINGFORMAT_R16U = 'unsigned-short';
 /**
  * Float 32 - indicates that depth sensing preferred raw data format is Float (32 bit).
  *
- * @type {string}
  * @category XR
  */
 export const XRDEPTHSENSINGFORMAT_F32 = 'float32';

--- a/src/platform/audio/constants.js
+++ b/src/platform/audio/constants.js
@@ -1,7 +1,6 @@
 /**
  * Linear distance model.
  *
- * @type {string}
  * @category Sound
  */
 export const DISTANCE_LINEAR = 'linear';
@@ -9,7 +8,6 @@ export const DISTANCE_LINEAR = 'linear';
 /**
  * Inverse distance model.
  *
- * @type {string}
  * @category Sound
  */
 export const DISTANCE_INVERSE = 'inverse';
@@ -17,7 +15,6 @@ export const DISTANCE_INVERSE = 'inverse';
 /**
  * Exponential distance model.
  *
- * @type {string}
  * @category Sound
  */
 export const DISTANCE_EXPONENTIAL = 'exponential';

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1,7 +1,6 @@
 /**
  * Ignores the integer part of texture coordinates, using only the fractional part.
  *
- * @type {number}
  * @category Graphics
  */
 export const ADDRESS_REPEAT = 0;
@@ -9,7 +8,6 @@ export const ADDRESS_REPEAT = 0;
 /**
  * Clamps texture coordinate to the range 0 to 1.
  *
- * @type {number}
  * @category Graphics
  */
 export const ADDRESS_CLAMP_TO_EDGE = 1;
@@ -18,7 +16,6 @@ export const ADDRESS_CLAMP_TO_EDGE = 1;
  * Texture coordinate to be set to the fractional part if the integer part is even. If the integer
  * part is odd, then the texture coordinate is set to 1 minus the fractional part.
  *
- * @type {number}
  * @category Graphics
  */
 export const ADDRESS_MIRRORED_REPEAT = 2;
@@ -26,7 +23,6 @@ export const ADDRESS_MIRRORED_REPEAT = 2;
 /**
  * Multiply all fragment components by zero.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_ZERO = 0;
@@ -34,7 +30,6 @@ export const BLENDMODE_ZERO = 0;
 /**
  * Multiply all fragment components by one.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_ONE = 1;
@@ -42,7 +37,6 @@ export const BLENDMODE_ONE = 1;
 /**
  * Multiply all fragment components by the components of the source fragment.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_SRC_COLOR = 2;
@@ -50,7 +44,6 @@ export const BLENDMODE_SRC_COLOR = 2;
 /**
  * Multiply all fragment components by one minus the components of the source fragment.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_ONE_MINUS_SRC_COLOR = 3;
@@ -58,7 +51,6 @@ export const BLENDMODE_ONE_MINUS_SRC_COLOR = 3;
 /**
  * Multiply all fragment components by the components of the destination fragment.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_DST_COLOR = 4;
@@ -66,7 +58,6 @@ export const BLENDMODE_DST_COLOR = 4;
 /**
  * Multiply all fragment components by one minus the components of the destination fragment.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_ONE_MINUS_DST_COLOR = 5;
@@ -74,7 +65,6 @@ export const BLENDMODE_ONE_MINUS_DST_COLOR = 5;
 /**
  * Multiply all fragment components by the alpha value of the source fragment.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_SRC_ALPHA = 6;
@@ -82,7 +72,6 @@ export const BLENDMODE_SRC_ALPHA = 6;
 /**
  * Multiply all fragment components by the alpha value of the source fragment.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_SRC_ALPHA_SATURATE = 7;
@@ -90,7 +79,6 @@ export const BLENDMODE_SRC_ALPHA_SATURATE = 7;
 /**
  * Multiply all fragment components by one minus the alpha value of the source fragment.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_ONE_MINUS_SRC_ALPHA = 8;
@@ -98,7 +86,6 @@ export const BLENDMODE_ONE_MINUS_SRC_ALPHA = 8;
 /**
  * Multiply all fragment components by the alpha value of the destination fragment.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_DST_ALPHA = 9;
@@ -106,7 +93,6 @@ export const BLENDMODE_DST_ALPHA = 9;
 /**
  * Multiply all fragment components by one minus the alpha value of the destination fragment.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_ONE_MINUS_DST_ALPHA = 10;
@@ -114,7 +100,6 @@ export const BLENDMODE_ONE_MINUS_DST_ALPHA = 10;
 /**
  * Multiplies all fragment components by a constant.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_CONSTANT = 11;
@@ -122,7 +107,6 @@ export const BLENDMODE_CONSTANT = 11;
 /**
  * Multiplies all fragment components by 1 minus a constant.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDMODE_ONE_MINUS_CONSTANT = 12;
@@ -130,7 +114,6 @@ export const BLENDMODE_ONE_MINUS_CONSTANT = 12;
 /**
  * Add the results of the source and destination fragment multiplies.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDEQUATION_ADD = 0;
@@ -138,7 +121,6 @@ export const BLENDEQUATION_ADD = 0;
 /**
  * Subtract the results of the source and destination fragment multiplies.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDEQUATION_SUBTRACT = 1;
@@ -146,7 +128,6 @@ export const BLENDEQUATION_SUBTRACT = 1;
 /**
  * Reverse and subtract the results of the source and destination fragment multiplies.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDEQUATION_REVERSE_SUBTRACT = 2;
@@ -154,7 +135,6 @@ export const BLENDEQUATION_REVERSE_SUBTRACT = 2;
 /**
  * Use the smallest value.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDEQUATION_MIN = 3;
@@ -162,7 +142,6 @@ export const BLENDEQUATION_MIN = 3;
 /**
  * Use the largest value.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLENDEQUATION_MAX = 4;
@@ -171,7 +150,6 @@ export const BLENDEQUATION_MAX = 4;
  * A flag utilized during the construction of a {@link StorageBuffer} to make it available for read
  * access by CPU.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFERUSAGE_READ = 0x0001;
@@ -180,7 +158,6 @@ export const BUFFERUSAGE_READ = 0x0001;
  * A flag utilized during the construction of a {@link StorageBuffer} to make it available for write
  * access by CPU.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFERUSAGE_WRITE = 0x0002;
@@ -189,7 +166,6 @@ export const BUFFERUSAGE_WRITE = 0x0002;
  * A flag utilized during the construction of a {@link StorageBuffer} to ensure its compatibility
  * when used as a source of a copy operation.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFERUSAGE_COPY_SRC = 0x0004;
@@ -198,7 +174,6 @@ export const BUFFERUSAGE_COPY_SRC = 0x0004;
  * A flag utilized during the construction of a {@link StorageBuffer} to ensure its compatibility
  * when used as a destination of a copy operation, or as a target of a write operation.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFERUSAGE_COPY_DST = 0x0008;
@@ -207,7 +182,6 @@ export const BUFFERUSAGE_COPY_DST = 0x0008;
  * A flag utilized during the construction of a {@link StorageBuffer} to ensure its compatibility
  * when used as an index buffer.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFERUSAGE_INDEX = 0x0010;
@@ -216,7 +190,6 @@ export const BUFFERUSAGE_INDEX = 0x0010;
  * A flag utilized during the construction of a {@link StorageBuffer} to ensure its compatibility
  * when used as a vertex buffer.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFERUSAGE_VERTEX = 0x0020;
@@ -225,7 +198,6 @@ export const BUFFERUSAGE_VERTEX = 0x0020;
  * A flag utilized during the construction of a {@link StorageBuffer} to ensure its compatibility
  * when used as an uniform buffer.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFERUSAGE_UNIFORM = 0x0040;
@@ -235,7 +207,6 @@ export const BUFFERUSAGE_UNIFORM = 0x0040;
  * compatibility when used as a storage buffer.
  * This flag is hidden as it's automatically used by the StorageBuffer constructor.
  *
- * @type {number}
  * @category Graphics
  * @ignore
  */
@@ -246,7 +217,6 @@ export const BUFFERUSAGE_STORAGE = 0x0080;
  * command arguments.
  * TODO: This flag is hidden till the feature is implemented.
  *
- * @type {number}
  * @category Graphics
  * @ignore
  */
@@ -255,7 +225,6 @@ export const BUFFERUSAGE_INDIRECT = 0x0100;
 /**
  * The data store contents will be modified once and used many times.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFER_STATIC = 0;
@@ -263,7 +232,6 @@ export const BUFFER_STATIC = 0;
 /**
  * The data store contents will be modified repeatedly and used many times.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFER_DYNAMIC = 1;
@@ -271,7 +239,6 @@ export const BUFFER_DYNAMIC = 1;
 /**
  * The data store contents will be modified once and used at most a few times.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFER_STREAM = 2;
@@ -280,7 +247,6 @@ export const BUFFER_STREAM = 2;
  * The data store contents will be modified repeatedly on the GPU and used many times. Optimal for
  * transform feedback usage.
  *
- * @type {number}
  * @category Graphics
  */
 export const BUFFER_GPUDYNAMIC = 3;
@@ -288,7 +254,6 @@ export const BUFFER_GPUDYNAMIC = 3;
 /**
  * Clear the color buffer.
  *
- * @type {number}
  * @category Graphics
  */
 export const CLEARFLAG_COLOR = 1;
@@ -296,7 +261,6 @@ export const CLEARFLAG_COLOR = 1;
 /**
  * Clear the depth buffer.
  *
- * @type {number}
  * @category Graphics
  */
 export const CLEARFLAG_DEPTH = 2;
@@ -304,7 +268,6 @@ export const CLEARFLAG_DEPTH = 2;
 /**
  * Clear the stencil buffer.
  *
- * @type {number}
  * @category Graphics
  */
 export const CLEARFLAG_STENCIL = 4;
@@ -312,7 +275,6 @@ export const CLEARFLAG_STENCIL = 4;
 /**
  * The positive X face of a cubemap.
  *
- * @type {number}
  * @category Graphics
  */
 export const CUBEFACE_POSX = 0;
@@ -320,7 +282,6 @@ export const CUBEFACE_POSX = 0;
 /**
  * The negative X face of a cubemap.
  *
- * @type {number}
  * @category Graphics
  */
 export const CUBEFACE_NEGX = 1;
@@ -328,7 +289,6 @@ export const CUBEFACE_NEGX = 1;
 /**
  * The positive Y face of a cubemap.
  *
- * @type {number}
  * @category Graphics
  */
 export const CUBEFACE_POSY = 2;
@@ -336,7 +296,6 @@ export const CUBEFACE_POSY = 2;
 /**
  * The negative Y face of a cubemap.
  *
- * @type {number}
  * @category Graphics
  */
 export const CUBEFACE_NEGY = 3;
@@ -344,7 +303,6 @@ export const CUBEFACE_NEGY = 3;
 /**
  * The positive Z face of a cubemap.
  *
- * @type {number}
  * @category Graphics
  */
 export const CUBEFACE_POSZ = 4;
@@ -352,7 +310,6 @@ export const CUBEFACE_POSZ = 4;
 /**
  * The negative Z face of a cubemap.
  *
- * @type {number}
  * @category Graphics
  */
 export const CUBEFACE_NEGZ = 5;
@@ -360,7 +317,6 @@ export const CUBEFACE_NEGZ = 5;
 /**
  * No triangles are culled.
  *
- * @type {number}
  * @category Graphics
  */
 export const CULLFACE_NONE = 0;
@@ -368,7 +324,6 @@ export const CULLFACE_NONE = 0;
 /**
  * Triangles facing away from the view direction are culled.
  *
- * @type {number}
  * @category Graphics
  */
 export const CULLFACE_BACK = 1;
@@ -376,7 +331,6 @@ export const CULLFACE_BACK = 1;
 /**
  * Triangles facing the view direction are culled.
  *
- * @type {number}
  * @category Graphics
  */
 export const CULLFACE_FRONT = 2;
@@ -385,7 +339,6 @@ export const CULLFACE_FRONT = 2;
  * Triangles are culled regardless of their orientation with respect to the view direction. Note
  * that point or line primitives are unaffected by this render state.
  *
- * @type {number}
  * @ignore
  * @category Graphics
  */
@@ -394,7 +347,6 @@ export const CULLFACE_FRONTANDBACK = 3;
 /**
  * Point sample filtering.
  *
- * @type {number}
  * @category Graphics
  */
 export const FILTER_NEAREST = 0;
@@ -402,7 +354,6 @@ export const FILTER_NEAREST = 0;
 /**
  * Bilinear filtering.
  *
- * @type {number}
  * @category Graphics
  */
 export const FILTER_LINEAR = 1;
@@ -410,7 +361,6 @@ export const FILTER_LINEAR = 1;
 /**
  * Use the nearest neighbor in the nearest mipmap level.
  *
- * @type {number}
  * @category Graphics
  */
 export const FILTER_NEAREST_MIPMAP_NEAREST = 2;
@@ -418,7 +368,6 @@ export const FILTER_NEAREST_MIPMAP_NEAREST = 2;
 /**
  * Linearly interpolate in the nearest mipmap level.
  *
- * @type {number}
  * @category Graphics
  */
 export const FILTER_NEAREST_MIPMAP_LINEAR = 3;
@@ -426,7 +375,6 @@ export const FILTER_NEAREST_MIPMAP_LINEAR = 3;
 /**
  * Use the nearest neighbor after linearly interpolating between mipmap levels.
  *
- * @type {number}
  * @category Graphics
  */
 export const FILTER_LINEAR_MIPMAP_NEAREST = 4;
@@ -434,7 +382,6 @@ export const FILTER_LINEAR_MIPMAP_NEAREST = 4;
 /**
  * Linearly interpolate both the mipmap levels and between texels.
  *
- * @type {number}
  * @category Graphics
  */
 export const FILTER_LINEAR_MIPMAP_LINEAR = 5;
@@ -442,7 +389,6 @@ export const FILTER_LINEAR_MIPMAP_LINEAR = 5;
 /**
  * Never pass.
  *
- * @type {number}
  * @category Graphics
  */
 export const FUNC_NEVER = 0;
@@ -450,7 +396,6 @@ export const FUNC_NEVER = 0;
 /**
  * Pass if (ref & mask) < (stencil & mask).
  *
- * @type {number}
  * @category Graphics
  */
 export const FUNC_LESS = 1;
@@ -458,7 +403,6 @@ export const FUNC_LESS = 1;
 /**
  * Pass if (ref & mask) == (stencil & mask).
  *
- * @type {number}
  * @category Graphics
  */
 export const FUNC_EQUAL = 2;
@@ -466,7 +410,6 @@ export const FUNC_EQUAL = 2;
 /**
  * Pass if (ref & mask) <= (stencil & mask).
  *
- * @type {number}
  * @category Graphics
  */
 export const FUNC_LESSEQUAL = 3;
@@ -474,7 +417,6 @@ export const FUNC_LESSEQUAL = 3;
 /**
  * Pass if (ref & mask) > (stencil & mask).
  *
- * @type {number}
  * @category Graphics
  */
 export const FUNC_GREATER = 4;
@@ -482,7 +424,6 @@ export const FUNC_GREATER = 4;
 /**
  * Pass if (ref & mask) != (stencil & mask).
  *
- * @type {number}
  * @category Graphics
  */
 export const FUNC_NOTEQUAL = 5;
@@ -490,7 +431,6 @@ export const FUNC_NOTEQUAL = 5;
 /**
  * Pass if (ref & mask) >= (stencil & mask).
  *
- * @type {number}
  * @category Graphics
  */
 export const FUNC_GREATEREQUAL = 6;
@@ -498,7 +438,6 @@ export const FUNC_GREATEREQUAL = 6;
 /**
  * Always pass.
  *
- * @type {number}
  * @category Graphics
  */
 export const FUNC_ALWAYS = 7;
@@ -506,7 +445,6 @@ export const FUNC_ALWAYS = 7;
 /**
  * 8-bit unsigned vertex indices (0 to 255).
  *
- * @type {number}
  * @category Graphics
  */
 export const INDEXFORMAT_UINT8 = 0;
@@ -514,7 +452,6 @@ export const INDEXFORMAT_UINT8 = 0;
 /**
  * 16-bit unsigned vertex indices (0 to 65,535).
  *
- * @type {number}
  * @category Graphics
  */
 export const INDEXFORMAT_UINT16 = 1;
@@ -522,7 +459,6 @@ export const INDEXFORMAT_UINT16 = 1;
 /**
  * 32-bit unsigned vertex indices (0 to 4,294,967,295).
  *
- * @type {number}
  * @category Graphics
  */
 export const INDEXFORMAT_UINT32 = 2;
@@ -534,7 +470,6 @@ export const PIXELFORMAT_LA8 = 2;
 /**
  * 16-bit RGB (5-bits for red channel, 6 for green and 5 for blue).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGB565 = 3;
@@ -542,7 +477,6 @@ export const PIXELFORMAT_RGB565 = 3;
 /**
  * 16-bit RGBA (5-bits for red channel, 5 for green, 5 for blue with 1-bit alpha).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA5551 = 4;
@@ -550,7 +484,6 @@ export const PIXELFORMAT_RGBA5551 = 4;
 /**
  * 16-bit RGBA (4-bits for red channel, 4 for green, 4 for blue with 4-bit alpha).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA4 = 5;
@@ -558,7 +491,6 @@ export const PIXELFORMAT_RGBA4 = 5;
 /**
  * 24-bit RGB (8-bits for red channel, 8 for green and 8 for blue).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGB8 = 6;
@@ -566,7 +498,6 @@ export const PIXELFORMAT_RGB8 = 6;
 /**
  * 32-bit RGBA (8-bits for red channel, 8 for green, 8 for blue with 8-bit alpha).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA8 = 7;
@@ -575,7 +506,6 @@ export const PIXELFORMAT_RGBA8 = 7;
  * Block compressed format storing 16 input pixels in 64 bits of output, consisting of two 16-bit
  * RGB 5:6:5 color values and a 4x4 two bit lookup table.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_DXT1 = 8;
@@ -585,7 +515,6 @@ export const PIXELFORMAT_DXT1 = 8;
  * bits of output, consisting of 64 bits of alpha channel data (4 bits for each pixel) followed by
  * 64 bits of color data; encoded the same way as DXT1.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_DXT3 = 9;
@@ -595,7 +524,6 @@ export const PIXELFORMAT_DXT3 = 9;
  * of alpha channel data (two 8 bit alpha values and a 4x4 3 bit lookup table) followed by 64 bits
  * of color data (encoded the same way as DXT1).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_DXT5 = 10;
@@ -603,7 +531,6 @@ export const PIXELFORMAT_DXT5 = 10;
 /**
  * 16-bit floating point RGB (16-bit float for each red, green and blue channels).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGB16F = 11;
@@ -611,7 +538,6 @@ export const PIXELFORMAT_RGB16F = 11;
 /**
  * 16-bit floating point RGBA (16-bit float for each red, green, blue and alpha channels).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA16F = 12;
@@ -619,7 +545,6 @@ export const PIXELFORMAT_RGBA16F = 12;
 /**
  * 32-bit floating point RGB (32-bit float for each red, green and blue channels).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGB32F = 13;
@@ -627,7 +552,6 @@ export const PIXELFORMAT_RGB32F = 13;
 /**
  * 32-bit floating point RGBA (32-bit float for each red, green, blue and alpha channels).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA32F = 14;
@@ -635,7 +559,6 @@ export const PIXELFORMAT_RGBA32F = 14;
 /**
  * 32-bit floating point single channel format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_R32F = 15;
@@ -643,7 +566,6 @@ export const PIXELFORMAT_R32F = 15;
 /**
  * A readable depth buffer format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_DEPTH = 16;
@@ -651,7 +573,6 @@ export const PIXELFORMAT_DEPTH = 16;
 /**
  * A readable depth/stencil buffer format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_DEPTHSTENCIL = 17;
@@ -660,7 +581,6 @@ export const PIXELFORMAT_DEPTHSTENCIL = 17;
  * A floating-point color-only format with 11 bits for red and green channels and 10 bits for the
  * blue channel.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_111110F = 18;
@@ -668,7 +588,6 @@ export const PIXELFORMAT_111110F = 18;
 /**
  * Color-only sRGB format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_SRGB8 = 19;
@@ -676,7 +595,6 @@ export const PIXELFORMAT_SRGB8 = 19;
 /**
  * Color sRGB format with additional alpha channel.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_SRGBA8 = 20;
@@ -684,7 +602,6 @@ export const PIXELFORMAT_SRGBA8 = 20;
 /**
  * ETC1 compressed format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_ETC1 = 21;
@@ -692,7 +609,6 @@ export const PIXELFORMAT_ETC1 = 21;
 /**
  * ETC2 (RGB) compressed format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_ETC2_RGB = 22;
@@ -700,7 +616,6 @@ export const PIXELFORMAT_ETC2_RGB = 22;
 /**
  * ETC2 (RGBA) compressed format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_ETC2_RGBA = 23;
@@ -708,7 +623,6 @@ export const PIXELFORMAT_ETC2_RGBA = 23;
 /**
  * PVRTC (2BPP RGB) compressed format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_PVRTC_2BPP_RGB_1 = 24;
@@ -716,7 +630,6 @@ export const PIXELFORMAT_PVRTC_2BPP_RGB_1 = 24;
 /**
  * PVRTC (2BPP RGBA) compressed format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_PVRTC_2BPP_RGBA_1 = 25;
@@ -724,7 +637,6 @@ export const PIXELFORMAT_PVRTC_2BPP_RGBA_1 = 25;
 /**
  * PVRTC (4BPP RGB) compressed format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_PVRTC_4BPP_RGB_1 = 26;
@@ -732,7 +644,6 @@ export const PIXELFORMAT_PVRTC_4BPP_RGB_1 = 26;
 /**
  * PVRTC (4BPP RGBA) compressed format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_PVRTC_4BPP_RGBA_1 = 27;
@@ -740,7 +651,6 @@ export const PIXELFORMAT_PVRTC_4BPP_RGBA_1 = 27;
 /**
  * ATC compressed format with alpha channel in blocks of 4x4.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_ASTC_4x4 = 28;
@@ -748,7 +658,6 @@ export const PIXELFORMAT_ASTC_4x4 = 28;
 /**
  * ATC compressed format with no alpha channel.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_ATC_RGB = 29;
@@ -756,7 +665,6 @@ export const PIXELFORMAT_ATC_RGB = 29;
 /**
  * ATC compressed format with alpha channel.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_ATC_RGBA = 30;
@@ -765,7 +673,6 @@ export const PIXELFORMAT_ATC_RGBA = 30;
  * 32-bit BGRA (8-bits for blue channel, 8 for green, 8 for red with 8-bit alpha). This is an
  * internal format used by the WebGPU's backbuffer only.
  *
- * @type {number}
  * @ignore
  * @category Graphics
  */
@@ -774,7 +681,6 @@ export const PIXELFORMAT_BGRA8 = 31;
 /**
  * 8-bit signed integer single-channel (R) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_R8I = 32;
@@ -782,7 +688,6 @@ export const PIXELFORMAT_R8I = 32;
 /**
  * 8-bit unsigned integer single-channel (R) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_R8U = 33;
@@ -790,7 +695,6 @@ export const PIXELFORMAT_R8U = 33;
 /**
  * 16-bit signed integer single-channel (R) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_R16I = 34;
@@ -798,7 +702,6 @@ export const PIXELFORMAT_R16I = 34;
 /**
  * 16-bit unsigned integer single-channel (R) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_R16U = 35;
@@ -806,7 +709,6 @@ export const PIXELFORMAT_R16U = 35;
 /**
  * 32-bit signed integer single-channel (R) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_R32I = 36;
@@ -814,7 +716,6 @@ export const PIXELFORMAT_R32I = 36;
 /**
  * 32-bit unsigned integer single-channel (R) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_R32U = 37;
@@ -822,7 +723,6 @@ export const PIXELFORMAT_R32U = 37;
 /**
  * 8-bit per-channel signed integer (RG) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RG8I = 38;
@@ -830,7 +730,6 @@ export const PIXELFORMAT_RG8I = 38;
 /**
  * 8-bit per-channel unsigned integer (RG) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RG8U = 39;
@@ -838,7 +737,6 @@ export const PIXELFORMAT_RG8U = 39;
 /**
  * 16-bit per-channel signed integer (RG) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RG16I = 40;
@@ -846,7 +744,6 @@ export const PIXELFORMAT_RG16I = 40;
 /**
  * 16-bit per-channel unsigned integer (RG) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RG16U = 41;
@@ -854,7 +751,6 @@ export const PIXELFORMAT_RG16U = 41;
 /**
  * 32-bit per-channel signed integer (RG) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RG32I = 42;
@@ -862,7 +758,6 @@ export const PIXELFORMAT_RG32I = 42;
 /**
  * 32-bit per-channel unsigned integer (RG) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RG32U = 43;
@@ -870,7 +765,6 @@ export const PIXELFORMAT_RG32U = 43;
 /**
  * 8-bit per-channel signed integer (RGBA) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA8I = 44;
@@ -878,7 +772,6 @@ export const PIXELFORMAT_RGBA8I = 44;
 /**
  * 8-bit per-channel unsigned integer (RGBA) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA8U = 45;
@@ -886,7 +779,6 @@ export const PIXELFORMAT_RGBA8U = 45;
 /**
  * 16-bit per-channel signed integer (RGBA) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA16I = 46;
@@ -894,7 +786,6 @@ export const PIXELFORMAT_RGBA16I = 46;
 /**
  * 16-bit per-channel unsigned integer (RGBA) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA16U = 47;
@@ -902,7 +793,6 @@ export const PIXELFORMAT_RGBA16U = 47;
 /**
  * 32-bit per-channel signed integer (RGBA) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA32I = 48;
@@ -910,7 +800,6 @@ export const PIXELFORMAT_RGBA32I = 48;
 /**
  * 32-bit per-channel unsigned integer (RGBA) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RGBA32U = 49;
@@ -918,7 +807,6 @@ export const PIXELFORMAT_RGBA32U = 49;
 /**
  * 16-bit floating point R (16-bit float for red channel).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_R16F = 50;
@@ -926,7 +814,6 @@ export const PIXELFORMAT_R16F = 50;
 /**
  * 16-bit floating point RG (16-bit float for each red and green channels).
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RG16F = 51;
@@ -934,7 +821,6 @@ export const PIXELFORMAT_RG16F = 51;
 /**
  * 8-bit per-channel (R) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_R8 = 52;
@@ -942,7 +828,6 @@ export const PIXELFORMAT_R8 = 52;
 /**
  * 8-bit per-channel (RG) format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_RG8 = 53;
@@ -950,7 +835,6 @@ export const PIXELFORMAT_RG8 = 53;
 /**
  * Format equivalent to {@link PIXELFORMAT_DXT1} but sampled in linear color space.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_DXT1_SRGB = 54;
@@ -958,7 +842,6 @@ export const PIXELFORMAT_DXT1_SRGB = 54;
 /**
  * Format equivalent to {@link PIXELFORMAT_DXT3} but sampled in linear color space.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_DXT3_SRGBA = 55;
@@ -966,7 +849,6 @@ export const PIXELFORMAT_DXT3_SRGBA = 55;
 /**
  * Format equivalent to {@link PIXELFORMAT_DXT5} but sampled in linear color space.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_DXT5_SRGBA = 56;
@@ -974,7 +856,6 @@ export const PIXELFORMAT_DXT5_SRGBA = 56;
 /**
  * Format equivalent to {@link PIXELFORMAT_ETC2_RGB} but sampled in linear color space.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_ETC2_SRGB = 61;
@@ -982,7 +863,6 @@ export const PIXELFORMAT_ETC2_SRGB = 61;
 /**
  * Format equivalent to {@link PIXELFORMAT_ETC2_RGBA} but sampled in linear color space.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_ETC2_SRGBA = 62;
@@ -990,7 +870,6 @@ export const PIXELFORMAT_ETC2_SRGBA = 62;
 /**
  * Format equivalent to {@link PIXELFORMAT_ASTC_4x4} but sampled in linear color space.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_ASTC_4x4_SRGB = 63;
@@ -998,7 +877,6 @@ export const PIXELFORMAT_ASTC_4x4_SRGB = 63;
 /**
  * 32-bit BGRA sRGB format. This is an internal format used by the WebGPU's backbuffer only.
  *
- * @type {number}
  * @ignore
  * @category Graphics
  */
@@ -1007,7 +885,6 @@ export const PIXELFORMAT_SBGRA8 = 64;
 /**
  * Compressed high dynamic range signed floating point format storing RGB values.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_BC6F = 65;
@@ -1015,7 +892,6 @@ export const PIXELFORMAT_BC6F = 65;
 /**
  * Compressed high dynamic range unsigned floating point format storing RGB values.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_BC6UF = 66;
@@ -1023,7 +899,6 @@ export const PIXELFORMAT_BC6UF = 66;
 /**
  * Compressed 8-bit fixed-point data. Each 4x4 block of texels consists of 128 bits of RGBA data.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_BC7 = 67;
@@ -1032,7 +907,6 @@ export const PIXELFORMAT_BC7 = 67;
  * Compressed 8-bit fixed-point data. Each 4x4 block of texels consists of 128 bits of SRGB_ALPHA
  * data.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_BC7_SRGBA = 68;
@@ -1040,7 +914,6 @@ export const PIXELFORMAT_BC7_SRGBA = 68;
 /**
  * A 16-bit depth buffer format.
  *
- * @type {number}
  * @category Graphics
  */
 export const PIXELFORMAT_DEPTH16 = 69;
@@ -1232,7 +1105,6 @@ export const getPixelFormatArrayType = (format) => {
 /**
  * List of distinct points.
  *
- * @type {number}
  * @category Graphics
  */
 export const PRIMITIVE_POINTS = 0;
@@ -1240,7 +1112,6 @@ export const PRIMITIVE_POINTS = 0;
 /**
  * Discrete list of line segments.
  *
- * @type {number}
  * @category Graphics
  */
 export const PRIMITIVE_LINES = 1;
@@ -1249,7 +1120,6 @@ export const PRIMITIVE_LINES = 1;
  * List of points that are linked sequentially by line segments, with a closing line segment
  * between the last and first points.
  *
- * @type {number}
  * @category Graphics
  */
 export const PRIMITIVE_LINELOOP = 2;
@@ -1257,7 +1127,6 @@ export const PRIMITIVE_LINELOOP = 2;
 /**
  * List of points that are linked sequentially by line segments.
  *
- * @type {number}
  * @category Graphics
  */
 export const PRIMITIVE_LINESTRIP = 3;
@@ -1265,7 +1134,6 @@ export const PRIMITIVE_LINESTRIP = 3;
 /**
  * Discrete list of triangles.
  *
- * @type {number}
  * @category Graphics
  */
 export const PRIMITIVE_TRIANGLES = 4;
@@ -1273,7 +1141,6 @@ export const PRIMITIVE_TRIANGLES = 4;
 /**
  * Connected strip of triangles where a specified vertex forms a triangle using the previous two.
  *
- * @type {number}
  * @category Graphics
  */
 export const PRIMITIVE_TRISTRIP = 5;
@@ -1281,7 +1148,6 @@ export const PRIMITIVE_TRISTRIP = 5;
 /**
  * Connected fan of triangles where the first vertex forms triangles with the following pairs of vertices.
  *
- * @type {number}
  * @category Graphics
  */
 export const PRIMITIVE_TRIFAN = 6;
@@ -1289,7 +1155,6 @@ export const PRIMITIVE_TRIFAN = 6;
 /**
  * Vertex attribute to be treated as a position.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_POSITION = 'POSITION';
@@ -1297,7 +1162,6 @@ export const SEMANTIC_POSITION = 'POSITION';
 /**
  * Vertex attribute to be treated as a normal.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_NORMAL = 'NORMAL';
@@ -1305,7 +1169,6 @@ export const SEMANTIC_NORMAL = 'NORMAL';
 /**
  * Vertex attribute to be treated as a tangent.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_TANGENT = 'TANGENT';
@@ -1313,7 +1176,6 @@ export const SEMANTIC_TANGENT = 'TANGENT';
 /**
  * Vertex attribute to be treated as skin blend weights.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_BLENDWEIGHT = 'BLENDWEIGHT';
@@ -1321,7 +1183,6 @@ export const SEMANTIC_BLENDWEIGHT = 'BLENDWEIGHT';
 /**
  * Vertex attribute to be treated as skin blend indices.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_BLENDINDICES = 'BLENDINDICES';
@@ -1329,7 +1190,6 @@ export const SEMANTIC_BLENDINDICES = 'BLENDINDICES';
 /**
  * Vertex attribute to be treated as a color.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_COLOR = 'COLOR';
@@ -1340,7 +1200,6 @@ export const SEMANTIC_TEXCOORD = 'TEXCOORD';
 /**
  * Vertex attribute to be treated as a texture coordinate (set 0).
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_TEXCOORD0 = 'TEXCOORD0';
@@ -1348,7 +1207,6 @@ export const SEMANTIC_TEXCOORD0 = 'TEXCOORD0';
 /**
  * Vertex attribute to be treated as a texture coordinate (set 1).
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_TEXCOORD1 = 'TEXCOORD1';
@@ -1356,7 +1214,6 @@ export const SEMANTIC_TEXCOORD1 = 'TEXCOORD1';
 /**
  * Vertex attribute to be treated as a texture coordinate (set 2).
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_TEXCOORD2 = 'TEXCOORD2';
@@ -1364,7 +1221,6 @@ export const SEMANTIC_TEXCOORD2 = 'TEXCOORD2';
 /**
  * Vertex attribute to be treated as a texture coordinate (set 3).
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_TEXCOORD3 = 'TEXCOORD3';
@@ -1372,7 +1228,6 @@ export const SEMANTIC_TEXCOORD3 = 'TEXCOORD3';
 /**
  * Vertex attribute to be treated as a texture coordinate (set 4).
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_TEXCOORD4 = 'TEXCOORD4';
@@ -1380,7 +1235,6 @@ export const SEMANTIC_TEXCOORD4 = 'TEXCOORD4';
 /**
  * Vertex attribute to be treated as a texture coordinate (set 5).
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_TEXCOORD5 = 'TEXCOORD5';
@@ -1388,7 +1242,6 @@ export const SEMANTIC_TEXCOORD5 = 'TEXCOORD5';
 /**
  * Vertex attribute to be treated as a texture coordinate (set 6).
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_TEXCOORD6 = 'TEXCOORD6';
@@ -1396,7 +1249,6 @@ export const SEMANTIC_TEXCOORD6 = 'TEXCOORD6';
 /**
  * Vertex attribute to be treated as a texture coordinate (set 7).
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_TEXCOORD7 = 'TEXCOORD7';
@@ -1404,7 +1256,6 @@ export const SEMANTIC_TEXCOORD7 = 'TEXCOORD7';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR0 = 'ATTR0';
@@ -1412,7 +1263,6 @@ export const SEMANTIC_ATTR0 = 'ATTR0';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR1 = 'ATTR1';
@@ -1420,7 +1270,6 @@ export const SEMANTIC_ATTR1 = 'ATTR1';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR2 = 'ATTR2';
@@ -1428,7 +1277,6 @@ export const SEMANTIC_ATTR2 = 'ATTR2';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR3 = 'ATTR3';
@@ -1436,7 +1284,6 @@ export const SEMANTIC_ATTR3 = 'ATTR3';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR4 = 'ATTR4';
@@ -1444,7 +1291,6 @@ export const SEMANTIC_ATTR4 = 'ATTR4';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR5 = 'ATTR5';
@@ -1452,7 +1298,6 @@ export const SEMANTIC_ATTR5 = 'ATTR5';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR6 = 'ATTR6';
@@ -1460,7 +1305,6 @@ export const SEMANTIC_ATTR6 = 'ATTR6';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR7 = 'ATTR7';
@@ -1468,7 +1312,6 @@ export const SEMANTIC_ATTR7 = 'ATTR7';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR8 = 'ATTR8';
@@ -1476,7 +1319,6 @@ export const SEMANTIC_ATTR8 = 'ATTR8';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR9 = 'ATTR9';
@@ -1484,7 +1326,6 @@ export const SEMANTIC_ATTR9 = 'ATTR9';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR10 = 'ATTR10';
@@ -1492,7 +1333,6 @@ export const SEMANTIC_ATTR10 = 'ATTR10';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR11 = 'ATTR11';
@@ -1500,7 +1340,6 @@ export const SEMANTIC_ATTR11 = 'ATTR11';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR12 = 'ATTR12';
@@ -1508,7 +1347,6 @@ export const SEMANTIC_ATTR12 = 'ATTR12';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR13 = 'ATTR13';
@@ -1516,7 +1354,6 @@ export const SEMANTIC_ATTR13 = 'ATTR13';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR14 = 'ATTR14';
@@ -1524,7 +1361,6 @@ export const SEMANTIC_ATTR14 = 'ATTR14';
 /**
  * Vertex attribute with a user defined semantic.
  *
- * @type {string}
  * @category Graphics
  */
 export const SEMANTIC_ATTR15 = 'ATTR15';
@@ -1534,7 +1370,6 @@ export const SHADERTAG_MATERIAL = 1;
 /**
  * Don't change the stencil buffer value.
  *
- * @type {number}
  * @category Graphics
  */
 export const STENCILOP_KEEP = 0;
@@ -1542,7 +1377,6 @@ export const STENCILOP_KEEP = 0;
 /**
  * Set value to zero.
  *
- * @type {number}
  * @category Graphics
  */
 export const STENCILOP_ZERO = 1;
@@ -1550,7 +1384,6 @@ export const STENCILOP_ZERO = 1;
 /**
  * Replace value with the reference value (see {@link StencilParameters}).
  *
- * @type {number}
  * @category Graphics
  */
 export const STENCILOP_REPLACE = 2;
@@ -1558,7 +1391,6 @@ export const STENCILOP_REPLACE = 2;
 /**
  * Increment the value.
  *
- * @type {number}
  * @category Graphics
  */
 export const STENCILOP_INCREMENT = 3;
@@ -1566,7 +1398,6 @@ export const STENCILOP_INCREMENT = 3;
 /**
  * Increment the value but wrap it to zero when it's larger than a maximum representable value.
  *
- * @type {number}
  * @category Graphics
  */
 export const STENCILOP_INCREMENTWRAP = 4;
@@ -1574,7 +1405,6 @@ export const STENCILOP_INCREMENTWRAP = 4;
 /**
  * Decrement the value.
  *
- * @type {number}
  * @category Graphics
  */
 export const STENCILOP_DECREMENT = 5;
@@ -1582,7 +1412,6 @@ export const STENCILOP_DECREMENT = 5;
 /**
  * Decrement the value but wrap it to a maximum representable value if the current value is 0.
  *
- * @type {number}
  * @category Graphics
  */
 export const STENCILOP_DECREMENTWRAP = 6;
@@ -1590,7 +1419,6 @@ export const STENCILOP_DECREMENTWRAP = 6;
 /**
  * Invert the value bitwise.
  *
- * @type {number}
  * @category Graphics
  */
 export const STENCILOP_INVERT = 7;
@@ -1598,7 +1426,6 @@ export const STENCILOP_INVERT = 7;
 /**
  * The texture is not in a locked state.
  *
- * @type {number}
  * @category Graphics
  */
 export const TEXTURELOCK_NONE = 0;
@@ -1606,7 +1433,6 @@ export const TEXTURELOCK_NONE = 0;
 /**
  * Read only. Any changes to the locked mip level's pixels will not update the texture.
  *
- * @type {number}
  * @category Graphics
  */
 export const TEXTURELOCK_READ = 1;
@@ -1614,7 +1440,6 @@ export const TEXTURELOCK_READ = 1;
 /**
  * Write only. The contents of the specified mip level will be entirely replaced.
  *
- * @type {number}
  * @category Graphics
  */
 export const TEXTURELOCK_WRITE = 2;
@@ -1622,7 +1447,6 @@ export const TEXTURELOCK_WRITE = 2;
 /**
  * Texture is a default type.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTURETYPE_DEFAULT = 'default';
@@ -1630,7 +1454,6 @@ export const TEXTURETYPE_DEFAULT = 'default';
 /**
  * Texture stores high dynamic range data in RGBM format.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTURETYPE_RGBM = 'rgbm';
@@ -1638,7 +1461,6 @@ export const TEXTURETYPE_RGBM = 'rgbm';
 /**
  * Texture stores high dynamic range data in RGBE format.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTURETYPE_RGBE = 'rgbe';
@@ -1646,7 +1468,6 @@ export const TEXTURETYPE_RGBE = 'rgbe';
 /**
  * Texture stores high dynamic range data in RGBP encoding.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTURETYPE_RGBP = 'rgbp';
@@ -1656,7 +1477,6 @@ export const TEXTURETYPE_RGBP = 'rgbp';
  * maps. The R component is stored in alpha and G is stored in RGB. This packing can result in
  * higher quality when the texture data is compressed.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTURETYPE_SWIZZLEGGGR = 'swizzleGGGR';
@@ -1669,7 +1489,6 @@ export const TEXHINT_LIGHTMAP = 3;
 /**
  * Texture data is stored in a 1-dimensional texture.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTUREDIMENSION_1D = '1d';
@@ -1677,7 +1496,6 @@ export const TEXTUREDIMENSION_1D = '1d';
 /**
  * Texture data is stored in a 2-dimensional texture.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTUREDIMENSION_2D = '2d';
@@ -1685,7 +1503,6 @@ export const TEXTUREDIMENSION_2D = '2d';
 /**
  * Texture data is stored in an array of 2-dimensional textures.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTUREDIMENSION_2D_ARRAY = '2d-array';
@@ -1693,7 +1510,6 @@ export const TEXTUREDIMENSION_2D_ARRAY = '2d-array';
 /**
  * Texture data is stored in a cube texture.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTUREDIMENSION_CUBE = 'cube';
@@ -1701,7 +1517,6 @@ export const TEXTUREDIMENSION_CUBE = 'cube';
 /**
  * Texture data is stored in an array of cube textures.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTUREDIMENSION_CUBE_ARRAY = 'cube-array';
@@ -1709,7 +1524,6 @@ export const TEXTUREDIMENSION_CUBE_ARRAY = 'cube-array';
 /**
  * Texture data is stored in a 3-dimensional texture.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTUREDIMENSION_3D = '3d';
@@ -1718,7 +1532,6 @@ export const TEXTUREDIMENSION_3D = '3d';
  * A sampler type of a texture that contains floating-point data. Typically stored for color
  * textures, where data can be filtered.
  *
- * @type {number}
  * @category Graphics
  */
 export const SAMPLETYPE_FLOAT = 0;
@@ -1727,7 +1540,6 @@ export const SAMPLETYPE_FLOAT = 0;
  * A sampler type of a texture that contains floating-point data, but cannot be filtered. Typically
  * used for textures storing data that cannot be interpolated.
  *
- * @type {number}
  * @category Graphics
  */
 export const SAMPLETYPE_UNFILTERABLE_FLOAT = 1;
@@ -1735,7 +1547,6 @@ export const SAMPLETYPE_UNFILTERABLE_FLOAT = 1;
 /**
  * A sampler type of a texture that contains depth data. Typically used for depth textures.
  *
- * @type {number}
  * @category Graphics
  */
 export const SAMPLETYPE_DEPTH = 2;
@@ -1743,7 +1554,6 @@ export const SAMPLETYPE_DEPTH = 2;
 /**
  * A sampler type of a texture that contains signed integer data.
  *
- * @type {number}
  * @category Graphics
  */
 export const SAMPLETYPE_INT = 3;
@@ -1751,7 +1561,6 @@ export const SAMPLETYPE_INT = 3;
 /**
  * A sampler type of a texture that contains unsigned integer data.
  *
- * @type {number}
  * @category Graphics
  */
 export const SAMPLETYPE_UINT = 4;
@@ -1759,7 +1568,6 @@ export const SAMPLETYPE_UINT = 4;
 /**
  * Texture data is not stored a specific projection format.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTUREPROJECTION_NONE = 'none';
@@ -1767,7 +1575,6 @@ export const TEXTUREPROJECTION_NONE = 'none';
 /**
  * Texture data is stored in cubemap projection format.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTUREPROJECTION_CUBE = 'cube';
@@ -1775,7 +1582,6 @@ export const TEXTUREPROJECTION_CUBE = 'cube';
 /**
  * Texture data is stored in equirectangular projection format.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTUREPROJECTION_EQUIRECT = 'equirect';
@@ -1783,7 +1589,6 @@ export const TEXTUREPROJECTION_EQUIRECT = 'equirect';
 /**
  * Texture data is stored in octahedral projection format.
  *
- * @type {string}
  * @category Graphics
  */
 export const TEXTUREPROJECTION_OCTAHEDRAL = 'octahedral';
@@ -1791,7 +1596,6 @@ export const TEXTUREPROJECTION_OCTAHEDRAL = 'octahedral';
 /**
  * Shader source code uses GLSL language.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERLANGUAGE_GLSL = 'glsl';
@@ -1799,7 +1603,6 @@ export const SHADERLANGUAGE_GLSL = 'glsl';
 /**
  * Shader source code uses WGSL language.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERLANGUAGE_WGSL = 'wgsl';
@@ -1807,7 +1610,6 @@ export const SHADERLANGUAGE_WGSL = 'wgsl';
 /**
  * Signed byte vertex element type.
  *
- * @type {number}
  * @category Graphics
  */
 export const TYPE_INT8 = 0;
@@ -1815,7 +1617,6 @@ export const TYPE_INT8 = 0;
 /**
  * Unsigned byte vertex element type.
  *
- * @type {number}
  * @category Graphics
  */
 export const TYPE_UINT8 = 1;
@@ -1823,7 +1624,6 @@ export const TYPE_UINT8 = 1;
 /**
  * Signed short vertex element type.
  *
- * @type {number}
  * @category Graphics
  */
 export const TYPE_INT16 = 2;
@@ -1831,7 +1631,6 @@ export const TYPE_INT16 = 2;
 /**
  * Unsigned short vertex element type.
  *
- * @type {number}
  * @category Graphics
  */
 export const TYPE_UINT16 = 3;
@@ -1839,7 +1638,6 @@ export const TYPE_UINT16 = 3;
 /**
  * Signed integer vertex element type.
  *
- * @type {number}
  * @category Graphics
  */
 export const TYPE_INT32 = 4;
@@ -1847,7 +1645,6 @@ export const TYPE_INT32 = 4;
 /**
  * Unsigned integer vertex element type.
  *
- * @type {number}
  * @category Graphics
  */
 export const TYPE_UINT32 = 5;
@@ -1855,7 +1652,6 @@ export const TYPE_UINT32 = 5;
 /**
  * Floating point vertex element type.
  *
- * @type {number}
  * @category Graphics
  */
 export const TYPE_FLOAT32 = 6;
@@ -1863,7 +1659,6 @@ export const TYPE_FLOAT32 = 6;
 /**
  * 16-bit floating point vertex element type.
  *
- * @type {number}
  * @category Graphics
  */
 export const TYPE_FLOAT16 = 7;
@@ -1876,7 +1671,6 @@ export const TYPE_FLOAT16 = 7;
 /**
  * Boolean uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_BOOL = 0;
@@ -1884,7 +1678,6 @@ export const UNIFORMTYPE_BOOL = 0;
 /**
  * Integer uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_INT = 1;
@@ -1892,7 +1685,6 @@ export const UNIFORMTYPE_INT = 1;
 /**
  * Float uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_FLOAT = 2;
@@ -1900,7 +1692,6 @@ export const UNIFORMTYPE_FLOAT = 2;
 /**
  * 2 x Float uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_VEC2 = 3;
@@ -1908,7 +1699,6 @@ export const UNIFORMTYPE_VEC2 = 3;
 /**
  * 3 x Float uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_VEC3 = 4;
@@ -1916,7 +1706,6 @@ export const UNIFORMTYPE_VEC3 = 4;
 /**
  * 4 x Float uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_VEC4 = 5;
@@ -1924,7 +1713,6 @@ export const UNIFORMTYPE_VEC4 = 5;
 /**
  * 2 x Integer uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_IVEC2 = 6;
@@ -1932,7 +1720,6 @@ export const UNIFORMTYPE_IVEC2 = 6;
 /**
  * 3 x Integer uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_IVEC3 = 7;
@@ -1940,7 +1727,6 @@ export const UNIFORMTYPE_IVEC3 = 7;
 /**
  * 4 x Integer uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_IVEC4 = 8;
@@ -1948,7 +1734,6 @@ export const UNIFORMTYPE_IVEC4 = 8;
 /**
  * 2 x Boolean uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_BVEC2 = 9;
@@ -1956,7 +1741,6 @@ export const UNIFORMTYPE_BVEC2 = 9;
 /**
  * 3 x Boolean uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_BVEC3 = 10;
@@ -1964,7 +1748,6 @@ export const UNIFORMTYPE_BVEC3 = 10;
 /**
  * 4 x Boolean uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_BVEC4 = 11;
@@ -1972,7 +1755,6 @@ export const UNIFORMTYPE_BVEC4 = 11;
 /**
  * 2 x 2 x Float uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_MAT2 = 12;
@@ -1980,7 +1762,6 @@ export const UNIFORMTYPE_MAT2 = 12;
 /**
  * 3 x 3 x Float uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_MAT3 = 13;
@@ -1988,7 +1769,6 @@ export const UNIFORMTYPE_MAT3 = 13;
 /**
  * 4 x 4 x Float uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_MAT4 = 14;
@@ -2010,7 +1790,6 @@ export const UNIFORMTYPE_TEXTURE2D_ARRAY = 25;
 /**
  * Unsigned integer uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_UINT = 26;
@@ -2018,7 +1797,6 @@ export const UNIFORMTYPE_UINT = 26;
 /**
  * 2 x Unsigned integer uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_UVEC2 = 27;
@@ -2026,7 +1804,6 @@ export const UNIFORMTYPE_UVEC2 = 27;
 /**
  * 3 x Unsigned integer uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_UVEC3 = 28;
@@ -2034,7 +1811,6 @@ export const UNIFORMTYPE_UVEC3 = 28;
 /**
  * 4 x Unsigned integer uniform type.
  *
- * @type {number}
  * @category Graphics
  */
 export const UNIFORMTYPE_UVEC4 = 29;
@@ -2244,7 +2020,6 @@ export const uniformTypeToStorage = new Uint8Array([
 /**
  * A WebGL 2 device type.
  *
- * @type {string}
  * @category Graphics
  */
 export const DEVICETYPE_WEBGL2 = 'webgl2';
@@ -2252,7 +2027,6 @@ export const DEVICETYPE_WEBGL2 = 'webgl2';
 /**
  * A WebGPU device type.
  *
- * @type {string}
  * @category Graphics
  */
 export const DEVICETYPE_WEBGPU = 'webgpu';
@@ -2260,7 +2034,6 @@ export const DEVICETYPE_WEBGPU = 'webgpu';
 /**
  * A Null device type.
  *
- * @type {string}
  * @category Graphics
  */
 export const DEVICETYPE_NULL = 'null';
@@ -2268,7 +2041,6 @@ export const DEVICETYPE_NULL = 'null';
 /**
  * The resource is visible to the vertex shader.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADERSTAGE_VERTEX = 1;
@@ -2276,7 +2048,6 @@ export const SHADERSTAGE_VERTEX = 1;
 /**
  * The resource is visible to the fragment shader.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADERSTAGE_FRAGMENT = 2;
@@ -2284,7 +2055,6 @@ export const SHADERSTAGE_FRAGMENT = 2;
 /**
  * The resource is visible to the compute shader.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADERSTAGE_COMPUTE = 4;
@@ -2294,7 +2064,6 @@ export const SHADERSTAGE_COMPUTE = 4;
  * does not implement linear alpha blending on the main framebuffer. Instead, alpha blending occurs
  * in sRGB space.
  *
- * @type {string}
  * @category Graphics
  */
 export const DISPLAYFORMAT_LDR = 'ldr';
@@ -2305,7 +2074,6 @@ export const DISPLAYFORMAT_LDR = 'ldr';
  * linear space. This is currently supported on WebGPU platform only. On unsupported platforms, it
  * silently falls back to {@link DISPLAYFORMAT_LDR}.
  *
- * @type {string}
  * @category Graphics
  */
 export const DISPLAYFORMAT_LDR_SRGB = 'ldr_srgb';
@@ -2317,7 +2085,6 @@ export const DISPLAYFORMAT_LDR_SRGB = 'ldr_srgb';
  * {@link GraphicsDevice.isHdr} to see if the HDR format is used. When it is, it's recommended to
  * use {@link TONEMAP_NONE} for the tonemapping mode, to avoid it clipping the high dynamic range.
  *
- * @type {string}
  * @category Graphics
  */
 export const DISPLAYFORMAT_HDR = 'hdr';
@@ -2413,7 +2180,6 @@ semanticToLocation[SEMANTIC_ATTR15] = 15;
 /**
  * Chunk API versions
  *
- * @type {string}
  * @category Graphics
  */
 export const CHUNKAPI_1_51 = '1.51';

--- a/src/platform/input/constants.js
+++ b/src/platform/input/constants.js
@@ -13,7 +13,6 @@ export const AXIS_KEY = 'key';
 /**
  * Name of event fired when a key is pressed.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_KEYDOWN = 'keydown';
@@ -21,7 +20,6 @@ export const EVENT_KEYDOWN = 'keydown';
 /**
  * Name of event fired when a key is released.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_KEYUP = 'keyup';
@@ -29,7 +27,6 @@ export const EVENT_KEYUP = 'keyup';
 /**
  * Name of event fired when a mouse button is pressed.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_MOUSEDOWN = 'mousedown';
@@ -37,7 +34,6 @@ export const EVENT_MOUSEDOWN = 'mousedown';
 /**
  * Name of event fired when the mouse is moved.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_MOUSEMOVE = 'mousemove';
@@ -45,7 +41,6 @@ export const EVENT_MOUSEMOVE = 'mousemove';
 /**
  * Name of event fired when a mouse button is released.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_MOUSEUP = 'mouseup';
@@ -53,7 +48,6 @@ export const EVENT_MOUSEUP = 'mouseup';
 /**
  * Name of event fired when the mouse wheel is rotated.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_MOUSEWHEEL = 'mousewheel';
@@ -61,7 +55,6 @@ export const EVENT_MOUSEWHEEL = 'mousewheel';
 /**
  * Name of event fired when a new touch occurs. For example, a finger is placed on the device.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_TOUCHSTART = 'touchstart';
@@ -69,7 +62,6 @@ export const EVENT_TOUCHSTART = 'touchstart';
 /**
  * Name of event fired when touch ends. For example, a finger is lifted off the device.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_TOUCHEND = 'touchend';
@@ -77,7 +69,6 @@ export const EVENT_TOUCHEND = 'touchend';
 /**
  * Name of event fired when a touch moves.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_TOUCHMOVE = 'touchmove';
@@ -88,7 +79,6 @@ export const EVENT_TOUCHMOVE = 'touchmove';
  * interaction; the touch point leaves the document area, or there are more touch points than the
  * device supports, in which case the earliest touch point is canceled.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_TOUCHCANCEL = 'touchcancel';
@@ -96,7 +86,6 @@ export const EVENT_TOUCHCANCEL = 'touchcancel';
 /**
  * Name of event fired when a new xr select occurs. For example, primary trigger was pressed.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_SELECT = 'select';
@@ -104,7 +93,6 @@ export const EVENT_SELECT = 'select';
 /**
  * Name of event fired when a new xr select starts. For example, primary trigger is now pressed.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_SELECTSTART = 'selectstart';
@@ -112,7 +100,6 @@ export const EVENT_SELECTSTART = 'selectstart';
 /**
  * Name of event fired when xr select ends. For example, a primary trigger is now released.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_SELECTEND = 'selectend';
@@ -702,7 +689,6 @@ export const KEY_META = 224;
 /**
  * No mouse buttons pressed.
  *
- * @type {number}
  * @category Input
  */
 export const MOUSEBUTTON_NONE = -1;
@@ -710,7 +696,6 @@ export const MOUSEBUTTON_NONE = -1;
 /**
  * The left mouse button.
  *
- * @type {number}
  * @category Input
  */
 export const MOUSEBUTTON_LEFT = 0;
@@ -718,7 +703,6 @@ export const MOUSEBUTTON_LEFT = 0;
 /**
  * The middle mouse button.
  *
- * @type {number}
  * @category Input
  */
 export const MOUSEBUTTON_MIDDLE = 1;
@@ -726,7 +710,6 @@ export const MOUSEBUTTON_MIDDLE = 1;
 /**
  * The right mouse button.
  *
- * @type {number}
  * @category Input
  */
 export const MOUSEBUTTON_RIGHT = 2;
@@ -734,7 +717,6 @@ export const MOUSEBUTTON_RIGHT = 2;
 /**
  * Index for pad 1.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_1 = 0;
@@ -742,7 +724,6 @@ export const PAD_1 = 0;
 /**
  * Index for pad 2.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_2 = 1;
@@ -750,7 +731,6 @@ export const PAD_2 = 1;
 /**
  * Index for pad 3.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_3 = 2;
@@ -758,7 +738,6 @@ export const PAD_3 = 2;
 /**
  * Index for pad 4.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_4 = 3;
@@ -766,7 +745,6 @@ export const PAD_4 = 3;
 /**
  * The first face button, from bottom going clockwise.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_FACE_1 = 0;
@@ -774,7 +752,6 @@ export const PAD_FACE_1 = 0;
 /**
  * The second face button, from bottom going clockwise.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_FACE_2 = 1;
@@ -782,7 +759,6 @@ export const PAD_FACE_2 = 1;
 /**
  * The third face button, from bottom going clockwise.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_FACE_3 = 2;
@@ -790,7 +766,6 @@ export const PAD_FACE_3 = 2;
 /**
  * The fourth face button, from bottom going clockwise.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_FACE_4 = 3;
@@ -798,7 +773,6 @@ export const PAD_FACE_4 = 3;
 /**
  * The first shoulder button on the left.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_L_SHOULDER_1 = 4;
@@ -806,7 +780,6 @@ export const PAD_L_SHOULDER_1 = 4;
 /**
  * The first shoulder button on the right.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_R_SHOULDER_1 = 5;
@@ -814,7 +787,6 @@ export const PAD_R_SHOULDER_1 = 5;
 /**
  * The second shoulder button on the left.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_L_SHOULDER_2 = 6;
@@ -822,7 +794,6 @@ export const PAD_L_SHOULDER_2 = 6;
 /**
  * The second shoulder button on the right.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_R_SHOULDER_2 = 7;
@@ -830,7 +801,6 @@ export const PAD_R_SHOULDER_2 = 7;
 /**
  * The select button.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_SELECT = 8;
@@ -838,7 +808,6 @@ export const PAD_SELECT = 8;
 /**
  * The start button.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_START = 9;
@@ -846,7 +815,6 @@ export const PAD_START = 9;
 /**
  * The button when depressing the left analogue stick.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_L_STICK_BUTTON = 10;
@@ -854,7 +822,6 @@ export const PAD_L_STICK_BUTTON = 10;
 /**
  * The button when depressing the right analogue stick.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_R_STICK_BUTTON = 11;
@@ -862,7 +829,6 @@ export const PAD_R_STICK_BUTTON = 11;
 /**
  * Direction pad up.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_UP = 12;
@@ -870,7 +836,6 @@ export const PAD_UP = 12;
 /**
  * Direction pad down.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_DOWN = 13;
@@ -878,7 +843,6 @@ export const PAD_DOWN = 13;
 /**
  * Direction pad left.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_LEFT = 14;
@@ -886,7 +850,6 @@ export const PAD_LEFT = 14;
 /**
  * Direction pad right.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_RIGHT = 15;
@@ -894,7 +857,6 @@ export const PAD_RIGHT = 15;
 /**
  * Vendor specific button.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_VENDOR = 16;
@@ -902,7 +864,6 @@ export const PAD_VENDOR = 16;
 /**
  * Horizontal axis on the left analogue stick.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_L_STICK_X = 0;
@@ -910,7 +871,6 @@ export const PAD_L_STICK_X = 0;
 /**
  * Vertical axis on the left analogue stick.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_L_STICK_Y = 1;
@@ -918,7 +878,6 @@ export const PAD_L_STICK_Y = 1;
 /**
  * Horizontal axis on the right analogue stick.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_R_STICK_X = 2;
@@ -926,7 +885,6 @@ export const PAD_R_STICK_X = 2;
 /**
  * Vertical axis on the right analogue stick.
  *
- * @type {number}
  * @category Input
  */
 export const PAD_R_STICK_Y = 3;
@@ -934,7 +892,6 @@ export const PAD_R_STICK_Y = 3;
 /**
  * Name of event fired when a gamepad connects.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_GAMEPADCONNECTED = 'gamepadconnected';
@@ -942,7 +899,6 @@ export const EVENT_GAMEPADCONNECTED = 'gamepadconnected';
 /**
  * Name of event fired when a gamepad disconnects.
  *
- * @type {string}
  * @category Input
  */
 export const EVENT_GAMEPADDISCONNECTED = 'gamepaddisconnected';
@@ -950,7 +906,6 @@ export const EVENT_GAMEPADDISCONNECTED = 'gamepaddisconnected';
 /**
  * Horizontal axis on the touchpad of a XR pad.
  *
- * @type {number}
  * @category Input
  */
 export const XRPAD_TOUCHPAD_X = 0;
@@ -958,7 +913,6 @@ export const XRPAD_TOUCHPAD_X = 0;
 /**
  * Vertical axis on the thouchpad of a XR pad.
  *
- * @type {number}
  * @category Input
  */
 export const XRPAD_TOUCHPAD_Y = 1;
@@ -966,7 +920,6 @@ export const XRPAD_TOUCHPAD_Y = 1;
 /**
  * Horizontal axis on the stick of a XR pad.
  *
- * @type {number}
  * @category Input
  */
 export const XRPAD_STICK_X = 2;
@@ -974,7 +927,6 @@ export const XRPAD_STICK_X = 2;
 /**
  * Vertical axis on the stick of a XR pad.
  *
- * @type {number}
  * @category Input
  */
 export const XRPAD_STICK_Y = 3;
@@ -982,7 +934,6 @@ export const XRPAD_STICK_Y = 3;
 /**
  * The button when pressing the XR pad's touchpad.
  *
- * @type {number}
  * @category Input
  */
 export const XRPAD_TOUCHPAD_BUTTON = 2;
@@ -990,7 +941,6 @@ export const XRPAD_TOUCHPAD_BUTTON = 2;
 /**
  * The trigger button from XR pad.
  *
- * @type {number}
  * @category Input
  */
 export const XRPAD_TRIGGER = 0;
@@ -998,7 +948,6 @@ export const XRPAD_TRIGGER = 0;
 /**
  * The squeeze button from XR pad.
  *
- * @type {number}
  * @category Input
  */
 export const XRPAD_SQUEEZE = 1;
@@ -1006,7 +955,6 @@ export const XRPAD_SQUEEZE = 1;
 /**
  * The button when pressing the XR pad's stick.
  *
- * @type {number}
  * @category Input
  */
 export const XRPAD_STICK_BUTTON = 3;
@@ -1014,7 +962,6 @@ export const XRPAD_STICK_BUTTON = 3;
 /**
  * The A button from XR pad.
  *
- * @type {number}
  * @category Input
  */
 export const XRPAD_A = 4;
@@ -1022,7 +969,6 @@ export const XRPAD_A = 4;
 /**
  * The B button from XR pad.
  *
- * @type {number}
  * @category Input
  */
 export const XRPAD_B = 5;

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -4,7 +4,6 @@ import { PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTH16, PIXELFORMAT_R32F, PIXELFORMAT_R
  * Subtract the color of the source fragment from the destination fragment and write the result to
  * the frame buffer.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_SUBTRACTIVE = 0;
@@ -13,7 +12,6 @@ export const BLEND_SUBTRACTIVE = 0;
  * Add the color of the source fragment to the destination fragment and write the result to the
  * frame buffer.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_ADDITIVE = 1;
@@ -23,7 +21,6 @@ export const BLEND_ADDITIVE = 1;
  * blend mode of {@link BLENDMODE_SRC_ALPHA} and a destination blend mode of
  * {@link BLENDMODE_ONE_MINUS_SRC_ALPHA}.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_NORMAL = 2;
@@ -31,7 +28,6 @@ export const BLEND_NORMAL = 2;
 /**
  * Disable blending.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_NONE = 3;
@@ -40,7 +36,6 @@ export const BLEND_NONE = 3;
  * Similar to {@link BLEND_NORMAL} expect the source fragment is assumed to have already been
  * multiplied by the source alpha value.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_PREMULTIPLIED = 4;
@@ -49,7 +44,6 @@ export const BLEND_PREMULTIPLIED = 4;
  * Multiply the color of the source fragment by the color of the destination fragment and write the
  * result to the frame buffer.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_MULTIPLICATIVE = 5;
@@ -57,7 +51,6 @@ export const BLEND_MULTIPLICATIVE = 5;
 /**
  * Same as {@link BLEND_ADDITIVE} except the source RGB is multiplied by the source alpha.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_ADDITIVEALPHA = 6;
@@ -65,7 +58,6 @@ export const BLEND_ADDITIVEALPHA = 6;
 /**
  * Multiplies colors and doubles the result.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_MULTIPLICATIVE2X = 7;
@@ -73,7 +65,6 @@ export const BLEND_MULTIPLICATIVE2X = 7;
 /**
  * Softer version of additive.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_SCREEN = 8;
@@ -81,7 +72,6 @@ export const BLEND_SCREEN = 8;
 /**
  * Minimum color.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_MIN = 9;
@@ -89,7 +79,6 @@ export const BLEND_MIN = 9;
 /**
  * Maximum color.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLEND_MAX = 10;
@@ -111,7 +100,6 @@ export const blendNames = {
 /**
  * No fog is applied to the scene.
  *
- * @type {string}
  * @category Graphics
  */
 export const FOG_NONE = 'none';
@@ -119,7 +107,6 @@ export const FOG_NONE = 'none';
 /**
  * Fog rises linearly from zero to 1 between a start and end depth.
  *
- * @type {string}
  * @category Graphics
  */
 export const FOG_LINEAR = 'linear';
@@ -127,7 +114,6 @@ export const FOG_LINEAR = 'linear';
 /**
  * Fog rises according to an exponential curve controlled by a density value.
  *
- * @type {string}
  * @category Graphics
  */
 export const FOG_EXP = 'exp';
@@ -135,7 +121,6 @@ export const FOG_EXP = 'exp';
 /**
  * Fog rises according to an exponential curve controlled by a density value.
  *
- * @type {string}
  * @category Graphics
  */
 export const FOG_EXP2 = 'exp2';
@@ -143,7 +128,6 @@ export const FOG_EXP2 = 'exp2';
 /**
  * No Fresnel.
  *
- * @type {number}
  * @category Graphics
  */
 export const FRESNEL_NONE = 0;
@@ -151,7 +135,6 @@ export const FRESNEL_NONE = 0;
 /**
  * Schlick's approximation of Fresnel.
  *
- * @type {number}
  * @category Graphics
  */
 export const FRESNEL_SCHLICK = 2;
@@ -171,7 +154,6 @@ export const LAYER_WORLD = 15;
 /**
  * The world layer.
  *
- * @type {number}
  * @category Graphics
  */
 export const LAYERID_WORLD = 0;
@@ -179,7 +161,6 @@ export const LAYERID_WORLD = 0;
 /**
  * The depth layer.
  *
- * @type {number}
  * @category Graphics
  */
 export const LAYERID_DEPTH = 1;
@@ -187,7 +168,6 @@ export const LAYERID_DEPTH = 1;
 /**
  * The skybox layer.
  *
- * @type {number}
  * @category Graphics
  */
 export const LAYERID_SKYBOX = 2;
@@ -195,7 +175,6 @@ export const LAYERID_SKYBOX = 2;
 /**
  * The immediate layer.
  *
- * @type {number}
  * @category Graphics
  */
 export const LAYERID_IMMEDIATE = 3;
@@ -203,7 +182,6 @@ export const LAYERID_IMMEDIATE = 3;
 /**
  * The UI layer.
  *
- * @type {number}
  * @category Graphics
  */
 export const LAYERID_UI = 4;
@@ -211,7 +189,6 @@ export const LAYERID_UI = 4;
 /**
  * Directional (global) light source.
  *
- * @type {number}
  * @category Graphics
  */
 export const LIGHTTYPE_DIRECTIONAL = 0;
@@ -219,7 +196,6 @@ export const LIGHTTYPE_DIRECTIONAL = 0;
 /**
  * Omni-directional (local) light source.
  *
- * @type {number}
  * @category Graphics
  */
 export const LIGHTTYPE_OMNI = 1;
@@ -227,7 +203,6 @@ export const LIGHTTYPE_OMNI = 1;
 /**
  * Point (local) light source.
  *
- * @type {number}
  * @ignore
  * @category Graphics
  */
@@ -236,7 +211,6 @@ export const LIGHTTYPE_POINT = LIGHTTYPE_OMNI;
 /**
  * Spot (local) light source.
  *
- * @type {number}
  * @category Graphics
  */
 export const LIGHTTYPE_SPOT = 2;
@@ -256,7 +230,6 @@ export const LIGHT_COLOR_DIVIDER = 100;
 /**
  * Infinitesimally small point light source shape.
  *
- * @type {number}
  * @category Graphics
  */
 export const LIGHTSHAPE_PUNCTUAL = 0;
@@ -264,7 +237,6 @@ export const LIGHTSHAPE_PUNCTUAL = 0;
 /**
  * Rectangle shape of light source.
  *
- * @type {number}
  * @category Graphics
  */
 export const LIGHTSHAPE_RECT = 1;
@@ -272,7 +244,6 @@ export const LIGHTSHAPE_RECT = 1;
 /**
  * Disk shape of light source.
  *
- * @type {number}
  * @category Graphics
  */
 export const LIGHTSHAPE_DISK = 2;
@@ -280,7 +251,6 @@ export const LIGHTSHAPE_DISK = 2;
 /**
  * Sphere shape of light source.
  *
- * @type {number}
  * @category Graphics
  */
 export const LIGHTSHAPE_SPHERE = 3;
@@ -295,7 +265,6 @@ export const lightShapeNames = {
 /**
  * Linear distance falloff model for light attenuation.
  *
- * @type {number}
  * @category Graphics
  */
 export const LIGHTFALLOFF_LINEAR = 0;
@@ -303,7 +272,6 @@ export const LIGHTFALLOFF_LINEAR = 0;
 /**
  * Inverse squared distance falloff model for light attenuation.
  *
- * @type {number}
  * @category Graphics
  */
 export const LIGHTFALLOFF_INVERSESQUARED = 1;
@@ -317,7 +285,6 @@ export const lightFalloffNames = {
  * A shadow sampling technique using 32bit shadow map that averages depth comparisons from a 3x3
  * grid of texels for softened shadow edges.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOW_PCF3_32F = 0;
@@ -334,7 +301,6 @@ export const SHADOW_PCF3 = 0; // alias for SHADOW_PCF3_32F for backwards compati
  * {@link GraphicsDevice#textureHalfFloatRenderable} is true. Falls back to {@link SHADOW_PCF3_32F},
  * if not supported.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOW_VSM_16F = 2;
@@ -351,7 +317,6 @@ export const SHADOW_VSM16 = 2; // alias for SHADOW_VSM_16F for backwards compati
  * {@link GraphicsDevice#textureFloatRenderable} is true. Falls back to {@link SHADOW_VSM_16F}, if
  * not supported.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOW_VSM_32F = 3;
@@ -366,7 +331,6 @@ export const SHADOW_VSM32 = 3; // alias for SHADOW_VSM_32F for backwards compati
  * A shadow sampling technique using 32bit shadow map that averages depth comparisons from a 5x5
  * grid of texels for softened shadow edges.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOW_PCF5_32F = 4;
@@ -381,7 +345,6 @@ export const SHADOW_PCF5 = 4;  // alias for SHADOW_PCF5_32F for backwards compat
  * A shadow sampling technique using a 32-bit shadow map that performs a single depth comparison for
  * sharp shadow edges.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOW_PCF1_32F = 5;
@@ -399,7 +362,6 @@ export const SHADOW_PCF1 = 5;  // alias for SHADOW_PCF1_32F for backwards compat
  * {@link GraphicsDevice#textureHalfFloatRenderable} to be true, and falls back to
  * {@link SHADOW_PCF3_32F} otherwise.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOW_PCSS_32F = 6;
@@ -408,7 +370,6 @@ export const SHADOW_PCSS_32F = 6;
  * A shadow sampling technique using a 16-bit shadow map that performs a single depth comparison for
  * sharp shadow edges.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOW_PCF1_16F = 7;
@@ -417,7 +378,6 @@ export const SHADOW_PCF1_16F = 7;
  * A shadow sampling technique using 16-bit shadow map that averages depth comparisons from a 3x3
  * grid of texels for softened shadow edges.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOW_PCF3_16F = 8;
@@ -426,7 +386,6 @@ export const SHADOW_PCF3_16F = 8;
  * A shadow sampling technique using 16-bit shadow map that averages depth comparisons from a 3x3
  * grid of texels for softened shadow edges.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOW_PCF5_16F = 9;
@@ -452,7 +411,6 @@ export const shadowTypeInfo = new Map([
 /**
  * Box filter.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLUR_BOX = 0;
@@ -460,7 +418,6 @@ export const BLUR_BOX = 0;
 /**
  * Gaussian filter. May look smoother than box, but requires more samples.
  *
- * @type {number}
  * @category Graphics
  */
 export const BLUR_GAUSSIAN = 1;
@@ -468,7 +425,6 @@ export const BLUR_GAUSSIAN = 1;
 /**
  * No sorting, particles are drawn in arbitrary order. Can be simulated on GPU.
  *
- * @type {number}
  * @category Graphics
  */
 export const PARTICLESORT_NONE = 0;
@@ -476,7 +432,6 @@ export const PARTICLESORT_NONE = 0;
 /**
  * Sorting based on distance to the camera. CPU only.
  *
- * @type {number}
  * @category Graphics
  */
 export const PARTICLESORT_DISTANCE = 1;
@@ -484,7 +439,6 @@ export const PARTICLESORT_DISTANCE = 1;
 /**
  * Newer particles are drawn first. CPU only.
  *
- * @type {number}
  * @category Graphics
  */
 export const PARTICLESORT_NEWER_FIRST = 2;
@@ -492,7 +446,6 @@ export const PARTICLESORT_NEWER_FIRST = 2;
 /**
  * Older particles are drawn first. CPU only.
  *
- * @type {number}
  * @category Graphics
  */
 export const PARTICLESORT_OLDER_FIRST = 3;
@@ -503,7 +456,6 @@ export const PARTICLEMODE_CPU = 1;
 /**
  * Box shape parameterized by emitterExtents. Initial velocity is directed towards local Z axis.
  *
- * @type {number}
  * @category Graphics
  */
 export const EMITTERSHAPE_BOX = 0;
@@ -512,7 +464,6 @@ export const EMITTERSHAPE_BOX = 0;
  * Sphere shape parameterized by emitterRadius. Initial velocity is directed outwards from the
  * center.
  *
- * @type {number}
  * @category Graphics
  */
 export const EMITTERSHAPE_SPHERE = 1;
@@ -520,7 +471,6 @@ export const EMITTERSHAPE_SPHERE = 1;
 /**
  * Particles are facing camera.
  *
- * @type {number}
  * @category Graphics
  */
 export const PARTICLEORIENTATION_SCREEN = 0;
@@ -528,7 +478,6 @@ export const PARTICLEORIENTATION_SCREEN = 0;
 /**
  * User defines world space normal (particleNormal) to set planes orientation.
  *
- * @type {number}
  * @category Graphics
  */
 export const PARTICLEORIENTATION_WORLD = 1;
@@ -536,7 +485,6 @@ export const PARTICLEORIENTATION_WORLD = 1;
 /**
  * Similar to previous, but the normal is affected by emitter(entity) transformation.
  *
- * @type {number}
  * @category Graphics
  */
 export const PARTICLEORIENTATION_EMITTER = 2;
@@ -544,7 +492,6 @@ export const PARTICLEORIENTATION_EMITTER = 2;
 /**
  * A perspective camera projection where the frustum shape is essentially pyramidal.
  *
- * @type {number}
  * @category Graphics
  */
 export const PROJECTION_PERSPECTIVE = 0;
@@ -552,7 +499,6 @@ export const PROJECTION_PERSPECTIVE = 0;
 /**
  * An orthographic camera projection where the frustum shape is essentially a cuboid.
  *
- * @type {number}
  * @category Graphics
  */
 export const PROJECTION_ORTHOGRAPHIC = 1;
@@ -560,7 +506,6 @@ export const PROJECTION_ORTHOGRAPHIC = 1;
 /**
  * Render mesh instance as solid geometry.
  *
- * @type {number}
  * @category Graphics
  */
 export const RENDERSTYLE_SOLID = 0;
@@ -568,7 +513,6 @@ export const RENDERSTYLE_SOLID = 0;
 /**
  * Render mesh instance as wireframe.
  *
- * @type {number}
  * @category Graphics
  */
 export const RENDERSTYLE_WIREFRAME = 1;
@@ -576,7 +520,6 @@ export const RENDERSTYLE_WIREFRAME = 1;
 /**
  * Render mesh instance as points.
  *
- * @type {number}
  * @category Graphics
  */
 export const RENDERSTYLE_POINTS = 2;
@@ -584,7 +527,6 @@ export const RENDERSTYLE_POINTS = 2;
 /**
  * The cube map is treated as if it is infinitely far away.
  *
- * @type {number}
  * @category Graphics
  */
 export const CUBEPROJ_NONE = 0;
@@ -592,7 +534,6 @@ export const CUBEPROJ_NONE = 0;
 /**
  * The cube map is box-projected based on a world space axis-aligned bounding box.
  *
- * @type {number}
  * @category Graphics
  */
 export const CUBEPROJ_BOX = 1;
@@ -606,7 +547,6 @@ export const cubemaProjectionNames = {
 /**
  * Multiply together the primary and secondary colors.
  *
- * @type {string}
  * @category Graphics
  */
 export const DETAILMODE_MUL = 'mul';
@@ -614,7 +554,6 @@ export const DETAILMODE_MUL = 'mul';
 /**
  * Add together the primary and secondary colors.
  *
- * @type {string}
  * @category Graphics
  */
 export const DETAILMODE_ADD = 'add';
@@ -622,7 +561,6 @@ export const DETAILMODE_ADD = 'add';
 /**
  * Softer version of {@link DETAILMODE_ADD}.
  *
- * @type {string}
  * @category Graphics
  */
 export const DETAILMODE_SCREEN = 'screen';
@@ -630,7 +568,6 @@ export const DETAILMODE_SCREEN = 'screen';
 /**
  * Multiplies or screens the colors, depending on the primary color.
  *
- * @type {string}
  * @category Graphics
  */
 export const DETAILMODE_OVERLAY = 'overlay';
@@ -638,7 +575,6 @@ export const DETAILMODE_OVERLAY = 'overlay';
 /**
  * Select whichever of the primary and secondary colors is darker, component-wise.
  *
- * @type {string}
  * @category Graphics
  */
 export const DETAILMODE_MIN = 'min';
@@ -646,7 +582,6 @@ export const DETAILMODE_MIN = 'min';
 /**
  * Select whichever of the primary and secondary colors is lighter, component-wise.
  *
- * @type {string}
  * @category Graphics
  */
 export const DETAILMODE_MAX = 'max';
@@ -654,7 +589,6 @@ export const DETAILMODE_MAX = 'max';
 /**
  * No gamma correction.
  *
- * @type {number}
  * @category Graphics
  */
 export const GAMMA_NONE = 0;
@@ -662,7 +596,6 @@ export const GAMMA_NONE = 0;
 /**
  * Apply sRGB gamma correction.
  *
- * @type {number}
  * @category Graphics
  */
 export const GAMMA_SRGB = 1;
@@ -676,7 +609,6 @@ export const gammaNames = {
 /**
  * Linear tonemapping. The colors are preserved, but the exposure is applied.
  *
- * @type {number}
  * @category Graphics
  */
 export const TONEMAP_LINEAR = 0;
@@ -684,7 +616,6 @@ export const TONEMAP_LINEAR = 0;
 /**
  * Filmic tonemapping curve.
  *
- * @type {number}
  * @category Graphics
  */
 export const TONEMAP_FILMIC = 1;
@@ -692,7 +623,6 @@ export const TONEMAP_FILMIC = 1;
 /**
  * Hejl filmic tonemapping curve.
  *
- * @type {number}
  * @category Graphics
  */
 export const TONEMAP_HEJL = 2;
@@ -700,7 +630,6 @@ export const TONEMAP_HEJL = 2;
 /**
  * ACES filmic tonemapping curve.
  *
- * @type {number}
  * @category Graphics
  */
 export const TONEMAP_ACES = 3;
@@ -708,7 +637,6 @@ export const TONEMAP_ACES = 3;
 /**
  * ACES v2 filmic tonemapping curve.
  *
- * @type {number}
  * @category Graphics
  */
 export const TONEMAP_ACES2 = 4;
@@ -716,7 +644,6 @@ export const TONEMAP_ACES2 = 4;
 /**
  * Khronos PBR Neutral tonemapping curve.
  *
- * @type {number}
  * @category Graphics
  */
 export const TONEMAP_NEUTRAL = 5;
@@ -724,7 +651,6 @@ export const TONEMAP_NEUTRAL = 5;
 /**
  * No tonemapping or exposure is applied. Used for HDR rendering.
  *
- * @type {number}
  * @category Graphics
  */
 export const TONEMAP_NONE = 6;
@@ -743,7 +669,6 @@ export const tonemapNames = [
 /**
  * No specular occlusion.
  *
- * @type {number}
  * @category Graphics
  */
 export const SPECOCC_NONE = 0;
@@ -751,7 +676,6 @@ export const SPECOCC_NONE = 0;
 /**
  * Use AO directly to occlude specular.
  *
- * @type {number}
  * @category Graphics
  */
 export const SPECOCC_AO = 1;
@@ -759,7 +683,6 @@ export const SPECOCC_AO = 1;
 /**
  * Modify AO based on material glossiness/view angle to occlude specular.
  *
- * @type {number}
  * @category Graphics
  */
 export const SPECOCC_GLOSSDEPENDENT = 2;
@@ -816,7 +739,6 @@ export const SHADERDEF_BATCH = 16384;
 /**
  * The shadow map is not to be updated.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOWUPDATE_NONE = 0;
@@ -824,7 +746,6 @@ export const SHADOWUPDATE_NONE = 0;
 /**
  * The shadow map is regenerated this frame and not on subsequent frames.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOWUPDATE_THISFRAME = 1;
@@ -832,7 +753,6 @@ export const SHADOWUPDATE_THISFRAME = 1;
 /**
  * The shadow map is regenerated every frame.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADOWUPDATE_REALTIME = 2;
@@ -845,7 +765,6 @@ export const MASK_BAKE = 4;
 /**
  * Render shaded materials using forward rendering.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADER_FORWARD = 0;
@@ -855,7 +774,6 @@ export const SHADER_PREPASS = 1;
 /**
  * Render RGBA-encoded depth value.
  *
- * @type {number}
  * @category Graphics
  */
 export const SHADER_DEPTH = 2;
@@ -869,7 +787,6 @@ export const SHADER_SHADOW = 4;
 /**
  * Shader that performs forward rendering.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_FORWARD = 'forward';
@@ -877,7 +794,6 @@ export const SHADERPASS_FORWARD = 'forward';
 /**
  * Shader used for debug rendering of albedo.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_ALBEDO = 'debug_albedo';
@@ -885,7 +801,6 @@ export const SHADERPASS_ALBEDO = 'debug_albedo';
 /**
  * Shader used for debug rendering of world normal.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_WORLDNORMAL = 'debug_world_normal';
@@ -893,7 +808,6 @@ export const SHADERPASS_WORLDNORMAL = 'debug_world_normal';
 /**
  * Shader used for debug rendering of opacity.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_OPACITY = 'debug_opacity';
@@ -901,7 +815,6 @@ export const SHADERPASS_OPACITY = 'debug_opacity';
 /**
  * Shader used for debug rendering of specularity.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_SPECULARITY = 'debug_specularity';
@@ -909,7 +822,6 @@ export const SHADERPASS_SPECULARITY = 'debug_specularity';
 /**
  * Shader used for debug rendering of gloss.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_GLOSS = 'debug_gloss';
@@ -917,7 +829,6 @@ export const SHADERPASS_GLOSS = 'debug_gloss';
 /**
  * Shader used for debug rendering of metalness.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_METALNESS = 'debug_metalness';
@@ -925,7 +836,6 @@ export const SHADERPASS_METALNESS = 'debug_metalness';
 /**
  * Shader used for debug rendering of ao.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_AO = 'debug_ao';
@@ -933,7 +843,6 @@ export const SHADERPASS_AO = 'debug_ao';
 /**
  * Shader used for debug rendering of emission.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_EMISSION = 'debug_emission';
@@ -941,7 +850,6 @@ export const SHADERPASS_EMISSION = 'debug_emission';
 /**
  * Shader used for debug rendering of lighting.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_LIGHTING = 'debug_lighting';
@@ -949,7 +857,6 @@ export const SHADERPASS_LIGHTING = 'debug_lighting';
 /**
  * Shader used for debug rendering of UV0 texture coordinates.
  *
- * @type {string}
  * @category Graphics
  */
 export const SHADERPASS_UV0 = 'debug_uv0';
@@ -957,7 +864,6 @@ export const SHADERPASS_UV0 = 'debug_uv0';
 /**
  * This mode renders a sprite as a simple quad.
  *
- * @type {number}
  * @category Graphics
  */
 export const SPRITE_RENDERMODE_SIMPLE = 0;
@@ -967,7 +873,6 @@ export const SPRITE_RENDERMODE_SIMPLE = 0;
  * bottom regions of the sprite horizontally, the left and right regions vertically and the middle
  * region both horizontally and vertically.
  *
- * @type {number}
  * @category Graphics
  */
 export const SPRITE_RENDERMODE_SLICED = 1;
@@ -977,7 +882,6 @@ export const SPRITE_RENDERMODE_SLICED = 1;
  * regions of the sprite horizontally, the left and right regions vertically and the middle region
  * both horizontally and vertically.
  *
- * @type {number}
  * @category Graphics
  */
 export const SPRITE_RENDERMODE_TILED = 2;
@@ -991,7 +895,6 @@ export const spriteRenderModeNames = {
 /**
  * Single color lightmap.
  *
- * @type {number}
  * @category Graphics
  */
 export const BAKE_COLOR = 0;
@@ -999,7 +902,6 @@ export const BAKE_COLOR = 0;
 /**
  * Single color lightmap + dominant light direction (used for bump/specular).
  *
- * @type {number}
  * @category Graphics
  */
 export const BAKE_COLORDIR = 1;
@@ -1007,7 +909,6 @@ export const BAKE_COLORDIR = 1;
 /**
  * Center of view.
  *
- * @type {number}
  * @category Graphics
  */
 export const VIEW_CENTER = 0;
@@ -1015,7 +916,6 @@ export const VIEW_CENTER = 0;
 /**
  * Left of view. Only used in stereo rendering.
  *
- * @type {number}
  * @category Graphics
  */
 export const VIEW_LEFT = 1;
@@ -1023,7 +923,6 @@ export const VIEW_LEFT = 1;
 /**
  * Right of view. Only used in stereo rendering.
  *
- * @type {number}
  * @category Graphics
  */
 export const VIEW_RIGHT = 2;
@@ -1031,7 +930,6 @@ export const VIEW_RIGHT = 2;
 /**
  * No sorting is applied. Mesh instances are rendered in the same order they were added to a layer.
  *
- * @type {number}
  * @category Graphics
  */
 export const SORTMODE_NONE = 0;
@@ -1039,7 +937,6 @@ export const SORTMODE_NONE = 0;
 /**
  * Mesh instances are sorted based on {@link MeshInstance#drawOrder}.
  *
- * @type {number}
  * @category Graphics
  */
 export const SORTMODE_MANUAL = 1;
@@ -1048,7 +945,6 @@ export const SORTMODE_MANUAL = 1;
  * Mesh instances are sorted to minimize switching between materials and meshes to improve
  * rendering performance.
  *
- * @type {number}
  * @category Graphics
  */
 export const SORTMODE_MATERIALMESH = 2;
@@ -1057,7 +953,6 @@ export const SORTMODE_MATERIALMESH = 2;
  * Mesh instances are sorted back to front. This is the way to properly render many
  * semi-transparent objects on different depth, one is blended on top of another.
  *
- * @type {number}
  * @category Graphics
  */
 export const SORTMODE_BACK2FRONT = 3;
@@ -1066,7 +961,6 @@ export const SORTMODE_BACK2FRONT = 3;
  * Mesh instances are sorted front to back. Depending on GPU and the scene, this option may give
  * better performance than {@link SORTMODE_MATERIALMESH} due to reduced overdraw.
  *
- * @type {number}
  * @category Graphics
  */
 export const SORTMODE_FRONT2BACK = 4;
@@ -1074,7 +968,6 @@ export const SORTMODE_FRONT2BACK = 4;
 /**
  * Provide custom functions for sorting drawcalls and calculating distance.
  *
- * @type {number}
  * @ignore
  * @category Graphics
  */
@@ -1083,7 +976,6 @@ export const SORTMODE_CUSTOM = 5;
 /**
  * Automatically set aspect ratio to current render target's width divided by height.
  *
- * @type {number}
  * @category Graphics
  */
 export const ASPECT_AUTO = 0;
@@ -1091,7 +983,6 @@ export const ASPECT_AUTO = 0;
 /**
  * Use the manual aspect ratio value.
  *
- * @type {number}
  * @category Graphics
  */
 export const ASPECT_MANUAL = 1;
@@ -1099,7 +990,6 @@ export const ASPECT_MANUAL = 1;
 /**
  * Horizontal orientation.
  *
- * @type {number}
  * @category Graphics
  */
 export const ORIENTATION_HORIZONTAL = 0;
@@ -1107,7 +997,6 @@ export const ORIENTATION_HORIZONTAL = 0;
 /**
  * Vertical orientation.
  *
- * @type {number}
  * @category Graphics
  */
 export const ORIENTATION_VERTICAL = 1;
@@ -1115,7 +1004,6 @@ export const ORIENTATION_VERTICAL = 1;
 /**
  * A sky texture is rendered using an infinite projection.
  *
- * @type {string}
  * @category Graphics
  */
 export const SKYTYPE_INFINITE = 'infinite';
@@ -1124,7 +1012,6 @@ export const SKYTYPE_INFINITE = 'infinite';
  * A sky texture is rendered using a box projection. This is generally suitable for interior
  * environments.
  *
- * @type {string}
  * @category Graphics
  */
 export const SKYTYPE_BOX = 'box';
@@ -1133,7 +1020,6 @@ export const SKYTYPE_BOX = 'box';
  *  A sky texture is rendered using a dome projection. This is generally suitable for exterior
  * environments.
  *
- * @type {string}
  * @category Graphics
  */
 export const SKYTYPE_DOME = 'dome';
@@ -1141,7 +1027,6 @@ export const SKYTYPE_DOME = 'dome';
 /**
  * Opacity dithering is disabled.
  *
- * @type {string}
  * @category Graphics
  */
 export const DITHER_NONE = 'none';
@@ -1149,7 +1034,6 @@ export const DITHER_NONE = 'none';
 /**
  * Opacity is dithered using a Bayer 8 matrix.
  *
- * @type {string}
  * @category Graphics
  */
 export const DITHER_BAYER8 = 'bayer8';
@@ -1157,7 +1041,6 @@ export const DITHER_BAYER8 = 'bayer8';
 /**
  * Opacity is dithered using a blue noise.
  *
- * @type {string}
  * @category Graphics
  */
 export const DITHER_BLUENOISE = 'bluenoise';
@@ -1165,7 +1048,6 @@ export const DITHER_BLUENOISE = 'bluenoise';
 /**
  * Opacity is dithered using an interleaved gradient noise.
  *
- * @type {string}
  * @category Graphics
  */
 export const DITHER_IGNNOISE = 'ignnoise';
@@ -1180,7 +1062,6 @@ export const ditherNames = {
 /**
  * Name of event fired before the camera renders the scene.
  *
- * @type {string}
  * @ignore
  */
 export const EVENT_PRERENDER = 'prerender';
@@ -1188,7 +1069,6 @@ export const EVENT_PRERENDER = 'prerender';
 /**
  * Name of event fired after the camera renders the scene.
  *
- * @type {string}
  * @ignore
  */
 export const EVENT_POSTRENDER = 'postrender';
@@ -1196,7 +1076,6 @@ export const EVENT_POSTRENDER = 'postrender';
 /**
  * Name of event fired before a layer is rendered by a camera.
  *
- * @type {string}
  * @ignore
  */
 export const EVENT_PRERENDER_LAYER = 'prerender:layer';
@@ -1204,7 +1083,6 @@ export const EVENT_PRERENDER_LAYER = 'prerender:layer';
 /**
  * Name of event fired after a layer is rendered by a camera.
  *
- * @type {string}
  * @ignore
  */
 export const EVENT_POSTRENDER_LAYER = 'postrender:layer';
@@ -1212,7 +1090,6 @@ export const EVENT_POSTRENDER_LAYER = 'postrender:layer';
 /**
  * Name of event fired before visibility culling is performed for the camera
  *
- * @type {string}
  * @ignore
  */
 export const EVENT_PRECULL = 'precull';
@@ -1220,7 +1097,6 @@ export const EVENT_PRECULL = 'precull';
 /**
  * Name of event after before visibility culling is performed for the camera
  *
- * @type {string}
  * @ignore
  */
 export const EVENT_POSTCULL = 'postcull';


### PR DESCRIPTION
Remove generic `string` and `number` types from engine constants because `tsc` can discern the constants are literal values and inherently knows the types. This results in 549 lines being removed from the engine source and types becoming stricter.

For example, old example from `playcanvas.d.ts`:

```js
/**
 * Ignores the integer part of texture coordinates, using only the fractional part.
 *
 * @type {number}
 * @category Graphics
 */
export const ADDRESS_REPEAT: number;
```

New example from `playcanvas.d.ts`:

```js
/**
 * Ignores the integer part of texture coordinates, using only the fractional part.
 *
 * @category Graphics
 */
export const ADDRESS_REPEAT: 0;
```

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
