### PR TITLE
[FIX] Fix glTF spot light luminance calculation

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -1624,10 +1624,11 @@ const createLight = (gltfLight, node) => {
     }
 
     // glTF stores light intensity in energy/area, convert to luminance
+    // getLightUnitConversion expects angles in radians, use original glTF values
     if (gltfLight.hasOwnProperty('intensity')) {
-        const outerConeAngle = lightProps.outerConeAngle ?? 0;
-        const innerConeAngle = lightProps.innerConeAngle ?? 0;
-        lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(lightTypes[lightProps.type], outerConeAngle, innerConeAngle);
+        const outerAngleRad = gltfLight.spot?.outerConeAngle ?? (Math.PI / 4);
+        const innerAngleRad = gltfLight.spot?.innerConeAngle ?? 0;
+        lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(lightTypes[lightProps.type], outerAngleRad, innerAngleRad);
     }
 
     // Rotate to match light orientation in glTF specification


### PR DESCRIPTION
Fixes luminance calculation to pass radian values to `getLightUnitConversion`, which expects radians.

## Changes

- Fixed luminance calculation to use original glTF radian values instead of converted degree values

## Technical Details

`Light.getLightUnitConversion` uses `Math.cos()` on the cone angles, which expects radians. The code was incorrectly passing the already-converted degree values.

**Before:**
```javascript
if (gltfLight.hasOwnProperty('intensity')) {
    const outerConeAngle = lightProps.outerConeAngle ?? 0;
    const innerConeAngle = lightProps.innerConeAngle ?? 0;
    lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(
        lightTypes[lightProps.type], outerConeAngle, innerConeAngle);
}
```

**After:**
```javascript
if (gltfLight.hasOwnProperty('intensity')) {
    const outerAngleRad = gltfLight.spot?.outerConeAngle ?? (Math.PI / 4);
    const innerAngleRad = gltfLight.spot?.innerConeAngle ?? 0;
    lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(
        lightTypes[lightProps.type], outerAngleRad, innerAngleRad);
}
```

Now uses the original glTF radian values directly, with defaults matching the glTF spec (π/4 for outer, 0 for inner).


## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
