### PR TITLE
perf: per-node granular SH color updates with angle-based threshold

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
@@ -110,10 +110,7 @@ assetListLoader.load(() => {
     app.scene.gsplat.lodUnderfillLimit = config.lodUnderfillLimit;
 
     // set up SH update parameters
-    app.scene.gsplat.colorUpdateDistance = 1;
-    app.scene.gsplat.colorUpdateAngle = 4;
-    app.scene.gsplat.colorUpdateDistanceLodScale = 2;
-    app.scene.gsplat.colorUpdateAngleLodScale = 2;
+    app.scene.gsplat.colorUpdateAngle = 10;
 
     data.on('renderer:set', () => {
         app.scene.gsplat.renderer = data.get('renderer');

--- a/examples/src/examples/gaussian-splatting/world.example.mjs
+++ b/examples/src/examples/gaussian-splatting/world.example.mjs
@@ -103,10 +103,7 @@ assetListLoader.load(() => {
     app.scene.gsplat.lodUnderfillLimit = config.lodUnderfillLimit;
 
     // set up SH update parameters
-    app.scene.gsplat.colorUpdateDistance = 1;
-    app.scene.gsplat.colorUpdateAngle = 4;
-    app.scene.gsplat.colorUpdateDistanceLodScale = 2;
-    app.scene.gsplat.colorUpdateAngleLodScale = 2;
+    app.scene.gsplat.colorUpdateAngle = 10;
 
     data.on('renderer:set', () => {
         app.scene.gsplat.renderer = data.get('renderer');

--- a/src/scene/gsplat-unified/gsplat-info.js
+++ b/src/scene/gsplat-unified/gsplat-info.js
@@ -13,6 +13,7 @@ import { TextureUtils } from '../../platform/graphics/texture-utils.js';
  * @import { GSplatStreams } from "../gsplat/gsplat-streams.js"
  * @import { GraphNode } from '../graph-node.js';
  * @import { GSplatOctreeNode } from './gsplat-octree-node.js';
+ * @import { NodeInfo } from './gsplat-octree-instance.js';
  * @import { ScopeId } from '../../platform/graphics/scope-id.js';
  */
 
@@ -157,12 +158,9 @@ class GSplatInfo {
      * Per-node info array from the octree instance, providing allocId for each node.
      * Indexed by nodeIndex. Null for non-octree splats.
      *
-     * @type {Array<{allocId: number}>|null}
+     * @type {NodeInfo[]|null}
      */
     nodeInfos = null;
-
-    /** @type {number} */
-    colorAccumulatedRotation = 0;
 
     /** @type {number} */
     colorAccumulatedTranslation = 0;
@@ -206,7 +204,7 @@ class GSplatInfo {
      * @param {GSplatPlacement} placement - The placement of the splat.
      * @param {Function|null} [consumeRenderDirty] - Callback to consume render dirty flag.
      * @param {GSplatOctreeNode[]|null} [octreeNodes] - Octree nodes for bounds lookup.
-     * @param {Array<{allocId: number}>|null} [nodeInfos] - Per-node info array from octree instance.
+     * @param {NodeInfo[]|null} [nodeInfos] - Per-node info array from octree instance.
      */
     constructor(device, resource, placement, consumeRenderDirty = null, octreeNodes = null, nodeInfos = null) {
         Debug.assert(resource);
@@ -450,14 +448,6 @@ class GSplatInfo {
         const renderDirty = this._consumeRenderDirty ? this._consumeRenderDirty() : false;
 
         return worldMatrixChanged || renderDirty;
-    }
-
-    resetColorAccumulators(colorUpdateAngle, colorUpdateDistance) {
-        // Use a single random factor (0 to 1) for both accumulators to keep them synchronized
-        // This ensures rotation and translation thresholds trigger at similar rates
-        const randomFactor = Math.random();
-        this.colorAccumulatedRotation = randomFactor * colorUpdateAngle;
-        this.colorAccumulatedTranslation = randomFactor * colorUpdateDistance;
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -939,6 +939,7 @@ class GSplatManager {
 
         // Calculate camera movement deltas for color updates
         const { translationDelta } = this.calculateColorCameraDeltas();
+        const hasCameraMovement = translationDelta > 0;
 
         // check each splat for full or color update
         let uploadedBlocks = 0;
@@ -961,7 +962,7 @@ class GSplatManager {
                 // Splat moved, need to re-sort
                 this.sortNeeded = true;
 
-            } else if (splat.hasSphericalHarmonics) {
+            } else if (hasCameraMovement && splat.hasSphericalHarmonics) {
 
                 _splatsWithSH.push(splat);
 

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -43,8 +43,11 @@ const invModelMat = new Mat4();
 const tempNonOctreePlacements = new Set();
 const tempOctreePlacements = new Set();
 const _updatedSplats = [];
-const _splatsNeedingColorUpdate = [];
-const _cameraDeltas = { rotationDelta: 0, translationDelta: 0 };
+const _splatsWithSH = [];
+const _changedColorAllocIds = new Set();
+const _cameraDeltas = { translationDelta: 0 };
+const _localCamPos = new Vec3();
+const _closestPt = new Vec3();
 const tempOctreesTicked = new Set();
 const _queuedSplats = new Set();
 
@@ -310,9 +313,6 @@ class GSplatManager {
 
     /** @type {Vec3} */
     lastColorUpdateCameraPos = new Vec3(Infinity, Infinity, Infinity);
-
-    /** @type {Vec3} */
-    lastColorUpdateCameraFwd = new Vec3(Infinity, Infinity, Infinity);
 
     /** @type {GraphNode} */
     cameraNode;
@@ -679,14 +679,10 @@ class GSplatManager {
             this.lastWorldStateVersion++;
             const splats = [];
 
-            // color update thresholds
-            const { colorUpdateAngle, colorUpdateDistance } = this.scene.gsplat;
-
             // add standalone splats
             for (const p of this.layerPlacements) {
                 p.ensureInstanceStreams(this.device);
                 const splatInfo = new GSplatInfo(this.device, p.resource, p, p.consumeRenderDirty.bind(p));
-                splatInfo.resetColorAccumulators(colorUpdateAngle, colorUpdateDistance);
                 splats.push(splatInfo);
             }
 
@@ -698,7 +694,6 @@ class GSplatManager {
                         const octreeNodes = p.intervals.size > 0 ? inst.octree.nodes : null;
                         const nodeInfos = octreeNodes ? inst.nodeInfos : null;
                         const splatInfo = new GSplatInfo(this.device, p.resource, p, p.consumeRenderDirty.bind(p), octreeNodes, nodeInfos);
-                        splatInfo.resetColorAccumulators(colorUpdateAngle, colorUpdateDistance);
                         splats.push(splatInfo);
                     }
                 });
@@ -849,12 +844,9 @@ class GSplatManager {
             this.workBuffer.render(splatsToRender, this.cameraNode, this.getDebugColors(), changedAllocIds);
         }
 
-        // update all splats to sync their transforms and reset color accumulators
-        // (prevents redundant re-render later)
-        const { colorUpdateAngle, colorUpdateDistance } = this.scene.gsplat;
+        // update all splats to sync their transforms (prevents redundant re-render later)
         for (let i = 0; i < worldState.splats.length; i++) {
             worldState.splats[i].update();
-            worldState.splats[i].resetColorAccumulators(colorUpdateAngle, colorUpdateDistance);
         }
 
         // update camera tracking for color updates
@@ -941,10 +933,12 @@ class GSplatManager {
      */
     applyWorkBufferUpdates(state) {
         // color update thresholds
-        const { colorUpdateAngle, colorUpdateDistance, colorUpdateDistanceLodScale, colorUpdateAngleLodScale } = this.scene.gsplat;
+        const { colorUpdateAngle } = this.scene.gsplat;
+        const ratio = Math.tan(colorUpdateAngle * math.DEG_TO_RAD);
+        const cameraPos = this.cameraNode.getPosition();
 
         // Calculate camera movement deltas for color updates
-        const { rotationDelta, translationDelta } = this.calculateColorCameraDeltas();
+        const { translationDelta } = this.calculateColorCameraDeltas();
 
         // check each splat for full or color update
         let uploadedBlocks = 0;
@@ -955,30 +949,49 @@ class GSplatManager {
                 _updatedSplats.push(splat);
                 uploadedBlocks += splat.intervalAllocIds.length;
 
-                // Reset accumulators for fully updated splats
-                splat.resetColorAccumulators(colorUpdateAngle, colorUpdateDistance);
+                // Reset all node accumulators for this splat
+                if (splat.nodeInfos) {
+                    for (const ni of splat.intervalNodeIndices) {
+                        splat.nodeInfos[ni].colorAccumulatedTranslation = 0;
+                    }
+                } else {
+                    splat.colorAccumulatedTranslation = 0;
+                }
 
                 // Splat moved, need to re-sort
                 this.sortNeeded = true;
 
             } else if (splat.hasSphericalHarmonics) {
 
-                // Otherwise, check if color needs updating (accumulator-based)
-                // Add this frame's camera movement to accumulators
-                splat.colorAccumulatedRotation += rotationDelta;
-                splat.colorAccumulatedTranslation += translationDelta;
+                _splatsWithSH.push(splat);
 
-                // Apply LOD-based scaling to thresholds
-                const lodIndex = splat.lodIndex ?? 0;
-                const distThreshold = colorUpdateDistance * Math.pow(colorUpdateDistanceLodScale, lodIndex);
-                const angleThreshold = colorUpdateAngle * Math.pow(colorUpdateAngleLodScale, lodIndex);
-
-                // Trigger update if either threshold exceeded
-                if (splat.colorAccumulatedRotation >= angleThreshold ||
-                    splat.colorAccumulatedTranslation >= distThreshold) {
-                    _splatsNeedingColorUpdate.push(splat);
-                    uploadedBlocks += splat.intervalAllocIds.length;
-                    splat.resetColorAccumulators(angleThreshold, distThreshold);
+                if (splat.nodeInfos) {
+                    // Per-node accumulation for octree splats
+                    const nodeIndices = splat.intervalNodeIndices;
+                    for (let j = 0; j < nodeIndices.length; j++) {
+                        const nodeInfo = splat.nodeInfos[nodeIndices[j]];
+                        nodeInfo.colorAccumulatedTranslation += translationDelta;
+                        const threshold = ratio * Math.max(1, nodeInfo.worldDistance);
+                        if (nodeInfo.colorAccumulatedTranslation >= threshold) {
+                            _changedColorAllocIds.add(splat.intervalAllocIds[j]);
+                            nodeInfo.colorAccumulatedTranslation = 0;
+                            uploadedBlocks++;
+                        }
+                    }
+                } else {
+                    // Non-octree: per-splat accumulation with AABB distance scaling
+                    splat.colorAccumulatedTranslation += translationDelta;
+                    invModelMat.copy(splat.node.getWorldTransform()).invert();
+                    invModelMat.transformPoint(cameraPos, _localCamPos);
+                    splat.aabb.closestPoint(_localCamPos, _closestPt);
+                    const dist = _localCamPos.distance(_closestPt) *
+                        splat.node.getWorldTransform().getScale().x;
+                    const threshold = ratio * Math.max(1, dist);
+                    if (splat.colorAccumulatedTranslation >= threshold) {
+                        _changedColorAllocIds.add(splat.allocId);
+                        uploadedBlocks += splat.intervalAllocIds.length;
+                        splat.colorAccumulatedTranslation = 0;
+                    }
                 }
             }
         });
@@ -993,11 +1006,15 @@ class GSplatManager {
             _updatedSplats.length = 0;
         }
 
-        // Batch render color updates for all splats that exceeded thresholds
-        if (_splatsNeedingColorUpdate.length > 0) {
-            this.workBuffer.renderColor(_splatsNeedingColorUpdate, this.cameraNode, this.getDebugColors());
-            _splatsNeedingColorUpdate.length = 0;
+        // Batch render color updates for nodes that exceeded angle thresholds
+        if (_changedColorAllocIds.size > 0) {
+            this.workBuffer.renderColor(
+                _splatsWithSH, this.cameraNode, this.getDebugColors(),
+                _changedColorAllocIds
+            );
+            _changedColorAllocIds.clear();
         }
+        _splatsWithSH.length = 0;
     }
 
     /**
@@ -1093,7 +1110,6 @@ class GSplatManager {
      */
     updateColorCameraTracking() {
         this.lastColorUpdateCameraPos.copy(this.cameraNode.getPosition());
-        this.lastColorUpdateCameraFwd.copy(this.cameraNode.forward);
     }
 
     /**
@@ -1123,24 +1139,16 @@ class GSplatManager {
     }
 
     /**
-     * Calculates camera movement deltas since last color update.
+     * Calculates camera translation delta since last color update.
      * Updates and returns the shared _cameraDeltas object.
      *
-     * @returns {{ rotationDelta: number, translationDelta: number }} Shared camera movement deltas object
+     * @returns {{ translationDelta: number }} Shared camera movement deltas object
      */
     calculateColorCameraDeltas() {
-        _cameraDeltas.rotationDelta = 0;
         _cameraDeltas.translationDelta = 0;
 
         // Skip delta calculation on first frame (camera position not yet initialized)
         if (isFinite(this.lastColorUpdateCameraPos.x)) {
-            // Calculate rotation delta in degrees using dot product
-            const currentCameraFwd = this.cameraNode.forward;
-            const dot = Math.min(1, Math.max(-1,
-                this.lastColorUpdateCameraFwd.dot(currentCameraFwd)));
-            _cameraDeltas.rotationDelta = Math.acos(dot) * math.RAD_TO_DEG;
-
-            // Calculate translation delta in world units
             const currentCameraPos = this.cameraNode.getPosition();
             _cameraDeltas.translationDelta = this.lastColorUpdateCameraPos.distance(currentCameraPos);
         }

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -61,6 +61,12 @@ class NodeInfo {
     worldDistance = 0;
 
     /**
+     * Accumulated camera translation for SH color update threshold tracking.
+     * @type {number}
+     */
+    colorAccumulatedTranslation = 0;
+
+    /**
      * Back-reference to owning GSplatOctreeInstance.
      * @type {GSplatOctreeInstance|null}
      */
@@ -1001,4 +1007,4 @@ class GSplatOctreeInstance {
     }
 }
 
-export { GSplatOctreeInstance };
+export { GSplatOctreeInstance, NodeInfo };

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../core/debug.js';
 import {
     PIXELFORMAT_R32U, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA16U,
     PIXELFORMAT_RGBA32U, PIXELFORMAT_RG32U
@@ -480,51 +481,55 @@ class GSplatParams {
     /**
      * Enables debug colorization to visualize when spherical harmonics are evaluated.
      * When true, each update pass renders with a random color to visualize the behavior
-     * of colorUpdateDistance and colorUpdateAngle thresholds. Defaults to false.
+     * of colorUpdateAngle thresholds. Defaults to false.
      *
      * @type {boolean}
      */
     colorizeColorUpdate = false;
 
     /**
-     * Distance threshold in world units for triggering spherical harmonics color updates.
-     * Used to control how often SH evaluation occurs based on camera translation.
-     * Only affects resources with spherical harmonics data. Set to 0 to update on
-     * every frame where camera moves. Defaults to 0.2.
+     * Viewing angle threshold in degrees for triggering spherical harmonics color updates.
+     * When the camera translates enough to change the viewing angle to an octree node or
+     * splat by this amount, its SH colors are re-evaluated. Distant nodes naturally update
+     * less frequently since they require more camera movement to reach the angle threshold.
+     * Set to 0 to update every frame where camera moves. Defaults to 10.
      *
      * @type {number}
      */
-    colorUpdateDistance = 0.2;
+    colorUpdateAngle = 10;
 
-    /**
-     * Angle threshold in degrees for triggering spherical harmonics color updates.
-     * Used to control how often SH evaluation occurs based on camera rotation.
-     * Only affects resources with spherical harmonics data. Set to 0 to update on
-     * every frame where camera rotates. Defaults to 2.
-     *
-     * @type {number}
-     */
-    colorUpdateAngle = 2;
+    /** @ignore */
+    set colorUpdateDistance(value) {
+        Debug.removed('GSplatParams#colorUpdateDistance is removed. Use colorUpdateAngle instead.');
+    }
 
-    /**
-     * Scale factor applied to colorUpdateDistance for each LOD level.
-     * Each LOD level multiplies the threshold by this value raised to the power of lodIndex.
-     * For example, with scale=2: LOD 0 uses 1x threshold, LOD 1 uses 2x, LOD 2 uses 4x.
-     * Higher values relax thresholds more aggressively for distant geometry. Defaults to 2.
-     *
-     * @type {number}
-     */
-    colorUpdateDistanceLodScale = 2;
+    /** @ignore */
+    get colorUpdateDistance() {
+        Debug.removed('GSplatParams#colorUpdateDistance is removed. Use colorUpdateAngle instead.');
+        return 0;
+    }
 
-    /**
-     * Scale factor applied to colorUpdateAngle for each LOD level.
-     * Each LOD level multiplies the threshold by this value raised to the power of lodIndex.
-     * For example, with scale=2: LOD 0 uses 1x threshold, LOD 1 uses 2x, LOD 2 uses 4x.
-     * Higher values relax thresholds more aggressively for distant geometry. Defaults to 2.
-     *
-     * @type {number}
-     */
-    colorUpdateAngleLodScale = 2;
+    /** @ignore */
+    set colorUpdateDistanceLodScale(value) {
+        Debug.removed('GSplatParams#colorUpdateDistanceLodScale is removed. Per-node distance scaling is now automatic.');
+    }
+
+    /** @ignore */
+    get colorUpdateDistanceLodScale() {
+        Debug.removed('GSplatParams#colorUpdateDistanceLodScale is removed. Per-node distance scaling is now automatic.');
+        return 0;
+    }
+
+    /** @ignore */
+    set colorUpdateAngleLodScale(value) {
+        Debug.removed('GSplatParams#colorUpdateAngleLodScale is removed. Per-node distance scaling is now automatic.');
+    }
+
+    /** @ignore */
+    get colorUpdateAngleLodScale() {
+        Debug.removed('GSplatParams#colorUpdateAngleLodScale is removed. Per-node distance scaling is now automatic.');
+        return 0;
+    }
 
     /**
      * Sets the alpha threshold below which splats are discarded during shadow, pick, and prepass

--- a/src/scene/gsplat-unified/gsplat-work-buffer.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer.js
@@ -348,10 +348,10 @@ class GSplatWorkBuffer {
      * @param {GraphNode} cameraNode - The camera node.
      * @param {number[][]|undefined} colorsByLod - Array of RGB colors per LOD. Index by lodIndex; if a
      * shorter array is provided, index 0 will be reused as fallback.
+     * @param {Set<number>|null} [changedAllocIds] - Set of changed allocIds for partial render.
      */
-    renderColor(splats, cameraNode, colorsByLod) {
-        // render only color using color-only render pass
-        if (this.colorRenderPass.update(splats, cameraNode, colorsByLod)) {
+    renderColor(splats, cameraNode, colorsByLod, changedAllocIds = null) {
+        if (this.colorRenderPass.update(splats, cameraNode, colorsByLod, changedAllocIds)) {
             this.colorRenderPass.render();
         }
     }


### PR DESCRIPTION
Dramatically reduces GPU cost of spherical harmonics color updates by moving from per-splat to per-octree-node granularity and using the existing partial rendering mechanism.

**Changes:**
- SH color updates now operate at per-octree-node granularity instead of per-splat, using `changedAllocIds` partial rendering to only re-evaluate nodes that exceed their viewing angle threshold
- Distant nodes naturally update less frequently since more camera translation is needed to change the viewing angle by the threshold amount
- Non-octree splats use AABB closest-point distance for threshold scaling

**API Changes:**
- `colorUpdateAngle` repurposed: now controls the viewing angle threshold in degrees for SH re-evaluation (default: 10). Previously controlled camera rotation threshold.
- `colorUpdateDistance` removed (`Debug.removed` stub, suggests `colorUpdateAngle`)
- `colorUpdateDistanceLodScale` removed (`Debug.removed` stub, per-node scaling is automatic)
- `colorUpdateAngleLodScale` removed (`Debug.removed` stub, per-node scaling is automatic)

**Examples:**
- Updated `world.example.mjs` and `lod-streaming-sh.example.mjs` to use `colorUpdateAngle`

**Performance:**
- For scenes with ~50 splats / ~50K octree nodes / 40M splats, this reduces `GSplatWorkBufferRenderPass` GPU traffic from re-evaluating all splats to only nearby nodes whose viewing angle changed, eliminating the texture cache limiter bottleneck during camera movement
- With LOD forced to level 0 (all 40M splats active), SH update cost dropped from ~10ms to <1ms per frame