### PR TITLE
Global splat budget for scene-wide GSplat LOD management

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-instances.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-instances.example.mjs
@@ -212,13 +212,7 @@ assetListLoader.load(() => {
 
     // internal LOD preset based on platform (7 LOD levels: 0-6)
     const isMobile = pc.platform.mobile;
-    if (isMobile) {
-        app.scene.gsplat.lodRangeMin = 3;  // skip levels 0, 1, 2
-        app.scene.gsplat.lodRangeMax = 6;
-    } else {
-        app.scene.gsplat.lodRangeMin = 2;  // skip level 0 and 1
-        app.scene.gsplat.lodRangeMax = 6;
-    }
+    app.scene.gsplat.splatBudget = isMobile ? 1000000 : 3000000;
 
     // create grid of instances centered around origin on XZ plane
     const half = (GRID_SIZE - 1) * 0.5;

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -187,7 +187,8 @@ assetListLoader.load(() => {
             '4M': 4000000,
             '6M': 6000000
         };
-        gs.splatBudget = budgetMap[preset] || 0;
+        // Global splat budget applies to all GSplats in the scene
+        app.scene.gsplat.splatBudget = budgetMap[preset] || 0;
     };
 
     applySplatBudget();

--- a/examples/src/examples/gaussian-splatting/world.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/world.controls.mjs
@@ -1,0 +1,54 @@
+/**
+ * @param {import('../../app/components/Example.mjs').ControlOptions} options - The options.
+ * @returns {JSX.Element} The returned JSX Element.
+ */
+export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
+    const { BindingTwoWay, LabelGroup, BooleanInput, Panel, SelectInput, Label } = ReactPCUI;
+    return fragment(
+        jsx(
+            Panel,
+            { headerText: 'Settings' },
+            jsx(
+                LabelGroup,
+                { text: 'Colorize LOD' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'debugLod' },
+                    value: observer.get('debugLod')
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Splat Budget' },
+                jsx(SelectInput, {
+                    type: 'string',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'splatBudget' },
+                    value: observer.get('splatBudget') || '4M',
+                    options: [
+                        { v: 'none', t: 'No limit' },
+                        { v: '1M', t: '1M' },
+                        { v: '2M', t: '2M' },
+                        { v: '3M', t: '3M' },
+                        { v: '4M', t: '4M' },
+                        { v: '6M', t: '6M' }
+                    ]
+                })
+            )
+        ),
+        jsx(
+            Panel,
+            { headerText: 'Stats' },
+            jsx(
+                LabelGroup,
+                { text: 'GSplat Count' },
+                jsx(Label, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.stats.gsplats' },
+                    value: observer.get('data.stats.gsplats')
+                })
+            )
+        )
+    );
+};

--- a/examples/src/examples/gaussian-splatting/world.example.mjs
+++ b/examples/src/examples/gaussian-splatting/world.example.mjs
@@ -1,4 +1,5 @@
 // @config DESCRIPTION Shows a large world scene with LOD streaming and additional moving splats.
+import { data } from 'examples/observer';
 import { deviceType, rootPath, fileImport } from 'examples/utils';
 import * as pc from 'playcanvas';
 
@@ -110,6 +111,33 @@ assetListLoader.load(() => {
     app.scene.gsplat.colorUpdateAngle = 4;
     app.scene.gsplat.colorUpdateDistanceLodScale = 2;
     app.scene.gsplat.colorUpdateAngleLodScale = 2;
+
+    // initialize UI settings
+    data.set('debugLod', false);
+    data.set('splatBudget', pc.platform.mobile ? '1M' : '4M');
+
+    app.scene.gsplat.colorizeLod = !!data.get('debugLod');
+
+    data.on('debugLod:set', () => {
+        app.scene.gsplat.colorizeLod = !!data.get('debugLod');
+    });
+
+    const applySplatBudget = () => {
+        const preset = data.get('splatBudget');
+        const budgetMap = {
+            'none': 0,
+            '1M': 1000000,
+            '2M': 2000000,
+            '3M': 3000000,
+            '4M': 4000000,
+            '6M': 6000000
+        };
+        // Global splat budget applies to all GSplats in the scene
+        app.scene.gsplat.splatBudget = budgetMap[preset] || 0;
+    };
+
+    applySplatBudget();
+    data.on('splatBudget:set', applySplatBudget);
 
     // Auto-select LOD preset based on device
     const preset = pc.platform.mobile ? 'mobile' : 'desktop';
@@ -228,6 +256,9 @@ assetListLoader.load(() => {
         );
         logo2.lookAt(centerVec);
         logo2.rotateLocal(0, 0, time * rollSpeed2);
+
+        // Update HUD stats
+        data.set('data.stats.gsplats', app.stats.frame.gsplats.toLocaleString());
     });
 });
 

