### PR TITLE
(fix) Debug.assert raising react error

### DIFF
--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -355,15 +355,11 @@ class CameraFrame {
     }
 
     enable() {
-        Debug.assert(!this.renderPassCamera);
-
         this.renderPassCamera = this.createRenderPass();
         this.cameraComponent.renderPasses = [this.renderPassCamera];
     }
 
     disable() {
-        Debug.assert(this.renderPassCamera);
-
         const cameraComponent = this.cameraComponent;
         cameraComponent.renderPasses?.forEach((renderPass) => {
             renderPass.destroy();


### PR DESCRIPTION
During @playcanvas/react rendering the camera-frame.js is disable is called `component.destroy()` before the script instance being destroyed itself. This was causing the `Debug.assert()` to raise a console error incorrectly, which looked like a user error. This PR removes the redundant assert.
