### PR TITLE
GSplatProcessor: Add numSplats uniforms and automatic padding skip

### DIFF
--- a/src/framework/gsplat/gsplat-processor.js
+++ b/src/framework/gsplat/gsplat-processor.js
@@ -52,6 +52,10 @@ import wgslGsplatProcess from '../../scene/shader-lib/wgsl/chunks/gsplat/frag/gs
  * Custom uniforms can be passed to the shader via {@link setParameter}, including scalar values,
  * vectors, and additional textures for effects like brush patterns or lookup tables.
  *
+ * The following built-in uniforms are available in processing shaders:
+ * - `srcNumSplats` (uint) - Number of splats in source resource
+ * - `dstNumSplats` (uint) - Number of splats in destination resource
+ *
  * @example
  * // Create a processor that reads splat positions and writes to a customColor texture
  * const processor = new pc.GSplatProcessor(
@@ -472,9 +476,11 @@ class GSplatProcessor {
             device.scope.resolve(name).setValue(texture);
         }
 
-        // Set texture size uniforms
+        // Set texture size and splat count uniforms
         device.scope.resolve('splatTextureSize').setValue(this._srcResource.textureDimensions.x);
         device.scope.resolve('dstTextureSize').setValue(this._dstResource.textureDimensions.x);
+        device.scope.resolve('srcNumSplats').setValue(this._srcResource.numSplats);
+        device.scope.resolve('dstNumSplats').setValue(this._dstResource.numSplats);
 
         // Bind non-texture parameters from resource (e.g., dequantization uniforms for SOG)
         for (const [name, value] of this._srcResource.parameters) {

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatProcess.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplatProcess.js
@@ -1,9 +1,11 @@
 // Fragment shader template for GSplatProcessor - processes splat data from src to dst streams
 export default /* glsl */`
 
-// Texture size uniforms
+// Texture size and splat count uniforms
 uniform uint splatTextureSize;
 uniform uint dstTextureSize;
+uniform uint srcNumSplats;
+uniform uint dstNumSplats;
 
 // Shared splat identification (index, uv) and setSplat() helper
 #include "gsplatSplatVS"
@@ -25,12 +27,15 @@ void main(void) {
     ivec2 fragCoords = ivec2(gl_FragCoord.xy);
     
     // Linear index of the destination splat
-    int splatIndex = fragCoords.y * int(dstTextureSize) + fragCoords.x;
+    uint splatIndex = uint(fragCoords.y * int(dstTextureSize) + fragCoords.x);
+    
+    // Skip padding pixels (texture may be larger than actual splat count)
+    if (splatIndex >= dstNumSplats) discard;
     
     // Initialize global splat for sampling
     // Note: splat.uv assumes 1:1 mapping using splatTextureSize. When sizes differ,
     // call setSplat() with a different index in user code.
-    setSplat(uint(splatIndex));
+    setSplat(splatIndex);
     
     // Call user's process function
     process();


### PR DESCRIPTION
## Summary

- Adds `srcNumSplats` and `dstNumSplats` uniforms to processing shaders
- Automatically skips padding pixels in the shader wrapper (texture may be larger than actual splat count)

## Details

GSplatProcessor now automatically discards padding pixels before calling the user's `process()` function. This matches the behavior of rendering shaders and removes the burden from users to handle texture padding manually.

The following uniforms are now available in processing shaders:
- `srcNumSplats` - Number of splats in source resource
- `dstNumSplats` - Number of splats in destination resource

These complement the existing `splatTextureSize` and `dstTextureSize` uniforms.