### PR TITLE
Mesh-based Skydome can write depth during prepass, to be comparible with DOF

### DIFF
--- a/examples/src/examples/graphics/shadow-catcher.controls.mjs
+++ b/examples/src/examples/graphics/shadow-catcher.controls.mjs
@@ -34,6 +34,15 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'data.rotate' }
                 })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'DOF' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.dof' }
+                })
             )
         )
     );

--- a/examples/src/examples/graphics/shadow-catcher.example.mjs
+++ b/examples/src/examples/graphics/shadow-catcher.example.mjs
@@ -55,6 +55,12 @@ const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets
 assetListLoader.load(() => {
     app.start();
 
+    // Depth layer is where prepass finishes rendering. Move the depth layer to take place after
+    // World and Skydome layers, to capture both of them in depth buffer, to be used by Depth of Field
+    const depthLayer = app.scene.layers.getLayerById(pc.LAYERID_DEPTH);
+    app.scene.layers.remove(depthLayer);
+    app.scene.layers.insertOpaque(depthLayer, 2);
+
     // add an instance of the statue
     const statueEntity = assets.statue.resource.instantiateRenderEntity({
         castShadows: true
@@ -107,11 +113,14 @@ assetListLoader.load(() => {
     };
 
     applyHdri(assets.hdri_street.resource);
+    app.scene.exposure = 0.4;
     app.scene.sky.type = pc.SKYTYPE_DOME;
     app.scene.sky.node.setLocalScale(new pc.Vec3(200, 200, 200));
     app.scene.sky.node.setLocalPosition(pc.Vec3.ZERO);
     app.scene.sky.center = new pc.Vec3(0, 0.05, 0);
-    app.scene.exposure = 0.4;
+
+    // enable depth writing for the sky, for DOF to work on it
+    app.scene.sky.depthWrite = true;
 
     // create two directional lights which cast shadows
     const light1 = new pc.Entity('Light1');
@@ -123,7 +132,7 @@ assetListLoader.load(() => {
         normalOffsetBias: 0.3,
         shadowDistance: 50,
         shadowResolution: 1024,
-        shadowIntensity: 0.2,
+        shadowIntensity: 0.4,
         shadowType: pc.SHADOW_PCSS_32F,
         penumbraSize: 10,
         penumbraFalloff: 4,
@@ -142,7 +151,7 @@ assetListLoader.load(() => {
         normalOffsetBias: 0.3,
         shadowDistance: 50,
         shadowResolution: 1024,
-        shadowIntensity: 0.3
+        shadowIntensity: 0.5
     });
     light2.setLocalEulerAngles(45, -30, 0);
     app.root.addChild(light2);
@@ -155,16 +164,47 @@ assetListLoader.load(() => {
             scale: new pc.Vec3(50, 50, 50)
         }
     });
+
+    // offset it slightly above the ground (skydome) - this is needed when DOF is enabled and the skydome
+    // writes depth to the depth buffer, to avoid depth conflicts with the shadow catcher plane
+    shadowCatcher.setLocalPosition(0, 0.01, 0);
+
     app.root.addChild(shadowCatcher);
 
     // set initial values
     data.set('data', {
         affectScene: false,
         catcher: true,
-        rotate: false
+        rotate: false,
+        dof: true
     });
 
+    // set up CameraFrame rendering, to give us access to Depth of Field
+    const cameraFrame = new pc.CameraFrame(app, cameraEntity.camera);
+    cameraFrame.rendering.toneMapping = pc.TONEMAP_ACES;
+    cameraFrame.dof.enabled = true;
+    cameraFrame.dof.nearBlur = true;
+    cameraFrame.dof.focusDistance = 30;
+    cameraFrame.dof.focusRange = 10;
+    cameraFrame.dof.blurRadius = 7;
+    cameraFrame.dof.blurRings = 5;
+    cameraFrame.dof.blurRingPoints = 5;
+    cameraFrame.dof.highQuality = true;
+    cameraFrame.update();
+
     app.on('update', (dt) => {
+
+        // toggle DOF
+        cameraFrame.dof.enabled = data.get('data.dof');
+
+        // DOF distance - distance between the camera and the entity
+        const distance = cameraEntity.position.distance(statueEntity.position);
+        cameraFrame.dof.focusDistance = distance;
+        cameraFrame.update();
+
+        // adjust shadow distance to never clip them
+        light1.light.shadowDistance = distance + 15;
+        light2.light.shadowDistance = distance + 15;
 
         // enable the shadow catcher
         shadowCatcher.enabled = data.get('data.catcher');

--- a/src/scene/shader-lib/glsl/chunks/skybox/vert/skybox.js
+++ b/src/scene/shader-lib/glsl/chunks/skybox/vert/skybox.js
@@ -1,15 +1,16 @@
 export default /* glsl */`
 attribute vec4 aPosition;
 
-#ifndef VIEWMATRIX
-#define VIEWMATRIX
 uniform mat4 matrix_view;
-#endif
-
 uniform mat4 matrix_projectionSkybox;
 uniform mat3 cubeMapRotationMatrix;
 
 varying vec3 vViewDir;
+
+#ifdef PREPASS_PASS
+    // when skydome renders depth during prepass, generate linear depth
+    varying float vLinearDepth;
+#endif
 
 #ifdef SKYMESH
     uniform mat4 matrix_model;
@@ -26,12 +27,21 @@ void main(void) {
         vWorldPos = worldPos.xyz;
         gl_Position = matrix_projectionSkybox * (view * worldPos);
 
+        #ifdef PREPASS_PASS
+            // linear depth from the worldPosition, see getLinearDepth
+            vLinearDepth = -(matrix_view * vec4(vWorldPos, 1.0)).z;
+        #endif
+
     #else
 
         view[3][0] = view[3][1] = view[3][2] = 0.0;
         gl_Position = matrix_projectionSkybox * (view * aPosition);
         vViewDir = aPosition.xyz * cubeMapRotationMatrix;
 
+        #ifdef PREPASS_PASS
+            // for infinite skybox, use negative gl_Position.w to get positive linear depth
+            vLinearDepth = -gl_Position.w;
+        #endif
     #endif
 
     // Force skybox to far Z, regardless of the clip planes on the camera

--- a/src/scene/shader-lib/wgsl/chunks/skybox/frag/skybox.js
+++ b/src/scene/shader-lib/wgsl/chunks/skybox/frag/skybox.js
@@ -5,6 +5,11 @@ export default /* wgsl */`
     #include "gammaPS"
     #include "tonemappingPS"
 
+    #ifdef PREPASS_PASS
+        varying vLinearDepth: f32;
+        #include "floatAsUintPS"
+    #endif
+
     // Varying and uniform declarations
     varying vViewDir : vec3f;
     uniform skyboxHighlightMultiplier : f32;
@@ -35,37 +40,48 @@ export default /* wgsl */`
     @fragment
     fn fragmentMain(input : FragmentInput) -> FragmentOutput {
 
-        var linear : vec3f;
-        var dir : vec3f;
+        var output: FragmentOutput;
 
-        #ifdef SKY_CUBEMAP
+        #ifdef PREPASS_PASS
 
-            #ifdef SKYMESH
-                // get vector from world space pos to tripod origin
-                var envDir : vec3f = normalize(input.vWorldPos - uniform.projectedSkydomeCenter);
-                dir = envDir * uniform.cubeMapRotationMatrix;
-            #else
-                dir = input.vViewDir;
+            // output linear depth during prepass
+            output.color = float2vec4(vLinearDepth);
+
+        #else
+
+            var linear : vec3f;
+            var dir : vec3f;
+
+            #ifdef SKY_CUBEMAP
+
+                #ifdef SKYMESH
+                    // get vector from world space pos to tripod origin
+                    var envDir : vec3f = normalize(input.vWorldPos - uniform.projectedSkydomeCenter);
+                    dir = envDir * uniform.cubeMapRotationMatrix;
+                #else
+                    dir = input.vViewDir;
+                #endif
+
+                dir.x *= -1.0;
+                linear = {SKYBOX_DECODE_FNC}(textureSample(texture_cubeMap, texture_cubeMap_sampler, dir));
+
+            #else // env-atlas
+
+                dir = input.vViewDir * vec3f(-1.0, 1.0, 1.0);
+                let uv : vec2f = toSphericalUv(normalize(dir));
+                linear = {SKYBOX_DECODE_FNC}(textureSample(texture_envAtlas, texture_envAtlas_sampler, mapRoughnessUv(uv, uniform.mipLevel)));
+
             #endif
 
-            dir.x *= -1.0;
-            linear = {SKYBOX_DECODE_FNC}(textureSample(texture_cubeMap, texture_cubeMap_sampler, dir));
-
-        #else // env-atlas
-
-            dir = input.vViewDir * vec3f(-1.0, 1.0, 1.0);
-            let uv : vec2f = toSphericalUv(normalize(dir));
-            linear = {SKYBOX_DECODE_FNC}(textureSample(texture_envAtlas, texture_envAtlas_sampler, mapRoughnessUv(uv, uniform.mipLevel)));
+            // our HDR encodes values up to 64, so allow extra brightness for the clipped values
+            if (any(linear >= vec3f(64.0))) {
+                linear *= uniform.skyboxHighlightMultiplier;
+            }
+            
+            output.color = vec4f(gammaCorrectOutput(toneMap(processEnvironment(linear))), 1.0);
 
         #endif
 
-        // our HDR encodes values up to 64, so allow extra brightness for the clipped values
-        if (any(linear >= vec3f(64.0))) {
-            linear *= uniform.skyboxHighlightMultiplier;
-        }
-        
-        var output: FragmentOutput;
-        output.color = vec4f(gammaCorrectOutput(toneMap(processEnvironment(linear))), 1.0);
         return output;
     }
 `;

--- a/src/scene/shader-lib/wgsl/chunks/skybox/vert/skybox.js
+++ b/src/scene/shader-lib/wgsl/chunks/skybox/vert/skybox.js
@@ -2,15 +2,16 @@ export default /* wgsl */`
     // Attribute
     attribute aPosition : vec4f;
 
-    #ifndef VIEWMATRIX
-    #define VIEWMATRIX
     uniform matrix_view : mat4x4f;
-    #endif
-
     uniform matrix_projectionSkybox : mat4x4f;
     uniform cubeMapRotationMatrix : mat3x3f;
 
     varying vViewDir : vec3f;
+
+    #ifdef PREPASS_PASS
+        // when skydome renders depth during prepass, generate linear depth
+        varying vLinearDepth: f32;
+    #endif
 
     #ifdef SKYMESH
         uniform matrix_model : mat4x4f;
@@ -29,6 +30,11 @@ export default /* wgsl */`
             output.vWorldPos = worldPos.xyz;
             output.position = uniform.matrix_projectionSkybox * (view * worldPos);
 
+            #ifdef PREPASS_PASS
+                // linear depth from the worldPosition, see getLinearDepth
+                output.vLinearDepth = -(uniform.matrix_view * vec4f(worldPos.xyz, 1.0)).z;
+            #endif
+
         #else
 
             view[3][0] = 0.0;
@@ -37,6 +43,10 @@ export default /* wgsl */`
             output.position = uniform.matrix_projectionSkybox * (view * input.aPosition);
             output.vViewDir = input.aPosition.xyz * uniform.cubeMapRotationMatrix;
 
+            #ifdef PREPASS_PASS
+                // for infinite skybox, use negative gl_Position.w to get positive linear depth
+                output.vLinearDepth = -pcPosition.w;
+            #endif
         #endif
 
         // Force skybox to far Z, regardless of the clip planes on the camera

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -27,6 +27,11 @@ class SkyMesh {
     meshInstance = null;
 
     /**
+     * @type {boolean}
+     */
+    _depthWrite = false;
+
+    /**
      * @param {GraphicsDevice} device - The graphics device.
      * @param {Scene} scene - The scene owning the sky.
      * @param {GraphNode} node - The graph node of the sky mesh instance.
@@ -60,8 +65,10 @@ class SkyMesh {
             material.setParameter('mipLevel', scene.skyboxMip);
         }
 
+        // render inside of the geometry
         material.cull = CULLFACE_FRONT;
-        material.depthWrite = false;
+
+        material.depthWrite = this._depthWrite;
 
         const skyLayer = scene.layers.getLayerById(LAYERID_SKYBOX);
         if (skyLayer) {
@@ -89,6 +96,17 @@ class SkyMesh {
             this.meshInstance.destroy();
             this.meshInstance = null;
         }
+    }
+
+    set depthWrite(value) {
+        this._depthWrite = value;
+        if (this.meshInstance) {
+            this.meshInstance.material.depthWrite = value;
+        }
+    }
+
+    get depthWrite() {
+        return this._depthWrite;
     }
 }
 

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -136,6 +136,11 @@ class Sky {
         }
     }
 
+    /**
+     * Returns whether depth writing is enabled for the sky.
+     *
+     * @type {boolean}
+     */
     get depthWrite() {
         return this._depthWrite;
     }

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -38,6 +38,12 @@ class Sky {
     skyMesh = null;
 
     /**
+     * @type {boolean}
+     * @private
+     */
+    _depthWrite = false;
+
+    /**
      * A graph node with a transform used to render the sky mesh. Adjust the position, rotation and
      * scale of this node to orient the sky mesh. Ignored for {@link SKYTYPE_INFINITE}.
      *
@@ -109,11 +115,37 @@ class Sky {
         return this._center;
     }
 
+    /**
+     * Whether depth writing is enabled for the sky. Defaults to false.
+     *
+     * Writing a depth value for the skydome is supported when its type is not
+     * {@link SKYTYPE_INFINITE}. When enabled, the depth is written during a prepass render pass and
+     * can be utilized by subsequent passes to apply depth-based effects, such as Depth of Field.
+     *
+     * Note: For the skydome to be rendered during the prepass, the Sky Layer must be ordered before
+     * the Depth layer, which is the final layer used in the prepass.
+     *
+     * @type {boolean}
+     */
+    set depthWrite(value) {
+        if (this._depthWrite !== value) {
+            this._depthWrite = value;
+            if (this.skyMesh) {
+                this.skyMesh.depthWrite = value;
+            }
+        }
+    }
+
+    get depthWrite() {
+        return this._depthWrite;
+    }
+
     updateSkyMesh() {
         const texture = this.scene._getSkyboxTex();
         if (texture) {
             this.resetSkyMesh();
             this.skyMesh = new SkyMesh(this.device, this.scene, this.node, texture, this.type);
+            this.skyMesh.depthWrite = this._depthWrite;
             this.scene.fire('set:skybox', texture);
         }
     }


### PR DESCRIPTION
New public API:

```
    // enable depth writing for the sky, for DOF to work on it
    app.scene.sky.depthWrite = true;
```

When `skydome` or `skybox` sky is used (and not `infinite`), it can write depth during the depth-prepass. This allows it to be affected by DOF.
Adjusted example to show how to use this.

Also other small example improvements - darker shadows, automatic shadow distance.


https://github.com/user-attachments/assets/e6bda984-16b4-494d-885a-f1b68c9b1cc5

