### PR TITLE
refactor(components): drive cloneComponent from shared _properties lists

### DIFF
--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -62,23 +62,17 @@ class ButtonComponentSystem extends ComponentSystem {
 
     cloneComponent(entity, clone) {
         const c = entity.button;
-        return this.addComponent(clone, {
-            enabled: c.enabled,
-            active: c.active,
-            imageEntity: c.imageEntity,
-            hitPadding: c.hitPadding,
-            transitionMode: c.transitionMode,
-            hoverTint: c.hoverTint,
-            pressedTint: c.pressedTint,
-            inactiveTint: c.inactiveTint,
-            fadeDuration: c.fadeDuration,
-            hoverSpriteAsset: c.hoverSpriteAsset,
-            hoverSpriteFrame: c.hoverSpriteFrame,
-            pressedSpriteAsset: c.pressedSpriteAsset,
-            pressedSpriteFrame: c.pressedSpriteFrame,
-            inactiveSpriteAsset: c.inactiveSpriteAsset,
-            inactiveSpriteFrame: c.inactiveSpriteFrame
-        });
+
+        const data = {
+            enabled: c.enabled
+        };
+
+        for (let i = 0; i < _properties.length; i++) {
+            const property = _properties[i];
+            data[property] = c[property];
+        }
+
+        return this.addComponent(clone, data);
     }
 
     onUpdate(dt) {

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -716,22 +716,22 @@ class CollisionComponentSystem extends ComponentSystem {
 
     cloneComponent(entity, clone) {
         const c = entity.collision;
-        return this.addComponent(clone, {
+
+        // type is initialized outside the property list; shape is created by the type's
+        // implementation during initialization and must not be shared with the clone
+        const data = {
             enabled: c.enabled,
-            type: c.type,
-            halfExtents: c.halfExtents,
-            linearOffset: c.linearOffset,
-            angularOffset: c.angularOffset,
-            radius: c.radius,
-            axis: c.axis,
-            height: c.height,
-            convexHull: c.convexHull,
-            asset: c.asset,
-            renderAsset: c.renderAsset,
-            model: c.model,
-            render: c.render,
-            checkVertexDuplicates: c.checkVertexDuplicates
-        });
+            type: c.type
+        };
+
+        for (let i = 0; i < _properties.length; i++) {
+            const property = _properties[i];
+            if (property !== 'shape') {
+                data[property] = c[property];
+            }
+        }
+
+        return this.addComponent(clone, data);
     }
 
     onBeforeRemove(entity, component) {

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -68,23 +68,17 @@ class ScrollViewComponentSystem extends ComponentSystem {
 
     cloneComponent(entity, clone) {
         const c = entity.scrollview;
-        return this.addComponent(clone, {
-            enabled: c.enabled,
-            horizontal: c.horizontal,
-            vertical: c.vertical,
-            scrollMode: c.scrollMode,
-            bounceAmount: c.bounceAmount,
-            friction: c.friction,
-            dragThreshold: c.dragThreshold,
-            useMouseWheel: c.useMouseWheel,
-            mouseWheelSensitivity: c.mouseWheelSensitivity,
-            horizontalScrollbarVisibility: c.horizontalScrollbarVisibility,
-            verticalScrollbarVisibility: c.verticalScrollbarVisibility,
-            viewportEntity: c.viewportEntity,
-            contentEntity: c.contentEntity,
-            horizontalScrollbarEntity: c.horizontalScrollbarEntity,
-            verticalScrollbarEntity: c.verticalScrollbarEntity
-        });
+
+        const data = {
+            enabled: c.enabled
+        };
+
+        for (let i = 0; i < _properties.length; i++) {
+            const property = _properties[i];
+            data[property] = c[property];
+        }
+
+        return this.addComponent(clone, data);
     }
 
     onUpdate(dt) {

--- a/src/framework/components/scrollbar/system.js
+++ b/src/framework/components/scrollbar/system.js
@@ -43,13 +43,17 @@ class ScrollbarComponentSystem extends ComponentSystem {
 
     cloneComponent(entity, clone) {
         const c = entity.scrollbar;
-        return this.addComponent(clone, {
-            enabled: c.enabled,
-            orientation: c.orientation,
-            value: c.value,
-            handleSize: c.handleSize,
-            handleEntity: c.handleEntity
-        });
+
+        const data = {
+            enabled: c.enabled
+        };
+
+        for (let i = 0; i < _properties.length; i++) {
+            const property = _properties[i];
+            data[property] = c[property];
+        }
+
+        return this.addComponent(clone, data);
     }
 
     _onAddComponent(entity) {


### PR DESCRIPTION
## Summary

Second PR in the component-consistency series (follows #8878).

Button, scroll-view, scrollbar and collision systems already define a module-level `_properties` array used by `initializeComponentData`, but each duplicated the same list as a hand-written object literal in `cloneComponent` — the exact drift hazard that bit the camera system in #8878. This PR builds the clone data from the shared list instead.

**Behavior-preserving** — before converting, each clone literal was verified to match its `_properties` list 1:1:

- **button**: 14 properties + `enabled`, exact match.
- **scroll-view**: 14 properties + `enabled`, exact match (init order, which is what matters, is unchanged).
- **scrollbar**: 4 properties + `enabled`, exact match.
- **collision**: the two intentional differences are now explicit and commented — `type` is initialized outside the property list (written to the backing field before the list is applied), and `shape` is skipped because the type implementation creates it during initialization and must not be shared with the clone.

Clone value semantics are unchanged: the loop passes the same references the literals passed (component setters handle copying, covered by the existing Color/Vec input-cloning tests).

## Testing

- All four systems have dedicated `#cloneComponent` tests (clone round-trips, entity-ref remapping) — 95 tests pass unchanged, no test edits needed
- Full `npm test` suite passes (1817 passing)
- ESLint clean on changed files

## Remaining PRs in the series

3. Hoist inline lists in model, sound, rigid-body
4. Animation system (isolated due to its post-add clone assignment)
5. Standardize `beforeremove` handler naming across all systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)
