### PR TITLE
feat: Add XrBridge for backend-specific WebXR presentation

### DIFF
--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
@@ -1,7 +1,6 @@
+// @config HIDDEN
 // @config WEBGPU_DISABLED
 // @config NO_MINISTATS
-// @config DESCRIPTION LOD-streamed Gaussian splats (Roman Parish) with radial reveal and WebXR VR; WebGL only. Desktop fly controls; Quest-style thumbstick locomotion when in VR.
-// Example route: #/gaussian-splatting-xr/vr-lod
 import { data } from 'examples/observer';
 import { deviceType, rootPath, fileImport } from 'examples/utils';
 import * as pc from 'playcanvas';

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -14,6 +14,7 @@ import { XrPlaneDetection } from './xr-plane-detection.js';
 import { XrAnchors } from './xr-anchors.js';
 import { XrMeshDetection } from './xr-mesh-detection.js';
 import { XrViews } from './xr-views.js';
+import { XrBridge } from '../../platform/graphics/xr-bridge.js';
 
 /**
  * @import { AppBase } from '../app-base.js'
@@ -154,16 +155,21 @@ class XrManager extends EventHandler {
     _session = null;
 
     /**
-     * @type {XRWebGLLayer|null}
-     * @private
-     */
-    _baseLayer = null;
-
-    /**
-     * @type {XRWebGLBinding|null}
+     * Graphics-backend XR glue for the active session.
+     *
+     * @type {XrBridge|null}
      * @ignore
      */
-    webglBinding = null;
+    xrBridge = null;
+
+    /**
+     * Backend-specific XR binding for GPU camera/depth paths (e.g. WebGL {@link XRWebGLBinding}).
+     *
+     * @type {XRWebGLBinding|null}
+     */
+    get graphicsBinding() {
+        return this.xrBridge?.graphicsBinding ?? null;
+    }
 
     /**
      * @type {XRReferenceSpace|null}
@@ -304,9 +310,6 @@ class XrManager extends EventHandler {
                 this._deviceAvailabilityCheck();
             });
             this._deviceAvailabilityCheck();
-
-            this.app.graphicsDevice.on('devicelost', this._onDeviceLost, this);
-            this.app.graphicsDevice.on('devicerestored', this._onDeviceRestored, this);
         }
     }
 
@@ -315,7 +318,12 @@ class XrManager extends EventHandler {
      *
      * @ignore
      */
