### PR TITLE
[Fix] ClusteredOmniShadows example - avoid debug render texture when destroyed

### DIFF
--- a/examples/src/examples/graphics/clustered-omni-shadows.example.mjs
+++ b/examples/src/examples/graphics/clustered-omni-shadows.example.mjs
@@ -264,17 +264,12 @@ assetListLoader.load(() => {
 
         // display shadow texture (debug feature)
         if (app.graphicsDevice.isWebGPU) {
-            // @ts-ignore engine-tsd
-            app.drawTexture(
-                -0.7,
-                -0.7,
-                0.5,
-                0.5,
-                app.renderer.lightTextureAtlas.shadowAtlas.texture,
-                undefined,
-                undefined,
-                false
-            );
+            const texture = app.renderer.lightTextureAtlas.shadowAtlas?.texture;
+            // skip if texture is not ready (placeholder or destroyed)
+            if (texture?.device && texture.width > 1) {
+                // @ts-ignore engine-tsd
+                app.drawTexture(-0.7, -0.7, 0.5, 0.5, texture, undefined, undefined, false);
+            }
         }
     });
 });

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -197,7 +197,12 @@ class WebgpuTexture {
             return view;
         }
 
-        Debug.assert(this.view);
+        Debug.call(() => {
+            if (!this.view) {
+                Debug.errorOnce('View failed to be created for texture, texture is possibly destroyed', this);
+            }
+        });
+
         return this.view;
     }
 


### PR DESCRIPTION
## Summary
- Fixes WebGPU error in clustered-omni-shadows example where `drawTexture` could reference a destroyed shadow atlas texture
- Adds checks to skip rendering when the texture is destroyed (`device === null`) or is still a 1x1 placeholder
