### PR TITLE
Fix WebGL array texture crash when created without levels data

### DIFF
--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -650,8 +650,11 @@ class WebglTexture {
                         this._glPixelType,
                         mipObject);
                 }
-            } else if (texture.array && typeof mipObject === 'object') {
-                if (texture._arrayLength === mipObject.length) {
+            } else if (texture.array) {
+                // ----- 2D ARRAY -----
+                // Only upload if mipObject is a valid array with correct length.
+                // If mipObject is null or length doesn't match, skip - storage was already allocated via texStorage3D.
+                if (Array.isArray(mipObject) && texture._arrayLength === mipObject.length) {
                     if (texture._compressed) {
                         for (let index = 0; index < texture._arrayLength; index++) {
                             gl.compressedTexSubImage3D(


### PR DESCRIPTION
## Fix WebGL array texture crash when created without levels data

Fixes a crash when creating a WebGL array texture without providing `levels` data.

**The bug:** When `mipObject` is `null`, the condition `typeof mipObject === 'object'` evaluated to `true` (since `typeof null === 'object'` in JavaScript), causing a crash when trying to access `mipObject.length`.

**The fix:** Changed the condition to use `Array.isArray(mipObject)` which correctly returns `false` for `null`. The behavior now matches WebGPU - silently skip upload when data isn't ready (storage is already allocated via `texStorage3D`).

### Changes

- `src/platform/graphics/webgl/webgl-texture.js`: Fixed array texture upload condition to handle null `mipObject`
- `examples/src/examples/loaders/bundle.example.mjs`: Added array texture creation test case

### Before
```javascript
} else if (texture.array && typeof mipObject === 'object') {
    if (texture._arrayLength === mipObject.length) {  // CRASH: null.length
```

### After
```javascript
} else if (texture.array) {
    if (Array.isArray(mipObject) && texture._arrayLength === mipObject.length) {
```

Fixes #8370
