### PR TITLE
Add KHR_materials_anisotropy export support

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -117,6 +117,7 @@ function isCanvasTransparent(canvas) {
 
 // supported texture semantics on a material
 const textureSemantics = [
+    'anisotropyMap',
     'clearCoatGlossMap',
     'clearCoatMap',
     'clearCoatNormalMap',
@@ -435,6 +436,25 @@ class GltfExporter extends CoreExporter {
         }
 
         // === Material Extensions ===
+
+        // KHR_materials_anisotropy
+        if (mat.enableGGXSpecular && (mat.anisotropyIntensity !== 0 || mat.anisotropyRotation !== 0 || mat.anisotropyMap)) {
+            const anisotropyExt = {};
+
+            if (mat.anisotropyIntensity !== 0) {
+                anisotropyExt.anisotropyStrength = mat.anisotropyIntensity;
+            }
+
+            if (mat.anisotropyRotation !== 0) {
+                anisotropyExt.anisotropyRotation = mat.anisotropyRotation * math.DEG_TO_RAD;
+            }
+
+            this.attachTexture(resources, mat, anisotropyExt, 'anisotropyTexture', 'anisotropyMap', json);
+
+            if (Object.keys(anisotropyExt).length > 0) {
+                this.addExtension(json, output, 'KHR_materials_anisotropy', anisotropyExt);
+            }
+        }
 
         // KHR_materials_clearcoat
         if (mat.clearCoat > 0) {


### PR DESCRIPTION
This PR adds export support for the `KHR_materials_anisotropy` glTF extension to the `GltfExporter`.

## Changes

### GltfExporter (`src/extras/exporters/gltf-exporter.js`)

- Export `KHR_materials_anisotropy` extension when `material.enableGGXSpecular` is true and anisotropy properties are set:
  - `anisotropyStrength` from `material.anisotropyIntensity` (if not 0)
  - `anisotropyRotation` from `material.anisotropyRotation` (converted from degrees to radians, if not 0)
  - `anisotropyTexture` from `material.anisotropyMap`
- Added `anisotropyMap` to texture semantics

## glTF Extension Reference

The [KHR_materials_anisotropy](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_anisotropy) extension adds anisotropic reflection to materials, simulating the directional surface structure found in brushed metal, carbon fiber, hair, satin, and similar materials.

## Example Output

```json
{
  "extensions": {
    "KHR_materials_anisotropy": {
      "anisotropyStrength": 0.8,
      "anisotropyRotation": 1.57
    }
  }
}
```

## Notes

- Rotation is stored in degrees in PlayCanvas but exported as radians per glTF spec
- Requires `enableGGXSpecular = true` for anisotropy to be active

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
