### PR TITLE
Add alphaDither property for independent dither strength

### DIFF
--- a/examples/src/examples/graphics/dithered-transparency.controls.mjs
+++ b/examples/src/examples/graphics/dithered-transparency.controls.mjs
@@ -23,6 +23,17 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
             ),
             jsx(
                 LabelGroup,
+                { text: 'Alpha Dither' },
+                jsx(SliderInput, {
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.alphaDither' },
+                    min: 0.0,
+                    max: 1,
+                    precision: 2
+                })
+            ),
+            jsx(
+                LabelGroup,
                 { text: 'Dither Color' },
                 jsx(SelectInput, {
                     binding: new BindingTwoWay(),

--- a/examples/src/examples/graphics/dithered-transparency.example.mjs
+++ b/examples/src/examples/graphics/dithered-transparency.example.mjs
@@ -1,3 +1,12 @@
+// @config
+//
+// <div style="color:black">
+//     Independent strengths for alpha blending and opacity dithering. Both tables have alpha
+//     blending and dither enabled. Left: <code>alphaDither</code> untouched — opacity drives both
+//     blend and dither (legacy behavior). Right: <code>alphaDither</code> driven by its slider —
+//     opacity drives only blend; <b>Alpha Dither</b> drives only dither.
+// </div>
+
 import * as pc from 'playcanvas';
 
 import { data, deviceType } from 'examples/context';
@@ -99,22 +108,39 @@ assetListLoader.load(() => {
     }
 
     // create a ground plane
-    createPrimitive('plane', new pc.Vec3(0, 0, 0), new pc.Vec3(30, 1, 30), new pc.Color(0.8, 0.8, 0.8));
+    createPrimitive('plane', new pc.Vec3(0, 0, 0), new pc.Vec3(60, 1, 30), new pc.Color(0.8, 0.8, 0.8));
 
-    // create an instance of the table
-    const tableEntity = assets.table.resource.instantiateRenderEntity();
-    tableEntity.setLocalScale(3, 3, 3);
-    app.root.addChild(tableEntity);
+    /**
+     * Instantiate the glass table, collect its alpha-blended materials. Each blended material is
+     * cloned so the two tables can be configured independently.
+     *
+     * @param {pc.Vec3} position - The world-space position to place the table at.
+     * @returns {pc.StandardMaterial[]} The alpha-blended materials of the instantiated table.
+     */
+    const spawnTable = (position) => {
+        const entity = assets.table.resource.instantiateRenderEntity();
+        entity.setLocalScale(3, 3, 3);
+        entity.setLocalPosition(position);
+        app.root.addChild(entity);
 
-    // get all materials that have blending enabled
-    const materials = [];
-    tableEntity.findComponents('render').forEach((render) => {
-        render.meshInstances.forEach((meshInstance) => {
-            if (meshInstance.material.blendType !== pc.BLEND_NONE) {
-                materials.push(meshInstance.material);
-            }
+        const materials = [];
+        entity.findComponents('render').forEach((render) => {
+            render.meshInstances.forEach((meshInstance) => {
+                if (meshInstance.material.blendType !== pc.BLEND_NONE) {
+                    meshInstance.material = meshInstance.material.clone();
+                    materials.push(meshInstance.material);
+                }
+            });
         });
-    });
+        return materials;
+    };
+
+    // LEFT — BC demo: alphaDither stays untouched (implicit) so opacity drives both blend
+    // strength and dither density, exactly like the legacy engine
+    const leftMaterials = spawnTable(new pc.Vec3(-7, 0, 0));
+
+    // RIGHT — new feature: alphaDither set explicitly from the slider, decoupled from opacity
+    const rightMaterials = spawnTable(new pc.Vec3(7, 0, 0));
 
     // Create an Entity with a directional light, casting soft VSM shadow
     const light = new pc.Entity();
@@ -137,8 +163,8 @@ assetListLoader.load(() => {
     cameraEntity.addComponent('camera', {
         fov: 70
     });
-    cameraEntity.translate(-14, 12, 12);
-    cameraEntity.lookAt(1, 4, 0);
+    cameraEntity.translate(-14, 12, 20);
+    cameraEntity.lookAt(0, 4, 0);
     app.root.addChild(cameraEntity);
 
     // add orbit camera script with a mouse and a touch support
@@ -146,8 +172,7 @@ assetListLoader.load(() => {
     cameraEntity.script.create('orbitCamera', {
         attributes: {
             inertiaFactor: 0.2,
-            focusEntity: tableEntity,
-            distanceMax: 30,
+            distanceMax: 40,
             frameOnStart: false
         }
     });
@@ -170,32 +195,33 @@ assetListLoader.load(() => {
 
     // ------
 
+    // alphaDither is routed to the right table only — leaving the left's _alphaDither at its
+    // null default, so its dither uses the legacy fallback to opacity. Everything else is applied
+    // to both tables so the only difference between them is alphaDither's null vs explicit state.
+    const rightOnly = new Set(['alphaDither']);
+
     // handle UI changes
     data.on('*:set', (/** @type {string} */ path, value) => {
         const propertyName = path.split('.')[1];
+        const targets = rightOnly.has(propertyName) ?
+            rightMaterials :
+            [...leftMaterials, ...rightMaterials];
 
-        materials.forEach((material) => {
-            // apply the value to the material
+        targets.forEach((material) => {
             material[propertyName] = value;
-
-            if (propertyName === 'opacityDither') {
-                // turn on / off blending depending on the dithering of the color
-                material.blendType = value === pc.DITHER_NONE ? pc.BLEND_NORMAL : pc.BLEND_NONE;
-
-                // turn on / off depth write depending on the dithering of the color
-                material.depthWrite = value !== pc.DITHER_NONE;
-            }
-
             material.update();
         });
 
         applySettings();
     });
 
-    // initial values
+    // initial values — alphaDither starts at 0.5 to match opacity, so on load the right table's
+    // dither matches the left's (both look identical). Drag Opacity and only the left's dither
+    // density follows; drag Alpha Dither and only the right's does.
     data.set('data', {
         taa: false,
         opacity: 0.5,
+        alphaDither: 0.5,
         opacityDither: pc.DITHER_BAYER8,
         opacityShadowDither: pc.DITHER_BAYER8
     });

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -92,6 +92,7 @@ const standardMaterialParameterTypes = {
     alphaToCoverage: 'boolean',
     alphaTest: 'number',
     alphaFade: 'number',
+    alphaDither: 'number',
     opacity: 'number',
     ..._textureParameter('opacity'),
     opacityFadesSpecular: 'boolean',

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -397,6 +397,16 @@ const _tempColor = new Color();
  * Defaults to {@link DITHER_NONE}.
  * @property {number} alphaFade Used to fade out materials when {@link opacityFadesSpecular} is
  * set to false.
+ * @property {number} alphaDither The alpha value used by the opacity dither path, in the range
+ * [0, 1]. Independent of {@link opacity}, which keeps driving alpha blending. Lets a material be
+ * alpha-blended and dithered at the same time with different strengths — useful for fading
+ * objects out via dither while preserving their alpha-blended look (e.g. fading glass as the
+ * camera approaches). Has no effect unless {@link opacityDither} (or
+ * {@link opacityShadowDither}) is set to a dither mode. Set to `1.0` to disable dither at runtime
+ * without changing the dither mode, or `0.0` to fully discard via dither. For backwards
+ * compatibility, a material that has never had this property assigned uses {@link opacity} as
+ * the dither alpha, matching the historical behavior where the dither pass shares the blend
+ * alpha.
  * @property {Texture|null} normalMap The main (primary) normal map of the material (default is
  * null). The texture must contains normalized, tangent space normals.
  * @property {number} normalMapUv Main (primary) normal map UV channel.
@@ -622,6 +632,11 @@ class StandardMaterial extends Material {
             this[k] = source[k];
         });
 
+        // alphaDither uses a null sentinel for "implicit, mirror opacity"; the prop-loop above
+        // goes through the getter which materializes null into a number, so copy the raw field
+        // directly to preserve the implicit state across clone
+        this._alphaDither = source._alphaDither;
+
         // clone user attributes
         this.userAttributes = new Map(source.userAttributes);
 
@@ -775,6 +790,13 @@ class StandardMaterial extends Material {
         }
 
         this._setParameter('material_opacity', this.opacity);
+
+        if (this.opacityDither !== DITHER_NONE || this.opacityShadowDither !== DITHER_NONE) {
+            // dither shader does dAlpha * scale; this.alphaDither getter falls back to opacity
+            // when the user hasn't opted in, giving scale = 1 and bit-identical legacy behavior
+            const scale = this._opacity > 0 ? this.alphaDither / this._opacity : 1;
+            this._setParameter('material_alphaDitherScale', scale);
+        }
 
         if (this.opacityFadesSpecular === false) {
             this._setParameter('material_alphaFade', this.alphaFade);
@@ -1130,6 +1152,20 @@ function _defineMaterialProps() {
     });
     _defineFloat('opacity', 1);
     _defineFloat('alphaFade', 1);
+
+    // alphaDither is the alpha used by the dither path, independent of opacity (the blend alpha).
+    // Defaults to null: the getter then falls back to opacity, matching the historical behavior
+    // where dither and blend share the same alpha value. Setter stores the raw value, so passing
+    // null resets to the default fall-through.
+    defineProp({
+        name: 'alphaDither',
+        defaultValue: null,
+        dirtyShaderFunc: () => false,
+        getterFunc: function () {
+            return this._alphaDither ?? this._opacity;
+        }
+    });
+
     _defineFloat('alphaTest', 0);       // NOTE: overwrites Material.alphaTest
     _defineFloat('bumpiness', 1);
     _defineFloat('normalDetailMapBumpiness', 1);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -791,12 +791,13 @@ class StandardMaterial extends Material {
 
         this._setParameter('material_opacity', this.opacity);
 
-        if (this.opacityDither !== DITHER_NONE || this.opacityShadowDither !== DITHER_NONE) {
-            // dither shader does dAlpha * scale; this.alphaDither getter falls back to opacity
-            // when the user hasn't opted in, giving scale = 1 and bit-identical legacy behavior
-            const scale = this._opacity > 0 ? this.alphaDither / this._opacity : 1;
-            this._setParameter('material_alphaDitherScale', scale);
-        }
+        // dither shader does dAlpha * scale; this.alphaDither getter falls back to opacity when
+        // the user hasn't opted in, giving scale = 1 and bit-identical legacy behavior. Set the
+        // uniform unconditionally so any shader compiled with dither enabled (including via
+        // onUpdateShader overrides that bypass opacityDither / opacityShadowDither) sees a safe
+        // value rather than an uninitialized one
+        const ditherScale = this._opacity > 0 ? this.alphaDither / this._opacity : 1;
+        this._setParameter('material_alphaDitherScale', ditherScale);
 
         if (this.opacityFadesSpecular === false) {
             this._setParameter('material_alphaFade', this.alphaFade);

--- a/src/scene/shader-lib/glsl/chunks/standard/frag/opacity.js
+++ b/src/scene/shader-lib/glsl/chunks/standard/frag/opacity.js
@@ -1,5 +1,6 @@
 export default /* glsl */`
 uniform float material_opacity;
+uniform float material_alphaDitherScale;
 
 void getOpacity() {
     dAlpha = material_opacity;

--- a/src/scene/shader-lib/glsl/chunks/standard/frag/stdFrontEnd.js
+++ b/src/scene/shader-lib/glsl/chunks/standard/frag/stdFrontEnd.js
@@ -112,7 +112,7 @@ export default /* glsl */`
             #endif
 
             #if STD_OPACITY_DITHER != NONE
-                opacityDither(dAlpha, 0.0);
+                opacityDither(dAlpha * material_alphaDitherScale, 0.0);
             #endif
 
             litArgs_opacity = dAlpha;

--- a/src/scene/shader-lib/wgsl/chunks/standard/frag/opacity.js
+++ b/src/scene/shader-lib/wgsl/chunks/standard/frag/opacity.js
@@ -1,5 +1,6 @@
 export default /* wgsl */`
 uniform material_opacity: f32;
+uniform material_alphaDitherScale: f32;
 
 fn getOpacity() {
     dAlpha = uniform.material_opacity;

--- a/src/scene/shader-lib/wgsl/chunks/standard/frag/stdFrontEnd.js
+++ b/src/scene/shader-lib/wgsl/chunks/standard/frag/stdFrontEnd.js
@@ -112,7 +112,7 @@ export default /* wgsl */`
             #endif
 
             #if STD_OPACITY_DITHER != NONE
-                opacityDither(dAlpha, 0.0);
+                opacityDither(dAlpha * uniform.material_alphaDitherScale, 0.0);
             #endif
 
             litArgs_opacity = dAlpha;


### PR DESCRIPTION
Add a new `alphaDither` property on `StandardMaterial` so alpha blending and opacity dithering can be active at the same time with independent strengths. Resolves #8764.

Previously, when `opacityDither` was enabled the dither threshold was driven by the same `opacity` scalar as alpha blending, so a material was effectively either alpha-blended or dithered — never both at meaningful strengths. The new `alphaDither` property feeds the dither path with its own alpha, decoupled from blend.

**Changes:**
- New `alphaDither` property on `StandardMaterial` (range [0, 1])
- New shader uniform `material_alphaDitherScale` (JS computes `alphaDither / opacity` and the GLSL/WGSL dither call site multiplies it into `dAlpha`)
- BC preserved via a getter fallback: a material that has never had `alphaDither` assigned reads back as `opacity`, so the dither pass uses the same alpha as before (scale = 1, bit-identical output)
- `copy()` patched to preserve the implicit-fallback state across `material.clone()`

**API Changes:**
- Added: `StandardMaterial.alphaDither` — `number` in [0, 1]. Set to `1.0` to disable dither without recompiling the shader, `0.0` to fully discard via dither. Reads back as `opacity` until explicitly assigned.

**Examples:**
- `examples/graphics/dithered-transparency`: rebuilt as a side-by-side comparison — left table never assigns `alphaDither` (legacy "opacity drives dither" behavior), right table is driven by an Alpha Dither slider (new independent control). Demonstrates both BC and the new feature in one view.