### PR TITLE
fix: Register StorageBuffer for WebGPU device lose/restore

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -784,9 +784,9 @@ class GraphicsDevice extends EventHandler {
         this.initializeRenderState();
         this.initializeContextCaches();
 
-        // Recreate buffer objects and reupload buffer data to the GPU
+        // Recreate buffer GPU objects; vertex/index reupload from CPU storage, storage buffers empty
         for (const buffer of this.buffers) {
-            buffer.unlock();
+            buffer.restoreContext();
         }
 
         this.gpuProfiler?.restoreContext?.();

--- a/src/platform/graphics/index-buffer.js
+++ b/src/platform/graphics/index-buffer.js
@@ -113,6 +113,16 @@ class IndexBuffer {
     }
 
     /**
+     * Called when the rendering context is restored. Recreates the GPU buffer and uploads from
+     * {@link IndexBuffer#lock|lock} storage.
+     *
+     * @ignore
+     */
+    restoreContext() {
+        this.unlock();
+    }
+
+    /**
      * Returns the data format of the specified index buffer.
      *
      * @returns {number} The data format of the specified index buffer. Can be:

--- a/src/platform/graphics/storage-buffer.js
+++ b/src/platform/graphics/storage-buffer.js
@@ -13,6 +13,10 @@ let id = 0;
  * used to provide data for compute shader, and to store the result of the computation.
  * Note that this class is only supported on the WebGPU platform.
  *
+ * After a graphics device is lost and restored, the GPU backing for a storage buffer is
+ * recreated at the same byte size but its contents are undefined until you write to it again or
+ * repopulate it via compute.
+ *
  * @category Graphics
  */
 class StorageBuffer {
@@ -39,10 +43,7 @@ class StorageBuffer {
         this.impl = graphicsDevice.createBufferImpl(usage);
         this.impl.allocate(graphicsDevice, byteSize);
 
-        // Note: not registered in device.buffers — storage buffer contents are not
-        // recoverable on device-lost (no CPU-side shadow, may be GPU-written), so
-        // they don't participate in the engine's auto lose/restore iteration.
-        // Consumers handling device-lost must destroy() and recreate storage buffers.
+        graphicsDevice.buffers.add(this);
 
         this.adjustVramSizeTracking(graphicsDevice._vram, this.byteSize);
     }
@@ -51,8 +52,29 @@ class StorageBuffer {
      * Frees resources associated with this storage buffer.
      */
     destroy() {
-        this.adjustVramSizeTracking(this.device._vram, -this.byteSize);
-        this.impl.destroy(this.device);
+        const device = this.device;
+        device.buffers.delete(this);
+        this.impl.destroy(device);
+        this.adjustVramSizeTracking(device._vram, -this.byteSize);
+    }
+
+    /**
+     * Called when the rendering context was lost. It releases the GPU buffer handle.
+     *
+     * @ignore
+     */
+    loseContext() {
+        this.impl.loseContext();
+    }
+
+    /**
+     * Called when the rendering context is restored. Recreates an empty GPU buffer of the same
+     * size; contents are not restored from CPU memory.
+     *
+     * @ignore
+     */
+    restoreContext() {
+        this.impl.allocate(this.device, this.byteSize);
     }
 
     adjustVramSizeTracking(vram, size) {

--- a/src/platform/graphics/vertex-buffer.js
+++ b/src/platform/graphics/vertex-buffer.js
@@ -92,6 +92,16 @@ class VertexBuffer {
     }
 
     /**
+     * Called when the rendering context is restored. Recreates the GPU buffer and uploads from
+     * {@link VertexBuffer#lock|lock} storage.
+     *
+     * @ignore
+     */
+    restoreContext() {
+        this.unlock();
+    }
+
+    /**
      * Returns the data format of the specified vertex buffer.
      *
      * @returns {VertexFormat} The data format of the specified vertex buffer.

--- a/src/platform/graphics/webgpu/webgpu-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-buffer.js
@@ -37,6 +37,7 @@ class WebgpuBuffer {
     }
 
     loseContext() {
+        this.buffer = null;
     }
 
     allocate(device, size) {
@@ -45,6 +46,14 @@ class WebgpuBuffer {
             size,
             usage: this.usageFlags
         });
+
+        DebugHelper.setLabel(this.buffer,
+            this.usageFlags & GPUBufferUsage.VERTEX ? 'VertexBuffer' :
+                this.usageFlags & GPUBufferUsage.INDEX ? 'IndexBuffer' :
+                    this.usageFlags & GPUBufferUsage.UNIFORM ? 'UniformBuffer' :
+                        this.usageFlags & GPUBufferUsage.STORAGE ? 'StorageBuffer' :
+                            ''
+        );
     }
 
     /**
@@ -65,15 +74,6 @@ class WebgpuBuffer {
 
             this.usageFlags |= GPUBufferUsage.COPY_DST;
             this.allocate(device, size);
-
-            DebugHelper.setLabel(this.buffer,
-                this.usageFlags & GPUBufferUsage.VERTEX ? 'VertexBuffer' :
-                    this.usageFlags & GPUBufferUsage.INDEX ? 'IndexBuffer' :
-                        this.usageFlags & GPUBufferUsage.UNIFORM ? 'UniformBuffer' :
-                            this.usageFlags & GPUBufferUsage.STORAGE ? 'StorageBuffer' :
-                                ''
-            );
-
 
             // mappedAtCreation path - this could be used when the data is provided
 


### PR DESCRIPTION
WebGPU device loss previously either crashed when iterating `GraphicsDevice.buffers` (if `StorageBuffer` was tracked without `loseContext`/`unlock`) or skipped storage buffers entirely, leaving stale `GPUBuffer` references after `requestDevice()`. This change registers storage buffers on the device and runs the same lose/restore path as other buffers.

**Changes:**
- Add `StorageBuffer` to `GraphicsDevice.buffers` on construction; remove on `destroy()`.
- Implement `StorageBuffer` `loseContext()` / `restoreContext()` (GPU backing recreated at the same byte size; contents are undefined until rewritten or recomputed). Document that in the class JSDoc.
- `GraphicsDevice.restoreContext()` calls `buffer.restoreContext()` instead of `unlock()`.
- `VertexBuffer` and `IndexBuffer` add `@ignore` `restoreContext()` delegating to `unlock()` so the public lock/unlock API is unchanged.
- `WebgpuBuffer`: `loseContext()` clears the buffer reference only (aligned with `WebglBuffer`); `allocate()` applies the GPU debug label so staging and storage paths stay consistent.

Supersedes the approach of excluding `StorageBuffer` from `device.buffers` (e.g. PR #8690).