### PR TITLE
fix(gsplat): unified-mode follow-ups (orbit-camera AABB, internal warnings)

### DIFF
--- a/examples/src/examples/gaussian-splatting/global-sorting.example.mjs
+++ b/examples/src/examples/gaussian-splatting/global-sorting.example.mjs
@@ -119,7 +119,6 @@ assetListLoader.load(() => {
     camera.script.create('orbitCamera', {
         attributes: {
             inertiaFactor: 0.2,
-            focusEntity: guitar,
             distanceMax: 3.2,
             frameOnStart: false
         }
@@ -127,4 +126,9 @@ assetListLoader.load(() => {
     camera.script.create('orbitCameraInputMouse');
     camera.script.create('orbitCameraInputTouch');
     app.root.addChild(camera);
+
+    // orbit around the statue's world-space centre
+    const orbitPivot = new pc.Vec3();
+    hotel.getWorldTransform().transformPoint(new pc.Vec3(0, 0.2, 0), orbitPivot);
+    camera.script.orbitCamera.resetAndLookAtPoint(new pc.Vec3(3, 1, 0.5), orbitPivot);
 });

--- a/scripts/camera/orbit-camera.js
+++ b/scripts/camera/orbit-camera.js
@@ -310,20 +310,46 @@ OrbitCamera.prototype._buildAabb = function (entity) {
         }
     }
 
+    // additional world-space AABBs collected from gsplats (unified mode has no per-component
+    // mesh instance, so we transform the gsplat's object-space AABB into world space here)
+    var extraAabbs = [];
+
     var gsplats = entity.findComponents('gsplat');
     for (i = 0; i < gsplats.length; i++) {
         var gsplat = gsplats[i];
-        var instance = gsplat.instance;
-        if (instance?.meshInstance) {
-            meshInstances.push(instance.meshInstance);
+        if (gsplat.unified) {
+            // unified gsplat: customAabb returns object-space (custom AABB, placement AABB, or
+            // resource AABB) - transform it to world space using the entity's world transform
+            var localAabb = gsplat.customAabb;
+            if (localAabb) {
+                var worldAabb = new pc.BoundingBox();
+                worldAabb.setFromTransformedAabb(localAabb, gsplat.entity.getWorldTransform());
+                extraAabbs.push(worldAabb);
+            }
+        } else {
+            // legacy gsplat: mesh instance already exposes a world-space AABB
+            var instance = gsplat.instance;
+            if (instance?.meshInstance) {
+                meshInstances.push(instance.meshInstance);
+            }
         }
     }
 
+    var first = true;
     for (i = 0; i < meshInstances.length; i++) {
-        if (i === 0) {
+        if (first) {
             this._modelsAabb.copy(meshInstances[i].aabb);
+            first = false;
         } else {
             this._modelsAabb.add(meshInstances[i].aabb);
+        }
+    }
+    for (i = 0; i < extraAabbs.length; i++) {
+        if (first) {
+            this._modelsAabb.copy(extraAabbs[i]);
+            first = false;
+        } else {
+            this._modelsAabb.add(extraAabbs[i]);
         }
     }
 };

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -403,7 +403,7 @@ class GSplatComponent extends Component {
             }
 
             // Handle non-unified mode mesh instance
-            const mi = this.instance?.meshInstance;
+            const mi = this._instance?.meshInstance;
 
             if (mi) {
                 if (this._castShadows && !value) {
@@ -777,7 +777,7 @@ class GSplatComponent extends Component {
             return;
         }
 
-        const meshInstance = this.instance?.meshInstance;
+        const meshInstance = this._instance?.meshInstance;
         if (meshInstance) {
             const layers = this.system.app.scene.layers;
             for (let i = 0; i < this._layers.length; i++) {
@@ -800,7 +800,7 @@ class GSplatComponent extends Component {
             return;
         }
 
-        const meshInstance = this.instance?.meshInstance;
+        const meshInstance = this._instance?.meshInstance;
         if (meshInstance) {
             const layers = this.system.app.scene.layers;
             for (let i = 0; i < this._layers.length; i++) {
@@ -844,10 +844,8 @@ class GSplatComponent extends Component {
     onLayerAdded(layer) {
         const index = this.layers.indexOf(layer.id);
         if (index < 0) return;
-        if (this.unified) {
-            Debug.errorOnce(`GSplatComponent#onLayerAdded is only used in legacy non-unified mode. ${UNIFIED_LEGACY_HINT}`);
-            return;
-        }
+        // unified mode manages layer membership via GSplatPlacement; no legacy mesh-instance work
+        if (this.unified) return;
 
         if (this._instance) {
             layer.addMeshInstances(this._instance.meshInstance);
@@ -857,10 +855,8 @@ class GSplatComponent extends Component {
     onLayerRemoved(layer) {
         const index = this.layers.indexOf(layer.id);
         if (index < 0) return;
-        if (this.unified) {
-            Debug.errorOnce(`GSplatComponent#onLayerRemoved is only used in legacy non-unified mode. ${UNIFIED_LEGACY_HINT}`);
-            return;
-        }
+        // unified mode manages layer membership via GSplatPlacement; no legacy mesh-instance work
+        if (this.unified) return;
 
         if (this._instance) {
             layer.removeMeshInstances(this._instance.meshInstance);


### PR DESCRIPTION
Follow-up cleanups to #8802 (flip of `GSplatComponent#unified` default to `true`). Addresses spurious deprecation warnings raised by engine-internal code, and updates the bundled orbit-camera script to be unified-aware.

**Changes:**
- `GSplatComponent`: route internal mesh-instance probes through the private `_instance` field instead of the deprecated public `instance` getter (avoids spurious warnings from `set castShadows`, `addToLayers`, `removeFromLayers`).
- `GSplatComponent`: silence the spurious `Debug.errorOnce` in `onLayerAdded` / `onLayerRemoved`. These are engine-driven event handlers (subscribed to the layer composition's `add` / `remove` events) — not user-facing APIs — so they now silently no-op in unified mode. The portal example was triggering them on every portal crossing via `reorderLayersForSwap`.
- `scripts/camera/orbit-camera.js`: `_buildAabb` now collects AABBs for unified gsplats via `gsplat.customAabb` transformed by the entity's world matrix (`BoundingBox.setFromTransformedAabb`), so unified gsplats contribute to the orbit camera's focus AABB instead of being silently skipped.
- `examples/.../global-sorting.example.mjs`: now that the orbit camera correctly builds an AABB for unified gsplats, the prior framing (which incidentally relied on an empty AABB at origin) needed an explicit pivot — switched to `resetAndLookAtPoint` targeting the statue's world-space centre.

**API Changes:**
- None — all changes are internal or in user-facing example/script behaviour. No public API surface was added or removed.

**Examples:**
- Updated `gaussian-splatting/global-sorting.example.mjs` to pivot the orbit camera on the statue (matches the visual intent of the scene now that the orbit camera honours unified gsplat bounds).