### PR TITLE
Updated Ministats with additional timings

### DIFF
--- a/examples/src/examples/gaussian-splatting/shader-effects.example.mjs
+++ b/examples/src/examples/gaussian-splatting/shader-effects.example.mjs
@@ -278,16 +278,6 @@ assetListLoader.load(() => {
     camera.script?.create('orbitCameraInputTouch');
     app.root.addChild(camera);
 
-    // Setup bloom post-processing
-    if (camera.camera) {
-        const cameraFrame = new pc.CameraFrame(app, camera.camera);
-        cameraFrame.rendering.samples = 4;
-        cameraFrame.rendering.toneMapping = pc.TONEMAP_ACES;
-        cameraFrame.bloom.intensity = 0.03;
-        cameraFrame.bloom.blurLevel = 6;
-        cameraFrame.update();
-    }
-
     // Auto-rotate camera when idle
     let autoRotateEnabled = true;
     let lastInteractionTime = 0;

--- a/examples/src/examples/graphics/shadow-soft.example.mjs
+++ b/examples/src/examples/graphics/shadow-soft.example.mjs
@@ -150,7 +150,7 @@ assetListLoader.load(() => {
     app.root.addChild(camera);
 
     // Create a directional light casting soft shadows
-    const dirLight = new pc.Entity('Cascaded Light');
+    const dirLight = new pc.Entity('MainLight');
     dirLight.addComponent('light', {
         ...{
             type: 'directional',

--- a/src/extras/mini-stats/render2d.js
+++ b/src/extras/mini-stats/render2d.js
@@ -19,6 +19,16 @@ import { VertexBuffer } from '../../platform/graphics/vertex-buffer.js';
 import { VertexFormat } from '../../platform/graphics/vertex-format.js';
 import { ShaderMaterial } from '../../scene/materials/shader-material.js';
 
+// Graph colors for MiniStats
+const graphColorRed = '1.0, 0.412, 0.380';      // Pastel Red
+const graphColorGreen = '0.467, 0.867, 0.467';  // Pastel Green
+const graphColorBlue = '0.424, 0.627, 0.863';   // Little Boy Blue
+
+// Background colors for MiniStats graphs
+const mainBackgroundColor = '0.0, 0.0, 0.0';
+const gpuBackgroundColor = '0.15, 0.15, 0.0';
+const cpuBackgroundColor = '0.15, 0.0, 0.1';
+
 const vertexShaderGLSL = /* glsl */ `
     attribute vec3 vertex_position;         // unnormalized xy, word flag
     attribute vec4 vertex_texCoord0;        // unnormalized texture space uv, normalized uv
@@ -66,17 +76,29 @@ const fragmentShaderGLSL = /* glsl */ `
 
         vec4 graph;
         if (uv0.w < graphSample.r)
-            graph = vec4(1.0, 0.412, 0.380, 1.0);      // Pastel Red
+            graph = vec4(${graphColorRed}, 1.0);
         else if (uv0.w < graphSample.g)
-            graph = vec4(0.467, 0.867, 0.467, 1.0);    // Pastel Green
+            graph = vec4(${graphColorGreen}, 1.0);
         else if (uv0.w < graphSample.b)
-            graph = vec4(0.424, 0.627, 0.863, 1.0);    // Little Boy Blue
-        else
-            graph = vec4(0.0, 0.0, 0.0, 1.0 - 0.25 * sin(uv0.w * 3.14159));
+            graph = vec4(${graphColorBlue}, 1.0);
+        else {
+            vec3 bgColor = vec3(${mainBackgroundColor});
+            if (wordFlag > 0.5) {
+                bgColor = vec3(${cpuBackgroundColor});  // CPU: red tint
+            } else if (wordFlag > 0.2) {
+                bgColor = vec3(${gpuBackgroundColor});  // GPU: blue tint
+            }
+            graph = vec4(bgColor, 1.0);
+        }
 
         vec4 words = texture2D(wordsTex, vec2(uv0.x, 1.0 - uv0.y));
 
-        gl_FragColor = mix(graph, words, wordFlag) * clr;
+        // Binary blend: either graph or text, no partial mixing
+        if (wordFlag > 0.99) {
+            gl_FragColor = words * clr;
+        } else {
+            gl_FragColor = graph * clr;
+        }
     }
 `;
 
@@ -98,19 +120,30 @@ const fragmentShaderWGSL = /* wgsl */ `
 
         var graph: vec4f;
         if (uv0.w < graphSample.r) {
-            graph = vec4f(1.0, 0.412, 0.380, 1.0);      // Pastel Red
+            graph = vec4f(${graphColorRed}, 1.0);
         } else if (uv0.w < graphSample.g) {
-            graph = vec4f(0.467, 0.867, 0.467, 1.0);    // Pastel Green
+            graph = vec4f(${graphColorGreen}, 1.0);
         } else if (uv0.w < graphSample.b) {
-            graph = vec4f(0.424, 0.627, 0.863, 1.0);    // Little Boy Blue
+            graph = vec4f(${graphColorBlue}, 1.0);
         } else {
-            graph = vec4f(0.0, 0.0, 0.0, 1.0 - 0.25 * sin(uv0.w * 3.14159));
+            var bgColor: vec3f = vec3f(${mainBackgroundColor});
+            if (input.wordFlag > 0.5) {
+                bgColor = vec3f(${cpuBackgroundColor});  // CPU: red tint
+            } else if (input.wordFlag > 0.2) {
+                bgColor = vec3f(${gpuBackgroundColor});  // GPU: blue tint
+            }
+            graph = vec4f(bgColor, 1.0);
         }
 
         var words: vec4f = textureSample(wordsTex, wordsTex_sampler, vec2f(uv0.x, 1.0 - uv0.y));
 
         var output: FragmentOutput;
-        output.color = mix(graph, words, input.wordFlag) * uniform.clr;
+        // Binary blend: either graph or text, no partial mixing
+        if (input.wordFlag > 0.99) {
+            output.color = words * uniform.clr;
+        } else {
+            output.color = graph * uniform.clr;
+        }
         return output;
     }
 `;

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -740,7 +740,8 @@ class GSplatComponent extends Component {
             if (asset) {
                 this.instance = new GSplatInstance(asset.resource, {
                     material: this._materialTmp,
-                    highQualitySH: this._highQualitySH
+                    highQualitySH: this._highQualitySH,
+                    scene: this.system.app.scene
                 });
                 this._materialTmp = null;
             }

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -1053,9 +1053,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
     onUpdate(dt) {
         let i, len;
 
-        // #if _PROFILER
         this._stats.physicsStart = now();
-        // #endif
 
         // downcast gravity to float32 so we can accurately compare with existing
         // gravity set in ammo.
@@ -1101,9 +1099,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
             this._checkForCollisions(Ammo.getPointer(this.dynamicsWorld), dt);
         }
 
-        // #if _PROFILER
         this._stats.physicsTime = now() - this._stats.physicsStart;
-        // #endif
     }
 
     destroy() {

--- a/src/framework/stats.js
+++ b/src/framework/stats.js
@@ -25,6 +25,12 @@ class ApplicationStats {
             renderTime: 0,
             physicsStart: 0,
             physicsTime: 0,
+            scriptUpdateStart: 0,
+            scriptUpdate: 0,
+            scriptPostUpdateStart: 0,
+            scriptPostUpdate: 0,
+            animUpdateStart: 0,
+            animUpdate: 0,
             cullTime: 0,
             sortTime: 0,
             skinTime: 0,
@@ -33,6 +39,7 @@ class ApplicationStats {
 
             triangles: 0,
             gsplats: 0,
+            gsplatSort: 0,
             otherPrimitives: 0,
             shaders: 0,
             materials: 0,
@@ -103,6 +110,15 @@ class ApplicationStats {
     get batcher() {
         const batcher = getApplication()._batcher;
         return batcher ? batcher._stats : null;
+    }
+
+    /**
+     * Called at the end of each frame to reset per-frame statistics.
+     *
+     * @ignore
+     */
+    frameEnd() {
+        this.frame.gsplatSort = 0;
     }
 }
 

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -223,7 +223,7 @@ class GSplatManager {
 
     createSorter() {
         // create sorter
-        const sorter = new GSplatUnifiedSorter();
+        const sorter = new GSplatUnifiedSorter(this.scene);
         sorter.on('sorted', (count, version, orderData) => {
             this.onSorted(count, version, orderData);
         });

--- a/src/scene/gsplat-unified/gsplat-unified-sort-worker.js
+++ b/src/scene/gsplat-unified/gsplat-unified-sort-worker.js
@@ -279,6 +279,7 @@ function UnifiedSortWorker() {
     };
 
     const sort = (sortParams, order, centersData) => {
+        const sortStartTime = performance.now();
 
         // distance bounds from AABB projections per splat
         const { minDist, maxDist } = _radialSort ?
@@ -330,11 +331,13 @@ function UnifiedSortWorker() {
         const count = numVertices;
 
         // send results
+        const sortTime = performance.now() - sortStartTime;
         const transferList = [order.buffer];
         const response = {
             order: order.buffer,
             count,
-            version: centersData.version
+            version: centersData.version,
+            sortTime: sortTime
         };
 
         myself.postMessage(response, transferList);

--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -57,6 +57,7 @@ class GSplatInstance {
      * @param {object} [options] - Options for the instance.
      * @param {ShaderMaterial|null} [options.material] - The material instance.
      * @param {boolean} [options.highQualitySH] - Whether to use the high quality or the approximate spherical harmonic calculation. Only applies to SOGS data.
+     * @param {import('../scene.js').Scene} [options.scene] - The scene to fire sort timing events on.
      */
     constructor(resource, options = {}) {
         this.resource = resource;
@@ -107,7 +108,7 @@ class GSplatInstance {
         const chunks = resource.chunks?.slice();
 
         // create sorter
-        this.sorter = new GSplatSorter();
+        this.sorter = new GSplatSorter(options.scene);
         this.sorter.init(this.orderTexture, centers, chunks);
         this.sorter.on('updated', (count) => {
             // limit splat render count to exclude those behind the camera

--- a/src/scene/gsplat/gsplat-sort-worker.js
+++ b/src/scene/gsplat/gsplat-sort-worker.js
@@ -44,6 +44,8 @@ function SortWorker() {
     const update = () => {
         if (!order || !centers || centers.length === 0 || !cameraPosition || !cameraDirection) return;
 
+        const sortStartTime = performance.now();
+
         const px = cameraPosition.x;
         const py = cameraPosition.y;
         const pz = cameraPosition.z;
@@ -197,7 +199,8 @@ function SortWorker() {
         // send results
         myself.postMessage({
             order: order.buffer,
-            count
+            count,
+            sortTime: performance.now() - sortStartTime
         }, [order.buffer]);
 
         order = null;

--- a/src/scene/gsplat/gsplat-sorter.js
+++ b/src/scene/gsplat/gsplat-sorter.js
@@ -10,11 +10,19 @@ class GSplatSorter extends EventHandler {
 
     centers;
 
-    constructor() {
+    scene;
+
+    constructor(scene) {
         super();
+        this.scene = scene ?? null;
 
         const messageHandler = (message) => {
             const msgData = message.data ?? message;
+
+            // Fire sortTime event on scene
+            if (this.scene && msgData.sortTime !== undefined) {
+                this.scene.fire('gsplat:sorted', msgData.sortTime);
+            }
 
             const newOrder = msgData.order;
             const oldOrder = this.orderTexture._levels[0].buffer;

--- a/src/scene/renderer/render-pass-shadow-directional.js
+++ b/src/scene/renderer/render-pass-shadow-directional.js
@@ -10,7 +10,7 @@ import { SHADOWUPDATE_NONE, SHADOWUPDATE_THISFRAME } from '../constants.js';
 class RenderPassShadowDirectional extends RenderPass {
     constructor(device, shadowRenderer, light, camera, allCascadesRendering) {
         super(device);
-        DebugHelper.setName(this, `${this.name}-${light._node.name}`);
+        DebugHelper.setName(this, `RenderPassShadowDir-${light._node.name}`);
 
         this.shadowRenderer = shadowRenderer;
         this.light = light;


### PR DESCRIPTION
- additioanl CPU (all platforms) and GPU (WebGPU only for now) timings exposed in Ministats
- those are only rendered in larger version if ministats (configurable)
- add new stats for tracing gsplat sorting timings, as well as script update / postUpdate / animationUpdate

Examples:
- cpu details and gpu render passes
<img width="259" height="412" alt="Screenshot 2025-12-11 at 11 09 58" src="https://github.com/user-attachments/assets/c0b9a026-33f9-40e9-81d4-25c617b889c1" />

- Compute Pass
<img width="257" height="344" alt="Screenshot 2025-12-11 at 11 10 38" src="https://github.com/user-attachments/assets/ef0195ef-dbb2-474a-a7b3-6b89c103d20e" />

- Splat Sorting
<img width="261" height="348" alt="Screenshot 2025-12-11 at 11 09 12" src="https://github.com/user-attachments/assets/f6db0e6f-5c4c-49ec-bf54-f8654175f20b" />
