### PR TITLE
feat: Respect gsplat alphaCull on CPU raster and compute paths

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
@@ -198,10 +198,10 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
-                { text: 'Alpha Cull' },
+                { text: 'Alpha Clip' },
                 jsx(SliderInput, {
                     binding: new BindingTwoWay(),
-                    link: { observer, path: 'alphaCull' },
+                    link: { observer, path: 'alphaClipForward' },
                     min: 0,
                     max: 1,
                     precision: 3

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -185,8 +185,8 @@ assetListLoader.load(async () => {
     data.on('minPixelSize:set', () => {
         app.scene.gsplat.minPixelSize = data.get('minPixelSize');
     });
-    data.on('alphaCull:set', () => {
-        app.scene.gsplat.alphaCull = data.get('alphaCull');
+    data.on('alphaClipForward:set', () => {
+        app.scene.gsplat.alphaClipForward = data.get('alphaClipForward');
     });
     data.on('minContribution:set', () => {
         app.scene.gsplat.minContribution = data.get('minContribution');
@@ -206,7 +206,7 @@ assetListLoader.load(async () => {
     data.set('toneMapping', pc.TONEMAP_LINEAR);
     data.set('exposure', 1);
     data.set('minPixelSize', 2);
-    data.set('alphaCull', 1 / 255);
+    data.set('alphaClipForward', 1 / 255);
     data.set('minContribution', 3);
     data.set('radialSorting', true);
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);

--- a/examples/src/examples/gaussian-splatting/shadows.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/shadows.controls.mjs
@@ -23,7 +23,7 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
         ),
         jsx(
             LabelGroup,
-            { text: 'Alpha Clip' },
+            { text: 'Shadow Clip' },
             jsx(SliderInput, {
                 binding: new BindingTwoWay(),
                 link: { observer, path: 'alphaClip' },

--- a/examples/src/examples/gaussian-splatting/simple.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/simple.controls.mjs
@@ -3,23 +3,49 @@
  * @returns {JSX.Element} The returned JSX Element.
  */
 export const controls = ({ observer, ReactPCUI, jsx, fragment }) => {
-    const { BindingTwoWay, LabelGroup, SelectInput } = ReactPCUI;
+    const { BindingTwoWay, LabelGroup, Panel, SelectInput, SliderInput } = ReactPCUI;
     return fragment(
         jsx(
-            LabelGroup,
-            { text: 'Renderer' },
-            jsx(SelectInput, {
-                type: 'number',
-                binding: new BindingTwoWay(),
-                link: { observer, path: 'renderer' },
-                value: observer.get('renderer') ?? 0,
-                options: [
-                    { v: 0, t: 'Auto' },
-                    { v: 1, t: 'Raster (CPU Sort)' },
-                    { v: 2, t: 'Raster (GPU Sort)' },
-                    { v: 3, t: 'Compute' }
-                ]
-            })
+            Panel,
+            { headerText: 'Scene' },
+            jsx(
+                LabelGroup,
+                { text: 'Shadow Clip' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'alphaClip' },
+                    min: 0,
+                    max: 1,
+                    precision: 3
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Alpha Clip' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'alphaClipForward' },
+                    min: 0,
+                    max: 1,
+                    precision: 4
+                })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Renderer' },
+                jsx(SelectInput, {
+                    type: 'number',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'renderer' },
+                    value: observer.get('renderer') ?? 0,
+                    options: [
+                        { v: 0, t: 'Auto' },
+                        { v: 1, t: 'Raster (CPU Sort)' },
+                        { v: 2, t: 'Raster (GPU Sort)' },
+                        { v: 3, t: 'Compute' }
+                    ]
+                })
+            )
         )
     );
 };

--- a/examples/src/examples/gaussian-splatting/simple.example.mjs
+++ b/examples/src/examples/gaussian-splatting/simple.example.mjs
@@ -60,7 +60,17 @@ assetListLoader.load(() => {
             setTimeout(() => data.set('renderer', current), 0);
         }
     });
+    data.on('alphaClip:set', () => {
+        app.scene.gsplat.alphaClip = data.get('alphaClip');
+    });
+    data.on('alphaClipForward:set', () => {
+        app.scene.gsplat.alphaClipForward = data.get('alphaClipForward');
+    });
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
+    data.set('alphaClip', 0.4);
+    data.set('alphaClipForward', 1 / 255);
+    app.scene.gsplat.alphaClip = data.get('alphaClip');
+    app.scene.gsplat.alphaClipForward = data.get('alphaClipForward');
 
     // create a splat entity and place it in the world
     const biker = new pc.Entity();
@@ -80,9 +90,6 @@ assetListLoader.load(() => {
     const ORBIT_DISTANCE = 4;
     const ORBIT_INITIAL_YAW = 32;
     const ORBIT_INITIAL_PITCH = -10;
-
-    // alpha clip for unified splats (shadows); scene-level for unified path
-    app.scene.gsplat.alphaClip = 0.4;
 
     // Create an Entity with a camera component
     const camera = new pc.Entity();

--- a/src/scene/gsplat-unified/constants.js
+++ b/src/scene/gsplat-unified/constants.js
@@ -1,5 +1,8 @@
 // Shared constants for the gsplat-unified module.
 
+/** Minimum alpha treated as visible; matches historical 1/255 shader floor. */
+export const ALPHA_VISIBILITY_THRESHOLD = 1.0 / 255.0;
+
 // Number of u32 slots per splat in projCache. 8 = 32 bytes (cache-line friendly).
 // Slots: [0] centerX, [1] centerY, [2..4] conic coeffs, [5] pickId/color, [6] viewDepth/opacity,
 // [7] precomputed -0.5 * radiusFactor (power cutoff for rasterize early-out).

--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -165,7 +165,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
     _alphaClip = 0.3;
 
     /** @type {number} */
-    _alphaCull = ALPHA_VISIBILITY_THRESHOLD;
+    _alphaClipForward = ALPHA_VISIBILITY_THRESHOLD;
 
     /** @type {number} */
     _exposure = 1.0;
@@ -435,7 +435,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         this._minPixelSize = gsplat.minPixelSize;
         this._minContribution = gsplat.minContribution;
         this._alphaClip = gsplat.alphaClip;
-        this._alphaCull = gsplat.alphaCull;
+        this._alphaClipForward = gsplat.alphaClipForward;
         this._exposure = exposure ?? 1.0;
         this._fisheye = gsplat.fisheye;
         this._fogParams = fogParams ?? null;
@@ -653,7 +653,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         _viewData.set(view.data);
         const focal = width * _shaderProjMat.data[0];
 
-        const alphaClip = pickMode ? this._alphaClip : Math.max(ALPHA_VISIBILITY_THRESHOLD, this._alphaCull);
+        const alphaClip = pickMode ? this._alphaClip : Math.max(ALPHA_VISIBILITY_THRESHOLD, this._alphaClipForward);
 
         // Ensure fisheyeProj is up-to-date (culling may not have run this frame)
         this.fisheyeProj.update(this._fisheye, camera.fov, cam.projectionMatrix);

--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -38,7 +38,7 @@ import { computeGsplatCommonSource } from '../shader-lib/wgsl/chunks/gsplat/comp
 import { computeGsplatTileIntersectSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-tile-intersect.js';
 import { GSplatTileComposite } from './gsplat-tile-composite.js';
 import { GSplatLocalDispatchSet } from './gsplat-local-dispatch-set.js';
-import { CACHE_STRIDE } from './constants.js';
+import { ALPHA_VISIBILITY_THRESHOLD, CACHE_STRIDE } from './constants.js';
 import computeSplatSource from '../shader-lib/wgsl/chunks/gsplat/vert/gsplatComputeSplat.js';
 
 /**
@@ -163,6 +163,9 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
 
     /** @type {number} */
     _alphaClip = 0.3;
+
+    /** @type {number} */
+    _alphaCull = ALPHA_VISIBILITY_THRESHOLD;
 
     /** @type {number} */
     _exposure = 1.0;
@@ -432,6 +435,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         this._minPixelSize = gsplat.minPixelSize;
         this._minContribution = gsplat.minContribution;
         this._alphaClip = gsplat.alphaClip;
+        this._alphaCull = gsplat.alphaCull;
         this._exposure = exposure ?? 1.0;
         this._fisheye = gsplat.fisheye;
         this._fogParams = fogParams ?? null;
@@ -649,7 +653,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
         _viewData.set(view.data);
         const focal = width * _shaderProjMat.data[0];
 
-        const alphaClip = pickMode ? this._alphaClip : (1.0 / 255.0);
+        const alphaClip = pickMode ? this._alphaClip : Math.max(ALPHA_VISIBILITY_THRESHOLD, this._alphaCull);
 
         // Ensure fisheyeProj is up-to-date (culling may not have run this frame)
         this.fisheyeProj.update(this._fisheye, camera.fov, cam.projectionMatrix);

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -208,12 +208,12 @@ class GSplatHybridRenderer extends GSplatRenderer {
      * @param {StorageBuffer} projCache - Per-splat projection cache produced by the projector.
      * @param {StorageBuffer} numSplatsBuffer - GPU-written visible-splat count.
      * @param {number} alphaClip - Fragment alpha threshold for picking.
-     * @param {number} alphaCull - Forward alpha floor (must match {@link GSplatRenderer#frameUpdate}).
+     * @param {number} alphaClipForward - Forward alpha floor (must match {@link GSplatRenderer#frameUpdate}).
      * @param {GraphNode} cameraNode - The picker camera node, used to derive the
      * `clipToViewZ` reconstruction uniform.
      * @returns {MeshInstance} The pick mesh instance.
      */
-    prepareForPicking(drawSlot, sortedIndices, projCache, numSplatsBuffer, alphaClip, alphaCull, cameraNode) {
+    prepareForPicking(drawSlot, sortedIndices, projCache, numSplatsBuffer, alphaClip, alphaClipForward, cameraNode) {
         if (!this._pickMaterial) {
             this._pickMaterial = new ShaderMaterial({
                 uniqueName: 'UnifiedSplatHybridPickMaterial',
@@ -254,7 +254,7 @@ class GSplatHybridRenderer extends GSplatRenderer {
         pickMaterial.setParameter('projCache', projCache);
         pickMaterial.setParameter('numSplatsStorage', numSplatsBuffer);
         pickMaterial.setParameter('alphaClip', alphaClip);
-        pickMaterial.setParameter('alphaCull', alphaCull);
+        pickMaterial.setParameter('alphaClipForward', alphaClipForward);
         this._clipToViewZPick ??= new Float32Array(4);
         this._computeClipToViewZ(cameraNode, this._clipToViewZPick);
         pickMaterial.setParameter('clipToViewZ', this._clipToViewZPick);
@@ -317,9 +317,9 @@ class GSplatHybridRenderer extends GSplatRenderer {
 
     frameUpdate(params) {
         this._material.setParameter('alphaClip', params.alphaClip);
-        this._material.setParameter('alphaCull', params.alphaCull);
+        this._material.setParameter('alphaClipForward', params.alphaClipForward);
         this._pickMaterial?.setParameter('alphaClip', params.alphaClip);
-        this._pickMaterial?.setParameter('alphaCull', params.alphaCull);
+        this._pickMaterial?.setParameter('alphaClipForward', params.alphaClipForward);
 
         if (params.colorRamp) {
             this._material.setParameter('colorRampIntensity', params.colorRampIntensity);

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -208,11 +208,12 @@ class GSplatHybridRenderer extends GSplatRenderer {
      * @param {StorageBuffer} projCache - Per-splat projection cache produced by the projector.
      * @param {StorageBuffer} numSplatsBuffer - GPU-written visible-splat count.
      * @param {number} alphaClip - Fragment alpha threshold for picking.
+     * @param {number} alphaCull - Forward alpha floor (must match {@link GSplatRenderer#frameUpdate}).
      * @param {GraphNode} cameraNode - The picker camera node, used to derive the
      * `clipToViewZ` reconstruction uniform.
      * @returns {MeshInstance} The pick mesh instance.
      */
-    prepareForPicking(drawSlot, sortedIndices, projCache, numSplatsBuffer, alphaClip, cameraNode) {
+    prepareForPicking(drawSlot, sortedIndices, projCache, numSplatsBuffer, alphaClip, alphaCull, cameraNode) {
         if (!this._pickMaterial) {
             this._pickMaterial = new ShaderMaterial({
                 uniqueName: 'UnifiedSplatHybridPickMaterial',
@@ -253,6 +254,7 @@ class GSplatHybridRenderer extends GSplatRenderer {
         pickMaterial.setParameter('projCache', projCache);
         pickMaterial.setParameter('numSplatsStorage', numSplatsBuffer);
         pickMaterial.setParameter('alphaClip', alphaClip);
+        pickMaterial.setParameter('alphaCull', alphaCull);
         this._clipToViewZPick ??= new Float32Array(4);
         this._computeClipToViewZ(cameraNode, this._clipToViewZPick);
         pickMaterial.setParameter('clipToViewZ', this._clipToViewZPick);

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -315,7 +315,9 @@ class GSplatHybridRenderer extends GSplatRenderer {
 
     frameUpdate(params) {
         this._material.setParameter('alphaClip', params.alphaClip);
+        this._material.setParameter('alphaCull', params.alphaCull);
         this._pickMaterial?.setParameter('alphaClip', params.alphaClip);
+        this._pickMaterial?.setParameter('alphaCull', params.alphaCull);
 
         if (params.colorRamp) {
             this._material.setParameter('colorRampIntensity', params.colorRampIntensity);

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -25,6 +25,7 @@ import {
 import { Color } from '../../core/math/color.js';
 import { GSplatBudgetBalancer } from './gsplat-budget-balancer.js';
 import { BlockAllocator } from '../../core/block-allocator.js';
+import { ALPHA_VISIBILITY_THRESHOLD } from './constants.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
@@ -59,7 +60,6 @@ const _localCamPos = new Vec3();
 const _closestPt = new Vec3();
 const tempOctreesTicked = new Set();
 const _queuedSplats = new Set();
-const ALPHA_VISIBILITY_THRESHOLD = 1.0 / 255.0;
 
 const _lodColorsRaw = [
     [1, 0, 0],  // red

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -529,6 +529,7 @@ class GSplatManager {
                 /** @type {StorageBuffer} */ (proj.projCache),
                 /** @type {StorageBuffer} */ (ic.numSplatsBuffer),
                 this.scene.gsplat.alphaClip,
+                this.scene.gsplat.alphaCull,
                 camera.node
             );
         }

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -529,7 +529,7 @@ class GSplatManager {
                 /** @type {StorageBuffer} */ (proj.projCache),
                 /** @type {StorageBuffer} */ (ic.numSplatsBuffer),
                 this.scene.gsplat.alphaClip,
-                this.scene.gsplat.alphaCull,
+                this.scene.gsplat.alphaClipForward,
                 camera.node
             );
         }
@@ -1605,7 +1605,7 @@ class GSplatManager {
             this.cameraNode,
             viewportWidth,
             viewportHeight,
-            Math.max(ALPHA_VISIBILITY_THRESHOLD, this.scene.gsplat.alphaCull),
+            Math.max(ALPHA_VISIBILITY_THRESHOLD, this.scene.gsplat.alphaClipForward),
             false
         );
 

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -69,7 +69,7 @@ class GSplatParams {
         this._format = this._createFormat(GSPLATDATA_COMPACT);
 
         this._material.setParameter('alphaClip', 0.3);
-        this._material.setParameter('alphaCull', 1.0 / 255.0);
+        this._material.setParameter('alphaClipForward', 1.0 / 255.0);
         this._material.setParameter('minPixelSize', 2.0);
         this._material.setParameter('minContribution', 3.0);
     }
@@ -575,8 +575,8 @@ class GSplatParams {
     }
 
     /**
-     * Sets the alpha threshold below which splats are discarded during shadow, pick, and prepass
-     * rendering. Higher values create more aggressive clipping, while lower values preserve more
+     * Sets the alpha threshold for shadow, pick, and prepass rendering (not the main forward
+     * splat pass). Higher values create more aggressive clipping, while lower values preserve more
      * translucent splats. Defaults to 0.3.
      *
      * @type {number}
@@ -587,7 +587,7 @@ class GSplatParams {
     }
 
     /**
-     * Gets the alpha clip threshold.
+     * Gets the alpha threshold for shadow, pick, and prepass rendering.
      *
      * @type {number}
      */
@@ -596,24 +596,25 @@ class GSplatParams {
     }
 
     /**
-     * Sets the alpha threshold below which splats are discarded before forward rendering.
-     * Higher values improve performance by culling more low-opacity splats, while lower
-     * values preserve more translucent splats. Defaults to 1 / 255.
+     * Sets the alpha threshold below which splats are culled or clipped in the **forward** splat
+     * rendering pass. Does not apply to shadow, pick, or prepass — use {@link GSplatParams#alphaClip}
+     * for those. Higher values improve performance by culling more low-opacity splats; lower values
+     * preserve more translucent splats. Defaults to 1 / 255.
      *
      * @type {number}
      */
-    set alphaCull(value) {
-        this._material.setParameter('alphaCull', value);
+    set alphaClipForward(value) {
+        this._material.setParameter('alphaClipForward', value);
         this._material.update();
     }
 
     /**
-     * Gets the forward alpha cull threshold.
+     * Gets the forward-pass alpha threshold.
      *
      * @type {number}
      */
-    get alphaCull() {
-        return this._material.getParameter('alphaCull')?.data ?? (1.0 / 255.0);
+    get alphaClipForward() {
+        return this._material.getParameter('alphaClipForward')?.data ?? (1.0 / 255.0);
     }
 
     /**

--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -89,6 +89,7 @@ class GSplatInstance {
             this._material = options.material;
             this._material.setDefine('{GSPLAT_INSTANCE_SIZE}', String(GSplatResourceBase.instanceSize));
             this.setMaterialOrderData(this._material);
+            this._material.setParameter('alphaCull', 1.0 / 255.0);
         } else {
             this._material = new ShaderMaterial({
                 uniqueName: 'SplatMaterial',
@@ -155,6 +156,7 @@ class GSplatInstance {
             this._material = value;
             this._material.setDefine('{GSPLAT_INSTANCE_SIZE}', String(GSplatResourceBase.instanceSize));
             this.setMaterialOrderData(this._material);
+            this._material.setParameter('alphaCull', 1.0 / 255.0);
 
             if (this.meshInstance) {
                 this.meshInstance.material = value;
@@ -180,6 +182,7 @@ class GSplatInstance {
         material.setParameter('numSplats', 0);
         this.setMaterialOrderData(material);
         material.setParameter('alphaClip', 0.3);
+        material.setParameter('alphaCull', 1.0 / 255.0);
         material.setParameter('minPixelSize', 2.0);
         material.setDefine(`DITHER_${options.dither ? 'BLUENOISE' : 'NONE'}`, '');
         material.cull = CULLFACE_NONE;

--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -89,7 +89,7 @@ class GSplatInstance {
             this._material = options.material;
             this._material.setDefine('{GSPLAT_INSTANCE_SIZE}', String(GSplatResourceBase.instanceSize));
             this.setMaterialOrderData(this._material);
-            this._material.setParameter('alphaCull', 1.0 / 255.0);
+            this._material.setParameter('alphaClipForward', 1.0 / 255.0);
         } else {
             this._material = new ShaderMaterial({
                 uniqueName: 'SplatMaterial',
@@ -156,7 +156,7 @@ class GSplatInstance {
             this._material = value;
             this._material.setDefine('{GSPLAT_INSTANCE_SIZE}', String(GSplatResourceBase.instanceSize));
             this.setMaterialOrderData(this._material);
-            this._material.setParameter('alphaCull', 1.0 / 255.0);
+            this._material.setParameter('alphaClipForward', 1.0 / 255.0);
 
             if (this.meshInstance) {
                 this.meshInstance.material = value;
@@ -182,7 +182,7 @@ class GSplatInstance {
         material.setParameter('numSplats', 0);
         this.setMaterialOrderData(material);
         material.setParameter('alphaClip', 0.3);
-        material.setParameter('alphaCull', 1.0 / 255.0);
+        material.setParameter('alphaClipForward', 1.0 / 255.0);
         material.setParameter('minPixelSize', 2.0);
         material.setDefine(`DITHER_${options.dither ? 'BLUENOISE' : 'NONE'}`, '');
         material.cull = CULLFACE_NONE;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
@@ -15,6 +15,10 @@ export default /* glsl */`
     #include "floatAsUintPS"
 #endif
 
+#if !defined(SHADOW_PASS) && !defined(PICK_PASS) && !defined(PREPASS_PASS)
+    uniform float alphaCull;
+#endif
+
 varying mediump vec2 gaussianUV;
 varying mediump vec4 gaussianColor;
 
@@ -69,7 +73,7 @@ void main(void) {
         gl_FragColor = float2vec4(vLinearDepth);
 
     #else
-        if (alpha < 1.0 / 255.0) {
+        if (alpha < alphaCull) {
             discard;
         }
 

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
@@ -16,7 +16,7 @@ export default /* glsl */`
 #endif
 
 #if !defined(SHADOW_PASS) && !defined(PICK_PASS) && !defined(PREPASS_PASS)
-    uniform float alphaCull;
+    uniform float alphaClipForward;
 #endif
 
 varying mediump vec2 gaussianUV;
@@ -73,7 +73,7 @@ void main(void) {
         gl_FragColor = float2vec4(vLinearDepth);
 
     #else
-        if (alpha < alphaCull) {
+        if (alpha < alphaClipForward) {
             discard;
         }
 

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
@@ -80,8 +80,13 @@ void main(void) {
 
     modifySplatColor(modelCenter, clr);
 
-    // discard splats with alpha too low to contribute any visible pixel
-    if (clr.w <= alphaCull) {
+    // discard splats with alpha too low to contribute any visible pixel (threshold matches frag pass)
+    #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
+        float alphaClipValue = alphaClip;
+    #else
+        float alphaClipValue = alphaClipForward;
+    #endif
+    if (clr.w <= alphaClipValue) {
         gl_Position = discardVec;
         return;
     }

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
@@ -81,7 +81,7 @@ void main(void) {
     modifySplatColor(modelCenter, clr);
 
     // discard splats with alpha too low to contribute any visible pixel
-    if (255.0 * clr.w <= 1.0) {
+    if (clr.w <= alphaCull) {
         gl_Position = discardVec;
         return;
     }

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCommon.js
@@ -12,11 +12,20 @@ export default /* glsl */`
 #include "gsplatCornerVS"
 #include "gsplatOutputVS"
 
-uniform float alphaCull;
+#if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
+uniform float alphaClip;
+#else
+uniform float alphaClipForward;
+#endif
 
-// modify the gaussian corner so it excludes gaussian regions below alphaCull (forward pass)
+// modify the gaussian corner; uses alphaClip (non-forward) or alphaClipForward (forward) to match frag
 void clipCorner(inout SplatCorner corner, float alpha) {
-    float clip = min(1.0, sqrt(max(0.0, log(alpha / alphaCull))) * 0.5);
+    #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
+        float alphaClipValue = alphaClip;
+    #else
+        float alphaClipValue = alphaClipForward;
+    #endif
+    float clip = min(1.0, sqrt(max(0.0, log(alpha / alphaClipValue))) * 0.5);
     corner.offset *= clip;
     corner.uv *= clip;
 }

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatCommon.js
@@ -12,9 +12,11 @@ export default /* glsl */`
 #include "gsplatCornerVS"
 #include "gsplatOutputVS"
 
-// modify the gaussian corner so it excludes gaussian regions with alpha less than 1/255
+uniform float alphaCull;
+
+// modify the gaussian corner so it excludes gaussian regions below alphaCull (forward pass)
 void clipCorner(inout SplatCorner corner, float alpha) {
-    float clip = min(1.0, sqrt(log(255.0 * alpha)) * 0.5);
+    float clip = min(1.0, sqrt(max(0.0, log(alpha / alphaCull))) * 0.5);
     corner.offset *= clip;
     corner.uv *= clip;
 }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
@@ -16,7 +16,7 @@ export default /* wgsl */`
 #endif
 
 #if !defined(SHADOW_PASS) && !defined(PICK_PASS) && !defined(PREPASS_PASS)
-    uniform alphaCull: f32;
+    uniform alphaClipForward: f32;
 #endif
 
 const EXP4: half = exp(half(-4.0));
@@ -80,7 +80,7 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
 
     #else
 
-        if (alpha < half(uniform.alphaCull)) {
+        if (alpha < half(uniform.alphaClipForward)) {
             discard;
             return output;
         }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
@@ -15,6 +15,10 @@ export default /* wgsl */`
     #include "floatAsUintPS"
 #endif
 
+#if !defined(SHADOW_PASS) && !defined(PICK_PASS) && !defined(PREPASS_PASS)
+    uniform alphaCull: f32;
+#endif
+
 const EXP4: half = exp(half(-4.0));
 const INV_EXP4: half = half(1.0) / (half(1.0) - EXP4);
 
@@ -76,7 +80,7 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
 
     #else
 
-        if (alpha < half(1.0 / 255.0)) {
+        if (alpha < half(uniform.alphaCull)) {
             discard;
             return output;
         }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
@@ -88,7 +88,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     clr = half4(clrF32);
 
     // discard splats with alpha too low to contribute any visible pixel
-    if (half(255.0) * clr.w <= half(1.0)) {
+    if (clr.w <= half(uniform.alphaCull)) {
         output.position = discardVec;
         return output;
     }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
@@ -87,8 +87,13 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     modifySplatColor(modelCenter, &clrF32);
     clr = half4(clrF32);
 
-    // discard splats with alpha too low to contribute any visible pixel
-    if (clr.w <= half(uniform.alphaCull)) {
+    // discard splats with alpha too low (threshold matches fragment pass)
+    #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
+        let alphaClipValue = half(uniform.alphaClip);
+    #else
+        let alphaClipValue = half(uniform.alphaClipForward);
+    #endif
+    if (clr.w <= alphaClipValue) {
         output.position = discardVec;
         return output;
     }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCommon.js
@@ -12,9 +12,11 @@ export default /* wgsl */`
 #include "gsplatCornerVS"
 #include "gsplatOutputVS"
 
-// modify the gaussian corner so it excludes gaussian regions with alpha less than 1/255
+uniform alphaCull: f32;
+
+// modify the gaussian corner so it excludes gaussian regions below alphaCull (forward pass)
 fn clipCorner(corner: ptr<function, SplatCorner>, alpha: half) {
-    let clip = min(half(1.0), sqrt(log(half(255.0) * alpha)) * half(0.5));
+    let clip = min(half(1.0), sqrt(max(half(0.0), log(alpha / half(uniform.alphaCull)))) * half(0.5));
     corner.offset = corner.offset * f32(clip);
     corner.uv = corner.uv * clip;
 }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCommon.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCommon.js
@@ -12,11 +12,20 @@ export default /* wgsl */`
 #include "gsplatCornerVS"
 #include "gsplatOutputVS"
 
-uniform alphaCull: f32;
+#if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
+uniform alphaClip: f32;
+#else
+uniform alphaClipForward: f32;
+#endif
 
-// modify the gaussian corner so it excludes gaussian regions below alphaCull (forward pass)
+// modify the gaussian corner; uses alphaClip (non-forward) or alphaClipForward (forward) to match frag
 fn clipCorner(corner: ptr<function, SplatCorner>, alpha: half) {
-    let clip = min(half(1.0), sqrt(max(half(0.0), log(alpha / half(uniform.alphaCull)))) * half(0.5));
+    #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
+        let alphaClipValue = half(uniform.alphaClip);
+    #else
+        let alphaClipValue = half(uniform.alphaClipForward);
+    #endif
+    let clip = min(half(1.0), sqrt(max(half(0.0), log(alpha / alphaClipValue))) * half(0.5));
     corner.offset = corner.offset * f32(clip);
     corner.uv = corner.uv * clip;
 }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
@@ -33,6 +33,9 @@ uniform viewport_size: vec4f;
 // renderer (see GSplatHybridRenderer).
 uniform clipToViewZ: vec4f;
 
+// Forward-pass opacity floor (scene.gsplat.alphaCull); matches gsplatCommonVS clipCorner.
+uniform alphaCull: f32;
+
 // Globally sorted indices into projCache (output of the radix sort).
 var<storage, read> sortedIndices: array<u32>;
 
@@ -111,7 +114,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     // clipCorner: shrink the quad to exclude near-zero alpha regions. Mirrors the
     // helper in gsplatCommonVS (kept inline to avoid pulling in the full gsplatCommonVS).
     let cornerUV = vec2f(vertex_position.xy);
-    let clip = min(half(1.0), sqrt(log(half(255.0) * alpha)) * half(0.5));
+    let clip = min(half(1.0), sqrt(max(half(0.0), log(alpha / half(uniform.alphaCull)))) * half(0.5));
     let cornerClipped = cornerUV * f32(clip);
 
     // Convert pixel-space offset into clip-space. proj.w is the real clipPos.w,

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
@@ -33,8 +33,11 @@ uniform viewport_size: vec4f;
 // renderer (see GSplatHybridRenderer).
 uniform clipToViewZ: vec4f;
 
-// Forward-pass opacity floor (scene.gsplat.alphaCull); matches gsplatCommonVS clipCorner.
-uniform alphaCull: f32;
+#if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
+    uniform alphaClip: f32;
+#else
+    uniform alphaClipForward: f32;
+#endif
 
 // Globally sorted indices into projCache (output of the radix sort).
 var<storage, read> sortedIndices: array<u32>;
@@ -111,10 +114,14 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
         var clr: half4 = half4(half(rg.x), half(rg.y), half(ba.x), alpha);
     #endif
 
-    // clipCorner: shrink the quad to exclude near-zero alpha regions. Mirrors the
-    // helper in gsplatCommonVS (kept inline to avoid pulling in the full gsplatCommonVS).
+    // clipCorner: shrink the quad to exclude near-zero alpha regions (matches gsplatCommonVS per-pass threshold).
     let cornerUV = vec2f(vertex_position.xy);
-    let clip = min(half(1.0), sqrt(max(half(0.0), log(alpha / half(uniform.alphaCull)))) * half(0.5));
+    #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
+        let alphaClipValue = half(uniform.alphaClip);
+    #else
+        let alphaClipValue = half(uniform.alphaClipForward);
+    #endif
+    let clip = min(half(1.0), sqrt(max(half(0.0), log(alpha / alphaClipValue))) * half(0.5));
     let cornerClipped = cornerUV * f32(clip);
 
     // Convert pixel-space offset into clip-space. proj.w is the real clipPos.w,


### PR DESCRIPTION
`scene.gsplat.alphaCull` was applied only on the hybrid GPU-sort projector path. CPU-sorted raster and the tiled compute renderer still used a hardcoded ~1/255 floor. This change aligns those renderers with the same threshold (with the existing `max(1/255, alphaCull)` convention used for hybrid/compute projection).

**Changes:**
- Compute local renderer: non-pick dispatches pass `max(ALPHA_VISIBILITY_THRESHOLD, alphaCull)` into tile-count / raster `alphaClip` uniforms (same rule as hybrid sort).
- CPU raster (GLSL/WGSL): forward pass discards using `alphaCull`; `clipCorner` and vertex early-out use `alphaCull`; guard `sqrt(log(...))` when opacity is at or below the threshold.
- Hybrid raster vertex (`gsplatHybrid`): `alphaCull` uniform for quad shrink; `frameUpdate` syncs `alphaCull` on forward and pick materials.
- `ALPHA_VISIBILITY_THRESHOLD` exported from `gsplat-unified/constants.js`; `gsplat-manager` imports it instead of a local constant.

**Public API:** No changes — existing `GSplatParams#alphaCull` behavior now affects CPU raster and compute renderer paths consistently with hybrid GPU sort.

**Performance:** Raising `alphaCull` can reduce work on compute and CPU raster (fewer splats / smaller quads); lowering it preserves more translucent splats.