### PR TITLE
Enable debug warning if the required uniform is null or undefined

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1720,14 +1720,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
             return;
         }
 
-        let sampler, samplerValue, texture, numTextures; // Samplers
-        let uniform, scopeId, uniformVersion, programVersion; // Uniforms
         const shader = this.shader;
         if (!shader) {
             return;
         }
-        const samplers = shader.impl.samplers;
-        const uniforms = shader.impl.uniforms;
 
         // vertex buffers
         if (!keepBuffers) {
@@ -1738,10 +1734,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         // Commit the shader program variables
         let textureUnit = 0;
-
+        const samplers = shader.impl.samplers;
         for (let i = 0, len = samplers.length; i < len; i++) {
-            sampler = samplers[i];
-            samplerValue = sampler.scopeId.value;
+            const sampler = samplers[i];
+            let samplerValue = sampler.scopeId.value;
             if (!samplerValue) {
 
                 const samplerName = sampler.scopeId.name;
@@ -1765,7 +1761,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
             }
 
             if (samplerValue instanceof Texture) {
-                texture = samplerValue;
+                const texture = samplerValue;
                 this.setTexture(texture, textureUnit);
 
                 // #if _DEBUG
@@ -1788,9 +1784,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 textureUnit++;
             } else { // Array
                 sampler.array.length = 0;
-                numTextures = samplerValue.length;
+                const numTextures = samplerValue.length;
                 for (let j = 0; j < numTextures; j++) {
-                    texture = samplerValue[j];
+                    const texture = samplerValue[j];
                     this.setTexture(texture, textureUnit);
 
                     sampler.array[j] = textureUnit;
@@ -1801,11 +1797,12 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
 
         // Commit any updated uniforms
+        const uniforms = shader.impl.uniforms;
         for (let i = 0, len = uniforms.length; i < len; i++) {
-            uniform = uniforms[i];
-            scopeId = uniform.scopeId;
-            uniformVersion = uniform.version;
-            programVersion = scopeId.versionObject.version;
+            const uniform = uniforms[i];
+            const scopeId = uniform.scopeId;
+            const uniformVersion = uniform.version;
+            const programVersion = scopeId.versionObject.version;
 
             // Check the value is valid
             if (uniformVersion.globalId !== programVersion.globalId || uniformVersion.revision !== programVersion.revision) {
@@ -1813,11 +1810,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 uniformVersion.revision = programVersion.revision;
 
                 // Call the function to commit the uniform value
-                if (scopeId.value !== null) {
-                    this.commitFunction[uniform.dataType](uniform, scopeId.value);
+                const value = scopeId.value;
+                if (value !== null && value !== undefined) {
+                    this.commitFunction[uniform.dataType](uniform, value);
                 } else {
-                    // commented out till engine issue #4971 is sorted out
-                    // Debug.warnOnce(`Shader [${shader.label}] requires uniform [${uniform.scopeId.name}] which has not been set, while rendering [${DebugGraphics.toString()}]`);
+                    Debug.warnOnce(`Shader [${shader.label}] requires uniform [${uniform.scopeId.name}] which has not been set, while rendering [${DebugGraphics.toString()}]`);
                 }
             }
         }


### PR DESCRIPTION
- now that the related #4971 has been sorted out, enable warnOnce if uniform is null or undefined. This gives user useful error, instead of failing with less context later.
- this change brings it to match WebGPU device behaviour
- small cleanup along this change