### PR TITLE
[FIX] Fix ElementComponent not rendering when entity already in hierarchy

### DIFF
--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -337,6 +337,12 @@ class ImageElement {
         this._element.on('set:screen', this._onScreenChange, this);
         this._element.on('set:draworder', this._onDrawOrderChange, this);
         this._element.on('screen:set:resolution', this._onResolutionChange, this);
+
+        // If not being initialized (i.e., type changed after component was already enabled),
+        // we need to call onEnable to add the model to layers
+        if (!element._beingInitialized && element.enabled && element.entity.enabled) {
+            this.onEnable();
+        }
     }
 
     destroy() {

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -221,6 +221,12 @@ class TextElement {
         // substring render range
         this._rangeStart = 0;
         this._rangeEnd = 0;
+
+        // If not being initialized (i.e., type changed after component was already enabled),
+        // we need to call onEnable to add the model to layers
+        if (!element._beingInitialized && element.enabled && element.entity.enabled) {
+            this.onEnable();
+        }
     }
 
     destroy() {

--- a/test/framework/components/element/component.test.mjs
+++ b/test/framework/components/element/component.test.mjs
@@ -156,4 +156,38 @@ describe('ElementComponent', function () {
 
         expect(screen.screen._elements).to.not.include(e.element);
     });
+
+    describe('#type', function () {
+
+        it('adds model to layers when type is set to image after entity is in hierarchy', function () {
+            // This tests the fix for: https://github.com/playcanvas/engine/issues/1989
+            // When entity is added to hierarchy before element type is set, the image should still render
+            const e = new Entity();
+            app.root.addChild(e);
+
+            e.addComponent('element');
+            e.element.type = 'image';
+
+            // Verify that the image element's model has been added to the layers
+            const uiLayer = app.scene.layers.getLayerById(LAYERID_UI);
+            expect(uiLayer).to.not.be.null;
+            expect(e.element._image).to.not.be.null;
+            expect(e.element._image._renderable.model).to.not.be.null;
+            expect(e.element._addedModels).to.include(e.element._image._renderable.model);
+        });
+
+        it('adds model to layers when type is set to text after entity is in hierarchy', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+
+            e.addComponent('element');
+            e.element.type = 'text';
+
+            // Verify that the text element's model has been added to the layers
+            expect(e.element._text).to.not.be.null;
+            expect(e.element._text._model).to.not.be.null;
+            expect(e.element._addedModels).to.include(e.element._text._model);
+        });
+
+    });
 });


### PR DESCRIPTION
Fixes #1989

### Description

When an entity is already in the scene hierarchy and an element component is added with its type subsequently set to "image" or "text", the element fails to render. This is because `onEnable()` is called during component initialization when the type is still "group" (the default), so the newly created `ImageElement` or `TextElement` never has its `onEnable()` called, and therefore its model is never added to the render layers.

**Before (broken):**
```javascript
const testEntity = new pc.Entity();
app.root.addChild(testEntity);           // Entity added to hierarchy first
testEntity.addComponent("element");      // onEnable called, but type is still "group"
testEntity.element.type = "image";       // ImageElement created, but onEnable never called
// Image doesn't render!
```

**After (works):**
```javascript
const testEntity = new pc.Entity();
app.root.addChild(testEntity);
testEntity.addComponent("element");
testEntity.element.type = "image";
// Image renders correctly
```

### Changes

- `ImageElement` and `TextElement` constructors now check if the component is already enabled when they are created (i.e., type changed after initialization), and if so, call `onEnable()` to ensure the model is added to render layers
- Uses the existing `_beingInitialized` flag to distinguish between initial component setup vs. runtime type changes


## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
