### PR TITLE
Add Color Enhance post-processing effect

### DIFF
--- a/examples/src/examples/gaussian-splatting/viewer.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.controls.mjs
@@ -97,6 +97,63 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     precision: 3
                 })
             )
+        ),
+        jsx(
+            Panel,
+            { headerText: 'Color Enhance' },
+            jsx(
+                LabelGroup,
+                { text: 'enabled' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.enabled' }
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'shadows' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.shadows' },
+                    min: -3,
+                    max: 3,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'highlights' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.highlights' },
+                    min: -3,
+                    max: 3,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'vibrance' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.vibrance' },
+                    min: -1,
+                    max: 1,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'dehaze' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.dehaze' },
+                    min: -1,
+                    max: 1,
+                    precision: 2
+                })
+            )
         )
     );
 };

--- a/examples/src/examples/gaussian-splatting/viewer.example.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.example.mjs
@@ -174,6 +174,13 @@ assetListLoader.load(() => {
         bloom: {
             enabled: false,
             intensity: 0.03
+        },
+        colorEnhance: {
+            enabled: false,
+            shadows: 0,
+            highlights: 0,
+            vibrance: 0,
+            dehaze: 0
         }
     });
 
@@ -198,6 +205,13 @@ assetListLoader.load(() => {
         if (bloomEnabled) {
             cameraFrame.bloom.blurLevel = 7;
         }
+
+        // Color Enhance
+        cameraFrame.colorEnhance.enabled = data.get('data.colorEnhance.enabled');
+        cameraFrame.colorEnhance.shadows = data.get('data.colorEnhance.shadows');
+        cameraFrame.colorEnhance.highlights = data.get('data.colorEnhance.highlights');
+        cameraFrame.colorEnhance.vibrance = data.get('data.colorEnhance.vibrance');
+        cameraFrame.colorEnhance.dehaze = data.get('data.colorEnhance.dehaze');
 
         cameraFrame.update();
     };

--- a/examples/src/examples/graphics/post-processing.controls.mjs
+++ b/examples/src/examples/graphics/post-processing.controls.mjs
@@ -168,6 +168,63 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
         ),
         jsx(
             Panel,
+            { headerText: 'Color Enhance' },
+            jsx(
+                LabelGroup,
+                { text: 'enabled' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.enabled' }
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'shadows' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.shadows' },
+                    min: -3,
+                    max: 3,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'highlights' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.highlights' },
+                    min: -3,
+                    max: 3,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'vibrance' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.vibrance' },
+                    min: -1,
+                    max: 1,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'dehaze' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.dehaze' },
+                    min: -1,
+                    max: 1,
+                    precision: 2
+                })
+            )
+        ),
+        jsx(
+            Panel,
             { headerText: 'Vignette' },
             jsx(
                 LabelGroup,

--- a/examples/src/examples/graphics/post-processing.example.mjs
+++ b/examples/src/examples/graphics/post-processing.example.mjs
@@ -256,6 +256,15 @@ assetListLoader.load(() => {
         cameraFrame.grading.brightness = data.get('data.grading.brightness');
         cameraFrame.grading.contrast = data.get('data.grading.contrast');
 
+        // colorEnhance
+        cameraFrame.colorEnhance.enabled = data.get('data.colorEnhance.enabled');
+        if (cameraFrame.colorEnhance.enabled) {
+            cameraFrame.colorEnhance.shadows = data.get('data.colorEnhance.shadows');
+            cameraFrame.colorEnhance.highlights = data.get('data.colorEnhance.highlights');
+            cameraFrame.colorEnhance.vibrance = data.get('data.colorEnhance.vibrance');
+            cameraFrame.colorEnhance.dehaze = data.get('data.colorEnhance.dehaze');
+        }
+
         // vignette
         cameraFrame.vignette.inner = data.get('data.vignette.inner');
         cameraFrame.vignette.outer = data.get('data.vignette.outer');
@@ -306,6 +315,13 @@ assetListLoader.load(() => {
             saturation: 1,
             brightness: 1,
             contrast: 1
+        },
+        colorEnhance: {
+            enabled: false,
+            shadows: 0,
+            highlights: 0,
+            vibrance: 0,
+            dehaze: 0
         },
         vignette: {
             enabled: false,

--- a/examples/src/examples/graphics/sky.controls.mjs
+++ b/examples/src/examples/graphics/sky.controls.mjs
@@ -5,7 +5,7 @@ import * as pc from 'playcanvas';
  * @returns {JSX.Element} The returned JSX Element.
  */
 export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
-    const { BindingTwoWay, VectorInput, LabelGroup, Panel, SliderInput, SelectInput } = ReactPCUI;
+    const { BindingTwoWay, BooleanInput, VectorInput, LabelGroup, Panel, SliderInput, SelectInput } = ReactPCUI;
     return fragment(
         jsx(
             Panel,
@@ -87,6 +87,63 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     binding: new BindingTwoWay(),
                     link: { observer, path: 'data.skybox.tripodY' },
                     min: 0,
+                    max: 1,
+                    precision: 2
+                })
+            )
+        ),
+        jsx(
+            Panel,
+            { headerText: 'Color Enhance' },
+            jsx(
+                LabelGroup,
+                { text: 'enabled' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.enabled' }
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'shadows' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.shadows' },
+                    min: -3,
+                    max: 3,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'highlights' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.highlights' },
+                    min: -3,
+                    max: 3,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'vibrance' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.vibrance' },
+                    min: -1,
+                    max: 1,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'dehaze' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.dehaze' },
+                    min: -1,
                     max: 1,
                     precision: 2
                 })

--- a/examples/src/examples/graphics/sky.example.mjs
+++ b/examples/src/examples/graphics/sky.example.mjs
@@ -91,6 +91,10 @@ assetListLoader.load(() => {
     cameraEntity.lookAt(0, 0, 1);
     app.root.addChild(cameraEntity);
 
+    // ------ Custom render passes set up ------
+    const cameraFrame = new pc.CameraFrame(app, cameraEntity.camera);
+    cameraFrame.update();
+
     // skydome presets
     const presetStreetDome = {
         skybox: {
@@ -167,11 +171,28 @@ assetListLoader.load(() => {
             app.scene.sky.center = new pc.Vec3(0, data.get('data.skybox.tripodY') ?? 0, 0);
             app.scene.skyboxRotation = new pc.Quat().setFromEulerAngles(0, data.get('data.skybox.rotation'), 0);
             app.scene.exposure = data.get('data.skybox.exposure');
+
+            // colorEnhance
+            cameraFrame.colorEnhance.enabled = data.get('data.colorEnhance.enabled');
+            cameraFrame.colorEnhance.shadows = data.get('data.colorEnhance.shadows');
+            cameraFrame.colorEnhance.highlights = data.get('data.colorEnhance.highlights');
+            cameraFrame.colorEnhance.vibrance = data.get('data.colorEnhance.vibrance');
+            cameraFrame.colorEnhance.dehaze = data.get('data.colorEnhance.dehaze');
+            cameraFrame.update();
         }
     });
 
     // apply initial preset
     data.set('data.skybox.preset', 'Street Dome');
+
+    // set initial colorEnhance values (AFTER preset so it doesn't get overwritten)
+    data.set('data.colorEnhance', {
+        enabled: false,
+        shadows: 0,
+        highlights: 0,
+        vibrance: 0,
+        dehaze: 0
+    });
 });
 
 export { app };

--- a/scripts/esm/camera-frame.mjs
+++ b/scripts/esm/camera-frame.mjs
@@ -298,6 +298,43 @@ class Fringing {
 }
 
 /** @interface */
+class ColorEnhance {
+    enabled = false;
+
+    /**
+     * @visibleif {enabled}
+     * @range [-3, 3]
+     * @precision 2
+     * @step 0.1
+     */
+    shadows = 0;
+
+    /**
+     * @visibleif {enabled}
+     * @range [-3, 3]
+     * @precision 2
+     * @step 0.1
+     */
+    highlights = 0;
+
+    /**
+     * @visibleif {enabled}
+     * @range [-1, 1]
+     * @precision 3
+     * @step 0.01
+     */
+    vibrance = 0;
+
+    /**
+     * @visibleif {enabled}
+     * @range [-1, 1]
+     * @precision 3
+     * @step 0.01
+     */
+    dehaze = 0;
+}
+
+/** @interface */
 class Taa {
     enabled = false;
 
@@ -415,6 +452,12 @@ class CameraFrame extends Script {
 
     /**
      * @attribute
+     * @type {ColorEnhance}
+     */
+    colorEnhance = new ColorEnhance();
+
+    /**
+     * @attribute
      * @type {Dof}
      */
     dof = new Dof();
@@ -445,7 +488,7 @@ class CameraFrame extends Script {
     postUpdate(dt) {
 
         const cf = this.engineCameraFrame;
-        const { rendering, bloom, grading, vignette, fringing, taa, ssao, dof, colorLUT } = this;
+        const { rendering, bloom, grading, colorEnhance, vignette, fringing, taa, ssao, dof, colorLUT } = this;
 
         const dstRendering = cf.rendering;
         dstRendering.renderFormats.length = 0;
@@ -518,6 +561,16 @@ class CameraFrame extends Script {
         // fringing
         const dstFringing = cf.fringing;
         dstFringing.intensity = fringing.enabled ? fringing.intensity : 0;
+
+        // colorEnhance
+        const dstColorEnhance = cf.colorEnhance;
+        dstColorEnhance.enabled = colorEnhance.enabled;
+        if (colorEnhance.enabled) {
+            dstColorEnhance.shadows = colorEnhance.shadows;
+            dstColorEnhance.highlights = colorEnhance.highlights;
+            dstColorEnhance.vibrance = colorEnhance.vibrance;
+            dstColorEnhance.dehaze = colorEnhance.dehaze;
+        }
 
         // dof
         const dstDof = cf.dof;

--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -145,6 +145,25 @@ import { CameraFrameOptions, RenderPassCameraFrame } from './render-pass-camera-
  */
 
 /**
+ * @typedef {Object} ColorEnhance
+ * Properties related to the color enhancement effect, a postprocessing technique that provides
+ * HDR-aware adjustments for shadows, highlights, vibrance, and dehaze. Shadows and highlights allow
+ * selective adjustment of dark and bright areas of the image, vibrance is a smart saturation
+ * that boosts less-saturated colors more than already-saturated ones, and dehaze removes atmospheric
+ * haze to increase clarity and contrast.
+ * @property {boolean} enabled - Whether color enhancement is enabled. Defaults to false.
+ * @property {number} shadows - The shadow adjustment, -3 to 3 range. Uses an exponential curve where
+ * -3 gives 0.125x, 0 gives 1x, and +3 gives 8x brightness on dark areas. Defaults to 0.
+ * @property {number} highlights - The highlight adjustment, -3 to 3 range. Uses an exponential curve
+ * where -3 gives 0.125x, 0 gives 1x, and +3 gives 8x brightness on bright areas. Defaults to 0.
+ * @property {number} vibrance - The vibrance (smart saturation), -1 to 1 range. Positive values boost
+ * saturation of less-saturated colors more than already-saturated ones. Negative values desaturate.
+ * Defaults to 0.
+ * @property {number} dehaze - The dehaze adjustment, -1 to 1 range. Positive values remove atmospheric
+ * haze, increasing clarity and contrast. Negative values add a haze effect. Defaults to 0.
+ */
+
+/**
  * @typedef {Object} Taa
  * Properties related to temporal anti-aliasing (TAA), which is a technique used to reduce aliasing
  * in the rendered image by blending multiple frames together over time.
@@ -303,6 +322,19 @@ class CameraFrame {
     };
 
     /**
+     * Color enhancement settings.
+     *
+     * @type {ColorEnhance}
+     */
+    colorEnhance = {
+        enabled: false,
+        shadows: 0,
+        highlights: 0,
+        vibrance: 0,
+        dehaze: 0
+    };
+
+    /**
      * DoF settings.
      *
      * @type {Dof}
@@ -443,7 +475,7 @@ class CameraFrame {
         if (!this._enabled) return;
 
         const cameraComponent = this.cameraComponent;
-        const { options, renderPassCamera, rendering, bloom, grading, vignette, fringing, taa, ssao } = this;
+        const { options, renderPassCamera, rendering, bloom, grading, colorEnhance, vignette, fringing, taa, ssao } = this;
 
         // options that can cause the passes to be re-created
         this.updateOptions();
@@ -502,6 +534,14 @@ class CameraFrame {
         composePass.fringingEnabled = fringing.intensity > 0;
         if (composePass.fringingEnabled) {
             composePass.fringingIntensity = fringing.intensity;
+        }
+
+        composePass.colorEnhanceEnabled = colorEnhance.enabled;
+        if (colorEnhance.enabled) {
+            composePass.colorEnhanceShadows = colorEnhance.shadows;
+            composePass.colorEnhanceHighlights = colorEnhance.highlights;
+            composePass.colorEnhanceVibrance = colorEnhance.vibrance;
+            composePass.colorEnhanceDehaze = colorEnhance.dehaze;
         }
 
         // enable camera jitter if taa is enabled

--- a/src/extras/render-passes/render-pass-compose.js
+++ b/src/extras/render-passes/render-pass-compose.js
@@ -67,6 +67,16 @@ class RenderPassCompose extends RenderPassShaderQuad {
 
     fringingIntensity = 10;
 
+    _colorEnhanceEnabled = false;
+
+    colorEnhanceShadows = 0;
+
+    colorEnhanceHighlights = 0;
+
+    colorEnhanceVibrance = 0;
+
+    colorEnhanceDehaze = 0;
+
     _taaEnabled = false;
 
     _sharpness = 0.5;
@@ -116,6 +126,7 @@ class RenderPassCompose extends RenderPassShaderQuad {
         this.colorLUTId = scope.resolve('colorLUT');
         this.colorLUTParams = new Float32Array(4);
         this.colorLUTParamsId = scope.resolve('colorLUTParams');
+        this.colorEnhanceParamsId = scope.resolve('colorEnhanceParams');
     }
 
     set debug(value) {
@@ -217,6 +228,17 @@ class RenderPassCompose extends RenderPassShaderQuad {
         return this._fringingEnabled;
     }
 
+    set colorEnhanceEnabled(value) {
+        if (this._colorEnhanceEnabled !== value) {
+            this._colorEnhanceEnabled = value;
+            this._shaderDirty = true;
+        }
+    }
+
+    get colorEnhanceEnabled() {
+        return this._colorEnhanceEnabled;
+    }
+
     set toneMapping(value) {
         if (this._toneMapping !== value) {
             this._toneMapping = value;
@@ -292,6 +314,7 @@ class RenderPassCompose extends RenderPassShaderQuad {
                 `-${this.blurTextureUpscale ? 'dofupscale' : ''}` +
                 `-${this.ssaoTexture ? 'ssao' : 'nossao'}` +
                 `-${this.gradingEnabled ? 'grading' : 'nograding'}` +
+                `-${this.colorEnhanceEnabled ? 'colorenhance' : 'nocolorenhance'}` +
                 `-${this.colorLUT ? 'colorlut' : 'nocolorlut'}` +
                 `-${this.vignetteEnabled ? 'vignette' : 'novignette'}` +
                 `-${this.fringingEnabled ? 'fringing' : 'nofringing'}` +
@@ -311,6 +334,7 @@ class RenderPassCompose extends RenderPassShaderQuad {
                 if (this.blurTextureUpscale) defines.set('DOF_UPSCALE', true);
                 if (this.ssaoTexture) defines.set('SSAO', true);
                 if (this.gradingEnabled) defines.set('GRADING', true);
+                if (this.colorEnhanceEnabled) defines.set('COLOR_ENHANCE', true);
                 if (this.colorLUT) defines.set('COLOR_LUT', true);
                 if (this.vignetteEnabled) defines.set('VIGNETTE', true);
                 if (this.fringingEnabled) defines.set('FRINGING', true);
@@ -357,6 +381,10 @@ class RenderPassCompose extends RenderPassShaderQuad {
         if (this._gradingEnabled) {
             this.bcsId.setValue([this.gradingBrightness, this.gradingContrast, this.gradingSaturation]);
             this.tintId.setValue([this.gradingTint.r, this.gradingTint.g, this.gradingTint.b]);
+        }
+
+        if (this._colorEnhanceEnabled) {
+            this.colorEnhanceParamsId.setValue([this.colorEnhanceShadows, this.colorEnhanceHighlights, this.colorEnhanceVibrance, this.colorEnhanceDehaze]);
         }
 
         const lutTexture = this._colorLUT;

--- a/src/scene/shader-lib/glsl/chunks/render-pass/frag/compose/compose-color-enhance.js
+++ b/src/scene/shader-lib/glsl/chunks/render-pass/frag/compose/compose-color-enhance.js
@@ -1,0 +1,63 @@
+export default /* glsl */`
+    #ifdef COLOR_ENHANCE
+        uniform vec4 colorEnhanceParams; // x=shadows, y=highlights, z=vibrance, w=dehaze
+
+        vec3 applyColorEnhance(vec3 color) {
+            float maxChannel = max(color.r, max(color.g, color.b));
+            float lum = dot(color, vec3(0.2126, 0.7152, 0.0722));
+
+            // Shadows/Highlights - skip if both are zero (coherent branch, essentially free)
+            // Uses exponential curve: pow(2, param) gives 0.5x at -1, 1x at 0, 2x at +1
+            if (colorEnhanceParams.x != 0.0 || colorEnhanceParams.y != 0.0) {
+                float logLum = log2(max(lum, 0.001)) / 10.0 + 0.5;
+                logLum = clamp(logLum, 0.0, 1.0);
+
+                float shadowWeight = pow(1.0 - logLum, 2.0);
+                float highlightWeight = pow(logLum, 2.0);
+
+                color *= pow(2.0, colorEnhanceParams.x * shadowWeight);
+                color *= pow(2.0, colorEnhanceParams.y * highlightWeight);
+            }
+
+            // Vibrance - skip if zero (coherent branch)
+            if (colorEnhanceParams.z != 0.0) {
+                float minChannel = min(color.r, min(color.g, color.b));
+                maxChannel = max(color.r, max(color.g, color.b));
+                float sat = (maxChannel - minChannel) / max(maxChannel, 0.001);
+
+                lum = dot(color, vec3(0.2126, 0.7152, 0.0722));
+                float normalizedLum = lum / max(1.0, maxChannel);
+                vec3 grey = vec3(normalizedLum) * maxChannel;
+
+                float satBoost = colorEnhanceParams.z * (1.0 - sat);
+                color = mix(grey, color, 1.0 + satBoost);
+            }
+
+            // Dehaze - skip if zero (coherent branch)
+            // Based on dark channel prior: haze lifts the minimum RGB channel
+            if (colorEnhanceParams.w != 0.0) {
+                // Normalize to work in HDR
+                maxChannel = max(color.r, max(color.g, color.b));
+                float scale = max(1.0, maxChannel);
+                vec3 normalized = color / scale;
+
+                // Estimate transmission from dark channel (per-pixel approximation)
+                float darkChannel = min(normalized.r, min(normalized.g, normalized.b));
+                float atmosphericLight = 0.95;
+
+                // transmission: 1 = clear, 0 = fully hazed
+                // strength controls how aggressively we remove haze
+                float t = 1.0 - colorEnhanceParams.w * darkChannel / atmosphericLight;
+                t = max(t, 0.1); // prevent extreme amplification
+
+                // Dehaze formula: J = (I - A) / t + A
+                vec3 dehazed = (normalized - atmosphericLight) / t + atmosphericLight;
+
+                // Restore HDR range
+                color = dehazed * scale;
+            }
+
+            return max(vec3(0.0), color);
+        }
+    #endif
+`;

--- a/src/scene/shader-lib/glsl/chunks/render-pass/frag/compose/compose.js
+++ b/src/scene/shader-lib/glsl/chunks/render-pass/frag/compose/compose.js
@@ -10,6 +10,7 @@ export default /* glsl */`
     #include "composeDofPS"
     #include "composeSsaoPS"
     #include "composeGradingPS"
+    #include "composeColorEnhancePS"
     #include "composeVignettePS"
     #include "composeFringingPS"
     #include "composeCasPS"
@@ -56,6 +57,11 @@ export default /* glsl */`
         // Apply Bloom
         #ifdef BLOOM
             result = applyBloom(result, uv0);
+        #endif
+
+        // Apply Color Enhancement (shadows, highlights, vibrance)
+        #ifdef COLOR_ENHANCE
+            result = applyColorEnhance(result);
         #endif
 
         // Apply Color Grading

--- a/src/scene/shader-lib/glsl/collections/compose-chunks-glsl.js
+++ b/src/scene/shader-lib/glsl/collections/compose-chunks-glsl.js
@@ -3,6 +3,7 @@ import composeBloomPS from '../chunks/render-pass/frag/compose/compose-bloom.js'
 import composeDofPS from '../chunks/render-pass/frag/compose/compose-dof.js';
 import composeSsaoPS from '../chunks/render-pass/frag/compose/compose-ssao.js';
 import composeGradingPS from '../chunks/render-pass/frag/compose/compose-grading.js';
+import composeColorEnhancePS from '../chunks/render-pass/frag/compose/compose-color-enhance.js';
 import composeVignettePS from '../chunks/render-pass/frag/compose/compose-vignette.js';
 import composeFringingPS from '../chunks/render-pass/frag/compose/compose-fringing.js';
 import composeCasPS from '../chunks/render-pass/frag/compose/compose-cas.js';
@@ -14,6 +15,7 @@ export const composeChunksGLSL = {
     composeDofPS,
     composeSsaoPS,
     composeGradingPS,
+    composeColorEnhancePS,
     composeVignettePS,
     composeFringingPS,
     composeCasPS,

--- a/src/scene/shader-lib/wgsl/chunks/render-pass/frag/compose/compose-color-enhance.js
+++ b/src/scene/shader-lib/wgsl/chunks/render-pass/frag/compose/compose-color-enhance.js
@@ -1,0 +1,64 @@
+export default /* wgsl */`
+    #ifdef COLOR_ENHANCE
+        uniform colorEnhanceParams: vec4f; // x=shadows, y=highlights, z=vibrance, w=dehaze
+
+        fn applyColorEnhance(color: vec3f) -> vec3f {
+            var colorOut = color;
+            var maxChannel = max(colorOut.r, max(colorOut.g, colorOut.b));
+            var lum = dot(colorOut, vec3f(0.2126, 0.7152, 0.0722));
+
+            // Shadows/Highlights - skip if both are zero (coherent branch, essentially free)
+            // Uses exponential curve: pow(2, param) gives 0.5x at -1, 1x at 0, 2x at +1
+            if (uniform.colorEnhanceParams.x != 0.0 || uniform.colorEnhanceParams.y != 0.0) {
+                var logLum = log2(max(lum, 0.001)) / 10.0 + 0.5;
+                logLum = clamp(logLum, 0.0, 1.0);
+
+                let shadowWeight = pow(1.0 - logLum, 2.0);
+                let highlightWeight = pow(logLum, 2.0);
+
+                colorOut *= pow(2.0, uniform.colorEnhanceParams.x * shadowWeight);
+                colorOut *= pow(2.0, uniform.colorEnhanceParams.y * highlightWeight);
+            }
+
+            // Vibrance - skip if zero (coherent branch)
+            if (uniform.colorEnhanceParams.z != 0.0) {
+                let minChannel = min(colorOut.r, min(colorOut.g, colorOut.b));
+                maxChannel = max(colorOut.r, max(colorOut.g, colorOut.b));
+                let sat = (maxChannel - minChannel) / max(maxChannel, 0.001);
+
+                lum = dot(colorOut, vec3f(0.2126, 0.7152, 0.0722));
+                let normalizedLum = lum / max(1.0, maxChannel);
+                let grey = vec3f(normalizedLum) * maxChannel;
+
+                let satBoost = uniform.colorEnhanceParams.z * (1.0 - sat);
+                colorOut = mix(grey, colorOut, 1.0 + satBoost);
+            }
+
+            // Dehaze - skip if zero (coherent branch)
+            // Based on dark channel prior: haze lifts the minimum RGB channel
+            if (uniform.colorEnhanceParams.w != 0.0) {
+                // Normalize to work in HDR
+                maxChannel = max(colorOut.r, max(colorOut.g, colorOut.b));
+                let scale = max(1.0, maxChannel);
+                let normalized = colorOut / scale;
+
+                // Estimate transmission from dark channel (per-pixel approximation)
+                let darkChannel = min(normalized.r, min(normalized.g, normalized.b));
+                let atmosphericLight = 0.95;
+
+                // transmission: 1 = clear, 0 = fully hazed
+                // strength controls how aggressively we remove haze
+                var t = 1.0 - uniform.colorEnhanceParams.w * darkChannel / atmosphericLight;
+                t = max(t, 0.1); // prevent extreme amplification
+
+                // Dehaze formula: J = (I - A) / t + A
+                let dehazed = (normalized - atmosphericLight) / t + atmosphericLight;
+
+                // Restore HDR range
+                colorOut = dehazed * scale;
+            }
+
+            return max(vec3f(0.0), colorOut);
+        }
+    #endif
+`;

--- a/src/scene/shader-lib/wgsl/chunks/render-pass/frag/compose/compose.js
+++ b/src/scene/shader-lib/wgsl/chunks/render-pass/frag/compose/compose.js
@@ -11,6 +11,7 @@ export default /* wgsl */`
     #include "composeDofPS"
     #include "composeSsaoPS"
     #include "composeGradingPS"
+    #include "composeColorEnhancePS"
     #include "composeVignettePS"
     #include "composeFringingPS"
     #include "composeCasPS"
@@ -57,6 +58,11 @@ export default /* wgsl */`
         // Apply Bloom
         #ifdef BLOOM
             result = applyBloom(result, uv0);
+        #endif
+
+        // Apply Color Enhancement (shadows, highlights, vibrance)
+        #ifdef COLOR_ENHANCE
+            result = applyColorEnhance(result);
         #endif
 
         // Apply Color Grading

--- a/src/scene/shader-lib/wgsl/collections/compose-chunks-wgsl.js
+++ b/src/scene/shader-lib/wgsl/collections/compose-chunks-wgsl.js
@@ -3,6 +3,7 @@ import composeBloomPS from '../chunks/render-pass/frag/compose/compose-bloom.js'
 import composeDofPS from '../chunks/render-pass/frag/compose/compose-dof.js';
 import composeSsaoPS from '../chunks/render-pass/frag/compose/compose-ssao.js';
 import composeGradingPS from '../chunks/render-pass/frag/compose/compose-grading.js';
+import composeColorEnhancePS from '../chunks/render-pass/frag/compose/compose-color-enhance.js';
 import composeVignettePS from '../chunks/render-pass/frag/compose/compose-vignette.js';
 import composeFringingPS from '../chunks/render-pass/frag/compose/compose-fringing.js';
 import composeCasPS from '../chunks/render-pass/frag/compose/compose-cas.js';
@@ -14,6 +15,7 @@ export const composeChunksWGSL = {
     composeDofPS,
     composeSsaoPS,
     composeGradingPS,
+    composeColorEnhancePS,
     composeVignettePS,
     composeFringingPS,
     composeCasPS,


### PR DESCRIPTION
Adds a new `colorEnhance` post-processing block to `CameraFrame` with HDR-aware tonal and color adjustments:

### New Features

- **Shadows** (-3 to 3): Selectively adjust dark areas using an exponential curve in log-space
- **Highlights** (-3 to 3): Selectively adjust bright areas using an exponential curve in log-space
- **Vibrance** (-1 to 1): Smart saturation that boosts less-saturated colors more than already-saturated ones
- **Dehaze** (-1 to 1): Remove atmospheric haze using dark channel prior, or add haze with negative values

### Technical Details

- Fully HDR-aware - works correctly with values outside 0-1 range
- Optional effect with compile-time `#ifdef COLOR_ENHANCE` when disabled (zero cost)
- Coherent branching for individual parameters when set to zero (minimal cost for unused features)
- Both GLSL and WGSL implementations

### API

const cameraFrame = new pc.CameraFrame(app, camera.camera);
cameraFrame.colorEnhance.enabled = true;
cameraFrame.colorEnhance.shadows = 0.5;    // lift shadows
cameraFrame.colorEnhance.highlights = -0.3; // recover highlights
cameraFrame.colorEnhance.vibrance = 0.2;   // boost color
cameraFrame.colorEnhance.dehaze = 0.4;     // remove haze
cameraFrame.update();

<img width="281" height="181" alt="Screenshot 2026-02-04 at 15 31 45" src="https://github.com/user-attachments/assets/cb69ee03-1a80-4d90-b1db-939cfa0f46e1" />
