### PR TITLE
docs: fix incorrect JSDoc in public APIs

### DIFF
--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -138,7 +138,7 @@ class Gizmo extends EventHandler {
     static EVENT_NODESDETACH = 'nodes:detach';
 
     /**
-     * Fired when when the gizmo render has updated.
+     * Fired when the gizmo render has updated.
      *
      * @event
      * @example

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -51,7 +51,7 @@ const AXES = /** @type {('x' | 'y' | 'z')[]} */ (['x', 'y', 'z']);
  */
 class TransformGizmo extends Gizmo {
     /**
-     * Fired when when the transformation has started.
+     * Fired when the transformation has started.
      *
      * @event
      * @example
@@ -69,13 +69,13 @@ class TransformGizmo extends Gizmo {
      * @example
      * const gizmo = new pc.TransformGizmo(camera, layer);
      * gizmo.on('transform:move', (pointDelta, angleDelta) => {
-     *     console.log('Transformation moved by ${pointDelta} (angle: ${angleDelta})');
+     *     console.log(`Transformation moved by ${pointDelta} (angle: ${angleDelta})`);
      * });
      */
     static EVENT_TRANSFORMMOVE = 'transform:move';
 
     /**
-     * Fired when when the transformation has ended.
+     * Fired when the transformation has ended.
      *
      * @event
      * @example

--- a/src/framework/i18n/i18n.js
+++ b/src/framework/i18n/i18n.js
@@ -15,7 +15,7 @@ import { I18nParser } from './i18n-parser.js';
  */
 class I18n extends EventHandler {
     /**
-     * Fired when when the locale is changed.
+     * Fired when the locale is changed.
      *
      * @event
      * @example

--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -7,8 +7,8 @@ import { Script } from './script.js';
  */
 
 /**
- * This is the legacy format for creating PlayCanvas script returned when calling `pc.createScript()`.
- * You should not use this inherit from this class directly.
+ * This is the legacy format for creating a PlayCanvas script returned when calling `pc.createScript()`.
+ * Do not inherit from this class directly.
  *
  * @deprecated Use {@link Script} instead.
  * @category Script

--- a/src/platform/graphics/compute.js
+++ b/src/platform/graphics/compute.js
@@ -131,7 +131,7 @@ class Compute {
      * Returns the value of a shader parameter from the compute instance.
      *
      * @param {string} name - The name of the parameter to get.
-     * @returns {number|number[]|Float32Array|Texture|StorageBuffer|VertexBuffer|IndexBuffer|undefined}
+     * @returns {number|number[]|Float32Array|Texture|StorageBuffer|VertexBuffer|IndexBuffer|TextureView|undefined}
      * The value of the specified parameter.
      */
     getParameter(name) {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -590,7 +590,7 @@ class GraphNode extends EventHandler {
      * string then it represents the name of a field or a method of the node. If this is the name
      * of a field then the value passed as the second argument will be checked for equality. If
      * this is the name of a function then the return value of the function will be checked for
-     * equality against the valued passed as the second argument to this function.
+     * equality against the value passed as the second argument to this function.
      * @param {*} [value] - If the first argument (attr) is a property name then this value
      * will be checked against the value of the property.
      * @returns {GraphNode[]} The array of graph nodes that match the search criteria.
@@ -626,10 +626,10 @@ class GraphNode extends EventHandler {
      * findOne. If it's a string then it represents the name of a field or a method of the node. If
      * this is the name of a field then the value passed as the second argument will be checked for
      * equality. If this is the name of a function then the return value of the function will be
-     * checked for equality against the valued passed as the second argument to this function.
+     * checked for equality against the value passed as the second argument to this function.
      * @param {*} [value] - If the first argument (attr) is a property name then this value
      * will be checked against the value of the property.
-     * @returns {GraphNode|null} A graph node that match the search criteria. Returns null if no
+     * @returns {GraphNode|null} A graph node that matches the search criteria. Returns null if no
      * node is found.
      * @example
      * // Find the first node that is called 'head' and has a model component
@@ -649,21 +649,21 @@ class GraphNode extends EventHandler {
      * Return all graph nodes that satisfy the search query. Query can be simply a string, or comma
      * separated strings, to have inclusive results of assets that match at least one query. A
      * query that consists of an array of tags can be used to match graph nodes that have each tag
-     * of array.
+     * of the array.
      *
      * @param {...*} query - Name of a tag or array of tags.
      * @returns {GraphNode[]} A list of all graph nodes that match the query.
      * @example
-     * // Return all graph nodes that tagged by `animal`
+     * // Return all graph nodes tagged with `animal`
      * const animals = node.findByTag("animal");
      * @example
-     * // Return all graph nodes that tagged by `bird` OR `mammal`
+     * // Return all graph nodes tagged with `bird` OR `mammal`
      * const birdsAndMammals = node.findByTag("bird", "mammal");
      * @example
-     * // Return all assets that tagged by `carnivore` AND `mammal`
+     * // Return all graph nodes tagged with `carnivore` AND `mammal`
      * const meatEatingMammals = node.findByTag(["carnivore", "mammal"]);
      * @example
-     * // Return all assets that tagged by (`carnivore` AND `mammal`) OR (`carnivore` AND `reptile`)
+     * // Return all graph nodes tagged with (`carnivore` AND `mammal`) OR (`carnivore` AND `reptile`)
      * const meatEatingMammalsAndReptiles = node.findByTag(["carnivore", "mammal"], ["carnivore", "reptile"]);
      */
     findByTag(...query) {
@@ -687,7 +687,7 @@ class GraphNode extends EventHandler {
     /**
      * Get the first node found in the graph with the name. The search is depth first.
      *
-     * @param {string} name - The name of the graph.
+     * @param {string} name - The name of the node.
      * @returns {GraphNode|null} The first node to be found matching the supplied name. Returns
      * null if no node is found.
      */

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -647,7 +647,7 @@ class GraphNode extends EventHandler {
 
     /**
      * Return all graph nodes that satisfy the search query. Query can be simply a string, or comma
-     * separated strings, to have inclusive results of assets that match at least one query. A
+     * separated strings, to have inclusive results of graph nodes that match at least one query. A
      * query that consists of an array of tags can be used to match graph nodes that have each tag
      * of the array.
      *

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -177,7 +177,8 @@ class ShaderInstance {
  * @param {MeshInstance} meshInstance - The mesh instance.
  * @param {Vec3} cameraPosition - The position of the camera.
  * @param {Vec3} cameraForward - The forward vector of the camera.
- * @returns {void}
+ * @returns {number} The sort distance for the mesh instance. Mesh instances are sorted by this
+ * value in ascending or descending order depending on the layer's sort mode.
  */
 
 /**


### PR DESCRIPTION
## Summary

Docs-only PR fixing a small set of objectively-wrong JSDoc issues in public-facing APIs. No runtime behaviour changes.

### Type corrections

- `CalculateSortDistanceCallback` in `src/scene/mesh-instance.js`: was documented as `@returns {void}`, but `Layer#_calculateSortDistances` uses the result as a numeric sort distance. Corrected to `@returns {number}`.
- `Compute#getParameter` in `src/platform/graphics/compute.js`: return union was missing `TextureView`, which is an allowed value per `setParameter`. Added to the union.

### Typos / grammar in public JSDoc prose

- `src/scene/graph-node.js`:
  - `findByName` param described "the name of the graph" -> "the name of the node".
  - `find` / `findOne` said "the valued passed" -> "the value passed".
  - `findOne` `@returns` "A graph node that match" -> "that matches".
  - `findByTag` description "each tag of array" -> "each tag of the array"; examples "nodes that tagged by" -> "nodes tagged with" (and fixed "assets" -> "graph nodes" for accuracy).
- `src/framework/script/script-type.js`: class summary rewritten from "You should not use this inherit from this class directly." to "Do not inherit from this class directly.", and fixed missing article.
- Removed duplicated "when when" in event descriptions in `src/extras/gizmo/transform-gizmo.js` (2 sites), `src/extras/gizmo/gizmo.js`, and `src/framework/i18n/i18n.js`.

### Broken @example

- `TransformGizmo.EVENT_TRANSFORMMOVE` example used `${...}` inside single quotes, so it logged literal `${pointDelta}`. Converted to a backtick template literal.

## Public API changes

Only JSDoc types change; no runtime signatures change. Two documented types are widened:

Before:
```js
/**
 * @callback CalculateSortDistanceCallback
 * @returns {void}
 */
```
After:
```js
/**
 * @callback CalculateSortDistanceCallback
 * @returns {number}
 */
```

Before:
```js
/**
 * @returns {number|number[]|Float32Array|Texture|StorageBuffer|VertexBuffer|IndexBuffer|undefined}
 */
getParameter(name) { ... }
```
After:
```js
/**
 * @returns {number|number[]|Float32Array|Texture|StorageBuffer|VertexBuffer|IndexBuffer|TextureView|undefined}
 */
getParameter(name) { ... }
```

## Test plan

- `npx eslint` on all touched files passes.
- No behavioural code changes; nothing else to test.
