### PR TITLE
fix: split batches by castShadow and shadowCascadeMask

### DIFF
--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -467,6 +467,8 @@ class BatchManager {
      * - Too many instances for a single batch (hardware-dependent, expect 128 on low-end and 1024
      * on high-end).
      * - Bounding box of a batch is larger than maxAabbSize in any dimension.
+     * - Mesh instances differ in shadow casting ({@link MeshInstance#castShadow}) or directional
+     * shadow cascade mask ({@link MeshInstance#shadowCascadeMask}).
      *
      * @param {MeshInstance[]} meshInstances - Input list of mesh instances
      * @param {boolean} dynamic - Are we preparing for a dynamic batch? Instance count will matter
@@ -528,6 +530,8 @@ class BatchManager {
             const scaleSign = getScaleSign(meshInstancesLeftA[0]);
             const vertexFormatBatchingHash = meshInstancesLeftA[0].mesh.vertexBuffer.format.batchingHash;
             const indexed = meshInstancesLeftA[0].mesh.primitive[0].indexed;
+            const castShadow = meshInstancesLeftA[0].castShadow;
+            const shadowCascadeMask = meshInstancesLeftA[0].shadowCascadeMask;
             skipTranslucentAabb = null;
 
             for (let i = 1; i < meshInstancesLeftA.length; i++) {
@@ -567,6 +571,12 @@ class BatchManager {
                 }
                 // Split by negative scale
                 if (scaleSign !== getScaleSign(mi)) {
+                    skipMesh(mi);
+                    continue;
+                }
+
+                // Split by shadow casting — the batched MeshInstance exposes a single castShadow flag
+                if (castShadow !== mi.castShadow || shadowCascadeMask !== mi.shadowCascadeMask) {
                     skipMesh(mi);
                     continue;
                 }

--- a/test/scene/batching/batch-manager.test.mjs
+++ b/test/scene/batching/batch-manager.test.mjs
@@ -76,6 +76,32 @@ describe('BatchManager', function () {
     });
 
 
+    it('prepare: splits batches when castShadow differs', function () {
+        const e1 = new Entity();
+        e1.addComponent('model', {
+            type: 'box',
+            batchGroupId: this.bg.id
+        });
+        const e2 = new Entity();
+        e2.addComponent('model', {
+            type: 'box',
+            batchGroupId: this.bg.id
+        });
+
+        app.root.addChild(e1);
+        app.root.addChild(e2);
+
+        e1.model.meshInstances[0].castShadow = false;
+        e2.model.meshInstances[0].castShadow = true;
+
+        app.batcher.generate();
+
+        const layer = app.scene.layers.getLayerById(LAYERID_WORLD);
+        expect(layer.meshInstances.length).to.equal(2);
+        const flags = layer.meshInstances.map(mi => mi.castShadow).sort();
+        expect(flags).to.deep.equal([false, true]);
+    });
+
     it('batch with all invisible meshinstances works', function () {
         const e1 = new Entity();
         e1.name = 'e1';


### PR DESCRIPTION
When mesh instances were merged into one batch, the resulting single `MeshInstance` took `castShadow` (and related state) only from the first source instance. Instances that matched on material, shader defines, and other batch keys but differed in shadow casting could all inherit the wrong flag, which showed up as incorrect shadow maps (see #8646).

**Changes**
- Split batch groups in `BatchManager.prepare` when `castShadow` or `shadowCascadeMask` differs between candidates.
- Document the new split rule in `prepare` JSDoc.
- Add a unit test that two batched boxes with different `castShadow` produce two world-layer mesh instances with the expected flags.

**API changes**
- None.

**Performance**
- Slightly more batches (and draw calls) when the same batch group mixes shadow-casting and non–shadow-casting geometry; behavior matches disabling batching for those cases.

Fixed #8646