### PR TITLE
perf: optimize tile-count pass with multi-splat threads and extract dispatch prep shaders

### DIFF
--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -20,6 +20,8 @@ import { Color } from '../../core/math/color.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { GSplatRenderer } from './gsplat-renderer.js';
 import { FramePassGSplatComputeLocal } from './frame-pass-gsplat-compute-local.js';
+import { computeGsplatLocalDispatchPrepSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-dispatch-prep.js';
+import { computeGsplatLocalDispatchPrepLargeSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-dispatch-prep-large.js';
 import { computeGsplatLocalTileCountSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js';
 import { computeGsplatLocalTileCountLargeSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count-large.js';
 import { computeGsplatLocalPlaceEntriesSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-place-entries.js';
@@ -48,6 +50,9 @@ const TILE_SIZE = 16;
 const MAX_TILES = 65535; // tile index must fit in 16 bits for pair packing (tileIdx << 16 | localOffset)
 const INITIAL_TILE_ENTRY_MULTIPLIER = 1.5; // floor for _tileEntryMultiplier (min tile entries per splat)
 const CACHE_STRIDE = 7;
+// Splats processed per thread in the tile-count pass. Higher values reduce workgroup count
+// (lowering launch limiter) but increase register pressure (lowering occupancy).
+const SPLATS_PER_THREAD = 8;
 const MAX_CHUNKS_PER_TILE = 8;
 const SHRINK_THRESHOLD = 200; // consecutive low-usage readbacks before considering multiplier shrink
 const ENTRY_HEADROOM_MULTIPLIER = 1.5; // headroom factor applied to measured entry demand
@@ -599,9 +604,9 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         const createCountShader = (pick, fisheye) => this._createCountShaderAndFormat(pick, fisheye);
         const countCompute = set.getCountCompute(fisheyeEnabled, createCountShader);
 
-        // Prep dispatch: compute indirect dispatch dimensions from the visible count
-        // (sortElementCount[0]). Both the count and place-entries passes use @workgroup_size(256),
-        // so they share the same dispatch args.
+        // Prep dispatch: compute indirect dispatch dimensions from the visible count.
+        // Writes two dispatch slots: slot 0 for tile-count (2 splats/thread, half workgroups),
+        // slot 1 for place-entries (1 splat/thread, full workgroups).
         this._placeEntryPrepCompute.setParameter('sortElementCount', this._sortElementCountBuffer);
         this._placeEntryPrepCompute.setParameter('dispatchArgs', this._placeEntryPrepDispatchBuffer);
         this._placeEntryPrepCompute.setupDispatch(1, 1, 1);
@@ -695,8 +700,8 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         set.placeEntriesCompute.setParameter('tileEntries', this._tileEntriesBuffer);
         set.placeEntriesCompute.setParameter('sortElementCount', this._sortElementCountBuffer);
 
-        // Reuse the same indirect dispatch buffer from the prep pass above.
-        set.placeEntriesCompute.setupIndirectDispatch(0, this._placeEntryPrepDispatchBuffer);
+        // Slot 1 of the prep buffer holds the full (1 splat/thread) dispatch dimensions.
+        set.placeEntriesCompute.setupIndirectDispatch(1, this._placeEntryPrepDispatchBuffer);
         device.computeDispatch([set.placeEntriesCompute], pickMode ? 'GSplatPickPlaceEntries' : 'GSplatLocalPlaceEntries');
 
         // --- Pass 3b: Cooperative place entries for large splats ---
@@ -931,27 +936,13 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         // device-level indirect dispatch buffer written earlier in the frame. ---
         {
             const maxDim = device.limits.maxComputeWorkgroupsPerDimension || 65535;
-            const prepSource = /* wgsl */`
-@group(0) @binding(0) var<storage, read> sortElementCount: array<u32>;
-@group(0) @binding(1) var<storage, read_write> dispatchArgs: array<u32>;
+            const splatsPerWg = 256 * SPLATS_PER_THREAD;
+            const prepDefines = new Map();
+            prepDefines.set('{MAX_DIM}', maxDim.toString());
+            prepDefines.set('{SPLATS_PER_WG}', splatsPerWg.toString());
+            prepDefines.set('{SPLATS_PER_WG_MINUS_1}', (splatsPerWg - 1).toString());
+            prepDefines.set('{SPLATS_PER_THREAD}', SPLATS_PER_THREAD.toString());
 
-@compute @workgroup_size(1)
-fn main() {
-    let count = sortElementCount[0];
-    let wgCount = (count + 255u) / 256u;
-    let maxDim = ${maxDim}u;
-    if (wgCount <= maxDim) {
-        dispatchArgs[0] = wgCount;
-        dispatchArgs[1] = 1u;
-    } else {
-        let y = (wgCount + maxDim - 1u) / maxDim;
-        let x = (wgCount + y - 1u) / y;
-        dispatchArgs[0] = x;
-        dispatchArgs[1] = y;
-    }
-    dispatchArgs[2] = 1u;
-}
-`;
             this._placeEntryPrepBindGroupFormat = new BindGroupFormat(device, [
                 new BindStorageBufferFormat('sortElementCount', SHADERSTAGE_COMPUTE, true),
                 new BindStorageBufferFormat('dispatchArgs', SHADERSTAGE_COMPUTE)
@@ -959,11 +950,12 @@ fn main() {
             this._placeEntryPrepShader = new Shader(device, {
                 name: 'GSplatLocalPlaceEntryPrep',
                 shaderLanguage: SHADERLANGUAGE_WGSL,
-                cshader: prepSource,
+                cshader: computeGsplatLocalDispatchPrepSource,
+                cdefines: prepDefines,
                 computeBindGroupFormat: this._placeEntryPrepBindGroupFormat
             });
 
-            this._placeEntryPrepDispatchBuffer = new StorageBuffer(device, 3 * 4, BUFFERUSAGE_INDIRECT);
+            this._placeEntryPrepDispatchBuffer = new StorageBuffer(device, 6 * 4, BUFFERUSAGE_INDIRECT);
             this._placeEntryPrepCompute = new Compute(device, this._placeEntryPrepShader);
         }
 
@@ -1003,27 +995,9 @@ fn main() {
         // --- Large-splat prep: reads countersBuffer[1] (large splat count) and computes indirect dispatch args ---
         {
             const maxDim = device.limits.maxComputeWorkgroupsPerDimension || 65535;
-            const largePrepSource = /* wgsl */`
-@group(0) @binding(0) var<storage, read> countersBuffer: array<u32>;
-@group(0) @binding(1) var<storage, read_write> dispatchArgs: array<u32>;
-@group(0) @binding(2) var<storage, read> largeSplatIds: array<u32>;
+            const largePrepDefines = new Map();
+            largePrepDefines.set('{MAX_DIM}', maxDim.toString());
 
-@compute @workgroup_size(1)
-fn main() {
-    let count = min(countersBuffer[1], arrayLength(&largeSplatIds));
-    let maxDim = ${maxDim}u;
-    if (count <= maxDim) {
-        dispatchArgs[0] = count;
-        dispatchArgs[1] = 1u;
-    } else {
-        let y = (count + maxDim - 1u) / maxDim;
-        let x = (count + y - 1u) / y;
-        dispatchArgs[0] = x;
-        dispatchArgs[1] = y;
-    }
-    dispatchArgs[2] = 1u;
-}
-`;
             this._largeSplatPrepBindGroupFormat = new BindGroupFormat(device, [
                 new BindStorageBufferFormat('countersBuffer', SHADERSTAGE_COMPUTE, true),
                 new BindStorageBufferFormat('dispatchArgs', SHADERSTAGE_COMPUTE),
@@ -1032,7 +1006,8 @@ fn main() {
             this._largeSplatPrepShader = new Shader(device, {
                 name: 'GSplatLocalLargeSplatPrep',
                 shaderLanguage: SHADERLANGUAGE_WGSL,
-                cshader: largePrepSource,
+                cshader: computeGsplatLocalDispatchPrepLargeSource,
+                cdefines: largePrepDefines,
                 computeBindGroupFormat: this._largeSplatPrepBindGroupFormat
             });
 
@@ -1237,6 +1212,7 @@ fn main() {
         cincludes.set('gsplatFormatReadCS', wbFormat.getReadCode());
 
         const cdefines = new Map();
+        cdefines.set('{SPLATS_PER_THREAD}', SPLATS_PER_THREAD.toString());
         if (fisheyeEnabled) {
             cdefines.set('GSPLAT_FISHEYE', '');
         }

--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -605,7 +605,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         const countCompute = set.getCountCompute(fisheyeEnabled, createCountShader);
 
         // Prep dispatch: compute indirect dispatch dimensions from the visible count.
-        // Writes two dispatch slots: slot 0 for tile-count (2 splats/thread, half workgroups),
+        // Writes two dispatch slots: slot 0 for tile-count (SPLATS_PER_THREAD splats/thread),
         // slot 1 for place-entries (1 splat/thread, full workgroups).
         this._placeEntryPrepCompute.setParameter('sortElementCount', this._sortElementCountBuffer);
         this._placeEntryPrepCompute.setParameter('dispatchArgs', this._placeEntryPrepDispatchBuffer);

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-dispatch-prep-large.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-dispatch-prep-large.js
@@ -1,0 +1,24 @@
+// Tiny 1-thread shader that reads the large-splat count from countersBuffer[1] and
+// computes indirect dispatch args for the cooperative large-splat tile-count pass.
+export const computeGsplatLocalDispatchPrepLargeSource = /* wgsl */`
+
+@group(0) @binding(0) var<storage, read> countersBuffer: array<u32>;
+@group(0) @binding(1) var<storage, read_write> dispatchArgs: array<u32>;
+@group(0) @binding(2) var<storage, read> largeSplatIds: array<u32>;
+
+@compute @workgroup_size(1)
+fn main() {
+    let count = min(countersBuffer[1], arrayLength(&largeSplatIds));
+    let maxDim = {MAX_DIM}u;
+    if (count <= maxDim) {
+        dispatchArgs[0] = count;
+        dispatchArgs[1] = 1u;
+    } else {
+        let y = (count + maxDim - 1u) / maxDim;
+        let x = (count + y - 1u) / y;
+        dispatchArgs[0] = x;
+        dispatchArgs[1] = y;
+    }
+    dispatchArgs[2] = 1u;
+}
+`;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-dispatch-prep.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-dispatch-prep.js
@@ -1,0 +1,40 @@
+// Tiny 1-thread shader that reads the visible splat count and writes indirect dispatch
+// args for both the tile-count pass and the place-entries pass. This avoids relying on
+// the device-level indirect dispatch buffer written earlier in the frame.
+export const computeGsplatLocalDispatchPrepSource = /* wgsl */`
+
+@group(0) @binding(0) var<storage, read> sortElementCount: array<u32>;
+@group(0) @binding(1) var<storage, read_write> dispatchArgs: array<u32>;
+
+@compute @workgroup_size(1)
+fn main() {
+    let count = sortElementCount[0];
+    let maxDim = {MAX_DIM}u;
+
+    // Slot 0: tile-count pass ({SPLATS_PER_THREAD} splats per thread)
+    let countWg = (count + {SPLATS_PER_WG_MINUS_1}u) / {SPLATS_PER_WG}u;
+    if (countWg <= maxDim) {
+        dispatchArgs[0] = countWg;
+        dispatchArgs[1] = 1u;
+    } else {
+        let y = (countWg + maxDim - 1u) / maxDim;
+        let x = (countWg + y - 1u) / y;
+        dispatchArgs[0] = x;
+        dispatchArgs[1] = y;
+    }
+    dispatchArgs[2] = 1u;
+
+    // Slot 1: place-entries pass (1 splat per thread)
+    let placeWg = (count + 255u) / 256u;
+    if (placeWg <= maxDim) {
+        dispatchArgs[3] = placeWg;
+        dispatchArgs[4] = 1u;
+    } else {
+        let y = (placeWg + maxDim - 1u) / maxDim;
+        let x = (placeWg + y - 1u) / y;
+        dispatchArgs[3] = x;
+        dispatchArgs[4] = y;
+    }
+    dispatchArgs[5] = 1u;
+}
+`;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js
@@ -115,11 +115,10 @@ fn main(
     var cyArr: array<f32, {SPLATS_PER_THREAD}>;
     var czArr: array<f32, {SPLATS_PER_THREAD}>;
     var radiusFactorArr: array<f32, {SPLATS_PER_THREAD}>;
-    var aabbWArr: array<u32, {SPLATS_PER_THREAD}>;
 
     for (var i: u32 = 0u; i < {SPLATS_PER_THREAD}; i++) {
-        maxTileXArr[i] = -1i;
-        maxTileYArr[i] = -1i;
+        pairCounts[i] = 0u;
+        bitmasks[i] = 0u;
     }
 
     // =========================================================================
@@ -206,7 +205,6 @@ fn main(
                 maxTileXArr[s] = maxTileX;
                 minTileYArr[s] = minTileY;
                 maxTileYArr[s] = maxTileY;
-                aabbWArr[s] = aabbW;
 
                 // Defer large splats to the cooperative large-splat pass where
                 // 256 threads process them in parallel, avoiding wavefront divergence.

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js
@@ -1,21 +1,24 @@
 // Per-splat projection + projection cache write + atomic per-tile counting + pair buffer writes.
 //
-// This pass merges what was previously two separate dispatches (count + scatter) into one.
-// The old scatter pass re-read projCache and recomputed tile intersections just to place
-// splat indices into per-tile entry lists via global atomics — redundant and expensive.
+// Each thread processes SPLATS_PER_THREAD consecutive splats to reduce workgroup count and
+// amortize launch overhead. At 40M splats the launch limiter was 74% at N=1, meaning the GPU
+// spent 3/4 of its time scheduling workgroups instead of running them.
 //
-// New approach: iterate tiles twice within the same dispatch.
-//   Loop 1 (count-only): counts overlapping tiles per splat and builds a 6x5 bitmask
-//     recording which tiles passed the intersection test. Pure ALU, no atomics.
-//   Workgroup barrier: prefix sum over per-thread pair counts, then one global atomicAdd
-//     per workgroup to allocate a contiguous block in the pair buffer.
-//   Loop 2 (count + pair-write): performs atomicAdd on tileSplatCounts and writes
-//     (tileIdx, localOffset) pairs to the pair buffer. Uses the bitmask to skip intersection
-//     recomputation for AABBs within 6x5 tiles (covers ~95% of splats). Larger AABBs use
-//     the bitmask for the first 6x5 region and recompute intersection for the remainder.
+// Hybrid architecture: per-thread atomicAdd for pair buffer reservation (no barrier, no
+// shared memory) combined with register arrays to keep all Phase 2 data in registers,
+// avoiding projCache reads that cause L1 cache pressure.
 //
-// All projection data (screen, cx/cy/cz, radiusFactor, tile AABB) persists in registers
-// across the workgroup barrier, so the second loop only re-evaluates cheap bitmask lookups.
+// Bitmask: 8x4 = 32 bits in a single u32. The bit index localY * 8 + localX compiles
+// to a pure shift (localY << 3 | localX). Tiles outside the 8x4 region fall back to
+// intersection recomputation. Splats over 64 tiles are deferred to the cooperative
+// large-splat pass.
+//
+// Structure:
+//   Phase 1 — loop over N splats: project, write projCache/depthBuffer, count tiles,
+//             build bitmask. All per-splat state stored in register arrays.
+//   Atomic  — one atomicAdd per thread to reserve pair buffer space (no barrier).
+//   Phase 2 — for each splat, write pairs using register arrays and bitmask.
+//             Zero projCache reads — all data stays in registers.
 //
 // The pair buffer is later consumed by a lightweight PlaceEntries pass that writes
 // tileEntries using prefix-summed offsets — zero atomics, zero projCache reads.
@@ -25,15 +28,14 @@ export const computeGsplatLocalTileCountSource = /* wgsl */`
 #include "gsplatTileIntersectCS"
 
 const CACHE_STRIDE: u32 = 7u;
-const WG_SIZE: u32 = 256u;
 
 // Caps the 16-bit localOffset field in packed pairs (tileIdx << 16 | localOffset).
 const MAX_TILE_ENTRIES: u32 = 0xFFFFu;
 
-// 6x5 = 30 bits fits in a single u32 bitmask. Covers ~95% of splats without needing
-// to recompute the intersection test in the second tile loop.
-const BITMASK_W: u32 = 6u;
-const BITMASK_H: u32 = 5u;
+// 8x4 = 32 bits fits in a single u32 bitmask. The bit index localY * 8 + localX
+// compiles to a pure shift (localY << 3 | localX), avoiding any multiply.
+const BITMASK_W: u32 = 8u;
+const BITMASK_H: u32 = 4u;
 
 // Splats whose AABB exceeds this many tiles are deferred to a cooperative
 // large-splat pass where 256 threads handle them in parallel, eliminating
@@ -85,13 +87,6 @@ struct Uniforms {
 #include "gsplatFormatDeclCS"
 #include "gsplatFormatReadCS"
 
-// Shared memory for workgroup-level pair buffer allocation.
-// Each thread publishes its pair count; a serial prefix sum computes offsets;
-// the leader thread reserves a contiguous global block with a single atomicAdd.
-var<workgroup> wgPairCounts: array<u32, WG_SIZE>;
-var<workgroup> wgPairOffsets: array<u32, WG_SIZE>;
-var<workgroup> wgBase: u32;
-
 // NOTE on tile entry cap: if a tile exceeds MAX_TILE_ENTRIES (65535), the atomicAdd
 // count overcounts. Impact: the prefix sum allocates extra tileEntries slots that go
 // unwritten (wasting capacity), and the rasterize pass processes stale/zero entries in
@@ -102,34 +97,46 @@ var<workgroup> wgBase: u32;
 @compute @workgroup_size(256)
 fn main(
     @builtin(global_invocation_id) gid: vec3u,
-    @builtin(num_workgroups) numWorkgroups: vec3u,
-    @builtin(local_invocation_index) localIdx: u32
+    @builtin(num_workgroups) numWorkgroups: vec3u
 ) {
-    let threadIdx = gid.y * (numWorkgroups.x * 256u) + gid.x;
+    let baseIdx = (gid.y * (numWorkgroups.x * 256u) + gid.x) * {SPLATS_PER_THREAD};
     let numVisible = sortElementCount[0];
 
-    // Threads beyond numVisible still participate in the workgroup prefix sum
-    // and barrier — they just contribute zero pairs.
-    var myPairCount: u32 = 0u;
-    var bitmask: u32 = 0u;
-    var minTileX: i32 = 0i;
-    var maxTileX: i32 = -1i;
-    var minTileY: i32 = 0i;
-    var maxTileY: i32 = -1i;
-    var screen: vec2f = vec2f(0.0);
-    var cx: f32 = 0.0;
-    var cy: f32 = 0.0;
-    var cz: f32 = 0.0;
-    var radiusFactor: f32 = 0.0;
-    var aabbW: u32 = 0u;
-    var isVisible: bool = false;
+    // Per-splat state persisted across the atomic reservation in register arrays.
+    // The compiler unrolls the constant-bound loops and promotes these to registers.
+    var pairCounts: array<u32, {SPLATS_PER_THREAD}>;
+    var bitmasks: array<u32, {SPLATS_PER_THREAD}>;
+    var minTileXArr: array<i32, {SPLATS_PER_THREAD}>;
+    var maxTileXArr: array<i32, {SPLATS_PER_THREAD}>;
+    var minTileYArr: array<i32, {SPLATS_PER_THREAD}>;
+    var maxTileYArr: array<i32, {SPLATS_PER_THREAD}>;
+    var screenArr: array<vec2f, {SPLATS_PER_THREAD}>;
+    var cxArr: array<f32, {SPLATS_PER_THREAD}>;
+    var cyArr: array<f32, {SPLATS_PER_THREAD}>;
+    var czArr: array<f32, {SPLATS_PER_THREAD}>;
+    var radiusFactorArr: array<f32, {SPLATS_PER_THREAD}>;
+    var aabbWArr: array<u32, {SPLATS_PER_THREAD}>;
 
-    if (threadIdx < numVisible) {
+    for (var i: u32 = 0u; i < {SPLATS_PER_THREAD}; i++) {
+        maxTileXArr[i] = -1i;
+        maxTileYArr[i] = -1i;
+    }
+
+    // =========================================================================
+    // Phase 1: Project + count tiles for all splats
+    // =========================================================================
+    var totalPairs: u32 = 0u;
+
+    for (var s: u32 = 0u; s < {SPLATS_PER_THREAD}; s++) {
+        let threadIdx = baseIdx + s;
+        if (threadIdx >= numVisible) { continue; }
+
         let splatId = compactedSplatIds[threadIdx];
-
         setSplat(splatId);
         let center = getCenter();
         let opacity = getOpacity();
+
+        var isVisible = false;
 
         if (opacity >= uniforms.alphaClip) {
             let rotation = half4(getRotation());
@@ -152,9 +159,9 @@ fn main(
 
                 let det = proj.a * proj.c - proj.b * proj.b;
                 let invDet = 1.0 / det;
-                cx = 4.0 * proj.c * invDet;
-                cy = -4.0 * proj.b * invDet;
-                cz = 4.0 * proj.a * invDet;
+                let cx = 4.0 * proj.c * invDet;
+                let cy = -4.0 * proj.b * invDet;
+                let cz = 4.0 * proj.a * invDet;
 
                 let base = threadIdx * CACHE_STRIDE;
                 projCache[base + 0u] = bitcast<u32>(proj.screen.x);
@@ -176,18 +183,30 @@ fn main(
 
                 depthBuffer[threadIdx] = bitcast<u32>(proj.viewDepth);
 
-                screen = proj.screen;
+                let screen = proj.screen;
                 let eval = computeSplatTileEval(screen, cx, cy, cz, half(opacity),
                                                 uniforms.viewportWidth, uniforms.viewportHeight,
                                                 uniforms.alphaClip);
-                radiusFactor = eval.radiusFactor;
+                let radiusFactor = eval.radiusFactor;
 
-                minTileX = max(0i, i32(floor(eval.splatMin.x / f32(TILE_SIZE))));
-                maxTileX = min(i32(uniforms.numTilesX) - 1i, i32(floor(eval.splatMax.x / f32(TILE_SIZE))));
-                minTileY = max(0i, i32(floor(eval.splatMin.y / f32(TILE_SIZE))));
-                maxTileY = min(i32(uniforms.numTilesY) - 1i, i32(floor(eval.splatMax.y / f32(TILE_SIZE))));
+                let minTileX = max(0i, i32(floor(eval.splatMin.x / f32(TILE_SIZE))));
+                let maxTileX = min(i32(uniforms.numTilesX) - 1i, i32(floor(eval.splatMax.x / f32(TILE_SIZE))));
+                let minTileY = max(0i, i32(floor(eval.splatMin.y / f32(TILE_SIZE))));
+                let maxTileY = min(i32(uniforms.numTilesY) - 1i, i32(floor(eval.splatMax.y / f32(TILE_SIZE))));
 
-                aabbW = u32(maxTileX - minTileX + 1i);
+                let aabbW = u32(maxTileX - minTileX + 1i);
+
+                // Store per-splat state for Phase 2
+                screenArr[s] = screen;
+                cxArr[s] = cx;
+                cyArr[s] = cy;
+                czArr[s] = cz;
+                radiusFactorArr[s] = radiusFactor;
+                minTileXArr[s] = minTileX;
+                maxTileXArr[s] = maxTileX;
+                minTileYArr[s] = minTileY;
+                maxTileYArr[s] = maxTileY;
+                aabbWArr[s] = aabbW;
 
                 // Defer large splats to the cooperative large-splat pass where
                 // 256 threads process them in parallel, avoiding wavefront divergence.
@@ -208,117 +227,101 @@ fn main(
                 }
 
                 if (!deferredToLarge) {
+                    var myPairCount: u32 = 0u;
+                    var bitmask: u32 = 0u;
 
-                // Fast path: 1x1 AABB — the splat definitely intersects its only tile,
-                // skip the intersection test entirely.
-                if (minTileX == maxTileX && minTileY == maxTileY) {
-                    myPairCount = 1u;
-                    bitmask = 1u;
-                } else {
-
-                // --- Loop 1: count-only + bitmask ---
-                // Pure ALU — no atomics, no memory writes. Records which tiles within the
-                // AABB pass the ellipse intersection test. The bitmask avoids recomputing
-                // intersections in Loop 2. Always populated for the first 6x5 tiles of the
-                // AABB regardless of AABB size.
-                for (var ty = minTileY; ty <= maxTileY; ty++) {
-                    for (var tx = minTileX; tx <= maxTileX; tx++) {
-                        let tMin = vec2f(f32(tx) * f32(TILE_SIZE), f32(ty) * f32(TILE_SIZE));
-                        let tMax = tMin + vec2f(f32(TILE_SIZE));
-                        if (tileIntersectsEllipse(tMin, tMax, screen, cx, cy, cz, radiusFactor)) {
-                            myPairCount++;
-                            let localX = u32(tx - minTileX);
-                            let localY = u32(ty - minTileY);
-                            if (localX < BITMASK_W && localY < BITMASK_H) {
-                                let bitIdx = localY * BITMASK_W + localX;
-                                bitmask |= (1u << bitIdx);
+                    if (minTileX == maxTileX && minTileY == maxTileY) {
+                        myPairCount = 1u;
+                        bitmask = 1u;
+                    } else {
+                        for (var ty = minTileY; ty <= maxTileY; ty++) {
+                            for (var tx = minTileX; tx <= maxTileX; tx++) {
+                                let tMin = vec2f(f32(tx) * f32(TILE_SIZE), f32(ty) * f32(TILE_SIZE));
+                                let tMax = tMin + vec2f(f32(TILE_SIZE));
+                                if (tileIntersectsEllipse(tMin, tMax, screen, cx, cy, cz, radiusFactor)) {
+                                    myPairCount++;
+                                    let localX = u32(tx - minTileX);
+                                    let localY = u32(ty - minTileY);
+                                    if (localX < BITMASK_W && localY < BITMASK_H) {
+                                        let bitIdx = localY * BITMASK_W + localX;
+                                        bitmask |= (1u << bitIdx);
+                                    }
+                                }
                             }
                         }
                     }
-                }
 
-                } // end else (non-1x1)
-                } // end if (!deferredToLarge)
+                    pairCounts[s] = myPairCount;
+                    bitmasks[s] = bitmask;
+                    totalPairs += myPairCount;
+                }
             }
         }
 
-        // Zero out opacity marker for invisible splats so downstream passes skip them
         if (!isVisible) {
             projCache[threadIdx * CACHE_STRIDE + 6u] = 0u;
         }
     }
 
-    // --- Workgroup prefix sum + global pair buffer allocation ---
-    // All threads (including inactive ones beyond numVisible) participate in the barrier.
-    // The prefix sum computes per-thread offsets within the workgroup's pair block.
-    // A single global atomicAdd per workgroup reserves a contiguous region, reducing
-    // global atomic contention from ~44M (old scatter) to ~60K (one per workgroup).
-    wgPairCounts[localIdx] = myPairCount;
-    workgroupBarrier();
-
-    if (localIdx == 0u) {
-        var sum: u32 = 0u;
-        for (var i: u32 = 0u; i < WG_SIZE; i++) {
-            wgPairOffsets[i] = sum;
-            sum += wgPairCounts[i];
-        }
-        if (sum > 0u) {
-            wgBase = atomicAdd(&countersBuffer[0], sum);
-        } else {
-            wgBase = 0u;
-        }
+    // =========================================================================
+    // Per-thread pair buffer reservation (no barrier, no shared memory)
+    // =========================================================================
+    var pairBase: u32 = 0u;
+    if (totalPairs > 0u) {
+        pairBase = atomicAdd(&countersBuffer[0], totalPairs);
     }
-    workgroupBarrier();
 
-    if (myPairCount == 0u) {
-        if (threadIdx < numVisible) {
+    // =========================================================================
+    // Phase 2: Write pairs for all splats using register arrays (zero projCache reads)
+    // =========================================================================
+    var runningOffset: u32 = 0u;
+
+    for (var s: u32 = 0u; s < {SPLATS_PER_THREAD}; s++) {
+        let threadIdx = baseIdx + s;
+        if (threadIdx >= numVisible) { continue; }
+
+        if (pairCounts[s] == 0u) {
             splatPairStart[threadIdx] = 0u;
             splatPairCount[threadIdx] = 0u;
+            continue;
         }
-        return;
-    }
 
-    let myBase = wgBase + wgPairOffsets[localIdx];
+        let splatBase = pairBase + runningOffset;
+        splatPairStart[threadIdx] = splatBase;
+        splatPairCount[threadIdx] = pairCounts[s];
 
-    splatPairStart[threadIdx] = myBase;
-    splatPairCount[threadIdx] = myPairCount;
+        var j: u32 = 0u;
+        for (var ty = minTileYArr[s]; ty <= maxTileYArr[s]; ty++) {
+            for (var tx = minTileXArr[s]; tx <= maxTileXArr[s]; tx++) {
 
-    // --- Loop 2: atomicAdd on tileSplatCounts + pair writes ---
-    // Uses the bitmask from Loop 1 to skip intersection tests for splats fitting
-    // in the 6x5 region. For larger AABBs, the bitmask covers the first 6x5 rows/columns
-    // and intersection is recomputed only for tiles outside that region.
-    var j: u32 = 0u;
-    for (var ty = minTileY; ty <= maxTileY; ty++) {
-        for (var tx = minTileX; tx <= maxTileX; tx++) {
+                let localX = u32(tx - minTileXArr[s]);
+                let localY = u32(ty - minTileYArr[s]);
 
-            let localX = u32(tx - minTileX);
-            let localY = u32(ty - minTileY);
+                var hits: bool;
+                if (localX < BITMASK_W && localY < BITMASK_H) {
+                    let bitIdx = localY * BITMASK_W + localX;
+                    hits = (bitmasks[s] & (1u << bitIdx)) != 0u;
+                } else {
+                    let tMin = vec2f(f32(tx) * f32(TILE_SIZE), f32(ty) * f32(TILE_SIZE));
+                    let tMax = tMin + vec2f(f32(TILE_SIZE));
+                    hits = tileIntersectsEllipse(tMin, tMax, screenArr[s], cxArr[s], cyArr[s], czArr[s], radiusFactorArr[s]);
+                }
 
-            var hits: bool;
-            if (localX < BITMASK_W && localY < BITMASK_H) {
-                let bitIdx = localY * BITMASK_W + localX;
-                hits = (bitmask & (1u << bitIdx)) != 0u;
-            } else {
-                let tMin = vec2f(f32(tx) * f32(TILE_SIZE), f32(ty) * f32(TILE_SIZE));
-                let tMax = tMin + vec2f(f32(TILE_SIZE));
-                hits = tileIntersectsEllipse(tMin, tMax, screen, cx, cy, cz, radiusFactor);
-            }
-
-            if (hits) {
-                let tileIdx = u32(ty) * uniforms.numTilesX + u32(tx);
-                let localOff = atomicAdd(&tileSplatCounts[tileIdx], 1u);
-                if (localOff < MAX_TILE_ENTRIES) {
-                    pairBuffer[myBase + j] = (tileIdx << 16u) | (localOff & 0xFFFFu);
-                    j++;
+                if (hits) {
+                    let tileIdx = u32(ty) * uniforms.numTilesX + u32(tx);
+                    let localOff = atomicAdd(&tileSplatCounts[tileIdx], 1u);
+                    if (localOff < MAX_TILE_ENTRIES) {
+                        pairBuffer[splatBase + j] = (tileIdx << 16u) | (localOff & 0xFFFFu);
+                        j++;
+                    }
                 }
             }
         }
-    }
 
-    // If some pairs were dropped by the cap, update the stored count to reflect
-    // only the pairs actually written.
-    if (j != myPairCount) {
-        splatPairCount[threadIdx] = j;
+        if (j != pairCounts[s]) {
+            splatPairCount[threadIdx] = j;
+        }
+        runningOffset += pairCounts[s];
     }
 }
 `;


### PR DESCRIPTION
Optimizes the compute GSplat tile-count pass by processing 8 splats per thread, reducing GPU launch overhead. Extracts inline dispatch-prep shaders into dedicated chunk files.

**Changes:**
- Rewrite tile-count shader with barrier-free architecture: each thread processes 8 consecutive splats, persisting all Phase 2 data in register arrays to avoid projCache reads and shared memory barriers
- Use 8x4 fixed bitmask (pure shift `localY << 3 | localX`) instead of 6x5 (multiply) for lower register pressure
- Per-thread `atomicAdd` for pair buffer reservation instead of workgroup prefix sum + barrier
- Extract two inline WGSL dispatch-prep shaders into chunk files (`compute-gsplat-local-dispatch-prep.js`, `compute-gsplat-local-dispatch-prep-large.js`) using cdefines for constant injection
- Dispatch prep now writes two slots: slot 0 for tile-count (8 splats/thread, fewer workgroups), slot 1 for place-entries (1 splat/thread, full workgroups)

**Performance:**
- Tile-count pass improved from 6.6ms (N=1) → 5.1ms (N=4 barrier) → 5.0ms (N=8 barrier-free) on M4 with 40M visible splats
- Zero global memory reads in Phase 2 (all data in registers) should benefit lower-powered GPUs with smaller caches