### PR TITLE
fix(particles): use mesh UVs when texturing mesh particles (#7858)

### DIFF
--- a/examples/src/examples/graphics/particles-mesh.controls.jsx
+++ b/examples/src/examples/graphics/particles-mesh.controls.jsx
@@ -58,6 +58,13 @@ export function Controls({ observer }) {
                         link={{ observer, path: 'settings.alignToMotion' }}
                     />
                 </LabelGroup>
+                <LabelGroup text='Textured'>
+                    <BooleanInput
+                        type='toggle'
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'settings.textured' }}
+                    />
+                </LabelGroup>
             </Panel>
         </>
     );

--- a/examples/src/examples/graphics/particles-mesh.example.mjs
+++ b/examples/src/examples/graphics/particles-mesh.example.mjs
@@ -7,6 +7,7 @@ window.focus();
 
 const assets = {
     torus: new pc.Asset('heart', 'container', { url: './assets/models/torus.glb' }),
+    color: new pc.Asset('color', 'texture', { url: './assets/textures/clouds.jpg' }, { srgb: true }),
     script: new pc.Asset('script', 'script', { url: './scripts/camera/orbit-camera.js' }),
     helipad: new pc.Asset(
         'helipad-env-atlas',
@@ -160,7 +161,10 @@ assetListLoader.load(() => {
         depthWrite: true,
         lighting: true,
         halfLambert: true,
-        alignToMotion: true
+        alignToMotion: true,
+
+        // texture applied to the mesh particles using the mesh UVs
+        colorMap: assets.color.resource
     });
 
     data.set('settings', {
@@ -168,11 +172,20 @@ assetListLoader.load(() => {
         numParticles: 150,
         lighting: true,
         alignToMotion: true,
+        textured: true,
         enabled: true
     });
 
     data.on('*:set', (/** @type {string} */ path, value) => {
         const propertyName = path.split('.')[1];
+
+        // the 'textured' toggle switches the color map on and off (null falls back to the
+        // default white texture), demonstrating mesh UVs are used for texturing
+        if (propertyName === 'textured') {
+            entity.particlesystem.colorMap = value ? assets.color.resource : null;
+            return;
+        }
+
         entity.particlesystem[propertyName] = value;
     });
 });

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -870,7 +870,9 @@ class ParticleEmitter {
             // GPU: XYZ = quad vertex position; W = INT: particle ID, FRAC: random factor
             elements.push({ semantic: SEMANTIC_ATTR0, components: 4, type: TYPE_FLOAT32 });
             if (this.useMesh) {
-                elements.push({ semantic: SEMANTIC_ATTR1, components: 2, type: TYPE_FLOAT32 });
+                // mesh UVs - use the TEXCOORD0 semantic so the mesh instance reports SHADERDEF_UV0,
+                // which enables the meshUv shader path and binds particle_uv at the matching location
+                elements.push({ semantic: SEMANTIC_TEXCOORD0, components: 2, type: TYPE_FLOAT32 });
             }
         } else {
             elements.push(


### PR DESCRIPTION
Fixes mesh particles ignoring their mesh UVs, so a `colorMap` texture now maps across the mesh instead of rendering as a flat single-texel color. Regression from the particle shader generator refactor; reported in #7858.

**Root cause:**
- The GPU particle vertex buffer stored the mesh UV under the `SEMANTIC_ATTR1` semantic. As a result the particle mesh instance never reported `SHADERDEF_UV0`, so `ParticleMaterial`'s `meshUv` option (`objDefs & SHADERDEF_UV0`) was always false.
- With `meshUv` off, `USE_MESH_UV` was not defined and `particle_uv` fell back to a constant `vec2(0.0)`, so every particle sampled a single texel. Even if forced on, `particle_uv` (mapped to `TEXCOORD0`, location 5) did not match the vertex buffer's `ATTR1` (location 1).

**Changes:**
- Store the mesh UV under `SEMANTIC_TEXCOORD0` in `ParticleEmitter.getVertexInfo()`. This makes the particle mesh instance report `SHADERDEF_UV0`, which both enables the `USE_MESH_UV` shader path and binds `particle_uv` at the matching attribute location.
- Fixes both WebGL2 and WebGPU (shared shader generator); the CPU particle path is unaffected (it packs UVs separately via `ATTR4`).

**Examples:**
- Added a "Textured" toggle to the Particles Mesh example that applies a color map to the mesh particles, demonstrating the mesh UVs are used.