### PR TITLE
Gsplat render fix for wgpu

### DIFF
--- a/src/scene/shader-lib/chunks/gsplat/vert/gsplatCenter.js
+++ b/src/scene/shader-lib/chunks/gsplat/vert/gsplatCenter.js
@@ -16,7 +16,11 @@ bool initCenter(vec3 modelCenter, out SplatCenter center) {
     vec4 centerProj = matrix_projection * centerView;
 
     // ensure gaussians are not clipped by camera near and far
+#if WEBGPU
+    centerProj.z = clamp(centerProj.z, 0, abs(centerProj.w));
+#else
     centerProj.z = clamp(centerProj.z, -abs(centerProj.w), abs(centerProj.w));
+#endif
 
     center.view = centerView.xyz / centerView.w;
     center.proj = centerProj;


### PR DESCRIPTION
Fix for gaussian splats on webgpu.

Webgpu uses z clip range of 0..1, unlike webgl which uses range -1..1.