### PR TITLE
fix(particle): null module-scope vars after construction to prevent memory leak

### DIFF
--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -326,6 +326,8 @@ class ParticleEmitter {
 
         setProperty('radialSpeedGraph', default0Curve);
         setProperty('radialSpeedGraph2', this.radialSpeedGraph);
+        setPropertyTarget = null;
+        setPropertyOptions = null;
 
         this.animTilesParams = new Float32Array(2);
         this.animParams = new Float32Array(4);


### PR DESCRIPTION
## Description

The module-scope variables `setPropertyTarget` and `setPropertyOptions` are used as scratch variables in the ParticleEmitter constructor, but it does not set them to null after using them. This causes a large memory leak in SPA apps because the garbage collector does not free the ParticleEmitter (assigned to `setPropertyTarget`), which has a reference to `graphicsDevice`, which adds up to 100+ MB per navigation in my testing.

## Changes
Null `setPropertyOptions` and `setPropertyTarget` immediately after we are finished using them in the constructor.

## Testing
I tested this fix by comparing heap snapshots after a SPA page navigation in a production app, and the change fixed the memory leak. Before the change, the previous page's ParticleEmitter was retained via setPropertyTarget and the SourceTextModule.

Related to #7674

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
