### PR TITLE
refactor: drop vendor-prefixed Page Visibility API support

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -556,22 +556,8 @@ class AppBase extends EventHandler {
 
         this._visibilityChangeHandler = this.onVisibilityChange.bind(this);
 
-        // Depending on browser add the correct visibilitychange event and store the name of the
-        // hidden attribute in this._hiddenAttr.
         if (typeof document !== 'undefined') {
-            if (document.hidden !== undefined) {
-                this._hiddenAttr = 'hidden';
-                document.addEventListener('visibilitychange', this._visibilityChangeHandler, false);
-            } else if (document.mozHidden !== undefined) {
-                this._hiddenAttr = 'mozHidden';
-                document.addEventListener('mozvisibilitychange', this._visibilityChangeHandler, false);
-            } else if (document.msHidden !== undefined) {
-                this._hiddenAttr = 'msHidden';
-                document.addEventListener('msvisibilitychange', this._visibilityChangeHandler, false);
-            } else if (document.webkitHidden !== undefined) {
-                this._hiddenAttr = 'webkitHidden';
-                document.addEventListener('webkitvisibilitychange', this._visibilityChangeHandler, false);
-            }
+            document.addEventListener('visibilitychange', this._visibilityChangeHandler, false);
         }
 
         // bind tick function to current scope
@@ -1247,7 +1233,7 @@ class AppBase extends EventHandler {
      * @returns {boolean} True if the application is not visible and false otherwise.
      */
     isHidden() {
-        return document[this._hiddenAttr];
+        return document.hidden;
     }
 
     /**
@@ -1867,9 +1853,6 @@ class AppBase extends EventHandler {
 
         if (typeof document !== 'undefined') {
             document.removeEventListener('visibilitychange', this._visibilityChangeHandler, false);
-            document.removeEventListener('mozvisibilitychange', this._visibilityChangeHandler, false);
-            document.removeEventListener('msvisibilitychange', this._visibilityChangeHandler, false);
-            document.removeEventListener('webkitvisibilitychange', this._visibilityChangeHandler, false);
         }
         this._visibilityChangeHandler = null;
 


### PR DESCRIPTION
## Summary

- Drops legacy vendor-prefixed Page Visibility API handling (`mozvisibilitychange`, `msvisibilitychange`, `webkitvisibilitychange` and the paired `mozHidden` / `msHidden` / `webkitHidden` attribute lookup) from `AppBase`.
- Registers a single unprefixed `visibilitychange` listener in `init()`, tears it down with a single `removeEventListener` in `destroy()`, and rewrites `isHidden()` to read `document.hidden` directly.
- Removes the now-unused internal `_hiddenAttr` property.

## Rationale

The unprefixed Page Visibility API (`document.hidden` + `visibilitychange`) is universally supported by the engine's target browsers (WebGL 2 baseline: Chrome 56+, Firefox 51+, Safari 15+, Edge 79+). `keyboard.js` already only uses the unprefixed event, so this brings `AppBase` in line.

## Public API

- `AppBase#isHidden()` — unchanged signature and return semantics, only the internal implementation changed.
- `_hiddenAttr` was private (underscore-prefixed, not a declared class field) and had no external consumers.

## Test plan

- [x] `npx eslint src/framework/app-base.js` — clean.
- [x] Launch an engine example, switch browser tab away and back, confirm audio suspends/resumes as before.
