### PR TITLE
fix(examples): set unified=false in gsplat-legacy picking example

### DIFF
--- a/examples/src/examples/gaussian-splatting-legacy/picking.example.mjs
+++ b/examples/src/examples/gaussian-splatting-legacy/picking.example.mjs
@@ -77,7 +77,8 @@ assetListLoader.load(() => {
         const splat = new pc.Entity(`splat-${i}`);
         splat.addComponent('gsplat', {
             asset: assets.logo,
-            castShadows: false
+            castShadows: false,
+            unified: false
         });
 
         app.root.addChild(splat);


### PR DESCRIPTION
The legacy gsplat picking example documents itself as "using legacy (non-unified) mode" but its `addComponent('gsplat', { ... })` calls never specified `unified: false`. After #8802 flipped the default to `true`, the example was silently created in unified mode and then crashed in its click handler at `gsplat.instance.meshInstance` (instance is `null` in unified mode).

**Changes:**
- Pass `unified: false` to the gsplat `addComponent` call in the legacy picking example. Restores legacy mode as the example's header documents.

**Examples:**
- `examples/.../gaussian-splatting-legacy/picking.example.mjs`: now prints exactly one `DEPRECATED: GSplatComponent#unified is deprecated. ...` line on startup (the intended migration signal from #8802) and picking works again.