### PR TITLE
Fix spotlight rendering issues with small cone angles in clustered lighting

### DIFF
--- a/src/scene/lighting/lights-buffer.js
+++ b/src/scene/lighting/lights-buffer.js
@@ -15,7 +15,7 @@ const areaHalfAxisHeight = new Vec3(0, 0, 0.5);
 const TextureIndexFloat = {
     POSITION_RANGE: 0,              // positions.xyz, range
     DIRECTION_FLAGS: 1,             // spot direction.xyz, 32bit flags
-    COLOR_ANGLES_BIAS: 2,           // color.rgb, spot inner and outer, bias and normal bias (half floats format), 16bits unused
+    COLOR_ANGLES_BIAS: 2,           // x: color.rg, y: color.b & angle flags, z: cone angles, w: biases (all packed as 16-bit values)
 
     PROJ_MAT_0: 3,                  // projection matrix row 0 (spot light)
     ATLAS_VIEWPORT: 3,              // atlas viewport data (omni light)


### PR DESCRIPTION
related to https://github.com/playcanvas/engine/issues/8058 (does not fix it, but improves it - the leak is constant instead of precision based)

Fixes spotlights with very small cone angles (< 1.3 degrees) failing to render in clustered lighting due to half-float precision loss.
Implemented hybrid versine/cosine encoding: for small angles (cos > 0.5), store 1.0 - cos(angle) (versine) which has better precision near 0.0. For large angles, store cos(angle) directly. Uses 2 integer flag bits to indicate encoding format, with 14 bits reserved for future flags.