### PR TITLE
fix(webgpu): defer GPU resource destruction for pending commands

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-query-set.js
+++ b/src/platform/graphics/webgpu/webgpu-query-set.js
@@ -39,10 +39,10 @@ class WebgpuQuerySet {
     }
 
     destroy() {
-        this.querySet?.destroy();
+        this.device.deferDestroy(this.querySet);
         this.querySet = null;
 
-        this.queryBuffer?.destroy();
+        this.device.deferDestroy(this.queryBuffer);
         this.queryBuffer = null;
 
         this.activeStagingBuffer = null;

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -29,8 +29,8 @@ class ColorAttachment {
      */
     multisampledBuffer;
 
-    destroy() {
-        this.multisampledBuffer?.destroy();
+    destroy(device) {
+        device.deferDestroy(this.multisampledBuffer);
         this.multisampledBuffer = null;
     }
 }
@@ -85,7 +85,7 @@ class DepthAttachment {
 
     destroy(device) {
         if (this.depthTextureInternal) {
-            this.depthTexture?.destroy();
+            device.deferDestroy(this.depthTexture);
             this.depthTexture = null;
         }
 
@@ -163,7 +163,7 @@ class WebgpuRenderTarget {
         this.assignedColorTexture = null;
 
         this.colorAttachments.forEach((colorAttachment) => {
-            colorAttachment.destroy();
+            colorAttachment.destroy(device);
         });
         this.colorAttachments.length = 0;
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -361,7 +361,7 @@ class WebgpuTexture {
         if (this.desc && (this.desc.size.width !== texture.width || this.desc.size.height !== texture.height)) {
             Debug.warnOnce(`Texture '${texture.name}' is being recreated due to dimension change from ${this.desc.size.width}x${this.desc.size.height} to ${texture.width}x${texture.height}. Consider creating the texture with correct dimensions to avoid recreation.`);
 
-            this.gpuTexture.destroy();
+            device.deferDestroy(this.gpuTexture);
             this.create(device);
 
             // Notify bind groups that this texture has changed and needs rebinding


### PR DESCRIPTION
Defer destruction of WebGPU textures and buffers that may still be referenced by encoded-but-not-yet-submitted command buffers, matching the existing pattern used by `WebgpuBuffer` and `WebgpuTexture.destroy`.

**Changes:**
- **Query sets:** Defer destruction of `GPUQuerySet` and its resolve buffer when tearing down profiling queries.
- **Render targets:** Defer destruction of multisampled color attachments and internally allocated depth textures when releasing or resizing render targets.
- **Textures:** When recreating a GPU texture after a dimension change during upload, defer destruction of the previous `gpuTexture`.

No public API changes.