### PR TITLE
fix: avoid camera_params redefinition in pickPS (WGSL)

### DIFF
--- a/src/scene/shader-lib/wgsl/chunks/common/frag/pick.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/pick.js
@@ -16,8 +16,10 @@ fn encodePickOutput(id: u32) -> vec4f {
 
 #ifdef DEPTH_PICK_PASS
     #include "floatAsUintPS"
-    uniform camera_params: vec4f; // x: 1/far, y: far, z: near, w: isOrtho
-
+    #ifndef CAMERAPLANES
+        #define CAMERAPLANES
+        uniform camera_params: vec4f; // x: 1/far, y: far, z: near, w: isOrtho
+    #endif
     fn getPickDepth() -> vec4f {
         var linearDepth: f32;
         if (uniform.camera_params.w > 0.5) {


### PR DESCRIPTION
## Description

This PR mirrors the fix from #8640 for the WGSL version of the `pickPS` chunk. It adds a `CAMERAPLANES` include guard around the `camera_params` uniform in `src/scene/shader-lib/wgsl/chunks/common/frag/pick.js`, preventing duplicate definition errors when multiple shader chunks that declare `camera_params` are included together.

The pattern matches the existing guard used in other WGSL chunks (`linearizeDepth`, `screenDepth`, `particle`, `particle_init`) and is now consistent with the GLSL version fixed in #8640.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change