### PR TITLE
feat(assets): throttle concurrent asset requests

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -805,6 +805,11 @@ class AppBase extends EventHandler {
             this.loader.enableRetry(props.maxAssetRetries);
         }
 
+        // configure the concurrent request limit - overrides the default (0 is valid, meaning unlimited)
+        if (typeof props.maxConcurrentRequests === 'number' && props.maxConcurrentRequests >= 0) {
+            this.loader.maxConcurrentRequests = props.maxConcurrentRequests;
+        }
+
         // TODO: remove this temporary block after migrating properties
         if (!props.useDevicePixelRatio) {
             props.useDevicePixelRatio = props.use_device_pixel_ratio;

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -1,4 +1,5 @@
 import { Debug } from '../../core/debug.js';
+import { http } from '../../platform/net/http.js';
 
 /**
  * @import { AppBase } from '../app-base.js'
@@ -356,6 +357,35 @@ class ResourceLoader {
         for (const key in this._handlers) {
             this._handlers[key].maxRetries = 0;
         }
+    }
+
+    /**
+     * Sets the maximum number of asset requests that can be in flight at the same time. Additional
+     * requests are queued and dispatched as earlier ones complete. This prevents browsers from
+     * rejecting requests with `net::ERR_INSUFFICIENT_RESOURCES` when an app loads a very large
+     * number of assets at once. Set to `0` to disable throttling. Defaults to 128.
+     *
+     * Note: this is a process-global limit (it applies to the shared HTTP layer, matching the
+     * browser's per-process resource limit), so with multiple applications the last value set wins.
+     * It applies to all XHR-based requests, which covers the large majority of asset loads.
+     *
+     * @type {number}
+     * @example
+     * // never have more than 50 asset requests in flight at once
+     * app.loader.maxConcurrentRequests = 50;
+     */
+    set maxConcurrentRequests(value) {
+        // clamp to a non-negative integer (Infinity is preserved and also means "unlimited")
+        http.maxConcurrentRequests = Math.max(0, Math.floor(value)) || 0;
+    }
+
+    /**
+     * Gets the maximum number of asset requests that can be in flight at the same time.
+     *
+     * @type {number}
+     */
+    get maxConcurrentRequests() {
+        return http.maxConcurrentRequests;
     }
 
     /**

--- a/src/platform/net/http.js
+++ b/src/platform/net/http.js
@@ -69,6 +69,69 @@ class Http {
     static retryDelay = 100;
 
     /**
+     * The configured concurrency limit. See {@link Http#maxConcurrentRequests}.
+     *
+     * @type {number}
+     * @private
+     */
+    _maxConcurrentRequests = 128;
+
+    /**
+     * The number of slot-accounted requests currently in flight. Only throttled async requests are
+     * counted - when throttling is disabled (a limit of 0 or Infinity) requests are sent without
+     * accounting and this stays at 0.
+     *
+     * @type {number}
+     * @private
+     */
+    _activeRequests = 0;
+
+    /**
+     * Requests waiting for an in-flight slot to free up. Each entry holds the request's `xhr` and
+     * the deferred `send` thunk. Consumed from `_sendQueueHead` (rather than `Array#shift`) so
+     * draining a large queue stays O(n) overall rather than O(n^2).
+     *
+     * @type {{ xhr: XMLHttpRequest, send: Function }[]}
+     * @private
+     */
+    _sendQueue = [];
+
+    /**
+     * Index of the next entry to dispatch from `_sendQueue`. The array is compacted once drained.
+     *
+     * @type {number}
+     * @private
+     */
+    _sendQueueHead = 0;
+
+    /**
+     * The maximum number of requests allowed to be in flight at the same time. Additional requests
+     * are queued and dispatched as earlier ones complete. This guards against browsers rejecting
+     * requests with `net::ERR_INSUFFICIENT_RESOURCES` when too many are issued at once. Set to `0`
+     * (or `Infinity`) to disable throttling. Defaults to 128.
+     *
+     * This is a process-global limit on the shared {@link http} instance, matching the browser's
+     * per-process resource limit, and applies to all XHR-based requests (most asset loads). Prefer
+     * setting it via {@link ResourceLoader#maxConcurrentRequests}.
+     *
+     * @type {number}
+     * @ignore
+     */
+    set maxConcurrentRequests(value) {
+        this._maxConcurrentRequests = value;
+        // raising the limit may allow queued requests to be sent
+        this._pump();
+    }
+
+    /**
+     * @type {number}
+     * @ignore
+     */
+    get maxConcurrentRequests() {
+        return this._maxConcurrentRequests;
+    }
+
+    /**
      * Perform an HTTP GET request to the given url with additional options such as headers,
      * retries, credentials, etc.
      *
@@ -412,15 +475,22 @@ class Http {
             errored = true;
         };
 
-        try {
-            xhr.send(postdata);
-        } catch (e) {
-            // DWE: Don't callback on exceptions as behavior is inconsistent, e.g. cross-domain request errors don't throw an exception.
-            // Error callback should be called by xhr.onerror() callback instead.
-            if (!errored) {
-                options.error(xhr.status, xhr, e);
+        const send = () => {
+            try {
+                xhr.send(postdata);
+            } catch (e) {
+                // a failed send fires no completion event, so free the slot we acquired for it
+                this._releaseSlot(xhr);
+                // DWE: Don't callback on exceptions as behavior is inconsistent, e.g. cross-domain request errors don't throw an exception.
+                // Error callback should be called by xhr.onerror() callback instead.
+                if (!errored && typeof options.error === 'function') {
+                    options.error(xhr.status, xhr, e);
+                }
             }
-        }
+        };
+
+        // throttle the number of concurrent in-flight requests by deferring the actual send
+        this._acquire(xhr, options, send);
 
         // Return the request object as it can be handy for blocking calls
         return xhr;
@@ -499,6 +569,8 @@ class Http {
     }
 
     _onSuccess(method, url, options, xhr) {
+        this._releaseSlot(xhr);
+
         let response;
         let contentType;
         const header = xhr.getResponseHeader('Content-Type');
@@ -530,6 +602,9 @@ class Http {
     }
 
     _onError(method, url, options, xhr) {
+        // the request is no longer in flight; free its slot (a retry below re-acquires one)
+        this._releaseSlot(xhr);
+
         if (options.retrying) {
             return;
         }
@@ -548,6 +623,83 @@ class Http {
         } else {
             // no more retries or not retry so just fail
             options.callback(xhr.status === 0 ? 'Network error' : xhr.status, null);
+        }
+    }
+
+    /**
+     * Send a request immediately if a concurrency slot is free, otherwise queue it. Synchronous
+     * requests and the unthrottled case (a limit of 0 or Infinity) always send immediately and are
+     * not slot-accounted. Slot state is tracked on the `xhr` (not `options`, which callers may
+     * reuse across requests).
+     *
+     * @param {XMLHttpRequest} xhr - The request object (gains a private `_slotHeld` flag).
+     * @param {object} options - The request options.
+     * @param {Function} send - Thunk that performs the actual `xhr.send()`.
+     * @private
+     */
+    _acquire(xhr, options, send) {
+        const limit = this._maxConcurrentRequests;
+        const throttled = limit > 0 && Number.isFinite(limit) && options.async !== false;
+
+        if (!throttled || this._activeRequests < limit) {
+            if (throttled) {
+                this._activeRequests++;
+                xhr._slotHeld = true;
+            }
+            send();
+        } else {
+            this._sendQueue.push({ xhr, send });
+        }
+    }
+
+    /**
+     * Release the concurrency slot held by a completed request (if any) and dispatch any queued
+     * requests that now fit under the limit. Idempotent per request via the `xhr._slotHeld` flag, so
+     * it is safe to call from multiple completion paths (success, error, failed send).
+     *
+     * @param {XMLHttpRequest} xhr - The request object.
+     * @private
+     */
+    _releaseSlot(xhr) {
+        if (xhr._slotHeld) {
+            xhr._slotHeld = false;
+            this._activeRequests--;
+            this._pump();
+        }
+    }
+
+    /**
+     * Dispatch queued requests while there is spare concurrency.
+     *
+     * @private
+     */
+    _pump() {
+        const limit = this._maxConcurrentRequests;
+        const throttled = limit > 0 && Number.isFinite(limit);
+
+        if (!throttled) {
+            // unthrottled (0 or Infinity): send everything immediately, with no slot accounting
+            while (this._sendQueueHead < this._sendQueue.length) {
+                this._sendQueue[this._sendQueueHead++].send();
+            }
+        } else {
+            // throttled: keep the number of in-flight requests under the limit
+            while (this._sendQueueHead < this._sendQueue.length && this._activeRequests < limit) {
+                const { xhr, send } = this._sendQueue[this._sendQueueHead++];
+                this._activeRequests++;
+                xhr._slotHeld = true;
+                send();
+            }
+        }
+
+        // drop already-dispatched entries so the backing array (and the closures it retains) does
+        // not grow without bound during large preloads
+        if (this._sendQueueHead === this._sendQueue.length) {
+            this._sendQueue.length = 0;
+            this._sendQueueHead = 0;
+        } else if (this._sendQueueHead > 256) {
+            this._sendQueue = this._sendQueue.slice(this._sendQueueHead);
+            this._sendQueueHead = 0;
         }
     }
 }

