### PR TITLE
examples: Convert XR examples to AppBase and WebGPU device setup

### DIFF
--- a/examples/src/examples/xr/ar-anchors-persistence.example.mjs
+++ b/examples/src/examples/xr/ar-anchors-persistence.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGPU_DISABLED
+import { deviceType } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -25,12 +25,34 @@ const message = function (msg) {
     el.textContent = msg;
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window),
-    graphicsDeviceOptions: { alpha: true }
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
+
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
@@ -40,9 +62,6 @@ window.addEventListener('resize', resize);
 app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 app.start();
 

--- a/examples/src/examples/xr/ar-hit-test-anchors.example.mjs
+++ b/examples/src/examples/xr/ar-hit-test-anchors.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGPU_DISABLED
+import { deviceType } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -18,12 +18,34 @@ const message = function (msg) {
     el.textContent = msg;
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window),
-    graphicsDeviceOptions: { alpha: true }
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
+
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
@@ -33,9 +55,6 @@ window.addEventListener('resize', resize);
 app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 app.start();
 

--- a/examples/src/examples/xr/ar-hit-test.example.mjs
+++ b/examples/src/examples/xr/ar-hit-test.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGPU_DISABLED
+import { deviceType } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -18,12 +18,34 @@ const message = function (msg) {
     el.textContent = msg;
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window),
-    graphicsDeviceOptions: { alpha: true }
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
+
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
@@ -33,9 +55,6 @@ window.addEventListener('resize', resize);
 app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 app.start();
 

