### PR TITLE
[Fix] restore mouse movement in pointer lock mode

### DIFF
--- a/src/extras/input/sources/keyboard-mouse-source.js
+++ b/src/extras/input/sources/keyboard-mouse-source.js
@@ -206,9 +206,9 @@ class KeyboardMouseSource extends InputSource {
      */
     _onPointerMove(event) {
         // Use native movementX/Y when pointer lock is active, otherwise use custom calculation
-        const [movementX, movementY] = this._pointerLock && document.pointerLockElement === this._element
-            ? [event.movementX, event.movementY]
-            : this._movementState.move(event);
+        const [movementX, movementY] = this._pointerLock && document.pointerLockElement === this._element ?
+            [event.movementX, event.movementY] :
+            this._movementState.move(event);
 
         if (event.pointerType !== 'mouse') {
             return;


### PR DESCRIPTION
Fixes #8112

### Problem
Mouse movement stopped working in the camera/first-person example after #8057 was merged. The camera would no longer respond to mouse input when pointer lock was enabled.

### Root Cause
PR #8057 introduced a custom wrapper to calculate `movementX` and `movementY` by tracking the difference between consecutive `screenX` and `screenY` coordinates. However, when pointer lock is active, the cursor position is locked and `screenX`/`screenY` values remain constant. This caused the calculation to always return `[0, 0]`, making the camera unresponsive to mouse movement.

### Solution
Modified `KeyboardMouseSource._onPointerMove()` to use native `event.movementX` and `event.movementY` when pointer lock is active, as these values correctly represent raw mouse movement in pointer lock mode. The custom calculation is still used as a fallback for non-pointer-lock scenarios (where it was intended to work).

### Testing
- Verified mouse movement works correctly in the first-person camera example with pointer lock enabled
- Custom calculation still works for non-pointer-lock mouse capture scenarios