### PR TITLE
[Fix] improve error messages for script attribute validation

### DIFF
--- a/src/framework/script/script-attributes.js
+++ b/src/framework/script/script-attributes.js
@@ -323,6 +323,16 @@ class ScriptAttributes {
      * });
      */
     add(name, args) {
+        if (!args) {
+            Debug.error(`Cannot add attribute '${name}' to script type '${this.scriptType.name}': args parameter is required`);
+            return;
+        }
+
+        if (!args.type) {
+            Debug.error(`Cannot add attribute '${name}' to script type '${this.scriptType.name}': args.type is required`);
+            return;
+        }
+
         if (this.index[name]) {
             Debug.warn(`attribute '${name}' is already defined for script type '${this.scriptType.name}'`);
             return;


### PR DESCRIPTION
Fixes: https://github.com/playcanvas/engine/issues/7906

Improves error messages when `ScriptAttributes.add()` is called with missing or invalid parameters. Previously, calling `attributes.add('test')` without required arguments would result in a cryptic internal error. Now it shows clear, actionable error messages.
