### PR TITLE
Fix bloom artifacts appearing due to bad specular data

### DIFF
--- a/src/scene/shader-lib/chunks/lit/frag/fresnelSchlick.js
+++ b/src/scene/shader-lib/chunks/lit/frag/fresnelSchlick.js
@@ -9,7 +9,8 @@ vec3 getFresnel(
         float iridescenceIntensity
 #endif
     ) {
-    float fresnel = pow(1.0 - max(cosTheta, 0.0), 5.0);
+    float safeCosTheta = clamp(cosTheta, 0.0, 1.0);
+    float fresnel = pow(1.0 - safeCosTheta, 5.0);
     float glossSq = gloss * gloss;
     vec3 ret = specularity + (max(vec3(glossSq), specularity) - specularity) * fresnel;
 #if defined(LIT_IRIDESCENCE)
@@ -20,7 +21,8 @@ vec3 getFresnel(
 }
 
 float getFresnelCC(float cosTheta) {
-    float fresnel = pow(1.0 - max(cosTheta, 0.0), 5.0);
+    float safeCosTheta = clamp(cosTheta, 0.0, 1.0);
+    float fresnel = pow(1.0 - safeCosTheta, 5.0);
     return 0.04 + (1.0 - 0.04) * fresnel;
 }
 `;


### PR DESCRIPTION
## Description

Fixes black square artifacts appearing on screen when the Bloom or Dof effects were used with the CameraFrame script. This bug was only reproduced on Ubuntu with an nvidia GPU.

![image](https://github.com/user-attachments/assets/954dc1fd-09b9-4b24-b69e-1662c073996f)

### Solution

This patch adds a clamp to the fresnelSchlick.js functions, `getFresnel()` and `getFresnelCC()`, to avoid bad specular values.

### Explanation

I still don't think I'm 100% sure why it was happening, but from what I can tell:

1. When the angle of light and the camera were exactly parallel it would cause this dot product calculation to be -1.
https://github.com/playcanvas/engine/blob/49ffb62ad79069fa77f987ea257cdcfcc970a585/src/scene/shader-lib/chunks/lit/frag/pass-forward/litForwardBackend.js#L106-L114
2. With the current implementation, a `cosTheta` of `-1` should not break anything. `max()` would set it to `0.0` and the function should work okay.
https://github.com/playcanvas/engine/blob/49ffb62ad79069fa77f987ea257cdcfcc970a585/src/scene/shader-lib/chunks/lit/frag/fresnelSchlick.js#L1-L21
3. But, for whatever reason on certain devices it was causing `getFresnel()` to return a bad specular value.
4. This seems limited to only a pixel or two, but bloom upscaling makes these artifacts a lot more noticeable.

### Before vs After

(Note that the flashing is more visible in-person, the low-FPS recording hides it somewhat)

https://github.com/user-attachments/assets/9b0767c8-105c-41ce-949a-3b7d69a59976

### Testing

Project for testing: https://playcanvas.com/editor/scene/2210459

Fixes #7492

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
