### PR TITLE
Rebuild bind group when its dynamic uniform buffer is re-allocated mid-frame

### DIFF
--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -53,6 +53,16 @@ class BindGroup {
     uniformBufferOffsets = [];
 
     /**
+     * For each uniform buffer slot, the dynamic GPU buffer a non-persistent uniform buffer was
+     * last built against. Used to detect when such a buffer is re-allocated into a different
+     * dynamic buffer (which requires the bind group to be rebuilt).
+     *
+     * @type {object[]}
+     * @private
+     */
+    _uniformBufferContainers = [];
+
+    /**
      * Create a new Bind Group.
      *
      * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this uniform buffer.
@@ -232,9 +242,15 @@ class BindGroup {
             // offset
             this.uniformBufferOffsets[i] = uniformBuffer.offset;
 
-            // test if any of the uniform buffers have changed (not their content, but the buffer container itself)
-            if (this.renderVersionUpdated < uniformBuffer.renderVersionDirty) {
-                this.dirty = true;
+            // a non-persistent uniform buffer can be re-allocated into a different dynamic buffer,
+            // possibly several times per frame (e.g. XR multiview re-bakes the bind groups per
+            // view); rebuild the bind group whenever it moves. Persistent buffers never move.
+            if (!uniformBuffer.persistent) {
+                const container = uniformBuffer.allocation.gpuBuffer;
+                if (this._uniformBufferContainers[i] !== container) {
+                    this._uniformBufferContainers[i] = container;
+                    this.dirty = true;
+                }
             }
         }
 

--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -7,6 +7,7 @@ import { TextureView } from './texture-view.js';
 
 /**
  * @import { BindGroupFormat } from './bind-group-format.js'
+ * @import { DynamicBuffer } from './dynamic-buffer.js'
  * @import { GraphicsDevice } from './graphics-device.js'
  * @import { StorageBuffer } from './storage-buffer.js'
  * @import { Texture } from './texture.js'
@@ -57,7 +58,7 @@ class BindGroup {
      * last built against. Used to detect when such a buffer is re-allocated into a different
      * dynamic buffer (which requires the bind group to be rebuilt).
      *
-     * @type {object[]}
+     * @type {DynamicBuffer[]}
      * @private
      */
     _uniformBufferContainers = [];

--- a/src/platform/graphics/uniform-buffer.js
+++ b/src/platform/graphics/uniform-buffer.js
@@ -226,12 +226,6 @@ class UniformBuffer {
     storageUint32;
 
     /**
-     * A render version used to track the last time the properties requiring bind group to be
-     * updated were changed.
-     */
-    renderVersionDirty = 0;
-
-    /**
      * Create a new UniformBuffer instance.
      *
      * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this uniform
@@ -345,7 +339,6 @@ class UniformBuffer {
 
             // allocate memory from dynamic buffer for this frame
             const allocation = this.allocation;
-            const oldGpuBuffer = allocation.gpuBuffer;
             this.device.dynamicBuffers.alloc(allocation, this.format.byteSize);
             this.assignStorage(allocation.storage);
 
@@ -353,11 +346,6 @@ class UniformBuffer {
             if (dynamicBindGroup) {
                 dynamicBindGroup.bindGroup = allocation.gpuBuffer.getBindGroup(this);
                 dynamicBindGroup.offsets[0] = allocation.offset;
-            }
-
-            // buffer has changed, update the render version to force bind group to be updated
-            if (oldGpuBuffer !== allocation.gpuBuffer) {
-                this.renderVersionDirty = this.device.renderVersion;
             }
         }
     }


### PR DESCRIPTION
### Summary

A non-persistent uniform buffer is allocated from a per-frame dynamic (ring) buffer, and its underlying GPU buffer can change mid-frame. When the **same** bind group is re-baked multiple times in one frame — as the WebGPU XR multiview pass does (it replays the per-view bind groups once per view) — the buffer can move more than once per frame.

`BindGroup.update()` detected such a move via the per-frame `renderVersion` (`renderVersionUpdated < uniformBuffer.renderVersionDirty`). Since `renderVersion` is constant within a frame, this only catches the **first** move per frame. A later move left the bind group's GPU resource pointing at the **old** buffer while its dynamic offset advanced into the **new** one, so it sampled the wrong data.

Symptom: in the WebGPU `test > xr-views` example, the last (most-rotated) multiview view rendered with another view's matrices, shifting as the camera moved.

### Fix

Compare the uniform buffer's `allocation.gpuBuffer` directly per non-persistent slot and rebuild the bind group whenever it changes — catching every move within a frame, not just the first. Persistent buffers never move and are skipped. The now-unused `UniformBuffer.renderVersionDirty` is removed.

The change stays in the generic `BindGroup`/`UniformBuffer` layer (no backend-specific access); the texture change-detection path is untouched.

### Testing

- `npm test` — all passing
- `npm run build:types` — clean
- Verified on the WebGPU `test > xr-views` example: all 4 multiview views now render correctly and remain correct under camera/pivot motion. WebGL unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)