### PR TITLE
Fix XrNavigation teleport offset

### DIFF
--- a/scripts/esm/xr-navigation.mjs
+++ b/scripts/esm/xr-navigation.mjs
@@ -249,6 +249,13 @@ class XrNavigation extends Script {
 
         const hitPoint = this.findPlaneIntersection(origin, direction);
         if (hitPoint) {
+            // Adjust for camera's local XZ offset so the user's head ends up at the target
+            if (this.cameraEntity) {
+                const cameraLocalPos = this.cameraEntity.getLocalPosition();
+                hitPoint.x -= cameraLocalPos.x;
+                hitPoint.z -= cameraLocalPos.z;
+            }
+
             const cameraY = this.entity.getPosition().y;
             hitPoint.y = cameraY;
             this.entity.setPosition(hitPoint);


### PR DESCRIPTION
## Summary

- Fixes XrNavigation teleport landing short of the target position by accounting for the camera's local XZ offset from XR head tracking

## Technical Details

In WebXR, the camera entity's local position represents the user's physical head position within their play space. The previous code moved the navigation entity directly to the hit point without compensating for this offset, causing the camera to end up at `hitPoint + cameraLocalOffset` instead of directly above `hitPoint`.

The fix subtracts the camera's local XZ position from the hit point before setting the navigation entity position.

## Test Plan

- [x] Run the XR Menu example in VR
- [x] Point at a spot on the ground and teleport
- [x] Verify the camera ends up directly above the target location

Closes #8408
