### PR TITLE
Destroy orderTexture

### DIFF
--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -124,6 +124,7 @@ class GSplatInstance {
     }
 
     destroy() {
+        this.orderTexture?.destroy();
         this.resolveSH?.destroy();
         this.material?.destroy();
         this.meshInstance?.destroy();


### PR DESCRIPTION
## Description
Memleak in GSplatInstance by orderTexture

Fixes #
Call to destroy the orderTexture within the GSplatInstance.destroy() method. 
