### PR TITLE
Use Set instead of array for buffer tracking

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -477,7 +477,7 @@ class GraphicsDevice extends EventHandler {
         // eg Oculus Quest 1 which returns a window.devicePixelRatio of 0.8
         this._maxPixelRatio = platform.browser ? Math.min(1, window.devicePixelRatio) : 1;
 
-        this.buffers = [];
+        this.buffers = new Set();
 
         this._vram = {
             // #if _PROFILER

--- a/src/platform/graphics/index-buffer.js
+++ b/src/platform/graphics/index-buffer.js
@@ -76,7 +76,7 @@ class IndexBuffer {
 
         this.adjustVramSizeTracking(graphicsDevice._vram, this.numBytes);
 
-        this.device.buffers.push(this);
+        this.device.buffers.add(this);
     }
 
     /**
@@ -86,10 +86,7 @@ class IndexBuffer {
 
         // stop tracking the index buffer
         const device = this.device;
-        const idx = device.buffers.indexOf(this);
-        if (idx !== -1) {
-            device.buffers.splice(idx, 1);
-        }
+        device.buffers.delete(this);
 
         if (this.device.indexBuffer === this) {
             this.device.indexBuffer = null;

--- a/src/platform/graphics/storage-buffer.js
+++ b/src/platform/graphics/storage-buffer.js
@@ -38,7 +38,7 @@ class StorageBuffer {
         const usage = addStorageUsage ? (BUFFERUSAGE_STORAGE | bufferUsage) : bufferUsage;
         this.impl = graphicsDevice.createBufferImpl(usage);
         this.impl.allocate(graphicsDevice, byteSize);
-        this.device.buffers.push(this);
+        this.device.buffers.add(this);
 
         this.adjustVramSizeTracking(graphicsDevice._vram, this.byteSize);
     }
@@ -50,10 +50,7 @@ class StorageBuffer {
 
         // stop tracking the buffer
         const device = this.device;
-        const idx = device.buffers.indexOf(this);
-        if (idx !== -1) {
-            device.buffers.splice(idx, 1);
-        }
+        device.buffers.delete(this);
 
         this.adjustVramSizeTracking(device._vram, -this.byteSize);
         this.impl.destroy(device);

--- a/src/platform/graphics/vertex-buffer.js
+++ b/src/platform/graphics/vertex-buffer.js
@@ -59,7 +59,7 @@ class VertexBuffer {
             this.storage = new ArrayBuffer(this.numBytes);
         }
 
-        this.device.buffers.push(this);
+        this.device.buffers.add(this);
     }
 
     /**
@@ -69,10 +69,7 @@ class VertexBuffer {
 
         // stop tracking the vertex buffer
         const device = this.device;
-        const idx = device.buffers.indexOf(this);
-        if (idx !== -1) {
-            device.buffers.splice(idx, 1);
-        }
+        device.buffers.delete(this);
 
         if (this.impl.initialized) {
             this.impl.destroy(device);


### PR DESCRIPTION
## Description

Optimizes buffer tracking in `GraphicsDevice` by replacing the `buffers` array with a `Set`.

## Changes

- Changed `device.buffers` from an array to a `Set`
- Buffer registration uses `.add()` instead of `.push()`
- Buffer removal uses `.delete()` instead of `indexOf()` + `splice()`

## Performance Impact

Buffer destruction is now O(1) instead of O(n):
- **Before**: `indexOf()` O(n) + `splice()` O(n)
- **After**: `delete()` O(1)

This improves performance in scenes with many vertex, index, or storage buffers being created and destroyed.