### PR TITLE
perf(gsplat): scalable per-splat culling for hybrid shadows

### DIFF
--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer-scratch.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer-scratch.js
@@ -1,0 +1,72 @@
+import { DebugHelper } from '../../core/debug.js';
+import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
+import { BUFFERUSAGE_COPY_SRC } from '../../platform/graphics/constants.js';
+
+/**
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ */
+
+/**
+ * Transient GPU scratch shared by the GPU-sort (hybrid) rendering path within a single
+ * {@link GSplatManager} — the forward {@link GSplatHybridRenderer} and the directional
+ * {@link GSplatShadowRenderer}. The manager creates one instance while a GPU-sort renderer is in use
+ * and injects it into both paths' {@link GSplatIntervalCompaction}; it is freed when the manager
+ * switches to a non-GPU-sort renderer or is destroyed. The CPU-sort (quad) path uses none of this.
+ *
+ * Buffers here are written + read at disjoint points in the frame (the forward sort in
+ * `update()`, the shadow cull in `updateShadows()`), so a single shared allocation is safe — the
+ * backend serialises them with the usual read/write barriers. It is per-manager (hence per-world),
+ * so separate cameras/layers never contend on the same buffer.
+ *
+ * Starts with just the compaction candidate-index list; further shared scratch can be added here as
+ * the hybrid path grows.
+ *
+ * @ignore
+ */
+class GSplatHybridRendererScratch {
+    /** @type {GraphicsDevice} */
+    device;
+
+    /**
+     * Dense compacted work-buffer index list produced by {@link GSplatIntervalCompaction} (the
+     * coarse-cull survivors). Sized to the work buffer's active splat count; grows monotonically.
+     *
+     * @type {StorageBuffer|null}
+     */
+    compactedSplatIds = null;
+
+    /** @type {number} */
+    _allocatedCompacted = 0;
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device (must support compute).
+     */
+    constructor(device) {
+        this.device = device;
+    }
+
+    /**
+     * Ensures the shared candidate-index scratch holds at least `capacity` u32 entries, growing it
+     * if needed. Returns the buffer so the caller can bind it.
+     *
+     * @param {number} capacity - Required entry count (work-buffer total active splats).
+     * @returns {StorageBuffer} The candidate-index scratch buffer.
+     */
+    ensureCompactedSplatIds(capacity) {
+        if (capacity > this._allocatedCompacted) {
+            this.compactedSplatIds?.destroy();
+            this._allocatedCompacted = capacity;
+            this.compactedSplatIds = new StorageBuffer(this.device, capacity * 4, BUFFERUSAGE_COPY_SRC);
+            DebugHelper.setName(this.compactedSplatIds, 'GSplatHybridRendererScratch.compactedSplatIds');
+        }
+        return this.compactedSplatIds;
+    }
+
+    destroy() {
+        this.compactedSplatIds?.destroy();
+        this.compactedSplatIds = null;
+        this._allocatedCompacted = 0;
+    }
+}
+
+export { GSplatHybridRendererScratch };

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -121,6 +121,15 @@ class GSplatHybridRenderer extends GSplatRenderer {
     intervalCompaction = null;
 
     /**
+     * Manager-owned shared scratch injected at construction; forwarded to the interval compaction so
+     * its compacted index list is shared with the directional-shadow cull. Null when not provided.
+     *
+     * @type {import('./gsplat-hybrid-renderer-scratch.js').GSplatHybridRendererScratch|null}
+     * @private
+     */
+    _scratch = null;
+
+    /**
      * Per-frame indirect draw slot index (-1 when unallocated).
      *
      * @type {number}
@@ -149,9 +158,13 @@ class GSplatHybridRenderer extends GSplatRenderer {
      * @param {Layer} layer - The layer to add mesh instances to.
      * @param {GSplatWorkBuffer} workBuffer - The work buffer (kept for parent compatibility;
      * the hybrid renderer does not bind work-buffer textures itself).
+     * @param {import('./gsplat-hybrid-renderer-scratch.js').GSplatHybridRendererScratch|null} [scratch] -
+     * Manager-owned shared scratch; forwarded to the interval compaction (shared with the shadow cull).
      */
-    constructor(device, node, cameraNode, layer, workBuffer) {
+    constructor(device, node, cameraNode, layer, workBuffer, scratch = null) {
         super(device, node, cameraNode, layer, workBuffer);
+
+        this._scratch = scratch;
 
         this._material = new ShaderMaterial({
             uniqueName: 'UnifiedSplatHybridMaterial',
@@ -292,7 +305,7 @@ class GSplatHybridRenderer extends GSplatRenderer {
     _ensureGpuPipeline() {
         if (!this.gpuSorter) this.gpuSorter = new ComputeRadixSort(this.device, { indirect: true });
         if (!this.projector) this.projector = new GSplatProjector(this.device);
-        if (!this.intervalCompaction) this.intervalCompaction = new GSplatIntervalCompaction(this.device);
+        if (!this.intervalCompaction) this.intervalCompaction = new GSplatIntervalCompaction(this.device, this._scratch);
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-interval-compaction.js
+++ b/src/scene/gsplat-unified/gsplat-interval-compaction.js
@@ -46,7 +46,21 @@ class GSplatIntervalCompaction {
     /** @type {GraphicsDevice} */
     device;
 
-    /** @type {StorageBuffer|null} */
+    /**
+     * Manager-owned shared scratch (see {@link GSplatHybridRendererScratch}) the compacted index list
+     * is borrowed from — shared with the directional-shadow cull. The prefix-sum / count / interval
+     * buffers stay per-instance.
+     *
+     * @type {import('./gsplat-hybrid-renderer-scratch.js').GSplatHybridRendererScratch}
+     * @private
+     */
+    _scratch;
+
+    /**
+     * Borrowed candidate index list from {@link _scratch}, refreshed each dispatch (not owned here).
+     *
+     * @type {StorageBuffer|null}
+     */
     compactedSplatIds = null;
 
     /** @type {StorageBuffer|null} */
@@ -63,9 +77,6 @@ class GSplatIntervalCompaction {
 
     /** @type {StorageBuffer|null} */
     sortElementCountBuffer = null;
-
-    /** @type {number} */
-    allocatedCompactedCount = 0;
 
     /** @type {number} */
     allocatedIntervalCount = 0;
@@ -120,10 +131,15 @@ class GSplatIntervalCompaction {
 
     /**
      * @param {GraphicsDevice} device - The graphics device (must support compute).
+     * @param {import('./gsplat-hybrid-renderer-scratch.js').GSplatHybridRendererScratch} scratch -
+     * Manager-owned shared scratch the compacted index list is borrowed from (shared across the
+     * forward + shadow GPU-sort passes within a manager).
      */
-    constructor(device) {
+    constructor(device, scratch) {
         Debug.assert(device.supportsCompute, 'GSplatIntervalCompaction requires compute shader support (WebGPU)');
+        Debug.assert(scratch, 'GSplatIntervalCompaction requires a shared scratch (GSplatHybridRendererScratch)');
         this.device = device;
+        this._scratch = scratch;
 
         this.numSplatsBuffer = new StorageBuffer(device, 4, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
         this.sortElementCountBuffer = new StorageBuffer(device, 4, BUFFERUSAGE_COPY_SRC | BUFFERUSAGE_COPY_DST);
@@ -137,7 +153,7 @@ class GSplatIntervalCompaction {
     }
 
     destroy() {
-        this.compactedSplatIds?.destroy();
+        // compactedSplatIds is borrowed from the manager-owned scratch — never freed here.
         this.intervalsBuffer?.destroy();
         this.countBuffer?.destroy();
         this.prefixSumKernel?.destroy();
@@ -335,12 +351,9 @@ class GSplatIntervalCompaction {
      * @private
      */
     _ensureCapacity(numIntervals, totalActiveSplats) {
-        if (totalActiveSplats > this.allocatedCompactedCount) {
-            this.compactedSplatIds?.destroy();
-            this.allocatedCompactedCount = totalActiveSplats;
-            this.compactedSplatIds = new StorageBuffer(this.device, totalActiveSplats * 4, BUFFERUSAGE_COPY_SRC);
-            DebugHelper.setName(this.compactedSplatIds, 'GsplatIntervalCompaction.compactedSplatIds');
-        }
+        // borrow the manager-owned shared candidate list (shared with the shadow cull). The scratch
+        // grows monotonically and is freed by the manager, not here.
+        this.compactedSplatIds = this._scratch.ensureCompactedSplatIds(totalActiveSplats);
 
         const requiredCountSize = numIntervals + 1;
         if (requiredCountSize > this.allocatedCountBufferSize) {

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -5,6 +5,7 @@ import { GSplatUnifiedSorter } from './gsplat-unified-sorter.js';
 import { GSplatWorld } from './gsplat-world.js';
 import { GSplatQuadRenderer } from './gsplat-quad-renderer.js';
 import { GSplatHybridRenderer } from './gsplat-hybrid-renderer.js';
+import { GSplatHybridRendererScratch } from './gsplat-hybrid-renderer-scratch.js';
 import { GSplatShadowRenderer } from './gsplat-shadow-renderer.js';
 import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
@@ -86,6 +87,17 @@ class GSplatManager {
      * @type {GSplatShadowRenderer|null}
      */
     shadowRenderer = null;
+
+    /**
+     * Shared GPU scratch for the GPU-sort (hybrid) path, created while a GPU-sort renderer is in use
+     * and injected into both the forward {@link GSplatHybridRenderer} and the
+     * {@link GSplatShadowRenderer} so they share the compaction candidate buffer. Null for the
+     * CPU-sort (quad) renderer.
+     *
+     * @type {GSplatHybridRendererScratch|null}
+     * @private
+     */
+    _hybridScratch = null;
 
     /**
      * The currently active renderer mode. Starts as undefined so the first
@@ -223,6 +235,10 @@ class GSplatManager {
         // its cast mesh instances from the layer.
         this.shadowRenderer?.destroy();
         this.shadowRenderer = null;
+
+        // Free the shared GPU-sort scratch after its borrowers (forward + shadow compactions) are gone.
+        this._hybridScratch?.destroy();
+        this._hybridScratch = null;
     }
 
     /**
@@ -396,10 +412,18 @@ class GSplatManager {
     _syncShadowRenderer() {
         const wantShadow = !!(this.renderMode & GSPLAT_SHADOW) && this.renderer.usesGpuSort;
         if (wantShadow && !this.shadowRenderer) {
-            this.shadowRenderer = new GSplatShadowRenderer(this.device, this.node, this.cameraNode, this.layer, this.world);
+            this.shadowRenderer = new GSplatShadowRenderer(this.device, this.node, this.cameraNode, this.layer, this.world, this._hybridScratch);
         } else if (!wantShadow && this.shadowRenderer) {
             this.shadowRenderer.destroy();
             this.shadowRenderer = null;
+        }
+
+        // Free the shared scratch once no GPU-sort renderer remains (forward switched to CPU-sort).
+        // Runs after the forward renderer (_createRenderer) and shadow renderer above are torn down,
+        // so neither borrower references it anymore.
+        if (!this.renderer.usesGpuSort && this._hybridScratch) {
+            this._hybridScratch.destroy();
+            this._hybridScratch = null;
         }
     }
 
@@ -412,8 +436,12 @@ class GSplatManager {
     _createRenderer(mode) {
         const workBuffer = this.world.workBuffer;
         if (mode === GSPLAT_RENDERER_RASTER_GPU_SORT) {
+            // The GPU-sort path shares one scratch (compaction candidate buffer) across the forward
+            // renderer and the shadow cull; create it here so it exists for both constructors. Freed
+            // in _syncShadowRenderer once no GPU-sort renderer remains (and in destroy()).
+            this._hybridScratch ??= new GSplatHybridRendererScratch(this.device);
             // The hybrid renderer creates its own GPU sort resources (radix sorter, projector).
-            this.renderer = new GSplatHybridRenderer(this.device, this.node, this.cameraNode, this.layer, workBuffer);
+            this.renderer = new GSplatHybridRenderer(this.device, this.node, this.cameraNode, this.layer, workBuffer, this._hybridScratch);
         } else {
             this.renderer = new GSplatQuadRenderer(this.device, this.node, this.cameraNode, this.layer, workBuffer);
             this.initCpuSorting();

--- a/src/scene/gsplat-unified/gsplat-shadow-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-shadow-renderer.js
@@ -12,6 +12,7 @@ import {
     SEMANTIC_POSITION,
     SHADERLANGUAGE_WGSL,
     SHADERSTAGE_COMPUTE,
+    UNIFORMTYPE_FLOAT,
     UNIFORMTYPE_UINT,
     UNIFORMTYPE_VEC4
 } from '../../platform/graphics/constants.js';
@@ -21,7 +22,10 @@ import { MeshInstance } from '../mesh-instance.js';
 import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js';
 import { computeGsplatShadowCullSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-shadow-cull.js';
 import { computeGsplatShadowIndirectArgsSource } from '../shader-lib/wgsl/chunks/gsplat/compute-gsplat-shadow-indirect-args.js';
-import { buildGSplatIntervalData, INTERVAL_STRIDE } from './gsplat-interval-data.js';
+import computeSplatSource from '../shader-lib/wgsl/chunks/gsplat/vert/gsplatComputeSplat.js';
+import gsplatModifyDefaultSource from '../shader-lib/wgsl/chunks/gsplat/vert/gsplatModify.js';
+import gsplatHelpersSource from '../shader-lib/wgsl/chunks/gsplat/vert/gsplatHelpers.js';
+import { GSplatIntervalCompaction } from './gsplat-interval-compaction.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
@@ -50,7 +54,10 @@ const INDEX_COUNT = 6 * GSplatResourceBase.instanceSize;
  * @property {StorageBuffer|null} indexBuffer - Dense visible work-buffer index list (grows with splat count).
  * @property {number} allocatedIndexCount - Capacity of `indexBuffer` in splats.
  * @property {StorageBuffer} countBuffer - Single-element atomic visible counter (also bound as `numSplatsStorage`).
- * @property {Compute} cullCompute - Per-entry cull compute (own uniform buffer/bind group).
+ * @property {Compute|null} cullCompute - Per-entry cull compute (own uniform buffer/bind group),
+ * lazily (re)created against the current cull shader; see {@link ShadowLightEntry.cullComputeGen}.
+ * @property {number} cullComputeGen - Cull-shader generation `cullCompute` was built for; when it no
+ * longer matches the renderer's {@link GSplatShadowRenderer#_cullShaderGen} the compute is rebuilt.
  * @property {Compute} argsCompute - Per-entry indirect-args compute (own uniform buffer/bind group).
  */
 
@@ -105,19 +112,16 @@ class GSplatShadowRenderer {
      */
     _desiredLights = new Set();
 
-    /** @type {StorageBuffer|null} */
-    intervalsBuffer = null;
-
-    /** @type {number} */
-    allocatedIntervalCount = 0;
-
     /**
-     * World-state version the intervals were last uploaded for (intervals are camera/light
-     * independent, so they are shared across all light entries and uploaded once per version).
+     * Pass 1 (coarse): interval compaction run with each light's frustum, producing a dense candidate
+     * list (`compactedSplatIds`) + candidate count (`countBuffer[numIntervals]`). Reused across all
+     * lights — one shared scratch, since lights are culled sequentially (light A's pass 2 consumes the
+     * candidate list before light B's pass 1 overwrites it). The expensive per-splat fine cull (pass
+     * 2) then runs flat over the candidate list, so occupancy is independent of interval count.
      *
-     * @type {number}
+     * @type {GSplatIntervalCompaction|null}
      */
-    _uploadedVersion = -1;
+    _compaction = null;
 
     /** @type {Vec2} */
     _cullDispatchSize = new Vec2(1, 1);
@@ -159,6 +163,33 @@ class GSplatShadowRenderer {
     /** @type {BindGroupFormat|null} */
     _cullBindGroupFormat = null;
 
+    /**
+     * Work-buffer format version the cull shader was last built for. The cull shader reads the work
+     * buffer (texture bindings + read code derived from the format), so a format change rebuilds it.
+     *
+     * @type {number}
+     * @private
+     */
+    _cullFormatVersion = -1;
+
+    /**
+     * The scene material's shader-chunks key the cull shader was last built for. A change means the
+     * user `gsplatModifyVS` chunk changed, so the cull shader is rebuilt to match the shadow draw.
+     *
+     * @type {string|null}
+     * @private
+     */
+    _cullBuiltChunksKey = null;
+
+    /**
+     * Monotonic cull-shader generation, bumped on every (re)build. Per-light cull Computes reference
+     * the shared shader, so they are recreated when this changes (see {@link _cullEntry}).
+     *
+     * @type {number}
+     * @private
+     */
+    _cullShaderGen = 0;
+
     /** @type {Shader|null} */
     _argsShader = null;
 
@@ -172,15 +203,25 @@ class GSplatShadowRenderer {
      * resolve each light's shadow camera via `light.getRenderData(sceneCamera, 0)`.
      * @param {Layer} layer - The layer to register shadow casters on (and read directional lights from).
      * @param {GSplatWorld} world - The shared world (work buffer, cull bounds, world states).
+     * @param {import('./gsplat-hybrid-renderer-scratch.js').GSplatHybridRendererScratch|null} [scratch] -
+     * Manager-owned shared scratch; forwarded to the pass-1 compaction so its candidate index list is
+     * shared with the forward hybrid renderer (they use it at disjoint points in the frame).
      */
-    constructor(device, node, cameraNode, layer, world) {
+    constructor(device, node, cameraNode, layer, world, scratch = null) {
         this.device = device;
         this.node = node;
         this.cameraNode = cameraNode;
         this.layer = layer;
         this.world = world;
 
-        this._createCullShader();
+        // Pass 1 coarse cull / candidate compaction, shared across all this manager's lights. The
+        // candidate index list is borrowed from the manager-owned shared scratch (also used by the
+        // forward hybrid renderer); the count / prefix-sum / interval buffers stay per-instance.
+        this._compaction = new GSplatIntervalCompaction(device, scratch);
+
+        // the (pass 2) cull shader reads the work buffer (format-dependent), so it is built lazily
+        // once the work buffer + any user modify chunk are known (see _ensureCullShader). The args
+        // shader is format-independent and can be built up front.
         this._createArgsShader();
     }
 
@@ -188,8 +229,8 @@ class GSplatShadowRenderer {
         this.entries.forEach(entry => this._destroyEntry(entry));
         this.entries.clear();
 
-        this.intervalsBuffer?.destroy();
-        this.intervalsBuffer = null;
+        this._compaction?.destroy();
+        this._compaction = null;
 
         this._cullShader?.destroy();
         this._cullBindGroupFormat?.destroy();
@@ -199,32 +240,89 @@ class GSplatShadowRenderer {
         this._argsShader = null;
     }
 
-    /** @private */
-    _createCullShader() {
-        const device = this.device;
+    /**
+     * (Re)builds the shared cull shader when the work-buffer format or the user `gsplatModifyVS`
+     * chunk changes, bumping {@link _cullShaderGen} so per-light Computes are recreated. Must run
+     * after {@link _syncUserModify} (which refreshes the tracked modify chunk) and once the work
+     * buffer is ready.
+     *
+     * @private
+     */
+    _ensureCullShader() {
+        const wbFormat = this.world.workBuffer.format;
+        const version = wbFormat.extraStreamsVersion;
+        if (!this._cullShader || version !== this._cullFormatVersion || this._userChunksKey !== this._cullBuiltChunksKey) {
+            this._cullFormatVersion = version;
+            this._cullBuiltChunksKey = this._userChunksKey;
+            this._buildCullShader();
+        }
+    }
 
-        this._cullBindGroupFormat = new BindGroupFormat(device, [
+    /**
+     * Builds the pass-2 fine-cull shader + bind group format against the current work-buffer format
+     * and the tracked user modify chunk. The fixed bindings (0..4) are followed by the work-buffer
+     * format texture bindings; the shader reads each candidate splat (center/opacity/rotation/scale),
+     * applies the render-stage modifier, and runs the opacity/size/frustum fine tests.
+     *
+     * @private
+     */
+    _buildCullShader() {
+        const device = this.device;
+        const wbFormat = this.world.workBuffer.format;
+
+        // fixed bindings 0..4; work-buffer format texture bindings follow at 5+ (matches the
+        // @binding indices generated by getComputeInputDeclarations(fixedBindings.length)).
+        const fixedBindings = [
             new BindUniformBufferFormat('uniforms', SHADERSTAGE_COMPUTE),
-            new BindStorageBufferFormat('intervals', SHADERSTAGE_COMPUTE, true),
+            // pass-1 outputs (read): the shared candidate list + its count at [numIntervals]
+            new BindStorageBufferFormat('compactedSplatIds', SHADERSTAGE_COMPUTE, true),
+            new BindStorageBufferFormat('candidateCountBuffer', SHADERSTAGE_COMPUTE, true),
+            // per-light outputs (read/write): the final visible list + atomic count
             new BindStorageBufferFormat('outputIndices', SHADERSTAGE_COMPUTE, false),
-            new BindStorageBufferFormat('globalCount', SHADERSTAGE_COMPUTE, false),
-            new BindStorageBufferFormat('boundsBuffer', SHADERSTAGE_COMPUTE, true),
-            new BindStorageBufferFormat('transformsBuffer', SHADERSTAGE_COMPUTE, true)
+            new BindStorageBufferFormat('globalCount', SHADERSTAGE_COMPUTE, false)
+        ];
+
+        this._cullBindGroupFormat?.destroy();
+        this._cullBindGroupFormat = new BindGroupFormat(device, [
+            ...fixedBindings,
+            ...wbFormat.getComputeBindFormats()
         ]);
 
         const uniformBufferFormat = new UniformBufferFormat(device, [
             new UniformFormat('frustumPlanes', UNIFORMTYPE_VEC4, 6),
-            new UniformFormat('numIntervals', UNIFORMTYPE_UINT)
+            new UniformFormat('numIntervals', UNIFORMTYPE_UINT),
+            new UniformFormat('splatTextureSize', UNIFORMTYPE_UINT),
+            new UniformFormat('alphaClip', UNIFORMTYPE_FLOAT),
+            new UniformFormat('worldSizeThreshold', UNIFORMTYPE_FLOAT)
         ]);
 
+        const cincludes = new Map();
+        cincludes.set('gsplatComputeSplatCS', computeSplatSource);
+        cincludes.set('gsplatFormatDeclCS', wbFormat.getComputeInputDeclarations(fixedBindings.length));
+        cincludes.set('gsplatFormatReadCS', wbFormat.getReadCode());
+        cincludes.set('gsplatHelpersVS', gsplatHelpersSource);
+        // the user's render-stage modify chunk (or the default no-op), so the cull keeps exactly the
+        // splats the shadow draw renders. Shadow path is WebGPU-only, so only the WGSL variant is used.
+        cincludes.set('gsplatModifyVS', this._userModifyWgsl ?? gsplatModifyDefaultSource);
+
+        const cdefines = new Map([['{WORKGROUP_SIZE}', WORKGROUP_SIZE.toString()]]);
+        const colorStream = wbFormat.getStream('dataColor');
+        if (colorStream && colorStream.format !== PIXELFORMAT_RGBA16U) {
+            cdefines.set('GSPLAT_COLOR_FLOAT', '');
+        }
+
+        this._cullShader?.destroy();
         this._cullShader = new Shader(device, {
             name: 'GSplatShadowCull',
             shaderLanguage: SHADERLANGUAGE_WGSL,
             cshader: computeGsplatShadowCullSource,
-            cdefines: new Map([['{WORKGROUP_SIZE}', WORKGROUP_SIZE.toString()]]),
+            cincludes: cincludes,
+            cdefines: cdefines,
             computeBindGroupFormat: this._cullBindGroupFormat,
             computeUniformBufferFormats: { uniforms: uniformBufferFormat }
         });
+
+        this._cullShaderGen++;
     }
 
     /** @private */
@@ -262,7 +360,10 @@ class GSplatShadowRenderer {
      */
     setDataSource(workBuffer) {
         // Force a re-upload of intervals; offsets/bounds indices may have shifted.
-        this._uploadedVersion = -1;
+        this._compaction?.invalidateUpload();
+        // Force a cull-shader rebuild against the new work-buffer format (a swapped format object
+        // can reset its version, so don't rely on extraStreamsVersion alone).
+        this._cullFormatVersion = -1;
         this.entries.forEach((entry) => {
             this._configureMaterialWorkBuffer(entry.material);
             entry.material.update();
@@ -326,9 +427,10 @@ class GSplatShadowRenderer {
     }
 
     /**
-     * Post-cull pass: for each light entry run the coarse node-frustum cull + expand and the
-     * indirect-args write, then bind the results to the entry's mesh instance. Runs after
-     * `cullComposition` and before the frame graph renders the shadow maps.
+     * Post-cull pass: for each light entry run the two-pass cull (coarse candidate compaction with
+     * the light frustum, then a flat per-splat fine cull) and the indirect-args write, then bind the
+     * results to the entry's mesh instance. Runs after `cullComposition` and before the frame graph
+     * renders the shadow maps.
      *
      * @param {GSplatParams} gsplatParams - Scene gsplat params (alphaClip etc.).
      */
@@ -343,7 +445,8 @@ class GSplatShadowRenderer {
             return;
         }
 
-        this._ensureIntervals(worldState);
+        // upload interval metadata to the pass-1 compaction (cached per world-state version)
+        this._compaction.uploadIntervals(worldState);
 
         // Refresh the per-node world transforms the coarse cull reads. The forward renderer also
         // does this each frame, but a shadow-only manager has no forward pass — so we keep them
@@ -354,6 +457,10 @@ class GSplatShadowRenderer {
         // per-light shadow materials, so cast shadows follow the same per-vertex animation as the
         // forward pass (the shadow draw uses the same quad VS).
         this._syncUserModify(gsplatParams);
+
+        // (re)build the cull shader if the work-buffer format or the user modify chunk changed, so
+        // the cull reads the current format and culls on the same modified positions as the draw.
+        this._ensureCullShader();
 
         const numIntervals = worldState.totalIntervals;
         const totalActiveSplats = worldState.totalActiveSplats;
@@ -427,16 +534,32 @@ class GSplatShadowRenderer {
     _cullEntry(entry, numIntervals, totalActiveSplats, textureSize, gsplatParams) {
         const device = this.device;
 
-        // resolve the light's shadow-camera frustum (fitted during cullComposition) and the shared
-        // camera-independent cull bounds (populated by the forward renderer's frustum culler).
+        // resolve the light's shadow camera (fitted during cullComposition) and the shared camera-
+        // independent cull bounds (populated by the forward renderer's frustum culler).
         const sceneCamera = this.cameraNode.camera?.camera;
-        const frustum = sceneCamera && entry.light.getRenderData(sceneCamera, 0).shadowCamera?.frustum;
+        const shadowCamera = sceneCamera && entry.light.getRenderData(sceneCamera, 0).shadowCamera;
+        const frustum = shadowCamera && shadowCamera.frustum;
         const frustumCuller = this.world.workBuffer.frustumCuller;
         if (!frustum || !frustumCuller?.boundsBuffer || !frustumCuller?.transformsBuffer) {
             entry.meshInstance.visible = false;
             return;
         }
         this._fillFrustumPlanes(frustum);
+
+        // World-space size threshold for the minPixelSize fine cull. The directional shadow camera
+        // is orthographic, so the projected pixel size is linear in world size: focal = resolution /
+        // orthoHeight (the forward projector's focal = viewportWidth * projMat00, and ortho projMat00
+        // = 1 / orthoHeight). The forward gate is max(radiusX, radiusY) < minPixelSize with the
+        // radius ~ sqrt(2) * focal * extent plus a 0.3 px² variance floor; inverting that to a single
+        // world extent gives sqrt(max(0, minPixelSize²/2 - 0.3)) / focal. The shader compares this to
+        // the max scale axis, an upper bound on the projected extent, so the cull stays conservative
+        // (never drops a splat the forward path keeps). A threshold of 0 disables the size test.
+        const orthoHeight = shadowCamera.orthoHeight;
+        const shadowRes = entry.light._shadowResolution;
+        const minPixelSize = gsplatParams.minPixelSize;
+        const focal = (orthoHeight > 0 && shadowRes > 0) ? shadowRes / orthoHeight : 0;
+        const t2 = minPixelSize * minPixelSize * 0.5 - 0.3;
+        const worldSizeThreshold = (focal > 0 && t2 > 0) ? Math.sqrt(t2) / focal : 0;
 
         // grow the visible-index buffer to hold all active splats (worst case: nothing culled)
         if (totalActiveSplats > entry.allocatedIndexCount) {
@@ -446,20 +569,70 @@ class GSplatShadowRenderer {
             DebugHelper.setName(entry.indexBuffer, 'GSplatShadow.indices');
         }
 
-        // reset the atomic visible counter, then run the cull (coarse node-frustum reject + expand)
+        // PASS 1 (coarse): run the interval compaction with this light's frustum to produce a dense
+        // candidate list of work-buffer indices (splats in nodes intersecting the light frustum) +
+        // the candidate count at countBuffer[numIntervals]. The candidate buffer is shared across all
+        // lights — lights are culled sequentially, so this light's pass 2 consumes it before the next
+        // light's pass 1 overwrites it (compute passes are ordered). bounds/transforms are the shared
+        // camera-independent buffers; only the planes are per-light, passed via a lightweight culler
+        // view so the forward culler's own planes are never mutated.
+        const compaction = this._compaction;
+        compaction.dispatchCompact({
+            boundsBuffer: frustumCuller.boundsBuffer,
+            transformsBuffer: frustumCuller.transformsBuffer,
+            frustumPlanes: this._frustumPlanes
+        }, numIntervals, totalActiveSplats, false);
+
+        // PASS 2 (fine): flat one-thread-per-candidate cull over the candidate list — read + apply the
+        // vertex modify + opacity/size/frustum tests — compacting survivors into this light's final
+        // index buffer + count. Reset the final atomic counter first.
         entry.countBuffer.clear();
 
+        // (re)create the per-entry cull Compute against the current cull-shader generation (the cull
+        // shader is built lazily and rebuilt on work-buffer-format / modify-chunk changes).
+        if (!entry.cullCompute || entry.cullComputeGen !== this._cullShaderGen) {
+            entry.cullCompute?.destroy();
+            entry.cullCompute = new Compute(device, this._cullShader, 'GSplatShadowCull');
+            entry.cullComputeGen = this._cullShaderGen;
+        }
         const cull = entry.cullCompute;
-        cull.setParameter('intervals', this.intervalsBuffer);
+
+        // forward the user render-stage material parameters (e.g. uTime, referenced by the modify
+        // chunk and reflected into the compute's auto-generated bind group) BEFORE the cull's own
+        // bindings, so the cull's bindings win on any name collision (matches the forward projector).
+        const userMat = gsplatParams.material;
+        if (userMat) {
+            const srcParams = userMat.parameters;
+            for (const name in srcParams) {
+                if (srcParams.hasOwnProperty(name)) {
+                    cull.setParameter(name, srcParams[name].data);
+                }
+            }
+        }
+
+        cull.setParameter('compactedSplatIds', compaction.compactedSplatIds);
+        cull.setParameter('candidateCountBuffer', compaction.countBuffer);
         cull.setParameter('outputIndices', entry.indexBuffer);
         cull.setParameter('globalCount', entry.countBuffer);
-        cull.setParameter('boundsBuffer', frustumCuller.boundsBuffer);
-        cull.setParameter('transformsBuffer', frustumCuller.transformsBuffer);
         cull.setParameter('frustumPlanes[0]', this._frustumPlanes);
         cull.setParameter('numIntervals', numIntervals);
+        cull.setParameter('splatTextureSize', textureSize);
+        cull.setParameter('alphaClip', gsplatParams.alphaClip);
+        cull.setParameter('worldSizeThreshold', worldSizeThreshold);
 
-        // one workgroup per interval, tiled across X/Y when over the per-dimension limit
-        Compute.calcDispatchSize(numIntervals, this._cullDispatchSize, device.limits.maxComputeWorkgroupsPerDimension || 65535);
+        // bind the work-buffer textures the fine cull reads (same set the forward projector binds)
+        const workBuffer = this.world.workBuffer;
+        for (const stream of workBuffer.format.resourceStreams) {
+            const texture = workBuffer.getTexture(stream.name);
+            if (texture) {
+                cull.setParameter(stream.name, texture);
+            }
+        }
+
+        // flat dispatch over the work-buffer capacity (a CPU-known upper bound); threads beyond the
+        // candidate count early-out in the shader. Tiled across X/Y over the per-dimension limit.
+        const workgroupCount = Math.ceil(totalActiveSplats / WORKGROUP_SIZE);
+        Compute.calcDispatchSize(workgroupCount, this._cullDispatchSize, device.limits.maxComputeWorkgroupsPerDimension || 65535);
         cull.setupDispatch(this._cullDispatchSize.x, this._cullDispatchSize.y, 1);
         device.computeDispatch([cull], 'GSplatShadowCull');
 
@@ -487,30 +660,6 @@ class GSplatShadowRenderer {
         if (entry.meshInstance.instancingCount <= 0) {
             entry.meshInstance.instancingCount = 1;
         }
-    }
-
-    /**
-     * Uploads interval metadata for the world state (cached per version).
-     *
-     * @param {import('./gsplat-world-state.js').GSplatWorldState} worldState - The world state.
-     * @private
-     */
-    _ensureIntervals(worldState) {
-        if (worldState.version === this._uploadedVersion) return;
-        this._uploadedVersion = worldState.version;
-
-        const numIntervals = worldState.totalIntervals;
-        if (numIntervals === 0) return;
-
-        if (numIntervals > this.allocatedIntervalCount) {
-            this.intervalsBuffer?.destroy();
-            this.allocatedIntervalCount = numIntervals;
-            this.intervalsBuffer = new StorageBuffer(this.device, numIntervals * INTERVAL_STRIDE * 4, BUFFERUSAGE_COPY_DST);
-            DebugHelper.setName(this.intervalsBuffer, 'GSplatShadow.intervals');
-        }
-
-        const data = buildGSplatIntervalData(worldState);
-        this.intervalsBuffer.write(0, data, 0, numIntervals * INTERVAL_STRIDE);
     }
 
     /**
@@ -552,7 +701,8 @@ class GSplatShadowRenderer {
 
         // Per-entry Compute instances (own uniform buffers + bind groups) sharing the renderer's
         // shaders, so per-light dispatches don't alias each other's uniforms (see field comment).
-        const cullCompute = new Compute(device, this._cullShader, 'GSplatShadowCull');
+        // The cull Compute is created lazily in _cullEntry: the cull shader is built lazily (it is
+        // work-buffer-format dependent) and recreated on rebuild, tracked via cullComputeGen.
         const argsCompute = new Compute(device, this._argsShader, 'GSplatShadowIndirectArgs');
 
         const entry = {
@@ -562,7 +712,8 @@ class GSplatShadowRenderer {
             indexBuffer: null,
             allocatedIndexCount: 0,
             countBuffer,
-            cullCompute,
+            cullCompute: null,
+            cullComputeGen: -1,
             argsCompute
         };
 
@@ -584,7 +735,7 @@ class GSplatShadowRenderer {
         entry.material.destroy();
         entry.indexBuffer?.destroy();
         entry.countBuffer.destroy();
-        entry.cullCompute.destroy();
+        entry.cullCompute?.destroy();
         entry.argsCompute.destroy();
     }
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-shadow-cull.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/compute-gsplat-shadow-cull.js
@@ -1,109 +1,140 @@
-// Directional-shadow cull + compaction for the GPU-sort (hybrid) gsplat path.
+// Directional-shadow fine cull — pass 2 of the GPU-sort (hybrid) shadow path.
 //
-// Dispatched with one workgroup per interval (tiled across X/Y when the interval count exceeds the
-// per-dimension workgroup limit). Each workgroup processes one interval's splats and appends the
-// visible ones to a single output index buffer, reserving space with a workgroup-aggregated atomic
-// (one atomicAdd per workgroup, not one per visible splat — mobile-friendly, no subgroups).
+// Pass 1 (GSplatIntervalCompaction, run with the light's frustum) produces a dense candidate list
+// `compactedSplatIds[0..candidateCount)` of work-buffer splat indices that survived the coarse
+// per-node frustum cull, with `candidateCount = candidateCountBuffer[numIntervals]` (the interval
+// prefix-sum total). This pass runs flat — one thread per candidate — so occupancy is independent of
+// how the scene is split into intervals (a single 2M-splat AABB and a 10M/5K-node octree both
+// saturate the GPU equally).
 //
-// Cull stage: coarse per-interval reject — the octree node's world-space bounding sphere is tested
-// against the light's 6 frustum planes (same math as compute-gsplat-interval-cull.js); rejected
-// intervals are skipped entirely by the whole workgroup. Surviving intervals expand all their
-// splats. (The per-splat fine tests — opacity/projected-size/offscreen — are intentionally not done
-// here: they need projector-grade per-splat projection + work-buffer-format coupling, and shadow
-// correctness is already enforced by the shadow VS/FS alphaClip + clip. They can be layered in later
-// as a per-thread visible flag + workgroup prefix-sum before the atomic reservation.)
+// Each thread reads its candidate splat, applies the render-stage vertex modifier (matching the quad
+// VS the shadow draw uses), then runs three projection-free fine tests:
+//   - opacity <= alphaClip                            (matches the forward alpha cull + shadow PS)
+//   - max world-space scale axis < worldSizeThreshold (sub-pixel in the shadow map; the directional
+//     shadow camera is orthographic so projected size is linear in world size, and the threshold is
+//     precomputed CPU-side from orthoHeight + shadow-map resolution — no projection needed here)
+//   - modified center (± a conservative gaussian radius) outside any of the 6 frustum planes
+//     (per-splat frustum cull within boundary nodes; the ortho near/far planes also cull by depth)
 //
-// The output order is unspecified (it depends on the inter-workgroup atomic race), which is fine for
-// shadows: only depth is written, so draw order does not matter.
+// Survivors are compacted into the per-light output index buffer using the projector's workgroup-
+// aggregated atomic pattern (one global atomicAdd per workgroup, no subgroups). Output order is
+// unspecified — fine for shadows, which only write depth.
 
 export const computeGsplatShadowCullSource = /* wgsl */`
 
-struct Interval {
-    workBufferBase: u32,
-    splatCount: u32,
-    boundsIndex: u32,
-    pad: u32
-};
-
-struct BoundsEntry {
-    centerX: f32,
-    centerY: f32,
-    centerZ: f32,
-    radius: f32,
-    transformIndex: u32,
-    pad0: u32,
-    pad1: u32,
-    pad2: u32
-};
+// Conservative gaussian extent (in std-devs) for the per-splat frustum radius, so a splat whose
+// tail still reaches into the light frustum is not culled at the boundary.
+const SPLAT_FRUSTUM_SIGMA: f32 = 3.0;
 
 struct CullUniforms {
     frustumPlanes: array<vec4f, 6>,
-    numIntervals: u32
+    numIntervals: u32,
+    splatTextureSize: u32,
+    alphaClip: f32,
+    worldSizeThreshold: f32
 };
 @group(0) @binding(0) var<uniform> uniforms: CullUniforms;
 
-@group(0) @binding(1) var<storage, read> intervals: array<Interval>;
+// Pass-1 outputs (read): the shared candidate list + the candidate count at [numIntervals].
+@group(0) @binding(1) var<storage, read> compactedSplatIds: array<u32>;
+@group(0) @binding(2) var<storage, read> candidateCountBuffer: array<u32>;
 
-// Output: dense list of visible work-buffer splat indices (unordered).
-@group(0) @binding(2) var<storage, read_write> outputIndices: array<u32>;
+// Per-light outputs: dense visible work-buffer indices (unordered) + a single atomic visible count.
+@group(0) @binding(3) var<storage, read_write> outputIndices: array<u32>;
+@group(0) @binding(4) var<storage, read_write> globalCount: array<atomic<u32>>;
 
-// Single global atomic visible counter. Must be cleared to 0 before each dispatch.
-@group(0) @binding(3) var<storage, read_write> globalCount: array<atomic<u32>>;
+// Work-buffer format texture bindings (binding 5+) and the splat read/modify helpers. setSplat
+// (gsplatComputeSplatCS) reads uniforms.splatTextureSize, so the uniform struct is declared above.
+#include "gsplatComputeSplatCS"
+#include "gsplatFormatDeclCS"
+#include "gsplatFormatReadCS"
+#include "gsplatHelpersVS"
+#include "gsplatModifyVS"
 
-// Per-node bounding spheres + their transforms (camera-independent; shared with the forward cull).
-@group(0) @binding(4) var<storage, read> boundsBuffer: array<BoundsEntry>;
-@group(0) @binding(5) var<storage, read> transformsBuffer: array<vec4f>;
+// Fine per-splat cull: read + apply the render-stage modifier + opacity/size/frustum tests. Returns
+// true when the splat should be drawn into the shadow map.
+fn fineCull(splatId: u32) -> bool {
+    setSplat(splatId);
 
-// Base output offset reserved by this workgroup, broadcast from thread 0 to the rest.
+    // world-space center + render-stage position modifier (matches the quad VS / forward projector)
+    let originalCenter = getCenter();
+    var center = originalCenter;
+    modifySplatCenter(&center);
+
+    // opacity cull (matches the forward alpha cull + the shadow PS alphaClip)
+    let opacity = getOpacity();
+    if (opacity <= uniforms.alphaClip) {
+        return false;
+    }
+
+    // render-stage rotation/scale modifier; getRotation() is (w,x,y,z), the hook contract is (x,y,z,w)
+    var rotation: vec4f = getRotation().yzwx;
+    var scale: vec3f = getScale();
+    modifySplatRotationScale(originalCenter, center, &rotation, &scale);
+
+    // size cull: the orthographic shadow projection is linear, so a splat whose max world-space
+    // extent maps below the precomputed per-light threshold is sub-pixel in the shadow map. The max
+    // scale axis is an orientation-independent upper bound on the projected radius (conservative —
+    // never culls a splat the forward path would keep). A threshold of 0 disables the test.
+    let maxScale = max(scale.x, max(scale.y, scale.z));
+    if (maxScale < uniforms.worldSizeThreshold) {
+        return false;
+    }
+
+    // per-splat frustum cull: the modified center (± a conservative gaussian radius) against the
+    // light's 6 frustum planes. Trims splats in boundary nodes; the ortho near/far planes also cull
+    // by depth.
+    let splatRadius = maxScale * SPLAT_FRUSTUM_SIGMA;
+    for (var p = 0; p < 6; p++) {
+        let plane = uniforms.frustumPlanes[p];
+        if (dot(plane.xyz, center) + plane.w <= -splatRadius) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// One global atomicAdd per workgroup; intra-workgroup slots via a workgroup atomic (no subgroups).
+var<workgroup> wgCount: atomic<u32>;
 var<workgroup> wgBase: u32;
 
 @compute @workgroup_size({WORKGROUP_SIZE})
 fn main(
-    @builtin(workgroup_id) wgId: vec3u,
+    @builtin(global_invocation_id) gid: vec3u,
     @builtin(num_workgroups) numWorkgroups: vec3u,
-    @builtin(local_invocation_id) lid: vec3u
+    @builtin(local_invocation_index) localIdx: u32
 ) {
-    // reconstruct the linear interval index from the (possibly Y-tiled) 2D dispatch
-    let intervalIdx = wgId.y * numWorkgroups.x + wgId.x;
-    if (intervalIdx >= uniforms.numIntervals) { return; }
-
-    let interval = intervals[intervalIdx];
-    let count = interval.splatCount;
-    if (count == 0u) { return; }
-
-    // Coarse cull: transform the node's bounding sphere to world space and test it against the
-    // light's frustum planes. The result is uniform across the workgroup (same interval), so the
-    // early-out keeps control flow uniform for the workgroupBarrier below.
-    let entry = boundsBuffer[interval.boundsIndex];
-    let localCenter = vec3f(entry.centerX, entry.centerY, entry.centerZ);
-    let base3 = entry.transformIndex * 3u;
-    let row0 = transformsBuffer[base3];
-    let row1 = transformsBuffer[base3 + 1u];
-    let row2 = transformsBuffer[base3 + 2u];
-    let worldCenter = vec3f(
-        dot(vec4f(localCenter, 1.0), row0),
-        dot(vec4f(localCenter, 1.0), row1),
-        dot(vec4f(localCenter, 1.0), row2)
-    );
-    let worldRadius = entry.radius * length(vec3f(row0.x, row1.x, row2.x));
-
-    for (var p = 0; p < 6; p++) {
-        let plane = uniforms.frustumPlanes[p];
-        if (dot(plane.xyz, worldCenter) + plane.w <= -worldRadius) {
-            return; // node fully outside this plane -> whole interval culled
-        }
-    }
-
-    // Reserve a contiguous block for this (visible) interval's splats with a single atomic add.
-    if (lid.x == 0u) {
-        wgBase = atomicAdd(&globalCount[0], count);
+    if (localIdx == 0u) {
+        atomicStore(&wgCount, 0u);
     }
     workgroupBarrier();
-    let base = wgBase;
 
-    let workBufferBase = interval.workBufferBase;
-    for (var j = lid.x; j < count; j += {WORKGROUP_SIZE}u) {
-        outputIndices[base + j] = workBufferBase + j;
+    // flat thread index from the (possibly Y-tiled) 2D dispatch grid
+    let threadIdx = gid.y * (numWorkgroups.x * {WORKGROUP_SIZE}u) + gid.x;
+    let candidateCount = candidateCountBuffer[uniforms.numIntervals];
+
+    var valid = false;
+    var splatId = 0u;
+    if (threadIdx < candidateCount) {
+        splatId = compactedSplatIds[threadIdx];
+        valid = fineCull(splatId);
+    }
+
+    var localSlot = 0u;
+    if (valid) {
+        localSlot = atomicAdd(&wgCount, 1u);
+    }
+    workgroupBarrier();
+
+    // workgroup leader reserves a contiguous global block for this workgroup's survivors
+    if (localIdx == 0u) {
+        wgBase = atomicAdd(&globalCount[0], atomicLoad(&wgCount));
+    }
+    workgroupBarrier();
+
+    if (valid) {
+        outputIndices[wgBase + localSlot] = splatId;
     }
 }
 `;


### PR DESCRIPTION
Adds per-splat culling (opacity, size, frustum) to the GPU-sort (hybrid) directional-shadow path, while sharing its candidate buffer with the forward renderer to save GPU memory.

**Changes:**
- The hybrid directional-shadow cull now runs as a projector-style two pass: a coarse per-node frustum compaction (reusing `GSplatIntervalCompaction` with the light's frustum) produces a dense candidate list, then a flat one-thread-per-candidate pass applies the per-splat fine tests — opacity (`alphaClip`), world-space size (a CPU-precomputed orthographic threshold; no per-splat projection), and the 6 light frustum planes — and compacts the survivors. This replaces the previous coarse-only cull and applies the same `gsplatModifyVS` vertex-modify as the draw, so cast shadows still match the forward pass.
- The flat fine-cull dispatch keeps full GPU occupancy regardless of how a scene is split into intervals (a single large object vs many octree nodes), fixing a pathological case where few/large intervals serialized the cull onto a handful of workgroups.
- The compaction candidate buffer is now shared, per manager, between the forward hybrid renderer and the shadow cull (new internal `GSplatHybridRendererScratch`, manager-owned, created only while a GPU-sort renderer is in use). They use it at disjoint points in the frame, so one allocation suffices.
