### PR TITLE
Add custom feedback varyings for WebGL Shader with useTransformFeedback

### DIFF
--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -63,6 +63,9 @@ class Shader {
      * vertex shader attribute names to semantics SEMANTIC_*. This enables the engine to match
      * vertex buffer data as inputs to the shader. When not specified, rendering without vertex
      * buffer is assumed.
+     * @param {string[]} [definition.outVaryings] - A list of shader output variable
+     * names that will be captured when using transform feedback. This setting is only effective
+     * if the {@link definition.useTransformFeedback} property is enabled.
      * @param {string} [definition.vshader] - Vertex shader source (GLSL code). Optional when
      * compute shader is specified.
      * @param {string} [definition.fshader] - Fragment shader source (GLSL code). Optional when

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -63,7 +63,7 @@ class Shader {
      * vertex shader attribute names to semantics SEMANTIC_*. This enables the engine to match
      * vertex buffer data as inputs to the shader. When not specified, rendering without vertex
      * buffer is assumed.
-     * @param {string[]} [definition.outVaryings] - A list of shader output variable
+     * @param {string[]} [definition.feedbackVaryings] - A list of shader output variable
      * names that will be captured when using transform feedback. This setting is only effective
      * if the {@link definition.useTransformFeedback} property is enabled.
      * @param {string} [definition.vshader] - Vertex shader source (GLSL code). Optional when

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -150,13 +150,21 @@ class WebglShader {
         const definition = shader.definition;
         const attrs = definition.attributes;
         if (definition.useTransformFeedback) {
-            // Collect all "out_" attributes and use them for output
-            const outNames = [];
-            for (const attr in attrs) {
-                if (attrs.hasOwnProperty(attr)) {
-                    outNames.push(`out_${attr}`);
+
+            let outNames = definition.outVaryings;
+            
+            if (!outNames) {
+
+                outNames = [];
+
+                // Collect all "out_" attributes and use them for output
+                for (const attr in attrs) {
+                    if (attrs.hasOwnProperty(attr)) {
+                        outNames.push(`out_${attr}`);
+                    }
                 }
             }
+
             gl.transformFeedbackVaryings(glProgram, outNames, gl.INTERLEAVED_ATTRIBS);
         }
 

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -151,8 +151,8 @@ class WebglShader {
         const attrs = definition.attributes;
         if (definition.useTransformFeedback) {
 
-            let outNames = definition.outVaryings;
-            
+            let outNames = definition.feedbackVaryings;
+
             if (!outNames) {
 
                 outNames = [];


### PR DESCRIPTION
## Add custom feedback varyings
This PR introduces support for passing a list of output varyings for use with transform feedback in WebglShader

Ensured compatibility with the existing shader compilation flow — if varyings are not specified, the behavior remains unchanged.