### PR TITLE
style: update examples sidebar styling

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -1209,9 +1209,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1226,9 +1223,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1243,9 +1237,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1260,9 +1251,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1277,9 +1265,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1294,9 +1279,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1311,9 +1293,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1328,9 +1307,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1345,9 +1321,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1362,9 +1335,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1379,9 +1349,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1396,9 +1363,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1413,9 +1377,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -51,7 +51,7 @@ body {
 }
 
 #sideBar {
-    background-color: #324447;
+    background-color: #283437;
     min-width: 280px;
     max-width: 280px;
     margin: 8px;
@@ -160,7 +160,7 @@ body {
 }
 
 #sideBar .nav-item-text {
-    color: rgb(177, 184, 186) !important;
+    color: #c7ced1 !important;
     user-select: none;
 }
 
@@ -178,7 +178,7 @@ body {
 
 #sideBar .nav-item-text a {
     text-decoration: none;
-    color: rgb(177, 184, 186) !important;
+    color: #c7ced1 !important;
 }
 
 #sideBar .nav-item-text:hover {
@@ -212,8 +212,10 @@ body {
 
 #sideBar .categoryPanel {
     margin: 0 8px 8px 8px !important;
-    border: 1px solid #5b7073;
+    background-color: #334044;
+    border: 1px solid #4a5a5f;
     border-radius: 4px;
+    overflow: hidden;
 }
 
 .categoryPanel:first-child {
@@ -226,19 +228,19 @@ body {
 
 /* Category panel header styling */
 #sideBar .categoryPanel > .pcui-panel-header {
-    background-color: #1a2426;
+    background-color: #20292b;
 }
 
 .nav-item {
     margin: 12px;
     overflow: auto;
     border-radius: 4px;
-    background-color: #2C393C;
+    background-color: #2a3437;
     position: relative;
 }
 
 .nav-item:last-child {
-    margin: 12px 12px 4px 12px;
+    margin: 12px;
 }
 
 .nav-item.selected {


### PR DESCRIPTION
## Description
- Refresh the examples browser sidebar palette for category panels, headers, item backgrounds, and item text.
- Keep category panel borders visible with a softer color, clip panel contents to the rounded border, and add bottom spacing inside panels.
- Update examples lockfile metadata after npm-generated cleanup.

Manual tests: not run

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change