--- a/examples/src/examples/xr/ar-mesh-detection.example.mjs
+++ b/examples/src/examples/xr/ar-mesh-detection.example.mjs
@@ -1,5 +1,4 @@
-// @config WEBGPU_DISABLED
-import { rootPath } from 'examples/utils';
+import { deviceType, rootPath } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -30,12 +29,37 @@ const assets = {
     font: new pc.Asset('font', 'font', { url: `${rootPath}/static/assets/fonts/courier.json` })
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window),
-    graphicsDeviceOptions: { alpha: true }
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+createOptions.elementInput = new pc.ElementInput(canvas);
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem,
+    pc.ScreenComponentSystem,
+    pc.ElementComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.FontHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
 
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
@@ -47,221 +71,219 @@ app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
 
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
-
-const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
-assetListLoader.load(() => {
-    app.start();
-
-    // create camera
-    const camera = new pc.Entity();
-    camera.addComponent('camera', {
-        clearColor: new pc.Color(0, 0, 0, 0),
-        farClip: 10000
-    });
-    app.root.addChild(camera);
-
-    const l = new pc.Entity();
-    l.addComponent('light', {
-        type: 'omni',
-        range: 20
-    });
-    camera.addChild(l);
-
-    if (app.xr.supported) {
-        const activate = function () {
-            if (app.xr.isAvailable(pc.XRTYPE_AR)) {
-                camera.camera.startXr(pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR, {
-                    meshDetection: true,
-                    callback: function (err) {
-                        if (err) message(`WebXR Immersive AR failed to start: ${err.message}`);
-                    }
-                });
-            } else {
-                message('Immersive AR is not available');
-            }
-        };
-
-        app.mouse.on('mousedown', () => {
-            if (!app.xr.active) activate();
-        });
-
-        if (app.touch) {
-            app.touch.on('touchend', (evt) => {
-                if (!app.xr.active) {
-                    // if not in VR, activate
-                    activate();
-                } else {
-                    // otherwise reset camera
-                    camera.camera.endXr();
-                }
-
-                evt.event.preventDefault();
-                evt.event.stopPropagation();
-            });
-        }
-
-        // end session by keyboard ESC
-        app.keyboard.on('keydown', (evt) => {
-            if (evt.key === pc.KEY_ESCAPE && app.xr.active) {
-                app.xr.end();
-            }
-        });
-
-        app.xr.on('start', () => {
-            message('Immersive AR session has started');
-
-            // Trigger manual room capture
-            // With a delay due to some issues on Quest 3 triggering immediately
-            setTimeout(() => {
-                app.xr.initiateRoomCapture((err) => {
-                    if (err) console.log(err);
-                });
-            }, 500);
-        });
-        app.xr.on('end', () => {
-            message('Immersive AR session has ended');
-        });
-        app.xr.on(`available:${pc.XRTYPE_AR}`, (available) => {
-            if (available) {
-                if (app.xr.meshDetection.supported) {
-                    message('Touch screen to start AR session and look at the floor or walls');
-                } else {
-                    message('AR Mesh Detection is not supported');
-                }
-            } else {
-                message('Immersive AR is unavailable');
-            }
-        });
-
-        const entities = new Map();
-
-        // materials
-        const materialDefault = new pc.StandardMaterial();
-
-        const materialGlobalMesh = new pc.StandardMaterial();
-        materialGlobalMesh.blendType = pc.BLEND_ADDITIVEALPHA;
-        materialGlobalMesh.opacity = 0.2;
-
-        const materialWireframe = new pc.StandardMaterial();
-        materialWireframe.emissive = new pc.Color(1, 1, 1);
-
-        // create entities for each XrMesh as they are added
-        app.xr.meshDetection.on('add', (xrMesh) => {
-            // solid mesh
-            const mesh = new pc.Mesh(app.graphicsDevice);
-            mesh.clear(true, false);
-            mesh.setPositions(xrMesh.vertices);
-            mesh.setNormals(pc.calculateNormals(xrMesh.vertices, xrMesh.indices));
-            mesh.setIndices(xrMesh.indices);
-            mesh.update(pc.PRIMITIVE_TRIANGLES);
-            const material = xrMesh.label === 'global mesh' ? materialGlobalMesh : materialDefault;
-            const meshInstance = new pc.MeshInstance(mesh, material);
-
-            // wireframe mesh
-            const meshWireframe = new pc.Mesh(app.graphicsDevice);
-            meshWireframe.clear(true, false);
-            meshWireframe.setPositions(xrMesh.vertices);
-            const indices = new Uint16Array((xrMesh.indices.length / 3) * 4);
-            for (let i = 0; i < xrMesh.indices.length; i += 3) {
-                const ind = (i / 3) * 4;
-                indices[ind + 0] = xrMesh.indices[i + 0];
-                indices[ind + 1] = xrMesh.indices[i + 1];
-                indices[ind + 2] = xrMesh.indices[i + 1];
-                indices[ind + 3] = xrMesh.indices[i + 2];
-            }
-            meshWireframe.setIndices(indices);
-            meshWireframe.update(pc.PRIMITIVE_LINES);
-            const meshInstanceWireframe = new pc.MeshInstance(meshWireframe, materialWireframe);
-            meshInstanceWireframe.renderStyle = pc.RENDERSTYLE_WIREFRAME;
-
-            // entity
-            const entity = new pc.Entity();
-            entity.addComponent('render', {
-                meshInstances: [meshInstance, meshInstanceWireframe]
-            });
-            app.root.addChild(entity);
-            entities.set(xrMesh, entity);
-
-            // label
-            const label = new pc.Entity();
-            label.setLocalPosition(0, 0, 0);
-            label.addComponent('element', {
-                pivot: new pc.Vec2(0.5, 0.5),
-                fontAsset: assets.font.id,
-                fontSize: 0.05,
-                text: xrMesh.label,
-                width: 1,
-                height: 0.1,
-                color: new pc.Color(1, 0, 0),
-                type: pc.ELEMENTTYPE_TEXT
-            });
-            entity.addChild(label);
-            label.setLocalPosition(0, 0, 0.05);
-            entity.label = label;
-
-            // transform
-            entity.setPosition(xrMesh.getPosition());
-            entity.setRotation(xrMesh.getRotation());
-        });
-
-        // when XrMesh is removed, destroy related entity
-        app.xr.meshDetection.on('remove', (xrMesh) => {
-            const entity = entities.get(xrMesh);
-            if (entity) {
-                entity.destroy();
-                entities.delete(xrMesh);
-            }
-        });
-
-        const vec3A = new pc.Vec3();
-        const vec3B = new pc.Vec3();
-        const vec3C = new pc.Vec3();
-        const transform = new pc.Mat4();
-
-        app.on('update', () => {
-            if (app.xr.active && app.xr.meshDetection.supported) {
-                // iterate through each XrMesh
-                for (let i = 0; i < app.xr.meshDetection.meshes.length; i++) {
-                    const mesh = app.xr.meshDetection.meshes[i];
-
-                    const entity = entities.get(mesh);
-                    if (entity) {
-                        // update entity transforms based on XrMesh
-                        entity.setPosition(mesh.getPosition());
-                        entity.setRotation(mesh.getRotation());
-
-                        // make sure label is looking at the camera
-                        entity.label.lookAt(camera.getPosition());
-                        entity.label.rotateLocal(0, 180, 0);
-                    }
-
-                    // render XrMesh gizmo axes
-                    transform.setTRS(mesh.getPosition(), mesh.getRotation(), pc.Vec3.ONE);
-                    vec3A.set(0.2, 0, 0);
-                    vec3B.set(0, 0.2, 0);
-                    vec3C.set(0, 0, 0.2);
-                    transform.transformPoint(vec3A, vec3A);
-                    transform.transformPoint(vec3B, vec3B);
-                    transform.transformPoint(vec3C, vec3C);
-                    app.drawLine(mesh.getPosition(), vec3A, pc.Color.RED, false);
-                    app.drawLine(mesh.getPosition(), vec3B, pc.Color.GREEN, false);
-                    app.drawLine(mesh.getPosition(), vec3C, pc.Color.BLUE, false);
-                }
-            }
-        });
-
-        if (!app.xr.isAvailable(pc.XRTYPE_AR)) {
-            message('Immersive AR is not available');
-        } else if (!app.xr.meshDetection.supported) {
-            message('AR Mesh Detection is not available');
-        } else {
-            message('Touch screen to start AR session and look at the floor or walls');
-        }
-    } else {
-        message('WebXR is not supported');
-    }
+await new Promise((resolve) => {
+    new pc.AssetListLoader(Object.values(assets), app.assets).load(resolve);
 });
+
+app.start();
+
+// create camera
+const camera = new pc.Entity();
+camera.addComponent('camera', {
+    clearColor: new pc.Color(0, 0, 0, 0),
+    farClip: 10000
+});
+app.root.addChild(camera);
+
+const l = new pc.Entity();
+l.addComponent('light', {
+    type: 'omni',
+    range: 20
+});
+camera.addChild(l);
+
+if (app.xr.supported) {
+    const activate = function () {
+        if (app.xr.isAvailable(pc.XRTYPE_AR)) {
+            camera.camera.startXr(pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR, {
+                meshDetection: true,
+                callback: function (err) {
+                    if (err) message(`WebXR Immersive AR failed to start: ${err.message}`);
+                }
+            });
+        } else {
+            message('Immersive AR is not available');
+        }
+    };
+
+    app.mouse.on('mousedown', () => {
+        if (!app.xr.active) activate();
+    });
+
+    if (app.touch) {
+        app.touch.on('touchend', (evt) => {
+            if (!app.xr.active) {
+                // if not in VR, activate
+                activate();
+            } else {
+                // otherwise reset camera
+                camera.camera.endXr();
+            }
+
+            evt.event.preventDefault();
+            evt.event.stopPropagation();
+        });
+    }
+
+    // end session by keyboard ESC
+    app.keyboard.on('keydown', (evt) => {
+        if (evt.key === pc.KEY_ESCAPE && app.xr.active) {
+            app.xr.end();
+        }
+    });
+
+    app.xr.on('start', () => {
+        message('Immersive AR session has started');
+
+        // Trigger manual room capture
+        // With a delay due to some issues on Quest 3 triggering immediately
+        setTimeout(() => {
+            app.xr.initiateRoomCapture((err) => {
+                if (err) console.log(err);
+            });
+        }, 500);
+    });
+    app.xr.on('end', () => {
+        message('Immersive AR session has ended');
+    });
+    app.xr.on(`available:${pc.XRTYPE_AR}`, (available) => {
+        if (available) {
+            if (app.xr.meshDetection.supported) {
+                message('Touch screen to start AR session and look at the floor or walls');
+            } else {
+                message('AR Mesh Detection is not supported');
+            }
+        } else {
+            message('Immersive AR is unavailable');
+        }
+    });
+
+    const entities = new Map();
+
+    // materials
+    const materialDefault = new pc.StandardMaterial();
+
+    const materialGlobalMesh = new pc.StandardMaterial();
+    materialGlobalMesh.blendType = pc.BLEND_ADDITIVEALPHA;
+    materialGlobalMesh.opacity = 0.2;
+
+    const materialWireframe = new pc.StandardMaterial();
+    materialWireframe.emissive = new pc.Color(1, 1, 1);
+
+    // create entities for each XrMesh as they are added
+    app.xr.meshDetection.on('add', (xrMesh) => {
+        // solid mesh
+        const mesh = new pc.Mesh(app.graphicsDevice);
+        mesh.clear(true, false);
+        mesh.setPositions(xrMesh.vertices);
+        mesh.setNormals(pc.calculateNormals(xrMesh.vertices, xrMesh.indices));
+        mesh.setIndices(xrMesh.indices);
+        mesh.update(pc.PRIMITIVE_TRIANGLES);
+        const material = xrMesh.label === 'global mesh' ? materialGlobalMesh : materialDefault;
+        const meshInstance = new pc.MeshInstance(mesh, material);
+
+        // wireframe mesh
+        const meshWireframe = new pc.Mesh(app.graphicsDevice);
+        meshWireframe.clear(true, false);
+        meshWireframe.setPositions(xrMesh.vertices);
+        const indices = new Uint16Array((xrMesh.indices.length / 3) * 4);
+        for (let i = 0; i < xrMesh.indices.length; i += 3) {
+            const ind = (i / 3) * 4;
+            indices[ind + 0] = xrMesh.indices[i + 0];
+            indices[ind + 1] = xrMesh.indices[i + 1];
+            indices[ind + 2] = xrMesh.indices[i + 1];
+            indices[ind + 3] = xrMesh.indices[i + 2];
+        }
+        meshWireframe.setIndices(indices);
+        meshWireframe.update(pc.PRIMITIVE_LINES);
+        const meshInstanceWireframe = new pc.MeshInstance(meshWireframe, materialWireframe);
+        meshInstanceWireframe.renderStyle = pc.RENDERSTYLE_WIREFRAME;
+
+        // entity
+        const entity = new pc.Entity();
+        entity.addComponent('render', {
+            meshInstances: [meshInstance, meshInstanceWireframe]
+        });
+        app.root.addChild(entity);
+        entities.set(xrMesh, entity);
+
+        // label
+        const label = new pc.Entity();
+        label.setLocalPosition(0, 0, 0);
+        label.addComponent('element', {
+            pivot: new pc.Vec2(0.5, 0.5),
+            fontAsset: assets.font.id,
+            fontSize: 0.05,
+            text: xrMesh.label,
+            width: 1,
+            height: 0.1,
+            color: new pc.Color(1, 0, 0),
+            type: pc.ELEMENTTYPE_TEXT
+        });
+        entity.addChild(label);
+        label.setLocalPosition(0, 0, 0.05);
+        entity.label = label;
+
+        // transform
+        entity.setPosition(xrMesh.getPosition());
+        entity.setRotation(xrMesh.getRotation());
+    });
+
+    // when XrMesh is removed, destroy related entity
+    app.xr.meshDetection.on('remove', (xrMesh) => {
+        const entity = entities.get(xrMesh);
+        if (entity) {
+            entity.destroy();
+            entities.delete(xrMesh);
+        }
+    });
+
+    const vec3A = new pc.Vec3();
+    const vec3B = new pc.Vec3();
+    const vec3C = new pc.Vec3();
+    const transform = new pc.Mat4();
+
+    app.on('update', () => {
+        if (app.xr.active && app.xr.meshDetection.supported) {
+            // iterate through each XrMesh
+            for (let i = 0; i < app.xr.meshDetection.meshes.length; i++) {
+                const mesh = app.xr.meshDetection.meshes[i];
+
+                const entity = entities.get(mesh);
+                if (entity) {
+                    // update entity transforms based on XrMesh
+                    entity.setPosition(mesh.getPosition());
+                    entity.setRotation(mesh.getRotation());
+
+                    // make sure label is looking at the camera
+                    entity.label.lookAt(camera.getPosition());
+                    entity.label.rotateLocal(0, 180, 0);
+                }
+
+                // render XrMesh gizmo axes
+                transform.setTRS(mesh.getPosition(), mesh.getRotation(), pc.Vec3.ONE);
+                vec3A.set(0.2, 0, 0);
+                vec3B.set(0, 0.2, 0);
+                vec3C.set(0, 0, 0.2);
+                transform.transformPoint(vec3A, vec3A);
+                transform.transformPoint(vec3B, vec3B);
+                transform.transformPoint(vec3C, vec3C);
+                app.drawLine(mesh.getPosition(), vec3A, pc.Color.RED, false);
+                app.drawLine(mesh.getPosition(), vec3B, pc.Color.GREEN, false);
+                app.drawLine(mesh.getPosition(), vec3C, pc.Color.BLUE, false);
+            }
+        }
+    });
+
+    if (!app.xr.isAvailable(pc.XRTYPE_AR)) {
+        message('Immersive AR is not available');
+    } else if (!app.xr.meshDetection.supported) {
+        message('AR Mesh Detection is not available');
+    } else {
+        message('Touch screen to start AR session and look at the floor or walls');
+    }
+} else {
+    message('WebXR is not supported');
+}
 
 export { app };

--- a/examples/src/examples/xr/ar-plane-detection.example.mjs
+++ b/examples/src/examples/xr/ar-plane-detection.example.mjs
@@ -1,5 +1,4 @@
-// @config WEBGPU_DISABLED
-import { rootPath } from 'examples/utils';
+import { deviceType, rootPath } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -30,12 +29,37 @@ const assets = {
     font: new pc.Asset('font', 'font', { url: `${rootPath}/static/assets/fonts/courier.json` })
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window),
-    graphicsDeviceOptions: { alpha: true }
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+createOptions.elementInput = new pc.ElementInput(canvas);
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem,
+    pc.ScreenComponentSystem,
+    pc.ElementComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.FontHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
 
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
@@ -47,255 +71,253 @@ app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
 
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
-
-const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
-assetListLoader.load(() => {
-    app.start();
-
-    // create camera
-    const camera = new pc.Entity();
-    camera.addComponent('camera', {
-        clearColor: new pc.Color(0, 0, 0, 0),
-        farClip: 10000
-    });
-    app.root.addChild(camera);
-
-    const l = new pc.Entity();
-    l.addComponent('light', {
-        type: 'spot',
-        range: 30
-    });
-    l.translate(0, 10, 0);
-    camera.addChild(l);
-
-    if (app.xr.supported) {
-        const activate = function () {
-            if (app.xr.isAvailable(pc.XRTYPE_AR)) {
-                camera.camera.startXr(pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR, {
-                    planeDetection: true,
-                    callback: function (err) {
-                        if (err) message(`WebXR Immersive AR failed to start: ${err.message}`);
-                    }
-                });
-            } else {
-                message('Immersive AR is not available');
-            }
-        };
-
-        app.mouse.on('mousedown', () => {
-            if (!app.xr.active) activate();
-        });
-
-        if (app.touch) {
-            app.touch.on('touchend', (evt) => {
-                if (!app.xr.active) {
-                    // if not in VR, activate
-                    activate();
-                } else {
-                    // otherwise reset camera
-                    camera.camera.endXr();
-                }
-
-                evt.event.preventDefault();
-                evt.event.stopPropagation();
-            });
-        }
-
-        // end session by keyboard ESC
-        app.keyboard.on('keydown', (evt) => {
-            if (evt.key === pc.KEY_ESCAPE && app.xr.active) {
-                app.xr.end();
-            }
-        });
-
-        app.xr.on('start', () => {
-            message('Immersive AR session has started');
-
-            // trigger manual scanning on session start
-            // app.xr.initiateRoomCapture((err) => { });
-        });
-        app.xr.on('end', () => {
-            message('Immersive AR session has ended');
-        });
-        app.xr.on(`available:${pc.XRTYPE_AR}`, (available) => {
-            if (available) {
-                if (app.xr.planeDetection.supported) {
-                    message('Touch screen to start AR session and look at the floor or walls');
-                } else {
-                    message('AR Plane Detection is not supported');
-                }
-            } else {
-                message('Immersive AR is unavailable');
-            }
-        });
-
-        const material = new pc.StandardMaterial();
-        material.blendType = pc.BLEND_PREMULTIPLIED;
-        material.opacity = 0.5;
-
-        const materialWireframe = new pc.StandardMaterial();
-        materialWireframe.emissive = new pc.Color(1, 1, 1);
-
-        const updateMesh = (xrPlane, entity) => {
-            let created = false;
-            let mesh = entity.render.meshInstances[0]?.mesh;
-            if (!mesh) {
-                mesh = new pc.Mesh(app.graphicsDevice);
-                created = true;
-            }
-            mesh.clear(true, false);
-
-            let meshWireframe = entity.render.meshInstances[1]?.mesh;
-            if (created) {
-                meshWireframe = new pc.Mesh(app.graphicsDevice);
-            }
-            meshWireframe.clear(true, false);
-
-            const vertices = new Float32Array((xrPlane.points.length + 1) * 3);
-            const verticesWireframe = new Float32Array(xrPlane.points.length * 3);
-            vertices[0] = 0;
-            vertices[1] = 0;
-            vertices[2] = 0;
-
-            const indices = new Uint32Array(xrPlane.points.length * 3);
-            const indicesWireframe = new Uint32Array(xrPlane.points.length);
-
-            for (let i = 0; i < xrPlane.points.length; i++) {
-                vertices[i * 3 + 3 + 0] = xrPlane.points[i].x;
-                vertices[i * 3 + 3 + 1] = xrPlane.points[i].y;
-                vertices[i * 3 + 3 + 2] = xrPlane.points[i].z;
-                verticesWireframe[i * 3 + 0] = xrPlane.points[i].x;
-                verticesWireframe[i * 3 + 1] = xrPlane.points[i].y;
-                verticesWireframe[i * 3 + 2] = xrPlane.points[i].z;
-                indices[i * 3 + 0] = 0;
-                indices[i * 3 + 1] = i + 1;
-                indices[i * 3 + 2] = ((i + 1) % xrPlane.points.length) + 1;
-                indicesWireframe[i] = i;
-            }
-
-            mesh.setPositions(vertices);
-            mesh.setNormals(pc.calculateNormals(vertices, indices));
-            mesh.setIndices(indices);
-            mesh.update(pc.PRIMITIVE_TRIANGLES);
-
-            meshWireframe.setPositions(verticesWireframe);
-            meshWireframe.setIndices(indicesWireframe);
-            meshWireframe.update(pc.PRIMITIVE_LINELOOP);
-
-            let meshInstance = entity.render.meshInstances[0];
-            if (created) {
-                meshInstance = new pc.MeshInstance(mesh, material);
-            }
-
-            let meshInstanceWireframe = entity.render.meshInstances[1];
-            if (created) {
-                meshInstanceWireframe = new pc.MeshInstance(meshWireframe, materialWireframe);
-                meshInstanceWireframe.renderStyle = pc.RENDERSTYLE_WIREFRAME;
-            }
-
-            if (created) entity.render.meshInstances = [meshInstance, meshInstanceWireframe];
-        };
-
-        const entities = new Map();
-
-        app.xr.planeDetection.on('add', (xrPlane) => {
-            // entity
-            const entity = new pc.Entity();
-            entity.addComponent('render');
-            app.root.addChild(entity);
-            entities.set(xrPlane, entity);
-
-            updateMesh(xrPlane, entity);
-
-            // label
-            const label = new pc.Entity();
-            label.setLocalPosition(0, 0, 0);
-            label.addComponent('element', {
-                pivot: new pc.Vec2(0.5, 0.5),
-                fontAsset: assets.font.id,
-                fontSize: 0.05,
-                text: xrPlane.label || '-',
-                width: 1,
-                height: 0.1,
-                color: new pc.Color(1, 0, 0),
-                type: pc.ELEMENTTYPE_TEXT
-            });
-            entity.addChild(label);
-            label.setLocalPosition(0, -0.05, 0);
-            entity.label = label;
-
-            // transform
-            entity.setPosition(xrPlane.getPosition());
-            entity.setRotation(xrPlane.getRotation());
-
-            xrPlane.on('change', () => {
-                updateMesh(xrPlane, entity);
-            });
-        });
-
-        // when XrPlane is removed, destroy related entity
-        app.xr.planeDetection.on('remove', (xrPlane) => {
-            const entity = entities.get(xrPlane);
-            if (entity) {
-                entity.destroy();
-                entities.delete(xrPlane);
-            }
-        });
-
-        const vec3A = new pc.Vec3();
-        const vec3B = new pc.Vec3();
-        const vec3C = new pc.Vec3();
-        const transform = new pc.Mat4();
-
-        app.on('update', () => {
-            if (app.xr.active && app.xr.planeDetection.supported) {
-                // iterate through each XrMesh
-                for (let i = 0; i < app.xr.planeDetection.planes.length; i++) {
-                    const plane = app.xr.planeDetection.planes[i];
-
-                    const entity = entities.get(plane);
-                    if (entity) {
-                        // update entity transforms based on XrPlane
-                        entity.setPosition(plane.getPosition());
-                        entity.setRotation(plane.getRotation());
-
-                        // make sure label is looking at the camera
-                        entity.label.setLocalPosition(0, -0.05, 0);
-                        entity.label.lookAt(camera.getPosition());
-                        entity.label.rotateLocal(0, 180, 0);
-                        entity.label.translateLocal(0, 0, 0.05);
-                    }
-
-                    // render XrPlane gizmo axes
-                    transform.setTRS(plane.getPosition(), plane.getRotation(), pc.Vec3.ONE);
-                    vec3A.set(0.2, 0, 0);
-                    vec3B.set(0, 0.2, 0);
-                    vec3C.set(0, 0, 0.2);
-                    transform.transformPoint(vec3A, vec3A);
-                    transform.transformPoint(vec3B, vec3B);
-                    transform.transformPoint(vec3C, vec3C);
-                    app.drawLine(plane.getPosition(), vec3A, pc.Color.RED, false);
-                    app.drawLine(plane.getPosition(), vec3B, pc.Color.GREEN, false);
-                    app.drawLine(plane.getPosition(), vec3C, pc.Color.BLUE, false);
-
-                    vec3A.copy(plane.points[0]);
-                    transform.transformPoint(vec3A, vec3A);
-                }
-            }
-        });
-
-        if (!app.xr.isAvailable(pc.XRTYPE_AR)) {
-            message('Immersive AR is not available');
-        } else if (!app.xr.planeDetection.supported) {
-            message('AR Plane Detection is not supported');
-        } else {
-            message('Touch screen to start AR session and look at the floor or walls');
-        }
-    } else {
-        message('WebXR is not supported');
-    }
+await new Promise((resolve) => {
+    new pc.AssetListLoader(Object.values(assets), app.assets).load(resolve);
 });
+
+app.start();
+
+// create camera
+const camera = new pc.Entity();
+camera.addComponent('camera', {
+    clearColor: new pc.Color(0, 0, 0, 0),
+    farClip: 10000
+});
+app.root.addChild(camera);
+
+const l = new pc.Entity();
+l.addComponent('light', {
+    type: 'spot',
+    range: 30
+});
+l.translate(0, 10, 0);
+camera.addChild(l);
+
+if (app.xr.supported) {
+    const activate = function () {
+        if (app.xr.isAvailable(pc.XRTYPE_AR)) {
+            camera.camera.startXr(pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR, {
+                planeDetection: true,
+                callback: function (err) {
+                    if (err) message(`WebXR Immersive AR failed to start: ${err.message}`);
+                }
+            });
+        } else {
+            message('Immersive AR is not available');
+        }
+    };
+
+    app.mouse.on('mousedown', () => {
+        if (!app.xr.active) activate();
+    });
+
+    if (app.touch) {
+        app.touch.on('touchend', (evt) => {
+            if (!app.xr.active) {
+                // if not in VR, activate
+                activate();
+            } else {
+                // otherwise reset camera
+                camera.camera.endXr();
+            }
+
+            evt.event.preventDefault();
+            evt.event.stopPropagation();
+        });
+    }
+
+    // end session by keyboard ESC
+    app.keyboard.on('keydown', (evt) => {
+        if (evt.key === pc.KEY_ESCAPE && app.xr.active) {
+            app.xr.end();
+        }
+    });
+
+    app.xr.on('start', () => {
+        message('Immersive AR session has started');
+
+        // trigger manual scanning on session start
+        // app.xr.initiateRoomCapture((err) => { });
+    });
+    app.xr.on('end', () => {
+        message('Immersive AR session has ended');
+    });
+    app.xr.on(`available:${pc.XRTYPE_AR}`, (available) => {
+        if (available) {
+            if (app.xr.planeDetection.supported) {
+                message('Touch screen to start AR session and look at the floor or walls');
+            } else {
+                message('AR Plane Detection is not supported');
+            }
+        } else {
+            message('Immersive AR is unavailable');
+        }
+    });
+
+    const material = new pc.StandardMaterial();
+    material.blendType = pc.BLEND_PREMULTIPLIED;
+    material.opacity = 0.5;
+
+    const materialWireframe = new pc.StandardMaterial();
+    materialWireframe.emissive = new pc.Color(1, 1, 1);
+
+    const updateMesh = (xrPlane, entity) => {
+        let created = false;
+        let mesh = entity.render.meshInstances[0]?.mesh;
+        if (!mesh) {
+            mesh = new pc.Mesh(app.graphicsDevice);
+            created = true;
+        }
+        mesh.clear(true, false);
+
+        let meshWireframe = entity.render.meshInstances[1]?.mesh;
+        if (created) {
+            meshWireframe = new pc.Mesh(app.graphicsDevice);
+        }
+        meshWireframe.clear(true, false);
+
+        const vertices = new Float32Array((xrPlane.points.length + 1) * 3);
+        const verticesWireframe = new Float32Array(xrPlane.points.length * 3);
+        vertices[0] = 0;
+        vertices[1] = 0;
+        vertices[2] = 0;
+
+        const indices = new Uint32Array(xrPlane.points.length * 3);
+        const indicesWireframe = new Uint32Array(xrPlane.points.length);
+
+        for (let i = 0; i < xrPlane.points.length; i++) {
+            vertices[i * 3 + 3 + 0] = xrPlane.points[i].x;
+            vertices[i * 3 + 3 + 1] = xrPlane.points[i].y;
+            vertices[i * 3 + 3 + 2] = xrPlane.points[i].z;
+            verticesWireframe[i * 3 + 0] = xrPlane.points[i].x;
+            verticesWireframe[i * 3 + 1] = xrPlane.points[i].y;
+            verticesWireframe[i * 3 + 2] = xrPlane.points[i].z;
+            indices[i * 3 + 0] = 0;
+            indices[i * 3 + 1] = i + 1;
+            indices[i * 3 + 2] = ((i + 1) % xrPlane.points.length) + 1;
+            indicesWireframe[i] = i;
+        }
+
+        mesh.setPositions(vertices);
+        mesh.setNormals(pc.calculateNormals(vertices, indices));
+        mesh.setIndices(indices);
+        mesh.update(pc.PRIMITIVE_TRIANGLES);
+
+        meshWireframe.setPositions(verticesWireframe);
+        meshWireframe.setIndices(indicesWireframe);
+        meshWireframe.update(pc.PRIMITIVE_LINELOOP);
+
+        let meshInstance = entity.render.meshInstances[0];
+        if (created) {
+            meshInstance = new pc.MeshInstance(mesh, material);
+        }
+
+        let meshInstanceWireframe = entity.render.meshInstances[1];
+        if (created) {
+            meshInstanceWireframe = new pc.MeshInstance(meshWireframe, materialWireframe);
+            meshInstanceWireframe.renderStyle = pc.RENDERSTYLE_WIREFRAME;
+        }
+
+        if (created) entity.render.meshInstances = [meshInstance, meshInstanceWireframe];
+    };
+
+    const entities = new Map();
+
+    app.xr.planeDetection.on('add', (xrPlane) => {
+        // entity
+        const entity = new pc.Entity();
+        entity.addComponent('render');
+        app.root.addChild(entity);
+        entities.set(xrPlane, entity);
+
+        updateMesh(xrPlane, entity);
+
+        // label
+        const label = new pc.Entity();
+        label.setLocalPosition(0, 0, 0);
+        label.addComponent('element', {
+            pivot: new pc.Vec2(0.5, 0.5),
+            fontAsset: assets.font.id,
+            fontSize: 0.05,
+            text: xrPlane.label || '-',
+            width: 1,
+            height: 0.1,
+            color: new pc.Color(1, 0, 0),
+            type: pc.ELEMENTTYPE_TEXT
+        });
+        entity.addChild(label);
+        label.setLocalPosition(0, -0.05, 0);
+        entity.label = label;
+
+        // transform
+        entity.setPosition(xrPlane.getPosition());
+        entity.setRotation(xrPlane.getRotation());
+
+        xrPlane.on('change', () => {
+            updateMesh(xrPlane, entity);
+        });
+    });
+
+    // when XrPlane is removed, destroy related entity
+    app.xr.planeDetection.on('remove', (xrPlane) => {
+        const entity = entities.get(xrPlane);
+        if (entity) {
+            entity.destroy();
+            entities.delete(xrPlane);
+        }
+    });
+
+    const vec3A = new pc.Vec3();
+    const vec3B = new pc.Vec3();
+    const vec3C = new pc.Vec3();
+    const transform = new pc.Mat4();
+
+    app.on('update', () => {
+        if (app.xr.active && app.xr.planeDetection.supported) {
+            // iterate through each XrMesh
+            for (let i = 0; i < app.xr.planeDetection.planes.length; i++) {
+                const plane = app.xr.planeDetection.planes[i];
+
+                const entity = entities.get(plane);
+                if (entity) {
+                    // update entity transforms based on XrPlane
+                    entity.setPosition(plane.getPosition());
+                    entity.setRotation(plane.getRotation());
+
+                    // make sure label is looking at the camera
+                    entity.label.setLocalPosition(0, -0.05, 0);
+                    entity.label.lookAt(camera.getPosition());
+                    entity.label.rotateLocal(0, 180, 0);
+                    entity.label.translateLocal(0, 0, 0.05);
+                }
+
+                // render XrPlane gizmo axes
+                transform.setTRS(plane.getPosition(), plane.getRotation(), pc.Vec3.ONE);
+                vec3A.set(0.2, 0, 0);
+                vec3B.set(0, 0.2, 0);
+                vec3C.set(0, 0, 0.2);
+                transform.transformPoint(vec3A, vec3A);
+                transform.transformPoint(vec3B, vec3B);
+                transform.transformPoint(vec3C, vec3C);
+                app.drawLine(plane.getPosition(), vec3A, pc.Color.RED, false);
+                app.drawLine(plane.getPosition(), vec3B, pc.Color.GREEN, false);
+                app.drawLine(plane.getPosition(), vec3C, pc.Color.BLUE, false);
+
+                vec3A.copy(plane.points[0]);
+                transform.transformPoint(vec3A, vec3A);
+            }
+        }
+    });
+
+    if (!app.xr.isAvailable(pc.XRTYPE_AR)) {
+        message('Immersive AR is not available');
+    } else if (!app.xr.planeDetection.supported) {
+        message('AR Plane Detection is not supported');
+    } else {
+        message('Touch screen to start AR session and look at the floor or walls');
+    }
+} else {
+    message('WebXR is not supported');
+}
 
 export { app };

--- a/examples/src/examples/xr/vr-controllers.example.mjs
+++ b/examples/src/examples/xr/vr-controllers.example.mjs
@@ -1,5 +1,4 @@
-// @config WEBGPU_DISABLED
-import { rootPath } from 'examples/utils';
+import { deviceType, rootPath } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -19,11 +18,34 @@ const message = function (msg) {
     el.textContent = msg;
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window)
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.ModelComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
 
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
@@ -41,8 +63,6 @@ const assets = {
 
 const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
 assetListLoader.load(() => {
-    // use device pixel ratio
-    app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
     app.start();
 
     // create camera

--- a/examples/src/examples/xr/vr-movement.example.mjs
+++ b/examples/src/examples/xr/vr-movement.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGPU_DISABLED
+import { deviceType } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -17,11 +17,35 @@ const message = function (msg) {
     }
     el.textContent = msg;
 };
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window)
-});
+
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
+
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
@@ -31,9 +55,6 @@ window.addEventListener('resize', resize);
 app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 app.start();
 

--- a/examples/src/examples/xr/xr-hands.example.mjs
+++ b/examples/src/examples/xr/xr-hands.example.mjs
@@ -1,5 +1,5 @@
-// @config WEBGPU_DISABLED
 import files from 'examples/files';
+import { deviceType } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -22,13 +22,35 @@ const message = function (msg) {
     document.querySelector('.message').textContent = msg;
 };
 
-// application
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window),
-    graphicsDeviceOptions: { alpha: true }
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.ModelComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
+
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
@@ -38,9 +60,6 @@ window.addEventListener('resize', resize);
 app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 app.scene.ambientLight = new pc.Color(0.1, 0.1, 0.1);
 

--- a/examples/src/examples/xr/xr-menu.example.mjs
+++ b/examples/src/examples/xr/xr-menu.example.mjs
@@ -1,4 +1,3 @@
-// @config WEBGPU_DISABLED
 import files from 'examples/files';
 import { deviceType, fileImport, rootPath } from 'examples/utils';
 import * as pc from 'playcanvas';
@@ -68,13 +67,13 @@ const gfxOptions = {
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
 device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
-// Create application with required component systems for UI and physics
+// AppBase with minimal component systems for UI, scripts, audio, and physics
 const createOptions = new pc.AppOptions();
-createOptions.xr = pc.XrManager;
 createOptions.graphicsDevice = device;
-createOptions.mouse = new pc.Mouse(document.body);
-createOptions.touch = new pc.TouchDevice(document.body);
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
 createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
 createOptions.elementInput = new pc.ElementInput(canvas);
 createOptions.soundManager = new pc.SoundManager();
 

--- a/examples/src/examples/xr/xr-picking.example.mjs
+++ b/examples/src/examples/xr/xr-picking.example.mjs
@@ -1,4 +1,4 @@
-// @config WEBGPU_DISABLED
+import { deviceType } from 'examples/utils';
 import * as pc from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
@@ -18,11 +18,34 @@ const message = function (msg) {
     el.textContent = msg;
 };
 
-const app = new pc.Application(canvas, {
-    mouse: new pc.Mouse(canvas),
-    touch: new pc.TouchDevice(canvas),
-    keyboard: new pc.Keyboard(window)
-});
+const gfxOptions = {
+    deviceTypes: [deviceType],
+    alpha: true
+};
+
+const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+device.maxPixelRatio = window.devicePixelRatio;
+
+const createOptions = new pc.AppOptions();
+createOptions.graphicsDevice = device;
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
+
+createOptions.componentSystems = [
+    pc.RenderComponentSystem,
+    pc.CameraComponentSystem,
+    pc.LightComponentSystem
+];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler
+];
+
+const app = new pc.AppBase(canvas);
+app.init(createOptions);
+
 app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
 app.setCanvasResolution(pc.RESOLUTION_AUTO);
 
@@ -32,9 +55,6 @@ window.addEventListener('resize', resize);
 app.on('destroy', () => {
     window.removeEventListener('resize', resize);
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 app.start();
 

--- a/examples/src/examples/xr/xr-ui.example.mjs
+++ b/examples/src/examples/xr/xr-ui.example.mjs
@@ -1,4 +1,3 @@
-// @config WEBGPU_DISABLED
 import files from 'examples/files';
 import { deviceType, rootPath } from 'examples/utils';
 import * as pc from 'playcanvas';
@@ -39,11 +38,11 @@ const device = await pc.createGraphicsDevice(canvas, gfxOptions);
 device.maxPixelRatio = Math.min(window.devicePixelRatio, 2);
 
 const createOptions = new pc.AppOptions();
-createOptions.xr = pc.XrManager;
 createOptions.graphicsDevice = device;
-createOptions.keyboard = new pc.Keyboard(document.body);
-createOptions.mouse = new pc.Mouse(document.body);
-createOptions.touch = new pc.TouchDevice(document.body);
+createOptions.mouse = new pc.Mouse(canvas);
+createOptions.touch = new pc.TouchDevice(canvas);
+createOptions.keyboard = new pc.Keyboard(window);
+createOptions.xr = pc.XrManager;
 createOptions.elementInput = new pc.ElementInput(canvas);
 
 createOptions.componentSystems = [
@@ -75,9 +74,6 @@ app.on('destroy', () => {
     div.remove();
     css.remove();
 });
-
-// use device pixel ratio
-app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
 
 const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
 assetListLoader.load(() => {


### PR DESCRIPTION
## Overview

Migrates the remaining XR engine examples from `pc.Application` to the explicit `createGraphicsDevice` + `AppOptions` + `AppBase` pattern used elsewhere, removes `// @config WEBGPU_DISABLED` so examples follow the global `deviceType` (WebGL / WebGPU), and wires minimal `componentSystems` / `resourceHandlers` per example.

## Changes

- **AR:** `ar-anchors-persistence`, `ar-hit-test`, `ar-hit-test-anchors`, `ar-mesh-detection`, `ar-plane-detection` — `AppBase`, alpha canvas, XR manager, render/camera/light; mesh/plane examples add `Screen` + `Element` + `ElementInput` and font handlers for world labels.
- **VR:** `vr-controllers`, `vr-movement` — add `ModelComponentSystem` where needed, `ContainerHandler` for GLB.
- **XR UI / interaction:** `xr-hands`, `xr-menu`, `xr-picking`, `xr-ui` — align device creation, input (`canvas` / `window`), and systems (e.g. UI, physics, audio for `xr-menu` unchanged in behavior).

related to https://github.com/playcanvas/engine/issues/7404