### PR TITLE
Adds export conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,18 @@
   "exports": {
     ".": {
       "types": "./build/playcanvas.d.ts",
-      "import": "./build/playcanvas/src/index.js",
-      "require": "./build/playcanvas.js"
+      "development": {
+        "import": "./build/playcanvas.dbg/src/index.js",
+        "require": "./build/playcanvas.dbg.js"
+      },
+      "profiler": {
+        "import": "./build/playcanvas.prf/src/index.js",
+        "require": "./build/playcanvas.prf.js"
+      },
+      "production": {
+        "import": "./build/playcanvas/src/index.js",
+        "require": "./build/playcanvas.js"
+      }
     },
     "./debug": {
       "types": "./build/playcanvas.d.ts",


### PR DESCRIPTION
This PR adds `development` and `profiler` [export conditions](https://nodejs.org/api/packages.html#conditional-exports) to the package.json.

Libraries the implement the engine cannot easily provide a way for end users to select different engine builds. Given the following use case its not possible to select the dev build:

1. User imports @playcanvas/react.
2. User makes a WGSL shader.
3. User needs better debug information from playcanvas about shader compilation.

This is not a new problem. Node has introduced [export conditions](https://nodejs.org/api/packages.html#resolving-user-conditions) (already used for import/require). This allows users to select versions of a lib globally

```bash
node --conditions=development index.js 
```

In addition Modern dev environments (Webpack 5, Vite, Rollup, Parcel) feed those conditions automatically, meaning that by default in local dev mode you get the development version, and running `npm run build` will automatically export the production version.

I have kept the original `./debug` export etc, but unless needed these could be removed.

