### PR TITLE
feat: example credits, keybinds, and description overlay

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -183,11 +183,16 @@ Examples can also contain comments which allow you to define the default configu
 ```js
 // @config
 //
-// <div style='text-align:center'>
-//     <div>(<b>WASD</b>) Move</div>
-//     <div>(<b>Space</b>) Jump</div>
-//     <div>(<b>Mouse</b>) Look</div>
-// </div>
+// @keybinds
+// WASD: Move
+// Space: Jump
+// Mouse: Look
+//
+// @credit
+// title: Example Asset
+// author: Artist Name
+// source: https://example.com/asset
+// license: CC BY 4.0
 //
 // @flag HIDDEN
 // @flag ENGINE=performance

--- a/examples/eslint.config.mjs
+++ b/examples/eslint.config.mjs
@@ -3,7 +3,24 @@ import globals from 'globals';
 
 const configLine = /^[ \t]*\/\/ @config[ \t]*$/;
 const commentLine = /^[ \t]*\/\/[^\r\n]*$/;
+const commentText = /^[ \t]*\/\/ ?(.*)$/;
 const emptyLine = /^[ \t]*$/;
+const booleanFlags = new Set([
+    'HIDDEN',
+    'NO_DEVICE_SELECTOR',
+    'NO_MINISTATS',
+    'WEBGPU_DISABLED',
+    'WEBGPU_BARE_DISABLED',
+    'WEBGL_DISABLED'
+]);
+const engineTypes = new Set(['development', 'performance', 'debug']);
+const attributionFields = ['title', 'author', 'source', 'license'];
+const attributionFieldSet = new Set(attributionFields);
+
+const splitFlag = (line) => {
+    const eq = line.indexOf('=');
+    return eq === -1 ? [line, undefined] : [line.slice(0, eq), line.slice(eq + 1).trim()];
+};
 
 const configBlockAtTop = {
     meta: {
@@ -66,6 +83,155 @@ const configBlockAtTop = {
     }
 };
 
+const configBlockShape = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'validate example config block contents'
+        },
+        messages: {
+            duplicateAttributionField: 'Duplicate @attribution field "{{name}}".',
+            duplicateFlag: 'Duplicate @flag "{{name}}".',
+            emptyAttributionField: '@attribution field "{{name}}" must not be empty.',
+            invalidAttributionLine: 'Invalid @attribution line: expected "name: value".',
+            invalidFlagValue: 'Invalid value "{{value}}" for @flag "{{name}}".',
+            malformedFlag: 'Malformed @flag line.',
+            missingAttributionFields: 'Incomplete @attribution: missing {{fields}}.',
+            missingFlagValue: '@flag "{{name}}" requires a value.',
+            unknownAttributionField: 'Invalid @attribution field "{{name}}".',
+            unknownFlag: 'Unknown @flag "{{name}}".'
+        }
+    },
+
+    create(context) {
+        return {
+            Program(node) {
+                const lines = context.sourceCode.lines;
+                const flags = new Set();
+
+                const report = (line, messageId, data) => {
+                    context.report({
+                        node,
+                        loc: {
+                            line: line + 1,
+                            column: 0
+                        },
+                        messageId,
+                        data
+                    });
+                };
+
+                const reportMissing = (attribution, line) => {
+                    if (!attribution) {
+                        return;
+                    }
+
+                    const missing = attributionFields.filter(field => !attribution.fields[field]);
+                    if (missing.length) {
+                        report(line, 'missingAttributionFields', { fields: missing.join(', ') });
+                    }
+                };
+
+                const validateFlag = (line, text) => {
+                    const body = text.slice(6).trim();
+                    if (!body) {
+                        report(line, 'malformedFlag');
+                        return;
+                    }
+
+                    const [raw, value] = splitFlag(body);
+                    const name = raw.trim();
+                    if (!name || /\s/.test(name)) {
+                        report(line, 'malformedFlag');
+                        return;
+                    }
+
+                    if (name === 'ENGINE') {
+                        if (flags.has(name)) {
+                            report(line, 'duplicateFlag', { name });
+                        } else {
+                            flags.add(name);
+                        }
+
+                        if (!value) {
+                            report(line, 'missingFlagValue', { name });
+                        } else if (!engineTypes.has(value)) {
+                            report(line, 'invalidFlagValue', { name, value });
+                        }
+                        return;
+                    }
+
+                    if (!booleanFlags.has(name)) {
+                        report(line, 'unknownFlag', { name });
+                        return;
+                    }
+
+                    if (flags.has(name)) {
+                        report(line, 'duplicateFlag', { name });
+                    } else {
+                        flags.add(name);
+                    }
+
+                    if (value !== undefined && value !== 'true' && value !== 'false') {
+                        report(line, 'invalidFlagValue', { name, value });
+                    }
+                };
+
+                const validateAttribution = (line, attribution, text) => {
+                    if (!text) {
+                        return attribution;
+                    }
+
+                    const idx = text.indexOf(':');
+                    if (idx === -1) {
+                        report(line, 'invalidAttributionLine');
+                        return attribution;
+                    }
+
+                    const name = text.slice(0, idx).trim();
+                    const value = text.slice(idx + 1).trim();
+                    if (!attributionFieldSet.has(name)) {
+                        report(line, 'unknownAttributionField', { name });
+                        return attribution;
+                    }
+                    if (attribution.fields[name] !== undefined) {
+                        report(line, 'duplicateAttributionField', { name });
+                        return attribution;
+                    }
+                    if (!value) {
+                        report(line, 'emptyAttributionField', { name });
+                    }
+
+                    attribution.fields[name] = value;
+                    return attributionFields.every(field => attribution.fields[field]) ? null : attribution;
+                };
+
+                for (let i = 0; i < lines.length; i++) {
+                    if (!configLine.test(lines[i])) {
+                        continue;
+                    }
+
+                    let attribution = null;
+                    let end = i;
+                    for (let j = i + 1; j < lines.length && commentLine.test(lines[j]); j++) {
+                        end = j;
+                        const text = commentText.exec(lines[j])[1].trim();
+                        if (text === '@attribution') {
+                            reportMissing(attribution, j);
+                            attribution = { fields: {} };
+                        } else if (attribution) {
+                            attribution = validateAttribution(j, attribution, text);
+                        } else if (text === '@flag' || text.startsWith('@flag ')) {
+                            validateFlag(j, text);
+                        }
+                    }
+                    reportMissing(attribution, end);
+                }
+            }
+        };
+    }
+};
+
 const importOrder = ['error', {
     groups: ['builtin', 'external', 'internal', ['parent', 'sibling'], 'index', 'unknown'],
     pathGroups: [
@@ -117,12 +283,14 @@ export default [
         plugins: {
             examples: {
                 rules: {
-                    'config-block-at-top': configBlockAtTop
+                    'config-block-at-top': configBlockAtTop,
+                    'config-block-shape': configBlockShape
                 }
             }
         },
         rules: {
-            'examples/config-block-at-top': 'error'
+            'examples/config-block-at-top': 'error',
+            'examples/config-block-shape': 'error'
         }
     },
     {

--- a/examples/eslint.config.mjs
+++ b/examples/eslint.config.mjs
@@ -1,10 +1,15 @@
 import playcanvasConfig from '@playcanvas/eslint-config';
 import globals from 'globals';
 
+import { COLOR_NAMES, INLINE_MD_PATTERN, SAFE_URL_PATTERN } from './utils/inline-markdown.mjs';
+
 const configLine = /^[ \t]*\/\/ @config[ \t]*$/;
 const commentLine = /^[ \t]*\/\/[^\r\n]*$/;
 const commentText = /^[ \t]*\/\/ ?(.*)$/;
 const emptyLine = /^[ \t]*$/;
+// only flag delimiters that almost never appear in prose — `**` and backticks.
+// brackets/parens/braces appear too often in legitimate text to lint reliably.
+const STRAY_DELIM_PATTERN = /\*\*|`/;
 const booleanFlags = new Set([
     'HIDDEN',
     'NO_DEVICE_SELECTOR',
@@ -100,8 +105,11 @@ const configBlockShape = {
             malformedFlag: 'Malformed @flag line.',
             missingCreditFields: 'Incomplete @credit: missing {{fields}}.',
             missingFlagValue: '@flag "{{name}}" requires a value.',
+            unclosedMarkdown: 'Unclosed markdown delimiter in description (`**` or backtick).',
+            unknownColor: 'Unknown color "{{name}}" in description. Use one of: accent, warn, success, info, muted.',
             unknownCreditField: 'Invalid @credit field "{{name}}".',
-            unknownFlag: 'Unknown @flag "{{name}}".'
+            unknownFlag: 'Unknown @flag "{{name}}".',
+            unsafeLink: 'Unsafe link URL "{{url}}" in description. Only http(s): and mailto: are allowed.'
         }
     },
 
@@ -219,6 +227,30 @@ const configBlockShape = {
                     }
                 };
 
