### PR TITLE
Input source codes fixes

### DIFF
--- a/src/extras/input/sources/gamepad-source.js
+++ b/src/extras/input/sources/gamepad-source.js
@@ -1,5 +1,21 @@
 import { InputSource } from '../input.js';
 
+const BUTTON_CODES = /** @type {const} */ ({
+    A: 0,
+    B: 1,
+    X: 2,
+    Y: 3,
+    LB: 4,
+    RB: 5,
+    LT: 6,
+    RT: 7,
+    SELECT: 8,
+    START: 9,
+    LEFT_STICK: 10,
+    RIGHT_STICK: 11
+});
+const BUTTON_COUNT = Object.keys(BUTTON_CODES).length;
+
 /**
  * Game pad input source class
  *
@@ -18,30 +34,17 @@ class GamepadSource extends InputSource {
      *
      * @readonly
      */
-    static buttonCode = {
-        A: 0,
-        B: 1,
-        X: 2,
-        Y: 3,
-        LB: 4,
-        RB: 5,
-        LT: 6,
-        RT: 7,
-        SELECT: 8,
-        START: 9,
-        LEFT_STICK: 10,
-        RIGHT_STICK: 11
-    };
+    static buttonCode = BUTTON_CODES;
 
     /**
      * @type {number[]}
      * @private
      */
-    _buttonPrev = Array(11).fill(0);
+    _buttonPrev = Array(BUTTON_COUNT).fill(0);
 
     constructor() {
         super({
-            buttons: Array(11).fill(0),
+            buttons: Array(BUTTON_COUNT).fill(0),
             leftStick: [0, 0],
             rightStick: [0, 0]
         });
@@ -71,7 +74,7 @@ class GamepadSource extends InputSource {
             }
 
             // check if gamepad has enough buttons
-            if (gp.buttons.length < 12) {
+            if (gp.buttons.length < BUTTON_COUNT) {
                 continue;
             }
 

--- a/src/extras/input/sources/keyboard-mouse-source.js
+++ b/src/extras/input/sources/keyboard-mouse-source.js
@@ -1,8 +1,52 @@
 import { InputSource } from '../input.js';
 
-/** @type {AddEventListenerOptions & EventListenerOptions} */
-const PASSIVE = { passive: false };
-const KEY_COUNT = 42;
+const PASSIVE = /** @type {AddEventListenerOptions & EventListenerOptions} */ ({ passive: false });
+const KEYS = /** @type {const} */ ({
+    A: 0,
+    B: 1,
+    C: 2,
+    D: 3,
+    E: 4,
+    F: 5,
+    G: 6,
+    H: 7,
+    I: 8,
+    J: 9,
+    K: 10,
+    L: 11,
+    M: 12,
+    N: 13,
+    O: 14,
+    P: 15,
+    Q: 16,
+    R: 17,
+    S: 18,
+    T: 19,
+    U: 20,
+    V: 21,
+    W: 22,
+    X: 23,
+    Y: 24,
+    Z: 25,
+    '0': 26,
+    '1': 27,
+    '2': 28,
+    '3': 29,
+    '4': 30,
+    '5': 31,
+    '6': 32,
+    '7': 33,
+    '8': 34,
+    '9': 35,
+    UP: 36,
+    DOWN: 37,
+    LEFT: 38,
+    RIGHT: 39,
+    SPACE: 40,
+    SHIFT: 41,
+    CTRL: 42
+});
+const KEY_COUNT = Object.keys(KEYS).length;
 
 const array = Array(KEY_COUNT).fill(0);
 
@@ -25,51 +69,7 @@ class KeyboardMouseSource extends InputSource {
      *
      * @readonly
      */
-    static keyCode = {
-        A: 0,
-        B: 1,
-        C: 2,
-        D: 3,
-        E: 4,
-        F: 5,
-        G: 6,
-        H: 7,
-        I: 8,
-        J: 9,
-        K: 10,
-        L: 11,
-        M: 12,
-        N: 13,
-        O: 14,
-        P: 15,
-        Q: 16,
-        R: 17,
-        S: 18,
-        T: 19,
-        U: 20,
-        V: 21,
-        W: 22,
-        X: 23,
-        Y: 24,
-        Z: 25,
-        '0': 26,
-        '1': 27,
-        '2': 28,
-        '3': 29,
-        '4': 30,
-        '5': 31,
-        '6': 32,
-        '7': 33,
-        '8': 34,
-        '9': 35,
-        UP: 36,
-        DOWN: 37,
-        LEFT: 38,
-        RIGHT: 39,
-        SPACE: 40,
-        SHIFT: 41,
-        CTRL: 42
-    };
+    static keyCode = KEYS;
 
     /**
      * @type {number}

--- a/src/extras/input/sources/keyboard-mouse-source.js
+++ b/src/extras/input/sources/keyboard-mouse-source.js
@@ -1,7 +1,7 @@
 import { InputSource } from '../input.js';
 
 const PASSIVE = /** @type {AddEventListenerOptions & EventListenerOptions} */ ({ passive: false });
-const KEYS = /** @type {const} */ ({
+const KEY_CODES = /** @type {const} */ ({
     A: 0,
     B: 1,
     C: 2,
@@ -46,7 +46,7 @@ const KEYS = /** @type {const} */ ({
     SHIFT: 41,
     CTRL: 42
 });
-const KEY_COUNT = Object.keys(KEYS).length;
+const KEY_COUNT = Object.keys(KEY_CODES).length;
 
 const array = Array(KEY_COUNT).fill(0);
 
@@ -69,7 +69,7 @@ class KeyboardMouseSource extends InputSource {
      *
      * @readonly
      */
-    static keyCode = KEYS;
+    static keyCode = KEY_CODES;
 
     /**
      * @type {number}


### PR DESCRIPTION
- Fixes range for `KeyboardMouseSource` key codes (was missing `CTRL`)
- Refactored code length to be derived from readonly const 
