### PR TITLE
Fix overestimated WebGPU GPU frame timing in profiler

### DIFF
--- a/src/platform/graphics/gpu-profiler.js
+++ b/src/platform/graphics/gpu-profiler.js
@@ -130,7 +130,7 @@ class GpuProfiler {
         return parsedName;
     }
 
-    report(renderVersion, timings) {
+    report(renderVersion, timings, frameTime) {
 
         if (timings) {
             const allocations = this.pastFrameAllocations.get(renderVersion);
@@ -139,9 +139,13 @@ class GpuProfiler {
             }
             Debug.assert(allocations.length === timings.length);
 
-            // store frame duration
+            // Store frame duration. When the caller supplies an explicit frameTime (the WebGPU
+            // profiler passes the span from the first begin to the last end timestamp), use it -
+            // per-pass timestamp intervals can overlap on pipelined GPUs, so their sum overestimates
+            // the real cost. Otherwise fall back to summing per-pass timings (WebGL measures the
+            // whole frame with a single query, so its timings do not overlap).
             if (timings.length > 0) {
-                this._frameTime = timings.reduce((sum, t) => sum + t, 0);
+                this._frameTime = frameTime ?? timings.reduce((sum, t) => sum + t, 0);
             }
 
             // clear old pass timings

--- a/src/platform/graphics/webgpu/webgpu-gpu-profiler.js
+++ b/src/platform/graphics/webgpu/webgpu-gpu-profiler.js
@@ -38,7 +38,7 @@ class WebgpuGpuProfiler extends GpuProfiler {
             // request results
             const renderVersion = this.device.renderVersion;
             this.timestampQueriesSet?.request(this.slotCount, renderVersion).then((results) => {
-                this.report(results.renderVersion, results.timings);
+                this.report(results.renderVersion, results.timings, results.frameTime);
             });
 
             super.request(renderVersion);

--- a/src/platform/graphics/webgpu/webgpu-query-set.js
+++ b/src/platform/graphics/webgpu/webgpu-query-set.js
@@ -60,8 +60,7 @@ class WebgpuQuerySet {
                 size: this.queryBuffer.size,
                 usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
             });
-            DebugHelper.setLabel(this.queryBuffer, 'QueryStagingBuffer');
-
+            DebugHelper.setLabel(stagingBuffer, 'QueryStagingBuffer');
         }
         return stagingBuffer;
     }
@@ -89,18 +88,54 @@ class WebgpuQuerySet {
             // timestamps in nanoseconds. Note that this array is valid only till we unmap the staging buffer.
             const srcTimings = new BigInt64Array(stagingBuffer.getMappedRange());
 
-            // convert to ms per sample pair
+            // Convert each begin/end pair to a per-pass duration in ms.
+            //
+            // Durations are clamped to be non-negative: on some GPUs the begin/end timestamps of a
+            // pass can be reported slightly out of order (begin > end), giving a small negative
+            // duration. This is a driver / architecture timing artifact rather than a real
+            // measurement, so we clamp it to zero instead of letting it corrupt the totals.
             const timings = [];
+            let minTime = null;
+            let maxTime = null;
             for (let i = 0; i < count; i++) {
-                timings.push(Number(srcTimings[i * 2 + 1] - srcTimings[i * 2]) * 0.000001);
+                const begin = srcTimings[i * 2];
+                const end = srcTimings[i * 2 + 1];
+
+                timings.push(Math.max(0, Number(end - begin) * 0.000001));
+
+                // track the earliest and latest timestamp across all passes (used for frameTime
+                // below). Both begin and end are considered to stay robust to the out-of-order
+                // case described above.
+                if (minTime === null || begin < minTime) minTime = begin;
+                if (end < minTime) minTime = end;
+                if (maxTime === null || end > maxTime) maxTime = end;
+                if (begin > maxTime) maxTime = begin;
             }
+
+            // Frame GPU time is reported as the span from the earliest begin to the latest end
+            // timestamp across all passes, NOT the sum of per-pass durations.
+            //
+            // On tile-based and other heavily pipelined GPU architectures (Apple Silicon is one
+            // well known example, but it is not unique to it) consecutive passes overlap in time -
+            // the vertex stage of one pass runs concurrently with the fragment stage of the
+            // previous one, so their timestamp intervals overlap. Summing per-pass durations then
+            // massively overestimates the real frame cost: the total grows with the number of
+            // passes even while the GPU sits mostly idle. The span stays within the actual frame
+            // time and gives a realistic figure regardless of architecture.
+            //
+            // Note the span also includes any GPU idle bubbles between passes (e.g. while the GPU
+            // waits on the CPU or on dependencies), so on those frames it can read slightly higher
+            // than the pure GPU work. This is the same property the WebGL profiler has, as it
+            // measures the whole frame with a single query that likewise spans those gaps.
+            const frameTime = count > 0 ? Number(maxTime - minTime) * 0.000001 : 0;
 
             stagingBuffer.unmap();
             this.stagingBuffers?.push(stagingBuffer);
 
             return {
                 renderVersion,
-                timings
+                timings,
+                frameTime
             };
         });
     }


### PR DESCRIPTION
The GPU time reported by the WebGPU profiler (and shown in mini-stats) was massively overestimated, growing with the number of render/compute passes even when the GPU was mostly idle. On tile-based / pipelined GPUs (Apple Silicon is a well known example) consecutive passes overlap in time — the vertex stage of one pass runs concurrently with the fragment stage of the previous one — so summing per-pass timestamp durations double-counts the overlap.

This reports the frame GPU time as the span between the earliest begin and latest end timestamp across all passes, which stays within the real frame time. Per-pass timings are kept as-is (useful for relative comparison) but are now clamped to be non-negative, fixing the negative readings some users observed.

**Changes:**
- WebGPU frame GPU time is now the timestamp span (max end − min begin) across all passes, instead of the sum of per-pass durations.
- Per-pass GPU durations are clamped to ≥ 0, fixing occasional negative timings caused by begin/end timestamps reported out of order by the driver.
- WebGL profiling is unchanged — it already measures the whole frame with a single query, so its reported time does not overlap.
- Fixed a debug-label bug where the timestamp staging buffer was mislabelled.

Closes #8350