### PR TITLE
[Fix] Correct typed array is used when locking PIXELFORMAT_RG32F texture

### DIFF
--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1074,6 +1074,7 @@ export const requiresManualGamma = (format) => {
 export const getPixelFormatArrayType = (format) => {
     switch (format) {
         case PIXELFORMAT_R32F:
+        case PIXELFORMAT_RG32F:
         case PIXELFORMAT_RGB32F:
         case PIXELFORMAT_RGBA32F:
             return Float32Array;


### PR DESCRIPTION
- the type was not handled and floats were returned as uint8 types