### PR TITLE
[Fix] More flexible Preprocessor handling of include directive

### DIFF
--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -37,7 +37,8 @@ const COMPARISON = /([a-z_]\w*)\s*(==|!=|<|<=|>|>=)\s*([\w"']+)/i;
 const INVALID = /[+\-]/g;
 
 // #include "identifier" or optional second identifier #include "identifier1, identifier2"
-const INCLUDE = /include[ \t]+"([\w-]+)(?:\s*,\s*([\w-]+))?"\r?(?:\n|$)/g;
+// Matches only up to the closing quote of the include directive
+const INCLUDE = /include[ \t]+"([\w-]+)(?:\s*,\s*([\w-]+))?"/g;
 
 // loop index to replace, in the format {i}
 const LOOP_INDEX = /\{i\}/g;


### PR DESCRIPTION
Before, the include directive had to have end of line directly after closing quote, so this would work: 
```
#include "endPS"
```
, but this would not 
```
#include "endPS"  // comment
```

This PR updates regex to stop matching at the closing quite.