### PR TITLE
ci: update engine release workflows

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -1,0 +1,46 @@
+name: Alpha
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  alpha:
+    runs-on: ubuntu-latest
+    if: github.repository == 'playcanvas/engine' && github.ref_name != 'main'
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_KEY }}
+
+      - name: Check out code
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: "npm"
+
+      - name: Configure Git User
+        run: |
+          git config --global user.email "playcanvas[bot]@users.noreply.github.com"
+          git config --global user.name "PlayCanvas [bot]"
+        shell: bash
+
+      - name: Tag alpha
+        run: |
+          base=$(npm pkg get version | sed 's/"//g' | sed 's/-.*//')
+          version="$base-alpha.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          npm version "$version" --no-git-tag-version
+          git commit -m "Alpha $version" -- package.json package-lock.json
+          git tag "v$version"
+          git push origin "v$version"

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,6 +1,8 @@
 name: Beta
 
 on:
+  schedule:
+    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
       force:
@@ -29,6 +31,12 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Set up Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: "npm"
+
       - name: Configure Git User
         run: |
           git config --global user.email "playcanvas[bot]@users.noreply.github.com"
@@ -36,21 +44,32 @@ jobs:
         shell: bash
 
       - name: Check for changes
-        if: github.event.inputs.force == 'false'
+        id: changes
         run: |
-          last_tag=$(git describe --tags --abbrev=0)
-          if ! git diff --quiet --exit-code $last_tag; then
-            echo "Changes found since v$last_tag"
+          if [[ "${{ github.event.inputs.force }}" == "true" ]]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          last_tag=$(git describe --tags --match "v*-beta.*" --abbrev=0 2>/dev/null || true)
+          if [[ -z "$last_tag" ]]; then
+            echo "No beta tag found"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          elif ! git diff --quiet --exit-code "$last_tag"..HEAD; then
+            echo "Changes found since $last_tag"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No changes detected since v$last_tag"
-            exit 1
+            echo "No changes detected since $last_tag"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Bump version
+        if: steps.changes.outputs.has_changes == 'true'
         run: |
           npm version prerelease --preid=beta
 
       - name: Push version
+        if: steps.changes.outputs.has_changes == 'true'
         run: |
           git push origin HEAD:${{ github.ref_name }}
           git push origin --tags

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-preview.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
 
@@ -32,8 +33,11 @@ jobs:
           echo "TAG=${TAG_NAME}" >> $GITHUB_ENV
           echo "VERSION=${TAG_NAME/v/}" >> $GITHUB_ENV
 
-      - name: Install Dependencies
-        run: npm install
+      - name: Install dependencies
+        run: npm clean-install --progress=false --no-fund
+
+      - name: Run ESLint
+        run: npm run lint
 
       - name: Build PlayCanvas
         run: npm run build
@@ -41,9 +45,33 @@ jobs:
       - name: Run Publint
         run: npm run publint
 
+      - name: Run Post-build tests
+        run: npm run test:build
+
+      - name: Build API reference manual
+        run: npm run docs
+
+      - name: Build TypeScript declarations
+        run: npm run build:types
+
+      - name: Compile TypeScript declarations
+        run: npm run test:types
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Build Examples Browser
+        working-directory: ./examples
+        run: |
+          npm clean-install --progress=false --no-fund
+          npm run lint
+          npm run build
+
       - name: Publish to npm
         run: |
-          if [[ "${{ env.TAG }}" =~ "preview" ]]; then
+          if [[ "${{ env.TAG }}" =~ "alpha" ]]; then
+            tag=alpha
+          elif [[ "${{ env.TAG }}" =~ "preview" ]]; then
             tag=preview
           elif [[ "${{ env.TAG }}" =~ "beta" ]]; then
             tag=beta

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,26 +39,23 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
-      - name: Build PlayCanvas
-        run: npm run build
-
-      - name: Run Publint
-        run: npm run publint
-
-      - name: Run Post-build tests
-        run: npm run test:build
+      - name: Run unit tests
+        run: npm test
 
       - name: Build API reference manual
         run: npm run docs
 
