### PR TITLE
Expose CameraComponent.depthValue and fix issue when that is zero

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -461,6 +461,24 @@ class CameraComponent extends Component {
     }
 
     /**
+     * Sets the depth value to clear the depth buffer to. Defaults to 1.
+     *
+     * @type {number}
+     */
+    set clearDepth(value) {
+        this._camera.clearDepth = value;
+    }
+
+    /**
+     * Gets the depth value to clear the depth buffer to.
+     *
+     * @type {number}
+     */
+    get clearDepth() {
+        return this._camera.clearDepth;
+    }
+
+    /**
      * Sets whether the camera will automatically clear the depth buffer before rendering. Defaults to true.
      *
      * @type {boolean}

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -54,6 +54,7 @@ class CameraComponentSystem extends ComponentSystem {
             'calculateTransform',
             'clearColor',
             'clearColorBuffer',
+            'clearDepth',
             'clearDepthBuffer',
             'clearStencilBuffer',
             'renderSceneColorMap',

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -415,7 +415,7 @@ class RenderPass {
      * the existing content.
      */
     setClearDepth(depthValue) {
-        if (depthValue) {
+        if (depthValue !== undefined) {
             this.depthStencilOps.clearDepthValue = depthValue;
         }
         this.depthStencilOps.clearDepth = depthValue !== undefined;
@@ -428,7 +428,7 @@ class RenderPass {
      * preserve the existing content.
      */
     setClearStencil(stencilValue) {
-        if (stencilValue) {
+        if (stencilValue !== undefined) {
             this.depthStencilOps.clearStencilValue = stencilValue;
         }
         this.depthStencilOps.clearStencil = stencilValue !== undefined;


### PR DESCRIPTION
- there are cases when setting up the depth clear value for the camera is useful, so exposing that as a public API:
```
CameraComponent.clearDepth = 0.4;
```

- also test for `undefined` when testing for the value, to correctly handle 0.