### PR TITLE
Strip comments from the chunk before the validation

### DIFF
--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -89,7 +89,9 @@ class ShaderGeneratorStandard extends ShaderGenerator {
 
     _validateMapChunk(propName, chunkName, chunks) {
         Debug.call(() => {
-            const code = chunks[chunkName];
+            // strip comments from the chunk
+            const code = chunks[chunkName].replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, '$1');
+
             const requiredChangeStrings = [];
 
             // Helper function to add a formatted change string if the old syntax is found


### PR DESCRIPTION
Validation, which executes in debug mode only, strips comments from the shader chunk before the validation, to avoid triggering errors on commented out shader code.