### PR TITLE
Add support for baseVertex in index buffer creation within wireframe generator

### DIFF
--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -1079,15 +1079,15 @@ class Mesh extends RefCountedObject {
 
             const base = this.primitive[RENDERSTYLE_SOLID].base;
             const count = this.primitive[RENDERSTYLE_SOLID].count;
+            const baseVertex = this.primitive[RENDERSTYLE_SOLID].baseVertex || 0;
             const indexBuffer = this.indexBuffer[RENDERSTYLE_SOLID];
             const srcIndices = new typedArrayIndexFormats[indexBuffer.format](indexBuffer.storage);
-
             const seen = new Set();
 
             for (let j = base; j < base + count; j += 3) {
                 for (let k = 0; k < 3; k++) {
-                    const i1 = srcIndices[j + offsets[k][0]];
-                    const i2 = srcIndices[j + offsets[k][1]];
+                    const i1 = srcIndices[j + offsets[k][0]] + baseVertex;
+                    const i2 = srcIndices[j + offsets[k][1]] + baseVertex;
                     const hash = (i1 > i2) ? ((i2 * numVertices) + i1) : ((i1 * numVertices) + i2);
                     if (!seen.has(hash)) {
                         seen.add(hash);


### PR DESCRIPTION
When creating the index buffer in the wireframe generator, the baseVertex parameter is taken into account.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
