### PR TITLE
fix(gsplat): avoid GLSL ES reserved word 'packed' in compact format shader

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/formats/containerCompactRead.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/formats/containerCompactRead.js
@@ -17,21 +17,21 @@ float getOpacity() {
 }
 
 vec3 getColor() {
-    uint packed = loadDataColor().x;
-    float r = float(packed & 0x7FFu) * (4.0 / 2047.0);
-    float g = float((packed >> 11u) & 0x7FFu) * (4.0 / 2047.0);
-    float b = float((packed >> 22u) & 0x3FFu) * (4.0 / 1023.0);
+    uint data = loadDataColor().x;
+    float r = float(data & 0x7FFu) * (4.0 / 2047.0);
+    float g = float((data >> 11u) & 0x7FFu) * (4.0 / 2047.0);
+    float b = float((data >> 22u) & 0x3FFu) * (4.0 / 1023.0);
     return vec3(r, g, b);
 }
 
 vec4 getRotation() {
-    uint packed = loadDataTransformB().x;
+    uint data = loadDataTransformB().x;
 
     // dequantize half-angle projected quaternion: 11+11+10 bits to [-1, 1]
     vec3 p = vec3(
-        float(packed & 0x7FFu) / 2047.0 * 2.0 - 1.0,
-        float((packed >> 11u) & 0x7FFu) / 2047.0 * 2.0 - 1.0,
-        float((packed >> 22u) & 0x3FFu) / 1023.0 * 2.0 - 1.0
+        float(data & 0x7FFu) / 2047.0 * 2.0 - 1.0,
+        float((data >> 11u) & 0x7FFu) / 2047.0 * 2.0 - 1.0,
+        float((data >> 22u) & 0x3FFu) / 1023.0 * 2.0 - 1.0
     );
 
     // inverse half-angle transform, returns (w, x, y, z) format
@@ -40,10 +40,10 @@ vec4 getRotation() {
 }
 
 vec3 getScale() {
-    uint packed = cachedTransformA.a;
-    float sx = float(packed & 0xFFu);
-    float sy = float((packed >> 8u) & 0xFFu);
-    float sz = float((packed >> 16u) & 0xFFu);
+    uint data = cachedTransformA.a;
+    float sx = float(data & 0xFFu);
+    float sy = float((data >> 8u) & 0xFFu);
+    float sz = float((data >> 16u) & 0xFFu);
 
     // decode log-encoded scale: 0 = true zero, 1-255 maps linearly in log-space to e^-12..e^9
     const float logRange = 21.0 / 255.0;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/formats/uncompressed.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/formats/uncompressed.js
@@ -6,8 +6,8 @@ export default /* glsl */`
 uint tAw;
 vec4 tBcached;
 
-vec4 unpackRotation(vec3 packed) {
-    return vec4(packed.xyz, sqrt(max(0.0, 1.0 - dot(packed, packed))));
+vec4 unpackRotation(vec3 data) {
+    return vec4(data.xyz, sqrt(max(0.0, 1.0 - dot(data, data))));
 }
 
 // read the model-space center of the gaussian

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/containerCompactRead.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/containerCompactRead.js
@@ -17,21 +17,21 @@ fn getOpacity() -> f32 {
 }
 
 fn getColor() -> vec3f {
-    let packed = loadDataColor().x;
-    let r = f32(packed & 0x7FFu) * (4.0 / 2047.0);
-    let g = f32((packed >> 11u) & 0x7FFu) * (4.0 / 2047.0);
-    let b = f32((packed >> 22u) & 0x3FFu) * (4.0 / 1023.0);
+    let data = loadDataColor().x;
+    let r = f32(data & 0x7FFu) * (4.0 / 2047.0);
+    let g = f32((data >> 11u) & 0x7FFu) * (4.0 / 2047.0);
+    let b = f32((data >> 22u) & 0x3FFu) * (4.0 / 1023.0);
     return vec3f(r, g, b);
 }
 
 fn getRotation() -> vec4f {
-    let packed = loadDataTransformB().x;
+    let data = loadDataTransformB().x;
 
     // dequantize half-angle projected quaternion: 11+11+10 bits to [-1, 1]
     let p = vec3f(
-        f32(packed & 0x7FFu) / 2047.0 * 2.0 - 1.0,
-        f32((packed >> 11u) & 0x7FFu) / 2047.0 * 2.0 - 1.0,
-        f32((packed >> 22u) & 0x3FFu) / 1023.0 * 2.0 - 1.0
+        f32(data & 0x7FFu) / 2047.0 * 2.0 - 1.0,
+        f32((data >> 11u) & 0x7FFu) / 2047.0 * 2.0 - 1.0,
+        f32((data >> 22u) & 0x3FFu) / 1023.0 * 2.0 - 1.0
     );
 
     // inverse half-angle transform, returns (w, x, y, z) format
@@ -40,10 +40,10 @@ fn getRotation() -> vec4f {
 }
 
 fn getScale() -> vec3f {
-    let packed = cachedTransformA.a;
-    let sx = f32(packed & 0xFFu);
-    let sy = f32((packed >> 8u) & 0xFFu);
-    let sz = f32((packed >> 16u) & 0xFFu);
+    let data = cachedTransformA.a;
+    let sx = f32(data & 0xFFu);
+    let sy = f32((data >> 8u) & 0xFFu);
+    let sz = f32((data >> 16u) & 0xFFu);
 
     // decode log-encoded scale: 0 = true zero, 1-255 maps linearly in log-space to e^-12..e^9
     let logRange = 21.0 / 255.0;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/uncompressed.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/formats/uncompressed.js
@@ -6,8 +6,8 @@ export default /* wgsl */`
 var<private> tAw: u32;
 var<private> tBcached: vec4f;
 
-fn unpackRotation(packed: vec3f) -> vec4f {
-    return vec4f(packed.xyz, sqrt(max(0.0, 1.0 - dot(packed, packed))));
+fn unpackRotation(data: vec3f) -> vec4f {
+    return vec4f(data.xyz, sqrt(max(0.0, 1.0 - dot(data, data))));
 }
 
 // read the model-space center of the gaussian


### PR DESCRIPTION
The compact gsplat format read chunk used a local variable named `packed`, which is a reserved keyword in GLSL ES 3.00+ (§3.7). The current stable ANGLE shader compiler in Chrome accepts it, but the newer ANGLE in Chrome Canary correctly rejects it, breaking gsplat rendering:

```
ERROR: 0:197: 'packed' : Illegal use of reserved word
ERROR: 0:197: 'packed' : syntax error
```

**Fix:**
- `glsl/chunks/gsplat/vert/formats/containerCompactRead.js` — rename the three local `uint packed` declarations (in `getColor`, `getRotation`, `getScale`) and their uses to `data`.
- `glsl/chunks/gsplat/vert/formats/uncompressed.js` — rename the `vec3 packed` parameter on `unpackRotation` and its uses to `data`.
- Matching WGSL chunks (`wgsl/chunks/gsplat/vert/formats/containerCompactRead.js`, `wgsl/chunks/gsplat/vert/formats/uncompressed.js`) renamed identically so the GLSL/WGSL pair stays symmetric. WGSL itself doesn't reserve `packed`, but keeping the names in sync makes the chunks easier to maintain.

No public API changes, no behaviour changes.