### PR TITLE
XR elevation control

### DIFF
--- a/scripts/esm/xr-navigation.mjs
+++ b/scripts/esm/xr-navigation.mjs
@@ -306,7 +306,10 @@ class XrNavigation extends Script {
                     // Apply movement to camera parent (this entity)
                     this.entity.translate(this.tmpVec2A.x, 0, this.tmpVec2A.y);
                 }
-            } else if (inputSource.handedness === 'right') { // Right controller - snap turning
+            } else if (inputSource.handedness === 'right') { // Right controller - snap turning and elevation
+                //control elevation via right controller y-axis
+                this.entity.translate(0, Math.sign( inputSource.gamepad.axes[3] ) * this.movementSpeed * dt, 0);
+                
                 this.handleSnapTurning(inputSource);
             }
         }


### PR DESCRIPTION
Let the user control elevation (y-level altitude, to raise or lower camera view) with the right controller y-axis (currently unused).  

Because the navigation is missing this control, in order to adjust elevation viewpoint in a scene, the user must stand on a chair or get a ladder in the real world, which can cause injury when wearing a VR headset. (This is a joke, no one would try that. It is necessary to use a different viewer app.)

## Description
Allowing the viewer to control the elevation is standard in all VR/XR applications, except for first-person games where mobility is restricted for gameplay rules. But in the Playcanvas engine WebXR viewer navigation system, when viewing a scene in VR or AR, the user is locked into a single elevation. In AR, if the scene's data floor doesn't align with the real-world floor, the scene is permanently broken and unusable with this viewer.  

## Fix

The fix requires one line to adjust the elevation.
I implemented in my local dev version, tested it, and found it working flawlessly on Desktop (SteamVR) and Mobile (Quest3).  

I appreciate you taking the time to read this pull request. If you would like me to make any changes, please let me know, or feel free to change as desired.  
Thank you for all the hard work and time you have invested in this great viewer for the open-source community.  

## Checklist
- [ ✓ ] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [ ✓ ] My code follows the project's coding standards
- [ ✓ ] This PR focuses on a single change
