### PR TITLE
feat: WebGPU immersive XR presentation

### DIFF
--- a/examples/src/examples/xr/ar-basic.example.mjs
+++ b/examples/src/examples/xr/ar-basic.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGPU_DISABLED
+import { deviceType } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -18,12 +18,33 @@ const message = function (msg) {
     el.textContent = msg;
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window),
-    graphicsDeviceOptions: { alpha: true }
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
 
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
@@ -34,9 +55,6 @@ window.addEventListener('resize', resize);
 app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 app.start();
 

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -915,7 +915,7 @@ class XrManager extends EventHandler {
 
         this.fire('update', frame);
 
-        this.xrBridge.beginFrame(frame);
+        this.xrBridge.beginFrame(frame, this._referenceSpace);
 
         return true;
     }

--- a/src/platform/graphics/webgl/webgl-xr-bridge.js
+++ b/src/platform/graphics/webgl/webgl-xr-bridge.js
@@ -44,8 +44,9 @@ class WebglXrBridge {
      * canvas framebuffer by assigning null.
      *
      * @param {XRFrame} frame - Current XR frame.
+     * @param {XRReferenceSpace|null} _referenceSpace - Active XR reference space.
      */
-    beginFrame(frame) {
+    beginFrame(frame, _referenceSpace) {
         const baseLayer = frame.session.renderState.baseLayer;
         this.xrBridge.device.defaultFramebuffer = baseLayer ? baseLayer.framebuffer : null;
     }

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -540,6 +540,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             this.xrColorTexture ??
             this.gpuContext?.getCurrentTexture?.() ??
             this.externalBackbuffer?.impl.gpuTexture;
+        Debug.assert(outColorBuffer, 'WebGPU frameStart requires an XR color texture, canvas swapchain texture, or externalBackbuffer.');
         DebugHelper.setLabel(outColorBuffer, `${this.backBuffer.name}`);
 
         // reallocate framebuffer if dimensions change, to match the output texture

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -158,16 +158,14 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
     /**
      * When set, immersive XR writes color to this texture instead of the canvas swapchain.
-     *
-     * @type {GPUTexture|null}
+     * @type {any} // `GPUTexture | null`; using `any` to avoid exporting WebGPU types in published typings.
      * @ignore
      */
     xrColorTexture = null;
 
     /**
      * View format of {@link WebgpuGraphicsDevice#xrColorTexture} for render pass attachment views.
-     *
-     * @type {GPUTextureFormat|null}
+     * @type {any} // `GPUTextureFormat | null`; using `any` to avoid exporting WebGPU types in published typings.
      * @ignore
      */
     xrColorTextureViewFormat = null;

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -37,6 +37,7 @@ import { WebgpuXrBridge } from './webgpu-xr-bridge.js';
 
 /**
  * @import { RenderPass } from '../render-pass.js'
+ * @import { Texture } from '../texture.js'
  */
 
 const _uniqueLocations = new Map();
@@ -156,6 +157,33 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     submitVersion = 0;
 
     /**
+     * When set, immersive XR writes color to this texture instead of the canvas swapchain.
+     *
+     * @type {GPUTexture|null}
+     * @ignore
+     */
+    xrColorTexture = null;
+
+    /**
+     * View format of {@link WebgpuGraphicsDevice#xrColorTexture} for render pass attachment views.
+     *
+     * @type {GPUTextureFormat|null}
+     * @ignore
+     */
+    xrColorTextureViewFormat = null;
+
+    /**
+     * When set, used as the main color attachment in {@link WebgpuGraphicsDevice#frameStart} if there is
+     * no XR color texture and no canvas {@link GPUCanvasContext#getCurrentTexture} (for example headless
+     * or custom-surface hosts). Must be a WebGPU-backed {@link Texture}; {@link Texture#impl} must expose
+     * {@link WebgpuTexture#gpuTexture}.
+     *
+     * @type {Texture|null}
+     * @ignore
+     */
+    externalBackbuffer = null;
+
+    /**
      * Current command buffer encoder.
      *
      * @type {GPUCommandEncoder|null}
@@ -211,6 +239,11 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
         this.resolver.destroy();
         this.resolver = null;
+
+        this.xrColorTexture = null;
+        this.xrColorTextureViewFormat = null;
+
+        this.externalBackbuffer = null;
 
         super.destroy();
     }
@@ -504,8 +537,11 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         WebgpuDebug.memory(this);
         WebgpuDebug.validate(this);
 
-        // current frame color output buffer (fallback to external backbuffer if not available)
-        const outColorBuffer = this.gpuContext?.getCurrentTexture?.() ?? this.externalBackbuffer?.impl.gpuTexture;
+        // current frame color output buffer (XR overrides canvas swapchain; external backbuffer is last resort)
+        const outColorBuffer =
+            this.xrColorTexture ??
+            this.gpuContext?.getCurrentTexture?.() ??
+            this.externalBackbuffer?.impl.gpuTexture;
         DebugHelper.setLabel(outColorBuffer, `${this.backBuffer.name}`);
 
         // reallocate framebuffer if dimensions change, to match the output texture
@@ -522,13 +558,17 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         const rt = this.backBuffer;
         const wrt = rt.impl;
 
+        const attachmentViewFormat = (outColorBuffer === this.xrColorTexture && this.xrColorTextureViewFormat) ?
+            this.xrColorTextureViewFormat :
+            this.backBufferViewFormat;
+
         // assign the format, allowing following init call to use it to allocate matching multisampled buffer
-        wrt.setColorAttachment(0, undefined, this.backBufferViewFormat);
+        wrt.setColorAttachment(0, undefined, attachmentViewFormat);
 
         this.initRenderTarget(rt);
 
         // assign current frame's render texture
-        wrt.assignColorTexture(this, outColorBuffer);
+        wrt.assignColorTexture(outColorBuffer, attachmentViewFormat);
 
         WebgpuDebug.end(this, 'frameStart');
         WebgpuDebug.end(this, 'frameStart');

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -188,16 +188,16 @@ class WebgpuRenderTarget {
      * Assign a color buffer. This allows the color buffer of the main framebuffer
      * to be swapped each frame to a buffer provided by the context.
      *
-     * @param {WebgpuGraphicsDevice} device - The WebGPU graphics device.
-     * @param {any} gpuTexture - The color buffer.
+     * @param {GPUTexture} gpuTexture - The color buffer.
+     * @param {GPUTextureFormat} viewFormat - View format for the render pass attachment (may differ from texture storage for sRGB).
      */
-    assignColorTexture(device, gpuTexture) {
+    assignColorTexture(gpuTexture, viewFormat) {
 
         Debug.assert(gpuTexture);
         this.assignedColorTexture = gpuTexture;
 
         // create view (optionally handles srgb conversion)
-        const view = gpuTexture.createView({ format: device.backBufferViewFormat });
+        const view = gpuTexture.createView({ format: viewFormat });
         DebugHelper.setLabel(view, 'Framebuffer.assignedColor');
 
         // use it as render buffer or resolve target
@@ -210,7 +210,7 @@ class WebgpuRenderTarget {
         }
 
         // for main framebuffer, this is how the format is obtained
-        this.setColorAttachment(0, undefined, device.backBufferViewFormat);
+        this.setColorAttachment(0, undefined, viewFormat);
 
         this.updateKey();
     }
@@ -431,7 +431,12 @@ class WebgpuRenderTarget {
         // multi-sampled color buffer
         if (samples > 1) {
 
-            const format = this.isBackbuffer ? device.backBufferViewFormat : colorBuffer.impl.format;
+            // Main framebuffer: MSAA texture format must match the attachment view format used for
+            // resolve; WebgpuGraphicsDevice#frameStart sets that on this impl via setColorAttachment
+            // before the first init.
+            const format = this.isBackbuffer ?
+                (this.colorAttachments[index]?.format ?? device.backBufferViewFormat) :
+                colorBuffer.impl.format;
 
             /** @type {GPUTextureDescriptor} */
             const multisampledTextureDesc = {

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -188,8 +188,8 @@ class WebgpuRenderTarget {
      * Assign a color buffer. This allows the color buffer of the main framebuffer
      * to be swapped each frame to a buffer provided by the context.
      *
-     * @param {GPUTexture} gpuTexture - The color buffer.
-     * @param {GPUTextureFormat} viewFormat - View format for the render pass attachment (may differ from texture storage for sRGB).
+     * @param {any} gpuTexture - // `GPUTexture`; using `any` to avoid exporting WebGPU types in published typings.
+     * @param {any} viewFormat - // `GPUTextureFormat`; using `any` to avoid exporting WebGPU types in published typings (may differ from texture storage for sRGB).
      */
     assignColorTexture(gpuTexture, viewFormat) {
 

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -12,13 +12,13 @@ import { Vec2 } from '../../../core/math/vec2.js';
  */
 class WebgpuXrBridge {
     /**
-     * @type {XRGPUBinding|null}
+     * @type {any} // `XRGPUBinding | null`; using `any` to avoid exporting WebXR GPU types in published typings.
      * @private
      */
     _binding = null;
 
     /**
-     * @type {XRProjectionLayer|null}
+     * @type {any} // `XRProjectionLayer | null`; using `any` to avoid exporting WebXR GPU types in published typings.
      * @private
      */
     _layer = null;
@@ -69,7 +69,7 @@ class WebgpuXrBridge {
             return;
         }
 
-        /** @type {XRGPUSubImage|null} */
+        /** @type {any} // `XRGPUSubImage | null`; using `any` to avoid exporting WebXR GPU types in published typings. */
         let firstSub = null;
         for (let i = 0; i < pose.views.length; i++) {
             try {
@@ -101,14 +101,14 @@ class WebgpuXrBridge {
     }
 
     /**
-     * @returns {XRProjectionLayer|null} Active projection layer, if any.
+     * @returns {any} // `XRProjectionLayer | null`; using `any` to avoid exporting WebXR GPU types in published typings.
      */
     get presentationLayer() {
         return this._layer;
     }
 
     /**
-     * @returns {XRGPUBinding|null} WebXR WebGPU binding, if any.
+     * @returns {any} // `XRGPUBinding | null`; using `any` to avoid exporting WebXR GPU types in published typings.
      */
     get graphicsBinding() {
         return this._binding;

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -1,8 +1,9 @@
 /**
  * @import { XrBridge } from '../xr-bridge.js'
  * @import { GraphicsDevice } from '../graphics-device.js'
- * @import { Vec2 } from '../../../core/math/vec2.js'
  */
+
+import { Vec2 } from '../../../core/math/vec2.js';
 
 /**
  * WebGPU graphics implementation for {@link XrBridge}.
@@ -10,6 +11,26 @@
  * @ignore
  */
 class WebgpuXrBridge {
+    /**
+     * @type {XRGPUBinding|null}
+     * @private
+     */
+    _binding = null;
+
+    /**
+     * @type {XRProjectionLayer|null}
+     * @private
+     */
+    _layer = null;
+
+    /**
+     * Last known immersive color buffer size in pixels (updated in {@link WebgpuXrBridge#beginFrame}).
+     *
+     * @type {Vec2}
+     * @private
+     */
+    _cachedFramebufferSize = new Vec2();
+
     /**
      * @param {XrBridge} xrBridge - The XR bridge.
      */
@@ -22,52 +43,162 @@ class WebgpuXrBridge {
      * @param {GraphicsDevice} device - The graphics device.
      */
     destroy(device) {
+        this._binding = null;
+        this._layer = null;
+        this._cachedFramebufferSize.set(0, 0);
+        device.xrColorTexture = null;
+        device.xrColorTextureViewFormat = null;
     }
 
     /**
-     * @param {XRFrame} _frame - Current XR frame.
+     * @param {XRFrame} frame - Current XR frame.
+     * @param {XRReferenceSpace|null} referenceSpace - Active reference space for the XR session.
      */
-    beginFrame(_frame) {
+    beginFrame(frame, referenceSpace) {
+        const device = this.xrBridge.device;
+
+        device.xrColorTexture = null;
+        device.xrColorTextureViewFormat = null;
+
+        if (!this._binding || !this._layer || !referenceSpace) {
+            return;
+        }
+
+        const pose = frame.getViewerPose(referenceSpace);
+        if (!pose || !pose.views?.length) {
+            return;
+        }
+
+        /** @type {XRGPUSubImage|null} */
+        let firstSub = null;
+        for (let i = 0; i < pose.views.length; i++) {
+            try {
+                const sub = this._binding.getViewSubImage(this._layer, pose.views[i]);
+                // TODO: stereo / multiview WebGPU — drive per-eye color (e.g. texture-array projection layer);
+                // v1 only keeps the first view for xrColorTexture (see createProjectionLayer TODO).
+                if (i === 0) {
+                    firstSub = sub;
+                }
+            } catch (e) {
+                this.xrBridge._onBindingError?.(e);
+                return;
+            }
+        }
+
+        if (firstSub?.colorTexture) {
+            device.xrColorTexture = firstSub.colorTexture;
+            device.xrColorTextureViewFormat = firstSub.colorTexture.format;
+            this._cachedFramebufferSize.set(firstSub.colorTexture.width, firstSub.colorTexture.height);
+        }
     }
 
     endFrame() {
+        const device = this.xrBridge.device;
+        if (device) {
+            device.xrColorTexture = null;
+            device.xrColorTextureViewFormat = null;
+        }
     }
 
     /**
-     * @returns {null} WebGPU XR presentation is not implemented yet.
+     * @returns {XRProjectionLayer|null} Active projection layer, if any.
      */
     get presentationLayer() {
-        return null;
+        return this._layer;
     }
 
     /**
-     * @returns {null} WebGPU XR binding is not implemented yet.
+     * @returns {XRGPUBinding|null} WebXR WebGPU binding, if any.
      */
     get graphicsBinding() {
-        return null;
+        return this._binding;
     }
 
     /**
-     * @param {XRFrame} _frame - Current XR frame.
-     * @param {Vec2} out - Placeholder until WebGPU XR presentation is implemented.
+     * @param {XRFrame} frame - Current XR frame.
+     * @param {Vec2} out - Width in {@link Vec2#x}, height in {@link Vec2#y}.
      */
     getFramebufferSize(_frame, out) {
+        const layer = /** @type {any} */ (this._layer);
+        if (layer) {
+            const lw = layer.textureWidth ?? layer.width;
+            const lh = layer.textureHeight ?? layer.height;
+            if (lw > 0 && lh > 0) {
+                out.set(lw, lh);
+                return;
+            }
+        }
+        if (this._cachedFramebufferSize.x > 0 && this._cachedFramebufferSize.y > 0) {
+            out.copy(this._cachedFramebufferSize);
+            return;
+        }
         out.set(0, 0);
     }
 
     /**
-     * @param {XRFrame} _frame - Current XR frame.
-     * @param {XRView} _xrView - WebXR view.
-     * @returns {XRViewport} Stub until WebGPU XR presentation is implemented.
+     * @param {XRFrame} frame - Current XR frame.
+     * @param {XRView} xrView - WebXR view.
+     * @returns {XRViewport|null} Viewport for this view, or null if unavailable.
      */
-    getViewport(_frame, _xrView) {
-        return null;
+    getViewport(_frame, xrView) {
+        if (this._binding && this._layer) {
+            try {
+                const sub = this._binding.getViewSubImage(this._layer, xrView);
+                if (sub?.viewport) {
+                    return sub.viewport;
+                }
+            } catch {
+            }
+        }
+        return /** @type {XRViewport} */ ({ x: 0, y: 0, width: 0, height: 0 });
     }
 
-    attachPresentation(_session, _options) {
+    /**
+     * @param {XRSession} session - XR session.
+     * @param {object} options - Presentation options.
+     * @param {number} options.framebufferScaleFactor - Resolved framebuffer scale factor.
+     * @param {number} options.depthNear - Depth near plane.
+     * @param {number} options.depthFar - Depth far plane.
+     * @param {Function} [options.onBindingError] - Called if XRGPUBinding construction fails.
+     */
+    attachPresentation(session, options) {
+        const XRGPUBindingCtor = globalThis.XRGPUBinding;
+        if (typeof XRGPUBindingCtor === 'undefined') {
+            this.xrBridge._onBindingError?.(new Error('XRGPUBinding is not available in this browser.'));
+            return;
+        }
+
+        const device = this.xrBridge.device;
+        const wgpu = device.wgpu;
+
+        try {
+            this._binding = new XRGPUBindingCtor(session, wgpu);
+        } catch (ex) {
+            this.xrBridge._onBindingError?.(ex);
+            return;
+        }
+
+        const colorFormat = this._binding.getPreferredColorFormat();
+
+        this._layer = this._binding.createProjectionLayer({
+            colorFormat,
+            // TODO: Support textureType 'texture-array' for stereo array layouts (multiview / per-eye slices).
+            textureType: 'texture',
+            scaleFactor: options.framebufferScaleFactor
+        });
+
+        session.updateRenderState({
+            layers: [this._layer],
+            depthNear: options.depthNear,
+            depthFar: options.depthFar
+        });
     }
 
+    /**
+     * Clears the WebXR WebGPU binding reference (projection layer remains until session end).
+     */
     releasePresentation() {
+        this._binding = null;
     }
 
     onGraphicsDeviceLost() {

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -138,7 +138,7 @@ class WebgpuXrBridge {
     /**
      * @param {XRFrame} frame - Current XR frame.
      * @param {XRView} xrView - WebXR view.
-     * @returns {XRViewport|null} Viewport for this view, or null if unavailable.
+     * @returns {XRViewport} Viewport for this view, or zeros if unavailable.
      */
     getViewport(_frame, xrView) {
         if (this._binding && this._layer) {

--- a/src/platform/graphics/xr-bridge.js
+++ b/src/platform/graphics/xr-bridge.js
@@ -128,9 +128,11 @@ class XrBridge {
      * Called once per XR frame before rendering to set the backend render target for this frame.
      *
      * @param {XRFrame} frame - Current XR frame.
+     * @param {XRReferenceSpace|null} referenceSpace - Active XR reference space (WebGPU path uses
+     * it for subimages).
      */
-    beginFrame(frame) {
-        this.impl.beginFrame(frame);
+    beginFrame(frame, referenceSpace) {
+        this.impl.beginFrame(frame, referenceSpace);
     }
 
     /**


### PR DESCRIPTION
partial implementation of https://github.com/playcanvas/engine/issues/7404

Adds initial WebXR immersive rendering support when using a WebGPU graphics device (`XRGPUBinding`, `XRGPUProjectionLayer`), including routing the session color texture into the WebGPU backbuffer path each frame. WebGL behavior is unchanged aside from an extra ignored `beginFrame` argument for API parity.

**Changes:**
- WebGPU: XR bridge attaches a projection layer, updates `xrColorTexture` / view format per frame from `getViewSubImage`, and clears them in `endFrame` / destroy.
- WebGPU: `frameStart` prefers the XR color texture over the canvas swapchain (with optional `externalBackbuffer` fallback for non-canvas hosts).
- WebGPU: render-target color assignment and MSAA formats follow the configured attachment view format (including XR subimage format).
- XR: `XrBridge.beginFrame(frame, referenceSpace)` and `XrManager` pass the active reference space through to the backend.
- Examples: `ar-basic` uses `deviceType` and `createGraphicsDevice` so the device selector matches the runtime backend (WebGPU or WebGL2).

**Examples:**
- Updated `examples/src/examples/xr/ar-basic.example.mjs`.

**Notes:**
- Stereo WebGPU is still first-view oriented; follow-up work is noted in code for `texture-array` / multiview.

This is required to run the example on Android
<img width="907" height="541" alt="Screenshot 2026-05-11 at 15 34 34" src="https://github.com/user-attachments/assets/626c18fa-e75e-4830-b29e-2ab82c663571" />


<img width="1344" height="2992" alt="Screenshot_20260511-151153" src="https://github.com/user-attachments/assets/24faa465-061f-4668-a46f-84b4a5597210" />
