### PR TITLE
Add compute pipeline creation caching for WebGPU

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-compute-pipeline.js
@@ -1,5 +1,7 @@
+import { array } from '../../../core/array-utils.js';
 import { Debug, DebugHelper } from '../../../core/debug.js';
 import { TRACEID_COMPUTEPIPELINE_ALLOC } from '../../../core/constants.js';
+import { hash32Fnv1a } from '../../../core/hash.js';
 import { WebgpuDebug } from './webgpu-debug.js';
 import { WebgpuPipeline } from './webgpu-pipeline.js';
 
@@ -9,16 +11,68 @@ import { WebgpuPipeline } from './webgpu-pipeline.js';
 
 let _pipelineId = 0;
 
+class CacheEntry {
+    /**
+     * Compute pipeline
+     *
+     * @type {GPUComputePipeline|null}
+     * @private
+     */
+    pipeline = null;
+
+    /**
+     * The full array of hashes used to lookup the pipeline, used in case of hash collision.
+     *
+     * @type {Uint32Array|null}
+     */
+    hashes = null;
+}
+
 class WebgpuComputePipeline extends WebgpuPipeline {
+    lookupHashes = new Uint32Array(2);
+
+    /**
+     * The cache of compute pipelines
+     *
+     * @type {Map<number, CacheEntry[]>}
+     */
+    cache = new Map();
+
     get(shader, bindGroupFormat) {
 
-        // pipeline layout
+        // unique hash for the pipeline
+        const lookupHashes = this.lookupHashes;
+        lookupHashes[0] = shader.impl.computeKey;
+        lookupHashes[1] = bindGroupFormat.impl.key;
+        const hash = hash32Fnv1a(lookupHashes);
+
+        // Check cache
+        let cacheEntries = this.cache.get(hash);
+        if (cacheEntries) {
+            // Handle hash collisions by checking actual values
+            for (let i = 0; i < cacheEntries.length; i++) {
+                const entry = cacheEntries[i];
+                if (array.equals(entry.hashes, lookupHashes)) {
+                    return entry.pipeline;
+                }
+            }
+        }
+
+        // Cache miss - create new pipeline
         const pipelineLayout = this.getPipelineLayout([bindGroupFormat.impl]);
+        const cacheEntry = new CacheEntry();
+        cacheEntry.hashes = new Uint32Array(lookupHashes);
+        cacheEntry.pipeline = this.create(shader, pipelineLayout);
 
-        // TODO: this could be cached
+        // Add to cache
+        if (cacheEntries) {
+            cacheEntries.push(cacheEntry);
+        } else {
+            cacheEntries = [cacheEntry];
+        }
+        this.cache.set(hash, cacheEntries);
 
-        const pipeline = this.create(shader, pipelineLayout);
-        return pipeline;
+        return cacheEntry.pipeline;
     }
 
     create(shader, pipelineLayout) {

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -1,4 +1,5 @@
 import { Debug, DebugHelper } from '../../../core/debug.js';
+import { StringIds } from '../../../core/string-ids.js';
 import { SHADERLANGUAGE_WGSL } from '../constants.js';
 import { DebugGraphics } from '../debug-graphics.js';
 import { ShaderProcessorGLSL } from '../shader-processor-glsl.js';
@@ -9,6 +10,9 @@ import { WebgpuShaderProcessorWGSL } from './webgpu-shader-processor-wgsl.js';
  * @import { GraphicsDevice } from '../graphics-device.js'
  * @import { Shader } from '../shader.js'
  */
+
+// Shared StringIds instance for content-based compute shader keys
+const computeShaderIds = new StringIds();
 
 /**
  * A WebGPU implementation of the Shader.
@@ -36,6 +40,14 @@ class WebgpuShader {
      * @type {string|null}
      */
     _computeCode = null;
+
+    /**
+     * Cached content-based key for compute shader.
+     *
+     * @type {number|undefined}
+     * @private
+     */
+    _computeKey;
 
     /**
      * Name of the vertex entry point function.
@@ -223,6 +235,21 @@ class WebgpuShader {
     get fragmentCode() {
         Debug.assert(this._fragmentCode);
         return this._fragmentCode;
+    }
+
+    /**
+     * Content-based key for compute shader caching. Returns the same key for identical
+     * shader code and entry point combinations, regardless of how many Shader instances exist.
+     *
+     * @type {number}
+     * @ignore
+     */
+    get computeKey() {
+        if (this._computeKey === undefined) {
+            const keyString = `${this._computeCode}|${this.computeEntryPoint}`;
+            this._computeKey = computeShaderIds.get(keyString);
+        }
+        return this._computeKey;
     }
 
     /**


### PR DESCRIPTION
## Description

Implements content-based caching for WebGPU compute pipelines, following the same pattern used for render pipelines.

### Changes

**webgpu-shader.js**
- Added `computeKey` getter that generates a unique numeric ID based on shader source code and entry point
exist

**webgpu-compute-pipeline.js**
- Added `CacheEntry` class and hash-based cache lookup
- Modified `get()` to check cache before creating new pipelines
- Cache key combines `shader.impl.computeKey` + `bindGroupFormat.impl.key`
- Handles hash collisions by comparing full hash arrays (same as render pipeline)

### Benefits

- Avoids redundant GPU pipeline creation when multiple `Compute` instances use identical shader code
- Particularly beneficial for algorithms like radix sort that create many compute passes with shared shader patterns
