### PR TITLE
refactor: fold gsplat debug AABB flags into debug enum

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.controls.mjs
@@ -36,7 +36,9 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'None' },
                         { v: 1, t: 'LOD' },
                         { v: 2, t: 'SH Update' },
-                        { v: 3, t: 'Heatmap' }
+                        { v: 3, t: 'Heatmap' },
+                        { v: 4, t: 'AABBs' },
+                        { v: 5, t: 'Node AABBs' }
                     ]
                 })
             ),

--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
@@ -228,7 +228,9 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'None' },
                         { v: 1, t: 'LOD' },
                         { v: 2, t: 'SH Update' },
-                        { v: 3, t: 'Heatmap' }
+                        { v: 3, t: 'Heatmap' },
+                        { v: 4, t: 'AABBs' },
+                        { v: 5, t: 'Node AABBs' }
                     ]
                 })
             ),

--- a/examples/src/examples/gaussian-splatting/world.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/world.controls.mjs
@@ -54,7 +54,9 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'None' },
                         { v: 1, t: 'LOD' },
                         { v: 2, t: 'SH Update' },
-                        { v: 3, t: 'Heatmap' }
+                        { v: 3, t: 'Heatmap' },
+                        { v: 4, t: 'AABBs' },
+                        { v: 5, t: 'Node AABBs' }
                     ]
                 })
             ),

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1275,3 +1275,20 @@ export const GSPLAT_DEBUG_SH_UPDATE = 2;
  * @category Graphics
  */
 export const GSPLAT_DEBUG_HEATMAP = 3;
+
+/**
+ * Debug rendering that draws world-space AABBs for each GSplat, colorized by LOD.
+ *
+ * @type {number}
+ * @category Graphics
+ */
+export const GSPLAT_DEBUG_AABBS = 4;
+
+/**
+ * Debug rendering that draws world-space AABBs for each octree node of streamed GSplats,
+ * colorized by the currently selected LOD.
+ *
+ * @type {number}
+ * @category Graphics
+ */
+export const GSPLAT_DEBUG_NODE_AABBS = 5;

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -18,7 +18,7 @@ import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import {
     GSPLAT_RENDERER_RASTER_CPU_SORT, GSPLAT_RENDERER_RASTER_GPU_SORT, GSPLAT_RENDERER_COMPUTE,
-    GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE
+    GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE, GSPLAT_DEBUG_AABBS
 } from '../constants.js';
 import { Color } from '../../core/math/color.js';
 import { GSplatBudgetBalancer } from './gsplat-budget-balancer.js';
