### PR TITLE
fix(particles): report isPlaying() in sync with particle lifetime

### DIFF
--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -568,7 +568,7 @@ class ParticleSystemComponent extends Component {
         this._loop = arg;
         if (this.emitter) {
             this.emitter.loop = arg;
-            this.emitter.resetTime();
+            this.emitter.resetTime(arg ? undefined : this.emitter.lifetime);
             this.emitter.resetMaterial();
         }
     }
@@ -2265,7 +2265,7 @@ class ParticleSystemComponent extends Component {
     stop() {
         if (this.emitter) {
             this.emitter.loop = false;
-            this.emitter.resetTime();
+            this.emitter.resetTime(this.emitter.lifetime);
             this.emitter.addTime(0, true);
         }
     }
@@ -2309,9 +2309,7 @@ class ParticleSystemComponent extends Component {
             return true;
         }
 
-        // possible bug here what happens if the non looping emitter
-        // was paused in the meantime?
-        return Date.now() <= this.emitter.endTime;
+        return this.emitter.simTimeTotal <= this.emitter.endTime;
     }
 
     /**

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -170,9 +170,10 @@ function packTexture2Floats(qA, qB) {
     return colors;
 }
 
-function calcEndTime(emitter) {
-    const interval = (Math.max(emitter.rate, emitter.rate2) * emitter.numParticles + emitter.lifetime);
-    return Date.now() + interval * 1000;
+// Estimated seconds for a non-looping emitter to spawn every particle and for the last one to
+// reach the end of its life.
+function calcSpawnDuration(emitter) {
+    return Math.max(emitter.rate, emitter.rate2) * emitter.numParticles + emitter.lifetime;
 }
 
 function subGraph(A, B) {
@@ -1061,8 +1062,10 @@ class ParticleEmitter {
         }
     }
 
-    resetTime() {
-        this.endTime = calcEndTime(this);
+    resetTime(duration = calcSpawnDuration(this)) {
+        // measured against the emitter's own simulation clock (simTimeTotal) so that pausing,
+        // time scaling and frame drops keep the finished state in sync with the particles
+        this.endTime = this.simTimeTotal + duration;
     }
 
     finishFrame() {
@@ -1139,7 +1142,7 @@ class ParticleEmitter {
         }
 
         if (!this.loop) {
-            if (Date.now() > this.endTime) {
+            if (this.simTimeTotal > this.endTime) {
                 if (this.onFinished) this.onFinished();
                 this.meshInstance.visible = false;
             }

--- a/test/framework/components/particlesystem/component.test.mjs
+++ b/test/framework/components/particlesystem/component.test.mjs
@@ -309,6 +309,53 @@ describe('ParticleSystemComponent', function () {
         expect(e.particlesystem.isPlaying()).to.be.false;
     });
 
+    it('isPlaying() tracks the emitter simulation clock for a non-looping system', function () {
+        const e = new Entity();
+        e.addComponent('particlesystem');
+        app.root.addChild(e);
+        const c = e.particlesystem;
+
+        // NullGraphicsDevice creates no emitter, so stub one to exercise the time logic
+        c.emitter = { loop: false, simTimeTotal: 0, endTime: 5 };
+
+        expect(c.isPlaying()).to.be.true;       // within the window
+
+        c.emitter.simTimeTotal = 5;
+        expect(c.isPlaying()).to.be.true;       // boundary is still playing
+
+        c.emitter.simTimeTotal = 5.001;
+        expect(c.isPlaying()).to.be.false;      // simulation has passed endTime
+
+        c.emitter = null;                       // drop the stub before teardown
+    });
+
+    it('isPlaying() is true for a looping emitter regardless of elapsed time', function () {
+        const e = new Entity();
+        e.addComponent('particlesystem');
+        app.root.addChild(e);
+        const c = e.particlesystem;
+
+        c.emitter = { loop: true, simTimeTotal: 1e6, endTime: 0 };
+
+        expect(c.isPlaying()).to.be.true;
+
+        c.emitter = null;                       // drop the stub before teardown
+    });
+
+    it('isPlaying() is false while paused even within the end time', function () {
+        const e = new Entity();
+        e.addComponent('particlesystem');
+        app.root.addChild(e);
+        const c = e.particlesystem;
+
+        c.emitter = { loop: false, simTimeTotal: 0, endTime: 5 };
+        c.pause();
+
+        expect(c.isPlaying()).to.be.false;
+
+        c.emitter = null;                       // drop the stub before teardown
+    });
+
     it('ColorMap Asset unbinds on destroy', function () {
         const e = new Entity();
         app.root.addChild(e);


### PR DESCRIPTION
## Description
`particlesystem.isPlaying()` returned `true` long after a stopped or non-looping system's particles had visually died. `endTime` was the full "spawn every particle and outlive the last one" estimate (`max(rate, rate2) * numParticles + lifetime`) anchored to `Date.now()`. But after `stop()` (or `loop = false`) emission has already halted, so the only remaining work is the alive particles draining — at most `lifetime`. The wall clock also desynced the playing state under pause / `timeScale`.

This measures `endTime` on the emitter's own simulation clock (`simTimeTotal`, which only advances while ticking and not paused) and uses a `lifetime` budget once emission halts (`stop()` and the `loop = false` setter). Adds unit tests covering the `isPlaying()` state.

Verified against the issue's repro project (built against this branch): after Stop the label flips to "stopped" at ~5s (the lifetime) instead of ~11s, and the state now survives a pause correctly.

Fixes #2146

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
