### PR TITLE
Expose `dracoDecode` for decoder reuse

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -345,7 +345,7 @@ export { RenderPassPicker } from './framework/graphics/render-pass-picker.js';
 
 // FRAMEWORK / HANDLERS
 export { basisInitialize } from './framework/handlers/basis.js';
-export { dracoInitialize } from './framework/parsers/draco-decoder.js';
+export { dracoInitialize, dracoDecode } from './framework/parsers/draco-decoder.js';
 export { AnimClipHandler } from './framework/handlers/anim-clip.js';
 export { AnimStateGraphHandler } from './framework/handlers/anim-state-graph.js';
 export { AnimationHandler } from './framework/handlers/animation.js';


### PR DESCRIPTION
## Description
A small change that will allow users (me :D) to reuse the draco decoder. It's not really that useful for regular folks, but it can really come in clutch sometimes and it won't bother anyone I think anyway.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
