### PR TITLE
fix(build): preserve live bindings of mutable UMD exports (pc.app)

### DIFF
--- a/utils/esbuild-build-target.mjs
+++ b/utils/esbuild-build-target.mjs
@@ -133,7 +133,11 @@ const getUmdBanner = (banner) => {
 };
 
 const getUmdFooter = () => {
-    return /* js */ `Object.assign(exports, pc);
+    // Copy the property descriptors rather than the values, so that live bindings of mutable
+    // exports (e.g. `app`, which is null until an application is created) are preserved on the
+    // UMD namespace. `Object.assign` would snapshot each getter to its load-time value, leaving
+    // `pc.app` permanently null. See https://github.com/playcanvas/engine/issues/8836
+    return /* js */ `Object.defineProperties(exports, Object.getOwnPropertyDescriptors(pc));
 }));`;
 };
 


### PR DESCRIPTION
## Summary

Since 2.19.0, `pc.app` is permanently `null` in the **UMD / global build** (`playcanvas.js`), breaking any project or script that reads the global `pc.app` (e.g. the classic orbit-camera `mouse-input` script used by the WebXR AR Starter Kit). The ESM build is unaffected.

Fixes #8836. Also explains [forum thread #42337](https://forum.playcanvas.com/t/pc-app-null/42337).

## Root cause

2.19.0 migrated the JS builds to esbuild (#8722). The UMD output wraps the engine as an esbuild IIFE whose exports are live getters (`app: () => app`), then bridges that namespace to the outer UMD `exports` (= `window.pc`) via a hand-written footer:

```js
var pc = (() => { … __export(index_exports, { app: () => app, … }); return __toCommonJS(index_exports); })();
Object.assign(exports, pc);   // ← snapshots every getter to its load-time value
```

`Object.assign` invokes each getter once and copies the **value**. At module-load time no application exists, so `app` is `null`. `window.pc.app` becomes a frozen `null` data property; when an app is later constructed and the inner module's `app = this` runs, `window.pc.app` never updates.

This only affects **mutable** exports. `app` is the one that bites in practice. Scripts using `this.app` are unaffected (which is why the regression looked project-specific), but scripts reading the global `pc.app` break.

## Fix

Copy the property **descriptors** rather than the values, preserving the getter (and thus the live binding) on the UMD namespace:

```js
Object.defineProperties(exports, Object.getOwnPropertyDescriptors(pc));
```

## Verification

Built both UMD bundles and loaded them as a browser global (`window.pc`) in a `vm` sandbox, then constructed an `AppBase`:

| build | `pc.app` descriptor | `pc.app === new AppBase(canvas)` |
|-------|--------------------|----------------------------------|
| before (`Object.assign`) | `value = null` (frozen) | `false` — stays `null` |
| after (`Object.defineProperties`) | getter (live) | `true` — updates correctly |

All 1272 exports remain present; only the binding semantics for mutable exports change.

A regression test would ideally assert `pc.app` updates after construction in the UMD build, but the current mocha suite runs against `src/` (ESM, where live bindings already work), so there's no build-output test harness to hook into — noting it here as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)