### PR TITLE
Remove MiniStats div from DOM on destroy

### DIFF
--- a/src/extras/mini-stats/mini-stats.js
+++ b/src/extras/mini-stats/mini-stats.js
@@ -143,6 +143,7 @@ class MiniStats {
         this.graphs.forEach(graph => graph.destroy());
         this.wordAtlas.destroy();
         this.texture.destroy();
+        this.div.remove();
     }
 
     /**


### PR DESCRIPTION
## Description
Correctly removes the MiniStats div from the DOM on calling `MiniStats#destroy`.

Fixes #8068

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
