### PR TITLE
feat(examples): LOD streaming Debug panel and one-frame texture trace

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
@@ -3,7 +3,7 @@
  * @returns {JSX.Element} The returned JSX Element.
  */
 export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
-    const { BindingTwoWay, LabelGroup, BooleanInput, Panel, SelectInput, SliderInput, Label, TextInput } = ReactPCUI;
+    const { BindingTwoWay, LabelGroup, BooleanInput, Button, Panel, SelectInput, SliderInput, Label, TextInput } = ReactPCUI;
     return fragment(
         jsx(
             Panel,
@@ -229,24 +229,6 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
-                { text: 'Debug' },
-                jsx(SelectInput, {
-                    type: 'number',
-                    binding: new BindingTwoWay(),
-                    link: { observer, path: 'debug' },
-                    value: observer.get('debug') ?? 0,
-                    options: [
-                        { v: 0, t: 'None' },
-                        { v: 1, t: 'LOD' },
-                        { v: 2, t: 'SH Update' },
-                        { v: 3, t: 'Heatmap' },
-                        { v: 4, t: 'AABBs' },
-                        { v: 5, t: 'Node AABBs' }
-                    ]
-                })
-            ),
-            jsx(
-                LabelGroup,
                 { text: 'LOD Preset' },
                 jsx(SelectInput, {
                     type: 'string',
@@ -295,6 +277,34 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     step: 0.1
                 })
             )
+        ),
+        jsx(
+            Panel,
+            { headerText: 'Debug' },
+            jsx(
+                LabelGroup,
+                { text: 'Debug Render' },
+                jsx(SelectInput, {
+                    type: 'number',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'debug' },
+                    value: observer.get('debug') ?? 0,
+                    options: [
+                        { v: 0, t: 'None' },
+                        { v: 1, t: 'LOD' },
+                        { v: 2, t: 'SH Update' },
+                        { v: 3, t: 'Heatmap' },
+                        { v: 4, t: 'AABBs' },
+                        { v: 5, t: 'Node AABBs' }
+                    ]
+                })
+            ),
+            jsx(Button, {
+                text: 'Log Textures',
+                onClick: () => {
+                    observer.emit('logTextures');
+                }
+            })
         ),
         jsx(
             Panel,

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -536,8 +536,17 @@ assetListLoader.load(async () => {
         });
     });
 
-    // update HUD stats every frame
+    let logTexturesRequested = false;
+    data.on('logTextures', () => {
+        logTexturesRequested = true;
+    });
+
     app.on('update', () => {
+
+        // log textures for one frame if requested
+        pc.Tracing.set(pc.TRACEID_TEXTURES, logTexturesRequested);
+        logTexturesRequested = false;
+
         data.set('data.stats.gsplats', app.stats.frame.gsplats.toLocaleString());
         const bb = app.graphicsDevice.backBufferSize;
         data.set('data.stats.resolution', `${bb.x} x ${bb.y}`);


### PR DESCRIPTION
Adds a dedicated Debug section to the LOD streaming example UI and a control to dump GPU texture memory (via `GraphicsDevice.frameStart` / `TRACEID_TEXTURES`) for a single frame.

**Changes:**
- Move the gsplat debug visualization dropdown out of Settings into a new **Debug** panel; label it **Debug Render**.
- Add **Log Textures** button that enables `pc.TRACEID_TEXTURES` for one frame using `pc.Tracing.set` synced from a request flag in `update` (then cleared), so `frameStart` runs with tracing on without a `postrender` hook.

