### PR TITLE
Sync GLSL gsplat chunks with WGSL

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCommon.js
@@ -11,7 +11,7 @@ export default /* glsl */`
 
 // modify the gaussian corner so it excludes gaussian regions with alpha less than 1/255
 void clipCorner(inout SplatCorner corner, float alpha) {
-    float clip = min(1.0, sqrt(-log(1.0 / 255.0 / alpha)) / 2.0);
+    float clip = min(1.0, sqrt(-log(1.0 / (255.0 * alpha))) / 2.0);
     corner.offset *= clip;
     corner.uv *= clip;
 }

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatSogsColor.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatSogsColor.js
@@ -4,7 +4,7 @@ uniform highp sampler2D packedSh0;
 uniform float sh0_mins;
 uniform float sh0_maxs;
 
-float SH_C0 = 0.28209479177387814;
+const float SH_C0 = 0.28209479177387814;
 
 vec4 readColor(in SplatSource source) {
     vec3 clr = mix(vec3(sh0_mins), vec3(sh0_maxs), unpack111110(pack8888(texelFetch(packedSh0, source.uv, 0))));

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCommon.js
@@ -15,5 +15,4 @@ fn clipCorner(corner: ptr<function, SplatCorner>, alpha: f32) {
     corner.offset = corner.offset * clip;
     corner.uv = corner.uv * clip;
 }
-
 `;


### PR DESCRIPTION
## Description
Update GLSL chunks to more closely mirror the WGSL equivalents:

* Use `const` for `SH_C0`
* Prefer mult instead of div in `clipCorner`

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
