### PR TITLE
feat(xr): add smooth turn mode to XrNavigation

### DIFF
--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
@@ -171,7 +171,7 @@ assetListLoader.load(() => {
     });
 
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
-    data.set('splatBudget', 1.5);
+    data.set('splatBudget', 1);
     data.set('data.stats.gsplats', '—');
     data.set('data.stats.resolution', '—');
 
@@ -217,7 +217,9 @@ assetListLoader.load(() => {
         properties: {
             enableTeleport: false,
             enableSnapVertical: false,
-            movementThreshold: 0
+            movementThreshold: 0,
+            turnMode: 'smooth',
+            smoothTurnSpeed: 90
         }
     });
 
@@ -306,7 +308,10 @@ assetListLoader.load(() => {
             return;
         }
         if (app.xr.isAvailable(pc.XRTYPE_VR)) {
-            app.fire('vr:start', pc.XRSPACE_LOCAL);
+            // local-floor: WebXR puts the local-space origin at the floor below the viewer at
+            // session start, so the camera (child of the rig) ends up at rig + ~1.6 m on Y.
+            // `local` would put the head at rig.y, sinking the viewpoint into the scene floor.
+            app.fire('vr:start', pc.XRSPACE_LOCALFLOOR);
         } else {
             setMessage('Immersive VR is not available');
         }
@@ -335,7 +340,7 @@ assetListLoader.load(() => {
         app.xr.on('start', () => {
             setCameraControlsForXr();
             updateEnterVrButton();
-            setMessage('VR active — left thumbstick: move, right: snap turn; tap to exit');
+            setMessage('VR active — left thumbstick: move, right: turn; tap to exit');
         });
         app.xr.on('end', () => {
             setMessage('VR ended — click Enter VR to re-enter');

--- a/scripts/esm/xr-navigation.mjs
+++ b/scripts/esm/xr-navigation.mjs
@@ -3,13 +3,14 @@ import { Color, Script, Vec2, Vec3 } from 'playcanvas';
 /** @import { XrInputSource } from 'playcanvas' */
 
 /**
- * Handles VR navigation with support for teleportation, smooth locomotion, and snap vertical movement.
- * All methods can be enabled simultaneously, allowing users to choose their preferred
- * navigation method on the fly.
+ * Handles VR navigation with support for teleportation, smooth locomotion, snap or smooth
+ * turning, and snap vertical movement. All methods can be enabled simultaneously, allowing
+ * users to choose their preferred navigation method on the fly.
  *
  * Teleportation: Point and teleport using trigger/pinch gestures
  * Smooth Locomotion: Use left thumbstick for XZ movement
- * Snap Turn: Use right thumbstick X-axis for snap turning
+ * Turning: Right thumbstick X-axis — snap turn (default) or continuous smooth turn, selected
+ *   via {@link XrNavigation#turnMode}
  * Snap Vertical: Use right thumbstick Y-axis to snap up/down (right grip for larger jumps)
  *
  * This script should be attached to a parent entity of the camera entity used for the XR
@@ -40,7 +41,19 @@ class XrNavigation extends Script {
     movementSpeed = 1.5;
 
     /**
-     * Angle in degrees for each snap turn.
+     * Selects the right-thumbstick turn behaviour. One of:
+     * - `'snap'`: discrete rotation of {@link XrNavigation#rotateSpeed} degrees per gesture
+     *   (default; existing behaviour).
+     * - `'smooth'`: continuous rotation at {@link XrNavigation#smoothTurnSpeed} degrees/second
+     *   while the thumbstick is past {@link XrNavigation#smoothTurnThreshold}.
+     * - `'none'`: thumbstick X is ignored.
+     * @attribute
+     * @enabledif {enableMove}
+     */
+    turnMode = 'snap';
+
+    /**
+     * Angle in degrees for each snap turn. Used when {@link XrNavigation#turnMode} is `'snap'`.
      * @attribute
      * @range [15, 180]
      * @enabledif {enableMove}
@@ -73,6 +86,24 @@ class XrNavigation extends Script {
      * @enabledif {enableMove}
      */
     rotateResetThreshold = 0.25;
+
+    /**
+     * Rotation speed in degrees per second when {@link XrNavigation#turnMode} is `'smooth'`.
+     * @attribute
+     * @range [30, 360]
+     * @enabledif {enableMove}
+     */
+    smoothTurnSpeed = 90;
+
+    /**
+     * Deadzone for the right-thumbstick X-axis when {@link XrNavigation#turnMode} is `'smooth'`.
+     * Below this magnitude the stick is treated as centred.
+     * @attribute
+     * @range [0, 0.5]
+     * @precision 0.01
+     * @enabledif {enableMove}
+     */
+    smoothTurnThreshold = 0.15;
 
     /**
      * Maximum distance for teleportation in meters.
@@ -366,8 +397,13 @@ class XrNavigation extends Script {
                     // Apply movement to camera parent (this entity)
                     this.entity.translate(this.tmpVec2A.x, 0, this.tmpVec2A.y);
                 }
-            } else if (inputSource.handedness === 'right') { // Right controller - snap turning
-                this.handleSnapTurning(inputSource);
+            } else if (inputSource.handedness === 'right') { // Right controller - turning
+                if (this.turnMode === 'smooth') {
+                    this.handleSmoothTurning(inputSource, dt);
+                } else if (this.turnMode === 'snap') {
+                    this.handleSnapTurning(inputSource);
+                }
+                // 'none' → thumbstick X is ignored
             }
         }
     }
@@ -395,6 +431,26 @@ class XrNavigation extends Script {
                 this.entity.translateLocal(this.tmpVec3A.mulScalar(-1));
             }
         }
+    }
+
+    /**
+     * Continuous turn at {@link XrNavigation#smoothTurnSpeed} degrees per second while the
+     * right thumbstick X-axis is held past {@link XrNavigation#smoothTurnThreshold}. Rotates
+     * around the camera's local position so the view pivots in place rather than orbiting
+     * the rig origin.
+     *
+     * @param {XrInputSource} inputSource - The right-hand input source.
+     * @param {number} dt - Frame delta time in seconds.
+     */
+    handleSmoothTurning(inputSource, dt) {
+        const turn = -inputSource.gamepad.axes[2];
+        if (Math.abs(turn) <= this.smoothTurnThreshold) return;
+        if (!this.cameraEntity) return;
+
+        this.tmpVec3A.copy(this.cameraEntity.getLocalPosition());
+        this.entity.translateLocal(this.tmpVec3A);
+        this.entity.rotateLocal(0, turn * this.smoothTurnSpeed * dt, 0);
+        this.entity.translateLocal(this.tmpVec3A.mulScalar(-1));
     }
 
     /**


### PR DESCRIPTION
Adds a continuous-turn option to `XrNavigation` alongside the existing snap turn, and updates the `vr-lod` example to use it.

**Changes:**
- New `turnMode` attribute on `XrNavigation` selects how the right thumbstick rotates the view: `'snap'` (default — existing behaviour), `'smooth'` (continuous angular rate), or `'none'`.
- New `smoothTurnSpeed` (default `90` °/s) and `smoothTurnThreshold` (default `0.15` deadzone) attributes drive the smooth path.
- `handleSmoothTurning(inputSource, dt)` rotates the rig around the camera's local position so the view pivots in place rather than orbiting the rig origin (same math as `handleSnapTurning`, just continuous).
- Backward compatible: default `turnMode = 'snap'` keeps every existing caller on the current path. `rotateSpeed` / `rotateThreshold` / `rotateResetThreshold` are unchanged and remain snap-specific.

**API Changes:**
- New attribute `XrNavigation#turnMode: 'snap' | 'smooth' | 'none'` (default `'snap'`).
- New attribute `XrNavigation#smoothTurnSpeed: number` (default `90`).
- New attribute `XrNavigation#smoothTurnThreshold: number` (default `0.15`).
- New method `XrNavigation#handleSmoothTurning(inputSource, dt)`.

**Examples:**
- `vr-lod`: switched to `XrNavigation` with `turnMode: 'smooth'`.
- `vr-lod`: initial splat budget lowered from 1.5M to 1M.
- `vr-lod`: switched the VR reference space from `XRSPACE_LOCAL` to `XRSPACE_LOCALFLOOR` so the viewer starts at proper standing height instead of with the head at floor level.