+                const validateDescription = (line, text) => {
+                    if (!text) {
+                        return;
+                    }
+                    INLINE_MD_PATTERN.lastIndex = 0;
+                    let residue = '';
+                    let lastIndex = 0;
+                    let match;
+                    while ((match = INLINE_MD_PATTERN.exec(text)) !== null) {
+                        residue += text.slice(lastIndex, match.index);
+                        if (match[4] !== undefined && !SAFE_URL_PATTERN.test(match[5])) {
+                            report(line, 'unsafeLink', { url: match[5] });
+                        }
+                        if (match[6] !== undefined && !COLOR_NAMES.has(match[6])) {
+                            report(line, 'unknownColor', { name: match[6] });
+                        }
+                        lastIndex = INLINE_MD_PATTERN.lastIndex;
+                    }
+                    residue += text.slice(lastIndex);
+                    if (STRAY_DELIM_PATTERN.test(residue)) {
+                        report(line, 'unclosedMarkdown');
+                    }
+                };
+
                 for (let i = 0; i < lines.length; i++) {
                     if (!configLine.test(lines[i])) {
                         continue;
@@ -254,6 +286,8 @@ const configBlockShape = {
                             validateKeybind(j, text);
                         } else if (credit) {
                             credit = validateCredit(j, credit, text);
+                        } else {
+                            validateDescription(j, text);
                         }
                     }
                     reportMissing(credit, end);

--- a/examples/eslint.config.mjs
+++ b/examples/eslint.config.mjs
@@ -19,7 +19,6 @@ const booleanFlags = new Set([
     'WEBGL_DISABLED'
 ]);
 const engineTypes = new Set(['development', 'performance', 'debug']);
-const KEYBIND_INPUT_SEPARATOR = /\s+\/\s+/;
 const creditFields = ['title', 'author', 'source', 'license'];
 const creditFieldSet = new Set(creditFields);
 
@@ -101,7 +100,6 @@ const configBlockShape = {
             emptyCreditField: '@credit field "{{name}}" must not be empty.',
             invalidCreditLine: 'Invalid @credit line: expected "name: value".',
             invalidFlagValue: 'Invalid value "{{value}}" for @flag "{{name}}".',
-            invalidKeybindLine: 'Invalid @keybinds line: expected "input: action".',
             malformedFlag: 'Malformed @flag line.',
             missingCreditFields: 'Incomplete @credit: missing {{fields}}.',
             missingFlagValue: '@flag "{{name}}" requires a value.',
@@ -217,16 +215,6 @@ const configBlockShape = {
                     return creditFields.every(field => credit.fields[field]) ? null : credit;
                 };
 
-                const validateKeybind = (line, text) => {
-                    const idx = text.indexOf(':');
-                    const input = idx === -1 ? '' : text.slice(0, idx).trim();
-                    const action = idx === -1 ? '' : text.slice(idx + 1).trim();
-                    const inputs = input ? input.split(KEYBIND_INPUT_SEPARATOR) : [];
-                    if (idx === -1 || !inputs.length || !action || inputs.some(value => !value)) {
-                        report(line, 'invalidKeybindLine');
-                    }
-                };
-
                 const validateDescription = (line, text) => {
                     if (!text) {
                         return;
@@ -257,33 +245,16 @@ const configBlockShape = {
                     }
 
                     let credit = null;
-                    let keybinds = false;
                     let end = i;
                     for (let j = i + 1; j < lines.length && commentLine.test(lines[j]); j++) {
                         end = j;
                         const text = commentText.exec(lines[j])[1].trim();
-                        if (!text && keybinds) {
-                            keybinds = false;
-                            continue;
-                        }
-                        if (text === '@keybinds') {
+                        if (text === '@credit') {
                             credit = reportMissing(credit, j);
-                            keybinds = true;
-                        } else if (text === '@credit') {
-                            credit = reportMissing(credit, j);
-                            keybinds = false;
                             credit = { fields: {} };
                         } else if (text === '@flag' || text.startsWith('@flag ')) {
                             credit = reportMissing(credit, j);
-                            keybinds = false;
                             validateFlag(j, text);
-                        } else if (keybinds) {
-                            if (text.startsWith('@')) {
-                                keybinds = false;
-                                continue;
-                            }
-
-                            validateKeybind(j, text);
                         } else if (credit) {
                             credit = validateCredit(j, credit, text);
                         } else {

--- a/examples/eslint.config.mjs
+++ b/examples/eslint.config.mjs
@@ -14,8 +14,9 @@ const booleanFlags = new Set([
     'WEBGL_DISABLED'
 ]);
 const engineTypes = new Set(['development', 'performance', 'debug']);
-const attributionFields = ['title', 'author', 'source', 'license'];
-const attributionFieldSet = new Set(attributionFields);
+const KEYBIND_INPUT_SEPARATOR = /\s+\/\s+/;
+const creditFields = ['title', 'author', 'source', 'license'];
+const creditFieldSet = new Set(creditFields);
 
 const splitFlag = (line) => {
     const eq = line.indexOf('=');
@@ -90,15 +91,16 @@ const configBlockShape = {
             description: 'validate example config block contents'
         },
         messages: {
-            duplicateAttributionField: 'Duplicate @attribution field "{{name}}".',
+            duplicateCreditField: 'Duplicate @credit field "{{name}}".',
             duplicateFlag: 'Duplicate @flag "{{name}}".',
-            emptyAttributionField: '@attribution field "{{name}}" must not be empty.',
-            invalidAttributionLine: 'Invalid @attribution line: expected "name: value".',
+            emptyCreditField: '@credit field "{{name}}" must not be empty.',
+            invalidCreditLine: 'Invalid @credit line: expected "name: value".',
             invalidFlagValue: 'Invalid value "{{value}}" for @flag "{{name}}".',
+            invalidKeybindLine: 'Invalid @keybinds line: expected "input: action".',
             malformedFlag: 'Malformed @flag line.',
-            missingAttributionFields: 'Incomplete @attribution: missing {{fields}}.',
+            missingCreditFields: 'Incomplete @credit: missing {{fields}}.',
             missingFlagValue: '@flag "{{name}}" requires a value.',
-            unknownAttributionField: 'Invalid @attribution field "{{name}}".',
+            unknownCreditField: 'Invalid @credit field "{{name}}".',
             unknownFlag: 'Unknown @flag "{{name}}".'
         }
     },
@@ -121,15 +123,16 @@ const configBlockShape = {
                     });
                 };
 
-                const reportMissing = (attribution, line) => {
-                    if (!attribution) {
-                        return;
+                const reportMissing = (credit, line) => {
+                    if (!credit) {
+                        return null;
                     }
 
-                    const missing = attributionFields.filter(field => !attribution.fields[field]);
+                    const missing = creditFields.filter(field => !credit.fields[field]);
                     if (missing.length) {
-                        report(line, 'missingAttributionFields', { fields: missing.join(', ') });
+                        report(line, 'missingCreditFields', { fields: missing.join(', ') });
                     }
+                    return null;
                 };
 
                 const validateFlag = (line, text) => {
@@ -177,33 +180,43 @@ const configBlockShape = {
                     }
                 };
 
-                const validateAttribution = (line, attribution, text) => {
+                const validateCredit = (line, credit, text) => {
                     if (!text) {
-                        return attribution;
+                        return credit;
                     }
 
                     const idx = text.indexOf(':');
                     if (idx === -1) {
-                        report(line, 'invalidAttributionLine');
-                        return attribution;
+                        report(line, 'invalidCreditLine');
+                        return credit;
                     }
 
                     const name = text.slice(0, idx).trim();
                     const value = text.slice(idx + 1).trim();
-                    if (!attributionFieldSet.has(name)) {
-                        report(line, 'unknownAttributionField', { name });
-                        return attribution;
+                    if (!creditFieldSet.has(name)) {
+                        report(line, 'unknownCreditField', { name });
+                        return credit;
                     }
-                    if (attribution.fields[name] !== undefined) {
-                        report(line, 'duplicateAttributionField', { name });
-                        return attribution;
+                    if (credit.fields[name] !== undefined) {
+                        report(line, 'duplicateCreditField', { name });
+                        return credit;
                     }
                     if (!value) {
-                        report(line, 'emptyAttributionField', { name });
+                        report(line, 'emptyCreditField', { name });
                     }
 
-                    attribution.fields[name] = value;
-                    return attributionFields.every(field => attribution.fields[field]) ? null : attribution;
+                    credit.fields[name] = value;
+                    return creditFields.every(field => credit.fields[field]) ? null : credit;
+                };
+
+                const validateKeybind = (line, text) => {
+                    const idx = text.indexOf(':');
+                    const input = idx === -1 ? '' : text.slice(0, idx).trim();
+                    const action = idx === -1 ? '' : text.slice(idx + 1).trim();
+                    const inputs = input ? input.split(KEYBIND_INPUT_SEPARATOR) : [];
+                    if (idx === -1 || !inputs.length || !action || inputs.some(value => !value)) {
+                        report(line, 'invalidKeybindLine');
+                    }
                 };
 
                 for (let i = 0; i < lines.length; i++) {
@@ -211,21 +224,39 @@ const configBlockShape = {
                         continue;
                     }
 
-                    let attribution = null;
+                    let credit = null;
+                    let keybinds = false;
                     let end = i;
                     for (let j = i + 1; j < lines.length && commentLine.test(lines[j]); j++) {
                         end = j;
                         const text = commentText.exec(lines[j])[1].trim();
-                        if (text === '@attribution') {
-                            reportMissing(attribution, j);
-                            attribution = { fields: {} };
-                        } else if (attribution) {
-                            attribution = validateAttribution(j, attribution, text);
+                        if (!text && keybinds) {
+                            keybinds = false;
+                            continue;
+                        }
+                        if (text === '@keybinds') {
+                            credit = reportMissing(credit, j);
+                            keybinds = true;
+                        } else if (text === '@credit') {
+                            credit = reportMissing(credit, j);
+                            keybinds = false;
+                            credit = { fields: {} };
                         } else if (text === '@flag' || text.startsWith('@flag ')) {
+                            credit = reportMissing(credit, j);
+                            keybinds = false;
                             validateFlag(j, text);
+                        } else if (keybinds) {
+                            if (text.startsWith('@')) {
+                                keybinds = false;
+                                continue;
+                            }
+
+                            validateKeybind(j, text);
+                        } else if (credit) {
+                            credit = validateCredit(j, credit, text);
                         }
                     }
-                    reportMissing(attribution, end);
+                    reportMissing(credit, end);
                 }
             }
         };

--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -79,7 +79,6 @@ class ExampleLoader {
                 observer: data,
                 files,
                 description: this._config.DESCRIPTION || '',
-                keybinds: this._config.KEYBINDS || [],
                 credits: this._config.CREDITS || []
             });
         }
@@ -90,7 +89,6 @@ class ExampleLoader {
             observer: data,
             files,
             description: this._config.DESCRIPTION || '',
-            keybinds: this._config.KEYBINDS || [],
             credits: this._config.CREDITS || []
         });
 

--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -75,12 +75,22 @@ class ExampleLoader {
             // Sets code editor component files
             // Sets example component files (for controls + description)
             // Sets mini stats enabled state based on UI
-            fire('exampleLoad', { observer: data, files, description: this._config.DESCRIPTION || '' });
+            fire('exampleLoad', {
+                observer: data,
+                files,
+                description: this._config.DESCRIPTION || '',
+                attributions: this._config.ATTRIBUTIONS || []
+            });
         }
         this._started = true;
 
         // Updates controls UI
-        fire('updateFiles', { observer: data, files });
+        fire('updateFiles', {
+            observer: data,
+            files,
+            description: this._config.DESCRIPTION || '',
+            attributions: this._config.ATTRIBUTIONS || []
+        });
 
         if (this._app) {
             // Report the selected variant (e.g. 'webgpu:bare') back to the UI when the

--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -79,7 +79,8 @@ class ExampleLoader {
                 observer: data,
                 files,
                 description: this._config.DESCRIPTION || '',
-                attributions: this._config.ATTRIBUTIONS || []
+                keybinds: this._config.KEYBINDS || [],
+                credits: this._config.CREDITS || []
             });
         }
         this._started = true;
@@ -89,7 +90,8 @@ class ExampleLoader {
             observer: data,
             files,
             description: this._config.DESCRIPTION || '',
-            attributions: this._config.ATTRIBUTIONS || []
+            keybinds: this._config.KEYBINDS || [],
+            credits: this._config.CREDITS || []
         });
 
         if (this._app) {

--- a/examples/iframe/runtime.mjs
+++ b/examples/iframe/runtime.mjs
@@ -35,6 +35,8 @@ const blobUrls = [];
 const moduleUrls = new Map();
 const moduleUrlTasks = new Map();
 const configRegex = /^[ \t]*\/\/ @config[ \t]*(?:\r?\n[ \t]*\/\/[^\r\n]*)*(?:\r?\n|$)/gm;
+const ATTRIBUTION_FIELDS = ['title', 'author', 'source', 'license'];
+const ATTRIBUTION_FIELD_SET = new Set(ATTRIBUTION_FIELDS);
 
 const parseValue = (val) => {
     return val === undefined || val === 'true' ? true : val === 'false' ? false : val;
@@ -47,6 +49,19 @@ const splitFlag = (line) => {
 
 const parseExampleConfig = (block, config) => {
     const description = [];
+    let attribution = null;
+
+    const completeAttribution = () => {
+        const missing = ATTRIBUTION_FIELDS.filter(field => !attribution[field]);
+        if (missing.length) {
+            throw new Error(`Incomplete @attribution: missing ${missing.join(', ')}`);
+        }
+
+        config.ATTRIBUTIONS ??= [];
+        config.ATTRIBUTIONS.push(attribution);
+        attribution = null;
+    };
+
     const lines = block.split(/\r?\n/).slice(1);
     for (let i = 0; i < lines.length; i++) {
         const match = /^[ \t]*\/\/ ?(.*)$/.exec(lines[i]);
@@ -55,13 +70,51 @@ const parseExampleConfig = (block, config) => {
         }
         const text = match[1];
         const line = text.trim();
-        if (line.startsWith('@flag ')) {
+        if (line === '@attribution') {
+            if (attribution) {
+                completeAttribution();
+            }
+            attribution = {};
+        } else if (attribution) {
+            if (!line) {
+                continue;
+            }
+
+            const idx = line.indexOf(':');
+            if (idx === -1) {
+                throw new Error(`Invalid @attribution line: ${line}`);
+            }
+
+            const name = line.slice(0, idx).trim();
+            if (!ATTRIBUTION_FIELD_SET.has(name)) {
+                throw new Error(`Invalid @attribution field: ${name}`);
+            }
+            if (attribution[name] !== undefined) {
+                throw new Error(`Duplicate @attribution field: ${name}`);
+            }
+
+            attribution[name] = line.slice(idx + 1).trim();
+            let complete = true;
+            for (let j = 0; j < ATTRIBUTION_FIELDS.length; j++) {
+                if (!attribution[ATTRIBUTION_FIELDS[j]]) {
+                    complete = false;
+                    break;
+                }
+            }
+            if (complete) {
+                completeAttribution();
+            }
+        } else if (line.startsWith('@flag ')) {
             const [name, val] = splitFlag(line.slice(6).trim());
             config[name.trim()] = parseValue(val);
         } else {
             description.push(text);
         }
     }
+    if (attribution) {
+        completeAttribution();
+    }
+
     const html = description.join('\n').trim();
     if (html) {
         config.DESCRIPTION = html;

--- a/examples/iframe/runtime.mjs
+++ b/examples/iframe/runtime.mjs
@@ -151,9 +151,9 @@ const parseExampleConfig = (block, config) => {
         completeCredit();
     }
 
-    const html = description.join('\n').trim();
-    if (html) {
-        config.DESCRIPTION = html;
+    const text = description.join('\n').trim();
+    if (text) {
+        config.DESCRIPTION = text;
     }
 };
 

--- a/examples/iframe/runtime.mjs
+++ b/examples/iframe/runtime.mjs
@@ -35,8 +35,9 @@ const blobUrls = [];
 const moduleUrls = new Map();
 const moduleUrlTasks = new Map();
 const configRegex = /^[ \t]*\/\/ @config[ \t]*(?:\r?\n[ \t]*\/\/[^\r\n]*)*(?:\r?\n|$)/gm;
-const ATTRIBUTION_FIELDS = ['title', 'author', 'source', 'license'];
-const ATTRIBUTION_FIELD_SET = new Set(ATTRIBUTION_FIELDS);
+const KEYBIND_INPUT_SEPARATOR = /\s+\/\s+/;
+const CREDIT_FIELDS = ['title', 'author', 'source', 'license'];
+const CREDIT_FIELD_SET = new Set(CREDIT_FIELDS);
 
 const parseValue = (val) => {
     return val === undefined || val === 'true' ? true : val === 'false' ? false : val;
@@ -49,17 +50,18 @@ const splitFlag = (line) => {
 
 const parseExampleConfig = (block, config) => {
     const description = [];
-    let attribution = null;
+    let credit = null;
+    let keybinds = false;
 
-    const completeAttribution = () => {
-        const missing = ATTRIBUTION_FIELDS.filter(field => !attribution[field]);
+    const completeCredit = () => {
+        const missing = CREDIT_FIELDS.filter(field => !credit[field]);
         if (missing.length) {
-            throw new Error(`Incomplete @attribution: missing ${missing.join(', ')}`);
+            throw new Error(`Incomplete @credit: missing ${missing.join(', ')}`);
         }
 
-        config.ATTRIBUTIONS ??= [];
-        config.ATTRIBUTIONS.push(attribution);
-        attribution = null;
+        config.CREDITS ??= [];
+        config.CREDITS.push(credit);
+        credit = null;
     };
 
     const lines = block.split(/\r?\n/).slice(1);
@@ -70,49 +72,83 @@ const parseExampleConfig = (block, config) => {
         }
         const text = match[1];
         const line = text.trim();
-        if (line === '@attribution') {
-            if (attribution) {
-                completeAttribution();
+        if (!line && keybinds) {
+            keybinds = false;
+            continue;
+        }
+        if (line === '@keybinds') {
+            if (credit) {
+                completeCredit();
             }
-            attribution = {};
-        } else if (attribution) {
+            keybinds = true;
+        } else if (line === '@credit') {
+            if (credit) {
+                completeCredit();
+            }
+            keybinds = false;
+            credit = {};
+        } else if (line.startsWith('@flag ')) {
+            if (credit) {
+                completeCredit();
+            }
+            keybinds = false;
+            const [name, val] = splitFlag(line.slice(6).trim());
+            config[name.trim()] = parseValue(val);
+        } else if (keybinds) {
+            if (line.startsWith('@')) {
+                keybinds = false;
+                description.push(text);
+                continue;
+            }
+
+            const idx = line.indexOf(':');
+            const input = idx === -1 ? '' : line.slice(0, idx).trim();
+            const action = idx === -1 ? '' : line.slice(idx + 1).trim();
+            const inputs = input ? input.split(KEYBIND_INPUT_SEPARATOR) : [];
+            if (idx === -1 || !inputs.length || !action || inputs.some(value => !value)) {
+                throw new Error(`Invalid @keybinds line: ${line}`);
+            }
+
+            config.KEYBINDS ??= [];
+            config.KEYBINDS.push({
+                inputs,
+                action
+            });
+        } else if (credit) {
             if (!line) {
                 continue;
             }
 
             const idx = line.indexOf(':');
             if (idx === -1) {
-                throw new Error(`Invalid @attribution line: ${line}`);
+                throw new Error(`Invalid @credit line: ${line}`);
             }
 
             const name = line.slice(0, idx).trim();
-            if (!ATTRIBUTION_FIELD_SET.has(name)) {
-                throw new Error(`Invalid @attribution field: ${name}`);
+            if (!CREDIT_FIELD_SET.has(name)) {
+                throw new Error(`Invalid @credit field: ${name}`);
             }
-            if (attribution[name] !== undefined) {
-                throw new Error(`Duplicate @attribution field: ${name}`);
+            if (credit[name] !== undefined) {
+                throw new Error(`Duplicate @credit field: ${name}`);
             }
 
-            attribution[name] = line.slice(idx + 1).trim();
+            credit[name] = line.slice(idx + 1).trim();
             let complete = true;
-            for (let j = 0; j < ATTRIBUTION_FIELDS.length; j++) {
-                if (!attribution[ATTRIBUTION_FIELDS[j]]) {
+            for (let j = 0; j < CREDIT_FIELDS.length; j++) {
+                if (!credit[CREDIT_FIELDS[j]]) {
                     complete = false;
                     break;
                 }
             }
             if (complete) {
-                completeAttribution();
+                completeCredit();
             }
-        } else if (line.startsWith('@flag ')) {
-            const [name, val] = splitFlag(line.slice(6).trim());
-            config[name.trim()] = parseValue(val);
         } else {
             description.push(text);
         }
     }
-    if (attribution) {
-        completeAttribution();
+    if (credit) {
+        completeCredit();
     }
 
     const html = description.join('\n').trim();

--- a/examples/iframe/runtime.mjs
+++ b/examples/iframe/runtime.mjs
@@ -35,7 +35,6 @@ const blobUrls = [];
 const moduleUrls = new Map();
 const moduleUrlTasks = new Map();
 const configRegex = /^[ \t]*\/\/ @config[ \t]*(?:\r?\n[ \t]*\/\/[^\r\n]*)*(?:\r?\n|$)/gm;
-const KEYBIND_INPUT_SEPARATOR = /\s+\/\s+/;
 const CREDIT_FIELDS = ['title', 'author', 'source', 'license'];
 const CREDIT_FIELD_SET = new Set(CREDIT_FIELDS);
 
@@ -51,7 +50,6 @@ const splitFlag = (line) => {
 const parseExampleConfig = (block, config) => {
     const description = [];
     let credit = null;
-    let keybinds = false;
 
     const completeCredit = () => {
         const missing = CREDIT_FIELDS.filter(field => !credit[field]);
@@ -72,48 +70,17 @@ const parseExampleConfig = (block, config) => {
         }
         const text = match[1];
         const line = text.trim();
-        if (!line && keybinds) {
-            keybinds = false;
-            continue;
-        }
-        if (line === '@keybinds') {
+        if (line === '@credit') {
             if (credit) {
                 completeCredit();
             }
-            keybinds = true;
-        } else if (line === '@credit') {
-            if (credit) {
-                completeCredit();
-            }
-            keybinds = false;
             credit = {};
         } else if (line.startsWith('@flag ')) {
             if (credit) {
                 completeCredit();
             }
-            keybinds = false;
             const [name, val] = splitFlag(line.slice(6).trim());
             config[name.trim()] = parseValue(val);
-        } else if (keybinds) {
-            if (line.startsWith('@')) {
-                keybinds = false;
-                description.push(text);
-                continue;
-            }
-
-            const idx = line.indexOf(':');
-            const input = idx === -1 ? '' : line.slice(0, idx).trim();
-            const action = idx === -1 ? '' : line.slice(idx + 1).trim();
-            const inputs = input ? input.split(KEYBIND_INPUT_SEPARATOR) : [];
-            if (idx === -1 || !inputs.length || !action || inputs.some(value => !value)) {
-                throw new Error(`Invalid @keybinds line: ${line}`);
-            }
-
-            config.KEYBINDS ??= [];
-            config.KEYBINDS.push({
-                inputs,
-                action
-            });
         } else if (credit) {
             if (!line) {
                 continue;

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -726,11 +726,7 @@ class Example extends TypedComponent {
                 class: mobilePanel === 'description' ?
                     ['mobile-dock-button', 'mobile-dock-description', 'selected'] :
                     ['mobile-dock-button', 'mobile-dock-description'],
-                onClick: () => {
-                    if (hasInfo) {
-                        setMobilePanel?.('description');
-                    }
-                }
+                onClick: () => setMobilePanel?.('description')
             })
         );
     }

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -8,6 +8,7 @@ import { CodeEditorMobile } from './code-editor/CodeEditorMobile.mjs';
 import { DeviceSelector } from './DeviceSelector.mjs';
 import { ErrorBoundary } from './ErrorBoundary.mjs';
 import { SelectInput as OverlaySelectInput } from './OverlaySelectInput.mjs';
+import { COLOR_NAMES, INLINE_MD_PATTERN, SAFE_URL_PATTERN } from '../../../utils/inline-markdown.mjs';
 import { CLOSE_SELECTS_EVENT } from '../constants.mjs';
 import { iframe } from '../iframe.mjs';
 import { jsx, fragment } from '../jsx.mjs';
@@ -26,9 +27,6 @@ const CONTROLS_REACT_PCUI = /** @satisfies {typeof ReactPCUI} */ ({
     SelectInput: OverlaySelectInput
 });
 const URL_IN_TEXT_PATTERN = /(https?:\/\/[^\s)]+)/;
-const INLINE_MD_PATTERN = /\*\*([^*\n]+)\*\*|\*([^*\n]+)\*|`([^`\n]+)`|\[([^\]\n]+)\]\(([^)\n]+)\)|\{([a-z]+):([^}\n]+)\}/g;
-const SAFE_URL_PATTERN = /^(?:https?:|mailto:)/i;
-const COLOR_NAMES = new Set(['accent', 'warn', 'success', 'info', 'muted']);
 
 /**
  * Renders a plain-text description with a markdown-lite inline subset:

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -429,24 +429,15 @@ class Example extends TypedComponent {
 
     /**
      * @param {string} href - link href.
-     * @param {string} text - link text.
+     * @param {ReactElement | string} content - link content.
      * @returns {ReactElement} rendered link.
      */
-    renderAttributionLink(href, text) {
+    renderAttributionLink(href, content) {
         return jsx('a', {
             href,
             target: '_blank',
             rel: 'noopener'
-        }, text);
-    }
-
-    /**
-     * @param {string} source - source value.
-     * @returns {ReactElement | string} rendered source.
-     */
-    renderSourceLink(source) {
-        const match = URL_IN_TEXT_PATTERN.exec(source);
-        return match ? this.renderAttributionLink(match[1], 'Source') : source;
+        }, content);
     }
 
     /**
@@ -469,17 +460,21 @@ class Example extends TypedComponent {
      * @returns {ReactElement} rendered attribution row.
      */
     renderAttribution(attribution, index) {
+        const source = URL_IN_TEXT_PATTERN.exec(attribution.source);
+        const credit = fragment(
+            jsx('span', { className: 'example-attribution-title' }, attribution.title),
+            ' by ',
+            jsx('span', { className: 'example-attribution-author' }, attribution.author)
+        );
         return jsx(
             'p',
             {
                 className: 'example-attribution',
                 key: index
             },
-            jsx('span', { className: 'example-attribution-title' }, attribution.title),
-            ' by ',
-            jsx('span', { className: 'example-attribution-author' }, attribution.author),
-            ' \u00b7 ',
-            this.renderSourceLink(attribution.source),
+            source ? this.renderAttributionLink(source[1], credit) : credit,
+            source ? null : ' \u00b7 ',
+            source ? null : attribution.source,
             ' \u00b7 ',
             this.renderLicenseLink(attribution.license)
         );

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -17,7 +17,7 @@ import { getLayout } from '../utils.mjs';
 /**
  * @import { Observer } from '@playcanvas/observer'
  * @import { ComponentType, ReactElement } from 'react'
- * @import { Attribution, ErrorEvent as ExampleErrorEvent, LoadingEvent, StateEvent } from '../events.js'
+ * @import { Credit, Keybind, ErrorEvent as ExampleErrorEvent, LoadingEvent, StateEvent } from '../events.js'
  */
 
 const PC_IMPORT = /^[ \t]*import[\s\w*{},]+["']playcanvas["'];?[ \t]*(?:\r?\n|$)/gm;
@@ -80,7 +80,8 @@ const MOBILE_PANEL_TITLES = {
  * @property {boolean} showDeviceSelector - Show device selector.
  * @property {Record<string, string>} files - Files of example (controls, shaders, example itself)
  * @property {string} description - Description of example.
- * @property {Attribution[]} attributions - Attributions for the example.
+ * @property {Keybind[]} keybinds - Keybinds for the example.
+ * @property {Credit[]} credits - Credits for the example.
  */
 
 /** @type {typeof Component<Props, State>} */
@@ -100,7 +101,8 @@ class Example extends TypedComponent {
         files: { 'example.mjs': '// loading' },
         observer: null,
         description: '',
-        attributions: []
+        keybinds: [],
+        credits: []
     };
 
     /** @type {HTMLElement | null} */
@@ -172,7 +174,8 @@ class Example extends TypedComponent {
             controls: null,
             showDeviceSelector: showDeviceSelector,
             description: '',
-            attributions: []
+            keybinds: [],
+            credits: []
         });
     }
 
@@ -181,9 +184,9 @@ class Example extends TypedComponent {
      */
     async _handleExampleLoad(event) {
         const path = this.iframePath;
-        const { files, observer, description, attributions = [] } = event.detail;
+        const { files, observer, description, keybinds = [], credits = [] } = event.detail;
         const controlsSrc = files['controls.mjs'];
-        if (!description && !attributions.length && this.props.mobilePanel === 'description') {
+        if (!description && !keybinds.length && !credits.length && this.props.mobilePanel === 'description') {
             this.props.setMobilePanel?.(null);
         }
         if (controlsSrc) {
@@ -196,7 +199,8 @@ class Example extends TypedComponent {
                 observer,
                 files,
                 description,
-                attributions
+                keybinds,
+                credits
             });
         } else {
             // When switching examples from one with controls to one without controls...
@@ -208,7 +212,8 @@ class Example extends TypedComponent {
                 observer: null,
                 files,
                 description,
-                attributions
+                keybinds,
+                credits
             });
         }
     }
@@ -252,7 +257,7 @@ class Example extends TypedComponent {
      */
     async _handleUpdateFiles(event) {
         const path = this.iframePath;
-        const { files, observer, description, attributions = [] } = event.detail;
+        const { files, observer, description, keybinds = [], credits = [] } = event.detail;
         const controlsSrc = files['controls.mjs'] ?? '';
         if (!files['controls.mjs']) {
             this.mergeState({
@@ -262,7 +267,8 @@ class Example extends TypedComponent {
                 controls: null,
                 observer: null,
                 description,
-                attributions
+                keybinds,
+                credits
             });
         }
         const controls = await this._buildControls(controlsSrc);
@@ -273,7 +279,8 @@ class Example extends TypedComponent {
             controls,
             observer,
             description,
-            attributions
+            keybinds,
+            credits
         });
         window.dispatchEvent(new CustomEvent('resetErrorBoundary'));
     }
@@ -432,7 +439,7 @@ class Example extends TypedComponent {
      * @param {ReactElement | string} content - link content.
      * @returns {ReactElement} rendered link.
      */
-    renderAttributionLink(href, content) {
+    renderCreditLink(href, content) {
         return jsx('a', {
             href,
             target: '_blank',
@@ -451,38 +458,38 @@ class Example extends TypedComponent {
         }
 
         const label = license.slice(0, match.index).trim().replace(/\s*\($/, '').trim();
-        return this.renderAttributionLink(match[1], label || 'License');
+        return this.renderCreditLink(match[1], label || 'License');
     }
 
     /**
-     * @param {Attribution} attribution - attribution data.
-     * @param {number} index - attribution index.
-     * @returns {ReactElement} rendered attribution row.
+     * @param {Credit} credit - credit data.
+     * @param {number} index - credit index.
+     * @returns {ReactElement} rendered credit row.
      */
-    renderAttribution(attribution, index) {
-        const source = URL_IN_TEXT_PATTERN.exec(attribution.source);
-        const credit = fragment(
-            jsx('span', { className: 'example-attribution-title' }, attribution.title),
+    renderCredit(credit, index) {
+        const source = URL_IN_TEXT_PATTERN.exec(credit.source);
+        const label = fragment(
+            jsx('span', { className: 'example-credit-title' }, credit.title),
             ' by ',
-            jsx('span', { className: 'example-attribution-author' }, attribution.author)
+            jsx('span', { className: 'example-credit-author' }, credit.author)
         );
         return jsx(
             'p',
             {
-                className: 'example-attribution',
+                className: 'example-credit',
                 key: index
             },
-            source ? this.renderAttributionLink(source[1], credit) : credit,
+            source ? this.renderCreditLink(source[1], label) : label,
             source ? null : ' \u00b7 ',
-            source ? null : attribution.source,
+            source ? null : credit.source,
             ' \u00b7 ',
-            this.renderLicenseLink(attribution.license)
+            this.renderLicenseLink(credit.license)
         );
     }
 
-    renderAttributions() {
-        const { attributions } = this.state;
-        if (!attributions.length) {
+    renderCredits() {
+        const { credits } = this.state;
+        if (!credits.length) {
             return null;
         }
 
@@ -490,14 +497,62 @@ class Example extends TypedComponent {
             Panel,
             {
                 class: ['example-info-subpanel'],
-                headerText: 'Attribution'
+                headerText: 'Credits'
             },
             jsx(
                 Container,
                 {
-                    class: ['example-attributions']
+                    class: ['example-credits']
                 },
-                attributions.map((attribution, index) => this.renderAttribution(attribution, index))
+                credits.map((credit, index) => this.renderCredit(credit, index))
+            )
+        );
+    }
+
+    renderKeybinds() {
+        const { keybinds } = this.state;
+        if (!keybinds.length) {
+            return null;
+        }
+
+        return jsx(
+            Panel,
+            {
+                class: ['example-info-subpanel'],
+                headerText: 'Keybinds'
+            },
+            jsx(
+                Container,
+                {
+                    class: ['example-keybinds']
+                },
+                keybinds.map((keybind, index) => jsx(
+                    'div',
+                    {
+                        className: 'example-keybind',
+                        key: index
+                    },
+                    jsx(
+                        'div',
+                        {
+                            className: 'example-keybind-inputs'
+                        },
+                        keybind.inputs.map((input, inputIndex) => jsx(
+                            'kbd',
+                            {
+                                key: inputIndex
+                            },
+                            input
+                        ))
+                    ),
+                    jsx(
+                        'div',
+                        {
+                            className: 'example-keybind-action'
+                        },
+                        keybind.action
+                    )
+                ))
             )
         );
     }
@@ -522,14 +577,15 @@ class Example extends TypedComponent {
                     }
                 }) :
                 null,
-            this.renderAttributions()
+            this.renderKeybinds(),
+            this.renderCredits()
         );
     }
 
     renderInfoPanel() {
-        const { exampleLoaded, description, attributions } = this.state;
+        const { exampleLoaded, description, keybinds, credits } = this.state;
         const ready = exampleLoaded && iframe.ready;
-        if (!ready || (!description && !attributions.length)) {
+        if (!ready || (!description && !keybinds.length && !credits.length)) {
             return null;
         }
 
@@ -632,8 +688,8 @@ class Example extends TypedComponent {
 
     renderMobileDock() {
         const { mobilePanel, setMobilePanel } = this.props;
-        const { description, attributions } = this.state;
-        const hasInfo = description || attributions.length;
+        const { description, keybinds, credits } = this.state;
+        const hasInfo = description || keybinds.length || credits.length;
         return jsx(
             Container,
             {

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -17,7 +17,7 @@ import { getLayout } from '../utils.mjs';
 /**
  * @import { Observer } from '@playcanvas/observer'
  * @import { ComponentType, ReactElement } from 'react'
- * @import { ErrorEvent as ExampleErrorEvent, LoadingEvent, StateEvent } from '../events.js'
+ * @import { Attribution, ErrorEvent as ExampleErrorEvent, LoadingEvent, StateEvent } from '../events.js'
  */
 
 const PC_IMPORT = /^[ \t]*import[\s\w*{},]+["']playcanvas["'];?[ \t]*(?:\r?\n|$)/gm;
@@ -25,6 +25,7 @@ const CONTROLS_REACT_PCUI = /** @satisfies {typeof ReactPCUI} */ ({
     ...ReactPCUI,
     SelectInput: OverlaySelectInput
 });
+const URL_IN_TEXT_PATTERN = /(https?:\/\/[^\s)]+)/;
 
 /** @type {Record<string, string>} */
 const MOBILE_PANEL_TITLES = {
@@ -78,6 +79,7 @@ const MOBILE_PANEL_TITLES = {
  * @property {boolean} showDeviceSelector - Show device selector.
  * @property {Record<string, string>} files - Files of example (controls, shaders, example itself)
  * @property {string} description - Description of example.
+ * @property {Attribution[]} attributions - Attributions for the example.
  */
 
 /** @type {typeof Component<Props, State>} */
@@ -95,7 +97,8 @@ class Example extends TypedComponent {
         showDeviceSelector: true,
         files: { 'example.mjs': '// loading' },
         observer: null,
-        description: ''
+        description: '',
+        attributions: []
     };
 
     /** @type {HTMLElement | null} */
@@ -165,7 +168,9 @@ class Example extends TypedComponent {
             loadedPath: '',
             loadError: null,
             controls: null,
-            showDeviceSelector: showDeviceSelector
+            showDeviceSelector: showDeviceSelector,
+            description: '',
+            attributions: []
         });
     }
 
@@ -174,9 +179,9 @@ class Example extends TypedComponent {
      */
     async _handleExampleLoad(event) {
         const path = this.iframePath;
-        const { files, observer, description } = event.detail;
+        const { files, observer, description, attributions = [] } = event.detail;
         const controlsSrc = files['controls.mjs'];
-        if (!description && this.props.mobilePanel === 'description') {
+        if (!description && !attributions.length && this.props.mobilePanel === 'description') {
             this.props.setMobilePanel?.(null);
         }
         if (controlsSrc) {
@@ -188,7 +193,8 @@ class Example extends TypedComponent {
                 controls,
                 observer,
                 files,
-                description
+                description,
+                attributions
             });
         } else {
             // When switching examples from one with controls to one without controls...
@@ -199,7 +205,8 @@ class Example extends TypedComponent {
                 controls: null,
                 observer: null,
                 files,
-                description
+                description,
+                attributions
             });
         }
     }
@@ -243,7 +250,7 @@ class Example extends TypedComponent {
      */
     async _handleUpdateFiles(event) {
         const path = this.iframePath;
-        const { files, observer } = event.detail;
+        const { files, observer, description, attributions = [] } = event.detail;
         const controlsSrc = files['controls.mjs'] ?? '';
         if (!files['controls.mjs']) {
             this.mergeState({
@@ -251,7 +258,9 @@ class Example extends TypedComponent {
                 loadedPath: path,
                 loadError: null,
                 controls: null,
-                observer: null
+                observer: null,
+                description,
+                attributions
             });
         }
         const controls = await this._buildControls(controlsSrc);
@@ -260,7 +269,9 @@ class Example extends TypedComponent {
             loadedPath: path,
             loadError: null,
             controls,
-            observer
+            observer,
+            description,
+            attributions
         });
         window.dispatchEvent(new CustomEvent('resetErrorBoundary'));
     }
@@ -396,24 +407,98 @@ class Example extends TypedComponent {
         );
     }
 
+    /**
+     * @param {string} href - link href.
+     * @param {string} text - link text.
+     * @returns {ReactElement} rendered link.
+     */
+    renderAttributionLink(href, text) {
+        return jsx('a', {
+            href,
+            target: '_blank',
+            rel: 'noopener'
+        }, text);
+    }
+
+    /**
+     * @param {string} source - source value.
+     * @returns {ReactElement | string} rendered source.
+     */
+    renderSourceLink(source) {
+        const match = URL_IN_TEXT_PATTERN.exec(source);
+        return match ? this.renderAttributionLink(match[1], 'Source') : source;
+    }
+
+    /**
+     * @param {string} license - license value.
+     * @returns {ReactElement | string} rendered license.
+     */
+    renderLicenseLink(license) {
+        const match = URL_IN_TEXT_PATTERN.exec(license);
+        if (!match) {
+            return license;
+        }
+
+        const label = license.slice(0, match.index).trim().replace(/\s*\($/, '').trim();
+        return this.renderAttributionLink(match[1], label || 'License');
+    }
+
+    /**
+     * @param {Attribution} attribution - attribution data.
+     * @param {number} index - attribution index.
+     * @returns {ReactElement} rendered attribution row.
+     */
+    renderAttribution(attribution, index) {
+        return jsx(
+            'p',
+            {
+                className: 'example-attribution',
+                key: index
+            },
+            jsx('span', { className: 'example-attribution-title' }, attribution.title),
+            ' by ',
+            jsx('span', { className: 'example-attribution-author' }, attribution.author),
+            ' \u00b7 ',
+            this.renderSourceLink(attribution.source),
+            ' \u00b7 ',
+            this.renderLicenseLink(attribution.license)
+        );
+    }
+
+    renderAttributions() {
+        const { attributions } = this.state;
+        if (!attributions.length) {
+            return null;
+        }
+
+        return jsx(
+            'div',
+            {
+                className: 'example-attributions'
+            },
+            attributions.map((attribution, index) => this.renderAttribution(attribution, index))
+        );
+    }
+
     renderDescription() {
-        const { exampleLoaded, description } = this.state;
-        const layout = this.props.layout ?? this.state.layout;
+        const { exampleLoaded, description, attributions } = this.state;
         const ready = exampleLoaded && iframe.ready;
-        if (!ready) {
+        if (!ready || (!description && !attributions.length)) {
             return;
         }
         return jsx(
             Container,
             {
-                id: 'descriptionPanel',
-                class: layout === 'mobile' ? 'mobile' : undefined
+                id: 'descriptionPanel'
             },
-            jsx('span', {
-                dangerouslySetInnerHTML: {
-                    __html: description
-                }
-            })
+            description ?
+                jsx('span', {
+                    dangerouslySetInnerHTML: {
+                        __html: description
+                    }
+                }) :
+                null,
+            this.renderAttributions()
         );
     }
 
@@ -460,11 +545,14 @@ class Example extends TypedComponent {
                     key: 'description',
                     id: 'mobileDescriptionPanel'
                 },
-                jsx('span', {
-                    dangerouslySetInnerHTML: {
-                        __html: description
-                    }
-                })
+                description ?
+                    jsx('span', {
+                        dangerouslySetInnerHTML: {
+                            __html: description
+                        }
+                    }) :
+                    null,
+                this.renderAttributions()
             );
         }
 
@@ -495,7 +583,8 @@ class Example extends TypedComponent {
 
     renderMobileDock() {
         const { mobilePanel, setMobilePanel } = this.props;
-        const { description } = this.state;
+        const { description, attributions } = this.state;
+        const hasDescription = description || attributions.length;
         return jsx(
             Container,
             {
@@ -528,11 +617,11 @@ class Example extends TypedComponent {
             jsx(Button, {
                 key: 'description',
                 text: 'Info',
-                enabled: Boolean(description),
+                enabled: Boolean(hasDescription),
                 class: mobilePanel === 'description' ?
                     ['mobile-dock-button', 'mobile-dock-description', 'selected'] :
                     ['mobile-dock-button', 'mobile-dock-description'],
-                onClick: () => this.state.description && setMobilePanel?.('description')
+                onClick: () => (this.state.description || this.state.attributions.length) && setMobilePanel?.('description')
             })
         );
     }

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -26,6 +26,60 @@ const CONTROLS_REACT_PCUI = /** @satisfies {typeof ReactPCUI} */ ({
     SelectInput: OverlaySelectInput
 });
 const URL_IN_TEXT_PATTERN = /(https?:\/\/[^\s)]+)/;
+const INLINE_MD_PATTERN = /\*\*([^*\n]+)\*\*|\*([^*\n]+)\*|`([^`\n]+)`|\[([^\]\n]+)\]\(([^)\n]+)\)|\{([a-z]+):([^}\n]+)\}/g;
+const SAFE_URL_PATTERN = /^(?:https?:|mailto:)/i;
+const COLOR_NAMES = new Set(['accent', 'warn', 'success', 'info', 'muted']);
+
+/**
+ * Renders a plain-text description with a markdown-lite inline subset:
+ * `**bold**`, `*italic*`, `` `code` ``, `[text](url)`, and `{color:text}`.
+ * Output is a React node array, never an HTML string, so the text content
+ * is always auto-escaped by React. Link URLs are restricted to http(s) and
+ * mailto. Color names are restricted to a fixed whitelist mapped to CSS
+ * classes; unknown names are passed through as literal text.
+ *
+ * @param {string} text - The source text.
+ * @returns {(string | ReactElement)[]} The rendered nodes.
+ */
+const renderInlineMarkdown = (text) => {
+    const nodes = [];
+    let lastIndex = 0;
+    let key = 0;
+    INLINE_MD_PATTERN.lastIndex = 0;
+    let match;
+    while ((match = INLINE_MD_PATTERN.exec(text)) !== null) {
+        if (match.index > lastIndex) {
+            nodes.push(text.slice(lastIndex, match.index));
+        }
+        if (match[1] !== undefined) {
+            nodes.push(jsx('strong', { key: key++ }, match[1]));
+        } else if (match[2] !== undefined) {
+            nodes.push(jsx('em', { key: key++ }, match[2]));
+        } else if (match[3] !== undefined) {
+            nodes.push(jsx('code', { key: key++ }, match[3]));
+        } else if (match[4] !== undefined) {
+            const href = SAFE_URL_PATTERN.test(match[5]) ? match[5] : '#';
+            nodes.push(jsx('a', {
+                key: key++,
+                href,
+                target: '_blank',
+                rel: 'noopener'
+            }, match[4]));
+        } else if (COLOR_NAMES.has(match[6])) {
+            nodes.push(jsx('span', {
+                key: key++,
+                className: `example-color-${match[6]}`
+            }, match[7]));
+        } else {
+            nodes.push(match[0]);
+        }
+        lastIndex = INLINE_MD_PATTERN.lastIndex;
+    }
+    if (lastIndex < text.length) {
+        nodes.push(text.slice(lastIndex));
+    }
+    return nodes;
+};
 
 /** @type {Record<string, string>} */
 const MOBILE_PANEL_TITLES = {
@@ -559,9 +613,10 @@ class Example extends TypedComponent {
 
     /**
      * @param {string} id - The info content id.
+     * @param {boolean} [includeDescription] - Whether to include the description block.
      * @returns {ReactElement} rendered info content.
      */
-    renderInfoContent(id) {
+    renderInfoContent(id, includeDescription = false) {
         const { description } = this.state;
         return jsx(
             Container,
@@ -569,23 +624,39 @@ class Example extends TypedComponent {
                 id,
                 class: ['example-info-content']
             },
-            description ?
-                jsx('div', {
-                    className: 'example-info-description',
-                    dangerouslySetInnerHTML: {
-                        __html: description
-                    }
-                }) :
+            includeDescription && description ?
+                jsx(
+                    'div',
+                    {
+                        className: 'example-description-body example-info-description'
+                    },
+                    renderInlineMarkdown(description)
+                ) :
                 null,
             this.renderKeybinds(),
             this.renderCredits()
         );
     }
 
+    renderDescription() {
+        const { exampleLoaded, description } = this.state;
+        if (!exampleLoaded || !description || !iframe.ready) {
+            return null;
+        }
+        return jsx(
+            'div',
+            {
+                id: 'exampleDescription',
+                className: 'example-description-body'
+            },
+            renderInlineMarkdown(description)
+        );
+    }
+
     renderInfoPanel() {
-        const { exampleLoaded, description, keybinds, credits } = this.state;
+        const { exampleLoaded, keybinds, credits } = this.state;
         const ready = exampleLoaded && iframe.ready;
-        if (!ready || (!description && !keybinds.length && !credits.length)) {
+        if (!ready || (!keybinds.length && !credits.length)) {
             return null;
         }
 
@@ -658,7 +729,7 @@ class Example extends TypedComponent {
         }
 
         if (mobilePanel === 'description') {
-            return this.renderInfoContent('mobileInfoPanel');
+            return this.renderInfoContent('mobileInfoPanel', true);
         }
 
         if (mobilePanel === 'controls') {
@@ -827,6 +898,7 @@ class Example extends TypedComponent {
                 key: iframePath,
                 src: iframePath
             }),
+            layout !== 'mobile' && this.renderDescription(),
             layout === 'mobile' ? this.renderMobile() : this.renderDesktop()
         );
     }

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -32,7 +32,7 @@ const MOBILE_PANEL_TITLES = {
     examples: 'EXAMPLES',
     code: 'SOURCE',
     controls: 'CONTROLS',
-    description: 'DESCRIPTION'
+    description: 'INFO'
 };
 
 /**
@@ -71,7 +71,7 @@ const MOBILE_PANEL_TITLES = {
  * @typedef {object} State
  * @property {'mobile' | 'desktop'} layout - The layout.
  * @property {boolean} collapsed - Collapsed or not.
- * @property {boolean} attributionCollapsed - attribution panel collapsed or not.
+ * @property {boolean} infoCollapsed - Info panel collapsed or not.
  * @property {boolean} exampleLoaded - Example is loaded or not.
  * @property {string} loadedPath - The loaded iframe path.
  * @property {{ path: string, message: string } | null} loadError - The current loading error.
@@ -91,7 +91,7 @@ class Example extends TypedComponent {
     state = {
         layout: getLayout(),
         collapsed: getLayout() === 'mobile',
-        attributionCollapsed: false,
+        infoCollapsed: false,
         exampleLoaded: false,
         loadedPath: '',
         loadError: null,
@@ -327,8 +327,8 @@ class Example extends TypedComponent {
         controlPanelHeader.onclick = () => this.toggleCollapse();
     }
 
-    setupAttributionPanel() {
-        const panel = document.getElementById('attributionPanel');
+    setupInfoPanel() {
+        const panel = document.getElementById('infoPanel');
         if (!panel) {
             return;
         }
@@ -340,12 +340,12 @@ class Example extends TypedComponent {
             return;
         }
 
-        header.onclick = () => this.toggleAttributionCollapse();
+        header.onclick = () => this.toggleInfoCollapse();
     }
 
     componentDidMount() {
         this.setupControlPanel();
-        this.setupAttributionPanel();
+        this.setupInfoPanel();
         window.addEventListener('resize', this._onLayoutChange);
         window.addEventListener('requestedFiles', this._handleRequestedFiles);
         window.addEventListener('orientationchange', this._onLayoutChange);
@@ -368,7 +368,7 @@ class Example extends TypedComponent {
         }
 
         this.setupControlPanel();
-        this.setupAttributionPanel();
+        this.setupInfoPanel();
     }
 
     componentWillUnmount() {
@@ -487,57 +487,67 @@ class Example extends TypedComponent {
         }
 
         return jsx(
-            'div',
+            Panel,
             {
-                className: 'example-attributions'
+                class: ['example-info-subpanel'],
+                headerText: 'Attribution'
             },
-            attributions.map((attribution, index) => this.renderAttribution(attribution, index))
+            jsx(
+                Container,
+                {
+                    class: ['example-attributions']
+                },
+                attributions.map((attribution, index) => this.renderAttribution(attribution, index))
+            )
         );
     }
 
-    renderDescription() {
-        const { exampleLoaded, description } = this.state;
-        const ready = exampleLoaded && iframe.ready;
-        if (!ready || !description) {
-            return;
-        }
+    /**
+     * @param {string} id - The info content id.
+     * @returns {ReactElement} rendered info content.
+     */
+    renderInfoContent(id) {
+        const { description } = this.state;
         return jsx(
             Container,
             {
-                id: 'descriptionPanel'
+                id,
+                class: ['example-info-content']
             },
             description ?
-                jsx('span', {
+                jsx('div', {
+                    className: 'example-info-description',
                     dangerouslySetInnerHTML: {
                         __html: description
                     }
                 }) :
-                null
+                null,
+            this.renderAttributions()
         );
     }
 
-    renderAttributionPanel() {
-        const { exampleLoaded, attributions } = this.state;
+    renderInfoPanel() {
+        const { exampleLoaded, description, attributions } = this.state;
         const ready = exampleLoaded && iframe.ready;
-        if (!ready || !attributions.length) {
+        if (!ready || (!description && !attributions.length)) {
             return null;
         }
 
         return jsx(
             Panel,
             {
-                id: 'attributionPanel',
+                id: 'infoPanel',
                 class: ['desktop'],
-                headerText: 'ATTRIBUTION',
+                headerText: 'INFO',
                 collapsible: true,
-                collapsed: this.state.attributionCollapsed
+                collapsed: this.state.infoCollapsed
             },
             jsx(
                 Container,
                 {
-                    id: 'attributionPanel-scroll-region'
+                    id: 'infoPanel-scroll-region'
                 },
-                this.renderAttributions()
+                this.renderInfoContent('infoPanel-content')
             )
         );
     }
@@ -561,8 +571,8 @@ class Example extends TypedComponent {
         return collapsed;
     }
 
-    get attributionCollapsed() {
-        const panel = document.getElementById('attributionPanel');
+    get infoCollapsed() {
+        const panel = document.getElementById('infoPanel');
         if (!panel) {
             return false;
         }
@@ -574,13 +584,13 @@ class Example extends TypedComponent {
         this.mergeState({ collapsed: !this.collapsed });
     }
 
-    toggleAttributionCollapse() {
-        this.mergeState({ attributionCollapsed: !this.attributionCollapsed });
+    toggleInfoCollapse() {
+        this.mergeState({ infoCollapsed: !this.infoCollapsed });
     }
 
     renderMobilePanel() {
         const { mobilePanel } = this.props;
-        const { files, description } = this.state;
+        const { files } = this.state;
 
         if (mobilePanel === 'code') {
             return jsx(CodeEditorMobile, {
@@ -592,21 +602,7 @@ class Example extends TypedComponent {
         }
 
         if (mobilePanel === 'description') {
-            return jsx(
-                Container,
-                {
-                    key: 'description',
-                    id: 'mobileDescriptionPanel'
-                },
-                description ?
-                    jsx('span', {
-                        dangerouslySetInnerHTML: {
-                            __html: description
-                        }
-                    }) :
-                    null,
-                this.renderAttributions()
-            );
+            return this.renderInfoContent('mobileInfoPanel');
         }
 
         if (mobilePanel === 'controls') {
@@ -637,7 +633,7 @@ class Example extends TypedComponent {
     renderMobileDock() {
         const { mobilePanel, setMobilePanel } = this.props;
         const { description, attributions } = this.state;
-        const hasDescription = description || attributions.length;
+        const hasInfo = description || attributions.length;
         return jsx(
             Container,
             {
@@ -670,11 +666,15 @@ class Example extends TypedComponent {
             jsx(Button, {
                 key: 'description',
                 text: 'Info',
-                enabled: Boolean(hasDescription),
+                enabled: Boolean(hasInfo),
                 class: mobilePanel === 'description' ?
                     ['mobile-dock-button', 'mobile-dock-description', 'selected'] :
                     ['mobile-dock-button', 'mobile-dock-description'],
-                onClick: () => (this.state.description || this.state.attributions.length) && setMobilePanel?.('description')
+                onClick: () => {
+                    if (hasInfo) {
+                        setMobilePanel?.('description');
+                    }
+                }
             })
         );
     }
@@ -731,9 +731,8 @@ class Example extends TypedComponent {
                         this.renderControls()
                     )
                 ),
-                this.renderAttributionPanel()
-            ),
-            this.renderDescription()
+                this.renderInfoPanel()
+            )
         );
     }
 

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -116,6 +116,7 @@ const MOBILE_PANEL_TITLES = {
  * @property {'mobile'|'desktop'} [layout] - Current layout.
  * @property {null|'examples'|'code'|'controls'|'description'} [mobilePanel] - Active mobile panel.
  * @property {(mobilePanel: null|'examples'|'code'|'controls'|'description') => void} [setMobilePanel] - Set active mobile panel.
+ * @property {boolean} [showCredits] - Whether the desktop credits overlay is visible.
  * @property {(event: PointerEvent | import('react').PointerEvent<HTMLElement>) => void} [onMobilePanelDragStart] - Start mobile panel drag.
  */
 
@@ -123,7 +124,6 @@ const MOBILE_PANEL_TITLES = {
  * @typedef {object} State
  * @property {'mobile' | 'desktop'} layout - The layout.
  * @property {boolean} collapsed - Collapsed or not.
- * @property {boolean} infoCollapsed - Info panel collapsed or not.
  * @property {boolean} exampleLoaded - Example is loaded or not.
  * @property {string} loadedPath - The loaded iframe path.
  * @property {{ path: string, message: string } | null} loadError - The current loading error.
@@ -143,7 +143,6 @@ class Example extends TypedComponent {
     state = {
         layout: getLayout(),
         collapsed: getLayout() === 'mobile',
-        infoCollapsed: false,
         exampleLoaded: false,
         loadedPath: '',
         loadError: null,
@@ -379,25 +378,8 @@ class Example extends TypedComponent {
         controlPanelHeader.onclick = () => this.toggleCollapse();
     }
 
-    setupInfoPanel() {
-        const panel = document.getElementById('infoPanel');
-        if (!panel) {
-            return;
-        }
-
-        const header = /** @type {HTMLElement | null} */ (
-            /** @type {unknown} */ (panel.querySelector('.pcui-panel-header'))
-        );
-        if (!header) {
-            return;
-        }
-
-        header.onclick = () => this.toggleInfoCollapse();
-    }
-
     componentDidMount() {
         this.setupControlPanel();
-        this.setupInfoPanel();
         window.addEventListener('resize', this._onLayoutChange);
         window.addEventListener('requestedFiles', this._handleRequestedFiles);
         window.addEventListener('orientationchange', this._onLayoutChange);
@@ -420,7 +402,6 @@ class Example extends TypedComponent {
         }
 
         this.setupControlPanel();
-        this.setupInfoPanel();
     }
 
     componentWillUnmount() {
@@ -595,29 +576,16 @@ class Example extends TypedComponent {
         );
     }
 
-    renderInfoPanel() {
+    renderCreditsOverlay() {
         const { exampleLoaded, credits } = this.state;
-        const ready = exampleLoaded && iframe.ready;
-        if (!ready || !credits.length) {
+        const { showCredits, layout } = this.props;
+        if (layout !== 'desktop' || !showCredits || !exampleLoaded || !iframe.ready || !credits.length) {
             return null;
         }
-
         return jsx(
-            Panel,
-            {
-                id: 'infoPanel',
-                class: ['desktop'],
-                headerText: 'INFO',
-                collapsible: true,
-                collapsed: this.state.infoCollapsed
-            },
-            jsx(
-                Container,
-                {
-                    id: 'infoPanel-scroll-region'
-                },
-                this.renderInfoContent('infoPanel-content')
-            )
+            'div',
+            { id: 'exampleCredits' },
+            credits.map((credit, index) => this.renderCredit(credit, index))
         );
     }
 
@@ -640,21 +608,8 @@ class Example extends TypedComponent {
         return collapsed;
     }
 
-    get infoCollapsed() {
-        const panel = document.getElementById('infoPanel');
-        if (!panel) {
-            return false;
-        }
-        const collapsed = panel.classList.contains('pcui-collapsed');
-        return collapsed;
-    }
-
     toggleCollapse() {
         this.mergeState({ collapsed: !this.collapsed });
-    }
-
-    toggleInfoCollapse() {
-        this.mergeState({ infoCollapsed: !this.infoCollapsed });
     }
 
     renderMobilePanel() {
@@ -795,8 +750,7 @@ class Example extends TypedComponent {
                         },
                         this.renderControls()
                     )
-                ),
-                this.renderInfoPanel()
+                )
             )
         );
     }
@@ -841,6 +795,7 @@ class Example extends TypedComponent {
                 src: iframePath
             }),
             layout !== 'mobile' && this.renderDescription(),
+            layout !== 'mobile' && this.renderCreditsOverlay(),
             layout === 'mobile' ? this.renderMobile() : this.renderDesktop()
         );
     }

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -71,6 +71,7 @@ const MOBILE_PANEL_TITLES = {
  * @typedef {object} State
  * @property {'mobile' | 'desktop'} layout - The layout.
  * @property {boolean} collapsed - Collapsed or not.
+ * @property {boolean} attributionCollapsed - attribution panel collapsed or not.
  * @property {boolean} exampleLoaded - Example is loaded or not.
  * @property {string} loadedPath - The loaded iframe path.
  * @property {{ path: string, message: string } | null} loadError - The current loading error.
@@ -90,6 +91,7 @@ class Example extends TypedComponent {
     state = {
         layout: getLayout(),
         collapsed: getLayout() === 'mobile',
+        attributionCollapsed: false,
         exampleLoaded: false,
         loadedPath: '',
         loadError: null,
@@ -325,8 +327,25 @@ class Example extends TypedComponent {
         controlPanelHeader.onclick = () => this.toggleCollapse();
     }
 
+    setupAttributionPanel() {
+        const panel = document.getElementById('attributionPanel');
+        if (!panel) {
+            return;
+        }
+
+        const header = /** @type {HTMLElement | null} */ (
+            /** @type {unknown} */ (panel.querySelector('.pcui-panel-header'))
+        );
+        if (!header) {
+            return;
+        }
+
+        header.onclick = () => this.toggleAttributionCollapse();
+    }
+
     componentDidMount() {
         this.setupControlPanel();
+        this.setupAttributionPanel();
         window.addEventListener('resize', this._onLayoutChange);
         window.addEventListener('requestedFiles', this._handleRequestedFiles);
         window.addEventListener('orientationchange', this._onLayoutChange);
@@ -349,6 +368,7 @@ class Example extends TypedComponent {
         }
 
         this.setupControlPanel();
+        this.setupAttributionPanel();
     }
 
     componentWillUnmount() {
@@ -481,9 +501,9 @@ class Example extends TypedComponent {
     }
 
     renderDescription() {
-        const { exampleLoaded, description, attributions } = this.state;
+        const { exampleLoaded, description } = this.state;
         const ready = exampleLoaded && iframe.ready;
-        if (!ready || (!description && !attributions.length)) {
+        if (!ready || !description) {
             return;
         }
         return jsx(
@@ -497,8 +517,33 @@ class Example extends TypedComponent {
                         __html: description
                     }
                 }) :
-                null,
-            this.renderAttributions()
+                null
+        );
+    }
+
+    renderAttributionPanel() {
+        const { exampleLoaded, attributions } = this.state;
+        const ready = exampleLoaded && iframe.ready;
+        if (!ready || !attributions.length) {
+            return null;
+        }
+
+        return jsx(
+            Panel,
+            {
+                id: 'attributionPanel',
+                class: ['desktop'],
+                headerText: 'ATTRIBUTION',
+                collapsible: true,
+                collapsed: this.state.attributionCollapsed
+            },
+            jsx(
+                Container,
+                {
+                    id: 'attributionPanel-scroll-region'
+                },
+                this.renderAttributions()
+            )
         );
     }
 
@@ -521,8 +566,21 @@ class Example extends TypedComponent {
         return collapsed;
     }
 
+    get attributionCollapsed() {
+        const panel = document.getElementById('attributionPanel');
+        if (!panel) {
+            return false;
+        }
+        const collapsed = panel.classList.contains('pcui-collapsed');
+        return collapsed;
+    }
+
     toggleCollapse() {
         this.mergeState({ collapsed: !this.collapsed });
+    }
+
+    toggleAttributionCollapse() {
+        this.mergeState({ attributionCollapsed: !this.attributionCollapsed });
     }
 
     renderMobilePanel() {
@@ -655,23 +713,30 @@ class Example extends TypedComponent {
             'div',
             { style: { display: 'contents' } },
             jsx(
-                Panel,
+                'div',
                 {
-                    id: 'controlPanel',
-                    class: ['desktop'],
-                    resizable: 'top',
-                    headerText: 'CONTROLS',
-                    collapsible: true,
-                    collapsed
+                    id: 'desktopPanelStack'
                 },
-                this.renderDeviceSelector(),
                 jsx(
-                    Container,
+                    Panel,
                     {
-                        id: 'controlPanel-scroll-region'
+                        id: 'controlPanel',
+                        class: ['desktop'],
+                        resizable: 'top',
+                        headerText: 'CONTROLS',
+                        collapsible: true,
+                        collapsed
                     },
-                    this.renderControls()
-                )
+                    this.renderDeviceSelector(),
+                    jsx(
+                        Container,
+                        {
+                            id: 'controlPanel-scroll-region'
+                        },
+                        this.renderControls()
+                    )
+                ),
+                this.renderAttributionPanel()
             ),
             this.renderDescription()
         );

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -18,7 +18,7 @@ import { getLayout } from '../utils.mjs';
 /**
  * @import { Observer } from '@playcanvas/observer'
  * @import { ComponentType, ReactElement } from 'react'
- * @import { Credit, Keybind, ErrorEvent as ExampleErrorEvent, LoadingEvent, StateEvent } from '../events.js'
+ * @import { Credit, ErrorEvent as ExampleErrorEvent, LoadingEvent, StateEvent } from '../events.js'
  */
 
 const PC_IMPORT = /^[ \t]*import[\s\w*{},]+["']playcanvas["'];?[ \t]*(?:\r?\n|$)/gm;
@@ -132,7 +132,6 @@ const MOBILE_PANEL_TITLES = {
  * @property {boolean} showDeviceSelector - Show device selector.
  * @property {Record<string, string>} files - Files of example (controls, shaders, example itself)
  * @property {string} description - Description of example.
- * @property {Keybind[]} keybinds - Keybinds for the example.
  * @property {Credit[]} credits - Credits for the example.
  */
 
@@ -153,7 +152,6 @@ class Example extends TypedComponent {
         files: { 'example.mjs': '// loading' },
         observer: null,
         description: '',
-        keybinds: [],
         credits: []
     };
 
@@ -226,7 +224,6 @@ class Example extends TypedComponent {
             controls: null,
             showDeviceSelector: showDeviceSelector,
             description: '',
-            keybinds: [],
             credits: []
         });
     }
@@ -236,9 +233,9 @@ class Example extends TypedComponent {
      */
     async _handleExampleLoad(event) {
         const path = this.iframePath;
-        const { files, observer, description, keybinds = [], credits = [] } = event.detail;
+        const { files, observer, description, credits = [] } = event.detail;
         const controlsSrc = files['controls.mjs'];
-        if (!description && !keybinds.length && !credits.length && this.props.mobilePanel === 'description') {
+        if (!description && !credits.length && this.props.mobilePanel === 'description') {
             this.props.setMobilePanel?.(null);
         }
         if (controlsSrc) {
@@ -251,7 +248,6 @@ class Example extends TypedComponent {
                 observer,
                 files,
                 description,
-                keybinds,
                 credits
             });
         } else {
@@ -264,7 +260,6 @@ class Example extends TypedComponent {
                 observer: null,
                 files,
                 description,
-                keybinds,
                 credits
             });
         }
@@ -309,7 +304,7 @@ class Example extends TypedComponent {
      */
     async _handleUpdateFiles(event) {
         const path = this.iframePath;
-        const { files, observer, description, keybinds = [], credits = [] } = event.detail;
+        const { files, observer, description, credits = [] } = event.detail;
         const controlsSrc = files['controls.mjs'] ?? '';
         if (!files['controls.mjs']) {
             this.mergeState({
@@ -319,7 +314,6 @@ class Example extends TypedComponent {
                 controls: null,
                 observer: null,
                 description,
-                keybinds,
                 credits
             });
         }
@@ -331,7 +325,6 @@ class Example extends TypedComponent {
             controls,
             observer,
             description,
-            keybinds,
             credits
         });
         window.dispatchEvent(new CustomEvent('resetErrorBoundary'));
@@ -561,54 +554,6 @@ class Example extends TypedComponent {
         );
     }
 
-    renderKeybinds() {
-        const { keybinds } = this.state;
-        if (!keybinds.length) {
-            return null;
-        }
-
-        return jsx(
-            Panel,
-            {
-                class: ['example-info-subpanel'],
-                headerText: 'Keybinds'
-            },
-            jsx(
-                Container,
-                {
-                    class: ['example-keybinds']
-                },
-                keybinds.map((keybind, index) => jsx(
-                    'div',
-                    {
-                        className: 'example-keybind',
-                        key: index
-                    },
-                    jsx(
-                        'div',
-                        {
-                            className: 'example-keybind-inputs'
-                        },
-                        keybind.inputs.map((input, inputIndex) => jsx(
-                            'kbd',
-                            {
-                                key: inputIndex
-                            },
-                            input
-                        ))
-                    ),
-                    jsx(
-                        'div',
-                        {
-                            className: 'example-keybind-action'
-                        },
-                        keybind.action
-                    )
-                ))
-            )
-        );
-    }
-
     /**
      * @param {string} id - The info content id.
      * @param {boolean} [includeDescription] - Whether to include the description block.
@@ -631,7 +576,6 @@ class Example extends TypedComponent {
                     renderInlineMarkdown(description)
                 ) :
                 null,
-            this.renderKeybinds(),
             this.renderCredits()
         );
     }
@@ -652,9 +596,9 @@ class Example extends TypedComponent {
     }
 
     renderInfoPanel() {
-        const { exampleLoaded, keybinds, credits } = this.state;
+        const { exampleLoaded, credits } = this.state;
         const ready = exampleLoaded && iframe.ready;
-        if (!ready || (!keybinds.length && !credits.length)) {
+        if (!ready || !credits.length) {
             return null;
         }
 
@@ -757,8 +701,8 @@ class Example extends TypedComponent {
 
     renderMobileDock() {
         const { mobilePanel, setMobilePanel } = this.props;
-        const { description, keybinds, credits } = this.state;
-        const hasInfo = description || keybinds.length || credits.length;
+        const { description, credits } = this.state;
+        const hasInfo = description || credits.length;
         return jsx(
             Container,
             {

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -84,7 +84,7 @@ class MainLayout extends TypedComponent {
         mobilePanel: null,
         mobilePanelHeight: getDefaultMobilePanelHeight(),
         mobilePanelWidth: getDefaultMobilePanelWidth(),
-        showCredits: true
+        showCredits: localStorage.getItem('showCredits') !== 'false'
     };
 
     /** @type {{ axis: 'x'|'y', position: number, size: number } | null} */
@@ -220,6 +220,7 @@ class MainLayout extends TypedComponent {
      * @param {boolean} value - Show credits state.
      */
     setShowCredits = (value) => {
+        localStorage.setItem('showCredits', `${value}`);
         this.setState({ showCredits: value });
     };
 

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -70,6 +70,7 @@ function getDefaultMobilePanelWidth() {
  * @property {null|'examples'|'code'|'controls'|'description'} mobilePanel - Active mobile panel.
  * @property {number} mobilePanelHeight - Active mobile panel height.
  * @property {number} mobilePanelWidth - Active mobile panel width.
+ * @property {boolean} showCredits - Whether the desktop credits overlay is visible.
  */
 
 /** @type {typeof Component<Props, State>} */
@@ -82,7 +83,8 @@ class MainLayout extends TypedComponent {
         mobileOrientation: getMobileOrientation(),
         mobilePanel: null,
         mobilePanelHeight: getDefaultMobilePanelHeight(),
-        mobilePanelWidth: getDefaultMobilePanelWidth()
+        mobilePanelWidth: getDefaultMobilePanelWidth(),
+        showCredits: true
     };
 
     /** @type {{ axis: 'x'|'y', position: number, size: number } | null} */
@@ -214,8 +216,15 @@ class MainLayout extends TypedComponent {
         iframe.fire('stats', { state: value });
     };
 
+    /**
+     * @param {boolean} value - Show credits state.
+     */
+    setShowCredits = (value) => {
+        this.setState({ showCredits: value });
+    };
+
     render() {
-        const { layout, mobileOrientation, mobilePanel, mobilePanelHeight, mobilePanelWidth } = this.state;
+        const { layout, mobileOrientation, mobilePanel, mobilePanelHeight, mobilePanelWidth, showCredits } = this.state;
         return jsx(
             'div',
             {
@@ -252,7 +261,9 @@ class MainLayout extends TypedComponent {
                                 { id: 'main-view-wrapper' },
                                 jsx(Menu, {
                                     layout,
-                                    setShowMiniStats: this.updateShowMiniStats.bind(this)
+                                    setShowMiniStats: this.updateShowMiniStats.bind(this),
+                                    showCredits,
+                                    setShowCredits: this.setShowCredits
                                 }),
                                 jsx(
                                     Container,
@@ -262,6 +273,7 @@ class MainLayout extends TypedComponent {
                                         layout,
                                         mobilePanel,
                                         setMobilePanel: this.setMobilePanel,
+                                        showCredits,
                                         onMobilePanelDragStart: this.startMobilePanelDrag
                                     })
                                 )

--- a/examples/src/app/components/Menu.mjs
+++ b/examples/src/app/components/Menu.mjs
@@ -10,11 +10,14 @@ import { getLayout } from '../utils.mjs';
  * @typedef {object} Props
  * @property {(value: boolean) => void} setShowMiniStats - The state set function .
  * @property {'mobile'|'desktop'} [layout] - Current layout.
+ * @property {boolean} showCredits - Whether the desktop credits overlay is visible.
+ * @property {(value: boolean) => void} setShowCredits - Set credits overlay visibility.
  */
 
 /**
  * @typedef {object} State
  * @property {boolean} showMiniStats - Show MiniStats state.
+ * @property {boolean} hasCredits - Whether the loaded example has any credits.
  */
 
 /** @type {typeof Component<Props, State>} */
@@ -23,7 +26,8 @@ const TypedComponent = Component;
 class Menu extends TypedComponent {
     /** @type {State} */
     state = {
-        showMiniStats: getLayout() === 'desktop'
+        showMiniStats: getLayout() === 'desktop',
+        hasCredits: false
     };
 
     mouseTimeout = null;
@@ -37,6 +41,11 @@ class Menu extends TypedComponent {
         this._handleExampleLoad = this._handleExampleLoad.bind(this);
         this._handleMiniStats = this._handleMiniStats.bind(this);
         this.toggleMiniStats = this.toggleMiniStats.bind(this);
+        this.toggleCredits = this.toggleCredits.bind(this);
+    }
+
+    toggleCredits() {
+        this.props.setShowCredits(!this.props.showCredits);
     }
 
     /** @type {EventListener | null} */
@@ -113,8 +122,13 @@ class Menu extends TypedComponent {
         }
     }
 
-    _handleExampleLoad() {
+    /**
+     * @param {Event} event - exampleLoad event.
+     */
+    _handleExampleLoad(event) {
         this.props.setShowMiniStats(this.state.showMiniStats);
+        const detail = /** @type {CustomEvent<{ credits?: unknown[] }>} */ (event).detail;
+        this.setState({ hasCredits: (detail?.credits?.length ?? 0) > 0 });
     }
 
     toggleMiniStats() {
@@ -132,7 +146,8 @@ class Menu extends TypedComponent {
     }
 
     render() {
-        const { showMiniStats } = this.state;
+        const { showMiniStats, hasCredits } = this.state;
+        const { layout, showCredits } = this.props;
         return jsx(
             Container,
             {
@@ -166,6 +181,12 @@ class Menu extends TypedComponent {
                     class: showMiniStats ? 'selected' : undefined,
                     text: '',
                     onClick: this.toggleMiniStats
+                }),
+                hasCredits && layout === 'desktop' && jsx(Button, {
+                    id: 'showCreditsButton',
+                    class: showCredits ? 'selected' : undefined,
+                    text: '',
+                    onClick: this.toggleCredits
                 }),
                 jsx(Button, {
                     icon: 'E127',

--- a/examples/src/app/constants.mjs
+++ b/examples/src/app/constants.mjs
@@ -1,6 +1,8 @@
 export const VERSION = process.env.VERSION;
 
-export const MIN_DESKTOP_WIDTH = 601;
+export const MIN_DESKTOP_WIDTH = 967;
+
+export const MIN_DESKTOP_HEIGHT = 601;
 
 export const DEVICETYPE_WEBGL2 = 'webgl2';
 

--- a/examples/src/app/events.js
+++ b/examples/src/app/events.js
@@ -11,10 +11,17 @@
  */
 
 /**
+ * @typedef {object} Attribution
+ * @property {string} title - The attribution title.
+ * @property {string} author - The attribution author.
+ * @property {string} source - The attribution source.
+ * @property {string} license - The attribution license.
+ *
  * @typedef {object} StateEventDetail
  * @property {Observer} observer - The PCUI observer.
  * @property {Record<string, string>} files - The example files.
  * @property {string} description - The example description.
+ * @property {Attribution[]} attributions - The example attributions.
  *
  * @typedef {CustomEvent<StateEventDetail>} StateEvent
  */

--- a/examples/src/app/events.js
+++ b/examples/src/app/events.js
@@ -17,15 +17,10 @@
  * @property {string} source - The credit source.
  * @property {string} license - The credit license.
  *
- * @typedef {object} Keybind
- * @property {string[]} inputs - The keybind inputs.
- * @property {string} action - The keybind action.
- *
  * @typedef {object} StateEventDetail
  * @property {Observer} observer - The PCUI observer.
  * @property {Record<string, string>} files - The example files.
  * @property {string} description - The example description.
- * @property {Keybind[]} keybinds - The example keybinds.
  * @property {Credit[]} credits - The example credits.
  *
  * @typedef {CustomEvent<StateEventDetail>} StateEvent

--- a/examples/src/app/events.js
+++ b/examples/src/app/events.js
@@ -11,17 +11,22 @@
  */
 
 /**
- * @typedef {object} Attribution
- * @property {string} title - The attribution title.
- * @property {string} author - The attribution author.
- * @property {string} source - The attribution source.
- * @property {string} license - The attribution license.
+ * @typedef {object} Credit
+ * @property {string} title - The credit title.
+ * @property {string} author - The credit author.
+ * @property {string} source - The credit source.
+ * @property {string} license - The credit license.
+ *
+ * @typedef {object} Keybind
+ * @property {string[]} inputs - The keybind inputs.
+ * @property {string} action - The keybind action.
  *
  * @typedef {object} StateEventDetail
  * @property {Observer} observer - The PCUI observer.
  * @property {Record<string, string>} files - The example files.
  * @property {string} description - The example description.
- * @property {Attribution[]} attributions - The example attributions.
+ * @property {Keybind[]} keybinds - The example keybinds.
+ * @property {Credit[]} credits - The example credits.
  *
  * @typedef {CustomEvent<StateEventDetail>} StateEvent
  */

--- a/examples/src/app/utils.mjs
+++ b/examples/src/app/utils.mjs
@@ -1,4 +1,4 @@
-import { MIN_DESKTOP_WIDTH } from './constants.mjs';
+import { MIN_DESKTOP_HEIGHT, MIN_DESKTOP_WIDTH } from './constants.mjs';
 
 /**
  * @typedef {'mobile'|'desktop'} Layout
@@ -10,7 +10,7 @@ import { MIN_DESKTOP_WIDTH } from './constants.mjs';
 const getLayout = () => {
     const win = window.top ?? window;
     const touch = window.matchMedia('(pointer: coarse)').matches || navigator.maxTouchPoints > 0;
-    return win.innerWidth < MIN_DESKTOP_WIDTH || (touch && win.innerHeight < MIN_DESKTOP_WIDTH) ? 'mobile' : 'desktop';
+    return win.innerWidth < MIN_DESKTOP_WIDTH || (touch && win.innerHeight < MIN_DESKTOP_HEIGHT) ? 'mobile' : 'desktop';
 };
 
 export { getLayout };

--- a/examples/src/examples/camera/first-person.example.mjs
+++ b/examples/src/examples/camera/first-person.example.mjs
@@ -1,9 +1,6 @@
 // @config
 //
-// @keybinds
-// WASD: Move
-// Space: Jump
-// Mouse: Look
+// `WASD` Move · `Space` Jump · `Mouse` Look
 
 import * as pc from 'playcanvas';
 import { FirstPersonController } from 'playcanvas/scripts/esm/first-person-controller.mjs';

--- a/examples/src/examples/camera/first-person.example.mjs
+++ b/examples/src/examples/camera/first-person.example.mjs
@@ -1,10 +1,9 @@
 // @config
 //
-// <div style='text-align:center'>
-//     <div>(<b>WASD</b>) Move</div>
-//     <div>(<b>Space</b>) Jump</div>
-//     <div>(<b>Mouse</b>) Look</div>
-// </div>
+// @keybinds
+// WASD: Move
+// Space: Jump
+// Mouse: Look
 
 import * as pc from 'playcanvas';
 import { FirstPersonController } from 'playcanvas/scripts/esm/first-person-controller.mjs';

--- a/examples/src/examples/camera/fly.example.mjs
+++ b/examples/src/examples/camera/fly.example.mjs
@@ -1,10 +1,10 @@
 // @config
 //
-// <div style='text-align:center'>
-//     <div>(<b>WASDQE</b>) Move </div>
-//     <div>(<b>Hold Shift</b>) Move Fast (<b>Hold Ctrl</b>) Move Slow</div>
-//     <div>(<b>LMB / RMB </b>) Fly</div>
-// </div>
+// @keybinds
+// WASDQE: Move
+// Hold Shift: Move fast
+// Hold Ctrl: Move slow
+// LMB / RMB: Fly
 
 import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';

--- a/examples/src/examples/camera/fly.example.mjs
+++ b/examples/src/examples/camera/fly.example.mjs
@@ -1,10 +1,6 @@
 // @config
 //
-// @keybinds
-// WASDQE: Move
-// Hold Shift: Move fast
-// Hold Ctrl: Move slow
-// LMB / RMB: Fly
+// `WASDQE` Move · Hold `Shift` Move fast · Hold `Ctrl` Move slow · `LMB` / `RMB` Fly
 
 import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';

--- a/examples/src/examples/camera/multi.example.mjs
+++ b/examples/src/examples/camera/multi.example.mjs
@@ -1,14 +1,6 @@
 // @config
 //
-// @keybinds
-// WASDQE: Move
-// Hold Shift: Move fast
-// Hold Ctrl: Move slow
-// LMB / RMB: Orbit / fly
-// Hold Shift / MMB: Pan
-// Wheel / Pinch: Zoom
-// F: Focus
-// R: Reset
+// `WASDQE` Move · Hold `Shift` Move fast · Hold `Ctrl` Move slow · `LMB` / `RMB` Orbit / fly · Hold `Shift` / `MMB` Pan · `Wheel` / `Pinch` Zoom · `F` Focus · `R` Reset
 
 import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';

--- a/examples/src/examples/camera/multi.example.mjs
+++ b/examples/src/examples/camera/multi.example.mjs
@@ -1,13 +1,14 @@
 // @config
 //
-// <div style='text-align:center'>
-//     <div>(<b>WASDQE</b>) Move </div>
-//     <div>(<b>Hold Shift</b>) Move Fast (<b>Hold Ctrl</b>) Move Slow</div>
-//     <div>(<b>LMB / RMB </b>) Orbit / Fly</div>
-//     <div>(<b>Hold Shift / MMB </b>) Pan</div>
-//     <div>(<b>Wheel / Pinch</b>) Zoom</div>
-//     <div>(<b>F</b>) Focus (<b>R</b>) Reset</div>
-// </div>
+// @keybinds
+// WASDQE: Move
+// Hold Shift: Move fast
+// Hold Ctrl: Move slow
+// LMB / RMB: Orbit / fly
+// Hold Shift / MMB: Pan
+// Wheel / Pinch: Zoom
+// F: Focus
+// R: Reset
 
 import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';

--- a/examples/src/examples/camera/orbit.example.mjs
+++ b/examples/src/examples/camera/orbit.example.mjs
@@ -1,11 +1,6 @@
 // @config
 //
-// @keybinds
-// LMB / RMB: Orbit
-// Hold Shift / MMB: Pan
-// Wheel / Pinch: Zoom
-// F: Focus
-// R: Reset
+// `LMB` / `RMB` Orbit · Hold `Shift` / `MMB` Pan · `Wheel` / `Pinch` Zoom · `F` Focus · `R` Reset
 
 import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';

--- a/examples/src/examples/camera/orbit.example.mjs
+++ b/examples/src/examples/camera/orbit.example.mjs
@@ -1,11 +1,11 @@
 // @config
 //
-// <div style='text-align:center'>
-//     <div>(<b>LMB / RMB </b>) Orbit</div>
-//     <div>(<b>Hold Shift / MMB </b>) Pan</div>
-//     <div>(<b>Wheel / Pinch</b>) Zoom</div>
-//     <div>(<b>F</b>) Focus (<b>R</b>) Reset</div>
-// </div>
+// @keybinds
+// LMB / RMB: Orbit
+// Hold Shift / MMB: Pan
+// Wheel / Pinch: Zoom
+// F: Focus
+// R: Reset
 
 import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';

--- a/examples/src/examples/gaussian-splatting/editor.example.mjs
+++ b/examples/src/examples/gaussian-splatting/editor.example.mjs
@@ -1,11 +1,11 @@
 // @config
 //
-// <span style="color:yellow">
-//     <b>Controls:</b> Select button - show selection box | Gizmo - move selection box | Left Mouse
-//     Button - orbit
-// </span>
-// <br>
 // GSplat editor with AABB selection, deletion, and cloning using GSplatProcessor.
+//
+// @keybinds
+// Select button: Show selection box
+// Gizmo: Move selection box
+// LMB: Orbit
 
 import * as pc from 'playcanvas';
 

--- a/examples/src/examples/gaussian-splatting/editor.example.mjs
+++ b/examples/src/examples/gaussian-splatting/editor.example.mjs
@@ -2,10 +2,7 @@
 //
 // GSplat editor with AABB selection, deletion, and cloning using GSplatProcessor.
 //
-// @keybinds
-// Select button: Show selection box
-// Gizmo: Move selection box
-// LMB: Orbit
+// `Select button` Show selection box · `Gizmo` Move selection box · `LMB` Orbit
 
 import * as pc from 'playcanvas';
 

--- a/examples/src/examples/gaussian-splatting/first-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/first-person.example.mjs
@@ -5,13 +5,12 @@
 //     <div>(<b>Space</b>) Jump</div>
 //     <div>(<b>Mouse</b>) Look</div>
 // </div>
-
 //
-// Scene attribution:
-//   Title:   Sunnyvale Heritage Park Museum
-//   Author:  zeitgeistarchivescans
-//   Source:  https://superspl.at/scene/d5d397aa
-//   License: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
+// @attribution
+// title: Sunnyvale Heritage Park Museum
+// author: zeitgeistarchivescans
+// source: https://superspl.at/scene/d5d397aa
+// license: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
 
 import * as pc from 'playcanvas';
 import { FirstPersonController } from 'playcanvas/scripts/esm/first-person-controller.mjs';

--- a/examples/src/examples/gaussian-splatting/first-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/first-person.example.mjs
@@ -1,9 +1,6 @@
 // @config
 //
-// @keybinds
-// WASD: Move
-// Space: Jump
-// Mouse: Look
+// `WASD` Move · `Space` Jump · `Mouse` Look
 //
 // @credit
 // title: Sunnyvale Heritage Park Museum

--- a/examples/src/examples/gaussian-splatting/first-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/first-person.example.mjs
@@ -1,12 +1,11 @@
 // @config
 //
-// <div style='text-align:center'>
-//     <div>(<b>WASD</b>) Move</div>
-//     <div>(<b>Space</b>) Jump</div>
-//     <div>(<b>Mouse</b>) Look</div>
-// </div>
+// @keybinds
+// WASD: Move
+// Space: Jump
+// Mouse: Look
 //
-// @attribution
+// @credit
 // title: Sunnyvale Heritage Park Museum
 // author: zeitgeistarchivescans
 // source: https://superspl.at/scene/d5d397aa

--- a/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
@@ -2,10 +2,7 @@
 //
 // Pick two LUTs and use Blend to crossfade between them, or enable Animate.
 //
-// @keybinds
-// WASD: Move
-// Space: Jump
-// Mouse: Look
+// `WASD` Move · `Space` Jump · `Mouse` Look
 //
 // @credit
 // title: Sunnyvale Heritage Park Museum

--- a/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
@@ -1,13 +1,13 @@
 // @config
 //
-// <div style='text-align:center'>
-//     <div>(<b>WASD</b>) Move</div>
-//     <div>(<b>Space</b>) Jump</div>
-//     <div>(<b>Mouse</b>) Look</div>
-//     <div>Pick two LUTs and use Blend to crossfade between them, or enable Animate.</div>
-// </div>
+// Pick two LUTs and use Blend to crossfade between them, or enable Animate.
 //
-// @attribution
+// @keybinds
+// WASD: Move
+// Space: Jump
+// Mouse: Look
+//
+// @credit
 // title: Sunnyvale Heritage Park Museum
 // author: zeitgeistarchivescans
 // source: https://superspl.at/scene/d5d397aa

--- a/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
@@ -6,13 +6,12 @@
 //     <div>(<b>Mouse</b>) Look</div>
 //     <div>Pick two LUTs and use Blend to crossfade between them, or enable Animate.</div>
 // </div>
-
 //
-// Scene attribution:
-//   Title:   Sunnyvale Heritage Park Museum
-//   Author:  zeitgeistarchivescans
-//   Source:  https://superspl.at/scene/d5d397aa
-//   License: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
+// @attribution
+// title: Sunnyvale Heritage Park Museum
+// author: zeitgeistarchivescans
+// source: https://superspl.at/scene/d5d397aa
+// license: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
 
 import * as pc from 'playcanvas';
 import { FirstPersonController } from 'playcanvas/scripts/esm/first-person-controller.mjs';

--- a/examples/src/examples/gaussian-splatting/paint.example.mjs
+++ b/examples/src/examples/gaussian-splatting/paint.example.mjs
@@ -1,10 +1,10 @@
 // @config
 //
-// <span style="color:yellow">
-//     <b>Controls:</b> Right Mouse Button - paint | Left Mouse Button - orbit
-// </span>
-// <br>
 // 3D painting on gaussian splats using GSplatProcessor.
+//
+// @keybinds
+// RMB: Paint
+// LMB: Orbit
 
 import * as pc from 'playcanvas';
 

--- a/examples/src/examples/gaussian-splatting/paint.example.mjs
+++ b/examples/src/examples/gaussian-splatting/paint.example.mjs
@@ -2,9 +2,7 @@
 //
 // 3D painting on gaussian splats using GSplatProcessor.
 //
-// @keybinds
-// RMB: Paint
-// LMB: Orbit
+// `RMB` Paint · `LMB` Orbit
 
 import * as pc from 'playcanvas';
 

--- a/examples/src/examples/gaussian-splatting/third-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/third-person.example.mjs
@@ -1,15 +1,14 @@
 // @config
 //
-// <div style='text-align:center'>
-//     <div>(<b>WASD</b>) Move</div>
-//     <div>(<b>Shift</b>) Sprint</div>
-//     <div>(<b>Space</b>) Jump</div>
-//     <div>(<b>Q</b>) Dance</div>
-//     <div>(<b>Mouse</b>) Orbit camera</div>
-//     <div>(<b>Wheel</b>) Zoom</div>
-// </div>
+// @keybinds
+// WASD: Move
+// Shift: Sprint
+// Space: Jump
+// Q: Dance
+// Mouse: Orbit camera
+// Wheel: Zoom
 //
-// @attribution
+// @credit
 // title: Sunnyvale Heritage Park Museum
 // author: zeitgeistarchivescans
 // source: https://superspl.at/scene/d5d397aa

--- a/examples/src/examples/gaussian-splatting/third-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/third-person.example.mjs
@@ -1,12 +1,6 @@
 // @config
 //
-// @keybinds
-// WASD: Move
-// Shift: Sprint
-// Space: Jump
-// Q: Dance
-// Mouse: Orbit camera
-// Wheel: Zoom
+// `WASD` Move · `Shift` Sprint · `Space` Jump · `Q` Dance · `Mouse` Orbit camera · `Wheel` Zoom
 //
 // @credit
 // title: Sunnyvale Heritage Park Museum

--- a/examples/src/examples/gaussian-splatting/third-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/third-person.example.mjs
@@ -8,13 +8,12 @@
 //     <div>(<b>Mouse</b>) Orbit camera</div>
 //     <div>(<b>Wheel</b>) Zoom</div>
 // </div>
-
 //
-// Scene attribution:
-//   Title:   Sunnyvale Heritage Park Museum
-//   Author:  zeitgeistarchivescans
-//   Source:  https://superspl.at/scene/d5d397aa
-//   License: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
+// @attribution
+// title: Sunnyvale Heritage Park Museum
+// author: zeitgeistarchivescans
+// source: https://superspl.at/scene/d5d397aa
+// license: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
 
 import * as pc from 'playcanvas';
 import { ShadowCatcher } from 'playcanvas/scripts/esm/shadow-catcher.mjs';

--- a/examples/src/examples/misc/editor.example.mjs
+++ b/examples/src/examples/misc/editor.example.mjs
@@ -1,11 +1,14 @@
 // @config
 //
-// <div style='text-align:center'>
-//     <div>Translate (1), Rotate (2), Scale (3)</div>
-//     <div>World/Local (X)</div>
-//     <div>Perspective (P), Orthographic (O)</div>
-//     <div>Snap (Hold Shift), Non-Uniform (Hold Ctrl)</div>
-// </div>
+// @keybinds
+// 1: Translate
+// 2: Rotate
+// 3: Scale
+// X: Toggle world/local
+// P: Perspective
+// O: Orthographic
+// Hold Shift: Snap
+// Hold Ctrl: Non-uniform scale
 
 import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';

--- a/examples/src/examples/misc/editor.example.mjs
+++ b/examples/src/examples/misc/editor.example.mjs
@@ -1,14 +1,6 @@
 // @config
 //
-// @keybinds
-// 1: Translate
-// 2: Rotate
-// 3: Scale
-// X: Toggle world/local
-// P: Perspective
-// O: Orthographic
-// Hold Shift: Snap
-// Hold Ctrl: Non-uniform scale
+// `1` Translate · `2` Rotate · `3` Scale · `X` Toggle world/local · `P` Perspective · `O` Orthographic · Hold `Shift` Snap · Hold `Ctrl` Non-uniform scale
 
 import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';

--- a/examples/src/examples/misc/html-texture-configurator.example.mjs
+++ b/examples/src/examples/misc/html-texture-configurator.example.mjs
@@ -1,6 +1,6 @@
 // @config
 //
-// <div style="color:black">
+// <div>
 //     3D product configurator with an HTML UI panel rendered as a WebGL texture via
 //     <b>HTML-in-Canvas</b> API. Uses <code>getElementTransform</code> for interactive hit testing —
 //     clicks and hovers on the 3D panel are handled by the browser's native DOM event system.

--- a/examples/src/examples/misc/html-texture-configurator.example.mjs
+++ b/examples/src/examples/misc/html-texture-configurator.example.mjs
@@ -1,12 +1,10 @@
 // @config
 //
-// <div>
-//     3D product configurator with an HTML UI panel rendered as a WebGL texture via
-//     <b>HTML-in-Canvas</b> API. Uses <code>getElementTransform</code> for interactive hit testing —
-//     clicks and hovers on the 3D panel are handled by the browser's native DOM event system.
-//     <br>
-//     <b>Click</b> to switch shoe material variants.
-// </div>
+// 3D product configurator with an HTML UI panel rendered as a WebGL texture via
+// the {accent:HTML-in-Canvas} API. Uses {accent:getElementTransform} for
+// interactive hit testing — clicks and hovers on the 3D panel are handled by
+// the browser's native DOM event system. {accent:Click} to switch shoe
+// material variants.
 
 //
 // This example demonstrates a 3D product configurator where an interactive HTML

--- a/examples/src/examples/misc/html-texture.example.mjs
+++ b/examples/src/examples/misc/html-texture.example.mjs
@@ -1,6 +1,6 @@
 // @config
 //
-// <div style="color:black">
+// <div>
 //     Renders live HTML content directly as a WebGL texture via the <b>HTML-in-Canvas</b> API
 //     (<code>texElementImage2D</code>).
 //     <br>

--- a/examples/src/examples/misc/html-texture.example.mjs
+++ b/examples/src/examples/misc/html-texture.example.mjs
@@ -1,11 +1,8 @@
 // @config
 //
-// <div>
-//     Renders live HTML content directly as a WebGL texture via the <b>HTML-in-Canvas</b> API
-//     (<code>texElementImage2D</code>).
-//     <br>
-//     Includes animated CSS gradients, text glow, and a pulsing circle — all driven by standard CSS.
-// </div>
+// Renders live HTML content directly as a WebGL texture via the
+// {accent:HTML-in-Canvas} API ({accent:texElementImage2D}). Includes animated
+// CSS gradients, text glow, and a pulsing circle — all driven by standard CSS.
 
 //
 // This example demonstrates the HTML-in-Canvas API: a styled HTML element with

--- a/examples/src/examples/shaders/cloud-shadows.example.mjs
+++ b/examples/src/examples/shaders/cloud-shadows.example.mjs
@@ -1,9 +1,7 @@
 // @config
 //
-// <div style='color: white;'>
-//     This example demonstrates scrolling cloud shadows using a shader chunk override on
-//     StandardMaterial.
-// </div>
+// This example demonstrates scrolling cloud shadows using a shader chunk
+// override on {accent:StandardMaterial}.
 
 import * as pc from 'playcanvas';
 

--- a/examples/src/examples/shaders/integer-textures.example.mjs
+++ b/examples/src/examples/shaders/integer-textures.example.mjs
@@ -1,9 +1,6 @@
 // @config
 //
-// @keybinds
-// Click: Add sand
-// Shift-click: Remove sand
-// Space: Reset
+// `Click` Add sand · `Shift-click` Remove sand · `Space` Reset
 
 import * as pc from 'playcanvas';
 

--- a/examples/src/examples/shaders/integer-textures.example.mjs
+++ b/examples/src/examples/shaders/integer-textures.example.mjs
@@ -1,10 +1,9 @@
 // @config
 //
-// <ul>
-//     <li>Click to add sand
-//     <li>Shift-click to remove sand
-//     <li>Press space to reset.
-// </ul>
+// @keybinds
+// Click: Add sand
+// Shift-click: Remove sand
+// Space: Reset
 
 import * as pc from 'playcanvas';
 

--- a/examples/src/examples/shaders/trees.example.mjs
+++ b/examples/src/examples/shaders/trees.example.mjs
@@ -1,8 +1,6 @@
 // @config
 //
-// <div>
-//     This example shows how to override shader chunks of StandardMaterial.
-// </div>
+// This example shows how to override shader chunks of {accent:StandardMaterial}.
 
 import * as pc from 'playcanvas';
 

--- a/examples/src/examples/shaders/trees.example.mjs
+++ b/examples/src/examples/shaders/trees.example.mjs
@@ -1,6 +1,6 @@
 // @config
 //
-// <div style='color: black;'>
+// <div>
 //     This example shows how to override shader chunks of StandardMaterial.
 // </div>
 

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -455,6 +455,7 @@ body {
     z-index: 9999;
     display: flex;
     flex-direction: column;
+    align-items: flex-end;
     gap: 8px;
     width: 280px;
     max-height: none;
@@ -492,11 +493,19 @@ body {
 #appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed,
 #appInner.desktop #desktopPanelStack #infoPanel.pcui-collapsed {
     overflow: hidden;
+    width: auto;
+    min-width: 0;
+}
+
+#appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed > .pcui-panel-content,
+#appInner.desktop #desktopPanelStack #infoPanel.pcui-collapsed > .pcui-panel-content {
+    display: none;
 }
 
 #appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed > .pcui-panel-header,
 #appInner.desktop #desktopPanelStack #infoPanel.pcui-collapsed > .pcui-panel-header {
     border-radius: var(--desktop-panel-radius);
+    padding-right: 12px;
 }
 
 #controlPanel.empty {

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -289,6 +289,7 @@ body {
     overflow: hidden;
     flex-grow: 1;
     position: relative;
+    container-type: inline-size;
 }
 #appInner.desktop #canvas-container {
     min-width: 445px;
@@ -644,7 +645,10 @@ body {
     transform: translateX(-50%);
     z-index: 9998;
     box-sizing: border-box;
-    max-width: 475px;
+    /* Centered description shrinks within [300, 475]px as the canvas
+       narrows, keeping clear of the controls panel (288px + 8px gap each
+       side = 592px total reserved). */
+    max-width: max(300px, min(475px, calc(100cqi - 592px)));
     padding: 8px 16px;
     background-color: rgba(54, 67, 70, 0.85);
     border-radius: 6px;
@@ -656,6 +660,19 @@ body {
     overflow-wrap: anywhere;
     pointer-events: none;
     user-select: none;
+}
+
+/* Once even the 300px minimum can't fit centered between menu and controls
+   (canvas < 892px), drop the description below the menu row and left-align
+   it. Width is now clamped against just the controls column (304px). */
+@container (max-width: 891px) {
+    #exampleDescription {
+        top: 64px;
+        left: 8px;
+        transform: none;
+        text-align: left;
+        max-width: min(475px, calc(100cqi - 304px));
+    }
 }
 
 #exampleCredits {

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -451,12 +451,17 @@ body {
     position: absolute;
     top: 8px;
     right: 8px;
+    bottom: 8px;
     z-index: 9999;
     display: flex;
     flex-direction: column;
     gap: 8px;
     width: 280px;
-    max-height: calc(100% - 16px);
+    max-height: none;
+}
+
+#appInner.desktop #desktopPanelStack #infoPanel {
+    margin-top: auto;
 }
 
 #appInner.desktop #desktopPanelStack #controlPanel,

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -732,14 +732,10 @@ body {
 
 .example-keybind {
     display: grid;
-    grid-template-columns: 100px minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 6px;
     align-items: center;
     min-height: 24px;
-}
-
-#appInner.mobile .example-keybind {
-    grid-template-columns: 94px minmax(0, 1fr);
 }
 
 .example-keybind-inputs {

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -430,8 +430,7 @@ body {
     opacity: 50%;
 }
 
-#controlPanel,
-#infoPanel {
+#controlPanel {
     --desktop-panel-radius: 6px;
 
     position: absolute;
@@ -458,10 +457,14 @@ body {
     gap: 8px;
     width: 280px;
     max-height: none;
+    pointer-events: none;
 }
 
-#appInner.desktop #desktopPanelStack #controlPanel,
-#appInner.desktop #desktopPanelStack #infoPanel {
+#desktopPanelStack > * {
+    pointer-events: auto;
+}
+
+#appInner.desktop #desktopPanelStack #controlPanel {
     position: relative;
     top: auto;
     right: auto;
@@ -470,35 +473,29 @@ body {
     max-height: none;
 }
 
-#appInner.desktop #desktopPanelStack #controlPanel > .pcui-panel-header,
-#appInner.desktop #desktopPanelStack #infoPanel > .pcui-panel-header {
+#appInner.desktop #desktopPanelStack #controlPanel > .pcui-panel-header {
     border-radius: var(--desktop-panel-radius) var(--desktop-panel-radius) 0 0;
 }
 
-#appInner.desktop #desktopPanelStack #controlPanel > .pcui-panel-content,
-#appInner.desktop #desktopPanelStack #infoPanel > .pcui-panel-content {
+#appInner.desktop #desktopPanelStack #controlPanel > .pcui-panel-content {
     border-radius: 0 0 var(--desktop-panel-radius) var(--desktop-panel-radius);
 }
 
-#appInner.desktop #desktopPanelStack #controlPanel-scroll-region,
-#appInner.desktop #desktopPanelStack #infoPanel-scroll-region {
+#appInner.desktop #desktopPanelStack #controlPanel-scroll-region {
     border-radius: 0 0 var(--desktop-panel-radius) var(--desktop-panel-radius);
 }
 
-#appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed,
-#appInner.desktop #desktopPanelStack #infoPanel.pcui-collapsed {
+#appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed {
     overflow: hidden;
     width: auto;
     min-width: 0;
 }
 
-#appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed > .pcui-panel-content,
-#appInner.desktop #desktopPanelStack #infoPanel.pcui-collapsed > .pcui-panel-content {
+#appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed > .pcui-panel-content {
     display: none;
 }
 
-#appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed > .pcui-panel-header,
-#appInner.desktop #desktopPanelStack #infoPanel.pcui-collapsed > .pcui-panel-header {
+#appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed > .pcui-panel-header {
     border-radius: var(--desktop-panel-radius);
     padding-right: 12px;
 }
@@ -611,8 +608,7 @@ body {
     min-width: 46px;
 }
 
-#controlPanel > .pcui-panel-content,
-#infoPanel > .pcui-panel-content {
+#controlPanel > .pcui-panel-content {
     background-color: #364346;
 }
 
@@ -641,11 +637,6 @@ body {
     overflow-y: auto;
 }
 
-#infoPanel-scroll-region {
-    max-height: min(260px, 35vh);
-    overflow-y: auto;
-}
-
 #exampleDescription {
     position: absolute;
     top: 8px;
@@ -665,6 +656,33 @@ body {
     overflow-wrap: anywhere;
     pointer-events: none;
     user-select: none;
+}
+
+#exampleCredits {
+    position: absolute;
+    bottom: 8px;
+    right: 8px;
+    z-index: 9998;
+    box-sizing: border-box;
+    max-width: 475px;
+    padding: 8px 16px;
+    background-color: rgba(54, 67, 70, 0.85);
+    border-radius: 6px;
+    color: #f2f2f2;
+    font-size: 13px;
+    line-height: 1.45;
+    text-align: right;
+    pointer-events: none;
+    user-select: none;
+}
+
+#exampleCredits a {
+    color: #f2f2f2;
+    pointer-events: auto;
+}
+
+#exampleCredits .example-credit {
+    margin: 0;
 }
 
 /* When the canvas itself is too narrow for a centered overlay between the
@@ -1120,9 +1138,26 @@ body {
     max-width: 272px;
 }
 
-#menu #showMiniStatsButton.selected {
+#menu #showMiniStatsButton.selected,
+#menu #showCreditsButton.selected {
     color: white;
     background-color: #F60;
+}
+
+#menu #showCreditsButton {
+    --credits-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 1.5a8.5 8.5 0 1 1 0 17 8.5 8.5 0 0 1 0-17Z'/%3E%3Cpath d='M12.5 7a5 5 0 1 0 0 10c1.7 0 3.2-.8 4-2.2l-1.7-1c-.5.9-1.4 1.4-2.3 1.4a3 3 0 1 1 0-6c.9 0 1.8.5 2.3 1.4l1.7-1A5 5 0 0 0 12.5 7z'/%3E%3C/svg%3E");
+}
+
+#menu #showCreditsButton::before {
+    content: '';
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    width: 20px;
+    height: 20px;
+    background-color: currentColor;
+    -webkit-mask: var(--credits-icon) no-repeat center / contain;
+    mask: var(--credits-icon) no-repeat center / contain;
 }
 
 #mobileDock {

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -655,7 +655,7 @@ body {
     transform: translateX(-50%);
     z-index: 9998;
     box-sizing: border-box;
-    max-width: min(50%, 640px);
+    max-width: 475px;
     padding: 8px 16px;
     background-color: rgba(54, 67, 70, 0.64);
     backdrop-filter: blur(32px);
@@ -670,6 +670,10 @@ body {
     user-select: none;
 }
 
+/* When the canvas itself is too narrow for a centered overlay between the
+   top-left menu and the top-right controls panel, drop the description
+   below the menu/controls row and left-align it. Reserve 320px on the right
+   so it stays clear of the panel stack column. */
 .example-info-description {
     padding: 12px;
     white-space: pre-line;

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -795,52 +795,6 @@ body {
     padding: 6px;
 }
 
-.example-keybinds {
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-    font-size: 12px;
-    line-height: 24px;
-}
-
-.example-keybind {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    gap: 6px;
-    align-items: center;
-    min-height: 24px;
-}
-
-.example-keybind-inputs {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 3px;
-    min-width: 0;
-}
-
-.example-keybind-inputs kbd {
-    display: inline-flex;
-    align-items: center;
-    min-height: 20px;
-    box-sizing: border-box;
-    padding: 0 6px;
-    border: 1px solid #6d7476;
-    border-radius: 3px;
-    background: #20292b;
-    color: #f2f2f2;
-    font-family: monospace;
-    font-size: 12px;
-    line-height: 18px;
-    white-space: nowrap;
-}
-
-.example-keybind-action {
-    min-width: 0;
-    color: #b1b8ba;
-    overflow-wrap: anywhere;
-}
-
 .example-credit {
     color: #b1b8ba;
     max-width: 100%;

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -461,10 +461,6 @@ body {
     max-height: none;
 }
 
-#appInner.desktop #desktopPanelStack #infoPanel {
-    margin-top: auto;
-}
-
 #appInner.desktop #desktopPanelStack #controlPanel,
 #appInner.desktop #desktopPanelStack #infoPanel {
     position: relative;

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -593,11 +593,6 @@ body {
     text-align: center;
 }
 
-#descriptionPanel.mobile {
-    bottom: 100px;
-    width: 90%;
-}
-
 #descriptionPanel a {
     color: #f2f2f2;
 }
@@ -620,6 +615,28 @@ body {
 #appInner.mobile #controlPanel.mobile > .pcui-panel-content,
 #appInner.mobile .code-editor-mobile-files {
     touch-action: pan-y;
+}
+
+.example-attributions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    margin-top: 8px;
+    font-size: 12px;
+    line-height: 1.35;
+}
+
+.example-attribution {
+    max-width: 100%;
+    margin: 0;
+    opacity: 0.82;
+    overflow-wrap: anywhere;
+    text-align: center;
+}
+
+.example-attribution-title {
+    font-weight: 600;
 }
 
 #appInner.mobile #menu,

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -701,6 +701,14 @@ body {
     font-weight: 600;
 }
 
+#mobileDescriptionPanel .example-attributions {
+    align-items: stretch;
+}
+
+#mobileDescriptionPanel .example-attribution {
+    text-align: left;
+}
+
 #attributionPanel .example-attributions {
     align-items: stretch;
     margin-top: 0;

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -431,7 +431,7 @@ body {
 }
 
 #controlPanel,
-#attributionPanel {
+#infoPanel {
     --desktop-panel-radius: 6px;
 
     position: absolute;
@@ -460,7 +460,7 @@ body {
 }
 
 #appInner.desktop #desktopPanelStack #controlPanel,
-#appInner.desktop #desktopPanelStack #attributionPanel {
+#appInner.desktop #desktopPanelStack #infoPanel {
     position: relative;
     top: auto;
     right: auto;
@@ -470,27 +470,27 @@ body {
 }
 
 #appInner.desktop #desktopPanelStack #controlPanel > .pcui-panel-header,
-#appInner.desktop #desktopPanelStack #attributionPanel > .pcui-panel-header {
+#appInner.desktop #desktopPanelStack #infoPanel > .pcui-panel-header {
     border-radius: var(--desktop-panel-radius) var(--desktop-panel-radius) 0 0;
 }
 
 #appInner.desktop #desktopPanelStack #controlPanel > .pcui-panel-content,
-#appInner.desktop #desktopPanelStack #attributionPanel > .pcui-panel-content {
+#appInner.desktop #desktopPanelStack #infoPanel > .pcui-panel-content {
     border-radius: 0 0 var(--desktop-panel-radius) var(--desktop-panel-radius);
 }
 
 #appInner.desktop #desktopPanelStack #controlPanel-scroll-region,
-#appInner.desktop #desktopPanelStack #attributionPanel-scroll-region {
+#appInner.desktop #desktopPanelStack #infoPanel-scroll-region {
     border-radius: 0 0 var(--desktop-panel-radius) var(--desktop-panel-radius);
 }
 
 #appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed,
-#appInner.desktop #desktopPanelStack #attributionPanel.pcui-collapsed {
+#appInner.desktop #desktopPanelStack #infoPanel.pcui-collapsed {
     overflow: hidden;
 }
 
 #appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed > .pcui-panel-header,
-#appInner.desktop #desktopPanelStack #attributionPanel.pcui-collapsed > .pcui-panel-header {
+#appInner.desktop #desktopPanelStack #infoPanel.pcui-collapsed > .pcui-panel-header {
     border-radius: var(--desktop-panel-radius);
 }
 
@@ -604,7 +604,7 @@ body {
 }
 
 #controlPanel > .pcui-panel-content,
-#attributionPanel > .pcui-panel-content {
+#infoPanel > .pcui-panel-content {
     background-color: #364346;
 }
 
@@ -633,9 +633,8 @@ body {
     overflow-y: auto;
 }
 
-#attributionPanel-scroll-region {
-    max-height: 180px;
-    padding: 8px;
+#infoPanel-scroll-region {
+    max-height: min(260px, 35vh);
     overflow-y: auto;
 }
 
@@ -666,13 +665,28 @@ body {
     cursor: pointer;
 }
 
+.example-info-content {
+    box-sizing: border-box;
+    color: #f2f2f2;
+    font-size: 13px;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+}
+
+.example-info-content a,
 .example-attribution a {
     color: #f2f2f2;
+}
+
+.example-info-description {
+    max-width: 100%;
+    padding: 12px;
 }
 
 #appInner.mobile #sideBar-contents,
 #appInner.mobile #controlPanel-scroll-region,
 #appInner.mobile #controlPanel-controls,
+#appInner.mobile #mobileInfoPanel,
 #appInner.mobile #controlPanel.mobile > .pcui-panel-content,
 #appInner.mobile .code-editor-mobile-files {
     touch-action: pan-y;
@@ -681,11 +695,19 @@ body {
 .example-attributions {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
     gap: 4px;
-    margin-top: 8px;
+    margin-top: 0;
     font-size: 12px;
     line-height: 1.35;
+}
+
+.example-info-description + .example-info-subpanel {
+    margin-top: 12px;
+}
+
+.example-info-subpanel > .pcui-panel-content {
+    padding: 12px;
 }
 
 .example-attribution {
@@ -694,28 +716,11 @@ body {
     margin: 0;
     opacity: 0.82;
     overflow-wrap: anywhere;
-    text-align: center;
+    text-align: left;
 }
 
 .example-attribution-title {
     font-weight: 600;
-}
-
-#mobileDescriptionPanel .example-attributions {
-    align-items: stretch;
-}
-
-#mobileDescriptionPanel .example-attribution {
-    text-align: left;
-}
-
-#attributionPanel .example-attributions {
-    align-items: stretch;
-    margin-top: 0;
-}
-
-#attributionPanel .example-attribution {
-    text-align: left;
 }
 
 #appInner.mobile #menu,
@@ -1269,19 +1274,16 @@ body.mobile-panel-resizing #appInner.mobile-landscape #sideBar.mobile-sheet::aft
     --mobile-dock-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='9'/%3E%3Cpath d='M12 11v6M12 7h.01'/%3E%3C/svg%3E");
 }
 
-#mobileDescriptionPanel {
+#mobileInfoPanel {
     box-sizing: border-box;
     height: 100%;
-    padding: 12px;
-    color: #f2f2f2;
-    line-height: 1.45;
 }
 
 #controlPanel.mobile.description-sheet,
 #controlPanel.mobile.description-sheet > .pcui-panel-content,
-#mobileDescriptionPanel,
-#mobileDescriptionPanel *,
-#mobileDescriptionPanel a {
+#mobileInfoPanel,
+#mobileInfoPanel *,
+#mobileInfoPanel a {
     color: #f2f2f2;
 }
 

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -1522,7 +1522,9 @@ body.mobile-panel-resizing #appInner.mobile-landscape #sideBar.mobile-sheet::aft
 
 #appInner.fullscreen #controlPanel,
 #appInner.fullscreen #desktopPanelStack,
-#appInner.fullscreen #sideBar {
+#appInner.fullscreen #sideBar,
+#appInner.fullscreen #exampleCredits,
+#appInner.fullscreen #showCreditsButton {
     display: none;
 }
 

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -643,19 +643,90 @@ body {
     overflow-y: auto;
 }
 
-#descriptionPanel {
-    /* center on the bottom of the page */
+#exampleDescription {
     position: absolute;
+    top: 8px;
     left: 50%;
-    bottom: 8px;
     transform: translateX(-50%);
+    z-index: 9998;
+    box-sizing: border-box;
+    max-width: min(50%, 640px);
+    padding: 8px 16px;
+    background-color: rgba(54, 67, 70, 0.64);
+    backdrop-filter: blur(32px);
+    border-radius: 6px;
     color: #f2f2f2;
-    width: 50%;
+    font-size: 13px;
+    line-height: 1.45;
     text-align: center;
+    white-space: pre-line;
+    overflow-wrap: anywhere;
+    pointer-events: none;
+    user-select: none;
 }
 
-#descriptionPanel a {
+.example-info-description {
+    padding: 12px;
+    white-space: pre-line;
+    overflow-wrap: anywhere;
+}
+
+.example-info-description + .example-info-subpanel {
+    margin-top: 12px;
+}
+
+.example-description-body strong {
+    font-weight: 700;
+}
+
+.example-description-body em {
+    font-style: italic;
+}
+
+.example-description-body code {
+    font-family: inconsolatamedium, Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+    font-size: 0.92em;
+    padding: 1px 4px;
+    border-radius: 3px;
+    background-color: rgba(0, 0, 0, 0.3);
+}
+
+.example-description-body a {
     color: #f2f2f2;
+    pointer-events: auto;
+}
+
+.example-description-body .example-color-accent,
+.example-description-body .example-color-warn,
+.example-description-body .example-color-success,
+.example-description-body .example-color-info,
+.example-description-body .example-color-muted {
+    font-weight: 700;
+}
+
+.example-description-body .example-color-accent,
+#mobileInfoPanel .example-color-accent {
+    color: #ffb380;
+}
+
+.example-description-body .example-color-warn,
+#mobileInfoPanel .example-color-warn {
+    color: #ffd966;
+}
+
+.example-description-body .example-color-success,
+#mobileInfoPanel .example-color-success {
+    color: #95e095;
+}
+
+.example-description-body .example-color-info,
+#mobileInfoPanel .example-color-info {
+    color: #a8d0f0;
+}
+
+.example-description-body .example-color-muted,
+#mobileInfoPanel .example-color-muted {
+    color: #c5cdd0;
 }
 
 .pcui-container.pcui-select-input-list.pcui-select-input-list-overlay {
@@ -686,11 +757,6 @@ body {
     color: #f2f2f2;
 }
 
-.example-info-description {
-    max-width: 100%;
-    padding: 12px;
-}
-
 #appInner.mobile #sideBar-contents,
 #appInner.mobile #controlPanel-scroll-region,
 #appInner.mobile #controlPanel-controls,
@@ -708,10 +774,6 @@ body {
     margin-top: 0;
     font-size: 12px;
     line-height: 1.35;
-}
-
-.example-info-description + .example-info-subpanel {
-    margin-top: 12px;
 }
 
 .example-info-subpanel + .example-info-subpanel {

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -430,7 +430,10 @@ body {
     opacity: 50%;
 }
 
-#controlPanel {
+#controlPanel,
+#attributionPanel {
+    --desktop-panel-radius: 6px;
+
     position: absolute;
     right: 8px;
     top: 8px;
@@ -438,10 +441,57 @@ body {
     z-index: 9999;
     background-color: rgba(54, 67, 70, 0.64);
     backdrop-filter: blur(32px);
-    border-radius: 6px;
+    border-radius: var(--desktop-panel-radius);
     transition: opacity 500ms;
     opacity: 1;
     max-height: calc(100% - 16px);
+}
+
+#desktopPanelStack {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 280px;
+    max-height: calc(100% - 16px);
+}
+
+#appInner.desktop #desktopPanelStack #controlPanel,
+#appInner.desktop #desktopPanelStack #attributionPanel {
+    position: relative;
+    top: auto;
+    right: auto;
+    width: 100%;
+    min-height: 0;
+    max-height: none;
+}
+
+#appInner.desktop #desktopPanelStack #controlPanel > .pcui-panel-header,
+#appInner.desktop #desktopPanelStack #attributionPanel > .pcui-panel-header {
+    border-radius: var(--desktop-panel-radius) var(--desktop-panel-radius) 0 0;
+}
+
+#appInner.desktop #desktopPanelStack #controlPanel > .pcui-panel-content,
+#appInner.desktop #desktopPanelStack #attributionPanel > .pcui-panel-content {
+    border-radius: 0 0 var(--desktop-panel-radius) var(--desktop-panel-radius);
+}
+
+#appInner.desktop #desktopPanelStack #controlPanel-scroll-region,
+#appInner.desktop #desktopPanelStack #attributionPanel-scroll-region {
+    border-radius: 0 0 var(--desktop-panel-radius) var(--desktop-panel-radius);
+}
+
+#appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed,
+#appInner.desktop #desktopPanelStack #attributionPanel.pcui-collapsed {
+    overflow: hidden;
+}
+
+#appInner.desktop #desktopPanelStack #controlPanel.pcui-collapsed > .pcui-panel-header,
+#appInner.desktop #desktopPanelStack #attributionPanel.pcui-collapsed > .pcui-panel-header {
+    border-radius: var(--desktop-panel-radius);
 }
 
 #controlPanel.empty {
@@ -553,7 +603,8 @@ body {
     min-width: 46px;
 }
 
-#controlPanel > .pcui-panel-content {
+#controlPanel > .pcui-panel-content,
+#attributionPanel > .pcui-panel-content {
     background-color: #364346;
 }
 
@@ -579,6 +630,12 @@ body {
 #controlPanel-scroll-region {
     flex: 1 1 auto;
     min-height: 0;
+    overflow-y: auto;
+}
+
+#attributionPanel-scroll-region {
+    max-height: 180px;
+    padding: 8px;
     overflow-y: auto;
 }
 
@@ -609,6 +666,10 @@ body {
     cursor: pointer;
 }
 
+.example-attribution a {
+    color: #f2f2f2;
+}
+
 #appInner.mobile #sideBar-contents,
 #appInner.mobile #controlPanel-scroll-region,
 #appInner.mobile #controlPanel-controls,
@@ -628,6 +689,7 @@ body {
 }
 
 .example-attribution {
+    color: #b1b8ba;
     max-width: 100%;
     margin: 0;
     opacity: 0.82;
@@ -637,6 +699,15 @@ body {
 
 .example-attribution-title {
     font-weight: 600;
+}
+
+#attributionPanel .example-attributions {
+    align-items: stretch;
+    margin-top: 0;
+}
+
+#attributionPanel .example-attribution {
+    text-align: left;
 }
 
 #appInner.mobile #menu,
@@ -1303,7 +1374,9 @@ body.mobile-panel-resizing #appInner.mobile-landscape #sideBar.mobile-sheet::aft
     bottom: inherit;
 }
 
-#appInner.fullscreen #controlPanel, #appInner.fullscreen #sideBar {
+#appInner.fullscreen #controlPanel,
+#appInner.fullscreen #desktopPanelStack,
+#appInner.fullscreen #sideBar {
     display: none;
 }
 

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -439,8 +439,7 @@ body {
     top: 8px;
     width: 280px;
     z-index: 9999;
-    background-color: rgba(54, 67, 70, 0.64);
-    backdrop-filter: blur(32px);
+    background-color: rgba(54, 67, 70, 0.85);
     border-radius: var(--desktop-panel-radius);
     transition: opacity 500ms;
     opacity: 1;
@@ -516,8 +515,7 @@ body {
     top: inherit;
     display: flex;
     flex-direction: column;
-    background-color: rgba(54, 67, 70, 0.64);
-    backdrop-filter: blur(32px);
+    background-color: rgba(54, 67, 70, 0.85);
     min-height: 0;
     border-radius: var(--mobile-radius);
     overflow: visible;
@@ -657,8 +655,7 @@ body {
     box-sizing: border-box;
     max-width: 475px;
     padding: 8px 16px;
-    background-color: rgba(54, 67, 70, 0.64);
-    backdrop-filter: blur(32px);
+    background-color: rgba(54, 67, 70, 0.85);
     border-radius: 6px;
     color: #f2f2f2;
     font-size: 13px;
@@ -1298,8 +1295,7 @@ body.mobile-panel-resizing #appInner.mobile-landscape #sideBar.mobile-sheet::aft
     height: var(--mobile-dock-height);
     padding: 4px 8px;
     box-sizing: border-box;
-    background-color: rgba(54, 67, 70, 0.64);
-    backdrop-filter: blur(32px);
+    background-color: rgba(54, 67, 70, 0.85);
     border-radius: var(--mobile-radius);
     z-index: 100000;
     -webkit-tap-highlight-color: transparent;

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -668,13 +668,16 @@ body {
 .example-info-content {
     box-sizing: border-box;
     color: #f2f2f2;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
     font-size: 13px;
     line-height: 1.45;
     overflow-wrap: anywhere;
 }
 
 .example-info-content a,
-.example-attribution a {
+.example-credit a {
     color: #f2f2f2;
 }
 
@@ -692,7 +695,7 @@ body {
     touch-action: pan-y;
 }
 
-.example-attributions {
+.example-credits {
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -706,11 +709,70 @@ body {
     margin-top: 12px;
 }
 
-.example-info-subpanel > .pcui-panel-content {
-    padding: 12px;
+.example-info-subpanel + .example-info-subpanel {
+    margin-top: 0;
 }
 
-.example-attribution {
+.example-info-subpanel {
+    flex: none;
+}
+
+.example-info-subpanel > .pcui-panel-content {
+    flex: 0 0 auto;
+    padding: 6px;
+}
+
+.example-keybinds {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    font-size: 12px;
+    line-height: 24px;
+}
+
+.example-keybind {
+    display: grid;
+    grid-template-columns: 100px minmax(0, 1fr);
+    gap: 6px;
+    align-items: center;
+    min-height: 24px;
+}
+
+#appInner.mobile .example-keybind {
+    grid-template-columns: 94px minmax(0, 1fr);
+}
+
+.example-keybind-inputs {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 3px;
+    min-width: 0;
+}
+
+.example-keybind-inputs kbd {
+    display: inline-flex;
+    align-items: center;
+    min-height: 20px;
+    box-sizing: border-box;
+    padding: 0 6px;
+    border: 1px solid #6d7476;
+    border-radius: 3px;
+    background: #20292b;
+    color: #f2f2f2;
+    font-family: monospace;
+    font-size: 12px;
+    line-height: 18px;
+    white-space: nowrap;
+}
+
+.example-keybind-action {
+    min-width: 0;
+    color: #b1b8ba;
+    overflow-wrap: anywhere;
+}
+
+.example-credit {
     color: #b1b8ba;
     max-width: 100%;
     margin: 0;
@@ -719,7 +781,7 @@ body {
     text-align: left;
 }
 
-.example-attribution-title {
+.example-credit-title {
     font-weight: 600;
 }
 

--- a/examples/utils/example-source.mjs
+++ b/examples/utils/example-source.mjs
@@ -128,6 +128,7 @@ export const stripConfig = (source) => {
  * @property {boolean} [NO_DEVICE_SELECTOR] - No device selector.
  * @property {boolean} [NO_MINISTATS] - No ministats.
  * @property {boolean} [WEBGPU_DISABLED] - If webgpu is disabled.
+ * @property {boolean} [WEBGPU_BARE_DISABLED] - If webgpu bare is disabled.
  * @property {boolean} [WEBGL_DISABLED] - If webgl is disabled.
  */
 

--- a/examples/utils/example-source.mjs
+++ b/examples/utils/example-source.mjs
@@ -5,8 +5,9 @@ const regexPatterns = [
     /^\s*import\s*(?:\S.*|[\t\v\f \xa0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff])\s*;\s*$/gm
 ];
 const configRegex = /^[ \t]*\/\/ @config[ \t]*(?:\r?\n[ \t]*\/\/[^\r\n]*)*(?:\r?\n|$)/gm;
-const ATTRIBUTION_FIELDS = ['title', 'author', 'source', 'license'];
-const ATTRIBUTION_FIELD_SET = new Set(ATTRIBUTION_FIELDS);
+const KEYBIND_INPUT_SEPARATOR = /\s+\/\s+/;
+const CREDIT_FIELDS = ['title', 'author', 'source', 'license'];
+const CREDIT_FIELD_SET = new Set(CREDIT_FIELDS);
 
 const parseValue = (val) => {
     return val === undefined || val === 'true' ? true : val === 'false' ? false : val;
@@ -19,17 +20,18 @@ const splitFlag = (line) => {
 
 const parseExampleConfig = (block, config) => {
     const description = [];
-    let attribution = null;
+    let credit = null;
+    let keybinds = false;
 
-    const completeAttribution = () => {
-        const missing = ATTRIBUTION_FIELDS.filter(field => !attribution[field]);
+    const completeCredit = () => {
+        const missing = CREDIT_FIELDS.filter(field => !credit[field]);
         if (missing.length) {
-            throw new Error(`Incomplete @attribution: missing ${missing.join(', ')}`);
+            throw new Error(`Incomplete @credit: missing ${missing.join(', ')}`);
         }
 
-        config.ATTRIBUTIONS ??= [];
-        config.ATTRIBUTIONS.push(attribution);
-        attribution = null;
+        config.CREDITS ??= [];
+        config.CREDITS.push(credit);
+        credit = null;
     };
 
     const lines = block.split(/\r?\n/).slice(1);
@@ -40,49 +42,83 @@ const parseExampleConfig = (block, config) => {
         }
         const text = match[1];
         const line = text.trim();
-        if (line === '@attribution') {
-            if (attribution) {
-                completeAttribution();
+        if (!line && keybinds) {
+            keybinds = false;
+            continue;
+        }
+        if (line === '@keybinds') {
+            if (credit) {
+                completeCredit();
             }
-            attribution = {};
-        } else if (attribution) {
+            keybinds = true;
+        } else if (line === '@credit') {
+            if (credit) {
+                completeCredit();
+            }
+            keybinds = false;
+            credit = {};
+        } else if (line.startsWith('@flag ')) {
+            if (credit) {
+                completeCredit();
+            }
+            keybinds = false;
+            const [name, val] = splitFlag(line.slice(6).trim());
+            config[name.trim()] = parseValue(val);
+        } else if (keybinds) {
+            if (line.startsWith('@')) {
+                keybinds = false;
+                description.push(text);
+                continue;
+            }
+
+            const idx = line.indexOf(':');
+            const input = idx === -1 ? '' : line.slice(0, idx).trim();
+            const action = idx === -1 ? '' : line.slice(idx + 1).trim();
+            const inputs = input ? input.split(KEYBIND_INPUT_SEPARATOR) : [];
+            if (idx === -1 || !inputs.length || !action || inputs.some(value => !value)) {
+                throw new Error(`Invalid @keybinds line: ${line}`);
+            }
+
+            config.KEYBINDS ??= [];
+            config.KEYBINDS.push({
+                inputs,
+                action
+            });
+        } else if (credit) {
             if (!line) {
                 continue;
             }
 
             const idx = line.indexOf(':');
             if (idx === -1) {
-                throw new Error(`Invalid @attribution line: ${line}`);
+                throw new Error(`Invalid @credit line: ${line}`);
             }
 
             const name = line.slice(0, idx).trim();
-            if (!ATTRIBUTION_FIELD_SET.has(name)) {
-                throw new Error(`Invalid @attribution field: ${name}`);
+            if (!CREDIT_FIELD_SET.has(name)) {
+                throw new Error(`Invalid @credit field: ${name}`);
             }
-            if (attribution[name] !== undefined) {
-                throw new Error(`Duplicate @attribution field: ${name}`);
+            if (credit[name] !== undefined) {
+                throw new Error(`Duplicate @credit field: ${name}`);
             }
 
-            attribution[name] = line.slice(idx + 1).trim();
+            credit[name] = line.slice(idx + 1).trim();
             let complete = true;
-            for (let j = 0; j < ATTRIBUTION_FIELDS.length; j++) {
-                if (!attribution[ATTRIBUTION_FIELDS[j]]) {
+            for (let j = 0; j < CREDIT_FIELDS.length; j++) {
+                if (!credit[CREDIT_FIELDS[j]]) {
                     complete = false;
                     break;
                 }
             }
             if (complete) {
-                completeAttribution();
+                completeCredit();
             }
-        } else if (line.startsWith('@flag ')) {
-            const [name, val] = splitFlag(line.slice(6).trim());
-            config[name.trim()] = parseValue(val);
         } else {
             description.push(text);
         }
     }
-    if (attribution) {
-        completeAttribution();
+    if (credit) {
+        completeCredit();
     }
 
     const html = description.join('\n').trim();
@@ -122,7 +158,8 @@ export const stripConfig = (source) => {
 /**
  * @typedef {object} ExampleConfig
  * @property {string} [DESCRIPTION] - The example description.
- * @property {{ title: string, author: string, source: string, license: string }[]} [ATTRIBUTIONS] - Scene attributions.
+ * @property {{ inputs: string[], action: string }[]} [KEYBINDS] - The example keybinds.
+ * @property {{ title: string, author: string, source: string, license: string }[]} [CREDITS] - Scene credits.
  * @property {boolean} [HIDDEN] - The example is hidden from the sidebar list in production builds (`npm run build`). It is still built and reachable via its URL. In development (`npm run develop`) it is still shown in the sidebar.
  * @property {'development' | 'performance' | 'debug'} [ENGINE] - The engine type.
  * @property {boolean} [NO_DEVICE_SELECTOR] - No device selector.

--- a/examples/utils/example-source.mjs
+++ b/examples/utils/example-source.mjs
@@ -5,7 +5,6 @@ const regexPatterns = [
     /^\s*import\s*(?:\S.*|[\t\v\f \xa0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff])\s*;\s*$/gm
 ];
 const configRegex = /^[ \t]*\/\/ @config[ \t]*(?:\r?\n[ \t]*\/\/[^\r\n]*)*(?:\r?\n|$)/gm;
-const KEYBIND_INPUT_SEPARATOR = /\s+\/\s+/;
 const CREDIT_FIELDS = ['title', 'author', 'source', 'license'];
 const CREDIT_FIELD_SET = new Set(CREDIT_FIELDS);
 
@@ -21,7 +20,6 @@ const splitFlag = (line) => {
 const parseExampleConfig = (block, config) => {
     const description = [];
     let credit = null;
-    let keybinds = false;
 
     const completeCredit = () => {
         const missing = CREDIT_FIELDS.filter(field => !credit[field]);
@@ -42,48 +40,17 @@ const parseExampleConfig = (block, config) => {
         }
         const text = match[1];
         const line = text.trim();
-        if (!line && keybinds) {
-            keybinds = false;
-            continue;
-        }
-        if (line === '@keybinds') {
+        if (line === '@credit') {
             if (credit) {
                 completeCredit();
             }
-            keybinds = true;
-        } else if (line === '@credit') {
-            if (credit) {
-                completeCredit();
-            }
-            keybinds = false;
             credit = {};
         } else if (line.startsWith('@flag ')) {
             if (credit) {
                 completeCredit();
             }
-            keybinds = false;
             const [name, val] = splitFlag(line.slice(6).trim());
             config[name.trim()] = parseValue(val);
-        } else if (keybinds) {
-            if (line.startsWith('@')) {
-                keybinds = false;
-                description.push(text);
-                continue;
-            }
-
-            const idx = line.indexOf(':');
-            const input = idx === -1 ? '' : line.slice(0, idx).trim();
-            const action = idx === -1 ? '' : line.slice(idx + 1).trim();
-            const inputs = input ? input.split(KEYBIND_INPUT_SEPARATOR) : [];
-            if (idx === -1 || !inputs.length || !action || inputs.some(value => !value)) {
-                throw new Error(`Invalid @keybinds line: ${line}`);
-            }
-
-            config.KEYBINDS ??= [];
-            config.KEYBINDS.push({
-                inputs,
-                action
-            });
         } else if (credit) {
             if (!line) {
                 continue;
@@ -158,7 +125,6 @@ export const stripConfig = (source) => {
 /**
  * @typedef {object} ExampleConfig
  * @property {string} [DESCRIPTION] - The example description.
- * @property {{ inputs: string[], action: string }[]} [KEYBINDS] - The example keybinds.
  * @property {{ title: string, author: string, source: string, license: string }[]} [CREDITS] - Scene credits.
  * @property {boolean} [HIDDEN] - The example is hidden from the sidebar list in production builds (`npm run build`). It is still built and reachable via its URL. In development (`npm run develop`) it is still shown in the sidebar.
  * @property {'development' | 'performance' | 'debug'} [ENGINE] - The engine type.

--- a/examples/utils/example-source.mjs
+++ b/examples/utils/example-source.mjs
@@ -121,9 +121,9 @@ const parseExampleConfig = (block, config) => {
         completeCredit();
     }
 
-    const html = description.join('\n').trim();
-    if (html) {
-        config.DESCRIPTION = html;
+    const text = description.join('\n').trim();
+    if (text) {
+        config.DESCRIPTION = text;
     }
 };
 

--- a/examples/utils/example-source.mjs
+++ b/examples/utils/example-source.mjs
@@ -5,6 +5,8 @@ const regexPatterns = [
     /^\s*import\s*(?:\S.*|[\t\v\f \xa0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff])\s*;\s*$/gm
 ];
 const configRegex = /^[ \t]*\/\/ @config[ \t]*(?:\r?\n[ \t]*\/\/[^\r\n]*)*(?:\r?\n|$)/gm;
+const ATTRIBUTION_FIELDS = ['title', 'author', 'source', 'license'];
+const ATTRIBUTION_FIELD_SET = new Set(ATTRIBUTION_FIELDS);
 
 const parseValue = (val) => {
     return val === undefined || val === 'true' ? true : val === 'false' ? false : val;
@@ -17,6 +19,19 @@ const splitFlag = (line) => {
 
 const parseExampleConfig = (block, config) => {
     const description = [];
+    let attribution = null;
+
+    const completeAttribution = () => {
+        const missing = ATTRIBUTION_FIELDS.filter(field => !attribution[field]);
+        if (missing.length) {
+            throw new Error(`Incomplete @attribution: missing ${missing.join(', ')}`);
+        }
+
+        config.ATTRIBUTIONS ??= [];
+        config.ATTRIBUTIONS.push(attribution);
+        attribution = null;
+    };
+
     const lines = block.split(/\r?\n/).slice(1);
     for (let i = 0; i < lines.length; i++) {
         const match = /^[ \t]*\/\/ ?(.*)$/.exec(lines[i]);
@@ -25,13 +40,51 @@ const parseExampleConfig = (block, config) => {
         }
         const text = match[1];
         const line = text.trim();
-        if (line.startsWith('@flag ')) {
+        if (line === '@attribution') {
+            if (attribution) {
+                completeAttribution();
+            }
+            attribution = {};
+        } else if (attribution) {
+            if (!line) {
+                continue;
+            }
+
+            const idx = line.indexOf(':');
+            if (idx === -1) {
+                throw new Error(`Invalid @attribution line: ${line}`);
+            }
+
+            const name = line.slice(0, idx).trim();
+            if (!ATTRIBUTION_FIELD_SET.has(name)) {
+                throw new Error(`Invalid @attribution field: ${name}`);
+            }
+            if (attribution[name] !== undefined) {
+                throw new Error(`Duplicate @attribution field: ${name}`);
+            }
+
+            attribution[name] = line.slice(idx + 1).trim();
+            let complete = true;
+            for (let j = 0; j < ATTRIBUTION_FIELDS.length; j++) {
+                if (!attribution[ATTRIBUTION_FIELDS[j]]) {
+                    complete = false;
+                    break;
+                }
+            }
+            if (complete) {
+                completeAttribution();
+            }
+        } else if (line.startsWith('@flag ')) {
             const [name, val] = splitFlag(line.slice(6).trim());
             config[name.trim()] = parseValue(val);
         } else {
             description.push(text);
         }
     }
+    if (attribution) {
+        completeAttribution();
+    }
+
     const html = description.join('\n').trim();
     if (html) {
         config.DESCRIPTION = html;
@@ -69,6 +122,7 @@ export const stripConfig = (source) => {
 /**
  * @typedef {object} ExampleConfig
  * @property {string} [DESCRIPTION] - The example description.
+ * @property {{ title: string, author: string, source: string, license: string }[]} [ATTRIBUTIONS] - Scene attributions.
  * @property {boolean} [HIDDEN] - The example is hidden from the sidebar list in production builds (`npm run build`). It is still built and reachable via its URL. In development (`npm run develop`) it is still shown in the sidebar.
  * @property {'development' | 'performance' | 'debug'} [ENGINE] - The engine type.
  * @property {boolean} [NO_DEVICE_SELECTOR] - No device selector.

--- a/examples/utils/inline-markdown.mjs
+++ b/examples/utils/inline-markdown.mjs
@@ -1,0 +1,17 @@
+/**
+ * Shared spec for the markdown-lite syntax used in example `@config`
+ * descriptions. Imported by the renderer (`Example.mjs`) and the
+ * `@config` lint rule (`eslint.config.mjs`) so they cannot drift.
+ *
+ * Supported tokens (in regex group order):
+ *   1) `**bold**`
+ *   2) `*italic*`
+ *   3) `` `code` ``
+ *   4-5) `[text](url)`
+ *   6-7) `{name:text}`
+ */
+export const INLINE_MD_PATTERN = /\*\*([^*\n]+)\*\*|\*([^*\n]+)\*|`([^`\n]+)`|\[([^\]\n]+)\]\(([^)\n]+)\)|\{([a-z]+):([^}\n]+)\}/g;
+
+export const SAFE_URL_PATTERN = /^(?:https?:|mailto:)/i;
+
+export const COLOR_NAMES = new Set(['accent', 'warn', 'success', 'info', 'muted']);


### PR DESCRIPTION
## Description
- Adds `@credit` / `@flag` blocks to example `@config` comments, with schema validation.
- Folds the legacy `@keybinds` directive into description prose using markdown-lite — authors write keybinds inline as `` `key` `` chips separated by ` · `. No more dedicated subpanel.
- Renders the description as a centered top-of-canvas overlay (capped at 475px wide). Supports markdown-lite inline syntax — `**bold**`, `*italic*`, `` `code` ``, `[text](url)`, and `{accent:text}` palette colors — parsed safely to React nodes (no raw HTML).
- Renders credits as a separate bottom-right overlay, toggleable via a new © button in the top-left menu (highlighted orange when active, matching the MiniStats button). Replaces the previous desktop Info panel entirely.
- Raises the mobile breakpoint to 967px so the desktop layout switches to mobile UI before the canvas would overflow the sidebar.
- Drops `backdrop-filter: blur` from every overlay (Controls panel, mobile sheet, mobile dock, description, credits) — was burning GPU time per frame over the live canvas; bumped background opacity 0.64 → 0.85 to compensate.
- Mobile flow unchanged: the info sheet (via mobile dock "Info" button) still hosts the combined description + credits.

## Preview
<table>
  <tr>
    <td align="center" valign="top" width="70%">
      <img width="560" alt="Desktop: credits overlay bottom-right with © toggle in menu"
           src="https://github.com/user-attachments/assets/91a08c6c-70ea-4559-b16a-033edd0adfb4" />
      <br/><sub>Desktop: credits overlay in the bottom-right, toggled via the © button in the top-left menu</sub>
    </td>
    <td align="center" valign="top" width="30%">
      <img width="200" alt="Mobile: credits inside the info sheet"
           src="https://github.com/user-attachments/assets/b3907118-3a63-4514-9be1-1eeb8e834b04" />
      <br/><sub>Mobile: credits rendered inside the info sheet alongside the description</sub>
    </td>
  </tr>
</table>

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

## Manual tests
- Verified credits overlay shows/hides via the © menu button across examples with and without `@credit` blocks (button is hidden when there are no credits).
- Verified credits links (source, license) are clickable and show pointer cursor on hover; canvas drag/pan still works in the empty space behind the overlay.
- Verified keybinds render inline inside the description across all 11 examples that previously used `@keybinds`.
- Resized 1400 → 950 → 700px to confirm the 967px breakpoint handoff is clean and the credits overlay reflows to mobile sheet.