### PR TITLE
fix(examples): avoid clipping select dropdowns in landscape controls

### DIFF
--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -386,7 +386,13 @@ class Example extends TypedComponent {
                     collapsed
                 },
                 this.renderDeviceSelector(),
-                this.renderControls()
+                jsx(
+                    Container,
+                    {
+                        id: 'controlPanel-scroll-region'
+                    },
+                    this.renderControls()
+                )
             ),
             this.renderDescription()
         );

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -415,15 +415,29 @@ body {
     background-color: #364346;
 }
 
-/* Landscape/desktop: tall controls scroll inside the panel (same idea as #sideBar-contents). */
+/* Landscape/desktop: scroll only the example controls, not the device selector, so PCUI
+   SelectInput dropdowns (position: absolute) are not clipped by overflow. */
 #controlPanel.landscape {
-    overflow: hidden;
+    overflow: visible;
+    max-height: min(calc(100% - 16px), calc(100vh - 48px));
 }
 
 #controlPanel.landscape > .pcui-panel-content {
-    overflow-y: auto;
-    max-height: calc(100vh - 48px);
+    display: flex;
+    flex-direction: column;
+    flex: 1;
     min-height: 0;
+    overflow: visible;
+}
+
+#controlPanel.landscape #deviceTypeSelectInput {
+    flex-shrink: 0;
+}
+
+#controlPanel-scroll-region {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
 }
 
 #descriptionPanel {


### PR DESCRIPTION
Follow-up to #8707: scrolling the whole `.pcui-panel-content` clipped PCUI `SelectInput` menus (they use `position: absolute` inside the overflow region). Examples with only **Active Device** (e.g. loaders/bundle) showed an empty-looking dropdown until the panel was scrolled.

**Changes:**
- Wrap landscape `renderControls()` in `#controlPanel-scroll-region` so only example parameters scroll.
- Keep the device selector above that region; use flex layout + `min-height: 0` so the scroll area still fills remaining height when the panel hits its max height.
- Set `#controlPanel.landscape` to `overflow: visible` and cap height with `max-height: min(calc(100% - 16px), calc(100vh - 48px))` so tall control lists remain usable on short viewports.

**Note:** `SelectInput` controls that live inside a long, scrolled `.controls.mjs` panel can still be clipped if their list opens past the bottom of `#controlPanel-scroll-region`; fixing that would require rendering the list outside the scroll subtree (e.g. PCUI portal/fixed overlay).