### PR TITLE
feat(xr): WebGPU AR camera color and syncCameraColorTexture bridge

### DIFF
--- a/examples/src/examples/xr/ar-camera-color.example.mjs
+++ b/examples/src/examples/xr/ar-camera-color.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGPU_DISABLED
+import { deviceType } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -25,12 +25,33 @@ const message = function (msg) {
     el.textContent = msg;
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window),
-    graphicsDeviceOptions: { alpha: true }
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
 
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
@@ -41,9 +62,6 @@ window.addEventListener('resize', resize);
 app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 app.start();
 

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -454,8 +454,6 @@ class XrManager extends EventHandler {
             opts.requiredFeatures.push('webgpu');
         }
 
-        const webgl = device?.isWebGL2;
-
         if (type === XRTYPE_AR) {
             opts.optionalFeatures.push('light-estimation');
             opts.optionalFeatures.push('hit-test');
@@ -510,7 +508,7 @@ class XrManager extends EventHandler {
                 };
             }
 
-            if (webgl && options && options.cameraColor && this.views.supportedColor) {
+            if (options && options.cameraColor && this.views.supportedColor) {
                 opts.optionalFeatures.push('camera-access');
             }
         }

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -352,57 +352,7 @@ class XrView extends EventHandler {
             return;
         }
 
-        const binding = this._manager.graphicsBinding;
-        if (!binding) {
-            return;
-        }
-
-        const texture = binding.getCameraImage(this._xrCamera);
-        if (!texture) {
-            return;
-        }
-
-        const device = this._manager.app.graphicsDevice;
-        const gl = device.gl;
-
-        if (!this._frameBufferSource) {
-            // create frame buffer to read from
-            this._frameBufferSource = gl.createFramebuffer();
-
-            // create frame buffer to write to
-            this._frameBuffer = gl.createFramebuffer();
-        } else {
-            const attachmentBaseConstant = gl.COLOR_ATTACHMENT0;
-            const width = this._xrCamera.width;
-            const height = this._xrCamera.height;
-
-            // set frame buffer to read from
-            device.setFramebuffer(this._frameBufferSource);
-            gl.framebufferTexture2D(
-                gl.FRAMEBUFFER,
-                attachmentBaseConstant,
-                gl.TEXTURE_2D,
-                texture,
-                0
-            );
-
-            // set frame buffer to write to
-            device.setFramebuffer(this._frameBuffer);
-            gl.framebufferTexture2D(
-                gl.FRAMEBUFFER,
-                attachmentBaseConstant,
-                gl.TEXTURE_2D,
-                this._textureColor.impl._glTexture,
-                0
-            );
-
-            // bind buffers
-            gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this._frameBufferSource);
-            gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, this._frameBuffer);
-
-            // copy buffers with flip Y
-            gl.blitFramebuffer(0, height, width, 0, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
-        }
+        this._manager.xrBridge?.syncCameraColorTexture(this._xrCamera, this._textureColor);
     }
 
     /**
@@ -519,8 +469,6 @@ class XrView extends EventHandler {
     }
 
     _onDeviceLost() {
-        this._frameBufferSource = null;
-        this._frameBuffer = null;
         this._depthInfo = null;
     }
 
@@ -560,16 +508,6 @@ class XrView extends EventHandler {
         if (this._textureDepth) {
             this._textureDepth.destroy();
             this._textureDepth = null;
-        }
-
-        if (this._frameBufferSource) {
-            const gl = this._manager.app.graphicsDevice.gl;
-
-            gl.deleteFramebuffer(this._frameBufferSource);
-            this._frameBufferSource = null;
-
-            gl.deleteFramebuffer(this._frameBuffer);
-            this._frameBuffer = null;
         }
     }
 }

--- a/src/framework/xr/xr-views.js
+++ b/src/framework/xr/xr-views.js
@@ -68,7 +68,7 @@ class XrViews extends EventHandler {
      * @type {boolean}
      * @private
      */
