### PR TITLE
Add asset load event

### DIFF
--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -609,6 +609,9 @@ class PlyParser {
                     }
                 );
 
+                // allow application to process the data
+                asset.fire('load:data', data);
+
                 // reorder data
                 if (!data.isCompressed) {
                     if (asset.data.reorder ?? true) {


### PR DESCRIPTION
This PR adds an event fire on PLY asset load.

The event is called `load:data` and sends the newly created `GSplatData` instance so the user can modify it before constructing the `GSplatInstance`.

This was needed so we can continue to support things like 2dgs in supersplat (https://github.com/playcanvas/supersplat/issues/528).