### PR TITLE
Fix annotation hotspot sizing

### DIFF
--- a/scripts/esm/annotations.mjs
+++ b/scripts/esm/annotations.mjs
@@ -540,19 +540,19 @@ export class AnnotationManager extends Script {
     /**
      * Updates 3D rotation and scale of hotspot planes.
      * @param {Annotation} annotation - The annotation
+     * @param {number} viewDepth - The view-space depth (positive distance along the camera's forward direction)
      * @private
      */
-    _updateAnnotationRotationAndScale(annotation) {
+    _updateAnnotationRotationAndScale(annotation, viewDepth) {
         const cameraRotation = this._camera.getRotation();
         annotation.entity.setRotation(cameraRotation);
         annotation.entity.rotateLocal(90, 0, 0);
 
-        const cameraPos = this._camera.getPosition();
-        const distance = annotation.entity.getPosition().distance(cameraPos);
+        // Use view-space depth (not Euclidean distance) to match the projection matrix
         const canvas = this.app.graphicsDevice.canvas;
         const screenHeight = canvas.clientHeight;
         const projMatrix = this._camera.camera.projectionMatrix;
-        const worldSize = (this._hotspotSize / screenHeight) * (2 * distance / projMatrix.data[5]);
+        const worldSize = (this._hotspotSize / screenHeight) * (2 * viewDepth / projMatrix.data[5]);
 
         annotation.entity.setLocalScale(worldSize, worldSize, worldSize);
     }
@@ -902,7 +902,7 @@ export class AnnotationManager extends Script {
                 }
 
                 this._updateAnnotationPositions(annotation, resources, screenPos);
-                this._updateAnnotationRotationAndScale(annotation);
+                this._updateAnnotationRotationAndScale(annotation, -vec.z);
 
                 // Update material opacity
                 resources.materials[0].opacity = this._opacity;


### PR DESCRIPTION
## Summary

- Fix annotation hotspot scaling to use view-space depth instead of Euclidean distance, ensuring projection-correct sizing that matches the camera's perspective projection

## Details

### Annotation hotspot sizing

`_updateAnnotationRotationAndScale` previously computed the Euclidean distance between the camera and annotation positions to derive world-space hotspot size. This is incorrect because the projection matrix operates in view space — a point off to the side at the same depth would have a larger Euclidean distance but the same projected size. The fix passes the view-space depth (`-vec.z` from the view matrix transform) directly, producing stable hotspot sizes regardless of screen position.