### PR TITLE
feat: add WGSL linear_indexing and CAPS_STORAGE_TEXTURE_READ

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -239,9 +239,10 @@ class GraphicsDevice extends EventHandler {
     /**
      * True if the device can read from StorageTexture in the compute shader. By default, the
      * storage texture can be only used with the write operation.
-     * When a shader uses this feature, it's recommended to use a `requires` directive to signal the
-     * potential for non-portability at the top of the WGSL shader code:
-     * ```javascript
+     * When a shader uses this feature, add a `requires` directive to signal non-portability at the
+     * top of the WGSL shader code. The shader define `CAPS_STORAGE_TEXTURE_READ` is set when this
+     * capability is available.
+     * ```wgsl
      * requires readonly_and_readwrite_storage_textures;
      * ```
      *
@@ -281,6 +282,18 @@ class GraphicsDevice extends EventHandler {
      * @readonly
      */
     supportsSubgroupId = false;
+
+    /**
+     * True if the device supports the WGSL `linear_indexing` extension, which provides the
+     * `global_invocation_index` and `workgroup_index` built-in values in compute shaders. The
+     * `requires linear_indexing;` directive is then automatically injected for compute shader
+     * modules, and the shader define `CAPS_LINEAR_INDEXING` is set for conditional
+     * compilation.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    supportsLinearIndexing = false;
 
     /**
      * Maximum subgroup (warp/wavefront) size supported by the device. Zero if subgroups are
@@ -668,6 +681,8 @@ class GraphicsDevice extends EventHandler {
         if (this.supportsShaderF16) capsDefines.set('CAPS_SHADER_F16', '');
         if (this.supportsSubgroups) capsDefines.set('CAPS_SUBGROUPS', '');
         if (this.supportsSubgroupId) capsDefines.set('CAPS_SUBGROUP_ID', '');
+        if (this.supportsLinearIndexing) capsDefines.set('CAPS_LINEAR_INDEXING', '');
+        if (this.supportsStorageTextureRead) capsDefines.set('CAPS_STORAGE_TEXTURE_READ', '');
 
         // Platform defines
         if (platform.desktop) capsDefines.set('PLATFORM_DESKTOP', '');

--- a/src/platform/graphics/shader-definition-utils.js
+++ b/src/platform/graphics/shader-definition-utils.js
@@ -205,7 +205,7 @@ class ShaderDefinitionUtils {
     }
 
     /**
-     * Generates WGSL enable directives based on device capabilities. Enable directives must come
+     * Generates WGSL `enable` / `requires` directives based on device capabilities. They must come
      * before all global declarations in WGSL shaders.
      *
      * @param {GraphicsDevice} device - The graphics device.
@@ -226,6 +226,9 @@ class ShaderDefinitionUtils {
         }
         if (device.supportsSubgroupId) {
             code += 'requires subgroup_id;\n';
+        }
+        if (shaderType === 'compute' && device.supportsLinearIndexing) {
+            code += 'requires linear_indexing;\n';
         }
         return code;
     }

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -248,6 +248,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsStorageTextureRead = wgslFeatures?.has('readonly_and_readwrite_storage_textures');
         this.supportsSubgroupUniformity = wgslFeatures?.has('subgroup_uniformity');
         this.supportsSubgroupId = wgslFeatures?.has('subgroup_id');
+        this.supportsLinearIndexing = wgslFeatures?.has('linear_indexing');
 
         this.initCapsDefines();
     }


### PR DESCRIPTION
Adds support for the WGSL `linear_indexing` language extension (Chrome 147+): `global_invocation_index` and `workgroup_index` in compute shaders. Also sets `CAPS_STORAGE_TEXTURE_READ` when storage-texture reads are supported, and clarifies JSDoc for `supportsStorageTextureRead`.

**Changes:**
- `WebgpuGraphicsDevice`: set `supportsLinearIndexing` from `wgslLanguageFeatures.has("linear_indexing")`.
- `GraphicsDevice`: new `supportsLinearIndexing` property; `initCapsDefines` sets `CAPS_LINEAR_INDEXING` and `CAPS_STORAGE_TEXTURE_READ` when applicable.
- `ShaderDefinitionUtils.getWGSLEnables`: inject `requires linear_indexing;` for **compute** shader modules only when supported.
- JSDoc: `supportsStorageTextureRead` now notes `CAPS_STORAGE_TEXTURE_READ` and uses a WGSL code fence for the `requires` example.

**API (public):**
- `GraphicsDevice#supportsLinearIndexing` — `boolean`, default `false` (WebGL and unsupported browsers).
- Preprocessor: `CAPS_LINEAR_INDEXING`, `CAPS_STORAGE_TEXTURE_READ` (when the device reports the matching capability).

https://developer.chrome.com/blog/new-in-webgpu-147-148#wgsl_linear_indexing_extension