### PR TITLE
[FIX] Notify existing element descendants when a screen is added

### DIFF
--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -68,9 +68,27 @@ class ScreenComponentSystem extends ComponentSystem {
             component.referenceResolution = component._referenceResolution;
         }
 
+        // Update any existing element components in the hierarchy that don't have a screen yet.
+        // This handles cases where element components were added before the screen component.
+        this._updateDescendantElements(component.entity, component.entity);
+
         // queue up a draw order sync
         component.syncDrawOrder();
         super.initializeComponentData(component, data, _schema);
+    }
+
+    _updateDescendantElements(entity, screenEntity) {
+        const children = entity.children;
+        for (let i = 0; i < children.length; i++) {
+            const child = children[i];
+            if (child.element && !child.element.screen) {
+                child.element._updateScreen(screenEntity);
+            }
+            // Continue traversing unless this child has its own screen component
+            if (!child.screen) {
+                this._updateDescendantElements(child, screenEntity);
+            }
+        }
     }
 
     destroy() {


### PR DESCRIPTION
When element components are added to entities before the screen component is added to an ancestor entity, the elements fail to find their screen. This occurs because `_parseUpToScreen()` is only called during element initialization, and there's no mechanism to notify existing elements when a screen is later added.

This is particularly problematic for declarative frameworks (like web components) where component initialization order is not guaranteed.

### Changes

- Added `_updateDescendantElements()` method to `ScreenComponentSystem` that traverses descendant entities and updates any element components that don't have a screen
- Called this method at the end of `initializeComponentData()` after the screen component is fully set up

### Technical Details

When a screen component is initialized, it now scans its entity's descendants. For each child with an element component that has `screen === null`, it calls `_updateScreen()` to establish the screen reference. The traversal stops at any child that has its own screen component (nested screens).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
