### PR TITLE
[Fix] Fixed particles update speed on high refresh screens

### DIFF
--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -200,7 +200,6 @@ class ParticleSystemComponentSystem extends ComponentSystem {
 
     onUpdate(dt) {
         const components = this.store;
-        let numSteps;
         const stats = this.app.stats.particles;
         const composition = this.app.scene.layers;
 
@@ -231,6 +230,7 @@ class ParticleSystemComponentSystem extends ComponentSystem {
                     }
 
                     if (!data.paused) {
+                        let numSteps = 0;
                         emitter.simTime += dt;
                         if (emitter.simTime > emitter.fixedTimeStep) {
                             numSteps = Math.floor(emitter.simTime / emitter.fixedTimeStep);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/1721 (most likely)

- on high screen refresh rates (120Hz+) and multiple particle systems, in some cases a particle simulation with multiple system simulating at the same time would run at higher speed. The issues seems to be that the numSteps is not reset to 0 for each particle, and in case particle does not need update, it would still run number of simulation steps from a previous particle system.

forum thread: https://forum.playcanvas.com/t/is-particles-speed-frame-rate-dependant/39952
