### PR TITLE
[BREAKING] Move gsplat lodRangeMin/lodRangeMax to GSplatComponent

### DIFF
--- a/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting-xr/vr-lod.example.mjs
@@ -415,9 +415,9 @@ assetListLoader.load(() => {
 
     const applyPreset = () => {
         const presetData = LOD_PRESETS[lodPresetKey] || LOD_PRESETS.desktop;
-        app.scene.gsplat.lodRangeMin = presetData.range[0];
-        app.scene.gsplat.lodRangeMax = presetData.range[1];
         if (gsplatGs) {
+            gsplatGs.lodRangeMin = presetData.range[0];
+            gsplatGs.lodRangeMax = presetData.range[1];
             gsplatGs.lodBaseDistance = presetData.lodBaseDistance;
             gsplatGs.lodMultiplier = presetData.lodMultiplier;
         }
@@ -450,8 +450,8 @@ assetListLoader.load(() => {
         const lodLevels = gsplatGs.resource?.octree?.lodLevels;
         if (lodLevels) {
             const worstLod = lodLevels - 1;
-            app.scene.gsplat.lodRangeMin = worstLod;
-            app.scene.gsplat.lodRangeMax = worstLod;
+            gsplatGs.lodRangeMin = worstLod;
+            gsplatGs.lodRangeMax = worstLod;
         }
 
         const onFrameReady = (/** @type {any} */ cam, /** @type {any} */ layer, /** @type {boolean} */ ready, /** @type {number} */ loadingCount) => {

--- a/examples/src/examples/gaussian-splatting/billions.example.mjs
+++ b/examples/src/examples/gaussian-splatting/billions.example.mjs
@@ -268,6 +268,21 @@ assetListLoader.load(() => {
         return { pos: [x, y, z], eulerX };
     };
 
+    // Start at the lowest LOD for a fast initial display, then open up to the FULL LOD range
+    // (all levels, 0..worst) once the first frame's data is ready. The range is per-component,
+    // so it is applied to every tile on creation and whenever it changes.
+    const lodLevels = /** @type {any} */ (assets.scene.resource).octree?.lodLevels ?? 1;
+    const worstLod = lodLevels - 1;
+    const lodRange = { min: worstLod, max: worstLod };
+    const applyLodRange = (min, max) => {
+        lodRange.min = min;
+        lodRange.max = max;
+        gsInstances.forEach((gs) => {
+            gs.lodRangeMin = min;
+            gs.lodRangeMax = max;
+        });
+    };
+
     // Add/remove entities to match the requested count. Newly added tiles are positioned and
     // LOD-configured once, on creation; surplus tiles are destroyed from the end. Tiles that
     // remain are left completely untouched, so the shared streamed resource isn't re-fetched
@@ -287,6 +302,8 @@ assetListLoader.load(() => {
             const gs = /** @type {any} */ (entity.gsplat);
             gs.lodBaseDistance = data.get('lodBaseDistance');
             gs.lodMultiplier = data.get('lodMultiplier');
+            gs.lodRangeMin = lodRange.min;
+            gs.lodRangeMax = lodRange.max;
             gsInstances.push(gs);
         }
         while (instanceEntities.length > N) {
@@ -301,19 +318,11 @@ assetListLoader.load(() => {
     rebuildInstances();
     data.on('instances:set', rebuildInstances);
 
-    // Start at the lowest LOD for a fast initial display, then open up to the FULL LOD range
-    // (all levels, 0..worst) once the first frame's data is ready.
-    const lodLevels = /** @type {any} */ (assets.scene.resource).octree?.lodLevels ?? 1;
-    const worstLod = lodLevels - 1;
-    app.scene.gsplat.lodRangeMin = worstLod;
-    app.scene.gsplat.lodRangeMax = worstLod;
-
     const gsplatSystem = /** @type {any} */ (app.systems.gsplat);
     const onFrameReady = (/** @type {any} */ cam, /** @type {any} */ layer, /** @type {boolean} */ ready, /** @type {number} */ loadingCount) => {
         if (ready && loadingCount === 0) {
             gsplatSystem.off('frame:ready', onFrameReady);
-            app.scene.gsplat.lodRangeMin = 0;
-            app.scene.gsplat.lodRangeMax = worstLod;
+            applyLodRange(0, worstLod);
             // reveal the backdrop now, together with the loaded scene (not before it)
             app.scene.skybox = skyboxCubemap;
         }

--- a/examples/src/examples/gaussian-splatting/depth-of-field.example.mjs
+++ b/examples/src/examples/gaussian-splatting/depth-of-field.example.mjs
@@ -130,15 +130,15 @@ assetListLoader.load(() => {
     // streams in) and enable Depth of Field at the same time.
     const lodLevels = splat.gsplat.resource?.octree?.lodLevels;
     if (lodLevels) {
-        app.scene.gsplat.lodRangeMin = lodLevels - 1;
-        app.scene.gsplat.lodRangeMax = lodLevels - 1;
+        splat.gsplat.lodRangeMin = lodLevels - 1;
+        splat.gsplat.lodRangeMax = lodLevels - 1;
     }
     const onFrameReady = (camera, layer, ready, loadingCount) => {
         if (ready && loadingCount === 0) {
             app.systems.gsplat.off('frame:ready', onFrameReady);
             if (lodLevels) {
-                app.scene.gsplat.lodRangeMin = 0;
-                app.scene.gsplat.lodRangeMax = lodLevels - 1;
+                splat.gsplat.lodRangeMin = 0;
+                splat.gsplat.lodRangeMax = lodLevels - 1;
             }
             data.set('data.dof.enabled', true);
         }

--- a/examples/src/examples/gaussian-splatting/downtown.example.mjs
+++ b/examples/src/examples/gaussian-splatting/downtown.example.mjs
@@ -207,14 +207,18 @@ assetListLoader.load(() => {
     // Start with the 4 lowest (coarsest) LODs for a fast initial display that still gets some
     // nearby detail, then open up to the full range once the first frame's data is ready.
     const worstLod = lodLevels - 1;
-    app.scene.gsplat.lodRangeMin = Math.max(0, worstLod - 3);
-    app.scene.gsplat.lodRangeMax = worstLod;
+    gsInstances.forEach((gs) => {
+        gs.lodRangeMin = Math.max(0, worstLod - 3);
+        gs.lodRangeMax = worstLod;
+    });
     const gsplatSystem = /** @type {any} */ (app.systems.gsplat);
     const onFrameReady = (/** @type {any} */ cam, /** @type {any} */ layer, /** @type {boolean} */ ready, /** @type {number} */ loadingCount) => {
         if (ready && loadingCount === 0) {
             gsplatSystem.off('frame:ready', onFrameReady);
-            app.scene.gsplat.lodRangeMin = 0;
-            app.scene.gsplat.lodRangeMax = worstLod;
+            gsInstances.forEach((gs) => {
+                gs.lodRangeMin = 0;
+                gs.lodRangeMax = worstLod;
+            });
             // reveal the backdrop and sweep the splats in, together, now that the scene is ready
             app.scene.skybox = skyboxCubemap;
             revealStarted = true;

--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
@@ -151,8 +151,8 @@ assetListLoader.load(() => {
     const applyPreset = () => {
         const preset = data.get('lodPreset');
         const presetData = LOD_PRESETS[preset] || LOD_PRESETS.desktop;
-        app.scene.gsplat.lodRangeMin = presetData.range[0];
-        app.scene.gsplat.lodRangeMax = presetData.range[1];
+        gs.lodRangeMin = presetData.range[0];
+        gs.lodRangeMax = presetData.range[1];
         gs.lodBaseDistance = presetData.lodBaseDistance;
         data.set('lodBaseDistance', presetData.lodBaseDistance);
     };

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -425,9 +425,9 @@ assetListLoader.load(async () => {
     const applyPreset = () => {
         const preset = data.get('lodPreset');
         const presetData = LOD_PRESETS[preset] || LOD_PRESETS.desktop;
-        app.scene.gsplat.lodRangeMin = presetData.range[0];
-        app.scene.gsplat.lodRangeMax = presetData.range[1];
         if (gsplatGs) {
+            gsplatGs.lodRangeMin = presetData.range[0];
+            gsplatGs.lodRangeMax = presetData.range[1];
             gsplatGs.lodBaseDistance = presetData.lodBaseDistance;
             gsplatGs.lodMultiplier = presetData.lodMultiplier;
         }
@@ -484,8 +484,8 @@ assetListLoader.load(async () => {
         const lodLevels = gsplatGs.resource?.octree?.lodLevels;
         if (lodLevels) {
             const worstLod = lodLevels - 1;
-            app.scene.gsplat.lodRangeMin = worstLod;
-            app.scene.gsplat.lodRangeMax = worstLod;
+            gsplatGs.lodRangeMin = worstLod;
+            gsplatGs.lodRangeMax = worstLod;
         }
 
         const onFrameReady = (/** @type {any} */ cam, /** @type {any} */ layer, /** @type {boolean} */ ready, /** @type {number} */ loadingCount) => {

--- a/examples/src/examples/gaussian-splatting/relighting.example.mjs
+++ b/examples/src/examples/gaussian-splatting/relighting.example.mjs
@@ -634,9 +634,9 @@ assetListLoader.load(async () => {
     const applyPreset = () => {
         const preset = data.get('lodPreset');
         const presetData = LOD_PRESETS[preset] || LOD_PRESETS.desktop;
-        app.scene.gsplat.lodRangeMin = presetData.range[0];
-        app.scene.gsplat.lodRangeMax = presetData.range[1];
         if (gsplatGs) {
+            gsplatGs.lodRangeMin = presetData.range[0];
+            gsplatGs.lodRangeMax = presetData.range[1];
             gsplatGs.lodBaseDistance = presetData.lodBaseDistance;
             gsplatGs.lodMultiplier = presetData.lodMultiplier;
         }
@@ -693,8 +693,8 @@ assetListLoader.load(async () => {
         const lodLevels = gsplatGs.resource?.octree?.lodLevels;
         if (lodLevels) {
             const worstLod = lodLevels - 1;
-            app.scene.gsplat.lodRangeMin = worstLod;
-            app.scene.gsplat.lodRangeMax = worstLod;
+            gsplatGs.lodRangeMin = worstLod;
+            gsplatGs.lodRangeMax = worstLod;
         }
 
         const onFrameReady = (/** @type {any} */ cam, /** @type {any} */ layer, /** @type {boolean} */ ready, /** @type {number} */ loadingCount) => {

--- a/examples/src/examples/gaussian-splatting/splat-portal.example.mjs
+++ b/examples/src/examples/gaussian-splatting/splat-portal.example.mjs
@@ -104,10 +104,6 @@ assetListLoader.load(() => {
     app.scene.gsplat.lodUnderfillLimit = 5;
     app.scene.gsplat.splatBudget = pc.platform.mobile ? 500000 : 1500000;
 
-    // start with the lowest LOD until the first frame settles, then unlock the full range
-    app.scene.gsplat.lodRangeMin = 4;
-    app.scene.gsplat.lodRangeMax = 5;
-
     // ---------- Layer setup ----------
     // Each splat scene has its own dedicated layer (outsideLayer for Parish,
     // insideLayer for Skatepark). The data on each layer never changes - we
@@ -373,6 +369,9 @@ assetListLoader.load(() => {
         const gs = /** @type {any} */ (entity.gsplat);
         gs.lodBaseDistance = config.lodBaseDistance;
         gs.lodMultiplier = config.lodMultiplier;
+        // start with the lowest LOD until the first frame settles, then unlock the full range
+        gs.lodRangeMin = 4;
+        gs.lodRangeMax = 5;
 
         sceneStates.set(config.layer, { entity, fromTransform, throughTransform });
     });
@@ -665,8 +664,11 @@ assetListLoader.load(() => {
     const onFrameReady = (/** @type {any} */ cam, /** @type {any} */ layer, /** @type {boolean} */ ready, /** @type {number} */ loadingCount) => {
         if (ready && loadingCount === 0) {
             gsplatSystem.off('frame:ready', onFrameReady);
-            app.scene.gsplat.lodRangeMin = 0;
-            app.scene.gsplat.lodRangeMax = 5;
+            for (const { entity } of sceneStates.values()) {
+                const gs = /** @type {any} */ (entity.gsplat);
+                gs.lodRangeMin = 0;
+                gs.lodRangeMax = 5;
+            }
         }
     };
     gsplatSystem.on('frame:ready', onFrameReady);

--- a/examples/src/examples/gaussian-splatting/world.example.mjs
+++ b/examples/src/examples/gaussian-splatting/world.example.mjs
@@ -141,9 +141,6 @@ assetListLoader.load(() => {
     const preset = pc.platform.mobile ? 'mobile' : 'desktop';
     const presetData = LOD_PRESETS[preset];
 
-    app.scene.gsplat.lodRangeMin = presetData.range[0];
-    app.scene.gsplat.lodRangeMax = presetData.range[1];
-
     // Create skatepark entity
     const skatepark = new pc.Entity('Skatepark');
     skatepark.addComponent('gsplat', {
@@ -157,6 +154,8 @@ assetListLoader.load(() => {
 
     // Apply LOD distances to skatepark
     const gs = /** @type {any} */ (skatepark.gsplat);
+    gs.lodRangeMin = presetData.range[0];
+    gs.lodRangeMax = presetData.range[1];
     gs.lodBaseDistance = presetData.lodBaseDistance;
     gs.lodMultiplier = 4;
 

--- a/scripts/esm/gsplat/streamed-gsplat.mjs
+++ b/scripts/esm/gsplat/streamed-gsplat.mjs
@@ -240,12 +240,10 @@ class StreamedGsplat extends Script {
         const range = this._getCurrentLodRange();
         if (!range) return;
 
-        const app = this.app;
-        app.scene.gsplat.lodRangeMin = range[0];
-        app.scene.gsplat.lodRangeMax = range[1];
-
         // Apply to main streaming asset only (environment doesn't support these settings)
         if (this.entity.gsplat) {
+            this.entity.gsplat.lodRangeMin = range[0];
+            this.entity.gsplat.lodRangeMax = range[1];
             this.entity.gsplat.lodBaseDistance = this._getCurrentLodBaseDistance();
             this.entity.gsplat.lodMultiplier = this._getCurrentLodMultiplier();
         }

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -115,6 +115,20 @@ class GSplatComponent extends Component {
     _lodMultiplier = 3;
 
     /**
+     * Minimum allowed LOD index (inclusive).
+     *
+     * @private
+     */
+    _lodRangeMin = 0;
+
+    /**
+     * Maximum allowed LOD index (inclusive).
+     *
+     * @private
+     */
+    _lodRangeMax = 99;
+
+    /**
      * @type {BoundingBox|null}
      * @private
      */
@@ -433,6 +447,54 @@ class GSplatComponent extends Component {
      */
     get lodMultiplier() {
         return this._lodMultiplier;
+    }
+
+    /**
+     * Sets the minimum allowed LOD index (inclusive) for this splat. The optimal LOD selected by
+     * distance is clamped so it never goes finer (lower index) than this value. The value is
+     * further clamped to the asset's valid LOD range `[0, octree.lodLevels - 1]` at use. Setting a
+     * higher minimum prevents downloading the highest quality (largest) LOD files. Defaults to 0.
+     *
+     * @type {number}
+     */
+    set lodRangeMin(value) {
+        this._lodRangeMin = value;
+        if (this._placement) {
+            this._placement.lodRangeMin = value;
+        }
+    }
+
+    /**
+     * Gets the minimum allowed LOD index.
+     *
+     * @type {number}
+     */
+    get lodRangeMin() {
+        return this._lodRangeMin;
+    }
+
+    /**
+     * Sets the maximum allowed LOD index (inclusive) for this splat. The optimal LOD selected by
+     * distance is clamped so it never goes coarser (higher index) than this value. The value is
+     * clamped to the asset's valid LOD range `[0, octree.lodLevels - 1]` at use, so the default of
+     * 99 effectively means "no cap". Defaults to 99.
+     *
+     * @type {number}
+     */
+    set lodRangeMax(value) {
+        this._lodRangeMax = value;
+        if (this._placement) {
+            this._placement.lodRangeMax = value;
+        }
+    }
+
+    /**
+     * Gets the maximum allowed LOD index.
+     *
+     * @type {number}
+     */
+    get lodRangeMax() {
+        return this._lodRangeMax;
     }
 
     /**
@@ -953,6 +1015,8 @@ class GSplatComponent extends Component {
             this._placement = new GSplatPlacement(resource, this.entity, 0, this._parameters, null, this._id);
             this._placement.lodBaseDistance = this._lodBaseDistance;
             this._placement.lodMultiplier = this._lodMultiplier;
+            this._placement.lodRangeMin = this._lodRangeMin;
+            this._placement.lodRangeMax = this._lodRangeMax;
             this._placement.workBufferUpdate = this._workBufferUpdate;
             this._placement.workBufferModifier = this._workBufferModifier;
 

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -464,7 +464,7 @@ class GSplatOctreeInstance {
         const { lodBaseDistance, lodMultiplier } = this.placement;
 
         // Clamp configured LOD range to valid bounds [0, maxLod] and ensure min <= max
-        const { lodRangeMin, lodRangeMax } = params;
+        const { lodRangeMin, lodRangeMax } = this.placement;
         const rangeMin = Math.max(0, Math.min(lodRangeMin ?? 0, maxLod));
         const rangeMax = Math.max(rangeMin, Math.min(lodRangeMax ?? maxLod, maxLod));
 
@@ -661,7 +661,7 @@ class GSplatOctreeInstance {
     evaluateOptimalLods(cameraNode, params, budgetScale = 1, globalMaxDistanceForBuckets = 0) {
         const maxLod = this.octree.lodLevels - 1;
         const { lodBaseDistance, lodMultiplier } = this.placement;
-        const { lodRangeMin, lodRangeMax } = params;
+        const { lodRangeMin, lodRangeMax } = this.placement;
         const rangeMin = Math.max(0, Math.min(lodRangeMin ?? 0, maxLod));
         const rangeMax = Math.max(rangeMin, Math.min(lodRangeMax ?? maxLod, maxLod));
 

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -379,52 +379,42 @@ class GSplatParams {
         return this._lodBehindPenalty;
     }
 
-    /** @private */
-    _lodRangeMin = 0;
-
     /**
-     * Minimum allowed LOD index (inclusive). Defaults to 0.
-     *
      * @type {number}
+     * @deprecated Set {@link GSplatComponent#lodRangeMin} on the gsplat component instead.
+     * @ignore
      */
     set lodRangeMin(value) {
-        if (this._lodRangeMin !== value) {
-            this._lodRangeMin = value;
-            this.dirty = true;
-        }
+        Debug.warnOnce('GSplatParams#lodRangeMin is deprecated. Use lodRangeMin on the GSplatComponent instead.');
     }
 
     /**
-     * Gets minimum allowed LOD index (inclusive).
-     *
      * @type {number}
+     * @deprecated Set {@link GSplatComponent#lodRangeMin} on the gsplat component instead.
+     * @ignore
      */
     get lodRangeMin() {
-        return this._lodRangeMin;
+        Debug.warnOnce('GSplatParams#lodRangeMin is deprecated. Use lodRangeMin on the GSplatComponent instead.');
+        return 0;
     }
 
-    /** @private */
-    _lodRangeMax = 10;
-
     /**
-     * Maximum allowed LOD index (inclusive). Defaults to 10.
-     *
      * @type {number}
+     * @deprecated Set {@link GSplatComponent#lodRangeMax} on the gsplat component instead.
+     * @ignore
      */
     set lodRangeMax(value) {
-        if (this._lodRangeMax !== value) {
-            this._lodRangeMax = value;
-            this.dirty = true;
-        }
+        Debug.warnOnce('GSplatParams#lodRangeMax is deprecated. Use lodRangeMax on the GSplatComponent instead.');
     }
 
     /**
-     * Gets maximum allowed LOD index (inclusive).
-     *
      * @type {number}
+     * @deprecated Set {@link GSplatComponent#lodRangeMax} on the gsplat component instead.
+     * @ignore
      */
     get lodRangeMax() {
-        return this._lodRangeMax;
+        Debug.warnOnce('GSplatParams#lodRangeMax is deprecated. Use lodRangeMax on the GSplatComponent instead.');
+        return 99;
     }
 
     /** @private */

--- a/src/scene/gsplat-unified/gsplat-placement.js
+++ b/src/scene/gsplat-unified/gsplat-placement.js
@@ -105,6 +105,48 @@ class GSplatPlacement {
     }
 
     /**
+     * Minimum allowed LOD index (inclusive). Clamped to the asset's valid range at use.
+     *
+     * @private
+     */
+    _lodRangeMin = 0;
+
+    /**
+     * Maximum allowed LOD index (inclusive). Clamped to the asset's valid range at use.
+     *
+     * @private
+     */
+    _lodRangeMax = 99;
+
+    /**
+     * @type {number}
+     */
+    set lodRangeMin(value) {
+        if (this._lodRangeMin !== value) {
+            this._lodRangeMin = value;
+            this.lodDirty = true;
+        }
+    }
+
+    get lodRangeMin() {
+        return this._lodRangeMin;
+    }
+
+    /**
+     * @type {number}
+     */
+    set lodRangeMax(value) {
+        if (this._lodRangeMax !== value) {
+            this._lodRangeMax = value;
+            this.lodDirty = true;
+        }
+    }
+
+    get lodRangeMax() {
+        return this._lodRangeMax;
+    }
+
+    /**
      * The axis-aligned bounding box for this placement, in local space.
      * Null means use resource.aabb as fallback.
      *


### PR DESCRIPTION
Moves `lodRangeMin` / `lodRangeMax` off the global `Scene#gsplat` (`GSplatParams`) onto the per-`GSplatComponent`, since the valid LOD range is asset-specific (depends on each asset's `octree.lodLevels`). The budget balancer already operated on per-instance ranges, so this just changes where the values originate.

**Changes:**
- Add `lodRangeMin` (default 0) and `lodRangeMax` (default 99) to `GSplatComponent`; the values flow through `GSplatPlacement` to the octree instance and are clamped to the asset's valid LOD range at use.
- Deprecate `GSplatParams#lodRangeMin` / `GSplatParams#lodRangeMax` as warn-once no-ops.
- Update gsplat examples and the `streamed-gsplat` script to set the range per component.

**API Changes (breaking):**
- `app.scene.gsplat.lodRangeMin` / `lodRangeMax` are now deprecated no-ops (warn once). Use the component instead:

Before:
```js
app.scene.gsplat.lodRangeMin = 0;
app.scene.gsplat.lodRangeMax = 3;
```
After:
```js
entity.gsplat.lodRangeMin = 0;
entity.gsplat.lodRangeMax = 3;
```
- New public API: `GSplatComponent#lodRangeMin` (default 0) and `GSplatComponent#lodRangeMax` (default 99). Note the max default is now 99 (effectively "no cap", clamped to the asset's max LOD), versus the old global default of 10.

**Examples:**
- Updated: downtown, billions, depth-of-field, relighting, lod-streaming, lod-streaming-sh, world, splat-portal, vr-lod.