### PR TITLE
Add KHR_materials_dispersion export support

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -427,6 +427,13 @@ class GltfExporter extends CoreExporter {
 
         // === Material Extensions ===
 
+        // KHR_materials_dispersion
+        if (mat.dispersion !== 0) {
+            this.addExtension(json, output, 'KHR_materials_dispersion', {
+                dispersion: mat.dispersion
+            });
+        }
+
         // KHR_materials_emissive_strength
         if (mat.useLighting && mat.emissiveIntensity !== 1) {
             this.addExtension(json, output, 'KHR_materials_emissive_strength', {


### PR DESCRIPTION
Adds export support for the `KHR_materials_dispersion` glTF extension to `GltfExporter`.

### Changes

- Export `dispersion` property directly (1:1 mapping)
- Only exports when `dispersion !== 0` (non-default)

### Public API

Materials with chromatic dispersion now roundtrip correctly:

```javascript
material.dispersion = 0.044; // Diamond-like dispersion
```

Exported glTF:
```json
{
  "materials": [{
    "extensions": {
      "KHR_materials_dispersion": {
        "dispersion": 0.044
      }
    }
  }],
  "extensionsUsed": ["KHR_materials_dispersion"]
}
```

### Testing

Added roundtrip tests for dispersion values (low, medium, high, realistic diamond).



## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
