### PR TITLE
Morphing uses texture array to store morph targets

### DIFF
--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -1,5 +1,5 @@
 import { Debug } from '../core/debug.js';
-import { BLENDEQUATION_ADD, BLENDMODE_ONE, SEMANTIC_POSITION, SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL } from '../platform/graphics/constants.js';
+import { SEMANTIC_POSITION, SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL } from '../platform/graphics/constants.js';
 import { drawQuadWithShader } from './graphics/quad-render-utils.js';
 import { RenderTarget } from '../platform/graphics/render-target.js';
 import { DebugGraphics } from '../platform/graphics/debug-graphics.js';
@@ -13,8 +13,6 @@ import { shaderChunksWGSL } from './shader-lib/chunks-wgsl/chunks-wgsl.js';
  * @import { Shader } from '../platform/graphics/shader.js'
  */
 
-const blendStateAdditive = new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE);
-
 /**
  * An instance of {@link Morph}. Contains weights to assign to every {@link MorphTarget}, manages
  * selection of active morph targets.
@@ -22,9 +20,6 @@ const blendStateAdditive = new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_ONE
  * @category Graphics
  */
 class MorphInstance {
-    /** @private */
-    shaderCache = [];
-
     /**
      * Create a new MorphInstance instance.
      *
@@ -40,6 +35,10 @@ class MorphInstance {
         morph.incRefCount();
         this.device = morph.device;
 
+        // shader to blend a required number of morph targets
+        const maxNumTargets = morph._targets.length;
+        this.shader = this._createShader(maxNumTargets);
+
         // weights
         this._weights = [];
         this._weightMap = new Map();
@@ -51,19 +50,16 @@ class MorphInstance {
             this.setWeight(v, target.defaultWeight);
         }
 
-        // temporary array of targets with non-zero weight
-        this._activeTargets = [];
-
-        // max number of morph targets rendered at a time (each uses single texture slot)
-        this.maxSubmitCount = this.device.maxTextures;
-
         // array for max number of weights
-        this._shaderMorphWeights = new Float32Array(this.maxSubmitCount);
+        this._shaderMorphWeights = new Float32Array(maxNumTargets);
+
+        // array for target indices
+        this._shaderMorphIndex = new Uint32Array(maxNumTargets);
 
         // create render targets to morph targets into
         const createRT = (name, textureVar) => {
 
-            // render to appropriate, RGBA formats, we cannot render to RGB float / half float format in WEbGL
+            // render to appropriate, RGBA formats
             this[textureVar] = morph._createTexture(name, morph._renderTextureFormat);
             return new RenderTarget({
                 colorBuffer: this[textureVar],
@@ -79,7 +75,6 @@ class MorphInstance {
             this.rtNormals = createRT('MorphRTNrm', 'textureNormals');
         }
 
-        // texture params
         this._textureParams = new Float32Array([morph.morphTextureWidth, morph.morphTextureHeight]);
 
         // position aabb data - expand it 2x on each side to handle the expected worse range. Note
@@ -96,12 +91,11 @@ class MorphInstance {
         this.aabbSizeId = this.device.scope.resolve('aabbSize');
         this.aabbMinId = this.device.scope.resolve('aabbMin');
 
-        // resolve possible texture names
-        for (let i = 0; i < this.maxSubmitCount; i++) {
-            this[`morphBlendTex${i}`] = this.device.scope.resolve(`morphBlendTex${i}`);
-        }
-
+        // resolve shader inputs
+        this.morphTextureId = this.device.scope.resolve('morphTexture');
         this.morphFactor = this.device.scope.resolve('morphFactor[0]');
+        this.morphIndex = this.device.scope.resolve('morphIndex[0]');
+        this.countId = this.device.scope.resolve('count');
 
         // true indicates render target textures are full of zeros to avoid rendering to them when all weights are zero
         this.zeroTextures = false;
@@ -128,25 +122,17 @@ class MorphInstance {
             }
         }
 
-        if (this.rtPositions) {
-            this.rtPositions.destroy();
-            this.rtPositions = null;
-        }
+        this.rtPositions?.destroy();
+        this.rtPositions = null;
 
-        if (this.texturePositions) {
-            this.texturePositions.destroy();
-            this.texturePositions = null;
-        }
+        this.texturePositions?.destroy();
+        this.texturePositions = null;
 
-        if (this.rtNormals) {
-            this.rtNormals.destroy();
-            this.rtNormals = null;
-        }
+        this.rtNormals?.destroy();
+        this.rtNormals = null;
 
-        if (this.textureNormals) {
-            this.textureNormals.destroy();
-            this.textureNormals = null;
-        }
+        this.textureNormals?.destroy();
+        this.textureNormals = null;
     }
 
     /**
@@ -163,7 +149,7 @@ class MorphInstance {
         if (typeof key === 'string') {
             const index = this._weightMap.get(key);
             if (index === undefined) {
-                Debug.error(`Cannot find morph target with name: ${key}.`);
+                Debug.errorOnce(`Cannot find morph target with name: ${key}.`);
             }
             return index;
         }
@@ -197,118 +183,68 @@ class MorphInstance {
     }
 
     /**
-     * Create complete shader for texture based morphing.
+     * Create the shader for texture based morphing.
      *
-     * @param {number} count - Number of textures to blend.
+     * @param {number} maxCount - Maximum bumber of textures to blend.
      * @returns {Shader} Shader.
      * @private
      */
-    _getShader(count) {
+    _createShader(maxCount) {
 
-        let shader = this.shaderCache[count];
+        const wgsl = this.device.isWebGPU;
+        const chunks = wgsl ? shaderChunksWGSL : shaderChunks;
 
-        // if shader is not in cache, generate one
-        if (!shader) {
+        const defines = new Map();
+        defines.set('{MORPH_TEXTURE_MAX_COUNT}', maxCount);
+        if (this.morph.intRenderFormat) defines.set('MORPH_INT', '');
 
-            const wgsl = this.device.isWebGPU;
-            const chunks = wgsl ? shaderChunksWGSL : shaderChunks;
-
-            const defines = new Map();
-            defines.set('MORPH_TEXTURE_COUNT', count);
-            defines.set('{MORPH_TEXTURE_COUNT}', count);
-            if (this.morph.intRenderFormat) defines.set('MORPH_INT', '');
-
-            const includes = new Map();
-            includes.set('morphDeclarationPS', chunks.morphDeclarationPS);
-            includes.set('morphEvaluationPS', chunks.morphEvaluationPS);
-
-            const outputType = this.morph.intRenderFormat ? 'uvec4' : 'vec4';
-            shader = createShaderFromCode(this.device, chunks.morphVS, chunks.morphPS, `textureMorph${count}`, {
-                vertex_position: SEMANTIC_POSITION
-            }, {
-                shaderLanguage: wgsl ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL,
-                fragmentIncludes: includes,
-                fragmentDefines: defines,
-                fragmentOutputTypes: [outputType]
-            });
-            this.shaderCache[count] = shader;
-        }
-
-        return shader;
+        const outputType = this.morph.intRenderFormat ? 'uvec4' : 'vec4';
+        return createShaderFromCode(this.device, chunks.morphVS, chunks.morphPS, 'TextureMorphShader', {
+            vertex_position: SEMANTIC_POSITION
+        }, {
+            shaderLanguage: wgsl ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL,
+            fragmentDefines: defines,
+            fragmentOutputTypes: [outputType]
+        });
     }
 
-    _updateTextureRenderTarget(renderTarget, srcTextureName, isPos) {
+    _updateTextureRenderTarget(renderTarget, activeCount, isPos) {
 
-        const device = this.device;
-
-        // blend currently set up textures to render target
-        const submitBatch = (usedCount, blending) => {
-
-            // factors
-            this.morphFactor.setValue(this._shaderMorphWeights);
-
-            // alpha blending - first pass gets none, following passes are additive
-            device.setBlendState(blending ? blendStateAdditive : BlendState.NOBLEND);
-
-            // render quad with shader for required number of textures
-            const shader = this._getShader(usedCount);
-            drawQuadWithShader(device, renderTarget, shader);
-        };
-
+        const { morph, device } = this;
         this.setAabbUniforms(isPos);
+        this.morphTextureId.setValue(isPos ? morph.targetsTexturePositions : morph.targetsTextureNormals);
+
+        device.setBlendState(BlendState.NOBLEND);
 
         // set up parameters for active blend targets
-        let usedCount = 0;
-        let blending = false;
-        const count = this._activeTargets.length;
-        for (let i = 0; i < count; i++) {
-            const activeTarget = this._activeTargets[i];
-            const tex = activeTarget.target[srcTextureName];
-            if (tex) {
+        this.countId.setValue(activeCount);
+        this.morphFactor.setValue(this._shaderMorphWeights);
+        this.morphIndex.setValue(this._shaderMorphIndex);
 
-                // texture
-                this[`morphBlendTex${usedCount}`].setValue(tex);
-
-                // weight
-                this._shaderMorphWeights[usedCount] = activeTarget.weight;
-
-                // submit if batch is full
-                usedCount++;
-                if (usedCount >= this.maxSubmitCount) {
-
-                    submitBatch(usedCount, blending);
-                    usedCount = 0;
-                    blending = true;
-                }
-            }
-        }
-
-        // leftover batch, or just to clear texture
-        if (usedCount > 0 || (count === 0 && !this.zeroTextures)) {
-            submitBatch(usedCount, blending);
-        }
+        // render quad with shader
+        drawQuadWithShader(device, renderTarget, this.shader);
     }
 
-    _updateTextureMorph() {
+    _updateTextureMorph(activeCount) {
 
         const device = this.device;
 
         DebugGraphics.pushGpuMarker(device, 'MorphUpdate');
 
         // update textures if active targets, or no active targets and textures need to be cleared
-        if (this._activeTargets.length > 0 || !this.zeroTextures) {
+        if (activeCount > 0 || !this.zeroTextures) {
 
             // blend morph targets into render targets
             if (this.rtPositions) {
-                this._updateTextureRenderTarget(this.rtPositions, 'texturePositions', true);
+                this._updateTextureRenderTarget(this.rtPositions, activeCount, true);
             }
 
             if (this.rtNormals) {
-                this._updateTextureRenderTarget(this.rtNormals, 'textureNormals', false);
+                this._updateTextureRenderTarget(this.rtNormals, activeCount, false);
             }
 
             // textures were cleared if no active targets
-            this.zeroTextures = this._activeTargets.length === 0;
+            this.zeroTextures = activeCount === 0;
         }
 
         DebugGraphics.popGpuMarker(device);
@@ -333,42 +269,22 @@ class MorphInstance {
         this._dirty = false;
         const targets = this.morph._targets;
 
-        // collect active targets, reuse objects in _activeTargets array to avoid allocations
-        let activeCount = 0;
+        // collect weights for active targets
         const epsilon = 0.00001;
+        const weights = this._shaderMorphWeights;
+        const indices = this._shaderMorphIndex;
+
+        let activeCount = 0;
         for (let i = 0; i < targets.length; i++) {
-            const absWeight = Math.abs(this.getWeight(i));
-            if (absWeight > epsilon) {
-
-                // create new object if needed
-                if (this._activeTargets.length <= activeCount) {
-                    this._activeTargets[activeCount] = {};
-                }
-
-                const activeTarget = this._activeTargets[activeCount++];
-                activeTarget.absWeight = absWeight;
-                activeTarget.weight = this.getWeight(i);
-                activeTarget.target = targets[i];
-            }
-        }
-        this._activeTargets.length = activeCount;
-
-        // with int texture, we do not have blending and so only support a single submit
-        if (this.morph.intRenderFormat) {
-            if (this._activeTargets.length > this.maxSubmitCount) {
-
-                // sort them by absWeight
-                this._activeTargets.sort((l, r) => {
-                    return (l.absWeight < r.absWeight) ? 1 : (r.absWeight < l.absWeight ? -1 : 0);
-                });
-
-                // remove excess
-                this._activeTargets.length = this.maxSubmitCount;
+            if (Math.abs(this.getWeight(i)) > epsilon) {
+                weights[activeCount] = this.getWeight(i);
+                indices[activeCount] = i;
+                activeCount++;
             }
         }
 
         // prepare for rendering
-        this._updateTextureMorph();
+        this._updateTextureMorph(activeCount);
     }
 }
 

--- a/src/scene/morph-target.js
+++ b/src/scene/morph-target.js
@@ -42,14 +42,10 @@ class MorphTarget {
 
         // store delta positions, used by aabb evaluation
         this.deltaPositions = options.deltaPositions;
-    }
 
-    destroy() {
-        this.texturePositions?.destroy();
-        this.texturePositions = null;
-
-        this.textureNormals?.destroy();
-        this.textureNormals = null;
+        // true if the streams are available
+        this.morphPositions = !!options.deltaPositions;
+        this.morphNormals = !!options.deltaNormals;
     }
 
     /**
@@ -83,14 +79,6 @@ class MorphTarget {
         return this._aabb;
     }
 
-    get morphPositions() {
-        return !!this.texturePositions;
-    }
-
-    get morphNormals() {
-        return !!this.textureNormals;
-    }
-
     /**
      * Returns an identical copy of the specified morph target. This can only be used if the morph target
      * was created with options.preserveData set to true.
@@ -111,10 +99,6 @@ class MorphTarget {
 
         // mark it as used
         this.used = true;
-    }
-
-    _setTexture(name, texture) {
-        this[name] = texture;
     }
 }
 

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -72,6 +72,20 @@ class Morph extends RefCountedObject {
         this._updateMorphFlags();
     }
 
+    /**
+     * Frees video memory allocated by this object.
+     */
+    destroy() {
+        this.vertexBufferIds?.destroy();
+        this.vertexBufferIds = null;
+
+        this.targetsTexturePositions?.destroy();
+        this.targetsTexturePositions = null;
+
+        this.targetsTextureNormals?.destroy();
+        this.targetsTextureNormals = null;
+    }
+
     get aabb() {
 
         // lazy evaluation, which allows us to skip this completely if customAABB is used
@@ -149,15 +163,16 @@ class Morph extends RefCountedObject {
 
         // collect all source delta arrays to find sparse set of vertices
         const deltaArrays = [], deltaInfos = [];
-        for (let i = 0; i < this._targets.length; i++) {
-            const target = this._targets[i];
+        const targets = this._targets;
+        for (let i = 0; i < targets.length; i++) {
+            const target = targets[i];
             if (target.options.deltaPositions) {
                 deltaArrays.push(target.options.deltaPositions);
-                deltaInfos.push({ target: target, name: 'texturePositions' });
+                deltaInfos.push(true);  // position
             }
             if (target.options.deltaNormals) {
                 deltaArrays.push(target.options.deltaNormals);
-                deltaInfos.push({ target: target, name: 'textureNormals' });
+                deltaInfos.push(false); // normal
             }
         }
 
@@ -173,7 +188,8 @@ class Morph extends RefCountedObject {
 
         // if data cannot fit into max size texture, fail this set up
         if (morphTextureHeight > maxTextureSize) {
-            return false;
+            Debug.warnOnce(`Morph target data is too large to fit into a texture array. Required texture size: ${morphTextureWidth}x${morphTextureHeight}, max texture size: ${maxTextureSize}x${maxTextureSize}.`);
+            return;
         }
 
         this.morphTextureWidth = morphTextureWidth;
@@ -186,17 +202,14 @@ class Morph extends RefCountedObject {
             halfFloat = true;
         }
 
-        // create textures
-        const textures = [];
-        for (let i = 0; i < deltaArrays.length; i++) {
-            textures.push(this._createTexture('MorphTarget', this._textureFormat));
-        }
-
-        // build texture for each delta array, all textures are the same size
+        // build texture data for each delta array, to be used as a texture array
+        const texturesDataPositions = [];
+        const texturesDataNormals = [];
+        const textureDataSize = morphTextureWidth * morphTextureHeight * 4;
         for (let i = 0; i < deltaArrays.length; i++) {
             const data = deltaArrays[i];
-            const texture = textures[i];
-            const textureData = texture.lock();
+            const textureData = this._textureFormat === PIXELFORMAT_RGBA16F ? new Uint16Array(textureDataSize) : new Float32Array(textureDataSize);
+            (deltaInfos[i] ? texturesDataPositions : texturesDataNormals).push(textureData);
 
             // copy full arrays into sparse arrays and convert format (skip 0th pixel - used by non-morphed vertices)
             if (halfFloat) {
@@ -219,11 +232,17 @@ class Morph extends RefCountedObject {
                     textureData[dstIndex + 2] = data[index + 2];
                 }
             }
+        }
 
-            // assign texture to target
-            texture.unlock();
-            const target = deltaInfos[i].target;
-            target._setTexture(deltaInfos[i].name, texture);
+        // allocate texture arrays to store data from all morph targets
+        if (texturesDataPositions.length > 0) {
+            this.targetsTexturePositions = this._createTexture('MorphPositionsTexture', this._textureFormat, targets.length, [texturesDataPositions]);
+            this.targetsTexturePositions.upload();
+        }
+
+        if (texturesDataNormals.length > 0) {
+            this.targetsTextureNormals = this._createTexture('MorphNormalsTexture', this._textureFormat, targets.length, [texturesDataNormals]);
+            this.targetsTextureNormals.upload();
         }
 
         // create vertex stream with vertex_id used to map vertex to texture
@@ -233,19 +252,6 @@ class Morph extends RefCountedObject {
         });
 
         return true;
-    }
-
-    /**
-     * Frees video memory allocated by this object.
-     */
-    destroy() {
-        this.vertexBufferIds?.destroy();
-        this.vertexBufferIds = null;
-
-        for (let i = 0; i < this._targets.length; i++) {
-            this._targets[i].destroy();
-        }
-        this._targets.length = 0;
     }
 
     /**
@@ -274,16 +280,20 @@ class Morph extends RefCountedObject {
     }
 
     /**
-     * Creates texture. Used to create both source morph target data, as well as render target used
-     * to morph these into, positions and normals.
+     * Creates a texture / texture array. Used to create both source morph target data, as well as
+     * render target used to morph these into, positions and normals.
      *
      * @param {string} name - The name of the texture.
      * @param {number} format - The format of the texture.
+     * @param {Array} [levels] - The levels of the texture.
+     * @param {number} [arrayLength] - The length of the texture array.
      * @returns {Texture} The created texture.
      * @private
      */
-    _createTexture(name, format) {
+    _createTexture(name, format, arrayLength, levels) {
         return new Texture(this.device, {
+            levels: levels,
+            arrayLength: arrayLength,
             width: this.morphTextureWidth,
             height: this.morphTextureHeight,
             format: format,

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -88,8 +88,6 @@ import litShaderCorePS from './standard/frag/litShaderCore.js';
 import metalnessPS from './standard/frag/metalness.js';
 // import msdfPS from './common/frag/msdf.js';
 import metalnessModulatePS from './lit/frag/metalnessModulate.js';
-import morphEvaluationPS from './internal/morph/frag/morphEvaluation.js';
-import morphDeclarationPS from './internal/morph/frag/morphDeclaration.js';
 import morphPS from './internal/morph/frag/morph.js';
 import morphVS from './internal/morph/vert/morph.js';
 // import msdfVS from './common/vert/msdf.js';
@@ -303,8 +301,6 @@ const shaderChunksWGSL = {
     // ltcPS,
     metalnessPS,
     metalnessModulatePS,
-    morphEvaluationPS,
-    morphDeclarationPS,
     morphPS,
     morphVS,
     // msdfPS,

--- a/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morph.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morph.js
@@ -4,22 +4,22 @@ export default /* wgsl */`
 
     varying uv0: vec2f;
 
-    // LOOP - source morph target textures
-    #include "morphDeclarationPS, MORPH_TEXTURE_COUNT"
-
-    #if MORPH_TEXTURE_COUNT > 0
-        uniform morphFactor: array<f32, {MORPH_TEXTURE_COUNT}>;
-    #endif
+    var morphTexture: texture_2d_array<f32>;
+    var morphTextureSampler : sampler;
+    uniform morphFactor: array<f32, {MORPH_TEXTURE_MAX_COUNT}>;
+    uniform morphIndex: array<u32, {MORPH_TEXTURE_MAX_COUNT}>;
+    uniform count: u32;
 
     @fragment
     fn fragmentMain(input : FragmentInput) -> FragmentOutput {
-        var output: FragmentOutput;
-
         var color = vec3f(0, 0, 0);
+        for (var i: u32 = 0; i < uniform.count; i = i + 1) {
+            var textureIndex: u32 = uniform.morphIndex[i].element;
+            var delta = textureSample(morphTexture, morphTextureSampler, input.uv0, textureIndex).xyz;
+            color += uniform.morphFactor[i].element * delta;
+        }
 
-        // LOOP - source morph target textures
-        #include "morphEvaluationPS, MORPH_TEXTURE_COUNT"
-
+        var output: FragmentOutput;
         output.color = vec4f(color, 1.0);
         return output;
     }

--- a/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphDeclaration.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphDeclaration.js
@@ -1,4 +1,0 @@
-export default /* wgsl */`
-    var morphBlendTex{i}: texture_2d<f32>;
-    var morphBlendTex{i}Sampler : sampler;
-`;

--- a/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphEvaluation.js
+++ b/src/scene/shader-lib/chunks-wgsl/internal/morph/frag/morphEvaluation.js
@@ -1,3 +1,0 @@
-export default /* wgsl */`
-    color += uniform.morphFactor[{i}].element * textureSampleLevel(morphBlendTex{i}, morphBlendTex{i}Sampler, input.uv0, 0).xyz;
-`;

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -91,8 +91,6 @@ import ltcPS from './lit/frag/ltc.js';
 import metalnessPS from './standard/frag/metalness.js';
 import msdfPS from './common/frag/msdf.js';
 import metalnessModulatePS from './lit/frag/metalnessModulate.js';
-import morphEvaluationPS from './internal/morph/frag/morphEvaluation.js';
-import morphDeclarationPS from './internal/morph/frag/morphDeclaration.js';
 import morphPS from './internal/morph/frag/morph.js';
 import morphVS from './internal/morph/vert/morph.js';
 import msdfVS from './common/vert/msdf.js';
@@ -308,8 +306,6 @@ const shaderChunks = {
     ltcPS,
     metalnessPS,
     metalnessModulatePS,
-    morphEvaluationPS,
-    morphDeclarationPS,
     morphPS,
     morphVS,
     msdfPS,

--- a/src/scene/shader-lib/chunks/internal/morph/frag/morphDeclaration.js
+++ b/src/scene/shader-lib/chunks/internal/morph/frag/morphDeclaration.js
@@ -1,3 +1,0 @@
-export default /* glsl */`
-    uniform highp sampler2D morphBlendTex{i};
-`;

--- a/src/scene/shader-lib/chunks/internal/morph/frag/morphEvaluation.js
+++ b/src/scene/shader-lib/chunks/internal/morph/frag/morphEvaluation.js
@@ -1,3 +1,0 @@
-export default /* glsl */`
-    color.xyz += morphFactor[{i}] * texture2DLod(morphBlendTex{i}, uv0, 0.0).xyz;
-`;


### PR DESCRIPTION
- fixes https://github.com/playcanvas/engine/issues/7555
- additionally fixes the handling of texture arrays in WGSL