### PR TITLE
refactor: remove dead `this.controller` references from AppBase and hide Controller class

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1052,9 +1052,6 @@ class AppBase extends EventHandler {
      * @private
      */
     inputUpdate(dt) {
-        if (this.controller) {
-            this.controller.update(dt);
-        }
         if (this.mouse) {
             this.mouse.update();
         }
@@ -1863,10 +1860,6 @@ class AppBase extends EventHandler {
         if (this.gamepads) {
             this.gamepads.destroy();
             this.gamepads = null;
-        }
-
-        if (this.controller) {
-            this.controller = null;
         }
 
         this.systems.destroy();

--- a/src/platform/input/controller.js
+++ b/src/platform/input/controller.js
@@ -14,7 +14,7 @@ import { Mouse } from './mouse.js';
  * A general input handler which handles both mouse and keyboard input assigned to named actions.
  * This allows you to define input handlers separately to defining keyboard/mouse configurations.
  *
- * @category Input
+ * @ignore
  */
 class Controller {
     /**


### PR DESCRIPTION
## Summary

- Remove the two dead `if (this.controller) { ... }` blocks from `AppBase.inputUpdate` and `AppBase.destroy`. Workspace-wide grep (engine + editor + supersplat + react + web-components and the other first-party repos) turns up zero places that ever set, declare, subclass-override, or read `app.controller`, so both guards are permanently false.
- Hide the orphaned `Controller` class (`src/platform/input/controller.js`) from the public API reference by swapping `@category Input` for `@ignore` on its class-level JSDoc. No engine code constructs one, no `AppOptions` wires one in, and no component uses it.
- The runtime export (`export { Controller }` and the re-export via `src/index.js`) is kept, so any existing user code that does `new pc.Controller(...)` keeps working. Only the documentation surface changes.
- The Controller-only constants (`ACTION_*`, `AXIS_*`) in `src/platform/input/constants.js` are left untouched: they're bare `export const` declarations with no JSDoc, and `typedoc.json` has `"excludeNotDocumented": true`, so typedoc already omits them.

Net diff: `+1 / -8` across two files.

## Test plan

- [x] `npm run lint` (clean; only a pre-existing unused-disable-directive warning)
- [x] `npm run build:types` (succeeds; `Controller` still emitted in `build/playcanvas.d.ts`)
- [x] `npm test` (1652 passing, 2 pending, 0 failing)
- [x] Spot-check next API-reference build: `Controller` no longer listed in the Input category or elsewhere.
