### PR TITLE
Optimize texture tracking with Set-based dirty texture management

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -264,12 +264,20 @@ class GraphicsDevice extends EventHandler {
     shaders = [];
 
     /**
-     * An array of currently created textures.
+     * A set of currently created textures.
      *
-     * @type {Texture[]}
+     * @type {Set<Texture>}
      * @ignore
      */
-    textures = [];
+    textures = new Set();
+
+    /**
+     * A set of textures that need to be uploaded to the GPU.
+     *
+     * @type {Set<Texture>}
+     * @ignore
+     */
+    texturesToUpload = new Set();
 
     /**
      * A set of currently created render targets.
@@ -580,6 +588,18 @@ class GraphicsDevice extends EventHandler {
         if (idx !== -1) {
             this.shaders.splice(idx, 1);
         }
+    }
+
+    /**
+     * Called when a texture is destroyed to remove it from internal tracking structures.
+     *
+     * @param {Texture} texture - The texture being destroyed.
+     * @ignore
+     */
+    onTextureDestroyed(texture) {
+        this.textures.delete(texture);
+        this.texturesToUpload.delete(texture);
+        this.scope.removeValue(texture);
     }
 
     // executes after the extended classes have executed their destroy function
@@ -1043,7 +1063,7 @@ class GraphicsDevice extends EventHandler {
 
             // log out all loaded textures, sorted by gpu memory size
             if (Tracing.get(TRACEID_TEXTURES)) {
-                const textures = this.textures.slice();
+                const textures = [...this.textures];
                 textures.sort((a, b) => b.gpuSize - a.gpuSize);
                 Debug.log(`Textures: ${textures.length}`);
                 let textureTotal = 0;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -679,6 +679,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
     }
 
     createTextureImpl(texture) {
+        this.textures.add(texture);
         return new WebglTexture(texture);
     }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -510,6 +510,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     }
 
     createTextureImpl(texture) {
+        this.textures.add(texture);
         return new WebgpuTexture(texture);
     }
 
@@ -791,12 +792,12 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     }
 
     _uploadDirtyTextures() {
-
-        this.textures.forEach((texture) => {
-            if (texture._needsUpload || texture._needsMipmaps) {
+        this.texturesToUpload.forEach((texture) => {
+            if (texture._needsUpload || texture._needsMipmapsUpload) {
                 texture.upload();
             }
         });
+        this.texturesToUpload.clear();
     }
 
     setupTimeStampWrites(passDesc, name) {
@@ -922,6 +923,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     }
 
     startComputePass(name) {
+
+        // upload textures that need it, to avoid them being uploaded during the pass
+        this._uploadDirtyTextures();
 
         WebgpuDebug.internal(this);
         WebgpuDebug.validate(this);


### PR DESCRIPTION
partially solves https://github.com/playcanvas/engine/issues/5717

Optimizes texture upload tracking by avoiding iteration over all textures before render/compute passes.

**Changes:**
- Convert `textures` from array to `Set` for O(1) deletion on destroy
- Add `texturesToUpload` Set to track only textures needing upload
- Add `markForUpload()` method on Texture that sets the dirty flag and adds to the upload set
- Update `_uploadDirtyTextures()` to iterate the dirty set instead of all textures
- Call `_uploadDirtyTextures()` before compute passes (previously only called before render passes)
- Add `onTextureDestroyed()` for centralized texture cleanup
- Move texture registration into `createTextureImpl()` 

**Performance impact:**
- Dirty texture upload check: O(dirty) instead of O(all textures)
- Texture deletion: O(1) instead of O(n)