### PR TITLE
Unified gsplat does not use material, avoid warning when cloning

### DIFF
--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -103,9 +103,11 @@ class GSplatComponentSystem extends ComponentSystem {
         const data = {};
         _properties.forEach((prop) => {
             if (prop === 'material') {
-                const srcMaterial = gSplatComponent[prop];
-                if (srcMaterial) {
-                    data[prop] = srcMaterial.clone();
+                if (!gSplatComponent.unified) { // unified gsplat does not use material
+                    const srcMaterial = gSplatComponent[prop];
+                    if (srcMaterial) {
+                        data[prop] = srcMaterial.clone();
+                    }
                 }
             } else {
                 data[prop] = gSplatComponent[prop];


### PR DESCRIPTION
When cloning gsplat component in unified mode, do not clone material to avoid warnings to be logged. Unified splats do not use the material and have different system.