### PR TITLE
chore(graphics): update @webgpu/types to 0.1.70 and migrate deprecated type names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/webxr": "^0.5.24",
-        "@webgpu/types": "^0.1.66"
+        "@webgpu/types": "^0.1.70"
       },
       "devDependencies": {
         "@playcanvas/eslint-config": "2.1.0",
@@ -2153,9 +2153,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.66",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
-      "integrity": "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==",
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
+      "integrity": "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@zeit/schemas": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   ],
   "dependencies": {
     "@types/webxr": "^0.5.24",
-    "@webgpu/types": "^0.1.66"
+    "@webgpu/types": "^0.1.70"
   },
   "devDependencies": {
     "@playcanvas/eslint-config": "2.1.0",

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1495,14 +1495,14 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         if (color) {
 
             // read from supplied render target, or from the framebuffer
-            /** @type {GPUImageCopyTexture} */
+            /** @type {GPUTexelCopyTextureInfo} */
             const copySrc = {
                 texture: source ? source.colorBuffer.impl.gpuTexture : this.backBuffer.impl.assignedColorTexture,
                 mipLevel: source ? source.mipLevel : 0
             };
 
             // write to supplied render target, or to the framebuffer
-            /** @type {GPUImageCopyTexture} */
+            /** @type {GPUTexelCopyTextureInfo} */
             const copyDst = {
                 texture: dest ? dest.colorBuffer.impl.gpuTexture : this.backBuffer.impl.assignedColorTexture,
                 mipLevel: dest ? dest.mipLevel : 0
@@ -1541,13 +1541,13 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
                 const destTexture = dest ? dest.depthBuffer.impl.gpuTexture : this.renderTarget.impl.depthAttachment.depthTexture;
                 const destMipLevel = dest ? dest.mipLevel : this.renderTarget.mipLevel;
 
-                /** @type {GPUImageCopyTexture} */
+                /** @type {GPUTexelCopyTextureInfo} */
                 const copySrc = {
                     texture: sourceTexture,
                     mipLevel: sourceMipLevel
                 };
 
-                /** @type {GPUImageCopyTexture} */
+                /** @type {GPUTexelCopyTextureInfo} */
                 const copyDst = {
                     texture: destTexture,
                     mipLevel: destMipLevel

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -555,7 +555,7 @@ class WebgpuTexture {
         const texture = this.texture;
         const wgpu = device.wgpu;
 
-        /** @type {GPUImageCopyTexture} */
+        /** @type {GPUTexelCopyTextureInfo} */
         const dest = {
             texture: this.gpuTexture,
             origin: [0, 0, index],
@@ -574,7 +574,7 @@ class WebgpuTexture {
         const formatInfo = pixelFormatInfo.get(texture.format);
         Debug.assert(formatInfo);
 
-        /** @type {GPUImageDataLayout} */
+        /** @type {GPUTexelCopyBufferLayout} */
         let dataLayout;
         let size;
 


### PR DESCRIPTION
Updates @webgpu/types to the latest (0.1.70) and migrates WebGPU JSDoc type annotations off the names the package now marks as @deprecated.

**Changes:**
- Bump `@webgpu/types` from `^0.1.66` to `^0.1.70` (package.json + lockfile)
- Replace deprecated WebGPU type names in JSDoc annotations with their current spec equivalents:
  - `GPUImageCopyTexture` → `GPUTexelCopyTextureInfo` (webgpu-graphics-device.js ×4, webgpu-texture.js ×1)
  - `GPUImageDataLayout` → `GPUTexelCopyBufferLayout` (webgpu-texture.js ×1)

These are type-only (JSDoc) changes with no runtime impact — the underlying WebGPU API methods (`copyTextureToTexture`, `writeTexture`, etc.) are unchanged. The renamed types are exact aliases of the old ones, so behavior is identical.