### PR TITLE
docs: replace opaque any/* types with real types in API reference

### DIFF
--- a/src/extras/input/input.js
+++ b/src/extras/input/input.js
@@ -216,7 +216,6 @@ class InputConsumer {
     /**
      * @param {InputFrame} frame - The input frame.
      * @param {number} dt - The delta time.
-     * @returns {any} - The controller pose.
      */
     update(frame, dt) {
         // discard frame by default

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -514,7 +514,7 @@ class RenderTarget {
     /**
      * Accessor for multiple render target color buffers.
      *
-     * @param {*} index - Index of the color buffer to get.
+     * @param {number} index - Index of the color buffer to get.
      * @returns {Texture} - Color buffer at the specified index.
      */
     getColorBuffer(index) {


### PR DESCRIPTION
## Description

Two public, reference-visible members documented their JSDoc types as the opaque `*`/`any`, which renders as a meaningless `any` in the generated TypeDoc [API reference](https://api.playcanvas.com/engine/). This replaces them with accurate types:

- **`RenderTarget.getColorBuffer(index)`** — `index` is an array index, typed `{*}` → `{number}`.
- **`InputConsumer.update()`** — the base method discards the frame and returns nothing, so the bogus `@returns {any}` is dropped (per the engine convention of omitting `@returns` when nothing is returned). The `InputController` subclass override already documents its `{Pose}` return.

After the change the generated declarations read `getColorBuffer(index: number): Texture`, `InputConsumer.update(...): void`, and `InputController.update(...): Pose`; the rendered `RenderTarget` page drops from 2 → 0 `any` tokens.

### Scope note for reviewers

This is a deliberately small, surgical change. A wider audit of `@param {*}`/`{any}` usage (~100 hits across 37 files) found that the large majority sit on `@private`/`@ignore` members that are excluded from the reference (`excludePrivate` defaults to `true`), or are legitimately dynamic public APIs (`EventHandler` event args, `Http` response payloads, `Asset.resource`, uniform values) where `any` is the correct type. These were the only public, reference-visible members whose type was genuinely recoverable.

### Verification
- `npm run lint` ✅
- `npm run build:types` ✅
- `npm run test:types` ✅
- `npm run docs` — 0 errors ✅

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)