### PR TITLE
Support for progressive LOD loading for unified splats

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-instances.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-instances.example.mjs
@@ -164,8 +164,8 @@ assetListLoader.load(() => {
     const cc = /** @type { CameraControls} */ (camera.script.create(CameraControls));
     Object.assign(cc, {
         sceneSize: 500,
-        moveSpeed: 0.003,
-        moveFastSpeed: 0.01,
+        moveSpeed: 1.5,
+        moveFastSpeed: 5,
         enableOrbit: false,
         enablePan: false,
         focusPoint: new pc.Vec3(2, 0.6, 0)

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -78,6 +78,21 @@ class GSplatOctreeInstance {
     previousPosition = new Vec3();
 
     /**
+     * Set when a resource has completed loading and LOD should be re-evaluated.
+     *
+     * @type {boolean}
+     */
+    needsLodUpdate = false;
+
+    /**
+     * Tracks prefetched file indices that are being loaded without active placements.
+     * When any completes, we trigger LOD re-evaluation to allow promotion.
+     *
+     * @type {Set<number>}
+     */
+    prefetchPending = new Set();
+
+    /**
      * @param {GSplatOctree} octree - The octree.
      * @param {GSplatPlacement} placement - The placement.
      * @param {GSplatAssetLoaderBase} assetLoader - The asset loader.
@@ -166,6 +181,79 @@ class GSplatOctreeInstance {
     }
 
     /**
+     * Selects desired LOD index for a node using the underfill strategy. When underfill is enabled,
+     * it prefers already-loaded LODs within [optimalLodIndex .. optimalLodIndex + lodUnderfillLimit].
+     * If none are loaded, it selects the coarsest available LOD within the range.
+     *
+     * @param {import('./gsplat-octree-node.js').GSplatOctreeNode} node - The octree node.
+     * @param {number} optimalLodIndex - Optimal LOD index based on camera/distance.
+     * @param {number} maxLod - Maximum LOD index.
+     * @param {number} lodUnderfillLimit - Allowed coarse range above optimal.
+     * @returns {number} Desired LOD index to display.
+     */
+    selectDesiredLodIndex(node, optimalLodIndex, maxLod, lodUnderfillLimit) {
+        if (lodUnderfillLimit > 0) {
+            const allowedMaxCoarseLod = Math.min(maxLod, optimalLodIndex + lodUnderfillLimit);
+
+            // prefer highest quality already-loaded within the allowed range
+            for (let lod = optimalLodIndex; lod <= allowedMaxCoarseLod; lod++) {
+                const fi = node.lods[lod].fileIndex;
+                if (fi !== -1 && this.octree.getFileResource(fi)) {
+                    return lod;
+                }
+            }
+
+            // fallback: choose the coarsest available within the range
+            for (let lod = allowedMaxCoarseLod; lod >= optimalLodIndex; lod--) {
+                const fi = node.lods[lod].fileIndex;
+                if (fi !== -1) {
+                    return lod;
+                }
+            }
+        }
+
+        return optimalLodIndex;
+    }
+
+    /**
+     * Prefetch only the next-better LOD toward optimal. This stages loading in steps across all
+     * nodes, avoiding intermixing requests before coarse is present.
+     *
+     * @param {import('./gsplat-octree-node.js').GSplatOctreeNode} node - The octree node.
+     * @param {number} desiredLodIndex - Currently selected LOD for display (may be coarser than optimal).
+     * @param {number} optimalLodIndex - Target optimal LOD.
+     */
+    prefetchNextLod(node, desiredLodIndex, optimalLodIndex) {
+        if (desiredLodIndex === -1 || optimalLodIndex === -1) return;
+
+        // If we're already at optimal but it's not loaded yet, request it
+        if (desiredLodIndex === optimalLodIndex) {
+            const fi = node.lods[optimalLodIndex].fileIndex;
+            if (fi !== -1) {
+                this.octree.ensureFileResource(fi, this.assetLoader);
+                if (!this.octree.getFileResource(fi)) {
+                    this.prefetchPending.add(fi);
+                }
+            }
+            return;
+        }
+
+        // Step one level finer toward optimal
+        const targetLod = Math.max(optimalLodIndex, desiredLodIndex - 1);
+        // Find first valid fileIndex between targetLod..optimalLodIndex
+        for (let lod = targetLod; lod >= optimalLodIndex; lod--) {
+            const fi = node.lods[lod].fileIndex;
+            if (fi !== -1) {
+                this.octree.ensureFileResource(fi, this.assetLoader);
+                if (!this.octree.getFileResource(fi)) {
+                    this.prefetchPending.add(fi);
+                }
+                break;
+            }
+        }
+    }
+
+    /**
      * Updates the octree instance when LOD needs to be updated.
      *
      * @param {GraphNode} cameraNode - The camera node.
@@ -186,7 +274,8 @@ class GSplatOctreeInstance {
         const lodDistances = this.placement.lodDistances || [5, 10, 15, 20, 25];
 
         // parameters
-        const { lodBehindPenalty, lodRangeMin, lodRangeMax } = params;
+        const { lodBehindPenalty, lodRangeMin, lodRangeMax, lodUnderfillLimit = 0 } = params;
+
 
         // process all nodes
         const nodes = this.octree.nodes;
@@ -194,28 +283,32 @@ class GSplatOctreeInstance {
             const node = nodes[nodeIndex];
 
             // LOD for the node, clamped by configured range
-            let newLodIndex = this.calculateNodeLod(localCameraPosition, localCameraForward, nodeIndex, maxLod, lodDistances, lodBehindPenalty);
-            if (newLodIndex < lodRangeMin) newLodIndex = lodRangeMin;
-            if (newLodIndex > lodRangeMax) newLodIndex = lodRangeMax;
+            // optimal target LOD based on distance and range
+            let optimalLodIndex = this.calculateNodeLod(localCameraPosition, localCameraForward, nodeIndex, maxLod, lodDistances, lodBehindPenalty);
+            if (optimalLodIndex < lodRangeMin) optimalLodIndex = lodRangeMin;
+            if (optimalLodIndex > lodRangeMax) optimalLodIndex = lodRangeMax;
             const currentLodIndex = this.nodeLods[nodeIndex];
 
-            // if LOD changed
-            if (newLodIndex !== currentLodIndex) {
+            // Determine desired display LOD using underfill strategy within allowed range
+            const desiredLodIndex = this.selectDesiredLodIndex(node, optimalLodIndex, maxLod, lodUnderfillLimit);
 
-                // update the stored LOD index
-                this.nodeLods[nodeIndex] = newLodIndex;
+            // if LOD to display changed
+            if (desiredLodIndex !== currentLodIndex) {
+
+                // update the stored displayed LOD index
+                this.nodeLods[nodeIndex] = desiredLodIndex;
 
                 // Determine visibility based on the presence of a valid file index
                 const currentFileIndex = currentLodIndex >= 0 ? node.lods[currentLodIndex].fileIndex : -1;
-                const newFileIndex = newLodIndex >= 0 ? node.lods[newLodIndex].fileIndex : -1;
+                const desiredFileIndex = desiredLodIndex >= 0 ? node.lods[desiredLodIndex].fileIndex : -1;
                 const wasVisible = currentFileIndex !== -1;
-                const willBeVisible = newFileIndex !== -1;
+                const willBeVisible = desiredFileIndex !== -1;
 
                 // if there's a pending transition, manage it without dropping the currently visible LOD
                 const pendingEntry = this.pendingDecrements.get(nodeIndex);
                 if (pendingEntry) {
                     // if desired target changed while previous target was still loading, cancel previous target for this node
-                    if (pendingEntry.newFileIndex !== newFileIndex) {
+                    if (pendingEntry.newFileIndex !== desiredFileIndex) {
                         // remove this node's interval from the previously pending target if it still exists
                         const prevPendingPlacement = this.filePlacements[pendingEntry.newFileIndex];
                         if (prevPendingPlacement) {
@@ -224,7 +317,7 @@ class GSplatOctreeInstance {
 
                         // update or clear pending transition
                         if (wasVisible && willBeVisible) {
-                            this.pendingDecrements.set(nodeIndex, { oldFileIndex: pendingEntry.oldFileIndex, newFileIndex });
+                            this.pendingDecrements.set(nodeIndex, { oldFileIndex: pendingEntry.oldFileIndex, newFileIndex: desiredFileIndex });
                         } else {
                             // no longer targeting a visible LOD; clear pending and let normal logic handle hide/show
                             this.pendingDecrements.delete(nodeIndex);
@@ -236,7 +329,7 @@ class GSplatOctreeInstance {
                 if (!wasVisible && willBeVisible) {
 
                     // becoming visible (invisible -> visible)
-                    this.incrementFileRef(newFileIndex, nodeIndex, newLodIndex);
+                    this.incrementFileRef(desiredFileIndex, nodeIndex, desiredLodIndex);
 
                 } else if (wasVisible && !willBeVisible) {
 
@@ -252,9 +345,9 @@ class GSplatOctreeInstance {
                 } else if (wasVisible && willBeVisible) {
 
                     // switching between visible LODs (visible -> visible)
-                    this.incrementFileRef(newFileIndex, nodeIndex, newLodIndex);
+                    this.incrementFileRef(desiredFileIndex, nodeIndex, desiredLodIndex);
 
-                    const newPlacement = this.filePlacements[newFileIndex];
+                    const newPlacement = this.filePlacements[desiredFileIndex];
                     if (newPlacement?.resource) {
                         // new LOD ready - remove old LOD immediately
                         this.decrementFileRef(currentFileIndex, nodeIndex);
@@ -262,10 +355,13 @@ class GSplatOctreeInstance {
                         this.pendingDecrements.delete(nodeIndex);
                     } else {
                         // new LOD not ready - track pending decrement for when it loads
-                        this.pendingDecrements.set(nodeIndex, { oldFileIndex: currentFileIndex, newFileIndex });
+                        this.pendingDecrements.set(nodeIndex, { oldFileIndex: currentFileIndex, newFileIndex: desiredFileIndex });
                     }
                 }
             }
+
+            // Prefetch loading: request only the next-better LOD toward optimal
+            this.prefetchNextLod(node, desiredLodIndex, optimalLodIndex);
         }
     }
 
@@ -425,6 +521,11 @@ class GSplatOctreeInstance {
                 }
             }
 
+            // mark LOD update if any resource completed
+            if (_tempCompletedUrls.length > 0) {
+                this.needsLodUpdate = true;
+            }
+
             // remove completed items from pending
             for (const fileIndex of _tempCompletedUrls) {
                 this.pending.delete(fileIndex);
@@ -434,10 +535,50 @@ class GSplatOctreeInstance {
             _tempCompletedUrls.length = 0;
         }
 
+        // watch prefetched loads for completion to allow promotion
+        this.pollPrefetchCompletions();
+
         // check if any placements need LOD update
         const dirty = this.dirtyModifiedPlacements;
         this.dirtyModifiedPlacements = false;
         return dirty;
+    }
+
+    /**
+     * Returns true if this instance requests LOD re-evaluation and resets the flag.
+     * @returns {boolean} True if LOD should be re-evaluated.
+     */
+    consumeNeedsLodUpdate() {
+        const v = this.needsLodUpdate;
+        this.needsLodUpdate = false;
+        return v;
+    }
+
+    /**
+     * Polls prefetched file indices for completion and updates state.
+     */
+    pollPrefetchCompletions() {
+
+        if (this.prefetchPending.size) {
+
+            // poll loader and store resource in octree if ready
+            for (const fileIndex of this.prefetchPending) {
+                this.octree.ensureFileResource(fileIndex, this.assetLoader);
+                if (this.octree.getFileResource(fileIndex)) {
+                    _tempCompletedUrls.push(fileIndex);
+                }
+            }
+
+            // remove completed from prefetchPending
+            if (_tempCompletedUrls.length > 0) {
+                this.needsLodUpdate = true;
+            }
+
+            for (const fileIndex of _tempCompletedUrls) {
+                this.prefetchPending.delete(fileIndex);
+            }
+            _tempCompletedUrls.length = 0;
+        }
     }
 }
 

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -148,6 +148,36 @@ class GSplatParams {
     get lodRangeMax() {
         return this._lodRangeMax;
     }
+
+    /**
+     * @type {number}
+     * @private
+     */
+    _lodUnderfillLimit = 0;
+
+    /**
+     * Maximum number of LOD levels allowed below the optimal level when the optimal data is not
+     * resident in memory. The system may temporarily use a coarser LOD within this limit until the
+     * optimal LOD is available. Defaults to 0, which disables fallback (always load optimal).
+     * Higher values allow faster loading by using lower-quality data.
+     *
+     * @type {number}
+     */
+    set lodUnderfillLimit(value) {
+        if (this._lodUnderfillLimit !== value) {
+            this._lodUnderfillLimit = value;
+            this.dirty = true;
+        }
+    }
+
+    /**
+     * Gets the maximum allowed underfill LOD range.
+     *
+     * @type {number}
+     */
+    get lodUnderfillLimit() {
+        return this._lodUnderfillLimit;
+    }
 }
 
 export { GSplatParams };


### PR DESCRIPTION
- instead of directly loading the required LOD level, we can load a lower quality first and progress to the required level, to speed up the getting to the rendered image

public API to control this:
<img width="668" height="176" alt="Screenshot 2025-09-16 at 09 32 30" src="https://github.com/user-attachments/assets/c0a57329-b5e6-4db9-a25e-73ddac7b4b79" />
