### PR TITLE
ES2020 compatibility for GSplatSortBinWeights worker injection

### DIFF
--- a/src/scene/gsplat-unified/gsplat-sort-bin-weights.js
+++ b/src/scene/gsplat-unified/gsplat-sort-bin-weights.js
@@ -14,7 +14,9 @@ class GSplatSortBinWeights {
      *
      * @type {number}
      */
-    static NUM_BINS = 32;
+    static get NUM_BINS() {
+        return 32;
+    }
 
     /**
      * Weight tiers for camera-relative precision (distance from camera bin -> weight multiplier).
@@ -22,13 +24,15 @@ class GSplatSortBinWeights {
      *
      * @type {Array<{maxDistance: number, weight: number}>}
      */
-    static WEIGHT_TIERS = [
-        { maxDistance: 0, weight: 40.0 },   // Camera bin
-        { maxDistance: 2, weight: 20.0 },   // Adjacent bins
-        { maxDistance: 5, weight: 8.0 },    // Nearby bins
-        { maxDistance: 10, weight: 3.0 },   // Medium distance
-        { maxDistance: Infinity, weight: 1.0 }  // Far bins
-    ];
+    static get WEIGHT_TIERS() {
+        return [
+            { maxDistance: 0, weight: 40.0 },   // Camera bin
+            { maxDistance: 2, weight: 20.0 },   // Adjacent bins
+            { maxDistance: 5, weight: 8.0 },    // Nearby bins
+            { maxDistance: 10, weight: 3.0 },   // Medium distance
+            { maxDistance: Infinity, weight: 1.0 }  // Far bins
+        ];
+    }
 
     /**
      * Pre-allocated interleaved array [base0, divider0, base1, divider1, ...].


### PR DESCRIPTION
## Description

Fixes gsplat sorting not working in release builds when targeting ES2020.

## Problem

When SWC transpiles to ES2020, static class fields are moved outside the class body:

```javascript
// ES2022 (native)
class Foo {
    static BAR = 42;
}

// ES2020 (transpiled)
class Foo {}
Foo.BAR = 42;
```

Since `GSplatSortBinWeights` is stringified via `.toString()` and injected into a web worker, the static properties were lost after transpilation. This caused `NUM_BINS` and `WEIGHT_TIERS` to be `undefined` in the worker, breaking the sorting algorithm.

## Solution

Convert static class fields to static getters, which are ES2015 syntax and remain inside the class body when stringified:

```javascript
// Before
static NUM_BINS = 32;

// After  
static get NUM_BINS() {
    return 32;
}
```

## Testing

- Verified gsplat sorting works correctly with `npm run build && npm run serve`
- Both WebGL and WebGPU backends affected and fixed
