### PR TITLE
[Fix] WebGPU: Use textureLoad for data textures instead of textureSample

### DIFF
--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -358,8 +358,8 @@ export const SHADOW_PCF1 = 5;  // alias for SHADOW_PCF1_32F for backwards compat
 /**
  * A shadow sampling technique using a 32-bit shadow map that adjusts filter size based on blocker
  * distance, producing realistic, soft shadow edges that vary with the light's occlusion. Note that
- * this technique requires either {@link GraphicsDevice#textureFloatRenderable} or
- * {@link GraphicsDevice#textureHalfFloatRenderable} to be true, and falls back to
+ * this technique requires both {@link GraphicsDevice#textureFloatRenderable} and
+ * {@link GraphicsDevice#textureFloatFilterable} to be true, and falls back to
  * {@link SHADOW_PCF3_32F} otherwise.
  *
  * @category Graphics

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -493,8 +493,8 @@ class Light {
 
         const device = this.device;
 
-        // PCSS requires F16 or F32 render targets
-        if (value === SHADOW_PCSS_32F && !device.textureFloatRenderable && !device.textureHalfFloatRenderable) {
+        // PCSS requires filterable F32 render targets
+        if (value === SHADOW_PCSS_32F && (!device.textureFloatRenderable || !device.textureFloatFilterable)) {
             value = SHADOW_PCF3_32F;
         }
 

--- a/src/scene/shader-lib/wgsl/chunks/common/vert/skin.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/vert/skin.js
@@ -3,7 +3,7 @@ export default /* wgsl */`
 attribute vertex_boneWeights: vec4f;
 attribute vertex_boneIndices: vec4f;
 
-var texture_poseMap: texture_2d<f32>;
+var texture_poseMap: texture_2d<uff>;
 
 struct BoneMatrix {
     v1: vec4f,

--- a/src/scene/shader-lib/wgsl/chunks/common/vert/skinBatch.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/vert/skinBatch.js
@@ -1,7 +1,7 @@
 export default /* wgsl */`
 attribute vertex_boneIndices: f32;
 
-var texture_poseMap: texture_2d<f32>;
+var texture_poseMap: texture_2d<uff>;
 
 fn getBoneMatrix(indexFloat: f32) -> mat4x4f {
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatColor.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatColor.js
@@ -1,6 +1,6 @@
 export default /* wgsl */`
 
-var splatColor: texture_2d<f32>;
+var splatColor: texture_2d<uff>;
 
 fn readColor(source: ptr<function, SplatSource>) -> vec4f {
     return textureLoad(splatColor, source.uv, 0);

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCompressedData.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCompressedData.js
@@ -1,6 +1,6 @@
 export default /* wgsl */`
 var packedTexture: texture_2d<u32>;
-var chunkTexture: texture_2d<f32>;
+var chunkTexture: texture_2d<uff>;
 
 // work values
 var<private> chunkDataA: vec4f;    // x: min_x, y: min_y, z: min_z, w: max_x

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatData.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatData.js
@@ -1,6 +1,6 @@
 export default /* wgsl */`
 var transformA: texture_2d<u32>;
-var transformB: texture_2d<f32>;
+var transformB: texture_2d<uff>;
 
 // work values
 var<private> tAw: u32;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatWorkBuffer.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatWorkBuffer.js
@@ -1,8 +1,8 @@
 export default /* wgsl */`
-var center: texture_2d<f32>;
-var covA: texture_2d<f32>;
-var covB: texture_2d<f32>;
-var splatColor: texture_2d<f32>;
+var center: texture_2d<uff>;
+var covA: texture_2d<uff>;
+var covB: texture_2d<uff>;
+var splatColor: texture_2d<uff>;
 
 // read the model-space center of the gaussian
 fn readCenter(source: ptr<function, SplatSource>) -> vec3f {

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/clusteredLight.js
@@ -14,7 +14,7 @@ export default /* wgsl */`
 #endif
 
 var clusterWorldTexture: texture_2d<f32>;
-var lightsTexture: texture_2d<f32>;
+var lightsTexture: texture_2d<uff>;
 
 #ifdef CLUSTER_SHADOWS
     // TODO: when VSM shadow is supported, it needs to use sampler2D in webgl2

--- a/src/scene/shader-lib/wgsl/chunks/particle/frag/particleInputFloat.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/frag/particleInputFloat.js
@@ -1,7 +1,10 @@
 export default /* wgsl */`
 fn readInput(uv: f32) {
-    let tex: vec4f = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.25), 0.0);
-    let tex2: vec4f = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.75), 0.0);
+    let textureSize = textureDimensions(particleTexIN, 0);
+    let texel0: vec2i = vec2i(vec2f(uv, 0.25) * vec2f(textureSize));
+    let texel1: vec2i = vec2i(vec2f(uv, 0.75) * vec2f(textureSize));
+    let tex: vec4f = textureLoad(particleTexIN, texel0, 0);
+    let tex2: vec4f = textureLoad(particleTexIN, texel1, 0);
 
     inPos = tex.xyz;
     inVel = tex2.xyz;

