### PR TITLE
Unified gsplat - use render pass to update work buffer

### DIFF
--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -22,6 +22,7 @@ const translation = new Vec3();
 const invModelMat = new Mat4();
 const tempNonOctreePlacements = new Set();
 const tempOctreePlacements = new Set();
+const _updatedSplats = [];
 
 /**
  * GSplatManager manages the rendering of splats using a work buffer, where all active splats are
@@ -338,12 +339,19 @@ class GSplatManager {
         const sortedState = this.worldStates.get(this.sortedVersion);
         if (sortedState) {
             const updateVersion = ++this.updateVersion;
-            const rt = this.workBuffer.renderTarget;
+
+            // Collect splats that have been updated
             sortedState.splats.forEach((splat) => {
                 if (splat.update(updateVersion)) {
-                    splat.render(rt, this.cameraNode, splat.lodIndex);
+                    _updatedSplats.push(splat);
                 }
             });
+
+            // Batch render all updated splats in a single render pass
+            if (_updatedSplats.length > 0) {
+                this.workBuffer.render(_updatedSplats, this.cameraNode);
+                _updatedSplats.length = 0;
+            }
         }
     }
 

--- a/src/scene/gsplat-unified/gsplat-work-buffer-render-pass.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer-render-pass.js
@@ -1,0 +1,143 @@
+import { Debug } from '../../core/debug.js';
+import { Mat4 } from '../../core/math/mat4.js';
+import { RenderPass } from '../../platform/graphics/render-pass.js';
+import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
+
+/**
+ * @import { GSplatInfo } from './gsplat-info.js'
+ * @import { GraphNode } from '../graph-node.js'
+ * @import { RenderTarget } from '../../platform/graphics/render-target.js'
+ */
+
+const _viewMat = new Mat4();
+
+const _lodColors = [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+    [1, 1, 0],
+    [1, 0, 1]
+];
+
+// enable to colorize LODs
+const colorizeLod = false;
+
+/**
+ * A render pass used to render multiple gsplats to a work buffer render target.
+ *
+ * @ignore
+ */
+class GSplatWorkBufferRenderPass extends RenderPass {
+    /**
+     * Array of GSplatInfo objects to render in this pass.
+     *
+     * @type {GSplatInfo[]}
+     */
+    splats = [];
+
+    /**
+     * The camera node used for rendering.
+     *
+     * @type {GraphNode}
+     */
+    cameraNode;
+
+    /**
+     * Initialize the render pass with the specified render target.
+     *
+     * @param {RenderTarget} renderTarget - The target to render to.
+     */
+    init(renderTarget) {
+        super.init(renderTarget);
+        this.colorOps.clear = false;
+        this.depthStencilOps.clearDepth = false;
+    }
+
+    /**
+     * Update the render pass with splats to render and camera.
+     *
+     * @param {GSplatInfo[]} splats - Array of GSplatInfo objects to render.
+     * @param {GraphNode} cameraNode - The camera node for rendering.
+     * @returns {boolean} True if there are splats to render, false otherwise.
+     */
+    update(splats, cameraNode) {
+        this.splats.length = 0;
+
+        // Filter active splats that need rendering
+        for (let i = 0; i < splats.length; i++) {
+            const splatInfo = splats[i];
+            if (splatInfo.activeSplats > 0) {
+                this.splats.push(splatInfo);
+            }
+        }
+
+        this.cameraNode = cameraNode;
+        return this.splats.length > 0;
+    }
+
+    execute() {
+        const { device, splats, cameraNode } = this;
+
+        DebugGraphics.pushGpuMarker(device, 'GSplatWorkBuffer');
+
+        // view matrix
+        const viewInvMat = cameraNode.getWorldTransform();
+        const viewMat = _viewMat.copy(viewInvMat).invert();
+        device.scope.resolve('matrix_view').setValue(viewMat.data);
+
+        // render each splat info
+        for (let i = 0; i < splats.length; i++) {
+            this.renderSplat(splats[i]);
+        }
+
+        DebugGraphics.popGpuMarker(device);
+    }
+
+    /**
+     * Render a single splat info object.
+     *
+     * @param {GSplatInfo} splatInfo - The splat info to render.
+     */
+    renderSplat(splatInfo) {
+        const { device, resource } = splatInfo;
+        const scope = device.scope;
+        Debug.assert(resource);
+
+        const { intervals, activeSplats, lineStart, viewport, intervalTexture } = splatInfo;
+
+        // quad renderer and material are cached in the resource
+        const workBufferRenderInfo = resource.getWorkBufferRenderInfo(intervals.length > 0, colorizeLod);
+
+        // Assign material properties to scope
+        workBufferRenderInfo.material.setParameters(device);
+
+        // Matrix to transform splats to the world space
+        scope.resolve('uTransform').setValue(splatInfo.node.getWorldTransform().data);
+
+        if (intervalTexture.texture) {
+            // Set LOD intervals texture for remapping of indices
+            scope.resolve('uIntervalsTexture').setValue(intervalTexture.texture);
+        }
+
+        scope.resolve('uActiveSplats').setValue(activeSplats);
+        scope.resolve('uStartLine').setValue(lineStart);
+        scope.resolve('uViewportWidth').setValue(viewport.z);
+
+        if (colorizeLod) {
+            scope.resolve('uLodColor').setValue(_lodColors[splatInfo.lodIndex]);
+        }
+
+        // SH related
+        scope.resolve('matrix_model').setValue(splatInfo.node.getWorldTransform().data);
+
+        // Render the quad - QuadRender handles all the complex setup internally
+        workBufferRenderInfo.quadRender.render(viewport);
+    }
+
+    destroy() {
+        this.splats.length = 0;
+        super.destroy();
+    }
+}
+
+export { GSplatWorkBufferRenderPass };

