### PR TITLE
Tidy RenderPassForward layer API and camera-use logging

### DIFF
--- a/src/extras/render-passes/frame-pass-camera-frame.js
+++ b/src/extras/render-passes/frame-pass-camera-frame.js
@@ -384,9 +384,52 @@ class FramePassCameraFrame extends FramePass {
         pass.toneMapping = TONEMAP_NONE;
     }
 
+    /**
+     * Adds the camera's layers from the pass's layer composition to a forward render pass, starting
+     * from the given index, till the end of the layer list, or till the last layer with the given id
+     * and transparency is reached (inclusive). Only layers that the camera renders are added.
+     *
+     * @param {RenderPassForward} renderPass - The forward render pass to add the layers to.
+     * @param {number} startIndex - The index of the first layer to be considered for adding.
+     * @param {boolean} firstLayerClears - True if the first layer added should clear the render target.
+     * @param {number} [lastLayerId] - The id of the last layer to be added. If not specified, all
+     * layers till the end of the layer list are added.
+     * @param {boolean} [lastLayerIsTransparent] - True if the last layer to be added is transparent.
+     * Defaults to true.
+     * @returns {number} Returns the index of last layer added.
+     */
+    addCameraLayers(renderPass, startIndex, firstLayerClears, lastLayerId, lastLayerIsTransparent = true) {
+
+        const cameraComponent = this.cameraComponent;
+        const { layerList, subLayerList } = renderPass.layerComposition;
+        let clearRenderTarget = firstLayerClears;
+
+        let index = startIndex;
+        while (index < layerList.length) {
+
+            const layer = layerList[index];
+            const isTransparent = subLayerList[index];
+
+            // add it for rendering if the camera renders it
+            if (cameraComponent.camera.layersSet.has(layer.id)) {
+                renderPass.addLayer(cameraComponent, layer, isTransparent, clearRenderTarget);
+                clearRenderTarget = false;
+            }
+
+            index++;
+
+            // stop at last requested layer
+            if (layer.id === lastLayerId && isTransparent === lastLayerIsTransparent) {
+                break;
+            }
+        }
+
+        return index;
+    }
+
     setupScenePass(options) {
 
-        const { app, device, cameraComponent } = this;
+        const { app, device } = this;
         const { scene, renderer } = app;
         const composition = scene.layers;
 
@@ -407,7 +450,7 @@ class FramePassCameraFrame extends FramePass {
             clearRenderTarget: true     // true if the render target should be cleared
         };
 
-        ret.lastAddedIndex = this.scenePass.addLayers(composition, cameraComponent, ret.lastAddedIndex, ret.clearRenderTarget, lastLayerId, lastLayerIsTransparent);
+        ret.lastAddedIndex = this.addCameraLayers(this.scenePass, ret.lastAddedIndex, ret.clearRenderTarget, lastLayerId, lastLayerIsTransparent);
         ret.clearRenderTarget = false;
 
         // grab pass allowing us to copy the render scene into a texture and use for refraction
@@ -420,7 +463,7 @@ class FramePassCameraFrame extends FramePass {
             this.scenePassTransparent = new RenderPassForward(device, composition, scene, renderer);
             this.setupScenePassSettings(this.scenePassTransparent);
             this.scenePassTransparent.init(this.rt);
-            ret.lastAddedIndex = this.scenePassTransparent.addLayers(composition, cameraComponent, ret.lastAddedIndex, ret.clearRenderTarget, options.lastSceneLayerId, options.lastSceneLayerIsTransparent);
+            ret.lastAddedIndex = this.addCameraLayers(this.scenePassTransparent, ret.lastAddedIndex, ret.clearRenderTarget, options.lastSceneLayerId, options.lastSceneLayerIsTransparent);
 
             // if no layers are rendered by this pass, remove it
             if (!this.scenePassTransparent.rendersAnything) {
@@ -520,7 +563,7 @@ class FramePassCameraFrame extends FramePass {
         this.afterPass.init(targetRenderTarget);
 
         // add all remaining layers the camera renders
-        this.afterPass.addLayers(composition, cameraComponent, scenePassesInfo.lastAddedIndex, scenePassesInfo.clearRenderTarget);
+        this.addCameraLayers(this.afterPass, scenePassesInfo.lastAddedIndex, scenePassesInfo.clearRenderTarget);
     }
 
     frameUpdate() {

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -375,8 +375,6 @@ class LayerComposition extends EventHandler {
                         (enabled ? ' ENABLED ' : ' DISABLED') +
                         (` RT: ${ra.renderTarget ? ra.renderTarget.name : '-'}`).padEnd(30, ' ')
                     } Clear: ${clear
-                    }${ra.firstCameraUse ? ' CAM-FIRST' : ''
-                    }${ra.lastCameraUse ? ' CAM-LAST' : ''
                     }${ra.triggerPostprocess ? ' POSTPROCESS' : ''}`
                     );
                 }

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -116,54 +116,6 @@ class RenderPassForward extends RenderPass {
         this.addLayerRenderStep(step);
     }
 
-    /**
-     * Adds layers to be rendered by this render pass, starting from the given index of the layer
-     * in the layer composition, till the end of the layer list, or till the last layer with the
-     * given id and transparency is reached (inclusive). Note that only layers that are rendered by
-     * the specified camera are added.
-     *
-     * @param {LayerComposition} composition - The layer composition containing the layers to be
-     * added, typically the scene layer composition.
-     * @param {CameraComponent} cameraComponent - The camera component that is used to render the
-     * layers.
-     * @param {number} startIndex - The index of the first layer to be considered for adding.
-     * @param {boolean} firstLayerClears - True if the first layer added should clear the render
-     * target.
-     * @param {number} [lastLayerId] - The id of the last layer to be added. If not specified, all
-     * layers till the end of the layer list are added.
-     * @param {boolean} [lastLayerIsTransparent] - True if the last layer to be added is transparent.
-     * Defaults to true.
-     * @returns {number} Returns the index of last layer added.
-     */
-    addLayers(composition, cameraComponent, startIndex, firstLayerClears, lastLayerId, lastLayerIsTransparent = true) {
-
-        const { layerList, subLayerList } = composition;
-        let clearRenderTarget = firstLayerClears;
-
-        let index = startIndex;
-        while (index < layerList.length) {
-
-            const layer = layerList[index];
-            const isTransparent = subLayerList[index];
-            const renderedByCamera = cameraComponent.camera.layersSet.has(layer.id);
-
-            // add it for rendering
-            if (renderedByCamera) {
-                this.addLayer(cameraComponent, layer, isTransparent, clearRenderTarget);
-                clearRenderTarget = false;
-            }
-
-            index++;
-
-            // stop at last requested layer
-            if (layer.id === lastLayerId && isTransparent === lastLayerIsTransparent) {
-                break;
-            }
-        }
-
-        return index;
-    }
-
     updateDirectionalShadows() {
         // add directional shadow passes if needed for the cameras used in this render pass
         const { renderer, layerRenderSteps } = this;
@@ -350,7 +302,9 @@ class RenderPassForward extends RenderPass {
                 }${(` Lay: ${layer.name}`).padEnd(22, ' ')
                 }${step.transparent ? ' TRANSP' : ' OPAQUE'
                 }${enabled ? ' ENABLED' : ' DISABLED'
-                }${(` Meshes: ${layer.meshInstances.length}`).padEnd(5, ' ')}`
+                }${(` Meshes: ${layer.meshInstances.length}`).padEnd(5, ' ')
+                }${step.firstCameraUse ? ' CAM-FIRST' : ''
+                }${step.lastCameraUse ? ' CAM-LAST' : ''}`
                 );
             });
         }


### PR DESCRIPTION
Small, behavior-neutral cleanups that slim `RenderPassForward` toward a minimal, single-camera-friendly API (groundwork for the upcoming culling-from-frame-graph work).

**Changes:**
- Move the bulk "add a camera's layers from the composition" loop out of `RenderPassForward` (`addLayers`) into its only consumer, `FramePassCameraFrame` (`addCameraLayers`). `RenderPassForward` now exposes just `addLayer`. The helper reads the pass's stored `layerComposition` and the frame's `cameraComponent`, so it takes neither as a parameter.
- Drop the redundant `composition` parameter `addLayers` took — it always matched the pass's stored `layerComposition`, and taking it risked walking a different composition than `execute()` checks `isEnabled` against.
- Report first/last camera use from render-pass detail (`TRACEID_RENDER_PASS_DETAIL`, off the steps) instead of the render-action log (`TRACEID_RENDER_ACTION`), which no longer prints `CAM-FIRST`/`CAM-LAST`.

**API:**
- Internal renderer change (`RenderPassForward` is `@ignore`); no public API change.