### PR TITLE
Fix XrNavigation NaN rig corruption on gamepads without thumbstick axes

### DIFF
--- a/scripts/esm/xr-navigation.mjs
+++ b/scripts/esm/xr-navigation.mjs
@@ -365,8 +365,9 @@ class XrNavigation extends Script {
         if (!this.cameraEntity) return;
 
         for (const inputSource of this.inputSources) {
-            // Only process controllers with gamepads
-            if (!inputSource.gamepad) continue;
+            // Require a gamepad with thumbstick axes (axes[2]/[3]). Hand-tracking sources
+            // (e.g. Apple Vision Pro) report a gamepad with no axes, which would read as NaN.
+            if (!inputSource.gamepad || inputSource.gamepad.axes.length < 4) continue;
 
             // Left controller - movement
             if (inputSource.handedness === 'left') {
@@ -465,7 +466,8 @@ class XrNavigation extends Script {
         let rightController = null;
 
         for (const inputSource of this.inputSources) {
-            if (!inputSource.gamepad) continue;
+            // Require a gamepad with thumbstick axes — see handleSmoothLocomotion.
+            if (!inputSource.gamepad || inputSource.gamepad.axes.length < 4) continue;
             if (inputSource.handedness === 'right') {
                 rightController = inputSource;
                 break;


### PR DESCRIPTION
Entering VR on Apple Vision Pro left the scene blank (only the camera clear color visible) while head tracking worked. The camera rig transform was being corrupted to NaN on the second XR frame.

**Cause:**
XrNavigation reads thumbstick input from `gamepad.axes[2]`/`[3]` (the WebXR xr-standard mapping). AVP hand-tracking input sources expose a gamepad with an empty axes array, so those reads return `undefined` and `-undefined` is `NaN`.

The visible corruption was specific to **`turnMode: 'smooth'`** — its guard `Math.abs(turn) <= threshold` does not catch NaN (NaN comparisons are always false), so the NaN flowed into `rotateLocal` and corrupted the rig — and its child camera — to NaN permanently. Splats still submitted but projected to NaN, so nothing rasterized.

This was *not* a problem in the general case: the snap-turn path (`Math.abs(rotate) > threshold`) and smooth locomotion (`length() > threshold`) gate on conditions that are correctly false for NaN, so they were already inert with absent axes — they just never moved. Only the smooth-turn polarity let NaN through. Controller-based headsets (Quest) report real `axes[2] = 0` and were unaffected regardless of turn mode.

**Changes:**
- Skip input sources whose gamepad does not expose thumbstick axes (`axes.length < 4`) in `handleSmoothLocomotion` (covers locomotion and both turn modes) and `handleSnapVertical`.

On hand-tracking-only devices, thumbstick locomotion/turning is now cleanly inert (there is no thumbstick to drive it) rather than corrupting the rig. Devices with conformant xr-standard gamepads report 4 axes and are unchanged.