### PR TITLE
[FIX] Fix WebXR stereo frustum culling

### DIFF
--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -117,6 +117,10 @@ class Frustum {
      * both. This is useful for multi-view rendering such as stereo XR where culling should keep
      * objects visible in any view.
      *
+     * Note: This method assumes both frustums have similar orientation (parallel views). This is
+     * valid for WebXR stereo rendering where eyes use parallel projection with only a horizontal
+     * offset, not toe-in convergence.
+     *
      * @param {Frustum} other - The other frustum to add.
      * @returns {Frustum} Self for chaining.
      */

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -508,8 +508,11 @@ class Renderer {
     updateCameraFrustum(camera) {
 
         if (camera.xr && camera.xr.views.list.length) {
-            // calculate combined frustum from all XR views to avoid culling objects
-            // visible in any view (e.g. right edge of right eye in stereo rendering)
+            // Calculate combined frustum from all XR views to avoid culling objects
+            // visible in any view (e.g. right edge of right eye in stereo rendering).
+            // This works because WebXR uses parallel projection for stereo views - both eyes
+            // look in the same direction with only a horizontal offset, so frustum plane
+            // normals are identical and we can merge by selecting outermost planes.
             const views = camera.xr.views.list;
 
             // first view establishes the base frustum


### PR DESCRIPTION
## Summary
- Fix incorrect frustum culling in WebXR stereo rendering that caused objects on the right edge of the right eye to be culled early
- Add `Frustum.add()` method to combine frustums by keeping the outermost plane for each boundary

## Details
The previous implementation used only the first view's (left eye) frustum for culling, causing objects visible in the right eye but outside the left eye's view to be incorrectly culled.

The fix computes a combined frustum that encompasses all XR views by selecting the plane with the largest distance for each of the 6 frustum boundaries (left, right, top, bottom, near, far).

### Why this works for WebXR
This approach assumes frustums have parallel orientation (same plane normals). This is valid for WebXR stereo rendering because modern VR/AR headsets use **parallel projection** - both eyes look in the same direction with only a horizontal IPD offset, not toe-in convergence. With parallel views, frustum plane normals are identical and only distances differ, making plane merging by distance comparison correct.

### Public API Addition
```js
// Frustum.add(other) - expands frustum to contain another
frustumA.add(frustumB);
```

Fixes #5787
Closes #7411

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
