### PR TITLE
refactor(particles): drop redundant material reset on camera change

### DIFF
--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -414,10 +414,6 @@ class ParticleEmitter {
         });
     }
 
-    onChangeCamera() {
-        this.resetMaterial();
-    }
-
     calculateWorldBounds() {
         if (!this.node) return;
 
@@ -1043,11 +1039,12 @@ class ParticleEmitter {
             animIndexParams[1] = this.randomizeAnimIndex; // animTexIndexParams.y
         }
 
+        // cache the currently active camera; only the CPU distance sorter consumes it. Nothing in
+        // the material depends on the camera, so no material/shader update is needed when it changes
+        // (the render shader's camera-dependent output gamma/tonemapping is handled at draw time in
+        // ParticleMaterial.getShaderVariant).
         if (this.scene) {
-            if (this.camera !== this.scene._activeCamera) {
-                this.camera = this.scene._activeCamera;
-                this.onChangeCamera();
-            }
+            this.camera = this.scene._activeCamera;
         }
 
         if (this.emitterShape === EMITTERSHAPE_BOX) {


### PR DESCRIPTION
Removes a vestigial per-frame material reset in the particle emitter that no longer does anything useful.

The emitter cached the scene's active camera in `addTime()` and, on any change, called `onChangeCamera()` → `resetMaterial()`. This was meaningful when `onChangeCamera()` also ran `regenShader()` and the particle shader was built eagerly from camera state (the wrong variant could compile before a camera was assigned — see issue #6700). Since #6804 moved particle shader creation to on-demand `getShaderVariant()`, keyed on the rendering camera's output gamma/tonemapping at draw time, `regenShader()` was removed — but the now-pointless `resetMaterial()` call was left behind.

`resetMaterial()` only re-uploads camera-independent uniforms, so re-running it whenever the active camera changes is wasted work, and it fires every frame when multiple/alternating cameras render the same emitter.

**Changes:**
- Remove the `onChangeCamera()` → `resetMaterial()` call from the per-frame camera-tracking in `addTime()`; the active camera is still cached for the CPU distance sorter (its only consumer).
- Delete the now-empty `onChangeCamera()` method.
- `resetMaterial()` remains as the one-time setup in `rebuild()`.

No behavior change: the only consumer of the cached camera is the CPU sorter (assignment preserved); screen-facing billboarding uses the rendering camera in-shader; and output gamma/tonemapping is still handled by `getShaderVariant()`.

**Performance:**
- Eliminates a redundant ~20-uniform material re-upload on every active-camera change (every frame in multi-camera scenes).