### PR TITLE
Lazy mesh creation for GSplat resources

### DIFF
--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -12,7 +12,9 @@ import { BLEND_NONE, BLEND_PREMULTIPLIED } from '../constants.js';
 /**
  * @import { Camera } from '../camera.js'
  * @import { GraphNode } from '../graph-node.js'
+ * @import { Mesh } from '../mesh.js'
  * @import { Texture } from '../../platform/graphics/texture.js'
+ * @import { VertexBuffer } from '../../platform/graphics/vertex-buffer.js'
  */
 
 const mat = new Mat4();
@@ -96,8 +98,9 @@ class GSplatInstance {
             this._material.update();
         }
 
-        this.meshInstance = new MeshInstance(resource.mesh, this._material);
-        this.meshInstance.setInstancing(resource.instanceIndices, true);
+        resource.ensureMesh();
+        this.meshInstance = new MeshInstance(/** @type {Mesh} */ (resource.mesh), this._material);
+        this.meshInstance.setInstancing(/** @type {VertexBuffer} */ (resource.instanceIndices), true);
         this.meshInstance.gsplatInstance = this;
 
         // only start rendering the splat after we've received the splat order data
@@ -123,6 +126,7 @@ class GSplatInstance {
     }
 
     destroy() {
+        this.resource?.releaseMesh();
         this.orderTexture?.destroy();
         this.resolveSH?.destroy();
         this.material?.destroy();


### PR DESCRIPTION
Defers mesh and instanceIndices allocation in `GSplatResourceBase` until actually needed by `GSplatInstance`, eliminating unnecessary GPU resource allocation when unified rendering mode is used.

### Changes

- `GSplatResourceBase` no longer creates mesh and instanceIndices in constructor
- Added `ensureMesh()` for lazy creation when `GSplatInstance` needs them
- Added `releaseMesh()` with ref counting to clean up instanceIndices when all instances are destroyed
- Mesh destruction is handled automatically by `MeshInstance` via its internal refCount

### Benefits

- Zero mesh/instanceIndices allocation when only unified mode is used
- Proper cleanup when switching from non-unified to unified mode
- Shared mesh across multiple instances of the same resource (existing behavior preserved)