### PR TITLE
Implementation of baseVertex support

### DIFF
--- a/src/extras/mini-stats/render2d.js
+++ b/src/extras/mini-stats/render2d.js
@@ -144,6 +144,7 @@ class Render2d {
             type: PRIMITIVE_TRIANGLES,
             indexed: true,
             base: 0,
+            baseVertex: 0,
             count: 0
         };
         this.quads = 0;

--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -159,6 +159,7 @@ class TransformFeedback {
         device.draw({
             type: PRIMITIVE_POINTS,
             base: 0,
+            baseVertex: 0,
             count: this._inputBuffer.numVertices,
             indexed: false
         });

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1708,6 +1708,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * device.draw({
      *     type: pc.PRIMITIVE_TRIANGLES,
      *     base: 0,
+     *     baseVertex: 0,
      *     count: 3,
      *     indexed: false
      * });

--- a/src/platform/graphics/webgpu/webgpu-clear-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-clear-renderer.js
@@ -16,6 +16,7 @@ import { DepthState } from '../depth-state.js';
 const primitive = {
     type: PRIMITIVE_TRISTRIP,
     base: 0,
+    baseVertex: 0,
     count: 4,
     indexed: false
 };

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -591,7 +591,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             // draw
             if (ib) {
                 passEncoder.setIndexBuffer(ib.impl.buffer, ib.impl.format);
-                passEncoder.drawIndexed(primitive.count, numInstances, primitive.base, 0, 0);
+                passEncoder.drawIndexed(primitive.count, numInstances, primitive.base, primitive.baseVertex || 0, 0);
             } else {
                 passEncoder.draw(primitive.count, numInstances, primitive.base, 0);
             }

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -658,7 +658,7 @@ class BatchManager {
             batch = new Batch(meshInstances, dynamic, batchGroupId);
             this._batchList.push(batch);
 
-            let indexBase, numIndices, indexData;
+            let indexBase, indexBaseVertex, numIndices, indexData;
             let verticesOffset = 0;
             let indexOffset = 0;
             let transform;
@@ -760,6 +760,7 @@ class BatchManager {
                 // index buffer
                 if (mesh.primitive[0].indexed) {
                     indexBase = mesh.primitive[0].base;
+                    indexBaseVertex = mesh.primitive[0].baseVertex || 0;
                     numIndices = mesh.primitive[0].count;
 
                     // source index buffer data mapped to its format
@@ -767,6 +768,8 @@ class BatchManager {
                     indexData = new typedArrayIndexFormats[srcFormat](mesh.indexBuffer[0].storage);
 
                 } else { // non-indexed
+
+                    indexBaseVertex = 0;
 
                     const primitiveType = mesh.primitive[0].type;
                     if (primitiveType === PRIMITIVE_TRIFAN || primitiveType === PRIMITIVE_TRISTRIP) {
@@ -782,7 +785,7 @@ class BatchManager {
                 }
 
                 for (let j = 0; j < numIndices; j++) {
-                    indices[j + indexOffset] = indexData[indexBase + j] + verticesOffset;
+                    indices[j + indexOffset] = indexData[indexBase + j] + indexBaseVertex + verticesOffset;
                 }
 
                 indexOffset += numIndices;

--- a/src/scene/graphics/quad-render.js
+++ b/src/scene/graphics/quad-render.js
@@ -14,6 +14,7 @@ import { ShaderUtils } from '../shader-lib/shader-utils.js';
 const _quadPrimitive = {
     type: PRIMITIVE_TRISTRIP,
     base: 0,
+    baseVertex: 0,
     count: 4,
     indexed: false
 };

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -201,15 +201,17 @@ class Mesh extends RefCountedObject {
      *   - {@link PRIMITIVE_TRIFAN}
      *
      * - `base` is the offset of the first index or vertex to dispatch in the draw call.
+     * - `baseVertex` is the number added to each index value before indexing into the vertex buffers. (available only for WebGPU and Batching)
      * - `count` is the number of indices or vertices to dispatch in the draw call.
      * - `indexed` specifies whether to interpret the primitive as indexed, thereby using the
      * currently set index buffer.
      *
-     * @type {{type: number, base: number, count: number, indexed?: boolean}[]}
+     * @type {{type: number, base: number, baseVertex: number, count: number, indexed?: boolean}[]}
      */
     primitive = [{
         type: 0,
         base: 0,
+        baseVertex: 0,
         count: 0
     }];
 
@@ -1044,6 +1046,7 @@ class Mesh extends RefCountedObject {
             this.primitive[RENDERSTYLE_POINTS] = {
                 type: PRIMITIVE_POINTS,
                 base: 0,
+                baseVertex: 0,
                 count: this.vertexBuffer ? this.vertexBuffer.numVertices : 0,
                 indexed: false
             };
@@ -1108,6 +1111,7 @@ class Mesh extends RefCountedObject {
         this.primitive[RENDERSTYLE_WIREFRAME] = {
             type: PRIMITIVE_LINES,
             base: 0,
+            baseVertex: 0,
             count: lines.length,
             indexed: true
         };


### PR DESCRIPTION
This PR introduces an important update related to support for the baseVertex parameter when rendering primitives. This functionality allows specifying an offset for vertex indices, which is especially useful for batching—combining multiple objects into a single draw call to improve efficiency.

Support for baseVertex is fully implemented for WebGPU, providing compatibility and high performance on modern graphics APIs designed for web applications. This implementation enables correct usage of baseVertex during batching, allowing more flexible management of indices and vertices without the need to duplicate data.

Regarding WebGL2, support for baseVertex is limited. Currently, WebGL2 does not offer full support for this feature, which imposes some restrictions on its use in browsers and applications based on WebGL2. However, partial support can be achieved through extensions such as WEBGL_draw_instanced_base_vertex_base_instance, which broadens rendering capabilities and optimization options.

It’s also worth noting that a previous PR on this topic was prepared but had to be closed due to certain issues—possibly related to technical difficulties or compatibility concerns.

For more detailed information, you can refer to the following sources:

Official PR on GitHub: https://github.com/KhronosGroup/WebGL/pull/2941
WebGL extension documentation: https://web3dsurvey.com/webgl2/extensions/WEBGL_draw_instanced_base_vertex_base_instance

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
