### PR TITLE
Only validate shader vertex attributes when vertex buffers are set

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1729,10 +1729,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
         const samplers = shader.impl.samplers;
         const uniforms = shader.impl.uniforms;
 
-        Debug.call(() => this.validateAttributes(this.shader, this.vertexBuffers[0]?.format, this.vertexBuffers[1]?.format));
-
         // vertex buffers
         if (!keepBuffers) {
+            Debug.call(() => this.validateAttributes(this.shader, this.vertexBuffers[0]?.format, this.vertexBuffers[1]?.format));
+
             this.setBuffers();
         }
 


### PR DESCRIPTION
Related #7431

When starting an immersive WebXR session with a debug build, the dev console is filled with errors stating that vertex attributes are missing, despite everything rendering as intended. It turns out these are false positives.

For stereo rendering, the second draw call passes the `keepBuffers` flag ([renderer.js#L849](https://github.com/playcanvas/engine/blob/efcc0466b34cfc8989457b77d3dfc53d0fc6fb87/src/scene/renderer/renderer.js#L849)), which indicate that the _currently set_ vertex buffers are to be (re)used. In that case the `vertexBuffers` array is empty, as the previous draw (for the left eye) cleared them ([webgl-graphics-device.js#L1672](https://github.com/playcanvas/engine/blob/efcc0466b34cfc8989457b77d3dfc53d0fc6fb87/src/platform/graphics/webgl/webgl-graphics-device.js#L1672)). This results in the `validateAttributes` to always fail and log these errors.

This PR moves the debug validation in the `!keepBuffers` clause, ensuring that the validation only takes place when vertex buffers are being set up and not when they are being reused for stereo rendering.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md).
I have _not_ (yet) signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform) as this link is dead. If it helps, I release this change under [CC0](https://creativecommons.org/public-domain/cc0/).
