### PR TITLE
feat(examples): support category: and example: tags in sidebar filter

### DIFF
--- a/examples/src/app/components/Sidebar.mjs
+++ b/examples/src/app/components/Sidebar.mjs
@@ -62,38 +62,65 @@ function getDefaultExampleFiles() {
 }
 
 /**
+ * Split a filter string into exact-match `category:`/`example:` tags and fuzzy free-text terms.
+ *
+ * @param {string} filter - Filter string.
+ * @returns {{ cats: string[], exs: string[], text: string }} Parsed tags and joined free text.
+ */
+function parseFilter(filter) {
+    /** @type {string[]} */
+    const cats = [];
+    /** @type {string[]} */
+    const exs = [];
+    /** @type {string[]} */
+    const terms = [];
+    filter.trim().split(/\s+/).forEach((tok) => {
+        const tag = /^(category|example):(.+)$/i.exec(tok);
+        if (!tag) {
+            if (tok) {
+                terms.push(tok);
+            }
+            return;
+        }
+        (tag[1].toLowerCase() === 'category' ? cats : exs).push(tag[2].toLowerCase());
+    });
+    // whitespace between free-text terms stays fuzzy, preserving the old behavior
+    return { cats, exs, text: terms.join('.*') };
+}
+
+/**
  * @param {Record<string, Record<string, any>>} defaultCategories - Default categories.
  * @param {string} filter - Filter string.
  * @returns {Record<string, Record<string, any>> | null} Filtered categories.
  */
 function filterCategories(defaultCategories, filter) {
-    const query = filter.replace(/\s/g, '.*');
-    const reg = query && query.length > 0 ? new RegExp(query, 'i') : null;
-    if (!reg) {
+    const { cats, exs, text } = parseFilter(filter);
+    if (!cats.length && !exs.length && !text) {
         return null;
     }
+    const reg = text ? new RegExp(text, 'i') : null;
 
     /** @type {Record<string, Record<string, any>>} */
     const updatedCategories = {};
     Object.keys(defaultCategories).forEach((category) => {
-        if (category.search(reg) !== -1) {
-            updatedCategories[category] = defaultCategories[category];
-            return null;
+        // category: tags require an exact (case-insensitive) category name
+        if (cats.length && !cats.includes(category.toLowerCase())) {
+            return;
         }
         Object.keys(defaultCategories[category].examples).forEach((example) => {
             const title = defaultCategories[category].examples[example];
-            if (title.search(reg) !== -1) {
-                if (!updatedCategories[category]) {
-                    updatedCategories[category] = {
-                        name: defaultCategories[category].name,
-                        examples: {
-                            [example]: title
-                        }
-                    };
-                } else {
-                    updatedCategories[category].examples[example] = title;
-                }
+            // example: tags require an exact (case-insensitive) example name
+            if (exs.length && !exs.includes(example.toLowerCase())) {
+                return;
             }
+            // any remaining free text fuzzy-matches the category or example name
+            if (reg && category.search(reg) === -1 && title.search(reg) === -1) {
+                return;
+            }
+            if (!updatedCategories[category]) {
+                updatedCategories[category] = { ...defaultCategories[category], examples: {} };
+            }
+            updatedCategories[category].examples[example] = title;
         });
     });
     return updatedCategories;
@@ -362,7 +389,7 @@ class SideBar extends TypedComponent {
                 jsx(/** @type {any} */ (TextInput), {
                     class: 'filter-input',
                     keyChange: true,
-                    placeholder: 'Filter...',
+                    placeholder: 'Filter, category:, example:',
                     value: this.state.filterText,
                     onChange: this.onChangeFilter.bind(this)
                 }),


### PR DESCRIPTION
## Summary

The examples-browser sidebar filter previously did fuzzy regex matching only. It now also understands `category:<name>` and `example:<name>` tags, layered on top of the existing free-text search.

- **`category:<name>`** — exact, case-insensitive match on a category's kebab name (e.g. `category:animation`, `category:gaussian-splatting`)
- **`example:<name>`** — exact, case-insensitive match on an example's kebab name (e.g. `example:blend-trees-1d`)
- **bare words** — unchanged fuzzy behavior (whitespace → `.*`), matching either the category or example name
- **combining** — multiple tags of the same kind union (OR); tags of different kinds and free text combine (AND)

The placeholder now advertises the syntax: `Filter, category:, example:`.

## Behavior

| Filter | Result |
|---|---|
| `gaussian splatting` | fuzzy search (unchanged) |
| `category:animation` | exactly the `animation` category |
| `example:gltf` | exactly the `gltf` example, any category |
| `category:animation example:blend-trees-1d` | that one example |
| `category:loaders category:animation` | both categories (OR) |
| `category:anim` | no match — exact, not partial |

## Implementation

Single file: `examples/src/app/components/Sidebar.mjs`. Added a `parseFilter` tokenizer that separates `category:`/`example:` tags from free-text terms; `filterCategories` evaluates each (category, example) pair against the parsed constraints.

## Testing

- `npm run -s lint` — clean
- `npm run -s type:check:app` — clean
- Standalone logic test across all cases in the table above produced the expected output.