### PR TITLE
Add missing docs for SoundSlot.EVENT_END

### DIFF
--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -87,6 +87,18 @@ class SoundSlot extends EventHandler {
     static EVENT_STOP = 'stop';
 
     /**
+     * Fired when a sound instance stops playing because it reached its end. The handler is passed
+     * the {@link SoundInstance} that ended.
+     *
+     * @event
+     * @example
+     * slot.on('end', (instance) => {
+     *     console.log('Sound instance playback ended');
+     * });
+     */
+    static EVENT_END = 'end';
+
+    /**
      * Fired when the sound {@link Asset} assigned to the slot is loaded. The handler is passed the
      * loaded {@link Sound} resource.
      *


### PR DESCRIPTION
It seems `EVENT_END` was documented on the `SoundComponent` but not `SoundSlot`.

Fixes #5076 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
