### PR TITLE
Convert many StandardMaterial front end and required backend chunks to WGSL

### DIFF
--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -1,16 +1,16 @@
-// import alphaTestPS from './standard/frag/alphaTest.js';
+import alphaTestPS from './standard/frag/alphaTest.js';
 import ambientPS from './lit/frag/ambient.js';
-// import aoPS from './standard/frag/ao.js';
-// import aoDiffuseOccPS from './lit/frag/aoDiffuseOcc.js';
-// import aoSpecOccPS from './lit/frag/aoSpecOcc.js';
+import aoPS from './standard/frag/ao.js';
+import aoDiffuseOccPS from './lit/frag/aoDiffuseOcc.js';
+import aoSpecOccPS from './lit/frag/aoSpecOcc.js';
 import basePS from './lit/frag/base.js';
 // import baseNineSlicedPS from './lit/frag/baseNineSliced.js';
 // import baseNineSlicedTiledPS from './lit/frag/baseNineSlicedTiled.js';
-// import bayerPS from './common/frag/bayer.js';
+import bayerPS from './common/frag/bayer.js';
 // import blurVSMPS from './lit/frag/blurVSM.js';
-// import clearCoatPS from './standard/frag/clearCoat.js';
-// import clearCoatGlossPS from './standard/frag/clearCoatGloss.js';
-// import clearCoatNormalPS from './standard/frag/clearCoatNormal.js';
+import clearCoatPS from './standard/frag/clearCoat.js';
+import clearCoatGlossPS from './standard/frag/clearCoatGloss.js';
+import clearCoatNormalPS from './standard/frag/clearCoatNormal.js';
 import clusteredLightUtilsPS from './lit/frag/clusteredLightUtils.js';
 // import clusteredLightCookiesPS from './lit/frag/clusteredLightCookies.js';
 // import clusteredLightShadowsPS from './lit/frag/clusteredLightShadows.js';
@@ -25,9 +25,9 @@ import cubeMapRotatePS from './lit/frag/cubeMapRotate.js';
 import debugOutputPS from './lit/frag/debug-output.js';
 import debugProcessFrontendPS from './lit/frag/debug-process-frontend.js';
 import decodePS from './common/frag/decode.js';
-// import detailModesPS from './standard/frag/detailModes.js';
-// import diffusePS from './standard/frag/diffuse.js';
-// import emissivePS from './standard/frag/emissive.js';
+import detailModesPS from './standard/frag/detailModes.js';
+import diffusePS from './standard/frag/diffuse.js';
+import emissivePS from './standard/frag/emissive.js';
 import encodePS from './common/frag/encode.js';
 import endPS from './lit/frag/end.js';
 import envAtlasPS from './common/frag/envAtlas.js';
@@ -42,7 +42,7 @@ import fresnelSchlickPS from './lit/frag/fresnelSchlick.js';
 import gammaPS from './common/frag/gamma.js';
 // import gles3PS from '../../../platform/graphics/shader-chunks/frag/gles3.js';
 // import gles3VS from '../../../platform/graphics/shader-chunks/vert/gles3.js';
-// import glossPS from './standard/frag/gloss.js';
+import glossPS from './standard/frag/gloss.js';
 // import gsplatCenterVS from './gsplat/vert/gsplatCenter.js';
 // import gsplatColorVS from './gsplat/vert/gsplatColor.js';
 // import gsplatCommonVS from './gsplat/vert/gsplatCommon.js';
@@ -58,9 +58,9 @@ import gammaPS from './common/frag/gamma.js';
 import immediateLinePS from './internal/frag/immediateLine.js';
 import immediateLineVS from './internal/vert/immediateLine.js';
 // import iridescenceDiffractionPS from './lit/frag/iridescenceDiffraction.js';
-// import iridescencePS from './standard/frag/iridescence.js';
-// import iridescenceThicknessPS from './standard/frag/iridescenceThickness.js';
-// import iorPS from './standard/frag/ior.js';
+import iridescencePS from './standard/frag/iridescence.js';
+import iridescenceThicknessPS from './standard/frag/iridescenceThickness.js';
+import iorPS from './standard/frag/ior.js';
 import lightDeclarationPS from './lit/frag/lighting/lightDeclaration.js';
 import lightDiffuseLambertPS from './lit/frag/lightDiffuseLambert.js';
 import lightDirPointPS from './lit/frag/lightDirPoint.js';
@@ -72,7 +72,7 @@ import lightingPS from './lit/frag/lighting/lighting.js';
 // import lightmapPS from './standard/frag/lightmap.js';
 // import lightSpecularAnisoGGXPS from './lit/frag/lightSpecularAnisoGGX.js';
 import lightSpecularBlinnPS from './lit/frag/lightSpecularBlinn.js';
-// import lightSheenPS from './lit/frag/lightSheen.js';
+import lightSheenPS from './lit/frag/lightSheen.js';
 // import linearizeDepthPS from './common/frag/linearizeDepth.js';
 import litForwardBackendPS from './lit/frag/pass-forward/litForwardBackend.js';
 import litForwardDeclarationPS from './lit/frag/pass-forward/litForwardDeclaration.js';
@@ -85,9 +85,9 @@ import litShaderArgsPS from './standard/frag/litShaderArgs.js';
 import litShaderCorePS from './standard/frag/litShaderCore.js';
 // import litShadowMainPS from './lit/frag/pass-shadow/litShadowMain.js';
 // import ltcPS from './lit/frag/ltc.js';
-// import metalnessPS from './standard/frag/metalness.js';
+import metalnessPS from './standard/frag/metalness.js';
 // import msdfPS from './common/frag/msdf.js';
-// import metalnessModulatePS from './lit/frag/metalnessModulate.js';
+import metalnessModulatePS from './lit/frag/metalnessModulate.js';
 import morphEvaluationPS from './internal/morph/frag/morphEvaluation.js';
 import morphDeclarationPS from './internal/morph/frag/morphDeclaration.js';
 import morphPS from './internal/morph/frag/morph.js';
@@ -95,15 +95,15 @@ import morphVS from './internal/morph/vert/morph.js';
 // import msdfVS from './common/vert/msdf.js';
 import normalVS from './lit/vert/normal.js';
 import normalCoreVS from './common/vert/normalCore.js';
-// import normalMapPS from './standard/frag/normalMap.js';
-// import opacityPS from './standard/frag/opacity.js';
-// import opacityDitherPS from './standard/frag/opacity-dither.js';
+import normalMapPS from './standard/frag/normalMap.js';
+import opacityPS from './standard/frag/opacity.js';
+import opacityDitherPS from './standard/frag/opacity-dither.js';
 import outputPS from './lit/frag/output.js';
 import outputAlphaPS from './lit/frag/outputAlpha.js';
 // import outputTex2DPS from './common/frag/outputTex2D.js';
-// import sheenPS from './standard/frag/sheen.js';
-// import sheenGlossPS from './standard/frag/sheenGloss.js';
-// import parallaxPS from './standard/frag/parallax.js';
+import sheenPS from './standard/frag/sheen.js';
+import sheenGlossPS from './standard/frag/sheenGloss.js';
+import parallaxPS from './standard/frag/parallax.js';
 // import particlePS from './particle/frag/particle.js';
 // import particleVS from './particle/vert/particle.js';
 // import particleAnimFrameClampVS from './particle/vert/particleAnimFrameClamp.js';
@@ -149,15 +149,15 @@ import outputAlphaPS from './lit/frag/outputAlpha.js';
 // import particle_wrapVS from './particle/vert/particle_wrap.js';
 // import pickPS from './common/frag/pick.js';
 import reflDirPS from './lit/frag/reflDir.js';
-// import reflDirAnisoPS from './lit/frag/reflDirAniso.js';
-// import reflectionCCPS from './lit/frag/reflectionCC.js';
+import reflDirAnisoPS from './lit/frag/reflDirAniso.js';
+import reflectionCCPS from './lit/frag/reflectionCC.js';
 // import reflectionCubePS from './lit/frag/reflectionCube.js';
 // import reflectionEnvHQPS from './lit/frag/reflectionEnvHQ.js';
 import reflectionEnvPS from './lit/frag/reflectionEnv.js';
 // import reflectionSpherePS from './lit/frag/reflectionSphere.js';
-// import reflectionSheenPS from './lit/frag/reflectionSheen.js';
+import reflectionSheenPS from './lit/frag/reflectionSheen.js';
 // import refractionCubePS from './lit/frag/refractionCube.js';
-// import refractionDynamicPS from './lit/frag/refractionDynamic.js';
+import refractionDynamicPS from './lit/frag/refractionDynamic.js';
 import reprojectPS from './internal/frag/reproject.js';
 import reprojectVS from './internal/vert/reproject.js';
 // import sampleCatmullRomPS from './common/frag/sampleCatmullRom.js';
@@ -173,17 +173,17 @@ import reprojectVS from './internal/vert/reproject.js';
 import skinVS from './common/vert/skin.js';
 import skyboxPS from './skybox/frag/skybox.js';
 import skyboxVS from './skybox/vert/skybox.js';
-// import specularPS from './standard/frag/specular.js';
+import specularPS from './standard/frag/specular.js';
 import sphericalPS from './common/frag/spherical.js';
-// import specularityFactorPS from './standard/frag/specularityFactor.js';
+import specularityFactorPS from './standard/frag/specularityFactor.js';
 import spotPS from './lit/frag/spot.js';
 // import startNineSlicedPS from './lit/frag/startNineSliced.js';
 // import startNineSlicedTiledPS from './lit/frag/startNineSlicedTiled.js';
-// import stdDeclarationPS from './standard/frag/stdDeclaration.js';
-// import stdFrontEndPS from './standard/frag/stdFrontEnd.js';
+import stdDeclarationPS from './standard/frag/stdDeclaration.js';
+import stdFrontEndPS from './standard/frag/stdFrontEnd.js';
 // import tangentBinormalVS from './lit/vert/tangentBinormal.js';
 import TBNPS from './lit/frag/TBN.js';
-// import thicknessPS from './standard/frag/thickness.js';
+import thicknessPS from './standard/frag/thickness.js';
 import tonemappingPS from './common/frag/tonemapping/tonemapping.js';
 import tonemappingAcesPS from './common/frag/tonemapping/tonemappingAces.js';
 import tonemappingAces2PS from './common/frag/tonemapping/tonemappingAces2.js';
@@ -195,7 +195,7 @@ import tonemappingNonePS from './common/frag/tonemapping/tonemappingNone.js';
 import transformVS from './common/vert/transform.js';
 import transformCoreVS from './common/vert/transformCore.js';
 // import transformInstancingVS from './common/vert/transformInstancing.js';
-// import transmissionPS from './standard/frag/transmission.js';
+import transmissionPS from './standard/frag/transmission.js';
 // import twoSidedLightingPS from './lit/frag/twoSidedLighting.js';
 import uv0VS from './lit/vert/uv0.js';
 import uv1VS from './lit/vert/uv1.js';
