### PR TITLE
Support .sog files generated with deflate

### DIFF
--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -125,7 +125,7 @@ class SogBundleParser {
             // deflate
             for (const file of files) {
                 if (file.compression === 'deflate') {
-                    file.data = await inflate(file.data);
+                    file.data = await inflate(file.data);   // eslint-disable-line no-await-in-loop
                 }
             }
 


### PR DESCRIPTION
## Description
Handle SOG files that are compressed with deflate. This is mostly supported as a convenience, as it's the default compression used by many tools.
