### PR TITLE
feat: TRACEID_BUFFERS trace, example control, and storage buffer debug names

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs
@@ -304,6 +304,12 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                 onClick: () => {
                     observer.emit('logTextures');
                 }
+            }),
+            jsx(Button, {
+                text: 'Log Buffers',
+                onClick: () => {
+                    observer.emit('logBuffers');
+                }
             })
         ),
         jsx(

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -541,11 +541,20 @@ assetListLoader.load(async () => {
         logTexturesRequested = true;
     });
 
+    let logBuffersRequested = false;
+    data.on('logBuffers', () => {
+        logBuffersRequested = true;
+    });
+
     app.on('update', () => {
 
         // log textures for one frame if requested
         pc.Tracing.set(pc.TRACEID_TEXTURES, logTexturesRequested);
         logTexturesRequested = false;
+
+        // eslint-disable-next-line import/namespace
+        pc.Tracing.set(pc.TRACEID_BUFFERS, logBuffersRequested);
+        logBuffersRequested = false;
 
         data.set('data.stats.gsplats', app.stats.frame.gsplats.toLocaleString());
         const bb = app.graphicsDevice.backBufferSize;

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -140,6 +140,13 @@ export const TRACEID_ELEMENT = 'Element';
 export const TRACEID_TEXTURES = 'Textures';
 
 /**
+ * Logs GPU buffer memory tracked on the graphics device (vertex, index, storage).
+ *
+ * @category Debug
+ */
+export const TRACEID_BUFFERS = 'Buffers';
+
+/**
  * Logs all assets in the asset registry.
  *
  * @category Debug

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -42,6 +42,7 @@ class Tracing {
      * - {@link TRACEID_COMPUTEPIPELINE_ALLOC}
      * - {@link TRACEID_PIPELINELAYOUT_ALLOC}
      * - {@link TRACEID_TEXTURES}
+     * - {@link TRACEID_BUFFERS}
      * - {@link TRACEID_ASSETS}
      * - {@link TRACEID_GPU_TIMINGS}
      *

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -6,7 +6,7 @@ import { now } from '../../core/time.js';
 import { Vec2 } from '../../core/math/vec2.js';
 import { Tracing } from '../../core/tracing.js';
 import { Color } from '../../core/math/color.js';
-import { TRACEID_TEXTURES } from '../../core/constants.js';
+import { TRACEID_BUFFERS, TRACEID_TEXTURES } from '../../core/constants.js';
 import {
     BUFFER_STATIC,
     CULLFACE_BACK, CULLFACE_NONE,
@@ -25,6 +25,7 @@ import { VertexBuffer } from './vertex-buffer.js';
 import { VertexFormat } from './vertex-format.js';
 import { StencilParameters } from './stencil-parameters.js';
 import { DebugGraphics } from './debug-graphics.js';
+import { StorageBuffer } from './storage-buffer.js';
 
 /**
  * @import { Compute } from './compute.js'
@@ -34,7 +35,6 @@ import { DebugGraphics } from './debug-graphics.js';
  * @import { RenderTarget } from './render-target.js'
  * @import { Shader } from './shader.js'
  * @import { Texture } from './texture.js'
- * @import { StorageBuffer } from './storage-buffer.js';
  * @import { DrawCommands } from './draw-commands.js';
  */
 
@@ -1286,6 +1286,52 @@ class GraphicsDevice extends EventHandler {
                     Debug.log(`${index}. Id: ${texture.id} ${texture.name} ${texture.width}x${texture.height} VRAM: ${(textureSize / 1024 / 1024).toFixed(2)} MB`);
                 });
                 Debug.log(`Total: ${(textureTotal / 1024 / 1024).toFixed(2)}MB`);
+            }
+
+            // log out all tracked GPU buffers, sorted by size
+            if (Tracing.get(TRACEID_BUFFERS)) {
+                const entries = [...this.buffers].map((buffer) => {
+                    let kind;
+                    let size;
+                    if (buffer instanceof VertexBuffer) {
+                        kind = 'VB';
+                        size = buffer.storage?.byteLength ?? buffer.numBytes ?? 0;
+                    } else if (buffer instanceof IndexBuffer) {
+                        kind = 'IB';
+                        size = buffer.storage?.byteLength ?? buffer.numBytes ?? 0;
+                    } else if (buffer instanceof StorageBuffer) {
+                        kind = 'SB';
+                        size = buffer.byteSize ?? 0;
+                    } else {
+                        kind = buffer.constructor?.name ?? '?';
+                        size = buffer.storage?.byteLength ?? buffer.numBytes ?? buffer.byteSize ?? 0;
+                    }
+                    return { buffer, kind, size };
+                });
+                entries.sort((a, b) => b.size - a.size);
+                Debug.log(`Buffers: ${entries.length}`);
+                let total = 0;
+                let totalVB = 0;
+                let totalIB = 0;
+                let totalSB = 0;
+                entries.forEach((entry, index) => {
+                    const { buffer, kind, size } = entry;
+                    total += size;
+                    if (kind === 'VB') {
+                        totalVB += size;
+                    } else if (kind === 'IB') {
+                        totalIB += size;
+                    } else if (kind === 'SB') {
+                        totalSB += size;
+                    }
+                    const namePart = buffer.name ? ` ${buffer.name}` : '';
+                    Debug.log(`${index}. ${kind} Id: ${buffer.id}${namePart} VRAM: ${(size / 1024 / 1024).toFixed(2)} MB`);
+                });
+                const mb = n => (n / 1024 / 1024).toFixed(2);
+                Debug.log(`Total VB: ${totalVB} bytes (${mb(totalVB)} MB)`);
+                Debug.log(`Total IB: ${totalIB} bytes (${mb(totalIB)} MB)`);
+                Debug.log(`Total SB: ${totalSB} bytes (${mb(totalSB)} MB)`);
+                Debug.log(`Total: ${total} bytes (${mb(total)} MB)`);
             }
         });
     }

