### PR TITLE
Support GSPLAT_AA in the hybrid gsplat renderer

### DIFF
--- a/examples/src/examples/gaussian-splatting/viewer.controls.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.controls.mjs
@@ -25,6 +25,15 @@ export const controls = ({ observer, ReactPCUI, React, jsx, fragment }) => {
                         { v: 3, t: 'Compute' }
                     ]
                 })
+            ),
+            jsx(
+                LabelGroup,
+                { text: 'Anti-alias' },
+                jsx(BooleanInput, {
+                    type: 'toggle',
+                    binding: new BindingTwoWay(),
+                    link: { observer, path: 'data.antialias' }
+                })
             )
         ),
         jsx(

--- a/examples/src/examples/gaussian-splatting/viewer.example.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.example.mjs
@@ -180,6 +180,7 @@ assetListLoader.load(() => {
     data.set('data', {
         skydome: false,
         compact: false,
+        antialias: false,
         orientation: 180,
         tonemapping: pc.TONEMAP_LINEAR,
         grading: {
@@ -251,6 +252,8 @@ assetListLoader.load(() => {
             applySkydome();
         } else if (path === 'data.compact') {
             app.scene.gsplat.dataFormat = data.get('data.compact') ? pc.GSPLATDATA_COMPACT : pc.GSPLATDATA_LARGE;
+        } else if (path === 'data.antialias') {
+            app.scene.gsplat.antiAlias = data.get('data.antialias');
         } else if (path === 'data.orientation') {
             // Apply orientation to splat entity
             if (splatEntity) {

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1715,7 +1715,8 @@ class GSplatManager {
             viewportHeight,
             flipY: !!cameraNode.camera.renderTarget?.flipY,
             pickMode,
-            fisheyeProj
+            fisheyeProj,
+            antiAlias: gsplat.antiAlias
         });
 
         projector.writeIndirectArgs(

--- a/src/scene/gsplat-unified/gsplat-projector.js
+++ b/src/scene/gsplat-unified/gsplat-projector.js
@@ -106,9 +106,10 @@ class GSplatProjector {
     binWeightsUtil;
 
     /**
-     * Lazily-created projector compute variants keyed by `radial|pick|fisheye`
-     * combination (see `_projectorKey`). Up to 8 variants exist; only the
-     * combinations actually needed by the running app are compiled.
+     * Lazily-created projector compute variants keyed by `radial|pick|fisheye|aa`
+     * combination (see `_projectorKey`). AA is mutually exclusive with pick, so up to
+     * 12 variants exist; only the combinations actually needed by the running app are
+     * compiled.
      *
      * @type {Map<string, Compute>}
      */
@@ -303,11 +304,12 @@ class GSplatProjector {
      * @param {boolean} radialSort - Radial vs linear sort.
      * @param {boolean} pickMode - Pick output mode.
      * @param {boolean} fisheyeMode - Fisheye projection mode.
+     * @param {boolean} antiAlias - Anti-aliasing opacity compensation mode.
      * @returns {string} The cache key.
      * @private
      */
-    _projectorKey(radialSort, pickMode, fisheyeMode) {
-        return `${radialSort ? 'r' : 'l'}${pickMode ? 'p' : ''}${fisheyeMode ? 'f' : ''}`;
+    _projectorKey(radialSort, pickMode, fisheyeMode, antiAlias) {
+        return `${radialSort ? 'r' : 'l'}${pickMode ? 'p' : ''}${fisheyeMode ? 'f' : ''}${antiAlias ? 'a' : ''}`;
     }
 
     /**
@@ -317,10 +319,12 @@ class GSplatProjector {
      * @param {boolean} radialSort - Whether to compile the RADIAL_SORT variant.
      * @param {boolean} pickMode - Whether to write pcId into the cache for picking.
      * @param {boolean} fisheyeMode - Whether to compile the GSPLAT_FISHEYE variant.
+     * @param {boolean} antiAlias - Whether to compile the GSPLAT_AA variant (bakes the
+     * anti-aliasing opacity compensation into the cached alpha).
      * @returns {Compute} The created compute instance.
      * @private
      */
-    _createProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode) {
+    _createProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode, antiAlias) {
         const device = this.device;
         const wbFormat = workBuffer.format;
 
@@ -360,6 +364,9 @@ class GSplatProjector {
         if (fisheyeMode) {
             cdefines.set('GSPLAT_FISHEYE', '');
         }
+        if (antiAlias) {
+            cdefines.set('GSPLAT_AA', '');
+        }
 
         // Format-specific defines mirroring the compute renderer (compute-gsplat-local-renderer.js).
         const colorStream = wbFormat.getStream('dataColor');
@@ -367,7 +374,7 @@ class GSplatProjector {
             cdefines.set('GSPLAT_COLOR_FLOAT', '');
         }
 
-        const name = `GSplatProjector${radialSort ? 'Radial' : 'Linear'}${pickMode ? 'Pick' : ''}${fisheyeMode ? 'Fisheye' : ''}`;
+        const name = `GSplatProjector${radialSort ? 'Radial' : 'Linear'}${pickMode ? 'Pick' : ''}${fisheyeMode ? 'Fisheye' : ''}${antiAlias ? 'Aa' : ''}`;
 
         const ubFormat = fisheyeMode ?
             this._projectorUniformBufferFormatFisheye :
@@ -395,20 +402,21 @@ class GSplatProjector {
      * @param {boolean} radialSort - Whether to use the radial sort variant.
      * @param {boolean} [pickMode] - Whether to use the pick-output variant.
      * @param {boolean} [fisheyeMode] - Whether to use the fisheye projection variant.
+     * @param {boolean} [antiAlias] - Whether to use the anti-aliasing variant.
      * @returns {Compute} The projector compute instance.
      * @private
      */
-    _getProjectorCompute(workBuffer, radialSort, pickMode = false, fisheyeMode = false) {
+    _getProjectorCompute(workBuffer, radialSort, pickMode = false, fisheyeMode = false, antiAlias = false) {
         const wbFormat = workBuffer.format;
         if (this._formatVersion !== wbFormat.extraStreamsVersion) {
             this._destroyProjectorComputes();
             this._formatVersion = wbFormat.extraStreamsVersion;
         }
 
-        const key = this._projectorKey(radialSort, pickMode, fisheyeMode);
+        const key = this._projectorKey(radialSort, pickMode, fisheyeMode, antiAlias);
         let compute = this._projectorComputes.get(key);
         if (!compute) {
-            compute = this._createProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode);
+            compute = this._createProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode, antiAlias);
             this._projectorComputes.set(key, compute);
         }
         return compute;
@@ -461,6 +469,9 @@ class GSplatProjector {
      * @param {import('../graphics/fisheye-projection.js').FisheyeProjection} [params.fisheyeProj] -
      * Fisheye projection state. When `fisheyeProj.enabled` is true the projector picks the
      * GSPLAT_FISHEYE variant and writes NDC-style clip data; otherwise the linear path runs.
+     * @param {boolean} [params.antiAlias] - Whether to bake anti-aliasing opacity
+     * compensation into the cached alpha. Ignored in pick mode (picking only gates on a
+     * binary opacity threshold), which keeps the projector variant count down.
      */
     dispatch(params) {
         const {
@@ -469,10 +480,15 @@ class GSplatProjector {
             alphaClip, minPixelSize, minContribution,
             viewportWidth, viewportHeight, flipY,
             pickMode = false,
-            fisheyeProj
+            fisheyeProj,
+            antiAlias = false
         } = params;
 
         const fisheyeMode = !!fisheyeProj?.enabled;
+
+        // AA only matters for the forward color path; skip it for picking to avoid
+        // doubling the projector variant count.
+        const aaMode = antiAlias && !pickMode;
 
         this._ensureCapacity(totalCapacity);
 
@@ -481,7 +497,7 @@ class GSplatProjector {
         // workgroups run their atomicAdds.
         this.renderCounter.clear();
 
-        const compute = this._getProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode);
+        const compute = this._getProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode, aaMode);
 
         // Camera position / forward (camera Z basis, matching cpu-sort path).
         const cameraPos = cameraNode.getPosition();

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-common.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-common.js
@@ -25,6 +25,9 @@ struct SplatCov2D {
     c: f32,
     viewDepth: f32,
     valid: bool,
+    #if GSPLAT_AA
+        aaFactor: f32,
+    #endif
 }
 
 fn computeSplatCov(
@@ -149,14 +152,24 @@ fn computeSplatCov(
     let b0 = M * tt0;
     let b1 = M * tt1;
 
-    let a = dot(b0, b0) + 0.3;
+    let aRaw = dot(b0, b0);
     let b = dot(b0, b1);
-    let c = dot(b1, b1) + 0.3;
+    let cRaw = dot(b1, b1);
+
+    let a = aRaw + 0.3;
+    let c = cRaw + 0.3;
 
     let det = a * c - b * b;
     if (det <= 0.0) {
         return result;
     }
+
+    #if GSPLAT_AA
+        // AA compensation: ratio of pre-blur to post-blur determinant. Matches the
+        // quad renderer's GSPLAT_AA branch in gsplatCorner.js initCornerCov.
+        let detOrig = aRaw * cRaw - b * b;
+        result.aaFactor = sqrt(max(detOrig / det, 0.0));
+    #endif
 
     // Rejects splats whose total visual contribution (opacity * projected area) is
     // negligible. Near the camera, projected areas are large so contributions naturally

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
@@ -190,7 +190,13 @@ fn main(
         #else
             let color = getColor();
             rgb = max(color, vec3f(0.0));
-            alpha = opacity;
+            #if GSPLAT_AA
+                // Bake the AA opacity compensation into the cached alpha (the hybrid VS
+                // reads it pre-modulated). Only compiled for the non-pick variant.
+                alpha = opacity * proj.aaFactor;
+            #else
+                alpha = opacity;
+            #endif
         #endif
 
         valid = true;


### PR DESCRIPTION
The quad gsplat renderer applies an anti-aliasing opacity compensation factor when `GSPLAT_AA` is enabled (via `GSplatParams#antiAlias`), but the hybrid (GPU-sort) renderer ignored it. This wires AA support through the hybrid pipeline.

Because the hybrid path projects splats in a compute pass and rasterizes from a pre-projected cache, the AA factor is computed in the projector and **baked into the cached alpha** — so the hybrid vertex shader and the cache layout need no changes. The formula matches the quad renderer's `initCornerCov` exactly: `aaFactor = sqrt(detOrig / detBlur)`, the ratio of the pre-blur to post-blur 2D covariance determinant.

**Changes:**
- `compute-gsplat-common.js`: `computeSplatCov` keeps the raw (pre-blur) covariance diagonal and, under `#if GSPLAT_AA`, computes `aaFactor` into a new `SplatCov2D` field.
- `compute-gsplat-projector.js`: the non-pick color branch multiplies `alpha *= proj.aaFactor` under `#if GSPLAT_AA`.
- `gsplat-projector.js`: threads `antiAlias` through `_projectorKey` / `_createProjectorCompute` / `_getProjectorCompute` / `dispatch`, adding the `GSPLAT_AA` cdefine and an `Aa` variant suffix. The setting is read live each frame, so toggling takes effect on the next frame.
- `gsplat-manager.js`: passes `antiAlias: gsplat.antiAlias` into `projector.dispatch`.

AA is gated to **non-pick mode** (`aaMode = antiAlias && !pickMode`) since picking only gates on a binary opacity threshold — this keeps the projector variant count at 12 rather than 16.

This is the WebGPU-only path, so only WGSL chunks were touched; the GLSL quad path already had AA.

**Examples:**
- Added an "Anti-alias" toggle to the gsplat viewer example's Renderer panel, wired to `GSplatParams#antiAlias`.

**Notes for reviewers:**
- Minor behavioural nuance vs. the quad renderer: the projector's `opacity <= alphaClip` early-out runs against raw opacity *before* AA modulation, whereas the quad VS applies AA before its alpha discard. The fragment shader's `alpha < alphaClipForward` test still catches anything AA pushes below threshold, so the visible result matches.
- WGSL shader chunks are template strings (not compiled at build), so this carries code-review + lint verification. Worth a manual check in the viewer with the GPU-sort renderer selected.