### PR TITLE
docs: clarify spotlight cone angles are half-angles

### DIFF
--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -530,8 +530,9 @@ class LightComponent extends Component {
     }
 
     /**
-     * Sets the angle at which the spotlight cone starts to fade off. The angle is specified in
-     * degrees. Affects spot lights only. Defaults to 40.
+     * Sets the half-angle (measured in degrees from the light's direction axis to the cone edge)
+     * at which the spotlight cone starts to fade off. The full inner beam angle is twice this
+     * value. Affects spot lights only. Defaults to 40 (i.e. an 80 degree full inner beam).
      *
      * @type {number}
      */
@@ -542,7 +543,8 @@ class LightComponent extends Component {
     }
 
     /**
-     * Gets the angle at which the spotlight cone starts to fade off.
+     * Gets the half-angle (measured in degrees from the light's direction axis to the cone edge)
+     * at which the spotlight cone starts to fade off.
      *
      * @type {number}
      */
@@ -551,8 +553,9 @@ class LightComponent extends Component {
     }
 
     /**
-     * Sets the angle at which the spotlight cone has faded to nothing. The angle is specified in
-     * degrees. Affects spot lights only. Defaults to 45.
+     * Sets the half-angle (measured in degrees from the light's direction axis to the cone edge)
+     * at which the spotlight cone has faded to nothing. The full outer beam angle is twice this
+     * value. Affects spot lights only. Defaults to 45 (i.e. a 90 degree full outer beam).
      *
      * @type {number}
      */
@@ -563,7 +566,8 @@ class LightComponent extends Component {
     }
 
     /**
-     * Gets the angle at which the spotlight cone has faded to nothing.
+     * Gets the half-angle (measured in degrees from the light's direction axis to the cone edge)
+     * at which the spotlight cone has faded to nothing.
      *
      * @type {number}
      */

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -532,7 +532,7 @@ class LightComponent extends Component {
     /**
      * Sets the half-angle (measured in degrees from the light's direction axis to the cone edge)
      * at which the spotlight cone starts to fade off. The full inner beam angle is twice this
-     * value. Affects spot lights only. Defaults to 40 (i.e. an 80 degree full inner beam).
+     * value. Affects spot lights only. Defaults to 40 (i.e. an 80-degree full inner beam).
      *
      * @type {number}
      */

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -555,7 +555,7 @@ class LightComponent extends Component {
     /**
      * Sets the half-angle (measured in degrees from the light's direction axis to the cone edge)
      * at which the spotlight cone has faded to nothing. The full outer beam angle is twice this
-     * value. Affects spot lights only. Defaults to 45 (i.e. a 90 degree full outer beam).
+     * value. Affects spot lights only. Defaults to 45 (i.e. a 90-degree full outer beam).
      *
      * @type {number}
      */


### PR DESCRIPTION
## Summary

- Clarifies in the `LightComponent.innerConeAngle` / `LightComponent.outerConeAngle` JSDoc that these are **half-angles** (measured from the light's direction axis to the cone edge), and calls out the resulting full beam angle.
- No runtime behavior change — documentation only.

## Motivation

The current wording ("the angle at which the spotlight cone has faded to nothing") reads naturally as the full beam angle. That's the convention every major DCC / engine uses — Unity, Maya, 3ds Max, Unreal, Blender all treat a "45° spot" as a 45° cone. PlayCanvas actually stores the half-angle (which is the natural form for the shader math and matches glTF `KHR_lights_punctual`), so a user setting `outerConeAngle = 45` gets a **90° cone**, not a 45° one. The default `45` compounds the confusion.

This PR doesn't change the convention (behavior stability + glTF alignment make that a separate discussion) — it just stops the docs from quietly misleading readers.

## Before / After

Before:

```javascript
/**
 * Sets the angle at which the spotlight cone has faded to nothing. The angle is specified in
 * degrees. Affects spot lights only. Defaults to 45.
 *
 * @type {number}
 */
set outerConeAngle(arg) { ... }
```

After:

```javascript
/**
 * Sets the half-angle (measured in degrees from the light's direction axis to the cone edge)
 * at which the spotlight cone has faded to nothing. The full outer beam angle is twice this
 * value. Affects spot lights only. Defaults to 45 (i.e. a 90 degree full outer beam).
 *
 * @type {number}
 */
set outerConeAngle(arg) { ... }
```

`innerConeAngle` gets the equivalent treatment (half-angle, full inner beam callout, default `40` → 80° full inner beam).

## Test plan

- [x] `npm run lint` clean
- Docs-only change; no runtime tests needed.
