### PR TITLE
fix: Setting renderSceneColorMap or renderSceneDepthMap to true when already set, sets it to false

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -897,7 +897,7 @@ class CameraComponent extends Component {
         if (value && !this._sceneColorMapRequested) {
             this.requestSceneColorMap(true);
             this._sceneColorMapRequested = true;
-        } else if (this._sceneColorMapRequested) {
+        } else if (!value && this._sceneColorMapRequested) {
             this.requestSceneColorMap(false);
             this._sceneColorMapRequested = false;
         }
@@ -911,7 +911,7 @@ class CameraComponent extends Component {
         if (value && !this._sceneDepthMapRequested) {
             this.requestSceneDepthMap(true);
             this._sceneDepthMapRequested = true;
-        } else if (this._sceneDepthMapRequested) {
+        } else if (!value && this._sceneDepthMapRequested) {
             this.requestSceneDepthMap(false);
             this._sceneDepthMapRequested = false;
         }


### PR DESCRIPTION
Setting renderSceneColorMap or renderSceneDepthMap to true when already set, sets it to false

## Description
I don't have a proveable issue here but I saw this function and it sounds dodgy af.  Passing true can cause it to set it to false, it seems unlikely to be intentional

Fixes #
n/a
## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
