### PR TITLE
docs(gsplat): drop "unified" framing now that it's the default

### DIFF
--- a/examples/src/examples/gaussian-splatting/annotations.example.mjs
+++ b/examples/src/examples/gaussian-splatting/annotations.example.mjs
@@ -104,8 +104,7 @@ assetListLoader.load(() => {
     // Create the bicycle gsplat
     const bicycle = new pc.Entity('Bicycle');
     bicycle.addComponent('gsplat', {
-        asset: assets.bicycle,
-        unified: true
+        asset: assets.bicycle
     });
     bicycle.setLocalEulerAngles(0, 0, 180);
     app.root.addChild(bicycle);

--- a/examples/src/examples/gaussian-splatting/benchmark.example.mjs
+++ b/examples/src/examples/gaussian-splatting/benchmark.example.mjs
@@ -760,21 +760,21 @@ async function runBenchmark(config, colIndex, budgetIndices) {
     });
 
     const bicycle = new pc.Entity('bicycle');
-    bicycle.addComponent('gsplat', { asset: bicycleAsset, unified: true });
+    bicycle.addComponent('gsplat', { asset: bicycleAsset });
     bicycle.setLocalPosition(11.2, 0, -3.5);
     bicycle.setLocalEulerAngles(0, 90, 180);
     bicycle.setLocalScale(2, 2, 2);
     app.root.addChild(bicycle);
 
     const logo = new pc.Entity('logo');
-    logo.addComponent('gsplat', { asset: logoAsset, unified: true });
+    logo.addComponent('gsplat', { asset: logoAsset });
     logo.setLocalPosition(8, 0, 2.6);
     logo.setLocalEulerAngles(180, 0, 0);
     logo.setLocalScale(2, 2, 2);
     app.root.addChild(logo);
 
     const church = new pc.Entity('church');
-    church.addComponent('gsplat', { asset: churchAsset, unified: true });
+    church.addComponent('gsplat', { asset: churchAsset });
     church.setLocalEulerAngles(-90, 0, 0);
     app.root.addChild(church);
 

--- a/examples/src/examples/gaussian-splatting/crop.example.mjs
+++ b/examples/src/examples/gaussian-splatting/crop.example.mjs
@@ -76,11 +76,10 @@ assetListLoader.load(() => {
         paused = !paused;
     });
 
-    // Create hotel gsplat with unified set to true
+    // Create hotel gsplat
     const hotel = new pc.Entity('hotel');
     hotel.addComponent('gsplat', {
-        asset: assets.hotel,
-        unified: true
+        asset: assets.hotel
     });
     hotel.setLocalEulerAngles(180, 0, 0);
     app.root.addChild(hotel);

--- a/examples/src/examples/gaussian-splatting/editor.example.mjs
+++ b/examples/src/examples/gaussian-splatting/editor.example.mjs
@@ -231,7 +231,7 @@ assetListLoader.load(() => {
     // Creates an editable gsplat entity with splatVisible and splatSelection streams
     const createEditableSplat = (name, asset, position, rotation, scale) => {
         const entity = new pc.Entity(name);
-        const gsplatComponent = entity.addComponent('gsplat', { asset, unified: true });
+        const gsplatComponent = entity.addComponent('gsplat', { asset });
         entity.setLocalPosition(...position);
         entity.setLocalEulerAngles(...rotation);
         entity.setLocalScale(...scale);
@@ -354,8 +354,7 @@ assetListLoader.load(() => {
         const name = `clone${cloneCounter}`;
         const entity = new pc.Entity(name);
         const gsplatComponent = entity.addComponent('gsplat', {
-            resource: container,
-            unified: true
+            resource: container
         });
         entity.setLocalPosition(aabbCenter.x + 0.1, aabbCenter.y, aabbCenter.z + 0.1);
         app.root.addChild(entity);

--- a/examples/src/examples/gaussian-splatting/first-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/first-person.example.mjs
@@ -141,8 +141,7 @@ app.root.addChild(sceneRoot);
 // Gaussian splat (visual)
 const splat = new pc.Entity('sunnyvale-gsplat');
 splat.addComponent('gsplat', {
-    asset: assets.splat,
-    unified: true
+    asset: assets.splat
 });
 sceneRoot.addChild(splat);
 

--- a/examples/src/examples/gaussian-splatting/flipbook.example.mjs
+++ b/examples/src/examples/gaussian-splatting/flipbook.example.mjs
@@ -124,8 +124,7 @@ assetListLoader.load(() => {
     // Create player flipbook
     const player = new pc.Entity('Player');
     player.addComponent('gsplat', {
-        castShadows: true,
-        unified: true
+        castShadows: true
     });
     player.addComponent('script');
     const flipbook = player.script.create(GsplatFlipbook);

--- a/examples/src/examples/gaussian-splatting/global-sorting.example.mjs
+++ b/examples/src/examples/gaussian-splatting/global-sorting.example.mjs
@@ -1,7 +1,7 @@
 // @config
 //
-// This example demonstrates unified gsplat rendering, where all individual gaussian splats are
-// consistently sorted in a global order, rather than rendering splat meshes based on camera distance.
+// This example demonstrates global gsplat sorting, where individual gaussian splats across
+// multiple components are consistently sorted in a single order, rather than per component.
 
 import * as pc from 'playcanvas';
 
@@ -72,8 +72,7 @@ assetListLoader.load(() => {
     // instantiate garage gsplat
     const hotel = new pc.Entity('garage');
     hotel.addComponent('gsplat', {
-        asset: assets.hotel,
-        unified: true
+        asset: assets.hotel
     });
     hotel.setLocalEulerAngles(180, 0, 0);
     app.root.addChild(hotel);
@@ -81,8 +80,7 @@ assetListLoader.load(() => {
     // create biker1
     const biker1 = new pc.Entity('biker1');
     biker1.addComponent('gsplat', {
-        asset: assets.biker,
-        unified: true
+        asset: assets.biker
     });
     biker1.setLocalPosition(0, -1.8, -2);
     biker1.setLocalEulerAngles(180, 90, 0);
@@ -97,8 +95,7 @@ assetListLoader.load(() => {
     // create guitar
     const guitar = new pc.Entity('guitar');
     guitar.addComponent('gsplat', {
-        asset: assets.guitar,
-        unified: true
+        asset: assets.guitar
     });
     guitar.setLocalPosition(2, -1.8, -0.5);
     guitar.setLocalEulerAngles(0, 0, 180);

--- a/examples/src/examples/gaussian-splatting/lod-instances.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-instances.example.mjs
@@ -233,14 +233,13 @@ assetListLoader.load(() => {
     // create grid of instances centered around origin on XZ plane
     const half = (GRID_SIZE - 1) * 0.5;
 
-    // Create a grid of playbot instances using unified gsplat component
+    // Create a grid of playbot instances
     let componentIndex = 0;
     for (let z = 0; z < GRID_SIZE; z++) {
         for (let x = 0; x < GRID_SIZE; x++) {
             const entity = new pc.Entity(`playbot-${x}-${z}`);
             entity.addComponent('gsplat', {
-                asset: assets.playbot,
-                unified: true
+                asset: assets.playbot
             });
             const px = (x - half) * GRID_SPACING;
             const pz = (z - half) * GRID_SPACING;

--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
@@ -139,8 +139,7 @@ assetListLoader.load(() => {
 
     const entity = new pc.Entity(config.name || 'gsplat');
     entity.addComponent('gsplat', {
-        asset: assets.church,
-        unified: true
+        asset: assets.church
     });
     entity.setLocalPosition(0, 0, 0);
     const [rotX, rotY, rotZ] = /** @type {[number, number, number]} */ (config.eulerAngles || [-90, 0, 0]);

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -468,8 +468,7 @@ assetListLoader.load(async () => {
 
         gsplatEntity = new pc.Entity(config.name || 'gsplat'); // eslint-disable-line require-atomic-updates
         gsplatEntity.addComponent('gsplat', {
-            asset: asset,
-            unified: true
+            asset: asset
         });
         gsplatEntity.setLocalPosition(0, 0, 0);
         gsplatEntity.setLocalEulerAngles(data.get('orientation'), 0, 0);

--- a/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
@@ -259,8 +259,7 @@ app.root.addChild(sceneRoot);
 // Gaussian splat (visual)
 const splat = new pc.Entity('sunnyvale-gsplat');
 splat.addComponent('gsplat', {
-    asset: assets.splat,
-    unified: true
+    asset: assets.splat
 });
 sceneRoot.addChild(splat);
 

--- a/examples/src/examples/gaussian-splatting/multi-splat.example.mjs
+++ b/examples/src/examples/gaussian-splatting/multi-splat.example.mjs
@@ -95,8 +95,7 @@ assetListLoader.load(() => {
 
     const guitar = new pc.Entity('guitar');
     guitar.addComponent('gsplat', {
-        asset: assets.guitar,
-        unified: true
+        asset: assets.guitar
     });
     guitar.setLocalPosition(0, 0.8, 0);
     guitar.setLocalEulerAngles(0, 0, 180);
@@ -106,8 +105,7 @@ assetListLoader.load(() => {
     const createSplatInstance = (name, asset, px, py, pz, scale) => {
         const entity = new pc.Entity(name);
         entity.addComponent('gsplat', {
-            asset,
-            unified: true
+            asset
         });
         entity.setLocalPosition(px, py, pz);
         entity.setLocalEulerAngles(180, 90, 0);
@@ -124,7 +122,6 @@ assetListLoader.load(() => {
 
     app.root.addChild(camera);
 
-    // Orbit around a fixed pivot (not focusEntity — unified gsplats have no meshInstance for AABB).
     camera.addComponent('script');
     const orbitCam = /** @type {any} */ (camera.script.create('orbitCamera', {
         attributes: {

--- a/examples/src/examples/gaussian-splatting/multi-view.example.mjs
+++ b/examples/src/examples/gaussian-splatting/multi-view.example.mjs
@@ -79,8 +79,7 @@ assetListLoader.load(() => {
     // create a splat entity and place it in the world
     const logoEntity1 = new pc.Entity();
     logoEntity1.addComponent('gsplat', {
-        asset: assets.logo,
-        unified: true
+        asset: assets.logo
     });
     logoEntity1.setLocalPosition(0, 0.05, 0);
     logoEntity1.setLocalEulerAngles(180, 90, 0);
@@ -90,8 +89,7 @@ assetListLoader.load(() => {
     // create another splat entity and place it in the world
     const logoEntity2 = new pc.Entity();
     logoEntity2.addComponent('gsplat', {
-        asset: assets.logo,
-        unified: true
+        asset: assets.logo
     });
     logoEntity2.setLocalPosition(0, -0.5, 0);
     logoEntity2.setLocalEulerAngles(-90, -90, 0);

--- a/examples/src/examples/gaussian-splatting/paint.example.mjs
+++ b/examples/src/examples/gaussian-splatting/paint.example.mjs
@@ -164,7 +164,7 @@ assetListLoader.load(() => {
     // Creates a paintable gsplat entity with position, rotation, scale, and sets up processing
     const createPaintableSplat = (name, asset, position, rotation, scale) => {
         const entity = new pc.Entity(name);
-        const gsplatComponent = entity.addComponent('gsplat', { asset, unified: true });
+        const gsplatComponent = entity.addComponent('gsplat', { asset });
         entity.setLocalPosition(...position);
         entity.setLocalEulerAngles(...rotation);
         entity.setLocalScale(...scale);

--- a/examples/src/examples/gaussian-splatting/picking.example.mjs
+++ b/examples/src/examples/gaussian-splatting/picking.example.mjs
@@ -74,8 +74,7 @@ assetListLoader.load(() => {
         const splat = new pc.Entity(`splat-${i}`);
         splat.addComponent('gsplat', {
             asset: assets.logo,
-            castShadows: false,
-            unified: true
+            castShadows: false
         });
 
         app.root.addChild(splat);
@@ -95,7 +94,7 @@ assetListLoader.load(() => {
     });
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
 
-    // Enable gsplat ID for unified picking
+    // Enable gsplat ID for picking
     app.scene.gsplat.enableIds = true;
     app.scene.gsplat.alphaClip = 0.2;
     app.scene.gsplat.minPixelSize = 1;

--- a/examples/src/examples/gaussian-splatting/procedural-instanced.example.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-instanced.example.mjs
@@ -190,8 +190,7 @@ for (let gx = 0; gx < 2; gx++) {
         for (let gz = 0; gz < 2; gz++) {
             const child = new pc.Entity(`splat_${gx}_${gy}_${gz}`);
             child.addComponent('gsplat', {
-                resource: container,
-                unified: true
+                resource: container
             });
             child.setLocalPosition(
                 (gx - 0.5) * spacing,

--- a/examples/src/examples/gaussian-splatting/procedural-mesh.example.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-mesh.example.mjs
@@ -181,7 +181,6 @@ assetListLoader.load(() => {
         for (let i = 1; i < 4; i++) {
             const cloneCloud = new pc.Entity(`GsplatCloud-${srcIndex}-${i}`);
             cloneCloud.addComponent('gsplat', {
-                unified: true,
                 resource: container
             });
             cloudParent.addChild(cloneCloud);

--- a/examples/src/examples/gaussian-splatting/procedural-shapes.example.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-shapes.example.mjs
@@ -87,8 +87,7 @@ assetListLoader.load(() => {
     // Create the bicycle gsplat
     const bicycle = new pc.Entity('Bicycle');
     bicycle.addComponent('gsplat', {
-        asset: assets.bicycle,
-        unified: true
+        asset: assets.bicycle
     });
     bicycle.setLocalEulerAngles(0, 0, 180);
     app.root.addChild(bicycle);

--- a/examples/src/examples/gaussian-splatting/reveal.example.mjs
+++ b/examples/src/examples/gaussian-splatting/reveal.example.mjs
@@ -74,11 +74,10 @@ assetListLoader.load(() => {
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
     data.set('effect', 'radial');
 
-    // Create hotel gsplat with unified set to true
+    // Create hotel gsplat
     const hotel = new pc.Entity('hotel');
     hotel.addComponent('gsplat', {
-        asset: assets.hotel,
-        unified: true
+        asset: assets.hotel
     });
     hotel.setLocalEulerAngles(180, 0, 0);
     app.root.addChild(hotel);

--- a/examples/src/examples/gaussian-splatting/shader-effects.example.mjs
+++ b/examples/src/examples/gaussian-splatting/shader-effects.example.mjs
@@ -172,11 +172,10 @@ assetListLoader.load(() => {
     data.set('enabled', true);
     data.set('effect', 'hide');
 
-    // Create hotel gsplat with unified set to true
+    // Create hotel gsplat
     const hotel = new pc.Entity('hotel');
     hotel.addComponent('gsplat', {
-        asset: assets.hotel,
-        unified: true
+        asset: assets.hotel
     });
     hotel.setLocalEulerAngles(180, 0, 0);
     app.root.addChild(hotel);

--- a/examples/src/examples/gaussian-splatting/shadows.example.mjs
+++ b/examples/src/examples/gaussian-splatting/shadows.example.mjs
@@ -109,8 +109,7 @@ assetListLoader.load(() => {
     const biker = new pc.Entity('biker');
     biker.addComponent('gsplat', {
         asset: assets.biker,
-        castShadows: true,
-        unified: true
+        castShadows: true
     });
     biker.setLocalPosition(-1.5, 0.05, 0);
     biker.setLocalEulerAngles(180, 90, 0);
@@ -121,8 +120,7 @@ assetListLoader.load(() => {
     const biker2 = new pc.Entity('biker2');
     biker2.addComponent('gsplat', {
         asset: assets.biker,
-        castShadows: true,
-        unified: true
+        castShadows: true
     });
     biker2.setLocalPosition(0.5, 0.05, 0);
     biker2.setLocalEulerAngles(180, 0, 0);

--- a/examples/src/examples/gaussian-splatting/simple.example.mjs
+++ b/examples/src/examples/gaussian-splatting/simple.example.mjs
@@ -79,15 +79,13 @@ assetListLoader.load(() => {
     const biker = new pc.Entity();
     biker.addComponent('gsplat', {
         asset: assets.biker,
-        castShadows: true,
-        unified: true
+        castShadows: true
     });
     biker.setLocalPosition(-1.5, 0.05, 0);
     biker.setLocalEulerAngles(180, 90, 0);
     biker.setLocalScale(0.7, 0.7, 0.7);
     app.root.addChild(biker);
 
-    // Orbit pivot at splat (unified gsplats have no mesh AABB for focusEntity framing).
     const ORBIT_PIVOT = new pc.Vec3().copy(biker.getPosition());
     ORBIT_PIVOT.y += 1;
     const ORBIT_DISTANCE = 4;

--- a/examples/src/examples/gaussian-splatting/spherical-harmonics.example.mjs
+++ b/examples/src/examples/gaussian-splatting/spherical-harmonics.example.mjs
@@ -69,22 +69,20 @@ assetListLoader.load(() => {
     const skull = new pc.Entity();
     skull.addComponent('gsplat', {
         asset: assets.skull,
-        castShadows: true,
-        unified: true
+        castShadows: true
     });
     skull.setLocalPosition(-1.5, 0.05, 0);
     skull.setLocalEulerAngles(180, 90, 0);
     skull.setLocalScale(0.7, 0.7, 0.7);
     app.root.addChild(skull);
 
-    // Orbit pivot at splat (unified gsplats have no mesh AABB for focusEntity framing).
     const ORBIT_PIVOT = new pc.Vec3().copy(skull.getPosition());
     ORBIT_PIVOT.y += 0.2;
     const ORBIT_DISTANCE = 4;
     const ORBIT_INITIAL_YAW = 32;
     const ORBIT_INITIAL_PITCH = -10;
 
-    // alpha clip for unified splats (shadows / cutout); scene-level for unified path
+    // scene-level alpha clip for splats (shadows / cutout)
     app.scene.gsplat.alphaClip = 0.1;
 
     // Create an Entity with a camera component

--- a/examples/src/examples/gaussian-splatting/splat-portal.example.mjs
+++ b/examples/src/examples/gaussian-splatting/splat-portal.example.mjs
@@ -111,9 +111,9 @@ assetListLoader.load(() => {
     // ---------- Layer setup ----------
     // Each splat scene has its own dedicated layer (outsideLayer for Parish,
     // insideLayer for Skatepark). The data on each layer never changes - we
-    // never reassign gsplat entities to a different layer, so the unified
-    // gsplat manager for each layer keeps its splat data preloaded and there's
-    // no reconciliation cost on portal crossings.
+    // never reassign gsplat entities to a different layer, so the gsplat manager
+    // for each layer keeps its splat data preloaded and there's no reconciliation
+    // cost on portal crossings.
     //
     // What changes on a crossing is:
     //   1) the order of the two splat transparent sub-layers, so the
@@ -350,7 +350,6 @@ assetListLoader.load(() => {
         const entity = new pc.Entity(`${config.name}Splat`);
         entity.addComponent('gsplat', {
             asset: config.asset,
-            unified: true,
             layers: [config.layer.id]
         });
 
@@ -544,7 +543,7 @@ assetListLoader.load(() => {
     portalGroup.addChild(glassPlane);
 
     // ---------- Stencil + depth setup for the two splat scenes ----------
-    // In unified mode the gsplat material is created lazily per (camera, layer) pair.
+    // The gsplat material is created lazily per (camera, layer) pair.
     // The from-scene (the world the camera is in) gets:
     //  - no stencil restriction
     //  - depthFunc = LESSEQUAL

--- a/examples/src/examples/gaussian-splatting/third-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/third-person.example.mjs
@@ -195,8 +195,7 @@ app.root.addChild(sceneRoot);
 
 const splat = new pc.Entity('sunnyvale-gsplat');
 splat.addComponent('gsplat', {
-    asset: assets.splat,
-    unified: true
+    asset: assets.splat
 });
 sceneRoot.addChild(splat);
 

--- a/examples/src/examples/gaussian-splatting/viewer.example.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.example.mjs
@@ -325,8 +325,7 @@ assetListLoader.load(() => {
             // Create gsplat entity
             entity = new pc.Entity(metaFile.name);
             entity.addComponent('gsplat', {
-                asset: asset,
-                unified: true
+                asset: asset
             });
             entity.setLocalEulerAngles(180, 0, 0);
             app.root.addChild(entity);
@@ -361,8 +360,7 @@ assetListLoader.load(() => {
             // Create gsplat entity
             entity = new pc.Entity(file.name);
             entity.addComponent('gsplat', {
-                asset: asset,
-                unified: true
+                asset: asset
             });
             entity.setLocalEulerAngles(180, 0, 0);
             app.root.addChild(entity);

--- a/examples/src/examples/gaussian-splatting/weather.example.mjs
+++ b/examples/src/examples/gaussian-splatting/weather.example.mjs
@@ -95,8 +95,7 @@ assetListLoader.load(() => {
     // Load the gsplat scene
     const gsplatEntity = new pc.Entity('Roman-Parish');
     gsplatEntity.addComponent('gsplat', {
-        asset: assets.scene,
-        unified: true
+        asset: assets.scene
     });
     gsplatEntity.setLocalEulerAngles(270, 0, 0);
     app.root.addChild(gsplatEntity);

--- a/examples/src/examples/gaussian-splatting/world.example.mjs
+++ b/examples/src/examples/gaussian-splatting/world.example.mjs
@@ -147,8 +147,7 @@ assetListLoader.load(() => {
     // Create skatepark entity
     const skatepark = new pc.Entity('Skatepark');
     skatepark.addComponent('gsplat', {
-        asset: assets.skatepark,
-        unified: true
+        asset: assets.skatepark
     });
     skatepark.setLocalPosition(0, 0, 0);
     const [rotX, rotY, rotZ] = /** @type {[number, number, number]} */ (config.eulerAngles);
@@ -177,8 +176,7 @@ assetListLoader.load(() => {
     // Create biker entity at center, ground level
     const biker = new pc.Entity('Biker');
     biker.addComponent('gsplat', {
-        asset: assets.biker,
-        unified: true
+        asset: assets.biker
     });
     biker.setLocalPosition(worldCenter.x, worldCenter.y, worldCenter.z);
     biker.setLocalEulerAngles(180, 0, 0);
@@ -188,8 +186,7 @@ assetListLoader.load(() => {
     // Create first orbiting logo
     const logo1 = new pc.Entity('Logo1');
     logo1.addComponent('gsplat', {
-        asset: assets.logo,
-        unified: true
+        asset: assets.logo
     });
     logo1.setLocalEulerAngles(180, 90, 0);
     app.root.addChild(logo1);
@@ -197,8 +194,7 @@ assetListLoader.load(() => {
     // Create second orbiting logo
     const logo2 = new pc.Entity('Logo2');
     logo2.addComponent('gsplat', {
-        asset: assets.logo,
-        unified: true
+        asset: assets.logo
     });
     logo2.setLocalEulerAngles(180, 90, 0);
     logo2.setLocalScale(0.5, 0.5, 0.5);

--- a/examples/src/examples/gaussian-splatting/xr-views.example.mjs
+++ b/examples/src/examples/gaussian-splatting/xr-views.example.mjs
@@ -62,8 +62,7 @@ assetListLoader.load(() => {
     // Create hotel gsplat
     const hotel = new pc.Entity('hotel');
     hotel.addComponent('gsplat', {
-        asset: assets.hotel,
-        unified: true
+        asset: assets.hotel
     });
     hotel.setLocalEulerAngles(180, 0, 0);
     app.root.addChild(hotel);

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -49,21 +49,6 @@ const UNIFIED_LEGACY_HINT = 'GSplatComponent#unified now defaults to true (unifi
  * console.log(entity.gsplat.customAabb);
  * ```
  *
- * ## Unified Rendering
- *
- * The {@link unified} property enables unified rendering mode, which provides advanced features
- * for Gaussian Splats:
- *
- * - **Global Sorting**: Multiple splat components are sorted together in a single unified sort,
- *   eliminating visibility artifacts and popping effects when splat components overlap.
- * - **LOD Streaming**: Dynamically loads and renders appropriate levels of detail based on camera
- *   distance, enabling efficient rendering of massive splat scenes.
- *
- * ```javascript
- * // Enable unified rendering for advanced features
- * entity.gsplat.unified = true;
- * ```
- *
  * Relevant Engine API examples:
  *
  * - [Simple Splat Loading](https://playcanvas.github.io/#/gaussian-splatting/simple)
@@ -305,15 +290,6 @@ class GSplatComponent extends Component {
         return this._instance;
     }
 
-    /**
-     * Sets the material used to render the gsplat.
-     *
-     * **Note:** This setter is only available in legacy (deprecated) non-unified mode. In unified
-     * mode, multiple gsplat components share a single material per camera/layer combination — use
-     * {@link GSplatComponentSystem#getMaterial} instead.
-     *
-     * @param {ShaderMaterial} value - The material instance.
-     */
     set material(value) {
         if (this.unified) {
             Debug.warn(`GSplatComponent#material setter is only available in legacy non-unified mode; in unified mode use app.systems.gsplat.getMaterial(camera, layer). ${UNIFIED_LEGACY_HINT}`);
@@ -326,16 +302,6 @@ class GSplatComponent extends Component {
         }
     }
 
-    /**
-     * Gets the material used to render the gsplat.
-     *
-     * **Note:** This getter returns `null` in unified mode (the default). In unified mode, materials
-     * are organized per camera/layer combination rather than per component — use
-     * {@link GSplatComponentSystem#getMaterial} instead. Per-component materials are only available
-     * in legacy (deprecated) non-unified mode.
-     *
-     * @type {ShaderMaterial|null}
-     */
     get material() {
         if (this.unified) {
             Debug.warnOnce(`GSplatComponent#material getter returns null in unified mode; use app.systems.gsplat.getMaterial(camera, layer) instead. ${UNIFIED_LEGACY_HINT}`);
@@ -344,19 +310,6 @@ class GSplatComponent extends Component {
         return this._instance?.material ?? this._materialTmp ?? null;
     }
 
-    /**
-     * Sets whether to use the high quality or the approximate (but fast) spherical-harmonic calculation when rendering SOG data.
-     *
-     * The low quality approximation evaluates the scene's spherical harmonic contributions
-     * along the camera's Z-axis instead of using each gaussian's view vector. This results
-     * in gaussians being accurate at the center of the screen and becoming less accurate
-     * as they appear further from the center. This is a good trade-off for performance
-     * when rendering large SOG datasets, especially on mobile devices.
-     *
-     * Defaults to false.
-     *
-     * @type {boolean}
-     */
     set highQualitySH(value) {
         if (value !== this._highQualitySH) {
             this._highQualitySH = value;
@@ -364,11 +317,6 @@ class GSplatComponent extends Component {
         }
     }
 
-    /**
-     * Gets whether the high quality (true) or the fast approximate (false) spherical-harmonic calculation is used when rendering SOG data.
-     *
-     * @type {boolean}
-     */
     get highQualitySH() {
         return this._highQualitySH;
     }
@@ -569,10 +517,10 @@ class GSplatComponent extends Component {
     }
 
     /**
-     * Sets the work buffer update mode. Only applicable in unified rendering mode.
+     * Sets the work buffer update mode.
      *
-     * In unified mode, splat data is rendered to a work buffer only when needed (e.g., when
-     * transforms change). Can be:
+     * Splat data is rendered to a work buffer only when needed (e.g., when transforms change).
+     * Can be:
      * - {@link WORKBUFFER_UPDATE_AUTO}: Update only when needed (default).
      * - {@link WORKBUFFER_UPDATE_ONCE}: Force update this frame, then switch to AUTO.
      * - {@link WORKBUFFER_UPDATE_ALWAYS}: Update every frame.
@@ -582,8 +530,8 @@ class GSplatComponent extends Component {
      *
      * Note: {@link WORKBUFFER_UPDATE_ALWAYS} has a performance impact as it re-renders
      * all splat data to the work buffer every frame. Where possible, consider using shader
-     * customization on the unified gsplat material (`app.scene.gsplat.material`) which is
-     * applied during final rendering without re-rendering the work buffer.
+     * customization on the gsplat material (`app.scene.gsplat.material`) which is applied
+     * during final rendering without re-rendering the work buffer.
      *
      * @type {number}
      */
@@ -604,8 +552,7 @@ class GSplatComponent extends Component {
     }
 
     /**
-     * Sets custom shader code for modifying splats when written to the work buffer. Only
-     * applicable in unified rendering mode.
+     * Sets custom shader code for modifying splats when written to the work buffer.
      *
      * Must provide all three functions:
      * - `modifySplatCenter`: Modify the splat center position
@@ -920,7 +867,7 @@ class GSplatComponent extends Component {
 
     /**
      * Sets a shader parameter for this gsplat instance. Parameters set here are applied
-     * during unified rendering.
+     * during rendering.
      *
      * @param {string} name - The name of the parameter (uniform name in shader).
      * @param {number|number[]|ArrayBufferView|Texture|StorageBuffer} data - The value for the parameter.
@@ -953,10 +900,10 @@ class GSplatComponent extends Component {
 
     /**
      * Gets an instance texture by name. Instance textures are per-component textures defined
-     * in the resource's format with `storage: GSPLAT_STREAM_INSTANCE`. Only available in unified mode.
+     * in the resource's format with `storage: GSPLAT_STREAM_INSTANCE`.
      *
      * @param {string} name - The name of the texture.
-     * @returns {Texture|null} The texture, or null if not found or not in unified mode.
+     * @returns {Texture|null} The texture, or null if not found.
      * @example
      * // Add an instance stream to the resource format
      * resource.format.addExtraStreams([

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -49,10 +49,9 @@ const _properties = [
  */
 class GSplatComponentSystem extends ComponentSystem {
     /**
-     * Fired when a GSplat material is created for a camera and layer combination. In unified
-     * mode, materials are created during the first frame update when the GSplat is rendered.
-     * The handler is passed the {@link ShaderMaterial}, the {@link CameraComponent}, and
-     * the {@link Layer}.
+     * Fired when a GSplat material is created for a camera and layer combination. Materials are
+     * created during the first frame update when the GSplat is rendered. The handler is passed
+     * the {@link ShaderMaterial}, the {@link CameraComponent}, and the {@link Layer}.
      *
      * This event is useful for setting up custom material chunks and parameters before the
      * first render.
@@ -68,7 +67,7 @@ class GSplatComponentSystem extends ComponentSystem {
     static EVENT_MATERIALCREATED = 'material:created';
 
     /**
-     * Fired every frame for each camera and layer combination rendering GSplats in unified mode.
+     * Fired every frame for each camera and layer combination rendering GSplats.
      * The handler is passed the {@link CameraComponent}, the {@link Layer}, a boolean indicating
      * if the current frame has up-to-date sorting, and a number indicating how many resources are
      * loading.
@@ -179,11 +178,11 @@ class GSplatComponentSystem extends ComponentSystem {
     }
 
     /**
-     * Gets the GSplat material used by unified GSplat rendering for the given camera and layer.
+     * Gets the GSplat material for the given camera and layer.
      *
-     * Returns null if the material hasn't been created yet. In unified mode, materials are created
-     * during the first frame update when the GSplat is rendered. To be notified immediately when
-     * materials are created, listen to the 'material:created' event on GSplatComponentSystem:
+     * Returns null if the material hasn't been created yet. Materials are created during the first
+     * frame update when the GSplat is rendered. To be notified immediately when materials are
+     * created, listen to the 'material:created' event on GSplatComponentSystem:
      *
      * @param {Camera} camera - The camera instance.
      * @param {Layer} layer - The layer instance.

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -28,7 +28,7 @@ import wgslPackedWrite from '../shader-lib/wgsl/chunks/gsplat/frag/formats/conta
  */
 
 /**
- * Parameters for GSplat unified system.
+ * Parameters for the GSplat system.
  *
  * @category Graphics
  */
@@ -767,7 +767,7 @@ class GSplatParams {
 
     /**
      * Work buffer data format. Controls the precision and bandwidth of the intermediate work buffer
-     * used during unified GSplat rendering. Can be set to {@link GSPLATDATA_COMPACT} (20 bytes/splat)
+     * used during GSplat rendering. Can be set to {@link GSPLATDATA_COMPACT} (20 bytes/splat)
      * or {@link GSPLATDATA_LARGE} (32 bytes/splat). Defaults to {@link GSPLATDATA_COMPACT}.
      *
      * @type {string}
@@ -806,9 +806,9 @@ class GSplatParams {
 
     /**
      * A material template that can be customized by the user. Any defines, parameters, or shader
-     * chunks set on this material will be automatically applied to all GSplat components rendered
-     * in unified mode. After making changes, call {@link Material#update} to for the changes to be applied
-     * on the next frame.
+     * chunks set on this material will be automatically applied to all GSplat components. After
+     * making changes, call {@link Material#update} to for the changes to be applied on the next
+     * frame.
      *
      * @type {ShaderMaterial}
      * @example
@@ -822,7 +822,7 @@ class GSplatParams {
 
     /**
      * Format descriptor for work buffer streams. Describes the textures used by the work buffer
-     * for intermediate storage during unified rendering. Users can add extra streams via
+     * for intermediate storage during rendering. Users can add extra streams via
      * {@link GSplatFormat#addExtraStreams} for custom per-splat data.
      *
      * @type {GSplatFormat}

--- a/src/scene/gsplat/gsplat-container.js
+++ b/src/scene/gsplat/gsplat-container.js
@@ -31,11 +31,11 @@ import { GSplatResourceBase } from './gsplat-resource-base.js';
  * // Set bounding box
  * container.aabb = new pc.BoundingBox();
  *
- * // fill centers only if you need CPU sorting or non-unified rendering
+ * // fill centers only if you need CPU sorting
  * container.centers.set([x0, y0, z0, x1, y1, z1, ...]);  // xyz per splat
  *
  * // Add to scene
- * entity.addComponent('gsplat', { resource: container, unified: true });
+ * entity.addComponent('gsplat', { resource: container });
  *
  * @example
  * // Example 2: Using a custom format
@@ -114,8 +114,8 @@ class GSplatContainer extends GSplatResourceBase {
     }
 
     /**
-     * CPU-side xyz per splat. Allocated lazily on first read; GPU-only unified rendering can omit
-     * touching this property to avoid the extra buffer.
+     * CPU-side xyz per splat. Allocated lazily on first read; GPU-only rendering can omit touching
+     * this property to avoid the extra buffer.
      *
      * @type {Float32Array}
      */


### PR DESCRIPTION
Follow-up cleanup to the unified-default flip (#8802, #8803, #8804). Unified rendering is now the default and the `unified` property is `@deprecated` + `@ignore`, so the public API docs and examples shouldn't be framed around "unified mode" any more — it's just gsplat rendering.

**Changes (engine source):**
- `GSplatComponent`:
  - Remove the `## Unified Rendering` section from the class JSDoc.
  - Strip the JSDoc blocks from `material` get/set and `highQualitySH` get/set (both are legacy-only and only documented the unified/non-unified distinction).
  - Drop "unified" qualifiers from `workBufferUpdate`, `workBufferModifier`, `setParameter`, and `getInstanceTexture` JSDocs.
- `GSplatComponentSystem`: drop "in unified mode" from the `material:created` and `frame:ready` event JSDocs, and from `getMaterial` JSDoc.
- `GSplatParams`: class JSDoc "Parameters for GSplat unified system" → "Parameters for the GSplat system"; drop "unified" qualifier from `dataFormat`, `material`, and `format` JSDocs.
- `GSplatContainer`: drop "non-unified rendering" from the class example comment, drop `unified: true` from the `addComponent` example, drop "unified" qualifier from the `centers` JSDoc.

**Changes (examples — `gaussian-splatting/` folder, 29 files):**
- Remove `unified: true` from every `addComponent('gsplat', { ... })` call (~40 occurrences) — it's the default now and the property is deprecated.
- Reword/remove comments that frame things around "unified" (e.g. `// Create hotel gsplat with unified set to true` → `// Create hotel gsplat`).
- Drop three stale orbit-pivot comments ("unified gsplats have no mesh AABB for focusEntity framing") — these became factually incorrect once #8803 made `orbit-camera.js` unified-aware.
- Update `global-sorting` example header from "demonstrates unified gsplat rendering" to "demonstrates global gsplat sorting" — what the example actually shows.

**API Changes:**
- None. All edits are docs/comments/examples. No runtime behaviour or public-API surface changes.

**Notes:**
- Remaining `unified` mentions in the engine are all either internal (private fields, code comments, code branches), runtime warning strings (which must keep the property name so users can search for it), `@ignore`'d JSDoc, or directory names — none render in public docs.
- The legacy `gsplat.unified = false` opt-in still works and still emits the one-time `Debug.deprecated` warning from #8802. This PR doesn't remove the legacy mode itself.