### PR TITLE
refactor(input): remove dead and broken GamePads previous getter

### DIFF
--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -816,14 +816,6 @@ class GamePads extends EventHandler {
     current = [];
 
     /**
-     * The list of previous buttons states
-     *
-     * @type {boolean[][]}
-     * @private
-     */
-    _previous = [];
-
-    /**
      * @type {(event: GamepadEvent) => void}
      * @private
      */
@@ -870,32 +862,6 @@ class GamePads extends EventHandler {
      */
     get deadZone() {
         return deadZone;
-    }
-
-    /**
-     * Gets the list of previous button states.
-     *
-     * @type {boolean[][]}
-     * @ignore
-     */
-    get previous() {
-        const current = this.current;
-
-        for (let i = 0, l = current.length; i < l; i++) {
-            const buttons = current[i]._buttons;
-
-            if (!this._previous[i]) {
-                this._previous[i] = [];
-            }
-
-            for (let j = 0, m = buttons.length; j < m; j++) {
-                const button = buttons[i];
-                this.previous[i][j] = button ? !button.wasPressed && button.pressed || button.wasReleased : false;
-            }
-        }
-
-        this._previous.length = this.current.length;
-        return this._previous;
     }
 
     /**


### PR DESCRIPTION
Removes the unused, broken `GamePads#previous` getter and its `_previous` backing field.

It was `@ignore` with no callers (engine, tests, or examples) and would overflow the stack if ever called — it indexed buttons by gamepad index and assigned through `this.previous`, re-entering the getter. Per-button `wasPressed`/`wasReleased` state on `GamePadButton` has long since superseded it.

Spotted while reviewing #1014. No public API change (the getter was `@ignore`, so it never appeared in generated types); lint and `npm run test:types` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)