### PR TITLE
Decouple RenderPassForward from RenderAction via LayerRenderStep

### DIFF
--- a/src/extras/render-passes/frame-pass-camera-frame.js
+++ b/src/extras/render-passes/frame-pass-camera-frame.js
@@ -299,7 +299,7 @@ class FramePassCameraFrame extends FramePass {
 
     /**
      * Scan all RenderPassForward instances in the pass chain and mark the first / last
-     * render action per camera with firstCameraUse / lastCameraUse. This mirrors what
+     * layer render step per camera with firstCameraUse / lastCameraUse. This mirrors what
      * LayerComposition does for the non-CameraFrame path and ensures that beforePasses
      * collection and EVENT_PRERENDER / EVENT_POSTRENDER fire exactly once per camera.
      *
@@ -312,25 +312,25 @@ class FramePassCameraFrame extends FramePass {
         for (let i = 0; i < this.beforePasses.length; i++) {
             const pass = this.beforePasses[i];
             if (pass instanceof RenderPassForward) {
-                const actions = pass.renderActions;
-                for (let j = 0; j < actions.length; j++) {
-                    const ra = actions[j];
-                    const cam = ra.camera;
+                const steps = pass.layerRenderSteps;
+                for (let j = 0; j < steps.length; j++) {
+                    const step = steps[j];
+                    const cam = step.cameraComponent;
                     if (cam) {
                         if (!firstSeen.has(cam)) {
-                            firstSeen.set(cam, ra);
+                            firstSeen.set(cam, step);
                         }
-                        lastSeen.set(cam, ra);
+                        lastSeen.set(cam, step);
                     }
                 }
             }
         }
 
-        firstSeen.forEach((ra) => {
-            ra.firstCameraUse = true;
+        firstSeen.forEach((step) => {
+            step.firstCameraUse = true;
         });
-        lastSeen.forEach((ra) => {
-            ra.lastCameraUse = true;
+        lastSeen.forEach((step) => {
+            step.lastCameraUse = true;
         });
     }
 

--- a/src/scene/composition/render-action.js
+++ b/src/scene/composition/render-action.js
@@ -29,9 +29,6 @@ class RenderAction {
          */
         this.renderTarget = null;
 
-        // light clusters (type WorldClusters)
-        this.lightClusters = null;
-
         // clear flags
         this.clearColor = false;
         this.clearDepth = false;

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -15,6 +15,7 @@ import { WorldClustersDebug } from '../lighting/world-clusters-debug.js';
 import { Renderer } from './renderer.js';
 import { LightCamera } from './light-camera.js';
 import { RenderPassForward } from './render-pass-forward.js';
+import { LayerRenderStep } from './layer-render-step.js';
 import { FramePassPostprocessing } from './frame-pass-postprocessing.js';
 import { BINDGROUP_VIEW } from '../../platform/graphics/constants.js';
 
@@ -23,6 +24,7 @@ import { BINDGROUP_VIEW } from '../../platform/graphics/constants.js';
  * @import { FrameGraph } from '../frame-graph.js'
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { LayerComposition } from '../composition/layer-composition.js'
+ * @import { RenderAction } from '../composition/render-action.js'
  * @import { Layer } from '../layer.js'
  * @import { MeshInstance } from '../mesh-instance.js'
  * @import { RenderTarget } from '../../platform/graphics/render-target.js'
@@ -1072,10 +1074,29 @@ class ForwardRenderer extends Renderer {
 
         const renderActions = layerComposition._renderActions;
         for (let i = startIndex; i <= endIndex; i++) {
-            renderPass.addRenderAction(renderActions[i]);
+            renderPass.addLayerRenderStep(this._layerRenderStepFromRenderAction(renderActions[i]));
         }
 
         frameGraph.addRenderPass(renderPass);
+    }
+
+    /**
+     * Build a {@link LayerRenderStep} from a composition {@link RenderAction}. This is the only
+     * place that bridges the internal RenderAction scheduling type to the render pass's own
+     * LayerRenderStep, so neither RenderPassForward nor LayerRenderStep reference RenderAction.
+     *
+     * @param {RenderAction} renderAction - The composition render action.
+     * @returns {LayerRenderStep} The layer render step.
+     * @private
+     */
+    _layerRenderStepFromRenderAction(renderAction) {
+        const step = new LayerRenderStep(renderAction.camera, renderAction.layer, renderAction.transparent, renderAction.renderTarget);
+        step.clearColor = renderAction.clearColor;
+        step.clearDepth = renderAction.clearDepth;
+        step.clearStencil = renderAction.clearStencil;
+        step.firstCameraUse = renderAction.firstCameraUse;
+        step.lastCameraUse = renderAction.lastCameraUse;
+        return step;
     }
 
     /**

--- a/src/scene/renderer/layer-render-step.js
+++ b/src/scene/renderer/layer-render-step.js
@@ -1,0 +1,68 @@
+/**
+ * @import { CameraComponent } from '../../framework/components/camera/component.js'
+ * @import { Layer } from '../layer.js'
+ * @import { RenderTarget } from '../../platform/graphics/render-target.js'
+ * @import { WorldClusters } from '../lighting/world-clusters.js'
+ */
+
+/**
+ * Represents a single layer rendered by a {@link RenderPassForward}: one layer (its opaque or
+ * transparent sublayer) rendered with one camera to one render target.
+ *
+ * @ignore
+ */
+class LayerRenderStep {
+    /** @type {CameraComponent|null} */
+    cameraComponent;
+
+    /** @type {Layer|null} */
+    layer;
+
+    /** True if this uses the transparent sublayer, opaque otherwise. */
+    transparent;
+
+    /** @type {RenderTarget|null} */
+    renderTarget;
+
+    /**
+     * The world clusters to use for clustered lighting. Assigned later by the
+     * {@link WorldClustersAllocator}, so it always starts as null.
+     *
+     * @type {WorldClusters|null}
+     */
+    lightClusters = null;
+
+    // clear flags
+    clearColor = false;
+
+    clearDepth = false;
+
+    clearStencil = false;
+
+    // true if this is the first render step using its camera
+    firstCameraUse = false;
+
+    // true if this is the last render step using its camera
+    lastCameraUse = false;
+
+    /**
+     * @param {CameraComponent} cameraComponent - The camera component used to render the layer.
+     * @param {Layer} layer - The layer to render.
+     * @param {boolean} transparent - True to render the transparent sublayer, opaque otherwise.
+     * @param {RenderTarget|null} renderTarget - The render target to render to.
+     */
+    constructor(cameraComponent, layer, transparent, renderTarget) {
+        this.cameraComponent = cameraComponent;
+        this.layer = layer;
+        this.transparent = transparent;
+        this.renderTarget = renderTarget;
+    }
+
+    setupClears(cameraComponent, layer) {
+        this.clearColor = cameraComponent?.clearColorBuffer || layer.clearColorBuffer;
+        this.clearDepth = cameraComponent?.clearDepthBuffer || layer.clearDepthBuffer;
+        this.clearStencil = cameraComponent?.clearStencilBuffer || layer.clearStencilBuffer;
+    }
+}
+
+export { LayerRenderStep };

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -5,7 +5,7 @@ import { Tracing } from '../../core/tracing.js';
 import { BlendState } from '../../platform/graphics/blend-state.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { RenderPass } from '../../platform/graphics/render-pass.js';
-import { RenderAction } from '../composition/render-action.js';
+import { LayerRenderStep } from './layer-render-step.js';
 import { EVENT_POSTRENDER, EVENT_POSTRENDER_LAYER, EVENT_PRERENDER, EVENT_PRERENDER_LAYER, SHADER_FORWARD } from '../constants.js';
 
 /**
@@ -38,9 +38,9 @@ class RenderPassForward extends RenderPass {
     renderer;
 
     /**
-     * @type {RenderAction[]}
+     * @type {LayerRenderStep[]}
      */
-    renderActions = [];
+    layerRenderSteps = [];
 
     /**
      * The gamma correction setting for the render pass. If not set, the setting from the camera
@@ -82,11 +82,11 @@ class RenderPassForward extends RenderPass {
     }
 
     get rendersAnything() {
-        return this.renderActions.length > 0;
+        return this.layerRenderSteps.length > 0;
     }
 
-    addRenderAction(renderAction) {
-        this.renderActions.push(renderAction);
+    addLayerRenderStep(layerRenderStep) {
+        this.layerRenderSteps.push(layerRenderStep);
     }
 
     /**
@@ -105,19 +105,15 @@ class RenderPassForward extends RenderPass {
         Debug.assert(this.renderTarget !== undefined, 'Render pass needs to be initialized before adding layers');
         Debug.assert(cameraComponent.camera.layersSet.has(layer.id), `Camera ${cameraComponent.entity.name} does not render layer ${layer.name}.`);
 
-        const ra = new RenderAction();
-        ra.renderTarget = this.renderTarget;
-        ra.camera = cameraComponent;
-        ra.layer = layer;
-        ra.transparent = transparent;
+        const step = new LayerRenderStep(cameraComponent, layer, transparent, this.renderTarget);
 
         // camera / layer clear flags
         if (autoClears) {
-            const firstRa = this.renderActions.length === 0;
-            ra.setupClears(firstRa ? cameraComponent : undefined, layer);
+            const firstStep = this.layerRenderSteps.length === 0;
+            step.setupClears(firstStep ? cameraComponent : undefined, layer);
         }
 
-        this.addRenderAction(ra);
+        this.addLayerRenderStep(step);
     }
 
     /**
@@ -170,11 +166,11 @@ class RenderPassForward extends RenderPass {
 
     updateDirectionalShadows() {
         // add directional shadow passes if needed for the cameras used in this render pass
-        const { renderer, renderActions } = this;
-        for (let i = 0; i < renderActions.length; i++) {
-            const renderAction = renderActions[i];
-            const cameraComp = renderAction.camera;
-            const camera = cameraComp.camera;
+        const { renderer, layerRenderSteps } = this;
+        for (let i = 0; i < layerRenderSteps.length; i++) {
+            const step = layerRenderSteps[i];
+            const cameraComponent = step.cameraComponent;
+            const camera = cameraComponent.camera;
 
             // if this camera uses directional shadow lights
             const shadowDirLights = this.renderer.cameraDirShadowLights.get(camera);
@@ -201,17 +197,17 @@ class RenderPassForward extends RenderPass {
     updateClears() {
 
         // based on the first render action
-        const renderAction = this.renderActions[0];
-        if (renderAction) {
+        const step = this.layerRenderSteps[0];
+        if (step) {
 
             // set up clear params if the camera covers the full viewport
-            const cameraComponent = renderAction.camera;
+            const cameraComponent = step.cameraComponent;
             const camera = cameraComponent.camera;
             const fullSizeClearRect = camera.fullSizeClearRect;
 
-            this.setClearColor(fullSizeClearRect && renderAction.clearColor ? camera.clearColor : undefined);
-            this.setClearDepth(fullSizeClearRect && renderAction.clearDepth && !this.noDepthClear ? camera.clearDepth : undefined);
-            this.setClearStencil(fullSizeClearRect && renderAction.clearStencil ? camera.clearStencil : undefined);
+            this.setClearColor(fullSizeClearRect && step.clearColor ? camera.clearColor : undefined);
+            this.setClearDepth(fullSizeClearRect && step.clearDepth && !this.noDepthClear ? camera.clearDepth : undefined);
+            this.setClearStencil(fullSizeClearRect && step.clearStencil ? camera.clearStencil : undefined);
         }
     }
 
@@ -222,22 +218,22 @@ class RenderPassForward extends RenderPass {
     }
 
     before() {
-        const { renderActions } = this;
+        const { layerRenderSteps } = this;
 
         // onPreRender events
-        for (let i = 0; i < renderActions.length; i++) {
-            const ra = renderActions[i];
-            if (ra.firstCameraUse) {
-                this.scene.fire(EVENT_PRERENDER, ra.camera);
+        for (let i = 0; i < layerRenderSteps.length; i++) {
+            const step = layerRenderSteps[i];
+            if (step.firstCameraUse) {
+                this.scene.fire(EVENT_PRERENDER, step.cameraComponent);
             }
         }
     }
 
     execute() {
-        const { layerComposition, renderActions } = this;
-        for (let i = 0; i < renderActions.length; i++) {
-            const ra = renderActions[i];
-            const layer = ra.layer;
+        const { layerComposition, layerRenderSteps } = this;
+        for (let i = 0; i < layerRenderSteps.length; i++) {
+            const step = layerRenderSteps[i];
+            const layer = step.layer;
 
             Debug.call(() => {
                 const compLayer = layerComposition.getLayerByName(layer.name);
@@ -246,8 +242,8 @@ class RenderPassForward extends RenderPass {
                 }
             });
 
-            if (layerComposition.isEnabled(layer, ra.transparent)) {
-                this.renderRenderAction(ra, i === 0);
+            if (layerComposition.isEnabled(layer, step.transparent)) {
+                this.renderLayerRenderStep(step, i === 0);
             }
         }
     }
@@ -255,10 +251,10 @@ class RenderPassForward extends RenderPass {
     after() {
 
         // onPostRender events
-        for (let i = 0; i < this.renderActions.length; i++) {
-            const ra = this.renderActions[i];
-            if (ra.lastCameraUse) {
-                this.scene.fire(EVENT_POSTRENDER, ra.camera);
+        for (let i = 0; i < this.layerRenderSteps.length; i++) {
+            const step = this.layerRenderSteps[i];
+            if (step.lastCameraUse) {
+                this.scene.fire(EVENT_POSTRENDER, step.cameraComponent);
             }
         }
 
@@ -267,51 +263,51 @@ class RenderPassForward extends RenderPass {
     }
 
     /**
-     * @param {RenderAction} renderAction - The render action.
-     * @param {boolean} firstRenderAction - True if this is the first render action in the render pass.
+     * @param {LayerRenderStep} step - The layer render step.
+     * @param {boolean} firstStep - True if this is the first render step in the render pass.
      */
-    renderRenderAction(renderAction, firstRenderAction) {
+    renderLayerRenderStep(step, firstStep) {
 
         const { renderer, scene } = this;
         const device = renderer.device;
 
         // layer
-        const { layer, transparent, camera } = renderAction;
+        const { layer, transparent, cameraComponent } = step;
 
-        DebugGraphics.pushGpuMarker(this.device, `Camera: ${camera ? camera.entity.name : 'Unnamed'}, Layer: ${layer.name}(${transparent ? 'TRANSP' : 'OPAQUE'})`);
+        DebugGraphics.pushGpuMarker(this.device, `Camera: ${cameraComponent ? cameraComponent.entity.name : 'Unnamed'}, Layer: ${layer.name}(${transparent ? 'TRANSP' : 'OPAQUE'})`);
 
         // #if _PROFILER
         const drawTime = now();
         // #endif
 
-        if (camera) {
+        if (cameraComponent) {
 
             // override gamma correction and tone mapping settings
-            const originalGammaCorrection = camera.gammaCorrection;
-            const originalToneMapping = camera.toneMapping;
-            if (this.gammaCorrection !== undefined) camera.gammaCorrection = this.gammaCorrection;
-            if (this.toneMapping !== undefined) camera.toneMapping = this.toneMapping;
+            const originalGammaCorrection = cameraComponent.gammaCorrection;
+            const originalToneMapping = cameraComponent.toneMapping;
+            if (this.gammaCorrection !== undefined) cameraComponent.gammaCorrection = this.gammaCorrection;
+            if (this.toneMapping !== undefined) cameraComponent.toneMapping = this.toneMapping;
 
             // layer pre render event
-            scene.fire(EVENT_PRERENDER_LAYER, camera, layer, transparent);
+            scene.fire(EVENT_PRERENDER_LAYER, cameraComponent, layer, transparent);
 
             const options = {
-                lightClusters: renderAction.lightClusters
+                lightClusters: step.lightClusters
             };
 
             // shader pass - use setting from camera if available, otherwise forward
-            const shaderPass = camera.camera.shaderPassInfo?.index ?? SHADER_FORWARD;
+            const shaderPass = cameraComponent.camera.shaderPassInfo?.index ?? SHADER_FORWARD;
 
             // if this is not a first render action to the render target, or if the render target was not
             // fully cleared on pass start, we need to execute clears here
-            if (!firstRenderAction || !camera.camera.fullSizeClearRect) {
-                options.clearColor = renderAction.clearColor;
-                options.clearDepth = renderAction.clearDepth;
-                options.clearStencil = renderAction.clearStencil;
+            if (!firstStep || !cameraComponent.camera.fullSizeClearRect) {
+                options.clearColor = step.clearColor;
+                options.clearDepth = step.clearDepth;
+                options.clearStencil = step.clearStencil;
             }
 
-            const renderTarget = renderAction.renderTarget ?? device.backBuffer;
-            renderer.renderForwardLayer(camera.camera, renderTarget, layer, transparent,
+            const renderTarget = step.renderTarget ?? device.backBuffer;
+            renderer.renderForwardLayer(cameraComponent.camera, renderTarget, layer, transparent,
                 shaderPass, options);
 
             // Revert temp frame stuff
@@ -322,11 +318,11 @@ class RenderPassForward extends RenderPass {
             device.setAlphaToCoverage(false);
 
             // layer post render event
-            scene.fire(EVENT_POSTRENDER_LAYER, camera, layer, transparent);
+            scene.fire(EVENT_POSTRENDER_LAYER, cameraComponent, layer, transparent);
 
             // restore gamma correction and tone mapping settings
-            if (this.gammaCorrection !== undefined) camera.gammaCorrection = originalGammaCorrection;
-            if (this.toneMapping !== undefined) camera.toneMapping = originalToneMapping;
+            if (this.gammaCorrection !== undefined) cameraComponent.gammaCorrection = originalGammaCorrection;
+            if (this.toneMapping !== undefined) cameraComponent.toneMapping = originalToneMapping;
         }
 
         DebugGraphics.popGpuMarker(this.device);
@@ -343,16 +339,16 @@ class RenderPassForward extends RenderPass {
         if (Tracing.get(TRACEID_RENDER_PASS_DETAIL)) {
 
             const { layerComposition } = this;
-            this.renderActions.forEach((ra, index) => {
+            this.layerRenderSteps.forEach((step, index) => {
 
-                const layer = ra.layer;
-                const enabled = layer.enabled && layerComposition.isEnabled(layer, ra.transparent);
-                const camera = ra.camera;
+                const layer = step.layer;
+                const enabled = layer.enabled && layerComposition.isEnabled(layer, step.transparent);
+                const cameraComponent = step.cameraComponent;
 
                 Debug.trace(TRACEID_RENDER_PASS_DETAIL, `    ${index}:${
-                    (` Cam: ${camera ? camera.entity.name : '-'}`).padEnd(22, ' ')
+                    (` Cam: ${cameraComponent ? cameraComponent.entity.name : '-'}`).padEnd(22, ' ')
                 }${(` Lay: ${layer.name}`).padEnd(22, ' ')
-                }${ra.transparent ? ' TRANSP' : ' OPAQUE'
+                }${step.transparent ? ' TRANSP' : ' OPAQUE'
                 }${enabled ? ' ENABLED' : ' DISABLED'
                 }${(` Meshes: ${layer.meshInstances.length}`).padEnd(5, ' ')}`
                 );

--- a/src/scene/renderer/world-clusters-allocator.js
+++ b/src/scene/renderer/world-clusters-allocator.js
@@ -4,7 +4,7 @@ import { FramePassMultiView } from './frame-pass-multi-view.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
- * @import { RenderAction } from '../composition/render-action.js'
+ * @import { LayerRenderStep } from './layer-render-step.js'
  */
 
 const tempClusterArray = [];
@@ -31,10 +31,10 @@ class WorldClustersAllocator {
     _allocated = [];
 
     /**
-     * Render actions with all unique light clusters. The key is the hash of lights on a layer, the
-     * value is a render action with unique light clusters.
+     * Layer render steps with all unique light clusters. The key is the hash of lights on a layer,
+     * the value is a layer render step with unique light clusters.
      *
-     * @type {Map<number, RenderAction>}
+     * @type {Map<number, LayerRenderStep>}
      */
     _clusters = new Map();
 
@@ -83,32 +83,32 @@ class WorldClustersAllocator {
     }
 
     /**
-     * Assign clusters for one frame pass that owns {@link RenderPass#renderActions}.
-     * No-op when the pass has no render actions.
+     * Assign clusters for one frame pass that owns {@link RenderPassForward#layerRenderSteps}.
+     * No-op when the pass has no layer render steps.
      *
      * @param {import('../../platform/graphics/frame-pass.js').FramePass} renderPass - Render pass
      * (not a {@link FramePassMultiView} wrapper; those are unwrapped in {@link WorldClustersAllocator#assign}).
      * @private
      */
     _assignClustersForPass(renderPass) {
-        const renderActions = renderPass.renderActions;
-        if (!renderActions) {
+        const layerRenderSteps = renderPass.layerRenderSteps;
+        if (!layerRenderSteps) {
             return;
         }
 
-        const count = renderActions.length;
+        const count = layerRenderSteps.length;
         for (let i = 0; i < count; i++) {
-            const ra = renderActions[i];
-            ra.lightClusters = null;
+            const step = layerRenderSteps[i];
+            step.lightClusters = null;
 
             // if the layer has lights used by clusters, and meshes
-            const layer = ra.layer;
+            const layer = step.layer;
             if (layer.hasClusteredLights && layer.meshInstances.length) {
 
                 // use existing clusters if the lights on the layer are the same
                 const hash = layer.getLightIdHash();
-                const existingRenderAction = this._clusters.get(hash);
-                let clusters = existingRenderAction?.lightClusters;
+                const existingStep = this._clusters.get(hash);
+                let clusters = existingStep?.lightClusters;
 
                 // no match, needs new clusters
                 if (!clusters) {
@@ -118,20 +118,20 @@ class WorldClustersAllocator {
                     DebugHelper.setName(clusters, `Cluster-${this._allocated.length}`);
 
                     this._allocated.push(clusters);
-                    this._clusters.set(hash, ra);
+                    this._clusters.set(hash, step);
                 }
 
-                ra.lightClusters = clusters;
+                step.lightClusters = clusters;
             }
 
             // no clustered lights, use the cluster with no lights
-            if (!ra.lightClusters) {
-                ra.lightClusters = this.empty;
+            if (!step.lightClusters) {
+                step.lightClusters = this.empty;
             }
         }
     }
 
-    // assign light clusters to render actions that need it
+    // assign light clusters to layer render steps that need it
     assign(renderPasses) {
 
         // reuse previously allocated clusters
@@ -140,7 +140,7 @@ class WorldClustersAllocator {
         this._clusters.clear();
 
         // FramePassMultiView children are not on the frame graph list (merge safety); still assign
-        // clusters to their render actions before those passes run.
+        // clusters to their layer render steps before those passes run.
         const passCount = renderPasses.length;
         for (let p = 0; p < passCount; p++) {
             const pass = renderPasses[p];
@@ -161,13 +161,13 @@ class WorldClustersAllocator {
 
     update(renderPasses, lighting) {
 
-        // assign clusters to render actions
+        // assign clusters to layer render steps
         this.assign(renderPasses);
 
         // update all unique clusters
-        this._clusters.forEach((renderAction) => {
-            const layer = renderAction.layer;
-            const cluster = renderAction.lightClusters;
+        this._clusters.forEach((step) => {
+            const layer = step.layer;
+            const cluster = step.lightClusters;
             cluster.update(layer.clusteredLightsSet, lighting);
         });
     }


### PR DESCRIPTION
Introduces a pass-owned `LayerRenderStep` so `RenderPassForward` no longer depends on the `LayerComposition` scheduling type `RenderAction`. This is a step toward making `RenderPassForward` a generic, public pass that can render any layer with any camera.

**Changes:**
- New `LayerRenderStep` (`scene/renderer`): the render pass's own per-layer execution record — one layer (its opaque or transparent sublayer) rendered with one camera to one render target. Plain data, 4-arg constructor, no knowledge of `RenderAction`.
- `RenderPassForward` now stores `layerRenderSteps` (was `renderActions`) and references `LayerRenderStep` only; internal `RenderAction`-derived naming removed (`step`, `renderLayerRenderStep`).
- The `camera` member is renamed to `cameraComponent` (it holds a `CameraComponent`), so `cameraComponent.camera` now unambiguously means the `Camera`.
- `ForwardRenderer._layerRenderStepFromRenderAction` is the single bridge from the internal `RenderAction` to `LayerRenderStep` — the only place that knows both types, and removable when the forward renderer is eventually replaced.
- `WorldClustersAllocator` and `FramePassCameraFrame` updated to the new field / names.
- Removed the now-dead `RenderAction.lightClusters` (it only ever lived on the render step, assigned by the clustered lighting allocator).

**API:**
- Internal renderer refactor; no public API change.