### PR TITLE
feat(gsplat): cast directional shadows from the hybrid renderer

### DIFF
--- a/examples/src/examples/gaussian-splatting/shadows.controls.jsx
+++ b/examples/src/examples/gaussian-splatting/shadows.controls.jsx
@@ -34,6 +34,16 @@ export function Controls({ observer }) {
                     precision={2}
                 />
             </LabelGroup>
+            <LabelGroup text='Lights'>
+                <SliderInput
+                    binding={new BindingTwoWay()}
+                    link={{ observer, path: 'numLights' }}
+                    min={0}
+                    max={6}
+                    step={1}
+                    precision={0}
+                />
+            </LabelGroup>
         </>
     );
 }

--- a/examples/src/examples/gaussian-splatting/shadows.example.mjs
+++ b/examples/src/examples/gaussian-splatting/shadows.example.mjs
@@ -159,27 +159,47 @@ assetListLoader.load(() => {
     }
     app.root.addChild(shadowCatcher);
 
-    // Shadow casting directional light casting shadows
-    const directionalLight = new pc.Entity('light');
-    directionalLight.addComponent('light', {
-        type: 'directional',
-        color: pc.Color.WHITE,
-        castShadows: true,
-        intensity: 1,
-        shadowBias: 0.1,
-        normalOffsetBias: 0.05,
-        shadowDistance: 20,
-        shadowIntensity: 0.5,
-        shadowResolution: 2048,
-        shadowType: pc.SHADOW_PCF5_16F
+    // Create up to 6 shadow-casting directional lights; the 'Lights' slider enables the first N of
+    // them. Each light keeps a fixed base azimuth (so adding or removing one never moves the
+    // others) and they all rotate together in the same direction. The azimuths are ordered so the
+    // enabled set stays well-distributed: light 1 is opposite light 0, and at the full count of 6
+    // they are evenly spaced 60° apart ({30,90,150,210,270,330}). Intermediate odd counts are
+    // intentionally not symmetrical.
+    const lightBaseAzimuths = [30, 210, 90, 270, 150, 330];
+    const lights = lightBaseAzimuths.map((azimuth, i) => {
+        const light = new pc.Entity(`light${i}`);
+        light.addComponent('light', {
+            type: 'directional',
+            color: pc.Color.WHITE,
+            castShadows: true,
+            intensity: 1,
+            shadowBias: 0.1,
+            normalOffsetBias: 0.05,
+            shadowDistance: 20,
+            shadowIntensity: 0.5,
+            shadowResolution: 2048,
+            shadowType: pc.SHADOW_PCF5_16F
+        });
+        light.setEulerAngles(55, azimuth, 0);
+        app.root.addChild(light);
+        return light;
     });
-    directionalLight.setEulerAngles(55, 30, 0);
-    app.root.addChild(directionalLight);
 
-    // Auto-rotate light
+    // Number of active lights (0..6). Enables the first N; the rest are disabled.
+    data.on('numLights:set', () => {
+        const count = data.get('numLights');
+        lights.forEach((light, i) => {
+            light.enabled = i < count;
+        });
+    });
+    data.set('numLights', 2);
+
+    // Rotate all lights together (same direction), preserving each light's fixed azimuth offset.
     let lightAngle = 0;
     app.on('update', (/** @type {number} */ dt) => {
         lightAngle += dt * 20;
-        directionalLight.setEulerAngles(55, 90 + lightAngle, 0);
+        lights.forEach((light, i) => {
+            light.setEulerAngles(55, lightBaseAzimuths[i] + lightAngle, 0);
+        });
     });
 });

--- a/src/scene/gsplat-unified/gsplat-director.js
+++ b/src/scene/gsplat-unified/gsplat-director.js
@@ -429,6 +429,22 @@ class GSplatDirector {
             comp.layerList[i].gsplatPlacementsDirty = false;
         }
     }
+
+    /**
+     * Post-cull shadow pass. Runs AFTER `cullComposition` (so each directional light's shadow-camera
+     * frustum has been fitted) and before the frame graph renders the shadow maps, dispatching each
+     * manager's per-light gsplat shadow cull. Only managers whose forward renderer is GPU-sort
+     * (which cannot self-cast) hold a shadow renderer; for the rest this is a no-op. The CPU-sort
+     * quad renderer self-casts and is unaffected.
+     */
+    updateShadows() {
+        this.camerasMap.forEach((cameraData) => {
+            cameraData.layersMap.forEach((layerData) => {
+                layerData.gsplatManager?.updateShadows();
+                layerData.gsplatManagerShadow?.updateShadows();
+            });
+        });
+    }
 }
 
 export { GSplatDirector };

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -180,11 +180,9 @@ class GSplatHybridRenderer extends GSplatRenderer {
         this._internalDefines.add('GSPLAT_NO_FOG');
         this._internalDefines.add('GSPLAT_XR');
 
-        // GPU sort pipeline resources (owned by the renderer). Interval compaction is created
-        // lazily on the first sort.
-        this.gpuSorter = new ComputeRadixSort(this.device, { indirect: true });
-        this.projector = new GSplatProjector(this.device);
-
+        // GPU sort pipeline resources (gpuSorter, projector, intervalCompaction) are created lazily
+        // on the first forward sort (see _ensureGpuPipeline). A hybrid renderer that only exists to
+        // satisfy a shadow-casting manager (no forward pass) never allocates them.
         this.meshInstance = this.createMeshInstance();
     }
 
