### PR TITLE
Minor fixes to various toArray function docs

### DIFF
--- a/src/core/math/color.js
+++ b/src/core/math/color.js
@@ -294,14 +294,14 @@ class Color {
     }
 
     /**
-     * Converts the color to an array of numbers.
+     * Converts the color to an array.
      *
-     * @param {number[]} [arr] - The array to populate with the color components. If not specified,
-     * a new array is created. Default is true.
+     * @param {number[]|ArrayBufferView} [arr] - The array to populate with the color's number
+     * components. If not specified, a new array is created.
      * @param {number} [offset] - The zero-based index at which to start copying elements to the
      * array. Default is 0.
      * @param {boolean} [alpha] - If true, the output array will include the alpha value.
-     * @returns {number[]} The color as an array of numbers.
+     * @returns {number[]|ArrayBufferView} The color as an array.
      * @example
      * const c = new pc.Color(1, 1, 1);
      * // Outputs [1, 1, 1, 1]

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -691,8 +691,8 @@ class Vec2 {
     /**
      * Converts the vector to an array.
      *
-     * @param {number[]|ArrayBufferView} [arr] - The array to populate with the color components. If not specified,
-     * a new array is created.
+     * @param {number[]|ArrayBufferView} [arr] - The array to populate with the vector's number
+     * components. If not specified, a new array is created.
      * @param {number} [offset] - The zero-based index at which to start copying elements to the
      * array. Default is 0.
      * @returns {number[]|ArrayBufferView} The vector as an array.

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -710,8 +710,8 @@ class Vec3 {
     /**
      * Converts the vector to an array.
      *
-     * @param {number[]|ArrayBufferView} [arr] - The array to populate with the color components. If not specified,
-     * a new array is created.
+     * @param {number[]|ArrayBufferView} [arr] - The array to populate with the vector's number
+     * components. If not specified, a new array is created.
      * @param {number} [offset] - The zero-based index at which to start copying elements to the
      * array. Default is 0.
      * @returns {number[]|ArrayBufferView} The vector as an array.

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -675,8 +675,8 @@ class Vec4 {
     /**
      * Converts the vector to an array.
      *
-     * @param {number[]|ArrayBufferView} [arr] - The array to populate with the color components. If not specified,
-     * a new array is created.
+     * @param {number[]|ArrayBufferView} [arr] - The array to populate with the vector's number
+     * components. If not specified, a new array is created.
      * @param {number} [offset] - The zero-based index at which to start copying elements to the
      * array. Default is 0.
      * @returns {number[]|ArrayBufferView} The vector as an array.


### PR DESCRIPTION
* Allow `Color#toArray` to take typed array as well as generic array to bring it in line with the `Vec` classes.
* Remove references to color components from vector classes.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
