### PR TITLE
docs: simplify self-referential JSDoc @link tags

### DIFF
--- a/src/core/block-allocator.js
+++ b/src/core/block-allocator.js
@@ -169,8 +169,8 @@ class BlockAllocator {
     _freeRegionCount = 0;
 
     /**
-     * Multiplicative growth factor used by {@link BlockAllocator#updateAllocation}.
-     * When growing, the new capacity is at least `capacity * growMultiplier`.
+     * Multiplicative growth factor used by {@link updateAllocation}. When growing, the new
+     * capacity is at least `capacity * growMultiplier`.
      *
      * @type {number}
      * @private
@@ -182,7 +182,7 @@ class BlockAllocator {
      *
      * @param {number} [capacity] - Initial address space capacity. Defaults to 0.
      * @param {number} [growMultiplier] - Multiplicative growth factor for auto-grow in
-     * {@link BlockAllocator#updateAllocation}. Defaults to 1.1 (10% extra).
+     * {@link updateAllocation}. Defaults to 1.1 (10% extra).
      */
     constructor(capacity = 0, growMultiplier = 1.1) {
         this._growMultiplier = growMultiplier;
@@ -450,8 +450,7 @@ class BlockAllocator {
     /**
      * Free a previously allocated block. Adjacent free regions are merged automatically.
      *
-     * @param {MemBlock} block - The block to free (must have been returned by
-     * {@link BlockAllocator#allocate}).
+     * @param {MemBlock} block - The block to free (must have been returned by {@link allocate}).
      */
     free(block) {
         Debug.assert(block && !block._free, 'BlockAllocator.free: block is null or already free');

--- a/src/core/math/mat4.js
+++ b/src/core/math/mat4.js
@@ -297,8 +297,7 @@ class Mat4 {
      * instance. This function assumes the matrices are affine transformation matrices, where the
      * upper left 3x3 elements are a rotation matrix, and the bottom left 3 elements are
      * translation. The rightmost column is assumed to be [0, 0, 0, 1]. The parameters are not
-     * verified to be in the expected format. This function is faster than general
-     * {@link Mat4#mul2}.
+     * verified to be in the expected format. This function is faster than general {@link mul2}.
      *
      * @param {Mat4} lhs - The affine transformation 4x4 matrix used as the first multiplicand of
      * the operation.

--- a/src/extras/gizmo/rotate-gizmo.js
+++ b/src/extras/gizmo/rotate-gizmo.js
@@ -440,7 +440,7 @@ class RotateGizmo extends TransformGizmo {
 
     /**
      * @type {boolean}
-     * @deprecated Use {@link RotateGizmo#rotationMode} instead.
+     * @deprecated Use {@link rotationMode} instead.
      * @ignore
      */
     set orbitRotation(value) {
@@ -449,7 +449,7 @@ class RotateGizmo extends TransformGizmo {
 
     /**
      * @type {boolean}
-     * @deprecated Use {@link RotateGizmo#rotationMode} instead.
+     * @deprecated Use {@link rotationMode} instead.
      * @ignore
      */
     get orbitRotation() {

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -377,7 +377,7 @@ class ScaleGizmo extends TransformGizmo {
 
     /**
      * @type {boolean}
-     * @deprecated Use {@link ScaleGizmo#flipPlanes} instead.
+     * @deprecated Use {@link flipPlanes} instead.
      * @ignore
      */
     set flipShapes(value) {
@@ -386,7 +386,7 @@ class ScaleGizmo extends TransformGizmo {
 
     /**
      * @type {boolean}
-     * @deprecated Use {@link ScaleGizmo#flipPlanes} instead.
+     * @deprecated Use {@link flipPlanes} instead.
      * @ignore
      */
     get flipShapes() {

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -611,7 +611,7 @@ class TransformGizmo extends Gizmo {
      * @param {number} y - The y coordinate.
      * @param {boolean} isFacing - Whether the axis is facing the camera.
      * @param {boolean} isLine - Whether the axis is a line.
-     * @returns {Vec3} The point (space is {@link coordSpace}).
+     * @returns {Vec3} The point (space is {@link Gizmo#coordSpace}).
      * @protected
      */
     _screenToPoint(x, y, isFacing = false, isLine = false) {

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -310,7 +310,7 @@ class TransformGizmo extends Gizmo {
 
     /**
      * @type {Color}
-     * @deprecated Use {@link TransformGizmo#setTheme} instead.
+     * @deprecated Use {@link setTheme} instead.
      * @ignore
      */
     set xAxisColor(value) {
@@ -330,7 +330,7 @@ class TransformGizmo extends Gizmo {
 
     /**
      * @type {Color}
-     * @deprecated Use {@link TransformGizmo#theme} instead.
+     * @deprecated Use {@link theme} instead.
      * @ignore
      */
     get xAxisColor() {
@@ -339,7 +339,7 @@ class TransformGizmo extends Gizmo {
 
     /**
      * @type {Color}
-     * @deprecated Use {@link TransformGizmo#setTheme} instead.
+     * @deprecated Use {@link setTheme} instead.
      * @ignore
      */
     set yAxisColor(value) {
@@ -359,7 +359,7 @@ class TransformGizmo extends Gizmo {
 
     /**
      * @type {Color}
-     * @deprecated Use {@link TransformGizmo#theme} instead.
+     * @deprecated Use {@link theme} instead.
      * @ignore
      */
     get yAxisColor() {
@@ -368,7 +368,7 @@ class TransformGizmo extends Gizmo {
 
     /**
      * @type {Color}
-     * @deprecated Use {@link TransformGizmo#setTheme} instead.
+     * @deprecated Use {@link setTheme} instead.
      * @ignore
      */
     set zAxisColor(value) {
@@ -388,7 +388,7 @@ class TransformGizmo extends Gizmo {
 
     /**
      * @type {Color}
-     * @deprecated Use {@link TransformGizmo#theme} instead.
+     * @deprecated Use {@link theme} instead.
      * @ignore
      */
     get zAxisColor() {
@@ -397,7 +397,7 @@ class TransformGizmo extends Gizmo {
 
     /**
      * @type {number}
-     * @deprecated Use {@link TransformGizmo#setTheme} instead.
+     * @deprecated Use {@link setTheme} instead.
      * @ignore
      */
     set colorAlpha(value) {
@@ -414,7 +414,7 @@ class TransformGizmo extends Gizmo {
 
     /**
      * @type {number}
-     * @deprecated Use {@link TransformGizmo#theme} instead.
+     * @deprecated Use {@link theme} instead.
      * @ignore
      */
     get colorAlpha() {
@@ -611,7 +611,7 @@ class TransformGizmo extends Gizmo {
      * @param {number} y - The y coordinate.
      * @param {boolean} isFacing - Whether the axis is facing the camera.
      * @param {boolean} isLine - Whether the axis is a line.
-     * @returns {Vec3} The point (space is {@link TransformGizmo#coordSpace}).
+     * @returns {Vec3} The point (space is {@link coordSpace}).
      * @protected
      */
     _screenToPoint(x, y, isFacing = false, isLine = false) {

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -357,7 +357,7 @@ class TranslateGizmo extends TransformGizmo {
 
     /**
      * @type {boolean}
-     * @deprecated Use {@link TranslateGizmo#flipPlanes} instead.
+     * @deprecated Use {@link flipPlanes} instead.
      * @ignore
      */
     set flipShapes(value) {
@@ -366,7 +366,7 @@ class TranslateGizmo extends TransformGizmo {
 
     /**
      * @type {boolean}
-     * @deprecated Use {@link TranslateGizmo#flipPlanes} instead.
+     * @deprecated Use {@link flipPlanes} instead.
      * @ignore
      */
     get flipShapes() {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -236,7 +236,7 @@ class CameraComponent extends Component {
 
     /**
      * @type {FramePass[]|null}
-     * @deprecated Use {@link CameraComponent#framePasses} instead.
+     * @deprecated Use {@link framePasses} instead.
      * @ignore
      */
     set renderPasses(passes) {
@@ -246,7 +246,7 @@ class CameraComponent extends Component {
 
     /**
      * @type {FramePass[]}
-     * @deprecated Use {@link CameraComponent#framePasses} instead.
+     * @deprecated Use {@link framePasses} instead.
      * @ignore
      */
     get renderPasses() {

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -519,9 +519,9 @@ class GSplatComponent extends Component {
     /**
      * Sets whether to use the unified gsplat rendering. Default is false.
      *
-     * Note: Material handling differs between modes. When unified is false, use
-     * {@link GSplatComponent#material}. When unified is true, materials are shared per
-     * camera/layer - use {@link GSplatComponentSystem#getMaterial} instead.
+     * Note: Material handling differs between modes. When unified is false, use {@link material}.
+     * When unified is true, materials are shared per camera/layer - use
+     * {@link GSplatComponentSystem#getMaterial} instead.
      *
      * @type {boolean}
      */
@@ -899,7 +899,7 @@ class GSplatComponent extends Component {
     }
 
     /**
-     * Enable rendering of the component if hidden using {@link GSplatComponent#hide}.
+     * Enable rendering of the component if hidden using {@link hide}.
      */
     show() {
         if (this._instance) {

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -298,8 +298,7 @@ class LayoutGroupComponent extends Component {
 
     /**
      * Sets the height fitting mode to be applied when positioning and scaling child elements.
-     * Identical to {@link LayoutGroupComponent#widthFitting} but for the Y axis. Defaults to
-     * {@link FITTING_NONE}.
+     * Identical to {@link widthFitting} but for the Y axis. Defaults to {@link FITTING_NONE}.
      *
      * @type {number}
      */
@@ -324,9 +323,8 @@ class LayoutGroupComponent extends Component {
      * exceeded. Defaults to false, which means that children will be rendered in a single row
      * (horizontal orientation) or column (vertical orientation). Note that setting wrap to true
      * makes it impossible for the {@link FITTING_BOTH} fitting mode to operate in any logical
-     * manner. For this reason, when wrap is true, a {@link LayoutGroupComponent#widthFitting} or
-     * {@link LayoutGroupComponent#heightFitting} mode of {@link FITTING_BOTH} will be coerced to
-     * {@link FITTING_STRETCH}.
+     * manner. For this reason, when wrap is true, a {@link widthFitting} or {@link heightFitting}
+     * mode of {@link FITTING_BOTH} will be coerced to {@link FITTING_STRETCH}.
      *
      * @type {boolean}
      */

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -468,10 +468,9 @@ class LightComponent extends Component {
 
     /**
      * Sets the distribution of subdivision of the camera frustum for individual shadow cascades.
-     * Only used if {@link LightComponent#numCascades} is larger than 1. Can be a value in range of
-     * 0 and 1. Value of 0 represents a linear distribution, value of 1 represents a logarithmic
-     * distribution. Defaults to 0.5. Larger value increases the resolution of the shadows in the
-     * near distance.
+     * Only used if {@link numCascades} is larger than 1. Can be a value in range of 0 and 1. Value
+     * of 0 represents a linear distribution, value of 1 represents a logarithmic distribution.
+     * Defaults to 0.5. Larger value increases the resolution of the shadows in the near distance.
      *
      * @type {number}
      */

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -1105,8 +1105,8 @@ class ModelComponent extends Component {
     }
 
     /**
-     * Enable rendering of the model if hidden using {@link ModelComponent#hide}. This method sets
-     * all the {@link MeshInstance#visible} property on all mesh instances to true.
+     * Enable rendering of the model if hidden using {@link hide}. This method sets all the
+     * {@link MeshInstance#visible} property on all mesh instances to true.
      */
     show() {
         if (this._model) {

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -231,8 +231,7 @@ class ParticleSystemComponent extends Component {
 
     /**
      * Sets whether the particle system plays automatically on creation. If set to false, it is
-     * necessary to call {@link ParticleSystemComponent#play} for the particle system to play.
-     * Defaults to true.
+     * necessary to call {@link play} for the particle system to play. Defaults to true.
      *
      * @type {boolean}
      */

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -924,9 +924,8 @@ class RenderComponent extends Component {
     }
 
     /**
-     * Enable rendering of the component's {@link MeshInstance}s if hidden using
-     * {@link RenderComponent#hide}. This method sets the {@link MeshInstance#visible} property on
-     * all mesh instances to true.
+     * Enable rendering of the component's {@link MeshInstance}s if hidden using {@link hide}. This
+     * method sets the {@link MeshInstance#visible} property on all mesh instances to true.
      */
     show() {
         if (this._meshInstances) {

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -612,7 +612,7 @@ class SoundComponent extends Component {
 
     /**
      * Pauses playback of the slot with the specified name. If the name is undefined then all slots
-     * currently played will be paused. The slots can be resumed by calling {@link SoundComponent#resume}.
+     * currently played will be paused. The slots can be resumed by calling {@link resume}.
      *
      * @param {string} [name] - The name of the slot to pause. Leave undefined to pause everything.
      * @example

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -109,9 +109,9 @@ class ComponentSystem extends EventHandler {
     }
 
     /**
-     * Called during {@link ComponentSystem#addComponent} to initialize the component data in the
-     * store. This can be overridden by derived Component Systems and either called by the derived
-     * System or replaced entirely.
+     * Called during {@link addComponent} to initialize the component data in the store. This can
+     * be overridden by derived Component Systems and either called by the derived System or
+     * replaced entirely.
      *
      * @param {Component} component - The component being initialized.
      * @param {object} data - The data block used to initialize the component.

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -34,9 +34,9 @@ const _int32View = new Int32Array(_floatView.buffer);
  * values to compute world positions.
  *
  * **Main API methods:**
- * - {@link Picker#prepare} - Renders the pick buffer (call once per frame before picking)
- * - {@link Picker#getSelectionAsync} - Get mesh instances in a screen area
- * - {@link Picker#getWorldPointAsync} - Get world position at screen coordinates (requires depth)
+ * - {@link prepare} - Renders the pick buffer (call once per frame before picking)
+ * - {@link getSelectionAsync} - Get mesh instances in a screen area
+ * - {@link getWorldPointAsync} - Get world position at screen coordinates (requires depth)
  *
  * **Performance considerations:**
  * The picker resolution can be set lower than the screen resolution for better performance,
@@ -183,9 +183,9 @@ class Picker {
      * Return the list of mesh instances selected by the specified rectangle in the previously
      * prepared pick buffer. The rectangle using top-left coordinate system.
      *
-     * Note: This function is not supported on WebGPU. Use {@link Picker#getSelectionAsync} instead.
+     * Note: This function is not supported on WebGPU. Use {@link getSelectionAsync} instead.
      * Note: This function is blocks the main thread while reading pixels from GPU memory. It's
-     * recommended to use {@link Picker#getSelectionAsync} instead.
+     * recommended to use {@link getSelectionAsync} instead.
      *
      * @param {number} x - The left edge of the rectangle.
      * @param {number} y - The top edge of the rectangle.
@@ -448,9 +448,9 @@ class Picker {
 
     /**
      * Primes the pick buffer with a rendering of the specified models from the point of view of
-     * the supplied camera. Once the pick buffer has been prepared, {@link Picker#getSelection} can
+     * the supplied camera. Once the pick buffer has been prepared, {@link getSelection} can
      * be called multiple times on the same picker object. Therefore, if the models or camera do
-     * not change in any way, {@link Picker#prepare} does not need to be called again.
+     * not change in any way, {@link prepare} does not need to be called again.
      *
      * @param {CameraComponent} camera - The camera component used to render the scene.
      * @param {Scene} scene - The scene containing the pickable mesh instances.
@@ -486,7 +486,7 @@ class Picker {
      * Sets the resolution of the pick buffer. The pick buffer resolution does not need to match
      * the resolution of the corresponding frame buffer use for general rendering of the 3D scene.
      * However, the lower the resolution of the pick buffer, the less accurate the selection
-     * results returned by {@link Picker#getSelection}. On the other hand, smaller pick buffers
+     * results returned by {@link getSelection}. On the other hand, smaller pick buffers
      * will yield greater performance, so there is a trade off.
      *
      * @param {number} width - The width of the pick buffer in pixels.

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -80,7 +80,7 @@ class ResourceHandler {
      * into a format that can be used at runtime. The base implementation simply returns the data.
      *
      * @param {string} url - The URL of the resource to open.
-     * @param {*} data - The raw resource data passed by callback from {@link ResourceHandler#load}.
+     * @param {*} data - The raw resource data passed by callback from {@link load}.
      * @param {Asset} [asset] - Optional asset that is passed by ResourceLoader.
      * @returns {*} The parsed resource data.
      */

--- a/src/framework/i18n/i18n.js
+++ b/src/framework/i18n/i18n.js
@@ -11,7 +11,7 @@ import { I18nParser } from './i18n-parser.js';
 /**
  * Handles localization. Responsible for loading localization assets and returning translations for
  * a certain key. Can also handle plural forms. To override its default behavior define a different
- * implementation for {@link I18n#getText} and {@link I18n#getPluralText}.
+ * implementation for {@link getText} and {@link getPluralText}.
  */
 class I18n extends EventHandler {
     /**
@@ -342,7 +342,7 @@ class I18n extends EventHandler {
      * Removes localization data.
      *
      * @param {object} data - The localization data. The data is expected to be in the same format
-     * as {@link I18n#addData}.
+     * as {@link addData}.
      */
     removeData(data) {
         let parsed;

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -179,7 +179,7 @@ class SceneRegistry {
      * data which may be undesired behavior with projects that have many scenes.
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
-     * {@link SceneRegistry#find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
+     * {@link find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
      * @param {boolean} storeInCache - Whether to store the loaded data in the scene item.
      * @param {LoadSceneDataCallback} callback - The function to call after loading,
      * passed (err, sceneItem) where err is null if no errors occurred.
@@ -246,11 +246,11 @@ class SceneRegistry {
     /**
      * Loads and stores the scene data to reduce the number of the network requests when the same
      * scenes are loaded multiple times. Can also be used to load data before calling
-     * {@link SceneRegistry#loadSceneHierarchy} and {@link SceneRegistry#loadSceneSettings} to make
-     * scene loading quicker for the user.
+     * {@link loadSceneHierarchy} and {@link loadSceneSettings} to make scene loading quicker for
+     * the user.
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
-     * {@link SceneRegistry#find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
+     * {@link find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
      * @param {LoadSceneDataCallback} callback - The function to call after loading,
      * passed (err, sceneItem) where err is null if no errors occurred.
      * @example
@@ -266,10 +266,10 @@ class SceneRegistry {
     }
 
     /**
-     * Unloads scene data that has been loaded previously using {@link SceneRegistry#loadSceneData}.
+     * Unloads scene data that has been loaded previously using {@link loadSceneData}.
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
-     * {@link SceneRegistry#find} or URL of the scene file. Usually this will be "scene_id.json".
+     * {@link find} or URL of the scene file. Usually this will be "scene_id.json".
      * @example
      * const sceneItem = app.scenes.find("Scene Name");
      * app.scenes.unloadSceneData(sceneItem);
@@ -334,7 +334,7 @@ class SceneRegistry {
      * application root Entity.
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
-     * {@link SceneRegistry#find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
+     * {@link find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
      * @param {LoadHierarchyCallback} callback - The function to call after loading,
      * passed (err, entity) where err is null if no errors occurred.
      * @example
@@ -355,7 +355,7 @@ class SceneRegistry {
      * Load a scene file and apply the scene settings to the current scene.
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
-     * {@link SceneRegistry#find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
+     * {@link find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
      * @param {LoadSettingsCallback} callback - The function called after the settings
      * are applied. Passed (err) where err is null if no error occurred.
      * @example
@@ -388,7 +388,7 @@ class SceneRegistry {
      * entities and graph nodes under `app.root` and load the scene settings and hierarchy.
      *
      * @param {SceneRegistryItem | string} sceneItem - The scene item (which can be found with
-     * {@link SceneRegistry#find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
+     * {@link find}, URL of the scene file (e.g."scene_id.json") or name of the scene.
      * @param {ChangeSceneCallback} [callback] - The function to call after loading,
      * passed (err, entity) where err is null if no errors occurred.
      * @example

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -464,7 +464,7 @@ class XrInputSource extends EventHandler {
     }
 
     /**
-     * If {@link XrInputSource#elementInput} is true, this property will hold entity with Element
+     * If {@link elementInput} is true, this property will hold entity with Element
      * component at which this input source is hovering, or null if not hovering over any element.
      *
      * @type {Entity|null}
@@ -580,8 +580,8 @@ class XrInputSource extends EventHandler {
     }
 
     /**
-     * Get the world space position of input source if it is handheld ({@link XrInputSource#grip}
-     * is true). Otherwise it will return null.
+     * Get the world space position of input source if it is handheld ({@link grip} is true).
+     * Otherwise it will return null.
      *
      * @returns {Vec3|null} The world space position of handheld input source.
      */
@@ -595,8 +595,8 @@ class XrInputSource extends EventHandler {
     }
 
     /**
-     * Get the local space position of input source if it is handheld ({@link XrInputSource#grip}
-     * is true). Local space is relative to parent of the XR camera. Otherwise it will return null.
+     * Get the local space position of input source if it is handheld ({@link grip} is true). Local
+     * space is relative to parent of the XR camera. Otherwise it will return null.
      *
      * @returns {Vec3|null} The local space position of handheld input source.
      */
@@ -605,8 +605,8 @@ class XrInputSource extends EventHandler {
     }
 
     /**
-     * Get the world space rotation of input source if it is handheld ({@link XrInputSource#grip}
-     * is true). Otherwise it will return null.
+     * Get the world space rotation of input source if it is handheld ({@link grip} is true).
+     * Otherwise it will return null.
      *
      * @returns {Quat|null} The world space rotation of handheld input source.
      */
@@ -620,8 +620,8 @@ class XrInputSource extends EventHandler {
     }
 
     /**
-     * Get the local space rotation of input source if it is handheld ({@link XrInputSource#grip}
-     * is true). Local space is relative to parent of the XR camera. Otherwise it will return null.
+     * Get the local space rotation of input source if it is handheld ({@link grip} is true). Local
+     * space is relative to parent of the XR camera. Otherwise it will return null.
      *
      * @returns {Quat|null} The local space rotation of handheld input source.
      */
@@ -631,7 +631,7 @@ class XrInputSource extends EventHandler {
 
     /**
      * Get the linear velocity (units per second) of the input source if it is handheld
-     * ({@link XrInputSource#grip} is true). Otherwise it will return null.
+     * ({@link grip} is true). Otherwise it will return null.
      *
      * @returns {Vec3|null} The world space linear velocity of the handheld input source.
      */

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -18,7 +18,7 @@ import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, FILTER_NEAREST, PIXELFORMAT_R32F,
  */
 class XrView extends EventHandler {
     /**
-     * Fired when the depth sensing texture been resized. The {@link XrView#depthUvMatrix} needs
+     * Fired when the depth sensing texture been resized. The {@link depthUvMatrix} needs
      * to be updated for relevant shaders. The handler is passed the new width and height of the
      * depth texture in pixels.
      *
@@ -212,7 +212,7 @@ class XrView extends EventHandler {
      * and more.
      * The format of this texture is any of {@link PIXELFORMAT_LA8}, {@link PIXELFORMAT_DEPTH}, or
      * {@link PIXELFORMAT_R32F} based on {@link XrViews#depthPixelFormat}. It is UV transformed
-     * based on the underlying AR system which can be normalized using {@link XrView#depthUvMatrix}.
+     * based on the underlying AR system which can be normalized using {@link depthUvMatrix}.
      * Equals to null if camera depth is not supported.
      *
      * @type {Texture|null}

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -18,7 +18,7 @@ import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, FILTER_NEAREST, PIXELFORMAT_R32F,
  */
 class XrView extends EventHandler {
     /**
-     * Fired when the depth sensing texture been resized. The {@link depthUvMatrix} needs
+     * Fired when the depth sensing texture has been resized. The {@link depthUvMatrix} needs
      * to be updated for relevant shaders. The handler is passed the new width and height of the
      * depth texture in pixels.
      *

--- a/src/platform/graphics/draw-commands.js
+++ b/src/platform/graphics/draw-commands.js
@@ -3,8 +3,8 @@ import { Debug } from '../../core/debug.js';
 /**
  * Container holding parameters for multi-draw commands.
  *
- * Obtain an instance via {@link MeshInstance#setMultiDraw} and populate it using
- * {@link DrawCommands#add} followed by {@link DrawCommands#update}.
+ * Obtain an instance via {@link MeshInstance#setMultiDraw} and populate it using {@link add}
+ * followed by {@link update}.
  *
  * @category Graphics
  */

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -273,7 +273,7 @@ class GraphicsDevice extends EventHandler {
      * True if the device supports the WGSL subgroup_uniformity extension, which allows
      * subgroup functionality to be considered uniform in more cases during shader compilation.
      * This is automatically enabled via the `enable subgroups;` directive when
-     * {@link GraphicsDevice#supportsSubgroups} is true.
+     * {@link supportsSubgroups} is true.
      *
      * @readonly
      * @type {boolean}
@@ -1117,9 +1117,8 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * Sets the width and height of the canvas, then fires the `resizecanvas` event. Note that the
-     * specified width and height values will be multiplied by the value of
-     * {@link GraphicsDevice#maxPixelRatio} to give the final resultant width and height for the
-     * canvas.
+     * specified width and height values will be multiplied by the value of {@link maxPixelRatio}
+     * to give the final resultant width and height for the canvas.
      *
      * @param {number} width - The new width of the canvas.
      * @param {number} height - The new height of the canvas.
@@ -1136,7 +1135,7 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * Sets the width and height of the canvas, then fires the `resizecanvas` event. Note that the
-     * value of {@link GraphicsDevice#maxPixelRatio} is ignored.
+     * value of {@link maxPixelRatio} is ignored.
      *
      * @param {number} width - The new width of the canvas.
      * @param {number} height - The new height of the canvas.

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -110,7 +110,7 @@ class RenderTarget {
      *
      * @param {object} [options] - Object for passing optional arguments.
      * @param {boolean} [options.autoResolve] - If samples > 1, enables or disables automatic MSAA
-     * resolve after rendering to this RT (see {@link RenderTarget#resolve}). Defaults to true.
+     * resolve after rendering to this RT (see {@link resolve}). Defaults to true.
      * @param {Texture} [options.colorBuffer] - The texture that this render target will treat as a
      * rendering surface.
      * @param {Texture[]} [options.colorBuffers] - The textures that this render target will treat

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -106,7 +106,7 @@ class Mouse extends EventHandler {
     }
 
     /**
-     * Check if the mouse pointer has been locked, using {@link Mouse#enablePointerLock}.
+     * Check if the mouse pointer has been locked, using {@link enablePointerLock}.
      *
      * @returns {boolean} True if locked.
      */

--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -939,7 +939,7 @@ class SoundInstance extends EventHandler {
     }
 
     /**
-     * Clears any external nodes set by {@link SoundInstance#setExternalNodes}.
+     * Clears any external nodes set by {@link setExternalNodes}.
      */
     clearExternalNodes() {
         const speakers = this._manager.context.destination;
@@ -960,10 +960,10 @@ class SoundInstance extends EventHandler {
     }
 
     /**
-     * Gets any external nodes set by {@link SoundInstance#setExternalNodes}.
+     * Gets any external nodes set by {@link setExternalNodes}.
      *
      * @returns {AudioNode[]} Returns an array that contains the two nodes set by
-     * {@link SoundInstance#setExternalNodes}.
+     * {@link setExternalNodes}.
      */
     getExternalNodes() {
         return [this._firstNode, this._lastNode];

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -108,8 +108,7 @@ class BatchManager {
      * @param {boolean} dynamic - Is this batch group dynamic? Will these objects move/rotate/scale
      * after being batched?
      * @param {number} maxAabbSize - Maximum size of any dimension of a bounding box around batched
-     * objects.
-     * {@link BatchManager#prepare} will split objects into local groups based on this size.
+     * objects. {@link prepare} will split objects into local groups based on this size.
      * @param {number} [id] - Optional custom unique id for the group (will be generated
      * automatically otherwise).
      * @param {number[]} [layers] - Optional layer ID array. Default is [{@link LAYERID_WORLD}].
@@ -478,7 +477,7 @@ class BatchManager {
      * This is useful to keep a balance between the number of draw calls and the number of drawn
      * triangles, because smaller batches can be hidden when not visible in camera.
      * @returns {MeshInstance[][]} An array of arrays of mesh instances, each valid to pass to
-     * {@link BatchManager#create}.
+     * {@link create}.
      */
     prepare(meshInstances, dynamic, maxAabbSize = Number.POSITIVE_INFINITY, translucent) {
         if (meshInstances.length === 0) return [];
@@ -664,7 +663,7 @@ class BatchManager {
     }
 
     /**
-     * Takes a mesh instance list that has been prepared by {@link BatchManager#prepare}, and
+     * Takes a mesh instance list that has been prepared by {@link prepare}, and
      * returns a {@link Batch} object. This method assumes that all mesh instances provided can be
      * rendered in a single draw call.
      *

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -45,7 +45,7 @@ class LayerComposition extends EventHandler {
     layerNameMap = new Map();
 
     /**
-     * A mapping of {@link Layer} to its opaque index in {@link LayerComposition#layerList}.
+     * A mapping of {@link Layer} to its opaque index in {@link layerList}.
      *
      * @type {Map<Layer, number>}
      * @ignore
@@ -53,7 +53,7 @@ class LayerComposition extends EventHandler {
     layerOpaqueIndexMap = new Map();
 
     /**
-     * A mapping of {@link Layer} to its transparent index in {@link LayerComposition#layerList}.
+     * A mapping of {@link Layer} to its transparent index in {@link layerList}.
      *
      * @type {Map<Layer, number>}
      * @ignore
@@ -61,7 +61,7 @@ class LayerComposition extends EventHandler {
     layerTransparentIndexMap = new Map();
 
     /**
-     * A read-only array of boolean values, matching {@link LayerComposition#layerList}. True means only
+     * A read-only array of boolean values, matching {@link layerList}. True means only
      * semi-transparent objects are rendered, and false means opaque.
      *
      * @type {boolean[]}
@@ -70,7 +70,7 @@ class LayerComposition extends EventHandler {
     subLayerList = [];
 
     /**
-     * A read-only array of boolean values, matching {@link LayerComposition#layerList}. True means the
+     * A read-only array of boolean values, matching {@link layerList}. True means the
      * layer is rendered, false means it's skipped.
      *
      * @type {boolean[]}
@@ -412,7 +412,7 @@ class LayerComposition extends EventHandler {
     // Whole layer API
 
     /**
-     * Adds a layer (both opaque and semi-transparent parts) to the end of the {@link LayerComposition#layerList}.
+     * Adds a layer (both opaque and semi-transparent parts) to the end of the {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to add.
      */
@@ -433,7 +433,7 @@ class LayerComposition extends EventHandler {
 
     /**
      * Inserts a layer (both opaque and semi-transparent parts) at the chosen index in the
-     * {@link LayerComposition#layerList}.
+     * {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to add.
      * @param {number} index - Insertion position.
@@ -455,7 +455,7 @@ class LayerComposition extends EventHandler {
     }
 
     /**
-     * Removes a layer (both opaque and semi-transparent parts) from {@link LayerComposition#layerList}.
+     * Removes a layer (both opaque and semi-transparent parts) from {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to remove.
      */
@@ -486,7 +486,7 @@ class LayerComposition extends EventHandler {
 
     /**
      * Adds part of the layer with opaque (non semi-transparent) objects to the end of the
-     * {@link LayerComposition#layerList}.
+     * {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to add.
      */
@@ -504,7 +504,7 @@ class LayerComposition extends EventHandler {
 
     /**
      * Inserts an opaque part of the layer (non semi-transparent mesh instances) at the chosen
-     * index in the {@link LayerComposition#layerList}.
+     * index in the {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to add.
      * @param {number} index - Insertion position.
@@ -527,7 +527,7 @@ class LayerComposition extends EventHandler {
 
     /**
      * Removes an opaque part of the layer (non semi-transparent mesh instances) from
-     * {@link LayerComposition#layerList}.
+     * {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to remove.
      */
@@ -553,7 +553,7 @@ class LayerComposition extends EventHandler {
     }
 
     /**
-     * Adds part of the layer with semi-transparent objects to the end of the {@link LayerComposition#layerList}.
+     * Adds part of the layer with semi-transparent objects to the end of the {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to add.
      */
@@ -570,7 +570,7 @@ class LayerComposition extends EventHandler {
     }
 
     /**
-     * Inserts a semi-transparent part of the layer at the chosen index in the {@link LayerComposition#layerList}.
+     * Inserts a semi-transparent part of the layer at the chosen index in the {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to add.
      * @param {number} index - Insertion position.
@@ -592,7 +592,7 @@ class LayerComposition extends EventHandler {
     }
 
     /**
-     * Removes a transparent part of the layer from {@link LayerComposition#layerList}.
+     * Removes a transparent part of the layer from {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to remove.
      */
@@ -618,7 +618,7 @@ class LayerComposition extends EventHandler {
     }
 
     /**
-     * Gets index of the opaque part of the supplied layer in the {@link LayerComposition#layerList}.
+     * Gets index of the opaque part of the supplied layer in the {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to find index of.
      * @returns {number} The index of the opaque part of the specified layer, or -1 if it is not
@@ -629,7 +629,7 @@ class LayerComposition extends EventHandler {
     }
 
     /**
-     * Gets index of the semi-transparent part of the supplied layer in the {@link LayerComposition#layerList}.
+     * Gets index of the semi-transparent part of the supplied layer in the {@link layerList}.
      *
      * @param {Layer} layer - A {@link Layer} to find index of.
      * @returns {number} The index of the semi-transparent part of the specified layer, or -1 if it

--- a/src/scene/graphics/fisheye-projection.js
+++ b/src/scene/graphics/fisheye-projection.js
@@ -1,8 +1,8 @@
 /**
  * Helper that caches derived fisheye projection values from a normalized slider value, camera FOV,
  * and projection matrix. Each consumer (renderer, culling, future skydome) creates its own instance
- * and calls {@link FisheyeProjection#update} when it needs current values. The instance only
- * mutates its own cached fields, with no external side effects.
+ * and calls {@link update} when it needs current values. The instance only mutates its own cached
+ * fields, with no external side effects.
  *
  * Uses the generalized fisheye model g(θ) = k·tan(θ/k), where k controls the projection
  * characteristic: k=1 is rectilinear perspective, lower k increases barrel distortion.

--- a/src/scene/graphics/quad-render.js
+++ b/src/scene/graphics/quad-render.js
@@ -25,9 +25,9 @@ const _dynamicBindGroup = new DynamicBindGroup();
 /**
  * An object that renders a quad using a {@link Shader}.
  *
- * Note: QuadRender does not modify render states. Before calling {@link QuadRender#render},
- * you should set up the required states using {@link GraphicsDevice#setDrawStates}, or the
- * individual setters ({@link GraphicsDevice#setBlendState}, {@link GraphicsDevice#setCullMode},
+ * Note: QuadRender does not modify render states. Before calling {@link render}, you should set
+ * up the required states using {@link GraphicsDevice#setDrawStates}, or the individual setters
+ * ({@link GraphicsDevice#setBlendState}, {@link GraphicsDevice#setCullMode},
  * {@link GraphicsDevice#setFrontFace}, {@link GraphicsDevice#setDepthState},
  * {@link GraphicsDevice#setStencilState}). Otherwise previously set states will be used.
  *

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -242,14 +242,14 @@ class GSplatParams {
         return this._debug;
     }
 
-    /** @deprecated Use {@link GSplatParams#debug} with {@link GSPLAT_DEBUG_LOD} instead. */
+    /** @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_LOD} instead. */
     set colorizeLod(value) {
         Debug.deprecated('GSplatParams#colorizeLod is deprecated. Use GSplatParams#debug = GSPLAT_DEBUG_LOD instead.');
         this.debug = value ? GSPLAT_DEBUG_LOD : GSPLAT_DEBUG_NONE;
     }
 
     /**
-     * @deprecated Use {@link GSplatParams#debug} with {@link GSPLAT_DEBUG_LOD} instead.
+     * @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_LOD} instead.
      * @returns {boolean} Whether LOD colorization is enabled.
      */
     get colorizeLod() {
@@ -320,8 +320,7 @@ class GSplatParams {
      * Value 1 means no penalty; higher values drop LOD faster for nodes behind the camera.
      *
      * Note: when using a penalty > 1, it often makes sense to set a positive
-     * {@link GSplatParams#lodUpdateAngle} so LOD is re-evaluated on camera rotation,
-     * not just translation.
+     * {@link lodUpdateAngle} so LOD is re-evaluated on camera rotation, not just translation.
      *
      * @type {number}
      */
@@ -501,14 +500,14 @@ class GSplatParams {
      */
     useFog = true;
 
-    /** @deprecated Use {@link GSplatParams#debug} with {@link GSPLAT_DEBUG_SH_UPDATE} instead. */
+    /** @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_SH_UPDATE} instead. */
     set colorizeColorUpdate(value) {
         Debug.deprecated('GSplatParams#colorizeColorUpdate is deprecated. Use GSplatParams#debug = GSPLAT_DEBUG_SH_UPDATE instead.');
         this.debug = value ? GSPLAT_DEBUG_SH_UPDATE : GSPLAT_DEBUG_NONE;
     }
 
     /**
-     * @deprecated Use {@link GSplatParams#debug} with {@link GSPLAT_DEBUG_SH_UPDATE} instead.
+     * @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_SH_UPDATE} instead.
      * @returns {boolean} Whether SH update colorization is enabled.
      */
     get colorizeColorUpdate() {
@@ -692,7 +691,7 @@ class GSplatParams {
      * Note: This only affects Gaussian splat rendering. Other objects in the scene (meshes,
      * sprites, etc.) continue to use the standard camera projection and are not distorted.
      *
-     * For best results, enable {@link GSplatParams#radialSorting} when using fisheye projection
+     * For best results, enable {@link radialSorting} when using fisheye projection
      * to avoid sorting artifacts caused by the wide field of view.
      *
      * Defaults to 0.

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -309,8 +309,8 @@ class Layer {
         /**
          * Custom function that is called after the layer has been enabled. This happens when:
          *
-         * - The layer is created with {@link Layer#enabled} set to true (which is the default value).
-         * - {@link Layer#enabled} was changed from false to true
+         * - The layer is created with {@link enabled} set to true (which is the default value).
+         * - {@link enabled} was changed from false to true
          *
          * @type {Function}
          */
@@ -319,8 +319,8 @@ class Layer {
         /**
          * Custom function that is called after the layer has been disabled. This happens when:
          *
-         * - {@link Layer#enabled} was changed from true to false
-         * - {@link Layer#decrementCounter} was called and set the counter to zero.
+         * - {@link enabled} was changed from true to false
+         * - {@link decrementCounter} was called and set the counter to zero.
          *
          * @type {Function}
          */

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -461,7 +461,7 @@ class Material {
     /**
      * Sets the blend state for this material. Controls how fragment shader outputs are blended
      * when being written to the currently active render target. This overwrites blending type set
-     * using {@link Material#blendType}, and offers more control over blending.
+     * using {@link blendType}, and offers more control over blending.
      *
      * @type {BlendState}
      */
@@ -545,8 +545,8 @@ class Material {
     }
 
     /**
-     * Sets the depth state. Note that this can also be done by using {@link Material#depthTest},
-     * {@link Material#depthFunc} and {@link Material#depthWrite}.
+     * Sets the depth state. Note that this can also be done by using {@link depthTest},
+     * {@link depthFunc} and {@link depthWrite}.
      *
      * @type {DepthState}
      */
@@ -714,7 +714,7 @@ class Material {
      * The method will clear cached shader variants and trigger recompilation if:
      * - Modified material properties require a different shader variant (e.g., enabling/disabling
      *   textures or other properties that affect shader generation)
-     * - Material-specific shader chunks (from {@link Material#getShaderChunks}) have been modified
+     * - Material-specific shader chunks (from {@link getShaderChunks}) have been modified
      * - Global shader chunks (from {@link ShaderChunks.get}) have been modified
      * - Material defines have been changed
      *

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -130,9 +130,9 @@ const _tempColor = new Color();
  * @property {string} specularityFactorVertexColorChannel Vertex color channels to use for specularity factor. Can be
  * "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} enableGGXSpecular Enables GGX specular. Also enables
- * {@link StandardMaterial#anisotropyIntensity} parameter to set material anisotropy.
+ * {@link anisotropyIntensity} parameter to set material anisotropy.
  * @property {number} anisotropyIntensity Defines amount of anisotropy. Requires
- * {@link StandardMaterial#enableGGXSpecular} is set to true.
+ * {@link enableGGXSpecular} is set to true.
  * - When anisotropyIntensity == 0, specular is isotropic.
  * - Specular anisotropy increases as anisotropyIntensity value increases to maximum of 1.
  * @property {number} anisotropyRotation Defines the rotation (in degrees) of anisotropy.
@@ -371,8 +371,8 @@ const _tempColor = new Color();
  * @property {string} opacityVertexColorChannel Vertex color channels to use for opacity. Can be
  * "r", "g", "b" or "a".
  * @property {boolean} opacityFadesSpecular Used to specify whether specular and reflections are
- * faded out using {@link StandardMaterial#opacity}. Default is true. When set to false use
- * {@link Material#alphaFade} to fade out materials.
+ * faded out using {@link opacity}. Default is true. When set to false use {@link Material#alphaFade}
+ * to fade out materials.
  * @property {string} opacityDither Used to specify whether opacity is dithered, which allows
  * transparency without alpha blending. Can be:
  *
@@ -391,8 +391,8 @@ const _tempColor = new Color();
  * - {@link DITHER_IGNNOISE}: Opacity is dithered using an interleaved gradient noise.
  *
  * Defaults to {@link DITHER_NONE}.
- * @property {number} alphaFade Used to fade out materials when
- * {@link StandardMaterial#opacityFadesSpecular} is set to false.
+ * @property {number} alphaFade Used to fade out materials when {@link opacityFadesSpecular} is
+ * set to false.
  * @property {Texture|null} normalMap The main (primary) normal map of the material (default is
  * null). The texture must contains normalized, tangent space normals.
  * @property {number} normalMapUv Main (primary) normal map UV channel.

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -371,8 +371,8 @@ const _tempColor = new Color();
  * @property {string} opacityVertexColorChannel Vertex color channels to use for opacity. Can be
  * "r", "g", "b" or "a".
  * @property {boolean} opacityFadesSpecular Used to specify whether specular and reflections are
- * faded out using {@link opacity}. Default is true. When set to false use {@link Material#alphaFade}
- * to fade out materials.
+ * faded out using {@link opacity}. Default is true. When set to false use {@link alphaFade} to
+ * fade out materials.
  * @property {string} opacityDither Used to specify whether opacity is dithered, which allows
  * transparency without alpha blending. Can be:
  *

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -101,9 +101,9 @@ class GeometryVertexStream {
  * There are two ways a mesh can be generated or updated.
  *
  * ### Simple Mesh API
- * {@link Mesh} class provides interfaces such as {@link Mesh#setPositions} and {@link Mesh#setUvs}
- * that provide a simple way to provide vertex and index data for the Mesh, and hiding the
- * complexity of creating the {@link VertexFormat}. This is the recommended interface to use.
+ * {@link Mesh} class provides interfaces such as {@link setPositions} and {@link setUvs} that
+ * provide a simple way to provide vertex and index data for the Mesh, and hiding the complexity
+ * of creating the {@link VertexFormat}. This is the recommended interface to use.
  *
  * A simple example which creates a Mesh with 3 vertices, containing position coordinates only, to
  * form a single triangle.
@@ -589,8 +589,8 @@ class Mesh extends RefCountedObject {
     /**
      * Clears the mesh of existing vertices and indices and resets the {@link VertexFormat}
      * associated with the mesh. This call is typically followed by calls to methods such as
-     * {@link Mesh#setPositions}, {@link Mesh#setVertexStream} or {@link Mesh#setIndices} and
-     * finally {@link Mesh#update} to rebuild the mesh, allowing different {@link VertexFormat}.
+     * {@link setPositions}, {@link setVertexStream} or {@link setIndices} and finally
+     * {@link update} to rebuild the mesh, allowing different {@link VertexFormat}.
      *
      * @param {boolean} [verticesDynamic] - Indicates the {@link VertexBuffer} should be created
      * with {@link BUFFER_DYNAMIC} usage. If not specified, {@link BUFFER_STATIC} is used.
@@ -881,9 +881,9 @@ class Mesh extends RefCountedObject {
      * Defaults to {@link PRIMITIVE_TRIANGLES} if not specified.
      * @param {boolean} [updateBoundingBox] - True to update bounding box. Bounding box is updated
      * only if positions were set since last time update was called, and `componentCount` for
-     * position was 3, otherwise bounding box is not updated. See {@link Mesh#setPositions}.
-     * Defaults to true if not specified. Set this to false to avoid update of the bounding box and
-     * use aabb property to set it instead.
+     * position was 3, otherwise bounding box is not updated. See {@link setPositions}. Defaults to
+     * true if not specified. Set this to false to avoid update of the bounding box and use aabb
+     * property to set it instead.
      */
     update(primitiveType = PRIMITIVE_TRIANGLES, updateBoundingBox = true) {
 

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -58,7 +58,7 @@ class Scene extends EventHandler {
     /**
      * Fired when the skybox is set. The handler is passed the {@link Texture} that is the
      * previously used skybox cubemap texture. The new skybox cubemap texture is in the
-     * {@link Scene#skybox} property.
+     * {@link skybox} property.
      *
      * @event
      * @example
@@ -144,23 +144,23 @@ class Scene extends EventHandler {
 
     /**
      * If enabled, the ambient lighting will be baked into lightmaps. This will be either the
-     * {@link Scene#skybox} if set up, otherwise {@link Scene#ambientLight}. Defaults to false.
+     * {@link skybox} if set up, otherwise {@link ambientLight}. Defaults to false.
      *
      * @type {boolean}
      */
     ambientBake = false;
 
     /**
-     * If {@link Scene#ambientBake} is true, this specifies the brightness of ambient occlusion.
-     * Typical range is -1 to 1. Defaults to 0, representing no change to brightness.
+     * If {@link ambientBake} is true, this specifies the brightness of ambient occlusion. Typical
+     * range is -1 to 1. Defaults to 0, representing no change to brightness.
      *
      * @type {number}
      */
     ambientBakeOcclusionBrightness = 0;
 
     /**
-     * If {@link Scene#ambientBake} is true, this specifies the contrast of ambient occlusion.
-     * Typical range is -1 to 1. Defaults to 0, representing no change to contrast.
+     * If {@link ambientBake} is true, this specifies the contrast of ambient occlusion. Typical
+     * range is -1 to 1. Defaults to 0, representing no change to contrast.
      *
      * @type {number}
      */
@@ -379,8 +379,8 @@ class Scene extends EventHandler {
 
     /**
      * Sets the number of samples used to bake the ambient light into the lightmap. Note that
-     * {@link Scene#ambientBake} must be true for this to have an effect. Defaults to 1. Maximum
-     * value is 255.
+     * {@link ambientBake} must be true for this to have an effect. Defaults to 1. Maximum value
+     * is 255.
      *
      * @type {number}
      */
@@ -399,7 +399,7 @@ class Scene extends EventHandler {
 
     /**
      * Sets the part of the sphere which represents the source of ambient light. Note that
-     * {@link Scene#ambientBake} must be true for this to have an effect. The valid range is 0..1,
+     * {@link ambientBake} must be true for this to have an effect. The valid range is 0..1,
      * representing a part of the sphere from top to the bottom. A value of 0.5 represents the
      * upper hemisphere. A value of 1 represents a full sphere. Defaults to 0.4, which is a smaller
      * upper hemisphere as this requires fewer samples to bake.
@@ -543,9 +543,9 @@ class Scene extends EventHandler {
     }
 
     /**
-     * Sets the range parameter of the bilateral filter. It's used when {@link Scene#lightmapFilterEnabled}
-     * is enabled. Larger value applies more widespread blur. This needs to be a positive non-zero
-     * value. Defaults to 10.
+     * Sets the range parameter of the bilateral filter. It's used when
+     * {@link lightmapFilterEnabled} is enabled. Larger value applies more widespread blur. This
+     * needs to be a positive non-zero value. Defaults to 10.
      *
      * @type {number}
      */
@@ -563,9 +563,9 @@ class Scene extends EventHandler {
     }
 
     /**
-     * Sets the spatial parameter of the bilateral filter. It's used when {@link Scene#lightmapFilterEnabled}
-     * is enabled. Larger value blurs less similar colors. This needs to be a positive non-zero
-     * value. Defaults to 0.2.
+     * Sets the spatial parameter of the bilateral filter. It's used when
+     * {@link lightmapFilterEnabled} is enabled. Larger value blurs less similar colors. This
+     * needs to be a positive non-zero value. Defaults to 0.2.
      *
      * @type {number}
      */


### PR DESCRIPTION
## Summary

- Drops the redundant `ClassName#` prefix from `{@link ClassName#member}` tags when the tag sits inside that class's own JSDoc (class-level block, fields, accessors, or methods). TypeDoc resolves bare `{@link member}` against the enclosing class, so the generated docs are unchanged while the source reads more cleanly.
- Leaves module-scope JSDoc blocks alone: `@callback` / `@typedef` blocks, standalone function/constant JSDoc, and JSDoc of other classes in multi-class files. Cross-class references (e.g. links to a base class from a subclass file) are also untouched.
- Lightly re-flows a handful of JSDoc paragraphs where the shorter link text left an awkward short continuation line, keeping everything within 100 columns and preserving the original wording.

## Scope

36 files touched across `src/`:

- **Components**: `camera`, `gsplat`, `light`, `layout-group`, `particle-system`, `render`, `model`, `sound`, `system`, `rigid-body/system`
- **Scene**: `scene`, `layer`, `mesh`, `composition/layer-composition`, `batching/batch-manager`, `graphics/quad-render`, `graphics/fisheye-projection`, `gsplat-unified/gsplat-params`, `materials/material`, `materials/standard-material`
- **Framework**: `scene-registry`, `handlers/handler`, `graphics/picker`, `i18n/i18n`
- **XR**: `xr-input-source`, `xr-view`
- **Platform**: `graphics/graphics-device`, `graphics/render-target`, `graphics/draw-commands`, `graphics/depth-state`, `sound/instance`, `input/mouse`
- **Extras/gizmo**: `rotate-gizmo`, `translate-gizmo`, `scale-gizmo`, `transform-gizmo`
- **Core**: `math/mat4`, `block-allocator`

## Test plan

- [x] `npm run lint` clean on the touched files (2 unrelated pre-existing lint errors in `test/gltf-roundtrip/roundtrip-test.mjs` remain on `main`)
- [x] `npm run build:types` succeeds
- [x] `npm run docs` produces the same 9 pre-existing TypeDoc warnings as `main` (verified by comparing the warning set against a clean checkout — no new unresolved-link warnings)
- [x] Spot-check a few rendered pages to confirm the cross-references still link correctly
