### PR TITLE
Fix XR over-culling: correct combined frustum and per-eye gsplat visibility

### DIFF
--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -1,10 +1,42 @@
 import { Plane } from './plane.js';
+import { Vec3 } from '../math/vec3.js';
 
 /**
  * @import { BoundingSphere } from './bounding-sphere.js'
  * @import { Mat4 } from '../math/mat4.js'
- * @import { Vec3 } from '../math/vec3.js'
  */
+
+// temporaries for three-plane intersection
+const _c23 = new Vec3();
+const _c31 = new Vec3();
+const _c12 = new Vec3();
+const _corner = new Vec3();
+
+/**
+ * Intersects three planes and writes the intersection point to out.
+ *
+ * @param {Plane} p1 - The first plane.
+ * @param {Plane} p2 - The second plane.
+ * @param {Plane} p3 - The third plane.
+ * @param {Vec3} out - The intersection point.
+ * @returns {boolean} False when the planes do not intersect in a single finite point.
+ */
+function intersectPlanes(p1, p2, p3, out) {
+    _c23.cross(p2.normal, p3.normal);
+    const denom = p1.normal.dot(_c23);
+    if (Math.abs(denom) < 1e-6) {
+        return false;
+    }
+    _c31.cross(p3.normal, p1.normal);
+    _c12.cross(p1.normal, p2.normal);
+    const invDenom = -1.0 / denom;
+    out.set(
+        (p1.distance * _c23.x + p2.distance * _c31.x + p3.distance * _c12.x) * invDenom,
+        (p1.distance * _c23.y + p2.distance * _c31.y + p3.distance * _c12.y) * invDenom,
+        (p1.distance * _c23.z + p2.distance * _c31.z + p3.distance * _c12.z) * invDenom
+    );
+    return isFinite(out.x) && isFinite(out.y) && isFinite(out.z);
+}
 
 /**
  * A frustum is a shape that defines the viewing space of a camera. It can be used to determine
@@ -111,24 +143,40 @@ class Frustum {
     }
 
     /**
-     * Expands this frustum to also contain another frustum. For each of the 6 planes, the plane
-     * that is further out (larger distance) is kept, creating a combined frustum that encompasses
-     * both. This is useful for multi-view rendering such as stereo XR where culling should keep
+     * Expands this frustum to also contain another frustum. The other frustum's 8 corner points
+     * are computed, and each of this frustum's planes is pushed outwards just far enough to
+     * contain them all. The result is a conservative convex volume that contains both frustums.
+     * This is useful for multi-view rendering such as stereo XR, where culling should keep
      * objects visible in any view.
      *
-     * Note: This method assumes both frustums have similar orientation (parallel views). This is
-     * valid for WebXR stereo rendering where eyes use parallel projection with only a horizontal
-     * offset, not toe-in convergence.
+     * Note: keeping each plane's orientation makes this correct for arbitrary frusta, including
+     * the asymmetric per-eye projections of XR headsets, where matching planes of the two eyes
+     * have different normals and a per-plane "outermost" selection would wrongly cut into the
+     * combined volume at a distance.
      *
      * @param {Frustum} other - The other frustum to add.
      * @returns {Frustum} Self for chaining.
      */
     add(other) {
         const planes = this.planes;
-        const otherPlanes = other.planes;
-        for (let p = 0; p < 6; p++) {
-            if (otherPlanes[p].distance > planes[p].distance) {
-                planes[p].copy(otherPlanes[p]);
+        const op = other.planes;
+
+        // The 8 corners of the other frustum: intersections of (FAR|NEAR) x (RIGHT|LEFT) x
+        // (BOTTOM|TOP) plane triplets - see the plane order in setFromMat4.
+        for (let zi = 4; zi <= 5; zi++) {
+            for (let xi = 0; xi <= 1; xi++) {
+                for (let yi = 2; yi <= 3; yi++) {
+                    if (intersectPlanes(op[zi], op[xi], op[yi], _corner)) {
+                        // push out any plane the corner is behind, so it ends up on the plane
+                        for (let p = 0; p < 6; p++) {
+                            const plane = planes[p];
+                            const d = plane.normal.dot(_corner) + plane.distance;
+                            if (d < 0) {
+                                plane.distance -= d;
+                            }
+                        }
+                    }
+                }
             }
         }
         return this;

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -26,6 +26,8 @@ const _deviceCoord = new Vec3();
 const _halfSize = new Vec3();
 const _point = new Vec3();
 const _invViewProjMat = new Mat4();
+const _xrViewProjMat = new Mat4();
+const _xrViewFrustum = new Frustum();
 const _frustumPoints = [new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3()];
 
 /**
@@ -628,6 +630,36 @@ class Camera {
             this._viewProjMat.mul2(this.projectionMatrix, this.viewMatrix);
             this._viewProjMatDirty = false;
         }
+    }
+
+    /**
+     * Updates {@link Camera#frustum} to the combined volume of all XR views, to avoid culling
+     * objects visible in any view (e.g. the right edge of the right eye in stereo rendering).
+     * The views are merged conservatively via {@link Frustum#add}, which handles the asymmetric
+     * per-eye projections real headsets report (matching planes of the two eyes have different
+     * normals, so a simple outermost-plane selection would over-cull at a distance).
+     *
+     * @returns {boolean} True when XR views were present and the frustum was updated, false
+     * otherwise (the caller should fall back to the mono frustum path).
+     * @ignore
+     */
+    updateXrFrustum() {
+        const views = this.xr?.views.list;
+        if (!views?.length) {
+            return false;
+        }
+
+        // first view establishes the base frustum
+        _xrViewProjMat.mul2(views[0].projMat, views[0].viewOffMat);
+        this.frustum.setFromMat4(_xrViewProjMat);
+
+        // for additional views, expand the frustum to encompass all views
+        for (let v = 1; v < views.length; v++) {
+            _xrViewProjMat.mul2(views[v].projMat, views[v].viewOffMat);
+            _xrViewFrustum.setFromMat4(_xrViewProjMat);
+            this.frustum.add(_xrViewFrustum);
+        }
+        return true;
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-frustum-culler.js
+++ b/src/scene/gsplat-unified/gsplat-frustum-culler.js
@@ -201,6 +201,23 @@ class GSplatFrustumCuller {
     }
 
     /**
+     * Stores the planes of the given frustum in {@link frustumPlanes} for use by the interval
+     * cull compute shader.
+     *
+     * @param {Frustum} frustum - The frustum to take the planes from.
+     */
+    setFrustumPlanes(frustum) {
+        const planes = this.frustumPlanes;
+        for (let p = 0; p < 6; p++) {
+            const plane = frustum.planes[p];
+            planes[p * 4 + 0] = plane.normal.x;
+            planes[p * 4 + 1] = plane.normal.y;
+            planes[p * 4 + 2] = plane.normal.z;
+            planes[p * 4 + 3] = plane.distance;
+        }
+    }
+
+    /**
      * Computes frustum planes from camera matrices and stores them in
      * {@link frustumPlanes} for use by the interval cull compute shader.
      *
@@ -210,14 +227,7 @@ class GSplatFrustumCuller {
     computeFrustumPlanes(projectionMatrix, viewMatrix) {
         _viewProjMat.mul2(projectionMatrix, viewMatrix);
         _frustum.setFromMat4(_viewProjMat);
-        const planes = this.frustumPlanes;
-        for (let p = 0; p < 6; p++) {
-            const plane = _frustum.planes[p];
-            planes[p * 4 + 0] = plane.normal.x;
-            planes[p * 4 + 1] = plane.normal.y;
-            planes[p * 4 + 2] = plane.normal.z;
-            planes[p * 4 + 3] = plane.distance;
-        }
+        this.setFrustumPlanes(_frustum);
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1900,7 +1900,22 @@ class GSplatManager {
         this.workBuffer.frustumCuller.updateTransformsData(worldState.boundsGroups);
 
         const cam = cameraNode.camera;
-        this.workBuffer.frustumCuller.computeFrustumPlanes(cam.projectionMatrix, cam.viewMatrix);
+        const sceneCamera = cam.camera;
+        const xrViews = sceneCamera.xr?.views.list;
+        if (xrViews?.length) {
+            // XR: cull against the combined frustum of all views, so splats visible only near
+            // one eye's edge (e.g. the right edge of the right eye) are not dropped. The per-view
+            // "off" matrices are refreshed at render time by setCameraUniforms, which runs AFTER
+            // this culling, so refresh them here (mirrors the projector dispatch).
+            const parent = cameraNode.parent?.getWorldTransform() ?? null;
+            for (let v = 0; v < xrViews.length; v++) {
+                xrViews[v].updateTransforms(parent);
+            }
+            sceneCamera.updateXrFrustum();
+            this.workBuffer.frustumCuller.setFrustumPlanes(sceneCamera.frustum);
+        } else {
+            this.workBuffer.frustumCuller.computeFrustumPlanes(cam.projectionMatrix, cam.viewMatrix);
+        }
 
         const gsplat = this.scene.gsplat;
         const fp = this.renderer.fisheyeProj;

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -7,7 +7,6 @@ import { Vec4 } from '../../core/math/vec4.js';
 import { Mat3 } from '../../core/math/mat3.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { BoundingSphere } from '../../core/shape/bounding-sphere.js';
-import { Frustum } from '../../core/shape/frustum.js';
 import {
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL,
     BINDGROUP_MESH, BINDGROUP_VIEW, UNIFORM_BUFFER_DEFAULT_SLOT_NAME,
@@ -57,7 +56,6 @@ const viewInvMat = new Mat4();
 const viewMat = new Mat4();
 const viewMat3 = new Mat3();
 const tempSphere = new BoundingSphere();
-const tempFrustum = new Frustum();
 const _tempLightSet = new Set();
 const _tempLayerSet = new Set();
 const _dynamicBindGroup = new DynamicBindGroup();
@@ -494,24 +492,8 @@ class Renderer {
 
     updateCameraFrustum(camera) {
 
-        if (camera.xr && camera.xr.views.list.length) {
-            // Calculate combined frustum from all XR views to avoid culling objects
-            // visible in any view (e.g. right edge of right eye in stereo rendering).
-            // This works because WebXR uses parallel projection for stereo views - both eyes
-            // look in the same direction with only a horizontal offset, so frustum plane
-            // normals are identical and we can merge by selecting outermost planes.
-            const views = camera.xr.views.list;
-
-            // first view establishes the base frustum
-            viewProjMat.mul2(views[0].projMat, views[0].viewOffMat);
-            camera.frustum.setFromMat4(viewProjMat);
-
-            // for additional views, expand frustum to encompass all views
-            for (let v = 1; v < views.length; v++) {
-                viewProjMat.mul2(views[v].projMat, views[v].viewOffMat);
-                tempFrustum.setFromMat4(viewProjMat);
-                camera.frustum.add(tempFrustum);
-            }
+        // XR: combined frustum from all views (avoids culling objects visible in only one eye)
+        if (camera.updateXrFrustum()) {
             return;
         }
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-common.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-common.js
@@ -28,6 +28,10 @@ struct SplatCov2D {
     #if GSPLAT_AA
         aaFactor: f32,
     #endif
+    #ifdef GSPLAT_XR
+        // Eye-1 NDC, computed for the union visibility test and reused by the cache write.
+        ndc1: vec2f,
+    #endif
 }
 
 fn computeSplatCov(
@@ -53,6 +57,9 @@ fn computeSplatCov(
         fisheye_inv_k: f32,
         fisheye_projMat00: f32,
         fisheye_projMat11: f32,
+    #endif
+    #ifdef GSPLAT_XR
+        viewProj1: mat4x4f,
     #endif
 ) -> SplatCov2D {
     var result: SplatCov2D;
@@ -99,6 +106,18 @@ fn computeSplatCov(
             (ndc.y * 0.5 + 0.5) * viewportHeight
         );
 
+    #endif
+
+    #ifdef GSPLAT_XR
+        // Eye-1 projection: used for union visibility (a splat is kept when visible in either
+        // eye) and stored in the result so the cache write does not re-project. The behind-camera
+        // test above covers both eyes (parallel-axis stereo shares view z).
+        let clip1 = viewProj1 * vec4f(worldCenter, 1.0);
+        let ndc1 = clip1.xy / clip1.w;
+        let screen1 = vec2f(
+            (ndc1.x * 0.5 + 0.5) * viewportWidth,
+            (ndc1.y * 0.5 + 0.5) * viewportHeight
+        );
     #endif
 
     let rot: half3x3 = quatToMat3(rotation);
@@ -182,8 +201,15 @@ fn computeSplatCov(
     // to full foveationStrength at the screen edge (r = 1) and beyond (corners). With
     // strength 0 this is an exact no-op.
     let fovNdc = screen * vec2f(2.0 / viewportWidth, 2.0 / viewportHeight) - vec2f(1.0);
+    #ifdef GSPLAT_XR
+        // Stereo: use the smaller of the two eyes' radii, so a splat near the centre of either
+        // eye is protected (the foveated boost only applies where it is peripheral in both).
+        let fovR = min(length(fovNdc), length(ndc1));
+    #else
+        let fovR = length(fovNdc);
+    #endif
     // manual smoothstep with a guard so foveationCenter near 1.0 cannot divide by zero
-    let fovT = saturate((length(fovNdc) - foveationCenter) / max(1.0 - foveationCenter, 1e-4));
+    let fovT = saturate((fovR - foveationCenter) / max(1.0 - foveationCenter, 1e-4));
     let effMinContribution = minContribution + foveationStrength * fovT * fovT * (3.0 - 2.0 * fovT);
 
     let totalContribution = opacity * 6.283185 * sqrt(det);
@@ -212,10 +238,21 @@ fn computeSplatCov(
     }
 
     // Frustum cull: reject splats entirely off-screen
-    if (screen.x + radiusX < 0.0 || screen.x - radiusX > viewportWidth ||
-        screen.y + radiusY < 0.0 || screen.y - radiusY > viewportHeight) {
-        return result;
-    }
+    #ifdef GSPLAT_XR
+        // Stereo union: reject only when off-screen in BOTH eyes, otherwise splats visible only
+        // near one eye's edge (e.g. the right edge of the right eye) would be missing.
+        if ((screen.x + radiusX < 0.0 || screen.x - radiusX > viewportWidth ||
+             screen.y + radiusY < 0.0 || screen.y - radiusY > viewportHeight) &&
+            (screen1.x + radiusX < 0.0 || screen1.x - radiusX > viewportWidth ||
+             screen1.y + radiusY < 0.0 || screen1.y - radiusY > viewportHeight)) {
+            return result;
+        }
+    #else
+        if (screen.x + radiusX < 0.0 || screen.x - radiusX > viewportWidth ||
+            screen.y + radiusY < 0.0 || screen.y - radiusY > viewportHeight) {
+            return result;
+        }
+    #endif
 
     // When the projected extent exceeds the radius cap, rescale the covariance
     // so the Gaussian reaches its cutoff at the capped boundary. Without this,
@@ -233,6 +270,9 @@ fn computeSplatCov(
         result.viewDepth = sqrt(d2);
     #else
         result.viewDepth = -viewCenter.z;
+    #endif
+    #ifdef GSPLAT_XR
+        result.ndc1 = ndc1;
     #endif
     result.valid = true;
     return result;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-project-common.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-project-common.js
@@ -48,6 +48,9 @@ fn projectSplatCommon(
         fisheye_projMat00: f32,
         fisheye_projMat11: f32,
     #endif
+    #ifdef GSPLAT_XR
+        viewProj1: mat4x4f,
+    #endif
 ) -> ProjectedSplatCommon {
     if (threadIdx >= numVisible) {
         return invalidProjectedSplatCommon();
@@ -84,6 +87,9 @@ fn projectSplatCommon(
         #ifdef GSPLAT_FISHEYE
             fisheye_k, fisheye_inv_k,
             fisheye_projMat00, fisheye_projMat11,
+        #endif
+        #ifdef GSPLAT_XR
+            viewProj1,
         #endif
     );
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-projector.js
@@ -139,6 +139,9 @@ fn main(
             uniforms.fisheye_projMat00,
             uniforms.fisheye_projMat11,
         #endif
+        #ifdef GSPLAT_XR
+            uniforms.viewProj1,
+        #endif
     );
 
     if (projected.valid) {
@@ -187,11 +190,11 @@ fn main(
             clipPos.z = clamp(clipPos.z, 0.0, abs(clipPos.w));
         #endif
 
-        // Stereo: project the same world center through eye 1 to get its screen position.
-        // Everything else (covariance/eigenvectors, depth w, color, sort key) is shared from eye 0.
+        // Stereo: eye-1 NDC was already computed by computeSplatCov for the union visibility
+        // test; reuse it for the cache write. Everything else (covariance/eigenvectors, depth w,
+        // color, sort key) is shared from eye 0.
         #ifdef GSPLAT_XR
-            let clip1 = uniforms.viewProj1 * vec4f(center, 1.0);
-            ndc1 = clip1.xy / clip1.w;
+            ndc1 = proj.ndc1;
         #endif
 
         // Sort key — shared depth-bin weighting (same as CPU worker).


### PR DESCRIPTION
Two related XR culling fixes, found while testing the hybrid gsplat renderer in stereo on Quest 3 / Apple Vision Pro.

## 1. `Frustum.add` over-culls with real headset projections (fixes #8449)

The combined XR culling frustum (introduced in #8393) merged the two eye frusta per-plane by keeping the larger `distance` scalar, assuming "frustum plane normals are identical" for parallel-axis stereo. That holds for the *view direction*, but real headsets report **asymmetric per-eye projections** (e.g. ~49° outer / ~37° inner on Quest-class devices), so the matching planes of the two eyes have **different normals**. The two candidate planes cross, and the picked one cuts into the true combined volume beyond the crossing — and because the `distance` scalars shift differently with camera world position when normals differ, *which* plane won depended on where the camera was in the world. This is why #8449 reproduced on hardware in some scenes but not in the simulator (symmetric, identical eye projections) or at other locations.

**Fix:** `Frustum.add` is rewritten as a conservative corner-based merge — the other frustum's 8 corners are computed (three-plane intersections) and this frustum's planes are pushed outward just enough to contain them. Plane orientations are preserved, making the merge correct for arbitrary frusta with no parallelism assumptions. Verified with a standalone reproduction (Quest-like asymmetric frusta, IPD 64 mm): the old merge over-culled 35/70 true-union edge points across 7 camera world positions; the new merge over-culls none, and still excludes behind-camera points.

The XR combined-frustum construction is also extracted from `Renderer.updateCameraFrustum` into a shared `Camera#updateXrFrustum`, now additionally used by the gsplat interval culling — which previously culled XR frames against a mono symmetric frustum.

## 2. Hybrid gsplat projector culled per-splat against eye 0 only

The GPU-sort projector's per-splat screen cull tested only eye 0's viewport, dropping splats visible only near the other eye's edge (visible as missing splats at the right edge of the right eye). The compute cull now also projects eye 1 — reusing the result for the cache write that needed it anyway, so the net cost is ~zero — and rejects a splat only when it is off-screen in **both** eyes. The foveated culling radius similarly uses the smaller of the two eyes' radii, so splats near the centre of either eye are protected from the foveated threshold boost.

**Changes:**
- `Frustum#add` — corner-based conservative merge (behaviour fix; API unchanged).
- `Camera#updateXrFrustum` (ignored/internal) — shared combined-XR-frustum helper, used by `Renderer.updateCameraFrustum` and gsplat interval culling.
- `GSplatFrustumCuller#setFrustumPlanes` — accepts a prebuilt frustum; `computeFrustumPlanes` delegates to it.
- `GSplatManager` — XR interval culling uses the combined frustum (with per-view transform refresh, matching the projector dispatch).
- WGSL (`computeSplatCov` / `projectSplatCommon` / projector): stereo union visibility test via eye-1 projection (`GSPLAT_XR`-gated; mono and compute-local paths unchanged), eye-1 NDC reused for the cache write, per-eye min foveation radius.

Fixes #8449