### PR TITLE
Fallback texture format for work buffer for unified gsplat rendering

### DIFF
--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -1,4 +1,4 @@
-import { SEMANTIC_POSITION, SEMANTIC_ATTR13, CULLFACE_NONE } from '../../platform/graphics/constants.js';
+import { SEMANTIC_POSITION, SEMANTIC_ATTR13, CULLFACE_NONE, PIXELFORMAT_RGBA16U } from '../../platform/graphics/constants.js';
 import { BLEND_NONE, BLEND_PREMULTIPLIED, BLEND_ADDITIVE } from '../constants.js';
 import { ShaderMaterial } from '../materials/shader-material.js';
 import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
@@ -82,6 +82,10 @@ class GSplatRenderer {
         // input format
         this._material.setDefine('GSPLAT_WORKBUFFER_DATA', true);
         this._material.setDefine('STORAGE_ORDER', device.isWebGPU);
+
+        // Check if using RGBA16U format (fallback for when RGBA16F not supported)
+        const isColorUint = workBuffer.colorTextureFormat === PIXELFORMAT_RGBA16U;
+        this._material.setDefine('GSPLAT_COLOR_UINT', isColorUint);
 
         // input textures (work buffer textures)
         this._material.setParameter('splatColor', workBuffer.colorTexture);

--- a/src/scene/gsplat-unified/gsplat-work-buffer-render-pass.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer-render-pass.js
@@ -10,6 +10,7 @@ import { CULLFACE_NONE } from '../../platform/graphics/constants.js';
  * @import { GSplatInfo } from './gsplat-info.js'
  * @import { GraphNode } from '../graph-node.js'
  * @import { RenderTarget } from '../../platform/graphics/render-target.js'
+ * @import { GSplatWorkBuffer } from './gsplat-work-buffer.js'
  */
 
 const _viewMat = new Mat4();
@@ -38,6 +39,14 @@ class GSplatWorkBufferRenderPass extends RenderPass {
      * @type {GraphNode}
      */
     cameraNode = /** @type {any} */ (null);
+
+    /** @type {GSplatWorkBuffer} */
+    workBuffer;
+
+    constructor(device, workBuffer) {
+        super(device);
+        this.workBuffer = workBuffer;
+    }
 
     /**
      * Initialize the render pass with the specified render target.
@@ -111,7 +120,7 @@ class GSplatWorkBufferRenderPass extends RenderPass {
         const { intervals, activeSplats, lineStart, viewport, intervalTexture } = splatInfo;
 
         // quad renderer and material are cached in the resource
-        const workBufferRenderInfo = resource.getWorkBufferRenderInfo(intervals.length > 0);
+        const workBufferRenderInfo = resource.getWorkBufferRenderInfo(intervals.length > 0, this.workBuffer.colorTextureFormat);
 
         // Assign material properties to scope
         workBufferRenderInfo.material.setParameters(device);

--- a/src/scene/gsplat-unified/gsplat-work-buffer.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer.js
@@ -1,5 +1,5 @@
 import { Debug } from '../../core/debug.js';
-import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_R32U, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32U, PIXELFORMAT_RG32U, BUFFERUSAGE_COPY_DST, SEMANTIC_POSITION } from '../../platform/graphics/constants.js';
+import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST, PIXELFORMAT_R32U, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA16U, PIXELFORMAT_RGBA32U, PIXELFORMAT_RG32U, BUFFERUSAGE_COPY_DST, SEMANTIC_POSITION } from '../../platform/graphics/constants.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
 import { Texture } from '../../platform/graphics/texture.js';
@@ -31,11 +31,18 @@ class WorkBufferRenderInfo {
     /** @type {QuadRender} */
     quadRender;
 
-    constructor(device, key, material) {
+    constructor(device, key, material, colorTextureFormat) {
         this.device = device;
         this.material = material;
 
         const clonedDefines = new Map(material.defines);
+
+        // when using fallback RGBA16U format
+        const isColorUint = colorTextureFormat === PIXELFORMAT_RGBA16U;
+        if (isColorUint) {
+            clonedDefines.set('GSPLAT_COLOR_UINT', '');
+        }
+
         const shader = ShaderUtils.createShader(this.device, {
             uniqueName: `SplatCopyToWorkBuffer:${key}`,
             attributes: { vertex_position: SEMANTIC_POSITION },
@@ -44,7 +51,7 @@ class WorkBufferRenderInfo {
             vertexChunk: 'fullscreenQuadVS',
             fragmentGLSL: glslGsplatCopyToWorkBufferPS,
             fragmentWGSL: wgslGsplatCopyToWorkBufferPS,
-            fragmentOutputTypes: ['vec4', 'uvec4', 'uvec2']
+            fragmentOutputTypes: [isColorUint ? 'uvec4' : 'vec4', 'uvec4', 'uvec2']
         });
 
         this.quadRender = new QuadRender(shader);
@@ -65,6 +72,9 @@ class GSplatWorkBuffer {
 
     /** @type {number} */
     id = id++;
+
+    /** @type {number} */
+    colorTextureFormat;
 
     /** @type {Texture} */
     colorTexture;
@@ -96,7 +106,10 @@ class GSplatWorkBuffer {
     constructor(device) {
         this.device = device;
 
-        this.colorTexture = this.createTexture('splatColor', PIXELFORMAT_RGBA16F, 1, 1);
+        // Detect compatible HDR format for color texture, fallback to RGBA16U if RGBA16F not supported
+        this.colorTextureFormat = device.getRenderableHdrFormat([PIXELFORMAT_RGBA16F]) || PIXELFORMAT_RGBA16U;
+
+        this.colorTexture = this.createTexture('splatColor', this.colorTextureFormat, 1, 1);
         this.splatTexture0 = this.createTexture('splatTexture0', PIXELFORMAT_RGBA32U, 1, 1);
         this.splatTexture1 = this.createTexture('splatTexture1', PIXELFORMAT_RG32U, 1, 1);
 
@@ -118,7 +131,7 @@ class GSplatWorkBuffer {
         }
 
         // Create the optimized render pass for batched splat rendering
-        this.renderPass = new GSplatWorkBufferRenderPass(device);
+        this.renderPass = new GSplatWorkBufferRenderPass(device, this);
         this.renderPass.init(this.renderTarget);
     }
 

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -79,9 +79,10 @@ class GSplatResourceBase {
      * Get or create a QuadRender for rendering to work buffer.
      *
      * @param {boolean} useIntervals - Whether to use intervals.
+     * @param {number} colorTextureFormat - The format of the color texture (RGBA16F or RGBA16U).
      * @returns {WorkBufferRenderInfo} The WorkBufferRenderInfo instance.
      */
-    getWorkBufferRenderInfo(useIntervals) {
+    getWorkBufferRenderInfo(useIntervals, colorTextureFormat) {
 
         // configure defines to fetch cached data
         this.configureMaterialDefines(tempMap);
@@ -99,7 +100,7 @@ class GSplatResourceBase {
             tempMap.forEach((v, k) => material.setDefine(k, v));
 
             // create new cache entry
-            info = new WorkBufferRenderInfo(this.device, key, material);
+            info = new WorkBufferRenderInfo(this.device, key, material, colorTextureFormat);
             this.workBufferRenderInfos.set(key, info);
         }
 


### PR DESCRIPTION
- on WebGL2 when RGBA16F is not supported, use RGBA16U format to store colors for unified splats in the workbuffer