### PR TITLE
Fix chromatic fringing shader undefined behavior with negative values

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/render-pass/frag/compose/compose-fringing.js
+++ b/src/scene/shader-lib/glsl/chunks/render-pass/frag/compose/compose-fringing.js
@@ -5,7 +5,7 @@ export default /* glsl */`
         vec3 applyFringing(vec3 color, vec2 uv) {
             // offset depends on the direction from the center
             vec2 centerDistance = uv - 0.5;
-            vec2 offset = fringingIntensity * pow(centerDistance, vec2(2.0, 2.0));
+            vec2 offset = fringingIntensity * centerDistance * centerDistance;
 
             color.r = texture2D(sceneTexture, uv - offset).r;
             color.b = texture2D(sceneTexture, uv + offset).b;

--- a/src/scene/shader-lib/wgsl/chunks/render-pass/frag/compose/compose-fringing.js
+++ b/src/scene/shader-lib/wgsl/chunks/render-pass/frag/compose/compose-fringing.js
@@ -5,7 +5,7 @@ export default /* wgsl */`
         fn applyFringing(color: vec3f, uv: vec2f) -> vec3f {
             // offset depends on the direction from the center
             let centerDistance = uv - 0.5;
-            let offset = uniform.fringingIntensity * pow(centerDistance, vec2f(2.0));
+            let offset = uniform.fringingIntensity * centerDistance * centerDistance;
 
             var colorOut = color;
             colorOut.r = textureSample(sceneTexture, sceneTextureSampler, uv - offset).r;


### PR DESCRIPTION
## Summary
- Fixed undefined behavior in the fringing (chromatic aberration) post-effect shader caused by using `pow()` with negative base values
- Replaced `pow(centerDistance, vec2(2.0))` with `centerDistance * centerDistance` in both GLSL and WGSL shaders

## Details
In GLSL/WGSL, `pow(x, y)` is undefined for negative `x` values. When UV coordinates are less than 0.5 (left/bottom portions of the screen), `centerDistance = uv - 0.5` becomes negative, causing undefined results that varied by GPU driver and rendering path. This manifested as screenshot corruption where only the top-right quadrant rendered correctly in some browsers.
