### PR TITLE
Add Options Object Support to `StandardMaterial#constructor`

### DIFF
--- a/examples/src/examples/physics/compound-collision.example.mjs
+++ b/examples/src/examples/physics/compound-collision.example.mjs
@@ -62,8 +62,8 @@ app.on('destroy', () => {
 app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
 // Create a couple of materials for our objects
-const red = new pc.StandardMaterial({diffuse: new pc.Color(0.7, 0.3, 0.3)});
-const gray = new pc.StandardMaterial({diffuse: new pc.Color(0.7, 0.7, 0.7)});
+const red = new pc.StandardMaterial({ diffuse: new pc.Color(0.7, 0.3, 0.3) });
+const gray = new pc.StandardMaterial({ diffuse: new pc.Color(0.7, 0.7, 0.7) });
 
 // Define a scene hierarchy in JSON format. This is loaded/parsed in
 // the parseScene function below

--- a/examples/src/examples/physics/compound-collision.example.mjs
+++ b/examples/src/examples/physics/compound-collision.example.mjs
@@ -60,20 +60,10 @@ app.on('destroy', () => {
 });
 
 app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
-/**
- * @param {pc.Color} color - The diffuse color.
- * @returns {pc.StandardMaterial} The standard material.
- */
-function createMaterial(color) {
-    const material = new pc.StandardMaterial();
-    material.diffuse = color;
-    material.update();
-    return material;
-}
 
 // Create a couple of materials for our objects
-const red = createMaterial(new pc.Color(0.7, 0.3, 0.3));
-const gray = createMaterial(new pc.Color(0.7, 0.7, 0.7));
+const red = new pc.StandardMaterial({diffuse: new pc.Color(0.7, 0.3, 0.3)});
+const gray = new pc.StandardMaterial({diffuse: new pc.Color(0.7, 0.7, 0.7)});
 
 // Define a scene hierarchy in JSON format. This is loaded/parsed in
 // the parseScene function below

--- a/examples/src/examples/physics/falling-shapes.example.mjs
+++ b/examples/src/examples/physics/falling-shapes.example.mjs
@@ -69,21 +69,10 @@ assetListLoader.load(() => {
 
     // Set the gravity for our rigid bodies
     app.systems.rigidbody.gravity.set(0, -9.81, 0);
-    /**
-     * @param {pc.Color} color - The color of the material.
-     * @returns {pc.StandardMaterial} The new material.
-     */
-    function createMaterial(color) {
-        const material = new pc.StandardMaterial();
-        material.diffuse = color;
-        // we need to call material.update when we change its properties
-        material.update();
-        return material;
-    }
 
     // create a few materials for our objects
-    const red = createMaterial(new pc.Color(1, 0.3, 0.3));
-    const gray = createMaterial(new pc.Color(0.7, 0.7, 0.7));
+    const red = new pc.StandardMaterial({diffuse: new pc.Color(1, 0.3, 0.3)});
+    const gray = new pc.StandardMaterial({diffuse: new pc.Color(0.7, 0.7, 0.7)});
 
     // ***********    Create our floor   *******************
 

--- a/examples/src/examples/physics/falling-shapes.example.mjs
+++ b/examples/src/examples/physics/falling-shapes.example.mjs
@@ -71,8 +71,8 @@ assetListLoader.load(() => {
     app.systems.rigidbody.gravity.set(0, -9.81, 0);
 
     // create a few materials for our objects
-    const red = new pc.StandardMaterial({diffuse: new pc.Color(1, 0.3, 0.3)});
-    const gray = new pc.StandardMaterial({diffuse: new pc.Color(0.7, 0.7, 0.7)});
+    const red = new pc.StandardMaterial({ diffuse: new pc.Color(1, 0.3, 0.3) });
+    const gray = new pc.StandardMaterial({ diffuse: new pc.Color(0.7, 0.7, 0.7) });
 
     // ***********    Create our floor   *******************
 

--- a/examples/src/examples/physics/offset-collision.example.mjs
+++ b/examples/src/examples/physics/offset-collision.example.mjs
@@ -95,8 +95,8 @@ assetListLoader.load(() => {
     app.systems.rigidbody.gravity.set(0, -9.81, 0);
 
     // create a few materials for our objects
-    const red = new pc.StandardMaterial({diffuse: new pc.Color(1, 0.3, 0.3)});
-    const gray = new pc.StandardMaterial({diffuse: new pc.Color(0.7, 0.7, 0.7)});
+    const red = new pc.StandardMaterial({ diffuse: new pc.Color(1, 0.3, 0.3) });
+    const gray = new pc.StandardMaterial({ diffuse: new pc.Color(0.7, 0.7, 0.7) });
 
     const floor = new pc.Entity();
     floor.addComponent('render', {

--- a/examples/src/examples/physics/offset-collision.example.mjs
+++ b/examples/src/examples/physics/offset-collision.example.mjs
@@ -94,21 +94,9 @@ assetListLoader.load(() => {
     // Set the gravity for our rigid bodies
     app.systems.rigidbody.gravity.set(0, -9.81, 0);
 
-    /**
-     * @param {pc.Color} color - The color.
-     * @returns {pc.StandardMaterial} The material.
-     */
-    function createMaterial(color) {
-        const material = new pc.StandardMaterial();
-        material.diffuse = color;
-        // we need to call material.update when we change its properties
-        material.update();
-        return material;
-    }
-
     // create a few materials for our objects
-    const red = createMaterial(new pc.Color(1, 0.3, 0.3));
-    const gray = createMaterial(new pc.Color(0.7, 0.7, 0.7));
+    const red = new pc.StandardMaterial({diffuse: new pc.Color(1, 0.3, 0.3)});
+    const gray = new pc.StandardMaterial({diffuse: new pc.Color(0.7, 0.7, 0.7)});
 
     const floor = new pc.Entity();
     floor.addComponent('render', {

--- a/examples/src/examples/physics/raycast.example.mjs
+++ b/examples/src/examples/physics/raycast.example.mjs
@@ -67,20 +67,9 @@ assetListLoader.load(() => {
 
     app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
-    /**
-     * @param {pc.Color} color - The color.
-     * @returns {pc.StandardMaterial} - The material.
-     */
-    function createMaterial(color) {
-        const material = new pc.StandardMaterial();
-        material.diffuse = color;
-        material.update();
-        return material;
-    }
-
     // Create a couple of materials
-    const red = createMaterial(new pc.Color(1, 0, 0));
-    const green = createMaterial(new pc.Color(0, 1, 0));
+    const red = new pc.StandardMaterial({diffuse: pc.Color.RED});
+    const green = new pc.StandardMaterial({diffuse: pc.Color.GREEN});
 
     // Create light
     const light = new pc.Entity();

--- a/examples/src/examples/physics/raycast.example.mjs
+++ b/examples/src/examples/physics/raycast.example.mjs
@@ -68,8 +68,8 @@ assetListLoader.load(() => {
     app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
     // Create a couple of materials
-    const red = new pc.StandardMaterial({diffuse: pc.Color.RED});
-    const green = new pc.StandardMaterial({diffuse: pc.Color.GREEN});
+    const red = new pc.StandardMaterial({ diffuse: pc.Color.RED });
+    const green = new pc.StandardMaterial({ diffuse: pc.Color.GREEN });
 
     // Create light
     const light = new pc.Entity();

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -575,8 +575,9 @@ class StandardMaterial extends Material {
      *
      * // Notify the material that it has been modified
      * material.update();
+     * @param {Partial<StandardMaterial>} [options] - Options for the material.
      */
-    constructor() {
+    constructor(options) {
         super();
 
         // storage for texture and cubemap asset references
@@ -588,6 +589,10 @@ class StandardMaterial extends Material {
         this.shaderOptBuilder = new StandardMaterialOptionsBuilder();
 
         this.reset();
+        if (options) {
+            Object.assign(this, options);
+            this.update();
+        }
     }
 
     reset() {


### PR DESCRIPTION
This PR aligns `StandardMaterial#constructor` with other classes like `Texture#constructor` to accept an optional options object, allowing properties (e.g., diffuse, depthTest) to be set during instantiation without being forced to call additional methods like `Material#update` - reducing boilerplate code.

Example:

```js
const entity = new pc.Entity("test");
entity.addComponent("render", {
    type: "box",
    material: new pc.StandardMaterial({diffuse: pc.Color.RED})
});
```

Basically, the aim is to keep the code short and readable and to reduce manual bookkeeping.

@mvaligursky I'm not entirely sure about the requirement for `this.update()` or if these property assignments should happen before e.g. `this.reset()`?

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
