### PR TITLE
refactor(collision): correct JSDoc visibility tags on internal methods

### DIFF
--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -766,7 +766,6 @@ class CollisionComponent extends Component {
         }
     }
 
-    /** @private */
     onBeforeRemove() {
         if (this.asset) {
             this.asset = null;

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -605,9 +605,9 @@ class CollisionComponent extends Component {
     }
 
     /**
-     * @param {*} shape - Ammo shape.
+     * @param {object} shape - The Ammo collision shape to find.
      * @returns {number|null} The shape's index in the child array of the compound shape.
-     * @private
+     * @ignore
      */
     getCompoundChildShapeIndex(shape) {
         const compound = this._shape;


### PR DESCRIPTION
Follow-up to the onBeforeRemove standardization in the component-consistency series. Two JSDoc visibility fixes in `CollisionComponent`, both verified against the generated `.d.ts`:

## `onBeforeRemove` - drop the stray `@private`

Collision was the only one of the 20 components tagging its `onBeforeRemove` lifecycle hook - every other component declares it bare, like `onEnable`/`onDisable`. The tag also made `build:types` emit the method as a `private` member in the published declarations while the other 19 are public. It now emits `onBeforeRemove(): void;`, identical to the rest.

## `getCompoundChildShapeIndex` - `@private` -> `@ignore`, type the param

The method is called by `CollisionComponentSystem` from outside the class, so `@private` was inaccurate (and emitted a `private` member in the `.d.ts` that the system nonetheless calls). `@ignore` matches the convention set by the base `Component` class for methods that systems invoke (`onEnable`, `onSetEnabled`, `buildAccessors`, etc.) - hidden from the API docs but public in the declarations. Also replaces `@param {*}` with `{object}`, following the precedent of `RigidBodyComponent._getEntityTransform` for Ammo-typed parameters. The declaration is now `getCompoundChildShapeIndex(shape: object): number | null;`.

If we later want lifecycle hooks excluded from the generated API docs, that should be a uniform `@ignore` sweep across all components rather than a one-off.

Verified with `npm test`, `npm run lint`, `npm run build:types` + `npm run test:types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)