### PR TITLE
feat(graphics): expose WGSL unrestricted_pointer_parameters as a device cap

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -296,6 +296,18 @@ class GraphicsDevice extends EventHandler {
     supportsLinearIndexing = false;
 
     /**
+     * True if the device supports the WGSL `unrestricted_pointer_parameters` language feature,
+     * which allows passing pointers in the `storage`, `uniform`, and `workgroup` address spaces
+     * as function arguments. The `requires unrestricted_pointer_parameters;` directive is
+     * automatically injected into WGSL shaders when this feature is available, and the shader
+     * define `CAPS_UNRESTRICTED_POINTER_PARAMETERS` is set for conditional compilation.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    supportsUnrestrictedPointerParameters = false;
+
+    /**
      * Maximum subgroup (warp/wavefront) size reported for the device. Zero means either
      * subgroups are not supported ({@link supportsSubgroups} is false), or the WebGPU
      * implementation did not expose the value.
@@ -684,6 +696,7 @@ class GraphicsDevice extends EventHandler {
         if (this.supportsSubgroups) capsDefines.set('CAPS_SUBGROUPS', '');
         if (this.supportsSubgroupId) capsDefines.set('CAPS_SUBGROUP_ID', '');
         if (this.supportsLinearIndexing) capsDefines.set('CAPS_LINEAR_INDEXING', '');
+        if (this.supportsUnrestrictedPointerParameters) capsDefines.set('CAPS_UNRESTRICTED_POINTER_PARAMETERS', '');
         if (this.supportsStorageTextureRead) capsDefines.set('CAPS_STORAGE_TEXTURE_READ', '');
 
         // Platform defines

--- a/src/platform/graphics/shader-definition-utils.js
+++ b/src/platform/graphics/shader-definition-utils.js
@@ -230,6 +230,9 @@ class ShaderDefinitionUtils {
         if (shaderType === 'compute' && device.supportsLinearIndexing) {
             code += 'requires linear_indexing;\n';
         }
+        if (device.supportsUnrestrictedPointerParameters) {
+            code += 'requires unrestricted_pointer_parameters;\n';
+        }
         return code;
     }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -324,6 +324,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsSubgroupUniformity = wgslFeatures?.has('subgroup_uniformity');
         this.supportsSubgroupId = wgslFeatures?.has('subgroup_id');
         this.supportsLinearIndexing = wgslFeatures?.has('linear_indexing');
+        this.supportsUnrestrictedPointerParameters = wgslFeatures?.has('unrestricted_pointer_parameters');
 
         this.initCapsDefines();
     }
@@ -413,11 +414,13 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsSubgroups = requireFeature('subgroups');
         this.maxSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.info?.subgroupMaxSize ?? 0) : 0;
         this.minSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.info?.subgroupMinSize ?? 0) : 0;
+        const wgslFeatureNames = window.navigator.gpu.wgslLanguageFeatures ?
+            Array.from(window.navigator.gpu.wgslLanguageFeatures) : [];
         Debug.log(
             `WEBGPU${this.gpuAdapter?.info ?
                 ` (${this.gpuAdapter.info.vendor || '?'} / ${this.gpuAdapter.info.architecture || this.gpuAdapter.info.device || '?'})` :
                 ''
-            } features [${bare ? 'bare' : 'full'}]: ${requiredFeatures.join(', ') || 'none'}`
+            } features [${bare ? 'bare' : 'full'}]: ${requiredFeatures.join(', ') || 'none'}, wgslFeatures(${wgslFeatureNames.join(', ') || 'none'})`
         );
 
         // copy all adapter limits to the requiredLimits object (skipped for bare mode to use spec defaults)


### PR DESCRIPTION
Adds detection and automatic wiring for the WGSL `unrestricted_pointer_parameters` language feature, following the same pattern as `linear_indexing`, `subgroup_id`, and the other WGSL feature caps.

Companion to #8784 — that PR worked around the missing feature by inlining the helper; this PR exposes the cap so future shaders can opt into pointer-of-storage parameters on devices that support it, with a portable fallback path on browsers that don't.

**Changes:**
- `GraphicsDevice.supportsUnrestrictedPointerParameters` flag, probed from `navigator.gpu.wgslLanguageFeatures` in `WebgpuGraphicsDevice#initDeviceCaps`.
- `CAPS_UNRESTRICTED_POINTER_PARAMETERS` shader define for conditional compilation (`#ifdef`).
- `requires unrestricted_pointer_parameters;` directive automatically injected into WGSL shaders on supporting devices via `ShaderDefinitionUtils.getWGSLEnables`.
- WebGPU init log extended to list the browser's advertised WGSL language features alongside the GPU feature list. Example:

  ```
  WEBGPU (apple / metal-3) features [full]: float32-filterable, ..., subgroups, wgslFeatures(readonly_and_readwrite_storage_textures, packed_4x8_integer_dot_product, unrestricted_pointer_parameters, ...)
  ```

**Notes:**
- Infrastructure-only — no shader callers yet. The cap is available for future WGSL helpers that benefit from passing storage/uniform/workgroup pointers across function boundaries.
- Firefox/naga doesn't currently expose this feature; the cap will be `false` there and no `requires` directive is emitted, so existing portable shaders continue to compile.