### PR TITLE
Limit large gaussians

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
@@ -22,14 +22,6 @@ export default /* glsl */`
 varying mediump vec2 gaussianUV;
 varying mediump vec4 gaussianColor;
 
-// Fast approximate e^x based on https://nic.schraudolph.org/pubs/Schraudolph99.pdf
-const float  EXP_A      = 12102203.0;   // ≈ 2^23 / ln(2)
-const int    EXP_BC_RMS = 1064866808;   // (127 << 23) - 60 801*8
-float fastExp(float x) {
-    int i = int(EXP_A * x) + EXP_BC_RMS;
-    return intBitsToFloat(i);
-}
-
 void main(void) {
     mediump float A = dot(gaussianUV, gaussianUV);
     if (A > 1.0) {
@@ -38,8 +30,6 @@ void main(void) {
 
     // evaluate alpha
     mediump float alpha = exp(-A * 4.0) * gaussianColor.a;
-    // mediump float alpha = fastExp(-A * 4.0) * gaussianColor.a;
-    // mediump float alpha = pow(1.0 - A, 3.0) * gaussianColor.a;
 
     #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
         if (alpha < alphaClip) {

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
@@ -22,6 +22,14 @@ export default /* glsl */`
 varying mediump vec2 gaussianUV;
 varying mediump vec4 gaussianColor;
 
+// Fast approximate e^x based on https://nic.schraudolph.org/pubs/Schraudolph99.pdf
+const float  EXP_A      = 12102203.0;   // ≈ 2^23 / ln(2)
+const int    EXP_BC_RMS = 1064866808;   // (127 << 23) - 60 801*8
+float fastExp(float x) {
+    int i = int(EXP_A * x) + EXP_BC_RMS;
+    return intBitsToFloat(i);
+}
+
 void main(void) {
     mediump float A = dot(gaussianUV, gaussianUV);
     if (A > 1.0) {
@@ -30,6 +38,8 @@ void main(void) {
 
     // evaluate alpha
     mediump float alpha = exp(-A * 4.0) * gaussianColor.a;
+    // mediump float alpha = fastExp(-A * 4.0) * gaussianColor.a;
+    // mediump float alpha = pow(1.0 - A, 3.0) * gaussianColor.a;
 
     #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
         if (alpha < alphaClip) {

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCorner.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCorner.js
@@ -46,7 +46,7 @@ bool initCorner(SplatSource source, SplatCenter center, out SplatCorner corner) 
     float lambda2 = max(mid - radius, 0.1);
 
     // Use the smaller viewport dimension to limit the kernel size relative to the screen resolution.
-    float vmin = min(viewport.x, viewport.y);
+    float vmin = min(1024.0, min(viewport.x, viewport.y));
 
     float l1 = 2.0 * min(sqrt(2.0 * lambda1), vmin);
     float l2 = 2.0 * min(sqrt(2.0 * lambda2), vmin);

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCorner.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCorner.js
@@ -47,7 +47,7 @@ fn initCorner(source: ptr<function, SplatSource>, center: ptr<function, SplatCen
     let lambda2 = max(mid - radius, 0.1);
 
     // Use the smaller viewport dimension to limit the kernel size relative to the screen resolution.
-    let vmin = min(uniform.viewport.x, uniform.viewport.y);
+    let vmin = min(1024.0, min(uniform.viewport.x, uniform.viewport.y));
 
     let l1 = 2.0 * min(sqrt(2.0 * lambda1), vmin);
     let l2 = 2.0 * min(sqrt(2.0 * lambda2), vmin);


### PR DESCRIPTION
Followup to #7696.

Reintroduce the 1024 pixel size limit, otherwise high resolution screens will have larger gaussians than before.