--- a/src/scene/gsplat/gsplat-compressed-resource.js
+++ b/src/scene/gsplat/gsplat-compressed-resource.js
@@ -91,17 +91,20 @@ class GSplatCompressedResource extends GSplatResourceBase {
         super.destroy();
     }
 
+    configureMaterialDefines(defines) {
+        defines.set('GSPLAT_COMPRESSED_DATA', true);
+        defines.set('SH_BANDS', this.shTexture0 ? 3 : 0);
+    }
+
     configureMaterial(material) {
-        material.setDefine('GSPLAT_COMPRESSED_DATA', true);
+        this.configureMaterialDefines(material.defines);
+
         material.setParameter('packedTexture', this.packedTexture);
         material.setParameter('chunkTexture', this.chunkTexture);
         if (this.shTexture0) {
-            material.setDefine('SH_BANDS', 3);
             material.setParameter('shTexture0', this.shTexture0);
             material.setParameter('shTexture1', this.shTexture1);
             material.setParameter('shTexture2', this.shTexture2);
-        } else {
-            material.setDefine('SH_BANDS', 0);
         }
     }
 

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -1,11 +1,16 @@
 import { Debug } from '../../core/debug.js';
 import { Vec2 } from '../../core/math/vec2.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
-import { ADDRESS_CLAMP_TO_EDGE, BUFFER_STATIC, FILTER_NEAREST, SEMANTIC_ATTR13, TYPE_UINT32 } from '../../platform/graphics/constants.js';
+import { ADDRESS_CLAMP_TO_EDGE, BUFFER_STATIC, FILTER_NEAREST, SEMANTIC_ATTR13, SEMANTIC_POSITION, TYPE_UINT32 } from '../../platform/graphics/constants.js';
 import { Texture } from '../../platform/graphics/texture.js';
 import { VertexFormat } from '../../platform/graphics/vertex-format.js';
 import { VertexBuffer } from '../../platform/graphics/vertex-buffer.js';
 import { Mesh } from '../mesh.js';
+import { ShaderMaterial } from '../materials/shader-material.js';
+import { QuadRender } from '../graphics/quad-render.js';
+import { ShaderUtils } from '../shader-lib/shader-utils.js';
+import glslGsplatCopyToWorkBufferPS from '../shader-lib/glsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js';
+import wgslGsplatCopyToWorkBufferPS from '../shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
@@ -15,6 +20,43 @@ import { Mesh } from '../mesh.js';
  */
 
 let id = 0;
+const tempMap = new Map();
+
+/**
+ * A helper class to cache quad renders for work buffer rendering.
+ *
+ * @ignore
+ */
+class WorkBufferRenderInfo {
+    /** @type {ShaderMaterial} */
+    material;
+
+    /** @type {QuadRender} */
+    quadRender;
+
+    constructor(device, key, material) {
+        this.device = device;
+        this.material = material;
+
+        const clonedDefines = new Map(material.defines);
+        const shader = ShaderUtils.createShader(this.device, {
+            uniqueName: `SplatCopyToWorkBuffer:${key}`,
+            attributes: { vertex_position: SEMANTIC_POSITION },
+            vertexDefines: clonedDefines,
+            fragmentDefines: clonedDefines,
+            vertexChunk: 'fullscreenQuadVS',
+            fragmentGLSL: glslGsplatCopyToWorkBufferPS,
+            fragmentWGSL: wgslGsplatCopyToWorkBufferPS
+        });
+
+        this.quadRender = new QuadRender(shader);
+    }
+
+    destroy() {
+        this.material?.destroy();
+        this.quadRender?.destroy();
+    }
+}
 
 /**
  * Base class for a GSplat resource and defines common properties.
@@ -43,6 +85,9 @@ class GSplatResourceBase {
     /** @type {number} */
     id = id++;
 
