### PR TITLE
Move test fixture server off port 3000 and use relative asset URLs

### DIFF
--- a/test/assets/sprites/red-sprite.json
+++ b/test/assets/sprites/red-sprite.json
@@ -1,6 +1,6 @@
 {
     "renderMode": 0,
     "pixelsPerUnit": 100,
-    "textureAtlasAsset": "http://localhost:3000/test/assets/sprites/red-atlas.json",
+    "textureAtlasAsset": "/test/assets/sprites/red-atlas.json",
     "frameKeys": [0]
 }

--- a/test/fixtures.mjs
+++ b/test/fixtures.mjs
@@ -16,8 +16,8 @@ export const mochaGlobalSetup = () => {
         return handler(request, response);
     });
 
-    server.listen(3000, () => {
-        console.log('Server started at http://localhost:3000');
+    server.listen(3210, () => {
+        console.log('Server started at http://localhost:3210');
     });
 };
 

--- a/test/fixtures.mjs
+++ b/test/fixtures.mjs
@@ -16,8 +16,13 @@ export const mochaGlobalSetup = () => {
         return handler(request, response);
     });
 
-    server.listen(3210, () => {
-        console.log('Server started at http://localhost:3210');
+    // Return a Promise so Mocha waits for the server to be listening before any test
+    // issues a request, avoiding a startup race against the first XHR.
+    return new Promise((resolve) => {
+        server.listen(3210, () => {
+            console.log('Server started at http://localhost:3210');
+            resolve();
+        });
     });
 };
 

--- a/test/framework/asset/asset-list-loader.test.mjs
+++ b/test/framework/asset/asset-list-loader.test.mjs
@@ -8,7 +8,7 @@ import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 describe('AssetListLoader', function () {
 
     let app;
-    const assetPath = 'http://localhost:3000/test/assets/';
+    const assetPath = '/test/assets/';
 
     beforeEach(function () {
         jsdomSetup();

--- a/test/framework/asset/asset-registry.test.mjs
+++ b/test/framework/asset/asset-registry.test.mjs
@@ -239,7 +239,7 @@ describe('AssetRegistry', function () {
 
     describe('#loadFromUrl', function () {
 
-        const assetPath = 'http://localhost:3000/test/assets/';
+        const assetPath = '/test/assets/';
 
         it('loads binary assets', (done) => {
             app.assets.loadFromUrl(`${assetPath}test.bin`, 'binary', (err, asset) => {

--- a/test/framework/components/animation/component.test.mjs
+++ b/test/framework/components/animation/component.test.mjs
@@ -29,10 +29,10 @@ describe('AnimationComponent', function () {
     const loadAssets = function (cb) {
         const assetlist = [
             new Asset('cube.json', 'model', {
-                url: 'http://localhost:3000/test/assets/cube/cube.json'
+                url: '/test/assets/cube/cube.json'
             }),
             new Asset('cube.animation.json', 'animation', {
-                url: 'http://localhost:3000/test/assets/cube/cube.animation.json'
+                url: '/test/assets/cube/cube.animation.json'
             })
         ];
         assets.model = assetlist[0];

--- a/test/framework/components/element/image-element.test.mjs
+++ b/test/framework/components/element/image-element.test.mjs
@@ -62,20 +62,20 @@ describe('ImageElement', function () {
         // load atlas first so that sprite is set up with out waiting for next frame
         const assetsToPreload = [
             new Asset('red-atlas', 'textureatlas', {
-                url: 'http://localhost:3000/test/assets/sprites/red-atlas.json'
+                url: '/test/assets/sprites/red-atlas.json'
             })
         ];
 
         // list of assets to load
         const assetsToLoad = [
             new Asset('red-sprite', 'sprite', {
-                url: 'http://localhost:3000/test/assets/sprites/red-sprite.json'
+                url: '/test/assets/sprites/red-sprite.json'
             }),
             new Asset('red-texture', 'texture', {
-                url: 'http://localhost:3000/test/assets/sprites/red-atlas.png'
+                url: '/test/assets/sprites/red-atlas.png'
             }),
             new Asset('red-material', 'material', {
-                url: 'http://localhost:3000/test/assets/sprites/red-material.json'
+                url: '/test/assets/sprites/red-material.json'
             })
         ];
 
@@ -1005,10 +1005,10 @@ describe('ImageElement', function () {
         });
 
         const spriteAsset = new Asset('red-sprite', 'sprite', {
-            url: 'http://localhost:3000/test/assets/sprites/red-sprite.json'
+            url: '/test/assets/sprites/red-sprite.json'
         });
         const textureAtlasAsset = new Asset('red-texture', 'texture', {
-            url: 'http://localhost:3000/test/assets/sprites/red-atlas.json'
+            url: '/test/assets/sprites/red-atlas.json'
         });
 
         if (spriteAsset.resource) {

--- a/test/framework/components/element/text-element.test.mjs
+++ b/test/framework/components/element/text-element.test.mjs
@@ -44,7 +44,7 @@ describe('TextElement', function () {
         element.width = 200;
 
         fontAsset = new Asset('arial.json', 'font', {
-            url: 'http://localhost:3000/test/assets/fonts/arial.json'
+            url: '/test/assets/fonts/arial.json'
         });
 
         fontAsset.ready(function () {
@@ -1507,7 +1507,7 @@ describe('TextElement', function () {
 
     it('changing the locale changes the font asset', function (done) {
         assets.font2 = new Asset('courier.json', 'font', {
-            url: 'http://localhost:3000/test/assets/fonts/courier.json'
+            url: '/test/assets/fonts/courier.json'
         });
 
         app.assets.add(assets.font2);
@@ -1532,7 +1532,7 @@ describe('TextElement', function () {
 
     it('text element that does not use localization uses the default font asset not its localized variant', function (done) {
         assets.font2 = new Asset('courier.json', 'font', {
-            url: 'http://localhost:3000/test/assets/fonts/courier.json'
+            url: '/test/assets/fonts/courier.json'
         });
 
         app.assets.add(assets.font2);
@@ -1554,7 +1554,7 @@ describe('TextElement', function () {
 
     it('if text element is disabled it does not automatically load localizedAssets', function () {
         assets.font2 = new Asset('courier.json', 'font', {
-            url: 'http://localhost:3000/test/assets/fonts/courier.json'
+            url: '/test/assets/fonts/courier.json'
         });
 
         app.assets.add(assets.font2);

--- a/test/framework/components/model/component.test.mjs
+++ b/test/framework/components/model/component.test.mjs
@@ -30,10 +30,10 @@ describe('ModelComponent', function () {
     const loadAssets = function (cb) {
         const assetlist = [
             new Asset('plane.json', 'model', {
-                url: 'http://localhost:3000/test/assets/plane/plane.json'
+                url: '/test/assets/plane/plane.json'
             }),
             new Asset('lambert1.json', 'material', {
-                url: 'http://localhost:3000/test/assets/plane/31208636/lambert1.json'
+                url: '/test/assets/plane/31208636/lambert1.json'
             })
         ];
 
@@ -257,7 +257,7 @@ describe('ModelComponent', function () {
 
     it('Materials applied when loading asynchronously', (done) => {
         const boxAsset = new Asset('Box', 'model', {
-            url: 'http://localhost:3000/test/assets/cube/cube.json'
+            url: '/test/assets/cube/cube.json'
         }, {
             'mapping': [
                 {
@@ -268,7 +268,7 @@ describe('ModelComponent', function () {
         });
 
         const materialAsset = new Asset('Material', 'material', {
-            url: 'http://localhost:3000/test/assets/cube/208808876/Material.json'
+            url: '/test/assets/cube/208808876/Material.json'
         });
 
         app.assets.add(boxAsset);
@@ -291,11 +291,11 @@ describe('ModelComponent', function () {
 
     it('Materials applied when added later', (done) => {
         const boxAsset = new Asset('Box', 'model', {
-            url: 'http://localhost:3000/test/assets/cube/cube.json'
+            url: '/test/assets/cube/cube.json'
         });
 
         const materialAsset = new Asset('Box Material', 'material', {
-            url: 'http://localhost:3000/test/assets/cube/208808876/Material.json'
+            url: '/test/assets/cube/208808876/Material.json'
         });
 
         app.assets.add(boxAsset);
@@ -328,11 +328,11 @@ describe('ModelComponent', function () {
 
     it('Material add events unbound on destroy', (done) => {
         const boxAsset = new Asset('Box', 'model', {
-            url: 'http://localhost:3000/test/assets/cube/cube.json'
+            url: '/test/assets/cube/cube.json'
         });
 
         const materialAsset = new Asset('Box Material', 'material', {
-            url: 'http://localhost:3000/test/assets/cube/208808876/Material.json'
+            url: '/test/assets/cube/208808876/Material.json'
         });
 
         app.assets.add(boxAsset);
@@ -376,7 +376,7 @@ describe('ModelComponent', function () {
 
     it('Asset materials unbound on destroy', (done) => {
         const modelAsset = new Asset('cube.json', 'model', {
-            url: 'http://localhost:3000/test/assets/cube/cube.json'
+            url: '/test/assets/cube/cube.json'
         }, {
             mapping: [{
                 material: assets.material.id
@@ -404,7 +404,7 @@ describe('ModelComponent', function () {
 
     it('Asset materials unbound on change model', (done) => {
         const modelAsset = new Asset('plane.json', 'model', {
-            url: 'http://localhost:3000/test/assets/plane/plane.json'
+            url: '/test/assets/plane/plane.json'
         }, {
             mapping: [{
                 material: assets.material.id
@@ -412,10 +412,10 @@ describe('ModelComponent', function () {
         });
 
         const materialAsset2 = new Asset('lambert2.json', 'material', {
-            url: 'http://localhost:3000/test/assets/plane/31208636/lambert1.json?t=1'
+            url: '/test/assets/plane/31208636/lambert1.json?t=1'
         });
         const modelAsset2 = new Asset('plane2.json', 'model', {
-            url: 'http://localhost:3000/test/assets/plane/plane.json?t=1'
+            url: '/test/assets/plane/plane.json?t=1'
         }, {
             mapping: [{
                 material: materialAsset2.id

--- a/test/framework/components/particlesystem/component.test.mjs
+++ b/test/framework/components/particlesystem/component.test.mjs
@@ -13,15 +13,15 @@ describe('ParticleSystemComponent', function () {
     const loadAssets = function (cb) {
         const assetList = [
             new Asset('Box', 'model', {
-                url: 'http://localhost:3000/test/assets/cube/cube.json'
+                url: '/test/assets/cube/cube.json'
             }),
             new Asset('ColorMap', 'texture', {
-                url: 'http://localhost:3000/test/assets/test.png'
+                url: '/test/assets/test.png'
             }, {
                 srgb: true
             }),
             new Asset('NormalMap', 'texture', {
-                url: 'http://localhost:3000/test/assets/test.png'
+                url: '/test/assets/test.png'
             })
         ];
         const loader = new AssetListLoader(assetList, app.assets);

--- a/test/framework/components/script/component.test.mjs
+++ b/test/framework/components/script/component.test.mjs
@@ -21,14 +21,14 @@ describe('ScriptComponent', function () {
         window.initializeCalls = [];
 
         const assets = scripts.map(script => new Asset(`${script}.js`, 'script', {
-            url: `http://localhost:3000/test/assets/scripts/${script}.js`
+            url: `/test/assets/scripts/${script}.js`
         }));
         assets.forEach((asset) => {
             asset.preload = asset.name !== 'loadedLater.js';
             app.assets.add(asset);
         });
         app.preload(function () {
-            app.scenes.loadScene('http://localhost:3000/test/assets/scenes/scene1.json', function () {
+            app.scenes.loadScene('/test/assets/scenes/scene1.json', function () {
                 app.start();
                 done();
             });
@@ -783,7 +783,7 @@ describe('ScriptComponent', function () {
             expect(app.root.findByName(name)).to.not.exist;
         });
 
-        app.loadSceneHierarchy('http://localhost:3000/test/assets/scenes/scene1.json', function () {
+        app.loadSceneHierarchy('/test/assets/scenes/scene1.json', function () {
 
             // verify entities are loaded
             names.forEach(function (name) {
@@ -1662,7 +1662,7 @@ describe('ScriptComponent', function () {
         app.root.children[0].destroy();
 
         window.initializeCalls.length = 0;
-        app.scenes.loadScene('http://localhost:3000/test/assets/scenes/scene2.json', function () {
+        app.scenes.loadScene('/test/assets/scenes/scene2.json', function () {
             const e = app.root.findByName('A');
             const other = app.root.findByName('B');
 
@@ -1782,7 +1782,7 @@ describe('ScriptComponent', function () {
         app.root.children[0].destroy();
 
         // load scene
-        app.loadSceneHierarchy('http://localhost:3000/test/assets/scenes/scene3.json', function () {
+        app.loadSceneHierarchy('/test/assets/scenes/scene3.json', function () {
             window.initializeCalls.length = 0;
             app.update();
 

--- a/test/framework/components/sprite/component.test.mjs
+++ b/test/framework/components/sprite/component.test.mjs
@@ -23,15 +23,15 @@ describe('SpriteComponent', function () {
         };
 
         atlasAsset = new Asset('red-atlas', 'textureatlas', {
-            url: 'http://localhost:3000/test/assets/sprites/red-atlas.json'
+            url: '/test/assets/sprites/red-atlas.json'
         });
 
         spriteAsset = new Asset('red-sprite', 'sprite', {
-            url: 'http://localhost:3000/test/assets/sprites/red-sprite.json'
+            url: '/test/assets/sprites/red-sprite.json'
         });
 
         spriteAsset2 = new Asset('red-sprite-2', 'sprite', {
-            url: 'http://localhost:3000/test/assets/sprites/red-sprite.json'
+            url: '/test/assets/sprites/red-sprite.json'
         });
 
         app.assets.add(atlasAsset);

--- a/test/framework/handlers/bundle-hander.test.mjs
+++ b/test/framework/handlers/bundle-hander.test.mjs
@@ -52,7 +52,7 @@ describe('BundleHandler', function () {
         // the bundle asset (created by calling tar in the root folder of the repo):
         // tar cvf test.tar test\assets\test.bin test\assets\test.css test\assets\test.glb test\assets\test.glsl test\assets\test.html test\assets\test.json test\assets\test.txt
         bundleAsset = new Asset('bundle asset', 'bundle', {
-            url: 'http://localhost:3000/test/assets/test.tar',
+            url: 'http://localhost:3210/test/assets/test.tar',
             size: 9728
         }, {
             assets: assets.map(function (asset) {
@@ -195,7 +195,7 @@ describe('BundleHandler', function () {
 
     it('asset loading should prefer smallest bundle', function (done) {
         const bundleAsset2 = new Asset('bundle asset 2', 'bundle', {
-            url: 'http://localhost:3000/test/assets/test.tar',
+            url: 'http://localhost:3210/test/assets/test.tar',
             size: 9728 + 1
         }, {
             assets: assets.map(function (asset) {
@@ -219,7 +219,7 @@ describe('BundleHandler', function () {
 
     it('asset loading with bundlesFilter', function (done) {
         const bundleAsset2 = new Asset('bundle asset 2', 'bundle', {
-            url: 'http://localhost:3000/test/assets/test.tar',
+            url: 'http://localhost:3210/test/assets/test.tar',
             size: 133632 + 1
         }, {
             assets: assets.map(function (asset) {

--- a/test/framework/handlers/sprite-handler.test.mjs
+++ b/test/framework/handlers/sprite-handler.test.mjs
@@ -22,11 +22,11 @@ describe('SpriteHandler', function () {
     it('loads from filesystem', function (done) {
 
         const atlasAsset = new Asset('Red Atlas', 'textureatlas', {
-            url: 'http://localhost:3000/test/assets/sprites/red-atlas.json'
+            url: '/test/assets/sprites/red-atlas.json'
         });
 
         const spriteAsset = new Asset('Red Sprite', 'sprite', {
-            url: 'http://localhost:3000/test/assets/sprites/red-sprite.json'
+            url: '/test/assets/sprites/red-sprite.json'
         });
 
         app.assets.add(atlasAsset);
@@ -62,7 +62,7 @@ describe('SpriteHandler', function () {
 
     it('loads from asset data', function (done) {
         const atlasAsset = new Asset('Red Atlas', 'textureatlas', {
-            url: 'http://localhost:3000/test/assets/sprites/red-atlas.json'
+            url: '/test/assets/sprites/red-atlas.json'
         });
 
         const spriteAsset = new Asset('Red Sprite', 'sprite', null, {

--- a/test/framework/parsers/sog.test.mjs
+++ b/test/framework/parsers/sog.test.mjs
@@ -7,7 +7,7 @@ import { http } from '../../../src/platform/net/http.js';
 import { createApp } from '../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
-const BASE_URL = 'http://localhost:3000/static/';
+const BASE_URL = 'http://localhost:3210/static/';
 const META_URL = 'assets/splats/meta.json';
 const META = {
     version: 2,
@@ -77,11 +77,11 @@ describe('SogParser', function () {
             expect(err).to.equal(null);
             expect(resource).to.equal(null);
             expect(urls).to.deep.equal([
-                'http://localhost:3000/static/assets/splats/means_l.webp',
-                'http://localhost:3000/static/assets/splats/means_u.webp',
-                'http://localhost:3000/static/assets/splats/quats.webp',
-                'http://localhost:3000/static/assets/splats/scales.webp',
-                'http://localhost:3000/static/assets/splats/sh0.webp'
+                'http://localhost:3210/static/assets/splats/means_l.webp',
+                'http://localhost:3210/static/assets/splats/means_u.webp',
+                'http://localhost:3210/static/assets/splats/quats.webp',
+                'http://localhost:3210/static/assets/splats/scales.webp',
+                'http://localhost:3210/static/assets/splats/sh0.webp'
             ]);
             done();
         }, sog);

--- a/test/framework/scene-registry.test.mjs
+++ b/test/framework/scene-registry.test.mjs
@@ -114,7 +114,7 @@ describe('SceneRegistry', function () {
 
     describe('#loadSceneData', function () {
 
-        const assetPath = 'http://localhost:3000/test/assets/';
+        const assetPath = '/test/assets/';
 
         it('load and cache, check data is valid, unload data, check data is removed with SceneItem', async () => {
             const registry = new SceneRegistry(app);

--- a/test/jsdom.mjs
+++ b/test/jsdom.mjs
@@ -10,7 +10,7 @@ export const jsdomSetup = () => {
     jsdom = new JSDOM(html, {
         resources: 'usable',         // Allow the engine to load assets
         runScripts: 'dangerously',   // Allow the engine to run scripts
-        url: 'http://localhost:3000' // Set the URL of the document
+        url: 'http://localhost:3210' // Set the URL of the document
     });
 
     // Copy the window and document to global scope

--- a/test/platform/net/http.test.mjs
+++ b/test/platform/net/http.test.mjs
@@ -3,11 +3,17 @@ import nise from 'nise';
 import { restore, spy } from 'sinon';
 
 import { http, Http } from '../../../src/platform/net/http.js';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
 describe('Http', function () {
     let retryDelay;
 
     beforeEach(function () {
+        // Set up a JSDOM document so global.XMLHttpRequest exists and root-relative
+        // request URLs resolve against the fixture server's origin, independent of
+        // whether any other test file ran jsdomSetup() first.
+        jsdomSetup();
+
         retryDelay = Http.retryDelay;
         Http.retryDelay = 1;
     });
@@ -15,6 +21,7 @@ describe('Http', function () {
     afterEach(function () {
         Http.retryDelay = retryDelay;
         restore();
+        jsdomTeardown();
     });
 
     describe('#get()', function () {

--- a/test/platform/net/http.test.mjs
+++ b/test/platform/net/http.test.mjs
@@ -20,7 +20,7 @@ describe('Http', function () {
     describe('#get()', function () {
 
         it('returns resource', (done) => {
-            http.get('http://localhost:3000/test/assets/test.json', (err, data) => {
+            http.get('/test/assets/test.json', (err, data) => {
                 expect(err).to.equal(null);
                 expect(data).to.deep.equal({
                     a: 1,
@@ -33,7 +33,7 @@ describe('Http', function () {
 
         it('does not retry if retry is false', (done) => {
             spy(http, 'request');
-            http.get('http://localhost:3000/someurl.json', (err, data) => {
+            http.get('/someurl.json', (err, data) => {
                 expect(err).to.equal(404);
                 expect(http.request.callCount).to.equal(1);
                 done();
@@ -42,7 +42,7 @@ describe('Http', function () {
 
         it('retries resource and returns 404 in the end if not found', (done) => {
             spy(http, 'request');
-            http.get('http://localhost:3000/someurl.json', {
+            http.get('/someurl.json', {
                 retry: true,
                 maxRetries: 2
             }, (err) => {
@@ -54,7 +54,7 @@ describe('Http', function () {
 
         it('retries resource 5 times by default', (done) => {
             spy(http, 'request');
-            http.get('http://localhost:3000/someurl.json', {
+            http.get('/someurl.json', {
                 retry: true
             }, (err) => {
                 expect(http.request.callCount).to.equal(6);


### PR DESCRIPTION
Engine tests started their fixture HTTP server on port 3000, colliding with the developer-site Docusaurus dev server (also default 3000) when both run together.

**Changes:**
- Move the test fixture server from port 3000 to 3210 (`test/fixtures.mjs`) and update the JSDOM document base URL to match (`test/jsdom.mjs`)
- Convert hardcoded `http://localhost:3000/...` asset URLs across the test suite to root-relative paths (`/test/assets/...`), which resolve against the JSDOM document base via `XMLHttpRequest` — removing the hardcoded host/port from individual tests
- Keep absolute URLs only where required: the bundle `.tar` URLs (BundleHandler uses global `fetch()`, which rejects relative URLs), and `sog.test.mjs` (deliberately tests absolute resolution against a `<base href>`)

**Test robustness improvements (from review):**
- `test/fixtures.mjs`: `mochaGlobalSetup` now returns a Promise that resolves on the server's `listening` callback, so Mocha waits for the server to be ready before any test issues a request (avoids a startup race)
- `test/platform/net/http.test.mjs`: now sets up its own JSDOM document via `jsdomSetup()`/`jsdomTeardown()`, so `global.XMLHttpRequest` exists and its root-relative request URLs resolve regardless of test execution order — the file is now runnable in isolation

Test-only change; no public API impact. Full suite passes (1734 passing, 2 pending).