@@ -285,6 +283,19 @@ class GSplatHybridRenderer extends GSplatRenderer {
     }
 
     /**
+     * Lazily creates the GPU sort pipeline resources on first forward use. Kept out of the
+     * constructor so a hybrid renderer that never renders a forward pass (e.g. one owned by a
+     * shadow-only manager) allocates none of them.
+     *
+     * @private
+     */
+    _ensureGpuPipeline() {
+        if (!this.gpuSorter) this.gpuSorter = new ComputeRadixSort(this.device, { indirect: true });
+        if (!this.projector) this.projector = new GSplatProjector(this.device);
+        if (!this.intervalCompaction) this.intervalCompaction = new GSplatIntervalCompaction(this.device);
+    }
+
+    /**
      * Per-frame forward render preparation: derives the viewport (handling stereo XR), runs the
      * cull + projector + radix sort for the current camera, and binds the result for indirect
      * drawing. Runs every frame — the indirect args are per-frame and the post-projector visible
@@ -381,15 +392,12 @@ class GSplatHybridRenderer extends GSplatRenderer {
      * @private
      */
     sortAndProjectForCamera(world, worldState, cameraNode, viewportWidth, viewportHeight, alphaClip, pickMode, isStereo, params) {
-        const gpuSorter = /** @type {ComputeRadixSort} */ (this.gpuSorter);
-        const projector = /** @type {GSplatProjector} */ (this.projector);
-
         const elementCount = worldState.totalActiveSplats;
         if (elementCount === 0) return null;
 
-        if (!this.intervalCompaction) {
-            this.intervalCompaction = new GSplatIntervalCompaction(this.device);
-        }
+        this._ensureGpuPipeline();
+        const gpuSorter = /** @type {ComputeRadixSort} */ (this.gpuSorter);
+        const projector = /** @type {GSplatProjector} */ (this.projector);
 
         this.intervalCompaction.uploadIntervals(worldState);
 

--- a/src/scene/gsplat-unified/gsplat-interval-compaction.js
+++ b/src/scene/gsplat-unified/gsplat-interval-compaction.js
@@ -21,6 +21,7 @@ import { computeGsplatIntervalScatterSource } from '../shader-lib/wgsl/chunks/gs
 import { computeGsplatWriteIndirectArgsSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-write-indirect-args.js';
 import { PrefixSumKernel } from '../graphics/prefix-sum-kernel.js';
 import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
+import { buildGSplatIntervalData, INTERVAL_STRIDE } from './gsplat-interval-data.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
@@ -31,9 +32,6 @@ import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
 const WORKGROUP_SIZE = 256;
 
 const INDEX_COUNT = 6 * GSplatResourceBase.instanceSize;
-
-// 16 bytes per interval: { workBufferBase, splatCount, boundsIndex, pad }
-const INTERVAL_STRIDE = 4;
 
 
 /**
@@ -376,7 +374,6 @@ class GSplatIntervalCompaction {
         if (worldState.version === this._uploadedVersion) return;
         this._uploadedVersion = worldState.version;
 
-        const splats = worldState.splats;
         const numIntervals = worldState.totalIntervals;
 
         if (numIntervals === 0) return;
@@ -389,31 +386,7 @@ class GSplatIntervalCompaction {
             DebugHelper.setName(this.intervalsBuffer, 'GsplatIntervalCompaction.intervals');
         }
 
-        const data = new Uint32Array(numIntervals * INTERVAL_STRIDE);
-        let writeIdx = 0;
-
-        for (let s = 0; s < splats.length; s++) {
-            const splat = splats[s];
-
-            if (splat.intervals.length > 0) {
-                // Octree: each interval has its own offset from per-node allocation
-                const nodeIndices = splat.intervalNodeIndices;
-                for (let i = 0; i < splat.intervals.length; i += 2) {
-                    const count = splat.intervals[i + 1] - splat.intervals[i];
-                    data[writeIdx++] = splat.intervalOffsets[i / 2];
-                    data[writeIdx++] = count;
-                    data[writeIdx++] = splat.boundsBaseIndex + (nodeIndices.length > 0 ? nodeIndices[i / 2] : 0);
-                    data[writeIdx++] = 0;
-                }
-            } else {
-                // Non-octree: single interval covering the entire splat
-                data[writeIdx++] = splat.intervalOffsets[0];
-                data[writeIdx++] = splat.activeSplats;
-                data[writeIdx++] = splat.boundsBaseIndex;
-                data[writeIdx++] = 0;
-            }
-        }
-
+        const data = buildGSplatIntervalData(worldState);
         this.intervalsBuffer.write(0, data, 0, numIntervals * INTERVAL_STRIDE);
     }
 

--- a/src/scene/gsplat-unified/gsplat-interval-data.js
+++ b/src/scene/gsplat-unified/gsplat-interval-data.js
@@ -1,0 +1,54 @@
+/**
+ * @import { GSplatWorldState } from './gsplat-world-state.js'
+ */
+
+// 4 u32 per interval: { workBufferBase, splatCount, boundsIndex, pad }
+const INTERVAL_STRIDE = 4;
+
+/**
+ * Builds the flat interval metadata array for a world state, shared by the forward GPU-sort path
+ * ({@link GSplatIntervalCompaction}) and the directional-shadow path ({@link GSplatShadowRenderer}).
+ *
+ * Each interval is a contiguous run of work-buffer splat slots for one octree node (or one whole
+ * splat in the non-octree case), packed as 4 u32s:
+ * - `workBufferBase` — first work-buffer pixel index of the run
+ * - `splatCount` — number of splats in the run
+ * - `boundsIndex` — index into the frustum culler's per-node bounds (for coarse sphere culling)
+ * - `pad` — padding to 16 bytes
+ *
+ * @param {GSplatWorldState} worldState - The world state to extract intervals from.
+ * @returns {Uint32Array} The packed interval data (`worldState.totalIntervals * INTERVAL_STRIDE` u32s).
+ */
+function buildGSplatIntervalData(worldState) {
+    const splats = worldState.splats;
+    const numIntervals = worldState.totalIntervals;
+
+    const data = new Uint32Array(numIntervals * INTERVAL_STRIDE);
+    let writeIdx = 0;
+
+    for (let s = 0; s < splats.length; s++) {
+        const splat = splats[s];
+
+        if (splat.intervals.length > 0) {
+            // Octree: each interval has its own offset from per-node allocation
+            const nodeIndices = splat.intervalNodeIndices;
+            for (let i = 0; i < splat.intervals.length; i += 2) {
+                const count = splat.intervals[i + 1] - splat.intervals[i];
+                data[writeIdx++] = splat.intervalOffsets[i / 2];
+                data[writeIdx++] = count;
+                data[writeIdx++] = splat.boundsBaseIndex + (nodeIndices.length > 0 ? nodeIndices[i / 2] : 0);
+                data[writeIdx++] = 0;
+            }
+        } else {
+            // Non-octree: single interval covering the entire splat
+            data[writeIdx++] = splat.intervalOffsets[0];
+            data[writeIdx++] = splat.activeSplats;
+            data[writeIdx++] = splat.boundsBaseIndex;
+            data[writeIdx++] = 0;
+        }
+    }
+
+    return data;
+}
+
+export { buildGSplatIntervalData, INTERVAL_STRIDE };

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -5,10 +5,13 @@ import { GSplatUnifiedSorter } from './gsplat-unified-sorter.js';
 import { GSplatWorld } from './gsplat-world.js';
 import { GSplatQuadRenderer } from './gsplat-quad-renderer.js';
 import { GSplatHybridRenderer } from './gsplat-hybrid-renderer.js';
+import { GSplatShadowRenderer } from './gsplat-shadow-renderer.js';
 import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 import {
     GSPLAT_RENDERER_RASTER_GPU_SORT,
+    GSPLAT_FORWARD,
+    GSPLAT_SHADOW,
     GSPLAT_DEBUG_AABBS
 } from '../constants.js';
 import { Color } from '../../core/math/color.js';
@@ -74,6 +77,15 @@ class GSplatManager {
 
     /** @type {GSplatRenderer} */
     renderer;
+
+    /**
+     * Casts directional shadows for the GPU-sort (hybrid) forward renderer, which cannot self-cast.
+     * Null when the forward renderer is CPU-sort (the quad renderer self-casts) or when this
+     * manager has no shadow render mode. Shares this manager's {@link GSplatWorld}.
+     *
+     * @type {GSplatShadowRenderer|null}
+     */
+    shadowRenderer = null;
 
     /**
      * The currently active renderer mode. Starts as undefined so the first
@@ -206,6 +218,11 @@ class GSplatManager {
 
         // The renderer frees its own GPU sort resources (radix sorter, projector, compaction).
         this.renderer.destroy();
+
+        // The shadow renderer frees its per-light pool (buffers, indirect slots) and unregisters
+        // its cast mesh instances from the layer.
+        this.shadowRenderer?.destroy();
+        this.shadowRenderer = null;
     }
 
     /**
@@ -364,6 +381,26 @@ class GSplatManager {
     setRenderMode(renderMode) {
         this.renderMode = renderMode;
         this.renderer.setRenderMode(renderMode);
+        this._syncShadowRenderer();
+    }
+
+    /**
+     * Creates or destroys {@link shadowRenderer} to match the current render mode and forward
+     * renderer. The GPU-sort (hybrid) renderer cannot self-cast shadows, so when shadow rendering
+     * is requested and the forward renderer uses GPU sort, a dedicated {@link GSplatShadowRenderer}
+     * casts on its behalf (sharing this manager's world). The CPU-sort quad renderer self-casts, so
+     * no shadow renderer is created for it.
+     *
+     * @private
+     */
+    _syncShadowRenderer() {
+        const wantShadow = !!(this.renderMode & GSPLAT_SHADOW) && this.renderer.usesGpuSort;
+        if (wantShadow && !this.shadowRenderer) {
+            this.shadowRenderer = new GSplatShadowRenderer(this.device, this.node, this.cameraNode, this.layer, this.world);
+        } else if (!wantShadow && this.shadowRenderer) {
+            this.shadowRenderer.destroy();
+            this.shadowRenderer = null;
+        }
     }
 
     /**
@@ -404,6 +441,11 @@ class GSplatManager {
         this.renderer.destroy();
         this._createRenderer(requested);
         this.renderer.setRenderMode(this.renderMode);
+
+        // The forward renderer type changed (CPU quad <-> GPU hybrid), which flips whether a
+        // dedicated shadow renderer is needed.
+        this._syncShadowRenderer();
+
         this.world.invalidate({ workBuffer: true });
         this.sortNeeded = true;
     }
@@ -506,7 +548,10 @@ class GSplatManager {
         // Detect work-buffer format changes (wholesale swap + extra streams) before world.update,
         // which reads the work buffer.
         this.world.syncFormat(this._formatResult);
-        if (this._formatResult.bufferRecreated) this.renderer.setDataSource(this.world.workBuffer);
+        if (this._formatResult.bufferRecreated) {
+            this.renderer.setDataSource(this.world.workBuffer);
+            this.shadowRenderer?.setDataSource(this.world.workBuffer);
+        }
         if (this._formatResult.sortNeeded) this.sortNeeded = true;
 
         // Check for runtime renderer mode changes and transition if needed.
@@ -601,7 +646,15 @@ class GSplatManager {
         if (lastState) {
             if (this.renderer.usesGpuSort) {
                 this._markSortedIfNeeded(lastState);
-                this.renderer.prepareRenderView(this.world, lastState, this._fillRenderViewParams());
+
+                // Only run the forward GPU pipeline (projector + radix sort) when this manager
+                // participates in the forward pass. A shadow-only manager (GPU renderer type, no
+                // GSPLAT_FORWARD bit) skips it: its GSplatShadowRenderer culls + draws the shadow
+                // independently, so the forward sorter/projector would be pure waste (and are never
+                // even allocated — see GSplatHybridRenderer._ensureGpuPipeline).
+                if (this.renderMode & GSPLAT_FORWARD) {
+                    this.renderer.prepareRenderView(this.world, lastState, this._fillRenderViewParams());
+                }
             } else if (this.sortNeeded) {
                 this.sortCpu(lastState);
             }
@@ -615,8 +668,18 @@ class GSplatManager {
             }
         }
 
-        // keep the shared mesh-instance's AABB in sync with the actual splat placements
-        this.renderer?.meshInstance?.setCustomAabb(this.world.computeAggregateAabb());
+        // Pre-cull: reconcile the shadow-caster pool against the layer's directional lights, so the
+        // standard shadow-caster culling in cullComposition (which runs after the director's update)
+        // sees the cast mesh instances. The per-light cull dispatch happens later in updateShadows.
+        this.shadowRenderer?.syncLights();
+
+        // Keep the mesh-instance AABBs in sync with the actual splat placements. This world-space
+        // AABB feeds the directional shadow camera's depth range (and thus world-space PCSS penumbra
+        // scaling), so the shadow casters need it too — set it pre-cull, before cullComposition fits
+        // the shadow cameras.
+        const aggregateAabb = this.world.computeAggregateAabb();
+        this.renderer?.meshInstance?.setCustomAabb(aggregateAabb);
+        this.shadowRenderer?.setCastersAabb(aggregateAabb);
 
         // fire frame:ready event
         this.fireFrameReadyEvent();
@@ -635,6 +698,16 @@ class GSplatManager {
         // return the number of active splats for stats
         const sortedState = this.world.getState(this.world.currentVersion);
         return sortedState ? sortedState.totalActiveSplats : 0;
+    }
+
+    /**
+     * Post-cull shadow pass. Called from the director after cullComposition has fitted each
+     * directional light's shadow-camera frustum, and before the frame graph renders the shadow
+     * maps. Dispatches the per-light gsplat shadow cull and binds the results. No-op unless this
+     * manager has a {@link shadowRenderer} (GPU-sort forward path with a shadow render mode).
+     */
+    updateShadows() {
+        this.shadowRenderer?.cull(this.scene.gsplat);
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-shadow-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-shadow-renderer.js
@@ -43,6 +43,7 @@ const INDEX_COUNT = 6 * GSplatResourceBase.instanceSize;
  * shadow caster and is visible only for its light's shadow camera.
  *
  * @typedef {object} ShadowLightEntry
+ * @ignore
  * @property {Light} light - The directional light this entry casts for.
  * @property {ShaderMaterial} material - The per-light shadow draw material.
  * @property {MeshInstance} meshInstance - The cast mesh instance (registered as a shadow caster).

--- a/src/scene/gsplat-unified/gsplat-shadow-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-shadow-renderer.js
@@ -1,0 +1,616 @@
+import { Debug, DebugHelper } from '../../core/debug.js';
+import { Vec2 } from '../../core/math/vec2.js';
+import { Compute } from '../../platform/graphics/compute.js';
+import { Shader } from '../../platform/graphics/shader.js';
+import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
+import { BindGroupFormat, BindStorageBufferFormat, BindUniformBufferFormat } from '../../platform/graphics/bind-group-format.js';
+import { UniformBufferFormat, UniformFormat } from '../../platform/graphics/uniform-buffer-format.js';
+import {
+    BUFFERUSAGE_COPY_DST,
+    CULLFACE_NONE,
+    PIXELFORMAT_RGBA16U,
+    SEMANTIC_POSITION,
+    SHADERLANGUAGE_WGSL,
+    SHADERSTAGE_COMPUTE,
+    UNIFORMTYPE_UINT,
+    UNIFORMTYPE_VEC4
+} from '../../platform/graphics/constants.js';
+import { BLEND_PREMULTIPLIED, LIGHTTYPE_DIRECTIONAL } from '../constants.js';
+import { ShaderMaterial } from '../materials/shader-material.js';
+import { MeshInstance } from '../mesh-instance.js';
+import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
+import { computeGsplatShadowCullSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-shadow-cull.js';
+import { computeGsplatShadowIndirectArgsSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-shadow-indirect-args.js';
+import { buildGSplatIntervalData, INTERVAL_STRIDE } from './gsplat-interval-data.js';
+
+/**
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ * @import { GraphNode } from '../graph-node.js'
+ * @import { Layer } from '../layer.js'
+ * @import { Light } from '../light.js'
+ * @import { GSplatWorld } from './gsplat-world.js'
+ * @import { GSplatWorkBuffer } from './gsplat-work-buffer.js'
+ * @import { GSplatParams } from './gsplat-params.js'
+ */
+
+const WORKGROUP_SIZE = 256;
+
+const INDEX_COUNT = 6 * GSplatResourceBase.instanceSize;
+
+/**
+ * Per-light shadow draw entry. One cheap material + mesh instance over the shared quad mesh, plus a
+ * visible-index buffer and an atomic visible-count buffer. The mesh instance is registered as a
+ * shadow caster and is visible only for its light's shadow camera.
+ *
+ * @typedef {object} ShadowLightEntry
+ * @property {Light} light - The directional light this entry casts for.
+ * @property {ShaderMaterial} material - The per-light shadow draw material.
+ * @property {MeshInstance} meshInstance - The cast mesh instance (registered as a shadow caster).
+ * @property {StorageBuffer|null} indexBuffer - Dense visible work-buffer index list (grows with splat count).
+ * @property {number} allocatedIndexCount - Capacity of `indexBuffer` in splats.
+ * @property {StorageBuffer} countBuffer - Single-element atomic visible counter (also bound as `numSplatsStorage`).
+ * @property {Compute} cullCompute - Per-entry cull compute (own uniform buffer/bind group).
+ * @property {Compute} argsCompute - Per-entry indirect-args compute (own uniform buffer/bind group).
+ */
+
+/**
+ * Casts gsplat directional shadows on behalf of the GPU-sort ({@link GSplatHybridRenderer}) path,
+ * which cannot self-cast. It shares the manager's {@link GSplatWorld} (work buffer + camera-
+ * independent cull bounds + world states) and never allocates a world of its own.
+ *
+ * For each non-cascaded directional light affecting the manager's layer it maintains a cheap draw
+ * entry (a per-light material + mesh instance over one shared quad mesh, plus a visible-index and
+ * count buffer). A projection-free compute cull against the light's frustum produces the visible
+ * index list, and a quad-style per-vertex-projected indirect draw writes the shadow map via the
+ * standard caster pipeline. No sort and no projection cache are needed.
+ *
+ * Lifecycle is split across the frame:
+ * - {@link syncLights} runs pre-cull (from {@link GSplatManager#update}) to reconcile the per-light
+ *   pool and register/unregister shadow casters, so `cullComposition` sees them.
+ * - {@link cull} runs post-cull (from {@link GSplatManager#updateShadows} via the director) once
+ *   each light's shadow-camera frustum has been fitted, to dispatch the culls and bind results.
+ *
+ * @ignore
+ */
+class GSplatShadowRenderer {
+    /** @type {GraphicsDevice} */
+    device;
+
+    /** @type {GraphNode} */
+    node;
+
+    /** @type {GraphNode} */
+    cameraNode;
+
+    /** @type {Layer} */
+    layer;
+
+    /** @type {GSplatWorld} */
+    world;
+
+    /**
+     * Per-light draw entries, keyed by light.
+     *
+     * @type {Map<Light, ShadowLightEntry>}
+     */
+    entries = new Map();
+
+    /**
+     * Reused scratch set of the qualifying directional shadow lights, rebuilt each {@link syncLights}
+     * to diff against {@link entries}.
+     *
+     * @type {Set<Light>}
+     * @private
+     */
+    _desiredLights = new Set();
+
+    /** @type {StorageBuffer|null} */
+    intervalsBuffer = null;
+
+    /** @type {number} */
+    allocatedIntervalCount = 0;
+
+    /**
+     * World-state version the intervals were last uploaded for (intervals are camera/light
+     * independent, so they are shared across all light entries and uploaded once per version).
+     *
+     * @type {number}
+     */
+    _uploadedVersion = -1;
+
+    /** @type {Vec2} */
+    _cullDispatchSize = new Vec2(1, 1);
+
+    /**
+     * Reused light frustum planes (6 × vec4(normal, distance)) for the cull uniform, refilled per
+     * light entry from its shadow camera.
+     *
+     * @type {Float32Array}
+     */
+    _frustumPlanes = new Float32Array(24);
+
+    // The cull/args shaders are shared, but each light entry gets its OWN Compute instances
+    // (created in _createEntry). A Compute owns a persistent uniform buffer, so a single shared
+    // Compute dispatched once per light per frame would have all dispatches read the last-written
+    // uniforms (frustum planes / draw slot) — making all but one light's shadow draw empty.
+
+    /** @type {Shader|null} */
+    _cullShader = null;
+
+    /** @type {BindGroupFormat|null} */
+    _cullBindGroupFormat = null;
+
+    /** @type {Shader|null} */
+    _argsShader = null;
+
+    /** @type {BindGroupFormat|null} */
+    _argsBindGroupFormat = null;
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {GraphNode} node - The graph node the cast mesh instances are parented to.
+     * @param {GraphNode} cameraNode - The main camera node this manager renders for; used to
+     * resolve each light's shadow camera via `light.getRenderData(sceneCamera, 0)`.
+     * @param {Layer} layer - The layer to register shadow casters on (and read directional lights from).
+     * @param {GSplatWorld} world - The shared world (work buffer, cull bounds, world states).
+     */
+    constructor(device, node, cameraNode, layer, world) {
+        this.device = device;
+        this.node = node;
+        this.cameraNode = cameraNode;
+        this.layer = layer;
+        this.world = world;
+
+        this._createCullShader();
+        this._createArgsShader();
+    }
+
+    destroy() {
+        this.entries.forEach(entry => this._destroyEntry(entry));
+        this.entries.clear();
+
+        this.intervalsBuffer?.destroy();
+        this.intervalsBuffer = null;
+
+        this._cullShader?.destroy();
+        this._cullBindGroupFormat?.destroy();
+        this._argsShader?.destroy();
+        this._argsBindGroupFormat?.destroy();
+        this._cullShader = null;
+        this._argsShader = null;
+    }
+
+    /** @private */
+    _createCullShader() {
+        const device = this.device;
+
+        this._cullBindGroupFormat = new BindGroupFormat(device, [
+            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE),
+            new BindStorageBufferFormat('intervals', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('outputIndices', SHADERSTAGE_COMPUTE, false),
+            new BindStorageBufferFormat('globalCount', SHADERSTAGE_COMPUTE, false),
+            new BindStorageBufferFormat('boundsBuffer', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('transformsBuffer', SHADERSTAGE_COMPUTE, true)
+        ]);
+
+        const uniformBufferFormat = new UniformBufferFormat(device, [
+            new UniformFormat('frustumPlanes', UNIFORMTYPE_VEC4, 6),
+            new UniformFormat('numIntervals', UNIFORMTYPE_UINT)
+        ]);
+
+        this._cullShader = new Shader(device, {
+            name: 'GSplatShadowCull',
+            shaderLanguage: SHADERLANGUAGE_WGSL,
+            cshader: computeGsplatShadowCullSource,
+            cdefines: new Map([['{WORKGROUP_SIZE}', WORKGROUP_SIZE.toString()]]),
+            computeBindGroupFormat: this._cullBindGroupFormat,
+            computeUniformBufferFormats: { uniforms: uniformBufferFormat }
+        });
+    }
+
+    /** @private */
+    _createArgsShader() {
+        const device = this.device;
+
+        this._argsBindGroupFormat = new BindGroupFormat(device, [
+            new BindStorageBufferFormat('countBuffer', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('indirectDrawArgs', SHADERSTAGE_COMPUTE, false),
+            new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE)
+        ]);
+
+        const uniformBufferFormat = new UniformBufferFormat(device, [
+            new UniformFormat('drawSlot', UNIFORMTYPE_UINT),
+            new UniformFormat('indexCount', UNIFORMTYPE_UINT),
+            new UniformFormat('pad0', UNIFORMTYPE_UINT),
+            new UniformFormat('pad1', UNIFORMTYPE_UINT)
+        ]);
+
+        this._argsShader = new Shader(device, {
+            name: 'GSplatShadowIndirectArgs',
+            shaderLanguage: SHADERLANGUAGE_WGSL,
+            cshader: computeGsplatShadowIndirectArgsSource,
+            cdefines: new Map([['{INSTANCE_SIZE}', GSplatResourceBase.instanceSize.toString()]]),
+            computeBindGroupFormat: this._argsBindGroupFormat,
+            computeUniformBufferFormats: { uniforms: uniformBufferFormat }
+        });
+    }
+
+    /**
+     * Rebinds to a new work buffer after a format/resize swap. The per-light materials read the
+     * work-buffer textures, so they must be re-pointed when the manager recreates it.
+     *
+     * @param {GSplatWorkBuffer} workBuffer - The new work buffer.
+     */
+    setDataSource(workBuffer) {
+        // Force a re-upload of intervals; offsets/bounds indices may have shifted.
+        this._uploadedVersion = -1;
+        this.entries.forEach((entry) => {
+            this._configureMaterialWorkBuffer(entry.material);
+            entry.material.update();
+        });
+    }
+
+    /**
+     * Sets the world-space AABB on every cast mesh instance. The directional shadow cull derives
+     * each cascade's depth range from the casters' AABBs (which world-space PCSS penumbra scaling
+     * depends on), and the shared quad mesh has no meaningful spatial bounds of its own — so without
+     * this the depth range is wrong and soft shadows are mis-scaled. Must run pre-cull (the manager
+     * calls it before cullComposition fits the shadow cameras). `setCustomAabb` copies, so passing a
+     * shared box instance to every entry is safe.
+     *
+     * @param {import('../../core/shape/bounding-box.js').BoundingBox|null} aabb - World-space splat AABB.
+     */
+    setCastersAabb(aabb) {
+        if (!aabb) return;
+        this.entries.forEach((entry) => {
+            entry.meshInstance.setCustomAabb(aabb);
+        });
+    }
+
+    /**
+     * Pre-cull pass: reconcile the per-light caster pool against the layer's directional shadow
+     * lights (enabled, shadow-casting, non-cascaded). Adds entries for new lights and tears down
+     * entries for lights that were disabled, removed, stopped casting, or became cascaded — freeing
+     * their GPU resources and unregistering their caster. Cascaded directional lights are skipped
+     * (warned once); they would need a per-cascade cull.
+     */
+    syncLights() {
+        const lights = this.layer.splitLights[LIGHTTYPE_DIRECTIONAL];
+
+        // build the set of lights that should have a draw entry this frame
+        const desired = this._desiredLights;
+        desired.clear();
+        for (let i = 0; i < lights.length; i++) {
+            const light = lights[i];
+            if (!light.enabled || !light.castShadows) continue;
+            if (light.numCascades !== 1) {
+                Debug.warnOnce('GSplatShadowRenderer: cascaded directional shadows are not supported for gsplats; the light will not cast a gsplat shadow.');
+                continue;
+            }
+            desired.add(light);
+        }
+
+        // tear down entries for lights no longer desired
+        this.entries.forEach((entry, light) => {
+            if (!desired.has(light)) {
+                this._destroyEntry(entry);
+                this.entries.delete(light);
+            }
+        });
+
+        // create entries for newly desired lights
+        desired.forEach((light) => {
+            if (!this.entries.has(light)) {
+                this.entries.set(light, this._createEntry(light));
+            }
+        });
+    }
+
+    /**
+     * Post-cull pass: for each light entry run the coarse node-frustum cull + expand and the
+     * indirect-args write, then bind the results to the entry's mesh instance. Runs after
+     * `cullComposition` and before the frame graph renders the shadow maps.
+     *
+     * @param {GSplatParams} gsplatParams - Scene gsplat params (alphaClip etc.).
+     */
+    cull(gsplatParams) {
+        const worldState = this.world.getState(this.world.currentVersion);
+        const ready = worldState && worldState.sortedBefore && worldState.totalActiveSplats > 0;
+
+        if (!ready) {
+            this.entries.forEach((entry) => {
+                entry.meshInstance.visible = false;
+            });
+            return;
+        }
+
+        this._ensureIntervals(worldState);
+
+        // Refresh the per-node world transforms the coarse cull reads. The forward renderer also
+        // does this each frame, but a shadow-only manager has no forward pass — so we keep them
+        // current here (cheap: one matrix per splat placement, correct for moving splats).
+        this.world.workBuffer.frustumCuller.updateTransformsData(worldState.boundsGroups);
+
+        const numIntervals = worldState.totalIntervals;
+        const totalActiveSplats = worldState.totalActiveSplats;
+        const textureSize = this.world.workBuffer.textureSize;
+
+        this.entries.forEach((entry) => {
+            this._cullEntry(entry, numIntervals, totalActiveSplats, textureSize, gsplatParams);
+        });
+    }
+
+    /**
+     * Dispatches the cull + indirect-args for one light entry and binds the results.
+     *
+     * @param {ShadowLightEntry} entry - The light entry.
+     * @param {number} numIntervals - Total interval count.
+     * @param {number} totalActiveSplats - Max output index count.
+     * @param {number} textureSize - Work buffer texture size.
+     * @param {GSplatParams} gsplatParams - Scene gsplat params.
+     * @private
+     */
+    _cullEntry(entry, numIntervals, totalActiveSplats, textureSize, gsplatParams) {
+        const device = this.device;
+
+        // resolve the light's shadow-camera frustum (fitted during cullComposition) and the shared
+        // camera-independent cull bounds (populated by the forward renderer's frustum culler).
+        const sceneCamera = this.cameraNode.camera?.camera;
+        const frustum = sceneCamera && entry.light.getRenderData(sceneCamera, 0).shadowCamera?.frustum;
+        const frustumCuller = this.world.workBuffer.frustumCuller;
+        if (!frustum || !frustumCuller?.boundsBuffer || !frustumCuller?.transformsBuffer) {
+            entry.meshInstance.visible = false;
+            return;
+        }
+        this._fillFrustumPlanes(frustum);
+
+        // grow the visible-index buffer to hold all active splats (worst case: nothing culled)
+        if (totalActiveSplats > entry.allocatedIndexCount) {
+            entry.indexBuffer?.destroy();
+            entry.allocatedIndexCount = totalActiveSplats;
+            entry.indexBuffer = new StorageBuffer(device, totalActiveSplats * 4);
+            DebugHelper.setName(entry.indexBuffer, 'GSplatShadow.indices');
+        }
+
+        // reset the atomic visible counter, then run the cull (coarse node-frustum reject + expand)
+        entry.countBuffer.clear();
+
+        const cull = entry.cullCompute;
+        cull.setParameter('intervals', this.intervalsBuffer);
+        cull.setParameter('outputIndices', entry.indexBuffer);
+        cull.setParameter('globalCount', entry.countBuffer);
+        cull.setParameter('boundsBuffer', frustumCuller.boundsBuffer);
+        cull.setParameter('transformsBuffer', frustumCuller.transformsBuffer);
+        cull.setParameter('frustumPlanes[0]', this._frustumPlanes);
+        cull.setParameter('numIntervals', numIntervals);
+
+        // one workgroup per interval, tiled across X/Y when over the per-dimension limit
+        Compute.calcDispatchSize(numIntervals, this._cullDispatchSize, device.limits.maxComputeWorkgroupsPerDimension || 65535);
+        cull.setupDispatch(this._cullDispatchSize.x, this._cullDispatchSize.y, 1);
+        device.computeDispatch([cull], 'GSplatShadowCull');
+
+        // turn the visible count into indirect draw args
+        const drawSlot = device.getIndirectDrawSlot(1);
+        const args = entry.argsCompute;
+        args.setParameter('countBuffer', entry.countBuffer);
+        args.setParameter('indirectDrawArgs', device.indirectDrawBuffer);
+        args.setParameter('drawSlot', drawSlot);
+        args.setParameter('indexCount', INDEX_COUNT);
+        args.setParameter('pad0', 0);
+        args.setParameter('pad1', 0);
+        args.setupDispatch(1);
+        device.computeDispatch([args], 'GSplatShadowIndirectArgs');
+
+        // bind to the cast mesh instance for the indirect draw
+        const material = entry.material;
+        entry.meshInstance.setIndirect(null, drawSlot, 1);
+        material.setParameter('compactedSplatIds', entry.indexBuffer);
+        material.setParameter('numSplatsStorage', entry.countBuffer);
+        material.setParameter('splatTextureSize', textureSize);
+        material.setParameter('alphaClip', gsplatParams.alphaClip);
+
+        entry.meshInstance.visible = true;
+        if (entry.meshInstance.instancingCount <= 0) {
+            entry.meshInstance.instancingCount = 1;
+        }
+    }
+
+    /**
+     * Uploads interval metadata for the world state (cached per version).
+     *
+     * @param {import('./gsplat-world-state.js').GSplatWorldState} worldState - The world state.
+     * @private
+     */
+    _ensureIntervals(worldState) {
+        if (worldState.version === this._uploadedVersion) return;
+        this._uploadedVersion = worldState.version;
+
+        const numIntervals = worldState.totalIntervals;
+        if (numIntervals === 0) return;
+
+        if (numIntervals > this.allocatedIntervalCount) {
+            this.intervalsBuffer?.destroy();
+            this.allocatedIntervalCount = numIntervals;
+            this.intervalsBuffer = new StorageBuffer(this.device, numIntervals * INTERVAL_STRIDE * 4, BUFFERUSAGE_COPY_DST);
+            DebugHelper.setName(this.intervalsBuffer, 'GSplatShadow.intervals');
+        }
+
+        const data = buildGSplatIntervalData(worldState);
+        this.intervalsBuffer.write(0, data, 0, numIntervals * INTERVAL_STRIDE);
+    }
+
+    /**
+     * Fills {@link _frustumPlanes} from a frustum: 6 planes packed as vec4(normal.xyz, distance).
+     *
+     * @param {import('../../core/shape/frustum.js').Frustum} frustum - The light's shadow-camera frustum.
+     * @private
+     */
+    _fillFrustumPlanes(frustum) {
+        const p = this._frustumPlanes;
+        for (let i = 0; i < 6; i++) {
+            const plane = frustum.planes[i];
+            p[i * 4 + 0] = plane.normal.x;
+            p[i * 4 + 1] = plane.normal.y;
+            p[i * 4 + 2] = plane.normal.z;
+            p[i * 4 + 3] = plane.distance;
+        }
+    }
+
+    /**
+     * Creates a per-light shadow draw entry (material + caster mesh instance + count buffer).
+     *
+     * @param {Light} light - The directional light.
+     * @returns {ShadowLightEntry} The created entry.
+     * @private
+     */
+    _createEntry(light) {
+        const device = this.device;
+
+        const material = this._createMaterial();
+        const meshInstance = this._createMeshInstance(light, material);
+
+        // register as a shadow caster so cullComposition's shadow-caster culling includes it
+        meshInstance.castShadow = true;
+        this.layer.addShadowCasters([meshInstance]);
+
+        const countBuffer = new StorageBuffer(device, 4, BUFFERUSAGE_COPY_DST);
+        DebugHelper.setName(countBuffer, 'GSplatShadow.count');
+
+        // Per-entry Compute instances (own uniform buffers + bind groups) sharing the renderer's
+        // shaders, so per-light dispatches don't alias each other's uniforms (see field comment).
+        const cullCompute = new Compute(device, this._cullShader, 'GSplatShadowCull');
+        const argsCompute = new Compute(device, this._argsShader, 'GSplatShadowIndirectArgs');
+
+        return {
+            light,
+            material,
+            meshInstance,
+            indexBuffer: null,
+            allocatedIndexCount: 0,
+            countBuffer,
+            cullCompute,
+            argsCompute
+        };
+    }
+
+    /**
+     * Tears down a light entry: unregisters the caster and frees its GPU resources.
+     *
+     * @param {ShadowLightEntry} entry - The entry to destroy.
+     * @private
+     */
+    _destroyEntry(entry) {
+        this.layer.removeShadowCasters([entry.meshInstance]);
+        entry.meshInstance.destroy();
+        entry.material.destroy();
+        entry.indexBuffer?.destroy();
+        entry.countBuffer.destroy();
+        entry.cullCompute.destroy();
+        entry.argsCompute.destroy();
+    }
+
+    /**
+     * Creates the quad-style shadow draw material. Uses the same gsplat vertex/fragment chunks as
+     * the forward quad renderer (direct per-vertex projection from the bound view/projection — the
+     * shadow camera's, supplied by the engine's shadow pass), trimmed to depth + alpha-clip (the
+     * engine injects `SHADOW_PASS` when compiling the shadow variant). Indirect-draw mode reads the
+     * visible index list and GPU count.
+     *
+     * @returns {ShaderMaterial} The configured material.
+     * @private
+     */
+    _createMaterial() {
+        const material = new ShaderMaterial({
+            uniqueName: 'GSplatShadowMaterial',
+            vertexGLSL: '#include "gsplatVS"',
+            fragmentGLSL: '#include "gsplatPS"',
+            vertexWGSL: '#include "gsplatVS"',
+            fragmentWGSL: '#include "gsplatPS"',
+            attributes: {
+                vertex_position: SEMANTIC_POSITION
+            }
+        });
+
+        material.setDefine('{GSPLAT_INSTANCE_SIZE}', GSplatResourceBase.instanceSize);
+        material.setDefine('SH_BANDS', '0');
+        material.setDefine('GSPLAT_SEPARATE_OPACITY', '');
+        material.setDefine('DITHER_NONE', '');
+        material.setDefine('GSPLAT_INDIRECT_DRAW', true);
+
+        this._configureMaterialWorkBuffer(material);
+
+        material.cull = CULLFACE_NONE;
+        material.blendType = BLEND_PREMULTIPLIED;
+        material.depthWrite = false;
+        material.update();
+
+        return material;
+    }
+
+    /**
+     * Injects the work-buffer format shader chunks and binds its textures + format-dependent defines
+     * to a material. Mirrors the relevant parts of {@link GSplatQuadRenderer}.
+     *
+     * @param {ShaderMaterial} material - The material to configure.
+     * @private
+     */
+    _configureMaterialWorkBuffer(material) {
+        const workBuffer = this.world.workBuffer;
+        const wbFormat = workBuffer.format;
+
+        // format declarations + read code
+        const chunks = this.device.isWebGPU ? material.shaderChunks.wgsl : material.shaderChunks.glsl;
+        chunks.set('gsplatDeclarationsVS', wbFormat.getInputDeclarations());
+        chunks.set('gsplatReadVS', wbFormat.getReadCode());
+
+        // color format define
+        const colorStream = wbFormat.getStream('dataColor');
+        if (colorStream && colorStream.format !== PIXELFORMAT_RGBA16U) {
+            material.setDefine('GSPLAT_COLOR_FLOAT', '');
+        }
+
+        // unified ID defines (kept consistent with the work buffer streams)
+        const hasPcId = !!wbFormat.getStream('pcId');
+        material.setDefine('GSPLAT_UNIFIED_ID', hasPcId);
+        material.setDefine('PICK_CUSTOM_ID', hasPcId);
+
+        // bind work buffer textures
+        for (const stream of wbFormat.resourceStreams) {
+            const texture = workBuffer.getTexture(stream.name);
+            if (texture) {
+                material.setParameter(stream.name, texture);
+            }
+        }
+    }
+
+    /**
+     * Creates the cast mesh instance for a light, visible only for that light's shadow camera.
+     *
+     * @param {Light} light - The directional light.
+     * @param {ShaderMaterial} material - The entry's material.
+     * @returns {MeshInstance} The mesh instance.
+     * @private
+     */
+    _createMeshInstance(light, material) {
+        const mesh = GSplatResourceBase.createMesh(this.device);
+        const meshInstance = new MeshInstance(mesh, material);
+        meshInstance.node = this.node;
+        meshInstance.setInstancing(true, true);
+        meshInstance.instancingCount = 0;
+        meshInstance.pick = false;
+
+        // visible only when rendering this light's shadow camera. Each directional light owns a
+        // distinct shadow-camera object (resolved lazily via the idempotent getRenderData), so the
+        // identity match routes this caster to exactly its light's shadow map.
+        const cameraNode = this.cameraNode;
+        meshInstance.isVisibleFunc = (camera) => {
+            const sceneCamera = cameraNode.camera?.camera;
+            if (!sceneCamera) return false;
+            return camera === light.getRenderData(sceneCamera, 0).shadowCamera;
+        };
+
+        return meshInstance;
+    }
+}
+
+export { GSplatShadowRenderer };

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1091,6 +1091,11 @@ class ForwardRenderer extends Renderer {
         // after this the scene culling is done and script callbacks can be called to report which objects are visible
         this.cullComposition(comp);
 
+        // Dispatch gsplat directional shadow culls. Runs after cullComposition so each directional
+        // light's shadow-camera frustum has been fitted, and before the frame graph renders the
+        // shadow maps. Only the GPU-sort (hybrid) gsplat path uses this; the CPU-sort path self-casts.
+        this.gsplatDirector?.updateShadows();
+
         // GPU update for visible objects requiring one
         this.gpuUpdate(this.processingMeshInstances);
     }

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-shadow-cull.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-shadow-cull.js
@@ -1,0 +1,111 @@
+// Directional-shadow cull + compaction for the GPU-sort (hybrid) gsplat path.
+//
+// Dispatched with one workgroup per interval (tiled across X/Y when the interval count exceeds the
+// per-dimension workgroup limit). Each workgroup processes one interval's splats and appends the
+// visible ones to a single output index buffer, reserving space with a workgroup-aggregated atomic
+// (one atomicAdd per workgroup, not one per visible splat — mobile-friendly, no subgroups).
+//
+// Cull stage: coarse per-interval reject — the octree node's world-space bounding sphere is tested
+// against the light's 6 frustum planes (same math as compute-gsplat-interval-cull.js); rejected
+// intervals are skipped entirely by the whole workgroup. Surviving intervals expand all their
+// splats. (The per-splat fine tests — opacity/projected-size/offscreen — are intentionally not done
+// here: they need projector-grade per-splat projection + work-buffer-format coupling, and shadow
+// correctness is already enforced by the shadow VS/FS alphaClip + clip. They can be layered in later
+// as a per-thread visible flag + workgroup prefix-sum before the atomic reservation.)
+//
+// The output order is unspecified (it depends on the inter-workgroup atomic race), which is fine for
+// shadows: only depth is written, so draw order does not matter.
+
+export const computeGsplatShadowCullSource = /* wgsl */`
+
+struct Interval {
+    workBufferBase: u32,
+    splatCount: u32,
+    boundsIndex: u32,
+    pad: u32
+};
+
+struct BoundsEntry {
+    centerX: f32,
+    centerY: f32,
+    centerZ: f32,
+    radius: f32,
+    transformIndex: u32,
+    pad0: u32,
+    pad1: u32,
+    pad2: u32
+};
+
+struct CullUniforms {
+    frustumPlanes: array<vec4f, 6>,
+    numIntervals: u32
+};
+@group(0) @binding(0) var<uniform> uniforms: CullUniforms;
+
+@group(0) @binding(1) var<storage, read> intervals: array<Interval>;
+
+// Output: dense list of visible work-buffer splat indices (unordered).
+@group(0) @binding(2) var<storage, read_write> outputIndices: array<u32>;
+
+// Single global atomic visible counter. Must be cleared to 0 before each dispatch.
+@group(0) @binding(3) var<storage, read_write> globalCount: array<atomic<u32>>;
+
+// Per-node bounding spheres + their transforms (camera-independent; shared with the forward cull).
+@group(0) @binding(4) var<storage, read> boundsBuffer: array<BoundsEntry>;
+@group(0) @binding(5) var<storage, read> transformsBuffer: array<vec4f>;
+
+// Base output offset reserved by this workgroup, broadcast from thread 0 to the rest.
+var<workgroup> wgBase: u32;
+
+@compute @workgroup_size({WORKGROUP_SIZE})
+fn main(
+    @builtin(workgroup_id) wgId: vec3u,
+    @builtin(num_workgroups) numWorkgroups: vec3u,
+    @builtin(local_invocation_id) lid: vec3u
+) {
+    // reconstruct the linear interval index from the (possibly Y-tiled) 2D dispatch
+    let intervalIdx = wgId.y * numWorkgroups.x + wgId.x;
+    if (intervalIdx >= uniforms.numIntervals) { return; }
+
+    let interval = intervals[intervalIdx];
+    let count = interval.splatCount;
+    if (count == 0u) { return; }
+
+    // Coarse cull: transform the node's bounding sphere to world space and test it against the
+    // light's frustum planes. The result is uniform across the workgroup (same interval), so the
+    // early-out keeps control flow uniform for the workgroupBarrier below.
+    let entry = boundsBuffer[interval.boundsIndex];
+    let localCenter = vec3f(entry.centerX, entry.centerY, entry.centerZ);
+    let base3 = entry.transformIndex * 3u;
+    let row0 = transformsBuffer[base3];
+    let row1 = transformsBuffer[base3 + 1u];
+    let row2 = transformsBuffer[base3 + 2u];
+    let worldCenter = vec3f(
+        dot(vec4f(localCenter, 1.0), row0),
+        dot(vec4f(localCenter, 1.0), row1),
+        dot(vec4f(localCenter, 1.0), row2)
+    );
+    let worldRadius = entry.radius * length(vec3f(row0.x, row1.x, row2.x));
+
+    for (var p = 0; p < 6; p++) {
+        let plane = uniforms.frustumPlanes[p];
+        if (dot(plane.xyz, worldCenter) + plane.w <= -worldRadius) {
+            return; // node fully outside this plane -> whole interval culled
+        }
+    }
+
+    // Reserve a contiguous block for this (visible) interval's splats with a single atomic add.
+    if (lid.x == 0u) {
+        wgBase = atomicAdd(&globalCount[0], count);
+    }
+    workgroupBarrier();
+    let base = wgBase;
+
+    let workBufferBase = interval.workBufferBase;
+    for (var j = lid.x; j < count; j += {WORKGROUP_SIZE}u) {
+        outputIndices[base + j] = workBufferBase + j;
+    }
+}
+`;
+
+export default computeGsplatShadowCullSource;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-shadow-indirect-args.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-shadow-indirect-args.js
@@ -1,0 +1,43 @@
+// Single-thread compute shader that reads the visible shadow-splat count and writes the indexed
+// indirect draw arguments for a directional-shadow gsplat draw.
+//
+// The count is produced by the fused shadow cull (an atomic counter), and is also bound directly to
+// the draw material as `numSplatsStorage` so the vertex shader reads the same value. This shader
+// only needs to turn the count into an instance count for the indirect draw.
+
+import indirectCoreCS from '../common/comp/indirect-core.js';
+
+export const computeGsplatShadowIndirectArgsSource = /* wgsl */`
+
+${indirectCoreCS}
+
+// Visible splat count (element 0), produced by the shadow cull's atomic counter.
+@group(0) @binding(0) var<storage, read> countBuffer: array<u32>;
+
+// Device's shared indirect draw buffer, indexed by slot.
+@group(0) @binding(1) var<storage, read_write> indirectDrawArgs: array<DrawIndexedIndirectArgs>;
+
+struct ShadowArgsUniforms {
+    drawSlot: u32,      // slot index into indirectDrawArgs
+    indexCount: u32,    // indices per instance (768 = 6 * 128)
+    pad0: u32,
+    pad1: u32
+};
+@group(0) @binding(2) var<uniform> uniforms: ShadowArgsUniforms;
+
+@compute @workgroup_size(1)
+fn main() {
+    let count = countBuffer[0];
+    let instanceCount = (count + {INSTANCE_SIZE}u - 1u) / {INSTANCE_SIZE}u;
+
+    indirectDrawArgs[uniforms.drawSlot] = DrawIndexedIndirectArgs(
+        uniforms.indexCount,
+        instanceCount,
+        0u,     // firstIndex
+        0,      // baseVertex
+        0u      // firstInstance
+    );
+}
+`;
+
+export default computeGsplatShadowIndirectArgsSource;


### PR DESCRIPTION
Lets the GPU-sort (hybrid) gsplat renderer cast directional shadows — previously only the CPU-sort quad renderer could, so scenes using the hybrid renderer got no gsplat shadows.

**Changes:**
- New `GSplatShadowRenderer`: a projection-free compute cull (coarse octree-node vs light-frustum reject) producing an unsorted visible-index buffer, then a quad-style per-vertex-projected indirect draw via the standard shadow-caster pipeline (no sort, no projection cache).
- Supports any number of non-cascaded directional lights, each with its own cull + draw. Shadow casting fans out at the renderer level only — one `GSplatWorld` per manager regardless of light count.
- A separate shadow-only manager no longer allocates the unused forward sorter/projector (the hybrid renderer's GPU sort/projection resources are now created lazily on first forward use).
- Correct world-space PCSS soft-shadow depth range: the shadow caster mesh instances are given the real aggregate splat AABB, matching the forward path.
- Extracted a shared interval-data builder (`gsplat-interval-data.js`) reused by the forward interval compaction and the shadow cull.

**Examples:**
- `gaussian-splatting/shadows`: added a "Lights" slider (0–6) demonstrating multiple directional gsplat shadows (lights evenly spaced at the full count, rotating together).

**Performance:**
- Shadow casting skips projection and sorting entirely; the coarse node-frustum cull rejects whole octree nodes outside each light's view — the biggest win on large scenes.