### PR TITLE
fix: Prevent setLayout from corrupting interval compaction data

### DIFF
--- a/src/scene/gsplat-unified/gsplat-world-state.js
+++ b/src/scene/gsplat-unified/gsplat-world-state.js
@@ -106,7 +106,7 @@ class GSplatWorldState {
             } else {
                 totalIntervals += 1;
             }
-            splat.setLayout(pixelOffset, this.textureSize, splat.activeSplats);
+            splat.setLayout(pixelOffset, this.textureSize);
             pixelOffset += splat.activeSplats;
         }
 


### PR DESCRIPTION
## Summary

- Fixes incorrect GPU frustum culling introduced by #8480 where `setLayout` mutated `this.intervals` by synthesizing a full-range interval, causing `uploadIntervals` in the GPU interval compaction to map all splats to a single bounds entry and lose per-node culling granularity
- Moves the interval synthesis into `updateSubDraws` as a local variable so `this.intervals` is never mutated and the compaction correctly falls back to `placementIntervals` for per-node bounds mapping
