### PR TITLE
docs(entity): make getGuid() part of the public API

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -473,10 +473,10 @@ class Entity extends GraphNode {
     }
 
     /**
-     * Get the GUID value for this Entity.
+     * Get the GUID value for this Entity. The GUID is generated lazily on first access if one has
+     * not been assigned.
      *
      * @returns {string} The GUID of the Entity.
-     * @ignore
      */
     getGuid() {
         // if the guid hasn't been set yet then set it now before returning it


### PR DESCRIPTION
## Summary

- Removes `@ignore` from `Entity.getGuid()` so it shows up in the generated API docs.
- Adds a note that the GUID is generated lazily on first access.

## Why

Users have been relying on the private `entity._guid` because there was no public accessor — even though `findByGuid()` is fully public. `getGuid()` is already widely used internally (scene parser, element-input, component systems, scroll-view, button, render, anim, script, rigid-body, screen, collision), so the contract is stable; it just wasn't documented for external use.

`setGuid()` is intentionally left `@ignore` — its existing JSDoc warns that misuse "will corrupt the graph this Entity is in", so it should stay an internal API.

Resolves #7394.

## Test plan

- [ ] Confirm `getGuid()` appears in the generated API reference.
- [ ] No behavior change — existing internal callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)