### PR TITLE
Adds a configurable color property to the vignette post-effect

### DIFF
--- a/examples/src/examples/graphics/post-processing.controls.mjs
+++ b/examples/src/examples/graphics/post-processing.controls.mjs
@@ -5,7 +5,7 @@ import * as pc from 'playcanvas';
  * @returns {JSX.Element} The returned JSX Element.
  */
 export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
-    const { BindingTwoWay, BooleanInput, LabelGroup, Panel, SelectInput, SliderInput } = ReactPCUI;
+    const { BindingTwoWay, BooleanInput, ColorPicker, LabelGroup, Panel, SelectInput, SliderInput } = ReactPCUI;
     return fragment(
         jsx(
             LabelGroup,
@@ -220,6 +220,14 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     min: 0,
                     max: 1,
                     precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'color' },
+                jsx(ColorPicker, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.vignette.color' }
                 })
             )
         ),

--- a/examples/src/examples/graphics/post-processing.example.mjs
+++ b/examples/src/examples/graphics/post-processing.example.mjs
@@ -261,6 +261,10 @@ assetListLoader.load(() => {
         cameraFrame.vignette.outer = data.get('data.vignette.outer');
         cameraFrame.vignette.curvature = data.get('data.vignette.curvature');
         cameraFrame.vignette.intensity = data.get('data.vignette.enabled') ? data.get('data.vignette.intensity') : 0;
+        const vignetteColor = data.get('data.vignette.color');
+        if (vignetteColor) {
+            cameraFrame.vignette.color.set(vignetteColor[0], vignetteColor[1], vignetteColor[2]);
+        }
 
         // fringing
         cameraFrame.fringing.intensity = data.get('data.fringing.enabled') ? data.get('data.fringing.intensity') : 0;
@@ -308,7 +312,8 @@ assetListLoader.load(() => {
             inner: 0.5,
             outer: 1.0,
             curvature: 0.5,
-            intensity: 0.3
+            intensity: 0.3,
+            color: [0, 0, 0]
         },
         fringing: {
             enabled: false,

--- a/scripts/esm/camera-frame.mjs
+++ b/scripts/esm/camera-frame.mjs
@@ -276,6 +276,12 @@ class Vignette {
      * @step 0.001
      */
     curvature = 0.5;
+
+    /**
+     * @attribute
+     * @visibleif {enabled}
+     */
+    color = new Color(0, 0, 0, 1);
 }
 
 /** @interface */
@@ -499,6 +505,7 @@ class CameraFrame extends Script {
             dstVignette.inner = vignette.inner;
             dstVignette.outer = vignette.outer;
             dstVignette.curvature = vignette.curvature;
+            dstVignette.color.copy(vignette.color);
         }
 
         // taa

--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -127,6 +127,7 @@ import { CameraFrameOptions, RenderPassCameraFrame } from './render-pass-camera-
  * is rendered using a rectangle with rounded corners, and this parameter controls the curvature of
  * the corners. Value of 1 represents a circle. Smaller values make the corners more square, while
  * larger values make them more rounded. Defaults to 0.5.
+ * @property {Color} color - The color of the vignette effect. Defaults to black.
  */
 
 /**
@@ -272,7 +273,8 @@ class CameraFrame {
         intensity: 0,
         inner: 0.5,
         outer: 1,
-        curvature: 0.5
+        curvature: 0.5,
+        color: new Color(0, 0, 0)
     };
 
     /**
@@ -488,6 +490,7 @@ class CameraFrame {
             composePass.vignetteOuter = vignette.outer;
             composePass.vignetteCurvature = vignette.curvature;
             composePass.vignetteIntensity = vignette.intensity;
+            composePass.vignetteColor.copy(vignette.color);
         }
 
         composePass.fringingEnabled = fringing.intensity > 0;

--- a/src/extras/render-passes/render-pass-compose.js
+++ b/src/extras/render-passes/render-pass-compose.js
@@ -61,6 +61,8 @@ class RenderPassCompose extends RenderPassShaderQuad {
 
     vignetteIntensity = 0.3;
 
+    vignetteColor = new Color(0, 0, 0);
+
     _fringingEnabled = false;
 
     fringingIntensity = 10;
@@ -106,6 +108,7 @@ class RenderPassCompose extends RenderPassShaderQuad {
         this.bcsId = scope.resolve('brightnessContrastSaturation');
         this.tintId = scope.resolve('tint');
         this.vignetterParamsId = scope.resolve('vignetterParams');
+        this.vignetteColorId = scope.resolve('vignetteColor');
         this.fringingIntensityId = scope.resolve('fringingIntensity');
         this.sceneTextureInvResId = scope.resolve('sceneTextureInvRes');
         this.sceneTextureInvResValue = new Float32Array(2);
@@ -368,6 +371,7 @@ class RenderPassCompose extends RenderPassShaderQuad {
 
         if (this._vignetteEnabled) {
             this.vignetterParamsId.setValue([this.vignetteInner, this.vignetteOuter, this.vignetteCurvature, this.vignetteIntensity]);
+            this.vignetteColorId.setValue([this.vignetteColor.r, this.vignetteColor.g, this.vignetteColor.b]);
         }
 
         if (this._fringingEnabled) {

--- a/src/scene/shader-lib/glsl/chunks/render-pass/frag/compose/compose-vignette.js
+++ b/src/scene/shader-lib/glsl/chunks/render-pass/frag/compose/compose-vignette.js
@@ -1,6 +1,7 @@
 export default /* glsl */`
     #ifdef VIGNETTE
         uniform vec4 vignetterParams;
+        uniform vec3 vignetteColor;
         
         // Global variable for debug
         float dVignette;
@@ -23,7 +24,7 @@ export default /* glsl */`
         }
 
         vec3 applyVignette(vec3 color, vec2 uv) {
-            return color * calcVignette(uv);
+            return mix(vignetteColor, color, calcVignette(uv));
         }
     #endif
 `;

--- a/src/scene/shader-lib/wgsl/chunks/render-pass/frag/compose/compose-vignette.js
+++ b/src/scene/shader-lib/wgsl/chunks/render-pass/frag/compose/compose-vignette.js
@@ -1,6 +1,7 @@
 export default /* wgsl */`
     #ifdef VIGNETTE
         uniform vignetterParams: vec4f;
+        uniform vignetteColor: vec3f;
         
         // Global variable for debug
         var<private> dVignette: f32;
@@ -23,7 +24,7 @@ export default /* wgsl */`
         }
 
         fn applyVignette(color: vec3f, uv: vec2f) -> vec3f {
-            return color * calcVignette(uv);
+            return mix(uniform.vignetteColor, color, calcVignette(uv));
         }
     #endif
 `;


### PR DESCRIPTION
# Add vignette color support

Adds a configurable color property to the vignette post-effect, allowing the vignette to blend toward any color instead of only black.

## Changes

- Added `vignetteColor` uniform to both GLSL and WGSL vignette shader chunks
- Modified `applyVignette` to use `mix()` for blending toward the specified color
- Added `vignetteColor` property to `RenderPassCompose`
- Added `color` to `Vignette` settings in `CameraFrame` API (defaults to black)
- Added `color` attribute to the `camera-frame.mjs` script wrapper
- Updated post-processing example with a color picker control for vignette

## API

cameraFrame.vignette.color = new pc.Color(0.2, 0, 0); // Dark red vignette

<img width="1332" height="1055" alt="Screenshot 2025-12-24 at 15 11 15" src="https://github.com/user-attachments/assets/ec01989a-9f85-425d-9fe0-615fe7aff86b" />
