### PR TITLE
test(build): add post-build tests for ESM/UMD bundles and API surface gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run Publint
         run: npm run publint
 
+      - name: Run Post-build tests
+        run: npm run test:build
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
     "lint": "eslint scripts src test utils build.mjs eslint.config.mjs rollup.config.mjs",
     "publint": "publint --level error",
     "serve": "serve build -l 51000 --cors",
-    "test": "mocha --ignore \"test/assets/scripts/*.js\" --recursive --require test/fixtures.mjs --timeout 5000",
+    "test": "mocha --ignore \"test/assets/scripts/*.js\" --ignore \"test/bundles/**\" --recursive --require test/fixtures.mjs --timeout 5000",
+    "test:build": "mocha --recursive \"test/bundles/**/*.test.mjs\" --timeout 30000",
     "test:coverage": "c8 npm test",
     "test:types": "tsc --pretty false build/playcanvas.d.ts"
   },

--- a/test/bundles/bindings.test.mjs
+++ b/test/bundles/bindings.test.mjs
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+
+import {
+    ESM_TARGETS, UMD_TARGETS,
+    createAppFrom, loadEsm, loadUmdCjs, loadUmdGlobal, setupDom, teardownDom
+} from './helpers.mjs';
+
+// guards the #8836 regression: `pc.app` must stay a live binding on the umd namespace, so that
+// reading the global `pc.app` reflects the app created later. Object.assign in the umd footer
+// froze it to its load-time null; Object.defineProperties (#8837) preserves the getter.
+describe('build / live bindings (pc.app)', function () {
+    this.timeout(30000);
+
+    describe('umd global', function () {
+        UMD_TARGETS.forEach((t) => {
+            it(t.name, function () {
+                const { pc, dom } = loadUmdGlobal(t.path);
+                expect(Object.getOwnPropertyDescriptor(pc, 'app').get, 'app is a live getter').to.be.a('function');
+                expect(pc.app, 'app starts null').to.be.null;
+                const app = createAppFrom(pc, dom.window.document);
+                expect(pc.app, 'app updates after construct').to.equal(app);
+                app.destroy();
+                dom.window.close();
+            });
+        });
+    });
+
+    describe('umd commonjs', function () {
+        UMD_TARGETS.forEach((t) => {
+            it(t.name, function () {
+                const pc = loadUmdCjs(t.path);
+                expect(Object.getOwnPropertyDescriptor(pc, 'app').get, 'app is a live getter').to.be.a('function');
+                expect(pc.app, 'app starts null').to.be.null;
+            });
+        });
+    });
+
+    describe('esm', function () {
+        afterEach(teardownDom);
+
+        ESM_TARGETS.forEach((t) => {
+            it(t.name, async function () {
+                setupDom();
+                const pc = await loadEsm(t.path);
+                const app = createAppFrom(pc, global.document);
+                expect(pc.app, 'app updates after construct').to.equal(app);
+                app.destroy();
+            });
+        });
+    });
+});
+
+// guards the #8839 follow-up: #8837 made every umd export getter-only, silently breaking
+// consumers that reassign members of the global `pc` (e.g. the editor's classic-script worker
+// overriding pc.createScript). exports must stay writable while keeping their live binding.
+describe('build / overridable exports (#8839)', function () {
+    this.timeout(30000);
+
+    describe('umd global', function () {
+        UMD_TARGETS.forEach((t) => {
+            it(t.name, function () {
+                const { pc, dom } = loadUmdGlobal(t.path);
+                expect(Object.getOwnPropertyDescriptor(pc, 'createScript').set, 'export has a setter').to.be.a('function');
+                const stub = function stub() {};
+                pc.createScript = stub;
+                expect(pc.createScript, 'override takes effect').to.equal(stub);
+                // overriding one member must not break another member's live binding
+                const app = createAppFrom(pc, dom.window.document);
+                expect(pc.app, 'live binding survives override').to.equal(app);
+                app.destroy();
+                dom.window.close();
+            });
+        });
+    });
+
+    describe('umd commonjs', function () {
+        UMD_TARGETS.forEach((t) => {
+            it(t.name, function () {
+                const pc = loadUmdCjs(t.path);
+                expect(Object.getOwnPropertyDescriptor(pc, 'createScript').set, 'export has a setter').to.be.a('function');
+                const stub = function stub() {};
+                pc.createScript = stub;
+                expect(pc.createScript, 'override takes effect').to.equal(stub);
+            });
+        });
+    });
+});
+
+// the spot-checks above prove the two real-world break cases (#8836 `app`, #8839 `createScript`)
+// end to end; this generalises the underlying invariant to the whole surface: every umd export
+// must be a live (get) and overridable (set) accessor, so a regression hitting any export — not
+// just those two — is caught.
+describe('build / all umd exports are live + overridable', function () {
+    this.timeout(30000);
+
+    UMD_TARGETS.forEach((t) => {
+        it(t.name, function () {
+            const { pc, dom } = loadUmdGlobal(t.path);
+            const broken = Object.keys(pc).filter((k) => {
+                const d = Object.getOwnPropertyDescriptor(pc, k);
+                return typeof d.get !== 'function' || typeof d.set !== 'function';
+            });
+            expect(broken, `exports not live+overridable: ${broken.slice(0, 5).join(', ')}`).to.be.empty;
+            dom.window.close();
+        });
+    });
+});

