### PR TITLE
refactor: Remove unused JSDoc @import lines from sound and rigid-body components

### DIFF
--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -9,10 +9,6 @@ import {
     BODYTYPE_DYNAMIC, BODYTYPE_KINEMATIC
 } from './constants.js';
 
-/**
- * @import { Entity } from '../../entity.js'
- */
-
 // Shared math variable to avoid excessive allocation
 let _ammoTransform;
 let _ammoVec1, _ammoVec2, _ammoQuat;

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -4,7 +4,6 @@ import { Component } from '../component.js';
 import { SoundSlot } from './slot.js';
 
 /**
- * @import { Entity } from '../../entity.js'
  * @import { SoundInstance } from '../../../platform/sound/instance.js'
  */
 


### PR DESCRIPTION
## Description
Removes unused JSDoc @import type-only lines that are not referenced in the file:

SoundComponent — Entity
RigidBodyComponent — Entity
These imports were only referenced via @link in documentation and not in type annotations (@type, @param, @returns). No runtime behavior changes.

Following the pattern established in #8677.


