### PR TITLE
Add clear/remove API to Curve and CurveSet

### DIFF
--- a/src/core/math/curve-set.js
+++ b/src/core/math/curve-set.js
@@ -124,6 +124,76 @@ class CurveSet {
     }
 
     /**
+     * Appends a new curve to the curve set. The new curve adopts the curve set's current
+     * {@link CurveSet#type} interpolation scheme, so that all curves in the set continue to share
+     * the same type.
+     *
+     * @param {number[]} [data] - An array of keys (pairs of numbers with the time first and value
+     * second) for the new curve.
+     * @returns {Curve} The newly created curve.
+     * @example
+     * const curveSet = new pc.CurveSet([[0, 0, 1, 1]]);
+     * const curve = curveSet.add([0, 0, 1, 0.5]); // append a second curve
+     */
+    add(data) {
+        const curve = new Curve(data);
+        curve.type = this._type;
+        this.curves.push(curve);
+        return curve;
+    }
+
+    /**
+     * Removes a curve from the curve set.
+     *
+     * @param {number|Curve} indexOrCurve - The index of the curve to remove, or the curve instance
+     * itself.
+     * @returns {Curve|null} The removed curve, or null if it was not found.
+     * @example
+     * const curveSet = new pc.CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+     * curveSet.remove(0);             // remove by index
+     * curveSet.remove(curveSet.get(0)); // or remove by reference
+     */
+    remove(indexOrCurve) {
+        const index = typeof indexOrCurve === 'number' ?
+            indexOrCurve : this.curves.indexOf(indexOrCurve);
+
+        if (index < 0 || index >= this.curves.length) {
+            return null;
+        }
+
+        return this.curves.splice(index, 1)[0];
+    }
+
+    /**
+     * Removes all keys from every curve in the set, while keeping the curves themselves. The number
+     * of curves is unchanged, so {@link CurveSet#value} still returns an array of the same length.
+     *
+     * @returns {this} The curve set instance.
+     * @example
+     * const curveSet = new pc.CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+     * curveSet.clearKeys(); // both curves are now empty, but the set still has 2 curves
+     */
+    clearKeys() {
+        for (let i = 0; i < this.curves.length; i++) {
+            this.curves[i].clear();
+        }
+        return this;
+    }
+
+    /**
+     * Removes all curves from the curve set, leaving it empty.
+     *
+     * @returns {this} The curve set instance.
+     * @example
+     * const curveSet = new pc.CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+     * curveSet.clear(); // the set now has no curves
+     */
+    clear() {
+        this.curves.length = 0;
+        return this;
+    }
+
+    /**
      * Returns the interpolated value of all curves in the curve set at the specified time.
      *
      * @param {number} time - The time at which to calculate the value.

--- a/src/core/math/curve.js
+++ b/src/core/math/curve.js
@@ -103,6 +103,37 @@ class Curve {
     }
 
     /**
+     * Removes the key at the specified index.
+     *
+     * @param {number} index - The index of the key to remove.
+     * @returns {number[]|null} The removed `[time, value]` pair, or null if the index is out of
+     * range.
+     * @example
+     * const curve = new pc.Curve([0, 1, 1, 2]);
+     * curve.remove(0); // removes the key at time 0
+     */
+    remove(index) {
+        if (index < 0 || index >= this.keys.length) {
+            return null;
+        }
+
+        return this.keys.splice(index, 1)[0];
+    }
+
+    /**
+     * Removes all keys from the curve.
+     *
+     * @returns {this} The curve instance.
+     * @example
+     * const curve = new pc.Curve([0, 1, 1, 2]);
+     * curve.clear(); // curve now has no keys
+     */
+    clear() {
+        this.keys.length = 0;
+        return this;
+    }
+
+    /**
      * Gets the `[time, value]` pair at the specified index.
      *
      * @param {number} index - The index of key to return.

--- a/test/core/math/curve-set.test.mjs
+++ b/test/core/math/curve-set.test.mjs
@@ -225,6 +225,100 @@ describe('CurveSet', function () {
 
     });
 
+    describe('#add()', function () {
+
+        it('appends a new curve and returns it', function () {
+            const curveSet = new CurveSet([[0, 0, 1, 1]]);
+            const curve = curveSet.add([0, 0, 1, 0.5]);
+
+            expect(curveSet.length).to.equal(2);
+            expect(curveSet.get(1)).to.equal(curve);
+            expect(curve.get(0)).to.deep.equal([0, 0]);
+            expect(curve.get(1)).to.deep.equal([1, 0.5]);
+        });
+
+        it('appends an empty curve when no data is supplied', function () {
+            const curveSet = new CurveSet();
+            const curve = curveSet.add();
+
+            expect(curveSet.length).to.equal(2);
+            expect(curve.length).to.equal(0);
+        });
+
+        it('makes the new curve adopt the curve set type', function () {
+            const curveSet = new CurveSet();
+            curveSet.type = CURVE_LINEAR;
+
+            const curve = curveSet.add();
+
+            expect(curve.type).to.equal(CURVE_LINEAR);
+        });
+
+    });
+
+    describe('#remove()', function () {
+
+        it('removes and returns the curve at the given index', function () {
+            const curveSet = new CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+            const first = curveSet.get(0);
+            const removed = curveSet.remove(0);
+
+            expect(removed).to.equal(first);
+            expect(curveSet.length).to.equal(1);
+        });
+
+        it('removes a curve by reference', function () {
+            const curveSet = new CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+            const second = curveSet.get(1);
+            const removed = curveSet.remove(second);
+
+            expect(removed).to.equal(second);
+            expect(curveSet.length).to.equal(1);
+            expect(curveSet.get(0)).to.not.equal(second);
+        });
+
+        it('returns null when the index is out of range', function () {
+            const curveSet = new CurveSet([[0, 0, 1, 1]]);
+            expect(curveSet.remove(1)).to.equal(null);
+            expect(curveSet.remove(-1)).to.equal(null);
+            expect(curveSet.length).to.equal(1);
+        });
+
+        it('returns null when the curve is not in the set', function () {
+            const curveSet = new CurveSet([[0, 0, 1, 1]]);
+            const other = new CurveSet().get(0);
+            expect(curveSet.remove(other)).to.equal(null);
+            expect(curveSet.length).to.equal(1);
+        });
+
+    });
+
+    describe('#clearKeys()', function () {
+
+        it('clears the keys of every curve but keeps the curves', function () {
+            const curveSet = new CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+            const result = curveSet.clearKeys();
+
+            expect(result).to.equal(curveSet);
+            expect(curveSet.length).to.equal(2);
+            expect(curveSet.get(0).length).to.equal(0);
+            expect(curveSet.get(1).length).to.equal(0);
+        });
+
+    });
+
+    describe('#clear()', function () {
+
+        it('removes all curves from the set', function () {
+            const curveSet = new CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+            const result = curveSet.clear();
+
+            expect(result).to.equal(curveSet);
+            expect(curveSet.length).to.equal(0);
+        });
+
+    });
+
     describe('#value()', function () {
 
         it('returns the optional array parameter', function () {

--- a/test/core/math/curve.test.mjs
+++ b/test/core/math/curve.test.mjs
@@ -87,6 +87,43 @@ describe('Curve', function () {
 
     });
 
+    describe('#remove', function () {
+
+        it('removes and returns the key at the given index', function () {
+            const c = new Curve([0, 0, 0.5, 1, 1, 2]);
+            const removed = c.remove(1);
+            expect(removed).to.deep.equal([0.5, 1]);
+            expect(c.length).to.equal(2);
+            expect(c.get(0)).to.deep.equal([0, 0]);
+            expect(c.get(1)).to.deep.equal([1, 2]);
+        });
+
+        it('returns null when the index is out of range', function () {
+            const c = new Curve([0, 0, 1, 2]);
+            expect(c.remove(2)).to.equal(null);
+            expect(c.remove(-1)).to.equal(null);
+            expect(c.length).to.equal(2);
+        });
+
+    });
+
+    describe('#clear', function () {
+
+        it('removes all keys from the curve', function () {
+            const c = new Curve([0, 0, 0.5, 1, 1, 2]);
+            const result = c.clear();
+            expect(c.length).to.equal(0);
+            expect(result).to.equal(c);
+        });
+
+        it('is a no-op on an empty curve', function () {
+            const c = new Curve();
+            c.clear();
+            expect(c.length).to.equal(0);
+        });
+
+    });
+
     describe('#clone', function () {
 
         it('clones an empty curve', function () {


### PR DESCRIPTION
Adds methods to remove keys and curves at runtime, so a `Curve` or `CurveSet` can be reset and rebuilt without allocating a new instance. Closes #5121.

**Changes:**
- `Curve.remove(index)` — removes the key at `index`, returns the removed `[time, value]` pair or `null` if out of range.
- `Curve.clear()` — removes all keys, returns the curve.
- `CurveSet.add(data?)` — appends a new curve (optionally from a keys array). The new curve adopts the set's current `type`, so all curves in the set continue to share the same interpolation scheme.
- `CurveSet.remove(index | Curve)` — removes a curve by index or by reference, returns it or `null`.
- `CurveSet.clearKeys()` — clears the keys of every curve while keeping the curves, so `value()` still returns an array of the same length.
- `CurveSet.clear()` — removes all curves, leaving the set empty.

**API Changes:**
- New public methods only; no changes to existing signatures or behavior.