### PR TITLE
Replace Debug.assert with errorOnce and early return in GSplatComponent

### DIFF
--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -219,7 +219,10 @@ class GSplatComponent extends Component {
      */
     set instance(value) {
 
-        Debug.assert(!this.unified);
+        if (this.unified) {
+            Debug.errorOnce('GSplatComponent#instance setter is not supported when unified is true.');
+            return;
+        }
 
         // destroy existing instance
         this.destroyInstance();
@@ -626,21 +629,27 @@ class GSplatComponent extends Component {
     onLayerAdded(layer) {
         const index = this.layers.indexOf(layer.id);
         if (index < 0) return;
+        if (this.unified) {
+            Debug.errorOnce('GSplatComponent#onLayerAdded is not supported when unified is true.');
+            return;
+        }
+
         if (this._instance) {
             layer.addMeshInstances(this._instance.meshInstance);
         }
-
-        Debug.assert(!this.unified);
     }
 
     onLayerRemoved(layer) {
         const index = this.layers.indexOf(layer.id);
         if (index < 0) return;
+        if (this.unified) {
+            Debug.errorOnce('GSplatComponent#onLayerRemoved is not supported when unified is true.');
+            return;
+        }
+
         if (this._instance) {
             layer.removeMeshInstances(this._instance.meshInstance);
         }
-
-        Debug.assert(!this.unified);
     }
 
     onEnable() {


### PR DESCRIPTION
Replace `Debug.assert(!this.unified)` calls with proper error handling that logs an error once and returns early, preventing the code from continuing in an invalid state. This is useful for our react implementation which sometimes calls all properties.
