### PR TITLE
Gaussian Splatting: Use half-precision for spherical harmonics evaluation on WebGPU

### DIFF
--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
@@ -110,7 +110,7 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
             let dir = normalize(center.view * mat3x3f(center.modelView[0].xyz, center.modelView[1].xyz, center.modelView[2].xyz));
 
             // read sh coefficients
-            var sh: array<vec3f, SH_COEFFS>;
+            var sh: array<half3, SH_COEFFS>;
             var scale: f32;
             readSHData(&sh, &scale);
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/compressedSH.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/compressedSH.js
@@ -2,47 +2,47 @@
 export default /* wgsl */`
 #if SH_BANDS > 0
 
-fn unpack8888s(bits: u32) -> vec4f {
+fn unpack8888s(bits: u32) -> half4 {
     let unpacked_u = (vec4<u32>(bits) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(0xffu);
-    return vec4f(unpacked_u) * (8.0 / 255.0) - 4.0;
+    return half4(vec4f(unpacked_u) * (8.0 / 255.0) - 4.0);
 }
 
-fn readSHData(sh: ptr<function, array<vec3f, 15>>, scale: ptr<function, f32>) {
+fn readSHData(sh: ptr<function, array<half3, 15>>, scale: ptr<function, f32>) {
     // read the sh coefficients using format-generated load functions
     let shData0: vec4<u32> = loadShTexture0();
     let shData1: vec4<u32> = loadShTexture1();
     let shData2: vec4<u32> = loadShTexture2();
 
-    let r0 = unpack8888s(shData0.x);
-    let r1 = unpack8888s(shData0.y);
-    let r2 = unpack8888s(shData0.z);
-    let r3 = unpack8888s(shData0.w);
+    let r0: half4 = unpack8888s(shData0.x);
+    let r1: half4 = unpack8888s(shData0.y);
+    let r2: half4 = unpack8888s(shData0.z);
+    let r3: half4 = unpack8888s(shData0.w);
 
-    let g0 = unpack8888s(shData1.x);
-    let g1 = unpack8888s(shData1.y);
-    let g2 = unpack8888s(shData1.z);
-    let g3 = unpack8888s(shData1.w);
+    let g0: half4 = unpack8888s(shData1.x);
+    let g1: half4 = unpack8888s(shData1.y);
+    let g2: half4 = unpack8888s(shData1.z);
+    let g3: half4 = unpack8888s(shData1.w);
 
-    let b0 = unpack8888s(shData2.x);
-    let b1 = unpack8888s(shData2.y);
-    let b2 = unpack8888s(shData2.z);
-    let b3 = unpack8888s(shData2.w);
+    let b0: half4 = unpack8888s(shData2.x);
+    let b1: half4 = unpack8888s(shData2.y);
+    let b2: half4 = unpack8888s(shData2.z);
+    let b3: half4 = unpack8888s(shData2.w);
 
-    sh[0] =  vec3f(r0.x, g0.x, b0.x);
-    sh[1] =  vec3f(r0.y, g0.y, b0.y);
-    sh[2] =  vec3f(r0.z, g0.z, b0.z);
-    sh[3] =  vec3f(r0.w, g0.w, b0.w);
-    sh[4] =  vec3f(r1.x, g1.x, b1.x);
-    sh[5] =  vec3f(r1.y, g1.y, b1.y);
-    sh[6] =  vec3f(r1.z, g1.z, b1.z);
-    sh[7] =  vec3f(r1.w, g1.w, b1.w);
-    sh[8] =  vec3f(r2.x, g2.x, b2.x);
-    sh[9] =  vec3f(r2.y, g2.y, b2.y);
-    sh[10] = vec3f(r2.z, g2.z, b2.z);
-    sh[11] = vec3f(r2.w, g2.w, b2.w);
-    sh[12] = vec3f(r3.x, g3.x, b3.x);
-    sh[13] = vec3f(r3.y, g3.y, b3.y);
-    sh[14] = vec3f(r3.z, g3.z, b3.z);
+    sh[0] =  half3(r0.x, g0.x, b0.x);
+    sh[1] =  half3(r0.y, g0.y, b0.y);
+    sh[2] =  half3(r0.z, g0.z, b0.z);
+    sh[3] =  half3(r0.w, g0.w, b0.w);
+    sh[4] =  half3(r1.x, g1.x, b1.x);
+    sh[5] =  half3(r1.y, g1.y, b1.y);
+    sh[6] =  half3(r1.z, g1.z, b1.z);
+    sh[7] =  half3(r1.w, g1.w, b1.w);
+    sh[8] =  half3(r2.x, g2.x, b2.x);
+    sh[9] =  half3(r2.y, g2.y, b2.y);
+    sh[10] = half3(r2.z, g2.z, b2.z);
+    sh[11] = half3(r2.w, g2.w, b2.w);
+    sh[12] = half3(r3.x, g3.x, b3.x);
+    sh[13] = half3(r3.y, g3.y, b3.y);
+    sh[14] = half3(r3.z, g3.z, b3.z);
 
     *scale = 1.0;
 }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/sogSH.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/sogSH.js
@@ -6,7 +6,7 @@ var packedShN: texture_2d<f32>;
 uniform shN_mins: f32;
 uniform shN_maxs: f32;
 
-fn readSHData(sh: ptr<function, array<vec3f, SH_COEFFS>>, scale: ptr<function, f32>) {
+fn readSHData(sh: ptr<function, array<half3, SH_COEFFS>>, scale: ptr<function, f32>) {
     // extract spherical harmonics palette index
     let t = vec2i(packedSample.xy & vec2u(255u));
     let n = t.x + t.y * 256;
@@ -15,7 +15,7 @@ fn readSHData(sh: ptr<function, array<vec3f, SH_COEFFS>>, scale: ptr<function, f
 
     // calculate offset into the centroids texture and read consecutive texels
     for (var i: i32 = 0; i < SH_COEFFS; i = i + 1) {
-        sh[i] = mix(vec3f(uniform.shN_mins), vec3f(uniform.shN_maxs), unpack111110(pack8888(textureLoad(packedShN, vec2i(u + i, v), 0))));
+        sh[i] = half3(mix(vec3f(uniform.shN_mins), vec3f(uniform.shN_maxs), unpack111110(pack8888(textureLoad(packedShN, vec2i(u + i, v), 0)))));
     }
 
     *scale = 1.0;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/uncompressedSH.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/uncompressedSH.js
@@ -47,54 +47,54 @@ fn fetch1(t_in: u32) -> vec3f {
 }
 
 #if SH_BANDS == 1
-    fn readSHData(sh: ptr<function, array<vec3f, 3>>, scale: ptr<function, f32>) {
+    fn readSHData(sh: ptr<function, array<half3, 3>>, scale: ptr<function, f32>) {
         let result = fetchScale(loadSplatSH_1to3());
         *scale = result.scale;
-        sh[0] = result.a;
-        sh[1] = result.b;
-        sh[2] = result.c;
+        sh[0] = half3(result.a);
+        sh[1] = half3(result.b);
+        sh[2] = half3(result.c);
     }
 #elif SH_BANDS == 2
-    fn readSHData(sh: ptr<function, array<vec3f, 8>>, scale: ptr<function, f32>) {
+    fn readSHData(sh: ptr<function, array<half3, 8>>, scale: ptr<function, f32>) {
         let first: ScaleAndSH = fetchScale(loadSplatSH_1to3());
         *scale = first.scale;
-        sh[0] = first.a;
-        sh[1] = first.b;
-        sh[2] = first.c;
+        sh[0] = half3(first.a);
+        sh[1] = half3(first.b);
+        sh[2] = half3(first.c);
 
         let second: SH = fetch4(loadSplatSH_4to7());
-        sh[3] = second.a;
-        sh[4] = second.b;
-        sh[5] = second.c;
-        sh[6] = second.d;
+        sh[3] = half3(second.a);
+        sh[4] = half3(second.b);
+        sh[5] = half3(second.c);
+        sh[6] = half3(second.d);
 
-        sh[7] = fetch1(loadSplatSH_8to11().x);
+        sh[7] = half3(fetch1(loadSplatSH_8to11().x));
     }
 #else
-    fn readSHData(sh: ptr<function, array<vec3f, 15>>, scale: ptr<function, f32>) {
+    fn readSHData(sh: ptr<function, array<half3, 15>>, scale: ptr<function, f32>) {
         let first: ScaleAndSH = fetchScale(loadSplatSH_1to3());
         *scale = first.scale;
-        sh[0] = first.a;
-        sh[1] = first.b;
-        sh[2] = first.c;
+        sh[0] = half3(first.a);
+        sh[1] = half3(first.b);
+        sh[2] = half3(first.c);
 
         let second: SH = fetch4(loadSplatSH_4to7());
-        sh[3] = second.a;
-        sh[4] = second.b;
-        sh[5] = second.c;
-        sh[6] = second.d;
+        sh[3] = half3(second.a);
+        sh[4] = half3(second.b);
+        sh[5] = half3(second.c);
+        sh[6] = half3(second.d);
 
         let third: SH = fetch4(loadSplatSH_8to11());
-        sh[7] = third.a;
-        sh[8] = third.b;
-        sh[9] = third.c;
-        sh[10] = third.d;
+        sh[7] = half3(third.a);
+        sh[8] = half3(third.b);
+        sh[9] = half3(third.c);
+        sh[10] = half3(third.d);
 
         let fourth: SH = fetch4(loadSplatSH_12to15());
-        sh[11] = fourth.a;
-        sh[12] = fourth.b;
-        sh[13] = fourth.c;
-        sh[14] = fourth.d;
+        sh[11] = half3(fourth.a);
+        sh[12] = half3(fourth.b);
+        sh[13] = half3(fourth.c);
+        sh[14] = half3(fourth.d);
     }
 #endif
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
@@ -70,7 +70,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
         let dir = normalize(center.view * modelView3x3);
 
         // read sh coefficients
-        var sh: array<vec3f, SH_COEFFS>;
+        var sh: array<half3, SH_COEFFS>;
         var scale: f32;
         readSHData(&sh, &scale);
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatEvalSH.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatEvalSH.js
@@ -11,48 +11,46 @@ export default /* wgsl */`
 
     #if SH_BANDS > 0
 
