### PR TITLE
Allow changing unified property without disabling component

### DIFF
--- a/examples/src/examples/gaussian-splatting/global-sorting.example.mjs
+++ b/examples/src/examples/gaussian-splatting/global-sorting.example.mjs
@@ -120,13 +120,9 @@ assetListLoader.load(() => {
     // toggle unified rendering for all gsplats via controls
     data.on('unified:set', () => {
         const unified = !!data.get('unified');
-        const comps = /** @type {any[]} */ (app.root.findComponents('gsplat'));
-        comps.forEach((comp /** @type {import('playcanvas').GSplatComponent} */) => {
-            comp.enabled = false;
-            comp.entity.enabled = false;
+        const comps = /** @type {pc.GSplatComponent[]} */ (app.root.findComponents('gsplat'));
+        comps.forEach((comp) => {
             comp.unified = unified;
-            comp.enabled = true;
-            comp.entity.enabled = true;
         });
     });
 });

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -54,8 +54,6 @@ import { GSplatPlacement } from '../../../scene/gsplat-unified/gsplat-placement.
  * entity.gsplat.unified = true;
  * ```
  *
- * Note: The `unified` property can only be changed when the component is disabled.
- *
  * Relevant Engine API examples:
  *
  * - [Simple Splat Loading](https://playcanvas.github.io/#/gaussian-splatting/simple)
@@ -439,21 +437,19 @@ class GSplatComponent extends Component {
     }
 
     /**
-     * Sets whether to use the unified gsplat rendering. Can be changed only when the component is
-     * not enabled. Default is false.
+     * Sets whether to use the unified gsplat rendering. Default is false.
+     *
+     * Note: Material handling differs between modes. When unified is false, use
+     * {@link GSplatComponent#material}. When unified is true, materials are shared per
+     * camera/layer - use {@link GSplatComponentSystem#getGSplatMaterial} instead.
      *
      * @type {boolean}
-     * @alpha
      */
     set unified(value) {
-
-        if (this.enabled && this.entity.enabled) {
-            Debug.warn('GSplatComponent#unified can be changed only when the component is not enabled. Ignoring change.');
-            return;
+        if (this._unified !== value) {
+            this._unified = value;
+            this._onGSplatAssetAdded();
         }
-
-        this._unified = value;
-        this._onGSplatAssetAdded();
     }
 
     /**


### PR DESCRIPTION
Allow the `GSplatComponent.unified` property to be changed at runtime without requiring manual disable/enable of the component.

### Changes

- Modified `unified` setter to automatically destroy and recreate internal data (instance/placement) when the value changes
- Simplified global-sorting example to demonstrate direct property assignment

### Before
```
comp.enabled = false;
comp.entity.enabled = false;
comp.unified = true;
comp.enabled = true;
comp.entity.enabled = true;
```

### After
```
comp.unified = true;
```