### PR TITLE
feat(gsplat): Rename GSPLAT_RENDERER_RASTER_HYBRID to RASTER_GPU_SORT

### DIFF
--- a/examples/src/examples/gaussian-splatting/annotations.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/annotations.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/benchmark.example.mjs
+++ b/examples/src/examples/gaussian-splatting/benchmark.example.mjs
@@ -24,7 +24,7 @@ const IDLE_FPS_SAMPLE_MS = 1000;
 const RENDERERS = [
     { device: 'webgl2', renderer: pc.GSPLAT_RENDERER_RASTER_CPU_SORT, label: 'WebGL2 CPU Sort', shortLabel: 'GL2 CPU' },
     { device: 'webgpu', renderer: pc.GSPLAT_RENDERER_RASTER_CPU_SORT, label: 'WebGPU CPU Sort', shortLabel: 'GPU CPU' },
-    { device: 'webgpu', renderer: pc.GSPLAT_RENDERER_RASTER_HYBRID, label: 'WebGPU Hybrid', shortLabel: 'Hybrid' },
+    { device: 'webgpu', renderer: pc.GSPLAT_RENDERER_RASTER_GPU_SORT, label: 'WebGPU GPU Sort', shortLabel: 'GPU Sort' },
     { device: 'webgpu', renderer: pc.GSPLAT_RENDERER_COMPUTE, label: 'WebGPU Compute', shortLabel: 'Compute' }
 ];
 

--- a/examples/src/examples/gaussian-splatting/crop.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/crop.controls.mjs
@@ -17,7 +17,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/editor.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/editor.controls.mjs
@@ -20,7 +20,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
-                        { v: 2, t: 'Raster (Hybrid)' },
+                        { v: 2, t: 'Raster (GPU Sort)' },
                         { v: 3, t: 'Compute' }
                     ]
                 })

--- a/examples/src/examples/gaussian-splatting/flipbook.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/flipbook.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/global-sorting.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/global-sorting.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/lod-instances.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-instances.controls.mjs
@@ -19,7 +19,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
-                        { v: 2, t: 'Raster (Hybrid)' },
+                        { v: 2, t: 'Raster (GPU Sort)' },
                         { v: 3, t: 'Compute' }
                     ]
                 })

--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.controls.mjs
@@ -19,7 +19,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
-                        { v: 2, t: 'Raster (Hybrid)' },
+                        { v: 2, t: 'Raster (GPU Sort)' },
                         { v: 3, t: 'Compute' }
                     ]
                 })

--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
@@ -169,7 +169,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
-                        { v: 2, t: 'Raster (Hybrid)' },
+                        { v: 2, t: 'Raster (GPU Sort)' },
                         { v: 3, t: 'Compute' }
                     ]
                 })

--- a/examples/src/examples/gaussian-splatting/multi-splat.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/multi-splat.controls.mjs
@@ -19,7 +19,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/multi-view.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/multi-view.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/paint.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/paint.controls.mjs
@@ -20,7 +20,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
-                        { v: 2, t: 'Raster (Hybrid)' },
+                        { v: 2, t: 'Raster (GPU Sort)' },
                         { v: 3, t: 'Compute' }
                     ]
                 })

--- a/examples/src/examples/gaussian-splatting/picking.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/picking.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/procedural-instanced.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-instanced.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/procedural-mesh.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-mesh.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/procedural-shapes.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-shapes.controls.mjs
@@ -17,7 +17,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/reveal.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/reveal.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/shader-effects.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/shader-effects.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/shadows.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/shadows.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/simple.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/simple.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/spherical-harmonics.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/spherical-harmonics.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/examples/src/examples/gaussian-splatting/viewer.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.controls.mjs
@@ -21,7 +21,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
-                        { v: 2, t: 'Raster (Hybrid)' },
+                        { v: 2, t: 'Raster (GPU Sort)' },
                         { v: 3, t: 'Compute' }
                     ]
                 })

--- a/examples/src/examples/gaussian-splatting/weather.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/weather.controls.mjs
@@ -19,7 +19,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
-                        { v: 2, t: 'Raster (Hybrid)' },
+                        { v: 2, t: 'Raster (GPU Sort)' },
                         { v: 3, t: 'Compute' }
                     ]
                 })

--- a/examples/src/examples/gaussian-splatting/world.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/world.controls.mjs
@@ -19,7 +19,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     options: [
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
-                        { v: 2, t: 'Raster (Hybrid)' },
+                        { v: 2, t: 'Raster (GPU Sort)' },
                         { v: 3, t: 'Compute' }
                     ]
                 })

