### PR TITLE
fix(scripts): remove inline {@link} from camera-frame LUT attribute description

### DIFF
--- a/scripts/esm/camera-frame.mjs
+++ b/scripts/esm/camera-frame.mjs
@@ -242,7 +242,7 @@ class ColorLUT {
 
     /**
      * Optional secondary LUT texture. When set, both LUTs are sampled and the two graded
-     * results are crossfaded according to {@link ColorLUT#blend}.
+     * results are crossfaded according to the blend factor.
      *
      * @attribute
      * @type {Asset}


### PR DESCRIPTION
The CameraFrame script fails to parse in the Editor after the dual-LUT change (#8749). The `texture2` attribute's description contained an inline JSDoc `{@link ColorLUT#blend}` tag.

When a JSDoc summary contains `{@link}`, TypeScript represents the comment as a `NodeArray` of comment nodes rather than a plain string. The attribute parser stores this verbatim as the attribute's `description`, and because those nodes carry circular `parent` references, serializing the parsed schema throws `Converting circular structure to JSON` — surfacing as an Editor parse error even though the program itself parses without error.

**Changes:**
- Replace the inline `{@link ColorLUT#blend}` reference in the `texture2` description with plain prose, so the description stays a string and the schema serializes cleanly.