### PR TITLE
Pack sogs data at load

### DIFF
--- a/src/framework/parsers/sogs.js
+++ b/src/framework/parsers/sogs.js
@@ -108,13 +108,14 @@ class SogsParser {
         data.sh_centroids = textures.shN?.[0]?.resource;
         data.sh_labels = textures.shN?.[1]?.resource;
 
-        if (asset.data?.reorder ?? true) {
-            await data.reorderData();
-        } else {
-            await data.readMeansImageData();
+        const decompress = asset.data?.decompress;
+
+        if (!decompress) {
+            // no need to prepare gpu data if decompressing
+            await data.prepareGpuData();
         }
 
-        const resource = asset.data?.decompress ?
+        const resource = decompress ?
             new GSplatResource(this.app.graphicsDevice, await data.decompress()) :
             new GSplatSogsResource(this.app.graphicsDevice, data);
 

--- a/src/scene/gsplat/gsplat-sogs-resource.js
+++ b/src/scene/gsplat/gsplat-sogs-resource.js
@@ -13,7 +13,7 @@ class GSplatSogsResource extends GSplatResourceBase {
         material.setDefine('GSPLAT_SOGS_DATA', true);
         material.setDefine('SH_BANDS', this.gsplatData.shBands);
 
-        ['means_l', 'means_u', 'quats', 'scales', 'sh0', 'sh_centroids', 'sh_labels'].forEach((name) => {
+        ['packedTexture', 'sh0', 'sh_centroids'].forEach((name) => {
             if (gsplatData[name]) {
                 material.setParameter(name, gsplatData[name]);
             }

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat-sogs-reorder.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat-sogs-reorder.js
@@ -1,18 +1,41 @@
 export default /* glsl */`
-    uniform usampler2D orderTexture;
-    uniform sampler2D sourceTexture;
+    uniform sampler2D means_l;
+    uniform sampler2D means_u;
+    uniform sampler2D quats;
+    uniform sampler2D scales;
+    uniform sampler2D sh_labels;
+
     uniform highp uint numSplats;
 
+    uint packU32(vec4 v) {
+        return uint(v.x * 255.0) << 24u |
+               uint(v.y * 255.0) << 16u |
+               uint(v.z * 255.0) << 8u |
+               uint(v.w * 255.0);
+    }
+
+    uvec4 packU32(vec4 a, vec4 b, vec4 c, vec4 d) {
+        return uvec4(packU32(a), packU32(b), packU32(c), packU32(d));
+    }
+
     void main(void) {
-        uint w = uint(textureSize(sourceTexture, 0).x);
-        uint idx = uint(gl_FragCoord.x) + uint(gl_FragCoord.y) * w;
-        if (idx >= numSplats) discard;
+        int w = int(textureSize(means_l, 0).x);
+        ivec2 uv = ivec2(gl_FragCoord.xy);
+        if (uint(uv.x + uv.y * w) >= numSplats) {
+            discard;
+        }
 
-        // fetch the source index and calculate source uv
-        uint sidx = texelFetch(orderTexture, ivec2(gl_FragCoord.xy), 0).x;
-        uvec2 suv = uvec2(sidx % w, sidx / w);
+        vec3 meansLSample = texelFetch(means_l, uv, 0).xyz;
+        vec3 meansUSample = texelFetch(means_u, uv, 0).xyz;
+        vec4 quatsSample = texelFetch(quats, uv, 0);
+        vec3 scalesSample = texelFetch(scales, uv, 0).xyz;
+        vec2 shLabelsSample = texelFetch(sh_labels, uv, 0).xy;
 
-        // sample the source texture
-        gl_FragColor = texelFetch(sourceTexture, ivec2(suv), 0);
+        pcFragColor0 = packU32(
+            vec4(meansLSample, shLabelsSample.x),
+            vec4(meansUSample, shLabelsSample.y),
+            vec4(quatsSample),
+            vec4(scalesSample, 0.0)
+        );
     }
 `;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatSogsSH.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatSogsSH.js
@@ -1,5 +1,4 @@
 export default /* glsl */`
-uniform highp sampler2D sh_labels;
 uniform highp sampler2D sh_centroids;
 
 uniform float shN_mins;
@@ -9,7 +8,7 @@ uniform float shN_maxs;
 
 void readSHData(in SplatSource source, out vec3 sh[SH_COEFFS], out float scale) {
     // extract spherical harmonics palette index
-    ivec2 t = ivec2(texelFetch(sh_labels, source.uv, 0).xy * 255.0);
+    ivec2 t = ivec2(packedSample.x & 255u, packedSample.y & 255u);
     int n = t.x + t.y * 256;
     int u = (n % 64) * SH_COEFFS;
     int v = n / 64;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat-sogs-reorder.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat-sogs-reorder.js
@@ -1,25 +1,48 @@
 export default /* wgsl */`
-    var orderTexture: texture_2d<u32>;
-    var sourceTexture: texture_2d<f32>;
+    var means_l: texture_2d<f32>;
+    var means_u: texture_2d<f32>;
+    var quats: texture_2d<f32>;
+    var scales: texture_2d<f32>;
+    var sh_labels: texture_2d<f32>;
+
     uniform numSplats: u32;
+
+    fn packU32(v: vec4<f32>) -> u32 {
+        return (u32(v.x * 255.0) << 24u)  |
+               (u32(v.y * 255.0) << 16u)  |
+               (u32(v.z * 255.0) << 8u) |
+               u32(v.w * 255.0);
+    }
+
+    fn packUVec32(a: vec4<f32>, b: vec4<f32>, c: vec4<f32>, d: vec4<f32>) -> vec4<u32> {
+        return vec4<u32>(packU32(a), packU32(b), packU32(c), packU32(d));
+    }
 
     @fragment
     fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         var output: FragmentOutput;
 
-        let w: u32 = textureDimensions(sourceTexture, 0).x;
-        let idx: u32 = u32(pcPosition.x) + u32(pcPosition.y) * w;
-        if (idx >= uniform.numSplats) {
+        let w: u32 = textureDimensions(means_l, 0).x;
+        let uv: vec2<u32> = vec2<u32>(pcPosition.xy);
+        if (uv.x + uv.y * w >= uniform.numSplats) {
             discard;
             return output;
         }
 
         // fetch the source index and calculate source uv
-        let sidx: u32 = textureLoad(orderTexture, vec2<i32>(input.position.xy), 0).x;
-        let suv: vec2<u32> = vec2<u32>(sidx % w, sidx / w);
+        let meansLSample: vec3<f32> = textureLoad(means_l, uv, 0).xyz;
+        let meansUSample: vec3<f32> = textureLoad(means_u, uv, 0).xyz;
+        let quatsSample: vec4<f32> = textureLoad(quats, uv, 0);
+        let scalesSample: vec3<f32> = textureLoad(scales, uv, 0).xyz;
+        let shLabelsSample: vec2<f32> = textureLoad(sh_labels, uv, 0).xy;
 
-        // sample the source texture
-        output.color = textureLoad(sourceTexture, vec2<i32>(suv), 0);
+        output.color = packUVec32(
+            vec4(meansLSample, shLabelsSample.x),
+            vec4(meansUSample, shLabelsSample.y),
+            vec4(quatsSample),
+            vec4(scalesSample, 0.0)
+        );
+
         return output;
     }
 `;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatSogsData.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatSogsData.js
@@ -7,7 +7,7 @@ uniform means_maxs: vec3f;
 uniform scales_mins: vec3f;
 uniform scales_maxs: vec3f;
 
-vec4 unpackU32(u: u32) -> vec4f {
+fn unpackU32(u: u32) -> vec4f {
     return vec4f(
         f32((u >> 24u) & 0xFFu) / 255.0,
         f32((u >> 16u) & 0xFFu) / 255.0,
@@ -16,7 +16,7 @@ vec4 unpackU32(u: u32) -> vec4f {
     );
 }
 
-vec4<u32> packedSample;
+var<private> packedSample: vec4<u32>;
 
 // read the model-space center of the gaussian
 fn readCenter(source: ptr<function, SplatSource>) -> vec3f {

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatSogsData.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatSogsData.js
@@ -1,8 +1,5 @@
 export default /* wgsl */`
-var means_u: texture_2d<f32>;
-var means_l: texture_2d<f32>;
-var quats: texture_2d<f32>;
-var scales: texture_2d<f32>;
+var packedTexture: texture_2d<u32>;
 
 uniform means_mins: vec3f;
 uniform means_maxs: vec3f;
@@ -10,13 +7,27 @@ uniform means_maxs: vec3f;
 uniform scales_mins: vec3f;
 uniform scales_maxs: vec3f;
 
+vec4 unpackU32(u: u32) -> vec4f {
+    return vec4f(
+        f32((u >> 24u) & 0xFFu) / 255.0,
+        f32((u >> 16u) & 0xFFu) / 255.0,
+        f32((u >> 8u) & 0xFFu) / 255.0,
+        f32(u & 0xFFu) / 255.0
+    );
+}
+
+vec4<u32> packedSample;
+
 // read the model-space center of the gaussian
 fn readCenter(source: ptr<function, SplatSource>) -> vec3f {
-    let u: vec3f = textureLoad(means_u, source.uv, 0).xyz;
-    let l: vec3f = textureLoad(means_l, source.uv, 0).xyz;
-    let n: vec3f = (l * 255.0 + u * 255.0 * 256.0) / 65535.0;
 
+    packedSample = textureLoad(packedTexture, source.uv, 0);
+
+    let l: vec3f = unpackU32(packedSample.x).xyz;
+    let u: vec3f = unpackU32(packedSample.y).xyz;
+    let n: vec3f = (l * 255.0 + u * 255.0 * 256.0) / 65535.0;
     let v: vec3f = mix(uniform.means_mins, uniform.means_maxs, n);
+
     return sign(v) * (exp(abs(v)) - 1.0);
 }
 
@@ -24,7 +35,9 @@ const norm: f32 = 2.0 / sqrt(2.0);
 
 // sample covariance vectors
 fn readCovariance(source: ptr<function, SplatSource>, covA_ptr: ptr<function, vec3f>, covB_ptr: ptr<function, vec3f>) {
-    let qdata: vec4f = textureLoad(quats, source.uv, 0);
+    let qdata: vec4f = unpackU32(packedSample.z);
+    let sdata: vec3f = unpackU32(packedSample.w).xyz;
+
     let abc: vec3f = (qdata.xyz - 0.5) * norm;
     let d: f32 = sqrt(max(0.0, 1.0 - dot(abc, abc)));
 
@@ -43,7 +56,7 @@ fn readCovariance(source: ptr<function, SplatSource>, covA_ptr: ptr<function, ve
 
 
     let rot: mat3x3f = quatToMat3(quat);
-    let scale: vec3f = exp(mix(uniform.scales_mins, uniform.scales_maxs, textureLoad(scales, source.uv, 0).xyz));
+    let scale: vec3f = exp(mix(uniform.scales_mins, uniform.scales_maxs, sdata));
 
     // M = S * R
     let M: mat3x3f = transpose(mat3x3f(

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatSogsSH.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatSogsSH.js
@@ -6,7 +6,7 @@ uniform shN_maxs: f32;
 
 fn readSHData(source: ptr<function, SplatSource>, sh: ptr<function, array<vec3f, SH_COEFFS>>, scale: ptr<function, f32>) {
     // extract spherical harmonics palette index
-    let t: vec2<i32> = vec2<i32>(packedSample.x & 255u, packedSample.y & 255u);
+    let t: vec2<i32> = vec2<i32>(i32(packedSample.x & 255u), i32(packedSample.y & 255u));
     let n: i32 = t.x + t.y * 256;
     let u: i32 = (n % 64) * SH_COEFFS;
     let v: i32 = n / 64;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatSogsSH.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatSogsSH.js
@@ -1,5 +1,4 @@
 export default /* wgsl */`
-var sh_labels: texture_2d<f32>;
 var sh_centroids: texture_2d<f32>;
 
 uniform shN_mins: f32;
@@ -7,7 +6,7 @@ uniform shN_maxs: f32;
 
 fn readSHData(source: ptr<function, SplatSource>, sh: ptr<function, array<vec3f, SH_COEFFS>>, scale: ptr<function, f32>) {
     // extract spherical harmonics palette index
-    let t: vec2<i32> = vec2<i32>(textureLoad(sh_labels, source.uv, 0).xy * 255.0);
+    let t: vec2<i32> = vec2<i32>(packedSample.x & 255u, packedSample.y & 255u);
     let n: i32 = t.x + t.y * 256;
     let u: i32 = (n % 64) * SH_COEFFS;
     let v: i32 = n / 64;


### PR DESCRIPTION
This PR updates the handling of SOGS data at load time:
- refrain from reordering the gaussian data by morton code, because tooling now does this at compression time
- use the GPU to pack the gaussian position, quaternion, scale and sh-label data into an interleaved RGBA32U texture
    - this brings render time memory caching performance inline with compressed.ply

## Notes
- This PR must only be merged after #7688 is fixed otherwise wgsl will fail