### PR TITLE
fix(gsplat): sort worker ReferenceError after esbuild migration

### DIFF
--- a/src/scene/gsplat-unified/gsplat-sort-bin-weights.js
+++ b/src/scene/gsplat-unified/gsplat-sort-bin-weights.js
@@ -35,47 +35,24 @@ class GSplatSortBinWeights {
     }
 
     /**
-     * Pre-allocated interleaved array [base0, divider0, base1, divider1, ...].
-     *
-     * @type {Float32Array}
-     */
-    binWeights = new Float32Array(GSplatSortBinWeights.NUM_BINS * 2);
-
-    /**
-     * Pre-computed weight lookup table by distance from camera (constant).
-     *
-     * @type {Float32Array}
-     */
-    weightByDistance;
-
-    /**
-     * Pre-allocated scratch array for bits per bin calculation.
-     *
-     * @type {Float32Array}
-     */
-    bitsPerBin;
-
-    /**
-     * Cached cameraBin from last compute call.
-     */
-    lastCameraBin = -1;
-
-    /**
-     * Cached bucketCount from last compute call.
-     */
-    lastBucketCount = -1;
-
-    /**
      * Creates a new GSplatSortBinWeights instance.
+     *
+     * All instance state is assigned here rather than via class field declarations.
+     * This class is stringified into a Worker blob; with esbuild targeting es2020,
+     * class fields are transpiled into __publicField() helper calls whose helper
+     * isn't present in the worker scope, causing ReferenceError on construction.
      */
     constructor() {
         const numBins = GSplatSortBinWeights.NUM_BINS;
         const weightTiers = GSplatSortBinWeights.WEIGHT_TIERS;
 
-        // Pre-allocate scratch array
+        /** @type {Float32Array} Interleaved [base0, divider0, base1, divider1, ...]. */
+        this.binWeights = new Float32Array(numBins * 2);
+
+        /** @type {Float32Array} Scratch array for bits per bin calculation. */
         this.bitsPerBin = new Float32Array(numBins);
 
-        // Pre-compute weight lookup table by distance from camera (constant)
+        /** @type {Float32Array} Weight lookup table by distance from camera. */
         this.weightByDistance = new Float32Array(numBins);
         for (let dist = 0; dist < numBins; dist++) {
             let weight = 1.0;
@@ -87,6 +64,12 @@ class GSplatSortBinWeights {
             }
             this.weightByDistance[dist] = weight;
         }
+
+        /** Cached cameraBin from last compute call. */
+        this.lastCameraBin = -1;
+
+        /** Cached bucketCount from last compute call. */
+        this.lastBucketCount = -1;
     }
 
     /**


### PR DESCRIPTION
Fixes a worker crash on first gsplat sort in minified UMD/min builds — only the unified ESM rel build (`playcanvas.mjs`) escaped because it sets `preserveClassFields`.

`GSplatSortBinWeights` is stringified via `toString()` and injected into the unified sorter's Worker blob. With esbuild's `target: 'es2020'`, public class fields are transpiled into `__publicField()` helper calls (minified to `n`). The helper lives only in the main bundle, so when the class runs inside the worker the constructor throws `ReferenceError: n is not defined` on its first field assignment. This regressed after the rollup+swc → esbuild migration in #8722; swc had inlined the fields directly as `this.x = …`.

**Changes:**
- Move `binWeights`, `bitsPerBin`, `weightByDistance`, `lastCameraBin`, `lastBucketCount` from class field declarations into the constructor as plain `this.x = …` assignments — keeps the class self-contained when stringified.
- Add a constructor-doc note explaining the constraint so the next person doesn't reintroduce class fields here.

Fixes #8806.