### PR TITLE
[Fix] Fix shader passes order

### DIFF
--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -771,11 +771,11 @@ export const SHADER_FORWARD = 0;
 
 export const SHADER_PREPASS = 1;
 
+// shadow pass used by the shadow rendering code
+export const SHADER_SHADOW = 2;
+
 // shader pass used by the Picker class to render mesh ID
 export const SHADER_PICK = 3;
-
-// shadow pass used by the shadow rendering code
-export const SHADER_SHADOW = 4;
 
 /**
  * Shader that performs forward rendering.

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -100,8 +100,8 @@ class ShaderPass {
         // add default passes in the required order, to match the constants
         add('forward', SHADER_FORWARD, { isForward: true });
         add('prepass', SHADER_PREPASS);
-        add('pick', SHADER_PICK);
         add('shadow', SHADER_SHADOW);
+        add('pick', SHADER_PICK);
     }
 
     /**


### PR DESCRIPTION
A follow up to https://github.com/playcanvas/engine/pull/7597 to make sure shader passes are in a continuos order, which is a requirement I missed.