### PR TITLE
refactor(components): standardize beforeremove handler naming

### DIFF
--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -41,7 +41,7 @@ class ButtonComponentSystem extends ComponentSystem {
 
         this.ComponentType = ButtonComponent;
 
-        this.on('beforeremove', this._onRemoveComponent, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
 
         this.app.systems.on('update', this.onUpdate, this);
     }
@@ -87,7 +87,7 @@ class ButtonComponentSystem extends ComponentSystem {
         }
     }
 
-    _onRemoveComponent(entity, component) {
+    onBeforeRemove(entity, component) {
         component.onRemove();
     }
 

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -71,7 +71,7 @@ class ElementComponentSystem extends ComponentSystem {
         this.defaultImageMaterials = [];
 
         this.on('add', this.onAddComponent, this);
-        this.on('beforeremove', this.onRemoveComponent, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
     }
 
     destroy() {
@@ -268,7 +268,7 @@ class ElementComponentSystem extends ComponentSystem {
         entity.fire('element:add');
     }
 
-    onRemoveComponent(entity, component) {
+    onBeforeRemove(entity, component) {
         component.onRemove();
     }
 

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -114,7 +114,7 @@ class GSplatComponentSystem extends ComponentSystem {
         ShaderChunks.get(app.graphicsDevice, SHADERLANGUAGE_GLSL).add(gsplatChunksGLSL);
         ShaderChunks.get(app.graphicsDevice, SHADERLANGUAGE_WGSL).add(gsplatChunksWGSL);
 
-        this.on('beforeremove', this.onRemove, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
     }
 
     initializeComponentData(component, _data, properties) {
@@ -164,7 +164,7 @@ class GSplatComponentSystem extends ComponentSystem {
         return component;
     }
 
-    onRemove(entity, component) {
+    onBeforeRemove(entity, component) {
         component.onRemove();
     }
 

--- a/src/framework/components/joint/system.js
+++ b/src/framework/components/joint/system.js
@@ -20,7 +20,6 @@ class JointComponentSystem extends ComponentSystem {
         super(app);
 
         this.id = 'joint';
-        this.app = app;
 
         this.ComponentType = JointComponent;
     }

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -30,7 +30,7 @@ class LayoutGroupComponentSystem extends ComponentSystem {
 
         this._reflowQueue = [];
 
-        this.on('beforeremove', this._onRemoveComponent, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
 
         // Perform reflow when running in the engine
         this.app.systems.on('postUpdate', this._onPostUpdate, this);
@@ -117,7 +117,7 @@ class LayoutGroupComponentSystem extends ComponentSystem {
         }
     }
 
-    _onRemoveComponent(entity, component) {
+    onBeforeRemove(entity, component) {
         component.onRemove();
     }
 

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -26,7 +26,7 @@ class LightComponentSystem extends ComponentSystem {
 
         this.ComponentType = LightComponent;
 
-        this.on('beforeremove', this._onRemoveComponent, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
     }
 
     initializeComponentData(component, _data) {
@@ -64,7 +64,7 @@ class LightComponentSystem extends ComponentSystem {
         super.initializeComponentData(component, data);
     }
 
-    _onRemoveComponent(entity, component) {
+    onBeforeRemove(entity, component) {
         component.onRemove();
     }
 

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -49,7 +49,7 @@ class ModelComponentSystem extends ComponentSystem {
 
         this.defaultMaterial = getDefaultMaterial(app.graphicsDevice);
 
-        this.on('beforeremove', this.onRemove, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
     }
 
     initializeComponentData(component, _data) {
@@ -146,7 +146,7 @@ class ModelComponentSystem extends ComponentSystem {
         return component;
     }
 
-    onRemove(entity, component) {
+    onBeforeRemove(entity, component) {
         component.onRemove();
     }
 }

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -49,7 +49,7 @@ class RenderComponentSystem extends ComponentSystem {
 
         this.defaultMaterial = getDefaultMaterial(app.graphicsDevice);
 
-        this.on('beforeremove', this.onRemove, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
     }
 
     initializeComponentData(component, _data, properties) {
@@ -107,7 +107,7 @@ class RenderComponentSystem extends ComponentSystem {
         return component;
     }
 
-    onRemove(entity, component) {
+    onBeforeRemove(entity, component) {
         component.onRemove();
     }
 }

--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -35,7 +35,7 @@ class ScreenComponentSystem extends ComponentSystem {
 
         this.app.systems.on('update', this._onUpdate, this);
 
-        this.on('beforeremove', this.onRemoveComponent, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
     }
 
     initializeComponentData(component, data, properties) {
@@ -118,7 +118,7 @@ class ScreenComponentSystem extends ComponentSystem {
         });
     }
 
-    onRemoveComponent(entity, component) {
+    onBeforeRemove(entity, component) {
         component.onRemove();
     }
 

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -57,7 +57,7 @@ class ScriptComponentSystem extends ComponentSystem {
         // if true then we are currently preloading scripts
         this.preloading = true;
 
-        this.on('beforeremove', this._onBeforeRemove, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
         this.app.systems.on('initialize', this._onInitialize, this);
         this.app.systems.on('postInitialize', this._onPostInitialize, this);
         this.app.systems.on('update', this._onUpdate, this);
@@ -182,7 +182,7 @@ class ScriptComponentSystem extends ComponentSystem {
         this._enabledComponents.remove(component);
     }
 
-    _onBeforeRemove(entity, component) {
+    onBeforeRemove(entity, component) {
         const ind = this._components.items.indexOf(component);
         if (ind >= 0) {
             component._onBeforeRemove();

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -45,7 +45,7 @@ class ScrollViewComponentSystem extends ComponentSystem {
 
         this.ComponentType = ScrollViewComponent;
 
-        this.on('beforeremove', this._onRemoveComponent, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
 
         this.app.systems.on('update', this.onUpdate, this);
     }
@@ -94,7 +94,7 @@ class ScrollViewComponentSystem extends ComponentSystem {
         }
     }
 
-    _onRemoveComponent(entity, component) {
+    onBeforeRemove(entity, component) {
         component.onRemove();
     }
 

--- a/src/framework/components/scrollbar/system.js
+++ b/src/framework/components/scrollbar/system.js
@@ -27,7 +27,7 @@ class ScrollbarComponentSystem extends ComponentSystem {
         this.ComponentType = ScrollbarComponent;
 
         this.on('add', this._onAddComponent, this);
-        this.on('beforeremove', this._onRemoveComponent, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
     }
 
     initializeComponentData(component, data, properties) {
@@ -60,7 +60,7 @@ class ScrollbarComponentSystem extends ComponentSystem {
         entity.fire('scrollbar:add');
     }
 
-    _onRemoveComponent(entity, component) {
+    onBeforeRemove(entity, component) {
         component.onRemove();
     }
 }

--- a/src/framework/components/zone/system.js
+++ b/src/framework/components/zone/system.js
@@ -25,7 +25,7 @@ class ZoneComponentSystem extends ComponentSystem {
 
         this.ComponentType = ZoneComponent;
 
-        this.on('beforeremove', this._onBeforeRemove, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
     }
 
     initializeComponentData(component, data, properties) {
@@ -49,7 +49,7 @@ class ZoneComponentSystem extends ComponentSystem {
         return this.addComponent(clone, data);
     }
 
-    _onBeforeRemove(entity, component) {
+    onBeforeRemove(entity, component) {
         component._onBeforeRemove();
     }
 }


### PR DESCRIPTION
## Summary

Fifth and final PR in the component-consistency series (follows #8878, #8879, #8880, #8881).

The system method bound to the `beforeremove` event was named five different ways across the 20 component systems that bind it:

| Old name | Systems |
| --- | --- |
| `onBeforeRemove` (kept) | camera, sound, animation, anim, rigid-body, collision, sprite, particle-system |
| `_onRemoveComponent` | light, button, scroll-view, scrollbar, layout-group |
| `onRemove` | model, render, gsplat |
| `onRemoveComponent` | screen, element |
| `_onBeforeRemove` | zone, script |

All are now `onBeforeRemove`, matching the majority convention. Rename-only — every binding and method body is otherwise unchanged.

Deliberately untouched:

- **Component-side** methods the handlers call (`component.onRemove()`, `component._onBeforeRemove()`) — only the system methods are renamed.
- **Collision's `onRemove`** — it is bound to the distinct `remove` event, not `beforeremove`, so its name already follows the convention.
- The `_onBeforeRemove` entry in `script/constants.js` — that is the reserved component-side script instance method, not the system handler.

Also removes a redundant `this.app = app` assignment from `JointComponentSystem` (the base `ComponentSystem` constructor already sets it).

Verified no references to the old names remain anywhere in `src/`, `test/`, or `examples/` (these were undocumented internals with no external call sites).

## Testing

- Full `npm test` suite passes (1817 passing), no test edits needed
- ESLint clean on all 13 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
