### PR TITLE
fix(shader): emit SCENE_DEPTHMAP_FLOAT for materials sampling scene depth

### DIFF
--- a/src/scene/shader-lib/shader-utils.js
+++ b/src/scene/shader-lib/shader-utils.js
@@ -143,6 +143,12 @@ class ShaderUtils {
         const defines = new Map(material.defines);
         params.cameraShaderParams.defines.forEach((value, key) => defines.set(key, value));
 
+        // cameraShaderParams.defines cannot emit SCENE_DEPTHMAP_FLOAT as it has no device
+        // reference, so add the screenDepth chunk defines here. This ensures screenDepthPS
+        // decodes the scene depth in the format the depth prepass allocated (R32F when the
+        // device is textureFloatRenderable, packed RGBA8 otherwise).
+        ShaderUtils.addScreenDepthChunkDefines(params.device, params.cameraShaderParams, defines);
+
         // add pass defines
         const shaderPassInfo = ShaderPass.get(params.device).getByIndex(params.pass);
         shaderPassInfo.defines.forEach((value, key) => defines.set(key, value));


### PR DESCRIPTION
## Description

Materials that sample the scene depth map via `screenDepthPS` were decoding it in the wrong format on `textureFloatRenderable` devices, producing garbage depth values (visible as zebra/banding artifacts on any geometry shaded against scene depth — e.g. a gsplat cutout effect, and StandardMaterial paths that read `uSceneDepthMap`).

### Root cause

`screenDepthPS` selects its decode from two defines:

```glsl
#ifdef SCENE_DEPTHMAP_LINEAR
    #ifdef SCENE_DEPTHMAP_FLOAT
        return texture2D(uSceneDepthMap, uv).r;   // R32F: read float directly
    #else
        // unpack a float from RGBA8 ...
    #endif
#endif
```

Material shaders assemble their defines through `ShaderUtils.getCoreDefines`, which copies `cameraShaderParams.defines`. `CameraShaderParams` can only ever emit `SCENE_DEPTHMAP_LINEAR` — it has no `device` reference, and `SCENE_DEPTHMAP_FLOAT` depends on `device.textureFloatRenderable`. So the material path never set `SCENE_DEPTHMAP_FLOAT`.

Meanwhile `RenderPassPrepass` allocates the linear-depth texture as `R32F` when `device.textureFloatRenderable` (and packed `RGBA8` otherwise). On a float-renderable device the texture is therefore R32F, but the material shader took the packed-RGBA8 decode branch → wrong values.

The post-process passes (`render-pass-taa`, `render-pass-coc`, `render-pass-ssao`, `render-pass-depth-aware-blur`) each already work around this by calling `ShaderUtils.addScreenDepthChunkDefines(device, ...)` themselves. The material define path was the one place that didn't.

### Fix

Call `ShaderUtils.addScreenDepthChunkDefines` from `getCoreDefines` (which already has `params.device` in scope), so materials get `SCENE_DEPTHMAP_FLOAT` whenever the device is float-renderable — matching the format the prepass allocated. The redundant `SCENE_DEPTHMAP_LINEAR` re-set is a no-op (same key/value).

Fixes #

## Checklist
- [x] I have read the [[contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change