### PR TITLE
refactor: Remove unused _batchGroup field from batched components

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -322,10 +322,6 @@ class ElementComponent extends Component {
         this._addedModels = []; // store models that have been added to layer so we can re-add when layer is changed
 
         this._batchGroupId = -1;
-        // #if _DEBUG
-        this._batchGroup = null;
-        // #endif
-        //
 
         this._offsetReadAt = 0;
         this._maskOffset = 0.5;

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -130,10 +130,6 @@ class ModelComponent extends Component {
     /** @private */
     _clonedModel = false;
 
-    // #if _DEBUG
-    _batchGroup = null;
-    // #endif
-
     /**
      * @type {EventHandle|null}
      * @private

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -208,9 +208,6 @@ class SpriteComponent extends Component {
     /** @private */
     _batchGroupId = -1;
 
-    /** @private */
-    _batchGroup = null;
-
     // node / mesh instance
 
     /** @private */

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -315,10 +315,6 @@ class BatchManager {
             if (valid) {
                 arr = groupMeshInstances[node.model.batchGroupId] = arr.concat(valid);
                 node.model.removeModelFromLayers();
-
-                // #if _DEBUG
-                node.model._batchGroup = group;
-                // #endif
             }
         }
 
@@ -351,9 +347,6 @@ class BatchManager {
 
         if (valid) {
             group._ui = true;
-            // #if _DEBUG
-            node.element._batchGroup = group;
-            // #endif
         }
     }
 
@@ -388,7 +381,6 @@ class BatchManager {
                     arr.push(node.sprite._meshInstance);
                     node.sprite.removeModelFromLayers();
                     group._sprite = true;
-                    node.sprite._batchGroup = group;
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Removes the unused private `_batchGroup` field from `ModelComponent`, `ElementComponent`, and `SpriteComponent`.
- Removes the three corresponding write sites in `BatchManager` (`_extractModel`, `_extractElement`, `_collectAndRemoveMeshInstances`).

## Details

The `_batchGroup` field was declared on three components and assigned from three places in `BatchManager`, but never read anywhere in the engine, tests, examples, or any consuming repo (editor, supersplat, web-components, etc.). Most writes were `// #if _DEBUG`-gated, signalling they were once intended for inspection tooling that no longer exists. The sprite write was not gated — an additional inconsistency in otherwise dead code.

Note: `BatchManager._batchGroups` (plural, on the manager itself) is the actual source-of-truth lookup and is unrelated to this change. The public `_batchGroupId` field on components is also retained.

No public API is affected; the field was never documented.

## Test plan

- `npm run lint` — clean.
- `npm test` — 1672 passing, 0 failing.
