### PR TITLE
fix(shader): select scene depth decode via CAPS_TEXTURE_FLOAT_RENDERABLE

### DIFF
--- a/src/extras/render-passes/render-pass-coc.js
+++ b/src/extras/render-passes/render-pass-coc.js
@@ -30,7 +30,7 @@ class RenderPassCoC extends RenderPassShaderQuad {
         if (nearBlur) defines.set('NEAR_BLUR', '');
 
         // add defines needed for correct use of screenDepthPS chunk
-        ShaderUtils.addScreenDepthChunkDefines(device, cameraComponent.shaderParams, defines);
+        ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
 
         this.shader = ShaderUtils.createShader(device, {
             uniqueName: `CocShader-${nearBlur}`,

--- a/src/extras/render-passes/render-pass-depth-aware-blur.js
+++ b/src/extras/render-passes/render-pass-depth-aware-blur.js
@@ -24,7 +24,7 @@ class RenderPassDepthAwareBlur extends RenderPassShaderQuad {
         if (horizontal) defines.set('HORIZONTAL', '');
 
         // add defines needed for correct use of screenDepthPS chunk
-        ShaderUtils.addScreenDepthChunkDefines(device, cameraComponent.shaderParams, defines);
+        ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
 
         this.shader = ShaderUtils.createShader(device, {
             uniqueName: `DepthAware${horizontal ? 'Horizontal' : 'Vertical'}BlurShader`,

--- a/src/extras/render-passes/render-pass-ssao.js
+++ b/src/extras/render-passes/render-pass-ssao.js
@@ -81,7 +81,7 @@ class RenderPassSsao extends RenderPassShaderQuad {
         const defines = new Map();
 
         // add defines needed for correct use of screenDepthPS chunk
-        ShaderUtils.addScreenDepthChunkDefines(device, cameraComponent.shaderParams, defines);
+        ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
 
         this.shader = ShaderUtils.createShader(device, {
             uniqueName: 'SsaoShader',

--- a/src/extras/render-passes/render-pass-taa.js
+++ b/src/extras/render-passes/render-pass-taa.js
@@ -57,7 +57,7 @@ class RenderPassTAA extends RenderPassShaderQuad {
         defines.set('QUALITY_HIGH', true);
 
         // add defines needed for correct use of screenDepthPS chunk
-        ShaderUtils.addScreenDepthChunkDefines(device, cameraComponent.shaderParams, defines);
+        ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
 
         this.shader = ShaderUtils.createShader(device, {
             uniqueName: 'TaaResolveShader',

--- a/src/scene/shader-lib/glsl/chunks/common/frag/screenDepth.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/screenDepth.js
@@ -38,7 +38,7 @@ float delinearizeDepth(float linearDepth) {
 // Retrieves rendered linear camera depth by UV
 float getLinearScreenDepth(vec2 uv) {
     #ifdef SCENE_DEPTHMAP_LINEAR
-        #ifdef SCENE_DEPTHMAP_FLOAT
+        #ifdef CAPS_TEXTURE_FLOAT_RENDERABLE
             return texture2D(uSceneDepthMap, uv).r;
         #else
 

--- a/src/scene/shader-lib/shader-utils.js
+++ b/src/scene/shader-lib/shader-utils.js
@@ -189,18 +189,17 @@ class ShaderUtils {
 
     /**
      * Add defines required for correct screenDepthPS chunk functionality for the given camera
-     * shader parameters.
+     * shader parameters. Note that the float vs packed-RGBA8 decode is selected inside the chunk
+     * using the global CAPS_TEXTURE_FLOAT_RENDERABLE define, which matches the format the depth
+     * prepass allocates the linear depth texture in.
      *
-     * @param {GraphicsDevice} device - The graphics device.
      * @param {CameraShaderParams} cameraShaderParams - The camera shader parameters.
+     * @param {Map<string, string>} defines - The map of defines to add to.
      * @ignore
      */
-    static addScreenDepthChunkDefines(device, cameraShaderParams, defines) {
+    static addScreenDepthChunkDefines(cameraShaderParams, defines) {
         if (cameraShaderParams.sceneDepthMapLinear) {
             defines.set('SCENE_DEPTHMAP_LINEAR', '');
-        }
-        if (device.textureFloatRenderable) {
-            defines.set('SCENE_DEPTHMAP_FLOAT', '');
         }
     }
 }


### PR DESCRIPTION
Materials sampling scene depth via the `screenDepthPS` chunk decoded it in the wrong format on `textureFloatRenderable` devices, producing zebra/banding artifacts (e.g. the ground-fog effect and StandardMaterial paths reading `uSceneDepthMap`).

This is an alternative to #8851. Rather than injecting a `SCENE_DEPTHMAP_FLOAT` define onto the material path, it removes that define entirely and selects the decode in the chunk from the global `CAPS_TEXTURE_FLOAT_RENDERABLE` define instead.

**Root cause:**
`RenderPassPrepass` allocates the linear depth texture as `R32F` when `device.textureFloatRenderable` (packed `RGBA8` otherwise), but the `screenDepthPS` decode was gated by a separate `SCENE_DEPTHMAP_FLOAT` define that the material path (`ShaderUtils.getCoreDefines`) never set — so the shader took the packed-RGBA8 branch against an R32F texture. The two were independent flags that could disagree.

**Changes:**
- `screenDepth` GLSL chunk now selects the float vs packed-RGBA8 decode using `CAPS_TEXTURE_FLOAT_RENDERABLE`, which `initCapsDefines` already emits into every shader from the same `device.textureFloatRenderable` flag the prepass uses. Format and decode now share a single source of truth and can never disagree.
- Removed the `SCENE_DEPTHMAP_FLOAT` define and dropped the `device.textureFloatRenderable` branch (plus the now-unused `device` param) from `ShaderUtils.addScreenDepthChunkDefines`, which now only sets the camera-specific `SCENE_DEPTHMAP_LINEAR`.
- Updated the four post-process passes (coc, taa, ssao, depth-aware-blur) to the new `addScreenDepthChunkDefines` signature.

The WGSL chunk was unaffected — it never had a float branch.