### PR TITLE
refactor(sprite): SpriteAnimationClip class fields, layer typings, and docs

### DIFF
--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -827,7 +827,7 @@ class SpriteComponent extends Component {
         }
     }
 
-    /** @private */
+    /** @ignore */
     addToLayers() {
         if (this._inLayers) return;
         if (!this._meshInstance) return;
@@ -844,7 +844,7 @@ class SpriteComponent extends Component {
         this._inLayers = true;
     }
 
-    /** @private */
+    /** @ignore */
     removeFromLayers() {
         if (!this._inLayers || !this._meshInstance) return;
 

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -261,10 +261,8 @@ class SpriteComponent extends Component {
     /**
      * Create a new SpriteComponent instance.
      *
-     * @param {SpriteComponentSystem} system - The ComponentSystem that
-     * created this Component.
-     * @param {Entity} entity - The Entity that this Component is
-     * attached to.
+     * @param {SpriteComponentSystem} system - The ComponentSystem that created this Component.
+     * @param {Entity} entity - The Entity that this Component is attached to.
      */
     constructor(system, entity) {
         super(system, entity);

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -55,6 +55,10 @@ const PARAM_ATLAS_RECT = 'atlasRect';
  * console.log(entity.sprite.color);   // Get the sprite tint and print it
  * ```
  *
+ * Relevant Engine API examples:
+ *
+ * - [Animated sprite](https://playcanvas.github.io/#/misc/animated-sprite)
+ *
  * @hideconstructor
  * @category Graphics
  */

--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -88,6 +88,51 @@ class SpriteAnimationClip extends EventHandler {
     _evtSetMeshes = null;
 
     /**
+     * @type {SpriteComponent}
+     * @private
+     */
+    _component;
+
+    /** @private */
+    _frame = 0;
+
+    /**
+     * @type {Sprite|null}
+     * @private
+     */
+    _sprite = null;
+
+    /**
+     * @type {number|null}
+     * @private
+     */
+    _spriteAsset = null;
+
+    /** @private */
+    _playing = false;
+
+    /** @private */
+    _paused = false;
+
+    /** @private */
+    _time = 0;
+
+    /**
+     * @type {string|undefined}
+     */
+    name;
+
+    /**
+     * @type {number}
+     */
+    fps = 0;
+
+    /**
+     * @type {boolean}
+     */
+    loop = false;
+
+    /**
      * Create a new SpriteAnimationClip instance.
      *
      * @param {SpriteComponent} component - The sprite component managing this clip.
@@ -102,19 +147,10 @@ class SpriteAnimationClip extends EventHandler {
 
         this._component = component;
 
-        this._frame = 0;
-        this._sprite = null;
-        this._spriteAsset = null;
-        this.spriteAsset = data.spriteAsset;
-
-        this.name = data.name;
         this.fps = data.fps || 0;
         this.loop = data.loop || false;
-
-        this._playing = false;
-        this._paused = false;
-
-        this._time = 0;
+        this.name = data.name;
+        this.spriteAsset = data.spriteAsset;
     }
 
     /**


### PR DESCRIPTION
## Summary

Migrates `SpriteAnimationClip` instance state to class fields (aligned with `SpriteComponent`), orders constructor data assignments to match JSDoc, and replaces `@private` with `@ignore` on `addToLayers` / `removeFromLayers` so internal callers type-check while API docs stay unchanged. Adds sprite **Relevant Engine API examples** on `SpriteComponent` and aligns constructor `@param` JSDoc line wrapping with other components.

## Changes

- **SpriteAnimationClip**: declare `_component`, `_frame`, `_sprite`, `_spriteAsset`, `_playing`, `_paused`, `_time`, `name`, `fps`, and `loop` as class fields with JSDoc; constructor only assigns `component`, then `fps`, `loop`, `name`, and `spriteAsset` from `data`.
- **SpriteComponent**: `addToLayers` and `removeFromLayers` use `/** @ignore */` instead of `/** @private */` so they emit as public in `playcanvas.d.ts` (same pattern as other `@ignore` helpers).
- **SpriteComponent** class JSDoc: link to the [Animated sprite](https://playcanvas.github.io/#/misc/animated-sprite) engine example (same style as `ParticleSystemComponent` and others).
- **SpriteComponent** constructor JSDoc: single-line `@param` descriptions (match `ModelComponent` / `CameraComponent` convention).

## Public API

No intentional changes. `addToLayers` and `removeFromLayers` were already callable at runtime; typings now match.
