### PR TITLE
fix: overhaul examples mobile view

### DIFF
--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -68,7 +68,6 @@ class ExampleLoader {
                 console.warn('No canvas found.');
                 return;
             }
-            this.setMiniStats(true);
         }
 
         if (!this._started) {
@@ -91,6 +90,7 @@ class ExampleLoader {
             const reportedType = (isWebGPU(selectedDeviceType) && engineType === 'webgpu') ?
                 selectedDeviceType :
                 engineType;
+            window.top.activeGraphicsDevice = reportedType;
             fire('updateActiveDevice', { deviceType: reportedType });
         }
 
@@ -254,9 +254,10 @@ class ExampleLoader {
      */
     setMiniStats(enabled = false) {
         if (this._config.NO_MINISTATS) {
+            fire('miniStats', { state: false });
             return;
         }
-        MiniStats.enable(this._app, enabled);
+        fire('miniStats', { state: MiniStats.enable(this._app, enabled) });
     }
 
     hotReload() {

--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -2,6 +2,7 @@ import files from './files.mjs';
 import MiniStats from './ministats.mjs';
 import { fetchFile, importModule, clearImports, parseConfig, fire } from './runtime.mjs';
 import { data, deviceType as selectedDeviceType, refreshContext, updateDeviceType } from './state.mjs';
+import { blockZoom } from './zoom.mjs';
 
 /** @import { AppBase } from 'playcanvas' */
 
@@ -157,6 +158,8 @@ class ExampleLoader {
      * @param {{ engineUrl: string, fileNames: string[], config?: Record<string, any> }} options - Options to start the loader
      */
     async start({ engineUrl, fileNames, config = {} }) {
+        blockZoom();
+
         this._baseConfig = config;
         this._fileNames = fileNames;
 

--- a/examples/iframe/ministats.mjs
+++ b/examples/iframe/ministats.mjs
@@ -11,20 +11,21 @@ export default class MiniStats {
     /**
      * @param {AppBase} app - The app instance.
      * @param {any} state - The enabled state.
+     * @returns {boolean} The resolved MiniStats enabled state.
      */
     static enable(app, state) {
         if (params.miniStats === 'false') {
-            return;
+            return false;
         }
         if (typeof window.pc === 'undefined') {
-            return;
+            return false;
         }
         if (!app) {
-            return;
+            return false;
         }
         const deviceType = app?.graphicsDevice?.deviceType;
         if (deviceType === 'null') {
-            return;
+            return false;
         }
         if (state) {
             if (!MiniStats.instance) {
@@ -32,9 +33,10 @@ export default class MiniStats {
             }
         }
         if (!MiniStats.instance) {
-            return;
+            return false;
         }
         MiniStats.instance.enabled = state;
+        return MiniStats.instance.enabled;
     }
 
     static destroy() {

--- a/examples/iframe/zoom.mjs
+++ b/examples/iframe/zoom.mjs
@@ -1,0 +1,31 @@
+let blocked = false;
+
+const blockZoom = () => {
+    if (blocked || !matchMedia('(pointer: coarse)').matches) {
+        return;
+    }
+
+    blocked = true;
+    let last = 0;
+
+    document.addEventListener('touchmove', (event) => {
+        if (event.touches.length > 1) {
+            event.preventDefault();
+        }
+    }, { passive: false });
+
+    document.addEventListener('touchend', (event) => {
+        const now = Date.now();
+        if (now - last < 300) {
+            event.preventDefault();
+        }
+        last = now;
+    }, { passive: false });
+
+    document.addEventListener('dblclick', event => event.preventDefault(), { passive: false });
+    document.addEventListener('gesturestart', event => event.preventDefault(), { passive: false });
+    document.addEventListener('gesturechange', event => event.preventDefault(), { passive: false });
+    document.addEventListener('gestureend', event => event.preventDefault(), { passive: false });
+};
+
+export { blockZoom };

--- a/examples/src/app/components/DeviceSelector.mjs
+++ b/examples/src/app/components/DeviceSelector.mjs
@@ -26,6 +26,12 @@ const deviceTypeNames = {
 };
 
 /**
+ * @param {string | null | undefined} value - Device type value.
+ * @returns {string | undefined} The valid device type.
+ */
+const validDeviceType = value => (value && deviceTypeNames[value] ? value : undefined);
+
+/**
  * @typedef {object} Props
  * @property {Function} onSelect - On select handler.
  */
@@ -45,7 +51,7 @@ class DeviceSelector extends TypedComponent {
     state = {
         fallbackOrder: null,
         disabledOptions: null,
-        activeDevice: this.preferredGraphicsDevice
+        activeDevice: this.activeGraphicsDevice
     };
 
     /**
@@ -66,6 +72,10 @@ class DeviceSelector extends TypedComponent {
 
     componentDidMount() {
         window.addEventListener('updateActiveDevice', this._handleUpdateDevice);
+        const activeDevice = validDeviceType(window.activeGraphicsDevice);
+        if (activeDevice) {
+            this.onSetActiveGraphicsDevice(activeDevice);
+        }
     }
 
     componentWillUnmount() {
@@ -93,7 +103,16 @@ class DeviceSelector extends TypedComponent {
      * @returns {string | undefined} The preferred graphics device.
      */
     get preferredGraphicsDevice() {
-        return window.preferredGraphicsDevice;
+        return validDeviceType(window.preferredGraphicsDevice) ??
+            validDeviceType(localStorage.getItem('preferredGraphicsDevice')) ??
+            DEVICETYPE_WEBGL2;
+    }
+
+    /**
+     * @returns {string | undefined} The active graphics device.
+     */
+    get activeGraphicsDevice() {
+        return validDeviceType(window.activeGraphicsDevice) ?? this.preferredGraphicsDevice;
     }
 
     /**

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -106,6 +106,7 @@ class Example extends TypedComponent {
         this._handleExampleHotReload = this._handleExampleHotReload.bind(this);
         this._handleExampleError = this._handleExampleError.bind(this);
         this._handleUpdateFiles = this._handleUpdateFiles.bind(this);
+        this._reloadIframe = this._reloadIframe.bind(this);
     }
 
     /**
@@ -201,6 +202,14 @@ class Example extends TypedComponent {
             loadedPath: '',
             loadError: null
         });
+    }
+
+    _reloadIframe() {
+        this.setState({
+            exampleLoaded: false,
+            loadedPath: '',
+            loadError: null
+        }, () => requestAnimationFrame(() => iframe.reload()));
     }
 
     /**
@@ -328,7 +337,7 @@ class Example extends TypedComponent {
         }
 
         return jsx(DeviceSelector, {
-            onSelect: () => iframe.reload() // reload the iframe after updating the device
+            onSelect: this._reloadIframe
         });
     }
 

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -280,11 +280,13 @@ class Example extends TypedComponent {
 
         if (controlPanel.classList.contains('mobile')) {
             const drag = this.props.onMobilePanelDragStart;
+            controlPanel.onpointerdown = drag ? event => drag(event) : null;
             controlPanelHeader.onclick = null;
-            controlPanelHeader.onpointerdown = drag ? event => drag(event) : null;
+            controlPanelHeader.onpointerdown = null;
             return;
         }
 
+        controlPanel.onpointerdown = null;
         controlPanelHeader.onpointerdown = null;
         controlPanelHeader.onclick = () => this.toggleCollapse();
     }

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -21,6 +21,14 @@ import { getOrientation } from '../utils.mjs';
 
 const PC_IMPORT = /^[ \t]*import[\s\w*{},]+["']playcanvas["'];?[ \t]*(?:\r?\n|$)/gm;
 
+/** @type {Record<string, string>} */
+const MOBILE_PANEL_TITLES = {
+    examples: 'EXAMPLES',
+    code: 'SOURCE',
+    controls: 'CONTROLS',
+    description: 'DESCRIPTION'
+};
+
 /**
  * @template {Record<string, string>} [FILES=Record<string, string>]
  * @typedef {object} ExampleOptions
@@ -47,6 +55,10 @@ const PC_IMPORT = /^[ \t]*import[\s\w*{},]+["']playcanvas["'];?[ \t]*(?:\r?\n|$)
 /**
  * @typedef {object} Props
  * @property {{params: {category: string, example: string}}} match - The match object.
+ * @property {'portrait'|'landscape'} [orientation] - Current orientation.
+ * @property {null|'examples'|'code'|'controls'|'description'} [mobilePanel] - Active mobile panel.
+ * @property {(mobilePanel: null|'examples'|'code'|'controls'|'description') => void} [setMobilePanel] - Set active mobile panel.
+ * @property {(event: import('react').PointerEvent<HTMLElement>) => void} [onMobilePanelDragStart] - Start mobile panel drag.
  */
 
 /**
@@ -57,7 +69,6 @@ const PC_IMPORT = /^[ \t]*import[\s\w*{},]+["']playcanvas["'];?[ \t]*(?:\r?\n|$)
  * @property {Control | null} controls - Controls function from example.
  * @property {Observer | null} observer - The PCUI observer
  * @property {boolean} showDeviceSelector - Show device selector.
- * @property {'code' | 'parameters' | 'description'} show - Used in case of mobile view.
  * @property {Record<string, string>} files - Files of example (controls, shaders, example itself)
  * @property {string} description - Description of example.
  */
@@ -74,7 +85,6 @@ class Example extends TypedComponent {
         exampleLoaded: false,
         controls: () => null,
         showDeviceSelector: true,
-        show: 'code',
         files: { 'example.mjs': '// loading' },
         observer: null,
         description: ''
@@ -148,6 +158,9 @@ class Example extends TypedComponent {
     async _handleExampleLoad(event) {
         const { files, observer, description } = event.detail;
         const controlsSrc = files['controls.mjs'];
+        if (!description && this.props.mobilePanel === 'description') {
+            this.props.setMobilePanel?.(null);
+        }
         if (controlsSrc) {
             const controls = await this._buildControls(controlsSrc);
             this.mergeState({
@@ -200,13 +213,21 @@ class Example extends TypedComponent {
         this.setState(prevState => ({ ...prevState, ...state }));
     }
 
-    componentDidMount() {
-        // PCUI should just have a "onHeaderClick" but can't find anything
+    /** @type {HTMLElement | null} */
+    _controlPanel = null;
+
+    setupControlPanel() {
         const controlPanel = document.getElementById('controlPanel');
-        if (!controlPanel) {
+        if (!controlPanel || this._controlPanel === controlPanel) {
+            return;
+        }
+        this._controlPanel = controlPanel;
+
+        if (controlPanel.classList.contains('mobile')) {
             return;
         }
 
+        // PCUI should just have a "onHeaderClick" but can't find anything
         const controlPanelHeader = /** @type {HTMLElement | null} */ (
             /** @type {unknown} */ (controlPanel.querySelector('.pcui-panel-header'))
         );
@@ -214,8 +235,10 @@ class Example extends TypedComponent {
             return;
         }
         controlPanelHeader.onclick = () => this.toggleCollapse();
+    }
 
-        // Other events
+    componentDidMount() {
+        this.setupControlPanel();
         window.addEventListener('resize', this._onLayoutChange);
         window.addEventListener('requestedFiles', this._handleRequestedFiles);
         window.addEventListener('orientationchange', this._onLayoutChange);
@@ -223,6 +246,10 @@ class Example extends TypedComponent {
         window.addEventListener('exampleLoad', this._handleExampleLoad);
         window.addEventListener('updateFiles', this._handleUpdateFiles);
         iframe.fire('requestFiles');
+    }
+
+    componentDidUpdate() {
+        this.setupControlPanel();
     }
 
     componentWillUnmount() {
@@ -319,66 +346,127 @@ class Example extends TypedComponent {
         this.mergeState({ collapsed: !this.collapsed });
     }
 
-    renderPortrait() {
-        const { collapsed, show, files, description } = this.state;
-        return jsx(
-            'div',
-            { style: { display: 'contents' } },
-            jsx(
-                Panel,
+    renderMobilePanel() {
+        const { mobilePanel } = this.props;
+        const { files, description } = this.state;
+
+        if (mobilePanel === 'code') {
+            return jsx(CodeEditorMobile, {
+                key: 'code',
+                files,
+                category: this.props.match.params.category,
+                example: this.props.match.params.example
+            });
+        }
+
+        if (mobilePanel === 'description') {
+            return jsx(
+                Container,
                 {
-                    id: 'controlPanel',
-                    class: ['mobile'],
-                    resizable: 'top',
-                    headerText: 'CODE & CONTROLS',
-                    collapsible: true,
-                    collapsed
+                    key: 'description',
+                    id: 'mobileDescriptionPanel'
+                },
+                jsx('span', {
+                    dangerouslySetInnerHTML: {
+                        __html: description
+                    }
+                })
+            );
+        }
+
+        if (mobilePanel === 'controls') {
+            return jsx(
+                Container,
+                {
+                    key: 'controls',
+                    id: 'mobileControlsPanel'
                 },
                 this.renderDeviceSelector(),
                 jsx(
                     Container,
                     {
-                        id: 'controls-wrapper'
+                        id: 'controlPanel-scroll-region'
                     },
                     jsx(
                         Container,
                         {
-                            id: 'controlPanel-tabs',
-                            class: 'tabs-container'
+                            id: 'controlPanel-controls'
                         },
-                        jsx(Button, {
-                            text: 'CODE',
-                            id: 'codeButton',
-                            class: show === 'code' ? 'selected' : undefined,
-                            onClick: () => this.mergeState({ show: 'code' })
-                        }),
-                        jsx(Button, {
-                            text: 'PARAMETERS',
-                            class: show === 'parameters' ? 'selected' : undefined,
-                            id: 'paramButton',
-                            onClick: () => this.mergeState({ show: 'parameters' })
-                        }),
-                        description ?
-                            jsx(Button, {
-                                text: 'DESCRIPTION',
-                                class: show === 'description' ? 'selected' : undefined,
-                                id: 'descButton',
-                                onClick: () => this.mergeState({ show: 'description' })
-                            }) :
-                            null
-                    ),
-                    show === 'parameters' &&
-                        jsx(
-                            Container,
-                            {
-                                id: 'controlPanel-controls'
-                            },
-                            this.renderControls()
-                        ),
-                    show === 'code' && jsx(CodeEditorMobile, { files })
+                        this.renderControls()
+                    )
                 )
+            );
+        }
+    }
+
+    renderMobileDock() {
+        const { mobilePanel, setMobilePanel } = this.props;
+        const { description } = this.state;
+        return jsx(
+            Container,
+            {
+                id: 'mobileDock'
+            },
+            jsx(Button, {
+                key: 'examples',
+                text: 'Examples',
+                class: mobilePanel === 'examples' ?
+                    ['mobile-dock-button', 'mobile-dock-examples', 'selected'] :
+                    ['mobile-dock-button', 'mobile-dock-examples'],
+                onClick: () => setMobilePanel?.('examples')
+            }),
+            jsx(Button, {
+                key: 'code',
+                text: 'Source',
+                class: mobilePanel === 'code' ?
+                    ['mobile-dock-button', 'mobile-dock-code', 'selected'] :
+                    ['mobile-dock-button', 'mobile-dock-code'],
+                onClick: () => setMobilePanel?.('code')
+            }),
+            jsx(Button, {
+                key: 'controls',
+                text: 'Controls',
+                class: mobilePanel === 'controls' ?
+                    ['mobile-dock-button', 'mobile-dock-controls', 'selected'] :
+                    ['mobile-dock-button', 'mobile-dock-controls'],
+                onClick: () => setMobilePanel?.('controls')
+            }),
+            jsx(Button, {
+                key: 'description',
+                text: 'Info',
+                enabled: Boolean(description),
+                class: mobilePanel === 'description' ?
+                    ['mobile-dock-button', 'mobile-dock-description', 'selected'] :
+                    ['mobile-dock-button', 'mobile-dock-description'],
+                onClick: () => this.state.description && setMobilePanel?.('description')
+            })
+        );
+    }
+
+    renderMobile() {
+        const { mobilePanel } = this.props;
+        const activePanel = mobilePanel && mobilePanel !== 'examples' ? mobilePanel : null;
+        return jsx(
+            Container,
+            {
+                id: 'mobileUi'
+            },
+            activePanel && jsx('div', {
+                className: 'mobile-resize-handle',
+                onPointerDown: this.props.onMobilePanelDragStart
+            }),
+            activePanel && jsx(
+                Panel,
+                {
+                    key: activePanel,
+                    id: 'controlPanel',
+                    class: ['mobile', `${activePanel}-sheet`],
+                    headerText: MOBILE_PANEL_TITLES[activePanel],
+                    collapsible: false
+                },
+                this.renderMobilePanel()
             ),
-            this.renderDescription()
+            this.renderMobileDock()
         );
     }
 
@@ -412,11 +500,15 @@ class Example extends TypedComponent {
 
     render() {
         const { iframePath } = this;
-        const { orientation, exampleLoaded } = this.state;
+        const { exampleLoaded } = this.state;
+        const orientation = this.props.orientation ?? this.state.orientation;
+        const mobilePanel = orientation === 'portrait' ? this.props.mobilePanel : null;
+        const className = mobilePanel ? 'mobile-panel-open' : undefined;
         return jsx(
             Container,
             {
-                id: 'canvas-container'
+                id: 'canvas-container',
+                class: className
             },
             !exampleLoaded && jsx(Spinner, { size: 50 }),
             jsx('iframe', {
@@ -424,19 +516,19 @@ class Example extends TypedComponent {
                 key: iframePath,
                 src: iframePath
             }),
-            orientation === 'portrait' ? this.renderPortrait() : this.renderLandscape()
+            orientation === 'portrait' ? this.renderMobile() : this.renderLandscape()
         );
     }
 }
 
 /**
- * Wrapper component to provide router params to the class component.
+ * @param {Omit<Props, 'match'>} props - Component properties.
  * @returns {ReactElement} The Example component with router params.
  */
-function ExampleWithRouter() {
+function ExampleWithRouter(props) {
     const params = useParams();
     // @ts-ignore
-    return jsx(Example, { match: { params } });
+    return jsx(Example, { ...props, match: { params } });
 }
 
 export { ExampleWithRouter as Example };

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -16,7 +16,7 @@ import { getOrientation } from '../utils.mjs';
 /**
  * @import { Observer } from '@playcanvas/observer'
  * @import { ComponentType, ReactElement } from 'react'
- * @import { LoadingEvent, StateEvent } from '../events.js'
+ * @import { ErrorEvent as ExampleErrorEvent, LoadingEvent, StateEvent } from '../events.js'
  */
 
 const PC_IMPORT = /^[ \t]*import[\s\w*{},]+["']playcanvas["'];?[ \t]*(?:\r?\n|$)/gm;
@@ -66,6 +66,8 @@ const MOBILE_PANEL_TITLES = {
  * @property {'portrait' | 'landscape'} orientation - The orientation.
  * @property {boolean} collapsed - Collapsed or not.
  * @property {boolean} exampleLoaded - Example is loaded or not.
+ * @property {string} loadedPath - The loaded iframe path.
+ * @property {{ path: string, message: string } | null} loadError - The current loading error.
  * @property {Control | null} controls - Controls function from example.
  * @property {Observer | null} observer - The PCUI observer
  * @property {boolean} showDeviceSelector - Show device selector.
@@ -83,6 +85,8 @@ class Example extends TypedComponent {
         // @ts-ignore
         collapsed: window.top.innerWidth < MIN_DESKTOP_WIDTH,
         exampleLoaded: false,
+        loadedPath: '',
+        loadError: null,
         controls: () => null,
         showDeviceSelector: true,
         files: { 'example.mjs': '// loading' },
@@ -99,6 +103,8 @@ class Example extends TypedComponent {
         this._handleRequestedFiles = this._handleRequestedFiles.bind(this);
         this._handleExampleLoading = this._handleExampleLoading.bind(this);
         this._handleExampleLoad = this._handleExampleLoad.bind(this);
+        this._handleExampleHotReload = this._handleExampleHotReload.bind(this);
+        this._handleExampleError = this._handleExampleError.bind(this);
         this._handleUpdateFiles = this._handleUpdateFiles.bind(this);
     }
 
@@ -147,6 +153,8 @@ class Example extends TypedComponent {
         const { showDeviceSelector } = event.detail;
         this.mergeState({
             exampleLoaded: false,
+            loadedPath: '',
+            loadError: null,
             controls: null,
             showDeviceSelector: showDeviceSelector
         });
@@ -156,6 +164,7 @@ class Example extends TypedComponent {
      * @param {StateEvent} event - The event.
      */
     async _handleExampleLoad(event) {
+        const path = this.iframePath;
         const { files, observer, description } = event.detail;
         const controlsSrc = files['controls.mjs'];
         if (!description && this.props.mobilePanel === 'description') {
@@ -165,6 +174,8 @@ class Example extends TypedComponent {
             const controls = await this._buildControls(controlsSrc);
             this.mergeState({
                 exampleLoaded: true,
+                loadedPath: path,
+                loadError: null,
                 controls,
                 observer,
                 files,
@@ -174,6 +185,8 @@ class Example extends TypedComponent {
             // When switching examples from one with controls to one without controls...
             this.mergeState({
                 exampleLoaded: true,
+                loadedPath: path,
+                loadError: null,
                 controls: null,
                 observer: null,
                 files,
@@ -182,15 +195,44 @@ class Example extends TypedComponent {
         }
     }
 
+    _handleExampleHotReload() {
+        this.mergeState({
+            exampleLoaded: false,
+            loadedPath: '',
+            loadError: null
+        });
+    }
+
+    /**
+     * @param {ExampleErrorEvent} event - The event.
+     */
+    _handleExampleError(event) {
+        const { exampleLoaded, loadedPath } = this.state;
+        if (exampleLoaded && loadedPath === this.iframePath) {
+            return;
+        }
+        const { name, message } = event.detail;
+        this.mergeState({
+            exampleLoaded: false,
+            loadError: {
+                path: this.iframePath,
+                message: `${name}: ${message}`
+            }
+        });
+    }
+
     /**
      * @param {StateEvent} event - The event.
      */
     async _handleUpdateFiles(event) {
+        const path = this.iframePath;
         const { files, observer } = event.detail;
         const controlsSrc = files['controls.mjs'] ?? '';
         if (!files['controls.mjs']) {
             this.mergeState({
                 exampleLoaded: true,
+                loadedPath: path,
+                loadError: null,
                 controls: null,
                 observer: null
             });
@@ -198,6 +240,8 @@ class Example extends TypedComponent {
         const controls = await this._buildControls(controlsSrc);
         this.mergeState({
             exampleLoaded: true,
+            loadedPath: path,
+            loadError: null,
             controls,
             observer
         });
@@ -245,6 +289,8 @@ class Example extends TypedComponent {
         window.addEventListener('orientationchange', this._onLayoutChange);
         window.addEventListener('exampleLoading', this._handleExampleLoading);
         window.addEventListener('exampleLoad', this._handleExampleLoad);
+        window.addEventListener('exampleHotReload', this._handleExampleHotReload);
+        window.addEventListener('exampleError', this._handleExampleError);
         window.addEventListener('updateFiles', this._handleUpdateFiles);
         iframe.fire('requestFiles');
     }
@@ -259,6 +305,8 @@ class Example extends TypedComponent {
         window.removeEventListener('orientationchange', this._onLayoutChange);
         window.removeEventListener('exampleLoading', this._handleExampleLoading);
         window.removeEventListener('exampleLoad', this._handleExampleLoad);
+        window.removeEventListener('exampleHotReload', this._handleExampleHotReload);
+        window.removeEventListener('exampleError', this._handleExampleError);
         window.removeEventListener('updateFiles', this._handleUpdateFiles);
     }
 
@@ -497,7 +545,9 @@ class Example extends TypedComponent {
 
     render() {
         const { iframePath } = this;
-        const { exampleLoaded } = this.state;
+        const { exampleLoaded, loadedPath, loadError } = this.state;
+        const error = loadError?.path === iframePath ? loadError : null;
+        const loading = !error && (!exampleLoaded || loadedPath !== iframePath);
         const orientation = this.props.orientation ?? this.state.orientation;
         const mobilePanel = orientation === 'portrait' ? this.props.mobilePanel : null;
         const className = mobilePanel ? 'mobile-panel-open' : undefined;
@@ -507,7 +557,26 @@ class Example extends TypedComponent {
                 id: 'canvas-container',
                 class: className
             },
-            !exampleLoaded && jsx(Spinner, { size: 50 }),
+            (loading || error) && jsx(
+                'div',
+                {
+                    id: 'exampleLoading',
+                    className: error ? 'error' : undefined
+                },
+                jsx(
+                    'div',
+                    {
+                        className: 'example-loading-content'
+                    },
+                    error ? fragment(
+                        jsx('div', { className: 'example-loading-title' }, 'Example failed to load'),
+                        jsx('div', { className: 'example-loading-message' }, error.message)
+                    ) : fragment(
+                        jsx(Spinner, { size: 34 }),
+                        jsx('div', { className: 'example-loading-title' }, 'LOADING')
+                    )
+                )
+            ),
             jsx('iframe', {
                 id: 'exampleIframe',
                 key: iframePath,

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -58,7 +58,7 @@ const MOBILE_PANEL_TITLES = {
  * @property {'portrait'|'landscape'} [orientation] - Current orientation.
  * @property {null|'examples'|'code'|'controls'|'description'} [mobilePanel] - Active mobile panel.
  * @property {(mobilePanel: null|'examples'|'code'|'controls'|'description') => void} [setMobilePanel] - Set active mobile panel.
- * @property {(event: import('react').PointerEvent<HTMLElement>) => void} [onMobilePanelDragStart] - Start mobile panel drag.
+ * @property {(event: PointerEvent | import('react').PointerEvent<HTMLElement>) => void} [onMobilePanelDragStart] - Start mobile panel drag.
  */
 
 /**
@@ -213,17 +213,9 @@ class Example extends TypedComponent {
         this.setState(prevState => ({ ...prevState, ...state }));
     }
 
-    /** @type {HTMLElement | null} */
-    _controlPanel = null;
-
     setupControlPanel() {
         const controlPanel = document.getElementById('controlPanel');
-        if (!controlPanel || this._controlPanel === controlPanel) {
-            return;
-        }
-        this._controlPanel = controlPanel;
-
-        if (controlPanel.classList.contains('mobile')) {
+        if (!controlPanel) {
             return;
         }
 
@@ -234,6 +226,15 @@ class Example extends TypedComponent {
         if (!controlPanelHeader) {
             return;
         }
+
+        if (controlPanel.classList.contains('mobile')) {
+            const drag = this.props.onMobilePanelDragStart;
+            controlPanelHeader.onclick = null;
+            controlPanelHeader.onpointerdown = drag ? event => drag(event) : null;
+            return;
+        }
+
+        controlPanelHeader.onpointerdown = null;
         controlPanelHeader.onclick = () => this.toggleCollapse();
     }
 
@@ -451,10 +452,6 @@ class Example extends TypedComponent {
             {
                 id: 'mobileUi'
             },
-            activePanel && jsx('div', {
-                className: 'mobile-resize-handle',
-                onPointerDown: this.props.onMobilePanelDragStart
-            }),
             activePanel && jsx(
                 Panel,
                 {

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -7,11 +7,10 @@ import { useParams } from 'react-router-dom';
 import { CodeEditorMobile } from './code-editor/CodeEditorMobile.mjs';
 import { DeviceSelector } from './DeviceSelector.mjs';
 import { ErrorBoundary } from './ErrorBoundary.mjs';
-import { MIN_DESKTOP_WIDTH } from '../constants.mjs';
 import { iframe } from '../iframe.mjs';
 import { jsx, fragment } from '../jsx.mjs';
 import { iframePath } from '../paths.mjs';
-import { getOrientation } from '../utils.mjs';
+import { getLayout } from '../utils.mjs';
 
 /**
  * @import { Observer } from '@playcanvas/observer'
@@ -55,7 +54,7 @@ const MOBILE_PANEL_TITLES = {
 /**
  * @typedef {object} Props
  * @property {{params: {category: string, example: string}}} match - The match object.
- * @property {'portrait'|'landscape'} [orientation] - Current orientation.
+ * @property {'mobile'|'desktop'} [layout] - Current layout.
  * @property {null|'examples'|'code'|'controls'|'description'} [mobilePanel] - Active mobile panel.
  * @property {(mobilePanel: null|'examples'|'code'|'controls'|'description') => void} [setMobilePanel] - Set active mobile panel.
  * @property {(event: PointerEvent | import('react').PointerEvent<HTMLElement>) => void} [onMobilePanelDragStart] - Start mobile panel drag.
@@ -63,7 +62,7 @@ const MOBILE_PANEL_TITLES = {
 
 /**
  * @typedef {object} State
- * @property {'portrait' | 'landscape'} orientation - The orientation.
+ * @property {'mobile' | 'desktop'} layout - The layout.
  * @property {boolean} collapsed - Collapsed or not.
  * @property {boolean} exampleLoaded - Example is loaded or not.
  * @property {string} loadedPath - The loaded iframe path.
@@ -81,9 +80,8 @@ const TypedComponent = Component;
 class Example extends TypedComponent {
     /** @type {State} */
     state = {
-        orientation: getOrientation(),
-        // @ts-ignore
-        collapsed: window.top.innerWidth < MIN_DESKTOP_WIDTH,
+        layout: getLayout(),
+        collapsed: getLayout() === 'mobile',
         exampleLoaded: false,
         loadedPath: '',
         loadError: null,
@@ -141,10 +139,10 @@ class Example extends TypedComponent {
     }
 
     /**
-     * Called for resizing and changing orientation of device.
+     * Called for resizing and changing layout.
      */
     _onLayoutChange() {
-        this.mergeState({ orientation: getOrientation() });
+        this.mergeState({ layout: getLayout() });
     }
 
     /**
@@ -362,7 +360,8 @@ class Example extends TypedComponent {
     }
 
     renderDescription() {
-        const { exampleLoaded, description, orientation } = this.state;
+        const { exampleLoaded, description } = this.state;
+        const layout = this.props.layout ?? this.state.layout;
         const ready = exampleLoaded && iframe.ready;
         if (!ready) {
             return;
@@ -371,7 +370,7 @@ class Example extends TypedComponent {
             Container,
             {
                 id: 'descriptionPanel',
-                class: orientation === 'portrait' ? 'mobile' : undefined
+                class: layout === 'mobile' ? 'mobile' : undefined
             },
             jsx('span', {
                 dangerouslySetInnerHTML: {
@@ -524,7 +523,7 @@ class Example extends TypedComponent {
         );
     }
 
-    renderLandscape() {
+    renderDesktop() {
         const { collapsed } = this.state;
         return jsx(
             'div',
@@ -533,7 +532,7 @@ class Example extends TypedComponent {
                 Panel,
                 {
                     id: 'controlPanel',
-                    class: ['landscape'],
+                    class: ['desktop'],
                     resizable: 'top',
                     headerText: 'CONTROLS',
                     collapsible: true,
@@ -557,8 +556,8 @@ class Example extends TypedComponent {
         const { exampleLoaded, loadedPath, loadError } = this.state;
         const error = loadError?.path === iframePath ? loadError : null;
         const loading = !error && (!exampleLoaded || loadedPath !== iframePath);
-        const orientation = this.props.orientation ?? this.state.orientation;
-        const mobilePanel = orientation === 'portrait' ? this.props.mobilePanel : null;
+        const layout = this.props.layout ?? this.state.layout;
+        const mobilePanel = layout === 'mobile' ? this.props.mobilePanel : null;
         const className = mobilePanel ? 'mobile-panel-open' : undefined;
         return jsx(
             Container,
@@ -591,7 +590,7 @@ class Example extends TypedComponent {
                 key: iframePath,
                 src: iframePath
             }),
-            orientation === 'portrait' ? this.renderMobile() : this.renderLandscape()
+            layout === 'mobile' ? this.renderMobile() : this.renderDesktop()
         );
     }
 }

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -10,6 +10,26 @@ import { iframe } from '../iframe.mjs';
 import { jsx } from '../jsx.mjs';
 import { getOrientation } from '../utils.mjs';
 
+const MOBILE_DOCK_HEIGHT = 48;
+const MOBILE_PANEL_MIN_HEIGHT = 220;
+const MOBILE_PANEL_DEFAULT_MIN_HEIGHT = 300;
+const MOBILE_PANEL_DEFAULT_MAX_HEIGHT = 440;
+const MOBILE_PANEL_DEFAULT_SCALE = 0.48;
+const MOBILE_CANVAS_MIN_HEIGHT = 160;
+
+function getMobilePanelHeight(height = window.innerHeight * MOBILE_PANEL_DEFAULT_SCALE) {
+    const max = Math.max(0, window.innerHeight - MOBILE_DOCK_HEIGHT - MOBILE_CANVAS_MIN_HEIGHT);
+    const min = Math.min(MOBILE_PANEL_MIN_HEIGHT, max);
+    return Math.min(max, Math.max(min, height));
+}
+
+function getDefaultMobilePanelHeight() {
+    return getMobilePanelHeight(Math.min(
+        MOBILE_PANEL_DEFAULT_MAX_HEIGHT,
+        Math.max(MOBILE_PANEL_DEFAULT_MIN_HEIGHT, window.innerHeight * MOBILE_PANEL_DEFAULT_SCALE)
+    ));
+}
+
 // eslint-disable-next-line jsdoc/require-property
 /**
  * @typedef {object} Props
@@ -18,6 +38,8 @@ import { getOrientation } from '../utils.mjs';
 /**
  * @typedef {object} State
  * @property {'portrait'|'landscape'} orientation - Current orientation.
+ * @property {null|'examples'|'code'|'controls'|'description'} mobilePanel - Active mobile panel.
+ * @property {number} mobilePanelHeight - Active mobile panel height.
  */
 
 /** @type {typeof Component<Props, State>} */
@@ -26,8 +48,13 @@ const TypedComponent = Component;
 class MainLayout extends TypedComponent {
     /** @type {State} */
     state = {
-        orientation: getOrientation()
+        orientation: getOrientation(),
+        mobilePanel: null,
+        mobilePanelHeight: getDefaultMobilePanelHeight()
     };
+
+    /** @type {{ y: number, height: number } | null} */
+    _mobilePanelDrag = null;
 
     /**
      * @param {Props} props - Component properties.
@@ -38,8 +65,67 @@ class MainLayout extends TypedComponent {
     }
 
     _onLayoutChange() {
-        this.setState({ ...this.state, orientation: getOrientation() });
+        const orientation = getOrientation();
+        this.setState(prevState => ({
+            orientation,
+            mobilePanel: orientation === 'portrait' ? prevState.mobilePanel : null,
+            mobilePanelHeight: getMobilePanelHeight(prevState.mobilePanelHeight)
+        }), this.resizeIframe);
     }
+
+    resizeIframe = () => {
+        requestAnimationFrame(() => iframe.window?.dispatchEvent(new Event('resize')));
+    };
+
+    /**
+     * @param {State['mobilePanel']} mobilePanel - Active mobile panel.
+     */
+    setMobilePanel = (mobilePanel) => {
+        this.setState(prevState => ({
+            mobilePanel: prevState.mobilePanel === mobilePanel ? null : mobilePanel
+        }), this.resizeIframe);
+    };
+
+    /**
+     * @param {number} height - Mobile panel height.
+     */
+    setMobilePanelHeight = (height) => {
+        this.setState({ mobilePanelHeight: getMobilePanelHeight(height) }, this.resizeIframe);
+    };
+
+    /**
+     * @param {PointerEvent} event - Pointer event.
+     */
+    onMobilePanelDrag = (event) => {
+        if (!this._mobilePanelDrag) {
+            return;
+        }
+        this.setMobilePanelHeight(this._mobilePanelDrag.height + this._mobilePanelDrag.y - event.clientY);
+    };
+
+    stopMobilePanelDrag = () => {
+        this._mobilePanelDrag = null;
+        document.body.classList.remove('mobile-panel-resizing');
+        window.removeEventListener('pointermove', this.onMobilePanelDrag);
+        window.removeEventListener('pointerup', this.stopMobilePanelDrag);
+        window.removeEventListener('pointercancel', this.stopMobilePanelDrag);
+    };
+
+    /**
+     * @param {import('react').PointerEvent<HTMLElement>} event - Pointer event.
+     */
+    startMobilePanelDrag = (event) => {
+        event.preventDefault();
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+        this._mobilePanelDrag = {
+            y: event.clientY,
+            height: this.state.mobilePanelHeight
+        };
+        document.body.classList.add('mobile-panel-resizing');
+        window.addEventListener('pointermove', this.onMobilePanelDrag);
+        window.addEventListener('pointerup', this.stopMobilePanelDrag);
+        window.addEventListener('pointercancel', this.stopMobilePanelDrag);
+    };
 
     componentDidMount() {
         window.addEventListener('resize', this._onLayoutChange);
@@ -47,6 +133,7 @@ class MainLayout extends TypedComponent {
     }
 
     componentWillUnmount() {
+        this.stopMobilePanelDrag();
         window.removeEventListener('resize', this._onLayoutChange);
         window.removeEventListener('orientationchange', this._onLayoutChange);
     }
@@ -59,10 +146,13 @@ class MainLayout extends TypedComponent {
     };
 
     render() {
-        const { orientation } = this.state;
+        const { orientation, mobilePanel, mobilePanelHeight } = this.state;
         return jsx(
             'div',
-            { id: 'appInner' },
+            {
+                id: 'appInner',
+                style: { '--mobile-panel-height': `${mobilePanelHeight}px` }
+            },
             jsx(
                 HashRouter,
                 null,
@@ -78,18 +168,29 @@ class MainLayout extends TypedComponent {
                         element: jsx(
                             'div',
                             { id: 'appInner-router', style: { display: 'contents' } },
-                            jsx(SideBar, null),
+                            jsx(SideBar, {
+                                orientation,
+                                mobilePanel,
+                                setMobilePanel: this.setMobilePanel,
+                                onMobilePanelDragStart: this.startMobilePanelDrag
+                            }),
                             jsx(
                                 Container,
                                 { id: 'main-view-wrapper' },
                                 jsx(Menu, {
+                                    orientation,
                                     setShowMiniStats: this.updateShowMiniStats.bind(this)
                                 }),
                                 jsx(
                                     Container,
                                     { id: 'main-view' },
                                     orientation === 'landscape' && jsx(CodeEditorDesktop),
-                                    jsx(Example, null)
+                                    jsx(Example, {
+                                        orientation,
+                                        mobilePanel,
+                                        setMobilePanel: this.setMobilePanel,
+                                        onMobilePanelDragStart: this.startMobilePanelDrag
+                                    })
                                 )
                             )
                         )

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -17,6 +17,16 @@ const MOBILE_PANEL_DEFAULT_MIN_HEIGHT = 300;
 const MOBILE_PANEL_DEFAULT_MAX_HEIGHT = 440;
 const MOBILE_PANEL_DEFAULT_SCALE = 0.48;
 const MOBILE_CANVAS_MIN_HEIGHT = 160;
+const MOBILE_PANEL_MIN_WIDTH = 280;
+const MOBILE_PANEL_DEFAULT_MIN_WIDTH = 320;
+const MOBILE_PANEL_DEFAULT_MAX_WIDTH = 420;
+const MOBILE_PANEL_DEFAULT_WIDTH_SCALE = 0.42;
+const MOBILE_CANVAS_MIN_WIDTH = 300;
+
+const getMobileOrientation = () => {
+    const win = window.top ?? window;
+    return win.innerWidth > win.innerHeight ? 'landscape' : 'portrait';
+};
 
 function getMobilePanelHeight(height = window.innerHeight * MOBILE_PANEL_DEFAULT_SCALE) {
     const max = Math.max(
@@ -34,6 +44,19 @@ function getDefaultMobilePanelHeight() {
     ));
 }
 
+function getMobilePanelWidth(width = window.innerWidth * MOBILE_PANEL_DEFAULT_WIDTH_SCALE) {
+    const max = Math.max(0, window.innerWidth - MOBILE_CANVAS_MIN_WIDTH - MOBILE_GAP * 3);
+    const min = Math.min(MOBILE_PANEL_MIN_WIDTH, max);
+    return Math.min(max, Math.max(min, width));
+}
+
+function getDefaultMobilePanelWidth() {
+    return getMobilePanelWidth(Math.min(
+        MOBILE_PANEL_DEFAULT_MAX_WIDTH,
+        Math.max(MOBILE_PANEL_DEFAULT_MIN_WIDTH, window.innerWidth * MOBILE_PANEL_DEFAULT_WIDTH_SCALE)
+    ));
+}
+
 // eslint-disable-next-line jsdoc/require-property
 /**
  * @typedef {object} Props
@@ -42,8 +65,10 @@ function getDefaultMobilePanelHeight() {
 /**
  * @typedef {object} State
  * @property {'mobile'|'desktop'} layout - Current layout.
+ * @property {'portrait'|'landscape'} mobileOrientation - Current mobile orientation.
  * @property {null|'examples'|'code'|'controls'|'description'} mobilePanel - Active mobile panel.
  * @property {number} mobilePanelHeight - Active mobile panel height.
+ * @property {number} mobilePanelWidth - Active mobile panel width.
  */
 
 /** @type {typeof Component<Props, State>} */
@@ -53,11 +78,13 @@ class MainLayout extends TypedComponent {
     /** @type {State} */
     state = {
         layout: getLayout(),
+        mobileOrientation: getMobileOrientation(),
         mobilePanel: null,
-        mobilePanelHeight: getDefaultMobilePanelHeight()
+        mobilePanelHeight: getDefaultMobilePanelHeight(),
+        mobilePanelWidth: getDefaultMobilePanelWidth()
     };
 
-    /** @type {{ y: number, height: number } | null} */
+    /** @type {{ axis: 'x'|'y', position: number, size: number } | null} */
     _mobilePanelDrag = null;
 
     /**
@@ -72,8 +99,10 @@ class MainLayout extends TypedComponent {
         const layout = getLayout();
         this.setState(prevState => ({
             layout,
+            mobileOrientation: getMobileOrientation(),
             mobilePanel: layout === 'mobile' ? prevState.mobilePanel : null,
-            mobilePanelHeight: getMobilePanelHeight(prevState.mobilePanelHeight)
+            mobilePanelHeight: getMobilePanelHeight(prevState.mobilePanelHeight),
+            mobilePanelWidth: getMobilePanelWidth(prevState.mobilePanelWidth)
         }), this.resizeIframe);
     }
 
@@ -98,18 +127,32 @@ class MainLayout extends TypedComponent {
     };
 
     /**
+     * @param {number} width - Mobile panel width.
+     */
+    setMobilePanelWidth = (width) => {
+        this.setState({ mobilePanelWidth: getMobilePanelWidth(width) }, this.resizeIframe);
+    };
+
+    /**
      * @param {PointerEvent} event - Pointer event.
      */
     onMobilePanelDrag = (event) => {
         if (!this._mobilePanelDrag) {
             return;
         }
-        this.setMobilePanelHeight(this._mobilePanelDrag.height + this._mobilePanelDrag.y - event.clientY);
+        const { axis, position, size } = this._mobilePanelDrag;
+        if (axis === 'x') {
+            this.setMobilePanelWidth(size + position - event.clientX);
+            return;
+        }
+        this.setMobilePanelHeight(size + position - event.clientY);
     };
 
     stopMobilePanelDrag = () => {
         this._mobilePanelDrag = null;
         document.body.classList.remove('mobile-panel-resizing');
+        document.body.classList.remove('mobile-panel-resizing-x');
+        document.body.classList.remove('mobile-panel-resizing-y');
         window.removeEventListener('pointermove', this.onMobilePanelDrag);
         window.removeEventListener('pointerup', this.stopMobilePanelDrag);
         window.removeEventListener('pointercancel', this.stopMobilePanelDrag);
@@ -126,21 +169,27 @@ class MainLayout extends TypedComponent {
 
         const rect = target.getBoundingClientRect();
         const style = getComputedStyle(target);
-        const width = parseFloat(style.getPropertyValue('--mobile-handle-hit-width')) || 96;
-        const height = parseFloat(style.getPropertyValue('--mobile-handle-hit-height')) || 44;
-        const x = event.clientX - rect.left - rect.width / 2;
+        const hitWidth = parseFloat(style.getPropertyValue('--mobile-handle-hit-width')) || 96;
+        const hitHeight = parseFloat(style.getPropertyValue('--mobile-handle-hit-height')) || 44;
+        const axis = this.state.mobileOrientation === 'landscape' ? 'x' : 'y';
+        const x = axis === 'x' ? event.clientX - rect.left : event.clientX - rect.left - rect.width / 2;
         const y = event.clientY - rect.top;
-        if (Math.abs(x) > width / 2 || Math.abs(y) > height / 2) {
+        const outside = axis === 'x' ?
+            Math.abs(x) > hitHeight / 2 :
+            Math.abs(x) > hitWidth / 2 || Math.abs(y) > hitHeight / 2;
+        if (outside) {
             return;
         }
 
         event.preventDefault();
         target.setPointerCapture?.(event.pointerId);
         this._mobilePanelDrag = {
-            y: event.clientY,
-            height: this.state.mobilePanelHeight
+            axis,
+            position: axis === 'x' ? event.clientX : event.clientY,
+            size: axis === 'x' ? this.state.mobilePanelWidth : this.state.mobilePanelHeight
         };
         document.body.classList.add('mobile-panel-resizing');
+        document.body.classList.add(`mobile-panel-resizing-${axis}`);
         window.addEventListener('pointermove', this.onMobilePanelDrag);
         window.addEventListener('pointerup', this.stopMobilePanelDrag);
         window.addEventListener('pointercancel', this.stopMobilePanelDrag);
@@ -165,13 +214,16 @@ class MainLayout extends TypedComponent {
     };
 
     render() {
-        const { layout, mobilePanel, mobilePanelHeight } = this.state;
+        const { layout, mobileOrientation, mobilePanel, mobilePanelHeight, mobilePanelWidth } = this.state;
         return jsx(
             'div',
             {
                 id: 'appInner',
-                className: layout,
-                style: { '--mobile-panel-height': `${mobilePanelHeight}px` }
+                className: layout === 'mobile' ? `mobile mobile-${mobileOrientation}` : 'desktop',
+                style: {
+                    '--mobile-panel-height': `${mobilePanelHeight}px`,
+                    '--mobile-panel-width': `${mobilePanelWidth}px`
+                }
             },
             jsx(
                 HashRouter,

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -11,6 +11,7 @@ import { jsx } from '../jsx.mjs';
 import { getOrientation } from '../utils.mjs';
 
 const MOBILE_DOCK_HEIGHT = 48;
+const MOBILE_GAP = 8;
 const MOBILE_PANEL_MIN_HEIGHT = 220;
 const MOBILE_PANEL_DEFAULT_MIN_HEIGHT = 300;
 const MOBILE_PANEL_DEFAULT_MAX_HEIGHT = 440;
@@ -18,7 +19,10 @@ const MOBILE_PANEL_DEFAULT_SCALE = 0.48;
 const MOBILE_CANVAS_MIN_HEIGHT = 160;
 
 function getMobilePanelHeight(height = window.innerHeight * MOBILE_PANEL_DEFAULT_SCALE) {
-    const max = Math.max(0, window.innerHeight - MOBILE_DOCK_HEIGHT - MOBILE_CANVAS_MIN_HEIGHT);
+    const max = Math.max(
+        0,
+        window.innerHeight - MOBILE_DOCK_HEIGHT - MOBILE_CANVAS_MIN_HEIGHT - MOBILE_GAP * 4
+    );
     const min = Math.min(MOBILE_PANEL_MIN_HEIGHT, max);
     return Math.min(max, Math.max(min, height));
 }

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -8,7 +8,7 @@ import { Menu } from './Menu.mjs';
 import { SideBar } from './Sidebar.mjs';
 import { iframe } from '../iframe.mjs';
 import { jsx } from '../jsx.mjs';
-import { getOrientation } from '../utils.mjs';
+import { getLayout } from '../utils.mjs';
 
 const MOBILE_DOCK_HEIGHT = 48;
 const MOBILE_GAP = 8;
@@ -41,7 +41,7 @@ function getDefaultMobilePanelHeight() {
 
 /**
  * @typedef {object} State
- * @property {'portrait'|'landscape'} orientation - Current orientation.
+ * @property {'mobile'|'desktop'} layout - Current layout.
  * @property {null|'examples'|'code'|'controls'|'description'} mobilePanel - Active mobile panel.
  * @property {number} mobilePanelHeight - Active mobile panel height.
  */
@@ -52,7 +52,7 @@ const TypedComponent = Component;
 class MainLayout extends TypedComponent {
     /** @type {State} */
     state = {
-        orientation: getOrientation(),
+        layout: getLayout(),
         mobilePanel: null,
         mobilePanelHeight: getDefaultMobilePanelHeight()
     };
@@ -69,10 +69,10 @@ class MainLayout extends TypedComponent {
     }
 
     _onLayoutChange() {
-        const orientation = getOrientation();
+        const layout = getLayout();
         this.setState(prevState => ({
-            orientation,
-            mobilePanel: orientation === 'portrait' ? prevState.mobilePanel : null,
+            layout,
+            mobilePanel: layout === 'mobile' ? prevState.mobilePanel : null,
             mobilePanelHeight: getMobilePanelHeight(prevState.mobilePanelHeight)
         }), this.resizeIframe);
     }
@@ -165,11 +165,12 @@ class MainLayout extends TypedComponent {
     };
 
     render() {
-        const { orientation, mobilePanel, mobilePanelHeight } = this.state;
+        const { layout, mobilePanel, mobilePanelHeight } = this.state;
         return jsx(
             'div',
             {
                 id: 'appInner',
+                className: layout,
                 style: { '--mobile-panel-height': `${mobilePanelHeight}px` }
             },
             jsx(
@@ -188,7 +189,7 @@ class MainLayout extends TypedComponent {
                             'div',
                             { id: 'appInner-router', style: { display: 'contents' } },
                             jsx(SideBar, {
-                                orientation,
+                                layout,
                                 mobilePanel,
                                 setMobilePanel: this.setMobilePanel,
                                 onMobilePanelDragStart: this.startMobilePanelDrag
@@ -197,15 +198,15 @@ class MainLayout extends TypedComponent {
                                 Container,
                                 { id: 'main-view-wrapper' },
                                 jsx(Menu, {
-                                    orientation,
+                                    layout,
                                     setShowMiniStats: this.updateShowMiniStats.bind(this)
                                 }),
                                 jsx(
                                     Container,
                                     { id: 'main-view' },
-                                    orientation === 'landscape' && jsx(CodeEditorDesktop),
+                                    layout === 'desktop' && jsx(CodeEditorDesktop),
                                     jsx(Example, {
-                                        orientation,
+                                        layout,
                                         mobilePanel,
                                         setMobilePanel: this.setMobilePanel,
                                         onMobilePanelDragStart: this.startMobilePanelDrag

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -116,11 +116,26 @@ class MainLayout extends TypedComponent {
     };
 
     /**
-     * @param {import('react').PointerEvent<HTMLElement>} event - Pointer event.
+     * @param {PointerEvent | import('react').PointerEvent<HTMLElement>} event - Pointer event.
      */
     startMobilePanelDrag = (event) => {
+        const target = /** @type {HTMLElement | null} */ (event.currentTarget);
+        if (!target) {
+            return;
+        }
+
+        const rect = target.getBoundingClientRect();
+        const style = getComputedStyle(target);
+        const width = parseFloat(style.getPropertyValue('--mobile-handle-hit-width')) || 96;
+        const height = parseFloat(style.getPropertyValue('--mobile-handle-hit-height')) || 44;
+        const x = event.clientX - rect.left - rect.width / 2;
+        const y = event.clientY - rect.top;
+        if (Math.abs(x) > width / 2 || Math.abs(y) > height / 2) {
+            return;
+        }
+
         event.preventDefault();
-        event.currentTarget.setPointerCapture?.(event.pointerId);
+        target.setPointerCapture?.(event.pointerId);
         this._mobilePanelDrag = {
             y: event.clientY,
             height: this.state.mobilePanelHeight

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -11,6 +11,7 @@ import { jsx } from '../jsx.mjs';
 import { getLayout } from '../utils.mjs';
 
 const MOBILE_DOCK_HEIGHT = 48;
+const MOBILE_DOCK_WIDTH = 48;
 const MOBILE_GAP = 8;
 const MOBILE_PANEL_MIN_HEIGHT = 220;
 const MOBILE_PANEL_DEFAULT_MIN_HEIGHT = 300;
@@ -45,7 +46,7 @@ function getDefaultMobilePanelHeight() {
 }
 
 function getMobilePanelWidth(width = window.innerWidth * MOBILE_PANEL_DEFAULT_WIDTH_SCALE) {
-    const max = Math.max(0, window.innerWidth - MOBILE_CANVAS_MIN_WIDTH - MOBILE_GAP * 3);
+    const max = Math.max(0, window.innerWidth - MOBILE_CANVAS_MIN_WIDTH - MOBILE_DOCK_WIDTH - MOBILE_GAP * 4);
     const min = Math.min(MOBILE_PANEL_MIN_WIDTH, max);
     return Math.min(max, Math.max(min, width));
 }

--- a/examples/src/app/components/Menu.mjs
+++ b/examples/src/app/components/Menu.mjs
@@ -4,12 +4,12 @@ import { Component } from 'react';
 import { iframe } from '../iframe.mjs';
 import { jsx } from '../jsx.mjs';
 import { logo } from '../paths.mjs';
-import { getOrientation } from '../utils.mjs';
+import { getLayout } from '../utils.mjs';
 
 /**
  * @typedef {object} Props
  * @property {(value: boolean) => void} setShowMiniStats - The state set function .
- * @property {'portrait'|'landscape'} [orientation] - Current orientation.
+ * @property {'mobile'|'desktop'} [layout] - Current layout.
  */
 
 /**
@@ -23,7 +23,7 @@ const TypedComponent = Component;
 class Menu extends TypedComponent {
     /** @type {State} */
     state = {
-        showMiniStats: getOrientation() !== 'portrait'
+        showMiniStats: getLayout() === 'desktop'
     };
 
     mouseTimeout = null;

--- a/examples/src/app/components/Menu.mjs
+++ b/examples/src/app/components/Menu.mjs
@@ -1,23 +1,31 @@
 import { Button, Container } from '@playcanvas/pcui/react';
 import { Component } from 'react';
 
+import { iframe } from '../iframe.mjs';
 import { jsx } from '../jsx.mjs';
 import { logo } from '../paths.mjs';
+import { getOrientation } from '../utils.mjs';
 
 /**
  * @typedef {object} Props
  * @property {(value: boolean) => void} setShowMiniStats - The state set function .
+ * @property {'portrait'|'landscape'} [orientation] - Current orientation.
  */
 
-// eslint-disable-next-line jsdoc/require-property
 /**
  * @typedef {object} State
+ * @property {boolean} showMiniStats - Show MiniStats state.
  */
 
 /** @type {typeof Component<Props, State>} */
 const TypedComponent = Component;
 
 class Menu extends TypedComponent {
+    /** @type {State} */
+    state = {
+        showMiniStats: getOrientation() !== 'portrait'
+    };
+
     mouseTimeout = null;
 
     /**
@@ -27,10 +35,20 @@ class Menu extends TypedComponent {
         super(props);
         this._handleKeyDown = this._handleKeyDown.bind(this);
         this._handleExampleLoad = this._handleExampleLoad.bind(this);
+        this._handleMiniStats = this._handleMiniStats.bind(this);
+        this.toggleMiniStats = this.toggleMiniStats.bind(this);
     }
 
     /** @type {EventListener | null} */
     clickFullscreenListener = null;
+
+    resizeIframe() {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                iframe.window?.dispatchEvent(new Event('resize'));
+            });
+        });
+    }
 
     toggleFullscreen() {
         const contentDocument = document.querySelector('iframe')?.contentDocument;
@@ -57,6 +75,7 @@ class Menu extends TypedComponent {
             };
             contentDocument.addEventListener('mousemove', this.clickFullscreenListener);
         }
+        this.resizeIframe();
     }
 
     componentDidMount() {
@@ -68,6 +87,7 @@ class Menu extends TypedComponent {
         }
         document.addEventListener('keydown', this._handleKeyDown);
         window.addEventListener('exampleLoad', this._handleExampleLoad);
+        window.addEventListener('miniStats', this._handleMiniStats);
     }
 
     componentWillUnmount() {
@@ -77,6 +97,7 @@ class Menu extends TypedComponent {
         }
         document.removeEventListener('keydown', this._handleKeyDown);
         window.removeEventListener('exampleLoad', this._handleExampleLoad);
+        window.removeEventListener('miniStats', this._handleMiniStats);
     }
 
     /**
@@ -93,15 +114,25 @@ class Menu extends TypedComponent {
     }
 
     _handleExampleLoad() {
-        const showMiniStatsBtn = document.getElementById('showMiniStatsButton');
-        if (!showMiniStatsBtn) {
-            return;
-        }
-        const selected = showMiniStatsBtn.classList.contains('selected');
-        this.props.setShowMiniStats(selected);
+        this.props.setShowMiniStats(this.state.showMiniStats);
+    }
+
+    toggleMiniStats() {
+        const value = !this.state.showMiniStats;
+        this.setState({ showMiniStats: value });
+        this.props.setShowMiniStats(value);
+    }
+
+    /**
+     * @param {Event} event - MiniStats state event.
+     */
+    _handleMiniStats(event) {
+        const customEvent = /** @type {CustomEvent<{ state: boolean }>} */ (event);
+        this.setState({ showMiniStats: !!customEvent.detail.state });
     }
 
     render() {
+        const { showMiniStats } = this.state;
         return jsx(
             Container,
             {
@@ -132,13 +163,9 @@ class Menu extends TypedComponent {
                 jsx(Button, {
                     icon: 'E149',
                     id: 'showMiniStatsButton',
-                    class: 'selected',
+                    class: showMiniStats ? 'selected' : undefined,
                     text: '',
-                    onClick: () => {
-                        document.getElementById('showMiniStatsButton')?.classList.toggle('selected');
-                        const selected = document.getElementById('showMiniStatsButton')?.classList.contains('selected');
-                        this.props.setShowMiniStats(!!selected);
-                    }
+                    onClick: this.toggleMiniStats
                 }),
                 jsx(Button, {
                     icon: 'E127',

--- a/examples/src/app/components/Sidebar.mjs
+++ b/examples/src/app/components/Sidebar.mjs
@@ -15,6 +15,10 @@ import { getOrientation } from '../utils.mjs';
 /**
  * @typedef {object} Props
  * @property {{ pathname: string, hash: string }} location - The router location.
+ * @property {'portrait'|'landscape'} [orientation] - Current orientation.
+ * @property {null|'examples'|'code'|'controls'|'description'} [mobilePanel] - Active mobile panel.
+ * @property {(mobilePanel: null|'examples'|'code'|'controls'|'description') => void} [setMobilePanel] - Set active mobile panel.
+ * @property {(event: import('react').PointerEvent<HTMLElement>) => void} [onMobilePanelDragStart] - Start mobile panel drag.
  */
 
 /**
@@ -68,6 +72,12 @@ class SideBar extends TypedComponent {
         orientation: getOrientation()
     };
 
+    /** @type {HTMLElement | null} */
+    _sideBar = null;
+
+    /** @type {string} */
+    _sideBarOrientation = '';
+
     /**
      * @param {Props} props - Component properties.
      */
@@ -75,32 +85,64 @@ class SideBar extends TypedComponent {
         super(props);
         this._onLayoutChange = this._onLayoutChange.bind(this);
         this._onClickExample = this._onClickExample.bind(this);
+        this._onLargeThumbnailsSet = this._onLargeThumbnailsSet.bind(this);
     }
 
-    componentDidMount() {
-        // PCUI should just have a "onHeaderClick" but can't find anything
+    setupSideBar() {
         const sideBar = document.getElementById('sideBar');
-        if (!sideBar) {
+        const orientation = this.props.orientation ?? this.state.orientation;
+        if (!sideBar || (this._sideBar === sideBar && this._sideBarOrientation === orientation)) {
             return;
         }
+        this._sideBar = sideBar;
+        this._sideBarOrientation = orientation;
 
+        // PCUI should just have a "onHeaderClick" but can't find anything
         const sideBarHeader = /** @type {HTMLElement | null} */ (
             /** @type {unknown} */ (sideBar.querySelector('.pcui-panel-header'))
         );
-        if (!sideBarHeader) {
-            return;
+        if (sideBarHeader) {
+            sideBarHeader.onclick = orientation === 'portrait' ? null : () => this.toggleCollapse();
         }
-        sideBarHeader.onclick = () => this.toggleCollapse();
         this.setupControlPanelToggleButton();
+    }
 
-        // setup events
+    componentDidMount() {
+        this.state.observer.on('largeThumbnails:set', this._onLargeThumbnailsSet);
+        this.setupSideBar();
         window.addEventListener('resize', this._onLayoutChange);
         window.addEventListener('orientationchange', this._onLayoutChange);
+    }
+
+    componentDidUpdate() {
+        this.setupSideBar();
     }
 
     componentWillUnmount() {
         window.removeEventListener('resize', this._onLayoutChange);
         window.removeEventListener('orientationchange', this._onLayoutChange);
+    }
+
+    _onLargeThumbnailsSet() {
+        const sideBar = document.getElementById('sideBar');
+        if (!sideBar) {
+            return;
+        }
+        let minTopNavItemDistance = Number.MAX_VALUE;
+
+        const navItems = /** @type {NodeListOf<HTMLElement>} */ (
+            /** @type {unknown} */ (document.querySelectorAll('.nav-item'))
+        );
+        for (let i = 0; i < navItems.length; i++) {
+            const nav = navItems[i];
+            const navItemDistance = Math.abs(120 - nav.getBoundingClientRect().top);
+            if (navItemDistance < minTopNavItemDistance) {
+                minTopNavItemDistance = navItemDistance;
+                sideBar.classList.toggle('small-thumbnails');
+                nav.scrollIntoView();
+                break;
+            }
+        }
     }
 
     setupControlPanelToggleButton() {
@@ -109,23 +151,6 @@ class SideBar extends TypedComponent {
         if (!sideBar) {
             return;
         }
-        this.state.observer.on('largeThumbnails:set', () => {
-            let minTopNavItemDistance = Number.MAX_VALUE;
-
-            const navItems = /** @type {NodeListOf<HTMLElement>} */ (
-                /** @type {unknown} */ (document.querySelectorAll('.nav-item'))
-            );
-            for (let i = 0; i < navItems.length; i++) {
-                const nav = navItems[i];
-                const navItemDistance = Math.abs(120 - nav.getBoundingClientRect().top);
-                if (navItemDistance < minTopNavItemDistance) {
-                    minTopNavItemDistance = navItemDistance;
-                    sideBar.classList.toggle('small-thumbnails');
-                    nav.scrollIntoView();
-                    break;
-                }
-            }
-        });
         sideBar.classList.add('visible');
         // when first opening the examples browser via a specific example, scroll it into view
         // @ts-ignore
@@ -199,10 +224,6 @@ class SideBar extends TypedComponent {
     }
 
     clearFilter() {
-        const input = document.querySelector('.filter-input input');
-        if (input) {
-            /** @type {HTMLInputElement} */ (/** @type {unknown} */ (input)).value = '';
-        }
         this.onChangeFilter('');
     }
 
@@ -215,6 +236,9 @@ class SideBar extends TypedComponent {
             iframe.fire('hotReload');
         } else {
             iframe.fire('destroy');
+        }
+        if (this.props.orientation === 'portrait') {
+            this.props.setMobilePanel?.(null);
         }
     }
 
@@ -283,7 +307,8 @@ class SideBar extends TypedComponent {
     }
 
     render() {
-        const { observer, collapsed, orientation } = this.state;
+        const { observer, collapsed } = this.state;
+        const orientation = this.props.orientation ?? this.state.orientation;
         const panelOptions = {
             headerText: `EXAMPLES - v${VERSION}`,
             collapsible: true,
@@ -292,13 +317,22 @@ class SideBar extends TypedComponent {
             class: ['small-thumbnails', ...(collapsed ? ['collapsed'] : [])]
         };
         if (orientation === 'portrait') {
-            panelOptions.class = ['small-thumbnails'];
-            panelOptions.collapsed = collapsed;
+            if (this.props.mobilePanel !== 'examples') {
+                return null;
+            }
+            panelOptions.headerText = `EXAMPLES - v${VERSION}`;
+            panelOptions.class = ['mobile-sheet', 'small-thumbnails'];
+            panelOptions.collapsible = false;
+            panelOptions.collapsed = false;
         }
         return jsx(
             Panel,
             // @ts-ignore
             panelOptions,
+            orientation === 'portrait' && jsx('div', {
+                className: 'mobile-resize-handle',
+                onPointerDown: this.props.onMobilePanelDragStart
+            }),
             jsx(
                 Container,
                 { class: ['filter-container', ...(this.state.filterText ? ['has-filter-text'] : [])] },
@@ -306,6 +340,7 @@ class SideBar extends TypedComponent {
                     class: 'filter-input',
                     keyChange: true,
                     placeholder: 'Filter...',
+                    value: this.state.filterText,
                     onChange: this.onChangeFilter.bind(this)
                 }),
                 this.state.filterText ? jsx(
@@ -317,7 +352,7 @@ class SideBar extends TypedComponent {
                     '\u2715'
                 ) : null
             ),
-            jsx(
+            orientation !== 'portrait' && jsx(
                 LabelGroup,
                 { text: 'Large thumbnails:' },
                 jsx(BooleanInput, {
@@ -332,12 +367,12 @@ class SideBar extends TypedComponent {
 }
 
 /**
- * Wrapper component to provide router location to the class component.
+ * @param {Omit<Props, 'location'>} props - Component properties.
  * @returns {ReactElement} The SideBar component with router location.
  */
-function SideBarWithRouter() {
+function SideBarWithRouter(props) {
     const location = useLocation();
-    return jsx(SideBar, { location });
+    return jsx(SideBar, { ...props, location });
 }
 
 export { SideBarWithRouter as SideBar };

--- a/examples/src/app/components/Sidebar.mjs
+++ b/examples/src/app/components/Sidebar.mjs
@@ -18,7 +18,7 @@ import { getOrientation } from '../utils.mjs';
  * @property {'portrait'|'landscape'} [orientation] - Current orientation.
  * @property {null|'examples'|'code'|'controls'|'description'} [mobilePanel] - Active mobile panel.
  * @property {(mobilePanel: null|'examples'|'code'|'controls'|'description') => void} [setMobilePanel] - Set active mobile panel.
- * @property {(event: import('react').PointerEvent<HTMLElement>) => void} [onMobilePanelDragStart] - Start mobile panel drag.
+ * @property {(event: PointerEvent | import('react').PointerEvent<HTMLElement>) => void} [onMobilePanelDragStart] - Start mobile panel drag.
  */
 
 /**
@@ -102,7 +102,9 @@ class SideBar extends TypedComponent {
             /** @type {unknown} */ (sideBar.querySelector('.pcui-panel-header'))
         );
         if (sideBarHeader) {
+            const drag = this.props.onMobilePanelDragStart;
             sideBarHeader.onclick = orientation === 'portrait' ? null : () => this.toggleCollapse();
+            sideBarHeader.onpointerdown = orientation === 'portrait' && drag ? event => drag(event) : null;
         }
         this.setupControlPanelToggleButton();
     }
@@ -329,10 +331,6 @@ class SideBar extends TypedComponent {
             Panel,
             // @ts-ignore
             panelOptions,
-            orientation === 'portrait' && jsx('div', {
-                className: 'mobile-resize-handle',
-                onPointerDown: this.props.onMobilePanelDragStart
-            }),
             jsx(
                 Container,
                 { class: ['filter-container', ...(this.state.filterText ? ['has-filter-text'] : [])] },

--- a/examples/src/app/components/Sidebar.mjs
+++ b/examples/src/app/components/Sidebar.mjs
@@ -4,18 +4,18 @@ import { Component } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import { exampleMetaData } from '../../../cache/metadata.mjs';
-import { MIN_DESKTOP_WIDTH, VERSION } from '../constants.mjs';
+import { VERSION } from '../constants.mjs';
 import { iframe } from '../iframe.mjs';
 import { jsx } from '../jsx.mjs';
 import { thumbnailPath } from '../paths.mjs';
-import { getOrientation } from '../utils.mjs';
+import { getLayout } from '../utils.mjs';
 
 /** @import { ReactElement } from 'react' */
 
 /**
  * @typedef {object} Props
  * @property {{ pathname: string, hash: string }} location - The router location.
- * @property {'portrait'|'landscape'} [orientation] - Current orientation.
+ * @property {'mobile'|'desktop'} [layout] - Current layout.
  * @property {null|'examples'|'code'|'controls'|'description'} [mobilePanel] - Active mobile panel.
  * @property {(mobilePanel: null|'examples'|'code'|'controls'|'description') => void} [setMobilePanel] - Set active mobile panel.
  * @property {(event: PointerEvent | import('react').PointerEvent<HTMLElement>) => void} [onMobilePanelDragStart] - Start mobile panel drag.
@@ -28,7 +28,7 @@ import { getOrientation } from '../utils.mjs';
  * @property {Observer} observer - The observer.
  * @property {boolean} collapsed - Collapsed or not.
  * @property {string} filterText - The current filter.
- * @property {string} orientation - Current orientation.
+ * @property {'mobile'|'desktop'} layout - Current layout.
  */
 
 /**
@@ -67,16 +67,15 @@ class SideBar extends TypedComponent {
         filteredCategories: null,
         filterText: '',
         observer: new Observer({ largeThumbnails: false }),
-        // @ts-ignore
-        collapsed: localStorage.getItem('sideBarCollapsed') === 'true' || window.top.innerWidth < MIN_DESKTOP_WIDTH,
-        orientation: getOrientation()
+        collapsed: localStorage.getItem('sideBarCollapsed') === 'true' || getLayout() === 'mobile',
+        layout: getLayout()
     };
 
     /** @type {HTMLElement | null} */
     _sideBar = null;
 
     /** @type {string} */
-    _sideBarOrientation = '';
+    _sideBarLayout = '';
 
     /**
      * @param {Props} props - Component properties.
@@ -90,12 +89,12 @@ class SideBar extends TypedComponent {
 
     setupSideBar() {
         const sideBar = document.getElementById('sideBar');
-        const orientation = this.props.orientation ?? this.state.orientation;
-        if (!sideBar || (this._sideBar === sideBar && this._sideBarOrientation === orientation)) {
+        const layout = this.props.layout ?? this.state.layout;
+        if (!sideBar || (this._sideBar === sideBar && this._sideBarLayout === layout)) {
             return;
         }
         this._sideBar = sideBar;
-        this._sideBarOrientation = orientation;
+        this._sideBarLayout = layout;
 
         // PCUI should just have a "onHeaderClick" but can't find anything
         const sideBarHeader = /** @type {HTMLElement | null} */ (
@@ -103,8 +102,8 @@ class SideBar extends TypedComponent {
         );
         if (sideBarHeader) {
             const drag = this.props.onMobilePanelDragStart;
-            sideBarHeader.onclick = orientation === 'portrait' ? null : () => this.toggleCollapse();
-            sideBarHeader.onpointerdown = orientation === 'portrait' && drag ? event => drag(event) : null;
+            sideBarHeader.onclick = layout === 'mobile' ? null : () => this.toggleCollapse();
+            sideBarHeader.onpointerdown = layout === 'mobile' && drag ? event => drag(event) : null;
         }
         this.setupControlPanelToggleButton();
     }
@@ -180,7 +179,7 @@ class SideBar extends TypedComponent {
     }
 
     _onLayoutChange() {
-        this.mergeState({ orientation: getOrientation() });
+        this.mergeState({ layout: getLayout() });
     }
 
     /**
@@ -307,7 +306,7 @@ class SideBar extends TypedComponent {
 
     render() {
         const { observer, collapsed } = this.state;
-        const orientation = this.props.orientation ?? this.state.orientation;
+        const layout = this.props.layout ?? this.state.layout;
         const panelOptions = {
             headerText: `EXAMPLES - v${VERSION}`,
             collapsible: true,
@@ -315,7 +314,7 @@ class SideBar extends TypedComponent {
             id: 'sideBar',
             class: ['small-thumbnails', ...(collapsed ? ['collapsed'] : [])]
         };
-        if (orientation === 'portrait') {
+        if (layout === 'mobile') {
             if (this.props.mobilePanel !== 'examples') {
                 return null;
             }
@@ -347,7 +346,7 @@ class SideBar extends TypedComponent {
                     '\u2715'
                 ) : null
             ),
-            orientation !== 'portrait' && jsx(
+            layout !== 'mobile' && jsx(
                 LabelGroup,
                 { text: 'Large thumbnails:' },
                 jsx(BooleanInput, {

--- a/examples/src/app/components/Sidebar.mjs
+++ b/examples/src/app/components/Sidebar.mjs
@@ -239,9 +239,6 @@ class SideBar extends TypedComponent {
         } else {
             iframe.fire('destroy');
         }
-        if (this.props.orientation === 'portrait') {
-            this.props.setMobilePanel?.(null);
-        }
     }
 
     renderContents() {

--- a/examples/src/app/components/Sidebar.mjs
+++ b/examples/src/app/components/Sidebar.mjs
@@ -95,15 +95,16 @@ class SideBar extends TypedComponent {
         }
         this._sideBar = sideBar;
         this._sideBarLayout = layout;
+        const drag = this.props.onMobilePanelDragStart;
+        sideBar.onpointerdown = layout === 'mobile' && drag ? event => drag(event) : null;
 
         // PCUI should just have a "onHeaderClick" but can't find anything
         const sideBarHeader = /** @type {HTMLElement | null} */ (
             /** @type {unknown} */ (sideBar.querySelector('.pcui-panel-header'))
         );
         if (sideBarHeader) {
-            const drag = this.props.onMobilePanelDragStart;
             sideBarHeader.onclick = layout === 'mobile' ? null : () => this.toggleCollapse();
-            sideBarHeader.onpointerdown = layout === 'mobile' && drag ? event => drag(event) : null;
+            sideBarHeader.onpointerdown = null;
         }
         this.setupControlPanelToggleButton();
     }

--- a/examples/src/app/components/code-editor/CodeEditorMobile.mjs
+++ b/examples/src/app/components/code-editor/CodeEditorMobile.mjs
@@ -1,12 +1,38 @@
-import MonacoEditor from '@monaco-editor/react';
+import { Button, Container } from '@playcanvas/pcui/react';
 
 import { CodeEditorBase } from './CodeEditorBase.mjs';
 import { jsx } from '../../jsx.mjs';
 
+/**
+ * @typedef {object} Props
+ * @property {Record<string, string>} files - Files of example.
+ * @property {string} category - Example category.
+ * @property {string} example - Example name.
+ */
+
+const GITHUB_ROOT = 'https://github.com/playcanvas/engine/blob/main';
 
 /**
- * @typedef {Record<string, any>} Props
+ * @param {string} example - Example name.
+ * @param {string} file - File suffix.
+ * @returns {string} Source file name.
  */
+const sourceName = (example, file) => `${example}.${file}`;
+
+/**
+ * @param {string} category - Example category.
+ * @param {string} example - Example name.
+ * @param {string} file - File suffix.
+ * @returns {string} Source URL.
+ */
+const sourceUrl = (category, example, file) => `${GITHUB_ROOT}/examples/src/examples/${category}/${sourceName(example, file)}`;
+
+/**
+ * @param {string} file - File suffix.
+ * @param {string} source - File source.
+ * @returns {boolean} True if the file is the empty controls template.
+ */
+const isDefaultControls = (file, source) => file === 'controls.mjs' && /\breturn\s+fragment\(\s*\)\s*;/.test(source);
 
 class CodeEditorMobile extends CodeEditorBase {
     /**
@@ -20,23 +46,27 @@ class CodeEditorMobile extends CodeEditorBase {
     }
 
     render() {
-        const { files, selectedFile, showMinimap } = this.state;
-        const options = {
-            className: 'code-editor-mobile',
-            value: files[selectedFile],
-            language: 'javascript',
-            beforeMount: this.beforeMount.bind(this),
-            onMount: this.editorDidMount.bind(this),
-            options: {
-                theme: 'playcanvas',
-                readOnly: true,
-                minimap: {
-                    enabled: showMinimap
-                }
-            }
-        };
+        const { category, example } = this.props;
+        const files = this.props.files ?? this.state.files;
+        const names = Object.keys(files).filter(name => !isDefaultControls(name, files[name]));
 
-        return jsx(MonacoEditor, options);
+        return jsx(
+            Container,
+            {
+                class: 'code-editor-mobile'
+            },
+            jsx(
+                Container,
+                {
+                    class: 'code-editor-mobile-files'
+                },
+                names.map(name => jsx(Button, {
+                    key: name,
+                    text: name,
+                    onClick: () => window.open(sourceUrl(category, example, name))
+                }))
+            )
+        );
     }
 }
 

--- a/examples/src/app/index.mjs
+++ b/examples/src/app/index.mjs
@@ -2,6 +2,7 @@ import { createRoot } from 'react-dom/client';
 
 import { MainLayout } from './components/MainLayout.mjs';
 import { jsx } from './jsx.mjs';
+import { blockZoom } from '../../iframe/zoom.mjs';
 
 
 import '@playcanvas/pcui/styles';
@@ -11,6 +12,8 @@ if (process.env.NODE_ENV === 'development' && import.meta.hot) {
 }
 
 function main() {
+    blockZoom();
+
     // render out the app
     const container = document.getElementById('app');
     if (!container) {

--- a/examples/src/app/types.d.ts
+++ b/examples/src/app/types.d.ts
@@ -46,6 +46,7 @@ declare module '*.txt' {
 declare global {
     interface Window {
         _scrolledToExample?: boolean;
+        activeGraphicsDevice?: string;
         editor?: editor.IStandaloneCodeEditor;
         monaco: typeof monaco;
         preferredGraphicsDevice?: string;

--- a/examples/src/app/utils.mjs
+++ b/examples/src/app/utils.mjs
@@ -1,10 +1,16 @@
 import { MIN_DESKTOP_WIDTH } from './constants.mjs';
 
 /**
- * @returns {'portrait'|'landscape'} Orientation, which is either 'portrait' (width < 601 px) or
- * 'landscape' (every width >= 601, not aspect related)
+ * @typedef {'mobile'|'desktop'} Layout
  */
-// @ts-ignore
-const getOrientation = () => (window.top.innerWidth < MIN_DESKTOP_WIDTH ? 'portrait' : 'landscape');
 
-export { getOrientation };
+/**
+ * @returns {Layout} The app layout.
+ */
+const getLayout = () => {
+    const win = window.top ?? window;
+    const touch = window.matchMedia('(pointer: coarse)').matches || navigator.maxTouchPoints > 0;
+    return win.innerWidth < MIN_DESKTOP_WIDTH || (touch && win.innerHeight < MIN_DESKTOP_WIDTH) ? 'mobile' : 'desktop';
+};
+
+export { getLayout };

--- a/examples/src/examples/animation/blend-trees-2d-cartesian.controls.mjs
+++ b/examples/src/examples/animation/blend-trees-2d-cartesian.controls.mjs
@@ -12,8 +12,17 @@ export const controls = ({ observer, React, jsx, fragment }) => {
         /** @type {React.RefObject<HTMLCanvasElement>} */
         refCanvas = createRef();
 
+        mouse = this.mouseEvent.bind(this);
+
+        draw = this.drawPosition.bind(this);
+
+        evt = null;
+
         mouseEvent(e) {
             const { position, width, canvas } = this;
+            if (!canvas || !width) {
+                return;
+            }
             if (e.targetTouches) {
                 const offset = canvas.getBoundingClientRect();
                 position
@@ -40,7 +49,8 @@ export const controls = ({ observer, React, jsx, fragment }) => {
 
         /** @type {number} */
         get width() {
-            return window.top.controlPanel.offsetWidth;
+            const panel = /** @type {HTMLElement | null} */ (this.canvas?.closest('#controlPanel') ?? null);
+            return panel?.offsetWidth ?? this.canvas?.parentElement?.offsetWidth ?? 0;
         }
 
         /** @type {number} */
@@ -50,13 +60,16 @@ export const controls = ({ observer, React, jsx, fragment }) => {
 
         drawPosition() {
             const { canvas, width, height } = this;
-            if (!canvas) {
+            if (!canvas || !width || !height) {
                 return;
             }
             const animPoints = observer.get('data.animPoints') || [];
             const pos = observer.get('data.pos') || { x: 0, y: 0 };
 
             const ctx = canvas.getContext('2d');
+            if (!ctx) {
+                return;
+            }
             const halfWidth = Math.floor(width / 2);
             const halfHeight = Math.floor(height / 2);
             ctx.clearRect(0, 0, width, height);
@@ -101,19 +114,36 @@ export const controls = ({ observer, React, jsx, fragment }) => {
         }
 
         componentDidMount() {
-            const { canvas } = this;
-            canvas.addEventListener('mousemove', this.mouseEvent.bind(this));
-            canvas.addEventListener('mousedown', this.mouseEvent.bind(this));
-            canvas.addEventListener('touchmove', this.mouseEvent.bind(this));
-            canvas.addEventListener('touchstart', this.mouseEvent.bind(this));
+            const { canvas, width, height } = this;
+            if (!canvas || !width || !height) {
+                return;
+            }
 
-            // @ts-ignore engine-tsd
-            const dim = `${window.top.controlPanel.offsetWidth}px`;
+            canvas.addEventListener('mousemove', this.mouse);
+            canvas.addEventListener('mousedown', this.mouse);
+            canvas.addEventListener('touchmove', this.mouse);
+            canvas.addEventListener('touchstart', this.mouse);
+
+            const dim = `${width}px`;
             canvas.setAttribute('style', `width: ${dim}; height: ${dim};`);
-            canvas.setAttribute('width', dim);
-            canvas.setAttribute('height', dim);
+            canvas.width = width;
+            canvas.height = height;
+            this.drawPosition();
 
-            observer.on('*:set', this.drawPosition.bind(this));
+            this.evt = observer.on('*:set', this.draw);
+        }
+
+        componentWillUnmount() {
+            const { canvas } = this;
+            if (canvas) {
+                canvas.removeEventListener('mousemove', this.mouse);
+                canvas.removeEventListener('mousedown', this.mouse);
+                canvas.removeEventListener('touchmove', this.mouse);
+                canvas.removeEventListener('touchstart', this.mouse);
+            }
+
+            this.evt?.unbind();
+            this.evt = null;
         }
 
         render() {

--- a/examples/src/static/index.html
+++ b/examples/src/static/index.html
@@ -5,7 +5,7 @@
     <meta name="description" content="">
     <meta name="keywords" content="PlayCanvas">
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <link rel="icon" type="image/png" href="./playcanvas-logo.png" />
     <link rel="stylesheet" href="styles.css">
 </head>

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -20,6 +20,7 @@ body {
     --mobile-handle-hit-height: 44px;
     --mobile-handle-hit-width: 96px;
     --mobile-panel-height: clamp(300px, 48svh, 440px);
+    --mobile-panel-width: clamp(320px, 42vw, 420px);
     --mobile-radius: 6px;
 }
 
@@ -356,12 +357,18 @@ body {
     height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
 }
 
-#appInner.mobile #canvas-container.mobile-panel-open iframe {
+#appInner.mobile-portrait #canvas-container.mobile-panel-open iframe {
     height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
 }
 
-#appInner.mobile #canvas-container.mobile-panel-open #exampleLoading {
+#appInner.mobile-portrait #canvas-container.mobile-panel-open #exampleLoading {
     height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
+}
+
+#appInner.mobile-landscape #canvas-container.mobile-panel-open iframe,
+#appInner.mobile-landscape #canvas-container.mobile-panel-open #exampleLoading {
+    width: calc(100vw - var(--mobile-panel-width) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap));
+    height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
 }
 
 @keyframes animation-spin {
@@ -449,6 +456,36 @@ body {
 #controlPanel.mobile.code-sheet,
 #controlPanel.mobile.description-sheet {
     height: var(--mobile-panel-height);
+}
+
+#appInner.mobile-landscape #controlPanel.mobile,
+#appInner.mobile-landscape #sideBar.mobile-sheet {
+    width: var(--mobile-panel-width);
+    min-width: 0;
+    max-width: var(--mobile-panel-width);
+    height: auto;
+    box-sizing: border-box;
+    touch-action: none;
+}
+
+#appInner.mobile-landscape #controlPanel.mobile {
+    top: 0;
+    right: 0;
+    bottom: calc(var(--mobile-dock-height) + var(--mobile-gap) + env(safe-area-inset-bottom));
+    left: auto;
+}
+
+#appInner.mobile-landscape #sideBar.mobile-sheet {
+    top: var(--mobile-gap);
+    right: var(--mobile-gap);
+    bottom: calc(var(--mobile-dock-height) + var(--mobile-gap) + var(--mobile-gap) + env(safe-area-inset-bottom));
+    left: auto;
+}
+
+#appInner.mobile-landscape #controlPanel.mobile.controls-sheet,
+#appInner.mobile-landscape #controlPanel.mobile.code-sheet,
+#appInner.mobile-landscape #controlPanel.mobile.description-sheet {
+    height: auto;
 }
 
 #controlPanel.mobile > .pcui-panel-content {
@@ -887,8 +924,15 @@ body {
 }
 
 body.mobile-panel-resizing {
-    cursor: ns-resize;
     user-select: none;
+}
+
+body.mobile-panel-resizing-x {
+    cursor: ew-resize;
+}
+
+body.mobile-panel-resizing-y {
+    cursor: ns-resize;
 }
 
 body.mobile-panel-resizing #exampleIframe {
@@ -933,6 +977,53 @@ body.mobile-panel-resizing #exampleIframe {
 
 body.mobile-panel-resizing #appInner.mobile #controlPanel.mobile > .pcui-panel-header::after,
 body.mobile-panel-resizing #appInner.mobile #sideBar.mobile-sheet > .pcui-panel-header::after {
+    background-color: #fff;
+}
+
+#appInner.mobile-landscape #controlPanel.mobile > .pcui-panel-header,
+#appInner.mobile-landscape #sideBar.mobile-sheet > .pcui-panel-header {
+    cursor: default;
+}
+
+#appInner.mobile-landscape #controlPanel.mobile > .pcui-panel-header::before,
+#appInner.mobile-landscape #sideBar.mobile-sheet > .pcui-panel-header::before,
+#appInner.mobile-landscape #controlPanel.mobile > .pcui-panel-header::after,
+#appInner.mobile-landscape #sideBar.mobile-sheet > .pcui-panel-header::after {
+    display: none;
+}
+
+#appInner.mobile-landscape #controlPanel.mobile::before,
+#appInner.mobile-landscape #sideBar.mobile-sheet::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: var(--mobile-handle-hit-height);
+    height: 100%;
+    background: transparent;
+    transform: translateX(-50%);
+    cursor: ew-resize;
+    pointer-events: auto;
+    z-index: 2;
+}
+
+#appInner.mobile-landscape #controlPanel.mobile::after,
+#appInner.mobile-landscape #sideBar.mobile-sheet::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    width: 4px;
+    height: 44px;
+    border-radius: 999px;
+    background-color: #8da0a5;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    z-index: 3;
+}
+
+body.mobile-panel-resizing #appInner.mobile-landscape #controlPanel.mobile::after,
+body.mobile-panel-resizing #appInner.mobile-landscape #sideBar.mobile-sheet::after {
     background-color: #fff;
 }
 
@@ -1133,11 +1224,13 @@ body.mobile-panel-resizing #appInner.mobile #sideBar.mobile-sheet > .pcui-panel-
 }
 
 #appInner.fullscreen #canvas-container iframe {
+    width: 100%;
     height: 100%;
 }
 
 #appInner.mobile.fullscreen #canvas-container iframe,
 #appInner.mobile.fullscreen #canvas-container #exampleLoading {
+    width: 100%;
     height: 100%;
 }
 

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 
 :root {
     --mobile-dock-height: 48px;
+    --mobile-dock-width: 48px;
     --mobile-gap: 8px;
     --mobile-handle-hit-height: 44px;
     --mobile-handle-hit-width: 96px;
@@ -357,6 +358,12 @@ body {
     height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
 }
 
+#appInner.mobile-landscape #canvas-container iframe,
+#appInner.mobile-landscape #exampleLoading {
+    width: calc(100vw - var(--mobile-dock-width) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap));
+    height: calc(100dvh - var(--mobile-gap) - var(--mobile-gap));
+}
+
 #appInner.mobile-portrait #canvas-container.mobile-panel-open iframe {
     height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
 }
@@ -367,8 +374,8 @@ body {
 
 #appInner.mobile-landscape #canvas-container.mobile-panel-open iframe,
 #appInner.mobile-landscape #canvas-container.mobile-panel-open #exampleLoading {
-    width: calc(100vw - var(--mobile-panel-width) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap));
-    height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
+    width: calc(100vw - var(--mobile-panel-width) - var(--mobile-dock-width) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap));
+    height: calc(100dvh - var(--mobile-gap) - var(--mobile-gap));
 }
 
 @keyframes animation-spin {
@@ -463,6 +470,7 @@ body {
     width: var(--mobile-panel-width);
     min-width: 0;
     max-width: var(--mobile-panel-width);
+    max-height: none;
     height: auto;
     box-sizing: border-box;
     touch-action: none;
@@ -470,15 +478,15 @@ body {
 
 #appInner.mobile-landscape #controlPanel.mobile {
     top: 0;
-    right: 0;
-    bottom: calc(var(--mobile-dock-height) + var(--mobile-gap) + env(safe-area-inset-bottom));
+    right: calc(var(--mobile-dock-width) + var(--mobile-gap));
+    bottom: 0;
     left: auto;
 }
 
 #appInner.mobile-landscape #sideBar.mobile-sheet {
     top: var(--mobile-gap);
-    right: var(--mobile-gap);
-    bottom: calc(var(--mobile-dock-height) + var(--mobile-gap) + var(--mobile-gap) + env(safe-area-inset-bottom));
+    right: calc(var(--mobile-dock-width) + var(--mobile-gap) + var(--mobile-gap));
+    bottom: var(--mobile-gap);
     left: auto;
 }
 
@@ -1044,6 +1052,18 @@ body.mobile-panel-resizing #appInner.mobile-landscape #sideBar.mobile-sheet::aft
     border-radius: var(--mobile-radius);
     z-index: 100000;
     -webkit-tap-highlight-color: transparent;
+}
+
+#appInner.mobile-landscape #mobileDock {
+    left: auto;
+    right: var(--mobile-gap);
+    top: var(--mobile-gap);
+    bottom: var(--mobile-gap);
+    width: var(--mobile-dock-width);
+    height: auto;
+    flex-direction: column;
+    gap: clamp(16px, 5dvh, 28px);
+    padding: 8px 4px;
 }
 
 #appInner.mobile #mobileDock .mobile-dock-button {

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -15,7 +15,9 @@ body {
 
 :root {
     --mobile-dock-height: 48px;
+    --mobile-gap: 8px;
     --mobile-panel-height: clamp(300px, 48svh, 440px);
+    --mobile-radius: 6px;
 }
 
 #app {
@@ -70,16 +72,16 @@ body {
     #sideBar {
         margin: 0;
         position: fixed;
-        left: 0;
-        right: 0;
-        bottom: calc(var(--mobile-dock-height) + env(safe-area-inset-bottom));
+        left: var(--mobile-gap);
+        right: var(--mobile-gap);
+        bottom: calc(var(--mobile-dock-height) + var(--mobile-gap) + var(--mobile-gap) + env(safe-area-inset-bottom));
         z-index: 99999;
-        width: 100%;
+        width: auto;
         height: var(--mobile-panel-height);
         min-width: 0;
         max-width: none;
         max-height: none;
-        border-radius: 0;
+        border-radius: var(--mobile-radius);
     }
 
     #sideBar .panel-toggle {
@@ -126,18 +128,18 @@ body {
 @media only screen and (max-width: 600px) {
     #sideBar > .pcui-panel-content {
         height: calc(100% - 32px);
-        background-color: rgba(54, 67, 70, 1);
+        background-color: #283437;
         margin-top: 0px;
     }
     #sideBar {
-        background-color: rgba(54, 67, 70, 1);
+        background-color: #283437;
     }
     #sideBar > .pcui-panel-header {
-        border-radius: 0 !important;
+        border-radius: var(--mobile-radius) var(--mobile-radius) 0 0 !important;
     }
 
     #sideBar.pcui-collapsed > .pcui-panel-header {
-        border-radius: 0 !important;
+        border-radius: var(--mobile-radius) !important;
     }
 
     #sideBar-contents {
@@ -298,17 +300,19 @@ body {
 
 @media only screen and (max-width: 600px) {
     #canvas-container {
-        margin: 0px;
-        border-radius: 0px;
-        height: 100dvh;
+        margin: var(--mobile-gap);
+        border-radius: var(--mobile-radius);
+        height: calc(100dvh - var(--mobile-gap) - var(--mobile-gap));
+        background-color: #171E20;
     }
 
     #canvas-container iframe {
-        height: calc(100dvh - var(--mobile-dock-height) - env(safe-area-inset-bottom));
+        border-radius: var(--mobile-radius);
+        height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
     }
 
     #canvas-container.mobile-panel-open iframe {
-        height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - env(safe-area-inset-bottom));
+        height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
     }
 }
 
@@ -382,16 +386,17 @@ body {
 
 /* @media only screen and (max-width: 600px) { */
 #controlPanel.mobile {
-    bottom: calc(var(--mobile-dock-height) + env(safe-area-inset-bottom));
+    bottom: calc(var(--mobile-dock-height) + var(--mobile-gap) + env(safe-area-inset-bottom));
     left: 0;
     right: 0;
-    width: 100%;
+    width: auto;
     top: inherit;
     display: flex;
     flex-direction: column;
-    background-color: rgba(54, 67, 70, 1);
+    background-color: rgba(54, 67, 70, 0.64);
+    backdrop-filter: blur(32px);
     min-height: 0;
-    border-radius: 0;
+    border-radius: var(--mobile-radius);
     overflow: visible;
 }
 
@@ -406,13 +411,14 @@ body {
     height: auto;
     min-height: 0;
     overflow: hidden;
+    border-radius: 0 0 var(--mobile-radius) var(--mobile-radius);
 }
 
 #controlPanel.mobile > .pcui-panel-header {
     flex: 0 0 32px;
     height: 32px !important;
     line-height: 32px !important;
-    border-radius: 0 !important;
+    border-radius: var(--mobile-radius) var(--mobile-radius) 0 0 !important;
 }
 
 #controlPanel.mobile.controls-sheet > .pcui-panel-content {
@@ -429,7 +435,7 @@ body {
 }
 
 #controlPanel.mobile > .pcui-panel-content > section {
-    border-radius: 6px;
+    border-radius: var(--mobile-radius);
 }
 /* } */
 
@@ -774,8 +780,10 @@ body {
 
 @media only screen and (max-width: 600px) {
     #menu {
-        top: 8px;
-        background-color: rgba(54, 67, 70, 1);
+        top: var(--mobile-gap);
+        margin-top: var(--mobile-gap);
+        margin-left: var(--mobile-gap);
+        background-color: rgba(54, 67, 70, 0.64);
     }
 
     #menu img {
@@ -838,13 +846,17 @@ body {
 
     .mobile-resize-handle {
         position: fixed;
-        left: 0;
-        right: 0;
-        bottom: calc(var(--mobile-dock-height) + var(--mobile-panel-height) + env(safe-area-inset-bottom) - 9px);
+        left: var(--mobile-gap);
+        right: var(--mobile-gap);
+        bottom: calc(var(--mobile-dock-height) + var(--mobile-panel-height) + var(--mobile-gap) + var(--mobile-gap) + env(safe-area-inset-bottom) - 9px);
         height: 18px;
         cursor: ns-resize;
         touch-action: none;
         z-index: 100001;
+    }
+
+    #mobileUi > .mobile-resize-handle {
+        bottom: calc(var(--mobile-dock-height) + var(--mobile-panel-height) + var(--mobile-gap) + env(safe-area-inset-bottom) - 9px);
     }
 
     .mobile-resize-handle::before {
@@ -865,14 +877,15 @@ body {
         justify-content: center;
         gap: clamp(28px, 10vw, 42px);
         position: fixed;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        height: calc(var(--mobile-dock-height) + env(safe-area-inset-bottom));
-        padding: 4px 8px calc(4px + env(safe-area-inset-bottom));
+        left: var(--mobile-gap);
+        right: var(--mobile-gap);
+        bottom: calc(var(--mobile-gap) + env(safe-area-inset-bottom));
+        height: var(--mobile-dock-height);
+        padding: 4px 8px;
         box-sizing: border-box;
-        background-color: #20292b;
-        border-top: 1px solid #4a5a5f;
+        background-color: rgba(54, 67, 70, 0.64);
+        backdrop-filter: blur(32px);
+        border-radius: var(--mobile-radius);
         z-index: 100000;
     }
 

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -305,6 +305,50 @@ body {
     touch-action: none;
 }
 
+#exampleLoading {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    height: 100%;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: 24px;
+    background-color: rgba(16, 21, 22, 0.88);
+    color: #f2f2f2;
+    text-align: center;
+    pointer-events: none;
+}
+
+.example-loading-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    max-width: min(320px, 100%);
+}
+
+.example-loading-title {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 18px;
+}
+
+.example-loading-message {
+    max-width: 100%;
+    color: #c8d0d2;
+    font-size: 12px;
+    line-height: 16px;
+    overflow-wrap: anywhere;
+}
+
+#exampleLoading.error .example-loading-title {
+    color: #ff6b6b;
+}
+
 @media only screen and (max-width: 600px) {
     #canvas-container {
         margin: var(--mobile-gap);
@@ -318,7 +362,16 @@ body {
         height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
     }
 
+    #exampleLoading {
+        border-radius: var(--mobile-radius);
+        height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
+    }
+
     #canvas-container.mobile-panel-open iframe {
+        height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
+    }
+
+    #canvas-container.mobile-panel-open #exampleLoading {
         height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
     }
 }

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -13,6 +13,11 @@ body {
     background-color: #171E20;
 }
 
+:root {
+    --mobile-dock-height: 48px;
+    --mobile-panel-height: clamp(300px, 48svh, 440px);
+}
+
 #app {
     display: flex;
 }
@@ -63,13 +68,18 @@ body {
 
 @media only screen and (max-width: 600px) {
     #sideBar {
-        /* display: none; */
-        margin: 8px;
+        margin: 0;
         position: fixed;
+        left: 0;
+        right: 0;
+        bottom: calc(var(--mobile-dock-height) + env(safe-area-inset-bottom));
         z-index: 99999;
-        max-height: calc(100% - 70px);
-        min-width: calc(50% - 12px);
-        max-width: calc(50% - 12px);
+        width: 100%;
+        height: var(--mobile-panel-height);
+        min-width: 0;
+        max-width: none;
+        max-height: none;
+        border-radius: 0;
     }
 
     #sideBar .panel-toggle {
@@ -115,35 +125,32 @@ body {
 
 @media only screen and (max-width: 600px) {
     #sideBar > .pcui-panel-content {
-        z-index: -1;
-        height: calc(100% - 48px);
+        height: calc(100% - 32px);
         background-color: rgba(54, 67, 70, 1);
         margin-top: 0px;
     }
     #sideBar {
-        background-color: rgba(1,1,1,0);
+        background-color: rgba(54, 67, 70, 1);
     }
     #sideBar > .pcui-panel-header {
-        border-top-left-radius: 6px !important;
-        border-top-right-radius: 6px !important;
+        border-radius: 0 !important;
     }
 
     #sideBar.pcui-collapsed > .pcui-panel-header {
-        border-radius: 6px !important;
+        border-radius: 0 !important;
     }
 
     #sideBar-contents {
-        height: calc(100% - 80px);
+        height: calc(100% - 56px);
         overflow-y: scroll;
-        margin-top: 0px;
-        position: absolute;
+        margin-top: 8px;
+        position: static;
         width: 100%;
-        max-height: 100%;
+        max-height: none;
     }
 
     #sideBar {
-        bottom: 0px;
-        min-height: calc(100% - 70px);
+        min-height: 0;
     }
 
     #sideBar.pcui-collapsed {
@@ -275,6 +282,7 @@ body {
     border-radius: 6px;
     overflow: hidden;
     flex-grow: 1;
+    position: relative;
 }
 @media only screen and (min-width: 601px) {
     #canvas-container {
@@ -292,6 +300,15 @@ body {
     #canvas-container {
         margin: 0px;
         border-radius: 0px;
+        height: 100dvh;
+    }
+
+    #canvas-container iframe {
+        height: calc(100dvh - var(--mobile-dock-height) - env(safe-area-inset-bottom));
+    }
+
+    #canvas-container.mobile-panel-open iframe {
+        height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - env(safe-area-inset-bottom));
     }
 }
 
@@ -365,28 +382,54 @@ body {
 
 /* @media only screen and (max-width: 600px) { */
 #controlPanel.mobile {
-    bottom: 48px;
-    left: 8px;
-    width: calc(100% - 16px);
+    bottom: calc(var(--mobile-dock-height) + env(safe-area-inset-bottom));
+    left: 0;
+    right: 0;
+    width: 100%;
     top: inherit;
+    display: flex;
+    flex-direction: column;
     background-color: rgba(54, 67, 70, 1);
-    min-height: calc(100% - 116px);
-}
-
-#controlPanel.mobile:has(#controlPanel-controls):not(.pcui-collapsed){
-    min-height: 300px;
-}
-
-#controlPanel.mobile.pcui-collapsed {
     min-height: 0;
+    border-radius: 0;
+    overflow: visible;
+}
+
+#controlPanel.mobile.controls-sheet,
+#controlPanel.mobile.code-sheet,
+#controlPanel.mobile.description-sheet {
+    height: var(--mobile-panel-height);
 }
 
 #controlPanel.mobile > .pcui-panel-content {
-    min-height: 100%;
+    flex: 1 1 auto;
+    height: auto;
+    min-height: 0;
+    overflow: hidden;
 }
+
+#controlPanel.mobile > .pcui-panel-header {
+    flex: 0 0 32px;
+    height: 32px !important;
+    line-height: 32px !important;
+    border-radius: 0 !important;
+}
+
+#controlPanel.mobile.controls-sheet > .pcui-panel-content {
+    display: flex;
+    flex-direction: column;
+    overflow: visible;
+}
+
+#mobileControlsPanel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
 #controlPanel.mobile > .pcui-panel-content > section {
     border-radius: 6px;
-    position: absolute !important;
 }
 /* } */
 
@@ -468,18 +511,68 @@ body {
     }
 
     #controlPanel-controls {
-        height: calc(100% - 48px);
+        min-height: 0;
+        overflow: auto;
+    }
+
+    #controlPanel.mobile.controls-sheet #controlPanel-scroll-region {
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow-y: auto;
+    }
+
+    #controlPanel.mobile.code-sheet > .pcui-panel-content,
+    #controlPanel.mobile.description-sheet > .pcui-panel-content {
         overflow: auto;
     }
 
     .code-editor-mobile {
-        height: calc(100% - 48px);
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
     }
+
+    .code-editor-mobile-files {
+        display: flex;
+        flex-direction: column;
+        flex: 0 0 auto;
+        overflow-y: auto;
+    }
+
+    .code-editor-mobile-files .pcui-button {
+        flex: 0 0 44px;
+        margin: 0;
+        padding: 0 12px;
+        width: 100%;
+        height: 44px;
+        border: 0;
+        border-bottom: 1px solid #4a5a5f;
+        border-radius: 0;
+        text-align: left;
+        font-family: inconsolatamedium, Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+        font-size: 12px;
+        background-color: transparent;
+    }
+
+    .code-editor-mobile-files .pcui-button:not(.pcui-disabled, .pcui-readonly):hover,
+    .code-editor-mobile-files .pcui-button:not(.pcui-disabled, .pcui-readonly):focus,
+    .code-editor-mobile-files .pcui-button:not(.pcui-disabled, .pcui-readonly):active {
+        background-color: transparent;
+        box-shadow: none;
+    }
+
 }
 
 #deviceTypeSelectInput {
+    flex: 0 0 32px;
+    height: 32px;
     margin: 8px;
     min-width: 200px;
+}
+
+#deviceTypeSelectInput > .pcui-select-input-container-value {
+    height: 32px;
 }
 
 #deviceTypeSelectInput > .pcui-select-input-container-value > .pcui-select-input-value {
@@ -725,6 +818,164 @@ body {
     background-color: #F60;
 }
 
+#mobileDock {
+    display: none;
+}
+
+#mobileUi {
+    display: contents;
+}
+
+@media only screen and (max-width: 600px) {
+    body.mobile-panel-resizing {
+        cursor: ns-resize;
+        user-select: none;
+    }
+
+    body.mobile-panel-resizing #exampleIframe {
+        pointer-events: none;
+    }
+
+    .mobile-resize-handle {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: calc(var(--mobile-dock-height) + var(--mobile-panel-height) + env(safe-area-inset-bottom) - 9px);
+        height: 18px;
+        cursor: ns-resize;
+        touch-action: none;
+        z-index: 100001;
+    }
+
+    .mobile-resize-handle::before {
+        content: '';
+        position: absolute;
+        left: 50%;
+        top: 7px;
+        width: 44px;
+        height: 4px;
+        border-radius: 999px;
+        background-color: #8da0a5;
+        transform: translateX(-50%);
+    }
+
+    #mobileDock {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: clamp(28px, 10vw, 42px);
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: calc(var(--mobile-dock-height) + env(safe-area-inset-bottom));
+        padding: 4px 8px calc(4px + env(safe-area-inset-bottom));
+        box-sizing: border-box;
+        background-color: #20292b;
+        border-top: 1px solid #4a5a5f;
+        z-index: 100000;
+    }
+
+    #mobileDock .mobile-dock-button {
+        --mobile-dock-icon-size: 22px;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex: 0 0 40px;
+        width: 40px;
+        height: 40px;
+        min-width: 0;
+        margin: 0;
+        padding: 0;
+        border: 0;
+        border-radius: 0;
+        color: #b1b8ba;
+        background: transparent;
+        box-shadow: none !important;
+        font-size: 0;
+        outline: 0;
+        -webkit-appearance: none;
+        appearance: none;
+        overflow: hidden;
+    }
+
+    #mobileDock .mobile-dock-button::before {
+        content: '';
+        display: block;
+        width: var(--mobile-dock-icon-size);
+        height: var(--mobile-dock-icon-size);
+        background-color: currentColor;
+        mask: var(--mobile-dock-icon) center / var(--mobile-dock-icon-size) var(--mobile-dock-icon-size) no-repeat;
+        -webkit-mask: var(--mobile-dock-icon) center / var(--mobile-dock-icon-size) var(--mobile-dock-icon-size) no-repeat;
+    }
+
+    #mobileDock .mobile-dock-button:hover,
+    #mobileDock .mobile-dock-button:focus,
+    #mobileDock .mobile-dock-button:active {
+        border: 0;
+        color: #f2f2f2;
+        background: transparent;
+        box-shadow: none !important;
+        outline: 0;
+    }
+
+    #mobileDock .mobile-dock-button.pcui-disabled,
+    #mobileDock .mobile-dock-button.pcui-disabled:hover,
+    #mobileDock .mobile-dock-button.pcui-disabled:focus,
+    #mobileDock .mobile-dock-button.pcui-disabled:active {
+        color: #b1b8ba;
+        cursor: default;
+        background: transparent;
+        box-shadow: none !important;
+    }
+
+    #mobileDock .mobile-dock-button.selected,
+    #mobileDock .mobile-dock-button.selected:hover,
+    #mobileDock .mobile-dock-button.selected:focus,
+    #mobileDock .mobile-dock-button.selected:active {
+        border: 0;
+        color: #F60 !important;
+        background: transparent !important;
+    }
+
+    #mobileDock .mobile-dock-button.selected::before {
+        background-color: #F60;
+    }
+
+    #mobileDock .mobile-dock-examples {
+        --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z'/%3E%3C/svg%3E");
+    }
+
+    #mobileDock .mobile-dock-code {
+        --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m16 18 6-6-6-6M8 6l-6 6 6 6'/%3E%3C/svg%3E");
+    }
+
+    #mobileDock .mobile-dock-controls {
+        --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 7h8M16 7h4M4 17h4M12 17h8'/%3E%3Ccircle cx='14' cy='7' r='2' fill='black'/%3E%3Ccircle cx='10' cy='17' r='2' fill='black'/%3E%3C/svg%3E");
+    }
+
+    #mobileDock .mobile-dock-description {
+        --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='9'/%3E%3Cpath d='M12 11v6M12 7h.01'/%3E%3C/svg%3E");
+    }
+}
+
+#mobileDescriptionPanel {
+    box-sizing: border-box;
+    height: 100%;
+    padding: 12px;
+    color: #f2f2f2;
+    line-height: 1.45;
+}
+
+#controlPanel.mobile.description-sheet,
+#controlPanel.mobile.description-sheet > .pcui-panel-content,
+#mobileDescriptionPanel,
+#mobileDescriptionPanel *,
+#mobileDescriptionPanel a {
+    color: #f2f2f2;
+}
+
 .tabs-wrapper {
     display: flex;
 }
@@ -797,6 +1048,10 @@ body {
     margin: 0;
 }
 
+#appInner.fullscreen #canvas-container iframe {
+    height: 100%;
+}
+
 #appInner.fullscreen #menu {
     opacity: 0;
 }
@@ -816,6 +1071,10 @@ body {
 }
 
 #appInner.fullscreen #controlPanel, #appInner.fullscreen #sideBar {
+    display: none;
+}
+
+#appInner.fullscreen #mobileDock {
     display: none;
 }
 

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -17,6 +17,8 @@ body {
 :root {
     --mobile-dock-height: 48px;
     --mobile-gap: 8px;
+    --mobile-handle-hit-height: 44px;
+    --mobile-handle-hit-width: 96px;
     --mobile-panel-height: clamp(300px, 48svh, 440px);
     --mobile-radius: 6px;
 }
@@ -83,6 +85,7 @@ body {
         max-width: none;
         max-height: none;
         border-radius: var(--mobile-radius);
+        overflow: visible;
     }
 
     #sideBar .panel-toggle {
@@ -131,6 +134,8 @@ body {
         height: calc(100% - 32px);
         background-color: #283437;
         margin-top: 0px;
+        border-radius: 0 0 var(--mobile-radius) var(--mobile-radius);
+        overflow: hidden;
     }
     #sideBar {
         background-color: #283437;
@@ -523,7 +528,8 @@ body {
     #menu,
     #mobileDock,
     #mobileDock .mobile-dock-button,
-    .mobile-resize-handle {
+    #controlPanel.mobile > .pcui-panel-header,
+    #sideBar.mobile-sheet > .pcui-panel-header {
         touch-action: none;
     }
 
@@ -861,31 +867,45 @@ body {
         pointer-events: none;
     }
 
-    .mobile-resize-handle {
-        position: fixed;
-        left: var(--mobile-gap);
-        right: var(--mobile-gap);
-        bottom: calc(var(--mobile-dock-height) + var(--mobile-panel-height) + var(--mobile-gap) + var(--mobile-gap) + env(safe-area-inset-bottom) - 9px);
-        height: 18px;
+    #controlPanel.mobile > .pcui-panel-header,
+    #sideBar.mobile-sheet > .pcui-panel-header {
+        position: relative;
         cursor: ns-resize;
         touch-action: none;
-        z-index: 100001;
+        user-select: none;
+        overflow: visible;
     }
 
-    #mobileUi > .mobile-resize-handle {
-        bottom: calc(var(--mobile-dock-height) + var(--mobile-panel-height) + var(--mobile-gap) + env(safe-area-inset-bottom) - 1px);
-    }
-
-    .mobile-resize-handle::before {
+    #controlPanel.mobile > .pcui-panel-header::before,
+    #sideBar.mobile-sheet > .pcui-panel-header::before {
         content: '';
         position: absolute;
         left: 50%;
-        top: 7px;
+        top: 0;
+        width: var(--mobile-handle-hit-width);
+        height: var(--mobile-handle-hit-height);
+        background: transparent;
+        transform: translate(-50%, -50%);
+        pointer-events: auto;
+    }
+
+    #controlPanel.mobile > .pcui-panel-header::after,
+    #sideBar.mobile-sheet > .pcui-panel-header::after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        top: 0;
         width: 44px;
         height: 4px;
         border-radius: 999px;
         background-color: #8da0a5;
-        transform: translateX(-50%);
+        transform: translate(-50%, -50%);
+        pointer-events: none;
+    }
+
+    body.mobile-panel-resizing #controlPanel.mobile > .pcui-panel-header::after,
+    body.mobile-panel-resizing #sideBar.mobile-sheet > .pcui-panel-header::after {
+        background-color: #fff;
     }
 
     #mobileDock {
@@ -904,6 +924,7 @@ body {
         backdrop-filter: blur(32px);
         border-radius: var(--mobile-radius);
         z-index: 100000;
+        -webkit-tap-highlight-color: transparent;
     }
 
     #mobileDock .mobile-dock-button {
@@ -925,9 +946,11 @@ body {
         box-shadow: none !important;
         font-size: 0;
         outline: 0;
+        -webkit-tap-highlight-color: transparent;
         -webkit-appearance: none;
         appearance: none;
         overflow: hidden;
+        user-select: none;
     }
 
     #mobileDock .mobile-dock-button::before {
@@ -942,10 +965,12 @@ body {
 
     #mobileDock .mobile-dock-button:hover,
     #mobileDock .mobile-dock-button:focus,
+    #mobileDock .mobile-dock-button.pcui-focus,
     #mobileDock .mobile-dock-button:active {
         border: 0;
         color: #f2f2f2;
-        background: transparent;
+        background: transparent !important;
+        background-image: none !important;
         box-shadow: none !important;
         outline: 0;
     }
@@ -953,20 +978,24 @@ body {
     #mobileDock .mobile-dock-button.pcui-disabled,
     #mobileDock .mobile-dock-button.pcui-disabled:hover,
     #mobileDock .mobile-dock-button.pcui-disabled:focus,
+    #mobileDock .mobile-dock-button.pcui-disabled.pcui-focus,
     #mobileDock .mobile-dock-button.pcui-disabled:active {
         color: #b1b8ba;
         cursor: default;
-        background: transparent;
+        background: transparent !important;
+        background-image: none !important;
         box-shadow: none !important;
     }
 
     #mobileDock .mobile-dock-button.selected,
     #mobileDock .mobile-dock-button.selected:hover,
     #mobileDock .mobile-dock-button.selected:focus,
+    #mobileDock .mobile-dock-button.selected.pcui-focus,
     #mobileDock .mobile-dock-button.selected:active {
         border: 0;
         color: #F60 !important;
         background: transparent !important;
+        background-image: none !important;
     }
 
     #mobileDock .mobile-dock-button.selected::before {

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -50,10 +50,8 @@ body {
     min-width: 30%;
 }
 
-@media only screen and (max-width: 600px) {
-    #codePane {
-        display: none;
-    }
+#appInner.mobile #codePane {
+    display: none;
 }
 
 #codePane.multiple-files > .pcui-panel-content > section {
@@ -71,32 +69,28 @@ body {
     opacity: 1;
 }
 
-@media only screen and (max-width: 600px) {
-    #sideBar {
-        margin: 0;
-        position: fixed;
-        left: var(--mobile-gap);
-        right: var(--mobile-gap);
-        bottom: calc(var(--mobile-dock-height) + var(--mobile-gap) + var(--mobile-gap) + env(safe-area-inset-bottom));
-        z-index: 99999;
-        width: auto;
-        height: var(--mobile-panel-height);
-        min-width: 0;
-        max-width: none;
-        max-height: none;
-        border-radius: var(--mobile-radius);
-        overflow: visible;
-    }
-
-    #sideBar .panel-toggle {
-        display: none !important;
-    }
+#appInner.mobile #sideBar {
+    margin: 0;
+    position: fixed;
+    left: var(--mobile-gap);
+    right: var(--mobile-gap);
+    bottom: calc(var(--mobile-dock-height) + var(--mobile-gap) + var(--mobile-gap) + env(safe-area-inset-bottom));
+    z-index: 99999;
+    width: auto;
+    height: var(--mobile-panel-height);
+    min-width: 0;
+    max-width: none;
+    max-height: none;
+    border-radius: var(--mobile-radius);
+    overflow: visible;
 }
 
-@media only screen and (min-width: 601px) {
-    #sideBar > .pcui-container > .pcui-panel-header::before {
-        display: none !important;
-    }
+#appInner.mobile #sideBar .panel-toggle {
+    display: none !important;
+}
+
+#appInner.desktop #sideBar > .pcui-container > .pcui-panel-header::before {
+    display: none !important;
 }
 
 #sideBar > .pcui-panel > .pcui-panel-content {
@@ -117,10 +111,8 @@ body {
     top: 8px !important;
 }
 
-@media only screen and (max-width: 600px) {
-    .sideBar-panel-toggle {
-        display: none;
-    }
+#appInner.mobile .sideBar-panel-toggle {
+    display: none;
 }
     
 
@@ -129,49 +121,49 @@ body {
         transform: rotateZ(90deg);
 }
 
-@media only screen and (max-width: 600px) {
-    #sideBar > .pcui-panel-content {
-        height: calc(100% - 32px);
-        background-color: #283437;
-        margin-top: 0px;
-        border-radius: 0 0 var(--mobile-radius) var(--mobile-radius);
-        overflow: hidden;
-    }
-    #sideBar {
-        background-color: #283437;
-    }
-    #sideBar > .pcui-panel-header {
-        border-radius: var(--mobile-radius) var(--mobile-radius) 0 0 !important;
-    }
+#appInner.mobile #sideBar > .pcui-panel-content {
+    height: calc(100% - 32px);
+    background-color: #283437;
+    margin-top: 0px;
+    border-radius: 0 0 var(--mobile-radius) var(--mobile-radius);
+    overflow: hidden;
+}
 
-    #sideBar.pcui-collapsed > .pcui-panel-header {
-        border-radius: var(--mobile-radius) !important;
-    }
+#appInner.mobile #sideBar {
+    background-color: #283437;
+}
 
-    #sideBar-contents {
-        height: calc(100% - 56px);
-        overflow-y: scroll;
-        margin-top: 8px;
-        position: static;
-        width: 100%;
-        max-height: none;
-    }
+#appInner.mobile #sideBar > .pcui-panel-header {
+    border-radius: var(--mobile-radius) var(--mobile-radius) 0 0 !important;
+}
 
-    #sideBar {
-        min-height: 0;
-    }
+#appInner.mobile #sideBar.pcui-collapsed > .pcui-panel-header {
+    border-radius: var(--mobile-radius) !important;
+}
 
-    #sideBar.pcui-collapsed {
-        min-height: 0;
-    }
+#appInner.mobile #sideBar-contents {
+    height: calc(100% - 56px);
+    overflow-y: scroll;
+    margin-top: 8px;
+    position: static;
+    width: 100%;
+    max-height: none;
+}
 
-    #sideBar.visible {
-        opacity: 1;
-    }
+#appInner.mobile #sideBar {
+    min-height: 0;
+}
 
-    #sideBar.pcui-collapsed > .pcui-panel-content {
-        display: none;
-    }
+#appInner.mobile #sideBar.pcui-collapsed {
+    min-height: 0;
+}
+
+#appInner.mobile #sideBar.visible {
+    opacity: 1;
+}
+
+#appInner.mobile #sideBar.pcui-collapsed > .pcui-panel-content {
+    display: none;
 }
 
 #sideBar .nav-item-text {
@@ -292,10 +284,8 @@ body {
     flex-grow: 1;
     position: relative;
 }
-@media only screen and (min-width: 601px) {
-    #canvas-container {
-        min-width: 445px;
-    }
+#appInner.desktop #canvas-container {
+    min-width: 445px;
 }
 
 #canvas-container iframe {
@@ -349,31 +339,29 @@ body {
     color: #ff6b6b;
 }
 
-@media only screen and (max-width: 600px) {
-    #canvas-container {
-        margin: var(--mobile-gap);
-        border-radius: var(--mobile-radius);
-        height: calc(100dvh - var(--mobile-gap) - var(--mobile-gap));
-        background-color: #171E20;
-    }
+#appInner.mobile #canvas-container {
+    margin: var(--mobile-gap);
+    border-radius: var(--mobile-radius);
+    height: calc(100dvh - var(--mobile-gap) - var(--mobile-gap));
+    background-color: #171E20;
+}
 
-    #canvas-container iframe {
-        border-radius: var(--mobile-radius);
-        height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
-    }
+#appInner.mobile #canvas-container iframe {
+    border-radius: var(--mobile-radius);
+    height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
+}
 
