### PR TITLE
fix(examples): show resolved gsplat renderer in dropdown at startup

### DIFF
--- a/examples/src/examples/gaussian-splatting/first-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/first-person.example.mjs
@@ -95,13 +95,8 @@ await new Promise((resolve) => {
 
 app.start();
 
-// Initial control values
-data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
-data.set('splatBudget', 4);
-data.set('data.stats.gsplats', '—');
-data.set('data.stats.resolution', '—');
-
-// Renderer selection
+// Renderer selection. Register before setting the initial value, so the initial
+// AUTO selection is resolved to the concrete renderer and shown in the dropdown.
 data.on('renderer:set', () => {
     app.scene.gsplat.renderer = data.get('renderer');
     const current = app.scene.gsplat.currentRenderer;
@@ -109,6 +104,12 @@ data.on('renderer:set', () => {
         setTimeout(() => data.set('renderer', current), 0);
     }
 });
+
+// Initial control values
+data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
+data.set('splatBudget', 4);
+data.set('data.stats.gsplats', '—');
+data.set('data.stats.resolution', '—');
 
 // Splat budget (in millions)
 const applySplatBudget = () => {

--- a/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lut-grading.example.mjs
@@ -149,6 +149,16 @@ await new Promise((resolve) => {
 
 app.start();
 
+// Renderer selection. Register before setting the initial value, so the initial
+// AUTO selection is resolved to the concrete renderer and shown in the dropdown.
+data.on('renderer:set', () => {
+    app.scene.gsplat.renderer = data.get('renderer');
+    const current = app.scene.gsplat.currentRenderer;
+    if (current !== data.get('renderer')) {
+        setTimeout(() => data.set('renderer', current), 0);
+    }
+});
+
 // Initial control values
 data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
 data.set('splatBudget', 4);
@@ -160,15 +170,6 @@ data.set('lutBlend', 0.0);
 data.set('lutAnimate', true);
 data.set('data.stats.gsplats', '—');
 data.set('data.stats.resolution', '—');
-
-// Renderer selection
-data.on('renderer:set', () => {
-    app.scene.gsplat.renderer = data.get('renderer');
-    const current = app.scene.gsplat.currentRenderer;
-    if (current !== data.get('renderer')) {
-        setTimeout(() => data.set('renderer', current), 0);
-    }
-});
 
 // Splat budget (in millions)
 const applySplatBudget = () => {

--- a/examples/src/examples/gaussian-splatting/third-person.example.mjs
+++ b/examples/src/examples/gaussian-splatting/third-person.example.mjs
@@ -118,6 +118,16 @@ app.scene.envAtlas = assets.envAtlas.resource;
 app.scene.skyboxIntensity = 0.5;
 app.scene.layers.getLayerById(pc.LAYERID_SKYBOX).enabled = false;
 
+// Register the renderer handler before setting the initial value, so the initial
+// AUTO selection is resolved to the concrete renderer and shown in the dropdown.
+data.on('renderer:set', () => {
+    app.scene.gsplat.renderer = data.get('renderer');
+    const current = app.scene.gsplat.currentRenderer;
+    if (current !== data.get('renderer')) {
+        setTimeout(() => data.set('renderer', current), 0);
+    }
+});
+
 // Initial control values
 data.set('renderer', pc.GSPLAT_RENDERER_AUTO);
 data.set('splatBudget', 4);
@@ -127,14 +137,6 @@ data.set('cameraSmoothing', 0.0005);
 data.set('lookSens', 0.15);
 data.set('data.stats.gsplats', '—');
 data.set('data.stats.resolution', '—');
-
-data.on('renderer:set', () => {
-    app.scene.gsplat.renderer = data.get('renderer');
-    const current = app.scene.gsplat.currentRenderer;
-    if (current !== data.get('renderer')) {
-        setTimeout(() => data.set('renderer', current), 0);
-    }
-});
 
 const applySplatBudget = () => {
     const millions = data.get('splatBudget');


### PR DESCRIPTION
Three gaussian-splatting examples left the Renderer dropdown stuck on "Auto" at startup instead of showing the concrete renderer in effect.

The dropdown reflects `data.get('renderer')`, and the `renderer:set` handler is what resolves AUTO to the active renderer (`currentRenderer`) and writes it back. In these examples the handler was registered *after* the initial `data.set('renderer', AUTO)`, so the initial value was never resolved. Moved the handler registration above the initial set, matching the other gsplat examples (e.g. world).

**Changes:**
- first-person.example.mjs: register `renderer:set` before initial `data.set`
- third-person.example.mjs: same
- lut-grading.example.mjs: same