### PR TITLE
fix(graphics): default xrCompatible for WebGL and WebGPU paths

### DIFF
--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
@@ -1,5 +1,4 @@
 // @config HIDDEN
-// @config WEBGPU_DISABLED
 // @config NO_MINISTATS
 import { data } from 'examples/observer';
 import { deviceType, rootPath, fileImport } from 'examples/utils';

--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -1,5 +1,3 @@
-import { platform } from '../../core/platform.js';
-
 import { DEVICETYPE_WEBGL2, DEVICETYPE_WEBGPU, DEVICETYPE_WEBGPU_BARE, DEVICETYPE_NULL } from './constants.js';
 import { WebgpuGraphicsDevice } from './webgpu/webgpu-graphics-device.js';
 import { WebglGraphicsDevice } from './webgl/webgl-graphics-device.js';
@@ -36,7 +34,8 @@ import { NullGraphicsDevice } from './null/null-graphics-device.js';
  * {@link DEVICETYPE_WEBGL2} device type creation.
  * @param {string} [options.twgslUrl] - An url to twgsl script, required if glslangUrl was specified.
  * @param {boolean} [options.xrCompatible] - Boolean that hints to the user agent to use a
- * compatible graphics adapter for an immersive XR device.
+ * compatible graphics adapter for an immersive XR device. When omitted in a browser, defaults to
+ * `true` if `navigator.xr` is present, otherwise `false` (see {@link GraphicsDevice} constructor).
  * @param {'default'|'high-performance'|'low-power'} [options.powerPreference] - A hint indicating
  * what configuration of GPU would be selected. Possible values are:
  *
@@ -59,11 +58,6 @@ function createGraphicsDevice(canvas, options = {}) {
     }
     if (!deviceTypes.includes(DEVICETYPE_NULL)) {
         deviceTypes.push(DEVICETYPE_NULL);
-    }
-
-    // XR compatibility if not specified
-    if (platform.browser && !!navigator.xr) {
-        options.xrCompatible ??= true;
     }
 
     // make a list of device creation functions in priority order

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -600,6 +600,9 @@ class GraphicsDevice extends EventHandler {
         this.initOptions.powerPreference ??= 'high-performance';
         this.initOptions.displayFormat ??= DISPLAYFORMAT_LDR;
 
+        // If WebXR is exposed, default to an XR-suitable GPU
+        this.initOptions.xrCompatible ??= platform.browser && !!navigator.xr;
+
         // Some devices window.devicePixelRatio can be less than one
         // eg Oculus Quest 1 which returns a window.devicePixelRatio of 0.8
         this._maxPixelRatio = platform.browser ? Math.min(1, window.devicePixelRatio) : 1;

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -288,7 +288,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         /** @type {GPURequestAdapterOptions} */
         const adapterOptions = {
             powerPreference: this.initOptions.powerPreference !== 'default' ? this.initOptions.powerPreference : undefined,
-            xrCompatible: this.initOptions.xrCompatible
+
+            // Required for WebXR sessions using WebGPU
+            xrCompatible: !!this.initOptions.xrCompatible
         };
 
         /**


### PR DESCRIPTION
Default `xrCompatible` in `GraphicsDevice` when `navigator.xr` is present in a browser, so WebGL context creation and WebGPU `requestAdapter` both receive the same hint without relying on `createGraphicsDevice` alone.

**Changes:**
- Set `initOptions.xrCompatible` in `GraphicsDevice` alongside other constructor defaults.
- Remove the redundant defaulting block from `createGraphicsDevice` and document the behavior in its JSDoc.
- Pass `xrCompatible` as an explicit boolean into `GPURequestAdapterOptions` in `WebgpuGraphicsDevice.createDevice`.