### PR TITLE
Add BatchManager.getGroupById method

### DIFF
--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -191,6 +191,17 @@ class BatchManager {
     }
 
     /**
+     * Retrieves a {@link BatchGroup} object with a corresponding id, if it exists, or null
+     * otherwise.
+     *
+     * @param {number} id - The batch group id.
+     * @returns {BatchGroup|null} The batch group matching the id or null if not found.
+     */
+    getGroupById(id) {
+        return this._batchGroups[id] ?? null;
+    }
+
+    /**
      * Return a list of all {@link Batch} objects that belong to the Batch Group supplied.
      *
      * @param {number} batchGroupId - The id of the batch group.


### PR DESCRIPTION
Adds a new public method `getGroupById(id)` to `BatchManager` that retrieves a `BatchGroup` by its numeric ID.

### Background

Components such as `render`, `model`, `element`, and `sprite` store a `batchGroupId` property, but there was no public API to retrieve the corresponding `BatchGroup` object from the manager. Users had to either:
- Use `getGroupByName()` (requires knowing the name)
- Access the private `_batchGroups` property directly

### Changes

- Added `getGroupById(id)` method that returns the `BatchGroup` with the specified ID, or `null` if not found
- Mirrors the existing `getGroupByName()` API

### Public API Additions

```javascript
/**
 * Retrieves a BatchGroup object with a corresponding id, if it exists, or null otherwise.
 * @param {number} id - The batch group id.
 * @returns {BatchGroup|null}
 */
batchManager.getGroupById(id)
```

### Usage Example

```javascript
const group = app.batcher.getGroupById(entity.render.batchGroupId);
if (group) {
    console.log(`Group: ${group.name}, dynamic: ${group.dynamic}`);
}
```

Fixes #8388
