### PR TITLE
Make StorageBuffer.read public

### DIFF
--- a/src/platform/graphics/storage-buffer.js
+++ b/src/platform/graphics/storage-buffer.js
@@ -101,7 +101,6 @@ class StorageBuffer {
      * to false.
      * @returns {Promise<ArrayBufferView>} A promise that resolves with the data read from the
      * storage buffer.
-     * @ignore
      */
     read(offset = 0, size = this.byteSize, data = null, immediate = false) {
         return this.impl.read(this.device, offset, size, data, immediate);


### PR DESCRIPTION
### Summary

Removes the stale `@ignore` tag from `StorageBuffer.read`, exposing it in the public API / generated type definitions.

`read` has carried `@ignore` since the method was first added (April 2024), before the storage-buffer API matured — and it was never revisited. There is no missing-feature or correctness reason for it to stay hidden:

- Its sibling mutators `write`, `clear` and `copy` are already public; `read` was the lone exception.
- The `immediate` parameter is fully documented in the JSDoc.
- The shipped public example `compute/histogram` already calls `storageBuffer.read(...)` to read compute results back to the CPU, so it is de-facto public API today.

This makes `read` the documented answer for the "run compute, get results back to the CPU" use case (see #6234). The genuinely-internal lifecycle hooks `loseContext` / `restoreContext` remain `@ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)