### PR TITLE
Enable highQualitySH by default

### DIFF
--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -62,7 +62,7 @@ class GSplatComponent extends Component {
     _materialTmp = null;
 
     /** @private */
-    _highQualitySH = false;
+    _highQualitySH = true;
 
     /**
      * @type {BoundingBox|null}


### PR DESCRIPTION
Users are finding the optimisation is too aggressive, so disable by default.