### PR TITLE
Shader transpilers are optional now for WebGPU

### DIFF
--- a/examples/src/examples/materials/material-refraction.example.mjs
+++ b/examples/src/examples/materials/material-refraction.example.mjs
@@ -18,9 +18,7 @@ const assets = {
 };
 
 const gfxOptions = {
-    deviceTypes: [deviceType],
-    glslangUrl: `${rootPath}/static/lib/glslang/glslang.js`,
-    twgslUrl: `${rootPath}/static/lib/twgsl/twgsl.js`
+    deviceTypes: [deviceType]
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -110,6 +110,12 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      */
     limits;
 
+    /** GLSL to SPIR-V transpiler */
+    glslang = null;
+
+    /** SPIR-V to WGSL transpiler */
+    twgsl = null;
+
     constructor(canvas, options = {}) {
         super(canvas, options);
         options = this.initOptions;
@@ -185,18 +191,22 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // temporary message to confirm Webgpu is being used
         Debug.log('WebgpuGraphicsDevice initialization ..');
 
-        // build a full URL from a relative or absolute path
-        const buildUrl = (srcPath) => {
-            return new URL(srcPath, window.location.href).toString();
-        };
+        // Import shader transpilers only if both URLs are provided
+        if (glslangUrl && twgslUrl) {
 
-        const results = await Promise.all([
-            import(`${buildUrl(twgslUrl)}`).then(module => twgsl(twgslUrl.replace('.js', '.wasm'))),
-            import(`${buildUrl(glslangUrl)}`).then(module => module.default())
-        ]);
+            // build a full URL from a relative or absolute path
+            const buildUrl = (srcPath) => {
+                return new URL(srcPath, window.location.href).toString();
+            };
 
-        this.twgsl = results[0];
-        this.glslang = results[1];
+            const results = await Promise.all([
+                import(`${buildUrl(twgslUrl)}`).then(module => twgsl(twgslUrl.replace('.js', '.wasm'))),
+                import(`${buildUrl(glslangUrl)}`).then(module => module.default())
+            ]);
+
+            this.twgsl = results[0];
+            this.glslang = results[1];
+        }
 
         // create the device
         return this.createDevice();

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -186,9 +186,20 @@ class WebgpuShader {
     }
 
     transpile(src, shaderType, originalSrc) {
+
+        // make sure shader transpilers are available
+        const device = this.shader.device;
+        if (!device.glslang || !device.twgsl) {
+            console.error(`Cannot transpile shader [${this.shader.label}] - shader transpilers (glslang/twgsl) are not available. Make sure to provide glslangUrl and twgslUrl when creating the device.`, {
+                shader: this.shader
+            });
+            return null;
+        }
+
+        // transpile
         try {
-            const spirv = this.shader.device.glslang.compileGLSL(src, shaderType);
-            const wgsl = this.shader.device.twgsl.convertSpirV2WGSL(spirv);
+            const spirv = device.glslang.compileGLSL(src, shaderType);
+            const wgsl = device.twgsl.convertSpirV2WGSL(spirv);
             return wgsl;
         } catch (err) {
             console.error(`Failed to transpile webgl ${shaderType} shader [${this.shader.label}] to WebGPU while rendering ${DebugGraphics.toString()}, error:\n [${err.stack}]`, {


### PR DESCRIPTION
GLSLANG and TINT transpilers are made optional on WebGPU platform. The device can be created without those, and error is reported when GLSL shader needs transpilation and those are not available.
When WGSL shaders are used, those modules are not needed.