### PR TITLE
Fix AnimationComponent crash on tracks with events

### DIFF
--- a/src/framework/anim/evaluator/anim-clip.js
+++ b/src/framework/anim/evaluator/anim-clip.js
@@ -186,7 +186,7 @@ class AnimClip {
     }
 
     fireNextEvent() {
-        this._eventHandler.fire(this.nextEvent.name, { track: this.track, ...this.nextEvent });
+        this._eventHandler?.fire(this.nextEvent.name, { track: this.track, ...this.nextEvent });
         this.moveEventCursor();
     }
 

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -337,7 +337,9 @@ class AnimationComponent extends Component {
                     this.animEvaluator.removeClips();
                 }
 
-                const clip = new AnimClip(this.animations[this.currAnim], 0, 1.0, true, this.loop);
+                // pass the component as the event handler so any events embedded in the track
+                // fire on this component (consistent with AnimComponent)
+                const clip = new AnimClip(this.animations[this.currAnim], 0, 1.0, true, this.loop, this);
                 clip.name = this.currAnim;
                 clip.blendWeight = this.blending ? 0 : 1;
                 clip.reset();


### PR DESCRIPTION
Fixes #4930.

The legacy `AnimationComponent` constructed `AnimClip` instances in `play()` without passing an event handler. Playing a track that contains `AnimEvents` then crashed during `AnimClip.fireNextEvent` with a `TypeError`, because `this._eventHandler` was `undefined`.

**Changes:**
- `AnimationComponent.play()` now passes the component itself (which extends `EventHandler`) as the `eventHandler` argument to `new AnimClip(...)`. Embedded track events now fire on the component, consistent with how `AnimComponent` fires events on itself.
- `AnimClip.fireNextEvent` guards the `fire` call (`this._eventHandler?.fire(...)`) so any clip constructed without a handler degrades gracefully instead of throwing.

No public API changes.