--- a/test/bundles/exports.test.mjs
+++ b/test/bundles/exports.test.mjs
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+
+import {
+    ESM_TARGETS, EXPECTED_EXPORTS, SOURCE_INDEX, UMD_TARGETS,
+    exportNames, loadEsm, loadUmdGlobal
+} from './helpers.mjs';
+
+describe('build / exports', function () {
+    this.timeout(30000);
+
+    let source;
+
+    before(async function () {
+        source = exportNames(await loadEsm(SOURCE_INDEX));
+    });
+
+    describe('expected exports present', function () {
+        UMD_TARGETS.forEach((t) => {
+            it(t.name, function () {
+                const { pc, dom } = loadUmdGlobal(t.path);
+                EXPECTED_EXPORTS.forEach(n => expect(pc, n).to.have.property(n));
+                dom.window.close();
+            });
+        });
+
+        ESM_TARGETS.forEach((t) => {
+            it(t.name, async function () {
+                const ns = await loadEsm(t.path);
+                EXPECTED_EXPORTS.forEach(n => expect(ns, n).to.have.property(n));
+            });
+        });
+    });
+
+    describe('export parity with src/index.js', function () {
+        UMD_TARGETS.forEach((t) => {
+            it(t.name, function () {
+                const { pc, dom } = loadUmdGlobal(t.path);
+                expect(exportNames(pc)).to.deep.equal(source);
+                dom.window.close();
+            });
+        });
+
+        ESM_TARGETS.forEach((t) => {
+            it(t.name, async function () {
+                expect(exportNames(await loadEsm(t.path))).to.deep.equal(source);
+            });
+        });
+    });
+});

--- a/test/bundles/helpers.mjs
+++ b/test/bundles/helpers.mjs
@@ -1,0 +1,121 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import vm from 'node:vm';
+
+import { JSDOM } from 'jsdom';
+
+// resolve a path under build/ relative to the repo root
+const build = p => fileURLToPath(new URL(`../../build/${p}`, import.meta.url));
+
+// url the engine assumes when reading document.baseURI / location
+const URL_ORIGIN = 'http://localhost:3210';
+
+// representative slice of the public api; parity (below) enforces the full surface
+export const EXPECTED_EXPORTS = [
+    'AppBase', 'app', 'Application', 'Entity', 'Scene',
+    'Vec2', 'Vec3', 'Vec4', 'Mat3', 'Mat4', 'Quat', 'Color',
+    'GraphicsDevice', 'NullGraphicsDevice', 'Texture', 'Mesh',
+    'Material', 'StandardMaterial', 'Asset', 'AssetRegistry', 'Camera'
+];
+
+// the four single-file umd bundles, loadable as a browser global or as commonjs
+export const UMD_TARGETS = [
+    { name: 'rel umd', path: build('playcanvas.js') },
+    { name: 'dbg umd', path: build('playcanvas.dbg.js') },
+    { name: 'prf umd', path: build('playcanvas.prf.js') },
+    { name: 'min umd', path: build('playcanvas.min.js') }
+];
+
+// esm single-file bundles plus the unbundled trees that `import 'playcanvas'` resolves to
+// (min has no tree)
+export const ESM_TARGETS = [
+    { name: 'rel esm bundle', path: build('playcanvas.mjs') },
+    { name: 'dbg esm bundle', path: build('playcanvas.dbg.mjs') },
+    { name: 'prf esm bundle', path: build('playcanvas.prf.mjs') },
+    { name: 'min esm bundle', path: build('playcanvas.min.mjs') },
+    { name: 'rel esm tree', path: build('playcanvas/src/index.js') },
+    { name: 'dbg esm tree', path: build('playcanvas.dbg/src/index.js') },
+    { name: 'prf esm tree', path: build('playcanvas.prf/src/index.js') }
+];
+
+// the engine's source export surface — the authoritative api every build must preserve.
+// anchoring on src (not a build artifact) means a uniform drop/rename by the build pipeline
+// is caught, instead of all targets silently agreeing with an equally-broken canonical.
+export const SOURCE_INDEX = fileURLToPath(new URL('../../src/index.js', import.meta.url));
+
+// the set of public export names, sorted, with the esm-only `default` filtered out
+export const exportNames = ns => Object.keys(ns).filter(k => k !== 'default').sort();
+
+// run a umd bundle inside a jsdom vm context so every dom reference it makes resolves to
+// that window, regardless of the realm calling into the returned classes
+export const loadUmdGlobal = (path) => {
+    const dom = new JSDOM('<!doctype html><body></body>', {
+        url: URL_ORIGIN,
+        runScripts: 'outside-only',
+        pretendToBeVisual: true
+    });
+    vm.runInContext(readFileSync(path, 'utf8'), dom.getInternalVMContext(), { filename: path });
+    return { pc: dom.window.pc, dom };
+};
+
+// run a umd bundle through its commonjs branch and return the populated exports
+export const loadUmdCjs = (path) => {
+    const mod = { exports: {} };
+    const ctx = vm.createContext({ module: mod, exports: mod.exports });
+    vm.runInContext(readFileSync(path, 'utf8'), ctx, { filename: path });
+    return mod.exports;
+};
+
+// native esm load
+export const loadEsm = path => import(pathToFileURL(path).href);
+
+let dom;
+
+// mirror test/jsdom.mjs: put the dom apis the engine reads onto node's global so an imported
+// esm bundle can construct an app. omits the src import that jsdom.mjs does.
+export const setupDom = () => {
+    dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>', {
+        resources: 'usable',
+        runScripts: 'dangerously',
+        url: URL_ORIGIN
+    });
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.ArrayBuffer = dom.window.ArrayBuffer;
+    global.Audio = dom.window.Audio;
+    global.DataView = dom.window.DataView;
+    global.Image = dom.window.Image;
+    global.KeyboardEvent = dom.window.KeyboardEvent;
+    global.MouseEvent = dom.window.MouseEvent;
+    global.XMLHttpRequest = dom.window.XMLHttpRequest;
+
+    global.Worker = class {
+        constructor(url) {
+            this.url = url;
+        }
+
+        postMessage(msg) {}
+
+        terminate() {}
+
+        onmessage = null;
+
+        addEventListener() {}
+
+        removeEventListener() {}
+    };
+
+    return dom;
+};
+
+export const teardownDom = () => {
+    dom?.window.close();
+    dom = null;
+};
+
+// build an app from a loaded bundle, mirroring test/app.mjs but sourced from `pc`
+export const createAppFrom = (pc, doc) => {
+    const canvas = doc.createElement('canvas');
+    return new pc.Application(canvas, { graphicsDevice: new pc.NullGraphicsDevice(canvas) });
+};

