### PR TITLE
Bunde load omit include credentials

### DIFF
--- a/src/framework/handlers/bundle.js
+++ b/src/framework/handlers/bundle.js
@@ -50,8 +50,7 @@ class BundleHandler extends ResourceHandler {
         }
 
         this._fetchRetries(url.load, {
-            mode: 'cors',
-            credentials: 'include'
+            mode: 'cors'
         }, this.maxRetries).then((res) => {
             const bundle = new Bundle();
             callback(null, bundle);


### PR DESCRIPTION
Fixes https://github.com/playcanvas/editor/issues/1173

- Removed `credentials: 'include'` from bundle loading (apps are public so not required + permissions handled separately)
