### PR TITLE
fix(gsplat): apply material changes made in frame:ready the same frame

### DIFF
--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1569,10 +1569,6 @@ class GSplatManager {
             gpuSortedThisFrame = true;
         }
 
-        // renderer per-frame update (material syncing, deferred setup)
-        const fogParams = this.scene.gsplat.useFog ? (this.cameraNode.camera.fogParams ?? this.scene.fog) : null;
-        this.renderer.frameUpdate(this.scene.gsplat, this.scene.exposure, fogParams);
-
         // keep the shared mesh-instance's AABB in sync with the actual splat placements
         this._updateMeshInstanceAabb();
 
@@ -1603,6 +1599,12 @@ class GSplatManager {
                 inst.needsLodUpdate = true;
             }
         }
+
+        // Renderer per-frame update (material syncing, deferred setup). Must run after
+        // fireFrameReadyEvent(): listeners may change material state (e.g. antiAlias), and
+        // syncing here applies it this same frame before frameEnd() clears the dirty flag.
+        const fogParams = this.scene.gsplat.useFog ? (this.cameraNode.camera.fogParams ?? this.scene.fog) : null;
+        this.renderer.frameUpdate(this.scene.gsplat, this.scene.exposure, fogParams);
 
         // return the number of active splats for stats
         return sortedState ? sortedState.totalActiveSplats : 0;


### PR DESCRIPTION
Material state changed from a `frame:ready` event listener (e.g. `app.scene.gsplat.antiAlias = ...`) was silently dropped: the renderer's per-frame material sync ran *before* the event fired, and `frameEnd()` cleared the material dirty flag before any later `frameUpdate` could observe it. As a result the GSPLAT_AA define (and other material defines/params) set from `frame:ready` never reached the quad renderer's rendering material, on both WebGL and WebGPU.

**Changes:**
- In `GSplatManager.update()`, move the renderer `frameUpdate()` call to after `fireFrameReadyEvent()` so material state mutated by `frame:ready` listeners is synced and applied the same frame. `frameUpdate` only prepares render-time state consumed during the subsequent draw/dispatch, so running it last is safe for all renderer paths (quad/hybrid/compute).