### PR TITLE
refactor(components): migrate ZoneComponent and ScreenComponent to class fields

### DIFF
--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -77,7 +77,7 @@ class ScreenComponent extends Component {
 
     /**
      * If true, then elements inside this screen will not be rendered when outside of the screen
-     * (only valid when screenSpace is true).
+     * (only valid when {@link screenSpace} is true).
      *
      * @type {boolean}
      */

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -54,6 +54,40 @@ const _transform = new Mat4();
  * @category User Interface
  */
 class ScreenComponent extends Component {
+    /** @private */
+    _resolution = new Vec2(640, 320);
+
+    /** @private */
+    _referenceResolution = new Vec2(640, 320);
+
+    /** @private */
+    _scaleMode = SCALEMODE_NONE;
+
+    scale = 1;
+
+    /** @private */
+    _scaleBlend = 0.5;
+
+    /** @private */
+    _priority = 0;
+
+    /** @private */
+    _screenSpace = false;
+
+    /**
+     * If true, then elements inside this screen will be not be rendered when outside of the
+     * screen (only valid when screenSpace is true).
+     *
+     * @type {boolean}
+     */
+    cull = false;
+
+    /** @private */
+    _screenMatrix = new Mat4();
+
+    /** @private */
+    _elements = new Set();
+
     /**
      * Create a new ScreenComponent.
      *
@@ -62,27 +96,6 @@ class ScreenComponent extends Component {
      */
     constructor(system, entity) {
         super(system, entity);
-
-        this._resolution = new Vec2(640, 320);
-        this._referenceResolution = new Vec2(640, 320);
-        this._scaleMode = SCALEMODE_NONE;
-        this.scale = 1;
-        this._scaleBlend = 0.5;
-
-        this._priority = 0;
-
-        this._screenSpace = false;
-
-        /**
-         * If true, then elements inside this screen will be not be rendered when outside of the
-         * screen (only valid when screenSpace is true).
-         *
-         * @type {boolean}
-         */
-        this.cull = this._screenSpace;
-        this._screenMatrix = new Mat4();
-
-        this._elements = new Set();
 
         system.app.graphicsDevice.on('resizecanvas', this._onResize, this);
     }

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -76,7 +76,7 @@ class ScreenComponent extends Component {
     _screenSpace = false;
 
     /**
-     * If true, then elements inside this screen will be not be rendered when outside of the
+     * If true, then elements inside this screen will not be rendered when outside of the
      * screen (only valid when screenSpace is true).
      *
      * @type {boolean}

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -76,8 +76,8 @@ class ScreenComponent extends Component {
     _screenSpace = false;
 
     /**
-     * If true, then elements inside this screen will not be rendered when outside of the
-     * screen (only valid when screenSpace is true).
+     * If true, then elements inside this screen will not be rendered when outside of the screen
+     * (only valid when screenSpace is true).
      *
      * @type {boolean}
      */

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -63,6 +63,7 @@ class ScreenComponent extends Component {
     /** @private */
     _scaleMode = SCALEMODE_NONE;
 
+    /** @ignore */
     scale = 1;
 
     /** @private */

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -62,6 +62,12 @@ class ZoneComponent extends Component {
      */
     static EVENT_REMOVE = 'remove';
 
+    /** @private */
+    _oldState = true;
+
+    /** @private */
+    _size = new Vec3();
+
     /**
      * Create a new ZoneComponent instance.
      *
@@ -71,8 +77,6 @@ class ZoneComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
-        this._oldState = true;
-        this._size = new Vec3();
         this.on('set_enabled', this._onSetEnabled, this);
     }
 


### PR DESCRIPTION
## Summary

Migrates the constructor-initialised instance state of `ZoneComponent` and `ScreenComponent` to ES2022 public class field declarations, continuing the modernisation pass applied earlier to component data and several other components.

- `ZoneComponent`: moves `_oldState` and `_size` out of the constructor; the `set_enabled` listener wiring stays in the constructor.
- `ScreenComponent`: moves 10 instance fields out of the constructor. The `graphicsDevice.on('resizecanvas', ...)` wiring stays in the constructor. One minor simplification: `this.cull = this._screenSpace;` becomes `cull = false;` — the original value was always `false` at that point (`_screenSpace` had just been assigned `false` on the line above), so the default is unchanged.
- `/** @private */` tags added to the newly-declared underscore-prefixed fields to match the convention already used elsewhere in the codebase (e.g. `button/component.js`, `layout-child/component.js`).

Pure internal refactor. No behavioral change, no public API change.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm test` — 1672 tests passing.