--- a/src/platform/graphics/storage-buffer.js
+++ b/src/platform/graphics/storage-buffer.js
@@ -17,6 +17,10 @@ let id = 0;
  * recreated at the same byte size but its contents are undefined until you write to it again or
  * repopulate it via compute.
  *
+ * For debug identification in buffer memory listings (when the {@link TRACEID_BUFFERS} trace
+ * channel is enabled), call sites may assign the instance's `name` property to a descriptive
+ * string.
+ *
  * @category Graphics
  */
 class StorageBuffer {

--- a/src/platform/graphics/webgpu/webgpu-draw-commands.js
+++ b/src/platform/graphics/webgpu/webgpu-draw-commands.js
@@ -1,5 +1,6 @@
 import { BUFFERUSAGE_COPY_DST, BUFFERUSAGE_INDIRECT } from '../constants.js';
 import { StorageBuffer } from '../storage-buffer.js';
+import { DebugHelper } from '../../../core/debug.js';
 
 /**
  * @import { GraphicsDevice } from '../graphics-device.js'
@@ -45,6 +46,7 @@ class WebgpuDrawCommands {
         this.gpuIndirect = new Uint32Array(5 * maxCount);
         this.gpuIndirectSigned = new Int32Array(this.gpuIndirect.buffer);
         this.storage = new StorageBuffer(this.device, this.gpuIndirect.byteLength, BUFFERUSAGE_INDIRECT | BUFFERUSAGE_COPY_DST);
+        DebugHelper.setName(this.storage, 'WebgpuDrawCommands.indirectStorage');
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -611,6 +611,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // allocate buffer
         if (this._indirectDrawBuffer === null) {
             this._indirectDrawBuffer = new StorageBuffer(this, this.maxIndirectDrawCount * _indirectEntryByteSize, BUFFERUSAGE_INDIRECT | BUFFERUSAGE_COPY_DST);
+            DebugHelper.setName(this._indirectDrawBuffer, 'WebgpuGraphicsDevice.indirectDraw');
             this._indirectDrawBufferCount = this.maxIndirectDrawCount;
         }
     }
@@ -644,6 +645,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // allocate buffer
         if (this._indirectDispatchBuffer === null) {
             this._indirectDispatchBuffer = new StorageBuffer(this, this.maxIndirectDispatchCount * _indirectDispatchEntryByteSize, BUFFERUSAGE_INDIRECT | BUFFERUSAGE_COPY_DST);
+            DebugHelper.setName(this._indirectDispatchBuffer, 'WebgpuGraphicsDevice.indirectDispatch');
             this._indirectDispatchBufferCount = this.maxIndirectDispatchCount;
         }
     }

--- a/src/scene/graphics/prefix-sum-kernel.js
+++ b/src/scene/graphics/prefix-sum-kernel.js
@@ -1,6 +1,7 @@
 import { Compute } from '../../platform/graphics/compute.js';
 import { Shader } from '../../platform/graphics/shader.js';
 import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
+import { DebugHelper } from '../../core/debug.js';
 import { BindGroupFormat, BindStorageBufferFormat, BindUniformBufferFormat } from '../../platform/graphics/bind-group-format.js';
 import { UniformBufferFormat, UniformFormat } from '../../platform/graphics/uniform-buffer-format.js';
 import { SHADERLANGUAGE_WGSL, SHADERSTAGE_COMPUTE, UNIFORMTYPE_UINT } from '../../platform/graphics/constants.js';
@@ -128,6 +129,7 @@ class PrefixSumKernel {
 
         // Create buffer for block sums
         const blockSumBuffer = new StorageBuffer(this.device, workgroupCount * 4);
+        DebugHelper.setName(blockSumBuffer, 'PrefixSumKernel.blockSum');
 
         // Create scan compute instance using shared shader
         const scanCompute = new Compute(this.device, this._scanShader, 'PrefixSumScan');

--- a/src/scene/graphics/radix-sort/compute-radix-sort-base.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-base.js
@@ -1,4 +1,4 @@
-import { Debug } from '../../../core/debug.js';
+import { Debug, DebugHelper } from '../../../core/debug.js';
 import { BUFFERUSAGE_COPY_DST, BUFFERUSAGE_COPY_SRC } from '../../../platform/graphics/constants.js';
 import { StorageBuffer } from '../../../platform/graphics/storage-buffer.js';
 
@@ -245,6 +245,11 @@ class ComputeRadixSortBase {
         this._values0 = new StorageBuffer(device, elementSize, usage);
         this._values1 = new StorageBuffer(device, elementSize, usage);
         this._sortedIndices = new StorageBuffer(device, elementSize, usage);
+        DebugHelper.setName(this._keys0, 'ComputeRadixSort.keys0');
+        DebugHelper.setName(this._keys1, 'ComputeRadixSort.keys1');
+        DebugHelper.setName(this._values0, 'ComputeRadixSort.values0');
+        DebugHelper.setName(this._values1, 'ComputeRadixSort.values1');
+        DebugHelper.setName(this._sortedIndices, 'ComputeRadixSort.sortedIndices');
     }
 
     /**

--- a/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
@@ -1,4 +1,4 @@
-import { Debug } from '../../../core/debug.js';
+import { Debug, DebugHelper } from '../../../core/debug.js';
 import { Vec2 } from '../../../core/math/vec2.js';
 import { Compute } from '../../../platform/graphics/compute.js';
 import { Shader } from '../../../platform/graphics/shader.js';
@@ -320,6 +320,7 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
 
             // Create block sums buffer (BUCKET_COUNT entries per workgroup)
             this._blockSums = new StorageBuffer(this.device, blockSumSize, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
+            DebugHelper.setName(this._blockSums, 'ComputeRadixSortMultipass.blockSums');
 
             // Create prefix sum kernel (hierarchical Blelloch scan, exclusive).
             // The radix sort reorder shader requires an exclusive scan over

--- a/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
@@ -1,4 +1,4 @@
-import { Debug } from '../../../core/debug.js';
+import { Debug, DebugHelper } from '../../../core/debug.js';
 import { Vec2 } from '../../../core/math/vec2.js';
 import { Compute } from '../../../platform/graphics/compute.js';
 import { Shader } from '../../../platform/graphics/shader.js';
@@ -388,6 +388,9 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
             this._globalHist = new StorageBuffer(device, MAX_PASSES * RADIX * 4, BUFFERUSAGE_COPY_DST);
             this._passHist = new StorageBuffer(device, MAX_PASSES * allocThreadBlocks * RADIX * 4, BUFFERUSAGE_COPY_DST);
             this._index = new StorageBuffer(device, MAX_PASSES * 4, BUFFERUSAGE_COPY_DST);
+            DebugHelper.setName(this._globalHist, 'ComputeRadixSortOnesweep.globalHist');
+            DebugHelper.setName(this._passHist, 'ComputeRadixSortOnesweep.passHist');
+            DebugHelper.setName(this._index, 'ComputeRadixSortOnesweep.index');
         }
 
         // Current sort's working size: the shader computes passHist offsets

--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -15,7 +15,7 @@ import {
     UNIFORMTYPE_UINT
 } from '../../platform/graphics/constants.js';
 import { GSPLAT_FORWARD, PROJECTION_ORTHOGRAPHIC, FOG_NONE, GSPLAT_DEBUG_HEATMAP } from '../constants.js';
-import { Debug } from '../../core/debug.js';
+import { Debug, DebugHelper } from '../../core/debug.js';
 import { Color } from '../../core/math/color.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { Camera } from '../camera.js';
@@ -532,11 +532,16 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
             this._depthBuffer = new StorageBuffer(device, numSplats * 4);
             this._splatPairStartBuffer = new StorageBuffer(device, numSplats * 4);
             this._splatPairCountBuffer = new StorageBuffer(device, numSplats * 4);
+            DebugHelper.setName(this._projCacheBuffer, 'GsplatComputeLocalRenderer.projCache');
+            DebugHelper.setName(this._depthBuffer, 'GsplatComputeLocalRenderer.depth');
+            DebugHelper.setName(this._splatPairStartBuffer, 'GsplatComputeLocalRenderer.splatPairStart');
+            DebugHelper.setName(this._splatPairCountBuffer, 'GsplatComputeLocalRenderer.splatPairCount');
         }
 
         // Packed atomic counters: [0] = global pair counter, [1] = large splat count.
         if (!this._countersBuffer) {
             this._countersBuffer = new StorageBuffer(device, 8, BUFFERUSAGE_COPY_DST | BUFFERUSAGE_COPY_SRC);
+            DebugHelper.setName(this._countersBuffer, 'GsplatComputeLocalRenderer.counters');
         }
 
         // Large-splat ID buffer (grow-only)
@@ -544,6 +549,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
             this._largeSplatIdsBuffer?.destroy();
             this._allocatedLargeSplatCapacity = this._largeSplatIdsCapacity;
             this._largeSplatIdsBuffer = new StorageBuffer(device, this._largeSplatIdsCapacity * 4);
+            DebugHelper.setName(this._largeSplatIdsBuffer, 'GsplatComputeLocalRenderer.largeSplatIds');
         }
 
         // Entry capacity (tileEntries + pairBuffer — both sized identically)
@@ -557,6 +563,8 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
             this._allocatedEntryCapacity = requiredEntryCapacity;
             this._tileEntriesBuffer = new StorageBuffer(device, requiredEntryCapacity * 4, BUFFERUSAGE_COPY_DST);
             this._pairBuffer = new StorageBuffer(device, requiredEntryCapacity * 4);
+            DebugHelper.setName(this._tileEntriesBuffer, 'GsplatComputeLocalRenderer.tileEntries');
+            DebugHelper.setName(this._pairBuffer, 'GsplatComputeLocalRenderer.pair');
         }
 
         this._lastBufferSubmitVersion = device.submitVersion;
@@ -1013,6 +1021,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
             });
 
             this._placeEntryPrepDispatchBuffer = new StorageBuffer(device, 6 * 4, BUFFERUSAGE_INDIRECT);
+            DebugHelper.setName(this._placeEntryPrepDispatchBuffer, 'GsplatComputeLocalRenderer.placeEntryPrepDispatch');
             this._placeEntryPrepCompute = new Compute(device, this._placeEntryPrepShader);
         }
 
@@ -1073,6 +1082,7 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
             });
 
             this._largeSplatDispatchBuffer = new StorageBuffer(device, 3 * 4, BUFFERUSAGE_INDIRECT);
+            DebugHelper.setName(this._largeSplatDispatchBuffer, 'GsplatComputeLocalRenderer.largeSplatDispatch');
             this._largeSplatPrepCompute = new Compute(device, this._largeSplatPrepShader);
         }
 

--- a/src/scene/gsplat-unified/gsplat-frustum-culler.js
+++ b/src/scene/gsplat-unified/gsplat-frustum-culler.js
@@ -1,5 +1,6 @@
 import { Frustum } from '../../core/shape/frustum.js';
 import { Mat4 } from '../../core/math/mat4.js';
+import { DebugHelper } from '../../core/debug.js';
 import { BUFFERUSAGE_COPY_DST } from '../../platform/graphics/constants.js';
 import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
 
@@ -124,6 +125,7 @@ class GSplatFrustumCuller {
             this.boundsBuffer?.destroy();
             this._allocatedBoundsEntries = totalEntries;
             this.boundsBuffer = new StorageBuffer(this.device, totalEntries * BOUNDS_ENTRY_FLOATS * 4, BUFFERUSAGE_COPY_DST);
+            DebugHelper.setName(this.boundsBuffer, 'GsplatFrustumCuller.bounds');
 
             const ab = new ArrayBuffer(totalEntries * BOUNDS_ENTRY_FLOATS * 4);
             this._boundsFloatView = new Float32Array(ab);
@@ -172,6 +174,7 @@ class GSplatFrustumCuller {
             this._allocatedTransformCount = numMatrices;
             // 3 vec4f per matrix = 12 floats = 48 bytes
             this.transformsBuffer = new StorageBuffer(this.device, numMatrices * 12 * 4, BUFFERUSAGE_COPY_DST);
+            DebugHelper.setName(this.transformsBuffer, 'GsplatFrustumCuller.transforms');
             this._transformsData = new Float32Array(numMatrices * 12);
         }
 

--- a/src/scene/gsplat-unified/gsplat-interval-compaction.js
+++ b/src/scene/gsplat-unified/gsplat-interval-compaction.js
@@ -1,4 +1,4 @@
-import { Debug } from '../../core/debug.js';
+import { Debug, DebugHelper } from '../../core/debug.js';
 import { Compute } from '../../platform/graphics/compute.js';
 import { Shader } from '../../platform/graphics/shader.js';
 import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
@@ -119,6 +119,8 @@ class GSplatIntervalCompaction {
 
         this.numSplatsBuffer = new StorageBuffer(device, 4, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
         this.sortElementCountBuffer = new StorageBuffer(device, 4, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
+        DebugHelper.setName(this.numSplatsBuffer, 'GsplatIntervalCompaction.numSplats');
+        DebugHelper.setName(this.sortElementCountBuffer, 'GsplatIntervalCompaction.sortElementCount');
         this.prefixSumKernel = new PrefixSumKernel(device);
 
         this._createUniformBufferFormats();
@@ -329,6 +331,7 @@ class GSplatIntervalCompaction {
             this.compactedSplatIds?.destroy();
             this.allocatedCompactedCount = totalActiveSplats;
             this.compactedSplatIds = new StorageBuffer(this.device, totalActiveSplats * 4, BUFFERUSAGE_COPY_SRC);
+            DebugHelper.setName(this.compactedSplatIds, 'GsplatIntervalCompaction.compactedSplatIds');
         }
 
         const requiredCountSize = numIntervals + 1;
@@ -336,6 +339,7 @@ class GSplatIntervalCompaction {
             this.countBuffer?.destroy();
             this.allocatedCountBufferSize = requiredCountSize;
             this.countBuffer = new StorageBuffer(this.device, requiredCountSize * 4);
+            DebugHelper.setName(this.countBuffer, 'GsplatIntervalCompaction.count');
 
             if (this.prefixSumKernel) {
                 this.prefixSumKernel.destroyPasses();
@@ -363,6 +367,7 @@ class GSplatIntervalCompaction {
             this.intervalsBuffer?.destroy();
             this.allocatedIntervalCount = numIntervals;
             this.intervalsBuffer = new StorageBuffer(this.device, numIntervals * INTERVAL_STRIDE * 4, BUFFERUSAGE_COPY_DST);
+            DebugHelper.setName(this.intervalsBuffer, 'GsplatIntervalCompaction.intervals');
         }
 
         const data = new Uint32Array(numIntervals * INTERVAL_STRIDE);

--- a/src/scene/gsplat-unified/gsplat-local-dispatch-set.js
+++ b/src/scene/gsplat-unified/gsplat-local-dispatch-set.js
@@ -2,6 +2,7 @@ import { Texture } from '../../platform/graphics/texture.js';
 import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
 import { Compute } from '../../platform/graphics/compute.js';
 import { Shader } from '../../platform/graphics/shader.js';
+import { DebugHelper } from '../../core/debug.js';
 import { BindGroupFormat, BindStorageBufferFormat, BindStorageTextureFormat, BindTextureFormat, BindUniformBufferFormat } from '../../platform/graphics/bind-group-format.js';
 import { UniformBufferFormat, UniformFormat } from '../../platform/graphics/uniform-buffer-format.js';
 import {
@@ -222,6 +223,15 @@ class GSplatLocalDispatchSet {
         this._chunkRangesBuffer = new StorageBuffer(this.device, maxChunks * 8);
         this._totalChunksBuffer = new StorageBuffer(this.device, 1 * 4, BUFFERUSAGE_COPY_DST);
         this._chunkSortIndirectBuffer = new StorageBuffer(this.device, 3 * 4, BUFFERUSAGE_COPY_DST | BUFFERUSAGE_INDIRECT);
+        DebugHelper.setName(this._tileSplatCountsBuffer, 'GsplatLocalDispatchSet.tileSplatCounts');
+        DebugHelper.setName(this._smallTileListBuffer, 'GsplatLocalDispatchSet.smallTileList');
+        DebugHelper.setName(this._largeTileListBuffer, 'GsplatLocalDispatchSet.largeTileList');
+        DebugHelper.setName(this._largeTileOverflowBasesBuffer, 'GsplatLocalDispatchSet.largeTileOverflowBases');
+        DebugHelper.setName(this._rasterizeTileListBuffer, 'GsplatLocalDispatchSet.rasterizeTileList');
+        DebugHelper.setName(this._tileListCountsBuffer, 'GsplatLocalDispatchSet.tileListCounts');
+        DebugHelper.setName(this._chunkRangesBuffer, 'GsplatLocalDispatchSet.chunkRanges');
+        DebugHelper.setName(this._totalChunksBuffer, 'GsplatLocalDispatchSet.totalChunks');
+        DebugHelper.setName(this._chunkSortIndirectBuffer, 'GsplatLocalDispatchSet.chunkSortIndirect');
 
         this.prefixSumKernel.destroyPasses();
     }

--- a/src/scene/gsplat-unified/gsplat-projector.js
+++ b/src/scene/gsplat-unified/gsplat-projector.js
@@ -1,4 +1,4 @@
-import { Debug } from '../../core/debug.js';
+import { Debug, DebugHelper } from '../../core/debug.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { Vec2 } from '../../core/math/vec2.js';
 import { Vec3 } from '../../core/math/vec3.js';
@@ -169,9 +169,11 @@ class GSplatProjector {
             GSplatSortBinWeights.NUM_BINS * 2 * 4,
             BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST
         );
+        DebugHelper.setName(this.binWeightsBuffer, 'GsplatProjector.binWeights');
 
         // 4 B counter, cleared every frame on the GPU via clear().
         this.renderCounter = new StorageBuffer(device, 4, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
+        DebugHelper.setName(this.renderCounter, 'GsplatProjector.renderCounter');
 
         this._createUniformBufferFormats();
         this._createWriteIndirectArgsCompute();
@@ -427,6 +429,8 @@ class GSplatProjector {
             this._allocatedCacheCount = capacity;
             this.projCache = new StorageBuffer(this.device, capacity * CACHE_STRIDE * 4);
             this.sortKeys = new StorageBuffer(this.device, capacity * 4, BUFFERUSAGE_COPY_SRC);
+            DebugHelper.setName(this.projCache, 'GsplatProjector.projCache');
+            DebugHelper.setName(this.sortKeys, 'GsplatProjector.sortKeys');
         }
     }
 

--- a/src/scene/gsplat-unified/gsplat-work-buffer.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer.js
@@ -1,4 +1,4 @@
-import { Debug } from '../../core/debug.js';
+import { Debug, DebugHelper } from '../../core/debug.js';
 import {
     ADDRESS_CLAMP_TO_EDGE, PIXELFORMAT_R32U, PIXELFORMAT_RGBA16U,
     BUFFERUSAGE_COPY_DST, SEMANTIC_POSITION, getGlslShaderType
@@ -197,6 +197,7 @@ class GSplatWorkBuffer {
         // Use storage buffer on WebGPU, texture on WebGL
         if (device.isWebGPU) {
             this.orderBuffer = new StorageBuffer(device, 4, BUFFERUSAGE_COPY_DST);
+            DebugHelper.setName(this.orderBuffer, 'GsplatWorkBuffer.order');
         } else {
             this.orderTexture = new Texture(device, {
                 name: 'SplatGlobalOrder',
@@ -320,6 +321,7 @@ class GSplatWorkBuffer {
             if (this.orderBuffer.byteSize < newByteSize) {
                 this.orderBuffer.destroy();
                 this.orderBuffer = new StorageBuffer(this.device, newByteSize, BUFFERUSAGE_COPY_DST);
+                DebugHelper.setName(this.orderBuffer, 'GsplatWorkBuffer.order');
             }
         } else {
             this.orderTexture.resize(textureSize, textureSize);

--- a/src/scene/gsplat/gsplat-instance.js
+++ b/src/scene/gsplat/gsplat-instance.js
@@ -1,4 +1,4 @@
-import { Debug } from '../../core/debug.js';
+import { Debug, DebugHelper } from '../../core/debug.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { BUFFERUSAGE_COPY_DST, CULLFACE_NONE, SEMANTIC_POSITION, PIXELFORMAT_R32U } from '../../platform/graphics/constants.js';
@@ -77,6 +77,7 @@ class GSplatInstance {
         // create order target: StorageBuffer on WebGPU, Texture on WebGL
         if (device.isWebGPU) {
             this.orderBuffer = new StorageBuffer(device, numSplats * 4, BUFFERUSAGE_COPY_DST);
+            DebugHelper.setName(this.orderBuffer, 'GsplatInstance.order');
         } else {
             this.orderTexture = resource.streams.createTexture(
                 'splatOrder',


### PR DESCRIPTION
Adds a debug trace channel to list GPU buffers tracked on the graphics device (vertex, index, storage), with per-type byte totals and optional per-buffer names. The LOD streaming example gets a one-frame "Log Buffers" control; engine-internal storage buffers are tagged for easier identification in that dump.

**Changes:**
- New `TRACEID_BUFFERS` constant and `GraphicsDevice.frameStart` logging (sorted by size, VB/IB/SB totals, optional `buffer.name` in the line output).
- LOD streaming example: "Log Buffers" button and `Tracing.set(TRACEID_BUFFERS, …)` for one frame (same pattern as textures).
- `DebugHelper.setName` after internal `new StorageBuffer` allocations (gsplat, radix sort, prefix sum, WebGPU indirect/draw paths).
- `StorageBuffer` docs: optional instance `name` for listings when `TRACEID_BUFFERS` is enabled.

**API Changes:**
- New public constant: `TRACEID_BUFFERS` (same family as `TRACEID_TEXTURES`). Enable with `Tracing.set(pc.TRACEID_BUFFERS, true)` for the frames where logging should run.

**Examples:**
- `examples/src/examples/gaussian-splatting/lod-streaming.example.mjs`
- `examples/src/examples/gaussian-splatting/lod-streaming.controls.mjs`

<img width="436" height="737" alt="Screenshot 2026-05-08 at 11 33 32" src="https://github.com/user-attachments/assets/3f9302d1-05c1-43e3-8311-9908590f0a78" />
