### PR TITLE
[BREAKING] Removing non-functional depth pass

### DIFF
--- a/src/extras/render-passes/render-pass-prepass.js
+++ b/src/extras/render-passes/render-pass-prepass.js
@@ -100,7 +100,7 @@ class RenderPassPrepass extends RenderPass {
     }
 
     after() {
-        // Assign the lienar depth texture to the uniform
+        // Assign the linear depth texture to the uniform
         this.device.scope.resolve(DEPTH_UNIFORM_NAME).setValue(this.linearDepthTexture);
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,6 @@ export { BatchGroup } from './scene/batching/batch-group.js';
 export { SkinBatchInstance } from './scene/batching/skin-batch-instance.js';
 export { BatchManager } from './scene/batching/batch-manager.js';
 export { Camera } from './scene/camera.js';
-export { CameraShaderParams } from './scene/camera-shader-params.js'; // needed by the Editor
 export { WorldClusters } from './scene/lighting/world-clusters.js';
 export { ForwardRenderer } from './scene/renderer/forward-renderer.js';
 export { GraphNode } from './scene/graph-node.js';

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -771,13 +771,6 @@ export const SHADER_FORWARD = 0;
 
 export const SHADER_PREPASS = 1;
 
-/**
- * Render RGBA-encoded depth value.
- *
- * @category Graphics
- */
-export const SHADER_DEPTH = 2;
-
 // shader pass used by the Picker class to render mesh ID
 export const SHADER_PICK = 3;
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -8,7 +8,7 @@ import {
     DETAILMODE_MUL,
     DITHER_NONE,
     FRESNEL_SCHLICK,
-    SHADER_DEPTH, SHADER_PICK,
+    SHADER_PICK,
     SHADER_PREPASS,
     SPECOCC_AO,
     tonemapNames
@@ -836,7 +836,7 @@ class StandardMaterial extends Material {
 
         // Minimal options for Depth, Shadow and Prepass passes
         const shaderPassInfo = ShaderPass.get(device).getByIndex(pass);
-        const minimalOptions = pass === SHADER_DEPTH || pass === SHADER_PICK || pass === SHADER_PREPASS || shaderPassInfo.isShadow;
+        const minimalOptions = pass === SHADER_PICK || pass === SHADER_PREPASS || shaderPassInfo.isShadow;
         let options = minimalOptions ? standard.optionsContextMin : standard.optionsContext;
         options.defines = getCoreDefines(this, params);
 

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-other/litOtherMain.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-other/litOtherMain.js
@@ -19,10 +19,6 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         output.color = getPickOutput();
     #endif
 
-    #ifdef DEPTH_PASS
-        output.color = vec4(1.0, 1.0, 1.0, 1.0);
-    #endif
-
     #ifdef PREPASS_PASS
         output.color = float2vec4(vLinearDepth);
     #endif

--- a/src/scene/shader-lib/chunks/lit/frag/pass-other/litOtherMain.js
+++ b/src/scene/shader-lib/chunks/lit/frag/pass-other/litOtherMain.js
@@ -16,10 +16,6 @@ void main(void) {
         gl_FragColor = getPickOutput();
     #endif
 
-    #ifdef DEPTH_PASS
-        gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
-    #endif
-
     #ifdef PREPASS_PASS
         gl_FragColor = float2vec4(vLinearDepth);
     #endif

--- a/src/scene/shader-lib/program-library.js
+++ b/src/scene/shader-lib/program-library.js
@@ -2,7 +2,7 @@ import { Debug } from '../../core/debug.js';
 import { hashCode } from '../../core/hash.js';
 import { version, revision } from '../../core/core.js';
 import { Shader } from '../../platform/graphics/shader.js';
-import { SHADER_FORWARD, SHADER_DEPTH, SHADER_PICK, SHADER_SHADOW, SHADER_PREPASS } from '../constants.js';
+import { SHADER_FORWARD, SHADER_PICK, SHADER_SHADOW, SHADER_PREPASS } from '../constants.js';
 import { ShaderPass } from '../shader-pass.js';
 import { StandardMaterialOptions } from '../materials/standard-material-options.js';
 import { CameraShaderParams } from '../camera-shader-params.js';
@@ -282,7 +282,7 @@ class ProgramLibrary {
 
     _getDefaultStdMatOptions(pass) {
         const shaderPassInfo = ShaderPass.get(this._device).getByIndex(pass);
-        return (pass === SHADER_DEPTH || pass === SHADER_PICK || pass === SHADER_PREPASS || shaderPassInfo.isShadow) ?
+        return (pass === SHADER_PICK || pass === SHADER_PREPASS || shaderPassInfo.isShadow) ?
             this._defaultStdMatOptionMin : this._defaultStdMatOption;
     }
 

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -8,7 +8,7 @@ import {
 import {
     LIGHTSHAPE_PUNCTUAL,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI, LIGHTTYPE_SPOT,
-    SHADER_DEPTH, SHADER_PICK,
+    SHADER_PICK,
     SPRITE_RENDERMODE_SLICED, SPRITE_RENDERMODE_TILED, shadowTypeInfo, SHADER_PREPASS,
     lightTypeNames, lightShapeNames, spriteRenderModeNames, fresnelNames, blendNames, lightFalloffNames,
     cubemaProjectionNames, specularOcclusionNames, reflectionSrcNames, ambientSrcNames,
@@ -506,7 +506,7 @@ class LitShader {
     generateFragmentShader(frontendDecl, frontendCode, lightingUv) {
         const options = this.options;
 
-        if (options.pass === SHADER_PICK || options.pass === SHADER_DEPTH || options.pass === SHADER_PREPASS) {
+        if (options.pass === SHADER_PICK || options.pass === SHADER_PREPASS) {
 
             Debug.assert(this.varyingsCode !== undefined && frontendCode !== undefined && frontendDecl !== undefined);
             this.fshader = `

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -1,7 +1,7 @@
 import { Debug } from '../core/debug.js';
 import { DeviceCache } from '../platform/graphics/device-cache.js';
 import {
-    SHADER_FORWARD, SHADER_DEPTH, SHADER_PICK, SHADER_SHADOW, SHADER_PREPASS
+    SHADER_FORWARD, SHADER_PICK, SHADER_SHADOW, SHADER_PREPASS
 } from './constants.js';
 
 /**
@@ -58,8 +58,6 @@ class ShaderPassInfo {
             keyword = 'SHADOW';
         } else if (this.isForward) {
             keyword = 'FORWARD';
-        } else if (this.index === SHADER_DEPTH) {
-            keyword = 'DEPTH';
         } else if (this.index === SHADER_PICK) {
             keyword = 'PICK';
         }
@@ -102,7 +100,6 @@ class ShaderPass {
         // add default passes in the required order, to match the constants
         add('forward', SHADER_FORWARD, { isForward: true });
         add('prepass', SHADER_PREPASS);
-        add('depth', SHADER_DEPTH);
         add('pick', SHADER_PICK);
         add('shadow', SHADER_SHADOW);
     }


### PR DESCRIPTION
- marking this as breaking, but as this was non-functional for a very long time (even in engine v1), this change likely won't affect anybody.
- Editor was using this, but this non-functional behaviour was replaced by using RenderPassPrepass, and this can be safely removed from the engine