### PR TITLE
Remove alphabetical import-order requirement from examples lint

### DIFF
--- a/examples/eslint.config.mjs
+++ b/examples/eslint.config.mjs
@@ -310,8 +310,7 @@ const importOrder = ['error', {
         }
     ],
     pathGroupsExcludedImportTypes: ['builtin', 'object'],
-    'newlines-between': 'always',
-    alphabetize: { order: 'asc', caseInsensitive: true }
+    'newlines-between': 'always'
 }];
 
 // minimal jsx-uses-vars: mark JSX-referenced identifiers as used so no-unused-vars sees imported


### PR DESCRIPTION
Drops the alphabetical ordering requirement for imports in the examples package. Reordering imports purely to satisfy alphabetical order adds churn without real benefit, and the constraint isn't applied to the engine source (`src/`, `scripts/`) — only to examples — so it was an inconsistent surprise.

**Changes:**
- Remove the `alphabetize` option from the `import/order` rule in `examples/eslint.config.mjs`. Group ordering (builtin → external → internal → parent/sibling …) and `newlines-between: always` are kept, so imports stay grouped and separated — they just no longer need to be alphabetical within a group.

No example sources needed changes (removing a constraint cannot introduce new violations); `examples` lint passes.