### PR TITLE
Temporarily disable WebGPU on Imagination PowerVR GPUs (Pixel 10)

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -383,6 +383,14 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
          */
         this.gpuAdapter = await window.navigator.gpu.requestAdapter(adapterOptions);
 
+        // Imagination PowerVR GPUs (Pixel 10 / Tensor G5) have buggy WebGPU drivers (broken
+        // compute, shader miscompiles), so fail device creation here to let createGraphicsDevice
+        // fall back to WebGL2. Remove when fixed: https://github.com/playcanvas/engine/issues/8874
+        if (this.gpuAdapter?.info?.vendor === 'img-tec') {
+            Debug.warn('WebGPU is disabled on Imagination PowerVR GPUs due to driver issues, falling back to WebGL2. See https://github.com/playcanvas/engine/issues/8874');
+            return null;
+        }
+
         const featureLevel = this.initOptions.featureLevel;
         const bare = featureLevel === 'bare';
 


### PR DESCRIPTION
Chrome's WebGPU support for the Imagination PowerVR GPU in the Pixel 10 family (Tensor G5) is still buggy — broken compute (e.g. the gsplat GPU radix sort) and shader miscompiles, with Dawn still carrying device-specific workarounds and CTS suppressions.

**Changes:**
- `WebgpuGraphicsDevice.createDevice()` now fails (returns null, with a warning) when the adapter reports vendor `img-tec`, so `createGraphicsDevice()` falls back to WebGL2 automatically via its existing device-type chain. No app-side changes needed.

Detection uses the standard `GPUAdapterInfo` API; on Chrome for Android the `img-tec` vendor currently only matches Tensor G5 devices, as older PowerVR parts were never allowlisted for WebGPU.

Temporary workaround — tracked for removal in #8874.