### PR TITLE
docs: remove redundant JSDoc @type tags from inferable fields

### DIFF
--- a/src/core/block-allocator.js
+++ b/src/core/block-allocator.js
@@ -785,4 +785,3 @@ class BlockAllocator {
 }
 
 export { BlockAllocator, MemBlock };
-

--- a/src/core/block-allocator.js
+++ b/src/core/block-allocator.js
@@ -11,7 +11,6 @@ class MemBlock {
     /**
      * Position in the address space.
      *
-     * @type {number}
      * @private
      */
     _offset = 0;
@@ -19,7 +18,6 @@ class MemBlock {
     /**
      * Size of this block.
      *
-     * @type {number}
      * @private
      */
     _size = 0;
@@ -27,7 +25,6 @@ class MemBlock {
     /**
      * True if this is a free region, false if allocated.
      *
-     * @type {boolean}
      * @private
      */
     _free = true;
@@ -67,7 +64,6 @@ class MemBlock {
     /**
      * Index of the size bucket this free block belongs to, or -1 if not in any bucket.
      *
-     * @type {number}
      * @private
      */
     _bucket = -1;
@@ -139,7 +135,6 @@ class BlockAllocator {
     /**
      * Total address space.
      *
-     * @type {number}
      * @private
      */
     _capacity = 0;
@@ -147,7 +142,6 @@ class BlockAllocator {
     /**
      * Sum of all allocated block sizes.
      *
-     * @type {number}
      * @private
      */
     _usedSize = 0;
@@ -155,7 +149,6 @@ class BlockAllocator {
     /**
      * Sum of all free region sizes.
      *
-     * @type {number}
      * @private
      */
     _freeSize = 0;
@@ -163,7 +156,6 @@ class BlockAllocator {
     /**
      * Number of free regions. Maintained O(1) for the fragmentation metric.
      *
-     * @type {number}
      * @private
      */
     _freeRegionCount = 0;
@@ -793,3 +785,4 @@ class BlockAllocator {
 }
 
 export { BlockAllocator, MemBlock };
+

--- a/src/core/event-handle.js
+++ b/src/core/event-handle.js
@@ -63,6 +63,7 @@ class EventHandle {
 
     /**
      * True if event has been removed.
+     *
      * @private
      */
     _removed = false;

--- a/src/core/event-handle.js
+++ b/src/core/event-handle.js
@@ -128,4 +128,3 @@ class EventHandle {
 }
 
 export { EventHandle };
-

--- a/src/core/event-handle.js
+++ b/src/core/event-handle.js
@@ -63,7 +63,6 @@ class EventHandle {
 
     /**
      * True if event has been removed.
-     * @type {boolean}
      * @private
      */
     _removed = false;
@@ -129,3 +128,4 @@ class EventHandle {
 }
 
 export { EventHandle };
+

--- a/src/core/math/curve.js
+++ b/src/core/math/curve.js
@@ -225,4 +225,3 @@ class Curve {
 }
 
 export { Curve };
-

--- a/src/core/math/curve.js
+++ b/src/core/math/curve.js
@@ -34,8 +34,6 @@ class Curve {
      * Controls how {@link CURVE_SPLINE} tangents are calculated. Valid range is between 0 and 1
      * where 0 results in a non-smooth curve (equivalent to linear interpolation) and 1 results in
      * a very smooth curve. Use 0.5 for a Catmull-Rom spline.
-     *
-     * @type {number}
      */
     tension = 0.5;
 
@@ -227,3 +225,4 @@ class Curve {
 }
 
 export { Curve };
+

--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -25,7 +25,6 @@ class ObjectPool {
     /**
      * The number of object instances that are currently allocated.
      *
-     * @type {number}
      * @private
      */
     _count = 0;
@@ -76,3 +75,4 @@ class ObjectPool {
 }
 
 export { ObjectPool };
+

--- a/src/core/object-pool.js
+++ b/src/core/object-pool.js
@@ -75,4 +75,3 @@ class ObjectPool {
 }
 
 export { ObjectPool };
-

--- a/src/core/ref-counted-object.js
+++ b/src/core/ref-counted-object.js
@@ -2,9 +2,7 @@
  * Base class that implements reference counting for objects.
  */
 class RefCountedObject {
-    /**
-     * @private
-     */
+    /** @private */
     _refCount = 0;
 
     /**

--- a/src/core/ref-counted-object.js
+++ b/src/core/ref-counted-object.js
@@ -3,7 +3,6 @@
  */
 class RefCountedObject {
     /**
-     * @type {number}
      * @private
      */
     _refCount = 0;
@@ -33,3 +32,4 @@ class RefCountedObject {
 }
 
 export { RefCountedObject };
+

--- a/src/core/ref-counted-object.js
+++ b/src/core/ref-counted-object.js
@@ -32,4 +32,3 @@ class RefCountedObject {
 }
 
 export { RefCountedObject };
-

--- a/src/core/shape/bounding-box.js
+++ b/src/core/shape/bounding-box.js
@@ -36,13 +36,11 @@ class BoundingBox {
     halfExtents = new Vec3(0.5, 0.5, 0.5);
 
     /**
-     * @type {Vec3}
      * @private
      */
     _min = new Vec3();
 
     /**
-     * @type {Vec3}
      * @private
      */
     _max = new Vec3();
@@ -496,3 +494,4 @@ class BoundingBox {
 }
 
 export { BoundingBox };
+

--- a/src/core/shape/bounding-box.js
+++ b/src/core/shape/bounding-box.js
@@ -494,4 +494,3 @@ class BoundingBox {
 }
 
 export { BoundingBox };
-

--- a/src/core/shape/bounding-box.js
+++ b/src/core/shape/bounding-box.js
@@ -35,14 +35,10 @@ class BoundingBox {
      */
     halfExtents = new Vec3(0.5, 0.5, 0.5);
 
-    /**
-     * @private
-     */
+    /** @private */
     _min = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _max = new Vec3();
 
     /**

--- a/src/core/shape/oriented-box.js
+++ b/src/core/shape/oriented-box.js
@@ -18,9 +18,7 @@ const tmpMat4 = new Mat4();
  * @category Math
  */
 class OrientedBox {
-    /**
-     * @private
-     */
+    /** @private */
     halfExtents = new Vec3(0.5, 0.5, 0.5);
 
     /**

--- a/src/core/shape/oriented-box.js
+++ b/src/core/shape/oriented-box.js
@@ -131,4 +131,3 @@ class OrientedBox {
 }
 
 export { OrientedBox };
-

--- a/src/core/shape/oriented-box.js
+++ b/src/core/shape/oriented-box.js
@@ -19,7 +19,6 @@ const tmpMat4 = new Mat4();
  */
 class OrientedBox {
     /**
-     * @type {Vec3}
      * @private
      */
     halfExtents = new Vec3(0.5, 0.5, 0.5);
@@ -132,3 +131,4 @@ class OrientedBox {
 }
 
 export { OrientedBox };
+

--- a/src/core/shape/plane.js
+++ b/src/core/shape/plane.js
@@ -13,8 +13,6 @@ import { Vec3 } from '../math/vec3.js';
 class Plane {
     /**
      * The normal of the plane.
-     *
-     * @type {Vec3}
      */
     normal = new Vec3();
 
@@ -148,3 +146,4 @@ class Plane {
 }
 
 export { Plane };
+

--- a/src/core/shape/plane.js
+++ b/src/core/shape/plane.js
@@ -146,4 +146,3 @@ class Plane {
 }
 
 export { Plane };
-

--- a/src/core/sorted-loop-array.js
+++ b/src/core/sorted-loop-array.js
@@ -15,8 +15,6 @@ class SortedLoopArray {
 
     /**
      * The number of elements in the array.
-     *
-     * @type {number}
      */
     length = 0;
 
@@ -24,8 +22,6 @@ class SortedLoopArray {
      * The current index used to loop through the array. This gets modified if we add or remove
      * elements from the array while looping. See the example to see how to loop through this
      * array.
-     *
-     * @type {number}
      */
     loopIndex = -1;
 
@@ -151,3 +147,4 @@ class SortedLoopArray {
 }
 
 export { SortedLoopArray };
+

--- a/src/core/sorted-loop-array.js
+++ b/src/core/sorted-loop-array.js
@@ -147,4 +147,3 @@ class SortedLoopArray {
 }
 
 export { SortedLoopArray };
-

--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -142,9 +142,7 @@ const textureSemantics = [
  * @category Exporter
  */
 class GltfExporter extends CoreExporter {
-    /**
-     * @ignore
-     */
+    /** @ignore */
     collectResources(root) {
         const resources = {
             buffers: [],

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -753,4 +753,3 @@ class Gizmo extends EventHandler {
 }
 
 export { Gizmo };
-

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -152,7 +152,6 @@ class Gizmo extends EventHandler {
     /**
      * Internal version of the gizmo size. Defaults to 1.
      *
-     * @type {number}
      * @private
      */
     _size = 1;
@@ -160,7 +159,6 @@ class Gizmo extends EventHandler {
     /**
      * Internal version of the gizmo scale. Defaults to 1.
      *
-     * @type {number}
      * @protected
      */
     _scale = 1;
@@ -224,7 +222,6 @@ class Gizmo extends EventHandler {
     /**
      * Internal flag to track if a render update is required.
      *
-     * @type {boolean}
      * @protected
      */
     _renderUpdate = false;
@@ -252,8 +249,6 @@ class Gizmo extends EventHandler {
 
     /**
      * Flag to indicate whether to call `preventDefault` on pointer events.
-     *
-     * @type {boolean}
      */
     preventDefault = true;
 
@@ -758,3 +753,4 @@ class Gizmo extends EventHandler {
 }
 
 export { Gizmo };
+

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -530,9 +530,7 @@ class Gizmo extends EventHandler {
         this.fire(Gizmo.EVENT_POINTERUP, e.offsetX, e.offsetY, selection[0]);
     }
 
-    /**
-     * @protected
-     */
+    /** @protected */
     _updatePosition() {
         position.set(0, 0, 0);
         if (this._coordSpace === 'local') {
@@ -555,9 +553,7 @@ class Gizmo extends EventHandler {
         this._renderUpdate = true;
     }
 
-    /**
-     * @protected
-     */
+    /** @protected */
     _updateRotation() {
         rotation.set(0, 0, 0, 1);
         if (this._coordSpace === 'local' && this.nodes.length !== 0) {
@@ -574,9 +570,7 @@ class Gizmo extends EventHandler {
         this._renderUpdate = true;
     }
 
-    /**
-     * @protected
-     */
+    /** @protected */
     _updateScale() {
         if (this._camera.projection === PROJECTION_PERSPECTIVE) {
             const gizmoPos = this.root.getLocalPosition();

--- a/src/extras/gizmo/mesh-line.js
+++ b/src/extras/gizmo/mesh-line.js
@@ -16,13 +16,9 @@ import { unlitShader } from './shaders.js';
 
 const tmpV1 = new Vec3();
 
-/**
- * @ignore
- */
+/** @ignore */
 class MeshLine {
-    /**
-     * @private
-     */
+    /** @private */
     _thickness = 0.02;
 
     /**

--- a/src/extras/gizmo/mesh-line.js
+++ b/src/extras/gizmo/mesh-line.js
@@ -101,4 +101,3 @@ class MeshLine {
 }
 
 export { MeshLine };
-

--- a/src/extras/gizmo/mesh-line.js
+++ b/src/extras/gizmo/mesh-line.js
@@ -21,7 +21,6 @@ const tmpV1 = new Vec3();
  */
 class MeshLine {
     /**
-     * @type {number}
      * @private
      */
     _thickness = 0.02;
@@ -102,3 +101,4 @@ class MeshLine {
 }
 
 export { MeshLine };
+

--- a/src/extras/gizmo/rotate-gizmo.js
+++ b/src/extras/gizmo/rotate-gizmo.js
@@ -815,4 +815,3 @@ class RotateGizmo extends TransformGizmo {
 }
 
 export { RotateGizmo };
-

--- a/src/extras/gizmo/rotate-gizmo.js
+++ b/src/extras/gizmo/rotate-gizmo.js
@@ -115,7 +115,6 @@ class RotateGizmo extends TransformGizmo {
     /**
      * Internal selection starting angle in world space.
      *
-     * @type {number}
      * @private
      */
     _selectionStartAngle = 0;
@@ -147,7 +146,6 @@ class RotateGizmo extends TransformGizmo {
     /**
      * Internal vector for storing the mouse position in screen space.
      *
-     * @type {Vec2}
      * @private
      */
     _screenPos = new Vec2();
@@ -155,7 +153,6 @@ class RotateGizmo extends TransformGizmo {
     /**
      * Internal vector for storing the mouse start position in screen space.
      *
-     * @type {Vec2}
      * @private
      */
     _screenStartPos = new Vec2();
@@ -163,7 +160,6 @@ class RotateGizmo extends TransformGizmo {
     /**
      * Internal vector for the start point of the guide line angle.
      *
-     * @type {Vec3}
      * @private
      */
     _guideAngleStart = new Vec3();
@@ -171,7 +167,6 @@ class RotateGizmo extends TransformGizmo {
     /**
      * Internal vector for the end point of the guide line angle.
      *
-     * @type {Vec3}
      * @private
      */
     _guideAngleEnd = new Vec3();
@@ -187,7 +182,6 @@ class RotateGizmo extends TransformGizmo {
     /**
      * Internal copy of facing direction to avoid unnecessary updates.
      *
-     * @type {Vec3}
      * @private
      */
     _facingDir = new Vec3();
@@ -821,3 +815,4 @@ class RotateGizmo extends TransformGizmo {
 }
 
 export { RotateGizmo };
+

--- a/src/extras/gizmo/rotate-gizmo.js
+++ b/src/extras/gizmo/rotate-gizmo.js
@@ -186,9 +186,7 @@ class RotateGizmo extends TransformGizmo {
      */
     _facingDir = new Vec3();
 
-    /**
-     * @override
-     */
+    /** @override */
     snapIncrement = 5;
 
     /**
@@ -461,9 +459,7 @@ class RotateGizmo extends TransformGizmo {
         this._shapes.z[prop] = value;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _storeGuidePoints() {
         const gizmoPos = this.root.getLocalPosition();
         const axis = this._selectedAxis;
@@ -520,9 +516,7 @@ class RotateGizmo extends TransformGizmo {
         }
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _shapesLookAtCamera() {
         // face shape
         if (this._camera.projection === PROJECTION_PERSPECTIVE) {
@@ -593,9 +587,7 @@ class RotateGizmo extends TransformGizmo {
         this._renderUpdate = true;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _storeNodeRotations() {
         const gizmoPos = this.root.getLocalPosition();
         for (let i = 0; i < this.nodes.length; i++) {
@@ -791,9 +783,7 @@ class RotateGizmo extends TransformGizmo {
         }
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     prerender() {
         super.prerender();
 
@@ -804,9 +794,7 @@ class RotateGizmo extends TransformGizmo {
         this._shapesLookAtCamera();
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     destroy() {
         this._guideAngleLines.forEach(line => line.destroy());
 

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -140,9 +140,7 @@ class ScaleGizmo extends TransformGizmo {
      */
     _uniform = false;
 
-    /**
-     * @override
-     */
+    /** @override */
     snapIncrement = 1;
 
     /**
@@ -410,9 +408,7 @@ class ScaleGizmo extends TransformGizmo {
         this._shapes.xy[prop] = value;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _shapesLookAtCamera() {
         const cameraDir = this.cameraDir;
 
@@ -512,9 +508,7 @@ class ScaleGizmo extends TransformGizmo {
         this._renderUpdate = true;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _storeNodeScales() {
         for (let i = 0; i < this.nodes.length; i++) {
             const node = this.nodes[i];
@@ -591,9 +585,7 @@ class ScaleGizmo extends TransformGizmo {
         return point;
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     prerender() {
         super.prerender();
 

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -136,7 +136,6 @@ class ScaleGizmo extends TransformGizmo {
     /**
      * Internal state if transform should use uniform scaling.
      *
-     * @type {boolean}
      * @protected
      */
     _uniform = false;
@@ -148,15 +147,11 @@ class ScaleGizmo extends TransformGizmo {
 
     /**
      * Flips the planes to face the camera.
-     *
-     * @type {boolean}
      */
     flipPlanes = true;
 
     /**
      * The lower bound for scaling.
-     *
-     * @type {Vec3}
      */
     lowerBoundScale = new Vec3(-Infinity, -Infinity, -Infinity);
 
@@ -611,3 +606,4 @@ class ScaleGizmo extends TransformGizmo {
 }
 
 export { ScaleGizmo };
+

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -606,4 +606,3 @@ class ScaleGizmo extends TransformGizmo {
 }
 
 export { ScaleGizmo };
-

--- a/src/extras/gizmo/shape/arc-shape.js
+++ b/src/extras/gizmo/shape/arc-shape.js
@@ -16,9 +16,7 @@ const TORUS_INTERSECT_SEGMENTS = 20;
  * @property {number} [sectorAngle] - The sector angle.
  */
 
-/**
- * @ignore
- */
+/** @ignore */
 class ArcShape extends Shape {
     /**
      * The internal tube radius of the arc.

--- a/src/extras/gizmo/shape/arc-shape.js
+++ b/src/extras/gizmo/shape/arc-shape.js
@@ -23,7 +23,6 @@ class ArcShape extends Shape {
     /**
      * The internal tube radius of the arc.
      *
-     * @type {number}
      * @private
      */
     _tubeRadius = 0.01;
@@ -31,7 +30,6 @@ class ArcShape extends Shape {
     /**
      * The internal ring radius of the arc.
      *
-     * @type {number}
      * @private
      */
     _ringRadius = 0.5;
@@ -39,7 +37,6 @@ class ArcShape extends Shape {
     /**
      * The internal sector angle of the arc.
      *
-     * @type {number}
      * @private
      */
     _sectorAngle = 360;
@@ -47,7 +44,6 @@ class ArcShape extends Shape {
     /**
      * The internal intersection tolerance of the arc.
      *
-     * @type {number}
      * @private
      */
     _tolerance = 0.05;
@@ -222,3 +218,4 @@ class ArcShape extends Shape {
 }
 
 export { ArcShape };
+

--- a/src/extras/gizmo/shape/arc-shape.js
+++ b/src/extras/gizmo/shape/arc-shape.js
@@ -218,4 +218,3 @@ class ArcShape extends Shape {
 }
 
 export { ArcShape };
-

--- a/src/extras/gizmo/shape/arrow-shape.js
+++ b/src/extras/gizmo/shape/arrow-shape.js
@@ -31,7 +31,6 @@ class ArrowShape extends Shape {
     /**
      * The internal gap between the arrow base and the center.
      *
-     * @type {number}
      * @private
      */
     _gap = 0;
@@ -39,7 +38,6 @@ class ArrowShape extends Shape {
     /**
      * The internal line thickness of the arrow.
      *
-     * @type {number}
      * @private
      */
     _lineThickness = 0.02;
@@ -47,7 +45,6 @@ class ArrowShape extends Shape {
     /**
      * The internal line length of the arrow.
      *
-     * @type {number}
      * @private
      */
     _lineLength = 0.5;
@@ -55,7 +52,6 @@ class ArrowShape extends Shape {
     /**
      * The internal arrow thickness of the arrow.
      *
-     * @type {number}
      * @private
      */
     _arrowThickness = 0.12;
@@ -63,7 +59,6 @@ class ArrowShape extends Shape {
     /**
      * The internal arrow length of the arrow.
      *
-     * @type {number}
      * @private
      */
     _arrowLength = 0.18;
@@ -71,7 +66,6 @@ class ArrowShape extends Shape {
     /**
      * The internal tolerance of the arrow.
      *
-     * @type {number}
      * @private
      */
     _tolerance = 0.1;
@@ -270,3 +264,4 @@ class ArrowShape extends Shape {
 }
 
 export { ArrowShape };
+

--- a/src/extras/gizmo/shape/arrow-shape.js
+++ b/src/extras/gizmo/shape/arrow-shape.js
@@ -264,4 +264,3 @@ class ArrowShape extends Shape {
 }
 
 export { ArrowShape };
-

--- a/src/extras/gizmo/shape/arrow-shape.js
+++ b/src/extras/gizmo/shape/arrow-shape.js
@@ -24,9 +24,7 @@ const tmpQ1 = new Quat();
  * @property {number} [tolerance] - The tolerance for intersection tests
  */
 
-/**
- * @ignore
- */
+/** @ignore */
 class ArrowShape extends Shape {
     /**
      * The internal gap between the arrow base and the center.

--- a/src/extras/gizmo/shape/box-shape.js
+++ b/src/extras/gizmo/shape/box-shape.js
@@ -18,7 +18,6 @@ class BoxShape extends Shape {
     /**
      * The internal size of the box.
      *
-     * @type {number}
      * @private
      */
     _size = 0.06;
@@ -80,3 +79,4 @@ class BoxShape extends Shape {
 }
 
 export { BoxShape };
+

--- a/src/extras/gizmo/shape/box-shape.js
+++ b/src/extras/gizmo/shape/box-shape.js
@@ -11,9 +11,7 @@ import { Shape } from './shape.js';
  * @property {number} [size] - The size of the box.
  */
 
-/**
- * @ignore
- */
+/** @ignore */
 class BoxShape extends Shape {
     /**
      * The internal size of the box.

--- a/src/extras/gizmo/shape/box-shape.js
+++ b/src/extras/gizmo/shape/box-shape.js
@@ -79,4 +79,3 @@ class BoxShape extends Shape {
 }
 
 export { BoxShape };
-

--- a/src/extras/gizmo/shape/boxline-shape.js
+++ b/src/extras/gizmo/shape/boxline-shape.js
@@ -272,4 +272,3 @@ class BoxLineShape extends Shape {
 }
 
 export { BoxLineShape };
-

--- a/src/extras/gizmo/shape/boxline-shape.js
+++ b/src/extras/gizmo/shape/boxline-shape.js
@@ -30,7 +30,6 @@ class BoxLineShape extends Shape {
     /**
      * The internal gap between the box and the line.
      *
-     * @type {number}
      * @private
      */
     _gap = 0;
@@ -38,7 +37,6 @@ class BoxLineShape extends Shape {
     /**
      * The internal line thickness of the box line.
      *
-     * @type {number}
      * @private
      */
     _lineThickness = 0.02;
@@ -46,7 +44,6 @@ class BoxLineShape extends Shape {
     /**
      * The internal line length of the box line.
      *
-     * @type {number}
      * @private
      */
     _lineLength = 0.5;
@@ -54,7 +51,6 @@ class BoxLineShape extends Shape {
     /**
      * The internal box size of the box line.
      *
-     * @type {number}
      * @private
      */
     _boxSize = 0.12;
@@ -62,7 +58,6 @@ class BoxLineShape extends Shape {
     /**
      * The internal tolerance of the box line.
      *
-     * @type {number}
      * @private
      */
     _tolerance = 0.1;
@@ -86,7 +81,6 @@ class BoxLineShape extends Shape {
     /**
      * The internal flipped state of the box line.
      *
-     * @type {boolean}
      * @private
      */
     _flipped = false;
@@ -278,3 +272,4 @@ class BoxLineShape extends Shape {
 }
 
 export { BoxLineShape };
+

--- a/src/extras/gizmo/shape/boxline-shape.js
+++ b/src/extras/gizmo/shape/boxline-shape.js
@@ -23,9 +23,7 @@ const tmpQ1 = new Quat();
  * @property {number} [tolerance] - The tolerance for intersection tests
  */
 
-/**
- * @ignore
- */
+/** @ignore */
 class BoxLineShape extends Shape {
     /**
      * The internal gap between the box and the line.

--- a/src/extras/gizmo/shape/plane-shape.js
+++ b/src/extras/gizmo/shape/plane-shape.js
@@ -157,4 +157,3 @@ class PlaneShape extends Shape {
 }
 
 export { PlaneShape };
-

--- a/src/extras/gizmo/shape/plane-shape.js
+++ b/src/extras/gizmo/shape/plane-shape.js
@@ -31,7 +31,6 @@ class PlaneShape extends Shape {
     /**
      * The size of the plane.
      *
-     * @type {number}
      * @private
      */
     _size = 0.16;
@@ -39,7 +38,6 @@ class PlaneShape extends Shape {
     /**
      * The gap between the plane and the center.
      *
-     * @type {number}
      * @private
      */
     _gap = 0;
@@ -47,7 +45,6 @@ class PlaneShape extends Shape {
     /**
      * The internal flipped state of the plane.
      *
-     * @type {Vec3}
      * @private
      */
     _flipped = new Vec3();
@@ -160,3 +157,4 @@ class PlaneShape extends Shape {
 }
 
 export { PlaneShape };
+

--- a/src/extras/gizmo/shape/plane-shape.js
+++ b/src/extras/gizmo/shape/plane-shape.js
@@ -16,9 +16,7 @@ const UPDATE_EPSILON = 1e-6;
  * @property {number} [gap] - The gap between the plane and the center
  */
 
-/**
- * @ignore
- */
+/** @ignore */
 class PlaneShape extends Shape {
     /**
      * The culling mode for the plane.

--- a/src/extras/gizmo/shape/shape.js
+++ b/src/extras/gizmo/shape/shape.js
@@ -318,4 +318,3 @@ class Shape {
 }
 
 export { Shape };
-

--- a/src/extras/gizmo/shape/shape.js
+++ b/src/extras/gizmo/shape/shape.js
@@ -36,9 +36,7 @@ tmpG.normals = [];
  * @property {number} [depth] - The depth of the shape. -1 = interpolated depth.
  */
 
-/**
- * @ignore
- */
+/** @ignore */
 class Shape {
     /**
      * The internal position of the shape.

--- a/src/extras/gizmo/shape/shape.js
+++ b/src/extras/gizmo/shape/shape.js
@@ -43,7 +43,6 @@ class Shape {
     /**
      * The internal position of the shape.
      *
-     * @type {Vec3}
      * @protected
      */
     _position = new Vec3();
@@ -51,7 +50,6 @@ class Shape {
     /**
      * The internal rotation of the shape.
      *
-     * @type {Vec3}
      * @protected
      */
     _rotation = new Vec3();
@@ -59,7 +57,6 @@ class Shape {
     /**
      * The internal scale of the shape.
      *
-     * @type {Vec3}
      * @protected
      */
     _scale = new Vec3(1, 1, 1);
@@ -84,14 +81,12 @@ class Shape {
      * The internal disabled state of the shape.
      *
      * @protected
-     * @type {boolean}
      */
     _disabled = false;
 
     /**
      * The internal visibility state of the shape.
      *
-     * @type {boolean}
      * @protected
      */
     _visible = true;
@@ -131,7 +126,6 @@ class Shape {
     /**
      * The internal depth state of the shape. -1 = interpolated depth.
      *
-     * @type {number}
      * @protected
      */
     _depth = -1;
@@ -324,3 +318,4 @@ class Shape {
 }
 
 export { Shape };
+

--- a/src/extras/gizmo/shape/sphere-shape.js
+++ b/src/extras/gizmo/shape/sphere-shape.js
@@ -18,7 +18,6 @@ class SphereShape extends Shape {
     /**
      * The internal size of the sphere.
      *
-     * @type {number}
      * @private
      */
     _radius = 0.03;
@@ -84,3 +83,4 @@ class SphereShape extends Shape {
 }
 
 export { SphereShape };
+

--- a/src/extras/gizmo/shape/sphere-shape.js
+++ b/src/extras/gizmo/shape/sphere-shape.js
@@ -83,4 +83,3 @@ class SphereShape extends Shape {
 }
 
 export { SphereShape };
-

--- a/src/extras/gizmo/shape/sphere-shape.js
+++ b/src/extras/gizmo/shape/sphere-shape.js
@@ -11,9 +11,7 @@ import { Shape } from './shape.js';
  * @property {number} [radius] - The radius of the sphere.
  */
 
-/**
- * @ignore
- */
+/** @ignore */
 class SphereShape extends Shape {
     /**
      * The internal size of the sphere.

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -119,7 +119,6 @@ class TransformGizmo extends Gizmo {
     /**
      * Internal gizmo starting rotation in world space.
      *
-     * @type {Vec3}
      * @protected
      */
     _rootStartPos = new Vec3();
@@ -127,7 +126,6 @@ class TransformGizmo extends Gizmo {
     /**
      * Internal gizmo starting rotation in world space.
      *
-     * @type {Quat}
      * @protected
      */
     _rootStartRot = new Quat();
@@ -167,7 +165,6 @@ class TransformGizmo extends Gizmo {
     /**
      * Internal state of if currently hovered shape is a plane.
      *
-     * @type {boolean}
      * @private
      */
     _hoverIsPlane = false;
@@ -183,7 +180,6 @@ class TransformGizmo extends Gizmo {
     /**
      * Internal state of if currently selected shape is a plane.
      *
-     * @type {boolean}
      * @protected
      */
     _selectedIsPlane = false;
@@ -191,22 +187,17 @@ class TransformGizmo extends Gizmo {
     /**
      * Internal selection starting coordinates in world space.
      *
-     * @type {Vec3}
      * @protected
      */
     _selectionStartPoint = new Vec3();
 
     /**
      * Whether snapping is enabled. Defaults to false.
-     *
-     * @type {boolean}
      */
     snap = false;
 
     /**
      * Snapping increment. Defaults to 1.
-     *
-     * @type {number}
      */
     snapIncrement = 1;
 
@@ -804,3 +795,4 @@ class TransformGizmo extends Gizmo {
 }
 
 export { TransformGizmo };
+

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -667,9 +667,7 @@ class TransformGizmo extends Gizmo {
         }
     }
 
-    /**
-     * @protected
-     */
+    /** @protected */
     _createTransform() {
         // shapes
         for (const key in this._shapes) {
@@ -765,9 +763,7 @@ class TransformGizmo extends Gizmo {
         }
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     prerender() {
         super.prerender();
 
@@ -782,9 +778,7 @@ class TransformGizmo extends Gizmo {
         this._drawGuideLines(gizmoPos, gizmoRot, activeAxis, activeIsPlane);
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     destroy() {
         super.destroy();
 

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -795,4 +795,3 @@ class TransformGizmo extends Gizmo {
 }
 
 export { TransformGizmo };
-

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -136,9 +136,7 @@ class TranslateGizmo extends TransformGizmo {
      */
     _nodePositions = new Map();
 
-    /**
-     * @override
-     */
+    /** @override */
     snapIncrement = 1;
 
     /**
@@ -393,9 +391,7 @@ class TranslateGizmo extends TransformGizmo {
         this._shapes.xy[prop] = value;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _shapesLookAtCamera() {
         const cameraDir = this.cameraDir;
 
@@ -494,9 +490,7 @@ class TranslateGizmo extends TransformGizmo {
         this._renderUpdate = true;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _storeNodePositions() {
         for (let i = 0; i < this.nodes.length; i++) {
             const node = this.nodes[i];
@@ -592,9 +586,7 @@ class TranslateGizmo extends TransformGizmo {
         }
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     prerender() {
         super.prerender();
 

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -143,8 +143,6 @@ class TranslateGizmo extends TransformGizmo {
 
     /**
      * Flips the planes to face the camera.
-     *
-     * @type {boolean}
      */
     flipPlanes = true;
 
@@ -609,3 +607,4 @@ class TranslateGizmo extends TransformGizmo {
 }
 
 export { TranslateGizmo };
+

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -607,4 +607,3 @@ class TranslateGizmo extends TransformGizmo {
 }
 
 export { TranslateGizmo };
-

--- a/src/extras/gizmo/tri-data.js
+++ b/src/extras/gizmo/tri-data.js
@@ -88,4 +88,3 @@ class TriData {
 }
 
 export { TriData };
-

--- a/src/extras/gizmo/tri-data.js
+++ b/src/extras/gizmo/tri-data.js
@@ -19,15 +19,11 @@ class TriData {
      *   - priority = 0 - no priority
      *   - priority > 0 - higher value represents a higher priority
      * defaults to 0.
-     *
-     * @type {number}
      */
     _priority = 0;
 
     /**
      * The transform of the triangles.
-     *
-     * @type {Mat4}
      */
     _transform = new Mat4();
 
@@ -92,3 +88,4 @@ class TriData {
 }
 
 export { TriData };
+

--- a/src/extras/gizmo/view-cube.js
+++ b/src/extras/gizmo/view-cube.js
@@ -23,9 +23,7 @@ class ViewCube extends EventHandler {
      */
     static EVENT_CAMERAALIGN = 'camera:align';
 
-    /**
-     * @private
-     */
+    /** @private */
     _size = 0;
 
     /**
@@ -40,49 +38,31 @@ class ViewCube extends EventHandler {
      */
     _group;
 
-    /**
-     * @private
-     */
+    /** @private */
     _anchor = new Vec4(1, 1, 1, 1);
 
-    /**
-     * @private
-     */
+    /** @private */
     _colorX = COLOR_RED.clone();
 
-    /**
-     * @private
-     */
+    /** @private */
     _colorY = COLOR_GREEN.clone();
 
-    /**
-     * @private
-     */
+    /** @private */
     _colorZ = COLOR_BLUE.clone();
 
-    /**
-     * @private
-     */
+    /** @private */
     _colorNeg = new Color(0.3, 0.3, 0.3);
 
-    /**
-     * @private
-     */
+    /** @private */
     _radius = 10;
 
-    /**
-     * @private
-     */
+    /** @private */
     _textSize = 10;
 
-    /**
-     * @private
-     */
+    /** @private */
     _lineThickness = 2;
 
-    /**
-     * @private
-     */
+    /** @private */
     _lineLength = 40;
 
     /**
@@ -312,9 +292,7 @@ class ViewCube extends EventHandler {
         return this._lineLength;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _resize() {
         this._size = 2 * (this.lineLength + this.radius + this.lineThickness);
 

--- a/src/extras/gizmo/view-cube.js
+++ b/src/extras/gizmo/view-cube.js
@@ -450,4 +450,3 @@ class ViewCube extends EventHandler {
 }
 
 export { ViewCube };
-

--- a/src/extras/gizmo/view-cube.js
+++ b/src/extras/gizmo/view-cube.js
@@ -24,7 +24,6 @@ class ViewCube extends EventHandler {
     static EVENT_CAMERAALIGN = 'camera:align';
 
     /**
-     * @type {number}
      * @private
      */
     _size = 0;
@@ -42,55 +41,46 @@ class ViewCube extends EventHandler {
     _group;
 
     /**
-     * @type {Vec4}
      * @private
      */
     _anchor = new Vec4(1, 1, 1, 1);
 
     /**
-     * @type {Color}
      * @private
      */
     _colorX = COLOR_RED.clone();
 
     /**
-     * @type {Color}
      * @private
      */
     _colorY = COLOR_GREEN.clone();
 
     /**
-     * @type {Color}
      * @private
      */
     _colorZ = COLOR_BLUE.clone();
 
     /**
-     * @type {Color}
      * @private
      */
     _colorNeg = new Color(0.3, 0.3, 0.3);
 
     /**
-     * @type {number}
      * @private
      */
     _radius = 10;
 
     /**
-     * @type {number}
      * @private
      */
     _textSize = 10;
 
     /**
-     * @type {number}
      * @private
      */
     _lineThickness = 2;
 
     /**
-     * @type {number}
      * @private
      */
     _lineLength = 40;
@@ -460,3 +450,4 @@ class ViewCube extends EventHandler {
 }
 
 export { ViewCube };
+

--- a/src/extras/input/controllers/fly-controller.js
+++ b/src/extras/input/controllers/fly-controller.js
@@ -31,16 +31,12 @@ class FlyController extends InputController {
     /**
      * The rotation damping. In the range 0 to 1, where a value of 0 means no damping and 1 means
      * full damping. Default is 0.98.
-     *
-     * @type {number}
      */
     rotateDamping = 0.98;
 
     /**
      * The movement damping. In the range 0 to 1, where a value of 0 means no damping and 1 means
      * full damping. Default is 0.98.
-     *
-     * @type {number}
      */
     moveDamping = 0.98;
 
@@ -115,3 +111,4 @@ class FlyController extends InputController {
 }
 
 export { FlyController };
+

--- a/src/extras/input/controllers/fly-controller.js
+++ b/src/extras/input/controllers/fly-controller.js
@@ -111,4 +111,3 @@ class FlyController extends InputController {
 }
 
 export { FlyController };
-

--- a/src/extras/input/controllers/focus-controller.js
+++ b/src/extras/input/controllers/focus-controller.js
@@ -47,8 +47,6 @@ class FocusController extends InputController {
     /**
      * The focus damping. In the range 0 to 1, where a value of 0 means no damping and 1 means
      * full damping. Default is 0.98.
-     *
-     * @type {number}
      */
     focusDamping = 0.98;
 
@@ -114,3 +112,4 @@ class FocusController extends InputController {
 }
 
 export { FocusController };
+

--- a/src/extras/input/controllers/focus-controller.js
+++ b/src/extras/input/controllers/focus-controller.js
@@ -112,4 +112,3 @@ class FocusController extends InputController {
 }
 
 export { FocusController };
-

--- a/src/extras/input/controllers/orbit-controller.js
+++ b/src/extras/input/controllers/orbit-controller.js
@@ -153,4 +153,3 @@ class OrbitController extends InputController {
 }
 
 export { OrbitController };
-

--- a/src/extras/input/controllers/orbit-controller.js
+++ b/src/extras/input/controllers/orbit-controller.js
@@ -46,23 +46,17 @@ class OrbitController extends InputController {
     /**
      * The rotation damping. In the range 0 to 1, where a value of 0 means no damping and 1 means
      * full damping. Default is 0.98.
-     *
-     * @type {number}
      */
     rotateDamping = 0.98;
 
     /**
      * The movement damping. In the range 0 to 1, where a value of 0 means no damping and 1 means
      * full damping. Default is 0.98.
-     *
-     * @type {number}
      */
     moveDamping = 0.98;
 
     /**
      * The zoom damping. A higher value means more damping. A value of 0 means no damping.
-     *
-     * @type {number}
      */
     zoomDamping = 0.98;
 
@@ -159,3 +153,4 @@ class OrbitController extends InputController {
 }
 
 export { OrbitController };
+

--- a/src/extras/input/pose.js
+++ b/src/extras/input/pose.js
@@ -42,19 +42,19 @@ class Pose {
 
     /**
      * The allowed range of positions along the x axis, stored as (min, max). Applied when the
-     * pose is translated via {@link Pose#translate}.
+     * pose is translated via {@link Pose#move}.
      */
     xRange = new Vec2(-Infinity, Infinity);
 
     /**
      * The allowed range of positions along the y axis, stored as (min, max). Applied when the
-     * pose is translated via {@link Pose#translate}.
+     * pose is translated via {@link Pose#move}.
      */
     yRange = new Vec2(-Infinity, Infinity);
 
     /**
      * The allowed range of positions along the z axis, stored as (min, max). Applied when the
-     * pose is translated via {@link Pose#translate}.
+     * pose is translated via {@link Pose#move}.
      */
     zRange = new Vec2(-Infinity, Infinity);
 

--- a/src/extras/input/pose.js
+++ b/src/extras/input/pose.js
@@ -29,22 +29,32 @@ class Pose {
     distance = 0;
 
     /**
+     * The allowed range of pitch angles in degrees, stored as (min, max). Applied when the pose
+     * is rotated via {@link Pose#rotate}.
      */
     pitchRange = new Vec2(-Infinity, Infinity);
 
     /**
+     * The allowed range of yaw angles in degrees, stored as (min, max). Applied when the pose is
+     * rotated via {@link Pose#rotate}.
      */
     yawRange = new Vec2(-Infinity, Infinity);
 
     /**
+     * The allowed range of positions along the x axis, stored as (min, max). Applied when the
+     * pose is translated via {@link Pose#translate}.
      */
     xRange = new Vec2(-Infinity, Infinity);
 
     /**
+     * The allowed range of positions along the y axis, stored as (min, max). Applied when the
+     * pose is translated via {@link Pose#translate}.
      */
     yRange = new Vec2(-Infinity, Infinity);
 
     /**
+     * The allowed range of positions along the z axis, stored as (min, max). Applied when the
+     * pose is translated via {@link Pose#translate}.
      */
     zRange = new Vec2(-Infinity, Infinity);
 

--- a/src/extras/input/pose.js
+++ b/src/extras/input/pose.js
@@ -30,31 +30,31 @@ class Pose {
 
     /**
      * The allowed range of pitch angles in degrees, stored as (min, max). Applied when the pose
-     * is rotated via {@link Pose#rotate}.
+     * is rotated via {@link rotate}.
      */
     pitchRange = new Vec2(-Infinity, Infinity);
 
     /**
      * The allowed range of yaw angles in degrees, stored as (min, max). Applied when the pose is
-     * rotated via {@link Pose#rotate}.
+     * rotated via {@link rotate}.
      */
     yawRange = new Vec2(-Infinity, Infinity);
 
     /**
      * The allowed range of positions along the x axis, stored as (min, max). Applied when the
-     * pose is translated via {@link Pose#move}.
+     * pose is translated via {@link move}.
      */
     xRange = new Vec2(-Infinity, Infinity);
 
     /**
      * The allowed range of positions along the y axis, stored as (min, max). Applied when the
-     * pose is translated via {@link Pose#move}.
+     * pose is translated via {@link move}.
      */
     yRange = new Vec2(-Infinity, Infinity);
 
     /**
      * The allowed range of positions along the z axis, stored as (min, max). Applied when the
-     * pose is translated via {@link Pose#move}.
+     * pose is translated via {@link move}.
      */
     zRange = new Vec2(-Infinity, Infinity);
 

--- a/src/extras/input/pose.js
+++ b/src/extras/input/pose.js
@@ -15,47 +15,36 @@ const rotation = new Quat();
 class Pose {
     /**
      * The position of the pose.
-     *
-     * @type {Vec3}
      */
     position = new Vec3();
 
     /**
      * The angles of the pose in degrees calculated from the forward vector.
-     *
-     * @type {Vec3}
      */
     angles = new Vec3();
 
     /**
      * The focus distance from the position to the pose.
-     *
-     * @type {number}
      */
     distance = 0;
 
     /**
-     * @type {Vec2}
      */
     pitchRange = new Vec2(-Infinity, Infinity);
 
     /**
-     * @type {Vec2}
      */
     yawRange = new Vec2(-Infinity, Infinity);
 
     /**
-     * @type {Vec2}
      */
     xRange = new Vec2(-Infinity, Infinity);
 
     /**
-     * @type {Vec2}
      */
     yRange = new Vec2(-Infinity, Infinity);
 
     /**
-     * @type {Vec2}
      */
     zRange = new Vec2(-Infinity, Infinity);
 
@@ -206,3 +195,4 @@ class Pose {
 }
 
 export { Pose };
+

--- a/src/extras/input/pose.js
+++ b/src/extras/input/pose.js
@@ -205,4 +205,3 @@ class Pose {
 }
 
 export { Pose };
-

--- a/src/extras/input/sources/dual-gesture-source.js
+++ b/src/extras/input/sources/dual-gesture-source.js
@@ -247,9 +247,7 @@ class DualGestureSource extends InputSource {
         super.detach();
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     read() {
         this.deltas.leftInput.append([this._leftJoystick.value.x, this._leftJoystick.value.y]);
         this.deltas.rightInput.append([this._rightJoystick.value.x, this._rightJoystick.value.y]);
@@ -257,9 +255,7 @@ class DualGestureSource extends InputSource {
         return super.read();
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     destroy() {
         this._leftJoystick.up();
         this._rightJoystick.up();

--- a/src/extras/input/sources/gamepad-source.js
+++ b/src/extras/input/sources/gamepad-source.js
@@ -50,9 +50,7 @@ class GamepadSource extends InputSource {
         });
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     read() {
         const gamepads = navigator.getGamepads();
         for (let i = 0; i < gamepads.length; i++) {

--- a/src/extras/input/sources/keyboard-mouse-source.js
+++ b/src/extras/input/sources/keyboard-mouse-source.js
@@ -78,9 +78,7 @@ class KeyboardMouseSource extends InputSource {
      */
     static keyCode = KEY_CODES;
 
-    /**
-     * @private
-     */
+    /** @private */
     _pointerId = -1;
 
     /**
@@ -280,9 +278,7 @@ class KeyboardMouseSource extends InputSource {
         this._setKey(event.code, 0);
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _clearButtons() {
         for (let i = 0; i < this._button.length; i++) {
             if (this._button[i] === 1) {
@@ -345,9 +341,7 @@ class KeyboardMouseSource extends InputSource {
         super.detach();
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     read() {
         for (let i = 0; i < array.length; i++) {
             array[i] = this._keyNow[i] - this._keyPrev[i];

--- a/src/extras/input/sources/keyboard-mouse-source.js
+++ b/src/extras/input/sources/keyboard-mouse-source.js
@@ -79,7 +79,6 @@ class KeyboardMouseSource extends InputSource {
     static keyCode = KEY_CODES;
 
     /**
-     * @type {number}
      * @private
      */
     _pointerId = -1;
@@ -361,3 +360,4 @@ class KeyboardMouseSource extends InputSource {
 }
 
 export { KeyboardMouseSource };
+

--- a/src/extras/input/sources/keyboard-mouse-source.js
+++ b/src/extras/input/sources/keyboard-mouse-source.js
@@ -360,4 +360,3 @@ class KeyboardMouseSource extends InputSource {
 }
 
 export { KeyboardMouseSource };
-

--- a/src/extras/input/sources/multi-touch-source.js
+++ b/src/extras/input/sources/multi-touch-source.js
@@ -30,13 +30,11 @@ class MultiTouchSource extends InputSource {
     _pointerEvents = new Map();
 
     /**
-     * @type {Vec2}
      * @private
      */
     _pointerPos = new Vec2();
 
     /**
-     * @type {number}
      * @private
      */
     _pinchDist = -1;
@@ -206,3 +204,4 @@ class MultiTouchSource extends InputSource {
 }
 
 export { MultiTouchSource };
+

--- a/src/extras/input/sources/multi-touch-source.js
+++ b/src/extras/input/sources/multi-touch-source.js
@@ -29,14 +29,10 @@ class MultiTouchSource extends InputSource {
      */
     _pointerEvents = new Map();
 
-    /**
-     * @private
-     */
+    /** @private */
     _pointerPos = new Vec2();
 
-    /**
-     * @private
-     */
+    /** @private */
     _pinchDist = -1;
 
     constructor() {

--- a/src/extras/input/sources/multi-touch-source.js
+++ b/src/extras/input/sources/multi-touch-source.js
@@ -204,4 +204,3 @@ class MultiTouchSource extends InputSource {
 }
 
 export { MultiTouchSource };
-

--- a/src/extras/input/sources/single-gesture-source.js
+++ b/src/extras/input/sources/single-gesture-source.js
@@ -200,9 +200,7 @@ class SingleGestureSource extends InputSource {
         super.detach();
     }
 
-    /**
-     * @override
-     */
+    /** @override */
     read() {
         this.deltas.input.append([this._joystick.value.x, this._joystick.value.y]);
 

--- a/src/extras/input/sources/virtual-joystick.js
+++ b/src/extras/input/sources/virtual-joystick.js
@@ -5,19 +5,16 @@ const v = new Vec2();
 
 class VirtualJoystick {
     /**
-     * @type {number}
      * @private
      */
     _range = 70;
 
     /**
-     * @type {Vec2}
      * @private
      */
     _position = new Vec2();
 
     /**
-     * @type {Vec2}
      * @private
      */
     _value = new Vec2();
@@ -81,3 +78,4 @@ class VirtualJoystick {
 }
 
 export { VirtualJoystick };
+

--- a/src/extras/input/sources/virtual-joystick.js
+++ b/src/extras/input/sources/virtual-joystick.js
@@ -4,19 +4,13 @@ import { Vec2 } from '../../../core/math/vec2.js';
 const v = new Vec2();
 
 class VirtualJoystick {
-    /**
-     * @private
-     */
+    /** @private */
     _range = 70;
 
-    /**
-     * @private
-     */
+    /** @private */
     _position = new Vec2();
 
-    /**
-     * @private
-     */
+    /** @private */
     _value = new Vec2();
 
     /**

--- a/src/extras/input/sources/virtual-joystick.js
+++ b/src/extras/input/sources/virtual-joystick.js
@@ -78,4 +78,3 @@ class VirtualJoystick {
 }
 
 export { VirtualJoystick };
-

--- a/src/extras/render-passes/frame-pass-camera-frame.js
+++ b/src/extras/render-passes/frame-pass-camera-frame.js
@@ -100,7 +100,6 @@ class FramePassCameraFrame extends FramePass {
     /**
      * True if the render pass needs to be re-created because layers have been added or removed.
      *
-     * @type {boolean}
      * @ignore
      */
     layersDirty = false;
@@ -543,3 +542,4 @@ class FramePassCameraFrame extends FramePass {
 }
 
 export { FramePassCameraFrame, CameraFrameOptions };
+

--- a/src/extras/render-passes/frame-pass-camera-frame.js
+++ b/src/extras/render-passes/frame-pass-camera-frame.js
@@ -542,4 +542,3 @@ class FramePassCameraFrame extends FramePass {
 }
 
 export { FramePassCameraFrame, CameraFrameOptions };
-

--- a/src/extras/render-passes/render-pass-ssao.js
+++ b/src/extras/render-passes/render-pass-ssao.js
@@ -212,4 +212,3 @@ class RenderPassSsao extends RenderPassShaderQuad {
 }
 
 export { RenderPassSsao };
-

--- a/src/extras/render-passes/render-pass-ssao.js
+++ b/src/extras/render-passes/render-pass-ssao.js
@@ -24,37 +24,27 @@ import wgslSsaoPS from '../../scene/shader-lib/wgsl/chunks/render-pass/frag/ssao
 class RenderPassSsao extends RenderPassShaderQuad {
     /**
      * The filter radius.
-     *
-     * @type {number}
      */
     radius = 5;
 
     /**
      * The intensity.
-     *
-     * @type {number}
      */
     intensity = 1;
 
     /**
      * The power controlling the falloff curve.
-     *
-     * @type {number}
      */
     power = 1;
 
     /**
      * The number of samples to take.
-     *
-     * @type {number}
      */
     sampleCount = 10;
 
     /**
      * The minimum angle in degrees that creates an occlusion. Helps to reduce fake occlusions due
      * to low geometry tessellation.
-     *
-     * @type {number}
      */
     minAngle = 5;
 
@@ -222,3 +212,4 @@ class RenderPassSsao extends RenderPassShaderQuad {
 }
 
 export { RenderPassSsao };
+

--- a/src/extras/render-passes/render-pass-taa.js
+++ b/src/extras/render-passes/render-pass-taa.js
@@ -24,8 +24,6 @@ import { ShaderChunks } from '../../scene/shader-lib/shader-chunks.js';
 class RenderPassTAA extends RenderPassShaderQuad {
     /**
      * The index of the history texture to render to.
-     *
-     * @type {number}
      */
     historyIndex = 0;
 
@@ -148,3 +146,4 @@ class RenderPassTAA extends RenderPassShaderQuad {
 }
 
 export { RenderPassTAA };
+

--- a/src/extras/render-passes/render-pass-taa.js
+++ b/src/extras/render-passes/render-pass-taa.js
@@ -146,4 +146,3 @@ class RenderPassTAA extends RenderPassShaderQuad {
 }
 
 export { RenderPassTAA };
-

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -175,13 +175,11 @@ class AppBase extends EventHandler {
     _entityIndex = {};
 
     /**
-     * @type {boolean}
      * @ignore
      */
     _inTools = false;
 
     /**
-     * @type {string}
      * @ignore
      */
     _scriptPrefix = '';
@@ -193,7 +191,6 @@ class AppBase extends EventHandler {
      * Set this to false if you want to run without using bundles. We set it to true only if
      * TextDecoder is available because we currently rely on it for untarring.
      *
-     * @type {boolean}
      * @ignore
      */
     enableBundles = (typeof TextDecoder !== 'undefined');
@@ -208,7 +205,6 @@ class AppBase extends EventHandler {
     /**
      * Scales the global time delta. Defaults to 1.
      *
-     * @type {number}
      * @example
      * // Set the app to run at half speed
      * this.app.timeScale = 0.5;
@@ -230,7 +226,6 @@ class AppBase extends EventHandler {
     /**
      * The total number of frames the application has updated since start() was called.
      *
-     * @type {number}
      * @ignore
      */
     frame = 0;
@@ -271,7 +266,6 @@ class AppBase extends EventHandler {
      * false is useful to applications where the rendered image may often be unchanged over time.
      * This can heavily reduce the application's load on the CPU and GPU. Defaults to true.
      *
-     * @type {boolean}
      * @example
      * // Disable rendering every frame and only render on a keydown event
      * this.app.autoRender = false;
@@ -286,7 +280,6 @@ class AppBase extends EventHandler {
      * effect if {@link autoRender} is set to false. The value of renderNextFrame is set back to
      * false again as soon as the scene has been rendered.
      *
-     * @type {boolean}
      * @example
      * // Render the scene only while space key is pressed
      * if (this.app.keyboard.isPressed(pc.KEY_SPACE)) {
@@ -2131,3 +2124,4 @@ const makeTick = function (_app) {
 };
 
 export { app, AppBase };
+

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -174,14 +174,10 @@ class AppBase extends EventHandler {
      */
     _entityIndex = {};
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     _inTools = false;
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     _scriptPrefix = '';
 
     /** @ignore */

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -2124,4 +2124,3 @@ const makeTick = function (_app) {
 };
 
 export { app, AppBase };
-

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -160,7 +160,6 @@ class Asset extends EventHandler {
     /**
      * Whether to preload the asset.
      *
-     * @type {boolean}
      * @private
      */
     _preload = false;
@@ -183,15 +182,11 @@ class Asset extends EventHandler {
     /**
      * True if the asset has finished attempting to load the resource. It is not guaranteed
      * that the resources are available as there could have been a network error.
-     *
-     * @type {boolean}
      */
     loaded = false;
 
     /**
      * True if the resource is currently being loaded.
-     *
-     * @type {boolean}
      */
     loading = false;
 
@@ -658,3 +653,4 @@ class Asset extends EventHandler {
 }
 
 export { Asset };
+

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -653,4 +653,3 @@ class Asset extends EventHandler {
 }
 
 export { Asset };
-

--- a/src/framework/bundle/bundle.js
+++ b/src/framework/bundle/bundle.js
@@ -8,6 +8,7 @@ import { EventHandler } from '../../core/event-handler.js';
 class Bundle extends EventHandler {
     /**
      * Index of file url to DataView.
+     *
      * @type {Map<string, DataView>}
      * @private
      */
@@ -15,6 +16,7 @@ class Bundle extends EventHandler {
 
     /**
      * If Bundle has all files loaded.
+     *
      * @private
      */
     _loaded = false;
@@ -87,6 +89,7 @@ class Bundle extends EventHandler {
 
     /**
      * True if all files of a Bundle are loaded.
+     *
      * @type {boolean}
      */
     set loaded(value) {

--- a/src/framework/bundle/bundle.js
+++ b/src/framework/bundle/bundle.js
@@ -104,4 +104,3 @@ class Bundle extends EventHandler {
 }
 
 export { Bundle };
-

--- a/src/framework/bundle/bundle.js
+++ b/src/framework/bundle/bundle.js
@@ -15,7 +15,6 @@ class Bundle extends EventHandler {
 
     /**
      * If Bundle has all files loaded.
-     * @type {boolean}
      * @private
      */
     _loaded = false;
@@ -105,3 +104,4 @@ class Bundle extends EventHandler {
 }
 
 export { Bundle };
+

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -741,4 +741,3 @@ class AnimationComponent extends Component {
 }
 
 export { AnimationComponent };
-

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -117,16 +117,12 @@ class AnimationComponent extends Component {
 
     /**
      * If true, the first animation asset will begin playing when the scene is loaded.
-     *
-     * @type {boolean}
      */
     activate = true;
 
     /**
      * Speed multiplier for animation play back. 1 is playback at normal speed and 0 pauses the
      * animation.
-     *
-     * @type {number}
      */
     speed = 1;
 
@@ -745,3 +741,4 @@ class AnimationComponent extends Component {
 }
 
 export { AnimationComponent };
+

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1387,4 +1387,3 @@ class CameraComponent extends Component {
 }
 
 export { CameraComponent };
-

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -82,7 +82,6 @@ class CameraComponent extends Component {
     /**
      * A counter of requests of depth map rendering.
      *
-     * @type {number}
      * @private
      */
     _renderSceneDepthMap = 0;
@@ -90,7 +89,6 @@ class CameraComponent extends Component {
     /**
      * A counter of requests of color map rendering.
      *
-     * @type {number}
      * @private
      */
     _renderSceneColorMap = 0;
@@ -1389,3 +1387,4 @@ class CameraComponent extends Component {
 }
 
 export { CameraComponent };
+

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -389,4 +389,3 @@ class PostEffectQueue {
 }
 
 export { PostEffectQueue };
-

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -56,7 +56,6 @@ class PostEffectQueue {
          * If the queue is enabled it will render all of its effects, otherwise it will not render
          * anything.
          *
-         * @type {boolean}
          * @ignore
          */
         this.enabled = false;
@@ -390,3 +389,4 @@ class PostEffectQueue {
 }
 
 export { PostEffectQueue };
+

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -1023,4 +1023,3 @@ class GSplatComponent extends Component {
 }
 
 export { GSplatComponent };
-

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -114,7 +114,6 @@ class GSplatComponent extends Component {
     /**
      * Base distance for the first LOD transition (LOD 0 to LOD 1).
      *
-     * @type {number}
      * @private
      */
     _lodBaseDistance = 5;
@@ -122,7 +121,6 @@ class GSplatComponent extends Component {
     /**
      * Geometric multiplier between successive LOD distance thresholds.
      *
-     * @type {number}
      * @private
      */
     _lodMultiplier = 3;
@@ -171,7 +169,6 @@ class GSplatComponent extends Component {
     /**
      * Whether to use the unified gsplat rendering.
      *
-     * @type {boolean}
      * @private
      */
     _unified = false;
@@ -1026,3 +1023,4 @@ class GSplatComponent extends Component {
 }
 
 export { GSplatComponent };
+

--- a/src/framework/components/gsplat/gsplat-asset-loader.js
+++ b/src/framework/components/gsplat/gsplat-asset-loader.js
@@ -332,4 +332,3 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
 }
 
 export { GSplatAssetLoader };
-

--- a/src/framework/components/gsplat/gsplat-asset-loader.js
+++ b/src/framework/components/gsplat/gsplat-asset-loader.js
@@ -34,7 +34,6 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
     /**
      * Maximum number of assets that can be loading concurrently.
      *
-     * @type {number}
      * @private
      */
     maxConcurrentLoads = 2;
@@ -42,7 +41,6 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
     /**
      * Maximum number of retry attempts for failed loads.
      *
-     * @type {number}
      * @private
      */
     maxRetries = 2;
@@ -74,7 +72,6 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
     /**
      * Whether this asset loader has been destroyed.
      *
-     * @type {boolean}
      * @private
      */
     _destroyed = false;
@@ -335,3 +332,4 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
 }
 
 export { GSplatAssetLoader };
+

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -1284,4 +1284,3 @@ class ModelComponent extends Component {
 }
 
 export { ModelComponent };
-

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -77,13 +77,11 @@ class ModelComponent extends Component {
     _mapping = {};
 
     /**
-     * @type {boolean}
      * @private
      */
     _castShadows = true;
 
     /**
-     * @type {boolean}
      * @private
      */
     _receiveShadows = true;
@@ -101,27 +99,22 @@ class ModelComponent extends Component {
     _material;
 
     /**
-     * @type {boolean}
      * @private
      */
     _castShadowsLightmap = true;
 
     /**
-     * @type {boolean}
      * @private
      */
     _lightmapped = false;
 
     /**
-     * @type {number}
      * @private
      */
     _lightmapSizeMultiplier = 1;
 
     /**
      * Mark meshes as non-movable (optimization).
-     *
-     * @type {boolean}
      */
     isStatic = false;
 
@@ -132,7 +125,6 @@ class ModelComponent extends Component {
     _layers = [LAYERID_WORLD]; // assign to the default world layer
 
     /**
-     * @type {number}
      * @private
      */
     _batchGroupId = -1;
@@ -148,7 +140,6 @@ class ModelComponent extends Component {
     _materialEvents = null;
 
     /**
-     * @type {boolean}
      * @private
      */
     _clonedModel = false;
@@ -1293,3 +1284,4 @@ class ModelComponent extends Component {
 }
 
 export { ModelComponent };
+

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -76,14 +76,10 @@ class ModelComponent extends Component {
      */
     _mapping = {};
 
-    /**
-     * @private
-     */
+    /** @private */
     _castShadows = true;
 
-    /**
-     * @private
-     */
+    /** @private */
     _receiveShadows = true;
 
     /**
@@ -98,19 +94,13 @@ class ModelComponent extends Component {
      */
     _material;
 
-    /**
-     * @private
-     */
+    /** @private */
     _castShadowsLightmap = true;
 
-    /**
-     * @private
-     */
+    /** @private */
     _lightmapped = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _lightmapSizeMultiplier = 1;
 
     /**
@@ -124,9 +114,7 @@ class ModelComponent extends Component {
      */
     _layers = [LAYERID_WORLD]; // assign to the default world layer
 
-    /**
-     * @private
-     */
+    /** @private */
     _batchGroupId = -1;
 
     /**
@@ -139,9 +127,7 @@ class ModelComponent extends Component {
 
     _materialEvents = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _clonedModel = false;
 
     // #if _DEBUG

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -82,8 +82,6 @@ class RenderComponent extends Component {
 
     /**
      * Mark meshes as non-movable (optimization).
-     *
-     * @type {boolean}
      */
     isStatic = false;
 
@@ -1075,3 +1073,4 @@ class RenderComponent extends Component {
 }
 
 export { RenderComponent };
+

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -1073,4 +1073,3 @@ class RenderComponent extends Component {
 }
 
 export { RenderComponent };
-

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -1128,4 +1128,3 @@ class RigidBodyComponentSystem extends ComponentSystem {
 Component._buildAccessors(RigidBodyComponent.prototype, _schema);
 
 export { ContactPoint, ContactResult, RaycastResult, RigidBodyComponentSystem, SingleContactResult };
-

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -362,9 +362,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
      */
     static EVENT_CONTACT = 'contact';
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     maxSubSteps = 10;
 
     /**

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -363,7 +363,6 @@ class RigidBodyComponentSystem extends ComponentSystem {
     static EVENT_CONTACT = 'contact';
 
     /**
-     * @type {number}
      * @ignore
      */
     maxSubSteps = 10;
@@ -378,7 +377,6 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * The world space vector representing global gravity in the physics simulation. Defaults to
      * [0, -9.81, 0] which is an approximation of the gravitational force on Earth.
      *
-     * @type {Vec3}
      * @example
      * // Set the gravity in the physics world to simulate a planet with low gravity
      * app.systems.rigidbody.gravity = new pc.Vec3(0, -3.7, 0);
@@ -1130,3 +1128,4 @@ class RigidBodyComponentSystem extends ComponentSystem {
 Component._buildAccessors(RigidBodyComponent.prototype, _schema);
 
 export { ContactPoint, ContactResult, RaycastResult, RigidBodyComponentSystem, SingleContactResult };
+

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -784,4 +784,3 @@ function resolveDuplicatedEntityReferenceProperties(oldSubtreeRoot, oldEntity, n
 }
 
 export { Entity };
-

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -275,7 +275,6 @@ class Entity extends GraphNode {
     /**
      * Used by component systems to speed up destruction.
      *
-     * @type {boolean}
      * @ignore
      */
     _destroying = false;
@@ -290,7 +289,6 @@ class Entity extends GraphNode {
      * Used to differentiate between the entities of a template root instance, which have it set to
      * true, and the cloned instance entities (set to false).
      *
-     * @type {boolean}
      * @ignore
      */
     _template = false;
@@ -786,3 +784,4 @@ function resolveDuplicatedEntityReferenceProperties(oldSubtreeRoot, oldEntity, n
 }
 
 export { Entity };
+

--- a/src/framework/font/font.js
+++ b/src/framework/font/font.js
@@ -30,8 +30,6 @@ class Font {
 
         /**
          * The font intensity.
-         *
-         * @type {number}
          */
         this.intensity = 0.0;
 
@@ -75,3 +73,4 @@ class Font {
 }
 
 export { Font };
+

--- a/src/framework/font/font.js
+++ b/src/framework/font/font.js
@@ -73,4 +73,3 @@ class Font {
 }
 
 export { Font };
-

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -137,7 +137,6 @@ class Picker {
     /**
      * When the device is destroyed, this allows us to ignore async results.
      *
-     * @type {boolean}
      * @private
      */
     deviceValid = true;
@@ -499,3 +498,4 @@ class Picker {
 }
 
 export { Picker };
+

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -498,4 +498,3 @@ class Picker {
 }
 
 export { Picker };
-

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -99,4 +99,3 @@ class ResourceHandler {
 }
 
 export { ResourceHandler };
-

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -18,8 +18,6 @@
 class ResourceHandler {
     /**
      * Type of the resource the handler handles.
-     *
-     * @type {string}
      */
     handlerType = '';
 
@@ -101,3 +99,4 @@ class ResourceHandler {
 }
 
 export { ResourceHandler };
+

--- a/src/framework/handlers/untar.js
+++ b/src/framework/handlers/untar.js
@@ -6,31 +6,26 @@ import { EventHandler } from '../../core/event-handler.js';
  */
 class Untar extends EventHandler {
     /**
-     * @type {number}
      * @private
      */
     headerSize = 512;
 
     /**
-     * @type {number}
      * @private
      */
     paddingSize = 512;
 
     /**
-     * @type {number}
      * @private
      */
     bytesRead = 0;
 
     /**
-     * @type {number}
      * @private
      */
     bytesReceived = 0;
 
     /**
-     * @type {boolean}
      * @private
      */
     headerRead = false;
@@ -54,31 +49,26 @@ class Untar extends EventHandler {
     decoder = null;
 
     /**
-     * @type {string}
      * @private
      */
     prefix = '';
 
     /**
-     * @type {string}
      * @private
      */
     fileName = '';
 
     /**
-     * @type {number}
      * @private
      */
     fileSize = 0;
 
     /**
-     * @type {string}
      * @private
      */
     fileType = '';
 
     /**
-     * @type {string}
      * @private
      */
     ustarFormat = '';
@@ -194,3 +184,4 @@ class Untar extends EventHandler {
 }
 
 export { Untar };
+

--- a/src/framework/handlers/untar.js
+++ b/src/framework/handlers/untar.js
@@ -184,4 +184,3 @@ class Untar extends EventHandler {
 }
 
 export { Untar };
-

--- a/src/framework/handlers/untar.js
+++ b/src/framework/handlers/untar.js
@@ -5,29 +5,19 @@ import { EventHandler } from '../../core/event-handler.js';
  * in a streamed manner, so asset parsing can happen in parallel instead of all at once at the end.
  */
 class Untar extends EventHandler {
-    /**
-     * @private
-     */
+    /** @private */
     headerSize = 512;
 
-    /**
-     * @private
-     */
+    /** @private */
     paddingSize = 512;
 
-    /**
-     * @private
-     */
+    /** @private */
     bytesRead = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     bytesReceived = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     headerRead = false;
 
     /**
@@ -48,29 +38,19 @@ class Untar extends EventHandler {
      */
     decoder = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     prefix = '';
 
-    /**
-     * @private
-     */
+    /** @private */
     fileName = '';
 
-    /**
-     * @private
-     */
+    /** @private */
     fileSize = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     fileType = '';
 
-    /**
-     * @private
-     */
+    /** @private */
     ustarFormat = '';
 
     /**

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -1198,4 +1198,3 @@ class ElementInput {
 }
 
 export { ElementInput, ElementInputEvent, ElementMouseEvent, ElementSelectEvent, ElementTouchEvent };
-

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -250,8 +250,6 @@ class ElementMouseEvent extends ElementInputEvent {
 
         /**
          * The amount of the wheel movement.
-         *
-         * @type {number}
          */
         this.wheelDelta = 0;
 
@@ -1200,3 +1198,4 @@ class ElementInput {
 }
 
 export { ElementInput, ElementInputEvent, ElementMouseEvent, ElementSelectEvent, ElementTouchEvent };
+

--- a/src/framework/xr/xr-anchor.js
+++ b/src/framework/xr/xr-anchor.js
@@ -82,13 +82,11 @@ class XrAnchor extends EventHandler {
     static EVENT_FORGET = 'forget';
 
     /**
-     * @type {Vec3}
      * @private
      */
     _position = new Vec3();
 
     /**
-     * @type {Quat}
      * @private
      */
     _rotation = new Quat();
@@ -274,3 +272,4 @@ class XrAnchor extends EventHandler {
 }
 
 export { XrAnchor };
+

--- a/src/framework/xr/xr-anchor.js
+++ b/src/framework/xr/xr-anchor.js
@@ -81,14 +81,10 @@ class XrAnchor extends EventHandler {
      */
     static EVENT_FORGET = 'forget';
 
-    /**
-     * @private
-     */
+    /** @private */
     _position = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _rotation = new Quat();
 
     /**

--- a/src/framework/xr/xr-anchor.js
+++ b/src/framework/xr/xr-anchor.js
@@ -272,4 +272,3 @@ class XrAnchor extends EventHandler {
 }
 
 export { XrAnchor };
-

--- a/src/framework/xr/xr-anchors.js
+++ b/src/framework/xr/xr-anchors.js
@@ -102,14 +102,10 @@ class XrAnchors extends EventHandler {
      */
     _supported = platform.browser && !!window.XRAnchor;
 
-    /**
-     * @private
-     */
+    /** @private */
     _available = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _checkingAvailability = false;
 
     /**

--- a/src/framework/xr/xr-anchors.js
+++ b/src/framework/xr/xr-anchors.js
@@ -103,13 +103,11 @@ class XrAnchors extends EventHandler {
     _supported = platform.browser && !!window.XRAnchor;
 
     /**
-     * @type {boolean}
      * @private
      */
     _available = false;
 
     /**
-     * @type {boolean}
      * @private
      */
     _checkingAvailability = false;
@@ -538,3 +536,4 @@ class XrAnchors extends EventHandler {
 }
 
 export { XrAnchors };
+

--- a/src/framework/xr/xr-anchors.js
+++ b/src/framework/xr/xr-anchors.js
@@ -536,4 +536,3 @@ class XrAnchors extends EventHandler {
 }
 
 export { XrAnchors };
-

--- a/src/framework/xr/xr-hand.js
+++ b/src/framework/xr/xr-hand.js
@@ -313,4 +313,3 @@ class XrHand extends EventHandler {
 }
 
 export { XrHand };
-

--- a/src/framework/xr/xr-hand.js
+++ b/src/framework/xr/xr-hand.js
@@ -70,7 +70,6 @@ class XrHand extends EventHandler {
     _inputSource;
 
     /**
-     * @type {boolean}
      * @private
      */
     _tracking = false;
@@ -314,3 +313,4 @@ class XrHand extends EventHandler {
 }
 
 export { XrHand };
+

--- a/src/framework/xr/xr-hand.js
+++ b/src/framework/xr/xr-hand.js
@@ -69,9 +69,7 @@ class XrHand extends EventHandler {
      */
     _inputSource;
 
-    /**
-     * @private
-     */
+    /** @private */
     _tracking = false;
 
     /**

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -111,13 +111,11 @@ class XrHitTest extends EventHandler {
     _supported = platform.browser && !!(window.XRSession && window.XRSession.prototype.requestHitTestSource);
 
     /**
-     * @type {boolean}
      * @private
      */
     _available = false;
 
     /**
-     * @type {boolean}
      * @private
      */
     _checkingAvailability = false;
@@ -376,3 +374,4 @@ class XrHitTest extends EventHandler {
 }
 
 export { XrHitTest };
+

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -374,4 +374,3 @@ class XrHitTest extends EventHandler {
 }
 
 export { XrHitTest };
-

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -110,14 +110,10 @@ class XrHitTest extends EventHandler {
      */
     _supported = platform.browser && !!(window.XRSession && window.XRSession.prototype.requestHitTestSource);
 
-    /**
-     * @private
-     */
+    /** @private */
     _available = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _checkingAvailability = false;
 
     /**

--- a/src/framework/xr/xr-image-tracking.js
+++ b/src/framework/xr/xr-image-tracking.js
@@ -40,7 +40,6 @@ class XrImageTracking extends EventHandler {
     _supported = platform.browser && !!window.XRImageTrackingResult;
 
     /**
-     * @type {boolean}
      * @private
      */
     _available = false;
@@ -220,3 +219,4 @@ class XrImageTracking extends EventHandler {
 }
 
 export { XrImageTracking };
+

--- a/src/framework/xr/xr-image-tracking.js
+++ b/src/framework/xr/xr-image-tracking.js
@@ -219,4 +219,3 @@ class XrImageTracking extends EventHandler {
 }
 
 export { XrImageTracking };
-

--- a/src/framework/xr/xr-image-tracking.js
+++ b/src/framework/xr/xr-image-tracking.js
@@ -39,9 +39,7 @@ class XrImageTracking extends EventHandler {
      */
     _supported = platform.browser && !!window.XRImageTrackingResult;
 
-    /**
-     * @private
-     */
+    /** @private */
     _available = false;
 
     /**

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -182,19 +182,16 @@ class XrInputSource extends EventHandler {
     _xrInputSource;
 
     /**
-     * @type {Ray}
      * @private
      */
     _ray = new Ray();
 
     /**
-     * @type {Ray}
      * @private
      */
     _rayLocal = new Ray();
 
     /**
-     * @type {boolean}
      * @private
      */
     _grip = false;
@@ -206,13 +203,11 @@ class XrInputSource extends EventHandler {
     _hand = null;
 
     /**
-     * @type {boolean}
      * @private
      */
     _velocitiesAvailable = false;
 
     /**
-     * @type {number}
      * @private
      */
     _velocitiesTimestamp = now();
@@ -230,13 +225,11 @@ class XrInputSource extends EventHandler {
     _worldTransform = null;
 
     /**
-     * @type {Vec3}
      * @private
      */
     _position = new Vec3();
 
     /**
-     * @type {Quat}
      * @private
      */
     _rotation = new Quat();
@@ -266,31 +259,26 @@ class XrInputSource extends EventHandler {
     _linearVelocity = null;
 
     /**
-     * @type {boolean}
      * @private
      */
     _dirtyLocal = true;
 
     /**
-     * @type {boolean}
      * @private
      */
     _dirtyRay = false;
 
     /**
-     * @type {boolean}
      * @private
      */
     _selecting = false;
 
     /**
-     * @type {boolean}
      * @private
      */
     _squeezing = false;
 
     /**
-     * @type {boolean}
      * @private
      */
     _elementInput = true;
@@ -737,3 +725,4 @@ class XrInputSource extends EventHandler {
 }
 
 export { XrInputSource };
+

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -725,4 +725,3 @@ class XrInputSource extends EventHandler {
 }
 
 export { XrInputSource };
-

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -181,19 +181,13 @@ class XrInputSource extends EventHandler {
      */
     _xrInputSource;
 
-    /**
-     * @private
-     */
+    /** @private */
     _ray = new Ray();
 
-    /**
-     * @private
-     */
+    /** @private */
     _rayLocal = new Ray();
 
-    /**
-     * @private
-     */
+    /** @private */
     _grip = false;
 
     /**
@@ -202,14 +196,10 @@ class XrInputSource extends EventHandler {
      */
     _hand = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _velocitiesAvailable = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _velocitiesTimestamp = now();
 
     /**
@@ -224,14 +214,10 @@ class XrInputSource extends EventHandler {
      */
     _worldTransform = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _position = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _rotation = new Quat();
 
     /**
@@ -258,29 +244,19 @@ class XrInputSource extends EventHandler {
      */
     _linearVelocity = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _dirtyLocal = true;
 
-    /**
-     * @private
-     */
+    /** @private */
     _dirtyRay = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _selecting = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _squeezing = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _elementInput = true;
 
     /**

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -144,9 +144,7 @@ class XrInput extends EventHandler {
      */
     _onInputSourcesChangeEvt;
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     velocitiesSupported = false;
 
     /**

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -328,4 +328,3 @@ class XrInput extends EventHandler {
 }
 
 export { XrInput };
-

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -145,7 +145,6 @@ class XrInput extends EventHandler {
     _onInputSourcesChangeEvt;
 
     /**
-     * @type {boolean}
      * @ignore
      */
     velocitiesSupported = false;
@@ -329,3 +328,4 @@ class XrInput extends EventHandler {
 }
 
 export { XrInput };
+

--- a/src/framework/xr/xr-joint.js
+++ b/src/framework/xr/xr-joint.js
@@ -71,43 +71,36 @@ class XrJoint {
     _radius = null;
 
     /**
-     * @type {Mat4}
      * @private
      */
     _localTransform = new Mat4();
 
     /**
-     * @type {Mat4}
      * @private
      */
     _worldTransform = new Mat4();
 
     /**
-     * @type {Vec3}
      * @private
      */
     _localPosition = new Vec3();
 
     /**
-     * @type {Quat}
      * @private
      */
     _localRotation = new Quat();
 
     /**
-     * @type {Vec3}
      * @private
      */
     _position = new Vec3();
 
     /**
-     * @type {Quat}
      * @private
      */
     _rotation = new Quat();
 
     /**
-     * @type {boolean}
      * @private
      */
     _dirtyLocal = true;
@@ -247,3 +240,4 @@ class XrJoint {
 }
 
 export { XrJoint };
+

--- a/src/framework/xr/xr-joint.js
+++ b/src/framework/xr/xr-joint.js
@@ -240,4 +240,3 @@ class XrJoint {
 }
 
 export { XrJoint };
-

--- a/src/framework/xr/xr-joint.js
+++ b/src/framework/xr/xr-joint.js
@@ -70,39 +70,25 @@ class XrJoint {
      */
     _radius = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _localTransform = new Mat4();
 
-    /**
-     * @private
-     */
+    /** @private */
     _worldTransform = new Mat4();
 
-    /**
-     * @private
-     */
+    /** @private */
     _localPosition = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _localRotation = new Quat();
 
-    /**
-     * @private
-     */
+    /** @private */
     _position = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _rotation = new Quat();
 
-    /**
-     * @private
-     */
+    /** @private */
     _dirtyLocal = true;
 
     /**

--- a/src/framework/xr/xr-light-estimation.js
+++ b/src/framework/xr/xr-light-estimation.js
@@ -54,19 +54,16 @@ class XrLightEstimation extends EventHandler {
     _manager;
 
     /**
-     * @type {boolean}
      * @private
      */
     _supported = false;
 
     /**
-     * @type {boolean}
      * @private
      */
     _available = false;
 
     /**
-     * @type {boolean}
      * @private
      */
     _lightProbeRequested = false;
@@ -78,19 +75,16 @@ class XrLightEstimation extends EventHandler {
     _lightProbe = null;
 
     /**
-     * @type {number}
      * @private
      */
     _intensity = 0;
 
     /**
-     * @type {Quat}
      * @private
      */
     _rotation = new Quat();
 
     /**
-     * @type {Color}
      * @private
      */
     _color = new Color();
@@ -296,3 +290,4 @@ class XrLightEstimation extends EventHandler {
 }
 
 export { XrLightEstimation };
+

--- a/src/framework/xr/xr-light-estimation.js
+++ b/src/framework/xr/xr-light-estimation.js
@@ -290,4 +290,3 @@ class XrLightEstimation extends EventHandler {
 }
 
 export { XrLightEstimation };
-

--- a/src/framework/xr/xr-light-estimation.js
+++ b/src/framework/xr/xr-light-estimation.js
@@ -53,19 +53,13 @@ class XrLightEstimation extends EventHandler {
      */
     _manager;
 
-    /**
-     * @private
-     */
+    /** @private */
     _supported = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _available = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _lightProbeRequested = false;
 
     /**
@@ -74,19 +68,13 @@ class XrLightEstimation extends EventHandler {
      */
     _lightProbe = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _intensity = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     _rotation = new Quat();
 
-    /**
-     * @private
-     */
+    /** @private */
     _color = new Color();
 
     /**

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -241,24 +241,16 @@ class XrManager extends EventHandler {
      */
     _camera = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _localPosition = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _localRotation = new Quat();
 
-    /**
-     * @private
-     */
+    /** @private */
     _depthNear = 0.1;
 
-    /**
-     * @private
-     */
+    /** @private */
     _depthFar = 1000;
 
     /**
@@ -267,19 +259,13 @@ class XrManager extends EventHandler {
      */
     _supportedFrameRates = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _width = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     _height = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     _framebufferScaleFactor = 1.0;
 
     /**

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -1090,4 +1090,3 @@ class XrManager extends EventHandler {
 }
 
 export { XrManager };
-

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -242,25 +242,21 @@ class XrManager extends EventHandler {
     _camera = null;
 
     /**
-     * @type {Vec3}
      * @private
      */
     _localPosition = new Vec3();
 
     /**
-     * @type {Quat}
      * @private
      */
     _localRotation = new Quat();
 
     /**
-     * @type {number}
      * @private
      */
     _depthNear = 0.1;
 
     /**
-     * @type {number}
      * @private
      */
     _depthFar = 1000;
@@ -272,19 +268,16 @@ class XrManager extends EventHandler {
     _supportedFrameRates = null;
 
     /**
-     * @type {number}
      * @private
      */
     _width = 0;
 
     /**
-     * @type {number}
      * @private
      */
     _height = 0;
 
     /**
-     * @type {number}
      * @private
      */
     _framebufferScaleFactor = 1.0;
@@ -1097,3 +1090,4 @@ class XrManager extends EventHandler {
 }
 
 export { XrManager };
+

--- a/src/framework/xr/xr-mesh-detection.js
+++ b/src/framework/xr/xr-mesh-detection.js
@@ -85,7 +85,6 @@ class XrMeshDetection extends EventHandler {
     _supported = platform.browser && !!window.XRMesh;
 
     /**
-     * @type {boolean}
      * @private
      */
     _available = false;
@@ -219,3 +218,4 @@ class XrMeshDetection extends EventHandler {
 }
 
 export { XrMeshDetection };
+

--- a/src/framework/xr/xr-mesh-detection.js
+++ b/src/framework/xr/xr-mesh-detection.js
@@ -218,4 +218,3 @@ class XrMeshDetection extends EventHandler {
 }
 
 export { XrMeshDetection };
-

--- a/src/framework/xr/xr-mesh-detection.js
+++ b/src/framework/xr/xr-mesh-detection.js
@@ -84,9 +84,7 @@ class XrMeshDetection extends EventHandler {
      */
     _supported = platform.browser && !!window.XRMesh;
 
-    /**
-     * @private
-     */
+    /** @private */
     _available = false;
 
     /**

--- a/src/framework/xr/xr-mesh.js
+++ b/src/framework/xr/xr-mesh.js
@@ -48,19 +48,13 @@ class XrMesh extends EventHandler {
      */
     _xrMesh;
 
-    /**
-     * @private
-     */
+    /** @private */
     _lastChanged = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     _position = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _rotation = new Quat();
 
     /**

--- a/src/framework/xr/xr-mesh.js
+++ b/src/framework/xr/xr-mesh.js
@@ -161,4 +161,3 @@ class XrMesh extends EventHandler {
 }
 
 export { XrMesh };
-

--- a/src/framework/xr/xr-mesh.js
+++ b/src/framework/xr/xr-mesh.js
@@ -49,19 +49,16 @@ class XrMesh extends EventHandler {
     _xrMesh;
 
     /**
-     * @type {number}
      * @private
      */
     _lastChanged = 0;
 
     /**
-     * @type {Vec3}
      * @private
      */
     _position = new Vec3();
 
     /**
-     * @type {Quat}
      * @private
      */
     _rotation = new Quat();
@@ -164,3 +161,4 @@ class XrMesh extends EventHandler {
 }
 
 export { XrMesh };
+

--- a/src/framework/xr/xr-plane-detection.js
+++ b/src/framework/xr/xr-plane-detection.js
@@ -85,7 +85,6 @@ class XrPlaneDetection extends EventHandler {
     _supported = platform.browser && !!window.XRPlane;
 
     /**
-     * @type {boolean}
      * @private
      */
     _available = false;
@@ -224,3 +223,4 @@ class XrPlaneDetection extends EventHandler {
 }
 
 export { XrPlaneDetection };
+

--- a/src/framework/xr/xr-plane-detection.js
+++ b/src/framework/xr/xr-plane-detection.js
@@ -223,4 +223,3 @@ class XrPlaneDetection extends EventHandler {
 }
 
 export { XrPlaneDetection };
-

--- a/src/framework/xr/xr-plane-detection.js
+++ b/src/framework/xr/xr-plane-detection.js
@@ -84,9 +84,7 @@ class XrPlaneDetection extends EventHandler {
      */
     _supported = platform.browser && !!window.XRPlane;
 
-    /**
-     * @private
-     */
+    /** @private */
     _available = false;
 
     /**

--- a/src/framework/xr/xr-plane.js
+++ b/src/framework/xr/xr-plane.js
@@ -71,13 +71,11 @@ class XrPlane extends EventHandler {
     _orientation;
 
     /**
-     * @type {Vec3}
      * @private
      */
     _position = new Vec3();
 
     /**
-     * @type {Quat}
      * @private
      */
     _rotation = new Quat();
@@ -225,3 +223,4 @@ class XrPlane extends EventHandler {
 }
 
 export { XrPlane };
+

--- a/src/framework/xr/xr-plane.js
+++ b/src/framework/xr/xr-plane.js
@@ -223,4 +223,3 @@ class XrPlane extends EventHandler {
 }
 
 export { XrPlane };
-

--- a/src/framework/xr/xr-plane.js
+++ b/src/framework/xr/xr-plane.js
@@ -70,14 +70,10 @@ class XrPlane extends EventHandler {
      */
     _orientation;
 
-    /**
-     * @private
-     */
+    /** @private */
     _position = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _rotation = new Quat();
 
     /**

--- a/src/framework/xr/xr-tracked-image.js
+++ b/src/framework/xr/xr-tracked-image.js
@@ -50,24 +50,16 @@ class XrTrackedImage extends EventHandler {
      */
     _bitmap = null;
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     _measuredWidth = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     _trackable = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _tracking = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _emulated = false;
 
     /**
@@ -76,14 +68,10 @@ class XrTrackedImage extends EventHandler {
      */
     _pose = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _position = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _rotation = new Quat();
 
     /**

--- a/src/framework/xr/xr-tracked-image.js
+++ b/src/framework/xr/xr-tracked-image.js
@@ -229,4 +229,3 @@ class XrTrackedImage extends EventHandler {
 }
 
 export { XrTrackedImage };
-

--- a/src/framework/xr/xr-tracked-image.js
+++ b/src/framework/xr/xr-tracked-image.js
@@ -51,25 +51,21 @@ class XrTrackedImage extends EventHandler {
     _bitmap = null;
 
     /**
-     * @type {number}
      * @ignore
      */
     _measuredWidth = 0;
 
     /**
-     * @type {boolean}
      * @private
      */
     _trackable = false;
 
     /**
-     * @type {boolean}
      * @private
      */
     _tracking = false;
 
     /**
-     * @type {boolean}
      * @private
      */
     _emulated = false;
@@ -81,13 +77,11 @@ class XrTrackedImage extends EventHandler {
     _pose = null;
 
     /**
-     * @type {Vec3}
      * @private
      */
     _position = new Vec3();
 
     /**
-     * @type {Quat}
      * @private
      */
     _rotation = new Quat();
@@ -235,3 +229,4 @@ class XrTrackedImage extends EventHandler {
 }
 
 export { XrTrackedImage };
+

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -49,49 +49,41 @@ class XrView extends EventHandler {
     _positionData = new Float32Array(3);
 
     /**
-     * @type {Vec4}
      * @private
      */
     _viewport = new Vec4();
 
     /**
-     * @type {Mat4}
      * @private
      */
     _projMat = new Mat4();
 
     /**
-     * @type {Mat4}
      * @private
      */
     _projViewOffMat = new Mat4();
 
     /**
-     * @type {Mat4}
      * @private
      */
     _viewMat = new Mat4();
 
     /**
-     * @type {Mat4}
      * @private
      */
     _viewOffMat = new Mat4();
 
     /**
-     * @type {Mat3}
      * @private
      */
     _viewMat3 = new Mat3();
 
     /**
-     * @type {Mat4}
      * @private
      */
     _viewInvMat = new Mat4();
 
     /**
-     * @type {Mat4}
      * @private
      */
     _viewInvOffMat = new Mat4();
@@ -127,7 +119,6 @@ class XrView extends EventHandler {
     _emptyDepthBuffer = new Uint8Array(32);
 
     /**
-     * @type {Mat4}
      * @private
      */
     _depthMatrix = new Mat4();
@@ -606,3 +597,4 @@ class XrView extends EventHandler {
 }
 
 export { XrView };
+

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -48,44 +48,28 @@ class XrView extends EventHandler {
      */
     _positionData = new Float32Array(3);
 
-    /**
-     * @private
-     */
+    /** @private */
     _viewport = new Vec4();
 
-    /**
-     * @private
-     */
+    /** @private */
     _projMat = new Mat4();
 
-    /**
-     * @private
-     */
+    /** @private */
     _projViewOffMat = new Mat4();
 
-    /**
-     * @private
-     */
+    /** @private */
     _viewMat = new Mat4();
 
-    /**
-     * @private
-     */
+    /** @private */
     _viewOffMat = new Mat4();
 
-    /**
-     * @private
-     */
+    /** @private */
     _viewMat3 = new Mat3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _viewInvMat = new Mat4();
 
-    /**
-     * @private
-     */
+    /** @private */
     _viewInvOffMat = new Mat4();
 
     /**
@@ -118,9 +102,7 @@ class XrView extends EventHandler {
      */
     _emptyDepthBuffer = new Uint8Array(32);
 
-    /**
-     * @private
-     */
+    /** @private */
     _depthMatrix = new Mat4();
 
     /**
@@ -366,9 +348,7 @@ class XrView extends EventHandler {
         this._updateDepth(frame);
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _updateTextureColor() {
         if (!this._manager.views.availableColor || !this._xrCamera || !this._textureColor) {
             return;

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -597,4 +597,3 @@ class XrView extends EventHandler {
 }
 
 export { XrView };
-

--- a/src/framework/xr/xr-views.js
+++ b/src/framework/xr/xr-views.js
@@ -299,4 +299,3 @@ class XrViews extends EventHandler {
 }
 
 export { XrViews };
-

--- a/src/framework/xr/xr-views.js
+++ b/src/framework/xr/xr-views.js
@@ -77,25 +77,21 @@ class XrViews extends EventHandler {
     _supportedDepth = platform.browser && !!window.XRDepthInformation;
 
     /**
-     * @type {boolean}
      * @private
      */
     _availableColor = false;
 
     /**
-     * @type {boolean}
      * @private
      */
     _availableDepth = false;
 
     /**
-     * @type {string}
      * @private
      */
     _depthUsage = '';
 
     /**
-     * @type {string}
      * @private
      */
     _depthFormat = '';
@@ -303,3 +299,4 @@ class XrViews extends EventHandler {
 }
 
 export { XrViews };
+

--- a/src/framework/xr/xr-views.js
+++ b/src/framework/xr/xr-views.js
@@ -76,24 +76,16 @@ class XrViews extends EventHandler {
      */
     _supportedDepth = platform.browser && !!window.XRDepthInformation;
 
-    /**
-     * @private
-     */
+    /** @private */
     _availableColor = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _availableDepth = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _depthUsage = '';
 
-    /**
-     * @private
-     */
+    /** @private */
     _depthFormat = '';
 
     /**
@@ -260,9 +252,7 @@ class XrViews extends EventHandler {
         return this._index.get(eye) || null;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _onSessionStart() {
         if (this._manager.type !== XRTYPE_AR) {
             return;
@@ -282,9 +272,7 @@ class XrViews extends EventHandler {
         }
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _onSessionEnd() {
         for (const view of this._index.values()) {
             view.destroy();

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -362,4 +362,3 @@ class BindGroupFormat {
 }
 
 export { BindUniformBufferFormat, BindTextureFormat, BindGroupFormat, BindStorageTextureFormat, BindStorageBufferFormat };
-

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -20,7 +20,6 @@ let id = 0;
  */
 class BindBaseFormat {
     /**
-     * @type {number}
      * @ignore
      */
     slot = -1;
@@ -68,7 +67,6 @@ class BindStorageBufferFormat extends BindBaseFormat {
     /**
      * Format, extracted from vertex and fragment shader.
      *
-     * @type {string}
      * @ignore
      */
     format = '';
@@ -364,3 +362,4 @@ class BindGroupFormat {
 }
 
 export { BindUniformBufferFormat, BindTextureFormat, BindGroupFormat, BindStorageTextureFormat, BindStorageBufferFormat };
+

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -19,9 +19,7 @@ let id = 0;
  * @category Graphics
  */
 class BindBaseFormat {
-    /**
-     * @ignore
-     */
+    /** @ignore */
     slot = -1;
 
     /**

--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -247,4 +247,3 @@ class BindGroup {
 }
 
 export { BindGroup, DynamicBindGroup };
-

--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -37,7 +37,6 @@ class BindGroup {
     /**
      * A render version the bind group was last updated on.
      *
-     * @type {number}
      * @private
      */
     renderVersionUpdated = -1;
@@ -248,3 +247,4 @@ class BindGroup {
 }
 
 export { BindGroup, DynamicBindGroup };
+

--- a/src/platform/graphics/compute.js
+++ b/src/platform/graphics/compute.js
@@ -48,9 +48,7 @@ class Compute {
      */
     parameters = new Map();
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     countX = 1;
 
     /**

--- a/src/platform/graphics/compute.js
+++ b/src/platform/graphics/compute.js
@@ -234,4 +234,3 @@ class Compute {
 }
 
 export { Compute };
-

--- a/src/platform/graphics/compute.js
+++ b/src/platform/graphics/compute.js
@@ -49,7 +49,6 @@ class Compute {
     parameters = new Map();
 
     /**
-     * @type {number}
      * @ignore
      */
     countX = 1;
@@ -69,7 +68,6 @@ class Compute {
     /**
      * Slot index in the indirect dispatch buffer, or -1 for direct dispatch.
      *
-     * @type {number}
      * @ignore
      */
     indirectSlotIndex = -1;
@@ -86,7 +84,6 @@ class Compute {
      * Frame stamp (device.renderVersion) when indirect slot was set. Used for validation
      * when using the built-in buffer.
      *
-     * @type {number}
      * @ignore
      */
     indirectFrameStamp = 0;
@@ -237,3 +234,4 @@ class Compute {
 }
 
 export { Compute };
+

--- a/src/platform/graphics/depth-state.js
+++ b/src/platform/graphics/depth-state.js
@@ -39,8 +39,6 @@ class DepthState {
      * A unique number representing the depth state. You can use this number to quickly compare
      * two depth states for equality. The key is always maintained valid without a dirty flag,
      * to avoid condition check at runtime, considering these change rarely.
-     *
-     * @type {number}
      */
     key = 0;
 
@@ -238,3 +236,4 @@ class DepthState {
 }
 
 export { DepthState };
+

--- a/src/platform/graphics/depth-state.js
+++ b/src/platform/graphics/depth-state.js
@@ -236,4 +236,3 @@ class DepthState {
 }
 
 export { DepthState };
-

--- a/src/platform/graphics/draw-commands.js
+++ b/src/platform/graphics/draw-commands.js
@@ -136,4 +136,3 @@ class DrawCommands {
 }
 
 export { DrawCommands };
-

--- a/src/platform/graphics/draw-commands.js
+++ b/src/platform/graphics/draw-commands.js
@@ -28,7 +28,6 @@ class DrawCommands {
     /**
      * Maximum number of multi-draw calls the space is allocated for. Ignored for indirect draw commands.
      *
-     * @type {number}
      * @private
      */
     _maxCount = 0;
@@ -53,7 +52,6 @@ class DrawCommands {
     /**
      * Number of draw calls to perform.
      *
-     * @type {number}
      * @private
      */
     _count = 1;
@@ -70,7 +68,6 @@ class DrawCommands {
     /**
      * Slot index of the first indirect draw call. Ignored for multi-draw commands.
      *
-     * @type {number}
      * @ignore
      */
     slotIndex = 0;
@@ -78,7 +75,6 @@ class DrawCommands {
     /**
      * Total number of primitives across all sub-draws (pre-calculated).
      *
-     * @type {number}
      * @ignore
      */
     primitiveCount = 0;
@@ -140,3 +136,4 @@ class DrawCommands {
 }
 
 export { DrawCommands };
+

--- a/src/platform/graphics/draw-commands.js
+++ b/src/platform/graphics/draw-commands.js
@@ -90,9 +90,7 @@ class DrawCommands {
         this.impl = device.createDrawCommandImpl(this);
     }
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     destroy() {
         this.impl?.destroy?.();
         this.impl = null;

--- a/src/platform/graphics/frame-pass.js
+++ b/src/platform/graphics/frame-pass.js
@@ -159,4 +159,3 @@ class FramePass {
 }
 
 export { FramePass };
-

--- a/src/platform/graphics/frame-pass.js
+++ b/src/platform/graphics/frame-pass.js
@@ -27,7 +27,6 @@ class FramePass {
     /**
      * True if the frame pass is enabled.
      *
-     * @type {boolean}
      * @private
      */
     _enabled = true;
@@ -36,7 +35,6 @@ class FramePass {
      * True if the render pass start is skipped. This means the render pass is merged into the
      * previous one. Used by FrameGraph.compile() for pass merging.
      *
-     * @type {boolean}
      * @private
      */
     _skipStart = false;
@@ -45,7 +43,6 @@ class FramePass {
      * True if the render pass end is skipped. This means the following render pass is merged into
      * this one. Used by FrameGraph.compile() for pass merging.
      *
-     * @type {boolean}
      * @private
      */
     _skipEnd = false;
@@ -59,8 +56,6 @@ class FramePass {
     /**
      * If true, this pass might use dynamically rendered cubemaps. Defaults to false for non-render
      * passes (RenderPass overrides to true).
-     *
-     * @type {boolean}
      */
     requiresCubemaps = false;
 
@@ -164,3 +159,4 @@ class FramePass {
 }
 
 export { FramePass };
+

--- a/src/platform/graphics/gpu-profiler.js
+++ b/src/platform/graphics/gpu-profiler.js
@@ -63,8 +63,6 @@ class GpuProfiler {
 
     /**
      * The maximum number of slots that can be allocated during the frame.
-     *
-     * @type {number}
      */
     maxCount = 9999;
 
@@ -206,3 +204,4 @@ class GpuProfiler {
 }
 
 export { GpuProfiler };
+

--- a/src/platform/graphics/gpu-profiler.js
+++ b/src/platform/graphics/gpu-profiler.js
@@ -204,4 +204,3 @@ class GpuProfiler {
 }
 
 export { GpuProfiler };
-

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -1368,4 +1368,3 @@ class GraphicsDevice extends EventHandler {
 }
 
 export { GraphicsDevice };
-

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -504,9 +504,7 @@ class GraphicsDevice extends EventHandler {
      */
     gpuProfiler;
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     _destroyed = false;
 
     defaultClearOptions = {

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -911,6 +911,7 @@ class GraphicsDevice extends EventHandler {
     /**
      * Clears the vertex buffer set on the graphics device. This is called automatically by the
      * renderer.
+     *
      * @ignore
      */
     clearVertexBuffer() {

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -93,8 +93,6 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * True if the back buffer should use anti-aliasing.
-     *
-     * @type {boolean}
      */
     backBufferAntialias = false;
 
@@ -142,16 +140,12 @@ class GraphicsDevice extends EventHandler {
      * The maximum number of indirect draw calls that can be used within a single frame. Used on
      * WebGPU only. This needs to be adjusted based on the maximum number of draw calls that can
      * be used within a single frame. Defaults to 1024.
-     *
-     * @type {number}
      */
     maxIndirectDrawCount = 1024;
 
     /**
      * The maximum number of indirect compute dispatches that can be used within a single frame.
      * Used on WebGPU only. Defaults to 256.
-     *
-     * @type {number}
      */
     maxIndirectDispatchCount = 256;
 
@@ -231,8 +225,6 @@ class GraphicsDevice extends EventHandler {
     /**
      * True if the device supports multi-draw. This is always supported on WebGPU, and support on
      * WebGL2 is optional, but pretty common.
-     *
-     * @type {boolean}
      */
     supportsMultiDraw = true;
 
@@ -334,7 +326,6 @@ class GraphicsDevice extends EventHandler {
      * A version number that is incremented every frame. This is used to detect if some object were
      * invalidated.
      *
-     * @type {number}
      * @ignore
      */
     renderVersion = 0;
@@ -353,7 +344,6 @@ class GraphicsDevice extends EventHandler {
     /**
      * True if the device supports uniform buffers.
      *
-     * @type {boolean}
      * @ignore
      */
     supportsUniformBuffers = false;
@@ -361,8 +351,6 @@ class GraphicsDevice extends EventHandler {
     /**
      * True if the device supports clip distances (WebGPU only). Clip distances allow you to restrict
      * primitives' clip volume with user-defined half-spaces in the output of vertex stage.
-     *
-     * @type {boolean}
      */
     supportsClipDistances = false;
 
@@ -517,7 +505,6 @@ class GraphicsDevice extends EventHandler {
     gpuProfiler;
 
     /**
-     * @type {boolean}
      * @ignore
      */
     _destroyed = false;
@@ -543,7 +530,6 @@ class GraphicsDevice extends EventHandler {
     /**
      * A very heavy handed way to force all shaders to be rebuilt. Avoid using as much as possible.
      *
-     * @type {boolean}
      * @ignore
      */
     _shadersDirty = false;
@@ -1382,3 +1368,4 @@ class GraphicsDevice extends EventHandler {
 }
 
 export { GraphicsDevice };
+

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -34,22 +34,16 @@ class ColorAttachmentOps {
      * single or multi-sampled. Further, if a multi-sampled surface is used, the resolve flag
      * further specifies if this gets resolved to a single-sampled surface. This behavior matches
      * the WebGPU specification.
-     *
-     * @type {boolean}
      */
     store = false;
 
     /**
      * True if the attachment needs to be resolved.
-     *
-     * @type {boolean}
      */
     resolve = true;
 
     /**
      * True if the attachment needs to have mipmaps generated.
-     *
-     * @type {boolean}
      */
     genMipmaps = false;
 }
@@ -80,23 +74,17 @@ class DepthStencilAttachmentOps {
     /**
      * True if the depth attachment needs to be stored after the render pass. False
      * if it can be discarded.
-     *
-     * @type {boolean}
      */
     storeDepth = false;
 
     /**
      * True if the depth attachment needs to be resolved.
-     *
-     * @type {boolean}
      */
     resolveDepth = false;
 
     /**
      * True if the stencil attachment needs to be stored after the render pass. False
      * if it can be discarded.
-     *
-     * @type {boolean}
      */
     storeStencil = false;
 }
@@ -128,8 +116,6 @@ class RenderPass extends FramePass {
     /**
      * Number of samples. 0 if no render target, otherwise number of samples from the render target,
      * or the main framebuffer if render target is null.
-     *
-     * @type {number}
      */
     samples = 0;
 
@@ -157,15 +143,11 @@ class RenderPass extends FramePass {
      * If true, this pass might use dynamically rendered cubemaps. Use for a case where rendering to cubemap
      * faces is interleaved with rendering to shadows, to avoid generating cubemap mipmaps. This will likely
      * be retired when render target dependency tracking gets implemented.
-     *
-     * @type {boolean}
      */
     requiresCubemaps = true;
 
     /**
      * True if the render pass uses the full viewport / scissor for rendering into the render target.
-     *
-     * @type {boolean}
      */
     fullSizeClearRect = true;
 
@@ -425,3 +407,4 @@ class RenderPass extends FramePass {
 }
 
 export { RenderPass };
+

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -407,4 +407,3 @@ class RenderPass extends FramePass {
 }
 
 export { RenderPass };
-

--- a/src/platform/graphics/stencil-parameters.js
+++ b/src/platform/graphics/stencil-parameters.js
@@ -290,4 +290,3 @@ class StencilParameters {
 }
 
 export { StencilParameters };
-

--- a/src/platform/graphics/stencil-parameters.js
+++ b/src/platform/graphics/stencil-parameters.js
@@ -51,9 +51,7 @@ class StencilParameters {
      */
     _writeMask;
 
-    /**
-     * @private
-     */
+    /** @private */
     _dirty = true;
 
     /**

--- a/src/platform/graphics/stencil-parameters.js
+++ b/src/platform/graphics/stencil-parameters.js
@@ -52,7 +52,6 @@ class StencilParameters {
     _writeMask;
 
     /**
-     * @type {boolean}
      * @private
      */
     _dirty = true;
@@ -291,3 +290,4 @@ class StencilParameters {
 }
 
 export { StencilParameters };
+

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -120,7 +120,6 @@ class Texture {
      * A render version used to track the last time the texture properties requiring bind group
      * to be updated were changed.
      *
-     * @type {number}
      * @ignore
      */
     renderVersionDirty = 0;
@@ -1295,3 +1294,4 @@ class Texture {
 }
 
 export { Texture };
+

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -1294,4 +1294,3 @@ class Texture {
 }
 
 export { Texture };
-

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -63,6 +63,7 @@ let id = 0;
  *     - {@link PIXELFORMAT_RGB10A2} provides 10 bits per RGB channel with 2-bit alpha, offering
  * higher precision than {@link PIXELFORMAT_RGBA8} at the same memory cost. It is renderable on
  * both WebGL2 and WebGPU. {@link PIXELFORMAT_RGB10A2U} is the unsigned integer variant.
+ *
  * @category Graphics
  */
 class Texture {

--- a/src/platform/graphics/uniform-buffer-format.js
+++ b/src/platform/graphics/uniform-buffer-format.js
@@ -208,7 +208,6 @@ class UniformFormat {
  */
 class UniformBufferFormat {
     /**
-     * @type {number}
      * @ignore
      */
     byteSize = 0;
@@ -260,3 +259,4 @@ class UniformBufferFormat {
 }
 
 export { UniformFormat, UniformBufferFormat };
+

--- a/src/platform/graphics/uniform-buffer-format.js
+++ b/src/platform/graphics/uniform-buffer-format.js
@@ -259,4 +259,3 @@ class UniformBufferFormat {
 }
 
 export { UniformFormat, UniformBufferFormat };
-

--- a/src/platform/graphics/uniform-buffer-format.js
+++ b/src/platform/graphics/uniform-buffer-format.js
@@ -207,9 +207,7 @@ class UniformFormat {
  * @category Graphics
  */
 class UniformBufferFormat {
-    /**
-     * @ignore
-     */
+    /** @ignore */
     byteSize = 0;
 
     /**

--- a/src/platform/graphics/uniform-buffer.js
+++ b/src/platform/graphics/uniform-buffer.js
@@ -228,8 +228,6 @@ class UniformBuffer {
     /**
      * A render version used to track the last time the properties requiring bind group to be
      * updated were changed.
-     *
-     * @type {number}
      */
     renderVersionDirty = 0;
 
@@ -398,3 +396,4 @@ class UniformBuffer {
 }
 
 export { UniformBuffer };
+

--- a/src/platform/graphics/uniform-buffer.js
+++ b/src/platform/graphics/uniform-buffer.js
@@ -396,4 +396,3 @@ class UniformBuffer {
 }
 
 export { UniformBuffer };
-

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -78,7 +78,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     /**
      * Number of indirect draw slots allocated.
      *
-     * @type {number}
      * @private
      */
     _indirectDrawBufferCount = 0;
@@ -86,7 +85,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     /**
      * Next unused index in indirectDrawBuffer.
      *
-     * @type {number}
      * @private
      */
     _indirectDrawNextIndex = 0;
@@ -102,7 +100,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     /**
      * Number of indirect dispatch slots allocated.
      *
-     * @type {number}
      * @private
      */
     _indirectDispatchBufferCount = 0;
@@ -110,7 +107,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     /**
      * Next unused index in indirectDispatchBuffer.
      *
-     * @type {number}
      * @private
      */
     _indirectDispatchNextIndex = 0;
@@ -155,7 +151,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     /**
      * Monotonically increasing counter incremented each time queue.submit() is called.
      *
-     * @type {number}
      * @ignore
      */
     submitVersion = 0;
@@ -1422,3 +1417,4 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 }
 
 export { WebgpuGraphicsDevice };
+

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1417,4 +1417,3 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 }
 
 export { WebgpuGraphicsDevice };
-

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -58,8 +58,6 @@ class DepthAttachment {
 
     /**
      * True if the depthTexture is internally allocated / owned
-     *
-     * @type {boolean}
      */
     depthTextureInternal = false;
 
@@ -143,8 +141,6 @@ class WebgpuRenderTarget {
 
     /**
      * True if this is the backbuffer of the device.
-     *
-     * @type {boolean}
      */
     isBackbuffer = false;
 
@@ -509,3 +505,4 @@ class WebgpuRenderTarget {
 }
 
 export { WebgpuRenderTarget };
+

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -505,4 +505,3 @@ class WebgpuRenderTarget {
 }
 
 export { WebgpuRenderTarget };
-

--- a/src/platform/graphics/webgpu/webgpu-upload-stream.js
+++ b/src/platform/graphics/webgpu/webgpu-upload-stream.js
@@ -199,4 +199,3 @@ class WebgpuUploadStream {
 }
 
 export { WebgpuUploadStream };
-

--- a/src/platform/graphics/webgpu/webgpu-upload-stream.js
+++ b/src/platform/graphics/webgpu/webgpu-upload-stream.js
@@ -35,7 +35,6 @@ class WebgpuUploadStream {
      * The device's _submitVersion at the time the last staging copy was recorded.
      * Used to detect whether the copy has been submitted before the next upload.
      *
-     * @type {number}
      * @private
      */
     _lastUploadSubmitVersion = -1;
@@ -200,3 +199,4 @@ class WebgpuUploadStream {
 }
 
 export { WebgpuUploadStream };
+

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -1075,4 +1075,3 @@ class GamePads extends EventHandler {
 }
 
 export { GamePads, GamePad, GamePadButton };
-

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -268,43 +268,31 @@ function sleep(ms) {
 class GamePadButton {
     /**
      * The value for the button between 0 and 1, with 0 representing a button that is not pressed, and 1 representing a button that is fully pressed.
-     *
-     * @type {number}
      */
     value = 0;
 
     /**
      * Whether the button is currently down.
-     *
-     * @type {boolean}
      */
     pressed = false;
 
     /**
      * Whether the button is currently touched.
-     *
-     * @type {boolean}
      */
     touched = false;
 
     /**
      * Whether the button was pressed.
-     *
-     * @type {boolean}
      */
     wasPressed = false;
 
     /**
      * Whether the button was released since the last update.
-     *
-     * @type {boolean}
      */
     wasReleased = false;
 
     /**
      * Whether the button was touched since the last update.
-     *
-     * @type {boolean}
      */
     wasTouched = false;
 
@@ -1087,3 +1075,4 @@ class GamePads extends EventHandler {
 }
 
 export { GamePads, GamePad, GamePadButton };
+

--- a/src/platform/input/mouse-event.js
+++ b/src/platform/input/mouse-event.js
@@ -163,4 +163,3 @@ class MouseEvent {
 }
 
 export { isMousePointerLocked, MouseEvent };
-

--- a/src/platform/input/mouse-event.js
+++ b/src/platform/input/mouse-event.js
@@ -27,29 +27,21 @@ function isMousePointerLocked() {
 class MouseEvent {
     /**
      * The x coordinate of the mouse pointer relative to the element {@link Mouse} is attached to.
-     *
-     * @type {number}
      */
     x = 0;
 
     /**
      * The y coordinate of the mouse pointer relative to the element {@link Mouse} is attached to.
-     *
-     * @type {number}
      */
     y = 0;
 
     /**
      * The change in x coordinate since the last mouse event.
-     *
-     * @type {number}
      */
     dx = 0;
 
     /**
      * The change in y coordinate since the last mouse event.
-     *
-     * @type {number}
      */
     dy = 0;
 
@@ -67,8 +59,6 @@ class MouseEvent {
     /**
      * A value representing the amount the mouse wheel has moved, only valid for
      * {@link Mouse.EVENT_MOUSEWHEEL} events.
-     *
-     * @type {number}
      */
     wheelDelta = 0;
 
@@ -81,29 +71,21 @@ class MouseEvent {
 
     /**
      * True if the ctrl key was pressed when this event was fired.
-     *
-     * @type {boolean}
      */
     ctrlKey = false;
 
     /**
      * True if the alt key was pressed when this event was fired.
-     *
-     * @type {boolean}
      */
     altKey = false;
 
     /**
      * True if the shift key was pressed when this event was fired.
-     *
-     * @type {boolean}
      */
     shiftKey = false;
 
     /**
      * True if the meta key was pressed when this event was fired.
-     *
-     * @type {boolean}
      */
     metaKey = false;
 
@@ -181,3 +163,4 @@ class MouseEvent {
 }
 
 export { isMousePointerLocked, MouseEvent };
+

--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -134,7 +134,6 @@ class SoundInstance extends EventHandler {
         this._pitch = options.pitch !== undefined ? Math.max(0.01, Number(options.pitch) || 0) : 1;
 
         /**
-         * @type {boolean}
          * @private
          */
         this._loop = !!(options.loop !== undefined ? options.loop : false);
@@ -156,7 +155,6 @@ class SoundInstance extends EventHandler {
         /**
          * True if the manager was suspended.
          *
-         * @type {boolean}
          * @private
          */
         this._suspended = false;
@@ -166,7 +164,6 @@ class SoundInstance extends EventHandler {
          * When an 'onended' event is suspended, this counter is decremented by 1.
          * When a future 'onended' event is to be suspended, this counter is incremented by 1.
          *
-         * @type {number}
          * @private
          */
         this._suspendEndEvent = 0;
@@ -174,7 +171,6 @@ class SoundInstance extends EventHandler {
         /**
          * True if we want to suspend firing instance events.
          *
-         * @type {boolean}
          * @private
          */
         this._suspendInstanceEvents = false;
@@ -182,19 +178,16 @@ class SoundInstance extends EventHandler {
         /**
          * If true then the instance will start playing its source when its created.
          *
-         * @type {boolean}
          * @private
          */
         this._playWhenLoaded = true;
 
         /**
-         * @type {number}
          * @private
          */
         this._startTime = Math.max(0, Number(options.startTime) || 0);
 
         /**
-         * @type {number}
          * @private
          */
         this._duration = Math.max(0, Number(options.duration) || 0);
@@ -219,7 +212,6 @@ class SoundInstance extends EventHandler {
 
         if (hasAudioContext()) {
             /**
-             * @type {number}
              * @private
              */
             this._startedAt = 0;
@@ -228,13 +220,11 @@ class SoundInstance extends EventHandler {
              * Manually keep track of the playback position because the Web Audio API does not
              * provide a way to do this accurately if the playbackRate is not 1.
              *
-             * @type {number}
              * @private
              */
             this._currentTime = 0;
 
             /**
-             * @type {number}
              * @private
              */
             this._currentOffset = 0;
@@ -276,7 +266,6 @@ class SoundInstance extends EventHandler {
              * Set to true if a play() request was issued when the AudioContext was still suspended,
              * and will therefore wait until it is resumed to play the audio.
              *
-             * @type {boolean}
              * @private
              */
             this._waitingContextSuspension = false;
@@ -1262,3 +1251,4 @@ if (!hasAudioContext()) {
 }
 
 export { SoundInstance };
+

--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -133,9 +133,7 @@ class SoundInstance extends EventHandler {
          */
         this._pitch = options.pitch !== undefined ? Math.max(0.01, Number(options.pitch) || 0) : 1;
 
-        /**
-         * @private
-         */
+        /** @private */
         this._loop = !!(options.loop !== undefined ? options.loop : false);
 
         /**
@@ -182,14 +180,10 @@ class SoundInstance extends EventHandler {
          */
         this._playWhenLoaded = true;
 
-        /**
-         * @private
-         */
+        /** @private */
         this._startTime = Math.max(0, Number(options.startTime) || 0);
 
-        /**
-         * @private
-         */
+        /** @private */
         this._duration = Math.max(0, Number(options.duration) || 0);
 
         /**
@@ -211,9 +205,7 @@ class SoundInstance extends EventHandler {
         this._onEndCallback = options.onEnd;
 
         if (hasAudioContext()) {
-            /**
-             * @private
-             */
+            /** @private */
             this._startedAt = 0;
 
             /**
@@ -224,9 +216,7 @@ class SoundInstance extends EventHandler {
              */
             this._currentTime = 0;
 
-            /**
-             * @private
-             */
+            /** @private */
             this._currentOffset = 0;
 
             /**

--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -1251,4 +1251,3 @@ if (!hasAudioContext()) {
 }
 
 export { SoundInstance };
-

--- a/src/platform/sound/instance3d.js
+++ b/src/platform/sound/instance3d.js
@@ -293,4 +293,3 @@ if (!hasAudioContext()) {
 }
 
 export { SoundInstance3d };
-

--- a/src/platform/sound/instance3d.js
+++ b/src/platform/sound/instance3d.js
@@ -20,13 +20,11 @@ const MAX_DISTANCE = 10000;
  */
 class SoundInstance3d extends SoundInstance {
     /**
-     * @type {Vec3}
      * @private
      */
     _position = new Vec3();
 
     /**
-     * @type {Vec3}
      * @private
      */
     _velocity = new Vec3();
@@ -295,3 +293,4 @@ if (!hasAudioContext()) {
 }
 
 export { SoundInstance3d };
+

--- a/src/platform/sound/instance3d.js
+++ b/src/platform/sound/instance3d.js
@@ -19,14 +19,10 @@ const MAX_DISTANCE = 10000;
  * @category Sound
  */
 class SoundInstance3d extends SoundInstance {
-    /**
-     * @private
-     */
+    /** @private */
     _position = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _velocity = new Vec3();
 
     /**

--- a/src/platform/sound/listener.js
+++ b/src/platform/sound/listener.js
@@ -17,14 +17,10 @@ class Listener {
      */
     _manager;
 
-    /**
-     * @private
-     */
+    /** @private */
     position = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     orientation = new Mat4();
 
     /**

--- a/src/platform/sound/listener.js
+++ b/src/platform/sound/listener.js
@@ -18,13 +18,11 @@ class Listener {
     _manager;
 
     /**
-     * @type {Vec3}
      * @private
      */
     position = new Vec3();
 
     /**
-     * @type {Mat4}
      * @private
      */
     orientation = new Mat4();
@@ -111,3 +109,4 @@ class Listener {
 }
 
 export { Listener };
+

--- a/src/platform/sound/listener.js
+++ b/src/platform/sound/listener.js
@@ -109,4 +109,3 @@ class Listener {
 }
 
 export { Listener };
-

--- a/src/scene/animation/animation.js
+++ b/src/scene/animation/animation.js
@@ -83,4 +83,3 @@ class Animation {
 }
 
 export { Animation, AnimationKey, AnimationNode };
-

--- a/src/scene/animation/animation.js
+++ b/src/scene/animation/animation.js
@@ -36,15 +36,11 @@ class AnimationNode {
 class Animation {
     /**
      * Human-readable name of the animation.
-     *
-     * @type {string}
      */
     name = '';
 
     /**
      * Duration of the animation in seconds.
-     *
-     * @type {number}
      */
     duration = 0;
 
@@ -87,3 +83,4 @@ class Animation {
 }
 
 export { Animation, AnimationKey, AnimationNode };
+

--- a/src/scene/animation/skeleton.js
+++ b/src/scene/animation/skeleton.js
@@ -304,4 +304,3 @@ class Skeleton {
 }
 
 export { Skeleton };
-

--- a/src/scene/animation/skeleton.js
+++ b/src/scene/animation/skeleton.js
@@ -39,8 +39,6 @@ class InterpolatedKey {
 class Skeleton {
     /**
      * Determines whether skeleton is looping its animation.
-     *
-     * @type {boolean}
      */
     looping = true;
 
@@ -306,3 +304,4 @@ class Skeleton {
 }
 
 export { Skeleton };
+

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1139,19 +1139,13 @@ export const EVENT_POSTCULL = 'postcull';
  */
 export const EVENT_CULL_END = 'cull:end';
 
-/**
- * @ignore
- */
+/** @ignore */
 export const GSPLAT_FORWARD = 1;
 
-/**
- * @ignore
- */
+/** @ignore */
 export const GSPLAT_SHADOW = 2;
 
-/**
- * @ignore
- */
+/** @ignore */
 export const SHADOWCAMERA_NAME = 'pcShadowCamera';
 
 /**

--- a/src/scene/fog-params.js
+++ b/src/scene/fog-params.js
@@ -23,34 +23,27 @@ class FogParams {
 
     /**
      * The color of the fog (if enabled), specified in sRGB color space. Defaults to black (0, 0, 0).
-     *
-     * @type {Color}
      */
     color = new Color(0, 0, 0);
 
     /**
      * The density of the fog (if enabled). This property is only valid if the fog property is set
      * to {@link FOG_EXP} or {@link FOG_EXP2}. Defaults to 0.
-     *
-     * @type {number}
      */
     density = 0;
 
     /**
      * The distance from the viewpoint where linear fog begins. This property is only valid if the
      * fog property is set to {@link FOG_LINEAR}. Defaults to 1.
-     *
-     * @type {number}
      */
     start = 1;
 
     /**
      * The distance from the viewpoint where linear fog reaches its maximum. This property is only
      * valid if the fog property is set to {@link FOG_LINEAR}. Defaults to 1000.
-     *
-     * @type {number}
      */
     end = 1000;
 }
 
 export { FogParams };
+

--- a/src/scene/fog-params.js
+++ b/src/scene/fog-params.js
@@ -46,4 +46,3 @@ class FogParams {
 }
 
 export { FogParams };
-

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -128,19 +128,16 @@ class GraphNode extends EventHandler {
 
     // Local space properties of transform (only first 3 are settable by the user)
     /**
-     * @type {Vec3}
      * @private
      */
     localPosition = new Vec3();
 
     /**
-     * @type {Quat}
      * @private
      */
     localRotation = new Quat();
 
     /**
-     * @type {Vec3}
      * @private
      */
     localScale = new Vec3(1, 1, 1);
@@ -153,19 +150,16 @@ class GraphNode extends EventHandler {
 
     // World space properties of transform
     /**
-     * @type {Vec3}
      * @private
      */
     position = new Vec3();
 
     /**
-     * @type {Quat}
      * @private
      */
     rotation = new Quat();
 
     /**
-     * @type {Vec3}
      * @private
      */
     eulerAngles = new Vec3();
@@ -177,19 +171,16 @@ class GraphNode extends EventHandler {
     _scale = null;
 
     /**
-     * @type {Mat4}
      * @private
      */
     localTransform = new Mat4();
 
     /**
-     * @type {boolean}
      * @private
      */
     _dirtyLocal = false;
 
     /**
-     * @type {number}
      * @private
      */
     _aabbVer = 0;
@@ -199,19 +190,16 @@ class GraphNode extends EventHandler {
      * automatically freezes and unfreezes objects whenever required. Segregating dynamic and
      * stationary nodes into subhierarchies allows to reduce sync time significantly.
      *
-     * @type {boolean}
      * @private
      */
     _frozen = false;
 
     /**
-     * @type {Mat4}
      * @private
      */
     worldTransform = new Mat4();
 
     /**
-     * @type {boolean}
      * @private
      */
     _dirtyWorld = false;
@@ -222,19 +210,16 @@ class GraphNode extends EventHandler {
      * transform is not negatively scaled. If the value is -1, the world transform is negatively
      * scaled.
      *
-     * @type {number}
      * @private
      */
     _worldScaleSign = 0;
 
     /**
-     * @type {Mat3}
      * @private
      */
     _normalMatrix = new Mat3();
 
     /**
-     * @type {boolean}
      * @private
      */
     _dirtyNormal = true;
@@ -270,7 +255,6 @@ class GraphNode extends EventHandler {
     _children = [];
 
     /**
-     * @type {number}
      * @private
      */
     _graphDepth = 0;
@@ -279,7 +263,6 @@ class GraphNode extends EventHandler {
      * Represents enabled state of the entity. If the entity is disabled, the entity including all
      * children are excluded from updates.
      *
-     * @type {boolean}
      * @private
      */
     _enabled = true;
@@ -288,13 +271,11 @@ class GraphNode extends EventHandler {
      * Represents enabled state of the entity in the hierarchy. It's true only if this entity and
      * all parent entities all the way to the scene's root are enabled.
      *
-     * @type {boolean}
      * @private
      */
     _enabledInHierarchy = false;
 
     /**
-     * @type {boolean}
      * @ignore
      */
     scaleCompensation = false;
@@ -1832,3 +1813,4 @@ class GraphNode extends EventHandler {
 }
 
 export { GraphNode };
+

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1813,4 +1813,3 @@ class GraphNode extends EventHandler {
 }
 
 export { GraphNode };
-

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -127,19 +127,13 @@ class GraphNode extends EventHandler {
     tags = new Tags(this);
 
     // Local space properties of transform (only first 3 are settable by the user)
-    /**
-     * @private
-     */
+    /** @private */
     localPosition = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     localRotation = new Quat();
 
-    /**
-     * @private
-     */
+    /** @private */
     localScale = new Vec3(1, 1, 1);
 
     /**
@@ -149,19 +143,13 @@ class GraphNode extends EventHandler {
     localEulerAngles = new Vec3(); // Only calculated on request
 
     // World space properties of transform
-    /**
-     * @private
-     */
+    /** @private */
     position = new Vec3();
 
-    /**
-     * @private
-     */
+    /** @private */
     rotation = new Quat();
 
-    /**
-     * @private
-     */
+    /** @private */
     eulerAngles = new Vec3();
 
     /**
@@ -170,19 +158,13 @@ class GraphNode extends EventHandler {
      */
     _scale = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     localTransform = new Mat4();
 
-    /**
-     * @private
-     */
+    /** @private */
     _dirtyLocal = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _aabbVer = 0;
 
     /**
@@ -194,14 +176,10 @@ class GraphNode extends EventHandler {
      */
     _frozen = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     worldTransform = new Mat4();
 
-    /**
-     * @private
-     */
+    /** @private */
     _dirtyWorld = false;
 
     /**
@@ -214,14 +192,10 @@ class GraphNode extends EventHandler {
      */
     _worldScaleSign = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     _normalMatrix = new Mat3();
 
-    /**
-     * @private
-     */
+    /** @private */
     _dirtyNormal = true;
 
     /**
@@ -254,9 +228,7 @@ class GraphNode extends EventHandler {
      */
     _children = [];
 
-    /**
-     * @private
-     */
+    /** @private */
     _graphDepth = 0;
 
     /**
@@ -275,9 +247,7 @@ class GraphNode extends EventHandler {
      */
     _enabledInHierarchy = false;
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     scaleCompensation = false;
 
     /**

--- a/src/scene/graphics/compute-radix-sort.js
+++ b/src/scene/graphics/compute-radix-sort.js
@@ -629,4 +629,3 @@ class ComputeRadixSort {
 }
 
 export { ComputeRadixSort, ELEMENTS_PER_WORKGROUP as RADIX_SORT_ELEMENTS_PER_WORKGROUP };
-

--- a/src/scene/graphics/compute-radix-sort.js
+++ b/src/scene/graphics/compute-radix-sort.js
@@ -75,23 +75,17 @@ class ComputeRadixSort {
 
     /**
      * Current element count.
-     *
-     * @type {number}
      */
     _elementCount = 0;
 
     /**
      * Number of workgroups for current sort.
-     *
-     * @type {number}
      */
     _workgroupCount = 0;
 
     /**
      * Allocated workgroup capacity. Tracks the last allocated size; reallocation is triggered
      * when the effective workgroup count (derived from element count and capacity) differs.
-     *
-     * @type {number}
      */
     _allocatedWorkgroupCount = 0;
 
@@ -100,15 +94,11 @@ class ComputeRadixSort {
      * `max(elementCount, capacity)` as the effective size. The caller can lower this value
      * to request shrinkage; actual reallocation is deferred to the next sort call.
      * After allocation, this is updated to reflect the effective element count.
-     *
-     * @type {number}
      */
     capacity = 0;
 
     /**
      * Current number of bits for which passes are created.
-     *
-     * @type {number}
      */
     _numBits = 0;
 
@@ -163,8 +153,6 @@ class ComputeRadixSort {
 
     /**
      * Dispatch dimensions.
-     *
-     * @type {Vec2}
      */
     _dispatchSize = new Vec2(1, 1);
 
@@ -198,23 +186,17 @@ class ComputeRadixSort {
 
     /**
      * Whether the current passes are for indirect sort mode.
-     *
-     * @type {boolean}
      */
     _indirect = false;
 
     /**
      * Whether the current passes expect caller-supplied initial values on pass 0.
-     *
-     * @type {boolean}
      */
     _hasInitialValues = false;
 
     /**
      * Whether the last pass skips writing sorted keys (only values are written).
      * When true, `sortedKeys` will contain stale data after sorting.
-     *
-     * @type {boolean}
      */
     _skipLastPassKeyWrite = false;
 
@@ -647,3 +629,4 @@ class ComputeRadixSort {
 }
 
 export { ComputeRadixSort, ELEMENTS_PER_WORKGROUP as RADIX_SORT_ELEMENTS_PER_WORKGROUP };
+

--- a/src/scene/graphics/fisheye-projection.js
+++ b/src/scene/graphics/fisheye-projection.js
@@ -12,50 +12,36 @@
 class FisheyeProjection {
     /**
      * Whether fisheye is active (t > 0).
-     *
-     * @type {boolean}
      */
     enabled = false;
 
     /**
      * The fisheye k parameter controlling projection curvature.
-     *
-     * @type {number}
      */
     k = 1.0;
 
     /**
      * Precomputed 1/k to avoid per-splat division in shaders.
-     *
-     * @type {number}
      */
     invK = 1.0;
 
     /**
      * Scale factor blending from edge-fit (1.0) to corner-fit (sqrt(2)) based on t.
-     *
-     * @type {number}
      */
     cornerScale = 1.0;
 
     /**
      * Fisheye-adjusted horizontal projection scale for NDC conversion.
-     *
-     * @type {number}
      */
     projMat00 = 1.0;
 
     /**
      * Fisheye-adjusted vertical projection scale for NDC conversion.
-     *
-     * @type {number}
      */
     projMat11 = 1.0;
 
     /**
      * Maximum viewing angle before singularity, used for cone culling.
-     *
-     * @type {number}
      */
     maxTheta = Math.PI;
 
@@ -137,3 +123,4 @@ class FisheyeProjection {
 }
 
 export { FisheyeProjection };
+

--- a/src/scene/graphics/fisheye-projection.js
+++ b/src/scene/graphics/fisheye-projection.js
@@ -123,4 +123,3 @@ class FisheyeProjection {
 }
 
 export { FisheyeProjection };
-

--- a/src/scene/graphics/frame-pass-radix-sort.js
+++ b/src/scene/graphics/frame-pass-radix-sort.js
@@ -84,15 +84,11 @@ class FramePassRadixSort extends FramePass {
 
     /**
      * Current number of radix passes.
-     *
-     * @type {number}
      */
     _numPasses = 0;
 
     /**
      * Current internal texture size (power of 2).
-     *
-     * @type {number}
      */
     _internalSize = 0;
 
@@ -168,8 +164,6 @@ class FramePassRadixSort extends FramePass {
 
     /**
      * Number of elements to sort (set by setup()).
-     *
-     * @type {number}
      */
     _elementCount = 0;
 
@@ -489,3 +483,4 @@ class FramePassRadixSort extends FramePass {
 }
 
 export { FramePassRadixSort };
+

--- a/src/scene/graphics/frame-pass-radix-sort.js
+++ b/src/scene/graphics/frame-pass-radix-sort.js
@@ -483,4 +483,3 @@ class FramePassRadixSort extends FramePass {
 }
 
 export { FramePassRadixSort };
-

--- a/src/scene/graphics/post-effect.js
+++ b/src/scene/graphics/post-effect.js
@@ -89,4 +89,3 @@ class PostEffect {
 }
 
 export { PostEffect };
-

--- a/src/scene/graphics/post-effect.js
+++ b/src/scene/graphics/post-effect.js
@@ -34,8 +34,6 @@ class PostEffect {
         /**
          * The property that should to be set to `true` (by the custom post effect) if a depth map
          * is necessary (default is false).
-         *
-         * @type {boolean}
          */
         this.needsDepthBuffer = false;
     }
@@ -91,3 +89,4 @@ class PostEffect {
 }
 
 export { PostEffect };
+

--- a/src/scene/graphics/render-pass-radix-sort-count.js
+++ b/src/scene/graphics/render-pass-radix-sort-count.js
@@ -131,4 +131,3 @@ class RenderPassRadixSortCount extends RenderPassShaderQuad {
 }
 
 export { RenderPassRadixSortCount };
-

--- a/src/scene/graphics/render-pass-radix-sort-count.js
+++ b/src/scene/graphics/render-pass-radix-sort-count.js
@@ -26,29 +26,21 @@ import wgslRadixSortCountQuad from '../shader-lib/wgsl/chunks/radix-sort/radix-s
 class RenderPassRadixSortCount extends RenderPassShaderQuad {
     /**
      * Whether this pass reads from linear-layout source texture (first pass).
-     *
-     * @type {boolean}
      */
     sourceLinear = false;
 
     /**
      * Bits per radix step (usually 4).
-     *
-     * @type {number}
      */
     bitsPerStep = 0;
 
     /**
      * Log2 of group size (usually 4 for 16 elements).
-     *
-     * @type {number}
      */
     groupSize = 0;
 
     /**
      * Current bit offset for this pass.
-     *
-     * @type {number}
      */
     currentBit = 0;
 
@@ -139,3 +131,4 @@ class RenderPassRadixSortCount extends RenderPassShaderQuad {
 }
 
 export { RenderPassRadixSortCount };
+

--- a/src/scene/graphics/render-pass-radix-sort-reorder.js
+++ b/src/scene/graphics/render-pass-radix-sort-reorder.js
@@ -173,4 +173,3 @@ class RenderPassRadixSortReorder extends RenderPassShaderQuad {
 }
 
 export { RenderPassRadixSortReorder };
-

--- a/src/scene/graphics/render-pass-radix-sort-reorder.js
+++ b/src/scene/graphics/render-pass-radix-sort-reorder.js
@@ -25,36 +25,26 @@ import wgslRadixSortReorderPS from '../shader-lib/wgsl/chunks/radix-sort/radix-s
 class RenderPassRadixSortReorder extends RenderPassShaderQuad {
     /**
      * Whether this pass reads from linear-layout source texture (first pass).
-     *
-     * @type {boolean}
      */
     sourceLinear = false;
 
     /**
      * Whether to output indices in linear layout.
-     *
-     * @type {boolean}
      */
     outputLinear = false;
 
     /**
      * Bits per radix step (usually 4).
-     *
-     * @type {number}
      */
     bitsPerStep = 0;
 
     /**
      * Log2 of group size (usually 4 for 16 elements).
-     *
-     * @type {number}
      */
     groupSize = 0;
 
     /**
      * Current bit offset for this pass.
-     *
-     * @type {number}
      */
     currentBit = 0;
 
@@ -183,3 +173,4 @@ class RenderPassRadixSortReorder extends RenderPassShaderQuad {
 }
 
 export { RenderPassRadixSortReorder };
+

--- a/src/scene/gsplat-unified/gsplat-frustum-culler.js
+++ b/src/scene/gsplat-unified/gsplat-frustum-culler.js
@@ -236,4 +236,3 @@ class GSplatFrustumCuller {
 }
 
 export { GSplatFrustumCuller };
-

--- a/src/scene/gsplat-unified/gsplat-frustum-culler.js
+++ b/src/scene/gsplat-unified/gsplat-frustum-culler.js
@@ -36,8 +36,6 @@ class GSplatFrustumCuller {
 
     /**
      * Total number of bounds entries across all GSplatInfos.
-     *
-     * @type {number}
      */
     totalBoundsEntries = 0;
 
@@ -91,8 +89,6 @@ class GSplatFrustumCuller {
 
     /**
      * Maximum visible angle from forward direction for fisheye cone culling.
-     *
-     * @type {number}
      */
     fisheyeMaxTheta = Math.PI;
 
@@ -240,3 +236,4 @@ class GSplatFrustumCuller {
 }
 
 export { GSplatFrustumCuller };
+

--- a/src/scene/gsplat-unified/gsplat-info.js
+++ b/src/scene/gsplat-unified/gsplat-info.js
@@ -480,4 +480,3 @@ class GSplatInfo {
 }
 
 export { GSplatInfo };
-

--- a/src/scene/gsplat-unified/gsplat-info.js
+++ b/src/scene/gsplat-unified/gsplat-info.js
@@ -127,22 +127,16 @@ class GSplatInfo {
 
     /**
      * Number of sub-draw instances for instanced interval rendering.
-     *
-     * @type {number}
      */
     subDrawCount = 0;
 
     /**
      * Number of bounding sphere entries this GSplatInfo contributes to the shared bounds texture.
-     *
-     * @type {number}
      */
     numBoundsEntries = 0;
 
     /**
      * Base index into the shared bounds sphere texture for this GSplatInfo's entries.
-     *
-     * @type {number}
      */
     boundsBaseIndex = 0;
 
@@ -486,3 +480,4 @@ class GSplatInfo {
 }
 
 export { GSplatInfo };
+

--- a/src/scene/gsplat-unified/gsplat-interval-compaction.js
+++ b/src/scene/gsplat-unified/gsplat-interval-compaction.js
@@ -486,4 +486,3 @@ class GSplatIntervalCompaction {
 }
 
 export { GSplatIntervalCompaction };
-

--- a/src/scene/gsplat-unified/gsplat-interval-compaction.js
+++ b/src/scene/gsplat-unified/gsplat-interval-compaction.js
@@ -79,8 +79,6 @@ class GSplatIntervalCompaction {
     /**
      * World state version for which intervals were last uploaded. Avoids redundant
      * uploads when sortGpu is called repeatedly with the same world state.
-     *
-     * @type {number}
      */
     _uploadedVersion = -1;
 
@@ -488,3 +486,4 @@ class GSplatIntervalCompaction {
 }
 
 export { GSplatIntervalCompaction };
+

--- a/src/scene/gsplat-unified/gsplat-interval-compaction.js
+++ b/src/scene/gsplat-unified/gsplat-interval-compaction.js
@@ -156,9 +156,7 @@ class GSplatIntervalCompaction {
         this._writeArgsUniformBufferFormat = null;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _destroyCullPass() {
         this._cullComputePerspective?.shader?.destroy();
         this._cullBindGroupFormatPerspective?.destroy();
@@ -170,9 +168,7 @@ class GSplatIntervalCompaction {
         this._cullBindGroupFormatFisheye = null;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _createUniformBufferFormats() {
         const device = this.device;
 
@@ -264,9 +260,7 @@ class GSplatIntervalCompaction {
         return this._cullComputePerspective;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _createScatterCompute() {
         const device = this.device;
 
@@ -293,9 +287,7 @@ class GSplatIntervalCompaction {
         this._scatterCompute = new Compute(device, shader, 'GSplatIntervalScatter');
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _createWriteIndirectArgsCompute() {
         const device = this.device;
 

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -134,8 +134,6 @@ class GSplatManager {
 
     /**
      * The version of the last world state.
-     *
-     * @type {number}
      */
     lastWorldStateVersion = 0;
 
@@ -177,8 +175,6 @@ class GSplatManager {
 
     /**
      * Indirect draw slot index for the current frame (-1 when not using indirect draw).
-     *
-     * @type {number}
      */
     indirectDrawSlot = -1;
 
@@ -186,16 +182,12 @@ class GSplatManager {
      * Indirect dispatch slot index for GPU-sort indirect dispatch args.
      * Slot +0 = key gen, slot +1 = sort. The compute local renderer builds
      * its own indirect args in private buffers and does not use these slots.
-     *
-     * @type {number}
      */
     indirectDispatchSlot = -1;
 
     /**
      * Total intervals from the last interval compaction dispatch. Needed for
      * writeIndirectArgs to index into the prefix sum buffer for visible count.
-     *
-     * @type {number}
      */
     lastCompactedNumIntervals = 0;
 
@@ -206,7 +198,6 @@ class GSplatManager {
      * When true, suppresses ready=true in frame:ready until a fullUpdate cycle runs.
      * Only set when octreeInstances exist and params change (dirty).
      *
-     * @type {boolean}
      * @private
      */
     _awaitingLodUpdate = false;
@@ -214,7 +205,6 @@ class GSplatManager {
     /**
      * Cached work buffer format version for detecting extra stream changes.
      *
-     * @type {number}
      * @private
      */
     _workBufferFormatVersion = -1;
@@ -222,22 +212,17 @@ class GSplatManager {
     /**
      * Flag set when the work buffer needs a full rebuild due to format changes.
      *
-     * @type {boolean}
      * @private
      */
     _workBufferRebuildRequired = false;
 
     /**
      * Number of blocks uploaded to the work buffer this frame.
-     *
-     * @type {number}
      */
     bufferCopyUploaded = 0;
 
     /**
      * Total number of blocks in the work buffer this frame.
-     *
-     * @type {number}
      */
     bufferCopyTotal = 0;
 
@@ -299,7 +284,6 @@ class GSplatManager {
      * Values > 1 push boundaries outward (more splats), values < 1 pull them inward
      * (fewer splats).
      *
-     * @type {number}
      * @private
      */
     _budgetScale = 1.0;
@@ -344,7 +328,6 @@ class GSplatManager {
      * True when placements have been added or removed since the last world state was created.
      * Triggers a full work buffer rebuild so boundsBaseIndex stays consistent.
      *
-     * @type {boolean}
      * @private
      */
     _placementSetChanged = false;
@@ -362,8 +345,6 @@ class GSplatManager {
 
     /**
      * Flag set when new octree instances are added, to trigger immediate LOD evaluation.
-     *
-     * @type {boolean}
      */
     hasNewOctreeInstances = false;
 
@@ -1939,3 +1920,4 @@ class GSplatManager {
 }
 
 export { GSplatManager };
+

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1920,4 +1920,3 @@ class GSplatManager {
 }
 
 export { GSplatManager };
-

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -994,4 +994,3 @@ class GSplatOctreeInstance {
 }
 
 export { GSplatOctreeInstance, NodeInfo };
-

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -64,18 +64,21 @@ class NodeInfo {
 
     /**
      * Back-reference to owning GSplatOctreeInstance.
+     *
      * @type {GSplatOctreeInstance|null}
      */
     inst = null;
 
     /**
      * Cached reference to this node's LOD array for fast budget balancing.
+     *
      * @type {Array|null}
      */
     lods = null;
 
     /**
      * Unique allocation identifier for persistent work buffer allocation tracking.
+     *
      * @type {number}
      */
     allocId = GsplatAllocId.get();
@@ -113,6 +116,7 @@ class GSplatOctreeInstance {
 
     /**
      * Array of NodeInfo instances, one per octree node.
+     *
      * @type {NodeInfo[]}
      */
     nodeInfos;
@@ -120,12 +124,14 @@ class GSplatOctreeInstance {
     /**
      * Array of current placements per file. Index is fileIndex, value is GSplatPlacement or null.
      * Value null indicates file is not used / no placement.
+     *
      * @type {(GSplatPlacement|null)[]}
      */
     filePlacements;
 
     /**
      * Set of pending file loads (file indices).
+     *
      * @type {Set<number>}
      */
     pending = new Set();
@@ -178,6 +184,7 @@ class GSplatOctreeInstance {
     /**
      * Tracks invisible->visible pending adds per node: nodeIndex -> fileIndex.
      * Ensures only a single pending placement exists for a node while it's not yet displayed.
+     *
      * @type {Map<number, number>}
      */
     pendingVisibleAdds = new Map();
@@ -200,6 +207,7 @@ class GSplatOctreeInstance {
 
     /**
      * Environment placement.
+     *
      * @type {GSplatPlacement|null}
      */
     environmentPlacement = null;
@@ -957,6 +965,7 @@ class GSplatOctreeInstance {
 
     /**
      * Returns true if this instance requests LOD re-evaluation and resets the flag.
+     *
      * @returns {boolean} True if LOD should be re-evaluated.
      */
     consumeNeedsLodUpdate() {

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -43,26 +43,22 @@ const _lodColors = [
 class NodeInfo {
     /**
      * Current LOD index being rendered. -1 indicates node is not visible.
-     * @type {number}
      */
     currentLod = -1;
 
     /**
      * Optimal LOD index based on distance/visibility (before underfill).
-     * @type {number}
      */
     optimalLod = -1;
 
     /**
      * World-space distance from camera to this node.
      * Used for non-linear bucket mapping in budget enforcement.
-     * @type {number}
      */
     worldDistance = 0;
 
     /**
      * Accumulated camera translation for SH color update threshold tracking.
-     * @type {number}
      */
     colorAccumulatedTranslation = 0;
 
@@ -109,8 +105,6 @@ class GSplatOctreeInstance {
     /**
      * Set to true when placements are added or removed, signaling that the manager needs to
      * create a new world state and trigger a full work buffer rebuild.
-     *
-     * @type {boolean}
      */
     dirtyPlacementSetChanged = false;
 
@@ -154,30 +148,22 @@ class GSplatOctreeInstance {
 
     /**
      * Minimum allowed LOD index for this instance, clamped to valid octree bounds.
-     *
-     * @type {number}
      */
     rangeMin = 0;
 
     /**
      * Maximum allowed LOD index for this instance, clamped to valid octree bounds.
-     *
-     * @type {number}
      */
     rangeMax = 0;
 
     /**
      * Previous node position at which LOD was last updated. This is used to determine if LOD needs
      * to be updated as the octree splat moves.
-     *
-     * @type {Vec3}
      */
     previousPosition = new Vec3();
 
     /**
      * Set when a resource has completed loading and LOD should be re-evaluated.
-     *
-     * @type {boolean}
      */
     needsLodUpdate = false;
 
@@ -1008,3 +994,4 @@ class GSplatOctreeInstance {
 }
 
 export { GSplatOctreeInstance, NodeInfo };
+

--- a/src/scene/gsplat-unified/gsplat-octree-node.js
+++ b/src/scene/gsplat-unified/gsplat-octree-node.js
@@ -20,6 +20,7 @@ class GSplatOctreeNode {
     lods;
 
     /**
+     * The axis-aligned bounding box of this octree node in local space.
      */
     bounds = new BoundingBox();
 

--- a/src/scene/gsplat-unified/gsplat-octree-node.js
+++ b/src/scene/gsplat-unified/gsplat-octree-node.js
@@ -20,15 +20,12 @@ class GSplatOctreeNode {
     lods;
 
     /**
-     * @type {BoundingBox}
      */
     bounds = new BoundingBox();
 
     /**
      * Precomputed bounding sphere derived from the AABB. Stored as (center.x, center.y,
      * center.z, radius) for efficient GPU frustum culling.
-     *
-     * @type {Vec4}
      */
     boundingSphere = new Vec4();
 
@@ -53,3 +50,4 @@ class GSplatOctreeNode {
 }
 
 export { GSplatOctreeNode };
+

--- a/src/scene/gsplat-unified/gsplat-octree-node.js
+++ b/src/scene/gsplat-unified/gsplat-octree-node.js
@@ -51,4 +51,3 @@ class GSplatOctreeNode {
 }
 
 export { GSplatOctreeNode };
-

--- a/src/scene/gsplat-unified/gsplat-octree.js
+++ b/src/scene/gsplat-unified/gsplat-octree.js
@@ -74,8 +74,6 @@ class GSplatOctree {
 
     /**
      * Reference count for environment usage.
-     *
-     * @type {number}
      */
     environmentRefCount = 0;
 
@@ -88,15 +86,12 @@ class GSplatOctree {
 
     /**
      * Whether this octree has been destroyed.
-     *
-     * @type {boolean}
      */
     destroyed = false;
 
     /**
      * Number of update ticks before unloading unused file resources. Set from GSplatParams.
      *
-     * @type {number}
      * @private
      */
     cooldownTicks = 100;
@@ -439,3 +434,4 @@ class GSplatOctree {
 }
 
 export { GSplatOctree };
+

--- a/src/scene/gsplat-unified/gsplat-octree.js
+++ b/src/scene/gsplat-unified/gsplat-octree.js
@@ -180,6 +180,7 @@ class GSplatOctree {
 
     /**
      * Trace out per-LOD counts of currently loaded file resources.
+     *
      * @private
      */
     _traceLodCounts() {

--- a/src/scene/gsplat-unified/gsplat-octree.js
+++ b/src/scene/gsplat-unified/gsplat-octree.js
@@ -434,4 +434,3 @@ class GSplatOctree {
 }
 
 export { GSplatOctree };
-

--- a/src/scene/gsplat-unified/gsplat-octree.resource.js
+++ b/src/scene/gsplat-unified/gsplat-octree.resource.js
@@ -9,7 +9,6 @@ class GSplatOctreeResource {
     /**
      * Version counter for centers array changes. Always 0 for octree resources (static).
      *
-     * @type {number}
      * @ignore
      */
     centersVersion = 0;
@@ -38,3 +37,4 @@ class GSplatOctreeResource {
 }
 
 export { GSplatOctreeResource };
+

--- a/src/scene/gsplat-unified/gsplat-octree.resource.js
+++ b/src/scene/gsplat-unified/gsplat-octree.resource.js
@@ -37,4 +37,3 @@ class GSplatOctreeResource {
 }
 
 export { GSplatOctreeResource };
-

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -594,6 +594,7 @@ class GSplatParams {
      *
      * If the source splats were generated without anti-aliasing, enabling this
      * option may slightly soften the image or alter opacity.
+     *
      * @type {boolean}
      */
     set antiAlias(value) {
@@ -618,6 +619,7 @@ class GSplatParams {
      * was generated for 2D Gaussian Splatting.
      *
      * Enabling this with standard 3D splat data may produce incorrect results.
+     *
      * @type {boolean}
      */
     set twoDimensional(value) {

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -788,4 +788,3 @@ class GSplatParams {
 }
 
 export { GSplatParams };
-

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -119,8 +119,6 @@ class GSplatParams {
 
     /**
      * Enables debug rendering of AABBs for GSplat objects. Defaults to false.
-     *
-     * @type {boolean}
      */
     debugAabbs = false;
 
@@ -130,8 +128,6 @@ class GSplatParams {
      *
      * Note: Radial sorting helps reduce sorting artifacts when the camera rotates (looks around),
      * while linear sorting is better at minimizing artifacts when the camera translates (moves).
-     *
-     * @type {boolean}
      */
     radialSorting = false;
 
@@ -193,8 +189,6 @@ class GSplatParams {
 
     /**
      * Enables debug rendering of AABBs for GSplat octree nodes. Defaults to false.
-     *
-     * @type {boolean}
      */
     debugNodeAabbs = false;
 
@@ -202,7 +196,6 @@ class GSplatParams {
      * Internal dirty flag to trigger update of gsplat managers when some params change.
      *
      * @ignore
-     * @type {boolean}
      */
     dirty = false;
 
@@ -257,7 +250,6 @@ class GSplatParams {
     }
 
     /**
-     * @type {boolean}
      * @private
      */
     _enableIds = false;
@@ -296,21 +288,16 @@ class GSplatParams {
     /**
      * Distance threshold in world units to trigger LOD updates for camera and gsplat instances.
      * Defaults to 1.
-     *
-     * @type {number}
      */
     lodUpdateDistance = 1;
 
     /**
      * Angle threshold in degrees to trigger LOD updates based on camera rotation. Set to 0 to
      * disable rotation-based updates. Defaults to 0.
-     *
-     * @type {number}
      */
     lodUpdateAngle = 0;
 
     /**
-     * @type {number}
      * @private
      */
     _lodBehindPenalty = 1;
@@ -341,7 +328,6 @@ class GSplatParams {
     }
 
     /**
-     * @type {number}
      * @private
      */
     _lodRangeMin = 0;
@@ -368,7 +354,6 @@ class GSplatParams {
     }
 
     /**
-     * @type {number}
      * @private
      */
     _lodRangeMax = 10;
@@ -395,7 +380,6 @@ class GSplatParams {
     }
 
     /**
-     * @type {number}
      * @private
      */
     _lodUnderfillLimit = 0;
@@ -425,7 +409,6 @@ class GSplatParams {
     }
 
     /**
-     * @type {number}
      * @private
      */
     _splatBudget = 0;
@@ -487,16 +470,12 @@ class GSplatParams {
      * Intensity multiplier for overdraw visualization mode. Value of 1 uses alpha of 1/32,
      * allowing approximately 32 overdraws to reach full brightness with additive blending.
      * Higher values increase brightness per splat. Defaults to 1.
-     *
-     * @type {number}
      */
     colorRampIntensity = 1;
 
     /**
      * Whether to apply scene fog to Gaussian splats. When false, splats ignore fog settings
      * even if the scene or camera has fog configured. Defaults to true.
-     *
-     * @type {boolean}
      */
     useFog = true;
 
@@ -520,8 +499,6 @@ class GSplatParams {
      * splat by this amount, its SH colors are re-evaluated. Distant nodes naturally update
      * less frequently since they require more camera movement to reach the angle threshold.
      * Set to 0 to update every frame where camera moves. Defaults to 10.
-     *
-     * @type {number}
      */
     colorUpdateAngle = 10;
 
@@ -670,7 +647,6 @@ class GSplatParams {
     }
 
     /**
-     * @type {number}
      * @private
      */
     _fisheye = 0;
@@ -725,8 +701,6 @@ class GSplatParams {
      * reference count reaches zero, it enters a cooldown period before being unloaded. This allows
      * recently used data to remain in memory for quick reuse if needed again soon. Set to 0 to
      * unload immediately when unused. Defaults to 100.
-     *
-     * @type {number}
      */
     cooldownTicks = 100;
 
@@ -814,3 +788,4 @@ class GSplatParams {
 }
 
 export { GSplatParams };
+

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -249,9 +249,7 @@ class GSplatParams {
         return this._debug === GSPLAT_DEBUG_LOD;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _enableIds = false;
 
     /**
@@ -297,9 +295,7 @@ class GSplatParams {
      */
     lodUpdateAngle = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     _lodBehindPenalty = 1;
 
     /**
@@ -327,9 +323,7 @@ class GSplatParams {
         return this._lodBehindPenalty;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _lodRangeMin = 0;
 
     /**
@@ -353,9 +347,7 @@ class GSplatParams {
         return this._lodRangeMin;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _lodRangeMax = 10;
 
     /**
@@ -379,9 +371,7 @@ class GSplatParams {
         return this._lodRangeMax;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _lodUnderfillLimit = 0;
 
     /**
@@ -408,9 +398,7 @@ class GSplatParams {
         return this._lodUnderfillLimit;
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _splatBudget = 0;
 
     /**
@@ -646,9 +634,7 @@ class GSplatParams {
         return !!this._material.getDefine('GSPLAT_2DGS');
     }
 
-    /**
-     * @private
-     */
+    /** @private */
     _fisheye = 0;
 
     /**

--- a/src/scene/gsplat-unified/gsplat-placement.js
+++ b/src/scene/gsplat-unified/gsplat-placement.js
@@ -334,4 +334,3 @@ class GSplatPlacement {
 
 
 export { GSplatPlacement };
-

--- a/src/scene/gsplat-unified/gsplat-placement.js
+++ b/src/scene/gsplat-unified/gsplat-placement.js
@@ -46,8 +46,6 @@ class GSplatPlacement {
     /**
      * Unique identifier for this placement. Used by the picking system and available
      * for custom shader effects.
-     *
-     * @type {number}
      */
     id = 0;
 
@@ -60,15 +58,12 @@ class GSplatPlacement {
 
     /**
      * The LOD index for this placement.
-     *
-     * @type {number}
      */
     lodIndex = 0;
 
     /**
      * Base distance for the first LOD transition (LOD 0 to LOD 1).
      *
-     * @type {number}
      * @private
      */
     _lodBaseDistance = 5;
@@ -77,7 +72,6 @@ class GSplatPlacement {
      * Geometric multiplier between successive LOD distance thresholds.
      * Distance for LOD level i is: lodBaseDistance * lodMultiplier^i.
      *
-     * @type {number}
      * @private
      */
     _lodMultiplier = 3;
@@ -135,15 +129,11 @@ class GSplatPlacement {
 
     /**
      * Flag indicating LOD parameters have changed and LOD needs re-evaluation.
-     *
-     * @type {boolean}
      */
     lodDirty = false;
 
     /**
      * Flag indicating the splat needs to be re-rendered to work buffer.
-     *
-     * @type {boolean}
      */
     renderDirty = false;
 
@@ -157,7 +147,6 @@ class GSplatPlacement {
     /**
      * Last seen format version for auto-detecting format changes.
      *
-     * @type {number}
      * @private
      */
     _lastFormatVersion = -1;
@@ -345,3 +334,4 @@ class GSplatPlacement {
 
 
 export { GSplatPlacement };
+

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -41,7 +41,6 @@ class GSplatRenderer {
     /**
      * Cached work buffer format version for detecting extra stream changes.
      *
-     * @type {number}
      * @protected
      */
     _workBufferFormatVersion = -1;
@@ -187,3 +186,4 @@ class GSplatRenderer {
 }
 
 export { GSplatRenderer };
+

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -186,4 +186,3 @@ class GSplatRenderer {
 }
 
 export { GSplatRenderer };
-

--- a/src/scene/gsplat-unified/gsplat-sort-bin-weights.js
+++ b/src/scene/gsplat-unified/gsplat-sort-bin-weights.js
@@ -163,4 +163,3 @@ class GSplatSortBinWeights {
 }
 
 export { GSplatSortBinWeights };
-

--- a/src/scene/gsplat-unified/gsplat-sort-bin-weights.js
+++ b/src/scene/gsplat-unified/gsplat-sort-bin-weights.js
@@ -57,15 +57,11 @@ class GSplatSortBinWeights {
 
     /**
      * Cached cameraBin from last compute call.
-     *
-     * @type {number}
      */
     lastCameraBin = -1;
 
     /**
      * Cached bucketCount from last compute call.
-     *
-     * @type {number}
      */
     lastBucketCount = -1;
 
@@ -167,3 +163,4 @@ class GSplatSortBinWeights {
 }
 
 export { GSplatSortBinWeights };
+

--- a/src/scene/gsplat-unified/gsplat-sort-key-compute.js
+++ b/src/scene/gsplat-unified/gsplat-sort-key-compute.js
@@ -53,8 +53,6 @@ class GSplatSortKeyCompute {
 
     /**
      * Allocated capacity for sort keys (grow-only).
-     *
-     * @type {number}
      */
     allocatedCount = 0;
 
@@ -81,15 +79,11 @@ class GSplatSortKeyCompute {
 
     /**
      * Whether the current compute instance is for radial sorting.
-     *
-     * @type {boolean}
      */
     computeRadialSort = false;
 
     /**
      * Whether the current compute instance uses indirect sort (with compaction).
-     *
-     * @type {boolean}
      */
     computeUseIndirectSort = false;
 
@@ -444,3 +438,4 @@ class GSplatSortKeyCompute {
 }
 
 export { GSplatSortKeyCompute };
+

--- a/src/scene/gsplat-unified/gsplat-sort-key-compute.js
+++ b/src/scene/gsplat-unified/gsplat-sort-key-compute.js
@@ -438,4 +438,3 @@ class GSplatSortKeyCompute {
 }
 
 export { GSplatSortKeyCompute };
-

--- a/src/scene/gsplat-unified/gsplat-work-buffer.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer.js
@@ -117,9 +117,7 @@ class WorkBufferRenderInfo {
     }
 }
 
-/**
- * @ignore
- */
+/** @ignore */
 class GSplatWorkBuffer {
     /** @type {GraphicsDevice} */
     device;

--- a/src/scene/gsplat-unified/gsplat-world-state.js
+++ b/src/scene/gsplat-unified/gsplat-world-state.js
@@ -14,22 +14,16 @@ const _toFree = [];
 class GSplatWorldState {
     /**
      * The version of the world state.
-     *
-     * @type {number}
      */
     version = 0;
 
     /**
      * Whether the sort parameters have been set on the sorter.
-     *
-     * @type {boolean}
      */
     sortParametersSet = false;
 
     /**
      * Whether the world state has been sorted before.
-     *
-     * @type {boolean}
      */
     sortedBefore = false;
 
@@ -42,23 +36,17 @@ class GSplatWorldState {
 
     /**
      * The texture size of work buffer.
-     *
-     * @type {number}
      */
     textureSize = 0;
 
     /**
      * Total number of active splats across all placements.
-     *
-     * @type {number}
      */
     totalActiveSplats = 0;
 
     /**
      * Total number of intervals across all placements. Each placement contributes
      * either its interval count (intervals.length / 2) or 1 if it has no intervals.
-     *
-     * @type {number}
      */
     totalIntervals = 0;
 
@@ -106,8 +94,6 @@ class GSplatWorldState {
     /**
      * True when the allocator grew or defragmented, meaning all block offsets may have
      * changed and every splat must be re-rendered to the work buffer.
-     *
-     * @type {boolean}
      */
     fullRebuild = false;
 
@@ -371,3 +357,4 @@ class GSplatWorldState {
 }
 
 export { GSplatWorldState };
+

--- a/src/scene/gsplat-unified/gsplat-world-state.js
+++ b/src/scene/gsplat-unified/gsplat-world-state.js
@@ -357,4 +357,3 @@ class GSplatWorldState {
 }
 
 export { GSplatWorldState };
-

--- a/src/scene/gsplat-unified/gsplat-world-state.js
+++ b/src/scene/gsplat-unified/gsplat-world-state.js
@@ -64,6 +64,7 @@ class GSplatWorldState {
     /**
      * Files to decrement when this state becomes active.
      * Array of tuples: [octree, fileIndex]
+     *
      * @type {Array<[GSplatOctree, number]>}
      */
     pendingReleases = [];

--- a/src/scene/gsplat/gsplat-container.js
+++ b/src/scene/gsplat/gsplat-container.js
@@ -70,7 +70,6 @@ class GSplatContainer extends GSplatResourceBase {
      * of course, but not for cpu based sorting. The workaround is to recreate container when the
      * size changes.
      *
-     * @type {number}
      * @private
      */
     _maxSplats = 0;
@@ -78,7 +77,6 @@ class GSplatContainer extends GSplatResourceBase {
     /**
      * Current number of splats to render.
      *
-     * @type {number}
      * @private
      */
     _numSplats = 0;
@@ -186,3 +184,4 @@ class GSplatContainer extends GSplatResourceBase {
 }
 
 export { GSplatContainer };
+

--- a/src/scene/gsplat/gsplat-container.js
+++ b/src/scene/gsplat/gsplat-container.js
@@ -184,4 +184,3 @@ class GSplatContainer extends GSplatResourceBase {
 }
 
 export { GSplatContainer };
-

--- a/src/scene/gsplat/gsplat-format.js
+++ b/src/scene/gsplat/gsplat-format.js
@@ -107,7 +107,6 @@ class GSplatFormat {
      * When true, allows extra streams to be removed via {@link removeExtraStreams}.
      * Only work buffer formats (returned by {@link GSplatParams#format}) should set this.
      *
-     * @type {boolean}
      * @ignore
      */
     allowStreamRemoval = false;
@@ -133,7 +132,6 @@ class GSplatFormat {
     /**
      * Version counter that increments when extra streams change.
      *
-     * @type {number}
      * @private
      */
     _extraStreamsVersion = 0;
@@ -599,3 +597,4 @@ class GSplatFormat {
 }
 
 export { GSplatFormat };
+

--- a/src/scene/gsplat/gsplat-format.js
+++ b/src/scene/gsplat/gsplat-format.js
@@ -597,4 +597,3 @@ class GSplatFormat {
 }
 
 export { GSplatFormat };
-

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -99,14 +99,10 @@ class GSplatResourceBase {
      */
     parameters = new Map();
 
-    /**
-     * @private
-     */
+    /** @private */
     _refCount = 0;
 
-    /**
-     * @private
-     */
+    /** @private */
     _meshRefCount = 0;
 
     constructor(device, gsplatData) {

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -44,7 +44,6 @@ class GSplatResourceBase {
      * Version counter for centers array changes. Remains 0 for static resources.
      * Only GSplatContainer increments this via its update() method.
      *
-     * @type {number}
      * @ignore
      */
     centersVersion = 0;
@@ -101,13 +100,11 @@ class GSplatResourceBase {
     parameters = new Map();
 
     /**
-     * @type {number}
      * @private
      */
     _refCount = 0;
 
     /**
-     * @type {number}
      * @private
      */
     _meshRefCount = 0;
@@ -398,3 +395,4 @@ class GSplatResourceBase {
 }
 
 export { GSplatResourceBase };
+

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -395,4 +395,3 @@ class GSplatResourceBase {
 }
 
 export { GSplatResourceBase };
-

--- a/src/scene/gsplat/gsplat-sog-data.js
+++ b/src/scene/gsplat/gsplat-sog-data.js
@@ -183,15 +183,11 @@ class GSplatSogData {
 
     /**
      * URL of the asset, used for debugging texture names.
-     *
-     * @type {string}
      */
     url = '';
 
     /**
      * Whether to use minimal memory mode (releases source textures after packing).
-     *
-     * @type {boolean}
      */
     minimalMemory = false;
 
@@ -215,8 +211,6 @@ class GSplatSogData {
 
     /**
      * Number of spherical harmonics bands.
-     *
-     * @type {number}
      */
     shBands = 0;
 
@@ -634,3 +628,4 @@ class GSplatSogData {
 }
 
 export { GSplatSogData };
+

--- a/src/scene/gsplat/gsplat-sog-data.js
+++ b/src/scene/gsplat/gsplat-sog-data.js
@@ -628,4 +628,3 @@ class GSplatSogData {
 }
 
 export { GSplatSogData };
-

--- a/src/scene/gsplat/gsplat-sog-resource.js
+++ b/src/scene/gsplat/gsplat-sog-resource.js
@@ -40,9 +40,7 @@ class GSplatSogResource extends GSplatResourceBase {
         this._populateParameters();
     }
 
-    /**
-     * @protected
-     */
+    /** @protected */
     _actualDestroy() {
         // Remove externally-owned textures without destroying them (they're owned by gsplatData)
         this.streams.textures.delete('packedTexture');

--- a/src/scene/gsplat/gsplat-streams.js
+++ b/src/scene/gsplat/gsplat-streams.js
@@ -199,4 +199,3 @@ class GSplatStreams {
 }
 
 export { GSplatStreams };
-

--- a/src/scene/gsplat/gsplat-streams.js
+++ b/src/scene/gsplat/gsplat-streams.js
@@ -37,7 +37,6 @@ class GSplatStreams {
     /**
      * Texture dimensions (width and height).
      *
-     * @type {Vec2}
      * @private
      */
     _textureDimensions = new Vec2();
@@ -45,7 +44,6 @@ class GSplatStreams {
     /**
      * Whether this manages instance-level textures (true) or resource-level textures (false).
      *
-     * @type {boolean}
      * @private
      */
     _isInstance = false;
@@ -53,7 +51,6 @@ class GSplatStreams {
     /**
      * The format version at last sync.
      *
-     * @type {number}
      * @private
      */
     _formatVersion = -1;
@@ -202,3 +199,4 @@ class GSplatStreams {
 }
 
 export { GSplatStreams };
+

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -961,4 +961,3 @@ class Layer {
 }
 
 export { Layer, CulledInstances };
-

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -285,19 +285,13 @@ class Layer {
         }
 
         // clear flags
-        /**
-         * @private
-         */
+        /** @private */
         this._clearColorBuffer = !!options.clearColorBuffer;
 
-        /**
-         * @private
-         */
+        /** @private */
         this._clearDepthBuffer = !!options.clearDepthBuffer;
 
-        /**
-         * @private
-         */
+        /** @private */
         this._clearStencilBuffer = !!options.clearStencilBuffer;
 
         /**

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -147,7 +147,6 @@ class Layer {
      * True if _splitLights needs to be updated, which means if lights were added or removed from
      * the layer, or their key changed.
      *
-     * @type {boolean}
      * @private
      */
     _splitLightsDirty = true;
@@ -155,7 +154,6 @@ class Layer {
     /**
      * True if the objects rendered on the layer require light cube (emitters with lighting do).
      *
-     * @type {boolean}
      * @ignore
      */
     requiresLightCube = false;
@@ -199,7 +197,6 @@ class Layer {
     /**
      * True if the gsplatPlacements array was modified.
      *
-     * @type {boolean}
      * @ignore
      */
     gsplatPlacementsDirty = true;
@@ -289,19 +286,16 @@ class Layer {
 
         // clear flags
         /**
-         * @type {boolean}
          * @private
          */
         this._clearColorBuffer = !!options.clearColorBuffer;
 
         /**
-         * @type {boolean}
          * @private
          */
         this._clearDepthBuffer = !!options.clearDepthBuffer;
 
         /**
-         * @type {boolean}
          * @private
          */
         this._clearStencilBuffer = !!options.clearStencilBuffer;
@@ -967,3 +961,4 @@ class Layer {
 }
 
 export { Layer, CulledInstances };
+

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -159,7 +159,6 @@ class Light {
      * The flags used for clustered lighting. Stored as a bitfield, updated as properties change to
      * avoid those being updated each frame.
      *
-     * @type {number}
      * @ignore
      */
     clusteredFlags = 0;
@@ -1228,3 +1227,4 @@ class Light {
 }
 
 export { Light, lightTypes };
+

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -1227,4 +1227,3 @@ class Light {
 }
 
 export { Light, lightTypes };
-

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -924,4 +924,3 @@ class Material {
 }
 
 export { Material };
-

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -87,8 +87,6 @@ class Material {
 
     /**
      * The name of the material.
-     *
-     * @type {string}
      */
     name = 'Untitled';
 
@@ -96,8 +94,6 @@ class Material {
      * A unique id the user can assign to the material. The engine internally does not use this for
      * anything, and the user can assign a value to this id for any purpose they like. Defaults to
      * an empty string.
-     *
-     * @type {string}
      */
     userId = '';
 
@@ -129,8 +125,6 @@ class Material {
      * active render target based on alpha value. All fragments with an alpha value of less than
      * the alphaTest reference value will be discarded. alphaTest defaults to 0 (all fragments
      * pass).
-     *
-     * @type {number}
      */
     alphaTest = 0;
 
@@ -141,8 +135,6 @@ class Material {
      * otherwise sharp alpha cutouts, but isn't recommended for large area semi-transparent
      * surfaces. Note, that you don't need to enable blending to make alpha to coverage work. It
      * will work without it, just like alphaTest.
-     *
-     * @type {boolean}
      */
     alphaToCoverage = false;
 
@@ -932,3 +924,4 @@ class Material {
 }
 
 export { Material };
+

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -90,4 +90,3 @@ class StandardMaterialOptions {
 }
 
 export { StandardMaterialOptions };
-

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -17,29 +17,21 @@ class StandardMaterialOptions {
     /**
      * If UV1 (second set of texture coordinates) is required in the shader. Will be declared as
      * "vUv1" and passed to the fragment shader.
-     *
-     * @type {boolean}
      */
     forceUv1 = false;
 
     /**
      * Defines if {@link StandardMaterial#specular} constant should affect specular color.
-     *
-     * @type {boolean}
      */
     specularTint = false;
 
     /**
      * Defines if {@link StandardMaterial#metalness} constant should affect metalness value.
-     *
-     * @type {boolean}
      */
     metalnessTint = false;
 
     /**
      * Defines if {@link StandardMaterial#gloss} constant should affect glossiness value.
-     *
-     * @type {boolean}
      */
     glossTint = false;
 
@@ -51,50 +43,36 @@ class StandardMaterialOptions {
 
     /**
      * If normal map contains X in RGB, Y in Alpha, and Z must be reconstructed.
-     *
-     * @type {boolean}
      */
     packedNormal = false;
 
     /**
      * If normal detail map contains X in RGB, Y in Alpha, and Z must be reconstructed.
-     *
-     * @type {boolean}
      */
     normalDetailPackedNormal = false;
 
     /**
      * If normal clear coat map contains X in RGB, Y in Alpha, and Z must be reconstructed.
-     *
-     * @type {boolean}
      */
     clearCoatPackedNormal = false;
 
     /**
      * Invert the gloss channel.
-     *
-     * @type {boolean}
      */
     glossInvert = false;
 
     /**
      * Invert the sheen gloss channel.
-     *
-     * @type {boolean}
      */
     sheenGlossInvert = false;
 
     /**
      * Invert the clearcoat gloss channel.
-     *
-     * @type {boolean}
      */
     clearCoatGlossInvert = false;
 
     /**
      * True to include AO variables even if AO is not used, which allows SSAO to be used in the lit shader.
-     *
-     * @type {boolean}
      */
     useAO = false;
 
@@ -112,3 +90,4 @@ class StandardMaterialOptions {
 }
 
 export { StandardMaterialOptions };
+

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -1428,4 +1428,3 @@ class MeshInstance {
 }
 
 export { MeshInstance };
-

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -64,8 +64,6 @@ class InstancingData {
 
     /**
      * True if the vertex buffer is destroyed when the mesh instance is destroyed.
-     *
-     * @type {boolean}
      */
     _destroyVertexBuffer = false;
 
@@ -246,8 +244,6 @@ class MeshInstance {
      * casting without overhead of removing from scene. Note that this property does not add the
      * mesh instance to appropriate list of shadow casters on a {@link Layer}, but allows mesh to
      * be skipped from shadow casting while it is in the list already. Defaults to false.
-     *
-     * @type {boolean}
      */
     castShadow = false;
 
@@ -264,8 +260,6 @@ class MeshInstance {
     /**
      * Controls whether the mesh instance can be culled by frustum culling (see
      * {@link CameraComponent#frustumCulling}). Defaults to true.
-     *
-     * @type {boolean}
      */
     cull = true;
 
@@ -273,13 +267,10 @@ class MeshInstance {
      * Determines the rendering order of mesh instances. Only used when mesh instances are added to
      * a {@link Layer} with {@link Layer#opaqueSortMode} or {@link Layer#transparentSortMode}
      * (depending on the material) set to {@link SORTMODE_MANUAL}.
-     *
-     * @type {number}
      */
     drawOrder = 0;
 
     /**
-     * @type {number}
      * @ignore
      */
     _drawBucket = 127;
@@ -295,23 +286,18 @@ class MeshInstance {
      * Enable rendering for this mesh instance. Use visible property to enable/disable rendering
      * without overhead of removing from scene. But note that the mesh instance is still in the
      * hierarchy and still in the draw call list.
-     *
-     * @type {boolean}
      */
     visible = true;
 
     /**
      * Read this value in the {@link Scene.EVENT_POSTCULL} event to determine if the object is
      * actually going to be rendered.
-     *
-     * @type {boolean}
      */
     visibleThisFrame = false;
 
     /**
      * Negative scale batching support.
      *
-     * @type {number}
      * @ignore
      */
     flipFacesFactor = 1;
@@ -371,7 +357,6 @@ class MeshInstance {
     /**
      * True if the mesh instance is pickable by the {@link Picker}. Defaults to true.
      *
-     * @type {boolean}
      * @ignore
      */
     pick = true;
@@ -1443,3 +1428,4 @@ class MeshInstance {
 }
 
 export { MeshInstance };
+

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -270,9 +270,7 @@ class MeshInstance {
      */
     drawOrder = 0;
 
-    /**
-     * @ignore
-     */
+    /** @ignore */
     _drawBucket = 127;
 
     /**

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -1137,4 +1137,3 @@ class Mesh extends RefCountedObject {
 }
 
 export { Mesh };
-

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -240,7 +240,6 @@ class Mesh extends RefCountedObject {
     /**
      * AABB representing object space bounds of the mesh.
      *
-     * @type {BoundingBox}
      * @private
      */
     _aabb = new BoundingBox();
@@ -260,7 +259,6 @@ class Mesh extends RefCountedObject {
     /**
      * True if the created index buffer should be accessible as a storage buffer in compute shader.
      *
-     * @type {boolean}
      * @private
      */
     _storageIndex = false;
@@ -268,7 +266,6 @@ class Mesh extends RefCountedObject {
     /**
      * True if the created vertex buffer should be accessible as a storage buffer in compute shader.
      *
-     * @type {boolean}
      * @private
      */
     _storageVertex = false;
@@ -1140,3 +1137,4 @@ class Mesh extends RefCountedObject {
 }
 
 export { Mesh };
+

--- a/src/scene/morph-target.js
+++ b/src/scene/morph-target.js
@@ -11,8 +11,6 @@ import { BoundingBox } from '../core/shape/bounding-box.js';
 class MorphTarget {
     /**
      * A used flag. A morph target can be used / owned by the Morph class only one time.
-     *
-     * @type {boolean}
      */
     used = false;
 
@@ -103,3 +101,4 @@ class MorphTarget {
 }
 
 export { MorphTarget };
+

--- a/src/scene/morph-target.js
+++ b/src/scene/morph-target.js
@@ -101,4 +101,3 @@ class MorphTarget {
 }
 
 export { MorphTarget };
-

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -70,8 +70,6 @@ class RenderPassForward extends RenderPass {
     /**
      * If true, do not clear the depth buffer before rendering, as it was already primed by a depth
      * pre-pass.
-     *
-     * @type {boolean}
      */
     noDepthClear = false;
 
@@ -386,3 +384,4 @@ class RenderPassForward extends RenderPass {
 }
 
 export { RenderPassForward };
+

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -384,4 +384,3 @@ class RenderPassForward extends RenderPass {
 }
 
 export { RenderPassForward };
-

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -882,4 +882,3 @@ class Scene extends EventHandler {
 }
 
 export { Scene };
-

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -145,60 +145,44 @@ class Scene extends EventHandler {
     /**
      * If enabled, the ambient lighting will be baked into lightmaps. This will be either the
      * {@link skybox} if set up, otherwise {@link ambientLight}. Defaults to false.
-     *
-     * @type {boolean}
      */
     ambientBake = false;
 
     /**
      * If {@link ambientBake} is true, this specifies the brightness of ambient occlusion. Typical
      * range is -1 to 1. Defaults to 0, representing no change to brightness.
-     *
-     * @type {number}
      */
     ambientBakeOcclusionBrightness = 0;
 
     /**
      * If {@link ambientBake} is true, this specifies the contrast of ambient occlusion. Typical
      * range is -1 to 1. Defaults to 0, representing no change to contrast.
-     *
-     * @type {number}
      */
     ambientBakeOcclusionContrast = 0;
 
     /**
      * The color of the scene's ambient light, specified in sRGB color space. Defaults to black
      * (0, 0, 0).
-     *
-     * @type {Color}
      */
     ambientLight = new Color(0, 0, 0);
 
     /**
      * The luminosity of the scene's ambient light in lux (lm/m^2). Used if physicalUnits is true. Defaults to 0.
-     *
-     * @type {number}
      */
     ambientLuminance = 0;
 
     /**
      * The exposure value tweaks the overall brightness of the scene. Ignored if physicalUnits is true. Defaults to 1.
-     *
-     * @type {number}
      */
     exposure = 1;
 
     /**
      * The lightmap resolution multiplier. Defaults to 1.
-     *
-     * @type {number}
      */
     lightmapSizeMultiplier = 1;
 
     /**
      * The maximum lightmap resolution. Defaults to 2048.
-     *
-     * @type {number}
      */
     lightmapMaxResolution = 2048;
 
@@ -222,16 +206,12 @@ class Scene extends EventHandler {
      * in the image space of the lightmap, and it does not filter across lightmap UV space seams,
      * often making the seams more visible. It's important to balance the strength of the filter
      * with number of samples used for lightmap baking to limit the visible artifacts.
-     *
-     * @type {boolean}
      */
     lightmapFilterEnabled = false;
 
     /**
      * Enables HDR lightmaps. This can result in smoother lightmaps especially when many samples
      * are used. Defaults to false.
-     *
-     * @type {boolean}
      */
     lightmapHDR = false;
 
@@ -245,8 +225,6 @@ class Scene extends EventHandler {
 
     /**
      * Use physically based units for cameras and lights. When used, the exposure value is ignored.
-     *
-     * @type {boolean}
      */
     physicalUnits = false;
 
@@ -356,7 +334,6 @@ class Scene extends EventHandler {
          * This flag indicates changes were made to the scene which may require recompilation of
          * shaders that reference global settings.
          *
-         * @type {boolean}
          * @ignore
          */
         this.updateShaders = true;
@@ -905,3 +882,4 @@ class Scene extends EventHandler {
 }
 
 export { Scene };
+

--- a/src/scene/shader-lib/programs/lit-shader-options.js
+++ b/src/scene/shader-lib/programs/lit-shader-options.js
@@ -272,4 +272,3 @@ class LitShaderOptions {
 }
 
 export { LitShaderOptions };
-

--- a/src/scene/shader-lib/programs/lit-shader-options.js
+++ b/src/scene/shader-lib/programs/lit-shader-options.js
@@ -25,8 +25,6 @@ class LitShaderOptions {
 
     /**
      * Enable alpha testing. See {@link Material#alphaTest}.
-     *
-     * @type {boolean}
      */
     alphaTest = false;
 
@@ -48,22 +46,16 @@ class LitShaderOptions {
     /**
      * If hardware instancing compatible shader should be generated. Transform is read from
      * per-instance {@link VertexBuffer} instead of shader's uniforms.
-     *
-     * @type {boolean}
      */
     useInstancing = false;
 
     /**
      * If morphing code should be generated to morph positions.
-     *
-     * @type {boolean}
      */
     useMorphPosition = false;
 
     /**
      * If morphing code should be generated to morph normals.
-     *
-     * @type {boolean}
      */
     useMorphNormal = false;
 
@@ -104,44 +96,32 @@ class LitShaderOptions {
     /**
      * If ambient spherical harmonics are used. Ambient SH replace prefiltered cubemap ambient on
      * certain platforms (mostly Android) for performance reasons.
-     *
-     * @type {boolean}
      */
     ambientSH = false;
 
     /**
      * Apply SSAO during the lighting.
-     *
-     * @type {boolean}
      */
     ssao = false;
 
     /**
      * The value of {@link StandardMaterial#twoSidedLighting}.
-     *
-     * @type {boolean}
      */
     twoSidedLighting = false;
 
     /**
      * The value of {@link StandardMaterial#occludeDirect}.
-     *
-     * @type {boolean}
      */
     occludeDirect = false;
 
     /**
      * The value of {@link StandardMaterial#occludeSpecular}.
-     *
-     * @type {number}
      */
     occludeSpecular = 0;
 
     /**
      * Defines if {@link StandardMaterial#occludeSpecularIntensity} constant should affect specular
      * occlusion.
-     *
-     * @type {boolean}
      */
     occludeSpecularFloat = false;
 
@@ -151,15 +131,11 @@ class LitShaderOptions {
 
     /**
      * Enable alpha to coverage. See {@link Material#alphaToCoverage}.
-     *
-     * @type {boolean}
      */
     alphaToCoverage = false;
 
     /**
      * Enable specular fade. See {@link StandardMaterial#opacityFadesSpecular}.
-     *
-     * @type {boolean}
      */
     opacityFadesSpecular = false;
 
@@ -179,15 +155,11 @@ class LitShaderOptions {
 
     /**
      * The value of {@link StandardMaterial#cubeMapProjection}.
-     *
-     * @type {number}
      */
     cubeMapProjection = 0;
 
     /**
      * If any specular or reflections are needed at all.
-     *
-     * @type {boolean}
      */
     useSpecular = false;
 
@@ -197,15 +169,11 @@ class LitShaderOptions {
 
     /**
      * The value of {@link StandardMaterial#fresnelModel}.
-     *
-     * @type {number}
      */
     fresnelModel = 0;
 
     /**
      * If refraction is used.
-     *
-     * @type {boolean}
      */
     useRefraction = false;
 
@@ -217,8 +185,6 @@ class LitShaderOptions {
 
     /**
      * The value of {@link StandardMaterial#useMetalness}.
-     *
-     * @type {boolean}
      */
     useMetalness = false;
 
@@ -245,8 +211,6 @@ class LitShaderOptions {
     /**
      * The type of tone mapping being applied in the shader. See {@link CameraComponent#toneMapping}
      * for the list of possible values.
-     *
-     * @type {number}
      */
     toneMap = -1;
 
@@ -263,8 +227,6 @@ class LitShaderOptions {
 
     /**
      * One of "ambientSH", "envAtlas", "constant".
-     *
-     * @type {string}
      */
     ambientSource = 'constant';
 
@@ -275,15 +237,11 @@ class LitShaderOptions {
 
     /**
      * Skybox intensity factor.
-     *
-     * @type {number}
      */
     skyboxIntensity = 1.0;
 
     /**
      * If cube map rotation is enabled.
-     *
-     * @type {boolean}
      */
     useCubeMapRotation = false;
 
@@ -304,8 +262,6 @@ class LitShaderOptions {
 
     /**
      * Make vLinearDepth available in the shader.
-     *
-     * @type {boolean}
      */
     linearDepth = false;
 
@@ -316,3 +272,4 @@ class LitShaderOptions {
 }
 
 export { LitShaderOptions };
+

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -570,4 +570,3 @@ class LitShader {
 }
 
 export { LitShader };
-

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -40,8 +40,6 @@ const builtinAttributes = {
 class LitShader {
     /**
      * Shader code representing varyings.
-     *
-     * @type {string}
      */
     varyingsCode = '';
 
@@ -572,3 +570,4 @@ class LitShader {
 }
 
 export { LitShader };
+

--- a/src/scene/shader-lib/shader-chunks.js
+++ b/src/scene/shader-lib/shader-chunks.js
@@ -100,8 +100,6 @@ class ShaderChunks {
      * custom shader chunks, set this to the latest supported version. If a future engine release no
      * longer supports the specified version, a warning will be issued. In that case, update your
      * shader chunks to match the new format and set this to the latest version accordingly.
-     *
-     * @type {string}
      */
     version = '';
 
@@ -140,3 +138,4 @@ class ShaderChunks {
 }
 
 export { ShaderChunks };
+

--- a/src/scene/shader-lib/shader-chunks.js
+++ b/src/scene/shader-lib/shader-chunks.js
@@ -138,4 +138,3 @@ class ShaderChunks {
 }
 
 export { ShaderChunks };
-

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -26,6 +26,9 @@ class SkyMesh {
      */
     meshInstance = null;
 
+    /**
+     * @private
+     */
     _depthWrite = false;
 
     /**

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -26,8 +26,6 @@ class SkyMesh {
      */
     meshInstance = null;
 
-    /**
-     */
     _depthWrite = false;
 
     /**

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -26,9 +26,7 @@ class SkyMesh {
      */
     meshInstance = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _depthWrite = false;
 
     /**

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -27,7 +27,6 @@ class SkyMesh {
     meshInstance = null;
 
     /**
-     * @type {boolean}
      */
     _depthWrite = false;
 
@@ -111,3 +110,4 @@ class SkyMesh {
 }
 
 export { SkyMesh };
+

--- a/src/scene/skybox/sky-mesh.js
+++ b/src/scene/skybox/sky-mesh.js
@@ -111,4 +111,3 @@ class SkyMesh {
 }
 
 export { SkyMesh };
-

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -267,4 +267,3 @@ class Sky {
 }
 
 export { Sky };
-

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -25,7 +25,6 @@ class Sky {
     /**
      * The center of the sky.
      *
-     * @type {Vec3}
      * @private
      */
     _center = new Vec3(0, 1, 0);
@@ -39,13 +38,11 @@ class Sky {
     skyMesh = null;
 
     /**
-     * @type {boolean}
      * @private
      */
     _depthWrite = false;
 
     /**
-     * @type {number}
      * @private
      */
     _fisheye = 0;
@@ -270,3 +267,4 @@ class Sky {
 }
 
 export { Sky };
+

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -37,14 +37,10 @@ class Sky {
      */
     skyMesh = null;
 
-    /**
-     * @private
-     */
+    /** @private */
     _depthWrite = false;
 
-    /**
-     * @private
-     */
+    /** @private */
     _fisheye = 0;
 
     /**


### PR DESCRIPTION
## Summary

Removes ~500 redundant JSDoc `@type` tags on class fields whose initializer already provides unambiguous type inference to TypeScript. No public API changes; `build/playcanvas.d.ts` is byte-identical after stripping the removed `@type` comment lines, and TypeDoc output is unchanged (a few fields that previously carried only an `@type` annotation now carry a short description instead).

## What was removed

`@type` tags were removed from fields where the right-hand side is one of:
- Primitive literals: `= 0`, `= 1.5`, `= true`, `= false`, `= 'x'`
- Arithmetic / numeric expressions: `Math.PI`, `Math.clamp(...)`, `Number(x)`
- Boolean coercions: `!!x`, `typeof X !== 'undefined'`, `env === 'browser'`
- Concrete class instantiations: `new Vec2/Vec3/Vec4/Quat/Mat3/Mat4/Color/Ray/BoundingBox/BoundingSphere/Plane/Frustum(...)`
- `.clone()` calls on the corresponding concrete class (e.g. `Vec3.UP.clone()`, `COLOR_RED.clone()`)

Fields marked `@readonly` are deliberately **left untouched** — TypeScript preserves the literal type on readonly fields, so the `@type` tag is load-bearing there.

## Verification

- `npm run build:types` succeeds
- `npm run test:types` succeeds
- `build/playcanvas.d.ts` type declarations are byte-identical to `main` (after filtering out `@type` cosmetic comment lines, which naturally disappear when the source tags are removed)
- TypeDoc spot-check: 1056 of 1058 generated HTML pages are byte-identical; remaining 2 differ only because a handful of previously-empty JSDoc blocks gained meaningful descriptions

## Test plan

- [x] `npm run build:types`
- [x] `npm run test:types`
- [x] TypeDoc diff check against `main`
