### PR TITLE
[Fix] Fixed incorrect uv1 (unwrapped uvs for lightmapping) for box and cone geometry

### DIFF
--- a/src/scene/geometry/box-geometry.js
+++ b/src/scene/geometry/box-geometry.js
@@ -2,7 +2,7 @@ import { Vec3 } from '../../core/math/vec3.js';
 import { calculateTangents } from './geometry-utils.js';
 import { Geometry } from './geometry.js';
 
-const primitiveUv1Padding = 4.0 / 64;
+const primitiveUv1Padding = 8.0 / 64;
 const primitiveUv1PaddingScale = 1.0 - primitiveUv1Padding * 2;
 
 /**

--- a/src/scene/geometry/cone-base-geometry.js
+++ b/src/scene/geometry/cone-base-geometry.js
@@ -1,7 +1,7 @@
 import { Vec3 } from '../../core/math/vec3.js';
 import { Geometry } from './geometry.js';
 
-const primitiveUv1Padding = 4.0 / 64;
+const primitiveUv1Padding = 8.0 / 64;
 const primitiveUv1PaddingScale = 1.0 - primitiveUv1Padding * 2;
 
 /**


### PR DESCRIPTION
- this was making boxes mapped incorrectly (single face displayed 6 times)
- also updated padding to avoid lightmapping edge artifacts on box / cone / cylinder

before (padding of 4/64)
<img width="449" height="447" alt="Screenshot 2026-01-05 at 19 03 50" src="https://github.com/user-attachments/assets/c8fe3b9c-4e94-4c2a-8826-30f26ebffa1c" />

now (padding of 8/64)
<img width="441" height="488" alt="Screenshot 2026-01-05 at 19 04 11" src="https://github.com/user-attachments/assets/6b908366-b819-4c82-97de-8846b638f67e" />

