### PR TITLE
fix: include fresnelSchlick chunk when refraction is enabled without specular

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardPostCode.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardPostCode.js
@@ -13,12 +13,15 @@ export default /* glsl */`
         #include "metalnessModulatePS"
     #endif
 
-    #if LIT_FRESNEL_MODEL == SCHLICK
-        #include "fresnelSchlickPS"
-    #endif
-
     #ifdef LIT_IRIDESCENCE
         #include "iridescenceDiffractionPS"
+    #endif
+#endif
+
+// fresnel is also needed by refraction
+#if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
+    #if LIT_FRESNEL_MODEL == SCHLICK
+        #include "fresnelSchlickPS"
     #endif
 #endif
 

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardPostCode.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardPostCode.js
@@ -13,12 +13,15 @@ export default /* wgsl */`
         #include "metalnessModulatePS"
     #endif
 
-    #if LIT_FRESNEL_MODEL == SCHLICK
-        #include "fresnelSchlickPS"
-    #endif
-
     #ifdef LIT_IRIDESCENCE
         #include "iridescenceDiffractionPS"
+    #endif
+#endif
+
+// fresnel is also needed by refraction
+#if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
+    #if LIT_FRESNEL_MODEL == SCHLICK
+        #include "fresnelSchlickPS"
     #endif
 #endif
 


### PR DESCRIPTION
## Summary

- Fixes a shader compilation error (`'getFresnel' : no matching overloaded function found`) when a material has refraction enabled but specular is effectively disabled (e.g. black specular color with no metalness)

## Root Cause

The `fresnelSchlickPS` chunk — which defines the `getFresnel()` function — was only included inside the `#ifdef LIT_SPECULAR_OR_REFLECTION` guard in `litForwardPostCode.js`. However, the `refractionDynamicPS` chunk (included under `#ifdef LIT_REFRACTION`) calls `getFresnel()` regardless. When `LIT_SPECULAR_OR_REFLECTION` was false but `LIT_REFRACTION` was true, the function was called but never defined.

## Fix

Moved the `fresnelSchlickPS` include so it is also triggered when `LIT_REFRACTION` is defined:

```glsl
#if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
    #if LIT_FRESNEL_MODEL == SCHLICK
        #include "fresnelSchlickPS"
    #endif
#endif
```

Applied to both the GLSL and WGSL versions of `litForwardPostCode.js`.

## Steps to Reproduce

1. Create a standard material with specular color set to black
2. Remove any environment map / skybox
3. Enable refraction (non-zero value) and enable dynamic refraction
4. Apply to a mesh — shader compilation fails

## Test Plan

- [x] Verify the above repro steps no longer produce a shader error
- [x] Verify materials with specular + refraction still render correctly
- [x] Verify materials with specular only (no refraction) are unaffected
