### PR TITLE
fix(xr): visionOS MSAA resolve into XR framebuffer

### DIFF
--- a/examples/src/examples/xr/vr-basic.example.mjs
+++ b/examples/src/examples/xr/vr-basic.example.mjs
@@ -57,12 +57,23 @@ app.on('destroy', () => {
 });
 
 const assets = {
-    gallery: new pc.Asset('gallery', 'container', { url: `${rootPath}/static/assets/models/xr_gallery.glb` })
+    gallery: new pc.Asset('gallery', 'container', { url: `${rootPath}/static/assets/models/xr_gallery.glb` }),
+    envatlas: new pc.Asset(
+        'env-atlas',
+        'texture',
+        { url: `${rootPath}/static/assets/cubemaps/table-mountain-env-atlas.png` },
+        { type: pc.TEXTURETYPE_RGBP, mipmaps: false }
+    )
 };
 
 const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
 assetListLoader.load(() => {
     app.start();
+
+    // skydome
+    app.scene.envAtlas = assets.envatlas.resource;
+    app.scene.skyboxMip = 0;
+    app.scene.exposure = 0.5;
 
     const galleryEntity = assets.gallery.resource.instantiateRenderEntity();
     app.root.addChild(galleryEntity);

--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -38,6 +38,12 @@ const browserName =
                     'other')));
 
 const xbox = /xbox/i.test(ua);
+// visionOS Safari reports a macOS-style UA (no "visionOS" string) but uniquely has
+// maxTouchPoints > 0 on a "Macintosh" UA without any iPhone/iPad/iPod token.
+const visionos = /Macintosh/i.test(ua) &&
+    typeof navigator !== 'undefined' &&
+    navigator.maxTouchPoints > 0 &&
+    !/iPhone|iPad|iPod/i.test(ua);
 const touch = (environment === 'browser') && ('ontouchstart' in window || ('maxTouchPoints' in navigator && navigator.maxTouchPoints > 0));
 const gamepads = (environment === 'browser') && (!!navigator.getGamepads || !!navigator.webkitGetGamepads);
 const workers = (typeof Worker !== 'undefined');
