### PR TITLE
Cache RenderTarget dimensions and optimize resize

### DIFF
--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -136,6 +136,7 @@ class PostEffectQueue {
         rt.destroyTextureBuffers();
         rt._colorBuffer = this._allocateColorBuffer(format, name);
         rt._colorBuffers = [rt._colorBuffer];
+        rt.evaluateDimensions();
     }
 
     _destroyOffscreenTarget(rt) {

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -368,21 +368,24 @@ class Texture {
      */
     resize(width, height, depth = 1) {
 
-        // destroy texture impl
-        const device = this.device;
-        this.adjustVramSizeTracking(device._vram, -this._gpuSize);
-        this._gpuSize = 0;
-        this.impl.destroy(device);
-        this._clearLevels();
+        if (this.width !== width || this.height !== height || this.depth !== depth) {
 
-        this._width = Math.floor(width);
-        this._height = Math.floor(height);
-        this._depth = Math.floor(depth);
-        this._updateNumLevel();
+            // destroy texture impl
+            const device = this.device;
+            this.adjustVramSizeTracking(device._vram, -this._gpuSize);
+            this._gpuSize = 0;
+            this.impl.destroy(device);
+            this._clearLevels();
 
-        // re-create the implementation
-        this.impl = device.createTextureImpl(this);
-        this.dirtyAll();
+            this._width = Math.floor(width);
+            this._height = Math.floor(height);
+            this._depth = Math.floor(depth);
+            this._updateNumLevel();
+
+            // re-create the implementation
+            this.impl = device.createTextureImpl(this);
+            this.dirtyAll();
+        }
     }
 
     /**

--- a/src/scene/graphics/render-pass-color-grab.js
+++ b/src/scene/graphics/render-pass-color-grab.js
@@ -64,6 +64,9 @@ class RenderPassColorGrab extends RenderPass {
             // assign new texture
             renderTarget._colorBuffer = texture;
             renderTarget._colorBuffers = [texture];
+
+            // update cached dimensions
+            renderTarget.evaluateDimensions();
         } else {
 
             // create new render target with the texture

--- a/src/scene/graphics/render-pass-depth-grab.js
+++ b/src/scene/graphics/render-pass-depth-grab.js
@@ -63,6 +63,9 @@ class RenderPassDepthGrab extends RenderPass {
                 renderTarget._colorBuffers = [texture];
             }
 
+            // update cached dimensions
+            renderTarget.evaluateDimensions();
+
         } else {
 
             // create new render target with the texture


### PR DESCRIPTION
Caches width and height in RenderTarget to properly handle cases where multiple render targets share the same color or depth buffers.

Previously, first resized RT would resize the textures and internal RT data. The second resized RT would skip the resize as the already resized texture would early out as matching size.

Solution:
- Added _width and _height private members to cache the dimensions that framebuffers were built for
- Added evaluateDimensions() method to calculate and store dimensions from color/depth buffers with mipLevel adjustment
- Updated width and height getters to return cached values or fallback to device dimensions
- Optimized resize() to compare cached dimensions (what framebuffers were built for) against requested size, ensuring framebuffers are rebuilt when needed
- Fixed post-effect-queue.js, render-pass-depth-grab.js, and render-pass-color-grab.js to call evaluateDimensions() when manually updating render target buffers