### PR TITLE
GSplat streaming lod - used memory optimization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,14 @@ class Resource {
 }
 ```
 
+### 17. Root Cause Analysis
+
+Always address the root cause of issues rather than implementing workarounds that hide or suppress problems:
+
+- **Identify the root cause**: When you encounter an error or unexpected behavior, investigate why it's happening
+- **Don't mask symptoms**: Avoid solutions that simply hide errors or suppress warnings without fixing the underlying issue
+- **Fix at the source**: When you identify the root cause, fix it where the problem originates, not where it manifests
+
 ## Things to Avoid
 
 ### 18. Anti-Patterns

--- a/src/framework/components/gsplat/gsplat-asset-loader.js
+++ b/src/framework/components/gsplat/gsplat-asset-loader.js
@@ -133,7 +133,8 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
 
             if (!asset) {
                 // Create a new gsplat asset
-                asset = new Asset(url, 'gsplat', { url });
+                // @ts-ignore - minimalMemory is a custom option for gsplat assets
+                asset = new Asset(url, 'gsplat', { url }, {}, { minimalMemory: true });
                 this._registry.add(asset);
             }
 

--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -249,7 +249,11 @@ class SogBundleParser {
             });
 
             // construct the gsplat resource
+            const decompress = asset.data?.decompress;
+            const minimalMemory = asset.options?.minimalMemory ?? false;
+
             const data = new GSplatSogsData();
+            data.minimalMemory = minimalMemory;
             data.meta = meta;
             data.numSplats = meta.count;
             data.means_l = textures[meta.means.files[0]].resource;
@@ -259,8 +263,6 @@ class SogBundleParser {
             data.sh0 = textures[meta.sh0.files[0]].resource;
             data.sh_centroids = textures[meta.shN?.files[0]]?.resource;
             data.sh_labels = textures[meta.shN?.files[1]]?.resource;
-
-            const decompress = asset.data?.decompress;
 
             if (!decompress) {
                 // no need to prepare gpu data if decompressing

--- a/src/framework/parsers/sogs.js
+++ b/src/framework/parsers/sogs.js
@@ -166,6 +166,10 @@ class SogsParser {
         data.sh_labels = textures.shN?.[1]?.resource;
 
         const decompress = asset.data?.decompress;
+        const minimalMemory = asset.options?.minimalMemory ?? false;
+
+        // Pass minimalMemory to data
+        data.minimalMemory = minimalMemory;
 
         if (!decompress) {
             if (!this.app?.graphicsDevice || this.app?.graphicsDevice?._destroyed) return;

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -193,7 +193,7 @@ class GSplatManager {
 
                 // make sure octree instance exists for placement
                 if (!this.octreeInstances.has(p)) {
-                    this.octreeInstances.set(p, new GSplatOctreeInstance(p.resource.octree, p, this.director.assetLoader));
+                    this.octreeInstances.set(p, new GSplatOctreeInstance(this.device, p.resource.octree, p, this.director.assetLoader));
 
                     // mark that we have new instances that need initial LOD evaluation
                     this.hasNewOctreeInstances = true;
@@ -703,7 +703,7 @@ class GSplatManager {
                 const octree = inst.octree;
                 if (!tempOctreesTicked.has(octree)) {
                     tempOctreesTicked.add(octree);
-                    octree.updateCooldownTick(this.director.assetLoader);
+                    octree.updateCooldownTick();
                 }
             }
             tempOctreesTicked.clear();

--- a/src/scene/gsplat/gsplat-sogs-data.js
+++ b/src/scene/gsplat/gsplat-sogs-data.js
@@ -22,6 +22,10 @@ import wgslGsplatPackingPS from '../shader-lib/wgsl/chunks/gsplat/frag/gsplatPac
 import glslSogsCentersPS from '../shader-lib/glsl/chunks/gsplat/frag/gsplatSogsCenters.js';
 import wgslSogsCentersPS from '../shader-lib/wgsl/chunks/gsplat/frag/gsplatSogsCenters.js';
 
+/**
+ * @import { EventHandle } from '../../core/event-handle.js'
+ */
+
 const SH_C0 = 0.28209479177387814;
 
 const readImageDataAsync = (texture) => {
@@ -181,6 +185,20 @@ class GSplatSogsData {
     packedShN;
 
     /**
+     * Whether to use minimal memory mode (releases source textures after packing).
+     *
+     * @type {boolean}
+     */
+    minimalMemory = false;
+
+    /**
+     * Event handle for devicerestored listener (when minimalMemory is false).
+     *
+     * @type {EventHandle|null}
+     */
+    deviceRestoredEvent = null;
+
+    /**
      * Cached centers array (x, y, z per splat), length = numSplats * 3.
      *
      * @type {Float32Array | null}
@@ -205,6 +223,10 @@ class GSplatSogsData {
     }
 
     destroy() {
+        // Remove devicerestored listener if it was registered
+        this.deviceRestoredEvent?.off();
+        this.deviceRestoredEvent = null;
+
         this.destroyed = true;
         this._destroyGpuResources();
     }
@@ -534,12 +556,16 @@ class GSplatSogsData {
             mipmaps: false
         });
 
-        device.on('devicerestored', () => {
-            this.packGpuMemory();
-            if (this.packedShN) {
-                this.packShMemory();
-            }
-        });
+        if (!this.minimalMemory) {
+
+            // when context is restored, pack the gpu data again
+            this.deviceRestoredEvent = device.on('devicerestored', () => {
+                this.packGpuMemory();
+                if (this.packedShN) {
+                    this.packShMemory();
+                }
+            });
+        }
 
         // patch codebooks starting with a null entry
         ['scales', 'sh0', 'shN'].forEach((name) => {
@@ -557,6 +583,25 @@ class GSplatSogsData {
         if (this.packedShN) {
             if (this.destroyed || device._destroyed) return; // skip the rest if the resource was destroyed
             this.packShMemory();
+        }
+
+        if (this.minimalMemory) {
+            // Release source textures to save memory
+            this.means_l?.destroy();
+            this.means_u?.destroy();
+            this.quats?.destroy();
+            this.scales?.destroy();
+            this.sh0?.destroy();
+            this.sh_centroids?.destroy();
+            this.sh_labels?.destroy();
+
+            this.means_l = null;
+            this.means_u = null;
+            this.quats = null;
+            this.scales = null;
+            this.sh0 = null;
+            this.sh_centroids = null;
+            this.sh_labels = null;
         }
     }
 


### PR DESCRIPTION
Streaming LOD system uses dynamically loaded SOG format data. Internally, this is converted to a packed format for performance, but original data was left in memory for the case of lost context on the device. In that case, the original data was converted to packed format when the device was restored. This consumes memory which is only used in case of device lost.

This PR implements a solution, where those allocations are removed. When the context is lost, the octree is marked as unloaded, and when the context is restored, the octree reloads resources from url's as originally.

Used VRAM improvements in the streaming-lod example:
<img width="486" height="111" alt="Screenshot 2025-11-24 at 09 48 05" src="https://github.com/user-attachments/assets/773885ee-b5fc-4f8e-913d-58809af472fd" />
