### PR TITLE
Improve Texture JSDocs (and some others)

### DIFF
--- a/src/core/math/color.js
+++ b/src/core/math/color.js
@@ -3,9 +3,10 @@ import { math } from './math.js';
 /**
  * An RGBA color.
  *
- * Each color component is a floating point value in the range 0 to 1. The `r` (red), `g` (green)
- * and `b` (blue) components define a color in RGB color space. The `a` (alpha) component defines
- * transparency. An alpha of 1 is fully opaque. An alpha of 0 is fully transparent.
+ * Each color component is a floating point value in the range 0 to 1. The {@link r} (red),
+ * {@link g} (green) and {@link b} (blue) components define a color in RGB color space. The
+ * {@link a} (alpha) component defines transparency. An alpha of 1 is fully opaque. An alpha of
+ * 0 is fully transparent.
  *
  * @category Math
  */

--- a/src/framework/anim/binder/default-anim-binder.js
+++ b/src/framework/anim/binder/default-anim-binder.js
@@ -6,7 +6,6 @@ import { Entity } from '../../entity.js';
 /**
  * Implementation of {@link AnimBinder} for animating a skeleton in the graph-node hierarchy.
  *
- * @implements {AnimBinder}
  * @ignore
  */
 class DefaultAnimBinder {

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -630,9 +630,9 @@ class Texture {
     }
 
     /**
-     * Sets the integer value specifying the level of anisotropy to apply to the texture ranging
-     * from 1 (no anisotropic filtering) to the maximum anisotropy supported by the graphics device
-     * (see {@link GraphicsDevice#maxAnisotropy}).
+     * Sets the integer value specifying the level of anisotropy to apply to the texture. The value
+     * ranges from 1 (no anisotropic filtering) to the maximum anisotropy supported by the graphics
+     * device (see {@link GraphicsDevice#maxAnisotropy}).
      *
      * @type {number}
      */

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -28,8 +28,13 @@ import { TextureUtils } from './texture-utils.js';
 let id = 0;
 
 /**
- * A texture is a container for texel data that can be utilized in a fragment shader. Typically,
- * the texel data represents an image that is mapped over geometry.
+ * Represents a texture, which is typically an image composed of pixels (texels). Textures are
+ * fundamental resources for rendering graphical objects. They are commonly used by
+ * {@link Material}s and sampled in {@link Shader}s (usually fragment shaders) to define the visual
+ * appearance of a 3D model's surface. Beyond storing color images, textures can hold various data
+ * types like normal maps, environment maps (cubemaps), or custom data for shader computations. Key
+ * properties control how the texture data is sampled, including filtering modes and coordinate
+ * wrapping.
  *
  * Note on **HDR texture format** support:
  * 1. **As textures**:
@@ -597,7 +602,7 @@ class Texture {
     }
 
     /**
-     * Sets the comparison function when compareOnRead is enabled. Possible values:
+     * Sets the comparison function when {@link compareOnRead} is enabled. Possible values:
      *
      * - {@link FUNC_LESS}
      * - {@link FUNC_LESSEQUAL}
@@ -616,7 +621,7 @@ class Texture {
     }
 
     /**
-     * Sets the comparison function when compareOnRead is enabled.
+     * Gets the comparison function when {@link compareOnRead} is enabled.
      *
      * @type {number}
      */
@@ -626,7 +631,8 @@ class Texture {
 
     /**
      * Sets the integer value specifying the level of anisotropy to apply to the texture ranging
-     * from 1 (no anisotropic filtering) to the {@link GraphicsDevice} property maxAnisotropy.
+     * from 1 (no anisotropic filtering) to the maximum anisotropy supported by the graphics device
+     * (see {@link GraphicsDevice#maxAnisotropy}).
      *
      * @type {number}
      */
@@ -743,7 +749,7 @@ class Texture {
      * - {@link PIXELFORMAT_PVRTC_4BPP_RGB_1}
      * - {@link PIXELFORMAT_PVRTC_4BPP_RGBA_1}
      * - {@link PIXELFORMAT_111110F}
-     * - {@link PIXELFORMAT_ASTC_4x4}>/li>
+     * - {@link PIXELFORMAT_ASTC_4x4}
      * - {@link PIXELFORMAT_ATC_RGB}
      * - {@link PIXELFORMAT_ATC_RGBA}
      *
@@ -1127,10 +1133,10 @@ class Texture {
 
     /**
      * Forces a reupload of the textures pixel data to graphics memory. Ordinarily, this function
-     * is called by internally by {@link Texture#setSource} and {@link Texture#unlock}. However, it
-     * still needs to be called explicitly in the case where an HTMLVideoElement is set as the
-     * source of the texture.  Normally, this is done once every frame before video textured
-     * geometry is rendered.
+     * is called by internally by {@link setSource} and {@link unlock}. However, it still needs to
+     * be called explicitly in the case where an HTMLVideoElement is set as the source of the
+     * texture.  Normally, this is done once every frame before video textured geometry is
+     * rendered.
      */
     upload() {
         this._needsUpload = true;

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -62,8 +62,9 @@ let id = 0;
  */
 
 /**
- * A material determines how a particular mesh instance is rendered. It specifies the shader and
- * render state that is set before the mesh instance is submitted to the graphics device.
+ * A material determines how a particular {@link MeshInstance} is rendered. It specifies the
+ * {@link Shader} and render state that is set before the mesh instance is submitted to the
+ * {@link GraphicsDevice}.
  *
  * @category Graphics
  */

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -52,10 +52,10 @@ const _tempColor = new Color();
  */
 
 /**
- * A Standard material is the main, general purpose material that is most often used for rendering.
+ * A standard material is the main, general purpose material that is most often used for rendering.
  * It can approximate a wide variety of surface types and can simulate dynamic reflected light.
- * Most maps can use 3 types of input values in any combination: constant (color or number), mesh
- * vertex colors and a texture. All enabled inputs are multiplied together.
+ * Most maps can use 3 types of input values in any combination: constant ({@link Color} or number),
+ * mesh vertex colors and a {@link Texture}. All enabled inputs are multiplied together.
  *
  * @property {Color} ambient The ambient color of the material. This color value is 3-component
  * (RGB), where each component is between 0 and 1.


### PR DESCRIPTION
* Minor improvements to `Texture` JSDocs.
* Drop used of `@implements` tag in `DefaultAnimBinder`.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
