### PR TITLE
fix(build): keep UMD exports overridable while preserving live bindings

### DIFF
--- a/utils/esbuild-build-target.mjs
+++ b/utils/esbuild-build-target.mjs
@@ -133,11 +133,24 @@ const getUmdBanner = (banner) => {
 };
 
 const getUmdFooter = () => {
-    // Copy the property descriptors rather than the values, so that live bindings of mutable
-    // exports (e.g. `app`, which is null until an application is created) are preserved on the
-    // UMD namespace. `Object.assign` would snapshot each getter to its load-time value, leaving
-    // `pc.app` permanently null. See https://github.com/playcanvas/engine/issues/8836
-    return /* js */ `Object.defineProperties(exports, Object.getOwnPropertyDescriptors(pc));
+    // Bridge the bundled namespace onto the UMD `exports` object. Each export getter is wrapped in
+    // an accessor that:
+    //   - delegates reads to the live binding, so mutable exports (e.g. `app`, which is null until
+    //     an application is created) update on the UMD namespace. A plain `Object.assign` would
+    //     snapshot each getter to its load-time value, leaving `pc.app` permanently null
+    //     (see https://github.com/playcanvas/engine/issues/8836).
+    //   - keeps the property writable, so consumers can still override members of `pc` (e.g. the
+    //     Editor's classic-script worker reassigns `pc.createScript`). A bare descriptor copy makes
+    //     the export getter-only and breaks such overrides
+    //     (see https://github.com/playcanvas/engine/issues/8836).
+    return /* js */ `for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(pc))) {
+\tObject.defineProperty(exports, key, descriptor.get ? {
+\t\tget: descriptor.get,
+\t\tset: (value) => Object.defineProperty(exports, key, { value, writable: true, enumerable: true, configurable: true }),
+\t\tenumerable: descriptor.enumerable,
+\t\tconfigurable: true
+\t} : descriptor);
+}
 }));`;
 };
 

--- a/utils/esbuild-build-target.mjs
+++ b/utils/esbuild-build-target.mjs
@@ -140,13 +140,13 @@ const getUmdFooter = () => {
     //     snapshot each getter to its load-time value, leaving `pc.app` permanently null
     //     (see https://github.com/playcanvas/engine/issues/8836).
     //   - keeps the property writable, so consumers can still override members of `pc` (e.g. the
-    //     Editor's classic-script worker reassigns `pc.createScript`). A bare descriptor copy makes
-    //     the export getter-only and breaks such overrides
-    //     (see https://github.com/playcanvas/engine/issues/8836).
+    //     Editor's classic-script worker reassigns `pc.createScript`). The getter-only descriptor
+    //     copy introduced in #8837 breaks such overrides
+    //     (see https://github.com/playcanvas/engine/pull/8837).
     return /* js */ `for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(pc))) {
 \tObject.defineProperty(exports, key, descriptor.get ? {
 \t\tget: descriptor.get,
-\t\tset: (value) => Object.defineProperty(exports, key, { value, writable: true, enumerable: true, configurable: true }),
+\t\tset: (value) => Object.defineProperty(exports, key, { value, writable: true, enumerable: descriptor.enumerable, configurable: true }),
 \t\tenumerable: descriptor.enumerable,
 \t\tconfigurable: true
 \t} : descriptor);


### PR DESCRIPTION
## Summary

Follow-up to #8837. That PR fixed the live binding of mutable UMD exports (notably `pc.app`, see #8836) but, as a side effect, made **every** UMD export **getter-only**. This silently broke any consumer that reassigns a member of the global `pc` namespace.

The most visible casualty is the Editor's classic-script worker (`classic-script.worker.ts`), which parses scripts by overriding `pc.createScript` / `pc.registerScript` with stubs:

```js
pc.createScript = function (name, app, script) { /* stub */ };
pc.registerScript = function (script, name, app) { /* stub */ };
```

After #8837 those assignments hit a getter-only property and don't take effect, so the engine's **real** `createScript` → `registerScript` runs in the worker and throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'scripts')
  at registerScript  // const registry = app ? app.scripts : AppBase.getApplication().scripts;
```

`AppBase.getApplication()` is `undefined` in the worker (no application is ever created there), so `.scripts` throws. Reported on the forum (classic script parsing broken in 2.19.3).

## Fix

Wrap each export getter in an accessor that has **both** a getter and a setter:

```js
for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(pc))) {
    Object.defineProperty(exports, key, descriptor.get ? {
        get: descriptor.get,
        set: (value) => Object.defineProperty(exports, key, { value, writable: true, enumerable: true, configurable: true }),
        enumerable: descriptor.enumerable,
        configurable: true
    } : descriptor);
}
```

- **get** delegates to the live binding → `pc.app` still updates (keeps #8836 fixed).
- **set** redefines the property as a writable value → `pc.createScript = …` and similar overrides take effect again.

This restores the writable-export semantics of the pre-2.19 (Rollup) UMD build without regressing the live-binding fix.

## Verification

Built the UMD bundle, loaded it as a browser global in a `vm` sandbox:

| check | result |
|-------|--------|
| `Object.keys(pc).length` | 1272 (unchanged) |
| `pc.app` before app / after `new pc.AppBase()` | `null` → `=== app` (live) ✅ |
| `pc.createScript = stub` takes effect | ✅ (no throw) |
| `pc.registerScript = stub` takes effect | ✅ |
| `pc.app` still live after overriding other members | ✅ |
| `pc.script.createLoadingScreen = …` | ✅ |

Before this change (current `main` / 2.19.3) the override assignments throw *"Cannot set property createScript … which has only a getter"* and silently leave the engine implementation in place — reproducing the worker crash.

## Note

There's also a latent footgun worth a separate look: `registerScript` hard-requires `AppBase.getApplication()` when no `app` is passed, which is fragile in app-less contexts (workers, headless parsing). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)