### PR TITLE
Workbuffer for gsplat uniform no longer stores covariance, but directly the components

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
@@ -23,6 +23,10 @@ uniform vec3 uColorMultiply;
 // number of splats
 uniform int uActiveSplats;
 
+// pre-computed model matrix decomposition
+uniform vec3 model_scale;
+uniform vec4 model_rotation;  // (x,y,z,w) format
+
 void main(void) {
     // local fragment coordinates (within the viewport)
     ivec2 localFragCoords = ivec2(int(gl_FragCoord.x), int(gl_FragCoord.y) - uStartLine);
@@ -73,19 +77,19 @@ void main(void) {
         SplatCenter center;
         initCenter(modelCenter, center);
 
-        // read and transform covariance
-        vec3 covA, covB;
-        readCovariance(source, covA, covB);
+        // Get source rotation and scale
+        // getRotation() returns (w,x,y,z) format, convert to (x,y,z,w) for quatMul
+        vec4 srcRotation = getRotation().yzwx;
+        vec3 srcScale = getScale();
 
-        mat3 C = mat3(
-            covA.x, covA.y, covA.z,
-            covA.y, covB.x, covB.y,
-            covA.z, covB.y, covB.z
-        );
-        mat3 linear = mat3(matrix_model);
-        mat3 Ct = linear * C * transpose(linear);
-        covA = Ct[0];
-        covB = vec3(Ct[1][1], Ct[1][2], Ct[2][2]);
+        // Combine: world = model * source (both in x,y,z,w format)
+        vec4 worldRotation = quatMul(model_rotation, srcRotation);
+        // Ensure w is positive so sqrt() reconstruction works correctly
+        // (quaternions q and -q represent the same rotation)
+        if (worldRotation.w < 0.0) {
+            worldRotation = -worldRotation;
+        }
+        vec3 worldScale = model_scale * srcScale;
 
         // read color
         vec4 color = readColor(source);
@@ -121,8 +125,9 @@ void main(void) {
             pcFragColor0 = color;
         #endif
         #ifndef GSPLAT_COLOR_ONLY
-            pcFragColor1 = uvec4(floatBitsToUint(worldCenter.x), floatBitsToUint(worldCenter.y), floatBitsToUint(worldCenter.z), packHalf2x16Safe(vec2(covA.z, covB.z)));
-            pcFragColor2 = uvec2(packHalf2x16Safe(covA.xy), packHalf2x16Safe(covB.xy));
+            // Store rotation (xyz, w derived) and scale as 6 half-floats
+            pcFragColor1 = uvec4(floatBitsToUint(worldCenter.x), floatBitsToUint(worldCenter.y), floatBitsToUint(worldCenter.z), packHalf2x16Safe(worldRotation.xy));
+            pcFragColor2 = uvec2(packHalf2x16Safe(vec2(worldRotation.z, worldScale.x)), packHalf2x16Safe(worldScale.yz));
         #endif
     }
 }

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
@@ -27,10 +27,6 @@ void main(void) {
         return;
     }
 
-    #ifdef GSPLAT_WORKBUFFER_DATA
-        loadSplatTextures(source);
-    #endif
-
     vec3 modelCenter = readCenter(source);
 
     SplatCenter center;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCompressedData.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCompressedData.js
@@ -65,20 +65,4 @@ vec4 getRotation() {
 vec3 getScale() {
     return exp(mix(vec3(chunkDataB.zw, chunkDataC.x), chunkDataC.yzw, unpack111011(packedData.z)));
 }
-
-// given a rotation matrix and scale vector, compute 3d covariance A and B
-void readCovariance(in SplatSource source, out vec3 covA, out vec3 covB) {
-    mat3 rot = quatToMat3(getRotation());
-    vec3 scale = getScale();
-
-    // M = S * R
-    mat3 M = transpose(mat3(
-        scale.x * rot[0],
-        scale.y * rot[1],
-        scale.z * rot[2]
-    ));
-
-    covA = vec3(dot(M[0], M[0]), dot(M[0], M[1]), dot(M[0], M[2]));
-    covB = vec3(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
-}
 `;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCorner.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCorner.js
@@ -1,6 +1,22 @@
 export default /* glsl */`
 uniform vec4 viewport_size;             // viewport width, height, 1/width, 1/height
 
+// compute 3d covariance from rotation and scale
+void readCovariance(in SplatSource source, out vec3 covA, out vec3 covB) {
+    mat3 rot = quatToMat3(getRotation());
+    vec3 scale = getScale();
+
+    // M = S * R
+    mat3 M = transpose(mat3(
+        scale.x * rot[0],
+        scale.y * rot[1],
+        scale.z * rot[2]
+    ));
+
+    covA = vec3(dot(M[0], M[0]), dot(M[0], M[1]), dot(M[0], M[2]));
+    covB = vec3(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
+}
+
 // calculate the clip-space offset from the center for this gaussian
 bool initCornerCov(SplatSource source, SplatCenter center, out SplatCorner corner, vec3 covA, vec3 covB) {
 

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatData.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatData.js
@@ -4,12 +4,14 @@ uniform highp sampler2D transformB;
 
 // work values
 uint tAw;
+vec4 tBcached;
 
 // read the model-space center of the gaussian
 vec3 readCenter(SplatSource source) {
     // read transform data
     uvec4 tA = texelFetch(transformA, source.uv, 0);
     tAw = tA.w;
+    tBcached = texelFetch(transformB, source.uv, 0);
     return uintBitsToFloat(tA.xyz);
 }
 
@@ -17,21 +19,11 @@ vec4 unpackRotation(vec3 packed) {
     return vec4(packed.xyz, sqrt(max(0.0, 1.0 - dot(packed, packed))));
 }
 
-// sample covariance vectors
-void readCovariance(in SplatSource source, out vec3 covA, out vec3 covB) {
-    vec4 tB = texelFetch(transformB, source.uv, 0);
+vec4 getRotation() {
+    return unpackRotation(vec3(unpackHalf2x16(tAw), tBcached.w)).wxyz;
+}
 
-    mat3 rot = quatToMat3(unpackRotation(vec3(unpackHalf2x16(tAw), tB.w)).wxyz);
-    vec3 scale = tB.xyz;
-    
-    // M = S * R
-    mat3 M = transpose(mat3(
-        scale.x * rot[0],
-        scale.y * rot[1],
-        scale.z * rot[2]
-    ));
-
-    covA = vec3(dot(M[0], M[0]), dot(M[0], M[1]), dot(M[0], M[2]));
-    covB = vec3(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
+vec3 getScale() {
+    return tBcached.xyz;
 }
 `;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatQuatToMat3.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatQuatToMat3.js
@@ -18,4 +18,14 @@ mat3 quatToMat3(vec4 R) {
         1.0 - Y.y - Z.z
     );
 }
+
+// Quaternion multiplication: result = a * b
+vec4 quatMul(vec4 a, vec4 b) {
+    return vec4(
+        a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+        a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+        a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w,
+        a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z
+    );
+}
 `;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatSogsData.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatSogsData.js
@@ -27,31 +27,20 @@ vec3 readCenter(SplatSource source) {
 
 const float norm = sqrt(2.0);
 
-// sample covariance vectors
-void readCovariance(in SplatSource source, out vec3 covA, out vec3 covB) {
+vec4 getRotation() {
     // decode rotation quaternion
     vec3 qdata = unpack8888(packedSample.z).xyz;
-    vec3 sdata = unpack101010(packedSample.w >> 2u);
-
     uint qmode = packedSample.w & 0x3u;
     vec3 abc = (qdata - 0.5) * norm;
     float d = sqrt(max(0.0, 1.0 - dot(abc, abc)));
 
-    vec4 quat = (qmode == 0u) ? vec4(d, abc) :
-                ((qmode == 1u) ? vec4(abc.x, d, abc.yz) :
-                ((qmode == 2u) ? vec4(abc.xy, d, abc.z) : vec4(abc, d)));
+    return (qmode == 0u) ? vec4(d, abc) :
+           ((qmode == 1u) ? vec4(abc.x, d, abc.yz) :
+           ((qmode == 2u) ? vec4(abc.xy, d, abc.z) : vec4(abc, d)));
+}
 
-    mat3 rot = quatToMat3(quat);
-    vec3 scale = exp(mix(vec3(scales_mins), vec3(scales_maxs), sdata));
-
-    // M = S * R
-    mat3 M = transpose(mat3(
-        scale.x * rot[0],
-        scale.y * rot[1],
-        scale.z * rot[2]
-    ));
-
-    covA = vec3(dot(M[0], M[0]), dot(M[0], M[1]), dot(M[0], M[2]));
-    covB = vec3(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
+vec3 getScale() {
+    vec3 sdata = unpack101010(packedSample.w >> 2u);
+    return exp(mix(vec3(scales_mins), vec3(scales_maxs), sdata));
 }
 `;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
@@ -23,6 +23,10 @@ uniform uColorMultiply: vec3f;
 // number of splats
 uniform uActiveSplats: i32;
 
+// pre-computed model matrix decomposition
+uniform model_scale: vec3f;
+uniform model_rotation: vec4f;  // (x,y,z,w) format
+
 @fragment
 fn fragmentMain(input: FragmentInput) -> FragmentOutput {
     var output: FragmentOutput;
@@ -74,20 +78,19 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         var center: SplatCenter;
         initCenter(modelCenter, &center);
 
-        // read and transform covariance
-        var covA: vec3f;
-        var covB: vec3f;
-        readCovariance(&source, &covA, &covB);
+        // Get source rotation and scale
+        // getRotation() returns (w,x,y,z) format, convert to (x,y,z,w) for quatMul
+        let srcRotation = getRotation().yzwx;
+        let srcScale = getScale();
 
-        let C = mat3x3f(
-            vec3f(covA.x, covA.y, covA.z),
-            vec3f(covA.y, covB.x, covB.y),
-            vec3f(covA.z, covB.y, covB.z)
-        );
-        let linear = mat3x3f(uniform.matrix_model[0].xyz, uniform.matrix_model[1].xyz, uniform.matrix_model[2].xyz);
-        let Ct = linear * C * transpose(linear);
-        covA = Ct[0];
-        covB = vec3f(Ct[1][1], Ct[1][2], Ct[2][2]);
+        // Combine: world = model * source (both in x,y,z,w format)
+        var worldRotation = quatMul(uniform.model_rotation, srcRotation);
+        // Ensure w is positive so sqrt() reconstruction works correctly
+        // (quaternions q and -q represent the same rotation)
+        if (worldRotation.w < 0.0) {
+            worldRotation = -worldRotation;
+        }
+        let worldScale = uniform.model_scale * srcScale;
 
         // read color
         var color = readColor(&source);
@@ -111,8 +114,9 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         // write out results
         output.color = color;
         #ifndef GSPLAT_COLOR_ONLY
-            output.color1 = vec4u(bitcast<u32>(worldCenter.x), bitcast<u32>(worldCenter.y), bitcast<u32>(worldCenter.z), pack2x16floatSafe(vec2f(covA.z, covB.z)));
-            output.color2 = vec2u(pack2x16floatSafe(covA.xy), pack2x16floatSafe(covB.xy));
+            // Store rotation (xyz, w derived) and scale as 6 half-floats
+            output.color1 = vec4u(bitcast<u32>(worldCenter.x), bitcast<u32>(worldCenter.y), bitcast<u32>(worldCenter.z), pack2x16floatSafe(worldRotation.xy));
+            output.color2 = vec2u(pack2x16floatSafe(vec2f(worldRotation.z, worldScale.x)), pack2x16floatSafe(worldScale.yz));
         #endif
     }
     

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
@@ -31,10 +31,6 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
         return output;
     }
 
-    #ifdef GSPLAT_WORKBUFFER_DATA
-        loadSplatTextures(&source);
-    #endif
-
     var modelCenter: vec3f = readCenter(&source);
 
     var center: SplatCenter;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCompressedData.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCompressedData.js
@@ -61,20 +61,4 @@ fn getRotation() -> vec4f {
 fn getScale() -> vec3f {
     return exp(mix(vec3f(chunkDataB.zw, chunkDataC.x), chunkDataC.yzw, unpack111011(packedData.z)));
 }
-
-// given a rotation matrix and scale vector, compute 3d covariance A and B
-fn readCovariance(source: ptr<function, SplatSource>, covA_ptr: ptr<function, vec3f>, covB_ptr: ptr<function, vec3f>) {
-    let rot = quatToMat3(getRotation());
-    let scale = getScale();
-
-    // M = S * R
-    let M = transpose(mat3x3f(
-        scale.x * rot[0],
-        scale.y * rot[1],
-        scale.z * rot[2]
-    ));
-
-    *covA_ptr = vec3f(dot(M[0], M[0]), dot(M[0], M[1]), dot(M[0], M[2]));
-    *covB_ptr = vec3f(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
-}
 `;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCorner.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCorner.js
@@ -1,6 +1,22 @@
 export default /* wgsl */`
 uniform viewport_size: vec4f;             // viewport width, height, 1/width, 1/height
 
+// compute 3d covariance from rotation and scale
+fn readCovariance(source: ptr<function, SplatSource>, covA_ptr: ptr<function, vec3f>, covB_ptr: ptr<function, vec3f>) {
+    let rot = quatToMat3(getRotation());
+    let scale = getScale();
+
+    // M = S * R
+    let M = transpose(mat3x3f(
+        scale.x * rot[0],
+        scale.y * rot[1],
+        scale.z * rot[2]
+    ));
+
+    *covA_ptr = vec3f(dot(M[0], M[0]), dot(M[0], M[1]), dot(M[0], M[2]));
+    *covB_ptr = vec3f(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
+}
+
 // calculate the clip-space offset from the center for this gaussian
 fn initCornerCov(source: ptr<function, SplatSource>, center: ptr<function, SplatCenter>, corner: ptr<function, SplatCorner>, covA: vec3f, covB: vec3f) -> bool {
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatData.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatData.js
@@ -4,12 +4,14 @@ var transformB: texture_2d<uff>;
 
 // work values
 var<private> tAw: u32;
+var<private> tBcached: vec4f;
 
 // read the model-space center of the gaussian
 fn readCenter(source: ptr<function, SplatSource>) -> vec3f {
     // read transform data
     let tA: vec4<u32> = textureLoad(transformA, source.uv, 0);
     tAw = tA.w;
+    tBcached = textureLoad(transformB, source.uv, 0);
     return bitcast<vec3f>(tA.xyz);
 }
 
@@ -17,21 +19,11 @@ fn unpackRotation(packed: vec3f) -> vec4f {
     return vec4f(packed.xyz, sqrt(max(0.0, 1.0 - dot(packed, packed))));
 }
 
-// sample covariance vectors
-fn readCovariance(source: ptr<function, SplatSource>, covA_ptr: ptr<function, vec3f>, covB_ptr: ptr<function, vec3f>) {
-    let tB: vec4f = textureLoad(transformB, source.uv, 0);
+fn getRotation() -> vec4f {
+    return unpackRotation(vec3f(unpack2x16float(tAw), tBcached.w)).wxyz;
+}
 
-    let rot: mat3x3f = quatToMat3(unpackRotation(vec3f(unpack2x16float(bitcast<u32>(tAw)), tB.w)).wxyz);
-    let scale: vec3f = tB.xyz;
-
-    // M = S * R
-    let M = transpose(mat3x3f(
-        scale.x * rot[0],
-        scale.y * rot[1],
-        scale.z * rot[2]
-    ));
-
-    *covA_ptr = vec3f(dot(M[0], M[0]), dot(M[0], M[1]), dot(M[0], M[2]));
-    *covB_ptr = vec3f(dot(M[1], M[1]), dot(M[1], M[2]), dot(M[2], M[2]));
+fn getScale() -> vec3f {
+    return tBcached.xyz;
 }
 `;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatQuatToMat3.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatQuatToMat3.js
@@ -12,4 +12,14 @@ fn quatToMat3(R: vec4<f32>) -> mat3x3<f32> {
         Y.w + Z.x,      Z.w - Y.x,     1.0 - Y.y - Z.z
     );
 }
+
+// Quaternion multiplication: result = a * b
+fn quatMul(a: vec4<f32>, b: vec4<f32>) -> vec4<f32> {
+    return vec4<f32>(
+        a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+        a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+        a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w,
+        a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z
+    );
+}
 `;


### PR DESCRIPTION
- the work buffer stored precomputed covariance vectors, but when those are stored in half precision, this causes multiple issues for very small (or slim) splats where those are very close to zero, which half floats fail to store with enough precision
- this switches storage to center / scale / quat, using the same data sizes (no bandwidth change)
- precision issues are gone
- there is 5-7% performance hit when rendering with work buffer, but I do not see a better option to preserve the quality
- this allows us in the future to compress data to less than half formats (lets say for mobile) as well
- shader chunks reading source formats now all supply components instead of covariance, and so we now only have a single copy of that function