### PR TITLE
docs: unlink renderPasses note in CameraComponent

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1042,7 +1042,7 @@ class CameraComponent extends Component {
     /**
      * Request the scene to generate a texture containing the scene color map. Note that this call
      * is accumulative, and for each enable request, a disable request need to be called. Note that
-     * this setting is ignored when the {@link framePasses} is used.
+     * this setting is ignored when {@link framePasses} is used.
      *
      * @param {boolean} enabled - True to request the generation, false to disable it.
      */
@@ -1061,7 +1061,7 @@ class CameraComponent extends Component {
     /**
      * Request the scene to generate a texture containing the scene depth map. Note that this call
      * is accumulative, and for each enable request, a disable request need to be called. Note that
-     * this setting is ignored when the {@link framePasses} is used.
+     * this setting is ignored when {@link framePasses} is used.
      *
      * @param {boolean} enabled - True to request the generation, false to disable it.
      */

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1042,7 +1042,7 @@ class CameraComponent extends Component {
     /**
      * Request the scene to generate a texture containing the scene color map. Note that this call
      * is accumulative, and for each enable request, a disable request need to be called. Note that
-     * this setting is ignored when the {@link CameraComponent#framePasses} is used.
+     * this setting is ignored when the {@link framePasses} is used.
      *
      * @param {boolean} enabled - True to request the generation, false to disable it.
      */
@@ -1061,7 +1061,7 @@ class CameraComponent extends Component {
     /**
      * Request the scene to generate a texture containing the scene depth map. Note that this call
      * is accumulative, and for each enable request, a disable request need to be called. Note that
-     * this setting is ignored when the {@link CameraComponent#framePasses} is used.
+     * this setting is ignored when the {@link framePasses} is used.
      *
      * @param {boolean} enabled - True to request the generation, false to disable it.
      */

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1042,7 +1042,7 @@ class CameraComponent extends Component {
     /**
      * Request the scene to generate a texture containing the scene color map. Note that this call
      * is accumulative, and for each enable request, a disable request need to be called. Note that
-     * this setting is ignored when the `framePasses` is used.
+     * this setting is ignored when the {@link CameraComponent#framePasses} is used.
      *
      * @param {boolean} enabled - True to request the generation, false to disable it.
      */
@@ -1061,7 +1061,7 @@ class CameraComponent extends Component {
     /**
      * Request the scene to generate a texture containing the scene depth map. Note that this call
      * is accumulative, and for each enable request, a disable request need to be called. Note that
-     * this setting is ignored when the `framePasses` is used.
+     * this setting is ignored when the {@link CameraComponent#framePasses} is used.
      *
      * @param {boolean} enabled - True to request the generation, false to disable it.
      */

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1042,7 +1042,7 @@ class CameraComponent extends Component {
     /**
      * Request the scene to generate a texture containing the scene color map. Note that this call
      * is accumulative, and for each enable request, a disable request need to be called. Note that
-     * this setting is ignored when the {@link CameraComponent#renderPasses} is used.
+     * this setting is ignored when the `framePasses` is used.
      *
      * @param {boolean} enabled - True to request the generation, false to disable it.
      */
@@ -1061,7 +1061,7 @@ class CameraComponent extends Component {
     /**
      * Request the scene to generate a texture containing the scene depth map. Note that this call
      * is accumulative, and for each enable request, a disable request need to be called. Note that
-     * this setting is ignored when the {@link CameraComponent#renderPasses} is used.
+     * this setting is ignored when the `framePasses` is used.
      *
      * @param {boolean} enabled - True to request the generation, false to disable it.
      */


### PR DESCRIPTION
## Summary

`CameraComponent.requestSceneColorMap` and `.requestSceneDepthMap` each linked to `CameraComponent#renderPasses` in a "note" paragraph, but that property is deprecated and `@ignore`d, producing two TypeDoc warnings. Update the note to reference `framePasses` (the non-deprecated property name) instead.

The link still points at an `@ignore`d property, so it continues to emit the same kind of warning - this is not worse than before, and the `@ignore` on `framePasses` will be removed in a follow-up PR, at which point these warnings will go away too.

## Test plan

- [x] `npm run docs` - builds clean aside from the pre-existing `framePasses` "not included" warnings, which will be cleared by the follow-up.