--- a/test/platform/net/http.test.mjs
+++ b/test/platform/net/http.test.mjs
@@ -148,4 +148,118 @@ describe('Http', function () {
 
     });
 
+    describe('#maxConcurrentRequests', function () {
+        let originalXHR;
+        let created;
+
+        beforeEach(function () {
+            created = [];
+            originalXHR = global.XMLHttpRequest;
+            const fakeXhr = nise.fakeXhr.useFakeXMLHttpRequest();
+            global.XMLHttpRequest = fakeXhr;
+            // collect every created XHR but don't auto-respond, so requests stay in flight
+            fakeXhr.onCreate = (xhr) => {
+                created.push(xhr);
+            };
+
+            // start each test from a known, clean throttle state on the shared singleton
+            http.maxConcurrentRequests = 128;
+            http._activeRequests = 0;
+            http._sendQueue.length = 0;
+        });
+
+        afterEach(function () {
+            global.XMLHttpRequest = originalXHR;
+            // restore defaults so state doesn't leak into other test files
+            http.maxConcurrentRequests = 128;
+            http._activeRequests = 0;
+            http._sendQueue.length = 0;
+        });
+
+        const respond = (xhr) => {
+            xhr.respond(200, { 'Content-Type': 'application/json' }, '{}');
+        };
+
+        it('limits in-flight requests and queues the rest', function () {
+            http.maxConcurrentRequests = 2;
+
+            let completed = 0;
+            const onDone = () => {
+                completed++;
+            };
+            for (let i = 0; i < 4; i++) {
+                http.get(`/url${i}.json`, onDone);
+            }
+
+            // all 4 XHRs are created (cheap), but only 2 are sent; the other 2 are queued
+            expect(created.length).to.equal(4);
+            expect(http._activeRequests).to.equal(2);
+            expect(http._sendQueue.length).to.equal(2);
+
+            // completing the 2 in-flight requests dispatches the 2 queued ones
+            respond(created[0]);
+            respond(created[1]);
+            expect(http._activeRequests).to.equal(2);
+            expect(http._sendQueue.length).to.equal(0);
+            expect(completed).to.equal(2);
+
+            // completing those drains everything
+            respond(created[2]);
+            respond(created[3]);
+            expect(http._activeRequests).to.equal(0);
+            expect(completed).to.equal(4);
+        });
+
+        it('does not throttle when set to 0', function () {
+            http.maxConcurrentRequests = 0;
+
+            const noop = () => {};
+            for (let i = 0; i < 5; i++) {
+                http.get(`/url${i}.json`, noop);
+            }
+
+            // everything is sent immediately and nothing is queued or slot-accounted
+            expect(created.length).to.equal(5);
+            expect(http._sendQueue.length).to.equal(0);
+            expect(http._activeRequests).to.equal(0);
+        });
+
+        it('dispatches queued requests when the limit is raised', function () {
+            http.maxConcurrentRequests = 1;
+
+            const noop = () => {};
+            for (let i = 0; i < 3; i++) {
+                http.get(`/url${i}.json`, noop);
+            }
+            expect(http._activeRequests).to.equal(1);
+            expect(http._sendQueue.length).to.equal(2);
+
+            // raising the limit immediately pumps the queued requests
+            http.maxConcurrentRequests = 3;
+            expect(http._activeRequests).to.equal(3);
+            expect(http._sendQueue.length).to.equal(0);
+        });
+
+        it('tracks slots per request, not per shared options object', function () {
+            http.maxConcurrentRequests = 2;
+
+            // a single options object reused across concurrent requests must not corrupt slot
+            // accounting (state is keyed on the xhr, not on the caller's options object)
+            const shared = {};
+            const onDone = () => {};
+            for (let i = 0; i < 4; i++) {
+                http.get(`/url${i}.json`, shared, onDone);
+            }
+
+            expect(http._activeRequests).to.equal(2);
+            expect(http._sendQueue.length).to.equal(2);
+
+            // completing all four returns the active count cleanly to 0 (no leak)
+            created.forEach(respond);
+            expect(http._activeRequests).to.equal(0);
+            expect(http._sendQueue.length).to.equal(0);
+        });
+
+    });
+
 });


