### PR TITLE
fix(examples): restore MiniStats panel after hot reload

### DIFF
--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -50,6 +50,14 @@ class ExampleLoader {
     _allowRestart = true;
 
     /**
+     * The last requested MiniStats enabled state, re-applied on hot reload.
+     *
+     * @type {boolean}
+     * @private
+     */
+    _miniStatsEnabled = false;
+
+    /**
      * @type {Function[]}
      * @private
      */
@@ -71,7 +79,8 @@ class ExampleLoader {
             }
         }
 
-        if (!this._started) {
+        const firstStart = !this._started;
+        if (firstStart) {
             // Sets code editor component files
             // Sets example component files (for controls + description)
             // Sets mini stats enabled state based on UI
@@ -83,6 +92,12 @@ class ExampleLoader {
             });
         }
         this._started = true;
+
+        // 'exampleLoad' re-applies the MiniStats toggle but only fires on first start, so re-apply it
+        // here after a hot reload - otherwise the panel stays hidden until the button is toggled twice.
+        if (!firstStart) {
+            this.setMiniStats(this._miniStatsEnabled);
+        }
 
         // Updates controls UI
         fire('updateFiles', {
@@ -266,6 +281,7 @@ class ExampleLoader {
      * @param {boolean} enabled - The enabled state of ministats
      */
     setMiniStats(enabled = false) {
+        this._miniStatsEnabled = enabled;
         if (this._config.NO_MINISTATS) {
             fire('miniStats', { state: false });
             return;


### PR DESCRIPTION
## Description

Follow-up to #8894 for the remaining part of #8893: MiniStats was still broken on hot reload (the code-editor play button). Hitting it hid the panel, which only returned after toggling the MiniStats button twice.

A hot reload destroys the app and its MiniStats, but `exampleLoad` — which re-applies the UI's MiniStats toggle — only fires on first start. The loader now remembers the requested state and re-applies it when the example restarts.

Verified in the examples dev server with puppeteer: example loads with MiniStats visible → click play → MiniStats persists. Reverting the change reproduces the disappearance.

Fixes #8893

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
