### PR TITLE
Make app.assets available immediately after AppBase construction

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -411,7 +411,7 @@ class AppBase extends EventHandler {
      * // Search the asset registry for all assets with the tag 'vehicle'
      * const vehicleAssets = this.app.assets.findByTag('vehicle');
      */
-    assets;
+    assets = new AssetRegistry(this.loader);
 
     /**
      * The bundle registry managed by the application.
@@ -566,7 +566,6 @@ class AppBase extends EventHandler {
         this.scene = new Scene(graphicsDevice);
         this._registerSceneImmediate(this.scene);
 
-        this.assets = new AssetRegistry(this.loader);
         if (assetPrefix) this.assets.prefix = assetPrefix;
 
         this.bundles = new BundleRegistry(this.assets);


### PR DESCRIPTION
Fixes a discrepancy where `app.assets` was undefined when accessed before `AppBase#init()` — e.g. from a loading screen script (`pc.script.createLoadingScreen`) under WebGPU but not WebGL. Reported in the follow-up comment on #8932.

The app registers itself globally (via `setApplication`) in its constructor, but `app.assets` was only created in `init()`. WebGL's graphics device creation resolves synchronously (microtask), so `init()` runs before the loading screen script executes; WebGPU's device creation is genuinely async, so the loading screen script runs first — in the window where `app.assets` did not yet exist.

**Changes:**
- Create the `AssetRegistry` as an `AppBase` class field (`assets = new AssetRegistry(this.loader)`) instead of in `init()`, so `app.assets` is available right after construction on all backends. `init()` continues to apply the asset prefix and build the bundle registry on the same instance (no re-creation, so any early listeners are preserved).

Note: this only makes the registry available earlier; resource handlers are still registered in `init()`, so attempting to actually load a device-dependent asset (e.g. a texture) before `init()` returns a graceful "No resource handler" error rather than a `TypeError`. Adding assets to the registry for later loading works as expected.