### PR TITLE
Add GSplat to ComponentSystemRegistry

### DIFF
--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -8,6 +8,7 @@ import { EventHandler } from '../../core/event-handler.js';
  * @import { CameraComponentSystem } from './camera/system.js'
  * @import { CollisionComponentSystem } from './collision/system.js'
  * @import { ElementComponentSystem } from './element/system.js'
+ * @import { GSplatComponentSystem } from './gsplat/system.js'
  * @import { JointComponentSystem } from './joint/system.js'
  * @import { LayoutChildComponentSystem } from './layout-child/system.js'
  * @import { LayoutGroupComponentSystem } from './layout-group/system.js'
@@ -94,6 +95,14 @@ class ComponentSystemRegistry extends EventHandler {
      * @readonly
      */
     element;
+
+    /**
+     * Gets the {@link GSplatComponentSystem} from the registry.
+     *
+     * @type {GSplatComponentSystem|undefined}
+     * @readonly
+     */
+    gsplat;
 
     /**
      * Gets the {@link JointComponentSystem} from the registry.


### PR DESCRIPTION
This enables developers to access the GSplat component system through the standard app systems registry, consistent with other component systems like `app.systems.model` or `app.systems.camera`.

**Public API Changes:**
- Added `ComponentSystemRegistry.gsplat` property of type `GSplatComponentSystem|undefined`