### PR TITLE
Allow ArrayBuffer in StorageBuffer.write data type

### DIFF
--- a/src/platform/graphics/storage-buffer.js
+++ b/src/platform/graphics/storage-buffer.js
@@ -111,7 +111,7 @@ class StorageBuffer {
      * Issues a write operation of the provided data into a storage buffer.
      *
      * @param {number} bufferOffset - The offset in bytes to start writing to the storage buffer.
-     * @param {ArrayBufferView} data - The data to write to the storage buffer.
+     * @param {ArrayBufferView|ArrayBuffer} data - The data to write to the storage buffer.
      * @param {number} dataOffset - Offset in data to begin writing from. Given in elements if data
      * is a TypedArray and bytes otherwise.
      * @param {number} size - Size of content to write from data to buffer. Given in elements if

--- a/src/platform/graphics/webgpu/webgpu-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-buffer.js
@@ -104,6 +104,15 @@ class WebgpuBuffer {
         return device.readStorageBuffer(this, offset, size, data, immediate);
     }
 
+    /**
+     * @param {WebgpuGraphicsDevice} device - Graphics device.
+     * @param {number} bufferOffset - The offset in bytes to start writing to the storage buffer.
+     * @param {ArrayBufferView|ArrayBuffer} data - The data to write to the storage buffer.
+     * @param {number} dataOffset - Offset in data to begin writing from. Given in elements if data
+     * is a TypedArray and bytes otherwise.
+     * @param {number} size - Size of content to write from data to buffer. Given in elements if
+     * data is a TypedArray and bytes otherwise.
+     */
     write(device, bufferOffset, data, dataOffset, size) {
         device.writeStorageBuffer(this, bufferOffset, data, dataOffset, size);
     }

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1458,7 +1458,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      *
      * @param {WebgpuBuffer} storageBuffer - The storage buffer.
      * @param {number} bufferOffset - The offset in bytes to start writing to the storage buffer.
-     * @param {ArrayBufferView} data - The data to write to the storage buffer.
+     * @param {ArrayBufferView|ArrayBuffer} data - The data to write to the storage buffer.
      * @param {number} dataOffset - Offset in data to begin writing from. Given in elements if data
      * is a TypedArray and bytes otherwise.
      * @param {number} size - Size of content to write from data to buffer. Given in elements if


### PR DESCRIPTION
Fixes #8910.

The `data` parameter of `StorageBuffer.write` was documented as `ArrayBufferView`, but the underlying `GPUQueue.writeBuffer` accepts a `GPUAllowSharedBufferSource`, so a plain `ArrayBuffer` is also valid input. The previous annotation caused confusion and spurious type errors for callers passing an `ArrayBuffer`. WebGPU types are not part of the engine's public API surface, so the standard lib types are used rather than referencing `GPUAllowSharedBufferSource` directly.

**Changes:**
- Widen the JSDoc `data` type from `ArrayBufferView` to `ArrayBufferView|ArrayBuffer` on `StorageBuffer.write` and its internal WebGPU delegates.

**API Changes:**
- `StorageBuffer.write(bufferOffset, data, dataOffset, size)` — `data` type widened from `ArrayBufferView` to `ArrayBufferView | ArrayBuffer`. Non-breaking (a strict widening of accepted input).