### PR TITLE
refactor: migrate ComponentData classes to class fields

### DIFF
--- a/src/framework/components/anim/data.js
+++ b/src/framework/components/anim/data.js
@@ -1,7 +1,5 @@
 class AnimComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { AnimComponentData };

--- a/src/framework/components/animation/data.js
+++ b/src/framework/components/animation/data.js
@@ -1,7 +1,5 @@
 class AnimationComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { AnimationComponentData };

--- a/src/framework/components/audio-listener/data.js
+++ b/src/framework/components/audio-listener/data.js
@@ -1,5 +1,4 @@
 class AudioListenerComponentData {
-    // Serialized
     enabled = true;
 }
 

--- a/src/framework/components/audio-listener/data.js
+++ b/src/framework/components/audio-listener/data.js
@@ -1,8 +1,6 @@
 class AudioListenerComponentData {
-    constructor() {
-        // Serialized
-        this.enabled = true;
-    }
+    // Serialized
+    enabled = true;
 }
 
 export { AudioListenerComponentData };

--- a/src/framework/components/button/data.js
+++ b/src/framework/components/button/data.js
@@ -8,28 +8,39 @@ import { BUTTON_TRANSITION_MODE_TINT } from './constants.js';
  */
 
 class ButtonComponentData {
-    constructor() {
-        this.enabled = true;
+    enabled = true;
 
-        this.active = true;
-        /** @type {Entity} */
-        this.imageEntity = null;
-        this.hitPadding = new Vec4();
-        this.transitionMode = BUTTON_TRANSITION_MODE_TINT;
-        this.hoverTint = new Color(0.75, 0.75, 0.75);
-        this.pressedTint = new Color(0.5, 0.5, 0.5);
-        this.inactiveTint = new Color(0.25, 0.25, 0.25);
-        this.fadeDuration = 0;
-        /** @type {Asset} */
-        this.hoverSpriteAsset = null;
-        this.hoverSpriteFrame = 0;
-        /** @type {Asset} */
-        this.pressedSpriteAsset = null;
-        this.pressedSpriteFrame = 0;
-        /** @type {Asset} */
-        this.inactiveSpriteAsset = null;
-        this.inactiveSpriteFrame = 0;
-    }
+    active = true;
+
+    /** @type {Entity|null} */
+    imageEntity = null;
+
+    hitPadding = new Vec4();
+
+    transitionMode = BUTTON_TRANSITION_MODE_TINT;
+
+    hoverTint = new Color(0.75, 0.75, 0.75);
+
+    pressedTint = new Color(0.5, 0.5, 0.5);
+
+    inactiveTint = new Color(0.25, 0.25, 0.25);
+
+    fadeDuration = 0;
+
+    /** @type {Asset|null} */
+    hoverSpriteAsset = null;
+
+    hoverSpriteFrame = 0;
+
+    /** @type {Asset|null} */
+    pressedSpriteAsset = null;
+
+    pressedSpriteFrame = 0;
+
+    /** @type {Asset|null} */
+    inactiveSpriteAsset = null;
+
+    inactiveSpriteFrame = 0;
 }
 
 export { ButtonComponentData };

--- a/src/framework/components/camera/data.js
+++ b/src/framework/components/camera/data.js
@@ -1,7 +1,5 @@
 class CameraComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { CameraComponentData };

--- a/src/framework/components/collision/data.js
+++ b/src/framework/components/collision/data.js
@@ -7,29 +7,41 @@ import { Vec3 } from '../../../core/math/vec3.js';
  */
 
 class CollisionComponentData {
-    constructor() {
-        this.enabled = true;
-        this.type = 'box';
-        this.halfExtents = new Vec3(0.5, 0.5, 0.5);
-        this.linearOffset = new Vec3();
-        this.angularOffset = new Quat();
-        this.radius = 0.5;
-        this.axis = 1;
-        this.height = 2;
-        this.convexHull = false;
-        /** @type {Asset | number} */
-        this.asset = null;
-        /** @type {Asset | number} */
-        this.renderAsset = null;
-        this.checkVertexDuplicates = true;
+    enabled = true;
 
-        // Non-serialized properties
-        this.shape = null;
-        /** @type {Model | null} */
-        this.model = null;
-        this.render = null;
-        this.initialized = false;
-    }
+    type = 'box';
+
+    halfExtents = new Vec3(0.5, 0.5, 0.5);
+
+    linearOffset = new Vec3();
+
+    angularOffset = new Quat();
+
+    radius = 0.5;
+
+    axis = 1;
+
+    height = 2;
+
+    convexHull = false;
+
+    /** @type {Asset|number|null} */
+    asset = null;
+
+    /** @type {Asset|number|null} */
+    renderAsset = null;
+
+    checkVertexDuplicates = true;
+
+    // Non-serialized properties
+    shape = null;
+
+    /** @type {Model|null} */
+    model = null;
+
+    render = null;
+
+    initialized = false;
 }
 
 export { CollisionComponentData };

