### PR TITLE
Use GLSL transpilation to WGSL if only GLSL chunks were overriden

### DIFF
--- a/src/scene/shader-lib/programs/shader-generator-shader.js
+++ b/src/scene/shader-lib/programs/shader-generator-shader.js
@@ -86,7 +86,7 @@ class ShaderGeneratorShader extends ShaderGenerator {
     createShaderDefinition(device, options) {
 
         const desc = options.shaderDesc;
-        const wgsl = device.isWebGPU && !!desc.vertexWGSL && !!desc.fragmentWGSL;
+        const wgsl = device.isWebGPU && !!desc.vertexWGSL && !!desc.fragmentWGSL && (options.shaderChunks?.useWGSL ?? true);
         const definitionOptions = {
             name: `ShaderMaterial-${desc.uniqueName}`,
             shaderLanguage: wgsl ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL,


### PR DESCRIPTION
- when only GLSL chunks are overwritten, but not WGSL, transpile GLSL to WGSL on WebGPU