### PR TITLE
Add KHR_materials_iridescence export support

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -123,6 +123,8 @@ const textureSemantics = [
     'colorMap',
     'diffuseMap',
     'emissiveMap',
+    'iridescenceMap',
+    'iridescenceThicknessMap',
     'metalnessMap',
     'normalMap',
     'refractionMap',
@@ -480,6 +482,34 @@ class GltfExporter extends CoreExporter {
             this.addExtension(json, output, 'KHR_materials_ior', {
                 ior: 1.0 / mat.refractionIndex
             });
+        }
+
+        // KHR_materials_iridescence
+        if (mat.useIridescence) {
+            const iridescenceExt = {};
+
+            if (mat.iridescence !== 0) {
+                iridescenceExt.iridescenceFactor = mat.iridescence;
+            }
+
+            if (mat.iridescenceRefractionIndex !== 1.3) {
+                iridescenceExt.iridescenceIor = mat.iridescenceRefractionIndex;
+            }
+
+            if (mat.iridescenceThicknessMin !== 100) {
+                iridescenceExt.iridescenceThicknessMinimum = mat.iridescenceThicknessMin;
+            }
+
+            if (mat.iridescenceThicknessMax !== 400) {
+                iridescenceExt.iridescenceThicknessMaximum = mat.iridescenceThicknessMax;
+            }
+
+            this.attachTexture(resources, mat, iridescenceExt, 'iridescenceTexture', 'iridescenceMap', json);
+            this.attachTexture(resources, mat, iridescenceExt, 'iridescenceThicknessTexture', 'iridescenceThicknessMap', json);
+
+            if (Object.keys(iridescenceExt).length > 0) {
+                this.addExtension(json, output, 'KHR_materials_iridescence', iridescenceExt);
+            }
         }
 
         // KHR_materials_sheen


### PR DESCRIPTION
This PR adds export support for the `KHR_materials_iridescence` glTF extension to the `GltfExporter`.

## Changes

### GltfExporter (`src/extras/exporters/gltf-exporter.js`)

- Export `KHR_materials_iridescence` extension when `material.useIridescence` is true:
  - `iridescenceFactor` from `material.iridescence` (if not 0)
  - `iridescenceIor` from `material.iridescenceRefractionIndex` (if not 1.3)
  - `iridescenceThicknessMinimum` from `material.iridescenceThicknessMin` (if not 100)
  - `iridescenceThicknessMaximum` from `material.iridescenceThicknessMax` (if not 400)
  - `iridescenceTexture` from `material.iridescenceMap`
  - `iridescenceThicknessTexture` from `material.iridescenceThicknessMap`
- Added `iridescenceMap` and `iridescenceThicknessMap` to texture semantics

## glTF Extension Reference

The [KHR_materials_iridescence](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_iridescence) extension adds thin-film iridescence to materials, simulating the color-shifting effect seen in soap bubbles, oil slicks, beetle shells, and other surfaces with thin transparent coatings.

## Example Output

```json
{
  "extensions": {
    "KHR_materials_iridescence": {
      "iridescenceFactor": 1.0,
      "iridescenceIor": 1.5,
      "iridescenceThicknessMinimum": 100,
      "iridescenceThicknessMaximum": 400
    }
  }
}
```

## Notes

- Thickness values are in nanometers (nm)
- The parser uses PlayCanvas defaults which differ from glTF spec defaults for some properties

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