@@ -122,6 +128,13 @@ const platform = {
      * @type {boolean}
      */
     android: platformName === 'android',
+
+    /**
+     * True if running on Apple Vision Pro (visionOS).
+     *
+     * @type {boolean}
+     */
+    visionos: visionos,
 
     /**
      * True if running on an Xbox device.

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -38,6 +38,7 @@ import { WebglTexture } from './webgl-texture.js';
 import { WebglRenderTarget } from './webgl-render-target.js';
 import { WebglUploadStream } from './webgl-upload-stream.js';
 import { WebglXrBridge } from './webgl-xr-bridge.js';
+import { WebglXrMsaaCopy } from './webgl-xr-msaa-copy.js';
 import { BlendState } from '../blend-state.js';
 import { DepthState } from '../depth-state.js';
 import { StencilParameters } from '../stencil-parameters.js';
@@ -103,6 +104,15 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @ignore
      */
     _defaultFramebufferChanged = false;
+
+    /**
+     * Helper for resolving MSAA color into the XR framebuffer via two quad draws on visionOS.
+     * Created lazily; null on all other platforms.
+     *
+     * @type {import('./webgl-xr-msaa-copy.js').WebglXrMsaaCopy|null}
+     * @private
+     */
+    _xrMsaaCopy = null;
 
     /**
      * Creates a new WebglGraphicsDevice instance.
@@ -629,6 +639,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this.clearVertexArrayObjectCache();
 
+        this._xrMsaaCopy?.destroy();
+        this._xrMsaaCopy = null;
+
         this.canvas.removeEventListener('webglcontextlost', this._contextLostHandler, false);
         this.canvas.removeEventListener('webglcontextrestored', this._contextRestoredHandler, false);
 
@@ -1098,6 +1111,22 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
             this.activeFramebuffer = fb;
         }
+    }
+
+    /**
+     * Resolve multisampled color into the WebXR session framebuffer via two textured quad draws
+     * (horizontal SBS). Used on visionOS / Apple Vision Pro where direct `blitFramebuffer` into
+     * the XR opaque framebuffer does not produce correct results.
+     *
+     * @param {WebGLFramebuffer} msaaReadFbo - Multisampled source framebuffer.
+     * @param {WebGLFramebuffer} xrDrawFbo - XR base layer framebuffer.
+     * @param {number} width - Full SBS framebuffer width in pixels.
+     * @param {number} height - Framebuffer height in pixels.
+     * @ignore
+     */
+    resolveMsaaColorToXrFramebufferViaQuads(msaaReadFbo, xrDrawFbo, width, height) {
+        this._xrMsaaCopy ??= new WebglXrMsaaCopy(this);
+        this._xrMsaaCopy.copy(msaaReadFbo, xrDrawFbo, width, height);
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -106,8 +106,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
     _defaultFramebufferChanged = false;
 
     /**
-     * Helper for resolving MSAA color into the XR framebuffer via two quad draws on visionOS.
-     * Created lazily; null on all other platforms.
+     * Helper for resolving MSAA color into the XR framebuffer via a blit-to-scratch + fullscreen
+     * quad copy on visionOS. Created lazily; null on all other platforms.
      *
      * @type {import('./webgl-xr-msaa-copy.js').WebglXrMsaaCopy|null}
      * @private
@@ -1114,9 +1114,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
     }
 
     /**
-     * Resolve multisampled color into the WebXR session framebuffer via two textured quad draws
-     * (horizontal SBS). Used on visionOS / Apple Vision Pro where direct `blitFramebuffer` into
-     * the XR opaque framebuffer does not produce correct results.
+     * Resolve multisampled color into the WebXR session framebuffer by first blitting MSAA into
+     * an internal scratch texture, then copying that texture into the XR FBO with a single
+     * fullscreen textured quad. Used on visionOS / Apple Vision Pro where direct
+     * `blitFramebuffer` into the XR opaque framebuffer does not produce correct results.
      *
      * @param {WebGLFramebuffer} msaaReadFbo - Multisampled source framebuffer.
      * @param {WebGLFramebuffer} xrDrawFbo - XR base layer framebuffer.

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -1,4 +1,5 @@
 import { Debug } from '../../../core/debug.js';
+import { platform } from '../../../core/platform.js';
 import { PIXELFORMAT_RGBA8 } from '../constants.js';
 import { DebugGraphics } from '../debug-graphics.js';
 import { DeviceCache } from '../device-cache.js';
@@ -446,6 +447,12 @@ class WebglRenderTarget {
             gl.NEAREST);
     }
 
+    /**
+     * @param {WebglGraphicsDevice} device - The graphics device.
+     * @param {RenderTarget} target - The render target.
+     * @param {boolean} color - Whether to resolve the color buffer.
+     * @param {boolean} depth - Whether to resolve the depth buffer.
+     */
     resolve(device, target, color, depth) {
         const gl = device.gl;
 
@@ -471,10 +478,29 @@ class WebglRenderTarget {
             }
 
         } else {
-            DebugGraphics.pushGpuMarker(device, 'RESOLVE');
-            this.internalResolve(device, this._glFrameBuffer, this._glResolveFrameBuffer, target,
-                (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0));
-            DebugGraphics.popGpuMarker(device);
+            // true when this render target resolves into the active XR session's framebuffer.
+            const isXrFramebuffer = !!device.defaultFramebuffer && this._glResolveFrameBuffer === device.defaultFramebuffer;
+
+            // On visionOS / Apple Vision Pro, blitFramebuffer into the opaque XR FBO produces
+            // incorrect results (content appears scaled to a small sub-region). Instead we resolve
+            // MSAA to an intermediate scratch texture first and copy into the XR FBO via two
+            // textured quad draws
+            const xrColorQuad = color && isXrFramebuffer && platform.visionos;
+
+            if (xrColorQuad) {
+                DebugGraphics.pushGpuMarker(device, 'RESOLVE-XR-COLOR-QUAD');
+                device.resolveMsaaColorToXrFramebufferViaQuads(
+                    this._glFrameBuffer, this._glResolveFrameBuffer, target.width, target.height);
+                DebugGraphics.popGpuMarker(device);
+                color = false; // color is resolved; fall through to handle depth if needed
+            }
+
+            if (color || depth) {
+                DebugGraphics.pushGpuMarker(device, 'RESOLVE');
+                this.internalResolve(device, this._glFrameBuffer, this._glResolveFrameBuffer, target,
+                    (color ? gl.COLOR_BUFFER_BIT : 0) | (depth ? gl.DEPTH_BUFFER_BIT : 0));
+                DebugGraphics.popGpuMarker(device);
+            }
         }
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, this._glFrameBuffer);

--- a/src/platform/graphics/webgl/webgl-render-target.js
+++ b/src/platform/graphics/webgl/webgl-render-target.js
@@ -483,8 +483,8 @@ class WebglRenderTarget {
 
             // On visionOS / Apple Vision Pro, blitFramebuffer into the opaque XR FBO produces
             // incorrect results (content appears scaled to a small sub-region). Instead we resolve
-            // MSAA to an intermediate scratch texture first and copy into the XR FBO via two
-            // textured quad draws
+            // MSAA into an intermediate scratch texture first, then copy it into the XR FBO with
+            // a single fullscreen textured quad.
             const xrColorQuad = color && isXrFramebuffer && platform.visionos;
 
             if (xrColorQuad) {

--- a/src/platform/graphics/webgl/webgl-xr-msaa-copy.js
+++ b/src/platform/graphics/webgl/webgl-xr-msaa-copy.js
@@ -131,12 +131,17 @@ class WebglXrMsaaCopy {
         // Create if not present.
         if (!this._scratchTex) {
             this._scratchTex = Texture.createDataTexture2D(device, 'XrMsaaScratch', width, height, device.backBufferFormat);
-            this._scratchRt = new RenderTarget({ colorBuffer: this._scratchTex });
+            this._scratchRt = new RenderTarget({
+                colorBuffer: this._scratchTex,
+                depth: false,
+                stencil: false
+            });
         }
 
-        // Re-initialize the FBO if context was lost and restored since last call.
-        // The engine restores Texture/Shader automatically, but our RenderTarget bypasses
-        // startRenderPass so its FBO must be re-created explicitly here.
+        // Initialize the underlying GL FBO. Handles both first-time creation (a freshly
+        // constructed RenderTarget has initialized === false) and context-loss restore (engine
+        // restores Texture/Shader automatically, but this RT bypasses startRenderPass so its
+        // FBO must be re-created explicitly here).
         if (!this._scratchRt.impl.initialized) {
             this._scratchRt.impl.init(device, this._scratchRt);
         }

--- a/src/platform/graphics/webgl/webgl-xr-msaa-copy.js
+++ b/src/platform/graphics/webgl/webgl-xr-msaa-copy.js
@@ -1,0 +1,202 @@
+import { PRIMITIVE_TRIANGLES, SEMANTIC_POSITION } from '../constants.js';
+import { BlendState } from '../blend-state.js';
+import { DepthState } from '../depth-state.js';
+import { RenderTarget } from '../render-target.js';
+import { Shader } from '../shader.js';
+import { ShaderDefinitionUtils } from '../shader-definition-utils.js';
+import { Texture } from '../texture.js';
+
+/**
+ * @import { WebglGraphicsDevice } from './webgl-graphics-device.js'
+ */
+
+const _quadPrimitive = {
+    type: PRIMITIVE_TRIANGLES,
+    base: 0,
+    count: 6,
+    indexed: true
+};
+
+const vsSrc = /* glsl */`
+    attribute vec2 vertex_position;
+    varying vec2 pcTexCoord;
+    void main() {
+        gl_Position = vec4(vertex_position, 0.0, 1.0);
+        pcTexCoord = vertex_position * 0.5 + 0.5;
+    }
+`;
+
+const fsSrc = /* glsl */`
+    uniform sampler2D pcSource;
+    varying vec2 pcTexCoord;
+    void main() {
+        gl_FragColor = texture2D(pcSource, pcTexCoord);
+    }
+`;
+
+/**
+ * Helper that resolves the MSAA color buffer into the WebXR session framebuffer on platforms where
+ * direct `blitFramebuffer` into the XR opaque FBO does not work correctly (e.g. visionOS).
+ *
+ * The operation is two-stage:
+ *  1. Resolve step: MSAA renderbuffer → engine-owned scratch `Texture` via `blitFramebuffer` (this
+ *      blit is into an ordinary app-owned texture, which works on all platforms).
+ *  2. A single fullscreen quad draw into the XR FBO
+ *
+ * The instance lives on {@link WebglGraphicsDevice} and is created lazily the first time the copy
+ * is needed.
+ *
+ * @ignore
+ */
+class WebglXrMsaaCopy {
+    /**
+     * @type {WebglGraphicsDevice}
+     * @private
+     */
+    _device;
+
+    /**
+     * @type {Shader|null}
+     * @private
+     */
+    _shader = null;
+
+    /**
+     * @type {Texture|null}
+     * @private
+     */
+    _scratchTex = null;
+
+    /**
+     * @type {RenderTarget|null}
+     * @private
+     */
+    _scratchRt = null;
+
+    /**
+     * @type {import('../../../platform/graphics/scope-id.js').ScopeId|null}
+     * @private
+     */
+    _sourceId = null;
+
+    /**
+     * @param {WebglGraphicsDevice} device - The WebGL graphics device.
+     */
+    constructor(device) {
+        this._device = device;
+    }
+
+    /**
+     * Returns the copy shader, creating it on first call.
+     *
+     * @returns {Shader} The shader.
+     * @private
+     */
+    _getShader() {
+        if (!this._shader) {
+            const device = this._device;
+            this._shader = new Shader(device, ShaderDefinitionUtils.createDefinition(device, {
+                name: 'XrMsaaCopy',
+                attributes: { vertex_position: SEMANTIC_POSITION },
+                vertexCode: vsSrc,
+                fragmentCode: fsSrc
+            }));
+
+            this._sourceId = device.scope.resolve('pcSource');
+        }
+
+        return this._shader;
+    }
+
+    /**
+     * Ensure the scratch single-sample texture and its render target exist and match the given
+     * dimensions. Reallocates if the size has changed (rare: only when XR layer resolution
+     * changes).
+     *
+     * @param {number} width - Full SBS framebuffer width in pixels.
+     * @param {number} height - Framebuffer height in pixels.
+     * @private
+     */
+    _ensureScratch(width, height) {
+        const device = this._device;
+
+        // Destroy if the size no longer matches.
+        if (this._scratchTex && (this._scratchTex.width !== width || this._scratchTex.height !== height)) {
+            this._scratchRt.destroy();
+            this._scratchRt = null;
+            this._scratchTex.destroy();
+            this._scratchTex = null;
+        }
+
+        // Create if not present.
+        if (!this._scratchTex) {
+            this._scratchTex = Texture.createDataTexture2D(device, 'XrMsaaScratch', width, height, device.backBufferFormat);
+            this._scratchRt = new RenderTarget({ colorBuffer: this._scratchTex });
+        }
+
+        // Re-initialize the FBO if context was lost and restored since last call.
+        // The engine restores Texture/Shader automatically, but our RenderTarget bypasses
+        // startRenderPass so its FBO must be re-created explicitly here.
+        if (!this._scratchRt.impl.initialized) {
+            this._scratchRt.impl.init(device, this._scratchRt);
+        }
+    }
+
+    /**
+     * Resolve MSAA color into the XR session framebuffer via a scratch texture and a fullscreen quad.
+     *
+     * @param {WebGLFramebuffer} msaaReadFbo - Multisampled source framebuffer.
+     * @param {WebGLFramebuffer} xrDrawFbo - XR base layer framebuffer.
+     * @param {number} width - Full SBS framebuffer width in pixels.
+     * @param {number} height - Framebuffer height in pixels.
+     */
+    copy(msaaReadFbo, xrDrawFbo, width, height) {
+        this._ensureScratch(width, height);
+
+        const device = this._device;
+        const gl = device.gl;
+
+        // 1) Resolve MSAA → scratch (ordinary app-owned texture — works on all platforms).
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, msaaReadFbo);
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, this._scratchRt.impl._glFrameBuffer);
+        gl.blitFramebuffer(0, 0, width, height, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+
+        // 2) Copy resolved SBS texture 1:1 into the XR FBO with a single fullscreen quad.
+        device.setDrawStates(BlendState.NOBLEND, DepthState.NODEPTH);
+        device.setFramebuffer(xrDrawFbo);
+        device.setShader(this._getShader());
+        // clearVertexBuffer() is required: setVertexBuffer() pushes onto the array rather than
+        // replacing, so stale VBs from the preceding scene draw must be cleared first.
+        device.clearVertexBuffer();
+        device.setVertexBuffer(device.quadVertexBuffer);
+        this._sourceId.setValue(this._scratchTex);
+
+        // Save and set fullscreen viewport/scissor, then restore.
+        const { vx, vy, vw, vh, sx, sy, sw, sh } = device;
+        device.setViewport(0, 0, width, height);
+        device.setScissor(0, 0, width, height);
+
+        device.draw(_quadPrimitive, device.quadIndexBuffer);
+
+        device.setViewport(vx, vy, vw, vh);
+        device.setScissor(sx, sy, sw, sh);
+
+        // Restore active framebuffer to the MSAA FBO (matches expectation of callers).
+        device.setFramebuffer(msaaReadFbo);
+    }
+
+    /**
+     * Destroy all GPU resources owned by this instance.
+     */
+    destroy() {
+        this._shader?.destroy();
+        this._shader = null;
+        this._scratchRt?.destroy();
+        this._scratchRt = null;
+        this._scratchTex?.destroy();
+        this._scratchTex = null;
+        this._sourceId = null;
+    }
+}
+
+export { WebglXrMsaaCopy };


### PR DESCRIPTION
Fixed #7410

Working WebXR with MSAA on Apple Vision Pro. Previously the only way to get a usable image on AVP was to disable anti-aliasing, because the engine's MSAA resolve uses `gl.blitFramebuffer` directly into the `XRWebGLLayer`'s opaque framebuffer — a path that visionOS WebKit handles incorrectly, producing a small zoomed-in sub-region instead of full stereo content.

**Fix**: on visionOS only, MSAA color is resolved into an internal scratch texture via `blitFramebuffer`, then copied 1:1 into the XR framebuffer with a single fullscreen textured quad. The rasterization path is what AVP renders correctly.

**Changes:**
- Added `pc.platform.visionos` boolean — detects Apple Vision Pro. visionOS Safari spoofs a macOS UA (no `"visionOS"` string), so detection combines `Macintosh` UA + `maxTouchPoints > 0` + no iPhone/iPad/iPod token.
- New internal `WebglXrMsaaCopy` helper — owns a scratch `Texture`/`RenderTarget` and a fullscreen-quad copy shader, built via `Shader`, `ShaderDefinitionUtils`, and `device.scope`. Lazily created on `WebglGraphicsDevice`, only on visionOS.
- `WebglRenderTarget.resolve` routes XR color resolves through the helper when `platform.visionos` is true; all other XR platforms (Quest, Chrome, etc.) keep the existing direct-blit path with zero overhead.
- Depth resolve is unchanged on all platforms.

**API Changes:**
- Added `pc.platform.visionos` (`boolean`).

**Performance:**
- visionOS only: one extra `blitFramebuffer` (MSAA → scratch texture) plus one fullscreen quad draw per frame. Required because direct blits into the AVP XR FBO are broken; `WEBGL_multisampled_render_to_texture` is not available on AVP.
- Other platforms: zero impact, gated on `platform.visionos`.