### PR TITLE
[FIX] Document some missing pixel formats

### DIFF
--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -471,8 +471,25 @@ export const INDEXFORMAT_UINT32 = 2;
  */
 export const indexFormatByteSize = [1, 2, 4];
 
+/**
+ * 8-bit alpha.
+ *
+ * @category Graphics
+ */
 export const PIXELFORMAT_A8 = 0;
+
+/**
+ * 8-bit luminance (grayscale).
+ *
+ * @category Graphics
+ */
 export const PIXELFORMAT_L8 = 1;
+
+/**
+ * 8-bit luminance with 8-bit alpha.
+ *
+ * @category Graphics
+ */
 export const PIXELFORMAT_LA8 = 2;
 
 /**


### PR DESCRIPTION
Adds JSDoc documentation to three pixel format constants that were previously undocumented and therefore missing from the public API reference.

### Changes

- Added JSDoc comments with `@category Graphics` to:
  - `PIXELFORMAT_A8` - 8-bit alpha
  - `PIXELFORMAT_L8` - 8-bit luminance (grayscale)
  - `PIXELFORMAT_LA8` - 8-bit luminance with 8-bit alpha

### Why

These constants were already exported and used internally, but `PIXELFORMAT_LA8` was also referenced in the public API documentation for `XrView.texturedepth` and `XrViews.depthPixelFormat` without being documented itself. This caused broken links in the API reference.

Fixes #7498

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
