### PR TITLE
Support for unfiltrable texture in WGSL

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -72,8 +72,8 @@ const getTextureInfo = (baseType, componentType) => {
             case 'i32': finalSampleType = SAMPLETYPE_INT; break;
             case 'f32': finalSampleType = SAMPLETYPE_FLOAT; break;
 
-            // custom uf32 type for unfilterable float, allowing us to create correct bind, which is automatically generated based on the shader
-            case 'uf32': finalSampleType = SAMPLETYPE_UNFILTERABLE_FLOAT; break;
+            // custom 'uff' type for unfilterable float, allowing us to create correct bind, which is automatically generated based on the shader
+            case 'uff': finalSampleType = SAMPLETYPE_UNFILTERABLE_FLOAT; break;
         }
     }
 

--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -71,6 +71,9 @@ const getTextureInfo = (baseType, componentType) => {
             case 'u32': finalSampleType = SAMPLETYPE_UINT; break;
             case 'i32': finalSampleType = SAMPLETYPE_INT; break;
             case 'f32': finalSampleType = SAMPLETYPE_FLOAT; break;
+
+            // custom uf32 type for unfilterable float, allowing us to create correct bind, which is automatically generated based on the shader
+            case 'uf32': finalSampleType = SAMPLETYPE_UNFILTERABLE_FLOAT; break;
         }
     }
 

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -174,7 +174,7 @@ class Immediate {
         `, /* wgsl */`
 
             varying uv0: vec2f;
-            var colorMap: texture_2d<f32>;
+            var colorMap: texture_2d<uf32>;
             @fragment fn fragmentMain(input : FragmentInput) -> FragmentOutput {
                 var output: FragmentOutput;
                 let uv : vec2<i32> = vec2<i32>(input.uv0 * vec2f(textureDimensions(colorMap, 0)));

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -174,7 +174,7 @@ class Immediate {
         `, /* wgsl */`
 
             varying uv0: vec2f;
-            var colorMap: texture_2d<uf32>;
+            var colorMap: texture_2d<uff>;
             @fragment fn fragmentMain(input : FragmentInput) -> FragmentOutput {
                 var output: FragmentOutput;
                 let uv : vec2<i32> = vec2<i32>(input.uv0 * vec2f(textureDimensions(colorMap, 0)));


### PR DESCRIPTION
- we generate bindings for textures automatically, based on the content of the shader
- WGSL does not have a custom syntax for unfiltered-float sample types, and so this type cannot be supported this way
- we add a new texture sample type `uff`, allowing a texture to be declared as unfilterable-float, working around it.
- this is supported shader syntax to declare unfiltrable float cube texture: `var tex: texture_cube<uff>`
- this allows for the depth texture data to be sampled, used in a debug shader