### PR TITLE
refactor(lit): align WGSL and GLSL clustered-light chunks

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/clusteredLight.js
@@ -40,32 +40,22 @@ uniform ivec3 clusterCellsDot;
 uniform ivec3 clusterCellsMax;
 uniform vec2 shadowAtlasParams;
 
-// structure storing light properties of a clustered light
-// it's sorted to have all vectors aligned to 4 floats to limit padding
+// structure storing light properties of a clustered light. Vectors and scalars are interleaved
+// so each vec3 packs with an adjacent 4-byte field into a 16-byte slot, minimising padding for
+// compilers that don't reorder struct members.
 struct ClusterLightData {
-
-    // area light sizes / orientation
-    vec3 halfWidth;
-
-    bool isSpot;
-
-    // area light sizes / orientation
-    vec3 halfHeight;
-
-    // light index
-    int lightIndex;
 
     // world space position
     vec3 position;
 
-    // area light shape
-    uint shape;
+    // light index in the lights texture
+    int lightIndex;
 
     // world space direction (spot light only)
     vec3 direction;
 
-    // light follow mode
-    bool falloffModeLinear;
+    // area light shape
+    uint shape;
 
     // color
     vec3 color;
@@ -73,33 +63,42 @@ struct ClusterLightData {
     // 0.0 if the light doesn't cast shadows
     float shadowIntensity;
 
-    // atlas viewport for omni light shadow and cookie (.xy is offset to the viewport slot, .z is size of the face in the atlas)
-    vec3 omniAtlasViewport;
-
     // range of the light
     float range;
 
-    // channel mask - one of the channels has 1, the others are 0
-    vec4 cookieChannelMask;
-
-    // compressed biases, two haf-floats stored in a float
+    // compressed biases, two half-floats stored in a float
     float biasesData;
-
-    // shadow bias values
-    float shadowBias;
-    float shadowNormalBias;
-
-    // spot light inner and outer angle cosine
-    float innerConeAngleCos;
-    float outerConeAngleCos;
 
     // intensity of the cookie
     float cookieIntensity;
 
-    // light mask
-    //float mask;
+    // true for spot lights
+    bool isSpot;
+
+    // light follow mode
+    bool falloffModeLinear;
+
+    // light mask (mutually exclusive)
     bool isDynamic;
     bool isLightmapped;
+};
+
+// Spot light cone angles, decoded on demand only when the light is a spot light.
+struct ClusterLightSpotData {
+    float innerConeAngleCos;
+    float outerConeAngleCos;
+};
+
+// Area light dimensions and orientation, decoded on demand only for non-punctual lights.
+struct ClusterLightAreaData {
+    vec3 halfWidth;
+    vec3 halfHeight;
+};
+
+// Shadow bias parameters, decoded on demand only when the light casts shadows.
+struct ClusterLightShadowData {
+    float shadowBias;
+    float shadowNormalBias;
 };
 
 // Note: on some devices (tested on Pixel 3A XL), this matrix when stored inside the light struct has lower precision compared to
@@ -112,22 +111,24 @@ mat4 lightProjectionMatrix;
 // NOTE: On some Samsung devices, these values can suffer precision / corruption issues when stored
 // as members of ClusterLightData. Keep them as module-scope temporaries instead. See issue #7800.
 uint clusterLightData_flags;             // 32bit of flags
-float clusterLightData_anglesData;       // compressed angles, two haf-floats stored in a float
+float clusterLightData_anglesData;       // compressed angles, two half-floats stored in a float
 uint clusterLightData_colorBFlagsData;   // blue color component and angle flags (as uint for efficient bit operations)
 
-vec4 sampleLightTextureF(const ClusterLightData clusterLightData, int index) {
-    return texelFetch(lightsTexture, ivec2(index, clusterLightData.lightIndex), 0);
+vec4 sampleLightTextureF(int lightIndex, int index) {
+    return texelFetch(lightsTexture, ivec2(index, lightIndex), 0);
 }
 
-void decodeClusterLightCore(inout ClusterLightData clusterLightData, int lightIndex) {
+ClusterLightData decodeClusterLightCore(int lightIndex) {
+    ClusterLightData clusterLightData;
 
     // light index
     clusterLightData.lightIndex = lightIndex;
 
     // sample data encoding half-float values into 32bit uints
-    vec4 halfData = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_COLOR_ANGLES_BIAS});
+    vec4 halfData = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_COLOR_ANGLES_BIAS});
 
