### PR TITLE
[FIX] Fix XrInputSource crash when grip unavailable

### DIFF
--- a/scripts/esm/xr-controllers.mjs
+++ b/scripts/esm/xr-controllers.mjs
@@ -98,8 +98,10 @@ class XrControllers extends Script {
                         jointEntity.setRotation(joint.getRotation());
                     }
                 } else {
-                    entity.setPosition(inputSource.getPosition());
-                    entity.setRotation(inputSource.getRotation());
+                    const position = inputSource.getPosition();
+                    const rotation = inputSource.getRotation();
+                    if (position) entity.setPosition(position);
+                    if (rotation) entity.setRotation(rotation);
                 }
             }
         }

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -586,7 +586,7 @@ class XrInputSource extends EventHandler {
      * @returns {Vec3|null} The world space position of handheld input source.
      */
     getPosition() {
-        if (!this._position) return null;
+        if (!this._grip) return null;
 
         this._updateTransforms();
         this._worldTransform.getTranslation(this._position);
@@ -611,7 +611,7 @@ class XrInputSource extends EventHandler {
      * @returns {Quat|null} The world space rotation of handheld input source.
      */
     getRotation() {
-        if (!this._rotation) return null;
+        if (!this._grip) return null;
 
         this._updateTransforms();
         this._rotation.setFromMat4(this._worldTransform);


### PR DESCRIPTION
## Summary

- Fixed `TypeError: Cannot read properties of null (reading 'setTRS')` crash in VR mode
- `getPosition()` and `getRotation()` now correctly return `null` when grip data is not yet available, as documented
- Added defensive null checks in `XrControllers` script

## Technical Details

The `getPosition()` and `getRotation()` methods had incorrect null guards:

```javascript
// Before (broken)
getPosition() {
    if (!this._position) return null;  // _position is always initialized, never null
    this._updateTransforms();          // crashes when _localTransform is null
}

// After (fixed)
getPosition() {
    if (!this._grip) return null;      // correctly checks if grip data exists
    this._updateTransforms();
}
```

The crash occurred when `getPosition()` was called before the first valid `gripPose` was received from WebXR. The `_localTransform` matrix is only created when `_grip` becomes true, but the old guard checked `_position` which is always a valid `Vec3`.

This aligns the implementation with the existing JSDoc contract: *"Get the world space position of input source if it is handheld (grip is true). Otherwise it will return null."*

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
