### PR TITLE
Improve JSDocs for Geometry classes

### DIFF
--- a/src/scene/geometry/box-geometry.js
+++ b/src/scene/geometry/box-geometry.js
@@ -8,11 +8,13 @@ const primitiveUv1PaddingScale = 1.0 - primitiveUv1Padding * 2;
 /**
  * A procedural box-shaped geometry.
  *
- * The size, shape and tesselation properties of the box can be controlled via constructor options.
- * By default, a box centered on the object space origin with a width, length and height of 1.0 unit
- * and 1 segment in either axis (2 triangles per face).
+ * Typically, you would:
  *
- * Note that the box is created with UVs in the range of 0 to 1 on each face.
+ * 1. Create a BoxGeometry instance.
+ * 2. Generate a {@link Mesh} from the geometry.
+ * 3. Create a {@link MeshInstance} referencing the mesh.
+ * 4. Create an {@link Entity} with a {@link RenderComponent} and assign the {@link MeshInstance} to it.
+ * 5. Add the entity to the {@link Scene}.
  *
  * ```javascript
  * // Create a mesh instance
@@ -36,6 +38,10 @@ const primitiveUv1PaddingScale = 1.0 - primitiveUv1Padding * 2;
 class BoxGeometry extends Geometry {
     /**
      * Create a new BoxGeometry instance.
+     *
+     * By default, the constructor creates a box centered on the object space origin with a width,
+     * length and height of 1 unit and 1 segment in either axis (2 triangles per face). The box is
+     * created with UVs in the range of 0 to 1 on each face.
      *
      * @param {object} [opts] - Options object.
      * @param {Vec3} [opts.halfExtents] - The half dimensions of the box in each axis. Defaults to

--- a/src/scene/geometry/box-geometry.js
+++ b/src/scene/geometry/box-geometry.js
@@ -14,24 +14,48 @@ const primitiveUv1PaddingScale = 1.0 - primitiveUv1Padding * 2;
  *
  * Note that the box is created with UVs in the range of 0 to 1 on each face.
  *
+ * ```javascript
+ * // Create a mesh instance
+ * const geometry = new pc.BoxGeometry();
+ * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new pc.StandardMaterial();
+ * const meshInstance = new pc.MeshInstance(mesh, material);
+ *
+ * // Create an entity
+ * const entity = new pc.Entity();
+ * entity.addComponent('render', {
+ *     meshInstances: [meshInstance]
+ * });
+ *
+ * // Add the entity to the scene hierarchy
+ * app.scene.root.addChild(entity);
+ * ```
+ *
  * @category Graphics
  */
 class BoxGeometry extends Geometry {
     /**
      * Create a new BoxGeometry instance.
      *
-     * @param {object} [opts] - An object that specifies optional inputs for the function as follows:
-     * @param {Vec3} [opts.halfExtents] - The half dimensions of the box in each axis (defaults to
-     * [0.5, 0.5, 0.5]).
-     * @param {number} [opts.widthSegments] - The number of divisions along the X axis of the box
-     * (defaults to 1).
-     * @param {number} [opts.lengthSegments] - The number of divisions along the Z axis of the box
-     * (defaults to 1).
-     * @param {number} [opts.heightSegments] - The number of divisions along the Y axis of the box
-     * (defaults to 1).
-     * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
+     * @param {object} [opts] - Options object.
+     * @param {Vec3} [opts.halfExtents] - The half dimensions of the box in each axis. Defaults to
+     * [0.5, 0.5, 0.5].
+     * @param {number} [opts.widthSegments] - The number of divisions along the X axis of the box.
+     * Defaults to 1.
+     * @param {number} [opts.lengthSegments] - The number of divisions along the Z axis of the box.
+     * Defaults to 1.
+     * @param {number} [opts.heightSegments] - The number of divisions along the Y axis of the box.
+     * Defaults to 1.
+     * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
      * @param {number} [opts.yOffset] - Move the box vertically by given offset in local space. Pass
      * 0.5 to generate the box with pivot point at the bottom face. Defaults to 0.
+     * @example
+     * const geometry = new pc.BoxGeometry({
+     *     halfExtents: new pc.Vec3(1, 1, 1),
+     *     widthSegments: 2,
+     *     lengthSegments: 2,
+     *     heightSegments: 2
+     * });
      */
     constructor(opts = {}) {
         super();

--- a/src/scene/geometry/capsule-geometry.js
+++ b/src/scene/geometry/capsule-geometry.js
@@ -10,22 +10,46 @@ import { calculateTangents } from './geometry-utils.js';
  *
  * Note that the capsule is created with UVs in the range of 0 to 1.
  *
+ * ```javascript
+ * // Create a mesh instance
+ * const geometry = new pc.CapsuleGeometry();
+ * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new pc.StandardMaterial();
+ * const meshInstance = new pc.MeshInstance(mesh, material);
+ *
+ * // Create an entity
+ * const entity = new pc.Entity();
+ * entity.addComponent('render', {
+ *     meshInstances: [meshInstance]
+ * });
+ *
+ * // Add the entity to the scene hierarchy
+ * app.scene.root.addChild(entity);
+ * ```
+ *
  * @category Graphics
  */
 class CapsuleGeometry extends ConeBaseGeometry {
     /**
      * Create a new CapsuleGeometry instance.
      *
-     * @param {object} [opts] - An object that specifies optional inputs for the function as follows:
-     * @param {number} [opts.radius] - The radius of the tube forming the body of the capsule (defaults
-     * to 0.3).
-     * @param {number} [opts.height] - The length of the body of the capsule from tip to tip (defaults
-     * to 1.0).
+     * @param {object} [opts] - Options object.
+     * @param {number} [opts.radius] - The radius of the tube forming the body of the capsule. Defaults
+     * to 0.3.
+     * @param {number} [opts.height] - The length of the body of the capsule from tip to tip. Defaults
+     * to 1.
      * @param {number} [opts.heightSegments] - The number of divisions along the tubular length of the
-     * capsule (defaults to 1).
-     * @param {number} [opts.sides] - The number of divisions around the tubular body of the capsule
-     * (defaults to 20).
-     * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
+     * capsule. Defaults to 1.
+     * @param {number} [opts.sides] - The number of divisions around the tubular body of the capsule.
+     * Defaults to 20.
+     * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
+     * @example
+     * const geometry = new pc.CapsuleGeometry({
+     *     radius: 1,
+     *     height: 2,
+     *     heightSegments: 2,
+     *     sides: 20
+     * });
      */
     constructor(opts = {}) {
 

--- a/src/scene/geometry/capsule-geometry.js
+++ b/src/scene/geometry/capsule-geometry.js
@@ -4,11 +4,13 @@ import { calculateTangents } from './geometry-utils.js';
 /**
  * A procedural capsule-shaped geometry.
  *
- * The size, shape and tesselation properties of the capsule can be controlled via constructor
- * parameters. By default, the function will create a capsule standing vertically centered on the
- * XZ-plane with a radius of 0.3, a height of 1.0, 1 height segment and 20 cap segments.
+ * Typically, you would:
  *
- * Note that the capsule is created with UVs in the range of 0 to 1.
+ * 1. Create a CapsuleGeometry instance.
+ * 2. Generate a {@link Mesh} from the geometry.
+ * 3. Create a {@link MeshInstance} referencing the mesh.
+ * 4. Create an {@link Entity} with a {@link RenderComponent} and assign the {@link MeshInstance} to it.
+ * 5. Add the entity to the {@link Scene}.
  *
  * ```javascript
  * // Create a mesh instance
@@ -33,13 +35,17 @@ class CapsuleGeometry extends ConeBaseGeometry {
     /**
      * Create a new CapsuleGeometry instance.
      *
+     * By default, the constructor creates a capsule standing vertically centered on the XZ-plane
+     * with a radius of 0.3, a height of 1.0, 1 height segment and 20 cap segments. The capsule is
+     * created with UVs in the range of 0 to 1.
+     *
      * @param {object} [opts] - Options object.
-     * @param {number} [opts.radius] - The radius of the tube forming the body of the capsule. Defaults
-     * to 0.3.
-     * @param {number} [opts.height] - The length of the body of the capsule from tip to tip. Defaults
-     * to 1.
-     * @param {number} [opts.heightSegments] - The number of divisions along the tubular length of the
-     * capsule. Defaults to 1.
+     * @param {number} [opts.radius] - The radius of the tube forming the body of the capsule.
+     * Defaults to 0.3.
+     * @param {number} [opts.height] - The length of the body of the capsule from tip to tip.
+     * Defaults to 1.
+     * @param {number} [opts.heightSegments] - The number of divisions along the tubular length of
+     * the capsule. Defaults to 1.
      * @param {number} [opts.sides] - The number of divisions around the tubular body of the capsule.
      * Defaults to 20.
      * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.

--- a/src/scene/geometry/cone-base-geometry.js
+++ b/src/scene/geometry/cone-base-geometry.js
@@ -4,7 +4,10 @@ import { Geometry } from './geometry.js';
 const primitiveUv1Padding = 4.0 / 64;
 const primitiveUv1PaddingScale = 1.0 - primitiveUv1Padding * 2;
 
-// Internal class for generating cone based geometry
+/**
+ * Shared superclass of {@link CapsuleGeometry}, {@link ConeGeometry} and {@link CylinderGeometry}.
+ * Use those classes instead of this one.
+ */
 class ConeBaseGeometry extends Geometry {
     constructor(baseRadius, peakRadius, height, heightSegments, capSegments, roundedCaps) {
         super();

--- a/src/scene/geometry/cone-geometry.js
+++ b/src/scene/geometry/cone-geometry.js
@@ -10,21 +10,45 @@ import { calculateTangents } from './geometry-utils.js';
  *
  * Note that the cone is created with UVs in the range of 0 to 1.
  *
+ * ```javascript
+ * // Create a mesh instance
+ * const geometry = new pc.ConeGeometry();
+ * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new pc.StandardMaterial();
+ * const meshInstance = new pc.MeshInstance(mesh, material);
+ *
+ * // Create an entity
+ * const entity = new pc.Entity();
+ * entity.addComponent('render', {
+ *     meshInstances: [meshInstance]
+ * });
+ *
+ * // Add the entity to the scene hierarchy
+ * app.scene.root.addChild(entity);
+ * ```
+ *
  * @category Graphics
  */
 class ConeGeometry extends ConeBaseGeometry {
     /**
      * Create a new ConeGeometry instance.
      *
-     * @param {object} [opts] - An object that specifies optional inputs for the function as follows:
-     * @param {number} [opts.baseRadius] - The base radius of the cone (defaults to 0.5).
-     * @param {number} [opts.peakRadius] - The peak radius of the cone (defaults to 0.0).
-     * @param {number} [opts.height] - The length of the body of the cone (defaults to 1.0).
-     * @param {number} [opts.heightSegments] - The number of divisions along the length of the cone
-     * (defaults to 5).
-     * @param {number} [opts.capSegments] - The number of divisions around the tubular body of the cone
-     * (defaults to 18).
-     * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
+     * @param {object} [opts] - Options object.
+     * @param {number} [opts.baseRadius] - The base radius of the cone. Defaults to 0.5.
+     * @param {number} [opts.peakRadius] - The peak radius of the cone. Defaults to 0.
+     * @param {number} [opts.height] - The length of the body of the cone. Defaults to 1.
+     * @param {number} [opts.heightSegments] - The number of divisions along the length of the cone.
+     * Defaults to 5.
+     * @param {number} [opts.capSegments] - The number of divisions around the tubular body of the
+     * cone. Defaults to 18.
+     * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
+     * @example
+     * const geometry = new pc.ConeGeometry({
+     *     baseRadius: 1,
+     *     height: 2,
+     *     heightSegments: 2,
+     *     capSegments: 20
+     * });
      */
     constructor(opts = {}) {
 

--- a/src/scene/geometry/cone-geometry.js
+++ b/src/scene/geometry/cone-geometry.js
@@ -4,11 +4,13 @@ import { calculateTangents } from './geometry-utils.js';
 /**
  * A procedural cone-shaped geometry.
  *
- * The size, shape and tesselation properties of the cone can be controlled via constructor
- * parameters. By default, the function will create a cone standing vertically centered on the
- * XZ-plane with a base radius of 0.5, a height of 1.0, 5 height segments and 18 cap segments.
+ * Typically, you would:
  *
- * Note that the cone is created with UVs in the range of 0 to 1.
+ * 1. Create a ConeGeometry instance.
+ * 2. Generate a {@link Mesh} from the geometry.
+ * 3. Create a {@link MeshInstance} referencing the mesh.
+ * 4. Create an {@link Entity} with a {@link RenderComponent} and assign the {@link MeshInstance} to it.
+ * 5. Add the entity to the {@link Scene}.
  *
  * ```javascript
  * // Create a mesh instance
@@ -32,6 +34,10 @@ import { calculateTangents } from './geometry-utils.js';
 class ConeGeometry extends ConeBaseGeometry {
     /**
      * Create a new ConeGeometry instance.
+     *
+     * By default, the constructor creates a cone standing vertically centered on the XZ-plane with
+     * a base radius of 0.5, a height of 1.0, 5 height segments and 18 cap segments. The cone is
+     * created with UVs in the range of 0 to 1.
      *
      * @param {object} [opts] - Options object.
      * @param {number} [opts.baseRadius] - The base radius of the cone. Defaults to 0.5.

--- a/src/scene/geometry/cylinder-geometry.js
+++ b/src/scene/geometry/cylinder-geometry.js
@@ -10,21 +10,45 @@ import { calculateTangents } from './geometry-utils.js';
  *
  * Note that the cylinder is created with UVs in the range of 0 to 1.
  *
+ * ```javascript
+ * // Create a mesh instance
+ * const geometry = new pc.CylinderGeometry();
+ * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new pc.StandardMaterial();
+ * const meshInstance = new pc.MeshInstance(mesh, material);
+ *
+ * // Create an entity
+ * const entity = new pc.Entity();
+ * entity.addComponent('render', {
+ *     meshInstances: [meshInstance]
+ * });
+ *
+ * // Add the entity to the scene hierarchy
+ * app.scene.root.addChild(entity);
+ * ```
+ *
  * @category Graphics
  */
 class CylinderGeometry extends ConeBaseGeometry {
     /**
      * Create a new CylinderGeometry instance.
      *
-     * @param {object} [opts] - An object that specifies optional inputs for the function as follows:
-     * @param {number} [opts.radius] - The radius of the tube forming the body of the cylinder
-     * (defaults to 0.5).
-     * @param {number} [opts.height] - The length of the body of the cylinder (defaults to 1.0).
-     * @param {number} [opts.heightSegments] - The number of divisions along the length of the cylinder
-     * (defaults to 5).
+     * @param {object} [opts] - Options object.
+     * @param {number} [opts.radius] - The radius of the tube forming the body of the cylinder.
+     * Defaults to 0.5.
+     * @param {number} [opts.height] - The length of the body of the cylinder. Defaults to 1.
+     * @param {number} [opts.heightSegments] - The number of divisions along the length of the
+     * cylinder. Defaults to 5.
      * @param {number} [opts.capSegments] - The number of divisions around the tubular body of the
-     * cylinder (defaults to 20).
-     * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
+     * cylinder. Defaults to 20.
+     * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
+     * @example
+     * const geometry = new pc.CylinderGeometry({
+     *     radius: 1,
+     *     height: 2,
+     *     heightSegments: 2,
+     *     capSegments: 10
+     * });
      */
     constructor(opts = {}) {
 

--- a/src/scene/geometry/cylinder-geometry.js
+++ b/src/scene/geometry/cylinder-geometry.js
@@ -4,11 +4,13 @@ import { calculateTangents } from './geometry-utils.js';
 /**
  * A procedural cylinder-shaped geometry.
  *
- * The size, shape and tesselation properties of the cylinder can be controlled via constructor
- * parameters. By default, the function will create a cylinder standing vertically centered on the
- * XZ-plane with a radius of 0.5, a height of 1.0, 1 height segment and 20 cap segments.
+ * Typically, you would:
  *
- * Note that the cylinder is created with UVs in the range of 0 to 1.
+ * 1. Create a CylinderGeometry instance.
+ * 2. Generate a {@link Mesh} from the geometry.
+ * 3. Create a {@link MeshInstance} referencing the mesh.
+ * 4. Create an {@link Entity} with a {@link RenderComponent} and assign the {@link MeshInstance} to it.
+ * 5. Add the entity to the {@link Scene}.
  *
  * ```javascript
  * // Create a mesh instance
@@ -32,6 +34,10 @@ import { calculateTangents } from './geometry-utils.js';
 class CylinderGeometry extends ConeBaseGeometry {
     /**
      * Create a new CylinderGeometry instance.
+     *
+     * By default, the constructor creates a cylinder standing vertically centered on the XZ-plane
+     * with a radius of 0.5, a height of 1.0, 1 height segment and 20 cap segments. The cylinder is
+     * created with UVs in the range of 0 to 1.
      *
      * @param {object} [opts] - Options object.
      * @param {number} [opts.radius] - The radius of the tube forming the body of the cylinder.

--- a/src/scene/geometry/dome-geometry.js
+++ b/src/scene/geometry/dome-geometry.js
@@ -3,10 +3,13 @@ import { SphereGeometry } from './sphere-geometry.js';
 /**
  * A procedural dome-shaped geometry.
  *
- * The size and tesselation properties of the dome can be controlled via constructor parameters.
- * Radius is fixed to 0.5.
+ * Typically, you would:
  *
- * Note that the dome is created with UVs in the range of 0 to 1.
+ * 1. Create a DomeGeometry instance.
+ * 2. Generate a {@link Mesh} from the geometry.
+ * 3. Create a {@link MeshInstance} referencing the mesh.
+ * 4. Create an {@link Entity} with a {@link RenderComponent} and assign the {@link MeshInstance} to it.
+ * 5. Add the entity to the {@link Scene}.
  *
  * ```javascript
  * // Create a mesh instance
@@ -30,6 +33,9 @@ import { SphereGeometry } from './sphere-geometry.js';
 class DomeGeometry extends SphereGeometry {
     /**
      * Create a new DomeGeometry instance.
+     *
+     * By default, the constructor creates a dome with a radius of 0.5, 16 latitude bands and 16
+     * longitude bands. The dome is created with UVs in the range of 0 to 1.
      *
      * @param {object} [opts] - Options object.
      * @param {number} [opts.latitudeBands] - The number of divisions along the latitudinal axis of

--- a/src/scene/geometry/dome-geometry.js
+++ b/src/scene/geometry/dome-geometry.js
@@ -8,17 +8,39 @@ import { SphereGeometry } from './sphere-geometry.js';
  *
  * Note that the dome is created with UVs in the range of 0 to 1.
  *
+ * ```javascript
+ * // Create a mesh instance
+ * const geometry = new pc.DomeGeometry();
+ * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new pc.StandardMaterial();
+ * const meshInstance = new pc.MeshInstance(mesh, material);
+ *
+ * // Create an entity
+ * const entity = new pc.Entity();
+ * entity.addComponent('render', {
+ *     meshInstances: [meshInstance]
+ * });
+ *
+ * // Add the entity to the scene hierarchy
+ * app.scene.root.addChild(entity);
+ * ```
+ *
  * @category Graphics
  */
 class DomeGeometry extends SphereGeometry {
     /**
-     * Create a new CylinderGeometry instance.
+     * Create a new DomeGeometry instance.
      *
-     * @param {object} [opts] - An object that specifies optional inputs for the function as follows:
-     * @param {number} [opts.latitudeBands] - The number of divisions along the latitudinal axis of the
-     * sphere (defaults to 16).
+     * @param {object} [opts] - Options object.
+     * @param {number} [opts.latitudeBands] - The number of divisions along the latitudinal axis of
+     * the sphere. Defaults to 16.
      * @param {number} [opts.longitudeBands] - The number of divisions along the longitudinal axis of
-     * the sphere (defaults to 16).
+     * the sphere. Defaults to 16.
+     * @example
+     * const geometry = new pc.DomeGeometry({
+     *     latitudeBands: 32,
+     *     longitudeBands: 32
+     * });
      */
     constructor(opts = {}) {
 

--- a/src/scene/geometry/plane-geometry.js
+++ b/src/scene/geometry/plane-geometry.js
@@ -33,7 +33,7 @@ import { Geometry } from './geometry.js';
  */
 class PlaneGeometry extends Geometry {
     /**
-     * Create a new PlaneGeometry instance. 
+     * Create a new PlaneGeometry instance.
      *
      * @param {object} [opts] - Options object.
      * @param {Vec2} [opts.halfExtents] - The half dimensions of the plane in the X and Z axes.

--- a/src/scene/geometry/plane-geometry.js
+++ b/src/scene/geometry/plane-geometry.js
@@ -5,12 +5,13 @@ import { Geometry } from './geometry.js';
 /**
  * A procedural plane-shaped geometry.
  *
- * The size and tesselation properties of the plane can be controlled via constructor parameters.
- * By default, the function will create a plane centered on the object space origin with a width
- * and length of 1 and 5 segments in either axis (50 triangles). The normal vector of the plane is
- * aligned along the positive Y axis.
+ * Typically, you would:
  *
- * Note that the plane is created with UVs in the range of 0 to 1.
+ * 1. Create a PlaneGeometry instance.
+ * 2. Generate a {@link Mesh} from the geometry.
+ * 3. Create a {@link MeshInstance} referencing the mesh.
+ * 4. Create an {@link Entity} with a {@link RenderComponent} and assign the {@link MeshInstance} to it.
+ * 5. Add the entity to the {@link Scene}.
  *
  * ```javascript
  * // Create a mesh instance
@@ -34,6 +35,10 @@ import { Geometry } from './geometry.js';
 class PlaneGeometry extends Geometry {
     /**
      * Create a new PlaneGeometry instance.
+     *
+     * By default, the constructor creates a plane centered on the object space origin with a width
+     * and length of 1 and 5 segments in either axis (50 triangles). The normal vector of the plane is
+     * aligned along the positive Y axis. The plane is created with UVs in the range of 0 to 1.
      *
      * @param {object} [opts] - Options object.
      * @param {Vec2} [opts.halfExtents] - The half dimensions of the plane in the X and Z axes.

--- a/src/scene/geometry/plane-geometry.js
+++ b/src/scene/geometry/plane-geometry.js
@@ -5,27 +5,50 @@ import { Geometry } from './geometry.js';
 /**
  * A procedural plane-shaped geometry.
  *
- * The size and tesselation properties of the plane can be controlled via constructor parameters. By
- * default, the function will create a plane centered on the object space origin with a width and
- * length of 1.0 and 5 segments in either axis (50 triangles). The normal vector of the plane is
+ * The size and tesselation properties of the plane can be controlled via constructor parameters.
+ * By default, the function will create a plane centered on the object space origin with a width
+ * and length of 1 and 5 segments in either axis (50 triangles). The normal vector of the plane is
  * aligned along the positive Y axis.
  *
  * Note that the plane is created with UVs in the range of 0 to 1.
+ *
+ * ```javascript
+ * // Create a mesh instance
+ * const geometry = new pc.PlaneGeometry();
+ * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new pc.StandardMaterial();
+ * const meshInstance = new pc.MeshInstance(mesh, material);
+ *
+ * // Create an entity
+ * const entity = new pc.Entity();
+ * entity.addComponent('render', {
+ *     meshInstances: [meshInstance]
+ * });
+ *
+ * // Add the entity to the scene hierarchy
+ * app.scene.root.addChild(entity);
+ * ```
  *
  * @category Graphics
  */
 class PlaneGeometry extends Geometry {
     /**
-     * Create a new PlaneGeometry instance.
+     * Create a new PlaneGeometry instance. 
      *
-     * @param {object} [opts] - An object that specifies optional inputs for the function as follows:
-     * @param {Vec2} [opts.halfExtents] - The half dimensions of the plane in the X and Z axes
-     * (defaults to [0.5, 0.5]).
-     * @param {number} [opts.widthSegments] - The number of divisions along the X axis of the plane
-     * (defaults to 5).
-     * @param {number} [opts.lengthSegments] - The number of divisions along the Z axis of the plane
-     * (defaults to 5).
-     * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
+     * @param {object} [opts] - Options object.
+     * @param {Vec2} [opts.halfExtents] - The half dimensions of the plane in the X and Z axes.
+     * Defaults to [0.5, 0.5].
+     * @param {number} [opts.widthSegments] - The number of divisions along the X axis of the plane.
+     * Defaults to 5.
+     * @param {number} [opts.lengthSegments] - The number of divisions along the Z axis of the plane.
+     * Defaults to 5.
+     * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
+     * @example
+     * const geometry = new pc.PlaneGeometry({
+     *     halfExtents: new pc.Vec2(1, 1),
+     *     widthSegments: 10,
+     *     lengthSegments: 10
+     * });
      */
     constructor(opts = {}) {
         super();

--- a/src/scene/geometry/sphere-geometry.js
+++ b/src/scene/geometry/sphere-geometry.js
@@ -4,11 +4,13 @@ import { Geometry } from './geometry.js';
 /**
  * A procedural sphere-shaped geometry.
  *
- * The size and tesselation properties of the sphere can be controlled via constructor parameters. By
- * default, the function will create a sphere centered on the object space origin with a radius of
- * 0.5 and 16 segments in both longitude and latitude.
+ * Typically, you would:
  *
- * Note that the sphere is created with UVs in the range of 0 to 1.
+ * 1. Create a SphereGeometry instance.
+ * 2. Generate a {@link Mesh} from the geometry.
+ * 3. Create a {@link MeshInstance} referencing the mesh.
+ * 4. Create an {@link Entity} with a {@link RenderComponent} and assign the {@link MeshInstance} to it.
+ * 5. Add the entity to the {@link Scene}.
  *
  * ```javascript
  * // Create a mesh instance
@@ -32,6 +34,10 @@ import { Geometry } from './geometry.js';
 class SphereGeometry extends Geometry {
     /**
      * Create a new SphereGeometry instance.
+     *
+     * By default, the constructor creates a sphere centered on the object space origin with a radius
+     * of 0.5 and 16 segments in both longitude and latitude. The sphere is created with UVs in the
+     * range of 0 to 1.
      *
      * @param {object} [opts] - Options object.
      * @param {number} [opts.radius] - The radius of the sphere. Defaults to 0.5.

--- a/src/scene/geometry/sphere-geometry.js
+++ b/src/scene/geometry/sphere-geometry.js
@@ -10,19 +10,42 @@ import { Geometry } from './geometry.js';
  *
  * Note that the sphere is created with UVs in the range of 0 to 1.
  *
+ * ```javascript
+ * // Create a mesh instance
+ * const geometry = new pc.SphereGeometry();
+ * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new pc.StandardMaterial();
+ * const meshInstance = new pc.MeshInstance(mesh, material);
+ *
+ * // Create an entity
+ * const entity = new pc.Entity();
+ * entity.addComponent('render', {
+ *     meshInstances: [meshInstance]
+ * });
+ *
+ * // Add the entity to the scene hierarchy
+ * app.scene.root.addChild(entity);
+ * ```
+ *
  * @category Graphics
  */
 class SphereGeometry extends Geometry {
     /**
      * Create a new SphereGeometry instance.
      *
-     * @param {object} [opts] - An object that specifies optional inputs for the function as follows:
-     * @param {number} [opts.radius] - The radius of the sphere (defaults to 0.5).
-     * @param {number} [opts.latitudeBands] - The number of divisions along the latitudinal axis of the
-     * sphere (defaults to 16).
+     * @param {object} [opts] - Options object. 
+     * @param {number} [opts.radius] - The radius of the sphere. Defaults to 0.5.
+     * @param {number} [opts.latitudeBands] - The number of divisions along the latitudinal axis of
+     * the sphere. Defaults to 16.
      * @param {number} [opts.longitudeBands] - The number of divisions along the longitudinal axis of
-     * the sphere (defaults to 16).
-     * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
+     * the sphere. Defaults to 16.
+     * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
+     * @example
+     * const geometry = new pc.SphereGeometry({
+     *     radius: 1,
+     *     latitudeBands: 32,
+     *     longitudeBands: 32
+     * });
      */
     constructor(opts = {}) {
         super();

--- a/src/scene/geometry/sphere-geometry.js
+++ b/src/scene/geometry/sphere-geometry.js
@@ -33,7 +33,7 @@ class SphereGeometry extends Geometry {
     /**
      * Create a new SphereGeometry instance.
      *
-     * @param {object} [opts] - Options object. 
+     * @param {object} [opts] - Options object.
      * @param {number} [opts.radius] - The radius of the sphere. Defaults to 0.5.
      * @param {number} [opts.latitudeBands] - The number of divisions along the latitudinal axis of
      * the sphere. Defaults to 16.

--- a/src/scene/geometry/torus-geometry.js
+++ b/src/scene/geometry/torus-geometry.js
@@ -11,24 +11,49 @@ import { Geometry } from './geometry.js';
  *
  * Note that the torus is created with UVs in the range of 0 to 1.
  *
+ * ```javascript
+ * // Create a mesh instance
+ * const geometry = new pc.TorusGeometry();
+ * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new pc.StandardMaterial();
+ * const meshInstance = new pc.MeshInstance(mesh, material);
+ *
+ * // Create an entity
+ * const entity = new pc.Entity();
+ * entity.addComponent('render', {
+ *     meshInstances: [meshInstance]
+ * });
+ *
+ * // Add the entity to the scene hierarchy
+ * app.scene.root.addChild(entity);
+ * ```
+ *
  * @category Graphics
  */
 class TorusGeometry extends Geometry {
     /**
      * Create a new TorusGeometry instance.
      *
-     * @param {object} [opts] - An object that specifies optional inputs for the function as follows:
-     * @param {number} [opts.tubeRadius] - The radius of the tube forming the body of the torus
-     * (defaults to 0.2).
+     * @param {object} [opts] - Options object.
+     * @param {number} [opts.tubeRadius] - The radius of the tube forming the body of the torus.
+     * Defaults to 0.2.
      * @param {number} [opts.ringRadius] - The radius from the centre of the torus to the centre of the
-     * tube (defaults to 0.3).
-     * @param {number} [opts.sectorAngle] - The sector angle in degrees of the ring of the torus
-     * (defaults to 2 * Math.PI).
+     * tube. Defaults to 0.3.
+     * @param {number} [opts.sectorAngle] - The sector angle in degrees of the ring of the torus.
+     * Defaults to 2 * Math.PI.
      * @param {number} [opts.segments] - The number of radial divisions forming cross-sections of the
-     * torus ring (defaults to 20).
-     * @param {number} [opts.sides] - The number of divisions around the tubular body of the torus ring
-     * (defaults to 30).
-     * @param {boolean} [opts.calculateTangents] - Generate tangent information (defaults to false).
+     * torus ring. Defaults to 20.
+     * @param {number} [opts.sides] - The number of divisions around the tubular body of the torus ring.
+     * Defaults to 30.
+     * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
+     * @example
+     * const geometry = new pc.TorusGeometry({
+     *     tubeRadius: 1,
+     *     ringRadius: 2,
+     *     sectorAngle: 360,
+     *     segments: 30,
+     *     sides: 20
+     * });
      */
     constructor(opts = {}) {
         super();

--- a/src/scene/geometry/torus-geometry.js
+++ b/src/scene/geometry/torus-geometry.js
@@ -5,11 +5,13 @@ import { Geometry } from './geometry.js';
 /**
  * A procedural torus-shaped geometry.
  *
- * The size, shape and tesselation properties of the torus can be controlled via constructor
- * parameters. By default, the function will create a torus in the XZ-plane with a tube radius of
- * 0.2, a ring radius of 0.3, 30 segments and 20 sides.
+ * Typically, you would:
  *
- * Note that the torus is created with UVs in the range of 0 to 1.
+ * 1. Create a TorusGeometry instance.
+ * 2. Generate a {@link Mesh} from the geometry.
+ * 3. Create a {@link MeshInstance} referencing the mesh.
+ * 4. Create an {@link Entity} with a {@link RenderComponent} and assign the {@link MeshInstance} to it.
+ * 5. Add the entity to the {@link Scene}.
  *
  * ```javascript
  * // Create a mesh instance
@@ -33,6 +35,9 @@ import { Geometry } from './geometry.js';
 class TorusGeometry extends Geometry {
     /**
      * Create a new TorusGeometry instance.
+     *
+     * By default, the constructor creates a torus in the XZ-plane with a tube radius of 0.2, a ring
+     * radius of 0.3, 30 segments and 20 sides. The torus is created with UVs in the range of 0 to 1.
      *
      * @param {object} [opts] - Options object.
      * @param {number} [opts.tubeRadius] - The radius of the tube forming the body of the torus.


### PR DESCRIPTION
* Expose `ConeBaseGeometry` to the docs which allows the full class hierarchy to be shown.
* Add sample code showing how to fully instantiate geometries.
* Small tweaks to docs.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
