### PR TITLE
feat(xr): backend-aware WebXR support detection (isDeviceSupported)

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -17,6 +17,7 @@ import { XrAnchors } from './xr-anchors.js';
 import { XrMeshDetection } from './xr-mesh-detection.js';
 import { XrViews } from './xr-views.js';
 import { XrBridge } from '../../platform/graphics/xr-bridge.js';
+import { DEVICETYPE_WEBGPU } from '../../platform/graphics/constants.js';
 
 /**
  * @import { AppBase } from '../app-base.js'
@@ -322,6 +323,55 @@ class XrManager extends EventHandler {
             });
             this._deviceAvailabilityCheck();
         }
+    }
+
+    /**
+     * Tests whether an immersive WebXR session of the given type can run on the specified graphics
+     * backend. Unlike {@link XrManager#isAvailable}, this is a static method that can be called
+     * before a graphics device (or the {@link AppBase}) is created, which makes it useful for
+     * deciding which device type to create for XR - for example WebGPU vs WebGL2.
+     *
+     * This is a best-effort preflight check. The only authoritative test remains a successful
+     * {@link XrManager#start}, so a fallback path should always be kept.
+     *
+     * @param {string} deviceType - The graphics device type the session would run on. Can be
+     * {@link DEVICETYPE_WEBGPU} or {@link DEVICETYPE_WEBGL2}.
+     * @param {string} type - The session type. Can be:
+     *
+     * - {@link XRTYPE_VR}: Immersive VR session.
+     * - {@link XRTYPE_AR}: Immersive AR session.
+     *
+     * @returns {Promise<boolean>} Promise that resolves to true if a session of the given type is
+     * reported supported on the given backend, false otherwise.
+     * @example
+     * const supported = await pc.XrManager.isDeviceSupported(pc.DEVICETYPE_WEBGPU, pc.XRTYPE_VR);
+     * if (supported) {
+     *     // a WebGPU device can be created and used to offer VR
+     * }
+     */
+    static async isDeviceSupported(deviceType, type) {
+        if (!platform.browser || !navigator.xr || !XrManager._backendSupportsXr(deviceType)) {
+            return false;
+        }
+
+        try {
+            return await navigator.xr.isSessionSupported(type);
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Returns whether the given graphics backend meets the WebXR binding requirement. A WebGPU
+     * backend can only host an XR session when the browser exposes `XRGPUBinding`; a WebGL backend
+     * uses the classic `XRWebGLLayer` and needs no additional binding.
+     *
+     * @param {string} [deviceType] - The graphics device type, see DEVICETYPE_*.
+     * @returns {boolean} True if the backend can host a WebXR session.
+     * @private
+     */
+    static _backendSupportsXr(deviceType) {
+        return deviceType !== DEVICETYPE_WEBGPU || typeof globalThis.XRGPUBinding !== 'undefined';
     }
 
     /**
@@ -678,6 +728,13 @@ class XrManager extends EventHandler {
      */
     _sessionSupportCheck(type) {
         navigator.xr.isSessionSupported(type).then((available) => {
+            // A session reported as supported by the browser can still be unusable on the current
+            // graphics backend (a WebGPU device requires `XRGPUBinding`). Reflect that requirement
+            // so availability matches what can actually be started on this device.
+            if (available && !XrManager._backendSupportsXr(this.app?.graphicsDevice?.deviceType)) {
+                available = false;
+            }
+
             if (this._available[type] === available) {
                 return;
             }


### PR DESCRIPTION
Adds a way to detect whether a WebXR session can run on a given graphics backend, and makes the existing reactive XR availability backend-aware. This is needed because WebGPU WebXR is supported only on a subset of platforms, whereas WebGL WebXR has wider support — so the same headset can support a session under WebGL but not under WebGPU.

**Changes:**
- Add a static `XrManager.isDeviceSupported(deviceType, type)` reporting whether an immersive session of the given type can run on a given graphics backend. It can be called before a graphics device is created, so an app can decide which backend to request for XR.
- The reactive availability (`XrManager#isAvailable` and the `available` / `available:[type]` events) now accounts for the active graphics backend. Previously it reflected only what the browser/headset reported regardless of backend, so on a WebGPU device a session could be reported available when it could not actually start. WebGL behavior is unchanged.

**API Changes:**
- New: `XrManager.isDeviceSupported(deviceType: string, type: string): Promise<boolean>` (static).
- Behavior change (no signature change): `XrManager#isAvailable(type)` and the `available` / `available:[type]` events are now backend-aware. WebGL results are identical; WebGPU results are now accurate — a session is reported available only if it can actually run on the current device.