### PR TITLE
[Fix] - Fix related to behavior change where texture array no longer needs manual upload

### DIFF
--- a/examples/assets/scripts/misc/hatch-material.mjs
+++ b/examples/assets/scripts/misc/hatch-material.mjs
@@ -28,7 +28,6 @@ const createHatchMaterial = (device, textures) => {
         addressV: ADDRESS_REPEAT,
         levels: [sources]
     });
-    hatchTexture.upload();
 
     // create a new material with a custom shader
     const material = new ShaderMaterial({

--- a/examples/src/examples/loaders/loaders-gl.example.mjs
+++ b/examples/src/examples/loaders/loaders-gl.example.mjs
@@ -46,7 +46,6 @@ app.on('destroy', () => {
  * @param {string} url - The url to load.
  */
 async function loadModel(url) {
-    console.log('loader.gl example url', url);
     // load the url using the draco format loader
     // @ts-ignore: cannot find CORE and DRACO
     const modelData = await CORE.load(url, DRACO.DracoLoader);

--- a/examples/src/examples/shaders/texture-array.example.mjs
+++ b/examples/src/examples/shaders/texture-array.example.mjs
@@ -124,7 +124,6 @@ assetListLoader.load(() => {
     };
 
     const textureArray = new pc.Texture(app.graphicsDevice, textureArrayOptions);
-    textureArray.upload();
 
     // generate mipmaps for visualization
     const mipmaps = generateMipmaps(textureArrayOptions.width, textureArrayOptions.height);

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -457,7 +457,7 @@ class WebglTexture {
 
         const requiredMipLevels = texture.numLevels;
 
-        if (texture.array) {
+        if (texture.array && !this._glCreated) {
             // for texture arrays we reserve the space in advance
             gl.texStorage3D(gl.TEXTURE_2D_ARRAY,
                 requiredMipLevels,
@@ -801,8 +801,8 @@ class WebglTexture {
 
         if (texture._needsUpload || texture._needsMipmapsUpload) {
 
+            // this uploads the texture as well
             device.setTexture(texture, 0);
-            this.upload(device, texture);
 
             texture._needsUpload = false;
             texture._needsMipmapsUpload = false;

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -237,12 +237,10 @@ class Morph extends RefCountedObject {
         // allocate texture arrays to store data from all morph targets
         if (texturesDataPositions.length > 0) {
             this.targetsTexturePositions = this._createTexture('MorphPositionsTexture', this._textureFormat, targets.length, [texturesDataPositions]);
-            this.targetsTexturePositions.upload();
         }
 
         if (texturesDataNormals.length > 0) {
             this.targetsTextureNormals = this._createTexture('MorphNormalsTexture', this._textureFormat, targets.length, [texturesDataNormals]);
-            this.targetsTextureNormals.upload();
         }
 
         // create vertex stream with vertex_id used to map vertex to texture


### PR DESCRIPTION
- texture with array type no longer needs manual upload, that was done in some earlier PR
- this PR handles the case where upload is called manually by not creating the texture again, only uploading data
- removed few instancing of manual call to upload to avoid the cost od double upload
- this fixes few examples triggering `GL_INVALID_OPERATION: glTexStorage3D: Texture is immutable.` error - those related to morphing mostly, and few others using texture arrays