### PR TITLE
feat: radix sort facade, indirect mode, and WebGPU subgroup sizing

### DIFF
--- a/examples/src/examples/test/radix-sort-compute.example.mjs
+++ b/examples/src/examples/test/radix-sort-compute.example.mjs
@@ -137,25 +137,25 @@ let needsRegen = true;
 
 // Valid radix modes. After benchmarking across NVIDIA / Apple / Mali / IMG
 // the surviving variants are:
-//   - '4-shared-mem': the universal portable multi-pass fallback
-//     (ComputeRadixSort), subgroup-free, shipped as the production
-//     default on every non-NVIDIA device.
+//   - '4-shared-mem': the universal portable fallback
+//     (ComputeRadixSort with kind=RADIX_SORT_PORTABLE), subgroup-free,
+//     shipped as the production default on every non-NVIDIA device.
 //   - 'onesweep': the fused single-sweep implementation
-//     (ComputeOneSweepRadixSort). Fastest on NVIDIA; unstable on Mali
-//     (validates incorrectly) and Apple (GPU hangs under heavy validation
-//     load), so it is selectable manually but restricted to NVIDIA in the
-//     benchmark / validation sweeps.
+//     (ComputeRadixSort with kind=RADIX_SORT_ONESWEEP). Fastest on NVIDIA;
+//     unstable on Mali (validates incorrectly) and Apple (GPU hangs under
+//     heavy validation load), so it is selectable manually but restricted
+//     to NVIDIA in the benchmark / validation sweeps.
 const RADIX_MODES = {
-    '4-shared-mem': { },
-    'onesweep': { onesweep: true }
+    '4-shared-mem': { kind: pc.RADIX_SORT_PORTABLE },
+    'onesweep': { kind: pc.RADIX_SORT_ONESWEEP }
 };
 const DEFAULT_MODE = '4-shared-mem';
 
