### PR TITLE
docs: clean up 'Other' category on API reference index

### DIFF
--- a/utils/typedoc/typedoc-plugin.mjs
+++ b/utils/typedoc/typedoc-plugin.mjs
@@ -61,6 +61,19 @@ function load(app) {
         ['StandardMaterial', './src/scene/materials/standard-material.js']
     ]);
 
+    // Sweep away any top-level Accessor reflections that `typedoc-plugin-missing-exports` has
+    // incorrectly hoisted out of their owning class into the project root. These show up as
+    // orphan entries under the "Other" category on the generated index page, with broken
+    // self-links to anchors that don't exist. The canonical documentation for each accessor
+    // lives on its owning class's page; removing the project-root duplicates does not affect
+    // those class-member reflections.
+    app.converter.on(Converter.EVENT_RESOLVE_END, (/** @type {import('typedoc').Context} */ context) => {
+        const orphans = context.project.children?.filter(child => child.kind === ReflectionKind.Accessor) ?? [];
+        for (const orphan of orphans) {
+            context.project.removeReflection(orphan);
+        }
+    });
+
     app.converter.on(Converter.EVENT_RESOLVE_BEGIN, (/** @type {import('typedoc').Context} */ context) => {
         const getReference = (type) => {
             const reflection = context.project.children.find(child => child.name === type && child.kind === ReflectionKind.Class);


### PR DESCRIPTION
## Overview

The engine's API reference index page was showing ~57 orphan entries under the "Other" category — class accessors (`depthFunc`, `blendType`, `children`, `parent`, `enabled`, `volume`, `pitch`, `theme`, `maxPixelRatio`, etc.) that `typedoc-plugin-missing-exports` was incorrectly hoisting out of their owning class into the project root. Each entry had a broken self-link to an anchor that didn't exist, and the section was pure noise on the landing page of the generated docs.

## Fix

Added a `Converter.EVENT_RESOLVE_END` handler to the custom TypeDoc plugin (`utils/typedoc/typedoc-plugin.mjs`) that removes any top-level `ReflectionKind.Accessor` children from the project root after TypeDoc resolution completes.

```js
app.converter.on(Converter.EVENT_RESOLVE_END, (context) => {
    const orphans = context.project.children?.filter(
        child => child.kind === ReflectionKind.Accessor
    ) ?? [];
    for (const orphan of orphans) {
        context.project.removeReflection(orphan);
    }
});
```

## Technical details

- **Root cause**: a symbol-identity mismatch during TypeDoc's processing of JavaScript getter/setter pairs causes `typedoc-plugin-missing-exports` to re-surface the symbols as missing top-level exports. Bare `{@link memberName}` references in sibling JSDoc are *not* the trigger — they already resolve correctly to the class member.
- **Scope**: the filter is narrow (`kind === ReflectionKind.Accessor` at the project root only). Callbacks, typedefs, interfaces and everything else `typedoc-plugin-missing-exports` surfaces (correctly) continues through untouched.
- **Safety**: the engine exports no legitimate top-level accessors, so no valid documentation can be removed by this sweep.

## Verification

- TypeDoc build: 0 errors / 9 warnings (unchanged from baseline).
- "Other" category no longer present on the generated `docs/index.html`.
- Class pages (`Material`, `GraphNode`, `Layer`, etc.) still render all their accessors, and bare `{@link}` references in sibling JSDoc resolve to the correct `#anchor` on those class pages.
- Full rendered-HTML audit: **0 broken** cross-page links (12,828 scanned), **0 broken** anchor links (50,035 scanned).

## Public API changes

None. This change only affects the generated API reference documentation.
