### PR TITLE
Additional frustum culling events in order to better support indirect drawing

### DIFF
--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1081,15 +1081,22 @@ export const EVENT_PRERENDER_LAYER = 'prerender:layer';
 export const EVENT_POSTRENDER_LAYER = 'postrender:layer';
 
 /**
- * Name of event fired before visibility culling is performed for the camera
+ * Name of event fired before visibility culling is performed for the camera.
  *
  * @ignore
  */
 export const EVENT_PRECULL = 'precull';
 
 /**
- * Name of event after before visibility culling is performed for the camera
+ * Name of event after visibility culling is performed for the camera.
  *
  * @ignore
  */
 export const EVENT_POSTCULL = 'postcull';
+
+/**
+ * Name of event after the engine has finished culling all cameras.
+ *
+ * @ignore
+ */
+export const EVENT_CULL_END = 'cull:end';

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -24,8 +24,7 @@ import {
     VIEW_CENTER, PROJECTION_ORTHOGRAPHIC,
     LIGHTTYPE_DIRECTIONAL, MASK_AFFECT_DYNAMIC, MASK_AFFECT_LIGHTMAPPED, MASK_BAKE,
     SHADOWUPDATE_NONE, SHADOWUPDATE_THISFRAME,
-    EVENT_PRECULL,
-    EVENT_POSTCULL
+    EVENT_PRECULL, EVENT_POSTCULL, EVENT_CULL_END
 } from '../constants.js';
 import { LightCube } from '../graphics/light-cube.js';
 import { getBlueNoiseTexture } from '../graphics/noise-textures.js';
@@ -1136,6 +1135,9 @@ class Renderer {
 
         // cull shadow casters for all lights
         this.cullShadowmaps(comp);
+
+        // event after the engine has finished culling all cameras
+        scene?.fire(EVENT_CULL_END);
 
         // #if _PROFILER
         this._cullTime += now() - cullTime;

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -12,6 +12,8 @@ import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { drawQuadWithShader } from '../graphics/quad-render-utils.js';
 import {
     BLUR_GAUSSIAN,
+    EVENT_POSTCULL,
+    EVENT_PRECULL,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI,
     SHADER_SHADOW,
     SHADOWUPDATE_NONE, SHADOWUPDATE_THISFRAME,
@@ -163,6 +165,9 @@ class ShadowRenderer {
      */
     cullShadowCasters(comp, light, visible, camera, casters) {
 
+        // event before the camera is culling
+        this.renderer.scene?.fire(EVENT_PRECULL, camera);
+
         visible.length = 0;
 
         // if the casters are supplied, use them
@@ -193,6 +198,9 @@ class ShadowRenderer {
 
         // this sorts the shadow casters by the shader id
         visible.sort(this.sortCompareShader);
+
+        // event after the camera is done with culling
+        this.renderer.scene?.fire(EVENT_POSTCULL, camera);
     }
 
     sortCompareShader(drawCallA, drawCallB) {


### PR DESCRIPTION
This PR:
- fires existing `EVENT_PRECULL` and `EVENT_POSTCULL` events even for shadow cameras
- fires new `EVENT_CULL_END` event when all culling is completed (scene + shadow cameras)

This along with [Indirect Drawing](https://github.com/playcanvas/engine/pull/7777) can be used to implement instanced culling on GPU:
1. Collect all cameras the scene uses for rendering of the frame (scene + shadow cameras)
2. dispatch a Compute shader which culls instanced mesh instances, and uses indirect drawing to render visible instances per camera

