### PR TITLE
[FIX] Restore callback descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playcanvas",
-  "version": "2.8.0-dev",
+  "version": "2.7.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playcanvas",
-      "version": "2.8.0-dev",
+      "version": "2.7.0-dev",
       "license": "MIT",
       "dependencies": {
         "@types/webxr": "^0.5.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playcanvas",
-  "version": "2.7.0-dev",
+  "version": "2.8.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playcanvas",
-      "version": "2.7.0-dev",
+      "version": "2.8.0-dev",
       "license": "MIT",
       "dependencies": {
         "@types/webxr": "^0.5.16",

--- a/src/core/event-handler.js
+++ b/src/core/event-handler.js
@@ -1,9 +1,8 @@
 import { EventHandle } from './event-handle.js';
 
 /**
- * Callback used by {@link EventHandler} functions. Note the callback is limited to 8 arguments.
- *
  * @callback HandleEventCallback
+ * Callback used by {@link EventHandler} functions. Note the callback is limited to 8 arguments.
  * @param {any} [arg1] - First argument that is passed from caller.
  * @param {any} [arg2] - Second argument that is passed from caller.
  * @param {any} [arg3] - Third argument that is passed from caller.
@@ -12,6 +11,7 @@ import { EventHandle } from './event-handle.js';
  * @param {any} [arg6] - Sixth argument that is passed from caller.
  * @param {any} [arg7] - Seventh argument that is passed from caller.
  * @param {any} [arg8] - Eighth argument that is passed from caller.
+ * @returns {void}
  */
 
 /**

--- a/src/core/wasm-module.js
+++ b/src/core/wasm-module.js
@@ -110,17 +110,17 @@ class Impl {
 }
 
 /**
- * Callback used by {@link Module#setConfig}.
- *
  * @callback ModuleErrorCallback
+ * Callback used by {@link WasmModule.setConfig}.
  * @param {string} error - If the instance fails to load this will contain a description of the error.
+ * @returns {void}
  */
 
 /**
- * Callback used by {@link Module#getInstance}.
- *
  * @callback ModuleInstanceCallback
+ * Callback used by {@link WasmModule.getInstance}.
  * @param {any} moduleInstance - The module instance.
+ * @returns {void}
  */
 
 /**

--- a/src/framework/anim/evaluator/anim-target.js
+++ b/src/framework/anim/evaluator/anim-target.js
@@ -1,14 +1,4 @@
 /**
- * Callback function that the {@link AnimEvaluator} uses to set final animation values. These
- * callbacks are stored in {@link AnimTarget} instances which are constructed by an
- * {@link AnimBinder}.
- *
- * @callback AnimSetter
- * @param {number[]} value - Updated animation value.
- * @ignore
- */
-
-/**
  * Stores the information required by {@link AnimEvaluator} for updating a target value.
  *
  * @ignore
@@ -17,7 +7,7 @@ class AnimTarget {
     /**
      * Create a new AnimTarget instance.
      *
-     * @param {AnimSetter} func - This function will be called when a new animation value is output
+     * @param {(value: number[]) => void} func - This function will be called when a new animation value is output
      * by the {@link AnimEvaluator}.
      * @param {'vector'|'quaternion'} type - The type of animation data this target expects.
      * @param {number} components - The number of components on this target (this should ideally

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -72,26 +72,23 @@ import { getApplication, setApplication } from './globals.js';
  */
 
 /**
+ * @callback ConfigureAppCallback
  * Callback used by {@link AppBase#configure} when configuration file is loaded and parsed (or an
  * error occurs).
- *
- * @callback ConfigureAppCallback
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
  * @returns {void}
  */
 
 /**
- * Callback used by {@link AppBase#preload} when all assets (marked as 'preload') are loaded.
- *
  * @callback PreloadAppCallback
+ * Callback used by {@link AppBase#preload} when all assets (marked as 'preload') are loaded.
  * @returns {void}
  */
 
 /**
+ * @callback MakeTickCallback
  * Callback used by {@link AppBase#start} and itself to request the rendering of a new animation
  * frame.
- *
- * @callback MakeTickCallback
  * @param {number} [timestamp] - The timestamp supplied by requestAnimationFrame.
  * @param {XRFrame} [frame] - XRFrame from requestAnimationFrame callback.
  * @returns {void}

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -364,8 +364,8 @@ class AssetRegistry extends EventHandler {
      * is already loaded is bypassed, which forces loading of asset regardless.
      * @param {BundlesFilterCallback} [options.bundlesFilter] - A callback that will be called
      * when loading an asset that is contained in any of the bundles. It provides an array of
-     * bundles and will ensure asset is loaded from bundle returned from a callback. By default
-     * smallest filesize bundle is chosen.
+     * bundles and will ensure asset is loaded from bundle returned from a callback. By default,
+     * the smallest filesize bundle is chosen.
      * @example
      * // load some assets
      * const assetsToLoad = [

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -6,34 +6,32 @@ import { standardMaterialTextureParameters } from '../../scene/materials/standar
 import { Asset } from './asset.js';
 
 /**
- * @import { Bundle } from '../bundle/bundle.js'
  * @import { BundleRegistry } from '../bundle/bundle-registry.js'
  * @import { ResourceLoader } from '../handlers/loader.js'
  */
 
 /**
- * Callback used by {@link AssetRegistry#filter} to filter assets.
- *
  * @callback FilterAssetCallback
+ * Callback used by {@link AssetRegistry#filter} to filter assets.
  * @param {Asset} asset - The current asset to filter.
  * @returns {boolean} Return `true` to include asset to result list.
  */
 
 /**
+ * @callback LoadAssetCallback
  * Callback used by {@link AssetRegistry#loadFromUrl} and called when an asset is loaded (or an
  * error occurs).
- *
- * @callback LoadAssetCallback
  * @param {string|null} err - The error message is null if no errors were encountered.
  * @param {Asset} [asset] - The loaded asset if no errors were encountered.
+ * @returns {void}
  */
 
 /**
+ * @callback BundlesFilterCallback
  * Callback used by {@link ResourceLoader#load} and called when an asset is choosing a bundle
  * to load from. Return a single bundle to ensure asset is loaded from it.
- *
- * @callback BundlesFilterCallback
- * @param {Bundle[]} bundles - List of bundles which contain the asset.
+ * @param {Asset[]} bundles - List of bundle assets which contain the asset.
+ * @returns {Asset} Return a single bundle asset to ensure asset is loaded from it.
  */
 
 /**

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -26,10 +26,10 @@ const VARIANT_SUPPORT = {
 const VARIANT_DEFAULT_PRIORITY = ['pvr', 'dxt', 'etc2', 'etc1', 'basis'];
 
 /**
- * Callback used by {@link Asset#ready} and called when an asset is ready.
- *
  * @callback AssetReadyCallback
+ * Callback used by {@link Asset#ready} and called when an asset is ready.
  * @param {Asset} asset - The ready asset.
+ * @returns {void}
  */
 
 /**

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -23,11 +23,12 @@ import { PostEffectQueue } from './post-effect-queue.js';
  */
 
 /**
- * Callback used by {@link CameraComponent#calculateTransform} and {@link CameraComponent#calculateProjection}.
- *
  * @callback CalculateMatrixCallback
+ * Callback used by {@link CameraComponent#calculateTransform} and {@link CameraComponent#calculateProjection}.
  * @param {Mat4} transformMatrix - Output of the function.
- * @param {number} view - Type of view. Can be {@link VIEW_CENTER}, {@link VIEW_LEFT} or {@link VIEW_RIGHT}. Left and right are only used in stereo rendering.
+ * @param {number} view - Type of view. Can be {@link VIEW_CENTER}, {@link VIEW_LEFT} or
+ * {@link VIEW_RIGHT}. Left and right are only used in stereo rendering.
+ * @returns {void}
  */
 
 /**

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -5,11 +5,11 @@
  */
 
 /**
- * Callback used by {@link ResourceHandler#load} when a resource is loaded (or an error occurs).
- *
  * @callback ResourceHandlerCallback
+ * Callback used by {@link ResourceHandler#load} when a resource is loaded (or an error occurs).
  * @param {string|null} err - The error message in the case where the load fails.
  * @param {any} [response] - The raw data that has been successfully loaded.
+ * @returns {void}
  */
 
 /**

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -107,8 +107,8 @@ class ResourceLoader {
      * from a bundle. Defaults to false.
      * @param {BundlesFilterCallback} [options.bundlesFilter] - A callback that will be called
      * when loading an asset that is contained in any of the bundles. It provides an array of
-     * bundles and will ensure asset is loaded from bundle returned from a callback. By default
-     * smallest filesize bundle is chosen.
+     * bundles and will ensure asset is loaded from bundle returned from a callback. By default,
+     * the smallest filesize bundle is chosen.
      * @example
      * app.loader.load("../path/to/texture.png", "texture", function (err, texture) {
      *     // use texture here

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -9,11 +9,11 @@ import { Debug } from '../../core/debug.js';
  */
 
 /**
- * Callback used by {@link ResourceLoader#load} when a resource is loaded (or an error occurs).
- *
  * @callback ResourceLoaderCallback
+ * Callback used by {@link ResourceLoader#load} when a resource is loaded (or an error occurs).
  * @param {string|null} err - The error message in the case where the load fails.
  * @param {any} [resource] - The resource that has been successfully loaded.
+ * @returns {void}
  */
 
 /**
@@ -108,7 +108,7 @@ class ResourceLoader {
      * @param {BundlesFilterCallback} [options.bundlesFilter] - A callback that will be called
      * when loading an asset that is contained in any of the bundles. It provides an array of
      * bundles and will ensure asset is loaded from bundle returned from a callback. By default
-     * smallest filesize bundle is choosen.
+     * smallest filesize bundle is chosen.
      * @example
      * app.loader.load("../path/to/texture.png", "texture", function (err, texture) {
      *     // use texture here

--- a/src/framework/handlers/model.js
+++ b/src/framework/handlers/model.js
@@ -10,9 +10,8 @@ import { ResourceHandler } from './handler.js';
  */
 
 /**
- * Callback used by {@link ModelHandler#addParser} to decide on which parser to use.
- *
  * @callback AddParserCallback
+ * Callback used by {@link ModelHandler#addParser} to decide on which parser to use.
  * @param {string} url - The resource url.
  * @param {object} data - The raw model data.
  * @returns {boolean} Return true if this parser should be used to parse the data into a

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -9,42 +9,42 @@ import { SceneRegistryItem } from './scene-registry-item.js';
  */
 
 /**
- * Callback used by {@link SceneRegistry#loadSceneHierarchy}.
- *
  * @callback LoadHierarchyCallback
+ * Callback used by {@link SceneRegistry#loadSceneHierarchy}.
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
  * @param {Entity} [entity] - The loaded root entity if no errors were encountered.
+ * @returns {void}
  */
 
 /**
- * Callback used by {@link SceneRegistry#loadSceneSettings}.
- *
  * @callback LoadSettingsCallback
+ * Callback used by {@link SceneRegistry#loadSceneSettings}.
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
+ * @returns {void}
  */
 
 /**
- * Callback used by {@link SceneRegistry#changeScene}.
- *
  * @callback ChangeSceneCallback
+ * Callback used by {@link SceneRegistry#changeScene}.
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
  * @param {Entity} [entity] - The loaded root entity if no errors were encountered.
+ * @returns {void}
  */
 
 /**
- * Callback used by {@link SceneRegistry#loadScene}.
- *
  * @callback LoadSceneCallback
+ * Callback used by {@link SceneRegistry#loadScene}.
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
  * @param {Entity} [entity] - The loaded root entity if no errors were encountered.
+ * @returns {void}
  */
 
 /**
- * Callback used by {@link SceneRegistry#loadSceneData}.
- *
  * @callback LoadSceneDataCallback
+ * Callback used by {@link SceneRegistry#loadSceneData}.
  * @param {string|null} err - The error message in the case where the loading or parsing fails.
  * @param {SceneRegistryItem} [sceneItem] - The scene registry item if no errors were encountered.
+ * @returns {void}
  */
 
 /**

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -5,19 +5,10 @@ import { getApplication } from './globals.js';
  */
 
 /**
- * Callback used by {@link script.createLoadingScreen}.
- *
  * @callback CreateScreenCallback
+ * Callback used by {@link script.createLoadingScreen}.
  * @param {AppBase} app - The application.
- */
-
-/**
- * Callback used by {@link script.create}.
- *
- * @callback CreateScriptCallback
- * @param {AppBase} app - The application.
- * @returns {object} Return the Type of the script resource to be instanced for each Entity.
- * @ignore
+ * @returns {void}
  */
 
 // flag to avoid creating multiple loading screens e.g. when

--- a/src/framework/xr/xr-anchor.js
+++ b/src/framework/xr/xr-anchor.js
@@ -7,19 +7,20 @@ import { Quat } from '../../core/math/quat.js';
  */
 
 /**
- * Callback used by {@link XrAnchor#persist}.
- *
  * @callback XrAnchorPersistCallback
+ * Callback used by {@link XrAnchor#persist}.
  * @param {Error|null} err - The Error object if failed to persist an anchor or null.
- * @param {string|null} uuid - Unique string that can be used to restore {@link XrAnchor}
- * in another session.
+ * @param {string|null} uuid - Unique string that can be used to restore an {@link XrAnchor} in
+ * another session.
+ * @returns {void}
  */
 
 /**
- * Callback used by {@link XrAnchor#forget}.
- *
  * @callback XrAnchorForgetCallback
- * @param {Error|null} err - The Error object if failed to forget an anchor or null if succeeded.
+ * Callback used by {@link XrAnchor#forget}.
+ * @param {Error|null} err - The Error object if failed to forget an {@link XrAnchor} or null if
+ * succeeded.
+ * @returns {void}
  */
 
 /**

--- a/src/framework/xr/xr-anchors.js
+++ b/src/framework/xr/xr-anchors.js
@@ -10,11 +10,11 @@ import { XrAnchor } from './xr-anchor.js';
  */
 
 /**
- * Callback used by {@link XrAnchors#create}.
- *
  * @callback XrAnchorCreateCallback
+ * Callback used by {@link XrAnchors#create}.
  * @param {Error|null} err - The Error object if failed to create an anchor or null.
  * @param {XrAnchor|null} anchor - The anchor that is tracked against real world geometry.
+ * @returns {void}
  */
 
 /**

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -10,12 +10,12 @@ import { XrHitTestSource } from './xr-hit-test-source.js';
  */
 
 /**
- * Callback used by {@link XrHitTest#start} and {@link XrHitTest#startForInputSource}.
- *
  * @callback XrHitTestStartCallback
+ * Callback used by {@link XrHitTest#start} and {@link XrInputSource#hitTestStart}.
  * @param {Error|null} err - The Error object if failed to create hit test source or null.
  * @param {XrHitTestSource|null} hitTestSource - Object that provides access to hit results against
  * real world geometry.
+ * @returns {void}
  */
 
 /**

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -22,17 +22,17 @@ import { XrViews } from './xr-views.js';
  */
 
 /**
- * Callback used by {@link XrManager#endXr} and {@link XrManager#startXr}.
- *
  * @callback XrErrorCallback
+ * Callback used by {@link XrManager#start} and {@link XrManager#end}.
  * @param {Error|null} err - The Error object or null if operation was successful.
+ * @returns {void}
  */
 
 /**
- * Callback used by manual room capturing.
- *
  * @callback XrRoomCaptureCallback
+ * Callback used by manual room capturing.
  * @param {Error|null} err - The Error object or null if manual room capture was successful.
+ * @returns {void}
  */
 
 /**

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -4,9 +4,9 @@ import { EventHandler } from '../../core/event-handler.js';
 import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
 
 /**
- * Callback used by {@link Mouse#enablePointerLock} and {@link Application#disablePointerLock}.
- *
  * @callback LockMouseCallback
+ * Callback used by {@link Mouse#enablePointerLock} and {@link Mouse#disablePointerLock}.
+ * @returns {void}
  */
 
 /**

--- a/src/platform/net/http.js
+++ b/src/platform/net/http.js
@@ -6,12 +6,14 @@ import { URI } from '../../core/uri.js';
 import { math } from '../../core/math/math.js';
 
 /**
+ * @callback HttpResponseCallback
  * Callback used by {@link Http#get}, {@link Http#post}, {@link Http#put}, {@link Http#del}, and
  * {@link Http#request}.
- *
- * @callback HttpResponseCallback
- * @param {number|string|Error|null} err - The error code, message, or exception in the case where the request fails.
- * @param {any} [response] - The response data if no errors were encountered. (format depends on response type: text, Object, ArrayBuffer, XML).
+ * @param {number|string|Error|null} err - The error code, message, or exception in the case where
+ * the request fails.
+ * @param {any} [response] - The response data if no errors were encountered. Format depends on
+ * response type: text, Object, ArrayBuffer, XML.
+ * @returns {void}
  */
 
 /**

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -69,21 +69,20 @@ function findNode(node, test) {
 }
 
 /**
+ * @callback FindNodeCallback
  * Callback used by {@link GraphNode#find} and {@link GraphNode#findOne} to search through a graph
  * node and all of its descendants.
- *
- * @callback FindNodeCallback
  * @param {GraphNode} node - The current graph node.
  * @returns {boolean} Returning `true` will result in that node being returned from
  * {@link GraphNode#find} or {@link GraphNode#findOne}.
  */
 
 /**
+ * @callback ForEachNodeCallback
  * Callback used by {@link GraphNode#forEach} to iterate through a graph node and all of its
  * descendants.
- *
- * @callback ForEachNodeCallback
  * @param {GraphNode} node - The current graph node.
+ * @returns {void}
  */
 
 /**

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -167,13 +167,13 @@ class ShaderInstance {
 }
 
 /**
+ * @callback CalculateSortDistanceCallback
  * Callback used by {@link Layer} to calculate the "sort distance" for a {@link MeshInstance},
  * which determines its place in the render order.
- *
- * @callback CalculateSortDistanceCallback
  * @param {MeshInstance} meshInstance - The mesh instance.
  * @param {Vec3} cameraPosition - The position of the camera.
  * @param {Vec3} cameraForward - The forward vector of the camera.
+ * @returns {void}
  */
 
 /**


### PR DESCRIPTION
* Restores callback API ref descriptions.
* Removes `AnimSetter` (internal) and `CreateScriptCallback` (should have been removed with legacy scripts code).
* Correctly set return type of `void` where applicable (otherwise `any` is assumed).

Fixes #7604 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
