### PR TITLE
Add control mesh shadow in individual cascade.

### DIFF
--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -409,6 +409,48 @@ export const shadowTypeInfo = new Map([
 ]);
 
 /**
+ * The flag that controls shadow rendering for the 0 cascade
+ * 
+ * @category Graphics
+ */
+export const SHADOW_CASCADE_0 = 1;
+
+/**
+ * The flag that controls shadow rendering for the 1 cascade
+ * 
+ * @category Graphics
+ */
+export const SHADOW_CASCADE_1 = 2;
+
+/**
+ * The flag that controls shadow rendering for the 2 cascade
+ * 
+ * @category Graphics
+ */
+export const SHADOW_CASCADE_2 = 4;
+
+/**
+ * The flag that controls shadow rendering for the 3 cascade
+ * 
+ * @category Graphics
+ */
+export const SHADOW_CASCADE_3 = 8;
+
+/**
+ * The flag that controls shadow rendering for the 4 cascade
+ * 
+ * @category Graphics
+ */
+export const SHADOW_CASCADE_4 = 16;
+
+/**
+ * The flag that controls shadow rendering for the all cascades
+ * 
+ * @category Graphics
+ */
+export const SHADOW_CASCADE_ALL = 32767;
+
+/**
  * Box filter.
  *
  * @category Graphics

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -9,7 +9,8 @@ import {
     RENDERSTYLE_SOLID,
     SHADERDEF_UV0, SHADERDEF_UV1, SHADERDEF_VCOLOR, SHADERDEF_TANGENTS, SHADERDEF_NOSHADOW, SHADERDEF_SKIN,
     SHADERDEF_SCREENSPACE, SHADERDEF_MORPH_POSITION, SHADERDEF_MORPH_NORMAL, SHADERDEF_BATCH,
-    SHADERDEF_LM, SHADERDEF_DIRLM, SHADERDEF_LMAMBIENT, SHADERDEF_INSTANCING, SHADERDEF_MORPH_TEXTURE_BASED_INT
+    SHADERDEF_LM, SHADERDEF_DIRLM, SHADERDEF_LMAMBIENT, SHADERDEF_INSTANCING, SHADERDEF_MORPH_TEXTURE_BASED_INT,
+    SHADOW_CASCADE_ALL
 } from './constants.js';
 import { GraphNode } from './graph-node.js';
 import { getDefaultMaterial } from './materials/default-material.js';
@@ -259,6 +260,17 @@ class MeshInstance {
      * @type {boolean}
      */
     castShadow = false;
+
+    /**
+     * Mask describing which enable shadow casting in the cascade {@link ShadowRendererDirectional} for this mesh instance.
+     * Use this property to turn shadow casting in the cascade on or off without needing to remove the object from the scene.
+     * Note that this property only affects shadow casting when shadows are enabled {@link castShadow},
+     * it does not add the mesh instance to the appropriate list of shadow casters on {@link Layer}.
+     * Instead, it allows the mesh to be skipped during cascade shadow rendering while it remains in the list.
+     * 
+     * @type {number}
+     */
+    shadowCascadeFlags = SHADOW_CASCADE_ALL;
 
     /**
      * Controls whether the mesh instance can be culled by frustum culling (see


### PR DESCRIPTION
Solution: https://github.com/playcanvas/engine/issues/7828

Demo: https://launch.playcanvas.com/2281127?debug=true&use_local_engine=http://localhost:51000/playcanvas.js

This pull request introduces the ability to control mesh shadows individually for each cascade, enabling more effective rendering optimization.

**Key Benefits:**
- Allows independent shadow configuration for each cascade, providing greater flexibility in balancing visual quality and performance.
- Shadow settings can be defined separately for each layer of the mesh's level of detail (LOD), allowing precise control over shadow rendering depending on the mesh's importance in the scene.
- This enables developers to fine-tune shadow behavior, reducing unnecessary computations in areas where shadows have minimal visual impact.

**Practical Use:**
- Shadows can be disabled in specific cascades or LOD levels where they are not needed, reducing the system load.
- For key areas in the scene, high-quality shadows can be retained, while less important regions can have shadows minimized or turned off entirely.

In summary, this feature provides flexible and efficient shadow management in graphical scenes, supporting project optimization without sacrificing visual fidelity.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
