### PR TITLE
Gizmo angle guide fix

### DIFF
--- a/src/extras/gizmo/rotate-gizmo.js
+++ b/src/extras/gizmo/rotate-gizmo.js
@@ -670,7 +670,8 @@ class RotateGizmo extends TransformGizmo {
         const ray = this._createRay(mouseWPos);
         const plane = this._createPlane(axis, axis === 'f' || axis === 'xyz', false);
         if (!plane.intersectsRay(ray, point)) {
-            return point;
+            // use gizmo position if ray does not intersect to position angle guide correctly
+            return point.copy(this.root.getLocalPosition());
         }
 
         return point;


### PR DESCRIPTION
## Description
- Snap screenPoint to gizmo position when intersection fails for rotation gizmo to fix angle guide position 

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
