### PR TITLE
[FIX] Fix EventHandle cleanup in annotation script

### DIFF
--- a/scripts/esm/annotation.mjs
+++ b/scripts/esm/annotation.mjs
@@ -785,7 +785,7 @@ export class AnnotationManager extends Script {
         }
 
         // Unbind event handles
-        resources.eventHandles.forEach(handle => handle.unbind());
+        resources.eventHandles.forEach(handle => handle.off());
         resources.eventHandles.length = 0;
 
         // Remove DOM listeners


### PR DESCRIPTION
Fixes a runtime error when reloading scenes using the annotation script (e.g., the 3D Gaussian Splat annotations example in the Examples Browser).

The `_unregisterAnnotation` method was calling `handle.unbind()` on event handles, but PlayCanvas engine's `EventHandle` class uses `off()` to unsubscribe, not `unbind()` (which is the method used by `@playcanvas/observer`).

**Error before fix:**
```
Uncaught TypeError: handle.unbind is not a function
    at AnnotationManager._unregisterAnnotation (annotation.mjs:788:57)
```

Fixes #8331 

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
