### PR TITLE
Move frustum compute into Camera.updateFrustum

### DIFF
--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -769,7 +769,7 @@ class Lightmapper {
             shadowCam.aspectRatio = 1;
             shadowCam.fov = light._outerConeAngle * 2;
 
-            this.renderer.updateCameraFrustum(shadowCam);
+            shadowCam.updateFrustum();
         }
         return shadowCam;
     }

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -6,7 +6,7 @@ import { Vec4 } from '../core/math/vec4.js';
 import { math } from '../core/math/math.js';
 import { Frustum } from '../core/shape/frustum.js';
 import {
-    ASPECT_AUTO, PROJECTION_PERSPECTIVE, PROJECTION_ORTHOGRAPHIC,
+    VIEW_CENTER, ASPECT_AUTO, PROJECTION_PERSPECTIVE, PROJECTION_ORTHOGRAPHIC,
     LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI, LAYERID_IMMEDIATE
 } from './constants.js';
 import { FramePassColorGrab } from './graphics/frame-pass-color-grab.js';
@@ -30,6 +30,9 @@ const _point = new Vec3();
 const _invViewProjMat = new Mat4();
 const _xrViewProjMat = new Mat4();
 const _xrViewFrustum = new Frustum();
+const _frustumViewInvMat = new Mat4();
+const _frustumViewMat = new Mat4();
+const _frustumViewProjMat = new Mat4();
 const _frustumPoints = [new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3()];
 
 /**
@@ -749,6 +752,39 @@ class Camera {
             this.frustum.add(_xrViewFrustum);
         }
         return true;
+    }
+
+    /**
+     * Updates {@link Camera#frustum} for the camera's current transform and projection, for
+     * visibility culling. Uses the combined (VIEW_CENTER) view; XR cameras delegate to
+     * {@link Camera#updateXrFrustum}. Honors the {@link Camera#calculateProjection} and
+     * {@link Camera#calculateTransform} overrides.
+     *
+     * @ignore
+     */
+    updateFrustum() {
+
+        // XR: combined frustum from all views (avoids culling objects visible in only one eye)
+        if (this.updateXrFrustum()) {
+            return;
+        }
+
+        const projMat = this.projectionMatrix;
+        if (this.calculateProjection) {
+            this.calculateProjection(projMat, VIEW_CENTER);
+        }
+
+        if (this.calculateTransform) {
+            this.calculateTransform(_frustumViewInvMat, VIEW_CENTER);
+        } else {
+            const pos = this._node.getPosition();
+            const rot = this._node.getRotation();
+            _frustumViewInvMat.setTRS(pos, rot, Vec3.ONE);
+        }
+        _frustumViewMat.copy(_frustumViewInvMat).invert();
+
+        _frustumViewProjMat.mul2(projMat, _frustumViewMat);
+        this.frustum.setFromMat4(_frustumViewProjMat);
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-projector-constants.js
+++ b/src/scene/gsplat-unified/gsplat-projector-constants.js
@@ -19,7 +19,7 @@
 //
 // XR stereo variant (compiled with the `GSPLAT_XR` define; same 8 u32 / 32 B stride, so buffer
 // sizes are unchanged). Only the per-eye screen position is duplicated; everything else is shared
-// between the two eyes — valid because WebXR stereo is parallel-axis (see Renderer.updateCameraFrustum).
+// between the two eyes — valid because WebXR stereo is parallel-axis (see Camera.updateFrustum).
 // Perspective-only: clip.z is NOT stored, it is reconstructed in the hybrid VS from the shared w.
 //   [0,1] ndc0.xy   (f32)            — eye 0 normalized device coords (clip.xy / clip.w)
 //   [2,3] ndc1.xy   (f32)            — eye 1 normalized device coords

--- a/src/scene/renderer/culler.js
+++ b/src/scene/renderer/culler.js
@@ -322,7 +322,7 @@ class Culler {
             const camera = comp.cameras[i];
 
             // update the camera frustum for culling (aspect ratio auto-refreshes on read)
-            renderer.updateCameraFrustum(camera.camera);
+            camera.camera.updateFrustum();
 
             // for all of its enabled layers cull the non-directional lights once with each camera
             // lights aren't collected anywhere, but marked as visible
@@ -421,7 +421,7 @@ class Culler {
             // precull is fired before the frustum is refreshed, so a listener may adjust the camera
             scene?.fire(EVENT_PRECULL, cameraComponent);
 
-            renderer.updateCameraFrustum(camera);
+            camera.updateFrustum();
 
             for (const layer of camera.cullLayers) {
                 this.cullMeshInstances(camera, layer.meshInstances, layer.getCulledInstances(camera));

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -502,32 +502,6 @@ class Renderer {
         this.setupCullModeAndFrontFace(cullFaces, flipFactor, drawCall);
     }
 
-    updateCameraFrustum(camera) {
-
-        // XR: combined frustum from all views (avoids culling objects visible in only one eye)
-        if (camera.updateXrFrustum()) {
-            return;
-        }
-
-        const projMat = camera.projectionMatrix;
-        if (camera.calculateProjection) {
-            camera.calculateProjection(projMat, VIEW_CENTER);
-        }
-
-        if (camera.calculateTransform) {
-            camera.calculateTransform(viewInvMat, VIEW_CENTER);
-        } else {
-            const pos = camera._node.getPosition();
-            const rot = camera._node.getRotation();
-            viewInvMat.setTRS(pos, rot, Vec3.ONE);
-            this.viewInvId.setValue(viewInvMat.data);
-        }
-        viewMat.copy(viewInvMat).invert();
-
-        viewProjMat.mul2(projMat, viewMat);
-        camera.frustum.setFromMat4(viewProjMat);
-    }
-
     setBaseConstants(device, material) {
 
         // Cull mode

--- a/src/scene/renderer/shadow-renderer-directional.js
+++ b/src/scene/renderer/shadow-renderer-directional.js
@@ -181,7 +181,7 @@ class ShadowRendererDirectional {
             shadowCam.orthoHeight = radius;
 
             // cull shadow casters
-            this.renderer.updateCameraFrustum(shadowCam);
+            shadowCam.updateFrustum();
             this.shadowRenderer.cullShadowCasters(comp, light, lightRenderData.visibleCasters, shadowCam, casters);
 
             const cascadeFlag = 1 << cascade;

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -91,7 +91,7 @@ class ShadowRendererLocal {
             }
 
             // cull shadow casters
-            this.renderer.updateCameraFrustum(shadowCam);
+            shadowCam.updateFrustum();
             this.shadowRenderer.cullShadowCasters(comp, light, lightRenderData.visibleCasters, shadowCam, casters);
         }
     }


### PR DESCRIPTION
Moves the per-camera frustum computation from `Renderer.updateCameraFrustum(camera)` to a pure `Camera.updateFrustum()` — the frustum is camera state, so it belongs on `Camera`. No behavior change beyond dropping one dead side effect (below).

**Changes:**
- New `Camera.updateFrustum()`: computes the camera's culling frustum (XR-combined view when in XR; honors the `calculateProjection` / `calculateTransform` overrides). Replaces `Renderer.updateCameraFrustum`.
- Dropped the cull-time `matrix_viewInverse` uniform write that lived inside the old method. It was vestigial: the only consumers of that uniform are particle billboard shaders, which render in the forward pass *after* `setCameraUniforms` sets it (and the write was only on one of the method's two branches, so nothing could have relied on it during culling).
- Call sites updated to `camera.updateFrustum()` — the culler, both shadow renderers, and the lightmapper.

**Note:** Internal refactor (`Renderer` / `Camera` internals); no public API change.