+    /** @type {Map<string, WorkBufferRenderInfo>} */
+    workBufferRenderInfos = new Map();
+
     constructor(device, gsplatData) {
         this.device = device;
         this.gsplatData = gsplatData;
@@ -66,6 +111,42 @@ class GSplatResourceBase {
     destroy() {
         this.mesh?.destroy();
         this.instanceIndices?.destroy();
+        this.workBufferRenderInfos.forEach(info => info.destroy());
+        this.workBufferRenderInfos.clear();
+    }
+
+    /**
+     * Get or create a QuadRender for rendering to work buffer.
+     *
+     * @param {boolean} useIntervals - Whether to use intervals.
+     * @param {boolean} colorizeLod - Whether to colorize the LOD.
+     * @returns {WorkBufferRenderInfo} The WorkBufferRenderInfo instance.
+     */
+    getWorkBufferRenderInfo(useIntervals, colorizeLod) {
+
+        // configure defines to fetch cached data
+        this.configureMaterialDefines(tempMap);
+        if (useIntervals) tempMap.set('GSPLAT_LOD', '');
+        if (colorizeLod) tempMap.set('GSPLAT_COLORIZE', '');
+        const key = Array.from(tempMap.entries()).map(([k, v]) => `${k}=${v}`).join(';');
+
+        // get or create quad render
+        let info = this.workBufferRenderInfos.get(key);
+        if (!info) {
+
+            const material = new ShaderMaterial();
+            this.configureMaterial(material);
+
+            // copy tempMap to material defines
+            tempMap.forEach((v, k) => material.setDefine(k, v));
+
+            // create new cache entry
+            info = new WorkBufferRenderInfo(this.device, key, material);
+            this.workBufferRenderInfos.set(key, info);
+        }
+
+        tempMap.clear();
+        return info;
     }
 
     static createMesh(device) {
@@ -129,6 +210,9 @@ class GSplatResourceBase {
     }
 
     configureMaterial(material) {
+    }
+
+    configureMaterialDefines(defines) {
     }
 
     /**

--- a/src/scene/gsplat/gsplat-resource.js
+++ b/src/scene/gsplat/gsplat-resource.js
@@ -94,11 +94,15 @@ class GSplatResource extends GSplatResourceBase {
         super.destroy();
     }
 
+    configureMaterialDefines(defines) {
+        defines.set('SH_BANDS', this.shBands);
+    }
+
     configureMaterial(material) {
+        this.configureMaterialDefines(material.defines);
         material.setParameter('splatColor', this.colorTexture);
         material.setParameter('transformA', this.transformATexture);
         material.setParameter('transformB', this.transformBTexture);
-        material.setDefine('SH_BANDS', this.shBands);
         if (this.sh1to3Texture) material.setParameter('splatSH_1to3', this.sh1to3Texture);
         if (this.sh4to7Texture) material.setParameter('splatSH_4to7', this.sh4to7Texture);
         if (this.sh8to11Texture) material.setParameter('splatSH_8to11', this.sh8to11Texture);

--- a/src/scene/gsplat/gsplat-sogs-resource.js
+++ b/src/scene/gsplat/gsplat-sogs-resource.js
@@ -7,11 +7,15 @@ class GSplatSogsResource extends GSplatResourceBase {
         super.destroy();
     }
 
-    configureMaterial(material) {
-        const { gsplatData } = this;
+    configureMaterialDefines(defines) {
+        defines.set('GSPLAT_SOGS_DATA', true);
+        defines.set('SH_BANDS', this.gsplatData.shBands);
+    }
 
-        material.setDefine('GSPLAT_SOGS_DATA', true);
-        material.setDefine('SH_BANDS', this.gsplatData.shBands);
+    configureMaterial(material) {
+        this.configureMaterialDefines(material.defines);
+
+        const { gsplatData } = this;
 
         ['packedTexture', 'sh0', 'sh_centroids'].forEach((name) => {
             if (gsplatData[name]) {


### PR DESCRIPTION
- gsplats rendering to workbuffer used drawQuadWithShader, which under the hood allocates QuadRender each time, and executes render pass.
- as all gsplats are rendered to the same render target, its much more efficient to rendered them in a single render pass, and this was done. QuadRender are also preallocated and cached on a resource level