### PR TITLE
perf: improve GSplat compute renderer cold-start buffer capacities

### DIFF
--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -48,14 +48,39 @@ import computeSplatSource from '../shader-lib/wgsl/chunks/gsplat/vert/gsplatComp
  * @import { MeshInstance } from '../mesh-instance.js'
  */
 
+// ---- Tunable knobs (memory vs. quality / robustness trade-offs) ----
+
+// Floor for _tileEntryMultiplier (minimum tile entries per splat). Controls
+// tile-entry buffer capacity on the first few frames before GPU readback has
+// converged. Raising reduces cold-start tile clamping (missing tiles on scene
+// load / teleport) at a flat cost of numSplats * (value) * 8 bytes.
+const INITIAL_TILE_ENTRY_MULTIPLIER = 2.5;
+
+// Headroom factor applied to measured entry demand. Cushions steady-state
+// frame-to-frame spikes (camera motion, splats crossing tile boundaries) so
+// they don't exceed capacity and cause clamping.
+const ENTRY_HEADROOM_MULTIPLIER = 2.0;
+
+// Consecutive low-usage readbacks before the multiplier is allowed to shrink.
+const SHRINK_THRESHOLD = 200;
+
+// Initial capacity (in splat IDs) of the large-splat buffer, which holds IDs of
+// splats whose screen AABB covers more than 64 tiles and are deferred to the
+// cooperative tile-count / place-entries passes. Buffer is grow-only: it expands
+// on demand via readback but never shrinks, so demand exceeding this initial size
+// causes large splats to be dropped for the first few frames (missing coverage on
+// close-up views) until readback catches up. Fixed cost is (value) * 4 bytes.
+const INITIAL_LARGE_SPLAT_CAPACITY = 16384;
+
+// ---- Algorithmic invariants (must match shader code, do not change casually) ----
+
 const TILE_SIZE = 16;
 const MAX_TILES = 65535; // tile index must fit in 16 bits for pair packing (tileIdx << 16 | localOffset)
-const INITIAL_TILE_ENTRY_MULTIPLIER = 1.5; // floor for _tileEntryMultiplier (min tile entries per splat)
 const CACHE_STRIDE = 7;
 const MAX_CHUNKS_PER_TILE = 8;
-const SHRINK_THRESHOLD = 200; // consecutive low-usage readbacks before considering multiplier shrink
-const ENTRY_HEADROOM_MULTIPLIER = 1.5; // headroom factor applied to measured entry demand
-const INITIAL_LARGE_SPLAT_CAPACITY = 4096; // initial large-splat ID buffer capacity (grow-only)
+
+// ---- Module-scope scratch (reusable, never exported) ----
+
 const _viewProjMat = new Mat4();
 const _viewProjData = new Float32Array(16);
 const _viewData = new Float32Array(16);


### PR DESCRIPTION
Raises initial buffer capacities in the compute GSplat renderer to eliminate missing tiles / dropped large splats in the first few frames after scene load or camera teleport, before GPU readback has converged.

**Changes:**
- `INITIAL_TILE_ENTRY_MULTIPLIER`: 1.5 → 2.5 — floor on tile-entry capacity, ensures frame-1 buffer is large enough for dense scenes.
- `ENTRY_HEADROOM_MULTIPLIER`: 1.5 → 2.0 — cushions steady-state frame-to-frame spikes (camera motion, splats crossing tile boundaries).
- `INITIAL_LARGE_SPLAT_CAPACITY`: 4096 → 16384 — avoids dropping large splats on close-up views before the grow-only readback path catches up.
- Restructure the module-top constants block into three clearly-labeled groups (tunable knobs, algorithmic invariants, module-scope scratch) with expanded comments documenting the trade-off and memory cost of each knob.

**Rationale:**
The compute GSplat renderer targets desktop platforms, so the small additional memory cost is worthwhile in exchange for eliminating visible cold-start artifacts. Worst-case additional memory is dominated by the tile-entry buffers (`numSplats × multiplier × 8 bytes`); for a 10M-splat scene this is on the order of tens of MB and occurs only when needed.

No public API change.