### PR TITLE
WebGPU: add ImageBitmap upload fallback via writeTexture

### DIFF
--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -45,11 +45,6 @@ import { NullGraphicsDevice } from './null/null-graphics-device.js';
  * - 'low-power': Prioritizes power saving over rendering performance.
  *
  * Defaults to 'default'.
- * @param {boolean} [options.forceImageBitmapWriteTexture] - WebGPU only. When true, uploads from
- * `ImageBitmap` sources are routed through `GPUQueue.writeTexture` via a 2D-canvas readback
- * instead of `GPUQueue.copyExternalImageToTexture`. Works around environments where Chrome's
- * renderer→GPU SharedImage transport fails for external image copies — notably headless Chrome
- * on Linux. Slower than the native path. Defaults to false.
  * @returns {Promise} - Promise object representing the created graphics device.
  * @category Graphics
  */

--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -45,6 +45,11 @@ import { NullGraphicsDevice } from './null/null-graphics-device.js';
  * - 'low-power': Prioritizes power saving over rendering performance.
  *
  * Defaults to 'default'.
+ * @param {boolean} [options.forceImageBitmapWriteTexture] - WebGPU only. When true, uploads from
+ * `ImageBitmap` sources are routed through `GPUQueue.writeTexture` via a 2D-canvas readback
+ * instead of `GPUQueue.copyExternalImageToTexture`. Works around environments where Chrome's
+ * renderer→GPU SharedImage transport fails for external image copies — notably headless Chrome
+ * on Linux. Slower than the native path. Defaults to false.
  * @returns {Promise} - Promise object representing the created graphics device.
  * @category Graphics
  */

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -251,7 +251,10 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.isWebGPU = true;
         this._deviceType = DEVICETYPE_WEBGPU;
         this.featureLevel = options.featureLevel;
-        this.forceImageBitmapWriteTexture = options.forceImageBitmapWriteTexture ?? false;
+
+        // Sticky flag set the first time GPUQueue.copyExternalImageToTexture
+        // throws for an ImageBitmap source — see WebgpuTexture.uploadExternalImage.
+        this._imageBitmapUploadFallback = false;
 
         this.scope.resolve(UNUSED_UNIFORM_NAME).setValue(0);
     }

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -251,6 +251,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.isWebGPU = true;
         this._deviceType = DEVICETYPE_WEBGPU;
         this.featureLevel = options.featureLevel;
