### PR TITLE
WorldClusterDebug compatibility with WebGPU

### DIFF
--- a/src/scene/lighting/world-clusters-debug.js
+++ b/src/scene/lighting/world-clusters-debug.js
@@ -161,6 +161,7 @@ class WorldClustersDebug {
 
         if (cubes) {
             mesh.setPositions(positions);
+            mesh.setNormals(new Float32Array(positions.length));
             mesh.setColors32(colors);
             mesh.setIndices(indices);
             mesh.update(PRIMITIVE_TRIANGLES, false);


### PR DESCRIPTION
- standard material requires normals, set all zeros to avoid receiving ambient