### PR TITLE
feat(examples): download example as a standalone Vite project

### DIFF
--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -11,6 +11,7 @@ import { ErrorBoundary } from './ErrorBoundary.mjs';
 import { SelectInput as OverlaySelectInput } from './OverlaySelectInput.mjs';
 import { COLOR_NAMES, INLINE_MD_PATTERN, SAFE_URL_PATTERN } from '../../../utils/inline-markdown.mjs';
 import { CLOSE_SELECTS_EVENT } from '../constants.mjs';
+import { setExampleSnapshotProvider } from '../example-snapshot.mjs';
 import { iframe } from '../iframe.mjs';
 import { jsx, fragment } from '../jsx.mjs';
 import { iframePath } from '../paths.mjs';
@@ -496,8 +497,27 @@ class Example extends TypedComponent {
         controlPanelHeader.onclick = () => this.toggleCollapse();
     }
 
+    /**
+     * Captures the example's current control overrides as a flat dot-path map — the same state the
+     * share feature persists — so the exported project can replay it after the example loads.
+     *
+     * @returns {Record<string, any>} The flattened control state.
+     */
+    _captureControls() {
+        /** @type {Record<string, any>} */
+        const flat = {};
+        flattenLeaves(readState().controls ?? {}, '', flat);
+        return flat;
+    }
+
     componentDidMount() {
         this.setupControlPanel();
+        setExampleSnapshotProvider(() => ({
+            files: this.state.files,
+            category: this.props.match.params.category,
+            example: this.props.match.params.example,
+            data: this._captureControls()
+        }));
         window.addEventListener('resize', this._onLayoutChange);
         window.addEventListener('requestedFiles', this._handleRequestedFiles);
         window.addEventListener('orientationchange', this._onLayoutChange);
@@ -524,6 +544,7 @@ class Example extends TypedComponent {
     }
 
     componentWillUnmount() {
+        setExampleSnapshotProvider(null);
         window.dispatchEvent(new Event(CLOSE_SELECTS_EVENT));
         this.bindObserver(null);
         this._controlPanelScrollRegion?.removeEventListener('scroll', this._handleControlPanelScroll);

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -516,7 +516,8 @@ class Example extends TypedComponent {
             files: this.state.files,
             category: this.props.match.params.category,
             example: this.props.match.params.example,
-            data: this._captureControls()
+            data: this._captureControls(),
+            credits: this.state.credits
         }));
         window.addEventListener('resize', this._onLayoutChange);
         window.addEventListener('requestedFiles', this._handleRequestedFiles);

