### PR TITLE
Add 2D Gaussian Splatting (2DGS) Rendering Support

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
@@ -76,7 +76,13 @@ void main(void) {
     clipCorner(corner, clr.w);
 
     // write output
-    gl_Position = center.proj + vec4(corner.offset, 0, 0);
+    #if GSPLAT_2DGS
+        // 2DGS: Project world corner directly
+        vec3 modelCorner = center.modelCenterModified + corner.offset;
+        gl_Position = matrix_projection * center.modelView * vec4(modelCorner, 1.0);
+    #else
+        gl_Position = center.proj + vec4(corner.offset.xyz, 0);
+    #endif
     gaussianUV = corner.uv;
 
     #ifdef GSPLAT_OVERDRAW

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatStructs.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatStructs.js
@@ -20,7 +20,7 @@ struct SplatCenter {
 
 // stores the offset from center for the current gaussian
 struct SplatCorner {
-    vec2 offset;        // corner offset from center in clip space
+    vec3 offset;        // corner offset (clip XY for 3DGS, model XYZ for 2DGS)
     vec2 uv;            // corner uv
     #if GSPLAT_AA
         float aaFactor; // for scenes generated with antialiasing

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
@@ -81,7 +81,14 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     clipCorner(&corner, clr.w);
 
     // write output
-    output.position = center.proj + vec4f(corner.offset, 0.0, 0.0);
+    #if GSPLAT_2DGS
+        // 2DGS: Project world corner directly
+        let modelCorner: vec3f = center.modelCenterModified + corner.offset;
+        output.position = uniform.matrix_projection * center.modelView * vec4f(modelCorner, 1.0);
+    #else
+        // 3DGS: Add clip-space offset to projected center
+        output.position = center.proj + vec4f(corner.offset.xyz, 0.0);
+    #endif
     output.gaussianUV = corner.uv;
 
     #ifdef GSPLAT_OVERDRAW

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatStructs.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatStructs.js
@@ -20,7 +20,7 @@ struct SplatCenter {
 
 // stores the offset from center for the current gaussian
 struct SplatCorner {
-    offset: vec2f,        // corner offset from center in clip space
+    offset: vec3f,        // corner offset (clip XY for 3DGS, model XYZ for 2DGS)
     uv: vec2f,            // corner uv
     #if GSPLAT_AA
         aaFactor: f32, // for scenes generated with antialiasing


### PR DESCRIPTION
# Add 2D Gaussian Splatting (2DGS) Rendering Support

This PR adds support for rendering 2D Gaussian Splats using a new `GSPLAT_2DGS` shader define, similar to the existing `GSPLAT_AA` define.

## Summary

- Add `GSPLAT_2DGS` conditional rendering path for 2D Gaussian Splatting
- Implement oriented quad corner calculation in model space using direct quaternion-vector rotation
- Change `SplatCorner.offset` from `vec2` to `vec3` to support both 3DGS (clip-space XY) and 2DGS (model-space XYZ)
- Extract 2DGS corner calculation into dedicated `initCorner2DGS` function

## Technical Details

**2DGS Rendering Approach:**
- 2DGS splats are rendered as oriented 3D quads in model space
- Corner positions are computed by scaling the quad by 3σ (3-sigma coverage) and rotating using the splat's quaternion
- The GPU's hardware rasterizer handles perspective projection, eliminating the need for covariance-based screen-space projection

**Quaternion Rotation:**
Uses direct quaternion-vector rotation formula (faster than matrix conversion):
```glsl
vec3 t = 2.0 * cross(rotation.xyz, v);
corner.offset = v + rotation.w * t + cross(rotation.xyz, t);
```

## Public API Changes

**New Shader Define:**
- `GSPLAT_2DGS` - When enabled, uses the 2DGS oriented quad rendering path instead of the 3DGS covariance-based path

**Struct Change:**
- `SplatCorner.offset`: Changed from `vec2`/`vec2f` to `vec3`/`vec3f`
  - 3DGS: Uses XY for clip-space offset, Z is 0
  - 2DGS: Uses XYZ for model-space offset

## Files Changed

- `src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatStructs.js`
- `src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCorner.js`
- `src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js`
- `src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatStructs.js`
- `src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCorner.js`
- `src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js`

## Test Plan

- [ ] Verify 3DGS rendering is unchanged (no regressions)
- [ ] Enable `GSPLAT_2DGS` define and verify 2DGS splats render correctly
- [ ] Test rotation correctness with various quaternion orientations
- [ ] Verify WebGL2 and WebGPU backends both work correctly