### PR TITLE
docs: mark platform.visionos as @ignore in JSDoc

### DIFF
--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -133,6 +133,7 @@ const platform = {
      * True if running on Apple Vision Pro (visionOS).
      *
      * @type {boolean}
+     * @ignore
      */
     visionos: visionos,
 


### PR DESCRIPTION
## Summary

- Adds `@ignore` to the JSDoc for `pc.platform.visionos` so it is treated as an internal flag and excluded from generated public API documentation.
