### PR TITLE
TEST: restore setScissor during XR (WebKit #315274 repro — do not merge)

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1318,13 +1318,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         // TODO: this condition should be removed, it's here to handle fake grab pass, which should be refactored instead
         if (this.passEncoder) {
 
-            // When the backbuffer is bound to an XR projection-layer texture, do NOT call
-            // passEncoder.setScissorRect to avoid issues on Apple's visionOS. This should be ok in
-            // general, as we're not likely to do a multi-view rendering when XR is active.
-            if (this.xrColorTexture) {
-                return;
-            }
-
             if (!this.renderTarget.flipY) {
                 y = this.renderTarget.height - y - h;
             }


### PR DESCRIPTION
**Do not merge.** This PR exists solely to produce a deployed build for the Apple WebKit engineer investigating https://bugs.webkit.org/show_bug.cgi?id=315274.

Reverts the scissor-skip guard added in #8756 so that `passEncoder.setScissorRect(...)` is called during WebGPU XR rendering again — which is what triggers the visionOS Safari clipping bug.

The setViewport skip from #8756 is intentionally left in place; only scissor is restored, since the WebKit bug is specifically about scissor.

**Changes:**
- `WebgpuGraphicsDevice#setScissor` — remove the `if (this.xrColorTexture) return;` early-return so the underlying `passEncoder.setScissorRect` runs during XR passes again.

Once the WebKit engineer has captured the repro from the deployed build, this branch will be closed without merging.