### PR TITLE
Add KHR_materials_volume export support

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -127,7 +127,8 @@ const textureSemantics = [
     'normalMap',
     'refractionMap',
     'specularityFactorMap',
-    'specularMap'
+    'specularMap',
+    'thicknessMap'
 ];
 
 /**
@@ -518,6 +519,30 @@ class GltfExporter extends CoreExporter {
         // KHR_materials_unlit
         if (!mat.useLighting) {
             this.addExtension(json, output, 'KHR_materials_unlit');
+        }
+
+        // KHR_materials_volume
+        if (mat.useDynamicRefraction && (mat.thickness !== 0 || mat.attenuationDistance !== 0 || !mat.attenuation.equals(Color.WHITE) || mat.thicknessMap)) {
+            const volumeExt = {};
+
+            if (mat.thickness !== 0) {
+                volumeExt.thicknessFactor = mat.thickness;
+            }
+
+            if (mat.attenuationDistance !== 0) {
+                volumeExt.attenuationDistance = mat.attenuationDistance;
+            }
+
+            if (!mat.attenuation.equals(Color.WHITE)) {
+                const { r, g, b } = mat.attenuation.clone().linear();
+                volumeExt.attenuationColor = [r, g, b];
+            }
+
+            this.attachTexture(resources, mat, volumeExt, 'thicknessTexture', 'thicknessMap', json);
+
+            if (Object.keys(volumeExt).length > 0) {
+                this.addExtension(json, output, 'KHR_materials_volume', volumeExt);
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds export support for the `KHR_materials_volume` glTF extension to the `GltfExporter`.

## Changes

### GltfExporter (`src/extras/exporters/gltf-exporter.js`)

- Export `KHR_materials_volume` extension when volume properties are set:
  - `thicknessFactor` from `material.thickness` (if not 0)
  - `thicknessTexture` from `material.thicknessMap`
  - `attenuationDistance` from `material.attenuationDistance` (if not 0)
  - `attenuationColor` from `material.attenuation` (linear converted, if not white)
- Only exported when `material.useDynamicRefraction` is true (matching parser behavior)
- Added `thicknessMap` to texture semantics for proper texture collection

## glTF Extension Reference

The [KHR_materials_volume](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_volume) extension adds volumetric properties to materials. Combined with `KHR_materials_transmission`, it enables realistic rendering of glass, liquids, and other refractive materials with proper light absorption and scattering.

## Example Output

```json
{
  "extensions": {
    "KHR_materials_volume": {
      "thicknessFactor": 0.5,
      "attenuationDistance": 1.0,
      "attenuationColor": [0.9, 0.95, 1.0]
    }
  }
}
```

## Notes

- The parser sets `blendType = BLEND_NORMAL` when loading volume materials
- Works in conjunction with `KHR_materials_transmission` and `KHR_materials_ior`

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
