### PR TITLE
fastExp implementation for gsplat rendering

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
@@ -22,6 +22,14 @@ export default /* glsl */`
 varying mediump vec2 gaussianUV;
 varying mediump vec4 gaussianColor;
 
+// Fast approximate e^x based on https://nic.schraudolph.org/pubs/Schraudolph99.pdf
+const float  EXP_A      = 12102203.0;   // ≈ 2^23 / ln(2)
+const int    EXP_BC_RMS = 1064866808;   // (127 << 23) - 60 801*8
+float fastExp(float x) {
+    int i = int(EXP_A * x) + EXP_BC_RMS;
+    return intBitsToFloat(i);
+}
+
 void main(void) {
     mediump float A = dot(gaussianUV, gaussianUV);
     if (A > 1.0) {
@@ -30,6 +38,8 @@ void main(void) {
 
     // evaluate alpha
     mediump float alpha = exp(-A * 4.0) * gaussianColor.a;
+    // mediump float alpha = fastExp(-A * 4.0) * gaussianColor.a;
+    // mediump float alpha = pow(1.0 - A, 3.0) * gaussianColor.a;
 
     #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
         if (alpha < alphaClip) {

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
@@ -19,9 +19,6 @@ export default /* glsl */`
     #include "floatAsUintPS"
 #endif
 
-varying mediump vec2 gaussianUV;
-varying mediump vec4 gaussianColor;
-
 // Fast approximate e^x based on https://nic.schraudolph.org/pubs/Schraudolph99.pdf
 const float  EXP_A      = 12102203.0;   // ≈ 2^23 / ln(2)
 const int    EXP_BC_RMS = 1064866808;   // (127 << 23) - 60 801*8
@@ -30,6 +27,9 @@ float fastExp(float x) {
     return intBitsToFloat(i);
 }
 
+varying mediump vec2 gaussianUV;
+varying mediump vec4 gaussianColor;
+
 void main(void) {
     mediump float A = dot(gaussianUV, gaussianUV);
     if (A > 1.0) {
@@ -37,9 +37,7 @@ void main(void) {
     }
 
     // evaluate alpha
-    mediump float alpha = exp(-A * 4.0) * gaussianColor.a;
-    // mediump float alpha = fastExp(-A * 4.0) * gaussianColor.a;
-    // mediump float alpha = pow(1.0 - A, 3.0) * gaussianColor.a;
+    mediump float alpha = fastExp(-A * 4.0) * gaussianColor.a;
 
     #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
         if (alpha < alphaClip) {

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
@@ -19,6 +19,14 @@ export default /* wgsl */`
     #include "floatAsUintPS"
 #endif
 
+// Fast approximate e^x based on https://nic.schraudolph.org/pubs/Schraudolph99.pdf
+const EXP_A: f32      = 12102203.0;   // ≈ 2^23 / ln(2)
+const EXP_BC_RMS: i32 = 1064866808;   // (127 << 23) - 60 801*8
+fn fastExp(x: f32) -> f32 {
+    var i: i32 = i32(EXP_A * x) + EXP_BC_RMS;
+    return bitcast<f32>(i);
+}
+
 varying gaussianUV: vec2f;
 varying gaussianColor: vec4f;
 
@@ -33,7 +41,7 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
     }
 
     // evaluate alpha
-    var alpha: f32 = exp(-A * 4.0) * gaussianColor.a;
+    var alpha: f32 = fastExp(-A * 4.0) * gaussianColor.a;
 
     #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
         if (alpha < uniform.alphaClip) {


### PR DESCRIPTION
This PR implements a fast approximation for the exp function and makes use of it in the gsplat shader for both WebGL and WebGPU.

Resulting images are unchanged, but we require more performance testing to determine the speed gain up on various devices. My macbook shows only a small speedup (< 1%), but the hope is larger speedups are found on lower end devices.