### PR TITLE
refactor: Clean up vestigial Model plumbing on SpriteComponent

### DIFF
--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -10,7 +10,6 @@ import {
 import { BatchGroup } from '../../../scene/batching/batch-group.js';
 import { GraphNode } from '../../../scene/graph-node.js';
 import { MeshInstance } from '../../../scene/mesh-instance.js';
-import { Model } from '../../../scene/model.js';
 import { Component } from '../component.js';
 import { SPRITETYPE_SIMPLE, SPRITETYPE_ANIMATED } from './constants.js';
 import { SpriteAnimationClip } from './sprite-animation-clip.js';
@@ -214,9 +213,6 @@ class SpriteComponent extends Component {
     _node = new GraphNode();
 
     /** @private */
-    _model = new Model();
-
-    /** @private */
     _meshInstance = null;
 
     /** @private */
@@ -265,9 +261,7 @@ class SpriteComponent extends Component {
 
         this._material = system.defaultMaterial;
 
-        this._model.graph = this._node;
-        entity.addChild(this._model.graph);
-        this._model._entity = entity;
+        entity.addChild(this._node);
 
         this._updateAabbFunc = this._updateAabb.bind(this);
 
@@ -815,7 +809,6 @@ class SpriteComponent extends Component {
         this._clips = null;
 
         this._hideModel();
-        this._model = null;
 
         this._node?.remove();
         this._node = null;
@@ -889,7 +882,6 @@ class SpriteComponent extends Component {
             this._meshInstance.castShadow = false;
             this._meshInstance.receiveShadow = false;
             this._meshInstance.drawOrder = this._drawOrder;
-            this._model.meshInstances.push(this._meshInstance);
 
             // set overrides on mesh instance
             this._colorUniform[0] = this._color.r;

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -226,7 +226,10 @@ class SpriteComponent extends Component {
 
     // animated sprites
 
-    /** @private */
+    /**
+     * @type {string|null}
+     * @private
+     */
     _autoPlayClip = null;
 
     /**
@@ -857,6 +860,15 @@ class SpriteComponent extends Component {
         this._inLayers = false;
     }
 
+    /**
+     * @deprecated Use {@link SpriteComponent#removeFromLayers} instead.
+     * @ignore
+     */
+    removeModelFromLayers() {
+        Debug.deprecated('SpriteComponent#removeModelFromLayers is deprecated. Use SpriteComponent#removeFromLayers instead.');
+        this.removeFromLayers();
+    }
+
     // Set the desired mesh on the mesh instance
     _showFrame(frame) {
         if (!this.sprite) return;
@@ -1054,10 +1066,10 @@ class SpriteComponent extends Component {
     }
 
     _onLayersChanged(oldComp, newComp) {
-        oldComp.off('add', this.onLayerAdded, this);
-        oldComp.off('remove', this.onLayerRemoved, this);
-        newComp.on('add', this.onLayerAdded, this);
-        newComp.on('remove', this.onLayerRemoved, this);
+        oldComp.off('add', this._onLayerAdded, this);
+        oldComp.off('remove', this._onLayerRemoved, this);
+        newComp.on('add', this._onLayerAdded, this);
+        newComp.on('remove', this._onLayerRemoved, this);
 
         if (this.enabled && this.entity.enabled) {
             this.addToLayers();

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -890,7 +890,7 @@ class SpriteComponent extends Component {
             this._meshInstance.setParameter(PARAM_EMISSIVE, this._colorUniform);
             this._meshInstance.setParameter(PARAM_OPACITY, this._color.a);
 
-            // now that we created the mesh instance, add the model to the scene
+            // now that we created the mesh instance, add it to the layers
             if (this.enabled && this.entity.enabled) {
                 this._addToLayers();
             }

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -300,9 +300,9 @@ class SpriteComponent extends Component {
                 this._currentClip.frame = this.frame;
 
                 if (this._currentClip.sprite) {
-                    this._addToLayers();
+                    this.addToLayers();
                 } else {
-                    this._removeFromLayers();
+                    this.removeFromLayers();
                 }
             }
 
@@ -314,9 +314,9 @@ class SpriteComponent extends Component {
             }
 
             if (this._currentClip && this._currentClip.isPlaying && this.enabled && this.entity.enabled) {
-                this._addToLayers();
+                this.addToLayers();
             } else {
-                this._removeFromLayers();
+                this.removeFromLayers();
             }
         }
     }
@@ -498,7 +498,7 @@ class SpriteComponent extends Component {
 
         // if the current clip doesn't have a sprite then remove the mesh instance from layers
         if (!this._currentClip || !this._currentClip.sprite) {
-            this._removeFromLayers();
+            this.removeFromLayers();
         }
     }
 
@@ -654,7 +654,7 @@ class SpriteComponent extends Component {
             // re-add the sprite mesh instance to layers in case it was removed by batching
             if (prev >= 0) {
                 if (this._currentClip && this._currentClip.sprite && this.enabled && this.entity.enabled) {
-                    this._addToLayers();
+                    this.addToLayers();
                 }
             }
         }
@@ -718,7 +718,7 @@ class SpriteComponent extends Component {
      */
     set layers(value) {
         if (this._inLayers) {
-            this._removeFromLayers();
+            this.removeFromLayers();
         }
 
         this._layers = value;
@@ -729,7 +729,7 @@ class SpriteComponent extends Component {
         }
 
         if (this.enabled && this.entity.enabled) {
-            this._addToLayers();
+            this.addToLayers();
         }
     }
 
@@ -762,7 +762,7 @@ class SpriteComponent extends Component {
             this._evtLayerRemoved = layers.on('remove', this._onLayerRemoved, this);
         }
 
-        this._addToLayers();
+        this.addToLayers();
         if (this._autoPlayClip) {
             this._tryAutoPlay();
         }
@@ -788,7 +788,7 @@ class SpriteComponent extends Component {
         }
 
         this.stop();
-        this._removeFromLayers();
+        this.removeFromLayers();
 
 
         if (this._batchGroupId >= 0) {
@@ -808,7 +808,7 @@ class SpriteComponent extends Component {
         }
         this._clips = null;
 
-        this._removeFromLayers();
+        this.removeFromLayers();
 
         this._node?.remove();
         this._node = null;
@@ -821,7 +821,8 @@ class SpriteComponent extends Component {
         }
     }
 
-    _addToLayers() {
+    /** @private */
+    addToLayers() {
         if (this._inLayers) return;
         if (!this._meshInstance) return;
 
@@ -837,7 +838,8 @@ class SpriteComponent extends Component {
         this._inLayers = true;
     }
 
-    _removeFromLayers() {
+    /** @private */
+    removeFromLayers() {
         if (!this._inLayers || !this._meshInstance) return;
 
         const meshInstances = [this._meshInstance];
@@ -892,7 +894,7 @@ class SpriteComponent extends Component {
 
             // now that we created the mesh instance, add it to the layers
             if (this.enabled && this.entity.enabled) {
-                this._addToLayers();
+                this.addToLayers();
             }
         }
 
@@ -1055,7 +1057,7 @@ class SpriteComponent extends Component {
         newComp.on('remove', this.onLayerRemoved, this);
 
         if (this.enabled && this.entity.enabled) {
-            this._addToLayers();
+            this.addToLayers();
         }
     }
 
@@ -1074,14 +1076,6 @@ class SpriteComponent extends Component {
         const index = this.layers.indexOf(layer.id);
         if (index < 0) return;
         layer.removeMeshInstances([this._meshInstance]);
-    }
-
-    // Called by BatchManager when this sprite is absorbed into a batch. Delegates to
-    // _removeFromLayers so that `_inLayers` is kept in sync - otherwise _addToLayers
-    // would early-out when batching is undone and _onLayerAdded would re-add the
-    // mesh instance behind the batch's back.
-    removeModelFromLayers() {
-        this._removeFromLayers();
     }
 
     /**

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -496,7 +496,7 @@ class SpriteComponent extends Component {
             this._tryAutoPlay();
         }
 
-        // if the current clip doesn't have a sprite then hide the model
+        // if the current clip doesn't have a sprite then remove the mesh instance from layers
         if (!this._currentClip || !this._currentClip.sprite) {
             this._removeFromLayers();
         }
@@ -1076,12 +1076,12 @@ class SpriteComponent extends Component {
         layer.removeMeshInstances([this._meshInstance]);
     }
 
+    // Called by BatchManager when this sprite is absorbed into a batch. Delegates to
+    // _removeFromLayers so that `_inLayers` is kept in sync - otherwise _addToLayers
+    // would early-out when batching is undone and _onLayerAdded would re-add the
+    // mesh instance behind the batch's back.
     removeModelFromLayers() {
-        for (let i = 0; i < this.layers.length; i++) {
-            const layer = this.system.app.scene.layers.getLayerById(this.layers[i]);
-            if (!layer) continue;
-            layer.removeMeshInstances([this._meshInstance]);
-        }
+        this._removeFromLayers();
     }
 
     /**

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -860,15 +860,6 @@ class SpriteComponent extends Component {
         this._inLayers = false;
     }
 
-    /**
-     * @deprecated Use {@link SpriteComponent#removeFromLayers} instead.
-     * @ignore
-     */
-    removeModelFromLayers() {
-        Debug.deprecated('SpriteComponent#removeModelFromLayers is deprecated. Use SpriteComponent#removeFromLayers instead.');
-        this.removeFromLayers();
-    }
-
     // Set the desired mesh on the mesh instance
     _showFrame(frame) {
         if (!this.sprite) return;

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -219,7 +219,7 @@ class SpriteComponent extends Component {
     _updateAabbFunc = null;
 
     /** @private */
-    _addedModel = false;
+    _inLayers = false;
 
     // animated sprites
 
@@ -300,9 +300,9 @@ class SpriteComponent extends Component {
                 this._currentClip.frame = this.frame;
 
                 if (this._currentClip.sprite) {
-                    this._showModel();
+                    this._addToLayers();
                 } else {
-                    this._hideModel();
+                    this._removeFromLayers();
                 }
             }
 
@@ -314,9 +314,9 @@ class SpriteComponent extends Component {
             }
 
             if (this._currentClip && this._currentClip.isPlaying && this.enabled && this.entity.enabled) {
-                this._showModel();
+                this._addToLayers();
             } else {
-                this._hideModel();
+                this._removeFromLayers();
             }
         }
     }
@@ -498,7 +498,7 @@ class SpriteComponent extends Component {
 
         // if the current clip doesn't have a sprite then hide the model
         if (!this._currentClip || !this._currentClip.sprite) {
-            this._hideModel();
+            this._removeFromLayers();
         }
     }
 
@@ -654,7 +654,7 @@ class SpriteComponent extends Component {
             // re-add model to scene in case it was removed by batching
             if (prev >= 0) {
                 if (this._currentClip && this._currentClip.sprite && this.enabled && this.entity.enabled) {
-                    this._showModel();
+                    this._addToLayers();
                 }
             }
         }
@@ -717,8 +717,8 @@ class SpriteComponent extends Component {
      * @type {number[]}
      */
     set layers(value) {
-        if (this._addedModel) {
-            this._hideModel();
+        if (this._inLayers) {
+            this._removeFromLayers();
         }
 
         this._layers = value;
@@ -729,7 +729,7 @@ class SpriteComponent extends Component {
         }
 
         if (this.enabled && this.entity.enabled) {
-            this._showModel();
+            this._addToLayers();
         }
     }
 
@@ -762,7 +762,7 @@ class SpriteComponent extends Component {
             this._evtLayerRemoved = layers.on('remove', this._onLayerRemoved, this);
         }
 
-        this._showModel();
+        this._addToLayers();
         if (this._autoPlayClip) {
             this._tryAutoPlay();
         }
@@ -788,7 +788,7 @@ class SpriteComponent extends Component {
         }
 
         this.stop();
-        this._hideModel();
+        this._removeFromLayers();
 
 
         if (this._batchGroupId >= 0) {
@@ -808,7 +808,7 @@ class SpriteComponent extends Component {
         }
         this._clips = null;
 
-        this._hideModel();
+        this._removeFromLayers();
 
         this._node?.remove();
         this._node = null;
@@ -821,8 +821,8 @@ class SpriteComponent extends Component {
         }
     }
 
-    _showModel() {
-        if (this._addedModel) return;
+    _addToLayers() {
+        if (this._inLayers) return;
         if (!this._meshInstance) return;
 
         const meshInstances = [this._meshInstance];
@@ -834,11 +834,11 @@ class SpriteComponent extends Component {
             }
         }
 
-        this._addedModel = true;
+        this._inLayers = true;
     }
 
-    _hideModel() {
-        if (!this._addedModel || !this._meshInstance) return;
+    _removeFromLayers() {
+        if (!this._inLayers || !this._meshInstance) return;
 
         const meshInstances = [this._meshInstance];
 
@@ -849,7 +849,7 @@ class SpriteComponent extends Component {
             }
         }
 
-        this._addedModel = false;
+        this._inLayers = false;
     }
 
     // Set the desired mesh on the mesh instance
@@ -892,7 +892,7 @@ class SpriteComponent extends Component {
 
             // now that we created the mesh instance, add the model to the scene
             if (this.enabled && this.entity.enabled) {
-                this._showModel();
+                this._addToLayers();
             }
         }
 
@@ -1055,7 +1055,7 @@ class SpriteComponent extends Component {
         newComp.on('remove', this.onLayerRemoved, this);
 
         if (this.enabled && this.entity.enabled) {
-            this._showModel();
+            this._addToLayers();
         }
     }
 
@@ -1063,7 +1063,7 @@ class SpriteComponent extends Component {
         const index = this.layers.indexOf(layer.id);
         if (index < 0) return;
 
-        if (this._addedModel && this.enabled && this.entity.enabled && this._meshInstance) {
+        if (this._inLayers && this.enabled && this.entity.enabled && this._meshInstance) {
             layer.addMeshInstances([this._meshInstance]);
         }
     }

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -212,7 +212,10 @@ class SpriteComponent extends Component {
     /** @private */
     _node = new GraphNode();
 
-    /** @private */
+    /**
+     * @type {MeshInstance|null}
+     * @private
+     */
     _meshInstance = null;
 
     /** @private */

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -651,7 +651,7 @@ class SpriteComponent extends Component {
         if (this.entity.enabled && value >= 0) {
             this.system.app.batcher?.insert(BatchGroup.SPRITE, value, this.entity);
         } else {
-            // re-add model to scene in case it was removed by batching
+            // re-add the sprite mesh instance to layers in case it was removed by batching
             if (prev >= 0) {
                 if (this._currentClip && this._currentClip.sprite && this.enabled && this.entity.enabled) {
                     this._addToLayers();

--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -209,7 +209,7 @@ class SpriteAnimationClip extends EventHandler {
                     mi.deleteParameter('texture_opacityMap');
                 }
 
-                this._component._removeFromLayers();
+                this._component.removeFromLayers();
             } else {
                 // otherwise show sprite
 
@@ -222,7 +222,7 @@ class SpriteAnimationClip extends EventHandler {
                     }
 
                     if (this._component.enabled && this._component.entity.enabled) {
-                        this._component._addToLayers();
+                        this._component.addToLayers();
                     }
                 }
 

--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -209,7 +209,7 @@ class SpriteAnimationClip extends EventHandler {
                     mi.deleteParameter('texture_opacityMap');
                 }
 
-                this._component._hideModel();
+                this._component._removeFromLayers();
             } else {
                 // otherwise show sprite
 
@@ -222,7 +222,7 @@ class SpriteAnimationClip extends EventHandler {
                     }
 
                     if (this._component.enabled && this._component.entity.enabled) {
-                        this._component._showModel();
+                        this._component._addToLayers();
                     }
                 }
 

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -379,7 +379,7 @@ class BatchManager {
                 if (node.sprite && node.sprite._meshInstance &&
                     (group.dynamic || node.sprite.sprite._renderMode === SPRITE_RENDERMODE_SIMPLE)) {
                     arr.push(node.sprite._meshInstance);
-                    node.sprite.removeModelFromLayers();
+                    node.sprite.removeFromLayers();
                     group._sprite = true;
                 }
             }


### PR DESCRIPTION
## Summary

Cleans up `SpriteComponent`'s vestigial `Model` plumbing, fixes a layer-membership desync against `BatchManager`, fixes a pre-existing handler-name typo, and aligns the layer-membership API with `RenderComponent`.

## Details

### 1. Remove unused `_model` field

`SpriteComponent` declared a `_model = new Model()` field and performed bookkeeping on it (setting `graph`, pushing the mesh instance, nulling it out on destroy), but nothing ever consumed it:

- The sprite's single mesh instance is created against `this._node` directly, not `_model.graph`.
- The legacy `_showModel`/`_hideModel` helpers add/remove `[this._meshInstance]` to/from layers directly, bypassing `_model.meshInstances`.
- `BatchManager`'s sprite path reads `node.sprite._meshInstance`, not `_model`.
- No references to `sprite._model` or `sprite.model` exist anywhere (engine, tests, examples, editor, or any downstream repo).

The `Model` class is legacy; sprite was the one remaining component using it for no functional purpose.

### 2. Fix `_inLayers` desync against `BatchManager`

The legacy `removeModelFromLayers()` (called by `BatchManager` when a sprite is absorbed into a batch) removed the mesh instance from layers without clearing the membership flag. This caused two stale-state hazards:

- When `batchGroupId` returned to `-1`, `_addToLayers()` early-outed because the flag was still `true`, leaving the sprite invisible.
- `_onLayerAdded` would re-add the unbatched mesh to any newly added matching layer, racing the batch.

### 3. Fix `_onLayersChanged` handler-name typo

Pre-existing bug: `_onLayersChanged` was rebinding `this.onLayerAdded` / `this.onLayerRemoved` (no underscore) but the actual methods are `_onLayerAdded` / `_onLayerRemoved`. Replacing the scene's layers component silently failed to rebind the listeners (and would assert in debug builds).

### 4. Align layer-membership API with `RenderComponent`

With the `Model` plumbing gone, the symbols are renamed and the BatchManager hook is unified with the existing `RenderComponent` pattern:

| Before | After |
| --- | --- |
| `_addedModel` (private field) | `_inLayers` (private field) |
| `_showModel()` (private method) | `addToLayers()` (`@private` JSDoc) |
| `_hideModel()` (private method) | `removeFromLayers()` (`@private` JSDoc) |
| `removeModelFromLayers()` (undocumented, BatchManager-only) | removed |

`BatchManager._extractSprites` now calls `node.sprite.removeFromLayers()` directly &mdash; the same shape it already uses for `node.render.removeFromLayers()`. Because that path goes through `removeFromLayers()`, `_inLayers` stays in sync, the `_meshInstance` null guard is inherited, and the desync described in (2) is eliminated.

`removeModelFromLayers()` was undocumented and only ever called by `BatchManager` (the engine's own internal infrastructure), so it's removed outright rather than carried as a deprecated alias.

`ModelComponent` and `ElementComponent` still expose the legacy `addModelToLayers` / `removeModelFromLayers` pair; aligning those is left for a follow-up.

### 5. Minor type annotations

`_meshInstance` and `_autoPlayClip` got proper `@type` annotations (`MeshInstance|null` and `string|null`).

## Test plan

- `npm run lint` &mdash; clean.
- BatchManager + sprite-related tests pass locally.
