### PR TITLE
refactor(scrollbar): tighten ScrollbarComponent internals

### DIFF
--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -182,8 +182,8 @@ class ScrollbarComponent extends Component {
     }
 
     /**
-     * Sets the entity to be used as the scrollbar handle. This entity must have a
-     * {@link ScrollbarComponent}.
+     * Sets the entity to be used as the scrollbar handle. This entity must have an
+     * {@link ElementComponent} (with `useInput: true` for the handle to be draggable).
      *
      * @type {Entity|string|null}
      */

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -118,8 +118,12 @@ class ScrollbarComponent extends Component {
 
         this._orientation = arg;
 
+        // ElementDragHelper captures its axis at construction, so an existing helper
+        // must be rebuilt to keep dragging in sync with the new orientation
         if (this._handleEntity?.element) {
             this._handleEntity.element[this._getOppositeDimension()] = 0;
+            this._rebuildDragHelper();
+            this._updateHandlePositionAndSize();
         }
     }
 
@@ -253,14 +257,17 @@ class ScrollbarComponent extends Component {
 
     _onHandleElementGain() {
         this._handleEntityElementSubscribe();
+        this._rebuildDragHelper();
+        this._updateHandlePositionAndSize();
+    }
+
+    _rebuildDragHelper() {
         this._destroyDragHelper();
         this._handleDragHelper = new ElementDragHelper(this._handleEntity.element, this._getAxis());
         // ElementDragHelper defaults to enabled; mirror the component's current state so a helper
         // built while the scrollbar is disabled does not start out draggable
         this._handleDragHelper.enabled = this.enabled && this.entity.enabled;
         this._handleDragHelper.on('drag:move', this._onHandleDrag, this);
-
-        this._updateHandlePositionAndSize();
     }
 
     _onHandleElementLose() {

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -255,6 +255,9 @@ class ScrollbarComponent extends Component {
         this._handleEntityElementSubscribe();
         this._destroyDragHelper();
         this._handleDragHelper = new ElementDragHelper(this._handleEntity.element, this._getAxis());
+        // ElementDragHelper defaults to enabled; mirror the component's current state so a helper
+        // built while the scrollbar is disabled does not start out draggable
+        this._handleDragHelper.enabled = this.enabled && this.entity.enabled;
         this._handleDragHelper.on('drag:move', this._onHandleDrag, this);
 
         this._updateHandlePositionAndSize();

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -96,6 +96,12 @@ class ScrollbarComponent extends Component {
     _evtHandleEntityChanges = [];
 
     /**
+     * @type {ElementDragHelper|null}
+     * @private
+     */
+    _handleDragHelper = null;
+
+    /**
      * Sets whether the scrollbar moves horizontally or vertically. Can be:
      *
      * - {@link ORIENTATION_HORIZONTAL}: The scrollbar animates in the horizontal axis.
@@ -178,12 +184,16 @@ class ScrollbarComponent extends Component {
      * @type {Entity|string|null}
      */
     set handleEntity(arg) {
-        if (this._handleEntity === arg) {
-            return;
+        let newEntity;
+        if (arg instanceof GraphNode) {
+            newEntity = arg;
+        } else if (typeof arg === 'string') {
+            newEntity = this.system.app.getEntityFromIndex(arg) ?? null;
+        } else {
+            newEntity = null;
         }
 
-        const isString = typeof arg === 'string';
-        if (this._handleEntity && isString && this._handleEntity.getGuid() === arg) {
+        if (this._handleEntity === newEntity) {
             return;
         }
 
@@ -191,15 +201,9 @@ class ScrollbarComponent extends Component {
             this._handleEntityUnsubscribe();
         }
 
-        if (arg instanceof GraphNode) {
-            this._handleEntity = arg;
-        } else if (isString) {
-            this._handleEntity = this.system.app.getEntityFromIndex(arg) || null;
-        } else {
-            this._handleEntity = null;
-        }
+        this._handleEntity = newEntity;
 
-        if (this._handleEntity) {
+        if (newEntity) {
             this._handleEntitySubscribe();
         }
     }
@@ -235,9 +239,9 @@ class ScrollbarComponent extends Component {
 
         const handles = this._evtHandleEntityChanges;
         handles.push(element.once('beforeremove', this._onHandleElementLose, this));
-        handles.push(element.on('set:anchor', this._onSetHandleAlignment, this));
-        handles.push(element.on('set:margin', this._onSetHandleAlignment, this));
-        handles.push(element.on('set:pivot', this._onSetHandleAlignment, this));
+        handles.push(element.on('set:anchor', this._updateHandlePositionAndSize, this));
+        handles.push(element.on('set:margin', this._updateHandlePositionAndSize, this));
+        handles.push(element.on('set:pivot', this._updateHandlePositionAndSize, this));
     }
 
     _handleEntityElementUnsubscribe() {
@@ -267,22 +271,16 @@ class ScrollbarComponent extends Component {
         }
     }
 
-    _onSetHandleAlignment() {
-        this._updateHandlePositionAndSize();
-    }
-
     _updateHandlePositionAndSize() {
         const handleEntity = this._handleEntity;
-        const handleElement = handleEntity?.element;
+        if (!handleEntity) return;
 
-        if (handleEntity) {
-            const position = handleEntity.getLocalPosition();
-            position[this._getAxis()] = this._getHandlePosition();
-            handleEntity.setLocalPosition(position);
-        }
+        const position = handleEntity.getLocalPosition();
+        position[this._getAxis()] = this._getHandlePosition();
+        handleEntity.setLocalPosition(position);
 
-        if (handleElement) {
-            handleElement[this._getDimension()] = this._getHandleLength();
+        if (handleEntity.element) {
+            handleEntity.element[this._getDimension()] = this._getHandleLength();
         }
     }
 
@@ -331,23 +329,20 @@ class ScrollbarComponent extends Component {
     }
 
     _destroyDragHelper() {
-        if (this._handleDragHelper) {
-            this._handleDragHelper.destroy();
-        }
-    }
-
-    _setHandleDraggingEnabled(enabled) {
-        if (this._handleDragHelper) {
-            this._handleDragHelper.enabled = enabled;
-        }
+        this._handleDragHelper?.destroy();
+        this._handleDragHelper = null;
     }
 
     onEnable() {
-        this._setHandleDraggingEnabled(true);
+        if (this._handleDragHelper) {
+            this._handleDragHelper.enabled = true;
+        }
     }
 
     onDisable() {
-        this._setHandleDraggingEnabled(false);
+        if (this._handleDragHelper) {
+            this._handleDragHelper.enabled = false;
+        }
     }
 
     onRemove() {

--- a/test/framework/components/scrollbar/component.test.mjs
+++ b/test/framework/components/scrollbar/component.test.mjs
@@ -169,6 +169,26 @@ describe('ScrollbarComponent', function () {
             expect(handle.element.height).to.equal(heightBefore);
         });
 
+        it('rebuilds the drag helper for the new axis when orientation changes at runtime', function () {
+            const handle = new Entity();
+            handle.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+
+            const e = new Entity();
+            e.addChild(handle);
+            e.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+            e.addComponent('scrollbar', { handleEntity: handle, orientation: ORIENTATION_HORIZONTAL });
+            app.root.addChild(e);
+
+            // ElementDragHelper captures its axis at construction, so the helper must be
+            // rebuilt for the new axis when orientation flips - otherwise drags stay on the
+            // old axis and value updates can stop working
+            expect(e.scrollbar._handleDragHelper._axis).to.equal('x');
+
+            e.scrollbar.orientation = ORIENTATION_VERTICAL;
+
+            expect(e.scrollbar._handleDragHelper._axis).to.equal('y');
+        });
+
     });
 
     describe('#handleEntity', function () {

--- a/test/framework/components/scrollbar/component.test.mjs
+++ b/test/framework/components/scrollbar/component.test.mjs
@@ -210,6 +210,23 @@ describe('ScrollbarComponent', function () {
             expect(e.scrollbar.handleEntity).to.equal(null);
         });
 
+        it('does not leave a newly-built drag helper enabled when the scrollbar is disabled', function () {
+            const handle = new Entity();
+            // intentionally no element yet — adding it later triggers _onHandleElementGain and
+            // builds a fresh ElementDragHelper, which defaults to enabled = true
+
+            const e = new Entity();
+            e.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+            e.addComponent('scrollbar', { enabled: false, handleEntity: handle });
+            app.root.addChild(e);
+
+            handle.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+
+            // helper must mirror the component's disabled state, not its own default
+            expect(e.scrollbar._handleDragHelper).to.exist;
+            expect(e.scrollbar._handleDragHelper.enabled).to.equal(false);
+        });
+
         it('unsubscribes from the previous handle entity when reassigned', function () {
             const handle1 = new Entity();
             handle1.addComponent('element', { type: ELEMENTTYPE_IMAGE });


### PR DESCRIPTION
## Summary

Small follow-up cleanup to #8693, polishing the ScrollbarComponent internals while the file is fresh, plus two correctness fixes for `ElementDragHelper` lifecycle bugs that Copilot flagged on #8693 and on this PR's first commit.

### Cleanup

- Declare `_handleDragHelper` as a class field (`@type {ElementDragHelper|null}`, default `null`). It was previously implicit-via-assignment in `_onHandleElementGain`, the only piece of state on the component without a class-level declaration.
- Tighten the `handleEntity` setter: resolve the candidate entity first, then a single early-return covers both "same Entity by ref" and "same GUID-string by ref" cases. Switch `|| null` to `?? null`.
- Drop the `_onSetHandleAlignment` passthrough - bind `_updateHandlePositionAndSize` directly to the `set:anchor` / `set:margin` / `set:pivot` events on the handle element.
- Use an early return in `_updateHandlePositionAndSize`, drop the `handleElement` local.
- `_destroyDragHelper` now uses optional chaining and nulls the field after destroy.
- Inline the `_setHandleDraggingEnabled` helper into `onEnable` / `onDisable`.

### Bug fixes

- A fresh `ElementDragHelper` built in `_onHandleElementGain` now mirrors the component's current `enabled` state, instead of inheriting the helper's default `true`. Previously, attaching a handle (or its element appearing) to an already-disabled scrollbar produced a draggable helper.
- The `orientation` setter now rebuilds the drag helper (and refreshes the handle position / size) when an element is already attached. `ElementDragHelper` captures its axis at construction, so without this, flipping orientation at runtime left drags constrained to the old axis and could stop `value` updates from happening.

Both bug fixes have regression tests.

## Public API

No additions, removals, or behaviour changes.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build:types` regenerates `.d.ts` cleanly; `npm run test:types` passes
- [x] `npm test` - 1690 passing, 0 failing (18 ScrollbarComponent tests, including 2 new regression tests for the bug fixes above)
