### PR TITLE
[Fix] GSplatComponent.customAabb to fall back to resource AABB

### DIFF
--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -250,11 +250,12 @@ class GSplatComponent extends Component {
 
     /**
      * Gets the custom object space bounding box for visibility culling of the attached gsplat.
+     * Returns the custom AABB if set, otherwise falls back to the resource's AABB.
      *
      * @type {BoundingBox|null}
      */
     get customAabb() {
-        return this._customAabb;
+        return this._customAabb ?? this._placement?.aabb ?? this.resource?.aabb ?? null;
     }
 
     /**


### PR DESCRIPTION
Fix GSplatComponent.customAabb to fall back to resource AABB

## Summary

- Fixes `customAabb` getter to return the resource's AABB when no custom AABB is explicitly set
- Restores backwards compatibility broken by the AABB refactoring in #8415
- Fixes the viewer example failing to orbit when loading PLY files via drag-and-drop

## Technical Details

The `customAabb` getter now falls back to:
1. `placement.aabb` in unified mode (which itself falls back to `resource.aabb`)
2. `resource.aabb` in non-unified mode
