### PR TITLE
perf: Fuse GSplat budget bucket indices into LOD evaluation

### DIFF
--- a/src/scene/gsplat-unified/constants.js
+++ b/src/scene/gsplat-unified/constants.js
@@ -1,8 +1,13 @@
-// Shared constants for the local compute gsplat renderer. These values are mirrored into
-// the WGSL shaders via cdefines text substitution (e.g. `{CACHE_STRIDE}u`), so they must
-// live in a single place to keep JS-side buffer allocations and shader-side indexing in sync.
+// Shared constants for the gsplat-unified module.
 
 // Number of u32 slots per splat in projCache. 8 = 32 bytes (cache-line friendly).
 // Slots: [0] centerX, [1] centerY, [2..4] conic coeffs, [5] pickId/color, [6] viewDepth/opacity,
 // [7] precomputed -0.5 * radiusFactor (power cutoff for rasterize early-out).
 export const CACHE_STRIDE = 8;
+
+/**
+ * Number of distance buckets for global splat budget balancing.
+ * More buckets = finer granularity for budget prioritization (sqrt-based distance mapping).
+ * @type {number}
+ */
+export const NUM_BUCKETS = 64;

--- a/src/scene/gsplat-unified/gsplat-budget-balancer.js
+++ b/src/scene/gsplat-unified/gsplat-budget-balancer.js
@@ -43,9 +43,8 @@ class GSplatBudgetBalancer {
      * @param {Map<GSplatPlacement, GSplatOctreeInstance>} octreeInstances - Map of
      * GSplatOctreeInstance objects.
      * @param {number} budget - Target splat budget for octrees.
-     * @param {number} _globalMaxDistance - Unused; bucket indices are precomputed during LOD evaluation.
      */
-    balance(octreeInstances, budget, _globalMaxDistance) {
+    balance(octreeInstances, budget) {
         // Initialize buckets on first use
         this._initBuckets();
 

--- a/src/scene/gsplat-unified/gsplat-budget-balancer.js
+++ b/src/scene/gsplat-unified/gsplat-budget-balancer.js
@@ -3,12 +3,7 @@
  * @import { GSplatPlacement } from './gsplat-placement.js'
  */
 
-/**
- * Number of buckets for distance-based sorting.
- * More buckets = finer granularity for budget prioritization.
- * @type {number}
- */
-const NUM_BUCKETS = 64;
+import { NUM_BUCKETS } from './constants.js';
 
 /**
  * Balances splat budget across multiple octree instances by adjusting LOD levels.
@@ -48,9 +43,9 @@ class GSplatBudgetBalancer {
      * @param {Map<GSplatPlacement, GSplatOctreeInstance>} octreeInstances - Map of
      * GSplatOctreeInstance objects.
      * @param {number} budget - Target splat budget for octrees.
-     * @param {number} globalMaxDistance - Max world-space distance for bucket calculation.
+     * @param {number} _globalMaxDistance - Unused; bucket indices are precomputed during LOD evaluation.
      */
-    balance(octreeInstances, budget, globalMaxDistance) {
+    balance(octreeInstances, budget, _globalMaxDistance) {
         // Initialize buckets on first use
         this._initBuckets();
 
@@ -59,15 +54,7 @@ class GSplatBudgetBalancer {
             this._buckets[i].length = 0;
         }
 
-        // Pre-compute multiplier for fast bucket calculation:
-        // bucket = sqrt(worldDistance / globalMaxDistance) * NUM_BUCKETS
-        // Simplified to: sqrt(worldDistance) * (NUM_BUCKETS / sqrt(globalMaxDistance))
-        const bucketScale = NUM_BUCKETS / Math.sqrt(globalMaxDistance);
-
-        // Collect all nodes into buckets based on world distance
-        // Uses sqrt distribution: bucket 0 = nearest, bucket N-1 = farthest
-        // At distance=0: bucket=0, at distance=maxDistance: bucket=NUM_BUCKETS-1
-        // Nearby geometry gets more buckets (finer granularity) due to sqrt
+        // Collect all nodes into buckets (indices precomputed in evaluateNodeLods when enforcing budget).
         let totalOptimalSplats = 0;
         for (const [, inst] of octreeInstances) {
             const nodes = inst.octree.nodes;
@@ -82,11 +69,7 @@ class GSplatBudgetBalancer {
                 const lods = nodes[nodeIndex].lods;
                 nodeInfo.lods = lods;
 
-                // Fast bucket calculation: sqrt(distance) * pre-computed scale
-                // Bucket 0 = nearest (highest priority), bucket N-1 = farthest
-                const bucket = (Math.sqrt(nodeInfo.worldDistance) * bucketScale) >>> 0;
-                const bucketIdx = bucket < NUM_BUCKETS ? bucket : NUM_BUCKETS - 1;
-                this._buckets[bucketIdx].push(nodeInfo);
+                this._buckets[nodeInfo.budgetBucket].push(nodeInfo);
 
                 totalOptimalSplats += lods[optimalLod].count;
             }

--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -38,7 +38,7 @@ import { computeGsplatCommonSource } from '../shader-lib/wgsl/chunks/gsplat/comp
 import { computeGsplatTileIntersectSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-tile-intersect.js';
 import { GSplatTileComposite } from './gsplat-tile-composite.js';
 import { GSplatLocalDispatchSet } from './gsplat-local-dispatch-set.js';
-import { CACHE_STRIDE } from './gsplat-local-constants.js';
+import { CACHE_STRIDE } from './constants.js';
 import computeSplatSource from '../shader-lib/wgsl/chunks/gsplat/vert/gsplatComputeSplat.js';
 
 /**

--- a/src/scene/gsplat-unified/gsplat-local-dispatch-set.js
+++ b/src/scene/gsplat-unified/gsplat-local-dispatch-set.js
@@ -19,7 +19,7 @@ import {
 import { PrefixSumKernel } from '../graphics/prefix-sum-kernel.js';
 import { shaderChunksWGSL } from '../shader-lib/wgsl/collections/shader-chunks-wgsl.js';
 import { computeGsplatLocalRasterizeSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-rasterize.js';
-import { CACHE_STRIDE } from './gsplat-local-constants.js';
+import { CACHE_STRIDE } from './constants.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1286,7 +1286,7 @@ class GSplatManager {
         // Phase 2: Evaluate optimal LODs for all octrees and calculate padding for active placements
         let totalOptimalSplats = 0;
         for (const [, inst] of this.octreeInstances) {
-            totalOptimalSplats += inst.evaluateOptimalLods(this.cameraNode, this.scene.gsplat, this._budgetScale);
+            totalOptimalSplats += inst.evaluateOptimalLods(this.cameraNode, this.scene.gsplat, this._budgetScale, globalMaxDistance);
             for (const placement of inst.activePlacements) {
                 const resource = /** @type {GSplatResourceBase} */ (placement.resource);
                 const numSplats = resource?.numSplats ?? 0;

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1316,7 +1316,7 @@ class GSplatManager {
         }
 
         // Budget balancing across all octrees
-        this._budgetBalancer.balance(this.octreeInstances, adjustedBudget, globalMaxDistance);
+        this._budgetBalancer.balance(this.octreeInstances, adjustedBudget);
 
         // Apply LOD changes
         for (const [, inst] of this.octreeInstances) {

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -8,6 +8,7 @@ import { Color } from '../../core/math/color.js';
 import { GSplatPlacement } from './gsplat-placement.js';
 import { GsplatAllocId } from './gsplat-alloc-id.js';
 import { GSPLAT_DEBUG_NODE_AABBS } from '../constants.js';
+import { NUM_BUCKETS } from './constants.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
@@ -75,6 +76,15 @@ class NodeInfo {
      * @type {Array|null}
      */
     lods = null;
+
+    /**
+     * Distance bucket index [0, NUM_BUCKETS - 1] for global budget balancing (sqrt mapping).
+     * Written during {@link GSplatOctreeInstance.evaluateNodeLods} when a global max distance
+     * is supplied (budget enforcement path only).
+     *
+     * @type {number}
+     */
+    budgetBucket = 0;
 
     /**
      * Unique allocation identifier for persistent work buffer allocation tracking.
@@ -508,10 +518,11 @@ class GSplatOctreeInstance {
      * @param {import('./gsplat-params.js').GSplatParams} params - Global gsplat parameters.
      * @param {number} uniformScale - Uniform scale of the octree transform for world-space conversion.
      * @param {boolean} [accumulateSplats] - When true (default), sum splat counts for the chosen LOD per node and return the total (budget path). When false, skip counting (faster; return value unused).
+     * @param {number} [globalMaxDistanceForBuckets] - When > 0, writes {@link NodeInfo.budgetBucket} using the same sqrt mapping as the budget balancer. Omit or pass 0 when not enforcing global budget.
      * @returns {number} Total number of splats that would be used by optimal LODs when accumulateSplats is true; otherwise 0.
      * @private
      */
-    evaluateNodeLods(cameraNode, maxLod, lodBaseDistance, lodMultiplier, rangeMin, rangeMax, params, uniformScale, accumulateSplats = true) {
+    evaluateNodeLods(cameraNode, maxLod, lodBaseDistance, lodMultiplier, rangeMin, rangeMax, params, uniformScale, accumulateSplats = true, globalMaxDistanceForBuckets = 0) {
         const { lodBehindPenalty } = params;
 
         // Compute FOV compensation: use min(tanHalfV, tanHalfH) to handle ultra-wide and portrait
@@ -551,6 +562,8 @@ class GSplatOctreeInstance {
         if (maxLod >= 1) {
             minDistBuf = this._ensureLodMinDistThresholds(maxLod, lodBaseDistance, lodMultiplier);
         }
+
+        const bucketScale = globalMaxDistanceForBuckets > 0 ? NUM_BUCKETS / Math.sqrt(globalMaxDistanceForBuckets) : 0;
 
         for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {
             const nodeInfo = nodeInfos[nodeIndex];
@@ -615,6 +628,12 @@ class GSplatOctreeInstance {
             nodeInfo.optimalLod = optimalLodIndex;
             nodeInfo.worldDistance = fovAdjustedDistance * uniformScale;
 
+            // Budget balancer bucket (sqrt mapping; must match GSplatBudgetBalancer). Fused here when enforcing budget.
+            if (bucketScale > 0 && optimalLodIndex >= 0) {
+                const bucket = (Math.sqrt(nodeInfo.worldDistance) * bucketScale) >>> 0;
+                nodeInfo.budgetBucket = bucket < NUM_BUCKETS ? bucket : NUM_BUCKETS - 1;
+            }
+
             if (accumulateSplats) {
                 // Count splats for this optimal LOD
                 const lod = nodes[nodeIndex].lods[optimalLodIndex];
@@ -636,9 +655,10 @@ class GSplatOctreeInstance {
      * @param {number} [budgetScale] - Dynamic scale applied to LOD parameters to shift
      * boundaries closer to the budget target. Applied to lodBaseDistance directly, and
      * gently to lodMultiplier via pow(budgetScale, -0.2). Defaults to 1.
+     * @param {number} [globalMaxDistanceForBuckets] - When > 0, {@link NodeInfo.budgetBucket} is populated during LOD evaluation for budget balancing.
      * @returns {number} Total optimal splat count.
      */
-    evaluateOptimalLods(cameraNode, params, budgetScale = 1) {
+    evaluateOptimalLods(cameraNode, params, budgetScale = 1, globalMaxDistanceForBuckets = 0) {
         const maxLod = this.octree.lodLevels - 1;
         const { lodBaseDistance, lodMultiplier } = this.placement;
         const { lodRangeMin, lodRangeMax } = params;
@@ -656,7 +676,7 @@ class GSplatOctreeInstance {
         const effectiveMult = Math.max(1.2, lodMultiplier * Math.pow(budgetScale, -0.2));
 
         return this.evaluateNodeLods(cameraNode, maxLod, effectiveBase, effectiveMult,
-            rangeMin, rangeMax, params, uniformScale);
+            rangeMin, rangeMax, params, uniformScale, true, globalMaxDistanceForBuckets);
     }
 
     /**


### PR DESCRIPTION
Precomputes per-node sqrt-based distance bucket indices during optimal LOD evaluation when enforcing global splat budget, so `GSplatBudgetBalancer.balance()` no longer walks octree nodes again only for bucket placement.

**Changes**
- `evaluateOptimalLods` / `evaluateNodeLods`: optional `globalMaxDistance`; writes `NodeInfo.budgetBucket` (same mapping as before).
- `balance()`: fills buckets from `budgetBucket`; `NUM_BUCKETS` shared via `gsplat-unified/constants.js`.
- Rename `gsplat-local-constants.js` → `constants.js`; update imports.