### PR TITLE
Optimization: Material.meshInstances change to Set - faster removing MeshInstances

### DIFF
--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -79,10 +79,10 @@ class Material {
     /**
      * The mesh instances referencing this material
      *
-     * @type {MeshInstance[]}
+     * @type {Set<MeshInstance>}
      * @private
      */
-    meshInstances = [];
+    meshInstances = new Set();
 
     /**
      * The name of the material.
@@ -439,10 +439,8 @@ class Material {
     }
 
     _updateTransparency() {
-        const transparent = this.transparent;
-        const meshInstances = this.meshInstances;
-        for (let i = 0; i < meshInstances.length; i++) {
-            meshInstances[i].transparent = transparent;
+        for(const meshInstance of this.meshInstances) {
+            meshInstance.transparent = this.transparent;
         }
     }
 
@@ -675,9 +673,8 @@ class Material {
     }
 
     _updateMeshInstanceKeys() {
-        const meshInstances = this.meshInstances;
-        for (let i = 0; i < meshInstances.length; i++) {
-            meshInstances[i].updateKey();
+        for(const meshInstance of this.meshInstances) {
+            meshInstance.updateKey();
         }
     }
 
@@ -744,15 +741,12 @@ class Material {
     }
 
     clearVariants() {
-
         // clear variants on the material
         this.variants.clear();
 
         // but also clear them from all materials that reference them
-        const meshInstances = this.meshInstances;
-        const count = meshInstances.length;
-        for (let i = 0; i < count; i++) {
-            meshInstances[i].clearShaders();
+        for(const meshInstance of this.meshInstances) {
+            meshInstance.clearShaders();
         }
     }
 
@@ -884,8 +878,7 @@ class Material {
     destroy() {
         this.variants.clear();
 
-        for (let i = 0; i < this.meshInstances.length; i++) {
-            const meshInstance = this.meshInstances[i];
+        for(const meshInstance of this.meshInstances) {
             meshInstance.clearShaders();
             meshInstance._material = null;
 
@@ -899,7 +892,7 @@ class Material {
             }
         }
 
-        this.meshInstances.length = 0;
+        this.meshInstances.clear();
     }
 
     /**
@@ -909,7 +902,7 @@ class Material {
      * @ignore
      */
     addMeshInstanceRef(meshInstance) {
-        this.meshInstances.push(meshInstance);
+        this.meshInstances.add(meshInstance);
     }
 
     /**
@@ -919,11 +912,7 @@ class Material {
      * @ignore
      */
     removeMeshInstanceRef(meshInstance) {
-        const meshInstances = this.meshInstances;
-        const i = meshInstances.indexOf(meshInstance);
-        if (i !== -1) {
-            meshInstances.splice(i, 1);
-        }
+        this.meshInstances.delete(meshInstance);
     }
 }
 


### PR DESCRIPTION
## Description
Material stores a referenced list of meshInstances, to be updated when material might change blending, or gets destroyed.
It is private list (not public API). Currently it uses an array, and when compared to Sets they have cons and pros.
Based on many applications tested, the most referenced part is when adding/removing meshInstances, either through creation of many entities, or re-assigning materials.

In small number of mesh instances per material, the impact of this list is neglectable, but when some materials used on thousands of meshes, this leads to pretty slow removal.

This PR, changes array to set. Through tests the effect on iterators is neglectable as there is no hot code (does not iterate every frame). Adding to Set is tiny bit more expensive then pushing into an array. But deleting from Set is way faster O(1) vs indexOf + splice of array O(n).

When add/remove stats combined, this leads to **~26% speed up** in this particular code (in one of our projects this is significant time).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
