### PR TITLE
Adds support for specifying a custom entry point function name when creating compute shaders

### DIFF
--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -72,6 +72,8 @@ class Shader {
      * useTransformFeedback or compute shader is specified.
      * @param {string} [definition.cshader] - Compute shader source (WGSL code). Only supported on
      * WebGPU platform.
+     * @param {string} [definition.computeEntryPoint] - The entry point function name for the compute
+     * shader. Defaults to 'main'.
      * @param {Map<string, string>} [definition.vincludes] - A map containing key-value pairs of
      * include names and their content. These are used for resolving #include directives in the
      * vertex shader source.

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -69,6 +69,9 @@ class WebgpuShader {
                 this._computeCode = definition.cshader ?? null;
                 this.computeUniformBufferFormats = definition.computeUniformBufferFormats;
                 this.computeBindGroupFormat = definition.computeBindGroupFormat;
+                if (definition.computeEntryPoint) {
+                    this.computeEntryPoint = definition.computeEntryPoint;
+                }
 
             } else {
 


### PR DESCRIPTION
- default entry point is 'main', this allows to specify a custom one. It allows multiple entry points in a single shader module.

**Usage:**
```
new pc.Shader(device, {
    shaderLanguage: pc.SHADERLANGUAGE_WGSL,
    cshader: wgslCode,
    computeEntryPoint: 'myEntryPoint', // defaults to 'main' if not specified
    computeBindGroupFormat: ...
});
```