-    // store floats we decode later as needed
+    // store values needed by later decode steps (anglesData / colorBFlagsData live outside the
+    // struct due to Samsung precision issues - see #7800)
     clusterLightData_anglesData = halfData.z;
     clusterLightData.biasesData = halfData.w;
     clusterLightData_colorBFlagsData = floatBitsToUint(halfData.y);
@@ -138,17 +139,17 @@ void decodeClusterLightCore(inout ClusterLightData clusterLightData, int lightIn
     clusterLightData.color = vec3(colorRG, colorB_flags.x) * {LIGHT_COLOR_DIVIDER};
 
     // position and range, full floats
-    vec4 lightPosRange = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_POSITION_RANGE});
+    vec4 lightPosRange = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_POSITION_RANGE});
     clusterLightData.position = lightPosRange.xyz;
     clusterLightData.range = lightPosRange.w;
 
     // spot direction & flags data
-    vec4 lightDir_Flags = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_DIRECTION_FLAGS});
+    vec4 lightDir_Flags = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_DIRECTION_FLAGS});
 
     // spot light direction
     clusterLightData.direction = lightDir_Flags.xyz;
 
-    // 32bit flags
+    // 32bit flags (kept outside the struct, see #7800)
     clusterLightData_flags = floatBitsToUint(lightDir_Flags.w);
     clusterLightData.isSpot = (clusterLightData_flags & (1u << 30u)) != 0u;
     clusterLightData.shape = (clusterLightData_flags >> 28u) & 0x3u;
@@ -157,9 +158,11 @@ void decodeClusterLightCore(inout ClusterLightData clusterLightData, int lightIn
     clusterLightData.cookieIntensity = float((clusterLightData_flags >> 8u) & 0xFFu) / 255.0;
     clusterLightData.isDynamic = (clusterLightData_flags & (1u << 22u)) != 0u;
     clusterLightData.isLightmapped = (clusterLightData_flags & (1u << 21u)) != 0u;
+
+    return clusterLightData;
 }
 
-void decodeClusterLightSpot(inout ClusterLightData clusterLightData) {
+ClusterLightSpotData decodeClusterLightSpot() {
     // decompress spot light angles
     uint angleFlags = (clusterLightData_colorBFlagsData >> 16u) & 0xFFFFu;  // Extract upper 16 bits as integer
 
@@ -170,43 +173,44 @@ void decodeClusterLightSpot(inout ClusterLightData clusterLightData) {
     // decode based on flags (branch-free)
     float innerIsVersine = float(angleFlags & 1u);          // bit 0: inner angle format
     float outerIsVersine = float((angleFlags >> 1u) & 1u);  // bit 1: outer angle format
-    clusterLightData.innerConeAngleCos = mix(innerVal, 1.0 - innerVal, innerIsVersine);
-    clusterLightData.outerConeAngleCos = mix(outerVal, 1.0 - outerVal, outerIsVersine);
+
+    return ClusterLightSpotData(
+        mix(innerVal, 1.0 - innerVal, innerIsVersine),
+        mix(outerVal, 1.0 - outerVal, outerIsVersine)
+    );
 }
 
-void decodeClusterLightOmniAtlasViewport(inout ClusterLightData clusterLightData) {
-    clusterLightData.omniAtlasViewport = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_PROJ_MAT_0}).xyz;
+vec3 decodeClusterLightOmniAtlasViewport(int lightIndex) {
+    return sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_0}).xyz;
 }
 
-void decodeClusterLightAreaData(inout ClusterLightData clusterLightData) {
-    clusterLightData.halfWidth = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_AREA_DATA_WIDTH}).xyz;
-    clusterLightData.halfHeight = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_AREA_DATA_HEIGHT}).xyz;
+ClusterLightAreaData decodeClusterLightAreaData(int lightIndex) {
+    return ClusterLightAreaData(
+        sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_AREA_DATA_WIDTH}).xyz,
+        sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_AREA_DATA_HEIGHT}).xyz
+    );
 }
 
-void decodeClusterLightProjectionMatrixData(inout ClusterLightData clusterLightData) {
-    
+mat4 decodeClusterLightProjectionMatrixData(int lightIndex) {
     // shadow matrix
-    vec4 m0 = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_PROJ_MAT_0});
-    vec4 m1 = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_PROJ_MAT_1});
-    vec4 m2 = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_PROJ_MAT_2});
-    vec4 m3 = sampleLightTextureF(clusterLightData, {CLUSTER_TEXTURE_PROJ_MAT_3});
-    lightProjectionMatrix = mat4(m0, m1, m2, m3);
+    vec4 m0 = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_0});
+    vec4 m1 = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_1});
+    vec4 m2 = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_2});
+    vec4 m3 = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_3});
+    return mat4(m0, m1, m2, m3);
 }
 
