### PR TITLE
[FIX] Enforce WGSL syntax highlighting in all WGSL chunks

### DIFF
--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/lighting/lightEvaluation.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/lighting/lightEvaluation.js
@@ -1,5 +1,5 @@
 // evaluation of a light with index {i}, driven by defines
-export default /* glsl */`
+export default /* wgsl */`
 #if defined(LIGHT{i})
     evaluateLight{i}(
         #if defined(LIT_IRIDESCENCE)

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/lighting/shadowPCF3.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/lighting/shadowPCF3.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* wgsl */`
 // ----- Directional/Spot Sampling -----
 fn _getShadowPCF3x3(shadowMap: texture_depth_2d, shadowMapSampler: sampler_comparison, shadowCoord: vec3f, shadowParams: vec3f) -> f32 {
     let z: f32 = shadowCoord.z;

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/metalnessModulate.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/metalnessModulate.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* wgsl */`
 
 fn getSpecularModulate(specularity: vec3f, albedo: vec3f, metalness: f32, f0: f32, specularityFactor: f32) -> vec3f {
     // Apply specularityFactor to dielectric F0 only. For metals (metalness=1), F0 is the albedo

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionSheen.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionSheen.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* wgsl */`
 
 fn addReflectionSheen(worldNormal: vec3f, viewDir: vec3f, gloss: f32) {
     let NoV: f32 = dot(worldNormal, viewDir);

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/spot.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/spot.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* wgsl */`
 fn getSpotEffect(lightSpotDir: vec3f, lightInnerConeAngle: f32, lightOuterConeAngle: f32, lightDirNorm: vec3f) -> f32 {
     let cosAngle: f32 = dot(lightDirNorm, lightSpotDir);
     return smoothstep(lightOuterConeAngle, lightInnerConeAngle, cosAngle);

--- a/src/scene/shader-lib/wgsl/chunks/particle/frag/particle_blendNormal.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/frag/particle_blendNormal.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* wgsl */`
     if (a < 0.01) {
         discard;
     }

--- a/src/scene/shader-lib/wgsl/chunks/particle/frag/particle_lighting.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/frag/particle_lighting.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* wgsl */`
     let light: vec3f = negNormal.x * uniform.lightCube[0] + posNormal.x * uniform.lightCube[1] +
                        negNormal.y * uniform.lightCube[2] + posNormal.y * uniform.lightCube[3] +
                        negNormal.z * uniform.lightCube[4] + posNormal.z * uniform.lightCube[5];


### PR DESCRIPTION
This pull request updates several shader chunk files to clarify that they use the WGSL shading language instead of GLSL. The change is made by updating the comment in the default export of each file from `/* glsl */` to `/* wgsl */`. No functional or logic changes are introduced; this is a consistency and clarity improvement across the shader codebase.

Shader language annotation updates:

* Updated the language annotation in the default export from `/* glsl */` to `/* wgsl */` in the following files to accurately reflect the use of WGSL:
  - `src/scene/shader-lib/wgsl/chunks/lit/frag/lighting/lightEvaluation.js`
  - `src/scene/shader-lib/wgsl/chunks/lit/frag/lighting/shadowPCF3.js`
  - `src/scene/shader-lib/wgsl/chunks/lit/frag/metalnessModulate.js`
  - `src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionSheen.js`
  - `src/scene/shader-lib/wgsl/chunks/lit/frag/spot.js`
  - `src/scene/shader-lib/wgsl/chunks/particle/frag/particle_blendNormal.js`
  - `src/scene/shader-lib/wgsl/chunks/particle/frag/particle_lighting.js`

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
