### PR TITLE
Tune the Depth of Field example (splat budget + WebGPU)

### DIFF
--- a/examples/src/examples/gaussian-splatting/depth-of-field.example.mjs
+++ b/examples/src/examples/gaussian-splatting/depth-of-field.example.mjs
@@ -96,6 +96,9 @@ assetListLoader.load(() => {
 
     app.systems.rigidbody?.gravity.set(0, -10, 0);
 
+    // cap the number of rendered splats - lower on mobile to keep performance up
+    app.scene.gsplat.splatBudget = (pc.platform.mobile ? 1 : 3) * 1000000;
+
     // ------ Content root ------
     // The splat and the proxy / collision meshes share the same coordinate space, so we parent
     // them to a single entity to keep them aligned.

--- a/examples/src/examples/gaussian-splatting/depth-of-field.example.mjs
+++ b/examples/src/examples/gaussian-splatting/depth-of-field.example.mjs
@@ -4,6 +4,8 @@
 //
 // A Gaussian Splatting scene using Depth of Field post-processing, where the depth is based on a
 // proxy mesh.
+//
+// @flag PREFERRED_DEVICE=webgpu
 
 import * as pc from 'playcanvas';
 import { FirstPersonController } from 'playcanvas/scripts/esm/first-person-controller.mjs';
@@ -98,6 +100,11 @@ assetListLoader.load(() => {
 
     // cap the number of rendered splats - lower on mobile to keep performance up
     app.scene.gsplat.splatBudget = (pc.platform.mobile ? 1 : 3) * 1000000;
+
+    // use the GPU-sort raster renderer on WebGPU, CPU-sort on WebGL
+    app.scene.gsplat.renderer = device.isWebGPU ?
+        pc.GSPLAT_RENDERER_RASTER_GPU_SORT :
+        pc.GSPLAT_RENDERER_RASTER_CPU_SORT;
 
     // ------ Content root ------
     // The splat and the proxy / collision meshes share the same coordinate space, so we parent


### PR DESCRIPTION
Follow-up to #8853 — performance tuning for the `gaussian-splatting/depth-of-field` example.

**Changes:**
- Set `app.scene.gsplat.splatBudget`: 1M splats on mobile, 3M otherwise.
- Default the example to WebGPU via the `PREFERRED_DEVICE=webgpu` config flag.
- Use the GPU-sort raster renderer on WebGPU (CPU-sort on WebGL).