--- a/src/framework/components/element/data.js
+++ b/src/framework/components/element/data.js
@@ -1,7 +1,5 @@
 class ElementComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { ElementComponentData };

--- a/src/framework/components/gsplat/data.js
+++ b/src/framework/components/gsplat/data.js
@@ -1,7 +1,5 @@
 class GSplatComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { GSplatComponentData };

--- a/src/framework/components/joint/data.js
+++ b/src/framework/components/joint/data.js
@@ -1,7 +1,5 @@
 class JointComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { JointComponentData };

--- a/src/framework/components/layout-child/data.js
+++ b/src/framework/components/layout-child/data.js
@@ -1,7 +1,5 @@
 class LayoutChildComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { LayoutChildComponentData };

--- a/src/framework/components/layout-group/data.js
+++ b/src/framework/components/layout-group/data.js
@@ -1,7 +1,5 @@
 class LayoutGroupComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { LayoutGroupComponentData };

--- a/src/framework/components/light/data.js
+++ b/src/framework/components/light/data.js
@@ -1,7 +1,5 @@
 class LightComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { LightComponentData };

--- a/src/framework/components/model/data.js
+++ b/src/framework/components/model/data.js
@@ -1,7 +1,5 @@
 class ModelComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { ModelComponentData };

