### PR TITLE
fix: update HTML-in-Canvas texture upload to new copyElementImageToTexture/texElementImage2D API

### DIFF
--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -709,10 +709,7 @@ class WebglTexture {
 
                         gl.texElementImage2D(
                             gl.TEXTURE_2D,
-                            mipLevel,
                             this._glInternalFormat,
-                            this._glFormat,
-                            this._glPixelType,
                             mipObject
                         );
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -545,7 +545,9 @@ class WebgpuTexture {
         Debug.trace(TRACEID_RENDER_QUEUE, `ELEMENT-TO-TEX: mip:${mipLevel} index:${index} ${this.texture.name}`);
 
         // scale the element's rendered image to the mip level's dimensions
-        device.wgpu.queue.copyElementImageToTexture(element, width, height, dst);
+        const source = { source: element };
+        const destination = { destination: dst, width, height };
+        device.wgpu.queue.copyElementImageToTexture(source, destination);
     }
 
     uploadTypedArrayData(device, data, mipLevel, index) {


### PR DESCRIPTION
Update the HTML-in-Canvas texture upload paths to match the breaking API change in Chromium's HTML-in-Canvas proposal (see the [explainer](https://github.com/WICG/html-in-canvas/blob/main/README.md)). This only affects Chrome Canary, not a release version of any browser.

**Changes:**
- WebGPU: `copyElementImageToTexture` now takes two dictionaries — a source `{ source: element }` and a destination `{ destination, width, height }` — instead of positional `(element, width, height, dst)` args.
- WebGL: `texElementImage2D` now takes `(target, internalformat, element)`, dropping the old `level`, `srcFormat`, and `destType` parameters. The sized internal format (`_glInternalFormat`, e.g. `gl.RGBA8`) is used directly.

**API Changes:**
- WebGPU, before:
  `queue.copyElementImageToTexture(element, width, height, { texture })`
  after:
  `queue.copyElementImageToTexture({ source: element }, { destination: { texture }, width, height })`
- WebGL, before:
  `gl.texElementImage2D(TEXTURE_2D, level, internalFormat, srcFormat, destType, element)`
  after:
  `gl.texElementImage2D(TEXTURE_2D, RGBA8, element)`

These are internal graphics-layer calls; the public `Texture.setSource()` / `Texture.upload()` API is unchanged, so the `html-texture` and `html-texture-configurator` examples need no changes.