### PR TITLE
Particle system internal shaders use WGSL

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -282,6 +282,25 @@ class ResourceLine {
             shader.failed = true;
         }
     }
+
+    equals(other) {
+        if (this.name !== other.name) return false;
+        if (this.type !== other.type) return false;
+        if (this.isTexture !== other.isTexture) return false;
+        if (this.isSampler !== other.isSampler) return false;
+        if (this.isStorageTexture !== other.isStorageTexture) return false;
+        if (this.isStorageBuffer !== other.isStorageBuffer) return false;
+        if (this.isExternalTexture !== other.isExternalTexture) return false;
+        if (this.textureFormat !== other.textureFormat) return false;
+        if (this.textureDimension !== other.textureDimension) return false;
+        if (this.sampleType !== other.sampleType) return false;
+        if (this.textureType !== other.textureType) return false;
+        if (this.format !== other.format) return false;
+        if (this.access !== other.access) return false;
+        if (this.accessMode !== other.accessMode) return false;
+        if (this.samplerType !== other.samplerType) return false;
+        return true;
+    }
 }
 
 /**
@@ -340,9 +359,7 @@ class WebgpuShaderProcessorWGSL {
         fragmentExtracted.src = WebgpuShaderProcessorWGSL.renameUniformAccess(fragmentExtracted.src, parsedUniforms);
 
         // parse resource lines
-        const concatResources = vertexExtracted.resources.concat(fragmentExtracted.resources);
-        const resources = Array.from(new Set(concatResources));
-        const parsedResources = resources.map(line => new ResourceLine(line, shader));
+        const parsedResources = WebgpuShaderProcessorWGSL.mergeResources(vertexExtracted.resources, fragmentExtracted.resources, shader);
         const resourcesData = WebgpuShaderProcessorWGSL.processResources(device, parsedResources, shaderDefinition.processingOptions, shader);
 
         // generate fragment output struct
@@ -506,6 +523,34 @@ class WebgpuShaderProcessorWGSL {
             source = source.replace(regex, dstName);
         });
         return source;
+    }
+
+    static mergeResources(vertex, fragment, shader) {
+
+        const resources = vertex.map(line => new ResourceLine(line, shader));
+        const fragmentResources = fragment.map(line => new ResourceLine(line, shader));
+
+        // merge fragment list to resources, removing exact duplicates
+        fragmentResources.forEach((fragmentResource) => {
+            const existing = resources.find(resource => resource.name === fragmentResource.name);
+            if (existing) {
+                // if the resource is already in the list, check if it matches
+                if (!existing.equals(fragmentResource)) {
+                    Debug.error(`Resource '${fragmentResource.name}' is declared with different types in vertex and fragment shaders.`, {
+                        vertexLine: existing.line,
+                        fragmentLine: fragmentResource.line,
+                        shader,
+                        vertexResource: existing,
+                        fragmentResource
+                    });
+                    shader.failed = true;
+                }
+            } else {
+                resources.push(fragmentResource);
+            }
+        });
+
+        return resources;
     }
 
     static processResources(device, resources, processingOptions, shader) {
@@ -810,7 +855,7 @@ class WebgpuShaderProcessorWGSL {
                 // copy input variable to the private variable - convert type if needed
                 blockCopy += `    ${name} = ${originalType}(input.${name});\n`;
             } else {
-                Debug.error(`Attribute ${name} is not defined in the shader definition.`, shaderDefinitionAttributes);
+                Debug.error(`Attribute ${name} is specified in the shader source, but is not defined in the shader definition, and so will be removed from the shader, as it cannot be used without a known semantic.`, shaderDefinitionAttributes);
             }
         });
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -1174,7 +1174,6 @@ function _defineMaterialProps() {
     _defineFlag('fresnelModel', FRESNEL_SCHLICK); // NOTE: this has been made to match the default shading model (to fix a bug)
     _defineFlag('useDynamicRefraction', false);
     _defineFlag('cubeMapProjection', CUBEPROJ_NONE);
-    _defineFlag('customFragmentShader', null);
     _defineFlag('useFog', true);
     _defineFlag('useLighting', true);
     _defineFlag('useTonemap', true);

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -940,7 +940,7 @@ class ParticleEmitter {
             // GPU: XYZ = quad vertex position; W = INT: particle ID, FRAC: random factor
             elements.push({ semantic: SEMANTIC_ATTR0, components: 4, type: TYPE_FLOAT32 });
             if (this.useMesh) {
-                elements.push({ semantic: SEMANTIC_ATTR1,components: 2, type: TYPE_FLOAT32 });
+                elements.push({ semantic: SEMANTIC_ATTR1, components: 2, type: TYPE_FLOAT32 });
             }
         } else {
             elements.push(

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -20,7 +20,10 @@ import {
     TYPE_FLOAT32,
     typedArrayIndexFormats,
     requiresManualGamma,
-    PIXELFORMAT_SRGBA8
+    PIXELFORMAT_SRGBA8,
+    SHADERLANGUAGE_WGSL,
+    SHADERLANGUAGE_GLSL,
+    SEMANTIC_POSITION
 } from '../../platform/graphics/constants.js';
 import { DeviceCache } from '../../platform/graphics/device-cache.js';
 import { IndexBuffer } from '../../platform/graphics/index-buffer.js';
@@ -40,6 +43,7 @@ import { Mesh } from '../mesh.js';
 import { MeshInstance } from '../mesh-instance.js';
 import { createShaderFromCode } from '../shader-lib/utils.js';
 import { shaderChunks } from '../shader-lib/chunks/chunks.js';
+import { shaderChunksWGSL } from '../shader-lib/chunks-wgsl/chunks-wgsl.js';
 import { ParticleCPUUpdater } from './cpu-updater.js';
 import { ParticleGPUUpdater } from './gpu-updater.js';
 import { ParticleMaterial } from './particle-material.js';
@@ -662,27 +666,38 @@ class ParticleEmitter {
         if (this.pack8) defines.set('PACK8', '');
         if (this.emitterShape === EMITTERSHAPE_BOX) defines.set('EMITTERSHAPE_BOX', '');
 
-        const includes = new Map(Object.entries(shaderChunks));
+        const shaderLanguage = gd.isWebGPU ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL;
+        const chunks = shaderLanguage === SHADERLANGUAGE_WGSL ? shaderChunksWGSL : shaderChunks;
+        const includes = new Map(Object.entries(chunks));
 
-        const shaderCodeRespawn = `#define RESPAWN\n ${shaderChunks.particle_simulationPS}`;
-        const shaderCodeNoRespawn = `#define NO_RESPAWN\n ${shaderChunks.particle_simulationPS}`;
-        const shaderCodeOnStop = `#define ON_STOP\n ${shaderChunks.particle_simulationPS}`;
+        const shaderCodeRespawn = `#define RESPAWN\n ${chunks.particle_simulationPS}`;
+        const shaderCodeNoRespawn = `#define NO_RESPAWN\n ${chunks.particle_simulationPS}`;
+        const shaderCodeOnStop = `#define ON_STOP\n ${chunks.particle_simulationPS}`;
 
         // Note: createShaderFromCode can return a shader from the cache (not a new shader) so we *should not* delete these shaders
         // when the particle emitter is destroyed
         const params = `Shape:${this.emitterShape}-Pack:${this.pack8}-Local:${this.localSpace}`;
-        this.shaderParticleUpdateRespawn = createShaderFromCode(gd, shaderChunks.fullscreenQuadVS, shaderCodeRespawn, `ParticleUpdateRespawn-${params}`, undefined, false, {
-            fragmentDefines: defines,
-            fragmentIncludes: includes
-        });
-        this.shaderParticleUpdateNoRespawn = createShaderFromCode(gd, shaderChunks.fullscreenQuadVS, shaderCodeNoRespawn, `ParticleUpdateNoRespawn-${params}`, undefined, false, {
-            fragmentDefines: defines,
-            fragmentIncludes: includes
-        });
-        this.shaderParticleUpdateOnStop = createShaderFromCode(gd, shaderChunks.fullscreenQuadVS, shaderCodeOnStop, `ParticleUpdateStop-${params}`, undefined, false, {
-            fragmentDefines: defines,
-            fragmentIncludes: includes
-        });
+        this.shaderParticleUpdateRespawn = createShaderFromCode(gd, chunks.fullscreenQuadVS, shaderCodeRespawn, `ParticleUpdateRespawn-${params}`,
+            { vertex_position: SEMANTIC_POSITION }, {
+                fragmentDefines: defines,
+                fragmentIncludes: includes,
+                shaderLanguage: shaderLanguage
+            }
+        );
+        this.shaderParticleUpdateNoRespawn = createShaderFromCode(gd, chunks.fullscreenQuadVS, shaderCodeNoRespawn, `ParticleUpdateNoRespawn-${params}`,
+            { vertex_position: SEMANTIC_POSITION }, {
+                fragmentDefines: defines,
+                fragmentIncludes: includes,
+                shaderLanguage: shaderLanguage
+            }
+        );
+        this.shaderParticleUpdateOnStop = createShaderFromCode(gd, chunks.fullscreenQuadVS, shaderCodeOnStop, `ParticleUpdateStop-${params}`,
+            { vertex_position: SEMANTIC_POSITION }, {
+                fragmentDefines: defines,
+                fragmentIncludes: includes,
+                shaderLanguage: shaderLanguage
+            }
+        );
 
         this.numParticleVerts = this.useMesh ? this.mesh.vertexBuffer.numVertices : 4;
         this.numParticleIndices = this.useMesh ? this.mesh.indexBuffer[0].numIndices : 6;
@@ -919,6 +934,27 @@ class ParticleEmitter {
         this.material.setParameter('faceBinorm', binormal);
     }
 
+    getVertexInfo() {
+        const elements = [];
+        if (!this.useCpu) {
+            // GPU: XYZ = quad vertex position; W = INT: particle ID, FRAC: random factor
+            elements.push({ semantic: SEMANTIC_ATTR0, components: 4, type: TYPE_FLOAT32 });
+            if (this.useMesh) {
+                elements.push({ semantic: SEMANTIC_ATTR1,components: 2, type: TYPE_FLOAT32 });
+            }
+        } else {
+            elements.push(
+                { semantic: SEMANTIC_ATTR0, components: 4, type: TYPE_FLOAT32 },
+                { semantic: SEMANTIC_ATTR1, components: 4, type: TYPE_FLOAT32 },
+                { semantic: SEMANTIC_ATTR2, components: 4, type: TYPE_FLOAT32 },
+                { semantic: SEMANTIC_ATTR3, components: 1, type: TYPE_FLOAT32 },
+                { semantic: SEMANTIC_ATTR4, components: this.useMesh ? 4 : 2, type: TYPE_FLOAT32 }
+            );
+        }
+
+        return elements;
+    }
+
     // Declares vertex format, creates VB and IB
     _allocate(numParticles) {
         const psysVertCount = numParticles * this.numParticleVerts;
@@ -926,45 +962,7 @@ class ParticleEmitter {
 
         if ((this.vertexBuffer === undefined) || (this.vertexBuffer.getNumVertices() !== psysVertCount)) {
             // Create the particle vertex format
-            const elements = [];
-            if (!this.useCpu) {
-                // GPU: XYZ = quad vertex position; W = INT: particle ID, FRAC: random factor
-                elements.push({
-                    semantic: SEMANTIC_ATTR0,
-                    components: 4,
-                    type: TYPE_FLOAT32
-                });
-                if (this.useMesh) {
-                    elements.push({
-                        semantic: SEMANTIC_ATTR1,
-                        components: 2,
-                        type: TYPE_FLOAT32
-                    });
-                }
-            } else {
-                elements.push({
-                    semantic: SEMANTIC_ATTR0,
-                    components: 4,
-                    type: TYPE_FLOAT32
-                }, {
-                    semantic: SEMANTIC_ATTR1,
-                    components: 4,
-                    type: TYPE_FLOAT32
-                }, {
-                    semantic: SEMANTIC_ATTR2,
-                    components: 4,
-                    type: TYPE_FLOAT32
-                }, {
-                    semantic: SEMANTIC_ATTR3,
-                    components: 1,
-                    type: TYPE_FLOAT32
-                }, {
-                    semantic: SEMANTIC_ATTR4,
-                    components: this.useMesh ? 4 : 2,
-                    type: TYPE_FLOAT32
-                });
-            }
-
+            const elements = this.getVertexInfo();
             const vertexFormat = new VertexFormat(this.graphicsDevice, elements);
 
             this.vertexBuffer = new VertexBuffer(this.graphicsDevice, vertexFormat, psysVertCount, {

--- a/src/scene/particle-system/particle-material.js
+++ b/src/scene/particle-system/particle-material.js
@@ -4,6 +4,7 @@ import {
     GAMMA_NONE,
     PARTICLEORIENTATION_SCREEN,
     SHADER_FORWARD,
+    SHADERDEF_UV0,
     TONEMAP_LINEAR
 } from '../constants.js';
 import { getProgramLibrary } from '../shader-lib/get-program-library.js';
@@ -37,7 +38,7 @@ class ParticleMaterial extends Material {
 
     getShaderVariant(params) {
 
-        const { device, scene, cameraShaderParams } = params;
+        const { device, scene, cameraShaderParams, objDefs } = params;
         const { emitter } = this;
         const options = {
             defines: getCoreDefines(this, params),
@@ -49,6 +50,7 @@ class ParticleMaterial extends Material {
             alignToMotion: this.emitter.alignToMotion,
             soft: this.emitter.depthSoftening,
             mesh: this.emitter.useMesh,
+            meshUv: objDefs & SHADERDEF_UV0,
             gamma: cameraShaderParams?.shaderOutputGamma ?? GAMMA_NONE,
             toneMap: cameraShaderParams?.toneMapping ?? TONEMAP_LINEAR,
             fog: (scene && !this.emitter.noFog) ? scene.fog.type : 'none',

--- a/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
+++ b/src/scene/shader-lib/chunks-wgsl/chunks-wgsl.js
@@ -104,49 +104,49 @@ import outputTex2DPS from './common/frag/outputTex2D.js';
 import sheenPS from './standard/frag/sheen.js';
 import sheenGlossPS from './standard/frag/sheenGloss.js';
 import parallaxPS from './standard/frag/parallax.js';
-// import particlePS from './particle/frag/particle.js';
-// import particleVS from './particle/vert/particle.js';
-// import particleAnimFrameClampVS from './particle/vert/particleAnimFrameClamp.js';
-// import particleAnimFrameLoopVS from './particle/vert/particleAnimFrameLoop.js';
-// import particleAnimTexVS from './particle/vert/particleAnimTex.js';
-// import particleInputFloatPS from './particle/frag/particleInputFloat.js';
-// import particleInputRgba8PS from './particle/frag/particleInputRgba8.js';
-// import particleOutputFloatPS from './particle/frag/particleOutputFloat.js';
-// import particleOutputRgba8PS from './particle/frag/particleOutputRgba8.js';
-// import particleUpdaterAABBPS from './particle/frag/particleUpdaterAABB.js';
-// import particleUpdaterEndPS from './particle/frag/particleUpdaterEnd.js';
-// import particleUpdaterInitPS from './particle/frag/particleUpdaterInit.js';
-// import particleUpdaterNoRespawnPS from './particle/frag/particleUpdaterNoRespawn.js';
-// import particleUpdaterOnStopPS from './particle/frag/particleUpdaterOnStop.js';
-// import particleUpdaterRespawnPS from './particle/frag/particleUpdaterRespawn.js';
-// import particleUpdaterSpherePS from './particle/frag/particleUpdaterSphere.js';
-// import particleUpdaterStartPS from './particle/frag/particleUpdaterStart.js';
-// import particle_billboardVS from './particle/vert/particle_billboard.js';
-// import particle_blendAddPS from './particle/frag/particle_blendAdd.js';
-// import particle_blendMultiplyPS from './particle/frag/particle_blendMultiply.js';
-// import particle_blendNormalPS from './particle/frag/particle_blendNormal.js';
-// import particle_cpuVS from './particle/vert/particle_cpu.js';
-// import particle_cpu_endVS from './particle/vert/particle_cpu_end.js';
-// import particle_customFaceVS from './particle/vert/particle_customFace.js';
-// import particle_endPS from './particle/frag/particle_end.js';
-// import particle_endVS from './particle/vert/particle_end.js';
-// import particle_halflambertPS from './particle/frag/particle_halflambert.js';
-// import particle_initVS from './particle/vert/particle_init.js';
-// import particle_lambertPS from './particle/frag/particle_lambert.js';
-// import particle_lightingPS from './particle/frag/particle_lighting.js';
-// import particle_localShiftVS from './particle/vert/particle_localShift.js';
-// import particle_meshVS from './particle/vert/particle_mesh.js';
-// import particle_normalVS from './particle/vert/particle_normal.js';
-// import particle_normalMapPS from './particle/frag/particle_normalMap.js';
-// import particle_pointAlongVS from './particle/vert/particle_pointAlong.js';
-// import particle_simulationPS from './particle/frag/particle-simulation.js';
-// import particle_shaderPS from './particle/frag/particle-shader.js';
-// import particle_shaderVS from './particle/vert/particle-shader.js';
-// import particle_softPS from './particle/frag/particle_soft.js';
-// import particle_softVS from './particle/vert/particle_soft.js';
-// import particle_stretchVS from './particle/vert/particle_stretch.js';
-// import particle_TBNVS from './particle/vert/particle_TBN.js';
-// import particle_wrapVS from './particle/vert/particle_wrap.js';
+import particlePS from './particle/frag/particle.js';
+import particleVS from './particle/vert/particle.js';
+import particleAnimFrameClampVS from './particle/vert/particleAnimFrameClamp.js';
+import particleAnimFrameLoopVS from './particle/vert/particleAnimFrameLoop.js';
+import particleAnimTexVS from './particle/vert/particleAnimTex.js';
+import particleInputFloatPS from './particle/frag/particleInputFloat.js';
+import particleInputRgba8PS from './particle/frag/particleInputRgba8.js';
+import particleOutputFloatPS from './particle/frag/particleOutputFloat.js';
+import particleOutputRgba8PS from './particle/frag/particleOutputRgba8.js';
+import particleUpdaterAABBPS from './particle/frag/particleUpdaterAABB.js';
+import particleUpdaterEndPS from './particle/frag/particleUpdaterEnd.js';
+import particleUpdaterInitPS from './particle/frag/particleUpdaterInit.js';
+import particleUpdaterNoRespawnPS from './particle/frag/particleUpdaterNoRespawn.js';
+import particleUpdaterOnStopPS from './particle/frag/particleUpdaterOnStop.js';
+import particleUpdaterRespawnPS from './particle/frag/particleUpdaterRespawn.js';
+import particleUpdaterSpherePS from './particle/frag/particleUpdaterSphere.js';
+import particleUpdaterStartPS from './particle/frag/particleUpdaterStart.js';
+import particle_billboardVS from './particle/vert/particle_billboard.js';
+import particle_blendAddPS from './particle/frag/particle_blendAdd.js';
+import particle_blendMultiplyPS from './particle/frag/particle_blendMultiply.js';
+import particle_blendNormalPS from './particle/frag/particle_blendNormal.js';
+import particle_cpuVS from './particle/vert/particle_cpu.js';
+import particle_cpu_endVS from './particle/vert/particle_cpu_end.js';
+import particle_customFaceVS from './particle/vert/particle_customFace.js';
+import particle_endPS from './particle/frag/particle_end.js';
+import particle_endVS from './particle/vert/particle_end.js';
+import particle_halflambertPS from './particle/frag/particle_halflambert.js';
+import particle_initVS from './particle/vert/particle_init.js';
+import particle_lambertPS from './particle/frag/particle_lambert.js';
+import particle_lightingPS from './particle/frag/particle_lighting.js';
+import particle_localShiftVS from './particle/vert/particle_localShift.js';
+import particle_meshVS from './particle/vert/particle_mesh.js';
+import particle_normalVS from './particle/vert/particle_normal.js';
+import particle_normalMapPS from './particle/frag/particle_normalMap.js';
+import particle_pointAlongVS from './particle/vert/particle_pointAlong.js';
+import particle_simulationPS from './particle/frag/particle-simulation.js';
+import particle_shaderPS from './particle/frag/particle-shader.js';
+import particle_shaderVS from './particle/vert/particle-shader.js';
+import particle_softPS from './particle/frag/particle_soft.js';
+import particle_softVS from './particle/vert/particle_soft.js';
+import particle_stretchVS from './particle/vert/particle_stretch.js';
+import particle_TBNVS from './particle/vert/particle_TBN.js';
+import particle_wrapVS from './particle/vert/particle_wrap.js';
 import pickPS from './common/frag/pick.js';
 import reflDirPS from './lit/frag/reflDir.js';
 import reflDirAnisoPS from './lit/frag/reflDirAniso.js';
@@ -328,49 +328,49 @@ const shaderChunksWGSL = {
     sheenPS,
     sheenGlossPS,
     parallaxPS,
-    // particlePS,
-    // particleVS,
-    // particleAnimFrameClampVS,
-    // particleAnimFrameLoopVS,
-    // particleAnimTexVS,
-    // particleInputFloatPS,
-    // particleInputRgba8PS,
-    // particleOutputFloatPS,
-    // particleOutputRgba8PS,
-    // particleUpdaterAABBPS,
-    // particleUpdaterEndPS,
-    // particleUpdaterInitPS,
-    // particleUpdaterNoRespawnPS,
-    // particleUpdaterOnStopPS,
-    // particleUpdaterRespawnPS,
-    // particleUpdaterSpherePS,
-    // particleUpdaterStartPS,
-    // particle_billboardVS,
-    // particle_blendAddPS,
-    // particle_blendMultiplyPS,
-    // particle_blendNormalPS,
-    // particle_cpuVS,
-    // particle_cpu_endVS,
-    // particle_customFaceVS,
-    // particle_endPS,
-    // particle_endVS,
-    // particle_halflambertPS,
-    // particle_initVS,
-    // particle_lambertPS,
-    // particle_lightingPS,
-    // particle_localShiftVS,
-    // particle_meshVS,
-    // particle_normalVS,
-    // particle_normalMapPS,
-    // particle_pointAlongVS,
-    // particle_simulationPS,
-    // particle_shaderPS,
-    // particle_shaderVS,
-    // particle_softPS,
-    // particle_softVS,
-    // particle_stretchVS,
-    // particle_TBNVS,
-    // particle_wrapVS,
+    particlePS,
+    particleVS,
+    particleAnimFrameClampVS,
+    particleAnimFrameLoopVS,
+    particleAnimTexVS,
+    particleInputFloatPS,
+    particleInputRgba8PS,
+    particleOutputFloatPS,
+    particleOutputRgba8PS,
+    particleUpdaterAABBPS,
+    particleUpdaterEndPS,
+    particleUpdaterInitPS,
+    particleUpdaterNoRespawnPS,
+    particleUpdaterOnStopPS,
+    particleUpdaterRespawnPS,
+    particleUpdaterSpherePS,
+    particleUpdaterStartPS,
+    particle_billboardVS,
+    particle_blendAddPS,
+    particle_blendMultiplyPS,
+    particle_blendNormalPS,
+    particle_cpuVS,
+    particle_cpu_endVS,
+    particle_customFaceVS,
+    particle_endPS,
+    particle_endVS,
+    particle_halflambertPS,
+    particle_initVS,
+    particle_lambertPS,
+    particle_lightingPS,
+    particle_localShiftVS,
+    particle_meshVS,
+    particle_normalVS,
+    particle_normalMapPS,
+    particle_pointAlongVS,
+    particle_simulationPS,
+    particle_shaderPS,
+    particle_shaderVS,
+    particle_softPS,
+    particle_softVS,
+    particle_stretchVS,
+    particle_TBNVS,
+    particle_wrapVS,
     pickPS,
     reflDirPS,
     reflDirAnisoPS,

--- a/src/scene/shader-lib/chunks-wgsl/common/frag/screenDepth.js
+++ b/src/scene/shader-lib/chunks-wgsl/common/frag/screenDepth.js
@@ -1,4 +1,5 @@
 export default /* wgsl */`
+
 var uSceneDepthMap: texture_2d<f32>;
 var uSceneDepthMapSampler: sampler;
 
@@ -61,7 +62,7 @@ fn getLinearScreenDepth(uv: vec2f) -> f32 {
 
 #ifndef VERTEXSHADER
     // Retrieves rendered linear camera depth under the current pixel
-    fn getLinearScreenDepthFragCoord() -> f32 {
+    fn getLinearScreenDepthFrag() -> f32 {
         let uv: vec2f = pcPosition.xy * uniform.uScreenSize.zw;
         return getLinearScreenDepth(uv);
     }

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle-shader.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle-shader.js
@@ -1,0 +1,64 @@
+// The main code of particle system fragment shader used for rendering
+export default /* wgsl */`
+    #if NORMAL != NONE
+        #if NORMAL == VERTEX
+            varying Normal: vec3f;
+        #endif
+
+        #if NORMAL == MAP
+            varying ParticleMat0: vec3f;
+            varying ParticleMat1: vec3f;
+            varying ParticleMat2: vec3f;
+        #endif
+
+        uniform lightCube: array<vec3f, 6>;
+    #endif
+
+    #ifdef SOFT
+        varying vDepth: f32;
+        #include "screenDepthPS"
+    #endif
+
+    #include "gammaPS"
+    #include "tonemappingPS"
+    #include "fogPS"
+
+    #if NORMAL == MAP
+        var normalMap: texture_2d<f32>;
+        var normalMapSampler: sampler;
+    #endif
+
+    #include "particlePS"
+
+    #ifdef SOFT
+        #include "particle_softPS"
+    #endif
+
+    #if NORMAL == VERTEX
+        var normal: vec3f = Normal;
+    #endif
+
+    #if NORMAL == MAP
+        #include "particle_normalMapPS"
+    #endif
+
+    #if NORMAL != NONE
+        #ifdef HALF_LAMBERT
+            #include "particle_halflambertPS"
+        #else
+            #include "particle_lambertPS"
+        #endif
+
+        #include "particle_lightingPS"
+    #endif
+
+    #if BLEND == NORMAL
+        #include "particle_blendNormalPS"
+    #elif BLEND == ADDITIVE
+        #include "particle_blendAddPS"
+    #elif BLEND == MULTIPLICATIVE
+        #include "particle_blendMultiplyPS"
+    #endif
+
+    #include "particle_endPS"
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle-simulation.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle-simulation.js
@@ -1,0 +1,34 @@
+// The main code of particle system fragment shader used for the simulation
+export default /* wgsl */`
+    #include "particleUpdaterInitPS"
+
+    #ifdef PACK8
+        #include "particleInputRgba8PS"
+        #include "particleOutputRgba8PS"
+    #else
+        #include "particleInputFloatPS"
+        #include "particleOutputFloatPS"
+    #endif
+
+    #ifdef EMITTERSHAPE_BOX
+        #include "particleUpdaterAABBPS"
+    #else
+        #include "particleUpdaterSpherePS"
+    #endif
+
+    #include "particleUpdaterStartPS"
+
+    #ifdef RESPAWN
+        #include "particleUpdaterRespawnPS"
+    #endif
+
+    #ifdef NO_RESPAWN
+        #include "particleUpdaterNoRespawnPS"
+    #endif
+
+    #ifdef ON_STOP
+        #include "particleUpdaterOnStopPS"
+    #endif
+
+    #include "particleUpdaterEndPS"
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle.js
@@ -1,0 +1,36 @@
+export default /* wgsl */`
+varying texCoordsAlphaLife: vec4f;
+
+var colorMap: texture_2d<f32>;
+var colorMapSampler: sampler;
+var colorParam: texture_2d<f32>;
+var colorParamSampler: sampler;
+
+uniform graphSampleSize: f32;
+uniform graphNumSamples: f32;
+
+#ifndef CAMERAPLANES
+    #define CAMERAPLANES
+    uniform camera_params: vec4f;
+#endif
+
+uniform softening: f32;
+uniform colorMult: f32;
+
+fn saturate(x: f32) -> f32 {
+    return clamp(x, 0.0, 1.0);
+}
+
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+    var output: FragmentOutput;
+
+    let tex: vec4f  = textureSample(colorMap, colorMapSampler, vec2f(input.texCoordsAlphaLife.x, 1.0 - input.texCoordsAlphaLife.y));
+    var ramp: vec4f = textureSample(colorParam, colorParamSampler, vec2f(input.texCoordsAlphaLife.w, 0.0));
+    ramp = vec4f(ramp.rgb * uniform.colorMult, ramp.a);
+
+    ramp.a = ramp.a + input.texCoordsAlphaLife.z;
+
+    var rgb: vec3f = tex.rgb * ramp.rgb;
+    var a: f32 = tex.a * ramp.a;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleInputFloat.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleInputFloat.js
@@ -1,0 +1,12 @@
+export default /* wgsl */`
+fn readInput(uv: f32) {
+    let tex: vec4f = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.25), 0.0);
+    let tex2: vec4f = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.75), 0.0);
+
+    inPos = tex.xyz;
+    inVel = tex2.xyz;
+    inAngle = abs(tex.w) - 1000.0;
+    inShow = tex.w >= 0.0;
+    inLife = tex2.w;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleInputRgba8.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleInputRgba8.js
@@ -1,0 +1,41 @@
+export default /* wgsl */`
+//RG=X, BA=Y
+//RG=Z, BA=A
+//RGB=V, A=visMode
+//RGBA=life
+
+const PI2: f32 = 6.283185307179586;
+
+uniform inBoundsSize: vec3f;
+uniform inBoundsCenter: vec3f;
+
+uniform maxVel: f32;
+
+fn decodeFloatRG(rg: vec2f) -> f32 {
+    return rg.y * (1.0 / 255.0) + rg.x;
+}
+
+fn decodeFloatRGBA( rgba: vec4f ) -> f32 {
+    return dot(rgba, vec4f(1.0, 1.0 / 255.0, 1.0 / 65025.0, 1.0 / 160581375.0));
+}
+
+fn readInput(uv: f32) {
+    let tex0 = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.125), 0.0);
+    let tex1 = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.375), 0.0);
+    let tex2 = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.625), 0.0);
+    let tex3 = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.875), 0.0);
+
+    inPos = vec3f(decodeFloatRG(tex0.rg), decodeFloatRG(tex0.ba), decodeFloatRG(tex1.rg));
+    inPos = (inPos - vec3f(0.5)) * uniform.inBoundsSize + uniform.inBoundsCenter;
+
+    inVel = tex2.xyz;
+    inVel = (inVel - vec3f(0.5)) * uniform.maxVel;
+
+    inAngle = decodeFloatRG(tex1.ba) * PI2;
+    inShow = tex2.a > 0.5;
+
+    let life_decoded = decodeFloatRGBA(tex3);
+    let maxNegLife = max(uniform.lifetime, (uniform.numParticles - 1.0) * (uniform.rate + uniform.rateDiv));
+    let maxPosLife = uniform.lifetime + 1.0;
+    inLife = life_decoded * (maxNegLife + maxPosLife) - maxNegLife;
+}`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleOutputFloat.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleOutputFloat.js
@@ -1,0 +1,9 @@
+export default /* wgsl */`
+fn getOutput() -> vec4f {
+    if (pcPosition.y < 1.0) {
+        return vec4f(outPos, (outAngle + 1000.0) * visMode);
+    } else {
+        return vec4f(outVel, outLife);
+    }
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleOutputRgba8.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleOutputRgba8.js
@@ -1,0 +1,40 @@
+export default /* wgsl */`
+uniform outBoundsMul: vec3f;
+uniform outBoundsAdd: vec3f;
+
+fn encodeFloatRG( v: f32 ) -> vec2f {
+    var enc: vec2f = vec2f(1.0, 255.0) * v;
+    enc = fract(enc);
+    enc = enc - enc.yy * (1.0 / 255.0);
+    return enc;
+}
+
+fn encodeFloatRGBA( v: f32 ) -> vec4f {
+    let factors = vec4f(1.0, 255.0, 65025.0, 160581375.0);
+    var enc: vec4f = factors * v;
+    enc = fract(enc);
+    enc = enc - enc.yzww * vec4f(1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0, 0.0);
+    return enc;
+}
+
+fn getOutput() -> vec4f {
+    outPos = outPos * uniform.outBoundsMul + uniform.outBoundsAdd;
+    outAngle = fract(outAngle / PI2);
+
+    outVel = (outVel / uniform.maxVel) + vec3f(0.5); // TODO: mul
+
+    let maxNegLife = max(uniform.lifetime, (uniform.numParticles - 1.0) * (uniform.rate + uniform.rateDiv));
+    let maxPosLife = uniform.lifetime + 1.0;
+    outLife = (outLife + maxNegLife) / (maxNegLife + maxPosLife);
+
+    if (pcPosition.y < 1.0) {
+        return vec4f(encodeFloatRG(outPos.x), encodeFloatRG(outPos.y));
+    } else if (pcPosition.y < 2.0) {
+        return vec4f(encodeFloatRG(outPos.z), encodeFloatRG(outAngle));
+    } else if (pcPosition.y < 3.0) {
+        return vec4f(outVel, visMode * 0.5 + 0.5);
+    } else {
+        return encodeFloatRGBA(outLife);
+    }
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterAABB.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterAABB.js
@@ -1,0 +1,28 @@
+export default /* wgsl */`
+uniform spawnBounds: mat3x3f;
+uniform spawnPosInnerRatio: vec3f;
+
+fn calcSpawnPosition(inBounds: vec3f, rndFactor: f32) -> vec3f {
+    var pos = inBounds - vec3f(0.5);
+
+    let posAbs = abs(pos);
+    let maxComp = max(posAbs.x, max(posAbs.y, posAbs.z));
+    let maxPos = vec3f(maxComp);
+
+    let edge = maxPos + (vec3f(0.5) - maxPos) * uniform.spawnPosInnerRatio;
+
+    pos.x = edge.x * select(2.0 * pos.x, sign(pos.x), maxPos.x == posAbs.x);
+    pos.y = edge.y * select(2.0 * pos.y, sign(pos.y), maxPos.y == posAbs.y);
+    pos.z = edge.z * select(2.0 * pos.z, sign(pos.z), maxPos.z == posAbs.z);
+
+    #ifndef LOCAL_SPACE
+        return uniform.emitterPos + uniform.spawnBounds * pos;
+    #else
+        return uniform.spawnBounds * pos;
+    #endif
+}
+
+fn addInitialVelocity(localVelocity: ptr<function, vec3f>, inBounds: vec3f) {
+    *localVelocity = *localVelocity - vec3f(0.0, 0.0, uniform.initialVelocity);
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterEnd.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterEnd.js
@@ -1,0 +1,5 @@
+export default /* wgsl */`
+    output.color = getOutput();
+    return output;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterInit.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterInit.js
@@ -1,0 +1,50 @@
+export default /* wgsl */`
+varying vUv0: vec2f;
+
+var particleTexIN: texture_2d<f32>;
+var particleTexINSampler: sampler;
+var internalTex0: texture_2d<f32>;
+var internalTex0Sampler: sampler;
+var internalTex1: texture_2d<f32>;
+var internalTex1Sampler: sampler;
+var internalTex2: texture_2d<f32>;
+var internalTex2Sampler: sampler;
+var internalTex3: texture_2d<f32>;
+var internalTex3Sampler: sampler;
+
+uniform emitterMatrix: mat3x3f;
+uniform emitterMatrixInv: mat3x3f;
+uniform emitterScale: vec3f;
+
+uniform emitterPos: vec3f;
+uniform frameRandom: vec3f;
+uniform localVelocityDivMult: vec3f;
+uniform velocityDivMult: vec3f;
+uniform delta: f32;
+uniform rate: f32;
+uniform rateDiv: f32;
+uniform lifetime: f32;
+uniform numParticles: f32;
+uniform rotSpeedDivMult: f32;
+uniform radialSpeedDivMult: f32;
+uniform seed: f32;
+uniform startAngle: f32;
+uniform startAngle2: f32;
+uniform initialVelocity: f32;
+
+uniform graphSampleSize: f32;
+uniform graphNumSamples: f32;
+
+var<private> inPos: vec3f;
+var<private> inVel: vec3f;
+var<private> inAngle: f32;
+var<private> inShow: bool;
+var<private> inLife: f32;
+var<private> visMode: f32;
+
+var<private> outPos: vec3f;
+var<private> outVel: vec3f;
+var<private> outAngle: f32;
+var<private> outShow: bool;
+var<private> outLife: f32;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterNoRespawn.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterNoRespawn.js
@@ -1,0 +1,6 @@
+export default /* wgsl */`
+    if (outLife >= uniform.lifetime) {
+        outLife = outLife - max(uniform.lifetime, (uniform.numParticles - 1.0) * particleRate);
+        visMode = -1.0;
+    }
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterOnStop.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterOnStop.js
@@ -1,0 +1,3 @@
+export default /* wgsl */`
+    visMode = select(visMode, -1.0, outLife < 0.0);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterRespawn.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterRespawn.js
@@ -1,0 +1,8 @@
+export default /* wgsl */`
+    if (outLife >= uniform.lifetime) {
+        let subtractAmount = max(uniform.lifetime, (uniform.numParticles - 1.0) * particleRate);
+        outLife = outLife - subtractAmount;
+        visMode = 1.0;
+    }
+    visMode = select(visMode, 1.0, outLife < 0.0);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterSphere.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterSphere.js
@@ -1,0 +1,21 @@
+export default /* wgsl */`
+uniform spawnBoundsSphere: f32;
+uniform spawnBoundsSphereInnerRatio: f32;
+
+fn calcSpawnPosition(inBounds: vec3f, rndFactor: f32) -> vec3f {
+    let rnd4: f32 = fract(rndFactor * 1000.0);
+    let norm: vec3f = normalize(inBounds.xyz - vec3f(0.5));
+    let r: f32 = rnd4 * (1.0 - uniform.spawnBoundsSphereInnerRatio) + uniform.spawnBoundsSphereInnerRatio;
+
+    #ifndef LOCAL_SPACE
+        return uniform.emitterPos + norm * r * uniform.spawnBoundsSphere;
+    #else
+        return norm * r * uniform.spawnBoundsSphere;
+    #endif
+}
+
+fn addInitialVelocity(localVelocity: ptr<function, vec3f>, inBounds: vec3f) {
+    let initialVelOffset: vec3f = normalize(inBounds - vec3f(0.5)) * uniform.initialVelocity;
+    *localVelocity = *localVelocity + initialVelOffset;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterStart.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particleUpdaterStart.js
@@ -1,0 +1,104 @@
+export default /* wgsl */`
+fn saturate(x: f32) -> f32 {
+    return clamp(x, 0.0, 1.0);
+}
+
+fn unpack3NFloats(src: f32) -> vec3f {
+    let r = fract(src);
+    let g = fract(src * 256.0);
+    let b = fract(src * 65536.0);
+    return vec3f(r, g, b);
+}
+
+// Struct to handle multiple return values from tex1Dlod_lerp
+struct TexLerpUnpackResult {
+    result: vec3f,
+    unpacked: vec3f
+}
+
+fn tex1Dlod_lerp(tex: texture_2d<f32>, texSampler: sampler, tc: vec2f) -> TexLerpUnpackResult {
+    let tc_next = tc + vec2f(uniform.graphSampleSize);
+    let a = textureSampleLevel(tex, texSampler, tc, 0.0);
+    let b = textureSampleLevel(tex, texSampler, tc_next, 0.0);
+    let c = fract(tc.x * uniform.graphNumSamples);
+
+    let unpackedA = unpack3NFloats(a.w);
+    let unpackedB = unpack3NFloats(b.w);
+    let w_out = mix(unpackedA, unpackedB, c);
+
+    return TexLerpUnpackResult(mix(a.xyz, b.xyz, c), w_out);
+}
+
+const HASHSCALE4: vec4f = vec4f(1031.0, 0.1030, 0.0973, 0.1099);
+fn hash41(p: f32) -> vec4f {
+    var p4 = fract(vec4f(p) * HASHSCALE4);
+    p4 = p4 + dot(p4, p4.wzxy + 19.19);
+    return fract(vec4f((p4.x + p4.y)*p4.z, (p4.x + p4.z)*p4.y, (p4.y + p4.z)*p4.w, (p4.z + p4.w)*p4.x));
+}
+
+@fragment
+fn fragmentMain(input : FragmentInput) -> FragmentOutput {
+    var output: FragmentOutput;
+
+    if (pcPosition.x > uniform.numParticles) {
+        discard;
+        return output;
+    }
+
+    readInput(input.vUv0.x);
+    visMode = select(-1.0, 1.0, inShow);
+
+    let rndFactor = hash41(pcPosition.x + uniform.seed);
+
+    let particleRate = uniform.rate + uniform.rateDiv * rndFactor.x;
+
+    outLife = inLife + uniform.delta;
+    let nlife = clamp(outLife / uniform.lifetime, 0.0, 1.0);
+
+    let lerpResult0 = tex1Dlod_lerp(internalTex0, internalTex0Sampler, vec2f(nlife, 0.0));
+    var localVelocity = lerpResult0.result;
+    let localVelocityDiv = lerpResult0.unpacked;
+
+    let lerpResult1 = tex1Dlod_lerp(internalTex1, internalTex1Sampler, vec2f(nlife, 0.0));
+    var velocity = lerpResult1.result;
+    let velocityDiv = lerpResult1.unpacked;
+
+    let lerpResult2 = tex1Dlod_lerp(internalTex2, internalTex2Sampler, vec2f(nlife, 0.0));
+    let params = lerpResult2.result;
+    let paramDiv = lerpResult2.unpacked;
+    var rotSpeed = params.x;
+    let rotSpeedDiv = paramDiv.y;
+
+    let lerpResult3 = tex1Dlod_lerp(internalTex3, internalTex3Sampler, vec2f(nlife, 0.0));
+    let radialParams = lerpResult3.result;
+    let radialParamDiv = lerpResult3.unpacked;
+    let radialSpeed = radialParams.x;
+    let radialSpeedDiv = radialParamDiv.y;
+
+    let respawn = inLife <= 0.0 || outLife >= uniform.lifetime;
+    inPos = select(inPos, calcSpawnPosition(rndFactor.xyz, rndFactor.x), respawn);
+    inAngle = select(inAngle, mix(uniform.startAngle, uniform.startAngle2, rndFactor.x), respawn);
+
+    #ifndef LOCAL_SPACE
+        var radialVel: vec3f = inPos - uniform.emitterPos;
+    #else
+        var radialVel: vec3f = inPos;
+    #endif
+    radialVel = select(vec3f(0.0), radialSpeed * normalize(radialVel), dot(radialVel, radialVel) > 1.0E-8);
+    radialVel = radialVel + (radialSpeedDiv * vec3f(2.0) - vec3f(1.0)) * uniform.radialSpeedDivMult * rndFactor.xyz;
+
+    localVelocity = localVelocity + (localVelocityDiv * vec3f(2.0) - vec3f(1.0)) * uniform.localVelocityDivMult * rndFactor.xyz;
+    velocity = velocity + (velocityDiv * vec3f(2.0) - vec3f(1.0)) * uniform.velocityDivMult * rndFactor.xyz;
+    rotSpeed = rotSpeed + (rotSpeedDiv * 2.0 - 1.0) * uniform.rotSpeedDivMult * rndFactor.y;
+
+    addInitialVelocity(&localVelocity, rndFactor.xyz);
+
+    #ifndef LOCAL_SPACE
+        outVel = uniform.emitterMatrix * localVelocity + (radialVel + velocity) * uniform.emitterScale;
+    #else
+        outVel = (localVelocity + radialVel) / uniform.emitterScale + uniform.emitterMatrixInv * velocity;
+    #endif
+
+    outPos = inPos + outVel * uniform.delta;
+    outAngle = inAngle + rotSpeed * uniform.delta;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_blendAdd.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_blendAdd.js
@@ -1,0 +1,7 @@
+export default /* wgsl */`
+    dBlendModeFogFactor = 0.0;
+    rgb = rgb * saturate(gammaCorrectInput(max(a, 0.0)));
+    if ((rgb.r + rgb.g + rgb.b) < 0.000001) {
+        discard;
+    }    
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_blendMultiply.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_blendMultiply.js
@@ -1,0 +1,6 @@
+export default /* wgsl */`
+    rgb = mix(vec3f(1.0), rgb, a);
+    if ((rgb.r + rgb.g + rgb.b) > 2.99) {
+        discard;
+    }
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_blendNormal.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_blendNormal.js
@@ -1,0 +1,5 @@
+export default /* glsl */`
+    if (a < 0.01) {
+        discard;
+    }
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_end.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_end.js
@@ -1,0 +1,8 @@
+export default /* wgsl */`
+    rgb = addFog(rgb);
+    rgb = toneMap(rgb);
+    rgb = gammaCorrectOutput(rgb);
+    output.color = vec4f(rgb, a);
+    return output;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_halflambert.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_halflambert.js
@@ -1,0 +1,6 @@
+export default /* wgsl */`
+    var negNormal: vec3f = normal * 0.5 + 0.5;
+    var posNormal: vec3f = -normal * 0.5 + 0.5;
+    negNormal = negNormal * negNormal;
+    posNormal = posNormal * posNormal;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_lambert.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_lambert.js
@@ -1,0 +1,4 @@
+export default /* wgsl */`
+    var negNormal: vec3f = max(normal, vec3(0.0));
+    var posNormal: vec3f = max(-normal, vec3(0.0));
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_lighting.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_lighting.js
@@ -1,0 +1,7 @@
+export default /* glsl */`
+    let light: vec3f = negNormal.x * uniform.lightCube[0] + posNormal.x * uniform.lightCube[1] +
+                       negNormal.y * uniform.lightCube[2] + posNormal.y * uniform.lightCube[3] +
+                       negNormal.z * uniform.lightCube[4] + posNormal.z * uniform.lightCube[5];
+
+    rgb = rgb * light;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_normalMap.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_normalMap.js
@@ -1,0 +1,7 @@
+export default /* wgsl */`
+    let sampledNormal: vec4f = textureSample(normalMap, normalMapSampler, vec2f(input.texCoordsAlphaLife.x, 1.0 - input.texCoordsAlphaLife.y));
+    let normalMap: vec3f = normalize(sampledNormal.xyz * 2.0 - 1.0);
+
+    let ParticleMat = mat3x3<f32>(ParticleMat0, ParticleMat1, ParticleMat2);
+    let normal: vec3f = ParticleMat * normalMap;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_soft.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/frag/particle_soft.js
@@ -1,0 +1,6 @@
+export default /* wgsl */`
+    var depth: f32 = getLinearScreenDepthFrag();
+    var particleDepth: f32 = vDepth;
+    var depthDiff: f32 = saturate(abs(particleDepth - depth) * uniform.softening);
+    a = a * depthDiff;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle-shader.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle-shader.js
@@ -1,0 +1,108 @@
+// The main code of particle system vertex shader
+export default /* wgsl */`
+    #ifdef ANIMTEX
+        uniform animTexTilesParams: vec2f;
+        uniform animTexParams: vec4f;
+        uniform animTexIndexParams: vec2f;
+    #endif
+
+    #if NORMAL == MAP
+        varying ParticleMat0: vec3f;
+        varying ParticleMat1: vec3f;
+        varying ParticleMat2: vec3f;
+    #endif
+
+    #if NORMAL == VERTEX
+        varying Normal: vec3f;
+    #endif
+
+    #ifdef SOFT
+        varying vDepth: f32;
+    #endif
+
+    #ifdef PARTICLE_GPU
+
+        #include "particle_initVS"
+
+        #ifdef PACK8
+            #include "particleInputRgba8PS"     // why are these PS and not VS?
+        #else
+            #include  "particleInputFloatPS"    // why are these PS and not VS?
+        #endif
+
+        #ifdef SOFT
+            #include "screenDepthPS"
+        #endif
+
+        #include "particleVS"
+
+    #else // PARTICLE_CPU
+
+        #ifdef SOFT
+            #include "screenDepthPS"
+        #endif
+
+        #include "particle_cpuVS"
+
+    #endif
+
+    #ifdef LOCAL_SPACE
+        #include "particle_localShiftVS"
+    #endif
+
+    #ifdef ANIMTEX
+        #ifdef ANIMTEX_LOOP
+            #include "particleAnimFrameLoopVS"
+        #else
+            #include "particleAnimFrameClampVS"
+        #endif
+        #include "particleAnimTexVS"
+    #endif
+
+    // wrap is not used on CPU, it was commented out. TODO: investigate why
+    #ifdef PARTICLE_GPU
+        #ifdef WRAP
+            #include "particle_wrapVS"
+        #endif
+    #endif
+
+    #ifdef ALIGN_TO_MOTION
+        #include "particle_pointAlongVS"
+    #endif
+
+    #ifdef USE_MESH
+        #include "particle_meshVS"
+    #else
+        #ifdef CUSTOM_FACE
+            #include "particle_customFaceVS"
+        #else
+            #include "particle_billboardVS"
+        #endif
+    #endif
+
+    #if NORMAL == VERTEX
+        #include "particle_normalVS"
+    #endif
+
+    #if NORMAL == MAP
+        #include "particle_TBNVS"
+    #endif
+
+    #ifdef STRETCH
+        #include "particle_stretchVS"
+    #endif
+
+
+    #ifdef PARTICLE_GPU
+        #include "particle_endVS"
+    #else // PARTICLE_CPU
+        #include "particle_cpu_endVS"
+    #endif
+
+    #ifdef SOFT
+        #include "particle_softVS"
+    #endif
+
+    return output;
+}
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle.js
@@ -1,0 +1,115 @@
+export default /* wgsl */`
+fn unpack3NFloats(src: f32) -> vec3f {
+    let r = fract(src);
+    let g = fract(src * 256.0);
+    let b = fract(src * 65536.0);
+    return vec3f(r, g, b);
+}
+
+fn saturate(x: f32) -> f32 {
+    return clamp(x, 0.0, 1.0);
+}
+
+struct TexLerpUnpackResult {
+    result: vec4f,
+    unpacked: vec3f
+}
+
+fn tex1Dlod_lerp_simple(tex: texture_2d<f32>, texSampler: sampler, tc: vec2f) -> vec4f {
+    let tc_next = tc + vec2f(uniform.graphSampleSize);
+    return mix( textureSample(tex, texSampler, tc), textureSample(tex, texSampler, tc_next), fract(tc.x * uniform.graphNumSamples) );
+}
+
+fn tex1Dlod_lerp_unpack(tex: texture_2d<f32>, texSampler: sampler, tc: vec2f) -> TexLerpUnpackResult {
+    let tc_next = tc + vec2f(uniform.graphSampleSize);
+    let a = textureSampleLevel(tex, texSampler, tc, 0.0);
+    let b = textureSampleLevel(tex, texSampler, tc_next, 0.0);
+    let c = fract(tc.x * uniform.graphNumSamples);
+    let unpackedA = unpack3NFloats(a.w);
+    let unpackedB = unpack3NFloats(b.w);
+    let w_out = mix(unpackedA, unpackedB, c);
+    return TexLerpUnpackResult(mix(a, b, c), w_out);
+}
+
+struct RotateResult {
+    rotatedVec: vec2f,
+    matrix: mat2x2f
+}
+
+fn rotateWithMatrix(quadXY: vec2f, pRotation: f32) -> RotateResult {
+    let c = cos(pRotation);
+    let s = sin(pRotation);
+    let m = mat2x2f(vec2f(c, s), vec2f(-s, c));
+    return RotateResult(m * quadXY, m);
+}
+
+fn billboard(InstanceCoords: vec3f, quadXY: vec2f) -> vec3f {
+    var pos: vec3f;
+    #ifdef SCREEN_SPACE
+        pos = vec3f(-1.0, 0.0, 0.0) * quadXY.x + vec3f(0.0, -1.0, 0.0) * quadXY.y;
+    #else
+        pos = -uniform.matrix_viewInverse[0].xyz * quadXY.x + -uniform.matrix_viewInverse[1].xyz * quadXY.y;
+    #endif
+    return pos;
+}
+
+fn customFace(InstanceCoords: vec3f, quadXY: vec2f) -> vec3f {
+    let pos = uniform.faceTangent * quadXY.x + uniform.faceBinorm * quadXY.y;
+    return pos;
+}
+
+fn safeNormalize(v: vec2f) -> vec2f {
+    let l = length(v);
+    return select(v, v / l, l > 1e-06);
+}
+
+@vertex
+fn vertexMain(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+
+    let meshLocalPos_in = input.particle_vertexData.xyz;
+    let id = floor(input.particle_vertexData.w);
+
+    let rndFactor = fract(sin(id + 1.0 + uniform.seed));
+    let rndFactor3 = vec3f(rndFactor, fract(rndFactor*10.0), fract(rndFactor*100.0));
+
+    let uv = id / uniform.numParticlesPot;
+    readInput(uv);
+
+    #ifdef LOCAL_SPACE
+        let modelRotation = mat3x3f(uniform.matrix_model[0].xyz, uniform.matrix_model[1].xyz, uniform.matrix_model[2].xyz);
+        inVel = modelRotation * inVel;
+    #endif
+    let viewRotation = mat3x3f(uniform.matrix_view[0].xyz, uniform.matrix_view[1].xyz, uniform.matrix_view[2].xyz);
+    let velocityV = safeNormalize((viewRotation * inVel).xy);
+
+    let particleLifetime = uniform.lifetime;
+
+    var meshLocalPos = meshLocalPos_in;
+    if (inLife <= 0.0 || inLife > particleLifetime || !inShow) {
+         meshLocalPos = vec3f(0.0);
+    }
+    let quadXY = meshLocalPos.xy;
+    let nlife = clamp(inLife / particleLifetime, 0.0, 1.0);
+
+    let lerp_result = tex1Dlod_lerp_unpack(internalTex2, internalTex2Sampler, vec2f(nlife, 0.0));
+    let params = lerp_result.result;
+    let paramDiv = lerp_result.unpacked;
+
+    var scale = params.y;
+    let scaleDiv = paramDiv.x;
+    let alphaDiv = paramDiv.z;
+
+    scale = scale + (scaleDiv * 2.0 - 1.0) * uniform.scaleDivMult * fract(rndFactor*10000.0);
+
+    #ifndef USE_MESH
+        output.texCoordsAlphaLife = vec4f(quadXY * -0.5 + 0.5, (alphaDiv * 2.0 - 1.0) * uniform.alphaDivMult * fract(rndFactor*1000.0), nlife);
+    #else
+        output.texCoordsAlphaLife = vec4f(particle_uv, (alphaDiv * 2.0 - 1.0) * uniform.alphaDivMult * fract(rndFactor*1000.0), nlife);
+    #endif
+
+    var particlePos = inPos;
+    var particlePosMoved = vec3f(0.0);
+
+    var rotMatrix: mat2x2f;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particleAnimFrameClamp.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particleAnimFrameClamp.js
@@ -1,0 +1,3 @@
+export default /* wgsl */`
+    let animFrame: f32 = min(floor(input.texCoordsAlphaLife.w * uniform.animTexParams.y) + uniform.animTexParams.x, uniform.animTexParams.z);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particleAnimFrameLoop.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particleAnimFrameLoop.js
@@ -1,0 +1,3 @@
+export default /* wgsl */`
+    let animFrame: f32 = floor((output.texCoordsAlphaLife.w * uniform.animTexParams.y + uniform.animTexParams.x) % (uniform.animTexParams.z + 1.0));    
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particleAnimTex.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particleAnimTex.js
@@ -1,0 +1,18 @@
+export default /* wgsl */`
+    var animationIndex: f32;
+
+    if (uniform.animTexIndexParams.y == 1.0) {
+        animationIndex = floor((uniform.animTexParams.w + 1.0) * rndFactor3.z) * (uniform.animTexParams.z + 1.0);
+    } else {
+        animationIndex = uniform.animTexIndexParams.x * (uniform.animTexParams.z + 1.0);
+    }
+
+    var atlasX: f32 = (animationIndex + animFrame) * uniform.animTexTilesParams.x;
+    let atlasY: f32 = 1.0 - floor(atlasX + 1.0) * uniform.animTexTilesParams.y;
+    atlasX = fract(atlasX); // Reassign atlasX
+
+    let current_tcal_xy = output.texCoordsAlphaLife.xy;
+    let scaled_tcal_xy = current_tcal_xy * uniform.animTexTilesParams.xy;
+    let final_tcal_xy = scaled_tcal_xy + vec2f(atlasX, atlasY);
+    output.texCoordsAlphaLife = vec4f(final_tcal_xy, output.texCoordsAlphaLife.z, output.texCoordsAlphaLife.w);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_TBN.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_TBN.js
@@ -1,0 +1,20 @@
+export default /* wgsl */`
+    let rot3 = mat3x3f(
+        vec3f(rotMatrix[0][0], rotMatrix[1][0], 0.0),
+        vec3f(rotMatrix[0][1], rotMatrix[1][1], 0.0),
+        vec3f(0.0, 0.0, 1.0)
+    );
+
+    let viewBasis = mat3x3f(
+        -uniform.matrix_viewInverse[0].xyz,
+        -uniform.matrix_viewInverse[1].xyz,
+        uniform.matrix_viewInverse[2].xyz
+    );
+
+    let tempMat = viewBasis * rot3;
+
+    // WGSL does not support matrix varyings, decompose it to vec3s
+    output.ParticleMat0 = tempMat[0];
+    output.ParticleMat1 = tempMat[1];
+    output.ParticleMat2 = tempMat[2];
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_billboard.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_billboard.js
@@ -1,0 +1,6 @@
+export default /* wgsl */`
+    let rotationResult = rotateWithMatrix(quadXY, inAngle);
+    let rotatedQuadXY = rotationResult.rotatedVec;
+    rotMatrix = rotationResult.matrix;
+    var localPos = billboard(particlePos, rotatedQuadXY);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_cpu.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_cpu.js
@@ -1,0 +1,100 @@
+export default /* wgsl */`
+attribute particle_vertexData: vec4f;   // XYZ = world pos, W = life
+attribute particle_vertexData2: vec4f;  // X = angle, Y = scale, Z = alpha, W = velocity.x
+attribute particle_vertexData3: vec4f;  // XYZ = particle local pos, W = velocity.y
+attribute particle_vertexData4: f32;    // particle id
+
+// type depends on useMesh property. Start with X = velocity.z, Y = particle ID and for mesh particles proceeds with Z = mesh UV.x, W = mesh UV.y
+#ifndef USE_MESH
+    attribute particle_vertexData5: vec2f;
+#else
+    attribute particle_vertexData5: vec4f;
+#endif
+
+uniform matrix_viewProjection: mat4x4f;
+uniform matrix_model: mat4x4f;
+
+#ifndef VIEWMATRIX
+    #define VIEWMATRIX
+    uniform matrix_view: mat4x4f;
+#endif
+
+uniform matrix_normal: mat3x3f;
+uniform matrix_viewInverse: mat4x4f;
+
+uniform numParticles: f32;
+uniform lifetime: f32;
+uniform stretch: f32;
+uniform seed: f32;
+uniform wrapBounds: vec3f;
+uniform emitterScale: vec3f;
+uniform faceTangent: vec3f;
+uniform faceBinorm: vec3f;
+
+#ifdef PARTICLE_GPU
+    var internalTex0: texture_2d<f32>;
+    var internalTex0Sampler: sampler;
+    var internalTex1: texture_2d<f32>;
+    var internalTex1Sampler: sampler;
+    var internalTex2: texture_2d<f32>;
+    var internalTex2Sampler: sampler;
+#endif
+uniform emitterPos: vec3f;
+
+varying texCoordsAlphaLife: vec4f;
+
+struct RotateResult {
+    rotatedVec: vec2f,
+    matrix: mat2x2f
+}
+
+fn rotateWithMatrix(quadXY: vec2f, pRotation: f32) -> RotateResult {
+    let c = cos(pRotation);
+    let s = sin(pRotation);
+    let m = mat2x2f(vec2f(c, s), vec2f(-s, c));
+    return RotateResult(m * quadXY, m);
+}
+
+
+fn billboard(InstanceCoords: vec3f, quadXY: vec2f) -> vec3f {
+    let pos = -uniform.matrix_viewInverse[0].xyz * quadXY.x + -uniform.matrix_viewInverse[1].xyz * quadXY.y;
+    return pos;
+}
+
+fn customFace(InstanceCoords: vec3f, quadXY: vec2f) -> vec3f {
+    let pos = uniform.faceTangent * quadXY.x + uniform.faceBinorm * quadXY.y;
+    return pos;
+}
+
+@vertex
+fn vertexMain(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+
+    var particlePos = input.particle_vertexData.xyz;
+    let inPos = particlePos;
+    let vertPos = input.particle_vertexData3.xyz;
+    var inVel = vec3f(input.particle_vertexData2.w, input.particle_vertexData3.w, input.particle_vertexData5.x);
+
+    let id = floor(input.particle_vertexData4);
+    let rndFactor = fract(sin(id + 1.0 + uniform.seed));
+    let rndFactor3 = vec3f(rndFactor, fract(rndFactor*10.0), fract(rndFactor*100.0));
+
+    #ifdef LOCAL_SPACE
+        let modelRotation = mat3x3f(uniform.matrix_model[0].xyz, uniform.matrix_model[1].xyz, uniform.matrix_model[2].xyz);
+        inVel = modelRotation * inVel;
+    #endif
+    let velocityV = safeNormalize((mat3x3f(uniform.matrix_view[0].xyz, uniform.matrix_view[1].xyz, uniform.matrix_view[2].xyz) * inVel).xy);
+
+    let quadXY = vertPos.xy;
+
+    #ifdef USE_MESH
+        output.texCoordsAlphaLife = vec4f(input.particle_vertexData5.zw, input.particle_vertexData2.z, input.particle_vertexData.w);
+    #else
+        output.texCoordsAlphaLife = vec4f(quadXY * -0.5 + 0.5, input.particle_vertexData2.z, input.particle_vertexData.w);
+    #endif
+    var rotMatrix: mat2x2f;
+
+    let inAngle = input.particle_vertexData2.x;
+    var particlePosMoved = vec3f(0.0);
+    let meshLocalPos = input.particle_vertexData3.xyz;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_cpu_end.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_cpu_end.js
@@ -1,0 +1,6 @@
+export default /* wgsl */`
+    localPos = localPos * input.particle_vertexData2.y * emitterScale;
+    localPos = localPos + particlePos;
+
+    output.position = uniform.matrix_viewProjection * vec4f(localPos, 1.0);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_customFace.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_customFace.js
@@ -1,0 +1,6 @@
+export default /* wgsl */`
+    let rotationResult = rotateWithMatrix(quadXY, inAngle);
+    let rotatedQuadXY = rotationResult.rotatedVec;
+    rotMatrix = rotationResult.matrix;
+    var localPos = customFace(particlePos, rotatedQuadXY);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_end.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_end.js
@@ -1,0 +1,10 @@
+export default /* wgsl */`
+    localPos = localPos * scale * uniform.emitterScale;
+    localPos = localPos + particlePos;
+
+    #ifdef SCREEN_SPACE
+        output.position = vec4f(localPos.x, localPos.y, 0.0, 1.0);
+    #else
+        output.position = uniform.matrix_viewProjection * vec4f(localPos.xyz, 1.0);
+    #endif
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_init.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_init.js
@@ -1,0 +1,66 @@
+export default /* wgsl */`
+attribute particle_vertexData: vec4f; // XYZ = particle position, W = particle ID + random factor
+#if defined(USE_MESH)
+    #if defined(USE_MESH_UV)
+        attribute particle_uv: vec2f;         // mesh UV
+    #else
+        var<private> particle_uv: vec2f = vec2f(0.0, 0.0);
+    #endif
+#endif
+
+uniform matrix_viewProjection: mat4x4f;
+uniform matrix_model: mat4x4f;
+uniform matrix_normal: mat3x3f;
+uniform matrix_viewInverse: mat4x4f;
+
+#ifndef VIEWMATRIX
+    #define VIEWMATRIX
+    uniform matrix_view: mat4x4f;
+#endif
+
+uniform numParticles: f32;
+uniform numParticlesPot: f32;
+uniform graphSampleSize: f32;
+uniform graphNumSamples: f32;
+uniform stretch: f32;
+uniform wrapBounds: vec3f;
+uniform emitterScale: vec3f;
+uniform emitterPos: vec3f;
+uniform faceTangent: vec3f;
+uniform faceBinorm: vec3f;
+uniform rate: f32;
+uniform rateDiv: f32;
+uniform lifetime: f32;
+uniform deltaRandomnessStatic: f32;
+uniform scaleDivMult: f32;
+uniform alphaDivMult: f32;
+uniform seed: f32;
+uniform delta: f32;
+
+var particleTexOUT: texture_2d<f32>;
+var particleTexOUTSampler: sampler;
+var particleTexIN: texture_2d<f32>;
+var particleTexINSampler: sampler;
+
+#ifdef PARTICLE_GPU
+    var internalTex0: texture_2d<f32>;
+    var internalTex0Sampler: sampler;
+    var internalTex1: texture_2d<f32>;
+    var internalTex1Sampler: sampler;
+    var internalTex2: texture_2d<f32>;
+    var internalTex2Sampler: sampler;
+#endif
+
+#ifndef CAMERAPLANES
+    #define CAMERAPLANES
+    uniform camera_params: vec4f;
+#endif
+
+varying texCoordsAlphaLife: vec4f;
+
+var<private> inPos: vec3f;
+var<private> inVel: vec3f;
+var<private> inAngle: f32;
+var<private> inShow: bool;
+var<private> inLife: f32;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_localShift.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_localShift.js
@@ -1,0 +1,3 @@
+export default /* wgsl */`
+particlePos = (uniform.matrix_model * vec4f(particlePos, 1.0)).xyz;
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_mesh.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_mesh.js
@@ -1,0 +1,12 @@
+export default /* wgsl */`
+var localPos = meshLocalPos;
+let rotResultXY = rotateWithMatrix(localPos.xy, inAngle);
+localPos = vec3f(rotResultXY.rotatedVec, localPos.z);
+rotMatrix = rotResultXY.matrix;
+
+let rotResultYZ = rotateWithMatrix(localPos.yz, inAngle);
+localPos = vec3f(localPos.x, rotResultYZ.rotatedVec);
+rotMatrix = rotResultYZ.matrix;
+
+billboard(particlePos, quadXY);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_normal.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_normal.js
@@ -1,0 +1,3 @@
+export default /* wgsl */`
+output.Normal = normalize(localPos + uniform.matrix_viewInverse[2].xyz);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_pointAlong.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_pointAlong.js
@@ -1,5 +1,4 @@
-export default /* glsl */`
+export default /* wgsl */`
     // not the fastest way, but easier to plug in; TODO: create rot matrix right from vectors
-    inAngle = atan(velocityV.x, velocityV.y);
-
+    inAngle = atan2(velocityV.x, velocityV.y);
 `;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_soft.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_soft.js
@@ -1,0 +1,3 @@
+export default /* wgsl */`
+    output.vDepth = getLinearDepth(localPos);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_stretch.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_stretch.js
@@ -1,0 +1,12 @@
+export default /* wgsl */`
+    let moveDir: vec3f = inVel * uniform.stretch;
+    var posPrev: vec3f = particlePos - moveDir;
+    posPrev = posPrev + particlePosMoved;
+
+    let viewRotationTemp: mat3x3f = mat3x3f(uniform.matrix_view[0].xyz, uniform.matrix_view[1].xyz, uniform.matrix_view[2].xyz);
+    let centerToVertexV: vec2f = normalize((viewRotationTemp * localPos).xy);
+
+    let interpolation: f32 = dot(-velocityV, centerToVertexV) * 0.5 + 0.5;
+
+    particlePos = mix(particlePos, posPrev, interpolation);
+`;

--- a/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_wrap.js
+++ b/src/scene/shader-lib/chunks-wgsl/particle/vert/particle_wrap.js
@@ -1,0 +1,7 @@
+export default /* wgsl */`
+    let origParticlePos: vec3f = particlePos;
+    particlePos = particlePos - uniform.matrix_model[3].xyz;
+    particlePos = (particlePos % uniform.wrapBounds) - uniform.wrapBounds * 0.5;
+    particlePos = particlePos + uniform.matrix_model[3].xyz;
+    particlePosMoved = particlePos - origParticlePos;
+`;

--- a/src/scene/shader-lib/chunks/particle/frag/particle.js
+++ b/src/scene/shader-lib/chunks/particle/frag/particle.js
@@ -7,8 +7,8 @@ uniform float graphSampleSize;
 uniform float graphNumSamples;
 
 #ifndef CAMERAPLANES
-#define CAMERAPLANES
-uniform vec4 camera_params;
+    #define CAMERAPLANES
+    uniform vec4 camera_params;
 #endif
 
 uniform float softening;

--- a/src/scene/shader-lib/chunks/particle/frag/particleInputRgba8.js
+++ b/src/scene/shader-lib/chunks/particle/frag/particleInputRgba8.js
@@ -12,11 +12,11 @@ uniform vec3 inBoundsCenter;
 uniform float maxVel;
 
 float decodeFloatRG(vec2 rg) {
-    return rg.y*(1.0/255.0) + rg.x;
+    return rg.y * (1.0 / 255.0) + rg.x;
 }
 
 float decodeFloatRGBA( vec4 rgba ) {
-  return dot( rgba, vec4(1.0, 1.0/255.0, 1.0/65025.0, 1.0/160581375.0) );
+    return dot(rgba, vec4(1.0, 1.0 / 255.0, 1.0 / 65025.0, 1.0 / 160581375.0));
 }
 
 void readInput(float uv) {

--- a/src/scene/shader-lib/chunks/particle/frag/particle_halflambert.js
+++ b/src/scene/shader-lib/chunks/particle/frag/particle_halflambert.js
@@ -1,6 +1,6 @@
 export default /* glsl */`
-    vec3 negNormal = normal*0.5+0.5;
-    vec3 posNormal = -normal*0.5+0.5;
+    vec3 negNormal = normal * 0.5 + 0.5;
+    vec3 posNormal = -normal * 0.5 + 0.5;
     negNormal *= negNormal;
     posNormal *= posNormal;
 `;

--- a/src/scene/shader-lib/chunks/particle/vert/particle.js
+++ b/src/scene/shader-lib/chunks/particle/vert/particle.js
@@ -73,7 +73,8 @@ void main(void) {
 
     float particleLifetime = lifetime;
 
-    if (inLife <= 0.0 || inLife > particleLifetime || !inShow) meshLocalPos = vec3(0.0);
+    if (inLife <= 0.0 || inLife > particleLifetime || !inShow)
+        meshLocalPos = vec3(0.0);
     vec2 quadXY = meshLocalPos.xy;
     float nlife = clamp(inLife / particleLifetime, 0.0, 1.0);
 

--- a/src/scene/shader-lib/chunks/particle/vert/particle_cpu.js
+++ b/src/scene/shader-lib/chunks/particle/vert/particle_cpu.js
@@ -7,17 +7,17 @@ attribute float particle_vertexData4; // particle id
 // type depends on useMesh property. Start with X = velocity.z, Y = particle ID and for mesh particles proceeds with Z = mesh UV.x, W = mesh UV.y
 // Note: This generates a duplicate attribute warning, as the scanning we do is very simple.
 #ifndef USE_MESH
-attribute vec2 particle_vertexData5;
+    attribute vec2 particle_vertexData5;
 #else
-attribute vec4 particle_vertexData5;
+    attribute vec4 particle_vertexData5;
 #endif
 
 uniform mat4 matrix_viewProjection;
 uniform mat4 matrix_model;
 
 #ifndef VIEWMATRIX
-#define VIEWMATRIX
-uniform mat4 matrix_view;
+    #define VIEWMATRIX
+    uniform mat4 matrix_view;
 #endif
 
 uniform mat3 matrix_normal;

--- a/src/scene/shader-lib/chunks/particle/vert/particle_init.js
+++ b/src/scene/shader-lib/chunks/particle/vert/particle_init.js
@@ -1,7 +1,12 @@
 export default /* glsl */`
 attribute vec4 particle_vertexData; // XYZ = particle position, W = particle ID + random factor
-#ifdef USE_MESH
-attribute vec2 particle_uv;         // mesh UV
+
+#if defined(USE_MESH)
+    #if defined(USE_MESH_UV)
+        attribute vec2 particle_uv;         // mesh UV
+    #else
+        vec2 particle_uv = vec2(0.0, 0.0);
+    #endif
 #endif
 
 uniform mat4 matrix_viewProjection;
@@ -10,8 +15,8 @@ uniform mat3 matrix_normal;
 uniform mat4 matrix_viewInverse;
 
 #ifndef VIEWMATRIX
-#define VIEWMATRIX
-uniform mat4 matrix_view;
+    #define VIEWMATRIX
+    uniform mat4 matrix_view;
 #endif
 
 uniform float numParticles;
@@ -42,8 +47,8 @@ uniform sampler2D particleTexIN;
 #endif
 
 #ifndef CAMERAPLANES
-#define CAMERAPLANES
-uniform vec4 camera_params;
+    #define CAMERAPLANES
+    uniform vec4 camera_params;
 #endif
 
 varying vec4 texCoordsAlphaLife;

--- a/src/scene/shader-lib/programs/particle.js
+++ b/src/scene/shader-lib/programs/particle.js
@@ -1,5 +1,7 @@
+import { SEMANTIC_POSITION, SEMANTIC_TEXCOORD0, SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL } from '../../../platform/graphics/constants.js';
 import { ShaderUtils } from '../../../platform/graphics/shader-utils.js';
 import { blendNames } from '../../constants.js';
+import { shaderChunksWGSL } from '../chunks-wgsl/chunks-wgsl.js';
 import { shaderChunks } from '../chunks/chunks.js';
 import { ShaderGenerator } from './shader-generator.js';
 
@@ -21,10 +23,11 @@ class ShaderGeneratorParticle extends ShaderGenerator {
         return key;
     }
 
-    createVertexDefines(options) {
+    createVertexDefines(options, attributes) {
         const vDefines = new Map(options.defines);
 
         if (options.mesh) vDefines.set('USE_MESH', '');
+        if (options.meshUv) vDefines.set('USE_MESH_UV', '');
         if (options.localSpace) vDefines.set('LOCAL_SPACE', '');
         if (options.screenSpace) vDefines.set('SCREEN_SPACE', '');
         if (options.animTex) vDefines.set('ANIMTEX', '');
@@ -38,6 +41,12 @@ class ShaderGeneratorParticle extends ShaderGenerator {
         if (options.alignToMotion) vDefines.set('ALIGN_TO_MOTION', '');
 
         vDefines.set('NORMAL', normalTypeNames[options.normal]);
+
+        // attributes
+        attributes.particle_vertexData = SEMANTIC_POSITION;
+        if (options.mesh && options.meshUv) {
+            attributes.particle_uv = SEMANTIC_TEXCOORD0;
+        }
 
         return vDefines;
     }
@@ -56,7 +65,11 @@ class ShaderGeneratorParticle extends ShaderGenerator {
 
     createShaderDefinition(device, options) {
 
-        const vDefines = this.createVertexDefines(options);
+        const shaderLanguage = device.isWebGPU ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL;
+        const chunks = device.isWebGPU ? shaderChunksWGSL : shaderChunks;
+
+        const attributes = {};
+        const vDefines = this.createVertexDefines(options, attributes);
         const fDefines = this.createFragmentDefines(options);
 
         const executionDefine = `PARTICLE_${options.useCpu ? 'CPU' : 'GPU'}\n`;
@@ -64,14 +77,16 @@ class ShaderGeneratorParticle extends ShaderGenerator {
         fDefines.set(executionDefine, '');
 
         const includes = new Map(Object.entries({
-            ...shaderChunks,
+            ...chunks,
             ...options.chunks
         }));
 
         return ShaderUtils.createDefinition(device, {
             name: 'ParticleShader',
-            vertexCode: shaderChunks.particle_shaderVS,
-            fragmentCode: shaderChunks.particle_shaderPS,
+            shaderLanguage: shaderLanguage,
+            attributes: attributes,
+            vertexCode: chunks.particle_shaderVS,
+            fragmentCode: chunks.particle_shaderPS,
             fragmentDefines: fDefines,
             fragmentIncludes: includes,
             vertexIncludes: includes,


### PR DESCRIPTION
- converted all particle shader chunks to WGSL, and using those for both rendering and simulation shaders
- updated WGSL processor, to merge vertex and fragment resources based on parsed information, instead of simply comparing string, to allow for formatting variations
- made `particle_uv` attribute used by Particles driven by the mesh containing UV instead of relying on the shader compiler stripping out unused attributes, which does not happen on WGSL side
- particle system specifies used attributes when creating shaders, as that's required by WGSL processing (no reflection)
