### PR TITLE
Fixes to SOGS data unloading

### DIFF
--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -623,10 +623,7 @@ class Asset extends EventHandler {
 
         // destroy resources
         for (let i = 0; i < old.length; ++i) {
-            const resource = old[i];
-            if (resource && resource.destroy) {
-                resource.destroy();
-            }
+            old[i]?.destroy?.();
         }
     }
 

--- a/src/framework/parsers/sogs.js
+++ b/src/framework/parsers/sogs.js
@@ -89,13 +89,12 @@ class SogsParser {
     maxRetries;
 
     /**
-     * Returns true if the load should silently bail (during shutdown or resource/device destroyed).
-     * @param {GSplatSogsData} data - The SOGS data object being prepared.
+     * Returns true if the load should silently bail during shutdown.
      * @returns {boolean} True if we should quietly stop without error/callback.
      */
-    _shouldSilentlyBail(data) {
+    _shouldSilentlyBail() {
         const gd = this.app?.graphicsDevice;
-        return !gd || gd._destroyed || data?.destroyed || !data?.means_l?.device;
+        return !gd || gd._destroyed;
     }
 
     /**
@@ -178,13 +177,13 @@ class SogsParser {
         const decompress = asset.data?.decompress;
 
         if (!decompress) {
-            if (this._shouldSilentlyBail(data)) return;
+            if (this._shouldSilentlyBail()) return;
 
             // no need to prepare gpu data if decompressing
             await data.prepareGpuData();
         }
 
-        if (this._shouldSilentlyBail(data)) return;
+        if (this._shouldSilentlyBail()) return;
 
         const resource = decompress ?
             new GSplatResource(this.app.graphicsDevice, await data.decompress()) :

--- a/src/framework/parsers/sogs.js
+++ b/src/framework/parsers/sogs.js
@@ -89,15 +89,6 @@ class SogsParser {
     maxRetries;
 
     /**
-     * Returns true if the load should silently bail during shutdown.
-     * @returns {boolean} True if we should quietly stop without error/callback.
-     */
-    _shouldSilentlyBail() {
-        const gd = this.app?.graphicsDevice;
-        return !gd || gd._destroyed;
-    }
-
-    /**
      * @param {AppBase} app - The app instance.
      * @param {number} maxRetries - Maximum amount of retries.
      */
@@ -177,13 +168,13 @@ class SogsParser {
         const decompress = asset.data?.decompress;
 
         if (!decompress) {
-            if (this._shouldSilentlyBail()) return;
+            if (!this.app?.graphicsDevice || this.app?.graphicsDevice?._destroyed) return;
 
             // no need to prepare gpu data if decompressing
             await data.prepareGpuData();
         }
 
-        if (this._shouldSilentlyBail()) return;
+        if (!this.app?.graphicsDevice || this.app?.graphicsDevice?._destroyed) return;
 
         const resource = decompress ?
             new GSplatResource(this.app.graphicsDevice, await data.decompress()) :

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -389,6 +389,12 @@ class GraphicsDevice extends EventHandler {
      */
     gpuProfiler;
 
+    /**
+     * @type {boolean}
+     * @ignore
+     */
+    _destroyed = false;
+
     defaultClearOptions = {
         color: [0, 0, 0, 1],
         depth: 1,
@@ -539,6 +545,8 @@ class GraphicsDevice extends EventHandler {
 
         this.gpuProfiler?.destroy();
         this.gpuProfiler = null;
+
+        this._destroyed = true;
     }
 
     onDestroyShader(shader) {

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2021,6 +2021,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         return new Promise((resolve, reject) => {
             this.readPixelsAsync(x, y, width, height, data).then((data) => {
 
+                // return if the device was destroyed
+                if (this._destroyed) return;
+
                 // destroy RT if we created it
                 if (!options.renderTarget) {
                     renderTarget.destroy();

--- a/src/scene/gsplat/gsplat-sogs-data.js
+++ b/src/scene/gsplat/gsplat-sogs-data.js
@@ -446,13 +446,13 @@ class GSplatSogsData {
         const { device, height, width } = this.means_l;
 
         // copy back means_l and means_u data so cpu reorder has access to it
-        if (this.destroyed && device._destroyed) return; // skip the rest if the resource was destroyed
+        if (this.destroyed || device._destroyed) return; // skip the rest if the resource was destroyed
         this.means_l._levels[0] = await readImageDataAsync(this.means_l);
 
-        if (this.destroyed && device._destroyed) return; // skip the rest if the resource was destroyed
+        if (this.destroyed || device._destroyed) return; // skip the rest if the resource was destroyed
         this.means_u._levels[0] = await readImageDataAsync(this.means_u);
 
-        if (this.destroyed && device._destroyed) return; // skip the rest if the resource was destroyed
+        if (this.destroyed || device._destroyed) return; // skip the rest if the resource was destroyed
         this.packedTexture = new Texture(device, {
             name: 'sogsPackedTexture',
             width,
@@ -484,10 +484,10 @@ class GSplatSogsData {
             }
         });
 
-        if (this.destroyed && device._destroyed) return; // skip the rest if the resource was destroyed
+        if (this.destroyed || device._destroyed) return; // skip the rest if the resource was destroyed
         this.packGpuMemory();
         if (this.packedShN) {
-            if (this.destroyed && device._destroyed) return; // skip the rest if the resource was destroyed
+            if (this.destroyed || device._destroyed) return; // skip the rest if the resource was destroyed
             this.packShMemory();
         }
     }


### PR DESCRIPTION
- handle case when SOGS resource is waiting for async GPU processing and gets destroyed - skip early from unfinished processing, don't create resource when device / textures were destroyed
- while still GPU processing, postpone deletion of objects to avoid crashes, and destroy at the end
- when SOGS resource unloads, unload texture resources it created
- similarly, when the device is destroyed, cleanly handle async texture download