### PR TITLE
feat(gsplat): hybrid raster renderer with compute projector

### DIFF
--- a/examples/src/examples/gaussian-splatting/benchmark.example.mjs
+++ b/examples/src/examples/gaussian-splatting/benchmark.example.mjs
@@ -12,15 +12,21 @@ const MEASURE_FRAMES = 30;
 const RENDERER_RASTER_CPU_SORT = 1;
 const RENDERER_RASTER_GPU_SORT = 2;
 const RENDERER_COMPUTE = 3;
+const RENDERER_RASTER_HYBRID = 4;
 
 const RENDERERS = [
     { device: 'webgl2', renderer: RENDERER_RASTER_CPU_SORT, label: 'WebGL2 CPU Sort', shortLabel: 'GL2 CPU' },
     { device: 'webgpu', renderer: RENDERER_RASTER_CPU_SORT, label: 'WebGPU CPU Sort', shortLabel: 'GPU CPU' },
     { device: 'webgpu', renderer: RENDERER_RASTER_GPU_SORT, label: 'WebGPU GPU Sort', shortLabel: 'GPU Sort' },
-    { device: 'webgpu', renderer: RENDERER_COMPUTE, label: 'WebGPU Compute', shortLabel: 'Compute' }
+    { device: 'webgpu', renderer: RENDERER_COMPUTE, label: 'WebGPU Compute', shortLabel: 'Compute' },
+    { device: 'webgpu', renderer: RENDERER_RASTER_HYBRID, label: 'WebGPU Hybrid', shortLabel: 'Hybrid' }
 ];
 
-const BUDGETS = [1, 2, 4, 6, 8, 10, 20, 30]; // millions
+const BUDGETS = [1, 2, 3, 4, 6, 8, 10, 15, 20, 25, 30, 35]; // millions
+
+/** Design-time chart dimensions (CSS px); bitmap scales with table width × DPR. */
+const CHART_REF_W = 778;
+const CHART_REF_H = 389;
 
 // ── Stored results per renderer column ──
 // storedResults[col].budgetResults is length BUDGETS.length, entries are null or result object
@@ -169,9 +175,17 @@ for (let b = 0; b < BUDGETS.length; b++) {
     tbody.appendChild(tr);
 }
 table.appendChild(tbody);
-containerEl.appendChild(table);
 
-// Status line (inside container, visible when idle)
+// Wide table + chart share one column so the chart matches table width (horizontal scroll on narrow viewports).
+const benchScrollBlock = document.createElement('div');
+Object.assign(benchScrollBlock.style, {
+    width: 'max-content',
+    maxWidth: 'none',
+    boxSizing: 'border-box'
+});
+benchScrollBlock.appendChild(table);
+
+// Status line (inside scroll column, visible when idle)
 const statusEl = document.createElement('div');
 Object.assign(statusEl.style, {
     marginBottom: '12px',
@@ -181,7 +195,7 @@ Object.assign(statusEl.style, {
     minHeight: '1.4em',
     fontSize: '14px'
 });
-containerEl.appendChild(statusEl);
+benchScrollBlock.appendChild(statusEl);
 
 // Floating status overlay (visible during tests, on top of rendering)
 const floatingStatus = document.createElement('div');
@@ -201,9 +215,23 @@ Object.assign(floatingStatus.style, {
 });
 document.body.appendChild(floatingStatus);
 
-// Chart + download area
+// Chart + download area (same width as table via benchScrollBlock)
 const chartArea = document.createElement('div');
-containerEl.appendChild(chartArea);
+Object.assign(chartArea.style, {
+    width: '100%',
+    boxSizing: 'border-box'
+});
+benchScrollBlock.appendChild(chartArea);
+containerEl.appendChild(benchScrollBlock);
+
+let chartResizeTimer = 0;
+window.addEventListener('resize', () => {
+    if (!storedResults.some(r => r !== null)) return;
+    window.clearTimeout(chartResizeTimer);
+    chartResizeTimer = window.setTimeout(() => {
+        refreshChartAndDownload();
+    }, 200);
+});
 
 /**
  * @param {string} text - Status text.
@@ -580,6 +608,37 @@ async function runBenchmark(config, colIndex, budgetIndices) {
 // ── Chart + download ──
 
 /**
+ * Size the chart canvas to the benchmark table width and allocate a sharp bitmap (CSS size × DPR).
+ *
+ * @param {HTMLCanvasElement} chartCanvas - Chart canvas.
+ */
+function layoutBenchmarkChartCanvas(chartCanvas) {
+    const tw = Math.max(
+        table.offsetWidth,
+        table.scrollWidth,
+        Math.ceil(table.getBoundingClientRect().width)
+    );
+    const cssW = Math.max(1, Math.ceil(tw));
+    const cssH = cssW * (CHART_REF_H / CHART_REF_W);
+    const dpr = typeof window.devicePixelRatio === 'number' && window.devicePixelRatio > 0 ? window.devicePixelRatio : 1;
+    const pixW = Math.max(1, Math.round(cssW * dpr));
+    const pixH = Math.max(1, Math.round(cssH * dpr));
+
+    Object.assign(chartCanvas.style, {
+        display: 'block',
+        background: '#1a1a2e',
+        borderRadius: '4px',
+        width: `${cssW}px`,
+        height: `${cssH}px`,
+        marginBottom: '12px',
+        maxWidth: 'none',
+        boxSizing: 'border-box'
+    });
+    chartCanvas.width = pixW;
+    chartCanvas.height = pixH;
+}
+
+/**
  * @param {number} v - Value.
  * @returns {string} Formatted.
  */
@@ -594,18 +653,15 @@ function refreshChartAndDownload() {
     if (!anyResults) return;
 
     const chartCanvas = document.createElement('canvas');
-    chartCanvas.width = 778;
-    chartCanvas.height = 389;
-    Object.assign(chartCanvas.style, {
-        display: 'block',
-        background: '#1a1a2e',
-        borderRadius: '4px',
-        width: '100%',
-        maxWidth: '770px',
-        marginBottom: '12px'
-    });
     chartArea.appendChild(chartCanvas);
-    drawChart(chartCanvas);
+
+    const finishChart = () => {
+        layoutBenchmarkChartCanvas(chartCanvas);
+        drawChart(chartCanvas);
+    };
+    requestAnimationFrame(() => {
+        requestAnimationFrame(finishChart);
+    });
 
     const dlText = buildDownloadText();
     const btnStyle = {
@@ -736,26 +792,78 @@ function buildDownloadText() {
 }
 
 /**
- * Rasterize the visible benchmark page (containerEl) to a PNG blob,
+ * Full layout size of an element: scroll metrics plus max extent of large descendants.
+ * Mobile Safari often under-reports scrollHeight for width:100% canvases; probing fixes chart clipping.
+ *
+ * @param {HTMLElement} el - Element.
+ * @returns {{ w: number, h: number }} Pixel dimensions (ceil).
+ */
+function captureElementSize(el) {
+    const rect = el.getBoundingClientRect();
+    const rootTop = rect.top;
+    const rootLeft = rect.left;
+
+    let maxW = Math.max(el.scrollWidth, el.offsetWidth, rect.width);
+    let maxH = Math.max(el.scrollHeight, el.offsetHeight, rect.height);
+
+    const probe = (/** @type {Element} */ node) => {
+        if (!node || typeof node.getBoundingClientRect !== 'function') return;
+        const r = node.getBoundingClientRect();
+        maxW = Math.max(maxW, r.right - rootLeft);
+        maxH = Math.max(maxH, r.bottom - rootTop);
+    };
+
+    el.querySelectorAll('canvas, img, table, button').forEach(probe);
+
+    return {
+        w: Math.ceil(Math.max(1, maxW)),
+        h: Math.ceil(Math.max(1, maxH))
+    };
+}
+
+/**
+ * Rasterize the benchmark page (containerEl) to a PNG blob,
  * trimming uniform #111 background edges.
  *
  * @returns {Promise<Blob|null>} PNG blob.
  */
 async function pageToPngBlob() {
-    const { width, height } = containerEl.getBoundingClientRect();
-    const W = Math.ceil(width);
-    const H = Math.ceil(height);
+    const { w: W, h: H } = captureElementSize(containerEl);
 
     // Clone; canvases don't render inside foreignObject, so swap them for <img>.
     const clone = /** @type {HTMLElement} */ (containerEl.cloneNode(true));
     clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+    // Hint full content width so mobile browsers lay out the clone like desktop (wide table).
+    clone.style.boxSizing = 'border-box';
+    clone.style.width = `${W}px`;
+    clone.style.minHeight = `${H}px`;
+    clone.style.overflow = 'visible';
+
+    const tbl = clone.querySelector('table');
+    if (tbl) {
+        tbl.style.width = 'max-content';
+        tbl.style.maxWidth = 'none';
+    }
+
     const lives = containerEl.querySelectorAll('canvas');
     clone.querySelectorAll('canvas').forEach((c, i) => {
+        const live = lives[i];
+        const rr = live.getBoundingClientRect();
         const img = document.createElement('img');
-        img.src = lives[i].toDataURL();
-        img.width = lives[i].width;
-        img.height = lives[i].height;
-        img.style.cssText = c.style.cssText;
+        img.src = live.toDataURL();
+        img.width = live.width;
+        img.height = live.height;
+        // Match on-screen CSS pixel size so foreignObject reserves full chart height (avoids squashed / clipped canvas on mobile).
+        img.style.cssText = [
+            'display:block',
+            `background:${live.style.background || '#1a1a2e'}`,
+            `border-radius:${live.style.borderRadius || '4px'}`,
+            `margin-bottom:${live.style.marginBottom || '12px'}`,
+            `width:${Math.ceil(rr.width)}px`,
+            `height:${Math.ceil(rr.height)}px`,
+            'max-width:none',
+            'box-sizing:border-box'
+        ].join(';');
         c.replaceWith(img);
     });
 
@@ -770,26 +878,52 @@ async function pageToPngBlob() {
     const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
     ctx.fillStyle = '#111';
     ctx.fillRect(0, 0, W, H);
-    ctx.drawImage(pageImg, 0, 0);
+    ctx.drawImage(pageImg, 0, 0, W, H);
 
-    // Find bounding box of non-background pixels and crop with a small padding.
+    // Trim uniform #111 margins; keep alpha so AA edges are not misclassified as bg.
     const data = ctx.getImageData(0, 0, W, H).data;
-    const BG = 0x11, TOL = 6, PAD = 10;
-    let x0 = W, y0 = H, x1 = -1, y1 = -1;
+    const BG = 0x11;
+    const TOL = 4;
+    const PAD = 16;
+    /**
+     * Predicate for non-background pixels.
+     * @param {number} i - Index into data (rgba byte index of R).
+     * @returns {boolean} True if pixel is not uniform background.
+     */
+    const isContent = (i) => {
+        if (data[i + 3] < 255) {
+            return true;
+        }
+        const r = data[i];
+        const g = data[i + 1];
+        const b = data[i + 2];
+        return Math.abs(r - BG) > TOL || Math.abs(g - BG) > TOL || Math.abs(b - BG) > TOL;
+    };
+    let x0 = W;
+    let y0 = H;
+    let x1 = -1;
+    let y1 = -1;
     for (let y = 0; y < H; y++) {
         for (let x = 0; x < W; x++) {
             const i = (y * W + x) * 4;
-            if (Math.abs(data[i] - BG) > TOL || Math.abs(data[i + 1] - BG) > TOL || Math.abs(data[i + 2] - BG) > TOL) {
-                x0 = Math.min(x0, x); x1 = Math.max(x1, x);
-                y0 = Math.min(y0, y); y1 = Math.max(y1, y);
+            if (isContent(i)) {
+                x0 = Math.min(x0, x);
+                x1 = Math.max(x1, x);
+                y0 = Math.min(y0, y);
+                y1 = Math.max(y1, y);
             }
         }
     }
     if (x1 < 0) {
-        x0 = 0; y0 = 0; x1 = W - 1; y1 = H - 1;
+        x0 = 0;
+        y0 = 0;
+        x1 = W - 1;
+        y1 = H - 1;
     } else {
-        x0 = Math.max(0, x0 - PAD); y0 = Math.max(0, y0 - PAD);
-        x1 = Math.min(W - 1, x1 + PAD); y1 = Math.min(H - 1, y1 + PAD);
+        x0 = Math.max(0, x0 - PAD);
+        y0 = Math.max(0, y0 - PAD);
+        x1 = Math.min(W - 1, x1 + PAD);
+        y1 = Math.min(H - 1, y1 + PAD);
     }
 
     const out = document.createElement('canvas');
@@ -810,10 +944,48 @@ function drawChart(chartCanvas) {
 
     const W = chartCanvas.width;
     const H = chartCanvas.height;
-    const PAD = { top: 30, right: 20, bottom: 40, left: 50 };
+    const scale = W / CHART_REF_W;
+
+    const PAD = {
+        top: 30 * scale,
+        right: 20 * scale,
+        bottom: 40 * scale,
+        left: 50 * scale
+    };
     const plotW = W - PAD.left - PAD.right;
     const plotH = H - PAD.top - PAD.bottom;
-    const COLORS = ['#ff6b6b', '#2ecc71', '#a06bff', '#f7dc6f'];
+    const COLORS = ['#ff6b6b', '#2ecc71', '#a06bff', '#f7dc6f', '#4a9eff'];
+
+    /** X-axis range from actual results only (avoids empty space past last tested budget). */
+    let chartMinM = Infinity;
+    let chartMaxM = -Infinity;
+    for (let c = 0; c < RENDERERS.length; c++) {
+        const r = storedResults[c];
+        if (!r) continue;
+        const br = /** @type {any} */ (r).budgetResults;
+        for (let i = 0; i < BUDGETS.length; i++) {
+            if (!br[i]) continue;
+            const m = BUDGETS[i];
+            if (m < chartMinM) chartMinM = m;
+            if (m > chartMaxM) chartMaxM = m;
+        }
+    }
+    if (!(chartMinM <= chartMaxM)) {
+        chartMinM = BUDGETS[0];
+        chartMaxM = BUDGETS[BUDGETS.length - 1];
+    }
+    const chartSpanM = chartMaxM - chartMinM;
+
+    /**
+     * @param {number} millions - Splat budget in millions.
+     * @returns {number} Canvas x in plot area.
+     */
+    const budgetToX = (millions) => {
+        if (chartSpanM <= 0) {
+            return PAD.left + plotW * 0.5;
+        }
+        return PAD.left + ((millions - chartMinM) / chartSpanM) * plotW;
+    };
 
     let maxVal = 0;
     for (let c = 0; c < RENDERERS.length; c++) {
@@ -830,7 +1002,7 @@ function drawChart(chartCanvas) {
     if (maxVal === 0) maxVal = 1;
 
     ctx.strokeStyle = '#444';
-    ctx.lineWidth = 1;
+    ctx.lineWidth = Math.max(1, scale);
     ctx.beginPath();
     ctx.moveTo(PAD.left, PAD.top);
     ctx.lineTo(PAD.left, H - PAD.bottom);
@@ -838,13 +1010,13 @@ function drawChart(chartCanvas) {
     ctx.stroke();
 
     ctx.fillStyle = '#888';
-    ctx.font = '11px monospace';
+    ctx.font = `${11 * scale}px monospace`;
     ctx.textAlign = 'right';
     const yTicks = 5;
     for (let i = 0; i <= yTicks; i++) {
         const v = (maxVal / yTicks) * i;
         const y = H - PAD.bottom - (i / yTicks) * plotH;
-        ctx.fillText(v.toFixed(1), PAD.left - 5, y + 4);
+        ctx.fillText(v.toFixed(1), PAD.left - 5 * scale, y + 4 * scale);
         ctx.strokeStyle = '#333';
         ctx.beginPath();
         ctx.moveTo(PAD.left, y);
@@ -855,14 +1027,20 @@ function drawChart(chartCanvas) {
     ctx.textAlign = 'center';
     ctx.fillStyle = '#888';
     for (let i = 0; i < BUDGETS.length; i++) {
-        const x = PAD.left + (i / (BUDGETS.length - 1)) * plotW;
-        ctx.fillText(`${BUDGETS[i]}M`, x, H - PAD.bottom + 18);
+        const m = BUDGETS[i];
+        if (m < chartMinM || m > chartMaxM) continue;
+        const x = budgetToX(m);
+        ctx.fillText(`${m}M`, x, H - PAD.bottom + 18 * scale);
     }
 
     ctx.fillStyle = '#ccc';
-    ctx.font = '12px monospace';
+    ctx.font = `${12 * scale}px monospace`;
     ctx.textAlign = 'center';
-    ctx.fillText('GPU Frame Time (ms) vs Splat Budget', W / 2, 18);
+    ctx.fillText(
+        `GPU Frame Time (ms) vs Splat Budget (M, linear x: ${chartMinM}M–${chartMaxM}M)`,
+        W / 2,
+        18 * scale
+    );
 
     for (let c = 0; c < RENDERERS.length; c++) {
         const r = storedResults[c];
@@ -872,14 +1050,14 @@ function drawChart(chartCanvas) {
         const color = COLORS[c % COLORS.length];
         ctx.strokeStyle = color;
         ctx.fillStyle = color;
-        ctx.lineWidth = 2;
+        ctx.lineWidth = 2 * scale;
 
         /** @type {{x: number, y: number}[]} */
         const points = [];
         for (let i = 0; i < BUDGETS.length; i++) {
             if (!br[i]) continue;
             const v = br[i].avgGpu >= 0 ? br[i].avgGpu : br[i].avgCpu;
-            const x = PAD.left + (i / (BUDGETS.length - 1)) * plotW;
+            const x = budgetToX(BUDGETS[i]);
             const y = H - PAD.bottom - (v / maxVal) * plotH;
             points.push({ x, y });
         }
@@ -895,21 +1073,21 @@ function drawChart(chartCanvas) {
 
         for (const pt of points) {
             ctx.beginPath();
-            ctx.arc(pt.x, pt.y, 3, 0, Math.PI * 2);
+            ctx.arc(pt.x, pt.y, 3 * scale, 0, Math.PI * 2);
             ctx.fill();
         }
     }
 
     // Legend
-    ctx.font = '10px monospace';
+    ctx.font = `${10 * scale}px monospace`;
     ctx.textAlign = 'left';
     for (let c = 0; c < RENDERERS.length; c++) {
         const color = COLORS[c % COLORS.length];
-        const lx = PAD.left + 10;
-        const ly = PAD.top + 10 + c * 14;
+        const lx = PAD.left + 10 * scale;
+        const ly = PAD.top + 10 * scale + c * 14 * scale;
         ctx.fillStyle = storedResults[c] ? color : '#444';
-        ctx.fillRect(lx, ly - 4, 10, 3);
-        ctx.fillText(RENDERERS[c].label, lx + 14, ly);
+        ctx.fillRect(lx, ly - 4 * scale, 10 * scale, 3 * scale);
+        ctx.fillText(RENDERERS[c].label, lx + 14 * scale, ly);
     }
 }
 

--- a/examples/src/examples/gaussian-splatting/crop.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/crop.controls.mjs
@@ -18,7 +18,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         ),

--- a/examples/src/examples/gaussian-splatting/editor.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/editor.controls.mjs
@@ -21,7 +21,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
                         { v: 2, t: 'Raster (GPU Sort)' },
-                        { v: 3, t: 'Compute' }
+                        { v: 3, t: 'Compute' },
+                        { v: 4, t: 'Raster (Hybrid)' }
                     ]
                 })
             )

--- a/examples/src/examples/gaussian-splatting/flipbook.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/flipbook.controls.mjs
@@ -17,7 +17,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         )

--- a/examples/src/examples/gaussian-splatting/global-sorting.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/global-sorting.controls.mjs
@@ -17,7 +17,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         ),

--- a/examples/src/examples/gaussian-splatting/lod-instances.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-instances.controls.mjs
@@ -20,7 +20,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
                         { v: 2, t: 'Raster (GPU Sort)' },
-                        { v: 3, t: 'Compute' }
+                        { v: 3, t: 'Compute' },
+                        { v: 4, t: 'Raster (Hybrid)' }
                     ]
                 })
             ),

--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.controls.mjs
@@ -20,7 +20,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
                         { v: 2, t: 'Raster (GPU Sort)' },
-                        { v: 3, t: 'Compute' }
+                        { v: 3, t: 'Compute' },
+                        { v: 4, t: 'Raster (Hybrid)' }
                     ]
                 })
             ),

