### PR TITLE
Add numeric literal support to shader preprocessor

### DIFF
--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -538,6 +538,12 @@ class Preprocessor {
             return { result: false, error };
         }
 
+        // Handle numeric literals (0 is false, non-zero is true) - standard C preprocessor behavior
+        const num = parseFloat(expr);
+        if (!isNaN(num)) {
+            return { result: num !== 0, error };
+        }
+
         // Handle defined(expr) and !defined(expr)
         const definedMatch = DEFINED.exec(expr);
         if (definedMatch) {

--- a/test/core/preprocessor.test.mjs
+++ b/test/core/preprocessor.test.mjs
@@ -178,6 +178,31 @@ describe('Preprocessor', function () {
 
         TESTINJECTION {COUNT}
         INJECTSTRING {STRING}(x)
+
+        // Test numeric literals (standard C preprocessor behavior)
+        #if 1
+            NUM1
+        #endif
+
+        #if 0
+            NUM2
+        #endif
+
+        #if 42
+            NUM3
+        #endif
+
+        #if 0.0
+            NUM4
+        #endif
+
+        #if 1 && defined(A)
+            NUM5
+        #endif
+
+        #if 0 || defined(A)
+            NUM6
+        #endif
     `;
 
     it('returns false for MORPH_A', function () {
@@ -354,5 +379,30 @@ describe('Preprocessor', function () {
 
     it('returns true for PREC9 (spaces inside precedence parens)', function () {
         expect(Preprocessor.run(srcData, includes).includes('PREC9')).to.equal(true);
+    });
+
+    // Numeric literal tests
+    it('returns true for NUM1 (#if 1 is truthy)', function () {
+        expect(Preprocessor.run(srcData, includes).includes('NUM1')).to.equal(true);
+    });
+
+    it('returns false for NUM2 (#if 0 is falsy)', function () {
+        expect(Preprocessor.run(srcData, includes).includes('NUM2')).to.equal(false);
+    });
+
+    it('returns true for NUM3 (#if 42 non-zero is truthy)', function () {
+        expect(Preprocessor.run(srcData, includes).includes('NUM3')).to.equal(true);
+    });
+
+    it('returns false for NUM4 (#if 0.0 is falsy)', function () {
+        expect(Preprocessor.run(srcData, includes).includes('NUM4')).to.equal(false);
+    });
+
+    it('returns true for NUM5 (#if 1 && defined(A))', function () {
+        expect(Preprocessor.run(srcData, includes).includes('NUM5')).to.equal(true);
+    });
+
+    it('returns true for NUM6 (#if 0 || defined(A))', function () {
+        expect(Preprocessor.run(srcData, includes).includes('NUM6')).to.equal(true);
     });
 });


### PR DESCRIPTION
## Description

Adds support for numeric literals in `#if` preprocessor expressions, following standard C preprocessor behavior.

### Changes
- `#if 0` now evaluates to false (block is excluded)
- `#if 1` and any non-zero numeric literal evaluates to true (block is included)
- Works with floating point values (`#if 0.0` is falsy)
- Combines correctly with other expressions (`#if 1 && defined(FOO)`)

### Why
This is standard C preprocessor behavior that developers expect to work. Previously, `#if 1` would incorrectly evaluate to false because the preprocessor checked if `'1'` was a defined symbol rather than treating it as a numeric literal.

### Test Plan
- [x] Added 6 unit tests covering numeric literals (positive integers, zero, non-zero, floats, combined expressions)
- [x] All 49 preprocessor tests pass