-      - name: Build TypeScript declarations
-        run: npm run build:types
+      - name: Build PlayCanvas
+        run: npm run build
+
+      - name: Run Post-build tests
+        run: npm run test:build
 
       - name: Compile TypeScript declarations
         run: npm run test:types
 
-      - name: Run unit tests
-        run: npm test
+      - name: Run Publint
+        run: npm run publint
 
       - name: Publish to npm
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,13 +60,6 @@ jobs:
       - name: Run unit tests
         run: npm test
 
-      - name: Build Examples Browser
-        working-directory: ./examples
-        run: |
-          npm clean-install --progress=false --no-fund
-          npm run lint
-          npm run build
-
       - name: Publish to npm
         run: |
           if [[ "${{ env.TAG }}" =~ "alpha" ]]; then

--- a/release.sh
+++ b/release.sh
@@ -6,7 +6,7 @@ PRE_ID_BETA="beta"
 PRE_ID_PREVIEW="preview"
 
 RELEASE_PREFIX="release-"
-RELEASE_REGEX="^$RELEASE_PREFIX[0-9]+.[0-9]+$"
+RELEASE_REGEX="^${RELEASE_PREFIX}[0-9]+\\.[0-9]+$"
 
 # Help
 HELP=$1
@@ -35,6 +35,16 @@ fi
 
 BRANCH=$(git branch --show-current)
 VERSION=$(npm pkg get version | sed 's/"//g')
+
+if [[ "$BRANCH" == "$MAIN_BRANCH" || $BRANCH =~ $RELEASE_REGEX ]]; then
+    git fetch origin --tags
+    LOCAL=$(git rev-parse HEAD)
+    REMOTE=$(git rev-parse "origin/$BRANCH")
+    if [[ "$LOCAL" != "$REMOTE" ]]; then
+        echo "Local '$BRANCH' is not up to date with 'origin/$BRANCH'. Please pull before running this script."
+        exit 1
+    fi
+fi
 
 PARTS=(${VERSION//./ })
 MAJOR=${PARTS[0]}
@@ -94,9 +104,6 @@ if [[ $BRANCH =~ $RELEASE_REGEX ]]; then
     fi
 
     echo "Finalize release [BRANCH=$BRANCH, VERSION=$VERSION, TYPE=$TYPE]"
-
-    # Fetch all remote tags
-    git fetch --tags
 
     # Calculate the next version
     npm version $TYPE --preid=$PRE_ID_PREVIEW --no-git-tag-version >> /dev/null


### PR DESCRIPTION
## Description
- Adds Alpha releases for manual maintainer-triggered builds from PR branches. The workflow derives the base version from `package.json`, creates a `vX.Y.Z-alpha.<run_number>.<run_attempt>` tag, and does not push a version commit back to the branch.
- Converts Beta into the nightly engine build from `main`. The scheduled workflow runs at 02:00 UTC, compares `main` against the latest `v*-beta.*` tag, and only bumps/pushes a new beta when `main` changed; manual `force` bypasses the change check.
- Updates the Publish workflow so alpha tags publish with npm dist-tag `alpha`, beta tags publish with `beta`, source checks run before package build checks, and examples are not built for package publish.
- Guards `release.sh` so stable/preview releases run from `main` or `release-X.Y` only when the local branch matches `origin`.

## Manual smoke test
1. Run the Beta workflow manually on `main` with `force` disabled after no changes since the latest beta tag. Expected: it skips bumping and does not create a new beta tag.
2. Run the Beta workflow manually on `main` with `force` enabled, or after a `main` change. Expected: it creates a beta version commit and pushes the matching `vX.Y.Z-beta.N` tag.
3. Run the Alpha workflow manually on a PR branch. Expected: it creates and pushes a `vX.Y.Z-alpha.<run_number>.<run_attempt>` tag without updating the branch.
4. Open the matching Publish workflow for alpha and beta tags. Expected: alpha selects npm dist-tag `alpha`; beta selects npm dist-tag `beta`.

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change