### PR TITLE
refactor(components): remove redundant get data() overrides

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -356,16 +356,6 @@ class ButtonComponent extends Component {
         this._toggleLifecycleListeners('on', system);
     }
 
-    // TODO: Remove this override in upgrading component
-    /**
-     * @type {ButtonComponentData}
-     * @ignore
-     */
-    get data() {
-        const record = this.system.store[this.entity.getGuid()];
-        return record ? record.data : null;
-    }
-
     /**
      * Sets the enabled state of the component.
      *

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -153,16 +153,6 @@ class CollisionComponent extends Component {
         this.on('set_render', this.onSetRender, this);
     }
 
-    // TODO: Remove this override in upgrading component
-    /**
-     * @type {CollisionComponentData}
-     * @ignore
-     */
-    get data() {
-        const record = this.system.store[this.entity.getGuid()];
-        return record ? record.data : null;
-    }
-
     /**
      * Sets the enabled state of the component.
      *

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -332,16 +332,6 @@ class ElementComponent extends Component {
         this._maskedBy = null; // the entity that is masking this element
     }
 
-    // TODO: Remove this override in upgrading component
-    /**
-     * @type {ElementComponentData}
-     * @ignore
-     */
-    get data() {
-        const record = this.system.store[this.entity.getGuid()];
-        return record ? record.data : null;
-    }
-
     /**
      * Sets the enabled state of the component.
      *

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -201,16 +201,6 @@ class ParticleSystemComponent extends Component {
         });
     }
 
-    // TODO: Remove this override in upgrading component
-    /**
-     * @type {ParticleSystemComponentData}
-     * @ignore
-     */
-    get data() {
-        const record = this.system.store[this.entity.getGuid()];
-        return record ? record.data : null;
-    }
-
     /**
      * Sets the enabled state of the component.
      *

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -195,16 +195,6 @@ class ScrollViewComponent extends Component {
         this._toggleElementListeners('on');
     }
 
-    // TODO: Remove this override in upgrading component
-    /**
-     * @type {ScrollViewComponentData}
-     * @ignore
-     */
-    get data() {
-        const record = this.system.store[this.entity.getGuid()];
-        return record ? record.data : null;
-    }
-
     /**
      * Sets the enabled state of the component.
      *

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -99,16 +99,6 @@ class ScrollbarComponent extends Component {
         this._toggleLifecycleListeners('on');
     }
 
-    // TODO: Remove this override in upgrading component
-    /**
-     * @type {ScrollbarComponentData}
-     * @ignore
-     */
-    get data() {
-        const record = this.system.store[this.entity.getGuid()];
-        return record ? record.data : null;
-    }
-
     /**
      * Sets the enabled state of the component.
      *


### PR DESCRIPTION
## Summary

Removes six byte-identical `get data()` overrides in component subclasses. The base `Component` class in [src/framework/components/component.js](src/framework/components/component.js) already defines this getter, and every override was flagged with a `// TODO: Remove this override in upgrading component` comment — they existed purely to narrow the JSDoc return type (`@type {XxxComponentData}` vs base `@type {*}`).

Since the getter is `@ignore` / internal, the narrower type had no public API benefit. All subclasses now transparently inherit the base getter.

Affected files:

- `src/framework/components/button/component.js`
- `src/framework/components/collision/component.js`
- `src/framework/components/element/component.js`
- `src/framework/components/particle-system/component.js`
- `src/framework/components/scroll-view/component.js`
- `src/framework/components/scrollbar/component.js`

No behavioral change, no public API change. 60 lines of dead code removed.

## Test plan

- [x] `npm run lint` — passes (only pre-existing unrelated warning in `utils/rollup-build-target.mjs`).
- [x] `npm test` — 1672 tests passing.
