### PR TITLE
refactor(gsplat): move GPU sort/cull pipeline into the hybrid renderer

### DIFF
--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -1,4 +1,6 @@
 import { Mat4 } from '../../core/math/mat4.js';
+import { Vec3 } from '../../core/math/vec3.js';
+import { Debug } from '../../core/debug.js';
 import { SEMANTIC_POSITION, CULLFACE_NONE } from '../../platform/graphics/constants.js';
 import {
     BLEND_NONE, BLEND_PREMULTIPLIED, BLEND_ADDITIVE, GSPLAT_FORWARD,
@@ -8,7 +10,11 @@ import { ShaderMaterial } from '../materials/shader-material.js';
 import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
 import { MeshInstance } from '../mesh-instance.js';
 import { GSplatRenderer } from './gsplat-renderer.js';
+import { GSplatProjector } from './gsplat-projector.js';
+import { GSplatIntervalCompaction } from './gsplat-interval-compaction.js';
+import { ComputeRadixSort } from '../graphics/radix-sort/compute-radix-sort.js';
 import { CACHE_STRIDE } from './gsplat-projector-constants.js';
+import { ALPHA_VISIBILITY_THRESHOLD } from './constants.js';
 import { Camera } from '../camera.js';
 
 // Module-scope scratch matrices used only inside `_computeClipToViewZ`. The output
@@ -17,6 +23,12 @@ import { Camera } from '../camera.js';
 // render concurrently with different cameras.
 const _invProjMat = new Mat4();
 const _shaderProjMat = new Mat4();
+
+// Module-scope scratch used only inside `computeDistanceRange` (camera world position/direction
+// and a transformed AABB corner). Reused synchronously within a single call.
+const _camPos = new Vec3();
+const _camDir = new Vec3();
+const _tmpV = new Vec3();
 
 /**
  * @import { StorageBuffer } from '../../platform/graphics/storage-buffer.js'
@@ -85,6 +97,49 @@ class GSplatHybridRenderer extends GSplatRenderer {
     _cacheStride = CACHE_STRIDE;
 
     /**
+     * GPU radix sorter for the projected cache indices.
+     *
+     * @type {ComputeRadixSort|null}
+     */
+    gpuSorter = null;
+
+    /**
+     * Compute projector that builds the per-camera projection cache + sort keys.
+     *
+     * @type {GSplatProjector|null}
+     */
+    projector = null;
+
+    /**
+     * Interval-based GPU culling + compaction (lazily created on first sort).
+     *
+     * @type {GSplatIntervalCompaction|null}
+     */
+    intervalCompaction = null;
+
+    /**
+     * Per-frame indirect draw slot index (-1 when unallocated).
+     *
+     * @type {number}
+     */
+    indirectDrawSlot = -1;
+
+    /**
+     * Per-frame indirect dispatch slot index (projector + radix sort passes).
+     *
+     * @type {number}
+     */
+    indirectDispatchSlot = -1;
+
+    /**
+     * Total intervals from the last interval-compaction dispatch (index into the prefix sum
+     * for the visible count).
+     *
+     * @type {number}
+     */
+    lastCompactedNumIntervals = 0;
+
+    /**
      * @param {GraphicsDevice} device - The graphics device.
      * @param {GraphNode} node - The graph node.
      * @param {GraphNode} cameraNode - The camera node.
@@ -122,6 +177,11 @@ class GSplatHybridRenderer extends GSplatRenderer {
         this._internalDefines.add('GSPLAT_NO_FOG');
         this._internalDefines.add('GSPLAT_XR');
 
+        // GPU sort pipeline resources (owned by the renderer). Interval compaction is created
+        // lazily on the first sort.
+        this.gpuSorter = new ComputeRadixSort(this.device, { indirect: true });
+        this.projector = new GSplatProjector(this.device);
+
         this.meshInstance = this.createMeshInstance();
     }
 
@@ -150,6 +210,12 @@ class GSplatHybridRenderer extends GSplatRenderer {
         if (this.renderMode && (this.renderMode & GSPLAT_FORWARD)) {
             this.layer.removeMeshInstances([this.meshInstance], true);
         }
+        this.gpuSorter?.destroy();
+        this.gpuSorter = null;
+        this.projector?.destroy();
+        this.projector = null;
+        this.intervalCompaction?.destroy();
+        this.intervalCompaction = null;
         this._material.destroy();
         this._pickMaterial?.destroy();
         this.meshInstance.destroy();
@@ -209,6 +275,302 @@ class GSplatHybridRenderer extends GSplatRenderer {
             this.meshInstance.instancingCount = 1;
         }
         this.meshInstance.visible = count > 0;
+    }
+
+    invalidateCullUpload() {
+        this.intervalCompaction?.invalidateUpload();
+    }
+
+    /**
+     * Per-frame forward render preparation: derives the viewport (handling stereo XR), runs the
+     * cull + projector + radix sort for the current camera, and binds the result for indirect
+     * drawing. Runs every frame — the indirect args are per-frame and the post-projector visible
+     * count differs from the interval prefix sum.
+     *
+     * @param {object} world - The {@link GSplatWorld} providing the work buffer, bounds and states.
+     * @param {object} worldState - The render-ready world state to draw.
+     * @param {object} params - Per-call gsplat params + camera (see GSplatManager#_fillRenderViewParams).
+     * @returns {boolean} True if a GPU dispatch ran (false when there are no active splats).
+     */
+    prepareRenderView(world, worldState, params) {
+        const cameraNode = params.cameraNode;
+        const cam = cameraNode.camera;
+        const sceneCam = cam.camera;
+        const rt = cam.renderTarget;
+        const rect = cam.rect;
+
+        // Match Renderer#setCameraUniforms: in stereo XR the XR session reports the per-eye
+        // viewport directly, which is correct for both side-by-side single-texture and
+        // multi-pass per-eye-view layouts — preferred over inferring from target.width.
+        const xrView = sceneCam.xrActive ? (sceneCam.xrViews[0] ?? null) : null;
+        const viewportWidth = Math.floor((xrView ? xrView.viewport.z : (rt ? rt.width : this.device.width)) * rect.z);
+        const viewportHeight = Math.floor((xrView ? xrView.viewport.w : (rt ? rt.height : this.device.height)) * rect.w);
+
+        // Stereo XR: project both eyes in a single projector pass (GSPLAT_XR variant). Requires
+        // exactly 2 parallel-axis views. Keep the VS define in sync with the projector variant.
+        const xrViewCount = sceneCam.xrActive ? sceneCam.xrViews.length : 0;
+        if (xrViewCount > 2) {
+            Debug.errorOnce(`GSplatHybridRenderer: the hybrid GPU-sort renderer supports at most 2 XR views (stereo), but the session has ${xrViewCount}. Additional views will not render correctly.`);
+        }
+        const isStereo = xrViewCount === 2;
+        this.setStereo(isStereo);
+
+        const sortedIndices = this.sortAndProjectForCamera(
+            world, worldState, cameraNode, viewportWidth, viewportHeight,
+            Math.max(ALPHA_VISIBILITY_THRESHOLD, params.alphaClipForward), false, isStereo, params
+        );
+
+        if (!sortedIndices) return false;
+
+        this.setHybridSortedRendering(
+            this.indirectDrawSlot,
+            sortedIndices,
+            /** @type {StorageBuffer} */ (this.projector.projCache),
+            /** @type {StorageBuffer} */ (this.intervalCompaction.numSplatsBuffer)
+        );
+        return true;
+    }
+
+    /**
+     * Picker render preparation: runs the cull + projector + radix sort for the picker camera
+     * (pick mode, mono) and returns the configured pick mesh instance.
+     *
+     * @param {object} world - The {@link GSplatWorld}.
+     * @param {object} worldState - The render-ready world state.
+     * @param {object} pickParams - Per-call params + picker camera (see GSplatManager#_fillPickParams).
+     * @returns {MeshInstance|null} The pick mesh instance, or null if nothing was dispatched.
+     */
+    preparePickingView(world, worldState, pickParams) {
+        // pickMode writes pcId into the cache only when the work buffer actually carries that stream.
+        const pickMode = !!world.workBuffer.format.getStream('pcId');
+        const sortedIndices = this.sortAndProjectForCamera(
+            world, worldState, pickParams.cameraNode, pickParams.width, pickParams.height,
+            Math.max(ALPHA_VISIBILITY_THRESHOLD, pickParams.alphaClip), pickMode, false, pickParams
+        );
+        if (!sortedIndices) return null;
+
+        return this.prepareForPicking(
+            this.indirectDrawSlot,
+            sortedIndices,
+            /** @type {StorageBuffer} */ (this.projector.projCache),
+            /** @type {StorageBuffer} */ (this.intervalCompaction.numSplatsBuffer),
+            pickParams.alphaClip,
+            pickParams.alphaClipForward,
+            pickParams.cameraNode
+        );
+    }
+
+    /**
+     * Runs interval cull + compaction, the projector, and the indirect radix sort for a specific
+     * camera/view. Shared by the forward render and the picker. Assumes the work buffer is baked and
+     * render-ready (the manager's version lifecycle marks it before delegating).
+     *
+     * @param {object} world - The {@link GSplatWorld}.
+     * @param {object} worldState - The world state to sort.
+     * @param {GraphNode} cameraNode - Camera node used for projection and sort keys.
+     * @param {number} viewportWidth - Projection viewport width in pixels.
+     * @param {number} viewportHeight - Projection viewport height in pixels.
+     * @param {number} alphaClip - Projector producer alpha threshold.
+     * @param {boolean} pickMode - Whether the projector writes pcId into the cache.
+     * @param {boolean} isStereo - Whether to project both XR eyes in one pass (forward only).
+     * @param {object} params - Per-call gsplat params.
+     * @returns {StorageBuffer|null} The sorted cache indices, or null if no work was dispatched.
+     * @private
+     */
+    sortAndProjectForCamera(world, worldState, cameraNode, viewportWidth, viewportHeight, alphaClip, pickMode, isStereo, params) {
+        const gpuSorter = /** @type {ComputeRadixSort} */ (this.gpuSorter);
+        const projector = /** @type {GSplatProjector} */ (this.projector);
+
+        const elementCount = worldState.totalActiveSplats;
+        if (elementCount === 0) return null;
+
+        if (!this.intervalCompaction) {
+            this.intervalCompaction = new GSplatIntervalCompaction(this.device);
+        }
+
+        this.intervalCompaction.uploadIntervals(worldState);
+
+        if (world.hasBounds) {
+            const state = world.getState(world.currentVersion);
+            if (state) {
+                this._runFrustumCulling(world, state, cameraNode, params);
+            }
+        }
+
+        const fisheyeProj = this.fisheyeProj;
+        const numIntervals = worldState.totalIntervals;
+        const totalActiveSplats = worldState.totalActiveSplats;
+        this.intervalCompaction.dispatchCompact(world.workBuffer.frustumCuller, numIntervals, totalActiveSplats, fisheyeProj.enabled);
+
+        this.allocateAndWriteIntervalIndirectArgs(numIntervals);
+
+        const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
+        const compactedSplatIds = ic.compactedSplatIds;
+
+        const numBits = Math.max(10, Math.min(20, Math.round(Math.log2(elementCount / 4))));
+        const radixBits = gpuSorter.radixBits;
+        const roundedNumBits = Math.ceil(numBits / radixBits) * radixBits;
+
+        const { minDist, maxDist } = this.computeDistanceRange(worldState, cameraNode, params.radialSorting);
+
+        const sortIndirectInfo = gpuSorter.prepareIndirect();
+
+        projector.dispatch({
+            workBuffer: world.workBuffer,
+            cameraNode,
+            compactedSplatIds: /** @type {StorageBuffer} */ (compactedSplatIds),
+            sortElementCountBuffer: /** @type {StorageBuffer} */ (ic.sortElementCountBuffer),
+            totalCapacity: elementCount,
+            radialSort: params.radialSorting,
+            numBits: roundedNumBits,
+            minDist,
+            maxDist,
+            alphaClip,
+            minPixelSize: params.minPixelSize * 0.5,
+            minContribution: params.minContribution,
+            foveationStrength: params.foveationStrength,
+            foveationCenter: params.foveationCenter,
+            viewportWidth,
+            viewportHeight,
+            flipY: !!cameraNode.camera.renderTarget?.flipY,
+            pickMode,
+            fisheyeProj,
+            antiAlias: params.antiAlias,
+            isStereo,
+            material: params.material,
+            userCacheWords: params.varyings.words
+        });
+
+        projector.writeIndirectArgs(
+            this.indirectDrawSlot,
+            this.indirectDispatchSlot + 1,
+            /** @type {StorageBuffer} */ (ic.numSplatsBuffer),
+            /** @type {StorageBuffer} */ (ic.sortElementCountBuffer),
+            sortIndirectInfo
+        );
+
+        return gpuSorter.sortIndirect(
+            /** @type {StorageBuffer} */ (projector.sortKeys),
+            elementCount,
+            roundedNumBits,
+            this.indirectDispatchSlot + 1,
+            /** @type {StorageBuffer} */ (ic.sortElementCountBuffer),
+            undefined,
+            false,
+            true  // destructiveKeys: projector overwrites sortKeys each frame before the sort
+        );
+    }
+
+    /**
+     * Allocates per-frame indirect draw and dispatch slots and writes the interval-compaction
+     * indirect args.
+     *
+     * @param {number} numIntervals - Total interval count (index into prefix sum for visible count).
+     * @private
+     */
+    allocateAndWriteIntervalIndirectArgs(numIntervals) {
+        const gpuSorter = /** @type {ComputeRadixSort} */ (this.gpuSorter);
+        const sortInfo = gpuSorter.prepareIndirect();
+        const sortSlotCount = sortInfo[0];
+
+        this.indirectDrawSlot = this.device.getIndirectDrawSlot(1);
+        // Reserve contiguous dispatch slots for the projector + radix sort passes.
+        this.indirectDispatchSlot = this.device.getIndirectDispatchSlot(1 + sortSlotCount);
+        const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
+        ic.writeIndirectArgs(this.indirectDrawSlot, this.indirectDispatchSlot, numIntervals, sortInfo);
+        this.lastCompactedNumIntervals = numIntervals;
+    }
+
+    /**
+     * Prepares frustum culling data: updates the GPU transform buffers and computes frustum planes
+     * from the camera. The actual culling test runs inline in the interval compaction compute shader.
+     *
+     * @param {object} world - The {@link GSplatWorld} owning the frustum culler.
+     * @param {object} worldState - The world state whose splats provide transforms.
+     * @param {GraphNode} cameraNode - Camera node to cull against.
+     * @param {object} params - Per-call gsplat params (for fisheye).
+     * @private
+     */
+    _runFrustumCulling(world, worldState, cameraNode, params) {
+        world.workBuffer.frustumCuller.updateTransformsData(worldState.boundsGroups);
+
+        const cam = cameraNode.camera;
+        const sceneCamera = cam.camera;
+        const xrViews = sceneCamera.xrViews;
+        if (xrViews?.length) {
+            // XR: cull against the combined frustum of all views, so splats visible only near
+            // one eye's edge (e.g. the right edge of the right eye) are not dropped. The per-view
+            // "off" matrices are refreshed at render time by setCameraUniforms, which runs AFTER
+            // this culling, so refresh them here (mirrors the projector dispatch).
+            sceneCamera.updateViewTransforms();
+            sceneCamera.updateXrFrustum();
+            world.workBuffer.frustumCuller.setFrustumPlanes(sceneCamera.frustum);
+        } else {
+            world.workBuffer.frustumCuller.computeFrustumPlanes(cam.projectionMatrix, cam.viewMatrix);
+        }
+
+        const fp = this.fisheyeProj;
+        // XR does not support fisheye in any renderer; resolveFisheye forces it off (and warns once).
+        fp.update(this.resolveFisheye(params.fisheye), cam.fov, cam.projectionMatrix);
+
+        if (fp.enabled) {
+            world.workBuffer.frustumCuller.setFisheyeData(
+                cameraNode.getPosition(),
+                cameraNode.forward,
+                fp.maxTheta
+            );
+        }
+    }
+
+    /**
+     * Computes the min/max effective distances for the current world state (radial or linear).
+     *
+     * @param {object} worldState - The world state.
+     * @param {GraphNode} cameraNode - Camera node to measure distances from.
+     * @param {boolean} radialSort - Whether radial sorting is enabled.
+     * @returns {{minDist: number, maxDist: number}} The distance range.
+     * @private
+     */
+    computeDistanceRange(worldState, cameraNode, radialSort) {
+        const cameraMat = cameraNode.getWorldTransform();
+        cameraMat.getTranslation(_camPos);
+        cameraMat.getZ(_camDir).normalize();
+
+        // For radial: minDist is always 0, only track maxDist. For linear: track both along the
+        // camera direction.
+        let minDist = radialSort ? 0 : Infinity;
+        let maxDist = radialSort ? 0 : -Infinity;
+
+        for (const splat of worldState.splats) {
+            const modelMat = splat.node.getWorldTransform();
+            const aabbMin = splat.aabb.getMin();
+            const aabbMax = splat.aabb.getMax();
+
+            // Check all 8 corners of the local-space AABB
+            for (let i = 0; i < 8; i++) {
+                _tmpV.x = (i & 1) ? aabbMax.x : aabbMin.x;
+                _tmpV.y = (i & 2) ? aabbMax.y : aabbMin.y;
+                _tmpV.z = (i & 4) ? aabbMax.z : aabbMin.z;
+
+                modelMat.transformPoint(_tmpV, _tmpV);
+
+                if (radialSort) {
+                    const dist = _tmpV.distance(_camPos);
+                    if (dist > maxDist) maxDist = dist;
+                } else {
+                    const dist = _tmpV.sub(_camPos).dot(_camDir);
+                    if (dist < minDist) minDist = dist;
+                    if (dist > maxDist) maxDist = dist;
+                }
+            }
+        }
+
+        // Handle empty state
+        if (maxDist === 0 || maxDist === -Infinity) {
+            return { minDist: 0, maxDist: 1 };
+        }
+
+        return { minDist, maxDist };
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -161,6 +161,14 @@ class GSplatHybridRenderer extends GSplatRenderer {
         return this._material;
     }
 
+    get usesGpuSort() {
+        return true;
+    }
+
+    get requiresBounds() {
+        return true;
+    }
+
     onWorkBufferFormatChanged() {
         this.configureMaterial();
     }

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -36,6 +36,9 @@ const _tmpV = new Vec3();
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { Layer } from '../layer.js'
  * @import { GSplatWorkBuffer } from './gsplat-work-buffer.js'
+ * @import { GSplatWorld } from './gsplat-world.js'
+ * @import { GSplatWorldState } from './gsplat-world-state.js'
+ * @import { GSplatRenderViewParams } from './gsplat-renderer.js'
  */
 
 /**
@@ -287,9 +290,9 @@ class GSplatHybridRenderer extends GSplatRenderer {
      * drawing. Runs every frame — the indirect args are per-frame and the post-projector visible
      * count differs from the interval prefix sum.
      *
-     * @param {object} world - The {@link GSplatWorld} providing the work buffer, bounds and states.
-     * @param {object} worldState - The render-ready world state to draw.
-     * @param {object} params - Per-call gsplat params + camera (see GSplatManager#_fillRenderViewParams).
+     * @param {GSplatWorld} world - The world providing the work buffer, bounds and states.
+     * @param {GSplatWorldState} worldState - The render-ready world state to draw.
+     * @param {GSplatRenderViewParams} params - Per-call params + camera (see GSplatManager#_fillRenderViewParams).
      * @returns {boolean} True if a GPU dispatch ran (false when there are no active splats).
      */
     prepareRenderView(world, worldState, params) {
@@ -335,9 +338,9 @@ class GSplatHybridRenderer extends GSplatRenderer {
      * Picker render preparation: runs the cull + projector + radix sort for the picker camera
      * (pick mode, mono) and returns the configured pick mesh instance.
      *
-     * @param {object} world - The {@link GSplatWorld}.
-     * @param {object} worldState - The render-ready world state.
-     * @param {object} pickParams - Per-call params + picker camera (see GSplatManager#_fillPickParams).
+     * @param {GSplatWorld} world - The world providing the work buffer, bounds and states.
+     * @param {GSplatWorldState} worldState - The render-ready world state.
+     * @param {GSplatRenderViewParams} pickParams - Per-call params + picker camera (see GSplatManager#_fillPickParams).
      * @returns {MeshInstance|null} The pick mesh instance, or null if nothing was dispatched.
      */
     preparePickingView(world, worldState, pickParams) {
@@ -365,15 +368,15 @@ class GSplatHybridRenderer extends GSplatRenderer {
      * camera/view. Shared by the forward render and the picker. Assumes the work buffer is baked and
      * render-ready (the manager's version lifecycle marks it before delegating).
      *
-     * @param {object} world - The {@link GSplatWorld}.
-     * @param {object} worldState - The world state to sort.
+     * @param {GSplatWorld} world - The world providing the work buffer, bounds and states.
+     * @param {GSplatWorldState} worldState - The world state to sort.
      * @param {GraphNode} cameraNode - Camera node used for projection and sort keys.
      * @param {number} viewportWidth - Projection viewport width in pixels.
      * @param {number} viewportHeight - Projection viewport height in pixels.
      * @param {number} alphaClip - Projector producer alpha threshold.
      * @param {boolean} pickMode - Whether the projector writes pcId into the cache.
      * @param {boolean} isStereo - Whether to project both XR eyes in one pass (forward only).
-     * @param {object} params - Per-call gsplat params.
+     * @param {GSplatRenderViewParams} params - Per-call gsplat params.
      * @returns {StorageBuffer|null} The sorted cache indices, or null if no work was dispatched.
      * @private
      */

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -11,7 +11,7 @@ import { ComputeRadixSort } from '../graphics/radix-sort/compute-radix-sort.js';
 import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import {
-    GSPLAT_RENDERER_RASTER_CPU_SORT, GSPLAT_RENDERER_RASTER_GPU_SORT,
+    GSPLAT_RENDERER_RASTER_GPU_SORT,
     GSPLAT_DEBUG_AABBS
 } from '../constants.js';
 import { Color } from '../../core/math/color.js';
@@ -368,7 +368,7 @@ class GSplatManager {
      * @returns {import('../mesh-instance.js').MeshInstance|null} The pick mesh instance, or null.
      */
     prepareForPicking(camera, width, height) {
-        if (this.activeRenderer === GSPLAT_RENDERER_RASTER_GPU_SORT) {
+        if (this.renderer.usesGpuSort) {
             const sortedState = this.world.getState(this.world.currentVersion);
             if (!sortedState?.sortedBefore || !camera.node) return null;
 
@@ -430,7 +430,7 @@ class GSplatManager {
      * @private
      */
     get canCull() {
-        return this.activeRenderer !== GSPLAT_RENDERER_RASTER_CPU_SORT &&
+        return this.renderer.requiresBounds &&
             this.world.hasBounds;
     }
 
@@ -489,7 +489,7 @@ class GSplatManager {
         // World advances the render-ready version (cleanup + first-sort rebuild) and uploads the
         // sorted order texture; the manager applies the renderer-side reactions. Frustum-culling
         // bounds are only uploaded for non-CPU renderers (the CPU path doesn't allocate them).
-        const updateBounds = this.activeRenderer !== GSPLAT_RENDERER_RASTER_CPU_SORT;
+        const updateBounds = this.renderer.requiresBounds;
         const result = this.world.onSorted(version, count, orderData, this.cameraNode, updateBounds, this._markResult);
         if (result.rebuilt) {
             this.renderer.update(result.count, result.textureSize);
@@ -582,7 +582,7 @@ class GSplatManager {
 
         // GPU sorting is always ready, CPU sorting is ready if not too many jobs in flight. This is
         // the back-pressure gate the world uses to throttle LOD/world-state production.
-        const allowLodUpdate = this.activeRenderer !== GSPLAT_RENDERER_RASTER_CPU_SORT || (this.cpuSorter && this.cpuSorter.jobsInFlight < 3);
+        const allowLodUpdate = !this.renderer.requiresCpuSort || (this.cpuSorter && this.cpuSorter.jobsInFlight < 3);
 
         // World LOD / streaming / world-state creation.
         this.world.update(this.cameraNode, allowLodUpdate, !!this.cpuSorter, this._updateResult);
@@ -657,7 +657,7 @@ class GSplatManager {
         // Materialize the work buffer for the render-ready version (full rebuild or incremental).
         // Skipped internally until the state has been sorted at least once. Frustum-culling bounds
         // are only uploaded for non-CPU renderers (the CPU path doesn't allocate them).
-        const updateBounds = this.activeRenderer !== GSPLAT_RENDERER_RASTER_CPU_SORT;
+        const updateBounds = this.renderer.requiresBounds;
         this.world.bake(this.world.currentVersion, this.cameraNode, updateBounds, this._bakeResult);
         if (this._bakeResult.rebuilt) {
             this.renderer.update(this._bakeResult.count, this._bakeResult.textureSize);
@@ -674,7 +674,7 @@ class GSplatManager {
         // kick off sorting / compaction only if needed
         let gpuSortedThisFrame = false;
         if (this.sortNeeded && lastState) {
-            if (this.activeRenderer === GSPLAT_RENDERER_RASTER_GPU_SORT) {
+            if (this.renderer.usesGpuSort) {
                 this.sortGpuHybrid(lastState);
                 gpuSortedThisFrame = true;
             } else {
@@ -694,7 +694,7 @@ class GSplatManager {
 
         // Raster GPU sort needs projector + radix + fresh indirect args every frame (indirect
         // slots are per-frame; post-projector visible count differs from interval prefix sum).
-        if (this.activeRenderer === GSPLAT_RENDERER_RASTER_GPU_SORT && lastState && !gpuSortedThisFrame) {
+        if (this.renderer.usesGpuSort && lastState && !gpuSortedThisFrame) {
             this.sortGpuHybrid(lastState);
             gpuSortedThisFrame = true;
         }

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -500,6 +500,26 @@ class GSplatManager {
     }
 
     /**
+     * On the first sort of a world-state version, advances the render-ready version (cleanup +
+     * first-sort work-buffer rebuild) and applies the renderer rebuild reaction. The world version
+     * lifecycle is owned by the manager; the GPU pipeline (in the renderer) assumes a baked,
+     * render-ready work buffer. This is the synchronous GPU-sort counterpart of {@link onSorted}
+     * (the async CPU path). No-op once the version has been sorted before.
+     *
+     * @param {GSplatWorldState} worldState - The world state about to be sorted.
+     * @private
+     */
+    _markSortedIfNeeded(worldState) {
+        if (!worldState.sortedBefore) {
+            // GPU sort always runs interval culling, so upload bounds (updateBounds = true).
+            this.world.markSorted(worldState.version, worldState.totalActiveSplats, this.cameraNode, true, this._markResult);
+            if (this._markResult.rebuilt) {
+                this.renderer.update(this._markResult.count, this._markResult.textureSize);
+            }
+        }
+    }
+
+    /**
      * Tests if the camera has moved enough to require re-sorting.
      * - For radial sorting: only position matters (rotation doesn't affect sort order)
      * - For directional sorting: only forward direction matters (position doesn't affect sort order)
@@ -671,32 +691,27 @@ class GSplatManager {
         // an incremental update may have detected moved splats requiring a re-sort
         if (this._bakeResult.sortNeeded) this.sortNeeded = true;
 
-        // kick off sorting / compaction only if needed
-        let gpuSortedThisFrame = false;
-        if (this.sortNeeded && lastState) {
+        // Kick off sorting. The GPU path runs every frame (projector + radix + fresh per-frame
+        // indirect args; the post-projector visible count differs from the interval prefix sum).
+        // The CPU path posts to the worker only when a re-sort is needed. The version lifecycle
+        // (markSorted on the first sort of a version) stays here in the manager.
+        if (lastState) {
             if (this.renderer.usesGpuSort) {
+                this._markSortedIfNeeded(lastState);
                 this.sortGpuHybrid(lastState);
-                gpuSortedThisFrame = true;
-            } else {
-                // CPU sort just posts to the worker — indirect draw still needs updating below
+            } else if (this.sortNeeded) {
                 this.sortCpu(lastState);
             }
-            this.sortNeeded = false;
 
-            // Update camera tracking for next sort check
-            this.lastSortCameraPos.copy(this.cameraNode.getPosition());
-            this.lastSortCameraFwd.copy(this.cameraNode.forward);
+            if (this.sortNeeded) {
+                this.sortNeeded = false;
 
-            // Sort implies culling was also processed, so update culling trackers too
-            this.lastCullingCameraFwd.copy(this.cameraNode.forward);
-            this.lastCullingProjMat.copy(this.cameraNode.camera.projectionMatrix);
-        }
-
-        // Raster GPU sort needs projector + radix + fresh indirect args every frame (indirect
-        // slots are per-frame; post-projector visible count differs from interval prefix sum).
-        if (this.renderer.usesGpuSort && lastState && !gpuSortedThisFrame) {
-            this.sortGpuHybrid(lastState);
-            gpuSortedThisFrame = true;
+                // Update camera tracking for the next sort/cull check.
+                this.lastSortCameraPos.copy(this.cameraNode.getPosition());
+                this.lastSortCameraFwd.copy(this.cameraNode.forward);
+                this.lastCullingCameraFwd.copy(this.cameraNode.forward);
+                this.lastCullingProjMat.copy(this.cameraNode.camera.projectionMatrix);
+            }
         }
 
         // keep the shared mesh-instance's AABB in sync with the actual splat placements
@@ -818,16 +833,6 @@ class GSplatManager {
 
         if (!this.intervalCompaction) {
             this.intervalCompaction = new GSplatIntervalCompaction(this.device);
-        }
-
-        if (!worldState.sortedBefore) {
-            // World advances the render-ready version (cleanup + first-sort rebuild). Uses the
-            // manager's camera for the color bake (matches the prior rebuildWorkBuffer behavior).
-            // GPU sort / compute renderers always run interval culling, so upload bounds.
-            this.world.markSorted(worldState.version, elementCount, this.cameraNode, true, this._markResult);
-            if (this._markResult.rebuilt) {
-                this.renderer.update(this._markResult.count, this._markResult.textureSize);
-            }
         }
 
         this.intervalCompaction.uploadIntervals(worldState);

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -43,23 +43,17 @@ const _lodColors = [
 
 /**
  * GSplatManager manages the rendering of splats using a work buffer, where all active splats are
- * stored and rendered from.
+ * stored and rendered from. It owns the {@link GSplatWorld} (work buffer, world-state versions,
+ * streaming, bake), the world version lifecycle ({@link GSplatWorld#markSorted}/`onSorted`), and —
+ * for the CPU-sort path ({@link GSplatQuadRenderer}) — a web-worker sorter. Each frame it bakes the
+ * render-ready world state and then delegates per-view work to the active renderer:
  *
- * Shared culling + compaction (raster GPU-sort path, WebGPU only):
- *   Interval compaction operates on contiguous intervals of splats (one per octree node).
- *   1. Cull + count (compute): each interval's bounding sphere is tested against frustum
- *      planes (or a fisheye cone). The pass writes the interval's splat count (or 0 if
- *      culled) into a count buffer.
- *   2. Prefix sum: exclusive prefix sum over the count buffer produces output offsets.
- *      The last element gives visibleCount.
- *   3. Scatter (compute): one workgroup per interval expands visible intervals into
- *      compactedSplatIds (flat list of work-buffer pixel indices).
- *
- * Raster renderer — CPU sorting (WebGPU and WebGL, {@link GSplatQuadRenderer}):
- *   1. Sort on worker: camera position and splat centers are sent to a web worker which
- *      performs a counting sort and returns the sorted order as orderBuffer.
- *   2. Render: the vertex shader reads orderBuffer[vertexId] → splatId.
- *      No culling or compaction is used.
+ * - CPU sort (WebGPU + WebGL): the manager sends camera + centers to the worker, which returns a
+ *   sorted order; the quad renderer's vertex shader reads `orderBuffer[vertexId] → splatId`. No
+ *   GPU culling.
+ * - GPU sort ({@link GSplatHybridRenderer}, WebGPU only): the renderer owns the interval cull +
+ *   compaction, projector, and radix sort; the manager just marks the version sorted and calls
+ *   {@link GSplatRenderer#prepareRenderView}.
  *
  * @ignore
  */
@@ -110,12 +104,6 @@ class GSplatManager {
 
     /** @type {Vec3} */
     lastSortCameraFwd = new Vec3(Infinity, Infinity, Infinity);
-
-    /** @type {Vec3} */
-    lastCullingCameraFwd = new Vec3(Infinity, Infinity, Infinity);
-
-    /** @type {Mat4} */
-    lastCullingProjMat = new Mat4();
 
     /** @type {boolean} */
     sortNeeded = true;
@@ -377,17 +365,6 @@ class GSplatManager {
     }
 
     /**
-     * True when frustum culling can run (bounds data available).
-     *
-     * @type {boolean}
-     * @private
-     */
-    get canCull() {
-        return this.renderer.requiresBounds &&
-            this.world.hasBounds;
-    }
-
-    /**
      * Creates the renderer and sort resources for the given mode. Used at init time.
      *
      * @param {number} mode - The GSPLAT_RENDERER_* constant.
@@ -498,27 +475,6 @@ class GSplatManager {
 
         // first run, force update to initialize last orientation
         return true;
-    }
-
-    /**
-     * Tests if the camera frustum has changed since the last sort or compaction. Checks both
-     * projection matrix and camera rotation. Used to trigger re-culling/compaction independently of
-     * sort-key changes.
-     *
-     * @returns {boolean} True if the frustum changed.
-     */
-    testFrustumChanged() {
-        const epsilon = 0.001;
-
-        // Projection changes (window resize, FOV, near/far, custom projection, etc.)
-        if (!this.lastCullingProjMat.equals(this.cameraNode.camera.projectionMatrix)) {
-            return true;
-        }
-
-        // Rotation changes
-        const currentCameraFwd = this.cameraNode.forward;
-        const dot = Math.min(1, Math.max(-1, this.lastCullingCameraFwd.dot(currentCameraFwd)));
-        return Math.acos(dot) > epsilon;
     }
 
     /**
@@ -651,11 +607,9 @@ class GSplatManager {
             if (this.sortNeeded) {
                 this.sortNeeded = false;
 
-                // Update camera tracking for the next sort/cull check.
+                // Update camera tracking for the next CPU re-sort check.
                 this.lastSortCameraPos.copy(this.cameraNode.getPosition());
                 this.lastSortCameraFwd.copy(this.cameraNode.forward);
-                this.lastCullingCameraFwd.copy(this.cameraNode.forward);
-                this.lastCullingProjMat.copy(this.cameraNode.camera.projectionMatrix);
             }
         }
 

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -15,13 +15,13 @@ import { Color } from '../../core/math/color.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
- * @import { StorageBuffer } from '../../platform/graphics/storage-buffer.js'
  * @import { GSplatPlacement } from './gsplat-placement.js'
  * @import { GSplatWorldState } from './gsplat-world-state.js'
  * @import { Scene } from '../scene.js'
  * @import { Layer } from '../layer.js'
  * @import { GSplatDirector } from './gsplat-director.js'
  * @import { GSplatRenderer } from './gsplat-renderer.js'
+ * @import { GSplatRenderViewParams } from './gsplat-renderer.js'
  */
 
 const cameraPosition = new Vec3();
@@ -160,17 +160,19 @@ class GSplatManager {
      * Reused per-call parameter bag passed to the renderer's forward {@link GSplatRenderer#prepareRenderView}.
      * Avoids per-frame allocation and keeps the renderer free of a back-reference to the manager/scene.
      *
+     * @type {GSplatRenderViewParams}
      * @private
      */
-    _renderViewParams = {};
+    _renderViewParams = /** @type {GSplatRenderViewParams} */ ({});
 
     /**
      * Reused per-call parameter bag passed to the renderer's {@link GSplatRenderer#preparePickingView}.
      * Separate from {@link _renderViewParams} so mid-frame picking can't corrupt the forward params.
      *
+     * @type {GSplatRenderViewParams}
      * @private
      */
-    _pickParams = {};
+    _pickParams = /** @type {GSplatRenderViewParams} */ ({});
 
     /**
      * @param {GraphicsDevice} device - The graphics device.
@@ -290,7 +292,7 @@ class GSplatManager {
      * Writes the current scene gsplat params into a renderer per-view parameter bag. Lets the
      * renderer run its GPU pipeline without a back-reference to the manager or scene.
      *
-     * @param {object} p - The parameter bag to populate.
+     * @param {GSplatRenderViewParams} p - The parameter bag to populate.
      * @private
      */
     _writeGsplatParams(p) {
@@ -311,7 +313,7 @@ class GSplatManager {
     /**
      * Fills and returns the reused forward-view parameter bag for the manager's camera.
      *
-     * @returns {object} The populated {@link _renderViewParams}.
+     * @returns {GSplatRenderViewParams} The populated {@link _renderViewParams}.
      * @private
      */
     _fillRenderViewParams() {
@@ -327,7 +329,7 @@ class GSplatManager {
      * @param {object} camera - The picker camera.
      * @param {number} width - Pick target width.
      * @param {number} height - Pick target height.
-     * @returns {object} The populated {@link _pickParams}.
+     * @returns {GSplatRenderViewParams} The populated {@link _pickParams}.
      * @private
      */
     _fillPickParams(camera, width, height) {

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -5,9 +5,6 @@ import { GSplatUnifiedSorter } from './gsplat-unified-sorter.js';
 import { GSplatWorld } from './gsplat-world.js';
 import { GSplatQuadRenderer } from './gsplat-quad-renderer.js';
 import { GSplatHybridRenderer } from './gsplat-hybrid-renderer.js';
-import { GSplatProjector } from './gsplat-projector.js';
-import { GSplatIntervalCompaction } from './gsplat-interval-compaction.js';
-import { ComputeRadixSort } from '../graphics/radix-sort/compute-radix-sort.js';
 import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import {
@@ -15,7 +12,6 @@ import {
     GSPLAT_DEBUG_AABBS
 } from '../constants.js';
 import { Color } from '../../core/math/color.js';
-import { ALPHA_VISIBILITY_THRESHOLD } from './constants.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
@@ -31,7 +27,6 @@ import { ALPHA_VISIBILITY_THRESHOLD } from './constants.js';
 const cameraPosition = new Vec3();
 const cameraDirection = new Vec3();
 const translation = new Vec3();
-const _tempVec3 = new Vec3();
 const invModelMat = new Mat4();
 
 // Color instances used by debug wireframe rendering (GSPLAT_DEBUG_AABBS)
@@ -95,50 +90,11 @@ class GSplatManager {
     activeRenderer;
 
     /**
-     * CPU-based sorter (when not using GPU sorting).
+     * CPU-based sorter (used by the quad renderer; the hybrid renderer owns its own GPU sort).
      *
      * @type {GSplatUnifiedSorter|null}
      */
     cpuSorter = null;
-
-    /**
-     * GPU-based radix sorter (raster GPU sort path).
-     *
-     * @type {ComputeRadixSort|null}
-     */
-    gpuSorter = null;
-
-    /**
-     * Interval-based GPU compaction (raster GPU sort / compute paths).
-     *
-     * @type {GSplatIntervalCompaction|null}
-     */
-    intervalCompaction = null;
-
-    /**
-     * Compute projector + sort keys for {@link GSPLAT_RENDERER_RASTER_GPU_SORT}.
-     *
-     * @type {GSplatProjector|null}
-     */
-    projector = null;
-
-    /**
-     * Indirect draw slot index for the current frame (-1 when not using indirect draw).
-     */
-    indirectDrawSlot = -1;
-
-    /**
-     * Indirect dispatch slot for raster GPU sort (projector + radix) and compute paths.
-     * The compute local renderer builds its own indirect args in private buffers
-     * and does not use these slots.
-     */
-    indirectDispatchSlot = -1;
-
-    /**
-     * Total intervals from the last interval compaction dispatch. Needed for
-     * writeIndirectArgs to index into the prefix sum buffer for visible count.
-     */
-    lastCompactedNumIntervals = 0;
 
     /**
      * Tracks last seen centersVersion per resource ID for detecting centers updates. Used to feed
@@ -213,6 +169,22 @@ class GSplatManager {
     _streamAdvanced = false;
 
     /**
+     * Reused per-call parameter bag passed to the renderer's forward {@link GSplatRenderer#prepareRenderView}.
+     * Avoids per-frame allocation and keeps the renderer free of a back-reference to the manager/scene.
+     *
+     * @private
+     */
+    _renderViewParams = {};
+
+    /**
+     * Reused per-call parameter bag passed to the renderer's {@link GSplatRenderer#preparePickingView}.
+     * Separate from {@link _renderViewParams} so mid-frame picking can't corrupt the forward params.
+     *
+     * @private
+     */
+    _pickParams = {};
+
+    /**
      * @param {GraphicsDevice} device - The graphics device.
      * @param {GSplatDirector} director - The director.
      * @param {Layer} layer - The layer.
@@ -235,49 +207,15 @@ class GSplatManager {
     destroy() {
         this._destroyed = true;
 
-        // Tear down sorters first — destroyGpuSorting calls renderer.setCpuSortedRendering(), so the
-        // renderer must still be alive here.
-        this.destroyGpuSorting();
+        // Tear down the CPU sorter while the renderer and world are still alive.
         this.destroyCpuSorting();
 
         // World frees world states (decRef resources), octree instances, and the work buffer. Must
         // run before renderer.destroy() (the renderer references the work buffer's textures/format).
         this.world.destroy();
 
+        // The renderer frees its own GPU sort resources (radix sorter, projector, compaction).
         this.renderer.destroy();
-    }
-
-    /**
-     * Destroys GPU sorting resources (radix sorter, projector, compaction).
-     *
-     * @private
-     */
-    destroyGpuSorting() {
-        this.gpuSorter?.destroy();
-        this.gpuSorter = null;
-        this.projector?.destroy();
-        this.projector = null;
-
-        // Switch renderer to CPU mode once, before destroying compaction.
-        const useCpuSort = false;
-        this.renderer.setCpuSortedRendering();
-        this.destroyIntervalCompaction(useCpuSort);
-    }
-
-    /**
-     * Destroys interval compaction resources.
-     *
-     * @param {boolean} [useCpuSort] - Whether to switch the renderer to CPU-sorted mode.
-     * @private
-     */
-    destroyIntervalCompaction(useCpuSort = true) {
-        if (this.intervalCompaction) {
-            if (useCpuSort) {
-                this.renderer.setCpuSortedRendering();
-            }
-            this.intervalCompaction.destroy();
-            this.intervalCompaction = null;
-        }
     }
 
     /**
@@ -288,20 +226,6 @@ class GSplatManager {
     destroyCpuSorting() {
         this.cpuSorter?.destroy();
         this.cpuSorter = null;
-    }
-
-    /**
-     * GPU radix sort + projector for hybrid raster (no separate sort-key compute pass).
-     *
-     * @private
-     */
-    initHybridSorting() {
-        if (!this.gpuSorter) {
-            this.gpuSorter = new ComputeRadixSort(this.device, { indirect: true });
-        }
-        if (!this.projector) {
-            this.projector = new GSplatProjector(this.device);
-        }
     }
 
     /**
@@ -368,34 +292,63 @@ class GSplatManager {
      * @returns {import('../mesh-instance.js').MeshInstance|null} The pick mesh instance, or null.
      */
     prepareForPicking(camera, width, height) {
-        if (this.renderer.usesGpuSort) {
-            const sortedState = this.world.getState(this.world.currentVersion);
-            if (!sortedState?.sortedBefore || !camera.node) return null;
+        if (!this.renderer.usesGpuSort || !camera.node) return null;
+        const sortedState = this.world.getState(this.world.currentVersion);
+        if (!sortedState?.sortedBefore) return null;
+        return this.renderer.preparePickingView(this.world, sortedState, this._fillPickParams(camera, width, height));
+    }
 
-            const sortedIndices = this.sortGpuHybridForCamera(
-                sortedState,
-                camera.node,
-                width,
-                height,
-                Math.max(ALPHA_VISIBILITY_THRESHOLD, this.scene.gsplat.alphaClip),
-                !!this.world.workBuffer.format.getStream('pcId')
-            );
-            if (!sortedIndices) return null;
+    /**
+     * Writes the current scene gsplat params into a renderer per-view parameter bag. Lets the
+     * renderer run its GPU pipeline without a back-reference to the manager or scene.
+     *
+     * @param {object} p - The parameter bag to populate.
+     * @private
+     */
+    _writeGsplatParams(p) {
+        const gsplat = this.scene.gsplat;
+        p.radialSorting = gsplat.radialSorting;
+        p.alphaClip = gsplat.alphaClip;
+        p.alphaClipForward = gsplat.alphaClipForward;
+        p.minPixelSize = gsplat.minPixelSize;
+        p.minContribution = gsplat.minContribution;
+        p.foveationStrength = gsplat.foveationStrength;
+        p.foveationCenter = gsplat.foveationCenter;
+        p.antiAlias = gsplat.antiAlias;
+        p.fisheye = gsplat.fisheye;
+        p.material = gsplat.material;
+        p.varyings = gsplat.varyings;
+    }
 
-            const proj = /** @type {GSplatProjector} */ (this.projector);
-            const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
-            return /** @type {GSplatHybridRenderer} */ (/** @type {unknown} */ (this.renderer)).prepareForPicking(
-                this.indirectDrawSlot,
-                sortedIndices,
-                /** @type {StorageBuffer} */ (proj.projCache),
-                /** @type {StorageBuffer} */ (ic.numSplatsBuffer),
-                this.scene.gsplat.alphaClip,
-                this.scene.gsplat.alphaClipForward,
-                camera.node
-            );
-        }
+    /**
+     * Fills and returns the reused forward-view parameter bag for the manager's camera.
+     *
+     * @returns {object} The populated {@link _renderViewParams}.
+     * @private
+     */
+    _fillRenderViewParams() {
+        const p = this._renderViewParams;
+        this._writeGsplatParams(p);
+        p.cameraNode = this.cameraNode;
+        return p;
+    }
 
-        return null;
+    /**
+     * Fills and returns the reused picking parameter bag for the picker camera.
+     *
+     * @param {object} camera - The picker camera.
+     * @param {number} width - Pick target width.
+     * @param {number} height - Pick target height.
+     * @returns {object} The populated {@link _pickParams}.
+     * @private
+     */
+    _fillPickParams(camera, width, height) {
+        const p = this._pickParams;
+        this._writeGsplatParams(p);
+        p.cameraNode = camera.node;
+        p.width = width;
+        p.height = height;
+        return p;
     }
 
     /**
@@ -443,8 +396,8 @@ class GSplatManager {
     _createRenderer(mode) {
         const workBuffer = this.world.workBuffer;
         if (mode === GSPLAT_RENDERER_RASTER_GPU_SORT) {
+            // The hybrid renderer creates its own GPU sort resources (radix sorter, projector).
             this.renderer = new GSplatHybridRenderer(this.device, this.node, this.cameraNode, this.layer, workBuffer);
-            this.initHybridSorting();
         } else {
             this.renderer = new GSplatQuadRenderer(this.device, this.node, this.cameraNode, this.layer, workBuffer);
             this.initCpuSorting();
@@ -466,7 +419,8 @@ class GSplatManager {
         // world-state rebuild so splats[] matches the new sorter (see hasCenters gates).
         this.world.invalidate({ worldState: true });
 
-        this.destroyGpuSorting();
+        // The renderer owns its GPU sort resources and frees them in destroy(); the manager owns
+        // only the CPU sorter.
         this.destroyCpuSorting();
         this.renderer.destroy();
         this._createRenderer(requested);
@@ -633,18 +587,9 @@ class GSplatManager {
             this.cpuSorter.applyPendingSorted();
         }
 
-        // check if camera has moved enough to require re-sorting
+        // check if camera has moved enough to require re-sorting (CPU path; the GPU path re-sorts
+        // every frame regardless)
         if (this.testCameraMovedForSort()) {
-            this.sortNeeded = true;
-        }
-
-        // if culling is active but we do not need to sort, check if the frustum changed requiring re-culling
-        if (this.intervalCompaction && !this.sortNeeded && this.testFrustumChanged()) {
-
-            // store the current camera frustum related properties
-            this.lastCullingCameraFwd.copy(this.cameraNode.forward);
-            this.lastCullingProjMat.copy(this.cameraNode.camera.projectionMatrix);
-
             this.sortNeeded = true;
         }
 
@@ -686,7 +631,7 @@ class GSplatManager {
             this.renderer.setOrderData();
 
             // boundsBaseIndex may have changed — force interval metadata re-upload
-            this.intervalCompaction?.invalidateUpload();
+            this.renderer.invalidateCullUpload();
         }
         // an incremental update may have detected moved splats requiring a re-sort
         if (this._bakeResult.sortNeeded) this.sortNeeded = true;
@@ -698,7 +643,7 @@ class GSplatManager {
         if (lastState) {
             if (this.renderer.usesGpuSort) {
                 this._markSortedIfNeeded(lastState);
-                this.sortGpuHybrid(lastState);
+                this.renderer.prepareRenderView(this.world, lastState, this._fillRenderViewParams());
             } else if (this.sortNeeded) {
                 this.sortCpu(lastState);
             }
@@ -763,282 +708,6 @@ class GSplatManager {
 
         // update cpu sorter with current splats (adds new centers, removes unused ones)
         this.cpuSorter.updateCentersForSplats(splats);
-    }
-
-    /**
-     * Hybrid GPU path: interval compaction, projector (keys + proj cache), indirect radix sort
-     * over projector keys (indices are dense in projCache), then hybrid raster bindings.
-     *
-     * @param {GSplatWorldState} worldState - The world state to sort.
-     */
-    sortGpuHybrid(worldState) {
-        const cam = this.cameraNode.camera;
-        const sceneCam = cam.camera;
-        const rt = cam.renderTarget;
-        const rect = cam.rect;
-
-        // Match Renderer#setCameraUniforms: in stereo XR the XR session reports the per-eye
-        // viewport directly, which is correct for both side-by-side single-texture and
-        // multi-pass per-eye-view layouts — preferred over inferring from target.width.
-        const xrView = sceneCam.xrActive ? (sceneCam.xrViews[0] ?? null) : null;
-        const viewportWidth = Math.floor((xrView ? xrView.viewport.z : (rt ? rt.width : this.device.width)) * rect.z);
-        const viewportHeight = Math.floor((xrView ? xrView.viewport.w : (rt ? rt.height : this.device.height)) * rect.w);
-
-        // Stereo XR: project both eyes in a single projector pass (GSPLAT_XR variant). Requires
-        // exactly 2 parallel-axis views. Keep the VS define in sync with the projector variant.
-        const xrViewCount = sceneCam.xrActive ? sceneCam.xrViews.length : 0;
-        if (xrViewCount > 2) {
-            Debug.errorOnce(`GSplatManager: the hybrid GPU-sort renderer supports at most 2 XR views (stereo), but the session has ${xrViewCount}. Additional views will not render correctly.`);
-        }
-        const isStereo = xrViewCount === 2;
-        this.renderer.setStereo?.(isStereo);
-
-        const sortedIndices = this.sortGpuHybridForCamera(
-            worldState,
-            this.cameraNode,
-            viewportWidth,
-            viewportHeight,
-            Math.max(ALPHA_VISIBILITY_THRESHOLD, this.scene.gsplat.alphaClipForward),
-            false,
-            isStereo
-        );
-
-        if (sortedIndices) {
-            this.applyGpuSortResults(sortedIndices);
-        }
-    }
-
-    /**
-     * Runs the shared hybrid projector + indirect radix sort path for a specific camera.
-     *
-     * @param {GSplatWorldState} worldState - The world state to sort.
-     * @param {GraphNode} cameraNode - Camera node used for projection and sort keys.
-     * @param {number} viewportWidth - Projection viewport width in pixels.
-     * @param {number} viewportHeight - Projection viewport height in pixels.
-     * @param {number} alphaClip - Projector producer alpha threshold.
-     * @param {boolean} pickMode - Whether projector writes pcId into the cache.
-     * @param {boolean} [isStereo] - Whether to project both XR eyes in one pass (forward path only;
-     * picking stays mono).
-     * @returns {StorageBuffer|null} The sorted cache indices, or null if no work was dispatched.
-     * @private
-     */
-    sortGpuHybridForCamera(worldState, cameraNode, viewportWidth, viewportHeight, alphaClip, pickMode, isStereo = false) {
-        const gpuSorter = this.gpuSorter;
-        const projector = this.projector;
-        Debug.assert(gpuSorter && projector, 'Hybrid GPU sort not initialized');
-        if (!gpuSorter || !projector) return null;
-
-        const elementCount = worldState.totalActiveSplats;
-        if (elementCount === 0) return null;
-
-        if (!this.intervalCompaction) {
-            this.intervalCompaction = new GSplatIntervalCompaction(this.device);
-        }
-
-        this.intervalCompaction.uploadIntervals(worldState);
-
-        if (this.canCull) {
-            const state = this.world.getState(this.world.currentVersion);
-            if (state) {
-                this._runFrustumCulling(state, cameraNode);
-            }
-        }
-
-        const fisheyeProj = this.renderer.fisheyeProj;
-        const numIntervals = worldState.totalIntervals;
-        const totalActiveSplats = worldState.totalActiveSplats;
-        this.intervalCompaction.dispatchCompact(this.world.workBuffer.frustumCuller, numIntervals, totalActiveSplats, fisheyeProj.enabled);
-
-        this.allocateAndWriteIntervalIndirectArgs(numIntervals);
-
-        const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
-        const compactedSplatIds = ic.compactedSplatIds;
-        const gsplat = this.scene.gsplat;
-
-        const numBits = Math.max(10, Math.min(20, Math.round(Math.log2(elementCount / 4))));
-        const radixBits = gpuSorter.radixBits;
-        const roundedNumBits = Math.ceil(numBits / radixBits) * radixBits;
-
-        const { minDist, maxDist } = this.computeDistanceRange(worldState, cameraNode);
-
-        const sortIndirectInfo = gpuSorter.prepareIndirect();
-
-        projector.dispatch({
-            workBuffer: this.world.workBuffer,
-            cameraNode,
-            compactedSplatIds: /** @type {StorageBuffer} */ (compactedSplatIds),
-            sortElementCountBuffer: /** @type {StorageBuffer} */ (ic.sortElementCountBuffer),
-            totalCapacity: elementCount,
-            radialSort: gsplat.radialSorting,
-            numBits: roundedNumBits,
-            minDist,
-            maxDist,
-            alphaClip,
-            minPixelSize: gsplat.minPixelSize * 0.5,
-            minContribution: gsplat.minContribution,
-            foveationStrength: gsplat.foveationStrength,
-            foveationCenter: gsplat.foveationCenter,
-            viewportWidth,
-            viewportHeight,
-            flipY: !!cameraNode.camera.renderTarget?.flipY,
-            pickMode,
-            fisheyeProj,
-            antiAlias: gsplat.antiAlias,
-            isStereo,
-            material: gsplat.material,
-            userCacheWords: gsplat.varyings.words
-        });
-
-        projector.writeIndirectArgs(
-            this.indirectDrawSlot,
-            this.indirectDispatchSlot + 1,
-            /** @type {StorageBuffer} */ (ic.numSplatsBuffer),
-            /** @type {StorageBuffer} */ (ic.sortElementCountBuffer),
-            sortIndirectInfo
-        );
-
-        return gpuSorter.sortIndirect(
-            /** @type {StorageBuffer} */ (projector.sortKeys),
-            elementCount,
-            roundedNumBits,
-            this.indirectDispatchSlot + 1,
-            /** @type {StorageBuffer} */ (ic.sortElementCountBuffer),
-            undefined,
-            false,
-            true  // destructiveKeys: projector overwrites sortKeys each frame before the sort
-        );
-    }
-
-    /**
-     * Allocates per-frame indirect draw and dispatch slots and runs writeIndirectArgs
-     * for interval compaction.
-     *
-     * @param {number} numIntervals - Total interval count (index into prefix sum for visible count).
-     * @private
-     */
-    allocateAndWriteIntervalIndirectArgs(numIntervals) {
-        const gpuSorter = /** @type {ComputeRadixSort} */ (this.gpuSorter);
-        const sortInfo = gpuSorter.prepareIndirect();
-        const sortSlotCount = sortInfo[0];
-
-        this.indirectDrawSlot = this.device.getIndirectDrawSlot(1);
-        // Reserve contiguous dispatch slots for hybrid / legacy layout (e.g. sort passes).
-        this.indirectDispatchSlot = this.device.getIndirectDispatchSlot(1 + sortSlotCount);
-        const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
-        ic.writeIndirectArgs(this.indirectDrawSlot, this.indirectDispatchSlot, numIntervals, sortInfo);
-        this.lastCompactedNumIntervals = numIntervals;
-    }
-
-    /**
-     * Applies hybrid GPU sort results to the renderer with indirect draw from interval compaction.
-     *
-     * @param {StorageBuffer} sortedIndices - Buffer containing sorted splat IDs.
-     * @private
-     */
-    applyGpuSortResults(sortedIndices) {
-        const proj = /** @type {GSplatProjector} */ (this.projector);
-        const ic = /** @type {GSplatIntervalCompaction} */ (this.intervalCompaction);
-        /** @type {GSplatHybridRenderer} */ (/** @type {unknown} */ (this.renderer)).setHybridSortedRendering(
-            this.indirectDrawSlot,
-            sortedIndices,
-            /** @type {StorageBuffer} */ (proj.projCache),
-            /** @type {StorageBuffer} */ (ic.numSplatsBuffer)
-        );
-    }
-
-    /**
-     * Prepares frustum culling data: updates the GPU transform buffers and computes
-     * frustum planes from the camera. The actual culling test runs inline in the
-     * interval compaction compute shader.
-     *
-     * @param {GSplatWorldState} worldState - The world state whose splats provide transforms.
-     * @param {GraphNode} [cameraNode] - Camera node to cull against.
-     * @private
-     */
-    _runFrustumCulling(worldState, cameraNode = this.cameraNode) {
-        this.world.workBuffer.frustumCuller.updateTransformsData(worldState.boundsGroups);
-
-        const cam = cameraNode.camera;
-        const sceneCamera = cam.camera;
-        const xrViews = sceneCamera.xrViews;
-        if (xrViews?.length) {
-            // XR: cull against the combined frustum of all views, so splats visible only near
-            // one eye's edge (e.g. the right edge of the right eye) are not dropped. The per-view
-            // "off" matrices are refreshed at render time by setCameraUniforms, which runs AFTER
-            // this culling, so refresh them here (mirrors the projector dispatch).
-            sceneCamera.updateViewTransforms();
-            sceneCamera.updateXrFrustum();
-            this.world.workBuffer.frustumCuller.setFrustumPlanes(sceneCamera.frustum);
-        } else {
-            this.world.workBuffer.frustumCuller.computeFrustumPlanes(cam.projectionMatrix, cam.viewMatrix);
-        }
-
-        const gsplat = this.scene.gsplat;
-        const fp = this.renderer.fisheyeProj;
-        // XR does not support fisheye in any renderer; resolveFisheye forces it off (and warns once).
-        fp.update(this.renderer.resolveFisheye(gsplat.fisheye), cam.fov, cam.projectionMatrix);
-
-        if (fp.enabled) {
-            this.world.workBuffer.frustumCuller.setFisheyeData(
-                cameraNode.getPosition(),
-                cameraNode.forward,
-                fp.maxTheta
-            );
-        }
-    }
-
-    /**
-     * Computes the min/max effective distances for the current world state.
-     *
-     * @param {GSplatWorldState} worldState - The world state.
-     * @param {GraphNode} [cameraNode] - Camera node to measure distances from.
-     * @returns {{minDist: number, maxDist: number}} The distance range.
-     */
-    computeDistanceRange(worldState, cameraNode = this.cameraNode) {
-        const cameraMat = cameraNode.getWorldTransform();
-        cameraMat.getTranslation(cameraPosition);
-        cameraMat.getZ(cameraDirection).normalize();
-
-        const radialSort = this.scene.gsplat.radialSorting;
-
-        // For radial: minDist is always 0, only track maxDist
-        // For linear: track both min and max along camera direction
-        let minDist = radialSort ? 0 : Infinity;
-        let maxDist = radialSort ? 0 : -Infinity;
-
-        for (const splat of worldState.splats) {
-            const modelMat = splat.node.getWorldTransform();
-            const aabbMin = splat.aabb.getMin();
-            const aabbMax = splat.aabb.getMax();
-
-            // Check all 8 corners of local-space AABB
-            for (let i = 0; i < 8; i++) {
-                _tempVec3.x = (i & 1) ? aabbMax.x : aabbMin.x;
-                _tempVec3.y = (i & 2) ? aabbMax.y : aabbMin.y;
-                _tempVec3.z = (i & 4) ? aabbMax.z : aabbMin.z;
-
-                // Transform to world space
-                modelMat.transformPoint(_tempVec3, _tempVec3);
-
-                if (radialSort) {
-                    // Radial: distance from camera
-                    const dist = _tempVec3.distance(cameraPosition);
-                    if (dist > maxDist) maxDist = dist;
-                } else {
-                    // Linear: distance along camera direction
-                    const dist = _tempVec3.sub(cameraPosition).dot(cameraDirection);
-                    if (dist < minDist) minDist = dist;
-                    if (dist > maxDist) maxDist = dist;
-                }
-            }
-        }
-
-        // Handle empty state
-        if (maxDist === 0 || maxDist === -Infinity) {
-            return { minDist: 0, maxDist: 1 };
-        }
-
-        return { minDist, maxDist };
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -10,7 +10,33 @@ import { FisheyeProjection } from '../graphics/fisheye-projection.js';
  * @import { GraphNode } from '../graph-node.js'
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { GSplatWorkBuffer } from './gsplat-work-buffer.js'
+ * @import { GSplatWorld } from './gsplat-world.js'
+ * @import { GSplatWorldState } from './gsplat-world-state.js'
+ * @import { GSplatVaryings } from './gsplat-varyings.js'
+ * @import { MeshInstance } from '../mesh-instance.js'
  * @import { FogParams } from '../fog-params.js'
+ */
+
+/**
+ * Per-call parameters for a renderer view (forward or pick), populated by the manager each frame
+ * from the scene gsplat settings plus the view camera (and pick viewport). Reused per call to avoid
+ * per-frame allocation; the renderer must not retain a reference to it.
+ *
+ * @typedef {object} GSplatRenderViewParams
+ * @property {GraphNode} cameraNode - The camera node for this view.
+ * @property {boolean} radialSorting - Whether radial (vs linear) depth sorting is used.
+ * @property {number} alphaClip - Alpha threshold for shadow/pick/prepass rendering.
+ * @property {number} alphaClipForward - Alpha floor for the forward pass.
+ * @property {number} minPixelSize - Minimum projected splat size.
+ * @property {number} minContribution - Minimum visual contribution threshold.
+ * @property {number} foveationStrength - Foveation strength.
+ * @property {number} foveationCenter - Foveation center.
+ * @property {boolean} antiAlias - Whether antialiasing is enabled.
+ * @property {number} fisheye - Fisheye projection strength.
+ * @property {ShaderMaterial} material - The scene gsplat template material.
+ * @property {GSplatVaryings} varyings - User varying streams (provides the cache `words` count).
+ * @property {number} [width] - Pick viewport width in pixels (picking only).
+ * @property {number} [height] - Pick viewport height in pixels (picking only).
  */
 
 /**
@@ -217,6 +243,33 @@ class GSplatRenderer {
      * may have moved bounds indices). No-op for renderers without a GPU cull pipeline.
      */
     invalidateCullUpload() {
+    }
+
+    /**
+     * Prepares the forward view for rendering. Renderers that run their own GPU pipeline (cull +
+     * projection + sort) do their per-frame work here; CPU-sort renderers rely on the manager's
+     * worker instead and leave this as a no-op.
+     *
+     * @param {GSplatWorld} world - The world providing the work buffer, bounds, and states.
+     * @param {GSplatWorldState} worldState - The render-ready world state to draw.
+     * @param {GSplatRenderViewParams} params - Per-call parameters for this view.
+     * @returns {boolean} True if a GPU dispatch ran this call.
+     */
+    prepareRenderView(world, worldState, params) {
+        return false;
+    }
+
+    /**
+     * Prepares a pick view and returns the configured pick mesh instance. Only meaningful for
+     * renderers with a GPU pipeline; others return null.
+     *
+     * @param {GSplatWorld} world - The world providing the work buffer, bounds, and states.
+     * @param {GSplatWorldState} worldState - The render-ready world state.
+     * @param {GSplatRenderViewParams} pickParams - Per-call parameters for the pick view.
+     * @returns {MeshInstance|null} The pick mesh instance, or null.
+     */
+    preparePickingView(world, worldState, pickParams) {
+        return null;
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -12,7 +12,6 @@ import { FisheyeProjection } from '../graphics/fisheye-projection.js';
  * @import { GSplatWorkBuffer } from './gsplat-work-buffer.js'
  * @import { GSplatWorld } from './gsplat-world.js'
  * @import { GSplatWorldState } from './gsplat-world-state.js'
- * @import { GSplatVaryings } from './gsplat-varyings.js'
  * @import { MeshInstance } from '../mesh-instance.js'
  * @import { FogParams } from '../fog-params.js'
  */
@@ -23,6 +22,7 @@ import { FisheyeProjection } from '../graphics/fisheye-projection.js';
  * per-frame allocation; the renderer must not retain a reference to it.
  *
  * @typedef {object} GSplatRenderViewParams
+ * @ignore
  * @property {GraphNode} cameraNode - The camera node for this view.
  * @property {boolean} radialSorting - Whether radial (vs linear) depth sorting is used.
  * @property {number} alphaClip - Alpha threshold for shadow/pick/prepass rendering.
@@ -34,7 +34,7 @@ import { FisheyeProjection } from '../graphics/fisheye-projection.js';
  * @property {boolean} antiAlias - Whether antialiasing is enabled.
  * @property {number} fisheye - Fisheye projection strength.
  * @property {ShaderMaterial} material - The scene gsplat template material.
- * @property {GSplatVaryings} varyings - User varying streams (provides the cache `words` count).
+ * @property {import('./gsplat-varyings.js').GSplatVaryings} varyings - User varying streams (provides the cache `words` count).
  * @property {number} [width] - Pick viewport width in pixels (picking only).
  * @property {number} [height] - Pick viewport height in pixels (picking only).
  */

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -12,6 +12,7 @@ import { FisheyeProjection } from '../graphics/fisheye-projection.js';
  * @import { GSplatWorkBuffer } from './gsplat-work-buffer.js'
  * @import { GSplatWorld } from './gsplat-world.js'
  * @import { GSplatWorldState } from './gsplat-world-state.js'
+ * @import { GSplatVaryings } from './gsplat-varyings.js'
  * @import { MeshInstance } from '../mesh-instance.js'
  * @import { FogParams } from '../fog-params.js'
  */
@@ -34,7 +35,7 @@ import { FisheyeProjection } from '../graphics/fisheye-projection.js';
  * @property {boolean} antiAlias - Whether antialiasing is enabled.
  * @property {number} fisheye - Fisheye projection strength.
  * @property {ShaderMaterial} material - The scene gsplat template material.
- * @property {import('./gsplat-varyings.js').GSplatVaryings} varyings - User varying streams (provides the cache `words` count).
+ * @property {GSplatVaryings} varyings - User varying streams (provides the cache `words` count).
  * @property {number} [width] - Pick viewport width in pixels (picking only).
  * @property {number} [height] - Pick viewport height in pixels (picking only).
  */

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -102,6 +102,35 @@ class GSplatRenderer {
     }
 
     /**
+     * Whether this renderer runs the GPU sort/projection/cull pipeline itself (true) rather than
+     * relying on the manager's CPU worker sorter (false). Drives the manager's per-frame branching.
+     *
+     * @type {boolean}
+     */
+    get usesGpuSort() {
+        return false;
+    }
+
+    /**
+     * Whether this renderer needs frustum-culling bounds uploaded to the work buffer (the GPU cull
+     * path allocates them; the CPU path does not).
+     *
+     * @type {boolean}
+     */
+    get requiresBounds() {
+        return false;
+    }
+
+    /**
+     * Whether this renderer relies on the manager-owned CPU worker sorter.
+     *
+     * @type {boolean}
+     */
+    get requiresCpuSort() {
+        return !this.usesGpuSort;
+    }
+
+    /**
      * Returns the material used by this renderer, or null if not applicable.
      *
      * @type {ShaderMaterial|null}

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -213,6 +213,13 @@ class GSplatRenderer {
     }
 
     /**
+     * Invalidates any cached cull/compaction upload state (e.g. after a work-buffer rebuild that
+     * may have moved bounds indices). No-op for renderers without a GPU cull pipeline.
+     */
+    invalidateCullUpload() {
+    }
+
+    /**
      * Populates a cincludes map with tonemapping, gamma, decode and gsplatOutput
      * shader chunks needed by compute tile-count shaders.
      *


### PR DESCRIPTION
Moves the GPU sort/projection/cull pipeline out of `GSplatManager` and into `GSplatHybridRenderer`, so each renderer owns its own per-view GPU work. Behavior-preserving. This is the prerequisite for an upcoming directional-shadow renderer that needs to reuse the per-view cull without duplicating manager plumbing.

**Changes:**
- **`GSplatManager`** is slimmed to: `GSplatWorld` ownership, the world version lifecycle (`markSorted`/`onSorted`), the CPU worker sorter, and per-frame orchestration (~500 fewer lines). The version lifecycle stays here via a new `_markSortedIfNeeded` (the synchronous GPU counterpart of `onSorted`), called before delegating. The manager passes per-call parameter bags to the renderer, with no renderer→manager back-reference.
- **`GSplatHybridRenderer`** now owns its GPU pipeline: the radix sorter, projector, interval compaction, and indirect draw/dispatch slots (created in its constructor, freed in `destroy()`), plus the cull/project/sort methods (`prepareRenderView`, `sortAndProjectForCamera`, `_runFrustumCulling`, `computeDistanceRange`, `allocateAndWriteIntervalIndirectArgs`). Picking moves to `preparePickingView`.
- **`GSplatRenderer` (base)** gains capability getters (`usesGpuSort` / `requiresBounds` / `requiresCpuSort`) and the `prepareRenderView` / `preparePickingView` / `invalidateCullUpload` interface, plus a `GSplatRenderViewParams` typedef for the per-call param bag. The manager now branches on these capabilities instead of `activeRenderer`.
- The two per-frame GPU sort call sites collapse into one; vestigial frustum-change trackers (`testFrustumChanged`, `lastCulling*`) and the `canCull` getter are removed. `GSplatQuadRenderer` (CPU sort) is unchanged.

**API Changes:**
- None. All affected classes are internal (`@ignore`).

**Performance:**
- No change to rendered output or steady-state cost — this is a behavior-preserving move (`autoRender = true` and on-demand paths both unchanged).