### PR TITLE
fix: suppress frame:ready until full LOD update after param changes

### DIFF
--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -203,6 +203,15 @@ class GSplatManager {
     sortedVersion = 0;
 
     /**
+     * When true, suppresses ready=true in frame:ready until a fullUpdate cycle runs.
+     * Only set when octreeInstances exist and params change (dirty).
+     *
+     * @type {boolean}
+     * @private
+     */
+    _awaitingLodUpdate = false;
+
+    /**
      * Cached work buffer format version for detecting extra stream changes.
      *
      * @type {number}
@@ -1161,7 +1170,7 @@ class GSplatManager {
      * Fires the frame:ready event with current sorting and loading state.
      */
     fireFrameReadyEvent() {
-        const ready = this.sortedVersion === this.lastWorldStateVersion;
+        const ready = this.sortedVersion === this.lastWorldStateVersion && !this._awaitingLodUpdate;
 
         // Count total pending loads from octree instances (including environment)
         let loadingCount = 0;
@@ -1372,6 +1381,8 @@ class GSplatManager {
 
             // check if camera has moved/rotated enough to require LOD update
             cameraMovedOrRotatedForLod = this.testCameraMovedForLod();
+
+            this._awaitingLodUpdate = false;
         }
 
         // check if camera has moved enough to require re-sorting
@@ -1404,6 +1415,12 @@ class GSplatManager {
             // colorization) is refreshed immediately instead of trickling in over time.
             this._workBufferRebuildRequired = true;
             this.sortNeeded = true;
+
+            // Suppress ready=true in frame:ready until a fullUpdate cycle runs, so
+            // consumers can reliably detect the not-ready→ready transition after param changes.
+            if (this.octreeInstances.size > 0) {
+                this._awaitingLodUpdate = true;
+            }
         }
 
         // when camera or octree need LOD evaluated, or params are dirty, or resources completed, or new instances added


### PR DESCRIPTION
When gsplat params change (e.g. `splatBudget`), the `frame:ready` event could report `ready=true` before the LOD system had fully reacted — especially with GPU sorting where `sortedVersion` catches up in the same frame. This made it impossible for consumers to reliably detect the not-ready→ready transition after param changes.

**Changes:**
- Add `_awaitingLodUpdate` flag on `GSplatManager` that suppresses `ready=true` in the `frame:ready` event until a `fullUpdate` cycle runs (which polls load completions and re-evaluates LODs)
- The flag is only set when octree instances exist, so non-streaming scenarios are unaffected
- Set when `dirty` is detected in `update()`, cleared at end of `fullUpdate` block

This enables a reliable two-phase wait pattern: wait for `ready=false` (system reacted), then wait for `ready=true && loadingCount===0` (fully stabilized).