### PR TITLE
fix(webgl): reset active texture unit on device init for reused contexts

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -992,6 +992,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         gl.enable(gl.SCISSOR_TEST);
 
+        this.textureUnit = 0;
+        gl.activeTexture(gl.TEXTURE0);
+
         gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
 
         this.unpackFlipY = false;


### PR DESCRIPTION
## Description

WebGL device init reset the cached active texture unit to 0 but never issued the matching `gl.activeTexture(TEXTURE0)`. On a context reused by a second device — e.g. the Examples hot-reload, which rebuilds the device on the same canvas — the active unit could be left non-zero, so the directional shadow map bound to the wrong unit and shadowed scenes rendered dark. Adds the missing render-state reset.

Fixes #8893

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
