### PR TITLE
Fix unified gsplat work buffer extra streams for octrees and color-only updates

### DIFF
--- a/src/scene/gsplat-unified/gsplat-info.js
+++ b/src/scene/gsplat-unified/gsplat-info.js
@@ -98,11 +98,12 @@ class GSplatInfo {
     getWorkBufferModifier = null;
 
     /**
-     * Instance texture streams (reference to placement's streams, stable object).
+     * Function to get current instance streams from source placement.
+     * Retrieved live (not snapshotted) to ensure streams are available after lazy creation.
      *
-     * @type {GSplatStreams|null}
+     * @type {(() => GSplatStreams|null)|null}
      */
-    instanceStreams = null;
+    getInstanceStreams = null;
 
     /**
      * Callback to consume render dirty flag from the source placement.
@@ -132,11 +133,8 @@ class GSplatInfo {
         this.aabb.copy(placement.aabb);
         this.parameters = placement.parameters;
         this.getWorkBufferModifier = () => placement.workBufferModifier;
+        this.getInstanceStreams = () => placement.streams;
         this._consumeRenderDirty = consumeRenderDirty;
-
-        // no need to deep copy as streams can only be added to, so it won't hurt to have additional
-        // textures that the shader does not use yet.
-        this.instanceStreams = placement.streams;
 
         this.updateIntervals(placement.intervals);
     }

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -805,7 +805,7 @@ class GSplatOctreeInstance {
         if (!placement) {
 
             // create placement (with null resource initially)
-            placement = new GSplatPlacement(null, this.placement.node, lodIndex);
+            placement = new GSplatPlacement(null, this.placement.node, lodIndex, null, this.placement);
             this.filePlacements[fileIndex] = placement;
 
             // If we scheduled a remove for this file in this update, cancel it
@@ -989,7 +989,7 @@ class GSplatOctreeInstance {
 
             if (envResource) {
                 // create environment placement with the loaded resource
-                this.environmentPlacement = new GSplatPlacement(envResource, this.placement.node, 0);
+                this.environmentPlacement = new GSplatPlacement(envResource, this.placement.node, 0, null, this.placement);
                 this.environmentPlacement.aabb.copy(envResource.aabb);
                 this.activePlacements.add(this.environmentPlacement);
                 this.dirtyModifiedPlacements = true;

--- a/src/scene/gsplat-unified/gsplat-placement.js
+++ b/src/scene/gsplat-unified/gsplat-placement.js
@@ -117,18 +117,30 @@ class GSplatPlacement {
     _workBufferModifier = null;
 
     /**
+     * Parent placement
+     * Used by octree file placements to inherit workBufferModifier and parameters from
+     * the component's placement.
+     *
+     * @type {GSplatPlacement|null}
+     * @private
+     */
+    _parentPlacement = null;
+
+    /**
      * Create a new GSplatPlacement.
      *
      * @param {GSplatResource|null} resource - The resource of the splat.
      * @param {GraphNode} node - The node that the gsplat is linked to.
      * @param {number} [lodIndex] - The LOD index for this placement.
      * @param {Map<string, {scopeId: ScopeId, data: *}>|null} [parameters] - Per-instance shader parameters.
+     * @param {GSplatPlacement|null} [parentPlacement] - Parent placement for shader config delegation.
      */
-    constructor(resource, node, lodIndex = 0, parameters = null) {
+    constructor(resource, node, lodIndex = 0, parameters = null, parentPlacement = null) {
         this.resource = resource;
         this.node = node;
         this.lodIndex = lodIndex;
-        this.parameters = parameters;
+        this.parameters = parameters ?? parentPlacement?.parameters ?? null;
+        this._parentPlacement = parentPlacement;
     }
 
     /**
@@ -154,11 +166,12 @@ class GSplatPlacement {
 
     /**
      * Gets the work buffer modifier for this placement.
+     * Delegates to parent placement if available (for octree file placements).
      *
      * @type {{ code: string, hash: number }|null}
      */
     get workBufferModifier() {
-        return this._workBufferModifier;
+        return this._parentPlacement?.workBufferModifier ?? this._workBufferModifier;
     }
 
     /**
@@ -256,12 +269,13 @@ class GSplatPlacement {
 
     /**
      * Gets the instance streams container, or null if not initialized.
+     * Delegates to parent placement if available (for octree file placements).
      *
      * @type {GSplatStreams|null}
      * @ignore
      */
     get streams() {
-        return this._streams;
+        return this._parentPlacement?.streams ?? this._streams;
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-work-buffer-render-pass.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer-render-pass.js
@@ -196,11 +196,12 @@ class GSplatWorkBufferRenderPass extends RenderPass {
             }
         }
 
-        // Bind instance textures if available
-        if (splatInfo.instanceStreams) {
+        // Bind instance textures if available (fetched live from placement)
+        const instanceStreams = splatInfo.getInstanceStreams?.();
+        if (instanceStreams) {
             // Sync to ensure textures exist for any newly added streams
-            splatInfo.instanceStreams.syncWithFormat(splatInfo.resource.format);
-            for (const [name, texture] of splatInfo.instanceStreams.textures) {
+            instanceStreams.syncWithFormat(splatInfo.resource.format);
+            for (const [name, texture] of instanceStreams.textures) {
                 scope.resolve(name).setValue(texture);
             }
         }

--- a/src/scene/gsplat/gsplat-format.js
+++ b/src/scene/gsplat/gsplat-format.js
@@ -353,8 +353,36 @@ class GSplatFormat {
             .replace('{funcName}', funcName)
             .replace('{returnType}', info.returnType)
             .replace('{index}', String(i))
-            .replace('{colorSlot}', colorSlot);
+            .replace('{colorSlot}', colorSlot)
+            .replace('{defineGuard}', '1');
             lines.push(decl);
+        }
+
+        return lines.join('\n');
+    }
+
+    /**
+     * Generates no-op stub functions for streams that aren't render targets.
+     * Used in color-only mode so user modifier code compiles but writes are ignored.
+     *
+     * @param {GSplatStreamDescriptor[]} streams - Stream descriptors to generate stubs for.
+     * @returns {string} Shader code for no-op write functions.
+     * @ignore
+     */
+    getOutputStubs(streams) {
+        const isWebGPU = this._device.isWebGPU;
+        const lines = [];
+        const template = isWebGPU ? wgslStreamOutput : glslStreamOutput;
+        const getShaderType = isWebGPU ? getWgslShaderType : getGlslShaderType;
+
+        for (const stream of streams) {
+            const info = getShaderType(stream.format);
+            const funcName = stream.name.charAt(0).toUpperCase() + stream.name.slice(1);
+            const stub = template
+            .replace('{funcName}', funcName)
+            .replace('{returnType}', info.returnType)
+            .replace('{defineGuard}', '0');
+            lines.push(stub);
         }
 
         return lines.join('\n');

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -235,7 +235,14 @@ class GSplatResourceBase {
             const outputStreams = colorOnly ?
                 [workBufferFormat.getStream('splatColor')] :
                 [...workBufferFormat.streams, ...workBufferFormat.extraStreams];
-            chunks.set('gsplatWorkBufferOutputVS', workBufferFormat.getOutputDeclarations(outputStreams));
+            let outputCode = workBufferFormat.getOutputDeclarations(outputStreams);
+
+            // In color-only mode, generate no-op stubs for extra streams so user modifiers compile
+            if (colorOnly && workBufferFormat.extraStreams.length > 0) {
+                outputCode += `\n${workBufferFormat.getOutputStubs(workBufferFormat.extraStreams)}`;
+            }
+
+            chunks.set('gsplatWorkBufferOutputVS', outputCode);
 
             // copy tempMap to material defines
             tempMap.forEach((v, k) => material.setDefine(k, v));

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatStreamOutput.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatStreamOutput.js
@@ -1,5 +1,10 @@
 // Template for gsplat stream output - write function for MRT
-// Placeholders: {funcName}, {returnType}, {index}
+// Placeholders: {funcName}, {returnType}, {index}, {defineGuard}
+// {defineGuard} is 1 for real output, 0 for no-op stub
 export default /* glsl */`
-void write{funcName}({returnType} value) { pcFragColor{index} = value; }
+void write{funcName}({returnType} value) {
+#if {defineGuard}
+    pcFragColor{index} = value;
+#endif
+}
 `;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatStreamOutput.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatStreamOutput.js
@@ -1,6 +1,11 @@
 // Template for gsplat stream output - write function for MRT
-// Placeholders: {funcName}, {returnType}, {colorSlot}
+// Placeholders: {funcName}, {returnType}, {colorSlot}, {defineGuard}
 // Note: {colorSlot} is 'color' for index 0, 'color1', 'color2', etc. for others
+// {defineGuard} is 1 for real output, 0 for no-op stub
 export default /* wgsl */`
-fn write{funcName}(value: {returnType}) { processOutput.{colorSlot} = value; }
+fn write{funcName}(value: {returnType}) {
+#if {defineGuard}
+    processOutput.{colorSlot} = value;
+#endif
+}
 `;


### PR DESCRIPTION
Fixes two related issues with unified gsplat work buffer extra streams:

### 1. Octree parent placement delegation

Octree file placements now properly inherit shader configuration from the component's placement, enabling them to write to work buffer extra streams:
- `workBufferModifier` - delegated via getter (allows writing to extra streams)
- `parameters` - inherited in constructor (e.g., component ID uniforms)
- `streams` (instance textures) - delegated via getter

This allows octree splats to use per-component parameters and modifiers when writing to work buffer extra streams

### 2. Color-only shader compilation fix

When camera movement triggers a color-only update (spherical harmonics recalculation), the work buffer shader now generates no-op stub functions for extra stream writes. This prevents shader compilation errors when the user's `workBufferModifier` calls functions like `writeSplatComponentId()` that don't have render targets in color-only mode.
