### PR TITLE
Fix - missed default render state set up for rendering of splats to work buffer

### DIFF
--- a/src/scene/gsplat-unified/gsplat-work-buffer-render-pass.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer-render-pass.js
@@ -2,6 +2,9 @@ import { Debug } from '../../core/debug.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { RenderPass } from '../../platform/graphics/render-pass.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
+import { BlendState } from '../../platform/graphics/blend-state.js';
+import { DepthState } from '../../platform/graphics/depth-state.js';
+import { CULLFACE_NONE } from '../../platform/graphics/constants.js';
 
 /**
  * @import { GSplatInfo } from './gsplat-info.js'
@@ -79,6 +82,12 @@ class GSplatWorkBufferRenderPass extends RenderPass {
         const { device, splats, cameraNode } = this;
 
         DebugGraphics.pushGpuMarker(device, 'GSplatWorkBuffer');
+
+        // Set up render state
+        device.setBlendState(BlendState.NOBLEND);
+        device.setCullMode(CULLFACE_NONE);
+        device.setDepthState(DepthState.NODEPTH);
+        device.setStencilState();
 
         // view matrix
         const viewInvMat = cameraNode.getWorldTransform();


### PR DESCRIPTION
Issue introduced here: https://github.com/playcanvas/engine/pull/7913