### PR TITLE
Add WebGPU texture-format-tier1, texture-format-tier2, and primitive-index features

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -316,6 +316,16 @@ class GraphicsDevice extends EventHandler {
     supportsClipDistances = false;
 
     /**
+     * True if the device supports primitive index in fragment shaders (WebGPU only). When
+     * supported, fragment shaders can access the `pcPrimitiveIndex` built-in variable which
+     * uniquely identifies the current primitive being processed.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    supportsPrimitiveIndex = false;
+
+    /**
      * True if 32-bit floating-point textures can be used as a frame buffer.
      *
      * @type {boolean}
@@ -545,6 +555,7 @@ class GraphicsDevice extends EventHandler {
         if (this.textureFloatFilterable) capsDefines.set('CAPS_TEXTURE_FLOAT_FILTERABLE', '');
         if (this.textureFloatRenderable) capsDefines.set('CAPS_TEXTURE_FLOAT_RENDERABLE', '');
         if (this.supportsMultiDraw) capsDefines.set('CAPS_MULTI_DRAW', '');
+        if (this.supportsPrimitiveIndex) capsDefines.set('CAPS_PRIMITIVE_INDEX', '');
 
         // Platform defines
         if (platform.desktop) capsDefines.set('PLATFORM_DESKTOP', '');

--- a/src/platform/graphics/shader-definition-utils.js
+++ b/src/platform/graphics/shader-definition-utils.js
@@ -115,7 +115,12 @@ class ShaderDefinitionUtils {
 
         const getDefinesWgsl = (isVertex, options) => {
 
-            let attachmentsDefine = '';
+            let code = '';
+
+            // Enable directives must come before all global declarations
+            if (!isVertex && device.supportsPrimitiveIndex) {
+                code += 'enable primitive_index;\n';
+            }
 
             // Define the fragment shader output type, vec4 by default
             if (!isVertex) {
@@ -126,11 +131,11 @@ class ShaderDefinitionUtils {
                     const glslOutType = fragmentOutputTypes[i] ?? 'vec4';
                     const wgslOutType = primitiveGlslToWgslTypeMap.get(glslOutType);
                     Debug.assert(wgslOutType, `Unknown output type translation: ${glslOutType} -> ${wgslOutType}`);
-                    attachmentsDefine += `alias pcOutType${i} = ${wgslOutType};\n`;
+                    code += `alias pcOutType${i} = ${wgslOutType};\n`;
                 }
             }
 
-            return attachmentsDefine;
+            return code;
         };
 
         const name = options.name ?? 'Untitled';
@@ -145,17 +150,17 @@ class ShaderDefinitionUtils {
 
             vertCode = `
                 ${getDefinesWgsl(true, options)}
+                ${vertexDefinesCode}
                 ${wgslVS}
                 ${sharedWGSL}
-                ${vertexDefinesCode}
                 ${options.vertexCode}
             `;
 
             fragCode = `
                 ${getDefinesWgsl(false, options)}
+                ${fragmentDefinesCode}
                 ${wgslFS}
                 ${sharedWGSL}
-                ${fragmentDefinesCode}
                 ${options.fragmentCode}
             `;
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -277,6 +277,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsStorageRGBA8 = requireFeature('bgra8unorm-storage');
         this.textureRG11B10Renderable = requireFeature('rg11b10ufloat-renderable');
         this.supportsClipDistances = requireFeature('clip-distances');
+        this.supportsTextureFormatTier1 = requireFeature('texture-format-tier1');
+        this.supportsTextureFormatTier2 = requireFeature('texture-format-tier2');
+        this.supportsPrimitiveIndex = requireFeature('primitive-index');
         Debug.log(`WEBGPU features: ${requiredFeatures.join(', ')}`);
 
         // copy all adapter limits to the requiredLimits object - to created a device with the best feature sets available


### PR DESCRIPTION
Adds support for new WebGPU features:

- Request `texture-format-tier1` and `texture-format-tier2` GPU features for extended texture format support
- Request `primitive-index` feature and expose `pcPrimitiveIndex` built-in in fragment shaders
- Add `supportsPrimitiveIndex` public property to GraphicsDevice
- Add `CAPS_PRIMITIVE_INDEX` shader define when the feature is supported
- Reorder WGSL shader assembly to place defines before preamble chunks (order matches WebGL now)

When `primitive-index` is supported, fragment shaders can access `pcPrimitiveIndex` which uniquely identifies the current primitive being processed.

based on https://developer.chrome.com/blog/new-in-webgpu-142