### PR TITLE
[FIX] Fix KHR_materials_specular incorrectly affecting metals and diffuse

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/lit/frag/metalnessModulate.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/metalnessModulate.js
@@ -1,7 +1,9 @@
 export default /* glsl */`
 
-vec3 getSpecularModulate(in vec3 specularity, in vec3 albedo, in float metalness, in float f0) {
-    vec3 dielectricF0 = f0 * specularity;
+vec3 getSpecularModulate(in vec3 specularity, in vec3 albedo, in float metalness, in float f0, in float specularityFactor) {
+    // Apply specularityFactor to dielectric F0 only. For metals (metalness=1), F0 is the albedo
+    // and should not be affected by specularityFactor per the KHR_materials_specular glTF spec.
+    vec3 dielectricF0 = f0 * specularity * specularityFactor;
     return mix(dielectricF0, albedo, metalness);
 }
 

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardBackend.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardBackend.js
@@ -23,7 +23,11 @@ void evaluateBackend() {
             float f0 = 1.0 / litArgs_ior;
             f0 = (f0 - 1.0) / (f0 + 1.0);
             f0 *= f0;
-            litArgs_specularity = getSpecularModulate(litArgs_specularity, litArgs_albedo, litArgs_metalness, f0);
+            #ifdef LIT_SPECULARITY_FACTOR
+                litArgs_specularity = getSpecularModulate(litArgs_specularity, litArgs_albedo, litArgs_metalness, f0, litArgs_specularityFactor);
+            #else
+                litArgs_specularity = getSpecularModulate(litArgs_specularity, litArgs_albedo, litArgs_metalness, f0, 1.0);
+            #endif
             litArgs_albedo = getAlbedoModulate(litArgs_albedo, litArgs_metalness);
         #endif
 
@@ -119,10 +123,6 @@ void evaluateBackend() {
 
             #endif
 
-            #ifdef LIT_SPECULARITY_FACTOR
-                dReflection.rgb *= litArgs_specularityFactor;
-            #endif
-
         #endif
 
         #ifdef AREA_LIGHTS
@@ -195,10 +195,6 @@ void evaluateBackend() {
         #if LIT_OCCLUDE_SPECULAR != NONE
             occludeSpecular(litArgs_gloss, litArgs_ao, litArgs_worldNormal, dViewDirW);
         #endif
-    #endif
-
-    #ifdef LIT_SPECULARITY_FACTOR
-        dSpecularLight *= litArgs_specularityFactor;
     #endif
 
     #if !defined(LIT_OPACITY_FADES_SPECULAR)

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/metalnessModulate.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/metalnessModulate.js
@@ -1,7 +1,9 @@
 export default /* glsl */`
 
-fn getSpecularModulate(specularity: vec3f, albedo: vec3f, metalness: f32, f0: f32) -> vec3f {
-    let dielectricF0: vec3f = f0 * specularity;
+fn getSpecularModulate(specularity: vec3f, albedo: vec3f, metalness: f32, f0: f32, specularityFactor: f32) -> vec3f {
+    // Apply specularityFactor to dielectric F0 only. For metals (metalness=1), F0 is the albedo
+    // and should not be affected by specularityFactor per the KHR_materials_specular glTF spec.
+    let dielectricF0: vec3f = f0 * specularity * specularityFactor;
     return mix(dielectricF0, albedo, metalness);
 }
 

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardBackend.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardBackend.js
@@ -25,7 +25,11 @@ fn evaluateBackend() -> FragmentOutput {
             var f0: f32 = 1.0 / litArgs_ior;
             f0 = (f0 - 1.0) / (f0 + 1.0);
             f0 = f0 * f0;
-            litArgs_specularity = getSpecularModulate(litArgs_specularity, litArgs_albedo, litArgs_metalness, f0);
+            #ifdef LIT_SPECULARITY_FACTOR
+                litArgs_specularity = getSpecularModulate(litArgs_specularity, litArgs_albedo, litArgs_metalness, f0, litArgs_specularityFactor);
+            #else
+                litArgs_specularity = getSpecularModulate(litArgs_specularity, litArgs_albedo, litArgs_metalness, f0, 1.0);
+            #endif
             litArgs_albedo = getAlbedoModulate(litArgs_albedo, litArgs_metalness);
         #endif
 
@@ -124,10 +128,6 @@ fn evaluateBackend() -> FragmentOutput {
 
             #endif
 
-            #ifdef LIT_SPECULARITY_FACTOR
-                dReflection = vec4f(dReflection.rgb * litArgs_specularityFactor, dReflection.a);
-            #endif
-
         #endif
 
         #ifdef AREA_LIGHTS
@@ -200,10 +200,6 @@ fn evaluateBackend() -> FragmentOutput {
         #if LIT_OCCLUDE_SPECULAR != NONE
             occludeSpecular(litArgs_gloss, litArgs_ao, litArgs_worldNormal, dViewDirW);
         #endif
-    #endif
-
-    #ifdef LIT_SPECULARITY_FACTOR
-        dSpecularLight = dSpecularLight * litArgs_specularityFactor;
     #endif
 
     #if !defined(LIT_OPACITY_FADES_SPECULAR)


### PR DESCRIPTION
This PR fixes an issue where `specularityFactor` from the `KHR_materials_specular` glTF extension was incorrectly applied to all materials, including metals. When `specularFactor: 0` was set, metallic materials would appear completely black because their specular reflections were incorrectly zeroed out.

glTF Sample Viewer (Reference):

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/35728b3b-6626-433b-a643-3eada6451659" />

Before Fix (PlayCanvas Model Viewer):

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/b9330c6a-0acf-41e4-90eb-c2883f9a99ad" />

After Fix (PlayCanvas Model Viewer):

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/c5aac9a8-19c4-4147-90e5-b54f3b9b2392" />

## Changes

- Modified `getSpecularModulate()` to incorporate `specularityFactor` directly into the dielectric F0 calculation
- Removed the post-multiplication of `dSpecularLight` and `dReflection` by `specularityFactor`
- For metals (metalness=1), F0 is now correctly derived from the base color, unaffected by `specularityFactor`
- For dielectrics (metalness=0), F0 is correctly scaled by `specularityFactor`

## Technical Details

According to the [KHR_materials_specular specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_specular/README.md):

```
dielectric_f0 = specularFactor * ior_f0 * specularColor
F0 = lerp(dielectric_f0, baseColor, metalness)
```

For metals, F0 should always be the base color regardless of `specularFactor`. The previous implementation applied `specularityFactor` as a post-multiplier to all specular outputs, which incorrectly affected metals.

### Before (incorrect)

```glsl
// F0 calculated without specularityFactor
litArgs_specularity = getSpecularModulate(specularity, albedo, metalness, f0);

// ... later, specularityFactor applied to ALL specular (including metals)
dSpecularLight *= litArgs_specularityFactor;
dReflection.rgb *= litArgs_specularityFactor;
```

### After (correct)

```glsl
// specularityFactor incorporated into dielectric F0 only
litArgs_specularity = getSpecularModulate(specularity, albedo, metalness, f0, specularityFactor);
// mix(dielectricF0 * specularityFactor, albedo, metalness) ensures metals use albedo as F0
```

## Testing

- All 91 existing tests pass
- Tested with glTF assets using `KHR_materials_specular` extension
- Metallic materials with `specularFactor: 0` now correctly show their base color as specular
- Dielectric materials with `specularFactor: 0` now correctly show full diffuse with no specular

## API Changes

None - this is a bugfix with no public API changes.

Fixes #7304


## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
