### PR TITLE
Use AssetListLoader to load assets in AppBase.preload

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -708,7 +708,7 @@ class AppBase extends EventHandler {
         this.fire('preload:start');
 
         // get list of assets to preload
-        const assets = this.assets.filter(asset => asset.preload === true && asset.loaded === false)
+        const assets = this.assets.filter(asset => asset.preload === true && asset.loaded === false);
 
         if (assets.length === 0) {
             this.fire('preload:end');

--- a/test/framework/application.test.mjs
+++ b/test/framework/application.test.mjs
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 
+import { Asset } from '../../src/framework/asset/asset.js';
 import { AssetRegistry } from '../../src/framework/asset/asset-registry.js';
 import { ComponentSystemRegistry } from '../../src/framework/components/registry.js';
 import { FILLMODE_KEEP_ASPECT, RESOLUTION_FIXED } from '../../src/framework/constants.js';
@@ -19,6 +20,7 @@ import { jsdomSetup, jsdomTeardown } from '../jsdom.mjs';
 describe('Application', function () {
 
     let app;
+    const assetPath = 'http://localhost:3000/test/assets/';
 
     beforeEach(function () {
         jsdomSetup();
@@ -85,6 +87,45 @@ describe('Application', function () {
             // expect(app.xr).to.be.null;
 
             app = null;
+        });
+
+    });
+
+    describe('#preload', function () {
+
+        it('should preload assets with preload set to true', function (done) {
+            const assets = [
+                new Asset('model', 'container', { url: `${assetPath}test.glb` }),
+                new Asset('styling', 'css', { url: `${assetPath}test.css` })
+            ];
+            assets.forEach((asset) => {
+                asset.preload = true;
+                app.assets.add(asset);
+            });
+
+            app.preload(function () {
+                assets.forEach((asset) => {
+                    expect(asset.loaded).to.be.true;
+                });
+                done();
+            });
+        });
+
+        it('should not preload assets with preload set to false', function (done) {
+            const assets = [
+                new Asset('model', 'container', { url: `${assetPath}test.glb` }),
+                new Asset('styling', 'css', { url: `${assetPath}test.css` })
+            ];
+            assets.forEach((asset) => {
+                app.assets.add(asset);
+            });
+
+            app.preload(function () {
+                assets.forEach((asset) => {
+                    expect(asset.loaded).to.be.false;
+                });
+                done();
+            });
         });
 
     });

--- a/test/framework/application.test.mjs
+++ b/test/framework/application.test.mjs
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import { Asset } from '../../src/framework/asset/asset.js';
 import { AssetRegistry } from '../../src/framework/asset/asset-registry.js';
+import { Asset } from '../../src/framework/asset/asset.js';
 import { ComponentSystemRegistry } from '../../src/framework/components/registry.js';
 import { FILLMODE_KEEP_ASPECT, RESOLUTION_FIXED } from '../../src/framework/constants.js';
 import { Entity } from '../../src/framework/entity.js';


### PR DESCRIPTION
## Description
Uses AssetListLoader in AppBase.preload to load assets marked as preload.

I also changed the fetching of assets to filter by loaded as well. By the time preload is called some assets might already be loaded. (Wasm modules, as well as some assets which are already loading because they were added to the asset registry. See #3107)

Also added tests for preload

Fixes #4185

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
