### PR TITLE
Add MeshInstance.shaderPassMask to control shader pass participation

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -192,6 +192,9 @@ class CameraComponent extends Component {
      * - {@link SHADERPASS_LIGHTING}
      * - {@link SHADERPASS_UV0}
      *
+     * The returned index can be used with {@link MeshInstance#shaderPassMask} to control which mesh
+     * instances are rendered in this pass.
+     *
      * @returns {number} The id of the shader pass.
      */
     setShaderPass(name) {

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -288,6 +288,36 @@ class MeshInstance {
     visible = true;
 
     /**
+     * A bitmask controlling which shader passes this mesh instance is rendered in. Bit N
+     * corresponds to the shader pass with index N: the built-in forward pass is
+     * {@link SHADER_FORWARD}, and indices for custom shader passes are obtained from
+     * {@link CameraComponent#setShaderPass}. Defaults to `0xFFFFFFFF` (all passes). For example,
+     * clearing the forward pass bit keeps the mesh in the other passes (such as the camera depth
+     * prepass that feeds Depth of Field) while making it invisible in the rendered color image.
+     *
+     * @type {number}
+     * @example
+     * // clear the forward (color) pass bit, leaving all other pass bits set: the mesh is no longer
+     * // drawn in the color image, but still takes part in the other passes (such as the prepass)
+     * meshInstance.shaderPassMask &= ~(1 << pc.SHADER_FORWARD);
+     * @example
+     * // set the forward (color) pass bit, leaving all other pass bits unchanged
+     * meshInstance.shaderPassMask |= (1 << pc.SHADER_FORWARD);
+     * @example
+     * // exclude the mesh from a custom shader pass set up on the camera (see
+     * // CameraComponent#setShaderPass), leaving all other pass bits set
+     * const customPass = cameraComponent.setShaderPass('custom_rendering');
+     * meshInstance.shaderPassMask &= ~(1 << customPass);
+     * @example
+     * // test whether the forward (color) pass bit is set
+     * const forwardBitSet = (meshInstance.shaderPassMask & (1 << pc.SHADER_FORWARD)) !== 0;
+     * @example
+     * // set every pass bit (the default value)
+     * meshInstance.shaderPassMask = 0xFFFFFFFF;
+     */
+    shaderPassMask = 0xFFFFFFFF;
+
+    /**
      * Read this value in the {@link Scene.EVENT_POSTCULL} event to determine if the object is
      * actually going to be rendered.
      */

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -545,6 +545,12 @@ class ForwardRenderer extends Renderer {
             /** @type {MeshInstance} */
             const drawCall = drawCalls[i];
 
+            // skip mesh instances that are not rendered in this shader pass (inlined bit test to
+            // avoid a function call in this hot loop)
+            if ((drawCall.shaderPassMask & (1 << pass)) === 0) {
+                continue;
+            }
+
             // #if _PROFILER
             if (camera === ForwardRenderer.skipRenderCamera) {
                 if (ForwardRenderer._skipRenderCounter >= ForwardRenderer.skipRenderAfter) {


### PR DESCRIPTION
Adds a per-mesh-instance bitmask controlling which shader passes a mesh instance is rendered in.

**Changes:**
- New `MeshInstance.shaderPassMask` property (defaults to `0xFFFFFFFF`, all passes). Bit N enables the mesh instance in shader pass index N.
- The forward renderer skips a mesh instance in a pass when its bit is cleared (inlined bit test in the draw-call prepare loop).
- Cross-linked the docs between `MeshInstance#shaderPassMask` and `CameraComponent#setShaderPass`, so the custom pass index returned by `setShaderPass` can be used directly in the mask.

**API Changes:**
- Added `MeshInstance.shaderPassMask` (number, public).

A primary use case: render a mesh into the depth prepass (feeding effects such as Depth of Field) while excluding it from the forward color pass, so it contributes depth without being visible. Also supports including/excluding meshes from custom camera shader passes.