--- a/src/scene/shader-lib/wgsl/chunks/particle/frag/particleInputRgba8.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/frag/particleInputRgba8.js
@@ -20,10 +20,15 @@ fn decodeFloatRGBA( rgba: vec4f ) -> f32 {
 }
 
 fn readInput(uv: f32) {
-    let tex0 = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.125), 0.0);
-    let tex1 = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.375), 0.0);
-    let tex2 = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.625), 0.0);
-    let tex3 = textureSampleLevel(particleTexIN, particleTexINSampler, vec2f(uv, 0.875), 0.0);
+    let textureSize = textureDimensions(particleTexIN, 0);
+    let texel0: vec2i = vec2i(vec2f(uv, 0.125) * vec2f(textureSize));
+    let texel1: vec2i = vec2i(vec2f(uv, 0.375) * vec2f(textureSize));
+    let texel2: vec2i = vec2i(vec2f(uv, 0.625) * vec2f(textureSize));
+    let texel3: vec2i = vec2i(vec2f(uv, 0.875) * vec2f(textureSize));
+    let tex0 = textureLoad(particleTexIN, texel0, 0);
+    let tex1 = textureLoad(particleTexIN, texel1, 0);
+    let tex2 = textureLoad(particleTexIN, texel2, 0);
+    let tex3 = textureLoad(particleTexIN, texel3, 0);
 
     inPos = vec3f(decodeFloatRG(tex0.rg), decodeFloatRG(tex0.ba), decodeFloatRG(tex1.rg));
     inPos = (inPos - vec3f(0.5)) * uniform.inBoundsSize + uniform.inBoundsCenter;

