### PR TITLE
Make Texture.read() a public API

### DIFF
--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -1159,8 +1159,6 @@ class Texture {
     /**
      * Download the textures data from the graphics memory to the local memory.
      *
-     * Note a public API yet, as not all options are implemented on all platforms.
-     *
      * @param {number} x - The left edge of the rectangle.
      * @param {number} y - The top edge of the rectangle.
      * @param {number} width - The width of the rectangle.
@@ -1180,7 +1178,6 @@ class Texture {
      * to false.
      * @returns {Promise<Uint8Array|Uint16Array|Uint32Array|Float32Array>} A promise that resolves
      * with the pixel data of the texture.
-     * @ignore
      */
     read(x, y, width, height, options = {}) {
         return this.impl.read?.(x, y, width, height, options);

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2080,12 +2080,14 @@ class WebglGraphicsDevice extends GraphicsDevice {
     readTextureAsync(texture, x, y, width, height, options) {
 
         const face = options.face ?? 0;
+        const mipLevel = options.mipLevel ?? 0;
 
         // create a temporary render target if needed
         const renderTarget = options.renderTarget ?? new RenderTarget({
             colorBuffer: texture,
             depth: false,
-            face: face
+            face: face,
+            mipLevel: mipLevel
         });
         Debug.assert(renderTarget.colorBuffer === texture);
 
@@ -2095,6 +2097,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.setRenderTarget(renderTarget);
         this.initRenderTarget(renderTarget);
         this.setFramebuffer(renderTarget.impl._glFrameBuffer);
+
+        // flush commands to GPU immediately if requested
+        if (options.immediate) {
+            this.gl.flush();
+        }
 
         return new Promise((resolve, reject) => {
             this.readPixelsAsync(x, y, width, height, data).then((data) => {


### PR DESCRIPTION
# Make Texture.read() a public API

## Overview

Completes the `Texture.read()` API implementation and makes it public. This method allows downloading texture data from GPU memory to local memory asynchronously.

## Changes

- Add `mipLevel` option support to WebGL backend
- Add `immediate` option support to WebGL backend (calls `gl.flush()` to expedite GPU command submission)
- Remove `@ignore` tag to make the API public

## API

```
texture.read(x, y, width, height, {
    mipLevel: 0,        // which mip level to read
    face: 0,            // which cubemap face to read
    data: null,         // optional pre-allocated buffer
    immediate: false,   // flush commands immediately
    renderTarget: null  // optimization for WebGL (reuse RT)
}).then(data => {
    // data is Uint8Array, Float32Array, etc. based on texture format
});
```