### PR TITLE
[Fix] Reordered bindings when using a StorageBuffer 

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -685,7 +685,7 @@ class WebgpuShaderProcessorWGSL {
             if (format.hasSampler) {
                 // A slot should have been left empty for the sampler at format.slot+1
                 const samplerName = format.sampleType === SAMPLETYPE_DEPTH ? 'sampler_comparison' : 'sampler';
-                code += `@group(${bindGroup}) @binding(${format.slot+1}) var ${format.samplerName}: ${samplerName};\n`;
+                code += `@group(${bindGroup}) @binding(${format.slot + 1}) var ${format.samplerName}: ${samplerName};\n`;
             }
         });
 


### PR DESCRIPTION
## Description
I reached a weird bug where the Preprocessor generated code output and generated bind layout were misaligned.

(in `WebgpuShaderProcessorWGSL.processResources`) It seems that the constructor for `BindGroupFormat` assigns 'slots' based on the order of the `formats` arg, and then sorts the bindings into various groups (in my case, textures and buffers were sorted) - and then later `getTextureShaderDeclaration` ([here](https://github.com/playcanvas/engine/blob/371394e19d11dd667e397b217ea60c5639cd89c7/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js#L610)) assigns ids to first textures, then storage buffers (which is not the same order as `formats` was).

This ended up with my storage buffer being the first binding in the bind layout (slot 0), but the last one in the actual shader source code (slot 5). I would share a PoC but I haven't got time to write a repro outside of my codebase right now, though if you need one I may be able to write one in the future.

Fixes #

I wrote a naive fix (which makes my code work), but my changes mean that `getTextureShaderDeclaration` no longer does anything with `startBindIndex`, which seems to be used in other places (and seemingly added by this PR https://github.com/playcanvas/engine/pull/7342).

I don't have very much context on Playcanvas or your shader system, so I would appreciate some feedback on the proper way to fix this bug!

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
