### PR TITLE
Fix assignment of clustered lighting cells

### DIFF
--- a/src/scene/lighting/lighting-params.js
+++ b/src/scene/lighting/lighting-params.js
@@ -71,7 +71,7 @@ class LightingParams {
         this.maxLightsPerCell = render.lightingMaxLightsPerCell ?? this.maxLightsPerCell;
         this.shadowType = render.lightingShadowType ?? this.shadowType;
         if (render.lightingCells) {
-            this.cell = new Vec3(render.lightingCells);
+            this.cells = new Vec3(render.lightingCells);
         }
     }
 


### PR DESCRIPTION
When visualizing the clustered lighting cells, I noticed the number of cells was always (10, 3, 10) regardless of the corresponding rendering setting. Looking at the code, it seems the assignment was done to the (non-existent) `.cell` property instead of `.cells`. The former isn't referenced anywhere and seems like a typo.

This PR fixes it by assigning it to the `.cells` property instead.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md).
I have _not_ (yet) signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform) as this link is dead. If it helps, I release this change under [CC0](https://creativecommons.org/public-domain/cc0/).

