### PR TITLE
[Fix] Picker on WebGPU no longer creates a resource inside its render pass

### DIFF
--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -37,6 +37,10 @@ class RenderPassPicker extends RenderPass {
         this.scene = scene;
         this.layers = layers;
         this.mapping = mapping;
+
+        if (scene.clusteredLightingEnabled) {
+            this.emptyWorldClusters = this.renderer.worldClustersAllocator.empty;
+        }
     }
 
     execute() {
@@ -89,7 +93,7 @@ class RenderPassPicker extends RenderPass {
                         // upload clustered lights uniforms
                         const clusteredLightingEnabled = scene.clusteredLightingEnabled;
                         if (clusteredLightingEnabled) {
-                            const lightClusters = renderer.worldClustersAllocator.empty;
+                            const lightClusters = this.emptyWorldClusters;
                             lightClusters.activate();
                         }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -954,6 +954,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
     endCommandEncoder() {
 
+        Debug.assert(!this.insideRenderPass, 'Attempted to finish GPUCommandEncoder while inside a pass. This will invalidate the current pass encoder and cause "Parent encoder is already finished" validation errors.');
+
         const { commandEncoder } = this;
         if (commandEncoder) {
 
@@ -974,6 +976,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     }
 
     submit() {
+
+        Debug.assert(!this.insideRenderPass, 'Attempted to submit command buffers while inside a pass. This finishes the parent command encoder and invalidates the active pass ("Parent encoder is already finished") .');
 
         // end the current encoder
         this.endCommandEncoder();


### PR DESCRIPTION
- the empty world clusters object (with texture inside) is created outside of the render pass, as when the texture is created inside render pass, the render pass gets invalidated
- added asserts to generically catch this situation as wel