### PR TITLE
Add KHR_materials_specular export support

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -421,7 +421,7 @@ class GltfExporter extends CoreExporter {
             }
         }
 
-        if (mat.useMetalnessSpecularColor || mat.specularMap || mat.specularityFactorMap) {
+        if (mat.useMetalnessSpecularColor) {
             const specularExt = {};
 
             if (!mat.specular.equals(Color.WHITE)) {


### PR DESCRIPTION
Adds export support for the `KHR_materials_specular` glTF extension to `GltfExporter`.

### Changes

- Export `specular` color as `specularColorFactor` (with sRGB to linear conversion)
- Export `specularityFactor` as `specularFactor`
- Export `specularMap` as `specularColorTexture`
- Export `specularityFactorMap` as `specularTexture`
- Added `specularMap` and `specularityFactorMap` to supported texture semantics

### Public API

Materials with specular properties now roundtrip correctly through glTF export/import:

```javascript
material.useMetalnessSpecularColor = true;
material.specular = new pc.Color(1, 0.8, 0.3); // Gold tint
material.specularityFactor = 0.8;
material.specularMap = specularColorTexture;
material.specularityFactorMap = specularFactorTexture;
```

Exported glTF:
```json
{
  "materials": [{
    "extensions": {
      "KHR_materials_specular": {
        "specularColorFactor": [1, 0.8, 0.3],
        "specularFactor": 0.8,
        "specularColorTexture": { "index": 0 },
        "specularTexture": { "index": 1 }
      }
    }
  }],
  "extensionsUsed": ["KHR_materials_specular"]
}
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
