### PR TITLE
Removed passing obsolete parameter to an internal function

### DIFF
--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -152,7 +152,7 @@ class TransformFeedback {
         const oldRt = device.getRenderTarget();
         device.setRenderTarget(null);
         device.updateBegin();
-        device.setVertexBuffer(this._inputBuffer, 0);
+        device.setVertexBuffer(this._inputBuffer);
         device.setRaster(false);
         device.setTransformFeedbackBuffer(this._outputBuffer);
         device.setShader(shader);

--- a/src/scene/graphics/quad-render.js
+++ b/src/scene/graphics/quad-render.js
@@ -124,7 +124,7 @@ class QuadRender {
             device.setScissor(scissor.x, scissor.y, scissor.z, scissor.w);
         }
 
-        device.setVertexBuffer(device.quadVertexBuffer, 0);
+        device.setVertexBuffer(device.quadVertexBuffer);
 
         const shader = this.shader;
         device.setShader(shader);


### PR DESCRIPTION
- no longer used, removed a while back