### PR TITLE
Add progress for img loads

### DIFF
--- a/src/framework/parsers/sogs.js
+++ b/src/framework/parsers/sogs.js
@@ -84,14 +84,17 @@ class SogsParser {
                 });
 
                 assets.add(texture);
-                assets.load(texture);
                 promises.push(promise);
 
                 return texture;
             });
         });
 
-        combineProgress(asset, subs.map(sub => textures[sub]).flat());
+        const textureAssets = subs.map(sub => textures[sub]).flat();
+
+        combineProgress(asset, textureAssets);
+
+        textureAssets.forEach(t => assets.load(t));
 
         // wait for all textures to complete loading
         await Promise.allSettled(promises);

--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -97,11 +97,11 @@ class ImgParser extends TextureParser {
         const dummySize = 1024 * 1024;
 
         // HTMLImageElement doesn't support progress events, so we emulate it instead
-        asset.fire('progress', 0, dummySize);
+        asset?.fire('progress', 0, dummySize);
 
         // Call success callback after opening Texture
         image.onload = function () {
-            asset.fire('progress', dummySize, dummySize);
+            asset?.fire('progress', dummySize, dummySize);
             callback(null, image);
         };
 

--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -63,7 +63,7 @@ class ImgParser extends TextureParser {
         if (this.device.supportsImageBitmap) {
             this._loadImageBitmap(url.load, url.original, crossOrigin, handler, asset);
         } else {
-            this._loadImage(url.load, url.original, crossOrigin, handler);
+            this._loadImage(url.load, url.original, crossOrigin, handler, asset);
         }
     }
 
@@ -84,7 +84,7 @@ class ImgParser extends TextureParser {
         return texture;
     }
 
-    _loadImage(url, originalUrl, crossOrigin, callback) {
+    _loadImage(url, originalUrl, crossOrigin, callback, asset) {
         const image = new Image();
         if (crossOrigin) {
             image.crossOrigin = crossOrigin;
@@ -94,8 +94,14 @@ class ImgParser extends TextureParser {
         const maxRetries = this.maxRetries;
         let retryTimeout;
 
+        const dummySize = 1024 * 1024;
+
+        // HTMLImageElement doesn't support progress events, so we emulate it instead
+        asset.fire('progress', 0, dummySize);
+
         // Call success callback after opening Texture
         image.onload = function () {
+            asset.fire('progress', dummySize, dummySize);
             callback(null, image);
         };
 


### PR DESCRIPTION
Followup to #7847.

We still use `HTMLImageElement` to load jpg/png/webp images, because ImageBitmap still has the premultiplied alpha issue (see #5235 for more information).

However `HTMLImageElement` doesn't fire progress events and so SOGS loading progress bar doesn't work on Safari.

This PR emulates progress events by firing an initial 0% progress then 100% progress event. This means SOGS loading at least has 6 steps of loading.