-    const SH_C1: f32 = 0.4886025119029199;
+    const SH_C1: half = half(0.4886025119029199);
 
     #if SH_BANDS > 1
-        const SH_C2_0: f32 = 1.0925484305920792;
-        const SH_C2_1: f32 = -1.0925484305920792;
-        const SH_C2_2: f32 = 0.31539156525252005;
-        const SH_C2_3: f32 = -1.0925484305920792;
-        const SH_C2_4: f32 = 0.5462742152960396;
+        const SH_C2_0: half = half(1.0925484305920792);
+        const SH_C2_1: half = half(-1.0925484305920792);
+        const SH_C2_2: half = half(0.31539156525252005);
+        const SH_C2_3: half = half(-1.0925484305920792);
+        const SH_C2_4: half = half(0.5462742152960396);
     #endif
 
     #if SH_BANDS > 2
-        const SH_C3_0: f32 = -0.5900435899266435;
-        const SH_C3_1: f32 = 2.890611442640554;
-        const SH_C3_2: f32 = -0.4570457994644658;
-        const SH_C3_3: f32 = 0.3731763325901154;
-        const SH_C3_4: f32 = -0.4570457994644658;
-        const SH_C3_5: f32 = 1.445305721320277;
-        const SH_C3_6: f32 = -0.5900435899266435;
+        const SH_C3_0: half = half(-0.5900435899266435);
+        const SH_C3_1: half = half(2.890611442640554);
+        const SH_C3_2: half = half(-0.4570457994644658);
+        const SH_C3_3: half = half(0.3731763325901154);
+        const SH_C3_4: half = half(-0.4570457994644658);
+        const SH_C3_5: half = half(1.445305721320277);
+        const SH_C3_6: half = half(-0.5900435899266435);
     #endif
 
     // see https://github.com/graphdeco-inria/gaussian-splatting/blob/main/utils/sh_utils.py