@@ -1440,7 +1440,7 @@ class GSplatManager {
 
             // debug render world space bounds for all splats
             Debug.call(() => {
-                if (this.scene.gsplat.debugAabbs) {
+                if (this.scene.gsplat.debug === GSPLAT_DEBUG_AABBS) {
                     const tempAabb = new BoundingBox();
                     const scene = this.scene;
                     lastState.splats.forEach((splat) => {

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -7,6 +7,7 @@ import { BoundingBox } from '../../core/shape/bounding-box.js';
 import { Color } from '../../core/math/color.js';
 import { GSplatPlacement } from './gsplat-placement.js';
 import { GsplatAllocId } from './gsplat-alloc-id.js';
+import { GSPLAT_DEBUG_NODE_AABBS } from '../constants.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
@@ -948,7 +949,7 @@ class GSplatOctreeInstance {
     // debug render world space bounds for octree nodes based on current LOD selection
     debugRender(scene) {
         Debug.call(() => {
-            if (scene.gsplat.debugNodeAabbs) {
+            if (scene.gsplat.debug === GSPLAT_DEBUG_NODE_AABBS) {
                 const modelMat = this.placement.node.getWorldTransform();
                 const nodes = this.octree.nodes;
                 for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -9,7 +9,8 @@ import {
     GSPLATDATA_COMPACT,
     GSPLAT_RENDERER_AUTO, GSPLAT_RENDERER_RASTER_CPU_SORT,
     GSPLAT_RENDERER_RASTER_GPU_SORT, GSPLAT_RENDERER_COMPUTE,
-    GSPLAT_DEBUG_NONE, GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE, GSPLAT_DEBUG_HEATMAP
+    GSPLAT_DEBUG_NONE, GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE, GSPLAT_DEBUG_HEATMAP,
+    GSPLAT_DEBUG_AABBS, GSPLAT_DEBUG_NODE_AABBS
 } from '../constants.js';
 
 import glslCompactRead from '../shader-lib/glsl/chunks/gsplat/vert/formats/containerCompactRead.js';
@@ -118,11 +119,6 @@ class GSplatParams {
     }
 
     /**
-     * Enables debug rendering of AABBs for GSplat objects. Defaults to false.
-     */
-    debugAabbs = false;
-
-    /**
      * Enables radial sorting based on distance from camera (for cubemap rendering). When false,
      * uses directional sorting along camera forward vector. Defaults to false.
      *
@@ -195,11 +191,6 @@ class GSplatParams {
     }
 
     /**
-     * Enables debug rendering of AABBs for GSplat octree nodes. Defaults to false.
-     */
-    debugNodeAabbs = false;
-
-    /**
      * Internal dirty flag to trigger update of gsplat managers when some params change.
      *
      * @ignore
@@ -221,6 +212,9 @@ class GSplatParams {
      * frequency.
      * - {@link GSPLAT_DEBUG_HEATMAP}: Heatmap visualization of average splats processed per
      * pixel in each tile. Only supported with {@link GSPLAT_RENDERER_COMPUTE}.
+     * - {@link GSPLAT_DEBUG_AABBS}: Draw world-space AABBs for each GSplat, colorized by LOD.
+     * - {@link GSPLAT_DEBUG_NODE_AABBS}: Draw world-space AABBs for each octree node of
+     * streamed GSplats, colorized by the currently selected LOD.
      *
      * Only one debug mode can be active at a time. Defaults to {@link GSPLAT_DEBUG_NONE}.
      *
@@ -264,6 +258,44 @@ class GSplatParams {
      */
     get colorizeLod() {
         return this._debug === GSPLAT_DEBUG_LOD;
+    }
+
+    /**
+     * @type {boolean}
+     * @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_AABBS} instead.
+     * @ignore
+     */
+    set debugAabbs(value) {
+        Debug.deprecated('GSplatParams#debugAabbs is deprecated. Use GSplatParams#debug = GSPLAT_DEBUG_AABBS instead.');
+        this.debug = value ? GSPLAT_DEBUG_AABBS : GSPLAT_DEBUG_NONE;
+    }
+
+    /**
+     * @type {boolean}
+     * @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_AABBS} instead.
+     * @ignore
+     */
+    get debugAabbs() {
+        return this._debug === GSPLAT_DEBUG_AABBS;
+    }
+
+    /**
+     * @type {boolean}
+     * @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_NODE_AABBS} instead.
+     * @ignore
+     */
+    set debugNodeAabbs(value) {
+        Debug.deprecated('GSplatParams#debugNodeAabbs is deprecated. Use GSplatParams#debug = GSPLAT_DEBUG_NODE_AABBS instead.');
+        this.debug = value ? GSPLAT_DEBUG_NODE_AABBS : GSPLAT_DEBUG_NONE;
+    }
+
+    /**
+     * @type {boolean}
+     * @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_NODE_AABBS} instead.
+     * @ignore
+     */
+    get debugNodeAabbs() {
+        return this._debug === GSPLAT_DEBUG_NODE_AABBS;
     }
 
     /** @private */


### PR DESCRIPTION
Fold the standalone `GSplatParams#debugAabbs` and `GSplatParams#debugNodeAabbs` boolean flags into the existing `GSPLAT_DEBUG_*` enum-based `debug` property, for a single, consistent way to pick a gsplat debug mode. The old flags are retained as deprecated shims.

**Changes:**
- Add `GSPLAT_DEBUG_AABBS` and `GSPLAT_DEBUG_NODE_AABBS` enum values.
- Remove the `debugAabbs` / `debugNodeAabbs` boolean fields from `GSplatParams`.
- Consumers in `GSplatManager` and `GSplatOctreeInstance` now check `debug === GSPLAT_DEBUG_*`.
- Expose the two new modes in the Debug dropdown of the `world`, `lod-streaming`, and `lod-streaming-sh` gsplat examples.

**API Changes:**
- Added: `GSPLAT_DEBUG_AABBS`, `GSPLAT_DEBUG_NODE_AABBS`.
- Deprecated: `GSplatParams#debugAabbs`, `GSplatParams#debugNodeAabbs` — these now forward to `debug` and emit a deprecation warning. Migration:

  ```js
  // before
  app.scene.gsplat.debugAabbs = true;
  app.scene.gsplat.debugNodeAabbs = true;

  // after
  app.scene.gsplat.debug = pc.GSPLAT_DEBUG_AABBS;
  app.scene.gsplat.debug = pc.GSPLAT_DEBUG_NODE_AABBS;
  ```

**Examples:**
- `gaussian-splatting/world`, `gaussian-splatting/lod-streaming`, `gaussian-splatting/lod-streaming-sh`: Debug dropdown now includes `AABBs` and `Node AABBs`.