### PR TITLE
refactor(examples): remove unified toggle from gsplat global-sorting

### DIFF
--- a/examples/src/examples/gaussian-splatting/global-sorting.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/global-sorting.controls.mjs
@@ -3,7 +3,7 @@
  * @returns {JSX.Element} The returned JSX Element.
  */
 export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
-    const { BindingTwoWay, LabelGroup, BooleanInput, SelectInput } = ReactPCUI;
+    const { BindingTwoWay, LabelGroup, SelectInput } = ReactPCUI;
     return fragment(
         jsx(
             LabelGroup,
@@ -19,16 +19,6 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                     { v: 2, t: 'Raster (GPU Sort)' },
                     { v: 3, t: 'Compute' }
                 ]
-            })
-        ),
-        jsx(
-            LabelGroup,
-            { text: 'Unified' },
-            jsx(BooleanInput, {
-                type: 'toggle',
-                binding: new BindingTwoWay(),
-                link: { observer, path: 'unified' },
-                value: observer.get('unified')
             })
         )
     );

--- a/examples/src/examples/gaussian-splatting/global-sorting.example.mjs
+++ b/examples/src/examples/gaussian-splatting/global-sorting.example.mjs
@@ -67,9 +67,7 @@ assetListLoader.load(() => {
         }
     });
 
-    // default unified mode
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
-    data.set('unified', true);
 
     // instantiate garage gsplat
     const hotel = new pc.Entity('garage');
@@ -129,13 +127,4 @@ assetListLoader.load(() => {
     camera.script.create('orbitCameraInputMouse');
     camera.script.create('orbitCameraInputTouch');
     app.root.addChild(camera);
-
-    // toggle unified rendering for all gsplats via controls
-    data.on('unified:set', () => {
-        const unified = !!data.get('unified');
-        const comps = /** @type {pc.GSplatComponent[]} */ (app.root.findComponents('gsplat'));
-        comps.forEach((comp) => {
-            comp.unified = unified;
-        });
-    });
 });


### PR DESCRIPTION
Remove the runtime "Unified" toggle from the gaussian-splatting global-sorting example so it consistently demonstrates unified rendering, matching every other gsplat example in the folder.

**Changes:**
- Drop the `data.on('unified:set', ...)` handler and initial `data.set('unified', true)` in `global-sorting.example.mjs`
- Remove the corresponding `Unified` BooleanInput from `global-sorting.controls.mjs`