### PR TITLE
fix(template-asset): invalidate cached _previewRoot upon receiving new data

### DIFF
--- a/src/framework/handlers/template.js
+++ b/src/framework/handlers/template.js
@@ -52,6 +52,18 @@ class TemplateHandler extends ResourceHandler {
         this.decoder ??= new TextDecoder('utf-8');
         return new Template(this._app, JSON.parse(this.decoder.decode(data)));
     }
+
+    patch(asset, registry) {
+        // only process if this looks like valid template data
+        if (!asset || !asset.resource || !asset.data || !asset.data.entities) {
+            return;
+        }
+
+        const template = asset.resource;
+
+        // the `data` setter will handle cache invalidation
+        template.data = asset.data;
+    }
 }
 
 export { TemplateHandler };

--- a/src/framework/template.js
+++ b/src/framework/template.js
@@ -54,6 +54,16 @@ class Template {
 
         this._templateRoot = parser.parse(this._data);
     }
+
+    set data(value) {
+        this._data = value;
+        // cache invalidation: the next instantiate() will parse and use the new _data
+        this._templateRoot = null;
+    }
+
+    get data() {
+        return this._data;
+    }
 }
 
 export { Template };

--- a/test/framework/handlers/template-handler.test.mjs
+++ b/test/framework/handlers/template-handler.test.mjs
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+
+import { Asset } from '../../../src/framework/asset/asset.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+// Example template data in the database
+function createFakeTemplateData(name) {
+    const rootId = 'root-guid';
+    return {
+        entities: {
+            [rootId]: {
+                name,
+                resource_id: rootId,
+                parent: null,
+                children: [],
+                position: [0, 0, 0],
+                rotation: [0, 0, 0],
+                scale: [1, 1, 1],
+                components: {}
+            }
+        }
+    };
+}
+
+describe('TemplateHandler', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+
+    it('should reparse the new template data', function (done) {
+        // For this test case we pretend the data is already loaded
+        const file = null;
+
+        const data1 = createFakeTemplateData('root1');
+        const data2 = createFakeTemplateData('root2');
+
+        const templateAsset = new Asset('Template B', 'template', file, data1);
+
+        app.assets.add(templateAsset);
+        app.assets.load(templateAsset);
+
+        templateAsset.ready(function (asset) {
+            const first = asset.resource.instantiate();
+            expect(first.name).to.equal('root1');
+
+            // change asset data: should trigger handler.patch and resource invalidation
+            asset.data = data2;
+
+            expect(asset.resource.data).to.equal(asset.data);
+
+            const second = asset.resource.instantiate();
+            expect(second.name).to.equal('root2');
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Description

Fixes #8002 

* In the `TemplateResourceHandler`, we had no corresponding `patch` function that would make sure that the assets `Template` gets updated based on the new raw `data`.


## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
