### PR TITLE
docs(entity): expose guid as a public getter

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -842,8 +842,8 @@ class AnimComponent extends Component {
     }
 
     resolveDuplicatedEntityReferenceProperties(oldAnim, duplicatedIdsMap) {
-        if (oldAnim.rootBone && duplicatedIdsMap[oldAnim.rootBone.getGuid()]) {
-            this.rootBone = duplicatedIdsMap[oldAnim.rootBone.getGuid()];
+        if (oldAnim.rootBone && duplicatedIdsMap[oldAnim.rootBone.guid]) {
+            this.rootBone = duplicatedIdsMap[oldAnim.rootBone.guid];
         } else {
             this.rebind();
         }

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -401,7 +401,7 @@ class ButtonComponent extends Component {
     set imageEntity(arg) {
         if (this._imageEntity !== arg) {
             const isString = typeof arg === 'string';
-            if (this._imageEntity && isString && this._imageEntity.getGuid() === arg) {
+            if (this._imageEntity && isString && this._imageEntity.guid === arg) {
                 return;
             }
 
@@ -422,7 +422,7 @@ class ButtonComponent extends Component {
             }
 
             if (this._imageEntity) {
-                this.data.imageEntity = this._imageEntity.getGuid();
+                this.data.imageEntity = this._imageEntity.guid;
             } else if (isString && arg) {
                 this.data.imageEntity = arg;
             }
@@ -1185,7 +1185,7 @@ class ButtonComponent extends Component {
 
     resolveDuplicatedEntityReferenceProperties(oldButton, duplicatedIdsMap) {
         if (oldButton.imageEntity) {
-            this.imageEntity = duplicatedIdsMap[oldButton.imageEntity.getGuid()];
+            this.imageEntity = duplicatedIdsMap[oldButton.imageEntity.guid];
         }
     }
 }

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -192,7 +192,7 @@ class CollisionSystemImpl {
 
     // Called when the collision is cloned to another entity
     clone(entity, clone) {
-        const src = this.system.store[entity.getGuid()];
+        const src = this.system.store[entity.guid];
 
         const data = {
             enabled: src.data.enabled,

--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -121,7 +121,7 @@ class Component extends EventHandler {
      * @ignore
      */
     get data() {
-        const record = this.system.store[this.entity.getGuid()];
+        const record = this.system.store[this.entity.guid];
         return record ? record.data : null;
     }
 

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -725,7 +725,7 @@ class RenderComponent extends Component {
     set rootBone(value) {
         if (this._rootBone !== value) {
             const isString = typeof value === 'string';
-            if (this._rootBone && isString && this._rootBone.getGuid() === value) {
+            if (this._rootBone && isString && this._rootBone.guid === value) {
                 return;
             }
 
@@ -1067,7 +1067,7 @@ class RenderComponent extends Component {
 
     resolveDuplicatedEntityReferenceProperties(oldRender, duplicatedIdsMap) {
         if (oldRender.rootBone) {
-            this.rootBone = duplicatedIdsMap[oldRender.rootBone.getGuid()];
+            this.rootBone = duplicatedIdsMap[oldRender.rootBone.guid];
         }
     }
 }

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -746,7 +746,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
      */
     _storeCollision(entity, other) {
         let isNewCollision = false;
-        const guid = entity.getGuid();
+        const guid = entity.guid;
 
         this.collisions[guid] = this.collisions[guid] || { others: [], entity: entity };
 

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -107,7 +107,7 @@ class ScreenComponent extends Component {
      * the next update loop.
      */
     syncDrawOrder() {
-        this.system.queueDrawOrderSync(this.entity.getGuid(), this._processDrawOrderSync, this);
+        this.system.queueDrawOrderSync(this.entity.guid, this._processDrawOrderSync, this);
     }
 
     _recurseDrawOrderSync(e, i) {

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -610,9 +610,9 @@ class ScriptComponent extends Component {
 
             const newGuidArray = oldValue.slice();
             for (let i = 0; i < len; i++) {
-                const guid = newGuidArray[i] instanceof Entity ? newGuidArray[i].getGuid() : newGuidArray[i];
+                const guid = newGuidArray[i] instanceof Entity ? newGuidArray[i].guid : newGuidArray[i];
                 if (duplicatedIdsMap[guid]) {
-                    newGuidArray[i] = useGuid ? duplicatedIdsMap[guid].getGuid() : duplicatedIdsMap[guid];
+                    newGuidArray[i] = useGuid ? duplicatedIdsMap[guid].guid : duplicatedIdsMap[guid];
                 }
             }
 
@@ -620,7 +620,7 @@ class ScriptComponent extends Component {
         } else {
             // handle regular entity attribute
             if (oldValue instanceof Entity) {
-                oldValue = oldValue.getGuid();
+                oldValue = oldValue.guid;
             } else if (typeof oldValue !== 'string') {
                 return;
             }

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -470,7 +470,7 @@ class ScrollViewComponent extends Component {
         }
 
         const isString = typeof arg === 'string';
-        if (this._viewportEntity && isString && this._viewportEntity.getGuid() === arg) {
+        if (this._viewportEntity && isString && this._viewportEntity.guid === arg) {
             return;
         }
 
@@ -512,7 +512,7 @@ class ScrollViewComponent extends Component {
         }
 
         const isString = typeof arg === 'string';
-        if (this._contentEntity && isString && this._contentEntity.getGuid() === arg) {
+        if (this._contentEntity && isString && this._contentEntity.guid === arg) {
             return;
         }
 
@@ -554,7 +554,7 @@ class ScrollViewComponent extends Component {
         }
 
         const isString = typeof arg === 'string';
-        if (this._horizontalScrollbarEntity && isString && this._horizontalScrollbarEntity.getGuid() === arg) {
+        if (this._horizontalScrollbarEntity && isString && this._horizontalScrollbarEntity.guid === arg) {
             return;
         }
 
@@ -598,7 +598,7 @@ class ScrollViewComponent extends Component {
         }
 
         const isString = typeof arg === 'string';
-        if (this._verticalScrollbarEntity && isString && this._verticalScrollbarEntity.getGuid() === arg) {
+        if (this._verticalScrollbarEntity && isString && this._verticalScrollbarEntity.guid === arg) {
             return;
         }
 
@@ -1350,16 +1350,16 @@ class ScrollViewComponent extends Component {
 
     resolveDuplicatedEntityReferenceProperties(oldScrollView, duplicatedIdsMap) {
         if (oldScrollView.viewportEntity) {
-            this.viewportEntity = duplicatedIdsMap[oldScrollView.viewportEntity.getGuid()];
+            this.viewportEntity = duplicatedIdsMap[oldScrollView.viewportEntity.guid];
         }
         if (oldScrollView.contentEntity) {
-            this.contentEntity = duplicatedIdsMap[oldScrollView.contentEntity.getGuid()];
+            this.contentEntity = duplicatedIdsMap[oldScrollView.contentEntity.guid];
         }
         if (oldScrollView.horizontalScrollbarEntity) {
-            this.horizontalScrollbarEntity = duplicatedIdsMap[oldScrollView.horizontalScrollbarEntity.getGuid()];
+            this.horizontalScrollbarEntity = duplicatedIdsMap[oldScrollView.horizontalScrollbarEntity.guid];
         }
         if (oldScrollView.verticalScrollbarEntity) {
-            this.verticalScrollbarEntity = duplicatedIdsMap[oldScrollView.verticalScrollbarEntity.getGuid()];
+            this.verticalScrollbarEntity = duplicatedIdsMap[oldScrollView.verticalScrollbarEntity.guid];
         }
     }
 }

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -361,7 +361,7 @@ class ScrollbarComponent extends Component {
 
     resolveDuplicatedEntityReferenceProperties(oldScrollbar, duplicatedIdsMap) {
         if (oldScrollbar.handleEntity) {
-            this.handleEntity = duplicatedIdsMap[oldScrollbar.handleEntity.getGuid()];
+            this.handleEntity = duplicatedIdsMap[oldScrollbar.handleEntity.guid];
         }
     }
 }

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -54,7 +54,7 @@ class ComponentSystem extends EventHandler {
         const component = new this.ComponentType(this, entity);
         const componentData = new this.DataType();
 
-        this.store[entity.getGuid()] = {
+        this.store[entity.guid] = {
             entity: entity,
             data: componentData
         };
@@ -80,13 +80,13 @@ class ComponentSystem extends EventHandler {
      */
     removeComponent(entity) {
         const id = this.id;
-        const record = this.store[entity.getGuid()];
+        const record = this.store[entity.guid];
         const component = entity.c[id];
 
         component.fire('beforeremove');
         this.fire('beforeremove', entity, component);
 
-        delete this.store[entity.getGuid()];
+        delete this.store[entity.guid];
 
         entity[id] = undefined;
         delete entity.c[id];
@@ -104,7 +104,7 @@ class ComponentSystem extends EventHandler {
      */
     cloneComponent(entity, clone) {
         // default clone is just to add a new component with existing data
-        const src = this.store[entity.getGuid()];
+        const src = this.store[entity.guid];
         return this.addComponent(clone, src.data);
     }
 

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -473,10 +473,20 @@ class Entity extends GraphNode {
     }
 
     /**
+     * Gets the GUID for this Entity.
+     *
+     * @type {string}
+     */
+    get guid() {
+        return this.getGuid();
+    }
+
+    /**
      * Get the GUID value for this Entity. The GUID is generated lazily on first access if one has
      * not been assigned.
      *
      * @returns {string} The GUID of the Entity.
+     * @ignore
      */
     getGuid() {
         // if the guid hasn't been set yet then set it now before returning it

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -473,28 +473,48 @@ class Entity extends GraphNode {
     }
 
     /**
+     * Sets the GUID for this Entity. Note that it is unlikely that you should need to change the
+     * GUID value of an Entity at run-time. Doing so will corrupt the graph this Entity is in.
+     *
+     * @type {string}
+     * @ignore
+     */
+    set guid(value) {
+        // remove current guid from entityIndex
+        const index = this._app._entityIndex;
+        if (this._guid) {
+            delete index[this._guid];
+        }
+
+        // add new guid to entityIndex
+        this._guid = value;
+        index[this._guid] = this;
+    }
+
+    /**
      * Gets the GUID for this Entity.
      *
      * @type {string}
      */
     get guid() {
-        return this.getGuid();
-    }
-
-    /**
-     * Get the GUID value for this Entity. The GUID is generated lazily on first access if one has
-     * not been assigned.
-     *
-     * @returns {string} The GUID of the Entity.
-     * @ignore
-     */
-    getGuid() {
         // if the guid hasn't been set yet then set it now before returning it
         if (!this._guid) {
-            this.setGuid(guid.create());
+            this.guid = guid.create();
         }
 
         return this._guid;
+    }
+
+    /**
+     * Get the GUID value for this Entity.
+     *
+     * @returns {string} The GUID of the Entity.
+     * @ignore
+     * @deprecated Use {@link Entity#guid} instead.
+     */
+    getGuid() {
+        Debug.deprecated('Entity#getGuid is deprecated. Use Entity#guid instead.');
+        return this.guid;
     }
 
     /**
@@ -503,17 +523,11 @@ class Entity extends GraphNode {
      *
      * @param {string} guid - The GUID to assign to the Entity.
      * @ignore
+     * @deprecated Use {@link Entity#guid} instead.
      */
     setGuid(guid) {
-        // remove current guid from entityIndex
-        const index = this._app._entityIndex;
-        if (this._guid) {
-            delete index[this._guid];
-        }
-
-        // add new guid to entityIndex
-        this._guid = guid;
-        index[this._guid] = this;
+        Debug.deprecated('Entity#setGuid is deprecated. Use Entity#guid instead.');
+        this.guid = guid;
     }
 
     /**
@@ -652,7 +666,7 @@ class Entity extends GraphNode {
     clone() {
         const duplicatedIdsMap = {};
         const clone = this._cloneRecursively(duplicatedIdsMap);
-        duplicatedIdsMap[this.getGuid()] = clone;
+        duplicatedIdsMap[this.guid] = clone;
 
         resolveDuplicatedEntityReferenceProperties(this, this, clone, duplicatedIdsMap);
 
@@ -699,7 +713,7 @@ class Entity extends GraphNode {
             if (oldChild instanceof Entity) {
                 const newChild = oldChild._cloneRecursively(duplicatedIdsMap);
                 clone.addChild(newChild);
-                duplicatedIdsMap[oldChild.getGuid()] = newChild;
+                duplicatedIdsMap[oldChild.guid] = newChild;
             }
         }
 
@@ -740,7 +754,7 @@ function resolveDuplicatedEntityReferenceProperties(oldSubtreeRoot, oldEntity, n
                 const entityIsWithinOldSubtree = !!oldSubtreeRoot.findByGuid(oldEntityReferenceId);
 
                 if (entityIsWithinOldSubtree) {
-                    const newEntityReferenceId = duplicatedIdsMap[oldEntityReferenceId].getGuid();
+                    const newEntityReferenceId = duplicatedIdsMap[oldEntityReferenceId].guid;
 
                     if (newEntityReferenceId) {
                         newEntity.c[componentName][propertyName] = newEntityReferenceId;

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -660,9 +660,9 @@ class ElementInput {
                 const hovered = this._getTargetElementByCoords(cameras[c], coords.x, coords.y);
                 if (hovered === element) {
 
-                    if (!this._clickedEntities[element.entity.getGuid()]) {
+                    if (!this._clickedEntities[element.entity.guid]) {
                         this._fireEvent('click', new ElementTouchEvent(event, element, camera, x, y, touch));
-                        this._clickedEntities[element.entity.getGuid()] = Date.now();
+                        this._clickedEntities[element.entity.guid] = Date.now();
                     }
 
                 }
@@ -759,7 +759,7 @@ class ElementInput {
             // click event
             if (this._pressedElement === this._hoveredElement) {
                 // fire click event if it hasn't been fired already by the touchend handler
-                const guid = this._hoveredElement.entity.getGuid();
+                const guid = this._hoveredElement.entity.guid;
                 // Always fire, if there are no clicked entities
                 let fireClick = !this._clickedEntities;
                 // But if there are, we need to check how long ago touchend added a "click brake"

--- a/src/framework/parsers/scene.js
+++ b/src/framework/parsers/scene.js
@@ -52,7 +52,7 @@ class SceneParser {
     _createEntity(data, compressed) {
         const entity = new Entity(data.name, this._app);
 
-        entity.setGuid(data.resource_id);
+        entity.guid = data.resource_id;
         this._setPosRotScale(entity, data, compressed);
         entity._enabled = data.enabled ?? true;
 
@@ -93,7 +93,7 @@ class SceneParser {
         const systemsList = this._app.systems.list;
 
         let len = systemsList.length;
-        const entityData = entities[entity.getGuid()];
+        const entityData = entities[entity.guid];
         for (let i = 0; i < len; i++) {
             const system = systemsList[i];
             const componentData = entityData.components[system.id];

--- a/test/assets/scripts/cloner.js
+++ b/test/assets/scripts/cloner.js
@@ -3,12 +3,12 @@ const Cloner = pc.createScript('cloner');
 Cloner.attributes.add('entityToClone', { type: 'entity' });
 
 Cloner.prototype.initialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} initialize cloner`);
+    window.initializeCalls.push(`${this.entity.guid} initialize cloner`);
     const clone = this.entityToClone.clone();
     clone.name += ' - clone';
     this.app.root.addChild(clone);
 };
 
 Cloner.prototype.postInitialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postInitialize cloner`);
+    window.initializeCalls.push(`${this.entity.guid} postInitialize cloner`);
 };

--- a/test/assets/scripts/destroyer.js
+++ b/test/assets/scripts/destroyer.js
@@ -6,19 +6,19 @@ Destroyer.attributes.add('destroyScriptComponent', { type: 'boolean' });
 Destroyer.attributes.add('destroyScriptInstance', { type: 'boolean' });
 
 Destroyer.prototype.initialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} initialize destroyer`);
+    window.initializeCalls.push(`${this.entity.guid} initialize destroyer`);
 
     this.on('state', function (state) {
-        window.initializeCalls.push(`${this.entity.getGuid()} state ${state} destroyer`);
+        window.initializeCalls.push(`${this.entity.guid} state ${state} destroyer`);
     });
     this.on('disable', function () {
-        window.initializeCalls.push(`${this.entity.getGuid()} disable destroyer`);
+        window.initializeCalls.push(`${this.entity.guid} disable destroyer`);
     });
     this.on('enable', function () {
-        window.initializeCalls.push(`${this.entity.getGuid()} enable destroyer`);
+        window.initializeCalls.push(`${this.entity.guid} enable destroyer`);
     });
     this.on('destroy', function () {
-        window.initializeCalls.push(`${this.entity.getGuid()} destroy destroyer`);
+        window.initializeCalls.push(`${this.entity.guid} destroy destroyer`);
     });
 
     if (this.methodName === 'initialize') {
@@ -27,7 +27,7 @@ Destroyer.prototype.initialize = function () {
 };
 
 Destroyer.prototype.postInitialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postInitialize destroyer`);
+    window.initializeCalls.push(`${this.entity.guid} postInitialize destroyer`);
 
     if (this.methodName === 'postInitialize') {
         this.destroySomething();
@@ -35,7 +35,7 @@ Destroyer.prototype.postInitialize = function () {
 };
 
 Destroyer.prototype.update = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} update destroyer`);
+    window.initializeCalls.push(`${this.entity.guid} update destroyer`);
 
     if (!this.methodName || this.methodName === 'update')  {
         this.destroySomething();
@@ -43,7 +43,7 @@ Destroyer.prototype.update = function () {
 };
 
 Destroyer.prototype.postUpdate = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postUpdate destroyer`);
+    window.initializeCalls.push(`${this.entity.guid} postUpdate destroyer`);
 
     if (this.methodName === 'postUpdate') {
         this.destroySomething();

--- a/test/assets/scripts/disabler.js
+++ b/test/assets/scripts/disabler.js
@@ -5,7 +5,7 @@ Disabler.attributes.add('disableScriptComponent', { type: 'boolean' });
 Disabler.attributes.add('disableScriptInstance', { type: 'boolean' });
 
 Disabler.prototype.initialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} initialize disabler`);
+    window.initializeCalls.push(`${this.entity.guid} initialize disabler`);
 
     if (this.disableEntity) {
         this.entity.enabled = false;
@@ -27,5 +27,5 @@ Disabler.prototype.initialize = function () {
 };
 
 Disabler.prototype.postInitialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postInitialize disabler`);
+    window.initializeCalls.push(`${this.entity.guid} postInitialize disabler`);
 };

--- a/test/assets/scripts/enabler.js
+++ b/test/assets/scripts/enabler.js
@@ -3,7 +3,7 @@ const Enabler = pc.createScript('enabler');
 Enabler.attributes.add('entityToEnable', { type: 'entity' });
 
 Enabler.prototype.initialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} initialize enabler`);
+    window.initializeCalls.push(`${this.entity.guid} initialize enabler`);
     this.entityToEnable.enabled = true;
     this.entityToEnable.script.enabled = true;
     if (this.entityToEnable.script.scriptA) {
@@ -16,5 +16,5 @@ Enabler.prototype.initialize = function () {
 };
 
 Enabler.prototype.postInitialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postInitialize enabler`);
+    window.initializeCalls.push(`${this.entity.guid} postInitialize enabler`);
 };

--- a/test/assets/scripts/loadedLater.js
+++ b/test/assets/scripts/loadedLater.js
@@ -5,7 +5,7 @@ LoadedLater.attributes.add('disableScriptComponent', { type: 'boolean' });
 LoadedLater.attributes.add('disableScriptInstance', { type: 'boolean' });
 
 LoadedLater.prototype.initialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} initialize loadedLater`);
+    window.initializeCalls.push(`${this.entity.guid} initialize loadedLater`);
 
     if (this.disableEntity) {
         this.entity.enabled = false;
@@ -21,5 +21,5 @@ LoadedLater.prototype.initialize = function () {
 };
 
 LoadedLater.prototype.postInitialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postInitialize loadedLater`);
+    window.initializeCalls.push(`${this.entity.guid} postInitialize loadedLater`);
 };

--- a/test/assets/scripts/postInitializeReporter.js
+++ b/test/assets/scripts/postInitializeReporter.js
@@ -1,9 +1,9 @@
 const postInitializeReporter = pc.createScript('postInitializeReporter');
 
 postInitializeReporter.prototype.initialize = function () {
-    console.log(`${this.entity.getGuid()} initialize postInitializeReporter`);
+    console.log(`${this.entity.guid} initialize postInitializeReporter`);
 };
 
 postInitializeReporter.prototype.postInitialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postInitialize postInitializeReporter`);
+    window.initializeCalls.push(`${this.entity.guid} postInitialize postInitializeReporter`);
 };

--- a/test/assets/scripts/scriptA.js
+++ b/test/assets/scripts/scriptA.js
@@ -1,7 +1,7 @@
 const ScriptA = pc.createScript('scriptA');
 
 ScriptA.prototype.initialize = function () {
-    const guid = this.entity.getGuid();
+    const guid = this.entity.guid;
     window.initializeCalls.push(`${guid} initialize scriptA`);
     this.entity.script.on('enable', () => {
         window.initializeCalls.push(`${guid} enable scriptComponent scriptA`);
@@ -22,18 +22,18 @@ ScriptA.prototype.initialize = function () {
         window.initializeCalls.push(`${guid} state ${enabled} scriptA`);
     });
     this.on('destroy', function () {
-        window.initializeCalls.push(`${this.entity.getGuid()} destroy scriptA`);
+        window.initializeCalls.push(`${this.entity.guid} destroy scriptA`);
     });
 };
 
 ScriptA.prototype.postInitialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postInitialize scriptA`);
+    window.initializeCalls.push(`${this.entity.guid} postInitialize scriptA`);
 };
 
 ScriptA.prototype.update = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} update scriptA`);
+    window.initializeCalls.push(`${this.entity.guid} update scriptA`);
 };
 
 ScriptA.prototype.postUpdate = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postUpdate scriptA`);
+    window.initializeCalls.push(`${this.entity.guid} postUpdate scriptA`);
 };

--- a/test/assets/scripts/scriptB.js
+++ b/test/assets/scripts/scriptB.js
@@ -1,7 +1,7 @@
 const ScriptB = pc.createScript('scriptB');
 
 ScriptB.prototype.initialize = function () {
-    const guid = this.entity.getGuid();
+    const guid = this.entity.guid;
     window.initializeCalls.push(`${guid} initialize scriptB`);
     this.entity.script.on('enable', () => {
         window.initializeCalls.push(`${guid} enable scriptB`);
@@ -13,18 +13,18 @@ ScriptB.prototype.initialize = function () {
         window.initializeCalls.push(`${guid} state ${enabled} scriptB`);
     });
     this.on('destroy', function () {
-        window.initializeCalls.push(`${this.entity.getGuid()} destroy scriptB`);
+        window.initializeCalls.push(`${this.entity.guid} destroy scriptB`);
     });
 };
 
 ScriptB.prototype.postInitialize = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postInitialize scriptB`);
+    window.initializeCalls.push(`${this.entity.guid} postInitialize scriptB`);
 };
 
 ScriptB.prototype.update = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} update scriptB`);
+    window.initializeCalls.push(`${this.entity.guid} update scriptB`);
 };
 
 ScriptB.prototype.postUpdate = function () {
-    window.initializeCalls.push(`${this.entity.getGuid()} postUpdate scriptB`);
+    window.initializeCalls.push(`${this.entity.guid} postUpdate scriptB`);
 };

--- a/test/framework/components/script/component.test.mjs
+++ b/test/framework/components/script/component.test.mjs
@@ -42,7 +42,7 @@ describe('ScriptComponent', function () {
     });
 
     function checkInitCall(entity, index, text) {
-        expect(window.initializeCalls[index]).to.equal(`${entity.getGuid()} ${text}`);
+        expect(window.initializeCalls[index]).to.equal(`${entity.guid} ${text}`);
     }
 
     it('script assets are loaded', function () {
@@ -265,7 +265,7 @@ describe('ScriptComponent', function () {
                 enabler: {
                     enabled: true,
                     attributes: {
-                        entityToEnable: e.getGuid()
+                        entityToEnable: e.guid
                     }
                 }
             }
@@ -313,7 +313,7 @@ describe('ScriptComponent', function () {
                 enabler: {
                     enabled: true,
                     attributes: {
-                        entityToEnable: e.getGuid()
+                        entityToEnable: e.guid
                     }
                 }
             }
@@ -362,7 +362,7 @@ describe('ScriptComponent', function () {
                 enabler: {
                     enabled: true,
                     attributes: {
-                        entityToEnable: e.getGuid()
+                        entityToEnable: e.guid
                     }
                 }
             }
@@ -500,7 +500,7 @@ describe('ScriptComponent', function () {
                 postCloner: {
                     enabled: true,
                     attributes: {
-                        entityToClone: src.getGuid()
+                        entityToClone: src.guid
                     }
                 }
             }
@@ -525,7 +525,7 @@ describe('ScriptComponent', function () {
                 scriptWithAttributes: {
                     enabled: true,
                     attributes: {
-                        attribute1: e2.getGuid()
+                        attribute1: e2.guid
                     }
                 }
             }
@@ -552,7 +552,7 @@ describe('ScriptComponent', function () {
                 scriptWithAttributes: {
                     enabled: true,
                     attributes: {
-                        attribute1: e2.getGuid()
+                        attribute1: e2.guid
                     }
                 }
             }
@@ -577,7 +577,7 @@ describe('ScriptComponent', function () {
                 scriptWithAttributes: {
                     enabled: true,
                     attributes: {
-                        attribute1: e2.getGuid()
+                        attribute1: e2.guid
                     }
                 }
             }
@@ -601,7 +601,7 @@ describe('ScriptComponent', function () {
                 scriptWithAttributes: {
                     enabled: false,
                     attributes: {
-                        attribute1: e2.getGuid()
+                        attribute1: e2.guid
                     }
                 }
             }
@@ -625,7 +625,7 @@ describe('ScriptComponent', function () {
                 scriptWithAttributes: {
                     enabled: true,
                     attributes: {
-                        attribute1: e2.getGuid()
+                        attribute1: e2.guid
                     }
                 }
             }
@@ -654,7 +654,7 @@ describe('ScriptComponent', function () {
                 scriptWithAttributes: {
                     enabled: true,
                     attributes: {
-                        attribute1: e2.getGuid()
+                        attribute1: e2.guid
                     }
                 }
             }
@@ -682,7 +682,7 @@ describe('ScriptComponent', function () {
                 scriptWithAttributes: {
                     enabled: true,
                     attributes: {
-                        attribute1: e2.getGuid()
+                        attribute1: e2.guid
                     }
                 }
             }
@@ -710,7 +710,7 @@ describe('ScriptComponent', function () {
                 scriptWithAttributes: {
                     enabled: false,
                     attributes: {
-                        attribute1: e2.getGuid()
+                        attribute1: e2.guid
                     }
                 }
             }
@@ -862,11 +862,11 @@ describe('ScriptComponent', function () {
                     attributes: {
                         attribute3: {
                             fieldNumber: 1,
-                            fieldEntity: child.getGuid()
+                            fieldEntity: child.guid
                         },
                         attribute4: [{
                             fieldNumber: 2,
-                            fieldEntity: child.getGuid()
+                            fieldEntity: child.guid
                         }]
                     }
                 }
@@ -1891,11 +1891,11 @@ describe('ScriptComponent', function () {
     it('update and postUpdate are not called on script instance that was disabled during update loop', function () {
         const DisableDuringUpdateLoop = createScript('disableDuringUpdateLoop');
         DisableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update disableDuringUpdateLoop`);
             this.entity.script.scriptA.enabled = false;
         };
         DisableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate disableDuringUpdateLoop`);
         };
 
         const a = new Entity();
@@ -1927,11 +1927,11 @@ describe('ScriptComponent', function () {
     it('update and postUpdate are not called on script component that was disabled during update loop', function () {
         const DisableDuringUpdateLoop = createScript('disableDuringUpdateLoop');
         DisableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update disableDuringUpdateLoop`);
             this.entity.script.enabled = false;
         };
         DisableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate disableDuringUpdateLoop`);
         };
 
         const a = new Entity();
@@ -1964,11 +1964,11 @@ describe('ScriptComponent', function () {
     it('update and postUpdate are not called on entity that was disabled during update loop', function () {
         const DisableDuringUpdateLoop = createScript('disableDuringUpdateLoop');
         DisableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update disableDuringUpdateLoop`);
             this.entity.enabled = false;
         };
         DisableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate disableDuringUpdateLoop`);
         };
 
         const a = new Entity();
@@ -2001,7 +2001,7 @@ describe('ScriptComponent', function () {
     it('postUpdate not called on script instance that was disabled during post update loop', function () {
         const DisableDuringUpdateLoop = createScript('disableDuringUpdateLoop');
         DisableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate disableDuringUpdateLoop`);
             this.entity.script.scriptA.enabled = false;
         };
 
@@ -2034,7 +2034,7 @@ describe('ScriptComponent', function () {
     it('postUpdate not called on script component that was disabled during post update loop', function () {
         const DisableDuringUpdateLoop = createScript('disableDuringUpdateLoop');
         DisableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate disableDuringUpdateLoop`);
             this.entity.script.enabled = false;
         };
 
@@ -2069,7 +2069,7 @@ describe('ScriptComponent', function () {
     it('postUpdate not called on entity that was disabled during post update loop', function () {
         const DisableDuringUpdateLoop = createScript('disableDuringUpdateLoop');
         DisableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate disableDuringUpdateLoop`);
             this.entity.enabled = false;
         };
 
@@ -2104,13 +2104,13 @@ describe('ScriptComponent', function () {
     it('update not called second time on script instance that was re-enabled during the same frame', function () {
         const DisableDuringUpdateLoop = createScript('disableDuringUpdateLoop');
         DisableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update disableDuringUpdateLoop`);
             this.entity.script.disableDuringUpdateLoop.enabled = false;
         };
 
         const EnableDuringUpdateLoop = createScript('enableDuringUpdateLoop');
         EnableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update enableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update enableDuringUpdateLoop`);
             this.entity.script.disableDuringUpdateLoop.enabled = true; // enable first script back
         };
 
@@ -2141,13 +2141,13 @@ describe('ScriptComponent', function () {
     it('post update not called second time on script instance that was re-enabled during the same frame', function () {
         const DisableDuringUpdateLoop = createScript('disableDuringUpdateLoop');
         DisableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate disableDuringUpdateLoop`);
             this.entity.script.disableDuringUpdateLoop.enabled = false;
         };
 
         const EnableDuringUpdateLoop = createScript('enableDuringUpdateLoop');
         EnableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate enableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate enableDuringUpdateLoop`);
             this.entity.script.disableDuringUpdateLoop.enabled = true; // enable first script back
         };
 
@@ -2178,13 +2178,13 @@ describe('ScriptComponent', function () {
     it('update not called second time on script instance whose script component was re-enabled during the same frame', function () {
         const DisableDuringUpdateLoop = createScript('disableDuringUpdateLoop');
         DisableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update disableDuringUpdateLoop`);
             this.entity.script.enabled = false;
         };
 
         const EnableDuringUpdateLoop = createScript('enableDuringUpdateLoop');
         EnableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update enableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update enableDuringUpdateLoop`);
             const e = app.root.findByName('a');
             e.script.enabled = true; // enable first script component back
         };
@@ -2225,13 +2225,13 @@ describe('ScriptComponent', function () {
     it('post update not called second time on script instance whose script component was re-enabled during the same frame', function () {
         const DisableDuringUpdateLoop = createScript('disableDuringUpdateLoop');
         DisableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate disableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate disableDuringUpdateLoop`);
             this.entity.script.enabled = false;
         };
 
         const EnableDuringUpdateLoop = createScript('enableDuringUpdateLoop');
         EnableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate enableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate enableDuringUpdateLoop`);
             const e = app.root.findByName('a');
             e.script.enabled = true; // enable first script component back
         };
@@ -2366,7 +2366,7 @@ describe('ScriptComponent', function () {
     it('update and post update are called on the same frame for child entities that become enabled during a parent\s update', function () {
         const EnableDuringUpdateLoop = createScript('enableDuringUpdateLoop');
         EnableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update enableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update enableDuringUpdateLoop`);
             const e = app.root.findByName('b');
             e.enabled = true;
         };
@@ -2421,7 +2421,7 @@ describe('ScriptComponent', function () {
     it('update is called on the next frame and post update on the same frame for parent entities whose script component becomes enabled during a child\s update', function () {
         const EnableDuringUpdateLoop = createScript('enableDuringUpdateLoop');
         EnableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update enableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update enableDuringUpdateLoop`);
             const e = app.root.findByName('a');
             e.script.enabled = true;
         };
@@ -2482,7 +2482,7 @@ describe('ScriptComponent', function () {
     it('update is called on the same frame for subsequent script instance that gets enabled during update loop', function () {
         const EnableDuringUpdateLoop = createScript('enableDuringUpdateLoop');
         EnableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update enableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update enableDuringUpdateLoop`);
             this.entity.script.scriptB.enabled = true;
         };
 
@@ -2522,7 +2522,7 @@ describe('ScriptComponent', function () {
     it('update is called on the next frame and post update on the same frame for previous script instance that gets enabled during update loop', function () {
         const EnableDuringUpdateLoop = createScript('enableDuringUpdateLoop');
         EnableDuringUpdateLoop.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update enableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} update enableDuringUpdateLoop`);
             this.entity.script.scriptB.enabled = true;
         };
 
@@ -2571,7 +2571,7 @@ describe('ScriptComponent', function () {
     it('post update is called on the same frame for subsequent script instance that gets enabled during post update loop', function () {
         const EnableDuringUpdateLoop = createScript('enableDuringUpdateLoop');
         EnableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} post update enableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} post update enableDuringUpdateLoop`);
             this.entity.script.scriptB.enabled = true;
         };
 
@@ -2610,7 +2610,7 @@ describe('ScriptComponent', function () {
     it('post update is called on the next frame previous script instance that gets enabled during post update loop', function () {
         const EnableDuringUpdateLoop = createScript('enableDuringUpdateLoop');
         EnableDuringUpdateLoop.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} post update enableDuringUpdateLoop`);
+            window.initializeCalls.push(`${this.entity.guid} post update enableDuringUpdateLoop`);
             this.entity.script.scriptB.enabled = true;
         };
 
@@ -2881,10 +2881,10 @@ describe('ScriptComponent', function () {
         // so that 'swap' is triggered
         const NewScriptA = createScript('scriptA');
         NewScriptA.prototype.update = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} update new scriptA`);
+            window.initializeCalls.push(`${this.entity.guid} update new scriptA`);
         };
         NewScriptA.prototype.postUpdate = function () {
-            window.initializeCalls.push(`${this.entity.getGuid()} postUpdate new scriptA`);
+            window.initializeCalls.push(`${this.entity.guid} postUpdate new scriptA`);
         };
         NewScriptA.prototype.swap = function () {
         };

--- a/test/framework/components/scroll-view/component.test.mjs
+++ b/test/framework/components/scroll-view/component.test.mjs
@@ -296,7 +296,7 @@ describe('ScrollViewComponent', function () {
         it('accepts a GUID string and resolves via app.getEntityFromIndex', function () {
             const viewport = new Entity();
             viewport.addComponent('element', { type: ELEMENTTYPE_GROUP });
-            const guid = viewport.getGuid();
+            const guid = viewport.guid;
 
             const e = new Entity();
             e.addComponent('scrollview');
@@ -353,7 +353,7 @@ describe('ScrollViewComponent', function () {
         it('accepts a GUID string and resolves via app.getEntityFromIndex', function () {
             const content = new Entity();
             content.addComponent('element', { type: ELEMENTTYPE_IMAGE });
-            const guid = content.getGuid();
+            const guid = content.guid;
 
             const e = new Entity();
             e.addComponent('scrollview');
@@ -408,7 +408,7 @@ describe('ScrollViewComponent', function () {
 
         it('accepts a GUID string and resolves via app.getEntityFromIndex', function () {
             const { hScrollbar } = buildScrollViewEntity();
-            const guid = hScrollbar.getGuid();
+            const guid = hScrollbar.guid;
 
             const e = new Entity();
             e.addComponent('scrollview');
@@ -607,10 +607,10 @@ describe('ScrollViewComponent', function () {
             target.addComponent('scrollview');
 
             const map = {
-                [viewport.getGuid()]: newViewport,
-                [content.getGuid()]: newContent,
-                [hScrollbar.getGuid()]: newHScrollbar,
-                [vScrollbar.getGuid()]: newVScrollbar
+                [viewport.guid]: newViewport,
+                [content.guid]: newContent,
+                [hScrollbar.guid]: newHScrollbar,
+                [vScrollbar.guid]: newVScrollbar
             };
 
             target.scrollview.resolveDuplicatedEntityReferenceProperties(source.scrollview, map);

--- a/test/framework/components/scrollbar/component.test.mjs
+++ b/test/framework/components/scrollbar/component.test.mjs
@@ -208,7 +208,7 @@ describe('ScrollbarComponent', function () {
         it('accepts a GUID string and resolves via app.getEntityFromIndex', function () {
             const handle = new Entity();
             handle.addComponent('element', { type: ELEMENTTYPE_IMAGE });
-            const handleGuid = handle.getGuid();
+            const handleGuid = handle.guid;
 
             const e = new Entity();
             e.addComponent('scrollbar');
@@ -328,7 +328,7 @@ describe('ScrollbarComponent', function () {
             target.addComponent('element', { type: ELEMENTTYPE_IMAGE });
             target.addComponent('scrollbar');
 
-            const map = { [handle.getGuid()]: replacement };
+            const map = { [handle.guid]: replacement };
             target.scrollbar.resolveDuplicatedEntityReferenceProperties(source.scrollbar, map);
 
             expect(target.scrollbar.handleEntity).to.equal(replacement);

--- a/test/framework/entity.test.mjs
+++ b/test/framework/entity.test.mjs
@@ -241,7 +241,7 @@ describe('Entity', function () {
 
             const clone = entity.clone();
             expect(clone).to.be.an.instanceof(Entity);
-            expect(clone.getGuid()).to.not.equal(entity.getGuid());
+            expect(clone.guid).to.not.equal(entity.guid);
             expect(clone.name).to.equal('Test');
             for (const name in components) {
                 expect(clone[name]).to.be.an.instanceof(components[name]);
@@ -268,7 +268,7 @@ describe('Entity', function () {
 
             const clone = root.clone();
             expect(clone).to.be.an.instanceof(Entity);
-            expect(clone.getGuid()).to.not.equal(root.getGuid());
+            expect(clone.guid).to.not.equal(root.guid);
             expect(clone.name).to.equal('Test');
             for (const name in components) {
                 expect(clone[name]).to.be.an.instanceof(components[name]);
@@ -276,7 +276,7 @@ describe('Entity', function () {
             expect(clone.children.length).to.equal(root.children.length);
 
             const cloneChild = clone.findByName('Child');
-            expect(cloneChild.getGuid()).to.not.equal(child.getGuid());
+            expect(cloneChild.guid).to.not.equal(child.guid);
             for (const name in components) {
                 expect(cloneChild[name]).to.be.an.instanceof(components[name]);
             }
@@ -332,33 +332,33 @@ describe('Entity', function () {
             expect(subtree1.a_a_b.sound).to.not.equal(subtree2.a_a_b.sound);
 
             // Ensure new guids were created
-            expect(subtree1.a.getGuid()).to.not.equal(subtree2.a.getGuid());
-            expect(subtree1.a_a.getGuid()).to.not.equal(subtree2.a_a.getGuid());
-            expect(subtree1.a_b.getGuid()).to.not.equal(subtree2.a_b.getGuid());
-            expect(subtree1.a_a_a.getGuid()).to.not.equal(subtree2.a_a_a.getGuid());
-            expect(subtree1.a_a_b.getGuid()).to.not.equal(subtree2.a_a_b.getGuid());
+            expect(subtree1.a.guid).to.not.equal(subtree2.a.guid);
+            expect(subtree1.a_a.guid).to.not.equal(subtree2.a_a.guid);
+            expect(subtree1.a_b.guid).to.not.equal(subtree2.a_b.guid);
+            expect(subtree1.a_a_a.guid).to.not.equal(subtree2.a_a_a.guid);
+            expect(subtree1.a_a_b.guid).to.not.equal(subtree2.a_a_b.guid);
         });
 
         it('resolves entity property references that refer to entities within the duplicated subtree', function () {
             const subtree1 = createSubtree();
-            subtree1.a.addComponent('dummy', { myEntity1: subtree1.a_a.getGuid(), myEntity2: subtree1.a_a_b.getGuid() });
-            subtree1.a_a_a.addComponent('dummy', { myEntity1: subtree1.a.getGuid(), myEntity2: subtree1.a_b.getGuid() });
+            subtree1.a.addComponent('dummy', { myEntity1: subtree1.a_a.guid, myEntity2: subtree1.a_a_b.guid });
+            subtree1.a_a_a.addComponent('dummy', { myEntity1: subtree1.a.guid, myEntity2: subtree1.a_b.guid });
 
             const subtree2 = cloneSubtree(subtree1);
-            expect(subtree2.a.dummy.myEntity1).to.equal(subtree2.a_a.getGuid());
-            expect(subtree2.a.dummy.myEntity2).to.equal(subtree2.a_a_b.getGuid());
-            expect(subtree2.a_a_a.dummy.myEntity1).to.equal(subtree2.a.getGuid());
-            expect(subtree2.a_a_a.dummy.myEntity2).to.equal(subtree2.a_b.getGuid());
+            expect(subtree2.a.dummy.myEntity1).to.equal(subtree2.a_a.guid);
+            expect(subtree2.a.dummy.myEntity2).to.equal(subtree2.a_a_b.guid);
+            expect(subtree2.a_a_a.dummy.myEntity1).to.equal(subtree2.a.guid);
+            expect(subtree2.a_a_a.dummy.myEntity2).to.equal(subtree2.a_b.guid);
         });
 
         it('resolves entity property references that refer to the cloned entity itself', function () {
             const subtree1 = createSubtree();
-            subtree1.a.addComponent('dummy', { myEntity1: subtree1.a.getGuid() });
-            subtree1.a_a_a.addComponent('dummy', { myEntity1: subtree1.a_a_a.getGuid() });
+            subtree1.a.addComponent('dummy', { myEntity1: subtree1.a.guid });
+            subtree1.a_a_a.addComponent('dummy', { myEntity1: subtree1.a_a_a.guid });
 
             const subtree2 = cloneSubtree(subtree1);
-            expect(subtree2.a.dummy.myEntity1).to.equal(subtree2.a.getGuid());
-            expect(subtree2.a_a_a.dummy.myEntity1).to.equal(subtree2.a_a_a.getGuid());
+            expect(subtree2.a.dummy.myEntity1).to.equal(subtree2.a.guid);
+            expect(subtree2.a_a_a.dummy.myEntity1).to.equal(subtree2.a_a_a.guid);
         });
 
         it('does not attempt to resolve entity property references that refer to entities outside of the duplicated subtree', function () {
@@ -369,11 +369,11 @@ describe('Entity', function () {
             root.addChild(subtree1.a);
             root.addChild(sibling);
 
-            subtree1.a.addComponent('dummy', { myEntity1: root.getGuid(), myEntity2: sibling.getGuid() });
+            subtree1.a.addComponent('dummy', { myEntity1: root.guid, myEntity2: sibling.guid });
 
             const subtree2 = cloneSubtree(subtree1);
-            expect(subtree2.a.dummy.myEntity1).to.equal(root.getGuid());
-            expect(subtree2.a.dummy.myEntity2).to.equal(sibling.getGuid());
+            expect(subtree2.a.dummy.myEntity1).to.equal(root.guid);
+            expect(subtree2.a.dummy.myEntity2).to.equal(sibling.guid);
         });
 
         it('ignores null and undefined entity property references', function () {
@@ -395,41 +395,41 @@ describe('Entity', function () {
             subtree1.a.addComponent('script');
             subtree1.a.script.create('test', {
                 attributes: {
-                    entityAttr: subtree1.a_a.getGuid(),
-                    entityArrayAttr: [subtree1.a_a.getGuid()]
+                    entityAttr: subtree1.a_a.guid,
+                    entityArrayAttr: [subtree1.a_a.guid]
                 }
             });
-            expect(subtree1.a.script.test.entityAttr.getGuid()).to.equal(subtree1.a_a.getGuid());
+            expect(subtree1.a.script.test.entityAttr.guid).to.equal(subtree1.a_a.guid);
             expect(subtree1.a.script.test.entityArrayAttr).to.be.an('array');
             expect(subtree1.a.script.test.entityArrayAttr.length).to.equal(1);
-            expect(subtree1.a.script.test.entityArrayAttr[0].getGuid()).to.equal(subtree1.a_a.getGuid());
+            expect(subtree1.a.script.test.entityArrayAttr[0].guid).to.equal(subtree1.a_a.guid);
 
             subtree1.a_a.addComponent('script');
             subtree1.a_a.script.create('test', {
                 attributes: {
-                    entityAttr: subtree1.a.getGuid(),
-                    entityArrayAttr: [subtree1.a.getGuid(), subtree1.a_a_a.getGuid()]
+                    entityAttr: subtree1.a.guid,
+                    entityArrayAttr: [subtree1.a.guid, subtree1.a_a_a.guid]
                 }
             });
 
-            expect(subtree1.a_a.script.test.entityAttr.getGuid()).to.equal(subtree1.a.getGuid());
+            expect(subtree1.a_a.script.test.entityAttr.guid).to.equal(subtree1.a.guid);
             expect(subtree1.a_a.script.test.entityArrayAttr).to.be.an('array');
             expect(subtree1.a_a.script.test.entityArrayAttr.length).to.equal(2);
-            expect(subtree1.a_a.script.test.entityArrayAttr[0].getGuid()).to.equal(subtree1.a.getGuid());
-            expect(subtree1.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(subtree1.a_a_a.getGuid());
+            expect(subtree1.a_a.script.test.entityArrayAttr[0].guid).to.equal(subtree1.a.guid);
+            expect(subtree1.a_a.script.test.entityArrayAttr[1].guid).to.equal(subtree1.a_a_a.guid);
 
             const subtree2 = cloneSubtree(subtree1);
             app.root.addChild(subtree2.a);
-            expect(subtree2.a.script.test.entityAttr.getGuid()).to.equal(subtree2.a_a.getGuid());
+            expect(subtree2.a.script.test.entityAttr.guid).to.equal(subtree2.a_a.guid);
             expect(subtree2.a.script.test.entityArrayAttr).to.be.an('array');
             expect(subtree2.a.script.test.entityArrayAttr.length).to.equal(1);
-            expect(subtree2.a.script.test.entityArrayAttr[0].getGuid()).to.equal(subtree2.a_a.getGuid());
+            expect(subtree2.a.script.test.entityArrayAttr[0].guid).to.equal(subtree2.a_a.guid);
 
-            expect(subtree2.a_a.script.test.entityAttr.getGuid()).to.equal(subtree2.a.getGuid());
+            expect(subtree2.a_a.script.test.entityAttr.guid).to.equal(subtree2.a.guid);
             expect(subtree2.a_a.script.test.entityArrayAttr).to.be.an('array');
             expect(subtree2.a_a.script.test.entityArrayAttr.length).to.equal(2);
-            expect(subtree2.a_a.script.test.entityArrayAttr[0].getGuid()).to.equal(subtree2.a.getGuid());
-            expect(subtree2.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(subtree2.a_a_a.getGuid());
+            expect(subtree2.a_a.script.test.entityArrayAttr[0].guid).to.equal(subtree2.a.guid);
+            expect(subtree2.a_a.script.test.entityArrayAttr[1].guid).to.equal(subtree2.a_a_a.guid);
         });
 
         it('resolves entity script attributes that refer to entities within the duplicated subtree after preloading has finished', function () {
@@ -444,42 +444,42 @@ describe('Entity', function () {
             subtree1.a.addComponent('script');
             subtree1.a.script.create('test', {
                 attributes: {
-                    entityAttr: subtree1.a_a.getGuid(),
-                    entityArrayAttr: [subtree1.a_a.getGuid()]
+                    entityAttr: subtree1.a_a.guid,
+                    entityArrayAttr: [subtree1.a_a.guid]
                 }
             });
-            expect(subtree1.a.script.test.entityAttr.getGuid()).to.equal(subtree1.a_a.getGuid());
+            expect(subtree1.a.script.test.entityAttr.guid).to.equal(subtree1.a_a.guid);
             expect(subtree1.a.script.test.entityArrayAttr).to.be.an('array');
             expect(subtree1.a.script.test.entityArrayAttr.length).to.equal(1);
-            expect(subtree1.a.script.test.entityArrayAttr[0].getGuid()).to.equal(subtree1.a_a.getGuid());
+            expect(subtree1.a.script.test.entityArrayAttr[0].guid).to.equal(subtree1.a_a.guid);
 
             subtree1.a_a.addComponent('script');
             subtree1.a_a.script.create('test', {
                 attributes: {
-                    entityAttr: subtree1.a.getGuid(),
-                    entityArrayAttr: [subtree1.a.getGuid(), subtree1.a_a_a.getGuid()]
+                    entityAttr: subtree1.a.guid,
+                    entityArrayAttr: [subtree1.a.guid, subtree1.a_a_a.guid]
                 }
             });
 
-            expect(subtree1.a_a.script.test.entityAttr.getGuid()).to.equal(subtree1.a.getGuid());
+            expect(subtree1.a_a.script.test.entityAttr.guid).to.equal(subtree1.a.guid);
             expect(subtree1.a_a.script.test.entityArrayAttr).to.be.an('array');
             expect(subtree1.a_a.script.test.entityArrayAttr.length).to.equal(2);
-            expect(subtree1.a_a.script.test.entityArrayAttr[0].getGuid()).to.equal(subtree1.a.getGuid());
-            expect(subtree1.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(subtree1.a_a_a.getGuid());
+            expect(subtree1.a_a.script.test.entityArrayAttr[0].guid).to.equal(subtree1.a.guid);
+            expect(subtree1.a_a.script.test.entityArrayAttr[1].guid).to.equal(subtree1.a_a_a.guid);
 
 
             const subtree2 = cloneSubtree(subtree1);
             app.root.addChild(subtree2.a);
-            expect(subtree2.a.script.test.entityAttr.getGuid()).to.equal(subtree2.a_a.getGuid());
+            expect(subtree2.a.script.test.entityAttr.guid).to.equal(subtree2.a_a.guid);
             expect(subtree2.a.script.test.entityArrayAttr).to.be.an('array');
             expect(subtree2.a.script.test.entityArrayAttr.length).to.equal(1);
-            expect(subtree2.a.script.test.entityArrayAttr[0].getGuid()).to.equal(subtree2.a_a.getGuid());
+            expect(subtree2.a.script.test.entityArrayAttr[0].guid).to.equal(subtree2.a_a.guid);
 
-            expect(subtree2.a_a.script.test.entityAttr.getGuid()).to.equal(subtree2.a.getGuid());
+            expect(subtree2.a_a.script.test.entityAttr.guid).to.equal(subtree2.a.guid);
             expect(subtree2.a_a.script.test.entityArrayAttr).to.be.an('array');
             expect(subtree2.a_a.script.test.entityArrayAttr.length).to.equal(2);
-            expect(subtree2.a_a.script.test.entityArrayAttr[0].getGuid()).to.equal(subtree2.a.getGuid());
-            expect(subtree2.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(subtree2.a_a_a.getGuid());
+            expect(subtree2.a_a.script.test.entityArrayAttr[0].guid).to.equal(subtree2.a.guid);
+            expect(subtree2.a_a.script.test.entityArrayAttr[1].guid).to.equal(subtree2.a_a_a.guid);
         });
 
         it('does not attempt to resolve entity script attributes that refer to entities outside of the duplicated subtree', function () {
@@ -493,24 +493,24 @@ describe('Entity', function () {
             subtree1.a_a.addComponent('script');
             subtree1.a_a.script.create('test', {
                 attributes: {
-                    entityAttr: app.root.getGuid(),
-                    entityArrayAttr: [subtree1.a.getGuid(), app.root.getGuid()]
+                    entityAttr: app.root.guid,
+                    entityArrayAttr: [subtree1.a.guid, app.root.guid]
                 }
             });
 
-            expect(subtree1.a_a.script.test.entityAttr.getGuid()).to.equal(app.root.getGuid());
+            expect(subtree1.a_a.script.test.entityAttr.guid).to.equal(app.root.guid);
             expect(subtree1.a_a.script.test.entityArrayAttr).to.be.an('array');
             expect(subtree1.a_a.script.test.entityArrayAttr.length).to.equal(2);
-            expect(subtree1.a_a.script.test.entityArrayAttr[0].getGuid()).to.equal(subtree1.a.getGuid());
-            expect(subtree1.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(app.root.getGuid());
+            expect(subtree1.a_a.script.test.entityArrayAttr[0].guid).to.equal(subtree1.a.guid);
+            expect(subtree1.a_a.script.test.entityArrayAttr[1].guid).to.equal(app.root.guid);
 
             const subtree2 = cloneSubtree(subtree1);
             app.root.addChild(subtree2.a);
-            expect(subtree2.a_a.script.test.entityAttr.getGuid()).to.equal(app.root.getGuid());
+            expect(subtree2.a_a.script.test.entityAttr.guid).to.equal(app.root.guid);
             expect(subtree2.a_a.script.test.entityArrayAttr).to.be.an('array');
             expect(subtree2.a_a.script.test.entityArrayAttr.length).to.equal(2);
-            expect(subtree2.a_a.script.test.entityArrayAttr[0].getGuid()).to.equal(subtree2.a.getGuid());
-            expect(subtree2.a_a.script.test.entityArrayAttr[1].getGuid()).to.equal(app.root.getGuid());
+            expect(subtree2.a_a.script.test.entityArrayAttr[0].guid).to.equal(subtree2.a.guid);
+            expect(subtree2.a_a.script.test.entityArrayAttr[1].guid).to.equal(app.root.guid);
         });
 
         it('ensures that an instance of a subclass keeps its class prototype', function () {
@@ -541,14 +541,14 @@ describe('Entity', function () {
 
         it('returns same entity', function () {
             const e = new Entity();
-            expect(e.findByGuid(e.getGuid())).to.equal(e);
+            expect(e.findByGuid(e.guid)).to.equal(e);
         });
 
         it('returns direct child entity', function () {
             const e = new Entity();
             const c = new Entity();
             e.addChild(c);
-            expect(e.findByGuid(c.getGuid())).to.equal(c);
+            expect(e.findByGuid(c.guid)).to.equal(c);
         });
 
         it('returns child of child entity', function () {
@@ -557,14 +557,14 @@ describe('Entity', function () {
             const c2 = new Entity();
             e.addChild(c);
             c.addChild(c2);
-            expect(e.findByGuid(c2.getGuid())).to.equal(c2);
+            expect(e.findByGuid(c2.guid)).to.equal(c2);
         });
 
         it('does not return parent', function () {
             const e = new Entity();
             const c = new Entity();
             e.addChild(c);
-            expect(c.findByGuid(e.getGuid())).to.equal(null);
+            expect(c.findByGuid(e.guid)).to.equal(null);
         });
 
         it('does not return destroyed entity', function () {
@@ -572,7 +572,7 @@ describe('Entity', function () {
             const c = new Entity();
             e.addChild(c);
             c.destroy();
-            expect(e.findByGuid(c.getGuid())).to.equal(null);
+            expect(e.findByGuid(c.guid)).to.equal(null);
         });
 
         it('does not return entity that was removed from hierarchy', function () {
@@ -580,7 +580,7 @@ describe('Entity', function () {
             const c = new Entity();
             e.addChild(c);
             e.removeChild(c);
-            expect(e.findByGuid(c.getGuid())).to.equal(null);
+            expect(e.findByGuid(c.guid)).to.equal(null);
         });
 
         it('does not return entity that does not exist', function () {


### PR DESCRIPTION
## Summary

- Promotes `Entity#guid` to a public read/write property — the lazy GUID generation and `_entityIndex` bookkeeping now live in the getter/setter directly.
- `Entity#getGuid()` and `Entity#setGuid()` are retained as `@ignore` + `@deprecated` wrappers that emit `Debug.deprecated(...)` and delegate to the property, so existing external callers (notably the editor) keep working.
- Migrates every in-engine caller (14 src files, 12 test/asset files) off the deprecated methods so the engine doesn't trigger its own deprecation warnings.

## Why

Follow-up to #8795 and #7394. Per review on the previous follow-up:
- @willeastcott suggested making `getGuid/setGuid` deprecated wrappers that call the new property accessors.
- Exposing the setter publicly is debatable, but keeping `setGuid` working (via `@ignore` + deprecation) doesn't add public API surface and avoids breaking the editor, which calls it in many places.

## Test plan

- [x] Full test suite passes (`npm test` — 1720 passing).
- [x] Lint clean across all modified files.
- [ ] Confirm `Entity#guid` appears in the generated API reference and `getGuid`/`setGuid` do not.
- [ ] Confirm calling `getGuid()`/`setGuid()` from user code logs a single deprecation warning and still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)