### PR TITLE
[FIX] Fix screen space particles when CPU simulation is used

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/particle/vert/particle_cpu.js
+++ b/src/scene/shader-lib/glsl/chunks/particle/vert/particle_cpu.js
@@ -60,7 +60,11 @@ vec2 rotate(vec2 quadXY, float pRotation, out mat2 rotMatrix)
 
 vec3 billboard(vec3 InstanceCoords, vec2 quadXY)
 {
-    vec3 pos = -matrix_viewInverse[0].xyz * quadXY.x + -matrix_viewInverse[1].xyz * quadXY.y;
+    #ifdef SCREEN_SPACE
+        vec3 pos = vec3(-1, 0, 0) * quadXY.x + vec3(0, -1, 0) * quadXY.y;
+    #else
+        vec3 pos = -matrix_viewInverse[0].xyz * quadXY.x + -matrix_viewInverse[1].xyz * quadXY.y;
+    #endif
     return pos;
 }
 

--- a/src/scene/shader-lib/glsl/chunks/particle/vert/particle_cpu_end.js
+++ b/src/scene/shader-lib/glsl/chunks/particle/vert/particle_cpu_end.js
@@ -2,5 +2,9 @@ export default /* glsl */`
     localPos *= particle_vertexData2.y * emitterScale;
     localPos += particlePos;
 
+    #ifdef SCREEN_SPACE
+    gl_Position = vec4(localPos.x, localPos.y, 0.0, 1.0);
+    #else
     gl_Position = matrix_viewProjection * vec4(localPos, 1.0);
+    #endif
 `;

--- a/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_cpu.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_cpu.js
@@ -59,7 +59,12 @@ fn rotateWithMatrix(quadXY: vec2f, pRotation: f32) -> RotateResult {
 
 
 fn billboard(InstanceCoords: vec3f, quadXY: vec2f) -> vec3f {
-    let pos = -uniform.matrix_viewInverse[0].xyz * quadXY.x + -uniform.matrix_viewInverse[1].xyz * quadXY.y;
+    var pos: vec3f;
+    #ifdef SCREEN_SPACE
+        pos = vec3f(-1.0, 0.0, 0.0) * quadXY.x + vec3f(0.0, -1.0, 0.0) * quadXY.y;
+    #else
+        pos = -uniform.matrix_viewInverse[0].xyz * quadXY.x + -uniform.matrix_viewInverse[1].xyz * quadXY.y;
+    #endif
     return pos;
 }
 

--- a/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_cpu_end.js
+++ b/src/scene/shader-lib/wgsl/chunks/particle/vert/particle_cpu_end.js
@@ -2,5 +2,9 @@ export default /* wgsl */`
     localPos = localPos * input.particle_vertexData2.y * uniform.emitterScale;
     localPos = localPos + particlePos;
 
-    output.position = uniform.matrix_viewProjection * vec4f(localPos, 1.0);
+    #ifdef SCREEN_SPACE
+        output.position = vec4f(localPos.x, localPos.y, 0.0, 1.0);
+    #else
+        output.position = uniform.matrix_viewProjection * vec4f(localPos, 1.0);
+    #endif
 `;


### PR DESCRIPTION
Fixes #7534

When `screenSpace: true` is set on a particle system and CPU particles are used (either forced via `device.supportsGpuParticles = false` or when sorting is enabled), screen space particles were not rendering correctly.

## Changes

- Added `SCREEN_SPACE` handling to the CPU particle `billboard` function in both GLSL and WGSL shaders
- Added `SCREEN_SPACE` handling to the CPU particle position output in both GLSL and WGSL shaders

## Root Cause

The GPU particle shaders had proper `SCREEN_SPACE` conditional handling, but the CPU particle shaders were missing this logic entirely. This caused CPU particles to:

1. Use view-inverse matrix billboarding instead of simple axis-aligned billboarding for screen space
2. Transform positions through the view-projection matrix instead of outputting directly to normalized device coordinates

## Testing

Tested with the `user-interface/particle-system` example with CPU particles forced via:
```javascript
device.supportsGpuParticles = false;
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
