### PR TITLE
Add simple render pipeline cache for mipmap renderer (WebGPU)

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -22,6 +22,7 @@ class WebgpuMipmapRenderer {
      * Cache of render pipelines keyed by texture format.
      *
      * @type {Map<string, GPURenderPipeline>}
+     * @private
      */
     pipelineCache = new Map();
 


### PR DESCRIPTION
small optimization to reuse pipelines for the same texture format