### PR TITLE
[Fix] Fix to morphing using incorrect shader when multiple morph meshes are used

### DIFF
--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -196,7 +196,7 @@ class MorphInstance {
         const outputType = this.morph.intRenderFormat ? 'uvec4' : 'vec4';
 
         return ShaderUtils.createShader(this.device, {
-            uniqueName: 'TextureMorphShader',
+            uniqueName: `TextureMorphShader_${maxCount}-${this.morph.intRenderFormat ? 'int' : 'float'}`,
             attributes: { vertex_position: SEMANTIC_POSITION },
             vertexChunk: 'morphVS',
             fragmentChunk: 'morphPS',

--- a/src/scene/shader-lib/glsl/chunks/internal/morph/frag/morph.js
+++ b/src/scene/shader-lib/glsl/chunks/internal/morph/frag/morph.js
@@ -17,9 +17,11 @@ export default /* glsl */`
     void main (void) {
         highp vec3 color = vec3(0, 0, 0);
 
+        ivec2 pixelCoords = ivec2(uv0 * vec2(textureSize(morphTexture, 0).xy));
+        
         for (int i = 0; i < count; i++) {
             uint textureIndex = morphIndex[i];
-            vec3 delta = texture(morphTexture, vec3(uv0, textureIndex)).xyz;
+            vec3 delta = texelFetch(morphTexture, ivec3(pixelCoords, int(textureIndex)), 0).xyz;
             color += morphFactor[i] * delta;
         }
 

--- a/src/scene/shader-lib/wgsl/chunks/internal/morph/frag/morph.js
+++ b/src/scene/shader-lib/wgsl/chunks/internal/morph/frag/morph.js
@@ -5,7 +5,6 @@ export default /* wgsl */`
     varying uv0: vec2f;
 
     var morphTexture: texture_2d_array<f32>;
-    var morphTextureSampler : sampler;
     uniform morphFactor: array<f32, {MORPH_TEXTURE_MAX_COUNT}>;
     uniform morphIndex: array<u32, {MORPH_TEXTURE_MAX_COUNT}>;
     uniform count: u32;
@@ -13,9 +12,12 @@ export default /* wgsl */`
     @fragment
     fn fragmentMain(input : FragmentInput) -> FragmentOutput {
         var color = vec3f(0, 0, 0);
+        let textureDims = textureDimensions(morphTexture);
+        let pixelCoords = vec2i(input.uv0 * vec2f(textureDims));
+        
         for (var i: u32 = 0; i < uniform.count; i = i + 1) {
             var textureIndex: u32 = uniform.morphIndex[i].element;
-            var delta = textureSample(morphTexture, morphTextureSampler, input.uv0, textureIndex).xyz;
+            var delta = textureLoad(morphTexture, pixelCoords, textureIndex, 0).xyz;
             color += uniform.morphFactor[i].element * delta;
         }
 


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/7835
- the unique morph shader name was not customized using defines, and so incorrect shader variant was used.

Separate change:
- converted sampled texture reading to fetching, to improve performance, limit possible sampling issues.