### PR TITLE
ci: report minified bundle size changes on PRs

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -28,6 +28,11 @@ jobs:
     name: Build Size
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Pin the embedded git revision to a constant for both builds; otherwise the differing commit
+    # hashes baked into each bundle show up as a phantom (compressed-)size diff even when no code
+    # changed. Honoured by utils/rollup-version-revision.mjs.
+    env:
+      ENGINE_BUILD_REVISION: ci-build-size
     steps:
       - name: Check out base
         uses: actions/checkout@v6
@@ -48,6 +53,7 @@ jobs:
       - name: Build base bundles
         run: |
           cp pr/utils/build-size.mjs base/utils/build-size.mjs
+          cp pr/utils/rollup-version-revision.mjs base/utils/rollup-version-revision.mjs
           cd base
           npm clean-install --progress=false --no-fund
           npm run build:min:umd

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -101,14 +101,13 @@ jobs:
             });
 
             const headline = changed
-              ? 'This PR changes the size of the minified bundles:'
+              ? 'This PR changes the size of the minified bundles.'
               : 'This PR does not change the size of the minified bundles.';
             const body = `${MARKER}\n### Build size report\n\n`
-              + `${headline}\n\n`
+              + `${headline} Each cell shows the PR size and the change vs \`main\`. Informational only.\n\n`
               + `| Bundle | Minified | Gzip | Brotli |\n`
               + `| --- | --- | --- | --- |\n`
-              + `${rows.join('\n')}\n\n`
-              + `_Each cell shows the PR size and the change vs \`main\`. Informational only — this never fails the build._`;
+              + `${rows.join('\n')}\n`;
 
             const { owner, repo } = context.repo;
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: prNumber });

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -104,7 +104,7 @@ jobs:
               ? 'This PR changes the size of the minified bundles.'
               : 'This PR does not change the size of the minified bundles.';
             const body = `${MARKER}\n### Build size report\n\n`
-              + `${headline} Each cell shows the PR size and the change vs \`main\`. Informational only.\n\n`
+              + `${headline}\n\n`
               + `| Bundle | Minified | Gzip | Brotli |\n`
               + `| --- | --- | --- | --- |\n`
               + `${rows.join('\n')}\n`;

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -1,0 +1,115 @@
+name: Build Size
+
+# Builds only the minified engine bundles (UMD + ESM) for the PR head and its base, measures their
+# raw / gzip / brotli sizes, diffs the two and posts/updates a sticky PR comment. There is no stored
+# baseline — the base commit is rebuilt fresh in the same run, so the comparison is always "this PR
+# vs the main it targets". Informative only; never fails the build.
+#
+# Only the min bundles are built (not rel/dbg/prf/types) to keep the run fast.
+#
+# Note: comments directly, so on fork PRs (read-only token) the comment step can't post; it is
+# marked continue-on-error so those runs stay green (just without a comment).
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: build-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-size:
+    name: Build Size
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out base
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Check out PR
+        uses: actions/checkout@v6
+        with:
+          path: pr
+
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+
+      - name: Build base bundles
+        run: |
+          cp pr/utils/build-size.mjs base/utils/build-size.mjs
+          cd base
+          npm clean-install --progress=false --no-fund
+          npm run build:min:umd
+          npm run build:min:esm
+          node utils/build-size.mjs > sizes.json
+
+      - name: Build PR bundles
+        run: |
+          cd pr
+          npm clean-install --progress=false --no-fund
+          npm run build:min:umd
+          npm run build:min:esm
+          node utils/build-size.mjs > sizes.json
+
+      - name: Comment on PR
+        continue-on-error: true # fork PRs get a read-only token; don't fail the run if commenting is denied
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- build-size-bot -->';
+            const prNumber = context.payload.pull_request.number;
+
+            const read = p => fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')) : {};
+            const base = read('base/sizes.json');
+            const pr = read('pr/sizes.json');
+
+            const kb = n => `${(n / 1024).toFixed(1)} KB`;
+            const cell = (b, p) => {
+              const d = p - b;
+              if (!b) return `${kb(p)} (new)`;
+              if (!d) return `${kb(p)} —`;
+              const sign = d > 0 ? '+' : '−';
+              const pct = (Math.abs(d) / b * 100).toFixed(2);
+              return `${kb(p)} (${sign}${kb(Math.abs(d))}, ${sign}${pct}%)`;
+            };
+
+            const bundles = [...new Set([...Object.keys(base), ...Object.keys(pr)])].sort();
+            const changed = bundles.some(name =>
+              ['raw', 'gzip', 'brotli'].some(m => (base[name]?.[m] ?? 0) !== (pr[name]?.[m] ?? 0)));
+
+            const rows = bundles.map((name) => {
+              const b = base[name] || {}, p = pr[name] || {};
+              return `| \`${name}\` | ${cell(b.raw, p.raw)} | ${cell(b.gzip, p.gzip)} | ${cell(b.brotli, p.brotli)} |`;
+            });
+
+            const headline = changed
+              ? 'This PR changes the size of the minified bundles:'
+              : 'This PR does not change the size of the minified bundles.';
+            const body = `${MARKER}\n### Build size report\n\n`
+              + `${headline}\n\n`
+              + `| Bundle | Minified | Gzip | Brotli |\n`
+              + `| --- | --- | --- | --- |\n`
+              + `${rows.join('\n')}\n\n`
+              + `_Each cell shows the PR size and the change vs \`main\`. Informational only — this never fails the build._`;
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: prNumber });
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            }

