### PR TITLE
GSplat: Centralize texture management with GSplatStreams class

### DIFF
--- a/src/scene/gsplat/gsplat-container.js
+++ b/src/scene/gsplat/gsplat-container.js
@@ -1,4 +1,3 @@
-import { Vec2 } from '../../core/math/vec2.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import { GSplatResourceBase } from './gsplat-resource-base.js';
 
@@ -46,23 +45,14 @@ class GSplatContainer extends GSplatResourceBase {
         this.format = format;
         this._numSplats = numSplats;
 
-        // Allocate textures based on format streams
-        const size = this.evalTextureSize(numSplats);
-        this.textureSize = size.x;
-        for (const stream of format.streams) {
-            const texture = this.createTexture(stream.name, stream.format, size);
-            this.textures.set(stream.name, texture);
-        }
+        // Use streams to create textures from format
+        this.streams.init(format, numSplats);
     }
 
     /**
      * Destroys this container and releases all resources.
      */
     destroy() {
-        for (const texture of this.textures.values()) {
-            texture.destroy();
-        }
-        this.textures.clear();
         super.destroy();
     }
 
@@ -73,18 +63,6 @@ class GSplatContainer extends GSplatResourceBase {
      */
     get numSplats() {
         return this._numSplats;
-    }
-
-    /**
-     * Evaluates the texture size needed to store a given number of elements.
-     *
-     * @param {number} count - The number of elements to store.
-     * @returns {Vec2} The width and height of the texture.
-     * @ignore
-     */
-    evalTextureSize(count) {
-        const width = Math.ceil(Math.sqrt(count));
-        return new Vec2(width, Math.ceil(count / width));
     }
 
     /**

--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../core/debug.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { CULLFACE_NONE, SEMANTIC_ATTR13, SEMANTIC_POSITION, PIXELFORMAT_R32U } from '../../platform/graphics/constants.js';
@@ -64,11 +65,14 @@ class GSplatInstance {
     constructor(resource, options = {}) {
         this.resource = resource;
 
-        // create the order texture
-        this.orderTexture = resource.createTexture(
+        // create the order texture with the same dimensions as resource's splat data textures
+        const dims = resource.streams.textureDimensions;
+        Debug.assert(dims.x > 0 && dims.y > 0, 'Resource must have valid texture dimensions before creating instance');
+
+        this.orderTexture = resource.streams.createTexture(
             'splatOrder',
             PIXELFORMAT_R32U,
-            resource.evalTextureSize(resource.numSplats)
+            dims
         );
 
         if (options.material) {

--- a/src/scene/gsplat/gsplat-resolve-sh.js
+++ b/src/scene/gsplat/gsplat-resolve-sh.js
@@ -217,7 +217,7 @@ class GSplatResolveSH {
             }
         });
 
-        this.texture = resource.createTexture('centroids', PIXELFORMAT_RGBA8, new Vec2(64, 1024));
+        this.texture = resource.streams.createTexture('centroids', PIXELFORMAT_RGBA8, new Vec2(64, 1024));
         this.renderTarget = new RenderTarget({
             colorBuffer: this.texture,
             depth: false

--- a/src/scene/gsplat/gsplat-streams.js
+++ b/src/scene/gsplat/gsplat-streams.js
@@ -1,0 +1,137 @@
+import { Vec2 } from '../../core/math/vec2.js';
+import { ADDRESS_CLAMP_TO_EDGE, FILTER_NEAREST } from '../../platform/graphics/constants.js';
+import { Texture } from '../../platform/graphics/texture.js';
+
+/**
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ * @import { GSplatFormat } from './gsplat-format.js'
+ */
+
+/**
+ * Manages textures for a GSplatFormat, creating them from stream definitions.
+ *
+ * @ignore
+ */
+class GSplatStreams {
+    /**
+     * The graphics device.
+     *
+     * @type {GraphicsDevice}
+     */
+    device;
+
+    /**
+     * The format defining the streams.
+     *
+     * @type {GSplatFormat|null}
+     */
+    format = null;
+
+    /**
+     * Map of texture names to Texture instances.
+     *
+     * @type {Map<string, Texture>}
+     */
+    textures = new Map();
+
+    /**
+     * Texture dimensions (width and height).
+     *
+     * @type {Vec2}
+     * @private
+     */
+    _textureDimensions = new Vec2();
+
+    /**
+     * Gets the texture dimensions (width and height).
+     *
+     * @type {Vec2}
+     */
+    get textureDimensions() {
+        return this._textureDimensions;
+    }
+
+    /**
+     * Creates a new GSplatStreams instance.
+     *
+     * @param {GraphicsDevice} device - The graphics device.
+     */
+    constructor(device) {
+        this.device = device;
+    }
+
+    /**
+     * Destroys all managed textures.
+     */
+    destroy() {
+        for (const texture of this.textures.values()) {
+            texture.destroy();
+        }
+        this.textures.clear();
+    }
+
+    /**
+     * Initialize with format and create textures for all streams.
+     *
+     * @param {GSplatFormat} format - The format defining streams.
+     * @param {number} numElements - Number of elements (splats) to size textures for.
+     */
+    init(format, numElements) {
+        this.format = format;
+        this._textureDimensions = this.evalTextureSize(numElements);
+
+        // Create textures for all streams
+        for (const stream of format.streams) {
+            const texture = this.createTexture(stream.name, stream.format, this._textureDimensions);
+            this.textures.set(stream.name, texture);
+        }
+    }
+
+    /**
+     * Gets a texture by name.
+     *
+     * @param {string} name - Texture name.
+     * @returns {Texture|undefined} The texture, or undefined if not found.
+     */
+    getTexture(name) {
+        return this.textures.get(name);
+    }
+
+    /**
+     * Evaluates the texture size needed to store a given number of elements.
+     *
+     * @param {number} count - The number of elements to store.
+     * @returns {Vec2} The width and height of the texture.
+     */
+    evalTextureSize(count) {
+        const width = Math.ceil(Math.sqrt(count));
+        return new Vec2(width, Math.ceil(count / width));
+    }
+
+    /**
+     * Creates a new texture with the specified parameters.
+     *
+     * @param {string} name - The name of the texture to be created.
+     * @param {number} format - The pixel format of the texture.
+     * @param {Vec2} size - The size of the texture in a Vec2 object, containing width (x) and height (y).
+     * @param {Uint8Array|Uint16Array|Uint32Array} [data] - The initial data to fill the texture with.
+     * @returns {Texture} The created texture instance.
+     */
+    createTexture(name, format, size, data) {
+        return new Texture(this.device, {
+            name: name,
+            width: size.x,
+            height: size.y,
+            format: format,
+            cubemap: false,
+            mipmaps: false,
+            minFilter: FILTER_NEAREST,
+            magFilter: FILTER_NEAREST,
+            addressU: ADDRESS_CLAMP_TO_EDGE,
+            addressV: ADDRESS_CLAMP_TO_EDGE,
+            ...(data ? { levels: [data] } : { })
+        });
+    }
+}
+
+export { GSplatStreams };

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/formats/compressedSH.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/formats/compressedSH.js
@@ -2,19 +2,15 @@
 export default /* glsl */`
 #if SH_BANDS > 0
 
-uniform highp usampler2D shTexture0;
-uniform highp usampler2D shTexture1;
-uniform highp usampler2D shTexture2;
-
 vec4 unpack8888s(in uint bits) {
     return vec4((uvec4(bits) >> uvec4(0u, 8u, 16u, 24u)) & 0xffu) * (8.0 / 255.0) - 4.0;
 }
 
 void readSHData(in SplatSource source, out vec3 sh[15], out float scale) {
-    // read the sh coefficients
-    uvec4 shData0 = texelFetch(shTexture0, source.uv, 0);
-    uvec4 shData1 = texelFetch(shTexture1, source.uv, 0);
-    uvec4 shData2 = texelFetch(shTexture2, source.uv, 0);
+    // read the sh coefficients using format-generated load functions
+    uvec4 shData0 = loadShTexture0();
+    uvec4 shData1 = loadShTexture1();
+    uvec4 shData2 = loadShTexture2();
 
     vec4 r0 = unpack8888s(shData0.x);
     vec4 r1 = unpack8888s(shData0.y);

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/formats/uncompressedSH.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/formats/uncompressedSH.js
@@ -29,29 +29,21 @@ void fetch(in uint t, out vec3 a) {
 }
 
 #if SH_BANDS == 1
-    uniform highp usampler2D splatSH_1to3;
     void readSHData(in SplatSource source, out vec3 sh[3], out float scale) {
-        fetchScale(texelFetch(splatSH_1to3, source.uv, 0), scale, sh[0], sh[1], sh[2]);
+        fetchScale(loadSplatSH_1to3(), scale, sh[0], sh[1], sh[2]);
     }
 #elif SH_BANDS == 2
-    uniform highp usampler2D splatSH_1to3;
-    uniform highp usampler2D splatSH_4to7;
-    uniform highp usampler2D splatSH_8to11;
     void readSHData(in SplatSource source, out vec3 sh[8], out float scale) {
-        fetchScale(texelFetch(splatSH_1to3, source.uv, 0), scale, sh[0], sh[1], sh[2]);
-        fetch(texelFetch(splatSH_4to7, source.uv, 0), sh[3], sh[4], sh[5], sh[6]);
-        fetch(texelFetch(splatSH_8to11, source.uv, 0).x, sh[7]);
+        fetchScale(loadSplatSH_1to3(), scale, sh[0], sh[1], sh[2]);
+        fetch(loadSplatSH_4to7(), sh[3], sh[4], sh[5], sh[6]);
+        fetch(loadSplatSH_8to11().x, sh[7]);
     }
 #else
-    uniform highp usampler2D splatSH_1to3;
-    uniform highp usampler2D splatSH_4to7;
-    uniform highp usampler2D splatSH_8to11;
-    uniform highp usampler2D splatSH_12to15;
     void readSHData(in SplatSource source, out vec3 sh[15], out float scale) {
-        fetchScale(texelFetch(splatSH_1to3, source.uv, 0), scale, sh[0], sh[1], sh[2]);
-        fetch(texelFetch(splatSH_4to7, source.uv, 0), sh[3], sh[4], sh[5], sh[6]);
-        fetch(texelFetch(splatSH_8to11, source.uv, 0), sh[7], sh[8], sh[9], sh[10]);
-        fetch(texelFetch(splatSH_12to15, source.uv, 0), sh[11], sh[12], sh[13], sh[14]);
+        fetchScale(loadSplatSH_1to3(), scale, sh[0], sh[1], sh[2]);
+        fetch(loadSplatSH_4to7(), sh[3], sh[4], sh[5], sh[6]);
+        fetch(loadSplatSH_8to11(), sh[7], sh[8], sh[9], sh[10]);
+        fetch(loadSplatSH_12to15(), sh[11], sh[12], sh[13], sh[14]);
     }
 #endif
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/compressedSH.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/compressedSH.js
@@ -2,20 +2,16 @@
 export default /* wgsl */`
 #if SH_BANDS > 0
 
-var shTexture0: texture_2d<u32>;
-var shTexture1: texture_2d<u32>;
-var shTexture2: texture_2d<u32>;
-
 fn unpack8888s(bits: u32) -> vec4f {
     let unpacked_u = (vec4<u32>(bits) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(0xffu);
     return vec4f(unpacked_u) * (8.0 / 255.0) - 4.0;
 }
 
 fn readSHData(source: ptr<function, SplatSource>, sh: ptr<function, array<vec3f, 15>>, scale: ptr<function, f32>) {
-    // read the sh coefficients
-    let shData0: vec4<u32> = textureLoad(shTexture0, source.uv, 0);
-    let shData1: vec4<u32> = textureLoad(shTexture1, source.uv, 0);
-    let shData2: vec4<u32> = textureLoad(shTexture2, source.uv, 0);
+    // read the sh coefficients using format-generated load functions
+    let shData0: vec4<u32> = loadShTexture0();
+    let shData1: vec4<u32> = loadShTexture1();
+    let shData2: vec4<u32> = loadShTexture2();
 
     let r0 = unpack8888s(shData0.x);
     let r1 = unpack8888s(shData0.y);

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/uncompressedSH.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/uncompressedSH.js
@@ -47,61 +47,50 @@ fn fetch1(t_in: u32) -> vec3f {
 }
 
 #if SH_BANDS == 1
-    var splatSH_1to3: texture_2d<u32>;
-
     fn readSHData(source: ptr<function, SplatSource>, sh: ptr<function, array<vec3f, 3>>, scale: ptr<function, f32>) {
-        let result = fetchScale(textureLoad(splatSH_1to3, source.uv, 0));
+        let result = fetchScale(loadSplatSH_1to3());
         *scale = result.scale;
         sh[0] = result.a;
         sh[1] = result.b;
         sh[2] = result.c;
     }
 #elif SH_BANDS == 2
-    var splatSH_1to3: texture_2d<u32>;
-    var splatSH_4to7: texture_2d<u32>;
-    var splatSH_8to11: texture_2d<u32>;
-
     fn readSHData(source: ptr<function, SplatSource>, sh: ptr<function, array<vec3f, 8>>, scale: ptr<function, f32>) {
-        let first: ScaleAndSH = fetchScale(textureLoad(splatSH_1to3, source.uv, 0));
+        let first: ScaleAndSH = fetchScale(loadSplatSH_1to3());
         *scale = first.scale;
         sh[0] = first.a;
         sh[1] = first.b;
         sh[2] = first.c;
 
-        let second: SH = fetch4(textureLoad(splatSH_4to7, source.uv, 0));
+        let second: SH = fetch4(loadSplatSH_4to7());
         sh[3] = second.a;
         sh[4] = second.b;
         sh[5] = second.c;
         sh[6] = second.d;
 
-        sh[7] = fetch1(textureLoad(splatSH_8to11, source.uv, 0).x);
+        sh[7] = fetch1(loadSplatSH_8to11().x);
     }
 #else
-    var splatSH_1to3: texture_2d<u32>;
-    var splatSH_4to7: texture_2d<u32>;
-    var splatSH_8to11: texture_2d<u32>;
-    var splatSH_12to15: texture_2d<u32>;
-
     fn readSHData(source: ptr<function, SplatSource>, sh: ptr<function, array<vec3f, 15>>, scale: ptr<function, f32>) {
-        let first: ScaleAndSH = fetchScale(textureLoad(splatSH_1to3, source.uv, 0));
+        let first: ScaleAndSH = fetchScale(loadSplatSH_1to3());
         *scale = first.scale;
         sh[0] = first.a;
         sh[1] = first.b;
         sh[2] = first.c;
 
-        let second: SH = fetch4(textureLoad(splatSH_4to7, source.uv, 0));
+        let second: SH = fetch4(loadSplatSH_4to7());
         sh[3] = second.a;
         sh[4] = second.b;
         sh[5] = second.c;
         sh[6] = second.d;
 
-        let third: SH = fetch4(textureLoad(splatSH_8to11, source.uv, 0));
+        let third: SH = fetch4(loadSplatSH_8to11());
         sh[7] = third.a;
         sh[8] = third.b;
         sh[9] = third.c;
         sh[10] = third.d;
 
-        let fourth: SH = fetch4(textureLoad(splatSH_12to15, source.uv, 0));
+        let fourth: SH = fetch4(loadSplatSH_12to15());
         sh[11] = fourth.a;
         sh[12] = fourth.b;
         sh[13] = fourth.c;


### PR DESCRIPTION
## Summary

Introduces `GSplatStreams` class to centralize texture management for GSplat resources, replacing manual texture map handling across resource classes. 
## Changes

### New `GSplatStreams` Class
- Manages texture creation, storage, and destruction for GSplat resources
- Provides `textureDimensions` (Vec2) for consistent texture sizing
- Exposes `createTexture()`, `evalTextureSize()`, `getTexture()`, and `destroy()` methods

### Resource Classes Refactored
- `GSplatResourceBase`: Now uses `GSplatStreams` instance instead of manual `textures` Map
- `GSplatContainer`, `GSplatResource`, `GSplatCompressedResource`: Use `streams.init()` for texture creation
- `GSplatSogResource`: Manually sets `textureDimensions` from loaded texture dimensions (SOG textures are externally owned)

### Shader Chunks Updated
- texture sampling now uses injected load function, avoiding manual uniform management
