### PR TITLE
Add KHR_materials_sheen export support

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -126,6 +126,8 @@ const textureSemantics = [
     'metalnessMap',
     'normalMap',
     'refractionMap',
+    'sheenGlossMap',
+    'sheenMap',
     'specularityFactorMap',
     'specularMap',
     'thicknessMap'
@@ -478,6 +480,27 @@ class GltfExporter extends CoreExporter {
             this.addExtension(json, output, 'KHR_materials_ior', {
                 ior: 1.0 / mat.refractionIndex
             });
+        }
+
+        // KHR_materials_sheen
+        if (mat.useSheen) {
+            const sheenExt = {};
+
+            if (!mat.sheen.equals(Color.BLACK)) {
+                const { r, g, b } = mat.sheen.clone().linear();
+                sheenExt.sheenColorFactor = [r, g, b];
+            }
+
+            if (mat.sheenGloss !== 0) {
+                sheenExt.sheenRoughnessFactor = mat.sheenGloss;
+            }
+
+            this.attachTexture(resources, mat, sheenExt, 'sheenColorTexture', 'sheenMap', json);
+            this.attachTexture(resources, mat, sheenExt, 'sheenRoughnessTexture', 'sheenGlossMap', json);
+
+            if (Object.keys(sheenExt).length > 0) {
+                this.addExtension(json, output, 'KHR_materials_sheen', sheenExt);
+            }
         }
 
         // KHR_materials_specular


### PR DESCRIPTION
This PR adds export support for the `KHR_materials_sheen` glTF extension to the `GltfExporter`.

## Changes

### GltfExporter (`src/extras/exporters/gltf-exporter.js`)

- Export `KHR_materials_sheen` extension when `material.useSheen` is true:
  - `sheenColorFactor` from `material.sheen` (linear converted, if not black)
  - `sheenRoughnessFactor` from `material.sheenGloss` (if not 0)
  - `sheenColorTexture` from `material.sheenMap`
  - `sheenRoughnessTexture` from `material.sheenGlossMap`
- Added `sheenMap` and `sheenGlossMap` to texture semantics

## glTF Extension Reference

The [KHR_materials_sheen](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_sheen) extension adds a sheen layer to simulate the appearance of cloth and fabric materials. The sheen BRDF models the microfiber structure of textiles.

## Example Output

```json
{
  "extensions": {
    "KHR_materials_sheen": {
      "sheenColorFactor": [0.8, 0.4, 0.2],
      "sheenRoughnessFactor": 0.5
    }
  }
}
```

## Notes

- glTF's default `sheenColorFactor` is `[0, 0, 0]` (black/no sheen), so we export whenever sheen color is non-black
- The parser sets `sheenGlossInvert = true`, so `sheenGloss` directly maps to glTF's `sheenRoughnessFactor`

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
