### PR TITLE
Fix null values in asset cache for ESM scripts causing error

### DIFF
--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -467,8 +467,7 @@ class AssetRegistry extends EventHandler {
                         document.head.removeChild(handler._cache[asset.id]);
                     }
                     // prevents setting a null value in cache for esm scripts
-                    const isEsmScript = asset.file.filename.endsWith('.mjs');
-                    if(!isEsmScript && extra) {
+                    if (extra) {
                         handler._cache[asset.id] = extra;
                     }
                 }


### PR DESCRIPTION
## Description
This PR adds a check whether or not a loaded script asset is an ESM script. If so, it does not set the value of the `extra` variable in `AssetRegistry::loaded::_loaded` (which is null for ESM scripts) as the value in `ScriptHandler._cache[asset.id]`. This avoids an uncaught error later when calling `app.destroy()`, which calls `scriptHandler?.clearCache();`.

Fixes #8220

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
