### PR TITLE
docs: fix more incorrect JSDoc in public APIs

### DIFF
--- a/src/core/math/mat4.js
+++ b/src/core/math/mat4.js
@@ -1171,7 +1171,7 @@ class Mat4 {
     }
 
     /**
-     * -1 if the the matrix has an odd number of negative scales (mirrored); 1 otherwise.
+     * -1 if the matrix has an odd number of negative scales (mirrored); 1 otherwise.
      *
      * @type {number}
      * @ignore

--- a/src/extras/gizmo/rotate-gizmo.js
+++ b/src/extras/gizmo/rotate-gizmo.js
@@ -440,7 +440,7 @@ class RotateGizmo extends TransformGizmo {
 
     /**
      * @type {boolean}
-     * @deprecated Use {@link RotationGizmo#rotationMode} instead.
+     * @deprecated Use {@link RotateGizmo#rotationMode} instead.
      * @ignore
      */
     set orbitRotation(value) {
@@ -449,7 +449,7 @@ class RotateGizmo extends TransformGizmo {
 
     /**
      * @type {boolean}
-     * @deprecated Use {@link RotationGizmo#rotationMode} instead.
+     * @deprecated Use {@link RotateGizmo#rotationMode} instead.
      * @ignore
      */
     get orbitRotation() {

--- a/src/framework/bundle/bundle.js
+++ b/src/framework/bundle/bundle.js
@@ -7,7 +7,7 @@ import { EventHandler } from '../../core/event-handler.js';
  */
 class Bundle extends EventHandler {
     /**
-     * Index of file url to to DataView.
+     * Index of file url to DataView.
      * @type {Map<string, DataView>}
      * @private
      */

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -293,7 +293,7 @@ class LayoutGroupComponent extends Component {
 
     /**
      * Sets whether or not to wrap children onto a new row/column when the size of the container is
-     * exceeded. Defaults to false, which means that children will be be rendered in a single row
+     * exceeded. Defaults to false, which means that children will be rendered in a single row
      * (horizontal orientation) or column (vertical orientation). Note that setting wrap to true
      * makes it impossible for the {@link FITTING_BOTH} fitting mode to operate in any logical
      * manner. For this reason, when wrap is true, a {@link LayoutGroupComponent#widthFitting} or

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -746,8 +746,8 @@ class RigidBodyComponent extends Component {
 
     /**
      * Apply a force to the body at a point. By default, the force is applied at the origin of the
-     * body. However, the force can be applied at an offset this point by specifying a world space
-     * vector from the body's origin to the point of application.
+     * body. However, the force can be applied at an offset from this point by specifying a world
+     * space vector from the body's origin to the point of application.
      *
      * @overload
      * @param {number} x - X-component of the force in world space.
@@ -769,8 +769,8 @@ class RigidBodyComponent extends Component {
      */
     /**
      * Apply a force to the body at a point. By default, the force is applied at the origin of the
-     * body. However, the force can be applied at an offset this point by specifying a world space
-     * vector from the body's origin to the point of application.
+     * body. However, the force can be applied at an offset from this point by specifying a world
+     * space vector from the body's origin to the point of application.
      *
      * @overload
      * @param {Vec3} force - Vector representing the force in world space.

--- a/src/framework/xr/xr-anchor.js
+++ b/src/framework/xr/xr-anchor.js
@@ -59,7 +59,7 @@ class XrAnchor extends EventHandler {
     static EVENT_CHANGE = 'change';
 
     /**
-     * Fired when an anchor has has been persisted. The handler is passed the UUID string that can
+     * Fired when an anchor has been persisted. The handler is passed the UUID string that can
      * be used to restore this anchor.
      *
      * @event

--- a/src/platform/graphics/dynamic-buffers.js
+++ b/src/platform/graphics/dynamic-buffers.js
@@ -19,7 +19,7 @@ class UsedBuffer {
     stagingBuffer;
 
     /**
-     * The beginning position of the used area that needs to be copied from staging to to the GPU
+     * The beginning position of the used area that needs to be copied from staging to the GPU
      * buffer.
      *
      * @type {number}

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -53,7 +53,7 @@ let id = 0;
  *     - on WebGPU, rendering to float and half-float formats is always supported.
  *     - on WebGPU, rendering to small-float format is supported only if
  * {@link GraphicsDevice#textureRG11B10Renderable} is true.
- *     - on WebGL2, rendering to these 3 formats formats is supported only if
+ *     - on WebGL2, rendering to these 3 formats is supported only if
  * {@link GraphicsDevice#textureFloatRenderable} is true.
  *     - on WebGL2, if {@link GraphicsDevice#textureFloatRenderable} is false, but
  * {@link GraphicsDevice#textureHalfFloatRenderable} is true, rendering to half-float formats only

--- a/src/platform/graphics/uniform-buffer-format.js
+++ b/src/platform/graphics/uniform-buffer-format.js
@@ -202,7 +202,7 @@ class UniformFormat {
 }
 
 /**
- * A descriptor that defines the layout of of data inside the uniform buffer.
+ * A descriptor that defines the layout of data inside the uniform buffer.
  *
  * @category Graphics
  */

--- a/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
+++ b/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
@@ -5,7 +5,7 @@ import { WebgpuDynamicBuffer } from './webgpu-dynamic-buffer.js';
 
 class WebgpuDynamicBuffers extends DynamicBuffers {
     /**
-     * Staging buffers which are getting copied over to gpu buffers in the the command buffer waiting
+     * Staging buffers which are getting copied over to gpu buffers in the command buffer waiting
      * to be submitted. When those command buffers are submitted, we can mapAsync these staging
      * buffers for reuse.
      *

--- a/src/scene/graphics/post-effect.js
+++ b/src/scene/graphics/post-effect.js
@@ -11,8 +11,8 @@ import { drawQuadWithShader } from './quad-render-utils.js';
 const _viewport = new Vec4();
 
 /**
- * Base class for all post effects. Post effects take a render target as input apply effects to
- * it and then render the result to an output render target or the screen if no output is
+ * Base class for all post effects. Post effects take a render target as input, apply effects to
+ * it, and then render the result to an output render target or the screen if no output is
  * specified.
  *
  * @category Graphics

--- a/src/scene/graphics/post-effect.js
+++ b/src/scene/graphics/post-effect.js
@@ -11,7 +11,7 @@ import { drawQuadWithShader } from './quad-render-utils.js';
 const _viewport = new Vec4();
 
 /**
- * Base class for all post effects. Post effects take a a render target as input apply effects to
+ * Base class for all post effects. Post effects take a render target as input apply effects to
  * it and then render the result to an output render target or the screen if no output is
  * specified.
  *

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -270,7 +270,7 @@ const _tempColor = new Color();
  * @property {string} refractionMapChannel Color channels of the refraction map to use. Can be "r",
  * "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} refractionVertexColor Use mesh vertex colors for refraction. If
- * refraction map is set, it will be be multiplied by vertex colors.
+ * refraction map is set, it will be multiplied by vertex colors.
  * @property {boolean} refractionVertexColorChannel Vertex color channel to use for refraction.
  * Can be "r", "g", "b" or "a".
  * @property {number} refractionIndex Defines the index of refraction, i.e. The amount of
@@ -295,7 +295,7 @@ const _tempColor = new Color();
  * @property {string} thicknessMapChannel Color channels of the thickness map to use. Can be "r",
  * "g", "b" or "a".
  * @property {boolean} thicknessVertexColor Use mesh vertex colors for thickness. If
- * thickness map is set, it will be be multiplied by vertex colors.
+ * thickness map is set, it will be multiplied by vertex colors.
  * @property {Color} attenuation The attenuation color for refractive materials, only used when
  * useDynamicRefraction is enabled.
  * @property {number} attenuationDistance The distance defining the absorption rate of light

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -1304,7 +1304,8 @@ class MeshInstance {
      * Retrieves the specified shader parameter from a mesh instance.
      *
      * @param {string} name - The name of the parameter to query.
-     * @returns {object} The named parameter.
+     * @returns {object|undefined} The named parameter, or `undefined` if no parameter with that
+     * name is set on this mesh instance.
      */
     getParameter(name) {
         return this.parameters[name];

--- a/src/scene/shader-lib/glsl/chunks/render-pass/frag/sampleCatmullRom.js
+++ b/src/scene/shader-lib/glsl/chunks/render-pass/frag/sampleCatmullRom.js
@@ -4,7 +4,7 @@
 export default /* glsl */`
 
 vec4 SampleTextureCatmullRom(TEXTURE_ACCEPT(tex), vec2 uv, vec2 texSize) {
-    // We're going to sample a a 4x4 grid of texels surrounding the target UV coordinate. We'll do this by rounding
+    // We're going to sample a 4x4 grid of texels surrounding the target UV coordinate. We'll do this by rounding
     // down the sample location to get the exact center of our "starting" texel. The starting texel will be at
     // location [1, 1] in the grid, where [0, 0] is the top left corner.
     vec2 samplePos = uv * texSize;

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -53,7 +53,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
     }
 
     /**
-     * Get the code with which to to replace '*_TEXTURE_UV' in the map shader functions.
+     * Get the code with which to replace '*_TEXTURE_UV' in the map shader functions.
      *
      * @param {string} transformPropName - Name of the transform id in the options block. Usually "basenameTransform".
      * @param {string} uVPropName - Name of the UV channel in the options block. Usually "basenameUv".

--- a/src/scene/shader-lib/wgsl/chunks/render-pass/frag/sampleCatmullRom.js
+++ b/src/scene/shader-lib/wgsl/chunks/render-pass/frag/sampleCatmullRom.js
@@ -4,7 +4,7 @@
 export default /* wgsl */`
 
 fn SampleTextureCatmullRom(tex: texture_2d<f32>, texSampler: sampler, uv: vec2f, texSize: vec2f) -> vec4f {
-    // We're going to sample a a 4x4 grid of texels surrounding the target UV coordinate. We'll do this by rounding
+    // We're going to sample a 4x4 grid of texels surrounding the target UV coordinate. We'll do this by rounding
     // down the sample location to get the exact center of our "starting" texel. The starting texel will be at
     // location [1, 1] in the grid, where [0, 0] is the top left corner.
     let samplePos: vec2f = uv * texSize;


### PR DESCRIPTION
## Summary

Follow-up to #8612. Another docs-only pass fixing objectively-wrong JSDoc and comment issues across the engine. No runtime behaviour changes.

### Duplicate-word typos (14 sites)

Each is a one-word fix inside a JSDoc or shader-source comment line:

- `src/core/math/mat4.js` — "the the matrix"
- `src/framework/bundle/bundle.js` — "to to DataView"
- `src/framework/components/layout-group/component.js` — "will be be rendered"
- `src/framework/xr/xr-anchor.js` — "has has been persisted" (public `@event`)
- `src/platform/graphics/dynamic-buffers.js` — "staging to to the GPU buffer"
- `src/platform/graphics/texture.js` — "3 formats formats"
- `src/platform/graphics/uniform-buffer-format.js` — "layout of of data"
- `src/platform/graphics/webgpu/webgpu-dynamic-buffers.js` — "in the the command buffer"
- `src/scene/graphics/post-effect.js` — "take a a render target"
- `src/scene/materials/standard-material.js` (x2) — "will be be multiplied" on `refractionVertexColor` and `thicknessVertexColor` props
- `src/scene/shader-lib/programs/standard.js` — "to to replace"
- `src/scene/shader-lib/glsl/chunks/render-pass/frag/sampleCatmullRom.js` and its WGSL twin — "sample a a 4x4 grid" in shader source comments

### Broken `{@link}` cross-reference

- `src/extras/gizmo/rotate-gizmo.js` (2 sites) — `@deprecated Use {@link RotationGizmo#rotationMode}`. The class is `RotateGizmo`; `RotationGizmo` does not exist anywhere in `src/`. Fixed to `{@link RotateGizmo#rotationMode}`.

### Missing word in `applyForce` description

- `src/framework/components/rigid-body/component.js` (2 overload blocks) — "the force can be applied at an offset this point..." -> "...at an offset from this point...".

### Incomplete `@returns` type

- `src/scene/mesh-instance.js` — `MeshInstance#getParameter` returns `this.parameters[name]`, which is `undefined` when the key is missing. Documented `@returns {object}` -> `@returns {object|undefined}` with a matching description. This mirrors the `Compute#getParameter` fix already merged in #8612.

## Public API changes

Only JSDoc changes; no runtime signatures change. One documented return type is widened:

Before:
```js
/**
 * @returns {object} The named parameter.
 */
getParameter(name) { ... }
```
After:
```js
/**
 * @returns {object|undefined} The named parameter, or `undefined` if no parameter with that
 * name is set on this mesh instance.
 */
getParameter(name) { ... }
```

## Test plan

- `npx eslint` on all 16 touched files passes.
- No behavioural code changes; nothing else to test.
