### PR TITLE
refactor: Extract NumericIds from PickerId for reusable ID generation

### DIFF
--- a/src/core/numeric-ids.js
+++ b/src/core/numeric-ids.js
@@ -1,0 +1,21 @@
+/**
+ * A sequential numeric ID generator. Each instance maintains its own independent counter,
+ * allowing separate ID spaces for different purposes.
+ *
+ * @ignore
+ */
+class NumericIds {
+    /** @type {number} */
+    _counter = 0;
+
+    /**
+     * Get the next unique ID.
+     *
+     * @returns {number} A unique sequential ID.
+     */
+    get() {
+        return this._counter++;
+    }
+}
+
+export { NumericIds };

--- a/src/scene/picker-id.js
+++ b/src/scene/picker-id.js
@@ -1,21 +1,12 @@
+import { NumericIds } from '../core/numeric-ids.js';
+
 /**
  * Centralized picker ID generator. Provides unique IDs for objects that need
  * to be identifiable during GPU-based picking operations.
  *
+ * @type {NumericIds}
  * @ignore
  */
-class PickerId {
-    /** @type {number} */
-    static _counter = 0;
-
-    /**
-     * Get the next unique picker ID.
-     *
-     * @returns {number} A unique picker ID.
-     */
-    static get() {
-        return this._counter++;
-    }
-}
+const PickerId = new NumericIds();
 
 export { PickerId };


### PR DESCRIPTION
## Summary

- Adds `NumericIds` class (`src/core/numeric-ids.js`) — a general-purpose sequential numeric ID generator that supports multiple independent instances
- Refactors `PickerId` to be a pre-created `NumericIds` instance, preserving the existing `PickerId.get()` API with no changes needed at call sites
