### PR TITLE
fix(examples): hide description overlay in fullscreen mode

### DIFF
--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -1524,7 +1524,8 @@ body.mobile-panel-resizing #appInner.mobile-landscape #sideBar.mobile-sheet::aft
 #appInner.fullscreen #desktopPanelStack,
 #appInner.fullscreen #sideBar,
 #appInner.fullscreen #exampleCredits,
-#appInner.fullscreen #showCreditsButton {
+#appInner.fullscreen #showCreditsButton,
+#appInner.fullscreen #exampleDescription {
     display: none;
 }
 


### PR DESCRIPTION
Hide the example description overlay when the fullscreen button is toggled in the examples browser, matching the behavior of the other panels (side bar, control panel, credits, etc.).

**Changes:**
- Add `#exampleDescription` to the list of elements hidden by the `#appInner.fullscreen` CSS rule in `examples/src/static/styles.css`.