### PR TITLE
Update the device-cache system so its no longer relies on memory addresses

### DIFF
--- a/src/platform/graphics/device-cache.js
+++ b/src/platform/graphics/device-cache.js
@@ -26,7 +26,7 @@ class DeviceCache {
     get(device, onCreate) {
         const cacheId = device?.canvas.id
         // Check if the device has a canvas, and if the canvas has a non null id
-        Debug.assert(cacheId, 'Canvas element should have a unique id')
+        Debug.assert(cacheId  || device.isNull, 'Canvas element should have a unique id')
 
         if (!this._cache.has(cacheId)) {
             Debug.assert(onCreate, 'No cached device has been found and create callback is invalid ')


### PR DESCRIPTION
This PR attempts to fix #8107 when the app object is used  behind a proxy (ex: vue / solidjs).
The cache system use the `canvas.id` as key instead of the memory address of the object.
Maybe it would be useful to fallback on memory address if canvas has undefined id.

Is also add an assertion for to check if onCreate callback  is properly defined when no cached device exists.