### PR TITLE
refactor: tidy ResourceLoader.enableRetry defaults and input handling

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -629,7 +629,7 @@ class AppBase extends EventHandler {
 
         // default to retrying failed asset loads to make apps more resilient to transient network
         // errors
-        this.loader.enableRetry(5);
+        this.loader.enableRetry();
 
         // Create and register all required component systems
         componentSystems.forEach((componentSystem) => {

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -342,7 +342,7 @@ class ResourceLoader {
      * Defaults to 5.
      */
     enableRetry(maxRetries = 5) {
-        maxRetries = Math.max(0, maxRetries) || 0;
+        maxRetries = Math.max(0, Math.floor(maxRetries)) || 0;
 
         for (const key in this._handlers) {
             this._handlers[key].maxRetries = maxRetries;


### PR DESCRIPTION
Small follow-up to #8744 addressing review comments on `ResourceLoader.enableRetry`.

**Changes:**
- `AppBase` now calls `this.loader.enableRetry()` without arguments, so the default retry count (5) lives in a single place — the `ResourceLoader.enableRetry` signature — instead of being duplicated in `AppBase`.
- `ResourceLoader.enableRetry` now floors `maxRetries` before clamping, so non-integer inputs produce a predictable number of attempts (the underlying `Http` retry counter compares against an integer).