### PR TITLE
Clustered lighting integer arithmetic optimization

### DIFF
--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -10,7 +10,7 @@ import { BoundingSphere } from '../../core/shape/bounding-sphere.js';
 import {
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL,
     BINDGROUP_MESH, BINDGROUP_VIEW, UNIFORM_BUFFER_DEFAULT_SLOT_NAME,
-    UNIFORMTYPE_MAT4, UNIFORMTYPE_MAT3, UNIFORMTYPE_VEC4, UNIFORMTYPE_VEC3, UNIFORMTYPE_VEC2, UNIFORMTYPE_FLOAT, UNIFORMTYPE_INT,
+    UNIFORMTYPE_MAT4, UNIFORMTYPE_MAT3, UNIFORMTYPE_VEC4, UNIFORMTYPE_VEC3, UNIFORMTYPE_IVEC3, UNIFORMTYPE_VEC2, UNIFORMTYPE_FLOAT, UNIFORMTYPE_INT,
     SHADERSTAGE_VERTEX, SHADERSTAGE_FRAGMENT,
     CULLFACE_BACK, CULLFACE_FRONT, CULLFACE_NONE,
     BINDGROUP_MESH_UB
@@ -766,14 +766,14 @@ class Renderer {
             if (isClustered) {
                 uniforms.push(...[
                     new UniformFormat('clusterCellsCountByBoundsSize', UNIFORMTYPE_VEC3),
-                    new UniformFormat('clusterTextureSize', UNIFORMTYPE_VEC3),
                     new UniformFormat('clusterBoundsMin', UNIFORMTYPE_VEC3),
                     new UniformFormat('clusterBoundsDelta', UNIFORMTYPE_VEC3),
-                    new UniformFormat('clusterCellsDot', UNIFORMTYPE_VEC3),
-                    new UniformFormat('clusterCellsMax', UNIFORMTYPE_VEC3),
+                    new UniformFormat('clusterCellsDot', UNIFORMTYPE_IVEC3),
+                    new UniformFormat('clusterCellsMax', UNIFORMTYPE_IVEC3),
                     new UniformFormat('shadowAtlasParams', UNIFORMTYPE_VEC2),
                     new UniformFormat('clusterMaxCells', UNIFORMTYPE_INT),
-                    new UniformFormat('clusterSkip', UNIFORMTYPE_FLOAT)
+                    new UniformFormat('numClusteredLights', UNIFORMTYPE_INT),
+                    new UniformFormat('clusterTextureWidth', UNIFORMTYPE_INT)
                 ]);
             }
 

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/clusteredLight.js
@@ -13,7 +13,7 @@ export default /* glsl */`
     #include "clusteredLightShadowsPS"
 #endif
 
-uniform highp sampler2D clusterWorldTexture;
+uniform highp usampler2D clusterWorldTexture;
 uniform highp sampler2D lightsTexture;
 
 #ifdef CLUSTER_SHADOWS
@@ -27,15 +27,17 @@ uniform highp sampler2D lightsTexture;
 
 uniform int clusterMaxCells;
 
-// 1.0 if clustered lighting can be skipped (0 lights in the clusters)
-uniform float clusterSkip;
+// number of lights in the cluster structure
+uniform int numClusteredLights;
+
+// width of the cluster texture
+uniform int clusterTextureWidth;
 
 uniform vec3 clusterCellsCountByBoundsSize;
-uniform vec3 clusterTextureSize;
 uniform vec3 clusterBoundsMin;
 uniform vec3 clusterBoundsDelta;
-uniform vec3 clusterCellsDot;
-uniform vec3 clusterCellsMax;
+uniform ivec3 clusterCellsDot;
+uniform ivec3 clusterCellsMax;
 uniform vec2 shadowAtlasParams;
 
 // structure storing light properties of a clustered light
@@ -120,10 +122,10 @@ vec4 sampleLightTextureF(const ClusterLightData clusterLightData, int index) {
     return texelFetch(lightsTexture, ivec2(index, clusterLightData.lightIndex), 0);
 }
 
-void decodeClusterLightCore(inout ClusterLightData clusterLightData, float lightIndex) {
+void decodeClusterLightCore(inout ClusterLightData clusterLightData, int lightIndex) {
 
     // light index
-    clusterLightData.lightIndex = int(lightIndex);
+    clusterLightData.lightIndex = lightIndex;
 
     // sample data encoding half-float values into 32bit uints
     vec4 halfData = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_COLOR_ANGLES_BIAS});
@@ -492,7 +494,7 @@ void evaluateLight(
 }
 
 void evaluateClusterLight(
-    float lightIndex, 
+    int lightIndex, 
     vec3 worldNormal, 
     vec3 viewDir, 
     vec3 reflectionDir, 
@@ -566,36 +568,34 @@ void addClusteredLights(
     float iridescence_intensity
 ) {
 
-    // skip lights if no lights at all
-    if (clusterSkip > 0.5)
+    // skip if no lights (index 0 is reserved for 'no light')
+    if (numClusteredLights <= 1)
         return;
 
     // world space position to 3d integer cell cordinates in the cluster structure
-    vec3 cellCoords = floor((vPositionW - clusterBoundsMin) * clusterCellsCountByBoundsSize);
+    ivec3 cellCoords = ivec3(floor((vPositionW - clusterBoundsMin) * clusterCellsCountByBoundsSize));
 
     // no lighting when cell coordinate is out of range
-    if (!(any(lessThan(cellCoords, vec3(0.0))) || any(greaterThanEqual(cellCoords, clusterCellsMax)))) {
+    if (!(any(lessThan(cellCoords, ivec3(0))) || any(greaterThanEqual(cellCoords, clusterCellsMax)))) {
 
         // cell index (mapping from 3d cell coordinates to linear memory)
-        float cellIndex = dot(clusterCellsDot, cellCoords);
+        int cellIndex = cellCoords.x * clusterCellsDot.x + cellCoords.y * clusterCellsDot.y + cellCoords.z * clusterCellsDot.z;
 
         // convert cell index to uv coordinates
-        // add small epsilon before floor to handle precision issues at row boundaries
-        // where cellIndex/width should be an exact integer but computes slightly less
-        float clusterV = floor(cellIndex * clusterTextureSize.y + 0.0005);
-        float clusterU = cellIndex - (clusterV * clusterTextureSize.x);
+        int clusterV = cellIndex / clusterTextureWidth;
+        int clusterU = cellIndex - clusterV * clusterTextureWidth;
 
         // loop over maximum number of light cells
         for (int lightCellIndex = 0; lightCellIndex < clusterMaxCells; lightCellIndex++) {
 
             // using a single channel texture with data in red channel
-            float lightIndex = texelFetch(clusterWorldTexture, ivec2(int(clusterU) + lightCellIndex, clusterV), 0).x;
+            uint lightIndex = texelFetch(clusterWorldTexture, ivec2(clusterU + lightCellIndex, clusterV), 0).x;
 
-            if (lightIndex <= 0.0)
+            if (lightIndex == 0u)
                 break;
 
             evaluateClusterLight(
-                lightIndex * 255.0, 
+                int(lightIndex), 
                 worldNormal, 
                 viewDir, 
                 reflectionDir,

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/clusteredLight.js
@@ -13,7 +13,7 @@ export default /* wgsl */`
     #include "clusteredLightShadowsPS"
 #endif
 
-var clusterWorldTexture: texture_2d<f32>;
+var clusterWorldTexture: texture_2d<u32>;
 var lightsTexture: texture_2d<uff>;
 
 #ifdef CLUSTER_SHADOWS
@@ -29,15 +29,17 @@ var lightsTexture: texture_2d<uff>;
 
 uniform clusterMaxCells: i32;
 
-// 1.0 if clustered lighting can be skipped (0 lights in the clusters)
-uniform clusterSkip: f32;
+// number of lights in the cluster structure
+uniform numClusteredLights: i32;
+
+// width of the cluster texture
+uniform clusterTextureWidth: i32;
 
 uniform clusterCellsCountByBoundsSize: vec3f;
-uniform clusterTextureSize: vec3f;
 uniform clusterBoundsMin: vec3f;
 uniform clusterBoundsDelta: vec3f;
-uniform clusterCellsDot: vec3f;
-uniform clusterCellsMax: vec3f;
+uniform clusterCellsDot: vec3i;
+uniform clusterCellsMax: vec3i;
 uniform shadowAtlasParams: vec2f;
 
 // structure storing light properties of a clustered light
@@ -122,10 +124,10 @@ fn sampleLightTextureF(lightIndex: i32, index: i32) -> vec4f {
     return textureLoad(lightsTexture, vec2<i32>(index, lightIndex), 0);
 }
 
-fn decodeClusterLightCore(clusterLightData: ptr<function, ClusterLightData>, lightIndex: f32) {
+fn decodeClusterLightCore(clusterLightData: ptr<function, ClusterLightData>, lightIndex: i32) {
 
     // light index
-    clusterLightData.lightIndex = i32(lightIndex);
+    clusterLightData.lightIndex = lightIndex;
 
     // sample data encoding half-float values into 32bit uints
     let halfData: vec4f = sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_COLOR_ANGLES_BIAS});
@@ -501,7 +503,7 @@ fn evaluateLight(
 
 
 fn evaluateClusterLight(
-    lightIndex: f32,
+    lightIndex: i32,
     worldNormal: vec3f,
     viewDir: vec3f,
     reflectionDir: vec3f,
@@ -577,38 +579,36 @@ fn addClusteredLights(
     iridescence_intensity: f32
 ) {
 
-    // skip lights if no lights at all
-    if (uniform.clusterSkip > 0.5) {
+    // skip if no lights (index 0 is reserved for 'no light')
+    if (uniform.numClusteredLights <= 1) {
         return;
     }
 
     // world space position to 3d integer cell cordinates in the cluster structure
-    let cellCoords: vec3f = floor((vPositionW - uniform.clusterBoundsMin) * uniform.clusterCellsCountByBoundsSize);
+    let cellCoords: vec3i = vec3i(floor((vPositionW - uniform.clusterBoundsMin) * uniform.clusterCellsCountByBoundsSize));
 
     // no lighting when cell coordinate is out of range
-    if (!(any(cellCoords < vec3f(0.0)) || any(cellCoords >= uniform.clusterCellsMax))) {
+    if (!(any(cellCoords < vec3i(0)) || any(cellCoords >= uniform.clusterCellsMax))) {
 
         // cell index (mapping from 3d cell coordinates to linear memory)
-        let cellIndex: f32 = dot(uniform.clusterCellsDot, cellCoords);
+        let cellIndex: i32 = cellCoords.x * uniform.clusterCellsDot.x + cellCoords.y * uniform.clusterCellsDot.y + cellCoords.z * uniform.clusterCellsDot.z;
 
         // convert cell index to uv coordinates
-        // add small epsilon before floor to handle precision issues at row boundaries
-        // where cellIndex/width should be an exact integer but computes slightly less
-        let clusterV: f32 = floor(cellIndex * uniform.clusterTextureSize.y + 0.0005);
-        let clusterU: f32 = cellIndex - (clusterV * uniform.clusterTextureSize.x);
+        let clusterV: i32 = cellIndex / uniform.clusterTextureWidth;
+        let clusterU: i32 = cellIndex - clusterV * uniform.clusterTextureWidth;
 
         // loop over maximum number of light cells
         for (var lightCellIndex: i32 = 0; lightCellIndex < uniform.clusterMaxCells; lightCellIndex = lightCellIndex + 1) {
 
             // using a single channel texture with data in red channel
-            let lightIndexPacked: f32 = textureLoad(clusterWorldTexture, vec2<i32>(i32(clusterU) + lightCellIndex, i32(clusterV)), 0).r;
+            let lightIndex: u32 = textureLoad(clusterWorldTexture, vec2<i32>(clusterU + lightCellIndex, clusterV), 0).r;
 
-            if (lightIndexPacked <= 0.0) {
+            if (lightIndex == 0u) {
                 break;
             }
 
             evaluateClusterLight(
-                lightIndexPacked * 255.0,
+                i32(lightIndex),
                 worldNormal,
                 viewDir,
                 reflectionDir,


### PR DESCRIPTION
## Overview

Refactors clustered lighting shaders to use proper integer arithmetic instead of floating-point emulation now that WebGL 1 support is not needed. This eliminates precision workarounds (epsilon), removes unnecessary type conversions, and uses more appropriate data types throughout the lighting pipeline.

## Changes

- Replace float-based UV calculations with integer division/modulo
- Convert cluster uniforms to integer types where semantically appropriate (`clusterCellsDot`, `clusterCellsMax`, `numClusteredLights`, `clusterTextureWidth`)
- Change cluster texture format from normalized float (R8) to unsigned integer (R8U)
- Pass light index as integer through the decode/evaluate chain
- Remove the `clusterTextureSize` vec3 uniform, add simpler `clusterTextureWidth` int uniform

## Benefits

- Cleaner, more type-correct code
- Eliminates floating-point precision workarounds
- Removes unnecessary float↔int conversions per light
- Slightly reduced uniform buffer size