### PR TITLE
feat(examples): unified gsplat for annotations and multi-splat

### DIFF
--- a/examples/src/examples/gaussian-splatting/annotations.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/annotations.controls.mjs
@@ -3,8 +3,25 @@
  * @returns {JSX.Element} The returned JSX Element.
  */
 export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
-    const { BindingTwoWay, ColorPicker, LabelGroup, Panel, SliderInput } = ReactPCUI;
+    const { BindingTwoWay, ColorPicker, LabelGroup, Panel, SelectInput, SliderInput } = ReactPCUI;
     return fragment(
+        jsx(
+            LabelGroup,
+            { text: 'Renderer' },
+            jsx(SelectInput, {
+                type: 'number',
+                binding: new BindingTwoWay(),
+                link: { observer, path: 'renderer' },
+                value: observer.get('renderer') ?? 0,
+                options: [
+                    { v: 0, t: 'Auto' },
+                    { v: 1, t: 'Raster (CPU Sort)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
+                    { v: 3, t: 'Compute' },
+                    { v: 4, t: 'Raster (Hybrid)' }
+                ]
+            })
+        ),
         jsx(
             Panel,
             { headerText: 'Annotations' },

--- a/examples/src/examples/gaussian-splatting/annotations.example.mjs
+++ b/examples/src/examples/gaussian-splatting/annotations.example.mjs
@@ -84,10 +84,20 @@ const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets
 assetListLoader.load(() => {
     app.start();
 
+    data.on('renderer:set', () => {
+        app.scene.gsplat.renderer = data.get('renderer');
+        const current = app.scene.gsplat.currentRenderer;
+        if (current !== data.get('renderer')) {
+            setTimeout(() => data.set('renderer', current), 0);
+        }
+    });
+    data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
+
     // Create the bicycle gsplat
     const bicycle = new pc.Entity('Bicycle');
     bicycle.addComponent('gsplat', {
-        asset: assets.bicycle
+        asset: assets.bicycle,
+        unified: true
     });
     bicycle.setLocalEulerAngles(0, 0, 180);
     app.root.addChild(bicycle);

--- a/examples/src/examples/gaussian-splatting/multi-splat.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/multi-splat.controls.mjs
@@ -3,6 +3,9 @@
  * @returns {JSX.Element} The returned JSX Element.
  */
 export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
+    if (observer.get('shader') === undefined) {
+        observer.set('shader', false);
+    }
     const { Button } = ReactPCUI;
     return fragment(
         jsx(Button, {

--- a/examples/src/examples/gaussian-splatting/multi-splat.example.mjs
+++ b/examples/src/examples/gaussian-splatting/multi-splat.example.mjs
@@ -16,8 +16,6 @@ const gfxOptions = {
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
 device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
-const shaderLanguage = device.isWebGPU ? 'wgsl' : 'glsl';
-
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);
@@ -58,6 +56,12 @@ const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets
 assetListLoader.load(() => {
     app.start();
 
+    // camera placement
+    const ORBIT_PIVOT = new pc.Vec3(0, 0.8, 0);
+    const ORBIT_DISTANCE = 5;
+    const ORBIT_INITIAL_YAW = 28;
+    const ORBIT_INITIAL_PITCH = -8;
+
     // get the instance of the gallery and set up with render component
     const galleryEntity = assets.gallery.resource.instantiateRenderEntity();
     app.root.addChild(galleryEntity);
@@ -68,25 +72,22 @@ assetListLoader.load(() => {
         clearColor: new pc.Color(0.2, 0.2, 0.2),
         toneMapping: pc.TONEMAP_ACES
     });
-    camera.setLocalPosition(-3, 1, 2);
 
-    // instantiate guitar with a custom shader
     const guitar = new pc.Entity('guitar');
     guitar.addComponent('gsplat', {
-        asset: assets.guitar
+        asset: assets.guitar,
+        unified: true
     });
-    const customShaderFile = shaderLanguage === 'wgsl' ? 'shader.wgsl.vert' : 'shader.glsl.vert';
-    guitar.gsplat.material.getShaderChunks(shaderLanguage).set('gsplatModifyVS', files[customShaderFile]);
     guitar.setLocalPosition(0, 0.8, 0);
     guitar.setLocalEulerAngles(0, 0, 180);
     guitar.setLocalScale(0.4, 0.4, 0.4);
     app.root.addChild(guitar);
 
-    // helper function to create a splat instance
-    const createSplatInstance = (name, asset, px, py, pz, scale, vertex, fragment) => {
+    const createSplatInstance = (name, asset, px, py, pz, scale) => {
         const entity = new pc.Entity(name);
         entity.addComponent('gsplat', {
-            asset: asset
+            asset,
+            unified: true
         });
         entity.setLocalPosition(px, py, pz);
         entity.setLocalEulerAngles(180, 90, 0);
@@ -96,53 +97,53 @@ assetListLoader.load(() => {
         return entity;
     };
 
-    const biker = createSplatInstance('biker', assets.biker, -1.5, 0.05, 0, 0.7);
+    createSplatInstance('biker', assets.biker, -1.5, 0.05, 0, 0.7);
 
-    // clone the biker and add the clone to the scene
     const skull = createSplatInstance('skull', assets.skull, 1.5, 0.05, 0, 0.7);
     skull.rotate(0, 150, 0);
-    app.root.addChild(skull);
 
-    // add orbit camera script with a mouse and a touch support
+    app.root.addChild(camera);
+
+    // Orbit around a fixed pivot (not focusEntity — unified gsplats have no meshInstance for AABB).
     camera.addComponent('script');
-    camera.script.create('orbitCamera', {
+    const orbitCam = /** @type {any} */ (camera.script.create('orbitCamera', {
         attributes: {
             inertiaFactor: 0.2,
-            focusEntity: guitar,
             distanceMax: 60,
             frameOnStart: false
         }
-    });
+    }));
+    if (orbitCam) {
+        orbitCam.pivotPoint.copy(ORBIT_PIVOT);
+        orbitCam.reset(ORBIT_INITIAL_YAW, ORBIT_INITIAL_PITCH, ORBIT_DISTANCE);
+        orbitCam._updatePosition();
+    }
     camera.script.create('orbitCameraInputMouse');
     camera.script.create('orbitCameraInputTouch');
-    app.root.addChild(camera);
 
-    let useCustomShader = true;
+    const glslVs = files['shader.glsl.vert'];
+    const wgslVs = files['shader.wgsl.vert'];
+    const sceneMat = app.scene.gsplat.material;
+
+    /**
+     * @param {boolean} enabled - Whether to apply the shared gsplatModifyVS chunk.
+     */
+    const applyCustomShader = (enabled) => {
+        if (enabled) {
+            sceneMat.getShaderChunks('glsl').set('gsplatModifyVS', glslVs);
+            sceneMat.getShaderChunks('wgsl').set('gsplatModifyVS', wgslVs);
+        } else {
+            sceneMat.getShaderChunks('glsl').delete('gsplatModifyVS');
+            sceneMat.getShaderChunks('wgsl').delete('gsplatModifyVS');
+        }
+        sceneMat.update();
+    };
+
     data.on('shader:set', () => {
-        // Apply custom or default material options to the splats when the button is clicked. Note
-        // that this uses non-public API, which is subject to change when a proper API is added.
-        const customShaderFile = shaderLanguage === 'wgsl' ? 'shader.wgsl.vert' : 'shader.glsl.vert';
-        const vs = files[customShaderFile];
-
-        const mat1 = biker.gsplat.material;
-        if (useCustomShader) {
-            mat1.getShaderChunks(shaderLanguage).set('gsplatModifyVS', vs);
-        } else {
-            mat1.getShaderChunks(shaderLanguage).delete('gsplatModifyVS');
-        }
-        mat1.update();
-
-        const mat2 = skull.gsplat.material;
-        if (useCustomShader) {
-            mat2.getShaderChunks(shaderLanguage).set('gsplatModifyVS', vs);
-        } else {
-            mat2.getShaderChunks(shaderLanguage).delete('gsplatModifyVS');
-        }
-        mat2.setDefine('CUTOUT', true);
-        mat2.update();
-
-        useCustomShader = !useCustomShader;
+        applyCustomShader(!!data.get('shader'));
     });
+    applyCustomShader(false);
+    data.set('shader', false);
 
     const uTime = app.graphicsDevice.scope.resolve('uTime');
 

--- a/examples/src/examples/gaussian-splatting/multi-splat.shader.glsl.vert
+++ b/examples/src/examples/gaussian-splatting/multi-splat.shader.glsl.vert
@@ -13,15 +13,7 @@ void modifySplatRotationScale(vec3 originalCenter, vec3 modifiedCenter, inout ve
 void modifySplatColor(vec3 center, inout vec4 clr) {
     float sineValue = abs(sin(uTime * 5.0 + center.y));
 
-    #ifdef CUTOUT
-        // in cutout mode, remove pixels along the wave
-        if (sineValue < 0.5) {
-            clr.a = 0.0;
-        }
-    #else
-        // in non-cutout mode, add a golden tint to the wave
-        vec3 gold = vec3(1.0, 0.85, 0.0);
-        float blend = smoothstep(0.9, 1.0, sineValue);
-        clr.xyz = mix(clr.xyz, gold, blend);
-    #endif
+    vec3 gold = vec3(1.0, 0.85, 0.0);
+    float blend = smoothstep(0.9, 1.0, sineValue);
+    clr.xyz = mix(clr.xyz, gold, blend);
 }

--- a/examples/src/examples/gaussian-splatting/multi-splat.shader.wgsl.vert
+++ b/examples/src/examples/gaussian-splatting/multi-splat.shader.wgsl.vert
@@ -13,15 +13,7 @@ fn modifySplatRotationScale(originalCenter: vec3f, modifiedCenter: vec3f, rotati
 fn modifySplatColor(center: vec3f, clr: ptr<function, vec4f>) {
     let sineValue = abs(sin(uniform.uTime * 5.0 + center.y));
 
-    #ifdef CUTOUT
-        // in cutout mode, remove pixels along the wave
-        if (sineValue < 0.5) {
-            (*clr).a = 0.0;
-        }
-    #else
-        // in non-cutout mode, add a golden tint to the wave
-        let gold = vec3f(1.0, 0.85, 0.0);
-        let blend = smoothstep(0.9, 1.0, sineValue);
-        (*clr) = vec4f(mix((*clr).xyz, gold, blend), (*clr).a);
-    #endif
+    let gold = vec3f(1.0, 0.85, 0.0);
+    let blend = smoothstep(0.9, 1.0, sineValue);
+    (*clr) = vec4f(mix((*clr).xyz, gold, blend), (*clr).a);
 }


### PR DESCRIPTION
## Summary

Updates two Gaussian splatting examples: **annotations** (unified splat + renderer control) and **multi-splat** (unified splats, shared scene material modifier, orbit pivot, simplified shaders).

## Changes

**Annotations**
- Enable `unified: true` on the bicycle gsplat.
- Add Renderer `SelectInput` in controls (same options as flipbook).
- Wire `data` observer to `app.scene.gsplat.renderer` with fallback when the active renderer differs from the requested value.

**Multi-splat**
- Use `unified: true` for guitar, biker, and skull; drive `gsplatModifyVS` from `app.scene.gsplat.material` (GLSL + WGSL) with the Custom Shader toggle defaulting off.
- Orbit camera: fixed world pivot at the guitar base, fixed distance/yaw/pitch constants; no `focusEntity` (unified gsplats do not contribute mesh AABB to orbit framing).
- Shader modifiers: single golden-tint path only (remove `CUTOUT` variant); controls initialize `shader` to `false` when unset.