--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
@@ -170,7 +170,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
                         { v: 2, t: 'Raster (GPU Sort)' },
-                        { v: 3, t: 'Compute' }
+                        { v: 3, t: 'Compute' },
+                        { v: 4, t: 'Raster (Hybrid)' }
                     ]
                 })
             ),
@@ -194,6 +195,17 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     min: 0,
                     max: 10,
                     precision: 1
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Alpha Cull' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'alphaCull' },
+                    min: 0,
+                    max: 1,
+                    precision: 3
                 })
             ),
             jsx(

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -185,6 +185,9 @@ assetListLoader.load(async () => {
     data.on('minPixelSize:set', () => {
         app.scene.gsplat.minPixelSize = data.get('minPixelSize');
     });
+    data.on('alphaCull:set', () => {
+        app.scene.gsplat.alphaCull = data.get('alphaCull');
+    });
     data.on('minContribution:set', () => {
         app.scene.gsplat.minContribution = data.get('minContribution');
     });
@@ -203,6 +206,7 @@ assetListLoader.load(async () => {
     data.set('toneMapping', pc.TONEMAP_LINEAR);
     data.set('exposure', 1);
     data.set('minPixelSize', 2);
+    data.set('alphaCull', 1 / 255);
     data.set('minContribution', 3);
     data.set('radialSorting', true);
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);

--- a/examples/src/examples/gaussian-splatting/multi-view.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/multi-view.controls.mjs
@@ -17,7 +17,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         )

--- a/examples/src/examples/gaussian-splatting/paint.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/paint.controls.mjs
@@ -21,7 +21,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
                         { v: 2, t: 'Raster (GPU Sort)' },
-                        { v: 3, t: 'Compute' }
+                        { v: 3, t: 'Compute' },
+                        { v: 4, t: 'Raster (Hybrid)' }
                     ]
                 })
             )

--- a/examples/src/examples/gaussian-splatting/picking.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/picking.controls.mjs
@@ -17,7 +17,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         ),

--- a/examples/src/examples/gaussian-splatting/procedural-instanced.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-instanced.controls.mjs
@@ -17,7 +17,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         )

--- a/examples/src/examples/gaussian-splatting/procedural-mesh.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-mesh.controls.mjs
@@ -17,7 +17,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         )

--- a/examples/src/examples/gaussian-splatting/procedural-shapes.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-shapes.controls.mjs
@@ -18,7 +18,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         ),

--- a/examples/src/examples/gaussian-splatting/reveal.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/reveal.controls.mjs
@@ -17,7 +17,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         ),

--- a/examples/src/examples/gaussian-splatting/shader-effects.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/shader-effects.controls.mjs
@@ -17,7 +17,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         ),

--- a/examples/src/examples/gaussian-splatting/shadows.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/shadows.controls.mjs
@@ -17,7 +17,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         ),

--- a/examples/src/examples/gaussian-splatting/viewer.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.controls.mjs
@@ -22,7 +22,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
                         { v: 2, t: 'Raster (GPU Sort)' },
-                        { v: 3, t: 'Compute' }
+                        { v: 3, t: 'Compute' },
+                        { v: 4, t: 'Raster (Hybrid)' }
                     ]
                 })
             )

--- a/examples/src/examples/gaussian-splatting/weather.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/weather.controls.mjs
@@ -20,7 +20,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
                         { v: 2, t: 'Raster (GPU Sort)' },
-                        { v: 3, t: 'Compute' }
+                        { v: 3, t: 'Compute' },
+                        { v: 4, t: 'Raster (Hybrid)' }
                     ]
                 })
             )

--- a/examples/src/examples/gaussian-splatting/world.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/world.controls.mjs
@@ -20,7 +20,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
                         { v: 2, t: 'Raster (GPU Sort)' },
-                        { v: 3, t: 'Compute' }
+                        { v: 3, t: 'Compute' },
+                        { v: 4, t: 'Raster (Hybrid)' }
                     ]
                 })
             )

