### PR TITLE
Fix uninitialized SplatCenter members in GLSL gsplat shader

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCenter.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCenter.js
@@ -7,7 +7,7 @@ uniform vec4 camera_params;             // 1 / far, far, near, isOrtho
 #endif
 
 // project the model space gaussian center to view and clip space
-bool initCenter(vec3 modelCenter, out SplatCenter center) {
+bool initCenter(vec3 modelCenter, inout SplatCenter center) {
     mat4 modelView = matrix_view * matrix_model;
     vec4 centerView = modelView * vec4(modelCenter, 1.0);
 


### PR DESCRIPTION
Fixed a bug in the GLSL gaussian splatting shader where `initCenter` was using an `out` parameter instead of `inout` for the `SplatCenter` struct.

**Details:**
- In GLSL, `out` parameters are uninitialized on function entry, causing any values assigned to `SplatCenter` members (specifically `modelCenterOriginal` and `modelCenterModified`) prior to the call to be discarded.
- This prevented custom shader effects that rely on the original or modified center positions (such as cropping or masking effects) from working correctly in WebGL.
- Changed the parameter qualifier to `inout` to preserve the pre-initialized values, matching the behavior of the WebGPU implementation.