### PR TITLE
Added node name to batch insertion/removal assert message

### DIFF
--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -234,7 +234,7 @@ class BatchManager {
 
     insert(type, groupId, node) {
         const group = this._batchGroups[groupId];
-        Debug.assert(group, `Invalid batch ${groupId} insertion`);
+        Debug.assert(group, `Invalid batch ${groupId} insertion with node: "${node.name}"`);
 
         if (group) {
             if (group._obj[type].indexOf(node) < 0) {
@@ -246,7 +246,7 @@ class BatchManager {
 
     remove(type, groupId, node) {
         const group = this._batchGroups[groupId];
-        Debug.assert(group, `Invalid batch ${groupId} insertion`);
+        Debug.assert(group, `Invalid batch ${groupId} removal with node: "${node.name}"`);
 
         if (group) {
             const idx = group._obj[type].indexOf(node);


### PR DESCRIPTION
## Description
If a batch group is deleted in the editor, it's hard to find the entities that still have that batch group id for whatever reason. This PR adds the node name to the assert message to make it a little easier.

I was thinking about adding the GUID or node path but didn't want to add extra processing/conditional in the assert message.

Error messages now look like this 

<img width="408" height="142" alt="image" src="https://github.com/user-attachments/assets/954d4018-0189-4633-abdd-9cb2c31c2562" />

## Testing

* Create a new editor project and add a batch group in project settings. 
* Add a render component to the batch group 
* Delate the batch group in project settings
* Launch the project to see the new error message

Example project: 

* Launch Tab https://launch.playcanvas.com/2393655?debug=true&use_local_engine=http://localhost:8000/playcanvas.dbg.js
* Project: https://playcanvas.com/project/1444577/overview/test-invalid-batch-group

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
