### PR TITLE
Rename GSplatParams.id to enableIds

### DIFF
--- a/examples/src/examples/gaussian-splatting/picking.example.mjs
+++ b/examples/src/examples/gaussian-splatting/picking.example.mjs
@@ -83,7 +83,7 @@ assetListLoader.load(() => {
     }
 
     // Enable gsplat ID for unified picking
-    app.scene.gsplat.id = true;
+    app.scene.gsplat.enableIds = true;
 
     // Create an Entity with a camera component
     const camera = new pc.Entity();

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -513,7 +513,7 @@ class GSplatComponent extends Component {
 
     /**
      * Gets the unique identifier for this component. This ID is used by the picking system
-     * and is also written to the work buffer when `app.scene.gsplat.id` is enabled, making
+     * and is also written to the work buffer when `app.scene.gsplat.enableIds` is enabled, making
      * it available to custom shaders for effects like highlighting or animation.
      *
      * @type {number}

--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -122,7 +122,7 @@ class RenderPassPicker extends RenderPass {
                     // Process gsplat placements when ID is enabled
                     // The gsplat unified mesh instance is already handled above (added to layer.meshInstances)
                     // Here we just need to add the placement ID -> component mapping
-                    if (scene.gsplat.id) {
+                    if (scene.gsplat.enableIds) {
                         const placements = srcLayer.gsplatPlacements;
                         for (let j = 0; j < placements.length; j++) {
                             const placement = placements[j];

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -127,7 +127,7 @@ class GSplatParams {
      * @type {boolean}
      * @private
      */
-    _id = false;
+    _enableIds = false;
 
     /**
      * Enables per-component ID storage in the work buffer. When enabled, each GSplat component
@@ -139,10 +139,10 @@ class GSplatParams {
      *
      * @type {boolean}
      */
-    set id(value) {
+    set enableIds(value) {
         // Only accept true (once enabled, cannot be disabled)
-        if (value && !this._id) {
-            this._id = true;
+        if (value && !this._enableIds) {
+            this._enableIds = true;
             if (!this._format.getStream('pcId')) {
                 this._format.addExtraStreams([
                     { name: 'pcId', format: PIXELFORMAT_R32U }
@@ -157,8 +157,8 @@ class GSplatParams {
      *
      * @type {boolean}
      */
-    get id() {
-        return this._id;
+    get enableIds() {
+        return this._enableIds;
     }
 
     /**


### PR DESCRIPTION
Renames the `id` property in `GSplatParams` to `enableIds` to better reflect its purpose as a boolean flag that enables per-component ID storage.
