### PR TITLE
SOGS progress events

### DIFF
--- a/src/framework/parsers/sogs.js
+++ b/src/framework/parsers/sogs.js
@@ -5,7 +5,7 @@ import { GSplatSogsData } from '../../scene/gsplat/gsplat-sogs-data.js';
 import { GSplatSogsResource } from '../../scene/gsplat/gsplat-sogs-resource.js';
 
 // combine the progress updates from multiple assets
-// and fire process events on the target
+// and fire progress events on the target
 const combineProgress = (target, assets) => {
     const map = new Map();
 

--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -61,7 +61,7 @@ class ImgParser extends TextureParser {
         }
 
         if (this.device.supportsImageBitmap) {
-            this._loadImageBitmap(url.load, url.original, crossOrigin, handler);
+            this._loadImageBitmap(url.load, url.original, crossOrigin, handler, asset);
         } else {
             this._loadImage(url.load, url.original, crossOrigin, handler);
         }
@@ -125,12 +125,13 @@ class ImgParser extends TextureParser {
         image.src = url;
     }
 
-    _loadImageBitmap(url, originalUrl, crossOrigin, callback) {
+    _loadImageBitmap(url, originalUrl, crossOrigin, callback, asset) {
         const options = {
             cache: true,
             responseType: 'blob',
             retry: this.maxRetries > 0,
-            maxRetries: this.maxRetries
+            maxRetries: this.maxRetries,
+            progress: asset
         };
         http.get(url, options, (err, blob) => {
             if (err) {

--- a/src/platform/net/http.js
+++ b/src/platform/net/http.js
@@ -108,21 +108,21 @@ class Http {
         const result = this.request('GET', url, options, callback);
 
         const { progress } = options;
-
         if (progress) {
             const handler = (event) => {
                 if (event.lengthComputable) {
                     progress.fire('progress', event.loaded, event.total);
                 }
             };
-            result.addEventListener('loadstart', handler);
-            result.addEventListener('progress', handler);
-            result.addEventListener('loadend', (event) => {
+            const endHandler = (event) => {
                 handler(event);
                 result.removeEventListener('loadstart', handler);
                 result.removeEventListener('progress', handler);
-                result.removeEventListener('loadend', handler);
-            });
+                result.removeEventListener('loadend', endHandler);
+            };
+            result.addEventListener('loadstart', handler);
+            result.addEventListener('progress', handler);
+            result.addEventListener('loadend', endHandler);
         }
 
         return result;

--- a/src/platform/net/http.js
+++ b/src/platform/net/http.js
@@ -104,13 +104,24 @@ class Http {
             callback = options;
             options = {};
         }
+
         const result = this.request('GET', url, options, callback);
 
-        if (options.progress) {
-            result.addEventListener('progress', (event) => {
+        const { progress } = options;
+
+        if (progress) {
+            const handler = (event) => {
                 if (event.lengthComputable) {
-                    options.progress.fire('progress', event.loaded, event.total);
+                    progress.fire('progress', event.loaded, event.total);
                 }
+            };
+            result.addEventListener('loadstart', handler);
+            result.addEventListener('progress', handler);
+            result.addEventListener('loadend', (event) => {
+                handler(event);
+                result.removeEventListener('loadstart', handler);
+                result.removeEventListener('progress', handler);
+                result.removeEventListener('loadend', handler);
             });
         }
 


### PR DESCRIPTION
This PR:
- adds a progress option to http get which will send progress updates
- adds the progress event to `Img`'s _loadImageBitmap implementation
- collate the progress events and fire them on the parent SOGS asset

## Notes

- `combineProgress` functionality can possibly be made available outside of sogs