### PR TITLE
fix(gsplat): apply lodRangeMin/lodRangeMax from component init data

### DIFF
--- a/examples/src/examples/gaussian-splatting/splat-portal.example.mjs
+++ b/examples/src/examples/gaussian-splatting/splat-portal.example.mjs
@@ -346,7 +346,12 @@ assetListLoader.load(() => {
         const entity = new pc.Entity(`${config.name}Splat`);
         entity.addComponent('gsplat', {
             asset: config.asset,
-            layers: [config.layer.id]
+            layers: [config.layer.id],
+            lodBaseDistance: config.lodBaseDistance,
+            lodMultiplier: config.lodMultiplier,
+            // start with the lowest LOD until the first frame settles, then unlock the full range
+            lodRangeMin: 4,
+            lodRangeMax: 5
         });
 
         // "from" pose - the portal-aligned natural transform (used while you live in this scene)
@@ -365,13 +370,6 @@ assetListLoader.load(() => {
         const startMat = config.layer === insideLayer ? throughTransform : fromTransform;
         applyMatToEntity(entity, startMat);
         app.root.addChild(entity);
-
-        const gs = /** @type {any} */ (entity.gsplat);
-        gs.lodBaseDistance = config.lodBaseDistance;
-        gs.lodMultiplier = config.lodMultiplier;
-        // start with the lowest LOD until the first frame settles, then unlock the full range
-        gs.lodRangeMin = 4;
-        gs.lodRangeMax = 5;
 
         sceneStates.set(config.layer, { entity, fromTransform, throughTransform });
     });

--- a/examples/src/examples/gaussian-splatting/world.example.mjs
+++ b/examples/src/examples/gaussian-splatting/world.example.mjs
@@ -144,7 +144,9 @@ assetListLoader.load(() => {
     // Create skatepark entity
     const skatepark = new pc.Entity('Skatepark');
     skatepark.addComponent('gsplat', {
-        asset: assets.skatepark
+        asset: assets.skatepark,
+        lodRangeMin: presetData.range[0],
+        lodRangeMax: presetData.range[1]
     });
     skatepark.setLocalPosition(0, 0, 0);
     const [rotX, rotY, rotZ] = /** @type {[number, number, number]} */ (config.eulerAngles);
@@ -154,8 +156,6 @@ assetListLoader.load(() => {
 
     // Apply LOD distances to skatepark
     const gs = /** @type {any} */ (skatepark.gsplat);
-    gs.lodRangeMin = presetData.range[0];
-    gs.lodRangeMax = presetData.range[1];
     gs.lodBaseDistance = presetData.lodBaseDistance;
     gs.lodMultiplier = 4;
 

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -28,6 +28,8 @@ const _properties = [
     'unified',
     'lodBaseDistance',
     'lodMultiplier',
+    'lodRangeMin',
+    'lodRangeMax',
     'castShadows',
     'material',
     'asset',

--- a/test/framework/components/gsplat/component.test.mjs
+++ b/test/framework/components/gsplat/component.test.mjs
@@ -1,0 +1,95 @@
+import { expect } from 'chai';
+
+import { Entity } from '../../../../src/framework/entity.js';
+import { createApp } from '../../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
+
+describe('GSplatComponent', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    describe('#addComponent', function () {
+
+        it('creates a component with sensible defaults', function () {
+            const e = new Entity();
+            e.addComponent('gsplat');
+
+            expect(e.gsplat).to.exist;
+            expect(e.gsplat.enabled).to.equal(true);
+            expect(e.gsplat.castShadows).to.equal(false);
+            expect(e.gsplat.lodBaseDistance).to.equal(5);
+            expect(e.gsplat.lodMultiplier).to.equal(3);
+            expect(e.gsplat.lodRangeMin).to.equal(0);
+            expect(e.gsplat.lodRangeMax).to.equal(99);
+        });
+
+        it('initializes LOD properties from data', function () {
+            const e = new Entity();
+            e.addComponent('gsplat', {
+                castShadows: true,
+                lodBaseDistance: 8,
+                lodMultiplier: 2,
+                lodRangeMin: 2,
+                lodRangeMax: 7
+            });
+
+            expect(e.gsplat.castShadows).to.equal(true);
+            expect(e.gsplat.lodBaseDistance).to.equal(8);
+            expect(e.gsplat.lodMultiplier).to.equal(2);
+            expect(e.gsplat.lodRangeMin).to.equal(2);
+            expect(e.gsplat.lodRangeMax).to.equal(7);
+        });
+
+    });
+
+    describe('#properties', function () {
+
+        it('clamps lodBaseDistance to a minimum of 0.1', function () {
+            const e = new Entity();
+            e.addComponent('gsplat');
+            e.gsplat.lodBaseDistance = 0;
+            expect(e.gsplat.lodBaseDistance).to.equal(0.1);
+        });
+
+        it('clamps lodMultiplier to a minimum of 1.2', function () {
+            const e = new Entity();
+            e.addComponent('gsplat');
+            e.gsplat.lodMultiplier = 1;
+            expect(e.gsplat.lodMultiplier).to.equal(1.2);
+        });
+
+    });
+
+    describe('#cloneComponent', function () {
+
+        it('copies LOD properties to the clone', function () {
+            const e = new Entity();
+            e.addComponent('gsplat', {
+                castShadows: true,
+                lodBaseDistance: 8,
+                lodMultiplier: 2,
+                lodRangeMin: 3,
+                lodRangeMax: 6
+            });
+
+            const clone = e.clone();
+
+            expect(clone.gsplat.castShadows).to.equal(true);
+            expect(clone.gsplat.lodBaseDistance).to.equal(8);
+            expect(clone.gsplat.lodMultiplier).to.equal(2);
+            expect(clone.gsplat.lodRangeMin).to.equal(3);
+            expect(clone.gsplat.lodRangeMax).to.equal(6);
+        });
+
+    });
+});


### PR DESCRIPTION
## Description

`lodRangeMin` and `lodRangeMax` were added to `GSplatComponent` in #8908, but were never added to the gsplat component system's `_properties` list. As a result they were:

- silently **ignored** when passed as initialization data to `addComponent('gsplat', { lodRangeMin, lodRangeMax })`, and
- **dropped on clone** — `cloneComponent` copies state via the same `_properties` list, so duplicating/templating/`entity.clone()`-ing a gsplat entity reset both properties back to their defaults (`0` / `99`).

This adds them to `_properties`, next to the sibling `lodBaseDistance` / `lodMultiplier` props that were already there. The component setters already exist and propagate to the `GSplatPlacement`, so no other engine change is needed.

### Also included
- **Test**: new `test/framework/components/gsplat/component.test.mjs` covering defaults, init-from-data, setter clamps, and clone preservation (there was no gsplat component test before). I confirmed the init/clone cases fail without the `_properties` change.
- **Examples**: `splat-portal` and `world` now pass their *static* LOD values directly to `addComponent` rather than assigning them immediately afterwards. This is behavior-preserving — init data is applied before `asset`, so `_onGSplatAssetLoad` copies the identical values onto the placement. The other gsplat LOD examples (`lod-streaming`, `lod-streaming-sh`, `relighting`, `vr-lod`, `downtown`, `depth-of-field`, `billions`) set these dynamically via preset/toggle handlers or from the loaded asset's LOD count, so they're intentionally left as-is.

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change