### PR TITLE
refactor: inline AppBase tick as a class-field arrow

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -91,15 +91,6 @@ import { ShaderChunks } from '../scene/shader-lib/shader-chunks.js';
  */
 
 /**
- * @callback MakeTickCallback
- * Callback used by {@link AppBase#start} and itself to request the rendering of a new animation
- * frame.
- * @param {number} [timestamp] - The timestamp supplied by requestAnimationFrame.
- * @param {XRFrame} [frame] - XRFrame from requestAnimationFrame callback.
- * @returns {void}
- */
-
-/**
  * Gets the current application, if any.
  *
  * @type {AppBase|null}
@@ -197,6 +188,96 @@ class AppBase extends EventHandler {
      * @ignore
      */
     frameRequestId;
+
+    /**
+     * Main loop tick, invoked by `requestAnimationFrame` each frame. Bound to this instance so
+     * it can be passed directly to `requestAnimationFrame`. Subclasses may replace this with
+     * their own tick function.
+     *
+     * @param {number} [timestamp] - The timestamp supplied by requestAnimationFrame.
+     * @param {XRFrame} [xrFrame] - XRFrame from requestAnimationFrame callback.
+     * @ignore
+     */
+    tick = (timestamp, xrFrame) => {
+        if (!this.graphicsDevice) {
+            return;
+        }
+
+        // cancel any hanging rAF to avoid multiple rAF callbacks per frame
+        if (this.frameRequestId) {
+            this.xr?.session?.cancelAnimationFrame(this.frameRequestId);
+            cancelAnimationFrame(this.frameRequestId);
+            this.frameRequestId = null;
+        }
+
+        this._inFrameUpdate = true;
+
+        setApplication(this);
+
+        // have current application pointer in pc
+        app = this;
+
+        const currentTime = this._processTimestamp(timestamp) || now();
+        const ms = currentTime - (this._time || currentTime);
+        let dt = ms / 1000.0;
+        dt = math.clamp(dt, 0, this.maxDeltaTime);
+        dt *= this.timeScale;
+
+        this._time = currentTime;
+
+        // Submit a request to queue up a new animation frame immediately
+        this.requestAnimationFrame();
+
+        if (this.graphicsDevice.contextLost) {
+            return;
+        }
+
+        this._fillFrameStatsBasic(currentTime, dt, ms);
+
+        // #if _PROFILER
+        this._fillFrameStats();
+        // #endif
+
+        this.fire('frameupdate', ms);
+
+        let skipUpdate = false;
+
+        if (xrFrame) {
+            skipUpdate = !this.xr?.update(xrFrame);
+            this.graphicsDevice.defaultFramebuffer = xrFrame.session.renderState.baseLayer.framebuffer;
+        } else {
+            this.graphicsDevice.defaultFramebuffer = null;
+        }
+
+        if (!skipUpdate) {
+
+            Debug.trace(TRACEID_RENDER_FRAME, `---- Frame ${this.frame}`);
+            Debug.trace(TRACEID_RENDER_FRAME_TIME, `-- UpdateStart ${now().toFixed(2)}ms`);
+
+            this.update(dt);
+
+            this.fire('framerender');
+
+            if (this.autoRender || this.renderNextFrame) {
+
+                Debug.trace(TRACEID_RENDER_FRAME_TIME, `-- RenderStart ${now().toFixed(2)}ms`);
+
+                this.render();
+                this.renderNextFrame = false;
+
+                Debug.trace(TRACEID_RENDER_FRAME_TIME, `-- RenderEnd ${now().toFixed(2)}ms`);
+            }
+
+            this.fire('frameend');
+            this.stats.frameEnd();
+        }
+
+        this._inFrameUpdate = false;
+
+        if (this._destroyRequested) {
+            this.destroy();
+        }
+    };
 
     /**
      * Scales the global time delta. Defaults to 1.
@@ -559,10 +640,6 @@ class AppBase extends EventHandler {
         if (typeof document !== 'undefined') {
             document.addEventListener('visibilitychange', this._visibilityChangeHandler, false);
         }
-
-        // bind tick function to current scope
-        /* eslint-disable-next-line no-use-before-define */
-        this.tick = makeTick(this); // Circular linting issue as makeTick and Application reference each other
     }
 
     static _applications = {};
@@ -2006,100 +2083,5 @@ class AppBase extends EventHandler {
         });
     }
 }
