### PR TITLE
fix: resolve sog texture urls from document base

### DIFF
--- a/src/framework/parsers/sog.js
+++ b/src/framework/parsers/sog.js
@@ -134,12 +134,13 @@ class SogParser {
 
         const textures = {};
         const promises = [];
+        const base = window.document?.baseURI ?? window.location.href;
 
         subs.forEach((sub) => {
             const files = meta[sub]?.files ?? [];
             textures[sub] = files.map((filename) => {
                 const texture = new Asset(filename, 'texture', {
-                    url: asset.options?.mapUrl?.(filename) ?? (new URL(filename, new URL(url.load, window.location.href).toString())).toString(),
+                    url: asset.options?.mapUrl?.(filename) ?? (new URL(filename, new URL(url.load, base).toString())).toString(),
                     filename
                 }, {
                     mipmaps: false

--- a/test/framework/parsers/sog.test.mjs
+++ b/test/framework/parsers/sog.test.mjs
@@ -1,0 +1,89 @@
+import { expect } from 'chai';
+import { restore, stub } from 'sinon';
+
+import { Asset } from '../../../src/framework/asset/asset.js';
+import { SogParser } from '../../../src/framework/parsers/sog.js';
+import { http } from '../../../src/platform/net/http.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+const BASE_URL = 'http://localhost:3000/static/';
+const META_URL = 'assets/splats/meta.json';
+const META = {
+    version: 2,
+    count: 1,
+    means: {
+        files: ['means_l.webp', 'means_u.webp']
+    },
+    quats: {
+        files: ['quats.webp']
+    },
+    scales: {
+        files: ['scales.webp']
+    },
+    sh0: {
+        files: ['sh0.webp']
+    }
+};
+
+describe('SogParser', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+
+        const base = document.createElement('base');
+        base.href = BASE_URL;
+        document.head.appendChild(base);
+
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+
+        jsdomTeardown();
+        restore();
+    });
+
+    it('resolves texture urls from the document base uri', function (done) {
+        const parser = new SogParser(app, 0);
+        const sog = new Asset('sog', 'gsplat', {
+            url: META_URL
+        });
+        const urls = [];
+        let removed = false;
+
+        app.assets.add(sog);
+
+        stub(http, 'get').callsFake((url, options, callback) => {
+            expect(url).to.equal(META_URL);
+            callback(null, META);
+        });
+
+        stub(app.assets, 'load').callsFake((texture) => {
+            urls.push(texture.file.url);
+
+            if (!removed) {
+                removed = true;
+                app.assets.remove(sog);
+            }
+
+            texture.fire('load', texture);
+        });
+
+        parser.load(META_URL, (err, resource) => {
+            expect(err).to.equal(null);
+            expect(resource).to.equal(null);
+            expect(urls).to.deep.equal([
+                'http://localhost:3000/static/assets/splats/means_l.webp',
+                'http://localhost:3000/static/assets/splats/means_u.webp',
+                'http://localhost:3000/static/assets/splats/quats.webp',
+                'http://localhost:3000/static/assets/splats/scales.webp',
+                'http://localhost:3000/static/assets/splats/sh0.webp'
+            ]);
+            done();
+        }, sog);
+    });
+});


### PR DESCRIPTION
## Description
Resolve unpacked SOG child texture URL generation relative to document.baseURI when no asset.options.mapUrl override is provided.

meta.json requests can honor a page <base> tag, but SogParser previously resolved sibling .webp files against window.location.href. The scope is limited to unpacked SOG fallback texture URL resolution; absolute URLs and asset.options.mapUrl behavior are unchanged.

## Manual testing
Manual tests: not run. Browser validation recommended:
- Load targeted unpacked SOG examples.
- Confirm .webp requests resolve from /static/assets/splats/... when the page uses <base href="http://localhost:3000/static/">.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change