### PR TITLE
feat: add example attributions

### DIFF
--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -75,12 +75,22 @@ class ExampleLoader {
             // Sets code editor component files
             // Sets example component files (for controls + description)
             // Sets mini stats enabled state based on UI
-            fire('exampleLoad', { observer: data, files, description: this._config.DESCRIPTION || '' });
+            fire('exampleLoad', {
+                observer: data,
+                files,
+                description: this._config.DESCRIPTION || '',
+                attributions: this._config.ATTRIBUTIONS || []
+            });
         }
         this._started = true;
 
         // Updates controls UI
-        fire('updateFiles', { observer: data, files });
+        fire('updateFiles', {
+            observer: data,
+            files,
+            description: this._config.DESCRIPTION || '',
+            attributions: this._config.ATTRIBUTIONS || []
+        });
 
         if (this._app) {
             // Report the selected variant (e.g. 'webgpu:bare') back to the UI when the

--- a/examples/iframe/runtime.mjs
+++ b/examples/iframe/runtime.mjs
@@ -35,6 +35,8 @@ const blobUrls = [];
 const moduleUrls = new Map();
 const moduleUrlTasks = new Map();
 const configRegex = /^[ \t]*\/\/ @config[ \t]*(?:\r?\n[ \t]*\/\/[^\r\n]*)*(?:\r?\n|$)/gm;
+const ATTRIBUTION_FIELDS = ['title', 'author', 'source', 'license'];
+const ATTRIBUTION_FIELD_SET = new Set(ATTRIBUTION_FIELDS);
 
 const parseValue = (val) => {
     return val === undefined || val === 'true' ? true : val === 'false' ? false : val;
@@ -47,6 +49,19 @@ const splitFlag = (line) => {
 
 const parseExampleConfig = (block, config) => {
     const description = [];
+    let attribution = null;
+
+    const completeAttribution = () => {
+        const missing = ATTRIBUTION_FIELDS.filter(field => !attribution[field]);
+        if (missing.length) {
+            throw new Error(`Incomplete @attribution: missing ${missing.join(', ')}`);
+        }
+
+        config.ATTRIBUTIONS ??= [];
+        config.ATTRIBUTIONS.push(attribution);
+        attribution = null;
+    };
+
     const lines = block.split(/\r?\n/).slice(1);
     for (let i = 0; i < lines.length; i++) {
         const match = /^[ \t]*\/\/ ?(.*)$/.exec(lines[i]);
@@ -55,13 +70,51 @@ const parseExampleConfig = (block, config) => {
         }
         const text = match[1];
         const line = text.trim();
-        if (line.startsWith('@flag ')) {
+        if (line === '@attribution') {
+            if (attribution) {
+                completeAttribution();
+            }
+            attribution = {};
+        } else if (attribution) {
+            if (!line) {
+                continue;
+            }
+
+            const idx = line.indexOf(':');
+            if (idx === -1) {
+                throw new Error(`Invalid @attribution line: ${line}`);
+            }
+
+            const name = line.slice(0, idx).trim();
+            if (!ATTRIBUTION_FIELD_SET.has(name)) {
+                throw new Error(`Invalid @attribution field: ${name}`);
+            }
+            if (attribution[name] !== undefined) {
+                throw new Error(`Duplicate @attribution field: ${name}`);
+            }
+
+            attribution[name] = line.slice(idx + 1).trim();
+            let complete = true;
+            for (let j = 0; j < ATTRIBUTION_FIELDS.length; j++) {
+                if (!attribution[ATTRIBUTION_FIELDS[j]]) {
+                    complete = false;
+                    break;
+                }
+            }
+            if (complete) {
+                completeAttribution();
+            }
+        } else if (line.startsWith('@flag ')) {
             const [name, val] = splitFlag(line.slice(6).trim());
             config[name.trim()] = parseValue(val);
         } else {
             description.push(text);
         }
     }
+    if (attribution) {
+        completeAttribution();
+    }
+
     const html = description.join('\n').trim();
     if (html) {
         config.DESCRIPTION = html;

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -15,10 +15,11 @@ import { getLayout } from '../utils.mjs';
 /**
  * @import { Observer } from '@playcanvas/observer'
  * @import { ComponentType, ReactElement } from 'react'
- * @import { ErrorEvent as ExampleErrorEvent, LoadingEvent, StateEvent } from '../events.js'
+ * @import { Attribution, ErrorEvent as ExampleErrorEvent, LoadingEvent, StateEvent } from '../events.js'
  */
 
 const PC_IMPORT = /^[ \t]*import[\s\w*{},]+["']playcanvas["'];?[ \t]*(?:\r?\n|$)/gm;
+const URL_IN_TEXT_PATTERN = /(https?:\/\/[^\s)]+)/;
 
 /** @type {Record<string, string>} */
 const MOBILE_PANEL_TITLES = {
@@ -72,6 +73,7 @@ const MOBILE_PANEL_TITLES = {
  * @property {boolean} showDeviceSelector - Show device selector.
  * @property {Record<string, string>} files - Files of example (controls, shaders, example itself)
  * @property {string} description - Description of example.
+ * @property {Attribution[]} attributions - Attributions for the example.
  */
 
 /** @type {typeof Component<Props, State>} */
@@ -89,7 +91,8 @@ class Example extends TypedComponent {
         showDeviceSelector: true,
         files: { 'example.mjs': '// loading' },
         observer: null,
-        description: ''
+        description: '',
+        attributions: []
     };
 
     /**
@@ -155,7 +158,9 @@ class Example extends TypedComponent {
             loadedPath: '',
             loadError: null,
             controls: null,
-            showDeviceSelector: showDeviceSelector
+            showDeviceSelector: showDeviceSelector,
+            description: '',
+            attributions: []
         });
     }
 
@@ -164,9 +169,9 @@ class Example extends TypedComponent {
      */
     async _handleExampleLoad(event) {
         const path = this.iframePath;
-        const { files, observer, description } = event.detail;
+        const { files, observer, description, attributions = [] } = event.detail;
         const controlsSrc = files['controls.mjs'];
-        if (!description && this.props.mobilePanel === 'description') {
+        if (!description && !attributions.length && this.props.mobilePanel === 'description') {
             this.props.setMobilePanel?.(null);
         }
         if (controlsSrc) {
@@ -178,7 +183,8 @@ class Example extends TypedComponent {
                 controls,
                 observer,
                 files,
-                description
+                description,
+                attributions
             });
         } else {
             // When switching examples from one with controls to one without controls...
@@ -189,7 +195,8 @@ class Example extends TypedComponent {
                 controls: null,
                 observer: null,
                 files,
-                description
+                description,
+                attributions
             });
         }
     }
@@ -233,7 +240,7 @@ class Example extends TypedComponent {
      */
     async _handleUpdateFiles(event) {
         const path = this.iframePath;
-        const { files, observer } = event.detail;
+        const { files, observer, description, attributions = [] } = event.detail;
         const controlsSrc = files['controls.mjs'] ?? '';
         if (!files['controls.mjs']) {
             this.mergeState({
@@ -241,7 +248,9 @@ class Example extends TypedComponent {
                 loadedPath: path,
                 loadError: null,
                 controls: null,
-                observer: null
+                observer: null,
+                description,
+                attributions
             });
         }
         const controls = await this._buildControls(controlsSrc);
@@ -250,7 +259,9 @@ class Example extends TypedComponent {
             loadedPath: path,
             loadError: null,
             controls,
-            observer
+            observer,
+            description,
+            attributions
         });
         window.dispatchEvent(new CustomEvent('resetErrorBoundary'));
     }
@@ -361,24 +372,98 @@ class Example extends TypedComponent {
         );
     }
 
+    /**
+     * @param {string} href - link href.
+     * @param {string} text - link text.
+     * @returns {ReactElement} rendered link.
+     */
+    renderAttributionLink(href, text) {
+        return jsx('a', {
+            href,
+            target: '_blank',
+            rel: 'noopener'
+        }, text);
+    }
+
+    /**
+     * @param {string} source - source value.
+     * @returns {ReactElement | string} rendered source.
+     */
+    renderSourceLink(source) {
+        const match = URL_IN_TEXT_PATTERN.exec(source);
+        return match ? this.renderAttributionLink(match[1], 'Source') : source;
+    }
+
+    /**
+     * @param {string} license - license value.
+     * @returns {ReactElement | string} rendered license.
+     */
+    renderLicenseLink(license) {
+        const match = URL_IN_TEXT_PATTERN.exec(license);
+        if (!match) {
+            return license;
+        }
+
+        const label = license.slice(0, match.index).trim().replace(/\s*\($/, '').trim();
+        return this.renderAttributionLink(match[1], label || 'License');
+    }
+
+    /**
+     * @param {Attribution} attribution - attribution data.
+     * @param {number} index - attribution index.
+     * @returns {ReactElement} rendered attribution row.
+     */
+    renderAttribution(attribution, index) {
+        return jsx(
+            'p',
+            {
+                className: 'example-attribution',
+                key: index
+            },
+            jsx('span', { className: 'example-attribution-title' }, attribution.title),
+            ' by ',
+            jsx('span', { className: 'example-attribution-author' }, attribution.author),
+            ' \u00b7 ',
+            this.renderSourceLink(attribution.source),
+            ' \u00b7 ',
+            this.renderLicenseLink(attribution.license)
+        );
+    }
+
+    renderAttributions() {
+        const { attributions } = this.state;
+        if (!attributions.length) {
+            return null;
+        }
+
+        return jsx(
+            'div',
+            {
+                className: 'example-attributions'
+            },
+            attributions.map((attribution, index) => this.renderAttribution(attribution, index))
+        );
+    }
+
     renderDescription() {
-        const { exampleLoaded, description } = this.state;
-        const layout = this.props.layout ?? this.state.layout;
+        const { exampleLoaded, description, attributions } = this.state;
         const ready = exampleLoaded && iframe.ready;
-        if (!ready) {
+        if (!ready || (!description && !attributions.length)) {
             return;
         }
         return jsx(
             Container,
             {
-                id: 'descriptionPanel',
-                class: layout === 'mobile' ? 'mobile' : undefined
+                id: 'descriptionPanel'
             },
-            jsx('span', {
-                dangerouslySetInnerHTML: {
-                    __html: description
-                }
-            })
+            description ?
+                jsx('span', {
+                    dangerouslySetInnerHTML: {
+                        __html: description
+                    }
+                }) :
+                null,
+            this.renderAttributions()
         );
     }
 
@@ -425,11 +510,14 @@ class Example extends TypedComponent {
                     key: 'description',
                     id: 'mobileDescriptionPanel'
                 },
-                jsx('span', {
-                    dangerouslySetInnerHTML: {
-                        __html: description
-                    }
-                })
+                description ?
+                    jsx('span', {
+                        dangerouslySetInnerHTML: {
+                            __html: description
+                        }
+                    }) :
+                    null,
+                this.renderAttributions()
             );
         }
 
@@ -460,7 +548,8 @@ class Example extends TypedComponent {
 
     renderMobileDock() {
         const { mobilePanel, setMobilePanel } = this.props;
-        const { description } = this.state;
+        const { description, attributions } = this.state;
+        const hasDescription = description || attributions.length;
         return jsx(
             Container,
             {
@@ -493,11 +582,11 @@ class Example extends TypedComponent {
             jsx(Button, {
                 key: 'description',
                 text: 'Info',
-                enabled: Boolean(description),
+                enabled: Boolean(hasDescription),
                 class: mobilePanel === 'description' ?
                     ['mobile-dock-button', 'mobile-dock-description', 'selected'] :
                     ['mobile-dock-button', 'mobile-dock-description'],
-                onClick: () => this.state.description && setMobilePanel?.('description')
+                onClick: () => (this.state.description || this.state.attributions.length) && setMobilePanel?.('description')
             })
         );
     }

--- a/examples/src/app/events.js
+++ b/examples/src/app/events.js
@@ -11,10 +11,17 @@
  */
 
 /**
+ * @typedef {object} Attribution
+ * @property {string} title - The attribution title.
+ * @property {string} author - The attribution author.
+ * @property {string} source - The attribution source.
+ * @property {string} license - The attribution license.
+ *
  * @typedef {object} StateEventDetail
  * @property {Observer} observer - The PCUI observer.
  * @property {Record<string, string>} files - The example files.
  * @property {string} description - The example description.
+ * @property {Attribution[]} attributions - The example attributions.
  *
  * @typedef {CustomEvent<StateEventDetail>} StateEvent
  */

--- a/examples/src/examples/gaussian-splatting/first-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/first-person.example.mjs
@@ -5,13 +5,12 @@
 //     <div>(<b>Space</b>) Jump</div>
 //     <div>(<b>Mouse</b>) Look</div>
 // </div>
-
 //
-// Scene attribution:
-//   Title:   Sunnyvale Heritage Park Museum
-//   Author:  zeitgeistarchivescans
-//   Source:  https://superspl.at/scene/d5d397aa
-//   License: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
+// @attribution
+// title: Sunnyvale Heritage Park Museum
+// author: zeitgeistarchivescans
+// source: https://superspl.at/scene/d5d397aa
+// license: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
 
 import * as pc from 'playcanvas';
 import { FirstPersonController } from 'playcanvas/scripts/esm/first-person-controller.mjs';

--- a/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
@@ -6,13 +6,12 @@
 //     <div>(<b>Mouse</b>) Look</div>
 //     <div>Pick two LUTs and use Blend to crossfade between them, or enable Animate.</div>
 // </div>
-
 //
-// Scene attribution:
-//   Title:   Sunnyvale Heritage Park Museum
-//   Author:  zeitgeistarchivescans
-//   Source:  https://superspl.at/scene/d5d397aa
-//   License: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
+// @attribution
+// title: Sunnyvale Heritage Park Museum
+// author: zeitgeistarchivescans
+// source: https://superspl.at/scene/d5d397aa
+// license: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
 
 import * as pc from 'playcanvas';
 import { FirstPersonController } from 'playcanvas/scripts/esm/first-person-controller.mjs';

--- a/examples/src/examples/gaussian-splatting/third-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/third-person.example.mjs
@@ -8,13 +8,12 @@
 //     <div>(<b>Mouse</b>) Orbit camera</div>
 //     <div>(<b>Wheel</b>) Zoom</div>
 // </div>
-
 //
-// Scene attribution:
-//   Title:   Sunnyvale Heritage Park Museum
-//   Author:  zeitgeistarchivescans
-//   Source:  https://superspl.at/scene/d5d397aa
-//   License: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
+// @attribution
+// title: Sunnyvale Heritage Park Museum
+// author: zeitgeistarchivescans
+// source: https://superspl.at/scene/d5d397aa
+// license: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
 
 import * as pc from 'playcanvas';
 import { ShadowCatcher } from 'playcanvas/scripts/esm/shadow-catcher.mjs';

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -593,11 +593,6 @@ body {
     text-align: center;
 }
 
-#descriptionPanel.mobile {
-    bottom: 100px;
-    width: 90%;
-}
-
 #descriptionPanel a {
     color: #f2f2f2;
 }
@@ -608,6 +603,28 @@ body {
 #appInner.mobile #controlPanel.mobile > .pcui-panel-content,
 #appInner.mobile .code-editor-mobile-files {
     touch-action: pan-y;
+}
+
+.example-attributions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    margin-top: 8px;
+    font-size: 12px;
+    line-height: 1.35;
+}
+
+.example-attribution {
+    max-width: 100%;
+    margin: 0;
+    opacity: 0.82;
+    overflow-wrap: anywhere;
+    text-align: center;
+}
+
+.example-attribution-title {
+    font-weight: 600;
 }
 
 #appInner.mobile #menu,

--- a/examples/utils/example-source.mjs
+++ b/examples/utils/example-source.mjs
@@ -5,6 +5,8 @@ const regexPatterns = [
     /^\s*import\s*(?:\S.*|[\t\v\f \xa0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff])\s*;\s*$/gm
 ];
 const configRegex = /^[ \t]*\/\/ @config[ \t]*(?:\r?\n[ \t]*\/\/[^\r\n]*)*(?:\r?\n|$)/gm;
+const ATTRIBUTION_FIELDS = ['title', 'author', 'source', 'license'];
+const ATTRIBUTION_FIELD_SET = new Set(ATTRIBUTION_FIELDS);
 
 const parseValue = (val) => {
     return val === undefined || val === 'true' ? true : val === 'false' ? false : val;
@@ -17,6 +19,19 @@ const splitFlag = (line) => {
 
 const parseExampleConfig = (block, config) => {
     const description = [];
+    let attribution = null;
+
+    const completeAttribution = () => {
+        const missing = ATTRIBUTION_FIELDS.filter(field => !attribution[field]);
+        if (missing.length) {
+            throw new Error(`Incomplete @attribution: missing ${missing.join(', ')}`);
+        }
+
+        config.ATTRIBUTIONS ??= [];
+        config.ATTRIBUTIONS.push(attribution);
+        attribution = null;
+    };
+
     const lines = block.split(/\r?\n/).slice(1);
     for (let i = 0; i < lines.length; i++) {
         const match = /^[ \t]*\/\/ ?(.*)$/.exec(lines[i]);
@@ -25,13 +40,51 @@ const parseExampleConfig = (block, config) => {
         }
         const text = match[1];
         const line = text.trim();
-        if (line.startsWith('@flag ')) {
+        if (line === '@attribution') {
+            if (attribution) {
+                completeAttribution();
+            }
+            attribution = {};
+        } else if (attribution) {
+            if (!line) {
+                continue;
+            }
+
+            const idx = line.indexOf(':');
+            if (idx === -1) {
+                throw new Error(`Invalid @attribution line: ${line}`);
+            }
+
+            const name = line.slice(0, idx).trim();
+            if (!ATTRIBUTION_FIELD_SET.has(name)) {
+                throw new Error(`Invalid @attribution field: ${name}`);
+            }
+            if (attribution[name] !== undefined) {
+                throw new Error(`Duplicate @attribution field: ${name}`);
+            }
+
+            attribution[name] = line.slice(idx + 1).trim();
+            let complete = true;
+            for (let j = 0; j < ATTRIBUTION_FIELDS.length; j++) {
+                if (!attribution[ATTRIBUTION_FIELDS[j]]) {
+                    complete = false;
+                    break;
+                }
+            }
+            if (complete) {
+                completeAttribution();
+            }
+        } else if (line.startsWith('@flag ')) {
             const [name, val] = splitFlag(line.slice(6).trim());
             config[name.trim()] = parseValue(val);
         } else {
             description.push(text);
         }
     }
+    if (attribution) {
+        completeAttribution();
+    }
+
     const html = description.join('\n').trim();
     if (html) {
         config.DESCRIPTION = html;
@@ -69,6 +122,7 @@ export const stripConfig = (source) => {
 /**
  * @typedef {object} ExampleConfig
  * @property {string} [DESCRIPTION] - The example description.
+ * @property {{ title: string, author: string, source: string, license: string }[]} [ATTRIBUTIONS] - Scene attributions.
  * @property {boolean} [HIDDEN] - The example is hidden from the sidebar list in production builds (`npm run build`). It is still built and reachable via its URL. In development (`npm run develop`) it is still shown in the sidebar.
  * @property {'development' | 'performance' | 'debug'} [ENGINE] - The engine type.
  * @property {boolean} [NO_DEVICE_SELECTOR] - No device selector.


### PR DESCRIPTION
## Description
- Adds @attribution parsing to example configs.
- Renders compact attribution rows beneath example instructions and in the mobile Info sheet.
- Adds attribution metadata to the gaussian splatting character controller examples.

## Preview
<img width="420" alt="image" src="https://github.com/user-attachments/assets/7f785eca-1f1c-464c-920e-64d0532f7382" />
<img width="260" alt="image" src="https://github.com/user-attachments/assets/47e22756-a147-4448-bbc7-20206f26fee1" />

## Manual tests
- Opened the gaussian splatting first-person example in desktop layout and confirmed the attribution appears under the instructions with Source and license links.
- Opened the mobile Info sheet and confirmed the attribution appears there.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project coding standards
- [x] This PR focuses on a single change
