### PR TITLE
feat: Add BlockAllocator for 1D block memory management

### DIFF
--- a/src/core/block-allocator.js
+++ b/src/core/block-allocator.js
@@ -612,7 +612,7 @@ class BlockAllocator {
                 result.add(allocBlock);
                 i++;
 
-                // Continue from allocBlock (now to the left) to find more
+                // Continue from the block after freeBlock to find more opportunities
                 block = freeBlock._next;
             } else {
                 block = next;


### PR DESCRIPTION
## Summary

- Adds a general-purpose `BlockAllocator` class (`src/core/block-allocator.js`) for managing a 1D linear address space with contiguous block allocations
- Backed by a doubly-linked list with free-list threading for O(f) first-fit allocation and O(1) free with automatic neighbor merging
- Supports grow-only expansion, incremental defragmentation (hybrid relocate-last + slide-left), full single-pass compaction, and a batch `updateAllocation` API
- `MemBlock` handles are pooled to minimize GC pressure
- Includes O(1) fragmentation metric
- Comprehensive unit tests (35 tests) covering basic ops, merging, defrag, pool reuse, and stress tests with `Uint32Array` buffer integrity validation