--- a/utils/build-size.mjs
+++ b/utils/build-size.mjs
@@ -1,0 +1,23 @@
+// Measures the size of the minified engine bundles — raw bytes plus gzip and brotli compressed sizes
+// (gzip/brotli reflect real download cost). Both compressors are built into Node's zlib, so this has
+// no dependencies. Run from the repo root after building the min bundles; emits JSON on stdout:
+//   node utils/build-size.mjs > sizes.json
+// Output shape: { "playcanvas.min.js": { raw, gzip, brotli }, "playcanvas.min.mjs": { ... } }
+
+import { readFileSync } from 'node:fs';
+import { brotliCompressSync, constants, gzipSync } from 'node:zlib';
+
+// the minified UMD and ESM bundles — the only artifacts this report tracks
+const BUNDLES = ['build/playcanvas.min.js', 'build/playcanvas.min.mjs'];
+
+const sizes = {};
+for (const file of BUNDLES) {
+    const buf = readFileSync(file);
+    sizes[file.replace('build/', '')] = {
+        raw: buf.length,
+        gzip: gzipSync(buf, { level: 9 }).length,
+        brotli: brotliCompressSync(buf, { params: { [constants.BROTLI_PARAM_QUALITY]: 11 } }).length
+    };
+}
+
+process.stdout.write(`${JSON.stringify(sizes, null, 2)}\n`);

--- a/utils/rollup-version-revision.mjs
+++ b/utils/rollup-version-revision.mjs
@@ -19,6 +19,11 @@ function getVersion() {
  * @returns {string} Revision string like `644d08d39` (9 digits/chars).
  */
 function getRevision() {
+    // Allow CI to pin the revision so otherwise-identical builds are byte-identical (the build-size
+    // workflow builds two commits and the embedded git hash would otherwise show as a phantom diff).
+    if (process.env.ENGINE_BUILD_REVISION) {
+        return process.env.ENGINE_BUILD_REVISION;
+    }
     let revision;
     try {
         revision = execSync('git rev-parse --short HEAD').toString().trim();


### PR DESCRIPTION
## Summary

Adds a **Build Size** GitHub Actions workflow ([`.github/workflows/build-size.yml`](.github/workflows/build-size.yml)) that reports how a PR affects the size of the minified engine bundles. It mirrors the existing [API Report](.github/workflows/api-report.yml) workflow's mechanism — same trigger, same sticky-comment pattern — but for bundle size.

### How it works

- Triggers on `pull_request` to `main` (`opened`, `synchronize`, `reopened`), so it refreshes on every commit.
- **No persistent baseline.** It checks out *both* the PR head and `pull_request.base.sha`, builds each, and compares them in the same run — so the report is always "this PR vs the `main` it targets".
- Builds **only the minified bundles** (`build:min:umd` + `build:min:esm`), not the rel/dbg/prf/types variants, to keep the run fast.
- A small dependency-free measurer ([`utils/build-size.mjs`](utils/build-size.mjs)) records **raw, gzip and brotli** sizes of `playcanvas.min.js` (UMD) and `playcanvas.min.mjs` (ESM) using Node's built-in `zlib`.
- Posts/updates **one sticky comment** (deduped via a hidden `<!-- build-size-bot -->` marker — `listComments` → find → create/update), showing each bundle's PR size and its delta vs `main`.
- **Informative only** — never fails the build; the comment step is `continue-on-error` so fork PRs (read-only token) stay green.

### Notes / things to decide in review

- The comment is **always posted** (even when sizes are unchanged, where it reports "does not change the size"), unlike the API report which deletes its comment when there's no change. Easy to switch to delete-on-no-change if preferred.
- This PR itself touches no engine source, so its own Build Size comment should report **no change** — a useful first check that the report renders correctly.
- Build cost is two `npm ci` + four minified esbuild builds; well within the 20-min timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)