### PR TITLE
Add heatmap debug mode for compute GSplat rasterizer

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.controls.mjs
@@ -35,7 +35,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'None' },
                         { v: 1, t: 'LOD' },
-                        { v: 2, t: 'SH Update' }
+                        { v: 2, t: 'SH Update' },
+                        { v: 3, t: 'Heatmap' }
                     ]
                 })
             ),

--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
@@ -227,7 +227,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'None' },
                         { v: 1, t: 'LOD' },
-                        { v: 2, t: 'SH Update' }
+                        { v: 2, t: 'SH Update' },
+                        { v: 3, t: 'Heatmap' }
                     ]
                 })
             ),

--- a/examples/src/examples/gaussian-splatting/world.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/world.controls.mjs
@@ -53,7 +53,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'None' },
                         { v: 1, t: 'LOD' },
-                        { v: 2, t: 'SH Update' }
+                        { v: 2, t: 'SH Update' },
+                        { v: 3, t: 'Heatmap' }
                     ]
                 })
             ),

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1271,3 +1271,13 @@ export const GSPLAT_DEBUG_LOD = 1;
  * @category Graphics
  */
 export const GSPLAT_DEBUG_SH_UPDATE = 2;
+
+/**
+ * Debug heatmap rendering for the compute rasterizer. Visualizes the average number of splats
+ * processed per pixel in each tile as a blue-to-red color ramp. Only supported with
+ * {@link GSPLAT_RENDERER_COMPUTE}.
+ *
+ * @type {number}
+ * @category Graphics
+ */
+export const GSPLAT_DEBUG_HEATMAP = 3;

--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -14,7 +14,7 @@ import {
     UNIFORMTYPE_MAT4,
     UNIFORMTYPE_UINT
 } from '../../platform/graphics/constants.js';
-import { GSPLAT_FORWARD, PROJECTION_ORTHOGRAPHIC, FOG_NONE } from '../constants.js';
+import { GSPLAT_FORWARD, PROJECTION_ORTHOGRAPHIC, FOG_NONE, GSPLAT_DEBUG_HEATMAP } from '../constants.js';
 import { Debug } from '../../core/debug.js';
 import { Color } from '../../core/math/color.js';
 import { Mat4 } from '../../core/math/mat4.js';
@@ -383,6 +383,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         this._exposure = exposure ?? 1.0;
         this._fisheye = gsplat.fisheye;
         this._fogParams = fogParams ?? null;
