### PR TITLE
Support Draco mesh decoding in Node via worker_threads

### DIFF
--- a/src/framework/parsers/draco-decoder.js
+++ b/src/framework/parsers/draco-decoder.js
@@ -1,6 +1,7 @@
 import { WasmModule } from '../../core/wasm-module.js';
 import { DracoWorker } from './draco-worker.js';
 import { Debug } from '../../core/debug.js';
+import { platform } from '../../core/platform.js';
 import { http } from '../../platform/net/http.js';
 
 const downloadMaxRetries = 3;
@@ -28,8 +29,10 @@ class JobQueue {
     // initialize the queue with worker instances
     init(workers) {
         workers.forEach((worker) => {
-            worker.addEventListener('message', (message) => {
-                const data = message.data;
+            const messageHandler = (message) => {
+                // browser/web workers deliver a MessageEvent (data on `.data`); Node
+                // worker_threads `message` events deliver the posted value directly.
+                const data = message.data ?? message;
                 const callback = this.jobCallbacks.get(data.jobId);
                 if (callback) {
                     callback(data.error, {
@@ -60,7 +63,13 @@ class JobQueue {
                         }
                     }
                 }
-            });
+            };
+
+            if (platform.environment === 'node') {
+                worker.on('message', messageHandler);
+            } else {
+                worker.addEventListener('message', messageHandler);
+            }
         });
 
         // assign workers to the first queue
@@ -202,14 +211,17 @@ const initializeWorkers = (config) => {
             '/* worker */',
             `(\n${DracoWorker.toString()}\n)()\n\n`
         ].join('\n');
-        const blob = new Blob([code], { type: 'application/javascript' });
-        const workerUrl = URL.createObjectURL(blob);
         const numWorkers = Math.max(1, Math.min(16, config.numWorkers || defaultNumWorkers));
+
+        // Node uses worker_threads (no Blob/URL.createObjectURL), passing the worker source as
+        // an eval string; the browser builds a blob URL and spawns a web worker from it.
+        const isNode = platform.environment === 'node';
+        const workerUrl = isNode ? null : URL.createObjectURL(new Blob([code], { type: 'application/javascript' }));
 
         // create worker instances
         const workers = [];
         for (let i = 0; i < numWorkers; ++i) {
-            const worker = new Worker(workerUrl);
+            const worker = isNode ? new Worker(code, { eval: true }) : new Worker(workerUrl);
             worker.postMessage({
                 type: 'init',
                 module: dracoModule

--- a/src/framework/parsers/draco-worker.js
+++ b/src/framework/parsers/draco-worker.js
@@ -1,4 +1,7 @@
 function DracoWorker(jsUrl, wasmUrl) {
+    // In a browser/web worker this is `self`; in a Node worker_threads worker it's the parentPort.
+    const myself = (typeof self !== 'undefined' && self) || (require('node:worker_threads').parentPort);
+
     let draco;
 
     // https://github.com/google/draco/blob/master/src/draco/attributes/geometry_attribute.h#L43
@@ -263,7 +266,7 @@ function DracoWorker(jsUrl, wasmUrl) {
 
     const decode = (data) => {
         const result = decodeMesh(new Uint8Array(data.buffer));
-        self.postMessage({
+        myself.postMessage({
             jobId: data.jobId,
             error: result.error,
             indices: result.indices,
@@ -276,12 +279,18 @@ function DracoWorker(jsUrl, wasmUrl) {
     const workQueue = [];
 
     // handle incoming message
-    self.onmessage = (message) => {
+    myself.addEventListener('message', (message) => {
         const data = message.data;
         switch (data.type) {
-            case 'init':
+            case 'init': {
+                // The glue script concatenated ahead of this worker exposes the module factory
+                // differently per environment: as a global in a browser worker, and via
+                // `module.exports` (CommonJS) in a Node worker_threads worker.
+                const DracoDecoderModule = myself.DracoDecoderModule ||
+                    (typeof module !== 'undefined' && module.exports);
+
                 // initialize draco module
-                self.DracoDecoderModule({
+                DracoDecoderModule({
                     instantiateWasm: (imports, successCallback) => {
                         WebAssembly.instantiate(data.module, imports)
                         .then(result => successCallback(result))
@@ -294,6 +303,7 @@ function DracoWorker(jsUrl, wasmUrl) {
                     workQueue.forEach(data => decode(data));
                 });
                 break;
+            }
             case 'decodeMesh':
                 if (draco) {
                     decode(data);
@@ -302,7 +312,7 @@ function DracoWorker(jsUrl, wasmUrl) {
                 }
                 break;
         }
-    };
+    });
 }
 
 export {


### PR DESCRIPTION
Fixes #8524. Draco glb loading failed in Node: `initializeWorkers` in `draco-decoder.js` unconditionally used browser-only APIs (`Blob`, `URL.createObjectURL`, the web `Worker` constructor), and the worker body in `draco-worker.js` talked to `self` — none of which exist in a Node `worker_threads` worker.

This branches on `platform.environment === 'node'` to use `worker_threads`, mirroring the existing `gsplat-sorter` / `gsplat-sort-worker` pattern already in the engine.

**Changes:**
- `draco-worker.js`: resolve the worker scope as `const myself = (typeof self !== 'undefined' && self) || require('node:worker_threads').parentPort;` and use `myself.postMessage` / `myself.addEventListener('message', …)` instead of `self`. The decoder module factory is resolved as `myself.DracoDecoderModule || (typeof module !== 'undefined' && module.exports)` — the emscripten glue exposes it as a global in a browser worker but on `module.exports` (CommonJS) in a Node eval worker.
- `draco-decoder.js`: in Node, spawn `new Worker(code, { eval: true })` and listen with `worker.on('message', …)`; the browser keeps the blob-URL path. The message handler normalizes `message.data ?? message` (web `MessageEvent` vs Node raw payload).

**Notes:**
- As with the existing gsplat sorter, the Node main thread relies on a global `Worker` being available — consumers shim `globalThis.Worker = require('node:worker_threads').Worker`.
- Out of scope: `downloadScript` / `compileModule` still require http(s)-reachable URLs in Node (local file paths won't `fetch`).

Verified by decoding `examples/assets/models/heart_draco.glb` with the modified source in **both** environments (identical output — indices 1080, vertices 12960, stride 24, position + normal): in Node (`environment = node`) and in the browser (`environment = browser`).