### PR TITLE
test(element): cover reparenting an element after its screen is destroyed

### DIFF
--- a/test/framework/components/element/component.test.mjs
+++ b/test/framework/components/element/component.test.mjs
@@ -157,6 +157,28 @@ describe('ElementComponent', function () {
         expect(screen.screen._elements).to.not.include(e.element);
     });
 
+    it('can be reparented after its screen has been destroyed (#1151)', function () {
+        const screen = new Entity();
+        screen.addComponent('screen');
+        app.root.addChild(screen);
+
+        const e = new Entity();
+        e.addComponent('element');
+        screen.addChild(e);
+
+        // detach the element for later reuse, then destroy its screen (e.g. on scene unload)
+        e.reparent(null);
+        screen.destroy();
+
+        // the dangling screen reference should have been cleared
+        expect(e.element.screen).to.equal(null);
+
+        // reparenting the element again should not throw
+        const newParent = new Entity();
+        app.root.addChild(newParent);
+        expect(() => newParent.addChild(e)).to.not.throw();
+    });
+
     describe('#type', function () {
 
         it('adds model to layers when type is set to image after entity is in hierarchy', function () {


### PR DESCRIPTION
Adds a regression test for #1151: an element reparented to `null` whose screen is then destroyed (e.g. on scene unload) can be reparented again without throwing `this.screen.screen is undefined`.

The behaviour is already correct in current code — the screen's `onBeforeRemove` clears the dangling `screen` reference on its bound elements — so this just locks it in. The existing tests covered reparenting to a non-screen parent and destroying the element, but not this combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
