### PR TITLE
Public API to control unified gsplat behavior

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod.controls.mjs
@@ -1,0 +1,44 @@
+/**
+ * @param {import('../../app/components/Example.mjs').ControlOptions} options - The options.
+ * @returns {JSX.Element} The returned JSX Element.
+ */
+export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
+    const { BindingTwoWay, LabelGroup, BooleanInput, SliderInput } = ReactPCUI;
+    if (!observer.get('lod')) {
+        observer.set('lod', { distance: 5 });
+    }
+    return fragment(
+        jsx(
+            LabelGroup,
+            { text: 'Debug AABBs' },
+            jsx(BooleanInput, {
+                type: 'toggle',
+                binding: new BindingTwoWay(),
+                link: { observer, path: 'debugAabbs' },
+                value: observer.get('debugAabbs')
+            })
+        ),
+        jsx(
+            LabelGroup,
+            { text: 'Debug LOD' },
+            jsx(BooleanInput, {
+                type: 'toggle',
+                binding: new BindingTwoWay(),
+                link: { observer, path: 'debugLod' },
+                value: observer.get('debugLod')
+            })
+        ),
+        jsx(
+            LabelGroup,
+            { text: 'Distance' },
+            jsx(SliderInput, {
+                precision: 1,
+                min: 3,
+                max: 20,
+                step: 0.1,
+                binding: new BindingTwoWay(),
+                link: { observer, path: 'lod.distance' }
+            })
+        )
+    );
+};

--- a/examples/src/examples/gaussian-splatting/lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod.example.mjs
@@ -1,6 +1,6 @@
 // @config HIDDEN
-import { deviceType, rootPath, fileImport } from 'examples/utils';
 import { data } from 'examples/observer';
