### PR TITLE
Publish workflow repo restriction

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'playcanvas'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'playcanvas'
+    if: github.repository == 'playcanvas/engine'
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
- Restricts publish workflow to only execute on the master repo `playcanvas/engine`
