### PR TITLE
Fix memory leak in WebGPU multi-draw allocation

### DIFF
--- a/src/platform/graphics/webgl/webgl-draw-commands.js
+++ b/src/platform/graphics/webgl/webgl-draw-commands.js
@@ -28,6 +28,10 @@ class WebglDrawCommands {
      * @param {number} maxCount - Number of sub-draws.
      */
     allocate(maxCount) {
+        // Skip reallocation if size matches exactly
+        if (this.glCounts && this.glCounts.length === maxCount) {
+            return;
+        }
         this.glCounts = new Int32Array(maxCount);
         this.glOffsetsBytes = new Int32Array(maxCount);
         this.glInstanceCounts = new Int32Array(maxCount);

--- a/src/platform/graphics/webgpu/webgpu-draw-commands.js
+++ b/src/platform/graphics/webgpu/webgpu-draw-commands.js
@@ -37,6 +37,11 @@ class WebgpuDrawCommands {
      * @param {number} maxCount - Number of sub-draws.
      */
     allocate(maxCount) {
+        // Skip reallocation if size matches exactly
+        if (this.gpuIndirect && this.gpuIndirect.length === 5 * maxCount) {
+            return;
+        }
+        this.storage?.destroy();
         this.gpuIndirect = new Uint32Array(5 * maxCount);
         this.gpuIndirectSigned = new Int32Array(this.gpuIndirect.buffer);
         this.storage = new StorageBuffer(this.device, this.gpuIndirect.byteLength, BUFFERUSAGE_INDIRECT | BUFFERUSAGE_COPY_DST);

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -1193,6 +1193,9 @@ class MeshInstance {
      * Sets the {@link MeshInstance} to be rendered using multi-draw, where multiple sub-draws are
      * executed with a single draw call.
      *
+     * Note: Each call to this method invalidates any previously stored draw command data for the
+     * specified camera.
+     *
      * @param {CameraComponent|null} camera - Camera component to bind commands to, or null to share
      * across all cameras.
      * @param {number} [maxCount] - Maximum number of sub-draws to allocate. Defaults to 1. Pass 0


### PR DESCRIPTION
Fixes #8345

Fixes a memory leak when calling `setMultiDraw()` multiple times on WebGPU. The `StorageBuffer` was not being destroyed before creating a new one during reallocation.

### Changes

- **WebGPU**: Destroy existing `StorageBuffer` before reallocating in `allocate()`
- **WebGL/WebGPU**: Skip reallocation when size matches exactly (optimization)
- **Documentation**: Updated `setMultiDraw()` JSDoc to clarify that each call invalidates previously stored draw command data for the specified camera
