### PR TITLE
Skip WebXR startup probe when xr-spatial-tracking is disallowed

### DIFF
--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -317,12 +317,35 @@ class XrManager extends EventHandler {
         // 2. Space class
         // 3. Controllers class
 
-        if (this._supported) {
+        if (this._supported && XrManager._allowsSpatialTracking()) {
             navigator.xr.addEventListener('devicechange', () => {
                 this._deviceAvailabilityCheck();
             });
             this._deviceAvailabilityCheck();
         }
+    }
+
+    /**
+     * The startup availability probe calls {@link navigator.xr.isSessionSupported}, which the
+     * browser blocks - logging a `xr-spatial-tracking is not allowed in this document` permissions
+     * policy violation - when the `xr-spatial-tracking` feature is disallowed for the document (for
+     * example when the app runs in an iframe without `allow="xr-spatial-tracking"`). Only skip the
+     * probe when the policy explicitly disallows the feature; when the Feature Policy API is
+     * unavailable (e.g. Safari / visionOS) we cannot tell, so proceed as before.
+     *
+     * @returns {boolean} - True if the probe should run.
+     * @private
+     */
+    static _allowsSpatialTracking() {
+        const featurePolicy = platform.browser && document.featurePolicy;
+        if (featurePolicy?.allowsFeature) {
+            const allowed = featurePolicy.allowsFeature('xr-spatial-tracking');
+            if (!allowed) {
+                Debug.warn('WebXR availability detection skipped: the "xr-spatial-tracking" feature is disallowed for this document. If XR is needed, add allow="xr-spatial-tracking" to the embedding iframe or send a matching Permissions-Policy header.');
+            }
+            return allowed;
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
Suppresses the `[Violation] Permissions policy violation: xr-spatial-tracking is not allowed in this document` console warning that appears on startup for every app — even ones that never use XR.

**Why:**
`AppBase` always creates an `XrManager` (via `pc.Application`), and its constructor unconditionally probes WebXR by calling `navigator.xr.isSessionSupported()` for inline/VR/AR. When the document's permissions policy disallows `xr-spatial-tracking` (e.g. the app runs in an iframe without `allow="xr-spatial-tracking"`), the browser blocks that call and logs a policy violation — regardless of whether the project uses XR.

**Changes:**
- Gate the startup availability probe (and the `devicechange` listener) on a new private `XrManager._allowsSpatialTracking()` check.
- Only skip the probe when the Feature Policy API reports the feature is **explicitly disallowed**. When the API is unavailable (e.g. Safari / visionOS, where `navigator.xr` exists but `document.featurePolicy` does not) we cannot tell, so we proceed as before — avoiding a regression on those platforms.
- When skipped, emit a `Debug.warn` (debug builds only) explaining the cause and how to fix it (iframe `allow` attribute / `Permissions-Policy` header).

No public API changes.