### PR TITLE
Update gsplat work buffer to use 2 uint textures instead of 3 half-float textures

### DIFF
--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -63,9 +63,8 @@ class GSplatRenderer {
 
         // input textures (work buffer textures)
         this._material.setParameter('splatColor', workBuffer.colorTexture);
-        this._material.setParameter('covA', workBuffer.covATexture);
-        this._material.setParameter('covB', workBuffer.covBTexture);
-        this._material.setParameter('center', workBuffer.centerTexture);
+        this._material.setParameter('splatTexture0', workBuffer.splatTexture0);
+        this._material.setParameter('splatTexture1', workBuffer.splatTexture1);
         this._material.setDefine('SH_BANDS', '0');
 
         // set instance properties

--- a/src/scene/gsplat-unified/gsplat-work-buffer.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer.js
@@ -1,5 +1,5 @@
 import { Debug } from '../../core/debug.js';
-import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_R32U, PIXELFORMAT_RGBA16F, BUFFERUSAGE_COPY_DST } from '../../platform/graphics/constants.js';
+import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_R32U, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32U, PIXELFORMAT_RG32U, BUFFERUSAGE_COPY_DST } from '../../platform/graphics/constants.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
 import { Texture } from '../../platform/graphics/texture.js';
@@ -28,13 +28,10 @@ class GSplatWorkBuffer {
     colorTexture;
 
     /** @type {Texture} */
-    covATexture;
+    splatTexture0;
 
     /** @type {Texture} */
-    covBTexture;
-
-    /** @type {Texture} */
-    centerTexture;
+    splatTexture1;
 
     /** @type {RenderTarget} */
     renderTarget;
@@ -58,13 +55,12 @@ class GSplatWorkBuffer {
         this.device = device;
 
         this.colorTexture = this.createTexture('splatColor', PIXELFORMAT_RGBA16F, 1, 1);
-        this.covATexture = this.createTexture('covA', PIXELFORMAT_RGBA16F, 1, 1);
-        this.covBTexture = this.createTexture('covB', PIXELFORMAT_RGBA16F, 1, 1);
-        this.centerTexture = this.createTexture('center', PIXELFORMAT_RGBA16F, 1, 1);
+        this.splatTexture0 = this.createTexture('splatTexture0', PIXELFORMAT_RGBA32U, 1, 1);
+        this.splatTexture1 = this.createTexture('splatTexture1', PIXELFORMAT_RG32U, 1, 1);
 
         this.renderTarget = new RenderTarget({
             name: `GsplatWorkBuffer-MRT-${this.id}`,
-            colorBuffers: [this.colorTexture, this.centerTexture, this.covATexture, this.covBTexture],
+            colorBuffers: [this.colorTexture, this.splatTexture0, this.splatTexture1],
             depth: false,
             flipY: true
         });
@@ -87,9 +83,8 @@ class GSplatWorkBuffer {
     destroy() {
         this.renderPass?.destroy();
         this.colorTexture?.destroy();
-        this.covATexture?.destroy();
-        this.covBTexture?.destroy();
-        this.centerTexture?.destroy();
+        this.splatTexture0?.destroy();
+        this.splatTexture1?.destroy();
         this.orderTexture?.destroy();
         this.orderBuffer?.destroy();
         this.renderTarget?.destroy();

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -46,7 +46,8 @@ class WorkBufferRenderInfo {
             fragmentDefines: clonedDefines,
             vertexChunk: 'fullscreenQuadVS',
             fragmentGLSL: glslGsplatCopyToWorkBufferPS,
-            fragmentWGSL: wgslGsplatCopyToWorkBufferPS
+            fragmentWGSL: wgslGsplatCopyToWorkBufferPS,
+            fragmentOutputTypes: ['vec4', 'uvec4', 'uvec2']
         });
 
         this.quadRender = new QuadRender(shader);

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
@@ -34,9 +34,8 @@ void main(void) {
 
         // Out of bounds: write zeros
         pcFragColor0 = vec4(0.0);
-        pcFragColor1 = vec4(0.0);
-        pcFragColor2 = vec4(0.0);
-        pcFragColor3 = vec4(0.0);
+        pcFragColor1 = uvec4(0u);
+        pcFragColor2 = uvec2(0u);
 
     } else {
 
@@ -102,9 +101,8 @@ void main(void) {
 
         // write out results
         pcFragColor0 = color;
-        pcFragColor1 = vec4(modelCenter, 1.0);
-        pcFragColor2 = vec4(covA, 1.0);
-        pcFragColor3 = vec4(covB, 1.0);
+        pcFragColor1 = uvec4(floatBitsToUint(modelCenter.x), floatBitsToUint(modelCenter.y), floatBitsToUint(modelCenter.z), packHalf2x16(vec2(covA.z, covB.z)));
+        pcFragColor2 = uvec2(packHalf2x16(covA.xy), packHalf2x16(covB.xy));
     }
 }
 `;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
@@ -22,6 +22,10 @@ void main(void) {
         return;
     }
 
+    #ifdef GSPLAT_WORKBUFFER_DATA
+        loadSplatTextures(source);
+    #endif
+
     vec3 modelCenter = readCenter(source);
 
     SplatCenter center;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatWorkBuffer.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatWorkBuffer.js
@@ -1,18 +1,30 @@
 export default /* glsl */`
-uniform highp sampler2D center;
-uniform highp sampler2D covA;
-uniform highp sampler2D covB;
+uniform highp usampler2D splatTexture0;
+uniform highp usampler2D splatTexture1;
 uniform mediump sampler2D splatColor;
+
+// cached texture fetches
+uvec4 cachedSplatTexture0Data;
+uvec2 cachedSplatTexture1Data;
+
+// load splat textures into globals to avoid redundant fetches
+void loadSplatTextures(SplatSource source) {
+    cachedSplatTexture0Data = texelFetch(splatTexture0, source.uv, 0);
+    cachedSplatTexture1Data = texelFetch(splatTexture1, source.uv, 0).xy;
+}
 
 // read the model-space center of the gaussian
 vec3 readCenter(SplatSource source) {
-    return texelFetch(center, source.uv, 0).xyz;
+    return vec3(uintBitsToFloat(cachedSplatTexture0Data.r), uintBitsToFloat(cachedSplatTexture0Data.g), uintBitsToFloat(cachedSplatTexture0Data.b));
 }
 
 // sample covariance vectors
 void readCovariance(in SplatSource source, out vec3 cov_A, out vec3 cov_B) {
-    cov_A = texelFetch(covA, source.uv, 0).xyz;
-    cov_B = texelFetch(covB, source.uv, 0).xyz;
+    vec2 covAxy = unpackHalf2x16(cachedSplatTexture1Data.x);
+    vec2 covBxy = unpackHalf2x16(cachedSplatTexture1Data.y);
+    vec2 covAzBz = unpackHalf2x16(cachedSplatTexture0Data.a);
+    cov_A = vec3(covAxy, covAzBz.x);
+    cov_B = vec3(covBxy, covAzBz.y);
 }
 
 vec4 readColor(in SplatSource source) {

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
@@ -38,9 +38,8 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
 
         // Out of bounds: write zeros
         output.color = vec4f(0.0);
-        output.color1 = vec4f(0.0);
-        output.color2 = vec4f(0.0);
-        output.color3 = vec4f(0.0);
+        output.color1 = vec4u(0u);
+        output.color2 = vec2u(0u);
 
     } else {
 
@@ -108,9 +107,8 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
 
         // write out results
         output.color = color;
-        output.color1 = vec4f(modelCenter, 1.0);
-        output.color2 = vec4f(covA, 1.0);
-        output.color3 = vec4f(covB, 1.0);
+        output.color1 = vec4u(bitcast<u32>(modelCenter.x), bitcast<u32>(modelCenter.y), bitcast<u32>(modelCenter.z), pack2x16float(vec2f(covA.z, covB.z)));
+        output.color2 = vec2u(pack2x16float(covA.xy), pack2x16float(covB.xy));
     }
     
     return output;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
@@ -25,6 +25,10 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
         return output;
     }
 
+    #ifdef GSPLAT_WORKBUFFER_DATA
+        loadSplatTextures(&source);
+    #endif
+
     let modelCenter: vec3f = readCenter(&source);
 
     var center: SplatCenter;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatWorkBuffer.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatWorkBuffer.js
@@ -1,18 +1,30 @@
 export default /* wgsl */`
-var center: texture_2d<uff>;
-var covA: texture_2d<uff>;
-var covB: texture_2d<uff>;
+var splatTexture0: texture_2d<u32>;
+var splatTexture1: texture_2d<u32>;
 var splatColor: texture_2d<uff>;
+
+// cached texture fetches
+var<private> cachedSplatTexture0Data: vec4u;
+var<private> cachedSplatTexture1Data: vec2u;
+
+// load splat textures into globals to avoid redundant fetches
+fn loadSplatTextures(source: ptr<function, SplatSource>) {
+    cachedSplatTexture0Data = textureLoad(splatTexture0, source.uv, 0);
+    cachedSplatTexture1Data = textureLoad(splatTexture1, source.uv, 0).xy;
+}
 
 // read the model-space center of the gaussian
 fn readCenter(source: ptr<function, SplatSource>) -> vec3f {
-    return textureLoad(center, source.uv, 0).xyz;
+    return vec3f(bitcast<f32>(cachedSplatTexture0Data.r), bitcast<f32>(cachedSplatTexture0Data.g), bitcast<f32>(cachedSplatTexture0Data.b));
 }
 
 // sample covariance vectors
 fn readCovariance(source: ptr<function, SplatSource>, cov_A: ptr<function, vec3f>, cov_B: ptr<function, vec3f>) {
-    *cov_A = textureLoad(covA, source.uv, 0).xyz;
-    *cov_B = textureLoad(covB, source.uv, 0).xyz;
+    let covAxy = unpack2x16float(cachedSplatTexture1Data.x);
+    let covBxy = unpack2x16float(cachedSplatTexture1Data.y);
+    let covAzBz = unpack2x16float(cachedSplatTexture0Data.a);
+    *cov_A = vec3f(covAxy, covAzBz.x);
+    *cov_B = vec3f(covBxy, covAzBz.y);
 }
 
 fn readColor(source: ptr<function, SplatSource>) -> vec4f {


### PR DESCRIPTION
- use uint format to ensure wide compatibility (half / float formats are less widely supported)
- use f32 to store position in work buffer instead of f16 to avoid precision issues in larger scenes