### PR TITLE
[BREAKING] Deprecate GSplatComponent#unified and default it to true

### DIFF
--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -20,6 +20,10 @@ import { PickerId } from '../../../scene/picker-id.js';
  * @import { Texture } from '../../../platform/graphics/texture.js'
  */
 
+// Appended to warnings fired when a legacy (non-unified) API is hit in unified mode.
+// Explains the default flip and the temporary workaround.
+const UNIFIED_LEGACY_HINT = 'GSplatComponent#unified now defaults to true (unified rendering). To temporarily restore the deprecated legacy behavior, explicitly set unified=false when creating the component — note that non-unified mode will be removed in a future release.';
+
 /**
  * The GSplatComponent enables an {@link Entity} to render 3D Gaussian Splats. Splats are always
  * loaded from {@link Asset}s rather than being created programmatically. The asset type is
@@ -167,11 +171,11 @@ class GSplatComponent extends Component {
     _castShadows = false;
 
     /**
-     * Whether to use the unified gsplat rendering.
+     * Whether to use the unified gsplat rendering. Defaults to true.
      *
      * @private
      */
-    _unified = false;
+    _unified = true;
 
     /**
      * Per-instance shader parameters. Stores objects with scopeId and data.
@@ -263,7 +267,7 @@ class GSplatComponent extends Component {
     set instance(value) {
 
         if (this.unified) {
-            Debug.errorOnce('GSplatComponent#instance setter is not supported when unified is true.');
+            Debug.errorOnce(`GSplatComponent#instance setter is only available in legacy non-unified mode. ${UNIFIED_LEGACY_HINT}`);
             return;
         }
 
@@ -295,21 +299,24 @@ class GSplatComponent extends Component {
      * @ignore
      */
     get instance() {
+        if (this.unified) {
+            Debug.warnOnce(`GSplatComponent#instance getter returns null in unified mode. ${UNIFIED_LEGACY_HINT}`);
+        }
         return this._instance;
     }
 
     /**
      * Sets the material used to render the gsplat.
      *
-     * **Note:** This setter is only supported when {@link unified} is `false`. When it's true, multiple
-     * gsplat components share a single material per camera/layer combination. To access materials in
-     * unified mode, use {@link GSplatComponentSystem#getMaterial}.
+     * **Note:** This setter is only available in legacy (deprecated) non-unified mode. In unified
+     * mode, multiple gsplat components share a single material per camera/layer combination — use
+     * {@link GSplatComponentSystem#getMaterial} instead.
      *
      * @param {ShaderMaterial} value - The material instance.
      */
     set material(value) {
         if (this.unified) {
-            Debug.warn('GSplatComponent#material setter is not supported when unified true. Use app.systems.gsplat.getMaterial(camera, layer) to access materials.');
+            Debug.warn(`GSplatComponent#material setter is only available in legacy non-unified mode; in unified mode use app.systems.gsplat.getMaterial(camera, layer). ${UNIFIED_LEGACY_HINT}`);
             return;
         }
         if (this._instance) {
@@ -322,15 +329,16 @@ class GSplatComponent extends Component {
     /**
      * Gets the material used to render the gsplat.
      *
-     * **Note:** This getter returns `null` when {@link unified} is `true`. In unified mode, materials are
-     * organized per camera/layer combination rather than per component. To access materials in
-     * unified mode, use {@link GSplatComponentSystem#getMaterial}.
+     * **Note:** This getter returns `null` in unified mode (the default). In unified mode, materials
+     * are organized per camera/layer combination rather than per component — use
+     * {@link GSplatComponentSystem#getMaterial} instead. Per-component materials are only available
+     * in legacy (deprecated) non-unified mode.
      *
      * @type {ShaderMaterial|null}
      */
     get material() {
         if (this.unified) {
-            Debug.warnOnce('GSplatComponent#material getter returns null when unified=true. Use app.systems.gsplat.getMaterial(camera, layer) instead.');
+            Debug.warnOnce(`GSplatComponent#material getter returns null in unified mode; use app.systems.gsplat.getMaterial(camera, layer) instead. ${UNIFIED_LEGACY_HINT}`);
             return null;
         }
         return this._instance?.material ?? this._materialTmp ?? null;
@@ -522,15 +530,16 @@ class GSplatComponent extends Component {
     }
 
     /**
-     * Sets whether to use the unified gsplat rendering. Default is false.
-     *
-     * Note: Material handling differs between modes. When unified is false, use {@link material}.
-     * When unified is true, materials are shared per camera/layer - use
-     * {@link GSplatComponentSystem#getMaterial} instead.
+     * Sets whether to use the unified gsplat rendering.
      *
      * @type {boolean}
+     * @deprecated Non-unified gsplat rendering is being removed; unified rendering will be the only supported mode.
+     * @ignore
      */
     set unified(value) {
+        if (value === false) {
+            Debug.deprecated('GSplatComponent#unified is deprecated. Non-unified gsplat rendering will be removed in a future release; please migrate to unified rendering (the new default).');
+        }
         if (this._unified !== value) {
             this._unified = value;
             this._onGSplatAssetAdded();
@@ -541,7 +550,8 @@ class GSplatComponent extends Component {
      * Gets whether to use the unified gsplat rendering.
      *
      * @type {boolean}
-     * @alpha
+     * @deprecated Non-unified gsplat rendering is being removed; unified rendering will be the only supported mode.
+     * @ignore
      */
     get unified() {
         return this._unified;
@@ -835,7 +845,7 @@ class GSplatComponent extends Component {
         const index = this.layers.indexOf(layer.id);
         if (index < 0) return;
         if (this.unified) {
-            Debug.errorOnce('GSplatComponent#onLayerAdded is not supported when unified is true.');
+            Debug.errorOnce(`GSplatComponent#onLayerAdded is only used in legacy non-unified mode. ${UNIFIED_LEGACY_HINT}`);
             return;
         }
 
@@ -848,7 +858,7 @@ class GSplatComponent extends Component {
         const index = this.layers.indexOf(layer.id);
         if (index < 0) return;
         if (this.unified) {
-            Debug.errorOnce('GSplatComponent#onLayerRemoved is not supported when unified is true.');
+            Debug.errorOnce(`GSplatComponent#onLayerRemoved is only used in legacy non-unified mode. ${UNIFIED_LEGACY_HINT}`);
             return;
         }
 


### PR DESCRIPTION
Marks `GSplatComponent#unified` as deprecated and flips its default from `false` to `true`, making unified gsplat rendering the default mode. Non-unified ("legacy") rendering will be removed in a future release.

**Changes:**
- `_unified` field now initializes to `true` so new gsplat components use unified rendering by default.
- `unified` getter and setter are marked `@deprecated` + `@ignore` (hidden from generated docs).
- Setting `unified = false` now logs a one-time `Debug.deprecated` message recommending migration to unified rendering.
- Reworded all legacy-mode warnings on `GSplatComponent` (`instance` get/set, `material` get/set, `onLayerAdded`, `onLayerRemoved`) to clarify those APIs are only available in legacy non-unified mode. A shared `UNIFIED_LEGACY_HINT` string is appended to each warning so users understand the default flip and how to opt back into legacy mode temporarily.
- Added a `Debug.warnOnce` to the previously silent `get instance` so users hit a clear message when reading `gsplat.instance` from a unified component (returns `null` in that case).
- Updated JSDoc on `material` get/set to match the new framing ("legacy non-unified mode" instead of "when unified is false").

**API Changes:**
- `GSplatComponent#unified` (get/set) is now `@deprecated` and hidden from public docs.
- Default value of `GSplatComponent#unified` changed from `false` to `true`. Existing code that implicitly relied on the old default and uses legacy-only APIs (e.g. `gsplat.instance`, the `material` setter) will now hit warnings; the suggested temporary workaround is to explicitly set `unified: false` when adding the component.

**Examples:**
- No example changes in this PR. The existing legacy gsplat picking example serves as a manual smoke test for the deprecation path and will be updated separately.