### PR TITLE
Exports `SogsMeta` type

### DIFF
--- a/src/framework/parsers/sogs.js
+++ b/src/framework/parsers/sogs.js
@@ -8,6 +8,31 @@ import { GSplatSogsData } from '../../scene/gsplat/gsplat-sogs-data.js';
  * @import { ResourceHandlerCallback } from '../handlers/handler.js'
  */
 
+/**
+ * @typedef {'float32' | 'uint8' | 'int32'} DType
+ */
+
+/**
+ * @typedef {Object} SogsTexture
+ * @property {number[]} shape - The dimensions of the texture data array
+ * @property {DType} dtype - The data type of the texture values
+ * @property {string[]} files - Array of file paths containing the texture data
+ * @property {number | number[]} [mins] - Minimum values for normalization
+ * @property {number | number[]} [maxs] - Maximum values for normalization
+ * @property {string} [encoding] - The encoding format of the texture data
+ * @property {number} [quantization] - The quantization level of the texture data
+ */
+
+/**
+ * @typedef {Object} SogsMeta
+ * @property {SogsTexture} means - The k-means index for each splat
+ * @property {SogsTexture} scales - The scale factors for each splat
+ * @property {SogsTexture} quats - The quaternion rotations for each splat
+ * @property {SogsTexture} sh0 - The zeroth order spherical harmonics coefficients
+ * @property {SogsTexture} shN - The higher order spherical harmonics coefficients
+ */
+
+
 class SogsParser {
     /** @type {AppBase} */
     app;
@@ -24,6 +49,15 @@ class SogsParser {
         this.maxRetries = maxRetries;
     }
 
+    /**
+     * Loads the textures for the SOGS data.
+     *
+     * @param {string} url - The URL of the resource to load.
+     * @param {ResourceHandlerCallback} callback - The callback used when
+     * the resource is loaded or an error occurs.
+     * @param {Asset} asset - Container asset.
+     * @param {SogsMeta} meta - The metadata for the SOGS data.
+     */
     async loadTextures(url, callback, asset, meta) {
         const { assets } = this.app;
 

--- a/src/index.js
+++ b/src/index.js
@@ -238,6 +238,10 @@ export { GSplat } from './scene/gsplat/gsplat.js';
 export { GSplatInstance } from './scene/gsplat/gsplat-instance.js';
 export { GSplatSogsData } from './scene/gsplat/gsplat-sogs-data.js';
 
+/**
+ * @typedef {import('./framework/parsers/sogs.js').SogsMeta} SogsMeta
+ */
+
 // FRAMEWORK
 export * from './framework/constants.js';
 export { script } from './framework/script.js';


### PR DESCRIPTION
Exports a `SogsMeta` type for Sogs meta data. This is a handy type that's useful for engine consumers (@playcanvas/react). Also generates associated docs.

prop descriptions tbd

![image](https://github.com/user-attachments/assets/a54cf12d-b003-437c-8244-819fa7c7c4e9)

