### PR TITLE
Warn and fail GLB loading when Draco decoder is unavailable

### DIFF
--- a/src/framework/parsers/draco-decoder.js
+++ b/src/framework/parsers/draco-decoder.js
@@ -81,7 +81,21 @@ class JobQueue {
         }
     }
 
+    // mark the queue as failed: notify pending jobs and fail any future ones
+    fail(error) {
+        this.error = error;
+        this.jobQueue.length = 0;
+        const callbacks = this.jobCallbacks;
+        this.jobCallbacks = new Map();
+        callbacks.forEach(callback => callback(error));
+    }
+
     enqueueJob(buffer, callback) {
+        if (this.error) {
+            callback(this.error);
+            return;
+        }
+
         const job = {
             jobId: this.jobId++,
             buffer: buffer
@@ -203,6 +217,10 @@ const initializeWorkers = (config) => {
             workers.push(worker);
         }
         jobQueue.init(workers);
+    })
+    .catch((err) => {
+        Debug.warnOnce(`Failed to load the Draco decoder (${config.jsUrl}, ${config.wasmUrl}): ${err}. Draco compressed meshes will not load.`);
+        jobQueue.fail(err instanceof Error ? err : new Error(err));
     });
 
     return true;

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -640,7 +640,7 @@ const createDracoMesh = (device, primitive, accessors, bufferViews, meshVariants
     promises.push(new Promise((resolve, reject) => {
         // decode draco data
         const dracoExt = primitive.extensions.KHR_draco_mesh_compression;
-        dracoDecode(bufferViews[dracoExt.bufferView].slice().buffer, (err, decompressedData) => {
+        const initialized = dracoDecode(bufferViews[dracoExt.bufferView].slice().buffer, (err, decompressedData) => {
             if (err) {
                 console.log(err);
                 reject(err);
@@ -716,6 +716,12 @@ const createDracoMesh = (device, primitive, accessors, bufferViews, meshVariants
                 resolve();
             }
         });
+
+        if (!initialized) {
+            const message = 'glTF file contains Draco compressed meshes, but the Draco decoder is not configured. Call dracoInitialize() or WasmModule.setConfig(\'DracoDecoderModule\', ...) before loading the asset.';
+            Debug.warnOnce(message);
+            reject(new Error(message));
+        }
     }));
 
     // handle material variants


### PR DESCRIPTION
Previously, loading a Draco-compressed GLB without a configured Draco decoder would hang the asset load forever with no error or warning, in two distinct ways: the decoder config being missing/invalid (decode requests silently dropped), and the decoder script/wasm failing to download or compile (decode jobs queued into a dead worker pool).

**Changes:**
- `createDracoMesh` now checks the return value of `dracoDecode()`; when the decoder is not configured, it emits a `Debug.warnOnce` explaining how to configure it (`dracoInitialize()` / `WasmModule.setConfig('DracoDecoderModule', ...)`) and rejects the mesh promise so the asset fires its `error` event instead of hanging.
- Draco worker initialization now catches download/compile failures, emits a `Debug.warnOnce` with the attempted URLs and underlying error, and fails the job queue: pending decode callbacks receive the error and future decode requests fail immediately.

Neither warning can fire spuriously — both correspond to states the load can never recover from. No change to successful load paths; decode requests issued while the decoder is still downloading continue to be queued and processed as before.