### PR TITLE
Fix physics components order

### DIFF
--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -122,6 +122,8 @@ class CollisionComponent extends Component {
      */
     static EVENT_TRIGGERLEAVE = 'triggerleave';
 
+    static order = 2;
+
     /** @private */
     _compoundParent = null;
 

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -126,7 +126,7 @@ class RigidBodyComponent extends Component {
      */
     static EVENT_TRIGGERLEAVE = 'triggerleave';
 
-    static order = -1;
+    static order = 1;
 
     /** @private */
     _angularDamping = 0;


### PR DESCRIPTION
Fixes #7769

PR fixes the components order for RigidBody and Collision components:

RigidBody: 1
Collision: 2

This is done to maintain both of their relative positions in the end of the components list of application lifecycle.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
