### PR TITLE
Outline renderer WGSL chunk 

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1256,6 +1256,10 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         return true;
     }
 
+    get hasTranspilers() {
+        return this.glslang && this.twgsl;
+    }
+
     // #if _DEBUG
     pushMarker(name) {
         this.passEncoder?.pushDebugGroup(name);

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -104,7 +104,15 @@ class LitShader {
 
         // shader language
         const userChunks = options.shaderChunks;
-        this.shaderLanguage = (device.isWebGPU && allowWGSL && userChunks?.useWGSL) ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL;
+        this.shaderLanguage = (device.isWebGPU && allowWGSL && (!userChunks || userChunks.useWGSL)) ? SHADERLANGUAGE_WGSL : SHADERLANGUAGE_GLSL;
+
+        if (device.isWebGPU && this.shaderLanguage === SHADERLANGUAGE_GLSL) {
+            if (!device.hasTranspilers) {
+                Debug.errorOnce('Cannot use GLSL shader on WebGPU without transpilers', {
+                    litShader: this
+                });
+            }
+        }
 
         // resolve custom chunk attributes
         this.attributes = {


### PR DESCRIPTION
- outline renderer uses WGSL chunk to avoid transpilation
- also added error report when standard material generates GLSL shader on WebGPU device without transpilers, as this is hard to find otherwise