### PR TITLE
Add shader defines for prepass to support alpha test and dithered opacity

### DIFF
--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -13,6 +13,7 @@ import {
     SPRITE_RENDERMODE_SLICED, SPRITE_RENDERMODE_TILED, shadowTypeInfo, SHADER_PREPASS,
     lightTypeNames, lightShapeNames, spriteRenderModeNames, fresnelNames, blendNames, lightFalloffNames,
     cubemaProjectionNames, specularOcclusionNames, reflectionSrcNames, ambientSrcNames,
+    ditherNames,
     REFLECTIONSRC_NONE
 } from '../../constants.js';
 import { ChunkUtils } from '../chunk-utils.js';
@@ -513,6 +514,13 @@ class LitShader {
         this._setupLightingDefines(hasAreaLights, options.clusteredLightingEnabled);
     }
 
+    preparePrepassPass() {
+        const { options } = this;
+        this.fDefineSet(options.alphaTest, 'LIT_ALPHA_TEST');
+        this.fDefineSet(true, 'LIT_BLEND_TYPE', blendNames[options.blendType]);
+        this.fDefineSet(true, 'STD_OPACITY_DITHER', ditherNames[options.opacityShadowDither]);
+    }
+
     prepareShadowPass() {
 
         const { options } = this;
@@ -548,8 +556,10 @@ class LitShader {
         this.includes.set('frontendDeclPS', frontendDecl ?? '');
         this.includes.set('frontendCodePS', frontendCode ?? '');
 
-        if (options.pass === SHADER_PICK || options.pass === SHADER_PREPASS) {
+        if (options.pass === SHADER_PICK) {
             // nothing to prepare currently
+        } else if (options.pass === SHADER_PREPASS) {
+            this.preparePrepassPass();
         } else if (this.shadowPass) {
             this.prepareShadowPass();
         } else {

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -517,7 +517,6 @@ class LitShader {
     preparePrepassPass() {
         const { options } = this;
         this.fDefineSet(options.alphaTest, 'LIT_ALPHA_TEST');
-        this.fDefineSet(true, 'LIT_BLEND_TYPE', blendNames[options.blendType]);
         this.fDefineSet(true, 'STD_OPACITY_DITHER', ditherNames[options.opacityShadowDither]);
     }
 


### PR DESCRIPTION
## Summary

The prepass shader pass was sharing the same empty code path as the pick pass, which meant it had no shader defines set. This caused materials with alpha testing or opacity dithering to render incorrectly during the prepass because the relevant shader code was never compiled in.

This PR separates the prepass from the pick pass and adds a dedicated `preparePrepassPass()` method to `LitShader` that sets:

- `LIT_ALPHA_TEST` — enables alpha-test discard in the prepass
- `LIT_BLEND_TYPE` — sets the blend type so the shader can handle transparency correctly
- `STD_OPACITY_DITHER` — enables opacity dithering (matching the shadow pass behavior via `opacityShadowDither`)

## Technical Details

- Adds the `ditherNames` import from `constants.js`
- Splits the `SHADER_PICK` / `SHADER_PREPASS` combined branch in `generateFragmentShader()` so each pass gets its own preparation
- The new `preparePrepassPass()` follows the same pattern as `prepareShadowPass()`