### PR TITLE
[Fix] ScreenComponent now copies screen.priority and scaleBlend properties

### DIFF
--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -100,6 +100,8 @@ class ScreenComponentSystem extends ComponentSystem {
             enabled: screen.enabled,
             screenSpace: screen.screenSpace,
             scaleMode: screen.scaleMode,
+            scaleBlend: screen.scaleBlend,
+            priority: screen.priority,
             resolution: screen.resolution.clone(),
             referenceResolution: screen.referenceResolution.clone()
         });


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/7926