### PR TITLE
[FIX] Fix ScriptComponent clone not handling awaiting scripts

### DIFF
--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -121,8 +121,9 @@ class ScriptComponentSystem extends ComponentSystem {
         }
 
         for (const key in entity.script._scriptsIndex) {
-            if (key.awaiting) {
-                order.splice(key.ind, 0, key);
+            const scriptEntry = entity.script._scriptsIndex[key];
+            if (scriptEntry.awaiting) {
+                order.splice(scriptEntry.ind, 0, key);
             }
         }
 


### PR DESCRIPTION
### Description

When cloning an entity with a ScriptComponent, scripts in an "awaiting" state were not being properly included in the clone's script order.

### Bug

The `cloneComponent` method was iterating over `_scriptsIndex` using `for...in`, but incorrectly checking properties on the string key instead of the script entry object:

```js
for (const key in entity.script._scriptsIndex) {
    if (key.awaiting) {  // ❌ key is a string, key.awaiting is always undefined
        order.splice(key.ind, 0, key);
    }
}
```

Since `key` is a string (the property name), `key.awaiting` was always `undefined` (falsy), making this code block effectively dead code.

### Fix

Access the actual script entry object stored at that key:

```js
for (const key in entity.script._scriptsIndex) {
    const scriptEntry = entity.script._scriptsIndex[key];
    if (scriptEntry.awaiting) {  // ✅ correctly checks the script entry
        order.splice(scriptEntry.ind, 0, key);
    }
}
```

Fixes #2796

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
