### PR TITLE
Optimize 16-bit unpacking in gsplat chunks

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatSogsCenters.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatSogsCenters.js
@@ -17,7 +17,7 @@ void main(void) {
 
     vec3 l = texelFetch(means_l, uv, 0).xyz;
     vec3 u = texelFetch(means_u, uv, 0).xyz;
-    vec3 n = (l * 255.0 + u * 255.0 * 256.0) / 65535.0;
+    vec3 n = (l + u * 256.0) / 257.0;
     vec3 v = mix(means_mins, means_maxs, n);
     vec3 center = sign(v) * (exp(abs(v)) - 1.0);
 

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatSogsData.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatSogsData.js
@@ -19,7 +19,7 @@ vec3 readCenter(SplatSource source) {
 
     vec3 l = unpack8888(packedSample.x).xyz;
     vec3 u = unpack8888(packedSample.y).xyz;
-    vec3 n = (l * 255.0 + u * 255.0 * 256.0) / 65535.0;
+    vec3 n = (l + u * 256.0) / 257.0;
     vec3 v = mix(means_mins, means_maxs, n);
 
     return sign(v) * (exp(abs(v)) - 1.0);

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatSogsCenters.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatSogsCenters.js
@@ -19,7 +19,7 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
 
     let l: vec3f = textureLoad(means_l, uv, 0).xyz;
     let u: vec3f = textureLoad(means_u, uv, 0).xyz;
-    let n: vec3f = (l * 255.0 + u * 255.0 * 256.0) / 65535.0;
+    let n: vec3f = (l + u * 256.0) / 257.0;
     let v: vec3f = mix(uniform.means_mins, uniform.means_maxs, n);
     let center: vec3f = sign(v) * (exp(abs(v)) - 1.0);
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatSogsData.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatSogsData.js
@@ -18,7 +18,7 @@ fn readCenter(source: ptr<function, SplatSource>) -> vec3f {
 
     let l = unpack8888(packedSample.x).xyz;
     let u = unpack8888(packedSample.y).xyz;
-    let n = (l * 255.0 + u * 255.0 * 256.0) / 65535.0;
+    let n = (l + u * 256.0) / 257.0;
     let v = mix(uniform.means_mins, uniform.means_maxs, n);
 
     return sign(v) * (exp(abs(v)) - 1.0);


### PR DESCRIPTION
## Description
Optimization: (l * 255.0 + u * 255.0 * 256.0) / 65535.0 → (l + u * 256.0) / 257.0

Impact: Reduces from 4 operations per component (3 multiplications + 1 division) to 2 operations per component (1 multiplication + 1 division), saving 6 operations total per vec3.

All optimizations maintain mathematical correctness while significantly improving performance, especially in GPU shaders that execute thousands of times per frame.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
