### PR TITLE
perf: split viewDepth into separate depthBuffer for sort cache locality

### DIFF
--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -47,7 +47,7 @@ import computeSplatSource from '../shader-lib/wgsl/chunks/gsplat/vert/gsplatComp
 const TILE_SIZE = 16;
 const MAX_TILES = 65535; // tile index must fit in 16 bits for pair packing (tileIdx << 16 | localOffset)
 const INITIAL_TILE_ENTRY_MULTIPLIER = 1.5; // floor for _tileEntryMultiplier (min tile entries per splat)
-const CACHE_STRIDE = 8;
+const CACHE_STRIDE = 7;
 const MAX_CHUNKS_PER_TILE = 8;
 const SHRINK_THRESHOLD = 200; // consecutive low-usage readbacks before considering multiplier shrink
 const ENTRY_HEADROOM_MULTIPLIER = 1.5; // headroom factor applied to measured entry demand
@@ -158,8 +158,12 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
     /** @type {StorageBuffer|null} */
     _pairBuffer = null;
 
-    /** @type {StorageBuffer|null} */
-    _globalPairCounterBuffer = null;
+    /**
+     * Packed atomic counters: [0] = global pair counter, [1] = large splat count.
+     *
+     * @type {StorageBuffer|null}
+     */
+    _countersBuffer = null;
 
     /** @type {StorageBuffer|null} */
     _splatPairStartBuffer = null;
@@ -171,9 +175,6 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
 
     /** @type {StorageBuffer|null} */
     _largeSplatIdsBuffer = null;
-
-    /** @type {StorageBuffer|null} */
-    _largeSplatCountBuffer = null;
 
     /** @type {number} */
     _largeSplatIdsCapacity = INITIAL_LARGE_SPLAT_CAPACITY;
@@ -332,13 +333,13 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         this._chunkSortBindGroupFormat.destroy();
 
         this._projCacheBuffer?.destroy();
+        this._depthBuffer?.destroy();
         this._tileEntriesBuffer?.destroy();
         this._pairBuffer?.destroy();
-        this._globalPairCounterBuffer?.destroy();
+        this._countersBuffer?.destroy();
         this._splatPairStartBuffer?.destroy();
         this._splatPairCountBuffer?.destroy();
         this._largeSplatIdsBuffer?.destroy();
-        this._largeSplatCountBuffer?.destroy();
 
         this.tileComposite.destroy();
 
@@ -458,25 +459,22 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
 
         if (!canResize) return;
 
-        // Splat capacity (projCache + per-splat pair metadata)
+        // Splat capacity (projCache + depthBuffer + per-splat pair metadata)
         if (numSplats > this._allocatedSplatCapacity) {
             this._projCacheBuffer?.destroy();
+            this._depthBuffer?.destroy();
             this._splatPairStartBuffer?.destroy();
             this._splatPairCountBuffer?.destroy();
             this._allocatedSplatCapacity = numSplats;
             this._projCacheBuffer = new StorageBuffer(device, numSplats * CACHE_STRIDE * 4);
+            this._depthBuffer = new StorageBuffer(device, numSplats * 4);
             this._splatPairStartBuffer = new StorageBuffer(device, numSplats * 4);
             this._splatPairCountBuffer = new StorageBuffer(device, numSplats * 4);
         }
 
