### PR TITLE
docs: standardize JSDoc class overviews across components

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -13,8 +13,40 @@ import {
 import { AnimTrack } from '../../anim/evaluator/anim-track.js';
 
 /**
- * The AnimComponent allows an {@link Entity} to playback animations on models and entity
- * properties.
+ * The AnimComponent enables an {@link Entity} to play back animations on models and entity
+ * properties. Animations are driven by animation state graphs, which can be authored in the
+ * PlayCanvas Editor or constructed programmatically, and support blending between multiple
+ * layers and clips.
+ *
+ * You should never need to use the AnimComponent constructor directly. To add an AnimComponent
+ * to an {@link Entity}, use {@link Entity#addComponent}:
+ *
+ * ```javascript
+ * const entity = new pc.Entity();
+ * entity.addComponent('anim', {
+ *     activate: true,
+ *     speed: 1
+ * });
+ * ```
+ *
+ * Once the AnimComponent is added to the entity, you can access it via the {@link Entity#anim}
+ * property:
+ *
+ * ```javascript
+ * entity.anim.speed = 2; // Play animations at double speed
+ *
+ * console.log(entity.anim.speed); // Get the playback speed and print it
+ * ```
+ *
+ * Relevant Engine API examples:
+ *
+ * - [1D Blend Trees](https://playcanvas.github.io/#/animation/blend-trees-1d)
+ * - [2D Cartesian Blend Trees](https://playcanvas.github.io/#/animation/blend-trees-2d-cartesian)
+ * - [2D Directional Blend Trees](https://playcanvas.github.io/#/animation/blend-trees-2d-directional)
+ * - [Animation Events](https://playcanvas.github.io/#/animation/events)
+ * - [Component Properties](https://playcanvas.github.io/#/animation/component-properties)
+ * - [Layer Masks](https://playcanvas.github.io/#/animation/layer-masks)
+ * - [Locomotion](https://playcanvas.github.io/#/animation/locomotion)
  *
  * @hideconstructor
  * @category Animation

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -13,7 +13,29 @@ import { Component } from '../component.js';
  */
 
 /**
- * The Animation Component allows an Entity to playback animations on models.
+ * The AnimationComponent enables an {@link Entity} to play back skeletal animations on a model.
+ * It is a legacy component that has largely been superseded by {@link AnimComponent}, which
+ * supports more advanced features such as animation state graphs and blending.
+ *
+ * You should never need to use the AnimationComponent constructor directly. To add an
+ * AnimationComponent to an {@link Entity}, use {@link Entity#addComponent}:
+ *
+ * ```javascript
+ * const entity = new pc.Entity();
+ * entity.addComponent('animation', {
+ *     assets: [animationAsset.id],
+ *     speed: 1
+ * });
+ * ```
+ *
+ * Once the AnimationComponent is added to the entity, you can access it via the
+ * {@link Entity#animation} property:
+ *
+ * ```javascript
+ * entity.animation.speed = 2; // Play the animation at double speed
+ *
+ * console.log(entity.animation.speed); // Get the playback speed and print it
+ * ```
  *
  * @hideconstructor
  * @category Animation

--- a/src/framework/components/audio-listener/component.js
+++ b/src/framework/components/audio-listener/component.js
@@ -13,6 +13,15 @@ import { Component } from '../component.js';
  * entity.addComponent('audiolistener');
  * ```
  *
+ * Once the AudioListenerComponent is added to the entity, you can access it via the
+ * {@link Entity#audiolistener} property:
+ *
+ * ```javascript
+ * entity.audiolistener.enabled = false; // Disable the audio listener
+ *
+ * console.log(entity.audiolistener.enabled); // Get the enabled state and print it
+ * ```
+ *
  * Relevant Engine API examples:
  *
  * - [Positional Sound](https://playcanvas.github.io/#/sound/positional)

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -43,8 +43,36 @@ STATES_TO_SPRITE_FRAME_NAMES[VisualState.PRESSED] = 'pressedSpriteFrame';
 STATES_TO_SPRITE_FRAME_NAMES[VisualState.INACTIVE] = 'inactiveSpriteFrame';
 
 /**
- * A ButtonComponent enables a group of entities to behave like a button, with different visual
- * states for hover and press interactions.
+ * The ButtonComponent enables an {@link Entity} to behave like a button, with different visual
+ * states for hover and press interactions. It is designed to be used together with an
+ * {@link ElementComponent} on the same entity, which provides the button's visual appearance and
+ * input hit area.
+ *
+ * You should never need to use the ButtonComponent constructor directly. To add a
+ * ButtonComponent to an {@link Entity}, use {@link Entity#addComponent}:
+ *
+ * ```javascript
+ * const entity = new pc.Entity();
+ * entity.addComponent('element', {
+ *     type: pc.ELEMENTTYPE_IMAGE,
+ *     useInput: true
+ * });
+ * entity.addComponent('button');
+ * ```
+ *
+ * Once the ButtonComponent is added to the entity, you can access it via the
+ * {@link Entity#button} property:
+ *
+ * ```javascript
+ * entity.button.hoverTint = pc.Color.YELLOW; // Set the hover tint color
+ *
+ * console.log(entity.button.hoverTint);      // Get the hover tint color and print it
+ * ```
+ *
+ * Relevant Engine API examples:
+ *
+ * - [Basic Button](https://playcanvas.github.io/#/user-interface/button-basic)
+ * - [Sprite Button](https://playcanvas.github.io/#/user-interface/button-sprite)
  *
  * @hideconstructor
  * @category User Interface

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -60,6 +60,13 @@ import { PostEffectQueue } from './post-effect-queue.js';
  * console.log(entity.camera.nearClip); // Get the near clip of the camera
  * ```
  *
+ * Relevant Engine API examples:
+ *
+ * - [First Person Camera](https://playcanvas.github.io/#/camera/first-person)
+ * - [Fly Camera](https://playcanvas.github.io/#/camera/fly)
+ * - [Multiple Cameras](https://playcanvas.github.io/#/camera/multi)
+ * - [Orbit Camera](https://playcanvas.github.io/#/camera/orbit)
+ *
  * @hideconstructor
  * @category Graphics
  */

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -22,18 +22,18 @@ const _quat = new Quat();
  * When an entity is configured as a trigger volume, if an entity with a dynamic or kinematic body
  * enters or leaves that trigger volume, both entities will receive trigger events.
  *
- * You should never need to use the CollisionComponent constructor directly. To add an
+ * You should never need to use the CollisionComponent constructor directly. To add a
  * CollisionComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = pc.Entity();
+ * const entity = new pc.Entity();
  * entity.addComponent('collision'); // This defaults to 1x1x1 box-shaped trigger volume
  * ```
  *
  * To create a 0.5 radius dynamic rigid body sphere:
  *
  * ```javascript
- * const entity = pc.Entity();
+ * const entity = new pc.Entity();
  * entity.addComponent('collision', {
  *     type: 'sphere'
  * });

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -49,7 +49,7 @@ const matD = new Mat4();
  * ElementComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = pc.Entity();
+ * const entity = new pc.Entity();
  * entity.addComponent('element'); // This defaults to a 'group' element
  * ```
  *

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -38,9 +38,9 @@ const matC = new Mat4();
 const matD = new Mat4();
 
 /**
- * ElementComponents are used to construct user interfaces. The {@link ElementComponent#type}
- * property can be configured in 3 main ways: as a text element, as an image element or as a group
- * element. If the ElementComponent has a {@link ScreenComponent} ancestor in the hierarchy, it
+ * ElementComponents are used to construct user interfaces. The {@link type} property can be
+ * configured in 3 main ways: as a text element, as an image element or as a group element. If
+ * the ElementComponent has a {@link ScreenComponent} ancestor in the hierarchy, it
  * will be transformed with respect to the coordinate system of the screen. If there is no
  * {@link ScreenComponent} ancestor, the ElementComponent will be transformed like any other
  * entity.

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -26,11 +26,11 @@ import { PickerId } from '../../../scene/picker-id.js';
  * `gsplat` which supports multiple file formats including `.ply`, `.sog`, `.meta.json` (SOG
  * format), and `.lod-meta.json` (streaming LOD format).
  *
- * You should never need to use the GSplatComponent constructor directly. To add an
+ * You should never need to use the GSplatComponent constructor directly. To add a
  * GSplatComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = pc.Entity();
+ * const entity = new pc.Entity();
  * entity.addComponent('gsplat', {
  *     asset: asset
  * });

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -47,8 +47,8 @@ import { PickerId } from '../../../scene/picker-id.js';
  *
  * ## Unified Rendering
  *
- * The {@link GSplatComponent#unified} property enables unified rendering mode, which provides
- * advanced features for Gaussian Splats:
+ * The {@link unified} property enables unified rendering mode, which provides advanced features
+ * for Gaussian Splats:
  *
  * - **Global Sorting**: Multiple splat components are sorted together in a single unified sort,
  *   eliminating visibility artifacts and popping effects when splat components overlap.

--- a/src/framework/components/joint/component.js
+++ b/src/framework/components/joint/component.js
@@ -28,7 +28,8 @@ const properties = [
 ];
 
 /**
- * The JointComponent adds a physics joint constraint linking two rigid bodies.
+ * The JointComponent enables an {@link Entity} to act as a physics joint constraint that links
+ * two rigid bodies, controlling the relative motion between them.
  *
  * @ignore
  */

--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -1,8 +1,33 @@
 import { Component } from '../component.js';
 
 /**
- * A LayoutChildComponent enables the Entity to control the sizing applied to it by its parent
- * {@link LayoutGroupComponent}.
+ * The LayoutChildComponent enables an {@link Entity} to control the sizing and fitting behavior
+ * applied to it by its parent {@link LayoutGroupComponent}. It allows per-child overrides of
+ * minimum and maximum dimensions as well as fit priority.
+ *
+ * You should never need to use the LayoutChildComponent constructor directly. To add a
+ * LayoutChildComponent to an {@link Entity}, use {@link Entity#addComponent}:
+ *
+ * ```javascript
+ * const entity = new pc.Entity();
+ * entity.addComponent('element', {
+ *     type: pc.ELEMENTTYPE_IMAGE
+ * });
+ * entity.addComponent('layoutchild', {
+ *     minWidth: 50,
+ *     maxWidth: 200,
+ *     fitWidthProportion: 1
+ * });
+ * ```
+ *
+ * Once the LayoutChildComponent is added to the entity, you can access it via the
+ * {@link Entity#layoutchild} property:
+ *
+ * ```javascript
+ * entity.layoutchild.minWidth = 80; // Increase the minimum width
+ *
+ * console.log(entity.layoutchild.minWidth); // Get the minimum width and print it
+ * ```
  *
  * @hideconstructor
  * @category User Interface

--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -3,7 +3,7 @@ import { Component } from '../component.js';
 /**
  * The LayoutChildComponent enables an {@link Entity} to control the sizing and fitting behavior
  * applied to it by its parent {@link LayoutGroupComponent}. It allows per-child overrides of
- * minimum and maximum dimensions as well as fit priority.
+ * minimum and maximum dimensions as well as fit proportions.
  *
  * You should never need to use the LayoutChildComponent constructor directly. To add a
  * LayoutChildComponent to an {@link Entity}, use {@link Entity#addComponent}:

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -20,8 +20,36 @@ function isEnabledAndHasEnabledElement(entity) {
 }
 
 /**
- * A LayoutGroupComponent enables the Entity to position and scale child {@link ElementComponent}s
- * according to configurable layout rules.
+ * The LayoutGroupComponent enables an {@link Entity} to position and scale its child
+ * {@link ElementComponent}s according to configurable layout rules. It supports horizontal and
+ * vertical orientations and a variety of alignment, spacing, wrapping and sizing options.
+ *
+ * You should never need to use the LayoutGroupComponent constructor directly. To add a
+ * LayoutGroupComponent to an {@link Entity}, use {@link Entity#addComponent}:
+ *
+ * ```javascript
+ * const entity = new pc.Entity();
+ * entity.addComponent('element', {
+ *     type: pc.ELEMENTTYPE_GROUP
+ * });
+ * entity.addComponent('layoutgroup', {
+ *     orientation: pc.ORIENTATION_HORIZONTAL,
+ *     spacing: new pc.Vec2(10, 0)
+ * });
+ * ```
+ *
+ * Once the LayoutGroupComponent is added to the entity, you can access it via the
+ * {@link Entity#layoutgroup} property:
+ *
+ * ```javascript
+ * entity.layoutgroup.spacing = new pc.Vec2(20, 0); // Increase spacing between children
+ *
+ * console.log(entity.layoutgroup.spacing);         // Get the spacing and print it
+ * ```
+ *
+ * Relevant Engine API examples:
+ *
+ * - [Layout Group](https://playcanvas.github.io/#/user-interface/layout-group)
  *
  * @hideconstructor
  * @category User Interface

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -25,7 +25,7 @@ import { properties } from './data.js';
  * - `spot`: A local light that emits light similarly to an omni light but is bounded by a cone
  * centered on the owner entity's negative y-axis. Emulates flashlights, spotlights, etc.
  *
- * You should never need to use the LightComponent constructor directly. To add an LightComponent
+ * You should never need to use the LightComponent constructor directly. To add a LightComponent
  * to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -48,6 +48,7 @@ import { Component } from '../component.js';
  * console.log(entity.model.type); // Get the model component's type and print it
  * ```
  *
+ * @hideconstructor
  * @category Graphics
  */
 class ModelComponent extends Component {

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -90,19 +90,50 @@ const ASSET_PROPERTIES = ['colorMapAsset', 'normalMapAsset', 'meshAsset', 'rende
 let depthLayer;
 
 /**
- * Used to simulate particles and produce renderable particle mesh on either CPU or GPU. GPU
- * simulation is generally much faster than its CPU counterpart, because it avoids slow CPU-GPU
- * synchronization and takes advantage of many GPU cores. However, it requires client to support
- * reasonable uniform count, reading from multiple textures in vertex shader and OES_texture_float
- * extension, including rendering into float textures. Most mobile devices fail to satisfy these
- * requirements, so it's not recommended to simulate thousands of particles on them. GPU version
- * also can't sort particles, so enabling sorting forces CPU mode too. Particle rotation is
- * specified by a single angle parameter: default billboard particles rotate around camera facing
- * axis, while mesh particles rotate around 2 different view-independent axes. Most of the
- * simulation parameters are specified with {@link Curve} or {@link CurveSet}. Curves are
- * interpolated based on each particle's lifetime, therefore parameters are able to change over
- * time. Most of the curve parameters can also be specified by 2 minimum/maximum curves, this way
- * each particle will pick a random value in-between.
+ * The ParticleSystemComponent enables an {@link Entity} to simulate particles and produce a
+ * renderable particle mesh on either CPU or GPU. GPU simulation is generally much faster than
+ * its CPU counterpart, because it avoids slow CPU-GPU synchronization and takes advantage of
+ * many GPU cores. However, it requires client support for reasonable uniform counts, reading
+ * from multiple textures in a vertex shader and the OES_texture_float extension, including
+ * rendering into float textures. Most mobile devices fail to satisfy these requirements, so it's
+ * not recommended to simulate thousands of particles on them. The GPU version also can't sort
+ * particles, so enabling sorting forces CPU mode too.
+ *
+ * Particle rotation is specified by a single angle parameter: default billboard particles rotate
+ * around the camera-facing axis, while mesh particles rotate around two different view-independent
+ * axes. Most of the simulation parameters are specified with {@link Curve} or {@link CurveSet}.
+ * Curves are interpolated based on each particle's lifetime, therefore parameters are able to
+ * change over time. Most curve parameters can also be specified by 2 minimum/maximum curves, so
+ * that each particle picks a random value in-between.
+ *
+ * You should never need to use the ParticleSystemComponent constructor directly. To add a
+ * ParticleSystemComponent to an {@link Entity}, use {@link Entity#addComponent}:
+ *
+ * ```javascript
+ * const entity = new pc.Entity();
+ * entity.addComponent('particlesystem', {
+ *     numParticles: 100,
+ *     lifetime: 2,
+ *     rate: 0.1
+ * });
+ * ```
+ *
+ * Once the ParticleSystemComponent is added to the entity, you can access it via the
+ * {@link Entity#particlesystem} property:
+ *
+ * ```javascript
+ * entity.particlesystem.loop = false; // Play the system once then stop
+ *
+ * console.log(entity.particlesystem.loop); // Get the loop flag and print it
+ * ```
+ *
+ * Relevant Engine API examples:
+ *
+ * - [Particle Animated Index](https://playcanvas.github.io/#/graphics/particles-anim-index)
+ * - [Particle Mesh](https://playcanvas.github.io/#/graphics/particles-mesh)
+ * - [Particle Random Sprites](https://playcanvas.github.io/#/graphics/particles-random-sprites)
+ * - [Particle Snow](https://playcanvas.github.io/#/graphics/particles-snow)
+ * - [Particle Spark](https://playcanvas.github.io/#/graphics/particles-spark)
  *
  * @hideconstructor
  * @category Graphics

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -55,6 +55,7 @@ import { Component } from '../component.js';
  * - [Primitive Shapes](https://playcanvas.github.io/#/graphics/shapes)
  * - [Spinning Cube](https://playcanvas.github.io/#/misc/hello-world)
  *
+ * @hideconstructor
  * @category Graphics
  */
 class RenderComponent extends Component {

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -26,12 +26,12 @@ const _vec3 = new Vec3();
  * collide with other rigid bodies. Using scripts, you can apply forces and impulses to rigid
  * bodies.
  *
- * You should never need to use the RigidBodyComponent constructor directly. To add an
+ * You should never need to use the RigidBodyComponent constructor directly. To add a
  * RigidBodyComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
  * // Create a static 1x1x1 box-shaped rigid body
- * const entity = pc.Entity();
+ * const entity = new pc.Entity();
  * entity.addComponent('collision'); // Without options, this defaults to a 1x1x1 box shape
  * entity.addComponent('rigidbody'); // Without options, this defaults to a 'static' body
  * ```
@@ -39,7 +39,7 @@ const _vec3 = new Vec3();
  * To create a dynamic sphere with mass of 10, do:
  *
  * ```javascript
- * const entity = pc.Entity();
+ * const entity = new pc.Entity();
  * entity.addComponent('collision', {
  *     type: 'sphere'
  * });

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -18,21 +18,19 @@ import { getScriptName } from '../../script/script.js';
 const toLowerCamelCase = str => str[0].toLowerCase() + str.substring(1);
 
 /**
- * The ScriptComponent allows you add custom behavior to an {@link Entity} by attaching
- * your own scripts written in JavaScript (or TypeScript).
+ * The ScriptComponent enables an {@link Entity} to have custom behavior by attaching scripts
+ * written in JavaScript (or TypeScript).
  *
  * You should never need to use the ScriptComponent constructor directly. To add a
- * ScriptComponent to an Entity, use {@link Entity#addComponent}:
+ * ScriptComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
  * const entity = new pc.Entity();
  * entity.addComponent('script');
  * ```
  *
- * Once the ScriptComponent is added to the entity, you can access it via the {@link Entity#script}
- * property.
- *
- * Add scripts to the entity by calling the `create` method:
+ * Once the ScriptComponent is added to the entity, you can access it via the
+ * {@link Entity#script} property:
  *
  * ```javascript
  * // Option 1: Add a script using the name registered in the ScriptRegistry

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -20,8 +20,39 @@ import { Component } from '../component.js';
 const _tempScrollValue = new Vec2();
 
 /**
- * A ScrollViewComponent enables a group of entities to behave like a masked scrolling area, with
- * optional horizontal and vertical scroll bars.
+ * The ScrollViewComponent enables an {@link Entity} to behave like a masked scrolling area, with
+ * optional horizontal and vertical scroll bars. The component exposes references to child
+ * entities that represent the viewport, the content, and the (optional) horizontal and vertical
+ * {@link ScrollbarComponent}s.
+ *
+ * You should never need to use the ScrollViewComponent constructor directly. To add a
+ * ScrollViewComponent to an {@link Entity}, use {@link Entity#addComponent}:
+ *
+ * ```javascript
+ * const entity = new pc.Entity();
+ * entity.addComponent('element', {
+ *     type: pc.ELEMENTTYPE_GROUP,
+ *     useInput: true
+ * });
+ * entity.addComponent('scrollview', {
+ *     horizontal: false,
+ *     vertical: true,
+ *     bounceAmount: 0.1
+ * });
+ * ```
+ *
+ * Once the ScrollViewComponent is added to the entity, you can access it via the
+ * {@link Entity#scrollview} property:
+ *
+ * ```javascript
+ * entity.scrollview.scroll = new pc.Vec2(0, 1); // Scroll to the top
+ *
+ * console.log(entity.scrollview.scroll);        // Get the scroll position and print it
+ * ```
+ *
+ * Relevant Engine API examples:
+ *
+ * - [Scroll View](https://playcanvas.github.io/#/user-interface/scroll-view)
  *
  * @hideconstructor
  * @category User Interface

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -19,17 +19,29 @@ import { ElementDragHelper } from '../element/element-drag-helper.js';
  * contents of a scroll view area.
  *
  * You should never need to use the ScrollbarComponent constructor directly. To add a
- * ScrollbarComponent to an {@link Entity}, use {@link Entity#addComponent}:
+ * ScrollbarComponent to an {@link Entity}, use {@link Entity#addComponent}. A draggable
+ * scrollbar requires a child handle entity with an input-enabled {@link ElementComponent},
+ * wired up via the scrollbar's {@link handleEntity} property:
  *
  * ```javascript
+ * // Create a child handle entity that the user can drag
+ * const handle = new pc.Entity();
+ * handle.addComponent('element', {
+ *     type: pc.ELEMENTTYPE_IMAGE,
+ *     useInput: true
+ * });
+ *
+ * // Create the scrollbar entity and wire in the handle
  * const entity = new pc.Entity();
+ * entity.addChild(handle);
  * entity.addComponent('element', {
  *     type: pc.ELEMENTTYPE_IMAGE
  * });
  * entity.addComponent('scrollbar', {
  *     orientation: pc.ORIENTATION_VERTICAL,
  *     value: 0,
- *     handleSize: 0.5
+ *     handleSize: 0.5,
+ *     handleEntity: handle
  * });
  * ```
  *

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -14,7 +14,33 @@ import { ElementDragHelper } from '../element/element-drag-helper.js';
  */
 
 /**
- * A ScrollbarComponent enables a group of entities to behave like a draggable scrollbar.
+ * The ScrollbarComponent enables an {@link Entity} to behave like a draggable scrollbar. It is
+ * typically used together with a {@link ScrollViewComponent} to allow the user to scroll the
+ * contents of a scroll view area.
+ *
+ * You should never need to use the ScrollbarComponent constructor directly. To add a
+ * ScrollbarComponent to an {@link Entity}, use {@link Entity#addComponent}:
+ *
+ * ```javascript
+ * const entity = new pc.Entity();
+ * entity.addComponent('element', {
+ *     type: pc.ELEMENTTYPE_IMAGE
+ * });
+ * entity.addComponent('scrollbar', {
+ *     orientation: pc.ORIENTATION_VERTICAL,
+ *     value: 0,
+ *     handleSize: 0.5
+ * });
+ * ```
+ *
+ * Once the ScrollbarComponent is added to the entity, you can access it via the
+ * {@link Entity#scrollbar} property:
+ *
+ * ```javascript
+ * entity.scrollbar.value = 0.25; // Scroll the bar to 25%
+ *
+ * console.log(entity.scrollbar.value); // Get the scroll value and print it
+ * ```
  *
  * @hideconstructor
  * @category User Interface

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -33,9 +33,9 @@ const PARAM_ATLAS_RECT = 'atlasRect';
 
 /**
  * The SpriteComponent enables an {@link Entity} to render a simple static sprite or sprite
- * animations. The {@link SpriteComponent#type} property can be set to either
- * {@link SPRITETYPE_SIMPLE} to render a single frame from a sprite asset, or
- * {@link SPRITETYPE_ANIMATED} to play one or more {@link SpriteAnimationClip}s.
+ * animations. The {@link type} property can be set to either {@link SPRITETYPE_SIMPLE} to render
+ * a single frame from a sprite asset, or {@link SPRITETYPE_ANIMATED} to play one or more
+ * {@link SpriteAnimationClip}s.
  *
  * You should never need to use the SpriteComponent constructor directly. To add a
  * SpriteComponent to an {@link Entity}, use {@link Entity#addComponent}:

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -32,7 +32,29 @@ const PARAM_OUTER_SCALE = 'outerScale';
 const PARAM_ATLAS_RECT = 'atlasRect';
 
 /**
- * Enables an Entity to render a simple static sprite or sprite animations.
+ * The SpriteComponent enables an {@link Entity} to render a simple static sprite or sprite
+ * animations. The {@link SpriteComponent#type} property can be set to either
+ * {@link SPRITETYPE_SIMPLE} to render a single frame from a sprite asset, or
+ * {@link SPRITETYPE_ANIMATED} to play one or more {@link SpriteAnimationClip}s.
+ *
+ * You should never need to use the SpriteComponent constructor directly. To add a
+ * SpriteComponent to an {@link Entity}, use {@link Entity#addComponent}:
+ *
+ * ```javascript
+ * const entity = new pc.Entity();
+ * entity.addComponent('sprite', {
+ *     spriteAsset: spriteAsset
+ * });
+ * ```
+ *
+ * Once the SpriteComponent is added to the entity, you can access it via the
+ * {@link Entity#sprite} property:
+ *
+ * ```javascript
+ * entity.sprite.color = pc.Color.RED; // Tint the sprite red
+ *
+ * console.log(entity.sprite.color);   // Get the sprite tint and print it
+ * ```
  *
  * @hideconstructor
  * @category Graphics

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -7,11 +7,10 @@ import { Component } from '../component.js';
  */
 
 /**
- * The ZoneComponent allows you to define an area in world space of certain size. This can be used
- * in various ways, such as affecting audio reverb when {@link AudioListenerComponent} is within
- * zone. Or create culling system with portals between zones to hide whole indoor sections for
- * performance reasons. And many other possible options. Zones are building blocks and meant to be
- * used in many different ways.
+ * The ZoneComponent enables an {@link Entity} to define a box-shaped area in world space of a
+ * certain size. Zones are a building block that can be used in various ways, such as affecting
+ * audio reverb when an {@link AudioListenerComponent} is within the zone, or creating a culling
+ * system with portals between zones to hide whole indoor sections for performance reasons.
  *
  * @ignore
  */


### PR DESCRIPTION
## Summary

Standardizes the class-level JSDoc overview of every public component in `src/framework/components/*/component.js` to a single common template derived from the best-documented components (`ElementComponent`, `RigidBodyComponent`).

Each public component's class-level JSDoc now follows this structure:

1. Description paragraph(s) - what the component does and why.
2. `You should never need to use the XxxComponent constructor directly. To add a XxxComponent to an {@link Entity}, use {@link Entity#addComponent}:`
3. Fenced `addComponent` example (plus optional extra variants).
4. `Once the XxxComponent is added to the entity, you can access it via the {@link Entity#xxx} property:`
5. Fenced getter/setter example via `entity.xxx`.
6. Optional `Relevant Engine API examples:` bullet list - only included when real examples exist on `playcanvas.github.io`.
7. `@hideconstructor` and `@category`.

## Changes by component

Gold-standard normalizations (grammar + `new pc.Entity()`):
- `element`, `rigid-body`, `collision`, `light`, `gsplat`

Additive fixes:
- `camera`: added `Relevant Engine API examples:` section.
- `render`, `model`: added missing `@hideconstructor`.
- `audio-listener`: added the missing access-via-`entity.audiolistener` paragraph and example.
- `script`: reshaped prose-only access description into a proper access-via-`entity.script` block.

Expanded from one-line descriptions to the full template:
- `sprite`, `button`, `scrollbar`, `scroll-view`, `layout-group`, `layout-child`, `animation`, `anim`, `particle-system`

`@ignore` components (kept hidden, wording only tidied):
- `zone`, `joint`

## Public API changes

None. This PR is documentation-only. No JSDoc annotations affecting generated TypeScript definitions (e.g. types, parameters, return values) have been changed; only class-level overview prose, fenced code examples and `@hideconstructor` / `@category` tags on component classes were touched.

## Test plan

- [x] CI passes (lint + type generation + build).
- [x] Spot-check generated API reference for a few components (e.g. `SpriteComponent`, `CameraComponent`, `AudioListenerComponent`) to confirm the new sections render correctly.
