### PR TITLE
refactor(animation): share property list between init and clone

### DIFF
--- a/src/framework/components/animation/system.js
+++ b/src/framework/components/animation/system.js
@@ -67,11 +67,9 @@ class AnimationComponentSystem extends ComponentSystem {
         const data = {};
 
         for (const property of _properties) {
-            data[property] = c[property];
+            // copy the assets array so the clone does not share it with the source
+            data[property] = property === 'assets' ? c.assets.slice() : c[property];
         }
-
-        // copy the assets array so the clone does not share it with the source
-        data.assets = c.assets.slice();
 
         const component = this.addComponent(clone, data);
 

--- a/src/framework/components/animation/system.js
+++ b/src/framework/components/animation/system.js
@@ -6,6 +6,11 @@ import { AnimationComponent } from './component.js';
  * @import { Entity } from '../../entity.js'
  */
 
+// properties need to be set in a specific order due to some setters in the component
+// having extra logic. `assets` needs to be last as it checks other properties
+// to see if it should play the animation
+const _properties = ['activate', 'enabled', 'loop', 'speed', 'assets'];
+
 /**
  * The AnimationComponentSystem manages creating and deleting AnimationComponents.
  *
@@ -36,16 +41,10 @@ class AnimationComponentSystem extends ComponentSystem {
      *
      * @param {AnimationComponent} component - The component being initialized.
      * @param {object} data - The data block used to initialize the component.
-     * @param {Array<string | {name: string, type: string}>} properties - The array of property descriptors for the component.
-     * A descriptor can be either a plain property name, or an object specifying the name and type.
      * @ignore
      */
-    initializeComponentData(component, data, properties) {
-        // properties need to be set in a specific order due to some setters in the component
-        // having extra logic. `assets` need to be last as it checks other properties
-        // to see if it should play the animation
-        properties = ['activate', 'enabled', 'loop', 'speed', 'assets'];
-        for (const property of properties) {
+    initializeComponentData(component, data) {
+        for (const property of _properties) {
             if (data.hasOwnProperty(property)) {
                 component[property] = data[property];
             }
@@ -63,33 +62,38 @@ class AnimationComponentSystem extends ComponentSystem {
      * @ignore
      */
     cloneComponent(entity, clone) {
-        this.addComponent(clone, {});
+        const c = entity.animation;
 
-        clone.animation.assets = entity.animation.assets.slice();
-        clone.animation.speed = entity.animation.speed;
-        clone.animation.loop = entity.animation.loop;
-        clone.animation.activate = entity.animation.activate;
-        clone.animation.enabled = entity.animation.enabled;
+        const data = {};
+
+        for (const property of _properties) {
+            data[property] = c[property];
+        }
+
+        // copy the assets array so the clone does not share it with the source
+        data.assets = c.assets.slice();
+
+        const component = this.addComponent(clone, data);
 
         const clonedAnimations = {};
-        const animations = entity.animation.animations;
+        const animations = c.animations;
         for (const key in animations) {
             if (animations.hasOwnProperty(key)) {
                 clonedAnimations[key] = animations[key];
             }
         }
-        clone.animation.animations = clonedAnimations;
+        component.animations = clonedAnimations;
 
         const clonedAnimationsIndex = {};
-        const animationsIndex = entity.animation.animationsIndex;
+        const animationsIndex = c.animationsIndex;
         for (const key in animationsIndex) {
             if (animationsIndex.hasOwnProperty(key)) {
                 clonedAnimationsIndex[key] = animationsIndex[key];
             }
         }
-        clone.animation.animationsIndex = clonedAnimationsIndex;
+        component.animationsIndex = clonedAnimationsIndex;
 
-        return clone.animation;
+        return component;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fourth PR in the component-consistency series (follows #8878, #8879, #8880). Animation got its own PR because its clone path was structured differently from every other system.

`AnimationComponentSystem.cloneComponent` previously added an **empty** component and then assigned properties onto it post-add — duplicating the property list and, notably, assigning `assets` *before* `activate`/`enabled`, the opposite of the order `initializeComponentData` documents as required ("assets needs to be last as it checks other properties to see if it should play").

This PR:

- Hoists the ordered list to a module-level `_properties` array (with the ordering comment) and drives both `initializeComponentData` and `cloneComponent` from it.
- Routes the clone data through `addComponent` like every other system, so clone applies properties in the documented init order.
- Keeps the post-`addComponent` copying of the loaded `animations` / `animationsIndex` dictionaries, and the `assets.slice()` so the clone doesn't share the source's array.
- Drops the unused legacy `properties` parameter.

**On behavior:** the ordering change (assets-first → assets-last) is provably unobservable. The auto-play gate in `onSetAnimations` requires `this.entity.enabled`, and `GraphNode#enabled` returns `_enabled && _enabledInHierarchy` — which is always false for the detached clone entity while `cloneComponent` runs, in both the old and new code paths. Auto-play decisions happen later, when the clone is added to the hierarchy (`onEnable`), by which point all properties were copied in both versions.

## Testing

- Animation component tests pass unchanged, including the async clone auto-play test
- Full `npm test` suite passes (1817 passing)
- ESLint clean

## Remaining PRs in the series

5. Standardize `beforeremove` handler naming across all systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)
