### PR TITLE
Fix: Dynamic batching now uses skinning normal for lighting

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/common/vert/normalCore.js
+++ b/src/scene/shader-lib/glsl/chunks/common/vert/normalCore.js
@@ -31,7 +31,7 @@ vec3 getLocalNormal(vec3 vertexNormal) {
     return localNormal;
 }
 
-#ifdef SKIN
+#if defined(SKIN) || defined(BATCH)
     mat3 getNormalMatrix(mat4 modelMatrix) {
         return mat3(modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz);
     }

--- a/src/scene/shader-lib/wgsl/chunks/common/vert/normalCore.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/vert/normalCore.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* wgsl */`
 
 attribute vertex_normal: vec3f;
 
@@ -18,19 +18,15 @@ fn getLocalNormal(vertexNormal: vec3f) -> vec3f {
 
     #ifdef MORPHING_NORMAL
 
-        // Assuming getTextureMorphCoords() returns vec2i
         let morphUV: vec2i = getTextureMorphCoords();
 
         #ifdef MORPHING_INT
-            // Use textureLoad (texelFetch equivalent), requires integer coordinates and returns vec4u
             let morphNormalInt: vec4u = textureLoad(morphNormalTex, morphUV, 0);
-            // Convert unsigned int vector components to float vector for calculations
             let morphNormalF: vec3f = vec3f(morphNormalInt.xyz) / 65535.0 * 2.0 - 1.0;
-            localNormal = localNormal + morphNormalF; // Expand +=
+            localNormal = localNormal + morphNormalF;
         #else
-            // Use textureLoad, requires integer coordinates and returns vec4f
             let morphNormal: vec3f = textureLoad(morphNormalTex, morphUV, 0).xyz;
-            localNormal = localNormal + morphNormal; // Expand +=
+            localNormal = localNormal + morphNormal;
         #endif
 
     #endif
@@ -38,19 +34,16 @@ fn getLocalNormal(vertexNormal: vec3f) -> vec3f {
     return localNormal;
 }
 
-#ifdef SKIN
+#if defined(SKIN) || defined(BATCH)
     fn getNormalMatrix(modelMatrix: mat4x4f) -> mat3x3f {
-        // Construct mat3x3f from columns' xyz components
         return mat3x3f(modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz);
     }
 #elif defined(INSTANCING)
     fn getNormalMatrix(modelMatrix: mat4x4f) -> mat3x3f {
-        // Construct mat3x3f from columns' xyz components
         return mat3x3f(modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz);
     }
 #else
     fn getNormalMatrix(modelMatrix: mat4x4f) -> mat3x3f {
-        // Access uniform via uniform.<name>
         return uniform.matrix_normal;
     }
 #endif


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/7673

- fixed a regression, where during batching, the skinned normal was no used .. and so lighting was in object instead of world space
- removed some automatic comments missed before