### PR TITLE
Tighten up typing for RigidBodyComponent#type

### DIFF
--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -170,7 +170,10 @@ class RigidBodyComponent extends Component {
     /** @private */
     _simulationEnabled = false;
 
-    /** @private */
+    /**
+     * @type {BODYTYPE_DYNAMIC|BODYTYPE_KINEMATIC|BODYTYPE_STATIC}
+     * @private
+     */
     _type = BODYTYPE_STATIC;
 
     /** @ignore */
@@ -546,7 +549,7 @@ class RigidBodyComponent extends Component {
      *
      * Defaults to {@link BODYTYPE_STATIC}.
      *
-     * @type {string}
+     * @type {BODYTYPE_DYNAMIC|BODYTYPE_KINEMATIC|BODYTYPE_STATIC}
      */
     set type(type) {
         if (this._type !== type) {
@@ -579,7 +582,7 @@ class RigidBodyComponent extends Component {
     /**
      * Gets the rigid body type determines how the body is simulated.
      *
-     * @type {string}
+     * @type {BODYTYPE_DYNAMIC|BODYTYPE_KINEMATIC|BODYTYPE_STATIC}
      */
     get type() {
         return this._type;


### PR DESCRIPTION
This pull request improves type safety and documentation for the `type` property in the `RigidBodyComponent` class by specifying a more precise type annotation. The changes clarify that the `type` property can only be one of `BODYTYPE_DYNAMIC`, `BODYTYPE_KINEMATIC`, or `BODYTYPE_STATIC`, rather than a generic string.

Type annotation improvements for `RigidBodyComponent.type`:

* Updated the private `_type` property declaration to specify its type as `BODYTYPE_DYNAMIC|BODYTYPE_KINEMATIC|BODYTYPE_STATIC` instead of a generic type.
* Updated the setter and getter JSDoc comments for `type` to use the more precise type annotation, improving code clarity and tooling support. [[1]](diffhunk://#diff-c3ef3ed4b237f1d65d2aab9ae3709f5793c24d0b57a3c0c787e04be5e9d44e63L549-R552) [[2]](diffhunk://#diff-c3ef3ed4b237f1d65d2aab9ae3709f5793c24d0b57a3c0c787e04be5e9d44e63L582-R585)

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
