### PR TITLE
[FIX] Refresh texture state when toggling mipmaps

### DIFF
--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -265,7 +265,7 @@ class Texture {
         if (options.numLevels !== undefined) {
             this._numLevels = options.numLevels;
         }
-        this._updateNumLevel();
+        this._updateNumLevels();
 
         this._minFilter = options.minFilter ?? FILTER_LINEAR_MIPMAP_LINEAR;
         this._magFilter = options.magFilter ?? FILTER_LINEAR;
@@ -376,7 +376,7 @@ class Texture {
             this._width = Math.floor(width);
             this._height = Math.floor(height);
             this._depth = Math.floor(depth);
-            this._updateNumLevel();
+            this._updateNumLevels();
 
             // re-create the implementation
             this.impl = device.createTextureImpl(this);
@@ -421,7 +421,7 @@ class Texture {
         this.renderVersionDirty = this.device.renderVersion;
     }
 
-    _updateNumLevel() {
+    _updateNumLevels() {
 
         const maxLevels = this.mipmaps ? TextureUtils.calcMipLevelsCount(this.width, this.height) : 1;
         const requestedLevels = this._numLevelsRequested;
@@ -677,7 +677,7 @@ class Texture {
                 const oldNumLevels = this._numLevels;
 
                 this._mipmaps = v;
-                this._updateNumLevel();
+                this._updateNumLevels();
 
                 // Changing mip count on array textures requires re-creating immutable storage.
                 if (this.array && this._numLevels !== oldNumLevels) {


### PR DESCRIPTION
Fixes https://github.com/playcanvas/editor/issues/1187

## Summary
- update `Texture#mipmaps` to recalculate mip level count when toggled at runtime
- mark minification filter parameters dirty when mipmaps changes so sampler state updates immediately
- preserve existing mip upload scheduling when enabling mipmaps and keep current WebGPU/integer-format guards
- addresses the viewport update behavior reported in playcanvas/editor#1187

## Test plan
- [x] linked Editor to this Engine branch and confirmed toggling texture `Mipmaps` updates viewport visuals immediately
- [x] confirmed no filtering-mode change or scene reload is needed after toggling mipmaps
- [x] confirmed PR scope is only `src/platform/graphics/texture.js`
- [x] no new automated test file included in this PR (by request)