### PR TITLE
Revert "[FIX] Fix Non-Standard Fresnel Term to Match glTF 2.0 Spec"

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/lit/frag/fresnelSchlick.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/fresnelSchlick.js
@@ -1,6 +1,5 @@
 export default /* glsl */`
-// Schlick's approximation (glTF 2.0 compliant)
-// F = F0 + (F90 - F0) * (1 - V·H)^5, where F90 = 1.0
+// Schlick's approximation
 vec3 getFresnel(
         float cosTheta, 
         float gloss, 
@@ -11,7 +10,11 @@ vec3 getFresnel(
 #endif
     ) {
     float fresnel = pow(1.0 - saturate(cosTheta), 5.0);
-    vec3 ret = specularity + (vec3(1.0) - specularity) * fresnel;
+    float glossSq = gloss * gloss;
+
+    // Scale gloss contribution by specularity intensity to ensure F90 approaches 0 when F0 is 0
+    float specIntensity = max(specularity.r, max(specularity.g, specularity.b));
+    vec3 ret = specularity + (max(vec3(glossSq * specIntensity), specularity) - specularity) * fresnel;
 
 #if defined(LIT_IRIDESCENCE)
     return mix(ret, iridescenceFresnel, iridescenceIntensity);


### PR DESCRIPTION
Reverts playcanvas/engine#8298

This PR caused a significant shading change so backing out for now.