-    #exampleLoading {
-        border-radius: var(--mobile-radius);
-        height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
-    }
+#appInner.mobile #exampleLoading {
+    border-radius: var(--mobile-radius);
+    height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
+}
 
-    #canvas-container.mobile-panel-open iframe {
-        height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
-    }
+#appInner.mobile #canvas-container.mobile-panel-open iframe {
+    height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
+}
 
-    #canvas-container.mobile-panel-open #exampleLoading {
-        height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
-    }
+#appInner.mobile #canvas-container.mobile-panel-open #exampleLoading {
+    height: calc(100dvh - var(--mobile-dock-height) - var(--mobile-panel-height) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - var(--mobile-gap) - env(safe-area-inset-bottom));
 }
 
 @keyframes animation-spin {
@@ -438,13 +426,10 @@ body {
     max-height: calc(100% - 16px);
 }
 
-/* @media only screen and (min-width: 601px) { */
 #controlPanel.empty {
     display: none;
 }
-/* } */
 
-/* @media only screen and (max-width: 600px) { */
 #controlPanel.mobile {
     bottom: calc(var(--mobile-dock-height) + var(--mobile-gap) + env(safe-area-inset-bottom));
     left: 0;
@@ -497,7 +482,6 @@ body {
 #controlPanel.mobile > .pcui-panel-content > section {
     border-radius: var(--mobile-radius);
 }
