### PR TITLE
Route view uniforms through dynamic buffers; remove view bind groups

### DIFF
--- a/src/extras/render-passes/render-pass-prepass.js
+++ b/src/extras/render-passes/render-pass-prepass.js
@@ -31,9 +31,6 @@ const DEPTH_UNIFORM_NAME = 'uSceneDepthMap';
  * @ignore
  */
 class RenderPassPrepass extends RenderPass {
-    /** @type {BindGroup[]} */
-    viewBindGroups = [];
-
     /** @type {Texture} */
     linearDepthTexture;
 
@@ -56,12 +53,6 @@ class RenderPassPrepass extends RenderPass {
         this.renderTarget = null;
         this.linearDepthTexture?.destroy();
         this.linearDepthTexture = null;
-
-        this.viewBindGroups.forEach((bg) => {
-            bg.defaultUniformBuffer.destroy();
-            bg.destroy();
-        });
-        this.viewBindGroups.length = 0;
     }
 
     setupRenderTarget(options) {
@@ -126,7 +117,7 @@ class RenderPassPrepass extends RenderPass {
                         }
                     }
 
-                    renderer.renderForwardLayer(camera, renderTarget, null, undefined, SHADER_PREPASS, this.viewBindGroups, {
+                    renderer.renderForwardLayer(camera, renderTarget, null, undefined, SHADER_PREPASS, {
                         meshInstances: tempMeshInstances
                     });
 

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1892,11 +1892,6 @@ class AppBase extends EventHandler {
 
         this.systems.destroy();
 
-        // layer composition
-        if (this.scene.layers) {
-            this.scene.layers.destroy();
-        }
-
         // destroy bundle registry
         this.bundles.destroy();
         this.bundles = null;

--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -1,6 +1,8 @@
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { BlendState } from '../../platform/graphics/blend-state.js';
 import { RenderPass } from '../../platform/graphics/render-pass.js';
+import { UNIFORMTYPE_MAT4 } from '../../platform/graphics/constants.js';
+import { UniformBufferFormat, UniformFormat } from '../../platform/graphics/uniform-buffer-format.js';
 import { SHADER_PICK, SHADER_DEPTH_PICK } from '../../scene/constants.js';
 
 /**
@@ -14,7 +16,6 @@ import { SHADER_PICK, SHADER_DEPTH_PICK } from '../../scene/constants.js';
 
 const tempMeshInstances = [];
 const lights = [[], [], []];
-const defaultShadowAtlasParams = new Float32Array(2);
 
 /**
  * A render pass implementing rendering of mesh instances into a pick buffer.
@@ -22,9 +23,6 @@ const defaultShadowAtlasParams = new Float32Array(2);
  * @ignore
  */
 class RenderPassPicker extends RenderPass {
-    /** @type {BindGroup[]} */
-    viewBindGroups = [];
-
     /** @type {BlendState} */
     blendState = BlendState.NOBLEND;
 
@@ -49,17 +47,30 @@ class RenderPassPicker extends RenderPass {
     /** @type {Map<number, MeshInstance|null>} */
     _pickMeshInstances = new Map();
 
+    /**
+     * Minimal view uniform format used by the picker. The pick shaders only need the view
+     * projection (and the view matrix for depth picking); any other view uniform a shader happens
+     * to reference falls back to the per-mesh uniform buffer automatically. This avoids pulling in
+     * the full forward view format (and its lighting / shadow uniforms) which the picker does not
+     * need.
+     *
+     * @type {UniformBufferFormat|null}
+     */
+    _viewUniformFormat = null;
+
     constructor(device, renderer) {
         super(device);
         this.renderer = renderer;
     }
 
-    destroy() {
-        this.viewBindGroups.forEach((bg) => {
-            bg.defaultUniformBuffer.destroy();
-            bg.destroy();
-        });
-        this.viewBindGroups.length = 0;
+    getViewUniformFormat() {
+        if (!this._viewUniformFormat) {
+            this._viewUniformFormat = new UniformBufferFormat(this.device, [
+                new UniformFormat('matrix_viewProjection', UNIFORMTYPE_MAT4),
+                new UniformFormat('matrix_view', UNIFORMTYPE_MAT4)
+            ]);
+        }
+        return this._viewUniformFormat;
     }
 
     /**
@@ -170,30 +181,16 @@ class RenderPassPicker extends RenderPass {
 
             if (tempMeshInstances.length > 0) {
 
-                // upload clustered lights uniforms
-                const clusteredLightingEnabled = scene.clusteredLightingEnabled;
-                if (clusteredLightingEnabled) {
-                    const lightClusters = this.emptyWorldClusters;
-                    lightClusters.activate();
-                }
-
-                renderer.setCameraUniforms(camera.camera, renderTarget);
-
-                // TODO: These uniforms are not required by the picker pass, but it uses the
-                // forward view format which includes them. Ideally, each pass should be able
-                // to specify its own view format to avoid setting unnecessary uniforms.
-                renderer.dispatchGlobalLights(scene);
-                device.scope.resolve('shadowAtlasParams').setValue(defaultShadowAtlasParams);
-
-                if (device.supportsUniformBuffers) {
-                    // Initialize view bind group format if not already done
-                    renderer.initViewBindGroupFormat(clusteredLightingEnabled);
-                    renderer.setupViewUniformBuffers(this.viewBindGroups, renderer.viewUniformFormat, renderer.viewBindGroupFormat, null);
-                }
-
+                // render the mesh instances through the standard forward layer path, using the
+                // picker's own minimal view uniform format; it sets up the camera and view uniforms,
+                // and the callback forces the picker blend state per mesh
                 const shaderPass = this.depth ? SHADER_DEPTH_PICK : SHADER_PICK;
-                renderer.renderForward(camera.camera, renderTarget, tempMeshInstances, lights, shaderPass, (meshInstance) => {
-                    device.setBlendState(this.blendState);
+                renderer.renderForwardLayer(camera.camera, renderTarget, null, undefined, shaderPass, {
+                    meshInstances: tempMeshInstances,
+                    splitLights: lights,
+                    lightClusters: this.emptyWorldClusters,
+                    viewUniformFormat: device.supportsUniformBuffers ? this.getViewUniformFormat() : undefined,
+                    drawCallback: () => device.setBlendState(this.blendState)
                 });
 
                 tempMeshInstances.length = 0;

--- a/src/framework/lightmapper/render-pass-lightmapper.js
+++ b/src/framework/lightmapper/render-pass-lightmapper.js
@@ -10,9 +10,6 @@ import { SHADER_FORWARD } from '../../scene/constants.js';
  * A render pass implementing rendering of mesh instance receivers for light-mapper.
  */
 class RenderPassLightmapper extends RenderPass {
-    /** @type {BindGroup[]} */
-    viewBindGroups = [];
-
     constructor(device, renderer, camera, worldClusters, receivers, lightArray) {
         super(device);
         this.renderer = renderer;
@@ -22,26 +19,13 @@ class RenderPassLightmapper extends RenderPass {
         this.lightArray = lightArray;
     }
 
-    destroy() {
-        this.viewBindGroups.forEach((bg) => {
-            bg.defaultUniformBuffer.destroy();
-            bg.destroy();
-        });
-        this.viewBindGroups.length = 0;
-    }
-
     execute() {
         const device = this.device;
         DebugGraphics.pushGpuMarker(device, 'Lightmapper');
 
         const { renderer, camera, receivers, renderTarget, worldClusters, lightArray } = this;
 
-        // Initialize view bind group format if not already done
-        if (device.supportsUniformBuffers && !renderer.viewUniformFormat) {
-            renderer.initViewBindGroupFormat(renderer.scene.clusteredLightingEnabled);
-        }
-
-        renderer.renderForwardLayer(camera, renderTarget, null, undefined, SHADER_FORWARD, this.viewBindGroups, {
+        renderer.renderForwardLayer(camera, renderTarget, null, undefined, SHADER_FORWARD, {
             meshInstances: receivers,
             splitLights: lightArray,
             lightClusters: worldClusters

--- a/src/platform/graphics/shader-processor-options.js
+++ b/src/platform/graphics/shader-processor-options.js
@@ -25,15 +25,15 @@ class ShaderProcessorOptions {
     /**
      * Constructs shader processing options, used to process the shader for uniform buffer support.
      *
-     * @param {UniformBufferFormat} [viewUniformFormat] - Format of the uniform buffer.
-     * @param {BindGroupFormat} [viewBindGroupFormat] - Format of the bind group.
+     * @param {UniformBufferFormat} [viewUniformFormat] - Format of the view uniform buffer. The
+     * view bind group contains only this single uniform buffer (no textures), so its layout is
+     * derived from the uniform format alone and no bind group format is required.
      * @param {VertexFormat} [vertexFormat] - Format of the vertex buffer.
      */
-    constructor(viewUniformFormat, viewBindGroupFormat, vertexFormat) {
+    constructor(viewUniformFormat, vertexFormat) {
 
         // construct a sparse array
         this.uniformFormats[BINDGROUP_VIEW] = viewUniformFormat;
-        this.bindGroupFormats[BINDGROUP_VIEW] = viewBindGroupFormat;
 
         this.vertexFormat = vertexFormat;
     }

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -123,15 +123,6 @@ class LayerComposition extends EventHandler {
         this._transparentOrder = {};
     }
 
-    destroy() {
-        this.destroyRenderActions();
-    }
-
-    destroyRenderActions() {
-        this._renderActions.forEach(ra => ra.destroy());
-        this._renderActions.length = 0;
-    }
-
     markDirty() {
         this._dirty = true;
     }
@@ -180,7 +171,7 @@ class LayerComposition extends EventHandler {
 
             // render in order of cameras sorted by priority
             let renderActionCount = 0;
-            this.destroyRenderActions();
+            this._renderActions.length = 0;
 
             for (let i = 0; i < this.cameras.length; i++) {
                 const camera = this.cameras[i];

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -47,21 +47,8 @@ class RenderAction {
         // true if this is the last render action using this camera
         this.lastCameraUse = false;
 
-        // an array of view bind groups (the number of these corresponds to the number of views when XR is used)
-        /** @type {BindGroup[]} */
-        this.viewBindGroups = [];
-
         // true if the camera should render using render passes it specifies
         this.useCameraPasses = false;
-    }
-
-    // releases GPU resources
-    destroy() {
-        this.viewBindGroups.forEach((bg) => {
-            bg.defaultUniformBuffer.destroy();
-            bg.destroy();
-        });
-        this.viewBindGroups.length = 0;
     }
 
     setupClears(camera, layer) {

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -102,19 +102,6 @@ class LightRenderData {
 
         // visible shadow casters
         this.visibleCasters = [];
-
-        // an array of view bind groups, single entry is used for shadows
-        /** @type {BindGroup[]} */
-        this.viewBindGroups = [];
-    }
-
-    // releases GPU resources
-    destroy() {
-        this.viewBindGroups.forEach((bg) => {
-            bg.defaultUniformBuffer.destroy();
-            bg.destroy();
-        });
-        this.viewBindGroups.length = 0;
     }
 
     // returns shadow buffer currently attached to the shadow camera
@@ -331,10 +318,6 @@ class Light {
     releaseRenderData() {
 
         if (this._renderData) {
-            for (let i = 0; i < this._renderData.length; i++) {
-                this._renderData[i].destroy();
-            }
-
             this._renderData.length = 0;
         }
     }

--- a/src/scene/materials/lit-material.js
+++ b/src/scene/materials/lit-material.js
@@ -95,7 +95,7 @@ class LitMaterial extends Material {
         options.defines = ShaderUtils.getCoreDefines(this, params);
 
         LitMaterialOptionsBuilder.update(options.litOptions, this, params.scene, params.cameraShaderParams, params.objDefs, params.pass, params.sortedLights);
-        const processingOptions = new ShaderProcessorOptions(params.viewUniformFormat, params.viewBindGroupFormat, params.vertexFormat);
+        const processingOptions = new ShaderProcessorOptions(params.viewUniformFormat, params.vertexFormat);
         const library = getProgramLibrary(params.device);
         library.register('lit', lit);
         const shader = library.getProgram('lit', options, processingOptions, this.userId);

--- a/src/scene/materials/lit-material.js
+++ b/src/scene/materials/lit-material.js
@@ -87,6 +87,7 @@ class LitMaterial extends Material {
 
     hasClearCoatNormals = false;
 
+    /** @ignore */
     getShaderVariant(params) {
 
         options.usedUvs = this.usedUvs.slice();

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -20,7 +20,6 @@ import { getDefaultMaterial } from './default-material.js';
 import { ShaderChunks } from '../shader-lib/shader-chunks.js';
 
 /**
- * @import { BindGroupFormat } from '../../platform/graphics/bind-group-format.js';
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { Light } from '../light.js';
  * @import { MeshInstance } from '../mesh-instance.js'
@@ -61,7 +60,6 @@ let id = 0;
  * @property {number} pass - The shader pass.
  * @property {Light[][]} sortedLights - The sorted lights.
  * @property {UniformBufferFormat|undefined} viewUniformFormat - The view uniform format.
- * @property {BindGroupFormat|undefined} viewBindGroupFormat - The view bind group format.
  * @property {VertexFormat} vertexFormat - The vertex format.
  * @ignore
  */

--- a/src/scene/materials/shader-material.js
+++ b/src/scene/materials/shader-material.js
@@ -147,7 +147,7 @@ class ShaderMaterial extends Material {
             shaderChunks: this.shaderChunks // override chunks from the material
         };
 
-        const processingOptions = new ShaderProcessorOptions(params.viewUniformFormat, params.viewBindGroupFormat, params.vertexFormat);
+        const processingOptions = new ShaderProcessorOptions(params.viewUniformFormat, params.vertexFormat);
 
         const library = getProgramLibrary(params.device);
         library.register('shader-material', shaderGeneratorShader);

--- a/src/scene/materials/shader-material.js
+++ b/src/scene/materials/shader-material.js
@@ -128,6 +128,7 @@ class ShaderMaterial extends Material {
         return this;
     }
 
+    /** @ignore */
     getShaderVariant(params) {
 
         const { objDefs } = params;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -898,7 +898,7 @@ class StandardMaterial extends Material {
             options = this.onUpdateShader(options);
         }
 
-        const processingOptions = new ShaderProcessorOptions(params.viewUniformFormat, params.viewBindGroupFormat, params.vertexFormat);
+        const processingOptions = new ShaderProcessorOptions(params.viewUniformFormat, params.vertexFormat);
 
         const library = getProgramLibrary(device);
         library.register('standard', standard);

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -868,6 +868,7 @@ class StandardMaterial extends Material {
         this._processParameters('_activeLightingParams');
     }
 
+    /** @ignore */
     getShaderVariant(params) {
 
         const { device, scene, pass, objDefs, sortedLights, cameraShaderParams } = params;

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -24,7 +24,6 @@ import { array } from '../core/array-utils.js';
 import { PickerId } from './picker-id.js';
 
 /**
- * @import { BindGroupFormat } from '../platform/graphics/bind-group-format.js'
  * @import { Camera } from './camera.js'
  * @import { GSplatInstance } from './gsplat/gsplat-instance.js'
  * @import { GraphicsDevice } from '../platform/graphics/graphics-device.js'
@@ -752,12 +751,11 @@ class MeshInstance {
      * @param {Scene} scene - The scene.
      * @param {CameraShaderParams} cameraShaderParams - The camera shader parameters.
      * @param {UniformBufferFormat} [viewUniformFormat] - The format of the view uniform buffer.
-     * @param {BindGroupFormat} [viewBindGroupFormat] - The format of the view bind group.
      * @param {any} [sortedLights] - Array of arrays of lights.
      * @returns {ShaderInstance} - the shader instance.
      * @ignore
      */
-    getShaderInstance(shaderPass, lightHash, scene, cameraShaderParams, viewUniformFormat, viewBindGroupFormat, sortedLights) {
+    getShaderInstance(shaderPass, lightHash, scene, cameraShaderParams, viewUniformFormat, sortedLights) {
 
         const shaderDefs = this._shaderDefs;
 
@@ -795,7 +793,6 @@ class MeshInstance {
                     pass: shaderPass,
                     sortedLights: sortedLights,
                     viewUniformFormat: viewUniformFormat,
-                    viewBindGroupFormat: viewBindGroupFormat,
                     vertexFormat: this.mesh.vertexBuffer?.format
                 });
 

--- a/src/scene/particle-system/particle-material.js
+++ b/src/scene/particle-system/particle-material.js
@@ -37,6 +37,7 @@ class ParticleMaterial extends Material {
         Debug.assert(emitter);
     }
 
+    /** @ignore */
     getShaderVariant(params) {
 
         const { device, scene, cameraShaderParams, objDefs } = params;

--- a/src/scene/particle-system/particle-material.js
+++ b/src/scene/particle-system/particle-material.js
@@ -67,7 +67,7 @@ class ParticleMaterial extends Material {
             customFace: this.emitter.orientation !== PARTICLEORIENTATION_SCREEN
         };
 
-        const processingOptions = new ShaderProcessorOptions(params.viewUniformFormat, params.viewBindGroupFormat, params.vertexFormat);
+        const processingOptions = new ShaderProcessorOptions(params.viewUniformFormat, params.vertexFormat);
 
         const library = getProgramLibrary(device);
         library.register('particle', particle);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -28,6 +28,7 @@ import { BINDGROUP_VIEW } from '../../platform/graphics/constants.js';
  * @import { MeshInstance } from '../mesh-instance.js'
  * @import { RenderTarget } from '../../platform/graphics/render-target.js'
  * @import { Scene } from '../scene.js'
+ * @import { UniformBufferFormat } from '../../platform/graphics/uniform-buffer-format.js'
  * @import { WorldClusters } from '../lighting/world-clusters.js'
  */
 
@@ -513,7 +514,7 @@ class ForwardRenderer extends Renderer {
     }
 
     // execute first pass over draw calls, in order to update materials / shaders
-    renderForwardPrepareMaterials(camera, renderTarget, drawCalls, sortedLights, layer, pass) {
+    renderForwardPrepareMaterials(camera, renderTarget, drawCalls, sortedLights, layer, pass, viewUniformFormat) {
 
         // fog params from the scene, or overridden by the camera
         const fogParams = camera.fogParams ?? this.scene.fog;
@@ -594,7 +595,7 @@ class ForwardRenderer extends Renderer {
                 }
             }
 
-            const shaderInstance = drawCall.getShaderInstance(pass, lightHash, scene, shaderParams, this.viewUniformFormat, this.viewBindGroupFormat, sortedLights);
+            const shaderInstance = drawCall.getShaderInstance(pass, lightHash, scene, shaderParams, viewUniformFormat, sortedLights);
 
             addCall(drawCall, shaderInstance, material !== prevMaterial, !prevMaterial || lightMask !== prevLightMask);
 
@@ -606,7 +607,7 @@ class ForwardRenderer extends Renderer {
         return _drawCallList;
     }
 
-    renderForwardInternal(camera, preparedCalls, sortedLights, pass, drawCallback, flipFaces, viewBindGroups) {
+    renderForwardInternal(camera, preparedCalls, sortedLights, pass, drawCallback, flipFaces) {
         const device = this.device;
         const scene = this.scene;
         const passFlag = 1 << pass;
@@ -706,8 +707,9 @@ class ForwardRenderer extends Renderer {
 
                     if (device.supportsUniformBuffers) {
 
-                        const viewBindGroup = viewBindGroups[v];
-                        device.setBindGroup(BINDGROUP_VIEW, viewBindGroup);
+                        // per-view dynamic bind group + offset captured during setupViewUniformBuffers
+                        this._viewOffsetScratch[0] = this._viewBindGroupOffsets[v];
+                        device.setBindGroup(BINDGROUP_VIEW, this._viewBindGroups[v], this._viewOffsetScratch);
 
                     } else {
 
@@ -741,17 +743,17 @@ class ForwardRenderer extends Renderer {
         }
     }
 
-    renderForward(camera, renderTarget, allDrawCalls, sortedLights, pass, drawCallback, layer, flipFaces, viewBindGroups) {
+    renderForward(camera, renderTarget, allDrawCalls, sortedLights, pass, drawCallback, layer, flipFaces, viewUniformFormat) {
 
         // #if _PROFILER
         const forwardStartTime = now();
         // #endif
 
         // run first pass over draw calls and handle material / shader updates
-        const preparedCalls = this.renderForwardPrepareMaterials(camera, renderTarget, allDrawCalls, sortedLights, layer, pass);
+        const preparedCalls = this.renderForwardPrepareMaterials(camera, renderTarget, allDrawCalls, sortedLights, layer, pass, viewUniformFormat);
 
         // render mesh instances
-        this.renderForwardInternal(camera, preparedCalls, sortedLights, pass, drawCallback, flipFaces, viewBindGroups);
+        this.renderForwardInternal(camera, preparedCalls, sortedLights, pass, drawCallback, flipFaces);
 
         _drawCallList.clear();
 
@@ -770,8 +772,6 @@ class ForwardRenderer extends Renderer {
      * @param {boolean} transparent - True if transparent sublayer should be rendered, opaque
      * otherwise.
      * @param {number} shaderPass - A type of shader to use during rendering.
-     * @param {BindGroup[]} viewBindGroups - An array storing the view level bing groups (can be
-     * empty array, and this function populates if per view).
      * @param {object} [options] - Object for passing optional arguments.
      * @param {boolean} [options.clearColor] - True if the color buffer should be cleared.
      * @param {boolean} [options.clearDepth] - True if the depth buffer should be cleared.
@@ -781,8 +781,14 @@ class ForwardRenderer extends Renderer {
      * @param {MeshInstance[]} [options.meshInstances] - The mesh instances to be rendered. Use
      * when layer is not provided.
      * @param {object} [options.splitLights] - The split lights to be used for clustered lighting.
+     * @param {Function} [options.drawCallback] - Function called before each mesh instance is
+     * rendered, with the mesh instance as the argument.
+     * @param {UniformBufferFormat} [options.viewUniformFormat] - A custom view uniform buffer
+     * format to use for this layer. When not provided, the renderer's default view uniform format
+     * is used. The shaders are processed and the view uniform buffer is set up using the same
+     * format, so they always match.
      */
-    renderForwardLayer(camera, renderTarget, layer, transparent, shaderPass, viewBindGroups, options = {}) {
+    renderForwardLayer(camera, renderTarget, layer, transparent, shaderPass, options = {}) {
 
         const { scene, device } = this;
         const clusteredLightingEnabled = scene.clusteredLightingEnabled;
@@ -844,7 +850,16 @@ class ForwardRenderer extends Renderer {
 
         const viewList = this.setCameraUniforms(camera, renderTarget);
         if (device.supportsUniformBuffers) {
-            this.setupViewUniformBuffers(viewBindGroups, this.viewUniformFormat, this.viewBindGroupFormat, viewList);
+            // ensure the default view uniform format exists - renderForwardLayer can run outside
+            // the main frame update (e.g. the picker and lightmapper passes)
+            this.initViewUniformFormat(scene.clusteredLightingEnabled);
+        }
+
+        // callers may supply a custom view uniform format, otherwise the renderer default is used
+        const viewUniformFormat = options.viewUniformFormat ?? this.viewUniformFormat;
+
+        if (device.supportsUniformBuffers) {
+            this.setupViewUniformBuffers(viewUniformFormat, viewList);
         }
 
         // clearing - do it after the view bind groups are set up, to avoid overriding those
@@ -864,10 +879,10 @@ class ForwardRenderer extends Renderer {
             visible,
             splitLights,
             shaderPass,
-            null,
+            options.drawCallback ?? null,
             layer,
             flipFaces,
-            viewBindGroups);
+            viewUniformFormat);
 
         if (layer) {
             layer._forwardDrawCalls += this._forwardDrawCalls - forwardDrawCalls;

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -312,7 +312,7 @@ class RenderPassForward extends RenderPass {
 
             const renderTarget = renderAction.renderTarget ?? device.backBuffer;
             renderer.renderForwardLayer(camera.camera, renderTarget, layer, transparent,
-                shaderPass, renderAction.viewBindGroups, options);
+                shaderPass, options);
 
             // Revert temp frame stuff
             // TODO: this should not be here, as each rendering / clearing should explicitly set up what

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1,4 +1,4 @@
-import { Debug, DebugHelper } from '../../core/debug.js';
+import { Debug } from '../../core/debug.js';
 import { now } from '../../core/time.js';
 import { BlueNoise } from '../../core/math/blue-noise.js';
 import { Vec2 } from '../../core/math/vec2.js';
@@ -9,9 +9,8 @@ import { Mat4 } from '../../core/math/mat4.js';
 import { BoundingSphere } from '../../core/shape/bounding-sphere.js';
 import {
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL,
-    BINDGROUP_MESH, BINDGROUP_VIEW, UNIFORM_BUFFER_DEFAULT_SLOT_NAME,
+    BINDGROUP_MESH, BINDGROUP_VIEW,
     UNIFORMTYPE_MAT4, UNIFORMTYPE_MAT3, UNIFORMTYPE_VEC4, UNIFORMTYPE_VEC3, UNIFORMTYPE_IVEC3, UNIFORMTYPE_VEC2, UNIFORMTYPE_FLOAT, UNIFORMTYPE_INT, UNIFORMTYPE_UINT,
-    SHADERSTAGE_VERTEX, SHADERSTAGE_FRAGMENT,
     CULLFACE_NONE,
     BINDGROUP_MESH_UB,
     FRONTFACE_CCW,
@@ -19,9 +18,8 @@ import {
 } from '../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { UniformBuffer } from '../../platform/graphics/uniform-buffer.js';
-import { BindGroup, DynamicBindGroup } from '../../platform/graphics/bind-group.js';
+import { DynamicBindGroup } from '../../platform/graphics/bind-group.js';
 import { UniformFormat, UniformBufferFormat } from '../../platform/graphics/uniform-buffer-format.js';
-import { BindGroupFormat, BindUniformBufferFormat } from '../../platform/graphics/bind-group-format.js';
 import {
     VIEW_CENTER, LIGHTTYPE_DIRECTIONAL, MASK_AFFECT_DYNAMIC, MASK_AFFECT_LIGHTMAPPED, MASK_BAKE,
     SHADOWUPDATE_NONE, SHADOWUPDATE_THISFRAME,
@@ -40,8 +38,10 @@ import { FramePassUpdateClustered } from './frame-pass-update-clustered.js';
 import { Camera } from '../camera.js';
 
 /**
+ * @import { BindGroup } from '../../platform/graphics/bind-group.js'
  * @import { CulledInstances } from '../layer.js'
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ * @import { RenderView } from '../render-view.js'
  * @import { LayerComposition } from '../composition/layer-composition.js'
  * @import { Light } from '../light.js'
  * @import { MeshInstance } from '../mesh-instance.js'
@@ -157,6 +157,40 @@ class Renderer {
      */
     dirLightShadows = new Map();
 
+    /**
+     * Shared non-persistent view uniform buffers, keyed by their uniform format. Reused every frame
+     * and bound via the dynamic buffer system, so no per-render-action view bind groups are needed.
+     *
+     * @type {WeakMap<UniformBufferFormat, UniformBuffer>}
+     */
+    _viewUniformBuffers = new WeakMap();
+
+    /**
+     * Reusable receiver for a view uniform buffer's dynamic bind group + offset.
+     *
+     * @type {DynamicBindGroup}
+     */
+    _dynamicViewBindGroup = new DynamicBindGroup();
+
+    /**
+     * Per-view dynamic bind groups, captured during multiview view-uniform setup (allocations may
+     * span dynamic buffers, so the bind group is captured per view alongside its offset).
+     *
+     * @type {BindGroup[]}
+     */
+    _viewBindGroups = [];
+
+    /** @type {number[]} */
+    _viewBindGroupOffsets = [];
+
+    /**
+     * Reused single-element array passed as the dynamic offsets to per-view setBindGroup, to avoid
+     * per-draw allocation.
+     *
+     * @type {number[]}
+     */
+    _viewOffsetScratch = [0];
+
     blueNoise = new BlueNoise(123);
 
     /**
@@ -194,9 +228,8 @@ class Renderer {
                 this._shadowRendererLocal, this.lightTextureAtlas);
         }
 
-        // view bind group format with its uniform buffer format
+        // format of the view uniform buffer
         this.viewUniformFormat = null;
-        this.viewBindGroupFormat = null;
 
         // timing
         this._skinTime = 0;
@@ -669,7 +702,7 @@ class Renderer {
         this.viewPosId.setValue(vp);
     }
 
-    initViewBindGroupFormat(isClustered) {
+    initViewUniformFormat(isClustered) {
 
         if (this.device.supportsUniformBuffers && !this.viewUniformFormat) {
 
@@ -705,32 +738,6 @@ class Renderer {
             }
 
             this.viewUniformFormat = new UniformBufferFormat(this.device, uniforms);
-
-            // format of the view bind group - contains single uniform buffer, and some textures
-            const formats = [
-
-                // uniform buffer needs to be first, as the shader processor assumes slot 0 for it
-                new BindUniformBufferFormat(UNIFORM_BUFFER_DEFAULT_SLOT_NAME, SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT)
-
-                // disable view level textures, as they consume texture slots. They get automatically added to mesh bind group
-                // for the meshes that uses them
-                // new BindTextureFormat('lightsTexture', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT),
-                // new BindTextureFormat('shadowAtlasTexture', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_DEPTH),
-                // new BindTextureFormat('cookieAtlasTexture', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_FLOAT),
-
-                // new BindTextureFormat('areaLightsLutTex1', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_FLOAT),
-                // new BindTextureFormat('areaLightsLutTex2', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_FLOAT)
-            ];
-
-            // disable view level textures, as they consume texture slots. They get automatically added to mesh bind group
-            // for the meshes that uses them
-            // if (isClustered) {
-            //     formats.push(...[
-            //         new BindTextureFormat('clusterWorldTexture', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT)
-            //     ]);
-            // }
-
-            this.viewBindGroupFormat = new BindGroupFormat(this.device, formats);
         }
     }
 
@@ -739,7 +746,7 @@ class Renderer {
      */
     setupViewUniforms(view, index) {
 
-        // any view uniforms need to be part of the view uniform buffer, see initViewBindGroupFormat
+        // any view uniforms need to be part of the view uniform buffer, see initViewUniformFormat
         this.projId.setValue(view.projMat.data);
         this.projSkyboxId.setValue(view.projMat.data);
         this.viewId.setValue(view.viewOffMat.data);
@@ -750,43 +757,54 @@ class Renderer {
         this.viewIndexId.setValue(index);
     }
 
-    setupViewUniformBuffers(viewBindGroups, viewUniformFormat, viewBindGroupFormat, viewList) {
-
-        Debug.assert(Array.isArray(viewBindGroups), 'viewBindGroups must be an array');
-        const { device } = this;
-
-        // make sure we have bind group for each view
-        const viewCount = viewList?.length ?? 1;
-        while (viewBindGroups.length < viewCount) {
-            const ub = new UniformBuffer(device, viewUniformFormat, false);
-            const bg = new BindGroup(device, viewBindGroupFormat, ub);
-            DebugHelper.setName(bg, `ViewBindGroup_${bg.id}`);
-            viewBindGroups.push(bg);
+    /**
+     * Returns the shared non-persistent view uniform buffer for the given format, creating it on
+     * first use. It is bound via the dynamic buffer system, so it needs no explicit bind group.
+     *
+     * @param {UniformBufferFormat} viewUniformFormat - The view uniform buffer format.
+     * @returns {UniformBuffer} The shared view uniform buffer.
+     */
+    getViewUniformBuffer(viewUniformFormat) {
+        let ub = this._viewUniformBuffers.get(viewUniformFormat);
+        if (!ub) {
+            ub = new UniformBuffer(this.device, viewUniformFormat, false);
+            this._viewUniformBuffers.set(viewUniformFormat, ub);
         }
+        return ub;
+    }
+
+    /**
+     * Sets up the view uniform buffer(s) for the current camera and binds the single-view case.
+     * Uses the shared per-format view uniform buffer, sourcing its bind group + dynamic offset from
+     * the dynamic buffer system (no per-render-action view bind groups).
+     *
+     * @param {UniformBufferFormat} viewUniformFormat - The view uniform buffer format.
+     * @param {RenderView[]|null} viewList - The list of XR views for multiview, or null for a
+     * single view.
+     */
+    setupViewUniformBuffers(viewUniformFormat, viewList) {
+
+        Debug.assert(viewUniformFormat);
+        const { device } = this;
+        const ub = this.getViewUniformBuffer(viewUniformFormat);
 
         if (viewList) {
 
+            // multiview: set up a dynamic bind group + offset per view, captured for per-view
+            // binding in the render loop (allocations may span dynamic buffers, so capture both)
+            const viewCount = viewList.length;
             for (let i = 0; i < viewCount; i++) {
-
-                // set up view uniforms
-                const view = viewList[i];
-                this.setupViewUniforms(view, i);
-
-                // update view bind group / uniforms
-                const viewBindGroup = viewBindGroups[i];
-                viewBindGroup.defaultUniformBuffer.update();
-                viewBindGroup.update();
+                this.setupViewUniforms(viewList[i], i);
+                ub.update(this._dynamicViewBindGroup);
+                this._viewBindGroups[i] = this._dynamicViewBindGroup.bindGroup;
+                this._viewBindGroupOffsets[i] = this._dynamicViewBindGroup.offsets[0];
             }
+
         } else {
 
-            const viewBindGroup = viewBindGroups[0];
-            viewBindGroup.defaultUniformBuffer.update();
-            viewBindGroup.update();
-        }
-
-        // bind it when a single view is used, otherwise this is handled per view inside rendering loop
-        if (!viewList) {
-            device.setBindGroup(BINDGROUP_VIEW, viewBindGroups[0]);
+            // single view: uniforms were set by setCameraUniforms; update the buffer and bind
+            ub.update(this._dynamicViewBindGroup);
+            device.setBindGroup(BINDGROUP_VIEW, this._dynamicViewBindGroup.bindGroup, this._dynamicViewBindGroup.offsets);
         }
     }
 
@@ -1359,7 +1377,7 @@ class Renderer {
 
         this.clustersDebugRendered = false;
 
-        this.initViewBindGroupFormat(this.scene.clusteredLightingEnabled);
+        this.initViewUniformFormat(this.scene.clusteredLightingEnabled);
 
         // no valid shadows at the start of the frame
         this.dirLightShadows.clear();

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -5,8 +5,8 @@ import { Mat4 } from '../../core/math/mat4.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Vec4 } from '../../core/math/vec4.js';
 import {
-    SEMANTIC_POSITION, SHADERSTAGE_FRAGMENT, SHADERSTAGE_VERTEX,
-    UNIFORMTYPE_MAT4, UNIFORM_BUFFER_DEFAULT_SLOT_NAME
+    SEMANTIC_POSITION,
+    UNIFORMTYPE_MAT4
 } from '../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { drawQuadWithShader } from '../graphics/quad-render-utils.js';
@@ -24,7 +24,6 @@ import { ShaderPass } from '../shader-pass.js';
 import { ShaderUtils } from '../shader-lib/shader-utils.js';
 import { LightCamera } from './light-camera.js';
 import { UniformBufferFormat, UniformFormat } from '../../platform/graphics/uniform-buffer-format.js';
-import { BindUniformBufferFormat, BindGroupFormat } from '../../platform/graphics/bind-group-format.js';
 import { BlendState } from '../../platform/graphics/blend-state.js';
 
 /**
@@ -102,9 +101,8 @@ class ShadowRenderer {
         // uniforms
         this.shadowMapLightRadiusId = scope.resolve('light_radius');
 
-        // view bind group format with its uniform buffer format
+        // format of the view uniform buffer
         this.viewUniformFormat = null;
-        this.viewBindGroupFormat = null;
 
         // blend states
         this.blendStateWrite = new BlendState();
@@ -339,7 +337,7 @@ class ShadowRenderer {
             // Uniforms II (shadow): meshInstance overrides
             meshInstance.setParameters(device, passFlags);
 
-            const shaderInstance = meshInstance.getShaderInstance(shadowPass, 0, scene, cameraShaderParams, this.viewUniformFormat, this.viewBindGroupFormat);
+            const shaderInstance = meshInstance.getShaderInstance(shadowPass, 0, scene, cameraShaderParams, this.viewUniformFormat);
             const shadowShader = shaderInstance.shader;
             Debug.assert(shadowShader, `no shader for pass ${shadowPass}`, material);
 
@@ -447,7 +445,7 @@ class ShadowRenderer {
         const renderer = this.renderer;
         renderer.setCameraUniforms(shadowCam, rt);
         if (device.supportsUniformBuffers) {
-            renderer.setupViewUniformBuffers(lightRenderData.viewBindGroups, this.viewUniformFormat, this.viewBindGroupFormat, null);
+            renderer.setupViewUniformBuffers(this.viewUniformFormat, null);
         }
 
         renderer.setupViewport(shadowCam, rt);
@@ -554,7 +552,7 @@ class ShadowRenderer {
         DebugGraphics.popGpuMarker(device);
     }
 
-    initViewBindGroupFormat() {
+    initViewUniformFormat() {
 
         if (this.device.supportsUniformBuffers && !this.viewUniformFormat) {
 
@@ -562,16 +560,11 @@ class ShadowRenderer {
             this.viewUniformFormat = new UniformBufferFormat(this.device, [
                 new UniformFormat('matrix_viewProjection', UNIFORMTYPE_MAT4)
             ]);
-
-            // format of the view bind group - contains single uniform buffer, and no textures
-            this.viewBindGroupFormat = new BindGroupFormat(this.device, [
-                new BindUniformBufferFormat(UNIFORM_BUFFER_DEFAULT_SLOT_NAME, SHADERSTAGE_VERTEX | SHADERSTAGE_FRAGMENT)
-            ]);
         }
     }
 
     frameUpdate() {
-        this.initViewBindGroupFormat();
+        this.initViewUniformFormat();
     }
 }
 


### PR DESCRIPTION
Replaces the per-render-action view bind group storage and the dedicated view bind group format with the engine's existing dynamic uniform buffer mechanism, and lets the standard forward layer path own all view-uniform setup. This is a step toward making `RenderPassForward` a generic, layer/camera-agnostic pass.

**View uniforms:**
- Remove `viewBindGroups` storage from `RenderAction`, `LightRenderData`, and the picker / prepass / lightmapper passes.
- The view uniform buffer is now a shared non-persistent buffer (per uniform format, cached on the renderer) bound via the dynamic buffer system — no per-render-action bind groups and no manual lifetime / pooling management (the dynamic buffer system owns recycling).
- `setupViewUniformBuffers(viewUniformFormat, viewList)` is the single entry point; multiview captures the per-view bind group + dynamic offset.

**View bind group format:**
- Drop `viewBindGroupFormat` entirely. The view bind group has no textures, so its single-UB layout comes from the actually-bound dynamic buffer; shaders only need the view *uniform* format. `ShaderProcessorOptions` no longer takes a bind group format, and it is removed from the renderers, `MeshInstance.getShaderInstance`, and the material `getShaderVariant` path. `initViewBindGroupFormat` is renamed `initViewUniformFormat`.

**Forward layer path:**
- `renderForwardLayer` ensures the view uniform format lazily (so the picker and lightmapper no longer pre-seed it) and accepts optional `drawCallback` and `viewUniformFormat` arguments. A custom view format is threaded into both the view buffer setup and shader generation so they always match.
- The picker now renders through `renderForwardLayer` (instead of the low-level `renderForward`) with its own minimal view format, dropping the `dispatchGlobalLights` / `shadowAtlasParams` workaround.

**Cleanup:**
- Remove `LayerComposition#destroyRenderActions` / `destroy` (render actions no longer hold GPU resources) and inline the reset into `_update`.

**API:**
- Internal renderer refactor; no public API change. `RenderPassForward` is unchanged; `renderForwardLayer` only gains optional arguments.

Verified across ~30 graphics examples plus picker (color + depth pick) on WebGL2 and WebGPU.