### PR TITLE
feat(webgpu): log uncaptured WebGPU errors

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -452,6 +452,12 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // handle lost device
         this.wgpu.lost?.then(this.handleDeviceLost.bind(this));
 
+        // surface any uncaptured WebGPU errors
+        this.wgpu.addEventListener?.('uncapturederror', (ev) => {
+            const e = /** @type {any} */ (ev).error;
+            Debug.error(`WebGPU uncaptured ${e?.constructor?.name ?? 'Error'}: ${e?.message ?? e}`);
+        });
+
         this.initDeviceCaps();
 
         this.gpuContext = this.canvas.getContext('webgpu');


### PR DESCRIPTION
Surface uncaptured WebGPU errors (validation, out-of-memory, internal) via `Debug.error`. Without this, errors that escape error scopes are silently swallowed by the browser, producing symptoms that are hard to diagnose (e.g. "rendering looks fine but nothing is composited").

**Changes:**
- `WebgpuGraphicsDevice` registers an `uncapturederror` listener on the GPU device right after the `lost` handler, logging the error name and message.