### PR TITLE
Android sogs fix

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat-sogs-reorder.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat-sogs-reorder.js
@@ -1,9 +1,9 @@
 export default /* glsl */`
-    uniform sampler2D means_l;
-    uniform sampler2D means_u;
-    uniform sampler2D quats;
-    uniform sampler2D scales;
-    uniform sampler2D sh_labels;
+    uniform highp sampler2D means_l;
+    uniform highp sampler2D means_u;
+    uniform highp sampler2D quats;
+    uniform highp sampler2D scales;
+    uniform highp sampler2D sh_labels;
 
     uniform highp uint numSplats;
 


### PR DESCRIPTION
Android doesn't load SOGS correctly due to reorder shader not flagging inputs as highp.