### PR TITLE
fix: Inline WGSL resolveCodebook to fix Firefox naga compatibility

### DIFF
--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatPacking.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatPacking.js
@@ -24,16 +24,4 @@ fn unpack101010(v: u32) -> vec3f {
 
 fn unpack111110(v: u32) -> vec3f {
     return vec3f((vec3u(v) >> vec3u(21u, 10u, 0u)) & vec3u(0x7ffu, 0x7ffu, 0x3ffu)) / vec3f(2047.0, 2047.0, 1023.0);
-}
-
-// resolve the sample using the supplied codebook and return a normalized value relative to codebook min and max
-fn resolveCodebook(s: vec3f, codebook: ptr<uniform, array<vec4f, 64>>) -> vec3f {
-    let idx = vec3u(s * 255.0);
-    let v = vec3f(
-        codebook[idx.x >> 2u][idx.x & 3u],
-        codebook[idx.y >> 2u][idx.y & 3u],
-        codebook[idx.z >> 2u][idx.z & 3u]
-    );
-    return (v - codebook[0].x) / (codebook[63].w - codebook[0].x);
-}
-`;
+}`;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatSogReorder.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatSogReorder.js
@@ -49,8 +49,23 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         let sh0 = pack111110(resolve(uniform.sh0Mins.xyz, uniform.sh0Maxs.xyz, sh0Sample.xyz));
         let alpha = sigmoid(mix(uniform.sh0Mins.w, uniform.sh0Maxs.w, sh0Sample.w));
     #else
-        let scale = pack101010(resolveCodebook(scalesSample, &uniform.scales_codebook));    // resolve scale to 10,10,10 bits
-        let sh0 = pack111110(resolveCodebook(sh0Sample.xyz, &uniform.sh0_codebook));        // resolve sh0 to 11,11,10 bits
+        // resolve scale codebook to 10,10,10 bits
+        let scalesIdx = vec3u(scalesSample * 255.0);
+        let scalesV = vec3f(
+            uniform.scales_codebook[scalesIdx.x >> 2u][scalesIdx.x & 3u],
+            uniform.scales_codebook[scalesIdx.y >> 2u][scalesIdx.y & 3u],
+            uniform.scales_codebook[scalesIdx.z >> 2u][scalesIdx.z & 3u]
+        );
+        let scale = pack101010((scalesV - uniform.scales_codebook[0].x) / (uniform.scales_codebook[63].w - uniform.scales_codebook[0].x));
+
+        // resolve sh0 codebook to 11,11,10 bits
+        let sh0Idx = vec3u(sh0Sample.xyz * 255.0);
+        let sh0V = vec3f(
+            uniform.sh0_codebook[sh0Idx.x >> 2u][sh0Idx.x & 3u],
+            uniform.sh0_codebook[sh0Idx.y >> 2u][sh0Idx.y & 3u],
+            uniform.sh0_codebook[sh0Idx.z >> 2u][sh0Idx.z & 3u]
+        );
+        let sh0 = pack111110((sh0V - uniform.sh0_codebook[0].x) / (uniform.sh0_codebook[63].w - uniform.sh0_codebook[0].x));
         let alpha = sh0Sample.w;
     #endif
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatSogReorderSh.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatSogReorderSh.js
@@ -16,7 +16,14 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
 #ifdef REORDER_V1
     output.color = unpack8888(pack111110(shNSample));
 #else
-    output.color = unpack8888(pack111110(resolveCodebook(shNSample, &uniform.shN_codebook)));
+    // resolve shN codebook
+    let shNIdx = vec3u(shNSample * 255.0);
+    let shNV = vec3f(
+        uniform.shN_codebook[shNIdx.x >> 2u][shNIdx.x & 3u],
+        uniform.shN_codebook[shNIdx.y >> 2u][shNIdx.y & 3u],
+        uniform.shN_codebook[shNIdx.z >> 2u][shNIdx.z & 3u]
+    );
+    output.color = unpack8888(pack111110((shNV - uniform.shN_codebook[0].x) / (uniform.shN_codebook[63].w - uniform.shN_codebook[0].x)));
 #endif
 
     return output;


### PR DESCRIPTION
## Summary

- we were pass uniform arrays by reference, which WebGPU spec does not allow (Chrome is ok with it, Firefox correctly is rejecting this)
- Inlines the WGSL `resolveCodebook` function at all 3 call sites to fix Firefox WebGPU shader validation errors
- Firefox's naga WGSL compiler rejects `ptr<uniform, ...>` as a function parameter per the WGSL spec (only `function`, `private`, and `workgroup` address spaces are allowed for pointer parameters)
- Codebook uniform arrays are now accessed directly at each call site instead of being passed through a function

## Files changed

- `src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatPacking.js` — Removed `resolveCodebook` function
- `src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatSogReorder.js` — Inlined codebook resolution for `scales_codebook` and `sh0_codebook`
- `src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatSogReorderSh.js` — Inlined codebook resolution for `shN_codebook`

## Test plan

- [ ] Verify SOG gaussian splat rendering works correctly on Chrome (WebGPU)
- [ ] Verify SOG gaussian splat rendering works correctly on Firefox (WebGPU)
- [ ] Verify no shader validation errors in Firefox console

Made with [Cursor](https://cursor.com)