### PR TITLE
fix: Texture#lock allocates when mip level slot is missing

### DIFF
--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -1039,7 +1039,7 @@ class Texture {
         this._lockedLevel = options.level;
 
         const levels = this.cubemap ? this._levels[options.face] : this._levels;
-        if (levels[options.level] === null) {
+        if (!levels[options.level]) {
             // allocate storage for this mip level
             const width = Math.max(1, this._width >> options.level);
             const height = Math.max(1, this._height >> options.level);


### PR DESCRIPTION
When the texture is created without `options.levels`, `_clearLevels()` only initializes mip 0 (`[null]` for 2D). Higher mip indices are `undefined`, not `null`, so the previous `=== null` check skipped allocation and `lock()` returned `undefined` (see #8659).

**Changes:**
- Treat an empty mip slot as missing using `if (!levels[options.level])` before allocating the typed array for `Texture#lock`.

Fixes #8659