### PR TITLE
refactor(button): align ButtonComponent with CameraComponent architecture

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -766,7 +766,7 @@ class ButtonComponent extends Component {
      * Sets one of the state sprite asset/frame fields, reapplying the visual state on change.
      *
      * @param {string} name - The name of the private field to set.
-     * @param {*} arg - The new value.
+     * @param {Asset|number|null} arg - The new value.
      * @private
      */
     _setTransitionValue(name, arg) {

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -624,7 +624,7 @@ class ButtonComponent extends Component {
     /**
      * Sets the sprite to be used as the button image when the user hovers over it.
      *
-     * @type {Asset|number|null}
+     * @type {Asset|null}
      */
     set hoverSpriteAsset(arg) {
         this._setTransitionValue('_hoverSpriteAsset', arg);
@@ -633,7 +633,7 @@ class ButtonComponent extends Component {
     /**
      * Gets the sprite to be used as the button image when the user hovers over it.
      *
-     * @type {Asset|number|null}
+     * @type {Asset|null}
      */
     get hoverSpriteAsset() {
         return this._hoverSpriteAsset;
@@ -660,7 +660,7 @@ class ButtonComponent extends Component {
     /**
      * Sets the sprite to be used as the button image when the user presses it.
      *
-     * @type {Asset|number|null}
+     * @type {Asset|null}
      */
     set pressedSpriteAsset(arg) {
         this._setTransitionValue('_pressedSpriteAsset', arg);
@@ -669,7 +669,7 @@ class ButtonComponent extends Component {
     /**
      * Gets the sprite to be used as the button image when the user presses it.
      *
-     * @type {Asset|number|null}
+     * @type {Asset|null}
      */
     get pressedSpriteAsset() {
         return this._pressedSpriteAsset;
@@ -696,7 +696,7 @@ class ButtonComponent extends Component {
     /**
      * Sets the sprite to be used as the button image when the button is not interactive.
      *
-     * @type {Asset|number|null}
+     * @type {Asset|null}
      */
     set inactiveSpriteAsset(arg) {
         this._setTransitionValue('_inactiveSpriteAsset', arg);
@@ -705,7 +705,7 @@ class ButtonComponent extends Component {
     /**
      * Gets the sprite to be used as the button image when the button is not interactive.
      *
-     * @type {Asset|number|null}
+     * @type {Asset|null}
      */
     get inactiveSpriteAsset() {
         return this._inactiveSpriteAsset;

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -624,7 +624,7 @@ class ButtonComponent extends Component {
     /**
      * Sets the sprite to be used as the button image when the user hovers over it.
      *
-     * @type {Asset}
+     * @type {Asset|number|null}
      */
     set hoverSpriteAsset(arg) {
         this._setTransitionValue('_hoverSpriteAsset', arg);
@@ -633,7 +633,7 @@ class ButtonComponent extends Component {
     /**
      * Gets the sprite to be used as the button image when the user hovers over it.
      *
-     * @type {Asset}
+     * @type {Asset|number|null}
      */
     get hoverSpriteAsset() {
         return this._hoverSpriteAsset;
@@ -660,7 +660,7 @@ class ButtonComponent extends Component {
     /**
      * Sets the sprite to be used as the button image when the user presses it.
      *
-     * @type {Asset}
+     * @type {Asset|number|null}
      */
     set pressedSpriteAsset(arg) {
         this._setTransitionValue('_pressedSpriteAsset', arg);
@@ -669,7 +669,7 @@ class ButtonComponent extends Component {
     /**
      * Gets the sprite to be used as the button image when the user presses it.
      *
-     * @type {Asset}
+     * @type {Asset|number|null}
      */
     get pressedSpriteAsset() {
         return this._pressedSpriteAsset;
@@ -696,7 +696,7 @@ class ButtonComponent extends Component {
     /**
      * Sets the sprite to be used as the button image when the button is not interactive.
      *
-     * @type {Asset}
+     * @type {Asset|number|null}
      */
     set inactiveSpriteAsset(arg) {
         this._setTransitionValue('_inactiveSpriteAsset', arg);
@@ -705,7 +705,7 @@ class ButtonComponent extends Component {
     /**
      * Gets the sprite to be used as the button image when the button is not interactive.
      *
-     * @type {Asset}
+     * @type {Asset|number|null}
      */
     get inactiveSpriteAsset() {
         return this._inactiveSpriteAsset;

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -277,10 +277,7 @@ class ButtonComponent extends Component {
     /** @private */
     _active = true;
 
-    /**
-     * @type {Vec4}
-     * @private
-     */
+    /** @private */
     _hitPadding = new Vec4();
 
     /** @private */

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -1,6 +1,7 @@
 import { now } from '../../../core/time.js';
 import { math } from '../../../core/math/math.js';
 import { Color } from '../../../core/math/color.js';
+import { Vec4 } from '../../../core/math/vec4.js';
 
 import { GraphNode } from '../../../scene/graph-node.js';
 
@@ -13,7 +14,6 @@ import { ELEMENTTYPE_GROUP } from '../element/constants.js';
  * @import { ButtonComponentSystem } from './system.js'
  * @import { Entity } from '../../entity.js'
  * @import { EventHandle } from '../../../core/event-handle.js'
- * @import { Vec4 } from '../../../core/math/vec4.js'
  */
 
 const VisualState = {
@@ -275,6 +275,57 @@ class ButtonComponent extends Component {
     static EVENT_PRESSEDEND = 'pressedend';
 
     /** @private */
+    _active = true;
+
+    /**
+     * @type {Vec4}
+     * @private
+     */
+    _hitPadding = new Vec4();
+
+    /** @private */
+    _transitionMode = BUTTON_TRANSITION_MODE_TINT;
+
+    /** @private */
+    _hoverTint = new Color(0.75, 0.75, 0.75);
+
+    /** @private */
+    _pressedTint = new Color(0.5, 0.5, 0.5);
+
+    /** @private */
+    _inactiveTint = new Color(0.25, 0.25, 0.25);
+
+    /** @private */
+    _fadeDuration = 0;
+
+    /**
+     * @type {Asset|null}
+     * @private
+     */
+    _hoverSpriteAsset = null;
+
+    /** @private */
+    _hoverSpriteFrame = 0;
+
+    /**
+     * @type {Asset|null}
+     * @private
+     */
+    _pressedSpriteAsset = null;
+
+    /** @private */
+    _pressedSpriteFrame = 0;
+
+    /**
+     * @type {Asset|null}
+     * @private
+     */
+    _inactiveSpriteAsset = null;
+
+    /** @private */
+    _inactiveSpriteFrame = 0;
+
+    /** @private */
     _visualState = VisualState.DEFAULT;
 
     /** @private */
@@ -285,6 +336,21 @@ class ButtonComponent extends Component {
 
     /** @private */
     _isPressed = false;
+
+    /** @private */
+    _hasHitElementListeners = false;
+
+    /** @private */
+    _isApplyingTint = false;
+
+    /** @private */
+    _isApplyingSprite = false;
+
+    /**
+     * @type {{startTime: number, from: Color, to: Color, lerpColor: Color}|null}
+     * @private
+     */
+    _tweenInfo = null;
 
     /** @private */
     _defaultTint = new Color(1, 1, 1, 1);
@@ -352,25 +418,7 @@ class ButtonComponent extends Component {
     constructor(system, entity) {
         super(system, entity);
 
-        this._toggleLifecycleListeners('on', system);
-    }
-
-    /**
-     * Sets the enabled state of the component.
-     *
-     * @type {boolean}
-     */
-    set enabled(arg) {
-        this._setValue('enabled', arg);
-    }
-
-    /**
-     * Gets the enabled state of the component.
-     *
-     * @type {boolean}
-     */
-    get enabled() {
-        return this.data.enabled;
+        this._evtElementAdd = this.entity.on('element:add', this._onElementComponentAdd, this);
     }
 
     /**
@@ -380,7 +428,12 @@ class ButtonComponent extends Component {
      * @type {boolean}
      */
     set active(arg) {
-        this._setValue('active', arg);
+        if (this._active === arg) {
+            return;
+        }
+
+        this._active = arg;
+        this._updateVisualState();
     }
 
     /**
@@ -389,7 +442,7 @@ class ButtonComponent extends Component {
      * @type {boolean}
      */
     get active() {
-        return this.data.active;
+        return this._active;
     }
 
     /**
@@ -399,33 +452,27 @@ class ButtonComponent extends Component {
      * @type {Entity|string|null}
      */
     set imageEntity(arg) {
-        if (this._imageEntity !== arg) {
-            const isString = typeof arg === 'string';
-            if (this._imageEntity && isString && this._imageEntity.guid === arg) {
-                return;
-            }
+        let newEntity;
+        if (arg instanceof GraphNode) {
+            newEntity = arg;
+        } else if (typeof arg === 'string') {
+            newEntity = this.system.app.getEntityFromIndex(arg) ?? null;
+        } else {
+            newEntity = null;
+        }
 
-            if (this._imageEntity) {
-                this._imageEntityUnsubscribe();
-            }
+        if (this._imageEntity === newEntity) {
+            return;
+        }
 
-            if (arg instanceof GraphNode) {
-                this._imageEntity = arg;
-            } else if (isString) {
-                this._imageEntity = this.system.app.getEntityFromIndex(arg) || null;
-            } else {
-                this._imageEntity = null;
-            }
+        if (this._imageEntity) {
+            this._imageEntityUnsubscribe();
+        }
 
-            if (this._imageEntity) {
-                this._imageEntitySubscribe();
-            }
+        this._imageEntity = newEntity;
 
-            if (this._imageEntity) {
-                this.data.imageEntity = this._imageEntity.guid;
-            } else if (isString && arg) {
-                this.data.imageEntity = arg;
-            }
+        if (newEntity) {
+            this._imageEntitySubscribe();
         }
     }
 
@@ -445,7 +492,19 @@ class ButtonComponent extends Component {
      * @type {Vec4}
      */
     set hitPadding(arg) {
-        this._setValue('hitPadding', arg);
+        // Mirror the old schema-driven `type: 'vec4'` conversion in
+        // ComponentSystem.convertValue: pass null/undefined through untouched (the
+        // falsy fallback in ElementInput.buildHitCorners relies on this), clone a
+        // Vec4 input so caller mutations do not leak into component state, and
+        // treat anything else as indexable to support `[x, y, z, w]` arrays from
+        // JSON-loaded scenes.
+        if (!arg) {
+            this._hitPadding = arg;
+        } else if (arg instanceof Vec4) {
+            this._hitPadding = arg.clone();
+        } else {
+            this._hitPadding = new Vec4(arg[0], arg[1], arg[2], arg[3]);
+        }
     }
 
     /**
@@ -454,7 +513,7 @@ class ButtonComponent extends Component {
      * @type {Vec4}
      */
     get hitPadding() {
-        return this.data.hitPadding;
+        return this._hitPadding;
     }
 
     /**
@@ -469,7 +528,16 @@ class ButtonComponent extends Component {
      * @type {number}
      */
     set transitionMode(arg) {
-        this._setValue('transitionMode', arg);
+        if (this._transitionMode === arg) {
+            return;
+        }
+
+        const oldMode = this._transitionMode;
+        this._transitionMode = arg;
+
+        this._cancelTween();
+        this._resetToDefaultVisualState(oldMode);
+        this._forceReapplyVisualState();
     }
 
     /**
@@ -478,7 +546,7 @@ class ButtonComponent extends Component {
      * @type {number}
      */
     get transitionMode() {
-        return this.data.transitionMode;
+        return this._transitionMode;
     }
 
     /**
@@ -488,7 +556,7 @@ class ButtonComponent extends Component {
      * @type {Color}
      */
     set hoverTint(arg) {
-        this._setValue('hoverTint', arg);
+        this._setTint('_hoverTint', arg);
     }
 
     /**
@@ -497,7 +565,7 @@ class ButtonComponent extends Component {
      * @type {Color}
      */
     get hoverTint() {
-        return this.data.hoverTint;
+        return this._hoverTint;
     }
 
     /**
@@ -507,7 +575,7 @@ class ButtonComponent extends Component {
      * @type {Color}
      */
     set pressedTint(arg) {
-        this._setValue('pressedTint', arg);
+        this._setTint('_pressedTint', arg);
     }
 
     /**
@@ -516,7 +584,7 @@ class ButtonComponent extends Component {
      * @type {Color}
      */
     get pressedTint() {
-        return this.data.pressedTint;
+        return this._pressedTint;
     }
 
     /**
@@ -526,7 +594,7 @@ class ButtonComponent extends Component {
      * @type {Color}
      */
     set inactiveTint(arg) {
-        this._setValue('inactiveTint', arg);
+        this._setTint('_inactiveTint', arg);
     }
 
     /**
@@ -535,7 +603,7 @@ class ButtonComponent extends Component {
      * @type {Color}
      */
     get inactiveTint() {
-        return this.data.inactiveTint;
+        return this._inactiveTint;
     }
 
     /**
@@ -544,7 +612,7 @@ class ButtonComponent extends Component {
      * @type {number}
      */
     set fadeDuration(arg) {
-        this._setValue('fadeDuration', arg);
+        this._fadeDuration = arg;
     }
 
     /**
@@ -553,7 +621,7 @@ class ButtonComponent extends Component {
      * @type {number}
      */
     get fadeDuration() {
-        return this.data.fadeDuration;
+        return this._fadeDuration;
     }
 
     /**
@@ -562,7 +630,7 @@ class ButtonComponent extends Component {
      * @type {Asset}
      */
     set hoverSpriteAsset(arg) {
-        this._setValue('hoverSpriteAsset', arg);
+        this._setTransitionValue('_hoverSpriteAsset', arg);
     }
 
     /**
@@ -571,7 +639,7 @@ class ButtonComponent extends Component {
      * @type {Asset}
      */
     get hoverSpriteAsset() {
-        return this.data.hoverSpriteAsset;
+        return this._hoverSpriteAsset;
     }
 
     /**
@@ -580,7 +648,7 @@ class ButtonComponent extends Component {
      * @type {number}
      */
     set hoverSpriteFrame(arg) {
-        this._setValue('hoverSpriteFrame', arg);
+        this._setTransitionValue('_hoverSpriteFrame', arg);
     }
 
     /**
@@ -589,7 +657,7 @@ class ButtonComponent extends Component {
      * @type {number}
      */
     get hoverSpriteFrame() {
-        return this.data.hoverSpriteFrame;
+        return this._hoverSpriteFrame;
     }
 
     /**
@@ -598,7 +666,7 @@ class ButtonComponent extends Component {
      * @type {Asset}
      */
     set pressedSpriteAsset(arg) {
-        this._setValue('pressedSpriteAsset', arg);
+        this._setTransitionValue('_pressedSpriteAsset', arg);
     }
 
     /**
@@ -607,7 +675,7 @@ class ButtonComponent extends Component {
      * @type {Asset}
      */
     get pressedSpriteAsset() {
-        return this.data.pressedSpriteAsset;
+        return this._pressedSpriteAsset;
     }
 
     /**
@@ -616,7 +684,7 @@ class ButtonComponent extends Component {
      * @type {number}
      */
     set pressedSpriteFrame(arg) {
-        this._setValue('pressedSpriteFrame', arg);
+        this._setTransitionValue('_pressedSpriteFrame', arg);
     }
 
     /**
@@ -625,7 +693,7 @@ class ButtonComponent extends Component {
      * @type {number}
      */
     get pressedSpriteFrame() {
-        return this.data.pressedSpriteFrame;
+        return this._pressedSpriteFrame;
     }
 
     /**
@@ -634,7 +702,7 @@ class ButtonComponent extends Component {
      * @type {Asset}
      */
     set inactiveSpriteAsset(arg) {
-        this._setValue('inactiveSpriteAsset', arg);
+        this._setTransitionValue('_inactiveSpriteAsset', arg);
     }
 
     /**
@@ -643,7 +711,7 @@ class ButtonComponent extends Component {
      * @type {Asset}
      */
     get inactiveSpriteAsset() {
-        return this.data.inactiveSpriteAsset;
+        return this._inactiveSpriteAsset;
     }
 
     /**
@@ -652,7 +720,7 @@ class ButtonComponent extends Component {
      * @type {number}
      */
     set inactiveSpriteFrame(arg) {
-        this._setValue('inactiveSpriteFrame', arg);
+        this._setTransitionValue('_inactiveSpriteFrame', arg);
     }
 
     /**
@@ -661,56 +729,56 @@ class ButtonComponent extends Component {
      * @type {number}
      */
     get inactiveSpriteFrame() {
-        return this.data.inactiveSpriteFrame;
+        return this._inactiveSpriteFrame;
     }
 
-    /** @ignore */
-    _setValue(name, value) {
-        const data = this.data;
-        const oldValue = data[name];
-        data[name] = value;
-        this.fire('set', name, oldValue, value);
-    }
+    /**
+     * Sets one of the state tint fields, mirroring the old schema-driven `type: 'rgba'`
+     * conversion in ComponentSystem.convertValue: pass null/undefined through untouched, clone a
+     * Color input (so caller mutations do not leak into component state), and treat anything else
+     * as indexable to support `[r, g, b, a]` arrays from JSON-loaded scenes. The visual state is
+     * only reapplied when the tint actually changes in value, as reapplying cancels any in-flight
+     * fade tween.
+     *
+     * @param {string} name - The name of the private tint field to set.
+     * @param {Color|number[]|null} arg - The new tint value.
+     * @private
+     */
+    _setTint(name, arg) {
+        const oldValue = this[name];
 
-    _toggleLifecycleListeners(onOrOff, system) {
-        this[onOrOff]('set_active', this._onSetActive, this);
-        this[onOrOff]('set_transitionMode', this._onSetTransitionMode, this);
-        this[onOrOff]('set_hoverTint', this._onSetTransitionValue, this);
-        this[onOrOff]('set_pressedTint', this._onSetTransitionValue, this);
-        this[onOrOff]('set_inactiveTint', this._onSetTransitionValue, this);
-        this[onOrOff]('set_hoverSpriteAsset', this._onSetTransitionValue, this);
-        this[onOrOff]('set_hoverSpriteFrame', this._onSetTransitionValue, this);
-        this[onOrOff]('set_pressedSpriteAsset', this._onSetTransitionValue, this);
-        this[onOrOff]('set_pressedSpriteFrame', this._onSetTransitionValue, this);
-        this[onOrOff]('set_inactiveSpriteAsset', this._onSetTransitionValue, this);
-        this[onOrOff]('set_inactiveSpriteFrame', this._onSetTransitionValue, this);
-
-        if (onOrOff === 'on') {
-            this._evtElementAdd = this.entity.on('element:add', this._onElementComponentAdd, this);
+        let value;
+        if (!arg) {
+            value = arg;
+        } else if (arg instanceof Color) {
+            value = arg.clone();
         } else {
-            this._evtElementAdd?.off();
-            this._evtElementAdd = null;
+            value = new Color(arg[0], arg[1], arg[2], arg[3]);
         }
+
+        this[name] = value;
+
+        if (oldValue === value || (oldValue instanceof Color && value instanceof Color && oldValue.equals(value))) {
+            return;
+        }
+
+        this._forceReapplyVisualState();
     }
 
-    _onSetActive(name, oldValue, newValue) {
-        if (oldValue !== newValue) {
-            this._updateVisualState();
+    /**
+     * Sets one of the state sprite asset/frame fields, reapplying the visual state on change.
+     *
+     * @param {string} name - The name of the private field to set.
+     * @param {*} arg - The new value.
+     * @private
+     */
+    _setTransitionValue(name, arg) {
+        if (this[name] === arg) {
+            return;
         }
-    }
 
-    _onSetTransitionMode(name, oldValue, newValue) {
-        if (oldValue !== newValue) {
-            this._cancelTween();
-            this._resetToDefaultVisualState(oldValue);
-            this._forceReapplyVisualState();
-        }
-    }
-
-    _onSetTransitionValue(name, oldValue, newValue) {
-        if (oldValue !== newValue) {
-            this._forceReapplyVisualState();
-        }
+        this[name] = arg;
+        this._forceReapplyVisualState();
     }
 
     _imageEntitySubscribe() {
@@ -970,7 +1038,7 @@ class ButtonComponent extends Component {
     }
 
     _fireIfActive(name, event) {
-        if (this.data.active) {
+        if (this._active) {
             this.fire(name, event);
         }
     }
@@ -1153,7 +1221,7 @@ class ButtonComponent extends Component {
     }
 
     _cancelTween() {
-        delete this._tweenInfo;
+        this._tweenInfo = null;
     }
 
     onUpdate() {
@@ -1179,7 +1247,10 @@ class ButtonComponent extends Component {
 
     onRemove() {
         this._imageEntityUnsubscribe();
-        this._toggleLifecycleListeners('off', this.system);
+
+        this._evtElementAdd?.off();
+        this._evtElementAdd = null;
+
         this.onDisable();
     }
 

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -490,7 +490,7 @@ class ButtonComponent extends Component {
      */
     set hitPadding(arg) {
         // Mirror the old schema-driven `type: 'vec4'` conversion in
-        // ComponentSystem.convertValue: pass null/undefined through untouched (the
+        // ComponentSystem.convertValue: pass falsy values through untouched (the
         // falsy fallback in ElementInput.buildHitCorners relies on this), clone a
         // Vec4 input so caller mutations do not leak into component state, and
         // treat anything else as indexable to support `[x, y, z, w]` arrays from
@@ -731,7 +731,7 @@ class ButtonComponent extends Component {
 
     /**
      * Sets one of the state tint fields, mirroring the old schema-driven `type: 'rgba'`
-     * conversion in ComponentSystem.convertValue: pass null/undefined through untouched, clone a
+     * conversion in ComponentSystem.convertValue: pass falsy values through untouched, clone a
      * Color input (so caller mutations do not leak into component state), and treat anything else
      * as indexable to support `[r, g, b, a]` arrays from JSON-loaded scenes. The visual state is
      * only reapplied when the tint actually changes in value, as reapplying cancels any in-flight

--- a/src/framework/components/button/data.js
+++ b/src/framework/components/button/data.js
@@ -1,46 +1,5 @@
-import { Color } from '../../../core/math/color.js';
-import { Vec4 } from '../../../core/math/vec4.js';
-import { BUTTON_TRANSITION_MODE_TINT } from './constants.js';
-
-/**
- * @import { Asset } from '../../../framework/asset/asset.js'
- * @import { Entity } from '../../../framework/entity.js'
- */
-
 class ButtonComponentData {
     enabled = true;
-
-    active = true;
-
-    /** @type {Entity|null} */
-    imageEntity = null;
-
-    hitPadding = new Vec4();
-
-    transitionMode = BUTTON_TRANSITION_MODE_TINT;
-
-    hoverTint = new Color(0.75, 0.75, 0.75);
-
-    pressedTint = new Color(0.5, 0.5, 0.5);
-
-    inactiveTint = new Color(0.25, 0.25, 0.25);
-
-    fadeDuration = 0;
-
-    /** @type {Asset|null} */
-    hoverSpriteAsset = null;
-
-    hoverSpriteFrame = 0;
-
-    /** @type {Asset|null} */
-    pressedSpriteAsset = null;
-
-    pressedSpriteFrame = 0;
-
-    /** @type {Asset|null} */
-    inactiveSpriteAsset = null;
-
-    inactiveSpriteFrame = 0;
 }
 
 export { ButtonComponentData };

--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -1,3 +1,4 @@
+import { Component } from '../component.js';
 import { ComponentSystem } from '../system.js';
 import { ButtonComponent } from './component.js';
 import { ButtonComponentData } from './data.js';
@@ -6,14 +7,16 @@ import { ButtonComponentData } from './data.js';
  * @import { AppBase } from '../../app-base.js'
  */
 
-const _schema = [
-    'enabled',
+const _schema = ['enabled'];
+
+const _properties = [
+    'imageEntity',
     'active',
-    { name: 'hitPadding', type: 'vec4' },
+    'hitPadding',
     'transitionMode',
-    { name: 'hoverTint', type: 'rgba' },
-    { name: 'pressedTint', type: 'rgba' },
-    { name: 'inactiveTint', type: 'rgba' },
+    'hoverTint',
+    'pressedTint',
+    'inactiveTint',
     'fadeDuration',
     'hoverSpriteAsset',
     'hoverSpriteFrame',
@@ -51,8 +54,38 @@ class ButtonComponentSystem extends ComponentSystem {
     }
 
     initializeComponentData(component, data, properties) {
-        component.imageEntity = data.imageEntity;
+        for (let i = 0; i < _properties.length; i++) {
+            const property = _properties[i];
+            // Guard on `undefined` rather than `hasOwnProperty` so that explicitly
+            // passing `{ hoverTint: undefined }` does not clobber the class-field
+            // default, matching the base initializer's behavior
+            if (data[property] !== undefined) {
+                component[property] = data[property];
+            }
+        }
+
         super.initializeComponentData(component, data, _schema);
+    }
+
+    cloneComponent(entity, clone) {
+        const c = entity.button;
+        return this.addComponent(clone, {
+            enabled: c.enabled,
+            active: c.active,
+            imageEntity: c.imageEntity,
+            hitPadding: c.hitPadding,
+            transitionMode: c.transitionMode,
+            hoverTint: c.hoverTint,
+            pressedTint: c.pressedTint,
+            inactiveTint: c.inactiveTint,
+            fadeDuration: c.fadeDuration,
+            hoverSpriteAsset: c.hoverSpriteAsset,
+            hoverSpriteFrame: c.hoverSpriteFrame,
+            pressedSpriteAsset: c.pressedSpriteAsset,
+            pressedSpriteFrame: c.pressedSpriteFrame,
+            inactiveSpriteAsset: c.inactiveSpriteAsset,
+            inactiveSpriteFrame: c.inactiveSpriteFrame
+        });
     }
 
     onUpdate(dt) {
@@ -77,5 +110,7 @@ class ButtonComponentSystem extends ComponentSystem {
         this.app.systems.off('update', this.onUpdate, this);
     }
 }
+
+Component._buildAccessors(ButtonComponent.prototype, _schema);
 
 export { ButtonComponentSystem };

--- a/test/framework/components/button/component.test.mjs
+++ b/test/framework/components/button/component.test.mjs
@@ -19,7 +19,7 @@ function createButton(data = {}) {
     const button = new Entity('button');
     button.addChild(image);
     button.addComponent('element', { type: ELEMENTTYPE_IMAGE, useInput: true });
-    button.addComponent('button', { imageEntity: image, ...data });
+    button.addComponent('button', { ...data, imageEntity: image });
 
     return { image, button };
 }

--- a/test/framework/components/button/component.test.mjs
+++ b/test/framework/components/button/component.test.mjs
@@ -1,0 +1,406 @@
+import { expect } from 'chai';
+
+import { Color } from '../../../../src/core/math/color.js';
+import { Vec4 } from '../../../../src/core/math/vec4.js';
+import { BUTTON_TRANSITION_MODE_SPRITE_CHANGE, BUTTON_TRANSITION_MODE_TINT } from '../../../../src/framework/components/button/constants.js';
+import { ELEMENTTYPE_IMAGE } from '../../../../src/framework/components/element/constants.js';
+import { Entity } from '../../../../src/framework/entity.js';
+import { createApp } from '../../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
+
+/**
+ * @param {object} [data] - Additional button component data.
+ * @returns {{ image: Entity, button: Entity }} A button entity wired to an image entity.
+ */
+function createButton(data = {}) {
+    const image = new Entity('image');
+    image.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+
+    const button = new Entity('button');
+    button.addChild(image);
+    button.addComponent('element', { type: ELEMENTTYPE_IMAGE, useInput: true });
+    button.addComponent('button', { imageEntity: image, ...data });
+
+    return { image, button };
+}
+
+describe('ButtonComponent', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    describe('#addComponent', function () {
+
+        it('creates a component with sensible defaults', function () {
+            const e = new Entity();
+            e.addComponent('button');
+
+            expect(e.button).to.exist;
+            expect(e.button.enabled).to.equal(true);
+            expect(e.button.active).to.equal(true);
+            expect(e.button.imageEntity).to.equal(null);
+            expect(e.button.hitPadding).to.be.an.instanceof(Vec4);
+            expect(e.button.hitPadding.equals(new Vec4())).to.equal(true);
+            expect(e.button.transitionMode).to.equal(BUTTON_TRANSITION_MODE_TINT);
+            expect(e.button.hoverTint.equals(new Color(0.75, 0.75, 0.75))).to.equal(true);
+            expect(e.button.pressedTint.equals(new Color(0.5, 0.5, 0.5))).to.equal(true);
+            expect(e.button.inactiveTint.equals(new Color(0.25, 0.25, 0.25))).to.equal(true);
+            expect(e.button.fadeDuration).to.equal(0);
+            expect(e.button.hoverSpriteAsset).to.equal(null);
+            expect(e.button.hoverSpriteFrame).to.equal(0);
+            expect(e.button.pressedSpriteAsset).to.equal(null);
+            expect(e.button.pressedSpriteFrame).to.equal(0);
+            expect(e.button.inactiveSpriteAsset).to.equal(null);
+            expect(e.button.inactiveSpriteFrame).to.equal(0);
+        });
+
+        it('round-trips every property passed via the data argument', function () {
+            const { image, button } = createButton({
+                enabled: false,
+                active: false,
+                hitPadding: new Vec4(1, 2, 3, 4),
+                transitionMode: BUTTON_TRANSITION_MODE_SPRITE_CHANGE,
+                hoverTint: new Color(0.1, 0.2, 0.3, 0.4),
+                pressedTint: new Color(0.5, 0.6, 0.7, 0.8),
+                inactiveTint: new Color(0.9, 0.8, 0.7, 0.6),
+                fadeDuration: 100,
+                hoverSpriteAsset: 11,
+                hoverSpriteFrame: 1,
+                pressedSpriteAsset: 22,
+                pressedSpriteFrame: 2,
+                inactiveSpriteAsset: 33,
+                inactiveSpriteFrame: 3
+            });
+
+            const c = button.button;
+            expect(c.enabled).to.equal(false);
+            expect(c.active).to.equal(false);
+            expect(c.imageEntity).to.equal(image);
+            expect(c.hitPadding.equals(new Vec4(1, 2, 3, 4))).to.equal(true);
+            expect(c.transitionMode).to.equal(BUTTON_TRANSITION_MODE_SPRITE_CHANGE);
+            expect(c.hoverTint.equals(new Color(0.1, 0.2, 0.3, 0.4))).to.equal(true);
+            expect(c.pressedTint.equals(new Color(0.5, 0.6, 0.7, 0.8))).to.equal(true);
+            expect(c.inactiveTint.equals(new Color(0.9, 0.8, 0.7, 0.6))).to.equal(true);
+            expect(c.fadeDuration).to.equal(100);
+            expect(c.hoverSpriteAsset).to.equal(11);
+            expect(c.hoverSpriteFrame).to.equal(1);
+            expect(c.pressedSpriteAsset).to.equal(22);
+            expect(c.pressedSpriteFrame).to.equal(2);
+            expect(c.inactiveSpriteAsset).to.equal(33);
+            expect(c.inactiveSpriteFrame).to.equal(3);
+        });
+
+        it('preserves class-field defaults when properties are passed as explicit undefined', function () {
+            const e = new Entity();
+            e.addComponent('button', {
+                hoverTint: undefined,
+                hitPadding: undefined,
+                fadeDuration: undefined
+            });
+
+            expect(e.button.hoverTint.equals(new Color(0.75, 0.75, 0.75))).to.equal(true);
+            expect(e.button.hitPadding.equals(new Vec4())).to.equal(true);
+            expect(e.button.fadeDuration).to.equal(0);
+        });
+
+    });
+
+    describe('#hoverTint', function () {
+
+        it('accepts an [r, g, b, a] array', function () {
+            const e = new Entity();
+            e.addComponent('button');
+
+            e.button.hoverTint = [0.1, 0.2, 0.3, 0.4];
+
+            expect(e.button.hoverTint).to.be.an.instanceof(Color);
+            expect(e.button.hoverTint.equals(new Color(0.1, 0.2, 0.3, 0.4))).to.equal(true);
+        });
+
+        it('defaults alpha to 1 for an [r, g, b] array', function () {
+            const e = new Entity();
+            e.addComponent('button');
+
+            e.button.hoverTint = [0.1, 0.2, 0.3];
+
+            expect(e.button.hoverTint.a).to.equal(1);
+        });
+
+        it('clones Color inputs so caller mutations do not leak into component state', function () {
+            const e = new Entity();
+            e.addComponent('button');
+
+            const source = new Color(0.1, 0.2, 0.3, 0.4);
+            e.button.hoverTint = source;
+
+            expect(e.button.hoverTint).to.not.equal(source);
+
+            source.r = 0.9;
+            expect(e.button.hoverTint.r).to.be.closeTo(0.1, 1e-6);
+        });
+
+    });
+
+    describe('#hitPadding', function () {
+
+        it('accepts an [x, y, z, w] array', function () {
+            const e = new Entity();
+            e.addComponent('button');
+
+            e.button.hitPadding = [1, 2, 3, 4];
+
+            expect(e.button.hitPadding).to.be.an.instanceof(Vec4);
+            expect(e.button.hitPadding.equals(new Vec4(1, 2, 3, 4))).to.equal(true);
+        });
+
+        it('clones Vec4 inputs so caller mutations do not leak into component state', function () {
+            const e = new Entity();
+            e.addComponent('button');
+
+            const source = new Vec4(1, 2, 3, 4);
+            e.button.hitPadding = source;
+
+            expect(e.button.hitPadding).to.not.equal(source);
+
+            source.x = 9;
+            expect(e.button.hitPadding.x).to.equal(1);
+        });
+
+        it('passes falsy values through untouched', function () {
+            const e = new Entity();
+            e.addComponent('button');
+
+            e.button.hitPadding = null;
+
+            expect(e.button.hitPadding).to.equal(null);
+        });
+
+    });
+
+    describe('#active', function () {
+
+        it('applies the inactive tint to the image element when deactivated', function () {
+            const { image, button } = createButton();
+            app.root.addChild(button);
+
+            // image element starts at its default white tint
+            expect(image.element.color.r).to.be.closeTo(1, 1e-6);
+
+            button.button.active = false;
+
+            expect(image.element.color.r).to.be.closeTo(0.25, 1e-6);
+            expect(image.element.color.g).to.be.closeTo(0.25, 1e-6);
+            expect(image.element.color.b).to.be.closeTo(0.25, 1e-6);
+            expect(image.element.opacity).to.be.closeTo(1, 1e-6);
+        });
+
+        it('reapplies the inactive tint when it changes while inactive', function () {
+            const { image, button } = createButton({ active: false });
+            app.root.addChild(button);
+
+            button.button.inactiveTint = new Color(0.2, 0.4, 0.6);
+
+            expect(image.element.color.r).to.be.closeTo(0.2, 1e-6);
+            expect(image.element.color.g).to.be.closeTo(0.4, 1e-6);
+            expect(image.element.color.b).to.be.closeTo(0.6, 1e-6);
+        });
+
+        it('suppresses button events while inactive', function () {
+            const { button } = createButton({ active: false });
+            app.root.addChild(button);
+
+            let clicks = 0;
+            button.button.on('click', () => {
+                clicks++;
+            });
+
+            button.element.fire('click', {});
+            expect(clicks).to.equal(0);
+
+            button.button.active = true;
+
+            button.element.fire('click', {});
+            expect(clicks).to.equal(1);
+        });
+
+    });
+
+    describe('#transitionMode', function () {
+
+        it('restores the default tint and applies the state sprite when switching to sprite mode', function () {
+            const { image, button } = createButton({
+                active: false,
+                inactiveSpriteFrame: 2
+            });
+            app.root.addChild(button);
+
+            // tint mode has applied the inactive tint
+            expect(image.element.color.r).to.be.closeTo(0.25, 1e-6);
+
+            button.button.transitionMode = BUTTON_TRANSITION_MODE_SPRITE_CHANGE;
+
+            // the previous mode's tint is reset to the stored default...
+            expect(image.element.color.r).to.be.closeTo(1, 1e-6);
+            // ...and the sprite for the current (inactive) state is applied
+            expect(image.element.spriteFrame).to.equal(2);
+        });
+
+        it('is a no-op when the mode is unchanged', function () {
+            const { image, button } = createButton({ active: false });
+            app.root.addChild(button);
+
+            button.button.transitionMode = BUTTON_TRANSITION_MODE_TINT;
+
+            // the inactive tint remains applied - no reset to the default tint occurred
+            expect(image.element.color.r).to.be.closeTo(0.25, 1e-6);
+        });
+
+    });
+
+    describe('#imageEntity', function () {
+
+        it('accepts an Entity reference', function () {
+            const image = new Entity();
+            image.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+
+            const e = new Entity();
+            e.addComponent('button');
+
+            e.button.imageEntity = image;
+
+            expect(e.button.imageEntity).to.equal(image);
+        });
+
+        it('accepts a GUID string and resolves via app.getEntityFromIndex', function () {
+            const image = new Entity();
+            image.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+
+            const e = new Entity();
+            e.addComponent('button');
+
+            e.button.imageEntity = image.guid;
+
+            expect(e.button.imageEntity).to.equal(image);
+        });
+
+        it('accepts null', function () {
+            const image = new Entity();
+            image.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+
+            const e = new Entity();
+            e.addComponent('button', { imageEntity: image });
+
+            e.button.imageEntity = null;
+
+            expect(e.button.imageEntity).to.equal(null);
+        });
+
+        it('unsubscribes from the previous image entity when reassigned', function () {
+            const image1 = new Entity();
+            image1.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+
+            const image2 = new Entity();
+            image2.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+
+            const e = new Entity();
+            e.addComponent('button', { imageEntity: image1 });
+
+            // button should be listening to image1's element:add
+            expect(image1.hasEvent('element:add')).to.equal(true);
+            expect(image2.hasEvent('element:add')).to.equal(false);
+
+            e.button.imageEntity = image2;
+
+            expect(e.button.imageEntity).to.equal(image2);
+            expect(image1.hasEvent('element:add')).to.equal(false);
+            expect(image2.hasEvent('element:add')).to.equal(true);
+        });
+
+    });
+
+    describe('#cloneComponent', function () {
+
+        it('clones every property', function () {
+            const { button } = createButton({
+                enabled: false,
+                active: false,
+                hitPadding: new Vec4(1, 2, 3, 4),
+                hoverTint: new Color(0.1, 0.2, 0.3, 0.4),
+                pressedTint: new Color(0.5, 0.6, 0.7, 0.8),
+                inactiveTint: new Color(0.9, 0.8, 0.7, 0.6),
+                fadeDuration: 100,
+                hoverSpriteAsset: 11,
+                hoverSpriteFrame: 1,
+                pressedSpriteAsset: 22,
+                pressedSpriteFrame: 2,
+                inactiveSpriteAsset: 33,
+                inactiveSpriteFrame: 3
+            });
+
+            const clone = button.clone();
+            const c = clone.button;
+
+            expect(c).to.exist;
+            expect(c.enabled).to.equal(false);
+            expect(c.active).to.equal(false);
+            expect(c.hitPadding.equals(new Vec4(1, 2, 3, 4))).to.equal(true);
+            expect(c.hitPadding).to.not.equal(button.button.hitPadding);
+            expect(c.hoverTint.equals(new Color(0.1, 0.2, 0.3, 0.4))).to.equal(true);
+            expect(c.hoverTint).to.not.equal(button.button.hoverTint);
+            expect(c.pressedTint.equals(new Color(0.5, 0.6, 0.7, 0.8))).to.equal(true);
+            expect(c.inactiveTint.equals(new Color(0.9, 0.8, 0.7, 0.6))).to.equal(true);
+            expect(c.fadeDuration).to.equal(100);
+            expect(c.hoverSpriteAsset).to.equal(11);
+            expect(c.hoverSpriteFrame).to.equal(1);
+            expect(c.pressedSpriteAsset).to.equal(22);
+            expect(c.pressedSpriteFrame).to.equal(2);
+            expect(c.inactiveSpriteAsset).to.equal(33);
+            expect(c.inactiveSpriteFrame).to.equal(3);
+        });
+
+        it('remaps imageEntity to the cloned child via the duplicated ids map', function () {
+            const { image, button } = createButton();
+
+            const clone = button.clone();
+            const cloneImage = clone.findByName('image');
+
+            expect(cloneImage).to.exist;
+            expect(cloneImage).to.not.equal(image);
+            expect(clone.button.imageEntity).to.equal(cloneImage);
+        });
+
+    });
+
+    describe('resolveDuplicatedEntityReferenceProperties', function () {
+
+        it('remaps the image entity through duplicatedIdsMap', function () {
+            const image = new Entity();
+            image.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+
+            const replacement = new Entity();
+            replacement.addComponent('element', { type: ELEMENTTYPE_IMAGE });
+
+            const source = new Entity();
+            source.addComponent('button', { imageEntity: image });
+
+            const target = new Entity();
+            target.addComponent('button');
+
+            const map = { [image.guid]: replacement };
+            target.button.resolveDuplicatedEntityReferenceProperties(source.button, map);
+
+            expect(target.button.imageEntity).to.equal(replacement);
+        });
+
+    });
+
+});


### PR DESCRIPTION
﻿## Description

Applies the refactor pattern from #8693 (`ScrollbarComponent`) and #8777 (`ScrollViewComponent`) to `ButtonComponent`, continuing the move away from `*ComponentData` property bags. Runtime behaviour and the public property surface are unchanged (verified against the regenerated `.d.ts`: all 14 properties plus `enabled` via the base `Component`, and all events preserved), with one deliberate documentation correction: the six state sprite asset accessors were declared as bare `Asset`, but `null` is their default — they are now declared `Asset|null`. (Numeric asset ids still work internally — scene data ships them and `ImageElement.spriteAsset` accepts both — but the public contract encourages `Asset` references, so the docs deliberately do not advertise `number`.)

- `ButtonComponent` now owns `_active`, `_hitPadding`, `_transitionMode`, `_hoverTint`, `_pressedTint`, `_inactiveTint`, `_fadeDuration` and the six state sprite asset/frame fields directly. The side effects that used to live in `set_*` listeners are inlined into the setters (`active` → visual state update; `transitionMode` → cancel tween, reset previous mode's visuals, reapply; tints and sprite props → force reapply). The `_setValue` helper, `_toggleLifecycleListeners`, `_onSetActive`, `_onSetTransitionMode` and `_onSetTransitionValue` are gone. The `imageEntity` setter is restyled like scrollbar's `handleEntity` (resolve first, single early-out) and drops its trailing `this.data.imageEntity = guid` writes.
- `ButtonComponentData` is reduced to a single `enabled` field.
- `ButtonComponentSystem` matches `ScrollbarComponentSystem`: `_schema = ['enabled']`, an explicit `_properties` list drives `initializeComponentData` (guarded on `!== undefined` so explicit-`undefined` data does not clobber class-field defaults, per the scroll-view fix), an explicit `cloneComponent` is added (the default base-class clone would otherwise lose every non-`enabled` field), and `Component._buildAccessors(ButtonComponent.prototype, _schema)` handles the `enabled` accessor.

The schema previously declared `hitPadding` as `type: 'vec4'` and the three tints as `type: 'rgba'`, which made `ComponentSystem.convertValue` clone instances and construct values from arrays. That normalization is moved into the setters so JSON-loaded scenes shipping arrays (e.g. `hoverTint: [0.75, 0.75, 0.75, 1]`) and callers passing shared instances continue to work. The `hitPadding` setter passes falsy values through untouched, which `ElementInput.buildHitCorners`'s `|| ZERO_VEC4` fallback relies on. Tint setters skip the visual reapply when the value is unchanged, so value-equal writes no longer cancel an in-flight fade tween.

Also declares the previously-undeclared `_hasHitElementListeners`, `_isApplyingTint`, `_isApplyingSprite` and `_tweenInfo` fields (`_cancelTween` now assigns `null` instead of `delete`).

One accepted behaviour nuance (same as the scrollbar/scroll-view migrations): a guid string that fails to resolve via `getEntityFromIndex` is no longer stashed in the data bag for re-resolution on a later clone.

## Tests

Adds `test/framework/components/button/component.test.mjs` (21 tests), modelled on the `ScrollbarComponent` suite, covering: defaults; full data round-trip; explicit-`undefined` handling; tint/`hitPadding` array conversion and clone-on-set; inactive-state tinting and event suppression; `transitionMode` switching (tint reset + state sprite applied) and same-value no-op; `imageEntity` Entity/guid/null resolution and unsubscribe-on-reassign; `cloneComponent` round-trip and entity remapping; `resolveDuplicatedEntityReferenceProperties`.

- `npm run lint` passes
- `npm test` — 1770 passing, 0 failures
- `npm run build:types` + `npm run test:types` pass

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

