### PR TITLE
fix(scripts): register nameless scripts under their verbatim class name

### DIFF
--- a/src/framework/script/script-create.js
+++ b/src/framework/script/script-create.js
@@ -5,7 +5,7 @@ import { ScriptAttributes } from './script-attributes.js';
 import { ScriptType } from './script-type.js';
 import { ScriptTypes } from './script-types.js';
 import { reservedScriptNames } from './constants.js';
-import { Script, getScriptRegistryName } from './script.js';
+import { Script, getScriptName } from './script.js';
 
 function getReservedScriptNames() {
     return reservedScriptNames;
@@ -120,9 +120,15 @@ function registerScript(script, name, app) {
     }
 
     // Resolve the name: an explicit `name` argument wins, otherwise the name is derived from the
-    // class itself (own `__name`, own `scriptName`, or lowerCamelCase class name). Only own
-    // properties are considered, so a subclass never inherits (and overwrites) its base's name.
-    name = name || getScriptRegistryName(script);
+    // class itself - its own `__name`, its own `scriptName`, or, as a fallback, its verbatim class
+    // name. Only own properties are considered, so a subclass never inherits (and overwrites) its
+    // base's name. The verbatim class-name fallback (rather than the lowerCamelCase form used by
+    // `ScriptComponent.create` and the asset loader) preserves the pre-2.19.3 registration name, so
+    // projects that register ES6 classes via `registerScript(Class)` and reference them by their
+    // class name keep working.
+    name = name ||
+        (Object.prototype.hasOwnProperty.call(script, '__name') && script.__name) ||
+        getScriptName(script);
 
     if (!name) {
         Debug.error(`script class '${script.name || script}' has no name and cannot be registered. Add a static "scriptName" property or pass an explicit name.`);

--- a/test/framework/script/script-registry.test.mjs
+++ b/test/framework/script/script-registry.test.mjs
@@ -164,26 +164,46 @@ describe('ScriptRegistry', function () {
             expect(app.scripts.get('derivedScript2')).to.equal(Derived);
         });
 
-        it('a subclass without an explicit name resolves to its own class name (camelCase)', function () {
+        it('a subclass without an explicit name registers under its own (verbatim) class name', function () {
             class ParentScript extends Script {}
             class ChildScript extends ParentScript {}
 
             registerScript(ParentScript, undefined, app);
             registerScript(ChildScript, undefined, app);
 
-            // nameless scripts fall back to the lowerCamelCase class name, consistently across paths
-            expect(app.scripts.get('parentScript')).to.equal(ParentScript);
-            expect(app.scripts.get('childScript')).to.equal(ChildScript);
-            expect(ParentScript.__name).to.not.equal(ChildScript.__name);
+            // registerScript falls back to the verbatim class name; each subclass uses its own name
+            // and never inherits (and overwrites) its base's
+            expect(app.scripts.get('ParentScript')).to.equal(ParentScript);
+            expect(app.scripts.get('ChildScript')).to.equal(ChildScript);
+            expect(ParentScript.__name).to.equal('ParentScript');
+            expect(ChildScript.__name).to.equal('ChildScript');
         });
 
-        it('resolves a nameless script to the same camelCase name via registerScript and create', function () {
+        it('registers a nameless script via registerScript under its verbatim class name', function () {
             class FreeScript extends Script {}
             registerScript(FreeScript, undefined, app);
 
-            // matches the camelCase fallback used by ScriptComponent.create and the asset loader
-            expect(app.scripts.has('freeScript')).to.equal(true);
-            expect(app.scripts.has('FreeScript')).to.equal(false);
+            // registerScript uses the verbatim class name (pre-2.19.3 behaviour), so projects that
+            // reference the script by its class name keep resolving it
+            expect(FreeScript.__name).to.equal('FreeScript');
+            expect(app.scripts.has('FreeScript')).to.equal(true);
+            expect(app.scripts.get('FreeScript')).to.equal(FreeScript);
+            expect(app.scripts.has('freeScript')).to.equal(false);
+        });
+
+        it('attaches a script referenced by its class name after a nameless registerScript', function () {
+            // the pre-2.19.3 pattern that regressed in 2.19.3: register an ES6 class with no
+            // explicit name, then reference it on an entity by its (verbatim) class name
+            class PlayerController extends Script {}
+            registerScript(PlayerController, undefined, app);
+
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('script');
+
+            const instance = e.script.create('PlayerController');
+            expect(instance).to.be.an.instanceof(PlayerController);
+            expect(e.script.PlayerController).to.equal(instance);
         });
 
         it('an explicit name passed to registerScript still wins for a subclass', function () {


### PR DESCRIPTION
## Summary

Since **2.19.3**, registering an ES6 script class without an explicit name and referencing it by the class name stopped working — the script silently fails to attach. Reported by a user with "hundreds of scripts" extending `pc.ScriptType` and registered via `pc.registerScript(Class)`.

## Root cause

#8831 changed the name `registerScript`/`createScript` derive when no explicit name is given:

```js
// before (≤ 2.19.2): verbatim class name → "PlayerController"
name = name || script.__name || ScriptType.__getScriptName(script);
// after (2.19.3, #8831): lowerCamelCase → "playerController"
name = name || getScriptRegistryName(script);
```

The registry is keyed by that name, so an entity referencing the script as `PlayerController` no longer resolves it. Passing an explicit name works, but that's painful across hundreds of scripts.

## Fix

Restore the verbatim class-name fallback in `registerScript` only:

```js
name = name ||
    (Object.prototype.hasOwnProperty.call(script, '__name') && script.__name) ||
    getScriptName(script); // own scriptName, else verbatim class name
```

- **Own-property only**, so #8831's two real fixes are preserved: the ESM `static scriptName` class-field case and the subclass-name-collision case.
- **Scoped to `registerScript`.** `ScriptComponent.create`, `ScriptRegistry.add` and the asset loader still use the lowerCamelCase `getScriptRegistryName`. The editor and asset pipeline always pass an explicit name, so they're unaffected — only code-driven nameless `registerScript(Class)` changes (the regressed path).

This was chosen over a dual-name alias (previous draft, #8840) to avoid the long-term maintenance cost and edge cases of registering each script under two names.

### Note on `create(Class)`
`create()` is unchanged. For the register-then-reference flow it stays consistent: `registerScript(Class)` sets `__name` to the verbatim name, and `create()` reuses an existing own `__name` rather than recomputing. lowerCamelCase derivation in `create(Class)` only applies to a class that was never registered — long-standing behavior.

## Tests

- Updated the two tests that asserted the lowerCamelCase fallback to assert verbatim.
- Added a regression test: `registerScript(class PlayerController)` → `entity.script.create('PlayerController')` attaches the instance.
- Full suite: **1749 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)