### PR TITLE
Improve examples sidebar category panel styling

### DIFF
--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -211,6 +211,8 @@ body {
 
 #sideBar .categoryPanel {
     margin: 0 8px 8px 8px !important;
+    border: 1px solid #5b7073;
+    border-radius: 4px;
 }
 
 .categoryPanel:first-child {
@@ -224,12 +226,6 @@ body {
 /* Category panel header styling */
 #sideBar .categoryPanel > .pcui-panel-header {
     background-color: #1a2426;
-}
-
-/* Border around category panels */
-#sideBar .categoryPanel {
-    border: 1px solid #5b7073;
-    border-radius: 4px;
 }
 
 .nav-item {


### PR DESCRIPTION
Enhances the visual distinction of category panels in the examples browser sidebar:

- Added darker background color to category headers for better visual hierarchy
- Added subtle gray border around category panels with rounded corners

These changes make it easier to distinguish between different example categories when browsing the sidebar.

before (left) / now (right)
<img width="1012" height="666" alt="Screenshot 2026-01-09 at 16 16 50" src="https://github.com/user-attachments/assets/1e7efef7-f4c4-4b1f-a8b4-ca0aa50f148e" />