--- a/test/bundles/smoke.test.mjs
+++ b/test/bundles/smoke.test.mjs
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+
+import {
+    ESM_TARGETS, UMD_TARGETS,
+    createAppFrom, loadEsm, loadUmdGlobal, setupDom, teardownDom
+} from './helpers.mjs';
+
+// the built bundle can actually boot an application with the null graphics device
+describe('build / smoke', function () {
+    this.timeout(30000);
+
+    const assertApp = (pc, app) => {
+        expect(app.root, 'root entity').to.be.instanceOf(pc.Entity);
+        expect(app.scene, 'scene').to.be.instanceOf(pc.Scene);
+        expect(app.assets, 'asset registry').to.be.instanceOf(pc.AssetRegistry);
+    };
+
+    describe('umd global', function () {
+        UMD_TARGETS.forEach((t) => {
+            it(t.name, function () {
+                const { pc, dom } = loadUmdGlobal(t.path);
+                const app = createAppFrom(pc, dom.window.document);
+                assertApp(pc, app);
+                app.destroy();
+                dom.window.close();
+            });
+        });
+    });
+
+    describe('esm', function () {
+        afterEach(teardownDom);
+
+        ESM_TARGETS.forEach((t) => {
+            it(t.name, async function () {
+                setupDom();
+                const pc = await loadEsm(t.path);
+                const app = createAppFrom(pc, global.document);
+                assertApp(pc, app);
+                app.destroy();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

The mocha suite runs against `src/`, and CI only `publint`s the bundles — so build-output
regressions ship undetected. That's how #8836 (`pc.app` null in UMD) and #8839 (getter-only
exports breaking `pc.createScript` overrides) reached users. Closes #8838.

Adds a post-build runtime suite:

| Guard | Command | Checks | CI job |
|-------|---------|--------|--------|
| Post-build runtime suite (`test/bundles/`) | `npm run test:build` | each built bundle (rel/dbg/prf/min × UMD/ESM) loads (UMD global + CJS, ESM import) and boots an `Application`; runtime exports match `src/index.js`; `pc.app` live binding (#8836/#8837); UMD exports overridable (#8839); blanket invariant — **every** UMD export is a live + overridable accessor | `build` |

The public API surface gate (api-extractor) is split into a separate PR: #8848.

## Verification

| Check | Result |
|-------|--------|
| `npm run test:build` | 60 passing |
| `npm test` (unit) | unchanged |
| revert UMD footer to broken forms | corresponding `test:build` specs fail (#8836 + #8839) |