-void decodeClusterLightShadowData(inout ClusterLightData clusterLightData) {
-    
+ClusterLightShadowData decodeClusterLightShadowData(float biasesData) {
     // shadow biases
-    vec2 biases = unpackHalf2x16(floatBitsToUint(clusterLightData.biasesData));
-    clusterLightData.shadowBias = biases.x;
-    clusterLightData.shadowNormalBias = biases.y;
+    vec2 biases = unpackHalf2x16(floatBitsToUint(biasesData));
+    return ClusterLightShadowData(biases.x, biases.y);
 }
 
-void decodeClusterLightCookieData(inout ClusterLightData clusterLightData) {
-
+vec4 decodeClusterLightCookieData() {
     // extract channel mask from flags
     uint cookieFlags = (clusterLightData_flags >> 23u) & 0x0Fu;  // 4bits, each bit enables a channel
-    clusterLightData.cookieChannelMask = vec4(uvec4(cookieFlags) & uvec4(1u, 2u, 4u, 8u));
-    clusterLightData.cookieChannelMask = step(1.0, clusterLightData.cookieChannelMask);  // Normalize to 0.0 or 1.0
+    vec4 mask = vec4(uvec4(cookieFlags) & uvec4(1u, 2u, 4u, 8u));
+    return step(1.0, mask);  // Normalize to 0.0 or 1.0
 }
 
 void evaluateLight(
@@ -244,15 +248,15 @@ void evaluateLight(
     if (light.shape != {LIGHTSHAPE_PUNCTUAL}) { // area light
 
         // area lights
-        decodeClusterLightAreaData(light);
+        ClusterLightAreaData areaData = decodeClusterLightAreaData(light.lightIndex);
 
         // handle light shape
         if (light.shape == {LIGHTSHAPE_RECT}) {
-            calcRectLightValues(light.position, light.halfWidth, light.halfHeight);
+            calcRectLightValues(light.position, areaData.halfWidth, areaData.halfHeight);
         } else if (light.shape == {LIGHTSHAPE_DISK}) {
-            calcDiskLightValues(light.position, light.halfWidth, light.halfHeight);
+            calcDiskLightValues(light.position, areaData.halfWidth, areaData.halfHeight);
         } else { // sphere
-            calcSphereLightValues(light.position, light.halfWidth, light.halfHeight);
+            calcSphereLightValues(light.position, areaData.halfWidth, areaData.halfHeight);
         }
 
         falloffAttenuation = getFalloffWindow(light.range, lightDirW);
@@ -294,8 +298,8 @@ void evaluateLight(
 
         // spot light falloff
         if (light.isSpot) {
-            decodeClusterLightSpot(light);
-            falloffAttenuation *= getSpotEffect(light.direction, light.innerConeAngleCos, light.outerConeAngleCos, lightDirNormW);
+            ClusterLightSpotData spotData = decodeClusterLightSpot();
+            falloffAttenuation *= getSpotEffect(light.direction, spotData.innerConeAngleCos, spotData.outerConeAngleCos, lightDirNormW);
         }
 
         #if defined(CLUSTER_COOKIES) || defined(CLUSTER_SHADOWS)
@@ -305,11 +309,13 @@ void evaluateLight(
             // shadow / cookie
             if (light.shadowIntensity > 0.0 || light.cookieIntensity > 0.0) {
 
+                vec3 omniAtlasViewport = vec3(0.0);
+
                 // shared shadow / cookie data depends on light type
                 if (light.isSpot) {
-                    decodeClusterLightProjectionMatrixData(light);
+                    lightProjectionMatrix = decodeClusterLightProjectionMatrixData(light.lightIndex);
                 } else {
-                    decodeClusterLightOmniAtlasViewport(light);
+                    omniAtlasViewport = decodeClusterLightOmniAtlasViewport(light.lightIndex);
                 }
 
                 float shadowTextureResolution = shadowAtlasParams.x;
@@ -319,12 +325,12 @@ void evaluateLight(
 
                 // cookie
                 if (light.cookieIntensity > 0.0) {
-                    decodeClusterLightCookieData(light);
+                    vec4 cookieChannelMask = decodeClusterLightCookieData();
 
                     if (light.isSpot) {
-                        cookieAttenuation = getCookie2DClustered(TEXTURE_PASS(cookieAtlasTexture), lightProjectionMatrix, vPositionW, light.cookieIntensity, light.cookieChannelMask);
+                        cookieAttenuation = getCookie2DClustered(TEXTURE_PASS(cookieAtlasTexture), lightProjectionMatrix, vPositionW, light.cookieIntensity, cookieChannelMask);
                     } else {
-                        cookieAttenuation = getCookieCubeClustered(TEXTURE_PASS(cookieAtlasTexture), lightDirW, light.cookieIntensity, light.cookieChannelMask, shadowTextureResolution, shadowEdgePixels, light.omniAtlasViewport);
+                        cookieAttenuation = getCookieCubeClustered(TEXTURE_PASS(cookieAtlasTexture), lightDirW, light.cookieIntensity, cookieChannelMask, shadowTextureResolution, shadowEdgePixels, omniAtlasViewport);
                     }
                 }
 
@@ -334,9 +340,9 @@ void evaluateLight(
 
                 // shadow
                 if (light.shadowIntensity > 0.0) {
-                    decodeClusterLightShadowData(light);
+                    ClusterLightShadowData shadowData = decodeClusterLightShadowData(light.biasesData);
 
-                    vec4 shadowParams = vec4(shadowTextureResolution, light.shadowNormalBias, light.shadowBias, 1.0 / light.range);
+                    vec4 shadowParams = vec4(shadowTextureResolution, shadowData.shadowNormalBias, shadowData.shadowBias, 1.0 / light.range);
 
                     if (light.isSpot) {
 
@@ -360,11 +366,11 @@ void evaluateLight(
                         vec3 dir = normalOffsetPointShadow(shadowParams, light.position, lightDirW, lightDirNormW, geometricNormal);  // normalBias adjusted for distance
 
                         #if defined(CLUSTER_SHADOW_TYPE_PCF1)
-                            float shadow = getShadowOmniClusteredPCF1(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams, light.omniAtlasViewport, shadowEdgePixels, dir);
+                            float shadow = getShadowOmniClusteredPCF1(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams, omniAtlasViewport, shadowEdgePixels, dir);
                         #elif defined(CLUSTER_SHADOW_TYPE_PCF3)
-                            float shadow = getShadowOmniClusteredPCF3(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams, light.omniAtlasViewport, shadowEdgePixels, dir);
+                            float shadow = getShadowOmniClusteredPCF3(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams, omniAtlasViewport, shadowEdgePixels, dir);
                         #elif defined(CLUSTER_SHADOW_TYPE_PCF5)
-                            float shadow = getShadowOmniClusteredPCF5(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams, light.omniAtlasViewport, shadowEdgePixels, dir);
+                            float shadow = getShadowOmniClusteredPCF5(SHADOWMAP_PASS(shadowAtlasTexture), shadowParams, omniAtlasViewport, shadowEdgePixels, dir);
                         #endif
                         falloffAttenuation *= mix(1.0, shadow, light.shadowIntensity);
                     }
@@ -512,8 +518,7 @@ void evaluateClusterLight(
 ) {
 
     // decode core light data from textures
-    ClusterLightData clusterLightData;
-    decodeClusterLightCore(clusterLightData, lightIndex);
+    ClusterLightData clusterLightData = decodeClusterLightCore(lightIndex);
 
     // evaluate light if it uses accepted light mask
     #ifdef CLUSTER_MESH_DYNAMIC_LIGHTS

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/clusteredLight.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/clusteredLight.js
@@ -42,30 +42,22 @@ uniform clusterCellsDot: vec3i;
 uniform clusterCellsMax: vec3i;
 uniform shadowAtlasParams: vec2f;
 
-// structure storing light properties of a clustered light
-// it's sorted to have all vectors aligned to 4 floats to limit padding
+// structure storing light properties of a clustered light. Vectors and scalars are interleaved
+// so each vec3 packs with an adjacent 4-byte field into a 16-byte slot, minimising padding for
+// compilers that don't reorder struct members.
 struct ClusterLightData {
-
-    // 32bit of flags
-    flags: u32,
-
-    // light index
-    lightIndex: i32,
 
     // world space position
     position: vec3f,
 
-    // area light shape
-    shape: u32,
+    // light index in the lights texture
+    lightIndex: i32,
 
     // world space direction (spot light only)
     direction: vec3f,
 
-    // true for spot lights
-    isSpot: bool,
-
-    // light follow mode
-    falloffModeLinear: bool,
+    // area light shape
+    shape: u32,
 
     // color
     color: vec3f,
@@ -76,34 +68,36 @@ struct ClusterLightData {
     // range of the light
     range: f32,
 
-    // compressed biases, two haf-floats stored in a float
+    // compressed biases, two half-floats stored in a float
     biasesData: f32,
-
-    // blue color component and angle flags (as uint for efficient bit operations)
-    colorBFlagsData: u32,
-
-    // compressed angles, two haf-floats stored in a float
-    anglesData: f32,
 
     // intensity of the cookie
     cookieIntensity: f32,
 
-    // light mask
-    //float mask;
+    // true for spot lights
+    isSpot: bool,
+
+    // light follow mode
+    falloffModeLinear: bool,
+
+    // light mask (mutually exclusive)
     isDynamic: bool,
     isLightmapped: bool
 }
 
+// Spot light cone angles, decoded on demand only when the light is a spot light.
 struct ClusterLightSpotData {
     innerConeAngleCos: f32,
     outerConeAngleCos: f32
 }
 
+// Area light dimensions and orientation, decoded on demand only for non-punctual lights.
 struct ClusterLightAreaData {
     halfWidth: vec3f,
     halfHeight: vec3f
 }
 
+// Shadow bias parameters, decoded on demand only when the light casts shadows.
 struct ClusterLightShadowData {
     shadowBias: f32,
     shadowNormalBias: f32
@@ -116,6 +110,12 @@ struct ClusterLightShadowData {
 // shadow (spot light only) / cookie projection matrix
 var<private> lightProjectionMatrix: mat4x4f;
 
+// NOTE: On some Samsung devices, these values can suffer precision / corruption issues when stored
+// as members of ClusterLightData. Keep them as module-scope temporaries instead. See issue #7800.
+var<private> clusterLightData_flags: u32;             // 32bit of flags
+var<private> clusterLightData_anglesData: f32;        // compressed angles, two half-floats stored in a float
+var<private> clusterLightData_colorBFlagsData: u32;   // blue color component and angle flags (as uint for efficient bit operations)
+
 fn sampleLightTextureF(lightIndex: i32, index: i32) -> vec4f {
     return textureLoad(lightsTexture, vec2<i32>(index, lightIndex), 0);
 }
@@ -127,48 +127,48 @@ fn decodeClusterLightCore(lightIndex: i32) -> ClusterLightData {
     clusterLightData.lightIndex = lightIndex;
 
     // sample data encoding half-float values into 32bit uints
-    let halfData: vec4f = sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_COLOR_ANGLES_BIAS});
+    let halfData: vec4f = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_COLOR_ANGLES_BIAS});
 
-    // store floats we decode later as needed
-    clusterLightData.anglesData = halfData.z;
+    // store values needed by later decode steps (anglesData / colorBFlagsData live outside the
+    // struct due to Samsung precision issues - see #7800)
+    clusterLightData_anglesData = halfData.z;
     clusterLightData.biasesData = halfData.w;
-    clusterLightData.colorBFlagsData = bitcast<u32>(halfData.y);
+    clusterLightData_colorBFlagsData = bitcast<u32>(halfData.y);
 
     // decompress color half-floats
     let colorRG: vec2f = unpack2x16float(bitcast<u32>(halfData.x));
-    let colorB_flags: vec2f = unpack2x16float(clusterLightData.colorBFlagsData);
+    let colorB_flags: vec2f = unpack2x16float(clusterLightData_colorBFlagsData);
     clusterLightData.color = vec3f(colorRG, colorB_flags.x) * {LIGHT_COLOR_DIVIDER};
 
     // position and range, full floats
-    let lightPosRange: vec4f = sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_POSITION_RANGE});
+    let lightPosRange: vec4f = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_POSITION_RANGE});
     clusterLightData.position = lightPosRange.xyz;
     clusterLightData.range = lightPosRange.w;
 
     // spot direction & flags data
-    let lightDir_Flags: vec4f = sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_DIRECTION_FLAGS});
+    let lightDir_Flags: vec4f = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_DIRECTION_FLAGS});
 
     // spot light direction
     clusterLightData.direction = lightDir_Flags.xyz;
 
-    // 32bit flags
-    let flags_uint: u32 = bitcast<u32>(lightDir_Flags.w);
-    clusterLightData.flags = flags_uint;
-    clusterLightData.isSpot = (flags_uint & (1u << 30u)) != 0u;
-    clusterLightData.shape = (flags_uint >> 28u) & 0x3u;
-    clusterLightData.falloffModeLinear = (flags_uint & (1u << 27u)) == 0u;
-    clusterLightData.shadowIntensity = f32((flags_uint >> 0u) & 0xFFu) / 255.0;
-    clusterLightData.cookieIntensity = f32((flags_uint >> 8u) & 0xFFu) / 255.0;
-    clusterLightData.isDynamic = (flags_uint & (1u << 22u)) != 0u;
-    clusterLightData.isLightmapped = (flags_uint & (1u << 21u)) != 0u;
+    // 32bit flags (kept outside the struct, see #7800)
+    clusterLightData_flags = bitcast<u32>(lightDir_Flags.w);
+    clusterLightData.isSpot = (clusterLightData_flags & (1u << 30u)) != 0u;
+    clusterLightData.shape = (clusterLightData_flags >> 28u) & 0x3u;
+    clusterLightData.falloffModeLinear = (clusterLightData_flags & (1u << 27u)) == 0u;
+    clusterLightData.shadowIntensity = f32((clusterLightData_flags >> 0u) & 0xFFu) / 255.0;
+    clusterLightData.cookieIntensity = f32((clusterLightData_flags >> 8u) & 0xFFu) / 255.0;
+    clusterLightData.isDynamic = (clusterLightData_flags & (1u << 22u)) != 0u;
+    clusterLightData.isLightmapped = (clusterLightData_flags & (1u << 21u)) != 0u;
 
     return clusterLightData;
 }
 
-fn decodeClusterLightSpot(clusterLightData: ClusterLightData) -> ClusterLightSpotData {
+fn decodeClusterLightSpot() -> ClusterLightSpotData {
     // decompress spot light angles
-    let angleFlags: u32 = (clusterLightData.colorBFlagsData >> 16u) & 0xFFFFu;  // Extract upper 16 bits as integer
+    let angleFlags: u32 = (clusterLightData_colorBFlagsData >> 16u) & 0xFFFFu;  // Extract upper 16 bits as integer
 
-    let angleValues: vec2f = unpack2x16float(bitcast<u32>(clusterLightData.anglesData));
+    let angleValues: vec2f = unpack2x16float(bitcast<u32>(clusterLightData_anglesData));
     let innerVal: f32 = angleValues.x;
     let outerVal: f32 = angleValues.y;
 
@@ -182,36 +182,36 @@ fn decodeClusterLightSpot(clusterLightData: ClusterLightData) -> ClusterLightSpo
     );
 }
 
-fn decodeClusterLightOmniAtlasViewport(clusterLightData: ClusterLightData) -> vec3f {
-    return sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_0}).xyz;
+fn decodeClusterLightOmniAtlasViewport(lightIndex: i32) -> vec3f {
+    return sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_0}).xyz;
 }
 
-fn decodeClusterLightAreaData(clusterLightData: ClusterLightData) -> ClusterLightAreaData {
+fn decodeClusterLightAreaData(lightIndex: i32) -> ClusterLightAreaData {
     return ClusterLightAreaData(
-        sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_AREA_DATA_WIDTH}).xyz,
-        sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_AREA_DATA_HEIGHT}).xyz
+        sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_AREA_DATA_WIDTH}).xyz,
+        sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_AREA_DATA_HEIGHT}).xyz
     );
 }
 
