### PR TITLE
[FIX] Fix clustered lighting artifacts caused by UV precision

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/clusteredLight.js
@@ -580,7 +580,9 @@ void addClusteredLights(
         float cellIndex = dot(clusterCellsDot, cellCoords);
 
         // convert cell index to uv coordinates
-        float clusterV = floor(cellIndex * clusterTextureSize.y);
+        // add small epsilon before floor to handle precision issues at row boundaries
+        // where cellIndex/width should be an exact integer but computes slightly less
+        float clusterV = floor(cellIndex * clusterTextureSize.y + 0.0005);
         float clusterU = cellIndex - (clusterV * clusterTextureSize.x);
 
         // loop over maximum number of light cells

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/clusteredLight.js
@@ -592,7 +592,9 @@ fn addClusteredLights(
         let cellIndex: f32 = dot(uniform.clusterCellsDot, cellCoords);
 
         // convert cell index to uv coordinates
-        let clusterV: f32 = floor(cellIndex * uniform.clusterTextureSize.y);
+        // add small epsilon before floor to handle precision issues at row boundaries
+        // where cellIndex/width should be an exact integer but computes slightly less
+        let clusterV: f32 = floor(cellIndex * uniform.clusterTextureSize.y + 0.0005);
         let clusterU: f32 = cellIndex - (clusterV * uniform.clusterTextureSize.x);
 
         // loop over maximum number of light cells


### PR DESCRIPTION
Fixes #7923

### Summary

Fixes "square noise" artifacts in clustered lighting that appeared with certain `maxLightsPerCell` values (notably 40).

### Problem

When computing the cluster texture row coordinate, the calculation `floor(cellIndex * (1/width))` could produce incorrect results at row boundaries. Due to float32 precision, the product would sometimes be slightly less than the expected integer (e.g., `0.9999997` instead of `1.0`), causing `floor()` to return the wrong row.

This resulted in some cells reading light data from incorrect texture rows, creating visible grid-aligned artifacts.

### Solution

Add a small epsilon (0.0005) before the `floor()` operation:

```glsl
float clusterV = floor(cellIndex * clusterTextureSize.y + 0.0005);
```

The epsilon value is chosen to:
- Be large enough to correct float32 precision errors (up to ~5×10⁻⁴ for row 4096)
- Be small enough to not affect non-boundary cells (minimum fractional part is `maxLightsPerCell/width` ≥ 4/4096 ≈ 10⁻³ for reasonable configurations)

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
