### PR TITLE
A way to force linear encoded spec textures

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -54,7 +54,7 @@ class StandardMaterialOptionsBuilder {
     updateRef(options, scene, cameraShaderParams, stdMat, objDefs, pass, sortedLights) {
         this._updateSharedOptions(options, scene, stdMat, objDefs, pass);
         this._updateEnvOptions(options, stdMat, scene, cameraShaderParams);
-        this._updateMaterialOptions(options, stdMat);
+        this._updateMaterialOptions(options, stdMat, scene);
         options.litOptions.hasTangents = objDefs && ((objDefs & SHADERDEF_TANGENTS) !== 0);
         this._updateLightOptions(options, scene, stdMat, objDefs, sortedLights);
         this._updateUVOptions(options, stdMat, objDefs, false, cameraShaderParams);
@@ -201,7 +201,7 @@ class StandardMaterialOptionsBuilder {
         options.litOptions.lights = [];
     }
 
-    _updateMaterialOptions(options, stdMat) {
+    _updateMaterialOptions(options, stdMat, scene) {
         const useSpecular = !!(stdMat.useMetalness || stdMat.specularMap || stdMat.sphereMap || stdMat.cubeMap ||
                             notBlack(stdMat.specular) || (stdMat.specularityFactor > 0 && stdMat.useMetalness) ||
                             stdMat.enableGGXSpecular ||
@@ -245,6 +245,12 @@ class StandardMaterialOptionsBuilder {
         options.clearCoatGlossTint = (stdMat.clearCoatGloss !== 1.0);
         options.clearCoatPackedNormal = isPackedNormalMap(stdMat.clearCoatNormalMap);
         options.iorTint = equalish(stdMat.refractionIndex, 1.0 / 1.5);
+
+        // hack, see Scene.forcePassThroughSpecular description
+        if (scene.forcePassThroughSpecular) {
+            options.specularEncoding = 'linear';
+            options.sheenEncoding = 'linear';
+        }
 
         options.iridescenceTint = stdMat.iridescence !== 1.0;
 

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -273,6 +273,17 @@ class Scene extends EventHandler {
     _fogParams = new FogParams();
 
     /**
+     * Internal flag to indicate that the specular (and sheen) maps of standard materials should be
+     * assumed to be in a linear space, instead of sRGB. This is used by the editor using engine v2
+     * internally to render in a style of engine v1, where spec those textures were specified as
+     * linear, while engine 2 assumes they are in sRGB space. This should be removed when the editor
+     * no longer supports engine v1 projects.
+     *
+     * @ignore
+     */
+    forcePassThroughSpecular = false;
+
+    /**
      * Create a new Scene instance.
      *
      * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this scene.


### PR DESCRIPTION
Related to: https://github.com/playcanvas/engine/pull/7572

Engine V1 in most cases (apart from glbs) used specular and sheen textures in linear space.
Engine V2 aligns with glTF spec, and also handles all cases internally the same (glb or not), and those textures are expected in gamma (sRGB space).

This PR adds an internal flag which allows v1 projects to render similarly when using engine v2, but forcing no decoding on sampled data. This assume the textures do not use sRGB formats, as those would apply conversion automatically.

Note: The intended use here is the Editor, as it internally uses v2 engine and needs to render v1 projects correctly.