### PR TITLE
feat: expose WebGPU texture format tier capabilities

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -360,6 +360,24 @@ class GraphicsDevice extends EventHandler {
     supportsClipDistances = false;
 
     /**
+     * True if the device supports WebGPU texture format tier 1 capabilities. When enabled, a wider
+     * set of normalized texture formats can be used as render targets and storage textures.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    supportsTextureFormatTier1 = false;
+
+    /**
+     * True if the device supports WebGPU texture format tier 2 capabilities. This extends tier 1
+     * and enables read-write storage access for selected texture formats.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    supportsTextureFormatTier2 = false;
+
+    /**
      * True if the device supports primitive index in fragment shaders (WebGPU only). When
      * supported, fragment shaders can access the `pcPrimitiveIndex` built-in variable which
      * uniquely identifies the current primitive being processed.

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -317,6 +317,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsClipDistances = requireFeature('clip-distances');
         this.supportsTextureFormatTier1 = requireFeature('texture-format-tier1');
         this.supportsTextureFormatTier2 = requireFeature('texture-format-tier2');
+        this.supportsTextureFormatTier1 ||= this.supportsTextureFormatTier2;
         this.supportsPrimitiveIndex = requireFeature('primitive-index');
         Debug.log(`WEBGPU features: ${requiredFeatures.join(', ')}`);
 


### PR DESCRIPTION
## Summary
- add `GraphicsDevice.supportsTextureFormatTier1` and `GraphicsDevice.supportsTextureFormatTier2` capability flags with JSDoc defaults
- keep WebGPU optional feature requests for `texture-format-tier1` and `texture-format-tier2` and ensure tier1 is reported when tier2 is enabled
- make runtime capability checks for texture format tiers consistent with WebGPU feature tier semantics