--- a/src/scene/shader-lib/wgsl/chunks/particle/frag/particleUpdaterInit.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/frag/particleUpdaterInit.js
@@ -1,16 +1,11 @@
 export default /* wgsl */`
 varying vUv0: vec2f;
 
-var particleTexIN: texture_2d<f32>;
-var particleTexINSampler: sampler;
-var internalTex0: texture_2d<f32>;
-var internalTex0Sampler: sampler;
-var internalTex1: texture_2d<f32>;
-var internalTex1Sampler: sampler;
-var internalTex2: texture_2d<f32>;
-var internalTex2Sampler: sampler;
-var internalTex3: texture_2d<f32>;
-var internalTex3Sampler: sampler;
+var particleTexIN: texture_2d<uff>;
+var internalTex0: texture_2d<uff>;
+var internalTex1: texture_2d<uff>;
+var internalTex2: texture_2d<uff>;
+var internalTex3: texture_2d<uff>;
 
 uniform emitterMatrix: mat3x3f;
 uniform emitterMatrixInv: mat3x3f;

--- a/src/scene/shader-lib/wgsl/chunks/particle/frag/particleUpdaterStart.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/frag/particleUpdaterStart.js
@@ -16,10 +16,12 @@ struct TexLerpUnpackResult {
     unpacked: vec3f
 }
 
-fn tex1Dlod_lerp(tex: texture_2d<f32>, texSampler: sampler, tc: vec2f) -> TexLerpUnpackResult {
+fn tex1Dlod_lerp(tex: texture_2d<f32>, textureSize: vec2u, tc: vec2f) -> TexLerpUnpackResult {
     let tc_next = tc + vec2f(uniform.graphSampleSize);
-    let a = textureSampleLevel(tex, texSampler, tc, 0.0);
-    let b = textureSampleLevel(tex, texSampler, tc_next, 0.0);
+    let texelA: vec2i = vec2i(tc * vec2f(textureSize));
+    let texelB: vec2i = vec2i(tc_next * vec2f(textureSize));
+    let a = textureLoad(tex, texelA, 0);
+    let b = textureLoad(tex, texelB, 0);
     let c = fract(tc.x * uniform.graphNumSamples);
 
     let unpackedA = unpack3NFloats(a.w);
@@ -55,21 +57,23 @@ fn fragmentMain(input : FragmentInput) -> FragmentOutput {
     outLife = inLife + uniform.delta;
     let nlife = clamp(outLife / uniform.lifetime, 0.0, 1.0);
 
-    let lerpResult0 = tex1Dlod_lerp(internalTex0, internalTex0Sampler, vec2f(nlife, 0.0));
+    let internalTexSize = textureDimensions(internalTex0, 0);
+
+    let lerpResult0 = tex1Dlod_lerp(internalTex0, internalTexSize, vec2f(nlife, 0.0));
     var localVelocity = lerpResult0.result;
     let localVelocityDiv = lerpResult0.unpacked;
 
-    let lerpResult1 = tex1Dlod_lerp(internalTex1, internalTex1Sampler, vec2f(nlife, 0.0));
+    let lerpResult1 = tex1Dlod_lerp(internalTex1, internalTexSize, vec2f(nlife, 0.0));
     var velocity = lerpResult1.result;
     let velocityDiv = lerpResult1.unpacked;
 
-    let lerpResult2 = tex1Dlod_lerp(internalTex2, internalTex2Sampler, vec2f(nlife, 0.0));
+    let lerpResult2 = tex1Dlod_lerp(internalTex2, internalTexSize, vec2f(nlife, 0.0));
     let params = lerpResult2.result;
     let paramDiv = lerpResult2.unpacked;
     var rotSpeed = params.x;
     let rotSpeedDiv = paramDiv.y;
 
-    let lerpResult3 = tex1Dlod_lerp(internalTex3, internalTex3Sampler, vec2f(nlife, 0.0));
+    let lerpResult3 = tex1Dlod_lerp(internalTex3, internalTexSize, vec2f(nlife, 0.0));
     let radialParams = lerpResult3.result;
     let radialParamDiv = lerpResult3.unpacked;
     let radialSpeed = radialParams.x;

--- a/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_cpu.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_cpu.js
@@ -37,12 +37,9 @@ uniform faceBinorm: vec3f;
 #endif
 
 #ifdef PARTICLE_GPU
-    var internalTex0: texture_2d<f32>;
-    var internalTex0Sampler: sampler;
-    var internalTex1: texture_2d<f32>;
-    var internalTex1Sampler: sampler;
-    var internalTex2: texture_2d<f32>;
-    var internalTex2Sampler: sampler;
+    var internalTex0: texture_2d<uff>;
+    var internalTex1: texture_2d<uff>;
+    var internalTex2: texture_2d<uff>;
 #endif
 uniform emitterPos: vec3f;
 

--- a/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_init.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_init.js
@@ -41,18 +41,13 @@ uniform delta: f32;
     #endif
 #endif
 
-var particleTexOUT: texture_2d<f32>;
-var particleTexOUTSampler: sampler;
-var particleTexIN: texture_2d<f32>;
-var particleTexINSampler: sampler;
+var particleTexOUT: texture_2d<uff>;
+var particleTexIN: texture_2d<uff>;
 
 #ifdef PARTICLE_GPU
-    var internalTex0: texture_2d<f32>;
-    var internalTex0Sampler: sampler;
-    var internalTex1: texture_2d<f32>;
-    var internalTex1Sampler: sampler;
-    var internalTex2: texture_2d<f32>;
-    var internalTex2Sampler: sampler;
+    var internalTex0: texture_2d<uff>;
+    var internalTex1: texture_2d<uff>;
+    var internalTex2: texture_2d<uff>;
 #endif
 
 #ifndef CAMERAPLANES


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/8015

Converts multiple WGSL shaders to use direct textureLoad instead of sampled access. This allows those shaders to be compatible with the devices that do not support float texture filtering.

This can be forced by commenting out this in the engine code:
```
//this.textureFloatFilterable = requireFeature('float32-filterable');
```

This makes all engine examples compatible with those devices.
