### PR TITLE
Add KHR_materials_ior export support

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -436,7 +436,7 @@ class GltfExporter extends CoreExporter {
 
         // KHR_materials_ior
         const defaultRefractionIndex = 1.0 / 1.5;
-        if (mat.refractionIndex !== defaultRefractionIndex) {
+        if (mat.refractionIndex !== defaultRefractionIndex && mat.refractionIndex > 0) {
             this.addExtension(json, output, 'KHR_materials_ior', {
                 ior: 1.0 / mat.refractionIndex
             });


### PR DESCRIPTION
Adds export support for the `KHR_materials_ior` glTF extension to `GltfExporter`.

### Changes

- Export `refractionIndex` as `ior` (using inverse: `ior = 1 / refractionIndex`)
- Only exports when `refractionIndex` differs from default (1/1.5 ≈ 0.667)

### Public API

Materials with custom index of refraction now roundtrip correctly:

```javascript
material.refractionIndex = 1.0 / 1.33; // Water (ior = 1.33)
```

Exported glTF:
```json
{
  "materials": [{
    "extensions": {
      "KHR_materials_ior": {
        "ior": 1.33
      }
    }
  }],
  "extensionsUsed": ["KHR_materials_ior"]
}
```

### Common IOR Values

| Material | IOR | refractionIndex |
|----------|-----|-----------------|
| Air | 1.0 | 1.0 |
| Water | 1.33 | 0.75 |
| Glass | 1.5 | 0.667 (default) |
| Diamond | 2.42 | 0.41 |

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
