### PR TITLE
[FIX] Fix glTF node matrix decomposition with negative scale

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -1517,6 +1517,7 @@ const createAnimation = (gltfAnimation, animationIndex, gltfAccessors, bufferVie
 
 const tempMat = new Mat4();
 const tempVec = new Vec3();
+const tempQuat = new Quat();
 
 const createNode = (gltfNode, nodeIndex, nodeInstancingMap) => {
     const entity = new GraphNode();
@@ -1532,9 +1533,14 @@ const createNode = (gltfNode, nodeIndex, nodeInstancingMap) => {
         tempMat.data.set(gltfNode.matrix);
         tempMat.getTranslation(tempVec);
         entity.setLocalPosition(tempVec);
-        tempMat.getEulerAngles(tempVec);
-        entity.setLocalEulerAngles(tempVec);
+        // Use Quat.setFromMat4 which properly handles negative determinant (mirrored matrices)
+        // by normalizing the rotation before extraction
+        tempQuat.setFromMat4(tempMat);
+        entity.setLocalRotation(tempQuat);
         tempMat.getScale(tempVec);
+        // Apply negative sign to X scale if the matrix is mirrored (negative determinant).
+        // This matches the convention used in Quat.setFromMat4 which flips the X axis.
+        tempVec.x *= tempMat.scaleSign;
         entity.setLocalScale(tempVec);
     }
 


### PR DESCRIPTION
Fixes #8328

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/bbc852f6-e7ea-4d4b-a170-91758a778898" />

### Description

When a glTF node uses a `matrix` property (instead of separate `translation`, `rotation`, `scale` properties) that contains a negative scale component (creating a reflection/flip), the model was displayed incorrectly - appearing flipped or upside down.

### Changes

- Use `Quat.setFromMat4()` for rotation extraction instead of `Mat4.getEulerAngles()` when decomposing node matrices
- Apply `scaleSign` to the X scale component to preserve negative determinant (mirrored) transforms

### Technical Details

The root cause was that `Mat4.getScale()` returns only positive values (it computes vector lengths), and `Mat4.getEulerAngles()` doesn't coordinate with negative determinant handling. This could cause the flip to be absorbed into the rotation as an extra 180° rotation, or be lost entirely.

The fix uses `Quat.setFromMat4()` which already properly handles negative determinant matrices by normalizing the X axis before rotation extraction (see lines 589-597 in `quat.js`). The negative scale is then preserved by multiplying the X scale by `Mat4.scaleSign`, which returns -1 for mirrored matrices.

This approach is consistent with how the engine handles mirrored transforms elsewhere (e.g., batch manager, `GraphNode._worldScaleSign`).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