-/* } */
 
 #controlPanel.mobile .pcui-label-group .pcui-label {
     font-size: 14px;
@@ -524,14 +508,14 @@ body {
     background-color: #364346;
 }
 
-/* Landscape/desktop: scroll only the example controls, not the device selector, so PCUI
+/* Desktop: scroll only the example controls, not the device selector, so PCUI
    SelectInput dropdowns (position: absolute) are not clipped by overflow. */
-#controlPanel.landscape {
+#controlPanel.desktop {
     overflow: visible;
     max-height: min(calc(100% - 16px), calc(100vh - 48px));
 }
 
-#controlPanel.landscape > .pcui-panel-content {
+#controlPanel.desktop > .pcui-panel-content {
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -539,7 +523,7 @@ body {
     overflow: visible;
 }
 
-#controlPanel.landscape #deviceTypeSelectInput {
+#controlPanel.desktop #deviceTypeSelectInput {
     flex-shrink: 0;
 }
 
@@ -569,81 +553,78 @@ body {
     color: #f2f2f2;
 }
 
-@media only screen and (max-width: 600px) {
-    #sideBar-contents,
-    #controlPanel-scroll-region,
-    #controlPanel-controls,
-    #controlPanel.mobile > .pcui-panel-content,
-    .code-editor-mobile-files {
-        touch-action: pan-y;
-    }
+#appInner.mobile #sideBar-contents,
+#appInner.mobile #controlPanel-scroll-region,
+#appInner.mobile #controlPanel-controls,
+#appInner.mobile #controlPanel.mobile > .pcui-panel-content,
+#appInner.mobile .code-editor-mobile-files {
+    touch-action: pan-y;
+}
 
