### PR TITLE
docs: Fix executeCallback JSDoc type in gsplat-resolve-sh

### DIFF
--- a/src/scene/gsplat/gsplat-resolve-sh.js
+++ b/src/scene/gsplat/gsplat-resolve-sh.js
@@ -172,7 +172,7 @@ const resolve = (scope, values) => {
 
 class CustomRenderPass extends RenderPass {
     /**
-     * @type {() => void | null}
+     * @type {(() => void) | null}
      */
     executeCallback = null;
 


### PR DESCRIPTION
Corrects the JSDoc for `CustomRenderPass.executeCallback`. The previous annotation `() => void | null` was parsed as a function returning `void | null`, not a nullable callback. The property is initialized as `null` and later assigned a function, so the type is `(() => void) | null`.
