### PR TITLE
fix(gsplat): free SOG bundle archive memory after texture upload

### DIFF
--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -242,6 +242,17 @@ class SogBundleParser {
 
             await Promise.allSettled(promises);
 
+            // Release the encoded source bytes held by the embedded texture assets. These are
+            // views into the downloaded zip arrayBuffer; once the textures have been decoded and
+            // uploaded, dropping them lets the whole archive buffer be garbage collected. The
+            // decoded ImageBitmap retained by each texture (for re-upload on device context loss)
+            // is unaffected.
+            Object.values(textures).forEach((t) => {
+                if (t.file) {
+                    t.file.contents = null;
+                }
+            });
+
             const { assets } = this.app;
 
             asset.once('unload', () => {


### PR DESCRIPTION
## Summary

`SogBundleParser` keeps the downloaded `.sog` zip archive `ArrayBuffer` alive after parsing: each embedded texture `Asset` is created with `contents: file.data`, and for stored (non-deflate) entries `file.data` is a `Uint8Array` **view into the archive buffer**. As long as those assets retain `file.contents`, the whole archive cannot be garbage collected — duplicating the CPU footprint of the splat.

This nulls each embedded texture asset's `file.contents` once the textures have been decoded and uploaded (`await Promise.allSettled(promises)`), letting the archive buffer be freed.

The decoded source kept by each texture (for re-upload on device context loss) is standard engine behaviour for all textures and is intentionally left untouched, so context restore is unaffected.

Fixes #8080.

## Testing

Verified on the `shadow-soft` example (`bicycle.sog`, 14.8 MB archive):
- Baseline retained **14.1 MB** of encoded `file.contents` across the 7 embedded textures.
- With the fix: **0 bytes** retained; used JS heap ~10 MB lower; rendering intact.
