### PR TITLE
fix(scene): fire EVENT_PRECULL after frustum update

### DIFF
--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1085,13 +1085,14 @@ class Renderer {
         for (let i = 0; i < numCameras; i++) {
             const camera = comp.cameras[i];
 
-            // event before the camera is culling
-            scene?.fire(EVENT_PRECULL, camera);
-
             // update camera and frustum
             const renderTarget = camera.renderTarget;
             camera.frameUpdate(renderTarget);
             this.updateCameraFrustum(camera.camera);
+
+            // event before the camera is culling, fired after the frustum has been updated so
+            // listeners can rely on the current camera state
+            scene?.fire(EVENT_PRECULL, camera);
 
             // for all of its enabled layers
             const layerIds = camera.layers;


### PR DESCRIPTION
Reorder `cullComposition` so `EVENT_PRECULL` is dispatched after `camera.frameUpdate` and `updateCameraFrustum` have run. Listeners now receive a camera whose frustum reflects the current frame's state, which makes the event usable for custom culling, LOD selection, and other logic that depends on up-to-date frustum planes.

This also aligns behavior with the shadow renderer's `EVENT_PRECULL` site, which already fires after its frustum is updated.

Fixes #8789.

**Changes:**
- `EVENT_PRECULL` now fires after the camera frustum has been recomputed for the frame.

**Behavior change:**
- Listeners that previously relied on `EVENT_PRECULL` firing *before* the frustum update (e.g., to mutate the camera transform and have that change picked up by this frame's frustum) must now call `Renderer#updateCameraFrustum` themselves, or move that logic earlier.