### PR TITLE
ci: comment the public API diff on PRs (informative)

### DIFF
--- a/.github/workflows/api-report.yml
+++ b/.github/workflows/api-report.yml
@@ -1,0 +1,102 @@
+name: API Report
+
+# Builds a full-signature view of the public API for the PR head and its base, sourced from
+# TypeDoc's --json model — so it follows the docs' public-API rules (excludeNotDocumented, @ignore,
+# @private, the typedoc plugin) and never reports internal/ignored symbols. Diffs the two and
+# posts/updates a sticky PR comment. Informative only; never fails the build.
+#
+# Note: comments directly, so on fork PRs (read-only token) the comment step can't post; it is
+# marked continue-on-error so those runs stay green (just without a comment).
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: api-report-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  api-report:
+    name: API Report
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out base
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Check out PR
+        uses: actions/checkout@v6
+        with:
+          path: pr
+
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+
+      - name: Build base API surface
+        run: |
+          cp pr/utils/api-surface.mjs base/utils/api-surface.mjs
+          cd base
+          npm clean-install --progress=false --no-fund
+          npx typedoc --json api.json --skipErrorChecking
+          node utils/api-surface.mjs api.json > surface.txt
+
+      - name: Build PR API surface
+        run: |
+          cd pr
+          npm clean-install --progress=false --no-fund
+          npx typedoc --json api.json --skipErrorChecking
+          node utils/api-surface.mjs api.json > surface.txt
+
+      - name: Diff surfaces
+        run: git --no-pager diff --no-index -U0 -- base/surface.txt pr/surface.txt > api-diff.txt || true
+
+      - name: Comment on PR
+        continue-on-error: true # fork PRs get a read-only token; don't fail the run if commenting is denied
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- api-report-bot -->';
+            const prNumber = context.payload.pull_request.number;
+
+            const raw = fs.existsSync('api-diff.txt') ? fs.readFileSync('api-diff.txt', 'utf8') : '';
+            // each surface line is fully-qualified, so keep only +/- lines (drop diff/@@ headers)
+            const lines = raw.split('\n').filter(l => /^[+-]/.test(l) && !/^(\+\+\+|---)/.test(l));
+            const adds = lines.filter(l => l.startsWith('+')).length;
+            const dels = lines.filter(l => l.startsWith('-')).length;
+
+            let body;
+            if (!lines.length) {
+              body = `${MARKER}\n### Public API report\n\n✅ No public API changes in this PR.`;
+            } else {
+              // ~~~ fence (not ```), so backticks in PR-controlled content can't break out
+              let diff = lines.join('\n');
+              const LIMIT = 60000;
+              const note = diff.length > LIMIT ? '\n… (diff truncated)' : '';
+              if (note) diff = diff.slice(0, LIMIT);
+              body = `${MARKER}\n### Public API report\n\n`
+                + `This PR changes the public API surface (**+${adds} / −${dels}**), per the docs' rules `
+                + `(@ignore / @private / undocumented are excluded).\n\n`
+                + `<details><summary>Show API diff</summary>\n\n~~~diff\n${diff}${note}\n~~~\n\n</details>\n\n`
+                + `_Informational only — this never fails the build._`;
+            }
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: prNumber });
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            }

