### PR TITLE
[FIX] Fix Non-Standard Fresnel Term to Match glTF 2.0 Spec

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/lit/frag/fresnelSchlick.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/fresnelSchlick.js
@@ -1,5 +1,6 @@
 export default /* glsl */`
-// Schlick's approximation
+// Schlick's approximation (glTF 2.0 compliant)
+// F = F0 + (F90 - F0) * (1 - V·H)^5, where F90 = 1.0
 vec3 getFresnel(
         float cosTheta, 
         float gloss, 
@@ -10,11 +11,7 @@ vec3 getFresnel(
 #endif
     ) {
     float fresnel = pow(1.0 - saturate(cosTheta), 5.0);
-    float glossSq = gloss * gloss;
-
-    // Scale gloss contribution by specularity intensity to ensure F90 approaches 0 when F0 is 0
-    float specIntensity = max(specularity.r, max(specularity.g, specularity.b));
-    vec3 ret = specularity + (max(vec3(glossSq * specIntensity), specularity) - specularity) * fresnel;
+    vec3 ret = specularity + (vec3(1.0) - specularity) * fresnel;
 
 #if defined(LIT_IRIDESCENCE)
     return mix(ret, iridescenceFresnel, iridescenceIntensity);

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/fresnelSchlick.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/fresnelSchlick.js
@@ -1,5 +1,6 @@
 export default /* wgsl */`
-// Schlick's approximation
+// Schlick's approximation (glTF 2.0 compliant)
+// F = F0 + (F90 - F0) * (1 - V·H)^5, where F90 = 1.0
 fn getFresnel(
         cosTheta: f32,
         gloss: f32,
@@ -10,11 +11,7 @@ fn getFresnel(
     #endif
 ) -> vec3f {
     let fresnel: f32 = pow(1.0 - saturate(cosTheta), 5.0);
-    let glossSq: f32 = gloss * gloss;
-
-    // Scale gloss contribution by specularity intensity to ensure F90 approaches 0 when F0 is 0
-    let specIntensity: f32 = max(specularity.r, max(specularity.g, specularity.b));
-    let ret: vec3f = specularity + (max(vec3f(glossSq * specIntensity), specularity) - specularity) * fresnel;
+    let ret: vec3f = specularity + (vec3f(1.0) - specularity) * fresnel;
 
     #if defined(LIT_IRIDESCENCE)
         return mix(ret, iridescenceFresnel, iridescenceIntensity);


### PR DESCRIPTION
Updates the Schlick Fresnel approximation to use the standard glTF 2.0 BRDF formula with F90 = 1.0, replacing the previous gloss-dependent implementation.

## Changes

- Modified `getFresnel()` in both GLSL and WGSL shaders to use standard Schlick: `F = F0 + (1 - F0) × (1 - cosθ)^5`
- Removed gloss-dependent F90 calculation that was causing deviation from glTF specification
- No API changes - function signature preserved for backward compatibility

## Technical Details

**Before:**
```glsl
float fresnel = pow(1.0 - saturate(cosTheta), 5.0);
float glossSq = gloss * gloss;
float specIntensity = max(specularity.r, max(specularity.g, specularity.b));
vec3 ret = specularity + (max(vec3(glossSq * specIntensity), specularity) - specularity) * fresnel;
```

This computed F90 as `max(gloss² × specIntensity, F0)`, causing rough materials to exhibit reduced Fresnel at grazing angles.

**After:**
```glsl
float fresnel = pow(1.0 - saturate(cosTheta), 5.0);
vec3 ret = specularity + (vec3(1.0) - specularity) * fresnel;
```

Standard Schlick with F90 = 1.0 as specified by glTF 2.0.

## Visual Impact

- Rough materials now show stronger rim lighting at grazing angles
- Rendering output now matches other glTF-compliant engines (Babylon.js, three.js, Filament)
- Clearcoat Fresnel (`getFresnelCC`) was already correct and unchanged

## Files Changed

- `src/scene/shader-lib/glsl/chunks/lit/frag/fresnelSchlick.js`
- `src/scene/shader-lib/wgsl/chunks/lit/frag/fresnelSchlick.js`

## Breaking Changes

This is a visual change that affects all PBR materials. Rough dielectric surfaces will appear brighter at grazing angles. Projects that relied on the previous behavior may need material adjustments.

Fixed #8294

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
