### PR TITLE
[Fix] UV-coordinates debug rendering fix

### DIFF
--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -318,7 +318,7 @@ class LitShader {
 
         // generate varyings code
         varyings.forEach((type, name) => {
-            vDefines.set(`VARYING_${name.toUpperCase()}`, true);
+            this.varyingsCode += `#define VARYING_${name.toUpperCase()}\n`;
             this.varyingsCode += this.shaderLanguage === SHADERLANGUAGE_WGSL ?
                 `varying ${name}: ${varyingsWGSLTypes.get(type)};\n` :
                 `varying ${type} ${name};\n`;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/7643

- make sure the varying defines exist in both vertex and fragment shader, not only vertex shader