### PR TITLE
Fix doc types in rigidbody system

### DIFF
--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -7,6 +7,8 @@ import { ComponentSystem } from '../system.js';
 import { BODYFLAG_NORESPONSE_OBJECT } from './constants.js';
 import { RigidBodyComponent } from './component.js';
 import { RigidBodyComponentData } from './data.js';
+import { Trigger } from '../collision/trigger.js';
+import { CollisionComponent } from '../collision/component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
@@ -402,13 +404,13 @@ class RigidBodyComponentSystem extends ComponentSystem {
     _kinematic = [];
 
     /**
-     * @type {RigidBodyComponent[]}
+     * @type {Trigger[]}
      * @private
      */
     _triggers = [];
 
     /**
-     * @type {RigidBodyComponent[]}
+     * @type {CollisionComponent[]}
      * @private
      */
     _compounds = [];

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -10,9 +10,9 @@ import { RigidBodyComponentData } from './data.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { CollisionComponent } from '../collision/component.js'
  * @import { Entity } from '../../entity.js'
  * @import { Trigger } from '../collision/trigger.js'
- * @import { CollisionComponent } from '../collision/component.js'
  */
 
 let ammoRayStart, ammoRayEnd;

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -7,12 +7,12 @@ import { ComponentSystem } from '../system.js';
 import { BODYFLAG_NORESPONSE_OBJECT } from './constants.js';
 import { RigidBodyComponent } from './component.js';
 import { RigidBodyComponentData } from './data.js';
-import { Trigger } from '../collision/trigger.js';
-import { CollisionComponent } from '../collision/component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
  * @import { Entity } from '../../entity.js'
+ * @import { Trigger } from '../collision/trigger.js'
+ * @import { CollisionComponent } from '../collision/component.js'
  */
 
 let ammoRayStart, ammoRayEnd;


### PR DESCRIPTION
This PR fixes incorrectly set types in the documentation for the Rigidbody system. As a result of these changes, the documentation has become more accurate and clear, which will help developers better understand how to use the system and avoid errors related to data types.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
