### PR TITLE
Fix for bundled SOG loading

### DIFF
--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -157,7 +157,7 @@ class SogBundleParser {
                 if (file) {
                     // file is embedded
                     texture = new Asset(filename, 'texture', {
-                        url: filename,
+                        url: `${url.load}/${filename}`,
                         filename,
                         contents: file.data
                     }, {


### PR DESCRIPTION
## Description
Bundled SOGs were being loaded using the same URL for all embedded textures, resulting a cache hits in the asset system for all textures.

This PR makes the names unique using the original URL and filename.

