### PR TITLE
fix(element): cull screen-space text by content bounds

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -36,6 +36,9 @@ const matB = new Mat4();
 const matC = new Mat4();
 const matD = new Mat4();
 
+// scratch corners used when computing content bounds for culling
+const tmpCorners = [new Vec3(), new Vec3(), new Vec3(), new Vec3()];
+
 /**
  * ElementComponents are used to construct user interfaces. The {@link type} property can be
  * configured in 3 main ways: as a text element, as an image element or as a group element. If
@@ -827,32 +830,41 @@ class ElementComponent extends Component {
             return this._screenCorners;
         }
 
-        const parentBottomLeft = this.entity.parent && this.entity.parent.element && this.entity.parent.element.screenCorners[0];
-
-        // init corners
-        this._screenCorners[0].set(this._absLeft, this._absBottom, 0);
-        this._screenCorners[1].set(this._absRight, this._absBottom, 0);
-        this._screenCorners[2].set(this._absRight, this._absTop, 0);
-        this._screenCorners[3].set(this._absLeft, this._absTop, 0);
-
-        // transform corners to screen space
-        const screenSpace = this.screen.screen.screenSpace;
-        for (let i = 0; i < 4; i++) {
-            this._screenTransform.transformPoint(this._screenCorners[i], this._screenCorners[i]);
-            if (screenSpace) {
-                this._screenCorners[i].mulScalar(this.screen.screen.scale);
-            }
-
-            if (parentBottomLeft) {
-                this._screenCorners[i].add(parentBottomLeft);
-            }
-        }
+        this._calcScreenCorners(this._absLeft, this._absBottom, this._absRight, this._absTop, this._screenCorners);
 
         this._cornersDirty = false;
         this._canvasCornersDirty = true;
         this._worldCornersDirty = true;
 
         return this._screenCorners;
+    }
+
+    // Transforms an anchor-space rectangle (defined by its left/bottom/right/top edges) into the 4
+    // screen-space corners (bottom left, bottom right, top right, top left), populating and
+    // returning the supplied array. This is the shared logic behind screenCorners.
+    _calcScreenCorners(left, bottom, right, top, corners) {
+        const parentBottomLeft = this.entity.parent && this.entity.parent.element && this.entity.parent.element.screenCorners[0];
+
+        // init corners
+        corners[0].set(left, bottom, 0);
+        corners[1].set(right, bottom, 0);
+        corners[2].set(right, top, 0);
+        corners[3].set(left, top, 0);
+
+        // transform corners to screen space
+        const screenSpace = this.screen.screen.screenSpace;
+        for (let i = 0; i < 4; i++) {
+            this._screenTransform.transformPoint(corners[i], corners[i]);
+            if (screenSpace) {
+                corners[i].mulScalar(this.screen.screen.scale);
+            }
+
+            if (parentBottomLeft) {
+                corners[i].add(parentBottomLeft);
+            }
+        }
+
+        return corners;
     }
 
     /**
@@ -2793,7 +2805,27 @@ class ElementComponent extends Component {
             clipB = clipT - cameraHeight;
         }
 
-        const hitCorners = this.screenCorners;
+        // A text element's rendered glyphs can overflow its element box (e.g. wrapped text that is
+        // taller or wider than the configured size), so cull against the actual content bounds
+        // rather than the box - otherwise visible text whose box falls outside the clip region is
+        // wrongly culled (see https://github.com/playcanvas/engine/issues/4615).
+        let hitCorners = this.screenCorners;
+        const text = this._text;
+        if (text) {
+            const overflowX = Math.max(0, text.width - this.calculatedWidth);
+            const overflowY = Math.max(0, text.height - this.calculatedHeight);
+            if (overflowX > 0 || overflowY > 0) {
+                const ha = this.alignment.x;
+                const va = this.alignment.y;
+                hitCorners = this._calcScreenCorners(
+                    this._absLeft - ha * overflowX,
+                    this._absBottom - va * overflowY,
+                    this._absRight + (1 - ha) * overflowX,
+                    this._absTop + (1 - va) * overflowY,
+                    tmpCorners
+                );
+            }
+        }
 
         const left = Math.min(Math.min(hitCorners[0].x, hitCorners[1].x), Math.min(hitCorners[2].x, hitCorners[3].x));
         const right = Math.max(Math.max(hitCorners[0].x, hitCorners[1].x), Math.max(hitCorners[2].x, hitCorners[3].x));

--- a/test/framework/components/element/text-element.test.mjs
+++ b/test/framework/components/element/text-element.test.mjs
@@ -1426,6 +1426,73 @@ describe('TextElement', function () {
         expect(e.element.isVisibleForCamera(camera.camera.camera)).to.be.false;
     });
 
+    it('Masked text is not culled when its wrapped content overflows the element box (#4615)', function () {
+        // screen-space screens enable element culling
+        const screen = new Entity();
+        screen.addComponent('screen', {
+            screenSpace: true
+        });
+        app.root.addChild(screen);
+
+        const camera = new Entity();
+        camera.addComponent('camera');
+        app.root.addChild(camera);
+
+        // masking image element, centered on the screen
+        const mask = new Entity();
+        mask.addComponent('element', {
+            type: 'image',
+            mask: true,
+            anchor: [0.5, 0.5, 0.5, 0.5],
+            pivot: [0.5, 0.5],
+            width: 200,
+            height: 100
+        });
+        screen.addChild(mask);
+
+        // child text whose wrapped content is much taller than its one-line box
+        const e = new Entity();
+        e.addComponent('element', {
+            type: 'text',
+            text: 'the quick brown fox jumps over the lazy dog and keeps on running for a while',
+            fontAsset: fontAsset,
+            anchor: [0.5, 0.5, 0.5, 0.5],
+            pivot: [0.5, 0.5],
+            alignment: [0.5, 0.5],
+            autoWidth: false,
+            autoHeight: false,
+            wrapLines: true,
+            width: 150,
+            height: 20
+        });
+        mask.addChild(e);
+
+        app.update(0.1);
+        app.render();
+
+        // sanity: the text is masked and its rendered content overflows its box vertically
+        expect(e.element.maskedBy).to.equal(mask);
+        const contentHeight = e.element._text.height;
+        expect(contentHeight).to.be.greaterThan(e.element.calculatedHeight);
+
+        // centered over the mask -> visible
+        expect(e.element.isVisibleForCamera(camera.camera.camera)).to.be.true;
+
+        // move the box clear of the mask, but by less than the content overflow, so the wrapped
+        // glyphs still reach into the mask region. The box alone is outside the mask (the old
+        // box-based test culled it here), but the rendered text is not, so it must stay visible.
+        e.setLocalPosition(0, -(55 + contentHeight / 4), 0);
+        app.update(0.1);
+        app.render();
+        expect(e.element.isVisibleForCamera(camera.camera.camera)).to.be.true;
+
+        // move it far enough that even the overflowing content clears the mask -> culled
+        e.setLocalPosition(0, -(contentHeight / 2 + 100), 0);
+        app.update(0.1);
+        app.render();
+        expect(e.element.isVisibleForCamera(camera.camera.camera)).to.be.false;
+    });
+
     it('text is set to translated text when we set the key', function () {
         addText('en-US', 'key', 'translation');
         element.fontAsset = fontAsset;


### PR DESCRIPTION
Fixes #4615.

Screen-space UI elements are frustum-culled via `ElementComponent.isVisibleForCamera`, which tested the element's **anchored box**. A text element's wrapped glyphs can overflow that box, so masked (or off-screen) text whose box fell outside the clip region was culled even though its glyphs were still on screen — the text rendered as nothing at runtime, while still showing in the Editor (edit-mode culling differs).

This culls text against its **rendered content bounds** instead: the box is expanded by the horizontal/vertical overflow (`text.width/height` − `calculatedWidth/Height`), distributed according to the text alignment. Over-estimation is the safe direction — worst case it renders an element that the stencil then clips; it never wrongly culls.

The corner-building logic in `screenCorners` is extracted into a shared `_calcScreenCorners` helper used by both paths.

### Testing
- Added a regression test (`Masked text is not culled when its wrapped content overflows the element box`) — fails on `main`, passes here.
- All existing element tests pass; verified visually against the reported repro project (text now renders and is correctly clipped to the mask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)