### PR TITLE
Added tracing support to log all assets in the registry

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -140,6 +140,13 @@ export const TRACEID_ELEMENT = 'Element';
 export const TRACEID_TEXTURES = 'Textures';
 
 /**
+ * Logs all assets in the asset registry.
+ *
+ * @category Debug
+ */
+export const TRACEID_ASSETS = 'Assets';
+
+/**
  * Logs the render queue commands.
  *
  * @category Debug

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -42,6 +42,7 @@ class Tracing {
      * - {@link TRACEID_COMPUTEPIPELINE_ALLOC}
      * - {@link TRACEID_PIPELINELAYOUT_ALLOC}
      * - {@link TRACEID_TEXTURES}
+     * - {@link TRACEID_ASSETS}
      * - {@link TRACEID_GPU_TIMINGS}
      *
      * @param {boolean} enabled - New enabled state for the channel.

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1025,6 +1025,10 @@ class AppBase extends EventHandler {
     update(dt) {
         this.frame++;
 
+        Debug.call(() => {
+            this.assets.log();
+        });
+
         this.graphicsDevice.update();
 
         // #if _PROFILER


### PR DESCRIPTION
example of use:
```
pc.Tracing.set(pc.TRACEID_ASSETS, true);
```

example of output:
<img width="716" height="324" alt="Screenshot 2025-12-02 at 11 19 05" src="https://github.com/user-attachments/assets/381e4265-2587-426b-ab71-904f058a8f26" />
