### PR TITLE
Gsplat rotation fix

### DIFF
--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatData.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatData.js
@@ -32,7 +32,7 @@ mat3 quatToMat3(vec4 R) {
 }
 
 vec4 unpackRotation(vec3 packed) {
-    return vec4(packed.xyz, sqrt(1.0 - dot(packed, packed)));
+    return vec4(packed.xyz, sqrt(max(0.0, 1.0 - dot(packed, packed))));
 }
 
 // sample covariance vectors


### PR DESCRIPTION
Fixes https://github.com/playcanvas/supersplat/issues/485

We recently moved covariance vector calculation from cpu to gpu (in #7380) in order to gain precision during render.

This change included a subtle rotation bug which is fixed in this PR.