### PR TITLE
Unify GSplat debug rendering into a single enum-based API

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.controls.mjs
@@ -3,7 +3,7 @@
  * @returns {JSX.Element} The returned JSX Element.
  */
 export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
-    const { BindingTwoWay, LabelGroup, BooleanInput, Panel, SelectInput, SliderInput, Label } = ReactPCUI;
+    const { BindingTwoWay, LabelGroup, Panel, SelectInput, SliderInput, Label } = ReactPCUI;
     return fragment(
         jsx(
             Panel,
@@ -26,22 +26,17 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
-                { text: 'Colorize LOD' },
-                jsx(BooleanInput, {
-                    type: 'toggle',
+                { text: 'Debug' },
+                jsx(SelectInput, {
+                    type: 'number',
                     binding: new BindingTwoWay(),
-                    link: { observer, path: 'debugLod' },
-                    value: observer.get('debugLod')
-                })
-            ),
-            jsx(
-                LabelGroup,
-                { text: 'Colorize SH' },
-                jsx(BooleanInput, {
-                    type: 'toggle',
-                    binding: new BindingTwoWay(),
-                    link: { observer, path: 'colorizeSH' },
-                    value: observer.get('colorizeSH') || false
+                    link: { observer, path: 'debug' },
+                    value: observer.get('debug') ?? 0,
+                    options: [
+                        { v: 0, t: 'None' },
+                        { v: 1, t: 'LOD' },
+                        { v: 2, t: 'SH Update' }
+                    ]
                 })
             ),
             jsx(

--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
@@ -122,20 +122,12 @@ assetListLoader.load(() => {
 
     // initialize UI settings
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
-    data.set('debugLod', false);
-    data.set('colorizeSH', false);
+    data.set('debug', pc.GSPLAT_DEBUG_NONE);
     data.set('lodPreset', pc.platform.mobile ? 'mobile' : 'desktop');
     data.set('splatBudget', pc.platform.mobile ? 1 : 3);
 
-    app.scene.gsplat.colorizeLod = !!data.get('debugLod');
-    app.scene.gsplat.colorizeColorUpdate = !!data.get('colorizeSH');
-
-    data.on('debugLod:set', () => {
-        app.scene.gsplat.colorizeLod = !!data.get('debugLod');
-    });
-
-    data.on('colorizeSH:set', () => {
-        app.scene.gsplat.colorizeColorUpdate = !!data.get('colorizeSH');
+    data.on('debug:set', () => {
+        app.scene.gsplat.debug = data.get('debug');
     });
 
     const entity = new pc.Entity(config.name || 'gsplat');

--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
@@ -218,12 +218,17 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
-                { text: 'Colorize LOD' },
-                jsx(BooleanInput, {
-                    type: 'toggle',
+                { text: 'Debug' },
+                jsx(SelectInput, {
+                    type: 'number',
                     binding: new BindingTwoWay(),
-                    link: { observer, path: 'debugLod' },
-                    value: observer.get('debugLod')
+                    link: { observer, path: 'debug' },
+                    value: observer.get('debug') ?? 0,
+                    options: [
+                        { v: 0, t: 'None' },
+                        { v: 1, t: 'LOD' },
+                        { v: 2, t: 'SH Update' }
+                    ]
                 })
             ),
             jsx(

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -188,8 +188,8 @@ assetListLoader.load(async () => {
     data.on('minContribution:set', () => {
         app.scene.gsplat.minContribution = data.get('minContribution');
     });
-    data.on('debugLod:set', () => {
-        app.scene.gsplat.colorizeLod = !!data.get('debugLod');
+    data.on('debug:set', () => {
+        app.scene.gsplat.debug = data.get('debug');
     });
     data.on('compact:set', () => {
         app.scene.gsplat.dataFormat = data.get('compact') ? pc.GSPLATDATA_COMPACT : pc.GSPLATDATA_LARGE;
@@ -208,7 +208,7 @@ assetListLoader.load(async () => {
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
     data.set('culling', device.isWebGPU);
     data.set('compact', true);
-    data.set('debugLod', false);
+    data.set('debug', pc.GSPLAT_DEBUG_NONE);
     data.set('lodPreset', pc.platform.mobile ? 'mobile' : 'desktop');
     data.set('splatBudget', pc.platform.mobile ? 1 : 4);
     data.set('environment', 'none');

--- a/examples/src/examples/gaussian-splatting/world.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/world.controls.mjs
@@ -44,12 +44,17 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             { headerText: 'Settings' },
             jsx(
                 LabelGroup,
-                { text: 'Colorize LOD' },
-                jsx(BooleanInput, {
-                    type: 'toggle',
+                { text: 'Debug' },
+                jsx(SelectInput, {
+                    type: 'number',
                     binding: new BindingTwoWay(),
-                    link: { observer, path: 'debugLod' },
-                    value: observer.get('debugLod')
+                    link: { observer, path: 'debug' },
+                    value: observer.get('debug') ?? 0,
+                    options: [
+                        { v: 0, t: 'None' },
+                        { v: 1, t: 'LOD' },
+                        { v: 2, t: 'SH Update' }
+                    ]
                 })
             ),
             jsx(

--- a/examples/src/examples/gaussian-splatting/world.example.mjs
+++ b/examples/src/examples/gaussian-splatting/world.example.mjs
@@ -115,13 +115,11 @@ assetListLoader.load(() => {
 
     // initialize UI settings
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
-    data.set('debugLod', false);
+    data.set('debug', pc.GSPLAT_DEBUG_NONE);
     data.set('splatBudget', pc.platform.mobile ? 1 : 4);
 
-    app.scene.gsplat.colorizeLod = !!data.get('debugLod');
-
-    data.on('debugLod:set', () => {
-        app.scene.gsplat.colorizeLod = !!data.get('debugLod');
+    data.on('debug:set', () => {
+        app.scene.gsplat.debug = data.get('debug');
     });
 
     const applySplatBudget = () => {

--- a/scripts/esm/gsplat/streamed-gsplat.mjs
+++ b/scripts/esm/gsplat/streamed-gsplat.mjs
@@ -1,4 +1,4 @@
-import { Script, Asset, Entity, platform } from 'playcanvas';
+import { Script, Asset, Entity, platform, GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_NONE } from 'playcanvas';
 
 class StreamedGsplat extends Script {
     static scriptName = 'streamedGsplat';
@@ -268,7 +268,7 @@ class StreamedGsplat extends Script {
 
     _toggleColorize() {
         this._colorize = !this._colorize;
-        this.app.scene.gsplat.colorizeLod = this._colorize;
+        this.app.scene.gsplat.debug = this._colorize ? GSPLAT_DEBUG_LOD : GSPLAT_DEBUG_NONE;
 
         const statusEl = document.getElementById('colorize-status');
         if (statusEl) {

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1246,3 +1246,28 @@ export const GSPLAT_RENDERER_RASTER_GPU_SORT = 2;
  * @category Graphics
  */
 export const GSPLAT_RENDERER_COMPUTE = 3;
+
+/**
+ * No debug rendering for Gaussian splats. Normal rendering mode.
+ *
+ * @type {number}
+ * @category Graphics
+ */
+export const GSPLAT_DEBUG_NONE = 0;
+
+/**
+ * Debug rendering that colorizes Gaussian splats by their selected LOD level.
+ *
+ * @type {number}
+ * @category Graphics
+ */
+export const GSPLAT_DEBUG_LOD = 1;
+
+/**
+ * Debug rendering that assigns a random color per spherical harmonics update pass,
+ * visualizing when SH color updates occur.
+ *
+ * @type {number}
+ * @category Graphics
+ */
+export const GSPLAT_DEBUG_SH_UPDATE = 2;

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -17,7 +17,8 @@ import { ComputeRadixSort } from '../graphics/compute-radix-sort.js';
 import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import {
-    GSPLAT_RENDERER_RASTER_CPU_SORT, GSPLAT_RENDERER_RASTER_GPU_SORT, GSPLAT_RENDERER_COMPUTE
+    GSPLAT_RENDERER_RASTER_CPU_SORT, GSPLAT_RENDERER_RASTER_GPU_SORT, GSPLAT_RENDERER_COMPUTE,
+    GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE
 } from '../constants.js';
 import { Color } from '../../core/math/color.js';
 import { GSplatBudgetBalancer } from './gsplat-budget-balancer.js';
@@ -1119,9 +1120,9 @@ class GSplatManager {
      * @returns {Array<number[]>|undefined} Color array for debug visualization, or undefined for normal rendering
      */
     getDebugColors() {
-        if (this.scene.gsplat.colorizeColorUpdate) {
+        const debug = this.scene.gsplat.debug;
+        if (debug === GSPLAT_DEBUG_SH_UPDATE) {
             _randomColorRaw ??= [];
-            // Random color for this update pass - use same color for all LOD levels
             const r = Math.random();
             const g = Math.random();
             const b = Math.random();
@@ -1132,8 +1133,7 @@ class GSplatManager {
                 _randomColorRaw[i][2] = b;
             }
             return _randomColorRaw;
-        } else if (this.scene.gsplat.colorizeLod) {
-            // LOD colors
+        } else if (debug === GSPLAT_DEBUG_LOD) {
             return _lodColorsRaw;
         }
         return undefined;

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -8,7 +8,8 @@ import { GSplatFormat } from '../gsplat/gsplat-format.js';
 import {
     GSPLATDATA_COMPACT,
     GSPLAT_RENDERER_AUTO, GSPLAT_RENDERER_RASTER_CPU_SORT,
-    GSPLAT_RENDERER_RASTER_GPU_SORT, GSPLAT_RENDERER_COMPUTE
+    GSPLAT_RENDERER_RASTER_GPU_SORT, GSPLAT_RENDERER_COMPUTE,
+    GSPLAT_DEBUG_NONE, GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE
 } from '../constants.js';
 
 import glslCompactRead from '../shader-lib/glsl/chunks/gsplat/vert/formats/containerCompactRead.js';
@@ -206,31 +207,50 @@ class GSplatParams {
     dirty = false;
 
     /**
-     * @type {boolean}
+     * @type {number}
      * @private
      */
-    _colorizeLod = false;
+    _debug = GSPLAT_DEBUG_NONE;
 
     /**
-     * Enables colorization by selected LOD level when rendering GSplat objects. Defaults to false.
-     * Marks params dirty on change.
+     * Debug rendering mode for Gaussian splats. Can be:
      *
-     * @type {boolean}
+     * - {@link GSPLAT_DEBUG_NONE}: Normal rendering (default).
+     * - {@link GSPLAT_DEBUG_LOD}: Colorize splats by their selected LOD level.
+     * - {@link GSPLAT_DEBUG_SH_UPDATE}: Random color per SH update pass to visualize update
+     * frequency.
+     *
+     * Only one debug mode can be active at a time. Defaults to {@link GSPLAT_DEBUG_NONE}.
+     *
+     * @type {number}
      */
-    set colorizeLod(value) {
-        if (this._colorizeLod !== value) {
-            this._colorizeLod = value;
-            this.dirty = true;
+    set debug(value) {
+        if (this._debug !== value) {
+            const prev = this._debug;
+            this._debug = value;
+
+            if (value === GSPLAT_DEBUG_LOD || prev === GSPLAT_DEBUG_LOD) {
+                this.dirty = true;
+            }
         }
     }
 
+    get debug() {
+        return this._debug;
+    }
+
+    /** @deprecated Use {@link GSplatParams#debug} with {@link GSPLAT_DEBUG_LOD} instead. */
+    set colorizeLod(value) {
+        Debug.deprecated('GSplatParams#colorizeLod is deprecated. Use GSplatParams#debug = GSPLAT_DEBUG_LOD instead.');
+        this.debug = value ? GSPLAT_DEBUG_LOD : GSPLAT_DEBUG_NONE;
+    }
+
     /**
-     * Gets colorize-by-LOD flag.
-     *
-     * @returns {boolean} Current enabled state.
+     * @deprecated Use {@link GSplatParams#debug} with {@link GSPLAT_DEBUG_LOD} instead.
+     * @returns {boolean} Whether LOD colorization is enabled.
      */
     get colorizeLod() {
-        return this._colorizeLod;
+        return this._debug === GSPLAT_DEBUG_LOD;
     }
 
     /**
@@ -478,14 +498,19 @@ class GSplatParams {
      */
     useFog = true;
 
+    /** @deprecated Use {@link GSplatParams#debug} with {@link GSPLAT_DEBUG_SH_UPDATE} instead. */
+    set colorizeColorUpdate(value) {
+        Debug.deprecated('GSplatParams#colorizeColorUpdate is deprecated. Use GSplatParams#debug = GSPLAT_DEBUG_SH_UPDATE instead.');
+        this.debug = value ? GSPLAT_DEBUG_SH_UPDATE : GSPLAT_DEBUG_NONE;
+    }
+
     /**
-     * Enables debug colorization to visualize when spherical harmonics are evaluated.
-     * When true, each update pass renders with a random color to visualize the behavior
-     * of colorUpdateAngle thresholds. Defaults to false.
-     *
-     * @type {boolean}
+     * @deprecated Use {@link GSplatParams#debug} with {@link GSPLAT_DEBUG_SH_UPDATE} instead.
+     * @returns {boolean} Whether SH update colorization is enabled.
      */
-    colorizeColorUpdate = false;
+    get colorizeColorUpdate() {
+        return this._debug === GSPLAT_DEBUG_SH_UPDATE;
+    }
 
     /**
      * Viewing angle threshold in degrees for triggering spherical harmonics color updates.


### PR DESCRIPTION
Replaces the separate `colorizeLod` (boolean) and `colorizeColorUpdate` (boolean) properties on `GSplatParams` with a single `debug` property that accepts numeric constants, ensuring only one debug mode is active at a time.

**Changes:**
- Add `GSPLAT_DEBUG_NONE`, `GSPLAT_DEBUG_LOD`, and `GSPLAT_DEBUG_SH_UPDATE` constants
- Add `GSplatParams#debug` property (numeric enum) replacing two boolean flags
- Deprecate `GSplatParams#colorizeLod` and `GSplatParams#colorizeColorUpdate` with shims that forward to `debug`
- Update examples to use a dropdown selector (None / LOD / SH Update) instead of boolean toggles

**API Changes:**
- New: `GSplatParams#debug` — set to `GSPLAT_DEBUG_NONE` (default), `GSPLAT_DEBUG_LOD`, or `GSPLAT_DEBUG_SH_UPDATE`
- Deprecated: `GSplatParams#colorizeLod` — use `debug = GSPLAT_DEBUG_LOD` instead
- Deprecated: `GSplatParams#colorizeColorUpdate` — use `debug = GSPLAT_DEBUG_SH_UPDATE` instead

**Examples:**
- Updated `lod-streaming`, `lod-streaming-sh`, and `world` examples with a Debug dropdown