+        this.forceImageBitmapWriteTexture = options.forceImageBitmapWriteTexture ?? false;
 
         this.scope.resolve(UNUSED_UNIFORM_NAME).setValue(0);
     }

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -486,25 +486,17 @@ class WebgpuTexture {
 
         Debug.assert(mipLevel < this.desc.mipLevelCount, `Accessing mip level ${mipLevel} of texture with ${this.desc.mipLevelCount} mip levels`, this);
 
-        // Some environments (notably headless Chrome on Linux) fail the
-        // renderer→GPU SharedImage transport behind copyExternalImageToTexture
-        // for ImageBitmap sources. When the device opts in, route ImageBitmap
-        // uploads through writeTexture via a 2D-canvas readback. Only safe for
-        // 4-byte-per-pixel formats (RGBA8/SRGBA8), which is what the engine's
-        // image parsers produce; fall through for any other format.
-        if (device.forceImageBitmapWriteTexture &&
-            typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap) {
-            const formatInfo = pixelFormatInfo.get(this.texture.format);
-            if (formatInfo?.size === 4) {
-                const w = image.width;
-                const h = image.height;
-                const off = new OffscreenCanvas(w, h);
-                const ctx = off.getContext('2d');
-                ctx.drawImage(image, 0, 0);
-                const pixels = ctx.getImageData(0, 0, w, h).data;
-                this.uploadTypedArrayData(device, new Uint8Array(pixels.buffer), mipLevel, index);
-                return;
-            }
+        const isImageBitmap = typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap;
+        // ImageData is always 4 bytes/pixel; the writeTexture fallback below is
+        // only safe when the destination format matches that layout.
+        const fallbackAvailable = isImageBitmap && pixelFormatInfo.get(this.texture.format)?.size === 4;
+
+        // If a previous upload on this device already tripped the broken-environment
+        // path (see catch below), keep all subsequent ImageBitmap uploads on the
+        // writeTexture path instead of throwing every time.
+        if (fallbackAvailable && device._imageBitmapUploadFallback) {
+            this._uploadImageBitmapAsTypedArray(device, image, mipLevel, index);
+            return;
         }
 
         const src = {
@@ -534,7 +526,32 @@ class WebgpuTexture {
         dummyUse(image instanceof HTMLCanvasElement && image.getContext('2d'));
 
         Debug.trace(TRACEID_RENDER_QUEUE, `IMAGE-TO-TEX: mip:${mipLevel} index:${index} ${this.texture.name}`);
-        device.wgpu.queue.copyExternalImageToTexture(src, dst, copySize);
+
+        try {
+            device.wgpu.queue.copyExternalImageToTexture(src, dst, copySize);
+        } catch (err) {
+            // Some environments (notably headless Chrome on Linux) throw here
+            // because the renderer→GPU SharedImage transport for ImageBitmap
+            // sources is broken. Set a sticky device flag so future ImageBitmap
+            // uploads skip the failing call, and retry this one via writeTexture.
+            if (fallbackAvailable) {
+                Debug.warnOnce(`WebGPU: copyExternalImageToTexture failed (${err.message}); falling back to writeTexture for ImageBitmap uploads on this device.`);
+                device._imageBitmapUploadFallback = true;
+                this._uploadImageBitmapAsTypedArray(device, image, mipLevel, index);
+                return;
+            }
+            throw err;
+        }
+    }
+
+    _uploadImageBitmapAsTypedArray(device, image, mipLevel, index) {
+        const w = image.width;
+        const h = image.height;
+        const off = new OffscreenCanvas(w, h);
+        const ctx = off.getContext('2d');
+        ctx.drawImage(image, 0, 0);
+        const pixels = ctx.getImageData(0, 0, w, h).data;
+        this.uploadTypedArrayData(device, new Uint8Array(pixels.buffer), mipLevel, index);
     }
 
     uploadTypedArrayData(device, data, mipLevel, index) {

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -4,6 +4,7 @@ import { math } from '../../../core/math/math.js';
 import {
     pixelFormatInfo, isCompressedPixelFormat, getPixelFormatArrayType,
     ADDRESS_REPEAT, ADDRESS_CLAMP_TO_EDGE, ADDRESS_MIRRORED_REPEAT,
+    PIXELFORMAT_RGBA8, PIXELFORMAT_SRGBA8,
     PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F, PIXELFORMAT_DEPTHSTENCIL,
     SAMPLETYPE_UNFILTERABLE_FLOAT, SAMPLETYPE_DEPTH,
     FILTER_NEAREST, FILTER_LINEAR, FILTER_NEAREST_MIPMAP_NEAREST, FILTER_NEAREST_MIPMAP_LINEAR,
@@ -487,9 +488,11 @@ class WebgpuTexture {
         Debug.assert(mipLevel < this.desc.mipLevelCount, `Accessing mip level ${mipLevel} of texture with ${this.desc.mipLevelCount} mip levels`, this);
 
         const isImageBitmap = typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap;
-        // ImageData is always 4 bytes/pixel; the writeTexture fallback below is
-        // only safe when the destination format matches that layout.
-        const fallbackAvailable = isImageBitmap && pixelFormatInfo.get(this.texture.format)?.size === 4;
+        // ImageData from a 2D canvas is RGBA8 byte order, so the writeTexture
+        // fallback below is only correct for matching destination formats. The
+        // engine's image parsers produce exactly these two formats.
+        const fmt = this.texture.format;
+        const fallbackAvailable = isImageBitmap && (fmt === PIXELFORMAT_RGBA8 || fmt === PIXELFORMAT_SRGBA8);
 
         // If a previous upload on this device already tripped the broken-environment
         // path (see catch below), keep all subsequent ImageBitmap uploads on the
@@ -551,6 +554,18 @@ class WebgpuTexture {
         const ctx = off.getContext('2d');
         ctx.drawImage(image, 0, 0);
         const pixels = ctx.getImageData(0, 0, w, h).data;
+        // getImageData returns straight (non-premultiplied) RGBA; the native
+        // copyExternalImageToTexture path premultiplies when the destination
+        // texture asks for it. Match that behaviour here so alpha-blended
+        // content renders identically whether the fallback engaged or not.
+        if (this.texture._premultiplyAlpha) {
+            for (let i = 0; i < pixels.length; i += 4) {
+                const a = pixels[i + 3];
+                pixels[i] = (pixels[i] * a + 127) / 255 | 0;
+                pixels[i + 1] = (pixels[i + 1] * a + 127) / 255 | 0;
+                pixels[i + 2] = (pixels[i + 2] * a + 127) / 255 | 0;
+            }
+        }
         this.uploadTypedArrayData(device, new Uint8Array(pixels.buffer), mipLevel, index);
     }
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -486,6 +486,27 @@ class WebgpuTexture {
 
         Debug.assert(mipLevel < this.desc.mipLevelCount, `Accessing mip level ${mipLevel} of texture with ${this.desc.mipLevelCount} mip levels`, this);
 
+        // Some environments (notably headless Chrome on Linux) fail the
+        // renderer→GPU SharedImage transport behind copyExternalImageToTexture
+        // for ImageBitmap sources. When the device opts in, route ImageBitmap
+        // uploads through writeTexture via a 2D-canvas readback. Only safe for
+        // 4-byte-per-pixel formats (RGBA8/SRGBA8), which is what the engine's
+        // image parsers produce; fall through for any other format.
+        if (device.forceImageBitmapWriteTexture &&
+            typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap) {
+            const formatInfo = pixelFormatInfo.get(this.texture.format);
+            if (formatInfo?.size === 4) {
+                const w = image.width;
+                const h = image.height;
+                const off = new OffscreenCanvas(w, h);
+                const ctx = off.getContext('2d');
+                ctx.drawImage(image, 0, 0);
+                const pixels = ctx.getImageData(0, 0, w, h).data;
+                this.uploadTypedArrayData(device, new Uint8Array(pixels.buffer), mipLevel, index);
+                return;
+            }
+        }
+
         const src = {
             source: image,
             origin: [0, 0],


### PR DESCRIPTION
## Summary

In headless Chrome on Linux, `GPUQueue.copyExternalImageToTexture` throws synchronously for every `ImageBitmap` source upload, blocking any WebGPU app that loads image-backed textures (e.g. SOG `.webp` channels). This PR catches that throw in `WebgpuTexture.uploadExternalImage`, sets a sticky device-level flag, and routes the same upload — and all subsequent `ImageBitmap` uploads on that device — through `GPUQueue.writeTexture` via a 2D-canvas readback.

Fully automatic: no public API, no opt-in flag, no caller changes. Healthy environments pay nothing (one extra `try` around the existing call); broken environments self-heal after the first failed upload.

## Why

The bug: in headless Chrome on Linux, the renderer→GPU SharedImage transport behind `copyExternalImageToTexture` is broken for `ImageBitmap` sources. The rest of the engine — shader compilation, render passes, `writeTexture` for typed-array data — works correctly on the same setup, which isolates the bug to the `copyExternalImageToTexture` path. WebGL2 also works on the same hardware. This blocks headless WebGPU for thumbnail generation, server-side rendering, automated visual regression, etc.

## What

- `WebgpuGraphicsDevice` gets an internal `_imageBitmapUploadFallback` flag, initialised to `false`.
- `WebgpuTexture.uploadExternalImage` wraps the `copyExternalImageToTexture` call in a `try`. On `catch`, if the source is an `ImageBitmap` and the destination format is `PIXELFORMAT_RGBA8` or `PIXELFORMAT_SRGBA8` (the only formats the engine's image parsers produce), it logs a `Debug.warnOnce`, sets the device flag, and retries the upload via the new `_uploadImageBitmapAsTypedArray` helper. Every subsequent `ImageBitmap` upload on the same device skips the failing call and takes the fallback path directly.
- The helper does `OffscreenCanvas.drawImage` → `getImageData` → optional premultiplication (matching what `dst.premultipliedAlpha` would have done on the native path when `texture._premultiplyAlpha === true`) → `uploadTypedArrayData` → `writeTexture`.

## What this is not

- Not a public API change — no new option on `createGraphicsDevice`. The PR description in earlier revisions documented an opt-in flag; the design moved to auto-fallback during review and this description is up to date.
- Not autodetection at init — no synthetic probe. The first real `ImageBitmap` upload in the broken environment trips the catch and from then on the fallback applies to all subsequent uploads on that device. Healthy environments never enter the catch.
- Not an upstream Chromium fix — the underlying bug lives in Dawn / Chrome's SharedImage transport.

## Behaviour delta

| Environment | Before | After |
| --- | --- | --- |
| Healthy (browser, normal headless) | Native `copyExternalImageToTexture` | Identical — `try` around an already-non-throwing call |
| Broken (headless Chrome on Linux) | `TypeError` per upload, scene unrendered | One `TypeError` caught + `Debug.warnOnce`, then `writeTexture` for all `ImageBitmap` uploads on that device |
| Other broken env where `_premultiplyAlpha === true` | Wrong / no texture | Correct pixels (JS premultiply matches native behaviour) |

Format gating is by explicit `PIXELFORMAT_RGBA8` / `PIXELFORMAT_SRGBA8` comparison rather than `pixelFormatInfo.get(format).size === 4`, so we don't silently corrupt a `BGRA8` / `RGB10A2` / `R32F` / depth / integer texture if anyone ever feeds an `ImageBitmap` into one of those.

## Testing

The engine repo currently has no WebGPU test infrastructure — existing tests use `NullGraphicsDevice` and pure-logic units, and there is no fixture covering `WebgpuGraphicsDevice` or `WebgpuTexture` uploads. A meaningful unit test would mean standing up mock `GPUQueue` / `OffscreenCanvas` / `CanvasRenderingContext2D` machinery just for this fix — much larger scope than the change itself. Skipping it intentionally; happy to add scaffolding in a follow-up if maintainers prefer.

### Manual verification

The fallback path was exercised end-to-end via a `puppeteer` monkey-patch that intercepts `GPUQueue.prototype.copyExternalImageToTexture` and routes `ImageBitmap` sources through `writeTexture` — the same sequence the engine fix takes. With that in place, a SuperSplat thumbnail job running real WebGPU in headless Chrome on Linux (NVIDIA A10G, Vulkan 1.4.312, Chrome 143) loads all SOG `.webp` channels, renders the scene, and produces correct thumbnails. Without it, every upload throws and the scene is blank.

## Test plan

- [ ] Existing engine test suite passes
- [ ] In headless Chrome on Linux: WebGPU app with image-backed textures loads and renders (one `Debug.warnOnce` expected in console)
- [ ] In a normal browser: no behaviour change, no warning, no perf delta