### PR TITLE
[FIX] Fix duplicate XrViews instance and clean up handler in XrManager

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -305,7 +305,6 @@ class XrManager extends EventHandler {
         this._available[XRTYPE_VR] = false;
         this._available[XRTYPE_AR] = false;
 
-        this.views = new XrViews(this);
         this.domOverlay = new XrDomOverlay(this);
         this.hitTest = new XrHitTest(this);
         this.imageTracking = new XrImageTracking(this);
@@ -570,8 +569,7 @@ class XrManager extends EventHandler {
      * end.
      *
      * @param {XrErrorCallback} [callback] - Optional callback function called once session is
-     * started. The callback has one argument Error - it is null if successfully started XR
-     * session.
+     * ended. The callback has one argument Error - it is null if successfully ended XR session.
      * @example
      * app.keyboard.on('keydown', (evt) => {
      *     if (evt.key === pc.KEY_ESCAPE && app.xr.active) {
@@ -716,6 +714,10 @@ class XrManager extends EventHandler {
             this._setClipPlanes(this._camera.nearClip, this._camera.farClip);
         };
 
+        const onFrameRateChange = () => {
+            this.fire('frameratechange', this._session?.frameRate);
+        };
+
         // clean up once session is ended
         const onEnd = () => {
             if (this._camera) {
@@ -727,6 +729,7 @@ class XrManager extends EventHandler {
 
             session.removeEventListener('end', onEnd);
             session.removeEventListener('visibilitychange', onVisibilityChange);
+            session.removeEventListener('frameratechange', onFrameRateChange);
 
             if (!failed) this.fire('end');
 
@@ -763,9 +766,7 @@ class XrManager extends EventHandler {
             this._supportedFrameRates = null;
         }
 
-        this._session.addEventListener('frameratechange', () => {
-            this.fire('frameratechange', this._session?.frameRate);
-        });
+        this._session.addEventListener('frameratechange', onFrameRateChange);
 
         // request reference space
         session.requestReferenceSpace(spaceType).then((referenceSpace) => {


### PR DESCRIPTION
## Summary

- Remove duplicate `XrViews` instantiation in constructor that was accidentally introduced in #5848, causing memory leak
- Fix `frameratechange` event listener never being removed when XR session ends
- Fix incorrect JSDoc comment in `end()` method that said "started" instead of "ended"

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
