### PR TITLE
Build the frame graph before mesh and shadow-caster culling

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1156,10 +1156,15 @@ class AppBase extends EventHandler {
     renderComposition(layerComposition) {
         DebugGraphics.clearGpuMarkers();
 
-        // update composition, cull everything, assign atlas slots for clustered lighting
+        // update composition + light visibility, assign atlas slots for clustered lighting
         this.renderer.update(layerComposition);
 
+        // build the frame graph from the (not-yet-culled) composition
         this.renderer.buildFrameGraph(this.frameGraph, layerComposition);
+
+        // cull mesh instances and shadow casters - this fills what the passes read at render time
+        this.renderer.cull(layerComposition);
+
         this.frameGraph.render(this.graphicsDevice);
     }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -1030,11 +1030,6 @@ class ForwardRenderer extends Renderer {
                 }
             }
         }
-
-        // consume one-shot (THISFRAME) shadow updates - the frame graph is now built and shadow
-        // casters were culled earlier this frame, so both have read the shadow update mode before
-        // it is changed here
-        this.consumeOneShotShadows();
     }
 
     /**
@@ -1095,6 +1090,17 @@ class ForwardRenderer extends Renderer {
         // light visibility culling, light atlas allocation and directional shadow light collection
         // (mesh-independent, so it can run before the frame graph is built in a later refactor)
         this.updateLightVisibility(comp);
+    }
+
+    /**
+     * Visibility culling of mesh instances and shadow casters, followed by GPU data updates for the
+     * resulting visible objects, and consuming one-shot shadow updates. Runs after the frame graph
+     * has been built (which is itself after {@link ForwardRenderer#update}), so shadow-pass building
+     * and shadow-caster culling have both read the shadow update mode before it is consumed here.
+     *
+     * @param {LayerComposition} comp - The layer composition.
+     */
+    cull(comp) {
 
         // visibility culling of meshInstances and shadow casters
         // after this the scene culling is done and script callbacks can be called to report which objects are visible
@@ -1107,6 +1113,10 @@ class ForwardRenderer extends Renderer {
 
         // GPU update for visible objects requiring one
         this.gpuUpdate(this.processingMeshInstances);
+
+        // consume one-shot (THISFRAME) shadow updates - the frame graph has been built and shadow
+        // casters culled, so both have read the shadow update mode before it is changed here
+        this.consumeOneShotShadows();
     }
 }
 

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -819,7 +819,7 @@ class Renderer {
      * @param {MeshInstance[]} drawCalls - Draw calls to cull.
      * @param {CulledInstances} culledInstances - Stores culled instances.
      */
-    cull(camera, drawCalls, culledInstances) {
+    cullMeshInstances(camera, drawCalls, culledInstances) {
         // #if _PROFILER
         const cullTime = now();
         // #endif
@@ -1196,7 +1196,7 @@ class Renderer {
 
                     // cull mesh instances
                     const culledInstances = layer.getCulledInstances(camera.camera);
-                    this.cull(camera.camera, layer.meshInstances, culledInstances);
+                    this.cullMeshInstances(camera.camera, layer.meshInstances, culledInstances);
                 }
             }
 


### PR DESCRIPTION
Reorders the per-frame render pipeline so the frame graph is built before mesh-instance and shadow-caster culling. This is preparation for driving culling from the frame graph (so a custom `RenderPassForward` can render any layer with any camera). The cull now fills the visible-instance and shadow-caster lists that the passes read at render time, so output is unchanged for the standard composition.

**Changes:**
- `Renderer.update()` now performs only the mesh-independent prepare + light-visibility phase. The mesh / shadow-caster culling (plus gsplat shadow update, GPU data update, and one-shot shadow consume) moves into a new `ForwardRenderer.cull()` phase.
- `renderComposition` orders the phases as `update` → `buildFrameGraph` → `cull` → `render`.
- `consumeOneShotShadows` moves from the end of `buildFrameGraph` to the end of `cull`, so shadow-pass building and shadow-caster culling both read the shadow update mode before it is consumed.
- Renamed the low-level `Renderer.cull(camera, drawCalls, culledInstances)` to `cullMeshInstances`, freeing the `cull()` name for the new phase.

**Behavior note:**
- `EVENT_PRECULL` / `EVENT_POSTCULL` now fire after the frame graph is built (they still bracket the mesh cull). All affected methods are internal (`@ignore`).