### PR TITLE
Fix: Morph weights now respect animation layer weights

### DIFF
--- a/src/framework/anim/binder/default-anim-binder.js
+++ b/src/framework/anim/binder/default-anim-binder.js
@@ -79,32 +79,39 @@ class DefaultAnimBinder {
             },
 
             'weight': function (node, weightName) {
+                // Parse weight name: either a named weight ('name.something') or numeric index
                 if (weightName.indexOf('name.') === 0) {
                     weightName = weightName.replace('name.', '');
                 } else {
                     weightName = Number(weightName);
                 }
+
+                // Find all morph instances associated with this node
                 const meshInstances = findMeshInstances(node);
-                let setters;
+                const instances = [];
                 if (meshInstances) {
                     for (let i = 0; i < meshInstances.length; ++i) {
                         if (meshInstances[i].node.name === node.name && meshInstances[i].morphInstance) {
-                            const morphInstance = meshInstances[i].morphInstance;
-                            const func = (value) => {
-                                morphInstance.setWeight(weightName, value[0]);
-                            };
-                            if (!setters) setters = [];
-                            setters.push(func);
+                            instances.push(meshInstances[i].morphInstance);
                         }
                     }
                 }
-                if (setters) {
-                    const callSetters = (value) => {
-                        for (let i = 0; i < setters.length; ++i) {
-                            setters[i](value);
+
+                if (instances.length > 0) {
+                    // Provide both get/set functions to support layer blending
+                    const func = {
+                        set: (value) => {
+                            // Apply weight to all morph instances on this node
+                            for (let i = 0; i < instances.length; ++i) {
+                                instances[i].setWeight(weightName, value[0]);
+                            }
+                        },
+                        get: () => {
+                            // Return current weight from first instance (all should have same value)
+                            return [instances[0].getWeight(weightName)];
                         }
                     };
-                    return DefaultAnimBinder.createAnimTarget(callSetters, 'number', 1, node, `weight.${weightName}`);
+                    return DefaultAnimBinder.createAnimTarget(func, 'number', 1, node, `weight.${weightName}`);
                 }
                 return null;
             },

--- a/src/framework/anim/evaluator/anim-evaluator.js
+++ b/src/framework/anim/evaluator/anim-evaluator.js
@@ -263,7 +263,7 @@ class AnimEvaluator {
             if (targets.hasOwnProperty(path)) {
                 const target = targets[path];
                 // if this evaluator is associated with an anim component then we should blend the result of this evaluator with all other anim layer's evaluators
-                if (binder.animComponent && target.target.isTransform) {
+                if (binder.animComponent && target.target.usesLayerBlending) {
                     const animTarget = binder.animComponent.targets[path];
                     if (animTarget.counter === animTarget.layerCounter) {
                         animTarget.counter = 0;

--- a/src/framework/anim/evaluator/anim-target.js
+++ b/src/framework/anim/evaluator/anim-target.js
@@ -25,8 +25,9 @@ class AnimTarget {
         this._components = components;
         this._targetPath = targetPath;
         this._isTransform = (this._targetPath.substring(this._targetPath.length - 13) === 'localRotation') ||
-        (this._targetPath.substring(this._targetPath.length - 13) === 'localPosition') ||
-        (this._targetPath.substring(this._targetPath.length - 10) === 'localScale');
+            (this._targetPath.substring(this._targetPath.length - 13) === 'localPosition') ||
+            (this._targetPath.substring(this._targetPath.length - 10) === 'localScale');
+        this._isWeight = this._targetPath.indexOf('weight.') !== -1;
     }
 
     get set() {
@@ -51,6 +52,17 @@ class AnimTarget {
 
     get isTransform() {
         return this._isTransform;
+    }
+
+    get isWeight() {
+        return this._isWeight;
+    }
+
+    /**
+     * Returns true if this target should use layer blending (transforms and weights).
+     */
+    get usesLayerBlending() {
+        return this._isTransform || this._isWeight;
     }
 }
 


### PR DESCRIPTION
Fixes #7974

When animations modifying morph weights were weighted down using animation layer weights, the morph weights were unaffected. Transform animations (position, rotation, scale) correctly responded to layer weights, but morph target animations did not.

### Root Cause
Morph weight animation targets were bypassing the layer blending system. In anim-evaluator.js, only transform properties (localPosition, localRotation, localScale) were being processed through the layer blending path. Morph weights took a different code path that applied animation values directly without considering layer weights.

### Solution
Include morph weight targets in the animation layer blending system by:
- Detecting weight paths - Added isWeight property to AnimTarget to identify morph weight paths
- Providing get/set functions - Updated the weight handler in DefaultAnimBinder to provide both get and set functions (required for layer blending to read base values)
- Using layer blending - Changed AnimEvaluator to process weight paths through the same layer blending logic as transforms
