### PR TITLE
refactor: hoist constructor-assigned properties to class fields in src/core and src/platform/input

### DIFF
--- a/src/core/tags.js
+++ b/src/core/tags.js
@@ -51,6 +51,12 @@ class Tags extends EventHandler {
     _list = [];
 
     /**
+     * @type {object}
+     * @private
+     */
+    _parent;
+
+    /**
      * Create a new Tags instance.
      *
      * @param {object} [parent] - Parent object who tags belong to.

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -367,6 +367,73 @@ class GamePad {
     };
 
     /**
+     * The identifier for the gamepad. Its structure depends on device.
+     *
+     * @type {string}
+     */
+    id;
+
+    /**
+     * The index for this controller. A gamepad that is disconnected and reconnected will retain the same index.
+     *
+     * @type {number}
+     */
+    index;
+
+    /**
+     * The buttons present on the GamePad. Order is provided by API, use GamePad#buttons instead.
+     *
+     * @type {GamePadButton[]}
+     * @private
+     */
+    _buttons;
+
+    /**
+     * The axes values from the GamePad. Order is provided by API, use GamePad#axes instead.
+     *
+     * @type {number[]}
+     * @private
+     */
+    _axes;
+
+    /**
+     * Previous value for the analog axes present on the gamepad. Values are between -1 and 1.
+     *
+     * @type {number[]}
+     * @private
+     */
+    _previousAxes;
+
+    /**
+     * The gamepad mapping detected by the browser. Value is either "standard", "xr-standard", "" or "custom". When empty string, you may need to update the mapping yourself. "custom" means you updated the mapping.
+     *
+     * @type {string}
+     */
+    mapping;
+
+    /**
+     * The buttons and axes map.
+     *
+     * @type {object}
+     */
+    map;
+
+    /**
+     * The hand this gamepad is usually handled on. Only relevant for XR pads. Value is either "left", "right" or "none".
+     *
+     * @type {string}
+     */
+    hand;
+
+    /**
+     * The original Gamepad API gamepad.
+     *
+     * @type {Gamepad}
+     * @ignore
+     */
+    pad;
+
+    /**
      * Create a new GamePad Instance.
      *
      * @param {Gamepad} gamepad - The original Gamepad API gamepad.
@@ -374,71 +441,14 @@ class GamePad {
      * @ignore
      */
     constructor(gamepad, map) {
-        /**
-         * The identifier for the gamepad. Its structure depends on device.
-         *
-         * @type {string}
-         */
         this.id = gamepad.id;
-
-        /**
-         * The index for this controller. A gamepad that is disconnected and reconnected will retain the same index.
-         *
-         * @type {number}
-         */
         this.index = gamepad.index;
-
-        /**
-         * The buttons present on the GamePad. Order is provided by API, use GamePad#buttons instead.
-         *
-         * @type {GamePadButton[]}
-         * @private
-         */
         this._buttons = gamepad.buttons.map(b => new GamePadButton(b));
-
-        /**
-         * The axes values from the GamePad. Order is provided by API, use GamePad#axes instead.
-         *
-         * @type {number[]}
-         * @private
-         */
         this._axes = [...gamepad.axes];
-
-        /**
-         * Previous value for the analog axes present on the gamepad. Values are between -1 and 1.
-         *
-         * @type {number[]}
-         * @private
-         */
         this._previousAxes = [...gamepad.axes];
-
-        /**
-         * The gamepad mapping detected by the browser. Value is either "standard", "xr-standard", "" or "custom". When empty string, you may need to update the mapping yourself. "custom" means you updated the mapping.
-         *
-         * @type {string}
-         */
         this.mapping = map.mapping;
-
-        /**
-         * The buttons and axes map.
-         *
-         * @type {object}
-         */
         this.map = map;
-
-        /**
-         * The hand this gamepad is usually handled on. Only relevant for XR pads. Value is either "left", "right" or "none".
-         *
-         * @type {string}
-         */
         this.hand = gamepad.hand || 'none';
-
-        /**
-         * The original Gamepad API gamepad.
-         *
-         * @type {Gamepad}
-         * @ignore
-         */
         this.pad = gamepad;
 
         this._compileMapping();
@@ -792,32 +802,46 @@ class GamePads extends EventHandler {
     static EVENT_GAMEPADDISCONNECTED = 'gamepaddisconnected';
 
     /**
+     * Whether gamepads are supported by this device.
+     *
+     * @type {boolean}
+     */
+    gamepadsSupported;
+
+    /**
+     * The list of current gamepads.
+     *
+     * @type {GamePad[]}
+     */
+    current = [];
+
+    /**
+     * The list of previous buttons states
+     *
+     * @type {boolean[][]}
+     * @private
+     */
+    _previous = [];
+
+    /**
+     * @type {(event: GamepadEvent) => void}
+     * @private
+     */
+    _ongamepadconnectedHandler;
+
+    /**
+     * @type {(event: GamepadEvent) => void}
+     * @private
+     */
+    _ongamepaddisconnectedHandler;
+
+    /**
      * Create a new GamePads instance.
      */
     constructor() {
         super();
 
-        /**
-         * Whether gamepads are supported by this device.
-         *
-         * @type {boolean}
-         */
         this.gamepadsSupported = platform.gamepads;
-
-        /**
-         * The list of current gamepads.
-         *
-         * @type {GamePad[]}
-         */
-        this.current = [];
-
-        /**
-         * The list of previous buttons states
-         *
-         * @type {boolean[][]}
-         * @private
-         */
-        this._previous = [];
 
         this._ongamepadconnectedHandler = this._ongamepadconnected.bind(this);
         this._ongamepaddisconnectedHandler = this._ongamepaddisconnected.bind(this);

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -106,6 +106,50 @@ class Keyboard extends EventHandler {
     _lastmap = {};
 
     /**
+     * @type {(event: globalThis.KeyboardEvent) => void}
+     * @private
+     */
+    _keyDownHandler;
+
+    /**
+     * @type {(event: globalThis.KeyboardEvent) => void}
+     * @private
+     */
+    _keyUpHandler;
+
+    /**
+     * @type {(event: globalThis.KeyboardEvent) => void}
+     * @private
+     */
+    _keyPressHandler;
+
+    /**
+     * @type {() => void}
+     * @private
+     */
+    _visibilityChangeHandler;
+
+    /**
+     * @type {() => void}
+     * @private
+     */
+    _windowBlurHandler;
+
+    /**
+     * Call preventDefault() in key event handlers.
+     *
+     * @type {boolean}
+     */
+    preventDefault;
+
+    /**
+     * Call stopPropagation() in key event handlers.
+     *
+     * @type {boolean}
+     */
+    stopPropagation;
+
+    /**
      * Create a new Keyboard instance.
      *
      * @param {Element|Window} [element] - Element to attach Keyboard to. Note that elements like

--- a/src/platform/input/mouse-event.js
+++ b/src/platform/input/mouse-event.js
@@ -57,6 +57,14 @@ class MouseEvent {
     button = MOUSEBUTTON_NONE;
 
     /**
+     * The pressed state of all mouse buttons at the time this event was fired. A 3-element
+     * array of booleans for left, middle and right buttons respectively.
+     *
+     * @type {boolean[]}
+     */
+    buttons;
+
+    /**
      * A value representing the amount the mouse wheel has moved, only valid for
      * {@link Mouse.EVENT_MOUSEWHEEL} events.
      */

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -86,6 +86,36 @@ class Mouse extends EventHandler {
     _attached = false;
 
     /**
+     * @type {(event: globalThis.MouseEvent) => void}
+     * @private
+     */
+    _upHandler;
+
+    /**
+     * @type {(event: globalThis.MouseEvent) => void}
+     * @private
+     */
+    _downHandler;
+
+    /**
+     * @type {(event: globalThis.MouseEvent) => void}
+     * @private
+     */
+    _moveHandler;
+
+    /**
+     * @type {(event: globalThis.WheelEvent) => void}
+     * @private
+     */
+    _wheelHandler;
+
+    /**
+     * @type {(event: Event) => void}
+     * @private
+     */
+    _contextMenuHandler;
+
+    /**
      * Create a new Mouse instance.
      *
      * @param {Element} [element] - The Element that the mouse events are attached to.

--- a/src/platform/input/touch-device.js
+++ b/src/platform/input/touch-device.js
@@ -64,14 +64,42 @@ class TouchDevice extends EventHandler {
     static EVENT_TOUCHCANCEL = 'touchcancel';
 
     /**
+     * @type {Element|null}
+     * @private
+     */
+    _element = null;
+
+    /**
+     * @type {(e: globalThis.TouchEvent) => void}
+     * @private
+     */
+    _startHandler;
+
+    /**
+     * @type {(e: globalThis.TouchEvent) => void}
+     * @private
+     */
+    _endHandler;
+
+    /**
+     * @type {(e: globalThis.TouchEvent) => void}
+     * @private
+     */
+    _moveHandler;
+
+    /**
+     * @type {(e: globalThis.TouchEvent) => void}
+     * @private
+     */
+    _cancelHandler;
+
+    /**
      * Create a new touch device and attach it to an element.
      *
      * @param {Element} element - The element to attach listen for events on.
      */
     constructor(element) {
         super();
-
-        this._element = null;
 
         this._startHandler = this._handleTouchStart.bind(this);
         this._endHandler = this._handleTouchEnd.bind(this);

--- a/src/platform/input/touch-event.js
+++ b/src/platform/input/touch-event.js
@@ -7,8 +7,8 @@
  * the target DOM element.
  *
  * @param {globalThis.Touch} touch - The browser Touch object.
- * @returns {object} The coordinates of the touch relative to the touch.target DOM element. In the
- * format \{x, y\}.
+ * @returns {{x: number, y: number}} The coordinates of the touch relative to the touch.target
+ * DOM element.
  * @category Input
  */
 function getTouchTargetCoords(touch) {


### PR DESCRIPTION
## Summary

- Aligns `src/core/tags.js` and every class in `src/platform/input/` with the class-fields convention in `AGENTS.md` §15. All properties previously assigned only via `this.x = ...` in a constructor now have explicit class-field declarations with `@type` JSDoc blocks.
- Removes a couple of redundant constructor assignments that duplicated class-field initializers (`GamePads.current` / `GamePads._previous` and `TouchDevice._element`).
- Tightens the JSDoc return type of `getTouchTargetCoords` in `src/platform/input/touch-event.js` from the generic `object` to `{x: number, y: number}`.

Hoisted fields by class:

- `Tags`: `_parent`
- `MouseEvent`: `buttons`
- `Mouse`: `_upHandler`, `_downHandler`, `_moveHandler`, `_wheelHandler`, `_contextMenuHandler`
- `Keyboard`: `_keyDownHandler`, `_keyUpHandler`, `_keyPressHandler`, `_visibilityChangeHandler`, `_windowBlurHandler`, `preventDefault`, `stopPropagation`
- `TouchDevice`: `_element`, `_startHandler`, `_endHandler`, `_moveHandler`, `_cancelHandler`
- `GamePad`: `id`, `index`, `_buttons`, `_axes`, `_previousAxes`, `mapping`, `map`, `hand`, `pad` (existing inline JSDoc preserved)
- `GamePads`: `gamepadsSupported`, `current`, `_previous`, `_ongamepadconnectedHandler`, `_ongamepaddisconnectedHandler`

No behavior changes.

## Test plan

- [x] `npx eslint src/platform/input/` passes
- [x] `npm run build:types` succeeds
- [x] `npm run test:types` succeeds
- [x] CI green
