### PR TITLE
build: simplify rollup target generation

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -16,7 +16,6 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import path from 'node:path';
 import { parseArgs, stripVTControlCharacters } from 'node:util';
@@ -116,8 +115,6 @@ const fail = (msg) => {
 
 const bin = name => path.join(BIN_DIR, process.platform === 'win32' ? `${name}.cmd` : name);
 
-const relBundle = () => path.join('build', `playcanvas${format === 'umd' ? '.js' : '.mjs'}`);
-
 const getRollupBuild = () => {
     if (!BUILD_TYPES.includes(type)) {
         fail(`--type must be one of: ${BUILD_TYPES.join(', ')}`);
@@ -142,12 +139,7 @@ const getRollupBuild = () => {
         return 'build:types';
     }
 
-    if (type === 'min') {
-        const build = `build:${format}:min:bundled`;
-        return existsSync(relBundle()) ? `${build},bundleSource:rel` : build;
-    }
-
-    return `build:${format}:${type}${format === 'umd' ? ':bundled' : ''}`;
+    return `build:${format}:${type}`;
 };
 
 const runRollup = () => {

--- a/examples/rollup.config.mjs
+++ b/examples/rollup.config.mjs
@@ -220,7 +220,7 @@ const ENGINE_TARGETS = (() => {
             ...buildJSOptions({
                 moduleFormat: 'esm',
                 buildType: 'rel',
-                bundleState: 'bundled',
+                preserveModules: false,
                 input: '../src/index.js',
                 dir: 'dist/iframe'
             })
@@ -232,7 +232,7 @@ const ENGINE_TARGETS = (() => {
             ...buildJSOptions({
                 moduleFormat: 'esm',
                 buildType: 'dbg',
-                bundleState: 'bundled',
+                preserveModules: false,
                 input: '../src/index.js',
                 dir: 'dist/iframe'
             })
@@ -244,7 +244,7 @@ const ENGINE_TARGETS = (() => {
             ...buildJSOptions({
                 moduleFormat: 'esm',
                 buildType: 'prf',
-                bundleState: 'bundled',
+                preserveModules: false,
                 input: '../src/index.js',
                 dir: 'dist/iframe'
             })

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -7,21 +7,15 @@ const BOLD_OUT = '\x1b[1m';
 const RESET_OUT = '\x1b[0m';
 
 const BUILD_TYPES = /** @type {const} */ (['rel', 'dbg', 'prf', 'min']);
-const MODULE_FORMAT = /** @type {const} */ (['umd', 'esm']);
-const BUNDLE_STATES = /** @type {const} */ (['unbundled', 'bundled']);
+const MODULE_FORMATS = /** @type {const} */ (['umd', 'esm']);
 
 const envBuild = process.env.build ? process.env.build.toLowerCase() : null;
-const bundleSource = process.env.bundleSource ? process.env.bundleSource.toLowerCase() : null;
 
-function includeBuild(buildType, moduleFormat, bundleState) {
+function includeBuild(buildType, moduleFormat) {
     return envBuild === null ||
         envBuild === buildType ||
         envBuild === moduleFormat ||
-        envBuild === bundleState ||
-        envBuild === `${moduleFormat}:${buildType}` ||
-        envBuild === `${moduleFormat}:${bundleState}` ||
-        envBuild === `${buildType}:${bundleState}` ||
-        envBuild === `${moduleFormat}:${buildType}:${bundleState}`;
+        envBuild === `${moduleFormat}:${buildType}`;
 }
 
 /**
@@ -29,26 +23,15 @@ function includeBuild(buildType, moduleFormat, bundleState) {
  */
 const targets = [];
 BUILD_TYPES.forEach((buildType) => {
-    MODULE_FORMAT.forEach((moduleFormat) => {
-        BUNDLE_STATES.forEach((bundleState) => {
-            if (bundleState === 'unbundled' && moduleFormat === 'umd') {
-                return;
-            }
-            if (bundleState === 'unbundled' && buildType === 'min') {
-                return;
-            }
+    MODULE_FORMATS.forEach((moduleFormat) => {
+        if (!includeBuild(buildType, moduleFormat)) {
+            return;
+        }
 
-            if (!includeBuild(buildType, moduleFormat, bundleState)) {
-                return;
-            }
-
-            targets.push(...buildJSOptions({
-                moduleFormat,
-                buildType,
-                bundleState,
-                bundleSource
-            }));
-        });
+        targets.push(...buildJSOptions({
+            moduleFormat,
+            buildType
+        }));
     });
 });
 

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,6 @@
   "globalDependencies": [
     ".git/HEAD",
     ".git/packed-refs",
-    ".git/refs/heads/**",
     "build.mjs",
     "package-lock.json",
     "package.json",
@@ -125,22 +124,16 @@
       ]
     },
     "build:min:umd": {
-      "dependsOn": [
-        "build:rel:umd"
-      ],
       "inputs": [
-        "package.json"
+        "src/**/*.js"
       ],
       "outputs": [
         "build/playcanvas.min.js"
       ]
     },
     "build:min:esm": {
-      "dependsOn": [
-        "build:rel:esm"
-      ],
       "inputs": [
-        "package.json"
+        "src/**/*.js"
       ],
       "outputs": [
         "build/playcanvas.min.mjs"

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -2,6 +2,7 @@
 import resolve from '@rollup/plugin-node-resolve';
 import strip from '@rollup/plugin-strip';
 import swcPlugin from '@rollup/plugin-swc';
+import { minify } from '@swc/core';
 
 // unofficial package plugins
 import dts from 'rollup-plugin-dts';
@@ -75,7 +76,16 @@ const OUT_PREFIX = {
     min: 'playcanvas.min'
 };
 
-const HISTORY = new Map();
+const MINIFY_OPTIONS = {
+    compress: {
+        drop_console: true,
+        pure_funcs: []
+    },
+    mangle: true,
+    format: {
+        comments: false
+    }
+};
 
 /**
  * @param {'rel'|'dbg'|'prf'} buildType - The build type.
@@ -151,18 +161,29 @@ function getOutPlugins(type) {
     return plugins;
 }
 
+function minifyOutput(esm, banner) {
+    return {
+        name: 'swc-minify',
+        async renderChunk(code) {
+            const result = await minify(code, {
+                ...MINIFY_OPTIONS,
+                module: esm
+            });
+            return {
+                code: `${banner}\n${result.code}`,
+                map: null
+            };
+        }
+    };
+}
+
 /**
- * Build rollup options for JS (bundled and unbundled).
- *
- * For faster subsequent builds, the unbundled and rel builds are cached in the HISTORY map to
- * be used for bundled and minified builds. They are stored in the HISTORY map with the key:
- * `<rel|dbg|prf>-<umd|esm>-<bundled>`.
+ * Build rollup options for JS.
  *
  * @param {object} options - The build target options.
  * @param {'umd'|'esm'} options.moduleFormat - The module format.
  * @param {'rel'|'dbg'|'prf'|'min'} options.buildType - The build type.
- * @param {'unbundled'|'bundled'} [options.bundleState] - The bundle state.
- * @param {'rel'|null} [options.bundleSource] - The generated input source.
+ * @param {boolean} [options.preserveModules] - Generate the ESM module tree.
  * @param {string} [options.input] - Only used for examples to change it to `../src/index.js`.
  * @param {string} [options.dir] - Only used for examples to change the output location.
  * @returns {RollupOptions[]} Rollup targets.
@@ -170,93 +191,38 @@ function getOutPlugins(type) {
 function buildJSOptions({
     moduleFormat,
     buildType,
-    bundleState,
-    bundleSource = null,
+    preserveModules = moduleFormat === 'esm' && buildType !== 'min',
     input = 'src/index.js',
     dir = 'build'
 }) {
     const isUMD = moduleFormat === 'umd';
     const isDebug = buildType === 'dbg';
     const isMin = buildType === 'min';
-    const bundled = isUMD || isMin || bundleState === 'bundled';
+    const preserve = preserveModules && !isUMD && !isMin;
 
     const prefix = `${OUT_PREFIX[buildType]}`;
     const file = `${prefix}${isUMD ? '.js' : '.mjs'}`;
+    const banner = getBanner(BANNER[buildType]);
 
-    const targets = [];
+    const output = [{
+        banner: isMin ? undefined : banner,
+        plugins: buildType === 'rel' ? getOutPlugins(isUMD ? 'umd' : 'es') : undefined,
+        format: isUMD ? 'umd' : 'es',
+        indent: '\t',
+        sourcemap: isDebug && 'inline',
+        name: isUMD ? 'pc' : undefined,
+        file: `${dir}/${file}`
+    }];
 
-    // minify from the generated rel bundle in a separate turbo task.
-    if (isMin && bundleSource === 'rel') {
-        /**
-         * @type {RollupOptions}
-         */
-        const target = {
-            input: `${dir}/${OUT_PREFIX.rel}${isUMD ? '.js' : '.mjs'}`,
-            plugins: [
-                swcPlugin({ swc: swcOptions(isDebug, isMin) })
-            ],
-            output: {
-                banner: getBanner(BANNER[buildType]),
-                file: `${dir}/${file}`
-            },
-            context: isUMD ? 'this' : undefined
-        };
-
-        HISTORY.set(`${buildType}-${moduleFormat}-${bundled}`, target);
-        targets.push(target);
-
-        return targets;
-    }
-
-    // bundle from unbundled
-    if (bundled && HISTORY.has(`${buildType}-${moduleFormat}-false`)) {
-        const unbundled = HISTORY.get(`${buildType}-${moduleFormat}-false`);
-
-        /**
-         * @type {RollupOptions}
-         */
-        const target = {
-            input: `${unbundled.output.dir}/src/index.js`,
-            output: {
-                banner: getBanner(BANNER[buildType]),
-                format: 'es',
-                indent: '\t',
-                sourcemap: isDebug && 'inline',
-                name: 'pc',
-                preserveModules: false,
-                file: `${dir}/${prefix}.mjs`
-            }
-        };
-
-        HISTORY.set(`${buildType}-${moduleFormat}-true`, target);
-        targets.push(target);
-
-        return targets;
-    }
-
-    // minify from rel build
-    if (isMin && HISTORY.has(`rel-${moduleFormat}-true`)) {
-        const rel = HISTORY.get(`rel-${moduleFormat}-true`);
-
-        /**
-         * @type {RollupOptions}
-         */
-        const target = {
-            input: rel.output.file,
-            plugins: [
-                swcPlugin({ swc: swcOptions(isDebug, isMin) })
-            ],
-            output: {
-                banner: getBanner(BANNER[buildType]),
-                file: `${dir}/${file}`
-            },
-            context: isUMD ? 'this' : undefined
-        };
-
-        HISTORY.set(`${buildType}-${moduleFormat}-${bundled}`, target);
-        targets.push(target);
-
-        return targets;
+    if (preserve) {
+        output.push({
+            format: 'es',
+            indent: '\t',
+            preserveModules: true,
+            preserveModulesRoot: rootDir,
+            dir: `${dir}/${prefix}`,
+            entryFileNames: chunkInfo => `${chunkInfo.name.replace(/node_modules/g, 'modules')}.js`
+        });
     }
 
     /**
@@ -264,19 +230,8 @@ function buildJSOptions({
      */
     const target = {
         input,
-        output: {
-            banner: bundled ? getBanner(BANNER[buildType]) : undefined,
-            plugins: buildType === 'rel' ? getOutPlugins(isUMD ? 'umd' : 'es') : undefined,
-            format: isUMD ? 'umd' : 'es',
-            indent: '\t',
-            sourcemap: bundled && isDebug && 'inline',
-            name: 'pc',
-            preserveModules: !bundled,
-            preserveModulesRoot: !bundled ? rootDir : undefined,
-            file: bundled ? `${dir}/${file}` : undefined,
-            dir: !bundled ? `${dir}/${prefix}` : undefined,
-            entryFileNames: chunkInfo => `${chunkInfo.name.replace(/node_modules/g, 'modules')}.js`
-        },
+        output,
+        context: isUMD ? 'this' : undefined,
         plugins: [
             resolve(),
             jscc(getJSCCOptions(isMin ? 'rel' : buildType)),
@@ -284,16 +239,14 @@ function buildJSOptions({
             !isDebug ? shaderChunks() : undefined,
             isDebug ? engineLayerImportValidation(input) : undefined,
             !isDebug ? strip({ functions: STRIP_FUNCTIONS }) : undefined,
-            swcPlugin({ swc: swcOptions(isDebug, isMin) }),
+            swcPlugin({ swc: swcOptions(isDebug, false) }),
             !isUMD ? dynamicImportBundlerSuppress() : undefined,
-            !isDebug ? spacesToTabs() : undefined
+            !isDebug ? spacesToTabs() : undefined,
+            isMin ? minifyOutput(!isUMD, banner) : undefined
         ]
     };
 
-    HISTORY.set(`${buildType}-${moduleFormat}-${bundled}`, target);
-    targets.push(target);
-
-    return targets;
+    return [target];
 }
 
 /**

--- a/utils/rollup-build-target.mjs
+++ b/utils/rollup-build-target.mjs
@@ -76,17 +76,6 @@ const OUT_PREFIX = {
     min: 'playcanvas.min'
 };
 
-const MINIFY_OPTIONS = {
-    compress: {
-        drop_console: true,
-        pure_funcs: []
-    },
-    mangle: true,
-    format: {
-        comments: false
-    }
-};
-
 /**
  * @param {'rel'|'dbg'|'prf'} buildType - The build type.
  * @returns {object} - The JSCC options.
@@ -161,13 +150,27 @@ function getOutPlugins(type) {
     return plugins;
 }
 
+/**
+ * Create a Rollup plugin to minify the output using SWC.
+ *
+ * @param {boolean} esm - Whether the output is an ES module.
+ * @param {string} banner - The banner to prepend to the minified code.
+ * @returns {import('rollup').Plugin} The Rollup plugin.
+ */
 function minifyOutput(esm, banner) {
     return {
         name: 'swc-minify',
         async renderChunk(code) {
             const result = await minify(code, {
-                ...MINIFY_OPTIONS,
-                module: esm
+                module: esm,
+                compress: {
+                    drop_console: true,
+                    pure_funcs: []
+                },
+                mangle: true,
+                format: {
+                    comments: false
+                }
             });
             return {
                 code: `${banner}\n${result.code}`,
@@ -204,6 +207,7 @@ function buildJSOptions({
     const file = `${prefix}${isUMD ? '.js' : '.mjs'}`;
     const banner = getBanner(BANNER[buildType]);
 
+    /** @type {OutputOptions[]} */
     const output = [{
         banner: isMin ? undefined : banner,
         plugins: buildType === 'rel' ? getOutPlugins(isUMD ? 'umd' : 'es') : undefined,


### PR DESCRIPTION
## Description
Simplifies the Rollup target build process on top of the parallel build workflow:
- removes the custom in-memory HISTORY cache
- emits bundled and preserved-module ESM outputs from one Rollup target
- minifies through a Rollup output plugin instead of a bespoke follow-up target
- keeps examples and Turbo task wiring aligned with the new target shape

## Manual Testing
Manual tests: not run

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project coding standards
- [x] This PR focuses on a single change