### PR TITLE
[FIX] Hide __initializeAttributes from the API reference

### DIFF
--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -73,6 +73,7 @@ class ScriptType extends Script {
 
     /**
      * @param {boolean} [force] - Set to true to force initialization of the attributes.
+     * @ignore
      */
     __initializeAttributes(force) {
         if (!force && !this.__attributesRaw) {


### PR DESCRIPTION
Adds `@ignore` JSDoc tag to the `__initializeAttributes` method on `ScriptType` to exclude it from the TypeDoc-generated API documentation. This is an internal method (indicated by the `__` prefix) that should not be part of the public API surface.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
