### PR TITLE
Add new texture formats: RG32F, RGB9E5, RG8S, RGBA8S, RGB10A2, RGB10A2U 

### DIFF
--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -927,6 +927,48 @@ export const PIXELFORMAT_BC7_SRGBA = 68;
 export const PIXELFORMAT_DEPTH16 = 69;
 
 /**
+ * 32-bit floating point RG (32-bit float for each red and green channels). WebGPU only.
+ *
+ * @category Graphics
+ */
+export const PIXELFORMAT_RG32F = 70;
+
+/**
+ * 32-bit RGB format with shared 5-bit exponent (9 bits each for RGB mantissa). HDR format.
+ *
+ * @category Graphics
+ */
+export const PIXELFORMAT_RGB9E5 = 71;
+
+/**
+ * 8-bit per-channel signed normalized (RG) format.
+ *
+ * @category Graphics
+ */
+export const PIXELFORMAT_RG8S = 72;
+
+/**
+ * 8-bit per-channel signed normalized (RGBA) format.
+ *
+ * @category Graphics
+ */
+export const PIXELFORMAT_RGBA8S = 73;
+
+/**
+ * 10-bit RGB with 2-bit alpha unsigned normalized format.
+ *
+ * @category Graphics
+ */
+export const PIXELFORMAT_RGB10A2 = 74;
+
+/**
+ * 10-bit RGB with 2-bit alpha unsigned integer format.
+ *
+ * @category Graphics
+ */
+export const PIXELFORMAT_RGB10A2U = 75;
+
+/**
  * Information about pixel formats.
  *
  * ldr: whether the format is low dynamic range (LDR), which typically means it's not HDR, and uses
@@ -956,6 +998,12 @@ export const pixelFormatInfo = new Map([
     [PIXELFORMAT_RGB32F,        { name: 'RGB32F', size: 16 }],
     [PIXELFORMAT_RGBA32F,       { name: 'RGBA32F', size: 16 }],
     [PIXELFORMAT_R32F,          { name: 'R32F', size: 4 }],
+    [PIXELFORMAT_RG32F,         { name: 'RG32F', size: 8 }],
+    [PIXELFORMAT_RGB9E5,        { name: 'RGB9E5', size: 4 }],
+    [PIXELFORMAT_RG8S,          { name: 'RG8S', size: 2 }],
+    [PIXELFORMAT_RGBA8S,        { name: 'RGBA8S', size: 4 }],
+    [PIXELFORMAT_RGB10A2,       { name: 'RGB10A2', size: 4 }],
+    [PIXELFORMAT_RGB10A2U,      { name: 'RGB10A2U', size: 4, isInt: true }],
     [PIXELFORMAT_DEPTH,         { name: 'DEPTH', size: 4 }],
     [PIXELFORMAT_DEPTH16,       { name: 'DEPTH16', size: 2 }],
     [PIXELFORMAT_DEPTHSTENCIL,  { name: 'DEPTHSTENCIL', size: 4 }],
@@ -1074,6 +1122,7 @@ export const requiresManualGamma = (format) => {
 export const getPixelFormatArrayType = (format) => {
     switch (format) {
         case PIXELFORMAT_R32F:
+        case PIXELFORMAT_RG32F:
         case PIXELFORMAT_RGB32F:
         case PIXELFORMAT_RGBA32F:
             return Float32Array;
@@ -1084,6 +1133,9 @@ export const getPixelFormatArrayType = (format) => {
         case PIXELFORMAT_R32U:
         case PIXELFORMAT_RG32U:
         case PIXELFORMAT_RGBA32U:
+        case PIXELFORMAT_RGB9E5:
+        case PIXELFORMAT_RGB10A2:
+        case PIXELFORMAT_RGB10A2U:
             return Uint32Array;
         case PIXELFORMAT_R16I:
         case PIXELFORMAT_RG16I:
@@ -1104,6 +1156,8 @@ export const getPixelFormatArrayType = (format) => {
         case PIXELFORMAT_R8I:
         case PIXELFORMAT_RG8I:
         case PIXELFORMAT_RGBA8I:
+        case PIXELFORMAT_RG8S:
+        case PIXELFORMAT_RGBA8S:
             return Int8Array;
         default:
             return Uint8Array;

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -46,6 +46,8 @@ let id = 0;
  * sampling.
  *     - float formats are supported on WebGL2 and WebGPU with linear sampling only if
  * {@link GraphicsDevice#textureFloatFilterable} is true.
+ *     - {@link PIXELFORMAT_RGB9E5} is a compact HDR format with shared exponent, supported for
+ * sampling on both WebGL2 and WebGPU, but cannot be used as a render target.
  *
  * 2. **As renderable textures** that can be used as color buffers in a {@link RenderTarget}:
  *     - on WebGPU, rendering to float and half-float formats is always supported.
@@ -58,6 +60,9 @@ let id = 0;
  * is supported. This is the case of many mobile iOS devices.
  *     - you can determine available renderable HDR format using
  * {@link GraphicsDevice#getRenderableHdrFormat}.
+ *     - {@link PIXELFORMAT_RGB10A2} provides 10 bits per RGB channel with 2-bit alpha, offering
+ * higher precision than {@link PIXELFORMAT_RGBA8} at the same memory cost. It is renderable on
+ * both WebGL2 and WebGPU. {@link PIXELFORMAT_RGB10A2U} is the unsigned integer variant.
  * @category Graphics
  */
 class Texture {

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -13,7 +13,8 @@ import {
     PIXELFORMAT_DXT1_SRGB, PIXELFORMAT_DXT3_SRGBA, PIXELFORMAT_DXT5_SRGBA,
     PIXELFORMAT_ETC2_SRGB, PIXELFORMAT_ETC2_SRGBA, PIXELFORMAT_ASTC_4x4_SRGB, PIXELFORMAT_SBGRA8,
     PIXELFORMAT_BC6F, PIXELFORMAT_BC6UF, PIXELFORMAT_BC7, PIXELFORMAT_BC7_SRGBA,
-    PIXELFORMAT_DEPTH16
+    PIXELFORMAT_DEPTH16, PIXELFORMAT_RG32F,
+    PIXELFORMAT_RGB9E5, PIXELFORMAT_RG8S, PIXELFORMAT_RGBA8S, PIXELFORMAT_RGB10A2, PIXELFORMAT_RGB10A2U
 } from '../constants.js';
 
 /**
@@ -170,6 +171,34 @@ class WebglTexture {
             case PIXELFORMAT_BGRA8:
             case PIXELFORMAT_SBGRA8:
                 Debug.error('BGRA8 and SBGRA8 texture formats are not supported by WebGL.');
+                break;
+            case PIXELFORMAT_RG32F:
+                Debug.error('RG32F texture format is not supported by WebGL.');
+                break;
+            case PIXELFORMAT_RGB9E5:
+                this._glFormat = gl.RGB;
+                this._glInternalFormat = gl.RGB9_E5;
+                this._glPixelType = gl.UNSIGNED_INT_5_9_9_9_REV;
+                break;
+            case PIXELFORMAT_RG8S:
+                this._glFormat = gl.RG;
+                this._glInternalFormat = gl.RG8_SNORM;
+                this._glPixelType = gl.BYTE;
+                break;
+            case PIXELFORMAT_RGBA8S:
+                this._glFormat = gl.RGBA;
+                this._glInternalFormat = gl.RGBA8_SNORM;
+                this._glPixelType = gl.BYTE;
+                break;
+            case PIXELFORMAT_RGB10A2:
+                this._glFormat = gl.RGBA;
+                this._glInternalFormat = gl.RGB10_A2;
+                this._glPixelType = gl.UNSIGNED_INT_2_10_10_10_REV;
+                break;
+            case PIXELFORMAT_RGB10A2U:
+                this._glFormat = gl.RGBA_INTEGER;
+                this._glInternalFormat = gl.RGB10_A2UI;
+                this._glPixelType = gl.UNSIGNED_INT_2_10_10_10_REV;
                 break;
 
                 // compressed formats ----

--- a/src/platform/graphics/webgpu/constants.js
+++ b/src/platform/graphics/webgpu/constants.js
@@ -13,7 +13,9 @@ import {
     PIXELFORMAT_ETC2_SRGB, PIXELFORMAT_ETC2_SRGBA, PIXELFORMAT_SBGRA8,
     PIXELFORMAT_BC6F, PIXELFORMAT_BC6UF, PIXELFORMAT_BC7, PIXELFORMAT_BC7_SRGBA,
     PIXELFORMAT_ASTC_4x4_SRGB,
-    PIXELFORMAT_DEPTH16
+    PIXELFORMAT_DEPTH16,
+    PIXELFORMAT_RG32F,
+    PIXELFORMAT_RGB9E5, PIXELFORMAT_RG8S, PIXELFORMAT_RGBA8S, PIXELFORMAT_RGB10A2, PIXELFORMAT_RGB10A2U
 } from '../constants.js';
 
 // map of PIXELFORMAT_*** to GPUTextureFormat
@@ -38,6 +40,7 @@ gpuTextureFormats[PIXELFORMAT_RG16F] = 'rg16float';
 gpuTextureFormats[PIXELFORMAT_RGB32F] = '';
 gpuTextureFormats[PIXELFORMAT_RGBA32F] = 'rgba32float';
 gpuTextureFormats[PIXELFORMAT_R32F] = 'r32float';
+gpuTextureFormats[PIXELFORMAT_RG32F] = 'rg32float';
 gpuTextureFormats[PIXELFORMAT_DEPTH] = 'depth32float';
 gpuTextureFormats[PIXELFORMAT_DEPTH16] = 'depth16unorm';
 gpuTextureFormats[PIXELFORMAT_DEPTHSTENCIL] = 'depth24plus-stencil8';
@@ -77,6 +80,11 @@ gpuTextureFormats[PIXELFORMAT_RGBA32U] = 'rgba32uint';
 gpuTextureFormats[PIXELFORMAT_BC6F] = 'bc6h-rgb-float';
 gpuTextureFormats[PIXELFORMAT_BC6UF] = 'bc6h-rgb-ufloat';
 gpuTextureFormats[PIXELFORMAT_BC7] = 'bc7-rgba-unorm';
+gpuTextureFormats[PIXELFORMAT_RGB9E5] = 'rgb9e5ufloat';
+gpuTextureFormats[PIXELFORMAT_RG8S] = 'rg8snorm';
+gpuTextureFormats[PIXELFORMAT_RGBA8S] = 'rgba8snorm';
+gpuTextureFormats[PIXELFORMAT_RGB10A2] = 'rgb10a2unorm';
+gpuTextureFormats[PIXELFORMAT_RGB10A2U] = 'rgb10a2uint';
 
 // compressed sRGB formats ----
 gpuTextureFormats[PIXELFORMAT_DXT1_SRGB] = 'bc1-rgba-unorm-srgb';


### PR DESCRIPTION
Add support for 6 new texture formats:

- `PIXELFORMAT_RG32F` - 32-bit float RG format (WebGPU only)
- `PIXELFORMAT_RGB9E5` - Compact HDR format with shared exponent (sampling only, not renderable)
- `PIXELFORMAT_RG8S` / `PIXELFORMAT_RGBA8S` - Signed normalized formats
- `PIXELFORMAT_RGB10A2` - 10-bit RGB with 2-bit alpha, higher precision than RGBA8 (renderable)
- `PIXELFORMAT_RGB10A2U` - Unsigned integer variant of RGB10A2 (renderable)

All formats except RG32F are supported on both WebGL2 and WebGPU.