### PR TITLE
feat(gsplat): add nodeLodFilter hook for per-node LOD override

### DIFF
--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -14,7 +14,29 @@ import { NUM_BUCKETS } from './constants.js';
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { GraphNode } from '../graph-node.js'
  * @import { GSplatOctree } from './gsplat-octree.js'
+ * @import { GSplatOctreeNode } from './gsplat-octree-node.js'
  * @import { EventHandle } from '../../core/event-handle.js'
+ */
+
+/**
+ * Optional per-node LOD override callback invoked by
+ * {@link GSplatOctreeInstance#evaluateNodeLods} after the engine computes and clamps the
+ * optimal LOD index for a node. Returning a number replaces the engine-computed value;
+ * the override bypasses the `rangeMin`/`rangeMax` clamp, so consumers may route nodes to
+ * a level outside the configured range (e.g. an injected empty level for visibility
+ * culling). Returning `undefined` leaves the engine's value unchanged.
+ *
+ * @callback NodeLodFilter
+ * @param {number} nodeIndex - Index of the node within {@link GSplatOctree#nodes}.
+ * @param {GSplatOctreeNode} node - The octree node.
+ * @param {number} optimalLodIndex - Engine-computed LOD index, already clamped to the
+ *     instance's `rangeMin`..`rangeMax`.
+ * @param {Vec3} localCameraPosition - Camera position transformed to octree-local space.
+ * @param {Vec3} localCameraForward - Camera forward (normalized) in octree-local space.
+ * @param {number} actualDistance - Closest-point distance from the camera to this node's
+ *     AABB, in octree-local units (before FOV compensation).
+ * @returns {number|undefined} LOD index to use instead, or `undefined` to keep the
+ *     engine-computed value.
  */
 
 const _invWorldMat = new Mat4();
