### PR TITLE
toArray type overloading

### DIFF
--- a/src/core/math/color.js
+++ b/src/core/math/color.js
@@ -295,6 +295,22 @@ class Color {
     }
 
     /**
+     * @overload
+     * @param {number[]} [arr] - The array to populate with the color's number
+     * components. If not specified, a new array is created.
+     * @param {number} [offset] - The zero-based index at which to start copying elements to the
+     * array. Default is 0.
+     * @returns {number[]} The color as an array.
+     */
+    /**
+     * @overload
+     * @param {ArrayBufferView} arr - The array to populate with the color's number
+     * components. If not specified, a new array is created.
+     * @param {number} [offset] - The zero-based index at which to start copying elements to the
+     * array. Default is 0.
+     * @returns {ArrayBufferView} The color as an array.
+     */
+    /**
      * Converts the color to an array.
      *
      * @param {number[]|ArrayBufferView} [arr] - The array to populate with the color's number

--- a/src/core/math/quat.js
+++ b/src/core/math/quat.js
@@ -817,6 +817,22 @@ class Quat {
     }
 
     /**
+     * @overload
+     * @param {number[]} [arr] - The array to populate with the quaternion's number
+     * components. If not specified, a new array is created.
+     * @param {number} [offset] - The zero-based index at which to start copying elements to the
+     * array. Default is 0.
+     * @returns {number[]} The quaternion as an array.
+     */
+    /**
+     * @overload
+     * @param {ArrayBufferView} arr - The array to populate with the quaternion's number
+     * components. If not specified, a new array is created.
+     * @param {number} [offset] - The zero-based index at which to start copying elements to the
+     * array. Default is 0.
+     * @returns {ArrayBufferView} The quaternion as an array.
+     */
+    /**
      * Converts the quaternion to an array.
      *
      * @param {number[]|ArrayBufferView} [arr] - The array to populate with the quaternion's number

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -689,6 +689,22 @@ class Vec2 {
     }
 
     /**
+     * @overload
+     * @param {number[]} [arr] - The array to populate with the vector's number
+     * components. If not specified, a new array is created.
+     * @param {number} [offset] - The zero-based index at which to start copying elements to the
+     * array. Default is 0.
+     * @returns {number[]} The vector as an array.
+     */
+    /**
+     * @overload
+     * @param {ArrayBufferView} arr - The array to populate with the vector's number
+     * components. If not specified, a new array is created.
+     * @param {number} [offset] - The zero-based index at which to start copying elements to the
+     * array. Default is 0.
+     * @returns {ArrayBufferView} The vector as an array.
+     */
+    /**
      * Converts the vector to an array.
      *
      * @param {number[]|ArrayBufferView} [arr] - The array to populate with the vector's number

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -708,6 +708,22 @@ class Vec3 {
     }
 
     /**
+     * @overload
+     * @param {number[]} [arr] - The array to populate with the vector's number
+     * components. If not specified, a new array is created.
+     * @param {number} [offset] - The zero-based index at which to start copying elements to the
+     * array. Default is 0.
+     * @returns {number[]} The vector as an array.
+     */
+    /**
+     * @overload
+     * @param {ArrayBufferView} arr - The array to populate with the vector's number
+     * components. If not specified, a new array is created.
+     * @param {number} [offset] - The zero-based index at which to start copying elements to the
+     * array. Default is 0.
+     * @returns {ArrayBufferView} The vector as an array.
+     */
+    /**
      * Converts the vector to an array.
      *
      * @param {number[]|ArrayBufferView} [arr] - The array to populate with the vector's number

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -673,6 +673,22 @@ class Vec4 {
     }
 
     /**
+     * @overload
+     * @param {number[]} [arr] - The array to populate with the vector's number
+     * components. If not specified, a new array is created.
+     * @param {number} [offset] - The zero-based index at which to start copying elements to the
+     * array. Default is 0.
+     * @returns {number[]} The vector as an array.
+     */
+    /**
+     * @overload
+     * @param {ArrayBufferView} arr - The array to populate with the vector's number
+     * components. If not specified, a new array is created.
+     * @param {number} [offset] - The zero-based index at which to start copying elements to the
+     * array. Default is 0.
+     * @returns {ArrayBufferView} The vector as an array.
+     */
+    /**
      * Converts the vector to an array.
      *
      * @param {number[]|ArrayBufferView} [arr] - The array to populate with the vector's number


### PR DESCRIPTION
- Adds overloads for `toArray` method typing to correctly return `number[]` or `ArrayBufferView` depending on the type of the output array `arr`
