### PR TITLE
Clean up camera shader parameter setup

### DIFF
--- a/src/extras/render-passes/render-pass-coc.js
+++ b/src/extras/render-passes/render-pass-coc.js
@@ -56,8 +56,7 @@ class RenderPassCoC extends RenderPassShaderQuad {
         this.paramsId.setValue(paramsValue);
 
         const camera = this.cameraComponent.camera;
-        camera.fillShaderParams(this.cameraParams);
-        this.cameraParamsId.setValue(this.cameraParams);
+        this.cameraParamsId.setValue(camera.fillShaderParams(this.cameraParams));
 
         super.execute();
     }

--- a/src/extras/render-passes/render-pass-taa.js
+++ b/src/extras/render-passes/render-pass-taa.js
@@ -132,8 +132,7 @@ class RenderPassTAA extends RenderPassShaderQuad {
         this.viewProjInvId.setValue(camera._viewProjInverse.data);
         this.jittersId.setValue(camera._jitters);
 
-        camera.fillShaderParams(this.cameraParams);
-        this.cameraParamsId.setValue(this.cameraParams);
+        this.cameraParamsId.setValue(camera.fillShaderParams(this.cameraParams));
     }
 
     // called when the parent render pass gets added to the frame graph

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -760,6 +760,7 @@ class Camera {
      * The array format is: [1/far, far, near, isOrtho].
      *
      * @param {Float32Array} output - Array to fill with camera parameters.
+     * @returns {Float32Array} The output array.
      * @ignore
      */
     fillShaderParams(output) {
@@ -768,6 +769,7 @@ class Camera {
         output[1] = f;
         output[2] = this._nearClip;
         output[3] = this._projection === PROJECTION_ORTHOGRAPHIC ? 1 : 0;
+        return output;
     }
 }
 

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -422,8 +422,7 @@ class Renderer {
         this.tbnBasis.setValue(flipY ? -1 : 1);
 
         // camera params
-        camera.fillShaderParams(this.cameraParams);
-        this.cameraParamsId.setValue(this.cameraParams);
+        this.cameraParamsId.setValue(camera.fillShaderParams(this.cameraParams));
 
         // viewport size
         let viewportWidth = target ? target.width : this.device.width;


### PR DESCRIPTION
Removes redundant uniform setters and consolidates camera parameter setup code.

**Changes:**
- Removed unused `camera_near` and `camera_far` uniform setters from the renderer - these values are already provided via `camera_params` and no shaders consume the standalone uniforms
- Added `Camera.fillShaderParams()` method to centralize camera params array population
- Updated renderer, TAA render pass, and CoC render pass to use the new method, eliminating duplicate code