### PR TITLE
Gizmo infinity fix

### DIFF
--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -296,7 +296,7 @@ class Gizmo extends EventHandler {
      * @type {boolean}
      */
     set enabled(state) {
-        const cameraDist = this.root.getPosition().distance(this.camera.entity.getPosition());
+        const cameraDist = this.root.getLocalPosition().distance(this.camera.entity.getPosition());
         const enabled = state ? this.nodes.length > 0 && cameraDist > DIST_EPSILON : false;
         if (enabled !== this.root.enabled) {
             this.root.enabled = enabled;
@@ -407,7 +407,7 @@ class Gizmo extends EventHandler {
      */
     get facingDir() {
         if (this._camera.projection === PROJECTION_PERSPECTIVE) {
-            const gizmoPos = this.root.getPosition();
+            const gizmoPos = this.root.getLocalPosition();
             const cameraPos = this._camera.entity.getPosition();
             return tmpV2.sub2(cameraPos, gizmoPos).normalize();
         }
@@ -420,7 +420,7 @@ class Gizmo extends EventHandler {
      */
     get cameraDir() {
         const cameraPos = this._camera.entity.getPosition();
-        const gizmoPos = this.root.getPosition();
+        const gizmoPos = this.root.getLocalPosition();
         return tmpV2.sub2(cameraPos, gizmoPos).normalize();
     }
 
@@ -522,7 +522,7 @@ class Gizmo extends EventHandler {
      */
     _updateScale() {
         if (this._camera.projection === PROJECTION_PERSPECTIVE) {
-            const gizmoPos = this.root.getPosition();
+            const gizmoPos = this.root.getLocalPosition();
             const cameraPos = this._camera.entity.getPosition();
             const dist = gizmoPos.distance(cameraPos);
             this._scale = Math.tan(0.5 * this._camera.fov * math.DEG_TO_RAD) * dist * PERS_SCALE_RATIO;

--- a/src/extras/gizmo/rotate-gizmo.js
+++ b/src/extras/gizmo/rotate-gizmo.js
@@ -507,8 +507,9 @@ class RotateGizmo extends TransformGizmo {
         const plane = this._createPlane(axis, axis === 'f', false);
 
         const point = new Vec3();
-
-        plane.intersectsRay(ray, point);
+        if (!plane.intersectsRay(ray, point)) {
+            point.copy(this.root.getLocalPosition());
+        }
 
         return point;
     }

--- a/src/extras/gizmo/rotate-gizmo.js
+++ b/src/extras/gizmo/rotate-gizmo.js
@@ -318,7 +318,7 @@ class RotateGizmo extends TransformGizmo {
      * @private
      */
     _storeGuidePoints() {
-        const gizmoPos = this.root.getPosition();
+        const gizmoPos = this.root.getLocalPosition();
         const axis = this._selectedAxis;
         const isFacing = axis === 'f';
         const scale = isFacing ? this.faceRingRadius : this.xyzRingRadius;
@@ -438,7 +438,7 @@ class RotateGizmo extends TransformGizmo {
      * @private
      */
     _storeNodeRotations() {
-        const gizmoPos = this.root.getPosition();
+        const gizmoPos = this.root.getLocalPosition();
         for (let i = 0; i < this.nodes.length; i++) {
             const node = this.nodes[i];
             this._nodeLocalRotations.set(node, node.getLocalRotation().clone());
@@ -453,7 +453,7 @@ class RotateGizmo extends TransformGizmo {
      * @private
      */
     _setNodeRotations(axis, angleDelta) {
-        const gizmoPos = this.root.getPosition();
+        const gizmoPos = this.root.getLocalPosition();
         const isFacing = axis === 'f';
 
         // calculate rotation from axis and angle
@@ -521,7 +521,7 @@ class RotateGizmo extends TransformGizmo {
      * @protected
      */
     _calculateAngle(point, x, y) {
-        const gizmoPos = this.root.getPosition();
+        const gizmoPos = this.root.getLocalPosition();
 
         const axis = this._selectedAxis;
 
@@ -572,7 +572,7 @@ class RotateGizmo extends TransformGizmo {
         this._shapesLookAtCamera();
 
         if (this._dragging) {
-            const gizmoPos = this.root.getPosition();
+            const gizmoPos = this.root.getLocalPosition();
             const color = this._theme.guideBase[this._selectedAxis];
             const startColor = tmpC1.copy(color);
             startColor.a *= 0.3;

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -544,8 +544,9 @@ class ScaleGizmo extends TransformGizmo {
         const plane = this._createPlane(axis, axis === 'xyz', !isPlane);
 
         const point = new Vec3();
-
-        plane.intersectsRay(ray, point);
+        if (!plane.intersectsRay(ray, point)) {
+            point.copy(this.root.getLocalPosition());
+        }
 
         // uniform scaling for XYZ axis
         if (axis === 'xyz') {

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -533,7 +533,7 @@ class ScaleGizmo extends TransformGizmo {
      * @protected
      */
     _screenToPoint(x, y) {
-        const gizmoPos = this.root.getPosition();
+        const gizmoPos = this.root.getLocalPosition();
         const mouseWPos = this._camera.screenToWorld(x, y, 1);
 
         const axis = this._selectedAxis;

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -250,7 +250,7 @@ class TransformGizmo extends Gizmo {
             this._selectedAxis = this._getAxis(meshInstance);
             this._selectedIsPlane =  this._getIsPlane(meshInstance);
 
-            this._rootStartPos.copy(this.root.getPosition());
+            this._rootStartPos.copy(this.root.getLocalPosition());
             this._rootStartRot.copy(this.root.getRotation());
             const point = this._screenToPoint(x, y);
             this._selectionStartPoint.copy(point);
@@ -806,7 +806,7 @@ class TransformGizmo extends Gizmo {
             return;
         }
 
-        const gizmoPos = this.root.getPosition();
+        const gizmoPos = this.root.getLocalPosition();
         const gizmoRot = this.root.getRotation();
         const activeAxis = this._hoverAxis || this._selectedAxis;
         const activeIsPlane = this._hoverIsPlane || this._selectedIsPlane;

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -644,7 +644,9 @@ class TransformGizmo extends Gizmo {
         const plane = this._createPlane(axis, isFacing, isLine);
 
         const point = new Vec3();
-        plane.intersectsRay(ray, point);
+        if (!plane.intersectsRay(ray, point)) {
+            point.copy(this.root.getLocalPosition());
+        }
 
         return point;
     }

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -540,7 +540,6 @@ class TranslateGizmo extends TransformGizmo {
         const plane = this._createPlane(axis, axis === 'xyz', !isPlane);
 
         const point = new Vec3();
-
         if (!plane.intersectsRay(ray, point)) {
             point.copy(this.root.getLocalPosition());
         }

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -541,7 +541,9 @@ class TranslateGizmo extends TransformGizmo {
 
         const point = new Vec3();
 
-        plane.intersectsRay(ray, point);
+        if (!plane.intersectsRay(ray, point)) {
+            point.copy(this.root.getLocalPosition());
+        }
 
         // rotate point back to world coords
         tmpQ1.copy(this._rootStartRot).invert().transformVector(point, point);


### PR DESCRIPTION
## Fixes
- Doesn't move gizmo if translated near to infinity (instead of snapping back to world origin)

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
