### PR TITLE
Unified splats support radial sorting

### DIFF
--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -507,6 +507,9 @@ class GSplatManager {
             // transform by the full inverse matrix and then normalize, which cancels the (1/s) scaling factor
             const transformedDirection = invModelMat.transformVector(cameraDirection).normalize();
 
+            // camera position in splat's local space (for circular sorting)
+            const transformedPosition = invModelMat.transformPoint(cameraPosition);
+
             // world-space offset
             modelMat.getTranslation(translation);
             const offset = translation.sub(cameraPosition).dot(cameraDirection);
@@ -518,6 +521,7 @@ class GSplatManager {
 
             sorterRequest.push({
                 transformedDirection,
+                transformedPosition,
                 offset,
                 scale: uniformScale,
                 modelMat: modelMat.data.slice(),
@@ -526,7 +530,7 @@ class GSplatManager {
             });
         });
 
-        this.sorter.setSortParams(sorterRequest);
+        this.sorter.setSortParams(sorterRequest, this.scene.gsplat.radialSorting);
         this.renderer.updateViewport(cameraNode);
     }
 

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -12,6 +12,17 @@ class GSplatParams {
     debugAabbs = false;
 
     /**
+     * Enables radial sorting based on distance from camera (for cubemap rendering). When false,
+     * uses directional sorting along camera forward vector. Defaults to false.
+     *
+     * Note: Radial sorting helps reduce sorting artifacts when the camera rotates (looks around),
+     * while linear sorting is better at minimizing artifacts when the camera translates (moves).
+     *
+     * @type {boolean}
+     */
+    radialSorting = false;
+
+    /**
      * Enables debug rendering of AABBs for GSplat octree nodes. Defaults to false.
      *
      * @type {boolean}

--- a/src/scene/gsplat-unified/gsplat-unified-sorter.js
+++ b/src/scene/gsplat-unified/gsplat-unified-sorter.js
@@ -128,8 +128,9 @@ class GSplatUnifiedSorter extends EventHandler {
      * Sends sorting parameters to the sorter. Called every frame sorting is needed.
      *
      * @param {object} params - The sorting parameters - per-splat directions, offsets, scales, AABBs.
+     * @param {boolean} radialSorting - Whether to use radial distance sorting.
      */
-    setSortParams(params) {
+    setSortParams(params, radialSorting) {
 
         // only process job requests if we have a new version or no jobs are in flight
         if (this.hasNewVersion || this.jobsInFlight === 0) {
@@ -148,6 +149,7 @@ class GSplatUnifiedSorter extends EventHandler {
             this.worker.postMessage({
                 command: 'sort',
                 sortParams: params,
+                radialSorting: radialSorting,
                 order: orderData.buffer
             }, [
                 orderData.buffer


### PR DESCRIPTION
- sorting by radial distance from camera instead of sorting along camera's forward fector
- useful for for rendering to cubemaps, and others