### PR TITLE
Partial WGSL support for LitMaterial

### DIFF
--- a/examples/src/examples/graphics/lit-material.example.mjs
+++ b/examples/src/examples/graphics/lit-material.example.mjs
@@ -107,14 +107,34 @@ assetListLoader.load(() => {
     material.setParameter('texture_diffuseMap', assets.color.resource);
     material.setParameter('texture_glossMap', assets.gloss.resource);
     material.setParameter('texture_normalMap', assets.normal.resource);
-    material.useSkybox = true;
-    material.hasSpecular = true;
-    material.hasSpecularityFactor = true;
-    material.hasNormals = true;
-    material.hasMetalness = true;
-    material.occludeSpecular = pc.SPECOCC_AO;
 
-    const argumentsChunk = `
+    if (app.graphicsDevice.isWebGPU) {
+
+        material.useSkybox = false;
+        material.useLighting = false;
+        material.useFog = true;
+        material.useTonemap = true;
+        material.opacityFadesSpecular = true;
+        material.hasSpecular = false;
+        material.hasSpecularityFactor = true;
+        material.hasNormals = true;
+        material.hasMetalness = true;
+        material.occludeSpecular = pc.SPECOCC_AO;
+
+    } else {
+
+        material.useSkybox = true;
+        material.hasSpecular = true;
+        material.hasSpecularityFactor = true;
+        material.hasNormals = true;
+        material.hasMetalness = true;
+        material.occludeSpecular = pc.SPECOCC_AO;
+    }
+
+    material.shaderChunkGLSL = `
+
+        #include "litShaderCorePS"
+
         uniform sampler2D texture_diffuseMap;
         uniform sampler2D texture_glossMap;
         uniform sampler2D texture_normalMap;
@@ -136,7 +156,15 @@ assetListLoader.load(() => {
             litArgs_ao = 0.0;
             litArgs_opacity = 1.0;
         }`;
-    material.shaderChunk = argumentsChunk;
+
+    material.shaderChunkWGSL = `
+
+        #include "litShaderCorePS"
+
+        fn evaluateFrontend() {
+            litArgs_emission = vec3f(0.7, 0, 0);
+        }`;
+
     material.update();
 
     // create primitive

--- a/examples/src/examples/graphics/wgsl-shader.example.mjs
+++ b/examples/src/examples/graphics/wgsl-shader.example.mjs
@@ -53,9 +53,8 @@ assetListLoader.load(() => {
 
     const material = new pc.ShaderMaterial({
         uniqueName: 'MyWGSLShader',
-        vertexCode: files['shader.vert.wgsl'],
-        fragmentCode: files['shader.frag.wgsl'],
-        shaderLanguage: pc.SHADERLANGUAGE_WGSL,
+        vertexWGSL: files['shader.vert.wgsl'],
+        fragmentWGSL: files['shader.frag.wgsl'],
         attributes: {
             position: pc.SEMANTIC_POSITION,
             texCoords: pc.SEMANTIC_TEXCOORD0

--- a/examples/src/examples/test/global-shader-properties.example.mjs
+++ b/examples/src/examples/test/global-shader-properties.example.mjs
@@ -113,7 +113,8 @@ assetListLoader.load(() => {
     material.hasMetalness = true;
     material.occludeSpecular = pc.SPECOCC_AO;
 
-    const argumentsChunk = `
+    material.shaderChunkGLSL = `
+        #include "litShaderCorePS"
         void evaluateFrontend() {
             litArgs_emission = vec3(0.7, 0.4, 0);
             litArgs_metalness = 0.5;
@@ -124,7 +125,6 @@ assetListLoader.load(() => {
             litArgs_ao = 0.0;
             litArgs_opacity = 1.0;
         }`;
-    material.shaderChunk = argumentsChunk;
     material.update();
 
     // create primitive

--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -84,6 +84,7 @@ class Preprocessor {
 
         // preprocess defines / ifdefs ..
         source = this._preprocess(source, defines, injectDefines, includes, options.stripDefines);
+        if (source === null) return null;
 
         // extract defines that evaluate to an integer number
         const intDefines = new Map();
@@ -214,7 +215,7 @@ class Preprocessor {
      * @param {Map<string, string>} [includes] - An object containing key-value pairs of include names and their
      * content.
      * @param {boolean} [stripDefines] - If true, strips all defines from the source.
-     * @returns {string} Returns preprocessed source code.
+     * @returns {string|null} Returns preprocessed source code, or null if failed.
      */
     static _preprocess(source, defines = new Map(), injectDefines, includes, stripDefines) {
 
@@ -427,7 +428,11 @@ class Preprocessor {
                     INCLUDE.lastIndex = match.index;
                     const include = INCLUDE.exec(source);
                     error ||= include === null;
-                    Debug.assert(include, `Invalid [${keyword}]: ${source.substring(match.index, match.index + 100)}...`);
+                    if (!include) {
+                        Debug.assert(include, `Invalid [${keyword}] while preprocessing ${Preprocessor.sourceName}:\n${source.substring(match.index, match.index + 100)}...`);
+                        error = true;
+                        continue;
+                    }
                     const identifier = include[1].trim();
                     const countIdentifier = include[2]?.trim();
 
@@ -486,7 +491,7 @@ class Preprocessor {
 
         if (error) {
             console.error('Failed to preprocess shader: ', { source: originalSource });
-            return originalSource;
+            return null;
         }
 
         return source;

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -157,6 +157,12 @@ class Shader {
                 stripDefines: wgsl,
                 sourceName: `fragment shader for ${this.label}`
             });
+
+            if (!definition.vshader || !definition.fshader) {
+                Debug.error(`Shader: Failed to create shader ${this.label}. Vertex or fragment shader source is empty.`, this);
+                this.failed = true;
+                return;
+            }
         }
 
         this.impl = graphicsDevice.createShaderImpl(this);

--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -824,7 +824,7 @@ class WebgpuShaderProcessorWGSL {
 
         // check if match exists AND the parameter name (Group 2) was captured
         if (!match || !match[2]) {
-            Debug.warn('No entry function found or input parameter name not captured.', shader);
+            Debug.warn('No entry function found or input parameter name not captured.', { shader, src });
             return src;
         }
 

--- a/src/scene/materials/lit-material-options.js
+++ b/src/scene/materials/lit-material-options.js
@@ -4,8 +4,11 @@ class LitMaterialOptions {
     // array of booleans indicating which UV channels are used by the material
     usedUvs;
 
-    // custom shader chunk to be added to the shader
-    shaderChunk;
+    // custom GLSL shader chunk to be added to the shader
+    shaderChunkGLSL;
+
+    // custom WGSL shader chunk to be added to the shader
+    shaderChunkWGSL;
 
     // lit options
     litOptions = new LitShaderOptions();

--- a/src/scene/materials/lit-material.js
+++ b/src/scene/materials/lit-material.js
@@ -22,7 +22,9 @@ const options = new LitMaterialOptions();
 class LitMaterial extends Material {
     usedUvs = [true];
 
-    shaderChunk = 'void evaluateFrontend() {}\n';
+    shaderChunkGLSL = null;
+
+    shaderChunkWGSL = null;
 
     useLighting = true;
 
@@ -88,7 +90,8 @@ class LitMaterial extends Material {
     getShaderVariant(params) {
 
         options.usedUvs = this.usedUvs.slice();
-        options.shaderChunk = this.shaderChunk;
+        options.shaderChunkGLSL = this.shaderChunkGLSL;
+        options.shaderChunkWGSL = this.shaderChunkWGSL;
         options.defines = getCoreDefines(this, params);
 
         LitMaterialOptionsBuilder.update(options.litOptions, this, params.scene, params.cameraShaderParams, params.objDefs, params.pass, params.sortedLights);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -577,6 +577,8 @@ class ForwardRenderer extends Renderer {
             const material = drawCall.material;
             const lightMask = drawCall.mask;
 
+            if (shaderInstance.shader.failed) continue;
+
             if (newMaterial) {
 
                 const asyncCompile = false;

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -325,6 +325,8 @@ class ShadowRenderer {
             const shadowShader = shaderInstance.shader;
             Debug.assert(shadowShader, `no shader for pass ${shadowPass}`, material);
 
+            if (shadowShader.failed) continue;
+
             // sort shadow casters by shader
             meshInstance._sortKeyShadow = shadowShader.id;
 

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -1,5 +1,5 @@
 // import alphaTestPS from './standard/frag/alphaTest.js';
-// import ambientPS from './lit/frag/ambient.js';
+import ambientPS from './lit/frag/ambient.js';
 // import aoPS from './standard/frag/ao.js';
 // import aoDiffuseOccPS from './lit/frag/aoDiffuseOcc.js';
 // import aoSpecOccPS from './lit/frag/aoSpecOcc.js';
@@ -15,21 +15,21 @@ import basePS from './lit/frag/base.js';
 // import clusteredLightCookiesPS from './lit/frag/clusteredLightCookies.js';
 // import clusteredLightShadowsPS from './lit/frag/clusteredLightShadows.js';
 // import clusteredLightPS from './lit/frag/clusteredLight.js';
-// import combinePS from './lit/frag/combine.js';
+import combinePS from './lit/frag/combine.js';
 import cookieBlit2DPS from './internal/frag/cookie-blit-2d.js';
 import cookieBlitCubePS from './internal/frag/cookie-blit-cube.js';
 import cookieBlitVS from './internal/vert/cookie-blit.js';
 // import cookiePS from './lit/frag/cookie.js';
 // import cubeMapProjectPS from './lit/frag/cubeMapProject.js';
 // import cubeMapRotatePS from './lit/frag/cubeMapRotate.js';
-// import debugOutputPS from './lit/frag/debug-output.js';
-// import debugProcessFrontendPS from './lit/frag/debug-process-frontend.js';
+import debugOutputPS from './lit/frag/debug-output.js';
+import debugProcessFrontendPS from './lit/frag/debug-process-frontend.js';
 import decodePS from './common/frag/decode.js';
 // import detailModesPS from './standard/frag/detailModes.js';
 // import diffusePS from './standard/frag/diffuse.js';
 // import emissivePS from './standard/frag/emissive.js';
 import encodePS from './common/frag/encode.js';
-// import endPS from './lit/frag/end.js';
+import endPS from './lit/frag/end.js';
 import envAtlasPS from './common/frag/envAtlas.js';
 import envProcPS from './common/frag/envProc.js';
 // import falloffInvSquaredPS from './lit/frag/falloffInvSquared.js';
@@ -67,21 +67,22 @@ import immediateLineVS from './internal/vert/immediateLine.js';
 // import lightEvaluationPS from './lit/frag/lighting/lightEvaluation.js';
 // import lightFunctionLightPS from './lit/frag/lighting/lightFunctionLight.js';
 // import lightFunctionShadowPS from './lit/frag/lighting/lightFunctionShadow.js';
-// import lightingPS from './lit/frag/lighting/lighting.js';
+import lightingPS from './lit/frag/lighting/lighting.js';
 // import lightmapAddPS from './lit/frag/lightmapAdd.js';
 // import lightmapPS from './standard/frag/lightmap.js';
 // import lightSpecularAnisoGGXPS from './lit/frag/lightSpecularAnisoGGX.js';
 // import lightSpecularBlinnPS from './lit/frag/lightSpecularBlinn.js';
 // import lightSheenPS from './lit/frag/lightSheen.js';
 // import linearizeDepthPS from './common/frag/linearizeDepth.js';
-// import litForwardBackendPS from './lit/frag/main/litBackend.js';
-// import litForwardDeclarationPS from './lit/frag/main/litForwardDeclaration.js';
-// import litForwardMainPS from './lit/frag/main/litForwardMain.js';
-// import litForwardPostCodePS from './lit/frag/main-forward/litForwardPostCode.js';
-// import litForwardPreCodePS from './lit/frag/main-forward/litForwardPreCode.js';
-// import litMainVS from './lit/vert/litMain.js';
+import litForwardBackendPS from './lit/frag/pass-forward/litForwardBackend.js';
+import litForwardDeclarationPS from './lit/frag/pass-forward/litForwardDeclaration.js';
+import litForwardMainPS from './lit/frag/pass-forward/litForwardMain.js';
+import litForwardPostCodePS from './lit/frag/pass-forward/litForwardPostCode.js';
+import litForwardPreCodePS from './lit/frag/pass-forward/litForwardPreCode.js';
+import litMainVS from './lit/vert/litMain.js';
 // import litOtherMainPS from './lit/frag/pass-other/litOtherMain.js';
 import litShaderArgsPS from './standard/frag/litShaderArgs.js';
+import litShaderCorePS from './standard/frag/litShaderCore.js';
 // import litShadowMainPS from './lit/frag/pass-shadow/litShadowMain.js';
 // import ltcPS from './lit/frag/ltc.js';
 // import metalnessPS from './standard/frag/metalness.js';
@@ -97,8 +98,8 @@ import normalCoreVS from './common/vert/normalCore.js';
 // import normalMapPS from './standard/frag/normalMap.js';
 // import opacityPS from './standard/frag/opacity.js';
 // import opacityDitherPS from './standard/frag/opacity-dither.js';
-// import outputPS from './lit/frag/output.js';
-// import outputAlphaPS from './lit/frag/outputAlpha.js';
+import outputPS from './lit/frag/output.js';
+import outputAlphaPS from './lit/frag/outputAlpha.js';
 // import outputTex2DPS from './common/frag/outputTex2D.js';
 // import sheenPS from './standard/frag/sheen.js';
 // import sheenGlossPS from './standard/frag/sheenGloss.js';
@@ -191,15 +192,15 @@ import tonemappingHejlPS from './common/frag/tonemapping/tonemappingHejl.js';
 import tonemappingLinearPS from './common/frag/tonemapping/tonemappingLinear.js';
 import tonemappingNeutralPS from './common/frag/tonemapping/tonemappingNeutral.js';
 import tonemappingNonePS from './common/frag/tonemapping/tonemappingNone.js';
-// import transformVS from './common/vert/transform.js';
+import transformVS from './common/vert/transform.js';
 import transformCoreVS from './common/vert/transformCore.js';
 // import transformInstancingVS from './common/vert/transformInstancing.js';
 // import transmissionPS from './standard/frag/transmission.js';
 // import twoSidedLightingPS from './lit/frag/twoSidedLighting.js';
-// import uv0VS from './lit/vert/uv0.js';
-// import uv1VS from './lit/vert/uv1.js';
-// import uvTransformPS from './lit/vert/uvTransform.js';
-// import uvTransformUniformsPS from './lit/vert/uvTransformUniforms.js';
+import uv0VS from './lit/vert/uv0.js';
+import uv1VS from './lit/vert/uv1.js';
+import uvTransformVS from './lit/vert/uvTransform.js';
+import uvTransformUniformsPS from './lit/vert/uvTransformUniforms.js';
 // import viewDirPS from './lit/frag/viewDir.js';
 // import webgpuPS from '../../../platform/graphics/shader-chunks/frag/webgpu.js';
 // import webgpuVS from '../../../platform/graphics/shader-chunks/vert/webgpu.js';
@@ -212,7 +213,7 @@ import transformCoreVS from './common/vert/transformCore.js';
  */
 const shaderChunksWGSL = {
     // alphaTestPS,
-    // ambientPS,
+    ambientPS,
     // aoPS,
     // aoDiffuseOccPS,
     // aoSpecOccPS,
@@ -228,21 +229,21 @@ const shaderChunksWGSL = {
     // clusteredLightShadowsPS,
     // clusteredLightUtilsPS,
     // clusteredLightPS,
-    // combinePS,
+    combinePS,
     cookieBlit2DPS,
     cookieBlitCubePS,
     cookieBlitVS,
     // cookiePS,
     // cubeMapProjectPS,
     // cubeMapRotatePS,
-    // debugOutputPS,
-    // debugProcessFrontendPS,
+    debugOutputPS,
+    debugProcessFrontendPS,
     // detailModesPS,
     // diffusePS,
     decodePS,
     // emissivePS,
     encodePS,
-    // endPS,
+    endPS,
     envAtlasPS,
     // envConstPS,
     envProcPS,
@@ -282,21 +283,22 @@ const shaderChunksWGSL = {
     // lightEvaluationPS,
     // lightFunctionLightPS,
     // lightFunctionShadowPS,
-    // lightingPS,
+    lightingPS,
     // lightmapAddPS,
     // lightmapPS,
     // lightSpecularAnisoGGXPS,
     // lightSpecularBlinnPS,
     // lightSheenPS,
     // linearizeDepthPS,
-    // litForwardBackendPS,
-    // litForwardDeclarationPS,
-    // litForwardPSMain,
-    // litForwardPostCodePS,
-    // litForwardPreCodePS,
-    // litMainVS,
+    litForwardBackendPS,
+    litForwardDeclarationPS,
+    litForwardMainPS,
+    litForwardPostCodePS,
+    litForwardPreCodePS,
+    litMainVS,
     // litOtherMainPS,
     litShaderArgsPS,
+    litShaderCorePS,
     // litShadowMainPS,
     // ltcPS,
     // metalnessPS,
@@ -312,8 +314,8 @@ const shaderChunksWGSL = {
     // normalMapPS,
     // opacityPS,
     // opacityDitherPS,
-    // outputPS,
-    // outputAlphaPS,
+    outputPS,
+    outputAlphaPS,
     // outputTex2DPS,
     // sheenPS,
     // sheenGlossPS,
@@ -406,15 +408,15 @@ const shaderChunksWGSL = {
     tonemappingLinearPS,
     tonemappingNeutralPS,
     tonemappingNonePS,
-    // transformVS,
-    transformCoreVS
+    transformVS,
+    transformCoreVS,
     // transformInstancingVS,
     // transmissionPS,
     // twoSidedLightingPS,
-    // uv0VS,
-    // uv1VS,
-    // uvTransformPS,
-    // uvTransformUniformsPS,
+    uv0VS,
+    uv1VS,
+    uvTransformVS,
+    uvTransformUniformsPS
     // viewDirPS,
     // webgpuPS,
     // webgpuVS

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/decode.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/decode.js
@@ -11,7 +11,7 @@ fn decodeGammaFloat(raw: f32) -> f32 {
     return pow(raw, 2.2);
 }
 
-fn decodeGammaVec3(raw: vec3f) -> vec3f {
+fn decodeGamma3(raw: vec3f) -> vec3f {
     return pow(raw, vec3f(2.2));
 }
 

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/gamma.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/gamma.js
@@ -9,11 +9,11 @@ export default /* wgsl */`
     }
 
     fn gammaCorrectInputVec3(color: vec3f) -> vec3f {
-        return decodeGammaVec3(color);
+        return decodeGamma3(color);
     }
 
     fn gammaCorrectInputVec4(color: vec4f) -> vec4f {
-        return vec4f(decodeGammaVec3(color.xyz), color.w);
+        return vec4f(decodeGamma3(color.xyz), color.w);
     }
 
     fn gammaCorrectOutput(color: vec3f) -> vec3f {

--- a/src/scene/shader-lib/chunks-wgsl/common/vert/transform.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/vert/transform.js
@@ -1,0 +1,74 @@
+export default /* wgsl */`
+#ifdef PIXELSNAP
+    uniform uScreenSize: vec4f;
+#endif
+
+#ifdef SCREENSPACE
+    uniform projectionFlipY: f32;
+#endif
+
+fn evalWorldPosition(vertexPosition: vec3f, modelMatrix: mat4x4f) -> vec4f {
+
+    var localPos: vec3f = getLocalPosition(vertexPosition);
+
+    #ifdef NINESLICED
+        // outer and inner vertices are at the same position, scale both
+        localPos.xz *= uniform.outerScale;
+
+        // offset inner vertices inside
+        // (original vertices must be in [-1;1] range)
+        let positiveUnitOffset: vec2f = clamp(vertexPosition.xz, vec2f(0.0), vec2f(1.0));
+        let negativeUnitOffset: vec2f = clamp(-vertexPosition.xz, vec2f(0.0), vec2f(1.0));
+        localPos.xz += (-positiveUnitOffset * uniform.innerOffset.xy + negativeUnitOffset * uniform.innerOffset.zw) * vertex_texCoord0.xy;
+
+        vTiledUv = (localPos.xz - outerScale + uniform.innerOffset.xy) * -0.5 + 1.0; // uv = local pos - inner corner
+
+        localPos.xz *= -0.5; // move from -1;1 to -0.5;0.5
+        localPos = localPos.xzy;
+    #endif
+
+    var posW: vec4f = modelMatrix * vec4f(localPos, 1.0);
+
+    #ifdef SCREENSPACE
+        posW.zw = vec2f(0.0, 1.0);
+    #endif
+
+    return posW;
+}
+
+fn getPosition() -> vec4f {
+
+    dModelMatrix = getModelMatrix();
+
+    let posW: vec4f = evalWorldPosition(vertex_position.xyz, dModelMatrix);
+    dPositionW = posW.xyz;
+
+    var screenPos: vec4f;
+    #ifdef UV1LAYOUT
+        screenPos = vec4f(vertex_texCoord1.xy * 2.0 - 1.0, 0.5, 1.0);
+        screenPos.y *= -1.0;
+    #else
+        #ifdef SCREENSPACE
+            screenPos = posW;
+            screenPos.y *= uniforms.projectionFlipY;
+        #else
+            screenPos = uniform.matrix_viewProjection * posW;
+        #endif
+
+        #ifdef PIXELSNAP
+            // snap vertex to a pixel boundary
+            screenPos.xy = (screenPos.xy * 0.5) + 0.5;
+            screenPos.xy *= uniforms.uScreenSize.xy;
+            screenPos.xy = floor(screenPos.xy);
+            screenPos.xy *= uniforms.uScreenSize.zw;
+            screenPos.xy = (screenPos.xy * 2.0) - 1.0;
+        #endif
+    #endif
+
+    return screenPos;
+}
+
+fn getWorldPosition() -> vec3f {
+    return dPositionW;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/internal/frag/immediateLine.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/frag/immediateLine.js
@@ -4,7 +4,7 @@ export default /* wgsl */`
     @fragment
     fn fragmentMain(input : FragmentInput) -> FragmentOutput {
         var output: FragmentOutput;
-        output.color = vec4f(gammaCorrectOutput(decodeGammaVec3(input.color.rgb)), input.color.a);
+        output.color = vec4f(gammaCorrectOutput(decodeGamma3(input.color.rgb)), input.color.a);
         return output;
     }
 `;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/ambient.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/ambient.js
@@ -1,7 +1,6 @@
 export default /* wgsl */`
 
-#ifdef LIT_AMBIENT_SOURCE == AMBIENTSH
-    uniform ambientSH: array<vec3f, 9>;
+#if LIT_AMBIENT_SOURCE == AMBIENTSH
 #endif
 
 #if LIT_AMBIENT_SOURCE == ENVALATLAS

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/ambient.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/ambient.js
@@ -1,0 +1,53 @@
+export default /* wgsl */`
+
+#ifdef LIT_AMBIENT_SOURCE == AMBIENTSH
+    uniform ambientSH: array<vec3f, 9>;
+#endif
+
+#if LIT_AMBIENT_SOURCE == ENVALATLAS
+    #include "envAtlasPS"
+
+    #ifndef ENV_ATLAS
+        #define ENV_ATLAS
+        var texture_envAtlas: texture_2d<f32>;
+        var texture_envAtlasSampler: sampler;
+    #endif
+#endif
+
+fn addAmbient(worldNormal: vec3f) {
+    #ifdef LIT_AMBIENT_SOURCE == AMBIENTSH
+
+        let n: vec3f = cubeMapRotate(worldNormal);
+        let color: vec3f =
+            uniform.ambientSH[0] +
+            uniform.ambientSH[1] * n.x +
+            uniform.ambientSH[2] * n.y +
+            uniform.ambientSH[3] * n.z +
+            uniform.ambientSH[4] * n.x * n.z +
+            uniform.ambientSH[5] * n.z * n.y +
+            uniform.ambientSH[6] * n.y * n.x +
+            uniform.ambientSH[7] * (3.0 * n.z * n.z - 1.0) +
+            uniform.ambientSH[8] * (n.x * n.x - n.y * n.y);
+
+        dDiffuseLight += processEnvironment(max(color, vec3f(0.0)));
+
+    #endif
+
+    #if LIT_AMBIENT_SOURCE == ENVALATLAS
+
+        let dir: vec3f = normalize(cubeMapRotate(worldNormal) * vec3f(-1.0, 1.0, 1.0));
+        let uv: vec2f = mapUv(toSphericalUv(dir), vec4f(128.0, 256.0 + 128.0, 64.0, 32.0) / atlasSize);
+
+        let raw: vec4f = textureSample(texture_envAtlas, texture_envAtlasSampler, uv);
+        let linear: vec3f = {ambientDecode}(raw);
+        dDiffuseLight += processEnvironment(linear);
+
+    #endif
+
+    #if LIT_AMBIENT_SOURCE == CONSTANT
+
+        dDiffuseLight += uniform.light_globalAmbient;
+
+    #endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/base.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/base.js
@@ -11,7 +11,7 @@ fn saturate(x: f32) -> f32 {
     return clamp(x, 0.0, 1.0);
 }
 
-fn saturate(x: vec3f) -> vec3f {
+fn saturate3(x: vec3f) -> vec3f {
     return clamp(x, vec3f(0.0), vec3f(1.0));
 }
 `;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/combine.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/combine.js
@@ -1,0 +1,28 @@
+export default /* wgsl */`
+fn combineColor(albedo: vec3f, sheenSpecularity: vec3f, clearcoatSpecularity: f32) -> vec3f {
+    var ret: vec3f = vec3f(0.0);
+
+    #ifdef LIT_OLD_AMBIENT
+        ret += (dDiffuseLight - uniform.light_globalAmbient) * albedo + uniform.material_ambient * uniform.light_globalAmbient;
+    #else
+        ret += albedo * dDiffuseLight;
+    #endif // LIT_OLD_AMBIENT
+    #ifdef LIT_SPECULAR
+        ret += dSpecularLight;
+    #endif // LIT_SPECULAR
+    #ifdef LIT_REFLECTIONS
+        ret += dReflection.rgb * dReflection.a;
+    #endif // LIT_REFLECTIONS
+
+    #ifdef LIT_SHEEN
+        let sheenScaling: f32 = 1.0 - max(max(sheenSpecularity.r, sheenSpecularity.g), sheenSpecularity.b) * 0.157;
+        ret = ret * sheenScaling + (sSpecularLight + sReflection.rgb) * sheenSpecularity;
+    #endif // LIT_SHEEN
+    #ifdef LIT_CLEARCOAT
+        let clearCoatScaling: f32 = 1.0 - ccFresnel * clearcoatSpecularity;
+        ret = ret * clearCoatScaling + (ccSpecularLight + ccReflection.rgb) * clearcoatSpecularity;
+    #endif // LIT_CLEARCOAT
+
+    return ret;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/debug-output.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/debug-output.js
@@ -1,0 +1,37 @@
+export default /* wgsl */`
+#ifdef DEBUG_ALBEDO_PASS
+output.color = vec4(gammaCorrectOutput(dAlbedo), 1.0);
+#endif
+
+#ifdef DEBUG_UV0_PASS
+output.color = vec4f(litArgs_albedo , 1.0);
+#endif
+
+#ifdef DEBUG_WORLD_NORMAL_PASS
+output.color = vec4f(litArgs_worldNormal * 0.5 + 0.5, 1.0);
+#endif
+
+#ifdef DEBUG_OPACITY_PASS
+output.color = vec4f(vec3f(litArgs_opacity) , 1.0);
+#endif
+
+#ifdef DEBUG_SPECULARITY_PASS
+output.color = vec4f(litArgs_specularity, 1.0);
+#endif
+
+#ifdef DEBUG_GLOSS_PASS
+output.color = vec4f(vec3f(litArgs_gloss) , 1.0);
+#endif
+
+#ifdef DEBUG_METALNESS_PASS
+output.color = vec4f(vec3f(litArgs_metalness) , 1.0);
+#endif
+
+#ifdef DEBUG_AO_PASS
+output.color = vec4f(vec3f(litArgs_ao) , 1.0);
+#endif
+
+#ifdef DEBUG_EMISSION_PASS
+output.color = vec4f(gammaCorrectOutput(litArgs_emission), 1.0);
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/debug-process-frontend.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/debug-process-frontend.js
@@ -1,0 +1,13 @@
+export default /* wgsl */`
+#ifdef DEBUG_LIGHTING_PASS
+    litArgs_albedo = vec3f(0.5);
+#endif
+
+#ifdef DEBUG_UV0_PASS
+#ifdef VARYING_VUV0
+    litArgs_albedo = vec3f(vUv0, 0.0);
+#else
+    litArgs_albedo = vec3f(0.0);
+#endif
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/end.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/end.js
@@ -1,0 +1,9 @@
+export default /* wgsl */`
+    var finalRgb: vec3f = combineColor(litArgs_albedo, litArgs_sheen_specularity, litArgs_clearcoat_specularity);
+
+    finalRgb = finalRgb + litArgs_emission;
+    finalRgb = addFog(finalRgb);
+    finalRgb = toneMap(finalRgb);
+    finalRgb = gammaCorrectOutput(finalRgb);
+    output.color = vec4f(finalRgb, output.color.a);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/lighting/lighting.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/lighting/lighting.js
@@ -1,5 +1,5 @@
 // functionality includes for lighting / shadowing code.
-export default /* glsl */`
+export default /* wgsl */`
 
 #ifdef LIT_CLUSTERED_LIGHTS
     // all this functionality that needs to be included for clustered lighting
@@ -10,8 +10,10 @@ export default /* glsl */`
 #endif
 
 #ifdef AREA_LIGHTS
-    uniform highp sampler2D areaLightsLutTex1;
-    uniform highp sampler2D areaLightsLutTex2;
+    var areaLightsLutTex1: texture_2d<f32>;
+    var areaLightsLutTex1Sampler: sampler;
+    var areaLightsLutTex2: texture_2d<f32>;
+    var areaLightsLutTex2Sampler: sampler;
 #endif
 
 #ifdef LIT_LIGHTING

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/output.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/output.js
@@ -1,0 +1,2 @@
+export default /* wgsl */`
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/outputAlpha.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/outputAlpha.js
@@ -1,0 +1,16 @@
+export default /* wgsl */`
+
+#if LIT_BLEND_TYPE == NORMAL || LIT_BLEND_TYPE == ADDITIVEALPHA || defined(LIT_ALPHA_TO_COVERAGE)
+
+    output.color = vec4f(output.color.rgb, litArgs_opacity);
+
+#elif LIT_BLEND_TYPE == PREMULTIPLIED
+
+    output.color = vec4f(output.color.rgb * litArgs_opacity, litArgs_opacity);
+
+#else
+
+    output.color = vec4f(output.color.rgb, 1.0);
+
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-forward/litForwardDeclaration.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-forward/litForwardDeclaration.js
@@ -1,0 +1,61 @@
+// shader declarations for the lit material for forward rendering
+export default /* wgsl */`
+
+// globals
+var<private> sReflection: vec3f;
+var<private> dVertexNormalW: vec3f;
+var<private> dTangentW: vec3f;
+var<private> dBinormalW: vec3f;
+var<private> dViewDirW: vec3f;
+var<private> dReflDirW: vec3f;
+var<private> ccReflDirW: vec3f;
+
+// Per-light temporaries
+var<private> dLightDirNormW: vec3f;
+var<private> dAtten: f32;
+
+// Outputs
+var<private> dTBN: mat3x3f;
+var<private> dReflection: vec4f;
+var<private> dDiffuseLight: vec3f;
+var<private> dSpecularLight: vec3f;
+var<private> ccFresnel: f32;
+var<private> ccReflection: vec3f;
+var<private> ccSpecularLight: vec3f;
+var<private> ccSpecularityNoFres: f32;
+var<private> sSpecularLight: vec3f;
+
+// FRAGMENT SHADER INPUTS: UNIFORMS
+
+#ifdef LIT_DISPERSION
+    uniform material_dispersion: f32;
+#endif
+
+#ifndef LIT_OPACITY_FADES_SPECULAR
+    uniform material_alphaFade: f32;
+#endif
+
+#ifdef LIT_SSAO
+    var ssaoTexture : texture_2d<f32>;
+    var ssaoTextureSampler : sampler;
+    uniform ssaoTextureSizeInv: vec2f;
+#endif
+
+// lighting and shadowing declarations
+
+#ifdef LIT_SHADOW_CATCHER
+    // a variable to accumulate shadows for shadow catcher materials
+    var<private> dShadowCatcher: f32 = 1.0;
+#endif
+
+// LOOP - uniform declarations for all non-clustered lights
+#if LIGHT_COUNT > 0
+    #include "lightDeclarationPS, LIGHT_COUNT"
+#endif
+
+#ifdef LIT_SPECULAR
+    #if LIT_FRESNEL_MODEL == NONE && !defined(LIT_REFLECTIONS) && !defined(LIT_DIFFUSE_MAP) 
+        #define LIT_OLD_AMBIENT
+    #endif
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-forward/litForwardMain.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-forward/litForwardMain.js
@@ -1,0 +1,50 @@
+// main shader entry point for the lit material for forward rendering
+export default /* wgsl */`
+
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+
+    dReflection = vec4f(0.0);
+
+    #ifdef LIT_CLEARCOAT
+        ccSpecularLight = vec3f(0.0);
+        ccReflection = vec3f(0.0);
+    #endif
+
+    #if LIT_NONE_SLICE_MODE == SLICED
+        #include "startNineSlicedPS"
+    #elif LIT_NONE_SLICE_MODE == TILED
+        #include "startNineSlicedTiledPS"
+    #endif
+
+    #ifdef LIT_NEEDS_NORMAL
+        dVertexNormalW = normalize(vNormalW);
+
+        #ifdef LIT_TANGENTS
+            #if defined(LIT_HEIGHTS) || defined(LIT_USE_NORMALS) || defined(LIT_USE_CLEARCOAT_NORMALS)
+                dTangentW = vTangentW;
+                dBinormalW = vBinormalW;
+            #endif
+        #endif
+
+        getViewDir();
+
+        #ifdef LIT_TBN
+            getTBN(dTangentW, dBinormalW, dVertexNormalW);
+
+            #ifdef LIT_TWO_SIDED_LIGHTING
+                handleTwoSidedLighting();
+            #endif
+        #endif
+    #endif
+
+    // invoke frontend functions
+    evaluateFrontend();
+
+    #include "debugProcessFrontendPS"
+
+    var output: FragmentOutput = evaluateBackend();
+
+    return output;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-forward/litForwardPostCode.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-forward/litForwardPostCode.js
@@ -1,0 +1,109 @@
+// backend shader implementation code which executes after the front end code.
+export default /* wgsl */`
+
+#ifdef LIT_NEEDS_NORMAL
+    #include "cubeMapRotatePS"
+    #include "cubeMapProjectPS"
+    #include "envProcPS"
+#endif
+
+// ----- specular or reflections -----
+#ifdef LIT_SPECULAR_OR_REFLECTION
+    #ifdef LIT_METALNESS
+        #include "metalnessModulatePS"
+    #endif
+
+    #if LIT_FRESNEL_MODEL == SCHLICK
+        #include "fresnelSchlickPS"
+    #endif
+
+    #ifdef LIT_IRIDESCENCE
+        #include "iridescenceDiffractionPS"
+    #endif
+#endif
+
+// ----- ambient occlusion -----
+#ifdef LIT_AO
+    #include "aoDiffuseOccPS"
+    #include "aoSpecOccPS"
+#endif
+
+#if LIT_REFLECTION_SOURCE == ENVATLASHQ
+    #include "envAtlasPS"
+    #include "reflectionEnvHQPS"
+#elif LIT_REFLECTION_SOURCE == ENVATLAS
+    #include "envAtlasPS"
+    #include "reflectionEnvPS"
+#elif LIT_REFLECTION_SOURCE == CUBEMAP
+    #include "reflectionCubePS"
+#elif LIT_REFLECTION_SOURCE == SPHEREMAP
+    #include "reflectionSpherePS"
+#endif
+
+#ifdef LIT_REFLECTIONS
+    #ifdef LIT_CLEARCOAT
+        #include "reflectionCCPS"
+    #endif
+
+    #ifdef LIT_SHEEN
+        #include "reflectionSheenPS"
+    #endif
+#endif
+
+#ifdef LIT_REFRACTION
+    #if defined(LIT_DYNAMIC_REFRACTION)
+        #include "refractionDynamicPS"
+    #elif defined(LIT_REFLECTIONS)
+        #include "refractionCubePS"
+    #endif
+#endif
+
+#ifdef LIT_SHEEN
+    #include "lightSheenPS"
+#endif
+
+#ifdef LIT_GGX_SPECULAR
+    uniform material_anisotropy: f32;
+#endif
+
+uniform material_ambient: vec3f;
+
+#ifdef LIT_SPECULAR
+    #ifdef LIT_LIGHTING
+        #ifdef LIT_GGX_SPECULAR
+            #include "lightSpecularAnisoGGXPS"
+        #else
+            #include "lightSpecularBlinnPS"
+        #endif
+    #endif
+#endif
+
+#include "combinePS"
+
+#ifdef LIT_LIGHTMAP
+    #include "lightmapAddPS"
+#endif
+
+#ifdef LIT_ADD_AMBIENT
+    #include "ambientPS"
+#endif
+
+#ifdef LIT_MSDF
+    #include "msdfPS"
+#endif
+
+#ifdef LIT_NEEDS_NORMAL
+    #include "viewDirPS"
+    #ifdef LIT_SPECULAR
+        #ifdef LIT_GGX_SPECULAR
+            #include "reflDirAnisoPS"
+        #else
+            #include "reflDirPS"
+        #endif
+    #endif
+#endif
+
+// lighting functionality
+#include "lightingPS"
+
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-forward/litForwardPreCode.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-forward/litForwardPreCode.js
@@ -1,0 +1,28 @@
+// backend shader implementation code which executes prior to the front end code, and contains code
+// which is required by the frontend code.
+export default /* wgsl */`
+
+#include "basePS"
+#include "sphericalPS"
+#include "decodePS"
+#include "gammaPS"
+#include "tonemappingPS"
+#include "fogPS"
+
+// 9-slice support code
+#if LIT_NONE_SLICE_MODE == SLICED
+    #include "baseNineSlicedPS"
+#elif LIT_NONE_SLICE_MODE == TILED
+    #include "baseNineSlicedTiledPS"
+#endif
+
+// TBN
+#ifdef LIT_TBN
+    #include "TBNPS"
+
+    #ifdef LIT_TWO_SIDED_LIGHTING
+        #include "twoSidedLightingPS"
+    #endif
+#endif
+
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/vert/uv0.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/vert/uv0.js
@@ -1,0 +1,24 @@
+export default /* wgsl */`
+#ifdef NINESLICED
+    fn getUv0() -> vec2f {
+        var uv = vertex_position.xz;
+
+        // offset inner vertices inside
+        let positiveUnitOffset = clamp(vertex_position.xz, vec2f(0.0, 0.0), vec2f(1.0, 1.0));
+        let negativeUnitOffset = clamp(-vertex_position.xz, vec2f(0.0, 0.0), vec2f(1.0, 1.0));
+
+        uv = uv + ((-positiveUnitOffset * uniform.innerOffset.xy) + (negativeUnitOffset * uniform.innerOffset.zw)) * vertex_texCoord0.xy;
+
+        uv = uv * -0.5 + vec2f(0.5, 0.5);
+        uv = uv * uniform.atlasRect.zw + uniform.atlasRect.xy;
+
+        vMask = vertex_texCoord0.xy;
+
+        return uv;
+    }
+#else
+    fn getUv0() -> vec2f {
+        return vertex_texCoord0;
+    }
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/vert/uv1.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/vert/uv1.js
@@ -1,0 +1,5 @@
+export default /* wgsl */`
+fn getUv1() -> vec2f {
+    return vertex_texCoord1;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/vert/uvTransform.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/vert/uvTransform.js
@@ -1,0 +1,7 @@
+// chunk that generates uv coordinate transformed by uv transform matrix
+export default /* wgsl */`
+vUV{TRANSFORM_UV_{i}}_{TRANSFORM_ID_{i}} = vec2f(
+    dot(vec3f(uv{TRANSFORM_UV_{i}}, 1), {TRANSFORM_NAME_{i}}0),
+    dot(vec3f(uv{TRANSFORM_UV_{i}}, 1), {TRANSFORM_NAME_{i}}1)
+);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/vert/uvTransformUniforms.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/vert/uvTransformUniforms.js
@@ -1,0 +1,5 @@
+// uniform declaration for uv transform matrix, 3x2 matrix
+export default /* wgsl */`
+    uniform {TRANSFORM_NAME_{i}}0: vec3f;
+    uniform {TRANSFORM_NAME_{i}}1: vec3f;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/litShaderArgs.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/litShaderArgs.js
@@ -1,69 +1,69 @@
 export default /* wgsl */`
 
 // Surface albedo absorbance
-var litArgs_albedo: vec3f;
+var<private> litArgs_albedo: vec3f;
 
 // Transparency
-var litArgs_opacity: f32;
+var<private> litArgs_opacity: f32;
 
 // Emission color
-var litArgs_emission: vec3f;
+var<private> litArgs_emission: vec3f;
 
 // Normal direction in world space
-var litArgs_worldNormal: vec3f;
+var<private> litArgs_worldNormal: vec3f;
 
 // Ambient occlusion amount, range [0..1]
-var litArgs_ao: f32;
+var<private> litArgs_ao: f32;
 
 // Light map color
-var litArgs_lightmap: vec3f;
+var<private> litArgs_lightmap: vec3f;
 
 // Light map direction
-var litArgs_lightmapDir: vec3f;
+var<private> litArgs_lightmapDir: vec3f;
 
 // Surface metalness factor, range [0..1]
-var litArgs_metalness: f32;
+var<private> litArgs_metalness: f32;
 
 // The f0 specularity factor
-var litArgs_specularity: vec3f;
+var<private> litArgs_specularity: vec3f;
 
 // Specularity intensity factor, range [0..1]
-var litArgs_specularityFactor: f32;
+var<private> litArgs_specularityFactor: f32;
 
 // The microfacet glossiness factor, range [0..1]
-var litArgs_gloss: f32;
+var<private> litArgs_gloss: f32;
 
 // Glossiness of the sheen layer, range [0..1]
-var litArgs_sheen_gloss: f32;
+var<private> litArgs_sheen_gloss: f32;
 
 // The color of the f0 specularity factor for the sheen layer
-var litArgs_sheen_specularity: vec3f;
+var<private> litArgs_sheen_specularity: vec3f;
 
 // Transmission factor (refraction), range [0..1]
-var litArgs_transmission: f32;
+var<private> litArgs_transmission: f32;
 
 // Uniform thickness of medium, used by transmission, range [0..inf]
-var litArgs_thickness: f32;
+var<private> litArgs_thickness: f32;
 
 // Index of refraction
-var litArgs_ior: f32;
+var<private> litArgs_ior: f32;
 
 // Dispersion, range [0..1] typically, but can be higher
-var litArgs_dispersion: f32;
+var<private> litArgs_dispersion: f32;
 
 // Iridescence effect intensity, range [0..1]
-var litArgs_iridescence_intensity: f32;
+var<private> litArgs_iridescence_intensity: f32;
 
 // Thickness of the iridescent microfilm layer, value is in nanometers, range [0..1000]
-var litArgs_iridescence_thickness: f32;
+var<private> litArgs_iridescence_thickness: f32;
 
 // The normal used for the clearcoat layer
-var litArgs_clearcoat_worldNormal: vec3f;
+var<private> litArgs_clearcoat_worldNormal: vec3f;
 
 // Intensity of the clearcoat layer, range [0..1]
-var litArgs_clearcoat_specularity: f32;
+var<private> litArgs_clearcoat_specularity: f32;
 
 // Glossiness of clearcoat layer, range [0..1]
-var litArgs_clearcoat_gloss: f32;
+var<private> litArgs_clearcoat_gloss: f32;
 
 `;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/litShaderCore.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/litShaderCore.js
@@ -1,0 +1,11 @@
+export default /* wgsl */`
+
+    // global texture bias for standard textures
+    #if LIT_NONE_SLICE_MODE == TILED
+        var<private> textureBias: f32 = -1000.0;
+    #else
+        uniform textureBias: f32;
+    #endif
+
+    #include "litShaderArgsPS"
+`;

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -85,6 +85,7 @@ import litForwardPreCodePS from './lit/frag/pass-forward/litForwardPreCode.js';
 import litMainVS from './lit/vert/litMain.js';
 import litOtherMainPS from './lit/frag/pass-other/litOtherMain.js';
 import litShaderArgsPS from './standard/frag/litShaderArgs.js';
+import litShaderCorePS from './standard/frag/litShaderCore.js';
 import litShadowMainPS from './lit/frag/pass-shadow/litShadowMain.js';
 import ltcPS from './lit/frag/ltc.js';
 import metalnessPS from './standard/frag/metalness.js';
@@ -201,7 +202,7 @@ import transmissionPS from './standard/frag/transmission.js';
 import twoSidedLightingPS from './lit/frag/twoSidedLighting.js';
 import uv0VS from './lit/vert/uv0.js';
 import uv1VS from './lit/vert/uv1.js';
-import uvTransformPS from './lit/vert/uvTransform.js';
+import uvTransformVS from './lit/vert/uvTransform.js';
 import uvTransformUniformsPS from './lit/vert/uvTransformUniforms.js';
 import viewDirPS from './lit/frag/viewDir.js';
 import webgpuPS from '../../../platform/graphics/shader-chunks/frag/webgpu.js';
@@ -302,6 +303,7 @@ const shaderChunks = {
     litMainVS,
     litOtherMainPS,
     litShaderArgsPS,
+    litShaderCorePS,
     litShadowMainPS,
     ltcPS,
     metalnessPS,
@@ -418,7 +420,7 @@ const shaderChunks = {
     twoSidedLightingPS,
     uv0VS,
     uv1VS,
-    uvTransformPS,
+    uvTransformVS,
     uvTransformUniformsPS,
     viewDirPS,
     webgpuPS,

--- a/src/scene/shader-lib/chunks/common/vert/transform.js
+++ b/src/scene/shader-lib/chunks/common/vert/transform.js
@@ -45,26 +45,26 @@ vec4 getPosition() {
 
     vec4 screenPos;
     #ifdef UV1LAYOUT
-    screenPos = vec4(vertex_texCoord1.xy * 2.0 - 1.0, 0.5, 1);
+        screenPos = vec4(vertex_texCoord1.xy * 2.0 - 1.0, 0.5, 1);
         #ifdef WEBGPU
-        screenPos.y *= -1.0;
+            screenPos.y *= -1.0;
         #endif
     #else
-    #ifdef SCREENSPACE
-    screenPos = posW;
-    screenPos.y *= projectionFlipY;
-    #else
-    screenPos = matrix_viewProjection * posW;
-    #endif
+        #ifdef SCREENSPACE
+            screenPos = posW;
+            screenPos.y *= projectionFlipY;
+        #else
+            screenPos = matrix_viewProjection * posW;
+        #endif
 
-    #ifdef PIXELSNAP
-    // snap vertex to a pixel boundary
-    screenPos.xy = (screenPos.xy * 0.5) + 0.5;
-    screenPos.xy *= uScreenSize.xy;
-    screenPos.xy = floor(screenPos.xy);
-    screenPos.xy *= uScreenSize.zw;
-    screenPos.xy = (screenPos.xy * 2.0) - 1.0;
-    #endif
+        #ifdef PIXELSNAP
+            // snap vertex to a pixel boundary
+            screenPos.xy = (screenPos.xy * 0.5) + 0.5;
+            screenPos.xy *= uScreenSize.xy;
+            screenPos.xy = floor(screenPos.xy);
+            screenPos.xy *= uScreenSize.zw;
+            screenPos.xy = (screenPos.xy * 2.0) - 1.0;
+        #endif
     #endif
 
     return screenPos;

--- a/src/scene/shader-lib/chunks/lit/frag/pass-forward/litForwardDeclaration.js
+++ b/src/scene/shader-lib/chunks/lit/frag/pass-forward/litForwardDeclaration.js
@@ -48,7 +48,9 @@ vec3 sSpecularLight;
 #endif
 
 // LOOP - uniform declarations for all non-clustered lights
-#include "lightDeclarationPS, LIGHT_COUNT"
+#if LIGHT_COUNT > 0
+    #include "lightDeclarationPS, LIGHT_COUNT"
+#endif
 
 #ifdef LIT_SPECULAR
     #if LIT_FRESNEL_MODEL == NONE && !defined(LIT_REFLECTIONS) && !defined(LIT_DIFFUSE_MAP) 

--- a/src/scene/shader-lib/chunks/lit/vert/uv0.js
+++ b/src/scene/shader-lib/chunks/lit/vert/uv0.js
@@ -1,24 +1,24 @@
 export default /* glsl */`
 #ifdef NINESLICED
-vec2 getUv0() {
-    vec2 uv = vertex_position.xz;
+    vec2 getUv0() {
+        vec2 uv = vertex_position.xz;
 
-    // offset inner vertices inside
-    // (original vertices must be in [-1;1] range)
-    vec2 positiveUnitOffset = clamp(vertex_position.xz, vec2(0.0), vec2(1.0));
-    vec2 negativeUnitOffset = clamp(-vertex_position.xz, vec2(0.0), vec2(1.0));
-    uv += (-positiveUnitOffset * innerOffset.xy + negativeUnitOffset * innerOffset.zw) * vertex_texCoord0.xy;
+        // offset inner vertices inside
+        // (original vertices must be in [-1;1] range)
+        vec2 positiveUnitOffset = clamp(vertex_position.xz, vec2(0.0), vec2(1.0));
+        vec2 negativeUnitOffset = clamp(-vertex_position.xz, vec2(0.0), vec2(1.0));
+        uv += (-positiveUnitOffset * innerOffset.xy + negativeUnitOffset * innerOffset.zw) * vertex_texCoord0.xy;
 
-    uv = uv * -0.5 + 0.5;
-    uv = uv * atlasRect.zw + atlasRect.xy;
+        uv = uv * -0.5 + 0.5;
+        uv = uv * atlasRect.zw + atlasRect.xy;
 
-    vMask = vertex_texCoord0.xy;
+        vMask = vertex_texCoord0.xy;
 
-    return uv;
-}
+        return uv;
+    }
 #else
-vec2 getUv0() {
-    return vertex_texCoord0;
-}
+    vec2 getUv0() {
+        return vertex_texCoord0;
+    }
 #endif
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/litShaderCore.js
+++ b/src/scene/shader-lib/chunks/standard/frag/litShaderCore.js
@@ -1,0 +1,11 @@
+export default /* glsl */`
+
+    // global texture bias for standard textures
+    #if LIT_NONE_SLICE_MODE == TILED
+        const float textureBias = -1000.0;
+    #else
+        uniform float textureBias;
+    #endif
+
+    #include "litShaderArgsPS"
+`;

--- a/src/scene/shader-lib/chunks/standard/frag/stdDeclaration.js
+++ b/src/scene/shader-lib/chunks/standard/frag/stdDeclaration.js
@@ -2,13 +2,6 @@
 // by the fragment shader of the standard shader.
 export default /* glsl */`
 
-    // global texture bias for standard textures
-    #if LIT_NONE_SLICE_MODE == TILED
-        const float textureBias = -1000.0;
-    #else
-        uniform float textureBias;
-    #endif
-
     // globals
     float dAlpha = 1.0;
 
@@ -188,5 +181,5 @@ export default /* glsl */`
     #endif
 
     // front end outputs to lit shader
-    #include "litShaderArgsPS"
+    #include "litShaderCorePS"
 `;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -172,7 +172,7 @@ class LitShader {
      */
     generateVertexShader(useUv, useUnmodifiedUv, mapTransforms) {
 
-        const { options, vDefines, attributes, chunks } = this;
+        const { options, vDefines, attributes } = this;
 
         // varyings
         const varyings = new Map();

--- a/src/scene/shader-lib/programs/lit.js
+++ b/src/scene/shader-lib/programs/lit.js
@@ -1,8 +1,9 @@
 import { LitShader } from './lit-shader.js';
 import { LitOptionsUtils } from './lit-options-utils.js';
 import { ShaderGenerator } from './shader-generator.js';
-import { SHADERLANGUAGE_GLSL, SHADERTAG_MATERIAL } from '../../../platform/graphics/constants.js';
+import { SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL, SHADERTAG_MATERIAL } from '../../../platform/graphics/constants.js';
 import { ShaderUtils } from '../../../platform/graphics/shader-utils.js';
+import { hashCode } from '../../../core/hash.js';
 
 /**
  * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
@@ -14,14 +15,14 @@ const dummyUvs = [0, 1, 2, 3, 4, 5, 6, 7];
 class ShaderGeneratorLit extends ShaderGenerator {
     generateKey(options) {
         const definesHash = ShaderGenerator.definesHash(options.defines);
-        const key = `lit_${definesHash}_${
-            dummyUvs.map((dummy, index) => {
-                return options.usedUvs[index] ? '1' : '0';
-            }).join('')
-        }${options.shaderChunk
-        }${LitOptionsUtils.generateKey(options.litOptions)}`;
+        const glslHash = hashCode(options.shaderChunkGLSL ?? '');
+        const wgslHash = hashCode(options.shaderChunkWGSL ?? '');
+        const loHash = LitOptionsUtils.generateKey(options.litOptions);
+        const uvOptions = `${dummyUvs.map((dummy, index) => {
+            return options.usedUvs[index] ? '1' : '0';
+        }).join('')}`;
 
-        return key;
+        return `lit_${definesHash}_${uvOptions}_${glslHash}_${wgslHash}_${loHash}`;
     }
 
     /**
@@ -30,16 +31,13 @@ class ShaderGeneratorLit extends ShaderGenerator {
      * @returns {object} Returns the created shader definition.
      */
     createShaderDefinition(device, options) {
-        const litShader = new LitShader(device, options.litOptions);
-
-        const decl = `
-            uniform float textureBias;
-            #include "litShaderArgsPS"
-        `;
+        const wgsl = device.isWebGPU && options.shaderChunkWGSL;
+        const shaderLanguage = wgsl ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL;
+        const litShader = new LitShader(device, options.litOptions, shaderLanguage);
 
         const definitionOptions = {
             name: 'LitShader',
-            shaderLanguage: SHADERLANGUAGE_GLSL,
+            shaderLanguage: shaderLanguage,
             tag: litShader.shaderPassInfo.isForward ? SHADERTAG_MATERIAL : undefined
         };
 
@@ -47,7 +45,7 @@ class ShaderGeneratorLit extends ShaderGenerator {
         const mapTransforms = [];
         litShader.generateVertexShader(usedUvSets, usedUvSets, mapTransforms);
 
-        litShader.generateFragmentShader(decl, options.shaderChunk, 'vUv0');
+        litShader.generateFragmentShader('', wgsl ? options.shaderChunkWGSL : options.shaderChunkGLSL, 'vUv0');
 
         const includes = new Map(Object.entries({
             ...Object.getPrototypeOf(litShader.chunks), // the prototype stores the default chunks

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -11,7 +11,7 @@ import { StandardMaterialOptions } from '../../materials/standard-material-optio
 import { LitOptionsUtils } from './lit-options-utils.js';
 import { ShaderGenerator } from './shader-generator.js';
 import { ShaderUtils } from '../../../platform/graphics/shader-utils.js';
-import { SHADERTAG_MATERIAL } from '../../../platform/graphics/constants.js';
+import { SHADERLANGUAGE_GLSL, SHADERTAG_MATERIAL } from '../../../platform/graphics/constants.js';
 
 /**
  * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
@@ -312,7 +312,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
 
         const shaderPassInfo = ShaderPass.get(device).getByIndex(options.litOptions.pass);
         const isForwardPass = shaderPassInfo.isForward;
-        const litShader = new LitShader(device, options.litOptions);
+        const litShader = new LitShader(device, options.litOptions, SHADERLANGUAGE_GLSL);
 
         // generate vertex shader
         this.createVertexShader(litShader, options);


### PR DESCRIPTION
When a frontend chunk for LitMaterial (private) is specified using WGSL, the lit-shader generation takes place only using WGSL chunks now. There's a subset of functionality supported, and hidden LitMaterial example has been modified to only use that. It will reach parity with GLSL part in the future.

Actual changes:
- LitShader / LitMaterial can use WGSL chunks
- converted many chunks to WGSL
- improved shader processing error reporting