--- a/examples/src/examples/gaussian-splatting/xr-views.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/xr-views.controls.mjs
@@ -16,7 +16,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 options: [
                     { v: 0, t: 'Auto' },
                     { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (Hybrid)' },
+                    { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
             })

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1225,15 +1225,14 @@ export const GSPLAT_RENDERER_AUTO = 0;
 export const GSPLAT_RENDERER_RASTER_CPU_SORT = 1;
 
 /**
- * Hybrid rasterization renderer that performs projection, screen-space culling and sort key
- * generation in a single compute pass, sorts globally via a compute radix sort, and rasterizes
- * quads from a pre-projected cache. WebGPU only. Experimental with limited functionality.
+ * Rasterization-based rendering with GPU-side culling and sorting. WebGPU only. Experimental with
+ * limited functionality.
  *
  * @type {number}
  * @category Graphics
- * @ignore
+ * @alpha
  */
-export const GSPLAT_RENDERER_RASTER_HYBRID = 2;
+export const GSPLAT_RENDERER_RASTER_GPU_SORT = 2;
 
 /**
  * Full compute pipeline for rendering. WebGPU only. Experimental with limited functionality.

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -18,7 +18,7 @@ import { ComputeRadixSort } from '../graphics/radix-sort/compute-radix-sort.js';
 import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import {
-    GSPLAT_RENDERER_RASTER_CPU_SORT, GSPLAT_RENDERER_RASTER_HYBRID,
+    GSPLAT_RENDERER_RASTER_CPU_SORT, GSPLAT_RENDERER_RASTER_GPU_SORT,
     GSPLAT_RENDERER_COMPUTE,
     GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE, GSPLAT_DEBUG_AABBS
 } from '../constants.js';
@@ -90,7 +90,7 @@ let _randomColorRaw = null;
  * GSplatManager manages the rendering of splats using a work buffer, where all active splats are
  * stored and rendered from.
  *
- * Shared culling + compaction (hybrid raster and compute renderer, WebGPU only):
+ * Shared culling + compaction (raster GPU-sort path and compute renderer, WebGPU only):
  *   Interval compaction operates on contiguous intervals of splats (one per octree node).
  *   1. Cull + count (compute): each interval's bounding sphere is tested against frustum
  *      planes (or a fisheye cone). The pass writes the interval's splat count (or 0 if
@@ -154,21 +154,21 @@ class GSplatManager {
     cpuSorter = null;
 
     /**
-     * GPU-based radix sorter (hybrid raster path).
+     * GPU-based radix sorter (raster GPU sort path).
      *
      * @type {ComputeRadixSort|null}
      */
     gpuSorter = null;
 
     /**
-     * Interval-based GPU compaction (hybrid / compute paths).
+     * Interval-based GPU compaction (raster GPU sort / compute paths).
      *
      * @type {GSplatIntervalCompaction|null}
      */
     intervalCompaction = null;
 
     /**
-     * Compute projector + sort keys for {@link GSPLAT_RENDERER_RASTER_HYBRID}.
+     * Compute projector + sort keys for {@link GSPLAT_RENDERER_RASTER_GPU_SORT}.
      *
      * @type {GSplatProjector|null}
      */
@@ -180,7 +180,7 @@ class GSplatManager {
     indirectDrawSlot = -1;
 
     /**
-     * Indirect dispatch slot for hybrid raster (projector + radix) and compute paths.
+     * Indirect dispatch slot for raster GPU sort (projector + radix) and compute paths.
      * The compute local renderer builds its own indirect args in private buffers
      * and does not use these slots.
      */
@@ -507,7 +507,7 @@ class GSplatManager {
      * @returns {import('../mesh-instance.js').MeshInstance|null} The pick mesh instance, or null.
      */
     prepareForPicking(camera, width, height) {
-        if (this.activeRenderer === GSPLAT_RENDERER_RASTER_HYBRID) {
+        if (this.activeRenderer === GSPLAT_RENDERER_RASTER_GPU_SORT) {
             const sortedState = this.worldStates.get(this.sortedVersion);
             if (!sortedState?.sortedBefore || !camera.node) return null;
 
@@ -585,7 +585,7 @@ class GSplatManager {
     _createRenderer(mode) {
         if (mode === GSPLAT_RENDERER_COMPUTE) {
             this.renderer = new GSplatComputeLocalRenderer(this.device, this.node, this.cameraNode, this.layer, this.workBuffer);
-        } else if (mode === GSPLAT_RENDERER_RASTER_HYBRID) {
+        } else if (mode === GSPLAT_RENDERER_RASTER_GPU_SORT) {
             this.renderer = new GSplatHybridRenderer(this.device, this.node, this.cameraNode, this.layer, this.workBuffer);
             this.initHybridSorting();
         } else {
@@ -1518,7 +1518,7 @@ class GSplatManager {
                 // Compute renderer: run compaction only (no key generation or radix sort)
                 this.compactGpu(lastState);
                 gpuSortedThisFrame = true;
-            } else if (this.activeRenderer === GSPLAT_RENDERER_RASTER_HYBRID) {
+            } else if (this.activeRenderer === GSPLAT_RENDERER_RASTER_GPU_SORT) {
                 this.sortGpuHybrid(lastState);
                 gpuSortedThisFrame = true;
             } else {
@@ -1536,9 +1536,9 @@ class GSplatManager {
             this.lastCullingProjMat.copy(this.cameraNode.camera.projectionMatrix);
         }
 
-        // Hybrid raster needs projector + radix + fresh indirect args every frame (indirect
+        // Raster GPU sort needs projector + radix + fresh indirect args every frame (indirect
         // slots are per-frame; post-projector visible count differs from interval prefix sum).
-        if (this.activeRenderer === GSPLAT_RENDERER_RASTER_HYBRID && lastState && !gpuSortedThisFrame) {
+        if (this.activeRenderer === GSPLAT_RENDERER_RASTER_GPU_SORT && lastState && !gpuSortedThisFrame) {
             this.sortGpuHybrid(lastState);
             gpuSortedThisFrame = true;
         }

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -8,7 +8,7 @@ import { GSplatFormat } from '../gsplat/gsplat-format.js';
 import {
     GSPLATDATA_COMPACT,
     GSPLAT_RENDERER_AUTO, GSPLAT_RENDERER_RASTER_CPU_SORT,
-    GSPLAT_RENDERER_COMPUTE, GSPLAT_RENDERER_RASTER_HYBRID,
+    GSPLAT_RENDERER_COMPUTE, GSPLAT_RENDERER_RASTER_GPU_SORT,
     GSPLAT_DEBUG_NONE, GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE, GSPLAT_DEBUG_HEATMAP,
     GSPLAT_DEBUG_AABBS, GSPLAT_DEBUG_NODE_AABBS
 } from '../constants.js';
@@ -146,8 +146,8 @@ class GSplatParams {
      * - {@link GSPLAT_RENDERER_AUTO}: Automatically selects the best pipeline for the platform.
      * - {@link GSPLAT_RENDERER_RASTER_CPU_SORT}: Rasterization with CPU-side sorting.
      * - {@link GSPLAT_RENDERER_COMPUTE}: Full compute pipeline (WebGPU only, experimental).
-     * - {@link GSPLAT_RENDERER_RASTER_HYBRID}: Hybrid rasterization with a compute projection
-     * cache and global radix sort (WebGPU only, experimental, internal).
+     * - {@link GSPLAT_RENDERER_RASTER_GPU_SORT}: Rasterization with GPU-side sorting (WebGPU only,
+     * experimental).
      *
      * Defaults to {@link GSPLAT_RENDERER_AUTO}. Modes requiring WebGPU fall back to
      * {@link GSPLAT_RENDERER_RASTER_CPU_SORT} on WebGL devices. The resolved mode actually used
@@ -162,7 +162,7 @@ class GSplatParams {
             if (value === GSPLAT_RENDERER_AUTO) {
                 this._currentRenderer = GSPLAT_RENDERER_RASTER_CPU_SORT;
             } else if ((value === GSPLAT_RENDERER_COMPUTE ||
-                        value === GSPLAT_RENDERER_RASTER_HYBRID) &&
+                        value === GSPLAT_RENDERER_RASTER_GPU_SORT) &&
                 !this._device.isWebGPU) {
                 this._currentRenderer = GSPLAT_RENDERER_RASTER_CPU_SORT;
             } else {


### PR DESCRIPTION
Renames the renderer enum **`GSPLAT_RENDERER_RASTER_HYBRID`** to **`GSPLAT_RENDERER_RASTER_GPU_SORT`** (value **`2` unchanged**). The constant is now documented as raster GPU-side sorting (projector + radix), **`@ignore` removed**, **`@alpha`** added, with experimental wording retained.

**Changes**
- [`constants.js`](src/scene/constants.js): new export name + JSDoc + `@alpha`.
- [`gsplat-params.js`](src/scene/gsplat-unified/gsplat-params.js), [`gsplat-manager.js`](src/scene/gsplat-unified/gsplat-manager.js): imports, comparisons, and `@link` targets updated; light comment wording for “raster GPU sort”.
- Gaussian splatting examples: dropdown **`Raster (Hybrid)`** → **`Raster (GPU Sort)`** for `v: 2`; benchmark uses **`pc.GSPLAT_RENDERER_RASTER_GPU_SORT`** and **WebGPU GPU Sort** / **GPU Sort** labels.

**Public API**
- **`GSPLAT_RENDERER_RASTER_HYBRID`** removed; use **`GSPLAT_RENDERER_RASTER_GPU_SORT`** (`2`).