### PR TITLE
Optimize Gaussian splat sorting to skip unnecessary updates

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -135,6 +135,7 @@ assetListLoader.load(() => {
     // enable rotation-based LOD updates and behind-camera penalty
     app.scene.gsplat.lodUpdateAngle = 90;
     app.scene.gsplat.lodBehindPenalty = 5;
+    app.scene.gsplat.radialSorting = true;
     app.scene.gsplat.lodUpdateDistance = config.lodUpdateDistance;
     app.scene.gsplat.lodUnderfillLimit = config.lodUnderfillLimit;
 


### PR DESCRIPTION
Optimizes unified splat sorting by only triggering it when necessary, rather than every frame.

Sorting now only executes when:
- A new world state is created (new LOD, gsplat added / removed ..)
- The camera has moved (position for radial sorting mode, direction for directional sorting mode)
- Any splat transform has changed

This is achieved through a `sortNeeded` flag that gets set when these conditions occur and reset after sorting is kicked off.

In this example:
<img width="1115" height="1259" alt="Screenshot 2025-11-04 at 16 34 00" src="https://github.com/user-attachments/assets/2af1d981-c721-4864-979b-13fa67108f41" />

two cameras are automatically orbiting, so 2 sorters run constantly
one camera is manually orbited in the middle of the capture, causing sorting during that time only

<img width="1154" height="454" alt="Screenshot 2025-11-04 at 16 36 04" src="https://github.com/user-attachments/assets/8dd1af27-0870-4bd3-8a2b-de65009ab5f1" />

In LOD-STREAMING example which uses radial sorting, looking around only sort occasionally when camera rotates enough to trigger LOD updates

<img width="851" height="892" alt="Screenshot 2025-11-04 at 16 39 22" src="https://github.com/user-attachments/assets/1d34226f-6009-4ba8-9346-305c545d2eb1" />

<img width="950" height="157" alt="Screenshot 2025-11-04 at 16 37 55" src="https://github.com/user-attachments/assets/48d2c779-e796-4722-87ae-caf3ae32afc6" />
