### PR TITLE
Viewer: support drag-and-drop of unpacked SOG

### DIFF
--- a/examples/src/examples/gaussian-splatting/viewer.example.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.example.mjs
@@ -30,8 +30,10 @@ dropBox.style.cssText = `
     font-family: Arial, sans-serif;
     font-size: 24px;
     color: white;
+    text-align: center;
+    line-height: 1.4;
 `;
-dropBox.textContent = 'Drop .ply, .sog, or .glb file to view';
+dropBox.innerHTML = 'Drop .ply, .sog, or .glb file to view<br>or unpacked SOG (meta.json + .webp files)';
 dropOverlay.appendChild(dropBox);
 document.body.appendChild(dropOverlay);
 
@@ -260,29 +262,83 @@ assetListLoader.load(() => {
     canvas.addEventListener('drop', async (e) => {
         e.preventDefault();
 
-        const file = e.dataTransfer.files[0];
-        if (!file) return;
+        const files = Array.from(e.dataTransfer.files);
+        if (files.length === 0) return;
 
+        // Detect unpacked SOG: a meta.json file was dropped (with any number of sibling webp files).
+        const metaFile = files.find(f => f.name.toLowerCase() === 'meta.json');
+        const isUnpackedSog = !!metaFile;
+
+        // Otherwise expect a single gsplat/glb file
+        const file = files[0];
         const fileName = file.name.toLowerCase();
-        const isGsplat = fileName.endsWith('.ply') || fileName.endsWith('.sog');
-        const isGlb = fileName.endsWith('.glb');
+        const isGsplat = !isUnpackedSog && (fileName.endsWith('.ply') || fileName.endsWith('.sog'));
+        const isGlb = !isUnpackedSog && fileName.endsWith('.glb');
 
-        if (!isGsplat && !isGlb) {
-            console.warn('Please drop a .ply, .sog, or .glb file');
+        if (!isUnpackedSog && !isGsplat && !isGlb) {
+            console.warn('Please drop a .ply, .sog, .glb, or an unpacked SOG (meta.json + .webp files)');
             return;
         }
 
         // Hide instructions overlay
         dropOverlay.style.display = 'none';
 
-        // Create blob URL and load asset using loadFromUrlAndFilename
-        // This method is specifically for blob assets where the URL doesn't identify the format
-        const blobUrl = URL.createObjectURL(file);
-
         let entity;
         let aabb;
 
-        if (isGsplat) {
+        if (isUnpackedSog) {
+            // Build a filename -> blob URL map for all sibling files (webp textures).
+            // The SogParser will use options.mapUrl to resolve filenames referenced in meta.json.
+            const blobMap = new Map();
+            for (const f of files) {
+                if (f !== metaFile) {
+                    blobMap.set(f.name, URL.createObjectURL(f));
+                }
+            }
+
+            const metaBlobUrl = URL.createObjectURL(metaFile);
+
+            // Create gsplat asset manually so we can pass the mapUrl option
+            const asset = new pc.Asset(metaFile.name, 'gsplat', {
+                url: metaBlobUrl,
+                filename: metaFile.name
+            }, null, {
+                mapUrl: filename => blobMap.get(filename)
+            });
+
+            app.assets.add(asset);
+
+            await new Promise((resolve, reject) => {
+                asset.once('load', () => resolve(asset));
+                asset.once('error', err => reject(err));
+                app.assets.load(asset);
+            });
+
+            // Create gsplat entity
+            entity = new pc.Entity(metaFile.name);
+            entity.addComponent('gsplat', {
+                asset: asset,
+                unified: true
+            });
+            entity.setLocalEulerAngles(180, 0, 0);
+            app.root.addChild(entity);
+
+            splatEntity = entity;
+
+            await new Promise((resolve) => {
+                requestAnimationFrame(resolve);
+            });
+
+            aabb = entity.gsplat.customAabb;
+            if (!aabb) {
+                console.warn('customAabb not available');
+                return;
+            }
+        } else if (isGsplat) {
+            // Create blob URL and load asset using loadFromUrlAndFilename
+            // This method is specifically for blob assets where the URL doesn't identify the format
+            const blobUrl = URL.createObjectURL(file);
+
             // Load gaussian splat asset
             const asset = await new Promise((resolve, reject) => {
                 app.assets.loadFromUrlAndFilename(blobUrl, file.name, 'gsplat', (err, loadedAsset) => {
@@ -319,6 +375,7 @@ assetListLoader.load(() => {
             }
         } else {
             // Load GLB container asset
+            const blobUrl = URL.createObjectURL(file);
             let asset;
             try {
                 asset = await new Promise((resolve, reject) => {


### PR DESCRIPTION
Extend the gaussian splat viewer example to support loading "unpacked" SOG assets — a meta.json alongside its webp texture files — via drag and drop.

**Changes:**
- Drop handler now accepts multiple files; if `meta.json` is among them it routes to a new unpacked-SOG branch that creates a blob URL per file and constructs the `gsplat` asset with an `options.mapUrl` callback so `SogParser` resolves sibling texture filenames to the corresponding blob URLs.
- Existing `.ply`, `.sog`, and `.glb` single-file drop paths are unchanged.
- Drop overlay now shows a two-line message advertising both drop modes.

**Examples:**
- `examples/src/examples/gaussian-splatting/viewer.example.mjs` updated.