### PR TITLE
Shader creation no longer supplies dummy shader in none is specified

### DIFF
--- a/src/platform/graphics/shader-utils.js
+++ b/src/platform/graphics/shader-utils.js
@@ -149,7 +149,7 @@ class ShaderUtils {
                 ShaderUtils.precisionCode(device)}
                 ${sharedGLSL}
                 ${ShaderUtils.getShaderNameCode(name)}
-                ${options.fragmentCode || ShaderUtils.dummyFragmentCode()}`;
+                ${options.fragmentCode}`;
         }
 
         return {
@@ -191,10 +191,6 @@ class ShaderUtils {
     // SpectorJS integration
     static getShaderNameCode(name) {
         return `#define SHADER_NAME ${name}\n`;
-    }
-
-    static dummyFragmentCode() {
-        return 'void main(void) {gl_FragColor = vec4(0.0);}';
     }
 
     static versionCode(device) {

--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -123,7 +123,8 @@ class TransformFeedback {
         return new Shader(graphicsDevice, ShaderUtils.createDefinition(graphicsDevice, {
             name,
             vertexCode,
-            useTransformFeedback: true
+            useTransformFeedback: true,
+            fragmentCode: 'void main(void) {gl_FragColor = vec4(0.0);}'
         }));
     }
 


### PR DESCRIPTION
- internally, this was only used to for transform-feedback. Transform feedback handles it now.
- no need to do WGSL solution here