### PR TITLE
fix(examples): scroll landscape controls panel when content overflows

### DIFF
--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -415,6 +415,17 @@ body {
     background-color: #364346;
 }
 
+/* Landscape/desktop: tall controls scroll inside the panel (same idea as #sideBar-contents). */
+#controlPanel.landscape {
+    overflow: hidden;
+}
+
+#controlPanel.landscape > .pcui-panel-content {
+    overflow-y: auto;
+    max-height: calc(100vh - 48px);
+    min-height: 0;
+}
+
 #descriptionPanel {
     /* center on the bottom of the page */
     position: absolute;


### PR DESCRIPTION
The landscape (desktop-width) examples UI placed parameters in `#controlPanel` without a scroll region, so long controls files were unusable when the window was shorter than the panel—unlike the left sidebar, which already used `overflow: auto` on `#sideBar-contents`.

**Changes:**
- Scope scrolling to `#controlPanel.landscape`: clip the panel with `overflow: hidden` and make `.pcui-panel-content` the scroll container via `overflow-y: auto`, with a viewport-based `max-height` and `min-height: 0` for reliable overflow.

This restores wheel/trackpad/scrollbar and touch scrolling on short viewports and devices such as Meta Quest Browser.