### PR TITLE
Fix unified gsplat rendering when viewport is resized

### DIFF
--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -522,6 +522,9 @@ class GSplatManager {
         // apply any pending sorted results
         this.sorter.applyPendingSorted();
 
+        // update viewport for renderer
+        this.renderer.updateViewport(this.cameraNode);
+
         let fullUpdate = false;
         this.framesTillFullUpdate--;
         if (this.framesTillFullUpdate <= 0) {
@@ -763,7 +766,6 @@ class GSplatManager {
         });
 
         this.sorter.setSortParams(sorterRequest, this.scene.gsplat.radialSorting);
-        this.renderer.updateViewport(cameraNode);
     }
 
     /**


### PR DESCRIPTION
- now that sorting takes place only if needed, moved viewport update code to per-frame function instead
- this fixes the issue mentioned in this (and above) comments: https://github.com/playcanvas/engine/issues/7993#issuecomment-3548821754