### PR TITLE
Sogs load fix

### DIFF
--- a/src/scene/gsplat/gsplat-sogs-data.js
+++ b/src/scene/gsplat/gsplat-sogs-data.js
@@ -343,6 +343,10 @@ class GSplatSogsData {
         members.forEach((member) => {
             const sourceTexture = this[member];
 
+            if (!sourceTexture) {
+                return;
+            }
+
             const renderTarget = new RenderTarget({
                 colorBuffer: targetTexture,
                 depth: false,

--- a/src/scene/gsplat/gsplat-sogs-data.js
+++ b/src/scene/gsplat/gsplat-sogs-data.js
@@ -343,6 +343,7 @@ class GSplatSogsData {
         members.forEach((member) => {
             const sourceTexture = this[member];
 
+            // spherical harmonics labels are missing when no SH data is present
             if (!sourceTexture) {
                 return;
             }


### PR DESCRIPTION
During load time reorder, when no SH is present we must skip missing textures.