### PR TITLE
Improve MiniStats VRAM reporting and graph grouping

### DIFF
--- a/examples/src/examples/gaussian-splatting/flipbook.example.mjs
+++ b/examples/src/examples/gaussian-splatting/flipbook.example.mjs
@@ -76,16 +76,8 @@ assetListLoader.load(() => {
     roomEntity.setLocalScale(30, 30, 30);
     app.root.addChild(roomEntity);
 
-    // Mini-Stats: add VRAM on top of default stats
+    // Mini-Stats with default options
     const msOptions = pc.MiniStats.getDefaultOptions();
-    msOptions.stats.push({
-        name: 'VRAM',
-        stats: ['vram.tex'],
-        decimalPlaces: 1,
-        multiplier: 1 / (1024 * 1024),
-        unitsName: 'MB',
-        watermark: 1024
-    });
     const miniStats = new pc.MiniStats(app, msOptions); // eslint-disable-line no-unused-vars
 
     // Create an Entity with a camera component

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -119,16 +119,8 @@ assetListLoader.load(() => {
     app.scene.skyboxMip = 1;
     app.scene.exposure = 1.5;
 
-    // Mini-Stats: add VRAM and gsplats on top of default stats
+    // Mini-Stats: add gsplats on top of default stats
     const msOptions = pc.MiniStats.getDefaultOptions();
-    msOptions.stats.push({
-        name: 'VRAM',
-        stats: ['vram.tex'],
-        decimalPlaces: 1,
-        multiplier: 1 / (1024 * 1024),
-        unitsName: 'MB',
-        watermark: 1024
-    });
     msOptions.stats.push({
         name: 'GSplats',
         stats: ['frame.gsplats'],

--- a/examples/src/examples/misc/mini-stats.example.mjs
+++ b/examples/src/examples/misc/mini-stats.example.mjs
@@ -97,10 +97,10 @@ options.stats = [
         unitsName: 'ms'
     },
 
-    // used VRAM, displayed using 2 colors - red for textures, green for geometry
+    // used VRAM in MB
     {
         name: 'VRAM',
-        stats: ['vram.tex', 'vram.geom'],
+        stats: ['vram.totalUsed'],
         decimalPlaces: 1,
         multiplier: 1 / (1024 * 1024),
         unitsName: 'MB',

--- a/src/extras/mini-stats/graph.js
+++ b/src/extras/mini-stats/graph.js
@@ -44,7 +44,7 @@ class Graph {
     update(ms) {
         const timings = this.timer.timings;
 
-        // calculate stacked total
+        // calculate total
         const total = timings.reduce((a, v) => a + v, 0);
 
         // update averages and max
@@ -63,14 +63,11 @@ class Graph {
         }
 
         if (this.enabled) {
-            // update timings
-            let value = 0;
+            // update total timing sample
             const range = 1.5 * this.watermark;
-            for (let i = 0; i < timings.length; ++i) {
-                // scale the value into the range
-                value += Math.floor(timings[i] / range * 255);
-                this.sample[i] = value;
-            }
+            this.sample[0] = Math.floor(total / range * 255);
+            this.sample[1] = 0;
+            this.sample[2] = 0;
 
             // .a store watermark
             this.sample[3] = this.watermark / range * 255;

--- a/src/extras/mini-stats/stats-timer.js
+++ b/src/extras/mini-stats/stats-timer.js
@@ -4,11 +4,8 @@ class StatsTimer {
         this.app = app;
         this.values = [];
 
-        // supporting up to 3 stats
+        // support one or more stats and accumulate them in the graph total
         this.statNames = statNames;
-        if (this.statNames.length > 3) {
-            this.statNames.length = 3;
-        }
 
         this.unitsName = unitsName;
         this.decimalPlaces = decimalPlaces;

--- a/src/framework/stats.js
+++ b/src/framework/stats.js
@@ -88,13 +88,19 @@ class ApplicationStats {
 
         Object.defineProperty(this.vram, 'totalUsed', {
             get: function () {
-                return this.tex + this.vb + this.ib;
+                return this.tex + this.vb + this.ib + this.ub + this.sb;
             }
         });
 
         Object.defineProperty(this.vram, 'geom', {
             get: function () {
                 return this.vb + this.ib;
+            }
+        });
+
+        Object.defineProperty(this.vram, 'buffers', {
+            get: function () {
+                return this.ub + this.sb;
             }
         });
     }


### PR DESCRIPTION
## Summary
- make MiniStats VRAM reporting first-class by tracking `vram.totalUsed` as `tex + vb + ib + ub + sb`, adding `vram.buffers`, and adding default VRAM display support
- remove stacked graph rendering and switch graphs to single-height rendering while introducing consistent category coloring for CPU, GPU, and other graphs
- add expandable VRAM subcategories (`tex`, `geom`, and WebGPU-only `buffers`) with matching MB units/watermarks, and align examples with default VRAM behavior

<img width="267" height="171" alt="Screenshot 2026-02-13 at 13 32 07" src="https://github.com/user-attachments/assets/acb244b2-88b7-4fd9-b393-dd332a6fbaff" />


<img width="258" height="616" alt="Screenshot 2026-02-13 at 13 57 38" src="https://github.com/user-attachments/assets/6c1e0466-3a7c-42cf-b64b-167ddef1a816" />

