### PR TITLE
Defer WebGPU buffer destruction until submit

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-buffer.js
@@ -25,7 +25,9 @@ class WebgpuBuffer {
 
     destroy(device) {
         if (this.buffer) {
-            this.buffer.destroy();
+            // Defer destruction until after pending command buffers are submitted, since
+            // a recorded command buffer may still reference this buffer through a bind group.
+            device.deferDestroy(this.buffer);
             this.buffer = null;
         }
     }


### PR DESCRIPTION
## Summary
- Defers `GPUBuffer.destroy()` in `WebgpuBuffer.destroy()` until pending command buffers have been submitted.
- Matches the existing deferred-destroy behavior used for WebGPU textures.

## Details
A `GPUBuffer` can still be referenced by recorded command buffers through bind groups even after the engine-side buffer wrapper is destroyed. Destroying the underlying WebGPU buffer immediately can invalidate a later `queue.submit()` with validation errors such as “buffer used in submit while destroyed”.

This change routes buffer destruction through `device.deferDestroy(...)`, so the underlying `GPUBuffer` is destroyed only after pending command buffers are submitted.

## Test Plan
- Verified WebGPU picking no longer reports “Buffer used in submit while destroyed” during gsplat interaction.
- Existing WebGPU texture destruction already follows this deferred lifetime pattern.