### PR TITLE
feat: expose device.minSubgroupSize and device.maxSubgroupSize on GraphicsDevice

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -283,6 +283,15 @@ class GraphicsDevice extends EventHandler {
     supportsSubgroupId = false;
 
     /**
+     * Maximum subgroup (warp/wavefront) size supported by the device. Zero if subgroups are
+     * not supported. Used internally to gate algorithms that assume a specific subgroup size.
+     *
+     * @type {number}
+     * @ignore
+     */
+    maxSubgroupSize = 0;
+
+    /**
      * Currently active render target.
      *
      * @type {RenderTarget|null}

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -292,6 +292,18 @@ class GraphicsDevice extends EventHandler {
     maxSubgroupSize = 0;
 
     /**
+     * Minimum subgroup (warp/wavefront) size supported by the device. Zero if subgroups are
+     * not supported. On hardware where min and max differ, the WGSL `subgroup_size` builtin
+     * may report any value in `[minSubgroupSize, maxSubgroupSize]`; shaders sizing shared
+     * memory by the number of subgroups in a workgroup should use the minimum to cover the
+     * worst-case subgroup count.
+     *
+     * @type {number}
+     * @ignore
+     */
+    minSubgroupSize = 0;
+
+    /**
      * Currently active render target.
      *
      * @type {RenderTarget|null}

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -329,6 +329,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsPrimitiveIndex = requireFeature('primitive-index');
         this.supportsSubgroups = requireFeature('subgroups');
         this.maxSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.limits?.maxSubgroupSize ?? 0) : 0;
+        this.minSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.limits?.minSubgroupSize ?? 0) : 0;
         Debug.log(
             `WEBGPU${this.gpuAdapter?.info ?
                 ` (${this.gpuAdapter.info.vendor || '?'} / ${this.gpuAdapter.info.architecture || this.gpuAdapter.info.device || '?'})` :

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -328,6 +328,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsTextureFormatTier1 ||= this.supportsTextureFormatTier2;
         this.supportsPrimitiveIndex = requireFeature('primitive-index');
         this.supportsSubgroups = requireFeature('subgroups');
+        this.maxSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.limits?.maxSubgroupSize ?? 0) : 0;
         Debug.log(
             `WEBGPU${this.gpuAdapter?.info ?
                 ` (${this.gpuAdapter.info.vendor || '?'} / ${this.gpuAdapter.info.architecture || this.gpuAdapter.info.device || '?'})` :


### PR DESCRIPTION
## Summary

- Add new `GraphicsDevice.minSubgroupSize` and `GraphicsDevice.maxSubgroupSize` fields, populated by `WebgpuGraphicsDevice` from the adapter's corresponding limits. Both are `0` when subgroups are unsupported.
- Lands ahead of two upcoming feature PRs (GSplat tile radix sort, global WebGPU radix sort) that both need subgroup-size info for shared-memory sizing and for gating subgroup-based algorithms. Keeping it standalone so both PRs can rebase onto it cleanly.

## Why both bounds

On hardware where the subgroup size can vary at runtime (e.g. Intel, some Apple/Qualcomm), the WGSL `subgroup_size` builtin may report any value in `[minSubgroupSize, maxSubgroupSize]`. Shaders that size workgroup shared memory by the number of subgroups in a workgroup need the minimum (smaller subgroups → more of them → worst case), whereas code gating a specific subgroup-size assumption typically wants the maximum.

## Public API changes

Two new public fields on `GraphicsDevice`:

```js
/** @type {number} */
device.minSubgroupSize;

/** @type {number} */
device.maxSubgroupSize;
```

Both tagged `@ignore` for now — the only consumers are engine-internal compute algorithms.

## Test plan

- [ ] Verify both fields are populated correctly on WebGPU (Chrome + Safari)
- [ ] Verify both are `0` on WebGL and on WebGPU adapters without subgroup support