### PR TITLE
Rename Key and Node classes

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -20,6 +20,8 @@ import { VertexFormat } from '../platform/graphics/vertex-format.js';
 import { BlendState } from '../platform/graphics/blend-state.js';
 import { DepthState } from '../platform/graphics/depth-state.js';
 
+import { AnimationKey, AnimationNode } from '../scene/animation/animation.js';
+import { Geometry } from '../scene/geometry/geometry.js';
 import { CylinderGeometry } from '../scene/geometry/cylinder-geometry.js';
 import { BoxGeometry } from '../scene/geometry/box-geometry.js';
 import { CapsuleGeometry } from '../scene/geometry/capsule-geometry.js';
@@ -57,7 +59,6 @@ import {
 } from '../framework/components/rigid-body/constants.js';
 import { RigidBodyComponent } from '../framework/components/rigid-body/component.js';
 import { RigidBodyComponentSystem } from '../framework/components/rigid-body/system.js';
-import { Geometry } from '../scene/geometry/geometry.js';
 import { CameraComponent } from '../framework/components/camera/component.js';
 
 // MATH
@@ -407,6 +408,9 @@ GraphicsDevice.prototype.getCullMode = function () {
 };
 
 // SCENE
+
+export const Key = AnimationKey;
+export const Node = AnimationNode;
 
 export const LitOptions = LitShaderOptions;
 

--- a/src/framework/handlers/animation.js
+++ b/src/framework/handlers/animation.js
@@ -2,7 +2,7 @@ import { path } from '../../core/path.js';
 import { Quat } from '../../core/math/quat.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { http, Http } from '../../platform/net/http.js';
-import { Animation, Key, Node } from '../../scene/animation/animation.js';
+import { Animation, AnimationKey, AnimationNode } from '../../scene/animation/animation.js';
 import { AnimEvents } from '../anim/evaluator/anim-events.js';
 import { GlbParser } from '../parsers/glb-parser.js';
 import { ResourceHandler } from './handler.js';
@@ -89,7 +89,7 @@ class AnimationHandler extends ResourceHandler {
         anim.duration = animData.duration;
 
         for (let i = 0; i < animData.nodes.length; i++) {
-            const node = new Node();
+            const node = new AnimationNode();
 
             const n = animData.nodes[i];
             node._name = n.name;
@@ -105,7 +105,7 @@ class AnimationHandler extends ResourceHandler {
                 const rot = new Quat().setFromEulerAngles(r[0], r[1], r[2]);
                 const scl = new Vec3(s[0], s[1], s[2]);
 
-                const key = new Key(t, pos, rot, scl);
+                const key = new AnimationKey(t, pos, rot, scl);
 
                 node._keys.push(key);
             }
@@ -124,7 +124,7 @@ class AnimationHandler extends ResourceHandler {
         anim.duration = animData.duration;
 
         for (let i = 0; i < animData.nodes.length; i++) {
-            const node = new Node();
+            const node = new AnimationNode();
 
             const n = animData.nodes[i];
             node._name = n.name;
@@ -144,7 +144,7 @@ class AnimationHandler extends ResourceHandler {
                 const rot = new Quat().setFromEulerAngles(r[0], r[1], r[2]);
                 const scl = new Vec3(s[0], s[1], s[2]);
 
-                const key = new Key(t, pos, rot, scl);
+                const key = new AnimationKey(t, pos, rot, scl);
 
                 node._keys.push(key);
             }

--- a/src/index.js
+++ b/src/index.js
@@ -189,7 +189,7 @@ export { StencilParameters } from './platform/graphics/stencil-parameters.js';
 export { TextureAtlas } from './scene/texture-atlas.js';
 
 // SCENE / ANIMATION
-export { Animation, Key, Node } from './scene/animation/animation.js';
+export { Animation, AnimationKey, AnimationNode } from './scene/animation/animation.js';
 export { Skeleton } from './scene/animation/skeleton.js';
 
 // SCENE / GRAPHICS

--- a/src/scene/animation/animation.js
+++ b/src/scene/animation/animation.js
@@ -25,8 +25,11 @@ class AnimationNode {
 }
 
 /**
- * An animation is a sequence of keyframe arrays which map to the nodes of a skeletal hierarchy. It
- * controls how the nodes of the hierarchy are transformed over time.
+ * An Animation contains the data that defines how a {@link Skeleton} animates over time. The
+ * Animation contains an array of {@link AnimationNode}s, where each AnimationNode targets a
+ * specific {@link GraphNode} referenced by a {@link Skeleton}.
+ *
+ * An Animation can be played back by an {@link AnimationComponent}.
  *
  * @category Animation
  */

--- a/src/scene/animation/animation.js
+++ b/src/scene/animation/animation.js
@@ -1,4 +1,4 @@
-class Key {
+class AnimationKey {
     constructor(time, position, rotation, scale) {
         this.time = time;
         this.position = position;
@@ -12,9 +12,9 @@ class Key {
  *
  * @category Animation
  */
-class Node {
+class AnimationNode {
     /**
-     * Create a new Node instance.
+     * Create a new AnimationNode instance.
      */
     constructor() {
         this._name = '';
@@ -52,10 +52,10 @@ class Animation {
     }
 
     /**
-     * Gets a {@link Node} by name.
+     * Gets a {@link AnimationNode} by name.
      *
-     * @param {string} name - The name of the {@link Node}.
-     * @returns {Node} The {@link Node} with the specified name.
+     * @param {string} name - The name of the {@link AnimationNode}.
+     * @returns {AnimationNode} The {@link AnimationNode} with the specified name.
      */
     getNode(name) {
         return this._nodeDict[name];
@@ -64,7 +64,7 @@ class Animation {
     /**
      * Adds a node to the internal nodes array.
      *
-     * @param {Node} node - The node to add.
+     * @param {AnimationNode} node - The node to add.
      */
     addNode(node) {
         this._nodes.push(node);
@@ -74,11 +74,11 @@ class Animation {
     /**
      * A read-only property to get array of animation nodes.
      *
-     * @type {Node[]}
+     * @type {AnimationNode[]}
      */
     get nodes() {
         return this._nodes;
     }
 }
 
-export { Animation, Key, Node };
+export { Animation, AnimationKey, AnimationNode };

--- a/src/scene/animation/animation.js
+++ b/src/scene/animation/animation.js
@@ -8,7 +8,9 @@ class AnimationKey {
 }
 
 /**
- * A animation node has a name and contains an array of keyframes.
+ * AnimationNode represents an array of keyframes that animate the transform of a {@link GraphNode}
+ * over time. Typically, an {@link Animation} maintains a collection of AnimationNodes, one for
+ * each GraphNode in a {@link Skeleton}.
  *
  * @category Animation
  */


### PR DESCRIPTION
* Rename `Key` to `AnimationKey`
* Rename `Node` to `AnimationNode`

The original names were too generic and prone to collision. For example:

https://developer.mozilla.org/en-US/docs/Web/API/Node

This will group `Node` with other `AnimationXYZ` classes. Note that `Key` was never public API anyway but renaming nevertheless.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
