### PR TITLE
docs: fix url param JSDoc in ResourceHandler and ContainerHandler

### DIFF
--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -215,11 +215,10 @@ class ContainerHandler extends ResourceHandler {
     }
 
     /**
-     * @param {string|object} url - Either the URL of the resource to load or a structure
-     * containing the load and original URL.
-     * @param {string} [url.load] - The URL to be used for loading the resource.
-     * @param {string} [url.original] - The original URL to be used for identifying the resource
-     * format. This is necessary when loading, for example from blob.
+     * @param {string | {load: string, original: string}} url - Either the URL of the resource to
+     * load or a structure containing the load URL (used for loading the resource) and the original
+     * URL (used for identifying the resource format; necessary when loading, for example, from
+     * blob).
      * @param {ResourceHandlerCallback} callback - The callback used when the resource is loaded or
      * an error occurs.
      * @param {Asset} [asset] - Optional asset that is passed by ResourceLoader.

--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -218,7 +218,7 @@ class ContainerHandler extends ResourceHandler {
      * @param {string | {load: string, original: string}} url - Either the URL of the resource to
      * load or a structure containing the load URL (used for loading the resource) and the original
      * URL (used for identifying the resource format; necessary when loading, for example, from
-     * blob).
+     * a blob URL).
      * @param {ResourceHandlerCallback} callback - The callback used when the resource is loaded or
      * an error occurs.
      * @param {Asset} [asset] - Optional asset that is passed by ResourceLoader.

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -63,11 +63,10 @@ class ResourceHandler {
     /**
      * Load a resource from a remote URL. The base implementation does nothing.
      *
-     * @param {string|object} url - Either the URL of the resource to load or a structure
-     * containing the load and original URL.
-     * @param {string} [url.load] - The URL to be used for loading the resource.
-     * @param {string} [url.original] - The original URL to be used for identifying the resource
-     * format. This is necessary when loading, for example from blob.
+     * @param {string | {load: string, original: string}} url - Either the URL of the resource to
+     * load or a structure containing the load URL (used for loading the resource) and the original
+     * URL (used for identifying the resource format; necessary when loading, for example, from
+     * blob).
      * @param {ResourceHandlerCallback} callback - The callback used when the resource is loaded or
      * an error occurs.
      * @param {Asset} [asset] - Optional asset that is passed by ResourceLoader.

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -66,7 +66,7 @@ class ResourceHandler {
      * @param {string | {load: string, original: string}} url - Either the URL of the resource to
      * load or a structure containing the load URL (used for loading the resource) and the original
      * URL (used for identifying the resource format; necessary when loading, for example, from
-     * blob).
+     * a blob URL).
      * @param {ResourceHandlerCallback} callback - The callback used when the resource is loaded or
      * an error occurs.
      * @param {Asset} [asset] - Optional asset that is passed by ResourceLoader.


### PR DESCRIPTION
## Summary

Consolidate the separate `url.load` and `url.original` `@param` lines into a single union-typed `@param` on `ResourceHandler.load` and `ContainerHandler.load`. TypeDoc couldn't associate the sub-property `@param`s with the `string|object` union and emitted "unused @param" warnings for each. The union type `string | {load: string, original: string}` describes both accepted shapes accurately.

Clears all six warnings:

- `ContainerHandler.load` @param "url.load" / "url.original"
- `RenderHandler.load` @param "url.load" / "url.original" (inherited)
- `ResourceHandler.load` @param "url.load" / "url.original"

## Test plan

- [x] `npm run docs` - the six targeted warnings are gone.
- [x] Spot-check the generated `ResourceHandler.load` / `ContainerHandler.load` pages.
