### PR TITLE
Refactor gsplat shader chunks: move helpers and customize to common

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
@@ -1,6 +1,4 @@
 export default /* glsl */`
-#include "gsplatHelpersVS"
-#include "gsplatCustomizeVS"
 #include "gsplatCommonVS"
 
 varying mediump vec2 gaussianUV;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCommon.js
@@ -1,4 +1,6 @@
 export default /* glsl */`
+#include "gsplatHelpersVS"
+#include "gsplatCustomizeVS"
 
 #include "gsplatStructsVS"
 #include "gsplatEvalSHVS"

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
@@ -1,7 +1,4 @@
 export default /* wgsl */`
-
-#include "gsplatHelpersVS"
-#include "gsplatCustomizeVS"
 #include "gsplatCommonVS"
 
 varying gaussianUV: vec2f;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCommon.js
@@ -1,4 +1,6 @@
 export default /* wgsl */`
+#include "gsplatHelpersVS"
+#include "gsplatCustomizeVS"
 
 #include "gsplatStructsVS"
 #include "gsplatEvalSHVS"


### PR DESCRIPTION
Consolidates gsplat shader includes by moving gsplatHelpersVS and gsplatCustomizeVS 
from gsplatVS into gsplatCommonVS. This simplifies the include structure, as gsplatVS 
now only needs to include gsplatCommonVS to get all dependencies. Changes applied to 
both GLSL and WGSL shader systems.