### PR TITLE
fix(examples): portal select dropdowns to body

### DIFF
--- a/examples/src/app/components/DeviceSelector.mjs
+++ b/examples/src/app/components/DeviceSelector.mjs
@@ -1,6 +1,6 @@
-import { SelectInput } from '@playcanvas/pcui/react';
 import { Component } from 'react';
 
+import { SelectInput } from './OverlaySelectInput.mjs';
 import {
     DEVICETYPE_WEBGPU,
     DEVICETYPE_WEBGPU_BARE,

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -7,6 +7,8 @@ import { useParams } from 'react-router-dom';
 import { CodeEditorMobile } from './code-editor/CodeEditorMobile.mjs';
 import { DeviceSelector } from './DeviceSelector.mjs';
 import { ErrorBoundary } from './ErrorBoundary.mjs';
+import { SelectInput as OverlaySelectInput } from './OverlaySelectInput.mjs';
+import { CLOSE_SELECTS_EVENT } from '../constants.mjs';
 import { iframe } from '../iframe.mjs';
 import { jsx, fragment } from '../jsx.mjs';
 import { iframePath } from '../paths.mjs';
@@ -19,6 +21,10 @@ import { getLayout } from '../utils.mjs';
  */
 
 const PC_IMPORT = /^[ \t]*import[\s\w*{},]+["']playcanvas["'];?[ \t]*(?:\r?\n|$)/gm;
+const CONTROLS_REACT_PCUI = /** @type {typeof ReactPCUI} */ (/** @type {unknown} */ ({
+    ...ReactPCUI,
+    SelectInput: OverlaySelectInput
+}));
 
 /** @type {Record<string, string>} */
 const MOBILE_PANEL_TITLES = {
@@ -92,6 +98,9 @@ class Example extends TypedComponent {
         description: ''
     };
 
+    /** @type {HTMLElement | null} */
+    _controlPanelScrollRegion = null;
+
     /**
      * @param {Props} props - Component properties.
      */
@@ -104,6 +113,7 @@ class Example extends TypedComponent {
         this._handleExampleHotReload = this._handleExampleHotReload.bind(this);
         this._handleExampleError = this._handleExampleError.bind(this);
         this._handleUpdateFiles = this._handleUpdateFiles.bind(this);
+        this._handleControlPanelScroll = this._handleControlPanelScroll.bind(this);
         this._reloadIframe = this._reloadIframe.bind(this);
     }
 
@@ -264,10 +274,23 @@ class Example extends TypedComponent {
         this.setState(prevState => ({ ...prevState, ...state }));
     }
 
+    _handleControlPanelScroll() {
+        window.dispatchEvent(new Event(CLOSE_SELECTS_EVENT));
+    }
+
     setupControlPanel() {
         const controlPanel = document.getElementById('controlPanel');
         if (!controlPanel) {
+            this._controlPanelScrollRegion?.removeEventListener('scroll', this._handleControlPanelScroll);
+            this._controlPanelScrollRegion = null;
             return;
+        }
+
+        const scrollRegion = document.getElementById('controlPanel-scroll-region');
+        if (this._controlPanelScrollRegion !== scrollRegion) {
+            this._controlPanelScrollRegion?.removeEventListener('scroll', this._handleControlPanelScroll);
+            this._controlPanelScrollRegion = scrollRegion;
+            this._controlPanelScrollRegion?.addEventListener('scroll', this._handleControlPanelScroll, { passive: true });
         }
 
         // PCUI should just have a "onHeaderClick" but can't find anything
@@ -304,11 +327,23 @@ class Example extends TypedComponent {
         iframe.fire('requestFiles');
     }
 
-    componentDidUpdate() {
+    /**
+     * @param {Props} prevProps - Previous component properties.
+     */
+    componentDidUpdate(prevProps) {
+        const prevParams = prevProps.match.params;
+        const params = this.props.match.params;
+        if (prevParams.category !== params.category || prevParams.example !== params.example) {
+            window.dispatchEvent(new Event(CLOSE_SELECTS_EVENT));
+        }
+
         this.setupControlPanel();
     }
 
     componentWillUnmount() {
+        window.dispatchEvent(new Event(CLOSE_SELECTS_EVENT));
+        this._controlPanelScrollRegion?.removeEventListener('scroll', this._handleControlPanelScroll);
+        this._controlPanelScrollRegion = null;
         window.removeEventListener('resize', this._onLayoutChange);
         window.removeEventListener('requestedFiles', this._handleRequestedFiles);
         window.removeEventListener('orientationchange', this._onLayoutChange);
@@ -353,7 +388,7 @@ class Example extends TypedComponent {
             jsx(controls, {
                 observer,
                 PCUI,
-                ReactPCUI,
+                ReactPCUI: CONTROLS_REACT_PCUI,
                 React,
                 jsx,
                 fragment

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -21,10 +21,10 @@ import { getLayout } from '../utils.mjs';
  */
 
 const PC_IMPORT = /^[ \t]*import[\s\w*{},]+["']playcanvas["'];?[ \t]*(?:\r?\n|$)/gm;
-const CONTROLS_REACT_PCUI = /** @type {typeof ReactPCUI} */ (/** @type {unknown} */ ({
+const CONTROLS_REACT_PCUI = /** @satisfies {typeof ReactPCUI} */ ({
     ...ReactPCUI,
     SelectInput: OverlaySelectInput
-}));
+});
 
 /** @type {Record<string, string>} */
 const MOBILE_PANEL_TITLES = {

--- a/examples/src/app/components/OverlaySelectInput.mjs
+++ b/examples/src/app/components/OverlaySelectInput.mjs
@@ -1,4 +1,3 @@
-import { SelectInput as PCUISelectInput } from '@playcanvas/pcui';
 import { SelectInput as ReactSelectInput } from '@playcanvas/pcui/react';
 
 import { CLOSE_SELECTS_EVENT } from '../constants.mjs';
@@ -6,11 +5,9 @@ import { CLOSE_SELECTS_EVENT } from '../constants.mjs';
 const CLASS_OVERLAY = 'pcui-select-input-list-overlay';
 const VIEWPORT_PADDING = 8;
 
-/**
- * @import { SelectInputArgs } from '@playcanvas/pcui'
- */
+/** @typedef {ConstructorParameters<typeof ReactSelectInput.ctor>[0]} OverlaySelectInputArgs */
 
-class OverlaySelectInputElement extends PCUISelectInput {
+class OverlaySelectInputElement extends ReactSelectInput.ctor {
     /**
      * @type {Node | null}
      */
@@ -22,7 +19,7 @@ class OverlaySelectInputElement extends PCUISelectInput {
     _overlayNext = null;
 
     /**
-     * @param {Readonly<SelectInputArgs>} [args] - The constructor arguments.
+     * @param {OverlaySelectInputArgs} [args] - The constructor arguments.
      */
     constructor(args) {
         super(args);
@@ -154,14 +151,12 @@ class OverlaySelectInputElement extends PCUISelectInput {
     }
 }
 
-const OverlaySelectInput = /** @type {typeof ReactSelectInput} */ (class extends ReactSelectInput {
-    componentWillUnmount() {
-        /** @type {{ destroy?: () => void } | undefined} */ (this.element)?.destroy?.();
-    }
-});
+class OverlaySelectInput extends ReactSelectInput {
+    static ctor = OverlaySelectInputElement;
 
-OverlaySelectInput.ctor = /** @type {typeof ReactSelectInput.ctor} */ (
-    /** @type {unknown} */ (OverlaySelectInputElement)
-);
+    componentWillUnmount() {
+        this.element?.destroy();
+    }
+}
 
 export { OverlaySelectInput as SelectInput };

--- a/examples/src/app/components/OverlaySelectInput.mjs
+++ b/examples/src/app/components/OverlaySelectInput.mjs
@@ -1,0 +1,167 @@
+import { SelectInput as PCUISelectInput } from '@playcanvas/pcui';
+import { SelectInput as ReactSelectInput } from '@playcanvas/pcui/react';
+
+import { CLOSE_SELECTS_EVENT } from '../constants.mjs';
+
+const CLASS_OVERLAY = 'pcui-select-input-list-overlay';
+const VIEWPORT_PADDING = 8;
+
+/**
+ * @import { SelectInputArgs } from '@playcanvas/pcui'
+ */
+
+class OverlaySelectInputElement extends PCUISelectInput {
+    /**
+     * @type {Node | null}
+     */
+    _overlayParent = null;
+
+    /**
+     * @type {Node | null}
+     */
+    _overlayNext = null;
+
+    /**
+     * @param {Readonly<SelectInputArgs>} [args] - The constructor arguments.
+     */
+    constructor(args) {
+        super(args);
+
+        this._onOverlayLayout = () => {
+            if (this._containerOptions.hidden) {
+                return;
+            }
+
+            this._positionOverlay();
+        };
+
+        /**
+         * @param {PointerEvent} evt - The pointer event.
+         */
+        this._onDocumentPointerDown = (evt) => {
+            const target = /** @type {Node} */ (evt.composedPath()[0]);
+            if (!this.dom.contains(target) && !this._containerOptions.dom.contains(target)) {
+                this.close();
+            }
+        };
+
+        this._onOverlayClose = () => this.close();
+        window.addEventListener(CLOSE_SELECTS_EVENT, this._onOverlayClose);
+    }
+
+    _positionOverlay() {
+        const list = this._containerOptions.dom;
+        const field = this._allowInput ? this._input.dom : this._labelValue.dom;
+
+        if (!field.isConnected || !list.isConnected) {
+            this.close();
+            return;
+        }
+
+        const rect = field.getBoundingClientRect();
+        if (!rect.width || !rect.height) {
+            this.close();
+            return;
+        }
+
+        list.style.maxHeight = '';
+
+        const height = list.scrollHeight;
+        const width = Math.min(rect.width, window.innerWidth - VIEWPORT_PADDING * 2);
+        const below = window.innerHeight - rect.bottom - VIEWPORT_PADDING;
+        const above = rect.top - VIEWPORT_PADDING;
+        const down = below >= Math.min(height, above) || below >= above;
+        const maxHeight = Math.max(down ? below : above, 0);
+        const listHeight = Math.min(height, maxHeight);
+        const left = Math.min(
+            Math.max(rect.left, VIEWPORT_PADDING),
+            window.innerWidth - width - VIEWPORT_PADDING
+        );
+        const top = down ? rect.bottom : rect.top - listHeight;
+
+        list.style.position = 'fixed';
+        list.style.left = `${left}px`;
+        list.style.top = `${Math.max(top, VIEWPORT_PADDING)}px`;
+        list.style.bottom = 'auto';
+        list.style.width = `${width}px`;
+        list.style.maxHeight = `${maxHeight}px`;
+    }
+
+    _showOverlay() {
+        const list = this._containerOptions.dom;
+
+        if (!this._overlayParent) {
+            this._overlayParent = list.parentNode;
+            this._overlayNext = list.nextSibling;
+            document.body.appendChild(list);
+            window.addEventListener('resize', this._onOverlayLayout);
+            window.addEventListener('orientationchange', this._onOverlayLayout);
+        }
+
+        list.classList.add(CLASS_OVERLAY);
+        this._domShadow.style.height = '';
+        this._positionOverlay();
+    }
+
+    _hideOverlay() {
+        const list = this._containerOptions.dom;
+
+        window.removeEventListener('resize', this._onOverlayLayout);
+        window.removeEventListener('orientationchange', this._onOverlayLayout);
+        list.classList.remove(CLASS_OVERLAY);
+        list.style.position = '';
+        list.style.left = '';
+        list.style.top = '';
+        list.style.bottom = '';
+        list.style.width = '';
+        list.style.maxHeight = '';
+
+        if (this._overlayParent) {
+            const next = this._overlayNext?.parentNode === this._overlayParent ? this._overlayNext : null;
+            this._overlayParent.insertBefore(list, next);
+            this._overlayParent = null;
+            this._overlayNext = null;
+        }
+    }
+
+    /**
+     * @param {string} filter - The filter value.
+     */
+    _filterOptions(filter) {
+        super._filterOptions(filter);
+        if (!this._containerOptions.hidden) {
+            this._positionOverlay();
+        }
+    }
+
+    open() {
+        super.open();
+
+        if (!this._containerOptions.hidden) {
+            this._showOverlay();
+        }
+    }
+
+    close() {
+        super.close();
+        this._hideOverlay();
+    }
+
+    destroy() {
+        window.removeEventListener(CLOSE_SELECTS_EVENT, this._onOverlayClose);
+        this._hideOverlay();
+        super.destroy();
+    }
+}
+
+const OverlaySelectInput = /** @type {typeof ReactSelectInput} */ (class extends ReactSelectInput {
+    componentWillUnmount() {
+        /** @type {{ destroy?: () => void } | undefined} */ (this.element)?.destroy?.();
+    }
+});
+
+OverlaySelectInput.ctor = /** @type {typeof ReactSelectInput.ctor} */ (
+    /** @type {unknown} */ (OverlaySelectInputElement)
+);
+
+export { OverlaySelectInput as SelectInput };

--- a/examples/src/app/constants.mjs
+++ b/examples/src/app/constants.mjs
@@ -9,3 +9,5 @@ export const DEVICETYPE_WEBGPU = 'webgpu';
 export const DEVICETYPE_WEBGPU_BARE = 'webgpu:bare';
 
 export const DEVICETYPE_NULL = 'null';
+
+export const CLOSE_SELECTS_EVENT = 'closeSelects';

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -602,6 +602,18 @@ body {
     color: #f2f2f2;
 }
 
+.pcui-container.pcui-select-input-list.pcui-select-input-list-overlay {
+    position: fixed;
+    z-index: 10000;
+}
+
+.pcui-container.pcui-select-input-list.pcui-select-input-list-overlay > *:hover,
+.pcui-container.pcui-select-input-list.pcui-select-input-list-overlay > .pcui-select-input-label-highlighted {
+    color: #fff;
+    background-color: #20292b;
+    cursor: pointer;
+}
+
 #appInner.mobile #sideBar-contents,
 #appInner.mobile #controlPanel-scroll-region,
 #appInner.mobile #controlPanel-controls,


### PR DESCRIPTION
## Description
Fixes PCUI select option lists in the examples app underlapping the controls panel by rendering them as fixed overlays attached to document.body.

- Applies the overlay select to example controls and the device selector.
- Closes open option lists when the controls panel scrolls or routes clean up, so overlays do not linger.

Manual tests:
Opened #/gaussian-splatting/first-person; checked the Renderer dropdown options render above the controls panel without underlap, close on controls scroll, option selection restores cleanly, and the device selector opens as the same overlay.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project coding standards
- [x] This PR focuses on a single change
