### PR TITLE
Misc types fixes

### DIFF
--- a/src/core/string.js
+++ b/src/core/string.js
@@ -224,7 +224,7 @@ const string = {
      * @ignore
      */
     fromCodePoint(...args) {
-        return args.map(codePoint => {
+        return args.map((codePoint) => {
             if (codePoint > 0xFFFF) {
                 codePoint -= 0x10000;
                 return String.fromCharCode(

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -222,13 +222,13 @@ const string = {
      * @param {...number} args - The code points to convert to a string.
      * @returns {string} The converted string.
      */
-    fromCodePoint(/* ...args */) {
+    fromCodePoint(...args) {
         const chars = [];
         let current;
         let codePoint;
         let units;
-        for (let i = 0; i < arguments.length; ++i) {
-            current = Number(arguments[i]);
+        for (let i = 0; i < args.length; ++i) {
+            current = Number(args[i]);
             codePoint = current - 0x10000;
             units = current > 0xFFFF ? [(codePoint >> 10) + 0xD800, (codePoint % 0x400) + 0xDC00] : [current];
             chars.push(String.fromCharCode.apply(null, units));

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -223,17 +223,16 @@ const string = {
      * @returns {string} The converted string.
      */
     fromCodePoint(...args) {
-        const chars = [];
-        let current;
-        let codePoint;
-        let units;
-        for (let i = 0; i < args.length; ++i) {
-            current = Number(args[i]);
-            codePoint = current - 0x10000;
-            units = current > 0xFFFF ? [(codePoint >> 10) + 0xD800, (codePoint % 0x400) + 0xDC00] : [current];
-            chars.push(String.fromCharCode.apply(null, units));
-        }
-        return chars.join('');
+        return args.map(codePoint => {
+            if (codePoint > 0xFFFF) {
+                codePoint -= 0x10000;
+                return String.fromCharCode(
+                    (codePoint >> 10) + 0xD800,
+                    (codePoint % 0x400) + 0xDC00
+                );
+            }
+            return String.fromCharCode(codePoint);
+        }).join('');
     }
 };
 

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -221,6 +221,7 @@ const string = {
      *
      * @param {...number} args - The code points to convert to a string.
      * @returns {string} The converted string.
+     * @ignore
      */
     fromCodePoint(...args) {
         return args.map(codePoint => {

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -601,8 +601,6 @@ class ScrollViewComponent extends Component {
 
     /**
      * @param {string} onOrOff - 'on' or 'off'.
-     * @param {ScrollViewComponentSystem} system - The ComponentSystem that
-     * created this Component.
      * @private
      */
     _toggleLifecycleListeners(onOrOff) {

--- a/test/core/string.test.mjs
+++ b/test/core/string.test.mjs
@@ -42,4 +42,36 @@ describe('string', function () {
 
     });
 
+    describe.only('#fromCodePoint', function () {
+        it('converts basic ASCII code points to characters', function () {
+            expect(string.fromCodePoint(65)).to.equal('A');
+            expect(string.fromCodePoint(66, 67)).to.equal('BC');
+            expect(string.fromCodePoint(97, 98, 99)).to.equal('abc');
+        });
+
+        it('handles code points beyond the BMP (Basic Multilingual Plane)', function () {
+            // Emoji: 😀 (U+1F600 GRINNING FACE)
+            expect(string.fromCodePoint(0x1F600)).to.equal('😀');
+            
+            // Musical note: 𝄞 (U+1D11E MUSICAL SYMBOL G CLEF)
+            expect(string.fromCodePoint(0x1D11E)).to.equal('𝄞');
+        });
+
+        it('handles multiple code points including surrogate pairs', function () {
+            // Mix of BMP and astral code points
+            expect(string.fromCodePoint(65, 0x1F600, 66)).to.equal('A😀B');
+            
+            // Multiple astral code points: 💩 (U+1F4A9) and 🚀 (U+1F680)
+            expect(string.fromCodePoint(0x1F4A9, 0x1F680)).to.equal('💩🚀');
+        });
+        
+        it('matches native String.fromCodePoint behavior', function () {
+            // Only run if native method is available
+            if (String.fromCodePoint) {
+                const testPoints = [65, 0x1F600, 0x1D11E, 0x10437];
+                expect(string.fromCodePoint(...testPoints)).to.equal(String.fromCodePoint(...testPoints));
+            }
+        });
+    });
+
 });

--- a/test/core/string.test.mjs
+++ b/test/core/string.test.mjs
@@ -52,7 +52,7 @@ describe('string', function () {
         it('handles code points beyond the BMP (Basic Multilingual Plane)', function () {
             // Emoji: 😀 (U+1F600 GRINNING FACE)
             expect(string.fromCodePoint(0x1F600)).to.equal('😀');
-            
+
             // Musical note: 𝄞 (U+1D11E MUSICAL SYMBOL G CLEF)
             expect(string.fromCodePoint(0x1D11E)).to.equal('𝄞');
         });
@@ -60,11 +60,11 @@ describe('string', function () {
         it('handles multiple code points including surrogate pairs', function () {
             // Mix of BMP and astral code points
             expect(string.fromCodePoint(65, 0x1F600, 66)).to.equal('A😀B');
-            
+
             // Multiple astral code points: 💩 (U+1F4A9) and 🚀 (U+1F680)
             expect(string.fromCodePoint(0x1F4A9, 0x1F680)).to.equal('💩🚀');
         });
-        
+
         it('matches native String.fromCodePoint behavior', function () {
             // Only run if native method is available
             if (String.fromCodePoint) {


### PR DESCRIPTION
* Remove `string.fromCodePoint` from public API. It's just a polyfill for the now well-supported `String.fromCodePoint` and should be considered just for internal use.

Fixes #7616

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
