### PR TITLE
Remove redundant CameraComponent.frameUpdate

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1,5 +1,5 @@
 import { Debug } from '../../../core/debug.js';
-import { ASPECT_AUTO, LAYERID_UI, LAYERID_DEPTH } from '../../../scene/constants.js';
+import { LAYERID_UI, LAYERID_DEPTH } from '../../../scene/constants.js';
 import { Camera } from '../../../scene/camera.js';
 import { ShaderPass } from '../../../scene/shader-pass.js';
 import { Component } from '../component.js';
@@ -1258,20 +1258,6 @@ class CameraComponent extends Component {
      */
     calculateAspectRatio(rt) {
         return this._camera.calculateAspectRatio(rt);
-    }
-
-    /**
-     * Prepare the camera for frame rendering.
-     *
-     * @param {RenderTarget|null} [rt] - Render
-     * target to which rendering will be performed. Will affect camera's aspect ratio, if
-     * aspectRatioMode is {@link ASPECT_AUTO}.
-     * @ignore
-     */
-    frameUpdate(rt) {
-        if (this.aspectRatioMode === ASPECT_AUTO) {
-            this.aspectRatio = this.calculateAspectRatio(rt);
-        }
     }
 
     /**

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -1126,9 +1126,7 @@ class Renderer {
         for (let i = 0; i < numCameras; i++) {
             const camera = comp.cameras[i];
 
-            // update camera and frustum
-            const renderTarget = camera.renderTarget;
-            camera.frameUpdate(renderTarget);
+            // update the camera frustum for culling (aspect ratio auto-refreshes on read)
             this.updateCameraFrustum(camera.camera);
 
             // for all of its enabled layers cull the non-directional lights once with each camera


### PR DESCRIPTION
`CameraComponent.frameUpdate(rt)` eagerly recomputed the camera's aspect ratio for `ASPECT_AUTO`. That became redundant once [#8633](https://github.com/playcanvas/engine/pull/8633) made `Camera.aspectRatio` auto-refresh for `ASPECT_AUTO` on every read:

- `Renderer.updateCameraFrustum` reads `camera.projectionMatrix`, and `_evaluateProjectionMatrix` reads `this.aspectRatio` — which recomputes from current inputs for `ASPECT_AUTO`. So culling and rendering already get an up-to-date frustum without the eager call.
- The `rt` argument was moot: the getter recomputes from the camera's own render target on the next read (overwriting whatever `frameUpdate` set), and the sole caller passed `camera.renderTarget` anyway.

**Changes:**
- Remove `CameraComponent.frameUpdate` (it was `@ignore`) and its only caller in `Renderer.updateLightVisibility` (which now just updates the camera frustum).
- Drop the now-unused `ASPECT_AUTO` import in the camera component.
- Keep `CameraComponent.calculateAspectRatio` (public).

No public API or behavior change.