### PR TITLE
Fix camera.screenToWorld returning NaN when called in initialize

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -714,6 +714,12 @@ class GraphicsDevice extends EventHandler {
 
         this.textureBias = this.scope.resolve('textureBias');
         this.textureBias.setValue(0.0);
+
+        // initialize the client rect from the canvas, so that it is valid before the first frame
+        // update. This allows functions like CameraComponent#screenToWorld to work correctly when
+        // called from a script's initialize / postInitialize, which run before the first device
+        // update (see https://github.com/playcanvas/engine/issues/8932).
+        this.updateClientRect();
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -157,8 +157,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         super(canvas, options);
         options = this.initOptions;
 
-        this.updateClientRect();
-
         // initialize this before registering lost context handlers to avoid undefined access when the device is created lost.
         this.initTextureUnits();
 


### PR DESCRIPTION
Fixes #8932. `CameraComponent#screenToWorld` returned NaN when called from a script's `initialize`/`postInitialize` (or the app `initialize` event) on WebGPU, while working correctly on WebGL.

**Cause:**
`screenToWorld` divides by `device.clientRect.width/height`. `clientRect` initializes to `{0, 0}` and is only refreshed by `device.update()`, which runs in the frame loop *after* `app.start()` fires `initialize`/`postInitialize`. The WebGL device constructor happened to call `updateClientRect()`, so its rect was valid early; the WebGPU device constructor did not, leaving `clientRect` at `{0, 0}` until the first frame — causing a divide-by-zero and NaN results.

**Changes:**
- Move the `updateClientRect()` call into the base `GraphicsDevice` constructor so `clientRect` is valid before the first frame on all backends (WebGL, WebGPU, and any future ones).
- Remove the now-redundant call from the WebGL device constructor.