### PR TITLE
fix(text): render Devanagari and other complex scripts correctly

### DIFF
--- a/src/core/string.js
+++ b/src/core/string.js
@@ -6,6 +6,7 @@ const HIGH_SURROGATE_BEGIN = 0xD800;
 const HIGH_SURROGATE_END = 0xDBFF;
 const LOW_SURROGATE_BEGIN = 0xDC00;
 const LOW_SURROGATE_END = 0xDFFF;
+const ZERO_WIDTH_NON_JOINER = 0x200C;
 const ZERO_WIDTH_JOINER = 0x200D;
 
 // Flag emoji
@@ -16,13 +17,31 @@ const REGIONAL_INDICATOR_END = 0x1F1FF;
 const FITZPATRICK_MODIFIER_BEGIN = 0x1F3FB;
 const FITZPATRICK_MODIFIER_END = 0x1F3FF;
 
-// Accent characters
-const DIACRITICAL_MARKS_BEGIN = 0x20D0;
-const DIACRITICAL_MARKS_END = 0x20FF;
-
 // Special emoji joins
 const VARIATION_MODIFIER_BEGIN = 0xFE00;
 const VARIATION_MODIFIER_END = 0xFE0F;
+
+// Matches a single combining mark (Unicode general category Mark: Mn, Mc, Me). This covers
+// accents, Indic vowel signs and viramas, variation selectors, enclosing keycaps, etc.
+const COMBINING_MARK = /\p{M}/u;
+
+// Brahmic viramas/halants. A virama is itself a combining mark, but it also combines the
+// preceding consonant with the following one to form a conjunct (e.g. Devanagari क + ् + ष =>
+// क्ष), so the consonant after it must be pulled into the same grapheme cluster.
+const VIRAMAS = new Set([
+    0x094D, // Devanagari
+    0x09CD, // Bengali
+    0x0A4D, // Gurmukhi
+    0x0ACD, // Gujarati
+    0x0B4D, // Oriya
+    0x0BCD, // Tamil
+    0x0C4D, // Telugu
+    0x0CCD, // Kannada
+    0x0D4D, // Malayalam
+    0x0DCA, // Sinhala
+    0x1039, // Myanmar
+    0x17D2  // Khmer
+]);
 
 function getCodePointData(string, i = 0) {
     const size = string.length;
@@ -176,8 +195,9 @@ const string = {
 
     /**
      * Gets an array of all grapheme clusters (visible symbols) in a string. This is needed because
-     * some symbols (such as emoji or accented characters) are actually made up of multiple
-     * character codes. See {@link https://mathiasbynens.be/notes/javascript-unicode here} for more
+     * some symbols (such as emoji, accented characters, or complex scripts like Devanagari) are
+     * actually made up of multiple character codes - a base character followed by combining marks
+     * and/or joiners. See {@link https://mathiasbynens.be/notes/javascript-unicode here} for more
      * info.
      *
      * @param {string} string - The string to break into symbols.
@@ -195,20 +215,31 @@ const string = {
         while (index < length) {
             take += numCharsToTakeForNextSymbol(string, index + take);
             ch = string[index + take];
-            // Handle special cases
-            if (isCodeBetween(ch, DIACRITICAL_MARKS_BEGIN, DIACRITICAL_MARKS_END)) {
-                ch = string[index + (take++)];
+
+            // Absorb any following combining marks and joiners so that a base character together
+            // with its marks forms a single grapheme cluster. This keeps complex scripts (e.g.
+            // Devanagari vowel signs and conjuncts), accented characters and emoji sequences
+            // together as one symbol instead of splitting them into separately-rendered glyphs.
+            while (ch) {
+                const code = ch.charCodeAt(0);
+                const isJoiner = code === ZERO_WIDTH_JOINER || code === ZERO_WIDTH_NON_JOINER;
+
+                if (!isJoiner && !COMBINING_MARK.test(ch)) {
+                    break;
+                }
+
+                take++;
+
+                // Joiners and viramas link to the following base character (emoji ZWJ sequences
+                // and Indic conjuncts), so pull that base into the same cluster too.
+                if ((isJoiner || VIRAMAS.has(code)) && index + take < length) {
+                    take += numCharsToTakeForNextSymbol(string, index + take);
+                }
+
+                ch = string[index + take];
             }
-            if (isCodeBetween(ch, VARIATION_MODIFIER_BEGIN, VARIATION_MODIFIER_END)) {
-                ch = string[index + (take++)];
-            }
-            if (ch && ch.charCodeAt(0) === ZERO_WIDTH_JOINER) {
-                ch = string[index + (take++)];
-                // Not a complete char yet
-                continue;
-            }
-            const char = string.substring(index, index + take);
-            output.push(char);
+
+            output.push(string.substring(index, index + take));
             index += take;
             take = 0;
         }

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -348,6 +348,35 @@ class TextElement {
             this._symbols = [' '];
         }
 
+        // A grapheme cluster (e.g. a Devanagari syllable) is rendered as a single glyph only if
+        // the font actually contains it - which is the case for a CanvasFont, as it rasterizes
+        // whole clusters using the browser's text shaper. For fonts whose atlas is keyed by
+        // individual code points (e.g. a bitmap/MSDF font), expand any missing cluster back into
+        // its code points so they are still rendered individually rather than dropped.
+        const fontChars = this._font?.data?.chars;
+        if (fontChars) {
+            let expanded = null;
+            for (let i = 0; i < this._symbols.length; i++) {
+                const symbol = this._symbols[i];
+                if (symbol.length === 1 || fontChars[symbol]) {
+                    expanded?.push(symbol);
+                    continue;
+                }
+                const codePoints = string.getCodePoints(symbol);
+                if (codePoints.length === 1) {
+                    expanded?.push(symbol);
+                    continue;
+                }
+                expanded = expanded ?? this._symbols.slice(0, i);
+                for (let j = 0; j < codePoints.length; j++) {
+                    expanded.push(string.fromCodePoint(codePoints[j]));
+                }
+            }
+            if (expanded) {
+                this._symbols = expanded;
+            }
+        }
+
         // extract markup
         if (this._enableMarkup) {
             const results = Markup.evaluate(this._symbols);

--- a/test/core/string.test.mjs
+++ b/test/core/string.test.mjs
@@ -40,6 +40,28 @@ describe('string', function () {
             expect(string.getSymbols('🏴‍☠️').length).to.equal(1);
         });
 
+        it('keeps a base character and its combining marks together', function () {
+            // 'a' + combining acute accent (U+0301)
+            expect(string.getSymbols('á')).to.deep.equal(['á']);
+            // multiple stacked marks stay with their base
+            expect(string.getSymbols('ế')).to.deep.equal(['ế']);
+        });
+
+        it('clusters Devanagari vowel signs with their consonant', function () {
+            // क (ka) + ि (vowel sign i) => one cluster (the vowel sign is reordered before the
+            // consonant when shaped, so it must not be split into a separate symbol)
+            expect(string.getSymbols('कि')).to.deep.equal(['कि']);
+            // हिंदी => हिं (ha + i + anusvara) and दी (da + ii)
+            expect(string.getSymbols('हिंदी')).to.deep.equal(['हिं', 'दी']);
+        });
+
+        it('clusters Devanagari conjuncts joined by a virama', function () {
+            // क + ् (virama) + ष => single conjunct cluster क्ष
+            expect(string.getSymbols('क्ष')).to.deep.equal(['क्ष']);
+            // नमस्ते => न, म, स्ते (s + virama + t + e)
+            expect(string.getSymbols('नमस्ते')).to.deep.equal(['न', 'म', 'स्ते']);
+        });
+
     });
 
     describe('#fromCodePoint', function () {


### PR DESCRIPTION
Fixes #4102.

`string.getSymbols` split Devanagari into one symbol per code point, so vowel signs (matras) detached from their consonant and conjuncts never formed — text rendered garbled and out of order as reported.

`getSymbols` now forms proper grapheme clusters: a base character plus its trailing combining marks (`\p{M}`), `ZWJ`/`ZWNJ` joiners and virama-joined consonants. Because `CanvasFont` rasterizes each symbol with the browser's text shaper, whole syllables now shape into a single correctly-composed glyph (Devanagari, plus Arabic, Tamil, etc.).

Bitmap/MSDF fonts have per-code-point atlases that don't contain a multi-code-point cluster, so `TextElement` expands any font-missing cluster back into its code points — they render exactly as before.

Tested: added `getSymbols` unit tests for Devanagari vowel signs and conjuncts; existing emoji/flag/ZWJ cases are unchanged; verified end-to-end that a real `CanvasFont` atlas now contains correctly-shaped Hindi clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)