### PR TITLE
fix(examples): allow trycloudflare.com in Vite allowedHosts

### DIFF
--- a/examples/vite.config.mjs
+++ b/examples/vite.config.mjs
@@ -33,7 +33,7 @@ export default defineConfig({
         hmr: AUTO_RELOAD ? undefined : false,
         host: HOST,
         port: PORT,
-        // cloudflared quick tunnels (AVP / headset testing over HTTPS)
+        // cloudflared quick tunnels (device testing over HTTPS)
         allowedHosts: ['.trycloudflare.com'],
         fs: {
             allow: [

--- a/examples/vite.config.mjs
+++ b/examples/vite.config.mjs
@@ -33,6 +33,8 @@ export default defineConfig({
         hmr: AUTO_RELOAD ? undefined : false,
         host: HOST,
         port: PORT,
+        // cloudflared quick tunnels (AVP / headset testing over HTTPS)
+        allowedHosts: ['.trycloudflare.com'],
         fs: {
             allow: [
                 process.cwd(),
@@ -47,7 +49,8 @@ export default defineConfig({
     },
     preview: {
         host: HOST,
-        port: PORT
+        port: PORT,
+        allowedHosts: ['.trycloudflare.com']
     },
     define: {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? 'development'),


### PR DESCRIPTION
Allow the examples Vite dev and preview servers to accept requests when accessed through a Cloudflare quick tunnel (`*.trycloudflare.com`).

**Changes:**
- Set `server.allowedHosts` and `preview.allowedHosts` to `['.trycloudflare.com']` in `examples/vite.config.mjs`

Without this, Vite 6 returns 403 on assets such as `/@vite/client` when the browser sends the tunnel hostname in the `Host` header (common for HTTPS headset / AVP testing via `cloudflared`).

## Test plan
- [ ] `npm run dev` in `examples/`, tunnel with `cloudflared tunnel --url http://localhost:5555`, open tunnel URL — examples shell loads without 403 on Vite assets
- [ ] `npm run build && npm run serve`, same tunnel — preview works on tunnel URL
- [ ] Local `http://localhost:5555` still works unchanged