### PR TITLE
perf: avoid iterator allocations in Frustum.setFromMat4

### DIFF
--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -78,12 +78,11 @@ class Frustum {
      * frustum.setFromMat4(projection);
      */
     setFromMat4(matrix) {
-        const [
-            m00, m01, m02, m03,
-            m10, m11, m12, m13,
-            m20, m21, m22, m23,
-            m30, m31, m32, m33
-        ] = matrix.data;
+        const d = matrix.data;
+        const m00 = d[0], m01 = d[1], m02 = d[2], m03 = d[3];
+        const m10 = d[4], m11 = d[5], m12 = d[6], m13 = d[7];
+        const m20 = d[8], m21 = d[9], m22 = d[10], m23 = d[11];
+        const m30 = d[12], m31 = d[13], m32 = d[14], m33 = d[15];
         const planes = this.planes;
 
         planes[0].set(m03 - m00, m13 - m10, m23 - m20, m33 - m30).normalize(); // RIGHT


### PR DESCRIPTION
## Summary

`Frustum.setFromMat4` was destructuring a `Float32Array` with `const [m00, ..., m33] = matrix.data`. JavaScript array destructuring uses the iterator protocol, so on every call V8 allocates one `{ value, done }` result object per element (16 per call) plus the iterator object itself.

This function fires per-camera per-layer per-frame, so the iterator-result objects accumulated into measurable GC pressure on a representative scene workload — and even pulled additional V8 HeapNumber boxing into the Plane.normalize subtree downstream.

Replacing the destructuring with explicit indexed reads is behaviour-identical and eliminates the iterator allocations entirely.

## Technical details

```js
// before
const [
    m00, m01, m02, m03,
    m10, m11, m12, m13,
    m20, m21, m22, m23,
    m30, m31, m32, m33
] = matrix.data;

// after
const d = matrix.data;
const m00 = d[0], m01 = d[1], m02 = d[2], m03 = d[3];
const m10 = d[4], m11 = d[5], m12 = d[6], m13 = d[7];
const m20 = d[8], m21 = d[9], m22 = d[10], m23 = d[11];
const m30 = d[12], m31 = d[13], m32 = d[14], m33 = d[15];
```

## Measured impact

Captured via V8 sampling heap profiler (`node:inspector` `HeapProfiler.startSampling`) at 128 B interval, 1800 frames of a representative scene rendered against `NullGraphicsDevice`:

| Metric | Before | After | Δ |
|---|---|---|---|
| `Frustum.setFromMat4` subtree (selfSize incl. children) | 98,160 B | 36,216 B | **−63%** |
| Iterator `.next()` attribution under this site | ~22 KB | 0 B | **−100%** |

A targeted microbenchmark of `Frustum.setFromMat4` × 20,000 calls drops from ~56 B/iter to ~45 B/iter. The residual is V8 HeapNumber boxing inside the downstream Plane.normalize arithmetic — unrelated to this change.

## Public API changes

None.

## Test plan

- [x] Existing unit tests pass (`npm test`)
- [x] Existing examples that exercise area-light culling and shadow frustums render identically on both WebGL2 and WebGPU