### PR TITLE
feat(graphics): expose WGSL pointer_composite_access as a device cap

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -296,6 +296,19 @@ class GraphicsDevice extends EventHandler {
     supportsLinearIndexing = false;
 
     /**
+     * True if the device supports the WGSL `pointer_composite_access` language feature, which
+     * provides syntactic sugar for dereferencing pointers to composite types: `p.field` and
+     * `p[i]` may be written instead of `(*p).field` and `(*p)[i]`. The
+     * `requires pointer_composite_access;` directive is automatically injected into WGSL
+     * shaders when this feature is available, and the shader define
+     * `CAPS_POINTER_COMPOSITE_ACCESS` is set for conditional compilation.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    supportsPointerCompositeAccess = false;
+
+    /**
      * True if the device supports the WGSL `unrestricted_pointer_parameters` language feature,
      * which allows passing pointers in the `storage`, `uniform`, and `workgroup` address spaces
      * as function arguments. The `requires unrestricted_pointer_parameters;` directive is
@@ -697,6 +710,7 @@ class GraphicsDevice extends EventHandler {
         if (this.supportsSubgroupId) capsDefines.set('CAPS_SUBGROUP_ID', '');
         if (this.supportsLinearIndexing) capsDefines.set('CAPS_LINEAR_INDEXING', '');
         if (this.supportsUnrestrictedPointerParameters) capsDefines.set('CAPS_UNRESTRICTED_POINTER_PARAMETERS', '');
+        if (this.supportsPointerCompositeAccess) capsDefines.set('CAPS_POINTER_COMPOSITE_ACCESS', '');
         if (this.supportsStorageTextureRead) capsDefines.set('CAPS_STORAGE_TEXTURE_READ', '');
 
         // Platform defines

--- a/src/platform/graphics/shader-definition-utils.js
+++ b/src/platform/graphics/shader-definition-utils.js
@@ -233,6 +233,9 @@ class ShaderDefinitionUtils {
         if (device.supportsUnrestrictedPointerParameters) {
             code += 'requires unrestricted_pointer_parameters;\n';
         }
+        if (device.supportsPointerCompositeAccess) {
+            code += 'requires pointer_composite_access;\n';
+        }
         return code;
     }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -325,6 +325,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsSubgroupId = wgslFeatures?.has('subgroup_id');
         this.supportsLinearIndexing = wgslFeatures?.has('linear_indexing');
         this.supportsUnrestrictedPointerParameters = wgslFeatures?.has('unrestricted_pointer_parameters');
+        this.supportsPointerCompositeAccess = wgslFeatures?.has('pointer_composite_access');
 
         this.initCapsDefines();
     }


### PR DESCRIPTION
Adds detection and automatic wiring for the WGSL `pointer_composite_access` language feature, which provides [syntactic sugar for dereferencing pointers to composite types](https://developer.chrome.com/blog/new-in-webgpu-123#syntax_sugar_for_dereferencing_composites_in_wgsl) — `p.field` and `p[i]` instead of `(*p).field` and `(*p)[i]`.

Follows the same pattern as `unrestricted_pointer_parameters` (#8785) and `linear_indexing`.

**Changes:**
- `GraphicsDevice.supportsPointerCompositeAccess` flag, probed from `navigator.gpu.wgslLanguageFeatures` in `WebgpuGraphicsDevice#initDeviceCaps`.
- `CAPS_POINTER_COMPOSITE_ACCESS` shader define for conditional compilation (`#ifdef`).
- `requires pointer_composite_access;` directive automatically injected into WGSL shaders on supporting devices via `ShaderDefinitionUtils.getWGSLEnables`.

**Notes:**
- Infrastructure-only — no shader callers yet. The cap is available for future WGSL helpers that benefit from the more readable pointer-access syntax.
- Firefox/naga doesn't currently expose this feature; the cap will be `false` there and no `requires` directive is emitted, so existing portable shaders continue to compile.