### PR TITLE
docs: fix @param names/types that contradict the function signatures

### DIFF
--- a/src/framework/xr/xr-views.js
+++ b/src/framework/xr/xr-views.js
@@ -212,7 +212,7 @@ class XrViews extends EventHandler {
 
     /**
      * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
-     * @param {XRView} xrView - XRView from WebXR API.
+     * @param {XRView[]} xrViews - XRViews from the WebXR API.
      * @ignore
      */
     update(frame, xrViews) {

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -139,7 +139,7 @@ class WebgpuXrBridge {
     }
 
     /**
-     * @param {XRFrame} frame - Current XR frame.
+     * @param {XRFrame} _frame - Current XR frame.
      * @param {Vec2} out - Width in {@link Vec2#x}, height in {@link Vec2#y}.
      */
     getFramebufferSize(_frame, out) {
@@ -160,7 +160,7 @@ class WebgpuXrBridge {
     }
 
     /**
-     * @param {XRFrame} frame - Current XR frame.
+     * @param {XRFrame} _frame - Current XR frame.
      * @param {XRView} xrView - WebXR view.
      * @returns {XRViewport} Viewport for this view, or zeros if unavailable.
      */

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -283,8 +283,8 @@ class Morph extends RefCountedObject {
      *
      * @param {string} name - The name of the texture.
      * @param {number} format - The format of the texture.
-     * @param {Array} [levels] - The levels of the texture.
      * @param {number} [arrayLength] - The length of the texture array.
+     * @param {Array} [levels] - The levels of the texture.
      * @returns {Texture} The created texture.
      * @private
      */


### PR DESCRIPTION
## Description

Four JSDoc `@param` blocks documented parameter names (and in two cases types) that don't match the actual function signatures, so the [API reference](https://api.playcanvas.com/engine/) and the emitted `.d.ts` describe the wrong thing. Surfaced by enabling `jsdoc/check-param-names` (currently `off` in `@playcanvas/eslint-config`).

- **`Morph._createTexture`** — documented `levels` before `arrayLength`, but the signature is `(name, format, arrayLength, levels)`, so the two types were **swapped** (`arrayLength` shown as `{Array}`, `levels` as `{number}`). Reordered to match.
- **`XrViews.update`** — documented `xrView` typed `{XRView}`; the parameter is `xrViews` and is iterated as an array, so corrected to `{XRView[]} xrViews`.
- **`WebgpuXrBridge.getFramebufferSize` / `getViewport`** — documented `frame`; the parameter is the intentionally-unused `_frame`. Matched the docs to the real name.

### How these were found
Ran `eslint src --rule '{"jsdoc/check-param-names":"error"}'` as a one-off discovery pass; these were the only 4 mismatches in `src`.

### Verification
- `jsdoc/check-param-names`: 0 mismatches remaining (was 4) ✅
- `npm run lint` ✅
- `npm run build:types` + `npm run test:types` ✅ (the `morph.js` reorder corrects the emitted `.d.ts` param types)

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)