-    #menu,
-    #mobileDock,
-    #mobileDock .mobile-dock-button,
-    #controlPanel.mobile > .pcui-panel-header,
-    #sideBar.mobile-sheet > .pcui-panel-header {
-        touch-action: none;
-    }
+#appInner.mobile #menu,
+#appInner.mobile #mobileDock,
+#appInner.mobile #mobileDock .mobile-dock-button,
+#appInner.mobile #controlPanel.mobile > .pcui-panel-header,
+#appInner.mobile #sideBar.mobile-sheet > .pcui-panel-header {
+    touch-action: none;
+}
 
-    #controls-wrapper {
-        position: absolute;
-        width: 100%;
-        height: calc(100% - 48px);
-    }
+#appInner.mobile #controls-wrapper {
+    position: absolute;
+    width: 100%;
+    height: calc(100% - 48px);
+}
 
-    #controlPanel-controls {
-        min-height: 0;
-        overflow: auto;
-    }
+#appInner.mobile #controlPanel-controls {
+    min-height: 0;
+    overflow: auto;
+}
 
-    #controlPanel.mobile.controls-sheet #controlPanel-scroll-region {
-        flex: 1 1 auto;
-        min-height: 0;
-        overflow-y: auto;
-    }
+#appInner.mobile #controlPanel.mobile.controls-sheet #controlPanel-scroll-region {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+}
 
