### PR TITLE
docs: document both halves of accessor pairs in public API

### DIFF
--- a/src/extras/input/sources/dual-gesture-source.js
+++ b/src/extras/input/sources/dual-gesture-source.js
@@ -90,6 +90,10 @@ class DualGestureSource extends InputSource {
     }
 
     /**
+     * Sets the layout of the dual gesture input source. The value is a hyphen-separated pair
+     * describing the left and right inputs respectively, where each side can be either
+     * `joystick` (a virtual joystick) or `touch` (a touch). Defaults to `joystick-touch`.
+     *
      * @type {`${'joystick' | 'touch'}-${'joystick' | 'touch'}`}
      */
     set layout(value) {
@@ -105,6 +109,11 @@ class DualGestureSource extends InputSource {
         this._pointerData.clear();
     }
 
+    /**
+     * Gets the layout of the dual gesture input source.
+     *
+     * @type {`${'joystick' | 'touch'}-${'joystick' | 'touch'}`}
+     */
     get layout() {
         return this._layout;
     }

--- a/src/extras/input/sources/single-gesture-source.js
+++ b/src/extras/input/sources/single-gesture-source.js
@@ -59,12 +59,12 @@ class SingleGestureSource extends InputSource {
     }
 
     /**
-     * The layout of the single touch input source. The layout can be one of the following:
+     * Sets the layout of the single touch input source. Can be one of the following:
      *
      * - `joystick`: A virtual joystick.
      * - `touch`: A touch.
      *
-     * Default is `joystick`.
+     * Defaults to `joystick`.
      *
      * @type {'joystick' | 'touch'}
      */
@@ -81,6 +81,11 @@ class SingleGestureSource extends InputSource {
         this._pointerData.clear();
     }
 
+    /**
+     * Gets the layout of the single touch input source.
+     *
+     * @type {'joystick' | 'touch'}
+     */
     get layout() {
         return this._layout;
     }

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -480,8 +480,9 @@ class GSplatComponent extends Component {
     }
 
     /**
-     * @deprecated Use {@link lodBaseDistance} and {@link lodMultiplier} instead.
      * @type {number[]|null}
+     * @deprecated Use {@link lodBaseDistance} and {@link lodMultiplier} instead.
+     * @ignore
      */
     set lodDistances(value) {
         Debug.removed('GSplatComponent#lodDistances is removed. Use lodBaseDistance and lodMultiplier instead.');
@@ -492,8 +493,9 @@ class GSplatComponent extends Component {
     }
 
     /**
-     * @deprecated Use {@link lodBaseDistance} and {@link lodMultiplier} instead.
      * @type {number[]}
+     * @deprecated Use {@link lodBaseDistance} and {@link lodMultiplier} instead.
+     * @ignore
      */
     get lodDistances() {
         Debug.removed('GSplatComponent#lodDistances is removed. Use lodBaseDistance and lodMultiplier instead.');
@@ -501,13 +503,19 @@ class GSplatComponent extends Component {
     }
 
     /**
-     * @deprecated Use app.scene.gsplat.splatBudget instead for global budget control.
      * @type {number}
+     * @deprecated Use app.scene.gsplat.splatBudget instead for global budget control.
+     * @ignore
      */
     set splatBudget(value) {
         Debug.removed('GSplatComponent.splatBudget is removed. Use app.scene.gsplat.splatBudget instead for global budget control.');
     }
 
+    /**
+     * @type {number}
+     * @deprecated Use app.scene.gsplat.splatBudget instead for global budget control.
+     * @ignore
+     */
     get splatBudget() {
         Debug.removed('GSplatComponent.splatBudget is removed. Use app.scene.gsplat.splatBudget instead for global budget control.');
         return 0;

--- a/src/framework/script/script.js
+++ b/src/framework/script/script.js
@@ -217,11 +217,9 @@ export class Script extends EventHandler {
     }
 
     /**
-     * True if the instance of this script is in running state. False when script is not running,
-     * because the Entity or any of its parents are disabled or the {@link ScriptComponent} is
-     * disabled or the Script Instance is disabled. When disabled, no update methods will be called
-     * on each tick. `initialize` and `postInitialize` methods will run once when the script
-     * instance is in the `enabled` state during an app tick.
+     * Sets the enabled state of the script instance. When disabled, no update methods will be
+     * called on each tick. `initialize` and `postInitialize` methods will run once when the script
+     * instance is next in the `enabled` state during an app tick.
      *
      * @type {boolean}
      */
@@ -259,6 +257,13 @@ export class Script extends EventHandler {
         }
     }
 
+    /**
+     * Gets the running state of the script instance. Returns true when the script instance is
+     * enabled and its owning {@link Entity} (and all ancestors) and {@link ScriptComponent} are
+     * also enabled; otherwise false.
+     *
+     * @type {boolean}
+     */
     get enabled() {
         return this._enabled && !this._destroyed && this.entity.script.enabled && this.entity.enabled;
     }

--- a/src/scene/batching/batch.js
+++ b/src/scene/batching/batch.js
@@ -101,9 +101,9 @@ class Batch {
     }
 
     /**
+     * @type {undefined}
      * @deprecated
      * @ignore
-     * @type {undefined}
      */
     get model() {
         Debug.removed('pc.Batch#model was removed. Use pc.Batch#meshInstance to access batched mesh instead.');

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -174,9 +174,8 @@ class GSplatParams {
     }
 
     /**
-     * Gets the requested rendering pipeline for gaussian splatting. This is the value last
-     * assigned to {@link renderer}, which may differ from {@link currentRenderer} when a WebGPU
-     * mode falls back on a WebGL device.
+     * Gets the requested rendering pipeline for gaussian splatting. This may differ from
+     * {@link currentRenderer} when a WebGPU mode falls back on a WebGL device.
      *
      * @type {number}
      */

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -144,7 +144,7 @@ class GSplatParams {
     _currentRenderer = GSPLAT_RENDERER_RASTER_CPU_SORT;
 
     /**
-     * The rendering pipeline used for gaussian splatting. Can be:
+     * Sets the rendering pipeline used for gaussian splatting. Can be:
      *
      * - {@link GSPLAT_RENDERER_AUTO}: Automatically selects the best pipeline for the platform.
      * - {@link GSPLAT_RENDERER_RASTER_CPU_SORT}: Rasterization with CPU-side sorting.
@@ -153,7 +153,8 @@ class GSplatParams {
      * - {@link GSPLAT_RENDERER_COMPUTE}: Full compute pipeline (WebGPU only, experimental).
      *
      * Defaults to {@link GSPLAT_RENDERER_AUTO}. Modes requiring WebGPU fall back to
-     * {@link GSPLAT_RENDERER_RASTER_CPU_SORT} on WebGL devices.
+     * {@link GSPLAT_RENDERER_RASTER_CPU_SORT} on WebGL devices. The resolved mode actually used
+     * can be queried via {@link currentRenderer}.
      *
      * @type {number}
      */
@@ -172,6 +173,13 @@ class GSplatParams {
         }
     }
 
+    /**
+     * Gets the requested rendering pipeline for gaussian splatting. This is the value last
+     * assigned to {@link renderer}, which may differ from {@link currentRenderer} when a WebGPU
+     * mode falls back on a WebGL device.
+     *
+     * @type {number}
+     */
     get renderer() {
         return this._renderer;
     }
@@ -206,7 +214,7 @@ class GSplatParams {
     _debug = GSPLAT_DEBUG_NONE;
 
     /**
-     * Debug rendering mode for Gaussian splats. Can be:
+     * Sets the debug rendering mode for Gaussian splats. Can be:
      *
      * - {@link GSPLAT_DEBUG_NONE}: Normal rendering (default).
      * - {@link GSPLAT_DEBUG_LOD}: Colorize splats by their selected LOD level.
@@ -231,19 +239,29 @@ class GSplatParams {
         }
     }
 
+    /**
+     * Gets the debug rendering mode for Gaussian splats.
+     *
+     * @type {number}
+     */
     get debug() {
         return this._debug;
     }
 
-    /** @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_LOD} instead. */
+    /**
+     * @type {boolean}
+     * @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_LOD} instead.
+     * @ignore
+     */
     set colorizeLod(value) {
         Debug.deprecated('GSplatParams#colorizeLod is deprecated. Use GSplatParams#debug = GSPLAT_DEBUG_LOD instead.');
         this.debug = value ? GSPLAT_DEBUG_LOD : GSPLAT_DEBUG_NONE;
     }
 
     /**
+     * @type {boolean}
      * @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_LOD} instead.
-     * @returns {boolean} Whether LOD colorization is enabled.
+     * @ignore
      */
     get colorizeLod() {
         return this._debug === GSPLAT_DEBUG_LOD;

--- a/src/scene/skybox/sky.js
+++ b/src/scene/skybox/sky.js
@@ -95,12 +95,13 @@ class Sky {
     }
 
     /**
-     * The type of the sky. One of the SKYTYPE_* constants. Defaults to {@link SKYTYPE_INFINITE}.
-     * Can be:
+     * Sets the type of the sky. Can be:
      *
      * - {@link SKYTYPE_INFINITE}
      * - {@link SKYTYPE_BOX}
      * - {@link SKYTYPE_DOME}
+     *
+     * Defaults to {@link SKYTYPE_INFINITE}.
      *
      * @type {string}
      */
@@ -112,13 +113,18 @@ class Sky {
         }
     }
 
+    /**
+     * Gets the type of the sky.
+     *
+     * @type {string}
+     */
     get type() {
         return this._type;
     }
 
     /**
-     * The center of the sky. Ignored for {@link SKYTYPE_INFINITE}. Typically only the y-coordinate
-     * is used, representing the tripod height. Defaults to (0, 1, 0).
+     * Sets the center of the sky. Ignored for {@link SKYTYPE_INFINITE}. Typically only the
+     * y-coordinate is used, representing the tripod height. Defaults to (0, 1, 0).
      *
      * @type {Vec3}
      */
@@ -126,12 +132,17 @@ class Sky {
         this._center.copy(value);
     }
 
+    /**
+     * Gets the center of the sky.
+     *
+     * @type {Vec3}
+     */
     get center() {
         return this._center;
     }
 
     /**
-     * Whether depth writing is enabled for the sky. Defaults to false.
+     * Sets whether depth writing is enabled for the sky. Defaults to false.
      *
      * Writing a depth value for the skydome is supported when its type is not
      * {@link SKYTYPE_INFINITE}. When enabled, the depth is written during a prepass render pass and
@@ -152,7 +163,7 @@ class Sky {
     }
 
     /**
-     * Returns whether depth writing is enabled for the sky.
+     * Gets whether depth writing is enabled for the sky.
      *
      * @type {boolean}
      */
@@ -161,15 +172,13 @@ class Sky {
     }
 
     /**
-     * Controls the fisheye projection strength for the sky. The value is in the range [0, 1]:
+     * Sets the fisheye projection strength for the sky. The value is in the range [0, 1]:
      *
      * - 0: Standard rectilinear (perspective) projection.
      * - (0, 1]: Increasing barrel distortion, producing a wider field of view.
      *
      * Only supported with {@link SKYTYPE_INFINITE}. Has no effect on dome or box sky types,
-     * and has no effect with orthographic cameras.
-     *
-     * Defaults to 0.
+     * and has no effect with orthographic cameras. Defaults to 0.
      *
      * @type {number}
      */
@@ -188,6 +197,11 @@ class Sky {
         }
     }
 
+    /**
+     * Gets the fisheye projection strength for the sky.
+     *
+     * @type {number}
+     */
     get fisheye() {
         return this._fisheye;
     }


### PR DESCRIPTION
## Summary

Brings a handful of public-API accessors into line with the engine's documentation convention (demonstrated by `Mesh#aabb` in `src/scene/mesh.js`), where both halves of a `get`/`set` pair carry their own JSDoc block and `@type`.

The fix targets only accessors that actually appear in the generated API reference (classes with a class-level JSDoc block and no `@ignore`/`@private`). Classes excluded from the API reference by TypeDoc's `excludeNotDocumented: true` were left alone.

## Accessors updated

- `Script.enabled` - setter rephrased to "Sets the enabled state...", matching getter added describing the AND of entity/component/destroyed state.
- `Sky.type`, `Sky.center`, `Sky.fisheye` - setters rephrased to "Sets the ...", matching getters added. While in the file, `Sky.depthWrite` was also retuned to "Sets whether..."/"Gets whether..." so all four `Sky` accessors read consistently.
- `GSplatParams.renderer`, `GSplatParams.debug` - setters rephrased to "Sets the ...", matching getters added. The `renderer` getter notes the potential divergence from `currentRenderer` under WebGL fallback.
- `GSplatComponent.splatBudget` - getter now carries the same `@deprecated`/`@type` block as the setter, matching the neighbouring `lodDistances` pair.
- `SingleGestureSource.layout`, `DualGestureSource.layout` - setters rephrased to "Sets the layout...", matching getters added. For `DualGestureSource`, the previously bare `@type` setter doc was expanded to describe the hyphen-separated left/right form and default.

## Incidental JSDoc cleanup

- `Batch#model`: reordered JSDoc tags so `@type` precedes `@deprecated`/`@ignore`.
- `GSplatParams#colorizeLod`: added missing `@type {boolean}` on setter, normalized `@returns` to `@type {boolean}` on getter, and added `@ignore`.

## Verification

- Custom static scan for get/set JSDoc mismatches in the public API: **0 remaining** after these changes (17 remaining mismatches are all inside `@ignore`/undocumented classes not exposed in the API reference).
- `npm run lint` - clean (one pre-existing unrelated warning in `utils/rollup-build-target.mjs`).
- `npm run build:types` - `build/playcanvas.d.ts` builds without errors.

## Public API changes

No behaviour changes. Documentation-only; all affected accessors keep the same name, type, and runtime semantics.
