### PR TITLE
Keep HIDDEN examples reachable by URL in production builds

### DIFF
--- a/examples/scripts/build-metadata.mjs
+++ b/examples/scripts/build-metadata.mjs
@@ -8,7 +8,8 @@ import { parseConfig } from '../utils/utils.mjs';
  * @type {{
  *      path: string,
  *      categoryKebab: string,
- *      exampleNameKebab: string
+ *      exampleNameKebab: string,
+ *      hidden: boolean
  * }[]}
  */
 const exampleMetaData = [];
@@ -55,15 +56,16 @@ const main = () => {
             const exampleNameKebab = toKebabCase(exampleName);
 
             const config = parseConfig(fs.readFileSync(examplePath, 'utf-8'));
-            if (config.HIDDEN && process.env.NODE_ENV !== 'development') {
-                console.info(`skipping hidden ${categoryKebab}/${exampleNameKebab}`);
-                return;
+            const hidden = !!config.HIDDEN;
+            if (hidden) {
+                console.info(`hidden (not listed in sidebar): ${categoryKebab}/${exampleNameKebab}`);
             }
 
             exampleMetaData.push({
                 path: categoryPath,
                 categoryKebab,
-                exampleNameKebab
+                exampleNameKebab,
+                hidden
             });
         });
     });

--- a/examples/src/app/components/Sidebar.mjs
+++ b/examples/src/app/components/Sidebar.mjs
@@ -36,7 +36,14 @@ function getDefaultExampleFiles() {
     /** @type {Record<string, { examples: Record<string, string> }>} */
     const categories = {};
     for (let i = 0; i < exampleMetaData.length; i++) {
-        const { categoryKebab, exampleNameKebab } = exampleMetaData[i];
+        const { categoryKebab, exampleNameKebab, hidden } = exampleMetaData[i];
+
+        // hidden examples are always built and reachable via URL, but are only listed in the
+        // sidebar during development (`npm run develop`), not in production builds (`npm run build`)
+        if (hidden && process.env.NODE_ENV !== 'development') {
+            continue;
+        }
+
         if (!categories[categoryKebab]) {
             categories[categoryKebab] = { examples: {} };
         }

--- a/examples/utils/utils.mjs
+++ b/examples/utils/utils.mjs
@@ -26,7 +26,7 @@ export const isModuleWithExternalDependencies = (content) => {
 /**
  * @typedef {object} ExampleConfig
  * @property {string} [DESCRIPTION] - The example description.
- * @property {boolean} [HIDDEN] - The example is hidden on production.
+ * @property {boolean} [HIDDEN] - The example is hidden from the sidebar list in production builds (`npm run build`). It is still built and reachable via its URL. In development (`npm run develop`) it is still shown in the sidebar.
  * @property {'development' | 'performance' | 'debug'} [ENGINE] - The engine type.
  * @property {boolean} [NO_DEVICE_SELECTOR] - No device selector.
  * @property {boolean} [NO_MINISTATS] - No ministats.


### PR DESCRIPTION
## Summary

Examples tagged with `// @config HIDDEN` were previously excluded from the metadata in production builds (`npm run build`), which meant they were not built at all and could not be opened via URL. This change makes HIDDEN examples always build, so they remain reachable by URL, while still being hidden from the sidebar in production. Sidebar behavior in development (`npm run develop`) is unchanged — HIDDEN examples still appear in the sidebar there.

## Changes

- `examples/scripts/build-metadata.mjs`: Always emit metadata for HIDDEN examples, with a new `hidden: boolean` flag on each entry. This ensures Rollup's `EXAMPLE_TARGETS` still builds the iframe bundle / HTML for hidden examples in production.
- `examples/src/app/components/Sidebar.mjs`: Skip entries with `hidden === true` from the sidebar list only when `process.env.NODE_ENV !== 'development'` (substituted at build time by `@rollup/plugin-replace`). Preserves current dev-mode visibility.
- `examples/utils/utils.mjs`: Update the `HIDDEN` JSDoc to describe the new behavior.

## Behavior

- `npm run develop`: HIDDEN examples appear in the sidebar and are reachable by URL (unchanged).
- `npm run build`: HIDDEN examples do not appear in the sidebar, but their iframe bundle/HTML is still emitted to `dist/iframe/<category>_<example>.html` and reachable by direct URL.