### PR TITLE
[FIX] Fix black specular map still showing reflections

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/lit/frag/fresnelSchlick.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/fresnelSchlick.js
@@ -11,7 +11,11 @@ vec3 getFresnel(
     ) {
     float fresnel = pow(1.0 - saturate(cosTheta), 5.0);
     float glossSq = gloss * gloss;
-    vec3 ret = specularity + (max(vec3(glossSq), specularity) - specularity) * fresnel;
+
+    // Scale gloss contribution by specularity intensity to ensure F90 approaches 0 when F0 is 0
+    float specIntensity = max(specularity.r, max(specularity.g, specularity.b));
+    vec3 ret = specularity + (max(vec3(glossSq * specIntensity), specularity) - specularity) * fresnel;
+
 #if defined(LIT_IRIDESCENCE)
     return mix(ret, iridescenceFresnel, iridescenceIntensity);
 #else

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/fresnelSchlick.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/fresnelSchlick.js
@@ -11,7 +11,10 @@ fn getFresnel(
 ) -> vec3f {
     let fresnel: f32 = pow(1.0 - saturate(cosTheta), 5.0);
     let glossSq: f32 = gloss * gloss;
-    let ret: vec3f = specularity + (max(vec3f(glossSq), specularity) - specularity) * fresnel;
+
+    // Scale gloss contribution by specularity intensity to ensure F90 approaches 0 when F0 is 0
+    let specIntensity: f32 = max(specularity.r, max(specularity.g, specularity.b));
+    let ret: vec3f = specularity + (max(vec3f(glossSq * specIntensity), specularity) - specularity) * fresnel;
 
     #if defined(LIT_IRIDESCENCE)
         return mix(ret, iridescenceFresnel, iridescenceIntensity);


### PR DESCRIPTION
Fixes #5153

### Overview

When a material has a black specular color (no map), no reflections are rendered. However, when a material has a black specular *map*, reflections from the skybox were still visible. This inconsistent behavior is now fixed.

Before:

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/6ff12ead-aa11-451e-919a-bd9ac4484835" />

After:

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/38878fd4-40fb-49bd-9258-5fe03246170e" />

### Changes

- Modified the Fresnel calculation to scale the gloss contribution (F90) by specularity intensity
- When specularity (F0) is zero/black, the Fresnel term now correctly evaluates to zero
- Updated both GLSL and WGSL shader chunks for consistency across WebGL2 and WebGPU

### Technical Details

The Fresnel Schlick approximation was using `glossSq` as a minimum F90 value:

```glsl
vec3 ret = specularity + (max(vec3(glossSq), specularity) - specularity) * fresnel;
```

When `specularity = vec3(0)`, this simplified to `glossSq * fresnel`, producing non-zero reflections at grazing angles even with black specularity.

The fix scales `glossSq` by the specularity intensity:

```glsl
float specIntensity = max(specularity.r, max(specularity.g, specularity.b));
vec3 ret = specularity + (max(vec3(glossSq * specIntensity), specularity) - specularity) * fresnel;
```

This ensures F90 approaches zero when F0 is zero, matching the expected physical behavior where a material with no specular reflectance at normal incidence should have no reflections at any angle.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