-    destroy() { }
+    destroy() {
+        if (this.xrBridge) {
+            this.xrBridge.destroy();
+            this.xrBridge = null;
+        }
+    }
 
     /**
      * Attempts to start XR session for provided {@link CameraComponent} and optionally fires
@@ -562,7 +570,7 @@ class XrManager extends EventHandler {
             return;
         }
 
-        this.webglBinding = null;
+        this.xrBridge?.releasePresentation();
 
         if (callback) this.once('end', callback);
 
@@ -685,6 +693,8 @@ class XrManager extends EventHandler {
 
         this._session = session;
 
+        this.xrBridge = new XrBridge(this.app.graphicsDevice, this);
+
         const onVisibilityChange = () => {
             this.fire('visibility:change', session.visibilityState);
         };
@@ -712,6 +722,11 @@ class XrManager extends EventHandler {
 
             if (!failed) this.fire('end');
 
+            if (this.xrBridge) {
+                this.xrBridge.destroy();
+                this.xrBridge = null;
+            }
+
             this._session = null;
             this._referenceSpace = null;
             this._width = 0;
@@ -737,7 +752,17 @@ class XrManager extends EventHandler {
         // we've set this in the graphics device
         Debug.assert(window, 'window is needed to scale the XR framebuffer. Are you running XR headless?');
 
-        this._createBaseLayer();
+        const gd = this.app.graphicsDevice;
+        const framebufferScaleFactor = (gd.maxPixelRatio / window.devicePixelRatio) * this._framebufferScaleFactor;
+
+        this.xrBridge.attachPresentation(this._session, {
+            framebufferScaleFactor,
+            depthNear: this._depthNear,
+            depthFar: this._depthFar,
+            onBindingError: (ex) => {
+                this.fire('error', ex);
+            }
+        });
 
         if (this.session.supportedFrameRates) {
             this._supportedFrameRates = Array.from(this.session.supportedFrameRates);
@@ -788,69 +813,6 @@ class XrManager extends EventHandler {
             depthNear: this._depthNear,
             depthFar: this._depthFar
         });
-    }
-
-    _createBaseLayer() {
-        const device = this.app.graphicsDevice;
-        const framebufferScaleFactor = (device.maxPixelRatio / window.devicePixelRatio) * this._framebufferScaleFactor;
-
-        this._baseLayer = new XRWebGLLayer(this._session, device.gl, {
-            alpha: true,
-            depth: true,
-            stencil: true,
-            framebufferScaleFactor: framebufferScaleFactor,
-            antialias: false
-        });
-
-        if (device?.isWebGL2 && window.XRWebGLBinding) {
-            try {
-                this.webglBinding = new XRWebGLBinding(this._session, device.gl);
-            } catch (ex) {
-                this.fire('error', ex);
-            }
-        }
-
-        this._session.updateRenderState({
-            baseLayer: this._baseLayer,
-            depthNear: this._depthNear,
-            depthFar: this._depthFar
-        });
-    }
-
-    /** @private */
-    _onDeviceLost() {
-        if (!this._session) {
-            return;
-        }
-
-        if (this.webglBinding) {
-            this.webglBinding = null;
-        }
-
-        this._baseLayer = null;
-
-        this._session.updateRenderState({
-            baseLayer: this._baseLayer,
-            depthNear: this._depthNear,
-            depthFar: this._depthFar
-        });
-    }
-
-    /** @private */
-    _onDeviceRestored() {
-        if (!this._session) {
-            return;
-        }
-
-        setTimeout(() => {
-            this.app.graphicsDevice.gl.makeXRCompatible()
-            .then(() => {
-                this._createBaseLayer();
-            })
-            .catch((ex) => {
-                this.fire('error', ex);
-            });
-        }, 0);
     }
 
     /**
@@ -1031,12 +993,13 @@ class XrManager extends EventHandler {
      * @type {number}
      */
     set fixedFoveation(value) {
-        if ((this._baseLayer?.fixedFoveation ?? null) !== null) {
+        const layer = this.xrBridge?.presentationLayer;
+        if ((layer?.fixedFoveation ?? null) !== null) {
             if (this.app.graphicsDevice.samples > 1) {
                 Debug.warn('Fixed Foveation is ignored. Disable anti-aliasing for it to be effective.');
             }
 
-            this._baseLayer.fixedFoveation = value;
+            layer.fixedFoveation = value;
         }
     }
 
@@ -1047,7 +1010,8 @@ class XrManager extends EventHandler {
      * @type {number|null}
      */
     get fixedFoveation() {
-        return this._baseLayer?.fixedFoveation ?? null;
+        const layer = this.xrBridge?.presentationLayer;
+        return layer?.fixedFoveation ?? null;
     }
 
     /**

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -3,6 +3,7 @@ import { EventHandler } from '../../core/event-handler.js';
 import { platform } from '../../core/platform.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { Quat } from '../../core/math/quat.js';
+import { Vec2 } from '../../core/math/vec2.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { XRTYPE_INLINE, XRTYPE_VR, XRTYPE_AR, XRDEPTHSENSINGUSAGE_CPU, XRDEPTHSENSINGUSAGE_GPU, XRDEPTHSENSINGFORMAT_L8A8, XRDEPTHSENSINGFORMAT_R16U, XRDEPTHSENSINGFORMAT_F32 } from './constants.js';
 import { XrDomOverlay } from './xr-dom-overlay.js';
@@ -270,6 +271,14 @@ class XrManager extends EventHandler {
 
     /** @private */
     _height = 0;
+
+    /**
+     * Scratch for {@link XrBridge#getFramebufferSize}; avoids per-frame allocation.
+     *
+     * @type {Vec2}
+     * @private
+     */
+    _framebufferSize = new Vec2();
 
     /** @private */
     _framebufferScaleFactor = 1.0;
@@ -824,8 +833,9 @@ class XrManager extends EventHandler {
         if (!this._session) return false;
 
         // canvas resolution should be set on first frame availability or resolution changes
-        const width = frame.session.renderState.baseLayer.framebufferWidth;
-        const height = frame.session.renderState.baseLayer.framebufferHeight;
+        this.xrBridge.getFramebufferSize(frame, this._framebufferSize);
+        const width = this._framebufferSize.x;
+        const height = this._framebufferSize.y;
         if (this._width !== width || this._height !== height) {
             this._width = width;
             this._height = height;

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -330,10 +330,8 @@ class XrView extends EventHandler {
             this._xrCamera = this._xrView.camera;
         }
 
-        const layer = frame.session.renderState.baseLayer;
-
         // viewport
-        const viewport = layer.getViewport(this._xrView);
+        const viewport = this._manager.xrBridge.getViewport(frame, this._xrView);
         this._viewport.x = viewport.x;
         this._viewport.y = viewport.y;
         this._viewport.z = viewport.width;

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -354,7 +354,7 @@ class XrView extends EventHandler {
             return;
         }
 
-        const binding = this._manager.webglBinding;
+        const binding = this._manager.graphicsBinding;
         if (!binding) {
             return;
         }
@@ -418,7 +418,7 @@ class XrView extends EventHandler {
 
         const gpu = this._manager.views.depthGpuOptimized;
 
-        const infoSource = gpu ? this._manager.webglBinding : frame;
+        const infoSource = gpu ? this._manager.graphicsBinding : frame;
         if (!infoSource) {
             this._depthInfo = null;
             return;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -37,6 +37,7 @@ import { WebglDrawCommands } from './webgl-draw-commands.js';
 import { WebglTexture } from './webgl-texture.js';
 import { WebglRenderTarget } from './webgl-render-target.js';
 import { WebglUploadStream } from './webgl-upload-stream.js';
+import { WebglXrBridge } from './webgl-xr-bridge.js';
 import { BlendState } from '../blend-state.js';
 import { DepthState } from '../depth-state.js';
 import { StencilParameters } from '../stencil-parameters.js';
@@ -706,6 +707,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
     createTextureImpl(texture) {
         this.textures.add(texture);
         return new WebglTexture(texture);
+    }
+
+    createXrBridgeImpl(xrBridge) {
+        return new WebglXrBridge(xrBridge);
     }
 
     createRenderTargetImpl(renderTarget) {

--- a/src/platform/graphics/webgl/webgl-xr-bridge.js
+++ b/src/platform/graphics/webgl/webgl-xr-bridge.js
@@ -1,0 +1,152 @@
+/**
+ * @import { XrBridge } from '../xr-bridge.js'
+ * @import { GraphicsDevice } from '../graphics-device.js'
+ */
+
+/**
+ * WebGL graphics implementation for {@link XrBridge}.
+ *
+ * @ignore
+ */
+class WebglXrBridge {
+    /**
+     * @type {XRWebGLLayer|null}
+     * @private
+     */
+    _presentationLayer = null;
+
+    /**
+     * @type {XRWebGLBinding|null}
+     * @private
+     */
+    _graphicsBinding = null;
+
+    /**
+     * @param {XrBridge} xrBridge - The XR bridge.
+     */
+    constructor(xrBridge) {
+        /** @type {XrBridge} */
+        this.xrBridge = xrBridge;
+    }
+
+    /**
+     * @param {GraphicsDevice} _device - The graphics device.
+     */
+    destroy(_device) {
+        this._graphicsBinding = null;
+        this._presentationLayer = null;
+    }
+
+    /**
+     * @returns {XRWebGLLayer|null} The active XR output layer, if any.
+     */
+    get presentationLayer() {
+        return this._presentationLayer;
+    }
+
+    /**
+     * @returns {XRWebGLBinding|null} The WebXR GL binding for GPU camera/depth paths, if any.
+     */
+    get graphicsBinding() {
+        return this._graphicsBinding;
+    }
+
+    /**
+     * @param {XRSession} session - XR session.
+     * @param {object} options - Presentation options.
+     * @param {number} options.framebufferScaleFactor - Resolved framebuffer scale factor.
+     * @param {number} options.depthNear - Depth near plane.
+     * @param {number} options.depthFar - Depth far plane.
+     * @param {Function} [options.onBindingError] - Called if XRWebGLBinding construction fails.
+     */
+    attachPresentation(session, options) {
+        const device = this.xrBridge.device;
+
+        this._presentationLayer = new XRWebGLLayer(session, device.gl, {
+            alpha: true,
+            depth: true,
+            stencil: true,
+            framebufferScaleFactor: options.framebufferScaleFactor,
+            antialias: false
+        });
+
+        if (window.XRWebGLBinding) {
+            try {
+                this._graphicsBinding = new XRWebGLBinding(session, device.gl);
+            } catch (ex) {
+                this.xrBridge._onBindingError?.(ex);
+            }
+        }
+
+        session.updateRenderState({
+            baseLayer: this._presentationLayer,
+            depthNear: options.depthNear,
+            depthFar: options.depthFar
+        });
+    }
+
+    /**
+     * Matches {@link XrManager#end} clearing {@link XrManager#graphicsBinding} only.
+     */
+    releasePresentation() {
+        this._graphicsBinding = null;
+    }
+
+    onGraphicsDeviceLost() {
+        const session = this.xrBridge._session;
+
+        if (!session) {
+            return;
+        }
+
+        const rs = session.renderState;
+
+        this._graphicsBinding = null;
+        this._presentationLayer = null;
+
+        session.updateRenderState({
+            baseLayer: this._presentationLayer,
+            depthNear: rs.depthNear,
+            depthFar: rs.depthFar
+        });
+    }
+
+    /**
+     * Recreates presentation after GPU restore; fires `"error"` on the bridge {@link XrBridge#eventHandler} if restore fails.
+     */
+    onGraphicsDeviceRestored() {
+        const bridge = this.xrBridge;
+
+        if (!bridge._session) {
+            return;
+        }
+
+        const device = bridge.device;
+        const eventHandler = bridge.eventHandler;
+
+        setTimeout(() => {
+            if (!bridge._session) {
+                return;
+            }
+
+            device.gl.makeXRCompatible()
+            .then(() => {
+                if (!bridge._session) {
+                    return;
+                }
+                const rs = bridge._session.renderState;
+                bridge.attachPresentation(bridge._session, {
+                    framebufferScaleFactor: bridge._framebufferScaleFactor,
+                    depthNear: rs.depthNear,
+                    depthFar: rs.depthFar,
+                    onBindingError: bridge._onBindingError
+                });
+            })
+            .catch((ex) => {
+                eventHandler.fire('error', ex);
+            });
+        }, 0);
+    }
+}
+
+export { WebglXrBridge };

--- a/src/platform/graphics/webgl/webgl-xr-bridge.js
+++ b/src/platform/graphics/webgl/webgl-xr-bridge.js
@@ -1,6 +1,7 @@
 /**
  * @import { XrBridge } from '../xr-bridge.js'
  * @import { GraphicsDevice } from '../graphics-device.js'
+ * @import { Vec2 } from '../../../core/math/vec2.js'
  */
 
 /**
@@ -49,6 +50,28 @@ class WebglXrBridge {
      */
     get graphicsBinding() {
         return this._graphicsBinding;
+    }
+
+    /**
+     * @param {XRFrame} frame - Current XR frame.
+     * @param {Vec2} out - Width in {@link Vec2#x}, height in {@link Vec2#y}.
+     */
+    getFramebufferSize(frame, out) {
+        const baseLayer = frame.session.renderState.baseLayer;
+        if (!baseLayer) {
+            out.set(0, 0);
+            return;
+        }
+        out.set(baseLayer.framebufferWidth, baseLayer.framebufferHeight);
+    }
+
+    /**
+     * @param {XRFrame} frame - Current XR frame.
+     * @param {XRView} xrView - WebXR view.
+     * @returns {XRViewport} Viewport from the session base layer.
+     */
+    getViewport(frame, xrView) {
+        return frame.session.renderState.baseLayer.getViewport(xrView);
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -33,6 +33,7 @@ import { WebgpuBuffer } from './webgpu-buffer.js';
 import { StorageBuffer } from '../storage-buffer.js';
 import { WebgpuDrawCommands } from './webgpu-draw-commands.js';
 import { WebgpuUploadStream } from './webgpu-upload-stream.js';
+import { WebgpuXrBridge } from './webgpu-xr-bridge.js';
 
 /**
  * @import { RenderPass } from '../render-pass.js'
@@ -573,6 +574,10 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     createTextureImpl(texture) {
         this.textures.add(texture);
         return new WebgpuTexture(texture);
+    }
+
+    createXrBridgeImpl(xrBridge) {
+        return new WebgpuXrBridge(xrBridge);
     }
 
     createRenderTargetImpl(renderTarget) {

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -1,0 +1,53 @@
+/**
+ * @import { XrBridge } from '../xr-bridge.js'
+ * @import { GraphicsDevice } from '../graphics-device.js'
+ */
+
+/**
+ * WebGPU graphics implementation for {@link XrBridge}.
+ *
+ * @ignore
+ */
+class WebgpuXrBridge {
+    /**
+     * @param {XrBridge} xrBridge - The XR bridge.
+     */
+    constructor(xrBridge) {
+        /** @type {XrBridge} */
+        this.xrBridge = xrBridge;
+    }
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     */
+    destroy(device) {
+    }
+
+    /**
+     * @returns {null} WebGPU XR presentation is not implemented yet.
+     */
+    get presentationLayer() {
+        return null;
+    }
+
+    /**
+     * @returns {null} WebGPU XR binding is not implemented yet.
+     */
+    get graphicsBinding() {
+        return null;
+    }
+
+    attachPresentation(_session, _options) {
+    }
+
+    releasePresentation() {
+    }
+
+    onGraphicsDeviceLost() {
+    }
+
+    onGraphicsDeviceRestored() {
+    }
+}
+
+export { WebgpuXrBridge };

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -1,6 +1,7 @@
 /**
  * @import { XrBridge } from '../xr-bridge.js'
  * @import { GraphicsDevice } from '../graphics-device.js'
+ * @import { Vec2 } from '../../../core/math/vec2.js'
  */
 
 /**
@@ -34,6 +35,23 @@ class WebgpuXrBridge {
      * @returns {null} WebGPU XR binding is not implemented yet.
      */
     get graphicsBinding() {
+        return null;
+    }
+
+    /**
+     * @param {XRFrame} _frame - Current XR frame.
+     * @param {Vec2} out - Placeholder until WebGPU XR presentation is implemented.
+     */
+    getFramebufferSize(_frame, out) {
+        out.set(0, 0);
+    }
+
+    /**
+     * @param {XRFrame} _frame - Current XR frame.
+     * @param {XRView} _xrView - WebXR view.
+     * @returns {XRViewport} Stub until WebGPU XR presentation is implemented.
+     */
+    getViewport(_frame, _xrView) {
         return null;
     }
 

--- a/src/platform/graphics/xr-bridge.js
+++ b/src/platform/graphics/xr-bridge.js
@@ -1,0 +1,140 @@
+/**
+ * @import { GraphicsDevice } from './graphics-device.js'
+ * @import { EventHandler } from '../../core/event-handler.js'
+ * @import { EventHandle } from '../../core/event-handle.js'
+ */
+
+/**
+ * Bridges WebXR presentation to the graphics device backend.
+ *
+ * @ignore
+ */
+class XrBridge {
+    /**
+     * @type {GraphicsDevice}
+     */
+    device;
+
+    /**
+     * Receives XR presentation-related events (for example {@link EventHandler#fire} with name `"error"`).
+     *
+     * @type {EventHandler}
+     */
+    eventHandler;
+
+    /**
+     * @type {object}
+     */
+    impl;
+
+    /**
+     * @type {EventHandle|null}
+     * @private
+     */
+    _evtDeviceLost = null;
+
+    /**
+     * @type {EventHandle|null}
+     * @private
+     */
+    _evtDeviceRestored = null;
+
+    /**
+     * Active XR session for presentation (shared across graphics backends).
+     *
+     * @type {XRSession|null}
+     * @private
+     */
+    _session = null;
+
+    /**
+     * Resolved framebuffer scale from the last {@link XrBridge#attachPresentation}.
+     *
+     * @type {number}
+     * @private
+     */
+    _framebufferScaleFactor = 1;
+
+    /**
+     * Callback when backend GPU binding construction fails.
+     *
+     * @type {Function|undefined}
+     * @private
+     */
+    _onBindingError;
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {EventHandler} eventHandler - Target for firing XR-related errors.
+     */
+    constructor(device, eventHandler) {
+        this.device = device;
+        this.eventHandler = eventHandler;
+        this.impl = device.createXrBridgeImpl(this);
+
+        this._evtDeviceLost = device.on('devicelost', this._onDeviceLost, this);
+        this._evtDeviceRestored = device.on('devicerestored', this._onDeviceRestored, this);
+    }
+
+    destroy() {
+        const device = this.device;
+        if (device) {
+            this._evtDeviceLost?.off();
+            this._evtDeviceLost = null;
+            this._evtDeviceRestored?.off();
+            this._evtDeviceRestored = null;
+
+            this.impl.destroy(device);
+            this.impl = null;
+
+            this._session = null;
+            this._framebufferScaleFactor = 1;
+            this._onBindingError = undefined;
+
+            this.device = null;
+            this.eventHandler = null;
+        }
+    }
+
+    /** @private */
+    _onDeviceLost() {
+        this.impl.onGraphicsDeviceLost();
+    }
+
+    /** @private */
+    _onDeviceRestored() {
+        this.impl.onGraphicsDeviceRestored();
+    }
+
+    /**
+     * @param {XRSession} session - XR session.
+     * @param {object} options - Presentation options (backend-specific; includes framebufferScaleFactor, depthNear, depthFar).
+     */
+    attachPresentation(session, options) {
+        this._session = session;
+        this._framebufferScaleFactor = options.framebufferScaleFactor;
+        this._onBindingError = options.onBindingError;
+
+        this.impl.attachPresentation(session, options);
+    }
+
+    releasePresentation() {
+        this.impl.releasePresentation();
+    }
+
+    /**
+     * @returns {XRLayer|null} Backend output layer (e.g. XRWebGLLayer), if any.
+     */
+    get presentationLayer() {
+        return this.impl.presentationLayer ?? null;
+    }
+
+    /**
+     * @returns {XRWebGLBinding|null} Backend graphics binding for camera/depth, if any.
+     */
+    get graphicsBinding() {
+        return this.impl.graphicsBinding ?? null;
+    }
+}
+
+export { XrBridge };

--- a/src/platform/graphics/xr-bridge.js
+++ b/src/platform/graphics/xr-bridge.js
@@ -2,6 +2,7 @@
  * @import { GraphicsDevice } from './graphics-device.js'
  * @import { EventHandler } from '../../core/event-handler.js'
  * @import { EventHandle } from '../../core/event-handle.js'
+ * @import { Vec2 } from '../../core/math/vec2.js'
  */
 
 /**
@@ -120,6 +121,28 @@ class XrBridge {
 
     releasePresentation() {
         this.impl.releasePresentation();
+    }
+
+    /**
+     * Writes immersive framebuffer size in pixels for this frame (backend-specific source)
+     * into {@link Vec2#x} (width) and {@link Vec2#y} (height).
+     *
+     * @param {XRFrame} frame - Current XR frame.
+     * @param {Vec2} out - Receives width and height; reused by the caller to avoid per-frame allocation.
+     */
+    getFramebufferSize(frame, out) {
+        this.impl.getFramebufferSize(frame, out);
+    }
+
+    /**
+     * Viewport rectangle for an XR view within the immersive framebuffer (or per-view texture).
+     *
+     * @param {XRFrame} frame - Current XR frame.
+     * @param {XRView} xrView - WebXR view.
+     * @returns {XRViewport} Viewport for this view.
+     */
+    getViewport(frame, xrView) {
+        return this.impl.getViewport(frame, xrView);
     }
 
     /**


### PR DESCRIPTION
Introduces a small platform graphics abstraction so WebXR immersive presentation (output layer, optional `XRWebGLBinding`, and GPU loss/restore glue) lives next to each graphics backend instead of only inside the XR framework.

**Changes:**
- Add `XrBridge` facade plus `WebglXrBridge` and stub `WebgpuXrBridge`, wired from `WebglGraphicsDevice` / `WebgpuGraphicsDevice` via `createXrBridgeImpl`.
- `XrManager` creates a bridge for the active session, uses it for `attachPresentation` / `releasePresentation`, `graphicsBinding`, `presentationLayer` (e.g. fixed foveation), and routes restore failures through the manager `EventHandler`.
- Move `devicelost` / `devicerestored` subscriptions onto the bridge for the session lifetime; bridge holds shared session presentation fields used across backends.
- `XrView` reads `graphicsBinding` for camera/depth paths that use the WebXR GL binding.

**Public API:**
- `XrManager#graphicsBinding` — getter returning the active backend binding for XR camera/depth (`XRWebGLBinding` on WebGL when supported), or `null`.

related to https://github.com/playcanvas/engine/issues/7404