### PR TITLE
refactor(components): standardize component teardown method to onBeforeRemove

### DIFF
--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -1242,7 +1242,7 @@ class ButtonComponent extends Component {
         this._resetToDefaultVisualState(this.transitionMode);
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this._imageEntityUnsubscribe();
 
         this._evtElementAdd?.off();

--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -88,7 +88,7 @@ class ButtonComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onRemove();
+        component.onBeforeRemove();
     }
 
     destroy() {

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1238,7 +1238,7 @@ class CameraComponent extends Component {
         this.system.removeCamera(this);
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this.onDisable();
         this.off();
 

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -122,7 +122,7 @@ class CameraComponentSystem extends ComponentSystem {
     onBeforeRemove(entity, component) {
         this.removeCamera(component);
 
-        component.onRemove();
+        component.onBeforeRemove();
     }
 
     onAppPrerender() {

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -2574,7 +2574,7 @@ class ElementComponent extends Component {
         this.fire('disableelement');
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this.entity.off('insert', this._onInsert, this);
         this._unpatch();
         if (this._image) {

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -269,7 +269,7 @@ class ElementComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onRemove();
+        component.onBeforeRemove();
     }
 
     cloneComponent(entity, clone) {

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -770,7 +770,7 @@ class GSplatComponent extends Component {
         }
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this.destroyInstance();
 
         this.asset = null;

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -165,7 +165,7 @@ class GSplatComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onRemove();
+        component.onBeforeRemove();
     }
 
     /**

--- a/src/framework/components/joint/component.js
+++ b/src/framework/components/joint/component.js
@@ -472,7 +472,7 @@ class JointComponent extends Component {
     _onSetEnabled(prop, old, value) {
     }
 
-    _onBeforeRemove() {
+    onBeforeRemove() {
         this.fire('remove');
     }
 }

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -431,7 +431,7 @@ class LayoutGroupComponent extends Component {
         this._scheduleReflow();
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this.entity.off('childinsert', this._onChildInsert, this);
         this.entity.off('childremove', this._onChildRemove, this);
 

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -118,7 +118,7 @@ class LayoutGroupComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onRemove();
+        component.onBeforeRemove();
     }
 
     destroy() {

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -1447,7 +1447,7 @@ class LightComponent extends Component {
         this.removeLightFromLayers();
     }
 
-    onRemove() {
+    onBeforeRemove() {
         // remove from layers
         this.onDisable();
 

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -65,7 +65,7 @@ class LightComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onRemove();
+        component.onBeforeRemove();
     }
 
     cloneComponent(entity, clone) {

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -812,7 +812,7 @@ class ModelComponent extends Component {
         }
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this.asset = null;
         this.model = null;
         this.materialAsset = null;

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -147,7 +147,7 @@ class ModelComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onRemove();
+        component.onBeforeRemove();
     }
 }
 

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -810,7 +810,7 @@ class RenderComponent extends Component {
         }
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this.destroyMeshInstances();
 
         this.asset = null;

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -108,7 +108,7 @@ class RenderComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onRemove();
+        component.onBeforeRemove();
     }
 }
 

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -193,7 +193,7 @@ class ScreenComponent extends Component {
         this._elements.delete(element);
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this.system.app.graphicsDevice.off('resizecanvas', this._onResize, this);
         this.fire('remove');
 

--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -119,7 +119,7 @@ class ScreenComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onRemove();
+        component.onBeforeRemove();
     }
 
     processDrawOrderSyncQueue() {

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -370,7 +370,7 @@ class ScriptComponent extends Component {
         this._endLooping(wasLooping);
     }
 
-    _onBeforeRemove() {
+    onBeforeRemove() {
         this.fire('remove');
 
         const wasLooping = this._beginLooping();

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -185,7 +185,7 @@ class ScriptComponentSystem extends ComponentSystem {
     onBeforeRemove(entity, component) {
         const ind = this._components.items.indexOf(component);
         if (ind >= 0) {
-            component._onBeforeRemove();
+            component.onBeforeRemove();
         }
 
         this._removeComponentFromEnabled(component);

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -1325,7 +1325,7 @@ class ScrollViewComponent extends Component {
         this._setContentDraggingEnabled(false);
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this._evtElementAdd?.off();
         this._evtElementAdd = null;
 

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -95,7 +95,7 @@ class ScrollViewComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onRemove();
+        component.onBeforeRemove();
     }
 
     destroy() {

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -355,7 +355,7 @@ class ScrollbarComponent extends Component {
         }
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this._destroyDragHelper();
     }
 

--- a/src/framework/components/scrollbar/system.js
+++ b/src/framework/components/scrollbar/system.js
@@ -61,7 +61,7 @@ class ScrollbarComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onRemove();
+        component.onBeforeRemove();
     }
 }
 

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -433,7 +433,7 @@ class SoundComponent extends Component {
         this._playingBeforeDisable = playingBeforeDisable;
     }
 
-    onRemove() {
+    onBeforeRemove() {
         this.off();
     }
 

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -156,7 +156,7 @@ class SoundComponentSystem extends ComponentSystem {
             }
         }
 
-        component.onRemove();
+        component.onBeforeRemove();
     }
 
     destroy() {

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -804,7 +804,7 @@ class SpriteComponent extends Component {
         }
     }
 
-    onDestroy() {
+    onBeforeRemove() {
         this._currentClip = null;
 
         if (this._defaultClip) {

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -249,7 +249,7 @@ class SpriteComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component.onDestroy();
+        component.onBeforeRemove();
     }
 }
 

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -121,7 +121,7 @@ class ZoneComponent extends Component {
         this.fire('state', this.enabled);
     }
 
-    _onBeforeRemove() {
+    onBeforeRemove() {
         this.fire('remove');
     }
 }

--- a/src/framework/components/zone/system.js
+++ b/src/framework/components/zone/system.js
@@ -50,7 +50,7 @@ class ZoneComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        component._onBeforeRemove();
+        component.onBeforeRemove();
     }
 }
 


### PR DESCRIPTION
## Summary

#8882 standardized the *system-side* `beforeremove` handler name to `onBeforeRemove`. This PR completes the standardization on the *component side*: the teardown method that handler invokes was still named three different ways across the engine.

- `onRemove()` → `onBeforeRemove()` — button, camera, element, gsplat, layout-group, light, model, render, screen, scroll-view, scrollbar, sound (12 components + their system call sites)
- `_onBeforeRemove()` → `onBeforeRemove()` — zone, script, joint
- `onDestroy()` → `onBeforeRemove()` — sprite

Purely mechanical rename: 31 files, 1 line each (definition or call site). No behavioral change.

**Intentionally unchanged:** the collision system's *system-level* `onRemove(entity)` (`collision/system.js:742`), which is bound to the distinct `remove` event rather than `beforeremove`, and the unrelated `onRemoveChild` handlers in model/render/gsplat.

**Note:** `JointComponent.onBeforeRemove` (renamed from `_onBeforeRemove`) still has no caller — `JointComponentSystem` never binds the `beforeremove` event, so joint constraints are not torn down on `removeComponent`. That's a pre-existing bug worth a separate fix rather than folding into this mechanical rename.

These methods are engine-internal (invoked only by the component systems), but external code calling them by their old names would need updating.

## Testing

- `npm test` — 1817 passing
- ESLint clean on all touched files
- `git grep` confirms no remaining references to the old method names

🤖 Generated with [Claude Code](https://claude.com/claude-code)