### PR TITLE
refactor(xr): route XR framebuffer through XrBridge; refresh VR LOD example

### DIFF
--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.controls.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.controls.mjs
@@ -2,9 +2,40 @@
  * @param {import('../../app/components/Example.mjs').ControlOptions} options - The options.
  * @returns {JSX.Element} The returned JSX Element.
  */
-export const controls = ({ observer, ReactPCUI, jsx, fragment }) => {
-    const { BindingTwoWay, LabelGroup, Panel, SelectInput, SliderInput, Label } = ReactPCUI;
+export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
+    const { BindingTwoWay, Button, LabelGroup, Panel, SelectInput, SliderInput, Label } = ReactPCUI;
+    const { useEffect, useState } = React;
+
+    /**
+     * XR enter/exit toggle for the control panel.
+     *
+     * @returns {import('react').ReactElement} The button element.
+     */
+    const XrToggleButton = () => {
+        const [xrActive, setXrActive] = useState(!!observer.get('xrActive'));
+        useEffect(() => {
+            const handler = () => setXrActive(!!observer.get('xrActive'));
+            const evt = observer.on('xrActive:set', handler);
+            return () => evt.unbind();
+        }, [observer]);
+        return jsx(Button, {
+            text: xrActive ? 'Exit VR' : 'Enter VR',
+            onClick: () => {
+                if (observer.get('xrActive')) {
+                    observer.emit('xr:exit');
+                } else {
+                    observer.emit('vr:enter');
+                }
+            }
+        });
+    };
+
     return fragment(
+        jsx(
+            Panel,
+            { headerText: 'XR' },
+            jsx(XrToggleButton, null)
+        ),
         jsx(
             Panel,
             { headerText: 'Settings' },

--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
@@ -7,6 +7,8 @@ import * as pc from 'playcanvas';
 
 const { CameraControls } = await fileImport(`${rootPath}/static/scripts/esm/camera-controls.mjs`);
 const { GsplatRevealRadial } = await fileImport(`${rootPath}/static/scripts/esm/gsplat/reveal-radial.mjs`);
+const { XrSession } = await fileImport(`${rootPath}/static/scripts/esm/xr-session.mjs`);
+const { XrNavigation } = await fileImport(`${rootPath}/static/scripts/esm/xr-navigation.mjs`);
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();
@@ -167,6 +169,21 @@ assetListLoader.load(() => {
         focusPoint: focusPoint
     });
 
+    cameraRig.addComponent('script');
+    cameraRig.script.create(XrSession, {
+        properties: {
+            startVrEvent: 'vr:start',
+            endEvent: 'xr:end'
+        }
+    });
+    cameraRig.script.create(XrNavigation, {
+        properties: {
+            enableTeleport: false,
+            enableSnapVertical: false,
+            movementThreshold: 0
+        }
+    });
+
     /** @type {pc.Entity|null} */
     let gsplatEntity = null;
     /** @type {any} */
@@ -246,114 +263,63 @@ assetListLoader.load(() => {
         cc.enabled = !app.xr.active;
     };
 
-    const activateXr = () => {
+    const tryStartVr = () => {
+        if (!app.xr.supported) {
+            setMessage('WebXR is not supported');
+            return;
+        }
         if (app.xr.isAvailable(pc.XRTYPE_VR)) {
-            camera.camera.startXr(pc.XRTYPE_VR, pc.XRSPACE_LOCAL, {
-                callback: function (err) {
-                    if (err) setMessage(`WebXR VR failed to start: ${err.message}`);
-                }
-            });
+            app.fire('vr:start', pc.XRSPACE_LOCAL);
         } else {
             setMessage('Immersive VR is not available');
         }
     };
 
-    if (app.xr.supported) {
-        app.mouse.on('mousedown', () => {
-            if (!app.xr.active) activateXr();
-        });
+    data.on('vr:enter', tryStartVr);
+    data.on('xr:exit', () => {
+        app.fire('xr:end');
+    });
 
+    data.set('xrActive', false);
+
+    if (app.xr.supported) {
         if (app.touch) {
             app.touch.on('touchend', (evt) => {
-                if (!app.xr.active) {
-                    activateXr();
-                } else {
-                    camera.camera.endXr();
+                if (app.xr.active) {
+                    app.fire('xr:end');
+                    evt.event.preventDefault();
+                    evt.event.stopPropagation();
                 }
-                evt.event.preventDefault();
-                evt.event.stopPropagation();
             });
         }
 
-        app.keyboard.on('keydown', (evt) => {
-            if (evt.key === pc.KEY_ESCAPE && app.xr.active) {
-                app.xr.end();
-            }
-        });
-
         app.xr.on('start', () => {
+            data.set('xrActive', true);
             setCameraControlsForXr();
-            setMessage('VR active — left thumbstick: move, right: snap turn; tap to exit');
+            setMessage('VR active — left thumbstick: move, right: snap turn; tap to exit or use Exit VR in the XR panel');
         });
         app.xr.on('end', () => {
+            data.set('xrActive', false);
             setCameraControlsForXr();
-            setMessage('VR ended — click or tap to enter VR');
+            setMessage('VR ended — use Enter VR in the XR panel to re-enter');
         });
         app.xr.on(`available:${pc.XRTYPE_VR}`, (available) => {
-            setMessage(available ? 'Click or tap to enter VR' : 'Immersive VR is unavailable');
+            setMessage(available ? 'Use Enter VR in the XR panel' : 'Immersive VR is unavailable');
         });
 
         if (!app.xr.isAvailable(pc.XRTYPE_VR)) {
             setMessage('Immersive VR is not available');
         } else {
-            setMessage('Click or tap to enter VR');
+            setMessage('Use Enter VR in the XR panel');
         }
     } else {
         setMessage('WebXR is not supported');
     }
 
-    const movementSpeed = 1.5;
-    const rotateSpeed = 45;
-    const rotateThreshold = 0.5;
-    const rotateResetThreshold = 0.25;
-    let lastRotateValue = 0;
-
-    const tmpVec2A = new pc.Vec2();
-    const tmpVec2B = new pc.Vec2();
-    const tmpVec3A = new pc.Vec3();
-
-    app.on('update', (dt) => {
+    app.on('update', () => {
         data.set('data.stats.gsplats', app.stats.frame.gsplats.toLocaleString());
         const bb = app.graphicsDevice.backBufferSize;
         data.set('data.stats.resolution', `${bb.x} x ${bb.y}`);
-
-        if (!app.xr.active) return;
-
-        const sources = app.xr.input.inputSources;
-        for (let i = 0; i < sources.length; i++) {
-            const inputSource = sources[i];
-            if (!inputSource.gamepad) continue;
-
-            if (inputSource.handedness === pc.XRHAND_LEFT) {
-                tmpVec2A.set(inputSource.gamepad.axes[2], inputSource.gamepad.axes[3]);
-                if (tmpVec2A.length()) {
-                    tmpVec2A.normalize();
-                    tmpVec2B.x = camera.forward.x;
-                    tmpVec2B.y = camera.forward.z;
-                    tmpVec2B.normalize();
-                    const rad = Math.atan2(tmpVec2B.x, tmpVec2B.y) - Math.PI / 2;
-                    const t = tmpVec2A.x * Math.sin(rad) - tmpVec2A.y * Math.cos(rad);
-                    tmpVec2A.y = tmpVec2A.y * Math.sin(rad) + tmpVec2A.x * Math.cos(rad);
-                    tmpVec2A.x = t;
-                    tmpVec2A.mulScalar(movementSpeed * dt);
-                    cameraRig.translate(tmpVec2A.x, 0, tmpVec2A.y);
-                }
-            } else if (inputSource.handedness === pc.XRHAND_RIGHT) {
-                const rotate = -inputSource.gamepad.axes[2];
-                if (lastRotateValue > 0 && rotate < rotateResetThreshold) {
-                    lastRotateValue = 0;
-                } else if (lastRotateValue < 0 && rotate > -rotateResetThreshold) {
-                    lastRotateValue = 0;
-                }
-                if (lastRotateValue === 0 && Math.abs(rotate) > rotateThreshold) {
-                    lastRotateValue = Math.sign(rotate);
-                    tmpVec3A.copy(camera.getLocalPosition());
-                    cameraRig.translateLocal(tmpVec3A);
-                    cameraRig.rotateLocal(0, Math.sign(rotate) * rotateSpeed, 0);
-                    cameraRig.translateLocal(tmpVec3A.mulScalar(-1));
-                }
-            }
-        }
     });
 });
 

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -244,9 +244,6 @@ class AppBase extends EventHandler {
 
         if (xrFrame) {
             skipUpdate = !this.xr?.update(xrFrame);
-            this.graphicsDevice.defaultFramebuffer = xrFrame.session.renderState.baseLayer.framebuffer;
-        } else {
-            this.graphicsDevice.defaultFramebuffer = null;
         }
 
         if (!skipUpdate) {

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -915,6 +915,8 @@ class XrManager extends EventHandler {
 
         this.fire('update', frame);
 
+        this.xrBridge.beginFrame(frame);
+
         return true;
     }
 

--- a/src/platform/graphics/webgl/webgl-xr-bridge.js
+++ b/src/platform/graphics/webgl/webgl-xr-bridge.js
@@ -40,11 +40,14 @@ class WebglXrBridge {
 
     /**
      * Sets the WebGL default framebuffer to the XR session's base layer framebuffer.
+     * When there is no base layer (for example after GPU device loss), falls back to the
+     * canvas framebuffer by assigning null.
      *
      * @param {XRFrame} frame - Current XR frame.
      */
     beginFrame(frame) {
-        this.xrBridge.device.defaultFramebuffer = frame.session.renderState.baseLayer.framebuffer;
+        const baseLayer = frame.session.renderState.baseLayer;
+        this.xrBridge.device.defaultFramebuffer = baseLayer ? baseLayer.framebuffer : null;
     }
 
     /**
@@ -84,10 +87,14 @@ class WebglXrBridge {
     /**
      * @param {XRFrame} frame - Current XR frame.
      * @param {XRView} xrView - WebXR view.
-     * @returns {XRViewport} Viewport from the session base layer.
+     * @returns {XRViewport} Viewport from the session base layer, or zeros if the base layer is unavailable.
      */
     getViewport(frame, xrView) {
-        return frame.session.renderState.baseLayer.getViewport(xrView);
+        const baseLayer = frame.session.renderState.baseLayer;
+        if (!baseLayer) {
+            return /** @type {XRViewport} */ ({ x: 0, y: 0, width: 0, height: 0 });
+        }
+        return baseLayer.getViewport(xrView);
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-xr-bridge.js
+++ b/src/platform/graphics/webgl/webgl-xr-bridge.js
@@ -39,6 +39,22 @@ class WebglXrBridge {
     }
 
     /**
+     * Sets the WebGL default framebuffer to the XR session's base layer framebuffer.
+     *
+     * @param {XRFrame} frame - Current XR frame.
+     */
+    beginFrame(frame) {
+        this.xrBridge.device.defaultFramebuffer = frame.session.renderState.baseLayer.framebuffer;
+    }
+
+    /**
+     * Resets the WebGL default framebuffer to the canvas (null).
+     */
+    endFrame() {
+        this.xrBridge.device.defaultFramebuffer = null;
+    }
+
+    /**
      * @returns {XRWebGLLayer|null} The active XR output layer, if any.
      */
     get presentationLayer() {

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -25,6 +25,15 @@ class WebgpuXrBridge {
     }
 
     /**
+     * @param {XRFrame} _frame - Current XR frame.
+     */
+    beginFrame(_frame) {
+    }
+
+    endFrame() {
+    }
+
+    /**
      * @returns {null} WebGPU XR presentation is not implemented yet.
      */
     get presentationLayer() {

--- a/src/platform/graphics/xr-bridge.js
+++ b/src/platform/graphics/xr-bridge.js
@@ -85,6 +85,7 @@ class XrBridge {
             this._evtDeviceRestored?.off();
             this._evtDeviceRestored = null;
 
+            this.impl.endFrame();
             this.impl.destroy(device);
             this.impl = null;
 
@@ -121,6 +122,22 @@ class XrBridge {
 
     releasePresentation() {
         this.impl.releasePresentation();
+    }
+
+    /**
+     * Called once per XR frame before rendering to set the backend render target for this frame.
+     *
+     * @param {XRFrame} frame - Current XR frame.
+     */
+    beginFrame(frame) {
+        this.impl.beginFrame(frame);
+    }
+
+    /**
+     * Resets the backend render target after the XR session ends.
+     */
+    endFrame() {
+        this.impl.endFrame();
     }
 
     /**


### PR DESCRIPTION
WebGL XR presentation now binds the session framebuffer inside the graphics XR bridge each frame, instead of in `AppBase`. The Gaussian splatting VR LOD example is aligned with shared ESM XR helpers and uses the examples control panel for session entry and exit.

**Changes:**
- Add `XrBridge.beginFrame` / `endFrame` and wire WebGL to set `defaultFramebuffer` from the XR base layer; WebGPU stubs are no-ops.
- Call `xrBridge.beginFrame` at the end of `XrManager.update`; call `endFrame` from `XrBridge.destroy` before tearing down the implementation.
- Remove per-tick `defaultFramebuffer` assignment from `AppBase`.
- **VR LOD example:** use `xr-session.mjs` and `xr-navigation.mjs`; XR panel titled **XR** with **Enter VR** / **Exit VR** (observer `xrActive`); remove click-to-enter on the canvas; touch still exits when already in VR.

**Examples:**
- Updated `examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs` and `vr-lod.controls.mjs`.

related to https://github.com/playcanvas/engine/issues/7404