### PR TITLE
Fix Picker depth clear decoding

### DIFF
--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -346,7 +346,7 @@ class Picker {
         const pixels = await this._readTexture(this.depthBuffer, x, y, 1, 1, this.renderTargetDepth);
 
         // reconstruct uint bits from RGBA8
-        const intBits = (pixels[0] << 24) | (pixels[1] << 16) | (pixels[2] << 8) | pixels[3];
+        const intBits = ((pixels[0] << 24) | (pixels[1] << 16) | (pixels[2] << 8) | pixels[3]) >>> 0;
 
         // check for white (cleared) depth
         if (intBits === 0xFFFFFFFF) {


### PR DESCRIPTION
## Summary
- Fixes `Picker#getPointDepthAsync()` so RGBA8 depth bits are reconstructed as an unsigned 32-bit value.
- Ensures cleared depth pixels (`0xFFFFFFFF`) are correctly treated as “no hit” instead of being reinterpreted as `NaN`.

## Details
JavaScript bitwise operations produce signed 32-bit integers. For a cleared depth pixel `[255, 255, 255, 255]`, the previous decode produced `-1`, so the `0xFFFFFFFF` no-depth check failed. This could cause background picks to return a `NaN` world point.

The fix applies `>>> 0` after reconstructing the integer bits.

## Test Plan
- Verified background picks return `null` instead of a `NaN` world point.
- Verified valid object/gsplat picks still return a world-space point.