### PR TITLE
[Fix] Small changes to avoid unset uniform warnings when particle systems are rendered

### DIFF
--- a/src/scene/particle-system/gpu-updater.js
+++ b/src/scene/particle-system/gpu-updater.js
@@ -66,6 +66,7 @@ class ParticleGPUUpdater {
         this.constantMaxVel = gd.scope.resolve('maxVel');
         this.constantFaceTangent = gd.scope.resolve('faceTangent');
         this.constantFaceBinorm = gd.scope.resolve('faceBinorm');
+        this.constantRadialSpeedDivMult = gd.scope.resolve('radialSpeedDivMult');
     }
 
     _setInputBounds() {
@@ -97,6 +98,8 @@ class ParticleGPUUpdater {
         device.setCullMode(CULLFACE_NONE);
 
         this.randomize();
+
+        this.constantRadialSpeedDivMult.setValue(emitter.material.getParameter('radialSpeedDivMult').data);
 
         this.constantGraphSampleSize.setValue(1.0 / emitter.precision);
         this.constantGraphNumSamples.setValue(emitter.precision);

--- a/src/scene/shader-lib/glsl/chunks/particle/frag/particle.js
+++ b/src/scene/shader-lib/glsl/chunks/particle/frag/particle.js
@@ -11,7 +11,9 @@ uniform float graphNumSamples;
     uniform vec4 camera_params;
 #endif
 
-uniform float softening;
+#ifdef SOFT
+    uniform float softening;
+#endif
 uniform float colorMult;
 
 float saturate(float x) {

--- a/src/scene/shader-lib/glsl/chunks/particle/vert/particle_cpu.js
+++ b/src/scene/shader-lib/glsl/chunks/particle/vert/particle_cpu.js
@@ -27,10 +27,15 @@ uniform float numParticles;
 uniform float lifetime;
 uniform float stretch;
 uniform float seed;
-uniform vec3 wrapBounds;
 uniform vec3 emitterScale;
 uniform vec3 faceTangent;
 uniform vec3 faceBinorm;
+
+#ifdef PARTICLE_GPU
+    #ifdef WRAP
+        uniform vec3 wrapBounds;
+    #endif
+#endif
 
 #ifdef PARTICLE_GPU
     uniform highp sampler2D internalTex0;

--- a/src/scene/shader-lib/glsl/chunks/particle/vert/particle_init.js
+++ b/src/scene/shader-lib/glsl/chunks/particle/vert/particle_init.js
@@ -24,7 +24,6 @@ uniform float numParticlesPot;
 uniform float graphSampleSize;
 uniform float graphNumSamples;
 uniform float stretch;
-uniform vec3 wrapBounds;
 uniform vec3 emitterScale;
 uniform vec3 emitterPos;
 uniform vec3 faceTangent;
@@ -32,13 +31,18 @@ uniform vec3 faceBinorm;
 uniform float rate;
 uniform float rateDiv;
 uniform float lifetime;
-uniform float deltaRandomnessStatic;
 uniform float scaleDivMult;
 uniform float alphaDivMult;
 uniform float seed;
 uniform float delta;
 uniform sampler2D particleTexOUT;
 uniform sampler2D particleTexIN;
+
+#ifdef PARTICLE_GPU
+    #ifdef WRAP
+        uniform vec3 wrapBounds;
+    #endif
+#endif
 
 #ifdef PARTICLE_GPU
     uniform highp sampler2D internalTex0;

--- a/src/scene/shader-lib/wgsl/chunks/particle/frag/particle.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/frag/particle.js
@@ -14,7 +14,9 @@ uniform graphNumSamples: f32;
     uniform camera_params: vec4f;
 #endif
 
-uniform softening: f32;
+#ifdef SOFT
+    uniform softening: f32;
+#endif
 uniform colorMult: f32;
 
 fn saturate(x: f32) -> f32 {

--- a/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_cpu.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_cpu.js
@@ -26,10 +26,15 @@ uniform numParticles: f32;
 uniform lifetime: f32;
 uniform stretch: f32;
 uniform seed: f32;
-uniform wrapBounds: vec3f;
 uniform emitterScale: vec3f;
 uniform faceTangent: vec3f;
 uniform faceBinorm: vec3f;
+
+#ifdef PARTICLE_GPU
+    #ifdef WRAP
+        uniform wrapBounds: vec3f;
+    #endif
+#endif
 
 #ifdef PARTICLE_GPU
     var internalTex0: texture_2d<f32>;

--- a/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_init.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_init.js
@@ -23,7 +23,6 @@ uniform numParticlesPot: f32;
 uniform graphSampleSize: f32;
 uniform graphNumSamples: f32;
 uniform stretch: f32;
-uniform wrapBounds: vec3f;
 uniform emitterScale: vec3f;
 uniform emitterPos: vec3f;
 uniform faceTangent: vec3f;
@@ -31,11 +30,16 @@ uniform faceBinorm: vec3f;
 uniform rate: f32;
 uniform rateDiv: f32;
 uniform lifetime: f32;
-uniform deltaRandomnessStatic: f32;
 uniform scaleDivMult: f32;
 uniform alphaDivMult: f32;
 uniform seed: f32;
 uniform delta: f32;
+
+#ifdef PARTICLE_GPU
+    #ifdef WRAP
+        uniform wrapBounds: vec3f;
+    #endif
+#endif
 
 var particleTexOUT: texture_2d<f32>;
 var particleTexOUTSampler: sampler;


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/8001

- one uniform was not setup
- the other uniforms needed defines to be declared only as needed