### PR TITLE
perf(gsplat): avoid per-frame clearVariants in unified material sync

### DIFF
--- a/examples/src/examples/gaussian-splatting/multi-splat.example.mjs
+++ b/examples/src/examples/gaussian-splatting/multi-splat.example.mjs
@@ -159,13 +159,12 @@ assetListLoader.load(() => {
     applyCustomShader(false);
     data.set('shader', false);
 
-    const uTime = app.graphicsDevice.scope.resolve('uTime');
-
     let currentTime = 0;
     app.on('update', (dt) => {
         currentTime += dt;
 
-        uTime.setValue(currentTime);
+        sceneMat.setParameter('uTime', currentTime);
+        sceneMat.update();
 
         skull.rotate(0, 80 * dt, 0);
     });

--- a/src/scene/gsplat-unified/gsplat-quad-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-quad-renderer.js
@@ -40,6 +40,9 @@ class GSplatQuadRenderer extends GSplatRenderer {
     /** @private */
     _lastFisheyeEnabled = false;
 
+    /** @private */
+    _lastSourceChunksKey = '';
+
     /**
      * @param {GraphicsDevice} device - The graphics device.
      * @param {GraphNode} node - The graph node.
@@ -370,18 +373,22 @@ class GSplatQuadRenderer extends GSplatRenderer {
      * @private
      */
     copyMaterialSettings(sourceMaterial) {
-        // Clear user defines (preserve internal defines)
+        // Sync defines via setDefine so _definesDirty tracks real changes. Only delete keys the
+        // source no longer has (and that aren't internal). Deleting all user defines and re-adding
+        // them every frame would force _definesDirty true forever and trigger clearVariants on
+        // every frame.
         const keysToDelete = [];
         this._material.defines.forEach((value, key) => {
-            if (!this._internalDefines.has(key)) {
+            if (!this._internalDefines.has(key) && !sourceMaterial.defines.has(key)) {
                 keysToDelete.push(key);
             }
         });
-        keysToDelete.forEach(key => this._material.defines.delete(key));
+        keysToDelete.forEach(key => this._material.setDefine(key, undefined));
 
-        // Copy defines from source material
+        // Add/update defines from the source. setDefine is conditional — it only flips
+        // _definesDirty when the value actually changed, so unchanged entries stay cheap.
         sourceMaterial.defines.forEach((value, key) => {
-            this._material.defines.set(key, value);
+            this._material.setDefine(key, value);
         });
 
         // Copy parameters
@@ -392,13 +399,17 @@ class GSplatQuadRenderer extends GSplatRenderer {
             }
         }
 
-        // Copy shader chunks if they exist
+        // Copy shader chunks only when they actually changed on the source (chunks.key is a
+        // stable content hash). Otherwise the round-trip (copy → delete internal format chunks
+        // → re-inject) would mark chunks dirty every frame and force a per-frame clearVariants.
         if (sourceMaterial.hasShaderChunks) {
-            this._material.shaderChunks.copy(sourceMaterial.shaderChunks);
+            const sourceChunksKey = sourceMaterial.shaderChunks.key;
+            if (sourceChunksKey !== this._lastSourceChunksKey) {
+                this._material.shaderChunks.copy(sourceMaterial.shaderChunks);
+                this._injectFormatChunks();
+                this._lastSourceChunksKey = sourceChunksKey;
+            }
         }
-
-        // Re-inject format chunks that may have been overwritten by copy
-        this._injectFormatChunks();
 
         this._material.update();
     }

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -688,6 +688,7 @@ class Material {
     updateUniforms(device, scene) {
         if (this._dirtyShader) {
             this.clearVariants();
+            this._dirtyShader = false;
         }
     }
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -881,7 +881,6 @@ class StandardMaterial extends Material {
         library.register('standard', standard);
         const shader = library.getProgram('standard', options, processingOptions, this.userId);
 
-        this._dirtyShader = false;
         return shader;
     }
 

--- a/src/scene/shader-lib/shader-chunk-map.js
+++ b/src/scene/shader-lib/shader-chunk-map.js
@@ -151,7 +151,14 @@ class ShaderChunkMap extends Map {
      * @ignore
      */
     copy(source) {
-        this.clear();
+        // delete entries not present in source
+        for (const key of this.keys()) {
+            if (!source.has(key)) {
+                this.delete(key);
+            }
+        }
+
+        // add or update entries from source (set() only marks dirty when the value actually changes)
         for (const [key, value] of source) {
             this.set(key, value);
         }


### PR DESCRIPTION
Reduces the unified gsplat material sync to a no-op when nothing changed, so per-frame `material.setParameter` + `material.update()` on `app.scene.gsplat.material` no longer forces a shader variant clear every frame.

**Changes:**
- `GSplatQuadRenderer.copyMaterialSettings` now diffs defines and chunks against the source instead of clearing-and-readding every frame. Defines are synced via `setDefine` so `_definesDirty` is tracked correctly; chunks are only re-copied when the source's content key changed.
- `ShaderChunkMap.copy()` diffs against the source instead of `clear()` + re-`set()`, so unchanged entries no longer mark the map dirty.
- `Material.updateUniforms` resets `_dirtyShader` after `clearVariants`. The reset previously lived only in `StandardMaterial.getShaderVariant`, so all other Material subclasses (`ShaderMaterial`, `LitMaterial`, `ParticleMaterial`) left `_dirtyShader` permanently true and cleared variants on every render.

**Examples:**
- `multi-splat`: switched from `device.scope.resolve('uTime').setValue(...)` to `sceneMat.setParameter('uTime', ...)` + `sceneMat.update()`. This is the recommended pattern for driving animated uniforms on the unified gsplat material — global scope values can be overwritten by other code before the draw, material parameters cannot.

**Performance:**
- Eliminates per-frame `clearVariants` on the unified gsplat material when customizing `app.scene.gsplat.material` for animated effects.
- Eliminates per-frame `clearVariants` on all ShaderMaterials caused by `updateUniforms` not acknowledging `_dirtyShader`.