### PR TITLE
Fix to anisotropy-lamp example - layer order changed for sky to be captured by grab pass

### DIFF
--- a/examples/src/examples/materials/anisotropy-lamp.example.mjs
+++ b/examples/src/examples/materials/anisotropy-lamp.example.mjs
@@ -57,10 +57,17 @@ const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets
 assetListLoader.load(() => {
     app.start();
 
+    // Depth layer is where the framebuffer is copied to a texture to be used in the following layers.
+    // Move the depth layer to take place after World and Skydome layers, to capture both of them.
+    const depthLayer = app.scene.layers.getLayerById(pc.LAYERID_DEPTH);
+    app.scene.layers.remove(depthLayer);
+    app.scene.layers.insertOpaque(depthLayer, 2);
+
     // Setup skydome
     app.scene.envAtlas = assets.helipad.resource;
     app.scene.skyboxRotation = new pc.Quat().setFromEulerAngles(0, 70, 0);
     app.scene.skyboxIntensity = 0.5;
+    app.scene.skyboxMip = 1;
 
     const leftEntity = assets.model.resource.instantiateRenderEntity();
     leftEntity.setLocalEulerAngles(0, 0, 0);


### PR DESCRIPTION
before
![Screenshot 2025-06-16 at 11 19 47](https://github.com/user-attachments/assets/515f2f1f-1892-41b1-85a1-ee3507271395)

now - see the light bulb
![Screenshot 2025-06-16 at 11 17 13](https://github.com/user-attachments/assets/22e3aa2b-7ca0-4368-8cbb-874c9edf1e2f)
