### PR TITLE
Fix Screen.priority signed integer overflow

### DIFF
--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -1,4 +1,5 @@
 import { Debug } from '../../../core/debug.js';
+import { math } from '../../../core/math/math.js';
 import { Mat4 } from '../../../core/math/mat4.js';
 import { Vec2 } from '../../../core/math/vec2.js';
 import { Entity } from '../../entity.js';
@@ -355,16 +356,14 @@ class ScreenComponent extends Component {
 
     /**
      * Sets the screen's render priority. Priority determines the order in which ScreenComponents
-     * in the same layer are rendered. Number must be an integer between 0 and 255. Priority is set
+     * in the same layer are rendered. Number must be an integer between 0 and 127. Priority is set
      * into the top 8 bits of the {@link ElementComponent#drawOrder} property. Defaults to 0.
      *
      * @type {number}
      */
     set priority(value) {
-        if (value > 0xFF) {
-            Debug.warn(`Clamping screen priority from ${value} to 255`);
-            value = 0xFF;
-        }
+        Debug.assert(value >= 0 && value <= 0x7F, `Screen priority must be between 0 and 127, got ${value}`);
+        value = math.clamp(value, 0, 0x7F);
         if (this._priority === value) {
             return;
         }


### PR DESCRIPTION
## Overview

report: https://forum.playcanvas.com/t/wrong-documentation/41378
Fixes https://github.com/playcanvas/engine/issues/8179

Fixes a sorting issue where Screen components with priority values >= 128 would render incorrectly due to signed integer overflow when the priority is shifted into the drawOrder value.

## Problem

When Screen.priority values >= 128 were used, the bitwise left shift operation (`priority << 24`) would set bit 31 (the sign bit), creating negative drawOrder values. This caused sorting comparisons to fail when mixing screens with priorities above and below 128, resulting in incorrect render order.

## Solution

Changed the valid priority range from 0-255 to 0-127, preventing the sign bit from ever being set. This ensures all drawOrder values remain positive and sortable.

## Public API Changes

**Breaking Change**: `ScreenComponent.priority` valid range reduced from 0-255 to 0-127

- Note - this is breaking, but not really, as the changed part was never working correctly.
- Values outside the range 0-127 will trigger a debug assertion
- Values are automatically clamped to the valid range (0-127)
