### PR TITLE
Improve vr-lod XR example and fix XR menu/navigation on hand-tracking devices

### DIFF
--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.controls.jsx
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.controls.jsx
@@ -38,10 +38,10 @@ export function Controls({ observer }) {
                     <SliderInput
                         binding={new BindingTwoWay()}
                         link={{ observer, path: 'splatBudget' }}
-                        min={0.1}
-                        max={3}
-                        precision={2}
-                        step={0.05}
+                        min={0.5}
+                        max={4}
+                        precision={1}
+                        step={0.5}
                     />
                 </LabelGroup>
                 <LabelGroup text='XR Res Scale'>

--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
@@ -6,6 +6,22 @@
 // title: Roman Parish
 // author: Andrii Shramko
 // source: https://www.linkedin.com/in/andrii-shramko/
+//
+// @credit
+// title: Ice Cave
+// author: SpAItial AI
+// source: https://spaitial.ai/
+//
+// @credit
+// title: SA3D_R&D_XP47
+// author: Stephane Agullo
+// source: https://superspl.at/view?id=cdcec084
+// license: CC BY 4.0 (http://creativecommons.org/licenses/by/4.0/)
+//
+// @credit
+// title: Skatepark
+// author: Christoph Schindelar
+// source: https://superspl.at/user?id=schindelar3d
 
 import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
@@ -25,6 +41,10 @@ const gfxOptions = {
 };
 
 const device = await pc.createGraphicsDevice(canvas, gfxOptions);
+
+// Enable GPU timing (timestamp queries) so the HUD can show total GPU time per frame
+// (sum of all compute + render passes), same source MiniStats uses.
+device.gpuProfiler.enabled = true;
 
 const createOptions = new pc.AppOptions();
 createOptions.graphicsDevice = device;
@@ -191,8 +211,9 @@ assetListLoader.load(() => {
         }
     });
 
-    data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
-    data.set('splatBudget', 1);
+    // Pick the renderer per backend: GPU-sort (compute) on WebGPU, CPU-sort raster on WebGL.
+    data.set('renderer', device.isWebGPU ? pc.GSPLAT_RENDERER_RASTER_GPU_SORT : pc.GSPLAT_RENDERER_RASTER_CPU_SORT);
+    data.set('splatBudget', 2);
     // XR framebuffer scale factor (applied only when starting an XR session; does not affect 2D).
     data.set('framebufferScaleFactor', 1);
     data.set('data.stats.gsplats', '—');
@@ -236,15 +257,15 @@ assetListLoader.load(() => {
             endEvent: 'xr:end'
         }
     });
-    cameraRig.script.create(XrNavigation, {
+    const xrNavigation = /** @type {any} */ (cameraRig.script.create(XrNavigation, {
         properties: {
-            enableTeleport: false,
+            enableTeleport: true,
             enableSnapVertical: false,
             movementThreshold: 0,
             turnMode: 'smooth',
             smoothTurnSpeed: 90
         }
-    });
+    }));
 
     // In-XR debug HUD: an always-visible, camera-following menu. Label-only rows (no eventName)
     // act as live readouts updated each frame via setItemLabel. Starting with FPS.
