### PR TITLE
Use texImage2D for gsplat splat-order uploads

### DIFF
--- a/src/platform/graphics/webgl/webgl-upload-stream.js
+++ b/src/platform/graphics/webgl/webgl-upload-stream.js
@@ -133,9 +133,6 @@ class WebglUploadStream {
         device.setUnpackFlipY(false);
         device.setUnpackPremultiplyAlpha(false);
         device.setUnpackAlignment(data.BYTES_PER_ELEMENT);
-        gl.pixelStorei(gl.UNPACK_ROW_LENGTH, 0);
-        gl.pixelStorei(gl.UNPACK_SKIP_ROWS, 0);
-        gl.pixelStorei(gl.UNPACK_SKIP_PIXELS, 0);
 
         // Wrap the source TypedArray to match the texture's pixel type when needed
         // (e.g. RGBA8UI expects UNSIGNED_BYTE → Uint8Array, even if the caller passes Uint32Array).

--- a/src/platform/graphics/webgl/webgl-upload-stream.js
+++ b/src/platform/graphics/webgl/webgl-upload-stream.js
@@ -104,7 +104,11 @@ class WebglUploadStream {
     }
 
     /**
-     * Direct texture upload (simple, blocking).
+     * Direct texture upload via gl.texImage2D — uploads the full buffer with a
+     * fresh storage allocation each call. Bypasses the engine's Texture.upload
+     * path (which uses texSubImage2D after the first frame). This avoids the
+     * texSubImage2D path's stall on multi-MB integer-format uploads through
+     * Chrome's renderer→GPU IPC on some drivers.
      *
      * @param {Uint8Array|Uint32Array|Float32Array} data - The data to upload.
      * @param {Texture} target - The target texture.
@@ -114,10 +118,42 @@ class WebglUploadStream {
      */
     uploadDirect(data, target, offset, size) {
         Debug.assert(offset === 0, 'Direct texture upload with non-zero offset is not supported. Use PBO mode instead.');
-        Debug.assert(target._levels);
 
-        target._levels[0] = data;
-        target.upload();
+        const device = this.uploadStream.device;
+        // @ts-ignore - gl is available on WebglGraphicsDevice
+        const gl = device.gl;
+        const impl = target.impl;
+
+        // Ensure the GL texture object exists and is bound.
+        // @ts-ignore - setTexture is available on WebglGraphicsDevice
+        device.setTexture(target, 0);
+        device.activeTexture(0);
+        device.bindTexture(target);
+
+        device.setUnpackFlipY(false);
+        device.setUnpackPremultiplyAlpha(false);
+        device.setUnpackAlignment(data.BYTES_PER_ELEMENT);
+        gl.pixelStorei(gl.UNPACK_ROW_LENGTH, 0);
+        gl.pixelStorei(gl.UNPACK_SKIP_ROWS, 0);
+        gl.pixelStorei(gl.UNPACK_SKIP_PIXELS, 0);
+
+        // Wrap the source TypedArray to match the texture's pixel type when needed
+        // (e.g. RGBA8UI expects UNSIGNED_BYTE → Uint8Array, even if the caller passes Uint32Array).
+        let src = data;
+        if (impl._glPixelType === gl.UNSIGNED_BYTE && data.BYTES_PER_ELEMENT !== 1) {
+            const byteSize = size * data.BYTES_PER_ELEMENT;
+            src = new Uint8Array(data.buffer, data.byteOffset, byteSize);
+        }
+
+        // Full-buffer upload (texImage2D allocates fresh storage each call).
+        gl.texImage2D(
+            gl.TEXTURE_2D, 0, impl._glInternalFormat,
+            target.width, target.height, 0,
+            impl._glFormat, impl._glPixelType, src
+        );
+
+        // Keep engine texture state consistent: storage exists now.
+        impl._glCreated = true;
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-work-buffer.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer.js
@@ -187,8 +187,12 @@ class GSplatWorkBuffer {
         // Build render targets from textures
         this._createRenderTargets();
 
-        // Create upload stream for non-blocking uploads
-        this.uploadStream = new UploadStream(device);
+        // Create upload stream for the per-frame splat order. On WebGL, use
+        // single-buffer mode: the PBO + texSubImage2D path stalls the main
+        // thread on multi-MB uploads through Chrome's renderer→GPU IPC, while
+        // a single texImage2D (used by uploadDirect) does not. WebGPU keeps
+        // the staging path, which is already non-blocking.
+        this.uploadStream = new UploadStream(device, !device.isWebGPU);
 
         // Use storage buffer on WebGPU, texture on WebGL
         if (device.isWebGPU) {

--- a/src/scene/gsplat/gsplat-sorter.js
+++ b/src/scene/gsplat/gsplat-sorter.js
@@ -40,7 +40,10 @@ class GSplatSorter extends EventHandler {
     constructor(device, scene) {
         super();
         this.scene = scene ?? null;
-        this.uploadStream = new UploadStream(device);
+        // Use single-buffer mode on WebGL: a single texImage2D outperforms the
+        // PBO + texSubImage2D path on Chrome's renderer→GPU IPC for multi-MB
+        // integer-format uploads. WebGPU keeps the staging path.
+        this.uploadStream = new UploadStream(device, !device.isWebGPU);
 
         const messageHandler = (message) => {
             const msgData = message.data ?? message;


### PR DESCRIPTION
## Summary

On WebGL, the gsplat CPU-sort path uploads a per-frame `Uint32Array` of sorted
splat indices into an `R32UI` texture via `UploadStream.uploadPBO` →
`gl.bufferSubData` (PBO orphan) → `gl.texSubImage2D`. For multi-MB integer
textures, this stalls the main thread on Chrome's renderer→GPU IPC.

A `?cpu-sort` (WebGPU CPU sort, same JS sorter) vs `?webgl` (WebGL2 CPU sort)
comparison on the same splat scene:

|                        | WebGL2  | WebGPU CPU-sort |
|------------------------|---------|-----------------|
| FireAnimationFrame p90 | 74 ms   | 2.2 ms          |
| FireAnimationFrame max | 93 ms   | 2.4 ms          |
| Top hotspot            | `bufferSubData` (~25% of CPU) | `uploadStaging` (negligible) |

Switching `WebglUploadStream.uploadDirect` to call `gl.texImage2D` directly
(full-buffer, fresh allocation each frame) takes a different — much cheaper —
IPC path on Chrome and eliminates the stall. WebGPU is unchanged.

## Changes

- `WebglUploadStream.uploadDirect` rewritten to call `gl.texImage2D` directly,
  bypassing `Texture.upload()` (which uses `texSubImage2D` after the first
  frame). Wraps the source `TypedArray` as `Uint8Array` when the texture's
  pixel type is `UNSIGNED_BYTE`.
- `GSplatWorkBuffer` (unified) and `GSplatSorter` (legacy) construct their
  `UploadStream` with `useSingleBuffer = !device.isWebGPU`, so WebGL routes
  through the new `uploadDirect`. WebGPU continues using the staging path.

## Test plan

- [ ] WebGL2 gsplat scene (unified + legacy) renders correctly
- [ ] WebGPU gsplat scene unchanged (no visual or perf regression)
- [ ] Profile confirms main-thread stall is eliminated on WebGL
- [ ] Smoke-test on Windows / Linux WebGL2 to confirm no platform regresses