### PR TITLE
Removed unused react-es6 package from examples

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -34,7 +34,6 @@
         "puppeteer": "24.31.0",
         "react": "19.2.0",
         "react-dom": "19.2.0",
-        "react-es6": "1.0.2",
         "react-router-dom": "7.9.6",
         "rollup": "4.53.3",
         "serve": "14.2.5",
@@ -5386,13 +5385,6 @@
       "peerDependencies": {
         "react": "^19.2.0"
       }
-    },
-    "node_modules/react-es6": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-es6/-/react-es6-1.0.2.tgz",
-      "integrity": "sha512-Nw4SDw6JB87+qWwltgyKPQwepxIZ5LrANenBUh+PO6ofUVaml+fBRr8RGakFFVqB7vITKPARmjxpKfdTFAQE9Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/examples/package.json
+++ b/examples/package.json
@@ -40,7 +40,6 @@
     "puppeteer": "24.31.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-es6": "1.0.2",
     "react-router-dom": "7.9.6",
     "rollup": "4.53.3",
     "serve": "14.2.5",


### PR DESCRIPTION
## Description
- Removed unused react-es6 package from examples

Fixes #

## Checklist
- [ ] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [ ] My code follows the project's coding standards
- [ ] This PR focuses on a single change
