### PR TITLE
Free font textures when a font asset is unloaded

### DIFF
--- a/src/framework/font/font.js
+++ b/src/framework/font/font.js
@@ -1,6 +1,7 @@
 import { FONT_MSDF } from './constants.js';
 
 /**
+ * @import { ResourceLoader } from '../handlers/loader.js'
  * @import { Texture } from '../../platform/graphics/texture.js'
  */
 
@@ -33,9 +34,42 @@ class Font {
          */
         this.intensity = 0.0;
 
+        /**
+         * The resource loader used to load the font textures. Set by the {@link FontHandler} so
+         * that {@link Font#destroy} can release the textures from the loader cache. Null for fonts
+         * created without going through the resource loader.
+         *
+         * @type {ResourceLoader|null}
+         * @ignore
+         */
+        this._loader = null;
+
         // json data
         this._data = null;
         this.data = data;
+    }
+
+    /**
+     * Frees the GPU textures owned by the font and removes them from the resource loader cache.
+     * Called automatically when the owning font asset is unloaded (see {@link Asset#unload}).
+     */
+    destroy() {
+        const textures = this.textures;
+        if (textures) {
+            for (let i = 0; i < textures.length; i++) {
+                const texture = textures[i];
+
+                // font textures are loaded directly through the resource loader (keyed by their
+                // url, which is stored as the texture name), so remove the cache entry to avoid
+                // handing back a destroyed texture on a subsequent load
+                this._loader?.clearCache(texture.name, 'texture');
+                texture.destroy();
+            }
+            this.textures = null;
+        }
+
+        this._loader = null;
+        this._data = null;
     }
 
     set data(value) {

--- a/src/framework/handlers/font.js
+++ b/src/framework/handlers/font.js
@@ -140,6 +140,11 @@ class FontHandler extends ResourceHandler {
             // only textures
             font = new Font(data, null);
         }
+
+        // give the font access to the loader so it can release its textures from the cache when
+        // the asset is unloaded
+        font._loader = this._loader;
+
         return font;
     }
 

--- a/test/framework/handlers/font-handler.test.mjs
+++ b/test/framework/handlers/font-handler.test.mjs
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+
+import { Asset } from '../../../src/framework/asset/asset.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+describe('FontHandler', function () {
+
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    it('loads a font and its textures', function (done) {
+        const asset = new Asset('arial', 'font', {
+            url: 'http://localhost:3210/test/assets/fonts/arial.json'
+        });
+
+        app.assets.add(asset);
+        app.assets.load(asset);
+
+        asset.ready(function () {
+            const font = asset.resource;
+            expect(font).to.exist;
+            expect(font.textures).to.be.an('array').with.lengthOf(1);
+            done();
+        });
+
+        asset.on('error', err => done(new Error(err)));
+    });
+
+    // regression test for https://github.com/playcanvas/engine/issues/7033 - unloading a font
+    // asset must destroy its textures and remove them from the resource loader cache
+    it('destroys its textures and clears the loader cache on unload', function (done) {
+        const asset = new Asset('arial', 'font', {
+            url: 'http://localhost:3210/test/assets/fonts/arial.json'
+        });
+
+        app.assets.add(asset);
+        app.assets.load(asset);
+
+        asset.ready(function () {
+            // keep a reference to the textures, asset.resource becomes null after unload
+            const textures = asset.resource.textures.slice();
+            expect(textures).to.have.lengthOf(1);
+
+            // textures are present in the loader cache while loaded
+            textures.forEach((texture) => {
+                expect(app.loader.getFromCache(texture.name, 'texture')).to.equal(texture);
+            });
+
+            asset.unload();
+
+            // textures are destroyed (Texture.destroy clears the device reference) ...
+            textures.forEach((texture) => {
+                expect(texture.device).to.be.null;
+                // ... and removed from the loader cache so a reload does not return a dead texture
+                expect(app.loader.getFromCache(texture.name, 'texture')).to.be.undefined;
+            });
+
+            done();
+        });
+
+        asset.on('error', err => done(new Error(err)));
+    });
+
+});


### PR DESCRIPTION
Unloading a font asset (`asset.unload()`) did not release the GPU memory used by its textures. The `Font` resource had no `destroy()` method, so the asset system's generic `resource.destroy?.()` cleanup was a no-op and the textures stayed resident in VRAM. The textures were also left in the resource loader cache, so a subsequent load could return a stale entry.

Fixes #7033.

**Changes:**
- Add `Font.destroy()`, which destroys the font's textures and removes them from the resource loader cache.
- `FontHandler` now gives the created `Font` a reference to the resource loader so it can clear the cached texture entries on unload.

**API Changes:**
- Added `Font#destroy()`. It is called automatically when the owning font asset is unloaded; existing user workarounds that manually destroy the font's textures remain safe (double-destroy is a no-op).