### PR TITLE
refactor(button): remove redundant constructor assignments in ButtonComponent

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -353,15 +353,6 @@ class ButtonComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
-        this._visualState = VisualState.DEFAULT;
-        this._isHovering = false;
-        this._hoveringCounter = 0;
-        this._isPressed = false;
-
-        this._defaultTint = new Color(1, 1, 1, 1);
-        this._defaultSpriteAsset = null;
-        this._defaultSpriteFrame = 0;
-
         this._toggleLifecycleListeners('on', system);
     }
 


### PR DESCRIPTION
## Summary

Remove dead duplicate field initialisations from the `ButtonComponent` constructor. The same seven fields (`_visualState`, `_isHovering`, `_hoveringCounter`, `_isPressed`, `_defaultTint`, `_defaultSpriteAsset`, `_defaultSpriteFrame`) are already declared as class fields with identical default values, so the constructor was writing them a second time.

The constructor retains its `super()` call and the lifecycle-listener wiring.

Pure internal cleanup — no behavioral change, no public API change.

## Test plan

- [x] `npm run lint` — passes (only the single pre-existing unrelated warning in `utils/rollup-build-target.mjs`).
- [x] `npm test` — 1672 tests passing.
