### PR TITLE
refactor(components): hoist property lists in model, sound and rigid-body

### DIFF
--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -10,6 +10,23 @@ import { ModelComponent } from './component.js';
  * @import { AppBase } from '../../app-base.js'
  */
 
+// order matters here
+const _properties = [
+    'material',
+    'materialAsset',
+    'asset',
+    'castShadows',
+    'receiveShadows',
+    'castShadowsLightmap',
+    'lightmapped',
+    'lightmapSizeMultiplier',
+    'type',
+    'mapping',
+    'layers',
+    'isStatic',
+    'batchGroupId'
+];
+
 /**
  * Allows an Entity to render a model or a primitive shape like a box, capsule, sphere, cylinder,
  * cone etc.
@@ -35,24 +52,7 @@ class ModelComponentSystem extends ComponentSystem {
         this.on('beforeremove', this.onRemove, this);
     }
 
-    initializeComponentData(component, _data, properties) {
-        // order matters here
-        properties = [
-            'material',
-            'materialAsset',
-            'asset',
-            'castShadows',
-            'receiveShadows',
-            'castShadowsLightmap',
-            'lightmapped',
-            'lightmapSizeMultiplier',
-            'type',
-            'mapping',
-            'layers',
-            'isStatic',
-            'batchGroupId'
-        ];
-
+    initializeComponentData(component, _data) {
         if (_data.batchGroupId === null || _data.batchGroupId === undefined) {
             _data.batchGroupId = -1;
         }
@@ -62,9 +62,9 @@ class ModelComponentSystem extends ComponentSystem {
             _data.layers = _data.layers.slice(0);
         }
 
-        for (let i = 0; i < properties.length; i++) {
-            if (_data.hasOwnProperty(properties[i])) {
-                component[properties[i]] = _data[properties[i]];
+        for (let i = 0; i < _properties.length; i++) {
+            if (_data.hasOwnProperty(_properties[i])) {
+                component[_properties[i]] = _data[_properties[i]];
             }
         }
 
@@ -77,19 +77,25 @@ class ModelComponentSystem extends ComponentSystem {
 
     cloneComponent(entity, clone) {
         const data = {
-            type: entity.model.type,
-            asset: entity.model.asset,
-            castShadows: entity.model.castShadows,
-            receiveShadows: entity.model.receiveShadows,
-            castShadowsLightmap: entity.model.castShadowsLightmap,
-            lightmapped: entity.model.lightmapped,
-            lightmapSizeMultiplier: entity.model.lightmapSizeMultiplier,
-            isStatic: entity.model.isStatic,
-            enabled: entity.model.enabled,
-            layers: entity.model.layers,
-            batchGroupId: entity.model.batchGroupId,
-            mapping: extend({}, entity.model.mapping)
+            enabled: entity.model.enabled
         };
+
+        for (let i = 0; i < _properties.length; i++) {
+            const property = _properties[i];
+            switch (property) {
+                // material and materialAsset are handled below, after the
+                // appropriate one to clone has been determined
+                case 'material':
+                case 'materialAsset':
+                    break;
+                case 'mapping':
+                    data.mapping = extend({}, entity.model.mapping);
+                    break;
+                default:
+                    data[property] = entity.model[property];
+                    break;
+            }
+        }
 
         // if original has a different material
         // than the assigned materialAsset then make sure we

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -332,6 +332,20 @@ class ContactResult {
     }
 }
 
+const _properties = [
+    'mass',
+    'linearDamping',
+    'angularDamping',
+    'linearFactor',
+    'angularFactor',
+    'friction',
+    'rollingFriction',
+    'restitution',
+    'type',
+    'group',
+    'mask'
+];
+
 /**
  * The RigidBodyComponentSystem manages the physics simulation for all rigid body components
  * in the application. It creates and maintains the underlying Ammo.js physics world, handles
@@ -468,22 +482,8 @@ class RigidBodyComponentSystem extends ComponentSystem {
         }
     }
 
-    initializeComponentData(component, data, properties) {
-        const props = [
-            'mass',
-            'linearDamping',
-            'angularDamping',
-            'linearFactor',
-            'angularFactor',
-            'friction',
-            'rollingFriction',
-            'restitution',
-            'type',
-            'group',
-            'mask'
-        ];
-
-        for (const property of props) {
+    initializeComponentData(component, data) {
+        for (const property of _properties) {
             if (data.hasOwnProperty(property)) {
                 const value = data[property];
                 if (Array.isArray(value)) {
@@ -498,22 +498,15 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     cloneComponent(entity, clone) {
-        // create new data block for clone
-        const rigidbody = entity.rigidbody;
+        const c = entity.rigidbody;
+
         const data = {
-            enabled: rigidbody.enabled,
-            mass: rigidbody.mass,
-            linearDamping: rigidbody.linearDamping,
-            angularDamping: rigidbody.angularDamping,
-            linearFactor: [rigidbody.linearFactor.x, rigidbody.linearFactor.y, rigidbody.linearFactor.z],
-            angularFactor: [rigidbody.angularFactor.x, rigidbody.angularFactor.y, rigidbody.angularFactor.z],
-            friction: rigidbody.friction,
-            rollingFriction: rigidbody.rollingFriction,
-            restitution: rigidbody.restitution,
-            type: rigidbody.type,
-            group: rigidbody.group,
-            mask: rigidbody.mask
+            enabled: c.enabled
         };
+
+        for (const property of _properties) {
+            data[property] = c[property];
+        }
 
         return this.addComponent(clone, data);
     }

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -7,6 +7,17 @@ import { SoundComponent } from './component.js';
  * @import { SoundManager } from '../../../platform/sound/manager.js'
  */
 
