### PR TITLE
Fix PBO texture uploads by ensuring correct texture binding state

### DIFF
--- a/src/platform/graphics/webgl/webgl-upload-stream.js
+++ b/src/platform/graphics/webgl/webgl-upload-stream.js
@@ -153,6 +153,8 @@ class WebglUploadStream {
         // Ensure texture is created and bound
         // @ts-ignore - setTexture is available on WebglGraphicsDevice
         device.setTexture(target, 0);
+        device.activeTexture(0);
+        device.bindTexture(target);
 
         // Rebind PBO for texSubImage2D
         gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, pboInfo.pbo);
@@ -160,7 +162,9 @@ class WebglUploadStream {
         // Set pixel-store parameters (use device methods for cached state)
         device.setUnpackFlipY(false);
         device.setUnpackPremultiplyAlpha(false);
-        gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
+
+        // Use alignment matching the data's byte size (1, 2, 4, or 8)
+        gl.pixelStorei(gl.UNPACK_ALIGNMENT, data.BYTES_PER_ELEMENT);
         gl.pixelStorei(gl.UNPACK_ROW_LENGTH, 0);
         gl.pixelStorei(gl.UNPACK_SKIP_ROWS, 0);
         gl.pixelStorei(gl.UNPACK_SKIP_PIXELS, 0);


### PR DESCRIPTION
Fixes a `GL_INVALID_OPERATION` error when uploading R32UI texture data via PBOs on certain Android devices (e.g., Google Pixel 8).

```
[.WebGL-0x6c0056f800]GL ERROR :GL_INVALID_OPERATION : glTexSubImage2D: 
invalid internalformat/format/type combination GL_RGBA32UI/GL_RED_INTEGER/GL_UNSIGNED_INT
```

- Add explicit texture rebinding before PBO upload using device state management methods to ensure the correct texture is bound

- Also use `data.BYTES_PER_ELEMENT` for `UNPACK_ALIGNMENT` instead of hardcoded value, ensuring proper alignment for all typed array types - but this has no impact here, but is a good practice.
