### PR TITLE
Apply gsplat scene settings in applySceneSettings

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1417,6 +1417,24 @@ class AppBase extends EventHandler {
      * is subdivided into. Defaults to [10, 3, 10].
      *
      * Only lights with bakeDir=true will be used for generating the dominant light direction.
+     * @param {boolean} [settings.render.gsplatRadialSorting] - Enables radial sorting of Gaussian splats. Defaults to false.
+     * @param {number} [settings.render.gsplatLodUpdateDistance] - Distance threshold in world units to trigger gsplat LOD updates. Defaults to 1.
+     * @param {number} [settings.render.gsplatLodUpdateAngle] - Angle threshold in degrees to trigger gsplat LOD updates based on camera rotation. Defaults to 0.
+     * @param {number} [settings.render.gsplatLodBehindPenalty] - Multiplier applied to effective distance for gsplat nodes behind the camera. Defaults to 1.
+     * @param {number} [settings.render.gsplatLodUnderfillLimit] - Maximum number of gsplat LOD levels allowed below the optimal level when optimal data is not resident. Defaults to 0.
+     * @param {number} [settings.render.gsplatSplatBudget] - Target number of splats across all GSplats in the scene. 0 disables budget enforcement. Defaults to 0.
+     * @param {number} [settings.render.gsplatAlphaClip] - Alpha threshold for gsplat shadow, pick, and prepass rendering. Defaults to 0.3.
+     * @param {number} [settings.render.gsplatAlphaClipForward] - Alpha threshold for the forward gsplat rendering pass. Defaults to 1 / 255.
+     * @param {number} [settings.render.gsplatMinPixelSize] - Minimum screen-space pixel size below which splats are discarded. Defaults to 2.
+     * @param {number} [settings.render.gsplatMinContribution] - Minimum visual contribution threshold for the compute gsplat renderer. Defaults to 3.
+     * @param {number} [settings.render.gsplatFoveationStrength] - Foveated contribution culling strength. Defaults to 0.
+     * @param {number} [settings.render.gsplatFoveationCenter] - Protected centre radius for foveated contribution culling. Defaults to 0.3.
+     * @param {boolean} [settings.render.gsplatAntiAlias] - Enables anti-aliasing compensation for Gaussian splats. Defaults to false.
+     * @param {boolean} [settings.render.gsplatUseFog] - Whether to apply scene fog to Gaussian splats. Defaults to true.
+     * @param {number} [settings.render.gsplatColorUpdateAngle] - Viewing angle threshold in degrees for triggering gsplat spherical harmonics color updates. Defaults to 10.
+     * @param {number} [settings.render.gsplatCooldownTicks] - Number of update ticks before unloading unused streamed gsplat resources. Defaults to 100.
+     * @param {string} [settings.render.gsplatDataFormat] - Work buffer data format for gsplat rendering. One of the GSPLATDATA_* constants. Defaults to {@link GSPLATDATA_COMPACT}.
+     * @param {boolean} [settings.render.gsplatEnableIds] - Enables per-component ID storage in the gsplat work buffer. Defaults to false.
      * @example
      *
      * const settings = {

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -913,6 +913,38 @@ class GSplatParams {
     }
 
     /**
+     * Applies serialized scene settings (e.g. from the Editor) to the gsplat parameters. Reads
+     * flat `gsplat`-prefixed keys off the `render` settings object; missing keys leave the current
+     * value unchanged.
+     *
+     * @param {object} render - The render settings object.
+     * @ignore
+     */
+    applySettings(render) {
+        this.radialSorting = render.gsplatRadialSorting ?? this.radialSorting;
+
+        this.lodUpdateDistance = render.gsplatLodUpdateDistance ?? this.lodUpdateDistance;
+        this.lodUpdateAngle = render.gsplatLodUpdateAngle ?? this.lodUpdateAngle;
+        this.lodBehindPenalty = render.gsplatLodBehindPenalty ?? this.lodBehindPenalty;
+        this.lodUnderfillLimit = render.gsplatLodUnderfillLimit ?? this.lodUnderfillLimit;
+        this.splatBudget = render.gsplatSplatBudget ?? this.splatBudget;
+
+        this.alphaClip = render.gsplatAlphaClip ?? this.alphaClip;
+        this.alphaClipForward = render.gsplatAlphaClipForward ?? this.alphaClipForward;
+        this.minPixelSize = render.gsplatMinPixelSize ?? this.minPixelSize;
+        this.minContribution = render.gsplatMinContribution ?? this.minContribution;
+        this.foveationStrength = render.gsplatFoveationStrength ?? this.foveationStrength;
+        this.foveationCenter = render.gsplatFoveationCenter ?? this.foveationCenter;
+
+        this.antiAlias = render.gsplatAntiAlias ?? this.antiAlias;
+        this.useFog = render.gsplatUseFog ?? this.useFog;
+        this.colorUpdateAngle = render.gsplatColorUpdateAngle ?? this.colorUpdateAngle;
+        this.cooldownTicks = render.gsplatCooldownTicks ?? this.cooldownTicks;
+        this.dataFormat = render.gsplatDataFormat ?? this.dataFormat;
+        this.enableIds = render.gsplatEnableIds ?? this.enableIds;
+    }
+
+    /**
      * Called at the end of the frame to clear dirty flags.
      *
      * @ignore

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -809,6 +809,8 @@ class Scene extends EventHandler {
         this.clusteredLightingEnabled = render.clusteredLightingEnabled ?? false;
         this.lighting.applySettings(render);
 
+        this.gsplat.applySettings(render);
+
         // bake settings
         [
             'lightmapFilterEnabled',


### PR DESCRIPTION
Applies serialized scene render settings (e.g. from the Editor) to the gsplat parameters, so gsplat configuration round-trips through `AppBase#applySceneSettings` like fog, sky, and clustered lighting already do.

**Changes:**
- Add `GSplatParams#applySettings(render)` (internal) that reads flat `gsplat`-prefixed keys off the `render` settings object, assigning through the existing setters with fallbacks (missing keys leave the current value unchanged).
- Invoke it from `Scene#applySettings`, alongside the existing `sky` / `lighting` delegations.
- Document the supported `settings.render.gsplat*` keys in the `AppBase#applySceneSettings` JSDoc.

**Settings applied:**
`gsplatRadialSorting`, `gsplatLodUpdateDistance`, `gsplatLodUpdateAngle`, `gsplatLodBehindPenalty`, `gsplatLodUnderfillLimit`, `gsplatSplatBudget`, `gsplatAlphaClip`, `gsplatAlphaClipForward`, `gsplatMinPixelSize`, `gsplatMinContribution`, `gsplatFoveationStrength`, `gsplatFoveationCenter`, `gsplatAntiAlias`, `gsplatUseFog`, `gsplatColorUpdateAngle`, `gsplatCooldownTicks`, `gsplatDataFormat`, `gsplatEnableIds`.

No public API additions; this is additive and backward compatible.