@@ -237,6 +259,17 @@ class GSplatOctreeInstance {
      * @private
      */
     _lodMinDistThresholds = null;
+
+    /**
+     * Optional per-node LOD override callback. When set, called once per node from
+     * {@link GSplatOctreeInstance#evaluateNodeLods} after the engine computes and clamps
+     * the optimal LOD index. See the {@link NodeLodFilter} typedef for callback semantics.
+     *
+     * Default `null`. When `null`, evaluation cost is a single null-check per node.
+     *
+     * @type {NodeLodFilter|null}
+     */
+    nodeLodFilter = null;
 
     /**
      * @param {GraphicsDevice} device - The graphics device.
@@ -624,6 +657,17 @@ class GSplatOctreeInstance {
             // Clamp to configured range
             if (optimalLodIndex < rangeMin) optimalLodIndex = rangeMin;
             if (optimalLodIndex > rangeMax) optimalLodIndex = rangeMax;
+
+            // Optional per-node LOD override hook. The override bypasses the range clamp
+            // above, so consumers may route nodes to a level outside rangeMin..rangeMax
+            // (e.g. an injected empty level for visibility culling).
+            if (this.nodeLodFilter) {
+                const override = this.nodeLodFilter(
+                    nodeIndex, nodes[nodeIndex], optimalLodIndex,
+                    localCameraPosition, localCameraForward, actualDistance
+                );
+                if (typeof override === 'number') optimalLodIndex = override;
+            }
 
             nodeInfo.optimalLod = optimalLodIndex;
             nodeInfo.worldDistance = fovAdjustedDistance * uniformScale;


### PR DESCRIPTION
## Summary

Adds an optional per-node LOD override callback to `GSplatOctreeInstance`. When set, it fires once per node from `evaluateNodeLods` after the engine computes and clamps `optimalLodIndex`, letting an external consumer override the engine's per-node LOD choice without monkey-patching engine internals.

Default `null` — when unset, evaluation cost is a single `if (this.nodeLodFilter)` null check per node. Fires only for opt-in consumers.

## Use case

Downstream we ship visibility-aware streaming on top of unified gsplat: per node, decide whether the chunk is back-face, outside the camera FOV cone, or beyond a distance cutoff, and if so route it to an injected empty LOD level (`fileIndex: -1`, `count: 0`) so it doesn't load files and doesn't render. With this hook the consumer code is:

```js
inst.nodeLodFilter = (nodeIndex, node, optimalLodIndex, localCamPos, localCamFwd) => {
    // ... compute visibility for `node` from local-space camera position/forward ...
    return isVisible ? optimalLodIndex : emptyLevel;
};
```

We've been doing this via a runtime monkey-patch on `inst.calculateNodeLod` (pre-2.18). When 2.18 reshaped LOD evaluation into `evaluateNodeLods` writing to `nodeInfos[i].optimalLod`, our patch became a silent no-op. Rather than chase the next refactor, an officially supported extension point here is more durable.

## Diff

Three additions, all opt-in and additive — no behavior change for existing consumers:

### 1. `@callback` typedef at file scope

```diff
+/**
+ * Optional per-node LOD override callback invoked by
+ * {@link GSplatOctreeInstance#evaluateNodeLods} after the engine computes and clamps the
+ * optimal LOD index for a node. Returning a number replaces the engine-computed value;
+ * the override bypasses the `rangeMin`/`rangeMax` clamp, so consumers may route nodes to
+ * a level outside the configured range (e.g. an injected empty level for visibility
+ * culling). Returning `undefined` leaves the engine's value unchanged.
+ *
+ * @callback NodeLodFilter
+ * @param {number} nodeIndex
+ * @param {GSplatOctreeNode} node
+ * @param {number} optimalLodIndex - already clamped to the instance's rangeMin..rangeMax
+ * @param {Vec3} localCameraPosition
+ * @param {Vec3} localCameraForward
+ * @param {number} actualDistance - closest-point distance, octree-local units
+ * @returns {number|undefined}
+ */
```

### 2. Field declaration on `GSplatOctreeInstance`

```diff
+    /**
+     * Optional per-node LOD override callback. When set, called once per node from
+     * {@link GSplatOctreeInstance#evaluateNodeLods} after the engine computes and clamps
+     * the optimal LOD index. See the {@link NodeLodFilter} typedef for callback semantics.
+     *
+     * Default `null`. When `null`, evaluation cost is a single null-check per node.
+     *
+     * @type {NodeLodFilter|null}
+     */
+    nodeLodFilter = null;
```

### 3. The hook call inside `evaluateNodeLods`

Inserted between the engine's range clamp and the assignment to `nodeInfo.optimalLod`:

```diff
             // Clamp to configured range
             if (optimalLodIndex < rangeMin) optimalLodIndex = rangeMin;
             if (optimalLodIndex > rangeMax) optimalLodIndex = rangeMax;

+            // Optional per-node LOD override hook. The override bypasses the range clamp
+            // above, so consumers may route nodes to a level outside rangeMin..rangeMax
+            // (e.g. an injected empty level for visibility culling).
+            if (this.nodeLodFilter) {
+                const override = this.nodeLodFilter(
+                    nodeIndex, nodes[nodeIndex], optimalLodIndex,
+                    localCameraPosition, localCameraForward, actualDistance
+                );
+                if (typeof override === 'number') optimalLodIndex = override;
+            }
+
             nodeInfo.optimalLod = optimalLodIndex;
             nodeInfo.worldDistance = fovAdjustedDistance * uniformScale;
```

## Performance

I'm aware this function was just optimized in #8683 / #8684, so I tried to keep it cheap when the feature isn't used:

- Default `null` means the only cost on the unset path is `if (this.nodeLodFilter)` — a property read + null check. No allocation. No extra function call. Same V8 inline cache shape as before for existing consumers.
- The `nodes[nodeIndex]` lookup that's needed to pass `node` to the callback only happens when the hook is set.
- `totalSplats` accumulation at the bottom of the loop reads `optimalLodIndex` after our override, so the splat-count totals stay accurate when the hook overrides.
- The existing `bucketScale` budget-balancer fusion (#8684) still works correctly — it reads `optimalLodIndex` after our potential override, so budget buckets are computed from the override target, not the engine-computed value. That seems right: if a consumer routes a node to a different LOD, the budget should treat it as that LOD.

If there's a perf-sensitive variant of `evaluateNodeLods` you'd prefer to keep filter-free (e.g. the budget-only path through `evaluateOptimalLods`), I can gate the hook on a flag — happy to iterate.

## Why I think this belongs in the engine

There's no public surface today for per-node LOD policy in unified gsplat. Consumers wanting visibility-aware streaming, occlusion-aware streaming, or any application-specific LOD policy currently have to monkey-patch `evaluateNodeLods` (or its predecessor) — fragile and silently breaks on engine refactors (which is exactly what happened to us across the 2.18 LOD restructuring). A small documented hook is more maintainable for both sides.

## No breaking changes

- One class field (`nodeLodFilter`), one `@callback` typedef, one `if` block in `evaluateNodeLods`.
- All additions are opt-in via callback assignment.
- Existing consumers see identical behavior.

## Verified locally

Used in production via `patch-package` on PC 2.18 with a similar diff (signature shape adjusted for the post-#8683 inlined math); upstream PR adapted to current `main`. Confirmed working against multi-level LOD assets — back-face / FOV / distance culling correctly routes invisible chunks to the empty level, splat counts and budget bucketing stay consistent.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
