### PR TITLE
refactor: move per-frame stats collection from AppBase to ApplicationStats

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -14,7 +14,7 @@ import { Quat } from '../core/math/quat.js';
 import { Vec3 } from '../core/math/vec3.js';
 
 import {
-    PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP, CULLFACE_NONE,
+    CULLFACE_NONE,
     SHADERLANGUAGE_GLSL,
     SHADERLANGUAGE_WGSL
 } from '../platform/graphics/constants.js';
@@ -232,10 +232,10 @@ class AppBase extends EventHandler {
             return;
         }
 
-        this._fillFrameStatsBasic(currentTime, dt, ms);
+        this.stats.updateBasic(currentTime, dt, ms, this.renderer, this.graphicsDevice);
 
         // #if _PROFILER
-        this._fillFrameStats();
+        this.stats.updateDetailed(this.renderer, this.graphicsDevice);
         // #endif
 
         this.fire('frameupdate', ms);
@@ -1159,105 +1159,6 @@ class AppBase extends EventHandler {
 
         this.renderer.buildFrameGraph(this.frameGraph, layerComposition);
         this.frameGraph.render(this.graphicsDevice);
-    }
-
-    /**
-     * @param {number} now - The timestamp passed to the requestAnimationFrame callback.
-     * @param {number} dt - The time delta in seconds since the last frame. This is subject to the
-     * application's time scale and max delta values.
-     * @param {number} ms - The time in milliseconds since the last frame.
-     * @private
-     */
-    _fillFrameStatsBasic(now, dt, ms) {
-        // Timing stats
-        const stats = this.stats.frame;
-        stats.dt = dt;
-        stats.ms = ms;
-        if (now > stats._timeToCountFrames) {
-            stats.fps = stats._fpsAccum;
-            stats._fpsAccum = 0;
-            stats._timeToCountFrames = now + 1000;
-        } else {
-            stats._fpsAccum++;
-        }
-
-        // total draw call
-        this.stats.drawCalls.total = this.graphicsDevice._drawCallsPerFrame;
-        this.graphicsDevice._drawCallsPerFrame = 0;
-
-        stats.gsplats = this.renderer._gsplatCount;
-        stats.gsplatBufferCopy = this.renderer._gsplatBufferCopy ?? 0;
-    }
-
-    /** @private */
-    _fillFrameStats() {
-        let stats = this.stats.frame;
-
-        // Render stats
-        stats.cameras = this.renderer._camerasRendered;
-        stats.materials = this.renderer._materialSwitches;
-        stats.shaders = this.graphicsDevice._shaderSwitchesPerFrame;
-        stats.shadowMapUpdates = this.renderer._shadowMapUpdates;
-        stats.shadowMapTime = this.renderer._shadowMapTime;
-        stats.depthMapTime = this.renderer._depthMapTime;
-        stats.forwardTime = this.renderer._forwardTime;
-        const prims = this.graphicsDevice._primsPerFrame;
-        stats.triangles = prims[PRIMITIVE_TRIANGLES] / 3 +
-            Math.max(prims[PRIMITIVE_TRISTRIP] - 2, 0) +
-            Math.max(prims[PRIMITIVE_TRIFAN] - 2, 0);
-        stats.cullTime = this.renderer._cullTime;
-        stats.sortTime = this.renderer._sortTime;
-        stats.skinTime = this.renderer._skinTime;
-        stats.morphTime = this.renderer._morphTime;
-        stats.lightClusters = this.renderer._lightClusters;
-        stats.lightClustersTime = this.renderer._lightClustersTime;
-        stats.otherPrimitives = 0;
-        for (let i = 0; i < prims.length; i++) {
-            if (i < PRIMITIVE_TRIANGLES) {
-                stats.otherPrimitives += prims[i];
-            }
-            prims[i] = 0;
-        }
-        this.renderer._camerasRendered = 0;
-        this.renderer._materialSwitches = 0;
-        this.renderer._shadowMapUpdates = 0;
-        this.graphicsDevice._shaderSwitchesPerFrame = 0;
-        this.renderer._cullTime = 0;
-        this.renderer._layerCompositionUpdateTime = 0;
-        this.renderer._lightClustersTime = 0;
-        this.renderer._sortTime = 0;
-        this.renderer._skinTime = 0;
-        this.renderer._morphTime = 0;
-        this.renderer._shadowMapTime = 0;
-        this.renderer._depthMapTime = 0;
-        this.renderer._forwardTime = 0;
-
-        // Draw call stats
-        stats = this.stats.drawCalls;
-        stats.forward = this.renderer._forwardDrawCalls;
-        stats.culled = this.renderer._numDrawCallsCulled;
-        stats.depth = 0;
-        stats.shadow = this.renderer._shadowDrawCalls;
-        stats.skinned = this.renderer._skinDrawCalls;
-        stats.immediate = 0;
-        stats.instanced = 0;
-        stats.removedByInstancing = 0;
-        stats.misc = stats.total - (stats.forward + stats.shadow);
-        this.renderer._depthDrawCalls = 0;
-        this.renderer._shadowDrawCalls = 0;
-        this.renderer._forwardDrawCalls = 0;
-        this.renderer._numDrawCallsCulled = 0;
-        this.renderer._skinDrawCalls = 0;
-        this.renderer._immediateRendered = 0;
-        this.renderer._instancedDrawCalls = 0;
-
-        this.stats.misc.renderTargetCreationTime = this.graphicsDevice.renderTargetCreationTime;
-
-        stats = this.stats.particles;
-        stats.updatesPerFrame = stats._updatesPerFrame;
-        stats.frameTime = stats._frameTime;
-        stats._updatesPerFrame = 0;
-        stats._frameTime = 0;
     }
 
     /**

--- a/src/framework/stats.js
+++ b/src/framework/stats.js
@@ -1,6 +1,8 @@
+import { PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP } from '../platform/graphics/constants.js';
 import { getApplication } from './globals.js';
 
 /**
+ * @import { ForwardRenderer } from '../scene/renderer/forward-renderer.js'
  * @import { GraphicsDevice } from '../platform/graphics/graphics-device.js'
  */
 
