### PR TITLE
fix(graphics): align WebGPU backbuffer format with WebXR projection-layer format

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -299,7 +299,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
     /**
      * Reset all per-frame WebGPU XR render state to its inactive defaults. Called by the XR bridge
-     * at the end of each XR frame and on session teardown, and by the graphics device on destroy.
+     * at the start of each beginFrame and on session teardown, and by the graphics device on destroy.
      *
      * @ignore
      */

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -49,6 +49,17 @@ const _indirectEntryByteSize = 5 * 4;
 // size of indirect dispatch entry in bytes, 3 x 32bit (x, y, z workgroup counts)
 const _indirectDispatchEntryByteSize = 3 * 4;
 
+// WebGPU color formats a swapchain or WebXR projection layer can present, mapped to the matching
+// engine PIXELFORMAT_* constant. Used to align device.backBufferFormat with the color format the
+// WebXR runtime actually renders into while immersive (see WebgpuGraphicsDevice#setXrBackBufferFormat).
+const _gpuFormatToPixelFormat = {
+    'rgba8unorm': PIXELFORMAT_RGBA8,
+    'rgba8unorm-srgb': PIXELFORMAT_SRGBA8,
+    'bgra8unorm': PIXELFORMAT_BGRA8,
+    'bgra8unorm-srgb': PIXELFORMAT_SBGRA8,
+    'rgba16float': PIXELFORMAT_RGBA16F
+};
+
 class WebgpuGraphicsDevice extends GraphicsDevice {
     /**
      * Array of GPU resources pending destruction. Resources are destroyed after the current
@@ -156,6 +167,16 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      * @ignore
      */
     submitVersion = 0;
+
+    /**
+     * Canvas-derived backbuffer pixel format ({@link GraphicsDevice#backBufferFormat}), captured once
+     * the swapchain is configured. While immersive, {@link backBufferFormat} is temporarily overridden
+     * with the WebXR projection-layer format; this is the value {@link _clearXrState} restores to.
+     *
+     * @type {number|undefined}
+     * @private
+     */
+    _canvasBackBufferFormat;
 
     /**
      * When set, immersive XR writes color to this texture instead of the canvas swapchain.
@@ -288,6 +309,30 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.xrColorTextureViewDescriptor = null;
         this.xrSubImages.length = 0;
         this.xrCurrentViewIndex = -1;
+
+        // restore the canvas-derived backbuffer format that immersive rendering temporarily overrode
+        if (this._canvasBackBufferFormat !== undefined) {
+            this.backBufferFormat = this._canvasBackBufferFormat;
+        }
+    }
+
+    /**
+     * Override {@link backBufferFormat} with the color format of the active WebXR projection layer,
+     * so engine systems that key off the backbuffer format - notably {@link RenderTarget#isColorBufferSrgb}
+     * (which drives output gamma correction in the forward renderer and compose pass) and scene
+     * color-grab - stay consistent with the texture the XR runtime renders into. The view format is
+     * used (rather than the raw projection-layer color format) because it carries the runtime's per-eye
+     * sRGB reinterpretation, which is what actually determines hardware gamma encoding on write.
+     * Reverts to the canvas-derived format in {@link _clearXrState}. No-op for unrecognized formats.
+     *
+     * @param {any} viewFormat - WebGPU color view format of the XR projection layer (`GPUTextureFormat`).
+     * @ignore
+     */
+    setXrBackBufferFormat(viewFormat) {
+        const format = _gpuFormatToPixelFormat[viewFormat];
+        if (format !== undefined) {
+            this.backBufferFormat = format;
+        }
     }
 
     initDeviceCaps() {
@@ -546,6 +591,10 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             viewFormats: displayFormat === DISPLAYFORMAT_LDR_SRGB ? [this.backBufferViewFormat] : []
         };
         this.gpuContext?.configure(this.canvasConfig);
+
+        // remember the canvas-derived backbuffer format so it can be restored after an immersive XR
+        // session, which temporarily overrides backBufferFormat with the projection-layer format
+        this._canvasBackBufferFormat = this.backBufferFormat;
 
         this.createBackbuffer();
 

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -117,7 +117,8 @@ class WebgpuXrBridge {
             device.xrColorTextureViewFormat = first.viewFormat;
             // align the engine-level backbuffer format with the runtime's projection-layer format so
             // sRGB / gamma decisions (RenderTarget#isColorBufferSrgb) and scene color-grab match what
-            // we actually render into; reverted by device._clearXrState at frame/session end
+            // we actually render into; device._clearXrState reverts it to the canvas format at the
+            // start of the next beginFrame and on session teardown
             device.setXrBackBufferFormat(first.viewFormat);
             this._cachedFramebufferSize.set(first.colorTexture.width, first.colorTexture.height);
         }

--- a/src/platform/graphics/webgpu/webgpu-xr-bridge.js
+++ b/src/platform/graphics/webgpu/webgpu-xr-bridge.js
@@ -115,6 +115,10 @@ class WebgpuXrBridge {
         if (first) {
             device.xrColorTexture = first.colorTexture;
             device.xrColorTextureViewFormat = first.viewFormat;
+            // align the engine-level backbuffer format with the runtime's projection-layer format so
+            // sRGB / gamma decisions (RenderTarget#isColorBufferSrgb) and scene color-grab match what
+            // we actually render into; reverted by device._clearXrState at frame/session end
+            device.setXrBackBufferFormat(first.viewFormat);
             this._cachedFramebufferSize.set(first.colorTexture.width, first.colorTexture.height);
         }
     }


### PR DESCRIPTION
While in an immersive WebGPU XR session, the engine-level backbuffer format (`device.backBufferFormat`) stayed pinned to the canvas swapchain format chosen at startup, even though XR renders into the WebXR projection layer — whose format the runtime recommends independently via `XRGPUBinding.getPreferredColorFormat()`. Systems that key off `backBufferFormat` — notably `RenderTarget#isColorBufferSrgb`, which drives output gamma correction in the forward renderer and compose pass, plus scene color-grab — therefore used the wrong format during XR. This could produce gamma-incorrect XR output (too dark/bright vs the 2D canvas) when the projection layer's sRGB-ness differed from the canvas format.

**Changes:**
- WebGPU XR now overrides `device.backBufferFormat` with the active projection layer's per-eye view format each frame, reverting to the canvas-derived format when the immersive frame/session ends (centralized in `_clearXrState`, which is hit on every teardown path).
- The per-eye view format is used (rather than the raw `getPreferredColorFormat()` string) because it carries the runtime's sRGB reinterpretation, which is what actually determines hardware gamma encoding on write.

No public API changes — all additions are internal (`@ignore` / private).