### PR TITLE
[Fix] Fixed gsplat shader effect to handle limit to a camera

### DIFF
--- a/scripts/esm/gsplat/gsplat-shader-effect.mjs
+++ b/scripts/esm/gsplat/gsplat-shader-effect.mjs
@@ -198,9 +198,10 @@ class GsplatShaderEffect extends Script {
 
         // Determine which cameras to target
         let targetCameras;
-        if (this.camera && this.camera.camera && this.camera.camera.camera) {
+        const cam = this.camera?.camera?.camera;
+        if (cam) {
             // Specific camera specified via attribute
-            targetCameras = [this.camera.camera.camera];
+            targetCameras = [cam];
         } else {
             // All cameras in the composition
             targetCameras = composition.cameras.map(cameraComponent => cameraComponent.camera);


### PR DESCRIPTION
Fix to how the `camera` attribute of gsplat shader effect is used.

Typically, only a single camera is used, and so it does not need to be set. But when it's set to limit the effect to a single camera, there was a small bug and the effect would not be applied.