-    #controlPanel.mobile.code-sheet > .pcui-panel-content,
-    #controlPanel.mobile.description-sheet > .pcui-panel-content {
-        overflow: auto;
-    }
+#appInner.mobile #controlPanel.mobile.code-sheet > .pcui-panel-content,
+#appInner.mobile #controlPanel.mobile.description-sheet > .pcui-panel-content {
+    overflow: auto;
+}
 
-    .code-editor-mobile {
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-        min-height: 0;
-    }
+#appInner.mobile .code-editor-mobile {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
 
-    .code-editor-mobile-files {
-        display: flex;
-        flex-direction: column;
-        flex: 0 0 auto;
-        overflow-y: auto;
-    }
+#appInner.mobile .code-editor-mobile-files {
+    display: flex;
+    flex-direction: column;
+    flex: 0 0 auto;
+    overflow-y: auto;
+}
 
-    .code-editor-mobile-files .pcui-button {
-        flex: 0 0 44px;
-        margin: 0;
-        padding: 0 12px;
-        width: 100%;
-        height: 44px;
-        border: 0;
-        border-bottom: 1px solid #4a5a5f;
-        border-radius: 0;
-        text-align: left;
-        font-family: inconsolatamedium, Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
-        font-size: 12px;
-        background-color: transparent;
-    }
+#appInner.mobile .code-editor-mobile-files .pcui-button {
+    flex: 0 0 44px;
+    margin: 0;
+    padding: 0 12px;
+    width: 100%;
+    height: 44px;
+    border: 0;
+    border-bottom: 1px solid #4a5a5f;
+    border-radius: 0;
+    text-align: left;
+    font-family: inconsolatamedium, Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+    font-size: 12px;
+    background-color: transparent;
+}
 
