### PR TITLE
Support for exporting aoMaps and the second UV channels

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -774,7 +774,7 @@ class GltfExporter extends CoreExporter {
                                 return false;
                             }
 
-                            // This ensures that the seconds UV channel info doesn't get stripped out.
+                            // Preserve UV sets that are referenced by any material texture slot.
                             const uv = material[`${texSemantic}Uv`] ?? 0;
                             return uv === texCoordIndex;
                         });

--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -118,6 +118,7 @@ function isCanvasTransparent(canvas) {
 // supported texture semantics on a material
 const textureSemantics = [
     'anisotropyMap',
+    'aoMap',
     'clearCoatGlossMap',
     'clearCoatMap',
     'clearCoatNormalMap',
@@ -348,12 +349,14 @@ class GltfExporter extends CoreExporter {
 
     attachTexture(resources, material, destination, name, textureSemantic, json) {
         const texture = material[textureSemantic];
+        const textureTexCoord = material[`${textureSemantic}Uv`] ?? 0;
 
         if (texture) {
             const textureIndex = resources.textures.indexOf(texture);
             if (textureIndex < 0) console.warn(`Texture ${texture.name} wasn't collected.`);
             destination[name] = {
-                index: textureIndex
+                index: textureIndex,
+                texCoord: textureTexCoord
             };
 
             const scale = material[`${textureSemantic}Tiling`];
@@ -767,8 +770,13 @@ class GltfExporter extends CoreExporter {
                     isUsed = resources.materials.some((material) => {
                         return textureSemantics.some((texSemantic) => {
                             const texture = material[texSemantic];
-                            // Most materials use UV0 by default, so keep TEXCOORD_0 unless explicitly using a different UV set
-                            return texture && (texCoordIndex === 0 || material[`${texSemantic}Tiling`]?.uv === texCoordIndex);
+                            if (!texture) {
+                                return false;
+                            }
+
+                            // This ensures that the seconds UV channel info doesn't get stripped out.
+                            const uv = material[`${texSemantic}Uv`] ?? 0;
+                            return uv === texCoordIndex;
                         });
                     });
                 }


### PR DESCRIPTION
## Description
While testing out the GltfExporter with an asset that had maps in any other UV channel than 0, the exported GLB would not contain this map at all. Also noticed that the aoMap was not included in the textureSemantics (which seems to drive what will be exported), causing the AO maps to be ignored altogether.
Fixes Issue: #8727 

## Fixes
Fixes some bugs in GltfExporter where:
1. any texture map assigned to a non-zero UV channel (e.g. aoMapUv = 1) would not export as expected.
2. aoMap was missing from textureSemantics, causing it to not export at all. Was this by design? I couldn't anything mentioning why this was left out.
3. TEXCOORD_1 is no longer incorrectly stripped when stripUnusedAttributes: true is used together with a map assigned to a non-zero UV channel.

You can try it out by exporting this glb with the existing playcanvas build vs the build from this PR
[playcanvas_glb_export_test.zip](https://github.com/user-attachments/files/27770422/playcanvas_glb_export_test.zip)


## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change