### PR TITLE
fix(scripts): restore class-name lookup for nameless registered scripts

### DIFF
--- a/src/framework/script/script-registry.js
+++ b/src/framework/script/script-registry.js
@@ -1,7 +1,7 @@
 import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
 import { reservedScriptNames } from './constants.js';
-import { getScriptRegistryName } from './script.js';
+import { getScriptName, getScriptRegistryName, toLowerCamelCase } from './script.js';
 
 /**
  * @import { AppBase } from '../app-base.js'
@@ -131,6 +131,17 @@ class ScriptRegistry extends EventHandler {
 
         script.__name = scriptName;
 
+        // Back-compat alias. Before #8831 (2.19.3), a script registered without an explicit name
+        // was keyed by its verbatim class name (e.g. `PlayerController`); since then the registry
+        // name is the lowerCamelCase form (`playerController`). Projects reference scripts by the
+        // original name, so when the registry name was derived from the class name, also expose the
+        // script under that class name - provided it differs, is not reserved, and is not already
+        // taken by another script. See https://github.com/playcanvas/engine/pull/8831
+        const className = getScriptName(script);
+        const aliasName = (className && className !== scriptName &&
+            toLowerCamelCase(className) === scriptName &&
+            !reservedScriptNames.has(className) && !this._scripts.has(className)) ? className : null;
+
         if (this._scripts.has(scriptName)) {
             setTimeout(() => {
                 if (script.prototype.swap) {
@@ -139,6 +150,12 @@ class ScriptRegistry extends EventHandler {
                     const ind = this._list.indexOf(old);
                     this._list[ind] = script;
                     this._scripts.set(scriptName, script);
+
+                    // keep the class-name alias pointing at the swapped-in script
+                    const oldAlias = getScriptName(old);
+                    if (oldAlias && this._scripts.get(oldAlias) === old) {
+                        this._scripts.set(oldAlias, script);
+                    }
 
                     this.fire('swap', scriptName, script);
                     this.fire(`swap:${scriptName}`, script);
@@ -150,10 +167,12 @@ class ScriptRegistry extends EventHandler {
         }
 
         this._scripts.set(scriptName, script);
+        if (aliasName) this._scripts.set(aliasName, script);
         this._list.push(script);
 
         this.fire('add', scriptName, script);
         this.fire(`add:${scriptName}`, script);
+        if (aliasName) this.fire(`add:${aliasName}`, script);
 
         // for all components awaiting Script Type
         // create script instance
@@ -169,64 +188,77 @@ class ScriptRegistry extends EventHandler {
                 return;
             }
 
-            const components = this.app.systems.script._components;
-            let attributes;
-            const scriptInstances = [];
-            const scriptInstancesInitialized = [];
-
-            for (components.loopIndex = 0; components.loopIndex < components.length; components.loopIndex++) {
-                const component = components.items[components.loopIndex];
-                // check if awaiting for script
-                if (component._scriptsIndex[scriptName] && component._scriptsIndex[scriptName].awaiting) {
-                    if (component._scriptsData && component._scriptsData[scriptName]) {
-                        attributes = component._scriptsData[scriptName].attributes;
-                    }
-
-                    const scriptInstance = component.create(scriptName, {
-                        preloading: true,
-                        ind: component._scriptsIndex[scriptName].ind,
-                        attributes: attributes
-                    });
-
-                    if (scriptInstance) {
-                        scriptInstances.push(scriptInstance);
-                    }
-
-                    // initialize attributes
-                    for (const script of component.scripts) {
-                        component.initializeAttributes(script);
-                    }
-                }
-            }
-
-            // call initialize()
-            for (let i = 0; i < scriptInstances.length; i++) {
-                if (scriptInstances[i].enabled) {
-                    scriptInstances[i]._initialized = true;
-
-                    scriptInstancesInitialized.push(scriptInstances[i]);
-
-                    if (scriptInstances[i].initialize) {
-                        scriptInstances[i].initialize();
-                    }
-                }
-            }
-
-            // call postInitialize()
-            for (let i = 0; i < scriptInstancesInitialized.length; i++) {
-                if (!scriptInstancesInitialized[i].enabled || scriptInstancesInitialized[i]._postInitialized) {
-                    continue;
-                }
-
-                scriptInstancesInitialized[i]._postInitialized = true;
-
-                if (scriptInstancesInitialized[i].postInitialize) {
-                    scriptInstancesInitialized[i].postInitialize();
-                }
-            }
+            // instantiate on components awaiting either the registry name or the class-name alias
+            this._createAwaitingInstances(scriptName);
+            if (aliasName) this._createAwaitingInstances(aliasName);
         });
 
         return true;
+    }
+
+    /**
+     * Instantiate the just-added script on any script components that were awaiting it under the
+     * given name (the registry name or a back-compat class-name alias).
+     *
+     * @param {string} scriptName - The name components may be awaiting the script under.
+     * @private
+     */
+    _createAwaitingInstances(scriptName) {
+        const components = this.app.systems.script._components;
+        let attributes;
+        const scriptInstances = [];
+        const scriptInstancesInitialized = [];
+
+        for (components.loopIndex = 0; components.loopIndex < components.length; components.loopIndex++) {
+            const component = components.items[components.loopIndex];
+            // check if awaiting for script
+            if (component._scriptsIndex[scriptName] && component._scriptsIndex[scriptName].awaiting) {
+                if (component._scriptsData && component._scriptsData[scriptName]) {
+                    attributes = component._scriptsData[scriptName].attributes;
+                }
+
+                const scriptInstance = component.create(scriptName, {
+                    preloading: true,
+                    ind: component._scriptsIndex[scriptName].ind,
+                    attributes: attributes
+                });
+
+                if (scriptInstance) {
+                    scriptInstances.push(scriptInstance);
+                }
+
+                // initialize attributes
+                for (const script of component.scripts) {
+                    component.initializeAttributes(script);
+                }
+            }
+        }
+
+        // call initialize()
+        for (let i = 0; i < scriptInstances.length; i++) {
+            if (scriptInstances[i].enabled) {
+                scriptInstances[i]._initialized = true;
+
+                scriptInstancesInitialized.push(scriptInstances[i]);
+
+                if (scriptInstances[i].initialize) {
+                    scriptInstances[i].initialize();
+                }
+            }
+        }
+
+        // call postInitialize()
+        for (let i = 0; i < scriptInstancesInitialized.length; i++) {
+            if (!scriptInstancesInitialized[i].enabled || scriptInstancesInitialized[i]._postInitialized) {
+                continue;
+            }
+
+            scriptInstancesInitialized[i]._postInitialized = true;
+
+            if (scriptInstancesInitialized[i].postInitialize) {
+                scriptInstancesInitialized[i].postInitialize();
+            }
+        }
     }
 
     /**
@@ -252,12 +284,20 @@ class ScriptRegistry extends EventHandler {
             return false;
         }
 
-        this._scripts.delete(scriptName);
+        // delete the canonical registry name and any class-name alias that points at this script
+        const canonicalName = scriptType.__name;
+        this._scripts.delete(canonicalName);
+
+        const className = getScriptName(scriptType);
+        if (className && this._scripts.get(className) === scriptType) {
+            this._scripts.delete(className);
+        }
+
         const ind = this._list.indexOf(scriptType);
         this._list.splice(ind, 1);
 
-        this.fire('remove', scriptName, scriptType);
-        this.fire(`remove:${scriptName}`, scriptType);
+        this.fire('remove', canonicalName, scriptType);
+        this.fire(`remove:${canonicalName}`, scriptType);
 
         return true;
     }

--- a/src/framework/script/script-registry.js
+++ b/src/framework/script/script-registry.js
@@ -153,12 +153,18 @@ class ScriptRegistry extends EventHandler {
 
                     // keep the class-name alias pointing at the swapped-in script
                     const oldAlias = getScriptName(old);
-                    if (oldAlias && this._scripts.get(oldAlias) === old) {
+                    const aliasSwapped = oldAlias && this._scripts.get(oldAlias) === old;
+                    if (aliasSwapped) {
                         this._scripts.set(oldAlias, script);
                     }
 
                     this.fire('swap', scriptName, script);
                     this.fire(`swap:${scriptName}`, script);
+
+                    // notify listeners (e.g. components attached via the alias) keyed by the alias
+                    if (aliasSwapped && oldAlias !== scriptName) {
+                        this.fire(`swap:${oldAlias}`, script);
+                    }
                 } else {
                     console.warn(`script registry already has '${scriptName}' script, define 'swap' method for new script type to enable code hot swapping`);
                 }
@@ -205,7 +211,6 @@ class ScriptRegistry extends EventHandler {
      */
     _createAwaitingInstances(scriptName) {
         const components = this.app.systems.script._components;
-        let attributes;
         const scriptInstances = [];
         const scriptInstancesInitialized = [];
 
@@ -213,9 +218,8 @@ class ScriptRegistry extends EventHandler {
             const component = components.items[components.loopIndex];
             // check if awaiting for script
             if (component._scriptsIndex[scriptName] && component._scriptsIndex[scriptName].awaiting) {
-                if (component._scriptsData && component._scriptsData[scriptName]) {
-                    attributes = component._scriptsData[scriptName].attributes;
-                }
+                // resolve per component so attributes never leak from a previous iteration
+                const attributes = component._scriptsData?.[scriptName]?.attributes;
 
                 const scriptInstance = component.create(scriptName, {
                     preloading: true,
@@ -289,7 +293,8 @@ class ScriptRegistry extends EventHandler {
         this._scripts.delete(canonicalName);
 
         const className = getScriptName(scriptType);
-        if (className && this._scripts.get(className) === scriptType) {
+        const aliasRemoved = className && className !== canonicalName && this._scripts.get(className) === scriptType;
+        if (aliasRemoved) {
             this._scripts.delete(className);
         }
 
@@ -298,6 +303,11 @@ class ScriptRegistry extends EventHandler {
 
         this.fire('remove', canonicalName, scriptType);
         this.fire(`remove:${canonicalName}`, scriptType);
+
+        // mirror the alias `add:`/`remove:` events for listeners keyed by the class-name alias
+        if (aliasRemoved) {
+            this.fire(`remove:${className}`, scriptType);
+        }
 
         return true;
     }

--- a/test/framework/script/script-registry.test.mjs
+++ b/test/framework/script/script-registry.test.mjs
@@ -177,13 +177,65 @@ describe('ScriptRegistry', function () {
             expect(ParentScript.__name).to.not.equal(ChildScript.__name);
         });
 
-        it('resolves a nameless script to the same camelCase name via registerScript and create', function () {
+        it('registers a nameless script under its camelCase name and a class-name alias', function () {
             class FreeScript extends Script {}
             registerScript(FreeScript, undefined, app);
 
-            // matches the camelCase fallback used by ScriptComponent.create and the asset loader
+            // canonical registry name is the lowerCamelCase class name, matching
+            // ScriptComponent.create and the asset loader
+            expect(FreeScript.__name).to.equal('freeScript');
             expect(app.scripts.has('freeScript')).to.equal(true);
+            expect(app.scripts.get('freeScript')).to.equal(FreeScript);
+
+            // a back-compat alias under the verbatim class name keeps pre-2.19.3 references working
+            expect(app.scripts.has('FreeScript')).to.equal(true);
+            expect(app.scripts.get('FreeScript')).to.equal(FreeScript);
+        });
+
+        it('does not create a class-name alias when an explicit name is given', function () {
+            class PlayerController extends Script {}
+            registerScript(PlayerController, 'customName', app);
+
+            expect(PlayerController.__name).to.equal('customName');
+            expect(app.scripts.has('customName')).to.equal(true);
+            // an explicitly named script is registered only under that name (pre-2.19.3 behavior)
+            expect(app.scripts.has('PlayerController')).to.equal(false);
+            expect(app.scripts.has('playerController')).to.equal(false);
+        });
+
+        it('does not let a class-name alias overwrite an existing registration', function () {
+            class First extends Script {}
+            registerScript(First, 'PlayerController', app); // occupies 'PlayerController'
+
+            class PlayerController extends Script {}
+            registerScript(PlayerController, undefined, app); // alias 'PlayerController' is taken
+
+            expect(app.scripts.get('PlayerController')).to.equal(First);
+            expect(app.scripts.get('playerController')).to.equal(PlayerController);
+        });
+
+        it('remove() clears both the canonical name and the class-name alias', function () {
+            class FreeScript extends Script {}
+            registerScript(FreeScript, undefined, app);
+
+            expect(app.scripts.remove('FreeScript')).to.equal(true);
+            expect(app.scripts.has('freeScript')).to.equal(false);
             expect(app.scripts.has('FreeScript')).to.equal(false);
+        });
+
+        it('attaches a nameless script to an entity referenced by its class name', function () {
+            // mirrors the pre-2.19.3 pattern: register an ES6 class with no explicit name, then
+            // reference it on an entity by its (PascalCase) class name
+            class PlayerController extends Script {}
+            registerScript(PlayerController, undefined, app);
+
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('script');
+
+            const instance = e.script.create('PlayerController');
+            expect(instance).to.be.an.instanceof(PlayerController);
+            expect(e.script.PlayerController).to.equal(instance);
         });
 
         it('an explicit name passed to registerScript still wins for a subclass', function () {

--- a/test/framework/script/script-registry.test.mjs
+++ b/test/framework/script/script-registry.test.mjs
@@ -238,6 +238,31 @@ describe('ScriptRegistry', function () {
             expect(e.script.PlayerController).to.equal(instance);
         });
 
+        it('fires a swap event under the class-name alias when a nameless script is re-registered', function (done) {
+            class PlayerController extends Script {}
+            PlayerController.prototype.swap = function () {};
+            registerScript(PlayerController, undefined, app);
+
+            // a new class with the same class name re-registers under the same canonical name + alias
+            const NewPlayerController = class PlayerController extends Script {};
+            NewPlayerController.prototype.swap = function () {};
+
+            let canonicalSwap = false;
+            app.scripts.on('swap:playerController', () => {
+                canonicalSwap = true;
+            });
+            app.scripts.on('swap:PlayerController', (script) => {
+                // components attached via the alias subscribe to `swap:PlayerController`
+                expect(canonicalSwap).to.equal(true);
+                expect(script).to.equal(NewPlayerController);
+                expect(app.scripts.get('PlayerController')).to.equal(NewPlayerController);
+                expect(app.scripts.get('playerController')).to.equal(NewPlayerController);
+                done();
+            });
+
+            registerScript(NewPlayerController, undefined, app);
+        });
+
         it('an explicit name passed to registerScript still wins for a subclass', function () {
             class Base extends Script {
                 static scriptName = 'baseExplicit';


### PR DESCRIPTION
## Summary

Since **2.19.3**, projects that register ES6 script classes without an explicit name and reference them by the **class name** stopped working — the scripts silently fail to attach. Reported by a user with "hundreds of scripts": *"All my scripts stopped working (got not registered)… extending `pc.ScriptType` and registering them… only adding the second argument to `pc.registerScript` with the script name… fixed the problem."*

## Root cause

#8831 changed the name a script is registered under when no explicit name is passed to `registerScript`/`createScript`/`app.scripts.add`:

```js
// before (≤ 2.19.2)
name = name || script.__name || ScriptType.__getScriptName(script); // verbatim class name → "PlayerController"
// after (2.19.3, #8831)
name = name || getScriptRegistryName(script);                       // lowerCamelCase → "playerController"
```

That matches the ESM asset-loader convention, but it changed the long-standing manual-registration behavior. `ScriptRegistry` (a `Map` since #8835) is keyed solely by the new lowerCamelCase name with no alias, so an entity that references the script by its original `PlayerController` name no longer resolves it → the script never attaches. Passing an explicit name (`registerScript(Class, 'PlayerController')`) works because the explicit name wins — but that's painful across hundreds of scripts.

## Fix (option 1: back-compat alias)

In `ScriptRegistry.add`, when the registry name was **derived from the class name**, also expose the script under its verbatim class name:

```js
const className = getScriptName(script);
const aliasName = (className && className !== scriptName &&
    toLowerCamelCase(className) === scriptName &&
    !reservedScriptNames.has(className) && !this._scripts.has(className)) ? className : null;
```

- The canonical `__name` stays the lowerCamelCase form (no change to the ESM/asset path).
- The alias is added **only** when `toLowerCamelCase(className) === name` — so explicitly named scripts get no alias, and `createScript('foo')` is unaffected.
- The alias is skipped if reserved or already taken, so it never clobbers an existing registration.
- `remove()` clears both names; hot-swap keeps the alias pointing at the swapped-in class; components awaiting either name are instantiated.

This restores pre-2.19.3 lookups while keeping the lowerCamelCase canonical name.

## Tests

Added to `script-registry.test.mjs` (105 passing):
- nameless script resolves under both `playerController` and `PlayerController`;
- explicitly named scripts get **no** class-name alias;
- alias never overwrites an existing registration;
- `remove()` clears both names;
- end-to-end: an entity referencing the script by its class name attaches the instance.

Fixes the 2.19.3 script-registration regression reported on the forum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)