@@ -117,6 +119,115 @@ class ApplicationStats {
     get batcher() {
         const batcher = getApplication()._batcher;
         return batcher ? batcher._stats : null;
+    }
+
+    /**
+     * Update basic per-frame stats. Called every frame from `AppBase.tick`.
+     *
+     * @param {number} now - High-resolution timestamp for the current frame (ms).
+     * @param {number} dt - Delta time in seconds (time-scaled, clamped).
+     * @param {number} ms - Raw inter-frame time in ms.
+     * @param {ForwardRenderer} renderer - The forward renderer.
+     * @param {GraphicsDevice} device - The graphics device.
+     * @ignore
+     */
+    updateBasic(now, dt, ms, renderer, device) {
+        // Timing stats
+        const stats = this.frame;
+        stats.dt = dt;
+        stats.ms = ms;
+        if (now > stats._timeToCountFrames) {
+            stats.fps = stats._fpsAccum;
+            stats._fpsAccum = 0;
+            stats._timeToCountFrames = now + 1000;
+        } else {
+            stats._fpsAccum++;
+        }
+
+        // total draw call
+        this.drawCalls.total = device._drawCallsPerFrame;
+        device._drawCallsPerFrame = 0;
+
+        stats.gsplats = renderer._gsplatCount;
+        stats.gsplatBufferCopy = renderer._gsplatBufferCopy ?? 0;
+    }
+
+    /**
+     * Update detailed per-frame stats (profiler build only). Resets per-frame
+     * counters on the renderer and graphics device.
+     *
+     * @param {ForwardRenderer} renderer - The forward renderer.
+     * @param {GraphicsDevice} device - The graphics device.
+     * @ignore
+     */
+    updateDetailed(renderer, device) {
+        let stats = this.frame;
+
+        // Render stats
+        stats.cameras = renderer._camerasRendered;
+        stats.materials = renderer._materialSwitches;
+        stats.shaders = device._shaderSwitchesPerFrame;
+        stats.shadowMapUpdates = renderer._shadowMapUpdates;
+        stats.shadowMapTime = renderer._shadowMapTime;
+        stats.depthMapTime = renderer._depthMapTime;
+        stats.forwardTime = renderer._forwardTime;
+        const prims = device._primsPerFrame;
+        stats.triangles = prims[PRIMITIVE_TRIANGLES] / 3 +
+            Math.max(prims[PRIMITIVE_TRISTRIP] - 2, 0) +
+            Math.max(prims[PRIMITIVE_TRIFAN] - 2, 0);
+        stats.cullTime = renderer._cullTime;
+        stats.sortTime = renderer._sortTime;
+        stats.skinTime = renderer._skinTime;
+        stats.morphTime = renderer._morphTime;
+        stats.lightClusters = renderer._lightClusters;
+        stats.lightClustersTime = renderer._lightClustersTime;
+        stats.otherPrimitives = 0;
+        for (let i = 0; i < prims.length; i++) {
+            if (i < PRIMITIVE_TRIANGLES) {
+                stats.otherPrimitives += prims[i];
+            }
+            prims[i] = 0;
+        }
+        renderer._camerasRendered = 0;
+        renderer._materialSwitches = 0;
+        renderer._shadowMapUpdates = 0;
+        device._shaderSwitchesPerFrame = 0;
+        renderer._cullTime = 0;
+        renderer._layerCompositionUpdateTime = 0;
+        renderer._lightClustersTime = 0;
+        renderer._sortTime = 0;
+        renderer._skinTime = 0;
+        renderer._morphTime = 0;
+        renderer._shadowMapTime = 0;
+        renderer._depthMapTime = 0;
+        renderer._forwardTime = 0;
+
+        // Draw call stats
+        stats = this.drawCalls;
+        stats.forward = renderer._forwardDrawCalls;
+        stats.culled = renderer._numDrawCallsCulled;
+        stats.depth = 0;
+        stats.shadow = renderer._shadowDrawCalls;
+        stats.skinned = renderer._skinDrawCalls;
+        stats.immediate = 0;
+        stats.instanced = 0;
+        stats.removedByInstancing = 0;
+        stats.misc = stats.total - (stats.forward + stats.shadow);
+        renderer._depthDrawCalls = 0;
+        renderer._shadowDrawCalls = 0;
+        renderer._forwardDrawCalls = 0;
+        renderer._numDrawCallsCulled = 0;
+        renderer._skinDrawCalls = 0;
+        renderer._immediateRendered = 0;
+        renderer._instancedDrawCalls = 0;
+
+        this.misc.renderTargetCreationTime = device.renderTargetCreationTime;
+
+        stats = this.particles;
+        stats.updatesPerFrame = stats._updatesPerFrame;
+        stats.frameTime = stats._frameTime;
+        stats._updatesPerFrame = 0;
+        stats._frameTime = 0;
     }
 
     /**


### PR DESCRIPTION
## Summary

Relocates the two private per-frame stats collection methods from `AppBase` onto `ApplicationStats`, where the counters they populate already live. This is the first of several small, targeted refactors to break up `app-base.js` (currently ~2k lines, mixing ~10 distinct responsibilities).

- Moves `_fillFrameStatsBasic` and `_fillFrameStats` (~100 lines) out of `src/framework/app-base.js` and into `src/framework/stats.js` as `ApplicationStats.updateBasic()` and `ApplicationStats.updateDetailed()`.
- `AppBase.tick` now calls `this.stats.updateBasic(currentTime, dt, ms, this.renderer, this.graphicsDevice)` and `this.stats.updateDetailed(this.renderer, this.graphicsDevice)`, passing the renderer and graphics device as explicit dependencies rather than the callees reaching back through `this`.
- `PRIMITIVE_TRIANGLES`/`PRIMITIVE_TRIFAN`/`PRIMITIVE_TRISTRIP` imports move to `stats.js` along with the detailed update body.

## Public API

No changes. The stats object shape (`app.stats.frame.*`, `app.stats.drawCalls.*`, `app.stats.particles.*`, `app.stats.misc.*`) is identical. External consumers such as `mini-stats` continue to work without modification. Both new methods are marked `@ignore`, matching the visibility of the originals.

## File size impact

- `src/framework/app-base.js`: 2086 -> 1986 lines (-100)
- `src/framework/stats.js`: 133 -> 244 lines (+111)

## Test plan

- [x] `npm run lint` - clean (0 errors, 1 unrelated pre-existing warning in `utils/rollup-build-target.mjs`)
- [x] `npm run build:types` - types regenerate without errors
- [x] `npm run test:types` - passes
- [x] `npm test` - 1652 passing, 0 failing (2 pre-existing pending)
- [x] Spot-check `mini-stats` example in a local build to confirm frame stats still populate correctly
