### PR TITLE
Deprecate all remaining global event constants

### DIFF
--- a/examples/src/examples/graphics/area-picker.example.mjs
+++ b/examples/src/examples/graphics/area-picker.example.mjs
@@ -76,7 +76,7 @@ assetListLoader.load(() => {
 
     // handle mouse move event and store current mouse position to use as a position to pick from the scene
     new pc.Mouse(document.body).on(
-        pc.EVENT_MOUSEMOVE,
+        'mousemove',
         (event) => {
             mouseX = event.x;
             mouseY = event.y;

--- a/examples/src/examples/graphics/integer-textures.example.mjs
+++ b/examples/src/examples/graphics/integer-textures.example.mjs
@@ -251,7 +251,7 @@ assetListLoader.load(() => {
 
     // Reset on space bar, select brush on 1-4
     keyboard.on(
-        pc.EVENT_KEYUP,
+        'keyup',
         (event) => {
             switch (event.key) {
                 case pc.KEY_SPACE:
@@ -275,7 +275,7 @@ assetListLoader.load(() => {
     );
 
     let mouseState = 0;
-    mouse.on(pc.EVENT_MOUSEDOWN, (event) => {
+    mouse.on('mousedown', (event) => {
         if (event.button === pc.MOUSEBUTTON_LEFT) {
             if (keyboard.isPressed(pc.KEY_SHIFT)) {
                 mouseState = 2;
@@ -286,7 +286,7 @@ assetListLoader.load(() => {
             mouseState = 2;
         }
     });
-    mouse.on(pc.EVENT_MOUSEUP, () => {
+    mouse.on('mouseup', () => {
         mouseState = 0;
     });
 
@@ -294,7 +294,7 @@ assetListLoader.load(() => {
     const planePoint = new pc.Vec3();
     const mousePos = new pc.Vec2();
     const mouseUniform = new Float32Array(2);
-    mouse.on(pc.EVENT_MOUSEMOVE, (event) => {
+    mouse.on('mousemove', (event) => {
         const x = event.x;
         const y = event.y;
 

--- a/examples/src/examples/physics/vehicle.example.mjs
+++ b/examples/src/examples/physics/vehicle.example.mjs
@@ -212,7 +212,7 @@ assetListLoader.load(() => {
         }
     });
 
-    app.keyboard.on(pc.EVENT_KEYDOWN, (e) => {
+    app.keyboard.on('keydown', (e) => {
         if (e.key === pc.KEY_R) {
             app.fire('reset');
         }

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -751,6 +751,26 @@ Object.defineProperty(XrInputSource.prototype, 'rotation', {
 
 // INPUT
 
+export const EVENT_KEYDOWN = 'keydown';
+export const EVENT_KEYUP = 'keyup';
+
+export const EVENT_MOUSEDOWN = 'mousedown';
+export const EVENT_MOUSEMOVE = 'mousemove';
+export const EVENT_MOUSEUP = 'mouseup';
+export const EVENT_MOUSEWHEEL = 'mousewheel';
+
+export const EVENT_TOUCHSTART = 'touchstart';
+export const EVENT_TOUCHEND = 'touchend';
+export const EVENT_TOUCHMOVE = 'touchmove';
+export const EVENT_TOUCHCANCEL = 'touchcancel';
+
+export const EVENT_GAMEPADCONNECTED = 'gamepadconnected';
+export const EVENT_GAMEPADDISCONNECTED = 'gamepaddisconnected';
+
+export const EVENT_SELECT = 'select';
+export const EVENT_SELECTSTART = 'selectstart';
+export const EVENT_SELECTEND = 'selectend';
+
 Object.defineProperty(ElementInput.prototype, 'wheel', {
     get: function () {
         return this.wheelDelta * -2;

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -9,7 +9,6 @@ import { GraphNode } from '../../../scene/graph-node.js';
 import { ElementDragHelper } from '../element/element-drag-helper.js';
 import { SCROLL_MODE_BOUNCE, SCROLL_MODE_CLAMP, SCROLL_MODE_INFINITE, SCROLLBAR_VISIBILITY_SHOW_ALWAYS, SCROLLBAR_VISIBILITY_SHOW_WHEN_REQUIRED } from './constants.js';
 import { Component } from '../component.js';
-import { EVENT_MOUSEWHEEL } from '../../../platform/input/constants.js';
 
 /**
  * @import { Entity } from '../../entity.js'
@@ -624,7 +623,7 @@ class ScrollViewComponent extends Component {
             }
 
             this.entity.element[onOrOff]('resize', this._syncAll, this);
-            this.entity.element[onOrOff](EVENT_MOUSEWHEEL, this._onMouseWheel, this);
+            this.entity.element[onOrOff]('mousewheel', this._onMouseWheel, this);
 
             this._hasElementListeners = onOrOff === 'on';
         }

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -3,7 +3,6 @@ import { GSplatCompressedData } from '../../scene/gsplat/gsplat-compressed-data.
 import { GSplatResource } from './gsplat-resource.js';
 
 /**
- * @import { AssetRegistry } from '../asset/asset-registry.js'
  * @import { Asset } from '../asset/asset.js'
  * @import { AppBase } from '../app-base.js'
  * @import { ResourceHandlerCallback } from '../handlers/handler.js'
@@ -11,21 +10,26 @@ import { GSplatResource } from './gsplat-resource.js';
 
 /**
  * @typedef {Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array} DataType
+ * @ignore
  */
 
 /**
- * @typedef {object} PlyProperty
- * @property {string} type - E.g. 'float'.
- * @property {string} name - E.g. 'x', 'y', 'z', 'f_dc_0' etc.
- * @property {DataType} storage - Data type, e.g. instance of Float32Array.
- * @property {number} byteSize - BYTES_PER_ELEMENT of given data type.
+ * @typedef {{
+ *   type: string;
+ *   name: string;
+ *   storage: DataType | null;
+ *   byteSize: number;
+ * }} PlyProperty
+ * @ignore
  */
 
 /**
- * @typedef {object} PlyElement
- * @property {string} name - E.g. 'vertex'.
- * @property {number} count - Given count.
- * @property {PlyProperty[]} properties - The properties.
+ * @typedef {{
+ *   name: string;
+ *   count: number;
+ *   properties: PlyProperty[];
+ * }} PlyElement
+ * @ignore
  */
 
 const magicBytes = new Uint8Array([112, 108, 121, 10]);                                                 // ply\n

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -3,6 +3,7 @@ import { GSplatCompressedData } from '../../scene/gsplat/gsplat-compressed-data.
 import { GSplatResource } from './gsplat-resource.js';
 
 /**
+ * @import { AssetRegistry } from '../asset/asset-registry.js'
  * @import { Asset } from '../asset/asset.js'
  * @import { AppBase } from '../app-base.js'
  * @import { ResourceHandlerCallback } from '../handlers/handler.js'
@@ -10,26 +11,21 @@ import { GSplatResource } from './gsplat-resource.js';
 
 /**
  * @typedef {Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array} DataType
- * @ignore
  */
 
 /**
- * @typedef {{
- *   type: string;
- *   name: string;
- *   storage: DataType | null;
- *   byteSize: number;
- * }} PlyProperty
- * @ignore
+ * @typedef {object} PlyProperty
+ * @property {string} type - E.g. 'float'.
+ * @property {string} name - E.g. 'x', 'y', 'z', 'f_dc_0' etc.
+ * @property {DataType} storage - Data type, e.g. instance of Float32Array.
+ * @property {number} byteSize - BYTES_PER_ELEMENT of given data type.
  */
 
 /**
- * @typedef {{
- *   name: string;
- *   count: number;
- *   properties: PlyProperty[];
- * }} PlyElement
- * @ignore
+ * @typedef {object} PlyElement
+ * @property {string} name - E.g. 'vertex'.
+ * @property {number} count - Given count.
+ * @property {PlyProperty[]} properties - The properties.
  */
 
 const magicBytes = new Uint8Array([112, 108, 121, 10]);                                                 // ply\n

--- a/src/platform/input/constants.js
+++ b/src/platform/input/constants.js
@@ -14,6 +14,7 @@ export const AXIS_KEY = 'key';
  * Name of event fired when a key is pressed.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_KEYDOWN = 'keydown';
 
@@ -21,6 +22,7 @@ export const EVENT_KEYDOWN = 'keydown';
  * Name of event fired when a key is released.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_KEYUP = 'keyup';
 
@@ -28,6 +30,7 @@ export const EVENT_KEYUP = 'keyup';
  * Name of event fired when a mouse button is pressed.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_MOUSEDOWN = 'mousedown';
 
@@ -35,6 +38,7 @@ export const EVENT_MOUSEDOWN = 'mousedown';
  * Name of event fired when the mouse is moved.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_MOUSEMOVE = 'mousemove';
 
@@ -42,6 +46,7 @@ export const EVENT_MOUSEMOVE = 'mousemove';
  * Name of event fired when a mouse button is released.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_MOUSEUP = 'mouseup';
 
@@ -49,6 +54,7 @@ export const EVENT_MOUSEUP = 'mouseup';
  * Name of event fired when the mouse wheel is rotated.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_MOUSEWHEEL = 'mousewheel';
 
@@ -56,6 +62,7 @@ export const EVENT_MOUSEWHEEL = 'mousewheel';
  * Name of event fired when a new touch occurs. For example, a finger is placed on the device.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_TOUCHSTART = 'touchstart';
 
@@ -63,6 +70,7 @@ export const EVENT_TOUCHSTART = 'touchstart';
  * Name of event fired when touch ends. For example, a finger is lifted off the device.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_TOUCHEND = 'touchend';
 
@@ -70,6 +78,7 @@ export const EVENT_TOUCHEND = 'touchend';
  * Name of event fired when a touch moves.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_TOUCHMOVE = 'touchmove';
 
@@ -80,6 +89,7 @@ export const EVENT_TOUCHMOVE = 'touchmove';
  * device supports, in which case the earliest touch point is canceled.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_TOUCHCANCEL = 'touchcancel';
 
@@ -87,6 +97,7 @@ export const EVENT_TOUCHCANCEL = 'touchcancel';
  * Name of event fired when a new xr select occurs. For example, primary trigger was pressed.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_SELECT = 'select';
 
@@ -94,6 +105,7 @@ export const EVENT_SELECT = 'select';
  * Name of event fired when a new xr select starts. For example, primary trigger is now pressed.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_SELECTSTART = 'selectstart';
 
@@ -101,6 +113,7 @@ export const EVENT_SELECTSTART = 'selectstart';
  * Name of event fired when xr select ends. For example, a primary trigger is now released.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_SELECTEND = 'selectend';
 
@@ -893,6 +906,7 @@ export const PAD_R_STICK_Y = 3;
  * Name of event fired when a gamepad connects.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_GAMEPADCONNECTED = 'gamepadconnected';
 
@@ -900,6 +914,7 @@ export const EVENT_GAMEPADCONNECTED = 'gamepadconnected';
  * Name of event fired when a gamepad disconnects.
  *
  * @category Input
+ * @ignore
  */
 export const EVENT_GAMEPADDISCONNECTED = 'gamepaddisconnected';
 

--- a/src/platform/input/constants.js
+++ b/src/platform/input/constants.js
@@ -11,113 +11,6 @@ export const AXIS_PAD_R_Y = 'padry';
 export const AXIS_KEY = 'key';
 
 /**
- * Name of event fired when a key is pressed.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_KEYDOWN = 'keydown';
-
-/**
- * Name of event fired when a key is released.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_KEYUP = 'keyup';
-
-/**
- * Name of event fired when a mouse button is pressed.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_MOUSEDOWN = 'mousedown';
-
-/**
- * Name of event fired when the mouse is moved.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_MOUSEMOVE = 'mousemove';
-
-/**
- * Name of event fired when a mouse button is released.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_MOUSEUP = 'mouseup';
-
-/**
- * Name of event fired when the mouse wheel is rotated.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_MOUSEWHEEL = 'mousewheel';
-
-/**
- * Name of event fired when a new touch occurs. For example, a finger is placed on the device.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_TOUCHSTART = 'touchstart';
-
-/**
- * Name of event fired when touch ends. For example, a finger is lifted off the device.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_TOUCHEND = 'touchend';
-
-/**
- * Name of event fired when a touch moves.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_TOUCHMOVE = 'touchmove';
-
-/**
- * Name of event fired when a touch point is interrupted in some way. The exact reasons for
- * canceling a touch can vary from device to device. For example, a modal alert pops up during the
- * interaction; the touch point leaves the document area, or there are more touch points than the
- * device supports, in which case the earliest touch point is canceled.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_TOUCHCANCEL = 'touchcancel';
-
-/**
- * Name of event fired when a new xr select occurs. For example, primary trigger was pressed.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_SELECT = 'select';
-
-/**
- * Name of event fired when a new xr select starts. For example, primary trigger is now pressed.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_SELECTSTART = 'selectstart';
-
-/**
- * Name of event fired when xr select ends. For example, a primary trigger is now released.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_SELECTEND = 'selectend';
-
-/**
  * @type {number}
  * @category Input
  */
@@ -901,22 +794,6 @@ export const PAD_R_STICK_X = 2;
  * @category Input
  */
 export const PAD_R_STICK_Y = 3;
-
-/**
- * Name of event fired when a gamepad connects.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_GAMEPADCONNECTED = 'gamepadconnected';
-
-/**
- * Name of event fired when a gamepad disconnects.
- *
- * @category Input
- * @ignore
- */
-export const EVENT_GAMEPADDISCONNECTED = 'gamepaddisconnected';
 
 /**
  * Horizontal axis on the touchpad of a XR pad.

--- a/src/platform/input/controller.js
+++ b/src/platform/input/controller.js
@@ -1,6 +1,5 @@
 import {
     ACTION_GAMEPAD, ACTION_KEYBOARD, ACTION_MOUSE,
-    EVENT_MOUSEMOVE,
     PAD_1,
     PAD_L_STICK_X, PAD_L_STICK_Y, PAD_R_STICK_X, PAD_R_STICK_Y
 } from './constants.js';
@@ -258,12 +257,12 @@ class Controller {
         const bind = function (controller, source, value, key) {
             switch (source) {
                 case 'mousex':
-                    controller._mouse.on(EVENT_MOUSEMOVE, (e) => {
+                    controller._mouse.on('mousemove', (e) => {
                         controller._axesValues[name][i] = e.dx / 10;
                     });
                     break;
                 case 'mousey':
-                    controller._mouse.on(EVENT_MOUSEMOVE, (e) => {
+                    controller._mouse.on('mousemove', (e) => {
                         controller._axesValues[name][i] = e.dy / 10;
                     });
                     break;

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -1,5 +1,5 @@
 import { EventHandler } from '../../core/event-handler.js';
-import { EVENT_GAMEPADCONNECTED, EVENT_GAMEPADDISCONNECTED, PAD_FACE_1, PAD_FACE_2, PAD_FACE_3, PAD_FACE_4, PAD_L_SHOULDER_1, PAD_R_SHOULDER_1, PAD_L_SHOULDER_2, PAD_R_SHOULDER_2, PAD_SELECT, PAD_START, PAD_L_STICK_BUTTON, PAD_R_STICK_BUTTON, PAD_UP, PAD_DOWN, PAD_LEFT, PAD_RIGHT, PAD_VENDOR, XRPAD_TRIGGER, XRPAD_SQUEEZE, XRPAD_TOUCHPAD_BUTTON, XRPAD_STICK_BUTTON, XRPAD_A, XRPAD_B, PAD_L_STICK_X, PAD_L_STICK_Y, PAD_R_STICK_X, PAD_R_STICK_Y, XRPAD_TOUCHPAD_X, XRPAD_TOUCHPAD_Y, XRPAD_STICK_X, XRPAD_STICK_Y } from './constants.js';
+import { PAD_FACE_1, PAD_FACE_2, PAD_FACE_3, PAD_FACE_4, PAD_L_SHOULDER_1, PAD_R_SHOULDER_1, PAD_L_SHOULDER_2, PAD_R_SHOULDER_2, PAD_SELECT, PAD_START, PAD_L_STICK_BUTTON, PAD_R_STICK_BUTTON, PAD_UP, PAD_DOWN, PAD_LEFT, PAD_RIGHT, PAD_VENDOR, XRPAD_TRIGGER, XRPAD_SQUEEZE, XRPAD_TOUCHPAD_BUTTON, XRPAD_STICK_BUTTON, XRPAD_A, XRPAD_B, PAD_L_STICK_X, PAD_L_STICK_Y, PAD_R_STICK_X, PAD_R_STICK_Y, XRPAD_TOUCHPAD_X, XRPAD_TOUCHPAD_Y, XRPAD_STICK_X, XRPAD_STICK_Y } from './constants.js';
 import { math } from '../../core/math/math.js';
 import { platform } from '../../core/platform.js';
 
@@ -903,7 +903,7 @@ class GamePads extends EventHandler {
         }
 
         current.push(pad);
-        this.fire(EVENT_GAMEPADCONNECTED, pad);
+        this.fire('gamepadconnected', pad);
     }
 
     /**
@@ -917,7 +917,7 @@ class GamePads extends EventHandler {
         const padIndex = current.findIndex(gp => gp.index === event.gamepad.index);
 
         if (padIndex !== -1) {
-            this.fire(EVENT_GAMEPADDISCONNECTED, current[padIndex]);
+            this.fire('gamepaddisconnected', current[padIndex]);
             current.splice(padIndex, 1);
         }
     }

--- a/src/platform/input/keyboard-event.js
+++ b/src/platform/input/keyboard-event.js
@@ -3,8 +3,11 @@
  */
 
 /**
- * The KeyboardEvent is passed into all event callbacks from the {@link Keyboard}. It corresponds
- * to a key press or release.
+ * The KeyboardEvent is passed into all event handlers registered on the {@link Keyboard}. The
+ * events are:
+ *
+ * - {@link Keyboard.EVENT_KEYDOWN}
+ * - {@link Keyboard.EVENT_KEYUP}
  *
  * @category Input
  */

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -51,8 +51,13 @@ const _keyCodeToKeyIdentifier = {
 };
 
 /**
- * A Keyboard device bound to an Element. Allows you to detect the state of the key presses. Note
- * that the Keyboard object must be attached to an Element before it can detect any key presses.
+ * Manages keyboard input by tracking key states and dispatching events. Extends {@link EventHandler}
+ * in order to fire `keydown` and `keyup` events (see {@link KeyboardEvent}).
+ *
+ * Allows the state of individual keys to be queried to check if they are currently pressed or were
+ * pressed/released since the last update. The class automatically handles browser visibility
+ * changes and window blur events by clearing key states. The Keyboard instance must be attached to
+ * a DOM element before it can detect key events.
  *
  * @category Input
  */
@@ -69,7 +74,7 @@ class Keyboard extends EventHandler {
      *     e.event.preventDefault(); // Use original browser event to prevent browser action.
      * };
      *
-     * app.keyboard.on("keydown", onKeyDown, this);
+     * app.keyboard.on('keydown', onKeyDown, this);
      */
     static EVENT_KEYDOWN = 'keydown';
 
@@ -85,7 +90,7 @@ class Keyboard extends EventHandler {
      *     e.event.preventDefault(); // Use original browser event to prevent browser action.
      * };
      *
-     * app.keyboard.on("keyup", onKeyUp, this);
+     * app.keyboard.on('keyup', onKeyUp, this);
      */
     static EVENT_KEYUP = 'keyup';
 

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -59,6 +59,8 @@ const _keyCodeToKeyIdentifier = {
  * changes and window blur events by clearing key states. The Keyboard instance must be attached to
  * a DOM element before it can detect key events.
  *
+ * Your application's Keyboard instance is managed and accessible via {@link AppBase#keyboard}.
+ *
  * @category Input
  */
 class Keyboard extends EventHandler {

--- a/src/platform/input/mouse-event.js
+++ b/src/platform/input/mouse-event.js
@@ -60,7 +60,7 @@ class MouseEvent {
 
     /**
      * A value representing the amount the mouse wheel has moved, only valid for
-     * {@link EVENT_MOUSEWHEEL} events.
+     * {@link Mouse.EVENT_MOUSEWHEEL} events.
      *
      * @type {number}
      */

--- a/src/platform/input/mouse-event.js
+++ b/src/platform/input/mouse-event.js
@@ -14,7 +14,13 @@ function isMousePointerLocked() {
 }
 
 /**
- * MouseEvent object that is passed to events 'mousemove', 'mouseup', 'mousedown' and 'mousewheel'.
+ * The MouseEvent object is passed into all event handlers registered on the {@link Mouse}. The
+ * events are:
+ *
+ * - {@link Mouse.EVENT_MOUSEDOWN}
+ * - {@link Mouse.EVENT_MOUSEUP}
+ * - {@link Mouse.EVENT_MOUSEMOVE}
+ * - {@link Mouse.EVENT_MOUSEWHEEL}
  *
  * @category Input
  */

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -18,6 +18,8 @@ import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
  * raw mouse movement input and control over the context menu. The Mouse instance must be attached
  * to a DOM element before it can detect mouse events.
  *
+ * Your application's Mouse instance is managed and accessible via {@link AppBase#mouse}.
+ *
  * @category Input
  */
 class Mouse extends EventHandler {

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -10,7 +10,13 @@ import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
  */
 
 /**
- * A Mouse Device, bound to a DOM Element.
+ * Manages mouse input by tracking button states and dispatching events. Extends {@link EventHandler}
+ * to fire `mousedown`, `mouseup`, `mousemove` and `mousewheel` events (see {@link MouseEvent}).
+ *
+ * Allows the state of mouse buttons to be queried to check if they are currently pressed or were
+ * pressed/released since the last update. Provides methods to enable/disable pointer lock for
+ * raw mouse movement input and control over the context menu. The Mouse instance must be attached
+ * to a DOM element before it can detect mouse events.
  *
  * @category Input
  */

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -287,7 +287,7 @@ class Mouse extends EventHandler {
         if (!e.event) return;
 
         // send 'mouseup' event
-        this.fire(EVENT_MOUSEUP, e);
+        this.fire('mouseup', e);
     }
 
     _handleDown(event) {
@@ -297,14 +297,14 @@ class Mouse extends EventHandler {
         const e = new MouseEvent(this, event);
         if (!e.event) return;
 
-        this.fire(EVENT_MOUSEDOWN, e);
+        this.fire('mousedown', e);
     }
 
     _handleMove(event) {
         const e = new MouseEvent(this, event);
         if (!e.event) return;
 
-        this.fire(EVENT_MOUSEMOVE, e);
+        this.fire('mousemove', e);
 
         // Store the last offset position to calculate deltas
         this._lastX = e.x;
@@ -315,7 +315,7 @@ class Mouse extends EventHandler {
         const e = new MouseEvent(this, event);
         if (!e.event) return;
 
-        this.fire(EVENT_MOUSEWHEEL, e);
+        this.fire('mousewheel', e);
     }
 
     _getTargetCoords(event) {

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -1,7 +1,6 @@
 import { platform } from '../../core/platform.js';
 import { EventHandler } from '../../core/event-handler.js';
 
-import { EVENT_MOUSEDOWN, EVENT_MOUSEMOVE, EVENT_MOUSEUP, EVENT_MOUSEWHEEL } from './constants.js';
 import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
 
 /**
@@ -25,7 +24,7 @@ class Mouse extends EventHandler {
      *     console.log(`Current mouse position is: ${e.x}, ${e.y}`);
      * });
      */
-    static EVENT_MOUSEMOVE = EVENT_MOUSEMOVE;
+    static EVENT_MOUSEMOVE = 'mousemove';
 
     /**
      * Fired when a mouse button is pressed. The handler is passed a {@link MouseEvent}.
@@ -36,7 +35,7 @@ class Mouse extends EventHandler {
      *     console.log(`The ${e.button} button was pressed at position: ${e.x}, ${e.y}`);
      * });
      */
-    static EVENT_MOUSEDOWN = EVENT_MOUSEDOWN;
+    static EVENT_MOUSEDOWN = 'mousedown';
 
     /**
      * Fired when a mouse button is released. The handler is passed a {@link MouseEvent}.
@@ -47,7 +46,7 @@ class Mouse extends EventHandler {
      *     console.log(`The ${e.button} button was released at position: ${e.x}, ${e.y}`);
      * });
      */
-    static EVENT_MOUSEUP = EVENT_MOUSEUP;
+    static EVENT_MOUSEUP = 'mouseup';
 
     /**
      * Fired when a mouse wheel is moved. The handler is passed a {@link MouseEvent}.
@@ -58,7 +57,7 @@ class Mouse extends EventHandler {
      *     console.log(`The mouse wheel was moved by ${e.wheelDelta}`);
      * });
      */
-    static EVENT_MOUSEWHEEL = EVENT_MOUSEWHEEL;
+    static EVENT_MOUSEWHEEL = 'mousewheel';
 
     /** @private */
     _lastX = 0;

--- a/src/platform/input/touch-device.js
+++ b/src/platform/input/touch-device.js
@@ -43,7 +43,11 @@ class TouchDevice extends EventHandler {
     static EVENT_TOUCHMOVE = 'touchmove';
 
     /**
-     * Fired when a touch is canceled. The handler is passed a {@link TouchEvent}.
+     * Fired when a touch is interrupted in some way. The exact reasons for canceling a touch can
+     * vary from device to device. For example, a modal alert pops up during the interaction; the
+     * touch point leaves the document area, or there are more touch points than the device
+     * supports, in which case the earliest touch point is canceled. The handler is passed a
+     * {@link TouchEvent}.
      *
      * @event
      * @example

--- a/src/platform/input/touch-device.js
+++ b/src/platform/input/touch-device.js
@@ -10,6 +10,50 @@ import { TouchEvent } from './touch-event.js';
  */
 class TouchDevice extends EventHandler {
     /**
+     * Fired when a touch starts. The handler is passed a {@link TouchEvent}.
+     *
+     * @event
+     * @example
+     * app.touch.on('touchstart', (e) => {
+     *     console.log(`Touch started at position: ${e.x}, ${e.y}`);
+     * });
+     */
+    static EVENT_TOUCHSTART = 'touchstart';
+
+    /**
+     * Fired when a touch ends. The handler is passed a {@link TouchEvent}.
+     *
+     * @event
+     * @example
+     * app.touch.on('touchend', (e) => {
+     *     console.log(`Touch ended at position: ${e.x}, ${e.y}`);
+     * });
+     */
+    static EVENT_TOUCHEND = 'touchend';
+
+    /**
+     * Fired when a touch moves. The handler is passed a {@link TouchEvent}.
+     *
+     * @event
+     * @example
+     * app.touch.on('touchmove', (e) => {
+     *     console.log(`Touch moved to position: ${e.x}, ${e.y}`);
+     * });
+     */
+    static EVENT_TOUCHMOVE = 'touchmove';
+
+    /**
+     * Fired when a touch is canceled. The handler is passed a {@link TouchEvent}.
+     *
+     * @event
+     * @example
+     * app.touch.on('touchcancel', (e) => {
+     *     console.log(`Touch canceled at position: ${e.x}, ${e.y}`);
+     * });
+     */
+    static EVENT_TOUCHCANCEL = 'touchcancel';
+
+    /**
      * Create a new touch device and attach it to an element.
      *
      * @param {Element} element - The element to attach listen for events on.

--- a/src/platform/input/touch-device.js
+++ b/src/platform/input/touch-device.js
@@ -10,6 +10,8 @@ import { TouchEvent } from './touch-event.js';
  * to respond to common touch gestures. The TouchDevice instance must be attached to a DOM element
  * before it can detect touch events.
  *
+ * Your application's TouchDevice instance is managed and accessible via {@link AppBase#touch}.
+ *
  * @category Input
  */
 class TouchDevice extends EventHandler {

--- a/src/platform/input/touch-device.js
+++ b/src/platform/input/touch-device.js
@@ -3,8 +3,12 @@ import { EventHandler } from '../../core/event-handler.js';
 import { TouchEvent } from './touch-event.js';
 
 /**
- * Attach a TouchDevice to an element and it will receive and fire events when the element is
- * touched. See also {@link Touch} and {@link TouchEvent}.
+ * Manages touch input by handling and dispatching touch events. Extends {@link EventHandler}
+ * to fire `touchstart`, `touchend`, `touchmove`, and `touchcancel` events (see {@link TouchEvent}).
+ *
+ * Detects and processes touch interactions with the attached DOM element, allowing applications
+ * to respond to common touch gestures. The TouchDevice instance must be attached to a DOM element
+ * before it can detect touch events.
  *
  * @category Input
  */

--- a/src/platform/input/touch-event.js
+++ b/src/platform/input/touch-event.js
@@ -90,8 +90,13 @@ class Touch {
 }
 
 /**
- * A Event corresponding to touchstart, touchend, touchmove or touchcancel. TouchEvent wraps the
- * standard browser DOM event and provides lists of {@link Touch} objects.
+ * The TouchEvent object is passed into all event handlers registered on the {@link TouchDevice}.
+ * The events are:
+ *
+ * - {@link TouchDevice.EVENT_TOUCHSTART}
+ * - {@link TouchDevice.EVENT_TOUCHEND}
+ * - {@link TouchDevice.EVENT_TOUCHMOVE}
+ * - {@link TouchDevice.EVENT_TOUCHCANCEL}
  *
  * @category Input
  */

--- a/test/platform/input/keyboard.test.mjs
+++ b/test/platform/input/keyboard.test.mjs
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { EVENT_KEYDOWN, EVENT_KEYUP, KEY_UP } from '../../../src/platform/input/constants.js';
+import { KEY_UP } from '../../../src/platform/input/constants.js';
 import { Keyboard } from '../../../src/platform/input/keyboard.js';
 
 describe('Keyboard', function () {
@@ -56,7 +56,7 @@ describe('Keyboard', function () {
     describe('#on', function () {
 
         it('should handle keydown events', (done) => {
-            keyboard.on(EVENT_KEYDOWN, (event) => {
+            keyboard.on('keydown', (event) => {
                 expect(event.key).to.equal(KEY_UP);
                 expect(event.element).to.equal(window);
                 expect(event.event).to.be.an.instanceOf(KeyboardEvent);
@@ -71,7 +71,7 @@ describe('Keyboard', function () {
         });
 
         it('should handle keyup events', (done) => {
-            keyboard.on(EVENT_KEYUP, (event) => {
+            keyboard.on('keyup', (event) => {
                 expect(event.key).to.equal(KEY_UP);
                 expect(event.element).to.equal(window);
                 expect(event.event).to.be.an.instanceOf(KeyboardEvent);

--- a/test/platform/input/mouse.test.mjs
+++ b/test/platform/input/mouse.test.mjs
@@ -1,9 +1,6 @@
 import { expect } from 'chai';
 
-import {
-    EVENT_MOUSEDOWN, EVENT_MOUSEUP,
-    MOUSEBUTTON_LEFT, MOUSEBUTTON_MIDDLE, MOUSEBUTTON_RIGHT
-} from '../../../src/platform/input/constants.js';
+import { MOUSEBUTTON_LEFT, MOUSEBUTTON_MIDDLE, MOUSEBUTTON_RIGHT } from '../../../src/platform/input/constants.js';
 import { Mouse } from '../../../src/platform/input/mouse.js';
 
 const buttons = [MOUSEBUTTON_LEFT, MOUSEBUTTON_MIDDLE, MOUSEBUTTON_RIGHT];
@@ -61,7 +58,7 @@ describe('Mouse', function () {
     describe('#on', function () {
 
         it('should handle mousedown events', (done) => {
-            mouse.on(EVENT_MOUSEDOWN, (event) => {
+            mouse.on('mousedown', (event) => {
                 expect(event.button).to.equal(MOUSEBUTTON_LEFT);
                 expect(event.event).to.be.an.instanceOf(MouseEvent);
 
@@ -73,7 +70,7 @@ describe('Mouse', function () {
         });
 
         it('should handle mouseup events', (done) => {
-            mouse.on(EVENT_MOUSEUP, (event) => {
+            mouse.on('mouseup', (event) => {
                 expect(event.button).to.equal(MOUSEBUTTON_LEFT);
                 expect(event.event).to.be.an.instanceOf(MouseEvent);
 


### PR DESCRIPTION
For quite some time now, all events have been static class fields and the user is expected to use the event string directly when registering a handler using `EventHandler#on`. This PR hides the 15 remaining 'old' top-level event constants and adds some missing declarations for touch events.

This PR also improves input-related JSDocs.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
