### PR TITLE
Update SWC options to target ES5 for UMD builds

### DIFF
--- a/utils/rollup-swc-options.mjs
+++ b/utils/rollup-swc-options.mjs
@@ -13,6 +13,7 @@ function swcOptions(isDebug, isUMD, minify) {
     return {
         minify,
         jsc: {
+            target: isUMD ? 'es5' : 'es2022',
             minify: {
                 format: {
                     comments: !isDebug || minify ? false : 'all'
@@ -25,9 +26,6 @@ function swcOptions(isDebug, isUMD, minify) {
             },
             externalHelpers: false,
             loose: true
-        },
-        env: {
-            targets: isUMD ? 'fully supports webgl and > 0.1% and not dead' : 'supports es6-module'
         }
     };
 


### PR DESCRIPTION
The UMD build targeting `fully supports webgl and > 0.1% and not dead` was not wide enough to lower es6 `class X {}` syntax  to es5 `function X(){}`. This meant that super calls such as `PostEffects.call(this)` in user scripts would fail.

This PR ensures UMD build lowers to pseudo classes.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
