### PR TITLE
[FIX] Add setter for Script.scriptName for TypeScript compatibility

### DIFF
--- a/src/framework/script/script.js
+++ b/src/framework/script/script.js
@@ -291,8 +291,6 @@ export class Script extends EventHandler {
     }
 
     /**
-     * Name of a Script Type.
-     *
      * @type {string|null}
      * @private
      */
@@ -306,7 +304,7 @@ export class Script extends EventHandler {
     static __getScriptName = getScriptName;
 
     /**
-     * Sets the name of a Script Type.
+     * Sets the unique name of the script.
      *
      * @type {string|null}
      */
@@ -315,7 +313,7 @@ export class Script extends EventHandler {
     }
 
     /**
-     * Gets the name of a Script Type.
+     * Gets the unique name of the script.
      *
      * @type {string|null}
      */


### PR DESCRIPTION
Fixes #8148

### Problem

When TypeScript is configured with `"useDefineForClassFields": false` (required by some libraries like Lit), defining `static scriptName` on a Script subclass fails at runtime:

```
Uncaught TypeError: Cannot set property scriptName of class Script ... which has only a getter
```

This happens because:
- With `useDefineForClassFields: false`, TypeScript transpiles `static scriptName = 'myScript'` to a simple assignment
- The assignment traverses the prototype chain and finds the getter-only property on `Script`
- Since there's no setter, the assignment fails

### Solution

Added a static setter for `scriptName` that assigns to `__name`, matching the getter's behavior.

### API Changes

None - this is a bug fix that enables existing documented usage to work in more TypeScript configurations.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
