### PR TITLE
feat: enable asset load retries by default

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -627,6 +627,10 @@ class AppBase extends EventHandler {
             this.loader.addHandler(handler.handlerType, handler);
         });
 
+        // default to retrying failed asset loads to make apps more resilient to transient network
+        // errors
+        this.loader.enableRetry(5);
+
         // Create and register all required component systems
         componentSystems.forEach((componentSystem) => {
             this.systems.add(new componentSystem(this));
@@ -796,7 +800,7 @@ class AppBase extends EventHandler {
 
     // set application properties from data file
     _parseApplicationProperties(props, callback) {
-        // configure retrying assets
+        // configure retrying assets - overrides the default set in the constructor
         if (typeof props.maxAssetRetries === 'number' && props.maxAssetRetries > 0) {
             this.loader.enableRetry(props.maxAssetRetries);
         }

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -333,11 +333,11 @@ class ResourceLoader {
     }
 
     /**
-     * Enables retrying of failed requests when loading assets.
+     * Enables retrying of failed requests when loading assets. Retries use exponential backoff and
+     * are also enabled by default for new applications.
      *
-     * @param {number} maxRetries - The maximum number of times to retry loading an asset. Defaults
-     * to 5.
-     * @ignore
+     * @param {number} [maxRetries] - The maximum number of times to retry loading an asset.
+     * Defaults to 5.
      */
     enableRetry(maxRetries = 5) {
         maxRetries = Math.max(0, maxRetries) || 0;
@@ -349,8 +349,6 @@ class ResourceLoader {
 
     /**
      * Disables retrying of failed requests when loading assets.
-     *
-     * @ignore
      */
     disableRetry() {
         for (const key in this._handlers) {


### PR DESCRIPTION
Previously the engine only retried failed asset loads when the integrator explicitly opted in via the `maxAssetRetries` application property. Any transient network glitch (slow CDN, mobile connectivity hiccup, server flap) would immediately surface as a permanent load failure.

**Changes:**
- `AppBase` now calls `this.loader.enableRetry(5)` immediately after the built-in resource handlers are registered, so every application gets 5 retries with exponential backoff out of the box.
- The `maxAssetRetries` application property continues to override the default when set to a positive number (Editor-driven scenes are unaffected).
- Promotes `ResourceLoader.enableRetry()` / `ResourceLoader.disableRetry()` to public API by removing their `@ignore` JSDoc tags, giving engine-only users a clean way to configure retries without going through the scene-settings path. The `maxRetries` parameter on `enableRetry` is also marked optional in the JSDoc.

**Behaviour change:**
- Apps that previously relied on the implicit "fail on first network error" default will now retry up to 5 times with exponential backoff (200ms, 400ms, 800ms, 1600ms, 3200ms, capped at 5000ms).
- To opt out, call `app.loader.disableRetry()` after constructing the application, or pass a positive override via the `maxAssetRetries` application property and a custom value.

**API Changes:**
- `ResourceLoader.enableRetry(maxRetries?: number): void` is now public (was `@ignore`).
- `ResourceLoader.disableRetry(): void` is now public (was `@ignore`).

Example usage for engine-only projects:

```js
const app = new pc.Application(canvas, { /* ... */ });

// optional - change from the default of 5
app.loader.enableRetry(3);

// or turn retries off entirely
app.loader.disableRetry();
```