### PR TITLE
refactor: omit default texCoord in glTF exporter texture info

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -349,15 +349,19 @@ class GltfExporter extends CoreExporter {
 
     attachTexture(resources, material, destination, name, textureSemantic, json) {
         const texture = material[textureSemantic];
-        const textureTexCoord = material[`${textureSemantic}Uv`] ?? 0;
 
         if (texture) {
             const textureIndex = resources.textures.indexOf(texture);
             if (textureIndex < 0) console.warn(`Texture ${texture.name} wasn't collected.`);
             destination[name] = {
-                index: textureIndex,
-                texCoord: textureTexCoord
+                index: textureIndex
             };
+
+            // glTF defaults texCoord to 0, so only emit it when a non-default UV set is used
+            const textureTexCoord = material[`${textureSemantic}Uv`] ?? 0;
+            if (textureTexCoord !== 0) {
+                destination[name].texCoord = textureTexCoord;
+            }
 
             const scale = material[`${textureSemantic}Tiling`];
             const offset = material[`${textureSemantic}Offset`];


### PR DESCRIPTION
Follow-up cleanup for #8728. `GltfExporter.attachTexture` now omits the `texCoord` field on texture info objects when the material uses the default UV0 channel.

**Changes:**
- Only write `texCoord` when `material[\`${semantic}Uv\`]` is non-zero.
- Matches the rest of the exporter's "omit defaults" convention (e.g. `metallicFactor`, `roughnessFactor`, `KHR_texture_transform.scale/offset/rotation`).
- The glTF 2.0 spec defines the default for `texCoord` as `0`, so the exported asset is functionally identical for any conformant loader — just slightly smaller JSON in the common UV0-only case.

No public API changes.