### PR TITLE
[Fix] Fixes tags for assets

### DIFF
--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -193,7 +193,7 @@ class AssetRegistry extends EventHandler {
      *
      * @private
      */
-    _tags = new TagsCache('_id');
+    _tags = new TagsCache('id');
 
     /**
      * A URL prefix that will be added to all asset loading requests.


### PR DESCRIPTION
The Asset class had both `id` and `_id` members, and in https://github.com/playcanvas/engine/pull/7517 the `_id` had been removed. 

Unfortunately the tags class still used it, and tagging stoped working. This makes tags use `id`.

