### PR TITLE
[Fix] FIx to regex collecting global (bindable) resources from WGSL

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -30,9 +30,11 @@ const KEYWORD = /^[ \t]*(attribute|varying|uniform)[\t ]+/gm;
 // eslint-disable-next-line
 const KEYWORD_LINE = /^[ \t]*(attribute|varying|uniform)[ \t]*([^;]+)(;+)/gm;
 
-// match global variables of type texture, storage buffer, storage texture or external texture
+// match global variables
+//   branch A matches: var<storage,...>
+//   branch B matches: texture, storage buffer, storage texture or external texture
 // eslint-disable-next-line
-const KEYWORD_RESOURCE = /^[ \t]*var\s*(<[^>]+>)?\s*[\w\d_]+\s*:\s*(texture_.*|storage_texture_.*|storage.*|external_texture|sampler|sampler_comparison).*;\s*$/gm;
+const KEYWORD_RESOURCE = /^[ \t]*var\s*(?:(<storage,[^>]*>)\s*([\w\d_]+)\s*:\s*(.*?)\s*;|(<(?!storage,)[^>]*>)?\s*([\w\d_]+)\s*:\s*(texture_.*|storage_texture_.*|storage\w.*|external_texture|sampler(?:_comparison)?)\s*;)\s*$/gm;
 
 // match varying name from string like: '@interpolate(perspective, centroid) smoothColor : vec3f;'
 // eslint-disable-next-line


### PR DESCRIPTION
- modified the way storage buffers are matched using `var<storage,...>` instead of using 'array' type. This reflects a recent change to texture arrays handling, which is done differently.
- fixes the Compute Particles example broken that the time of that change