### PR TITLE
Add foveated contribution culling to the GPU-sort gsplat renderer

### DIFF
--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
@@ -216,6 +216,8 @@ assetListLoader.load(() => {
     data.set('splatBudget', 2);
     // XR framebuffer scale factor (applied only when starting an XR session; does not affect 2D).
     data.set('framebufferScaleFactor', 1);
+    // Foveated contribution culling strength (GPU-sort renderer only; 0 = off).
+    data.set('foveationStrength', 0);
     data.set('data.stats.gsplats', '—');
     data.set('data.stats.resolution', '—');
 
@@ -288,7 +290,9 @@ assetListLoader.load(() => {
                 { type: 'number', label: 'Contribution', value: '5', decEvent: 'contribution:dec', incEvent: 'contribution:inc' },
                 // [7] number row: alphaClipForward, stepped 1/255 .. 1/2
                 { type: 'number', label: 'AlphaClip', value: '1/16', decEvent: 'alphaclip:dec', incEvent: 'alphaclip:inc' },
-                { label: 'EXIT XR', eventName: 'xr:end' } // [8] interactive: ends the XR session
+                // [8] number row: foveated contribution culling strength (GPU-sort renderer only)
+                { type: 'number', label: 'FovCull', value: '0.0', decEvent: 'fovcull:dec', incEvent: 'fovcull:inc' },
+                { label: 'EXIT XR', eventName: 'xr:end' } // [9] interactive: ends the XR session
             ],
             fontAsset: assets.font,
             alwaysVisible: true,
@@ -386,6 +390,23 @@ assetListLoader.load(() => {
         applyAlphaClip();
     });
     applyAlphaClip(); // seed the readout
+
+    // Foveated contribution culling strength (number row [8]). +/- 5, clamped to 0..50
+    // (default 0 = off). Only affects the GPU-sort (hybrid) renderer.
+    const FOVCULL_ROW = 8;
+    const applyFovCull = () => {
+        const v = data.get('foveationStrength') ?? 0;
+        app.scene.gsplat.foveationStrength = v;
+        xrHud?.setItemValue(FOVCULL_ROW, v.toFixed(1));
+    };
+    data.on('foveationStrength:set', applyFovCull);
+    app.on('fovcull:dec', () => {
+        data.set('foveationStrength', Math.max(0, (data.get('foveationStrength') ?? 0) - 5));
+    });
+    app.on('fovcull:inc', () => {
+        data.set('foveationStrength', Math.min(50, (data.get('foveationStrength') ?? 0) + 5));
+    });
+    applyFovCull(); // seed the engine value and readout
 
     /** @type {pc.Entity|null} */
     let gsplatEntity = null;

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1762,6 +1762,8 @@ class GSplatManager {
             alphaClip,
             minPixelSize: gsplat.minPixelSize * 0.5,
             minContribution: gsplat.minContribution,
+            foveationStrength: gsplat.foveationStrength,
+            foveationCenter: gsplat.foveationCenter,
             viewportWidth,
             viewportHeight,
             flipY: !!cameraNode.camera.renderTarget?.flipY,

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -72,6 +72,8 @@ class GSplatParams {
         this._material.setParameter('alphaClipForward', 1.0 / 255.0);
         this._material.setParameter('minPixelSize', 2.0);
         this._material.setParameter('minContribution', 3.0);
+        this._material.setParameter('foveationStrength', 0);
+        this._material.setParameter('foveationCenter', 0.3);
     }
 
     /**
@@ -656,6 +658,53 @@ class GSplatParams {
      */
     get minContribution() {
         return this._material.getParameter('minContribution')?.data ?? 3.0;
+    }
+
+    /**
+     * Sets the foveated contribution culling strength. Only used by the
+     * {@link GSPLAT_RENDERER_RASTER_GPU_SORT} renderer. When greater than zero, the contribution
+     * culling threshold is raised radially from the screen centre: the effective threshold is
+     * `minContribution + foveationStrength * smoothstep(foveationCenter, 1, length(ndc))`, so the
+     * centre of the screen is unaffected and low-contribution splats are culled increasingly
+     * toward the edges, reaching full strength at the screen edge and beyond (corners). Set to 0
+     * to disable. Defaults to 0.
+     *
+     * @type {number}
+     */
+    set foveationStrength(value) {
+        this._material.setParameter('foveationStrength', value);
+        this._material.update();
+    }
+
+    /**
+     * Gets the foveated contribution culling strength.
+     *
+     * @type {number}
+     */
+    get foveationStrength() {
+        return this._material.getParameter('foveationStrength')?.data ?? 0;
+    }
+
+    /**
+     * Sets the protected centre radius for foveated contribution culling. Only used by the
+     * {@link GSPLAT_RENDERER_RASTER_GPU_SORT} renderer. Expressed in NDC radius units (0 at the
+     * screen centre, 1 at the edge): within this radius {@link foveationStrength} has no effect,
+     * and the falloff ramps smoothly from this radius to the screen edge. Defaults to 0.3.
+     *
+     * @type {number}
+     */
+    set foveationCenter(value) {
+        this._material.setParameter('foveationCenter', value);
+        this._material.update();
+    }
+
+    /**
+     * Gets the protected centre radius for foveated contribution culling.
+     *
+     * @type {number}
+     */
+    get foveationCenter() {
+        return this._material.getParameter('foveationCenter')?.data ?? 0.3;
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-projector.js
+++ b/src/scene/gsplat-unified/gsplat-projector.js
@@ -271,7 +271,9 @@ class GSplatProjector {
             new UniformFormat('alphaClip', UNIFORMTYPE_FLOAT),
             new UniformFormat('minContribution', UNIFORMTYPE_FLOAT),
             new UniformFormat('minDist', UNIFORMTYPE_FLOAT),
-            new UniformFormat('invRange', UNIFORMTYPE_FLOAT)
+            new UniformFormat('invRange', UNIFORMTYPE_FLOAT),
+            new UniformFormat('foveationStrength', UNIFORMTYPE_FLOAT),
+            new UniformFormat('foveationCenter', UNIFORMTYPE_FLOAT)
         ];
 
         this._projectorUniformBufferFormat = new UniformBufferFormat(device, baseFields);
@@ -590,6 +592,10 @@ class GSplatProjector {
      * @param {number} params.alphaClip - Alpha cull threshold.
      * @param {number} params.minPixelSize - Minimum on-screen pixel size before culling.
      * @param {number} params.minContribution - Minimum total contribution before culling.
+     * @param {number} params.foveationStrength - Foveated culling strength added to
+     * `minContribution` toward the screen edges (0 disables).
+     * @param {number} params.foveationCenter - Protected centre radius (NDC units) within which
+     * foveated culling has no effect.
      * @param {number} params.viewportWidth - Render viewport width in pixels.
      * @param {number} params.viewportHeight - Render viewport height in pixels.
      * @param {boolean} params.flipY - Whether the active render target uses `flipY` (must match
@@ -610,6 +616,7 @@ class GSplatProjector {
             workBuffer, cameraNode, compactedSplatIds, sortElementCountBuffer,
             totalCapacity, radialSort, numBits, minDist, maxDist,
             alphaClip, minPixelSize, minContribution,
+            foveationStrength = 0, foveationCenter = 0.3,
             viewportWidth, viewportHeight, flipY,
             pickMode = false,
             fisheyeProj,
@@ -734,6 +741,8 @@ class GSplatProjector {
         compute.setParameter('alphaClip', alphaClip);
         compute.setParameter('minPixelSize', minPixelSize);
         compute.setParameter('minContribution', minContribution);
+        compute.setParameter('foveationStrength', foveationStrength);
+        compute.setParameter('foveationCenter', foveationCenter);
         compute.setParameter('isOrtho', cam.projection === PROJECTION_ORTHOGRAPHIC ? 1 : 0);
         compute.setParameter('splatTextureSize', workBuffer.textureSize);
         compute.setParameter('numBins', GSplatSortBinWeights.NUM_BINS);

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-common.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-common.js
@@ -46,6 +46,8 @@ fn computeSplatCov(
     isOrtho: u32,
     alphaClip: f32,
     minContribution: f32,
+    foveationStrength: f32,
+    foveationCenter: f32,
     #ifdef GSPLAT_FISHEYE
         fisheye_k: f32,
         fisheye_inv_k: f32,
@@ -174,8 +176,18 @@ fn computeSplatCov(
     // Rejects splats whose total visual contribution (opacity * projected area) is
     // negligible. Near the camera, projected areas are large so contributions naturally
     // exceed the threshold; at distance, areas shrink and low-impact splats are culled.
+    //
+    // Foveation: the threshold is raised radially from the screen centre. Within
+    // foveationCenter (NDC radius) there is no effect; the boost ramps with a smoothstep
+    // to full foveationStrength at the screen edge (r = 1) and beyond (corners). With
+    // strength 0 this is an exact no-op.
+    let fovNdc = screen * vec2f(2.0 / viewportWidth, 2.0 / viewportHeight) - vec2f(1.0);
+    // manual smoothstep with a guard so foveationCenter near 1.0 cannot divide by zero
+    let fovT = saturate((length(fovNdc) - foveationCenter) / max(1.0 - foveationCenter, 1e-4));
+    let effMinContribution = minContribution + foveationStrength * fovT * fovT * (3.0 - 2.0 * fovT);
+
     let totalContribution = opacity * 6.283185 * sqrt(det);
-    if (totalContribution < minContribution) {
+    if (totalContribution < effMinContribution) {
         return result;
     }
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-local-tile-count.js
@@ -101,6 +101,8 @@ fn main(
         uniforms.alphaClip,
         uniforms.minPixelSize,
         uniforms.minContribution,
+        // foveated culling is not supported by the compute-local renderer (strength 0 = off)
+        0.0, 0.3,
         uniforms.viewMatrix,
         uniforms.viewProj,
         uniforms.focal,

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-project-common.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-project-common.js
@@ -32,6 +32,8 @@ fn projectSplatCommon(
     alphaClip: f32,
     minPixelSize: f32,
     minContribution: f32,
+    foveationStrength: f32,
+    foveationCenter: f32,
     viewMatrix: mat4x4f,
     viewProj: mat4x4f,
     focal: f32,
@@ -78,6 +80,7 @@ fn projectSplatCommon(
         focal, viewportWidth, viewportHeight,
         nearClip, farClip, opacity, minPixelSize,
         isOrtho, alphaClip, minContribution,
+        foveationStrength, foveationCenter,
         #ifdef GSPLAT_FISHEYE
             fisheye_k, fisheye_inv_k,
             fisheye_projMat00, fisheye_projMat11,

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
@@ -57,6 +57,8 @@ struct ProjectorUniforms {
     minContribution: f32,
     minDist: f32,
     invRange: f32,
+    foveationStrength: f32,
+    foveationCenter: f32,
     #ifdef GSPLAT_XR
         // Eye-1 view-projection (raw XR projViewOffMat). Eye 0 uses viewProj above.
         // Appended only for the stereo variant - matches the conditional CPU UBO field.
@@ -118,6 +120,8 @@ fn main(
         uniforms.alphaClip,
         uniforms.minPixelSize,
         uniforms.minContribution,
+        uniforms.foveationStrength,
+        uniforms.foveationCenter,
         uniforms.viewMatrix,
         uniforms.viewProj,
         uniforms.focal,


### PR DESCRIPTION
Adds an optional foveated mode to the GPU-sort (hybrid) gsplat renderer's contribution culling: the `minContribution` threshold is raised radially from the screen centre, so low-impact splats are culled increasingly toward the screen edges — where peripheral overdraw dominates XR frame cost — while the centre is untouched.

The effective threshold is:

```
minContribution + foveationStrength * smoothstep(foveationCenter, 1.0, length(ndc))
```

with `r = length(ndc)` being 0 at the screen centre, 1 at the edge (corners beyond 1 get full strength).

**Changes:**
- `GSplatParams.foveationStrength` (default 0 = off) and `GSplatParams.foveationCenter` (default 0.3, the protected-centre radius in NDC units). Only used by the `GSPLAT_RENDERER_RASTER_GPU_SORT` renderer.
- The values flow through `GSplatManager` → projector dispatch params → projector UBO → the shared `computeSplatCov` cull, which applies the radial boost. With strength 0 the cull is bit-identical to before (additive 0); no shader variant is added — the cost is a few ALU once per splat in the projection compute pass.
- Stereo XR: culling is evaluated from eye-0 NDC (consistent with the existing shared stereo cull); the projector's pick variant shares the same uniforms so picking stays consistent with the rendered set.
- The compute-local renderer is unaffected — it passes inert constants (strength 0) to the shared projection helper.

**API Changes:**
- `GSplatParams#foveationStrength` — new property (number, default 0).
- `GSplatParams#foveationCenter` — new property (number, default 0.3).

**Examples:**
- `gaussian-splatting-xr/vr-lod`: new in-XR HUD number row to tune the strength live (+/- 5, clamped 0–50).

**Performance:**
- Intended as a cheap complement to fixed (resolution) foveation on standalone XR devices: fewer surviving splats at the periphery → fewer quads sorted/rasterized → less peripheral overdraw, which profiling on Quest 3 showed to be the dominant frame cost.