### PR TITLE
fix: include error message context in load failure logs

### DIFF
--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -663,7 +663,7 @@ class AssetRegistry extends EventHandler {
         }
 
         const onTextureLoaded = (err, texture) => {
-            if (err) console.error(err);
+            if (err) console.error(`Failed to load material texture for "${materialAsset.name}": ${err?.message ?? err}`, err);
             textures.push(texture);
             if (textures.length === count) {
                 callback(null, textures);

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -259,7 +259,9 @@ class ResourceLoader {
     }
 
     _onFailure(key, err) {
-        console.error(err);
+        // include a string-form message so external error reporters (which often JSON.stringify the
+        // arguments) get useful context, while keeping the original Error available for dev tools
+        console.error(`Failed to load resource [${key}]: ${err?.message ?? err}`, err);
         if (this._requests[key]) {
             for (let i = 0; i < this._requests[key].length; i++) {
                 this._requests[key][i](err);

--- a/src/framework/i18n/i18n.js
+++ b/src/framework/i18n/i18n.js
@@ -313,7 +313,7 @@ class I18n extends EventHandler {
         try {
             parsed = this._parser.parse(data);
         } catch (err) {
-            console.error(err);
+            console.error(`I18n.addData: failed to parse localization data: ${err?.message ?? err}`, err);
             return;
         }
 
@@ -349,7 +349,7 @@ class I18n extends EventHandler {
         try {
             parsed = this._parser.parse(data);
         } catch (err) {
-            console.error(err);
+            console.error(`I18n.removeData: failed to parse localization data: ${err?.message ?? err}`, err);
             return;
         }
 


### PR DESCRIPTION
External error reporters (e.g. Poki) typically capture `console.error` arguments via `JSON.stringify`. `Error` objects have non-enumerable `message`/`stack` properties, so passing a raw `Error` as the only argument serializes to `{}`, producing dashboard entries like `console.error: [{}]` with no actionable context.

This patches the three engine call sites that logged raw errors to also include a string-form summary, while still passing the original `Error` as a secondary argument so it remains expandable in dev tools.

**Changes:**
- `ResourceLoader._onFailure`: log the resource key plus `err.message`
- `I18n.addData` / `I18n.removeData`: log the method name plus `err.message`
- `AssetRegistry._loadTextures` (material texture loader): log the material asset name plus `err.message`

**API Changes:**
- None. Only the message format passed to `console.error` changed.