### PR TITLE
Avoid gl_DrawID related warning during shader setup

### DIFF
--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -339,6 +339,11 @@ class WebglShader {
             const info = gl.getActiveUniform(glProgram, i);
             const location = gl.getUniformLocation(glProgram, info.name);
 
+            // a built-in variables reported as uniforms for which we do not need to provide any data
+            if (_vertexShaderBuiltins.has(info.name)) {
+                continue;
+            }
+
             const shaderInput = new WebglShaderInput(device, info.name, device.pcUniformType[info.type], location);
 
             if (samplerTypes.has(info.type)) {


### PR DESCRIPTION
Related to https://github.com/playcanvas/engine/pull/8007

When gl_DrawID is used in a shader, WebGL reports it as a uniform - ignore it, as its not a uniform. This avoids this warning:
```
Shader [Shader Id 0 (GLSL) StandardShader-forward-proc] requires uniform [gl_DrawID] which has not
been set, while rendering [Pass:RenderPassForward RT:WebglFramebuffer | Camera: Untitled, Layer:
World(OPAQUE) | Node: MultiDrawEntity, Material: Untitled]
```