### PR TITLE
Destroy WebGPU texture immediately instead of letting garbage collection do it

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -155,6 +155,11 @@ class WebgpuTexture {
     }
 
     destroy(device) {
+        this.gpuTexture?.destroy();
+        this.gpuTexture = null;
+        this.view = null;
+        this.viewCache.clear();
+        this.samplers.length = 0;
     }
 
     propertyChanged(flag) {


### PR DESCRIPTION
Previously, `WebgpuTexture.destroy()` was an empty method, relying on JavaScript garbage collection to eventually release the underlying `GPUTexture`. This could cause GPU memory pressure when many textures are destroyed without GC running.

This change updates `destroy()` to:
- Call `gpuTexture.destroy()` to immediately release GPU memory
- Clear the texture view and view cache
- Clear cached samplers

This aligns WebGPU behavior with the WebGL implementation, which already calls `gl.deleteTexture()` on destroy.