### PR TITLE
docs: unlink SHADER_ constants in Material.update

### DIFF
--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -720,7 +720,7 @@ class Material {
      *
      * Note: Shaders are not compiled immediately. Instead, existing shader variants are cleared
      * and new variants will be compiled on-demand as they are needed for different render passes
-     * (e.g., {@link SHADER_FORWARD}, {@link SHADER_SHADOW}).
+     * (e.g., forward, shadow, pick).
      *
      * When global shader chunks are modified, `update()` must be called on each material that
      * should reflect those changes.


### PR DESCRIPTION
## Summary

`Material.update` linked to `SHADER_FORWARD` and `SHADER_SHADOW`, but those constants are undocumented and stripped from the generated docs (via `excludeNotDocumented`), producing TypeDoc warnings on `Material.update`, `ShaderMaterial.update`, and `StandardMaterial.update` (inherited).

Replace the links with a plain list of example pass names (forward, shadow, pick) which is more readable and avoids referencing constants that aren't part of the public API surface.

## Test plan

- [x] `npm run docs` - the three `SHADER_SHADOW` warnings are gone.
