### PR TITLE
fix: support cross-origin example iframes

### DIFF
--- a/examples/iframe/context.mjs
+++ b/examples/iframe/context.mjs
@@ -1,2 +1,2 @@
-export { host } from './runtime.mjs';
+export { win } from './runtime.mjs';
 export { data, deviceType } from './state.mjs';

--- a/examples/iframe/context.mjs
+++ b/examples/iframe/context.mjs
@@ -1,1 +1,2 @@
+export { host } from './runtime.mjs';
 export { data, deviceType } from './state.mjs';

--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -1,6 +1,6 @@
 import files from './files.mjs';
 import MiniStats from './ministats.mjs';
-import { fetchFile, importModule, clearImports, parseConfig, fire } from './runtime.mjs';
+import { fetchFile, importModule, clearImports, parseConfig, fire, host } from './runtime.mjs';
 import { data, deviceType as selectedDeviceType, refreshContext, updateDeviceType } from './state.mjs';
 import { blockZoom } from './zoom.mjs';
 
@@ -165,8 +165,10 @@ class ExampleLoader {
 
         window.pc = await import(engineUrl);
 
-        // @ts-ignore
-        window.top.pc = window.pc;
+        const win = host();
+        if (win) {
+            win.pc = window.pc;
+        }
 
         await this._fetchFiles();
 

--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -1,6 +1,6 @@
 import files from './files.mjs';
 import MiniStats from './ministats.mjs';
-import { fetchFile, importModule, clearImports, parseConfig, fire, host } from './runtime.mjs';
+import { fetchFile, importModule, clearImports, parseConfig, fire, win } from './runtime.mjs';
 import { data, deviceType as selectedDeviceType, refreshContext, updateDeviceType } from './state.mjs';
 import { blockZoom } from './zoom.mjs';
 
@@ -91,7 +91,7 @@ class ExampleLoader {
             const reportedType = (isWebGPU(selectedDeviceType) && engineType === 'webgpu') ?
                 selectedDeviceType :
                 engineType;
-            window.top.activeGraphicsDevice = reportedType;
+            win.activeGraphicsDevice = reportedType;
             fire('updateActiveDevice', { deviceType: reportedType });
         }
 
@@ -165,9 +165,8 @@ class ExampleLoader {
 
         window.pc = await import(engineUrl);
 
-        if (host) {
-            host.pc = window.pc;
-        }
+        // @ts-ignore
+        win.pc = window.pc;
 
         await this._fetchFiles();
 

--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -165,9 +165,8 @@ class ExampleLoader {
 
         window.pc = await import(engineUrl);
 
-        const win = host();
-        if (win) {
-            win.pc = window.pc;
+        if (host) {
+            host.pc = window.pc;
         }
 
         await this._fetchFiles();

--- a/examples/iframe/runtime.mjs
+++ b/examples/iframe/runtime.mjs
@@ -250,9 +250,20 @@ export function parseConfig(script) {
 }
 
 /**
+ * @returns {Window | null} - The same-origin top window, if available.
+ */
+export const host = () => {
+    try {
+        return window.top && window.top.location.origin === window.location.origin ? window.top : null;
+    } catch (e) {
+        return null;
+    }
+};
+
+/**
  * @param {string} eventName - The name of the fired event.
  * @param {object} detail - The detail object.
  */
 export function fire(eventName, detail = {}) {
-    window.top?.dispatchEvent(new CustomEvent(eventName, { detail }));
+    host()?.dispatchEvent(new CustomEvent(eventName, { detail }));
 }

--- a/examples/iframe/runtime.mjs
+++ b/examples/iframe/runtime.mjs
@@ -250,20 +250,20 @@ export function parseConfig(script) {
 }
 
 /**
- * @returns {Window | null} - The same-origin top window, if available.
+ * @type {Window | null} - The same-origin top window, if available.
  */
-export const host = () => {
+export const host = (() => {
     try {
         return window.top && window.top.location.origin === window.location.origin ? window.top : null;
     } catch (e) {
         return null;
     }
-};
+})();
 
 /**
  * @param {string} eventName - The name of the fired event.
  * @param {object} detail - The detail object.
  */
 export function fire(eventName, detail = {}) {
-    host()?.dispatchEvent(new CustomEvent(eventName, { detail }));
+    host?.dispatchEvent(new CustomEvent(eventName, { detail }));
 }

--- a/examples/iframe/runtime.mjs
+++ b/examples/iframe/runtime.mjs
@@ -252,13 +252,18 @@ export function parseConfig(script) {
 /**
  * @type {Window | null} - The same-origin top window, if available.
  */
-export const host = (() => {
+const host = (() => {
     try {
         return window.top && window.top.location.origin === window.location.origin ? window.top : null;
-    } catch (e) {
+    } catch {
         return null;
     }
 })();
+
+/**
+ * @type {Window} - The example-facing window.
+ */
+export const win = host ?? window;
 
 /**
  * @param {string} eventName - The name of the fired event.

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -8,11 +8,11 @@ import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { GsplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
 
-import { data, deviceType } from 'examples/context';
+import { data, deviceType, host } from 'examples/context';
 
 // allow overriding scene url and orientation via hash query params, e.g.
 // #/gaussian-splatting/lod-streaming?url=https://example.com/scene/lod-meta.json&orientation=90
-const hashQuery = (window.top?.location.hash || window.location.hash || '').split('?')[1] || '';
+const hashQuery = (host()?.location.hash || window.location.hash || '').split('?')[1] || '';
 const hashParams = new URLSearchParams(hashQuery);
 const paramUrl = hashParams.get('url');
 const paramOrientation = hashParams.get('orientation');

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -12,7 +12,7 @@ import { data, deviceType, host } from 'examples/context';
 
 // allow overriding scene url and orientation via hash query params, e.g.
 // #/gaussian-splatting/lod-streaming?url=https://example.com/scene/lod-meta.json&orientation=90
-const hashQuery = (host()?.location.hash || window.location.hash || '').split('?')[1] || '';
+const hashQuery = (host?.location.hash || window.location.hash || '').split('?')[1] || '';
 const hashParams = new URLSearchParams(hashQuery);
 const paramUrl = hashParams.get('url');
 const paramOrientation = hashParams.get('orientation');

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -8,11 +8,11 @@ import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { GsplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
 
-import { data, deviceType, host } from 'examples/context';
+import { data, deviceType, win } from 'examples/context';
 
 // allow overriding scene url and orientation via hash query params, e.g.
 // #/gaussian-splatting/lod-streaming?url=https://example.com/scene/lod-meta.json&orientation=90
-const hashQuery = (host?.location.hash || window.location.hash || '').split('?')[1] || '';
+const hashQuery = (win.location.hash || window.location.hash || '').split('?')[1] || '';
 const hashParams = new URLSearchParams(hashQuery);
 const paramUrl = hashParams.get('url');
 const paramOrientation = hashParams.get('orientation');

--- a/examples/src/examples/graphics/light-physical-units.example.mjs
+++ b/examples/src/examples/graphics/light-physical-units.example.mjs
@@ -1,6 +1,6 @@
 import * as pc from 'playcanvas';
 
-import { data, deviceType, host } from 'examples/context';
+import { data, deviceType, win } from 'examples/context';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();
@@ -58,8 +58,6 @@ app.on('destroy', () => {
 
 const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
 assetListLoader.load(() => {
-    const doc = host?.document;
-
     app.start();
 
     app.scene.skyboxMip = 1;
@@ -297,7 +295,7 @@ assetListLoader.load(() => {
 
         // resize control panel to fit the content better
         if (resizeControlPanel) {
-            const panel = doc?.getElementById('controlPanel');
+            const panel = win.document.getElementById('controlPanel');
             if (panel) {
                 panel.style.width = '360px';
                 resizeControlPanel = false;

--- a/examples/src/examples/graphics/light-physical-units.example.mjs
+++ b/examples/src/examples/graphics/light-physical-units.example.mjs
@@ -1,6 +1,6 @@
 import * as pc from 'playcanvas';
 
-import { data, deviceType } from 'examples/context';
+import { data, deviceType, host } from 'examples/context';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();
@@ -58,6 +58,8 @@ app.on('destroy', () => {
 
 const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
 assetListLoader.load(() => {
+    const doc = host()?.document;
+
     app.start();
 
     app.scene.skyboxMip = 1;
@@ -295,7 +297,7 @@ assetListLoader.load(() => {
 
         // resize control panel to fit the content better
         if (resizeControlPanel) {
-            const panel = window.top.document.getElementById('controlPanel');
+            const panel = doc?.getElementById('controlPanel');
             if (panel) {
                 panel.style.width = '360px';
                 resizeControlPanel = false;

--- a/examples/src/examples/graphics/light-physical-units.example.mjs
+++ b/examples/src/examples/graphics/light-physical-units.example.mjs
@@ -58,7 +58,7 @@ app.on('destroy', () => {
 
 const assetListLoader = new pc.AssetListLoader(Object.values(assets), app.assets);
 assetListLoader.load(() => {
-    const doc = host()?.document;
+    const doc = host?.document;
 
     app.start();
 

--- a/examples/src/examples/test/contact-hardening-shadows.example.mjs
+++ b/examples/src/examples/test/contact-hardening-shadows.example.mjs
@@ -4,7 +4,7 @@
 
 import * as pc from 'playcanvas';
 
-import { data, deviceType } from 'examples/context';
+import { data, deviceType, host } from 'examples/context';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();
@@ -297,9 +297,10 @@ assetListLoader.load(() => {
         }
     });
 
-    const areaLightElement = window.top.document.getElementById('area-light');
-    const pointLightElement = window.top.document.getElementById('point-light');
-    const directionalLightElement = window.top.document.getElementById('directional-light');
+    const doc = host()?.document;
+    const areaLightElement = doc?.getElementById('area-light');
+    const pointLightElement = doc?.getElementById('point-light');
+    const directionalLightElement = doc?.getElementById('directional-light');
 
     let resizeControlPanel = true;
     let time = 0;
@@ -350,7 +351,7 @@ assetListLoader.load(() => {
 
         // resize control panel to fit the content better
         if (resizeControlPanel) {
-            const panel = window.top.document.getElementById('controlPanel');
+            const panel = doc?.getElementById('controlPanel');
             if (panel) {
                 panel.style.width = '360px';
                 resizeControlPanel = false;

--- a/examples/src/examples/test/contact-hardening-shadows.example.mjs
+++ b/examples/src/examples/test/contact-hardening-shadows.example.mjs
@@ -297,7 +297,7 @@ assetListLoader.load(() => {
         }
     });
 
-    const doc = host()?.document;
+    const doc = host?.document;
     const areaLightElement = doc?.getElementById('area-light');
     const pointLightElement = doc?.getElementById('point-light');
     const directionalLightElement = doc?.getElementById('directional-light');

--- a/examples/src/examples/test/contact-hardening-shadows.example.mjs
+++ b/examples/src/examples/test/contact-hardening-shadows.example.mjs
@@ -4,7 +4,7 @@
 
 import * as pc from 'playcanvas';
 
-import { data, deviceType, host } from 'examples/context';
+import { data, deviceType, win } from 'examples/context';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();
@@ -297,10 +297,9 @@ assetListLoader.load(() => {
         }
     });
 
-    const doc = host?.document;
-    const areaLightElement = doc?.getElementById('area-light');
-    const pointLightElement = doc?.getElementById('point-light');
-    const directionalLightElement = doc?.getElementById('directional-light');
+    const areaLightElement = win.document.getElementById('area-light');
+    const pointLightElement = win.document.getElementById('point-light');
+    const directionalLightElement = win.document.getElementById('directional-light');
 
     let resizeControlPanel = true;
     let time = 0;
@@ -351,7 +350,7 @@ assetListLoader.load(() => {
 
         // resize control panel to fit the content better
         if (resizeControlPanel) {
-            const panel = doc?.getElementById('controlPanel');
+            const panel = win.document.getElementById('controlPanel');
             if (panel) {
                 panel.style.width = '360px';
                 resizeControlPanel = false;


### PR DESCRIPTION
## Description
Make direct example iframe routes safe to embed from another origin.

- Add a same-origin host helper for examples iframe runtime parent interactions.
- Keep parent events and pc exposure same-origin only.
- Guard example-level parent hash/document reads used by standalone iframe routes.

## Public API Changes
None.

## Testing
Manual tests:
- Embedded `/iframe/misc_hello-world.html?deviceType=webgl2` from another local origin in Chromium and confirmed `ready=true` with zero SecurityError or permission errors.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change