-    .code-editor-mobile-files .pcui-button:not(.pcui-disabled, .pcui-readonly):hover,
-    .code-editor-mobile-files .pcui-button:not(.pcui-disabled, .pcui-readonly):focus,
-    .code-editor-mobile-files .pcui-button:not(.pcui-disabled, .pcui-readonly):active {
-        background-color: transparent;
-        box-shadow: none;
-    }
-
+#appInner.mobile .code-editor-mobile-files .pcui-button:not(.pcui-disabled, .pcui-readonly):hover,
+#appInner.mobile .code-editor-mobile-files .pcui-button:not(.pcui-disabled, .pcui-readonly):focus,
+#appInner.mobile .code-editor-mobile-files .pcui-button:not(.pcui-disabled, .pcui-readonly):active {
+    background-color: transparent;
+    box-shadow: none;
 }
 
 #deviceTypeSelectInput {
@@ -845,26 +826,23 @@ body {
     width: 36px;
 }
 
-@media only screen and (max-width: 600px) {
-    #menu #play-button {
-        display: none;
-    }
-    #menu #language-button {
-        display: none;
-    }
+#appInner.mobile #menu #play-button {
+    display: none;
 }
 
-@media only screen and (max-width: 600px) {
-    #menu {
-        top: var(--mobile-gap);
-        margin-top: var(--mobile-gap);
-        margin-left: var(--mobile-gap);
-        background-color: rgba(54, 67, 70, 0.64);
-    }
+#appInner.mobile #menu #language-button {
+    display: none;
+}
 
