### PR TITLE
[Fix] Fix to particle exmaple not setting up shader correctly

### DIFF
--- a/examples/src/examples/compute/particles.example.mjs
+++ b/examples/src/examples/compute/particles.example.mjs
@@ -214,6 +214,9 @@ assetListLoader.load(() => {
         fragmentWGSL: files['shader-shared.wgsl'] + files['shader-rendering.fragment.wgsl']
     });
 
+    // rendering shader needs the particle storage buffer to read the particle data
+    material.setParameter('particles', particleStorageBuffer);
+
     // index buffer - two triangles (6 indices) per particle using 4 vertices
     const indices = new Uint32Array(numParticles * 6);
     for (let i = 0; i < numParticles; ++i) {

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -31,6 +31,7 @@ import { ShaderChunks } from '../shader-lib/shader-chunks.js';
  * @import { UniformBufferFormat } from '../../platform/graphics/uniform-buffer-format.js';
  * @import { VertexFormat } from '../../platform/graphics/vertex-format.js';
  * @import { ShaderChunkMap } from '../shader-lib/shader-chunk-map.js';
+ * @import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
  */
 
 // blend mode mapping to op, srcBlend and dstBlend
@@ -773,7 +774,7 @@ class Material {
      * Sets a shader parameter on a material.
      *
      * @param {string} name - The name of the parameter to set.
-     * @param {number|number[]|Float32Array|Texture} data - The value for the specified parameter.
+     * @param {number|number[]|ArrayBufferView|Texture|StorageBuffer} data - The value for the specified parameter.
      */
     setParameter(name, data) {
 


### PR DESCRIPTION
- the example worked correctly, as compute shader set up this data in the scope
- but for correctness, material needs to set up that data too as something else can overwrite it
- cleanup the types as well