### PR TITLE
fix: avoid camera_params redefinition in pickPS

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/common/frag/pick.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/pick.js
@@ -16,8 +16,10 @@ vec4 encodePickOutput(uint id) {
 
 #ifdef DEPTH_PICK_PASS
     #include "floatAsUintPS"
-    uniform vec4 camera_params; // x: 1/far, y: far, z: near, w: isOrtho
-
+    #ifndef CAMERAPLANES
+        #define CAMERAPLANES
+        uniform vec4 camera_params; // x: 1/far, y: far, z: near, w: isOrtho
+    #endif
     vec4 getPickDepth() {
         float linearDepth;
         if (camera_params.w > 0.5) {


### PR DESCRIPTION
## Description
This PR adds a `CAMERAPLANES` include guard around the `camera_params` uniform in `pickPS.glsl`, preventing duplicate definition errors when multiple shader chunks that declare `camera_params` are included together.

The pattern matches the existing guard used in other engine shaders (e.g. depthPS.glsl).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change