-    #menu img {
-        min-width: 32px;
-    }
+#appInner.mobile #menu {
+    top: var(--mobile-gap);
+    margin-top: var(--mobile-gap);
+    margin-left: var(--mobile-gap);
+    background-color: rgba(54, 67, 70, 0.64);
+}
+
+#appInner.mobile #menu img {
+    min-width: 32px;
 }
 
 #menu-buttons {
@@ -891,10 +869,8 @@ body {
     font-size: 10px;
 }
 
-@media only screen and (min-width: 601px) {
-#menu #menu-embed-container {
+#appInner.desktop #menu #menu-embed-container {
     max-width: 272px;
-}
 }
 
 #menu #showMiniStatsButton.selected {
@@ -910,166 +886,164 @@ body {
     display: contents;
 }
 
-@media only screen and (max-width: 600px) {
-    body.mobile-panel-resizing {
-        cursor: ns-resize;
-        user-select: none;
-    }
+body.mobile-panel-resizing {
+    cursor: ns-resize;
+    user-select: none;
+}
 
-    body.mobile-panel-resizing #exampleIframe {
-        pointer-events: none;
-    }
+body.mobile-panel-resizing #exampleIframe {
+    pointer-events: none;
+}
 
-    #controlPanel.mobile > .pcui-panel-header,
-    #sideBar.mobile-sheet > .pcui-panel-header {
-        position: relative;
-        cursor: ns-resize;
-        touch-action: none;
-        user-select: none;
-        overflow: visible;
-    }
+#appInner.mobile #controlPanel.mobile > .pcui-panel-header,
+#appInner.mobile #sideBar.mobile-sheet > .pcui-panel-header {
+    position: relative;
+    cursor: ns-resize;
+    touch-action: none;
+    user-select: none;
+    overflow: visible;
+}
 
