### PR TITLE
Allocate local light shadow maps before the frame graph is built

### DIFF
--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1146,9 +1146,13 @@ class Renderer {
                         light.shadowUpdateMode = SHADOWUPDATE_THISFRAME;
                     }
                 } else {
-                    // force rendering the shadow at least once to allocate the shadow map needed by the shaders
-                    if (light.shadowUpdateMode === SHADOWUPDATE_NONE && light.castShadows) {
-                        if (!light.getRenderData(null, 0).shadowCamera.renderTarget) {
+                    // allocate the shadow map early (before the frame graph is built and before the
+                    // forward pass reads it), mirroring directional lights. Force a one-shot update
+                    // when the map was (re)created (first use, or destroyed by a property change such
+                    // as shadowType) so the new map actually gets rendered.
+                    if (light.castShadows && light.visibleThisFrame && !light._shadowMap) {
+                        this._shadowRendererLocal.prepareShadowMap(light);
+                        if (light.shadowUpdateMode === SHADOWUPDATE_NONE) {
                             light.shadowUpdateMode = SHADOWUPDATE_THISFRAME;
                         }
                     }

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -32,6 +32,17 @@ class ShadowRendererLocal {
         this.device = renderer.device;
     }
 
+    // Minimal prerequisite for local shadow-pass creation: ensure the shadow map exists. This is
+    // caster- and camera-independent, so it can run early in the frame (before the frame graph is
+    // built and before mesh culling), mirroring ShadowRendererDirectional#prepareShadowMap, so the
+    // map exists when the frame graph build and the forward pass reference it. Clustered lighting
+    // uses the shadow atlas, so no per-light map is allocated.
+    prepareShadowMap(light) {
+        if (!this.renderer.scene.clusteredLightingEnabled && !light._shadowMap) {
+            light._shadowMap = ShadowMap.create(this.device, light);
+        }
+    }
+
     // cull local shadow map
     cull(light, comp, casters = null) {
 
@@ -41,11 +52,7 @@ class ShadowRendererLocal {
         light.visibleThisFrame = true;
 
         // allocate shadow map unless in clustered lighting mode
-        if (!isClustered) {
-            if (!light._shadowMap) {
-                light._shadowMap = ShadowMap.create(this.device, light);
-            }
-        }
+        this.prepareShadowMap(light);
 
         const type = light._type;
         const faceCount = type === LIGHTTYPE_SPOT ? 1 : 6;


### PR DESCRIPTION
Fixes a crash (`Cannot read properties of null (reading 'renderTargets')` / `'width'`) when rendering local (spot / omni) non-clustered shadows whose shadow map is not yet allocated at frame-graph build time.

**Cause:**
Local shadow maps were allocated only in `ShadowRendererLocal.cull`, which runs in the cull phase — *after* `buildFrameGraph` builds the shadow pass (whose `prepareFace` reads `light._shadowMap`) and after the forward pass reads it via `dispatchSpotLight`. Building therefore relied on the map persisting from a previous frame. It crashed whenever the map was null at that point: the first frame a light needs a shadow, or after a property change such as `shadowType` / `shadowResolution` calls `_destroyShadowMap()`. Directional lights already avoid this by allocating early via `ShadowRendererDirectional.prepareShadowMap`; local lights had no equivalent.

Regression introduced by the culling-phase split / shadow update-mode rework in https://github.com/playcanvas/engine/pull/8961 and https://github.com/playcanvas/engine/pull/8962, which moved local shadow-map allocation after the frame graph build.

**Changes:**
- Add `ShadowRendererLocal.prepareShadowMap(light)` (allocation lifted out of `cull`), and call it early in `Renderer.updateLightVisibility` for visible shadow-casting local lights — mirroring the directional path — so the map exists before the frame graph is built and before the forward pass reads it.
- Fix the local re-render predicate to test `light._shadowMap` rather than `shadowCamera.renderTarget` (which is not cleared when the map is destroyed, so a destroyed map was not detected).

**Notes:**
- Internal renderer change only; no public API change.
- Reproduced with the `contact-hardening-shadows` test example on WebGL2 (`WEBGPU_DISABLED`); verified fixed there and across other shadow examples.