### PR TITLE
docs(sprite): SpriteAnimationClip name, fps, loop property JSDoc

### DIFF
--- a/src/framework/components/sprite/sprite-animation-clip.js
+++ b/src/framework/components/sprite/sprite-animation-clip.js
@@ -118,16 +118,22 @@ class SpriteAnimationClip extends EventHandler {
     _time = 0;
 
     /**
+     * The name of this animation clip.
+     *
      * @type {string|undefined}
      */
     name;
 
     /**
+     * Frames per second for this animation clip. A negative value plays the animation backwards.
+     *
      * @type {number}
      */
     fps = 0;
 
     /**
+     * Whether to loop the animation clip when it reaches the end.
+     *
      * @type {boolean}
      */
     loop = false;


### PR DESCRIPTION
## Summary

Adds brief JSDoc summaries for the public `name`, `fps`, and `loop` fields on `SpriteAnimationClip`, alongside existing `@type` tags. These properties are user-visible (e.g. via `SpriteComponent#addClip` and playback) and surfaced in the API reference after the class-fields refactor; they should be documented as first-class API rather than `@ignore` or `@private`.

## Changes

- **SpriteAnimationClip**: one-line description per field, aligned with constructor / `addClip` parameter wording; notes that negative `fps` plays backwards.

## Public API

Documentation only; runtime behavior unchanged.
