### PR TITLE
Unified gsplat architecture is available to GSplatComponent

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod.example.mjs
@@ -47,23 +47,9 @@ app.on('destroy', () => {
 pc.Tracing.set(pc.TRACEID_SHADER_ALLOC, true);
 
 const assets = {
-    biker: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/biker.compressed.ply` }),
-    // church: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/church.ply` }),
-    //    church: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/onsen.ply` }),
-    // church: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/uzumasa.ply` }),
     church: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/morocco.ply` }),
-
-    // logo: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/playcanvas-logo/meta.json` }),
     logo: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/pclogo.ply` }),
-    //    logo: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/anneli.ply` }),
-    //    logo: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/museum.ply` }),
-    // logo: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/uzumasa.ply` }),
     guitar: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/guitar.compressed.ply` }),
-
-    shoe: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/shoe-with-sh.ply` }),
-    shoeNoSh: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/shoe-without-sh.ply` }),
-
-    // pokemon: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/pokemon.ply` }),
     skull: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/skull.ply` }),
 
     fly: new pc.Asset('fly', 'script', { url: `${rootPath}/static/scripts/camera/fly-camera.js` }),
@@ -75,28 +61,42 @@ assetListLoader.load(() => {
     app.start();
 
     // create a splat entity and place it in the world
-    const biker = new pc.Entity();
-    biker.setLocalPosition(2.5, 1, 1);
-    biker.setLocalEulerAngles(180, 90, 0);
-    // biker.setLocalScale(0.7, 0.7, 0.7);
-    // biker.setLocalScale(7, 7, 7);
+    const skull = new pc.Entity();
+    skull.addComponent('gsplat', {
+        asset: assets.skull,
+        unified: true
+    });
+    skull.setLocalPosition(2.5, 1, 1);
+    skull.setLocalEulerAngles(180, 90, 0);
+    skull.setLocalScale(0.7, 0.7, 0.7);
+    app.root.addChild(skull);
 
-    const biker2 = new pc.Entity();
-    biker2.setLocalPosition(2.5, 1, 0);
-    biker2.setLocalEulerAngles(180, 90, 0);
-    //    biker2.setLocalScale(0.7, 0.7, 0.7);
-    biker2.setLocalScale(7, 7, 7);
-
-
+    // create a splat entity and place it in the world
     const logo = new pc.Entity();
+    logo.addComponent('gsplat', {
+        asset: assets.logo,
+        unified: true
+    });
+    app.root.addChild(logo);
     logo.setLocalPosition(0, 1.5, 1);
     logo.setLocalEulerAngles(180, 0, 0);
     logo.setLocalScale(0.5, 0.5, 0.5);
 
+    // create a splat entity and place it in the world
     const church = new pc.Entity();
+    church.addComponent('gsplat', {
+        asset: assets.church,
+        unified: true
+    });
+    app.root.addChild(church);
     church.setLocalEulerAngles(180, 90, 0);
 
     const guitar = new pc.Entity();
+    guitar.addComponent('gsplat', {
+        asset: assets.guitar,
+        unified: true
+    });
+    app.root.addChild(guitar);
     guitar.setLocalPosition(0, 0.6, 4);
     guitar.setLocalEulerAngles(180, 0, 0);
     guitar.setLocalScale(0.5, 0.5, 0.5);
@@ -120,17 +120,6 @@ assetListLoader.load(() => {
 
     app.root.addChild(camera);
 
-    // temporary API
-    const manager = new pc.GSplatManager(app.graphicsDevice, camera);
-
-    const worldLayer = app.scene.layers.getLayerByName('World');
-    worldLayer.addMeshInstances([manager.renderer.meshInstance]);
-
-    manager.add(assets.church.resource, church);
-    manager.add(assets.guitar.resource, guitar);
-    manager.add(assets.logo.resource, logo);
-
-
     let timeToChange = 1;
     let time = 0;
     let guitarTime = 0;
@@ -139,48 +128,31 @@ assetListLoader.load(() => {
         time += dt;
         timeToChange -= dt;
 
-        logo.rotateLocal(0, 100 * dt, 0);
-
-        // each even second, update the guitar as well
-        //        if (Math.floor(time) % 2 === 0) {
-        guitarTime += dt;
-
-        // orbit guitar around
-        guitar.setLocalPosition(0.5 * Math.sin(guitarTime), 2, 0.5 * Math.cos(guitarTime) + 1);
-        //        }
-
         // ping pong logo between two positions along x-axies
         logo.setLocalPosition(5.5 + 5 * Math.sin(time), 1.5, -2);
+        logo.rotateLocal(0, 100 * dt, 0);
 
+        // update the guitar as well
+        guitarTime += dt;
+        guitar.setLocalPosition(0.5 * Math.sin(guitarTime), 2, 0.5 * Math.cos(guitarTime) + 1);
 
         if (timeToChange <= 0) {
 
             if (!added) {
-                console.log('adding shoe');
+                console.log('adding skull');
                 added = true;
                 timeToChange = 1;
 
-                // worldLayer.removeMeshInstances([manager.meshInstance]);
-                manager.add(assets.skull.resource, biker);
-                // manager.add(assets.shoe.resource, biker2);
-                // worldLayer.addMeshInstances([manager.meshInstance]);
+                skull.enabled = true;
 
             } else {
-                console.log('removing shoe');
+                console.log('removing skull');
                 added = false;
                 timeToChange = 1;
 
-                // worldLayer.removeMeshInstances([manager.meshInstance]);
-
-
-                manager.remove(biker);
-                // manager.remove(biker2);
-                // worldLayer.addMeshInstances([manager.meshInstance]);
+                skull.enabled = false;
             }
         }
-
-
-        manager.update();
     });
 });
 

--- a/examples/src/examples/gaussian-splatting/multi-view.example.mjs
+++ b/examples/src/examples/gaussian-splatting/multi-view.example.mjs
@@ -1,0 +1,152 @@
+import { deviceType, rootPath } from 'examples/utils';
+import * as pc from 'playcanvas';
+
+const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
+window.focus();
+
+const gfxOptions = {
+    deviceTypes: [deviceType],
+
+    // disable antialiasing as gaussian splats do not benefit from it and it's expensive
+    antialias: false
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(document.body);
+createOptions.touch = new pc.TouchDevice(document.body);
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem,
+    pc.ScriptComponentSystem,
+    pc.GSplatComponentSystem
+];
+createOptions.resourceHandlers = [pc.TextureHandler, pc.ContainerHandler, pc.ScriptHandler, pc.GSplatHandler];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
+
+// Set the canvas to fill the window and automatically change resolution to be the same as the canvas size
+app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+// Ensure canvas is resized when window changes size
+const resize = () => app.resizeCanvas();
+window.addEventListener('resize', resize);
+app.on('destroy', () => {
+    window.removeEventListener('resize', resize);
+});
+
+const assets = {
+    logo: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/playcanvas-logo/meta.json` }),
+    orbit: new pc.Asset('script', 'script', { url: `${rootPath}/static/scripts/camera/orbit-camera.js` }),
+    helipad: new pc.Asset(
+        'helipad-env-atlas',
+        'texture',
+        { url: `${rootPath}/static/assets/cubemaps/helipad-env-atlas.png` },
+        { type: pc.TEXTURETYPE_RGBP, mipmaps: false }
+    )
+};
+
+const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+assetListLoader.load(() => {
+    app.start();
+
+    // setup skydome
+    app.scene.skyboxMip = 2;
+    app.scene.envAtlas = assets.helipad.resource;
+
+    // create a splat entity and place it in the world
+    const logoEntity1 = new pc.Entity();
+    logoEntity1.addComponent('gsplat', {
+        asset: assets.logo,
+        unified: true
+    });
+    logoEntity1.setLocalPosition(0, 0.05, 0);
+    logoEntity1.setLocalEulerAngles(180, 90, 0);
+    logoEntity1.setLocalScale(0.7, 0.7, 0.7);
+    app.root.addChild(logoEntity1);
+
+    // create another splat entity and place it in the world
+    const logoEntity2 = new pc.Entity();
+    logoEntity2.addComponent('gsplat', {
+        asset: assets.logo,
+        unified: true
+    });
+    logoEntity2.setLocalPosition(0, -0.5, 0);
+    logoEntity2.setLocalEulerAngles(-90, -90, 0);
+    logoEntity2.setLocalScale(2, 2, 2);
+    app.root.addChild(logoEntity2);
+
+    // Create left camera
+    const cameraLeft = new pc.Entity('LeftCamera');
+    cameraLeft.addComponent('camera', {
+        clearColor: new pc.Color(0.2, 0.2, 0.2),
+        farClip: 500,
+        rect: new pc.Vec4(0, 0, 0.5, 0.5),
+        toneMapping: pc.TONEMAP_ACES
+    });
+    cameraLeft.setLocalPosition(-0.8, 2, 3);
+    app.root.addChild(cameraLeft);
+
+    // Create right orthographic camera
+    const cameraRight = new pc.Entity('RightCamera');
+    cameraRight.addComponent('camera', {
+        clearColor: new pc.Color(0.2, 0.2, 0.2),
+        farClip: 500,
+        rect: new pc.Vec4(0.5, 0, 0.5, 0.5),
+        projection: pc.PROJECTION_ORTHOGRAPHIC,
+        orthoHeight: 4,
+        toneMapping: pc.TONEMAP_ACES
+    });
+    cameraRight.translate(0, 8, 0);
+    cameraRight.lookAt(pc.Vec3.ZERO, pc.Vec3.RIGHT);
+    app.root.addChild(cameraRight);
+
+    // Create top camera
+    const cameraTop = new pc.Entity('TopCamera');
+    cameraTop.addComponent('camera', {
+        clearColor: new pc.Color(0.2, 0.2, 0.2),
+        farClip: 500,
+        rect: new pc.Vec4(0, 0.5, 1, 0.5),
+        toneMapping: pc.TONEMAP_ACES
+    });
+    cameraTop.translate(-2, 6, 9);
+    app.root.addChild(cameraTop);
+
+    // add orbit camera script with a mouse and a touch support to top camera
+    cameraTop.addComponent('script');
+    if (cameraTop.script) {
+        cameraTop.script.create('orbitCamera', {
+            attributes: {
+                inertiaFactor: 0.2,
+                focusEntity: logoEntity2,
+                distanceMax: 60,
+                frameOnStart: false
+            }
+        });
+        cameraTop.script.create('orbitCameraInputMouse');
+        cameraTop.script.create('orbitCameraInputTouch');
+    }
+
+    // update function called once per frame
+    let time = 0;
+    app.on('update', (dt) => {
+        time += dt;
+
+        // orbit left camera around the splat
+        cameraLeft.setLocalPosition(6 * Math.sin(time * 0.2), 2, 6 * Math.cos(time * 0.2));
+        cameraLeft.lookAt(logoEntity2.getPosition());
+
+        // rotate camera right around splat differently
+        cameraRight.setLocalPosition(6 * Math.sin(-time * 0.4), 2, 6 * Math.cos(-time * 0.4));
+        cameraRight.lookAt(logoEntity2.getPosition());
+    });
+});
+
+export { app };

