### PR TITLE
Rebuild bind groups when a bound texture's GPU resource is recreated

### DIFF
--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -64,6 +64,25 @@ class BindGroup {
     _uniformBufferContainers = [];
 
     /**
+     * For each texture / storage-texture slot, the GPU implementation object the slot was last
+     * built against. A texture's `impl` is replaced when its GPU resource is recreated (e.g.
+     * {@link Texture#resize}), which can happen mid-render in the same render version the bind
+     * group was last built — so the {@link renderVersionDirty} check alone misses it and the bind
+     * group keeps a view of the (now destroyed) old GPU texture. Tracking impl identity forces a
+     * rebuild whenever the underlying GPU resource is recreated.
+     *
+     * @type {object[]}
+     * @private
+     */
+    _textureImpls = [];
+
+    /**
+     * @type {object[]}
+     * @private
+     */
+    _storageTextureImpls = [];
+
+    /**
      * Create a new Bind Group.
      *
      * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this uniform buffer.
@@ -153,7 +172,11 @@ class BindGroup {
         } else if (this.renderVersionUpdated < texture.renderVersionDirty) {
             // if the texture properties have changed
             this.dirty = true;
+        } else if (this._textureImpls[index] !== texture.impl) {
+            // the texture's GPU resource was recreated (e.g. resize) since the last build
+            this.dirty = true;
         }
+        this._textureImpls[index] = texture.impl;
     }
 
     /**
@@ -175,7 +198,11 @@ class BindGroup {
         } else if (this.renderVersionUpdated < texture.renderVersionDirty) {
             // if the texture properties have changed
             this.dirty = true;
+        } else if (this._storageTextureImpls[index] !== texture.impl) {
+            // the texture's GPU resource was recreated (e.g. resize) since the last build
+            this.dirty = true;
         }
+        this._storageTextureImpls[index] = texture.impl;
     }
 
     /**


### PR DESCRIPTION
## Summary

A `BindGroup` rebuilds its underlying GPU bind group when a bound texture changes, but the dirty check missed the case where a texture's GPU resource is *recreated in place* (same `Texture` JS object, new `impl`) during a render. When this happens, the bind group keeps a view of the old — now destroyed — GPU texture, which surfaces under WebGPU as `Destroyed texture [...] used in a submit` validation errors and visible corruption (e.g. black frames).

The existing texture dirty check in `setTexture`/`setStorageTexture` is:

```js
if (this.textures[index] !== value) {
    this.dirty = true;                                  // a different texture was bound
} else if (this.renderVersionUpdated < texture.renderVersionDirty) {
    this.dirty = true;                                  // texture properties changed
}
```

`renderVersionDirty` is stamped with `device.renderVersion`, which only increments once per rendered frame (`GraphicsDevice.frameStart`). So when a texture is resized *mid-render* — in the same render version the consuming bind group was last built — `renderVersionUpdated < renderVersionDirty` is false and the rebuild is skipped, leaving a stale view of the destroyed GPU texture.

## Repro context

Hit by unified gsplat LOD streaming with `app.autoRender = false`: the work-buffer textures (`Texture#resize`) grow mid-render as splats stream in, in the same render version as the renderers that bind them. `Texture.resize` already defers GPU destruction until after submit, but the deferred destroy still fires while a bind group holds a view of the old `impl`, producing `Destroyed texture [... R32Uint / RGBA32Uint ...] used in a submit`.

## Fix

Track the GPU `impl` object each texture/storage-texture slot was last built against, and mark the bind group dirty when it changes. `impl` identity changes exactly when the GPU resource is recreated (resize, lose-context, format change), so this catches mid-render recreation regardless of render-version timing, and adds no rebuilds in steady state (`impl` is otherwise stable across frames).

## Notes

- Not gsplat-specific — applies to any texture resized mid-render in the same render version as a consumer bind group.
- No API or behavior change beyond the added rebuild; steady-state cost is one identity comparison and array write per bound texture per `update()`.