### PR TITLE
[DOCS] Fix types and documentation for applySceneSettings

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1392,7 +1392,7 @@ class AppBase extends EventHandler {
      * Only valid for prefiltered cubemap skyboxes.
      * @param {number[]} [settings.render.skyboxRotation] - Rotation of skybox. Defaults to [0, 0, 0].
      *
-     * @param {string} [settings.render.skyType] - The type of the sky. One of the SKYMESH_* constants. Defaults to {@link SKYTYPE_INFINITE}.
+     * @param {string} [settings.render.skyType] - The type of the sky. One of the SKYTYPE_* constants. Defaults to {@link SKYTYPE_INFINITE}.
      * @param {number[]} [settings.render.skyMeshPosition] - The position of sky mesh. Ignored for {@link SKYTYPE_INFINITE}. Defaults to [0, 0, 0].
      * @param {number[]} [settings.render.skyMeshRotation] - The rotation of sky mesh. Ignored for {@link SKYTYPE_INFINITE}. Defaults to [0, 0, 0].
      * @param {number[]} [settings.render.skyMeshScale] - The scale of sky mesh. Ignored for {@link SKYTYPE_INFINITE}. Defaults to [1, 1, 1].


### PR DESCRIPTION
## Description

This PR does the following fixes to `applySceneSettings`'s `settings` parameter:
- Fixes type for `settings.render.lightingCells` from `Vec3` to `number[]`
- Fixes optional properties and documents the defaults
- Adds missing properties with description and defaults

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
