### PR TITLE
Add stereo XR support to hybrid GPU-sort gsplat renderer

### DIFF
--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.controls.jsx
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.controls.jsx
@@ -38,10 +38,20 @@ export function Controls({ observer }) {
                     <SliderInput
                         binding={new BindingTwoWay()}
                         link={{ observer, path: 'splatBudget' }}
-                        min={0}
-                        max={10}
+                        min={0.1}
+                        max={3}
                         precision={2}
                         step={0.05}
+                    />
+                </LabelGroup>
+                <LabelGroup text='XR Res Scale'>
+                    <SliderInput
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'framebufferScaleFactor' }}
+                        min={0.3}
+                        max={1}
+                        precision={1}
+                        step={0.1}
                     />
                 </LabelGroup>
             </Panel>

--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
@@ -10,9 +10,9 @@
 import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { GsplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
+import { XrMenu } from 'playcanvas/scripts/esm/xr-menu.mjs';
 import { XrNavigation } from 'playcanvas/scripts/esm/xr-navigation.mjs';
 import { XrSession } from 'playcanvas/scripts/esm/xr-session.mjs';
-import { XrMenu } from 'playcanvas/scripts/esm/xr-menu.mjs';
 
 import { data, deviceType } from 'examples/context';
 

--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
@@ -12,6 +12,7 @@ import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { GsplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
 import { XrNavigation } from 'playcanvas/scripts/esm/xr-navigation.mjs';
 import { XrSession } from 'playcanvas/scripts/esm/xr-session.mjs';
+import { XrMenu } from 'playcanvas/scripts/esm/xr-menu.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -36,10 +37,23 @@ createOptions.componentSystems = [
     pc.CameraComponentSystem,
     pc.LightComponentSystem,
     pc.ScriptComponentSystem,
-    pc.GSplatComponentSystem
+    pc.GSplatComponentSystem,
+    // UI systems required by the in-XR HUD (XrMenu builds screen/element/button components).
+    pc.ScreenComponentSystem,
+    pc.ElementComponentSystem,
+    pc.ButtonComponentSystem
 ];
-createOptions.resourceHandlers = [pc.TextureHandler, pc.ContainerHandler, pc.ScriptHandler, pc.GSplatHandler];
+createOptions.resourceHandlers = [
+    pc.TextureHandler,
+    pc.ContainerHandler,
+    pc.ScriptHandler,
+    pc.GSplatHandler,
+    // Required to load the HUD font asset.
+    pc.FontHandler
+];
 createOptions.xr = pc.XrManager;
+// Enables element click events (desktop fallback); XR ray/finger picking is handled inside XrMenu.
+createOptions.elementInput = new pc.ElementInput(canvas);
 
 const app = new pc.AppBase(canvas);
 app.init(createOptions);
@@ -96,7 +110,9 @@ const LOD_PRESETS = {
 const lodPresetKey = pc.platform.mobile ? 'mobile' : 'desktop';
 
 const assets = {
-    church: new pc.Asset('gsplat', 'gsplat', { url: config.url })
+    church: new pc.Asset('gsplat', 'gsplat', { url: config.url }),
+    // Monospace font for the in-XR debug HUD (XrMenu) text rendering.
+    font: new pc.Asset('font', 'font', { url: './assets/fonts/courier.json' })
 };
 
 /**
@@ -177,6 +193,8 @@ assetListLoader.load(() => {
 
     data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
     data.set('splatBudget', 1);
+    // XR framebuffer scale factor (applied only when starting an XR session; does not affect 2D).
+    data.set('framebufferScaleFactor', 1);
     data.set('data.stats.gsplats', '—');
     data.set('data.stats.resolution', '—');
 
@@ -226,6 +244,44 @@ assetListLoader.load(() => {
             turnMode: 'smooth',
             smoothTurnSpeed: 90
         }
+    });
+
+    // In-XR debug HUD: an always-visible, camera-following menu. Label-only rows (no eventName)
+    // act as live readouts updated each frame via setItemLabel. Starting with FPS.
+    // Base scale at full framebuffer resolution; scaled up at lower resolutions for readability.
+    const HUD_BASE_SCALE = 1.2;
+    const menuEntity = new pc.Entity('XrHud');
+    menuEntity.addComponent('script');
+    menuEntity.script.create(XrMenu, {
+        properties: {
+            menuItems: [
+                { label: 'FPS: --' },          // [0] label-only readout (updated each frame)
+                { label: 'RES: --' },          // [1] label-only readout (updated each frame)
+                { label: 'FOVEATION: OFF', eventName: 'xrhud:foveation' }, // [2] toggle (off by default)
+                { label: 'EXIT XR', eventName: 'xr:end' } // [3] interactive: ends the XR session
+            ],
+            fontAsset: assets.font,
+            alwaysVisible: true,
+            followDistance: 0.6,
+            followOffset: new pc.Vec2(0.1, -0.1),
+            menuScale: HUD_BASE_SCALE,
+            buttonWidth: 0.13
+        }
+    });
+    app.root.addChild(menuEntity);
+    const xrHud = /** @type {any} */ (menuEntity.script).xrMenu;
+
+    // Fixed foveation toggle, driven from the in-XR HUD. Off by default. fixedFoveation can only be
+    // set during an active session and is ignored unless anti-aliasing is off (it is here).
+    let foveationEnabled = false;
+    const FOVEATION_LEVEL = 1; // highest foveation when enabled
+    const applyFoveation = () => {
+        app.xr.fixedFoveation = foveationEnabled ? FOVEATION_LEVEL : 0;
+        xrHud?.setItemLabel(2, `FOVEATION: ${foveationEnabled ? 'ON' : 'OFF'}`);
+    };
+    app.on('xrhud:foveation', () => {
+        foveationEnabled = !foveationEnabled;
+        applyFoveation();
     });
 
     /** @type {pc.Entity|null} */
@@ -316,7 +372,16 @@ assetListLoader.load(() => {
             // local-floor: WebXR puts the local-space origin at the floor below the viewer at
             // session start, so the camera (child of the rig) ends up at rig + ~1.6 m on Y.
             // `local` would put the head at rig.y, sinking the viewpoint into the scene floor.
-            app.fire('vr:start', pc.XRSPACE_LOCALFLOOR);
+            //
+            // Start XR directly (rather than firing 'vr:start') so we can pass framebufferScaleFactor
+            // from the controls — it is read-only once a session is running. XrSession still performs
+            // its rig setup, as that is bound to the xr 'start' event, not the start call.
+            camera.camera.startXr(pc.XRTYPE_VR, pc.XRSPACE_LOCALFLOOR, {
+                framebufferScaleFactor: data.get('framebufferScaleFactor'),
+                callback: (err) => {
+                    if (err) setMessage(`Failed to start VR: ${err.message}`);
+                }
+            });
         } else {
             setMessage('Immersive VR is not available');
         }
@@ -345,6 +410,13 @@ assetListLoader.load(() => {
         app.xr.on('start', () => {
             setCameraControlsForXr();
             updateEnterVrButton();
+            // Fixed foveation is per-session (new layer each session); start disabled and sync the HUD.
+            foveationEnabled = false;
+            applyFoveation();
+            // Scale the HUD up inversely with the framebuffer scale so text stays readable at lower
+            // resolutions (e.g. 0.5x scale -> 2x larger menu). Full resolution keeps the base size.
+            const scaleFactor = data.get('framebufferScaleFactor') || 1;
+            xrHud?.setMenuScale(HUD_BASE_SCALE / scaleFactor);
             setMessage('VR active — left thumbstick: move, right: turn; tap to exit');
         });
         app.xr.on('end', () => {
@@ -376,5 +448,9 @@ assetListLoader.load(() => {
         data.set('data.stats.gsplats', app.stats.frame.gsplats.toLocaleString());
         const bb = app.graphicsDevice.backBufferSize;
         data.set('data.stats.resolution', `${bb.x} x ${bb.y}`);
+
+        // Live readouts in the in-XR HUD (app.stats.frame.fps is recomputed once per second).
+        xrHud?.setItemLabel(0, `FPS: ${app.stats.frame.fps}`);
+        xrHud?.setItemLabel(1, `RES: ${bb.x} x ${bb.y}`);
     });
 });

--- a/scripts/esm/xr-menu.mjs
+++ b/scripts/esm/xr-menu.mjs
@@ -480,6 +480,21 @@ class XrMenu extends Script {
     }
 
     /**
+     * Sets the overall menu scale at runtime, re-applying it to the menu screen immediately.
+     * Useful for compensating text readability when the XR framebuffer resolution is reduced
+     * (scale the menu up so it covers more framebuffer pixels).
+     *
+     * @param {number} value - New overall scale multiplier for the whole menu.
+     */
+    setMenuScale(value) {
+        this.menuScale = value;
+        if (this._screenEntity) {
+            const scale = this._uiScale * value;
+            this._screenEntity.setLocalScale(scale, scale, scale);
+        }
+    }
+
+    /**
      * @param {XrInputSource} inputSource - The input source that was added.
      * @private
      */

--- a/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-compute-local-renderer.js
@@ -664,8 +664,9 @@ class GSplatComputeLocalRenderer extends GSplatRenderer {
 
         const alphaClip = pickMode ? this._alphaClip : Math.max(ALPHA_VISIBILITY_THRESHOLD, this._alphaClipForward);
 
-        // Ensure fisheyeProj is up-to-date (culling may not have run this frame)
-        this.fisheyeProj.update(this._fisheye, camera.fov, cam.projectionMatrix);
+        // Ensure fisheyeProj is up-to-date (culling may not have run this frame).
+        // Forced off in XR — see GSplatRenderer.resolveFisheye.
+        this.fisheyeProj.update(this.resolveFisheye(this._fisheye), camera.fov, cam.projectionMatrix);
 
         const fisheyeEnabled = this.fisheyeProj.enabled;
         const createCountShader = (pick, fisheye) => this._createCountShaderAndFormat(pick, fisheye);

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -110,6 +110,7 @@ class GSplatHybridRenderer extends GSplatRenderer {
         this._internalDefines.add('PICK_CUSTOM_ID');
         this._internalDefines.add('GSPLAT_OVERDRAW');
         this._internalDefines.add('GSPLAT_NO_FOG');
+        this._internalDefines.add('GSPLAT_XR');
 
         this.meshInstance = this.createMeshInstance();
     }
@@ -165,6 +166,22 @@ class GSplatHybridRenderer extends GSplatRenderer {
         this._material.blendType = dither ? BLEND_NONE : BLEND_PREMULTIPLIED;
         this._material.depthWrite = !!dither;
         this._material.update();
+    }
+
+    /**
+     * Toggles the XR stereo (GSPLAT_XR) variant of the forward material. The vertex shader then
+     * reads the per-eye stereo projection-cache layout and selects the eye via `view_index`. Only
+     * recompiles when the stereo state changes, so it is cheap to call every frame. Must stay in
+     * sync with the projector's stereo variant (both driven by the same isStereo value).
+     *
+     * @param {boolean} enabled - Whether stereo (2-view) rendering is active.
+     */
+    setStereo(enabled) {
+        // The material is the single source of truth; only recompile when the state actually changes.
+        if (this._material.getDefine('GSPLAT_XR') !== enabled) {
+            this._material.setDefine('GSPLAT_XR', enabled);
+            this._material.update();
+        }
     }
 
     update(count, textureSize) {

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1661,13 +1661,23 @@ class GSplatManager {
         const viewportWidth = Math.floor((xrView ? xrView.viewport.z : (rt ? rt.width : this.device.width)) * rect.z);
         const viewportHeight = Math.floor((xrView ? xrView.viewport.w : (rt ? rt.height : this.device.height)) * rect.w);
 
+        // Stereo XR: project both eyes in a single projector pass (GSPLAT_XR variant). Requires
+        // exactly 2 parallel-axis views. Keep the VS define in sync with the projector variant.
+        const xrViewCount = sceneCam.xr?.session ? sceneCam.xr.views.list.length : 0;
+        if (xrViewCount > 2) {
+            Debug.errorOnce(`GSplatManager: the hybrid GPU-sort renderer supports at most 2 XR views (stereo), but the session has ${xrViewCount}. Additional views will not render correctly.`);
+        }
+        const isStereo = xrViewCount === 2;
+        this.renderer.setStereo?.(isStereo);
+
         const sortedIndices = this.sortGpuHybridForCamera(
             worldState,
             this.cameraNode,
             viewportWidth,
             viewportHeight,
             Math.max(ALPHA_VISIBILITY_THRESHOLD, this.scene.gsplat.alphaClipForward),
-            false
+            false,
+            isStereo
         );
 
         if (sortedIndices) {
@@ -1684,10 +1694,12 @@ class GSplatManager {
      * @param {number} viewportHeight - Projection viewport height in pixels.
      * @param {number} alphaClip - Projector producer alpha threshold.
      * @param {boolean} pickMode - Whether projector writes pcId into the cache.
+     * @param {boolean} [isStereo] - Whether to project both XR eyes in one pass (forward path only;
+     * picking stays mono).
      * @returns {StorageBuffer|null} The sorted cache indices, or null if no work was dispatched.
      * @private
      */
-    sortGpuHybridForCamera(worldState, cameraNode, viewportWidth, viewportHeight, alphaClip, pickMode) {
+    sortGpuHybridForCamera(worldState, cameraNode, viewportWidth, viewportHeight, alphaClip, pickMode, isStereo = false) {
         const gpuSorter = this.gpuSorter;
         const projector = this.projector;
         Debug.assert(gpuSorter && projector, 'Hybrid GPU sort not initialized');
@@ -1756,6 +1768,7 @@ class GSplatManager {
             pickMode,
             fisheyeProj,
             antiAlias: gsplat.antiAlias,
+            isStereo,
             material: gsplat.material
         });
 

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1901,7 +1901,8 @@ class GSplatManager {
 
         const gsplat = this.scene.gsplat;
         const fp = this.renderer.fisheyeProj;
-        fp.update(gsplat.fisheye, cam.fov, cam.projectionMatrix);
+        // XR does not support fisheye in any renderer; resolveFisheye forces it off (and warns once).
+        fp.update(this.renderer.resolveFisheye(gsplat.fisheye), cam.fov, cam.projectionMatrix);
 
         if (fp.enabled) {
             this.workBuffer.frustumCuller.setFisheyeData(

--- a/src/scene/gsplat-unified/gsplat-projector-constants.js
+++ b/src/scene/gsplat-unified/gsplat-projector-constants.js
@@ -16,5 +16,17 @@
 //   [5] v2.xy        (pack2x16float)  — screen-pixel eigenvector × eigenvalue (axis 2)
 //   [6] color rg     (pack2x16float)  — color channels R, G (or pcId in pick mode)
 //   [7] color b + a  (pack2x16float)  — color channel B and final opacity (after AA / alpha gate)
+//
+// XR stereo variant (compiled with the `GSPLAT_XR` define; same 8 u32 / 32 B stride, so buffer
+// sizes are unchanged). Only the per-eye screen position is duplicated; everything else is shared
+// between the two eyes — valid because WebXR stereo is parallel-axis (see Renderer.updateCameraFrustum).
+// Perspective-only: clip.z is NOT stored, it is reconstructed in the hybrid VS from the shared w.
+//   [0,1] ndc0.xy   (f32)            — eye 0 normalized device coords (clip.xy / clip.w)
+//   [2,3] ndc1.xy   (f32)            — eye 1 normalized device coords
+//   [4]   w         (f32)            — shared clip-space w (= clip.w of eye 0); drives corner-scale,
+//                                      depth reconstruction, and linear view depth (viewDepth = w)
+//   [5]   v1.xy     (pack2x16float)  — shared screen-pixel eigenvector (axis 1, from eye 0)
+//   [6]   v2.xy     (pack2x16float)  — shared screen-pixel eigenvector (axis 2)
+//   [7]   color     (pack4x8unorm)   — shared RGBA8 color + opacity (XR accepts 8-bit color)
 
 export const CACHE_STRIDE = 8;

--- a/src/scene/gsplat-unified/gsplat-projector.js
+++ b/src/scene/gsplat-unified/gsplat-projector.js
@@ -53,13 +53,14 @@ const PROJECTOR_WORKGROUP_SIZE = 256;
 // these are ignored when merged into the projector compute, so user customization can't clobber
 // the projector's own variant/format configuration.
 const PROJECTOR_INTERNAL_DEFINES = new Set([
-    '{CACHE_STRIDE}', 'RADIAL_SORT', 'PICK_MODE', 'GSPLAT_FISHEYE', 'GSPLAT_AA', 'GSPLAT_COLOR_FLOAT'
+    '{CACHE_STRIDE}', 'RADIAL_SORT', 'PICK_MODE', 'GSPLAT_FISHEYE', 'GSPLAT_AA', 'GSPLAT_COLOR_FLOAT', 'GSPLAT_XR'
 ]);
 
 const _cameraDir = new Vec3();
 const _dispatchSize = new Vec2();
 const _viewProjMat = new Mat4();
 const _viewProjData = new Float32Array(16);
+const _viewProj1Data = new Float32Array(16);
 const _viewData = new Float32Array(16);
 const _shaderProjMat = new Mat4();
 
@@ -141,6 +142,14 @@ class GSplatProjector {
      * @type {UniformBufferFormat|null}
      */
     _projectorUniformBufferFormatFisheye = null;
+
+    /**
+     * Uniform buffer format for the XR stereo projector variant. Adds the eye-1
+     * view-projection matrix after the shared fields.
+     *
+     * @type {UniformBufferFormat|null}
+     */
+    _projectorUniformBufferFormatStereo = null;
 
     /** @type {Compute|null} */
     _writeIndirectArgsCompute = null;
@@ -233,6 +242,7 @@ class GSplatProjector {
         this._projectorBindGroupFormat = null;
         this._projectorUniformBufferFormat = null;
         this._projectorUniformBufferFormatFisheye = null;
+        this._projectorUniformBufferFormatStereo = null;
         this._writeIndirectArgsCompute = null;
         this._writeArgsBindGroupFormat = null;
         this._writeArgsUniformBufferFormat = null;
@@ -274,6 +284,13 @@ class GSplatProjector {
             new UniformFormat('fisheye_inv_k', UNIFORMTYPE_FLOAT),
             new UniformFormat('fisheye_projMat00', UNIFORMTYPE_FLOAT),
             new UniformFormat('fisheye_projMat11', UNIFORMTYPE_FLOAT)
+        ]);
+
+        // Stereo variant appends the eye-1 view-projection matrix (matches the GSPLAT_XR
+        // ifdef'd field in compute-gsplat-projector.js). Mutually exclusive with fisheye.
+        this._projectorUniformBufferFormatStereo = new UniformBufferFormat(device, [
+            ...baseFields.map(f => new UniformFormat(f.name, f.type)),
+            new UniformFormat('viewProj1', UNIFORMTYPE_MAT4)
         ]);
 
         this._writeArgsUniformBufferFormat = new UniformBufferFormat(device, [
@@ -336,11 +353,12 @@ class GSplatProjector {
      * @param {boolean} pickMode - Pick output mode.
      * @param {boolean} fisheyeMode - Fisheye projection mode.
      * @param {boolean} antiAlias - Anti-aliasing opacity compensation mode.
+     * @param {boolean} stereo - XR stereo (2-view) projection mode.
      * @returns {string} The cache key.
      * @private
      */
-    _projectorKey(radialSort, pickMode, fisheyeMode, antiAlias) {
-        return `${radialSort ? 'r' : 'l'}${pickMode ? 'p' : ''}${fisheyeMode ? 'f' : ''}${antiAlias ? 'a' : ''}`;
+    _projectorKey(radialSort, pickMode, fisheyeMode, antiAlias, stereo) {
+        return `${radialSort ? 'r' : 'l'}${pickMode ? 'p' : ''}${fisheyeMode ? 'f' : ''}${antiAlias ? 'a' : ''}${stereo ? 's' : ''}`;
     }
 
     /**
@@ -352,10 +370,11 @@ class GSplatProjector {
      * @param {boolean} fisheyeMode - Whether to compile the GSPLAT_FISHEYE variant.
      * @param {boolean} antiAlias - Whether to compile the GSPLAT_AA variant (bakes the
      * anti-aliasing opacity compensation into the cached alpha).
+     * @param {boolean} stereo - Whether to compile the GSPLAT_XR (2-view stereo) variant.
      * @returns {Compute} The created compute instance.
      * @private
      */
-    _createProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode, antiAlias) {
+    _createProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode, antiAlias, stereo) {
         const device = this.device;
         const wbFormat = workBuffer.format;
 
@@ -405,6 +424,9 @@ class GSplatProjector {
         if (antiAlias) {
             cdefines.set('GSPLAT_AA', '');
         }
+        if (stereo) {
+            cdefines.set('GSPLAT_XR', '');
+        }
 
         // Format-specific defines mirroring the compute renderer (compute-gsplat-local-renderer.js).
         const colorStream = wbFormat.getStream('dataColor');
@@ -422,11 +444,13 @@ class GSplatProjector {
             });
         }
 
-        const name = `GSplatProjector${radialSort ? 'Radial' : 'Linear'}${pickMode ? 'Pick' : ''}${fisheyeMode ? 'Fisheye' : ''}${antiAlias ? 'Aa' : ''}`;
+        const name = `GSplatProjector${radialSort ? 'Radial' : 'Linear'}${pickMode ? 'Pick' : ''}${fisheyeMode ? 'Fisheye' : ''}${antiAlias ? 'Aa' : ''}${stereo ? 'Stereo' : ''}`;
 
-        const ubFormat = fisheyeMode ?
-            this._projectorUniformBufferFormatFisheye :
-            this._projectorUniformBufferFormat;
+        const ubFormat = stereo ?
+            this._projectorUniformBufferFormatStereo :
+            fisheyeMode ?
+                this._projectorUniformBufferFormatFisheye :
+                this._projectorUniformBufferFormat;
 
         const shader = new Shader(device, {
             name: name,
@@ -476,20 +500,21 @@ class GSplatProjector {
      * @param {boolean} [pickMode] - Whether to use the pick-output variant.
      * @param {boolean} [fisheyeMode] - Whether to use the fisheye projection variant.
      * @param {boolean} [antiAlias] - Whether to use the anti-aliasing variant.
+     * @param {boolean} [stereo] - Whether to use the XR stereo (2-view) variant.
      * @returns {Compute} The projector compute instance.
      * @private
      */
-    _getProjectorCompute(workBuffer, radialSort, pickMode = false, fisheyeMode = false, antiAlias = false) {
+    _getProjectorCompute(workBuffer, radialSort, pickMode = false, fisheyeMode = false, antiAlias = false, stereo = false) {
         const wbFormat = workBuffer.format;
         if (this._formatVersion !== wbFormat.extraStreamsVersion) {
             this._destroyProjectorComputes();
             this._formatVersion = wbFormat.extraStreamsVersion;
         }
 
-        const key = this._projectorKey(radialSort, pickMode, fisheyeMode, antiAlias);
+        const key = this._projectorKey(radialSort, pickMode, fisheyeMode, antiAlias, stereo);
         let compute = this._projectorComputes.get(key);
         if (!compute) {
-            compute = this._createProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode, antiAlias);
+            compute = this._createProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode, antiAlias, stereo);
             this._projectorComputes.set(key, compute);
         }
         return compute;
@@ -576,6 +601,9 @@ class GSplatProjector {
      * @param {boolean} [params.antiAlias] - Whether to bake anti-aliasing opacity
      * compensation into the cached alpha. Ignored in pick mode (picking only gates on a
      * binary opacity threshold), which keeps the projector variant count down.
+     * @param {boolean} [params.isStereo] - Whether to project both XR eyes in a single pass
+     * (GSPLAT_XR variant). Requires `cameraNode.camera.camera.xr.views.list` to have 2 views.
+     * Mutually exclusive with pick and fisheye.
      */
     dispatch(params) {
         const {
@@ -586,10 +614,14 @@ class GSplatProjector {
             pickMode = false,
             fisheyeProj,
             antiAlias = false,
+            isStereo = false,
             material
         } = params;
 
         const fisheyeMode = !!fisheyeProj?.enabled;
+
+        // Stereo is XR perspective-only; never combined with pick (mono) or fisheye.
+        const stereoMode = !!isStereo && !pickMode && !fisheyeMode;
 
         // AA only matters for the forward color path; skip it for picking to avoid
         // doubling the projector variant count.
@@ -606,7 +638,7 @@ class GSplatProjector {
         // workgroups run their atomicAdds.
         this.renderCounter.clear();
 
-        const compute = this._getProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode, aaMode);
+        const compute = this._getProjectorCompute(workBuffer, radialSort, pickMode, fisheyeMode, aaMode, stereoMode);
 
         // Forward the user render-stage material parameters (uniforms/textures referenced by the
         // modify chunk, reflected into the projector's auto-generated bind group, matched by name).
@@ -654,13 +686,29 @@ class GSplatProjector {
         // (gsplat-compute-local-renderer.js) for math parity.
         const cameraComponent = cameraNode.camera;
         const cam = cameraComponent.camera;
-        const view = cam.viewMatrix;
         const webgpu = this.device.isWebGPU;
-        _viewProjMat.mul2(Camera.applyShaderProjectionTransform(cam.projectionMatrix, _shaderProjMat, flipY, webgpu), view);
-        _viewProjData.set(_viewProjMat.data);
-        _viewData.set(view.data);
-
-        const focal = viewportWidth * _shaderProjMat.data[0];
+        let focal;
+        if (stereoMode) {
+            // XR stereo: use the per-eye matrices the forward path uses (raw projViewOffMat — NO
+            // applyShaderProjectionTransform). Eye 0 drives the shared covariance/depth/sort; eye 1
+            // contributes only its screen position. The per-eye "off" matrices are refreshed at
+            // render time by setCameraUniforms, which runs AFTER this dispatch, so refresh them here.
+            const views = cam.xr.views.list;
+            const parent = cameraNode.parent?.getWorldTransform() ?? null;
+            views[0].updateTransforms(parent);
+            views[1].updateTransforms(parent);
+            _viewProjData.set(views[0].projViewOffMat.data);
+            _viewProj1Data.set(views[1].projViewOffMat.data);
+            _viewData.set(views[0].viewOffMat.data);
+            // raw eye-0 projection x-scale; both eyes share it in standard stereo.
+            focal = viewportWidth * views[0].projMat.data[0];
+        } else {
+            const view = cam.viewMatrix;
+            _viewProjMat.mul2(Camera.applyShaderProjectionTransform(cam.projectionMatrix, _shaderProjMat, flipY, webgpu), view);
+            _viewProjData.set(_viewProjMat.data);
+            _viewData.set(view.data);
+            focal = viewportWidth * _shaderProjMat.data[0];
+        }
 
         this.cameraPositionData[0] = cameraPos.x;
         this.cameraPositionData[1] = cameraPos.y;
@@ -674,6 +722,9 @@ class GSplatProjector {
 
         compute.setParameter('viewMatrix', _viewData);
         compute.setParameter('viewProj', _viewProjData);
+        if (stereoMode) {
+            compute.setParameter('viewProj1', _viewProj1Data);
+        }
 
         compute.setParameter('focal', focal);
         compute.setParameter('viewportWidth', viewportWidth);

--- a/src/scene/gsplat-unified/gsplat-quad-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-quad-renderer.js
@@ -290,9 +290,9 @@ class GSplatQuadRenderer extends GSplatRenderer {
             this._material.setParameter('colorRampIntensity', params.colorRampIntensity);
         }
 
-        // Update fisheye projection
+        // Update fisheye projection (forced off in XR — see GSplatRenderer.resolveFisheye)
         const cam = this.cameraNode.camera;
-        this.fisheyeProj.update(params.fisheye, cam.fov, cam.projectionMatrix);
+        this.fisheyeProj.update(this.resolveFisheye(params.fisheye), cam.fov, cam.projectionMatrix);
 
         const fisheyeEnabled = this.fisheyeProj.enabled;
         if (fisheyeEnabled !== this._lastFisheyeEnabled) {

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../core/debug.js';
 import gsplatOutputVS from '../shader-lib/wgsl/chunks/gsplat/vert/gsplatOutput.js';
 import { shaderChunksWGSL } from '../shader-lib/wgsl/collections/shader-chunks-wgsl.js';
 import { FisheyeProjection } from '../graphics/fisheye-projection.js';
@@ -72,6 +73,23 @@ class GSplatRenderer {
     }
 
     destroy() {
+    }
+
+    /**
+     * Resolves the effective fisheye strength for this renderer's camera. Fisheye is not supported
+     * in XR by any renderer (it overrides the per-eye perspective projection), so it is forced off
+     * while an XR session is active. Warns once when a non-zero value is suppressed.
+     *
+     * @param {number} fisheye - Requested fisheye strength (typically `scene.gsplat.fisheye`).
+     * @returns {number} The fisheye strength to use (0 while in XR, otherwise `fisheye`).
+     */
+    resolveFisheye(fisheye) {
+        const xrActive = !!this.cameraNode.camera?.camera?.xr?.session;
+        if (xrActive && fisheye > 0) {
+            Debug.warnOnce('GSplat: fisheye projection is not supported in XR; disabling it.');
+            return 0;
+        }
+        return fisheye;
     }
 
     /**

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -11,7 +11,7 @@ import { Frustum } from '../../core/shape/frustum.js';
 import {
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL,
     BINDGROUP_MESH, BINDGROUP_VIEW, UNIFORM_BUFFER_DEFAULT_SLOT_NAME,
-    UNIFORMTYPE_MAT4, UNIFORMTYPE_MAT3, UNIFORMTYPE_VEC4, UNIFORMTYPE_VEC3, UNIFORMTYPE_IVEC3, UNIFORMTYPE_VEC2, UNIFORMTYPE_FLOAT, UNIFORMTYPE_INT,
+    UNIFORMTYPE_MAT4, UNIFORMTYPE_MAT3, UNIFORMTYPE_VEC4, UNIFORMTYPE_VEC3, UNIFORMTYPE_IVEC3, UNIFORMTYPE_VEC2, UNIFORMTYPE_FLOAT, UNIFORMTYPE_INT, UNIFORMTYPE_UINT,
     SHADERSTAGE_VERTEX, SHADERSTAGE_FRAGMENT,
     CULLFACE_NONE,
     BINDGROUP_MESH_UB,
@@ -710,7 +710,7 @@ class Renderer {
                 new UniformFormat('skyboxIntensity', UNIFORMTYPE_FLOAT),
                 new UniformFormat('exposure', UNIFORMTYPE_FLOAT),
                 new UniformFormat('textureBias', UNIFORMTYPE_FLOAT),
-                new UniformFormat('view_index', UNIFORMTYPE_FLOAT)
+                new UniformFormat('view_index', UNIFORMTYPE_UINT)
             ];
 
             if (isClustered) {

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
@@ -57,6 +57,11 @@ struct ProjectorUniforms {
     minContribution: f32,
     minDist: f32,
     invRange: f32,
+    #ifdef GSPLAT_XR
+        // Eye-1 view-projection (raw XR projViewOffMat). Eye 0 uses viewProj above.
+        // Appended only for the stereo variant - matches the conditional CPU UBO field.
+        viewProj1: mat4x4f,
+    #endif
     #ifdef GSPLAT_FISHEYE
         fisheye_k: f32,
         fisheye_inv_k: f32,
@@ -102,6 +107,10 @@ fn main(
     var alpha: f32 = 0.0;
     var pcId: u32 = 0u;
     var sortKey: u32 = 0u;
+    #ifdef GSPLAT_XR
+        // Eye-1 NDC (eye 0 NDC is derived from clipPos in the write below).
+        var ndc1: vec2f = vec2f(0.0);
+    #endif
 
     let projected = projectSplatCommon(
         threadIdx,
@@ -171,6 +180,13 @@ fn main(
             clipPos.z = clamp(clipPos.z, 0.0, abs(clipPos.w));
         #endif
 
+        // Stereo: project the same world center through eye 1 to get its screen position.
+        // Everything else (covariance/eigenvectors, depth w, color, sort key) is shared from eye 0.
+        #ifdef GSPLAT_XR
+            let clip1 = uniforms.viewProj1 * vec4f(center, 1.0);
+            ndc1 = clip1.xy / clip1.w;
+        #endif
+
         // Sort key — shared depth-bin weighting (same as CPU worker).
         #ifdef RADIAL_SORT
             let delta = center - uniforms.cameraPosition;
@@ -228,19 +244,33 @@ fn main(
         let dst = wgBase + localDst;
         let base = dst * {CACHE_STRIDE}u;
 
-        projCache[base + 0u] = bitcast<u32>(clipPos.x);
-        projCache[base + 1u] = bitcast<u32>(clipPos.y);
-        projCache[base + 2u] = bitcast<u32>(clipPos.z);
-        projCache[base + 3u] = bitcast<u32>(clipPos.w);
-        projCache[base + 4u] = pack2x16float(v1);
-        projCache[base + 5u] = pack2x16float(v2);
-
-        #ifdef PICK_MODE
-            projCache[base + 6u] = pcId;
-            projCache[base + 7u] = pack2x16float(vec2f(0.0, alpha));
+        #ifdef GSPLAT_XR
+            // Stereo layout: per-eye NDC in [0..3], shared w/v1/v2/color in [4..7].
+            // clip.z is not stored — the hybrid VS reconstructs it from w (perspective only).
+            let ndc0 = clipPos.xy / clipPos.w;
+            projCache[base + 0u] = bitcast<u32>(ndc0.x);
+            projCache[base + 1u] = bitcast<u32>(ndc0.y);
+            projCache[base + 2u] = bitcast<u32>(ndc1.x);
+            projCache[base + 3u] = bitcast<u32>(ndc1.y);
+            projCache[base + 4u] = bitcast<u32>(clipPos.w);
+            projCache[base + 5u] = pack2x16float(v1);
+            projCache[base + 6u] = pack2x16float(v2);
+            projCache[base + 7u] = pack4x8unorm(vec4f(rgb, alpha));
         #else
-            projCache[base + 6u] = pack2x16float(vec2f(rgb.x, rgb.y));
-            projCache[base + 7u] = pack2x16float(vec2f(rgb.z, alpha));
+            projCache[base + 0u] = bitcast<u32>(clipPos.x);
+            projCache[base + 1u] = bitcast<u32>(clipPos.y);
+            projCache[base + 2u] = bitcast<u32>(clipPos.z);
+            projCache[base + 3u] = bitcast<u32>(clipPos.w);
+            projCache[base + 4u] = pack2x16float(v1);
+            projCache[base + 5u] = pack2x16float(v2);
+
+            #ifdef PICK_MODE
+                projCache[base + 6u] = pcId;
+                projCache[base + 7u] = pack2x16float(vec2f(0.0, alpha));
+            #else
+                projCache[base + 6u] = pack2x16float(vec2f(rgb.x, rgb.y));
+                projCache[base + 7u] = pack2x16float(vec2f(rgb.z, alpha));
+            #endif
         #endif
 
         sortKeys[dst] = sortKey;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
@@ -33,6 +33,14 @@ uniform viewport_size: vec4f;
 // renderer (see GSplatHybridRenderer).
 uniform clipToViewZ: vec4f;
 
+#ifdef GSPLAT_XR
+    // Stereo: the cache stores per-eye NDC.xy plus a shared w; the active eye is selected by the
+    // per-view uniform view_index, and clip.z is reconstructed from w via matrix_projection.
+    // Both come from the per-view (BINDGROUP_VIEW) uniform buffer, set per eye by the renderer.
+    uniform view_index: u32;
+    uniform matrix_projection: mat4x4f;
+#endif
+
 #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
     uniform alphaClip: f32;
 #else
@@ -88,30 +96,53 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     let cacheIdx = sortedIndices[order];
     let base = cacheIdx * {CACHE_STRIDE}u;
 
-    let proj = vec4f(
-        bitcast<f32>(projCache[base + 0u]),
-        bitcast<f32>(projCache[base + 1u]),
-        bitcast<f32>(projCache[base + 2u]),
-        bitcast<f32>(projCache[base + 3u])
-    );
-    let v1 = unpack2x16float(projCache[base + 4u]);
-    let v2 = unpack2x16float(projCache[base + 5u]);
+    #ifdef GSPLAT_XR
+        // Stereo layout: pick this eye's NDC.xy ([0,1] eye 0 / [2,3] eye 1), shared w/v1/v2/color.
+        let off = uniform.view_index * 2u;
+        let ndc = vec2f(
+            bitcast<f32>(projCache[base + off + 0u]),
+            bitcast<f32>(projCache[base + off + 1u])
+        );
+        let w = bitcast<f32>(projCache[base + 4u]);
 
-    // Color / opacity / pickId: slot 6 is either packed (rg) or a raw u32 pcId.
-    let ba = unpack2x16float(projCache[base + 7u]);
-    let alpha = half(ba.y);
+        // Reconstruct clip.z from the shared w (perspective only). With P column-major:
+        //   clip.z = (P[2][2] / P[2][3]) * w + P[3][2]   (P[2][3] is the w-row z term)
+        // The z-row entries are identical for both eyes (same near/far), so this is eye-consistent.
+        let pz = (uniform.matrix_projection[2][2] / uniform.matrix_projection[2][3]) * w + uniform.matrix_projection[3][2];
 
-    #if defined(GSPLAT_UNIFIED_ID) && defined(PICK_PASS)
-        let pickId = projCache[base + 6u];
-    #endif
+        let proj = vec4f(ndc * w, clamp(pz, 0.0, abs(w)), w);
+        let v1 = unpack2x16float(projCache[base + 5u]);
+        let v2 = unpack2x16float(projCache[base + 6u]);
 
-    #ifdef PICK_PASS
-        // In the pick path slot 6 is repurposed as the picking ID; alpha is the only
-        // colour we care about in the FS gate. Slot 7's r channel is unused.
-        var clr: half4 = half4(half(0.0), half(0.0), half(0.0), alpha);
+        let rgba = unpack4x8unorm(projCache[base + 7u]);
+        let alpha = half(rgba.a);
+        var clr: half4 = half4(half(rgba.r), half(rgba.g), half(rgba.b), alpha);
     #else
-        let rg = unpack2x16float(projCache[base + 6u]);
-        var clr: half4 = half4(half(rg.x), half(rg.y), half(ba.x), alpha);
+        let proj = vec4f(
+            bitcast<f32>(projCache[base + 0u]),
+            bitcast<f32>(projCache[base + 1u]),
+            bitcast<f32>(projCache[base + 2u]),
+            bitcast<f32>(projCache[base + 3u])
+        );
+        let v1 = unpack2x16float(projCache[base + 4u]);
+        let v2 = unpack2x16float(projCache[base + 5u]);
+
+        // Color / opacity / pickId: slot 6 is either packed (rg) or a raw u32 pcId.
+        let ba = unpack2x16float(projCache[base + 7u]);
+        let alpha = half(ba.y);
+
+        #if defined(GSPLAT_UNIFIED_ID) && defined(PICK_PASS)
+            let pickId = projCache[base + 6u];
+        #endif
+
+        #ifdef PICK_PASS
+            // In the pick path slot 6 is repurposed as the picking ID; alpha is the only
+            // colour we care about in the FS gate. Slot 7's r channel is unused.
+            var clr: half4 = half4(half(0.0), half(0.0), half(0.0), alpha);
+        #else
+            let rg = unpack2x16float(projCache[base + 6u]);
+            var clr: half4 = half4(half(rg.x), half(rg.y), half(ba.x), alpha);
+        #endif
     #endif
 
     // clipCorner: shrink the quad to exclude near-zero alpha regions (matches gsplatCommonVS per-pass threshold).
@@ -138,7 +169,12 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     // uniform = -inverse(matrix_projection)[row 2]. For perspective this
     // collapses to clip.w; for ortho it produces the correct -view.z. Used by
     // fog/overdraw/prepass below.
-    let viewDepth = dot(uniform.clipToViewZ, proj);
+    #ifdef GSPLAT_XR
+        // XR is perspective-only, so linear view depth is exactly the shared w (= -view.z).
+        let viewDepth = proj.w;
+    #else
+        let viewDepth = dot(uniform.clipToViewZ, proj);
+    #endif
 
     #ifdef GSPLAT_OVERDRAW
         // Overdraw mode renders a flat colour ramp; depth-shade input not needed.


### PR DESCRIPTION
Adds 2-view (stereo) XR rendering to the hybrid GPU-sort gaussian-splat renderer, which previously projected for a single view so both eyes rendered identically.

**Changes:**
- Hybrid renderer now projects both XR eyes in a single compute pass (new `GSPLAT_XR` shader variant), keeping the 32-byte projection-cache stride unchanged. Only the per-eye screen position (NDC.xy) is duplicated; depth `w`, screen-space covariance (v1/v2) and color are shared between eyes — valid for parallel-axis WebXR stereo. Perspective-only: clip.z is reconstructed in the vertex shader from the shared `w`, and color is packed as RGBA8 for XR.
- Projector compute, hybrid vertex shader, and projector JS gain the `GSPLAT_XR` path/uniforms; the manager computes `isStereo`, keeps the material define in sync, and logs once if an XR session reports more than 2 views (unsupported).
- Mono (non-XR) rendering is unchanged — identical cache layout, buffers, and compiled shader variant.
- The min-pixel-size cull naturally removes more splats at lower XR resolution, as the projector derives focal/viewport from the scaled per-eye sub-image.

**API Changes:**
- `XrMenu.setMenuScale(value)` added (scripts/esm/xr-menu.mjs) — re-applies the overall menu scale at runtime.
- View uniform-buffer field `view_index` changed from `UNIFORMTYPE_FLOAT` to `UNIFORMTYPE_UINT` (read as `u32` in WGSL). It was previously written but read by no shader, so this is non-breaking in practice.

**Examples:**
- `gaussian-splatting-xr/vr-lod`: added an always-visible in-XR HUD (FPS, resolution, fixed-foveation toggle, exit), an "XR Res Scale" control (0.3–1) applied at session start, HUD auto-scales up at lower resolution for readability, and clamped the splat-budget slider to 0.1–3M (0 / large values caused OOM).