### PR TITLE
feat: Include GPU vendor/architecture in WebGPU feature log

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -328,7 +328,12 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsTextureFormatTier1 ||= this.supportsTextureFormatTier2;
         this.supportsPrimitiveIndex = requireFeature('primitive-index');
         this.supportsSubgroups = requireFeature('subgroups');
-        Debug.log(`WEBGPU features [${bare ? 'bare' : 'full'}]: ${requiredFeatures.join(', ') || 'none'}`);
+        Debug.log(
+            `WEBGPU${this.gpuAdapter?.info ?
+                ` (${this.gpuAdapter.info.vendor || '?'} / ${this.gpuAdapter.info.architecture || this.gpuAdapter.info.device || '?'})` :
+                ''
+            } features [${bare ? 'bare' : 'full'}]: ${requiredFeatures.join(', ') || 'none'}`
+        );
 
         // copy all adapter limits to the requiredLimits object (skipped for bare mode to use spec defaults)
         const requiredLimits = {};


### PR DESCRIPTION
Extends the `WEBGPU features [...]` init log with the adapter's vendor and architecture (or device) identifier, read from `GPUAdapter.info`. This makes the log self-identifying when triaging user reports — previously you could see the enabled features but not which GPU they came from.

**Changes:**
- Read `gpuAdapter.info.vendor` and `gpuAdapter.info.architecture` (falling back to `device`) and prefix the log with `(vendor / arch)`.
- Entire expression lives inside the `Debug.log(...)` call, so the full vendor lookup is stripped in non-debug builds along with the log itself.
- Log is broken across multiple lines for readability.

**Before:**
`WEBGPU features [full]: float32-filterable, ..., subgroups`

**After:**
`WEBGPU (apple / metal-3) features [full]: float32-filterable, ..., subgroups`

No public API changes.