### PR TITLE
[Fix] Mark splatDistances as property in gsplat component

### DIFF
--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -78,7 +78,7 @@ class GSplatComponent extends Component {
      * @type {number[]|null}
      * @private
      */
-    _lodDistances = [5, 10, 15, 20, 25, 30, 35, 40];
+    _lodDistances = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60];
 
     /**
      * @type {BoundingBox|null}

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -18,6 +18,7 @@ const _schema = [
 // order matters here
 const _properties = [
     'unified',
+    'lodDistances',
     'castShadows',
     'material',
     'highQualitySH',


### PR DESCRIPTION
- this allows to pass lod distances during component construction
- also more default lod values