### PR TITLE
Remove unused Camera.beforePasses

### DIFF
--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -117,14 +117,6 @@ class Camera {
      */
     framePasses = [];
 
-    /**
-     * Frame passes that execute before this camera's main scene rendering. Entries are picked up
-     * by the RenderPassForward that renders this camera's layers.
-     *
-     * @type {FramePass[]}
-     */
-    beforePasses = [];
-
     /** @type {number} */
     jitter = 0;
 

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -168,26 +168,6 @@ class RenderPassForward extends RenderPass {
         return index;
     }
 
-    // Collect before-passes from cameras whose first render action lives in this
-    // RenderPassForward. Uses the existing firstCameraUse flag (set by LayerComposition)
-    // to guarantee each camera's before-passes are scheduled exactly once, even when
-    // multiple RenderPassForward instances reference the same camera (e.g. CameraFrame's
-    // scenePass vs afterPass).
-    updateCameraBeforePasses() {
-        for (let i = 0; i < this.renderActions.length; i++) {
-            const ra = this.renderActions[i];
-            if (ra.firstCameraUse) {
-                const camera = ra.camera?.camera;
-                if (camera) {
-                    const { beforePasses } = camera;
-                    for (let j = 0; j < beforePasses.length; j++) {
-                        this.beforePasses.push(beforePasses[j]);
-                    }
-                }
-            }
-        }
-    }
-
     updateDirectionalShadows() {
         // add directional shadow passes if needed for the cameras used in this render pass
         const { renderer, renderActions } = this;
@@ -237,7 +217,6 @@ class RenderPassForward extends RenderPass {
 
     frameUpdate() {
         super.frameUpdate();
-        this.updateCameraBeforePasses();
         this.updateDirectionalShadows();
         this.updateClears();
     }


### PR DESCRIPTION
Removes the `Camera.beforePasses` extension point, which is no longer used by anything in the engine.

It was added in #8531 for the compute-based tiled GSplat renderer (`GSplatComputeGlobalRenderer`) to schedule compute work before a camera's main render pass. That renderer was removed in #8558, which deleted the only writer but left the field and its reader behind. This finishes that cleanup.

**Changes:**
- Remove the `beforePasses` field from `Camera`.
- Remove `RenderPassForward.updateCameraBeforePasses()` and its call in `frameUpdate()`.

**API Changes:**
- Removed `Camera.beforePasses` (`FramePass[]`). It was always empty in normal usage — the engine never populated it after #8558.