### PR TITLE
Ensure camera clip planes are correctly applied during XR sessions

### DIFF
--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -268,6 +268,10 @@ class Camera {
             this._farClip = newValue;
             this._projMatDirty = true;
         }
+        if (this._xr?.active) {
+            this._xrProperties.farClip = newValue;
+            this._xr._setClipPlanes(this._xrProperties.nearClip, newValue);
+        }
     }
 
     get farClip() {
@@ -329,6 +333,10 @@ class Camera {
         if (this._nearClip !== newValue) {
             this._nearClip = newValue;
             this._projMatDirty = true;
+        }
+        if (this._xr?.active) {
+            this._xrProperties.nearClip = newValue;
+            this._xr._setClipPlanes(newValue, this._xrProperties.farClip);
         }
     }
 
@@ -764,10 +772,10 @@ class Camera {
      * @ignore
      */
     fillShaderParams(output) {
-        const f = this._farClip;
+        const f = this.farClip;
         output[0] = 1 / f;
         output[1] = f;
-        output[2] = this._nearClip;
+        output[2] = this.nearClip;
         output[3] = this._projection === PROJECTION_ORTHOGRAPHIC ? 1 : 0;
         return output;
     }


### PR DESCRIPTION
## Summary

- When `nearClip` or `farClip` are set while an XR session is active, the new values are now forwarded to `_xrProperties` and the XR manager's `_setClipPlanes`, allowing clip plane changes to take effect at runtime during XR
- `fillShaderParams` now reads from the public `nearClip`/`farClip` getters instead of the private `_nearClip`/`_farClip` backing fields, ensuring shader uniforms receive the XR-aware clip distances when XR is active

## Details

Previously, setting `camera.nearClip` or `camera.farClip` during an active XR session had two issues:

1. The new values were only stored in the private backing fields (`_nearClip`/`_farClip`) and were not propagated to `_xrProperties` or the XR session's depth configuration. This meant the XR runtime continued using stale clip plane values.
2. `fillShaderParams` read directly from the private backing fields, bypassing the getters that return XR-specific values when XR is active. This caused shader parameters (used for depth calculations) to be inconsistent with the actual projection matrices provided by the XR system.

## Test Plan

- Verify that changing `camera.nearClip` / `camera.farClip` during an active WebXR session correctly updates the XR depth planes
- Verify that depth-dependent shader effects (e.g., fog, depth-based post-processing) use the correct clip distances during XR
- Confirm no regression in non-XR rendering paths