--- a/scripts/esm/gsplat/streamed-gsplat.mjs
+++ b/scripts/esm/gsplat/streamed-gsplat.mjs
@@ -63,30 +63,6 @@ class StreamedGsplat extends Script {
      */
     lowLodRange = [3, 5];
 
-    /**
-     * @attribute
-     * @type {number}
-     */
-    ultraSplatBudget = 6000000;
-
-    /**
-     * @attribute
-     * @type {number}
-     */
-    highSplatBudget = 4000000;
-
-    /**
-     * @attribute
-     * @type {number}
-     */
-    mediumSplatBudget = 2000000;
-
-    /**
-     * @attribute
-     * @type {number}
-     */
-    lowSplatBudget = 1000000;
-
     /** @type {Asset[]} */
     _assets = [];
 
@@ -225,27 +201,6 @@ class StreamedGsplat extends Script {
         return range && range.length >= 2 ? range : [0, 5];
     }
 
-    _getCurrentSplatBudget() {
-        let budget;
-        switch (this._currentPreset) {
-            case 'ultra':
-                budget = this.ultraSplatBudget;
-                break;
-            case 'high':
-                budget = this.highSplatBudget;
-                break;
-            case 'medium':
-                budget = this.mediumSplatBudget;
-                break;
-            case 'low':
-                budget = this.lowSplatBudget;
-                break;
-            default:
-                budget = 0;
-        }
-        return budget || 0;
-    }
-
     _applyPreset() {
         const range = this._getCurrentLodRange();
         if (!range) return;
@@ -255,12 +210,10 @@ class StreamedGsplat extends Script {
         app.scene.gsplat.lodRangeMax = range[1];
 
         const lodDistances = this._getCurrentLodDistances();
-        const splatBudget = this._getCurrentSplatBudget();
 
         // Apply to main streaming asset only (environment doesn't support these settings)
         if (this.entity.gsplat) {
             this.entity.gsplat.lodDistances = lodDistances;
-            this.entity.gsplat.splatBudget = splatBudget;
         }
     }
 

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -120,15 +120,6 @@ class GSplatComponent extends Component {
     _lodDistances = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60];
 
     /**
-     * Target number of splats to render for this component. The system will adjust LOD levels
-     * bidirectionally to reach this budget. Set to 0 to disable (default).
-     *
-     * @type {number}
-     * @private
-     */
-    _splatBudget = 0;
-
-    /**
      * @type {BoundingBox|null}
      * @private
      */
@@ -455,35 +446,16 @@ class GSplatComponent extends Component {
     }
 
     /**
-     * Sets the target number of splats to render for this component. The system will adjust LOD
-     * levels bidirectionally to reach this budget:
-     * - When over budget: degrades quality for less important geometry
-     * - When under budget: upgrades quality for more important geometry
-     *
-     * This ensures optimal use of available rendering budget while prioritizing quality for
-     * closer/more important geometry.
-     *
-     * Set to 0 to disable the budget (default). When disabled, optimal LOD is determined purely
-     * by distance and configured LOD parameters.
-     *
-     * Only applies to octree-based gsplat rendering in unified mode.
-     *
+     * @deprecated Use app.scene.gsplat.splatBudget instead for global budget control.
      * @type {number}
      */
     set splatBudget(value) {
-        this._splatBudget = value;
-        if (this._placement) {
-            this._placement.splatBudget = this._splatBudget;
-        }
+        Debug.removed('GSplatComponent.splatBudget is removed. Use app.scene.gsplat.splatBudget instead for global budget control.');
     }
 
-    /**
-     * Gets the splat budget limit for this component.
-     *
-     * @type {number}
-     */
     get splatBudget() {
-        return this._splatBudget;
+        Debug.removed('GSplatComponent.splatBudget is removed. Use app.scene.gsplat.splatBudget instead for global budget control.');
+        return 0;
     }
 
     /**
@@ -964,7 +936,6 @@ class GSplatComponent extends Component {
 
             this._placement = new GSplatPlacement(resource, this.entity, 0, this._parameters, null, this._id);
             this._placement.lodDistances = this._lodDistances;
-            this._placement.splatBudget = this._splatBudget;
             this._placement.workBufferUpdate = this._workBufferUpdate;
             this._placement.workBufferModifier = this._workBufferModifier;
 

--- a/src/scene/gsplat-unified/gsplat-budget-balancer.js
+++ b/src/scene/gsplat-unified/gsplat-budget-balancer.js
@@ -1,0 +1,155 @@
+/**
+ * @import { GSplatOctreeInstance } from './gsplat-octree-instance.js'
+ * @import { GSplatPlacement } from './gsplat-placement.js'
+ */
+
+/**
+ * Number of buckets for distance-based sorting.
+ * More buckets = finer granularity for budget prioritization.
+ * @type {number}
+ */
+const NUM_BUCKETS = 64;
+
+/**
+ * Balances splat budget across multiple octree instances by adjusting LOD levels.
+ * Uses sqrt-based bucket distribution to give more precision to nearby geometry.
+ * Bucket 0 = nearest to camera (highest priority), bucket N-1 = farthest (lowest priority).
+ *
+ * @ignore
+ */
+class GSplatBudgetBalancer {
+    /**
+     * Buckets storing NodeInfo references.
+     * @type {Array<Array>|null}
+     * @private
+     */
+    _buckets = null;
+
+    /**
+     * Initialize bucket infrastructure on first use.
+     * @private
+     */
+    _initBuckets() {
+        if (!this._buckets) {
+            // Pre-allocate bucket arrays (will hold NodeInfo references)
+            this._buckets = new Array(NUM_BUCKETS);
+            for (let i = 0; i < NUM_BUCKETS; i++) {
+                this._buckets[i] = [];
+            }
+        }
+    }
+
+    /**
+     * Balances splat budget across all octree instances by adjusting LOD levels.
+     * Uses sqrt-based bucket distribution to give more precision to nearby geometry.
+     * Makes multiple passes, adjusting by one LOD level per pass, until budget is reached
+     * or all nodes hit their respective limits (per-instance rangeMin or rangeMax).
+     *
+     * @param {Map<GSplatPlacement, GSplatOctreeInstance>} octreeInstances - Map of
+     * GSplatOctreeInstance objects.
+     * @param {number} budget - Target splat budget for octrees.
+     * @param {number} globalMaxDistance - Max world-space distance for bucket calculation.
+     */
+    balance(octreeInstances, budget, globalMaxDistance) {
+        // Initialize buckets on first use
+        this._initBuckets();
+
+        // Clear buckets
+        for (let i = 0; i < NUM_BUCKETS; i++) {
+            this._buckets[i].length = 0;
+        }
+
+        // Pre-compute multiplier for fast bucket calculation:
+        // bucket = sqrt(worldDistance / globalMaxDistance) * NUM_BUCKETS
+        // Simplified to: sqrt(worldDistance) * (NUM_BUCKETS / sqrt(globalMaxDistance))
+        const bucketScale = NUM_BUCKETS / Math.sqrt(globalMaxDistance);
+
+        // Collect all nodes into buckets based on world distance
+        // Uses sqrt distribution: bucket 0 = nearest, bucket N-1 = farthest
+        // At distance=0: bucket=0, at distance=maxDistance: bucket=NUM_BUCKETS-1
+        // Nearby geometry gets more buckets (finer granularity) due to sqrt
+        let totalOptimalSplats = 0;
+        for (const [, inst] of octreeInstances) {
+            const nodes = inst.octree.nodes;
+            const nodeInfos = inst.nodeInfos;
+
+            for (let nodeIndex = 0, len = nodes.length; nodeIndex < len; nodeIndex++) {
+                const nodeInfo = nodeInfos[nodeIndex];
+                const optimalLod = nodeInfo.optimalLod;
+                if (optimalLod < 0) continue;
+
+                // Cache lods array on nodeInfo for fast access in budget adjustment loops
+                const lods = nodes[nodeIndex].lods;
+                nodeInfo.lods = lods;
+
+                // Fast bucket calculation: sqrt(distance) * pre-computed scale
+                // Bucket 0 = nearest (highest priority), bucket N-1 = farthest
+                const bucket = (Math.sqrt(nodeInfo.worldDistance) * bucketScale) >>> 0;
+                const bucketIdx = bucket < NUM_BUCKETS ? bucket : NUM_BUCKETS - 1;
+                this._buckets[bucketIdx].push(nodeInfo);
+
+                totalOptimalSplats += lods[optimalLod].count;
+            }
+        }
+
+        // Skip if already at budget
+        let currentSplats = totalOptimalSplats;
+        if (currentSplats === budget) {
+            return;
+        }
+
+        // Determine direction
+        const isOverBudget = currentSplats > budget;
+
+        // Multiple passes: adjust by one LOD level per pass until budget is reached
+        while (isOverBudget ? currentSplats > budget : currentSplats < budget) {
+            let modified = false;
+
+            if (isOverBudget) {
+                // Degrade: process from FARTHEST (bucket NUM_BUCKETS-1) to NEAREST (bucket 0)
+                // This preserves quality for nearby geometry
+                for (let b = NUM_BUCKETS - 1; b >= 0 && currentSplats > budget; b--) {
+                    const bucket = this._buckets[b];
+                    for (let i = 0, len = bucket.length; i < len; i++) {
+                        const nodeInfo = bucket[i];
+                        if (nodeInfo.optimalLod < nodeInfo.inst.rangeMax) {
+                            const lods = nodeInfo.lods;
+                            const optimalLod = nodeInfo.optimalLod;
+                            currentSplats -= lods[optimalLod].count - lods[optimalLod + 1].count;
+                            nodeInfo.optimalLod = optimalLod + 1;
+                            modified = true;
+                            if (currentSplats <= budget) break;
+                        }
+                    }
+                }
+            } else {
+                // Upgrade: process from NEAREST (bucket 0) to FARTHEST (bucket NUM_BUCKETS-1)
+                // This improves quality for nearby geometry first
+                for (let b = 0; b < NUM_BUCKETS && currentSplats < budget; b++) {
+                    const bucket = this._buckets[b];
+                    for (let i = 0, len = bucket.length; i < len; i++) {
+                        const nodeInfo = bucket[i];
+                        if (nodeInfo.optimalLod > nodeInfo.inst.rangeMin) {
+                            const lods = nodeInfo.lods;
+                            const optimalLod = nodeInfo.optimalLod;
+                            const splatsAdded = lods[optimalLod - 1].count - lods[optimalLod].count;
+                            if (currentSplats + splatsAdded <= budget) {
+                                nodeInfo.optimalLod = optimalLod - 1;
+                                currentSplats += splatsAdded;
+                                modified = true;
+                                if (currentSplats >= budget) break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // If no nodes were modified, we can't adjust further (all at limits)
+            if (!modified) {
+                break;
+            }
+        }
+    }
+}
+
+export { GSplatBudgetBalancer };

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -1,4 +1,3 @@
-import { Debug } from '../../core/debug.js';
 import {
     PIXELFORMAT_R32U, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA16U, PIXELFORMAT_RGBA32U, PIXELFORMAT_RG32U
 } from '../../platform/graphics/constants.js';
@@ -293,13 +292,33 @@ class GSplatParams {
         return this._lodUnderfillLimit;
     }
 
+    /**
+     * @type {number}
+     * @private
+     */
+    _splatBudget = 0;
+
+    /**
+     * Target number of splats across all GSplats in the scene. When set > 0,
+     * the system adjusts LOD levels globally to stay within this budget.
+     * Set to 0 to disable budget enforcement and use LOD distances only (default).
+     *
+     * @type {number}
+     */
     set splatBudget(value) {
-        Debug.removed('GSplatParams.splatBudget is deprecated. Use GSplatComponent.splatBudget instead to set per-component budgets.');
+        if (this._splatBudget !== value) {
+            this._splatBudget = value;
+            this.dirty = true;
+        }
     }
 
+    /**
+     * Gets the target number of splats across all GSplats in the scene.
+     *
+     * @type {number}
+     */
     get splatBudget() {
-        Debug.removed('GSplatParams.splatBudget is deprecated. Use GSplatComponent.splatBudget instead to set per-component budgets.');
-        return 0;
+        return this._splatBudget;
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-placement.js
+++ b/src/scene/gsplat-unified/gsplat-placement.js
@@ -66,13 +66,6 @@ class GSplatPlacement {
     _lodDistances = null;
 
     /**
-     * Target number of splats to render for this placement. Set to 0 to disable (default).
-     *
-     * @type {number}
-     */
-    splatBudget = 0;
-
-    /**
      * The axis-aligned bounding box for this placement, in local space.
      * Null means use resource.aabb as fallback.
      *


### PR DESCRIPTION
Fixes https://github.com/playcanvas/engine/issues/8341

## Summary
Replaces per-component `splatBudget` with a scene-wide `GSplatParams.splatBudget` that intelligently distributes budget across all GSplat entities using distance-based prioritization.

### Global Budget System
- Add `GSplatParams.splatBudget` as the single scene-wide budget control (0 disables enforcement)
- Create `GSplatBudgetBalancer` class to handle budget distribution across octrees

### Fixed vs LOD Splats
- Non-octree placements (fixed splat count) are subtracted from budget first
- Remaining budget distributed to octree instances via LOD adjustment
- Account for work buffer texture row-alignment padding in budget calculation

### Deprecation
- Per-component `splatBudget` getter/setter now issues `Debug.removed` warning

### Examples
- Update `lod-streaming`, `streamed-gsplat`, and `world` examples to use global budget