-        // Global pair counter (fixed size, allocated once)
-        if (!this._globalPairCounterBuffer) {
-            this._globalPairCounterBuffer = new StorageBuffer(device, 4, BUFFERUSAGE_COPY_DST);
-        }
-
-        // Large-splat count buffer (fixed size, allocated once)
-        if (!this._largeSplatCountBuffer) {
-            this._largeSplatCountBuffer = new StorageBuffer(device, 4, BUFFERUSAGE_COPY_DST | BUFFERUSAGE_COPY_SRC);
+        // Packed atomic counters: [0] = global pair counter, [1] = large splat count.
+        if (!this._countersBuffer) {
+            this._countersBuffer = new StorageBuffer(device, 8, BUFFERUSAGE_COPY_DST | BUFFERUSAGE_COPY_SRC);
         }
 
         // Large-splat ID buffer (grow-only)
@@ -611,19 +609,18 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
 
         // --- Pass 1: Per-tile count + projection cache + pair buffer writes ---
         set._tileSplatCountsBuffer.clear();
-        this._globalPairCounterBuffer.clear();
-        this._largeSplatCountBuffer.clear();
+        this._countersBuffer.clear();
 
         countCompute.setParameter('compactedSplatIds', this._compactedSplatIds);
         countCompute.setParameter('sortElementCount', this._sortElementCountBuffer);
         countCompute.setParameter('projCache', this._projCacheBuffer);
         countCompute.setParameter('tileSplatCounts', set._tileSplatCountsBuffer);
         countCompute.setParameter('pairBuffer', this._pairBuffer);
-        countCompute.setParameter('globalPairCounter', this._globalPairCounterBuffer);
+        countCompute.setParameter('countersBuffer', this._countersBuffer);
         countCompute.setParameter('splatPairStart', this._splatPairStartBuffer);
         countCompute.setParameter('splatPairCount', this._splatPairCountBuffer);
         countCompute.setParameter('largeSplatIds', this._largeSplatIdsBuffer);
-        countCompute.setParameter('largeSplatCount', this._largeSplatCountBuffer);
+        countCompute.setParameter('depthBuffer', this._depthBuffer);
         for (const stream of wb.format.streams) {
             countCompute.setParameter(stream.name, wb.getTexture(stream.name));
         }
@@ -661,7 +658,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         // Compute indirect dispatch dimensions for the large-splat pass (one workgroup
         // per large splat), then dispatch. Writes to the same tileSplatCounts, pairBuffer,
         // and splatPairStart/Count as the main count pass.
-        this._largeSplatPrepCompute.setParameter('largeSplatCount', this._largeSplatCountBuffer);
+        this._largeSplatPrepCompute.setParameter('countersBuffer', this._countersBuffer);
         this._largeSplatPrepCompute.setParameter('dispatchArgs', this._largeSplatDispatchBuffer);
         this._largeSplatPrepCompute.setParameter('largeSplatIds', this._largeSplatIdsBuffer);
         this._largeSplatPrepCompute.setupDispatch(1, 1, 1);
@@ -670,11 +667,10 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         set.largeSplatCompute.setParameter('projCache', this._projCacheBuffer);
         set.largeSplatCompute.setParameter('tileSplatCounts', set._tileSplatCountsBuffer);
         set.largeSplatCompute.setParameter('pairBuffer', this._pairBuffer);
-        set.largeSplatCompute.setParameter('globalPairCounter', this._globalPairCounterBuffer);
+        set.largeSplatCompute.setParameter('countersBuffer', this._countersBuffer);
         set.largeSplatCompute.setParameter('splatPairStart', this._splatPairStartBuffer);
         set.largeSplatCompute.setParameter('splatPairCount', this._splatPairCountBuffer);
         set.largeSplatCompute.setParameter('largeSplatIds', this._largeSplatIdsBuffer);
-        set.largeSplatCompute.setParameter('largeSplatCount', this._largeSplatCountBuffer);
         set.largeSplatCompute.setParameter('numTilesX', numTilesX);
         set.largeSplatCompute.setParameter('numTilesY', numTilesY);
         set.largeSplatCompute.setParameter('viewportWidth', width);
@@ -711,7 +707,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         set.largePlaceEntriesCompute.setParameter('tileSplatCounts', set._tileSplatCountsBuffer);
         set.largePlaceEntriesCompute.setParameter('tileEntries', this._tileEntriesBuffer);
         set.largePlaceEntriesCompute.setParameter('largeSplatIds', this._largeSplatIdsBuffer);
-        set.largePlaceEntriesCompute.setParameter('largeSplatCount', this._largeSplatCountBuffer);
+        set.largePlaceEntriesCompute.setParameter('countersBuffer', this._countersBuffer);
 
         set.largePlaceEntriesCompute.setupIndirectDispatch(0, this._largeSplatDispatchBuffer);
         device.computeDispatch([set.largePlaceEntriesCompute], pickMode ? 'GSplatPickLargePlaceEntries' : 'GSplatLocalLargePlaceEntries');
@@ -745,7 +741,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         set.bucketSortCompute.setParameter('tileEntries', this._tileEntriesBuffer);
         set.bucketSortCompute.setParameter('largeTileOverflowBases', set._largeTileOverflowBasesBuffer);
         set.bucketSortCompute.setParameter('tileSplatCounts', set._tileSplatCountsBuffer);
-        set.bucketSortCompute.setParameter('projCache', this._projCacheBuffer);
+        set.bucketSortCompute.setParameter('depthBuffer', this._depthBuffer);
         set.bucketSortCompute.setParameter('largeTileList', set._largeTileListBuffer);
         set.bucketSortCompute.setParameter('chunkRanges', set._chunkRangesBuffer);
         set.bucketSortCompute.setParameter('totalChunks', set._totalChunksBuffer);
@@ -768,7 +764,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         // --- Pass 4a: Small tile sort ---
         set.sortCompute.setParameter('tileEntries', this._tileEntriesBuffer);
         set.sortCompute.setParameter('tileSplatCounts', set._tileSplatCountsBuffer);
-        set.sortCompute.setParameter('projCache', this._projCacheBuffer);
+        set.sortCompute.setParameter('depthBuffer', this._depthBuffer);
         set.sortCompute.setParameter('smallTileList', set._smallTileListBuffer);
         set.sortCompute.setParameter('tileListCounts', set._tileListCountsBuffer);
 
@@ -777,7 +773,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
 
         // --- Pass 4c: Chunk sort ---
         set.chunkSortCompute.setParameter('tileEntries', this._tileEntriesBuffer);
-        set.chunkSortCompute.setParameter('projCache', this._projCacheBuffer);
+        set.chunkSortCompute.setParameter('depthBuffer', this._depthBuffer);
         set.chunkSortCompute.setParameter('chunkRanges', set._chunkRangesBuffer);
         set.chunkSortCompute.setParameter('totalChunks', set._totalChunksBuffer);
         set.chunkSortCompute.setParameter('maxChunks', numTiles * MAX_CHUNKS_PER_TILE);
@@ -819,6 +815,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         rasterizeCompute.setParameter('projCache', this._projCacheBuffer);
         rasterizeCompute.setParameter('rasterizeTileList', set._rasterizeTileListBuffer);
         rasterizeCompute.setParameter('tileListCounts', set._tileListCountsBuffer);
+        rasterizeCompute.setParameter('depthBuffer', this._depthBuffer);
         if (pickMode) {
             rasterizeCompute.setParameter('pickIdTexture', set.pickIdTexture);
             rasterizeCompute.setParameter('pickDepthTexture', set.pickDepthTexture);
@@ -851,7 +848,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
 
         const readback1 = set._tileSplatCountsBuffer.read(numTiles * 4, 4);
         const readback2 = set._tileListCountsBuffer.read(3 * 4, 4);
-        const readback3 = this._largeSplatCountBuffer.read(0, 4);
+        const readback3 = this._countersBuffer.read(4, 4);
 
         Promise.all([readback1, readback2, readback3]).then(([r1, r2, r3]) => {
             const totalEntries = new Uint32Array(r1.buffer, r1.byteOffset, 1)[0];
@@ -986,11 +983,10 @@ fn main() {
                 new BindStorageBufferFormat('projCache', SHADERSTAGE_COMPUTE, true),
                 new BindStorageBufferFormat('tileSplatCounts', SHADERSTAGE_COMPUTE),
                 new BindStorageBufferFormat('pairBuffer', SHADERSTAGE_COMPUTE),
-                new BindStorageBufferFormat('globalPairCounter', SHADERSTAGE_COMPUTE),
+                new BindStorageBufferFormat('countersBuffer', SHADERSTAGE_COMPUTE),
                 new BindStorageBufferFormat('splatPairStart', SHADERSTAGE_COMPUTE),
                 new BindStorageBufferFormat('splatPairCount', SHADERSTAGE_COMPUTE),
                 new BindStorageBufferFormat('largeSplatIds', SHADERSTAGE_COMPUTE, true),
-                new BindStorageBufferFormat('largeSplatCount', SHADERSTAGE_COMPUTE, true),
                 new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
             ]);
 
@@ -1004,17 +1000,17 @@ fn main() {
             });
         }
 
-        // --- Large-splat prep: reads largeSplatCount and computes indirect dispatch args ---
+        // --- Large-splat prep: reads countersBuffer[1] (large splat count) and computes indirect dispatch args ---
         {
             const maxDim = device.limits.maxComputeWorkgroupsPerDimension || 65535;
             const largePrepSource = /* wgsl */`
-@group(0) @binding(0) var<storage, read> largeSplatCount: array<u32>;
+@group(0) @binding(0) var<storage, read> countersBuffer: array<u32>;
 @group(0) @binding(1) var<storage, read_write> dispatchArgs: array<u32>;
 @group(0) @binding(2) var<storage, read> largeSplatIds: array<u32>;
 
 @compute @workgroup_size(1)
 fn main() {
-    let count = min(largeSplatCount[0], arrayLength(&largeSplatIds));
+    let count = min(countersBuffer[1], arrayLength(&largeSplatIds));
     let maxDim = ${maxDim}u;
     if (count <= maxDim) {
         dispatchArgs[0] = count;
@@ -1029,7 +1025,7 @@ fn main() {
 }
 `;
             this._largeSplatPrepBindGroupFormat = new BindGroupFormat(device, [
-                new BindStorageBufferFormat('largeSplatCount', SHADERSTAGE_COMPUTE, true),
+                new BindStorageBufferFormat('countersBuffer', SHADERSTAGE_COMPUTE, true),
                 new BindStorageBufferFormat('dispatchArgs', SHADERSTAGE_COMPUTE),
                 new BindStorageBufferFormat('largeSplatIds', SHADERSTAGE_COMPUTE, true)
             ]);
@@ -1052,7 +1048,7 @@ fn main() {
             new BindStorageBufferFormat('tileSplatCounts', SHADERSTAGE_COMPUTE, true),
             new BindStorageBufferFormat('tileEntries', SHADERSTAGE_COMPUTE),
             new BindStorageBufferFormat('largeSplatIds', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('largeSplatCount', SHADERSTAGE_COMPUTE, true)
+            new BindStorageBufferFormat('countersBuffer', SHADERSTAGE_COMPUTE, true)
         ]);
         this._largePlaceEntriesShader = new Shader(device, {
             name: 'GSplatLocalPlaceEntriesLarge',
@@ -1094,7 +1090,7 @@ fn main() {
         this._sortBindGroupFormat = new BindGroupFormat(device, [
             new BindStorageBufferFormat('tileEntries', SHADERSTAGE_COMPUTE),
             new BindStorageBufferFormat('tileSplatCounts', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('projCache', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('depthBuffer', SHADERSTAGE_COMPUTE, true),
             new BindStorageBufferFormat('smallTileList', SHADERSTAGE_COMPUTE, true),
             new BindStorageBufferFormat('tileListCounts', SHADERSTAGE_COMPUTE, true)
         ]);
@@ -1116,7 +1112,7 @@ fn main() {
                 new BindStorageBufferFormat('tileEntries', SHADERSTAGE_COMPUTE),
                 new BindStorageBufferFormat('largeTileOverflowBases', SHADERSTAGE_COMPUTE, true),
                 new BindStorageBufferFormat('tileSplatCounts', SHADERSTAGE_COMPUTE, true),
-                new BindStorageBufferFormat('projCache', SHADERSTAGE_COMPUTE, true),
+                new BindStorageBufferFormat('depthBuffer', SHADERSTAGE_COMPUTE, true),
                 new BindStorageBufferFormat('largeTileList', SHADERSTAGE_COMPUTE, true),
                 new BindStorageBufferFormat('chunkRanges', SHADERSTAGE_COMPUTE),
                 new BindStorageBufferFormat('totalChunks', SHADERSTAGE_COMPUTE),
@@ -1159,7 +1155,7 @@ fn main() {
             ]);
             this._chunkSortBindGroupFormat = new BindGroupFormat(device, [
                 new BindStorageBufferFormat('tileEntries', SHADERSTAGE_COMPUTE),
-                new BindStorageBufferFormat('projCache', SHADERSTAGE_COMPUTE, true),
+                new BindStorageBufferFormat('depthBuffer', SHADERSTAGE_COMPUTE, true),
                 new BindStorageBufferFormat('chunkRanges', SHADERSTAGE_COMPUTE, true),
                 new BindStorageBufferFormat('totalChunks', SHADERSTAGE_COMPUTE, true),
                 new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
@@ -1223,11 +1219,11 @@ fn main() {
             new BindStorageBufferFormat('tileSplatCounts', SHADERSTAGE_COMPUTE),
             new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE),
             new BindStorageBufferFormat('pairBuffer', SHADERSTAGE_COMPUTE),
-            new BindStorageBufferFormat('globalPairCounter', SHADERSTAGE_COMPUTE),
+            new BindStorageBufferFormat('countersBuffer', SHADERSTAGE_COMPUTE),
             new BindStorageBufferFormat('splatPairStart', SHADERSTAGE_COMPUTE),
             new BindStorageBufferFormat('splatPairCount', SHADERSTAGE_COMPUTE),
             new BindStorageBufferFormat('largeSplatIds', SHADERSTAGE_COMPUTE),
-            new BindStorageBufferFormat('largeSplatCount', SHADERSTAGE_COMPUTE)
+            new BindStorageBufferFormat('depthBuffer', SHADERSTAGE_COMPUTE)
         ];
 
         const bindGroupFormat = new BindGroupFormat(device, [

--- a/src/scene/gsplat-unified/gsplat-local-dispatch-set.js
+++ b/src/scene/gsplat-unified/gsplat-local-dispatch-set.js
@@ -334,7 +334,8 @@ class GSplatLocalDispatchSet {
             new BindStorageBufferFormat('tileSplatCounts', SHADERSTAGE_COMPUTE, true),
             new BindStorageBufferFormat('projCache', SHADERSTAGE_COMPUTE, true),
             new BindStorageBufferFormat('rasterizeTileList', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('tileListCounts', SHADERSTAGE_COMPUTE, true)
+            new BindStorageBufferFormat('tileListCounts', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('depthBuffer', SHADERSTAGE_COMPUTE, true)
         ];
 
         const outputBindings = pickMode ? [

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-bitonic.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-bitonic.js
@@ -2,7 +2,7 @@
 // Included by both the small-tile sort and chunk-sort shaders.
 // Expects the including shader to declare:
 //   var<storage, read_write> tileEntries: array<u32>;
-//   var<storage, read> projCache: array<u32>;
+//   var<storage, read> depthBuffer: array<u32>;
 export const computeGsplatLocalBitonicSource = /* wgsl */`
 
 const MAX_TILE_ENTRIES: u32 = 4096u;
@@ -10,7 +10,6 @@ const INDEX_BITS: u32 = 12u;
 const INDEX_MASK: u32 = 0xFFFu;
 const DEPTH_LEVELS: f32 = 1048575.0;
 const BITONIC_WG_SIZE: u32 = 256u;
-const CACHE_STRIDE: u32 = 8u;
 
 var<workgroup> sData: array<u32, 4096>;
 var<workgroup> sDepthMin: atomic<u32>;
@@ -42,7 +41,7 @@ fn bitonicSortRange(localIdx: u32, tStart: u32, count: u32) {
     for (var i: u32 = localIdx; i < sortN; i += BITONIC_WG_SIZE) {
         if (i < clampedCount) {
             let entryIdx = tileEntries[tStart + i];
-            sData[i] = projCache[entryIdx * CACHE_STRIDE + 7u];
+            sData[i] = depthBuffer[entryIdx];
         } else {
             sData[i] = 0xFFFFFFFFu;
         }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-bucket-sort.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-bucket-sort.js
@@ -11,12 +11,10 @@ export const computeGsplatLocalBucketSortSource = /* wgsl */`
 const NUM_BUCKETS: u32 = ${NUM_BUCKETS}u;
 const MAX_CHUNK_SIZE: u32 = 4096u;
 const WG_SIZE: u32 = 256u;
-const CACHE_STRIDE: u32 = 8u;
-
 @group(0) @binding(0) var<storage, read_write> tileEntries: array<u32>;
 @group(0) @binding(1) var<storage, read> largeTileOverflowBases: array<u32>;
 @group(0) @binding(2) var<storage, read> tileSplatCounts: array<u32>;
-@group(0) @binding(3) var<storage, read> projCache: array<u32>;
+@group(0) @binding(3) var<storage, read> depthBuffer: array<u32>;
 @group(0) @binding(4) var<storage, read> largeTileList: array<u32>;
 @group(0) @binding(5) var<storage, read_write> chunkRanges: array<u32>;
 @group(0) @binding(6) var<storage, read_write> totalChunks: array<atomic<u32>>;
@@ -71,7 +69,7 @@ fn main(
 
     for (var i: u32 = localIdx; i < count; i += WG_SIZE) {
         let entryIdx = tileEntries[tStart + i];
-        let depthU = projCache[entryIdx * CACHE_STRIDE + 7u];
+        let depthU = depthBuffer[entryIdx];
         atomicMin(&sDepthMin, depthU);
         atomicMax(&sDepthMax, depthU);
     }
@@ -94,7 +92,7 @@ fn main(
     // the main tileEntries range (which Phase 4 writes to).
     for (var i: u32 = localIdx; i < count; i += WG_SIZE) {
         let entryIdx = tileEntries[tStart + i];
-        let depth = bitcast<f32>(projCache[entryIdx * CACHE_STRIDE + 7u]);
+        let depth = bitcast<f32>(depthBuffer[entryIdx]);
         let bucket = min(u32((log(max(depth, 1e-6)) - logMin) * bucketScale), NUM_BUCKETS - 1u);
         atomicAdd(&sBucketCounts[bucket], 1u);
         tileEntries[overflowBase + i] = entryIdx;
@@ -116,7 +114,7 @@ fn main(
     // Read from overflow scratch, recompute bucket, scatter to tileEntries main range.
     for (var i: u32 = localIdx; i < count; i += WG_SIZE) {
         let entryIdx = tileEntries[overflowBase + i];
-        let depth = bitcast<f32>(projCache[entryIdx * CACHE_STRIDE + 7u]);
+        let depth = bitcast<f32>(depthBuffer[entryIdx]);
         let bucket = min(u32((log(max(depth, 1e-6)) - logMin) * bucketScale), NUM_BUCKETS - 1u);
         let writePos = sBucketOffsets[bucket] + atomicAdd(&sBucketCursors[bucket], 1u);
         tileEntries[tStart + writePos] = entryIdx;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-chunk-sort.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-chunk-sort.js
@@ -6,7 +6,7 @@ export const computeGsplatLocalChunkSortSource = /* wgsl */`
 #include "gsplatLocalBitonicCS"
 
 @group(0) @binding(0) var<storage, read_write> tileEntries: array<u32>;
-@group(0) @binding(1) var<storage, read> projCache: array<u32>;
+@group(0) @binding(1) var<storage, read> depthBuffer: array<u32>;
 @group(0) @binding(2) var<storage, read> chunkRanges: array<u32>;
 @group(0) @binding(3) var<storage, read> totalChunks: array<u32>;
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-place-entries-large.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-place-entries-large.js
@@ -17,7 +17,7 @@ const WG_SIZE: u32 = 256u;
 @group(0) @binding(3) var<storage, read> tileSplatCounts: array<u32>;
 @group(0) @binding(4) var<storage, read_write> tileEntries: array<u32>;
 @group(0) @binding(5) var<storage, read> largeSplatIds: array<u32>;
-@group(0) @binding(6) var<storage, read> largeSplatCount: array<u32>;
+@group(0) @binding(6) var<storage, read> countersBuffer: array<u32>;
 
 @compute @workgroup_size(256)
 fn main(
@@ -26,7 +26,7 @@ fn main(
     @builtin(local_invocation_index) lid: u32
 ) {
     let largeSplatIdx = wgId.y * numWorkgroups.x + wgId.x;
-    let numLarge = min(largeSplatCount[0], arrayLength(&largeSplatIds));
+    let numLarge = min(countersBuffer[1], arrayLength(&largeSplatIds));
     if (largeSplatIdx >= numLarge) {
         return;
     }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-rasterize.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-rasterize.js
@@ -12,7 +12,7 @@ export const computeGsplatLocalRasterizeSource = /* wgsl */`
     #endif
 #endif
 
-const CACHE_STRIDE: u32 = 8u;
+const CACHE_STRIDE: u32 = 7u;
 const BATCH_SIZE: u32 = 64u;
 const WORKGROUP_SIZE: u32 = 64u;
 const ALPHA_THRESHOLD: half = half(1.0) / half(255.0);
@@ -41,15 +41,16 @@ struct Uniforms {
 @group(0) @binding(3) var<storage, read> projCache: array<u32>;
 @group(0) @binding(4) var<storage, read> rasterizeTileList: array<u32>;
 @group(0) @binding(5) var<storage, read> tileListCounts: array<u32>;
+@group(0) @binding(6) var<storage, read> depthBuffer: array<u32>;
 
 // Mode-specific output textures appended after the shared bindings.
 #ifdef PICK_MODE
-    @group(0) @binding(6) var pickIdTexture: texture_storage_2d<r32uint, write>;
-    @group(0) @binding(7) var pickDepthTexture: texture_storage_2d<rgba16float, write>;
+    @group(0) @binding(7) var pickIdTexture: texture_storage_2d<r32uint, write>;
+    @group(0) @binding(8) var pickDepthTexture: texture_storage_2d<rgba16float, write>;
 #else
-    @group(0) @binding(6) var outputTexture: texture_storage_2d<rgba16float, write>;
+    @group(0) @binding(7) var outputTexture: texture_storage_2d<rgba16float, write>;
     #ifdef DEPTH_TEST
-        @group(0) @binding(7) var sceneDepthMap: texture_2d<f32>;
+        @group(0) @binding(8) var sceneDepthMap: texture_2d<f32>;
     #endif
 #endif
 
@@ -209,13 +210,13 @@ fn main(
             #ifdef PICK_MODE
                 sharedPickId[localIdx] = projCache[base + 5u];
                 sharedOpacity[localIdx] = half(unpack2x16float(projCache[base + 6u]).y);
-                sharedViewDepth[localIdx] = bitcast<f32>(projCache[base + 7u]);
+                sharedViewDepth[localIdx] = bitcast<f32>(depthBuffer[cacheIdx]);
             #else
                 let rg = unpack2x16float(projCache[base + 5u]);
                 let ba = unpack2x16float(projCache[base + 6u]);
 
                 #if FOG != NONE
-                    let viewDepth = bitcast<f32>(projCache[base + 7u]);
+                    let viewDepth = bitcast<f32>(depthBuffer[cacheIdx]);
                     #if (FOG == LINEAR)
                         let fogFactor = evaluateFogFactorLinear(viewDepth, uniforms.fog_start, uniforms.fog_end);
                     #elif (FOG == EXP)
@@ -231,7 +232,7 @@ fn main(
                 #endif
 
                 #ifdef DEPTH_TEST
-                    sharedViewDepth[localIdx] = bitcast<f32>(projCache[base + 7u]);
+                    sharedViewDepth[localIdx] = bitcast<f32>(depthBuffer[cacheIdx]);
                 #endif
             #endif
         }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count-large.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count-large.js
@@ -17,18 +17,17 @@ export const computeGsplatLocalTileCountLargeSource = /* wgsl */`
 #include "gsplatCommonCS"
 #include "gsplatTileIntersectCS"
 
-const CACHE_STRIDE: u32 = 8u;
+const CACHE_STRIDE: u32 = 7u;
 const WG_SIZE: u32 = 256u;
 const MAX_TILE_ENTRIES: u32 = 0xFFFFu;
 
 @group(0) @binding(0) var<storage, read> projCache: array<u32>;
 @group(0) @binding(1) var<storage, read_write> tileSplatCounts: array<atomic<u32>>;
 @group(0) @binding(2) var<storage, read_write> pairBuffer: array<u32>;
-@group(0) @binding(3) var<storage, read_write> globalPairCounter: array<atomic<u32>>;
+@group(0) @binding(3) var<storage, read_write> countersBuffer: array<atomic<u32>>;
 @group(0) @binding(4) var<storage, read_write> splatPairStart: array<u32>;
 @group(0) @binding(5) var<storage, read_write> splatPairCount: array<u32>;
 @group(0) @binding(6) var<storage, read> largeSplatIds: array<u32>;
-@group(0) @binding(7) var<storage, read> largeSplatCount: array<u32>;
 
 struct Uniforms {
     numTilesX: u32,
@@ -37,7 +36,7 @@ struct Uniforms {
     viewportHeight: f32,
     alphaClip: f32,
 }
-@group(0) @binding(8) var<uniform> uniforms: Uniforms;
+@group(0) @binding(7) var<uniform> uniforms: Uniforms;
 
 var<workgroup> wgPairCounts: array<u32, WG_SIZE>;
 var<workgroup> wgPairOffsets: array<u32, WG_SIZE>;
@@ -50,42 +49,55 @@ fn main(
     @builtin(local_invocation_index) lid: u32
 ) {
     let largeSplatIdx = wgId.y * numWorkgroups.x + wgId.x;
-    let count = min(largeSplatCount[0], arrayLength(&largeSplatIds));
-    if (largeSplatIdx >= count) {
-        return;
-    }
+    let count = min(atomicLoad(&countersBuffer[1]), arrayLength(&largeSplatIds));
 
-    let threadIdx = largeSplatIds[largeSplatIdx];
+    // atomicLoad is non-uniform per WGSL rules, so early return would make
+    // subsequent workgroupBarrier calls non-uniform. Use an active flag instead;
+    // inactive workgroups still participate in barriers but skip all real work.
+    let isActive = largeSplatIdx < count;
 
-    let cacheBase = threadIdx * CACHE_STRIDE;
-    let screen = vec2f(bitcast<f32>(projCache[cacheBase + 0u]), bitcast<f32>(projCache[cacheBase + 1u]));
-    let cx = bitcast<f32>(projCache[cacheBase + 2u]);
-    let cy = bitcast<f32>(projCache[cacheBase + 3u]);
-    let cz = bitcast<f32>(projCache[cacheBase + 4u]);
-    let opacity = unpack2x16float(projCache[cacheBase + 6u]).y;
-
-    let eval = computeSplatTileEval(screen, cx, cy, cz, half(opacity),
-                                    uniforms.viewportWidth, uniforms.viewportHeight,
-                                    uniforms.alphaClip);
-    let radiusFactor = eval.radiusFactor;
-
-    let minTileX = max(0i, i32(floor(eval.splatMin.x / f32(TILE_SIZE))));
-    let maxTileX = min(i32(uniforms.numTilesX) - 1i, i32(floor(eval.splatMax.x / f32(TILE_SIZE))));
-    let minTileY = max(0i, i32(floor(eval.splatMin.y / f32(TILE_SIZE))));
-    let maxTileY = min(i32(uniforms.numTilesY) - 1i, i32(floor(eval.splatMax.y / f32(TILE_SIZE))));
-
-    // Guard against degenerate AABBs where maxTile < minTile. This can happen
-    // when capScale-driven radius shrinkage makes the tile-eval AABB smaller than
-    // the frustum-cull AABB. The u32 cast of the negative difference would wrap
-    // to ~4 billion, causing the tile loops to iterate for millions of iterations
-    // per thread and hang the GPU.
+    var threadIdx = u32(0);
+    var minTileX = 0i;
+    var maxTileX = 0i;
+    var minTileY = 0i;
+    var maxTileY = 0i;
     var aabbW = u32(0);
-    var aabbH = u32(0);
     var totalTiles = u32(0);
-    if (maxTileX >= minTileX && maxTileY >= minTileY) {
-        aabbW = u32(maxTileX - minTileX + 1i);
-        aabbH = u32(maxTileY - minTileY + 1i);
-        totalTiles = aabbW * aabbH;
+    var screen = vec2f(0.0);
+    var cx = 0.0f;
+    var cy = 0.0f;
+    var cz = 0.0f;
+    var radiusFactor = 0.0f;
+
+    if (isActive) {
+        threadIdx = largeSplatIds[largeSplatIdx];
+
+        let cacheBase = threadIdx * CACHE_STRIDE;
+        screen = vec2f(bitcast<f32>(projCache[cacheBase + 0u]), bitcast<f32>(projCache[cacheBase + 1u]));
+        cx = bitcast<f32>(projCache[cacheBase + 2u]);
+        cy = bitcast<f32>(projCache[cacheBase + 3u]);
+        cz = bitcast<f32>(projCache[cacheBase + 4u]);
+        let opacity = unpack2x16float(projCache[cacheBase + 6u]).y;
+
+        let eval = computeSplatTileEval(screen, cx, cy, cz, half(opacity),
+                                        uniforms.viewportWidth, uniforms.viewportHeight,
+                                        uniforms.alphaClip);
+        radiusFactor = eval.radiusFactor;
+
+        minTileX = max(0i, i32(floor(eval.splatMin.x / f32(TILE_SIZE))));
+        maxTileX = min(i32(uniforms.numTilesX) - 1i, i32(floor(eval.splatMax.x / f32(TILE_SIZE))));
+        minTileY = max(0i, i32(floor(eval.splatMin.y / f32(TILE_SIZE))));
+        maxTileY = min(i32(uniforms.numTilesY) - 1i, i32(floor(eval.splatMax.y / f32(TILE_SIZE))));
+
+        // Guard against degenerate AABBs where maxTile < minTile. This can happen
+        // when capScale-driven radius shrinkage makes the tile-eval AABB smaller than
+        // the frustum-cull AABB. The u32 cast of the negative difference would wrap
+        // to ~4 billion, causing the tile loops to iterate for millions of iterations
+        // per thread and hang the GPU.
+        if (maxTileX >= minTileX && maxTileY >= minTileY) {
+            aabbW = u32(maxTileX - minTileX + 1i);
+            totalTiles = aabbW * u32(maxTileY - minTileY + 1i);
+        }
     }
 
     // --- Phase 1: each thread counts its intersecting tiles ---
@@ -106,14 +118,14 @@ fn main(
     wgPairCounts[lid] = myHitCount;
     workgroupBarrier();
 
-    if (lid == 0u) {
+    if (lid == 0u && isActive) {
         var sum: u32 = 0u;
         for (var i: u32 = 0u; i < WG_SIZE; i++) {
             wgPairOffsets[i] = sum;
             sum += wgPairCounts[i];
         }
         if (sum > 0u) {
-            wgBase = atomicAdd(&globalPairCounter[0], sum);
+            wgBase = atomicAdd(&countersBuffer[0], sum);
         } else {
             wgBase = 0u;
         }
@@ -146,7 +158,7 @@ fn main(
     // If any pairs were dropped by the cap, correct the stored count via workgroup sum.
     wgPairCounts[lid] = j;
     workgroupBarrier();
-    if (lid == 0u) {
+    if (lid == 0u && isActive) {
         var actualTotal: u32 = 0u;
         for (var i: u32 = 0u; i < WG_SIZE; i++) {
             actualTotal += wgPairCounts[i];

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js
@@ -24,7 +24,7 @@ export const computeGsplatLocalTileCountSource = /* wgsl */`
 #include "gsplatCommonCS"
 #include "gsplatTileIntersectCS"
 
-const CACHE_STRIDE: u32 = 8u;
+const CACHE_STRIDE: u32 = 7u;
 const WG_SIZE: u32 = 256u;
 
 // Caps the 16-bit localOffset field in packed pairs (tileIdx << 16 | localOffset).
@@ -73,12 +73,13 @@ struct Uniforms {
 // Pair buffer bindings for the scatter-free approach.
 // pairBuffer stores packed (tileIdx << 16 | localOffset) per splat-tile intersection.
 // splatPairStart/splatPairCount let the PlaceEntries pass locate each splat's pairs.
+// countersBuffer packs two atomic counters: [0] = global pair counter, [1] = large splat count.
 @group(0) @binding(5) var<storage, read_write> pairBuffer: array<u32>;
-@group(0) @binding(6) var<storage, read_write> globalPairCounter: array<atomic<u32>>;
+@group(0) @binding(6) var<storage, read_write> countersBuffer: array<atomic<u32>>;
 @group(0) @binding(7) var<storage, read_write> splatPairStart: array<u32>;
 @group(0) @binding(8) var<storage, read_write> splatPairCount: array<u32>;
 @group(0) @binding(9) var<storage, read_write> largeSplatIds: array<u32>;
-@group(0) @binding(10) var<storage, read_write> largeSplatCount: array<atomic<u32>>;
+@group(0) @binding(10) var<storage, read_write> depthBuffer: array<u32>;
 
 #include "gsplatComputeSplatCS"
 #include "gsplatFormatDeclCS"
@@ -173,7 +174,7 @@ fn main(
                 projCache[base + 6u] = pack2x16float(vec2f(rgb.z, opacity));
             #endif
 
-                projCache[base + 7u] = bitcast<u32>(proj.viewDepth);
+                depthBuffer[threadIdx] = bitcast<u32>(proj.viewDepth);
 
                 screen = proj.screen;
                 let eval = computeSplatTileEval(screen, cx, cy, cz, half(opacity),
@@ -199,7 +200,7 @@ fn main(
                 var deferredToLarge = false;
                 if (maxTileX >= minTileX && maxTileY >= minTileY &&
                     aabbW * u32(maxTileY - minTileY + 1i) > LARGE_AABB_THRESHOLD) {
-                    let idx = atomicAdd(&largeSplatCount[0], 1u);
+                    let idx = atomicAdd(&countersBuffer[1], 1u);
                     if (idx < arrayLength(&largeSplatIds)) {
                         largeSplatIds[idx] = threadIdx;
                         deferredToLarge = true;
@@ -262,7 +263,7 @@ fn main(
             sum += wgPairCounts[i];
         }
         if (sum > 0u) {
-            wgBase = atomicAdd(&globalPairCounter[0], sum);
+            wgBase = atomicAdd(&countersBuffer[0], sum);
         } else {
             wgBase = 0u;
         }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-sort.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-sort.js
@@ -6,7 +6,7 @@ export const computeGsplatLocalTileSortSource = /* wgsl */`
 
 @group(0) @binding(0) var<storage, read_write> tileEntries: array<u32>;
 @group(0) @binding(1) var<storage, read> tileSplatCounts: array<u32>;
-@group(0) @binding(2) var<storage, read> projCache: array<u32>;
+@group(0) @binding(2) var<storage, read> depthBuffer: array<u32>;
 @group(0) @binding(3) var<storage, read> smallTileList: array<u32>;
 @group(0) @binding(4) var<storage, read> tileListCounts: array<u32>;
 


### PR DESCRIPTION
Splits `viewDepth` out of `projCache` into a dedicated parallel `depthBuffer`, improving sort pass cache behavior for zero additional memory cost.

**Changes:**
- Reduce `CACHE_STRIDE` from 8 to 7 by removing `viewDepth` from `projCache` slot 7
- Add a parallel `depthBuffer` (1 u32 per splat) written during tile count, read by all sort and rasterize passes
- Sort passes (bitonic, bucket sort, chunk sort) now read depth via stride-1 `depthBuffer[entryIdx]` instead of stride-8 `projCache[entryIdx * 8 + 7]`, eliminating cache thrashing on random depth lookups
- Merge `globalPairCounter` and `largeSplatCount` into a single `countersBuffer[2]` to stay within the WebGPU 10 storage-buffer-per-stage limit on Metal
- Restructure large tile count shader to use `isActive` flag instead of early return, required for WGSL uniform control flow with `atomicLoad`-derived bounds

**Performance:**
- Bucket sort: 0.6ms → 0.2ms (3x improvement)
- Tile sort: 1.3ms → 1.2ms
- Total frame: 8.5ms → 8.2ms (~3.5% improvement)
- Measured on 17M-splat scene, zero memory overhead (projCache shrinks by exactly the amount depthBuffer adds)