### PR TITLE
refactor: make camera aspect ratio auto-refresh in Camera class

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -110,8 +110,11 @@ class CameraComponent extends Component {
      */
     _disablePostEffectsLayer = LAYERID_UI;
 
-    /** @private */
-    _camera = new Camera();
+    /**
+     * @type {Camera}
+     * @private
+     */
+    _camera;
 
     /**
      * @type {EventHandle|null}
@@ -140,6 +143,7 @@ class CameraComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
+        this._camera = new Camera(system.app.graphicsDevice);
         this._camera.node = entity;
 
         // postprocessing management
@@ -1207,10 +1211,6 @@ class CameraComponent extends Component {
             this.addCameraToLayers();
         }
 
-        if (this.aspectRatioMode === ASPECT_AUTO) {
-            this.aspectRatio = this.calculateAspectRatio();
-        }
-
         this.postEffects.enable();
     }
 
@@ -1250,10 +1250,7 @@ class CameraComponent extends Component {
      * @returns {number} The aspect ratio of the render target (or backbuffer).
      */
     calculateAspectRatio(rt) {
-        const device = this.system.app.graphicsDevice;
-        const width = rt ? rt.width : device.width;
-        const height = rt ? rt.height : device.height;
-        return (width * this.rect.z) / (height * this.rect.w);
+        return this._camera.calculateAspectRatio(rt);
     }
 
     /**

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1243,11 +1243,15 @@ class CameraComponent extends Component {
     }
 
     /**
-     * Calculates aspect ratio value for a given render target.
+     * Computes the aspect ratio this camera would produce when rendering to the given render
+     * target, without changing the camera's state. When `rt` is omitted, the camera's own
+     * {@link CameraComponent#renderTarget} is used, and if that is also null, the backbuffer
+     * is used. The camera's {@link CameraComponent#rect} viewport is taken into account.
      *
-     * @param {RenderTarget|null} [rt] - Optional
-     * render target. If unspecified, the backbuffer is used.
-     * @returns {number} The aspect ratio of the render target (or backbuffer).
+     * @param {RenderTarget|null} [rt] - Optional render target to compute the aspect ratio
+     * against. Defaults to the camera's current render target, or the backbuffer if none is
+     * assigned.
+     * @returns {number} The computed aspect ratio.
      */
     calculateAspectRatio(rt) {
         return this._camera.calculateAspectRatio(rt);

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -153,7 +153,7 @@ class Lightmapper {
             LightmapCache.incRef(this.blackTex);
 
             // camera used for baking
-            const camera = new Camera();
+            const camera = new Camera(this.device);
             camera.clearColor.set(0, 0, 0, 0);
             camera.clearColorBuffer = true;
             camera.clearDepthBuffer = false;

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -14,7 +14,6 @@ import { FramePassDepthGrab } from './graphics/frame-pass-depth-grab.js';
 import { CameraShaderParams } from './camera-shader-params.js';
 
 /**
- * @import { EventHandle } from '../core/event-handle.js'
  * @import { FramePass } from '../platform/graphics/frame-pass.js'
  * @import { GraphicsDevice } from '../platform/graphics/graphics-device.js'
  * @import { RenderTarget } from '../platform/graphics/render-target.js'
@@ -85,32 +84,15 @@ class Camera {
 
     /**
      * The graphics device used by this camera. Required so the camera can compute its aspect
-     * ratio from the backbuffer and react to resize events.
+     * ratio from the backbuffer size when no render target is assigned.
      *
      * @type {GraphicsDevice}
      */
     device;
 
     /**
-     * Event handle for the graphics device 'resizecanvas' subscription.
-     *
-     * @type {EventHandle|null}
-     * @private
-     */
-    _evtResize = null;
-
-    /**
-     * When true and aspectRatioMode is ASPECT_AUTO, the next read of `aspectRatio` will
-     * recompute it from the current render target (or backbuffer) and the `rect`.
-     *
-     * @type {boolean}
-     * @private
-     */
-    _aspectDirty = true;
-
-    /**
      * @param {GraphicsDevice} graphicsDevice - The graphics device this camera will use for
-     * automatic aspect ratio calculation (and to listen to resize events).
+     * automatic aspect ratio calculation against the backbuffer size.
      */
     constructor(graphicsDevice) {
         Debug.assert(graphicsDevice, 'Camera constructor requires a GraphicsDevice.');
@@ -172,19 +154,9 @@ class Camera {
             farClip: this._farClip,
             nearClip: this._nearClip
         };
-
-        // if the backbuffer is resized, the AUTO aspect ratio (when using the backbuffer as
-        // the target) may change, so invalidate the cached value and projection matrix
-        this._evtResize = this.device.on('resizecanvas', () => {
-            this._aspectDirty = true;
-            this._projMatDirty = true;
-        });
     }
 
     destroy() {
-
-        this._evtResize?.off();
-        this._evtResize = null;
 
         this.renderPassColorGrab?.destroy();
         this.renderPassColorGrab = null;
@@ -223,9 +195,6 @@ class Camera {
     }
 
     set aspectRatio(newValue) {
-        // explicit write (used by ASPECT_MANUAL, clone/copy, renderer code)
-        // clears the dirty flag so the AUTO recompute doesn't immediately overwrite it
-        this._aspectDirty = false;
         if (this._aspectRatio !== newValue) {
             this._aspectRatio = newValue;
             this._projMatDirty = true;
@@ -235,10 +204,9 @@ class Camera {
     get aspectRatio() {
         if (this.xr?.active) return this._xrProperties.aspectRatio;
 
-        // lazy recompute when in ASPECT_AUTO mode and one of the inputs (rect, render target,
-        // backbuffer size) has changed since the last read
-        if (this._aspectDirty && this._aspectRatioMode === ASPECT_AUTO) {
-            this._aspectDirty = false;
+        // in ASPECT_AUTO mode, always recompute from current inputs (render target / backbuffer
+        // size and rect). The computation is trivially cheap, and this avoids few complexities.
+        if (this._aspectRatioMode === ASPECT_AUTO) {
             const newValue = this.calculateAspectRatio();
             if (this._aspectRatio !== newValue) {
                 this._aspectRatio = newValue;
@@ -252,7 +220,6 @@ class Camera {
         if (this._aspectRatioMode !== newValue) {
             this._aspectRatioMode = newValue;
             this._projMatDirty = true;
-            this._aspectDirty = true;
         }
     }
 
@@ -443,7 +410,6 @@ class Camera {
 
     set rect(newValue) {
         this._rect.copy(newValue);
-        this._aspectDirty = true;
         this._projMatDirty = true;
     }
 
@@ -453,7 +419,6 @@ class Camera {
 
     set renderTarget(newValue) {
         this._renderTarget = newValue;
-        this._aspectDirty = true;
         this._projMatDirty = true;
     }
 
@@ -711,15 +676,19 @@ class Camera {
     }
 
     _evaluateProjectionMatrix() {
+        // in ASPECT_AUTO, reading the aspectRatio getter recomputes it from current inputs
+        // and marks _projMatDirty if the value changed (e.g. after a backbuffer resize with
+        // no other input changes)
+        const aspect = this.aspectRatio;
         if (this._projMatDirty) {
             if (this._projection === PROJECTION_PERSPECTIVE) {
-                this._projMat.setPerspective(this.fov, this.aspectRatio, this.nearClip, this.farClip, this.horizontalFov);
+                this._projMat.setPerspective(this.fov, aspect, this.nearClip, this.farClip, this.horizontalFov);
                 this._projMatSkybox.copy(this._projMat);
             } else {
                 const y = this._orthoHeight;
-                const x = y * this.aspectRatio;
+                const x = y * aspect;
                 this._projMat.setOrtho(-x, x, -y, y, this.nearClip, this.farClip);
-                this._projMatSkybox.setPerspective(this.fov, this.aspectRatio, this.nearClip, this.farClip);
+                this._projMatSkybox.setPerspective(this.fov, aspect, this.nearClip, this.farClip);
             }
 
             this._projMatDirty = false;

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -205,7 +205,7 @@ class Camera {
         if (this.xr?.active) return this._xrProperties.aspectRatio;
 
         // in ASPECT_AUTO mode, always recompute from current inputs (render target / backbuffer
-        // size and rect). The computation is trivially cheap, and this avoids few complexities.
+        // size and rect). The computation is trivially cheap, and this avoids a few complexities.
         if (this._aspectRatioMode === ASPECT_AUTO) {
             const newValue = this.calculateAspectRatio();
             if (this._aspectRatio !== newValue) {

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -1,4 +1,5 @@
 import { Color } from '../core/math/color.js';
+import { Debug } from '../core/debug.js';
 import { Mat4 } from '../core/math/mat4.js';
 import { Vec3 } from '../core/math/vec3.js';
 import { Vec4 } from '../core/math/vec4.js';
@@ -13,7 +14,10 @@ import { FramePassDepthGrab } from './graphics/frame-pass-depth-grab.js';
 import { CameraShaderParams } from './camera-shader-params.js';
 
 /**
+ * @import { EventHandle } from '../core/event-handle.js'
  * @import { FramePass } from '../platform/graphics/frame-pass.js'
+ * @import { GraphicsDevice } from '../platform/graphics/graphics-device.js'
+ * @import { RenderTarget } from '../platform/graphics/render-target.js'
  * @import { FogParams } from './fog-params.js'
  * @import { ShaderPassInfo } from './shader-pass.js'
  */
@@ -79,7 +83,39 @@ class Camera {
     /** @type {number} */
     jitter = 0;
 
-    constructor() {
+    /**
+     * The graphics device used by this camera. Required so the camera can compute its aspect
+     * ratio from the backbuffer and react to resize events.
+     *
+     * @type {GraphicsDevice}
+     */
+    device;
+
+    /**
+     * Event handle for the graphics device 'resizecanvas' subscription.
+     *
+     * @type {EventHandle|null}
+     * @private
+     */
+    _evtResize = null;
+
+    /**
+     * When true and aspectRatioMode is ASPECT_AUTO, the next read of `aspectRatio` will
+     * recompute it from the current render target (or backbuffer) and the `rect`.
+     *
+     * @type {boolean}
+     * @private
+     */
+    _aspectDirty = true;
+
+    /**
+     * @param {GraphicsDevice} graphicsDevice - The graphics device this camera will use for
+     * automatic aspect ratio calculation (and to listen to resize events).
+     */
+    constructor(graphicsDevice) {
+        Debug.assert(graphicsDevice, 'Camera constructor requires a GraphicsDevice.');
+        this.device = graphicsDevice;
+
         this._aspectRatio = 16 / 9;
         this._aspectRatioMode = ASPECT_AUTO;
         this._calculateProjection = null;
@@ -136,9 +172,18 @@ class Camera {
             farClip: this._farClip,
             nearClip: this._nearClip
         };
+
+        // if the backbuffer is resized, the AUTO aspect ratio (when using the backbuffer as
+        // the target) may change, so invalidate the cached value
+        this._evtResize = this.device.on('resizecanvas', () => {
+            this._aspectDirty = true;
+        });
     }
 
     destroy() {
+
+        this._evtResize?.off();
+        this._evtResize = null;
 
         this.renderPassColorGrab?.destroy();
         this.renderPassColorGrab = null;
@@ -177,6 +222,9 @@ class Camera {
     }
 
     set aspectRatio(newValue) {
+        // explicit write (used by ASPECT_MANUAL, clone/copy, renderer code)
+        // clears the dirty flag so the AUTO recompute doesn't immediately overwrite it
+        this._aspectDirty = false;
         if (this._aspectRatio !== newValue) {
             this._aspectRatio = newValue;
             this._projMatDirty = true;
@@ -184,13 +232,26 @@ class Camera {
     }
 
     get aspectRatio() {
-        return (this.xr?.active) ? this._xrProperties.aspectRatio : this._aspectRatio;
+        if (this.xr?.active) return this._xrProperties.aspectRatio;
+
+        // lazy recompute when in ASPECT_AUTO mode and one of the inputs (rect, render target,
+        // backbuffer size) has changed since the last read
+        if (this._aspectDirty && this._aspectRatioMode === ASPECT_AUTO) {
+            this._aspectDirty = false;
+            const newValue = this.calculateAspectRatio();
+            if (this._aspectRatio !== newValue) {
+                this._aspectRatio = newValue;
+                this._projMatDirty = true;
+            }
+        }
+        return this._aspectRatio;
     }
 
     set aspectRatioMode(newValue) {
         if (this._aspectRatioMode !== newValue) {
             this._aspectRatioMode = newValue;
             this._projMatDirty = true;
+            this._aspectDirty = true;
         }
     }
 
@@ -381,6 +442,7 @@ class Camera {
 
     set rect(newValue) {
         this._rect.copy(newValue);
+        this._aspectDirty = true;
     }
 
     get rect() {
@@ -389,6 +451,7 @@ class Camera {
 
     set renderTarget(newValue) {
         this._renderTarget = newValue;
+        this._aspectDirty = true;
     }
 
     get renderTarget() {
@@ -448,12 +511,30 @@ class Camera {
     }
 
     /**
+     * Calculates the aspect ratio that should be used for the camera, based on the size of the
+     * given render target (or the backbuffer if no render target is given), and the camera's
+     * `rect`. The `rect` is included so that a camera rendering into a sub-region of a render
+     * target gets the aspect ratio of the actual rendered pixel area (important for split-screen
+     * and similar setups, otherwise rendering would appear stretched).
+     *
+     * @param {RenderTarget|null} [rt] - Optional render target. If unspecified, the camera's
+     * own render target (or, if that is also null, the backbuffer) is used.
+     * @returns {number} The computed aspect ratio.
+     */
+    calculateAspectRatio(rt) {
+        const target = rt ?? this._renderTarget;
+        const width = target ? target.width : this.device.width;
+        const height = target ? target.height : this.device.height;
+        return (width * this._rect.z) / (height * this._rect.w);
+    }
+
+    /**
      * Creates a duplicate of the camera.
      *
      * @returns {Camera} A cloned Camera.
      */
     clone() {
-        return new Camera().copy(this);
+        return new Camera(this.device).copy(this);
     }
 
     /**

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -174,9 +174,10 @@ class Camera {
         };
 
         // if the backbuffer is resized, the AUTO aspect ratio (when using the backbuffer as
-        // the target) may change, so invalidate the cached value
+        // the target) may change, so invalidate the cached value and projection matrix
         this._evtResize = this.device.on('resizecanvas', () => {
             this._aspectDirty = true;
+            this._projMatDirty = true;
         });
     }
 
@@ -443,6 +444,7 @@ class Camera {
     set rect(newValue) {
         this._rect.copy(newValue);
         this._aspectDirty = true;
+        this._projMatDirty = true;
     }
 
     get rect() {
@@ -452,6 +454,7 @@ class Camera {
     set renderTarget(newValue) {
         this._renderTarget = newValue;
         this._aspectDirty = true;
+        this._projMatDirty = true;
     }
 
     get renderTarget() {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -80,7 +80,7 @@ class LightRenderData {
         this.camera = camera;
 
         // camera used to cull / render the shadow map
-        this.shadowCamera = ShadowRenderer.createShadowCamera(light._shadowType, light._type, face);
+        this.shadowCamera = ShadowRenderer.createShadowCamera(light.device, light._shadowType, light._type, face);
 
         // shadow view-projection matrix
         this.shadowMatrix = new Mat4();

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -115,6 +115,9 @@ class LightRenderData {
             bg.destroy();
         });
         this.viewBindGroups.length = 0;
+
+        this.shadowCamera?.destroy();
+        this.shadowCamera = null;
     }
 
     // returns shadow buffer currently attached to the shadow camera

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -115,9 +115,6 @@ class LightRenderData {
             bg.destroy();
         });
         this.viewBindGroups.length = 0;
-
-        this.shadowCamera?.destroy();
-        this.shadowCamera = null;
     }
 
     // returns shadow buffer currently attached to the shadow camera

--- a/src/scene/renderer/light-camera.js
+++ b/src/scene/renderer/light-camera.js
@@ -22,9 +22,9 @@ class LightCamera {
         new Quat().setFromEulerAngles(0, 0, 180)
     ];
 
-    static create(name, lightType, face) {
+    static create(device, name, lightType, face) {
 
-        const camera = new Camera();
+        const camera = new Camera(device);
         camera.node = new GraphNode(name);
         camera.aspectRatio = 1;
         camera.aspectRatioMode = ASPECT_MANUAL;
@@ -58,7 +58,7 @@ class LightCamera {
 
         let cookieCamera = LightCamera._spotCookieCamera;
         if (!cookieCamera) {
-            cookieCamera = LightCamera.create('SpotCookieCamera', LIGHTTYPE_SPOT);
+            cookieCamera = LightCamera.create(light.device, 'SpotCookieCamera', LIGHTTYPE_SPOT);
             LightCamera._spotCookieCamera = cookieCamera;
         }
 

--- a/src/scene/renderer/render-pass-cookie-renderer.js
+++ b/src/scene/renderer/render-pass-cookie-renderer.js
@@ -123,7 +123,7 @@ class RenderPassCookieRenderer extends RenderPass {
     initInvViewProjMatrices() {
         if (!_invViewProjMatrices.length) {
             for (let face = 0; face < 6; face++) {
-                const camera = LightCamera.create(null, LIGHTTYPE_OMNI, face);
+                const camera = LightCamera.create(this.device, null, LIGHTTYPE_OMNI, face);
                 const projMat = camera.projectionMatrix;
                 const viewMat = camera.node.getLocalTransform().clone().invert();
                 _invViewProjMatrices[face] = new Mat4().mul2(projMat, viewMat).invert();

--- a/src/scene/renderer/render-pass-cookie-renderer.js
+++ b/src/scene/renderer/render-pass-cookie-renderer.js
@@ -127,6 +127,10 @@ class RenderPassCookieRenderer extends RenderPass {
                 const projMat = camera.projectionMatrix;
                 const viewMat = camera.node.getLocalTransform().clone().invert();
                 _invViewProjMatrices[face] = new Mat4().mul2(projMat, viewMat).invert();
+
+                // we only need the inverse view-projection matrix; the temporary camera
+                // must be destroyed to unsubscribe from the device's 'resizecanvas' event
+                camera.destroy();
             }
         }
     }

--- a/src/scene/renderer/render-pass-cookie-renderer.js
+++ b/src/scene/renderer/render-pass-cookie-renderer.js
@@ -127,10 +127,6 @@ class RenderPassCookieRenderer extends RenderPass {
                 const projMat = camera.projectionMatrix;
                 const viewMat = camera.node.getLocalTransform().clone().invert();
                 _invViewProjMatrices[face] = new Mat4().mul2(projMat, viewMat).invert();
-
-                // we only need the inverse view-projection matrix; the temporary camera
-                // must be destroyed to unsubscribe from the device's 'resizecanvas' event
-                camera.destroy();
             }
         }
     }

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -113,9 +113,9 @@ class ShadowRenderer {
     }
 
     // creates shadow camera for a light and sets up its constant properties
-    static createShadowCamera(shadowType, type, face) {
+    static createShadowCamera(device, shadowType, type, face) {
 
-        const shadowCam = LightCamera.create(SHADOWCAMERA_NAME, type, face);
+        const shadowCam = LightCamera.create(device, SHADOWCAMERA_NAME, type, face);
 
         const shadowInfo = shadowTypeInfo.get(shadowType);
         Debug.assert(shadowInfo);

--- a/test/framework/components/element/element-drag-helper.test.mjs
+++ b/test/framework/components/element/element-drag-helper.test.mjs
@@ -10,6 +10,7 @@ import { Entity } from '../../../../src/framework/entity.js';
 import { NullGraphicsDevice } from '../../../../src/platform/graphics/null/null-graphics-device.js';
 import { Mouse } from '../../../../src/platform/input/mouse.js';
 import { TouchDevice } from '../../../../src/platform/input/touch-device.js';
+import { ASPECT_MANUAL } from '../../../../src/scene/constants.js';
 import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
 
 describe('ElementDragHelper', function () {
@@ -86,6 +87,10 @@ describe('ElementDragHelper', function () {
         const cameraEntity = new Entity('camera', app);
         cameraEntity.setPosition(new Vec3(0, 0, 100));
         camera = cameraEntity.addComponent('camera', {});
+
+        // lock the aspect ratio so the drag math is independent of the test canvas dimensions
+        camera.aspectRatioMode = ASPECT_MANUAL;
+        camera.aspectRatio = 16 / 9;
 
         parent = new Entity('parent', app);
         parent.addChild(entity);

--- a/test/scene/camera.test.mjs
+++ b/test/scene/camera.test.mjs
@@ -1,0 +1,189 @@
+import { expect } from 'chai';
+
+import { Vec4 } from '../../src/core/math/vec4.js';
+import { Entity } from '../../src/framework/entity.js';
+import { Camera } from '../../src/scene/camera.js';
+import { ASPECT_AUTO, ASPECT_MANUAL } from '../../src/scene/constants.js';
+import { createApp } from '../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../jsdom.mjs';
+
+/**
+ * @import { Application } from '../../src/framework/application.js'
+ */
+
+describe('Camera', function () {
+    /** @type {Application} */
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    describe('#constructor', function () {
+
+        it('requires a graphics device', function () {
+            // Debug.assert is stripped in production, so this throws in dev builds only via
+            // the assertion; we simply verify that passing the device works.
+            const camera = new Camera(app.graphicsDevice);
+            expect(camera.device).to.equal(app.graphicsDevice);
+        });
+
+        it('defaults to ASPECT_AUTO', function () {
+            const camera = new Camera(app.graphicsDevice);
+            expect(camera.aspectRatioMode).to.equal(ASPECT_AUTO);
+        });
+    });
+
+    describe('#aspectRatio (ASPECT_AUTO)', function () {
+
+        it('reflects the backbuffer size synchronously', function () {
+            app.graphicsDevice.setResolution(800, 400);
+
+            const camera = new Camera(app.graphicsDevice);
+            expect(camera.aspectRatio).to.equal(2);
+        });
+
+        it('updates when renderTarget is assigned', function () {
+            app.graphicsDevice.setResolution(800, 400);
+
+            const camera = new Camera(app.graphicsDevice);
+            expect(camera.aspectRatio).to.equal(2);
+
+            // attach a mock render target with different dimensions
+            camera.renderTarget = { width: 1024, height: 512 };
+            expect(camera.aspectRatio).to.equal(2);
+
+            camera.renderTarget = { width: 300, height: 100 };
+            expect(camera.aspectRatio).to.equal(3);
+        });
+
+        it('updates when rect changes (viewport aspect ratio)', function () {
+            app.graphicsDevice.setResolution(1000, 1000);
+
+            const camera = new Camera(app.graphicsDevice);
+            expect(camera.aspectRatio).to.equal(1);
+
+            // half-width viewport on a square render target -> 2:1 viewport aspect
+            camera.rect = new Vec4(0, 0, 0.5, 1);
+            expect(camera.aspectRatio).to.equal(0.5);
+        });
+
+        it('updates when the backbuffer is resized', function () {
+            app.graphicsDevice.setResolution(800, 400);
+
+            const camera = new Camera(app.graphicsDevice);
+            expect(camera.aspectRatio).to.equal(2);
+
+            app.graphicsDevice.setResolution(1600, 400);
+            expect(camera.aspectRatio).to.equal(4);
+        });
+
+        it('recomputes when switching from MANUAL to AUTO', function () {
+            app.graphicsDevice.setResolution(800, 400);
+
+            const camera = new Camera(app.graphicsDevice);
+            camera.aspectRatioMode = ASPECT_MANUAL;
+            camera.aspectRatio = 3.14;
+            expect(camera.aspectRatio).to.equal(3.14);
+
+            camera.aspectRatioMode = ASPECT_AUTO;
+            expect(camera.aspectRatio).to.equal(2);
+        });
+    });
+
+    describe('#aspectRatio (ASPECT_MANUAL)', function () {
+
+        it('preserves the manually assigned value', function () {
+            app.graphicsDevice.setResolution(800, 400);
+
+            const camera = new Camera(app.graphicsDevice);
+            camera.aspectRatioMode = ASPECT_MANUAL;
+            camera.aspectRatio = 2.5;
+            expect(camera.aspectRatio).to.equal(2.5);
+
+            // changes to inputs that would affect AUTO must not affect MANUAL
+            camera.renderTarget = { width: 1000, height: 1000 };
+            app.graphicsDevice.setResolution(1920, 1080);
+            camera.rect = new Vec4(0, 0, 0.5, 1);
+
+            expect(camera.aspectRatio).to.equal(2.5);
+        });
+    });
+
+    describe('#destroy', function () {
+
+        it('unsubscribes from the device resize event', function () {
+            app.graphicsDevice.setResolution(800, 400);
+
+            const camera = new Camera(app.graphicsDevice);
+            // read the getter to clear the dirty flag
+            expect(camera.aspectRatio).to.equal(2);
+
+            camera.destroy();
+
+            // after destroy, a resize must not re-dirty the cached value or throw
+            app.graphicsDevice.setResolution(1600, 400);
+            expect(camera.aspectRatio).to.equal(2);
+        });
+    });
+
+    describe('#clone', function () {
+
+        it('preserves aspect ratio state', function () {
+            app.graphicsDevice.setResolution(800, 400);
+
+            const camera = new Camera(app.graphicsDevice);
+            expect(camera.aspectRatio).to.equal(2);
+
+            const clone = camera.clone();
+            expect(clone.device).to.equal(camera.device);
+            expect(clone.aspectRatio).to.equal(2);
+        });
+    });
+});
+
+describe('CameraComponent', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    describe('#aspectRatio', function () {
+
+        it('reflects the backbuffer size before the first frame', function () {
+            app.graphicsDevice.setResolution(1600, 400);
+
+            const entity = new Entity();
+            entity.addComponent('camera');
+            app.root.addChild(entity);
+
+            expect(entity.camera.aspectRatio).to.equal(4);
+        });
+
+        it('calculateAspectRatio forwards to the underlying Camera', function () {
+            app.graphicsDevice.setResolution(800, 400);
+
+            const entity = new Entity();
+            entity.addComponent('camera');
+            app.root.addChild(entity);
+
+            expect(entity.camera.calculateAspectRatio()).to.equal(2);
+            expect(entity.camera.calculateAspectRatio({ width: 300, height: 100 })).to.equal(3);
+        });
+    });
+});

--- a/test/scene/camera.test.mjs
+++ b/test/scene/camera.test.mjs
@@ -70,7 +70,7 @@ describe('Camera', function () {
             const camera = new Camera(app.graphicsDevice);
             expect(camera.aspectRatio).to.equal(1);
 
-            // half-width viewport on a square render target -> 2:1 viewport aspect
+            // half-width viewport on a square render target -> 1:2 viewport aspect
             camera.rect = new Vec4(0, 0, 0.5, 1);
             expect(camera.aspectRatio).to.equal(0.5);
         });

--- a/test/scene/camera.test.mjs
+++ b/test/scene/camera.test.mjs
@@ -117,20 +117,23 @@ describe('Camera', function () {
         });
     });
 
-    describe('#destroy', function () {
+    describe('#projectionMatrix', function () {
 
-        it('unsubscribes from the device resize event', function () {
+        it('refreshes after a backbuffer resize (no setter touched)', function () {
             app.graphicsDevice.setResolution(800, 400);
 
             const camera = new Camera(app.graphicsDevice);
-            // read the getter to clear the dirty flag
-            expect(camera.aspectRatio).to.equal(2);
 
-            camera.destroy();
+            // prime the projection matrix cache
+            const before = camera.projectionMatrix.clone();
 
-            // after destroy, a resize must not re-dirty the cached value or throw
+            // resize the backbuffer without touching any camera setter
             app.graphicsDevice.setResolution(1600, 400);
-            expect(camera.aspectRatio).to.equal(2);
+
+            // reading projectionMatrix should detect the aspect change via the getter and
+            // rebuild the matrix
+            const after = camera.projectionMatrix;
+            expect(after.equals(before)).to.equal(false);
         });
     });
 


### PR DESCRIPTION
Follow-up to #8632. Moves the automatic aspect ratio handling from `CameraComponent` into the `Camera` class itself, so it stays up to date whenever any of its inputs change — not just at `onEnable` time.

**Motivation:**
#8632 fixed the "stale aspect ratio before the first frame" problem inside `CameraComponent.onEnable`, but the same staleness still occurred when:
- the camera's `renderTarget` was assigned at runtime,
- the camera's `rect` was changed at runtime,
- the backbuffer was resized between frames,
- the user switched from `ASPECT_MANUAL` back to `ASPECT_AUTO`,
- the camera was not yet attached to the scene tree (so `onEnable` never ran).

**Changes:**
- `Camera` constructor now takes a `GraphicsDevice` (asserted non-null) and stores it on `camera.device`, so the camera can fall back to the backbuffer size when no render target is assigned.
- `Camera` now owns `calculateAspectRatio(rt)`; when `rt` is omitted it falls back to the camera's own `renderTarget`, then the backbuffer. `rect.z/rect.w` is included so the aspect matches the actually-rendered viewport.
- `get aspectRatio` recomputes on every read in `ASPECT_AUTO` (the calculation is trivially cheap — a few multiplies and a divide — and this avoids any need for a device-event subscription). If the recomputed value differs from the cached one, `_projMatDirty` is flipped so the projection matrix is rebuilt on its next read.
- `_evaluateProjectionMatrix` now force-reads `aspectRatio` before checking the dirty flag, so a backbuffer resize (with no camera setter touched) is picked up on the next `projectionMatrix` access.
- `CameraComponent.calculateAspectRatio` now forwards to the underlying `Camera`, with clarified JSDoc (falls back to the camera's render target before the backbuffer, includes `rect`). The `onEnable` block added in #8632 is removed (the lazy getter supersedes it).
- All `new Camera()` sites updated to pass a device: `CameraComponent`, `Camera.clone()`, `LightCamera.create` (and its callers in `ShadowRenderer.createShadowCamera`, `render-pass-cookie-renderer`, `evalSpotCookieMatrix`), and `Lightmapper`.

**API Changes:**
- `Camera` constructor — `new Camera()` → `new Camera(graphicsDevice)`. `Camera` is internal, so this is not a public API break, but any code instantiating `Camera` directly must pass a `GraphicsDevice`.
- `LightCamera.create(name, lightType, face)` → `LightCamera.create(device, name, lightType, face)` (internal).
- `ShadowRenderer.createShadowCamera(shadowType, type, face)` → `ShadowRenderer.createShadowCamera(device, shadowType, type, face)` (internal).

**Tests:**
- New `test/scene/camera.test.mjs` covering AUTO recompute on `renderTarget`, `rect`, backbuffer resize, MANUAL→AUTO switch, MANUAL preservation, `projectionMatrix` refresh after backbuffer resize, `clone()`, and the component-level forwarders.
- `element-drag-helper.test.mjs` updated to explicitly lock `ASPECT_MANUAL` + `16/9`, so its expected values don't drift with device dimensions.