### PR TITLE
feat: add midtones control to color enhance

### DIFF
--- a/examples/src/examples/gaussian-splatting/viewer.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.controls.mjs
@@ -134,6 +134,17 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
+                { text: 'midtones' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.midtones' },
+                    min: -1,
+                    max: 1,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
                 { text: 'vibrance' },
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),

--- a/examples/src/examples/gaussian-splatting/viewer.example.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.example.mjs
@@ -179,6 +179,7 @@ assetListLoader.load(() => {
             enabled: false,
             shadows: 0,
             highlights: 0,
+            midtones: 0,
             vibrance: 0,
             dehaze: 0
         }
@@ -210,6 +211,7 @@ assetListLoader.load(() => {
         cameraFrame.colorEnhance.enabled = data.get('data.colorEnhance.enabled');
         cameraFrame.colorEnhance.shadows = data.get('data.colorEnhance.shadows');
         cameraFrame.colorEnhance.highlights = data.get('data.colorEnhance.highlights');
+        cameraFrame.colorEnhance.midtones = data.get('data.colorEnhance.midtones');
         cameraFrame.colorEnhance.vibrance = data.get('data.colorEnhance.vibrance');
         cameraFrame.colorEnhance.dehaze = data.get('data.colorEnhance.dehaze');
 

--- a/examples/src/examples/graphics/post-processing.controls.mjs
+++ b/examples/src/examples/graphics/post-processing.controls.mjs
@@ -202,6 +202,17 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
+                { text: 'midtones' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.midtones' },
+                    min: -1,
+                    max: 1,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
                 { text: 'vibrance' },
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),

--- a/examples/src/examples/graphics/post-processing.example.mjs
+++ b/examples/src/examples/graphics/post-processing.example.mjs
@@ -261,6 +261,7 @@ assetListLoader.load(() => {
         if (cameraFrame.colorEnhance.enabled) {
             cameraFrame.colorEnhance.shadows = data.get('data.colorEnhance.shadows');
             cameraFrame.colorEnhance.highlights = data.get('data.colorEnhance.highlights');
+            cameraFrame.colorEnhance.midtones = data.get('data.colorEnhance.midtones');
             cameraFrame.colorEnhance.vibrance = data.get('data.colorEnhance.vibrance');
             cameraFrame.colorEnhance.dehaze = data.get('data.colorEnhance.dehaze');
         }
@@ -320,6 +321,7 @@ assetListLoader.load(() => {
             enabled: false,
             shadows: 0,
             highlights: 0,
+            midtones: 0,
             vibrance: 0,
             dehaze: 0
         },

--- a/examples/src/examples/graphics/sky.controls.mjs
+++ b/examples/src/examples/graphics/sky.controls.mjs
@@ -128,6 +128,17 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
+                { text: 'midtones' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.colorEnhance.midtones' },
+                    min: -1,
+                    max: 1,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
                 { text: 'vibrance' },
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),

--- a/examples/src/examples/graphics/sky.example.mjs
+++ b/examples/src/examples/graphics/sky.example.mjs
@@ -176,6 +176,7 @@ assetListLoader.load(() => {
             cameraFrame.colorEnhance.enabled = data.get('data.colorEnhance.enabled');
             cameraFrame.colorEnhance.shadows = data.get('data.colorEnhance.shadows');
             cameraFrame.colorEnhance.highlights = data.get('data.colorEnhance.highlights');
+            cameraFrame.colorEnhance.midtones = data.get('data.colorEnhance.midtones');
             cameraFrame.colorEnhance.vibrance = data.get('data.colorEnhance.vibrance');
             cameraFrame.colorEnhance.dehaze = data.get('data.colorEnhance.dehaze');
             cameraFrame.update();
@@ -190,6 +191,7 @@ assetListLoader.load(() => {
         enabled: false,
         shadows: 0,
         highlights: 0,
+        midtones: 0,
         vibrance: 0,
         dehaze: 0
     });

--- a/scripts/esm/camera-frame.mjs
+++ b/scripts/esm/camera-frame.mjs
@@ -323,6 +323,14 @@ class ColorEnhance {
      * @precision 3
      * @step 0.01
      */
+    midtones = 0;
+
+    /**
+     * @visibleif {enabled}
+     * @range [-1, 1]
+     * @precision 3
+     * @step 0.01
+     */
     vibrance = 0;
 
     /**
@@ -568,6 +576,7 @@ class CameraFrame extends Script {
         if (colorEnhance.enabled) {
             dstColorEnhance.shadows = colorEnhance.shadows;
             dstColorEnhance.highlights = colorEnhance.highlights;
+            dstColorEnhance.midtones = colorEnhance.midtones;
             dstColorEnhance.vibrance = colorEnhance.vibrance;
             dstColorEnhance.dehaze = colorEnhance.dehaze;
         }

--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -159,6 +159,9 @@ import { CameraFrameOptions, RenderPassCameraFrame } from './render-pass-camera-
  * @property {number} vibrance - The vibrance (smart saturation), -1 to 1 range. Positive values boost
  * saturation of less-saturated colors more than already-saturated ones. Negative values desaturate.
  * Defaults to 0.
+ * @property {number} midtones - The midtone adjustment, -1 to 1 range. Positive values brighten
+ * midtones, negative values darken midtones, with shadows and highlights more strongly preserved
+ * than by a linear exposure change. Defaults to 0.
  * @property {number} dehaze - The dehaze adjustment, -1 to 1 range. Positive values remove atmospheric
  * haze, increasing clarity and contrast. Negative values add a haze effect. Defaults to 0.
  */
@@ -331,6 +334,7 @@ class CameraFrame {
         shadows: 0,
         highlights: 0,
         vibrance: 0,
+        midtones: 0,
         dehaze: 0
     };
 
@@ -541,6 +545,7 @@ class CameraFrame {
             composePass.colorEnhanceShadows = colorEnhance.shadows;
             composePass.colorEnhanceHighlights = colorEnhance.highlights;
             composePass.colorEnhanceVibrance = colorEnhance.vibrance;
+            composePass.colorEnhanceMidtones = colorEnhance.midtones;
             composePass.colorEnhanceDehaze = colorEnhance.dehaze;
         }
 

--- a/src/extras/render-passes/render-pass-compose.js
+++ b/src/extras/render-passes/render-pass-compose.js
@@ -77,6 +77,8 @@ class RenderPassCompose extends RenderPassShaderQuad {
 
     colorEnhanceDehaze = 0;
 
+    colorEnhanceMidtones = 0;
+
     _taaEnabled = false;
 
     _sharpness = 0.5;
@@ -127,6 +129,7 @@ class RenderPassCompose extends RenderPassShaderQuad {
         this.colorLUTParams = new Float32Array(4);
         this.colorLUTParamsId = scope.resolve('colorLUTParams');
         this.colorEnhanceParamsId = scope.resolve('colorEnhanceParams');
+        this.colorEnhanceMidtonesId = scope.resolve('colorEnhanceMidtones');
     }
 
     set debug(value) {
@@ -385,6 +388,7 @@ class RenderPassCompose extends RenderPassShaderQuad {
 
         if (this._colorEnhanceEnabled) {
             this.colorEnhanceParamsId.setValue([this.colorEnhanceShadows, this.colorEnhanceHighlights, this.colorEnhanceVibrance, this.colorEnhanceDehaze]);
+            this.colorEnhanceMidtonesId.setValue(this.colorEnhanceMidtones);
         }
 
         const lutTexture = this._colorLUT;


### PR DESCRIPTION
## Summary
- add `colorEnhance.midtones` control across CameraFrame, script API, and compose pass
- implement midtones in GLSL/WGSL color-enhance shaders using a localized log-luminance exposure model
- expose the slider in updated graphics and gaussian-splatting examples

related to https://github.com/playcanvas/engine/pull/8443