+import { deviceType, rootPath, fileImport } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const { CameraControls } = await fileImport(`${rootPath}/static/scripts/esm/camera-controls.mjs`);

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -73,6 +73,14 @@ class GSplatComponent extends Component {
     _highQualitySH = true;
 
     /**
+     * LOD distance thresholds, stored as a copy.
+     *
+     * @type {number[]|null}
+     * @private
+     */
+    _lodDistances = [5, 10, 15, 20, 25];
+
+    /**
      * @type {BoundingBox|null}
      * @private
      */
@@ -311,6 +319,28 @@ class GSplatComponent extends Component {
      */
     get castShadows() {
         return this._castShadows;
+    }
+
+    /**
+     * Sets LOD distance thresholds used by octree-based gsplat rendering. The provided array
+     * is copied.
+     *
+     * @type {number[]|null}
+     */
+    set lodDistances(value) {
+        this._lodDistances = Array.isArray(value) ? value.slice() : null;
+        if (this._placement) {
+            this._placement.lodDistances = this._lodDistances;
+        }
+    }
+
+    /**
+     * Gets a copy of LOD distance thresholds previously set, or null when not set.
+     *
+     * @type {number[]|null}
+     */
+    get lodDistances() {
+        return this._lodDistances ? this._lodDistances.slice() : null;
     }
 
     /**
@@ -590,6 +620,7 @@ class GSplatComponent extends Component {
 
             if (asset) {
                 this._placement = new GSplatPlacement(asset.resource, this.entity);
+                this._placement.lodDistances = this._lodDistances;
             }
 
         } else {

--- a/src/scene/gsplat-unified/gsplat-director.js
+++ b/src/scene/gsplat-unified/gsplat-director.js
@@ -191,7 +191,7 @@ class GSplatDirector {
             // update gsplat managers
             // const cameraData = this.camerasMap.get(camera);
             cameraData?.layersMap.forEach((layerData) => {
-                layerData.gsplatManager.update(this.scene);
+                layerData.gsplatManager.update();
             });
         }
 

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -1,0 +1,30 @@
+/**
+ * Parameters for GSplat unified system.
+ *
+ * @category Graphics
+ */
+class GSplatParams {
+    /**
+     * Enables debug rendering of AABBs for GSplat objects. Defaults to false.
+     *
+     * @type {boolean}
+     */
+    debugAabbs = false;
+
+    /**
+     * Enables colorization by selected LOD level when rendering GSplat objects. Defaults to false.
+     *
+     * @type {boolean}
+     */
+    colorizeLod = false;
+
+    /**
+     * Distance threshold in world units to trigger LOD updates for camera and gsplat instances.
+     * Defaults to 1.
+     *
+     * @type {number}
+     */
+    lodUpdateThreshold = 1;
+}
+
+export { GSplatParams };

--- a/src/scene/gsplat-unified/gsplat-placement.js
+++ b/src/scene/gsplat-unified/gsplat-placement.js
@@ -1,4 +1,5 @@
 import { BoundingBox } from '../../core/shape/bounding-box.js';
+import { Debug } from '../../core/debug.js';
 
 /**
  * @import { GraphNode } from '../graph-node.js'
@@ -43,6 +44,14 @@ class GSplatPlacement {
     lodIndex = 0;
 
     /**
+     * LOD distance thresholds for octree-based gsplat. Only used when the
+     * resource is an octree resource; otherwise ignored and kept null.
+     *
+     * @type {number[]|null}
+     */
+    _lodDistances = null;
+
+    /**
      * The axis-aligned bounding box for this placement, in local space.
      *
      * @type {BoundingBox}
@@ -68,6 +77,38 @@ class GSplatPlacement {
 
     get aabb() {
         return this._aabb;
+    }
+
+    /**
+     * Sets LOD distance thresholds. Only applicable for octree resources. The provided array is
+     * copied. If the resource has an octree with N LOD levels, the array should contain N-1
+     * elements. For non-octree resources, the value is ignored and kept null.
+     *
+     * @type {number[]|null}
+     */
+    set lodDistances(distances) {
+        const isOctree = !!(this.resource && /** @type {any} */ (this.resource).octree);
+        if (isOctree) {
+            if (distances) {
+                const lodLevels = /** @type {any} */ (this.resource).octree?.lodLevels ?? 1;
+                Debug.assert(Array.isArray(distances), 'lodDistances must be an array');
+                Debug.assert(distances.length >= lodLevels, 'lodDistances must have at least octree LOD levels - 1 entries, privided:',
+                    distances.length, 'expected:', lodLevels);
+
+                this._lodDistances = distances.slice();
+            } else {
+                this._lodDistances = null;
+            }
+        }
+    }
+
+    /**
+     * Gets a copy of LOD distance thresholds, or null when not set.
+     *
+     * @type {number[]|null}
+     */
+    get lodDistances() {
+        return this._lodDistances ? this._lodDistances.slice() : null;
     }
 }
 

--- a/src/scene/gsplat-unified/gsplat-work-buffer.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer.js
@@ -120,10 +120,12 @@ class GSplatWorkBuffer {
      *
      * @param {GSplatInfo[]} splats - The splats to render.
      * @param {GraphNode} cameraNode - The camera node.
+     * @param {number[][]|undefined} colorsByLod - Array of RGB colors per LOD. Index by lodIndex; if a
+     * shorter array is provided, index 0 will be reused as fallback.
      */
-    render(splats, cameraNode) {
+    render(splats, cameraNode, colorsByLod) {
         // render splats using render pass
-        if (this.renderPass.update(splats, cameraNode)) {
+        if (this.renderPass.update(splats, cameraNode, colorsByLod)) {
             this.renderPass.render();
         }
     }

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -119,15 +119,13 @@ class GSplatResourceBase {
      * Get or create a QuadRender for rendering to work buffer.
      *
      * @param {boolean} useIntervals - Whether to use intervals.
-     * @param {boolean} colorizeLod - Whether to colorize the LOD.
      * @returns {WorkBufferRenderInfo} The WorkBufferRenderInfo instance.
      */
-    getWorkBufferRenderInfo(useIntervals, colorizeLod) {
+    getWorkBufferRenderInfo(useIntervals) {
 
         // configure defines to fetch cached data
         this.configureMaterialDefines(tempMap);
         if (useIntervals) tempMap.set('GSPLAT_LOD', '');
-        if (colorizeLod) tempMap.set('GSPLAT_COLORIZE', '');
         const key = Array.from(tempMap.entries()).map(([k, v]) => `${k}=${v}`).join(';');
 
         // get or create quad render

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -9,6 +9,7 @@ import { Mat4 } from '../core/math/mat4.js';
 import { PIXELFORMAT_RGBA8, ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR } from '../platform/graphics/constants.js';
 import { BAKE_COLORDIR, LAYERID_IMMEDIATE } from './constants.js';
 import { LightingParams } from './lighting/lighting-params.js';
+import { GSplatParams } from './gsplat-unified/gsplat-params.js';
 import { Sky } from './skybox/sky.js';
 import { Immediate } from './immediate/immediate.js';
 import { EnvLighting } from './graphics/env-lighting.js';
@@ -337,6 +338,9 @@ class Scene extends EventHandler {
             this.updateShaders = true;
         });
 
+        // gsplat params
+        this._gsplatParams = new GSplatParams();
+
         // skybox
         this._sky = new Sky(this);
 
@@ -518,6 +522,15 @@ class Scene extends EventHandler {
      */
     get lighting() {
         return this._lightingParams;
+    }
+
+    /**
+     * Gets the GSplat parameters.
+     *
+     * @type {GSplatParams}
+     */
+    get gsplat() {
+        return this._gsplatParams;
     }
 
     /**

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
@@ -19,9 +19,7 @@ uniform int uViewportWidth;  // Width of the destination viewport in pixels
     uniform usampler2D uIntervalsTexture;
 #endif
 
-#ifdef GSPLAT_COLORIZE
-    uniform vec3 uLodColor;
-#endif
+uniform vec3 uColorMultiply;
 
 // number of splats
 uniform int uActiveSplats;
@@ -100,9 +98,7 @@ void main(void) {
             color.xyz += evalSH(sh, dir) * scale;
         #endif
 
-        #ifdef GSPLAT_COLORIZE
-            color.xyz *= uLodColor;
-        #endif
+        color.xyz *= uColorMultiply;
 
         // write out results
         pcFragColor0 = color;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
@@ -19,9 +19,7 @@ uniform uViewportWidth: i32;  // Width of the destination viewport in pixels
     var uIntervalsTexture: texture_2d<u32>;
 #endif
 
-#ifdef GSPLAT_COLORIZE
-    uniform uLodColor: vec3f;
-#endif
+uniform uColorMultiply: vec3f;
 
 // number of splats
 uniform uActiveSplats: i32;
@@ -106,9 +104,7 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
             color = vec4f(color.xyz + evalSH(&sh, dir) * scale, color.w);
         #endif
 
-        #ifdef GSPLAT_COLORIZE
-            color = vec4f(color.xyz * uniform.uLodColor, color.w);
-        #endif
+        color = vec4f(color.xyz * uniform.uColorMultiply, color.w);
 
         // write out results
         output.color = color;


### PR DESCRIPTION
New API to control various aspects of unified gsplat rendering.
Note that these are the initially exposed parameters, there will be additional ones added as we go.

1.
```
Scene.gsplat - a getter for an instance of global parameters.
```

See the details here:
<img width="665" height="443" alt="Screenshot 2025-09-09 at 15 03 40" src="https://github.com/user-attachments/assets/5da9b7ca-6473-41c9-ae72-528212b92062" />

2.
```
GSplatComponent.lodDistances
```
<img width="660" height="300" alt="Screenshot 2025-09-09 at 15 07 18" src="https://github.com/user-attachments/assets/d57ecaac-49b9-4f6f-8bc4-557056abaf7c" />
