### PR TITLE
[FIX] Fix metalness and roughness handling in UsdzExporter

### DIFF
--- a/src/extras/exporters/usdz-exporter.js
+++ b/src/extras/exporters/usdz-exporter.js
@@ -438,8 +438,14 @@ class UsdzExporter extends CoreExporter {
         addTexture('normalMap', null, 'normal3f', 'normal', 'normal');
         addTexture('emissiveMap', material.emissive, 'color3f', 'emissiveColor', 'emissive', false, true);
         addTexture('aoMap', null, 'float', 'occlusion', 'occlusion');
-        addTexture('metalnessMap', material.metalness, 'float', 'metallic', 'metallic');
-        addTexture('glossMap', material.gloss, 'float', 'roughness', 'roughness');
+
+        // only export metalness for metalness workflow materials
+        const metalness = material.useMetalness ? material.metalness : 0;
+        addTexture('metalnessMap', metalness, 'float', 'metallic', 'metallic');
+
+        // convert gloss to roughness (they are inverse of each other)
+        const roughness = material.glossInvert ? material.gloss : 1 - material.gloss;
+        addTexture('glossMap', roughness, 'float', 'roughness', 'roughness');
 
         // main material object
         const materialObject = `


### PR DESCRIPTION
Fixes incorrect material appearance when exporting to USDZ format. Materials were appearing overly shiny/metallic in USD viewers.

### Bug Fixes

- **Gloss to roughness conversion**: USD uses roughness (0=smooth, 1=rough) while PlayCanvas uses gloss (0=rough, 1=smooth). The exporter now correctly inverts the value: `roughness = glossInvert ? gloss : 1 - gloss`, matching the behavior in GltfExporter.

- **Metalness for specular workflow**: Materials using the specular workflow (`useMetalness: false`) were incorrectly exporting their `metalness` property (often defaulting to 1). Now exports `metallic: 0` for specular workflow materials to prevent them appearing as reflective metals.

### Example

For a material with `shininess: 25` (gloss=0.25) and `useMetalness: false`:
- Before: metallic=1, roughness=0.25 (shiny metal)
- After: metallic=0, roughness=0.75 (matte non-metal)

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
