### PR TITLE
WGSL version of few internal chunks

### DIFF
--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -2196,3 +2196,4 @@ export const CHUNKAPI_2_3 = '2.3';
 export const CHUNKAPI_2_5 = '2.5';
 export const CHUNKAPI_2_6 = '2.6';
 export const CHUNKAPI_2_7 = '2.7';
+export const CHUNKAPI_2_8 = '2.8';

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -67,7 +67,7 @@ import lightFunctionShadowPS from './lit/frag/lighting/lightFunctionShadow.js';
 import lightingPS from './lit/frag/lighting/lighting.js';
 // import lightmapAddPS from './lit/frag/lightmapAdd.js';
 // import lightmapPS from './standard/frag/lightmap.js';
-// import lightSpecularAnisoGGXPS from './lit/frag/lightSpecularAnisoGGX.js';
+import lightSpecularAnisoGGXPS from './lit/frag/lightSpecularAnisoGGX.js';
 import lightSpecularBlinnPS from './lit/frag/lightSpecularBlinn.js';
 import lightSheenPS from './lit/frag/lightSheen.js';
 import linearizeDepthPS from './common/frag/linearizeDepth.js';
@@ -176,7 +176,6 @@ import startNineSlicedPS from './lit/frag/startNineSliced.js';
 import startNineSlicedTiledPS from './lit/frag/startNineSlicedTiled.js';
 import stdDeclarationPS from './standard/frag/stdDeclaration.js';
 import stdFrontEndPS from './standard/frag/stdFrontEnd.js';
-// import tangentBinormalVS from './lit/vert/tangentBinormal.js';
 import TBNPS from './lit/frag/TBN.js';
 import thicknessPS from './standard/frag/thickness.js';
 import tonemappingPS from './common/frag/tonemapping/tonemapping.js';
@@ -191,7 +190,7 @@ import transformVS from './common/vert/transform.js';
 import transformCoreVS from './common/vert/transformCore.js';
 import transformInstancingVS from './common/vert/transformInstancing.js';
 import transmissionPS from './standard/frag/transmission.js';
-// import twoSidedLightingPS from './lit/frag/twoSidedLighting.js';
+import twoSidedLightingPS from './lit/frag/twoSidedLighting.js';
 import uv0VS from './lit/vert/uv0.js';
 import uv1VS from './lit/vert/uv1.js';
 import uvTransformVS from './lit/vert/uvTransform.js';
