### PR TITLE
ESM Template instantiate fix

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -969,7 +969,7 @@ class ScriptComponent extends Component {
             // otherwise it means that the attributes have already been initialized
             // so convert the new guid to an entity
             // and put it in the new attributes
-            const newAttributesRaw = newScriptComponent[scriptName].__attributesRaw;
+            const newAttributesRaw = newScriptComponent[scriptName].__attributesRaw ?? newScriptComponent._attributeDataMap.get(scriptName);
             const newAttributes = newScriptComponent[scriptName].__attributes;
             if (!newAttributesRaw && !newAttributes) {
                 continue;
@@ -979,14 +979,15 @@ class ScriptComponent extends Component {
             const useGuid = !!newAttributesRaw;
 
             // get the old script attributes from the instance
-            const oldAttributes = script.instance.__attributes;
+            const oldAttributes = script.instance.__attributes ?? newScriptComponent._attributeDataMap.get(scriptName);
             for (const attributeName in oldAttributes) {
                 if (!oldAttributes[attributeName]) {
                     continue;
                 }
 
                 // get the attribute definition from the script type
-                const attribute = scriptType.attributes.get(attributeName);
+                const attribute = scriptType.attributes?.get(attributeName) ??
+                    this.system.app.scripts.getSchema(scriptName)?.attributes?.[attributeName];
                 if (!attribute) {
                     continue;
                 }


### PR DESCRIPTION
Fixes an issue whereby templates with ESM Scripts containing attributes referencing a sub Entity would not correctly resolve to the updated entity tree

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
