### PR TITLE
examples: serve gsplat example data over the CDN

### DIFF
--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
@@ -457,7 +457,7 @@ assetListLoader.load(() => {
     // gaussian-splatting/depth-of-field example. The cave splat is unrotated (its proxy is what's
     // flipped in that example), whereas the original needs a 180° flip.
     const caveAsset = new pc.Asset('gsplat-cave', 'gsplat', {
-        url: 'https://s3.eu-west-1.amazonaws.com/code.playcanvas.com/examples_data/example_cave_01/lod-meta.json'
+        url: 'https://code.playcanvas.com/examples_data/example_cave_01/lod-meta.json'
     });
     app.assets.add(caveAsset);
 

--- a/examples/src/examples/gaussian-splatting/billions.example.mjs
+++ b/examples/src/examples/gaussian-splatting/billions.example.mjs
@@ -83,7 +83,7 @@ app.on('destroy', () => {
 // capture storing Y as "down"; otherwise the world arrives upside-down.
 const config = {
     name: 'Poland-village',
-    url: 'https://s3.eu-west-1.amazonaws.com/code.playcanvas.com/examples_data/example_poland_02/lod-meta.json',
+    url: 'https://code.playcanvas.com/examples_data/example_poland_02/lod-meta.json',
     // Camera-movement threshold (world units) that retriggers LOD evaluation. Each instance
     // footprint is hundreds of units across, so re-evaluating every 0.5 units was overkill —
     // 32 still updates well before the camera crosses a meaningful fraction of a tile.

--- a/examples/src/examples/gaussian-splatting/depth-of-field.example.mjs
+++ b/examples/src/examples/gaussian-splatting/depth-of-field.example.mjs
@@ -92,7 +92,7 @@ app.on('destroy', () => {
 });
 
 const assets = {
-    island: new pc.Asset('gsplat', 'gsplat', { url: 'https://s3.eu-west-1.amazonaws.com/code.playcanvas.com/examples_data/example_cave_01/lod-meta.json' }),
+    island: new pc.Asset('gsplat', 'gsplat', { url: 'https://code.playcanvas.com/examples_data/example_cave_01/lod-meta.json' }),
     proxy: new pc.Asset('proxy', 'container', { url: './assets/models/cave.glb' }),
     collision: new pc.Asset('collision', 'container', { url: './assets/models/cave-collision.glb' })
 };

--- a/examples/src/examples/gaussian-splatting/first-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/first-person.example.mjs
@@ -85,8 +85,8 @@ app.on('destroy', () => {
 });
 
 const assets = {
-    splat: new pc.Asset('sunnyvale-splat', 'gsplat', { url: 'https://s3.eu-west-1.amazonaws.com/code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.sog' }),
-    collision: new pc.Asset('sunnyvale-collision', 'container', { url: 'https://s3.eu-west-1.amazonaws.com/code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.glb' })
+    splat: new pc.Asset('sunnyvale-splat', 'gsplat', { url: 'https://code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.sog' }),
+    collision: new pc.Asset('sunnyvale-collision', 'container', { url: 'https://code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.glb' })
 };
 
 await new Promise((resolve) => {

--- a/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
@@ -138,8 +138,8 @@ for (const { key, file } of LUT_CATALOG) {
 }
 
 const assets = {
-    splat: new pc.Asset('sunnyvale-splat', 'gsplat', { url: 'https://s3.eu-west-1.amazonaws.com/code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.sog' }),
-    collision: new pc.Asset('sunnyvale-collision', 'container', { url: 'https://s3.eu-west-1.amazonaws.com/code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.glb' }),
+    splat: new pc.Asset('sunnyvale-splat', 'gsplat', { url: 'https://code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.sog' }),
+    collision: new pc.Asset('sunnyvale-collision', 'container', { url: 'https://code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.glb' }),
     ...lutAssets
 };
 

--- a/examples/src/examples/gaussian-splatting/third-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/third-person.example.mjs
@@ -88,8 +88,8 @@ app.on('destroy', () => {
 });
 
 const assets = {
-    splat: new pc.Asset('sunnyvale-splat', 'gsplat', { url: 'https://s3.eu-west-1.amazonaws.com/code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.sog' }),
-    collision: new pc.Asset('sunnyvale-collision', 'container', { url: 'https://s3.eu-west-1.amazonaws.com/code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.glb' }),
+    splat: new pc.Asset('sunnyvale-splat', 'gsplat', { url: 'https://code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.sog' }),
+    collision: new pc.Asset('sunnyvale-collision', 'container', { url: 'https://code.playcanvas.com/examples_data/example_sunnyvale/sunnyvale.glb' }),
     character: new pc.Asset('character', 'container', { url: './assets/models/bitmoji.glb' }),
     idleAnim: new pc.Asset('idleAnim', 'container', { url: './assets/animations/bitmoji/idle.glb' }),
     walkAnim: new pc.Asset('walkAnim', 'container', { url: './assets/animations/bitmoji/walk.glb' }),


### PR DESCRIPTION
Switches the Gaussian-splat example data URLs from the direct S3 origin (`s3.eu-west-1.amazonaws.com/code.playcanvas.com/...`) to the CloudFront CDN (`code.playcanvas.com/...`). Same bucket, just cached at the edge — matching what `lod-streaming` and the other examples already use.

**Files:**
- `gaussian-splatting/first-person` — sunnyvale `.sog` + `.glb`
- `gaussian-splatting/third-person` — sunnyvale `.sog` + `.glb`
- `gaussian-splatting/lut-grading` — sunnyvale `.sog` + `.glb`
- `gaussian-splatting/depth-of-field` — cave `lod-meta.json`
- `gaussian-splatting/billions` — poland `lod-meta.json`
- `gaussian-splatting-xr/vr-lod` — cave `lod-meta.json`

All target assets verified reachable (HTTP 200, `via: ... cloudfront.net`).