### PR TITLE
feat: WebGPU XR device loss, devicelost events, and graphics binding typings

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -164,9 +164,10 @@ class XrManager extends EventHandler {
     xrBridge = null;
 
     /**
-     * Backend-specific XR binding for GPU camera/depth paths (e.g. WebGL {@link XRWebGLBinding}).
+     * Backend-specific XR binding for GPU camera/depth paths when available (for example WebGL
+     * {@link XRWebGLBinding} or WebGPU `XRGPUBinding` when exposed by the user agent).
      *
-     * @type {XRWebGLBinding|null}
+     * @type {Object|null}
      */
     get graphicsBinding() {
         return this.xrBridge?.graphicsBinding ?? null;

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -750,6 +750,8 @@ class GraphicsDevice extends EventHandler {
      */
     loseContext() {
 
+        Debug.log('pc.GraphicsDevice: Graphics context lost.');
+
         this.contextLost = true;
 
         // force the back-buffer to be recreated on restore
@@ -781,6 +783,8 @@ class GraphicsDevice extends EventHandler {
      * @ignore
      */
     restoreContext() {
+
+        Debug.log('pc.GraphicsDevice: Graphics context restored.');
 
         this.contextLost = false;
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -158,14 +158,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this._contextLostHandler = (event) => {
             event.preventDefault();
             this.loseContext();
-            Debug.log('pc.GraphicsDevice: WebGL context lost.');
-            this.fire('devicelost');
         };
 
         this._contextRestoredHandler = () => {
-            Debug.log('pc.GraphicsDevice: WebGL context restored.');
             this.restoreContext();
-            this.fire('devicerestored');
         };
 
         // #4136 - turn off antialiasing on AppleWebKit browsers 15.4
@@ -1030,6 +1026,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
         for (const shader of this.shaders) {
             shader.loseContext();
         }
+
+        this.fire('devicelost');
     }
 
     /**
@@ -1048,6 +1046,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
         for (const shader of this.shaders) {
             shader.restoreContext();
         }
+
+        this.fire('devicerestored');
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -489,10 +489,12 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             Debug.warn(`WebGPU device was lost: ${info.message}, this needs to be handled`);
 
             super.loseContext(); // 'super' works correctly here
+            this.fire('devicelost');
 
             await this.createDevice(); // Ensure this method is defined in your class
 
             super.restoreContext(); // 'super' works correctly here
+            this.fire('devicerestored');
         }
     }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -491,7 +491,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             super.loseContext(); // 'super' works correctly here
             this.fire('devicelost');
 
-            await this.createDevice(); // Ensure this method is defined in your class
+            await this.createDevice(); // Recreate the WebGPU device and associated resources after device loss.
 
             super.restoreContext(); // 'super' works correctly here
             this.fire('devicerestored');

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -201,10 +201,64 @@ class WebgpuXrBridge {
         this._binding = null;
     }
 
+    /**
+     * Clears WebXR WebGPU binding and projection layer references and removes immersive layers from
+     * the session (mirrors {@link WebglXrBridge#onGraphicsDeviceLost} clearing the base layer).
+     */
     onGraphicsDeviceLost() {
+        const bridge = this.xrBridge;
+        const session = bridge._session;
+
+        if (!session) {
+            return;
+        }
+
+        const rs = session.renderState;
+        const device = bridge.device;
+
+        this._binding = null;
+        this._layer = null;
+        this._cachedFramebufferSize.set(0, 0);
+        device.xrColorTexture = null;
+        device.xrColorTextureViewFormat = null;
+
+        session.updateRenderState({
+            layers: [],
+            depthNear: rs.depthNear,
+            depthFar: rs.depthFar
+        });
     }
 
+    /**
+     * Recreates WebXR WebGPU presentation after GPU restore; fires `"error"` on the bridge
+     * {@link XrBridge#eventHandler} if re-attachment fails.
+     */
     onGraphicsDeviceRestored() {
+        const bridge = this.xrBridge;
+
+        if (!bridge._session) {
+            return;
+        }
+
+        const eventHandler = bridge.eventHandler;
+
+        setTimeout(() => {
+            if (!bridge._session) {
+                return;
+            }
+
+            try {
+                const rs = bridge._session.renderState;
+                bridge.attachPresentation(bridge._session, {
+                    framebufferScaleFactor: bridge._framebufferScaleFactor,
+                    depthNear: rs.depthNear,
+                    depthFar: rs.depthFar,
+                    onBindingError: bridge._onBindingError
+                });
+            } catch (ex) {
+                eventHandler.fire('error', ex);
+            }
+        }, 0);
     }
 }
 

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -12,13 +12,13 @@ import { Vec2 } from '../../../core/math/vec2.js';
  */
 class WebgpuXrBridge {
     /**
-     * @type {any} // `XRGPUBinding | null`; using `any` to avoid exporting WebXR GPU types in published typings.
+     * @type {XRGPUBinding|null}
      * @private
      */
     _binding = null;
 
     /**
-     * @type {any} // `XRProjectionLayer | null`; using `any` to avoid exporting WebXR GPU types in published typings.
+     * @type {XRProjectionLayer|null}
      * @private
      */
     _layer = null;
@@ -69,7 +69,7 @@ class WebgpuXrBridge {
             return;
         }
 
-        /** @type {any} // `XRGPUSubImage | null`; using `any` to avoid exporting WebXR GPU types in published typings. */
+        /** @type {XRGPUSubImage|null} */
         let firstSub = null;
         for (let i = 0; i < pose.views.length; i++) {
             try {
@@ -119,7 +119,7 @@ class WebgpuXrBridge {
      * @param {Vec2} out - Width in {@link Vec2#x}, height in {@link Vec2#y}.
      */
     getFramebufferSize(_frame, out) {
-        const layer = /** @type {any} */ (this._layer);
+        const layer = this._layer;
         if (layer) {
             const lw = layer.textureWidth ?? layer.width;
             const lh = layer.textureHeight ?? layer.height;

--- a/src/platform/graphics/xr-bridge.js
+++ b/src/platform/graphics/xr-bridge.js
@@ -172,7 +172,10 @@ class XrBridge {
     }
 
     /**
-     * @returns {XRWebGLBinding|null} Backend graphics binding for camera/depth, if any.
+     * Backend graphics binding for camera/depth when available (for example WebGL
+     * {@link XRWebGLBinding} or WebGPU `XRGPUBinding` when exposed by the user agent).
+     *
+     * @returns {Object|null} The binding object, or null.
      */
     get graphicsBinding() {
         return this.impl.graphicsBinding ?? null;


### PR DESCRIPTION
Improves WebGPU immersive XR behavior when the GPU device is lost and restored, aligns `devicelost` / `devicerestored` with the WebGL path, and tightens typings documentation for `graphicsBinding` without requiring WebGPU type packages.

**Changes:**
- **WebGPU XR:** `WebgpuXrBridge` clears binding, layer, XR color texture state, and session `layers` on device loss; re-attaches presentation after restore (aligned with WebGL XR bridge behavior).
- **WebGPU graphics:** `handleDeviceLost` now fires `devicelost` after `loseContext` and `devicerestored` after `restoreContext`, so listeners (e.g. `XrBridge`) run on WebGPU as well.
- **WebGL graphics:** `devicelost` / `devicerestored` fire at the end of `WebglGraphicsDevice` lose/restore (after shader teardown); context lost/restored handlers only call `loseContext` / `restoreContext`.
- **Shared:** `GraphicsDevice` logs backend-neutral messages at the start of `loseContext` / `restoreContext` so WebGL and WebGPU both log the same lines in debug builds.
- **Types (JSDoc):** `XrManager#graphicsBinding` and `XrBridge#graphicsBinding` are documented as `Object | null` with WebGL / WebGPU binding notes instead of WebGL-only `XRWebGLBinding`.

**API changes:**
- Published typings for `XrManager.prototype.graphicsBinding` and `XrBridge.prototype.graphicsBinding` now resolve as `any | null` (from `Object | null` in JSDoc) rather than `XRWebGLBinding | null`, reflecting that the value may be a WebGPU binding when using WebGPU XR.