### PR TITLE
Various small gsplat fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -238,6 +238,7 @@ export { GSplatResourceBase } from './scene/gsplat/gsplat-resource-base.js';
 export { GSplatResource } from './scene/gsplat/gsplat-resource.js';
 export { GSplatInstance } from './scene/gsplat/gsplat-instance.js';
 export { GSplatSogsData } from './scene/gsplat/gsplat-sogs-data.js';
+export { GSplatSogsResource } from './scene/gsplat/gsplat-sogs-resource.js';
 
 // FRAMEWORK
 export * from './framework/constants.js';

--- a/src/scene/gsplat/gsplat-compressed-resource.js
+++ b/src/scene/gsplat/gsplat-compressed-resource.js
@@ -88,6 +88,7 @@ class GSplatCompressedResource extends GSplatResourceBase {
         this.shTexture0?.destroy();
         this.shTexture1?.destroy();
         this.shTexture2?.destroy();
+        super.destroy();
     }
 
     configureMaterial(material) {

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -88,6 +88,9 @@ class GSplatResourceBase {
         this.mesh.setIndices(meshIndices);
         this.mesh.update();
 
+        // keep extra reference since mesh is shared between instances
+        this.mesh.incRefCount();
+
         this.mesh.aabb.copy(this.aabb);
 
         this.instanceIndices = new VertexBuffer(device, vertexFormat, numSplatInstances, {

--- a/src/scene/gsplat/gsplat-resource.js
+++ b/src/scene/gsplat/gsplat-resource.js
@@ -92,6 +92,7 @@ class GSplatResource extends GSplatResourceBase {
         this.sh4to7Texture?.destroy();
         this.sh8to11Texture?.destroy();
         this.sh12to15Texture?.destroy();
+        super.destroy();
     }
 
     configureMaterial(material) {

--- a/src/scene/gsplat/gsplat-sogs-resource.js
+++ b/src/scene/gsplat/gsplat-sogs-resource.js
@@ -4,6 +4,7 @@ import { GSplatResourceBase } from './gsplat-resource-base.js';
 class GSplatSogsResource extends GSplatResourceBase {
     destroy() {
         this.gsplatData.destroy();
+        super.destroy();
     }
 
     configureMaterial(material) {


### PR DESCRIPTION
Fixes:
- GSplatResourceBase needs to keep a reference to the Mesh.
- GSplatResource types need to call super destroy