### PR TITLE
fix(gsplat): release ImageBitmap memory after streamed SOG texture upload

### DIFF
--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -105,6 +105,9 @@ class Texture {
     /** @ignore */
     _gpuSize = 0;
 
+    /** @ignore */
+    releaseSourceAfterUpload = false;
+
     /** @protected */
     id = id++;
 
@@ -352,8 +355,54 @@ class Texture {
             // Update texture stats
             this.adjustVramSizeTracking(device._vram, -this._gpuSize);
 
+            // Free CPU-side decoded pixel data; the GPU has its own copy after upload.
+            this.releaseImageSources();
+
             this._levels = null;
             this.device = null;
+        }
+    }
+
+    /**
+     * Closes any ImageBitmaps held on `_levels` and nulls those entries. The GPU has its own
+     * copy after upload, so the decoded pixels in CPU memory can be released. Safe to call only
+     * when no subsequent re-upload from CPU source will be needed.
+     *
+     * @ignore
+     */
+    releaseImageSources() {
+        if (typeof ImageBitmap === 'undefined' || !this._levels) {
+            return;
+        }
+        for (let i = 0; i < this._levels.length; i++) {
+            const level = this._levels[i];
+            if (level instanceof ImageBitmap) {
+                level.close();
+                this._levels[i] = null;
+            } else if (Array.isArray(level)) {
+                for (let j = 0; j < level.length; j++) {
+                    if (level[j] instanceof ImageBitmap) {
+                        level[j].close();
+                        level[j] = null;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Marks this texture so its CPU-side ImageBitmap source is released after the next upload.
+     * The caller must guarantee that no re-upload from CPU source will be needed (e.g. the owner
+     * re-creates the texture on device loss). Used by the gsplat octree for streamed SOG textures.
+     *
+     * @ignore
+     */
+    setReleaseSourceAfterUpload() {
+        this.releaseSourceAfterUpload = true;
+
+        // If upload has already happened, release eagerly.
+        if (!this._needsUpload && !this._needsMipmapsUpload) {
+            this.releaseImageSources();
         }
     }
 

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -858,6 +858,10 @@ class WebglTexture {
         texture._gpuSize = texture.gpuSize;
         texture.adjustVramSizeTracking(device._vram, texture._gpuSize);
 
+        if (texture.releaseSourceAfterUpload) {
+            texture.releaseImageSources();
+        }
+
         this._glCreated = true;
     }
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -467,6 +467,10 @@ class WebgpuTexture {
 
             texture._gpuSize = texture.gpuSize;
             texture.adjustVramSizeTracking(device._vram, texture._gpuSize);
+
+            if (texture.releaseSourceAfterUpload) {
+                texture.releaseImageSources();
+            }
         }
     }
 

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -1016,6 +1016,10 @@ class GSplatOctreeInstance {
                 this.activePlacements.add(this.environmentPlacement);
                 this.dirtyModifiedPlacements = true;
                 this.dirtyPlacementSetChanged = true;
+
+                // Now that the placement exists, _onDeviceLost will tear down this resource,
+                // so its CPU-side ImageBitmap sources are no longer needed for re-upload.
+                envResource.releaseTextureSources?.();
             }
         }
 

--- a/src/scene/gsplat-unified/gsplat-octree.js
+++ b/src/scene/gsplat-unified/gsplat-octree.js
@@ -373,6 +373,10 @@ class GSplatOctree {
         if (res) {
             this.fileResources.set(fileIndex, res);
 
+            // The octree fully re-creates these resources on device loss, so the CPU-side
+            // ImageBitmap sources retained on the textures are not needed for re-upload.
+            res.releaseTextureSources?.();
+
             // if the file finished loading and is no longer needed, schedule a cooldown
             if (this.fileRefCounts[fileIndex] === 0) {
                 this.cooldowns.set(fileIndex, this.cooldownTicks);

--- a/src/scene/gsplat/gsplat-sog-resource.js
+++ b/src/scene/gsplat/gsplat-sog-resource.js
@@ -74,6 +74,24 @@ class GSplatSogResource extends GSplatResourceBase {
         this._populateParameters();
     }
 
+    /**
+     * Opts each of the owned source textures into releasing its CPU-side ImageBitmap after
+     * upload. Called by the gsplat octree, which re-creates these resources from scratch on
+     * device loss and therefore does not need the CPU source retained for re-upload.
+     *
+     * @ignore
+     */
+    releaseTextureSources() {
+        const d = /** @type {GSplatSogData} */ (this.gsplatData);
+        d.means_l?.setReleaseSourceAfterUpload();
+        d.means_u?.setReleaseSourceAfterUpload();
+        d.quats?.setReleaseSourceAfterUpload();
+        d.scales?.setReleaseSourceAfterUpload();
+        d.sh0?.setReleaseSourceAfterUpload();
+        d.sh_centroids?.setReleaseSourceAfterUpload();
+        d.sh_labels?.setReleaseSourceAfterUpload();
+    }
+
     /** @protected */
     _actualDestroy() {
         // Remove externally-owned textures without destroying them (they're owned by gsplatData)


### PR DESCRIPTION
SOG textures loaded via the gsplat octree retained their source ImageBitmap on `Texture._levels` for the texture's lifetime, holding fully-decoded pixel data long after the GPU had its own copy of the texture. ImageBitmap storage is implementation-defined (CPU, GPU, or shared memory depending on browser and platform), but in all cases it sits in memory until `close()` is called — wasteful for streamed gsplat scenes that load many SOG files over time.

**Changes:**
- Close any ImageBitmaps held on `_levels` when a Texture is destroyed
- Add an opt-in mechanism for textures whose owner re-creates them on device loss: the WebGL and WebGPU upload paths close the ImageBitmap source immediately after upload when opted in
- Gsplat SOG resources expose a helper that opts in all their source textures; the octree calls it when a file resource arrives, and the octree-instance calls it when the environment placement is created — both points where the octree's `_onDeviceLost` is guaranteed to dump the resource

**Memory:**
- Releases ImageBitmap storage once the GPU upload is complete, for octree-managed SOG textures
- The Texture.destroy() change is a generic improvement for all textures, not just gsplat
- No GPU rendering work changes