### PR TITLE
fix: ensure opacity dither fully hides at alpha 0 and fully shows at alpha 1

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/standard/frag/opacity-dither.js
+++ b/src/scene/shader-lib/glsl/chunks/standard/frag/opacity-dither.js
@@ -11,6 +11,12 @@ uniform vec4 blueNoiseJitter;
 #endif
 
 void opacityDither(float alpha, float id) {
+    if (alpha <= 0.0)
+        discard;
+
+    if (alpha >= 1.0)
+        return;
+
     #if STD_OPACITY_DITHER == BAYER8
 
         float noise = bayer8(floor(mod(gl_FragCoord.xy + blueNoiseJitter.xy + id, 8.0))) / 64.0;

--- a/src/scene/shader-lib/wgsl/chunks/standard/frag/opacity-dither.js
+++ b/src/scene/shader-lib/wgsl/chunks/standard/frag/opacity-dither.js
@@ -12,6 +12,14 @@ uniform blueNoiseJitter: vec4f;
 #endif
 
 fn opacityDither(alpha: f32, id: f32) {
+    if (alpha <= 0.0) {
+        discard;
+    }
+
+    if (alpha >= 1.0) {
+        return;
+    }
+
     #if STD_OPACITY_DITHER == BAYER8
 
         var noise: f32 = bayer8(floor((pcPosition.xy + uniform.blueNoiseJitter.xy + id) % vec2f(8.0))) / 64.0;


### PR DESCRIPTION
## Summary

- Fix opacity dithering so `alpha = 0` produces a fully invisible surface and `alpha = 1` produces a fully opaque surface, regardless of dither mode.
- Previously, dither thresholds in `[0, 1]` (Bayer can hit `0`, blue-noise textures can hit `0` and `1`, IGN noise can hit `0`) caused `alpha < noise` to leave stray pixels visible at `alpha = 0` (and could discard pixels at `alpha = 1` for blue-noise).
- Adds explicit boundary early-outs in `opacityDither` so the contract is enforced at the source instead of relying on the noise range.
- Applied to both the GLSL and WGSL chunks (`src/scene/shader-lib/glsl/chunks/standard/frag/opacity-dither.js`, `src/scene/shader-lib/wgsl/chunks/standard/frag/opacity-dither.js`).

Before:
<img width="801" height="656" alt="image" src="https://github.com/user-attachments/assets/5b2cc90a-38d4-42a0-97ed-6c0b13114d3f" />

After:
<img width="802" height="658" alt="image" src="https://github.com/user-attachments/assets/e3a7d203-d70a-4a90-b174-5a05b22f4821" />

## Test plan

- [x] Open the `dithered-transparency` example and confirm a material with opacity intensity `0` renders fully invisible (no scattered dots) across all three dither modes: BAYER8, BLUENOISE, IGNNOISE.
- [x] Confirm opacity intensity `1` renders fully opaque with no discarded pixels in all three modes.
- [x] Confirm intermediate values still dither correctly (smooth fade-in/out as intensity sweeps `0 → 1`).
- [x] Verify on both WebGL2 and WebGPU backends.

Fixes #

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
