### PR TITLE
fix(gsplat): re-render work buffer for non-streaming splats on device restore

### DIFF
--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -18,6 +18,7 @@ import {
 import { Color } from '../../core/math/color.js';
 
 /**
+ * @import { EventHandle } from '../../core/event-handle.js'
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { GSplatPlacement } from './gsplat-placement.js'
  * @import { GSplatWorldState } from './gsplat-world-state.js'
@@ -132,6 +133,14 @@ class GSplatManager {
     /** @type {boolean} */
     sortNeeded = true;
 
+    /**
+     * Event handle for the graphics device restored event.
+     *
+     * @type {EventHandle|null}
+     * @private
+     */
+    _deviceRestoredEvent = null;
+
     /** @type {GraphNode} */
     cameraNode;
 
@@ -216,10 +225,18 @@ class GSplatManager {
 
         this.layer = layer;
         this._createRenderer(this.scene.gsplat.currentRenderer);
+
+        // On a graphics context restore the work buffer render target comes back blank (its
+        // contents are GPU-rendered, not re-uploaded from CPU like source textures), so the splats
+        // need re-materializing. See _onDeviceRestored.
+        this._deviceRestoredEvent = this.device.on('devicerestored', this._onDeviceRestored, this);
     }
 
     destroy() {
         this._destroyed = true;
+
+        this._deviceRestoredEvent?.off();
+        this._deviceRestoredEvent = null;
 
         // Tear down the CPU sorter while the renderer and world are still alive.
         this.destroyCpuSorting();
@@ -239,6 +256,23 @@ class GSplatManager {
         // Free the shared GPU-sort scratch after its borrowers (forward + shadow compactions) are gone.
         this._hybridScratch?.destroy();
         this._hybridScratch = null;
+    }
+
+    /**
+     * Handles a graphics context restore: the work buffer render target is recreated empty, so
+     * force a full rebuild and re-sort to re-materialize the splats from the (auto-restored) source
+     * textures.
+     *
+     * Skipped when the world has streaming octree instances: those destroy and asynchronously
+     * reload their source resources from URL via their own device-lost handling, and rebuilding the
+     * work buffer here would render from textures that have been destroyed (and not yet reloaded).
+     *
+     * @private
+     */
+    _onDeviceRestored() {
+        if (this.world.hasOctreeInstances) return;
+        this.world.invalidate({ workBuffer: true });
+        this.sortNeeded = true;
     }
 
     /**


### PR DESCRIPTION
## Summary

A non-streaming SOG/PLY gsplat disappears after a WebGL context lose/restore (the ground/rest of the scene renders, but the splat is gone).

**Cause:** the unified-gsplat **work buffer** is a render target whose contents are *GPU-rendered*, not re-uploaded from CPU like normal textures. On restore it is recreated empty, and nothing re-triggers the rebuild. (The streaming/octree path already handles this — its own `devicelost` handler reloads resources from URL, which drives a full rebuild.)

**Fix:** `GSplatManager` subscribes to `devicerestored` and forces a full work-buffer rebuild + re-sort (mirroring the existing `prepareRendererMode` invalidation). It is gated on `!world.hasOctreeInstances`:

- **Pure non-streaming world** — nothing else would rebuild → this handler does it.
- **World containing octree instances (pure or mixed)** — the octree's own reload already drives a *full* rebuild that re-renders all active splats (including direct ones), and forcing a rebuild here would render from octree source textures that were just destroyed for async reload → debug asserts. So it is correctly skipped.

The subscription uses the `EventHandle` returned by `on()` and removes it via `handle.off()` in `destroy()`.

## Testing

Lose/restore via `WEBGL_lose_context`, counting `"texture has been destroyed"` asserts:

| Scenario | Result |
|---|---|
| Non-streaming skull (`spherical-harmonics`), CPU sort | renders, 0 asserts |
| Non-streaming skull, GPU sort | renders, 0 asserts |
| Streaming (`lod-streaming`) | 0 asserts (gated out; matches clean baseline) |
| Mixed (`world` — octree + direct ply + SOG, ~4M splats) | all visible, 0 asserts |
