### PR TITLE
Improve SoundSlot API docs

### DIFF
--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -30,9 +30,11 @@ const instanceOptions = {
 };
 
 /**
- * The SoundSlot controls playback of an audio asset. A {@link SoundComponent} can have multiple
- * slots that can be queried via {@link SoundComponent#slot}.
+ * The SoundSlot controls the playback of {@link SoundInstance}s. SoundSlots are managed by
+ * {@link SoundComponent}s. To add and remove SoundSlots on a SoundComponent, use
+ * {@link SoundComponent#addSlot} and {@link SoundComponent#removeSlot} respectively.
  *
+ * @hideconstructor
  * @category Sound
  */
 class SoundSlot extends EventHandler {
@@ -113,8 +115,7 @@ class SoundSlot extends EventHandler {
     /**
      * Create a new SoundSlot.
      *
-     * @param {SoundComponent} component - The Component that created this
-     * slot.
+     * @param {SoundComponent} component - The Component that created this slot.
      * @param {string} [name] - The name of the slot. Defaults to 'Untitled'.
      * @param {object} [options] - Settings for the slot.
      * @param {number} [options.volume] - The playback volume, between 0 and 1.
@@ -164,7 +165,7 @@ class SoundSlot extends EventHandler {
     }
 
     /**
-     * Plays a sound. If {@link SoundSlot#overlap} is true the new sound instance will be played
+     * Plays a sound. If {@link overlap} is true the new sound instance will be played
      * independently of any other instances already playing. Otherwise existing sound instances
      * will stop before playing the new sound.
      *
@@ -207,7 +208,7 @@ class SoundSlot extends EventHandler {
     }
 
     /**
-     * Pauses all sound instances. To continue playback call {@link SoundSlot#resume}.
+     * Pauses all sound instances. To continue playback call {@link resume}.
      *
      * @returns {boolean} True if the sound instances paused successfully, false otherwise.
      */
@@ -339,7 +340,7 @@ class SoundSlot extends EventHandler {
     }
 
     /**
-     * Clears any external nodes set by {@link SoundSlot#setExternalNodes}.
+     * Clears any external nodes set by {@link setExternalNodes}.
      */
     clearExternalNodes() {
         this._firstNode = null;
@@ -355,10 +356,10 @@ class SoundSlot extends EventHandler {
     }
 
     /**
-     * Gets an array that contains the two external nodes set by {@link SoundSlot#setExternalNodes}.
+     * Gets an array that contains the two external nodes set by {@link setExternalNodes}.
      *
      * @returns {AudioNode[]} An array of 2 elements that contains the first and last nodes set by
-     * {@link SoundSlot#setExternalNodes}.
+     * {@link setExternalNodes}.
      */
     getExternalNodes() {
         return [this._firstNode, this._lastNode];


### PR DESCRIPTION
* Hide `SoundSlot` constructor since `SoundComponent#addSlot` should be used instead.
* No need to specify link class when inside that class.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
