### PR TITLE
refactor(webgpu): data-driven gating for WGSL built-in inputs

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -46,6 +46,53 @@ const MARKER = '@@@';
 // matches vertex of fragment entry function, extracts the input name. Ends at the start of the function body '{'.
 const ENTRY_FUNCTION = /(@vertex|@fragment)\s*fn\s+\w+\s*\(\s*(\w+)\s*:[\s\S]*?\{/;
 
+// Tables describing optional WGSL built-in inputs that the engine emits on demand. Each entry
+// maps a public private global (pcXxx) and a struct field (`<input>.xxx`) to the underlying
+// `@builtin(...)` declaration. Detection is data-driven so adding a new built-in is a one-row
+// change.
+//
+// - `requiresFeature` (optional): name of a `device.<X>` boolean that must be true to emit it.
+// - `isFallback` (optional): used as a sentinel when no other built-in or user input is present,
+//   to guarantee the input struct is never empty (which is invalid WGSL).
+const FRAGMENT_BUILTINS = [
+    { wgslName: 'position', wgslType: 'vec4f', wgslBuiltin: 'position', pcName: 'pcPosition', isFallback: true },
+    { wgslName: 'frontFacing', wgslType: 'bool', wgslBuiltin: 'front_facing', pcName: 'pcFrontFacing' },
+    { wgslName: 'sampleIndex', wgslType: 'u32', wgslBuiltin: 'sample_index', pcName: 'pcSampleIndex' },
+    { wgslName: 'primitiveIndex', wgslType: 'u32', wgslBuiltin: 'primitive_index', pcName: 'pcPrimitiveIndex', requiresFeature: 'supportsPrimitiveIndex' }
+];
+
+const VERTEX_BUILTINS = [
+    { wgslName: 'vertexIndex', wgslType: 'u32', wgslBuiltin: 'vertex_index', pcName: 'pcVertexIndex', isFallback: true },
+    { wgslName: 'instanceIndex', wgslType: 'u32', wgslBuiltin: 'instance_index', pcName: 'pcInstanceIndex' }
+];
+
+// Returns the subset of `builtins` whose pcName or `<entryInputName>.wgslName` appears in `source`
+// as a whole word, skipping any whose required device feature is not supported. Word boundaries
+// prevent false positives on identifiers that contain these names as a substring. Comments are
+// stripped by the preprocessor before this runs, so they don't need to be considered.
+const detectUsedBuiltins = (builtins, source, entryInputName, device) => {
+    return builtins.filter((b) => {
+        if (b.requiresFeature && !device[b.requiresFeature]) return false;
+        return new RegExp(`\\b(?:${b.pcName}|${entryInputName}\\.${b.wgslName})\\b`).test(source);
+    });
+};
+
+// Guarantees the input struct is never empty (which is invalid WGSL): if no built-ins were
+// detected and the rest of the struct (varyings / attributes) is also empty, fall back to the
+// stage's designated sentinel built-in.
+const ensureNonEmptyStruct = (used, builtins, device, otherFieldsPresent) => {
+    if (used.length === 0 && !otherFieldsPresent) {
+        const fallback = builtins.find(b => b.isFallback && (!b.requiresFeature || device[b.requiresFeature]));
+        if (fallback) return [fallback];
+    }
+    return used;
+};
+
+// Codegen helpers for a list of detected built-ins.
+const renderBuiltinStructFields = used => used.map(b => `    @builtin(${b.wgslBuiltin}) ${b.wgslName} : ${b.wgslType},\n`).join('');
+const renderBuiltinPrivates = used => used.map(b => `    var<private> ${b.pcName}: ${b.wgslType};\n`).join('');
+const renderBuiltinCopies = used => used.map(b => `    ${b.pcName} = input.${b.wgslName};\n`).join('');
+
 const textureBaseInfo = {
     'texture_1d': { viewDimension: TEXTUREDIMENSION_1D, baseSampleType: SAMPLETYPE_FLOAT },
     'texture_2d': { viewDimension: TEXTUREDIMENSION_2D, baseSampleType: SAMPLETYPE_FLOAT },
@@ -330,15 +377,22 @@ class WebgpuShaderProcessorWGSL {
         const vertexExtracted = WebgpuShaderProcessorWGSL.extract(shaderDefinition.vshader);
         const fragmentExtracted = WebgpuShaderProcessorWGSL.extract(shaderDefinition.fshader);
 
+        // extract the user's input parameter name from each entry function for built-in detection.
+        // Note: only the parameter name is captured here, not the brace position - `renameUniformAccess`
+        // below modifies the source and invalidates any cached match positions, so `copyInputs` re-runs
+        // the regex against the post-rename source to find its injection point.
+        const vertexInputName = vertexExtracted.src.match(ENTRY_FUNCTION)?.[2] ?? '';
+        const fragmentInputName = fragmentExtracted.src.match(ENTRY_FUNCTION)?.[2] ?? '';
+
         // VS - convert a list of attributes to a shader block with fixed locations
         const attributesMap = new Map();
-        const attributesBlock = WebgpuShaderProcessorWGSL.processAttributes(vertexExtracted.attributes, shaderDefinition.attributes, attributesMap, shaderDefinition.processingOptions, shader);
+        const attributesBlock = WebgpuShaderProcessorWGSL.processAttributes(vertexExtracted.attributes, shaderDefinition.attributes, attributesMap, shaderDefinition.processingOptions, shader, device, vertexExtracted.src, vertexInputName);
 
         // VS - convert a list of varyings to a shader block
         const vertexVaryingsBlock = WebgpuShaderProcessorWGSL.processVaryings(vertexExtracted.varyings, varyingMap, true, device);
 
         // FS - convert a list of varyings to a shader block
-        const fragmentVaryingsBlock = WebgpuShaderProcessorWGSL.processVaryings(fragmentExtracted.varyings, varyingMap, false, device, fragmentExtracted.src);
+        const fragmentVaryingsBlock = WebgpuShaderProcessorWGSL.processVaryings(fragmentExtracted.varyings, varyingMap, false, device, fragmentExtracted.src, fragmentInputName);
 
         // uniforms - merge vertex and fragment uniforms, and create shared uniform buffers
         // Note that as both vertex and fragment can declare the same uniform, we need to remove duplicates
@@ -701,16 +755,11 @@ class WebgpuShaderProcessorWGSL {
         return code;
     }
 
-    static processVaryings(varyingLines, varyingMap, isVertex, device, source = '') {
+    static processVaryings(varyingLines, varyingMap, isVertex, device, source = '', entryInputName = '') {
         let block = '';
         let blockPrivates = '';
         let blockCopy = '';
-        const needsPosition = !isVertex && source.includes('pcPosition');
-        const needsFrontFacing = !isVertex && source.includes('pcFrontFacing');
-        const needsPrimitiveIndex = !isVertex && source.includes('pcPrimitiveIndex');
 
-        // Requesting sample_index can force sample-rate shading on MSAA render targets.
-        const needsSampleIndex = !isVertex && source.includes('pcSampleIndex');
         varyingLines.forEach((line, index) => {
             const match = line.match(VARYING);
             Debug.assert(match, `Varying line is not valid: ${line}`);
@@ -742,74 +791,39 @@ class WebgpuShaderProcessorWGSL {
             }
         });
 
-        // add built-in varyings
+        // vertex output: @builtin(position) is required by WGSL, always emitted
         if (isVertex) {
-            block += '    @builtin(position) position : vec4f,\n';          // output position
-        } else {
-            if (needsPosition) {
-                block += '    @builtin(position) position : vec4f,\n';      // interpolated fragment position
-            }
-            if (needsFrontFacing) {
-                block += '    @builtin(front_facing) frontFacing : bool,\n'; // front-facing
-            }
-            if (needsSampleIndex) {
-                block += '    @builtin(sample_index) sampleIndex : u32,\n'; // sample index for MSAA
-            }
-            if (device.supportsPrimitiveIndex && needsPrimitiveIndex) {
-                block += '    @builtin(primitive_index) primitiveIndex : u32,\n';  // primitive index
-            }
+            block += '    @builtin(position) position : vec4f,\n';
+            return `
+                struct VertexOutput {
+                    ${block}
+                };
+            `;
         }
 
-        // primitive index support
-        const primitiveIndexGlobals = device.supportsPrimitiveIndex && needsPrimitiveIndex ? `
-            var<private> pcPrimitiveIndex: u32;
-        ` : '';
-        const primitiveIndexCopy = device.supportsPrimitiveIndex && needsPrimitiveIndex ? `
-                pcPrimitiveIndex = input.primitiveIndex;
-        ` : '';
-        const sampleIndexGlobal = needsSampleIndex ? `
-            var<private> pcSampleIndex: u32;
-        ` : '';
-        const sampleIndexCopy = needsSampleIndex ? `
-                pcSampleIndex = input.sampleIndex;
-        ` : '';
-        const positionGlobal = needsPosition ? `
-            var<private> pcPosition: vec4f;
-        ` : '';
-        const positionCopy = needsPosition ? `
-                pcPosition = input.position;
-        ` : '';
-        const frontFacingGlobal = needsFrontFacing ? `
-            var<private> pcFrontFacing: bool;
-        ` : '';
-        const frontFacingCopy = needsFrontFacing ? `
-                pcFrontFacing = input.frontFacing;
-        ` : '';
+        // fragment input: data-driven detection of optional built-ins, with sentinel fallback
+        // to guarantee a non-empty FragmentInput struct (which is invalid WGSL).
+        const usedBuiltins = ensureNonEmptyStruct(
+            detectUsedBuiltins(FRAGMENT_BUILTINS, source, entryInputName, device),
+            FRAGMENT_BUILTINS,
+            device,
+            block.length > 0
+        );
+        block += renderBuiltinStructFields(usedBuiltins);
 
-        // global variables for build-in input into fragment shader
-        const fragmentGlobals = isVertex ? '' : `
-            ${positionGlobal}
-            ${frontFacingGlobal}
-            ${sampleIndexGlobal}
-            ${primitiveIndexGlobals}
+        return `
+            struct FragmentInput {
+                ${block}
+            };
+
+            ${renderBuiltinPrivates(usedBuiltins)}
             ${blockPrivates}
-            
+
             // function to copy inputs (varyings) to private global variables
             fn _pcCopyInputs(input: FragmentInput) {
                 ${blockCopy}
-                ${positionCopy}
-                ${frontFacingCopy}
-                ${sampleIndexCopy}
-                ${primitiveIndexCopy}
+                ${renderBuiltinCopies(usedBuiltins)}
             }
-        `;
-
-        const structName = isVertex ? 'VertexOutput' : 'FragmentInput';
-        return `
-            struct ${structName} {
-                ${block}
-            };
-            ${fragmentGlobals}
         `;
     }
 
@@ -858,7 +872,7 @@ class WebgpuShaderProcessorWGSL {
         return floatToIntShort[shortType] || null;
     }
 
-    static processAttributes(attributeLines, shaderDefinitionAttributes = {}, attributesMap, processingOptions, shader) {
+    static processAttributes(attributeLines, shaderDefinitionAttributes = {}, attributesMap, processingOptions, shader, device, source = '', entryInputName = '') {
         let blockAttributes = '';
         let blockPrivates = '';
         let blockCopy = '';
@@ -909,35 +923,42 @@ class WebgpuShaderProcessorWGSL {
             }
         });
 
+        // vertex input: data-driven detection of optional built-ins, with sentinel fallback
+        // to guarantee a non-empty VertexInput struct (which is invalid WGSL).
+        const usedBuiltins = ensureNonEmptyStruct(
+            detectUsedBuiltins(VERTEX_BUILTINS, source, entryInputName, device),
+            VERTEX_BUILTINS,
+            device,
+            blockAttributes.length > 0
+        );
+
         return `
             struct VertexInput {
                 ${blockAttributes}
-                @builtin(vertex_index) vertexIndex : u32,       // built-in vertex index
-                @builtin(instance_index) instanceIndex : u32    // built-in instance index
+                ${renderBuiltinStructFields(usedBuiltins)}
             };
 
             ${blockPrivates}
-            var<private> pcVertexIndex: u32;
-            var<private> pcInstanceIndex: u32;
+            ${renderBuiltinPrivates(usedBuiltins)}
 
             fn _pcCopyInputs(input: VertexInput) {
                 ${blockCopy}
-                pcVertexIndex = input.vertexIndex;
-                pcInstanceIndex = input.instanceIndex;
+                ${renderBuiltinCopies(usedBuiltins)}
             }
         `;
     }
 
     /**
      * Injects a call to _pcCopyInputs with the function's input parameter right after the opening
-     * brace of a WGSL function marked with `@vertex` or `@fragment`.
+     * brace of a WGSL function marked with `@vertex` or `@fragment`. The regex is run inside this
+     * function (not hoisted) so the brace position is always derived from the current `src` - any
+     * earlier source-modifying step (e.g. `renameUniformAccess`) would invalidate a cached position.
      *
      * @param {string} src - The source string containing the WGSL code.
      * @param {Shader} shader - The shader.
      * @returns {string} - The modified source string.
      */
     static copyInputs(src, shader) {
-        // find @vertex or @fragment followed by the function signature and capture the input parameter name
         const match = src.match(ENTRY_FUNCTION);
 
         // check if match exists AND the parameter name (Group 2) was captured


### PR DESCRIPTION
Follow-up to #8733. Generalizes the WebGPU shader processor's gating of optional WGSL built-in inputs so that all stages are handled consistently, fixes a regression that produced invalid WGSL for shaders without varyings, and restructures the emission to be data-driven so adding a new built-in is a one-row change.

**Fixes:**
- Empty `FragmentInput` struct (invalid WGSL) for fragment shaders with no varyings and no `pc*` references (e.g. the `gizmo-unlit` shader). A sentinel built-in is now emitted only when the input struct would otherwise be empty.
- Detection now also recognises struct-field access (`input.frontFacing`, `input.sampleIndex`, ...), not only the `pc*` global form. Both forms are documented as supported in `wgsl-specifics.md`.
- Word-boundary regex (instead of `String.includes`) prevents false positives on identifiers containing the name as a substring.

**Changes:**
- New `FRAGMENT_BUILTINS` / `VERTEX_BUILTINS` tables describe each optional built-in (name, type, `@builtin(...)`, public `pc*` global, optional feature flag, optional sentinel role).
- Vertex inputs `vertex_index` / `instance_index` are now gated symmetrically with the fragment built-ins (previously always emitted). Gating uses both `pcVertexIndex` / `pcInstanceIndex` and `input.vertexIndex` / `input.instanceIndex`.
- Sentinel fallback per stage (`position` for fragment, `vertex_index` for vertex) keeps input structs non-empty even when nothing else is referenced.
- \`processAttributes\` signature extended with \`device\`, \`source\`, \`entryInputName\` (internal only).
- \`copyInputs\` left to do its own \`ENTRY_FUNCTION\` match against the post-\`renameUniformAccess\` source, since cached match positions would be invalidated by source-modifying passes.

**No public API changes** — all changes are internal to the WGSL shader processor. Behaviour for existing engine shaders is unchanged (the few vertex chunks that reference \`pcVertexIndex\` / \`pcInstanceIndex\` continue to receive those built-ins; the rest now no longer carry two unused inputs).