--- a/examples/src/examples/gaussian-splatting/picking.example.mjs
+++ b/examples/src/examples/gaussian-splatting/picking.example.mjs
@@ -47,7 +47,7 @@ app.on('destroy', () => {
 });
 
 const assets = {
-    skull: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/playcanvas-logo/meta.json` }),
+    logo: new pc.Asset('gsplat', 'gsplat', { url: `${rootPath}/static/assets/splats/playcanvas-logo/meta.json` }),
     orbit: new pc.Asset('script', 'script', { url: `${rootPath}/static/scripts/camera/orbit-camera.js` }),
     helipad: new pc.Asset(
         'helipad-env-atlas',
@@ -73,7 +73,7 @@ assetListLoader.load(() => {
         // create a splat entity and place it in the world
         const splat = new pc.Entity(`splat-${i}`);
         splat.addComponent('gsplat', {
-            asset: assets.skull,
+            asset: assets.logo,
             castShadows: false
         });
 

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -3,6 +3,8 @@ import { GSplatInstance } from '../../../scene/gsplat/gsplat-instance.js';
 import { Asset } from '../../asset/asset.js';
 import { AssetReference } from '../../asset/asset-reference.js';
 import { Component } from '../component.js';
+import { Debug } from '../../../core/debug.js';
+import { GSplatPlacement } from '../../../scene/gsplat/unified/gsplat-placement.js';
 
 /**
  * @import { BoundingBox } from '../../../core/shape/bounding-box.js'
@@ -56,6 +58,12 @@ class GSplatComponent extends Component {
     _instance = null;
 
     /**
+     * @type {GSplatPlacement|null}
+     * @private
+     */
+    _placement = null;
+
+    /**
      * @type {ShaderMaterial|null}
      * @private
      */
@@ -96,6 +104,14 @@ class GSplatComponent extends Component {
 
     /** @private */
     _castShadows = false;
+
+    /**
+     * Whether to use the unified gsplat rendering.
+     *
+     * @type {boolean}
+     * @private
+     */
+    _unified = false;
 
     /**
      * Create a new GSplatComponent.
@@ -156,6 +172,8 @@ class GSplatComponent extends Component {
      */
     set instance(value) {
 
+        Debug.assert(!this.unified);
+
         // destroy existing instance
         this.destroyInstance();
 
@@ -193,6 +211,9 @@ class GSplatComponent extends Component {
      * @param {ShaderMaterial} value - The material instance.
      */
     set material(value) {
+
+        Debug.assert(!this.unified);
+
         if (this._instance) {
             this._instance.material = value;
         } else {
@@ -225,9 +246,7 @@ class GSplatComponent extends Component {
     set highQualitySH(value) {
         if (value !== this._highQualitySH) {
             this._highQualitySH = value;
-            if (this._instance) {
-                this._instance.setHighQualitySH(value);
-            }
+            this._instance?.setHighQualitySH(value);
         }
     }
 
@@ -287,6 +306,31 @@ class GSplatComponent extends Component {
      */
     get castShadows() {
         return this._castShadows;
+    }
+
+    /**
+     * Sets whether to use the unified gsplat rendering. Can be changed only when the component is
+     * not enabled. Default is false.
+     *
+     * @type {boolean}
+     */
+    set unified(value) {
+
+        if (this.enabled && this.entity.enabled) {
+            Debug.warn('GSplatComponent#unified can be changed only when the component is not enabled. Ignoring change.');
+            return;
+        }
+
+        this._unified = value;
+    }
+
+    /**
+     * Gets whether to use the unified gsplat rendering.
+     *
+     * @type {boolean}
+     */
+    get unified() {
+        return this._unified;
     }
 
     /**
@@ -356,6 +400,12 @@ class GSplatComponent extends Component {
 
     /** @private */
     destroyInstance() {
+
+        if (this._placement) {
+            this.removeFromLayers();
+            this._placement = null;
+        }
+
         if (this._instance) {
             this.removeFromLayers();
             this._instance?.destroy();
@@ -365,6 +415,15 @@ class GSplatComponent extends Component {
 
     /** @private */
     addToLayers() {
+
+        if (this._placement) {
+            const layers = this.system.app.scene.layers;
+            for (let i = 0; i < this._layers.length; i++) {
+                layers.getLayerById(this._layers[i])?.addGSplatPlacement(this._placement);
+            }
+            return;
+        }
+
         const meshInstance = this.instance?.meshInstance;
         if (meshInstance) {
             const layers = this.system.app.scene.layers;
@@ -375,6 +434,15 @@ class GSplatComponent extends Component {
     }
 
     removeFromLayers() {
+
+        if (this._placement) {
+            const layers = this.system.app.scene.layers;
+            for (let i = 0; i < this._layers.length; i++) {
+                layers.getLayerById(this._layers[i])?.removeGSplatPlacement(this._placement);
+            }
+            return;
+        }
+
         const meshInstance = this.instance?.meshInstance;
         if (meshInstance) {
             const layers = this.system.app.scene.layers;
@@ -391,8 +459,10 @@ class GSplatComponent extends Component {
 
     /** @private */
     onInsertChild() {
-        if (this._instance && this.enabled && this.entity.enabled) {
-            this.addToLayers();
+        if (this.enabled && this.entity.enabled) {
+            if (this._instance || this._placement) {
+                this.addToLayers();
+            }
         }
     }
 
@@ -420,6 +490,8 @@ class GSplatComponent extends Component {
         if (this._instance) {
             layer.addMeshInstances(this._instance.meshInstance);
         }
+
+        Debug.assert(!this.unified);
     }
 
     onLayerRemoved(layer) {
@@ -428,6 +500,8 @@ class GSplatComponent extends Component {
         if (this._instance) {
             layer.removeMeshInstances(this._instance.meshInstance);
         }
+
+        Debug.assert(!this.unified);
     }
 
     onEnable() {
@@ -441,7 +515,7 @@ class GSplatComponent extends Component {
             this._evtLayerRemoved = layers.on('remove', this.onLayerRemoved, this);
         }
 
-        if (this._instance) {
+        if (this._instance || this._placement) {
             this.addToLayers();
         } else if (this.asset) {
             this._onGSplatAssetAdded();
@@ -500,15 +574,30 @@ class GSplatComponent extends Component {
         // remove existing instance
         this.destroyInstance();
 
-        // create new instance
         const asset = this._assetReference.asset;
+
+        if (this.unified) {
+
+            this._placement = null;
+
+            if (asset) {
+                this._placement = new GSplatPlacement(asset.resource, this.entity);
+            }
+
+        } else {
+
+            // create new instance
+            if (asset) {
+                this.instance = new GSplatInstance(asset.resource, {
+                    material: this._materialTmp,
+                    highQualitySH: this._highQualitySH
+                });
+                this._materialTmp = null;
+            }
+        }
+
         if (asset) {
-            this.instance = new GSplatInstance(asset.resource, {
-                material: this._materialTmp,
-                highQualitySH: this._highQualitySH
-            });
-            this._materialTmp = null;
-            this.customAabb = this.instance.resource.aabb.clone();
+            this.customAabb = asset.resource.aabb.clone();
         }
     }
 

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -15,6 +15,7 @@ const _schema = [
 
 // order matters here
 const _properties = [
+    'unified',
     'castShadows',
     'material',
     'highQualitySH',

--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,6 @@ export { GSplatData } from './scene/gsplat/gsplat-data.js';
 export { GSplatResourceBase } from './scene/gsplat/gsplat-resource-base.js';
 export { GSplatResource } from './scene/gsplat/gsplat-resource.js';
 export { GSplatInstance } from './scene/gsplat/gsplat-instance.js';
-export { GSplatManager } from './scene/gsplat/unified/gsplat-manager.js'; // temporary till proper API is exposed
 export { GSplatSogsData } from './scene/gsplat/gsplat-sogs-data.js';
 export { GSplatSogsResource } from './scene/gsplat/gsplat-sogs-resource.js';
 

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -9,6 +9,7 @@ import { RenderAction } from './render-action.js';
 /**
  * @import { CameraComponent } from '../../framework/components/camera/component.js'
  * @import { Layer } from '../layer.js'
+ * @import { Camera } from '../camera.js'
  */
 
 /**
@@ -85,6 +86,14 @@ class LayerComposition extends EventHandler {
     cameras = [];
 
     /**
+     * A set of {@link Camera}s.
+     *
+     * @type {Set<Camera>}
+     * @ignore
+     */
+    camerasSet = new Set();
+
+    /**
      * The actual rendering sequence, generated based on layers and cameras
      *
      * @type {RenderAction[]}
@@ -146,16 +155,17 @@ class LayerComposition extends EventHandler {
 
             // walk the layers and build an array of unique cameras from all layers
             this.cameras.length = 0;
+            this.camerasSet.clear();
             for (let i = 0; i < len; i++) {
                 const layer = this.layerList[i];
                 layer._dirtyComposition = false;
 
                 // for all cameras in the layer
                 for (let j = 0; j < layer.cameras.length; j++) {
-                    const camera = layer.cameras[j];
-                    const index = this.cameras.indexOf(camera);
-                    if (index < 0) {
-                        this.cameras.push(camera);
+                    const cameraComponent = layer.cameras[j];
+                    if (!this.camerasSet.has(cameraComponent.camera)) {
+                        this.camerasSet.add(cameraComponent.camera);
+                        this.cameras.push(cameraComponent);
                     }
                 }
             }

--- a/src/scene/gsplat/unified/gsplat-director.js
+++ b/src/scene/gsplat/unified/gsplat-director.js
@@ -1,0 +1,179 @@
+/**
+ * @import { LayerComposition } from '../../composition/layer-composition.js'
+ * @import { Camera } from '../../camera.js'
+ * @import { Layer } from '../../layer.js'
+ * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
+ * @import { GraphNode } from '../../graph-node.js';
+ */
+
+import { GSplatManager } from './gsplat-manager.js';
+
+/**
+ * Per layer data the director keeps track of.
+ *
+ * @ignore
+ */
+class GSplatLayerData {
+    /**
+     * @type {GSplatManager}
+     */
+    gsplatManager;
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {Layer} layer - The layer.
+     * @param {GraphNode} cameraNode - The camera node.
+     */
+    constructor(device, layer, cameraNode) {
+        this.gsplatManager = new GSplatManager(device, layer, cameraNode);
+    }
+
+    destroy() {
+        this.gsplatManager.destroy();
+    }
+}
+
+/**
+ * Per camera data the director keeps track of.
+ *
+ * @ignore
+ */
+class GSplatCameraData {
+    /**
+     * @type {Map<Layer, GSplatLayerData>}
+     */
+    layersMap = new Map();
+
+    destroy() {
+        this.layersMap.forEach(layerData => layerData.destroy());
+        this.layersMap.clear();
+    }
+
+    removeLayerData(layer) {
+        const layerData = this.layersMap.get(layer);
+        if (layerData) {
+            layerData.destroy();
+            this.layersMap.delete(layer);
+        }
+    }
+
+    getLayerData(device, layer, cameraNode) {
+        let layerData = this.layersMap.get(layer);
+        if (!layerData) {
+            layerData = new GSplatLayerData(device, layer, cameraNode);
+            this.layersMap.set(layer, layerData);
+        }
+        return layerData;
+    }
+}
+
+/**
+ * Class responsible for managing {@link GSplatManager} instances for Cameras and their Layers.
+ *
+ * @ignore
+ */
+class GSplatDirector {
+    /**
+     * @type {GraphicsDevice}
+     */
+    device;
+
+    /**
+     * @type {Map<Camera, GSplatCameraData>}
+     */
+    camerasMap = new Map();
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     */
+    constructor(device) {
+        this.device = device;
+    }
+
+    getCameraData(camera) {
+        let cameraData = this.camerasMap.get(camera);
+        if (!cameraData) {
+            cameraData = new GSplatCameraData();
+            this.camerasMap.set(camera, cameraData);
+        }
+        return cameraData;
+    }
+
+    /**
+     * Updates the director for the given layer composition cameras and layers.
+     *
+     * @param {LayerComposition} comp - The layer composition.
+     */
+    update(comp) {
+
+        // remove camera / layer entires for cameras / layers no longer in the composition
+        this.camerasMap.forEach((cameraData, camera) => {
+
+            // camera is no longer in the composition
+            if (!comp.camerasSet.has(camera)) {
+                cameraData.destroy();
+                this.camerasMap.delete(camera);
+
+            } else { // camera still exists
+
+                // remove all layerdata for removed / disabled layers of this camera
+                cameraData.layersMap.forEach((layerData, layer) => {
+                    if (!camera.layersSet.has(layer.id) || !layer.enabled) {
+                        layerData.destroy();
+                        cameraData.layersMap.delete(layer);
+                    }
+                });
+            }
+        });
+
+        // for all cameras in the composition
+        const camerasComponents = comp.cameras;
+        for (let i = 0; i < camerasComponents.length; i++) {
+            const camera = camerasComponents[i].camera;
+            let cameraData = this.camerasMap.get(camera);
+
+            // for all of its layers
+            const layerIds = camera.layers;
+            for (let j = 0; j < layerIds.length; j++) {
+
+                const layer = comp.getLayerById(layerIds[j]);
+                if (layer?.enabled) {
+
+                    // if layer's splat placements were modified, or new camera
+                    if (layer.gsplatPlacementsDirty || !cameraData) {
+
+                        // no splats on layer
+                        const placements = layer.gsplatPlacements;
+                        if (placements.length === 0) {
+
+                            // remove gsplat manager if it exists
+                            if (cameraData) {
+                                cameraData.removeLayerData(layer);
+                            }
+
+                        } else {
+
+                            // update gsplat manager with modified placements
+                            cameraData ??= this.getCameraData(camera);
+                            const layerData = cameraData.getLayerData(this.device, layer, camera.node);
+                            layerData.gsplatManager.reconcile(placements);
+                        }
+                    }
+                }
+            }
+
+            // update gsplat managers
+            // const cameraData = this.camerasMap.get(camera);
+            cameraData?.layersMap.forEach((layerData) => {
+                layerData.gsplatManager.update();
+            });
+        }
+
+        // clear dirty flags on all layers of the composition
+        for (let i = 0; i < comp.layerList.length; i++) {
+            comp.layerList[i].gsplatPlacementsDirty = false;
+        }
+    }
+}
+
+export { GSplatDirector };

--- a/src/scene/gsplat/unified/gsplat-info.js
+++ b/src/scene/gsplat/unified/gsplat-info.js
@@ -16,6 +16,7 @@ import { Vec3 } from '../../../core/math/vec3.js';
  */
 
 const _viewMat = new Mat4();
+
 /**
  * @ignore
  */
@@ -33,14 +34,14 @@ class GSplatInfo {
     node;
 
     /**
-     * A state of the splat currently used for rendering. This matches the work buffer.
+     * The state of the splat currently used for rendering. This matches the work buffer.
      *
      * @type {GSplatState}
      */
     renderState;
 
     /**
-     * A state of the splat currently used for sorting. When the sorting is done, this state will
+     * The state of the splat currently used for sorting. When the sorting is done, this state will
      * become the render state. This is where the next render state is prepared, but it's not used
      * until we get back the sorting data.
      *

--- a/src/scene/gsplat/unified/gsplat-placement.js
+++ b/src/scene/gsplat/unified/gsplat-placement.js
@@ -1,0 +1,38 @@
+/**
+ * @import { GraphNode } from '../../graph-node.js'
+ * @import { GSplatResource } from '../gsplat-resource.js'
+ */
+
+/**
+ * Class representing a placement of a gsplat resource.
+ *
+ * @ignore
+ */
+class GSplatPlacement {
+    /**
+     * The resource of the splat..
+     *
+     * @type {GSplatResource}
+     */
+    resource;
+
+    /**
+     * The node that the gsplat is linked to.
+     *
+     * @type {GraphNode}
+     */
+    node;
+
+    /**
+     * Create a new GSplatPlacement.
+     *
+     * @param {GSplatResource} resource - The resource that of the splat.
+     * @param {GraphNode} node - The node that the gsplat is linked to.
+     */
+    constructor(resource, node) {
+        this.resource = resource;
+        this.node = node;
+    }
+}
+
+export { GSplatPlacement };

--- a/src/scene/gsplat/unified/gsplat-renderer.js
+++ b/src/scene/gsplat/unified/gsplat-renderer.js
@@ -1,15 +1,20 @@
 import { SEMANTIC_POSITION, SEMANTIC_ATTR13, CULLFACE_NONE } from '../../../platform/graphics/constants.js';
 import { BLEND_NONE, BLEND_PREMULTIPLIED } from '../../constants.js';
 import { ShaderMaterial } from '../../materials/shader-material.js';
-import { MeshInstance } from '../../mesh-instance.js';
 import { GSplatResourceBase } from '../gsplat-resource-base.js';
+import { MeshInstance } from '../../mesh-instance.js';
 
 /**
  * @import { VertexBuffer } from '../../../platform/graphics/vertex-buffer.js'
+ * @import { Layer } from '../../layer.js'
+ * @import { GraphNode } from '../../graph-node.js'
  */
 
-const viewport = [0, 0];
-
+/**
+ * Class that renders the splats from the work buffer.
+ *
+ * @ignore
+ */
 class GSplatRenderer {
     /** @type {ShaderMaterial} */
     _material;
@@ -20,16 +25,22 @@ class GSplatRenderer {
     /** @type {number} */
     maxNumSplats = 0;
 
-    /** @type {VertexBuffer} */
-    instanceIndices;
+    /** @type {VertexBuffer|null} */
+    instanceIndices = null;
 
-    // TODO: is this the best option, or do we want to generate AABB
-    // - ideally generate aabb from individual splats, update each frame
-    cull = false;
+    /** @type {Layer} */
+    layer;
 
-    constructor(device, node, workBuffer) {
+    /** @type {GraphNode} */
+    cameraNode;
+
+    viewportParams = [0, 0];
+
+    constructor(device, node, cameraNode, layer, workBuffer) {
         this.device = device;
         this.node = node;
+        this.cameraNode = cameraNode;
+        this.layer = layer;
         this.workBuffer = workBuffer;
 
         // construct the material which renders the splats from the work buffer
@@ -66,10 +77,12 @@ class GSplatRenderer {
         this._material.depthWrite = !!dither;
         this._material.update();
 
-        this.createMeshInstance();
+        this.meshInstance = this.createMeshInstance();
+        layer.addMeshInstances([this.meshInstance]);
     }
 
     destroy() {
+        this.layer.removeMeshInstances([this.meshInstance]);
         this._material.destroy();
         this.meshInstance.destroy();
     }
@@ -96,7 +109,7 @@ class GSplatRenderer {
 
             // create new instance indices
             this.instanceIndices = GSplatResourceBase.createInstanceIndices(this.device, numSplats);
-            this.meshInstance.setInstancing(this.instanceIndices, this.cull);
+            this.meshInstance.setInstancing(this.instanceIndices, true);
         }
     }
 
@@ -104,22 +117,33 @@ class GSplatRenderer {
 
         const mesh = GSplatResourceBase.createMesh(this.device);
         const instanceIndices = GSplatResourceBase.createInstanceIndices(this.device, this.workBuffer.width * this.workBuffer.height);
-        this.meshInstance = new MeshInstance(mesh, this._material);
-        this.meshInstance.node = this.node;
-        this.meshInstance.setInstancing(instanceIndices, this.cull);
-        this.meshInstance.cull = this.cull;
+        const meshInstance = new MeshInstance(mesh, this._material);
+        meshInstance.node = this.node;
+        meshInstance.setInstancing(instanceIndices, true);
 
         // only start rendering the splat after we've received the splat order data
-        this.meshInstance.instancingCount = 0;
+        meshInstance.instancingCount = 0;
+
+        // custom culling to only disable rendering for matching camera
+        // TODO: consider using aabb as well to avoid rendering off-screen splats
+        const thisCamera = this.cameraNode.camera;
+        meshInstance.isVisibleFunc = (camera) => {
+            const vis = thisCamera.camera === camera;
+            return vis;
+        };
+
+        return meshInstance;
     }
 
     updateViewport(cameraNode) {
-        const camera = cameraNode?.camera;
+        const camera = cameraNode.camera;
+        const cameraRect = camera.rect;
         const renderTarget = camera?.renderTarget;
         const { width, height } = renderTarget ?? this.device;
 
-        viewport[0] = width;
-        viewport[1] = height;
+        const viewport = this.viewportParams;
+        viewport[0] = width * cameraRect.z;
+        viewport[1] = height * cameraRect.w;
 
         // adjust viewport for stereoscopic VR sessions
         const xr = camera?.camera?.xr;

--- a/src/scene/gsplat/unified/gsplat-unified-sort-worker.js
+++ b/src/scene/gsplat/unified/gsplat-unified-sort-worker.js
@@ -97,14 +97,18 @@ function UnifiedSortWorker() {
         // }
 
 
-        const minDist = -2300;
-        const maxDist = 2300;
+        const minDist = -1000;
+        const maxDist = 1000;
+        // const minDist = -50;
+        // const maxDist = 10;
 
 
         const numVertices = sortSplatCount ?? centers.length / 3;
 
         // calculate number of bits needed to store sorting result
-        const compareBits = Math.max(10, Math.min(20, Math.round(Math.log2(numVertices / 4))));
+        //const compareBits = Math.max(10, Math.min(20, Math.round(Math.log2(numVertices / 4))));
+        const compareBits = 20;
+
         const bucketCount = 2 ** compareBits + 1;
 
         // create distance buffer

--- a/src/scene/gsplat/unified/gsplat-work-buffer.js
+++ b/src/scene/gsplat/unified/gsplat-work-buffer.js
@@ -81,7 +81,6 @@ class GSplatWorkBuffer {
             Debug.error('setOrderData: data length mismatch, got:', data.length, 'expected:', len, `(${this.orderTexture.width}x${this.orderTexture.height})`);
         }
 
-
         // upload data to texture
         this.orderTexture._levels[0] = data;
         this.orderTexture.upload();

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -13,6 +13,7 @@ import { Material } from './materials/material.js';
  * @import { LightComponent } from '../framework/components/light/component.js'
  * @import { MeshInstance } from './mesh-instance.js'
  * @import { Vec3 } from '../core/math/vec3.js'
+ * @import { GSplatPlacement } from './gsplat/unified/gsplat-placement.js'
  */
 
 // Layers
@@ -170,6 +171,20 @@ class Layer {
      * @ignore
      */
     camerasSet = new Set();
+
+    /**
+     * @type {GSplatPlacement[]}
+     * @ignore
+     */
+    gsplatPlacements = [];
+
+    /**
+     * True if the gsplatPlacements array was modified.
+     *
+     * @type {boolean}
+     * @ignore
+     */
+    gsplatPlacementsDirty = true;
 
     /**
      * True if the composition is invalidated.
@@ -337,6 +352,7 @@ class Layer {
     set enabled(val) {
         if (val !== this._enabled) {
             this._dirtyComposition = true;
+            this.gsplatPlacementsDirty = true;
             this._enabled = val;
             if (val) {
                 this.incrementCounter();
@@ -469,6 +485,33 @@ class Layer {
             return;
         }
         this._refCounter--;
+    }
+
+    /**
+     * Adds a gsplat placement to this layer.
+     *
+     * @param {GSplatPlacement} placement - A placement of a gsplat.
+     * @ignore
+     */
+    addGSplatPlacement(placement) {
+        if (!this.gsplatPlacements.includes(placement)) {
+            this.gsplatPlacements.push(placement);
+            this.gsplatPlacementsDirty = true;
+        }
+    }
+
+    /**
+     * Removes a gsplat placement from this layer.
+     *
+     * @param {GSplatPlacement} placement - A placement of a gsplat.
+     * @ignore
+     */
+    removeGSplatPlacement(placement) {
+        const index = this.gsplatPlacements.indexOf(placement);
+        if (index >= 0) {
+            this.gsplatPlacements.splice(index, 1);
+            this.gsplatPlacementsDirty = true;
+        }
     }
 
     /**

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1005,6 +1005,9 @@ class ForwardRenderer extends Renderer {
         this.beginFrame(comp);
         this.setSceneConstants();
 
+        // update gsplat director
+        this.gsplatDirector.update(comp);
+
         // visibility culling of lights, meshInstances, shadows casters
         // after this the scene culling is done and script callbacks can be called to report which objects are visible
         this.cullComposition(comp);

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -36,6 +36,7 @@ import { ShadowRendererDirectional } from './shadow-renderer-directional.js';
 import { ShadowRenderer } from './shadow-renderer.js';
 import { WorldClustersAllocator } from './world-clusters-allocator.js';
 import { RenderPassUpdateClustered } from './render-pass-update-clustered.js';
+import { GSplatDirector } from '../gsplat/unified/gsplat-director.js';
 
 /**
  * @import { Camera } from '../camera.js'
@@ -112,7 +113,7 @@ class Renderer {
      * skinning or morphing. Extracted during culling.
      *
      * @type {Set<MeshInstance>}
-     * @private
+     * @protected
      */
     processingMeshInstances = new Set();
 
@@ -156,6 +157,13 @@ class Renderer {
     blueNoise = new BlueNoise(123);
 
     /**
+     * A gsplat director for unified splat rendering.
+     *
+     * @type {GSplatDirector}
+     */
+    gsplatDirector;
+
+    /**
      * Create a new instance.
      *
      * @param {GraphicsDevice} graphicsDevice - The graphics device used by the renderer.
@@ -165,6 +173,8 @@ class Renderer {
 
         /** @type {Scene|null} */
         this.scene = null;
+
+        this.gsplatDirector = new GSplatDirector(graphicsDevice);
 
         // TODO: allocate only when the scene has clustered lighting enabled
         this.worldClustersAllocator = new WorldClustersAllocator(graphicsDevice);

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
@@ -49,7 +49,7 @@ void main(void) {
         
         // source texture size
         #ifdef GSPLAT_SOGS_DATA
-            uint srcSize = uint(textureSize(scales, 0).x);
+            uint srcSize = uint(textureSize(packedTexture, 0).x);
         #elif GSPLAT_COMPRESSED_DATA
             uint srcSize = uint(textureSize(packedTexture, 0).x);
         #else

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
@@ -54,7 +54,7 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         // source texture size
         var srcSize: u32;
         #ifdef GSPLAT_SOGS_DATA
-            srcSize = u32(textureDimensions(scales, 0).x);
+            srcSize = u32(textureDimensions(packedTexture, 0).x);
         #elif GSPLAT_COMPRESSED_DATA
             srcSize = u32(textureDimensions(packedTexture, 0).x);
         #else


### PR DESCRIPTION
A public way to utilize unified gsplat architecture, using additiona `unified` component property:

```
entity.addComponent('gsplat', {
    asset: assets.logo,
    unified: true
});

```

Note that this property can be changed only when the splat is disabled (it's internal data not created) at the moment, and ignored with a warning otherwise.

Details:
- internal GSplatDirector class, managing instancing of GSplatManager for cameras / layers that have the gsplat component
- Layers stores array of GSplatPlacement (equivanent to MeshInstance) - this is all private, used by GSplatDirector to manage what it needs to render
- added an example to show / test rendering from multiple cameras.