### PR DESCRIPTION
Adds a limit on the number of concurrent asset requests, so large preloads no longer fail with `net::ERR_INSUFFICIENT_RESOURCES` — browsers reject requests once too many are in flight at once (empirically reproducible well below the asset counts some projects preload). Fixes #5258.

**Changes:**
- Throttle requests at the HTTP layer — the single choke point all resource handlers go through — so it applies transparently to every asset type with no changes to the registry, handlers, or preload. Requests beyond the limit are queued and dispatched as earlier ones complete.
- The `XMLHttpRequest` is still created and returned synchronously; only the `.send()` call is deferred, so progress/abort behaviour is unchanged.
- Default limit is **128**; `0` disables throttling (previous behaviour). It is a process-global limit, matching the browser's per-process resource limit, and covers all XHR-based loads (the large majority of assets; the `<img>`-element texture fallback, `<audio>`, `<script>` and bundle `fetch` paths are browser-managed and not affected).
- Editor projects can set it via a new `maxConcurrentRequests` application property, parsed alongside the existing `maxAssetRetries`.

**API Changes:**
- Add `app.loader.maxConcurrentRequests` (getter/setter) to read or override the limit at runtime:
  ```javascript
  app.loader.maxConcurrentRequests = 50; // at most 50 requests in flight at once
  app.loader.maxConcurrentRequests = 0;  // disable throttling
  ```

**Related:**
- Editor follow-up to surface this in the Network settings panel: playcanvas/editor#2119
- User-manual docs update tracked separately on the developer-site.