### PR TITLE
feat(graphics): expose WGSL texture_and_sampler_let as a device cap

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -324,6 +324,19 @@ class GraphicsDevice extends EventHandler {
     supportsPacked4x8IntegerDotProduct = false;
 
     /**
+     * True if the device supports the WGSL `texture_and_sampler_let` language feature, which
+     * allows assigning texture and sampler variables to `let` bindings within a WGSL shader
+     * (preparation for bindless-style indirection patterns). The
+     * `requires texture_and_sampler_let;` directive is automatically injected into WGSL
+     * shaders when this feature is available, and the shader define
+     * `CAPS_TEXTURE_AND_SAMPLER_LET` is set for conditional compilation.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    supportsTextureAndSamplerLet = false;
+
+    /**
      * True if the device supports the WGSL `unrestricted_pointer_parameters` language feature,
      * which allows passing pointers in the `storage`, `uniform`, and `workgroup` address spaces
      * as function arguments. The `requires unrestricted_pointer_parameters;` directive is
@@ -727,6 +740,7 @@ class GraphicsDevice extends EventHandler {
         if (this.supportsUnrestrictedPointerParameters) capsDefines.set('CAPS_UNRESTRICTED_POINTER_PARAMETERS', '');
         if (this.supportsPointerCompositeAccess) capsDefines.set('CAPS_POINTER_COMPOSITE_ACCESS', '');
         if (this.supportsPacked4x8IntegerDotProduct) capsDefines.set('CAPS_PACKED_4X8_INTEGER_DOT_PRODUCT', '');
+        if (this.supportsTextureAndSamplerLet) capsDefines.set('CAPS_TEXTURE_AND_SAMPLER_LET', '');
         if (this.supportsStorageTextureRead) capsDefines.set('CAPS_STORAGE_TEXTURE_READ', '');
 
         // Platform defines

--- a/src/platform/graphics/shader-definition-utils.js
+++ b/src/platform/graphics/shader-definition-utils.js
@@ -239,6 +239,9 @@ class ShaderDefinitionUtils {
         if (device.supportsPacked4x8IntegerDotProduct) {
             code += 'requires packed_4x8_integer_dot_product;\n';
         }
+        if (device.supportsTextureAndSamplerLet) {
+            code += 'requires texture_and_sampler_let;\n';
+        }
         return code;
     }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -327,6 +327,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsUnrestrictedPointerParameters = wgslFeatures?.has('unrestricted_pointer_parameters');
         this.supportsPointerCompositeAccess = wgslFeatures?.has('pointer_composite_access');
         this.supportsPacked4x8IntegerDotProduct = wgslFeatures?.has('packed_4x8_integer_dot_product');
+        this.supportsTextureAndSamplerLet = wgslFeatures?.has('texture_and_sampler_let');
 
         this.initCapsDefines();
     }


### PR DESCRIPTION
Adds detection and automatic wiring for the WGSL `texture_and_sampler_let` language feature, which allows assigning texture and sampler variables to `let` bindings within a WGSL shader:

```wgsl
let tex = myTexture;
let s = mySampler;
let c = textureSample(tex, s, uv);
```

Chrome describes it as preparation for bindless-style support — once textures/samplers can be stored in locals, shaders can do indirection/selection patterns that today require duplicated code paths.

Follows the same pattern as `unrestricted_pointer_parameters` (#8785), `pointer_composite_access` (#8786), and `packed_4x8_integer_dot_product` (#8787).

**Changes:**
- `GraphicsDevice.supportsTextureAndSamplerLet` flag, probed from `navigator.gpu.wgslLanguageFeatures` in `WebgpuGraphicsDevice#initDeviceCaps`.
- `CAPS_TEXTURE_AND_SAMPLER_LET` shader define for conditional compilation (`#ifdef`).
- `requires texture_and_sampler_let;` directive automatically injected into WGSL shaders on supporting devices via `ShaderDefinitionUtils.getWGSLEnables`.

**Notes:**
- Infrastructure-only — no shader callers yet. The cap unlocks future bindless-style helpers / indirection patterns.
- On devices that don't expose the feature, the cap is `false` and no `requires` directive is emitted, so existing portable shaders continue to compile.

See https://developer.chrome.com/blog/new-in-webgpu-146