### PR TITLE
Add KHR_materials_emissive_strength export support

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -356,12 +356,12 @@ class GltfExporter extends CoreExporter {
                 };
 
                 json.extensionsUsed = json.extensionsUsed ?? [];
-                if (json.extensionsUsed.indexOf('KHR_texture_transform') < 0) {
+                if (!json.extensionsUsed.includes('KHR_texture_transform')) {
                     json.extensionsUsed.push('KHR_texture_transform');
                 }
 
                 json.extensionsRequired = json.extensionsRequired ?? [];
-                if (json.extensionsRequired.indexOf('KHR_texture_transform') < 0) {
+                if (!json.extensionsRequired.includes('KHR_texture_transform')) {
                     json.extensionsRequired.push('KHR_texture_transform');
                 }
 


### PR DESCRIPTION
Adds export support for the `KHR_materials_emissive_strength` glTF extension to `GltfExporter`.

### Changes

- Export `emissiveIntensity` material property as `KHR_materials_emissive_strength` extension
- Automatically adds extension to `extensionsUsed` when materials use non-default emissive intensity

### Public API

Materials with `emissiveIntensity !== 1` will now roundtrip correctly through glTF export/import:

```javascript
const material = new pc.StandardMaterial();
material.emissive = new pc.Color(1, 0.5, 0);
material.emissiveIntensity = 5; // HDR emissive - now exported correctly
```

Exported glTF:
```json
{
  "materials": [{
    "emissiveFactor": [1, 0.5, 0],
    "extensions": {
      "KHR_materials_emissive_strength": {
        "emissiveStrength": 5
      }
    }
  }],
  "extensionsUsed": ["KHR_materials_emissive_strength"]
}
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