-// Lazy cache of ComputeRadixSort / ComputeOneSweepRadixSort instances, keyed
-// by the mode dropdown. Instances are created on first use and retained, so
-// subsequent toggles between configurations are free (no shader rebuild).
-// Each instance grows its internal buffers on demand.
-/** @type {Map<string, pc.ComputeRadixSort | pc.ComputeOneSweepRadixSort>} */
+// Lazy cache of ComputeRadixSort instances, keyed by the mode dropdown.
+// Instances are created on first use and retained, so subsequent toggles
+// between configurations are free (no shader rebuild). Each instance grows
+// its internal buffers on demand.
+/** @type {Map<string, pc.ComputeRadixSort>} */
 const radixSortCache = new Map();
 
 /**
@@ -163,17 +163,14 @@ const radixSortCache = new Map();
  * selection. Falls back to safe defaults if the observer value is not yet
  * populated.
  *
- * @returns {pc.ComputeRadixSort | pc.ComputeOneSweepRadixSort} The active
- * radix sort instance.
+ * @returns {pc.ComputeRadixSort} The active radix sort instance.
  */
 function getActiveRadixSort() {
     const mode = data.get('options.mode') ?? DEFAULT_MODE;
     const modeCfg = RADIX_MODES[mode] ?? RADIX_MODES[DEFAULT_MODE];
     let inst = radixSortCache.get(mode);
     if (!inst) {
-        inst = modeCfg.onesweep ?
-            new pc.ComputeOneSweepRadixSort(device) :
-            new pc.ComputeRadixSort(device);
+        inst = new pc.ComputeRadixSort(device, { kind: modeCfg.kind });
         radixSortCache.set(mode, inst);
     }
     return inst;
@@ -607,7 +604,7 @@ const BENCH_EXCLUDED_PASSES = new Set(['Forward']);
  *     frame: number,
  *     frameTimes: number[],
  *     passAccum: Map<string, number[]>,
- *     sortInst: pc.ComputeRadixSort | pc.ComputeOneSweepRadixSort | null,
+ *     sortInst: pc.ComputeRadixSort | null,
  *     keysBuf: pc.StorageBuffer | null,
  *     results: {size: number, configLabel: string, frameMs: number, passMs: Map<string, number>}[],
  *     saved: {elementsK: any, bits: any, mode: any, render: any, validation: any, profilerEnabled: boolean}
@@ -633,13 +630,11 @@ function fmtN(n) {
  * interactive UI state.
  *
  * @param {string} modeKey - Entry key into RADIX_MODES.
- * @returns {pc.ComputeRadixSort | pc.ComputeOneSweepRadixSort} Sort instance.
+ * @returns {pc.ComputeRadixSort} Sort instance.
  */
 function createBenchSort(modeKey) {
     const modeCfg = RADIX_MODES[modeKey];
-    return modeCfg.onesweep ?
-        new pc.ComputeOneSweepRadixSort(device) :
-        new pc.ComputeRadixSort(device);
+    return new pc.ComputeRadixSort(device, { kind: modeCfg.kind });
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -177,8 +177,7 @@ export { Animation, AnimationKey, AnimationNode } from './scene/animation/animat
 export { Skeleton } from './scene/animation/skeleton.js';
 
 // SCENE / GRAPHICS
-export { ComputeRadixSort } from './scene/graphics/compute-radix-sort.js';
-export { ComputeOneSweepRadixSort } from './scene/graphics/compute-onesweep-radix-sort.js';
+export { ComputeRadixSort } from './scene/graphics/radix-sort/compute-radix-sort.js';
 export { EnvLighting } from './scene/graphics/env-lighting.js';
 export { PostEffect } from './scene/graphics/post-effect.js';
 export { FramePass } from './platform/graphics/frame-pass.js';

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -296,8 +296,9 @@ class GraphicsDevice extends EventHandler {
     supportsLinearIndexing = false;
 
     /**
-     * Maximum subgroup (warp/wavefront) size supported by the device. Zero if subgroups are
-     * not supported. Used internally to gate algorithms that assume a specific subgroup size.
+     * Maximum subgroup (warp/wavefront) size reported for the device. Zero means either
+     * subgroups are not supported ({@link supportsSubgroups} is false), or the WebGPU
+     * implementation did not expose the value.
      *
      * @type {number}
      * @ignore
@@ -305,11 +306,9 @@ class GraphicsDevice extends EventHandler {
     maxSubgroupSize = 0;
 
     /**
-     * Minimum subgroup (warp/wavefront) size supported by the device. Zero if subgroups are
-     * not supported. On hardware where min and max differ, the WGSL `subgroup_size` builtin
-     * may report any value in `[minSubgroupSize, maxSubgroupSize]`; shaders sizing shared
-     * memory by the number of subgroups in a workgroup should use the minimum to cover the
-     * worst-case subgroup count.
+     * Minimum subgroup (warp/wavefront) size reported for the device. Zero means either
+     * subgroups are not supported ({@link supportsSubgroups} is false), or the WebGPU
+     * implementation did not expose the value.
      *
      * @type {number}
      * @ignore

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -328,8 +328,8 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsTextureFormatTier1 ||= this.supportsTextureFormatTier2;
         this.supportsPrimitiveIndex = requireFeature('primitive-index');
         this.supportsSubgroups = requireFeature('subgroups');
-        this.maxSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.limits?.maxSubgroupSize ?? 0) : 0;
-        this.minSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.limits?.minSubgroupSize ?? 0) : 0;
+        this.maxSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.info?.subgroupMaxSize ?? 0) : 0;
+        this.minSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.info?.subgroupMinSize ?? 0) : 0;
         Debug.log(
             `WEBGPU${this.gpuAdapter?.info ?
                 ` (${this.gpuAdapter.info.vendor || '?'} / ${this.gpuAdapter.info.architecture || this.gpuAdapter.info.device || '?'})` :

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1292,3 +1292,33 @@ export const GSPLAT_DEBUG_AABBS = 4;
  * @category Graphics
  */
 export const GSPLAT_DEBUG_NODE_AABBS = 5;
+
+/**
+ * Automatically selects the best radix sort backend for the current WebGPU device:
+ * OneSweep on supported hardware (NVIDIA), the portable backend elsewhere. See
+ * {@link ComputeRadixSort}.
+ *
+ * @type {number}
+ * @category Graphics
+ */
+export const RADIX_SORT_AUTO = 0;
+
+/**
+ * Portable radix sort backend. Runs on every WebGPU device (no subgroup
+ * intrinsics required) and is chosen by {@link RADIX_SORT_AUTO} when no
+ * faster hardware-specific backend is available. See {@link ComputeRadixSort}.
+ *
+ * @type {number}
+ * @category Graphics
+ */
+export const RADIX_SORT_PORTABLE = 1;
+
+/**
+ * Single-sweep 8-bit radix sort (OneSweep). Requires subgroup support, 32-lane
+ * subgroups, and forward-thread-progress guarantees — currently enabled only on
+ * NVIDIA. See {@link ComputeRadixSort}.
+ *
+ * @type {number}
+ * @category Graphics
+ */
+export const RADIX_SORT_ONESWEEP = 2;

--- a/src/scene/graphics/radix-sort/compute-radix-sort-base.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-base.js
@@ -1,0 +1,276 @@
+import { Debug } from '../../../core/debug.js';
+import { BUFFERUSAGE_COPY_DST, BUFFERUSAGE_COPY_SRC } from '../../../platform/graphics/constants.js';
+import { StorageBuffer } from '../../../platform/graphics/storage-buffer.js';
+
+/**
+ * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
+ */
+
+/**
+ * Abstract base class for the compute radix sort backends ({@link ComputeRadixSortMultipass}
+ * and {@link ComputeRadixSortOneSweep}). Not intended for direct use; always accessed via the
+ * {@link ComputeRadixSort} facade.
+ *
+ * Backends share the same public `sort` / `sortIndirect` / `prepareIndirect` API so the facade
+ * can forward calls without inspecting the concrete implementation.
+ *
+ * @category Graphics
+ * @ignore
+ */
+class ComputeRadixSortBase {
+    /**
+     * The graphics device.
+     *
+     * @type {GraphicsDevice}
+     */
+    device;
+
+    /**
+     * Whether this sorter instance was created for indirect-dispatch use only. When `true`,
+     * only indirect-mode shaders are compiled and {@link sort} is unavailable.
+     *
+     * @type {boolean}
+     */
+    _indirect = false;
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {boolean} [indirect] - Whether the instance is for indirect dispatch only.
+     */
+    constructor(device, indirect = false) {
+        this.device = device;
+        this._indirect = indirect;
+    }
+
+    /**
+     * Minimum element capacity for internal buffers. Set by the caller as a high-water mark to
+     * avoid reallocation churn when the workload shrinks; can be lowered to request shrinkage at
+     * the next sort call. Concrete backends size allocations using max(element count for the sort,
+     * `capacity`); reallocation is deferred until the next sort when that effective size changes.
+     * Updated by implementations after allocation.
+     *
+     * @type {number}
+     */
+    capacity = 0;
+
+    /**
+     * Current element count for the last or in-progress sort.
+     *
+     * @type {number}
+     * @protected
+     */
+    _elementCount = 0;
+
+    /**
+     * Number of key bits the current passes are built for.
+     *
+     * @type {number}
+     * @protected
+     */
+    _numBits = 0;
+
+    /**
+     * Whether the current sort uses caller-supplied initial values on pass 0.
+     *
+     * @type {boolean}
+     * @protected
+     */
+    _hasInitialValues = false;
+
+    /**
+     * When true, the last pass skips writing sorted keys (values only); {@link sortedKeys} may be stale.
+     *
+     * @type {boolean}
+     * @protected
+     */
+    _skipLastPassKeyWrite = false;
+
+    /**
+     * Internal keys buffer 0 (ping-pong).
+     *
+     * @type {StorageBuffer|null}
+     * @protected
+     */
+    _keys0 = null;
+
+    /**
+     * Internal keys buffer 1 (ping-pong).
+     *
+     * @type {StorageBuffer|null}
+     * @protected
+     */
+    _keys1 = null;
+
+    /**
+     * Internal values/indices buffer 0 (ping-pong).
+     *
+     * @type {StorageBuffer|null}
+     * @protected
+     */
+    _values0 = null;
+
+    /**
+     * Internal values/indices buffer 1 (ping-pong).
+     *
+     * @type {StorageBuffer|null}
+     * @protected
+     */
+    _values1 = null;
+
+    /**
+     * Output sorted indices (or caller values) buffer.
+     *
+     * @type {StorageBuffer|null}
+     * @protected
+     */
+    _sortedIndices = null;
+
+    /**
+     * Stable metadata buffer returned by {@link prepareIndirect}. Preallocated as four `u32`
+     * entries; concrete backends assign `[slotCount, g0, g1, g2]` after `super(device)`. The caller
+     * uploads its contents into a GPU uniform unchanged.
+     *
+     * @type {Uint32Array}
+     * @protected
+     */
+    _indirectInfo = new Uint32Array(4);
+
+    /**
+     * Returns the sorted indices (or values, when `initialValues` was passed) buffer of the last
+     * completed sort.
+     *
+     * @type {StorageBuffer|null}
+     */
+    get sortedIndices() {
+        return this._sortedIndices;
+    }
+
+    /**
+     * Returns the sorted keys buffer after the last sort. Keys live in one of the internal
+     * ping-pong buffers depending on pass count and {@link radixBits}.
+     *
+     * @type {StorageBuffer|null}
+     */
+    get sortedKeys() {
+        if (!this._keys0) {
+            return null;
+        }
+        const radix = this.radixBits;
+        const numPasses = this._numBits / radix;
+        return (numPasses % 2 === 0) ? this._keys1 : this._keys0;
+    }
+
+    /**
+     * Radix width in bits for this backend. Callers can align their key bit counts to the radix
+     * boundary generically without knowing which backend is active.
+     *
+     * @type {number}
+     * @abstract
+     */
+    get radixBits() {
+        Debug.error('ComputeRadixSortBase.radixBits must be implemented by a subclass');
+        return 0;
+    }
+
+    /**
+     * Executes a direct-dispatch radix sort. See subclass docs for argument semantics.
+     *
+     * @param {StorageBuffer} keysBuffer - Input keys buffer.
+     * @param {number} elementCount - Number of elements to sort.
+     * @param {number} [numBits] - Number of bits to sort.
+     * @param {StorageBuffer} [initialValues] - Optional initial values buffer for pass 0.
+     * @param {boolean} [skipLastPassKeyWrite] - Skip writing keys on the last pass.
+     * @returns {StorageBuffer} Sorted values buffer.
+     * @abstract
+     */
+    sort(keysBuffer, elementCount, numBits, initialValues, skipLastPassKeyWrite) {
+        Debug.error('ComputeRadixSortBase.sort must be implemented by a subclass');
+        return /** @type {any} */ (null);
+    }
+
+    /**
+     * Executes an indirect-dispatch radix sort using workgroup counts pre-written into
+     * `device.indirectDispatchBuffer` (typically by a shader that included the
+     * `sortIndirectArgsCS` WGSL chunk). See subclass docs for argument semantics.
+     *
+     * @param {StorageBuffer} keysBuffer - Input keys buffer.
+     * @param {number} maxElementCount - Maximum elements (allocation size).
+     * @param {number} numBits - Number of bits to sort.
+     * @param {number} sortSlotBase - Base indirect dispatch slot index. The backend uses
+     * `slotCount` consecutive slots starting at this index; see {@link prepareIndirect}.
+     * @param {StorageBuffer} sortElementCountBuffer - GPU-written element count buffer.
+     * @param {StorageBuffer} [initialValues] - Optional initial values buffer for pass 0.
+     * @param {boolean} [skipLastPassKeyWrite] - Skip writing keys on the last pass.
+     * @returns {StorageBuffer} Sorted values buffer.
+     * @abstract
+     */
+    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite) {
+        Debug.error('ComputeRadixSortBase.sortIndirect must be implemented by a subclass');
+        return /** @type {any} */ (null);
+    }
+
+    /**
+     * Returns stable sort metadata describing how many indirect dispatch slots this backend uses
+     * and the elements-per-workgroup granularity of each slot. The returned 4-element Uint32
+     * array is sorter-owned and never reallocated across calls, so it can be uploaded directly as
+     * a uniform `vec4<u32>` and reused as the `slotInfo` argument to the `writeSortIndirectArgs`
+     * WGSL helper (see `sortIndirectArgsCS` chunk):
+     *
+     * ```
+     * [slotCount, g0, g1, g2]   // g_i = elements-per-workgroup for slot i; unused entries = 0
+     * ```
+     *
+     * The caller must reserve `slotCount` consecutive slots in `device.indirectDispatchBuffer`
+     * via {@link GraphicsDevice#getIndirectDispatchSlot} and pass the resulting base to
+     * {@link sortIndirect}.
+     *
+     * @returns {Uint32Array} Sorter-owned 4-element Uint32 array (stable across calls).
+     */
+    prepareIndirect() {
+        return this._indirectInfo;
+    }
+
+    /**
+     * Allocates ping-pong key/value buffers and the sorted output buffer (`u32` per element).
+     *
+     * @param {number} effectiveCount - Element high-water count (same units as `capacity` sizing).
+     * @protected
+     */
+    _allocatePingPongElementBuffers(effectiveCount) {
+        const elementSize = effectiveCount * 4;
+        const usage = BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST;
+        const device = this.device;
+        this._keys0 = new StorageBuffer(device, elementSize, usage);
+        this._keys1 = new StorageBuffer(device, elementSize, usage);
+        this._values0 = new StorageBuffer(device, elementSize, usage);
+        this._values1 = new StorageBuffer(device, elementSize, usage);
+        this._sortedIndices = new StorageBuffer(device, elementSize, usage);
+    }
+
+    /**
+     * Destroys ping-pong keys/values and sorted output buffers owned by the base.
+     *
+     * @protected
+     */
+    _destroyPingPongBuffers() {
+        this._keys0?.destroy();
+        this._keys1?.destroy();
+        this._values0?.destroy();
+        this._values1?.destroy();
+        this._sortedIndices?.destroy();
+
+        this._keys0 = null;
+        this._keys1 = null;
+        this._values0 = null;
+        this._values1 = null;
+        this._sortedIndices = null;
+    }
+
+    /**
+     * Releases resources owned by this backend.
+     */
+    destroy() {
+    }
+}
+
+export { ComputeRadixSortBase };

--- a/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
@@ -1,17 +1,18 @@
-import { Debug } from '../../core/debug.js';
-import { Vec2 } from '../../core/math/vec2.js';
-import { Compute } from '../../platform/graphics/compute.js';
-import { Shader } from '../../platform/graphics/shader.js';
-import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
-import { BindGroupFormat, BindStorageBufferFormat, BindUniformBufferFormat } from '../../platform/graphics/bind-group-format.js';
-import { UniformBufferFormat, UniformFormat } from '../../platform/graphics/uniform-buffer-format.js';
-import { BUFFERUSAGE_COPY_SRC, BUFFERUSAGE_COPY_DST, SHADERLANGUAGE_WGSL, SHADERSTAGE_COMPUTE, UNIFORMTYPE_UINT } from '../../platform/graphics/constants.js';
-import { PrefixSumKernel } from './prefix-sum-kernel.js';
-import { radixSort4bitSource } from '../shader-lib/wgsl/chunks/radix-sort/compute-radix-sort-4bit.js';
-import { radixSortReorderSource } from '../shader-lib/wgsl/chunks/radix-sort/compute-radix-sort-reorder.js';
+import { Debug } from '../../../core/debug.js';
+import { Vec2 } from '../../../core/math/vec2.js';
+import { Compute } from '../../../platform/graphics/compute.js';
+import { Shader } from '../../../platform/graphics/shader.js';
+import { StorageBuffer } from '../../../platform/graphics/storage-buffer.js';
+import { BindGroupFormat, BindStorageBufferFormat, BindUniformBufferFormat } from '../../../platform/graphics/bind-group-format.js';
+import { UniformBufferFormat, UniformFormat } from '../../../platform/graphics/uniform-buffer-format.js';
+import { BUFFERUSAGE_COPY_SRC, BUFFERUSAGE_COPY_DST, SHADERLANGUAGE_WGSL, SHADERSTAGE_COMPUTE, UNIFORMTYPE_UINT } from '../../../platform/graphics/constants.js';
+import { PrefixSumKernel } from '../prefix-sum-kernel.js';
+import { radixSort4bitSource } from '../../shader-lib/wgsl/chunks/radix-sort/compute-radix-sort-4bit.js';
+import { radixSortReorderSource } from '../../shader-lib/wgsl/chunks/radix-sort/compute-radix-sort-reorder.js';
+import { ComputeRadixSortBase } from './compute-radix-sort-base.js';
 
 /**
- * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
  */
 
 // Workgroup / batching constants. The reorder shader processes ELEMENTS_PER_THREAD
@@ -31,9 +32,9 @@ const BITS_PER_PASS = 4;
 const BUCKET_COUNT = 16; // 2 ** BITS_PER_PASS
 
 /**
- * A compute-based GPU radix sort implementation using a 4-bit radix (16 buckets).
- * Provides stable sorting of 32-bit unsigned integer keys, returning sorted
- * indices. WebGPU only.
+ * Portable multi-pass 4-bit radix sort implementation (16 buckets per pass). Provides
+ * stable sorting of 32-bit unsigned integer keys and returns sorted indices or
+ * caller-supplied values. WebGPU only.
  *
  * **Performance characteristics:**
  * - 4 passes for 16-bit keys, 8 passes for 32-bit keys
@@ -54,38 +55,20 @@ const BUCKET_COUNT = 16; // 2 ** BITS_PER_PASS
  * following [WebGPU-Radix-Sort](https://github.com/kishimisu/WebGPU-Radix-Sort)
  * by kishimisu (MIT License).
  *
- * @example
- * // Create the radix sort instance (reusable)
- * const radixSort = new ComputeRadixSort(device);
+ * Selected as the portable fallback across all non-subgroup and non-NVIDIA
+ * devices after benchmarking wider radixes (6-bit, 8-bit shared, 8-bit
+ * subgroup variants, OneSweep) on Apple M1/M2/M4, NVIDIA, and Android Mali/
+ * IMG — 4-bit is the single most consistent winner or close-second in every
+ * target range.
  *
- * // Create a storage buffer with keys to sort
- * const keys = new Uint32Array([5, 2, 8, 1, 9, 3]);
- * const keysBuffer = new StorageBuffer(device, keys.byteLength, BUFFERUSAGE_COPY_DST);
- * keysBuffer.write(keys);
- *
- * // Sort and get indices buffer (keys with values [5,2,8,1,9,3] → indices [3,1,5,0,2,4])
- * const sortedIndices = radixSort.sort(keysBuffer, keys.length, 16); // 16-bit sort
- *
- * // Use sortedIndices buffer in subsequent GPU operations
- * // Clean up when done
- * radixSort.destroy();
+ * Not exported as a public class; always accessed through the
+ * {@link ComputeRadixSort} facade with `kind: RADIX_SORT_PORTABLE` or
+ * `RADIX_SORT_AUTO`.
  *
  * @category Graphics
  * @ignore
  */
-class ComputeRadixSort {
-    /**
-     * The graphics device.
-     *
-     * @type {GraphicsDevice}
-     */
-    device;
-
-    /**
-     * Current element count.
-     */
-    _elementCount = 0;
-
+class ComputeRadixSortMultipass extends ComputeRadixSortBase {
     /**
      * Number of workgroups actually dispatched for the current sort.
      * Derived from `elementCount` (not `capacity`) so that smaller sorts issue
@@ -101,59 +84,11 @@ class ComputeRadixSort {
     _allocatedWorkgroupCount = 0;
 
     /**
-     * Minimum element capacity for internal buffers. When set, `_allocateBuffers` uses
-     * `max(elementCount, capacity)` as the effective size. The caller can lower this value
-     * to request shrinkage; actual reallocation is deferred to the next sort call.
-     * After allocation, this is updated to reflect the effective element count.
-     */
-    capacity = 0;
-
-    /**
-     * Current number of bits for which passes are created.
-     */
-    _numBits = 0;
-
-    /**
-     * Internal keys buffer 0 (ping-pong).
-     *
-     * @type {StorageBuffer|null}
-     */
-    _keys0 = null;
-
-    /**
-     * Internal keys buffer 1 (ping-pong).
-     *
-     * @type {StorageBuffer|null}
-     */
-    _keys1 = null;
-
-    /**
-     * Internal values/indices buffer 0 (ping-pong).
-     *
-     * @type {StorageBuffer|null}
-     */
-    _values0 = null;
-
-    /**
-     * Internal values/indices buffer 1 (ping-pong).
-     *
-     * @type {StorageBuffer|null}
-     */
-    _values1 = null;
-
-    /**
      * Block sums buffer (BUCKET_COUNT entries per workgroup).
      *
      * @type {StorageBuffer|null}
      */
     _blockSums = null;
-
-    /**
-     * Output sorted indices buffer.
-     *
-     * @type {StorageBuffer|null}
-     */
-    _sortedIndices = null;
 
     /**
      * Prefix sum kernel for block sums (hierarchical Blelloch scan).
@@ -196,140 +131,22 @@ class ComputeRadixSort {
     _passes = [];
 
     /**
-     * Whether the current passes are for indirect sort mode.
-     */
-    _indirect = false;
-
-    /**
-     * Whether the current passes expect caller-supplied initial values on pass 0.
-     */
-    _hasInitialValues = false;
-
-    /**
-     * Whether the last pass skips writing sorted keys (only values are written).
-     * When true, `sortedKeys` will contain stale data after sorting.
-     */
-    _skipLastPassKeyWrite = false;
-
-    /**
-     * Creates a new ComputeRadixSort instance.
-     *
      * @param {GraphicsDevice} device - The graphics device (must support compute).
+     * @param {boolean} [indirect] - Whether this instance is for indirect dispatch only.
      */
-    constructor(device) {
-        Debug.assert(device.supportsCompute, 'ComputeRadixSort requires compute shader support (WebGPU)');
-        this.device = device;
+    constructor(device, indirect = false) {
+        super(device, indirect);
+        // prepareIndirect: one slot, multipass reorder/histogram granularity.
+        const info = this._indirectInfo;
+        info[0] = 1;
+        info[1] = ELEMENTS_PER_WORKGROUP;
 
-        // Create uniform buffer format (shared by both direct and indirect modes)
+        Debug.assert(device.supportsCompute, 'ComputeRadixSortMultipass requires compute shader support (WebGPU)');
+
         this._uniformBufferFormat = new UniformBufferFormat(device, [
             new UniformFormat('workgroupCount', UNIFORMTYPE_UINT),
             new UniformFormat('elementCount', UNIFORMTYPE_UINT)
         ]);
-    }
-
-    /**
-     * Destroys the ComputeRadixSort instance and releases all resources.
-     */
-    destroy() {
-        this._destroyBuffers();
-        this._destroyPasses();
-
-        this._histogramBindGroupFormat?.destroy();
-        this._reorderBindGroupFormat?.destroy();
-
-        this._histogramBindGroupFormat = null;
-        this._reorderBindGroupFormat = null;
-        this._uniformBufferFormat = null;
-    }
-
-    /**
-     * Destroys all cached passes and their shaders.
-     *
-     * @private
-     */
-    _destroyPasses() {
-        for (const pass of this._passes) {
-            pass.histogramCompute.shader?.destroy();
-            pass.reorderCompute.shader?.destroy();
-        }
-        this._passes.length = 0;
-        this._numBits = 0;
-    }
-
-    /**
-     * Destroys internal buffers (not passes or bind group formats).
-     *
-     * @private
-     */
-    _destroyBuffers() {
-        this._keys0?.destroy();
-        this._keys1?.destroy();
-        this._values0?.destroy();
-        this._values1?.destroy();
-        this._blockSums?.destroy();
-        this._sortedIndices?.destroy();
-        this._prefixSumKernel?.destroy();
-
-        this._keys0 = null;
-        this._keys1 = null;
-        this._values0 = null;
-        this._values1 = null;
-        this._blockSums = null;
-        this._sortedIndices = null;
-        this._prefixSumKernel = null;
-        this._workgroupCount = 0;
-        this._allocatedWorkgroupCount = 0;
-    }
-
-    /**
-     * Gets the sorted indices (or values) buffer.
-     *
-     * @type {StorageBuffer|null}
-     */
-    get sortedIndices() {
-        return this._sortedIndices;
-    }
-
-    /**
-     * Gets the sorted keys buffer after the last sort operation. The keys end up
-     * in one of the internal ping-pong buffers depending on the number of passes.
-     *
-     * @type {StorageBuffer|null}
-     */
-    get sortedKeys() {
-        if (!this._keys0) return null;
-        const numPasses = this._numBits / BITS_PER_PASS;
-        return (numPasses % 2 === 0) ? this._keys1 : this._keys0;
-    }
-
-    /**
-     * Radix width in bits. Always 4 for this implementation. Exposed so
-     * callers can align key-bit counts to the radix boundary generically
-     * across sort backends.
-     *
-     * @type {number}
-     */
-    get radixBits() {
-        return BITS_PER_PASS;
-    }
-
-    /**
-     * Ensures bind group formats exist for the given mode. Destroys and recreates
-     * them if switching between direct and indirect modes.
-     *
-     * @param {boolean} indirect - Whether to create indirect sort formats.
-     * @private
-     */
-    _ensureBindGroupFormats(indirect) {
-        if (this._histogramBindGroupFormat && this._indirect === indirect) {
-            return;
-        }
-
-        // Destroy existing formats if switching mode
-        this._histogramBindGroupFormat?.destroy();
-        this._reorderBindGroupFormat?.destroy();
-
-        const device = this.device;
 
         const histogramEntries = [
             new BindStorageBufferFormat('input', SHADERSTAGE_COMPUTE, true),
@@ -356,28 +173,81 @@ class ComputeRadixSort {
     }
 
     /**
+     * Destroys the instance and releases all resources.
+     */
+    destroy() {
+        this._destroyBuffers();
+        this._destroyPasses();
+
+        this._histogramBindGroupFormat?.destroy();
+        this._reorderBindGroupFormat?.destroy();
+
+        this._histogramBindGroupFormat = null;
+        this._reorderBindGroupFormat = null;
+        this._uniformBufferFormat = null;
+
+        super.destroy();
+    }
+
+    /**
+     * Destroys all cached passes and their shaders.
+     *
+     * @private
+     */
+    _destroyPasses() {
+        for (const pass of this._passes) {
+            pass.histogramCompute.shader?.destroy();
+            pass.reorderCompute.shader?.destroy();
+        }
+        this._passes.length = 0;
+        this._numBits = 0;
+    }
+
+    /**
+     * Destroys internal buffers (not passes or bind group formats).
+     *
+     * @private
+     */
+    _destroyBuffers() {
+        this._destroyPingPongBuffers();
+        this._blockSums?.destroy();
+        this._prefixSumKernel?.destroy();
+
+        this._blockSums = null;
+        this._prefixSumKernel = null;
+        this._workgroupCount = 0;
+        this._allocatedWorkgroupCount = 0;
+    }
+
+    /**
+     * Radix width in bits. Always 4 for this implementation. Exposed so
+     * callers can align key-bit counts to the radix boundary generically
+     * across sort backends.
+     *
+     * @type {number}
+     */
+    get radixBits() {
+        return BITS_PER_PASS;
+    }
+
+    /**
      * Creates cached compute passes for all bit offsets.
      *
      * @param {number} numBits - Number of bits to sort.
-     * @param {boolean} indirect - Whether to create indirect sort passes.
      * @param {boolean} hasInitialValues - Whether pass 0 reads from caller-supplied initial values.
      * @param {boolean} skipLastPassKeyWrite - Whether the last pass skips writing keys.
      * @private
      */
-    _createPasses(numBits, indirect, hasInitialValues, skipLastPassKeyWrite) {
+    _createPasses(numBits, hasInitialValues, skipLastPassKeyWrite) {
         // Destroy old passes and their shaders
         this._destroyPasses();
         this._numBits = numBits;
 
-        // Ensure bind group formats match the requested mode (must happen before
-        // updating _indirect, since _ensureBindGroupFormats compares against it)
-        this._ensureBindGroupFormats(indirect);
-        this._indirect = indirect;
         this._hasInitialValues = hasInitialValues;
         this._skipLastPassKeyWrite = skipLastPassKeyWrite;
 
         const numPasses = numBits / BITS_PER_PASS;
-        const suffix = indirect ? '-Indirect' : '';
+        const suffix = this._indirect ? '-Indirect' : '';
 
         for (let pass = 0; pass < numPasses; pass++) {
             const bitOffset = pass * BITS_PER_PASS;
@@ -390,8 +260,7 @@ class ComputeRadixSort {
                 bitOffset,
                 false,
                 false,
-                this._histogramBindGroupFormat,
-                indirect
+                this._histogramBindGroupFormat
             );
 
             const reorderShader = this._createShader(
@@ -400,8 +269,7 @@ class ComputeRadixSort {
                 bitOffset,
                 isFirstPass,
                 isLastPass,
-                this._reorderBindGroupFormat,
-                indirect
+                this._reorderBindGroupFormat
             );
 
             const histogramCompute = new Compute(this.device, histogramShader, `RadixSort4bit-Histogram${suffix}-${bitOffset}`);
@@ -416,12 +284,11 @@ class ComputeRadixSort {
      *
      * @param {number} elementCount - Number of elements to sort.
      * @param {number} numBits - Number of bits to sort.
-     * @param {boolean} indirect - Whether passes should use indirect dispatch.
      * @param {boolean} hasInitialValues - Whether pass 0 reads caller-supplied initial values.
      * @param {boolean} skipLastPassKeyWrite - Whether the last pass skips writing keys.
      * @private
      */
-    _allocateBuffers(elementCount, numBits, indirect, hasInitialValues, skipLastPassKeyWrite) {
+    _allocateBuffers(elementCount, numBits, hasInitialValues, skipLastPassKeyWrite) {
         // Buffer sizing is driven by `capacity` (the high-water mark) to avoid
         // realloc churn when the workload shrinks. Dispatch and scan sizes
         // must track the CURRENT sort's elementCount - otherwise a 1M sort
@@ -434,8 +301,8 @@ class ComputeRadixSort {
 
         const buffersNeedRealloc = allocWorkgroupCount !== this._allocatedWorkgroupCount || !this._keys0;
 
-        // Recreate passes when numBits, indirect mode, initial-values mode, or key-write mode changes
-        const passesNeedRecreate = numBits !== this._numBits || indirect !== this._indirect ||
+        // Recreate passes when numBits, initial-values mode, or key-write mode changes
+        const passesNeedRecreate = numBits !== this._numBits ||
             hasInitialValues !== this._hasInitialValues || skipLastPassKeyWrite !== this._skipLastPassKeyWrite;
 
         if (buffersNeedRealloc) {
@@ -447,20 +314,12 @@ class ComputeRadixSort {
             this._allocatedWorkgroupCount = allocWorkgroupCount;
             this.capacity = effectiveCount;
 
-            const elementSize = effectiveCount * 4;
             const blockSumSize = BUCKET_COUNT * allocWorkgroupCount * 4;
 
-            // Create ping-pong buffers for keys and values
-            this._keys0 = new StorageBuffer(this.device, elementSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
-            this._keys1 = new StorageBuffer(this.device, elementSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
-            this._values0 = new StorageBuffer(this.device, elementSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
-            this._values1 = new StorageBuffer(this.device, elementSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
+            this._allocatePingPongElementBuffers(effectiveCount);
 
             // Create block sums buffer (BUCKET_COUNT entries per workgroup)
             this._blockSums = new StorageBuffer(this.device, blockSumSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
-
-            // Create output buffer
-            this._sortedIndices = new StorageBuffer(this.device, elementSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
 
             // Create prefix sum kernel (hierarchical Blelloch scan, exclusive).
             // The radix sort reorder shader requires an exclusive scan over
@@ -479,7 +338,7 @@ class ComputeRadixSort {
         this._prefixSumKernel.resize(this._blockSums, BUCKET_COUNT * currentWorkgroupCount);
 
         if (passesNeedRecreate) {
-            this._createPasses(numBits, indirect, hasInitialValues, skipLastPassKeyWrite);
+            this._createPasses(numBits, hasInitialValues, skipLastPassKeyWrite);
         }
     }
 
@@ -492,11 +351,10 @@ class ComputeRadixSort {
      * @param {boolean} isFirstPass - Whether this is the first pass (uses GID for indices).
      * @param {boolean} isLastPass - Whether this is the last pass and can skip writing keys.
      * @param {BindGroupFormat} bindGroupFormat - Bind group format.
-     * @param {boolean} indirect - Whether to add the USE_INDIRECT_SORT define.
      * @returns {Shader} The created shader.
      * @private
      */
-    _createShader(name, source, currentBit, isFirstPass, isLastPass, bindGroupFormat, indirect) {
+    _createShader(name, source, currentBit, isFirstPass, isLastPass, bindGroupFormat) {
         const cdefines = new Map();
         cdefines.set('{WORKGROUP_SIZE_X}', WORKGROUP_SIZE_X);
         cdefines.set('{WORKGROUP_SIZE_Y}', WORKGROUP_SIZE_Y);
@@ -505,7 +363,7 @@ class ComputeRadixSort {
         cdefines.set('{CURRENT_BIT}', currentBit);
         cdefines.set('{IS_FIRST_PASS}', isFirstPass ? 1 : 0);
         cdefines.set('{IS_LAST_PASS}', isLastPass ? 1 : 0);
-        if (indirect) {
+        if (this._indirect) {
             cdefines.set('USE_INDIRECT_SORT', '');
         }
 
@@ -534,11 +392,9 @@ class ComputeRadixSort {
      * initialValues was provided).
      */
     sort(keysBuffer, elementCount, numBits = 16, initialValues, skipLastPassKeyWrite = false) {
-        Debug.assert(keysBuffer, 'ComputeRadixSort.sort: keysBuffer is required');
-        Debug.assert(elementCount > 0, 'ComputeRadixSort.sort: elementCount must be > 0');
-        Debug.assert(numBits % BITS_PER_PASS === 0, `ComputeRadixSort.sort: numBits must be a multiple of ${BITS_PER_PASS}`);
+        Debug.assert(numBits % BITS_PER_PASS === 0, `ComputeRadixSortMultipass.sort: numBits must be a multiple of ${BITS_PER_PASS}`);
 
-        return this._execute(keysBuffer, elementCount, numBits, false, -1, null, initialValues, skipLastPassKeyWrite);
+        return this._execute(keysBuffer, elementCount, numBits, -1, null, initialValues, skipLastPassKeyWrite);
     }
 
     /**
@@ -548,7 +404,9 @@ class ComputeRadixSort {
      * @param {StorageBuffer} keysBuffer - Input storage buffer containing u32 keys.
      * @param {number} maxElementCount - Maximum number of elements (buffer allocation size).
      * @param {number} numBits - Number of bits to sort (must be multiple of 4).
-     * @param {number} dispatchSlot - Slot index in the device's indirect dispatch buffer.
+     * @param {number} sortSlotBase - Base slot index in the device's indirect dispatch buffer.
+     * The multipass backend uses exactly 1 slot starting at this index (slotCount from
+     * {@link prepareIndirect} is 1).
      * @param {StorageBuffer} sortElementCountBuffer - GPU-written buffer containing visible count.
      * @param {StorageBuffer} [initialValues] - Optional buffer of initial values for pass 0.
      * When provided, the sort produces output values derived from this buffer instead of
@@ -557,13 +415,10 @@ class ComputeRadixSort {
      * keys for a small performance gain. Only use when sorted keys are not needed after sorting.
      * @returns {StorageBuffer} Storage buffer containing sorted values.
      */
-    sortIndirect(keysBuffer, maxElementCount, numBits, dispatchSlot, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false) {
-        Debug.assert(keysBuffer, 'ComputeRadixSort.sortIndirect: keysBuffer is required');
-        Debug.assert(maxElementCount > 0, 'ComputeRadixSort.sortIndirect: maxElementCount must be > 0');
-        Debug.assert(numBits % BITS_PER_PASS === 0, `ComputeRadixSort.sortIndirect: numBits must be a multiple of ${BITS_PER_PASS}`);
-        Debug.assert(sortElementCountBuffer, 'ComputeRadixSort.sortIndirect: sortElementCountBuffer is required');
+    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false) {
+        Debug.assert(numBits % BITS_PER_PASS === 0, `ComputeRadixSortMultipass.sortIndirect: numBits must be a multiple of ${BITS_PER_PASS}`);
 
-        return this._execute(keysBuffer, maxElementCount, numBits, true, dispatchSlot, sortElementCountBuffer, initialValues, skipLastPassKeyWrite);
+        return this._execute(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite);
     }
 
     /**
@@ -572,8 +427,7 @@ class ComputeRadixSort {
      * @param {StorageBuffer} keysBuffer - Input keys buffer.
      * @param {number} elementCount - Number of elements (or max elements for indirect).
      * @param {number} numBits - Number of bits to sort.
-     * @param {boolean} indirect - Whether to use indirect dispatch.
-     * @param {number} dispatchSlot - Indirect dispatch slot index (-1 for direct).
+     * @param {number} sortSlotBase - Indirect dispatch slot index (-1 for direct).
      * @param {StorageBuffer|null} sortElementCountBuffer - GPU-written element count (null for direct).
      * @param {StorageBuffer} [initialValues] - Optional initial values buffer for pass 0.
      * @param {boolean} [skipLastPassKeyWrite] - When true, the last pass skips writing sorted
@@ -581,16 +435,16 @@ class ComputeRadixSort {
      * @returns {StorageBuffer} Storage buffer containing sorted values.
      * @private
      */
-    _execute(keysBuffer, elementCount, numBits, indirect, dispatchSlot, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false) {
+    _execute(keysBuffer, elementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false) {
         this._elementCount = elementCount;
         const hasInitialValues = !!initialValues;
 
         // Allocate buffers and create passes if needed
-        this._allocateBuffers(elementCount, numBits, indirect, hasInitialValues, skipLastPassKeyWrite);
+        this._allocateBuffers(elementCount, numBits, hasInitialValues, skipLastPassKeyWrite);
 
         const device = this.device;
         const numPasses = numBits / BITS_PER_PASS;
-        const suffix = indirect ? '-Indirect' : '';
+        const suffix = this._indirect ? '-Indirect' : '';
 
         // When initial values are provided, pass 0 reads from that buffer (IS_FIRST_PASS=0).
         // Otherwise pass 0 uses GID as the value (IS_FIRST_PASS=1), ignoring currentValues.
@@ -608,7 +462,7 @@ class ComputeRadixSort {
             // write() uses queue.writeBuffer() which executes BEFORE the command buffer,
             // so all clears would happen before any dispatch. clear() executes in-order
             // within the command buffer, ensuring each pass sees zeroed inactive slots.
-            if (indirect) {
+            if (this._indirect) {
                 this._blockSums.clear();
             }
 
@@ -618,9 +472,9 @@ class ComputeRadixSort {
             histogramCompute.setParameter('workgroupCount', this._workgroupCount);
             histogramCompute.setParameter('elementCount', elementCount);
 
-            if (indirect) {
+            if (this._indirect) {
                 histogramCompute.setParameter('sortElementCount', sortElementCountBuffer);
-                histogramCompute.setupIndirectDispatch(dispatchSlot);
+                histogramCompute.setupIndirectDispatch(sortSlotBase);
             } else {
                 histogramCompute.setupDispatch(this._dispatchSize.x, this._dispatchSize.y, 1);
             }
@@ -640,9 +494,9 @@ class ComputeRadixSort {
             reorderCompute.setParameter('workgroupCount', this._workgroupCount);
             reorderCompute.setParameter('elementCount', elementCount);
 
-            if (indirect) {
+            if (this._indirect) {
                 reorderCompute.setParameter('sortElementCount', sortElementCountBuffer);
-                reorderCompute.setupIndirectDispatch(dispatchSlot);
+                reorderCompute.setupIndirectDispatch(sortSlotBase);
             } else {
                 reorderCompute.setupDispatch(this._dispatchSize.x, this._dispatchSize.y, 1);
             }
@@ -662,4 +516,4 @@ class ComputeRadixSort {
     }
 }
 
-export { ComputeRadixSort, ELEMENTS_PER_WORKGROUP as RADIX_SORT_ELEMENTS_PER_WORKGROUP };
+export { ComputeRadixSortMultipass };

--- a/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
@@ -1,17 +1,18 @@
-import { Debug } from '../../core/debug.js';
-import { Vec2 } from '../../core/math/vec2.js';
-import { Compute } from '../../platform/graphics/compute.js';
-import { Shader } from '../../platform/graphics/shader.js';
-import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
-import { BindGroupFormat, BindStorageBufferFormat, BindUniformBufferFormat } from '../../platform/graphics/bind-group-format.js';
-import { UniformBufferFormat, UniformFormat } from '../../platform/graphics/uniform-buffer-format.js';
-import { BUFFERUSAGE_COPY_SRC, BUFFERUSAGE_COPY_DST, SHADERLANGUAGE_WGSL, SHADERSTAGE_COMPUTE, UNIFORMTYPE_UINT } from '../../platform/graphics/constants.js';
-import { onesweepGlobalHistSource } from '../shader-lib/wgsl/chunks/radix-sort/onesweep-global-hist.js';
-import { onesweepScanSource } from '../shader-lib/wgsl/chunks/radix-sort/onesweep-scan.js';
-import { onesweepBinningSource } from '../shader-lib/wgsl/chunks/radix-sort/onesweep-binning.js';
+import { Debug } from '../../../core/debug.js';
+import { Vec2 } from '../../../core/math/vec2.js';
+import { Compute } from '../../../platform/graphics/compute.js';
+import { Shader } from '../../../platform/graphics/shader.js';
+import { StorageBuffer } from '../../../platform/graphics/storage-buffer.js';
+import { BindGroupFormat, BindStorageBufferFormat, BindUniformBufferFormat } from '../../../platform/graphics/bind-group-format.js';
+import { UniformBufferFormat, UniformFormat } from '../../../platform/graphics/uniform-buffer-format.js';
+import { BUFFERUSAGE_COPY_DST, SHADERLANGUAGE_WGSL, SHADERSTAGE_COMPUTE, UNIFORMTYPE_UINT } from '../../../platform/graphics/constants.js';
+import { onesweepGlobalHistSource } from '../../shader-lib/wgsl/chunks/radix-sort/onesweep-global-hist.js';
+import { onesweepScanSource } from '../../shader-lib/wgsl/chunks/radix-sort/onesweep-scan.js';
+import { onesweepBinningSource } from '../../shader-lib/wgsl/chunks/radix-sort/onesweep-binning.js';
+import { ComputeRadixSortBase } from './compute-radix-sort-base.js';
 
 /**
- * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
  */
 
 // DigitBinningPass tile geometry (mirrors the shader defines). KEYS_PER_THREAD=15
@@ -44,41 +45,27 @@ const MAX_PASSES = 4;
  * eliminates all but one round-trip to device memory for scan results.
  *
  * WGSL ported from [b0nes164/GPUSorting](https://github.com/b0nes164/GPUSorting)
- * (Thomas Smith, MIT License). See {@link ComputeRadixSort} for the classic
- * multi-pass fallback used on devices where OneSweep's spin-based lookback
- * cannot make forward progress (e.g. Apple Silicon lacking forward-thread
- * progress guarantees).
+ * (Thomas Smith, MIT License). See {@link ComputeRadixSortMultipass} for the classic
+ * multi-pass fallback used on devices where OneSweep's spin-based lookback cannot make
+ * forward progress (e.g. Apple Silicon lacking forward-thread progress guarantees).
  *
  * **Requirements:**
  *  - `device.supportsCompute` (WebGPU)
- *  - `device.supportsSubgroups` and a runtime subgroup size of 32
- *  - `elementCount` must be a multiple of 4 (GlobalHistogram issues vec4
- *    loads over the key buffer). Callers with odd sizes should either pad to
- *    a multiple of 4 or fall back to {@link ComputeRadixSort}.
+ *  - `device.supportsSubgroups` and a runtime subgroup size <= 32
  *  - The device's lookback must be able to make progress under producer/
  *    consumer partition scheduling (true on NVIDIA Turing+, AMD GCN+, Intel
  *    Gen9+). Apple Silicon and any other device lacking forward-thread-
- *    progress guarantees should use {@link ComputeRadixSort} (the 4-bit
- *    multi-pass portable fallback) instead.
+ *    progress guarantees should use {@link ComputeRadixSortMultipass}
+ *    instead.
+ *
+ * Not exported as a public class; always accessed through the
+ * {@link ComputeRadixSort} facade with `kind: RADIX_SORT_ONESWEEP` or
+ * `RADIX_SORT_AUTO` on supported hardware.
  *
  * @category Graphics
  * @ignore
  */
-class ComputeOneSweepRadixSort {
-    /**
-     * The graphics device.
-     *
-     * @type {GraphicsDevice}
-     */
-    device;
-
-    /**
-     * Current element count.
-     *
-     * @type {number}
-     */
-    _elementCount = 0;
-
+class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
     /**
      * Number of DigitBinningPass workgroups actually dispatched for the
      * current sort. Derived from `elementCount` (not `capacity`) so that
@@ -96,37 +83,6 @@ class ComputeOneSweepRadixSort {
      * @type {number}
      */
     _allocatedThreadBlocks = 0;
-
-    /**
-     * Minimum element capacity for internal buffers.
-     *
-     * @type {number}
-     */
-    capacity = 0;
-
-    /** @type {number} */
-    _numBits = 0;
-
-    /** @type {boolean} */
-    _hasInitialValues = false;
-
-    /** @type {boolean} */
-    _skipLastPassKeyWrite = false;
-
-    /** @type {StorageBuffer|null} */
-    _keys0 = null;
-
-    /** @type {StorageBuffer|null} */
-    _keys1 = null;
-
-    /** @type {StorageBuffer|null} */
-    _values0 = null;
-
-    /** @type {StorageBuffer|null} */
-    _values1 = null;
-
-    /** @type {StorageBuffer|null} */
-    _sortedIndices = null;
 
     /**
      * Per-pass 256-entry digit histograms, concatenated across MAX_PASSES
@@ -195,24 +151,132 @@ class ComputeOneSweepRadixSort {
     /** @type {Compute[]} */
     _binningComputes = [];
 
+
     /**
      * @param {GraphicsDevice} device - The graphics device (must support
      * compute and subgroups).
+     * @param {boolean} [indirect] - Whether this instance is for indirect dispatch only.
      */
-    constructor(device) {
-        Debug.assert(device.supportsCompute, 'ComputeOneSweepRadixSort requires compute shader support (WebGPU)');
-        Debug.assert(device.supportsSubgroups, 'ComputeOneSweepRadixSort requires subgroup support');
+    constructor(device, indirect = false) {
+        super(device, indirect);
+        // prepareIndirect: slot 0 = DigitBinningPass (PART_SIZE), slot 1 = GlobalHistogram.
+        const info = this._indirectInfo;
+        info[0] = 2;
+        info[1] = PART_SIZE;
+        info[2] = G_HIST_PART_SIZE;
+
+        Debug.assert(device.supportsCompute, 'ComputeRadixSortOneSweep requires compute shader support (WebGPU)');
+        Debug.assert(device.supportsSubgroups, 'ComputeRadixSortOneSweep requires subgroup support');
         // The OneSweep binning shader uses 32-bit subgroup ballot masks
         // (`subgroupBallot(...).x` and `1u << sgInvId`), which are only
         // valid when the runtime subgroup size is <= 32. On hardware with
         // 64 / 128 lane subgroups (AMD Wave64, future wider architectures)
         // those expressions silently truncate / UB and will corrupt the
         // sort output. Refuse to run rather than producing garbage.
-        Debug.assert(device.minSubgroupSize > 0, 'ComputeOneSweepRadixSort requires a valid minimum subgroup size');
-        Debug.assert(device.maxSubgroupSize <= 32, 'ComputeOneSweepRadixSort currently requires subgroup sizes <= 32 (binning shader uses 32-bit subgroup masks)');
-        this.device = device;
+        Debug.assert(device.minSubgroupSize > 0, 'ComputeRadixSortOneSweep requires a valid minimum subgroup size');
+        Debug.assert(device.maxSubgroupSize <= 32, 'ComputeRadixSortOneSweep currently requires subgroup sizes <= 32 (binning shader uses 32-bit subgroup masks)');
 
-        this._createFormatsAndShaders();
+        // Create uniform formats (shared between direct and indirect modes), then
+        // create bind group formats and shaders for the chosen mode only.
+        this._globalHistUniformFormat = new UniformBufferFormat(device, [
+            new UniformFormat('numKeys', UNIFORMTYPE_UINT),
+            new UniformFormat('threadBlocks', UNIFORMTYPE_UINT),
+            new UniformFormat('numPasses', UNIFORMTYPE_UINT),
+            new UniformFormat('_pad', UNIFORMTYPE_UINT)
+        ]);
+
+        this._scanUniformFormat = new UniformBufferFormat(device, [
+            new UniformFormat('threadBlocks', UNIFORMTYPE_UINT),
+            new UniformFormat('_pad0', UNIFORMTYPE_UINT),
+            new UniformFormat('_pad1', UNIFORMTYPE_UINT),
+            new UniformFormat('_pad2', UNIFORMTYPE_UINT)
+        ]);
+
+        this._binningUniformFormat = new UniformBufferFormat(device, [
+            new UniformFormat('numKeys', UNIFORMTYPE_UINT),
+            new UniformFormat('threadBlocks', UNIFORMTYPE_UINT),
+            new UniformFormat('pass_', UNIFORMTYPE_UINT),
+            new UniformFormat('flags', UNIFORMTYPE_UINT)
+        ]);
+
+        const minSubgroupSize = device.minSubgroupSize || device.maxSubgroupSize || 32;
+        const maxSubgroups = Math.max(1, Math.ceil(256 / minSubgroupSize));
+
+        const suffix = indirect ? 'Indirect' : '';
+        const elementCountBinding = new BindStorageBufferFormat('b_sortElementCount', SHADERSTAGE_COMPUTE, true);
+
+        const histGroupEntries = [
+            new BindStorageBufferFormat('b_sort', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('b_globalHist', SHADERSTAGE_COMPUTE, false),
+            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
+        ];
+        const scanGroupEntries = [
+            new BindStorageBufferFormat('b_globalHist', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('b_passHist', SHADERSTAGE_COMPUTE, false),
+            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
+        ];
+        const binGroupEntries = [
+            new BindStorageBufferFormat('inputKeys', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('outputKeys', SHADERSTAGE_COMPUTE, false),
+            new BindStorageBufferFormat('inputValues', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('outputValues', SHADERSTAGE_COMPUTE, false),
+            new BindStorageBufferFormat('b_passHist', SHADERSTAGE_COMPUTE, false),
+            new BindStorageBufferFormat('b_index', SHADERSTAGE_COMPUTE, false),
+            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
+        ];
+        if (indirect) {
+            histGroupEntries.push(elementCountBinding);
+            scanGroupEntries.push(elementCountBinding);
+            binGroupEntries.push(elementCountBinding);
+        }
+
+        this._globalHistBindGroupFormat = new BindGroupFormat(device, histGroupEntries);
+        this._scanBindGroupFormat = new BindGroupFormat(device, scanGroupEntries);
+        this._binningBindGroupFormat = new BindGroupFormat(device, binGroupEntries);
+
+        const histDefines = new Map();
+        histDefines.set('{G_HIST_DIM}', G_HIST_DIM);
+        histDefines.set('{G_HIST_PART_SIZE}', G_HIST_PART_SIZE);
+        if (indirect) histDefines.set('USE_INDIRECT_SORT', '');
+        this._globalHistShader = new Shader(device, {
+            name: `OneSweepGlobalHist${suffix}`,
+            shaderLanguage: SHADERLANGUAGE_WGSL,
+            cshader: onesweepGlobalHistSource,
+            cdefines: histDefines,
+            computeBindGroupFormat: this._globalHistBindGroupFormat,
+            computeUniformBufferFormats: { uniforms: this._globalHistUniformFormat }
+        });
+
+        const scanDefines = new Map();
+        scanDefines.set('{MAX_SUBGROUPS}', maxSubgroups);
+        scanDefines.set('{PART_SIZE}', PART_SIZE);
+        if (indirect) scanDefines.set('USE_INDIRECT_SORT', '');
+        this._scanShader = new Shader(device, {
+            name: `OneSweepScan${suffix}`,
+            shaderLanguage: SHADERLANGUAGE_WGSL,
+            cshader: onesweepScanSource,
+            cdefines: scanDefines,
+            computeBindGroupFormat: this._scanBindGroupFormat,
+            computeUniformBufferFormats: { uniforms: this._scanUniformFormat }
+        });
+
+        const binDefines = new Map();
+        binDefines.set('{D_DIM}', D_DIM);
+        binDefines.set('{KEYS_PER_THREAD}', KEYS_PER_THREAD);
+        binDefines.set('{MAX_SUBGROUPS}', maxSubgroups);
+        if (indirect) binDefines.set('USE_INDIRECT_SORT', '');
+        this._binningShader = new Shader(device, {
+            name: `OneSweepBinning${suffix}`,
+            shaderLanguage: SHADERLANGUAGE_WGSL,
+            cshader: onesweepBinningSource,
+            cdefines: binDefines,
+            computeBindGroupFormat: this._binningBindGroupFormat,
+            computeUniformBufferFormats: { uniforms: this._binningUniformFormat }
+        });
+
+        this._globalHistCompute = new Compute(device, this._globalHistShader, this._globalHistShader.name);
+        this._scanCompute = new Compute(device, this._scanShader, this._scanShader.name);
+        // Binning Computes are allocated per-pass in _ensureBinningComputes.
     }
 
     /**
@@ -240,53 +304,22 @@ class ComputeOneSweepRadixSort {
         this._globalHistUniformFormat = null;
         this._scanUniformFormat = null;
         this._binningUniformFormat = null;
+
+        super.destroy();
     }
 
     /** @private */
     _destroyBuffers() {
-        this._keys0?.destroy();
-        this._keys1?.destroy();
-        this._values0?.destroy();
-        this._values1?.destroy();
-        this._sortedIndices?.destroy();
+        this._destroyPingPongBuffers();
         this._globalHist?.destroy();
         this._passHist?.destroy();
         this._index?.destroy();
 
-        this._keys0 = null;
-        this._keys1 = null;
-        this._values0 = null;
-        this._values1 = null;
-        this._sortedIndices = null;
         this._globalHist = null;
         this._passHist = null;
         this._index = null;
         this._allocatedThreadBlocks = 0;
         this._threadBlocks = 0;
-    }
-
-    /**
-     * Gets the sorted values buffer (indices, or user-supplied initial
-     * values after sorting).
-     *
-     * @type {StorageBuffer|null}
-     */
-    get sortedIndices() {
-        return this._sortedIndices;
-    }
-
-    /**
-     * Gets the sorted keys buffer after the last sort. One of the ping-pong
-     * key buffers depending on pass parity.
-     *
-     * @type {StorageBuffer|null}
-     */
-    get sortedKeys() {
-        if (!this._keys0) return null;
-        const numPasses = this._numBits / 8;
-        // Pass 0 writes _keys0, pass 1 writes _keys1, ... last-pass parity
-        // determines final.
-        return (numPasses % 2 === 0) ? this._keys1 : this._keys0;
     }
 
     /**
@@ -298,111 +331,6 @@ class ComputeOneSweepRadixSort {
      */
     get radixBits() {
         return 8;
-    }
-
-    /** @private */
-    _createFormatsAndShaders() {
-        const device = this.device;
-
-        // ----- uniform formats -----
-        this._globalHistUniformFormat = new UniformBufferFormat(device, [
-            new UniformFormat('numKeys', UNIFORMTYPE_UINT),
-            new UniformFormat('threadBlocks', UNIFORMTYPE_UINT),
-            new UniformFormat('numPasses', UNIFORMTYPE_UINT),
-            new UniformFormat('_pad', UNIFORMTYPE_UINT)
-        ]);
-
-        this._scanUniformFormat = new UniformBufferFormat(device, [
-            new UniformFormat('threadBlocks', UNIFORMTYPE_UINT),
-            new UniformFormat('_pad0', UNIFORMTYPE_UINT),
-            new UniformFormat('_pad1', UNIFORMTYPE_UINT),
-            new UniformFormat('_pad2', UNIFORMTYPE_UINT)
-        ]);
-
-        this._binningUniformFormat = new UniformBufferFormat(device, [
-            new UniformFormat('numKeys', UNIFORMTYPE_UINT),
-            new UniformFormat('threadBlocks', UNIFORMTYPE_UINT),
-            new UniformFormat('pass_', UNIFORMTYPE_UINT),
-            new UniformFormat('flags', UNIFORMTYPE_UINT)
-        ]);
-
-        // ----- bind group formats -----
-        this._globalHistBindGroupFormat = new BindGroupFormat(device, [
-            new BindStorageBufferFormat('b_sort', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('b_globalHist', SHADERSTAGE_COMPUTE, false),
-            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
-        ]);
-
-        this._scanBindGroupFormat = new BindGroupFormat(device, [
-            new BindStorageBufferFormat('b_globalHist', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('b_passHist', SHADERSTAGE_COMPUTE, false),
-            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
-        ]);
-
-        this._binningBindGroupFormat = new BindGroupFormat(device, [
-            new BindStorageBufferFormat('inputKeys', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('outputKeys', SHADERSTAGE_COMPUTE, false),
-            new BindStorageBufferFormat('inputValues', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('outputValues', SHADERSTAGE_COMPUTE, false),
-            new BindStorageBufferFormat('b_passHist', SHADERSTAGE_COMPUTE, false),
-            new BindStorageBufferFormat('b_index', SHADERSTAGE_COMPUTE, false),
-            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
-        ]);
-
-        // ----- shaders -----
-        const histDefines = new Map();
-        histDefines.set('{G_HIST_DIM}', G_HIST_DIM);
-        histDefines.set('{G_HIST_PART_SIZE}', G_HIST_PART_SIZE);
-        this._globalHistShader = new Shader(device, {
-            name: 'OneSweepGlobalHist',
-            shaderLanguage: SHADERLANGUAGE_WGSL,
-            cshader: onesweepGlobalHistSource,
-            cdefines: histDefines,
-            computeBindGroupFormat: this._globalHistBindGroupFormat,
-            computeUniformBufferFormats: { uniforms: this._globalHistUniformFormat }
-        });
-
-        // `MAX_SUBGROUPS` is the worst-case number of subgroups in a
-        // 256-thread workgroup. The runtime `subgroup_size` WGSL builtin
-        // may be any value in [minSubgroupSize, maxSubgroupSize], and the
-        // scan and binning kernels size their per-subgroup reduction slots
-        // indexed by `waveIndex = gtid / sgSize`. To avoid under-allocating
-        // those arrays when the runtime subgroup size is smaller than the
-        // max (producing more subgroups than expected), we size from the
-        // minimum subgroup size. Falls back to maxSubgroupSize / 32 when
-        // the device doesn't report a minimum.
-        const minSubgroupSize = device.minSubgroupSize || device.maxSubgroupSize || 32;
-        const maxSubgroups = Math.max(1, Math.ceil(256 / minSubgroupSize));
-
-        const scanDefines = new Map();
-        scanDefines.set('{MAX_SUBGROUPS}', maxSubgroups);
-        this._scanShader = new Shader(device, {
-            name: 'OneSweepScan',
-            shaderLanguage: SHADERLANGUAGE_WGSL,
-            cshader: onesweepScanSource,
-            cdefines: scanDefines,
-            computeBindGroupFormat: this._scanBindGroupFormat,
-            computeUniformBufferFormats: { uniforms: this._scanUniformFormat }
-        });
-
-        const binDefines = new Map();
-        binDefines.set('{D_DIM}', D_DIM);
-        binDefines.set('{KEYS_PER_THREAD}', KEYS_PER_THREAD);
-        binDefines.set('{MAX_SUBGROUPS}', maxSubgroups);
-        this._binningShader = new Shader(device, {
-            name: 'OneSweepBinning',
-            shaderLanguage: SHADERLANGUAGE_WGSL,
-            cshader: onesweepBinningSource,
-            cdefines: binDefines,
-            computeBindGroupFormat: this._binningBindGroupFormat,
-            computeUniformBufferFormats: { uniforms: this._binningUniformFormat }
-        });
-
-        // ----- Compute objects -----
-        this._globalHistCompute = new Compute(device, this._globalHistShader, 'OneSweepGlobalHist');
-        this._scanCompute = new Compute(device, this._scanShader, 'OneSweepScan');
-
-        // Binning Computes are allocated per-pass in _ensureBinningComputes.
     }
 
     /**
@@ -443,14 +371,9 @@ class ComputeOneSweepRadixSort {
             this._allocatedThreadBlocks = allocThreadBlocks;
             this.capacity = effectiveCount;
 
-            const elementSize = effectiveCount * 4;
             const device = this.device;
 
-            this._keys0 = new StorageBuffer(device, elementSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
-            this._keys1 = new StorageBuffer(device, elementSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
-            this._values0 = new StorageBuffer(device, elementSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
-            this._values1 = new StorageBuffer(device, elementSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
-            this._sortedIndices = new StorageBuffer(device, elementSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
+            this._allocatePingPongElementBuffers(effectiveCount);
 
             this._globalHist = new StorageBuffer(device, MAX_PASSES * RADIX * 4, BUFFERUSAGE_COPY_DST);
             this._passHist = new StorageBuffer(device, MAX_PASSES * allocThreadBlocks * RADIX * 4, BUFFERUSAGE_COPY_DST);
@@ -472,11 +395,11 @@ class ComputeOneSweepRadixSort {
         // padding workgroups (as produced by calcDispatchSize when count
         // exceeds maxPerDim and it falls back to 2D) would OOB-read
         // b_passHist in the lookback loop and spin on FLAG_NOT_READY.
-        // In practice maxPerDim is 65535 and PART_SIZE ~= 7680, so this
-        // only triggers past ~500M elements.
+        // In practice maxPerDim is 65535 and PART_SIZE = 3840, so this
+        // only triggers past ~250M elements.
         Debug.assert(
             currentThreadBlocks <= maxPerDim,
-            `ComputeOneSweepRadixSort: threadBlocks (${currentThreadBlocks}) exceeds maxComputeWorkgroupsPerDimension (${maxPerDim}). Binning requires an exact 1D dispatch.`
+            `ComputeRadixSortOneSweep: threadBlocks (${currentThreadBlocks}) exceeds maxComputeWorkgroupsPerDimension (${maxPerDim}). Binning requires an exact 1D dispatch.`
         );
         Compute.calcDispatchSize(currentThreadBlocks, this._binningDispatchSize, maxPerDim);
 
@@ -502,11 +425,7 @@ class ComputeOneSweepRadixSort {
      * @returns {StorageBuffer} Sorted values buffer.
      */
     sort(keysBuffer, elementCount, numBits = 16, initialValues, skipLastPassKeyWrite = false) {
-        Debug.assert(keysBuffer, 'ComputeOneSweepRadixSort.sort: keysBuffer is required');
-        Debug.assert(elementCount > 0, 'ComputeOneSweepRadixSort.sort: elementCount must be > 0');
-        Debug.assert(elementCount % 4 === 0, `ComputeOneSweepRadixSort.sort: elementCount must be a multiple of 4 (vec4 GlobalHistogram), got ${elementCount}`);
-        Debug.assert(numBits % 8 === 0, `ComputeOneSweepRadixSort.sort: numBits must be a multiple of 8, got ${numBits}`);
-        Debug.assert(numBits > 0 && numBits <= 32, `ComputeOneSweepRadixSort.sort: numBits must be in (0, 32], got ${numBits}`);
+        Debug.assert(numBits <= 32, `ComputeRadixSortOneSweep.sort: numBits must be <= 32, got ${numBits}`);
 
         const numPasses = numBits / 8;
         const hasInitialValues = !!initialValues;
@@ -523,8 +442,7 @@ class ComputeOneSweepRadixSort {
 
         // Clear the chained-scan state. All three buffers must be zeroed BEFORE
         // any dispatch for this sort. `clear()` encodes clearBuffer into the
-        // command encoder so it is serialized ahead of the dispatches (unlike
-        // queue.writeBuffer which would race against a prior frame's sort).
+        // command encoder so it is serialized ahead of the dispatches.
         this._globalHist.clear();
         this._passHist.clear(0, MAX_PASSES * this._threadBlocks * RADIX * 4);
         this._index.clear();
@@ -588,6 +506,119 @@ class ComputeOneSweepRadixSort {
 
         return this._sortedIndices;
     }
+
+    /**
+     * Indirect-dispatch variant of {@link sort}. Workgroup counts for the
+     * GlobalHistogram and DigitBinningPass kernels are read from the device's
+     * built-in indirect dispatch buffer at consecutive slots starting at
+     * `sortSlotBase`, written beforehand by the caller using the
+     * `writeSortIndirectArgs` WGSL helper (chunk `sortIndirectArgsCS`) with
+     * metadata from {@link prepareIndirect}. `numKeys` and `threadBlocks`
+     * inside the shaders are computed from `sortElementCountBuffer[0]`; the
+     * uniform values of those fields are ignored in indirect mode.
+     *
+     * Buffers are sized for `maxElementCount` (the allocation high-water
+     * mark); the actual sort size may be any value in `[0, maxElementCount]`.
+     *
+     * @param {StorageBuffer} keysBuffer - Input u32 keys buffer (read-only).
+     * @param {number} maxElementCount - Maximum element count; sizes internal
+     * buffers. Must be >= the GPU-written element count.
+     * @param {number} numBits - Number of bits to sort. Must be a multiple of 8.
+     * @param {number} sortSlotBase - Base indirect dispatch slot index. The
+     * backend uses 2 consecutive slots starting here (see {@link prepareIndirect}).
+     * @param {StorageBuffer} sortElementCountBuffer - GPU-written storage
+     * buffer; element `[0]` holds the actual number of keys to sort.
+     * @param {StorageBuffer} [initialValues] - Optional initial values for pass 0.
+     * @param {boolean} [skipLastPassKeyWrite] - Skip writing keys on the last pass.
+     * @returns {StorageBuffer} Sorted values buffer.
+     */
+    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false) {
+        Debug.assert(numBits <= 32, `ComputeRadixSortOneSweep.sortIndirect: numBits must be <= 32, got ${numBits}`);
+
+        const numPasses = numBits / 8;
+        const hasInitialValues = !!initialValues;
+
+        this._elementCount = maxElementCount;
+        this._numBits = numBits;
+        this._hasInitialValues = hasInitialValues;
+        this._skipLastPassKeyWrite = skipLastPassKeyWrite;
+
+        this._allocateBuffers(maxElementCount);
+        this._ensureBinningComputes(numPasses);
+
+        const device = this.device;
+
+        // Clear chained-scan state based on the ALLOCATED thread-block count
+        // (runtime threadBlocks derived from the GPU element count is never
+        // larger, since maxElementCount is the upper bound).
+        this._globalHist.clear();
+        this._passHist.clear(0, MAX_PASSES * this._allocatedThreadBlocks * RADIX * 4);
+        this._index.clear();
+
+        // ---- Dispatch 1: GlobalHistogram (indirect) ----
+        const histCompute = this._globalHistCompute;
+        histCompute.setParameter('b_sort', keysBuffer);
+        histCompute.setParameter('b_globalHist', this._globalHist);
+        histCompute.setParameter('b_sortElementCount', sortElementCountBuffer);
+        // Uniform values are ignored in indirect mode but still written so
+        // the uniform buffer is populated.
+        histCompute.setParameter('numKeys', 0);
+        histCompute.setParameter('threadBlocks', 0);
+        histCompute.setParameter('numPasses', numPasses);
+        histCompute.setParameter('_pad', 0);
+        histCompute.setupIndirectDispatch(sortSlotBase + 1);
+        device.computeDispatch([histCompute], 'OneSweep-GlobalHistIndirect');
+
+        // ---- Dispatch 2: Scan (direct; numPasses workgroups is always small) ----
+        const scanCompute = this._scanCompute;
+        scanCompute.setParameter('b_globalHist', this._globalHist);
+        scanCompute.setParameter('b_passHist', this._passHist);
+        scanCompute.setParameter('b_sortElementCount', sortElementCountBuffer);
+        scanCompute.setParameter('threadBlocks', 0);
+        scanCompute.setParameter('_pad0', 0);
+        scanCompute.setParameter('_pad1', 0);
+        scanCompute.setParameter('_pad2', 0);
+        scanCompute.setupDispatch(numPasses, 1, 1);
+        device.computeDispatch([scanCompute], 'OneSweep-ScanIndirect');
+
+        // ---- Dispatch 3..N+2: DigitBinningPass per radix pass (indirect) ----
+        let currentKeys = keysBuffer;
+        let currentValues = initialValues ?? this._values0;
+        let nextKeys = this._keys0;
+        let nextValues = this._values1;
+
+        for (let pass = 0; pass < numPasses; pass++) {
+            const isFirstPass = pass === 0 && !hasInitialValues;
+            const isLastPass = pass === numPasses - 1;
+            const outputValues = isLastPass ? this._sortedIndices : nextValues;
+            const flags = (isFirstPass ? 1 : 0) | (isLastPass && skipLastPassKeyWrite ? 2 : 0);
+
+            const binCompute = this._binningComputes[pass];
+            binCompute.setParameter('inputKeys', currentKeys);
+            binCompute.setParameter('outputKeys', nextKeys);
+            binCompute.setParameter('inputValues', currentValues);
+            binCompute.setParameter('outputValues', outputValues);
+            binCompute.setParameter('b_passHist', this._passHist);
+            binCompute.setParameter('b_index', this._index);
+            binCompute.setParameter('b_sortElementCount', sortElementCountBuffer);
+            binCompute.setParameter('numKeys', 0);
+            binCompute.setParameter('threadBlocks', 0);
+            binCompute.setParameter('pass_', pass);
+            binCompute.setParameter('flags', flags);
+            binCompute.setupIndirectDispatch(sortSlotBase);
+            device.computeDispatch([binCompute], `OneSweep-BinningIndirect-${pass}`);
+
+            if (!isLastPass) {
+                currentKeys = nextKeys;
+                nextKeys = (currentKeys === this._keys0) ? this._keys1 : this._keys0;
+                const t = currentValues;
+                currentValues = nextValues;
+                nextValues = t;
+            }
+        }
+
+        return this._sortedIndices;
+    }
 }
 
-export { ComputeOneSweepRadixSort };
+export { ComputeRadixSortOneSweep };

--- a/src/scene/graphics/radix-sort/compute-radix-sort.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort.js
@@ -103,7 +103,8 @@ class ComputeRadixSort {
      */
     _canUseOneSweep(device) {
         if (!device.supportsCompute || !device.supportsSubgroups) return false;
-        if (!device.maxSubgroupSize || device.maxSubgroupSize > 32) return false;
+        // Adapter info may omit subgroup sizes (both stay 0); do not auto-select OneSweep then.
+        if (!device.minSubgroupSize || !device.maxSubgroupSize || device.maxSubgroupSize > 32) return false;
         // Only enable on NVIDIA for now; validated on Turing+ and Ampere.
         // Other vendors either lack forward-progress guarantees (Apple) or
         // have shown correctness issues in the lookback (Mali / Imagination /

--- a/src/scene/graphics/radix-sort/compute-radix-sort.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort.js
@@ -1,0 +1,252 @@
+import { Debug } from '../../../core/debug.js';
+import { RADIX_SORT_AUTO, RADIX_SORT_PORTABLE, RADIX_SORT_ONESWEEP } from '../../constants.js';
+import { ComputeRadixSortMultipass } from './compute-radix-sort-multipass.js';
+import { ComputeRadixSortOneSweep } from './compute-radix-sort-onesweep.js';
+
+/**
+ * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
+ * @import { StorageBuffer } from '../../../platform/graphics/storage-buffer.js'
+ * @import { ComputeRadixSortBase } from './compute-radix-sort-base.js'
+ */
+
+/**
+ * WebGPU compute radix sort for 32-bit unsigned integer keys. The backend
+ * is picked automatically from the device's capabilities, or selected
+ * explicitly via the `kind` option (see {@link RADIX_SORT_AUTO},
+ * {@link RADIX_SORT_PORTABLE}, {@link RADIX_SORT_ONESWEEP}).
+ *
+ * Available backends:
+ *  - **Portable** ({@link RADIX_SORT_PORTABLE}): Runs on every WebGPU device
+ *    (no subgroup intrinsics required). Default fallback.
+ *  - **OneSweep** ({@link RADIX_SORT_ONESWEEP}): Single-sweep 8-bit radix
+ *    sort. Currently supported for NVIDIA only.
+ *
+ * Indirect dispatch:
+ *  Use {@link prepareIndirect} to obtain the dispatch-slot metadata
+ *  (a stable `vec4<u32>` describing slot count and granularity), reserve
+ *  the reported number of slots via
+ *  {@link GraphicsDevice#getIndirectDispatchSlot}, and write dispatch args
+ *  from a compute shader using the `writeSortIndirectArgs` helper (WGSL
+ *  chunk `sortIndirectArgsCS`). Then call {@link sortIndirect} with the
+ *  slot base and a GPU-written element-count buffer.
+ *
+ * @example
+ * import { ComputeRadixSort, StorageBuffer, BUFFERUSAGE_COPY_SRC, BUFFERUSAGE_COPY_DST } from 'playcanvas';
+ *
+ * const radixSort = new ComputeRadixSort(device);
+ * const keys = new Uint32Array([5, 2, 8, 1, 9, 3]);
+ * const keysBuffer = new StorageBuffer(device, keys.byteLength, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
+ * keysBuffer.write(keys);
+ *
+ * // Sort and get the sorted-indices buffer (keys [5,2,8,1,9,3] → index order [3,1,5,0,2,4] for a 16-bit sort)
+ * const sortedIndices = radixSort.sort(keysBuffer, keys.length, 16);
+ *
+ * // Use sortedIndices in subsequent GPU operations, then clean up:
+ * radixSort.destroy();
+ *
+ * @category Graphics
+ * @ignore
+ */
+class ComputeRadixSort {
+    /**
+     * The active backend implementation.
+     *
+     * @type {ComputeRadixSortBase}
+     * @private
+     */
+    _impl;
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device (must support compute).
+     * @param {object} [options] - Options.
+     * @param {number} [options.kind] - Which radix sort backend to use. One of
+     * {@link RADIX_SORT_AUTO} (default), {@link RADIX_SORT_PORTABLE} or
+     * {@link RADIX_SORT_ONESWEEP}.
+     * @param {boolean} [options.indirect] - When `true`, the instance is configured for
+     * indirect-dispatch use only. Only indirect-mode shaders are compiled (avoiding the cost of
+     * compiling unused direct-mode pipelines); {@link sort} is unavailable and will assert.
+     * Defaults to `false`.
+     */
+    constructor(device, options = {}) {
+        const kind = options.kind ?? RADIX_SORT_AUTO;
+        const indirect = options.indirect ?? false;
+
+        let chosen = kind;
+        if (kind === RADIX_SORT_AUTO) {
+            chosen = this._canUseOneSweep(device) ? RADIX_SORT_ONESWEEP : RADIX_SORT_PORTABLE;
+        }
+
+        if (chosen === RADIX_SORT_ONESWEEP) {
+            // Hard hardware prerequisites (compute, subgroups, subgroupSize
+            // <= 32, valid minSubgroupSize) are asserted inside the OneSweep
+            // constructor. Here we only warn on soft policy mismatches
+            // (non-NVIDIA vendors), so callers can opt in for experimentation
+            // on devices where OneSweep has not been validated.
+            if (!this._canUseOneSweep(device)) {
+                Debug.warnOnce('ComputeRadixSort: RADIX_SORT_ONESWEEP requested on a device that is not a validated OneSweep target (non-NVIDIA, or missing compute / subgroups / subgroupSize <= 32). OneSweep may hang or produce incorrect results. Consider RADIX_SORT_PORTABLE or RADIX_SORT_AUTO.');
+            }
+            this._impl = new ComputeRadixSortOneSweep(device, indirect);
+        } else {
+            this._impl = new ComputeRadixSortMultipass(device, indirect);
+        }
+    }
+
+    /**
+     * Returns true when the current device is a good fit for the OneSweep
+     * backend. OneSweep relies on forward-thread-progress guarantees for its
+     * chained-scan lookback (producer/consumer across workgroups) and on
+     * 32-lane subgroup masks in the binning shader.
+     *
+     * @param {GraphicsDevice} device - Graphics device to inspect.
+     * @returns {boolean} True if OneSweep should be preferred.
+     * @private
+     */
+    _canUseOneSweep(device) {
+        if (!device.supportsCompute || !device.supportsSubgroups) return false;
+        if (!device.maxSubgroupSize || device.maxSubgroupSize > 32) return false;
+        // Only enable on NVIDIA for now; validated on Turing+ and Ampere.
+        // Other vendors either lack forward-progress guarantees (Apple) or
+        // have shown correctness issues in the lookback (Mali / Imagination /
+        // some Adreno).
+        const vendor = device.gpuAdapter?.info?.vendor?.toLowerCase?.();
+        return vendor === 'nvidia';
+    }
+
+    /**
+     * Returns the sorted indices (or values, when `initialValues` was passed
+     * to the last {@link sort} / {@link sortIndirect} call) buffer of the
+     * last completed sort.
+     *
+     * @type {StorageBuffer|null}
+     */
+    get sortedIndices() {
+        return this._impl.sortedIndices;
+    }
+
+    /**
+     * Returns the sorted keys buffer of the last completed sort, or `null`
+     * if the last pass skipped writing keys (`skipLastPassKeyWrite=true`).
+     *
+     * @type {StorageBuffer|null}
+     */
+    get sortedKeys() {
+        return this._impl.sortedKeys;
+    }
+
+    /**
+     * Radix width in bits of the active backend. Callers can align key bit
+     * counts to this boundary generically without knowing which backend is
+     * in use.
+     *
+     * @type {number}
+     */
+    get radixBits() {
+        return this._impl.radixBits;
+    }
+
+    /**
+     * High-water mark for internal buffer allocation. Setting this raises
+     * the floor for the next sort's allocation; lowering it requests
+     * shrinkage at the next sort call.
+     *
+     * @type {number}
+     */
+    set capacity(value) {
+        this._impl.capacity = value;
+    }
+
+    get capacity() {
+        return this._impl.capacity;
+    }
+
+    /**
+     * Executes a direct-dispatch radix sort of `elementCount` u32 keys.
+     *
+     * @param {StorageBuffer} keysBuffer - Input u32 keys buffer (read-only).
+     * @param {number} elementCount - Number of elements to sort.
+     * @param {number} [numBits] - Number of bits to sort. Must be a multiple
+     * of {@link radixBits}. Defaults to 16.
+     * @param {StorageBuffer} [initialValues] - Optional caller-supplied
+     * initial values for pass 0. When omitted, pass 0 synthesises sequential
+     * indices and the sort returns sorted indices.
+     * @param {boolean} [skipLastPassKeyWrite] - Skip writing sorted keys on
+     * the last pass (marginal perf win; only use when sorted keys aren't
+     * needed afterwards).
+     * @returns {StorageBuffer} Sorted values buffer (same as
+     * {@link sortedIndices}).
+     */
+    sort(keysBuffer, elementCount, numBits = 16, initialValues, skipLastPassKeyWrite) {
+        Debug.assert(!this._impl._indirect, 'ComputeRadixSort.sort: this instance was created with indirect:true and only supports sortIndirect');
+        Debug.assert(keysBuffer, 'ComputeRadixSort.sort: keysBuffer is required');
+        Debug.assert(elementCount > 0, 'ComputeRadixSort.sort: elementCount must be > 0');
+        Debug.assert(numBits % this.radixBits === 0, `ComputeRadixSort.sort: numBits must be a multiple of radixBits (${this.radixBits}), got ${numBits}`);
+        return this._impl.sort(keysBuffer, elementCount, numBits, initialValues, skipLastPassKeyWrite);
+    }
+
+    /**
+     * Executes an indirect-dispatch radix sort using workgroup counts
+     * pre-written into `device.indirectDispatchBuffer` (typically by a
+     * compute shader that included the `sortIndirectArgsCS` WGSL chunk and
+     * called `writeSortIndirectArgs`). See {@link prepareIndirect} for the
+     * slot metadata and the required slot count.
+     *
+     * @param {StorageBuffer} keysBuffer - Input u32 keys buffer (read-only).
+     * @param {number} maxElementCount - Maximum element count; sizes internal
+     * buffers. The GPU-written count in `sortElementCountBuffer[0]` must be
+     * `<= maxElementCount`.
+     * @param {number} numBits - Number of bits to sort.
+     * @param {number} sortSlotBase - Base indirect dispatch slot index. The
+     * backend uses `slotCount` consecutive slots starting here (see
+     * {@link prepareIndirect}).
+     * @param {StorageBuffer} sortElementCountBuffer - GPU-written storage
+     * buffer; element `[0]` holds the actual number of keys to sort.
+     * @param {StorageBuffer} [initialValues] - Optional initial values for
+     * pass 0.
+     * @param {boolean} [skipLastPassKeyWrite] - Skip writing keys on the
+     * last pass.
+     * @returns {StorageBuffer} Sorted values buffer.
+     */
+    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite) {
+        Debug.assert(this._impl._indirect, 'ComputeRadixSort.sortIndirect: this instance was created without indirect:true');
+        Debug.assert(keysBuffer, 'ComputeRadixSort.sortIndirect: keysBuffer is required');
+        Debug.assert(maxElementCount > 0, 'ComputeRadixSort.sortIndirect: maxElementCount must be > 0');
+        Debug.assert(numBits % this.radixBits === 0, `ComputeRadixSort.sortIndirect: numBits must be a multiple of radixBits (${this.radixBits}), got ${numBits}`);
+        Debug.assert(sortElementCountBuffer, 'ComputeRadixSort.sortIndirect: sortElementCountBuffer is required');
+        return this._impl.sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite);
+    }
+
+    /**
+     * Returns stable metadata describing how many indirect dispatch slots
+     * this backend needs and the elements-per-workgroup granularity of each
+     * slot. Forwarded unchanged from the active backend.
+     *
+     * The returned 4-element `Uint32Array` is sorter-owned and never
+     * reallocated; upload it directly as a uniform `vec4<u32>` and pass it
+     * as the `slotInfo` argument to the `writeSortIndirectArgs` WGSL helper:
+     *
+     * ```
+     * [slotCount, g0, g1, g2]   // g_i = elements-per-workgroup for slot i;
+     *                           // unused entries = 0
+     * ```
+     *
+     * The caller must then reserve `slotCount` consecutive slots in
+     * `device.indirectDispatchBuffer` via
+     * {@link GraphicsDevice#getIndirectDispatchSlot} and pass the resulting
+     * base index to {@link sortIndirect}.
+     *
+     * @returns {Uint32Array} Sorter-owned 4-element Uint32 array.
+     */
+    prepareIndirect() {
+        Debug.assert(this._impl._indirect, 'ComputeRadixSort.prepareIndirect: this instance was created without indirect:true');
+        return this._impl.prepareIndirect();
+    }
+
+    /**
+     * Releases all GPU resources owned by this sorter.
+     */
+    destroy() {
+        this._impl.destroy();
+    }
+}
+
+export { ComputeRadixSort };

--- a/src/scene/gsplat-unified/gsplat-interval-compaction.js
+++ b/src/scene/gsplat-unified/gsplat-interval-compaction.js
@@ -12,13 +12,13 @@ import {
     UNIFORMTYPE_FLOAT,
     UNIFORMTYPE_UINT,
     UNIFORMTYPE_VEC3,
-    UNIFORMTYPE_VEC4
+    UNIFORMTYPE_VEC4,
+    UNIFORMTYPE_UVEC4
 } from '../../platform/graphics/constants.js';
 import { computeGsplatIntervalCullSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-interval-cull.js';
 import { computeGsplatIntervalScatterSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-interval-scatter.js';
 import { computeGsplatWriteIndirectArgsSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-write-indirect-args.js';
 import { PrefixSumKernel } from '../graphics/prefix-sum-kernel.js';
-import { RADIX_SORT_ELEMENTS_PER_WORKGROUP } from '../graphics/compute-radix-sort.js';
 import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
 
 /**
@@ -30,8 +30,6 @@ import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
 const WORKGROUP_SIZE = 256;
 
 const INDEX_COUNT = 6 * GSplatResourceBase.instanceSize;
-
-const SORT_ELEMENTS_PER_WORKGROUP = RADIX_SORT_ELEMENTS_PER_WORKGROUP;
 
 // 16 bytes per interval: { workBufferBase, splatCount, boundsIndex, pad }
 const INTERVAL_STRIDE = 4;
@@ -182,8 +180,9 @@ class GSplatIntervalCompaction {
         this._writeArgsUniformBufferFormat = new UniformBufferFormat(device, [
             new UniformFormat('drawSlot', UNIFORMTYPE_UINT),
             new UniformFormat('indexCount', UNIFORMTYPE_UINT),
-            new UniformFormat('dispatchSlotOffset', UNIFORMTYPE_UINT),
-            new UniformFormat('totalSplats', UNIFORMTYPE_UINT)
+            new UniformFormat('dispatchSlotBase', UNIFORMTYPE_UINT),
+            new UniformFormat('totalSplats', UNIFORMTYPE_UINT),
+            new UniformFormat('sortIndirectInfo', UNIFORMTYPE_UVEC4)
         ]);
     }
 
@@ -303,7 +302,6 @@ class GSplatIntervalCompaction {
         const cdefines = new Map([
             ['{INSTANCE_SIZE}', GSplatResourceBase.instanceSize],
             ['{KEYGEN_THREADS_PER_WORKGROUP}', 256],
-            ['{SORT_ELEMENTS_PER_WORKGROUP}', SORT_ELEMENTS_PER_WORKGROUP],
             ['{MAX_WORKGROUPS_PER_DIM}', device.limits.maxComputeWorkgroupsPerDimension || 65535]
         ]);
 
@@ -455,10 +453,15 @@ class GSplatIntervalCompaction {
      * Writes indirect draw and dispatch arguments from the prefix sum visible count.
      *
      * @param {number} drawSlot - Slot index in the device's indirect draw buffer.
-     * @param {number} dispatchSlot - Slot index in the device's indirect dispatch buffer.
+     * @param {number} dispatchSlotBase - Base slot index in the device's indirect
+     * dispatch buffer. Key-gen args go to `dispatchSlotBase`; sort args to
+     * `dispatchSlotBase + 1` onwards (as described by `sortIndirectInfo`).
      * @param {number} numIntervals - Total interval count (index into prefix sum for visible count).
+     * @param {Uint32Array} sortIndirectInfo - Sorter-owned 4-element Uint32 array
+     * returned by `ComputeRadixSort.prepareIndirect()`, used as a `vec4<u32>`
+     * uniform by the shader to drive the `writeSortIndirectArgs` helper.
      */
-    writeIndirectArgs(drawSlot, dispatchSlot, numIntervals) {
+    writeIndirectArgs(drawSlot, dispatchSlotBase, numIntervals, sortIndirectInfo) {
         const compute = this._writeIndirectArgsCompute;
 
         compute.setParameter('prefixSumBuffer', this.countBuffer);
@@ -469,8 +472,9 @@ class GSplatIntervalCompaction {
 
         compute.setParameter('drawSlot', drawSlot);
         compute.setParameter('indexCount', INDEX_COUNT);
-        compute.setParameter('dispatchSlotOffset', dispatchSlot * 3);
+        compute.setParameter('dispatchSlotBase', dispatchSlotBase);
         compute.setParameter('totalSplats', numIntervals);
+        compute.setParameter('sortIndirectInfo', sortIndirectInfo);
 
         compute.setupDispatch(1);
         this.device.computeDispatch([compute], 'GSplatIntervalWriteIndirectArgs');

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -13,7 +13,7 @@ import { GSplatWorldState } from './gsplat-world-state.js';
 import { GSplatPlacementStateTracker } from './gsplat-placement-state-tracker.js';
 import { GSplatSortKeyCompute } from './gsplat-sort-key-compute.js';
 import { GSplatIntervalCompaction } from './gsplat-interval-compaction.js';
-import { ComputeRadixSort } from '../graphics/compute-radix-sort.js';
+import { ComputeRadixSort } from '../graphics/radix-sort/compute-radix-sort.js';
 import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import {
@@ -41,6 +41,12 @@ const cameraDirection = new Vec3();
 const translation = new Vec3();
 const _tempVec3 = new Vec3();
 const invModelMat = new Mat4();
+
+// Sentinel sort-indirect metadata used when there is no active GPU sorter
+// (e.g. the compute local renderer path, which runs interval compaction but
+// no radix sort). slotCount = 0 makes the writeSortIndirectArgs WGSL helper
+// skip all sort-slot writes.
+const NO_SORT_INDIRECT_INFO = new Uint32Array([0, 0, 0, 0]);
 const tempNonOctreePlacements = new Set();
 const tempOctreePlacements = new Set();
 const _updatedSplats = [];
@@ -464,7 +470,7 @@ class GSplatManager {
             this.keyGenerator = new GSplatSortKeyCompute(this.device);
         }
         if (!this.gpuSorter) {
-            this.gpuSorter = new ComputeRadixSort(this.device);
+            this.gpuSorter = new ComputeRadixSort(this.device, { indirect: true });
         }
     }
 
@@ -1680,10 +1686,18 @@ class GSplatManager {
      * @private
      */
     allocateAndWriteIntervalIndirectArgs(numIntervals) {
+        // The compute local renderer path runs interval compaction without a
+        // radix sort (no gpuSorter), so fall back to the sentinel metadata
+        // which tells the shader to write zero sort slots.
+        const gpuSorter = /** @type {ComputeRadixSort | null} */ (this.gpuSorter);
+        const sortInfo = gpuSorter ? gpuSorter.prepareIndirect() : NO_SORT_INDIRECT_INFO;
+        const sortSlotCount = sortInfo[0];
+
         this.indirectDrawSlot = this.device.getIndirectDrawSlot(1);
-        this.indirectDispatchSlot = this.device.getIndirectDispatchSlot(2);
+        // Reserve contiguous dispatch slots: [keygen, sort0, sort1?, sort2?].
+        this.indirectDispatchSlot = this.device.getIndirectDispatchSlot(1 + sortSlotCount);
         const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
-        ic.writeIndirectArgs(this.indirectDrawSlot, this.indirectDispatchSlot, numIntervals);
+        ic.writeIndirectArgs(this.indirectDrawSlot, this.indirectDispatchSlot, numIntervals, sortInfo);
         this.lastCompactedNumIntervals = numIntervals;
     }
 

--- a/src/scene/shader-lib/wgsl/chunks/common/comp/sort-indirect-args.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/comp/sort-indirect-args.js
@@ -1,0 +1,51 @@
+export default /* wgsl */`
+// Writes up to 3 indirect dispatch slots for a compute-based sorter, using
+// sorter-provided metadata. Each slot occupies 3 consecutive u32 entries
+// (workgroup count x, y, z) in the dispatch buffer; this helper writes a 1D
+// dispatch of \`ceil(count / granularity[i])\` workgroups into slots
+// \`baseSlot + i\` for every active slot \`i\`.
+//
+// Parameters:
+//   buf       - indirect dispatch buffer (plain array<u32>, not atomic).
+//   baseSlot  - index of the first slot to write (u32 offset = baseSlot * 3).
+//   count     - number of elements the sort will process.
+//   slotInfo  - sorter metadata, obtained verbatim from
+//               \`ComputeRadixSort#prepareIndirect()\` and passed in as a
+//               vec4<u32>:
+//                 .x = slotCount (1..3)
+//                 .y/.z/.w = per-slot elements-per-workgroup (granularity);
+//                            unused trailing entries are 0.
+fn writeSortIndirectArgs(
+    buf: ptr<storage, array<u32>, read_write>,
+    baseSlot: u32,
+    count: u32,
+    slotInfo: vec4<u32>
+) {
+    let n = slotInfo.x;
+
+    if (n >= 1u) {
+        let g = slotInfo.y;
+        let wc = (count + g - 1u) / g;
+        let off = baseSlot * 3u;
+        (*buf)[off + 0u] = wc;
+        (*buf)[off + 1u] = 1u;
+        (*buf)[off + 2u] = 1u;
+    }
+    if (n >= 2u) {
+        let g = slotInfo.z;
+        let wc = (count + g - 1u) / g;
+        let off = (baseSlot + 1u) * 3u;
+        (*buf)[off + 0u] = wc;
+        (*buf)[off + 1u] = 1u;
+        (*buf)[off + 2u] = 1u;
+    }
+    if (n >= 3u) {
+        let g = slotInfo.w;
+        let wc = (count + g - 1u) / g;
+        let off = (baseSlot + 2u) * 3u;
+        (*buf)[off + 0u] = wc;
+        (*buf)[off + 1u] = 1u;
+        (*buf)[off + 2u] = 1u;
+    }
+}
+`;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-write-indirect-args.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-write-indirect-args.js
@@ -9,11 +9,13 @@
 
 import indirectCoreCS from '../common/comp/indirect-core.js';
 import dispatchCoreCS from '../common/comp/dispatch-core.js';
+import sortIndirectArgsCS from '../common/comp/sort-indirect-args.js';
 
 export const computeGsplatWriteIndirectArgsSource = /* wgsl */`
 
 ${indirectCoreCS}
 ${dispatchCoreCS}
+${sortIndirectArgsCS}
 
 // Prefix sum buffer (flagBuffer after in-place exclusive scan)
 @group(0) @binding(0) var<storage, read> prefixSumBuffer: array<u32>;
@@ -34,8 +36,9 @@ ${dispatchCoreCS}
 struct WriteArgsUniforms {
     drawSlot: u32,              // slot index into indirectDrawArgs
     indexCount: u32,            // indices per instance (768 = 6 * 128)
-    dispatchSlotOffset: u32,    // u32 offset into indirectDispatchArgs (slot * 3)
-    totalSplats: u32            // total splat count, index into prefixSumBuffer for visible count
+    dispatchSlotBase: u32,      // slot index of keygen dispatch; sort slots follow
+    totalSplats: u32,           // total splat count, index into prefixSumBuffer for visible count
+    sortIndirectInfo: vec4<u32> // sorter-owned [slotCount, g0, g1, g2] from prepareIndirect()
 };
 @group(0) @binding(5) var<uniform> uniforms: WriteArgsUniforms;
 
@@ -58,21 +61,21 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
     // Write numSplats for vertex shader
     numSplatsBuf[0] = count;
 
-    // Write indirect dispatch args: slot 0 = key gen, slot 1 = sort.
-    // Use 2D layout to stay within maxComputeWorkgroupsPerDimension.
-    let dispatchOffset = uniforms.dispatchSlotOffset;
+    // --- Indirect dispatch args ---
+    // Layout: slot[base + 0] = key gen, slot[base + 1..base + 1 + sortSlotCount] = sort.
+    let keygenSlot = uniforms.dispatchSlotBase;
+    let keygenOffset = keygenSlot * 3u;
 
     let keygenWorkgroupCount = (count + {KEYGEN_THREADS_PER_WORKGROUP}u - 1u) / {KEYGEN_THREADS_PER_WORKGROUP}u;
     let keygenDim = calcDispatch2D(keygenWorkgroupCount, {MAX_WORKGROUPS_PER_DIM}u);
-    indirectDispatchArgs[dispatchOffset + 0u] = keygenDim.x;
-    indirectDispatchArgs[dispatchOffset + 1u] = keygenDim.y;
-    indirectDispatchArgs[dispatchOffset + 2u] = 1u;
+    indirectDispatchArgs[keygenOffset + 0u] = keygenDim.x;
+    indirectDispatchArgs[keygenOffset + 1u] = keygenDim.y;
+    indirectDispatchArgs[keygenOffset + 2u] = 1u;
 
-    let sortWorkgroupCount = (count + {SORT_ELEMENTS_PER_WORKGROUP}u - 1u) / {SORT_ELEMENTS_PER_WORKGROUP}u;
-    let sortDim = calcDispatch2D(sortWorkgroupCount, {MAX_WORKGROUPS_PER_DIM}u);
-    indirectDispatchArgs[dispatchOffset + 3u] = sortDim.x;
-    indirectDispatchArgs[dispatchOffset + 4u] = sortDim.y;
-    indirectDispatchArgs[dispatchOffset + 5u] = 1u;
+    // Sort dispatch slots — delegated to the sorter-agnostic helper so this
+    // shader doesn't need to know how many slots or what granularity the
+    // active radix sort backend uses.
+    writeSortIndirectArgs(&indirectDispatchArgs, keygenSlot + 1u, count, uniforms.sortIndirectInfo);
 
     // Write sortElementCount for sort shaders (= visibleCount)
     sortElementCountBuf[0] = count;

--- a/src/scene/shader-lib/wgsl/chunks/radix-sort/onesweep-binning.js
+++ b/src/scene/shader-lib/wgsl/chunks/radix-sort/onesweep-binning.js
@@ -60,12 +60,18 @@ export const onesweepBinningSource = /* wgsl */`
 @group(0) @binding(5) var<storage, read_write> b_index: array<atomic<u32>>;
 
 struct OneSweepBinningUniforms {
-    numKeys: u32,
-    threadBlocks: u32,   // DigitBinningPass workgroup count per pass
+    numKeys: u32,        // ignored in indirect mode
+    threadBlocks: u32,   // DigitBinningPass workgroup count per pass (ignored in indirect mode)
     pass_: u32,          // 0..NUM_PASSES-1
     flags: u32           // bit 0: isFirstPass, bit 1: isLastPass (skip key write)
 };
 @group(0) @binding(6) var<uniform> uniforms: OneSweepBinningUniforms;
+
+#ifdef USE_INDIRECT_SORT
+// Indirect dispatch: numKeys/threadBlocks are derived from a GPU-written
+// element count. The uniform fields are ignored.
+@group(0) @binding(7) var<storage, read> b_sortElementCount: array<u32>;
+#endif
 
 const RADIX: u32 = 256u;
 const RADIX_MASK: u32 = 255u;
@@ -117,8 +123,12 @@ var<workgroup> sg_totals: array<u32, MAX_SUBGROUPS>;
 // Broadcast slot for the atomically-acquired partition tile id.
 var<workgroup> wg_partIndex: u32;
 
-fn passHistOffset(pass_: u32, partitionIdx: u32) -> u32 {
-    return pass_ * uniforms.threadBlocks * RADIX + partitionIdx * RADIX;
+// 'passHistOffset' needs 'threadBlocks' to compute the per-pass row stride.
+// 'threadBlocks' is a local at the top of 'main' (from either the uniform or
+// the GPU-side element count); we plumb it through as an explicit argument
+// rather than a module-scope 'var' so the value stays in registers.
+fn passHistOffset(tb: u32, pass_: u32, partitionIdx: u32) -> u32 {
+    return pass_ * tb * RADIX + partitionIdx * RADIX;
 }
 
 @compute @workgroup_size(D_DIM, 1, 1)
@@ -138,7 +148,13 @@ fn main(
     let activeMask = select(0xFFFFFFFFu, (1u << sgSize) - 1u, sgSize < 32u);
     let pass_ = uniforms.pass_;
     let currentBit = pass_ << 3u;
+    #ifdef USE_INDIRECT_SORT
+    let numKeys = b_sortElementCount[0];
+    let threadBlocks = (numKeys + PART_SIZE - 1u) / PART_SIZE;
+    #else
+    let numKeys = uniforms.numKeys;
     let threadBlocks = uniforms.threadBlocks;
+    #endif
     let isFirstPass = (uniforms.flags & 1u) != 0u;
     let isLastPass = (uniforms.flags & 2u) != 0u;
 
@@ -159,8 +175,8 @@ fn main(
     let tileStart = partitionIndex * PART_SIZE;
     let validInBlock = select(
         0u,
-        min(PART_SIZE, uniforms.numKeys - tileStart),
-        tileStart < uniforms.numKeys
+        min(PART_SIZE, numKeys - tileStart),
+        tileStart < numKeys
     );
 
     // ---- Phase A.2: wave-interleaved load of keys + values ----
@@ -178,7 +194,7 @@ fn main(
     var validMask: u32 = 0u;
     for (var i = 0u; i < KEYS_PER_THREAD; i = i + 1u) {
         let gid = waveBase + sgInvId + i * sgSize;
-        let is_valid = gid < uniforms.numKeys;
+        let is_valid = gid < numKeys;
         // Dummy 0xFFFFFFFF for invalid lanes: validBallot drops them from
         // any real digit's run.
         keys[i] = select(0xFFFFFFFFu, inputKeys[gid], is_valid);
@@ -251,7 +267,7 @@ fn main(
     // slot partitionIndex+1 of passHist (i.e. its successor's inbox). The
     // last block has no successor and skips this step.
     if (partitionIndex + 1u < threadBlocks) {
-        let dst = passHistOffset(pass_, partitionIndex + 1u) + TID;
+        let dst = passHistOffset(threadBlocks, pass_, partitionIndex + 1u) + TID;
         atomicAdd(&b_passHist[dst], FLAG_REDUCTION | (myHistRed << 2u));
     }
 
@@ -325,7 +341,7 @@ fn main(
         var done: bool = false;
         loop {
             if (done) { break; }
-            let flagPayload = atomicLoad(&b_passHist[passHistOffset(pass_, k) + TID]);
+            let flagPayload = atomicLoad(&b_passHist[passHistOffset(threadBlocks, pass_, k) + TID]);
             let flag = flagPayload & FLAG_MASK;
 
             if (flag == FLAG_INCLUSIVE) {
@@ -334,7 +350,7 @@ fn main(
                     // Flip FLAG_REDUCTION (01) to FLAG_INCLUSIVE (10) by adding
                     // 1, and fold in the full exclusive prefix so downstream
                     // blocks can terminate their lookback on this slot.
-                    let dst = passHistOffset(pass_, partitionIndex + 1u) + TID;
+                    let dst = passHistOffset(threadBlocks, pass_, partitionIndex + 1u) + TID;
                     atomicAdd(&b_passHist[dst], 1u | (lookbackReduction << 2u));
                 }
                 // Convert digit_base[TID] from block-local base to the value

--- a/src/scene/shader-lib/wgsl/chunks/radix-sort/onesweep-global-hist.js
+++ b/src/scene/shader-lib/wgsl/chunks/radix-sort/onesweep-global-hist.js
@@ -25,10 +25,17 @@
 // The global histogram is the input to the Scan kernel, which in turn produces
 // the base offsets consumed by DigitBinningPass during lookback.
 //
-// Alignment requirement: numKeys must be a multiple of 4 (= the key buffer
-// size must be a multiple of 16 bytes). Enforced by an assert in
-// ComputeOneSweepRadixSort. Callers with odd sizes should pad or fall back to
-// the classic ComputeRadixSort.
+// Ragged tails: the vec4 load pattern processes keys in groups of 4. When
+// numKeys is not a multiple of 4 (e.g. after GPU-side stream compaction), the
+// last vec4 of the key buffer contains 1-3 valid keys and 3-1 "trailing" slots
+// that hold unrelated data (or zero, for WebGPU out-of-bounds reads). To keep
+// the hot loop branch-free, we split it in two:
+//   - Fast loop: runs over the FULL vec4s only (numKeys >> 2u), all 4 lanes
+//     valid, no per-lane guards.
+//   - Tail block: runs on at most a single thread per workgroup, processing
+//     the one ragged vec4 (if any) with explicit per-lane guards.
+// This is required for GPU-indirect sorting, where numKeys is only known at
+// shader launch time and cannot be padded to a vec4 boundary.
 
 export const onesweepGlobalHistSource = /* wgsl */`
 
@@ -42,6 +49,11 @@ struct OneSweepUniforms {
     _pad: u32
 };
 @group(0) @binding(2) var<uniform> uniforms: OneSweepUniforms;
+
+#ifdef USE_INDIRECT_SORT
+// Indirect dispatch: numKeys is GPU-written. uniforms.numKeys is ignored.
+@group(0) @binding(3) var<storage, read> b_sortElementCount: array<u32>;
+#endif
 
 const RADIX: u32 = 256u;
 const MAX_PASSES: u32 = 4u;
@@ -67,6 +79,12 @@ fn main(
     let flatGid = gid.x + gid.y * nwg.x;
     let numPasses = uniforms.numPasses;
 
+    #ifdef USE_INDIRECT_SORT
+        let numKeys = b_sortElementCount[0];
+    #else
+        let numKeys = uniforms.numKeys;
+    #endif
+
     // Clear shared histogram (only the rows we'll actually use).
     let sharedEnd = 2u * numPasses * RADIX;
     for (var i = gtid; i < sharedEnd; i = i + G_HIST_DIM) {
@@ -74,30 +92,33 @@ fn main(
     }
     workgroupBarrier();
 
-    // Process this workgroup's partition tile (vec4 units).
+    // Process this workgroup's partition tile (vec4 units). The loop bound
+    // is clamped to FULL vec4s (numKeys >> 2u); any partial trailing vec4
+    // is handled out-of-loop by a single thread below.
     let row = gtid / 64u; // 0 or 1
-    let numKeysVec = uniforms.numKeys >> 2u;
+    let numKeysVecFull = numKeys >> 2u;
     let partitionStartVec = flatGid * G_HIST_PART_SIZE_VEC;
-    let partitionEndVec = min(partitionStartVec + G_HIST_PART_SIZE_VEC, numKeysVec);
+    let partitionEndVec = min(partitionStartVec + G_HIST_PART_SIZE_VEC, numKeysVecFull);
 
+    // Fast path: all 4 lanes always valid, no per-lane bounds checks.
+    // Unrolled per-lane, per-pass digit extraction; numPasses is known at
+    // runtime but MAX_PASSES is compile-time, so naga strips the guarded
+    // blocks for NUM_PASSES < 4.
     for (var i = partitionStartVec + gtid; i < partitionEndVec; i = i + G_HIST_DIM) {
         let q = b_sort[i];
-        // Unrolled per-lane, per-pass digit extraction. MAX_PASSES is
-        // compile-time, so the naga optimizer will strip the guarded branches
-        // for NUM_PASSES < 4.
         if (numPasses >= 1u) {
             let off = histOffset(row, 0u);
-            atomicAdd(&g_gHist[(q.x & 0xFFu) + off], 1u);
-            atomicAdd(&g_gHist[(q.y & 0xFFu) + off], 1u);
-            atomicAdd(&g_gHist[(q.z & 0xFFu) + off], 1u);
-            atomicAdd(&g_gHist[(q.w & 0xFFu) + off], 1u);
+            atomicAdd(&g_gHist[(q.x         & 0xFFu) + off], 1u);
+            atomicAdd(&g_gHist[(q.y         & 0xFFu) + off], 1u);
+            atomicAdd(&g_gHist[(q.z         & 0xFFu) + off], 1u);
+            atomicAdd(&g_gHist[(q.w         & 0xFFu) + off], 1u);
         }
         if (numPasses >= 2u) {
             let off = histOffset(row, 1u);
-            atomicAdd(&g_gHist[((q.x >> 8u) & 0xFFu) + off], 1u);
-            atomicAdd(&g_gHist[((q.y >> 8u) & 0xFFu) + off], 1u);
-            atomicAdd(&g_gHist[((q.z >> 8u) & 0xFFu) + off], 1u);
-            atomicAdd(&g_gHist[((q.w >> 8u) & 0xFFu) + off], 1u);
+            atomicAdd(&g_gHist[((q.x >>  8u) & 0xFFu) + off], 1u);
+            atomicAdd(&g_gHist[((q.y >>  8u) & 0xFFu) + off], 1u);
+            atomicAdd(&g_gHist[((q.z >>  8u) & 0xFFu) + off], 1u);
+            atomicAdd(&g_gHist[((q.w >>  8u) & 0xFFu) + off], 1u);
         }
         if (numPasses >= 3u) {
             let off = histOffset(row, 2u);
@@ -112,6 +133,45 @@ fn main(
             atomicAdd(&g_gHist[((q.y >> 24u) & 0xFFu) + off], 1u);
             atomicAdd(&g_gHist[((q.z >> 24u) & 0xFFu) + off], 1u);
             atomicAdd(&g_gHist[((q.w >> 24u) & 0xFFu) + off], 1u);
+        }
+    }
+
+    // Ragged-tail path: at most ONE vec4 at index (numKeys >> 2u) has 1-3
+    // valid lanes (never 4 — if it were, the fast loop would own it). The
+    // thread whose position in the strided loop would have landed on
+    // tailIdx handles it; everyone else falls through.
+    let tailIdx = numKeysVecFull;
+    if ((numKeys & 3u) != 0u &&
+        tailIdx >= partitionStartVec &&
+        tailIdx <  partitionStartVec + G_HIST_PART_SIZE_VEC &&
+        (tailIdx - partitionStartVec) % G_HIST_DIM == gtid) {
+        let q = b_sort[tailIdx];
+        let base = tailIdx << 2u;
+        // Lane 3 is always invalid here (numKeys % 4 == 1/2/3), so it is
+        // unconditionally dropped. Lanes 0..2 are guarded.
+        if (numPasses >= 1u) {
+            let off = histOffset(row, 0u);
+            if (base + 0u < numKeys) { atomicAdd(&g_gHist[(q.x & 0xFFu) + off], 1u); }
+            if (base + 1u < numKeys) { atomicAdd(&g_gHist[(q.y & 0xFFu) + off], 1u); }
+            if (base + 2u < numKeys) { atomicAdd(&g_gHist[(q.z & 0xFFu) + off], 1u); }
+        }
+        if (numPasses >= 2u) {
+            let off = histOffset(row, 1u);
+            if (base + 0u < numKeys) { atomicAdd(&g_gHist[((q.x >>  8u) & 0xFFu) + off], 1u); }
+            if (base + 1u < numKeys) { atomicAdd(&g_gHist[((q.y >>  8u) & 0xFFu) + off], 1u); }
+            if (base + 2u < numKeys) { atomicAdd(&g_gHist[((q.z >>  8u) & 0xFFu) + off], 1u); }
+        }
+        if (numPasses >= 3u) {
+            let off = histOffset(row, 2u);
+            if (base + 0u < numKeys) { atomicAdd(&g_gHist[((q.x >> 16u) & 0xFFu) + off], 1u); }
+            if (base + 1u < numKeys) { atomicAdd(&g_gHist[((q.y >> 16u) & 0xFFu) + off], 1u); }
+            if (base + 2u < numKeys) { atomicAdd(&g_gHist[((q.z >> 16u) & 0xFFu) + off], 1u); }
+        }
+        if (numPasses >= 4u) {
+            let off = histOffset(row, 3u);
+            if (base + 0u < numKeys) { atomicAdd(&g_gHist[((q.x >> 24u) & 0xFFu) + off], 1u); }
+            if (base + 1u < numKeys) { atomicAdd(&g_gHist[((q.y >> 24u) & 0xFFu) + off], 1u); }
+            if (base + 2u < numKeys) { atomicAdd(&g_gHist[((q.z >> 24u) & 0xFFu) + off], 1u); }
         }
     }
     workgroupBarrier();

--- a/src/scene/shader-lib/wgsl/chunks/radix-sort/onesweep-scan.js
+++ b/src/scene/shader-lib/wgsl/chunks/radix-sort/onesweep-scan.js
@@ -18,15 +18,21 @@ export const onesweepScanSource = /* wgsl */`
 @group(0) @binding(1) var<storage, read_write> b_passHist: array<atomic<u32>>;
 
 struct OneSweepScanUniforms {
-    threadBlocks: u32,   // number of DigitBinningPass workgroups per pass
+    threadBlocks: u32,   // number of DigitBinningPass workgroups per pass (ignored in indirect mode)
     _pad0: u32,
     _pad1: u32,
     _pad2: u32
 };
 @group(0) @binding(2) var<uniform> uniforms: OneSweepScanUniforms;
 
+#ifdef USE_INDIRECT_SORT
+// Indirect dispatch: threadBlocks is derived from a GPU-written element count.
+@group(0) @binding(3) var<storage, read> b_sortElementCount: array<u32>;
+#endif
+
 const RADIX: u32 = 256u;
 const FLAG_INCLUSIVE: u32 = 2u;
+const PART_SIZE: u32 = {PART_SIZE}u;
 
 // Parametrized by the host from device.maxSubgroupSize (256 / sgSize).
 const MAX_SUBGROUPS: u32 = {MAX_SUBGROUPS}u;
@@ -44,7 +50,12 @@ fn main(
     @builtin(subgroup_size) sgSize: u32,
 ) {
     let pass_ = gid.x;
+    #ifdef USE_INDIRECT_SORT
+    let numKeys = b_sortElementCount[0];
+    let threadBlocks = (numKeys + PART_SIZE - 1u) / PART_SIZE;
+    #else
     let threadBlocks = uniforms.threadBlocks;
+    #endif
     let waveIndex = gtid / sgSize;
 
     // Load this pass's digit counts.

--- a/src/scene/shader-lib/wgsl/collections/shader-chunks-wgsl.js
+++ b/src/scene/shader-lib/wgsl/collections/shader-chunks-wgsl.js
@@ -120,6 +120,7 @@ import skinBatchVS from '../chunks/common/vert/skinBatch.js';
 import skinVS from '../chunks/common/vert/skin.js';
 import skyboxPS from '../chunks/skybox/frag/skybox.js';
 import skyboxVS from '../chunks/skybox/vert/skybox.js';
+import sortIndirectArgsCS from '../chunks/common/comp/sort-indirect-args.js';
 import specularPS from '../chunks/standard/frag/specular.js';
 import sphericalPS from '../chunks/common/frag/spherical.js';
 import specularityFactorPS from '../chunks/standard/frag/specularityFactor.js';
@@ -291,6 +292,7 @@ const shaderChunksWGSL = {
     skinVS,
     skyboxPS,
     skyboxVS,
+    sortIndirectArgsCS,
     specularPS,
     sphericalPS,
     specularityFactorPS,


### PR DESCRIPTION
Refactors WebGPU compute radix sort behind a single `ComputeRadixSort` entry point, adds optional indirect-dispatch integration for GSplat, and fixes subgroup size fields read from the adapter.

**Changes:**
- Move multipass and OneSweep implementations under `src/scene/graphics/radix-sort/` with a shared `ComputeRadixSortBase` and public `ComputeRadixSort` facade; backend selection uses `RADIX_SORT_AUTO` / `RADIX_SORT_PORTABLE` / `RADIX_SORT_ONESWEEP` constants.
- Add `indirect` constructor option so only the needed shader variant is compiled; `prepareIndirect` / `sortIndirect` assert when used without it.
- Add `sortIndirectArgsCS` WGSL chunk (`writeSortIndirectArgs`) and wire GSplat indirect-arg shaders to `prepareIndirect()` metadata.
- OneSweep: unified artefact lifecycle, ragged-tail global histogram handling, subgroup sizing from `minSubgroupSize`.
- WebGPU: read `minSubgroupSize` / `maxSubgroupSize` from `gpuAdapter.info` (`subgroupMinSize` / `subgroupMaxSize`), not `limits`.
- Radix sort compute example updated to use the facade and `kind` option.

**Examples:**
- `examples/src/examples/test/radix-sort-compute.example.mjs`