### PR TITLE
Remove obsolete parts of JSDocs on an internal function in ShaderDefinition

### DIFF
--- a/src/platform/graphics/shader-definition-utils.js
+++ b/src/platform/graphics/shader-definition-utils.js
@@ -52,9 +52,7 @@ class ShaderDefinitionUtils {
      * @param {object} [options.attributes] - Attributes. Will be extracted from the vertexCode if
      * not provided.
      * @param {string} options.vertexCode - The vertex shader code.
-     * @param {string} [options.vertexExtensions] - The vertex shader extensions code.
      * @param {string} [options.fragmentCode] - The fragment shader code.
-     * @param {string} [options.fragmentExtensions] - The fragment shader extensions code.
      * @param {string} [options.fragmentPreamble] - The preamble string for the fragment shader.
      * @param {string[]} [options.feedbackVaryings] - A list of shader output variable
      * names that will be captured when using transform feedback. This setting is only effective


### PR DESCRIPTION
those are not used in the code anymore, removing