### PR TITLE
Calculate camera aspect ration in CameraComponent onEnable

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1207,6 +1207,10 @@ class CameraComponent extends Component {
             this.addCameraToLayers();
         }
 
+        if (this.aspectRatioMode === ASPECT_AUTO) {
+            this.aspectRatio = this.calculateAspectRatio();
+        }
+
         this.postEffects.enable();
     }
 


### PR DESCRIPTION
## Description
Fixes an issue where a `CameraComponent` with `aspectRatioMode` set to `ASPECT_AUTO` would report a stale/incorrect `aspectRatio` until the first frame was rendered. The aspect ratio is now additionally calculated in `onEnable`, so it is correct from the moment the component is enabled.

### Problem
When a camera is enabled with `aspectRatioMode === ASPECT_AUTO`, `aspectRatio` was only refreshed by the render loop. Any code that read `camera.aspectRatio` before the first frame — e.g. during scene setup, picking, frustum tests, or screen-space math — would see the default value of `16/9`, not the actual current value for the target render surface.

Fixes #5825 

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
