### PR TITLE
feat(xr): WebGPU texture-array projection and vr-basic gallery refresh

### DIFF
--- a/examples/assets/models/xr_gallery.txt
+++ b/examples/assets/models/xr_gallery.txt
@@ -1,0 +1,8 @@
+Model Information:
+* title:	XR VR Gallery Space
+* source:	https://sketchfab.com/3d-models/xr-vr-gallery-space-873a1808080e47d2a804f3c991e33b4f
+* author:	Josh Johanson (https://sketchfab.com/johansome)
+
+Model License:
+* license type:	Creative Commons Attribution (CC BY 4.0)
+* license URL:	https://creativecommons.org/licenses/by/4.0/

--- a/examples/src/examples/xr/vr-basic.example.mjs
+++ b/examples/src/examples/xr/vr-basic.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGPU_DISABLED
+import { deviceType, rootPath } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -18,11 +18,34 @@ const message = function (msg) {
     el.textContent = msg;
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window)
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
+
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
@@ -33,104 +56,94 @@ app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
 
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
-
-app.start();
-
-// create camera
-const c = new pc.Entity();
-c.addComponent('camera', {
-    clearColor: new pc.Color(44 / 255, 62 / 255, 80 / 255),
-    farClip: 10000
-});
-app.root.addChild(c);
-
-const l = new pc.Entity();
-l.addComponent('light', {
-    type: 'spot',
-    range: 30
-});
-l.translate(0, 10, 0);
-app.root.addChild(l);
-
-/**
- * @param {number} x - The x coordinate.
- * @param {number} y - The y coordinate.
- * @param {number} z - The z coordinate.
- */
-const createCube = function (x, y, z) {
-    const cube = new pc.Entity();
-    cube.addComponent('render', {
-        type: 'box'
-    });
-    cube.setLocalScale(1, 1, 1);
-    cube.translate(x, y, z);
-    app.root.addChild(cube);
+const assets = {
+    gallery: new pc.Asset('gallery', 'container', { url: `${rootPath}/static/assets/models/xr_gallery.glb` })
 };
 
-// create a grid of cubes
-const SIZE = 16;
-for (let x = 0; x < SIZE; x++) {
-    for (let y = 0; y < SIZE; y++) {
-        createCube(2 * x - SIZE, -1.5, 2 * y - SIZE);
-    }
-}
+const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
+assetListLoader.load(() => {
+    app.start();
 
-if (app.xr.supported) {
-    const activate = function () {
-        if (app.xr.isAvailable(pc.XRTYPE_VR)) {
-            c.camera.startXr(pc.XRTYPE_VR, pc.XRSPACE_LOCAL, {
-                callback: function (err) {
-                    if (err) message(`WebXR Immersive VR failed to start: ${err.message}`);
+    const galleryEntity = assets.gallery.resource.instantiateRenderEntity();
+    app.root.addChild(galleryEntity);
+
+    // Initial camera (desktop / before XR): offset to the side and higher than default eye height.
+    const camX = 1.35;
+    const camY = 2.45;
+    const camZ = 3.0;
+    const lookX = 0;
+    const lookY = 1.25;
+    const lookZ = 0;
+
+    const c = new pc.Entity();
+    c.addComponent('camera', {
+        clearColor: new pc.Color(44 / 255, 62 / 255, 80 / 255),
+        farClip: 10000
+    });
+    c.setLocalPosition(camX, camY, camZ);
+    c.lookAt(lookX, lookY, lookZ);
+    app.root.addChild(c);
+
+    const l = new pc.Entity();
+    l.addComponent('light', {
+        type: 'spot',
+        range: 30
+    });
+    l.translate(0, 10, 0);
+    app.root.addChild(l);
+
+    if (app.xr.supported) {
+        const activate = function () {
+            if (app.xr.isAvailable(pc.XRTYPE_VR)) {
+                c.camera.startXr(pc.XRTYPE_VR, pc.XRSPACE_LOCALFLOOR, {
+                    callback: function (err) {
+                        if (err) message(`WebXR Immersive VR failed to start: ${err.message}`);
+                    }
+                });
+            } else {
+                message('Immersive VR is not available');
+            }
+        };
+
+        app.mouse.on('mousedown', () => {
+            if (!app.xr.active) activate();
+        });
+
+        if (app.touch) {
+            app.touch.on('touchend', (evt) => {
+                if (!app.xr.active) {
+                    activate();
+                } else {
+                    c.camera.endXr();
                 }
+
+                evt.event.preventDefault();
+                evt.event.stopPropagation();
             });
-        } else {
+        }
+
+        app.keyboard.on('keydown', (evt) => {
+            if (evt.key === pc.KEY_ESCAPE && app.xr.active) {
+                app.xr.end();
+            }
+        });
+
+        app.xr.on('start', () => {
+            message('Immersive VR session has started');
+        });
+        app.xr.on('end', () => {
+            message('Immersive VR session has ended');
+        });
+        app.xr.on(`available:${pc.XRTYPE_VR}`, (available) => {
+            message(`Immersive VR is ${available ? 'available' : 'unavailable'}`);
+        });
+
+        if (!app.xr.isAvailable(pc.XRTYPE_VR)) {
             message('Immersive VR is not available');
         }
-    };
-
-    app.mouse.on('mousedown', () => {
-        if (!app.xr.active) activate();
-    });
-
-    if (app.touch) {
-        app.touch.on('touchend', (evt) => {
-            if (!app.xr.active) {
-                // if not in VR, activate
-                activate();
-            } else {
-                // otherwise reset camera
-                c.camera.endXr();
-            }
-
-            evt.event.preventDefault();
-            evt.event.stopPropagation();
-        });
+    } else {
+        message('WebXR is not supported');
     }
-
-    // end session by keyboard ESC
-    app.keyboard.on('keydown', (evt) => {
-        if (evt.key === pc.KEY_ESCAPE && app.xr.active) {
-            app.xr.end();
-        }
-    });
-
-    app.xr.on('start', () => {
-        message('Immersive VR session has started');
-    });
-    app.xr.on('end', () => {
-        message('Immersive VR session has ended');
-    });
-    app.xr.on(`available:${pc.XRTYPE_VR}`, (available) => {
-        message(`Immersive VR is ${available ? 'available' : 'unavailable'}`);
-    });
-
-    if (!app.xr.isAvailable(pc.XRTYPE_VR)) {
-        message('Immersive VR is not available');
-    }
-} else {
-    message('WebXR is not supported');
-}
+});
 
 export { app };

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -588,7 +588,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         Debug.assert(outColorBuffer, 'WebGPU frameStart requires an XR color texture, canvas swapchain texture, or externalBackbuffer.');
         DebugHelper.setLabel(outColorBuffer, `${this.backBuffer.name}`);
 
-        // reallocate framebuffer if dimensions change, to match the output texture
+        // Reallocate framebuffer if dimensions change, to match the output texture. For WebXR
+        // WebGPU projection color targets that are 2d-array textures, width/height are the per-layer
+        // extent (same for every view), which matches what the render pass and internal depth need.
         if (this.backBufferSize.x !== outColorBuffer.width || this.backBufferSize.y !== outColorBuffer.height) {
 
             this.backBufferSize.set(outColorBuffer.width, outColorBuffer.height);

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -200,12 +200,23 @@ class WebgpuXrBridge {
 
         const colorFormat = this._binding.getPreferredColorFormat();
 
-        this._layer = this._binding.createProjectionLayer({
+        const layerOpts = {
             colorFormat,
-            // TODO: Support textureType 'texture-array' for stereo array layouts (multiview / per-eye slices).
-            textureType: 'texture',
             scaleFactor: options.framebufferScaleFactor
-        });
+        };
+
+        // Prefer texture-array for stereo (per-eye array layers); some runtimes only support 'texture'.
+        try {
+            this._layer = this._binding.createProjectionLayer({
+                ...layerOpts,
+                textureType: 'texture-array'
+            });
+        } catch {
+            this._layer = this._binding.createProjectionLayer({
+                ...layerOpts,
+                textureType: 'texture'
+            });
+        }
 
         session.updateRenderState({
             layers: [this._layer],


### PR DESCRIPTION
## Overview

Improves WebGPU immersive XR presentation by preferring a `texture-array` projection layer when the runtime supports it, and refreshes the `vr-basic` example for WebGPU-friendly bootstrapping, floor reference space, and a new gallery asset with attribution.

**Changes:**
- **WebGPU XR bridge:** Try `createProjectionLayer` with `textureType: 'texture-array'` first; fall back to `'texture'` if creation throws.
- **WebGPU device:** Comment in `frameStart` clarifying that XR array color targets use per-layer width/height for backbuffer sizing.
- **vr-basic example:** `AppBase` + `AppOptions` + `createGraphicsDevice(deviceType)` (examples iframe WebGPU picker); load **XR VR Gallery Space** (`xr_gallery.glb`) with Sketchfab attribution file; `XRSPACE_LOCALFLOOR`; initial camera pose constants for desktop preview.

**Public API:** None.

**Examples:**
- `examples/src/examples/xr/vr-basic.example.mjs`
- `examples/assets/models/xr_gallery.glb`, `examples/assets/models/xr_gallery.txt` (CC BY 4.0, Josh Johanson / Sketchfab link in txt)