### PR TITLE
perf: reduce radix sort GPU buffer footprint

### DIFF
--- a/src/scene/graphics/radix-sort/compute-radix-sort-base.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-base.js
@@ -86,6 +86,16 @@ class ComputeRadixSortBase {
     _skipLastPassKeyWrite = false;
 
     /**
+     * When true, the caller permits the sort to overwrite `keysBuffer` after pass 0 reads it.
+     * `_keys1` is not owned by the sorter in this mode — it is assigned to `keysBuffer` before
+     * each pass loop and must not be destroyed on realloc/destroy.
+     *
+     * @type {boolean}
+     * @protected
+     */
+    _destructiveKeys = false;
+
+    /**
      * Internal keys buffer 0 (ping-pong).
      *
      * @type {StorageBuffer|null}
@@ -94,7 +104,8 @@ class ComputeRadixSortBase {
     _keys0 = null;
 
     /**
-     * Internal keys buffer 1 (ping-pong).
+     * Internal keys buffer 1 (ping-pong). When `_destructiveKeys` is true this is borrowed from
+     * the caller's `keysBuffer` and must not be destroyed by the sorter.
      *
      * @type {StorageBuffer|null}
      * @protected
@@ -118,14 +129,6 @@ class ComputeRadixSortBase {
     _values1 = null;
 
     /**
-     * Output sorted indices (or caller values) buffer.
-     *
-     * @type {StorageBuffer|null}
-     * @protected
-     */
-    _sortedIndices = null;
-
-    /**
      * Stable metadata buffer returned by {@link prepareIndirect}. Preallocated as four `u32`
      * entries; concrete backends assign `[slotCount, g0, g1, g2]` after `super(device)`. The caller
      * uploads its contents into a GPU uniform unchanged.
@@ -137,12 +140,15 @@ class ComputeRadixSortBase {
 
     /**
      * Returns the sorted indices (or values, when `initialValues` was passed) buffer of the last
-     * completed sort.
+     * completed sort. The result lives in whichever ping-pong values buffer was written last,
+     * determined by pass-count parity — no separate output buffer is allocated.
      *
      * @type {StorageBuffer|null}
      */
     get sortedIndices() {
-        return this._sortedIndices;
+        if (!this._values0) return null;
+        const numPasses = this._numBits / this.radixBits;
+        return (numPasses % 2 === 1) ? this._values1 : this._values0;
     }
 
     /**
@@ -180,10 +186,13 @@ class ComputeRadixSortBase {
      * @param {number} [numBits] - Number of bits to sort.
      * @param {StorageBuffer} [initialValues] - Optional initial values buffer for pass 0.
      * @param {boolean} [skipLastPassKeyWrite] - Skip writing keys on the last pass.
+     * @param {boolean} [destructiveKeys] - When true, the sort may overwrite `keysBuffer` after
+     * the first pass reads it (saves one internal key buffer). The caller must not read
+     * `keysBuffer` after the sort returns.
      * @returns {StorageBuffer} Sorted values buffer.
      * @abstract
      */
-    sort(keysBuffer, elementCount, numBits, initialValues, skipLastPassKeyWrite) {
+    sort(keysBuffer, elementCount, numBits, initialValues, skipLastPassKeyWrite, destructiveKeys) {
         Debug.error('ComputeRadixSortBase.sort must be implemented by a subclass');
         return /** @type {any} */ (null);
     }
@@ -201,10 +210,13 @@ class ComputeRadixSortBase {
      * @param {StorageBuffer} sortElementCountBuffer - GPU-written element count buffer.
      * @param {StorageBuffer} [initialValues] - Optional initial values buffer for pass 0.
      * @param {boolean} [skipLastPassKeyWrite] - Skip writing keys on the last pass.
+     * @param {boolean} [destructiveKeys] - When true, the sort may overwrite `keysBuffer` after
+     * the first pass reads it (saves one internal key buffer). The caller must not read
+     * `keysBuffer` after the sort returns.
      * @returns {StorageBuffer} Sorted values buffer.
      * @abstract
      */
-    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite) {
+    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite, destructiveKeys) {
         Debug.error('ComputeRadixSortBase.sortIndirect must be implemented by a subclass');
         return /** @type {any} */ (null);
     }
@@ -231,7 +243,9 @@ class ComputeRadixSortBase {
     }
 
     /**
-     * Allocates ping-pong key/value buffers and the sorted output buffer (`u32` per element).
+     * Allocates ping-pong key/value buffers (`u32` per element). When `_destructiveKeys` is true,
+     * `_keys1` is left null — the caller's `keysBuffer` will be borrowed into it before each pass
+     * loop instead.
      *
      * @param {number} effectiveCount - Element high-water count (same units as `capacity` sizing).
      * @protected
@@ -241,34 +255,33 @@ class ComputeRadixSortBase {
         const usage = BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST;
         const device = this.device;
         this._keys0 = new StorageBuffer(device, elementSize, usage);
-        this._keys1 = new StorageBuffer(device, elementSize, usage);
+        DebugHelper.setName(this._keys0, 'ComputeRadixSort.keys0');
+        if (!this._destructiveKeys) {
+            this._keys1 = new StorageBuffer(device, elementSize, usage);
+            DebugHelper.setName(this._keys1, 'ComputeRadixSort.keys1');
+        }
         this._values0 = new StorageBuffer(device, elementSize, usage);
         this._values1 = new StorageBuffer(device, elementSize, usage);
-        this._sortedIndices = new StorageBuffer(device, elementSize, usage);
-        DebugHelper.setName(this._keys0, 'ComputeRadixSort.keys0');
-        DebugHelper.setName(this._keys1, 'ComputeRadixSort.keys1');
         DebugHelper.setName(this._values0, 'ComputeRadixSort.values0');
         DebugHelper.setName(this._values1, 'ComputeRadixSort.values1');
-        DebugHelper.setName(this._sortedIndices, 'ComputeRadixSort.sortedIndices');
     }
 
     /**
-     * Destroys ping-pong keys/values and sorted output buffers owned by the base.
+     * Destroys ping-pong keys/values buffers owned by the base. When `_destructiveKeys` is true,
+     * `_keys1` is borrowed from the caller and is not destroyed.
      *
      * @protected
      */
     _destroyPingPongBuffers() {
         this._keys0?.destroy();
-        this._keys1?.destroy();
+        if (!this._destructiveKeys) this._keys1?.destroy();
         this._values0?.destroy();
         this._values1?.destroy();
-        this._sortedIndices?.destroy();
 
         this._keys0 = null;
         this._keys1 = null;
         this._values0 = null;
         this._values1 = null;
-        this._sortedIndices = null;
     }
 
     /**

--- a/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
@@ -286,9 +286,10 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
      * @param {number} numBits - Number of bits to sort.
      * @param {boolean} hasInitialValues - Whether pass 0 reads caller-supplied initial values.
      * @param {boolean} skipLastPassKeyWrite - Whether the last pass skips writing keys.
+     * @param {boolean} [forceRealloc] - Force buffer reallocation even if sizes match.
      * @private
      */
-    _allocateBuffers(elementCount, numBits, hasInitialValues, skipLastPassKeyWrite) {
+    _allocateBuffers(elementCount, numBits, hasInitialValues, skipLastPassKeyWrite, forceRealloc = false) {
         // Buffer sizing is driven by `capacity` (the high-water mark) to avoid
         // realloc churn when the workload shrinks. Dispatch and scan sizes
         // must track the CURRENT sort's elementCount - otherwise a 1M sort
@@ -299,7 +300,7 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
         const allocWorkgroupCount = Math.ceil(effectiveCount / ELEMENTS_PER_WORKGROUP);
         const currentWorkgroupCount = Math.max(1, Math.ceil(elementCount / ELEMENTS_PER_WORKGROUP));
 
-        const buffersNeedRealloc = allocWorkgroupCount !== this._allocatedWorkgroupCount || !this._keys0;
+        const buffersNeedRealloc = forceRealloc || allocWorkgroupCount !== this._allocatedWorkgroupCount || !this._keys0;
 
         // Recreate passes when numBits, initial-values mode, or key-write mode changes
         const passesNeedRecreate = numBits !== this._numBits ||
@@ -389,13 +390,16 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
      * sequential indices. The buffer is only read, never modified.
      * @param {boolean} [skipLastPassKeyWrite] - When true, the last pass skips writing sorted
      * keys for a small performance gain. Only use when sorted keys are not needed after sorting.
+     * @param {boolean} [destructiveKeys] - When true, the sort may overwrite `keysBuffer` after
+     * the first pass reads it (saves one internal key buffer). The caller must not read
+     * `keysBuffer` after the sort returns.
      * @returns {StorageBuffer} Storage buffer containing sorted indices (or values if
      * initialValues was provided).
      */
-    sort(keysBuffer, elementCount, numBits = 16, initialValues, skipLastPassKeyWrite = false) {
+    sort(keysBuffer, elementCount, numBits = 16, initialValues, skipLastPassKeyWrite = false, destructiveKeys = false) {
         Debug.assert(numBits % BITS_PER_PASS === 0, `ComputeRadixSortMultipass.sort: numBits must be a multiple of ${BITS_PER_PASS}`);
 
-        return this._execute(keysBuffer, elementCount, numBits, -1, null, initialValues, skipLastPassKeyWrite);
+        return this._execute(keysBuffer, elementCount, numBits, -1, null, initialValues, skipLastPassKeyWrite, destructiveKeys);
     }
 
     /**
@@ -414,12 +418,15 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
      * sequential indices. The buffer is only read, never modified.
      * @param {boolean} [skipLastPassKeyWrite] - When true, the last pass skips writing sorted
      * keys for a small performance gain. Only use when sorted keys are not needed after sorting.
+     * @param {boolean} [destructiveKeys] - When true, the sort may overwrite `keysBuffer` after
+     * the first pass reads it (saves one internal key buffer). The caller must not read
+     * `keysBuffer` after the sort returns.
      * @returns {StorageBuffer} Storage buffer containing sorted values.
      */
-    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false) {
+    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false, destructiveKeys = false) {
         Debug.assert(numBits % BITS_PER_PASS === 0, `ComputeRadixSortMultipass.sortIndirect: numBits must be a multiple of ${BITS_PER_PASS}`);
 
-        return this._execute(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite);
+        return this._execute(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite, destructiveKeys);
     }
 
     /**
@@ -433,15 +440,26 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
      * @param {StorageBuffer} [initialValues] - Optional initial values buffer for pass 0.
      * @param {boolean} [skipLastPassKeyWrite] - When true, the last pass skips writing sorted
      * keys for a small performance gain. Only use when sorted keys are not needed after sorting.
+     * @param {boolean} [destructiveKeys] - When true, borrow `keysBuffer` as the second ping-pong
+     * key buffer (saves one N×4 allocation). The sort may overwrite `keysBuffer` after pass 0.
      * @returns {StorageBuffer} Storage buffer containing sorted values.
      * @private
      */
-    _execute(keysBuffer, elementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false) {
+    _execute(keysBuffer, elementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false, destructiveKeys = false) {
         this._elementCount = elementCount;
         const hasInitialValues = !!initialValues;
 
+        // Trigger realloc when the destructiveKeys mode changes (affects which buffers are owned).
+        const prevDestructiveKeys = this._destructiveKeys;
+        this._destructiveKeys = destructiveKeys;
+
         // Allocate buffers and create passes if needed
-        this._allocateBuffers(elementCount, numBits, hasInitialValues, skipLastPassKeyWrite);
+        this._allocateBuffers(elementCount, numBits, hasInitialValues, skipLastPassKeyWrite, destructiveKeys !== prevDestructiveKeys);
+
+        // When destructiveKeys, borrow keysBuffer as _keys1 (not owned; not destroyed on realloc).
+        if (destructiveKeys) {
+            this._keys1 = keysBuffer;
+        }
 
         const device = this.device;
         const numPasses = numBits / BITS_PER_PASS;
@@ -485,13 +503,11 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
             this._prefixSumKernel.dispatch(device);
 
             // Phase 3: Ranked scatter - recompute local ranks in shared memory and scatter
-            const outputValues = isLastPass ? this._sortedIndices : nextValues;
-
             reorderCompute.setParameter('inputKeys', currentKeys);
             reorderCompute.setParameter('outputKeys', nextKeys);
             reorderCompute.setParameter('prefix_block_sum', this._blockSums);
             reorderCompute.setParameter('inputValues', currentValues);
-            reorderCompute.setParameter('outputValues', outputValues);
+            reorderCompute.setParameter('outputValues', nextValues);
             reorderCompute.setParameter('workgroupCount', this._workgroupCount);
             reorderCompute.setParameter('elementCount', elementCount);
 
@@ -513,7 +529,7 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
             }
         }
 
-        return this._sortedIndices;
+        return this.sortedIndices;
     }
 }
 

--- a/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
@@ -360,9 +360,10 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
      * Allocates or resizes internal buffers.
      *
      * @param {number} elementCount - Number of elements to sort.
+     * @param {boolean} [forceRealloc] - Force buffer reallocation even if sizes match.
      * @private
      */
-    _allocateBuffers(elementCount) {
+    _allocateBuffers(elementCount, forceRealloc = false) {
         // Buffer sizing is driven by `capacity` (the high-water mark) to avoid
         // realloc churn when the workload shrinks. Dispatch/clear sizes must
         // track the CURRENT sort's elementCount - otherwise a 1M sort that
@@ -373,7 +374,7 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
         const allocThreadBlocks = Math.max(1, Math.ceil(effectiveCount / PART_SIZE));
         const currentThreadBlocks = Math.max(1, Math.ceil(elementCount / PART_SIZE));
 
-        const needRealloc = allocThreadBlocks !== this._allocatedThreadBlocks || !this._keys0;
+        const needRealloc = forceRealloc || allocThreadBlocks !== this._allocatedThreadBlocks || !this._keys0;
 
         if (needRealloc) {
             this._destroyBuffers();
@@ -435,9 +436,12 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
      * @param {boolean} [skipLastPassKeyWrite] - Skip writing sorted keys on
      * the last pass. Marginal perf win; only use when sorted keys are not
      * needed.
+     * @param {boolean} [destructiveKeys] - When true, the sort may overwrite
+     * `keysBuffer` after the first pass reads it (saves one internal key
+     * buffer). The caller must not read `keysBuffer` after the sort returns.
      * @returns {StorageBuffer} Sorted values buffer.
      */
-    sort(keysBuffer, elementCount, numBits = 16, initialValues, skipLastPassKeyWrite = false) {
+    sort(keysBuffer, elementCount, numBits = 16, initialValues, skipLastPassKeyWrite = false, destructiveKeys = false) {
         Debug.assert(numBits <= 32, `ComputeRadixSortOneSweep.sort: numBits must be <= 32, got ${numBits}`);
 
         const numPasses = numBits / 8;
@@ -448,8 +452,15 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
         this._hasInitialValues = hasInitialValues;
         this._skipLastPassKeyWrite = skipLastPassKeyWrite;
 
-        this._allocateBuffers(elementCount);
+        const prevDestructiveKeys = this._destructiveKeys;
+        this._destructiveKeys = destructiveKeys;
+
+        this._allocateBuffers(elementCount, destructiveKeys !== prevDestructiveKeys);
         this._ensureBinningComputes(numPasses);
+
+        if (destructiveKeys) {
+            this._keys1 = keysBuffer;
+        }
 
         const device = this.device;
 
@@ -491,14 +502,13 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
         for (let pass = 0; pass < numPasses; pass++) {
             const isFirstPass = pass === 0 && !hasInitialValues;
             const isLastPass = pass === numPasses - 1;
-            const outputValues = isLastPass ? this._sortedIndices : nextValues;
             const flags = (isFirstPass ? 1 : 0) | (isLastPass && skipLastPassKeyWrite ? 2 : 0);
 
             const binCompute = this._binningComputes[pass];
             binCompute.setParameter('inputKeys', currentKeys);
             binCompute.setParameter('outputKeys', nextKeys);
             binCompute.setParameter('inputValues', currentValues);
-            binCompute.setParameter('outputValues', outputValues);
+            binCompute.setParameter('outputValues', nextValues);
             binCompute.setParameter('b_passHist', this._passHist);
             binCompute.setParameter('b_index', this._index);
             binCompute.setParameter('numKeys', elementCount);
@@ -517,7 +527,7 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
             }
         }
 
-        return this._sortedIndices;
+        return this.sortedIndices;
     }
 
     /**
@@ -543,9 +553,12 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
      * buffer; element `[0]` holds the actual number of keys to sort.
      * @param {StorageBuffer} [initialValues] - Optional initial values for pass 0.
      * @param {boolean} [skipLastPassKeyWrite] - Skip writing keys on the last pass.
+     * @param {boolean} [destructiveKeys] - When true, the sort may overwrite
+     * `keysBuffer` after the first pass reads it (saves one internal key
+     * buffer). The caller must not read `keysBuffer` after the sort returns.
      * @returns {StorageBuffer} Sorted values buffer.
      */
-    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false) {
+    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite = false, destructiveKeys = false) {
         Debug.assert(numBits <= 32, `ComputeRadixSortOneSweep.sortIndirect: numBits must be <= 32, got ${numBits}`);
 
         const numPasses = numBits / 8;
@@ -556,8 +569,15 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
         this._hasInitialValues = hasInitialValues;
         this._skipLastPassKeyWrite = skipLastPassKeyWrite;
 
-        this._allocateBuffers(maxElementCount);
+        const prevDestructiveKeys = this._destructiveKeys;
+        this._destructiveKeys = destructiveKeys;
+
+        this._allocateBuffers(maxElementCount, destructiveKeys !== prevDestructiveKeys);
         this._ensureBinningComputes(numPasses);
+
+        if (destructiveKeys) {
+            this._keys1 = keysBuffer;
+        }
 
         const device = this.device;
 
@@ -603,14 +623,13 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
         for (let pass = 0; pass < numPasses; pass++) {
             const isFirstPass = pass === 0 && !hasInitialValues;
             const isLastPass = pass === numPasses - 1;
-            const outputValues = isLastPass ? this._sortedIndices : nextValues;
             const flags = (isFirstPass ? 1 : 0) | (isLastPass && skipLastPassKeyWrite ? 2 : 0);
 
             const binCompute = this._binningComputes[pass];
             binCompute.setParameter('inputKeys', currentKeys);
             binCompute.setParameter('outputKeys', nextKeys);
             binCompute.setParameter('inputValues', currentValues);
-            binCompute.setParameter('outputValues', outputValues);
+            binCompute.setParameter('outputValues', nextValues);
             binCompute.setParameter('b_passHist', this._passHist);
             binCompute.setParameter('b_index', this._index);
             binCompute.setParameter('b_sortElementCount', sortElementCountBuffer);
@@ -630,7 +649,7 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
             }
         }
 
-        return this._sortedIndices;
+        return this.sortedIndices;
     }
 }
 

--- a/src/scene/graphics/radix-sort/compute-radix-sort.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort.js
@@ -179,15 +179,19 @@ class ComputeRadixSort {
      * @param {boolean} [skipLastPassKeyWrite] - Skip writing sorted keys on
      * the last pass (marginal perf win; only use when sorted keys aren't
      * needed afterwards).
+     * @param {boolean} [destructiveKeys] - When true, the sort may overwrite
+     * `keysBuffer` after the first pass reads it, saving one internal N×4
+     * key buffer. The caller must not read `keysBuffer` after the sort
+     * returns.
      * @returns {StorageBuffer} Sorted values buffer (same as
      * {@link sortedIndices}).
      */
-    sort(keysBuffer, elementCount, numBits = 16, initialValues, skipLastPassKeyWrite) {
+    sort(keysBuffer, elementCount, numBits = 16, initialValues, skipLastPassKeyWrite, destructiveKeys = false) {
         Debug.assert(!this._impl._indirect, 'ComputeRadixSort.sort: this instance was created with indirect:true and only supports sortIndirect');
         Debug.assert(keysBuffer, 'ComputeRadixSort.sort: keysBuffer is required');
         Debug.assert(elementCount > 0, 'ComputeRadixSort.sort: elementCount must be > 0');
         Debug.assert(numBits % this.radixBits === 0, `ComputeRadixSort.sort: numBits must be a multiple of radixBits (${this.radixBits}), got ${numBits}`);
-        return this._impl.sort(keysBuffer, elementCount, numBits, initialValues, skipLastPassKeyWrite);
+        return this._impl.sort(keysBuffer, elementCount, numBits, initialValues, skipLastPassKeyWrite, destructiveKeys);
     }
 
     /**
@@ -211,15 +215,19 @@ class ComputeRadixSort {
      * pass 0.
      * @param {boolean} [skipLastPassKeyWrite] - Skip writing keys on the
      * last pass.
+     * @param {boolean} [destructiveKeys] - When true, the sort may overwrite
+     * `keysBuffer` after the first pass reads it, saving one internal N×4
+     * key buffer. The caller must not read `keysBuffer` after the sort
+     * returns.
      * @returns {StorageBuffer} Sorted values buffer.
      */
-    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite) {
+    sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite, destructiveKeys = false) {
         Debug.assert(this._impl._indirect, 'ComputeRadixSort.sortIndirect: this instance was created without indirect:true');
         Debug.assert(keysBuffer, 'ComputeRadixSort.sortIndirect: keysBuffer is required');
         Debug.assert(maxElementCount > 0, 'ComputeRadixSort.sortIndirect: maxElementCount must be > 0');
         Debug.assert(numBits % this.radixBits === 0, `ComputeRadixSort.sortIndirect: numBits must be a multiple of radixBits (${this.radixBits}), got ${numBits}`);
         Debug.assert(sortElementCountBuffer, 'ComputeRadixSort.sortIndirect: sortElementCountBuffer is required');
-        return this._impl.sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite);
+        return this._impl.sortIndirect(keysBuffer, maxElementCount, numBits, sortSlotBase, sortElementCountBuffer, initialValues, skipLastPassKeyWrite, destructiveKeys);
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1734,7 +1734,8 @@ class GSplatManager {
             this.indirectDispatchSlot + 1,
             /** @type {StorageBuffer} */ (ic.sortElementCountBuffer),
             undefined,
-            false
+            false,
+            true  // destructiveKeys: projector overwrites sortKeys each frame before the sort
         );
     }
 


### PR DESCRIPTION
Reduces WebGPU storage buffer usage for `ComputeRadixSort` by eliminating two N×4-byte allocations on typical paths.

**Changes:**
- **No dedicated `_sortedIndices` buffer:** sorted values live in the values ping-pong pair; `sortedIndices` is derived from pass parity (same idea as `sortedKeys`).
- **Optional `destructiveKeys`:** when `true`, the sorter does not allocate `_keys1`; it reuses the caller `keysBuffer` as the second key ping-pong slot after pass 0. Documented on `sort` / `sortIndirect`; default remains `false` for safety.
- **GSplat hybrid:** `gsplat-manager` passes `destructiveKeys: true` for `sortIndirect` because `projector.sortKeys` is overwritten every frame before the sort.

**API (additive):**
- `ComputeRadixSort.sort(..., skipLastPassKeyWrite, destructiveKeys)` — new last optional boolean, default `false`.
- `ComputeRadixSort.sortIndirect(..., skipLastPassKeyWrite, destructiveKeys)` — same.

**Performance:** ~2 × N × 4 bytes less VRAM for callers that opt into `destructiveKeys` and always use the new output path (e.g. hybrid GSplat at ~4M splats saves on the order of tens of MB).