### PR TITLE
fix(webgpu): WebGPU XR rendering on Apple Vision Pro

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -613,6 +613,11 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // assign the format, allowing following init call to use it to allocate matching multisampled buffer
         wrt.setColorAttachment(0, undefined, attachmentViewFormat);
 
+        // Track the backbuffer's dimensions to whatever texture we're rendering into
+        // this frame (canvas swapchain in normal use, XR projection-layer texture during XR).
+        rt._width = outColorBuffer.width;
+        rt._height = outColorBuffer.height;
+
         this.initRenderTarget(rt);
 
         // assign current frame's render texture
@@ -1277,6 +1282,13 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // TODO: this condition should be removed, it's here to handle fake grab pass, which should be refactored instead
         if (this.passEncoder) {
 
+            // When the backbuffer is bound to an XR projection-layer texture, do NOT call
+            // passEncoder.setViewport to avoid issues on Apple's visionOS. This should be ok in
+            // general, as we're not likely to do a multi-view rendering when XR is active.
+            if (this.xrColorTexture) {
+                return;
+            }
+
             if (!this.renderTarget.flipY) {
                 y = this.renderTarget.height - y - h;
             }
@@ -1295,6 +1307,13 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // so we can skip this if fullscreen
         // TODO: this condition should be removed, it's here to handle fake grab pass, which should be refactored instead
         if (this.passEncoder) {
+
+            // When the backbuffer is bound to an XR projection-layer texture, do NOT call
+            // passEncoder.setScissorRect to avoid issues on Apple's visionOS. This should be ok in
+            // general, as we're not likely to do a multi-view rendering when XR is active.
+            if (this.xrColorTexture) {
+                return;
+            }
 
             if (!this.renderTarget.flipY) {
                 y = this.renderTarget.height - y - h;

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -198,11 +198,13 @@ class WebgpuRenderTarget {
 
         const wgpuDevice = /** @type {WebgpuGraphicsDevice} */ (this.renderTarget.device);
         const xrViewDesc = wgpuDevice?.xrColorTextureViewDescriptor;
-        // WebXR may supply a per-eye view descriptor (e.g. array layer); merge in our view format
-        // for sRGB / reinterpret when it matches the session color texture.
         const xrSlice = xrViewDesc && gpuTexture === wgpuDevice.xrColorTexture;
+        // When the WebXR runtime supplies a per-eye view descriptor, pass it through as-is.
+        // The descriptor already carries the runtime's intended `format` (e.g. an sRGB view
+        // format over a linear texture) along with the per-eye slice selection — merging an
+        // override on top would discard the runtime's chosen format.
         const view = gpuTexture.createView(
-            xrSlice ? { ...xrViewDesc, format: viewFormat } : { format: viewFormat }
+            xrSlice ? xrViewDesc : { format: viewFormat }
         );
         DebugHelper.setLabel(view, xrSlice ? 'Framebuffer.xrColorTextureView' : 'Framebuffer.contextColorTextureView');
 

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -97,11 +97,15 @@ class WebgpuXrBridge {
                 }
             }
 
+            // Prefer the view descriptor's format when present: WebXR runtimes may use it to
+            // declare a per-eye view-format (e.g. bgra8unorm-srgb over a bgra8unorm texture) so
+            // shader writes are gamma-encoded for the compositor. Falling back to the texture's
+            // own format would silently drop that reinterpretation.
             subImages.push({
                 colorTexture,
                 viewDescriptor,
                 viewport: sub.viewport,
-                viewFormat: colorTexture.format
+                viewFormat: viewDescriptor?.format ?? colorTexture.format
             });
         }
 


### PR DESCRIPTION
## Summary

Related to #8755.

WebGPU+WebXR was rendering only into a sub-rectangle of each eye on Apple Vision Pro. Root cause is a visionOS Safari quirk where any explicit `passEncoder.setScissorRect(...)` call (even one equal to the WebGPU pass-start default = full attachment) is interpreted as a positional hint for the eye-display sub-region, clipping the content. Upstream WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=315274.

### Changes

- **`WebgpuGraphicsDevice#setViewport` / `#setScissor`** — early-return without calling the underlying `passEncoder` methods when `this.xrColorTexture` is set. The default viewport/scissor (= attachment extent) is what AVP needs to map the projection-layer texture across the full eye. Shadow state is deliberately not updated either, so non-XR cache checks aren't poisoned.
- **`frameStart`** — track the backbuffer's intrinsic `_width` / `_height` to whatever texture we're rendering into this frame (canvas swapchain or XR projection layer), instead of falling back to `device.width` via the getter.
- **`WebgpuRenderTarget#assignColorTexture`** — pass the WebXR runtime's per-eye view descriptor through to `createView` as-is, preserving its `format` (e.g. sRGB view over a linear texture) instead of clobbering with a separate format override.
- **`WebgpuXrBridge#beginFrame`** — prefer `viewDescriptor.format` for the per-view `viewFormat` so the render pipeline format matches what the view will see.
