### PR TITLE
Refactor light & directional-shadow culling into separate phases

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -849,6 +849,7 @@ class Lightmapper {
             }
 
             if (light.type === LIGHTTYPE_DIRECTIONAL) {
+                this.renderer._shadowRendererDirectional.prepareShadowMap(light);
                 this.renderer._shadowRendererDirectional.cull(light, comp, this.camera, casters);
 
                 const shadowPass = this.renderer._shadowRendererDirectional.getLightRenderPass(light, this.camera);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1087,7 +1087,11 @@ class ForwardRenderer extends Renderer {
         // update gsplat director
         this.gsplatDirector?.update(comp);
 
-        // visibility culling of lights, meshInstances, shadows casters
+        // light visibility culling, light atlas allocation and directional shadow light collection
+        // (mesh-independent, so it can run before the frame graph is built in a later refactor)
+        this.updateLightVisibility(comp);
+
+        // visibility culling of meshInstances and shadow casters
         // after this the scene culling is done and script callbacks can be called to report which objects are visible
         this.cullComposition(comp);
 

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -997,12 +997,8 @@ class Renderer {
             }
         }
 
-        // collect shadow-casting directional lights per camera + allocate their shadow maps. Kept
-        // separate (and mesh- / frustum-independent) so it can run before the frame graph is built
-        // in a later refactor.
-        this.collectDirectionalShadowLights(comp);
-
-        // cull shadow casters / fit cascades for the collected directional lights (mesh-dependent)
+        // cull shadow casters / fit cascades for the directional lights collected (earlier, in
+        // updateLightVisibility) into cameraDirShadowLights (mesh-dependent)
         this.cameraDirShadowLights.forEach((lightList, camera) => {
             for (let i = 0; i < lightList.length; i++) {
                 this._shadowRendererDirectional.cull(lightList[i], comp, camera);
@@ -1063,8 +1059,60 @@ class Renderer {
     }
 
     /**
-     * visibility culling of lights, meshInstances, shadows casters. Also applies
-     * `meshInstance.visible`.
+     * Per-camera light visibility culling, light-atlas allocation and directional-shadow-light
+     * collection. This is independent of mesh culling and the frame graph, so it runs before the
+     * frame graph is built. The mesh and shadow-caster culling that depends on it is done later in
+     * {@link Renderer#cullComposition}.
+     *
+     * @param {LayerComposition} comp - The layer composition.
+     */
+    updateLightVisibility(comp) {
+
+        const { scene } = this;
+
+        // reset per-frame light visibility: directional lights start visible, local lights start
+        // hidden (and are marked visible below by cullLights if they intersect a camera frustum)
+        const lights = this.lights;
+        for (let i = 0; i < lights.length; i++) {
+            lights[i].beginFrame();
+        }
+
+        // for all cameras: update the frustum and cull each layer's lights for visibility
+        const numCameras = comp.cameras.length;
+        for (let i = 0; i < numCameras; i++) {
+            const camera = comp.cameras[i];
+
+            // update camera and frustum
+            const renderTarget = camera.renderTarget;
+            camera.frameUpdate(renderTarget);
+            this.updateCameraFrustum(camera.camera);
+
+            // for all of its enabled layers cull the non-directional lights once with each camera
+            // lights aren't collected anywhere, but marked as visible
+            const layerIds = camera.layers;
+            for (let j = 0; j < layerIds.length; j++) {
+                const layer = comp.getLayerById(layerIds[j]);
+                if (layer && layer.enabled) {
+                    this.cullLights(camera.camera, layer._lights);
+                }
+            }
+        }
+
+        // update shadow / cookie atlas allocation for the visible lights. Update it after the lights
+        // were culled, but before shadow maps are culled, as it might force some 'update once'
+        // shadows to cull.
+        if (scene.clusteredLightingEnabled) {
+            this.updateLightTextureAtlas();
+        }
+
+        // collect shadow-casting directional lights per camera + allocate their shadow maps
+        this.collectDirectionalShadowLights(comp);
+    }
+
+    /**
+     * Visibility culling of meshInstances and shadow casters. Light visibility, the light atlas and
+     * the directional-shadow-light collection are done earlier in
+     * {@link Renderer#updateLightVisibility}.
      *
      * @param {LayerComposition} comp - The layer composition.
      */
@@ -1085,13 +1133,8 @@ class Renderer {
         for (let i = 0; i < numCameras; i++) {
             const camera = comp.cameras[i];
 
-            // update camera and frustum
-            const renderTarget = camera.renderTarget;
-            camera.frameUpdate(renderTarget);
-            this.updateCameraFrustum(camera.camera);
-
-            // event before the camera is culling, fired after the frustum has been updated so
-            // listeners can rely on the current camera state
+            // event before the camera is culling, fired after the frustum has been updated (in
+            // updateLightVisibility) so listeners can rely on the current camera state
             scene?.fire(EVENT_PRECULL, camera);
 
             // for all of its enabled layers
@@ -1099,10 +1142,6 @@ class Renderer {
             for (let j = 0; j < layerIds.length; j++) {
                 const layer = comp.getLayerById(layerIds[j]);
                 if (layer && layer.enabled) {
-
-                    // cull each layer's non-directional lights once with each camera
-                    // lights aren't collected anywhere, but marked as visible
-                    this.cullLights(camera.camera, layer._lights);
 
                     // cull mesh instances
                     const culledInstances = layer.getCulledInstances(camera.camera);
@@ -1112,12 +1151,6 @@ class Renderer {
 
             // event after the camera is done with culling
             scene?.fire(EVENT_POSTCULL, camera);
-        }
-
-        // update shadow / cookie atlas allocation for the visible lights. Update it after the ligthts were culled,
-        // but before shadow maps were culling, as it might force some 'update once' shadows to cull.
-        if (scene.clusteredLightingEnabled) {
-            this.updateLightTextureAtlas();
         }
 
         // cull shadow casters for all lights
@@ -1228,13 +1261,6 @@ class Renderer {
         // clear light arrays
         _tempMeshInstances.length = 0;
         _tempMeshInstancesSkinned.length = 0;
-
-        // clear light visibility
-        const lights = this.lights;
-        const lightCount = lights.length;
-        for (let i = 0; i < lightCount; i++) {
-            lights[i].beginFrame();
-        }
     }
 
     updateLightTextureAtlas() {

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -997,7 +997,31 @@ class Renderer {
             }
         }
 
-        // shadow casters culling for directional lights - start with none and collect lights for cameras
+        // collect shadow-casting directional lights per camera + allocate their shadow maps. Kept
+        // separate (and mesh- / frustum-independent) so it can run before the frame graph is built
+        // in a later refactor.
+        this.collectDirectionalShadowLights(comp);
+
+        // cull shadow casters / fit cascades for the collected directional lights (mesh-dependent)
+        this.cameraDirShadowLights.forEach((lightList, camera) => {
+            for (let i = 0; i < lightList.length; i++) {
+                this._shadowRendererDirectional.cull(lightList[i], comp, camera);
+            }
+        });
+    }
+
+    /**
+     * Collects the set of shadow-casting directional lights for each camera into
+     * {@link Renderer#cameraDirShadowLights}, and ensures each such light has a shadow map
+     * allocated. This is independent of mesh culling and camera frusta (it uses only the
+     * composition's cameras and the layers' directional lights), so it can run before the frame
+     * graph is built. The actual shadow-caster culling is done separately.
+     *
+     * @param {LayerComposition} comp - The layer composition.
+     */
+    collectDirectionalShadowLights(comp) {
+
+        // start with none and collect lights for cameras
         this.cameraDirShadowLights.clear();
         const cameras = comp.cameras;
         for (let i = 0; i < cameras.length; i++) {
@@ -1023,8 +1047,7 @@ class Renderer {
                                 lightList = lightList ?? [];
                                 lightList.push(light);
 
-                                // frustum culling for the directional shadow when rendering the camera
-                                this._shadowRendererDirectional.cull(light, comp, camera);
+                                this._shadowRendererDirectional.prepareShadowMap(light);
                             }
                         }
                     }

--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -76,8 +76,11 @@ class ShadowRendererDirectional {
         this.device = renderer.device;
     }
 
-    // cull directional shadow map
-    cull(light, comp, camera, casters = null) {
+    // Minimal prerequisite for directional shadow-pass creation: ensure the shadow map exists
+    // and the light is marked visible. This is caster- and camera-independent, so it can run
+    // early in the frame (before mesh culling), unlike cull() which sets up the per-cascade
+    // shadow cameras and culls casters.
+    prepareShadowMap(light) {
 
         // force light visibility if function was manually called
         light.visibleThisFrame = true;
@@ -85,6 +88,12 @@ class ShadowRendererDirectional {
         if (!light._shadowMap) {
             light._shadowMap = ShadowMap.create(this.device, light);
         }
+    }
+
+    // cull directional shadow map. prepareShadowMap(light) must have been called first.
+    cull(light, comp, camera, casters = null) {
+
+        Debug.assert(light._shadowMap, 'ShadowRendererDirectional.cull requires prepareShadowMap() to have been called for the light first.');
 
         // generate splits for the cascades
         const nearDist = camera._nearClip;

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -166,8 +166,9 @@ class ShadowRenderer {
      */
     cullShadowCasters(comp, light, visible, camera, casters) {
 
-        // event before the camera is culling
-        this.renderer.scene?.fire(EVENT_PRECULL, camera);
+        // event before culling - the camera is null as this is internal (shadow) culling rather
+        // than culling for a user camera
+        this.renderer.scene?.fire(EVENT_PRECULL, null);
 
         visible.length = 0;
 
@@ -200,8 +201,9 @@ class ShadowRenderer {
         // this sorts the shadow casters by the shader id
         visible.sort(this.sortCompareShader);
 
-        // event after the camera is done with culling
-        this.renderer.scene?.fire(EVENT_POSTCULL, camera);
+        // event after culling - the camera is null as this is internal (shadow) culling rather
+        // than culling for a user camera
+        this.renderer.scene?.fire(EVENT_POSTCULL, null);
     }
 
     sortCompareShader(drawCallA, drawCallB) {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -121,23 +121,33 @@ class Scene extends EventHandler {
     static EVENT_POSTRENDER_LAYER = 'postrender:layer';
 
     /**
-     * Fired before visibility culling is performed for the camera.
+     * Fired before mesh instance visibility culling is performed for a camera. The handler is
+     * passed the {@link CameraComponent} being culled, or null when the culling is internal (for
+     * example when culling shadow casters for a light's shadow map). Note that light visibility
+     * culling happens earlier in the frame and is not bracketed by this event.
      *
      * @event
      * @example
      * app.scene.on('precull', (camera) => {
-     *    console.log(`Visibility culling will be performed for camera ${camera.entity.name}`);
+     *    if (camera) {
+     *        console.log(`Visibility culling will be performed for camera ${camera.entity.name}`);
+     *    }
      * });
      */
     static EVENT_PRECULL = 'precull';
 
     /**
-     * Fired after visibility culling is performed for the camera.
+     * Fired after mesh instance visibility culling is performed for a camera; mesh instance
+     * visibility (such as {@link MeshInstance#visibleThisFrame}) is up to date when this fires. The
+     * handler is passed the {@link CameraComponent} that was culled, or null when the culling is
+     * internal (for example when culling shadow casters for a light's shadow map).
      *
      * @event
      * @example
      * app.scene.on('postcull', (camera) => {
-     *    console.log(`Visibility culling was performed for camera ${camera.entity.name}`);
+     *    if (camera) {
+     *        console.log(`Visibility culling was performed for camera ${camera.entity.name}`);
+     *    }
      * });
      */
     static EVENT_POSTCULL = 'postcull';


### PR DESCRIPTION
Internal renderer refactor that splits directional-shadow and light-visibility culling into smaller, single-responsibility phases. This is preparation for a later change that builds the frame graph before mesh culling; there is no change to rendering behavior.

**Changes:**
- `ShadowRendererDirectional`: split shadow-map allocation out of `cull()` into a new `prepareShadowMap()` — the minimal, caster- and camera-independent step needed before a directional shadow pass can be created.
- `Renderer`: extract `collectDirectionalShadowLights()` (builds the per-camera directional shadow-light set and allocates shadow maps) from `cullShadowmaps()`, separate from the mesh-dependent caster cull.
- `Renderer`: split the cull phase into `updateLightVisibility()` (per-frame light reset, per-camera frustum update + light-visibility culling, clustered light-atlas allocation, and directional shadow-light collection — all independent of mesh culling) and a slimmed `cullComposition()` (mesh-instance + shadow-caster culling only). The per-frame light-visibility reset moves from `Renderer.beginFrame()` into `updateLightVisibility()`.

All affected methods are internal (`@ignore`). Behavior-neutral: every producer still precedes its consumer; the only observable change is that `EVENT_PRECULL` now fires after light culling (the frustum is still updated beforehand).