### PR TITLE
refactor: Remove unused JSDoc @import lines

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -10,7 +10,6 @@ import { ELEMENTTYPE_GROUP } from '../element/constants.js';
 
 /**
  * @import { Asset } from '../../../framework/asset/asset.js'
- * @import { ButtonComponentData } from './data.js'
  * @import { ButtonComponentSystem } from './system.js'
  * @import { Entity } from '../../entity.js'
  * @import { EventHandle } from '../../../core/event-handle.js'

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -4,7 +4,6 @@ import { Asset } from '../../asset/asset.js';
 import { Component } from '../component.js';
 
 /**
- * @import { CollisionComponentData } from './data.js'
  * @import { CollisionComponentSystem } from './system.js'
  * @import { Entity } from '../../entity.js'
  * @import { GraphNode } from '../../../scene/graph-node.js'

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -18,7 +18,6 @@ import { TextElement } from './text-element.js';
  * @import { BoundingBox } from '../../../core/shape/bounding-box.js'
  * @import { CanvasFont } from '../../../framework/font/canvas-font.js'
  * @import { Color } from '../../../core/math/color.js'
- * @import { ElementComponentData } from './data.js'
  * @import { ElementComponentSystem } from './system.js'
  * @import { EventHandle } from '../../../core/event-handle.js'
  * @import { Font } from '../../../framework/font/font.js'

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -9,7 +9,6 @@ import { Component } from '../component.js';
  * @import { Curve } from '../../../core/math/curve.js'
  * @import { Entity } from '../../entity.js'
  * @import { EventHandle } from '../../../core/event-handle.js'
- * @import { ParticleSystemComponentData } from './data.js'
  * @import { ParticleSystemComponentSystem } from './system.js'
  * @import { Texture } from '../../../platform/graphics/texture.js'
  * @import { Vec3 } from '../../../core/math/vec3.js'

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -12,7 +12,6 @@ import { Component } from '../component.js';
 
 /**
  * @import { Entity } from '../../entity.js'
- * @import { ScrollViewComponentData } from './data.js'
  * @import { ScrollViewComponentSystem } from './system.js'
  * @import { EventHandle } from '../../../core/event-handle.js'
  */

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -9,7 +9,6 @@ import { ElementDragHelper } from '../element/element-drag-helper.js';
 /**
  * @import { EventHandle } from '../../../core/event-handle.js'
  * @import { Entity } from '../../entity.js'
- * @import { ScrollbarComponentData } from './data.js'
  * @import { ScrollbarComponentSystem } from './system.js'
  */
 

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -7,7 +7,6 @@ import { RenderPassQuad } from './render-pass-quad.js';
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { RenderTarget } from '../../platform/graphics/render-target.js'
  * @import { Shader } from '../../platform/graphics/shader.js'
- * @import { Texture } from '../../platform/graphics/texture.js'
  */
 
 const _tempRect = new Vec4();

--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -15,7 +15,6 @@ import { RenderPassShadowDirectional } from './render-pass-shadow-directional.js
  * @import { Light } from '../light.js'
  * @import { Renderer } from './renderer.js'
  * @import { ShadowRenderer } from './shadow-renderer.js'
- * @import { MeshInstance } from '../mesh-instance.js';
  */
 
 const visibleSceneAabb = new BoundingBox();


### PR DESCRIPTION
Removes unused JSDoc `@import` type-only lines that are not referenced in the file:

- `ButtonComponent` — `ButtonComponentData`
- `CollisionComponent` — `CollisionComponentData`
- `ElementComponent` — `ElementComponentData`
- `ParticleSystemComponent` — `ParticleSystemComponentData`
- `ScrollViewComponent` — `ScrollViewComponentData`
- `ScrollbarComponent` — `ScrollbarComponentData`
- `quad-render-utils.js` — `Texture`
- `shadow-renderer-directional.js` — `MeshInstance`
