### PR TITLE
fix(test): stop http retry tail from leaking across unit tests

### DIFF
--- a/test/fixtures.mjs
+++ b/test/fixtures.mjs
@@ -2,9 +2,16 @@ import { createServer } from 'http';
 
 import handler from 'serve-handler';
 
+import { Http } from '../src/platform/net/http.js';
+
 let server;
 
 export const mochaGlobalSetup = () => {
+    // Collapse the http retry tail so retries leaked by earlier tests (e.g. BundleHandler's
+    // blob-URL loads that fail under JSDOM) drain in ~60 ms instead of ~6 s, preventing them
+    // from polluting later tests that spy on http.request or swap global.XMLHttpRequest.
+    Http.retryDelay = 1;
+
     server = createServer((request, response) => {
         return handler(request, response);
     });


### PR DESCRIPTION
Fix flaky `Http #get()` unit tests that have intermittently failed CI for weeks.

**Root cause:**
Earlier tests (notably `BundleHandler`) trigger `http.get` with `retry: true` against blob URLs that fail under JSDOM with status 0. With the default `Http.retryDelay = 100`, each retry chain takes ~6.2 s to drain (200/400/800/1600/3200 ms). The originating test calls `done()` as soon as the bundle itself loads, so the retries keep firing in the background and pollute later tests — the `Http` describe block spies `http.request` and swaps `global.XMLHttpRequest`, so leaked retries bump call counts and intercept fake XHRs, producing `expected N to equal 6` and `expected 'Network error' to equal null` failures.

**Changes:**
- `test/fixtures.mjs`: set `Http.retryDelay = 1` in `mochaGlobalSetup` so leaked retries drain in ~60 ms instead of ~6 s.

No production code changes. Two test suites already overrode `Http.retryDelay = 1` per-`beforeEach`; this promotes that to a global setup so every test benefits.