-    #controlPanel.mobile > .pcui-panel-header::before,
-    #sideBar.mobile-sheet > .pcui-panel-header::before {
-        content: '';
-        position: absolute;
-        left: 50%;
-        top: 0;
-        width: var(--mobile-handle-hit-width);
-        height: var(--mobile-handle-hit-height);
-        background: transparent;
-        transform: translate(-50%, -50%);
-        pointer-events: auto;
-    }
+#appInner.mobile #controlPanel.mobile > .pcui-panel-header::before,
+#appInner.mobile #sideBar.mobile-sheet > .pcui-panel-header::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 0;
+    width: var(--mobile-handle-hit-width);
+    height: var(--mobile-handle-hit-height);
+    background: transparent;
+    transform: translate(-50%, -50%);
+    pointer-events: auto;
+}
 
-    #controlPanel.mobile > .pcui-panel-header::after,
-    #sideBar.mobile-sheet > .pcui-panel-header::after {
-        content: '';
-        position: absolute;
-        left: 50%;
-        top: 0;
-        width: 44px;
-        height: 4px;
-        border-radius: 999px;
-        background-color: #8da0a5;
-        transform: translate(-50%, -50%);
-        pointer-events: none;
-    }
+#appInner.mobile #controlPanel.mobile > .pcui-panel-header::after,
+#appInner.mobile #sideBar.mobile-sheet > .pcui-panel-header::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 0;
+    width: 44px;
+    height: 4px;
+    border-radius: 999px;
+    background-color: #8da0a5;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+}
 
-    body.mobile-panel-resizing #controlPanel.mobile > .pcui-panel-header::after,
-    body.mobile-panel-resizing #sideBar.mobile-sheet > .pcui-panel-header::after {
-        background-color: #fff;
-    }
+body.mobile-panel-resizing #appInner.mobile #controlPanel.mobile > .pcui-panel-header::after,
+body.mobile-panel-resizing #appInner.mobile #sideBar.mobile-sheet > .pcui-panel-header::after {
+    background-color: #fff;
+}
 
-    #mobileDock {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: clamp(28px, 10vw, 42px);
-        position: fixed;
-        left: var(--mobile-gap);
-        right: var(--mobile-gap);
-        bottom: calc(var(--mobile-gap) + env(safe-area-inset-bottom));
-        height: var(--mobile-dock-height);
-        padding: 4px 8px;
-        box-sizing: border-box;
-        background-color: rgba(54, 67, 70, 0.64);
-        backdrop-filter: blur(32px);
-        border-radius: var(--mobile-radius);
-        z-index: 100000;
-        -webkit-tap-highlight-color: transparent;
-    }
+#appInner.mobile #mobileDock {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: clamp(28px, 10vw, 42px);
+    position: fixed;
+    left: var(--mobile-gap);
+    right: var(--mobile-gap);
+    bottom: calc(var(--mobile-gap) + env(safe-area-inset-bottom));
+    height: var(--mobile-dock-height);
+    padding: 4px 8px;
+    box-sizing: border-box;
+    background-color: rgba(54, 67, 70, 0.64);
+    backdrop-filter: blur(32px);
+    border-radius: var(--mobile-radius);
+    z-index: 100000;
+    -webkit-tap-highlight-color: transparent;
+}
 
-    #mobileDock .mobile-dock-button {
-        --mobile-dock-icon-size: 22px;
+#appInner.mobile #mobileDock .mobile-dock-button {
+    --mobile-dock-icon-size: 22px;
 
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex: 0 0 40px;
-        width: 40px;
-        height: 40px;
-        min-width: 0;
-        margin: 0;
-        padding: 0;
-        border: 0;
-        border-radius: 0;
-        color: #b1b8ba;
-        background: transparent;
-        box-shadow: none !important;
-        font-size: 0;
-        outline: 0;
-        -webkit-tap-highlight-color: transparent;
-        -webkit-appearance: none;
-        appearance: none;
-        overflow: hidden;
-        user-select: none;
-    }
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 40px;
+    width: 40px;
+    height: 40px;
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    color: #b1b8ba;
+    background: transparent;
+    box-shadow: none !important;
+    font-size: 0;
+    outline: 0;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-appearance: none;
+    appearance: none;
+    overflow: hidden;
+    user-select: none;
+}
 
-    #mobileDock .mobile-dock-button::before {
-        content: '';
-        display: block;
-        width: var(--mobile-dock-icon-size);
-        height: var(--mobile-dock-icon-size);
-        background-color: currentColor;
-        mask: var(--mobile-dock-icon) center / var(--mobile-dock-icon-size) var(--mobile-dock-icon-size) no-repeat;
-        -webkit-mask: var(--mobile-dock-icon) center / var(--mobile-dock-icon-size) var(--mobile-dock-icon-size) no-repeat;
-    }
+#appInner.mobile #mobileDock .mobile-dock-button::before {
+    content: '';
+    display: block;
+    width: var(--mobile-dock-icon-size);
+    height: var(--mobile-dock-icon-size);
+    background-color: currentColor;
+    mask: var(--mobile-dock-icon) center / var(--mobile-dock-icon-size) var(--mobile-dock-icon-size) no-repeat;
+    -webkit-mask: var(--mobile-dock-icon) center / var(--mobile-dock-icon-size) var(--mobile-dock-icon-size) no-repeat;
+}
 
-    #mobileDock .mobile-dock-button:hover,
-    #mobileDock .mobile-dock-button:focus,
-    #mobileDock .mobile-dock-button.pcui-focus,
-    #mobileDock .mobile-dock-button:active {
-        border: 0;
-        color: #f2f2f2;
-        background: transparent !important;
-        background-image: none !important;
-        box-shadow: none !important;
-        outline: 0;
-    }
+#appInner.mobile #mobileDock .mobile-dock-button:hover,
+#appInner.mobile #mobileDock .mobile-dock-button:focus,
+#appInner.mobile #mobileDock .mobile-dock-button.pcui-focus,
+#appInner.mobile #mobileDock .mobile-dock-button:active {
+    border: 0;
+    color: #f2f2f2;
+    background: transparent !important;
+    background-image: none !important;
+    box-shadow: none !important;
+    outline: 0;
+}
 
-    #mobileDock .mobile-dock-button.pcui-disabled,
-    #mobileDock .mobile-dock-button.pcui-disabled:hover,
-    #mobileDock .mobile-dock-button.pcui-disabled:focus,
-    #mobileDock .mobile-dock-button.pcui-disabled.pcui-focus,
-    #mobileDock .mobile-dock-button.pcui-disabled:active {
-        color: #b1b8ba;
-        cursor: default;
-        background: transparent !important;
-        background-image: none !important;
-        box-shadow: none !important;
-    }
+#appInner.mobile #mobileDock .mobile-dock-button.pcui-disabled,
+#appInner.mobile #mobileDock .mobile-dock-button.pcui-disabled:hover,
+#appInner.mobile #mobileDock .mobile-dock-button.pcui-disabled:focus,
+#appInner.mobile #mobileDock .mobile-dock-button.pcui-disabled.pcui-focus,
+#appInner.mobile #mobileDock .mobile-dock-button.pcui-disabled:active {
+    color: #b1b8ba;
+    cursor: default;
+    background: transparent !important;
+    background-image: none !important;
+    box-shadow: none !important;
+}
 
-    #mobileDock .mobile-dock-button.selected,
-    #mobileDock .mobile-dock-button.selected:hover,
-    #mobileDock .mobile-dock-button.selected:focus,
-    #mobileDock .mobile-dock-button.selected.pcui-focus,
-    #mobileDock .mobile-dock-button.selected:active {
-        border: 0;
-        color: #F60 !important;
-        background: transparent !important;
-        background-image: none !important;
-    }
+#appInner.mobile #mobileDock .mobile-dock-button.selected,
+#appInner.mobile #mobileDock .mobile-dock-button.selected:hover,
+#appInner.mobile #mobileDock .mobile-dock-button.selected:focus,
+#appInner.mobile #mobileDock .mobile-dock-button.selected.pcui-focus,
+#appInner.mobile #mobileDock .mobile-dock-button.selected:active {
+    border: 0;
+    color: #F60 !important;
+    background: transparent !important;
+    background-image: none !important;
+}
 
-    #mobileDock .mobile-dock-button.selected::before {
-        background-color: #F60;
-    }
+#appInner.mobile #mobileDock .mobile-dock-button.selected::before {
+    background-color: #F60;
+}
 
-    #mobileDock .mobile-dock-examples {
-        --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z'/%3E%3C/svg%3E");
-    }
+#appInner.mobile #mobileDock .mobile-dock-examples {
+    --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z'/%3E%3C/svg%3E");
+}
 
-    #mobileDock .mobile-dock-code {
-        --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m16 18 6-6-6-6M8 6l-6 6 6 6'/%3E%3C/svg%3E");
-    }
+#appInner.mobile #mobileDock .mobile-dock-code {
+    --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m16 18 6-6-6-6M8 6l-6 6 6 6'/%3E%3C/svg%3E");
+}
 
-    #mobileDock .mobile-dock-controls {
-        --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 7h8M16 7h4M4 17h4M12 17h8'/%3E%3Ccircle cx='14' cy='7' r='2' fill='black'/%3E%3Ccircle cx='10' cy='17' r='2' fill='black'/%3E%3C/svg%3E");
-    }
+#appInner.mobile #mobileDock .mobile-dock-controls {
+    --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 7h8M16 7h4M4 17h4M12 17h8'/%3E%3Ccircle cx='14' cy='7' r='2' fill='black'/%3E%3Ccircle cx='10' cy='17' r='2' fill='black'/%3E%3C/svg%3E");
+}
 
-    #mobileDock .mobile-dock-description {
-        --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='9'/%3E%3Cpath d='M12 11v6M12 7h.01'/%3E%3C/svg%3E");
-    }
+#appInner.mobile #mobileDock .mobile-dock-description {
+    --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='9'/%3E%3Cpath d='M12 11v6M12 7h.01'/%3E%3C/svg%3E");
 }
 
 #mobileDescriptionPanel {
@@ -1144,10 +1118,8 @@ body {
     color: white;
 }
 
-@media only screen and (min-width: 601px) {
-    #controlPanel-tabs {
-        display: none;
-    }
+#appInner.desktop #controlPanel-tabs {
+    display: none;
 }
 
 #appInner.fullscreen #canvas-container {
@@ -1164,6 +1136,11 @@ body {
     height: 100%;
 }
 
+#appInner.mobile.fullscreen #canvas-container iframe,
+#appInner.mobile.fullscreen #canvas-container #exampleLoading {
+    height: 100%;
+}
+
 #appInner.fullscreen #menu {
     opacity: 0;
 }
@@ -1171,10 +1148,8 @@ body {
     opacity: 1;
 }
 
-@media only screen and (min-width: 601px) {
-    #appInner.fullscreen #menu:hover {
-        opacity: 1;
-    }
+#appInner.desktop.fullscreen #menu:hover {
+    opacity: 1;
 }
 
 #appInner.fullscreen #menu {

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -5,6 +5,7 @@
 html, body, #app {
     width: 100%;
     height: 100%;
+    touch-action: none;
 }
 
 body {
@@ -296,6 +297,7 @@ body {
     width: 100%;
     height: 100%;
     border: none;
+    touch-action: none;
 }
 
 @media only screen and (max-width: 600px) {
@@ -510,6 +512,21 @@ body {
 }
 
 @media only screen and (max-width: 600px) {
+    #sideBar-contents,
+    #controlPanel-scroll-region,
+    #controlPanel-controls,
+    #controlPanel.mobile > .pcui-panel-content,
+    .code-editor-mobile-files {
+        touch-action: pan-y;
+    }
+
+    #menu,
+    #mobileDock,
+    #mobileDock .mobile-dock-button,
+    .mobile-resize-handle {
+        touch-action: none;
+    }
+
     #controls-wrapper {
         position: absolute;
         width: 100%;

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -856,7 +856,7 @@ body {
     }
 
     #mobileUi > .mobile-resize-handle {
-        bottom: calc(var(--mobile-dock-height) + var(--mobile-panel-height) + var(--mobile-gap) + env(safe-area-inset-bottom) - 9px);
+        bottom: calc(var(--mobile-dock-height) + var(--mobile-panel-height) + var(--mobile-gap) + env(safe-area-inset-bottom) - 1px);
     }
 
     .mobile-resize-handle::before {

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -1,7 +1,7 @@
 <!-- N.B. All single quote strings starting with '@' and are in all caps denote placeholders for replacement code  -->
 <html>
     <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
         <base href="../static/" />
         <link rel="stylesheet" href="../iframe/main.css" />
         <title>'@TITLE'</title>

--- a/examples/utils/vite-dev-server.mjs
+++ b/examples/utils/vite-dev-server.mjs
@@ -93,6 +93,7 @@ const IFRAME_FILES = {
     '/iframe/playcanvas-observer.mjs': 'node_modules/@playcanvas/observer/dist/index.mjs',
     '/iframe/runtime.mjs': 'iframe/runtime.mjs',
     '/iframe/state.mjs': 'iframe/state.mjs',
+    '/iframe/zoom.mjs': 'iframe/zoom.mjs',
     '/iframe/playcanvas.d.ts': '../build/playcanvas.d.ts'
 };
 


### PR DESCRIPTION
## Description
Stabilizes the mobile examples UI so dock buttons stay in fixed positions while source, controls, and description content changes.

- Adds a persistent mobile dock and bottom-sheet style panels for examples, source, controls, and description.
- Keeps the Info dock slot visible and disabled when an example has no description.
- Changes the mobile Source view to a flat file list with desktop-matching file labels.
- Keeps mobile MiniStats and active device UI state synchronized with iframe events.

Manual tests: not run

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change