### PR TITLE
Add DrawCommands resize interface

### DIFF
--- a/src/platform/graphics/draw-commands.js
+++ b/src/platform/graphics/draw-commands.js
@@ -114,6 +114,18 @@ class DrawCommands {
     }
 
     /**
+     * Resize persistent storage for the draw commands.
+     *
+     * @param {number} maxCount - Maximum number of draw calls to allocate storage for.
+     * @param {boolean} preserve - Whether to copy previous draw commands.
+     * @ignore
+     */
+    resize(maxCount, preserve) {
+        this._maxCount = maxCount;
+        this.impl.resize?.(maxCount, preserve);
+    }
+
+    /**
      * Writes one draw command into the allocated storage.
      *
      * @param {number} i - Draw index to update.

--- a/src/platform/graphics/webgl/webgl-draw-commands.js
+++ b/src/platform/graphics/webgl/webgl-draw-commands.js
@@ -28,9 +28,35 @@ class WebglDrawCommands {
      * @param {number} maxCount - Number of sub-draws.
      */
     allocate(maxCount) {
-        this.glCounts = new Int32Array(maxCount);
-        this.glOffsetsBytes = new Int32Array(maxCount);
-        this.glInstanceCounts = new Int32Array(maxCount);
+        this.resize(maxCount, false);
+    }
+
+    /**
+     * Resize SoA arrays for multi-draw.
+     * @param {number} maxCount - Number of sub-draws.
+     * @param {boolean} preserve - Whether to copy previous draw commands.
+     */
+    resize(maxCount, preserve) {
+
+        // We will recreate the data if we need to clear the data.
+        if (preserve && this.glCounts?.length === maxCount) {
+            return;
+        }
+
+        const newGlCounts = new Int32Array(maxCount);
+        const newGlOffsetsBytes = new Int32Array(maxCount);
+        const newGlInstanceCounts = new Int32Array(maxCount);
+
+        if (preserve && this.glCounts) {
+            const keepCount = Math.min(this.glCounts.length, newGlCounts.length);
+            newGlCounts.set(this.glCounts.subarray(0, keepCount));
+            newGlOffsetsBytes.set(this.glOffsetsBytes.subarray(0, keepCount));
+            newGlInstanceCounts.set(this.glInstanceCounts.subarray(0, keepCount));
+        }
+
+        this.glCounts = newGlCounts;
+        this.glOffsetsBytes = newGlOffsetsBytes;
+        this.glInstanceCounts = newGlInstanceCounts;
     }
 
     /**

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -1197,9 +1197,10 @@ class MeshInstance {
      * across all cameras.
      * @param {number} [maxCount] - Maximum number of sub-draws to allocate. Defaults to 1. Pass 0
      * to disable multi-draw for the specified camera (or the shared entry when camera is null).
+     * @param {boolean} [preserve] - Whether to copy previous draw commands when resizing.
      * @returns {DrawCommands|undefined} The commands container to populate with sub-draw commands.
      */
-    setMultiDraw(camera, maxCount = 1) {
+    setMultiDraw(camera, maxCount = 1, preserve = false) {
         const key = camera?.camera ?? null;
         let cmd;
 
@@ -1221,7 +1222,7 @@ class MeshInstance {
                 cmd = new DrawCommands(this.mesh.device, indexSizeBytes);
                 this.drawCommands.set(key, cmd);
             }
-            cmd.allocate(maxCount);
+            cmd.resize(maxCount, preserve);
         }
         return cmd;
     }


### PR DESCRIPTION
**Add `preserve` parameter to `setMultiDraw` for safe resizing**

Added a new optional `preserve` parameter to the `setMultiDraw` method, which preserves previous draw commands when changing the `maxCount` size.

### Changes
- **New parameter**: `preserve: boolean` (defaults to `false`)
  - `true` - copies existing draw commands when increasing/decreasing `maxCount`
  - `false` - clears commands on each call (previous behavior)
- Updated JSDoc documentation with parameter description

### Usage
```javascript
// Previous behavior (clears commands)
meshInstance.setMultiDraw(camera, 16);

// New behavior with command preservation
meshInstance.setMultiDraw(camera, 32, true); // Increases to 32, preserves old commands
meshInstance.setMultiDraw(camera, 8, true);  // Decreases to 8, preserves commands
```

### Benefits
- **Safe resizing** without data loss
- **Backward compatibility** - existing code works unchanged
- Useful for **dynamic object count** changes in the scene

***

Fixes #8345

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
