### PR TITLE
feat(gsplat): expose parsed manifest on GSplatOctreeResource

### DIFF
--- a/src/scene/gsplat-unified/gsplat-octree.resource.js
+++ b/src/scene/gsplat-unified/gsplat-octree.resource.js
@@ -19,11 +19,11 @@ class GSplatOctreeResource {
     /**
      * Raw parsed manifest data, retained for consumers that read custom or extension
      * fields the octree itself does not consume (for example application-specific
-     * metadata accompanying a `lod-meta.json`).
+     * metadata accompanying a `lod-meta.json`). Cleared to `null` by {@link destroy}.
      *
-     * @type {object}
+     * @type {object|null}
      */
-    data;
+    data = null;
 
     /**
      * @param {string} assetFileUrl - The file URL of the container asset.
@@ -43,6 +43,7 @@ class GSplatOctreeResource {
     destroy() {
         this.octree?.destroy();
         this.octree = null;
+        this.data = null;
     }
 }
 

--- a/src/scene/gsplat-unified/gsplat-octree.resource.js
+++ b/src/scene/gsplat-unified/gsplat-octree.resource.js
@@ -19,7 +19,9 @@ class GSplatOctreeResource {
     /**
      * Raw parsed manifest data, retained for consumers that read custom or extension
      * fields the octree itself does not consume (for example application-specific
-     * metadata accompanying a `lod-meta.json`). Cleared to `null` by {@link destroy}.
+     * metadata accompanying a `lod-meta.json`). The `tree` field is nulled out by the
+     * constructor since {@link GSplatOctree} consumes it — access node hierarchy via
+     * {@link GSplatOctreeResource#octree} instead. Cleared to `null` by {@link destroy}.
      *
      * @type {object|null}
      */
@@ -35,6 +37,9 @@ class GSplatOctreeResource {
         this.octree.assetLoader = assetLoader;
         this.aabb.setMinMax(new Vec3(data.tree.bound.min), new Vec3(data.tree.bound.max));
         this.data = data;
+        // Tree hierarchy is fully consumed by GSplatOctree above; null it out so this
+        // retained reference doesn't keep the (typically large) tree data alive.
+        this.data.tree = null;
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-octree.resource.js
+++ b/src/scene/gsplat-unified/gsplat-octree.resource.js
@@ -21,11 +21,11 @@ class GSplatOctreeResource {
      * fields the octree itself does not consume (for example application-specific
      * metadata accompanying a `lod-meta.json`). The `tree` field is nulled out by the
      * constructor since {@link GSplatOctree} consumes it — access node hierarchy via
-     * {@link GSplatOctreeResource#octree} instead. Cleared to `null` by {@link destroy}.
+     * {@link GSplatOctreeResource#octree} instead.
      *
-     * @type {object|null}
+     * @type {object}
      */
-    data = null;
+    data;
 
     /**
      * @param {string} assetFileUrl - The file URL of the container asset.
@@ -48,7 +48,6 @@ class GSplatOctreeResource {
     destroy() {
         this.octree?.destroy();
         this.octree = null;
-        this.data = null;
     }
 }
 

--- a/src/scene/gsplat-unified/gsplat-octree.resource.js
+++ b/src/scene/gsplat-unified/gsplat-octree.resource.js
@@ -17,6 +17,15 @@ class GSplatOctreeResource {
     octree;
 
     /**
+     * Raw parsed manifest data, retained for consumers that read custom or extension
+     * fields the octree itself does not consume (for example application-specific
+     * metadata accompanying a `lod-meta.json`).
+     *
+     * @type {object}
+     */
+    data;
+
+    /**
      * @param {string} assetFileUrl - The file URL of the container asset.
      * @param {object} data - Parsed JSON data.
      * @param {object} assetLoader - Asset loader instance (framework-level object).
@@ -25,6 +34,7 @@ class GSplatOctreeResource {
         this.octree = new GSplatOctree(assetFileUrl, data);
         this.octree.assetLoader = assetLoader;
         this.aabb.setMinMax(new Vec3(data.tree.bound.min), new Vec3(data.tree.bound.max));
+        this.data = data;
     }
 
     /**


### PR DESCRIPTION
## Summary

`GSplatOctreeParser` fetches and parses the LOD manifest, then hands the parsed object to `GSplatOctreeResource`'s constructor. The resource retains the fields `GSplatOctree` consumes (`lodLevels`, `filenames`, `tree.bound`, `environment`) and **discards the rest**.

That's a problem for any consumer that ships custom/extension fields in the manifest (per-asset render settings, app-specific metadata, framing defaults, etc.) — they have no way to read those fields back without re-fetching and re-parsing the same JSON file PlayCanvas already loaded.

This PR retains a reference to the parsed object on `resource.data` so consumers can read whatever fields they wrote into the manifest.

## Diff

```diff
 class GSplatOctreeResource {
     /** @type {BoundingBox} */
     aabb = new BoundingBox();

     /**
      * Version counter for centers array changes. Always 0 for octree resources (static).
      *
      * @ignore
      */
     centersVersion = 0;

     /** @type {GSplatOctree|null} */
     octree;

+    /**
+     * Raw parsed manifest data, retained for consumers that read custom or extension
+     * fields the octree itself does not consume (for example application-specific
+     * metadata accompanying a `lod-meta.json`).
+     *
+     * @type {object}
+     */
+    data;
+
     /**
      * @param {string} assetFileUrl - The file URL of the container asset.
      * @param {object} data - Parsed JSON data.
      * @param {object} assetLoader - Asset loader instance (framework-level object).
      */
     constructor(assetFileUrl, data, assetLoader) {
         this.octree = new GSplatOctree(assetFileUrl, data);
         this.octree.assetLoader = assetLoader;
         this.aabb.setMinMax(new Vec3(data.tree.bound.min), new Vec3(data.tree.bound.max));
+        this.data = data;
     }
```

## Memory cost

The parsed JSON object already exists during construction (the constructor parameter holds it). This change just keeps a reference to the same object — no new allocation. Per-asset cost is the size of the parsed manifest, typically a few KB, dominated in scale by the octree's per-node AABB storage that the resource already retains.

If a future consumer wanted to opt out of retention they could `resource.data = null` after reading what they need.

## Use case (for context)

We carry per-asset metadata in `lod-meta.json` alongside the octree manifest — fields like `aa`, `shadow`, `lodBaseDistance`, and a `defaults` block of view/render settings — that PlayCanvas itself doesn't need to know about. Without this PR we have to fetch `lod-meta.json` ourselves before letting the asset load (so the data is available before `entity.addComponent('gsplat', { ... })`), causing a duplicate `GET` on every LOD load. With this PR we read everything from `modelAsset.resource.data` inside the asset's `ready` handler.

## No breaking changes

- Adds one class field (`data`) and one assignment.
- Default `null` until the constructor runs (matches `octree`).
- Doesn't touch any existing field, method, or signature.
- Existing consumers see no behavior difference.

## Verified locally

Built and used in production via `patch-package` on PC 2.18 with the same diff (line numbers shifted from the post-#8683 refactor); upstream PR adapted to the current `main`. Both confirmed working against multi-level LOD assets.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
