### PR TITLE
GSplat LOD format supports environment tag

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
@@ -49,8 +49,7 @@ app.on('destroy', () => {
 // Skatepark configuration
 const config = {
     name: 'Skatepark',
-    url: 'https://code.playcanvas.com/examples_data/example_skatepark_01/lod-meta.json',
-    environment: 'https://code.playcanvas.com/examples_data/example_skatepark_01/environment.sog',
+    url: 'https://code.playcanvas.com/examples_data/example_skatepark_02/lod-meta.json',
     lodUpdateDistance: 1,
     lodUnderfillLimit: 10,
     cameraPosition: [32, 2, 2],
@@ -93,11 +92,6 @@ const assets = {
         { type: pc.TEXTURETYPE_RGBP, mipmaps: false }
     )
 };
-
-// Add environment asset if specified in config
-if (config.environment) {
-    assets.environment = new pc.Asset('gsplat-environment', 'gsplat', { url: config.environment });
-}
 
 const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
 assetListLoader.load(() => {
@@ -158,19 +152,6 @@ assetListLoader.load(() => {
 
     applyPreset();
     data.on('lodPreset:set', applyPreset);
-
-    // Add environment gsplat if specified
-    if (assets.environment) {
-        const envEntity = new pc.Entity('gsplat-environment');
-        envEntity.addComponent('gsplat', {
-            asset: assets.environment,
-            unified: true
-        });
-        envEntity.setLocalPosition(0, 0, 0);
-        envEntity.setLocalEulerAngles(rotX, rotY, rotZ);
-        envEntity.setLocalScale(1, 1, 1);
-        app.root.addChild(envEntity);
-    }
 
     // Create a camera with fly controls
     const camera = new pc.Entity('camera');

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -62,8 +62,7 @@ app.on('destroy', () => {
 // original dataset: https://www.youtube.com/watch?v=3RtY_cLK13k
 const config = {
     name: 'Roman-Parish',
-    url: 'https://code.playcanvas.com/examples_data/example_roman_parish_01/lod-meta.json',
-    environment: 'https://code.playcanvas.com/examples_data/example_roman_parish_01/environment.sog',
+    url: 'https://code.playcanvas.com/examples_data/example_roman_parish_02/lod-meta.json',
     lodUpdateDistance: 0.5,
     lodUnderfillLimit: 5,
     cameraPosition: [10.3, 2, -10],
@@ -106,11 +105,6 @@ const assets = {
         { type: pc.TEXTURETYPE_RGBP, mipmaps: false }
     )
 };
-
-// Add environment asset if specified in config
-if (config.environment) {
-    assets.environment = new pc.Asset('gsplat-environment', 'gsplat', { url: config.environment });
-}
 
 const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
 assetListLoader.load(() => {
@@ -171,19 +165,6 @@ assetListLoader.load(() => {
 
     applyPreset();
     data.on('lodPreset:set', applyPreset);
-
-    // Add environment gsplat if specified
-    if (assets.environment) {
-        const envEntity = new pc.Entity('gsplat-environment');
-        envEntity.addComponent('gsplat', {
-            asset: assets.environment,
-            unified: true
-        });
-        envEntity.setLocalPosition(0, 0, 0);
-        envEntity.setLocalEulerAngles(rotX, rotY, rotZ);
-        envEntity.setLocalScale(1, 1, 1);
-        app.root.addChild(envEntity);
-    }
 
     // Create a camera with fly controls
     const camera = new pc.Entity('camera');


### PR DESCRIPTION
- streaming LOD json format supports `environment` tag, representing a relative url to a gsplat resource representing non-loaded part of the environment (typically skydome / distant splats). This is optional, and lod system loads it if specified.
- updated two streaming examples to use this new format instead of manually loading environment

example:
```
{
  "lodLevels": 1,
  "filenames": [
    "0_0/meta.json"
  ],
  "environment": "environment/environment.sog",
  "tree": {
    "bound": {
      "min": [-10, -10, -10],
      "max": [10, 10, 10]
    },
    "lods": {
      "0": {
        "file": 0,
        "offset": 0,
        "count": 1000
      }
    }
  }
}
```