### PR TITLE
[FIX] Address race condition when loading example code

### DIFF
--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -170,7 +170,8 @@ class ExampleLoader {
         }
 
         if (this._app) {
-            if (this._app.frame) {
+            // Check if app has already started (frame is a number, including 0)
+            if (this._app.frame !== undefined) {
                 this._appStart();
             } else {
                 this._app.once('start', () => this._appStart());


### PR DESCRIPTION
## Description

Fix examples browser code panel showing `// reloading` for some examples

### Issue

Some examples (like Hello World) showed `// reloading` instead of code, while others (like Multi App) worked correctly.

### Root Cause

Race condition in the iframe loader checking if an app has started:

```js
if (this._app.frame) {  // Bug: 0 is falsy!
```

When `app.start()` is called, it sets `frame = 0`. Since `0` is falsy, the condition failed and the loader missed the 'start' event.

### Fix

`if (this._app.frame !== undefined) {` 

Now properly detects when the app has started, regardless of the frame number.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
