### PR TITLE
fix(physics): clear cached collisions when a collision component is removed

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -732,6 +732,12 @@ class CollisionComponentSystem extends ComponentSystem {
     onBeforeRemove(entity, component) {
         this.implementations[component.type].beforeRemove(entity, component);
         component.onBeforeRemove();
+
+        // discard any stored collisions keyed to this entity so a later entity that reuses the
+        // same GUID (e.g. after reloading the same scene) does not inherit stale tracking
+        if (this.app.systems.rigidbody) {
+            this.app.systems.rigidbody.clearEntityCollisions(entity);
+        }
     }
 
     onRemove(entity) {

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -542,6 +542,20 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     /**
+     * Removes any stored collision keyed to the given entity. Called when a collision component is
+     * removed so the persistent collisions map does not retain a destroyed entity. A new entity
+     * that later reuses the same GUID (for example after reloading the same scene) would otherwise
+     * inherit the stale entry and never fire `triggerleave` / `collisionend`, because the cached
+     * entity no longer has a trigger or body.
+     *
+     * @param {Entity} entity - The entity whose stored collision should be removed.
+     * @ignore
+     */
+    clearEntityCollisions(entity) {
+        delete this.collisions[entity.guid];
+    }
+
+    /**
      * Returns true if the entity has a contact event attached and false otherwise.
      *
      * @param {Entity} entity - Entity to test.

--- a/test/framework/components/rigid-body/system.test.mjs
+++ b/test/framework/components/rigid-body/system.test.mjs
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+
+import { Entity } from '../../../../src/framework/entity.js';
+import { createApp } from '../../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
+
+describe('RigidBodyComponentSystem', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    describe('stored collisions', function () {
+
+        // Regression test for https://github.com/playcanvas/engine/issues/5797 - the persistent
+        // collisions map is keyed by entity GUID. Reloading the same scene recreates entities with
+        // the same GUIDs, so a stale entry referencing a destroyed entity must not survive removal,
+        // otherwise its triggerleave / collisionend events would never fire again.
+        it('discards stored collisions when the collision component is removed', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('collision');
+
+            app.systems.rigidbody.collisions[e.guid] = { entity: e, others: [new Entity()] };
+
+            e.removeComponent('collision');
+
+            expect(app.systems.rigidbody.collisions[e.guid]).to.be.undefined;
+        });
+
+        it('discards stored collisions when the entity is destroyed', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('collision');
+
+            const guid = e.guid;
+            app.systems.rigidbody.collisions[guid] = { entity: e, others: [] };
+
+            e.destroy();
+
+            expect(app.systems.rigidbody.collisions[guid]).to.be.undefined;
+        });
+
+        it('leaves collisions keyed to other entities untouched', function () {
+            const a = new Entity();
+            const b = new Entity();
+            app.root.addChild(a);
+            app.root.addChild(b);
+            a.addComponent('collision');
+            b.addComponent('collision');
+
+            app.systems.rigidbody.collisions[a.guid] = { entity: a, others: [b] };
+            app.systems.rigidbody.collisions[b.guid] = { entity: b, others: [a] };
+
+            a.removeComponent('collision');
+
+            expect(app.systems.rigidbody.collisions[a.guid]).to.be.undefined;
+            expect(app.systems.rigidbody.collisions[b.guid]).to.exist;
+        });
+
+    });
+
+});


### PR DESCRIPTION
## Description

The rigid-body `collisions` map is keyed by entity GUID and was never cleared when an entity is destroyed. Reloading the *same* scene recreates entities with identical GUIDs (from `resource_id`) within a single task — no physics step runs in between — so the stale entry, still referencing the destroyed entity, was reused by the new same-GUID entity.

From then on `triggerleave` / `collisionend` never fired, because `_cleanOldCollisions` decides which leave event to fire by inspecting the cached (now destroyed) entity, whose `trigger` / `body` had already been deleted on destroy.

This clears the entity's cached collision on collision `beforeremove`. Every physics body entity has a collision component, so this single hook covers both triggers and rigid bodies. Added a regression test.

Fixes #5797

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