--- a/examples/src/examples/gaussian-splatting/xr-views.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/xr-views.controls.mjs
@@ -17,7 +17,8 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
                     { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
                 ]
             })
         ),

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1242,6 +1242,17 @@ export const GSPLAT_RENDERER_RASTER_GPU_SORT = 2;
 export const GSPLAT_RENDERER_COMPUTE = 3;
 
 /**
+ * Hybrid rasterization renderer that performs projection, screen-space culling and sort key
+ * generation in a single compute pass, sorts globally via a compute radix sort, and rasterizes
+ * quads from a pre-projected cache. WebGPU only. Experimental with limited functionality.
+ *
+ * @type {number}
+ * @category Graphics
+ * @ignore
+ */
+export const GSPLAT_RENDERER_RASTER_HYBRID = 4;
+
+/**
  * No debug rendering for Gaussian splats. Normal rendering mode.
  *
  * @type {number}

--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -32,6 +32,7 @@ import { computeGsplatLocalBucketSortSource } from '../shader-lib/wgsl/chunks/gs
 import { computeGsplatLocalChunkSortSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-chunk-sort.js';
 import { computeGsplatLocalCopySource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-copy.js';
 import { computeGsplatLocalBitonicSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-bitonic.js';
+import { computeGsplatProjectCommonSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-project-common.js';
 import { computeGsplatCommonSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-common.js';
 import { computeGsplatTileIntersectSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-tile-intersect.js';
 import { GSplatTileComposite } from './gsplat-tile-composite.js';
@@ -1263,6 +1264,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         cincludes.set('gsplatComputeSplatCS', computeSplatSource);
         cincludes.set('gsplatFormatDeclCS', wbFormat.getComputeInputDeclarations(fixedBindings.length));
         cincludes.set('gsplatFormatReadCS', wbFormat.getReadCode());
+        cincludes.set('gsplatProjectCommonCS', computeGsplatProjectCommonSource);
 
         const cdefines = new Map();
         cdefines.set('{CACHE_STRIDE}', CACHE_STRIDE.toString());

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -154,7 +154,7 @@ class GSplatHybridRenderer extends GSplatRenderer {
 
     configureMaterial() {
         this._material.setDefine('SH_BANDS', '0');
-        this._material.setDefine('GSPLAT_INDIRECT_DRAW', '');
+        this._material.setDefine('GSPLAT_INDIRECT_DRAW', true);
         this._updateIdDefines(this._material);
 
         const dither = false;
@@ -224,7 +224,7 @@ class GSplatHybridRenderer extends GSplatRenderer {
             this._pickMaterial.setDefine('{GSPLAT_INSTANCE_SIZE}', GSplatResourceBase.instanceSize);
             this._pickMaterial.setDefine('{CACHE_STRIDE}', CACHE_STRIDE);
             this._pickMaterial.setDefine('SH_BANDS', '0');
-            this._pickMaterial.setDefine('GSPLAT_INDIRECT_DRAW', '');
+            this._pickMaterial.setDefine('GSPLAT_INDIRECT_DRAW', true);
             this._pickMaterial.setDefine('DITHER_NONE', '');
             this._updateIdDefines(this._pickMaterial);
             this._pickMaterial.cull = CULLFACE_NONE;

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -259,18 +259,35 @@ class GSplatHybridRenderer extends GSplatRenderer {
     }
 
     /**
-     * Computes `-inverse(matrix_projection)[row 2]` for the given camera into `dst`. The
-     * hybrid VS dot-products this with the cached `clipPos` to recover linear view depth,
-     * which is needed for fog / overdraw / prepass under both perspective and orthographic
-     * projections. The destination buffer must be retained by the caller (typically a
-     * per-material instance field) because the GPU upload happens at draw time.
+     * Computes the per-camera `clipToViewZ` value into `dst`. The hybrid VS dot-products
+     * this with the cached `clipPos` to recover linear view depth, used by fog / overdraw
+     * / prepass.
+     *
+     * - Perspective + orthographic: `dst = -inverse(matrix_projection)[row 2]`. The
+     *   projector stores `clipPos.w` in slot [3] and the dot-product yields `-view.z`.
+     * - Fisheye: `dst = (0, 0, far - near, near)`. The projector stores depthNdc in
+     *   slot [2] and `1.0` in slot [3], so the dot-product reduces to
+     *   `depthNdc * (far - near) + near`, which equals linear `-view.z`.
+     *
+     * The destination buffer must be retained by the caller (typically a per-material
+     * instance field) because the GPU upload happens at draw time.
      *
      * @param {GraphNode} cameraNode - Camera node to derive the uniform from.
      * @param {Float32Array} dst - 4-element destination, written in place.
      * @private
      */
     _computeClipToViewZ(cameraNode, dst) {
-        _invProjMat.copy(cameraNode.camera.projectionMatrix).invert();
+        const cam = cameraNode.camera;
+        if (this.fisheyeProj.enabled) {
+            const near = cam.nearClip;
+            const far = cam.farClip;
+            dst[0] = 0;
+            dst[1] = 0;
+            dst[2] = far - near;
+            dst[3] = near;
+            return;
+        }
+        _invProjMat.copy(cam.projectionMatrix).invert();
         const d = _invProjMat.data;
         dst[0] = -d[2];
         dst[1] = -d[6];

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -1,3 +1,4 @@
+import { Mat4 } from '../../core/math/mat4.js';
 import { SEMANTIC_POSITION, CULLFACE_NONE } from '../../platform/graphics/constants.js';
 import {
     BLEND_NONE, BLEND_PREMULTIPLIED, BLEND_ADDITIVE, GSPLAT_FORWARD,
@@ -8,6 +9,12 @@ import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
 import { MeshInstance } from '../mesh-instance.js';
 import { GSplatRenderer } from './gsplat-renderer.js';
 import { CACHE_STRIDE } from './gsplat-projector-constants.js';
+
+// Module-scope scratch matrix used only inside `_computeClipToViewZ`. The output
+// (`Float32Array`) lives on each renderer instance because it must remain valid
+// until the GPU upload happens at draw time, and multiple renderer instances may
+// render concurrently with different cameras.
+const _invProjMat = new Mat4();
 
 /**
  * @import { StorageBuffer } from '../../platform/graphics/storage-buffer.js'
@@ -39,6 +46,22 @@ class GSplatHybridRenderer extends GSplatRenderer {
 
     /** @type {MeshInstance|null} */
     _pickMeshInstance = null;
+
+    /**
+     * Per-camera `clipToViewZ` value for the forward material. Persistent: the GPU
+     * upload happens at draw time, so the buffer must outlive `setHybridSortedRendering`.
+     *
+     * @type {Float32Array}
+     */
+    _clipToViewZ = new Float32Array(4);
+
+    /**
+     * Per-camera `clipToViewZ` value for the pick material. Allocated on first
+     * `prepareForPicking` call and reused thereafter.
+     *
+     * @type {Float32Array|null}
+     */
+    _clipToViewZPick = null;
 
     /** @type {number} */
     originalBlendType = BLEND_ADDITIVE;
@@ -165,6 +188,8 @@ class GSplatHybridRenderer extends GSplatRenderer {
         this._material.setParameter('sortedIndices', sortedIndices);
         this._material.setParameter('projCache', projCache);
         this._material.setParameter('numSplatsStorage', numSplatsBuffer);
+        this._computeClipToViewZ(this.cameraNode, this._clipToViewZ);
+        this._material.setParameter('clipToViewZ', this._clipToViewZ);
 
         this.meshInstance.visible = true;
 
@@ -181,9 +206,11 @@ class GSplatHybridRenderer extends GSplatRenderer {
      * @param {StorageBuffer} projCache - Per-splat projection cache produced by the projector.
      * @param {StorageBuffer} numSplatsBuffer - GPU-written visible-splat count.
      * @param {number} alphaClip - Fragment alpha threshold for picking.
+     * @param {GraphNode} cameraNode - The picker camera node, used to derive the
+     * `clipToViewZ` reconstruction uniform.
      * @returns {MeshInstance} The pick mesh instance.
      */
-    prepareForPicking(drawSlot, sortedIndices, projCache, numSplatsBuffer, alphaClip) {
+    prepareForPicking(drawSlot, sortedIndices, projCache, numSplatsBuffer, alphaClip, cameraNode) {
         if (!this._pickMaterial) {
             this._pickMaterial = new ShaderMaterial({
                 uniqueName: 'UnifiedSplatHybridPickMaterial',
@@ -224,8 +251,31 @@ class GSplatHybridRenderer extends GSplatRenderer {
         pickMaterial.setParameter('projCache', projCache);
         pickMaterial.setParameter('numSplatsStorage', numSplatsBuffer);
         pickMaterial.setParameter('alphaClip', alphaClip);
+        this._clipToViewZPick ??= new Float32Array(4);
+        this._computeClipToViewZ(cameraNode, this._clipToViewZPick);
+        pickMaterial.setParameter('clipToViewZ', this._clipToViewZPick);
 
         return pickMeshInstance;
+    }
+
+    /**
+     * Computes `-inverse(matrix_projection)[row 2]` for the given camera into `dst`. The
+     * hybrid VS dot-products this with the cached `clipPos` to recover linear view depth,
+     * which is needed for fog / overdraw / prepass under both perspective and orthographic
+     * projections. The destination buffer must be retained by the caller (typically a
+     * per-material instance field) because the GPU upload happens at draw time.
+     *
+     * @param {GraphNode} cameraNode - Camera node to derive the uniform from.
+     * @param {Float32Array} dst - 4-element destination, written in place.
+     * @private
+     */
+    _computeClipToViewZ(cameraNode, dst) {
+        _invProjMat.copy(cameraNode.camera.projectionMatrix).invert();
+        const d = _invProjMat.data;
+        dst[0] = -d[2];
+        dst[1] = -d[6];
+        dst[2] = -d[10];
+        dst[3] = -d[14];
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -1,0 +1,323 @@
+import { SEMANTIC_POSITION, CULLFACE_NONE } from '../../platform/graphics/constants.js';
+import {
+    BLEND_NONE, BLEND_PREMULTIPLIED, BLEND_ADDITIVE, GSPLAT_FORWARD,
+    SHADOWCAMERA_NAME
+} from '../constants.js';
+import { ShaderMaterial } from '../materials/shader-material.js';
+import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
+import { MeshInstance } from '../mesh-instance.js';
+import { GSplatRenderer } from './gsplat-renderer.js';
+import { CACHE_STRIDE } from './gsplat-projector-constants.js';
+
+/**
+ * @import { StorageBuffer } from '../../platform/graphics/storage-buffer.js'
+ * @import { GraphNode } from '../graph-node.js'
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ * @import { Layer } from '../layer.js'
+ * @import { GSplatWorkBuffer } from './gsplat-work-buffer.js'
+ */
+
+/**
+ * Renders splats from a pre-projected cache built by the projector compute pass
+ * (see {@link GSplatProjector}) and a globally radix-sorted index array. The
+ * vertex shader is `gsplatHybridVS`; the fragment is the existing `gsplatPS`.
+ *
+ * Supports forward rendering and explicit pick/prepass paths. Shadow rendering is
+ * intentionally not supported because the projection cache is camera-specific.
+ *
+ * @ignore
+ */
+class GSplatHybridRenderer extends GSplatRenderer {
+    /** @type {ShaderMaterial} */
+    _material;
+
+    /** @type {MeshInstance} */
+    meshInstance;
+
+    /** @type {ShaderMaterial|null} */
+    _pickMaterial = null;
+
+    /** @type {MeshInstance|null} */
+    _pickMeshInstance = null;
+
+    /** @type {number} */
+    originalBlendType = BLEND_ADDITIVE;
+
+    /** @type {Set<string>} */
+    _internalDefines = new Set();
+
+    /** @type {boolean} */
+    forceCopyMaterial = true;
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {GraphNode} node - The graph node.
+     * @param {GraphNode} cameraNode - The camera node.
+     * @param {Layer} layer - The layer to add mesh instances to.
+     * @param {GSplatWorkBuffer} workBuffer - The work buffer (kept for parent compatibility;
+     * the hybrid renderer does not bind work-buffer textures itself).
+     */
+    constructor(device, node, cameraNode, layer, workBuffer) {
+        super(device, node, cameraNode, layer, workBuffer);
+
+        this._material = new ShaderMaterial({
+            uniqueName: 'UnifiedSplatHybridMaterial',
+            vertexWGSL: '#include "gsplatHybridVS"',
+            fragmentWGSL: '#include "gsplatPS"',
+            attributes: {
+                vertex_position: SEMANTIC_POSITION
+            }
+        });
+
+        this._material.setDefine('{GSPLAT_INSTANCE_SIZE}', GSplatResourceBase.instanceSize);
+        this._material.setDefine('{CACHE_STRIDE}', CACHE_STRIDE);
+
+        this.configureMaterial();
+
+        this._material.defines.forEach((value, key) => {
+            this._internalDefines.add(key);
+        });
+
+        // Defines that may be added dynamically; preserve them when copying user material.
+        this._internalDefines.add('{GSPLAT_INSTANCE_SIZE}');
+        this._internalDefines.add('{CACHE_STRIDE}');
+        this._internalDefines.add('GSPLAT_UNIFIED_ID');
+        this._internalDefines.add('PICK_CUSTOM_ID');
+        this._internalDefines.add('GSPLAT_OVERDRAW');
+        this._internalDefines.add('GSPLAT_NO_FOG');
+
+        this.meshInstance = this.createMeshInstance();
+    }
+
+    /**
+     * Sets the render mode. The hybrid path does not add shadow casters; shadow cameras
+     * need their own projection cache and remain unsupported here.
+     *
+     * @param {number} renderMode - Bitmask flags controlling render passes.
+     */
+    setRenderMode(renderMode) {
+        const oldRenderMode = this.renderMode ?? 0;
+        const wasForward = (oldRenderMode & GSPLAT_FORWARD) !== 0;
+        const isForward = (renderMode & GSPLAT_FORWARD) !== 0;
+
+        if (wasForward && !isForward) {
+            this.layer.removeMeshInstances([this.meshInstance], true);
+        }
+        if (!wasForward && isForward) {
+            this.layer.addMeshInstances([this.meshInstance], true);
+        }
+
+        super.setRenderMode(renderMode);
+    }
+
+    destroy() {
+        if (this.renderMode && (this.renderMode & GSPLAT_FORWARD)) {
+            this.layer.removeMeshInstances([this.meshInstance], true);
+        }
+        this._material.destroy();
+        this._pickMaterial?.destroy();
+        this.meshInstance.destroy();
+        this._pickMeshInstance?.destroy();
+        super.destroy();
+    }
+
+    get material() {
+        return this._material;
+    }
+
+    onWorkBufferFormatChanged() {
+        this.configureMaterial();
+    }
+
+    configureMaterial() {
+        this._material.setDefine('SH_BANDS', '0');
+        this._material.setDefine('GSPLAT_INDIRECT_DRAW', '');
+        this._updateIdDefines(this._material);
+
+        const dither = false;
+        this._material.setDefine(`DITHER_${dither ? 'BLUENOISE' : 'NONE'}`, '');
+        this._material.cull = CULLFACE_NONE;
+        this._material.blendType = dither ? BLEND_NONE : BLEND_PREMULTIPLIED;
+        this._material.depthWrite = !!dither;
+        this._material.update();
+    }
+
+    update(count, textureSize) {
+        // Indirect-draw path; the GPU-written instance count drives instancing. We just
+        // need a non-zero instancingCount so the forward renderer issues the draw call.
+        if (this.meshInstance.instancingCount <= 0) {
+            this.meshInstance.instancingCount = 1;
+        }
+        this.meshInstance.visible = count > 0;
+    }
+
+    /**
+     * Configures the renderer to draw from the projector's caches.
+     *
+     * @param {number} drawSlot - The indirect draw slot index.
+     * @param {StorageBuffer} sortedIndices - Globally-sorted indices into projCache.
+     * @param {StorageBuffer} projCache - Per-splat projection cache produced by the projector.
+     * @param {StorageBuffer} numSplatsBuffer - GPU-written visible-splat count.
+     */
+    setHybridSortedRendering(drawSlot, sortedIndices, projCache, numSplatsBuffer) {
+        this.meshInstance.setIndirect(null, drawSlot, 1);
+
+        this._material.setParameter('sortedIndices', sortedIndices);
+        this._material.setParameter('projCache', projCache);
+        this._material.setParameter('numSplatsStorage', numSplatsBuffer);
+
+        this.meshInstance.visible = true;
+
+        if (this.meshInstance.instancingCount <= 0) {
+            this.meshInstance.instancingCount = 1;
+        }
+    }
+
+    /**
+     * Configures and returns a transient pick mesh instance for the picker render pass.
+     *
+     * @param {number} drawSlot - The indirect draw slot index.
+     * @param {StorageBuffer} sortedIndices - Globally-sorted indices into projCache.
+     * @param {StorageBuffer} projCache - Per-splat projection cache produced by the projector.
+     * @param {StorageBuffer} numSplatsBuffer - GPU-written visible-splat count.
+     * @param {number} alphaClip - Fragment alpha threshold for picking.
+     * @returns {MeshInstance} The pick mesh instance.
+     */
+    prepareForPicking(drawSlot, sortedIndices, projCache, numSplatsBuffer, alphaClip) {
+        if (!this._pickMaterial) {
+            this._pickMaterial = new ShaderMaterial({
+                uniqueName: 'UnifiedSplatHybridPickMaterial',
+                vertexWGSL: '#include "gsplatHybridVS"',
+                fragmentWGSL: '#include "gsplatPS"',
+                attributes: {
+                    vertex_position: SEMANTIC_POSITION
+                }
+            });
+
+            this._pickMaterial.setDefine('{GSPLAT_INSTANCE_SIZE}', GSplatResourceBase.instanceSize);
+            this._pickMaterial.setDefine('{CACHE_STRIDE}', CACHE_STRIDE);
+            this._pickMaterial.setDefine('SH_BANDS', '0');
+            this._pickMaterial.setDefine('GSPLAT_INDIRECT_DRAW', '');
+            this._pickMaterial.setDefine('DITHER_NONE', '');
+            this._updateIdDefines(this._pickMaterial);
+            this._pickMaterial.cull = CULLFACE_NONE;
+            this._pickMaterial.blendType = BLEND_NONE;
+            this._pickMaterial.depthWrite = false;
+            this._pickMaterial.update();
+
+            const mesh = GSplatResourceBase.createMesh(this.device);
+            this._pickMeshInstance = new MeshInstance(mesh, this._pickMaterial);
+            this._pickMeshInstance.node = this.node;
+            this._pickMeshInstance.setInstancing(true, true);
+            this._pickMeshInstance.instancingCount = 1;
+        } else {
+            if (this._updateIdDefines(this._pickMaterial)) {
+                this._pickMaterial.update();
+            }
+        }
+
+        const pickMaterial = /** @type {ShaderMaterial} */ (this._pickMaterial);
+        const pickMeshInstance = /** @type {MeshInstance} */ (this._pickMeshInstance);
+
+        pickMeshInstance.setIndirect(null, drawSlot, 1);
+        pickMaterial.setParameter('sortedIndices', sortedIndices);
+        pickMaterial.setParameter('projCache', projCache);
+        pickMaterial.setParameter('numSplatsStorage', numSplatsBuffer);
+        pickMaterial.setParameter('alphaClip', alphaClip);
+
+        return pickMeshInstance;
+    }
+
+    /**
+     * The hybrid path is GPU-driven only; CPU-sort is handled by the quad renderer
+     * (the manager swaps renderers when the active mode changes).
+     */
+    setCpuSortedRendering() {
+        this.meshInstance.setIndirect(null, -1);
+        this.meshInstance.visible = false;
+    }
+
+    setOrderData() {
+        // No-op: order is consumed via sortedIndices storage buffer set in
+        // setHybridSortedRendering; nothing to bind from the work buffer.
+    }
+
+    frameUpdate(params) {
+        this._material.setParameter('alphaClip', params.alphaClip);
+        this._pickMaterial?.setParameter('alphaClip', params.alphaClip);
+
+        if (params.colorRamp) {
+            this._material.setParameter('colorRampIntensity', params.colorRampIntensity);
+        }
+
+        const noFog = !params.useFog;
+        if (noFog !== this._lastNoFog) {
+            this._lastNoFog = noFog;
+            this._material.setDefine('GSPLAT_NO_FOG', noFog);
+            this._material.update();
+        }
+    }
+
+    /**
+     * Updates pick ID defines to match the work-buffer format.
+     *
+     * @param {ShaderMaterial} material - Material to update.
+     * @returns {boolean} True if the material defines changed.
+     * @private
+     */
+    _updateIdDefines(material) {
+        const hasPcId = !!this.workBuffer.format.getStream('pcId');
+        const changed = material.getDefine('GSPLAT_UNIFIED_ID') !== hasPcId ||
+            material.getDefine('PICK_CUSTOM_ID') !== hasPcId;
+        material.setDefine('GSPLAT_UNIFIED_ID', hasPcId);
+        material.setDefine('PICK_CUSTOM_ID', hasPcId);
+        return changed;
+    }
+
+    updateOverdrawMode(params) {
+        const overdrawEnabled = !!params.colorRamp;
+        const wasOverdrawEnabled = this._material.getDefine('GSPLAT_OVERDRAW');
+
+        if (overdrawEnabled) {
+            this._material.setParameter('colorRamp', params.colorRamp);
+            this._material.setParameter('colorRampIntensity', params.colorRampIntensity);
+        }
+
+        if (overdrawEnabled !== wasOverdrawEnabled) {
+            this._material.setDefine('GSPLAT_OVERDRAW', overdrawEnabled);
+            if (overdrawEnabled) {
+                this.originalBlendType = this._material.blendType;
+                this._material.blendType = BLEND_ADDITIVE;
+            } else {
+                this._material.blendType = this.originalBlendType;
+            }
+            this._material.update();
+        }
+    }
+
+    createMeshInstance() {
+        const mesh = GSplatResourceBase.createMesh(this.device);
+        const meshInstance = new MeshInstance(mesh, this._material);
+        meshInstance.node = this.node;
+        meshInstance.setInstancing(true, true);
+        meshInstance.instancingCount = 0;
+        meshInstance.pick = false;
+
+        const thisCamera = this.cameraNode.camera;
+        meshInstance.isVisibleFunc = (camera) => {
+            const renderMode = this.renderMode ?? 0;
+            if (thisCamera.camera === camera && (renderMode & GSPLAT_FORWARD)) {
+                return true;
+            }
+            // Hybrid renderer never participates in shadow casting.
+            if (camera.node?.name === SHADOWCAMERA_NAME) {
+                return false;
+            }
+            return false;
+        };
+
+        return meshInstance;
+    }
+}
+
+export { GSplatHybridRenderer };

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -6,7 +6,9 @@ import { GSplatInfo } from './gsplat-info.js';
 import { GSplatUnifiedSorter } from './gsplat-unified-sorter.js';
 import { GSplatWorkBuffer } from './gsplat-work-buffer.js';
 import { GSplatQuadRenderer } from './gsplat-quad-renderer.js';
+import { GSplatHybridRenderer } from './gsplat-hybrid-renderer.js';
 import { GSplatComputeLocalRenderer } from './gsplat-compute-local-renderer.js';
+import { GSplatProjector } from './gsplat-projector.js';
 import { GSplatOctreeInstance } from './gsplat-octree-instance.js';
 import { GSplatOctreeResource } from './gsplat-octree.resource.js';
 import { GSplatWorldState } from './gsplat-world-state.js';
@@ -17,7 +19,8 @@ import { ComputeRadixSort } from '../graphics/radix-sort/compute-radix-sort.js';
 import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import {
-    GSPLAT_RENDERER_RASTER_CPU_SORT, GSPLAT_RENDERER_RASTER_GPU_SORT, GSPLAT_RENDERER_COMPUTE,
+    GSPLAT_RENDERER_RASTER_CPU_SORT, GSPLAT_RENDERER_RASTER_GPU_SORT, GSPLAT_RENDERER_RASTER_HYBRID,
+    GSPLAT_RENDERER_COMPUTE,
     GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE, GSPLAT_DEBUG_AABBS
 } from '../constants.js';
 import { Color } from '../../core/math/color.js';
@@ -57,6 +60,7 @@ const _localCamPos = new Vec3();
 const _closestPt = new Vec3();
 const tempOctreesTicked = new Set();
 const _queuedSplats = new Set();
+const ALPHA_VISIBILITY_THRESHOLD = 1.0 / 255.0;
 
 const _lodColorsRaw = [
     [1, 0, 0],  // red
@@ -178,6 +182,13 @@ class GSplatManager {
      * @type {GSplatIntervalCompaction|null}
      */
     intervalCompaction = null;
+
+    /**
+     * Compute projector + sort keys for {@link GSPLAT_RENDERER_RASTER_HYBRID}.
+     *
+     * @type {GSplatProjector|null}
+     */
+    projector = null;
 
     /**
      * Indirect draw slot index for the current frame (-1 when not using indirect draw).
@@ -427,6 +438,8 @@ class GSplatManager {
         this.keyGenerator = null;
         this.gpuSorter?.destroy();
         this.gpuSorter = null;
+        this.projector?.destroy();
+        this.projector = null;
 
         // Switch renderer to CPU mode once, before destroying compaction.
         const useCpuSort = false;
@@ -475,6 +488,20 @@ class GSplatManager {
     }
 
     /**
+     * GPU radix sort + projector for hybrid raster (no separate sort-key compute pass).
+     *
+     * @private
+     */
+    initHybridSorting() {
+        if (!this.gpuSorter) {
+            this.gpuSorter = new ComputeRadixSort(this.device, { indirect: true });
+        }
+        if (!this.projector) {
+            this.projector = new GSplatProjector(this.device);
+        }
+    }
+
+    /**
      * Creates the CPU sorter and prepares it for the current world state. Disables any
      * GPU-side indirect draw and hides the mesh until the first sort result arrives.
      *
@@ -502,8 +529,9 @@ class GSplatManager {
     }
 
     /**
-     * Dispatches compute pick pipeline and returns the configured pick mesh instance.
-     * Only works when the local compute renderer is active.
+     * Dispatches a renderer-specific pick pipeline and returns the configured pick mesh instance.
+     * The local compute renderer renders to pick textures; the hybrid renderer refreshes its
+     * shared projector/sort buffers for the picker camera and returns a transient pick mesh.
      *
      * @param {object} camera - The camera.
      * @param {number} width - Pick target width.
@@ -511,6 +539,31 @@ class GSplatManager {
      * @returns {import('../mesh-instance.js').MeshInstance|null} The pick mesh instance, or null.
      */
     prepareForPicking(camera, width, height) {
+        if (this.activeRenderer === GSPLAT_RENDERER_RASTER_HYBRID) {
+            const sortedState = this.worldStates.get(this.sortedVersion);
+            if (!sortedState?.sortedBefore || !camera.node) return null;
+
+            const sortedIndices = this.sortGpuHybridForCamera(
+                sortedState,
+                camera.node,
+                width,
+                height,
+                Math.max(ALPHA_VISIBILITY_THRESHOLD, this.scene.gsplat.alphaClip),
+                !!this.workBuffer.format.getStream('pcId')
+            );
+            if (!sortedIndices) return null;
+
+            const proj = /** @type {GSplatProjector} */ (this.projector);
+            const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
+            return /** @type {GSplatHybridRenderer} */ (/** @type {unknown} */ (this.renderer)).prepareForPicking(
+                this.indirectDrawSlot,
+                sortedIndices,
+                /** @type {StorageBuffer} */ (proj.projCache),
+                /** @type {StorageBuffer} */ (ic.numSplatsBuffer),
+                this.scene.gsplat.alphaClip
+            );
+        }
+
         if (this.activeRenderer !== GSPLAT_RENDERER_COMPUTE) return null;
 
         /** @type {GSplatComputeLocalRenderer} */
@@ -563,6 +616,9 @@ class GSplatManager {
     _createRenderer(mode) {
         if (mode === GSPLAT_RENDERER_COMPUTE) {
             this.renderer = new GSplatComputeLocalRenderer(this.device, this.node, this.cameraNode, this.layer, this.workBuffer);
+        } else if (mode === GSPLAT_RENDERER_RASTER_HYBRID) {
+            this.renderer = new GSplatHybridRenderer(this.device, this.node, this.cameraNode, this.layer, this.workBuffer);
+            this.initHybridSorting();
         } else {
             this.renderer = new GSplatQuadRenderer(this.device, this.node, this.cameraNode, this.layer, this.workBuffer);
             if (mode === GSPLAT_RENDERER_RASTER_GPU_SORT) {
@@ -1501,6 +1557,9 @@ class GSplatManager {
                 // GPU sort runs compaction internally, so indirect draw is always valid
                 this.sortGpu(lastState);
                 gpuSortedThisFrame = true;
+            } else if (this.activeRenderer === GSPLAT_RENDERER_RASTER_HYBRID) {
+                this.sortGpuHybrid(lastState);
+                gpuSortedThisFrame = true;
             } else {
                 // CPU sort just posts to the worker — indirect draw still needs updating below
                 this.sortCpu(lastState);
@@ -1516,9 +1575,17 @@ class GSplatManager {
             this.lastCullingProjMat.copy(this.cameraNode.camera.projectionMatrix);
         }
 
+        // Hybrid raster needs projector + radix + fresh indirect args every frame (indirect
+        // slots are per-frame; post-projector visible count differs from interval prefix sum).
+        if (this.activeRenderer === GSPLAT_RENDERER_RASTER_HYBRID && lastState && !gpuSortedThisFrame) {
+            this.sortGpuHybrid(lastState);
+            gpuSortedThisFrame = true;
+        }
+
         // Refresh the per-frame indirect draw slot on non-sort frames
         // (sortGpu already handled GPU-sort frames).
-        if (this.activeRenderer !== GSPLAT_RENDERER_COMPUTE && this.intervalCompaction && !gpuSortedThisFrame) {
+        if (this.activeRenderer !== GSPLAT_RENDERER_COMPUTE && this.activeRenderer !== GSPLAT_RENDERER_RASTER_HYBRID &&
+            this.intervalCompaction && !gpuSortedThisFrame) {
             this.refreshIndirectDraw();
         }
 
@@ -1628,6 +1695,133 @@ class GSplatManager {
 
         // Apply sorted results to the renderer
         this.applyGpuSortResults(worldState, sortedIndices);
+    }
+
+    /**
+     * Hybrid GPU path: interval compaction, projector (keys + proj cache), indirect radix sort
+     * over projector keys (indices are dense in projCache), then hybrid raster bindings.
+     *
+     * @param {GSplatWorldState} worldState - The world state to sort.
+     */
+    sortGpuHybrid(worldState) {
+        const cam = this.cameraNode.camera;
+        const rt = cam.renderTarget;
+        const rtWidth = rt ? rt.width : this.device.width;
+        const rtHeight = rt ? rt.height : this.device.height;
+        const rect = cam.rect;
+        const viewportWidth = Math.floor(rtWidth * rect.z);
+        const viewportHeight = Math.floor(rtHeight * rect.w);
+
+        const sortedIndices = this.sortGpuHybridForCamera(
+            worldState,
+            this.cameraNode,
+            viewportWidth,
+            viewportHeight,
+            Math.max(ALPHA_VISIBILITY_THRESHOLD, this.scene.gsplat.alphaCull),
+            false
+        );
+
+        if (sortedIndices) {
+            this.applyGpuSortResults(worldState, sortedIndices);
+        }
+    }
+
+    /**
+     * Runs the shared hybrid projector + indirect radix sort path for a specific camera.
+     *
+     * @param {GSplatWorldState} worldState - The world state to sort.
+     * @param {GraphNode} cameraNode - Camera node used for projection and sort keys.
+     * @param {number} viewportWidth - Projection viewport width in pixels.
+     * @param {number} viewportHeight - Projection viewport height in pixels.
+     * @param {number} alphaClip - Projector producer alpha threshold.
+     * @param {boolean} pickMode - Whether projector writes pcId into the cache.
+     * @returns {StorageBuffer|null} The sorted cache indices, or null if no work was dispatched.
+     * @private
+     */
+    sortGpuHybridForCamera(worldState, cameraNode, viewportWidth, viewportHeight, alphaClip, pickMode) {
+        const gpuSorter = this.gpuSorter;
+        const projector = this.projector;
+        Debug.assert(gpuSorter && projector, 'Hybrid GPU sort not initialized');
+        if (!gpuSorter || !projector) return null;
+
+        const elementCount = worldState.totalActiveSplats;
+        if (elementCount === 0) return null;
+
+        if (!this.intervalCompaction) {
+            this.intervalCompaction = new GSplatIntervalCompaction(this.device);
+        }
+
+        if (!worldState.sortedBefore) {
+            worldState.sortedBefore = true;
+
+            this.cleanupOldWorldStates(worldState.version);
+            this.sortedVersion = worldState.version;
+
+            this.rebuildWorkBuffer(worldState, elementCount);
+        }
+
+        this.intervalCompaction.uploadIntervals(worldState);
+
+        if (this.canCull) {
+            const state = this.worldStates.get(this.sortedVersion);
+            if (state) {
+                this._runFrustumCulling(state, cameraNode);
+            }
+        }
+
+        const numIntervals = worldState.totalIntervals;
+        const totalActiveSplats = worldState.totalActiveSplats;
+        this.intervalCompaction.dispatchCompact(this.workBuffer.frustumCuller, numIntervals, totalActiveSplats, false);
+
+        this.allocateAndWriteIntervalIndirectArgs(numIntervals);
+
+        const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
+        const compactedSplatIds = ic.compactedSplatIds;
+        const gsplat = this.scene.gsplat;
+
+        const numBits = Math.max(10, Math.min(20, Math.round(Math.log2(elementCount / 4))));
+        const radixBits = gpuSorter.radixBits;
+        const roundedNumBits = Math.ceil(numBits / radixBits) * radixBits;
+
+        const { minDist, maxDist } = this.computeDistanceRange(worldState, cameraNode);
+
+        const sortIndirectInfo = gpuSorter.prepareIndirect();
+
+        projector.dispatch({
+            workBuffer: this.workBuffer,
+            cameraNode,
+            compactedSplatIds: /** @type {StorageBuffer} */ (compactedSplatIds),
+            sortElementCountBuffer: /** @type {StorageBuffer} */ (ic.sortElementCountBuffer),
+            totalCapacity: elementCount,
+            radialSort: gsplat.radialSorting,
+            numBits: roundedNumBits,
+            minDist,
+            maxDist,
+            alphaClip,
+            minPixelSize: gsplat.minPixelSize * 0.5,
+            minContribution: gsplat.minContribution,
+            viewportWidth,
+            viewportHeight,
+            pickMode
+        });
+
+        projector.writeIndirectArgs(
+            this.indirectDrawSlot,
+            this.indirectDispatchSlot + 1,
+            /** @type {StorageBuffer} */ (ic.numSplatsBuffer),
+            /** @type {StorageBuffer} */ (ic.sortElementCountBuffer),
+            sortIndirectInfo
+        );
+
+        return gpuSorter.sortIndirect(
+            /** @type {StorageBuffer} */ (projector.sortKeys),
+            elementCount,
+            roundedNumBits,
+            this.indirectDispatchSlot + 1,
+            /** @type {StorageBuffer} */ (ic.sortElementCountBuffer),
+            undefined,
+            false
+        );
     }
 
     /**
@@ -1760,6 +1954,17 @@ class GSplatManager {
      * @private
      */
     applyGpuSortResults(worldState, sortedIndices) {
+        if (this.activeRenderer === GSPLAT_RENDERER_RASTER_HYBRID) {
+            const proj = /** @type {GSplatProjector} */ (this.projector);
+            const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
+            /** @type {GSplatHybridRenderer} */ (/** @type {unknown} */ (this.renderer)).setHybridSortedRendering(
+                this.indirectDrawSlot,
+                sortedIndices,
+                /** @type {StorageBuffer} */ (proj.projCache),
+                /** @type {StorageBuffer} */ (ic.numSplatsBuffer)
+            );
+            return;
+        }
         const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
         this.renderer.setGpuSortedRendering(this.indirectDrawSlot, sortedIndices, /** @type {StorageBuffer} */ (ic.numSplatsBuffer), worldState.textureSize);
     }
@@ -1770,12 +1975,13 @@ class GSplatManager {
      * interval compaction compute shader.
      *
      * @param {GSplatWorldState} worldState - The world state whose splats provide transforms.
+     * @param {GraphNode} [cameraNode] - Camera node to cull against.
      * @private
      */
-    _runFrustumCulling(worldState) {
+    _runFrustumCulling(worldState, cameraNode = this.cameraNode) {
         this.workBuffer.frustumCuller.updateTransformsData(worldState.boundsGroups);
 
-        const cam = this.cameraNode.camera;
+        const cam = cameraNode.camera;
         this.workBuffer.frustumCuller.computeFrustumPlanes(cam.projectionMatrix, cam.viewMatrix);
 
         const gsplat = this.scene.gsplat;
@@ -1784,8 +1990,8 @@ class GSplatManager {
 
         if (fp.enabled) {
             this.workBuffer.frustumCuller.setFisheyeData(
-                this.cameraNode.getPosition(),
-                this.cameraNode.forward,
+                cameraNode.getPosition(),
+                cameraNode.forward,
                 fp.maxTheta
             );
         }
@@ -1803,6 +2009,10 @@ class GSplatManager {
         const sortedState = this.worldStates.get(this.sortedVersion);
         if (!sortedState || !this.intervalCompaction) return;
 
+        if (this.activeRenderer === GSPLAT_RENDERER_RASTER_HYBRID) {
+            return;
+        }
+
         this.allocateAndWriteIntervalIndirectArgs(this.lastCompactedNumIntervals);
         const gpuSorter = /** @type {ComputeRadixSort} */ (this.gpuSorter);
         const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
@@ -1813,10 +2023,10 @@ class GSplatManager {
      * Computes the min/max effective distances for the current world state.
      *
      * @param {GSplatWorldState} worldState - The world state.
+     * @param {GraphNode} [cameraNode] - Camera node to measure distances from.
      * @returns {{minDist: number, maxDist: number}} The distance range.
      */
-    computeDistanceRange(worldState) {
-        const cameraNode = this.cameraNode;
+    computeDistanceRange(worldState, cameraNode = this.cameraNode) {
         const cameraMat = cameraNode.getWorldTransform();
         cameraMat.getTranslation(cameraPosition);
         cameraMat.getZ(cameraDirection).normalize();

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -560,7 +560,8 @@ class GSplatManager {
                 sortedIndices,
                 /** @type {StorageBuffer} */ (proj.projCache),
                 /** @type {StorageBuffer} */ (ic.numSplatsBuffer),
-                this.scene.gsplat.alphaClip
+                this.scene.gsplat.alphaClip,
+                camera.node
             );
         }
 

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1770,9 +1770,10 @@ class GSplatManager {
             }
         }
 
+        const fisheyeProj = this.renderer.fisheyeProj;
         const numIntervals = worldState.totalIntervals;
         const totalActiveSplats = worldState.totalActiveSplats;
-        this.intervalCompaction.dispatchCompact(this.workBuffer.frustumCuller, numIntervals, totalActiveSplats, false);
+        this.intervalCompaction.dispatchCompact(this.workBuffer.frustumCuller, numIntervals, totalActiveSplats, fisheyeProj.enabled);
 
         this.allocateAndWriteIntervalIndirectArgs(numIntervals);
 
@@ -1803,7 +1804,8 @@ class GSplatManager {
             minContribution: gsplat.minContribution,
             viewportWidth,
             viewportHeight,
-            pickMode
+            pickMode,
+            fisheyeProj
         });
 
         projector.writeIndirectArgs(

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -9,6 +9,7 @@ import {
     GSPLATDATA_COMPACT,
     GSPLAT_RENDERER_AUTO, GSPLAT_RENDERER_RASTER_CPU_SORT,
     GSPLAT_RENDERER_RASTER_GPU_SORT, GSPLAT_RENDERER_COMPUTE,
+    GSPLAT_RENDERER_RASTER_HYBRID,
     GSPLAT_DEBUG_NONE, GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE, GSPLAT_DEBUG_HEATMAP,
     GSPLAT_DEBUG_AABBS, GSPLAT_DEBUG_NODE_AABBS
 } from '../constants.js';
@@ -69,6 +70,7 @@ class GSplatParams {
         this._format = this._createFormat(GSPLATDATA_COMPACT);
 
         this._material.setParameter('alphaClip', 0.3);
+        this._material.setParameter('alphaCull', 1.0 / 255.0);
         this._material.setParameter('minPixelSize', 2.0);
         this._material.setParameter('minContribution', 3.0);
     }
@@ -147,6 +149,8 @@ class GSplatParams {
      * - {@link GSPLAT_RENDERER_RASTER_GPU_SORT}: Rasterization with compute shader sorting
      * (WebGPU only, experimental).
      * - {@link GSPLAT_RENDERER_COMPUTE}: Full compute pipeline (WebGPU only, experimental).
+     * - {@link GSPLAT_RENDERER_RASTER_HYBRID}: Hybrid rasterization with a compute projection
+     * cache and global radix sort (WebGPU only, experimental, internal).
      *
      * Defaults to {@link GSPLAT_RENDERER_AUTO}. Modes requiring WebGPU fall back to
      * {@link GSPLAT_RENDERER_RASTER_CPU_SORT} on WebGL devices. The resolved mode actually used
@@ -160,7 +164,9 @@ class GSplatParams {
 
             if (value === GSPLAT_RENDERER_AUTO) {
                 this._currentRenderer = GSPLAT_RENDERER_RASTER_CPU_SORT;
-            } else if ((value === GSPLAT_RENDERER_RASTER_GPU_SORT || value === GSPLAT_RENDERER_COMPUTE) &&
+            } else if ((value === GSPLAT_RENDERER_RASTER_GPU_SORT ||
+                        value === GSPLAT_RENDERER_COMPUTE ||
+                        value === GSPLAT_RENDERER_RASTER_HYBRID) &&
                 !this._device.isWebGPU) {
                 this._currentRenderer = GSPLAT_RENDERER_RASTER_CPU_SORT;
             } else {
@@ -591,6 +597,27 @@ class GSplatParams {
      */
     get alphaClip() {
         return this._material.getParameter('alphaClip')?.data ?? 0.3;
+    }
+
+    /**
+     * Sets the alpha threshold below which splats are discarded before forward rendering.
+     * Higher values improve performance by culling more low-opacity splats, while lower
+     * values preserve more translucent splats. Defaults to 1 / 255.
+     *
+     * @type {number}
+     */
+    set alphaCull(value) {
+        this._material.setParameter('alphaCull', value);
+        this._material.update();
+    }
+
+    /**
+     * Gets the forward alpha cull threshold.
+     *
+     * @type {number}
+     */
+    get alphaCull() {
+        return this._material.getParameter('alphaCull')?.data ?? (1.0 / 255.0);
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-projector-constants.js
+++ b/src/scene/gsplat-unified/gsplat-projector-constants.js
@@ -1,0 +1,17 @@
+// Shared constants for the hybrid gsplat renderer's projection cache. Mirrored into WGSL via
+// cdefines text substitution (e.g. `{CACHE_STRIDE}u`). Keeping this in a single place keeps
+// JS-side buffer allocations and WGSL indexing in sync.
+//
+// Layout (raster-friendly, 8 u32 slots = 32 B per splat):
+//   [0] proj.x       (f32)            — clip-space center X (viewProj * worldCenter)
+//   [1] proj.y       (f32)            — clip-space center Y
+//   [2] proj.z       (f32)            — clip-space center Z
+//   [3] proj.w       (f32)            — clip w (drives clip-space corner-scale c = w/viewport);
+//                                       also reused as linear view depth for prepass / fog (matches
+//                                       SplatCov2D.viewDepth: -viewCenter.z, or sqrt(d²) for fisheye)
+//   [4] v1.xy        (pack2x16float)  — screen-pixel eigenvector × eigenvalue (axis 1)
+//   [5] v2.xy        (pack2x16float)  — screen-pixel eigenvector × eigenvalue (axis 2)
+//   [6] color rg     (pack2x16float)  — color channels R, G (or pcId in pick mode)
+//   [7] color b + a  (pack2x16float)  — color channel B and final opacity (after AA / alpha gate)
+
+export const CACHE_STRIDE = 8;

--- a/src/scene/gsplat-unified/gsplat-projector-constants.js
+++ b/src/scene/gsplat-unified/gsplat-projector-constants.js
@@ -6,9 +6,12 @@
 //   [0] proj.x       (f32)            — clip-space center X (viewProj * worldCenter)
 //   [1] proj.y       (f32)            — clip-space center Y
 //   [2] proj.z       (f32)            — clip-space center Z
-//   [3] proj.w       (f32)            — clip w (drives clip-space corner-scale c = w/viewport);
-//                                       also reused as linear view depth for prepass / fog (matches
-//                                       SplatCov2D.viewDepth: -viewCenter.z, or sqrt(d²) for fisheye)
+//   [3] proj.w       (f32)            — clip-space homogeneous w; drives clip-space corner-scale
+//                                       c = w/viewport and the rasterizer's perspective divide.
+//                                       Linear view depth (used by fog / overdraw / prepass) is
+//                                       reconstructed in the hybrid VS via the clipToViewZ
+//                                       uniform = -inverse(matrix_projection)[row 2], which is
+//                                       correct for both perspective and orthographic cameras.
 //   [4] v1.xy        (pack2x16float)  — screen-pixel eigenvector × eigenvalue (axis 1)
 //   [5] v2.xy        (pack2x16float)  — screen-pixel eigenvector × eigenvalue (axis 2)
 //   [6] color rg     (pack2x16float)  — color channels R, G (or pcId in pick mode)

--- a/src/scene/gsplat-unified/gsplat-projector.js
+++ b/src/scene/gsplat-unified/gsplat-projector.js
@@ -1,0 +1,561 @@
+import { Debug } from '../../core/debug.js';
+import { Mat4 } from '../../core/math/mat4.js';
+import { Vec2 } from '../../core/math/vec2.js';
+import { Vec3 } from '../../core/math/vec3.js';
+import { Compute } from '../../platform/graphics/compute.js';
+import { Shader } from '../../platform/graphics/shader.js';
+import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
+import {
+    BindGroupFormat,
+    BindStorageBufferFormat,
+    BindUniformBufferFormat
+} from '../../platform/graphics/bind-group-format.js';
+import {
+    UniformBufferFormat,
+    UniformFormat
+} from '../../platform/graphics/uniform-buffer-format.js';
+import {
+    BUFFERUSAGE_COPY_DST,
+    BUFFERUSAGE_COPY_SRC,
+    PIXELFORMAT_RGBA16U,
+    SHADERLANGUAGE_WGSL,
+    SHADERSTAGE_COMPUTE,
+    UNIFORMTYPE_FLOAT,
+    UNIFORMTYPE_MAT4,
+    UNIFORMTYPE_UINT,
+    UNIFORMTYPE_UVEC4,
+    UNIFORMTYPE_VEC3
+} from '../../platform/graphics/constants.js';
+import { PROJECTION_ORTHOGRAPHIC } from '../constants.js';
+import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
+import { GSplatSortBinWeights } from './gsplat-sort-bin-weights.js';
+import { CACHE_STRIDE } from './gsplat-projector-constants.js';
+import { computeGsplatProjectorSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js';
+import { computeGsplatProjectorWriteIndirectArgsSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector-write-indirect-args.js';
+import { computeGsplatProjectCommonSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-project-common.js';
+import { computeGsplatCommonSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-common.js';
+import { computeGsplatTileIntersectSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-tile-intersect.js';
+import computeSplatSource from '../shader-lib/wgsl/chunks/gsplat/vert/gsplatComputeSplat.js';
+
+/**
+ * @import { GraphNode } from '../graph-node.js'
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ * @import { GSplatWorkBuffer } from './gsplat-work-buffer.js'
+ */
+
+const INDEX_COUNT = 6 * GSplatResourceBase.instanceSize;
+const PROJECTOR_WORKGROUP_SIZE = 256;
+
+const _cameraDir = new Vec3();
+const _dispatchSize = new Vec2();
+const _viewProjMat = new Mat4();
+const _viewProjData = new Float32Array(16);
+const _viewData = new Float32Array(16);
+
+/**
+ * Owns the per-splat compute pass for the hybrid GSplat renderer (Pass B in the pipeline):
+ *
+ *   project + screen-space cull + sort key generation + compaction
+ *
+ * The pass reads the post-frustum-culled `compactedSplatIds` produced by
+ * {@link GSplatIntervalCompaction} and writes a pre-projected raster-friendly
+ * cache (see {@link CACHE_STRIDE}) plus a parallel array of depth-based sort
+ * keys. A workgroup-local atomic compaction pattern (one global atomicAdd per
+ * workgroup of 256 threads) keeps post-cull entries dense in the output buffers.
+ *
+ * Designed to live alongside the existing renderers without affecting them. The
+ * cache layout is duplicated in `gsplat-projector-constants.js` (JS) and the
+ * projector / hybrid VS WGSL chunks via the `{CACHE_STRIDE}` cdefine.
+ *
+ * @ignore
+ */
+class GSplatProjector {
+    /** @type {GraphicsDevice} */
+    device;
+
+    /**
+     * 32 B per splat (8 u32 slots), sized to the work-buffer capacity (not the
+     * post-cull count) to avoid undersizing on transient cull-rate drops.
+     *
+     * @type {StorageBuffer|null}
+     */
+    projCache = null;
+
+    /** @type {StorageBuffer|null} */
+    sortKeys = null;
+
+    /**
+     * Single-element atomic counter; reset to 0 every frame and incremented by
+     * the projector pass via per-workgroup atomicAdd.
+     *
+     * @type {StorageBuffer|null}
+     */
+    renderCounter = null;
+
+    /**
+     * Storage buffer holding interleaved bin weights {base, divider} consumed by
+     * the projector for camera-relative sort key precision.
+     *
+     * @type {StorageBuffer|null}
+     */
+    binWeightsBuffer = null;
+
+    /** @type {GSplatSortBinWeights} */
+    binWeightsUtil;
+
+    /** @type {Compute|null} */
+    _projectorComputeLinear = null;
+
+    /** @type {Compute|null} */
+    _projectorComputeRadial = null;
+
+    /** @type {Compute|null} */
+    _projectorComputeLinearPick = null;
+
+    /** @type {Compute|null} */
+    _projectorComputeRadialPick = null;
+
+    /** @type {BindGroupFormat|null} */
+    _projectorBindGroupFormat = null;
+
+    /** @type {UniformBufferFormat|null} */
+    _projectorUniformBufferFormat = null;
+
+    /** @type {Compute|null} */
+    _writeIndirectArgsCompute = null;
+
+    /** @type {BindGroupFormat|null} */
+    _writeArgsBindGroupFormat = null;
+
+    /** @type {UniformBufferFormat|null} */
+    _writeArgsUniformBufferFormat = null;
+
+    /**
+     * Cached work-buffer format version; changes invalidate the projector
+     * compute (its bind group format is derived from the work-buffer format).
+     */
+    _formatVersion = -1;
+
+    /** @type {number} */
+    _allocatedCacheCount = 0;
+
+    /** @type {Float32Array} */
+    cameraPositionData = new Float32Array(3);
+
+    /** @type {Float32Array} */
+    cameraDirectionData = new Float32Array(3);
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device (must support compute).
+     */
+    constructor(device) {
+        Debug.assert(device.supportsCompute, 'GSplatProjector requires compute shader support (WebGPU)');
+        this.device = device;
+
+        this.binWeightsUtil = new GSplatSortBinWeights();
+        this.binWeightsBuffer = new StorageBuffer(
+            device,
+            GSplatSortBinWeights.NUM_BINS * 2 * 4,
+            BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST
+        );
+
+        // 4 B counter, cleared every frame on the GPU via clear().
+        this.renderCounter = new StorageBuffer(device, 4, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
+
+        this._createUniformBufferFormats();
+        this._createWriteIndirectArgsCompute();
+    }
+
+    destroy() {
+        this.projCache?.destroy();
+        this.sortKeys?.destroy();
+        this.renderCounter?.destroy();
+        this.binWeightsBuffer?.destroy();
+
+        this._projectorComputeLinear?.shader?.destroy();
+        this._projectorComputeRadial?.shader?.destroy();
+        this._projectorComputeLinearPick?.shader?.destroy();
+        this._projectorComputeRadialPick?.shader?.destroy();
+        this._projectorBindGroupFormat?.destroy();
+        this._writeIndirectArgsCompute?.shader?.destroy();
+        this._writeArgsBindGroupFormat?.destroy();
+
+        this.projCache = null;
+        this.sortKeys = null;
+        this.renderCounter = null;
+        this.binWeightsBuffer = null;
+        this._projectorComputeLinear = null;
+        this._projectorComputeRadial = null;
+        this._projectorComputeLinearPick = null;
+        this._projectorComputeRadialPick = null;
+        this._projectorBindGroupFormat = null;
+        this._projectorUniformBufferFormat = null;
+        this._writeIndirectArgsCompute = null;
+        this._writeArgsBindGroupFormat = null;
+        this._writeArgsUniformBufferFormat = null;
+    }
+
+    /** @private */
+    _createUniformBufferFormats() {
+        const device = this.device;
+
+        // Projector uniforms — kept in the same packing order the WGSL struct expects.
+        this._projectorUniformBufferFormat = new UniformBufferFormat(device, [
+            new UniformFormat('splatTextureSize', UNIFORMTYPE_UINT),
+            new UniformFormat('numBins', UNIFORMTYPE_UINT),
+            new UniformFormat('isOrtho', UNIFORMTYPE_UINT),
+            new UniformFormat('pad0', UNIFORMTYPE_UINT),
+            new UniformFormat('viewProj', UNIFORMTYPE_MAT4),
+            new UniformFormat('viewMatrix', UNIFORMTYPE_MAT4),
+            new UniformFormat('cameraPosition', UNIFORMTYPE_VEC3),
+            new UniformFormat('minPixelSize', UNIFORMTYPE_FLOAT),
+            new UniformFormat('cameraDirection', UNIFORMTYPE_VEC3),
+            new UniformFormat('focal', UNIFORMTYPE_FLOAT),
+            new UniformFormat('viewportWidth', UNIFORMTYPE_FLOAT),
+            new UniformFormat('viewportHeight', UNIFORMTYPE_FLOAT),
+            new UniformFormat('nearClip', UNIFORMTYPE_FLOAT),
+            new UniformFormat('farClip', UNIFORMTYPE_FLOAT),
+            new UniformFormat('alphaClip', UNIFORMTYPE_FLOAT),
+            new UniformFormat('minContribution', UNIFORMTYPE_FLOAT),
+            new UniformFormat('minDist', UNIFORMTYPE_FLOAT),
+            new UniformFormat('invRange', UNIFORMTYPE_FLOAT)
+        ]);
+
+        this._writeArgsUniformBufferFormat = new UniformBufferFormat(device, [
+            new UniformFormat('drawSlot', UNIFORMTYPE_UINT),
+            new UniformFormat('indexCount', UNIFORMTYPE_UINT),
+            new UniformFormat('sortSlotBase', UNIFORMTYPE_UINT),
+            new UniformFormat('pad0', UNIFORMTYPE_UINT),
+            new UniformFormat('sortIndirectInfo', UNIFORMTYPE_UVEC4)
+        ]);
+    }
+
+    /** @private */
+    _createWriteIndirectArgsCompute() {
+        const device = this.device;
+
+        this._writeArgsBindGroupFormat = new BindGroupFormat(device, [
+            new BindStorageBufferFormat('renderCounter', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('indirectDrawArgs', SHADERSTAGE_COMPUTE, false),
+            new BindStorageBufferFormat('numSplatsBuf', SHADERSTAGE_COMPUTE, false),
+            new BindStorageBufferFormat('indirectDispatchArgs', SHADERSTAGE_COMPUTE, false),
+            new BindStorageBufferFormat('sortElementCountBuf', SHADERSTAGE_COMPUTE, false),
+            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
+        ]);
+
+        const cdefines = new Map([
+            ['{INSTANCE_SIZE}', GSplatResourceBase.instanceSize.toString()]
+        ]);
+
+        const shader = new Shader(device, {
+            name: 'GSplatProjectorWriteIndirectArgs',
+            shaderLanguage: SHADERLANGUAGE_WGSL,
+            cshader: computeGsplatProjectorWriteIndirectArgsSource,
+            cdefines: cdefines,
+            computeBindGroupFormat: this._writeArgsBindGroupFormat,
+            computeUniformBufferFormats: { uniforms: this._writeArgsUniformBufferFormat }
+        });
+
+        this._writeIndirectArgsCompute = new Compute(device, shader, 'GSplatProjectorWriteIndirectArgs');
+    }
+
+    /**
+     * Destroys the projector compute pipelines so they are lazily rebuilt against the
+     * current work-buffer format.
+     *
+     * @private
+     */
+    _destroyProjectorComputes() {
+        this._projectorComputeLinear?.shader?.destroy();
+        this._projectorComputeRadial?.shader?.destroy();
+        this._projectorComputeLinearPick?.shader?.destroy();
+        this._projectorComputeRadialPick?.shader?.destroy();
+        this._projectorBindGroupFormat?.destroy();
+        this._projectorComputeLinear = null;
+        this._projectorComputeRadial = null;
+        this._projectorComputeLinearPick = null;
+        this._projectorComputeRadialPick = null;
+        this._projectorBindGroupFormat = null;
+    }
+
+    /**
+     * Builds the projector Compute (one variant per sort mode).
+     *
+     * @param {GSplatWorkBuffer} workBuffer - The current work buffer (provides format).
+     * @param {boolean} radialSort - Whether to compile the RADIAL_SORT variant.
+     * @param {boolean} pickMode - Whether to write pcId into the cache for picking.
+     * @returns {Compute} The created compute instance.
+     * @private
+     */
+    _createProjectorCompute(workBuffer, radialSort, pickMode) {
+        const device = this.device;
+        const wbFormat = workBuffer.format;
+
+        const fixedBindings = [
+            new BindStorageBufferFormat('compactedSplatIds', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('sortElementCount', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('projCache', SHADERSTAGE_COMPUTE),
+            new BindStorageBufferFormat('sortKeys', SHADERSTAGE_COMPUTE),
+            new BindStorageBufferFormat('renderCounter', SHADERSTAGE_COMPUTE),
+            new BindStorageBufferFormat('binWeights', SHADERSTAGE_COMPUTE, true),
+            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
+        ];
+
+        if (!this._projectorBindGroupFormat) {
+            this._projectorBindGroupFormat = new BindGroupFormat(device, [
+                ...fixedBindings,
+                ...wbFormat.getComputeBindFormats()
+            ]);
+        }
+
+        const cincludes = new Map();
+        cincludes.set('gsplatCommonCS', computeGsplatCommonSource);
+        cincludes.set('gsplatTileIntersectCS', computeGsplatTileIntersectSource);
+        cincludes.set('gsplatComputeSplatCS', computeSplatSource);
+        cincludes.set('gsplatFormatDeclCS', wbFormat.getComputeInputDeclarations(fixedBindings.length));
+        cincludes.set('gsplatFormatReadCS', wbFormat.getReadCode());
+        cincludes.set('gsplatProjectCommonCS', computeGsplatProjectCommonSource);
+
+        const cdefines = new Map();
+        cdefines.set('{CACHE_STRIDE}', CACHE_STRIDE.toString());
+        if (radialSort) {
+            cdefines.set('RADIAL_SORT', '');
+        }
+        if (pickMode) {
+            cdefines.set('PICK_MODE', '');
+        }
+
+        // Format-specific defines mirroring the compute renderer (compute-gsplat-local-renderer.js).
+        const colorStream = wbFormat.getStream('dataColor');
+        if (colorStream && colorStream.format !== PIXELFORMAT_RGBA16U) {
+            cdefines.set('GSPLAT_COLOR_FLOAT', '');
+        }
+
+        const shader = new Shader(device, {
+            name: `${radialSort ? 'GSplatProjectorRadial' : 'GSplatProjectorLinear'}${pickMode ? 'Pick' : ''}`,
+            shaderLanguage: SHADERLANGUAGE_WGSL,
+            cshader: computeGsplatProjectorSource,
+            cincludes: cincludes,
+            cdefines: cdefines,
+            computeBindGroupFormat: this._projectorBindGroupFormat,
+            computeUniformBufferFormats: { uniforms: this._projectorUniformBufferFormat }
+        });
+
+        return new Compute(device, shader, `${radialSort ? 'GSplatProjectorRadial' : 'GSplatProjectorLinear'}${pickMode ? 'Pick' : ''}`);
+    }
+
+    /**
+     * Returns the projector Compute for the requested sort mode, lazily creating it.
+     * Recreates all compute instances when the work-buffer format version changes.
+     *
+     * @param {GSplatWorkBuffer} workBuffer - The current work buffer.
+     * @param {boolean} radialSort - Whether to use the radial sort variant.
+     * @param {boolean} [pickMode] - Whether to use the pick-output variant.
+     * @returns {Compute} The projector compute instance.
+     * @private
+     */
+    _getProjectorCompute(workBuffer, radialSort, pickMode = false) {
+        const wbFormat = workBuffer.format;
+        if (this._formatVersion !== wbFormat.extraStreamsVersion) {
+            this._destroyProjectorComputes();
+            this._formatVersion = wbFormat.extraStreamsVersion;
+        }
+
+        if (radialSort) {
+            if (pickMode) {
+                if (!this._projectorComputeRadialPick) {
+                    this._projectorComputeRadialPick = this._createProjectorCompute(workBuffer, true, true);
+                }
+                return this._projectorComputeRadialPick;
+            }
+            if (!this._projectorComputeRadial) {
+                this._projectorComputeRadial = this._createProjectorCompute(workBuffer, true, false);
+            }
+            return this._projectorComputeRadial;
+        }
+        if (pickMode) {
+            if (!this._projectorComputeLinearPick) {
+                this._projectorComputeLinearPick = this._createProjectorCompute(workBuffer, false, true);
+            }
+            return this._projectorComputeLinearPick;
+        }
+        if (!this._projectorComputeLinear) {
+            this._projectorComputeLinear = this._createProjectorCompute(workBuffer, false, false);
+        }
+        return this._projectorComputeLinear;
+    }
+
+    /**
+     * Ensures projCache and sortKeys storage buffers are sized to at least `capacity` splats.
+     * Both buffers are sized to the work-buffer capacity (passed in by the caller) rather than
+     * post-cull counts, mirroring `compactedSplatIds` allocation in interval compaction.
+     *
+     * @param {number} capacity - Required splat capacity (work-buffer total active splats).
+     * @private
+     */
+    _ensureCapacity(capacity) {
+        if (capacity > this._allocatedCacheCount) {
+            this.projCache?.destroy();
+            this.sortKeys?.destroy();
+            this._allocatedCacheCount = capacity;
+            this.projCache = new StorageBuffer(this.device, capacity * CACHE_STRIDE * 4);
+            this.sortKeys = new StorageBuffer(this.device, capacity * 4, BUFFERUSAGE_COPY_SRC);
+        }
+    }
+
+    /**
+     * Runs the project + cull + key-gen + compact compute pass.
+     *
+     * @param {object} params - Dispatch parameters.
+     * @param {GSplatWorkBuffer} params.workBuffer - The current work buffer.
+     * @param {GraphNode} params.cameraNode - The camera node (with attached CameraComponent).
+     * @param {StorageBuffer} params.compactedSplatIds - Output of interval compaction.
+     * @param {StorageBuffer} params.sortElementCountBuffer - GPU-written visible count from
+     * interval compaction (single u32 element); the projector reads this to early-out
+     * threads beyond the post-frustum-cull range.
+     * @param {number} params.totalCapacity - Work-buffer capacity used to size projCache /
+     * sortKeys (typically `worldState.totalActiveSplats`).
+     * @param {boolean} params.radialSort - Whether to use the radial sort key variant.
+     * @param {number} params.numBits - Sort key bit count (defines bucket count = 1 << numBits).
+     * @param {number} params.minDist - Minimum distance for sort key normalisation.
+     * @param {number} params.maxDist - Maximum distance for sort key normalisation.
+     * @param {number} params.alphaClip - Alpha cull threshold.
+     * @param {number} params.minPixelSize - Minimum on-screen pixel size before culling.
+     * @param {number} params.minContribution - Minimum total contribution before culling.
+     * @param {number} params.viewportWidth - Render viewport width in pixels.
+     * @param {number} params.viewportHeight - Render viewport height in pixels.
+     * @param {boolean} [params.pickMode] - Whether to write picking IDs into the cache.
+     */
+    dispatch(params) {
+        const {
+            workBuffer, cameraNode, compactedSplatIds, sortElementCountBuffer,
+            totalCapacity, radialSort, numBits, minDist, maxDist,
+            alphaClip, minPixelSize, minContribution,
+            viewportWidth, viewportHeight, pickMode = false
+        } = params;
+
+        this._ensureCapacity(totalCapacity);
+
+        // Reset the global render counter on the GPU. This is encoded into the same
+        // command buffer as the dispatch, so it is correctly ordered before the projector
+        // workgroups run their atomicAdds.
+        this.renderCounter.clear();
+
+        const compute = this._getProjectorCompute(workBuffer, radialSort, pickMode);
+
+        // Camera position / forward (camera Z basis, matching cpu-sort and key-compute).
+        const cameraPos = cameraNode.getPosition();
+        const cameraMat = cameraNode.getWorldTransform();
+        const cameraDir = cameraMat.getZ(_cameraDir).normalize();
+
+        const range = maxDist - minDist;
+        const invRange = range > 0 ? 1.0 / range : 1.0;
+
+        // Bin weights — same pattern as GSplatSortKeyCompute.
+        const bucketCount = (1 << numBits);
+        const cameraBin = GSplatSortBinWeights.computeCameraBin(radialSort, minDist, range);
+        const binWeights = this.binWeightsUtil.compute(cameraBin, bucketCount);
+        this.binWeightsBuffer.write(0, binWeights);
+
+        compute.setParameter('compactedSplatIds', compactedSplatIds);
+        compute.setParameter('sortElementCount', sortElementCountBuffer);
+        compute.setParameter('projCache', this.projCache);
+        compute.setParameter('sortKeys', this.sortKeys);
+        compute.setParameter('renderCounter', this.renderCounter);
+        compute.setParameter('binWeights', this.binWeightsBuffer);
+
+        // Bind work-buffer textures.
+        for (const stream of workBuffer.format.resourceStreams) {
+            const texture = workBuffer.getTexture(stream.name);
+            if (texture) {
+                compute.setParameter(stream.name, texture);
+            }
+        }
+
+        // Camera + projection uniforms. Mirrors the compute renderer's setup
+        // (gsplat-compute-local-renderer.js) for math parity.
+        const cameraComponent = cameraNode.camera;
+        const cam = cameraComponent.camera;
+        const view = cam.viewMatrix;
+        const proj = cam.projectionMatrix;
+        _viewProjMat.mul2(proj, view);
+        _viewProjData.set(_viewProjMat.data);
+        _viewData.set(view.data);
+
+        const focal = viewportWidth * proj.data[0];
+
+        this.cameraPositionData[0] = cameraPos.x;
+        this.cameraPositionData[1] = cameraPos.y;
+        this.cameraPositionData[2] = cameraPos.z;
+        compute.setParameter('cameraPosition', this.cameraPositionData);
+
+        this.cameraDirectionData[0] = cameraDir.x;
+        this.cameraDirectionData[1] = cameraDir.y;
+        this.cameraDirectionData[2] = cameraDir.z;
+        compute.setParameter('cameraDirection', this.cameraDirectionData);
+
+        compute.setParameter('viewMatrix', _viewData);
+        compute.setParameter('viewProj', _viewProjData);
+
+        compute.setParameter('focal', focal);
+        compute.setParameter('viewportWidth', viewportWidth);
+        compute.setParameter('viewportHeight', viewportHeight);
+        compute.setParameter('nearClip', cam.nearClip);
+        compute.setParameter('farClip', cam.farClip);
+        compute.setParameter('alphaClip', alphaClip);
+        compute.setParameter('minPixelSize', minPixelSize);
+        compute.setParameter('minContribution', minContribution);
+        compute.setParameter('isOrtho', cam.projection === PROJECTION_ORTHOGRAPHIC ? 1 : 0);
+        compute.setParameter('splatTextureSize', workBuffer.textureSize);
+        compute.setParameter('numBins', GSplatSortBinWeights.NUM_BINS);
+        compute.setParameter('minDist', minDist);
+        compute.setParameter('invRange', invRange);
+        compute.setParameter('pad0', 0);
+
+        // 2D dispatch over the work-buffer capacity. The shader early-outs threads beyond
+        // sortElementCount[0]; sizing the dispatch for the full capacity (a CPU-known
+        // upper bound) avoids needing an extra indirect-args dispatch for this pass.
+        const workgroupCount = Math.ceil(totalCapacity / PROJECTOR_WORKGROUP_SIZE);
+        Compute.calcDispatchSize(
+            workgroupCount,
+            _dispatchSize,
+            this.device.limits.maxComputeWorkgroupsPerDimension || 65535
+        );
+        compute.setupDispatch(_dispatchSize.x, _dispatchSize.y, 1);
+        this.device.computeDispatch([compute], 'GSplatProjector');
+    }
+
+    /**
+     * Writes per-frame indirect draw / dispatch arguments derived from `renderCounter[0]`.
+     *
+     * @param {number} drawSlot - Slot index in `device.indirectDrawBuffer`.
+     * @param {number} sortSlotBase - Base slot index in `device.indirectDispatchBuffer`. The
+     * radix sort backend uses `sortIndirectInfo[0]` consecutive slots starting here.
+     * @param {StorageBuffer} numSplatsBuffer - Storage buffer the vertex shader reads for the
+     * post-cull splat count (single u32 element).
+     * @param {StorageBuffer} sortElementCountBuffer - Storage buffer the radix sort reads for
+     * its element count (single u32 element).
+     * @param {Uint32Array} sortIndirectInfo - Sorter-owned 4-element Uint32 array returned by
+     * `ComputeRadixSort.prepareIndirect()`, used as a `vec4<u32>` uniform by the shader.
+     */
+    writeIndirectArgs(drawSlot, sortSlotBase, numSplatsBuffer, sortElementCountBuffer, sortIndirectInfo) {
+        const compute = this._writeIndirectArgsCompute;
+
+        compute.setParameter('renderCounter', this.renderCounter);
+        compute.setParameter('indirectDrawArgs', this.device.indirectDrawBuffer);
+        compute.setParameter('numSplatsBuf', numSplatsBuffer);
+        compute.setParameter('indirectDispatchArgs', this.device.indirectDispatchBuffer);
+        compute.setParameter('sortElementCountBuf', sortElementCountBuffer);
+
+        compute.setParameter('drawSlot', drawSlot);
+        compute.setParameter('indexCount', INDEX_COUNT);
+        compute.setParameter('sortSlotBase', sortSlotBase);
+        compute.setParameter('pad0', 0);
+        compute.setParameter('sortIndirectInfo', sortIndirectInfo);
+
+        compute.setupDispatch(1);
+        this.device.computeDispatch([compute], 'GSplatProjectorWriteIndirectArgs');
+    }
+}
+
+export { GSplatProjector };

--- a/src/scene/gsplat-unified/gsplat-projector.js
+++ b/src/scene/gsplat-unified/gsplat-projector.js
@@ -103,23 +103,32 @@ class GSplatProjector {
     /** @type {GSplatSortBinWeights} */
     binWeightsUtil;
 
-    /** @type {Compute|null} */
-    _projectorComputeLinear = null;
-
-    /** @type {Compute|null} */
-    _projectorComputeRadial = null;
-
-    /** @type {Compute|null} */
-    _projectorComputeLinearPick = null;
-
-    /** @type {Compute|null} */
-    _projectorComputeRadialPick = null;
+    /**
+     * Lazily-created projector compute variants keyed by `radial|pick|fisheye`
+     * combination (see `_projectorKey`). Up to 8 variants exist; only the
+     * combinations actually needed by the running app are compiled.
+     *
+     * @type {Map<string, Compute>}
+     */
+    _projectorComputes = new Map();
 
     /** @type {BindGroupFormat|null} */
     _projectorBindGroupFormat = null;
 
-    /** @type {UniformBufferFormat|null} */
+    /**
+     * Uniform buffer format for the non-fisheye projector variant.
+     *
+     * @type {UniformBufferFormat|null}
+     */
     _projectorUniformBufferFormat = null;
+
+    /**
+     * Uniform buffer format for the fisheye projector variant. Adds 4 fisheye
+     * scalar uniforms after the shared fields.
+     *
+     * @type {UniformBufferFormat|null}
+     */
+    _projectorUniformBufferFormatFisheye = null;
 
     /** @type {Compute|null} */
     _writeIndirectArgsCompute = null;
@@ -172,10 +181,11 @@ class GSplatProjector {
         this.renderCounter?.destroy();
         this.binWeightsBuffer?.destroy();
 
-        this._projectorComputeLinear?.shader?.destroy();
-        this._projectorComputeRadial?.shader?.destroy();
-        this._projectorComputeLinearPick?.shader?.destroy();
-        this._projectorComputeRadialPick?.shader?.destroy();
+        for (const compute of this._projectorComputes.values()) {
+            compute.shader?.destroy();
+        }
+        this._projectorComputes.clear();
+
         this._projectorBindGroupFormat?.destroy();
         this._writeIndirectArgsCompute?.shader?.destroy();
         this._writeArgsBindGroupFormat?.destroy();
@@ -184,12 +194,9 @@ class GSplatProjector {
         this.sortKeys = null;
         this.renderCounter = null;
         this.binWeightsBuffer = null;
-        this._projectorComputeLinear = null;
-        this._projectorComputeRadial = null;
-        this._projectorComputeLinearPick = null;
-        this._projectorComputeRadialPick = null;
         this._projectorBindGroupFormat = null;
         this._projectorUniformBufferFormat = null;
+        this._projectorUniformBufferFormatFisheye = null;
         this._writeIndirectArgsCompute = null;
         this._writeArgsBindGroupFormat = null;
         this._writeArgsUniformBufferFormat = null;
@@ -199,8 +206,8 @@ class GSplatProjector {
     _createUniformBufferFormats() {
         const device = this.device;
 
-        // Projector uniforms — kept in the same packing order the WGSL struct expects.
-        this._projectorUniformBufferFormat = new UniformBufferFormat(device, [
+        // Shared base fields — order matches the WGSL ProjectorUniforms struct.
+        const baseFields = [
             new UniformFormat('splatTextureSize', UNIFORMTYPE_UINT),
             new UniformFormat('numBins', UNIFORMTYPE_UINT),
             new UniformFormat('isOrtho', UNIFORMTYPE_UINT),
@@ -219,6 +226,18 @@ class GSplatProjector {
             new UniformFormat('minContribution', UNIFORMTYPE_FLOAT),
             new UniformFormat('minDist', UNIFORMTYPE_FLOAT),
             new UniformFormat('invRange', UNIFORMTYPE_FLOAT)
+        ];
+
+        this._projectorUniformBufferFormat = new UniformBufferFormat(device, baseFields);
+
+        // Fisheye variant appends 4 fisheye scalars (matches the GSPLAT_FISHEYE
+        // ifdef'd block in compute-gsplat-projector.js).
+        this._projectorUniformBufferFormatFisheye = new UniformBufferFormat(device, [
+            ...baseFields.map(f => new UniformFormat(f.name, f.type)),
+            new UniformFormat('fisheye_k', UNIFORMTYPE_FLOAT),
+            new UniformFormat('fisheye_inv_k', UNIFORMTYPE_FLOAT),
+            new UniformFormat('fisheye_projMat00', UNIFORMTYPE_FLOAT),
+            new UniformFormat('fisheye_projMat11', UNIFORMTYPE_FLOAT)
         ]);
 
         this._writeArgsUniformBufferFormat = new UniformBufferFormat(device, [
@@ -266,28 +285,38 @@ class GSplatProjector {
      * @private
      */
     _destroyProjectorComputes() {
-        this._projectorComputeLinear?.shader?.destroy();
-        this._projectorComputeRadial?.shader?.destroy();
-        this._projectorComputeLinearPick?.shader?.destroy();
-        this._projectorComputeRadialPick?.shader?.destroy();
+        for (const compute of this._projectorComputes.values()) {
+            compute.shader?.destroy();
+        }
+        this._projectorComputes.clear();
         this._projectorBindGroupFormat?.destroy();
-        this._projectorComputeLinear = null;
-        this._projectorComputeRadial = null;
-        this._projectorComputeLinearPick = null;
-        this._projectorComputeRadialPick = null;
         this._projectorBindGroupFormat = null;
     }
 
     /**
-     * Builds the projector Compute (one variant per sort mode).
+     * Builds the cache key for a projector variant combination.
+     *
+     * @param {boolean} radialSort - Radial vs linear sort.
+     * @param {boolean} pickMode - Pick output mode.
+     * @param {boolean} fisheyeMode - Fisheye projection mode.
+     * @returns {string} The cache key.
+     * @private
+     */
+    _projectorKey(radialSort, pickMode, fisheyeMode) {
+        return `${radialSort ? 'r' : 'l'}${pickMode ? 'p' : ''}${fisheyeMode ? 'f' : ''}`;
+    }
+
+    /**
+     * Builds the projector Compute (one variant per sort/pick/fisheye combination).
      *
      * @param {GSplatWorkBuffer} workBuffer - The current work buffer (provides format).
      * @param {boolean} radialSort - Whether to compile the RADIAL_SORT variant.
      * @param {boolean} pickMode - Whether to write pcId into the cache for picking.
+     * @param {boolean} fisheyeMode - Whether to compile the GSPLAT_FISHEYE variant.
      * @returns {Compute} The created compute instance.
      * @private
      */
-    _createProjectorCompute(workBuffer, radialSort, pickMode) {
+    _createProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode) {
         const device = this.device;
         const wbFormat = workBuffer.format;
 
@@ -324,6 +353,9 @@ class GSplatProjector {
         if (pickMode) {
             cdefines.set('PICK_MODE', '');
         }
+        if (fisheyeMode) {
+            cdefines.set('GSPLAT_FISHEYE', '');
+        }
 
         // Format-specific defines mirroring the compute renderer (compute-gsplat-local-renderer.js).
         const colorStream = wbFormat.getStream('dataColor');
@@ -331,58 +363,51 @@ class GSplatProjector {
             cdefines.set('GSPLAT_COLOR_FLOAT', '');
         }
 
+        const name = `GSplatProjector${radialSort ? 'Radial' : 'Linear'}${pickMode ? 'Pick' : ''}${fisheyeMode ? 'Fisheye' : ''}`;
+
+        const ubFormat = fisheyeMode ?
+            this._projectorUniformBufferFormatFisheye :
+            this._projectorUniformBufferFormat;
+
         const shader = new Shader(device, {
-            name: `${radialSort ? 'GSplatProjectorRadial' : 'GSplatProjectorLinear'}${pickMode ? 'Pick' : ''}`,
+            name: name,
             shaderLanguage: SHADERLANGUAGE_WGSL,
             cshader: computeGsplatProjectorSource,
             cincludes: cincludes,
             cdefines: cdefines,
             computeBindGroupFormat: this._projectorBindGroupFormat,
-            computeUniformBufferFormats: { uniforms: this._projectorUniformBufferFormat }
+            computeUniformBufferFormats: { uniforms: ubFormat }
         });
 
-        return new Compute(device, shader, `${radialSort ? 'GSplatProjectorRadial' : 'GSplatProjectorLinear'}${pickMode ? 'Pick' : ''}`);
+        return new Compute(device, shader, name);
     }
 
     /**
-     * Returns the projector Compute for the requested sort mode, lazily creating it.
-     * Recreates all compute instances when the work-buffer format version changes.
+     * Returns the projector Compute for the requested sort/pick/fisheye combination,
+     * lazily creating it. Recreates all compute instances when the work-buffer format
+     * version changes.
      *
      * @param {GSplatWorkBuffer} workBuffer - The current work buffer.
      * @param {boolean} radialSort - Whether to use the radial sort variant.
      * @param {boolean} [pickMode] - Whether to use the pick-output variant.
+     * @param {boolean} [fisheyeMode] - Whether to use the fisheye projection variant.
      * @returns {Compute} The projector compute instance.
      * @private
      */
-    _getProjectorCompute(workBuffer, radialSort, pickMode = false) {
+    _getProjectorCompute(workBuffer, radialSort, pickMode = false, fisheyeMode = false) {
         const wbFormat = workBuffer.format;
         if (this._formatVersion !== wbFormat.extraStreamsVersion) {
             this._destroyProjectorComputes();
             this._formatVersion = wbFormat.extraStreamsVersion;
         }
 
-        if (radialSort) {
-            if (pickMode) {
-                if (!this._projectorComputeRadialPick) {
-                    this._projectorComputeRadialPick = this._createProjectorCompute(workBuffer, true, true);
-                }
-                return this._projectorComputeRadialPick;
-            }
-            if (!this._projectorComputeRadial) {
-                this._projectorComputeRadial = this._createProjectorCompute(workBuffer, true, false);
-            }
-            return this._projectorComputeRadial;
+        const key = this._projectorKey(radialSort, pickMode, fisheyeMode);
+        let compute = this._projectorComputes.get(key);
+        if (!compute) {
+            compute = this._createProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode);
+            this._projectorComputes.set(key, compute);
         }
-        if (pickMode) {
-            if (!this._projectorComputeLinearPick) {
-                this._projectorComputeLinearPick = this._createProjectorCompute(workBuffer, false, true);
-            }
-            return this._projectorComputeLinearPick;
-        }
-        if (!this._projectorComputeLinear) {
-            this._projectorComputeLinear = this._createProjectorCompute(workBuffer, false, false);
-        }
-        return this._projectorComputeLinear;
+        return compute;
     }
 
     /**
@@ -425,14 +450,20 @@ class GSplatProjector {
      * @param {number} params.viewportWidth - Render viewport width in pixels.
      * @param {number} params.viewportHeight - Render viewport height in pixels.
      * @param {boolean} [params.pickMode] - Whether to write picking IDs into the cache.
+     * @param {import('../graphics/fisheye-projection.js').FisheyeProjection} [params.fisheyeProj] -
+     * Fisheye projection state. When `fisheyeProj.enabled` is true the projector picks the
+     * GSPLAT_FISHEYE variant and writes NDC-style clip data; otherwise the linear path runs.
      */
     dispatch(params) {
         const {
             workBuffer, cameraNode, compactedSplatIds, sortElementCountBuffer,
             totalCapacity, radialSort, numBits, minDist, maxDist,
             alphaClip, minPixelSize, minContribution,
-            viewportWidth, viewportHeight, pickMode = false
+            viewportWidth, viewportHeight, pickMode = false,
+            fisheyeProj
         } = params;
+
+        const fisheyeMode = !!fisheyeProj?.enabled;
 
         this._ensureCapacity(totalCapacity);
 
@@ -441,7 +472,7 @@ class GSplatProjector {
         // workgroups run their atomicAdds.
         this.renderCounter.clear();
 
-        const compute = this._getProjectorCompute(workBuffer, radialSort, pickMode);
+        const compute = this._getProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode);
 
         // Camera position / forward (camera Z basis, matching cpu-sort and key-compute).
         const cameraPos = cameraNode.getPosition();
@@ -511,6 +542,13 @@ class GSplatProjector {
         compute.setParameter('minDist', minDist);
         compute.setParameter('invRange', invRange);
         compute.setParameter('pad0', 0);
+
+        if (fisheyeMode) {
+            compute.setParameter('fisheye_k', fisheyeProj.k);
+            compute.setParameter('fisheye_inv_k', fisheyeProj.invK);
+            compute.setParameter('fisheye_projMat00', fisheyeProj.projMat00);
+            compute.setParameter('fisheye_projMat11', fisheyeProj.projMat11);
+        }
 
         // 2D dispatch over the work-buffer capacity. The shader early-outs threads beyond
         // sortElementCount[0]; sizing the dispatch for the full capacity (a CPU-known

--- a/src/scene/shader-lib/wgsl/chunks/common/comp/sort-indirect-args.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/comp/sort-indirect-args.js
@@ -2,15 +2,15 @@ export default /* wgsl */`
 // Writes up to 3 indirect dispatch slots for a compute-based sorter, using
 // sorter-provided metadata. Each slot occupies 3 consecutive u32 entries
 // (workgroup count x, y, z) in the dispatch buffer; this helper writes a 1D
-// dispatch of \`ceil(count / granularity[i])\` workgroups into slots
-// \`baseSlot + i\` for every active slot \`i\`.
+// dispatch of ceil(count / granularity[i]) workgroups into slots
+// (baseSlot + i) for every active slot i.
 //
 // Parameters:
 //   buf       - indirect dispatch buffer (plain array<u32>, not atomic).
 //   baseSlot  - index of the first slot to write (u32 offset = baseSlot * 3).
 //   count     - number of elements the sort will process.
 //   slotInfo  - sorter metadata, obtained verbatim from
-//               \`ComputeRadixSort#prepareIndirect()\` and passed in as a
+//               ComputeRadixSort#prepareIndirect() and passed in as a
 //               vec4<u32>:
 //                 .x = slotCount (1..3)
 //                 .y/.z/.w = per-slot elements-per-workgroup (granularity);

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js
@@ -77,6 +77,7 @@ struct Uniforms {
 #include "gsplatComputeSplatCS"
 #include "gsplatFormatDeclCS"
 #include "gsplatFormatReadCS"
+#include "gsplatProjectCommonCS"
 
 // NOTE on tile entry cap: if a tile exceeds MAX_TILE_ENTRIES (65535), the atomicAdd
 // count overcounts. Impact: the prefix sum allocates extra tileEntries slots that go
@@ -93,43 +94,37 @@ fn main(
     let threadIdx = gid.y * (numWorkgroups.x * 256u) + gid.x;
     let numVisible = sortElementCount[0];
 
-    if (threadIdx >= numVisible) {
-        return;
-    }
-
-    let splatId = compactedSplatIds[threadIdx];
-    setSplat(splatId);
-    let center = getCenter();
-    let opacity = getOpacity();
-
-    if (opacity < uniforms.alphaClip) {
-        projCache[threadIdx * {CACHE_STRIDE}u + 6u] = 0u;
-        splatPairStart[threadIdx] = 0u;
-        splatPairCount[threadIdx] = 0u;
-        return;
-    }
-
-    let rotation = half4(getRotation());
-    let scale = half3(getScale());
-
-    let proj = computeSplatCov(
-        center, rotation, scale,
-        uniforms.viewMatrix, uniforms.viewProj,
-        uniforms.focal, uniforms.viewportWidth, uniforms.viewportHeight,
-        uniforms.nearClip, uniforms.farClip, opacity, uniforms.minPixelSize,
-        uniforms.isOrtho, uniforms.alphaClip, uniforms.minContribution,
+    let projected = projectSplatCommon(
+        threadIdx,
+        numVisible,
+        uniforms.alphaClip,
+        uniforms.minPixelSize,
+        uniforms.minContribution,
+        uniforms.viewMatrix,
+        uniforms.viewProj,
+        uniforms.focal,
+        uniforms.viewportWidth,
+        uniforms.viewportHeight,
+        uniforms.nearClip,
+        uniforms.farClip,
+        uniforms.isOrtho,
         #ifdef GSPLAT_FISHEYE
             uniforms.fisheye_k, uniforms.fisheye_inv_k,
             uniforms.fisheye_projMat00, uniforms.fisheye_projMat11,
         #endif
     );
 
-    if (!proj.valid) {
-        projCache[threadIdx * {CACHE_STRIDE}u + 6u] = 0u;
-        splatPairStart[threadIdx] = 0u;
-        splatPairCount[threadIdx] = 0u;
+    if (!projected.valid) {
+        if (threadIdx < numVisible) {
+            projCache[threadIdx * {CACHE_STRIDE}u + 6u] = 0u;
+            splatPairStart[threadIdx] = 0u;
+            splatPairCount[threadIdx] = 0u;
+        }
         return;
     }
+
+    let opacity = projected.opacity;
+    let proj = projected.proj;
 
     let det = proj.a * proj.c - proj.b * proj.b;
     let invDet = 1.0 / det;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-project-common.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-project-common.js
@@ -1,0 +1,86 @@
+// Shared per-splat load + projection gate for compute GSplat paths.
+//
+// This chunk intentionally declares no bindings or uniforms. Callers provide
+// `compactedSplatIds` and include the format/read chunks before including this
+// helper.
+
+export const computeGsplatProjectCommonSource = /* wgsl */`
+
+struct ProjectedSplatCommon {
+    valid: bool,
+    splatId: u32,
+    center: vec3f,
+    opacity: f32,
+    proj: SplatCov2D
+}
+
+fn invalidProjectedSplatCommon() -> ProjectedSplatCommon {
+    var cov: SplatCov2D;
+    cov.screen = vec2f(0.0);
+    cov.a = 0.0;
+    cov.b = 0.0;
+    cov.c = 0.0;
+    cov.viewDepth = 0.0;
+    cov.valid = false;
+
+    return ProjectedSplatCommon(false, 0u, vec3f(0.0), 0.0, cov);
+}
+
+fn projectSplatCommon(
+    threadIdx: u32,
+    numVisible: u32,
+    alphaClip: f32,
+    minPixelSize: f32,
+    minContribution: f32,
+    viewMatrix: mat4x4f,
+    viewProj: mat4x4f,
+    focal: f32,
+    viewportWidth: f32,
+    viewportHeight: f32,
+    nearClip: f32,
+    farClip: f32,
+    isOrtho: u32,
+    #ifdef GSPLAT_FISHEYE
+        fisheye_k: f32,
+        fisheye_inv_k: f32,
+        fisheye_projMat00: f32,
+        fisheye_projMat11: f32,
+    #endif
+) -> ProjectedSplatCommon {
+    if (threadIdx >= numVisible) {
+        return invalidProjectedSplatCommon();
+    }
+
+    let splatId = compactedSplatIds[threadIdx];
+    setSplat(splatId);
+
+    let center = getCenter();
+    let opacity = getOpacity();
+    if (opacity <= alphaClip) {
+        return invalidProjectedSplatCommon();
+    }
+
+    let rotation = half4(getRotation());
+    let scale = half3(getScale());
+
+    let proj = computeSplatCov(
+        center, rotation, scale,
+        viewMatrix, viewProj,
+        focal, viewportWidth, viewportHeight,
+        nearClip, farClip, opacity, minPixelSize,
+        isOrtho, alphaClip, minContribution,
+        #ifdef GSPLAT_FISHEYE
+            fisheye_k, fisheye_inv_k,
+            fisheye_projMat00, fisheye_projMat11,
+        #endif
+    );
+
+    if (!proj.valid) {
+        return invalidProjectedSplatCommon();
+    }
+
+    return ProjectedSplatCommon(true, splatId, center, opacity, proj);
+}
+`;
+
+export default computeGsplatProjectCommonSource;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-project-common.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-project-common.js
@@ -1,7 +1,7 @@
 // Shared per-splat load + projection gate for compute GSplat paths.
 //
 // This chunk intentionally declares no bindings or uniforms. Callers provide
-// `compactedSplatIds` and include the format/read chunks before including this
+// compactedSplatIds and include the format/read chunks before including this
 // helper.
 
 export const computeGsplatProjectCommonSource = /* wgsl */`

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector-write-indirect-args.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector-write-indirect-args.js
@@ -1,0 +1,60 @@
+// Single-thread compute shader that reads the post-projection visible count from
+// renderCounter[0] (written by compute-gsplat-projector.js) and produces:
+//   - the indexed indirect draw args for the hybrid quad raster pass,
+//   - numSplatsBuf[0] for the vertex shader,
+//   - sortElementCountBuf[0] for the radix sort,
+//   - the indirect dispatch args for the radix sort (via writeSortIndirectArgs).
+//
+// Same overall shape as compute-gsplat-write-indirect-args.js, but it sources the
+// element count from renderCounter (atomic counter populated per-workgroup by the
+// projector) instead of prefixSumBuffer[totalSplats]. There is no separate keygen
+// dispatch — sort keys are produced inline by the projector pass.
+
+import indirectCoreCS from '../common/comp/indirect-core.js';
+import dispatchCoreCS from '../common/comp/dispatch-core.js';
+import sortIndirectArgsCS from '../common/comp/sort-indirect-args.js';
+
+export const computeGsplatProjectorWriteIndirectArgsSource = /* wgsl */`
+
+${indirectCoreCS}
+${dispatchCoreCS}
+${sortIndirectArgsCS}
+
+@group(0) @binding(0) var<storage, read> renderCounter: array<u32>;
+@group(0) @binding(1) var<storage, read_write> indirectDrawArgs: array<DrawIndexedIndirectArgs>;
+@group(0) @binding(2) var<storage, read_write> numSplatsBuf: array<u32>;
+@group(0) @binding(3) var<storage, read_write> indirectDispatchArgs: array<u32>;
+@group(0) @binding(4) var<storage, read_write> sortElementCountBuf: array<u32>;
+
+struct WriteArgsUniforms {
+    drawSlot: u32,
+    indexCount: u32,
+    sortSlotBase: u32,
+    pad0: u32,
+    sortIndirectInfo: vec4<u32>
+};
+@group(0) @binding(5) var<uniform> uniforms: WriteArgsUniforms;
+
+@compute @workgroup_size(1)
+fn main() {
+    let count = renderCounter[0];
+    let instanceCount = (count + {INSTANCE_SIZE}u - 1u) / {INSTANCE_SIZE}u;
+
+    indirectDrawArgs[uniforms.drawSlot] = DrawIndexedIndirectArgs(
+        uniforms.indexCount,
+        instanceCount,
+        0u,
+        0,
+        0u
+    );
+
+    numSplatsBuf[0] = count;
+    sortElementCountBuf[0] = count;
+
+    // Sort dispatch args at sortSlotBase (no keygen slot — sort keys come from the
+    // projector pass directly).
+    writeSortIndirectArgs(&indirectDispatchArgs, uniforms.sortSlotBase, count, uniforms.sortIndirectInfo);
+}
+`;
+
+export default computeGsplatProjectorWriteIndirectArgsSource;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
@@ -1,0 +1,210 @@
+// Single-pass projector for the hybrid GSplat renderer.
+//
+// For each visible splat (compactedSplatIds[threadIdx]) this pass:
+//   1. Projects the splat to clip + screen space (computeSplatCov), applying the same
+//      alpha / minPixelSize / minContribution / off-screen culls used by the compute renderer.
+//   2. Derives the eigen-vectors v1, v2 (same eigen-decomposition as gsplatCorner.js)
+//      and bakes the clip-space viewDepth / viewport scale into them.
+//   3. Computes a depth-based sort key (camera-relative bin weighting, same math as
+//      compute-gsplat-sort-key.js, optionally radial via RADIAL_SORT define).
+//   4. Workgroup-local atomic compaction: each thread that survives culling gets a slot
+//      via a shared atomic, then the workgroup leader reserves a contiguous range in the
+//      global renderCounter. This caps global atomics at one per workgroup.
+//   5. Writes the 8 u32 slots of the projection cache and the sort key.
+//
+// Bindings 0..6 are fixed; texture bindings for the work-buffer format follow them
+// (injected via gsplatFormatDeclCS, starting at binding {FIXED_BINDINGS_LEN}).
+//
+// 3DGS only for v1. Fisheye is not supported (the hybrid vertex shader assumes
+// proj.w == viewDepth, which only holds for the perspective projection).
+export const computeGsplatProjectorSource = /* wgsl */`
+
+#include "gsplatCommonCS"
+#include "gsplatTileIntersectCS"
+
+@group(0) @binding(0) var<storage, read> compactedSplatIds: array<u32>;
+@group(0) @binding(1) var<storage, read> sortElementCount: array<u32>;
+@group(0) @binding(2) var<storage, read_write> projCache: array<u32>;
+@group(0) @binding(3) var<storage, read_write> sortKeys: array<u32>;
+@group(0) @binding(4) var<storage, read_write> renderCounter: array<atomic<u32>>;
+
+// Camera-relative bin weighting for sort key computation (same layout as
+// compute-gsplat-sort-key.js: 32 entries of {base, divider}).
+struct BinWeight {
+    base: f32,
+    divider: f32
+}
+@group(0) @binding(5) var<storage, read> binWeights: array<BinWeight>;
+
+struct ProjectorUniforms {
+    splatTextureSize: u32,
+    numBins: u32,
+    isOrtho: u32,
+    pad0: u32,
+    viewProj: mat4x4f,
+    viewMatrix: mat4x4f,
+    cameraPosition: vec3f,
+    minPixelSize: f32,
+    cameraDirection: vec3f,
+    focal: f32,
+    viewportWidth: f32,
+    viewportHeight: f32,
+    nearClip: f32,
+    farClip: f32,
+    alphaClip: f32,
+    minContribution: f32,
+    minDist: f32,
+    invRange: f32,
+}
+@group(0) @binding(6) var<uniform> uniforms: ProjectorUniforms;
+
+#include "gsplatComputeSplatCS"
+#include "gsplatFormatDeclCS"
+#include "gsplatFormatReadCS"
+#include "gsplatProjectCommonCS"
+
+// One global atomicAdd per workgroup (256 threads) — drastically lowers contention
+// vs a per-thread atomic on the global counter without needing subgroup ops.
+var<workgroup> wgCount: atomic<u32>;
+var<workgroup> wgBase: u32;
+
+@compute @workgroup_size(256)
+fn main(
+    @builtin(global_invocation_id) gid: vec3u,
+    @builtin(num_workgroups) numWorkgroups: vec3u,
+    @builtin(local_invocation_index) localIdx: u32
+) {
+    if (localIdx == 0u) {
+        atomicStore(&wgCount, 0u);
+    }
+    workgroupBarrier();
+
+    // Match the indirect dispatch linearisation used by compute-gsplat-sort-key.js
+    // / compute-gsplat-local-tile-count.js: a 2D grid expanded into a flat thread index.
+    let threadIdx = gid.y * (numWorkgroups.x * 256u) + gid.x;
+    let numVisible = sortElementCount[0];
+
+    var valid = false;
+    var clipPos: vec4f = vec4f(0.0);
+    var v1: vec2f = vec2f(0.0);
+    var v2: vec2f = vec2f(0.0);
+    var rgb: vec3f = vec3f(0.0);
+    var alpha: f32 = 0.0;
+    var pcId: u32 = 0u;
+    var sortKey: u32 = 0u;
+    var viewDepth: f32 = 0.0;
+
+    let projected = projectSplatCommon(
+        threadIdx,
+        numVisible,
+        uniforms.alphaClip,
+        uniforms.minPixelSize,
+        uniforms.minContribution,
+        uniforms.viewMatrix,
+        uniforms.viewProj,
+        uniforms.focal,
+        uniforms.viewportWidth,
+        uniforms.viewportHeight,
+        uniforms.nearClip,
+        uniforms.farClip,
+        uniforms.isOrtho,
+    );
+
+    if (projected.valid) {
+        let center = projected.center;
+        let opacity = projected.opacity;
+        let proj = projected.proj;
+
+        // Eigen-decomposition matches gsplatCorner.js initCornerCov: derives the two
+        // screen-pixel eigen-vectors of the 2D screen-space covariance.
+        let mid = 0.5 * (proj.a + proj.c);
+        let radius = length(vec2f(0.5 * (proj.a - proj.c), proj.b));
+        let lambda1 = mid + radius;
+        let lambda2 = max(mid - radius, 0.1);
+
+        // capScale was already applied to a, b, c inside computeSplatCov so the
+        // eigenvalues here are already in the radius-capped space. The vmin
+        // saturation mirrors gsplatCorner.js (line 89-90) for hard parity with
+        // the existing rasterizer when capScale > 1.
+        let vmin = min(1024.0, min(uniforms.viewportWidth, uniforms.viewportHeight));
+        let l1 = 2.0 * min(sqrt(2.0 * lambda1), vmin);
+        let l2 = 2.0 * min(sqrt(2.0 * lambda2), vmin);
+
+        let dir = normalize(vec2f(proj.b, lambda1 - proj.a));
+        v1 = l1 * dir;
+        v2 = l2 * vec2f(dir.y, -dir.x);
+
+        // Clip-space center. For perspective projections clip.w == -viewCenter.z
+        // == proj.viewDepth, which is the value the hybrid VS uses for both
+        // corner-scale c and prepass linear depth.
+        clipPos = uniforms.viewProj * vec4f(center, 1.0);
+        clipPos.z = clamp(clipPos.z, 0.0, abs(clipPos.w));
+        viewDepth = proj.viewDepth;
+
+        // Sort key — same math as compute-gsplat-sort-key.js. We reuse the
+        // already-loaded world-space center instead of re-fetching it.
+        #ifdef RADIAL_SORT
+            let delta = center - uniforms.cameraPosition;
+            let radialDist = length(delta);
+            let dist = (1.0 / uniforms.invRange) - radialDist - uniforms.minDist;
+        #else
+            let toSplat = center - uniforms.cameraPosition;
+            let dist = dot(toSplat, uniforms.cameraDirection) - uniforms.minDist;
+        #endif
+        let d = dist * uniforms.invRange * f32(uniforms.numBins);
+        let binFloat = clamp(d, 0.0, f32(uniforms.numBins) - 0.001);
+        let bin = u32(binFloat);
+        let binFrac = binFloat - f32(bin);
+        sortKey = u32(binWeights[bin].base + binWeights[bin].divider * binFrac);
+
+        #ifdef PICK_MODE
+            pcId = loadPcId().r;
+            alpha = opacity;
+        #else
+            let color = getColor();
+            rgb = max(color, vec3f(0.0));
+            alpha = opacity;
+        #endif
+
+        valid = true;
+    }
+
+    // Reserve a per-workgroup slot for this thread.
+    var localDst: u32 = 0u;
+    if (valid) {
+        localDst = atomicAdd(&wgCount, 1u);
+    }
+    workgroupBarrier();
+
+    // Workgroup leader reserves a contiguous output range in renderCounter[0].
+    if (localIdx == 0u) {
+        let total = atomicLoad(&wgCount);
+        wgBase = atomicAdd(&renderCounter[0], total);
+    }
+    workgroupBarrier();
+
+    if (valid) {
+        let dst = wgBase + localDst;
+        let base = dst * {CACHE_STRIDE}u;
+
+        projCache[base + 0u] = bitcast<u32>(clipPos.x);
+        projCache[base + 1u] = bitcast<u32>(clipPos.y);
+        projCache[base + 2u] = bitcast<u32>(clipPos.z);
+        projCache[base + 3u] = bitcast<u32>(viewDepth);
+        projCache[base + 4u] = pack2x16float(v1);
+        projCache[base + 5u] = pack2x16float(v2);
+
+        #ifdef PICK_MODE
+            projCache[base + 6u] = pcId;
+            projCache[base + 7u] = pack2x16float(vec2f(0.0, alpha));
+        #else
+            projCache[base + 6u] = pack2x16float(vec2f(rgb.x, rgb.y));
+            projCache[base + 7u] = pack2x16float(vec2f(rgb.z, alpha));
+        #endif
+
+        sortKeys[dst] = sortKey;
+    }
+}
+`;
+
+export default computeGsplatProjectorSource;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
@@ -3,8 +3,7 @@
 // For each visible splat (compactedSplatIds[threadIdx]) this pass:
 //   1. Projects the splat to clip + screen space (computeSplatCov), applying the same
 //      alpha / minPixelSize / minContribution / off-screen culls used by the compute renderer.
-//   2. Derives the eigen-vectors v1, v2 (same eigen-decomposition as gsplatCorner.js)
-//      and bakes the clip-space viewDepth / viewport scale into them.
+//   2. Derives the eigen-vectors v1, v2 (same eigen-decomposition as gsplatCorner.js).
 //   3. Computes a depth-based sort key (camera-relative bin weighting, same math as
 //      compute-gsplat-sort-key.js, optionally radial via RADIAL_SORT define).
 //   4. Workgroup-local atomic compaction: each thread that survives culling gets a slot
@@ -15,8 +14,9 @@
 // Bindings 0..6 are fixed; texture bindings for the work-buffer format follow them
 // (injected via gsplatFormatDeclCS, starting at binding {FIXED_BINDINGS_LEN}).
 //
-// 3DGS only for v1. Fisheye is not supported (the hybrid vertex shader assumes
-// proj.w == viewDepth, which only holds for the perspective projection).
+// 3DGS only for v1. Fisheye is not supported (the hybrid vertex shader reconstructs
+// linear view depth from clip via clipToViewZ, which is only valid for linear
+// (perspective + orthographic) projections).
 export const computeGsplatProjectorSource = /* wgsl */`
 
 #include "gsplatCommonCS"
@@ -92,7 +92,6 @@ fn main(
     var alpha: f32 = 0.0;
     var pcId: u32 = 0u;
     var sortKey: u32 = 0u;
-    var viewDepth: f32 = 0.0;
 
     let projected = projectSplatCommon(
         threadIdx,
@@ -134,12 +133,12 @@ fn main(
         v1 = l1 * dir;
         v2 = l2 * vec2f(dir.y, -dir.x);
 
-        // Clip-space center. For perspective projections clip.w == -viewCenter.z
-        // == proj.viewDepth, which is the value the hybrid VS uses for both
-        // corner-scale c and prepass linear depth.
+        // Clip-space center. The hybrid VS uses clipPos.w directly for both
+        // output.position.w (rasterizer correctness) and corner scale, and
+        // reconstructs linear view depth from clipPos via the clipToViewZ
+        // uniform (= -inverse(matrix_projection)[row 2]).
         clipPos = uniforms.viewProj * vec4f(center, 1.0);
         clipPos.z = clamp(clipPos.z, 0.0, abs(clipPos.w));
-        viewDepth = proj.viewDepth;
 
         // Sort key — same math as compute-gsplat-sort-key.js. We reuse the
         // already-loaded world-space center instead of re-fetching it.
@@ -190,7 +189,7 @@ fn main(
         projCache[base + 0u] = bitcast<u32>(clipPos.x);
         projCache[base + 1u] = bitcast<u32>(clipPos.y);
         projCache[base + 2u] = bitcast<u32>(clipPos.z);
-        projCache[base + 3u] = bitcast<u32>(viewDepth);
+        projCache[base + 3u] = bitcast<u32>(clipPos.w);
         projCache[base + 4u] = pack2x16float(v1);
         projCache[base + 5u] = pack2x16float(v2);
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
@@ -14,9 +14,12 @@
 // Bindings 0..6 are fixed; texture bindings for the work-buffer format follow them
 // (injected via gsplatFormatDeclCS, starting at binding {FIXED_BINDINGS_LEN}).
 //
-// 3DGS only for v1. Fisheye is not supported (the hybrid vertex shader reconstructs
-// linear view depth from clip via clipToViewZ, which is only valid for linear
-// (perspective + orthographic) projections).
+// 3DGS only. Fisheye is supported via the GSPLAT_FISHEYE define: when enabled
+// the projector writes (ndc.x, ndc.y, depthNdc, 1.0) into the cache (matching
+// gsplatCenter.js) and the hybrid VS reconstructs linear view depth from clip
+// via clipToViewZ = (0, 0, far - near, near). For perspective + orthographic
+// the projector keeps writing real clipPos and the VS uses the
+// inverse-projection-derived clipToViewZ.
 export const computeGsplatProjectorSource = /* wgsl */`
 
 #include "gsplatCommonCS"
@@ -55,6 +58,12 @@ struct ProjectorUniforms {
     minContribution: f32,
     minDist: f32,
     invRange: f32,
+    #ifdef GSPLAT_FISHEYE
+        fisheye_k: f32,
+        fisheye_inv_k: f32,
+        fisheye_projMat00: f32,
+        fisheye_projMat11: f32,
+    #endif
 }
 @group(0) @binding(6) var<uniform> uniforms: ProjectorUniforms;
 
@@ -107,6 +116,12 @@ fn main(
         uniforms.nearClip,
         uniforms.farClip,
         uniforms.isOrtho,
+        #ifdef GSPLAT_FISHEYE
+            uniforms.fisheye_k,
+            uniforms.fisheye_inv_k,
+            uniforms.fisheye_projMat00,
+            uniforms.fisheye_projMat11,
+        #endif
     );
 
     if (projected.valid) {
@@ -135,10 +150,25 @@ fn main(
 
         // Clip-space center. The hybrid VS uses clipPos.w directly for both
         // output.position.w (rasterizer correctness) and corner scale, and
-        // reconstructs linear view depth from clipPos via the clipToViewZ
-        // uniform (= -inverse(matrix_projection)[row 2]).
-        clipPos = uniforms.viewProj * vec4f(center, 1.0);
-        clipPos.z = clamp(clipPos.z, 0.0, abs(clipPos.w));
+        // reconstructs linear view depth from clipPos via the clipToViewZ uniform.
+        #ifdef GSPLAT_FISHEYE
+            // Fisheye: invert the screen→pixel mapping done by computeSplatCov to recover
+            // NDC, then store NDC + linear depthNdc with w=1.0 (matches gsplatCenter.js).
+            // The rasterizer's perspective divide is a no-op (w=1), so output.position is
+            // NDC directly. The VS recovers linear -view.z via clipToViewZ = (0, 0, far-near, near).
+            let viewCenter = uniforms.viewMatrix * vec4f(center, 1.0);
+            let neg_z = -viewCenter.z;
+            let ndcX = proj.screen.x / uniforms.viewportWidth * 2.0 - 1.0;
+            let ndcY = proj.screen.y / uniforms.viewportHeight * 2.0 - 1.0;
+            let depthNdc = clamp(
+                (neg_z - uniforms.nearClip) / (uniforms.farClip - uniforms.nearClip),
+                0.0, 1.0
+            );
+            clipPos = vec4f(ndcX, ndcY, depthNdc, 1.0);
+        #else
+            clipPos = uniforms.viewProj * vec4f(center, 1.0);
+            clipPos.z = clamp(clipPos.z, 0.0, abs(clipPos.w));
+        #endif
 
         // Sort key — same math as compute-gsplat-sort-key.js. We reuse the
         // already-loaded world-space center instead of re-fetching it.

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
@@ -9,11 +9,16 @@
 // vertex side of the existing rasterization path.
 //
 // Layout matches gsplat-projector-constants.js (CACHE_STRIDE = 8 u32 / 32 B):
-//   [0..3] proj.xyzw  (clip-space center; w == view depth for perspective)
+//   [0..3] proj.xyzw  (clip-space center; .w is the real homogeneous w)
 //   [4]    v1.xy      (pack2x16float)  — screen-pixel eigen-vectors
 //   [5]    v2.xy      (pack2x16float)
 //   [6]    color rg   (or pcId in pick mode)
 //   [7]    color b + a (pack2x16float)
+//
+// Linear view depth (used for fog / overdraw / prepass) is reconstructed from
+// clipPos via the clipToViewZ uniform = -inverse(matrix_projection)[row 2].
+// This is correct for both perspective and orthographic projections; for
+// perspective it collapses to clip.w, matching the previous behaviour exactly.
 export default /* wgsl */`
 
 #include "gsplatHelpersVS"
@@ -22,6 +27,11 @@ export default /* wgsl */`
 attribute vertex_position: vec3f;
 
 uniform viewport_size: vec4f;
+
+// -inverse(matrix_projection)[row 2]; lets the VS reconstruct linear view
+// depth from clipPos via dot(clipToViewZ, clip). Set per-camera by the
+// renderer (see GSplatHybridRenderer).
+uniform clipToViewZ: vec4f;
 
 // Globally sorted indices into projCache (output of the radix sort).
 var<storage, read> sortedIndices: array<u32>;
@@ -104,8 +114,9 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     let clip = min(half(1.0), sqrt(log(half(255.0) * alpha)) * half(0.5));
     let cornerClipped = cornerUV * f32(clip);
 
-    // Convert pixel-space offset into clip-space. For perspective proj.w == viewDepth
-    // and c == w / viewport, matching gsplatCorner.js line 97.
+    // Convert pixel-space offset into clip-space. proj.w is the real clipPos.w,
+    // so c == clip.w / viewport matches gsplatCorner.js line 97 for both
+    // perspective (w == -view.z) and orthographic (w == 1) projections.
     let c = vec2f(proj.w) * uniform.viewport_size.zw;
     let pixelOffset = cornerClipped.x * v1 + cornerClipped.y * v2;
     let clipOffset = pixelOffset * c;
@@ -113,9 +124,11 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     output.position = proj + vec4f(clipOffset, 0.0, 0.0);
     output.gaussianUV = half2(cornerClipped);
 
-    // Apply gamma / fog / tonemap for the forward path. proj.w doubles as linear
-    // view depth (matches -center.view.z used by the existing VS).
-    let viewDepth = proj.w;
+    // Reconstruct linear view depth from clip via the per-camera clipToViewZ
+    // uniform = -inverse(matrix_projection)[row 2]. For perspective this
+    // collapses to clip.w; for ortho it produces the correct -view.z. Used by
+    // fog/overdraw/prepass below.
+    let viewDepth = dot(uniform.clipToViewZ, proj);
 
     #ifdef GSPLAT_OVERDRAW
         // Overdraw mode renders a flat colour ramp; depth-shade input not needed.

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
@@ -1,0 +1,148 @@
+// Vertex shader for the hybrid GSplat renderer.
+//
+// Reads pre-projected splat data from a projection cache built by the projector
+// compute pass (see compute-gsplat-projector.js) plus a globally sorted index
+// list (radix sort). For each instanced quad vertex it expands the splat to a
+// screen-aligned quad using the cached eigen-vectors v1, v2.
+//
+// The fragment shader is the existing gsplatPS — this chunk only replaces the
+// vertex side of the existing rasterization path.
+//
+// Layout matches gsplat-projector-constants.js (CACHE_STRIDE = 8 u32 / 32 B):
+//   [0..3] proj.xyzw  (clip-space center; w == view depth for perspective)
+//   [4]    v1.xy      (pack2x16float)  — screen-pixel eigen-vectors
+//   [5]    v2.xy      (pack2x16float)
+//   [6]    color rg   (or pcId in pick mode)
+//   [7]    color b + a (pack2x16float)
+export default /* wgsl */`
+
+#include "gsplatHelpersVS"
+#include "gsplatOutputVS"
+
+attribute vertex_position: vec3f;
+
+uniform viewport_size: vec4f;
+
+// Globally sorted indices into projCache (output of the radix sort).
+var<storage, read> sortedIndices: array<u32>;
+
+// Pre-projected splat cache (8 u32 slots per splat).
+var<storage, read> projCache: array<u32>;
+
+// Visible splat count written by compute-gsplat-projector-write-indirect-args.js.
+var<storage, read> numSplatsStorage: array<u32>;
+
+varying gaussianUV: half2;
+varying gaussianColor: half4;
+
+#ifndef DITHER_NONE
+    varying id: f32;
+#endif
+
+#ifdef PREPASS_PASS
+    varying vLinearDepth: f32;
+#endif
+
+#if defined(GSPLAT_UNIFIED_ID) && defined(PICK_PASS)
+    varying @interpolate(flat) vPickId: u32;
+#endif
+
+#ifdef GSPLAT_OVERDRAW
+    uniform colorRampIntensity: f32;
+    var colorRamp: texture_2d<f32>;
+    var colorRampSampler: sampler;
+#endif
+
+const discardVec: vec4f = vec4f(0.0, 0.0, 2.0, 1.0);
+
+@vertex
+fn vertexMain(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+
+    // Same instance/quad linearisation as gsplatSourceVS:
+    // order = instanceIdx * GSPLAT_INSTANCE_SIZE + perInstanceQuadIdx.
+    let order = pcInstanceIndex * {GSPLAT_INSTANCE_SIZE}u + u32(vertex_position.z);
+
+    let numSplats = numSplatsStorage[0];
+    if (order >= numSplats) {
+        output.position = discardVec;
+        return output;
+    }
+
+    let cacheIdx = sortedIndices[order];
+    let base = cacheIdx * {CACHE_STRIDE}u;
+
+    let proj = vec4f(
+        bitcast<f32>(projCache[base + 0u]),
+        bitcast<f32>(projCache[base + 1u]),
+        bitcast<f32>(projCache[base + 2u]),
+        bitcast<f32>(projCache[base + 3u])
+    );
+    let v1 = unpack2x16float(projCache[base + 4u]);
+    let v2 = unpack2x16float(projCache[base + 5u]);
+
+    // Color / opacity / pickId: slot 6 is either packed (rg) or a raw u32 pcId.
+    let ba = unpack2x16float(projCache[base + 7u]);
+    let alpha = half(ba.y);
+
+    #if defined(GSPLAT_UNIFIED_ID) && defined(PICK_PASS)
+        let pickId = projCache[base + 6u];
+    #endif
+
+    #ifdef PICK_PASS
+        // In the pick path slot 6 is repurposed as the picking ID; alpha is the only
+        // colour we care about in the FS gate. Slot 7's r channel is unused.
+        var clr: half4 = half4(half(0.0), half(0.0), half(0.0), alpha);
+    #else
+        let rg = unpack2x16float(projCache[base + 6u]);
+        var clr: half4 = half4(half(rg.x), half(rg.y), half(ba.x), alpha);
+    #endif
+
+    // clipCorner: shrink the quad to exclude near-zero alpha regions. Mirrors the
+    // helper in gsplatCommonVS (kept inline to avoid pulling in the full gsplatCommonVS).
+    let cornerUV = vec2f(vertex_position.xy);
+    let clip = min(half(1.0), sqrt(log(half(255.0) * alpha)) * half(0.5));
+    let cornerClipped = cornerUV * f32(clip);
+
+    // Convert pixel-space offset into clip-space. For perspective proj.w == viewDepth
+    // and c == w / viewport, matching gsplatCorner.js line 97.
+    let c = vec2f(proj.w) * uniform.viewport_size.zw;
+    let pixelOffset = cornerClipped.x * v1 + cornerClipped.y * v2;
+    let clipOffset = pixelOffset * c;
+
+    output.position = proj + vec4f(clipOffset, 0.0, 0.0);
+    output.gaussianUV = half2(cornerClipped);
+
+    // Apply gamma / fog / tonemap for the forward path. proj.w doubles as linear
+    // view depth (matches -center.view.z used by the existing VS).
+    let viewDepth = proj.w;
+
+    #ifdef GSPLAT_OVERDRAW
+        // Overdraw mode renders a flat colour ramp; depth-shade input not needed.
+        let t: f32 = clamp(viewDepth / 20.0, 0.0, 1.0);
+        let rampColor: vec3f = textureSampleLevel(colorRamp, colorRampSampler, vec2f(t, 0.5), 0.0).rgb;
+        let outAlpha = alpha * half(1.0 / 32.0) * half(uniform.colorRampIntensity);
+        output.gaussianColor = half4(half3(rampColor), outAlpha);
+    #else
+        output.gaussianColor = half4(
+            half3(prepareOutputFromGamma(max(vec3f(clr.xyz), vec3f(0.0)), viewDepth)),
+            alpha
+        );
+    #endif
+
+    #ifndef DITHER_NONE
+        // Best-effort id from the cache index — used only for blue-noise dither.
+        output.id = f32(cacheIdx);
+    #endif
+
+    #ifdef PREPASS_PASS
+        output.vLinearDepth = viewDepth;
+    #endif
+
+    #if defined(GSPLAT_UNIFIED_ID) && defined(PICK_PASS)
+        output.vPickId = pickId;
+    #endif
+
+    return output;
+}
+`;

--- a/src/scene/shader-lib/wgsl/collections/gsplat-chunks-wgsl.js
+++ b/src/scene/shader-lib/wgsl/collections/gsplat-chunks-wgsl.js
@@ -13,6 +13,7 @@ import gsplatPS from '../chunks/gsplat/frag/gsplat.js';
 import gsplatTileCompositePS from '../chunks/gsplat/frag/gsplatTileComposite.js';
 import gsplatSourceVS from '../chunks/gsplat/vert/gsplatSource.js';
 import gsplatVS from '../chunks/gsplat/vert/gsplat.js';
+import gsplatHybridVS from '../chunks/gsplat/vert/gsplatHybrid.js';
 import gsplatPackingPS from '../chunks/gsplat/frag/gsplatPacking.js';
 import gsplatFormatVS from '../chunks/gsplat/vert/gsplatFormat.js';
 
@@ -43,6 +44,7 @@ export const gsplatChunksWGSL = {
     gsplatTileCompositePS,
     gsplatSourceVS,
     gsplatVS,
+    gsplatHybridVS,
     gsplatPackingPS,
     gsplatFormatVS,
     gsplatUncompressedVS,


### PR DESCRIPTION
Adds a WebGPU hybrid Gaussian splat renderer that combines a compute projection / sort-key pass with the existing instanced quad raster path, plus manager wiring, shared WGSL projection logic, and example updates.

**Changes:**
- New hybrid pipeline: `GSplatProjector` compute pass writes projection cache and sort keys; indirect radix sort orders splats; `GSplatHybridRenderer` draws with WGSL `gsplatHybrid` VS reading sorted indices + cache (forward, pick, prepass; shadow casting not included).
- `GSplatManager`: hybrid GPU sorting (`initHybridSorting`, `sortGpuHybrid` / `sortGpuHybridForCamera`), indirect args when projector visible count differs from interval compaction, pick integration.
- Shared WGSL `compute-gsplat-project-common` used by hybrid projector and compute local tile-count shader.
- `GSplatParams`: `alphaCull` for forward-pass projector-side threshold (default `1/255`).
- Examples: **Raster (Hybrid)** in gsplat renderer dropdowns where applicable; lod-streaming **Alpha Cull** slider; benchmark layout (linear x-axis from data, chart aligned to table width, DPR bitmap, scroll column, PNG capture fixes).

**Public API:**
- `scene.gsplat.alphaCull` — threshold passed through material/GSplat params for forward projector-side culling when hybrid mode is active (`GSplatParams`).
- `GSPLAT_RENDERER_RASTER_HYBRID` remains **`@ignore`** in API reference builds (experimental / internal); examples may still select the numeric mode for testing.

**Examples:**
- Gaussian splatting `.controls.mjs`: Hybrid option where other renderer modes are listed.
- `lod-streaming.example.mjs` / `.controls.mjs`: Alpha Cull slider.