### PR TITLE
fix(gsplat): make writeSortIndirectArgs WGSL helper portable for Firefox WebGPU

### DIFF
--- a/src/scene/shader-lib/wgsl/chunks/common/comp/sort-indirect-args.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/comp/sort-indirect-args.js
@@ -5,8 +5,14 @@ export default /* wgsl */`
 // dispatch of ceil(count / granularity[i]) workgroups into slots
 // (baseSlot + i) for every active slot i.
 //
+// Contract: the calling shader must declare a storage binding named
+// 'indirectDispatchArgs' of type array<u32> with read_write access. The helper
+// references that global directly rather than taking it as a pointer
+// parameter, because passing storage pointers across function boundaries
+// requires the 'unrestricted_pointer_parameters' WGSL language feature, which
+// is not portable (Firefox/naga rejects it).
+//
 // Parameters:
-//   buf       - indirect dispatch buffer (plain array<u32>, not atomic).
 //   baseSlot  - index of the first slot to write (u32 offset = baseSlot * 3).
 //   count     - number of elements the sort will process.
 //   slotInfo  - sorter metadata, obtained verbatim from
@@ -16,7 +22,6 @@ export default /* wgsl */`
 //                 .y/.z/.w = per-slot elements-per-workgroup (granularity);
 //                            unused trailing entries are 0.
 fn writeSortIndirectArgs(
-    buf: ptr<storage, array<u32>, read_write>,
     baseSlot: u32,
     count: u32,
     slotInfo: vec4<u32>
@@ -27,25 +32,25 @@ fn writeSortIndirectArgs(
         let g = slotInfo.y;
         let wc = (count + g - 1u) / g;
         let off = baseSlot * 3u;
-        (*buf)[off + 0u] = wc;
-        (*buf)[off + 1u] = 1u;
-        (*buf)[off + 2u] = 1u;
+        indirectDispatchArgs[off + 0u] = wc;
+        indirectDispatchArgs[off + 1u] = 1u;
+        indirectDispatchArgs[off + 2u] = 1u;
     }
     if (n >= 2u) {
         let g = slotInfo.z;
         let wc = (count + g - 1u) / g;
         let off = (baseSlot + 1u) * 3u;
-        (*buf)[off + 0u] = wc;
-        (*buf)[off + 1u] = 1u;
-        (*buf)[off + 2u] = 1u;
+        indirectDispatchArgs[off + 0u] = wc;
+        indirectDispatchArgs[off + 1u] = 1u;
+        indirectDispatchArgs[off + 2u] = 1u;
     }
     if (n >= 3u) {
         let g = slotInfo.w;
         let wc = (count + g - 1u) / g;
         let off = (baseSlot + 2u) * 3u;
-        (*buf)[off + 0u] = wc;
-        (*buf)[off + 1u] = 1u;
-        (*buf)[off + 2u] = 1u;
+        indirectDispatchArgs[off + 0u] = wc;
+        indirectDispatchArgs[off + 1u] = 1u;
+        indirectDispatchArgs[off + 2u] = 1u;
     }
 }
 `;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector-write-indirect-args.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector-write-indirect-args.js
@@ -53,7 +53,7 @@ fn main() {
 
     // Sort dispatch args at sortSlotBase (no keygen slot — sort keys come from the
     // projector pass directly).
-    writeSortIndirectArgs(&indirectDispatchArgs, uniforms.sortSlotBase, count, uniforms.sortIndirectInfo);
+    writeSortIndirectArgs(uniforms.sortSlotBase, count, uniforms.sortIndirectInfo);
 }
 `;
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-write-indirect-args.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-write-indirect-args.js
@@ -75,7 +75,7 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
     // Sort dispatch slots — delegated to the sorter-agnostic helper so this
     // shader doesn't need to know how many slots or what granularity the
     // active radix sort backend uses.
-    writeSortIndirectArgs(&indirectDispatchArgs, keygenSlot + 1u, count, uniforms.sortIndirectInfo);
+    writeSortIndirectArgs(keygenSlot + 1u, count, uniforms.sortIndirectInfo);
 
     // Write sortElementCount for sort shaders (= visibleCount)
     sortElementCountBuf[0] = count;


### PR DESCRIPTION
Fixes a WebGPU shader validation error in the unified gsplat renderer that prevented Firefox from rendering splats (observed on supersp.at scenes).

The `writeSortIndirectArgs` WGSL helper took the indirect dispatch buffer as a `ptr<storage, array<u32>, read_write>` parameter. Passing storage-space pointers across function boundaries requires the `unrestricted_pointer_parameters` WGSL language feature, which Chrome (Dawn) enables by default but Firefox (naga) rejects:

> Argument 'buf' at index 0 is a pointer of space Storage { access: StorageAccess(LOAD | STORE) }, which can't be passed into functions.

**Changes:**
- `sort-indirect-args.js`: drop the `buf` pointer parameter; the helper now references the global `indirectDispatchArgs` binding directly. Added a comment documenting the contract (calling shader must declare a `indirectDispatchArgs` storage binding) and the portability rationale.
- `compute-gsplat-write-indirect-args.js` / `compute-gsplat-projector-write-indirect-args.js`: updated the two call sites to drop the `&indirectDispatchArgs` argument. Both already used that exact binding name, so no rename was needed.

**Affected paths:**
- `GSPLAT_RENDERER_COMPUTE` (interval compaction)
- `GSPLAT_RENDERER_RASTER_GPU_SORT` (hybrid raster + projector)
- CPU sort path and WebGL paths are unaffected.