### PR TITLE
Small tweaks to anisotropy examples

### DIFF
--- a/examples/src/examples/materials/anisotropy-lamp.example.mjs
+++ b/examples/src/examples/materials/anisotropy-lamp.example.mjs
@@ -60,7 +60,7 @@ assetListLoader.load(() => {
     // Setup skydome
     app.scene.envAtlas = assets.helipad.resource;
     app.scene.skyboxRotation = new pc.Quat().setFromEulerAngles(0, 70, 0);
-    app.scene.skyboxIntensity = 1.5;
+    app.scene.skyboxIntensity = 0.5;
 
     const leftEntity = assets.model.resource.instantiateRenderEntity();
     leftEntity.setLocalEulerAngles(0, 0, 0);
@@ -85,16 +85,6 @@ assetListLoader.load(() => {
     camera.script.orbitCamera.yaw = 90;
     camera.script.orbitCamera.distance = 0.3;
     camera.camera.requestSceneColorMap(true);
-
-    const directionalLight = new pc.Entity();
-    directionalLight.addComponent('light', {
-        type: 'directional',
-        color: pc.Color.YELLOW,
-        castShadows: false,
-        intensity: 1
-    });
-    directionalLight.setEulerAngles(45, 180, 0);
-    app.root.addChild(directionalLight);
 });
 
 export { app };

--- a/examples/src/examples/materials/anisotropy-strength.example.mjs
+++ b/examples/src/examples/materials/anisotropy-strength.example.mjs
@@ -60,7 +60,7 @@ assetListLoader.load(() => {
     // Setup skydome
     app.scene.envAtlas = assets.helipad.resource;
     app.scene.skyboxRotation = new pc.Quat().setFromEulerAngles(0, 70, 0);
-    app.scene.skyboxIntensity = 1.5;
+    app.scene.skyboxIntensity = 0.5;
 
     const leftEntity = assets.model.resource.instantiateRenderEntity();
     leftEntity.setLocalEulerAngles(40, 90, 0);

--- a/examples/src/examples/materials/material-anisotropic.example.mjs
+++ b/examples/src/examples/materials/material-anisotropic.example.mjs
@@ -87,7 +87,8 @@ assetListLoader.load(() => {
         material.metalness = 1.0;
         material.gloss = z / (NUM_SPHERES_Z - 1);
         material.useMetalness = true;
-        material.anisotropy = ((2 * x) / (NUM_SPHERES_X - 1) - 1.0) * -1.0;
+        material.anisotropyIntensity = x / (NUM_SPHERES_X - 1);
+
         material.enableGGXSpecular = true;
         material.update();
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/7698#issuecomment-2901002677

- removed directional light diving us unexpected look
- tweaked exposure to avoid overexposure
- updated example to not use the deprecated API