### PR TITLE
feat(graphics): expose WGSL packed_4x8_integer_dot_product as a device cap

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -309,6 +309,21 @@ class GraphicsDevice extends EventHandler {
     supportsPointerCompositeAccess = false;
 
     /**
+     * True if the device supports the WGSL `packed_4x8_integer_dot_product` language feature,
+     * which exposes the DP4a-family built-in functions for 8-bit packed integer dot products:
+     * `dot4U8Packed`, `dot4I8Packed`, and the `pack4x{I,U}8`, `pack4x{I,U}8Clamp`,
+     * `unpack4x{I,U}8` helpers. Useful for accelerating quantized inference and similar
+     * integer-heavy compute workloads. The `requires packed_4x8_integer_dot_product;`
+     * directive is automatically injected into WGSL shaders when this feature is available,
+     * and the shader define `CAPS_PACKED_4X8_INTEGER_DOT_PRODUCT` is set for conditional
+     * compilation.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    supportsPacked4x8IntegerDotProduct = false;
+
+    /**
      * True if the device supports the WGSL `unrestricted_pointer_parameters` language feature,
      * which allows passing pointers in the `storage`, `uniform`, and `workgroup` address spaces
      * as function arguments. The `requires unrestricted_pointer_parameters;` directive is
@@ -711,6 +726,7 @@ class GraphicsDevice extends EventHandler {
         if (this.supportsLinearIndexing) capsDefines.set('CAPS_LINEAR_INDEXING', '');
         if (this.supportsUnrestrictedPointerParameters) capsDefines.set('CAPS_UNRESTRICTED_POINTER_PARAMETERS', '');
         if (this.supportsPointerCompositeAccess) capsDefines.set('CAPS_POINTER_COMPOSITE_ACCESS', '');
+        if (this.supportsPacked4x8IntegerDotProduct) capsDefines.set('CAPS_PACKED_4X8_INTEGER_DOT_PRODUCT', '');
         if (this.supportsStorageTextureRead) capsDefines.set('CAPS_STORAGE_TEXTURE_READ', '');
 
         // Platform defines

--- a/src/platform/graphics/shader-definition-utils.js
+++ b/src/platform/graphics/shader-definition-utils.js
@@ -236,6 +236,9 @@ class ShaderDefinitionUtils {
         if (device.supportsPointerCompositeAccess) {
             code += 'requires pointer_composite_access;\n';
         }
+        if (device.supportsPacked4x8IntegerDotProduct) {
+            code += 'requires packed_4x8_integer_dot_product;\n';
+        }
         return code;
     }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -326,6 +326,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsLinearIndexing = wgslFeatures?.has('linear_indexing');
         this.supportsUnrestrictedPointerParameters = wgslFeatures?.has('unrestricted_pointer_parameters');
         this.supportsPointerCompositeAccess = wgslFeatures?.has('pointer_composite_access');
+        this.supportsPacked4x8IntegerDotProduct = wgslFeatures?.has('packed_4x8_integer_dot_product');
 
         this.initCapsDefines();
     }


### PR DESCRIPTION
Adds detection and automatic wiring for the WGSL `packed_4x8_integer_dot_product` language feature, which exposes the [DP4a built-in functions](https://developer.chrome.com/blog/new-in-webgpu-123#dp4a_built-in_functions_support_in_wgsl) for 8-bit packed integer dot products:

- `dot4U8Packed`, `dot4I8Packed` — packed 4×i8/u8 dot product
- `pack4xI8`, `pack4xU8`, `pack4xI8Clamp`, `pack4xU8Clamp` — pack helpers
- `unpack4xI8`, `unpack4xU8` — unpack helpers

These accelerate quantized inference and similar integer-heavy compute workloads on hardware that exposes the DP4a instruction.

Follows the same pattern as `unrestricted_pointer_parameters` (#8785) and `pointer_composite_access` (#8786).

**Changes:**
- `GraphicsDevice.supportsPacked4x8IntegerDotProduct` flag, probed from `navigator.gpu.wgslLanguageFeatures` in `WebgpuGraphicsDevice#initDeviceCaps`.
- `CAPS_PACKED_4X8_INTEGER_DOT_PRODUCT` shader define for conditional compilation (`#ifdef`).
- `requires packed_4x8_integer_dot_product;` directive automatically injected into WGSL shaders on supporting devices via `ShaderDefinitionUtils.getWGSLEnables`.

**Notes:**
- Infrastructure-only — no shader callers yet. The cap is available for future compute shaders that benefit from DP4a (e.g. ML inference, image processing).
- On devices that don't expose the feature, the cap is `false` and no `requires` directive is emitted, so existing portable shaders continue to compile.