--- a/src/framework/components/particle-system/data.js
+++ b/src/framework/components/particle-system/data.js
@@ -10,113 +10,162 @@ import { BLEND_NORMAL, EMITTERSHAPE_BOX, LAYERID_WORLD, PARTICLEMODE_GPU, PARTIC
  */
 
 class ParticleSystemComponentData {
-    constructor() {
-        this.numParticles = 1;                  // Amount of particles allocated (max particles = max GL texture width at this moment)
-        this.rate = 1;                          // Emission rate
-        /** @type {number} */
-        this.rate2 = null;
-        this.startAngle = 0;
-        /** @type {number} */
-        this.startAngle2 = null;
-        this.lifetime = 50;                     // Particle lifetime
-        this.emitterExtents = new Vec3();       // Spawn point divergence
-        this.emitterExtentsInner = new Vec3();
-        this.emitterRadius = 0;
-        this.emitterRadiusInner = 0;
-        this.emitterShape = EMITTERSHAPE_BOX;
-        this.initialVelocity = 0;
-        this.wrap = false;
-        this.wrapBounds = new Vec3();
-        this.localSpace = false;
-        this.screenSpace = false;
-        /** @type {Texture} */
-        this.colorMap = null;
-        /** @type {Asset} */
-        this.colorMapAsset = null;
-        /** @type {Texture} */
-        this.normalMap = null;
-        /** @type {Asset} */
-        this.normalMapAsset = null;
-        this.loop = true;
-        this.preWarm = false;
-        this.sort = 0;                          // Sorting mode: 0 = none, 1 = by distance, 2 = by life, 3 = by -life;   Forces CPU mode if not 0
-        this.mode = PARTICLEMODE_GPU;
-        this.scene = null;
-        this.lighting = false;
-        this.halfLambert = false;            // Uses half-lambert lighting instead of Lambert
-        this.intensity = 1;
-        this.stretch = 0.0;
-        this.alignToMotion = false;
-        this.depthSoftening = 0;
-        /** @type {Asset} */
-        this.renderAsset = null;
-        /** @type {Asset} */
-        this.meshAsset = null;
-        /** @type {Mesh} */
-        this.mesh = null;                       // Mesh to be used as particle. Vertex buffer is supposed to hold vertex position in first 3 floats of each vertex
-        // Leave undefined to use simple quads
-        this.depthWrite = false;
-        this.noFog = false;
+    numParticles = 1;                  // Amount of particles allocated (max particles = max GL texture width at this moment)
 
-        this.orientation = PARTICLEORIENTATION_SCREEN;
-        this.particleNormal = new Vec3(0, 1, 0);
+    rate = 1;                          // Emission rate
 
-        this.animTilesX = 1;
-        this.animTilesY = 1;
-        this.animStartFrame = 0;
-        this.animNumFrames = 1;
-        this.animNumAnimations = 1;
-        this.animIndex = 0;
-        this.randomizeAnimIndex = false;
-        this.animSpeed = 1;
-        this.animLoop = true;
+    /** @type {number|null} */
+    rate2 = null;
 
-        // Time-dependent parameters
-        /** @type {Curve} */
-        this.scaleGraph = null;
-        /** @type {Curve} */
-        this.scaleGraph2 = null;
+    startAngle = 0;
 
-        /** @type {CurveSet} */
-        this.colorGraph = null;
-        /** @type {CurveSet} */
-        this.colorGraph2 = null;
+    /** @type {number|null} */
+    startAngle2 = null;
 
-        /** @type {Curve} */
-        this.alphaGraph = null;
-        /** @type {Curve} */
-        this.alphaGraph2 = null;
+    lifetime = 50;                     // Particle lifetime
 
-        /** @type {CurveSet} */
-        this.localVelocityGraph = null;
-        /** @type {CurveSet} */
-        this.localVelocityGraph2 = null;
+    emitterExtents = new Vec3();       // Spawn point divergence
 
-        /** @type {CurveSet} */
-        this.velocityGraph = null;
-        /** @type {CurveSet} */
-        this.velocityGraph2 = null;
+    emitterExtentsInner = new Vec3();
 
-        /** @type {Curve} */
-        this.rotationSpeedGraph = null;
-        /** @type {Curve} */
-        this.rotationSpeedGraph2 = null;
+    emitterRadius = 0;
 
-        /** @type {Curve} */
-        this.radialSpeedGraph = null;
-        /** @type {Curve} */
-        this.radialSpeedGraph2 = null;
+    emitterRadiusInner = 0;
 
-        this.blendType = BLEND_NORMAL;
+    emitterShape = EMITTERSHAPE_BOX;
 
-        this.enabled = true;
+    initialVelocity = 0;
 
-        this.paused = false;
+    wrap = false;
 
-        this.autoPlay = true;
+    wrapBounds = new Vec3();
 
-        this.layers = [LAYERID_WORLD]; // assign to the default world layer
-    }
+    localSpace = false;
+
+    screenSpace = false;
+
+    /** @type {Texture|null} */
+    colorMap = null;
+
+    /** @type {Asset|null} */
+    colorMapAsset = null;
+
+    /** @type {Texture|null} */
+    normalMap = null;
+
+    /** @type {Asset|null} */
+    normalMapAsset = null;
+
+    loop = true;
+
+    preWarm = false;
+
+    sort = 0;                          // Sorting mode: 0 = none, 1 = by distance, 2 = by life, 3 = by -life;   Forces CPU mode if not 0
+
+    mode = PARTICLEMODE_GPU;
+
+    scene = null;
+
+    lighting = false;
+
+    halfLambert = false;            // Uses half-lambert lighting instead of Lambert
+
+    intensity = 1;
+
+    stretch = 0.0;
+
+    alignToMotion = false;
+
+    depthSoftening = 0;
+
+    /** @type {Asset|null} */
+    renderAsset = null;
+
+    /** @type {Asset|null} */
+    meshAsset = null;
+
+    /** @type {Mesh|null} */
+    mesh = null;                       // Mesh to be used as particle. Vertex buffer is supposed to hold vertex position in first 3 floats of each vertex
+    // Leave undefined to use simple quads
+
+    depthWrite = false;
+
+    noFog = false;
+
+    orientation = PARTICLEORIENTATION_SCREEN;
+
+    particleNormal = new Vec3(0, 1, 0);
+
+    animTilesX = 1;
+
+    animTilesY = 1;
+
+    animStartFrame = 0;
+
+    animNumFrames = 1;
+
+    animNumAnimations = 1;
+
+    animIndex = 0;
+
+    randomizeAnimIndex = false;
+
+    animSpeed = 1;
+
+    animLoop = true;
+
+    // Time-dependent parameters
+    /** @type {Curve|null} */
+    scaleGraph = null;
+
+    /** @type {Curve|null} */
+    scaleGraph2 = null;
+
+    /** @type {CurveSet|null} */
+    colorGraph = null;
+
+    /** @type {CurveSet|null} */
+    colorGraph2 = null;
+
+    /** @type {Curve|null} */
+    alphaGraph = null;
+
+    /** @type {Curve|null} */
+    alphaGraph2 = null;
+
+    /** @type {CurveSet|null} */
+    localVelocityGraph = null;
+
+    /** @type {CurveSet|null} */
+    localVelocityGraph2 = null;
+
+    /** @type {CurveSet|null} */
+    velocityGraph = null;
+
+    /** @type {CurveSet|null} */
+    velocityGraph2 = null;
+
+    /** @type {Curve|null} */
+    rotationSpeedGraph = null;
+
+    /** @type {Curve|null} */
+    rotationSpeedGraph2 = null;
+
+    /** @type {Curve|null} */
+    radialSpeedGraph = null;
+
+    /** @type {Curve|null} */
+    radialSpeedGraph2 = null;
+
+    blendType = BLEND_NORMAL;
+
+    enabled = true;
+
+    paused = false;
+
+    autoPlay = true;
+
+    layers = [LAYERID_WORLD]; // assign to the default world layer
 }
 
 export { ParticleSystemComponentData };

--- a/src/framework/components/render/data.js
+++ b/src/framework/components/render/data.js
@@ -1,7 +1,5 @@
 class RenderComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { RenderComponentData };

--- a/src/framework/components/rigid-body/data.js
+++ b/src/framework/components/rigid-body/data.js
@@ -1,7 +1,5 @@
 class RigidBodyComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { RigidBodyComponentData };

--- a/src/framework/components/screen/data.js
+++ b/src/framework/components/screen/data.js
@@ -1,7 +1,5 @@
 class ScreenComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { ScreenComponentData };

--- a/src/framework/components/script/data.js
+++ b/src/framework/components/script/data.js
@@ -1,7 +1,5 @@
 class ScriptComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { ScriptComponentData };

--- a/src/framework/components/sound/data.js
+++ b/src/framework/components/sound/data.js
@@ -1,7 +1,5 @@
 class SoundComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { SoundComponentData };

--- a/src/framework/components/sprite/data.js
+++ b/src/framework/components/sprite/data.js
@@ -1,7 +1,5 @@
 class SpriteComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { SpriteComponentData };

--- a/src/framework/components/zone/data.js
+++ b/src/framework/components/zone/data.js
@@ -1,7 +1,5 @@
 class ZoneComponentData {
-    constructor() {
-        this.enabled = true;
-    }
+    enabled = true;
 }
 
 export { ZoneComponentData };


### PR DESCRIPTION
## Summary

Converts all `*ComponentData` classes in `src/framework/components/*/data.js` from constructor-based initialization to ES2022 public class field declarations, matching the style already used by `scroll-view` and `scrollbar`.

- 18 trivial data files (only `enabled = true`) collapsed to a single class field.
- `ButtonComponentData`, `CollisionComponentData` and `ParticleSystemComponentData` converted while preserving inline comments, section comments and JSDoc `@type` annotations.
- Nullable `@type` annotations are updated to include `|null` where the field is initialized to `null`, so TypeScript validation passes with class-field semantics.

This is a pure internal refactor — no behavioral changes, no public API changes, no renames.

## Test plan

- [x] `npm run lint` — passes (0 errors; the single pre-existing warning in `utils/rollup-build-target.mjs` is unrelated).
- [x] `npm test` — 1672 tests passing.