+const _properties = [
+    'volume',
+    'pitch',
+    'positional',
+    'refDistance',
+    'maxDistance',
+    'rollOffFactor',
+    'distanceModel',
+    'slots'
+];
+
 /**
  * Manages creation of {@link SoundComponent}s.
  *
@@ -67,21 +78,10 @@ class SoundComponentSystem extends ComponentSystem {
         return this.manager.context;
     }
 
-    initializeComponentData(component, data, properties) {
-        properties = [
-            'volume',
-            'pitch',
-            'positional',
-            'refDistance',
-            'maxDistance',
-            'rollOffFactor',
-            'distanceModel',
-            'slots'
-        ];
-
-        for (let i = 0; i < properties.length; i++) {
-            if (data.hasOwnProperty(properties[i])) {
-                component[properties[i]] = data[properties[i]];
+    initializeComponentData(component, data) {
+        for (let i = 0; i < _properties.length; i++) {
+            if (data.hasOwnProperty(_properties[i])) {
+                component[_properties[i]] = data[_properties[i]];
             }
         }
 
@@ -89,41 +89,38 @@ class SoundComponentSystem extends ComponentSystem {
     }
 
     cloneComponent(entity, clone) {
-        const srcComponent = entity.sound;
-        const srcSlots = srcComponent.slots;
+        const c = entity.sound;
 
-        // convert 'slots' back to
-        // simple option objects
-        const slots = {};
-        for (const key in srcSlots) {
-            const srcSlot = srcSlots[key];
-            slots[key] = {
-                name: srcSlot.name,
-                volume: srcSlot.volume,
-                pitch: srcSlot.pitch,
-                loop: srcSlot.loop,
-                duration: srcSlot.duration,
-                startTime: srcSlot.startTime,
-                overlap: srcSlot.overlap,
-                autoPlay: srcSlot.autoPlay,
-                asset: srcSlot.asset
-            };
-        }
-
-        const cloneData = {
-            distanceModel: srcComponent.distanceModel,
-            enabled: srcComponent.enabled,
-            maxDistance: srcComponent.maxDistance,
-            pitch: srcComponent.pitch,
-            positional: srcComponent.positional,
-            refDistance: srcComponent.refDistance,
-            rollOffFactor: srcComponent.rollOffFactor,
-            slots: slots,
-            volume: srcComponent.volume
+        const data = {
+            enabled: c.enabled
         };
 
-        // add component with new data
-        return this.addComponent(clone, cloneData);
+        for (let i = 0; i < _properties.length; i++) {
+            const property = _properties[i];
+            if (property === 'slots') {
+                // convert 'slots' back to simple option objects
+                const slots = {};
+                for (const key in c.slots) {
+                    const srcSlot = c.slots[key];
+                    slots[key] = {
+                        name: srcSlot.name,
+                        volume: srcSlot.volume,
+                        pitch: srcSlot.pitch,
+                        loop: srcSlot.loop,
+                        duration: srcSlot.duration,
+                        startTime: srcSlot.startTime,
+                        overlap: srcSlot.overlap,
+                        autoPlay: srcSlot.autoPlay,
+                        asset: srcSlot.asset
+                    };
+                }
+                data.slots = slots;
+            } else {
+                data[property] = c[property];
+            }
+        }
+
+        return this.addComponent(clone, data);
     }
 
     onUpdate(dt) {


### PR DESCRIPTION
## Summary

Third PR in the component-consistency series (follows #8878, #8879).

Model, sound and rigid-body each defined their property list inline inside `initializeComponentData` and duplicated it as a hand-written object literal in `cloneComponent`. This PR hoists each list to a module-level `_properties` array and drives both methods from it.

**Behavior-preserving** — each clone literal was verified against its init list before converting, and all special-case handling survives:

- **model**: clone skips `material`/`materialAsset` in the loop (the existing default-material/asset resolution logic below is untouched) and still shallow-copies `mapping` via `extend`. The post-`addComponent` model/mesh-instance/customAabb cloning is unchanged. Init order (which the original commented on) is preserved in the hoisted list.
- **sound**: `slots` are still converted back to plain option objects inside the loop; the other 7 properties matched 1:1.
- **rigid-body**: the only mechanical difference — `linearFactor`/`angularFactor` previously round-tripped through `[x, y, z]` arrays which init converted back to `Vec3`. The loop now passes the component's `Vec3`s directly; the component setters `.copy()` their input, so the end state is identical and nothing is aliased.

Also drops the unused legacy `properties` parameter from the three `initializeComponentData` overrides.

## Testing

- Model component tests pass unchanged (15 passing, includes clone coverage)
- Full `npm test` suite passes (1817 passing)
- ESLint clean on changed files

## Remaining PRs in the series

4. Animation system (isolated due to its post-add clone assignment)
5. Standardize `beforeremove` handler naming across all systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)
