### PR TITLE
Add request/execute mesh-instance culling

### DIFF
--- a/examples/src/examples/graphics/area-picker.example.mjs
+++ b/examples/src/examples/graphics/area-picker.example.mjs
@@ -4,6 +4,7 @@
 // highlighted.
 
 import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -31,7 +32,7 @@ createOptions.graphicsDevice = device;
 createOptions.mouse = new pc.Mouse(document.body);
 createOptions.touch = new pc.TouchDevice(document.body);
 
-createOptions.componentSystems = [pc.RenderComponentSystem, pc.CameraComponentSystem];
+createOptions.componentSystems = [pc.RenderComponentSystem, pc.CameraComponentSystem, pc.ScriptComponentSystem];
 createOptions.resourceHandlers = [pc.TextureHandler];
 
 const app = new pc.AppBase(canvas);
@@ -122,12 +123,26 @@ assetListLoader.load(() => {
         return primitive;
     }
 
-    // Create main camera
+    // Create main camera. It auto-orbits the scene until the first right-click, after which
+    // interactive orbit controls (drag to orbit, scroll to zoom) take over - letting the view be
+    // moved around to visually confirm culling. Left-click picks without stopping the orbit.
     const camera = new pc.Entity();
     camera.addComponent('camera', {
         clearColor: new pc.Color(0.1, 0.1, 0.1)
     });
+    camera.addComponent('script');
     app.root.addChild(camera);
+
+    // auto-rotation is active until the first right-click; at that point we create CameraControls
+    // (which attaches at the camera's current pose, so there's no jump) and hand control to the
+    // user, never auto-rotating again
+    let autoRotate = true;
+    const stopAutoRotate = () => {
+        if (!autoRotate) return;
+        autoRotate = false;
+        const cameraControls = /** @type {CameraControls} */ (camera.script.create(CameraControls));
+        cameraControls.focusPoint = new pc.Vec3(0, 0, 0);
+    };
 
     data.on('orthoCamera:set', (/** @type {boolean} */ value) => {
         camera.camera.projection = value ? pc.PROJECTION_ORTHOGRAPHIC : pc.PROJECTION_PERSPECTIVE;
@@ -197,28 +212,34 @@ assetListLoader.load(() => {
     /** @type {{ x: number, y: number } | null} */
     let pendingPickRequest = null;
 
-    // handle mouse click to pick world point
+    // handle mouse buttons: left button picks a world point (auto-rotation continues, so the picked
+    // marker can be seen from a moving viewpoint), right button hands control to the user and stops
+    // the auto-rotation. The context menu is disabled so the right button is usable.
     const mouse = new pc.Mouse(document.body);
+    mouse.disableContextMenu();
     mouse.on('mousedown', (event) => {
-        // store the pick request to be processed after picker.prepare
-        pendingPickRequest = {
-            x: event.x * pickerScale,
-            y: event.y * pickerScale
-        };
+        if (event.button === pc.MOUSEBUTTON_RIGHT) {
+            // right button stops the auto-rotation and hands control to the user
+            stopAutoRotate();
+        } else if (event.button === pc.MOUSEBUTTON_LEFT) {
+            // left button picks a world point; store the request to process after picker.prepare
+            pendingPickRequest = {
+                x: event.x * pickerScale,
+                y: event.y * pickerScale
+            };
+        }
     });
 
     // update each frame
     let time = 0;
     app.on('update', (/** @type {number} */ dt) => {
-        time += dt * 0.1;
 
-        // orbit the camera around
-        if (!camera) {
-            return;
+        // auto-orbit the camera until the user takes control
+        if (autoRotate) {
+            time += dt * 0.1;
+            camera.setLocalPosition(40 * Math.sin(time), 0, 40 * Math.cos(time));
+            camera.lookAt(pc.Vec3.ZERO);
         }
-
-        camera.setLocalPosition(40 * Math.sin(time), 0, 40 * Math.cos(time));
-        camera.lookAt(pc.Vec3.ZERO);
 
         // Make sure the picker is the right size, and prepare it, which renders meshes into its render target
         if (picker) {

--- a/src/extras/render-passes/render-pass-prepass.js
+++ b/src/extras/render-passes/render-pass-prepass.js
@@ -33,6 +33,14 @@ class RenderPassPrepass extends RenderPass {
     /** @type {Color} */
     linearDepthClearValue = new Color(0, 0, 0, 0);
 
+    /**
+     * The layerList indices of the sub-layers this prepass renders. Rebuilt each frame in
+     * frameUpdate (where culling is also requested) and consumed by execute.
+     *
+     * @type {number[]}
+     */
+    _qualifiedLayerIndices = [];
+
     constructor(device, scene, renderer, camera, options) {
         super(device);
         this.scene = scene;
@@ -85,41 +93,29 @@ class RenderPassPrepass extends RenderPass {
         const { renderer, scene, renderTarget } = this;
         const camera = this.camera.camera;
         const layers = scene.layers.layerList;
-        const subLayerEnabled = scene.layers.subLayerEnabled;
         const isTransparent = scene.layers.subLayerList;
 
-        for (let i = 0; i < layers.length; i++) {
+        // render the sub-layers collected (and culled) in frameUpdate
+        for (const i of this._qualifiedLayerIndices) {
             const layer = layers[i];
 
-            // only render the layers before the depth layer
-            if (layer.id === LAYERID_DEPTH) {
-                break;
-            }
+            const culledInstances = layer.getCulledInstances(camera);
+            const meshInstances = isTransparent[i] ? culledInstances.transparent : culledInstances.opaque;
 
-            if (layer.enabled && subLayerEnabled[i]) {
+            for (let j = 0; j < meshInstances.length; j++) {
+                const meshInstance = meshInstances[j];
 
-                // if the layer is rendered by the camera
-                if (layer.camerasSet.has(camera)) {
-
-                    const culledInstances = layer.getCulledInstances(camera);
-                    const meshInstances = isTransparent[i] ? culledInstances.transparent : culledInstances.opaque;
-
-                    for (let j = 0; j < meshInstances.length; j++) {
-                        const meshInstance = meshInstances[j];
-
-                        // only collect meshes that update the depth
-                        if (meshInstance.material?.depthWrite) {
-                            tempMeshInstances.push(meshInstance);
-                        }
-                    }
-
-                    renderer.renderForwardLayer(camera, renderTarget, null, undefined, SHADER_PREPASS, {
-                        meshInstances: tempMeshInstances
-                    });
-
-                    tempMeshInstances.length = 0;
+                // only collect meshes that update the depth
+                if (meshInstance.material?.depthWrite) {
+                    tempMeshInstances.push(meshInstance);
                 }
             }
+
+            renderer.renderForwardLayer(camera, renderTarget, null, undefined, SHADER_PREPASS, {
+                meshInstances: tempMeshInstances
+            });
+
+            tempMeshInstances.length = 0;
         }
     }
 
@@ -143,6 +139,23 @@ class RenderPassPrepass extends RenderPass {
             }
         }
         this.setClearColor(clearValue);
+
+        // collect the sub-layers this prepass will render and request culling of each, so their
+        // culled lists are ready when execute() reads them (execute() reuses these indices)
+        const { renderer, scene } = this;
+        const cullCamera = this.camera.camera;
+        const composition = scene.layers;
+        const layerList = composition.layerList;
+        const qualified = this._qualifiedLayerIndices;
+        qualified.length = 0;
+        for (let i = 0; i < layerList.length; i++) {
+            // only render the layers before the depth layer
+            if (layerList[i].id === LAYERID_DEPTH) break;
+            if (composition.isSubLayerRenderedByCamera(i, cullCamera)) {
+                qualified.push(i);
+                renderer.requestMeshInstanceCull(cullCamera, layerList[i]);
+            }
+        }
     }
 }
 

--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -97,22 +97,24 @@ class RenderPassPicker extends RenderPass {
         this._qualifiedLayerIndices.length = 0;
         this._pickMeshInstances.clear();
 
-        const { camera, scene, layers } = this;
+        const { camera, scene, layers, renderer } = this;
         const srcLayers = scene.layers.layerList;
-        const subLayerEnabled = scene.layers.subLayerEnabled;
 
-        const gsplatDirector = this.renderer.gsplatDirector;
+        const gsplatDirector = renderer.gsplatDirector;
         const pickerWidth = this.renderTarget?.width ?? 1;
         const pickerHeight = this.renderTarget?.height ?? 1;
 
         for (let i = 0; i < srcLayers.length; i++) {
             const srcLayer = srcLayers[i];
             if (layers && layers.indexOf(srcLayer) < 0) continue;
-            if (!srcLayer.enabled || !subLayerEnabled[i]) continue;
-            if (!srcLayer.camerasSet.has(camera.camera)) continue;
+            if (!scene.layers.isSubLayerRenderedByCamera(i, camera.camera)) continue;
 
             // store the index of the layers we need to render
             this._qualifiedLayerIndices.push(i);
+
+            // request culling of this layer for the picking camera, so execute() can read the
+            // camera-visible instances instead of the whole layer
+            renderer.requestMeshInstanceCull(camera.camera, srcLayer);
 
             // kick off a compute tiled renderer for the gsplat manager on this layer, and store the mesh instance
             // which copies the results to the pick buffer
@@ -123,6 +125,10 @@ class RenderPassPicker extends RenderPass {
                 }
             }
         }
+
+        // perform the requested culls now (the picker renders standalone, outside the main
+        // cullComposition), so the culled instance lists are ready for execute()
+        renderer.executeMeshInstanceCull();
     }
 
     execute() {
@@ -142,15 +148,15 @@ class RenderPassPicker extends RenderPass {
                 renderer.clear(camera.camera, false, true, false);
             }
 
-            // Use mesh instances from the layer. Ideally we'd just pick culled instances for the camera,
-            // but we have no way of knowing if culling has been performed since changes to the layer.
-            // Disadvantage here is that we render all mesh instances, even those not visible by the camera.
-            const meshInstances = srcLayer.meshInstances;
+            // use the camera-visible instances for this layer (culling was requested in before()),
+            // taking the bucket that matches this sub-layer's transparency
+            const culledInstances = srcLayer.getCulledInstances(camera.camera);
+            const meshInstances = transparent ? culledInstances.transparent : culledInstances.opaque;
 
-            // only need mesh instances with a pick flag
+            // only need mesh instances with a pick flag (the bucket already matches transparency)
             for (let j = 0; j < meshInstances.length; j++) {
                 const meshInstance = meshInstances[j];
-                if (meshInstance.pick && meshInstance.transparent === transparent) {
+                if (meshInstance.pick) {
                     tempMeshInstances.push(meshInstance);
 
                     // keep the index -> meshInstance index mapping

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -18,6 +18,7 @@ import { CameraShaderParams } from './camera-shader-params.js';
  * @import { GraphicsDevice } from '../platform/graphics/graphics-device.js'
  * @import { RenderTarget } from '../platform/graphics/render-target.js'
  * @import { FogParams } from './fog-params.js'
+ * @import { Layer } from './layer.js'
  * @import { RenderView } from './render-view.js'
  * @import { ShaderPassInfo } from './shader-pass.js'
  */
@@ -182,6 +183,12 @@ class Camera {
         this._jitters = [0, 0, 0, 0];            // jitter values for TAA, 0-1 - current frame, 2-3 - previous frame
 
         this.frustum = new Frustum();
+
+        // Reusable set of layers to cull for this camera in the current frame. Populated through
+        // requestMeshInstanceCull and drained by executeMeshInstanceCull on the renderer; kept on
+        // the camera so the per-camera cull state needs no per-frame allocation.
+        /** @type {Set<Layer>} */
+        this._cullLayers = new Set();
 
         // Set by XrManager when an XR session takes over this camera: a reference to the manager's
         // live per-view array (matrices, viewports, updated each frame), or null when not in XR.
@@ -544,6 +551,43 @@ class Camera {
      */
     get xrActive() {
         return this._xrViews !== null;
+    }
+
+    /**
+     * Registers a layer to be culled for this camera in the current frame. Used by the renderer's
+     * request/execute mesh-instance culling.
+     *
+     * @param {Layer} layer - The layer to cull for this camera.
+     * @returns {boolean} True if this is the first layer registered for this camera this frame,
+     * letting the caller track the camera exactly once.
+     * @ignore
+     */
+    addCullLayer(layer) {
+        const first = this._cullLayers.size === 0;
+        this._cullLayers.add(layer);
+        return first;
+    }
+
+    /**
+     * Gets the set of layers registered to be culled for this camera in the current frame. For
+     * read-only iteration; use {@link Camera#addCullLayer} and {@link Camera#clearCullLayers} to
+     * mutate it.
+     *
+     * @type {Set<Layer>}
+     * @ignore
+     */
+    get cullLayers() {
+        return this._cullLayers;
+    }
+
+    /**
+     * Clears the set of layers registered to be culled for this camera, called once the camera's
+     * culling has been performed.
+     *
+     * @ignore
+     */
+    clearCullLayers() {
+        this._cullLayers.clear();
     }
 
     /**

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -639,6 +639,21 @@ class LayerComposition extends EventHandler {
     }
 
     /**
+     * Returns true if the sub-layer at the given flat {@link LayerComposition#layerList} index is
+     * enabled and rendered by the given camera. Combines the per-layer enabled flag, the per
+     * sub-layer enabled flag and the layer's set of cameras.
+     *
+     * @param {number} index - The index of the sub-layer in {@link LayerComposition#layerList}.
+     * @param {Camera} camera - The camera to test.
+     * @returns {boolean} True if the sub-layer is enabled and the camera renders it.
+     * @ignore
+     */
+    isSubLayerRenderedByCamera(index, camera) {
+        const layer = this.layerList[index];
+        return layer.enabled && this.subLayerEnabled[index] && layer.camerasSet.has(camera);
+    }
+
+    /**
      * Update maps of layer IDs and names to match the layer list.
      *
      * @private

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -167,6 +167,19 @@ class RenderPassForward extends RenderPass {
         super.frameUpdate();
         this.updateDirectionalShadows();
         this.updateClears();
+
+        // request mesh-instance culling for the (camera, layer) pairs this pass will render, so
+        // their culled lists are ready by the time the pass executes. Gated by the same isEnabled
+        // check execute() uses, so a disabled sub-layer (e.g. one left in a persistent CameraFrame
+        // pass) is neither culled nor rendered. The same (camera, layer) appearing as both an
+        // opaque and a transparent step is de-duplicated by the request.
+        const { renderer, layerComposition, layerRenderSteps } = this;
+        for (let i = 0; i < layerRenderSteps.length; i++) {
+            const step = layerRenderSteps[i];
+            if (layerComposition.isEnabled(step.layer, step.transparent)) {
+                renderer.requestMeshInstanceCull(step.cameraComponent.camera, step.layer);
+            }
+        }
     }
 
     before() {

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -42,6 +42,7 @@ import { Camera } from '../camera.js';
  * @import { CulledInstances } from '../layer.js'
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { RenderView } from '../render-view.js'
+ * @import { Layer } from '../layer.js'
  * @import { LayerComposition } from '../composition/layer-composition.js'
  * @import { Light } from '../light.js'
  * @import { MeshInstance } from '../mesh-instance.js'
@@ -119,6 +120,16 @@ class Renderer {
      * @protected
      */
     processingMeshInstances = new Set();
+
+    /**
+     * The distinct cameras with mesh-instance cull requests registered for the current frame, in
+     * registration order. Populated by {@link Renderer#requestMeshInstanceCull} and drained by
+     * {@link Renderer#executeMeshInstanceCull}. Reused across frames to avoid per-frame allocation.
+     *
+     * @type {Camera[]}
+     * @private
+     */
+    _cullCameras = [];
 
     /**
      * @type {WorldClustersAllocator}
@@ -1181,6 +1192,70 @@ class Renderer {
     }
 
     /**
+     * Registers a request to cull a layer's mesh instances for a camera in the current frame. The
+     * culling itself is performed later, in a single batch, by
+     * {@link Renderer#executeMeshInstanceCull}. Requests are de-duplicated per (camera, layer), so
+     * requesting the same pair more than once (e.g. for its opaque and transparent sub-layers) is
+     * harmless.
+     *
+     * This lets the frame graph drive culling - each pass requests the (camera, layer) pairs it
+     * will actually render - instead of culling every camera/layer combination in the composition.
+     *
+     * @param {Camera} camera - The camera to cull for.
+     * @param {Layer} layer - The layer whose mesh instances should be culled.
+     * @ignore
+     */
+    requestMeshInstanceCull(camera, layer) {
+        // track each requested camera once, when its first layer this frame is registered
+        if (camera.addCullLayer(layer)) {
+            this._cullCameras.push(camera);
+        }
+    }
+
+    /**
+     * Performs all mesh-instance culling requested via {@link Renderer#requestMeshInstanceCull}
+     * this frame, then clears the request list. For each requested camera the precull event is
+     * fired (before the frustum is refreshed, so a listener may still adjust the camera), the
+     * camera frustum is updated, each requested layer is culled, and the postcull event is fired.
+     *
+     * The events are passed the owning camera component for a framework camera, or null for an
+     * internal camera (shadow / reflection / picker), matching the documented precull/postcull
+     * contract.
+     *
+     * @ignore
+     */
+    executeMeshInstanceCull() {
+
+        const { scene } = this;
+        const cameras = this._cullCameras;
+
+        for (let i = 0; i < cameras.length; i++) {
+            const camera = cameras[i];
+
+            // recover the owning camera component (framework camera) or null (internal camera),
+            // without the scene layer taking a dependency on the framework
+            const cameraComponent = camera.node?.camera ?? null;
+
+            // precull is fired before the frustum is refreshed, so a listener may adjust the camera
+            scene?.fire(EVENT_PRECULL, cameraComponent);
+
+            this.updateCameraFrustum(camera);
+
+            for (const layer of camera.cullLayers) {
+                this.cullMeshInstances(camera, layer.meshInstances, layer.getCulledInstances(camera));
+            }
+
+            scene?.fire(EVENT_POSTCULL, cameraComponent);
+
+            // reset the camera's per-frame cull layer set
+            camera.clearCullLayers();
+        }
+
+        // requests consumed - reset for the next frame
+        cameras.length = 0;
+    }
+
+    /**
      * Visibility culling of meshInstances and shadow casters. Light visibility, the light atlas and
      * the directional-shadow-light collection are done earlier in
      * {@link Renderer#updateLightVisibility}.
@@ -1197,32 +1272,11 @@ class Renderer {
 
         this.processingMeshInstances.clear();
 
-        // for all cameras
-        const numCameras = comp.cameras.length;
-        this._camerasRendered += numCameras;
+        this._camerasRendered += comp.cameras.length;
 
-        for (let i = 0; i < numCameras; i++) {
-            const camera = comp.cameras[i];
-
-            // event before the camera is culling, fired after the frustum has been updated (in
-            // updateLightVisibility) so listeners can rely on the current camera state
-            scene?.fire(EVENT_PRECULL, camera);
-
-            // for all of its enabled layers
-            const layerIds = camera.layers;
-            for (let j = 0; j < layerIds.length; j++) {
-                const layer = comp.getLayerById(layerIds[j]);
-                if (layer && layer.enabled) {
-
-                    // cull mesh instances
-                    const culledInstances = layer.getCulledInstances(camera.camera);
-                    this.cullMeshInstances(camera.camera, layer.meshInstances, culledInstances);
-                }
-            }
-
-            // event after the camera is done with culling
-            scene?.fire(EVENT_POSTCULL, camera);
-        }
+        // cull mesh instances for the (camera, layer) pairs the frame graph's passes requested
+        // (this also fires the per-camera precull / postcull events)
+        this.executeMeshInstanceCull();
 
         // cull shadow casters for all lights
         this.cullShadowmaps(comp);

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -121,8 +121,9 @@ class Scene extends EventHandler {
     static EVENT_POSTRENDER_LAYER = 'postrender:layer';
 
     /**
-     * Fired before mesh instance visibility culling is performed for a camera. The handler is
-     * passed the {@link CameraComponent} being culled, or null when the culling is internal (for
+     * Fired before mesh instance visibility culling is performed for a camera, just before the
+     * camera's culling frustum is refreshed (so a handler may still adjust the camera). The handler
+     * is passed the {@link CameraComponent} being culled, or null when the culling is internal (for
      * example when culling shadow casters for a light's shadow map). Note that light visibility
      * culling happens earlier in the frame and is not bracketed by this event.
      *


### PR DESCRIPTION
Replaces composition-driven mesh-instance culling with a request/execute model, so culling tracks what the frame graph actually renders rather than every camera×layer combination in the layer composition.

**Changes:**
- Culling is now request-driven: passes register the (camera, layer) pairs they will render during `frameUpdate`, and a single batched pass culls exactly those. The forward pass and depth prepass register their layers; `cullComposition` no longer walks `comp.cameras × camera.layers` for mesh instances. Light visibility and shadow-caster culling are unchanged.
- The area picker now renders only the camera-visible instances of each layer instead of the entire layer's mesh-instance list.
- Added `LayerComposition.isSubLayerRenderedByCamera(index, camera)` to centralize the "enabled sub-layer rendered by this camera" predicate (picker + prepass); the prepass now computes its rendered sub-layers once and reuses them.

**API Changes:**
- `Scene`'s `precull` event now fires immediately *before* the camera's culling frustum is refreshed (previously after), so a handler may adjust the camera before mesh culling. It still fires per camera with the `CameraComponent` (or `null` for internal culling). JSDoc updated.
- The picker no longer returns hidden mesh instances (`MeshInstance#visible === false`): picking uses the camera-culled set, which excludes hidden and off-frustum instances. Off-frustum instances never produced pick pixels (results unchanged there); hidden instances are no longer pickable.

**Examples:**
- `graphics/area-picker`: added an auto-orbiting camera that hands off to interactive `CameraControls` on right-click (left-click picks without stopping the orbit), making the culling visible.

**Performance:**
- Mesh-instance culling now scales with what the frame graph renders, not the whole composition; the picker stops rendering off-screen instances into the pick buffer.