### PR TITLE
refactor: Remove unused CollisionComponentData JSDoc import

### DIFF
--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -4,7 +4,6 @@ import { Asset } from '../../asset/asset.js';
 import { Component } from '../component.js';
 
 /**
- * @import { CollisionComponentData } from './data.js'
  * @import { CollisionComponentSystem } from './system.js'
  * @import { Entity } from '../../entity.js'
  * @import { GraphNode } from '../../../scene/graph-node.js'


### PR DESCRIPTION
Removes the unused \@import { CollisionComponentData }\ JSDoc type-only import from \CollisionComponent\; the type is not referenced in the file.

Made with [Cursor](https://cursor.com)