### PR TITLE
ScopeSpace.removeValue not clearing destroyed textures from scope

### DIFF
--- a/examples/src/examples/graphics/particles-snow.example.mjs
+++ b/examples/src/examples/graphics/particles-snow.example.mjs
@@ -134,15 +134,12 @@ assetListLoader.load(() => {
     ground.setLocalPosition(0, 0, 0);
     app.root.addChild(ground);
 
-    let depthRendering = false;
     data.on('*:set', (/** @type {string} */ path, value) => {
 
-        // toggle the depth texture for the camera based on the soft parameter
+        // toggle the depth softening on the particle system and the depth texture on the camera
         const soft = data.get('data.soft');
-        if (depthRendering !== soft) {
-            cameraEntity.camera.requestSceneDepthMap(soft);
-            depthRendering = soft;
-        }
+        entity.particlesystem.depthSoftening = soft ? 0.08 : 0;
+        cameraEntity.camera.requestSceneDepthMap(soft);
     });
 
     // initial values

--- a/src/platform/graphics/scope-space.js
+++ b/src/platform/graphics/scope-space.js
@@ -46,8 +46,7 @@ class ScopeSpace {
      * @ignore
      */
     removeValue(value) {
-        for (const uniformName in this.variables) {
-            const uniform = this.variables[uniformName];
+        for (const uniform of this.variables.values()) {
             if (uniform.value === value) {
                 uniform.value = null;
             }


### PR DESCRIPTION
### Description

Fixed a bug in `ScopeSpace.removeValue()` where destroyed textures were not being properly cleared from scope variables.

### Problem

The `removeValue` method was using `for...in` to iterate over `this.variables`, but `variables` is a `Map`. The `for...in` loop only iterates over enumerable object properties, not Map entries, so the method was effectively a no-op.

This caused issues on WebGPU where soft particles would continue using a stale/destroyed depth texture after `requestSceneDepthMap(false)` was called, instead of properly falling back to a white texture.

### Changes

- **`src/platform/graphics/scope-space.js`**: Changed `for...in` to `for...of this.variables.values()` to properly iterate over Map values
- **`examples/src/examples/graphics/particles-snow.example.mjs`**: Updated the example to properly toggle `depthSoftening` along with `requestSceneDepthMap`, ensuring the correct shader variant is used when soft particles are enabled/disabled

### Technical Details

When a texture is destroyed, it calls `device.scope.removeValue(this)` to clear any scope references to it. With the broken iteration, scope variables retained references to destroyed textures. On WebGPU, this caused bind groups to continue using the destroyed texture data instead of detecting the null value and falling back to a white placeholder texture.