### PR TITLE
refactor: standardize Layer on class fields with grouped ordering

### DIFF
--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -12,7 +12,6 @@ import { Material } from './materials/material.js';
  * @import { Light } from './light.js'
  * @import { LightComponent } from '../framework/components/light/component.js'
  * @import { MeshInstance } from './mesh-instance.js'
- * @import { RenderTarget } from '../platform/graphics/render-target.js'
  * @import { Vec3 } from '../core/math/vec3.js'
  * @import { GSplatPlacement } from './gsplat-unified/gsplat-placement.js'
  */
@@ -155,16 +154,14 @@ class Layer {
     customCalculateSortValues = null;
 
     // -------------------------------------------------------------------------
-    // Render target & clear flags
+    // Clear flags
     // -------------------------------------------------------------------------
 
-    /**
-     * The render target to render the layer to. If not set, the layer is rendered to the target
-     * of the camera rendering it.
-     *
-     * @type {RenderTarget|undefined}
-     */
-    renderTarget;
+    // Note: `renderTarget` is intentionally NOT declared as a class field. It is a removed public
+    // property (see `_removedClassProperty(Layer, 'renderTarget')` in deprecated.js), and the
+    // prototype accessor installed there is what surfaces the deprecation error when user code
+    // reads or writes it. Declaring a same-named class field would create an own property that
+    // shadows that accessor and silently breaks the deprecation warning.
 
     /** @private */
     _clearColorBuffer = false;

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -12,6 +12,7 @@ import { Material } from './materials/material.js';
  * @import { Light } from './light.js'
  * @import { LightComponent } from '../framework/components/light/component.js'
  * @import { MeshInstance } from './mesh-instance.js'
+ * @import { RenderTarget } from '../platform/graphics/render-target.js'
  * @import { Vec3 } from '../core/math/vec3.js'
  * @import { GSplatPlacement } from './gsplat-unified/gsplat-placement.js'
  */
@@ -69,6 +70,139 @@ class CulledInstances {
  * @category Graphics
  */
 class Layer {
+    // -------------------------------------------------------------------------
+    // Identity
+    // -------------------------------------------------------------------------
+
+    /**
+     * A unique ID of the layer. Layer IDs are stored inside {@link ModelComponent#layers},
+     * {@link RenderComponent#layers}, {@link CameraComponent#layers},
+     * {@link LightComponent#layers} and {@link ElementComponent#layers} instead of names.
+     * Can be used in {@link LayerComposition#getLayerById}.
+     *
+     * @type {number}
+     */
+    id;
+
+    /**
+     * Name of the layer. Can be used in {@link LayerComposition#getLayerByName}.
+     *
+     * @type {string}
+     */
+    name;
+
+    // -------------------------------------------------------------------------
+    // Enabled state & ref counting
+    // -------------------------------------------------------------------------
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    _enabled = true;
+
+    /**
+     * @type {number}
+     * @private
+     */
+    _refCounter = 1;
+
+    // -------------------------------------------------------------------------
+    // Sorting
+    // -------------------------------------------------------------------------
+
+    /**
+     * Defines the method used for sorting opaque (that is, not semi-transparent) mesh
+     * instances before rendering. Can be:
+     *
+     * - {@link SORTMODE_NONE}
+     * - {@link SORTMODE_MANUAL}
+     * - {@link SORTMODE_MATERIALMESH}
+     * - {@link SORTMODE_BACK2FRONT}
+     * - {@link SORTMODE_FRONT2BACK}
+     *
+     * Defaults to {@link SORTMODE_MATERIALMESH}.
+     *
+     * @type {number}
+     */
+    opaqueSortMode = SORTMODE_MATERIALMESH;
+
+    /**
+     * Defines the method used for sorting semi-transparent mesh instances before rendering. Can be:
+     *
+     * - {@link SORTMODE_NONE}
+     * - {@link SORTMODE_MANUAL}
+     * - {@link SORTMODE_MATERIALMESH}
+     * - {@link SORTMODE_BACK2FRONT}
+     * - {@link SORTMODE_FRONT2BACK}
+     *
+     * Defaults to {@link SORTMODE_BACK2FRONT}.
+     *
+     * @type {number}
+     */
+    transparentSortMode = SORTMODE_BACK2FRONT;
+
+    /**
+     * @type {Function|null}
+     * @ignore
+     */
+    customSortCallback = null;
+
+    /**
+     * @type {Function|null}
+     * @ignore
+     */
+    customCalculateSortValues = null;
+
+    // -------------------------------------------------------------------------
+    // Render target & clear flags
+    // -------------------------------------------------------------------------
+
+    /**
+     * The render target to render the layer to. If not set, the layer is rendered to the target
+     * of the camera rendering it.
+     *
+     * @type {RenderTarget|undefined}
+     */
+    renderTarget;
+
+    /** @private */
+    _clearColorBuffer = false;
+
+    /** @private */
+    _clearDepthBuffer = false;
+
+    /** @private */
+    _clearStencilBuffer = false;
+
+    // -------------------------------------------------------------------------
+    // Enable / disable callbacks
+    // -------------------------------------------------------------------------
+
+    /**
+     * Custom function that is called after the layer has been enabled. This happens when:
+     *
+     * - The layer is created with {@link enabled} set to true (which is the default value).
+     * - {@link enabled} was changed from false to true
+     *
+     * @type {Function}
+     */
+    onEnable;
+
+    /**
+     * Custom function that is called after the layer has been disabled. This happens when:
+     *
+     * - {@link enabled} was changed from true to false
+     * - {@link decrementCounter} was called and set the counter to zero.
+     *
+     * @type {Function}
+     */
+    onDisable;
+
+    // -------------------------------------------------------------------------
+    // Mesh instances & shadow casters
+    // -------------------------------------------------------------------------
+
     /**
      * Mesh instances assigned to this layer.
      *
@@ -108,6 +242,10 @@ class Layer {
      * @private
      */
     _visibleInstances = new WeakMap();
+
+    // -------------------------------------------------------------------------
+    // Lights
+    // -------------------------------------------------------------------------
 
     /**
      * All lights assigned to a layer.
@@ -151,12 +289,28 @@ class Layer {
      */
     _splitLightsDirty = true;
 
+    /** @private */
+    _lightHash = 0;
+
+    /** @private */
+    _lightHashDirty = false;
+
+    /** @private */
+    _lightIdHash = 0;
+
+    /** @private */
+    _lightIdHashDirty = false;
+
     /**
      * True if the objects rendered on the layer require light cube (emitters with lighting do).
      *
      * @ignore
      */
     requiresLightCube = false;
+
+    // -------------------------------------------------------------------------
+    // Cameras
+    // -------------------------------------------------------------------------
 
     /**
      * @type {CameraComponent[]}
@@ -169,6 +323,10 @@ class Layer {
      * @ignore
      */
     camerasSet = new Set();
+
+    // -------------------------------------------------------------------------
+    // GSplat
+    // -------------------------------------------------------------------------
 
     /**
      * @type {GSplatPlacement[]}
@@ -201,12 +359,36 @@ class Layer {
      */
     gsplatPlacementsDirty = true;
 
+    // -------------------------------------------------------------------------
+    // Composition / shader versioning
+    // -------------------------------------------------------------------------
+
     /**
      * True if the composition is invalidated.
      *
      * @ignore
      */
     _dirtyComposition = false;
+
+    /** @private */
+    _shaderVersion = -1;
+
+    // -------------------------------------------------------------------------
+    // Profiler
+    // -------------------------------------------------------------------------
+
+    // #if _PROFILER
+    skipRenderAfter = Number.MAX_VALUE;
+
+    _skipRenderCounter = 0;
+
+    _renderTime = 0;
+
+    _forwardDrawCalls = 0;
+
+    // deprecated, not useful on a layer anymore, could be moved to camera
+    _shadowDrawCalls = 0;
+    // #endif
 
     /**
      * Create a new Layer instance.
@@ -217,137 +399,34 @@ class Layer {
     constructor(options = {}) {
 
         if (options.id !== undefined) {
-            /**
-             * A unique ID of the layer. Layer IDs are stored inside {@link ModelComponent#layers},
-             * {@link RenderComponent#layers}, {@link CameraComponent#layers},
-             * {@link LightComponent#layers} and {@link ElementComponent#layers} instead of names.
-             * Can be used in {@link LayerComposition#getLayerById}.
-             *
-             * @type {number}
-             */
             this.id = options.id;
             layerCounter = Math.max(this.id + 1, layerCounter);
         } else {
             this.id = layerCounter++;
         }
 
-        /**
-         * Name of the layer. Can be used in {@link LayerComposition#getLayerByName}.
-         *
-         * @type {string}
-         */
         this.name = options.name;
 
-        /**
-         * @type {boolean}
-         * @private
-         */
         this._enabled = options.enabled ?? true;
-        /**
-         * @type {number}
-         * @private
-         */
         this._refCounter = this._enabled ? 1 : 0;
 
-        /**
-         * Defines the method used for sorting opaque (that is, not semi-transparent) mesh
-         * instances before rendering. Can be:
-         *
-         * - {@link SORTMODE_NONE}
-         * - {@link SORTMODE_MANUAL}
-         * - {@link SORTMODE_MATERIALMESH}
-         * - {@link SORTMODE_BACK2FRONT}
-         * - {@link SORTMODE_FRONT2BACK}
-         *
-         * Defaults to {@link SORTMODE_MATERIALMESH}.
-         *
-         * @type {number}
-         */
         this.opaqueSortMode = options.opaqueSortMode ?? SORTMODE_MATERIALMESH;
-
-        /**
-         * Defines the method used for sorting semi-transparent mesh instances before rendering. Can be:
-         *
-         * - {@link SORTMODE_NONE}
-         * - {@link SORTMODE_MANUAL}
-         * - {@link SORTMODE_MATERIALMESH}
-         * - {@link SORTMODE_BACK2FRONT}
-         * - {@link SORTMODE_FRONT2BACK}
-         *
-         * Defaults to {@link SORTMODE_BACK2FRONT}.
-         *
-         * @type {number}
-         */
         this.transparentSortMode = options.transparentSortMode ?? SORTMODE_BACK2FRONT;
 
         if (options.renderTarget) {
             this.renderTarget = options.renderTarget;
         }
 
-        // clear flags
-        /** @private */
         this._clearColorBuffer = !!options.clearColorBuffer;
-
-        /** @private */
         this._clearDepthBuffer = !!options.clearDepthBuffer;
-
-        /** @private */
         this._clearStencilBuffer = !!options.clearStencilBuffer;
 
-        /**
-         * Custom function that is called after the layer has been enabled. This happens when:
-         *
-         * - The layer is created with {@link enabled} set to true (which is the default value).
-         * - {@link enabled} was changed from false to true
-         *
-         * @type {Function}
-         */
         this.onEnable = options.onEnable;
-
-        /**
-         * Custom function that is called after the layer has been disabled. This happens when:
-         *
-         * - {@link enabled} was changed from true to false
-         * - {@link decrementCounter} was called and set the counter to zero.
-         *
-         * @type {Function}
-         */
         this.onDisable = options.onDisable;
 
         if (this._enabled && this.onEnable) {
             this.onEnable();
         }
-
-        /**
-         * @type {Function|null}
-         * @ignore
-         */
-        this.customSortCallback = null;
-
-        /**
-         * @type {Function|null}
-         * @ignore
-         */
-        this.customCalculateSortValues = null;
-
-        // light hash based on the light keys
-        this._lightHash = 0;
-        this._lightHashDirty = false;
-
-        // light hash based on light ids
-        this._lightIdHash = 0;
-        this._lightIdHashDirty = false;
-
-        // #if _PROFILER
-        this.skipRenderAfter = Number.MAX_VALUE;
-        this._skipRenderCounter = 0;
-
-        this._renderTime = 0;
-        this._forwardDrawCalls = 0;
-        this._shadowDrawCalls = 0;  // deprecated, not useful on a layer anymore, could be moved to camera
-        // #endif
-
-        this._shaderVersion = -1;
     }
 
     /**

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -69,9 +69,7 @@ class CulledInstances {
  * @category Graphics
  */
 class Layer {
-    // -------------------------------------------------------------------------
-    // Identity
-    // -------------------------------------------------------------------------
+    // --- Identity ---
 
     /**
      * A unique ID of the layer. Layer IDs are stored inside {@link ModelComponent#layers},
@@ -90,9 +88,7 @@ class Layer {
      */
     name;
 
-    // -------------------------------------------------------------------------
-    // Enabled state & ref counting
-    // -------------------------------------------------------------------------
+    // --- Enabled state & ref counting ---
 
     /**
      * @type {boolean}
@@ -106,9 +102,7 @@ class Layer {
      */
     _refCounter = 1;
 
-    // -------------------------------------------------------------------------
-    // Sorting
-    // -------------------------------------------------------------------------
+    // --- Sorting ---
 
     /**
      * Defines the method used for sorting opaque (that is, not semi-transparent) mesh
@@ -153,9 +147,7 @@ class Layer {
      */
     customCalculateSortValues = null;
 
-    // -------------------------------------------------------------------------
-    // Clear flags
-    // -------------------------------------------------------------------------
+    // --- Clear flags ---
 
     /** @private */
     _clearColorBuffer = false;
@@ -166,9 +158,7 @@ class Layer {
     /** @private */
     _clearStencilBuffer = false;
 
-    // -------------------------------------------------------------------------
-    // Enable / disable callbacks
-    // -------------------------------------------------------------------------
+    // --- Enable / disable callbacks ---
 
     /**
      * Custom function that is called after the layer has been enabled. This happens when:
@@ -190,9 +180,7 @@ class Layer {
      */
     onDisable;
 
-    // -------------------------------------------------------------------------
-    // Mesh instances & shadow casters
-    // -------------------------------------------------------------------------
+    // --- Mesh instances & shadow casters ---
 
     /**
      * Mesh instances assigned to this layer.
@@ -234,9 +222,7 @@ class Layer {
      */
     _visibleInstances = new WeakMap();
 
-    // -------------------------------------------------------------------------
-    // Lights
-    // -------------------------------------------------------------------------
+    // --- Lights ---
 
     /**
      * All lights assigned to a layer.
@@ -299,9 +285,7 @@ class Layer {
      */
     requiresLightCube = false;
 
-    // -------------------------------------------------------------------------
-    // Cameras
-    // -------------------------------------------------------------------------
+    // --- Cameras ---
 
     /**
      * @type {CameraComponent[]}
@@ -315,9 +299,7 @@ class Layer {
      */
     camerasSet = new Set();
 
-    // -------------------------------------------------------------------------
-    // GSplat
-    // -------------------------------------------------------------------------
+    // --- GSplat ---
 
     /**
      * @type {GSplatPlacement[]}
@@ -350,9 +332,7 @@ class Layer {
      */
     gsplatPlacementsDirty = true;
 
-    // -------------------------------------------------------------------------
-    // Composition / shader versioning
-    // -------------------------------------------------------------------------
+    // --- Composition / shader versioning ---
 
     /**
      * True if the composition is invalidated.
@@ -364,9 +344,7 @@ class Layer {
     /** @private */
     _shaderVersion = -1;
 
-    // -------------------------------------------------------------------------
-    // Profiler
-    // -------------------------------------------------------------------------
+    // --- Profiler ---
 
     // #if _PROFILER
     skipRenderAfter = Number.MAX_VALUE;

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -157,12 +157,6 @@ class Layer {
     // Clear flags
     // -------------------------------------------------------------------------
 
-    // Note: `renderTarget` is intentionally NOT declared as a class field. It is a removed public
-    // property (see `_removedClassProperty(Layer, 'renderTarget')` in deprecated.js), and the
-    // prototype accessor installed there is what surfaces the deprecation error when user code
-    // reads or writes it. Declaring a same-named class field would create an own property that
-    // shadows that accessor and silently breaks the deprecation warning.
-
     /** @private */
     _clearColorBuffer = false;
 
@@ -410,6 +404,11 @@ class Layer {
         this.opaqueSortMode = options.opaqueSortMode ?? SORTMODE_MATERIALMESH;
         this.transparentSortMode = options.transparentSortMode ?? SORTMODE_BACK2FRONT;
 
+        // Note: `renderTarget` is intentionally NOT declared as a class field. It is a removed
+        // public property (see `_removedClassProperty(Layer, 'renderTarget')` in deprecated.js),
+        // and the prototype accessor installed there is what surfaces the deprecation error when
+        // user code reads or writes it. Declaring a same-named class field would create an own
+        // property that shadows that accessor and silently breaks the deprecation warning.
         if (options.renderTarget) {
             this.renderTarget = options.renderTarget;
         }

--- a/src/scene/layer.js
+++ b/src/scene/layer.js
@@ -404,15 +404,6 @@ class Layer {
         this.opaqueSortMode = options.opaqueSortMode ?? SORTMODE_MATERIALMESH;
         this.transparentSortMode = options.transparentSortMode ?? SORTMODE_BACK2FRONT;
 
-        // Note: `renderTarget` is intentionally NOT declared as a class field. It is a removed
-        // public property (see `_removedClassProperty(Layer, 'renderTarget')` in deprecated.js),
-        // and the prototype accessor installed there is what surfaces the deprecation error when
-        // user code reads or writes it. Declaring a same-named class field would create an own
-        // property that shadows that accessor and silently breaks the deprecation warning.
-        if (options.renderTarget) {
-            this.renderTarget = options.renderTarget;
-        }
-
         this._clearColorBuffer = !!options.clearColorBuffer;
         this._clearDepthBuffer = !!options.clearDepthBuffer;
         this._clearStencilBuffer = !!options.clearStencilBuffer;


### PR DESCRIPTION
## Summary

- Standardizes `Layer` on class fields: every instance property is declared at the top of the class body with JSDoc and a default value (where appropriate), so the constructor no longer mixes class-field declarations with property initialization.
- Reorders the class fields into labelled logical groups (identity, enabled state & ref counting, sorting, clear flags, enable/disable callbacks, mesh instances & shadow casters, lights, cameras, gsplat, composition / shader versioning, profiler).
- Slims the constructor down to option-driven / runtime-only work: id allocation via `layerCounter`, copying values from `options`, and the initial `onEnable()` invocation.
- Drops the dead `if (options.renderTarget) { this.renderTarget = options.renderTarget; }` block from the constructor. `Layer#renderTarget` is already registered as a removed property via `_removedClassProperty(Layer, 'renderTarget')` in `src/deprecated/deprecated.js`, and nothing in the engine reads `layer.renderTarget`, so the block only ever hit the deprecation setter and had no useful effect. The `_removedClassProperty` entry itself stays for engine v2 cleanup.

No behavioral changes.

The `// #if _PROFILER` guard now wraps only the five profiler fields.

## Test plan

- [x] `npm run build` succeeds (class-field + `// #if _PROFILER` preprocessing).
- [x] `npm test` passes.
- [x] Manually verify a scene with multiple layers (including one created with explicit `id`, one disabled, and one with `onEnable`/`onDisable`) renders identically to `main`.
