### PR TITLE
fix(gsplat): tile interval-scatter dispatch over workgroup limit

### DIFF
--- a/src/scene/gsplat-unified/gsplat-interval-compaction.js
+++ b/src/scene/gsplat-unified/gsplat-interval-compaction.js
@@ -1,4 +1,5 @@
 import { Debug, DebugHelper } from '../../core/debug.js';
+import { Vec2 } from '../../core/math/vec2.js';
 import { Compute } from '../../platform/graphics/compute.js';
 import { Shader } from '../../platform/graphics/shader.js';
 import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
@@ -88,6 +89,15 @@ class GSplatIntervalCompaction {
 
     /** @type {Compute|null} */
     _scatterCompute = null;
+
+    /**
+     * Reused 2D dispatch size for the scatter pass. The scatter pass dispatches one workgroup per
+     * interval; when the interval count exceeds the device's per-dimension workgroup limit it is
+     * tiled across X and Y (see {@link Compute.calcDispatchSize}).
+     *
+     * @type {Vec2}
+     */
+    _scatterDispatchSize = new Vec2(1, 1);
 
     /** @type {Compute|null} */
     _writeIndirectArgsCompute = null;
@@ -449,8 +459,12 @@ class GSplatIntervalCompaction {
         scatterCompute.setParameter('pad1', 0);
         scatterCompute.setParameter('pad2', 0);
 
-        // One workgroup per interval (1D dispatch; numIntervals is always well below 65535)
-        scatterCompute.setupDispatch(numIntervals);
+        // One workgroup per interval. The interval count can exceed the device's per-dimension
+        // workgroup limit (e.g. many instances across the full LOD range), so tile the dispatch
+        // across X and Y. The shader reconstructs the linear interval index from (x, y) and
+        // discards any over-dispatched workgroups via its numIntervals bounds check.
+        Compute.calcDispatchSize(numIntervals, this._scatterDispatchSize, this.device.limits.maxComputeWorkgroupsPerDimension || 65535);
+        scatterCompute.setupDispatch(this._scatterDispatchSize.x, this._scatterDispatchSize.y, 1);
         this.device.computeDispatch([scatterCompute], 'GSplatIntervalScatter');
     }
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-interval-scatter.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-interval-scatter.js
@@ -1,6 +1,8 @@
 // Compute shader for interval-based scatter (stream compaction).
 //
-// Dispatched with numIntervals workgroups, each containing WORKGROUP_SIZE threads.
+// Dispatched with one workgroup per interval, each containing WORKGROUP_SIZE threads.
+// The dispatch is tiled across X and Y (the interval count can exceed the per-dimension
+// workgroup limit), so the linear interval index is reconstructed from the 2D workgroup id.
 // Each workgroup handles one interval: it reads the prefix-sum output to determine
 // the output offset and visible count, then writes contiguous work-buffer pixel
 // indices into the compacted output array.
@@ -33,8 +35,13 @@ struct ScatterUniforms {
 @group(0) @binding(3) var<storage, read_write> compactedOutput: array<u32>;
 
 @compute @workgroup_size({WORKGROUP_SIZE})
-fn main(@builtin(workgroup_id) wgId: vec3u, @builtin(local_invocation_id) lid: vec3u) {
-    let intervalIdx = wgId.x;
+fn main(
+    @builtin(workgroup_id) wgId: vec3u,
+    @builtin(num_workgroups) numWorkgroups: vec3u,
+    @builtin(local_invocation_id) lid: vec3u
+) {
+    // reconstruct the linear interval index from the (possibly Y-tiled) 2D dispatch
+    let intervalIdx = wgId.y * numWorkgroups.x + wgId.x;
     if (intervalIdx >= uniforms.numIntervals) { return; }
 
     let outputOffset = prefixSumBuffer[intervalIdx];


### PR DESCRIPTION
Fix a WebGPU GPUValidationError when rendering very large GPU-sorted gsplat scenes.

The interval-compaction "scatter" pass dispatched one workgroup per visible interval as a 1D dispatch, assuming the interval count stays below the device's max workgroups per dimension (65535). Scenes with a high visible-interval count (e.g. many gsplat instances across the full LOD range) exceed that limit and trigger: "Dispatch workgroup count X exceeds max compute workgroups per dimension".

**Changes:**
- Tile the scatter dispatch across X and Y via `Compute.calcDispatchSize`, using `device.limits.maxComputeWorkgroupsPerDimension`. Behavior is unchanged for scenes under the limit (stays a 1D dispatch).
- Reconstruct the linear interval index in the scatter shader from the 2D workgroup id (`wgId.y * numWorkgroups.x + wgId.x`); the existing `intervalIdx >= numIntervals` bounds check discards over-dispatched workgroups.

Only affects the WebGPU GPU-sort path; the WebGL/CPU-sort path is unchanged.