+        this._debugMode = gsplat.debug;
 
         const formatHash = this.workBuffer.format.hash;
         if (formatHash !== this._formatHash) {
@@ -796,7 +797,8 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
 
         const fogParams = this._fogParams;
         const fogType = (fogParams && fogParams.type !== FOG_NONE) ? fogParams.type : 'none';
-        const rasterizeCompute = set.getRasterizeCompute(pickMode, useDepth, fogType);
+        const heatmap = !pickMode && this._debugMode === GSPLAT_DEBUG_HEATMAP;
+        const rasterizeCompute = set.getRasterizeCompute(pickMode, useDepth, fogType, heatmap);
 
         rasterizeCompute.setParameter('screenWidth', width);
         rasterizeCompute.setParameter('screenHeight', height);

--- a/src/scene/gsplat-unified/gsplat-local-dispatch-set.js
+++ b/src/scene/gsplat-unified/gsplat-local-dispatch-set.js
@@ -281,15 +281,17 @@ class GSplatLocalDispatchSet {
      * @param {boolean} pickMode - Whether to use the pick variant.
      * @param {boolean} depthTest - Whether to enable depth testing against scene geometry.
      * @param {string} [fogType] - Fog type string: 'none', 'linear', 'exp', or 'exp2'.
+     * @param {boolean} [heatmap] - Whether to enable heatmap debug visualization.
      * @returns {Compute} The cached Compute instance.
      */
-    getRasterizeCompute(pickMode, depthTest, fogType = 'none') {
+    getRasterizeCompute(pickMode, depthTest, fogType = 'none', heatmap = false) {
         let key = pickMode ? 'pick' : 'color';
         if (depthTest) key += '-depth';
         if (fogType !== 'none') key += `-fog-${fogType}`;
+        if (heatmap) key += '-heatmap';
         let variant = this._rasterizeVariants.get(key);
         if (!variant) {
-            const { shader, bindGroupFormat } = this._createRasterizeShaderAndFormat(pickMode, depthTest, fogType);
+            const { shader, bindGroupFormat } = this._createRasterizeShaderAndFormat(pickMode, depthTest, fogType, heatmap);
             const compute = new Compute(this.device, shader, `GSplatRasterize-${key}`);
             variant = { shader, bindGroupFormat, compute };
             this._rasterizeVariants.set(key, variant);
@@ -303,10 +305,11 @@ class GSplatLocalDispatchSet {
      * @param {boolean} pickMode - Whether to create the pick variant.
      * @param {boolean} depthTest - Whether to enable depth testing against scene geometry.
      * @param {string} [fogType] - Fog type string: 'none', 'linear', 'exp', or 'exp2'.
+     * @param {boolean} [heatmap] - Whether to enable heatmap debug visualization.
      * @returns {{ shader: Shader, bindGroupFormat: BindGroupFormat }} The shader and format.
      * @private
      */
-    _createRasterizeShaderAndFormat(pickMode, depthTest = false, fogType = 'none') {
+    _createRasterizeShaderAndFormat(pickMode, depthTest = false, fogType = 'none', heatmap = false) {
         const device = this.device;
         const hasFog = fogType !== 'none';
 
@@ -354,6 +357,7 @@ class GSplatLocalDispatchSet {
         const cdefines = new Map();
         if (pickMode) cdefines.set('PICK_MODE', '');
         if (depthTest) cdefines.set('DEPTH_TEST', '');
+        if (heatmap) cdefines.set('HEATMAP_MODE', '');
         cdefines.set('GAMMA', 'SRGB'); // assumes splat colors are in gamma space, will need to change when we get linear splats
         cdefines.set('FOG', hasFog ? fogType.toUpperCase() : 'NONE');
 

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -9,7 +9,7 @@ import {
     GSPLATDATA_COMPACT,
     GSPLAT_RENDERER_AUTO, GSPLAT_RENDERER_RASTER_CPU_SORT,
     GSPLAT_RENDERER_RASTER_GPU_SORT, GSPLAT_RENDERER_COMPUTE,
-    GSPLAT_DEBUG_NONE, GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE
+    GSPLAT_DEBUG_NONE, GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE, GSPLAT_DEBUG_HEATMAP
 } from '../constants.js';
 
 import glslCompactRead from '../shader-lib/glsl/chunks/gsplat/vert/formats/containerCompactRead.js';
@@ -219,6 +219,8 @@ class GSplatParams {
      * - {@link GSPLAT_DEBUG_LOD}: Colorize splats by their selected LOD level.
      * - {@link GSPLAT_DEBUG_SH_UPDATE}: Random color per SH update pass to visualize update
      * frequency.
+     * - {@link GSPLAT_DEBUG_HEATMAP}: Heatmap visualization of average splats processed per
+     * pixel in each tile. Only supported with {@link GSPLAT_RENDERER_COMPUTE}.
      *
      * Only one debug mode can be active at a time. Defaults to {@link GSPLAT_DEBUG_NONE}.
      *
@@ -229,7 +231,8 @@ class GSplatParams {
             const prev = this._debug;
             this._debug = value;
 
-            if (value === GSPLAT_DEBUG_LOD || prev === GSPLAT_DEBUG_LOD) {
+            if (value === GSPLAT_DEBUG_LOD || prev === GSPLAT_DEBUG_LOD ||
+                value === GSPLAT_DEBUG_HEATMAP || prev === GSPLAT_DEBUG_HEATMAP) {
                 this.dirty = true;
             }
         }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-rasterize.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-rasterize.js
@@ -60,6 +60,9 @@ struct Uniforms {
 
 var<workgroup> sharedCenterScreen: array<vec2f, 64>;
 var<workgroup> sharedCoeffs: array<vec3f, 64>;
+#ifdef HEATMAP_MODE
+    var<workgroup> sharedHeatCount: atomic<u32>;
+#endif
 
 // Pick mode stores per-splat opacity, ID and depth; color mode stores packed RGBA.
 // Depth test mode also needs per-splat view depth for occlusion against scene geometry.
@@ -101,6 +104,20 @@ fn evalSplatPick(pixelCoord: vec2f, center: vec2f, coeffX: f32, coeffY: f32, coe
     }
 
     *T = newT;
+}
+#endif
+
+#ifdef HEATMAP_MODE
+fn heatmapColor(v: f32) -> vec3f {
+    let t = saturate(v / 2000.0);
+    if (t < 0.2) {
+        return mix(vec3f(0.0, 0.0, 1.0), vec3f(0.0, 1.0, 1.0), t * 5.0);
+    } else if (t < 0.4) {
+        return mix(vec3f(0.0, 1.0, 1.0), vec3f(1.0, 1.0, 0.0), (t - 0.2) * 5.0);
+    } else if (t < 0.6) {
+        return mix(vec3f(1.0, 1.0, 0.0), vec3f(1.0, 0.0, 0.0), (t - 0.4) * 5.0);
+    }
+    return mix(vec3f(1.0, 0.0, 0.0), vec3f(0.15, 0.0, 0.0), (t - 0.6) * 2.5);
 }
 #endif
 
@@ -178,6 +195,12 @@ fn main(
     #endif
 
     let tileCount = tEnd - tStart;
+
+    #ifdef HEATMAP_MODE
+        if (localIdx == 0u) { atomicStore(&sharedHeatCount, 0u); }
+        workgroupBarrier();
+        var processedCount: u32 = 0u;
+    #endif
 
     let numBatches = (tileCount + BATCH_SIZE - 1u) / BATCH_SIZE;
     var threadDone = false;
@@ -288,6 +311,10 @@ fn main(
                     c11 += splatColor.rgb * weight.w;
                     T = select(T, newT, valid);
 
+                    #ifdef HEATMAP_MODE
+                        processedCount += 1u;
+                    #endif
+
                     if (all(T < half4(ALPHA_THRESHOLD))) {
                         threadDone = true;
                         break;
@@ -299,44 +326,65 @@ fn main(
         workgroupBarrier();
     }
 
-    // Write results for the 2x2 pixel quad owned by this thread.
-    // Pick mode: store the front-most pick ID and (accumulated depth, weight) per pixel.
-    // Color mode: convert accumulated gamma-space color to linear via decodeGamma3 and store
-    // to the rgba16float output texture; alpha holds total opacity (1 - transmittance).
-    if (basePixel.x < uniforms.screenWidth && basePixel.y < uniforms.screenHeight) {
-        #ifdef PICK_MODE
-            textureStore(pickIdTexture, basePixel, vec4u(pickId00, 0u, 0u, 0u));
-            textureStore(pickDepthTexture, basePixel, vec4f(dAcc00, wAcc00, 0.0, 0.0));
-        #else
-            textureStore(outputTexture, basePixel, vec4f(decodeGamma3(vec3f(c00)), f32(half(1.0) - T.x)));
-        #endif
-    }
-    if (basePixel.x + 1u < uniforms.screenWidth && basePixel.y < uniforms.screenHeight) {
-        let px10 = vec2u(basePixel.x + 1u, basePixel.y);
-        #ifdef PICK_MODE
-            textureStore(pickIdTexture, px10, vec4u(pickId10, 0u, 0u, 0u));
-            textureStore(pickDepthTexture, px10, vec4f(dAcc10, wAcc10, 0.0, 0.0));
-        #else
-            textureStore(outputTexture, px10, vec4f(decodeGamma3(vec3f(c10)), f32(half(1.0) - T.y)));
-        #endif
-    }
-    if (basePixel.x < uniforms.screenWidth && basePixel.y + 1u < uniforms.screenHeight) {
-        let px01 = vec2u(basePixel.x, basePixel.y + 1u);
-        #ifdef PICK_MODE
-            textureStore(pickIdTexture, px01, vec4u(pickId01, 0u, 0u, 0u));
-            textureStore(pickDepthTexture, px01, vec4f(dAcc01, wAcc01, 0.0, 0.0));
-        #else
-            textureStore(outputTexture, px01, vec4f(decodeGamma3(vec3f(c01)), f32(half(1.0) - T.z)));
-        #endif
-    }
-    if (basePixel.x + 1u < uniforms.screenWidth && basePixel.y + 1u < uniforms.screenHeight) {
-        let px11 = vec2u(basePixel.x + 1u, basePixel.y + 1u);
-        #ifdef PICK_MODE
-            textureStore(pickIdTexture, px11, vec4u(pickId11, 0u, 0u, 0u));
-            textureStore(pickDepthTexture, px11, vec4f(dAcc11, wAcc11, 0.0, 0.0));
-        #else
-            textureStore(outputTexture, px11, vec4f(decodeGamma3(vec3f(c11)), f32(half(1.0) - T.w)));
-        #endif
-    }
+    #ifdef HEATMAP_MODE
+        atomicAdd(&sharedHeatCount, processedCount);
+        workgroupBarrier();
+        let avgCount = f32(atomicLoad(&sharedHeatCount)) / 64.0;
+        let heatColor = vec4f(heatmapColor(avgCount), 1.0);
+        if (basePixel.x < uniforms.screenWidth && basePixel.y < uniforms.screenHeight) {
+            textureStore(outputTexture, basePixel, heatColor);
+        }
+        if (basePixel.x + 1u < uniforms.screenWidth && basePixel.y < uniforms.screenHeight) {
+            textureStore(outputTexture, vec2u(basePixel.x + 1u, basePixel.y), heatColor);
+        }
+        if (basePixel.x < uniforms.screenWidth && basePixel.y + 1u < uniforms.screenHeight) {
+            textureStore(outputTexture, vec2u(basePixel.x, basePixel.y + 1u), heatColor);
+        }
+        if (basePixel.x + 1u < uniforms.screenWidth && basePixel.y + 1u < uniforms.screenHeight) {
+            textureStore(outputTexture, vec2u(basePixel.x + 1u, basePixel.y + 1u), heatColor);
+        }
+    #else
+
+        // Write results for the 2x2 pixel quad owned by this thread.
+        // Pick mode: store the front-most pick ID and (accumulated depth, weight) per pixel.
+        // Color mode: convert accumulated gamma-space color to linear via decodeGamma3 and store
+        // to the rgba16float output texture; alpha holds total opacity (1 - transmittance).
+        if (basePixel.x < uniforms.screenWidth && basePixel.y < uniforms.screenHeight) {
+            #ifdef PICK_MODE
+                textureStore(pickIdTexture, basePixel, vec4u(pickId00, 0u, 0u, 0u));
+                textureStore(pickDepthTexture, basePixel, vec4f(dAcc00, wAcc00, 0.0, 0.0));
+            #else
+                textureStore(outputTexture, basePixel, vec4f(decodeGamma3(vec3f(c00)), f32(half(1.0) - T.x)));
+            #endif
+        }
+        if (basePixel.x + 1u < uniforms.screenWidth && basePixel.y < uniforms.screenHeight) {
+            let px10 = vec2u(basePixel.x + 1u, basePixel.y);
+            #ifdef PICK_MODE
+                textureStore(pickIdTexture, px10, vec4u(pickId10, 0u, 0u, 0u));
+                textureStore(pickDepthTexture, px10, vec4f(dAcc10, wAcc10, 0.0, 0.0));
+            #else
+                textureStore(outputTexture, px10, vec4f(decodeGamma3(vec3f(c10)), f32(half(1.0) - T.y)));
+            #endif
+        }
+        if (basePixel.x < uniforms.screenWidth && basePixel.y + 1u < uniforms.screenHeight) {
+            let px01 = vec2u(basePixel.x, basePixel.y + 1u);
+            #ifdef PICK_MODE
+                textureStore(pickIdTexture, px01, vec4u(pickId01, 0u, 0u, 0u));
+                textureStore(pickDepthTexture, px01, vec4f(dAcc01, wAcc01, 0.0, 0.0));
+            #else
+                textureStore(outputTexture, px01, vec4f(decodeGamma3(vec3f(c01)), f32(half(1.0) - T.z)));
+            #endif
+        }
+        if (basePixel.x + 1u < uniforms.screenWidth && basePixel.y + 1u < uniforms.screenHeight) {
+            let px11 = vec2u(basePixel.x + 1u, basePixel.y + 1u);
+            #ifdef PICK_MODE
+                textureStore(pickIdTexture, px11, vec4u(pickId11, 0u, 0u, 0u));
+                textureStore(pickDepthTexture, px11, vec4f(dAcc11, wAcc11, 0.0, 0.0));
+            #else
+                textureStore(outputTexture, px11, vec4f(decodeGamma3(vec3f(c11)), f32(half(1.0) - T.w)));
+            #endif
+        }
+
+    #endif
 }
 `;


### PR DESCRIPTION
Adds a new `GSPLAT_DEBUG_HEATMAP` debug rendering mode for the compute Gaussian splat rasterizer. The heatmap visualizes the average number of splats processed per pixel in each tile before the transmittance early-out, displayed as a blue-to-red color ramp at tile resolution.

**Changes:**
- Add `GSPLAT_DEBUG_HEATMAP` constant for the new debug mode
- Implement tile-averaged splat count visualization in the compute rasterize shader using workgroup-shared atomics
- Wire heatmap mode through the dispatch set and compute renderer as a shader variant
- Add Heatmap option to the debug dropdown in all GSplat examples

**API Changes:**
- New constant: `GSPLAT_DEBUG_HEATMAP` — set via `app.scene.gsplat.debug = GSPLAT_DEBUG_HEATMAP`
- Only supported with `GSPLAT_RENDERER_COMPUTE`

<img width="1194" height="1067" alt="Screenshot 2026-04-14 at 14 38 56" src="https://github.com/user-attachments/assets/d252df46-cce8-4a6c-b385-45a0ae6ab8a2" />
