### PR TITLE
findScript|findScripts returns Script instead of the deprecated

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -23,7 +23,7 @@ import { getApplication } from './globals.js';
  * @import { RigidBodyComponent } from './components/rigid-body/component.js'
  * @import { ScreenComponent } from './components/screen/component.js'
  * @import { ScriptComponent } from './components/script/component.js'
- * @import { ScriptType } from './script/script-type.js'
+ * @import { Script } from './script/script.js'
  * @import { ScrollViewComponent } from './components/scroll-view/component.js'
  * @import { ScrollbarComponent } from './components/scrollbar/component.js'
  * @import { SoundComponent } from './components/sound/component.js'
@@ -447,8 +447,8 @@ class Entity extends GraphNode {
     /**
      * Search the entity and all of its descendants for the first script instance of specified type.
      *
-     * @param {string|typeof ScriptType} nameOrType - The name or type of {@link ScriptType}.
-     * @returns {ScriptType|undefined} A script instance of specified type, if the entity or any of
+     * @param {string|typeof Script} nameOrType - The name or type of {@link Script}.
+     * @returns {Script|undefined} A script instance of specified type, if the entity or any of
      * its descendants has one. Returns undefined otherwise.
      * @example
      * // Get the first found "playerController" instance in the hierarchy tree that starts with this entity
@@ -462,8 +462,8 @@ class Entity extends GraphNode {
     /**
      * Search the entity and all of its descendants for all script instances of specified type.
      *
-     * @param {string|typeof ScriptType} nameOrType - The name or type of {@link ScriptType}.
-     * @returns {ScriptType[]} All script instances of specified type in the entity or any of its
+     * @param {string|typeof Script} nameOrType - The name or type of {@link Script}.
+     * @returns {Script[]} All script instances of specified type in the entity or any of its
      * descendants. Returns empty array if none found.
      * @example
      * // Get all "playerController" instances in the hierarchy tree that starts with this entity

--- a/src/framework/script/script-attributes.js
+++ b/src/framework/script/script-attributes.js
@@ -10,7 +10,6 @@ import { Asset } from '../asset/asset.js';
 
 /**
  * @import { Application } from '../../framework/application.js'
- * @import { ScriptType } from './script-type.js'
  * @import { Script } from '../../framework/script/script.js'
  */
 
@@ -207,8 +206,8 @@ export function assignAttributesToScript(app, attributeSchemaMap, data, script) 
 
 /**
  * Container of Script Attribute definitions. Implements an interface to add/remove attributes and
- * store their definition for a {@link ScriptType}. Note: An instance of ScriptAttributes is
- * created automatically by each {@link ScriptType}.
+ * store their definition for a {@link Script}. Note: An instance of ScriptAttributes is
+ * created automatically by each {@link Script}.
  *
  * @category Script
  */
@@ -220,16 +219,16 @@ class ScriptAttributes {
     /**
      * Create a new ScriptAttributes instance.
      *
-     * @param {typeof ScriptType} scriptType - Script Type that attributes relate to.
+     * @param {typeof Script} Script - Script Type that attributes relate to.
      */
-    constructor(scriptType) {
-        this.scriptType = scriptType;
+    constructor(Script) {
+        this.Script = Script;
         this.index = {};
     }
 
     static reservedNames = new Set([
         'app', 'entity', 'enabled', '_enabled', '_enabledOld', '_destroyed',
-        '__attributes', '__attributesRaw', '__scriptType', '__executionOrder',
+        '__attributes', '__attributesRaw', '__Script', '__executionOrder',
         '_callbacks', '_callbackActive', 'has', 'get', 'on', 'off', 'fire', 'once', 'hasEvent'
     ]);
 
@@ -324,17 +323,17 @@ class ScriptAttributes {
      */
     add(name, args) {
         if (!args) {
-            Debug.error(`Cannot add attribute '${name}' to script type '${this.scriptType.name}': args parameter is required`);
+            Debug.error(`Cannot add attribute '${name}' to script type '${this.Script.name}': args parameter is required`);
             return;
         }
 
         if (!args.type) {
-            Debug.error(`Cannot add attribute '${name}' to script type '${this.scriptType.name}': args.type is required`);
+            Debug.error(`Cannot add attribute '${name}' to script type '${this.Script.name}': args.type is required`);
             return;
         }
 
         if (this.index[name]) {
-            Debug.warn(`attribute '${name}' is already defined for script type '${this.scriptType.name}'`);
+            Debug.warn(`attribute '${name}' is already defined for script type '${this.Script.name}'`);
             return;
         } else if (ScriptAttributes.reservedNames.has(name)) {
             Debug.warn(`attribute '${name}' is a reserved attribute name`);
@@ -343,7 +342,7 @@ class ScriptAttributes {
 
         this.index[name] = args;
 
-        Object.defineProperty(this.scriptType.prototype, name, {
+        Object.defineProperty(this.Script.prototype, name, {
             get: function () {
                 return this.__attributes[name];
             },
@@ -397,7 +396,7 @@ class ScriptAttributes {
         }
 
         delete this.index[name];
-        delete this.scriptType.prototype[name];
+        delete this.Script.prototype[name];
         return true;
     }
 


### PR DESCRIPTION

### Description
findScript and findScripts returns Script instead of the deprecated ScriptType.

### Changes
Now we can cast in typescript using

```const myScript = entity.findScript("scriptName") as MyExtendedScript```

### Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
