### PR TITLE
SOG fix on mobile

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatSogsColor.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatSogsColor.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-uniform mediump sampler2D packedSh0;
+uniform highp sampler2D packedSh0;
 
 uniform float sh0_mins;
 uniform float sh0_maxs;


### PR DESCRIPTION
## Description
Use highp for color sample since we're now packing r, g, b into 11,11,10 bits