--- a/examples/src/app/components/code-editor/CodeEditorBase.mjs
+++ b/examples/src/app/components/code-editor/CodeEditorBase.mjs
@@ -63,6 +63,7 @@ function getShowMinimap() {
  * @property {Record<string, string>} files - The example files.
  * @property {string} selectedFile - The selected file.
  * @property {boolean} showMinimap - The state of showing the Minimap
+ * @property {boolean} [downloading] - True while a standalone Vite project is being built.
  */
 
 /** @type {typeof Component<Props, State>} */

--- a/examples/src/app/components/code-editor/CodeEditorDesktop.mjs
+++ b/examples/src/app/components/code-editor/CodeEditorDesktop.mjs
@@ -2,6 +2,7 @@ import MonacoEditor, { loader } from '@monaco-editor/react';
 import { Button, Container, Panel } from '@playcanvas/pcui/react';
 
 import { CodeEditorBase } from './CodeEditorBase.mjs';
+import { downloadExampleProject } from '../../download-project.mjs';
 import { iframe } from '../../iframe.mjs';
 import { jsx } from '../../jsx.mjs';
 import { scriptsPath } from '../../paths.mjs';
@@ -17,6 +18,18 @@ import { getHashPath, getSelectedFile, patchState, readState } from '../../url-s
  */
 
 loader.config({ paths: { vs: './modules/monaco-editor/min/vs' } });
+
+/**
+ * @param {() => Promise<any>} task - Async task.
+ * @returns {Promise<[any, any]>} Error and result tuple.
+ */
+const tryCatchAsync = async (task) => {
+    try {
+        return [null, await task()];
+    } catch (err) {
+        return [err, null];
+    }
+};
 
 function getShowMinimap() {
     let showMinimap = true;
@@ -98,6 +111,19 @@ class CodeEditorDesktop extends CodeEditorBase {
         this._handleExampleHotReload = this._handleExampleHotReload.bind(this);
         this._handleExampleError = this._handleExampleError.bind(this);
         this._handleRequestedFiles = this._handleRequestedFiles.bind(this);
+        this._onDownload = this._onDownload.bind(this);
+    }
+
+    async _onDownload() {
+        if (this.state.downloading) {
+            return;
+        }
+        this.setState({ downloading: true });
+        const [err] = await tryCatchAsync(downloadExampleProject);
+        if (err) {
+            console.error('Failed to download Vite project', err);
+        }
+        this.setState({ downloading: false });
     }
 
     /**
@@ -535,7 +561,29 @@ class CodeEditorDesktop extends CodeEditorBase {
                                 `https://github.com/playcanvas/engine/blob/main/examples/src/examples/${examplePath}.example.mjs`
                             );
                         }
-                    })
+                    }),
+                    jsx('button', {
+                        type: 'button',
+                        className: 'pcui-button code-editor-download',
+                        'aria-label': 'Download as Vite project',
+                        disabled: this.state.downloading,
+                        onClick: this._onDownload
+                    }, jsx('svg', {
+                        viewBox: '0 0 24 24',
+                        fill: 'none',
+                        stroke: 'currentColor',
+                        strokeWidth: 2,
+                        strokeLinecap: 'round',
+                        strokeLinejoin: 'round',
+                        width: 14,
+                        height: 14
+                    },
+                    jsx('path', { d: 'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4' }),
+                    jsx('polyline', { points: '7 10 12 15 17 10' }),
+                    jsx('line', { x1: 12, y1: 15, x2: 12, y2: 3 })
+                    ), jsx('span', {
+                        className: 'code-editor-download-label'
+                    }, this.state.downloading ? 'Preparing…' : 'Download'))
                 ),
                 jsx(
                     Container,

--- a/examples/src/app/download-project.mjs
+++ b/examples/src/app/download-project.mjs
@@ -1,0 +1,322 @@
+import { zipSync, strToU8 } from 'fflate';
+
+import { VERSION } from './constants.mjs';
+import { getExampleSnapshot } from './example-snapshot.mjs';
+import { readState } from './url-state.mjs';
+
+// matches the module specifier of `from '...'`, side-effect `import '...'`, and dynamic `import('...')`
+const IMPORT_RE = /(\b(?:from|import)[\s(]*)(['"])([^'"\n]+)\2/g;
+
+// matches runtime asset url string literals like './assets/x.glb' or '/scripts/y.js'
+const ASSET_RE = /['"`](\.?\/(?:assets|scripts)\/[\w./-]+)['"`]/g;
+
+// files imported for their raw text contents (mirrors the iframe runtime's blob behaviour)
+const RAW_EXT = /\.(?:vert|frag|wgsl|glsl|html|css|txt)$/;
+
+// the `// @config` comment block (browser-safe copy of utils/example-source.mjs configRegex)
+const CONFIG_RE = /^[ \t]*\/\/ @config[ \t]*(?:\r?\n[ \t]*\/\/[^\r\n]*)*(?:\r?\n|$)/gm;
+
+const STATIC_BASE = '/static';
+
+// install the newest published release; the exact dev/beta version the site runs is often unpublished
+const PC_RANGE = 'latest';
+
+const OBSERVER_VERSION = '1.7.1';
+const VITE_VERSION = '8.0.14';
+
+/**
+ * @param {string} spec - Import specifier.
+ * @param {Set<string>} vendored - Collects relative asset-module paths to vendor (e.g. 'assets/scripts/misc/x.mjs').
+ * @returns {string} Rewritten specifier.
+ */
+const rewriteSpec = (spec, vendored) => {
+    if (spec === 'examples/context') {
+        return './context.mjs';
+    }
+    if (spec.startsWith('examples/assets/')) {
+        const rel = spec.slice('examples/'.length);
+        if (/\.(?:mjs|js)$/.test(rel)) {
+            vendored.add(rel);
+        }
+        return `./${rel}`;
+    }
+    if (/^\.{1,2}\//.test(spec) && RAW_EXT.test(spec.split('?')[0])) {
+        return `${spec}?raw`;
+    }
+    return spec;
+};
+
+/**
+ * @param {string} source - Module source.
+ * @param {Set<string>} vendored - Collects asset-module paths to vendor.
+ * @returns {string} Source with import specifiers rewritten for a standalone project.
+ */
+const rewriteImports = (source, vendored) => source.replace(IMPORT_RE, (m, pre, q, spec) => {
+    const next = rewriteSpec(spec, vendored);
+    return next === spec ? m : `${pre}${q}${next}${q}`;
+});
+
+/**
+ * Strips the @config block then trims leading blank lines (mirrors build-examples.mjs transformSource).
+ *
+ * @param {string} source - The example source.
+ * @returns {string} The transformed source.
+ */
+const transformSource = source => source.replace(CONFIG_RE, '').replace(/^(?:[ \t]*\r?\n)+/, '');
+
+/**
+ * @param {string[]} sources - Source strings to scan.
+ * @returns {{ urls: string[], dynamic: string[] }} Static asset urls (normalised to '/assets/..') and dynamic-dir prefixes.
+ */
+const scanAssetUrls = (sources) => {
+    const urls = new Set();
+    const dynamic = new Set();
+    for (const src of sources) {
+        if (!src) {
+            continue;
+        }
+        for (const [, raw] of src.matchAll(ASSET_RE)) {
+            const u = raw.replace(/^\.?\//, '/');
+            const last = u.slice(u.lastIndexOf('/') + 1);
+            // no extension on the final segment -> likely a directory used to build urls dynamically
+            if (!last.includes('.')) {
+                dynamic.add(u);
+                continue;
+            }
+            urls.add(u);
+        }
+    }
+    return { urls: [...urls], dynamic: [...dynamic] };
+};
+
+// mirrors the example's runtime context (examples/context): an empty observer the example seeds itself
+/**
+ * @param {string} deviceType - Graphics device type.
+ * @returns {string} The context shim source.
+ */
+const renderContextShim = deviceType => /* javascript */ `import { Observer } from '@playcanvas/observer';
+
+export const data = new Observer({});
+export const deviceType = ${JSON.stringify(deviceType)};
+export const win = window;
+`;
+
+/**
+ * @param {string} name - Project (package) name.
+ * @returns {string} The package.json contents.
+ */
+const renderPackageJson = name => `${JSON.stringify({
+    name,
+    private: true,
+    version: '0.0.0',
+    type: 'module',
+    scripts: { dev: 'vite', build: 'vite build', preview: 'vite preview' },
+    dependencies: { playcanvas: PC_RANGE, '@playcanvas/observer': OBSERVER_VERSION },
+    devDependencies: { vite: VITE_VERSION }
+}, null, 2)}\n`;
+
+const VITE_CONFIG = /* javascript */ `import { defineConfig } from 'vite';
+
+export default defineConfig({
+    assetsInclude: ['**/*.glb', '**/*.bin', '**/*.wasm']
+});
+`;
+
+/**
+ * @param {string} title - Page title.
+ * @returns {string} The index.html contents.
+ */
+const renderIndexHtml = title => /* html */ `<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+        <title>${title}</title>
+        <style>
+            html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
+            #appInner { position: absolute; inset: 0; }
+            #application-canvas { width: 100%; height: 100%; display: block; }
+            #controlPanel { position: absolute; top: 0; right: 0; max-height: 100%; overflow: auto; z-index: 1; }
+        </style>
+    </head>
+    <body>
+        <div id="appInner"><canvas id="application-canvas"></canvas></div>
+        <div id="controlPanel"></div>
+        <script type="module" src="/src/main.mjs"></script>
+    </body>
+</html>
+`;
+
+const MAIN = /* javascript */ `import seed from './data.json';
+import { data } from './context.mjs';
+
+import './example.mjs';
+
+// replay the captured control state after the example initialises (mirrors the examples browser)
+for (const [path, value] of Object.entries(seed)) {
+    if (data.has(path)) {
+        data.set(path, value);
+    }
+}
+`;
+
+/**
+ * @param {string} title - Example title.
+ * @param {string[]} dynamic - Dynamic asset prefixes that were not bundled.
+ * @param {string[]} failed - Asset urls that could not be fetched.
+ * @returns {string} The README contents.
+ */
+const renderReadme = (title, dynamic, failed) => {
+    let md = /* markdown */ `# ${title}
+
+A standalone PlayCanvas example, exported as a Vite project.
+
+\`\`\`bash
+npm install
+npm run dev
+\`\`\`
+
+Then open the printed local URL.
+
+The example's current control values are captured in \`src/data.json\` and applied after it loads.
+`;
+    if (VERSION) {
+        md += `\n> Depends on \`playcanvas@${PC_RANGE}\` (the newest published release). This example was authored against \`${VERSION}\`, so a newer release may behave slightly differently.\n`;
+    }
+    if (dynamic.length) {
+        md += `\n> **Heads up:** these assets are referenced dynamically and were not bundled — the example may need network access for them:\n${dynamic.map(d => `> - \`${d}\``).join('\n')}\n`;
+    }
+    if (failed.length) {
+        md += `\n> **Warning:** these referenced assets could not be fetched and are missing:\n${failed.map(f => `> - \`${f}\``).join('\n')}\n`;
+    }
+    return md;
+};
+
+/**
+ * Builds a standalone, runnable Vite project for a single example and returns the zip bytes.
+ *
+ * @param {object} opts - Options.
+ * @param {Record<string, string>} opts.files - Example source buffers keyed by filename.
+ * @param {string} opts.category - Kebab category.
+ * @param {string} opts.exampleName - Kebab example name.
+ * @param {string} opts.deviceType - Graphics device type to hardcode in the shim.
+ * @param {object} opts.data - The example's current control state, replayed after it loads.
+ * @returns {Promise<Uint8Array>} The zip archive bytes.
+ */
+export const buildProjectZip = async ({ files, category, exampleName, deviceType, data }) => {
+    const root = `${category}-${exampleName}`;
+    const title = `${category} / ${exampleName}`;
+    /** @type {Record<string, Uint8Array>} */
+    const out = {};
+    /**
+     * @param {string} p - Path within the project root.
+     * @param {string} text - File contents.
+     */
+    const add = (p, text) => {
+        out[`${root}/${p}`] = strToU8(text);
+    };
+
+    /** @type {Set<string>} */
+    const vendored = new Set();
+
+    // example source: strip @config, rewrite imports
+    add('src/example.mjs', rewriteImports(transformSource(files['example.mjs'] ?? ''), vendored));
+
+    // ship the example's remaining own files (shaders/text) verbatim; the controls UI is dropped
+    for (const [name, src] of Object.entries(files)) {
+        if (name === 'example.mjs' || name === 'controls.jsx') {
+            continue;
+        }
+        if (/\.(?:mjs|js)$/.test(name)) {
+            add(`src/${name}`, rewriteImports(src, vendored));
+        } else {
+            add(`src/${name}`, src);
+        }
+    }
+
+    // vendor non-published asset modules (e.g. assets/scripts/misc/*.mjs), recursing into their imports
+    /** @type {Set<string>} */
+    const vendoredSeen = new Set();
+    /** @type {string[]} */
+    const failed = [];
+    /**
+     * @param {string} rel - Asset-relative module path (e.g. 'assets/scripts/misc/x.mjs').
+     * @returns {Promise<void>} Resolves once the module (and its imports) are vendored.
+     */
+    const vendorModule = async (rel) => {
+        if (vendoredSeen.has(rel)) {
+            return;
+        }
+        vendoredSeen.add(rel);
+        const res = await fetch(`${STATIC_BASE}/${rel}`);
+        if (!res.ok) {
+            failed.push(`/${rel}`);
+            return;
+        }
+        /** @type {Set<string>} */
+        const nested = new Set();
+        add(`src/${rel}`, rewriteImports(await res.text(), nested));
+        await Promise.all([...nested].map(vendorModule));
+    };
+    await Promise.all([...vendored].map(vendorModule));
+
+    // scaffold
+    add('src/context.mjs', renderContextShim(deviceType));
+    add('src/data.json', `${JSON.stringify(data ?? {}, null, 2)}\n`);
+    add('src/main.mjs', MAIN);
+    add('index.html', renderIndexHtml(title));
+    add('package.json', renderPackageJson(root));
+    add('vite.config.mjs', VITE_CONFIG);
+
+    // scan + fetch referenced assets into public/ (paths resolve unchanged under Vite)
+    const { urls, dynamic } = scanAssetUrls([files['example.mjs']]);
+    await Promise.all(urls.map(async (u) => {
+        const res = await fetch(`${STATIC_BASE}${u}`);
+        if (!res.ok) {
+            failed.push(u);
+            return;
+        }
+        out[`${root}/public${u}`] = new Uint8Array(await res.arrayBuffer());
+    }));
+
+    if (dynamic.length) {
+        console.warn('[download] dynamic asset prefixes not bundled:', dynamic);
+    }
+    if (failed.length) {
+        console.warn('[download] assets that could not be fetched:', failed);
+    }
+
+    add('README.md', renderReadme(title, dynamic, failed));
+
+    return zipSync(out, { level: 0 });
+};
+
+/**
+ * Builds the current example's project zip and triggers a browser download.
+ *
+ * @returns {Promise<void>} Resolves once the download has been triggered.
+ */
+export const downloadExampleProject = async () => {
+    const snap = getExampleSnapshot();
+    if (!snap) {
+        return;
+    }
+    const deviceType = window.activeGraphicsDevice ?? readState().device ??
+        localStorage.getItem('preferredGraphicsDevice') ?? 'webgl2';
+    const bytes = await buildProjectZip({
+        files: snap.files,
+        category: snap.category,
+        exampleName: snap.example,
+        deviceType,
+        data: snap.data
+    });
+    const part = /** @type {BlobPart} */ (bytes);
+    const url = URL.createObjectURL(new Blob([part], { type: 'application/zip' }));
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${snap.category}-${snap.example}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+};

--- a/examples/src/app/download-project.mjs
+++ b/examples/src/app/download-project.mjs
@@ -279,6 +279,28 @@ export const buildProjectZip = async ({ files, category, exampleName, deviceType
         out[`${root}/public${u}`] = new Uint8Array(await res.arrayBuffer());
     }));
 
+    // cc license/attribution files ship as text sidecars next to assets but aren't referenced in
+    // source, so the scanner misses them. for each bundled asset try its '<name>.txt' sibling and
+    // a 'license.txt' in the same dir; co-locate any that exist to preserve attribution.
+    const licenses = new Set();
+    for (const u of urls) {
+        const slash = u.lastIndexOf('/');
+        const dot = u.lastIndexOf('.');
+        if (dot > slash) {
+            licenses.add(`${u.slice(0, dot)}.txt`);
+        }
+        licenses.add(`${u.slice(0, slash)}/license.txt`);
+    }
+    for (const u of urls) {
+        licenses.delete(u);
+    }
+    await Promise.all([...licenses].map(async (u) => {
+        const res = await fetch(`${STATIC_BASE}${u}`);
+        if (res.ok) {
+            out[`${root}/public${u}`] = new Uint8Array(await res.arrayBuffer());
+        }
+    }));
+
     if (dynamic.length) {
         console.warn('[download] dynamic asset prefixes not bundled:', dynamic);
     }

--- a/examples/src/app/download-project.mjs
+++ b/examples/src/app/download-project.mjs
@@ -24,6 +24,11 @@ const PC_RANGE = 'latest';
 const OBSERVER_VERSION = '1.7.1';
 const VITE_VERSION = '8.0.14';
 
+// folder-level license files whose terms require the file to ship alongside the assets. attribution
+// is preserved generally via @credit -> CREDITS.md; this co-locates the actual file only when its
+// assets are bundled (spine is the only such case today), avoiding any blanket sidecar probing.
+const COLOCATED_LICENSES = ['/assets/spine/license.txt'];
+
 /**
  * @param {string} spec - Import specifier.
  * @param {Set<string>} vendored - Collects relative asset-module paths to vendor (e.g. 'assets/scripts/misc/x.mjs').
@@ -193,6 +198,27 @@ The example's current control values are captured in \`src/data.json\` and appli
 };
 
 /**
+ * Renders the author-written `@credit` attribution into a standalone CREDITS.md.
+ *
+ * @param {{ title: string, author: string, source?: string, license?: string }[]} credits - Parsed @credit entries.
+ * @returns {string} The CREDITS.md contents.
+ */
+const renderCredits = credits => `# Credits
+
+Third-party assets used by this example:
+
+${credits.map((c) => {
+        const lines = [`## ${c.title}`, `- **Author:** ${c.author}`];
+        if (c.source) {
+            lines.push(`- **Source:** ${c.source}`);
+        }
+        if (c.license) {
+            lines.push(`- **License:** ${c.license}`);
+        }
+        return lines.join('\n');
+    }).join('\n\n')}\n`;
+
+/**
  * Builds a standalone, runnable Vite project for a single example and returns the zip bytes.
  *
  * @param {object} opts - Options.
@@ -201,9 +227,10 @@ The example's current control values are captured in \`src/data.json\` and appli
  * @param {string} opts.exampleName - Kebab example name.
  * @param {string} opts.deviceType - Graphics device type to hardcode in the shim.
  * @param {object} opts.data - The example's current control state, replayed after it loads.
+ * @param {{ title: string, author: string, source?: string, license?: string }[]} [opts.credits] - Parsed @credit attribution, written to CREDITS.md.
  * @returns {Promise<Uint8Array>} The zip archive bytes.
  */
-export const buildProjectZip = async ({ files, category, exampleName, deviceType, data }) => {
+export const buildProjectZip = async ({ files, category, exampleName, deviceType, data, credits }) => {
     const root = `${category}-${exampleName}`;
     const title = `${category} / ${exampleName}`;
     /** @type {Record<string, Uint8Array>} */
@@ -279,25 +306,15 @@ export const buildProjectZip = async ({ files, category, exampleName, deviceType
         out[`${root}/public${u}`] = new Uint8Array(await res.arrayBuffer());
     }));
 
-    // cc license/attribution files ship as text sidecars next to assets but aren't referenced in
-    // source, so the scanner misses them. for each bundled asset try its '<name>.txt' sibling and
-    // a 'license.txt' in the same dir; co-locate any that exist to preserve attribution.
-    const licenses = new Set();
-    for (const u of urls) {
-        const slash = u.lastIndexOf('/');
-        const dot = u.lastIndexOf('.');
-        if (dot > slash) {
-            licenses.add(`${u.slice(0, dot)}.txt`);
+    // co-locate folder-level license files whose terms require shipping the file with the assets
+    await Promise.all(COLOCATED_LICENSES.map(async (lic) => {
+        const dir = lic.slice(0, lic.lastIndexOf('/') + 1);
+        if (!urls.some(u => u.startsWith(dir))) {
+            return;
         }
-        licenses.add(`${u.slice(0, slash)}/license.txt`);
-    }
-    for (const u of urls) {
-        licenses.delete(u);
-    }
-    await Promise.all([...licenses].map(async (u) => {
-        const res = await fetch(`${STATIC_BASE}${u}`);
+        const res = await fetch(`${STATIC_BASE}${lic}`);
         if (res.ok) {
-            out[`${root}/public${u}`] = new Uint8Array(await res.arrayBuffer());
+            out[`${root}/public${lic}`] = new Uint8Array(await res.arrayBuffer());
         }
     }));
 
@@ -309,6 +326,11 @@ export const buildProjectZip = async ({ files, category, exampleName, deviceType
     }
 
     add('README.md', renderReadme(title, dynamic, failed));
+
+    // preserve author-written attribution (@credit blocks) as a dedicated CREDITS.md
+    if (credits?.length) {
+        add('CREDITS.md', renderCredits(credits));
+    }
 
     return zipSync(out, { level: 0 });
 };
@@ -330,7 +352,8 @@ export const downloadExampleProject = async () => {
         category: snap.category,
         exampleName: snap.example,
         deviceType,
-        data: snap.data
+        data: snap.data,
+        credits: snap.credits
     });
     const part = /** @type {BlobPart} */ (bytes);
     const url = URL.createObjectURL(new Blob([part], { type: 'application/zip' }));

--- a/examples/src/app/example-snapshot.mjs
+++ b/examples/src/app/example-snapshot.mjs
@@ -7,6 +7,7 @@
  * @property {string} category - Kebab category.
  * @property {string} example - Kebab example name.
  * @property {object} data - The example's current control state (flattened dot-path values).
+ * @property {{ title: string, author: string, source?: string, license?: string }[]} credits - Parsed @credit attribution.
  */
 
 /** @type {(() => ExampleSnapshot) | null} */

--- a/examples/src/app/example-snapshot.mjs
+++ b/examples/src/app/example-snapshot.mjs
@@ -1,0 +1,25 @@
+/**
+ * Pull-accessor bridge so the share dialog can read the current example's source
+ * and route at click time without lifting the hot `files` state into a shared store.
+ *
+ * @typedef {object} ExampleSnapshot
+ * @property {Record<string, string>} files - Current (possibly edited) source buffers.
+ * @property {string} category - Kebab category.
+ * @property {string} example - Kebab example name.
+ * @property {object} data - The example's current control state (flattened dot-path values).
+ */
+
+/** @type {(() => ExampleSnapshot) | null} */
+let provider = null;
+
+/**
+ * @param {(() => ExampleSnapshot) | null} fn - Snapshot accessor, or null to clear.
+ */
+export const setExampleSnapshotProvider = (fn) => {
+    provider = fn;
+};
+
+/**
+ * @returns {ExampleSnapshot | null} Current example snapshot, or null if none mounted.
+ */
+export const getExampleSnapshot = () => (provider ? provider() : null);

--- a/examples/src/examples/misc/spineboy.example.mjs
+++ b/examples/src/examples/misc/spineboy.example.mjs
@@ -1,3 +1,10 @@
+// @config
+// @credit
+// title: Spineboy
+// author: Esoteric Software
+// source: https://esotericsoftware.com/
+// license: (c) 2013 Esoteric Software, non-commercial use only
+
 import * as pc from 'playcanvas';
 
 import { deviceType } from 'examples/context';

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -1591,9 +1591,37 @@ body.mobile-panel-resizing #appInner.mobile-landscape #sideBar.mobile-sheet::aft
 }
 
 .code-editor-menu-container {
-    width: 110px;
-    min-width: 110px;
+    width: auto;
+    min-width: 0;
     margin-right: 0px;
+}
+
+.code-editor-menu-container > .pcui-button.code-editor-download {
+    flex: 0 0 auto;
+    width: auto;
+    gap: 6px;
+    padding: 0 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    color: #fff;
+    background-color: #f60;
+}
+
+.code-editor-menu-container > .pcui-button.code-editor-download:hover {
+    background-color: #ff7a1f;
+}
+
+.code-editor-menu-container > .pcui-button.code-editor-download:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
+.code-editor-download-label {
+    font-size: 12px;
+    line-height: 1;
+    font-weight: 600;
 }
 
 .tabs-container {
@@ -1610,13 +1638,28 @@ body.mobile-panel-resizing #appInner.mobile-landscape #sideBar.mobile-sheet::aft
 }
 
 .code-editor-menu-container > .pcui-button {
+    flex: 0 0 auto;
+    width: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     color: #fff;
     background-color: #2c393c;
     margin-right: 4px;
 }
 
+.code-editor-menu-container > .pcui-button:not(.code-editor-download)::before {
+    margin-top: 2px;
+}
+
 .code-editor-menu-container > .pcui-button:last-child {
     margin-right: 0px;
+}
+
+.tabs-container > .pcui-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .tabs-container > .pcui-button.selected {


### PR DESCRIPTION
## Summary

Adds a **Download** button to the examples-browser code panel toolbar (next to the refresh/GitHub icons) that exports the **currently-viewed example as a runnable, self-contained Vite project** — generated entirely in-browser, no server or hosting changes.

The zip is produced client-side with `fflate` (already bundled). It captures the live Monaco buffers, so any edits the user made in the code panel are included.

## Preview
<img width="3714" height="2220" alt="image" src="https://github.com/user-attachments/assets/98aa5f15-4389-4104-8fce-213d16c5aa39" />

## What's in the generated project

```
<category>-<example>/
  package.json      vite.config.mjs    index.html
  README.md
  CREDITS.md        (asset attribution from @credit — only when the example has credits)
  src/
    example.mjs       (@config stripped, imports rewritten)
    context.mjs       (local shim for `examples/context`)
    data.json         (captured control values)
    main.mjs          (imports the example, then replays data.json)
    <shaders / text>  (shipped verbatim, raw imports get `?raw`)
  public/
    assets/… scripts/…        (referenced assets, fetched from /static)
    assets/spine/license.txt  (folder licenses whose terms require shipping the file)
```

- **Imports rewritten** — `examples/context` → `./context.mjs`; non-published `examples/assets/scripts/**` modules are vendored (and their imports recursed); `playcanvas` / `playcanvas/scripts/**` left as npm specifiers.
- **Control state** — the example's current control values are captured into `src/data.json` and replayed *after* the example initialises, mirroring the browser's `applyControlState` (so values that the example seeds itself aren't clobbered).
- **Assets** — source is scanned for `./assets/` & `./scripts/` URLs, fetched from the live `/static/…`, and shipped under `public/` so they resolve unchanged. Dynamic/remote URLs that can't be bundled are noted in the generated README.
- **Attribution** — author-written `@credit` blocks (title / author / source / license) are written to a dedicated `CREDITS.md`, so asset attribution survives in the download. This covers **remote / CDN assets** (e.g. gaussian-splatting scenes) that ship no local license file. The credits come from the same parse the in-app credits overlay uses (surfaced via the example snapshot), so there's no guesswork or duplicate parsing. Folder-level license files whose terms require the file to travel with the assets (currently only spine) are co-located under `public/` alongside them.
- **Versions** — `package.json` pins `playcanvas: "latest"` + `@playcanvas/observer`; README notes the exact authoring version in case a newer release differs.

## Testing

- Verified end-to-end with Playwright: clicking **Download** produces `misc-hello-world.zip`; unzipped → `npm i && npm run dev` renders the example, with imports rewritten and the `@config` block stripped.
- Toolbar styling checked across examples (with/without a controls tab).
- Attribution verified via the real in-browser `buildProjectZip`:
  - `graphics/shadow-catcher` → `CREDITS.md` (Poly Haven, CC BY 4.0), asset still bundled.
  - `gaussian-splatting/first-person` (remote S3 splat, no local license) → `CREDITS.md` (Sunnyvale, CC BY 4.0).
  - `misc/spineboy` → `CREDITS.md` **and** co-located `public/assets/spine/license.txt`.
  - Non-attributed examples build with no `CREDITS.md` and make no extra license fetches.
