### PR TITLE
Add SpAItial AI attribution to the Depth of Field example

### DIFF
--- a/examples/src/examples/gaussian-splatting/depth-of-field.example.mjs
+++ b/examples/src/examples/gaussian-splatting/depth-of-field.example.mjs
@@ -6,6 +6,11 @@
 // proxy mesh.
 //
 // @flag PREFERRED_DEVICE=webgpu
+//
+// @credit
+// title: Ice Cave
+// author: SpAItial AI
+// source: https://spaitial.ai/
 
 import * as pc from 'playcanvas';
 import { FirstPersonController } from 'playcanvas/scripts/esm/first-person-controller.mjs';


### PR DESCRIPTION
Adds a `@credit` block crediting SpAItial AI (https://spaitial.ai/) as the source of the ice cave Gaussian Splat and its reconstructed proxy / collision meshes used in the `gaussian-splatting/depth-of-field` example.