### PR TITLE
feat: warn when WebGPU or WebXR is used in an insecure context

### DIFF
--- a/src/core/secure-context-warning.js
+++ b/src/core/secure-context-warning.js
@@ -1,16 +1,18 @@
 import { Debug } from './debug.js';
 
 /**
- * Warn once if the current page is not a secure context. Browsers treat
- * localhost / 127.0.0.1 / ::1 as secure even over http, so this only fires
- * on LAN/IP origins served over plain http.
+ * Warn once if the current page is not a secure context. Fires on any
+ * insecure origin; browsers treat localhost / 127.0.0.1 / ::1 as secure
+ * even over http, so those won't trigger it. No-ops outside the browser
+ * and when `window.isSecureContext` is not explicitly `false` (older or
+ * embedded runtimes may leave it undefined).
  *
  * @param {string} feature - Feature name (e.g. 'WebGPU', 'WebXR').
  * @ignore
  */
 const warnInsecureContext = (feature) => {
     if (typeof window === 'undefined') return;
-    if (window.isSecureContext) return;
+    if (window.isSecureContext !== false) return;
     Debug.warnOnce(
         `${feature} requires a secure context (HTTPS or localhost). ` +
         `The page is served over an insecure origin; ${feature} will be unavailable.`

--- a/src/core/secure-context-warning.js
+++ b/src/core/secure-context-warning.js
@@ -1,0 +1,20 @@
+import { Debug } from './debug.js';
+
+/**
+ * Warn once if the current page is not a secure context. Browsers treat
+ * localhost / 127.0.0.1 / ::1 as secure even over http, so this only fires
+ * on LAN/IP origins served over plain http.
+ *
+ * @param {string} feature - Feature name (e.g. 'WebGPU', 'WebXR').
+ * @ignore
+ */
+const warnInsecureContext = (feature) => {
+    if (typeof window === 'undefined') return;
+    if (window.isSecureContext) return;
+    Debug.warnOnce(
+        `${feature} requires a secure context (HTTPS or localhost). ` +
+        `The page is served over an insecure origin; ${feature} will be unavailable.`
+    );
+};
+
+export { warnInsecureContext };

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -1,6 +1,7 @@
 import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
 import { platform } from '../../core/platform.js';
+import { warnInsecureContext } from '../../core/secure-context-warning.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { Quat } from '../../core/math/quat.js';
 import { Vec2 } from '../../core/math/vec2.js';
@@ -418,6 +419,7 @@ class XrManager extends EventHandler {
         }
 
         if (!this._available[type]) {
+            warnInsecureContext('WebXR');
             if (callback) callback(new Error('XR is not available'));
             return;
         }

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1,5 +1,6 @@
 import { TRACEID_RENDER_QUEUE } from '../../../core/constants.js';
 import { Debug, DebugHelper } from '../../../core/debug.js';
+import { warnInsecureContext } from '../../../core/secure-context-warning.js';
 import {
     PIXELFORMAT_RGBA8, PIXELFORMAT_BGRA8, DEVICETYPE_WEBGPU,
     BUFFERUSAGE_READ, BUFFERUSAGE_COPY_DST, semanticToLocation,
@@ -330,6 +331,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     async initWebGpu(glslangUrl, twgslUrl) {
 
         if (!window.navigator.gpu) {
+            warnInsecureContext('WebGPU');
             throw new Error('Unable to retrieve GPU. Ensure you are using a browser that supports WebGPU rendering.');
         }
 


### PR DESCRIPTION
## Summary
- Adds `src/core/secure-context-warning.js`, a small browser-only helper that calls `Debug.warnOnce` when `window.isSecureContext` is `false`.
- Wires it into `WebgpuGraphicsDevice.initWebGpu()` and `XrManager.start()` so the warning only fires when WebGPU or WebXR is actually attempted — not on every engine init.
- Browsers treat `localhost` / `127.0.0.1` / `::1` as secure contexts, so the warning is silent during normal local development. It surfaces on LAN/IP origins served over plain `http`, which is the case where `navigator.gpu` / `navigator.xr` are missing and the failure is otherwise mysterious.
- No-ops in Node (typeof window guard), so server-side / test usage stays silent.
