### PR TITLE
Adds Script scriptName field

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -716,7 +716,7 @@ class ScriptComponent extends Component {
             const inferredScriptName = getScriptName(scriptType);
             const lowerInferredScriptName = toLowerCamelCase(inferredScriptName);
 
-            if (!scriptType.scriptName) {
+            if (!(scriptType.prototype instanceof ScriptType) && !scriptType.scriptName) {
                 Debug.warnOnce(`The Script class "${inferredScriptName}" must have a static "scriptName" property: \`${inferredScriptName}.scriptName = "${lowerInferredScriptName}";\`. This will be an error in future versions of PlayCanvas.`);
             }
 

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -712,7 +712,16 @@ class ScriptComponent extends Component {
         if (typeof scriptType === 'string') {
             scriptType = this.system.app.scripts.get(scriptType);
         } else if (scriptType) {
-            scriptName = scriptType.__name ??= toLowerCamelCase(getScriptName(scriptType));
+
+            const inferredScriptName = getScriptName(scriptType);
+            const lowerInferredScriptName = toLowerCamelCase(inferredScriptName);
+
+            if (!scriptType.scriptName) {
+                Debug.warnOnce(`The Script class "${inferredScriptName}" must have a static "scriptName" property: \`${inferredScriptName}.scriptName = "${lowerInferredScriptName}";\`. This will be an error in future versions of PlayCanvas.`);
+            }
+
+            scriptType.__name ??= scriptType.scriptName ?? lowerInferredScriptName;
+            scriptName = scriptType.__name;
         }
 
         if (scriptType) {

--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -1,4 +1,5 @@
 import { platform } from '../../core/platform.js';
+import { Debug } from '../../core/debug.js';
 import { script } from '../script.js';
 import { ScriptTypes } from '../script/script-types.js';
 import { registerScript } from '../script/script-create.js';
@@ -137,7 +138,13 @@ class ScriptHandler extends ResourceHandler {
 
                 if (extendsScriptType) {
 
-                    const scriptName = toLowerCamelCase(scriptClass.name);
+                    const lowerCamelCaseName = toLowerCamelCase(scriptClass.name);
+
+                    if (!scriptClass.scriptName) {
+                        Debug.warnOnce(`The Script class "${scriptClass.name}" must have a static "scriptName" property: \`${scriptClass.name}.scriptName = "${lowerCamelCaseName}";\`. This will be an error in future versions of PlayCanvas.`);
+                    }
+
+                    const scriptName = scriptClass.scriptName ?? lowerCamelCaseName;
 
                     // Register the script name
                     registerScript(scriptClass, scriptName);

--- a/src/framework/script/script.js
+++ b/src/framework/script/script.js
@@ -347,6 +347,7 @@ const funcNameRegex = /^\s*function(?:\s|\s*\/\*.*\*\/\s*)+([^(\s\/]*)\s*/;
  */
 export function getScriptName(constructorFn) {
     if (typeof constructorFn !== 'function') return undefined;
+    if (constructorFn.scriptName) return constructorFn.scriptName;
     if ('name' in Function.prototype) return constructorFn.name;
     if (constructorFn === Function || constructorFn === Function.prototype.constructor) return 'Function';
     const match = (`${constructorFn}`).match(funcNameRegex);

--- a/test/framework/components/script/component.test.mjs
+++ b/test/framework/components/script/component.test.mjs
@@ -2946,8 +2946,8 @@ describe('ScriptComponent', function () {
         a.addComponent('script', { enabled: true });
         a.script.create(TestScript);
 
-        expect(a.script.testScript).to.not.exist;
-        expect(a.script.myTestScript).to.exist;
+        expect(a.script.has('testScript')).to.equal(false);
+        expect(a.script.has('myTestScript')).to.equal(true);
     });
 
     it('falls back to camelCase script name if scriptName is not defined', function () {
@@ -2956,8 +2956,27 @@ describe('ScriptComponent', function () {
         a.addComponent('script', { enabled: true });
         a.script.create(TestScript);
 
-        expect(a.script.testScript).to.exist;
-        expect(a.script.myTestScript).to.not.exist;
+        expect(a.script.has('testScript')).to.equal(true);
+        expect(a.script.has('myTestScript')).to.equal(false);
+    });
+
+    it('does not warn when a ScriptType is used', function () {
+        Debug._loggedMessages.clear();
+        createScript('nullScript');
+        const e = new Entity();
+        e.addComponent('script', {
+            enabled: true,
+            order: ['nullScript'],
+            scripts: {
+                nullScript: {
+                    enabled: true
+                }
+            }
+        });
+        app.root.addChild(e);
+
+        expect(Debug._loggedMessages.size).to.equal(0);
+        expect(e.script.has('nullScript')).to.equal(true);
     });
 
 });


### PR DESCRIPTION
Adds support for explicit naming of ESM Scripts using a static `scriptName` field.

```js
class Rotator extends Script {
  static scriptName = 'customRotator'
}

entity.script.create(Rotator)
console.log(entity.script.customRotator);
```

This addresses #7580 where class names can get mangled whilst adding support for [more verbose script names](https://forum.playcanvas.com/t/custom-script-names-when-using-the-new-script-class-with-esm/39693)
and [custom casing](https://discord.com/channels/408617316415307776/1363545549390876912/1363545553748758730), both of which have been requested by users.

It handles both cases of loading Scripts as Assets, and also direct insantiation via `entity.script.create(Class)`

Fixes #7580. Tests included

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
