### PR TITLE
Fixed min amd mag filter for matrices texture

### DIFF
--- a/examples/src/examples/graphics/multi-draw-instanced-multi-platform.example.mjs
+++ b/examples/src/examples/graphics/multi-draw-instanced-multi-platform.example.mjs
@@ -166,6 +166,8 @@ assetListLoader.load(() => {
             width: totalInstances * 16 / 4, // write rbga as vec4
             height: 1,
             format: pc.PIXELFORMAT_RGBA32F,
+            minFilter: pc.FILTER_NEAREST,
+            magFilter: pc.FILTER_NEAREST,
             mipmaps: false,
             numLevels: 1,
             levels: [matrices]


### PR DESCRIPTION
Fixed min amd mag filter for matrices texture.
Some devices were reading the texture incorrectly.

- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
