### PR TITLE
docs: fix more incorrect JSDoc in public APIs

### DIFF
--- a/src/core/indexed-list.js
+++ b/src/core/indexed-list.js
@@ -17,7 +17,7 @@ class IndexedList {
     _index = {};
 
     /**
-     * Add a new item into the list with a index key.
+     * Add a new item into the list with an index key.
      *
      * @param {string} key - Key used to look up item in index.
      * @param {object} item - Item to be stored.

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -169,7 +169,7 @@ class URI {
     }
 
     /**
-     * Set the query section of the URI from a Object.
+     * Set the query section of the URI from an Object.
      *
      * @param {object} params - Key-Value pairs to encode into the query string.
      * @example

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -179,7 +179,7 @@ class URI {
      *     "a": 1,
      *     "b": 2
      * });
-     * console.log(uri.toString()); // logs "http://example.com?a=1&b=2
+     * console.log(uri.toString()); // logs "http://example.com?a=1&b=2"
      */
     setQuery(params) {
         let q = '';

--- a/src/extras/render-passes/render-pass-upsample.js
+++ b/src/extras/render-passes/render-pass-upsample.js
@@ -6,7 +6,7 @@ import wgslUpsamplePS from '../../scene/shader-lib/wgsl/chunks/render-pass/frag/
 import { ShaderChunks } from '../../scene/shader-lib/shader-chunks.js';
 
 /**
- * Render pass implementation of a up-sample filter.
+ * Render pass implementation of an up-sample filter.
  *
  * @category Graphics
  * @ignore

--- a/src/framework/script/script-create.js
+++ b/src/framework/script/script-create.js
@@ -98,8 +98,8 @@ createScript.reservedAttributes = reservedAttributes;
  * (underscore): system, entity, create, destroy, swap, move, scripts, onEnable, onDisable,
  * onPostStateChange, has, on, off, fire, once, hasEvent.
  * @param {AppBase} [app] - Optional application handler, to choose which {@link ScriptRegistry}
- * to register the script type to. By default it will use `Application.getApplication()` to get
- * current {@link AppBase}.
+ * to register the script type with. By default it will use `Application.getApplication()` to get
+ * the current {@link AppBase}.
  * @example
  * // define an ES6 script class
  * class PlayerController extends pc.ScriptType {

--- a/src/framework/script/script-create.js
+++ b/src/framework/script/script-create.js
@@ -83,12 +83,12 @@ ScriptAttributes.reservedNames.forEach((value, value2, set) => {
 createScript.reservedAttributes = reservedAttributes;
 
 /**
- * Register a existing class type as a Script Type to {@link ScriptRegistry}. Useful when defining
- * a ES6 script class that extends {@link ScriptType} (see example).
+ * Register an existing class type as a Script Type to {@link ScriptRegistry}. Useful when defining
+ * an ES6 script class that extends {@link ScriptType} (see example).
  *
  * @param {typeof ScriptType} script - The existing class type (constructor function) to be
  * registered as a Script Type. Class must extend {@link ScriptType} (see example). Please note: A
- * class created using {@link createScript} is auto-registered, and should therefore not be pass
+ * class created using {@link createScript} is auto-registered, and should therefore not be passed
  * into {@link registerScript} (which would result in swapping out all related script instances).
  * @param {string} [name] - Optional unique name of the Script Type. By default it will use the
  * same name as the existing class. If a Script Type with the same name has already been registered
@@ -101,7 +101,7 @@ createScript.reservedAttributes = reservedAttributes;
  * to register the script type to. By default it will use `Application.getApplication()` to get
  * current {@link AppBase}.
  * @example
- * // define a ES6 script class
+ * // define an ES6 script class
  * class PlayerController extends pc.ScriptType {
  *
  *     initialize() {

--- a/src/framework/script/script-create.js
+++ b/src/framework/script/script-create.js
@@ -83,7 +83,7 @@ ScriptAttributes.reservedNames.forEach((value, value2, set) => {
 createScript.reservedAttributes = reservedAttributes;
 
 /**
- * Register an existing class type as a Script Type to {@link ScriptRegistry}. Useful when defining
+ * Register an existing class type as a Script Type with {@link ScriptRegistry}. Useful when defining
  * an ES6 script class that extends {@link ScriptType} (see example).
  *
  * @param {typeof ScriptType} script - The existing class type (constructor function) to be

--- a/src/platform/graphics/vertex-iterator.js
+++ b/src/platform/graphics/vertex-iterator.js
@@ -172,10 +172,10 @@ class VertexIteratorAccessor {
     }
 
     /**
-     * Get a attribute component at the iterator's current index.
+     * Get an attribute component at the iterator's current index.
      *
      * @param {number} offset - The component offset. Should be either 0, 1, 2, or 3.
-     * @returns {number} The value of a attribute component.
+     * @returns {number} The value of an attribute component.
      */
     get(offset) {
         return this.array[this.index + offset];

--- a/src/platform/input/controller.js
+++ b/src/platform/input/controller.js
@@ -168,7 +168,7 @@ class Controller {
     }
 
     /**
-     * Create or update a action which is enabled when the supplied keys are pressed.
+     * Create or update an action which is enabled when the supplied keys are pressed.
      *
      * @param {string} action - The name of the action.
      * @param {number[]} keys - A list of keycodes.

--- a/src/platform/input/controller.js
+++ b/src/platform/input/controller.js
@@ -168,10 +168,11 @@ class Controller {
     }
 
     /**
-     * Create or update an action which is enabled when the supplied keys are pressed.
+     * Register a new action which is enabled when the supplied keys are pressed.
      *
      * @param {string} action - The name of the action.
      * @param {number[]} keys - A list of keycodes.
+     * @throws {Error} If the action is already registered, or if `keys` is undefined.
      */
     registerKeys(action, keys) {
         if (!this._keyboard) {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -1103,7 +1103,7 @@ class Light {
     }
 
     /**
-     * Updates a integer key for the light. The key is used to identify all shader related features
+     * Updates an integer key for the light. The key is used to identify all shader related features
      * of the light, and so needs to have all properties that modify the generated shader encoded.
      * Properties without an effect on the shader (color, shadow intensity) should not be encoded.
      */


### PR DESCRIPTION
A fourth small docs-only pass continuing from #8612, #8613 and #8614. This batch tackles a class of issues that my hard-coded keyword search in the previous PR didn't catch: incorrect `a`/`an` agreement before vowel-sound words. Found via a `rg --pcre2 '\ba\s+[aeiouAEIOU]\w*'` sweep over `src/**/*.js`, with manual filtering for variable-name false positives (e.g. `a is returned`), genuinely consonant-sound words (`a URI`, `a unit vector`), and `@example` code.

### Grammar: a/an agreement

- `src/core/uri.js` — `URI.setQuery`: `from a Object` -> `from an Object`.
- `src/core/indexed-list.js` — `IndexedList.push`: `with a index key` -> `with an index key`.
- `src/extras/render-passes/render-pass-upsample.js` — class summary: `a up-sample filter` -> `an up-sample filter`.
- `src/platform/input/controller.js` — `Controller#registerKeys`: `Create or update a action` -> see "Factual correction" below.
- `src/scene/light.js` — `Light.updateKey`: `Updates a integer key` -> `Updates an integer key`.
- `src/framework/script/script-create.js` — `registerScript` summary and `@example`:
  - `Register a existing class type` -> `Register an existing class type`.
  - `a ES6 script class` -> `an ES6 script class` (in the summary and in the `@example` comment).
- `src/platform/graphics/vertex-iterator.js` — `VertexIteratorAccessor.get`: `a attribute component` -> `an attribute component` (summary and `@returns`).

### Other grammar

- `src/framework/script/script-create.js` — `registerScript` summary: `Register ... as a Script Type to {@link ScriptRegistry}` -> `... as a Script Type with {@link ScriptRegistry}` (per review).
- `src/framework/script/script-create.js` — `registerScript` `@param script` description: `should therefore not be pass into {@link registerScript}` -> `should therefore not be passed into {@link registerScript}`.

### Factual correction

- `src/platform/input/controller.js` — `Controller#registerKeys`: the old JSDoc said "Create or update an action…", but the method throws `Action: ${action} already registered` when the action is already registered — it cannot update. Reworded to "Register a new action…" and added an `@throws` clause documenting the two error conditions (`action` already registered, or `keys` undefined). Per review, I intentionally did **not** touch the matching docs on sibling methods `registerMouse` / `registerPadButton`, because those methods genuinely append via `appendAction()` (`this._actions[name] = this._actions[name] || []`) and so can both create and extend an action.

### No runtime changes

Documentation-only. No API signatures, runtime behaviour, or generated `.d.ts` types are affected. (`@throws` is not emitted by TypeScript declaration generation.)