-fn decodeClusterLightProjectionMatrixData(clusterLightData: ClusterLightData) {
+fn decodeClusterLightProjectionMatrixData(lightIndex: i32) -> mat4x4f {
     // shadow matrix
-    let m0: vec4f = sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_0});
-    let m1: vec4f = sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_1});
-    let m2: vec4f = sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_2});
-    let m3: vec4f = sampleLightTextureF(clusterLightData.lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_3});
-    lightProjectionMatrix = mat4x4f(m0, m1, m2, m3);
+    let m0: vec4f = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_0});
+    let m1: vec4f = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_1});
+    let m2: vec4f = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_2});
+    let m3: vec4f = sampleLightTextureF(lightIndex, {CLUSTER_TEXTURE_PROJ_MAT_3});
+    return mat4x4f(m0, m1, m2, m3);
 }
 
-fn decodeClusterLightShadowData(clusterLightData: ClusterLightData) -> ClusterLightShadowData {
+fn decodeClusterLightShadowData(biasesData: f32) -> ClusterLightShadowData {
     // shadow biases
-    let biases: vec2f = unpack2x16float(bitcast<u32>(clusterLightData.biasesData));
+    let biases: vec2f = unpack2x16float(bitcast<u32>(biasesData));
     return ClusterLightShadowData(biases.x, biases.y);
 }
 
-fn decodeClusterLightCookieData(clusterLightData: ClusterLightData) -> vec4f {
+fn decodeClusterLightCookieData() -> vec4f {
 
     // extract channel mask from flags
-    let cookieFlags: u32 = (clusterLightData.flags >> 23u) & 0x0Fu;  // 4bits, each bit enables a channel
+    let cookieFlags: u32 = (clusterLightData_flags >> 23u) & 0x0Fu;  // 4bits, each bit enables a channel
     let mask_uvec: vec4<u32> = vec4<u32>(cookieFlags) & vec4<u32>(1u, 2u, 4u, 8u);
     return step(vec4f(1.0), vec4f(mask_uvec)); // Normalize to 0.0 or 1.0
 }
@@ -251,7 +251,7 @@ fn evaluateLight(
     if (light.shape != {LIGHTSHAPE_PUNCTUAL}) { // area light
 
         // area lights
-        let areaData: ClusterLightAreaData = decodeClusterLightAreaData(light);
+        let areaData: ClusterLightAreaData = decodeClusterLightAreaData(light.lightIndex);
 
         // handle light shape
         if (light.shape == {LIGHTSHAPE_RECT}) {
@@ -302,7 +302,7 @@ fn evaluateLight(
 
         // spot light falloff
         if (light.isSpot) {
-            let spotData: ClusterLightSpotData = decodeClusterLightSpot(light);
+            let spotData: ClusterLightSpotData = decodeClusterLightSpot();
             falloffAttenuation = falloffAttenuation * getSpotEffect(light.direction, spotData.innerConeAngleCos, spotData.outerConeAngleCos, lightDirNormW);
         }
 
@@ -317,9 +317,9 @@ fn evaluateLight(
 
                 // shared shadow / cookie data depends on light type
                 if (light.isSpot) {
-                    decodeClusterLightProjectionMatrixData(light);
+                    lightProjectionMatrix = decodeClusterLightProjectionMatrixData(light.lightIndex);
                 } else {
-                    omniAtlasViewport = decodeClusterLightOmniAtlasViewport(light);
+                    omniAtlasViewport = decodeClusterLightOmniAtlasViewport(light.lightIndex);
                 }
 
                 let shadowTextureResolution: f32 = uniform.shadowAtlasParams.x;
@@ -329,13 +329,11 @@ fn evaluateLight(
 
                 // cookie
                 if (light.cookieIntensity > 0.0) {
-                    let cookieChannelMask: vec4f = decodeClusterLightCookieData(light);
+                    let cookieChannelMask: vec4f = decodeClusterLightCookieData();
 
                     if (light.isSpot) {
-                        // !!!!!!!!!!! TEXTURE_PASS likely needs sampler. Assuming cookieAtlasTextureSampler exists.
                         cookieAttenuation = getCookie2DClustered(cookieAtlasTexture, cookieAtlasTextureSampler, lightProjectionMatrix, vPositionW, light.cookieIntensity, cookieChannelMask);
                     } else {
-                        // !!!!!!!!!!! TEXTURE_PASS likely needs sampler. Assuming cookieAtlasTextureSampler exists.
                         cookieAttenuation = getCookieCubeClustered(cookieAtlasTexture, cookieAtlasTextureSampler, lightDirW, light.cookieIntensity, cookieChannelMask, shadowTextureResolution, shadowEdgePixels, omniAtlasViewport);
                     }
                 }
@@ -346,7 +344,7 @@ fn evaluateLight(
 
                 // shadow
                 if (light.shadowIntensity > 0.0) {
-                    let shadowData: ClusterLightShadowData = decodeClusterLightShadowData(light);
+                    let shadowData: ClusterLightShadowData = decodeClusterLightShadowData(light.biasesData);
 
                     let shadowParams: vec4f = vec4f(shadowTextureResolution, shadowData.shadowNormalBias, shadowData.shadowBias, 1.0 / light.range);
 
@@ -355,8 +353,6 @@ fn evaluateLight(
                         // spot shadow
                         let shadowCoord: vec3f = getShadowCoordPerspZbufferNormalOffset(lightProjectionMatrix, shadowParams, geometricNormal);
 
-                        // !!!!!!!!!!! SHADOWMAP_PASS needs texture and sampler_comparison.
-                        // !!!!!!!!!!! Shadow functions need update for WGSL textureSampleCompare etc. Assuming these are handled in includes.
                         #if defined(CLUSTER_SHADOW_TYPE_PCF1)
                             let shadow: f32 = getShadowSpotClusteredPCF1(shadowAtlasTexture, shadowAtlasTextureSampler, shadowCoord, shadowParams);
                         #elif defined(CLUSTER_SHADOW_TYPE_PCF3)
@@ -373,8 +369,6 @@ fn evaluateLight(
                         // omni shadow
                         let dir: vec3f = normalOffsetPointShadow(shadowParams, light.position, lightDirW, lightDirNormW, geometricNormal);  // normalBias adjusted for distance
 
-                        // !!!!!!!!!!! SHADOWMAP_PASS needs texture and sampler_comparison.
-                        // !!!!!!!!!!! Shadow functions need update for WGSL textureSampleCompare etc. Assuming these are handled in includes.
                         #if defined(CLUSTER_SHADOW_TYPE_PCF1)
                             let shadow: f32 = getShadowOmniClusteredPCF1(shadowAtlasTexture, shadowAtlasTextureSampler, shadowParams, omniAtlasViewport, shadowEdgePixels, dir);
                         #elif defined(CLUSTER_SHADOW_TYPE_PCF3)


### PR DESCRIPTION
Follow-up to #8733. Brings the GLSL clustered-light chunk in line with the WGSL refactor, applies the Samsung-precision workaround to WGSL that was previously only in GLSL, and tightens decoder helper signatures.

**WGSL changes** (\`src/scene/shader-lib/wgsl/chunks/lit/frag/clusteredLight.js\`):
- \`ClusterLightData\` slimmed: removed \`flags\`, \`anglesData\`, \`colorBFlagsData\` from the struct; hoisted them to module-scope temporaries with the same comment that GLSL carries (Samsung precision / corruption issue, #7800).
- \`ClusterLightData\` members reordered so each \`vec3f\` packs with an adjacent 4-byte field into a 16-byte slot (minimises padding for compilers that don't reorder).
- \`decodeClusterLightProjectionMatrixData\` now returns \`mat4x4f\` instead of mutating the module-level \`lightProjectionMatrix\` via side effect; call site assigns the result.
- Remaining \`decode*\` helpers tightened to take only what they need (\`lightIndex: i32\` or \`biasesData: f32\`), or no args at all where they read from module-scope temps.
- One-line comments added to \`ClusterLightSpotData\` / \`ClusterLightAreaData\` / \`ClusterLightShadowData\` explaining when each is decoded.
- Removed four stale \`// !!!!!!!!!!!\` dev-comment leftovers from the original WGSL port. The code they annotated was already correct.

**GLSL changes** (\`src/scene/shader-lib/glsl/chunks/lit/frag/clusteredLight.js\`):
- Same \`ClusterLightData\` slim-down (removed \`halfWidth\`, \`halfHeight\`, \`omniAtlasViewport\`, \`cookieChannelMask\`, \`shadowBias\`, \`shadowNormalBias\`, \`innerConeAngleCos\`, \`outerConeAngleCos\` — now in sub-structs decoded on demand).
- Same \`ClusterLightData\` member reorder for minimal padding.
- Same three new sub-structs (\`ClusterLightSpotData\`, \`ClusterLightAreaData\`, \`ClusterLightShadowData\`) with matching one-line comments.
- All \`decode*\` helpers changed from \`inout\`-mutating to value-returning, taking \`int lightIndex\` / \`float biasesData\` / no-args as appropriate.
- \`decodeClusterLightCore\` returns \`ClusterLightData\` by value; call site is now \`ClusterLightData clusterLightData = decodeClusterLightCore(lightIndex);\`.
- \`sampleLightTextureF(int lightIndex, int index)\` — drops the struct parameter for symmetry with WGSL.

**No public API changes.** All changes are internal to the lit clustered-light shader chunks. The two backends now have near line-for-line equivalent structures, which makes cross-backend maintenance easier going forward.