### PR TITLE
chore(gsplat): remove compute-renderer leftovers

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.jsx
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.jsx
@@ -44,14 +44,6 @@ export function Controls({ observer }) {
                         ]}
                     />
                 </LabelGroup>
-                <LabelGroup text='Occluder'>
-                    <BooleanInput
-                        type='toggle'
-                        binding={new BindingTwoWay()}
-                        link={{ observer, path: 'occluder' }}
-                        value={observer.get('occluder') || false}
-                    />
-                </LabelGroup>
                 <LabelGroup text='Environment'>
                     <SelectInput
                         type='string'

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -256,35 +256,9 @@ assetListLoader.load(async () => {
         focusPoint: focusPoint
     });
 
-    // Orange occluder cube (hidden by default, toggled via UI)
-    const cube = new pc.Entity('orange-cube');
-    cube.addComponent('render', { type: 'box' });
-    const orangeMat = new pc.StandardMaterial();
-    orangeMat.diffuse = new pc.Color(0, 0, 0);
-    orangeMat.emissive = new pc.Color(1, 0.5, 0);
-    orangeMat.update();
-    cube.render.meshInstances[0].material = orangeMat;
-    cube.setLocalPosition(6, 1, -2);
-    cube.setLocalScale(2, 2, 2);
-    cube.enabled = false;
-    app.root.addChild(cube);
     // CameraFrame for HDR linear rendering (created lazily on first enable)
     /** @type {pc.CameraFrame|null} */
     let cameraFrame = null;
-
-    // Enable depth prepass so the compute splat rasterizer can depth-test
-    // against scene geometry (e.g. the occluder cube).
-    const applyOccluder = () => {
-        const enabled = !!data.get('occluder');
-        cube.enabled = enabled;
-        if (cameraFrame) {
-            cameraFrame.rendering.sceneDepthMap = enabled;
-            cameraFrame.update();
-        }
-    };
-
-    data.set('occluder', false);
-    data.on('occluder:set', applyOccluder);
 
     const applyToneMapping = () => {
         const tm = data.get('toneMapping');
@@ -302,7 +276,6 @@ assetListLoader.load(async () => {
             if (!cameraFrame) {
                 cameraFrame = new pc.CameraFrame(app, camera.camera);
                 cameraFrame.rendering.toneMapping = data.get('toneMapping');
-                applyOccluder();
             }
             cameraFrame.enabled = true;
             cameraFrame.update();

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -1,6 +1,4 @@
 import { Debug } from '../../core/debug.js';
-import gsplatOutputVS from '../shader-lib/wgsl/chunks/gsplat/vert/gsplatOutput.js';
-import { shaderChunksWGSL } from '../shader-lib/wgsl/collections/shader-chunks-wgsl.js';
 import { FisheyeProjection } from '../graphics/fisheye-projection.js';
 
 /**
@@ -42,7 +40,7 @@ import { FisheyeProjection } from '../graphics/fisheye-projection.js';
 
 /**
  * Base class for splat renderers. Holds common state shared by all renderer
- * implementations (instanced-quad, compute-based, etc.). Derived classes
+ * implementations (instanced-quad, hybrid GPU-sort, etc.). Derived classes
  * implement the actual rendering strategy.
  *
  * @ignore
@@ -168,8 +166,9 @@ class GSplatRenderer {
 
     /**
      * Sets the data source providing format and texture access. The base implementation updates
-     * the workBuffer and notifies derived classes of the format change. Derived classes (e.g.
-     * the compute renderer) may override this to decouple from the work buffer entirely.
+     * the workBuffer and notifies derived classes of the format change. Derived classes may
+     * override this to react to the source change (e.g. re-pointing materials at the new
+     * work-buffer textures).
      *
      * The source object must provide:
      * - `format` — a {@link GSplatFormat} describing the texture streams and shader read code.
@@ -271,25 +270,6 @@ class GSplatRenderer {
      */
     preparePickingView(world, worldState, pickParams) {
         return null;
-    }
-
-    /**
-     * Populates a cincludes map with tonemapping, gamma, decode and gsplatOutput
-     * shader chunks needed by compute tile-count shaders.
-     *
-     * @param {Map<string, string>} cincludes - The shader includes map to populate.
-     * @protected
-     */
-    _createTonemapIncludes(cincludes) {
-        cincludes.set('gsplatOutputVS', gsplatOutputVS);
-        const chunkNames = [
-            'tonemappingPS', 'tonemappingNonePS', 'tonemappingLinearPS', 'tonemappingFilmicPS',
-            'tonemappingHejlPS', 'tonemappingAcesPS', 'tonemappingAces2PS', 'tonemappingNeutralPS',
-            'decodePS', 'gammaPS'
-        ];
-        for (const name of chunkNames) {
-            cincludes.set(name, shaderChunksWGSL[name]);
-        }
     }
 }
 


### PR DESCRIPTION
Cleans up two pieces of dead code left behind by the compute-renderer removal (#8921).

**Changes:**
- Remove the unused `_createTonemapIncludes` helper and its two now-orphaned shader-chunk imports from `GSplatRenderer` (internal, `@ignore`).
- Refresh two stale comments in `gsplat-renderer.js` that still referenced the compute renderer (class header + `setDataSource` JSDoc).
- Remove the "Occluder" toggle from the `lod-streaming` example (control, orange cube, and observer wiring). It only enabled `sceneDepthMap` for the compute splat rasterizer's manual depth test; nothing in the raster path reads it, so it was dead demo UI.

**Examples:**
- `gaussian-splatting/lod-streaming` — "Occluder" toggle removed.