### PR TITLE
Add KHR_materials_clearcoat export support

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -117,16 +117,16 @@ function isCanvasTransparent(canvas) {
 
 // supported texture semantics on a material
 const textureSemantics = [
-    'diffuseMap',
-    'colorMap',
-    'normalMap',
-    'metalnessMap',
-    'emissiveMap',
-    'specularMap',
-    'specularityFactorMap',
-    'clearCoatMap',
     'clearCoatGlossMap',
-    'clearCoatNormalMap'
+    'clearCoatMap',
+    'clearCoatNormalMap',
+    'colorMap',
+    'diffuseMap',
+    'emissiveMap',
+    'metalnessMap',
+    'normalMap',
+    'specularityFactorMap',
+    'specularMap'
 ];
 
 /**


### PR DESCRIPTION
This PR adds export support for the `KHR_materials_clearcoat` glTF extension to the `GltfExporter`.

## Changes

### GltfExporter (`src/extras/exporters/gltf-exporter.js`)

- Export `KHR_materials_clearcoat` extension when clearcoat properties are non-default:
  - `clearcoatFactor` from `material.clearCoat` (if not 0)
  - `clearcoatRoughnessFactor` from `1 - material.clearCoatGloss` (if gloss is not 1)
  - `clearcoatTexture` from `material.clearCoatMap`
  - `clearcoatRoughnessTexture` from `material.clearCoatGlossMap`
  - `clearcoatNormalTexture` from `material.clearCoatNormalMap` with `scale` from `material.clearCoatBumpiness`
- Added texture semantics for clearcoat textures

## glTF Extension Reference

The [KHR_materials_clearcoat](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_clearcoat) extension adds a clear lacquer layer on top of the base material, commonly used for car paint, lacquered wood, or coated materials.

## Example Output

```json
{
  "extensions": {
    "KHR_materials_clearcoat": {
      "clearcoatFactor": 1.0,
      "clearcoatRoughnessFactor": 0.2
    }
  }
}
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