@@ -256,9 +277,18 @@ assetListLoader.load(() => {
         properties: {
             menuItems: [
                 { label: 'FPS: --' },          // [0] label-only readout (updated each frame)
-                { label: 'RES: --' },          // [1] label-only readout (updated each frame)
-                { label: 'FOVEATION: OFF', eventName: 'xrhud:foveation' }, // [2] toggle (off by default)
-                { label: 'EXIT XR', eventName: 'xr:end' } // [3] interactive: ends the XR session
+                { label: 'GPU: --' },          // [1] total GPU time per frame (updated each frame)
+                { label: 'RES: --' },          // [2] label-only readout (updated each frame)
+                { label: 'FOVEATION: OFF', eventName: 'xrhud:foveation' }, // [3] toggle (off by default)
+                // [4] number row: splat budget, +/- 0.5M (0.5..4M)
+                { type: 'number', label: 'BUDGET', value: '2.0M', decEvent: 'budget:dec', incEvent: 'budget:inc' },
+                // [5] number row: scene index (0 = original, 1 = cave, 2 = skatepark)
+                { type: 'number', label: 'SCENE', value: '0', decEvent: 'scene:dec', incEvent: 'scene:inc' },
+                // [6] number row: minContribution, +/- 2 (1..20)
+                { type: 'number', label: 'Contribution', value: '5', decEvent: 'contribution:dec', incEvent: 'contribution:inc' },
+                // [7] number row: alphaClipForward, stepped 1/255 .. 1/2
+                { type: 'number', label: 'AlphaClip', value: '1/16', decEvent: 'alphaclip:dec', incEvent: 'alphaclip:inc' },
+                { label: 'EXIT XR', eventName: 'xr:end' } // [8] interactive: ends the XR session
             ],
             fontAsset: assets.font,
             alwaysVisible: true,
@@ -271,18 +301,91 @@ assetListLoader.load(() => {
     app.root.addChild(menuEntity);
     const xrHud = /** @type {any} */ (menuEntity.script).xrMenu;
 
+    // Replace the engine's ray-to-ground teleport with a fixed-step "dash" in the direction the user
+    // is looking. The ray-to-ground jump behaves badly near floor level (a near-horizontal ray hits
+    // the ground far away, throwing you outside the scene), and AVP has no thumbstick for smooth
+    // locomotion. A pinch moves a fixed distance along the head's horizontal forward, keeping the
+    // current elevation (XZ only). The menu veto is preserved so pinches on the HUD just click.
+    const MOVE_STEP = 1.5; // metres per pinch
+    const moveDir = new pc.Vec3();
+    xrNavigation.tryTeleport = () => {
+        if (xrHud?.isPointerOverMenu) return;
+
+        moveDir.copy(camera.forward);
+        moveDir.y = 0; // flatten to the ground plane — never change elevation
+        if (moveDir.lengthSq() < 1e-6) return; // looking straight up/down: no horizontal direction
+        moveDir.normalize().mulScalar(MOVE_STEP);
+
+        cameraRig.translate(moveDir.x, 0, moveDir.z);
+    };
+
     // Fixed foveation toggle, driven from the in-XR HUD. Off by default. fixedFoveation can only be
     // set during an active session and is ignored unless anti-aliasing is off (it is here).
     let foveationEnabled = false;
     const FOVEATION_LEVEL = 1; // highest foveation when enabled
     const applyFoveation = () => {
         app.xr.fixedFoveation = foveationEnabled ? FOVEATION_LEVEL : 0;
-        xrHud?.setItemLabel(2, `FOVEATION: ${foveationEnabled ? 'ON' : 'OFF'}`);
+        xrHud?.setItemLabel(3, `FOVEATION: ${foveationEnabled ? 'ON' : 'OFF'}`);
     };
     app.on('xrhud:foveation', () => {
         foveationEnabled = !foveationEnabled;
         applyFoveation();
     });
+
+    // In-XR splat budget control (number row [4]). +/- 0.5M, clamped to 0.5..4M. Writes the same
+    // 'splatBudget' observer the 2D slider uses, so both stay in sync.
+    const BUDGET_ROW = 4;
+    let budgetM = data.get('splatBudget') ?? 2;
+    const applyBudget = () => {
+        data.set('splatBudget', budgetM);
+        xrHud?.setItemValue(BUDGET_ROW, `${budgetM.toFixed(1)}M`);
+    };
+    app.on('budget:dec', () => {
+        budgetM = Math.max(0.5, Math.round((budgetM - 0.5) * 2) / 2);
+        applyBudget();
+    });
+    app.on('budget:inc', () => {
+        budgetM = Math.min(4, Math.round((budgetM + 0.5) * 2) / 2);
+        applyBudget();
+    });
+    applyBudget(); // seed the readout
+
+    // In-XR minContribution control (number row [6]). +/- 2, clamped to 1..20 (default 5).
+    const CONTRIB_ROW = 6;
+    let contribution = 5;
+    const applyContribution = () => {
+        app.scene.gsplat.minContribution = contribution;
+        xrHud?.setItemValue(CONTRIB_ROW, `${contribution}`);
+    };
+    app.on('contribution:dec', () => {
+        contribution = Math.max(1, contribution - 2);
+        applyContribution();
+    });
+    app.on('contribution:inc', () => {
+        contribution = Math.min(20, contribution + 2);
+        applyContribution();
+    });
+    applyContribution(); // seed the readout
+
+    // In-XR alphaClipForward control (number row [7]). Stepped through nice reciprocals from the
+    // current default 1/255 up to 1/2 (10 steps); displayed as "1/N". '+' raises the alpha floor.
+    const ALPHACLIP_ROW = 7;
+    const ALPHACLIP_DENOMS = [255, 128, 64, 48, 32, 24, 16, 8, 4, 2];
+    let alphaClipIndex = 6; // 1/16
+    const applyAlphaClip = () => {
+        const denom = ALPHACLIP_DENOMS[alphaClipIndex];
+        app.scene.gsplat.alphaClipForward = 1 / denom;
+        xrHud?.setItemValue(ALPHACLIP_ROW, `1/${denom}`);
+    };
+    app.on('alphaclip:dec', () => {
+        alphaClipIndex = Math.max(0, alphaClipIndex - 1);
+        applyAlphaClip();
+    });
+    app.on('alphaclip:inc', () => {
+        alphaClipIndex = Math.min(ALPHACLIP_DENOMS.length - 1, alphaClipIndex + 1);
+        applyAlphaClip();
+    });
+    applyAlphaClip(); // seed the readout
 
     /** @type {pc.Entity|null} */
     let gsplatEntity = null;
@@ -299,14 +402,14 @@ assetListLoader.load(() => {
         }
     };
 
-    const loadGsplat = () => {
+    const loadGsplat = (scene) => {
         if (gsplatEntity) {
             gsplatEntity.destroy();
             gsplatEntity = null;
             gsplatGs = null;
         }
 
-        const asset = assets.church;
+        const asset = scene.asset;
 
         gsplatEntity = new pc.Entity(config.name || 'gsplat');
         gsplatEntity.addComponent('gsplat', {
@@ -314,7 +417,7 @@ assetListLoader.load(() => {
             unified: true
         });
         gsplatEntity.setLocalPosition(0, 0, 0);
-        gsplatEntity.setLocalEulerAngles(270, 0, 0);
+        gsplatEntity.setLocalEulerAngles(scene.euler[0], scene.euler[1], scene.euler[2]);
         gsplatEntity.setLocalScale(1, 1, 1);
         app.root.addChild(gsplatEntity);
         gsplatGs = /** @type {any} */ (gsplatEntity.gsplat);
@@ -341,8 +444,8 @@ assetListLoader.load(() => {
         gsplatEntity.addComponent('script');
         const revealScript = gsplatEntity.script?.create(GsplatRevealRadial);
         if (revealScript) {
-            revealScript.center.set(focusX, focusY, focusZ);
-            revealScript.speed = 5;
+            revealScript.center.set(scene.focus[0], scene.focus[1], scene.focus[2]);
+            revealScript.speed = 10;
             revealScript.acceleration = 0;
             revealScript.delay = 3;
             revealScript.oscillationIntensity = 0.2;
@@ -350,7 +453,84 @@ assetListLoader.load(() => {
         }
     };
 
-    loadGsplat();
+    // Selectable scenes via the in-XR SCENE number row: 0 = original, 1 = the cave from the
+    // gaussian-splatting/depth-of-field example. The cave splat is unrotated (its proxy is what's
+    // flipped in that example), whereas the original needs a 180° flip.
+    const caveAsset = new pc.Asset('gsplat-cave', 'gsplat', {
+        url: 'https://s3.eu-west-1.amazonaws.com/code.playcanvas.com/examples_data/example_cave_01/lod-meta.json'
+    });
+    app.assets.add(caveAsset);
+
+    const skateparkAsset = new pc.Asset('gsplat-skatepark', 'gsplat', {
+        url: 'https://code.playcanvas.com/examples_data/example_skatepark_02/lod-meta.json'
+    });
+    app.assets.add(skateparkAsset);
+
+    const apartmentAsset = new pc.Asset('gsplat-apartment', 'gsplat', {
+        url: './assets/splats/apartment.sog'
+    });
+    app.assets.add(apartmentAsset);
+
+    const SCENES = [
+        // 0: original Roman Parish church — rig at the configured start, looking at the focus point
+        { asset: assets.church, euler: [270, 0, 0], pos: config.cameraPosition, focus: config.focusPoint || [0, 0.6, 0] },
+        // 1: cave — small interior; viewpoint roughly matches the depth-of-field example
+        { asset: caveAsset, euler: [0, 0, 0], pos: [0.1, -0.1, 0.06], focus: [1.2, -0.4, 1.0] },
+        // 2: apartment (.sog) — start at the editor/paint "biker1" spot, transformed into this
+        // scene's frame (apartment at origin, euler 180, scale 1), looking toward the interior
+        { asset: apartmentAsset, euler: [180, 0, 0], pos: [-3.8, -0.1, 7.2], focus: [0, -0.1, 0] },
+        // 3: skatepark — viewpoint from the lod-streaming-sh example
+        { asset: skateparkAsset, euler: [-90, 0, 0], pos: [32, 2, 2], focus: [0, 0.6, 0] }
+    ];
+    const SCENE_ROW = 5;
+    let sceneIndex = 0;
+
+    // Place the XR rig for a scene: stand on the scene ground (y = 0, mirroring what XrSession does
+    // at session start) and face the focus horizontally. In XR the headset supplies eye height and
+    // pitch, so we keep yaw only — using the full desktop pos.y here would lift the viewer metres off
+    // the ground (the "giant" effect), and keeping the previous yaw would leave you facing the wrong
+    // way after a scene switch.
+    const placeForSceneXr = (scene) => {
+        const p = scene.pos;
+        const f = scene.focus;
+        // Stand on the ground (y = 0) by default; per-scene `xrY` lifts the spawn for scenes whose
+        // floor sits below the origin.
+        cameraRig.setLocalPosition(p[0], scene.xrY ?? 0, p[2]);
+        cameraRig.lookAt(f[0], f[1], f[2]);
+        const yaw = cameraRig.getLocalEulerAngles().y;
+        cameraRig.setLocalEulerAngles(0, yaw, 0);
+    };
+
+    const setScene = (index) => {
+        sceneIndex = pc.math.clamp(index, 0, SCENES.length - 1);
+        xrHud?.setItemValue(SCENE_ROW, `${sceneIndex}`);
+        const scene = SCENES[sceneIndex];
+
+        // Position the viewpoint for this scene. On desktop the fly camera (cc) owns the pose; in
+        // XR the rig is the floor-level navigation root and the headset supplies height/pitch.
+        if (app.xr.active) {
+            placeForSceneXr(scene);
+        } else {
+            const p = scene.pos;
+            const f = scene.focus;
+            cameraRig.setLocalPosition(p[0], p[1], p[2]);
+            cc.reset(new pc.Vec3(f[0], f[1], f[2]), new pc.Vec3(p[0], p[1], p[2]));
+        }
+
+        if (scene.asset.loaded) {
+            loadGsplat(scene);
+        } else {
+            // load on demand; guard against a newer selection completing first
+            scene.asset.once('load', () => {
+                if (SCENES[sceneIndex] === scene) loadGsplat(scene);
+            });
+            app.assets.load(scene.asset);
+        }
+    };
+    app.on('scene:dec', () => setScene(sceneIndex - 1));
+    app.on('scene:inc', () => setScene(sceneIndex + 1));
+
+    setScene(0);
 
     const applySplatBudget = () => {
         const millions = data.get('splatBudget');
@@ -417,6 +597,10 @@ assetListLoader.load(() => {
             // resolutions (e.g. 0.5x scale -> 2x larger menu). Full resolution keeps the base size.
             const scaleFactor = data.get('framebufferScaleFactor') || 1;
             xrHud?.setMenuScale(HUD_BASE_SCALE / scaleFactor);
+            // Stand on the ground facing the focus for the current scene. XrSession's own 'start'
+            // handler runs first (registered earlier) and derives the rig from the desktop camera —
+            // re-place here so the XR viewpoint is ground-level and correctly oriented.
+            placeForSceneXr(SCENES[sceneIndex]);
             setMessage('VR active — left thumbstick: move, right: turn; tap to exit');
         });
         app.xr.on('end', () => {
@@ -444,13 +628,20 @@ assetListLoader.load(() => {
         setMessage('WebXR is not supported');
     }
 
-    app.on('update', () => {
-        data.set('data.stats.gsplats', app.stats.frame.gsplats.toLocaleString());
+    // Refresh the readouts at ~2 Hz so the numbers are readable rather than flickering every frame.
+    let hudTimer = 0;
+    app.on('update', (dt) => {
+        hudTimer += dt;
+        if (hudTimer < 0.5) return;
+        hudTimer = 0;
+
         const bb = app.graphicsDevice.backBufferSize;
+        data.set('data.stats.gsplats', app.stats.frame.gsplats.toLocaleString());
         data.set('data.stats.resolution', `${bb.x} x ${bb.y}`);
 
-        // Live readouts in the in-XR HUD (app.stats.frame.fps is recomputed once per second).
+        // GPU time is the sum of all compute + render pass timings (device.gpuProfiler).
         xrHud?.setItemLabel(0, `FPS: ${app.stats.frame.fps}`);
-        xrHud?.setItemLabel(1, `RES: ${bb.x} x ${bb.y}`);
+        xrHud?.setItemLabel(1, `GPU: ${(device.gpuProfiler?._frameTime ?? 0).toFixed(1)}ms`);
+        xrHud?.setItemLabel(2, `RES: ${bb.x} x ${bb.y}`);
     });
 });

--- a/scripts/esm/xr-menu.mjs
+++ b/scripts/esm/xr-menu.mjs
@@ -88,10 +88,14 @@ class XrMenu extends Script {
     static scriptName = 'xrMenu';
 
     /**
-     * Array of menu item definitions. Each item should have a `label` (display text) and
-     * `eventName` (app event to fire when activated).
+     * Array of menu item definitions. Item kinds:
+     * - Interactive button: `{ label, eventName }` — fires `app.fire(eventName)` when activated.
+     * - Label (read-only): `{ label }` — non-interactive; update via {@link XrMenu#setItemLabel}.
+     * - Number row: `{ type: 'number', label, value, decEvent, incEvent }` — a single line with a
+     *   `label: value` readout and '-' / '+' buttons firing `decEvent` / `incEvent`. Update the
+     *   value via {@link XrMenu#setItemValue}.
      *
-     * @type {Array<{label: string, eventName: string}>}
+     * @type {Array<{label?: string, value?: string, eventName?: string, type?: string, decEvent?: string, incEvent?: string}>}
      * @attribute
      */
     menuItems = [];
@@ -331,6 +335,24 @@ class XrMenu extends Script {
     /** @type {Entity[]} */
     _buttons = [];
 
+    /**
+     * Per-line layout descriptors (one per generated menu row). A simple row is
+     * `{ kind: 'simple', entity }`; a number row is
+     * `{ kind: 'number', labelEntity, minus, plus, labelX, minusX, plusX, baseLabel }`.
+     *
+     * @type {Array<Object>}
+     */
+    _rows = [];
+
+    /**
+     * Per-`menuItems` text-update targets, so {@link XrMenu#setItemLabel} / {@link XrMenu#setItemValue}
+     * stay indexed by the original `menuItems` position even when a row expands into multiple
+     * entities (number rows). Each entry is `{ entity, baseLabel }`.
+     *
+     * @type {Array<{entity: Entity, baseLabel: string|null}>}
+     */
+    _itemTargets = [];
+
     /** @type {Set<XrInputSource>} */
     _inputSources = new Set();
 
@@ -416,8 +438,14 @@ class XrMenu extends Script {
         this.app.xr.input.on('add', this._onInputSourceAdd, this);
         this.app.xr.input.on('remove', this._onInputSourceRemove, this);
 
-        // Listen for XR session end to clean up
+        // Listen for XR session end to clean up.
         this.app.xr.on('end', this._onXrEnd, this);
+
+        // Drive clicks from the select/pinch event in addition to the gamepad-button polling in
+        // _updateRayInteraction. This is required on platforms (e.g. Apple Vision Pro) where a pinch
+        // arrives as a 'transient-pointer' select event with no pollable button on the hovering
+        // 'tracked-pointer' source.
+        this.app.xr.input.on('selectstart', this._onSelectStart, this);
 
         this.on('destroy', () => {
             this._onDestroy();
@@ -428,6 +456,7 @@ class XrMenu extends Script {
         if (this.app.xr) {
             this.app.xr.input.off('add', this._onInputSourceAdd, this);
             this.app.xr.input.off('remove', this._onInputSourceRemove, this);
+            this.app.xr.input.off('selectstart', this._onSelectStart, this);
             this.app.xr.off('end', this._onXrEnd, this);
         }
 
@@ -438,6 +467,8 @@ class XrMenu extends Script {
         }
 
         this._buttons = [];
+        this._rows = [];
+        this._itemTargets = [];
         this._inputSources.clear();
     }
 
@@ -446,6 +477,24 @@ class XrMenu extends Script {
         this._inputSources.clear();
         this._activeInputSource = null;
         this._followInitialized = false;
+    }
+
+    /**
+     * Handler for the raw 'selectstart' (pinch/trigger press) input event. Clicks the currently
+     * hovered button. This is the click path for platforms where the pinch arrives as a separate
+     * 'transient-pointer' select source (e.g. Apple Vision Pro) that the per-frame gamepad-button
+     * pick loop can't see; the hovered button is already tracked via the 'tracked-pointer' ray.
+     * The {@link _onButtonClick} debounce prevents a double-fire on platforms (e.g. Quest) where the
+     * gamepad-button path also fires for the same press.
+     *
+     * @private
+     */
+    _onSelectStart() {
+        // _hoveredButton is only ever an interactive button (labels are skipped during picking), and
+        // it reflects whatever the pointer ray is currently on.
+        if (this._hoveredButton) {
+            this._onButtonClick(this._hoveredButton);
+        }
     }
 
     /**
@@ -465,7 +514,9 @@ class XrMenu extends Script {
         const item = this.menuItems[index];
         if (item) item.label = text;
 
-        const entity = this._buttons[index];
+        // Index by menuItems position via _itemTargets (robust to number rows expanding a single
+        // item into multiple entities); fall back to the flat _buttons list before generation.
+        const entity = this._itemTargets[index]?.entity ?? this._buttons[index];
         if (!entity) return false;
 
         // Prefer the direct ref captured in menuData; fall back to children[0] for items that
@@ -476,6 +527,30 @@ class XrMenu extends Script {
         textElement.text = text;
         // @ts-ignore
         if (entity.menuData) entity.menuData.label = text;
+        return true;
+    }
+
+    /**
+     * Updates the value shown on a `number` row, recomposing the displayed text as `LABEL: value`
+     * from the row's static label. The new value is persisted into the `menuItems` entry so it
+     * survives regeneration.
+     *
+     * @param {number} index - Index into the `menuItems` array (the number row).
+     * @param {string} value - New value text (e.g. '1.5M').
+     * @returns {boolean} True if the item was found and updated, false otherwise.
+     */
+    setItemValue(index, value) {
+        const item = this.menuItems[index];
+        if (item) item.value = value;
+
+        const target = this._itemTargets[index];
+        if (!target?.entity) return false;
+
+        const text = target.baseLabel != null ? `${target.baseLabel}: ${value}` : `${value}`;
+        // @ts-ignore - menuData is a custom property attached in _createButton
+        const textElement = target.entity.menuData?.textElement ?? target.entity.children[0]?.element;
+        if (!textElement) return false;
+        textElement.text = text;
         return true;
     }
 
@@ -492,6 +567,18 @@ class XrMenu extends Script {
             const scale = this._uiScale * value;
             this._screenEntity.setLocalScale(scale, scale, scale);
         }
+    }
+
+    /**
+     * Whether a pointer ray (controller or hand) is currently over an interactive menu button.
+     * Updated every frame from the ray-picking pass. Useful for coordinating with world
+     * interactors — e.g. a navigation script can skip teleporting when a select/pinch gesture
+     * lands on the menu rather than the world.
+     *
+     * @type {boolean}
+     */
+    get isPointerOverMenu() {
+        return this._hoveredButton !== null;
     }
 
     /**
@@ -555,6 +642,8 @@ class XrMenu extends Script {
             button.destroy();
         }
         this._buttons = [];
+        this._rows = [];
+        this._itemTargets = [];
 
         // Convert meter sizes to UI pixels
         const widthPx = this.buttonWidth / this._uiScale;
@@ -566,6 +655,20 @@ class XrMenu extends Script {
             const item = this.menuItems[i];
             if (!item || typeof item !== 'object') continue;
 
+            // Number row: a value readout plus '-' / '+' buttons on a single line.
+            if (item.type === 'number') {
+                const row = this._createNumberRow(item, i, widthPx, heightPx);
+                this._screenEntity.addChild(row.labelEntity);
+                this._screenEntity.addChild(row.minus);
+                this._screenEntity.addChild(row.plus);
+                // The label is non-interactive; minus/plus are interactive (picked + clicked like
+                // any other button). All three are tracked in _buttons for picking/opacity.
+                this._buttons.push(row.labelEntity, row.minus, row.plus);
+                this._rows.push(row);
+                this._itemTargets.push({ entity: row.labelEntity, baseLabel: row.baseLabel });
+                continue;
+            }
+
             const label = item.label || `Button ${i}`;
             const eventName = item.eventName || '';
 
@@ -573,10 +676,12 @@ class XrMenu extends Script {
             if (button) {
                 this._screenEntity.addChild(button);
                 this._buttons.push(button);
+                this._rows.push({ kind: 'simple', entity: button });
+                this._itemTargets.push({ entity: button, baseLabel: null });
             }
         }
 
-        // Layout buttons vertically
+        // Layout rows vertically
         this._layoutButtons(heightPx, spacingPx);
     }
 
@@ -682,6 +787,40 @@ class XrMenu extends Script {
         button.menuData.textElement = textEntity.element;
 
         return button;
+    }
+
+    /**
+     * Creates a single-line "number" row: a value readout on the left and small '-' / '+' buttons
+     * on the right. The readout is a non-interactive label; the buttons fire `decEvent` / `incEvent`.
+     * Returns the three entities plus their precomputed horizontal positions for {@link XrMenu#_layoutButtons}.
+     *
+     * @param {Object} item - The menu item ({ type:'number', label, value, decEvent, incEvent }).
+     * @param {number} index - Index of the item in `menuItems`.
+     * @param {number} widthPx - Full row width in pixels.
+     * @param {number} heightPx - Row height in pixels.
+     * @returns {Object} Row descriptor.
+     * @private
+     */
+    _createNumberRow(item, index, widthPx, heightPx) {
+        const gap = heightPx * 0.25;
+        const btn = heightPx;                                       // square +/- buttons
+        const labelWidth = Math.max(1, widthPx - 2 * btn - 2 * gap);
+
+        // Centers, with the row centered at x = 0 (total width = widthPx).
+        const left = -widthPx / 2;
+        const labelX = left + labelWidth / 2;
+        const minusX = left + labelWidth + gap + btn / 2;
+        const plusX = left + labelWidth + gap + btn + gap + btn / 2;
+
+        const baseLabel = item.label ?? '';
+        const value = item.value ?? '';
+
+        // Reuse _createButton for all three cells (label = non-interactive, minus/plus = buttons).
+        const labelEntity = this._createButton(`${baseLabel}: ${value}`, '', index, labelWidth, heightPx);
+        const minus = this._createButton('-', item.decEvent || '', index, btn, heightPx);
+        const plus = this._createButton('+', item.incEvent || '', index, btn, heightPx);
+
+        return { kind: 'number', labelEntity, minus, plus, labelX, minusX, plusX, baseLabel };
     }
 
     /**
@@ -795,12 +934,21 @@ class XrMenu extends Script {
      * @private
      */
     _layoutButtons(heightPx, spacingPx) {
-        const totalHeight = (this._buttons.length - 1) * (heightPx + spacingPx) + heightPx;
+        // One line per row (a number row's value + '-' + '+' share a single line).
+        const rows = this._rows;
+        const totalHeight = (rows.length - 1) * (heightPx + spacingPx) + heightPx;
         const startY = totalHeight / 2 - heightPx / 2;
 
-        for (let i = 0; i < this._buttons.length; i++) {
-            const button = this._buttons[i];
-            button.setLocalPosition(0, startY - i * (heightPx + spacingPx), 0);
+        for (let r = 0; r < rows.length; r++) {
+            const y = startY - r * (heightPx + spacingPx);
+            const row = rows[r];
+            if (row.kind === 'number') {
+                row.labelEntity.setLocalPosition(row.labelX, y, 0);
+                row.minus.setLocalPosition(row.minusX, y, 0);
+                row.plus.setLocalPosition(row.plusX, y, 0);
+            } else {
+                row.entity.setLocalPosition(0, y, 0);
+            }
         }
     }
 
@@ -1275,8 +1423,12 @@ class XrMenu extends Script {
             }
             this._updateMenuOpacity(this._currentOpacity);
 
-            // Disable container when fully faded out
-            if (this._currentOpacity <= 0 && this._menuContainer) {
+            // Disable container only when fully faded *out* (hiding). The _targetOpacity guard is
+            // essential: on the first XR frame dt is ~0, so a fade-*in* leaves _currentOpacity at 0
+            // for a frame; without the guard this would disable the container, and since _menuVisible
+            // is already true, _setMenuVisible(true) never re-enables it — the menu stays hidden for
+            // the whole session (first-session-only bug).
+            if (this._currentOpacity <= 0 && this._targetOpacity <= 0 && this._menuContainer) {
                 this._menuContainer.enabled = false;
             }
         }
@@ -1335,6 +1487,18 @@ class XrMenu extends Script {
         tmpVec3A.add(tmpVec3B);
         tmpVec3B.copy(cam.up).mulScalar(this.followOffset.y);
         tmpVec3A.add(tmpVec3B);
+
+        // Guard against a not-yet-ready camera pose (e.g. Apple Vision Pro reports a degenerate /
+        // NaN pose on its first WebXR frame after a page load). Writing a non-finite transform here
+        // is fatal: the lerp/slerp below blend from the container's own value, so one NaN write
+        // propagates forever and the menu stays invisible for the whole session. Defer (without
+        // setting _followInitialized) until the pose is finite, so we snap the instant it's valid.
+        const poseValid =
+            Number.isFinite(tmpVec3A.x) && Number.isFinite(tmpVec3A.y) && Number.isFinite(tmpVec3A.z) &&
+            Number.isFinite(camRot.x) && Number.isFinite(camRot.y) && Number.isFinite(camRot.z) && Number.isFinite(camRot.w);
+        if (!poseValid) {
+            return;
+        }
 
         // Snap on the first frame so the menu doesn't fly in from the world origin
         if (!this._followInitialized) {

--- a/scripts/esm/xr-navigation.mjs
+++ b/scripts/esm/xr-navigation.mjs
@@ -284,7 +284,12 @@ class XrNavigation extends Script {
 
             const handleSelectEnd = () => {
                 this.activePointers.set(inputSource, false);
-                this.tryTeleport(inputSource);
+                // Only teleport when teleportation is enabled. Otherwise a select/pinch gesture
+                // (e.g. used to click a UI element) would still snap the rig to the floor point
+                // under the ray.
+                if (this.enableTeleport) {
+                    this.tryTeleport(inputSource);
+                }
             };
 
             // Attach the handlers

--- a/src/platform/graphics/webgpu/webgpu-debug.js
+++ b/src/platform/graphics/webgpu/webgpu-debug.js
@@ -13,6 +13,15 @@ const MAX_DUPLICATES = 5;
  * stripped out in other builds.
  */
 class WebgpuDebug {
+    /**
+     * When true, the WebGPU validation / error scopes (pushErrorScope / popErrorScope) are skipped
+     * entirely, removing their per-pass cost. Useful when profiling. Note these scopes are already
+     * stripped from non-debug builds, so this flag only has any effect on the debug build.
+     *
+     * @type {boolean}
+     */
+    static skipValidation = false;
+
     static _scopes = [];
 
     static _markers = [];
@@ -26,6 +35,7 @@ class WebgpuDebug {
      * @param {WebgpuGraphicsDevice} device - The graphics device.
      */
     static validate(device) {
+        if (WebgpuDebug.skipValidation) return;
         device.wgpu.pushErrorScope('validation');
         WebgpuDebug._scopes.push('validation');
         WebgpuDebug._markers.push(DebugGraphics.toString());
@@ -37,6 +47,7 @@ class WebgpuDebug {
      * @param {WebgpuGraphicsDevice} device - The graphics device.
      */
     static memory(device) {
+        if (WebgpuDebug.skipValidation) return;
         device.wgpu.pushErrorScope('out-of-memory');
         WebgpuDebug._scopes.push('out-of-memory');
         WebgpuDebug._markers.push(DebugGraphics.toString());
@@ -48,6 +59,7 @@ class WebgpuDebug {
      * @param {WebgpuGraphicsDevice} device - The graphics device.
      */
     static internal(device) {
+        if (WebgpuDebug.skipValidation) return;
         device.wgpu.pushErrorScope('internal');
         WebgpuDebug._scopes.push('internal');
         WebgpuDebug._markers.push(DebugGraphics.toString());
@@ -61,6 +73,7 @@ class WebgpuDebug {
      * @param {...any} args - Additional parameters that form the error message.
      */
     static async end(device, label, ...args) {
+        if (WebgpuDebug.skipValidation) return;
         const header = WebgpuDebug._scopes.pop();
         const marker = WebgpuDebug._markers.pop();
         Debug.assert(header, 'Non matching end.');
@@ -88,6 +101,8 @@ class WebgpuDebug {
      * @param {...any} args - Additional parameters providing context about the shader.
      */
     static async endShader(device, shaderModule, source, contextLines = 2, ...args) {
+        if (WebgpuDebug.skipValidation) return;
+
         const header = WebgpuDebug._scopes.pop();
         const marker = WebgpuDebug._markers.pop();
         Debug.assert(header, 'Non-matching error scope end.');


### PR DESCRIPTION
Improves the `vr-lod` Gaussian-splat XR example and fixes a few XR interaction issues uncovered while testing on Apple Vision Pro and Quest.

**XR menu (`scripts/esm/xr-menu.mjs`):**
- Clicks now fire from the `select`/pinch event in addition to gamepad-button polling, so hand-tracking pinches that arrive as a `transient-pointer` select source (e.g. Apple Vision Pro) actually trigger buttons. The existing press-cooldown prevents a double-fire where both paths run (e.g. Quest).
- Fixed the menu staying invisible for the entire first XR session after a page load: the always-visible container is now only disabled when actually fading *out* (`_targetOpacity <= 0`), so a `dt=0` first frame can't latch `enabled = false` for the session.
- Added a public `isPointerOverMenu` getter.
- Guarded the camera-follow snap against a non-finite cold-start pose.

**XR navigation (`scripts/esm/xr-navigation.mjs`):**
- Teleport-on-release now respects `enableTeleport`. Previously a pinch used to click UI would also jump the rig, because the select handler teleported unconditionally while only the preview ray was gated.

**WebGPU debug (`src/platform/graphics/webgpu/webgpu-debug.js`):**
- Added a `WebgpuDebug.skipValidation` static flag (default `false`) to skip the validation / error scopes (`pushErrorScope`/`popErrorScope`) for profiling. Gated across `validate`/`memory`/`internal`/`end`/`endShader`. Debug-build only (these scopes are already stripped from release builds).

**`vr-lod` example:**
- Scene selector — church, cave, apartment, skatepark — each with its own camera framing and XR (floor-relative) placement.
- Renderer auto-selects: GPU-sort (compute) on WebGPU, CPU-sort on WebGL.
- In-XR HUD number rows for splat budget, scene index, min contribution, and alpha clip, plus FPS / GPU-time / resolution readouts.
- Locomotion: replaced the ray-to-ground teleport (which jumped far outside the scene near floor level, and is unusable on stick-less AVP) with a fixed-step dash in the look direction that preserves elevation; suppressed when the pointer is over the HUD.
- Updated asset credits for the scenes used.

**API changes:**
- `WebgpuDebug.skipValidation` — new static boolean.
- `XrMenu#isPointerOverMenu` — new public getter (true when a pointer ray is over an interactive menu button).