### PR TITLE
[BREAKING][FIX] Specular and sheen texture correctly handle sRGB encoding

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -903,7 +903,6 @@ const extensionPbrSpecGlossiness = (data, material, textures) => {
     }
     if (data.hasOwnProperty('specularGlossinessTexture')) {
         const specularGlossinessTexture = data.specularGlossinessTexture;
-        material.specularEncoding = 'srgb';
         material.specularMap = material.glossMap = textures[specularGlossinessTexture.index];
         material.specularMapChannel = 'rgb';
         material.glossMapChannel = 'a';
@@ -981,7 +980,6 @@ const extensionSpecular = (data, material, textures) => {
     material.useMetalnessSpecularColor = true;
 
     if (data.hasOwnProperty('specularColorTexture')) {
-        material.specularEncoding = 'srgb';
         material.specularMap = textures[data.specularColorTexture.index];
         material.specularMapChannel = 'rgb';
         extractTextureTransform(data.specularColorTexture, material, ['specular']);
@@ -1043,7 +1041,6 @@ const extensionSheen = (data, material, textures) => {
     }
     if (data.hasOwnProperty('sheenColorTexture')) {
         material.sheenMap = textures[data.sheenColorTexture.index];
-        material.sheenEncoding = 'srgb';
         extractTextureTransform(data.sheenColorTexture, material, ['sheen']);
     }
 
@@ -2085,6 +2082,36 @@ const createImages = (gltf, bufferViews, urlBase, registry, options) => {
                 if (gltfMaterial.hasOwnProperty('emissiveTexture')) {
                     const gltfTexture = gltf.textures[gltfMaterial.emissiveTexture.index];
                     set.add(getTextureSource(gltfTexture));
+                }
+
+                if (gltfMaterial.hasOwnProperty('extensions')) {
+
+                    // sheen
+                    const sheen = gltfMaterial.extensions.KHR_materials_sheen;
+                    if (sheen) {
+                        if (sheen.hasOwnProperty('sheenColorTexture')) {
+                            const gltfTexture = gltf.textures[sheen.sheenColorTexture.index];
+                            set.add(getTextureSource(gltfTexture));
+                        }
+                    }
+
+                    // specular glossiness
+                    const specularGlossiness = gltfMaterial.extensions.KHR_materials_pbrSpecularGlossiness;
+                    if (specularGlossiness) {
+                        if (specularGlossiness.hasOwnProperty('specularGlossinessTexture')) {
+                            const gltfTexture = gltf.textures[specularGlossiness.specularGlossinessTexture.index];
+                            set.add(getTextureSource(gltfTexture));
+                        }
+                    }
+
+                    // specular
+                    const specular = gltfMaterial.extensions.KHR_materials_specular;
+                    if (specular) {
+                        if (specular.hasOwnProperty('specularColorTexture')) {
+                            const gltfTexture = gltf.textures[specular.specularColorTexture.index];
+                            set.add(getTextureSource(gltfTexture));
+                        }
+                    }
                 }
             });
         }

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -231,8 +231,8 @@ class StandardMaterialOptionsBuilder {
         options.refractionTint = equalish(stdMat.refraction, 1.0);
         options.refractionIndexTint = equalish(stdMat.refractionIndex, 1.0 / 1.5);
         options.thicknessTint = (stdMat.useDynamicRefraction && stdMat.thickness !== 1.0);
-        options.specularEncoding = stdMat.specularEncoding || 'linear';
-        options.sheenEncoding = stdMat.sheenEncoding || 'linear';
+        options.specularEncoding = stdMat.specularMap?.encoding;
+        options.sheenEncoding = stdMat.sheenMap?.encoding;
         options.aoMapUv = stdMat.aoUvSet; // backwards compatibility
         options.aoDetail = !!stdMat.aoDetailMap;
         options.diffuseDetail = !!stdMat.diffuseDetailMap;


### PR DESCRIPTION
In engine v1, and engine v2 until now:
- when specular/sheen texture was loaded at runtime from glb, it was assumed to be sRGB
- when specular/sheen texture was lloaded from glb imported into Editor, it was incorrectly handled as linear
- when StandardMaterial had specular texture, it was incorrectly handled as linear

This change makes sure specular/sheen textures are always handled as sRGB, in accordance with glTF 2.0 spec.
This could cause some visual changes in case 2 and 3 mentioned above. The solution is to convert the texture to sRGB space in Photoshop or similar tool.

Code changes in this PR:
- shader generator honors the sRGB texture flag, instead of some random assigned member on standard material
- when glb is loaded, spec/sheen maps are loaded using sRGB format to get free gamma correction