### PR TITLE
Fix WebGL readTextureAsync allocating too much memory for outputData

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2139,8 +2139,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         const needsRgbaReadback = rgbaChannels > 0;
 
         // Use caller's buffer or allocate output buffer in the user's expected format
-        const outputData = options.data ?? new (getPixelFormatArrayType(texture._format))(
-            TextureUtils.calcLevelGpuSize(width, height, 1, texture._format)
+        const ArrayType = getPixelFormatArrayType(texture._format);
+        const outputData = options.data ?? new ArrayType(
+            TextureUtils.calcLevelGpuSize(width, height, 1, texture._format) / ArrayType.BYTES_PER_ELEMENT
         );
 
         // For formats requiring RGBA readback, allocate a larger RGBA buffer


### PR DESCRIPTION
`readTextureAsync` passes the result of `TextureUtils.calcLevelGpuSize()` (which returns **bytes**) directly as the element count to a typed array constructor. For multi-byte element types this over-allocates by a factor of `BYTES_PER_ELEMENT` (e.g. 4× for `Float32Array`/`Uint32Array` formats, 2× for `Uint16Array` formats).

The fix divides the byte size by `ArrayType.BYTES_PER_ELEMENT` to produce the correct element count.