### PR TITLE
[Fix] Specify anonymous cross origin for gsplat assets to avoid security issues on iOS

### DIFF
--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -210,6 +210,8 @@ class SogBundleParser {
                         contents: file.data
                     }, {
                         mipmaps: false
+                    }, {
+                        crossOrigin: 'anonymous'
                     });
                 } else {
                     // file doesn't exist in bundle, treat it as a url
@@ -219,6 +221,8 @@ class SogBundleParser {
                         filename
                     }, {
                         mipmaps: false
+                    }, {
+                        crossOrigin: 'anonymous'
                     });
                 }
 

--- a/src/framework/parsers/sogs.js
+++ b/src/framework/parsers/sogs.js
@@ -133,6 +133,8 @@ class SogsParser {
                     filename
                 }, {
                     mipmaps: false
+                }, {
+                    crossOrigin: 'anonymous'
                 });
 
                 const promise = new Promise((resolve, reject) => {


### PR DESCRIPTION
Fix SecurityError when loading SOGS Gaussian Splats on iPhone/Safari

Fixed a cross-origin security error that prevented SOGS (compressed) Gaussian Splat assets from loading on iPhone and Safari browsers.

## Changes

- Added `crossOrigin: 'anonymous'` option when creating texture assets in SOGS parser
- Added `crossOrigin: 'anonymous'` option when creating texture assets in SOG bundle parser

## Technical Details

Safari/iOS strictly enforces cross-origin security when reading pixel data from images via `texture.read()`. The SOGS loader needs to read texture pixel data during the `generateCenters()` process, which requires the `crossOrigin` attribute to be set for cross-origin textures.

Without this attribute, Safari throws a SecurityError: "The operation is insecure" and prevents the textures from loading, causing the entire Gaussian Splat asset to fail.