-    _supportedColor = platform.browser && !!window.XRCamera && !!window.XRWebGLBinding;
+    _supportedColor = false;
 
     /**
      * @type {boolean}
@@ -108,6 +108,16 @@ class XrViews extends EventHandler {
         super();
 
         this._manager = manager;
+
+        const gd = manager.app?.graphicsDevice;
+        if (platform.browser && !!window.XRCamera) {
+            if (gd?.isWebGL2 && !!window.XRWebGLBinding) {
+                this._supportedColor = true;
+            } else if (gd?.isWebGPU && !!window.XRGPUBinding) {
+                this._supportedColor = true;
+            }
+        }
+
         this._manager.on('start', this._onSessionStart, this);
         this._manager.on('end', this._onSessionEnd, this);
     }

--- a/src/platform/graphics/webgl/webgl-xr-bridge.js
+++ b/src/platform/graphics/webgl/webgl-xr-bridge.js
@@ -1,6 +1,7 @@
 /**
  * @import { XrBridge } from '../xr-bridge.js'
  * @import { GraphicsDevice } from '../graphics-device.js'
+ * @import { Texture } from '../texture.js'
  * @import { Vec2 } from '../../../core/math/vec2.js'
  */
 
@@ -23,6 +24,22 @@ class WebglXrBridge {
     _graphicsBinding = null;
 
     /**
+     * Read framebuffer used to blit the XR camera image into the engine texture.
+     *
+     * @type {WebGLFramebuffer|null}
+     * @private
+     */
+    _cameraFbSource = null;
+
+    /**
+     * Draw framebuffer used to blit the XR camera image into the engine texture.
+     *
+     * @type {WebGLFramebuffer|null}
+     * @private
+     */
+    _cameraFbDest = null;
+
+    /**
      * @param {XrBridge} xrBridge - The XR bridge.
      */
     constructor(xrBridge) {
@@ -31,11 +48,26 @@ class WebglXrBridge {
     }
 
     /**
-     * @param {GraphicsDevice} _device - The graphics device.
+     * @param {GraphicsDevice} device - The graphics device.
      */
-    destroy(_device) {
+    destroy(device) {
         this._graphicsBinding = null;
         this._presentationLayer = null;
+        this._deleteCameraFramebuffers(device);
+    }
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @private
+     */
+    _deleteCameraFramebuffers(device) {
+        if (this._cameraFbSource) {
+            const gl = device.gl;
+            gl.deleteFramebuffer(this._cameraFbSource);
+            this._cameraFbSource = null;
+            gl.deleteFramebuffer(this._cameraFbDest);
+            this._cameraFbDest = null;
+        }
     }
 
     /**
@@ -139,6 +171,54 @@ class WebglXrBridge {
         this._graphicsBinding = null;
     }
 
+    /**
+     * Copies the XR passthrough camera image for the given XRCamera into a PlayCanvas
+     * {@link Texture}, with a Y-flip to match engine UV conventions. No-ops if the graphics
+     * binding is unavailable or the camera image is not ready this frame.
+     *
+     * @param {any} xrCamera - The XR camera whose image should be copied (XRCamera from WebXR API).
+     * @param {Texture} texture - Destination engine texture (must be GPU-uploaded).
+     */
+    syncCameraColorTexture(xrCamera, texture) {
+        if (!this._graphicsBinding) {
+            return;
+        }
+
+        const device = this.xrBridge.device;
+        const gl = device.gl;
+
+        const src = this._graphicsBinding.getCameraImage(xrCamera);
+        if (!src) {
+            return;
+        }
+
+        if (!this._cameraFbSource) {
+            // create frame buffer to read from
+            this._cameraFbSource = gl.createFramebuffer();
+
+            // create frame buffer to write to
+            this._cameraFbDest = gl.createFramebuffer();
+        }
+
+        const width = xrCamera.width;
+        const height = xrCamera.height;
+
+        // set frame buffer to read from
+        device.setFramebuffer(this._cameraFbSource);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, src, 0);
+
+        // set frame buffer to write to
+        device.setFramebuffer(this._cameraFbDest);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture.impl._glTexture, 0);
+
+        // bind buffers
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this._cameraFbSource);
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, this._cameraFbDest);
+
+        // copy buffers with flip Y
+        gl.blitFramebuffer(0, height, width, 0, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    }
+
     onGraphicsDeviceLost() {
         const session = this.xrBridge._session;
 
@@ -150,6 +230,10 @@ class WebglXrBridge {
 
         this._graphicsBinding = null;
         this._presentationLayer = null;
+
+        // FBO handles are invalid after context loss; just null them out without calling gl.delete
+        this._cameraFbSource = null;
+        this._cameraFbDest = null;
 
         session.updateRenderState({
             baseLayer: this._presentationLayer,

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -1,6 +1,7 @@
 /**
  * @import { XrBridge } from '../xr-bridge.js'
  * @import { GraphicsDevice } from '../graphics-device.js'
+ * @import { Texture } from '../texture.js'
  */
 
 import { Vec2 } from '../../../core/math/vec2.js';
@@ -192,6 +193,45 @@ class WebgpuXrBridge {
             depthNear: options.depthNear,
             depthFar: options.depthFar
         });
+    }
+
+    /**
+     * Copies the XR passthrough camera image for the given XRCamera into a PlayCanvas
+     * {@link Texture} using `copyTextureToTexture`. No-ops if `XRGPUBinding.getCameraImage` is
+     * unavailable or returns nothing this frame.
+     *
+     * @param {any} xrCamera - The XR camera whose image should be copied (XRCamera from WebXR API).
+     * @param {Texture} texture - Destination engine texture.
+     */
+    syncCameraColorTexture(xrCamera, texture) {
+        if (!this._binding?.getCameraImage) {
+            return;
+        }
+
+        const src = this._binding.getCameraImage(xrCamera);
+        if (!src) {
+            return;
+        }
+
+        const dst = texture.impl?.gpuTexture;
+        if (!dst) {
+            return;
+        }
+
+        const device = this.xrBridge.device;
+        const encoder = device.commandEncoder;
+        if (!encoder) {
+            return;
+        }
+
+        const width = xrCamera.width;
+        const height = xrCamera.height;
+
+        encoder.copyTextureToTexture(
+            { texture: src },
+            { texture: dst },
+            [width, height, 1]
+        );
     }
 
     /**

--- a/src/platform/graphics/xr-bridge.js
+++ b/src/platform/graphics/xr-bridge.js
@@ -2,6 +2,7 @@
  * @import { GraphicsDevice } from './graphics-device.js'
  * @import { EventHandler } from '../../core/event-handler.js'
  * @import { EventHandle } from '../../core/event-handle.js'
+ * @import { Texture } from './texture.js'
  * @import { Vec2 } from '../../core/math/vec2.js'
  */
 
@@ -162,6 +163,17 @@ class XrBridge {
      */
     getViewport(frame, xrView) {
         return this.impl.getViewport(frame, xrView);
+    }
+
+    /**
+     * Copies the XR passthrough camera image for the given `XRCamera` into a PlayCanvas
+     * {@link Texture}. Delegates to the backend implementation; no-ops if not supported.
+     *
+     * @param {any} xrCamera - The XR camera whose image should be copied (XRCamera from WebXR API).
+     * @param {Texture} texture - Destination engine texture.
+     */
+    syncCameraColorTexture(xrCamera, texture) {
+        this.impl?.syncCameraColorTexture?.(xrCamera, texture);
     }
 
     /**


### PR DESCRIPTION
related to https://github.com/playcanvas/engine/issues/7404

Enables immersive AR camera color (`camera-access`) when using a WebGPU graphics device, routes camera image sync through the XR bridge implementations, and updates the AR camera color example to the modern device bootstrap.

**Changes:**
- **Example:** `ar-camera-color` uses `createGraphicsDevice` + `AppBase` (same pattern as `ar-basic`), drops `WEBGPU_DISABLED`, and keeps camera color / `drawTexture` behavior.
- **Session options:** `camera-access` is requested whenever `cameraColor` is set and `views.supportedColor` is true (no longer gated on WebGL only).
- **`XrViews.supportedColor`:** Computed in the constructor from the active graphics device so WebGL apps only require `XRWebGLBinding`, WebGPU apps only `XRGPUBinding` (plus `XRCamera`).
- **Camera color sync:** `XrBridge.syncCameraColorTexture` delegates to `WebglXrBridge` (FBO + `blitFramebuffer` with original comments) or `WebgpuXrBridge` (`getCameraImage` + `copyTextureToTexture` when available). `XrView` only calls the bridge each frame.

**Examples:**
- Updated `examples/src/examples/xr/ar-camera-color.example.mjs`.

**Notes:** WebGPU `getCameraImage` / texture format compatibility depends on the user agent; the WebGPU path no-ops if the API is missing. Camera color texture resize-on-`XRCamera` dimension change is unchanged from prior behavior (still allocated once in `XrView`).