### PR TITLE
[FIX] Fix controller models in XR movement example

### DIFF
--- a/examples/src/examples/xr/vr-movement.example.mjs
+++ b/examples/src/examples/xr/vr-movement.example.mjs
@@ -77,7 +77,7 @@ const controllers = [];
 // create controller box
 const createController = function (inputSource) {
     const entity = new pc.Entity();
-    entity.addComponent('model', {
+    entity.addComponent('render', {
         type: 'box'
     });
     entity.setLocalScale(0.05, 0.05, 0.05);
@@ -239,12 +239,12 @@ if (app.xr.supported) {
             // render controller
             if (inputSource.grip) {
                 // some controllers can be gripped
-                controllers[i].model.enabled = true;
-                controllers[i].setLocalPosition(inputSource.getLocalPosition);
-                controllers[i].setLocalRotation(inputSource.getLocalRotation);
+                controllers[i].render.enabled = true;
+                controllers[i].setLocalPosition(inputSource.getLocalPosition());
+                controllers[i].setLocalRotation(inputSource.getLocalRotation());
             } else {
                 // some controllers cannot be gripped
-                controllers[i].model.enabled = false;
+                controllers[i].render.enabled = false;
             }
         }
     });


### PR DESCRIPTION
## Summary

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/683dcebf-e1f2-48c8-95a7-571973455c07" />

- Fix missing parentheses on `getLocalPosition()` and `getLocalRotation()` method calls that were passing function references instead of calling the methods
- Replace deprecated `model` component with `render` component for controller visualization

## Details

The example had two issues:

1. **Bug fix**: `inputSource.getLocalPosition` and `inputSource.getLocalRotation` were missing parentheses, causing the controller entities to receive function references instead of Vec3/Quat values. This prevented controller positions from updating correctly.

2. **Deprecation cleanup**: Replaced the deprecated `model` component with the `render` component for the controller box entities.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
