### PR TITLE
feat: add snap vertical movement to XrNavigation script

### DIFF
--- a/scripts/esm/xr-navigation.mjs
+++ b/scripts/esm/xr-navigation.mjs
@@ -127,7 +127,7 @@ class XrNavigation extends Script {
     enableSnapVertical = true;
 
     /**
-     * Height in meters for each vertical snap when using one grip.
+     * Height in meters for each vertical snap.
      * @attribute
      * @range [0.1, 2]
      * @precision 0.1


### PR DESCRIPTION
## Summary

- Add snap vertical movement to XrNavigation for comfortable VR height adjustment
- Uses right thumbstick Y-axis with hysteresis (same pattern as snap turning)
- Hold right grip while snapping for boost mode (larger jumps)

## New Controls

| Input | Action |
|-------|--------|
| Right thumbstick Y | Snap up/down by 0.5m |
| Right grip + Right thumbstick Y | Snap up/down by 2.0m (boost) |

## New Script Attributes

- \enableSnapVertical\ - Toggle feature on/off (default: true)
- \snapVerticalHeight\ - Height per snap (default: 0.5m)
- \snapVerticalBoostHeight\ - Height when boosting (default: 2.0m)
- \snapVerticalThreshold\ - Thumbstick threshold to trigger (default: 0.5)
- \snapVerticalResetThreshold\ - Threshold to reset snap state (default: 0.25)

## Why Snap Instead of Smooth?

Snap-based vertical movement is significantly more comfortable than continuous smooth movement because:
1. Instant transitions don't cause vection (false sense of motion)
2. Same pattern as snap turning which users are already familiar with
3. No continuous motion = much less motion sickness

## Test Plan

- [ ] Test on Quest with controllers - verify right thumbstick Y snaps up/down
- [ ] Test grip boost - verify larger snap height when holding right grip
- [ ] Verify snap turning still works (right thumbstick X)
- [ ] Verify XZ locomotion still works (left thumbstick)