### PR TITLE
feat(xr): WebGPU XR depth bridge, examples, and XR camera sync fixes

### DIFF
--- a/examples/src/examples/xr/ar-camera-depth.example.mjs
+++ b/examples/src/examples/xr/ar-camera-depth.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGPU_DISABLED
+import { deviceType } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -25,12 +25,36 @@ const message = function (msg) {
     el.textContent = msg;
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window),
-    graphicsDeviceOptions: { alpha: true }
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+/** GLSL-only depth plane; keep disabled on WebGPU until WGSL shaders are added. */
+const depthPlaneGlOnly = device.isWebGPU;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
 
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
@@ -41,9 +65,6 @@ window.addEventListener('resize', resize);
 app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 app.start();
 
@@ -146,6 +167,10 @@ plane.setLocalEulerAngles(90, 0, 0);
 plane.enabled = false;
 camera.addChild(plane);
 
+const touchToStartMsg = depthPlaneGlOnly
+    ? 'Touch screen to start AR session (depth texture preview is WebGL-only on WebGPU; check console for depthGpuOptimized / depthPixelFormat).'
+    : 'Touch screen to start AR session';
+
 if (app.xr.supported) {
     const activate = function () {
         if (app.xr.isAvailable(pc.XRTYPE_AR)) {
@@ -205,7 +230,7 @@ if (app.xr.supported) {
             if (!app.xr.views.supportedDepth) {
                 message('AR Camera Depth is not supported');
             } else {
-                message('Touch screen to start AR session');
+                message(touchToStartMsg);
             }
         } else {
             message('Immersive AR is not available');
@@ -215,6 +240,11 @@ if (app.xr.supported) {
     app.on('update', () => {
         // if camera depth is available
         if (app.xr.views.availableDepth) {
+            if (depthPlaneGlOnly) {
+                plane.enabled = false;
+                return;
+            }
+
             if (!shaderUpdated && app.xr.active) {
                 shaderUpdated = true;
                 updateShader(app.xr.views.list.length > 1, app.xr.views.depthPixelFormat !== pc.PIXELFORMAT_LA8);
@@ -237,7 +267,7 @@ if (app.xr.supported) {
     } else if (!app.xr.views.supportedDepth) {
         message('AR Camera Depth is not supported');
     } else {
-        message('Touch screen to start AR session');
+        message(touchToStartMsg);
     }
 } else {
     message('WebXR is not supported');

--- a/examples/src/examples/xr/ar-camera-depth.example.mjs
+++ b/examples/src/examples/xr/ar-camera-depth.example.mjs
@@ -167,9 +167,9 @@ plane.setLocalEulerAngles(90, 0, 0);
 plane.enabled = false;
 camera.addChild(plane);
 
-const touchToStartMsg = depthPlaneGlOnly
-    ? 'Touch screen to start AR session (depth texture preview is WebGL-only on WebGPU; check console for depthGpuOptimized / depthPixelFormat).'
-    : 'Touch screen to start AR session';
+const touchToStartMsg = depthPlaneGlOnly ?
+    'Touch screen to start AR session (depth texture preview is WebGL-only on WebGPU; check console for depthGpuOptimized / depthPixelFormat).' :
+    'Touch screen to start AR session';
 
 if (app.xr.supported) {
     const activate = function () {

--- a/examples/src/examples/xr/ar-depth-sensing-placer.example.mjs
+++ b/examples/src/examples/xr/ar-depth-sensing-placer.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGPU_DISABLED
+import { deviceType } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -25,12 +25,33 @@ const message = function (msg) {
     el.textContent = msg;
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window),
-    graphicsDeviceOptions: { alpha: true }
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
 
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
@@ -41,9 +62,6 @@ window.addEventListener('resize', resize);
 app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 app.start();
 

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -3,7 +3,7 @@ import { Texture } from '../../platform/graphics/texture.js';
 import { Vec4 } from '../../core/math/vec4.js';
 import { Mat3 } from '../../core/math/mat3.js';
 import { Mat4 } from '../../core/math/mat4.js';
-import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, FILTER_NEAREST, PIXELFORMAT_R32F, PIXELFORMAT_DEPTH, PIXELFORMAT_RGB8 } from '../../platform/graphics/constants.js';
+import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, FILTER_NEAREST, PIXELFORMAT_RGB8, PIXELFORMAT_R32F } from '../../platform/graphics/constants.js';
 
 /**
  * @import { XrManager } from './xr-manager.js'
@@ -406,33 +406,11 @@ class XrView extends EventHandler {
         // update texture
         if (this._depthInfo) {
             if (gpu) {
-                // gpu
-                if (this._depthInfo.texture) {
-                    const gl = this._manager.app.graphicsDevice.gl;
-
-                    this._textureDepth.impl._glTexture = this._depthInfo.texture;
-
-                    if (this._depthInfo.textureType === 'texture-array') {
-                        this._textureDepth.impl._glTarget = gl.TEXTURE_2D_ARRAY;
-                    } else {
-                        this._textureDepth.impl._glTarget = gl.TEXTURE_2D;
-                    }
-
-                    switch (this._manager.views.depthPixelFormat) {
-                        case PIXELFORMAT_R32F:
-                            this._textureDepth.impl._glInternalFormat = gl.R32F;
-                            this._textureDepth.impl._glPixelType = gl.FLOAT;
-                            this._textureDepth.impl._glFormat = gl.RED;
-                            break;
-                        case PIXELFORMAT_DEPTH:
-                            this._textureDepth.impl._glInternalFormat = gl.DEPTH_COMPONENT16;
-                            this._textureDepth.impl._glPixelType = gl.UNSIGNED_SHORT;
-                            this._textureDepth.impl._glFormat = gl.DEPTH_COMPONENT;
-                            break;
-                    }
-
-                    this._textureDepth.impl._glCreated = true;
-                }
+                this._manager.xrBridge?.syncCameraDepthTexture(
+                    this._depthInfo,
+                    this._textureDepth,
+                    this._manager.views.depthPixelFormat ?? PIXELFORMAT_R32F
+                );
             } else {
                 // cpu
                 this._textureDepth._levels[0] = new Uint8Array(this._depthInfo.data);

--- a/src/platform/graphics/webgl/webgl-xr-bridge.js
+++ b/src/platform/graphics/webgl/webgl-xr-bridge.js
@@ -5,6 +5,8 @@
  * @import { Vec2 } from '../../../core/math/vec2.js'
  */
 
+import { PIXELFORMAT_DEPTH, PIXELFORMAT_R32F } from '../constants.js';
+
 /**
  * WebGL graphics implementation for {@link XrBridge}.
  *
@@ -217,6 +219,46 @@ class WebglXrBridge {
 
         // copy buffers with flip Y
         gl.blitFramebuffer(0, height, width, 0, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+
+        device.setFramebuffer(device.defaultFramebuffer);
+    }
+
+    /**
+     * Aliases the XR runtime depth GL texture into the engine {@link Texture} implementation.
+     *
+     * @param {any} depthInfo - Depth information from WebXR (`getDepthInformation`).
+     * @param {Texture} texture - Destination engine texture.
+     * @param {number} depthPixelFormat - Resolved depth pixel format (`PIXELFORMAT_R32F` or `PIXELFORMAT_DEPTH`).
+     */
+    syncCameraDepthTexture(depthInfo, texture, depthPixelFormat) {
+        if (!depthInfo?.texture) {
+            return;
+        }
+
+        const gl = this.xrBridge.device.gl;
+
+        texture.impl._glTexture = depthInfo.texture;
+
+        if (depthInfo.textureType === 'texture-array') {
+            texture.impl._glTarget = gl.TEXTURE_2D_ARRAY;
+        } else {
+            texture.impl._glTarget = gl.TEXTURE_2D;
+        }
+
+        switch (depthPixelFormat) {
+            case PIXELFORMAT_R32F:
+                texture.impl._glInternalFormat = gl.R32F;
+                texture.impl._glPixelType = gl.FLOAT;
+                texture.impl._glFormat = gl.RED;
+                break;
+            case PIXELFORMAT_DEPTH:
+                texture.impl._glInternalFormat = gl.DEPTH_COMPONENT16;
+                texture.impl._glPixelType = gl.UNSIGNED_SHORT;
+                texture.impl._glFormat = gl.DEPTH_COMPONENT;
+                break;
+        }
+
+        texture.impl._glCreated = true;
     }
 
     onGraphicsDeviceLost() {

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -4,6 +4,7 @@
  * @import { Texture } from '../texture.js'
  */
 
+import { Debug } from '../../../core/debug.js';
 import { Vec2 } from '../../../core/math/vec2.js';
 
 /**
@@ -219,10 +220,7 @@ class WebgpuXrBridge {
         }
 
         const device = this.xrBridge.device;
-        const encoder = device.commandEncoder;
-        if (!encoder) {
-            return;
-        }
+        const encoder = device.getCommandEncoder();
 
         const width = xrCamera.width;
         const height = xrCamera.height;
@@ -232,6 +230,19 @@ class WebgpuXrBridge {
             { texture: dst },
             [width, height, 1]
         );
+    }
+
+    /**
+     * GPU XR depth texture binding is not implemented for WebGPU yet (`XRGPUBinding` has no depth API).
+     *
+     * @param {any} depthInfo - Depth information from WebXR (`getDepthInformation`); when `texture` is set, GPU depth was negotiated.
+     * @param {Texture} _texture - Unused until WebGPU depth is implemented.
+     * @param {number} _depthPixelFormat - Unused until WebGPU depth is implemented.
+     */
+    syncCameraDepthTexture(depthInfo, _texture, _depthPixelFormat) {
+        if (depthInfo?.texture) {
+            Debug.warnOnce('WebXR GPU depth textures are not supported on WebGPU in this engine build; use CPU depth or WebGL until XRGPUBinding exposes depth.');
+        }
     }
 
     /**

--- a/src/platform/graphics/xr-bridge.js
+++ b/src/platform/graphics/xr-bridge.js
@@ -177,6 +177,18 @@ class XrBridge {
     }
 
     /**
+     * Binds XR GPU depth information to the engine depth texture on backends that support it
+     * (WebGL). No-ops on WebGPU until a binding API exists.
+     *
+     * @param {any} depthInfo - Depth information from WebXR (`getDepthInformation`).
+     * @param {Texture} texture - Destination engine texture.
+     * @param {number} depthPixelFormat - Resolved depth pixel format constant (`PIXELFORMAT_*`).
+     */
+    syncCameraDepthTexture(depthInfo, texture, depthPixelFormat) {
+        this.impl?.syncCameraDepthTexture?.(depthInfo, texture, depthPixelFormat);
+    }
+
+    /**
      * @returns {XRLayer|null} Backend output layer (e.g. XRWebGLLayer), if any.
      */
     get presentationLayer() {


### PR DESCRIPTION
related to https://github.com/playcanvas/engine/issues/7404

Adds GPU XR depth texture handling behind the XR bridge (WebGL implementation, WebGPU no-op with a one-time warning when GPU depth textures are present), refactors `XrView` so it stays backend-agnostic for GPU depth, updates AR depth examples for `createGraphicsDevice` / `AppBase` and WebGPU-friendly messaging, restores the WebGL default framebuffer after the XR camera color blit so device framebuffer shadow state matches XR, and records WebGPU camera color copies via `getCommandEncoder()` so copies are not skipped when no encoder existed yet.

**Changes:**
- `XrBridge.syncCameraDepthTexture` facade; `WebglXrBridge.syncCameraDepthTexture` contains the former WebGL-only depth aliasing from `XrView`; `WebgpuXrBridge.syncCameraDepthTexture` warns once if GPU depth `texture` is present.
- `XrView._updateDepth` delegates GPU path to the bridge; CPU depth path unchanged.
- Examples: `ar-camera-depth.example.mjs`, `ar-depth-sensing-placer.example.mjs` use `deviceType`, `createGraphicsDevice`, `AppBase`; WebGPU note for GLSL-only depth preview plane where applicable.
- `WebglXrBridge.syncCameraColorTexture`: `setFramebuffer(defaultFramebuffer)` after blit.
- `WebgpuXrBridge.syncCameraColorTexture`: use `getCommandEncoder()` instead of reading `commandEncoder` only.

**Examples:**
- `examples/src/examples/xr/ar-camera-depth.example.mjs`
- `examples/src/examples/xr/ar-depth-sensing-placer.example.mjs`

**Performance:** No intentional hot-path regressions; `Debug.warnOnce` only when WebGPU receives GPU depth texture info.