@@ -277,7 +276,7 @@ const shaderChunksWGSL = {
     lightingPS,
     // lightmapAddPS,
     // lightmapPS,
-    // lightSpecularAnisoGGXPS,
+    lightSpecularAnisoGGXPS,
     lightSpecularBlinnPS,
     lightSheenPS,
     linearizeDepthPS,
@@ -386,7 +385,6 @@ const shaderChunksWGSL = {
     startNineSlicedTiledPS,
     stdDeclarationPS,
     stdFrontEndPS,
-    // tangentBinormalVS,
     TBNPS,
     thicknessPS,
     tonemappingPS,
@@ -401,7 +399,7 @@ const shaderChunksWGSL = {
     transformCoreVS,
     transformInstancingVS,
     transmissionPS,
-    // twoSidedLightingPS,
+    twoSidedLightingPS,
     uv0VS,
     uv1VS,
     uvTransformVS,

--- a/src/scene/shader-lib/chunks-wgsl/common/vert/normalCore.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/vert/normalCore.js
@@ -4,11 +4,11 @@ attribute vertex_normal: vec3f;
 
 #ifdef MORPHING_NORMAL
     #ifdef MORPHING_INT
-        uniform morphNormalTex: texture_2d<u32>;
-        uniform morphNormalTexSampler: sampler;
+        var morphNormalTex: texture_2d<u32>;
+        var morphNormalTexSampler: sampler;
     #else
-        uniform morphNormalTex: texture_2d<f32>;
-        uniform morphNormalTexSampler: sampler;
+        var morphNormalTex: texture_2d<f32>;
+        var morphNormalTexSampler: sampler;
     #endif
 #endif
 

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/lightSpecularAnisoGGX.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/lightSpecularAnisoGGX.js
@@ -1,0 +1,38 @@
+export default /* wgsl */`
+// Anisotropic GGX
+fn calcLightSpecular(gloss: f32, worldNormal: vec3f, viewDir: vec3f, h: vec3f, lightDirNorm: vec3f, tbn: mat3x3f) -> f32 {
+    let PI: f32 = 3.141592653589793;
+    let roughness: f32 = max((1.0 - gloss) * (1.0 - gloss), 0.001);
+    let anisotropy: f32 = uniform.material_anisotropy * roughness;
+
+    let at: f32 = max((roughness + anisotropy), roughness / 4.0);
+    let ab: f32 = max((roughness - anisotropy), roughness / 4.0);
+
+    let NoH: f32 = dot(worldNormal, h);
+    let ToH: f32 = dot(tbn[0], h);
+    let BoH: f32 = dot(tbn[1], h);
+
+    let a2: f32 = at * ab;
+    let v: vec3f = vec3f(ab * ToH, at * BoH, a2 * NoH);
+    let v2: f32 = dot(v, v);
+    let w2: f32 = a2 / v2;
+    let D: f32 = a2 * w2 * w2 * (1.0 / PI);
+
+    let ToV: f32 = dot(tbn[0], viewDir);
+    let BoV: f32 = dot(tbn[1], viewDir);
+    let ToL: f32 = dot(tbn[0], -lightDirNorm);
+    let BoL: f32 = dot(tbn[1], -lightDirNorm);
+    let NoV: f32 = dot(worldNormal, viewDir);
+    let NoL: f32 = dot(worldNormal, -lightDirNorm);
+
+    let lambdaV: f32 = NoL * length(vec3f(at * ToV, ab * BoV, NoV));
+    let lambdaL: f32 = NoV * length(vec3f(at * ToL, ab * BoL, NoL));
+    let G: f32 = 0.5 / (lambdaV + lambdaL);
+
+    return D * G;
+}
+
+fn getLightSpecular(h: vec3f, reflDir: vec3f, worldNormal: vec3f, viewDir: vec3f, lightDirNorm: vec3f, gloss: f32, tbn: mat3x3f) -> f32 {
+    return calcLightSpecular(gloss, worldNormal, viewDir, h, lightDirNorm, tbn);
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-forward/litForwardBackend.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/pass-forward/litForwardBackend.js
@@ -218,7 +218,7 @@ fn evaluateBackend() -> FragmentOutput {
 
         #endif
 
-        litArgs_opacity = litArgs_opacity * material_alphaFade;
+        litArgs_opacity = litArgs_opacity * uniform.material_alphaFade;
 
     #endif
 

--- a/src/scene/shader-lib/chunks-wgsl/lit/frag/twoSidedLighting.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/frag/twoSidedLighting.js
@@ -1,0 +1,7 @@
+export default /* wgsl */`
+uniform twoSidedLightingNegScaleFactor: f32;
+
+fn handleTwoSidedLighting() {
+    dTBN[2] = dTBN[2] * select(-uniform.twoSidedLightingNegScaleFactor, uniform.twoSidedLightingNegScaleFactor, pcFrontFacing);
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/lit/vert/litMain.js
+++ b/src/scene/shader-lib/chunks-wgsl/lit/vert/litMain.js
@@ -50,7 +50,6 @@ var<private> dModelMatrix: mat4x4f;
 
 #ifdef TANGENTS
     attribute vertex_tangent: vec4f;
-    #include "tangentBinormalVS"
 #endif
 
 // expand uniforms for uv transforms
@@ -71,8 +70,8 @@ fn vertexMain(input : VertexInput) -> VertexOutput {
     #endif
 
     #ifdef TANGENTS
-        output.vTangentW = getTangent();
-        output.vBinormalW = getBinormal();
+        output.vTangentW = normalize(dNormalMatrix * vertex_tangent.xyz);
+        output.vBinormalW = cross(output.vNormalW, output.vTangentW) * vertex_tangent.w;
     #elif defined(GGX_SPECULAR)
         output.vObjectSpaceUpW = normalize(dNormalMatrix * vec3f(0.0, 1.0, 0.0));
     #endif

--- a/src/scene/shader-lib/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/chunks/chunk-validation.js
@@ -1,6 +1,7 @@
 import {
     CHUNKAPI_1_51, CHUNKAPI_1_55, CHUNKAPI_1_56, CHUNKAPI_1_57, CHUNKAPI_1_60, CHUNKAPI_1_62, CHUNKAPI_1_65,
-    CHUNKAPI_1_70, CHUNKAPI_2_1, CHUNKAPI_2_3, CHUNKAPI_2_5, CHUNKAPI_2_6, CHUNKAPI_2_7
+    CHUNKAPI_1_70, CHUNKAPI_2_1, CHUNKAPI_2_3, CHUNKAPI_2_5, CHUNKAPI_2_6, CHUNKAPI_2_7,
+    CHUNKAPI_2_8
 } from '../../../platform/graphics/constants.js';
 import { Debug } from '../../../core/debug.js';
 import { shaderChunks } from './chunks.js';
@@ -129,7 +130,8 @@ const removedChunks = {
     normalXYZPS: CHUNKAPI_2_7,
     aoDetailMapPS: CHUNKAPI_2_7,
     lightmapDirPS: CHUNKAPI_2_7,
-    lightmapSinglePS: CHUNKAPI_2_7
+    lightmapSinglePS: CHUNKAPI_2_7,
+    tangentBinormalVS: CHUNKAPI_2_8
 };
 
 // compare two "major.minor" semantic version strings and return true if a is a smaller version than b.

--- a/src/scene/shader-lib/chunks/chunks.js
+++ b/src/scene/shader-lib/chunks/chunks.js
@@ -181,7 +181,6 @@ import startNineSlicedPS from './lit/frag/startNineSliced.js';
 import startNineSlicedTiledPS from './lit/frag/startNineSlicedTiled.js';
 import stdDeclarationPS from './standard/frag/stdDeclaration.js';
 import stdFrontEndPS from './standard/frag/stdFrontEnd.js';
-import tangentBinormalVS from './lit/vert/tangentBinormal.js';
 import TBNPS from './lit/frag/TBN.js';
 import thicknessPS from './standard/frag/thickness.js';
 import tonemappingPS from './common/frag/tonemapping/tonemapping.js';
@@ -396,7 +395,6 @@ const shaderChunks = {
     startNineSlicedTiledPS,
     stdDeclarationPS,
     stdFrontEndPS,
-    tangentBinormalVS,
     TBNPS,
     thicknessPS,
     tonemappingPS,

--- a/src/scene/shader-lib/chunks/lit/vert/litMain.js
+++ b/src/scene/shader-lib/chunks/lit/vert/litMain.js
@@ -47,7 +47,6 @@ mat4 dModelMatrix;
 
 #ifdef TANGENTS
     attribute vec4 vertex_tangent;
-    #include "tangentBinormalVS"
 #endif
 
 // expand uniforms for uv transforms
@@ -66,8 +65,8 @@ void main(void) {
     #endif
 
     #ifdef TANGENTS
-        vTangentW = getTangent();
-        vBinormalW = getBinormal();
+        vTangentW = normalize(dNormalMatrix * vertex_tangent.xyz);
+        vBinormalW = cross(vNormalW, vTangentW) * vertex_tangent.w;
     #elif defined(GGX_SPECULAR)
         vObjectSpaceUpW = normalize(dNormalMatrix * vec3(0, 1, 0));
     #endif

--- a/src/scene/shader-lib/chunks/lit/vert/tangentBinormal.js
+++ b/src/scene/shader-lib/chunks/lit/vert/tangentBinormal.js
@@ -1,9 +1,0 @@
-export default /* glsl */`
-vec3 getTangent() {
-    return normalize(dNormalMatrix * vertex_tangent.xyz);
-}
-
-vec3 getBinormal() {
-    return cross(vNormalW, vTangentW) * vertex_tangent.w;
-}
-`;


### PR DESCRIPTION
- removed and inlined tangentBinormalVS chunk to avoid having to create globals and assignments on WGSL due to not having access to output parameters globally
- converted few additional chunks to WGSL