### PR TITLE
feat: Add Scene#gsplatCentersEnabled opt-out for gsplat CPU centers

### DIFF
--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -589,6 +589,8 @@ class PlyParser {
      * @param {Asset} asset - Container asset.
      */
     async load(url, callback, asset) {
+        const gsplatCentersEnabledAtLoad = this.app.scene?.gsplatCentersEnabled !== false;
+
         try {
             // either use the fetch request passed in by the application or initiate it ourselves
             const response = await (asset.file?.contents ?? fetch(url.load));
@@ -620,9 +622,10 @@ class PlyParser {
                 }
 
                 // construct the resource
+                const prepareCenters = gsplatCentersEnabledAtLoad;
                 const resource = (data.isCompressed && !asset.data.decompress) ?
-                    new GSplatCompressedResource(this.app.graphicsDevice, data) :
-                    new GSplatResource(this.app.graphicsDevice, data.isCompressed ? data.decompress() : data);
+                    new GSplatCompressedResource(this.app.graphicsDevice, data, { prepareCenters }) :
+                    new GSplatResource(this.app.graphicsDevice, data.isCompressed ? data.decompress() : data, { prepareCenters });
 
                 callback(null, resource);
             }

--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -165,6 +165,8 @@ class SogBundleParser {
      * @param {Asset} asset - Container asset.
      */
     async load(url, callback, asset) {
+        const gsplatCentersEnabledAtLoad = this.app.scene?.gsplatCentersEnabled !== false;
+
         try {
             const arrayBuffer = await downloadArrayBuffer(url, asset);
 
@@ -271,12 +273,15 @@ class SogBundleParser {
             if (!decompress) {
                 // no need to prepare gpu data if decompressing
                 data.prepareCodebook();
-                await data.prepareGpuData();
+                if (gsplatCentersEnabledAtLoad) {
+                    await data.prepareGpuData();
+                }
             }
 
+            const prepareCenters = gsplatCentersEnabledAtLoad;
             const resource = decompress ?
-                new GSplatResource(this.app.graphicsDevice, await data.decompress()) :
-                new GSplatSogResource(this.app.graphicsDevice, data);
+                new GSplatResource(this.app.graphicsDevice, await data.decompress(), { prepareCenters }) :
+                new GSplatSogResource(this.app.graphicsDevice, data, { prepareCenters });
 
             callback(null, resource);
         } catch (err) {

--- a/src/framework/parsers/sog.js
+++ b/src/framework/parsers/sog.js
@@ -120,6 +120,8 @@ class SogParser {
     }
 
     async loadTextures(url, callback, asset, meta) {
+        const gsplatCentersEnabledAtLoad = this.app.scene?.gsplatCentersEnabled !== false;
+
         // transform meta to latest shape
         if (meta.version !== 2) {
             Debug.deprecated('Loading SOG v1 data which is deprecated. Please recompress your scene with latest tools.');
@@ -217,7 +219,9 @@ class SogParser {
 
             // no need to prepare gpu data if decompressing
             data.prepareCodebook();
-            await data.prepareGpuData();
+            if (gsplatCentersEnabledAtLoad) {
+                await data.prepareGpuData();
+            }
         }
 
         if (this._shouldAbort(asset, unloaded)) {
@@ -226,9 +230,10 @@ class SogParser {
             return;
         }
 
+        const prepareCenters = gsplatCentersEnabledAtLoad;
         const resource = decompress ?
-            new GSplatResource(this.app.graphicsDevice, await data.decompress()) :
-            new GSplatSogResource(this.app.graphicsDevice, data);
+            new GSplatResource(this.app.graphicsDevice, await data.decompress(), { prepareCenters }) :
+            new GSplatSogResource(this.app.graphicsDevice, data, { prepareCenters });
 
         if (this._shouldAbort(asset, unloaded)) {
             resource.destroy();

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -147,6 +147,14 @@ class GSplatManager {
     activeRenderer;
 
     /**
+     * When true, {@link updateWorldState} must rebuild the splat set.
+     *
+     * @type {boolean}
+     * @private
+     */
+    _worldStateDirty = false;
+
+    /**
      * CPU-based sorter (when not using GPU sorting).
      *
      * @type {GSplatUnifiedSorter|null}
@@ -607,6 +615,10 @@ class GSplatManager {
         const requested = this.scene.gsplat.currentRenderer;
         if (requested === this.activeRenderer) return;
 
+        // CPU raster sort vs GPU paths differ on which placements need centers; force a full
+        // updateWorldState rebuild so splats[] matches the new sorter (see hasCenters gates).
+        this._worldStateDirty = true;
+
         this.destroyGpuSorting();
         this.destroyCpuSorting();
         this.renderer.destroy();
@@ -693,13 +705,17 @@ class GSplatManager {
 
         // Recreate world state if there are changes
         const placementsChanged = this.layerPlacementsDirty;
-        const worldChanged = placementsChanged || stateChanged || this.worldStates.size === 0;
+        const worldChanged = placementsChanged || stateChanged || this.worldStates.size === 0 || this._worldStateDirty;
         if (worldChanged) {
             this.lastWorldStateVersion++;
             const splats = [];
 
             // add standalone splats
             for (const p of this.layerPlacements) {
+                if (this.cpuSorter && !p.resource.hasCenters) {
+                    Debug.warnOnce(`Skipping gsplat resource id ${p.resource.id} on the CPU sorting path — no centers buffer. See Scene#gsplatCentersEnabled.`);
+                    continue;
+                }
                 p.ensureInstanceStreams(this.device);
                 const splatInfo = new GSplatInfo(this.device, p.resource, p, p.consumeRenderDirty.bind(p));
                 splats.push(splatInfo);
@@ -709,6 +725,11 @@ class GSplatManager {
             for (const [, inst] of this.octreeInstances) {
                 inst.activePlacements.forEach((p) => {
                     if (p.resource) {
+                        const leafResource = /** @type {GSplatResourceBase} */ (p.resource);
+                        if (this.cpuSorter && !leafResource.hasCenters) {
+                            Debug.warnOnce(`Skipping gsplat resource id ${leafResource.id} on the CPU sorting path — no centers buffer. See Scene#gsplatCentersEnabled.`);
+                            return;
+                        }
                         p.ensureInstanceStreams(this.device);
                         const octreeNodes = p.intervals.size > 0 ? inst.octree.nodes : null;
                         const nodeInfos = octreeNodes ? inst.nodeInfos : null;
@@ -792,6 +813,8 @@ class GSplatManager {
 
             this.layerPlacementsDirty = false;
             this._placementSetChanged = false;
+
+            this._worldStateDirty = false;
 
             // New world state requires sorting
             this.sortNeeded = true;

--- a/src/scene/gsplat/gsplat-compressed-resource.js
+++ b/src/scene/gsplat/gsplat-compressed-resource.js
@@ -23,9 +23,10 @@ class GSplatCompressedResource extends GSplatResourceBase {
     /**
      * @param {GraphicsDevice} device - The graphics device.
      * @param {GSplatCompressedData} gsplatData - The splat data.
+     * @param {object} [options] - Passed to {@link GSplatResourceBase} constructor.
      */
-    constructor(device, gsplatData) {
-        super(device, gsplatData);
+    constructor(device, gsplatData, options = {}) {
+        super(device, gsplatData, options);
 
         const { chunkData, chunkSize, numChunks, numSplats, vertexData, shBands } = gsplatData;
 

--- a/src/scene/gsplat/gsplat-container.js
+++ b/src/scene/gsplat/gsplat-container.js
@@ -28,8 +28,10 @@ import { GSplatResourceBase } from './gsplat-resource-base.js';
  * // pixels is Float32Array, fill with [x, y, z, 0, x, y, z, 0, ...]
  * centerTex.unlock();
  *
- * // Set bounding box and centers (required for culling/sorting)
+ * // Set bounding box
  * container.aabb = new pc.BoundingBox();
+ *
+ * // fill centers only if you need CPU sorting or non-unified rendering
  * container.centers.set([x0, y0, z0, x1, y1, z1, ...]);  // xyz per splat
  *
  * // Add to scene
@@ -93,17 +95,15 @@ class GSplatContainer extends GSplatResourceBase {
     constructor(device, maxSplats, format) {
         Debug.assert(format);
 
-        // Pre-allocate data before super() since gsplatData callbacks need it
-        const centers = new Float32Array(maxSplats * 3);
         const aabb = new BoundingBox();
 
         // Create minimal gsplatData interface for base class
         const gsplatData = {
             numSplats: maxSplats,
-            getCenters: () => centers,
+            getCenters: () => null,
             calcAabb: box => box.copy(aabb)
         };
-        super(device, gsplatData);
+        super(device, gsplatData, { prepareCenters: false });
 
         this._format = format;
         this._maxSplats = maxSplats;
@@ -111,6 +111,24 @@ class GSplatContainer extends GSplatResourceBase {
 
         // Use streams to create textures from format
         this.streams.init(this._format, maxSplats);
+    }
+
+    /**
+     * CPU-side xyz per splat. Allocated lazily on first read; GPU-only unified rendering can omit
+     * touching this property to avoid the extra buffer.
+     *
+     * @type {Float32Array}
+     */
+    set centers(value) {
+        this._centers = value;
+    }
+
+    get centers() {
+        if (this._centers === null) {
+            this._centers = new Float32Array(this._maxSplats * 3);
+            this.centersVersion++;
+        }
+        return /** @type {Float32Array} */ (this._centers);
     }
 
     /**

--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -114,12 +114,16 @@ class GSplatInstance {
         // only start rendering the splat after we've received the splat order data
         this.meshInstance.instancingCount = 0;
 
-        const centers = resource.centers.slice();
-        const chunks = resource.chunks?.slice();
+        if (resource.hasCenters) {
+            const centers = resource.centers.slice();
+            const chunks = resource.chunks?.slice();
 
-        const orderTarget = this.orderBuffer ?? this.orderTexture;
-        this.sorter = new GSplatSorter(device, options.scene);
-        this.sorter.init(orderTarget, numSplats, centers, chunks);
+            const orderTarget = this.orderBuffer ?? this.orderTexture;
+            this.sorter = new GSplatSorter(device, options.scene);
+            this.sorter.init(orderTarget, numSplats, centers, chunks);
+        } else {
+            Debug.warnOnce(`Skipping gsplat resource id ${resource.id} on the non-unified rendering path — no centers buffer. Scene#gsplatCentersEnabled needs to be true.`);
+        }
 
         this.setHighQualitySH(options.highQualitySH ?? false);
     }

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -37,8 +37,34 @@ class GSplatResourceBase {
      */
     gsplatData;
 
-    /** @type {Float32Array} */
-    centers;
+    /**
+     * CPU-side splat center positions (xyz per splat), or null when not built for this resource.
+     *
+     * @type {Float32Array|null}
+     */
+    set centers(value) {
+        this._centers = value;
+    }
+
+    get centers() {
+        return this._centers;
+    }
+
+    /**
+     * True when a centers buffer has been allocated ({@link GSplatResourceBase#centers} is non-null).
+     * Reads internal storage only so checks do not trigger lazy allocation in {@link GSplatContainer}.
+     *
+     * @type {boolean}
+     */
+    get hasCenters() {
+        return this._centers != null;
+    }
+
+    /**
+     * @type {Float32Array|null}
+     * @protected
+     */
+    _centers = null;
 
     /**
      * Version counter for centers array changes. Remains 0 for static resources.
@@ -105,12 +131,24 @@ class GSplatResourceBase {
     /** @private */
     _meshRefCount = 0;
 
-    constructor(device, gsplatData) {
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {object} gsplatData - Data source with getCenters(), calcAabb(), numSplats, etc.
+     * @param {object} [options] - Construction options.
+     * @param {boolean} [options.prepareCenters] - When omitted or true, calls gsplatData.getCenters()
+     * and stores the result. When false, {@link GSplatResourceBase#centers} stays null until set or
+     * materialized by a subclass (e.g. lazy allocation in GSplatContainer).
+     */
+    constructor(device, gsplatData, options = {}) {
         this.device = device;
         this.gsplatData = gsplatData;
         this.streams = new GSplatStreams(device);
 
-        this.centers = gsplatData.getCenters();
+        if (options.prepareCenters !== false) {
+            this._centers = gsplatData.getCenters();
+        } else {
+            this._centers = null;
+        }
 
         this.aabb = new BoundingBox();
         gsplatData.calcAabb(this.aabb);

--- a/src/scene/gsplat/gsplat-resource.js
+++ b/src/scene/gsplat/gsplat-resource.js
@@ -28,9 +28,10 @@ class GSplatResource extends GSplatResourceBase {
     /**
      * @param {GraphicsDevice} device - The graphics device.
      * @param {GSplatData} gsplatData - The splat data.
+     * @param {object} [options] - Passed to {@link GSplatResourceBase} constructor.
      */
-    constructor(device, gsplatData) {
-        super(device, gsplatData);
+    constructor(device, gsplatData, options = {}) {
+        super(device, gsplatData, options);
 
         const numSplats = gsplatData.numSplats;
 

--- a/src/scene/gsplat/gsplat-sog-resource.js
+++ b/src/scene/gsplat/gsplat-sog-resource.js
@@ -5,11 +5,17 @@ import { GSplatFormat } from './gsplat-format.js';
 
 /**
  * @import { GSplatSogData } from './gsplat-sog-data.js'
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  */
 
 class GSplatSogResource extends GSplatResourceBase {
-    constructor(device, gsplatData) {
-        super(device, gsplatData);
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {GSplatSogData} gsplatData - The splat data.
+     * @param {object} [options] - Passed to {@link GSplatResourceBase} constructor.
+     */
+    constructor(device, gsplatData, options = {}) {
+        super(device, gsplatData, options);
 
         const { meta, means_l } = gsplatData;
         const isV2 = meta.version === 2;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -316,6 +316,18 @@ class Scene extends EventHandler {
             this.updateShaders = true;
         });
 
+        /**
+         * When true (default), loaded gsplat assets include the extra data needed for
+         * {@link GSPLAT_RENDERER_RASTER_CPU_SORT} and non-unified gsplat rendering. Set to false
+         * **before** you start loading a gsplat asset (e.g. before {@link AppBase#assets}.load) to
+         * use less memory if you only need unified rendering with GPU sorting. Each load uses the
+         * value in effect when that load begins.
+         *
+         * @type {boolean}
+         * @ignore
+         */
+        this.gsplatCentersEnabled = true;
+
         // gsplat params
         this._gsplatParams = new GSplatParams(this.device);
 


### PR DESCRIPTION
Adds an opt-out so loaded gsplat assets can omit the CPU-side centers buffer when only unified GPU sorting (or other paths that do not need it) is required, reducing memory for large SOG/PLY loads.

**Changes:**
- New `Scene#gsplatCentersEnabled` (default `true`) with JSDoc; each parser load snapshots the flag before its first `await` and passes `prepareCenters` into resources.
- `GSplatResourceBase`: `_centers` storage with `centers` accessor, optional `prepareCenters` in constructor, and `hasCenters` (non-null check without triggering container lazy `centers`).
- File-backed resources forward options; SOG parsers skip `prepareGpuData` when centers are disabled at load.
- `GSplatContainer`: lazy `centers` allocation via `super(..., { prepareCenters: false })`.
- Unified `GSplatManager`: when CPU sorting is active, omit placements without centers; `_worldStateDirty` on renderer mode change; clearer `warnOnce` messages.
- Non-unified `GSplatInstance`: gate on `hasCenters`, matching warning style.

**Hidden API:**
- `Scene#gsplatCentersEnabled` — `boolean`, default `true`. Set to `false` before starting a gsplat asset load to omit centers data for that load (see JSDoc for `GSPLAT_RENDERER_RASTER_CPU_SORT` and timing).

**Impact**
- this saves around 114MB for 10M splats.