### PR TITLE
Export UniformBuffer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,6 +120,7 @@ export { StorageBuffer } from './platform/graphics/storage-buffer.js';
 export { Texture } from './platform/graphics/texture.js';
 export { TextureUtils } from './platform/graphics/texture-utils.js';
 export { TransformFeedback } from './platform/graphics/transform-feedback.js';
+export { UniformBuffer } from './platform/graphics/uniform-buffer.js';
 export { UniformBufferFormat, UniformFormat } from './platform/graphics/uniform-buffer-format.js';
 export { VertexBuffer } from './platform/graphics/vertex-buffer.js';
 export { VertexFormat } from './platform/graphics/vertex-format.js';


### PR DESCRIPTION
The examples should probably use engine's exported interface to catch these missing exports.