### PR TITLE
Improve positional audio example

### DIFF
--- a/examples/src/examples/sound/positional.example.mjs
+++ b/examples/src/examples/sound/positional.example.mjs
@@ -106,7 +106,9 @@ assetListLoader.load(() => {
     const entity = new pc.Entity();
 
     // add sound component
-    entity.addComponent('sound');
+    entity.addComponent('sound', {
+        maxDistance: 9
+    });
 
     // add footsteps slot
     entity.sound.addSlot('footsteps', {


### PR DESCRIPTION
Improves the positional audio example.

Default max distance for the panner is 10km, which is too large for this example, making it hard to discern the positional properties of 3d audio.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
