### PR TITLE
Remove unused BindGroup JSDoc imports

### DIFF
--- a/src/extras/render-passes/render-pass-prepass.js
+++ b/src/extras/render-passes/render-pass-prepass.js
@@ -13,10 +13,6 @@ import {
 import { Color } from '../../core/math/color.js';
 import { FloatPacking } from '../../core/math/float-packing.js';
 
-/**
- * @import { BindGroup } from '../../platform/graphics/bind-group.js'
- */
-
 const tempMeshInstances = [];
 
 // uniform name of the depth texture

--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -6,7 +6,6 @@ import { UniformBufferFormat, UniformFormat } from '../../platform/graphics/unif
 import { SHADER_PICK, SHADER_DEPTH_PICK } from '../../scene/constants.js';
 
 /**
- * @import { BindGroup } from '../../platform/graphics/bind-group.js'
  * @import { CameraComponent } from '../components/camera/component.js'
  * @import { Scene } from '../../scene/scene.js'
  * @import { Layer } from '../../scene/layer.js'

--- a/src/framework/lightmapper/render-pass-lightmapper.js
+++ b/src/framework/lightmapper/render-pass-lightmapper.js
@@ -3,10 +3,6 @@ import { RenderPass } from '../../platform/graphics/render-pass.js';
 import { SHADER_FORWARD } from '../../scene/constants.js';
 
 /**
- * @import { BindGroup } from '../../platform/graphics/bind-group.js'
- */
-
-/**
  * A render pass implementing rendering of mesh instance receivers for light-mapper.
  */
 class RenderPassLightmapper extends RenderPass {

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -1,5 +1,4 @@
 /**
- * @import { BindGroup } from '../../platform/graphics/bind-group.js'
  * @import { Layer } from '../layer.js'
  * @import { RenderTarget } from '../../platform/graphics/render-target.js'
  */

--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -26,7 +26,6 @@ import { FloatPacking } from '../core/math/float-packing.js';
  */
 
 /**
- * @import { BindGroup } from '../platform/graphics/bind-group.js'
  * @import { Layer } from './layer.js'
  */
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -19,7 +19,6 @@ import { FramePassPostprocessing } from './frame-pass-postprocessing.js';
 import { BINDGROUP_VIEW } from '../../platform/graphics/constants.js';
 
 /**
- * @import { BindGroup } from '../../platform/graphics/bind-group.js'
  * @import { Camera } from '../camera.js'
  * @import { FrameGraph } from '../frame-graph.js'
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'


### PR DESCRIPTION
Removes leftover `@import { BindGroup }` JSDoc forward declarations that are no longer referenced, following the removal of the per-render-action view bind groups in #8967.

**Changes:**
- Drop the unused `@import { BindGroup }` type declaration from `render-pass-prepass`, `render-pass-picker`, `render-pass-lightmapper`, `render-action`, `light`, and `forward-renderer`.

No functional or public API change — JSDoc-only cleanup.