### PR TITLE
Strip comments from WGSL chunks

### DIFF
--- a/utils/plugins/rollup-shader-chunks.mjs
+++ b/utils/plugins/rollup-shader-chunks.mjs
@@ -29,8 +29,8 @@ export function shaderChunks({
         transform(source, shader) {
             if (!filter(shader)) return;
 
-            source = source.replace(/\/\* *glsl *\*\/\s*(`.*?`)/gs, (match, glsl) => {
-                return glsl
+            source = source.replace(/\/\* *(glsl|wgsl) *\*\/\s*(`.*?`)/gs, (match, type, code) => {
+                return code
                 .trim() // trim whitespace
                 .replace(/\r/g, '') // Remove carriage returns
                 .replace(/ {4}/g, '\t') // 4 spaces to tabs


### PR DESCRIPTION
- we have a roll up plugin to strip comments from bundled glsl chunks. This was extended to handle wgsl chunks as well.