-    fn evalSH(sh: ptr<function, array<vec3f, SH_COEFFS>>, dir: vec3f) -> vec3f {
-        let x = dir.x;
-        let y = dir.y;
-        let z = dir.z;
+    fn evalSH(sh: ptr<function, array<half3, SH_COEFFS>>, dir: vec3f) -> vec3f {
+        let d: half3 = half3(dir);
 
         // 1st degree
-        var result = SH_C1 * (-sh[0] * y + sh[1] * z - sh[2] * x);
+        var result: half3 = SH_C1 * (-sh[0] * d.y + sh[1] * d.z - sh[2] * d.x);
 
         #if SH_BANDS > 1
             // 2nd degree
-            let xx = x * x;
-            let yy = y * y;
-            let zz = z * z;
-            let xy = x * y;
-            let yz = y * z;
-            let xz = x * z;
+            let xx: half = d.x * d.x;
+            let yy: half = d.y * d.y;
+            let zz: half = d.z * d.z;
+            let xy: half = d.x * d.y;
+            let yz: half = d.y * d.z;
+            let xz: half = d.x * d.z;
 
             result = result + (
                 sh[3] * (SH_C2_0 * xy) +
                 sh[4] * (SH_C2_1 * yz) +
-                sh[5] * (SH_C2_2 * (2.0 * zz - xx - yy)) +
+                sh[5] * (SH_C2_2 * (half(2.0) * zz - xx - yy)) +
                 sh[6] * (SH_C2_3 * xz) +
                 sh[7] * (SH_C2_4 * (xx - yy))
             );
@@ -61,17 +59,17 @@ export default /* wgsl */`
         #if SH_BANDS > 2
             // 3rd degree
             result = result + (
-                sh[8]  * (SH_C3_0 * y * (3.0 * xx - yy)) +
-                sh[9]  * (SH_C3_1 * xy * z) +
-                sh[10] * (SH_C3_2 * y * (4.0 * zz - xx - yy)) +
-                sh[11] * (SH_C3_3 * z * (2.0 * zz - 3.0 * xx - 3.0 * yy)) +
-                sh[12] * (SH_C3_4 * x * (4.0 * zz - xx - yy)) +
-                sh[13] * (SH_C3_5 * z * (xx - yy)) +
-                sh[14] * (SH_C3_6 * x * (xx - 3.0 * yy))
+                sh[8]  * (SH_C3_0 * d.y * (half(3.0) * xx - yy)) +
+                sh[9]  * (SH_C3_1 * xy * d.z) +
+                sh[10] * (SH_C3_2 * d.y * (half(4.0) * zz - xx - yy)) +
+                sh[11] * (SH_C3_3 * d.z * (half(2.0) * zz - half(3.0) * xx - half(3.0) * yy)) +
+                sh[12] * (SH_C3_4 * d.x * (half(4.0) * zz - xx - yy)) +
+                sh[13] * (SH_C3_5 * d.z * (xx - yy)) +
+                sh[14] * (SH_C3_6 * d.x * (xx - half(3.0) * yy))
             );
         #endif
 
-        return result;
+        return vec3f(result);
     }
     #endif
 `;


### PR DESCRIPTION
## Summary
- Converts spherical harmonics (SH) evaluation to use half-precision types for improved performance on GPUs with f16 support
- Changes SH coefficient array type from `array<vec3f, SH_COEFFS>` to `array<half3, SH_COEFFS>`
- Updates all SH format readers (uncompressed, compressed, SOG) to output half3 coefficients

## Performance Impact
- Halves memory usage for SH coefficient arrays when f16 is supported (90 bytes vs 180 bytes for 15 coefficients)
- Keeps all SH math in half precision end-to-end, reducing register pressure
- Falls back to f32 automatically on devices without f16 support via the `half` type aliases