### PR TITLE
Move XR per-view data from the XR manager to the Camera (RenderView)

### DIFF
--- a/examples/src/examples/gaussian-splatting/xr-views.example.mjs
+++ b/examples/src/examples/gaussian-splatting/xr-views.example.mjs
@@ -101,68 +101,52 @@ assetListLoader.load(() => {
     // Interpupillary distance (~63mm), half for each eye offset from center
     const halfIPD = 0.032;
 
-    // Set up two XR views for stereo rendering (left eye, right eye)
-    const viewsList = [];
-    for (let i = 0; i < 2; i++) {
-        viewsList.push({
-            updateTransforms(transform) {
-            },
-            viewport: new pc.Vec4(),
-            projMat: new pc.Mat4(),
-            viewOffMat: new pc.Mat4(),
-            viewInvOffMat: new pc.Mat4(),
-            viewMat3: new pc.Mat3(),
-            projViewOffMat: new pc.Mat4(),
-            viewInvMat: new pc.Mat4(),
-            positionData: [0, 0, 0],
-            viewIndex: i
-        });
-    }
-
-    camera.camera.camera.xr = {
-        session: true,
-        views: {
-            list: viewsList
-        }
-    };
+    // Set up two RenderViews for stereo rendering (left eye, right eye)
+    const viewsList = [new pc.RenderView(), new pc.RenderView()];
 
     const cameraComponent = camera.camera;
+
+    // simulate an active XR session by handing the camera the per-view array directly. On a real
+    // headset the XrManager populates xrViews (and the per-eye device projection); here we build
+    // each eye's projection from the camera's settings, captured before the session is activated
+    // (once active, the fov/clip getters report XR-session values instead).
+    const projFov = cameraComponent.fov;
+    const projNearClip = cameraComponent.nearClip;
+    const projFarClip = cameraComponent.farClip;
+    const projHorizontalFov = cameraComponent.horizontalFov;
+    cameraComponent.camera.xrViews = viewsList;
+
+    // reused each frame; setView/setViewport copy the data into each view
+    const projMat = new pc.Mat4();
+    const viewInvMat = new pc.Mat4();
+
     app.on('update', (/** @type {number} */ dt) => {
 
         const width = canvas.width;
         const height = canvas.height;
 
-        viewsList.forEach((/** @type {XrView} */ view) => {
-            view.projMat.copy(cameraComponent.projectionMatrix);
+        // both eyes share the projection; the renderer derives the per-view matrices from setView
+        projMat.setPerspective(projFov, width / height, projNearClip, projFarClip, projHorizontalFov);
 
+        viewsList.forEach((view, viewIndex) => {
             const pos = camera.getPosition();
             const rot = camera.getRotation();
 
             // offset each eye along the camera's right vector, converging on the orbit target
-            const eyeSign = view.viewIndex === 0 ? -1 : 1;
+            const eyeSign = viewIndex === 0 ? -1 : 1;
             const offset = data.get('exaggeratedStereo') ? 0.5 : halfIPD;
             const right = new pc.Vec3();
             rot.transformVector(pc.Vec3.RIGHT, right);
             const eyePos = new pc.Vec3().add2(pos, right.mulScalar(eyeSign * offset));
 
             const focusPoint = hotel.getPosition();
-            const viewInvMat = new pc.Mat4().setLookAt(eyePos, focusPoint, pc.Vec3.UP);
-            const viewMat = new pc.Mat4().copy(viewInvMat).invert();
+            viewInvMat.setLookAt(eyePos, focusPoint, pc.Vec3.UP);
 
-            view.viewOffMat.copy(viewMat);
-            view.viewInvOffMat.copy(viewInvMat);
-            view.viewMat3.setFromMat4(viewMat);
-            view.projViewOffMat.mul2(view.projMat, viewMat);
-            view.positionData[0] = eyePos.x;
-            view.positionData[1] = eyePos.y;
-            view.positionData[2] = eyePos.z;
+            // supply the eye's projection and pose; the view matrix is derived from viewInvMat
+            view.setView(projMat.data, viewInvMat.data);
 
             // side-by-side viewports: left eye on left half, right eye on right half
-            const viewport = view.viewport;
-            viewport.x = view.viewIndex * (width / 2);
-            viewport.y = 0;
-            viewport.z = width / 2;
-            viewport.w = height;
+            view.setViewport(viewIndex * (width / 2), 0, width / 2, height);
         });
     });
 });

--- a/examples/src/examples/test/xr-views.example.mjs
+++ b/examples/src/examples/test/xr-views.example.mjs
@@ -203,27 +203,18 @@ assetListLoader.load(() => {
     const numViews = 4;
     const viewsList = [];
     for (let i = 0; i < numViews; i++) {
-        viewsList.push({
-            updateTransforms(transform) {
-            },
-            viewport: new pc.Vec4(),
-            projMat: new pc.Mat4(),
-            viewOffMat: new pc.Mat4(),
-            viewInvOffMat: new pc.Mat4(),
-            viewMat3: new pc.Mat3(),
-            projViewOffMat: new pc.Mat4(),
-            viewInvMat: new pc.Mat4(),
-            positionData: [0, 0, 0],
-            viewIndex: i
-        });
+        viewsList.push(new pc.RenderView());
     }
 
-    camera.camera.camera.xr = {
-        session: true,
-        views: {
-            list: viewsList
-        }
-    };
+    // simulate an active XR session by handing the camera the per-view array directly. On a real
+    // headset the XrManager populates xrViews (and the per-eye device projection); here we build
+    // each eye's projection from the camera's settings, captured before the session is activated
+    // (once active, the fov/clip getters report XR-session values instead).
+    const projFov = camera.camera.fov;
+    const projNearClip = camera.camera.nearClip;
+    const projFarClip = camera.camera.farClip;
+    const projHorizontalFov = camera.camera.horizontalFov;
+    camera.camera.camera.xrViews = viewsList;
 
     // ----------------------------------------------------------------------------------------
     // WebGPU-only setup: drive FramePassMultiView via a fake bridge - we provide the per-view
@@ -266,53 +257,47 @@ assetListLoader.load(() => {
         compositeCamera.camera.framePasses = [compositePass];
     }
 
-    const cameraComponent = camera.camera;
+    // reused each frame; setView/setViewport copy the data into each view
+    const projMat = new pc.Mat4();
+    const viewInvMat = new pc.Mat4();
+
     app.on('update', (/** @type {number} */ dt) => {
 
         const width = canvas.width;
         const height = canvas.height;
         const isWebgpu = device.isWebGPU;
 
-        // update all views - supply some matrices to make pre view rendering possible
-        // note that this is not complete set up, view frustum does not get updated and so
-        // culling does not work well
-        viewsList.forEach((/** @type {XrView} */ view) => {
-            view.projMat.copy(cameraComponent.projectionMatrix);
+        // all views share the projection; the renderer derives the per-view matrices from setView
+        projMat.setPerspective(projFov, width / height, projNearClip, projFarClip, projHorizontalFov);
 
+        // update all views - supply projection, pose and viewport for each
+        viewsList.forEach((view, viewIndex) => {
             const pos = camera.getPosition();
             const rot = camera.getRotation();
 
-            const viewInvMat = new pc.Mat4();
-
             // Rotate each view by 10 degrees * view index around UP axis
-            const angle = 10 * view.viewIndex;
+            const angle = 10 * viewIndex;
             const upRotation = new pc.Quat().setFromAxisAngle(pc.Vec3.UP, angle);
             const combinedRot = new pc.Quat().mul2(upRotation, rot);
             viewInvMat.setTRS(pos, combinedRot, pc.Vec3.ONE);
 
-            const viewMat = new pc.Mat4();
-            viewMat.copy(viewInvMat).invert();
+            // supply the view's projection and pose; the renderer derives the rest each frame
+            view.setView(projMat.data, viewInvMat.data);
 
-            view.viewMat3.setFromMat4(viewMat);
-
-            view.projViewOffMat.mul2(view.projMat, viewMat);
-
-            const viewport = view.viewport;
             if (isWebgpu) {
                 // each view writes into its own array layer at full size; the composite pass
                 // arranges the four layers into a 2x2 grid on the canvas
-                viewport.x = 0;
-                viewport.y = 0;
-                viewport.z = width;
-                viewport.w = height;
+                view.setViewport(0, 0, width, height);
             } else {
                 // WebGL: 4 sub-viewports of a single canvas-sized backbuffer (2x2 grid).
                 // WebGL viewport y=0 is the bottom of the canvas, so views 0,1 go in the top
                 // row (y = height/2) to match the WebGPU composite's top-down layout.
-                viewport.x = (view.viewIndex % 2 === 0) ? 0 : width / 2;
-                viewport.y = (view.viewIndex < 2) ? height / 2 : 0;
-                viewport.z = width / 2;
-                viewport.w = height / 2;
+                view.setViewport(
+                    (viewIndex % 2 === 0) ? 0 : width / 2,
+                    (viewIndex < 2) ? height / 2 : 0,
+                    width / 2,
+                    height / 2
+                );
             }
         });
 

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1349,12 +1349,13 @@ class CameraComponent extends Component {
      * });
      */
     endXr(callback) {
-        if (!this._camera.xr) {
+        const xr = this.system.app.xr;
+        if (xr?.camera !== this.entity) {
             if (callback) callback(new Error('Camera is not in XR'));
             return;
         }
 
-        this._camera.xr.end(callback);
+        xr.end(callback);
     }
 
     /**

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -430,12 +430,6 @@ class XrManager extends EventHandler {
         }
 
         this._camera = camera;
-
-        // hand the scene camera the per-view data it needs for rendering. `views.list` is a stable
-        // array that the manager mutates in place each frame, so the camera tracks it by reference.
-        // Assigning it marks the camera as XR-active (a null assignment on session end clears it).
-        camera.camera.xrViews = this.views.list;
-
         this._type = type;
         this._spaceType = spaceType;
 
@@ -556,7 +550,6 @@ class XrManager extends EventHandler {
         navigator.xr.requestSession(type, options).then((session) => {
             this._onSessionStart(session, spaceType, callback);
         }).catch((ex) => {
-            this._camera.camera.xrViews = null;
             this._camera = null;
             this._type = null;
             this._spaceType = null;
@@ -707,6 +700,13 @@ class XrManager extends EventHandler {
         let failed = false;
 
         this._session = session;
+
+        // hand the scene camera the per-view data it needs for rendering, now that the session is
+        // established. `views.list` is a stable array the manager mutates in place each frame, so
+        // the camera tracks it by reference; assigning it marks the camera XR-active (cleared on
+        // session end). Deferred to here rather than start() so the camera stays on the mono path
+        // during the asynchronous session request.
+        this._camera.camera.xrViews = this.views.list;
 
         this.xrBridge = new XrBridge(this.app.graphicsDevice, this);
 

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -430,7 +430,12 @@ class XrManager extends EventHandler {
         }
 
         this._camera = camera;
-        this._camera.camera.xr = this;
+
+        // hand the scene camera the per-view data it needs for rendering. `views.list` is a stable
+        // array that the manager mutates in place each frame, so the camera tracks it by reference.
+        // Assigning it marks the camera as XR-active (a null assignment on session end clears it).
+        camera.camera.xrViews = this.views.list;
+
         this._type = type;
         this._spaceType = spaceType;
 
@@ -551,7 +556,7 @@ class XrManager extends EventHandler {
         navigator.xr.requestSession(type, options).then((session) => {
             this._onSessionStart(session, spaceType, callback);
         }).catch((ex) => {
-            this._camera.camera.xr = null;
+            this._camera.camera.xrViews = null;
             this._camera = null;
             this._type = null;
             this._spaceType = null;
@@ -722,7 +727,7 @@ class XrManager extends EventHandler {
             if (this._camera) {
                 this._camera.off('set_nearClip', onClipPlanesChange);
                 this._camera.off('set_farClip', onClipPlanesChange);
-                this._camera.camera.xr = null;
+                this._camera.camera.xrViews = null;
                 this._camera = null;
             }
 

--- a/src/framework/xr/xr-view.js
+++ b/src/framework/xr/xr-view.js
@@ -1,7 +1,5 @@
-import { EventHandler } from '../../core/event-handler.js';
+import { RenderView } from '../../scene/render-view.js';
 import { Texture } from '../../platform/graphics/texture.js';
-import { Vec4 } from '../../core/math/vec4.js';
-import { Mat3 } from '../../core/math/mat3.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, FILTER_NEAREST, PIXELFORMAT_RGB8, PIXELFORMAT_R32F } from '../../platform/graphics/constants.js';
 
@@ -16,7 +14,7 @@ import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, FILTER_NEAREST, PIXELFORMAT_RGB8,
  *
  * @category XR
  */
-class XrView extends EventHandler {
+class XrView extends RenderView {
     /**
      * Fired when the depth sensing texture has been resized. The {@link depthUvMatrix} needs
      * to be updated for relevant shaders. The handler is passed the new width and height of the
@@ -41,36 +39,6 @@ class XrView extends EventHandler {
      * @private
      */
     _xrView;
-
-    /**
-     * @type {Float32Array}
-     * @private
-     */
-    _positionData = new Float32Array(3);
-
-    /** @private */
-    _viewport = new Vec4();
-
-    /** @private */
-    _projMat = new Mat4();
-
-    /** @private */
-    _projViewOffMat = new Mat4();
-
-    /** @private */
-    _viewMat = new Mat4();
-
-    /** @private */
-    _viewOffMat = new Mat4();
-
-    /** @private */
-    _viewMat3 = new Mat3();
-
-    /** @private */
-    _viewInvMat = new Mat4();
-
-    /** @private */
-    _viewInvOffMat = new Mat4();
 
     /**
      * @type {XRCamera}
@@ -261,65 +229,6 @@ class XrView extends EventHandler {
     }
 
     /**
-     * A Vec4 (x, y, width, height) that represents a view's viewport. For a monoscopic screen,
-     * it will define fullscreen view. But for stereoscopic views (left/right eye), it will define
-     * a part of a whole screen that view is occupying.
-     *
-     * @type {Vec4}
-     */
-    get viewport() {
-        return this._viewport;
-    }
-
-    /**
-     * @type {Mat4}
-     * @ignore
-     */
-    get projMat() {
-        return this._projMat;
-    }
-
-    /**
-     * @type {Mat4}
-     * @ignore
-     */
-    get projViewOffMat() {
-        return this._projViewOffMat;
-    }
-
-    /**
-     * @type {Mat4}
-     * @ignore
-     */
-    get viewOffMat() {
-        return this._viewOffMat;
-    }
-
-    /**
-     * @type {Mat4}
-     * @ignore
-     */
-    get viewInvOffMat() {
-        return this._viewInvOffMat;
-    }
-
-    /**
-     * @type {Mat3}
-     * @ignore
-     */
-    get viewMat3() {
-        return this._viewMat3;
-    }
-
-    /**
-     * @type {Float32Array}
-     * @ignore
-     */
-    get positionData() {
-        return this._positionData;
-    }
-
-    /**
      * @param {XRFrame} frame - XRFrame from requestAnimationFrame callback.
      * @param {XRView} xrView - XRView from WebXR API.
      * @ignore
@@ -332,15 +241,15 @@ class XrView extends EventHandler {
 
         // viewport
         const viewport = this._manager.xrBridge.getViewport(frame, this._xrView);
-        this._viewport.x = viewport.x;
-        this._viewport.y = viewport.y;
-        this._viewport.z = viewport.width;
-        this._viewport.w = viewport.height;
+        this.setViewport(viewport.x, viewport.y, viewport.width, viewport.height);
 
-        // matrices
-        this._projMat.set(this._xrView.projectionMatrix);
-        this._viewMat.set(this._xrView.transform.inverse.matrix);
-        this._viewInvMat.set(this._xrView.transform.matrix);
+        // matrices: WebXR provides both the view-to-world (transform.matrix) and world-to-view
+        // (transform.inverse.matrix) matrices, so both are passed to avoid recomputing the inverse
+        this.setView(
+            this._xrView.projectionMatrix,
+            this._xrView.transform.matrix,
+            this._xrView.transform.inverse.matrix
+        );
 
         this._updateTextureColor();
         this._updateDepth(frame);
@@ -423,27 +332,6 @@ class XrView extends EventHandler {
         }
 
         if (resized) this.fire('depth:resize', width, height);
-    }
-
-    /**
-     * @param {Mat4|null} transform - World Transform of a parents GraphNode.
-     * @ignore
-     */
-    updateTransforms(transform) {
-        if (transform) {
-            this._viewInvOffMat.mul2(transform, this._viewInvMat);
-            this.viewOffMat.copy(this._viewInvOffMat).invert();
-        } else {
-            this._viewInvOffMat.copy(this._viewInvMat);
-            this.viewOffMat.copy(this._viewMat);
-        }
-
-        this._viewMat3.setFromMat4(this._viewOffMat);
-        this._projViewOffMat.mul2(this._projMat, this._viewOffMat);
-
-        this._positionData[0] = this._viewInvOffMat.data[12];
-        this._positionData[1] = this._viewInvOffMat.data[13];
-        this._positionData[2] = this._viewInvOffMat.data[14];
     }
 
     _onDeviceLost() {

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,7 @@ export { BatchGroup } from './scene/batching/batch-group.js';
 export { SkinBatchInstance } from './scene/batching/skin-batch-instance.js';
 export { BatchManager } from './scene/batching/batch-manager.js';
 export { Camera } from './scene/camera.js';
+export { RenderView } from './scene/render-view.js';
 export { WorldClusters } from './scene/lighting/world-clusters.js';
 export { ForwardRenderer } from './scene/renderer/forward-renderer.js';
 export { GraphNode } from './scene/graph-node.js';

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -522,7 +522,6 @@ class Camera {
      * null when not rendering an XR session. Set by the XR manager.
      *
      * @param {RenderView[]|null} value - The per-view list, or null when not in XR.
-     * @ignore
      */
     set xrViews(value) {
         // the projection source switches between XR and non-XR when XR activeness changes, so the
@@ -535,7 +534,6 @@ class Camera {
 
     /**
      * @type {RenderView[]|null}
-     * @ignore
      */
     get xrViews() {
         return this._xrViews;
@@ -545,7 +543,6 @@ class Camera {
      * True while an XR session owns this camera (equivalent to {@link Camera#xrViews} being set).
      *
      * @type {boolean}
-     * @ignore
      */
     get xrActive() {
         return this._xrViews !== null;
@@ -670,8 +667,6 @@ class Camera {
      * `device.renderVersion` (as {@link Camera#_storeShaderMatrices} does) - left as a future
      * optimization, as it needs checking against cameras that render multiple times per frame
      * (e.g. multiple render targets).
-     *
-     * @ignore
      */
     updateViewTransforms() {
         const views = this.xrViews;

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -18,6 +18,7 @@ import { CameraShaderParams } from './camera-shader-params.js';
  * @import { GraphicsDevice } from '../platform/graphics/graphics-device.js'
  * @import { RenderTarget } from '../platform/graphics/render-target.js'
  * @import { FogParams } from './fog-params.js'
+ * @import { RenderView } from './render-view.js'
  * @import { ShaderPassInfo } from './shader-pass.js'
  */
 
@@ -190,8 +191,12 @@ class Camera {
 
         this.frustum = new Frustum();
 
-        // Set by XrManager
-        this._xr = null;
+        // Set by XrManager when an XR session takes over this camera: a reference to the manager's
+        // live per-view array (matrices, viewports, updated each frame), or null when not in XR.
+        // `xrActive` is derived from it. This replaces the previous back-pointer to the XrManager,
+        // keeping the scene layer decoupled from the framework XR module.
+        /** @type {RenderView[]|null} */
+        this._xrViews = null;
         this._xrProperties = {
             horizontalFov: this._horizontalFov,
             fov: this._fov,
@@ -247,7 +252,7 @@ class Camera {
     }
 
     get aspectRatio() {
-        if (this.xr?.active) return this._xrProperties.aspectRatio;
+        if (this.xrActive) return this._xrProperties.aspectRatio;
 
         // in ASPECT_AUTO mode, always recompute from current inputs (render target / backbuffer
         // size and rect). The computation is trivially cheap, and this avoids a few complexities.
@@ -353,7 +358,7 @@ class Camera {
     }
 
     get farClip() {
-        return (this.xr?.active) ? this._xrProperties.farClip : this._farClip;
+        return (this.xrActive) ? this._xrProperties.farClip : this._farClip;
     }
 
     set flipFaces(newValue) {
@@ -372,7 +377,7 @@ class Camera {
     }
 
     get fov() {
-        return (this.xr?.active) ? this._xrProperties.fov : this._fov;
+        return (this.xrActive) ? this._xrProperties.fov : this._fov;
     }
 
     set frustumCulling(newValue) {
@@ -391,7 +396,7 @@ class Camera {
     }
 
     get horizontalFov() {
-        return (this.xr?.active) ? this._xrProperties.horizontalFov : this._horizontalFov;
+        return (this.xrActive) ? this._xrProperties.horizontalFov : this._horizontalFov;
     }
 
     set layers(newValue) {
@@ -415,7 +420,7 @@ class Camera {
     }
 
     get nearClip() {
-        return (this.xr?.active) ? this._xrProperties.nearClip : this._nearClip;
+        return (this.xrActive) ? this._xrProperties.nearClip : this._nearClip;
     }
 
     set node(newValue) {
@@ -512,15 +517,38 @@ class Camera {
         return this._shutter;
     }
 
-    set xr(newValue) {
-        if (this._xr !== newValue) {
-            this._xr = newValue;
+    /**
+     * Sets the list of {@link RenderView}s this camera renders with (one per XR eye/screen), or
+     * null when not rendering an XR session. Set by the XR manager.
+     *
+     * @param {RenderView[]|null} value - The per-view list, or null when not in XR.
+     * @ignore
+     */
+    set xrViews(value) {
+        // the projection source switches between XR and non-XR when XR activeness changes, so the
+        // cached projection matrix must be invalidated on that transition
+        if ((value !== null) !== (this._xrViews !== null)) {
             this._projMatDirty = true;
         }
+        this._xrViews = value;
     }
 
-    get xr() {
-        return this._xr;
+    /**
+     * @type {RenderView[]|null}
+     * @ignore
+     */
+    get xrViews() {
+        return this._xrViews;
+    }
+
+    /**
+     * True while an XR session owns this camera (equivalent to {@link Camera#xrViews} being set).
+     *
+     * @type {boolean}
+     * @ignore
+     */
+    get xrActive() {
+        return this._xrViews !== null;
     }
 
     /**
@@ -633,6 +661,30 @@ class Camera {
     }
 
     /**
+     * Refreshes the derived per-view matrices of all {@link Camera#xrViews}, using this camera's
+     * parent world transform. The renderer (and the gsplat passes, which run earlier in the frame)
+     * call this before reading the per-view matrices.
+     *
+     * Note: this recomputes on every call. Within a frame the parent transform is stable, so the
+     * 2-3 calls/frame could be collapsed to a single recompute by guarding on
+     * `device.renderVersion` (as {@link Camera#_storeShaderMatrices} does) - left as a future
+     * optimization, as it needs checking against cameras that render multiple times per frame
+     * (e.g. multiple render targets).
+     *
+     * @ignore
+     */
+    updateViewTransforms() {
+        const views = this.xrViews;
+        if (!views) {
+            return;
+        }
+        const parentWorldTransform = this._node?.parent?.getWorldTransform() ?? null;
+        for (let i = 0; i < views.length; i++) {
+            views[i].updateTransforms(parentWorldTransform);
+        }
+    }
+
+    /**
      * Updates {@link Camera#frustum} to the combined volume of all XR views, to avoid culling
      * objects visible in any view (e.g. the right edge of the right eye in stereo rendering).
      * The views are merged conservatively via {@link Frustum#add}, which handles the asymmetric
@@ -644,7 +696,7 @@ class Camera {
      * @ignore
      */
     updateXrFrustum() {
-        const views = this.xr?.views.list;
+        const views = this.xrViews;
         if (!views?.length) {
             return false;
         }

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -1657,13 +1657,13 @@ class GSplatManager {
         // Match Renderer#setCameraUniforms: in stereo XR the XR session reports the per-eye
         // viewport directly, which is correct for both side-by-side single-texture and
         // multi-pass per-eye-view layouts — preferred over inferring from target.width.
-        const xrView = sceneCam.xr?.session ? sceneCam.xr.views.list[0] : null;
+        const xrView = sceneCam.xrActive ? (sceneCam.xrViews[0] ?? null) : null;
         const viewportWidth = Math.floor((xrView ? xrView.viewport.z : (rt ? rt.width : this.device.width)) * rect.z);
         const viewportHeight = Math.floor((xrView ? xrView.viewport.w : (rt ? rt.height : this.device.height)) * rect.w);
 
         // Stereo XR: project both eyes in a single projector pass (GSPLAT_XR variant). Requires
         // exactly 2 parallel-axis views. Keep the VS define in sync with the projector variant.
-        const xrViewCount = sceneCam.xr?.session ? sceneCam.xr.views.list.length : 0;
+        const xrViewCount = sceneCam.xrActive ? sceneCam.xrViews.length : 0;
         if (xrViewCount > 2) {
             Debug.errorOnce(`GSplatManager: the hybrid GPU-sort renderer supports at most 2 XR views (stereo), but the session has ${xrViewCount}. Additional views will not render correctly.`);
         }
@@ -1901,16 +1901,13 @@ class GSplatManager {
 
         const cam = cameraNode.camera;
         const sceneCamera = cam.camera;
-        const xrViews = sceneCamera.xr?.views.list;
+        const xrViews = sceneCamera.xrViews;
         if (xrViews?.length) {
             // XR: cull against the combined frustum of all views, so splats visible only near
             // one eye's edge (e.g. the right edge of the right eye) are not dropped. The per-view
             // "off" matrices are refreshed at render time by setCameraUniforms, which runs AFTER
             // this culling, so refresh them here (mirrors the projector dispatch).
-            const parent = cameraNode.parent?.getWorldTransform() ?? null;
-            for (let v = 0; v < xrViews.length; v++) {
-                xrViews[v].updateTransforms(parent);
-            }
+            sceneCamera.updateViewTransforms();
             sceneCamera.updateXrFrustum();
             this.workBuffer.frustumCuller.setFrustumPlanes(sceneCamera.frustum);
         } else {

--- a/src/scene/gsplat-unified/gsplat-projector.js
+++ b/src/scene/gsplat-unified/gsplat-projector.js
@@ -637,7 +637,7 @@ class GSplatProjector {
      * compensation into the cached alpha. Ignored in pick mode (picking only gates on a
      * binary opacity threshold), which keeps the projector variant count down.
      * @param {boolean} [params.isStereo] - Whether to project both XR eyes in a single pass
-     * (GSPLAT_XR variant). Requires `cameraNode.camera.camera.xr.views.list` to have 2 views.
+     * (GSPLAT_XR variant). Requires `cameraNode.camera.camera.xrViews` to have 2 views.
      * Mutually exclusive with pick and fisheye.
      */
     dispatch(params) {
@@ -730,10 +730,8 @@ class GSplatProjector {
             // applyShaderProjectionTransform). Eye 0 drives the shared covariance/depth/sort; eye 1
             // contributes only its screen position. The per-eye "off" matrices are refreshed at
             // render time by setCameraUniforms, which runs AFTER this dispatch, so refresh them here.
-            const views = cam.xr.views.list;
-            const parent = cameraNode.parent?.getWorldTransform() ?? null;
-            views[0].updateTransforms(parent);
-            views[1].updateTransforms(parent);
+            const views = cam.xrViews;
+            cam.updateViewTransforms();
             _viewProjData.set(views[0].projViewOffMat.data);
             _viewProj1Data.set(views[1].projViewOffMat.data);
             _viewData.set(views[0].viewOffMat.data);

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -84,7 +84,7 @@ class GSplatRenderer {
      * @returns {number} The fisheye strength to use (0 while in XR, otherwise `fisheye`).
      */
     resolveFisheye(fisheye) {
-        const xrActive = !!this.cameraNode.camera?.camera?.xr?.session;
+        const xrActive = !!this.cameraNode.camera?.camera?.xrActive;
         if (xrActive && fisheye > 0) {
             Debug.warnOnce('GSplat: fisheye projection is not supported in XR; disabling it.');
             return 0;

--- a/src/scene/render-view.js
+++ b/src/scene/render-view.js
@@ -1,0 +1,208 @@
+import { EventHandler } from '../core/event-handler.js';
+import { Vec4 } from '../core/math/vec4.js';
+import { Mat3 } from '../core/math/mat3.js';
+import { Mat4 } from '../core/math/mat4.js';
+
+/**
+ * Represents a single view of the scene - a region of the render target rendered from a single
+ * viewpoint. A standard camera produces one view, while in XR each eye (or screen) is a separate
+ * view. This is the base class for {@link XrView}.
+ *
+ * @category Graphics
+ */
+class RenderView extends EventHandler {
+    /**
+     * World space position of the view, used by shaders. Derived by {@link updateTransforms}.
+     *
+     * @type {Float32Array}
+     * @private
+     */
+    _positionData = new Float32Array(3);
+
+    /**
+     * The viewport (x, y, width, height) this view renders into.
+     *
+     * @type {Vec4}
+     * @private
+     */
+    _viewport = new Vec4();
+
+    /**
+     * Projection matrix, supplied by the producer.
+     *
+     * @type {Mat4}
+     * @private
+     */
+    _projMat = new Mat4();
+
+    /**
+     * Combined projection * view matrix, with the camera's parent transform applied. Derived.
+     *
+     * @type {Mat4}
+     * @private
+     */
+    _projViewOffMat = new Mat4();
+
+    /**
+     * View matrix (world-to-view), supplied by the producer.
+     *
+     * @type {Mat4}
+     * @private
+     */
+    _viewMat = new Mat4();
+
+    /**
+     * View matrix with the camera's parent transform applied. Derived.
+     *
+     * @type {Mat4}
+     * @private
+     */
+    _viewOffMat = new Mat4();
+
+    /**
+     * 3x3 rotational part of {@link _viewOffMat}. Derived.
+     *
+     * @type {Mat3}
+     * @private
+     */
+    _viewMat3 = new Mat3();
+
+    /**
+     * Inverse view matrix (view-to-world), supplied by the producer.
+     *
+     * @type {Mat4}
+     * @private
+     */
+    _viewInvMat = new Mat4();
+
+    /**
+     * Inverse view matrix with the camera's parent transform applied. Derived.
+     *
+     * @type {Mat4}
+     * @private
+     */
+    _viewInvOffMat = new Mat4();
+
+    /**
+     * A Vec4 (x, y, width, height) that represents the view's viewport. For a monoscopic screen it
+     * defines the fullscreen view; for stereoscopic views (left/right eye) it defines the part of
+     * the screen the view occupies.
+     *
+     * @type {Vec4}
+     */
+    get viewport() {
+        return this._viewport;
+    }
+
+    /**
+     * @type {Mat4}
+     * @ignore
+     */
+    get projMat() {
+        return this._projMat;
+    }
+
+    /**
+     * @type {Mat4}
+     * @ignore
+     */
+    get projViewOffMat() {
+        return this._projViewOffMat;
+    }
+
+    /**
+     * @type {Mat4}
+     * @ignore
+     */
+    get viewOffMat() {
+        return this._viewOffMat;
+    }
+
+    /**
+     * @type {Mat4}
+     * @ignore
+     */
+    get viewInvOffMat() {
+        return this._viewInvOffMat;
+    }
+
+    /**
+     * @type {Mat3}
+     * @ignore
+     */
+    get viewMat3() {
+        return this._viewMat3;
+    }
+
+    /**
+     * @type {Float32Array}
+     * @ignore
+     */
+    get positionData() {
+        return this._positionData;
+    }
+
+    /**
+     * Sets the projection and pose matrices for this view. Each matrix is supplied as a 16-element
+     * array (a `Float32Array` from WebXR, or the `data` of a {@link Mat4}). The inverse view matrix
+     * (view-to-world) is the source of truth; the view matrix is optional and is derived by
+     * inverting it when not supplied (WebXR provides both, so it is passed to avoid the inverse).
+     *
+     * @param {Float32Array|number[]} projMat - Projection matrix data (16 elements).
+     * @param {Float32Array|number[]} viewInvMat - Inverse view (view-to-world) matrix data (16
+     * elements).
+     * @param {Float32Array|number[]} [viewMat] - View (world-to-view) matrix data (16 elements). If
+     * omitted, it is computed by inverting `viewInvMat`.
+     * @ignore
+     */
+    setView(projMat, viewInvMat, viewMat) {
+        this._projMat.set(projMat);
+        this._viewInvMat.set(viewInvMat);
+        if (viewMat) {
+            this._viewMat.set(viewMat);
+        } else {
+            this._viewMat.copy(this._viewInvMat).invert();
+        }
+    }
+
+    /**
+     * Sets the viewport this view renders into.
+     *
+     * @param {number} x - The x coordinate of the viewport.
+     * @param {number} y - The y coordinate of the viewport.
+     * @param {number} width - The width of the viewport.
+     * @param {number} height - The height of the viewport.
+     * @ignore
+     */
+    setViewport(x, y, width, height) {
+        this._viewport.set(x, y, width, height);
+    }
+
+    /**
+     * Updates the derived "off" matrices from the supplied view matrices and the camera's parent
+     * world transform. Cheap and idempotent, so it can be called multiple times per frame (the
+     * gsplat passes refresh these before {@link Renderer#setCameraUniforms} runs).
+     *
+     * @param {Mat4|null} parentWorldTransform - World transform of the camera's parent node, or
+     * null when the camera has no parent.
+     * @ignore
+     */
+    updateTransforms(parentWorldTransform) {
+        if (parentWorldTransform) {
+            this._viewInvOffMat.mul2(parentWorldTransform, this._viewInvMat);
+            this._viewOffMat.copy(this._viewInvOffMat).invert();
+        } else {
+            this._viewInvOffMat.copy(this._viewInvMat);
+            this._viewOffMat.copy(this._viewMat);
+        }
+
+        this._viewMat3.setFromMat4(this._viewOffMat);
+        this._projViewOffMat.mul2(this._projMat, this._viewOffMat);
+
+        this._positionData[0] = this._viewInvOffMat.data[12];
+        this._positionData[1] = this._viewInvOffMat.data[13];
+        this._positionData[2] = this._viewInvOffMat.data[14];
+    }
+}
+
+export { RenderView };

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -614,7 +614,7 @@ class ForwardRenderer extends Renderer {
         const clusteredLightingEnabled = scene.clusteredLightingEnabled;
 
         // multiview xr rendering
-        const viewList = camera.xr?.session && camera.xr.views.list.length ? camera.xr.views.list : null;
+        const viewList = camera.xrActive && camera.xrViews.length ? camera.xrViews : null;
 
         // when the FramePassMultiView wrapper is iterating XR views, render only the active one
         // (xrCurrentViewIndex === -1 means "no wrapper active": fall back to the default behaviour
@@ -1034,17 +1034,17 @@ class ForwardRenderer extends Renderer {
 
     /**
      * @param {any} camera - The camera component for the current render action. The XR data lives on
-     * the underlying `Camera` (`CameraComponent.camera.xr`), not on the component itself, so we
-     * dereference it before checking.
+     * the underlying `Camera` (`CameraComponent.camera`), as `xrActive` / `xrViews`, not on the
+     * component itself, so we dereference it before checking.
      * @returns {boolean} True if the camera should have its passes replicated per XR view (currently
      * gated to the WebGPU backend; other backends keep the existing single-pass multi-viewport flow).
      * @private
      */
     _isMultiview(camera) {
-        const xr = camera.camera?.xr;
+        const sceneCamera = camera.camera;
         return this.device.isWebGPU &&
-            !!xr?.session &&
-            xr.views.list.length >= 2;
+            !!sceneCamera?.xrActive &&
+            sceneCamera.xrViews.length >= 2;
     }
 
     /**

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -313,16 +313,11 @@ class Renderer {
         const flipY = target?.flipY;
 
         let viewList = null;
-        if (camera.xr && camera.xr.session) {
-            const transform = camera._node?.parent?.getWorldTransform() || null;
-            const views = camera.xr.views;
-            viewList = views.list;
+        if (camera.xrActive) {
+            viewList = camera.xrViews;
 
-            // update transforms for all views
-            for (let v = 0; v < viewList.length; v++) {
-                const view = viewList[v];
-                view.updateTransforms(transform);
-            }
+            // refresh the derived per-view matrices for all views
+            camera.updateViewTransforms();
         } else {
 
             // Projection Matrix
@@ -419,7 +414,7 @@ class Renderer {
         // viewport size. In stereo XR the XR session reports the per-eye viewport directly,
         // which is correct for both side-by-side single-texture and multi-pass per-eye-view
         // layouts — preferred over inferring from target.width.
-        const xrView = camera.xr?.session ? camera.xr.views.list[0] : null;
+        const xrView = camera.xrActive ? (camera.xrViews[0] ?? null) : null;
         let viewportWidth = xrView ? xrView.viewport.z : (target ? target.width : this.device.width);
         let viewportHeight = xrView ? xrView.viewport.w : (target ? target.height : this.device.height);
         viewportWidth *= camera.rect.z;


### PR DESCRIPTION
Closes #5011.

### Background

When an XR session was active, the XR manager pointed the scene `Camera` at itself (`camera.camera.xr = manager`) purely so the renderer could reach the manager's per-view array. That made the **scene** layer (`renderer`, `forward-renderer`, unified gsplat) reach up into the **framework** XR module. This moves the per-view data onto the `Camera`, so the XR manager just updates it.

### Changes

- **New `RenderView` class** (`src/scene/render-view.js`) — a single view's projection / view matrices, viewport, and the derived "off" matrices, plus `updateTransforms()`. `XrView` now extends it and populates it from the WebXR frame (`setView` / `setViewport`). `RenderView` stays public because `XrView.viewport` was already public.
- **`Camera` owns the views** — `camera.xrViews` is the per-view list (`null` when not in XR), and `xrActive` is derived from it, replacing the manager back-pointer. `Camera.updateViewTransforms()` refreshes the per-view derived matrices (called by the renderer and the gsplat passes).
- **Consumers updated** — `renderer.js`, `forward-renderer.js` (`_isMultiview`), and the unified gsplat code read `camera.xrViews` / `xrActive` instead of `camera.xr.*`. `CameraComponent.endXr` now goes through `app.xr`.
- **Examples** — the two `xr-views` examples construct `pc.RenderView` directly instead of mocking the manager's `xr` object.

### Notes

- Relies on the dynamic-uniform-buffer bind-group fix from #8906 (already merged) for the WebGPU multiview `xr-views` example to render all views correctly.
- Net `-94` lines (the `RenderView` extraction removes duplication).
