### PR TITLE
[FIX] Fix ElementComponent 'mousemove' event firing outside element

### DIFF
--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -733,7 +733,7 @@ class ElementInput {
         // currently hovered element is whatever's being pointed by mouse (which may be null)
         this._hoveredElement = element;
 
-        // if there was a pressed element, it takes full priority of 'up' events
+        // if there was a pressed element, it takes full priority of 'up' events for click detection
         if (eventType === 'mouseup' && this._pressedElement) {
             this._fireEvent(eventType, new ElementMouseEvent(event, this._pressedElement, camera, targetX, targetY, this._lastX, this._lastY));
         } else if (element) {


### PR DESCRIPTION
Fixes #4755

### Overview

When the left mouse button was pressed inside an ElementComponent, `mousemove` events would continue to fire on that element even after the mouse cursor moved outside its bounds. This was a regression from engine version 1.55.0.

### Changes

- `mousemove` events now only fire on the element currently under the mouse cursor
- `mouseup` events still fire on the originally pressed element to maintain proper click detection
- `mouseenter`/`mouseleave` events continue to work correctly for hover state tracking

### Technical Details

The `_onElementMouseEvent` method was incorrectly "capturing" both `mousemove` and `mouseup` events when an element was pressed. This capture behavior is only needed for `mouseup` to properly detect clicks (comparing pressed element vs hovered element).

The fix changes the condition from:
```javascript
if ((eventType === 'mousemove' || eventType === 'mouseup') && this._pressedElement)
```
to:
```javascript
if (eventType === 'mouseup' && this._pressedElement)
```

This ensures `mousemove` is only dispatched to the element the cursor is actually over, while `mouseup` continues to be dispatched to the pressed element for click detection logic.

### Demonstration of Fix

https://github.com/user-attachments/assets/03fa32c9-8291-4887-8f56-d2ba38a3e8d2

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
