### PR TITLE
Fix ESM script registration by name and subclass name collision

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -725,6 +725,13 @@ class ScriptComponent extends Component {
                 scriptType.__name = getScriptRegistryName(scriptType);
             }
             scriptName = scriptType.__name;
+
+            // bail out rather than index the script under an `undefined`/empty name (which would
+            // attach it as `this.undefined` and could mask other scripts)
+            if (!scriptName) {
+                Debug.error(`The script class could not be added to entity '${this.entity.name}' because its name could not be resolved. Add a static "scriptName" property to the class.`);
+                return null;
+            }
         }
 
         if (scriptType) {

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -8,14 +8,12 @@ import {
     SCRIPT_POST_UPDATE, SCRIPT_SWAP
 } from '../../script/constants.js';
 import { ScriptType } from '../../script/script-type.js';
-import { getScriptName } from '../../script/script.js';
+import { getScriptName, getScriptRegistryName, toLowerCamelCase } from '../../script/script.js';
 
 /**
  * @import { ScriptComponentSystem } from './system.js'
  * @import { Script } from '../../script/script.js'
  */
-
-const toLowerCamelCase = str => str[0].toLowerCase() + str.substring(1);
 
 /**
  * The ScriptComponent enables an {@link Entity} to have custom behavior by attaching scripts
@@ -714,13 +712,18 @@ class ScriptComponent extends Component {
         } else if (scriptType) {
 
             const inferredScriptName = getScriptName(scriptType);
-            const lowerInferredScriptName = toLowerCamelCase(inferredScriptName);
 
-            if (!(scriptType.prototype instanceof ScriptType) && !scriptType.scriptName) {
-                Debug.warnOnce(`The Script class "${inferredScriptName}" must have a static "scriptName" property: \`${inferredScriptName}.scriptName = "${lowerInferredScriptName}";\`. This will be an error in future versions of PlayCanvas.`);
+            // a `scriptName` declared on THIS class; an inherited one would belong to a base class
+            const ownScriptName = Object.prototype.hasOwnProperty.call(scriptType, 'scriptName') && scriptType.scriptName;
+
+            if (!(scriptType.prototype instanceof ScriptType) && !ownScriptName) {
+                Debug.warnOnce(`The Script class "${inferredScriptName}" must have a static "scriptName" property: \`${inferredScriptName}.scriptName = "${toLowerCamelCase(inferredScriptName)}";\`. This will be an error in future versions of PlayCanvas.`);
             }
 
-            scriptType.__name ??= scriptType.scriptName ?? lowerInferredScriptName;
+            // assign an own `__name` so this class is never confused with a base class's name
+            if (!Object.prototype.hasOwnProperty.call(scriptType, '__name')) {
+                scriptType.__name = getScriptRegistryName(scriptType);
+            }
             scriptName = scriptType.__name;
         }
 

--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -5,13 +5,11 @@ import { ScriptTypes } from '../script/script-types.js';
 import { registerScript } from '../script/script-create.js';
 import { ResourceLoader } from './loader.js';
 import { ResourceHandler } from './handler.js';
-import { Script } from '../script/script.js';
+import { Script, getScriptRegistryName, toLowerCamelCase } from '../script/script.js';
 
 /**
  * @import { AppBase } from '../app-base.js'
  */
-
-const toLowerCamelCase = str => str[0].toLowerCase() + str.substring(1);
 
 /**
  * Resource handler for loading JavaScript files dynamically. Two types of JavaScript files can be
@@ -138,13 +136,14 @@ class ScriptHandler extends ResourceHandler {
 
                 if (extendsScriptType) {
 
-                    const lowerCamelCaseName = toLowerCamelCase(scriptClass.name);
+                    // a `scriptName` declared on THIS class; an inherited one belongs to a base
+                    const ownScriptName = Object.prototype.hasOwnProperty.call(scriptClass, 'scriptName') && scriptClass.scriptName;
 
-                    if (!scriptClass.scriptName) {
-                        Debug.warnOnce(`The Script class "${scriptClass.name}" must have a static "scriptName" property: \`${scriptClass.name}.scriptName = "${lowerCamelCaseName}";\`. This will be an error in future versions of PlayCanvas.`);
+                    if (!ownScriptName) {
+                        Debug.warnOnce(`The Script class "${scriptClass.name}" must have a static "scriptName" property: \`${scriptClass.name}.scriptName = "${toLowerCamelCase(scriptClass.name)}";\`. This will be an error in future versions of PlayCanvas.`);
                     }
 
-                    const scriptName = scriptClass.scriptName ?? lowerCamelCaseName;
+                    const scriptName = getScriptRegistryName(scriptClass);
 
                     // Register the script name
                     registerScript(scriptClass, scriptName);

--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -145,6 +145,13 @@ class ScriptHandler extends ResourceHandler {
 
                     const scriptName = getScriptRegistryName(scriptClass);
 
+                    // skip exports whose name cannot be resolved rather than registering under an
+                    // invalid key
+                    if (!scriptName) {
+                        Debug.error(`Script class exported as '${key}' from '${url}' has no resolvable name and was skipped. Add a static "scriptName" property.`);
+                        continue;
+                    }
+
                     // Register the script name
                     registerScript(scriptClass, scriptName);
 

--- a/src/framework/script/script-create.js
+++ b/src/framework/script/script-create.js
@@ -3,7 +3,7 @@ import { AppBase } from '../app-base.js';
 import { ScriptAttributes } from './script-attributes.js';
 import { ScriptType } from './script-type.js';
 import { ScriptTypes } from './script-types.js';
-import { Script } from './script.js';
+import { Script, getScriptRegistryName } from './script.js';
 
 const reservedScriptNames = new Set([
     'system', 'entity', 'create', 'destroy', 'swap', 'move', 'data',
@@ -129,7 +129,10 @@ function registerScript(script, name, app) {
         throw new Error(`script class: '${ScriptType.__getScriptName(script)}' does not extend pc.Script.`);
     }
 
-    name = name || script.__name || ScriptType.__getScriptName(script);
+    // Resolve the name: an explicit `name` argument wins, otherwise the name is derived from the
+    // class itself (own `__name`, own `scriptName`, or lowerCamelCase class name). Only own
+    // properties are considered, so a subclass never inherits (and overwrites) its base's name.
+    name = name || getScriptRegistryName(script);
 
     if (reservedScriptNames.has(name)) {
         throw new Error(`script name: '${name}' is reserved, please change script name`);

--- a/src/framework/script/script-create.js
+++ b/src/framework/script/script-create.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
 import { AppBase } from '../app-base.js';
 import { ScriptAttributes } from './script-attributes.js';
@@ -133,6 +134,11 @@ function registerScript(script, name, app) {
     // class itself (own `__name`, own `scriptName`, or lowerCamelCase class name). Only own
     // properties are considered, so a subclass never inherits (and overwrites) its base's name.
     name = name || getScriptRegistryName(script);
+
+    if (!name) {
+        Debug.error(`script class '${script.name || script}' has no name and cannot be registered. Add a static "scriptName" property or pass an explicit name.`);
+        return;
+    }
 
     if (reservedScriptNames.has(name)) {
         throw new Error(`script name: '${name}' is reserved, please change script name`);

--- a/src/framework/script/script-registry.js
+++ b/src/framework/script/script-registry.js
@@ -1,8 +1,11 @@
+import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
+import { getScriptRegistryName } from './script.js';
 
 /**
  * @import { AppBase } from '../app-base.js'
  * @import { AttributeSchema } from './script-attributes.js'
+ * @import { Script } from './script.js'
  * @import { ScriptType } from './script-type.js'
  */
 
@@ -72,21 +75,48 @@ class ScriptRegistry extends EventHandler {
     }
 
     /**
-     * Add {@link ScriptType} to registry. Note: when {@link createScript} is called, it will add
-     * the {@link ScriptType} to the registry automatically. If a script already exists in
-     * registry, and the new script has a `swap` method defined, it will perform code hot swapping
-     * automatically in async manner.
+     * Add a script to the registry, keyed by its name. The name is taken from the script's static
+     * `scriptName` property (for {@link Script} classes), or assigned by {@link createScript} /
+     * {@link registerScript}. Note: when {@link createScript} or {@link registerScript} is called,
+     * the script is added to the registry automatically, so calling this method directly is only
+     * required when registering a {@link Script} class manually (e.g. in an engine-only project).
      *
-     * @param {typeof ScriptType} script - Script Type that is created
-     * using {@link createScript}.
-     * @returns {boolean} True if added for the first time or false if script already exists.
+     * If a script with the same name already exists in the registry, and the new script has a
+     * `swap` method defined, it will perform code hot swapping automatically in an async manner.
+     *
+     * @param {typeof Script | typeof ScriptType} script - The script class to add. Must have a
+     * resolvable name (a static `scriptName`, an assigned `__name`, or an inferable class name).
+     * @returns {boolean} True if the script was added for the first time. False if a script with
+     * the same name already exists, or if the script has no resolvable name.
      * @example
      * var PlayerController = pc.createScript('playerController');
      * // playerController Script Type will be added to pc.ScriptRegistry automatically
      * console.log(app.scripts.has('playerController')); // outputs true
+     * @example
+     * // engine-only: register an ESM Script class manually
+     * class Rotator extends pc.Script {
+     *     static scriptName = 'rotator';
+     * }
+     * app.scripts.add(Rotator);
+     * console.log(app.scripts.has('rotator')); // outputs true
      */
     add(script) {
-        const scriptName = script.__name;
+        // Resolve the script name from the class itself, considering only own properties. This
+        // handles two cases:
+        // - ESM scripts declare their name with a static `scriptName` field. Being a class field,
+        //   it shadows the inherited `scriptName` accessor with [[Define]] semantics, so the setter
+        //   that would assign `__name` never runs and `__name` is left unset.
+        // - A subclass must not inherit (and then overwrite in the registry) the name of its base
+        //   class, which would happen if `__name`/`scriptName` were read through the prototype chain.
+        // The result is persisted as an own `__name` so subsequent lookups resolve correctly.
+        const scriptName = getScriptRegistryName(script);
+
+        if (!scriptName) {
+            Debug.error(`script class '${script?.name ?? script}' has no name and cannot be added to the script registry.`);
+            return false;
+        }
+
+        script.__name = scriptName;
 
         if (this._scripts.hasOwnProperty(scriptName)) {
             setTimeout(() => {

--- a/src/framework/script/script.js
+++ b/src/framework/script/script.js
@@ -365,14 +365,56 @@ export class Script extends EventHandler {
 const funcNameRegex = /^\s*function(?:\s|\s*\/\*.*\*\/\s*)+([^(\s\/]*)\s*/;
 
 /**
+ * Converts the first character of a string to lower case.
+ *
+ * @param {string} str - The string to convert.
+ * @returns {string} The converted string.
+ */
+export const toLowerCamelCase = str => str[0].toLowerCase() + str.substring(1);
+
+/**
+ * Returns the intrinsic (display) name of a script class - either a `scriptName` declared on the
+ * class itself, or its class name. Only an own `scriptName` is used, never one inherited from a
+ * base class: a subclass that does not declare its own `scriptName` would otherwise report its
+ * parent's name. This is primarily used for diagnostics; for the name a script is registered under
+ * use {@link getScriptRegistryName}.
+ *
  * @param {Function} constructorFn - The constructor function of the script type.
  * @returns {string|undefined} The script name.
  */
 export function getScriptName(constructorFn) {
     if (typeof constructorFn !== 'function') return undefined;
-    if (constructorFn.scriptName) return constructorFn.scriptName;
+    if (Object.prototype.hasOwnProperty.call(constructorFn, 'scriptName') && constructorFn.scriptName) {
+        return constructorFn.scriptName;
+    }
     if ('name' in Function.prototype) return constructorFn.name;
     if (constructorFn === Function || constructorFn === Function.prototype.constructor) return 'Function';
     const match = (`${constructorFn}`).match(funcNameRegex);
     return match ? match[1] : undefined;
+}
+
+/**
+ * Returns the name a script class should be registered (and looked up) under. Considers only
+ * properties declared on the class itself - never inherited from a base class - so that a subclass
+ * does not adopt (and then overwrite in the registry) the name already registered for its base
+ * class. Resolution order:
+ *
+ * 1. an own `__name` already assigned to the class (e.g. an explicit registration name);
+ * 2. an own `scriptName` declared on the class, used verbatim;
+ * 3. the class name converted to lowerCamelCase (the convention used when no name is declared,
+ *    matching the ESM asset loader and {@link ScriptComponent#create}).
+ *
+ * @param {Function} constructorFn - The constructor function of the script type.
+ * @returns {string|undefined} The resolved name, or undefined if it cannot be determined.
+ */
+export function getScriptRegistryName(constructorFn) {
+    if (typeof constructorFn !== 'function') return undefined;
+    if (Object.prototype.hasOwnProperty.call(constructorFn, '__name') && constructorFn.__name) {
+        return constructorFn.__name;
+    }
+    if (Object.prototype.hasOwnProperty.call(constructorFn, 'scriptName') && constructorFn.scriptName) {
+        return constructorFn.scriptName;
+    }
+    const name = getScriptName(constructorFn);
+    return name ? toLowerCamelCase(name) : undefined;
 }

--- a/src/framework/script/script.js
+++ b/src/framework/script/script.js
@@ -365,12 +365,13 @@ export class Script extends EventHandler {
 const funcNameRegex = /^\s*function(?:\s|\s*\/\*.*\*\/\s*)+([^(\s\/]*)\s*/;
 
 /**
- * Converts the first character of a string to lower case.
+ * Converts the first character of a string to lower case. Returns the input unchanged if it is
+ * empty or not a non-empty string (avoids throwing on e.g. an anonymous class's empty name).
  *
  * @param {string} str - The string to convert.
  * @returns {string} The converted string.
  */
-export const toLowerCamelCase = str => str[0].toLowerCase() + str.substring(1);
+export const toLowerCamelCase = str => (str ? str[0].toLowerCase() + str.substring(1) : str);
 
 /**
  * Returns the intrinsic (display) name of a script class - either a `scriptName` declared on the

--- a/test/framework/components/script/component.test.mjs
+++ b/test/framework/components/script/component.test.mjs
@@ -2962,6 +2962,20 @@ describe('ScriptComponent', function () {
         expect(a.script.has('myTestScript')).to.equal(false);
     });
 
+    it('returns null and does not index the script when its name cannot be resolved', function () {
+        // an anonymous class with neither scriptName nor an inferable name
+        const Anonymous = (() => class extends Script {})();
+        Object.defineProperty(Anonymous, 'name', { value: '' });
+
+        const a = new Entity();
+        a.addComponent('script', { enabled: true });
+        const instance = a.script.create(Anonymous);
+
+        expect(instance).to.equal(null);
+        expect(a.script.undefined).to.equal(undefined);
+        expect(a.script._scriptsIndex.undefined).to.equal(undefined);
+    });
+
     it('does not warn when a ScriptType is used', function () {
         Debug._loggedMessages.clear();
         createScript('nullScript');

--- a/test/framework/script/script-registry.test.mjs
+++ b/test/framework/script/script-registry.test.mjs
@@ -68,6 +68,18 @@ describe('ScriptRegistry', function () {
             expect(added).to.equal(false);
         });
 
+        it('registerScript fails fast (no throw, not registered) when no name can be resolved', function () {
+            // an anonymous class with neither scriptName nor an inferable name
+            const Anonymous = (() => class extends Script {})();
+            Object.defineProperty(Anonymous, 'name', { value: '' });
+
+            const before = app.scripts.list().length;
+            expect(() => registerScript(Anonymous, undefined, app)).to.not.throw();
+
+            expect(Anonymous.__name == null).to.equal(true);
+            expect(app.scripts.list().length).to.equal(before);
+        });
+
         it('registerScript and direct add resolve to the same name', function () {
             class ViaRegister extends Script {
                 static scriptName = 'viaRegister';

--- a/test/framework/script/script-registry.test.mjs
+++ b/test/framework/script/script-registry.test.mjs
@@ -1,0 +1,157 @@
+import { expect } from 'chai';
+
+import { Entity } from '../../../src/framework/entity.js';
+import { createScript, registerScript } from '../../../src/framework/script/script-create.js';
+import { Script } from '../../../src/framework/script/script.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+describe('ScriptRegistry', function () {
+
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    describe('#add', function () {
+
+        it('registers an ESM Script under its static scriptName', function () {
+            class EsmScript extends Script {
+                static scriptName = 'esmScript';
+            }
+
+            const added = app.scripts.add(EsmScript);
+
+            expect(added).to.equal(true);
+            expect(app.scripts.has('esmScript')).to.equal(true);
+            expect(app.scripts.get('esmScript')).to.equal(EsmScript);
+            // the resolved name is persisted on the class
+            expect(EsmScript.__name).to.equal('esmScript');
+        });
+
+        it('allows an ESM Script added by name to be created on an entity by name', function () {
+            class Rotator extends Script {
+                static scriptName = 'rotator';
+            }
+            app.scripts.add(Rotator);
+
+            const e = new Entity();
+            e.addComponent('script');
+            const instance = e.script.create('rotator');
+
+            expect(instance).to.be.an.instanceof(Rotator);
+            expect(e.script.has('rotator')).to.equal(true);
+        });
+
+        it('registers a ScriptType under its name', function () {
+            const Mover = createScript('mover');
+            // createScript already adds it; ensure it is retrievable by name
+            expect(app.scripts.has('mover')).to.equal(true);
+            expect(app.scripts.get('mover')).to.equal(Mover);
+        });
+
+        it('does not register a script that has no resolvable name', function () {
+            // an anonymous class with neither scriptName nor an inferable name
+            const Anonymous = (() => class extends Script {})();
+            Object.defineProperty(Anonymous, 'name', { value: '' });
+
+            const added = app.scripts.add(Anonymous);
+
+            expect(added).to.equal(false);
+        });
+
+        it('registerScript and direct add resolve to the same name', function () {
+            class ViaRegister extends Script {
+                static scriptName = 'viaRegister';
+            }
+            registerScript(ViaRegister, undefined, app);
+
+            expect(app.scripts.has('viaRegister')).to.equal(true);
+            expect(app.scripts.get('viaRegister')).to.equal(ViaRegister);
+        });
+
+    });
+
+    // a subclass must register under its own name, not inherit (and overwrite) its base's name
+    describe('#add subclassing', function () {
+
+        it('a subclass with its own scriptName does not overwrite its base (registerScript)', function () {
+            class Base extends Script {
+                static scriptName = 'baseScript';
+            }
+            class Derived extends Base {
+                static scriptName = 'derivedScript';
+            }
+
+            registerScript(Base, undefined, app);
+            registerScript(Derived, undefined, app);
+
+            expect(app.scripts.has('baseScript')).to.equal(true);
+            expect(app.scripts.has('derivedScript')).to.equal(true);
+            expect(app.scripts.get('baseScript')).to.equal(Base);
+            expect(app.scripts.get('derivedScript')).to.equal(Derived);
+            expect(Base.__name).to.equal('baseScript');
+            expect(Derived.__name).to.equal('derivedScript');
+        });
+
+        it('a subclass with its own scriptName does not overwrite its base (add)', function () {
+            class Base extends Script {
+                static scriptName = 'baseScript2';
+            }
+            class Derived extends Base {
+                static scriptName = 'derivedScript2';
+            }
+
+            app.scripts.add(Base);
+            app.scripts.add(Derived);
+
+            expect(app.scripts.get('baseScript2')).to.equal(Base);
+            expect(app.scripts.get('derivedScript2')).to.equal(Derived);
+        });
+
+        it('a subclass without an explicit name resolves to its own class name (camelCase)', function () {
+            class ParentScript extends Script {}
+            class ChildScript extends ParentScript {}
+
+            registerScript(ParentScript, undefined, app);
+            registerScript(ChildScript, undefined, app);
+
+            // nameless scripts fall back to the lowerCamelCase class name, consistently across paths
+            expect(app.scripts.get('parentScript')).to.equal(ParentScript);
+            expect(app.scripts.get('childScript')).to.equal(ChildScript);
+            expect(ParentScript.__name).to.not.equal(ChildScript.__name);
+        });
+
+        it('resolves a nameless script to the same camelCase name via registerScript and create', function () {
+            class FreeScript extends Script {}
+            registerScript(FreeScript, undefined, app);
+
+            // matches the camelCase fallback used by ScriptComponent.create and the asset loader
+            expect(app.scripts.has('freeScript')).to.equal(true);
+            expect(app.scripts.has('FreeScript')).to.equal(false);
+        });
+
+        it('an explicit name passed to registerScript still wins for a subclass', function () {
+            class Base extends Script {
+                static scriptName = 'baseExplicit';
+            }
+            class Derived extends Base {}
+
+            registerScript(Base, undefined, app);
+            registerScript(Derived, 'derivedExplicit', app);
+
+            expect(app.scripts.get('baseExplicit')).to.equal(Base);
+            expect(app.scripts.get('derivedExplicit')).to.equal(Derived);
+        });
+
+    });
+
+});


### PR DESCRIPTION
## Summary

Fixes two long-standing script name-resolution bugs that share one root cause: names were read through the prototype chain instead of from the class itself.

### #8824 — ESM script added to the registry not keyed by its name
ESM scripts declare their name with a static `scriptName` field. Because it's a class field, it shadows the inherited `scriptName` accessor (`[[Define]]` semantics), so the setter that assigns `__name` never runs. `ScriptRegistry.add()` read the unset `__name` and registered the script under a `null` key — so it couldn't be created by name:

```js
class Test extends Script { static scriptName = 'test'; }
app.scripts.add(Test);
entity.script.create('test'); // silently failed
```

This broke template instantiation, procedural creation, and async/dynamic script loading for engine-only projects.

### #2881 — subclass of a script replaces the superclass
A subclass inherited its base class's already-assigned `__name`/`scriptName`, so registering the subclass overwrote the base in the registry (and could trigger an unintended hot-swap):

```js
registerScript(Base);     // registered as 'Base'
registerScript(Derived);  // also resolved to 'Base' -> overwrote Base
```

## Fix

Name resolution now considers **only own properties** of the class. The logic is centralized in a new internal `getScriptRegistryName()` helper — own `__name` → own `scriptName` → lowerCamelCase class name — and used consistently by `registerScript`, `ScriptRegistry.add`, `ScriptComponent.create`, and the ESM script handler.

## Compatibility

- No public API signatures change. `registerScript`, `createScript`, `ScriptRegistry`/`.add()`, `Script` are unchanged; the new helpers are internal (not exported from `index.js`).
- Conforming scripts (with a declared `scriptName`, or a name passed to `createScript`/`registerScript`) are unaffected.
- Only observable change in the undocumented nameless path: `registerScript`/`add` now resolve to the lowerCamelCase class name (matching the asset loader and `create`, which already did) instead of PascalCase.

## Tests

Adds `test/framework/script/script-registry.test.mjs` covering both fixes (ESM `add` by name, subclass non-collision, explicit-name precedence, nameless camelCase unification). Full suite passes.