--- a/utils/api-surface.mjs
+++ b/utils/api-surface.mjs
@@ -1,0 +1,93 @@
+// Serialises a TypeDoc JSON model (`typedoc --json`) into a stable, sorted, full-signature text
+// view of the public API. Because it consumes TypeDoc's model, it inherits the docs' public-API
+// rules (excludeNotDocumented, @ignore, @private, the custom typedoc plugin) — so internal/ignored
+// symbols are absent. Usage: `node utils/api-surface.mjs <typedoc.json>` → surface on stdout.
+
+import { readFileSync } from 'node:fs';
+
+// TypeDoc ReflectionKind values we serialise at the top level
+const NAMESPACE = 4, ENUM = 8, VARIABLE = 32, FUNCTION = 64, CLASS = 128, INTERFACE = 256;
+const CONSTRUCTOR = 512, PROPERTY = 1024, METHOD = 2048, ACCESSOR = 262144, TYPE_ALIAS = 2097152;
+const TOP = [NAMESPACE, ENUM, VARIABLE, FUNCTION, CLASS, INTERFACE, TYPE_ALIAS];
+
+const flags = r => r.flags || {};
+
+function typeStr(t) {
+    if (!t) return 'unknown';
+    switch (t.type) {
+        case 'intrinsic': return t.name;
+        case 'literal': return typeof t.value === 'string' ? JSON.stringify(t.value) : `${t.value}`;
+        case 'reference': return t.name + (t.typeArguments?.length ? `<${t.typeArguments.map(typeStr).join(', ')}>` : '');
+        case 'array': return `${typeStr(t.elementType)}[]`;
+        case 'union': return t.types.map(typeStr).join(' | ');
+        case 'intersection': return t.types.map(typeStr).join(' & ');
+        case 'tuple': return `[${(t.elements || []).map(typeStr).join(', ')}]`;
+        case 'query': return `typeof ${typeStr(t.queryType)}`;
+        case 'indexedAccess': return `${typeStr(t.objectType)}[${typeStr(t.indexType)}]`;
+        case 'typeOperator': return `${t.operator} ${typeStr(t.target)}`;
+        case 'reflection': return reflStr(t.declaration);
+        case 'templateLiteral': return 'string';
+        case 'mapped': return '{ [mapped]: … }';
+        case 'predicate': return 'boolean';
+        default: return t.name || t.type || 'unknown';
+    }
+}
+
+function reflStr(decl) {
+    if (!decl) return 'object';
+    if (decl.signatures?.length) return `(${params(decl.signatures[0])}) => ${typeStr(decl.signatures[0].type)}`;
+    if (decl.children?.length) return `{ ${decl.children.map(c => `${c.name}: ${typeStr(c.type)}`).join('; ')} }`;
+    return 'object';
+}
+
+function params(sig) {
+    return (sig.parameters || []).map((p) => {
+        const f = flags(p);
+        return `${f.isRest ? '...' : ''}${p.name}${f.isOptional ? '?' : ''}: ${typeStr(p.type)}`;
+    }).join(', ');
+}
+
+function typeParams(r) {
+    return r.typeParameters?.length ?
+        `<${r.typeParameters.map(p => p.name + (p.type ? ` extends ${typeStr(p.type)}` : '')).join(', ')}>` : '';
+}
+
+// one member of a class/interface → one or more lines (overloads, get+set)
+function member(r) {
+    const f = flags(r);
+    const pre = (f.isStatic ? 'static ' : '') + (f.isReadonly ? 'readonly ' : '');
+    if (r.kind === CONSTRUCTOR) return r.signatures.map(s => `constructor(${params(s)})`);
+    if (r.kind === METHOD) return r.signatures.map(s => `${pre}${r.name}${typeParams(s)}(${params(s)}): ${typeStr(s.type)}`);
+    if (r.kind === ACCESSOR) {
+        const out = [];
+        if (r.getSignature) out.push(`${pre}get ${r.name}(): ${typeStr(r.getSignature.type)}`);
+        if (r.setSignature) out.push(`${pre}set ${r.name}(${params(r.setSignature)})`);
+        return out;
+    }
+    if (r.kind === PROPERTY) return [`${pre}${r.name}${f.isOptional ? '?' : ''}: ${typeStr(r.type)}`];
+    return [];
+}
+
+// flat, fully-qualified lines so each entry is self-contained in a diff (e.g. `Vec3.add(...)`)
+function decl(r) {
+    switch (r.kind) {
+        case CLASS:
+        case INTERFACE: {
+            const kw = r.kind === CLASS ? 'class' : 'interface';
+            const ext = r.extendedTypes?.length ? ` extends ${r.extendedTypes.map(typeStr).join(', ')}` : '';
+            return [`${kw} ${r.name}${typeParams(r)}${ext}`,
+                ...(r.children || []).flatMap(member).map(m => `${r.name}.${m}`)];
+        }
+        case FUNCTION: return (r.signatures || []).map(s => `function ${r.name}${typeParams(s)}(${params(s)}): ${typeStr(s.type)}`);
+        case VARIABLE: return [`const ${r.name}: ${typeStr(r.type)}`];
+        case TYPE_ALIAS: return [`type ${r.name}${typeParams(r)} = ${typeStr(r.type)}`];
+        case ENUM: return [`enum ${r.name}`, ...(r.children || []).map(c => `${r.name}.${c.name}`)];
+        case NAMESPACE: return [`namespace ${r.name}`,
+            ...(r.children || []).filter(c => TOP.includes(c.kind)).flatMap(decl).map(l => `${r.name}.${l}`)];
+        default: return [];
+    }
+}
+
+const json = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+const lines = (json.children || []).filter(r => TOP.includes(r.kind)).flatMap(decl).sort();
+process.stdout.write(`${lines.join('\n')}\n`);


### PR DESCRIPTION
## Summary

Posts an **informative, non-blocking** comment on each PR showing how it changes the public API
surface — sourced from **TypeDoc**, so it follows the exact rules the docs site uses
(`excludeNotDocumented`, `@ignore`, `@private`, the `utils/typedoc` plugin). Internal / ignored /
undocumented symbols never appear (e.g. the `@ignore`d `app` global is excluded).

A `pull_request` workflow builds a full-signature API surface for the PR head **and** its base,
diffs them, and posts/updates a sticky comment.

| Item | Detail |
|------|--------|
| Source of truth | `typedoc --json` (same config + plugin as `npm run docs`) → respects the docs' public-API rules |
| Serializer | `utils/api-surface.mjs` turns the TypeDoc model into a stable, sorted, fully-qualified, **full-signature** surface (e.g. `Vec3.add(rhs: Vec3): Vec3`) |
| Detail | full signatures — catches added/removed symbols **and** signature/type changes |
| Blocking? | **No** — comment step is `continue-on-error` |
| Footprint | 2 files: `utils/api-surface.mjs` + `.github/workflows/api-report.yml` |

**Why not api-extractor:** it keys off release tags (`@public`/`@internal`) and includes every
export in the `.d.ts` (marking undocumented ones), so it can't honour `@ignore` / `@private` /
`excludeNotDocumented` — which this engine uses (**323 `@ignore`, 233 `@private`, 0 `@internal`**).
TypeDoc already implements those rules, so the report is built from its model.

## Example

When a PR changes the public surface, the bot posts/updates one sticky comment. Example from a live
test on this PR (a temporary documented export, since reverted):

### Public API report

This PR changes the public API surface (**+1 / −0**), per the docs' rules (@ignore / @private / undocumented are excluded).

```diff
+const API_REPORT_SMOKE_TEST: 42
```

When nothing changes it instead says: **✅ No public API changes in this PR.**

## Forks

Comments directly, which needs a write token — granted only for same-repo branches. Fork PRs get a
read-only token, so the comment step is skipped (`continue-on-error`, so the run stays green without
a comment). Full fork coverage would need the `workflow_run` split, which can't run from a branch
before merging.

## Cost

Two `typedoc --json` runs per PR (head + base) — heavier than a unit job, but it's informational and
never gates merges.