@@ -212,19 +212,19 @@ import viewDirPS from './lit/frag/viewDir.js';
  * @category Graphics
  */
 const shaderChunksWGSL = {
-    // alphaTestPS,
+    alphaTestPS,
     ambientPS,
-    // aoPS,
-    // aoDiffuseOccPS,
-    // aoSpecOccPS,
+    aoPS,
+    aoDiffuseOccPS,
+    aoSpecOccPS,
     basePS,
     // baseNineSlicedPS,
     // baseNineSlicedTiledPS,
-    // bayerPS,
+    bayerPS,
     // blurVSMPS,
-    // clearCoatPS,
-    // clearCoatGlossPS,
-    // clearCoatNormalPS,
+    clearCoatPS,
+    clearCoatGlossPS,
+    clearCoatNormalPS,
     // clusteredLightCookiesPS,
     // clusteredLightShadowsPS,
     clusteredLightUtilsPS,
@@ -238,10 +238,10 @@ const shaderChunksWGSL = {
     cubeMapRotatePS,
     debugOutputPS,
     debugProcessFrontendPS,
-    // detailModesPS,
-    // diffusePS,
+    detailModesPS,
+    diffusePS,
     decodePS,
-    // emissivePS,
+    emissivePS,
     encodePS,
     endPS,
     envAtlasPS,
@@ -257,7 +257,7 @@ const shaderChunksWGSL = {
     gammaPS,
     // gles3PS,
     // gles3VS,
-    // glossPS,
+    glossPS,
     // gsplatCenterVS,
     // gsplatCornerVS,
     // gsplatColorVS,
@@ -273,9 +273,9 @@ const shaderChunksWGSL = {
     immediateLinePS,
     immediateLineVS,
     // iridescenceDiffractionPS,
-    // iridescencePS,
-    // iridescenceThicknessPS,
-    // iorPS,
+    iridescencePS,
+    iridescenceThicknessPS,
+    iorPS,
     lightBufferDefinesPS: '',  // this chunk gets genereated at startup
     lightDeclarationPS,
     lightDiffuseLambertPS,
@@ -288,7 +288,7 @@ const shaderChunksWGSL = {
     // lightmapPS,
     // lightSpecularAnisoGGXPS,
     lightSpecularBlinnPS,
-    // lightSheenPS,
+    lightSheenPS,
     // linearizeDepthPS,
     litForwardBackendPS,
     litForwardDeclarationPS,
@@ -301,8 +301,8 @@ const shaderChunksWGSL = {
     litShaderCorePS,
     // litShadowMainPS,
     // ltcPS,
-    // metalnessPS,
-    // metalnessModulatePS,
+    metalnessPS,
+    metalnessModulatePS,
     morphEvaluationPS,
     morphDeclarationPS,
     morphPS,
@@ -311,15 +311,15 @@ const shaderChunksWGSL = {
     // msdfVS,
     normalVS,
     normalCoreVS,
-    // normalMapPS,
-    // opacityPS,
-    // opacityDitherPS,
+    normalMapPS,
+    opacityPS,
+    opacityDitherPS,
     outputPS,
     outputAlphaPS,
     // outputTex2DPS,
-    // sheenPS,
-    // sheenGlossPS,
-    // parallaxPS,
+    sheenPS,
+    sheenGlossPS,
+    parallaxPS,
     // particlePS,
     // particleVS,
     // particleAnimFrameClampVS,
@@ -365,15 +365,15 @@ const shaderChunksWGSL = {
     // particle_wrapVS,
     // pickPS,
     reflDirPS,
-    // reflDirAnisoPS,
-    // reflectionCCPS,
+    reflDirAnisoPS,
+    reflectionCCPS,
     // reflectionCubePS,
     // reflectionEnvHQPS,
     reflectionEnvPS,
     // reflectionSpherePS,
-    // reflectionSheenPS,
+    reflectionSheenPS,
     // refractionCubePS,
-    // refractionDynamicPS,
+    refractionDynamicPS,
     reprojectPS,
     reprojectVS,
     // sampleCatmullRomPS,
@@ -389,17 +389,17 @@ const shaderChunksWGSL = {
     skinVS,
     skyboxPS,
     skyboxVS,
-    // specularPS,
+    specularPS,
     sphericalPS,
-    // specularityFactorPS,
+    specularityFactorPS,
     spotPS,
     // startNineSlicedPS,
     // startNineSlicedTiledPS,
-    // stdDeclarationPS,
-    // stdFrontEndPS,
+    stdDeclarationPS,
+    stdFrontEndPS,
     // tangentBinormalVS,
     TBNPS,
-    // thicknessPS,
+    thicknessPS,
     tonemappingPS,
     tonemappingAcesPS,
     tonemappingAces2PS,
@@ -411,7 +411,7 @@ const shaderChunksWGSL = {
     transformVS,
     transformCoreVS,
     // transformInstancingVS,
-    // transmissionPS,
+    transmissionPS,
     // twoSidedLightingPS,
     uv0VS,
     uv1VS,

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/bayer.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/bayer.js
@@ -1,0 +1,23 @@
+// procedural Bayer matrix, based on: https://www.shadertoy.com/view/Mlt3z8
+
+export default /* wgsl */`
+// 2x2 bayer matrix [1 2][3 0], p in [0,1]
+fn bayer2(p: vec2f) -> f32 {
+    return (2.0 * p.y + p.x + 1.0) % 4.0;
+}
+
+// 4x4 matrix, p - pixel coordinate
+fn bayer4(p: vec2f) -> f32 {
+    let p1: vec2f = p % vec2f(2.0);
+    let p2: vec2f = floor(0.5 * (p % vec2f(4.0)));
+    return 4.0 * bayer2(p1) + bayer2(p2);
+}
+
+// 8x8 matrix, p - pixel coordinate
+fn bayer8(p: vec2f) -> f32 {
+    let p1: vec2f = p % vec2f(2.0);
+    let p2: vec2f = floor(0.5 * (p % vec2f(4.0)));
+    let p4: vec2f = floor(0.25 * (p % vec2f(8.0)));
+    return 4.0 * (4.0 * bayer2(p1) + bayer2(p2)) + bayer2(p4);
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/aoDiffuseOcc.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/aoDiffuseOcc.js
@@ -1,0 +1,5 @@
+export default /* wgsl */`
+fn occludeDiffuse(ao: f32) {
+    dDiffuseLight = dDiffuseLight * ao;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/aoSpecOcc.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/aoSpecOcc.js
@@ -1,0 +1,41 @@
+export default /* wgsl */`
+
+#if LIT_OCCLUDE_SPECULAR != NONE
+    #ifdef LIT_OCCLUDE_SPECULAR_FLOAT
+        uniform material_occludeSpecularIntensity: f32;
+    #endif
+#endif
+
+fn occludeSpecular(gloss: f32, ao: f32, worldNormal: vec3f, viewDir: vec3f) {
+
+    #if LIT_OCCLUDE_SPECULAR == AO
+        #ifdef LIT_OCCLUDE_SPECULAR_FLOAT
+            var specOcc: f32 = mix(1.0, ao, uniform.material_occludeSpecularIntensity);
+        #else
+            var specOcc: f32 = ao;
+        #endif
+    #endif
+
+    #if LIT_OCCLUDE_SPECULAR == GLOSSDEPENDENT
+
+        // approximated specular occlusion from AO
+        // http://research.tri-ace.com/Data/cedec2011_RealtimePBR_Implementation_e.pptx
+        var specPow: f32 = exp2(gloss * 11.0);
+        var specOcc: f32 = saturate(pow(dot(worldNormal, viewDir) + ao, 0.01 * specPow) - 1.0 + ao);
+
+        #ifdef LIT_OCCLUDE_SPECULAR_FLOAT
+            specOcc = mix(1.0, specOcc, uniform.material_occludeSpecularIntensity);
+        #endif
+    #endif
+
+    #if LIT_OCCLUDE_SPECULAR != NONE
+        dSpecularLight = dSpecularLight * specOcc;
+        dReflection = dReflection * specOcc;
+
+        #ifdef LIT_SHEEN
+            sSpecularLight = sSpecularLight * specOcc;
+            sReflection = sReflection * specOcc;
+        #endif
+    #endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/lightSheen.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/lightSheen.js
@@ -1,0 +1,22 @@
+export default /* wgsl */`
+
+fn sheenD(normal: vec3f, h: vec3f, roughness: f32) -> f32 {
+    let PI: f32 = 3.141592653589793;
+    let invR: f32 = 1.0 / (roughness * roughness);
+    var cos2h: f32 = max(dot(normal, h), 0.0);
+    cos2h = cos2h * cos2h;
+    let sin2h: f32 = max(1.0 - cos2h, 0.0078125);
+    return (2.0 + invR) * pow(sin2h, invR * 0.5) / (2.0 * PI);
+}
+
+fn sheenV(normal: vec3f, viewDir: vec3f, light: vec3f) -> f32 {
+    let NoV: f32 = max(dot(normal, viewDir), 0.000001);
+    let NoL: f32 = max(dot(normal, light), 0.000001);
+    return 1.0 / (4.0 * (NoL + NoV - NoL * NoV));
+}
+
+fn getLightSpecularSheen(h: vec3f, worldNormal: vec3f, viewDir: vec3f, lightDirNorm: vec3f, sheenGloss: f32) -> f32 {
+    let D: f32 = sheenD(worldNormal, h, sheenGloss);
+    let V: f32 = sheenV(worldNormal, viewDir, -lightDirNorm);
+    return D * V;
+}`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/lighting/lightFunctionLight.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/lighting/lightFunctionLight.js
@@ -1,34 +1,30 @@
 // functions used to evaluate the light
-export default /* glsl */`
+export default /* wgsl */`
 #if defined(LIGHT{i})
 
-void evaluateLight{i}(
+fn evaluateLight{i}(
     #if defined(LIT_IRIDESCENCE)
-        vec3 iridescenceFresnel
+        iridescenceFresnel: vec3f
     #endif
 ) {
-
-    NON-CLUSTERED LIGHTS ARE NOT SUPPORTED YET
-/*
-
     // light color
-    vec3 lightColor = light{i}_color;
+    var lightColor: vec3f = uniform.light{i}_color;
 
     #if LIGHT{i}TYPE == DIRECTIONAL && !defined(LIT_SHADOW_CATCHER)
         // early return if the light color is black (used by shadow catcher - this way this light is very cheap)
-        if (all(equal(lightColor, vec3(0.0)))) {
+        if (all(lightColor == vec3f(0.0, 0.0, 0.0))) {
             return;
         }
     #endif
 
     #if LIGHT{i}TYPE == DIRECTIONAL // directional light
 
-        dLightDirNormW = light{i}_direction;
+        dLightDirNormW = uniform.light{i}_direction;
         dAtten = 1.0;
 
     #else // omni or spot light
-        
-        vec3 lightDirW = evalOmniLight(light{i}_position);
+
+        var lightDirW: vec3f = evalOmniLight(uniform.light{i}_position);
         dLightDirNormW = normalize(lightDirW);
 
         // cookie attenuation
@@ -37,44 +33,44 @@ void evaluateLight{i}(
             #if LIGHT{i}TYPE == SPOT
                 #ifdef LIGHT{i}COOKIE_FALLOFF
                     #ifdef LIGHT{i}COOKIE_TRANSFORM
-                        vec3 cookieAttenuation = getCookie2DXform(light{i}_cookie, light{i}_shadowMatrix, light{i}_cookieIntensity, light{i}_cookieMatrix, light{i}_cookieOffset).{LIGHT{i}COOKIE_CHANNEL};
+                        var cookieAttenuation: vec3f = getCookie2DXform(uniform.light{i}_cookie, uniform.light{i}_shadowMatrix, uniform.light{i}_cookieIntensity, uniform.light{i}_cookieMatrix, uniform.light{i}_cookieOffset).{LIGHT{i}COOKIE_CHANNEL};
                     #else
-                        vec3 cookieAttenuation = getCookie2D(light{i}_cookie, light{i}_shadowMatrix, light{i}_cookieIntensity).{LIGHT{i}COOKIE_CHANNEL};
+                        var cookieAttenuation: vec3f = getCookie2D(uniform.light{i}_cookie, uniform.light{i}_shadowMatrix, uniform.light{i}_cookieIntensity).{LIGHT{i}COOKIE_CHANNEL};
                     #endif
                 #else
                     #ifdef LIGHT{i}COOKIE_TRANSFORM
-                        vec3 cookieAttenuation = getCookie2DClipXform(light{i}_cookie, light{i}_shadowMatrix, light{i}_cookieIntensity, light{i}_cookieMatrix, light{i}_cookieOffset).{LIGHT{i}COOKIE_CHANNEL};
+                        var cookieAttenuation: vec3f = getCookie2DClipXform(uniform.light{i}_cookie, uniform.light{i}_shadowMatrix, uniform.light{i}_cookieIntensity, uniform.light{i}_cookieMatrix, uniform.light{i}_cookieOffset).{LIGHT{i}COOKIE_CHANNEL};
                     #else
-                        vec3 cookieAttenuation = getCookie2DClip(light{i}_cookie, light{i}_shadowMatrix, light{i}_cookieIntensity).{LIGHT{i}COOKIE_CHANNEL};
+                        var cookieAttenuation: vec3f = getCookie2DClip(uniform.light{i}_cookie, uniform.light{i}_shadowMatrix, uniform.light{i}_cookieIntensity).{LIGHT{i}COOKIE_CHANNEL};
                     #endif
                 #endif
             #endif
 
             #if LIGHT{i}TYPE == OMNI
-                vec3 cookieAttenuation = getCookieCube(light{i}_cookie, light{i}_shadowMatrix, light{i}_cookieIntensity).{LIGHT{i}COOKIE_CHANNEL};
+                var cookieAttenuation: vec3f = getCookieCube(uniform.light{i}_cookie, uniform.light{i}_shadowMatrix, uniform.light{i}_cookieIntensity).{LIGHT{i}COOKIE_CHANNEL};
             #endif
 
             // multiply light color by the cookie attenuation
-            lightColor *= cookieAttenuation;
+            lightColor = lightColor * cookieAttenuation;
 
         #endif
 
         // distance falloff
         #if LIGHT{i}SHAPE == PUNCTUAL
             #if LIGHT{i}FALLOFF == LINEAR
-                dAtten = getFalloffLinear(light{i}_radius, lightDirW);
+                dAtten = getFalloffLinear(uniform.light{i}_radius, lightDirW);
             #else
-                dAtten = getFalloffInvSquared(light{i}_radius, lightDirW);
+                dAtten = getFalloffInvSquared(uniform.light{i}_radius, lightDirW);
             #endif
         #else
             // non punctual lights only gets the range window here
-            dAtten = getFalloffWindow(light{i}_radius, lightDirW);
+            dAtten = getFalloffWindow(uniform.light{i}_radius, lightDirW);
         #endif
 
         // spot light angle falloff
         #if LIGHT{i}TYPE == SPOT
             #if !defined(LIGHT{i}COOKIE) || defined(LIGHT{i}COOKIE_FALLOFF)
-                dAtten *= getSpotEffect(light{i}_direction, light{i}_innerConeAngle, light{i}_outerConeAngle, dLightDirNormW);
+                dAtten = dAtten * getSpotEffect(uniform.light{i}_direction, uniform.light{i}_innerConeAngle, uniform.light{i}_outerConeAngle, dLightDirNormW);
             #endif
         #endif
     #endif
@@ -86,11 +82,11 @@ void evaluateLight{i}(
     // evaluate area light values
     #if LIGHT{i}SHAPE != PUNCTUAL
         #if LIGHT{i}SHAPE == RECT
-            calcRectLightValues(light{i}_position, light{i}_halfWidth, light{i}_halfHeight);
+            calcRectLightValues(uniform.light{i}_position, uniform.light{i}_halfWidth, uniform.light{i}_halfHeight);
         #elif LIGHT{i}SHAPE == DISK
-            calcDiskLightValues(light{i}_position, light{i}_halfWidth, light{i}_halfHeight);
+            calcDiskLightValues(uniform.light{i}_position, uniform.light{i}_halfWidth, uniform.light{i}_halfHeight);
         #elif LIGHT{i}SHAPE == SPHERE
-            calcSphereLightValues(light{i}_position, light{i}_halfWidth, light{i}_halfHeight);
+            calcSphereLightValues(uniform.light{i}_position, uniform.light{i}_halfWidth, uniform.light{i}_halfHeight);
         #endif
     #endif
 
@@ -101,39 +97,39 @@ void evaluateLight{i}(
 
         #if LIGHT{i}TYPE == DIRECTIONAL
             // NB: A better approximation perhaps using wrap lighting could be implemented here
-            float attenDiffuse = getLightDiffuse(litArgs_worldNormal, dViewDirW, dLightDirNormW);
+            var attenDiffuse: f32 = getLightDiffuse(litArgs_worldNormal, dViewDirW, dLightDirNormW);
         #else
             // 16.0 is a constant that is in getFalloffInvSquared()
             #if LIGHT{i}SHAPE == RECT
-                float attenDiffuse = getRectLightDiffuse(litArgs_worldNormal, dViewDirW, lightDirW, dLightDirNormW) * 16.0;
+                var attenDiffuse: f32 = getRectLightDiffuse(litArgs_worldNormal, dViewDirW, lightDirW, dLightDirNormW) * 16.0;
             #elif LIGHT{i}SHAPE == DISK
-                float attenDiffuse = getDiskLightDiffuse(litArgs_worldNormal, dViewDirW, lightDirW, dLightDirNormW) * 16.0;
+                var attenDiffuse: f32 = getDiskLightDiffuse(litArgs_worldNormal, dViewDirW, lightDirW, dLightDirNormW) * 16.0;
             #elif LIGHT{i}SHAPE == SPHERE
-                float attenDiffuse = getSphereLightDiffuse(litArgs_worldNormal, dViewDirW, lightDirW, dLightDirNormW) * 16.0;
+                var attenDiffuse: f32 = getSphereLightDiffuse(litArgs_worldNormal, dViewDirW, lightDirW, dLightDirNormW) * 16.0;
             #endif
         #endif
     #else
         // one parameter is unused for punctual lights
-        dAtten *= getLightDiffuse(litArgs_worldNormal, vec3(0.0), dLightDirNormW);
+        dAtten = dAtten * getLightDiffuse(litArgs_worldNormal, vec3(0.0), dLightDirNormW);
     #endif
 
     // apply the shadow attenuation
     #ifdef LIGHT{i}CASTSHADOW
 
         #if LIGHT{i}TYPE == DIRECTIONAL
-            float shadow = getShadow{i}(vec3(0.0));
+            var shadow: f32 = getShadow{i}(vec3(0.0));
         #else
-            float shadow = getShadow{i}(lightDirW);
+            var shadow: f32 = getShadow{i}(lightDirW);
         #endif
 
         // Apply shadow intensity to the shadow value
-        shadow = mix(1.0, shadow, light{i}_shadowIntensity);
+        shadow = mix(1.0, shadow, uniform.light{i}_shadowIntensity);
 
-        dAtten *= shadow;
+        dAtten = dAtten * shadow;
 
         #if defined(LIT_SHADOW_CATCHER) && LIGHT{i}TYPE == DIRECTIONAL
             // accumulate shadows for directional lights
-            dShadowCatcher *= shadow;
+            dShadowCatcher = dShadowCatcher * shadow;
         #endif            
 
     #endif
@@ -141,16 +137,16 @@ void evaluateLight{i}(
     #if LIGHT{i}SHAPE != PUNCTUAL
         // area light - they do not mix diffuse lighting into specular attenuation
         #ifdef LIT_SPECULAR
-            dDiffuseLight += ((attenDiffuse * dAtten) * lightColor) * (1.0 - dLTCSpecFres);
+            dDiffuseLight = dDiffuseLight + (((attenDiffuse * dAtten) * lightColor) * (1.0 - dLTCSpecFres));
         #else
-            dDiffuseLight += (attenDiffuse * dAtten) * lightColor;
+            dDiffuseLight = dDiffuseLight + ((attenDiffuse * dAtten) * lightColor);
         #endif                        
     #else
         // punctual light
         #if defined(AREA_LIGHTS) && defined(LIT_SPECULAR)
-            dDiffuseLight += (dAtten * lightColor) * (1.0 - litArgs_specularity);
+            dDiffuseLight = dDiffuseLight + ((dAtten * lightColor) * (1.0 - litArgs_specularity));
         #else
-            dDiffuseLight += dAtten * lightColor;
+            dDiffuseLight = dDiffuseLight + (dAtten * lightColor);
         #endif
     #endif
 
@@ -161,21 +157,21 @@ void evaluateLight{i}(
 
             #ifdef LIT_CLEARCOAT
                 #if LIGHT{i}SHAPE == RECT
-                    ccSpecularLight += ccLTCSpecFres * getRectLightSpecular(litArgs_clearcoat_worldNormal, dViewDirW) * dAtten * lightColor;
+                    ccSpecularLight = ccSpecularLight + (ccLTCSpecFres * getRectLightSpecular(litArgs_clearcoat_worldNormal, dViewDirW) * dAtten * lightColor);
                 #elif LIGHT{i}SHAPE == DISK
-                    ccSpecularLight += ccLTCSpecFres * getDiskLightSpecular(litArgs_clearcoat_worldNormal, dViewDirW) * dAtten * lightColor;
+                    ccSpecularLight = ccSpecularLight + (ccLTCSpecFres * getDiskLightSpecular(litArgs_clearcoat_worldNormal, dViewDirW) * dAtten * lightColor);
                 #elif LIGHT{i}SHAPE == SPHERE
-                    ccSpecularLight += ccLTCSpecFres * getSphereLightSpecular(litArgs_clearcoat_worldNormal, dViewDirW) * dAtten * lightColor;
+                    ccSpecularLight = ccSpecularLight + (ccLTCSpecFres * getSphereLightSpecular(litArgs_clearcoat_worldNormal, dViewDirW) * dAtten * lightColor);
                 #endif
             #endif
 
             #ifdef LIT_SPECULAR
                 #if LIGHT{i}SHAPE == RECT
-                    dSpecularLight += dLTCSpecFres * getRectLightSpecular(litArgs_worldNormal, dViewDirW) * dAtten * lightColor;
+                    dSpecularLight = dSpecularLight + (dLTCSpecFres * getRectLightSpecular(litArgs_worldNormal, dViewDirW) * dAtten * lightColor);
                 #elif LIGHT{i}SHAPE == DISK
-                    dSpecularLight += dLTCSpecFres * getDiskLightSpecular(litArgs_worldNormal, dViewDirW) * dAtten * lightColor;
+                    dSpecularLight = dSpecularLight + (dLTCSpecFres * getDiskLightSpecular(litArgs_worldNormal, dViewDirW) * dAtten * lightColor);
                 #elif LIGHT{i}SHAPE == SPHERE
-                    dSpecularLight += dLTCSpecFres * getSphereLightSpecular(litArgs_worldNormal, dViewDirW) * dAtten * lightColor;
+                    dSpecularLight = dSpecularLight + (dLTCSpecFres * getSphereLightSpecular(litArgs_worldNormal, dViewDirW) * dAtten * lightColor);
                 #endif
             #endif
 
@@ -187,42 +183,41 @@ void evaluateLight{i}(
             #endif
 
             #ifdef LIT_SPECULAR
-                vec3 halfDirW = normalize(-dLightDirNormW + dViewDirW);
+                var halfDirW: vec3f = normalize(-dLightDirNormW + dViewDirW);
             #endif
 
             // if LTC lights are present, specular must be accumulated with specularity (specularity is pre multiplied by punctual light fresnel)
             #ifdef LIT_CLEARCOAT
-                vec3 lightspecularCC = getLightSpecular(halfDirW, ccReflDirW, litArgs_clearcoat_worldNormal, dViewDirW, dLightDirNormW, litArgs_clearcoat_gloss, dTBN) * dAtten * lightColor;
+                var lightspecularCC: vec3f = getLightSpecular(halfDirW, ccReflDirW, litArgs_clearcoat_worldNormal, dViewDirW, dLightDirNormW, litArgs_clearcoat_gloss, dTBN) * dAtten * lightColor;
                 #ifdef LIGHT{i}FRESNEL
-                    lightspecularCC *= getFresnelCC(dot(dViewDirW, halfDirW));
+                    lightspecularCC = lightspecularCC * getFresnelCC(dot(dViewDirW, halfDirW));
                 #endif
-                ccSpecularLight += lightspecularCC;
+                ccSpecularLight = ccSpecularLight + lightspecularCC;
             #endif
 
             #ifdef LIT_SHEEN
-                sSpecularLight += getLightSpecularSheen(halfDirW, litArgs_worldNormal, dViewDirW, dLightDirNormW, litArgs_sheen_gloss) * dAtten * lightColor;
+                sSpecularLight = sSpecularLight + (getLightSpecularSheen(halfDirW, litArgs_worldNormal, dViewDirW, dLightDirNormW, litArgs_sheen_gloss) * dAtten * lightColor);
             #endif
 
             #ifdef LIT_SPECULAR
 
-                vec3 lightSpecular = getLightSpecular(halfDirW, dReflDirW, litArgs_worldNormal, dViewDirW, dLightDirNormW, litArgs_gloss, dTBN) * dAtten * lightColor;
+                var lightSpecular: vec3f = getLightSpecular(halfDirW, dReflDirW, litArgs_worldNormal, dViewDirW, dLightDirNormW, litArgs_gloss, dTBN) * dAtten * lightColor;
                 #ifdef LIGHT{i}FRESNEL
 
                     #if defined(LIT_IRIDESCENCE)
-                        lightSpecular *= getFresnel(dot(dViewDirW, halfDirW), litArgs_gloss, litArgs_specularity, iridescenceFresnel, litArgs_iridescence_intensity);
+                        lightSpecular = lightSpecular * getFresnel(dot(dViewDirW, halfDirW), litArgs_gloss, litArgs_specularity, iridescenceFresnel, litArgs_iridescence_intensity);
                     #else
-                        lightSpecular *= getFresnel(dot(dViewDirW, halfDirW), litArgs_gloss, litArgs_specularity);
+                        lightSpecular = lightSpecular * getFresnel(dot(dViewDirW, halfDirW), litArgs_gloss, litArgs_specularity);
                     #endif
 
                 #else
-                    lightSpecular *= litArgs_specularity;
+                    lightSpecular = lightSpecular * litArgs_specularity;
                 #endif
                 
-                dSpecularLight += lightSpecular;
+                dSpecularLight = dSpecularLight + lightSpecular;
             #endif
         #endif
     #endif
-*/
 }
 #endif
 `;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/metalnessModulate.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/metalnessModulate.js
@@ -1,0 +1,11 @@
+export default /* glsl */`
+
+fn getSpecularModulate(specularity: vec3f, albedo: vec3f, metalness: f32, f0: f32) -> vec3f {
+    let dielectricF0: vec3f = f0 * specularity;
+    return mix(dielectricF0, albedo, metalness);
+}
+
+fn getAlbedoModulate(albedo: vec3f, metalness: f32) -> vec3f {
+    return albedo * (1.0 - metalness);
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/reflDirAniso.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/reflDirAniso.js
@@ -1,0 +1,10 @@
+export default /* wgsl */`
+fn getReflDir(worldNormal: vec3f, viewDir: vec3f, gloss: f32, tbn: mat3x3f) {
+    let roughness: f32 = sqrt(1.0 - min(gloss, 1.0));
+    let anisotropy: f32 = uniform.material_anisotropy * roughness;
+    let anisotropicDirection: vec3f = select(tbn[0], tbn[1], anisotropy >= 0.0);
+    let anisotropicTangent: vec3f = cross(anisotropicDirection, viewDir);
+    let anisotropicNormal: vec3f = cross(anisotropicTangent, anisotropicDirection);
+    let bentNormal: vec3f = normalize(mix(normalize(worldNormal), normalize(anisotropicNormal), anisotropy));
+    dReflDirW = reflect(-viewDir, bentNormal);
+}`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/reflectionCC.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/reflectionCC.js
@@ -1,0 +1,7 @@
+export default /* wgsl */`
+#ifdef LIT_CLEARCOAT
+fn addReflectionCC(reflDir: vec3f, gloss: f32) {
+    ccReflection = ccReflection + calcReflection(reflDir, gloss);
+}
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/reflectionSheen.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/reflectionSheen.js
@@ -1,0 +1,25 @@
+export default /* glsl */`
+
+fn addReflectionSheen(worldNormal: vec3f, viewDir: vec3f, gloss: f32) {
+    let NoV: f32 = dot(worldNormal, viewDir);
+    let alphaG: f32 = gloss * gloss;
+
+    // Avoid using a LUT and approximate the values analytically
+    let a: f32 = select(
+        -8.48 * alphaG + 14.3 * gloss - 9.95,
+        -339.2 * alphaG + 161.4 * gloss - 25.9,
+        gloss < 0.25
+    );
+    let b: f32 = select(
+        1.97 * alphaG - 3.27 * gloss + 0.72,
+        44.0 * alphaG - 23.7 * gloss + 3.26,
+        gloss < 0.25
+    );
+    let dg_add: f32 = select(
+        0.1 * ( gloss - 0.25 ),
+        0.0,
+        gloss < 0.25
+    );
+    let dg: f32 = exp( a * NoV + b ) + dg_add;
+    sReflection = sReflection + (calcReflection(worldNormal, 0.0) * saturate(dg));
+}`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/refractionDynamic.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/refractionDynamic.js
@@ -1,0 +1,89 @@
+export default /* wgsl */`
+uniform material_invAttenuationDistance: f32;
+uniform material_attenuation: vec3f;
+
+fn evalRefractionColor(refractionVector: vec3f, gloss: f32, refractionIndex: f32) -> vec3f {
+
+    // The refraction point is the entry point + vector to exit point
+    let pointOfRefraction: vec4f = vec4f(vPositionW + refractionVector, 1.0);
+
+    // Project to texture space so we can sample it
+    let projectionPoint: vec4f = uniform.matrix_viewProjection * pointOfRefraction;
+
+    // use built-in getGrabScreenPos function to convert screen position to grab texture uv coords
+    let uv: vec2f = getGrabScreenPos(projectionPoint);
+
+    // Use IOR and roughness to select mip
+    let iorToRoughness: f32 = (1.0 - gloss) * clamp((1.0 / refractionIndex) * 2.0 - 2.0, 0.0, 1.0);
+    let refractionLod: f32 = log2(uScreenSize.x) * iorToRoughness;
+    let refraction: vec3f = textureSampleLevel(uSceneColorMap, uSceneColorMapSampler, uv, refractionLod).rgb;
+
+    return refraction;
+}
+
+fn addRefraction(
+    worldNormal: vec3f,
+    viewDir: vec3f,
+    thickness: f32,
+    gloss: f32,
+    specularity: vec3f,
+    albedo: vec3f,
+    transmission: f32,
+    refractionIndex: f32,
+    dispersion: f32,
+#if defined(LIT_IRIDESCENCE)
+    iridescenceFresnel: vec3f,
+    iridescenceIntensity: f32
+#endif
+) {
+
+    // Extract scale from the model transform
+    var modelScale: vec3f;
+    modelScale.x = length(uniform.matrix_model[0].xyz);
+    modelScale.y = length(uniform.matrix_model[1].xyz);
+    modelScale.z = length(uniform.matrix_model[2].xyz);
+
+    // Calculate the refraction vector, scaled by the thickness and scale of the object
+    let scale: vec3f = thickness * modelScale;
+    var refractionVector = normalize(refract(-viewDir, worldNormal, refractionIndex)) * scale;
+    var refraction = evalRefractionColor(refractionVector, gloss, refractionIndex);
+
+    #ifdef LIT_DISPERSION
+        // based on the dispersion material property, calculate modified refraction index values
+        // for R and B channels and evaluate the refraction color for them.
+        let halfSpread: f32 = (1.0 / refractionIndex - 1.0) * 0.025 * dispersion;
+
+        let refractionIndexR: f32 = refractionIndex - halfSpread;
+        refractionVector = normalize(refract(-viewDir, worldNormal, refractionIndexR)) * scale;
+        refraction.r = evalRefractionColor(refractionVector, gloss, refractionIndexR).r;
+
+        let refractionIndexB: f32 = refractionIndex + halfSpread;
+        refractionVector = normalize(refract(-viewDir, worldNormal, refractionIndexB)) * scale;
+        refraction.b = evalRefractionColor(refractionVector, gloss, refractionIndexB).b;
+    #endif
+
+    // Transmittance is our final refraction color
+    var transmittance: vec3f;
+    if (uniform.material_invAttenuationDistance != 0.0)
+    {
+        let attenuation: vec3f = -log(uniform.material_attenuation) * uniform.material_invAttenuationDistance;
+        transmittance = exp(-attenuation * length(refractionVector));
+    }
+    else
+    {
+        transmittance = refraction;
+    }
+
+    // Apply fresnel effect on refraction
+    let fresnel: vec3f = vec3f(1.0) -
+        getFresnel(
+            dot(viewDir, worldNormal),
+            gloss,
+            specularity
+        #if defined(LIT_IRIDESCENCE)
+            , iridescenceFresnel,
+            iridescenceIntensity
+        #endif
+        );
+    dDiffuseLight = mix(dDiffuseLight, refraction * transmittance * fresnel, transmission);
+}`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/vert/uvTransform.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/vert/uvTransform.js
@@ -1,7 +1,7 @@
 // chunk that generates uv coordinate transformed by uv transform matrix
 export default /* wgsl */`
-vUV{TRANSFORM_UV_{i}}_{TRANSFORM_ID_{i}} = vec2f(
-    dot(vec3f(uv{TRANSFORM_UV_{i}}, 1), {TRANSFORM_NAME_{i}}0),
-    dot(vec3f(uv{TRANSFORM_UV_{i}}, 1), {TRANSFORM_NAME_{i}}1)
+output.vUV{TRANSFORM_UV_{i}}_{TRANSFORM_ID_{i}} = vec2f(
+    dot(vec3f(uv{TRANSFORM_UV_{i}}, 1), uniform.{TRANSFORM_NAME_{i}}0),
+    dot(vec3f(uv{TRANSFORM_UV_{i}}, 1), uniform.{TRANSFORM_NAME_{i}}1)
 );
 `;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/alphaTest.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/alphaTest.js
@@ -1,0 +1,9 @@
+export default /* wgsl */`
+uniform alpha_ref: f32;
+
+fn alphaTest(a: f32) {
+    if (a < uniform.alpha_ref) {
+        discard;
+    }
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/ao.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/ao.js
@@ -1,0 +1,33 @@
+export default /* wgsl */`
+
+#if defined(STD_AO_TEXTURE) || defined(STD_AO_VERTEX)
+    uniform material_aoIntensity: f32;
+#endif
+
+#ifdef STD_AODETAIL_TEXTURE
+    #include "detailModesPS"
+#endif
+
+fn getAO() {
+    dAo = 1.0;
+
+    #ifdef STD_AO_TEXTURE
+        var aoBase: f32 = textureSampleBias({STD_AO_TEXTURE_NAME}, {STD_AO_TEXTURE_NAME}Sampler, {STD_AO_TEXTURE_UV}, uniform.textureBias).{STD_AO_TEXTURE_CHANNEL};
+
+        #ifdef STD_AODETAIL_TEXTURE
+            var aoDetail: f32 = textureSampleBias({STD_AODETAIL_TEXTURE_NAME}, {STD_AODETAIL_TEXTURE_NAME}Sampler, {STD_AODETAIL_TEXTURE_UV}, uniform.textureBias).{STD_AODETAIL_TEXTURE_CHANNEL};
+            aoBase = detailMode_{STD_AODETAIL_DETAILMODE}(vec3f(aoBase), vec3f(aoDetail)).r;
+        #endif
+
+        dAo = dAo * aoBase;
+    #endif
+
+    #ifdef STD_AO_VERTEX
+        dAo = dAo * saturate(vVertexColor.{STD_AO_VERTEX_CHANNEL});
+    #endif
+
+    #if defined(STD_AO_TEXTURE) || defined(STD_AO_VERTEX)
+        dAo = mix(1.0, dAo, uniform.material_aoIntensity);
+    #endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/clearCoat.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/clearCoat.js
@@ -1,0 +1,21 @@
+export default /* wgsl */`
+#ifdef STD_CLEARCOAT_CONSTANT
+    uniform material_clearCoat: f32;
+#endif
+
+fn getClearCoat() {
+    ccSpecularity = 1.0;
+
+    #ifdef STD_CLEARCOAT_CONSTANT
+    ccSpecularity = ccSpecularity * uniform.material_clearCoat;
+    #endif
+
+    #ifdef STD_CLEARCOAT_TEXTURE
+    ccSpecularity = ccSpecularity * textureSampleBias({STD_CLEARCOAT_TEXTURE_NAME}, {STD_CLEARCOAT_TEXTURE_NAME}Sampler, {STD_CLEARCOAT_TEXTURE_UV}, uniform.textureBias).{STD_CLEARCOAT_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_CLEARCOAT_VERTEX
+    ccSpecularity = ccSpecularity * saturate(vVertexColor.{STD_CLEARCOAT_VERTEX_CHANNEL});
+    #endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/clearCoatGloss.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/clearCoatGloss.js
@@ -1,0 +1,27 @@
+export default /* wgsl */`
+#ifdef STD_CLEARCOATGLOSS_CONSTANT
+    uniform material_clearCoatGloss: f32;
+#endif
+
+fn getClearCoatGlossiness() {
+    ccGlossiness = 1.0;
+
+    #ifdef STD_CLEARCOATGLOSS_CONSTANT
+    ccGlossiness = ccGlossiness * uniform.material_clearCoatGloss;
+    #endif
+
+    #ifdef STD_CLEARCOATGLOSS_TEXTURE
+    ccGlossiness = ccGlossiness * textureSampleBias({STD_CLEARCOATGLOSS_TEXTURE_NAME}, {STD_CLEARCOATGLOSS_TEXTURE_NAME}Sampler, {STD_CLEARCOATGLOSS_TEXTURE_UV}, uniform.textureBias).{STD_CLEARCOATGLOSS_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_CLEARCOATGLOSS_VERTEX
+    ccGlossiness = ccGlossiness * saturate(vVertexColor.{STD_CLEARCOATGLOSS_VERTEX_CHANNEL});
+    #endif
+
+    #ifdef STD_CLEARCOATGLOSS_INVERT
+    ccGlossiness = 1.0 - ccGlossiness;
+    #endif
+
+    ccGlossiness += 0.0000001;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/clearCoatNormal.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/clearCoatNormal.js
@@ -1,0 +1,15 @@
+export default /* wgsl */`
+#ifdef STD_CLEARCOATNORMAL_TEXTURE
+    uniform material_clearCoatBumpiness: f32;
+#endif
+
+fn getClearCoatNormal() {
+#ifdef STD_CLEARCOATNORMAL_TEXTURE
+    var normalMap: vec3f = {STD_CLEARCOATNORMAL_TEXTURE_DECODE}(textureSampleBias({STD_CLEARCOATNORMAL_TEXTURE_NAME}, {STD_CLEARCOATNORMAL_TEXTURE_NAME}Sampler, {STD_CLEARCOATNORMAL_TEXTURE_UV}, uniform.textureBias));
+    normalMap = mix(vec3f(0.0, 0.0, 1.0), normalMap, uniform.material_clearCoatBumpiness);
+    ccNormalW = normalize(dTBN * normalMap);
+#else
+    ccNormalW = dVertexNormalW;
+#endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/detailModes.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/detailModes.js
@@ -1,0 +1,33 @@
+export default /* wgsl */`
+
+#ifndef _DETAILMODES_INCLUDED_
+#define _DETAILMODES_INCLUDED_
+
+fn detailMode_mul(c1: vec3f, c2: vec3f) -> vec3f {
+    return c1 * c2;
+}
+
+fn detailMode_add(c1: vec3f, c2: vec3f) -> vec3f {
+    return c1 + c2;
+}
+
+// https://en.wikipedia.org/wiki/Blend_modes#Screen
+fn detailMode_screen(c1: vec3f, c2: vec3f) -> vec3f {
+    return 1.0 - (1.0 - c1)*(1.0 - c2);
+}
+
+// https://en.wikipedia.org/wiki/Blend_modes#Overlay
+fn detailMode_overlay(c1: vec3f, c2: vec3f) -> vec3f {
+    return mix(1.0 - 2.0 * (1.0 - c1)*(1.0 - c2), 2.0 * c1 * c2, step(c1, vec3f(0.5)));
+}
+
+fn detailMode_min(c1: vec3f, c2: vec3f) -> vec3f {
+    return min(c1, c2);
+}
+
+fn detailMode_max(c1: vec3f, c2: vec3f) -> vec3f {
+    return max(c1, c2);
+}
+
+#endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/diffuse.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/diffuse.js
@@ -1,0 +1,26 @@
+export default /* wgsl */`
+uniform material_diffuse: vec3f;
+
+#ifdef STD_DIFFUSEDETAIL_TEXTURE
+    #include "detailModesPS"
+#endif
+
+fn getAlbedo() {
+    dAlbedo = uniform.material_diffuse.rgb;
+
+    #ifdef STD_DIFFUSE_TEXTURE
+        var albedoTexture: vec3f = {STD_DIFFUSE_TEXTURE_DECODE}(textureSampleBias({STD_DIFFUSE_TEXTURE_NAME}, {STD_DIFFUSE_TEXTURE_NAME}Sampler, {STD_DIFFUSE_TEXTURE_UV}, uniform.textureBias)).{STD_DIFFUSE_TEXTURE_CHANNEL};
+
+        #ifdef STD_DIFFUSEDETAIL_TEXTURE
+            var albedoDetail: vec3f = {STD_DIFFUSEDETAIL_TEXTURE_DECODE}(textureSampleBias({STD_DIFFUSEDETAIL_TEXTURE_NAME}, {STD_DIFFUSEDETAIL_TEXTURE_NAME}Sampler, {STD_DIFFUSEDETAIL_TEXTURE_UV}, uniform.textureBias)).{STD_DIFFUSEDETAIL_TEXTURE_CHANNEL};
+            albedoTexture = detailMode_{STD_DIFFUSEDETAIL_DETAILMODE}(albedoTexture, albedoDetail);
+        #endif
+
+        dAlbedo = dAlbedo * albedoTexture;
+    #endif
+
+    #ifdef STD_DIFFUSE_VERTEX
+        dAlbedo = dAlbedo * gammaCorrectInput(saturate(vVertexColor.{STD_DIFFUSE_VERTEX_CHANNEL}));
+    #endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/emissive.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/emissive.js
@@ -1,0 +1,16 @@
+export default /* wgsl */`
+uniform material_emissive: vec3f;
+uniform material_emissiveIntensity: f32;
+
+fn getEmission() {
+    dEmission = uniform.material_emissive * uniform.material_emissiveIntensity;
+
+    #ifdef STD_EMISSIVE_TEXTURE
+    dEmission *= {STD_EMISSIVE_TEXTURE_DECODE}(textureSampleBias({STD_EMISSIVE_TEXTURE_NAME}, {STD_EMISSIVE_TEXTURE_NAME}Sampler, {STD_EMISSIVE_TEXTURE_UV}, uniform.textureBias)).{STD_EMISSIVE_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_EMISSIVE_VERTEX
+    dEmission = dEmission * gammaCorrectInput(saturate(vVertexColor.{STD_EMISSIVE_VERTEX_CHANNEL}));
+    #endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/gloss.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/gloss.js
@@ -1,0 +1,27 @@
+export default /* wgsl */`
+#ifdef STD_GLOSS_CONSTANT
+    uniform material_gloss: f32;
+#endif
+
+fn getGlossiness() {
+    dGlossiness = 1.0;
+
+    #ifdef STD_GLOSS_CONSTANT
+    dGlossiness = dGlossiness * uniform.material_gloss;
+    #endif
+
+    #ifdef STD_GLOSS_TEXTURE
+    dGlossiness = dGlossiness * textureSampleBias({STD_GLOSS_TEXTURE_NAME}, {STD_GLOSS_TEXTURE_NAME}Sampler, {STD_GLOSS_TEXTURE_UV}, uniform.textureBias).{STD_GLOSS_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_GLOSS_VERTEX
+    dGlossiness = dGlossiness * saturate(vVertexColor.{STD_GLOSS_VERTEX_CHANNEL});
+    #endif
+
+    #ifdef STD_GLOSS_INVERT
+    dGlossiness = 1.0 - dGlossiness;
+    #endif
+
+    dGlossiness = dGlossiness + 0.0000001;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/ior.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/ior.js
@@ -1,0 +1,13 @@
+export default /* wgsl */`
+#ifdef STD_IOR_CONSTANT
+    uniform material_refractionIndex: f32;
+#endif
+
+fn getIor() {
+#ifdef STD_IOR_CONSTANT
+    dIor = uniform.material_refractionIndex;
+#else
+    dIor = 1.0 / 1.5;
+#endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/iridescence.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/iridescence.js
@@ -1,0 +1,19 @@
+export default /* wgsl */`
+#ifdef STD_IRIDESCENCE_CONSTANT
+    uniform material_iridescence: f32;
+#endif
+
+fn getIridescence() {
+    var iridescence = 1.0;
+
+    #ifdef STD_IRIDESCENCE_CONSTANT
+    iridescence = iridescence * uniform.material_iridescence;
+    #endif
+
+    #ifdef STD_IRIDESCENCE_TEXTURE
+    iridescence = iridescence * textureSampleBias({STD_IRIDESCENCE_TEXTURE_NAME}, {STD_IRIDESCENCE_TEXTURE_NAME}Sampler, {STD_IRIDESCENCE_TEXTURE_UV}, uniform.textureBias).{STD_IRIDESCENCE_TEXTURE_CHANNEL};
+    #endif
+
+    dIridescence = iridescence; 
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/iridescenceThickness.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/iridescenceThickness.js
@@ -1,0 +1,19 @@
+export default /* wgsl */`
+uniform material_iridescenceThicknessMax: f32;
+
+#ifdef STD_IRIDESCENCETHICKNESS_TEXTURE
+    uniform material_iridescenceThicknessMin: f32;
+#endif
+
+fn getIridescenceThickness() {
+
+    #ifdef STD_IRIDESCENCETHICKNESS_TEXTURE
+        var blend: f32 = textureSampleBias({STD_IRIDESCENCETHICKNESS_TEXTURE_NAME}, {STD_IRIDESCENCETHICKNESS_TEXTURE_NAME}Sampler, {STD_IRIDESCENCETHICKNESS_TEXTURE_UV}, uniform.textureBias).{STD_IRIDESCENCETHICKNESS_TEXTURE_CHANNEL};
+        var iridescenceThickness: f32 = mix(uniform.material_iridescenceThicknessMin, uniform.material_iridescenceThicknessMax, blend);
+    #else
+        var iridescenceThickness: f32 = uniform.material_iridescenceThicknessMax;
+    #endif
+
+    dIridescenceThickness = iridescenceThickness; 
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/metalness.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/metalness.js
@@ -1,0 +1,23 @@
+export default /* wgsl */`
+#ifdef STD_METALNESS_CONSTANT
+uniform material_metalness: f32;
+#endif
+
+fn getMetalness() {
+    var metalness: f32 = 1.0;
+
+    #ifdef STD_METALNESS_CONSTANT
+        metalness = metalness * uniform.material_metalness;
+    #endif
+
+    #ifdef STD_METALNESS_TEXTURE
+        metalness = metalness * textureSampleBias({STD_METALNESS_TEXTURE_NAME}, {STD_METALNESS_TEXTURE_NAME}Sampler, {STD_METALNESS_TEXTURE_UV}, uniform.textureBias).{STD_METALNESS_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_METALNESS_VERTEX
+    metalness = metalness * saturate(vVertexColor.{STD_METALNESS_VERTEX_CHANNEL});
+    #endif
+
+    dMetalness = metalness;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/normalMap.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/normalMap.js
@@ -1,0 +1,33 @@
+export default /* wgsl */`
+#ifdef STD_NORMAL_TEXTURE
+    uniform material_bumpiness: f32;
+#endif
+
+#ifdef STD_NORMALDETAIL_TEXTURE
+    uniform material_normalDetailMapBumpiness: f32;
+
+    // https://blog.selfshadow.com/publications/blending-in-detail/#detail-oriented
+    fn blendNormals(inN1: vec3f, inN2: vec3f) -> vec3f {
+        let n1: vec3f = inN1 + vec3f(0.0, 0.0, 1.0);
+        let n2: vec3f = inN2 * vec3f(-1.0, -1.0, 1.0);
+        return n1 * dot(n1, n2) / n1.z - n2;
+    }
+#endif
+
+fn getNormal() {
+#ifdef STD_NORMAL_TEXTURE
+    var normalMap: vec3f = {STD_NORMAL_TEXTURE_DECODE}(textureSampleBias({STD_NORMAL_TEXTURE_NAME}, {STD_NORMAL_TEXTURE_NAME}Sampler, {STD_NORMAL_TEXTURE_UV}, uniform.textureBias));
+    normalMap = mix(vec3f(0.0, 0.0, 1.0), normalMap, uniform.material_bumpiness);
+
+    #ifdef STD_NORMALDETAIL_TEXTURE
+        var normalDetailMap: vec3f = {STD_NORMALDETAIL_TEXTURE_DECODE}(textureSampleBias({STD_NORMALDETAIL_TEXTURE_NAME}, {STD_NORMALDETAIL_TEXTURE_NAME}Sampler, {STD_NORMALDETAIL_TEXTURE_UV}, uniform.textureBias));
+        normalDetailMap = mix(vec3f(0.0, 0.0, 1.0), normalDetailMap, uniform.material_normalDetailMapBumpiness);
+        normalMap = blendNormals(normalMap, normalDetailMap);
+    #endif
+
+    dNormalW = normalize(dTBN * normalMap);
+#else
+    dNormalW = dVertexNormalW;
+#endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/opacity-dither.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/opacity-dither.js
@@ -1,0 +1,41 @@
+export default /* wgsl */`
+
+#if STD_OPACITY_DITHER == BAYER8
+    #include "bayerPS"
+#endif
+
+uniform blueNoiseJitter: vec4f;
+
+#if STD_OPACITY_DITHER == BLUENOISE
+    var blueNoiseTex32 : texture_2d<f32>;
+    var blueNoiseTex32Sampler : sampler;
+#endif
+
+fn opacityDither(alpha: f32, id: f32) {
+    #if STD_OPACITY_DITHER == BAYER8
+
+        var noise: f32 = bayer8(floor((pcPosition.xy + uniform.blueNoiseJitter.xy + id) % vec2f(8.0))) / 64.0;
+
+    #else
+
+        #if STD_OPACITY_DITHER == BLUENOISE
+            var uv = fract(pcPosition.xy / 32.0 + uniform.blueNoiseJitter.xy + id);
+            var noise: f32 = textureSampleLevel(blueNoiseTex32, blueNoiseTex32Sampler, uv, 0.0).y;
+        #endif
+
+        #if STD_OPACITY_DITHER == IGNNOISE
+            // based on https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare/
+            var magic = vec3f(0.06711056, 0.00583715, 52.9829189);
+            var noise: f32 = fract(magic.z * fract(dot(pcPosition.xy + uniform.blueNoiseJitter.xy + id, magic.xy)));
+        #endif
+
+    #endif
+
+    // convert the noise to linear space, as that is specified in sRGB space (stores perceptual values)
+    noise = pow(noise, 2.2);
+
+    if (alpha < noise) {
+        discard;
+    }
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/opacity.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/opacity.js
@@ -1,0 +1,15 @@
+export default /* wgsl */`
+uniform material_opacity: f32;
+
+fn getOpacity() {
+    dAlpha = uniform.material_opacity;
+
+    #ifdef STD_OPACITY_TEXTURE
+    dAlpha = dAlpha * textureSampleBias({STD_OPACITY_TEXTURE_NAME}, {STD_OPACITY_TEXTURE_NAME}Sampler, {STD_OPACITY_TEXTURE_UV}, uniform.textureBias).{STD_OPACITY_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_OPACITY_VERTEX
+    dAlpha = dAlpha * clamp(vVertexColor.{STD_OPACITY_VERTEX_CHANNEL}, 0.0, 1.0);
+    #endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/parallax.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/parallax.js
@@ -1,0 +1,14 @@
+export default /* wgsl */`
+uniform material_heightMapFactor: f32;
+
+fn getParallax() {
+    var parallaxScale = uniform.material_heightMapFactor;
+
+    var height: f32 = textureSampleBias({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_NAME}Sampler, {STD_HEIGHT_TEXTURE_UV}, uniform.textureBias).{STD_HEIGHT_TEXTURE_CHANNEL};
+    height = height * parallaxScale - parallaxScale * 0.5;
+    var viewDirT: vec3f = dViewDirW * dTBN;
+
+    viewDirT.z = viewDirT.z + 0.42;
+    dUvOffset = height * (viewDirT.xy / viewDirT.z);
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/sheen.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/sheen.js
@@ -1,0 +1,18 @@
+export default /* wgsl */`
+
+uniform material_sheen: vec3f;
+
+fn getSheen() {
+    var sheenColor = uniform.material_sheen;
+
+    #ifdef STD_SHEEN_TEXTURE
+    sheenColor = sheenColor * {STD_SHEEN_TEXTURE_DECODE}(textureSampleBias({STD_SHEEN_TEXTURE_NAME}, {STD_SHEEN_TEXTURE_NAME}Sampler, {STD_SHEEN_TEXTURE_UV}, uniform.textureBias)).{STD_SHEEN_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_SHEEN_VERTEX
+    sheenColor = sheenColor * saturate(vVertexColor.{STD_SHEEN_VERTEX_CHANNEL});
+    #endif
+
+    sSpecularity = sheenColor;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/sheenGloss.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/sheenGloss.js
@@ -1,0 +1,21 @@
+export default /* wgsl */`
+uniform material_sheenGloss: f32;
+
+fn getSheenGlossiness() {
+    var sheenGlossiness = uniform.material_sheenGloss;
+
+    #ifdef STD_SHEENGLOSS_TEXTURE
+    sheenGlossiness = sheenGlossiness * textureSampleBias({STD_SHEENGLOSS_TEXTURE_NAME}, {STD_SHEENGLOSS_TEXTURE_NAME}Sampler, {STD_SHEENGLOSS_TEXTURE_UV}, uniform.textureBias).{STD_SHEENGLOSS_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_SHEENGLOSS_VERTEX
+    sheenGlossiness = sheenGlossiness * saturate(vVertexColor.{STD_SHEENGLOSS_VERTEX_CHANNEL});
+    #endif
+
+    #ifdef STD_SHEENGLOSS_INVERT
+    sheenGlossiness = 1.0 - sheenGlossiness;
+    #endif
+
+    sGlossiness = sheenGlossiness + 0.0000001;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/specular.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/specular.js
@@ -1,0 +1,24 @@
+export default /* wgsl */`
+
+#ifdef STD_SPECULAR_CONSTANT
+    uniform material_specular: vec3f;
+#endif
+
+fn getSpecularity() {
+    var specularColor = vec3f(1.0, 1.0, 1.0);
+
+    #ifdef STD_SPECULAR_CONSTANT
+    specularColor = specularColor * uniform.material_specular;
+    #endif
+
+    #ifdef STD_SPECULAR_TEXTURE
+    specularColor = specularColor * {STD_SPECULAR_TEXTURE_DECODE}(textureSampleBias({STD_SPECULAR_TEXTURE_NAME}, {STD_SPECULAR_TEXTURE_NAME}Sampler, {STD_SPECULAR_TEXTURE_UV}, uniform.textureBias)).{STD_SPECULAR_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_SPECULAR_VERTEX
+    specularColor = specularColor * saturate(vVertexColor.{STD_SPECULAR_VERTEX_CHANNEL});
+    #endif
+
+    dSpecularity = specularColor;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/specularityFactor.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/specularityFactor.js
@@ -1,0 +1,24 @@
+export default /* wgsl */`
+
+#ifdef STD_SPECULARITYFACTOR_CONSTANT
+    uniform material_specularityFactor: f32;
+#endif
+
+fn getSpecularityFactor() {
+    var specularityFactor = 1.0;
+
+    #ifdef STD_SPECULARITYFACTOR_CONSTANT
+    specularityFactor = specularityFactor * uniform.material_specularityFactor;
+    #endif
+
+    #ifdef STD_SPECULARITYFACTOR_TEXTURE
+    specularityFactor = specularityFactor * textureSampleBias({STD_SPECULARITYFACTOR_TEXTURE_NAME}, {STD_SPECULARITYFACTOR_TEXTURE_NAME}Sampler, {STD_SPECULARITYFACTOR_TEXTURE_UV}, uniform.textureBias).{STD_SPECULARITYFACTOR_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_SPECULARITYFACTOR_VERTEX
+    specularityFactor = specularityFactor * saturate(vVertexColor.{STD_SPECULARITYFACTOR_VERTEX_CHANNEL});
+    #endif
+
+    dSpecularityFactor = specularityFactor;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/stdDeclaration.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/stdDeclaration.js
@@ -1,0 +1,208 @@
+// Declaration part of the standard shader. Declares the uniforms, textures and global variables used
+// by the fragment shader of the standard shader.
+export default /* wgsl */`
+
+    // globals
+    var<private> dAlpha: f32 = 1.0;
+
+    #if defined(LIT_ALPHA_TEST)
+        #include "alphaTestPS"
+    #endif
+
+    // dithering
+    #if STD_OPACITY_DITHER != NONE
+        #include "opacityDitherPS"
+    #endif
+
+    #ifdef FORWARD_PASS // ----------------
+
+        // globals
+        var<private> dAlbedo: vec3f;
+        var<private> dNormalW: vec3f;
+        var<private> dSpecularity: vec3f = vec3f(0.0, 0.0, 0.0);
+        var<private> dGlossiness: f32 = 0.0;
+
+        #ifdef LIT_REFRACTION
+            var<private> dTransmission: f32;
+            var<private> dThickness: f32;
+        #endif
+
+        #ifdef LIT_SCENE_COLOR
+            var uSceneColorMap : texture_2d<f32>;
+            var uSceneColorMapSampler : sampler;
+        #endif
+
+        #ifdef LIT_SCREEN_SIZE
+            var<private> uScreenSize: vec4f;
+        #endif
+
+        #ifdef LIT_TRANSFORMS
+            var<private> matrix_viewProjection: mat4x4f;
+            var<private> matrix_model: mat4x4f;
+        #endif
+
+        // parallax
+        #ifdef STD_HEIGHT_MAP
+            var<private> dUvOffset: vec2f;
+            #ifdef STD_DIFFUSE_TEXTURE_ALLOCATE
+                var texture_heightMap : texture_2d<f32>;
+                var texture_heightMapSampler : sampler;
+            #endif
+        #endif
+
+        // diffuse
+        #ifdef STD_DIFFUSE_TEXTURE_ALLOCATE
+            var texture_diffuseMap : texture_2d<f32>;
+            var texture_diffuseMapSampler : sampler;
+        #endif
+
+        #ifdef STD_DIFFUSEDETAIL_TEXTURE_ALLOCATE
+            var texture_diffuseDetailMap : texture_2d<f32>;
+            var texture_diffuseDetailMapSampler : sampler;
+        #endif
+
+        // normal
+        #ifdef STD_NORMAL_TEXTURE_ALLOCATE
+            var texture_normalMap : texture_2d<f32>;
+            var texture_normalMapSampler : sampler;
+        #endif
+
+        #ifdef STD_NORMALDETAIL_TEXTURE_ALLOCATE
+            var texture_normalDetailMap : texture_2d<f32>;
+            var texture_normalDetailMapSampler : sampler;
+        #endif
+
+        // refraction
+        #ifdef STD_THICKNESS_TEXTURE_ALLOCATE
+            var texture_thicknessMap : texture_2d<f32>;
+            var texture_thicknessMapSampler : sampler;
+        #endif
+        #ifdef STD_REFRACTION_TEXTURE_ALLOCATE
+            var texture_refractionMap : texture_2d<f32>;
+            var texture_refractionMapSampler : sampler;
+        #endif
+
+        // iridescence
+        #ifdef LIT_IRIDESCENCE
+            var<private> dIridescence: f32;
+            var<private> dIridescenceThickness: f32;
+
+            #ifdef STD_IRIDESCENCE_THICKNESS_TEXTURE_ALLOCATE
+                var texture_iridescenceThicknessMap : texture_2d<f32>;
+                var texture_iridescenceThicknessMapSampler : sampler;
+            #endif
+            #ifdef STD_IRIDESCENCE_TEXTURE_ALLOCATE
+                var texture_iridescenceMap : texture_2d<f32>;
+                var texture_iridescenceMapSampler : sampler;
+            #endif
+        #endif
+
+        #ifdef LIT_CLEARCOAT
+            var<private> ccSpecularity: f32;
+            var<private> ccGlossiness: f32;
+            var<private> ccNormalW: vec3f;
+        #endif
+
+        // specularity & glossiness
+        #ifdef LIT_SPECULAR_OR_REFLECTION
+
+            // sheen
+            #ifdef LIT_SHEEN
+                var<private> sSpecularity: vec3f;
+                var<private> sGlossiness: f32;
+
+                #ifdef STD_SHEEN_TEXTURE_ALLOCATE
+                    var texture_sheenMap : texture_2d<f32>;
+                    var texture_sheenMapSampler : sampler;
+                #endif
+                #ifdef STD_SHEENGLOSS_TEXTURE_ALLOCATE
+                    var texture_sheenGlossMap : texture_2d<f32>;
+                    var texture_sheenGlossMapSampler : sampler;
+                #endif
+            #endif
+
+            // metalness
+            #ifdef LIT_METALNESS
+                var<private> dMetalness: f32;
+                var<private> dIor: f32;
+
+                #ifdef STD_METALNESS_TEXTURE_ALLOCATE
+                    var texture_metalnessMap : texture_2d<f32>;
+                    var texture_metalnessMapSampler : sampler;
+                #endif
+            #endif
+
+            // specularity factor
+            #ifdef LIT_SPECULARITY_FACTOR
+                var<private> dSpecularityFactor: f32;
+
+                #ifdef STD_SPECULARITYFACTOR_TEXTURE_ALLOCATE
+                    var texture_specularityFactorMap : texture_2d<f32>;
+                    var texture_specularityFactorMapSampler : sampler;
+                #endif
+            #endif
+
+            // specular color
+            #ifdef STD_SPECULAR_COLOR
+                #ifdef STD_SPECULAR_TEXTURE_ALLOCATE
+                    var texture_specularMap : texture_2d<f32>;
+                    var texture_specularMapSampler : sampler;
+                #endif
+            #endif
+
+            // gloss
+            #ifdef STD_GLOSS_TEXTURE_ALLOCATE
+                var texture_glossMap : texture_2d<f32>;
+                var texture_glossMapSampler : sampler;
+            #endif
+        #endif
+
+        // ao
+        #ifdef STD_AO
+            var <private> dAo: f32;
+            #ifdef STD_AO_TEXTURE_ALLOCATE
+                var texture_aoMap : texture_2d<f32>;
+                var texture_aoMapSampler : sampler;
+            #endif
+            #ifdef STD_AODETAIL_TEXTURE_ALLOCATE
+                var texture_aoDetailMap : texture_2d<f32>;
+                var texture_aoDetailMapSampler : sampler;
+            #endif
+        #endif
+
+        // emission
+        var <private> dEmission: vec3f;
+        #ifdef STD_EMISSIVE_TEXTURE_ALLOCATE
+            var texture_emissiveMap : texture_2d<f32>;
+            var texture_emissiveMapSampler : sampler;
+        #endif
+
+        // clearcoat
+        #ifdef LIT_CLEARCOAT
+            #ifdef STD_CLEARCOAT_TEXTURE_ALLOCATE
+                var texture_clearCoatMap : texture_2d<f32>;
+                var texture_clearCoatMapSampler : sampler;
+            #endif
+            #ifdef STD_CLEARCOATGLOSS_TEXTURE_ALLOCATE
+                var texture_clearCoatGlossMap : texture_2d<f32>;
+                var texture_clearCoatGlossMapSampler : sampler;
+            #endif
+            #ifdef STD_CLEARCOATNORMAL_TEXTURE_ALLOCATE
+                var texture_clearCoatNormalMap : texture_2d<f32>;
+                var texture_clearCoatNormalMapSampler : sampler;
+            #endif
+        #endif
+
+        // lightmap
+        #if defined(STD_LIGHTMAP) || defined(STD_LIGHT_VERTEX_COLOR)
+            var<private> dLightmap: vec3f;
+            #ifdef STD_LIGHT_TEXTURE_ALLOCATE
+                var texture_lightMap : texture_2d<f32>;
+                var texture_lightMapSampler : sampler;
+            #endif
+        #endif
+    #endif
+
+    // front end outputs to lit shader
+    #include "litShaderCorePS"
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/stdFrontEnd.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/stdFrontEnd.js
@@ -1,0 +1,212 @@
+// includes and functionality of the front end shader, generates the input to the lit shader.
+export default /* wgsl */`
+
+    // all passes handle opacity
+    #if LIT_BLEND_TYPE != NONE || defined(LIT_ALPHA_TEST) || defined(LIT_ALPHA_TO_COVERAGE) || STD_OPACITY_DITHER != NONE
+        #ifdef STD_OPACITY_TEXTURE_ALLOCATE
+            var texture_opacityMap : texture_2d<f32>;
+            var texture_opacityMapSampler : sampler;
+        #endif
+        #include "opacityPS"
+    #endif
+
+    #ifdef FORWARD_PASS // ----------------
+
+        // parallax
+        #ifdef STD_HEIGHT_MAP
+            #include "parallaxPS"
+        #endif
+
+        // diffuse
+        #include  "diffusePS"
+
+        // normal
+        #ifdef LIT_NEEDS_NORMAL
+            #include "normalMapPS"
+        #endif
+
+        // refraction
+        #ifdef LIT_REFRACTION
+            #include "transmissionPS"
+            #include "thicknessPS"
+        #endif
+
+        // iridescence
+        #ifdef LIT_IRIDESCENCE
+            #include "iridescencePS"
+            #include "iridescenceThicknessPS"
+        #endif
+
+        // specularity & glossiness
+        #ifdef LIT_SPECULAR_OR_REFLECTION
+
+            // sheen
+            #ifdef LIT_SHEEN
+                #include "sheenPS"
+                #include "sheenGlossPS"
+            #endif
+
+            // metalness
+            #ifdef LIT_METALNESS
+                #include "metalnessPS"
+                #include "iorPS"
+            #endif
+
+            // specularity factor
+            #ifdef LIT_SPECULARITY_FACTOR
+                #include "specularityFactorPS"
+            #endif
+
+            // specular color
+            #ifdef STD_SPECULAR_COLOR
+                #include "specularPS"
+            #else
+                fn getSpecularity() { 
+                    dSpecularity = vec3f(1.0, 1.0, 1.0);
+                }
+            #endif
+
+            // gloss
+            #include "glossPS"
+        #endif
+
+        // ao
+        #ifdef STD_AO
+            #include "aoPS"
+        #endif
+
+        // emission
+        #include "emissivePS"
+
+        // clearcoat
+        #ifdef LIT_CLEARCOAT
+            #include "clearCoatPS"
+            #include "clearCoatGlossPS"
+            #include "clearCoatNormalPS"
+        #endif
+
+        // lightmap
+        #if defined(STD_LIGHTMAP) || defined(STD_LIGHT_VERTEX_COLOR)
+            #include "lightmapPS"
+        #endif
+    #endif
+
+    fn evaluateFrontend() {
+
+        // all passes handle opacity
+        #if LIT_BLEND_TYPE != NONE || defined(LIT_ALPHA_TEST) || defined(LIT_ALPHA_TO_COVERAGE) || STD_OPACITY_DITHER != NONE
+            getOpacity();
+
+            #if defined(LIT_ALPHA_TEST)
+                alphaTest(dAlpha);
+            #endif
+
+            #if STD_OPACITY_DITHER != NONE
+                opacityDither(dAlpha, 0.0);
+            #endif
+
+            litArgs_opacity = dAlpha;
+        #endif
+
+        #ifdef FORWARD_PASS // ----------------
+
+            // parallax
+            #ifdef STD_HEIGHT_MAP
+                getParallax();
+            #endif
+
+            // diffuse
+            getAlbedo();
+            litArgs_albedo = dAlbedo;
+
+            // normal
+            #ifdef LIT_NEEDS_NORMAL
+                getNormal();
+                litArgs_worldNormal = dNormalW;
+            #endif
+
+            // refraction
+            #ifdef LIT_REFRACTION
+                getRefraction();
+                litArgs_transmission = dTransmission;
+
+                getThickness();
+                litArgs_thickness = dThickness;
+
+                #ifdef LIT_DISPERSION
+                    litArgs_dispersion = uniform.material_dispersion;
+                #endif
+            #endif
+
+            // iridescence
+            #ifdef LIT_IRIDESCENCE
+                getIridescence();
+                getIridescenceThickness();
+                litArgs_iridescence_intensity = dIridescence;
+                litArgs_iridescence_thickness = dIridescenceThickness;
+            #endif
+
+            // specularity & glossiness
+            #ifdef LIT_SPECULAR_OR_REFLECTION
+
+                // sheen
+                #ifdef LIT_SHEEN
+                    getSheen();
+                    litArgs_sheen_specularity = sSpecularity;
+                    getSheenGlossiness();
+                    litArgs_sheen_gloss = sGlossiness;
+                #endif
+
+                // metalness
+                #ifdef LIT_METALNESS
+                    getMetalness();
+                    litArgs_metalness = dMetalness;
+                    getIor();
+                    litArgs_ior = dIor;
+                #endif
+
+                // specularity factor
+                #ifdef LIT_SPECULARITY_FACTOR
+                    getSpecularityFactor();
+                    litArgs_specularityFactor = dSpecularityFactor;
+                #endif
+
+                // gloss
+                getGlossiness();
+                getSpecularity();
+                litArgs_specularity = dSpecularity;
+                litArgs_gloss = dGlossiness;
+            #endif
+
+            // ao
+            #ifdef STD_AO
+                getAO();
+                litArgs_ao = dAo;
+            #endif
+
+            // emission
+            getEmission();
+            litArgs_emission = dEmission;
+
+            // clearcoat
+            #ifdef LIT_CLEARCOAT
+                getClearCoat();
+                getClearCoatGlossiness();
+                getClearCoatNormal();
+                litArgs_clearcoat_specularity = ccSpecularity;
+                litArgs_clearcoat_gloss = ccGlossiness;
+                litArgs_clearcoat_worldNormal = ccNormalW;
+            #endif
+
+            // lightmap
+            #if defined(STD_LIGHTMAP) || defined(STD_LIGHT_VERTEX_COLOR)
+                getLightMap();
+                litArgs_lightmap = dLightmap;
+
+                #ifdef STD_LIGHTMAP_DIR
+                    litArgs_lightmapDir = dLightmapDir;
+                #endif
+            #endif
+        #endif
+    }
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/thickness.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/thickness.js
@@ -1,0 +1,21 @@
+export default /* wgsl */`
+#ifdef STD_THICKNESS_CONSTANT
+uniform material_thickness: f32;
+#endif
+
+fn getThickness() {
+    dThickness = 1.0;
+
+    #ifdef STD_THICKNESS_CONSTANT
+    dThickness = dThickness * uniform.material_thickness;
+    #endif
+
+    #ifdef STD_THICKNESS_TEXTURE
+    dThickness = dThickness * textureSampleBias({STD_THICKNESS_TEXTURE_NAME}, {STD_THICKNESS_TEXTURE_NAME}Sampler, {STD_THICKNESS_TEXTURE_UV}, uniform.textureBias).{STD_THICKNESS_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_THICKNESS_VERTEX
+    dThickness = dThickness * saturate(vVertexColor.{STD_THICKNESS_VERTEX_CHANNEL});
+    #endif
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/standard/frag/transmission.js
+++ b/src/scene/shader-lib/chunks-wgsl/standard/frag/transmission.js
@@ -1,0 +1,24 @@
+export default /* wgsl */`
+
+#ifdef STD_REFRACTION_CONSTANT
+    uniform material_refraction: f32;
+#endif
+
+fn getRefraction() {
+    var refraction: f32 = 1.0;
+
+    #ifdef STD_REFRACTION_CONSTANT
+    refraction = uniform.material_refraction;
+    #endif
+
+    #ifdef STD_REFRACTION_TEXTURE
+    refraction = refraction * textureSampleBias({STD_REFRACTION_TEXTURE_NAME}, {STD_REFRACTION_TEXTURE_NAME}Sampler, {STD_REFRACTION_TEXTURE_UV}, uniform.textureBias).{STD_REFRACTION_TEXTURE_CHANNEL};
+    #endif
+
+    #ifdef STD_REFRACTION_VERTEX
+    refraction = refraction * saturate(vVertexColor.{STD_REFRACTION_VERTEX_CHANNEL});
+    #endif
+
+    dTransmission = refraction;
+}
+`;

--- a/src/scene/shader-lib/chunks/lit/frag/aoSpecOcc.js
+++ b/src/scene/shader-lib/chunks/lit/frag/aoSpecOcc.js
@@ -21,7 +21,7 @@ void occludeSpecular(float gloss, float ao, vec3 worldNormal, vec3 viewDir) {
         // approximated specular occlusion from AO
         // http://research.tri-ace.com/Data/cedec2011_RealtimePBR_Implementation_e.pptx
         float specPow = exp2(gloss * 11.0);
-        float specOcc = saturate(pow(dot(worldNormal, viewDir) + ao, 0.01*specPow) - 1.0 + ao);
+        float specOcc = saturate(pow(dot(worldNormal, viewDir) + ao, 0.01 * specPow) - 1.0 + ao);
 
         #ifdef LIT_OCCLUDE_SPECULAR_FLOAT
             specOcc = mix(1.0, specOcc, material_occludeSpecularIntensity);

--- a/src/scene/shader-lib/chunks/lit/frag/lighting/lightFunctionShadow.js
+++ b/src/scene/shader-lib/chunks/lit/frag/lighting/lightFunctionShadow.js
@@ -4,8 +4,6 @@ export default /* glsl */`
 // shadow casting functionality
 #ifdef LIGHT{i}CASTSHADOW
 
-    SHADOWS ARE NOT SUPPORTED YET
-/*
     // generate shadow coordinates function, based on per light defines:
     // - _SHADOW_SAMPLE_NORMAL_OFFSET
     // - _SHADOW_SAMPLE_ORTHO
@@ -192,6 +190,5 @@ export default /* glsl */`
 
         #endif
     }
-*/
 #endif
 `;

--- a/src/scene/shader-lib/chunks/standard/frag/detailModes.js
+++ b/src/scene/shader-lib/chunks/standard/frag/detailModes.js
@@ -18,7 +18,7 @@ vec3 detailMode_screen(vec3 c1, vec3 c2) {
 
 // https://en.wikipedia.org/wiki/Blend_modes#Overlay
 vec3 detailMode_overlay(vec3 c1, vec3 c2) {
-    return mix(1.0 - 2.0*(1.0 - c1)*(1.0 - c2), 2.0*c1*c2, step(c1, vec3(0.5)));
+    return mix(1.0 - 2.0 * (1.0 - c1)*(1.0 - c2), 2.0 * c1 * c2, step(c1, vec3(0.5)));
 }
 
 vec3 detailMode_min(vec3 c1, vec3 c2) {

--- a/src/scene/shader-lib/chunks/standard/frag/normalMap.js
+++ b/src/scene/shader-lib/chunks/standard/frag/normalMap.js
@@ -1,17 +1,17 @@
 export default /* glsl */`
 #ifdef STD_NORMAL_TEXTURE
-uniform float material_bumpiness;
+    uniform float material_bumpiness;
 #endif
 
 #ifdef STD_NORMALDETAIL_TEXTURE
-uniform float material_normalDetailMapBumpiness;
+    uniform float material_normalDetailMapBumpiness;
 
-vec3 blendNormals(vec3 n1, vec3 n2) {
-    // https://blog.selfshadow.com/publications/blending-in-detail/#detail-oriented
-    n1 += vec3(0, 0, 1);
-    n2 *= vec3(-1, -1, 1);
-    return n1 * dot(n1, n2) / n1.z - n2;
-}
+    vec3 blendNormals(vec3 n1, vec3 n2) {
+        // https://blog.selfshadow.com/publications/blending-in-detail/#detail-oriented
+        n1 += vec3(0, 0, 1);
+        n2 *= vec3(-1, -1, 1);
+        return n1 * dot(n1, n2) / n1.z - n2;
+    }
 #endif
 
 void getNormal() {

--- a/src/scene/shader-lib/chunks/standard/frag/parallax.js
+++ b/src/scene/shader-lib/chunks/standard/frag/parallax.js
@@ -5,7 +5,7 @@ void getParallax() {
     float parallaxScale = material_heightMapFactor;
 
     float height = texture2DBias({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_UV}, textureBias).{STD_HEIGHT_TEXTURE_CHANNEL};
-    height = height * parallaxScale - parallaxScale*0.5;
+    height = height * parallaxScale - parallaxScale * 0.5;
     vec3 viewDirT = dViewDirW * dTBN;
 
     viewDirT.z += 0.42;

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -508,6 +508,7 @@ class LitShader {
 
         if (options.pass === SHADER_PICK || options.pass === SHADER_DEPTH || options.pass === SHADER_PREPASS) {
 
+            Debug.assert(this.varyingsCode !== undefined && frontendCode !== undefined && frontendDecl !== undefined);
             this.fshader = `
 
                 ${this.varyingsCode}
@@ -518,6 +519,7 @@ class LitShader {
 
         } else if (this.shadowPass) { // SHADOW PASS
 
+            Debug.assert(this.varyingsCode !== undefined && frontendCode !== undefined && frontendDecl !== undefined);
             this.prepareShadowPass();
             this.fshader = `
                 ${this.varyingsCode}
@@ -528,6 +530,7 @@ class LitShader {
 
         } else if (options.customFragmentShader) {   // CUSTOM FRAGMENT SHADER
 
+            Debug.assert(options.customFragmentShader);
             this.fshader = `
                 ${options.customFragmentShader}
             `;
@@ -535,6 +538,7 @@ class LitShader {
         } else { // FORWARD PASS
 
             this.prepareForwardPass(lightingUv);
+            Debug.assert(this.varyingsCode !== undefined && frontendCode !== undefined && frontendDecl !== undefined);
             this.fshader = `
                 ${this.varyingsCode}
                 ${frontendDecl}

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -11,7 +11,7 @@ import { StandardMaterialOptions } from '../../materials/standard-material-optio
 import { LitOptionsUtils } from './lit-options-utils.js';
 import { ShaderGenerator } from './shader-generator.js';
 import { ShaderUtils } from '../../../platform/graphics/shader-utils.js';
-import { SHADERLANGUAGE_GLSL, SHADERTAG_MATERIAL } from '../../../platform/graphics/constants.js';
+import { SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL, SHADERTAG_MATERIAL } from '../../../platform/graphics/constants.js';
 
 /**
  * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
@@ -162,6 +162,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         const detailModeOption = options[detailModePropName];
 
         const chunkCode = chunks[chunkName];
+        Debug.assert(chunkCode, `Shader chunk ${chunkName} not found.`);
 
         // log errors if the chunk format is deprecated (format changed in engine 2.7)
         Debug.call(() => {
@@ -312,7 +313,8 @@ class ShaderGeneratorStandard extends ShaderGenerator {
 
         const shaderPassInfo = ShaderPass.get(device).getByIndex(options.litOptions.pass);
         const isForwardPass = shaderPassInfo.isForward;
-        const litShader = new LitShader(device, options.litOptions, SHADERLANGUAGE_GLSL);
+        const shaderLanguage = (device.isWebGPU && options.useWGSL) ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL;
+        const litShader = new LitShader(device, options.litOptions, shaderLanguage);
 
         // generate vertex shader
         this.createVertexShader(litShader, options);
@@ -443,6 +445,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         const definition = ShaderUtils.createDefinition(device, {
             name: 'StandardShader',
             attributes: litShader.attributes,
+            shaderLanguage: shaderLanguage,
             vertexCode: litShader.vshader,
             fragmentCode: litShader.fshader,
             vertexIncludes: includes,


### PR DESCRIPTION
- When shadows and cookies are disabled, many of engine example materials can be build from WGSL.
- this PR implements the functionality, but the mechanic to enable it on StandardMaterial is excluded for now, so all this is disabled.


![Screenshot 2025-04-18 at 17 02 47](https://github.com/user-attachments/assets/439081b2-c348-4e01-b184-3fa0ee1768d4)
![Screenshot 2025-04-18 at 17 02 35](https://github.com/user-attachments/assets/0f13d593-d95f-4b23-a854-a4875201cd89)
![Screenshot 2025-04-18 at 17 02 29](https://github.com/user-attachments/assets/ac4e04ba-f134-43c1-862a-e604de324c4b)
![Screenshot 2025-04-18 at 17 00 52](https://github.com/user-attachments/assets/b3c057ce-ed46-47cc-ba73-56369c06c387)