-
-/**
- * Create tick function to be wrapped in closure.
- *
- * @param {AppBase} _app - The application.
- * @returns {MakeTickCallback} The tick function.
- * @private
- */
-const makeTick = function (_app) {
-    const application = _app;
-    /**
-     * @param {number} [timestamp] - The timestamp supplied by requestAnimationFrame.
-     * @param {XRFrame} [xrFrame] - XRFrame from requestAnimationFrame callback.
-     */
-    return function (timestamp, xrFrame) {
-        if (!application.graphicsDevice) {
-            return;
-        }
-
-        // cancel any hanging rAF to avoid multiple rAF callbacks per frame
-        if (application.frameRequestId) {
-            application.xr?.session?.cancelAnimationFrame(application.frameRequestId);
-            cancelAnimationFrame(application.frameRequestId);
-            application.frameRequestId = null;
-        }
-
-        application._inFrameUpdate = true;
-
-        setApplication(application);
-
-        // have current application pointer in pc
-        app = application;
-
-        const currentTime = application._processTimestamp(timestamp) || now();
-        const ms = currentTime - (application._time || currentTime);
-        let dt = ms / 1000.0;
-        dt = math.clamp(dt, 0, application.maxDeltaTime);
-        dt *= application.timeScale;
-
-        application._time = currentTime;
-
-        // Submit a request to queue up a new animation frame immediately
-        application.requestAnimationFrame();
-
-        if (application.graphicsDevice.contextLost) {
-            return;
-        }
-
-        application._fillFrameStatsBasic(currentTime, dt, ms);
-
-        // #if _PROFILER
-        application._fillFrameStats();
-        // #endif
-
-        application.fire('frameupdate', ms);
-
-        let skipUpdate = false;
-
-        if (xrFrame) {
-            skipUpdate = !application.xr?.update(xrFrame);
-            application.graphicsDevice.defaultFramebuffer = xrFrame.session.renderState.baseLayer.framebuffer;
-        } else {
-            application.graphicsDevice.defaultFramebuffer = null;
-        }
-
-        if (!skipUpdate) {
-
-            Debug.trace(TRACEID_RENDER_FRAME, `---- Frame ${application.frame}`);
-            Debug.trace(TRACEID_RENDER_FRAME_TIME, `-- UpdateStart ${now().toFixed(2)}ms`);
-
-            application.update(dt);
-
-            application.fire('framerender');
-
-            if (application.autoRender || application.renderNextFrame) {
-
-                Debug.trace(TRACEID_RENDER_FRAME_TIME, `-- RenderStart ${now().toFixed(2)}ms`);
-
-                application.render();
-                application.renderNextFrame = false;
-
-                Debug.trace(TRACEID_RENDER_FRAME_TIME, `-- RenderEnd ${now().toFixed(2)}ms`);
-            }
-
-            application.fire('frameend');
-            application.stats.frameEnd();
-        }
-
-        application._inFrameUpdate = false;
-
-        if (application._destroyRequested) {
-            application.destroy();
-        }
-    };
-};
 
 export { app, AppBase };

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -2034,8 +2034,6 @@ class AppBase extends EventHandler {
         this.graphicsDevice.destroy();
         this.graphicsDevice = null;
 
-        this.tick = null;
-
         this.off(); // remove all events
 
         this._soundManager?.destroy();


### PR DESCRIPTION
## Summary

- Replaces the module-level `makeTick` closure factory in `AppBase` with a class-field arrow function `tick`, removing the `no-use-before-define` workaround and the `const application = _app` alias.
- Deletes the now-unused `@callback MakeTickCallback` JSDoc typedef.
- Drops the `this.tick = makeTick(this)` assignment (and its comment) from `init()`.

## Rationale

The old pattern was a forward-declared module-scope factory called from `init()`, which required an ESLint disable comment on every tick of development and obscured `this` behind a captured `application` alias. A class-field arrow is:

- idiomatic (matches the many other AppBase class fields),
- auto-bound, so `this.tick` can still be passed straight to `requestAnimationFrame`,
- initialised in the base constructor, making `this.tick` available to subclass constructor bodies.

## Public API

- No public API changes. `tick` is `@ignore` (internal), and remains a writable instance property, so subclasses like the editor's `ViewportApplication` can continue to reassign it after `super()`.

## Test plan

- [x] `npx eslint src/framework/app-base.js` — clean.
- [x] Run an engine example and confirm the main loop ticks normally and stats update.
- [x] Run an XR example and confirm the XR frame loop still drives updates.
