### PR TITLE
Use uniform buffers for view-level uniforms on WebGL2

### DIFF
--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -194,7 +194,7 @@ class RenderPassPicker extends RenderPass {
                     meshInstances: tempMeshInstances,
                     splitLights: lights,
                     lightClusters: this.emptyWorldClusters,
-                    viewUniformFormat: device.supportsUniformBuffers ? this.getViewUniformFormat() : undefined,
+                    viewUniformFormat: this.getViewUniformFormat(),
                     drawCallback: () => device.setBlendState(this.blendState)
                 });
 

--- a/src/platform/graphics/dynamic-buffer.js
+++ b/src/platform/graphics/dynamic-buffer.js
@@ -33,6 +33,14 @@ class DynamicBuffer {
         ]);
     }
 
+    /**
+     * Upload the buffer's data to the GPU. A no-op on backends (such as WebGPU) that copy the data
+     * to the GPU separately; WebGL overrides this to eagerly upload, as it has no buffer mapping and
+     * executes draws immediately.
+     */
+    upload() {
+    }
+
     getBindGroup(ub) {
         const ubSize = ub.format.byteSize;
         let bindGroup = this.bindGroupCache.get(ubSize);

--- a/src/platform/graphics/null/null-bind-group-format.js
+++ b/src/platform/graphics/null/null-bind-group-format.js
@@ -1,0 +1,11 @@
+/**
+ * A Null implementation of the BindGroupFormat.
+ *
+ * @ignore
+ */
+class NullBindGroupFormat {
+    destroy() {
+    }
+}
+
+export { NullBindGroupFormat };

--- a/src/platform/graphics/null/null-bind-group.js
+++ b/src/platform/graphics/null/null-bind-group.js
@@ -1,0 +1,14 @@
+/**
+ * A Null implementation of the BindGroup.
+ *
+ * @ignore
+ */
+class NullBindGroup {
+    update(bindGroup) {
+    }
+
+    destroy() {
+    }
+}
+
+export { NullBindGroup };

--- a/src/platform/graphics/null/null-dynamic-buffers.js
+++ b/src/platform/graphics/null/null-dynamic-buffers.js
@@ -1,0 +1,40 @@
+import { DynamicBuffer } from '../dynamic-buffer.js';
+import { DynamicBuffers } from '../dynamic-buffers.js';
+
+/**
+ * @import { DynamicBufferAllocation } from '../dynamic-buffers.js'
+ * @import { GraphicsDevice } from '../graphics-device.js'
+ */
+
+/**
+ * A Null implementation of the dynamic buffers system. It hands out CPU-only storage so the
+ * renderer's (unconditional) view uniform buffer path runs without errors and uploads nothing. A
+ * single base DynamicBuffer is reused for every allocation - it provides getBindGroup (which caches
+ * per uniform buffer size) and a no-op upload, which is all the null device needs.
+ *
+ * @ignore
+ */
+class NullDynamicBuffers extends DynamicBuffers {
+    /** @type {DynamicBuffer} */
+    buffer;
+
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     */
+    constructor(device) {
+        super(device, 0, 0);
+        this.buffer = new DynamicBuffer(device);
+    }
+
+    /**
+     * @param {DynamicBufferAllocation} allocation - The allocation info to fill.
+     * @param {number} size - The size of the allocation.
+     */
+    alloc(allocation, size) {
+        allocation.gpuBuffer = this.buffer;
+        allocation.offset = 0;
+        allocation.storage = new Int32Array(size / 4);
+    }
+}
+
+export { NullDynamicBuffers };

--- a/src/platform/graphics/null/null-graphics-device.js
+++ b/src/platform/graphics/null/null-graphics-device.js
@@ -10,6 +10,10 @@ import { NullShader } from './null-shader.js';
 import { NullTexture } from './null-texture.js';
 import { NullVertexBuffer } from './null-vertex-buffer.js';
 import { NullDrawCommands } from './null-draw-commands.js';
+import { NullUniformBuffer } from './null-uniform-buffer.js';
+import { NullBindGroup } from './null-bind-group.js';
+import { NullBindGroupFormat } from './null-bind-group-format.js';
+import { NullDynamicBuffers } from './null-dynamic-buffers.js';
 
 class NullGraphicsDevice extends GraphicsDevice {
     constructor(canvas, options = {}) {
@@ -29,6 +33,9 @@ class NullGraphicsDevice extends GraphicsDevice {
         });
 
         this.initDeviceCaps();
+
+        // no-op dynamic buffers so the (unconditional) view uniform buffer path runs harmlessly
+        this.dynamicBuffers = new NullDynamicBuffers(this);
     }
 
     destroy() {
@@ -87,6 +94,21 @@ class NullGraphicsDevice extends GraphicsDevice {
 
     createShaderImpl(shader) {
         return new NullShader(shader);
+    }
+
+    createUniformBufferImpl(uniformBuffer) {
+        return new NullUniformBuffer();
+    }
+
+    createBindGroupImpl(bindGroup) {
+        return new NullBindGroup();
+    }
+
+    createBindGroupFormatImpl(bindGroupFormat) {
+        return new NullBindGroupFormat();
+    }
+
+    setBindGroup(index, bindGroup, offsets) {
     }
 
     createTextureImpl(texture) {

--- a/src/platform/graphics/null/null-uniform-buffer.js
+++ b/src/platform/graphics/null/null-uniform-buffer.js
@@ -1,0 +1,17 @@
+/**
+ * A Null implementation of the UniformBuffer.
+ *
+ * @ignore
+ */
+class NullUniformBuffer {
+    destroy(device) {
+    }
+
+    loseContext() {
+    }
+
+    unlock(uniformBuffer) {
+    }
+}
+
+export { NullUniformBuffer };

--- a/src/platform/graphics/shader-processor-glsl.js
+++ b/src/platform/graphics/shader-processor-glsl.js
@@ -28,9 +28,6 @@ const KEYWORD = /[ \t]*(\battribute\b|\bvarying\b|\buniform\b)/g;
 // eslint-disable-next-line regexp/no-unused-capturing-group, regexp/no-super-linear-backtracking
 const KEYWORD_LINE = /(\battribute\b|\bvarying\b|\bout\b|\buniform\b)[ \t]*([^;]+)(;+)/g;
 
-// marker for a place in the source code to be replaced by code
-const MARKER = '@@@';
-
 // an array identifier, for example 'data[4]' - group 1 is 'data', group 2 is everything in brackets: '4'
 const ARRAY_IDENTIFIER = /([\w-]+)\[(.*?)\]/;
 
@@ -115,6 +112,14 @@ class UniformLine {
  */
 class ShaderProcessorGLSL {
     /**
+     * Marker for the place in the source code where generated code blocks are injected. Shared with
+     * subclasses (e.g. the WebGL2 processor) so the marker is defined in one place.
+     *
+     * @type {string}
+     */
+    static MARKER = '@@@';
+
+    /**
      * Process the shader.
      *
      * @param {GraphicsDevice} device - The graphics device.
@@ -165,11 +170,11 @@ class ShaderProcessorGLSL {
 
         // VS - insert the blocks to the source
         const vBlock = `${attributesBlock}\n${vertexVaryingsBlock}\n${uniformsData.code}`;
-        const vshader = vertexExtracted.src.replace(MARKER, vBlock);
+        const vshader = vertexExtracted.src.replace(ShaderProcessorGLSL.MARKER, vBlock);
 
         // FS - insert the blocks to the source
         const fBlock = `${fragmentVaryingsBlock}\n${outBlock}\n${uniformsData.code}`;
-        const fshader = fragmentExtracted.src.replace(MARKER, fBlock);
+        const fshader = fragmentExtracted.src.replace(ShaderProcessorGLSL.MARKER, fBlock);
 
         return {
             vshader: vshader,
@@ -180,8 +185,10 @@ class ShaderProcessorGLSL {
         };
     }
 
-    // Extract required information from the shader source code.
-    static extract(src) {
+    // Extract required information from the shader source code. When uniformsOnly is true, only
+    // 'uniform' lines are extracted - attributes and varyings are left in the source unchanged (the
+    // WebGL2 path relies on the gles3 compatibility macros to handle those).
+    static extract(src, uniformsOnly = false) {
 
         // collected data
         const attributes = [];
@@ -191,13 +198,19 @@ class ShaderProcessorGLSL {
 
         // replacement marker - mark a first replacement place, this is where code
         // blocks are injected later
-        let replacement = `${MARKER}\n`;
+        let replacement = `${ShaderProcessorGLSL.MARKER}\n`;
 
         // extract relevant parts of the shader
         let match;
         while ((match = KEYWORD.exec(src)) !== null) {
 
             const keyword = match[1];
+
+            // in uniforms-only mode, leave attribute / varying lines untouched
+            if (uniformsOnly && keyword !== 'uniform') {
+                continue;
+            }
+
             switch (keyword) {
                 case 'attribute':
                 case 'varying':
@@ -236,6 +249,18 @@ class ShaderProcessorGLSL {
             outs,
             uniforms
         };
+    }
+
+    /**
+     * Parse extracted uniform lines into {@link UniformLine} instances. Exposed so subclasses (e.g.
+     * the WebGL2 processor) can reuse the parsing without needing access to the private UniformLine.
+     *
+     * @param {string[]} uniformLines - The uniform lines (bodies, without the 'uniform' keyword).
+     * @param {Shader} shader - The shader.
+     * @returns {Array<UniformLine>} The parsed uniform lines.
+     */
+    static parseUniformLines(uniformLines, shader) {
+        return uniformLines.map(line => new UniformLine(line, shader));
     }
 
     /**
@@ -509,4 +534,4 @@ class ShaderProcessorGLSL {
     }
 }
 
-export { ShaderProcessorGLSL };
+export { ShaderProcessorGLSL, UniformLine };

--- a/src/platform/graphics/uniform-buffer.js
+++ b/src/platform/graphics/uniform-buffer.js
@@ -248,8 +248,9 @@ class UniformBuffer {
 
             graphicsDevice._vram.ub += this.format.byteSize;
 
-            // TODO: register with the device and handle lost context
-            // this.device.buffers.push(this);
+            // register with the device so the GPU buffer is recreated and re-uploaded on a lost
+            // context (non-persistent buffers re-allocate from the dynamic buffers on next update)
+            this.device.buffers.add(this);
         } else {
 
             this.allocation = new DynamicBufferAllocation();
@@ -262,9 +263,10 @@ class UniformBuffer {
     destroy() {
 
         if (this.persistent) {
-            // stop tracking the vertex buffer
-            // TODO: remove the buffer from the list on the device (lost context handling)
             const device = this.device;
+
+            // stop tracking the buffer for lost context handling
+            device.buffers.delete(this);
 
             this.impl.destroy(device);
 
@@ -292,6 +294,15 @@ class UniformBuffer {
      */
     loseContext() {
         this.impl?.loseContext();
+    }
+
+    /**
+     * Called when the rendering context is restored. Recreates the GPU buffer and re-uploads the
+     * data from the persistent CPU storage. Only persistent uniform buffers are tracked for context
+     * loss; non-persistent ones are re-allocated from the dynamic buffers on their next update.
+     */
+    restoreContext() {
+        this.impl?.unlock(this);
     }
 
     /**
@@ -356,6 +367,9 @@ class UniformBuffer {
             // Upload the new data
             this.impl.unlock(this);
         } else {
+            // upload the data to the dynamic buffer - a no-op on backends that copy it separately
+            // (WebGPU), but WebGL uploads eagerly here
+            this.allocation.gpuBuffer.upload();
             this.storageFloat32 = null;
             this.storageInt32 = null;
         }

--- a/src/platform/graphics/webgl/webgl-bind-group-format.js
+++ b/src/platform/graphics/webgl/webgl-bind-group-format.js
@@ -1,0 +1,15 @@
+/**
+ * A WebGL implementation of the BindGroupFormat.
+ *
+ * Uniform buffer binding points on WebGL2 are derived directly from the bind group index (see
+ * {@link WebglGraphicsDevice#setBindGroup} and {@link WebglShader} uniform block linking), so the
+ * format itself needs no GPU-side resources.
+ *
+ * @ignore
+ */
+class WebglBindGroupFormat {
+    destroy() {
+    }
+}
+
+export { WebglBindGroupFormat };

--- a/src/platform/graphics/webgl/webgl-bind-group.js
+++ b/src/platform/graphics/webgl/webgl-bind-group.js
@@ -1,17 +1,38 @@
 /**
  * A WebGL implementation of the BindGroup.
  *
- * On WebGL2 there is no GPU-side bind group object - uniform buffers are bound to their binding
- * points at draw time in {@link WebglGraphicsDevice#setBindGroup}, which reads the resolved GL
- * buffers directly from the {@link BindGroup}. This impl therefore holds no state.
+ * On WebGL2 there is no GPU-side bind group object. Instead, at update time this captures - per
+ * uniform buffer slot - the object that owns the GL buffer (the persistent buffer impl, or the
+ * dynamic buffer the uniform buffer is currently allocated from). {@link WebglGraphicsDevice#setBindGroup}
+ * then binds those captured buffers. Capturing here (rather than reading the uniform buffer's live
+ * allocation at draw time) is essential when a single uniform buffer is re-allocated several times
+ * in a frame - e.g. the shared view UB across XR multiview eyes: each eye's bind group must bind
+ * the buffer it was built for, not the buffer the shared uniform buffer ends up pointing at.
  *
  * @ignore
  */
 class WebglBindGroup {
+    /**
+     * Per uniform-buffer slot, the object exposing the GL buffer via its `bufferId` (a
+     * WebglUniformBuffer for persistent buffers, or a WebglDynamicBuffer for dynamic ones). The GL
+     * buffer is read lazily at bind time, as a dynamic buffer's `bufferId` is created on its first
+     * upload, after this bind group is built.
+     *
+     * @type {Array<{ bufferId: WebGLBuffer|null }>}
+     */
+    buffers = [];
+
     update(bindGroup) {
+        const uniformBuffers = bindGroup.uniformBuffers;
+        this.buffers.length = uniformBuffers.length;
+        for (let i = 0; i < uniformBuffers.length; i++) {
+            const uniformBuffer = uniformBuffers[i];
+            this.buffers[i] = uniformBuffer.persistent ? uniformBuffer.impl : uniformBuffer.allocation.gpuBuffer;
+        }
     }
 
     destroy() {
+        this.buffers.length = 0;
     }
 }
 

--- a/src/platform/graphics/webgl/webgl-bind-group.js
+++ b/src/platform/graphics/webgl/webgl-bind-group.js
@@ -1,0 +1,18 @@
+/**
+ * A WebGL implementation of the BindGroup.
+ *
+ * On WebGL2 there is no GPU-side bind group object - uniform buffers are bound to their binding
+ * points at draw time in {@link WebglGraphicsDevice#setBindGroup}, which reads the resolved GL
+ * buffers directly from the {@link BindGroup}. This impl therefore holds no state.
+ *
+ * @ignore
+ */
+class WebglBindGroup {
+    update(bindGroup) {
+    }
+
+    destroy() {
+    }
+}
+
+export { WebglBindGroup };

--- a/src/platform/graphics/webgl/webgl-dynamic-buffer.js
+++ b/src/platform/graphics/webgl/webgl-dynamic-buffer.js
@@ -1,0 +1,85 @@
+import { DynamicBuffer } from '../dynamic-buffer.js';
+
+/**
+ * @import { WebglGraphicsDevice } from './webgl-graphics-device.js'
+ */
+
+/**
+ * A WebGL implementation of a dynamic buffer - a single whole uniform buffer that is handed out
+ * from a pool for one frame at a time. The data is written into a CPU-side backing array and
+ * uploaded with `bufferData` (a full respecify), which orphans the previous storage and lets the
+ * driver hand back fresh storage - so reusing a buffer never stalls on in-flight draws. As each use
+ * gets its own buffer, the offset into it is always zero.
+ *
+ * @ignore
+ */
+class WebglDynamicBuffer extends DynamicBuffer {
+    /**
+     * The GL buffer object (mirrors WebgpuDynamicBuffer.buffer). Created lazily on the first
+     * upload, so it is also recreated automatically after a context loss nulls it.
+     *
+     * @type {WebGLBuffer|null}
+     */
+    bufferId = null;
+
+    /**
+     * CPU-side backing for the whole buffer, written to during the uniform buffer update and
+     * uploaded by {@link upload}.
+     *
+     * @type {Int32Array}
+     */
+    storage;
+
+    /**
+     * Byte size of the buffer.
+     *
+     * @type {number}
+     */
+    size;
+
+    /**
+     * @param {WebglGraphicsDevice} device - The graphics device.
+     * @param {number} size - The byte size of the buffer.
+     */
+    constructor(device, size) {
+        super(device);
+
+        this.size = size;
+        this.storage = new Int32Array(size / 4);
+
+        device._vram.ub += size;
+    }
+
+    destroy(device) {
+        if (this.bufferId) {
+            device.gl.deleteBuffer(this.bufferId);
+            this.bufferId = null;
+        }
+        device._vram.ub -= this.size;
+    }
+
+    /**
+     * Called when the rendering context is lost. The GL buffer is gone with the context, so drop
+     * the handle; the next upload recreates it. The CPU storage and pooling are preserved.
+     */
+    loseContext() {
+        this.bufferId = null;
+    }
+
+    /**
+     * Upload the CPU backing to the GL buffer, creating the buffer on first use (or after a context
+     * loss). Uses `bufferData` (full respecify) so the driver orphans the previous storage - this
+     * avoids a pipeline stall when the buffer is reused while the previous frame's draws may still
+     * be reading it.
+     */
+    upload() {
+        const gl = this.device.gl;
+        if (!this.bufferId) {
+            this.bufferId = gl.createBuffer();
+        }
+        gl.bindBuffer(gl.UNIFORM_BUFFER, this.bufferId);
+        gl.bufferData(gl.UNIFORM_BUFFER, this.storage, gl.STREAM_DRAW);
+    }
+}
+
+export { WebglDynamicBuffer };

--- a/src/platform/graphics/webgl/webgl-dynamic-buffers.js
+++ b/src/platform/graphics/webgl/webgl-dynamic-buffers.js
@@ -1,0 +1,101 @@
+import { WebglDynamicBuffer } from './webgl-dynamic-buffer.js';
+
+/**
+ * @import { DynamicBufferAllocation } from '../dynamic-buffers.js'
+ * @import { WebglGraphicsDevice } from './webgl-graphics-device.js'
+ */
+
+/**
+ * A WebGL implementation of the dynamic buffers system. Unlike WebGPU (which sub-allocates from
+ * large mapped pages and copies them to the GPU at submit time), WebGL2 has no buffer mapping and
+ * executes draws immediately. So instead this hands out a whole {@link WebglDynamicBuffer} per
+ * allocation from a pool keyed by size, and the buffer uploads its data eagerly using `bufferData`
+ * (orphaning). Each buffer is handed out at most once per frame and returned to the free pool at
+ * the end of the frame, which - together with orphaning - gives distinct buffers for uses that are
+ * live at the same time (e.g. XR multiview eyes) and stall-free reuse across frames.
+ *
+ * @ignore
+ */
+class WebglDynamicBuffers {
+    /**
+     * Free buffers available for allocation, keyed by byte size.
+     *
+     * @type {Map<number, WebglDynamicBuffer[]>}
+     */
+    free = new Map();
+
+    /**
+     * Buffers handed out during the current frame, returned to the free pool at frame end.
+     *
+     * @type {WebglDynamicBuffer[]}
+     */
+    used = [];
+
+    /**
+     * @param {WebglGraphicsDevice} device - The graphics device.
+     */
+    constructor(device) {
+        this.device = device;
+    }
+
+    destroy() {
+        this.used.forEach(buffer => buffer.destroy(this.device));
+        this.free.forEach(buffers => buffers.forEach(buffer => buffer.destroy(this.device)));
+        this.used = null;
+        this.free = null;
+    }
+
+    /**
+     * Allocate a whole buffer of the given size for this frame.
+     *
+     * @param {DynamicBufferAllocation} allocation - The allocation info to fill.
+     * @param {number} size - The size of the allocation.
+     */
+    alloc(allocation, size) {
+
+        // reuse a free buffer of matching size, or create a new one
+        let buffer = this.free.get(size)?.pop();
+        if (!buffer) {
+            buffer = new WebglDynamicBuffer(this.device, size);
+        }
+        this.used.push(buffer);
+
+        // a whole buffer per allocation - the offset is always zero
+        allocation.gpuBuffer = buffer;
+        allocation.offset = 0;
+        allocation.storage = buffer.storage;
+    }
+
+    /**
+     * Return the frame's buffers to the free pool. Called at the end of the frame, so it runs after
+     * all allocations (including any made before frameStart, e.g. from app update handlers).
+     */
+    onFrameEnd() {
+        const used = this.used;
+        for (let i = 0; i < used.length; i++) {
+            const buffer = used[i];
+            let pool = this.free.get(buffer.size);
+            if (!pool) {
+                pool = [];
+                this.free.set(buffer.size, pool);
+            }
+            pool.push(buffer);
+        }
+        used.length = 0;
+    }
+
+    /**
+     * Called when the rendering context is lost. Returns any in-flight buffers to the free pool and
+     * drops every buffer's GL handle (without deleting - the context is invalid). The buffer objects
+     * and their CPU storage are kept, so they are reused and their GL buffers recreated on the next
+     * upload after the context is restored.
+     */
+    loseContext() {
+        this.onFrameEnd();
+        this.free.forEach((buffers) => {
+            buffers.forEach(buffer => buffer.loseContext());
+        });
+    }
+}
+
+export { WebglDynamicBuffers };

--- a/src/platform/graphics/webgl/webgl-dynamic-buffers.js
+++ b/src/platform/graphics/webgl/webgl-dynamic-buffers.js
@@ -1,3 +1,4 @@
+import { DynamicBuffers } from '../dynamic-buffers.js';
 import { WebglDynamicBuffer } from './webgl-dynamic-buffer.js';
 
 /**
@@ -16,7 +17,7 @@ import { WebglDynamicBuffer } from './webgl-dynamic-buffer.js';
  *
  * @ignore
  */
-class WebglDynamicBuffers {
+class WebglDynamicBuffers extends DynamicBuffers {
     /**
      * Free buffers available for allocation, keyed by byte size.
      *
@@ -35,7 +36,9 @@ class WebglDynamicBuffers {
      * @param {WebglGraphicsDevice} device - The graphics device.
      */
     constructor(device) {
-        this.device = device;
+        // this implementation uses a per-size whole-buffer pool, not the base bump allocator, so
+        // the base buffer size / alignment are unused
+        super(device, 0, 0);
     }
 
     destroy() {

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -33,6 +33,10 @@ import { DebugGraphics } from '../debug-graphics.js';
 import { WebglVertexBuffer } from './webgl-vertex-buffer.js';
 import { WebglIndexBuffer } from './webgl-index-buffer.js';
 import { WebglShader } from './webgl-shader.js';
+import { WebglUniformBuffer } from './webgl-uniform-buffer.js';
+import { WebglBindGroup } from './webgl-bind-group.js';
+import { WebglBindGroupFormat } from './webgl-bind-group-format.js';
+import { WebglDynamicBuffers } from './webgl-dynamic-buffers.js';
 import { WebglDrawCommands } from './webgl-draw-commands.js';
 import { WebglTexture } from './webgl-texture.js';
 import { WebglRenderTarget } from './webgl-render-target.js';
@@ -47,6 +51,7 @@ import { TextureUtils } from '../texture-utils.js';
 import { getBuiltInTexture } from '../built-in-textures.js';
 
 /**
+ * @import { BindGroup } from '../bind-group.js'
  * @import { RenderPass } from '../render-pass.js'
  * @import { Shader } from '../shader.js'
  * @import { VertexBuffer } from '../vertex-buffer.js'
@@ -234,6 +239,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initializeContextCaches();
 
         this.createBackbuffer(null);
+
+        // dynamic uniform buffer support (whole-buffer pool, see WebglDynamicBuffers)
+        this.dynamicBuffers = new WebglDynamicBuffers(this);
 
         // only enable ImageBitmap on chrome
         this.supportsImageBitmap = !isSafari && typeof ImageBitmap !== 'undefined';
@@ -707,6 +715,41 @@ class WebglGraphicsDevice extends GraphicsDevice {
         return new WebglShader(shader);
     }
 
+    createUniformBufferImpl(uniformBuffer) {
+        return new WebglUniformBuffer();
+    }
+
+    createBindGroupFormatImpl(bindGroupFormat) {
+        return new WebglBindGroupFormat();
+    }
+
+    createBindGroupImpl(bindGroup) {
+        return new WebglBindGroup();
+    }
+
+    /**
+     * @param {number} index - Index of the bind group slot
+     * @param {BindGroup} bindGroup - Bind group to attach
+     * @param {number[]} [offsets] - Byte offsets for all uniform buffers in the bind group. Unused
+     * on WebGL: every uniform buffer is bound as a whole buffer from offset zero (see below).
+     */
+    setBindGroup(index, bindGroup, offsets) {
+
+        // WebGL2 has no bind group object, so we bind each of the bind group's uniform buffers to a
+        // uniform buffer binding point directly. The bind group index is used as the binding point,
+        // matching the uniform block linking done in WebglShader, and relies on a single uniform
+        // buffer per bind group (the case in the engine's view / mesh bind group layout). Each
+        // uniform buffer is a whole buffer - persistent, or a whole dynamic buffer from the pool -
+        // so it is always bound from offset zero with bindBufferBase, and the offsets are not used.
+        const gl = this.gl;
+        const uniformBuffers = bindGroup.uniformBuffers;
+        for (let i = 0; i < uniformBuffers.length; i++) {
+            const uniformBuffer = uniformBuffers[i];
+            const buffer = uniformBuffer.persistent ? uniformBuffer.impl.bufferId : uniformBuffer.allocation.gpuBuffer.bufferId;
+            gl.bindBufferBase(gl.UNIFORM_BUFFER, index, buffer);
+        }
+    }
+
     createDrawCommandImpl(drawCommands) {
         return new WebglDrawCommands(drawCommands.indexSizeBytes);
     }
@@ -1041,6 +1084,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
             shader.loseContext();
         }
 
+        // release dynamic uniform buffers (their GL buffers are gone with the context)
+        this.dynamicBuffers.loseContext();
+
         this.fire('devicelost');
     }
 
@@ -1290,6 +1336,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         super.frameEnd();
         this.gpuProfiler.frameEnd();
         this.gpuProfiler.request();
+
+        // recycle dynamic uniform buffers used this frame back to the free pool
+        this.dynamicBuffers.onFrameEnd();
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -746,6 +746,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
         // shared view UB across XR multiview eyes) binds the buffer this bind group was built for.
         const gl = this.gl;
         const buffers = bindGroup.impl.buffers;
+
+        // all uniform buffers in the group would bind to the same point (index), so only a single
+        // uniform buffer per bind group is supported (matches the uniform block linking in WebglShader)
+        Debug.assert(buffers.length <= 1, `Bind group at index ${index} has ${buffers.length} uniform buffers, but WebGL2 supports a single uniform buffer per bind group.`, bindGroup);
+
         for (let i = 0; i < buffers.length; i++) {
             gl.bindBufferBase(gl.UNIFORM_BUFFER, index, buffers[i].bufferId);
         }

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -741,12 +741,13 @@ class WebglGraphicsDevice extends GraphicsDevice {
         // buffer per bind group (the case in the engine's view / mesh bind group layout). Each
         // uniform buffer is a whole buffer - persistent, or a whole dynamic buffer from the pool -
         // so it is always bound from offset zero with bindBufferBase, and the offsets are not used.
+        // The buffers were captured by WebglBindGroup.update (not read from the uniform buffer's
+        // live allocation here), so a uniform buffer re-allocated several times in a frame (e.g. the
+        // shared view UB across XR multiview eyes) binds the buffer this bind group was built for.
         const gl = this.gl;
-        const uniformBuffers = bindGroup.uniformBuffers;
-        for (let i = 0; i < uniformBuffers.length; i++) {
-            const uniformBuffer = uniformBuffers[i];
-            const buffer = uniformBuffer.persistent ? uniformBuffer.impl.bufferId : uniformBuffer.allocation.gpuBuffer.bufferId;
-            gl.bindBufferBase(gl.UNIFORM_BUFFER, index, buffer);
+        const buffers = bindGroup.impl.buffers;
+        for (let i = 0; i < buffers.length; i++) {
+            gl.bindBufferBase(gl.UNIFORM_BUFFER, index, buffers[i].bufferId);
         }
     }
 

--- a/src/platform/graphics/webgl/webgl-shader-processor-glsl.js
+++ b/src/platform/graphics/webgl/webgl-shader-processor-glsl.js
@@ -1,0 +1,107 @@
+import { Debug } from '../../../core/debug.js';
+import { BINDGROUP_VIEW, bindGroupNames, uniformTypeToName } from '../constants.js';
+import { ShaderProcessorGLSL } from '../shader-processor-glsl.js';
+
+/**
+ * @import { GraphicsDevice } from '../graphics-device.js'
+ * @import { Shader } from '../shader.js'
+ * @import { ShaderProcessorOptions } from '../shader-processor-options.js'
+ * @import { UniformBufferFormat } from '../uniform-buffer-format.js'
+ * @import { UniformLine } from '../shader-processor-glsl.js'
+ */
+
+/**
+ * A WebGL2-specific GLSL shader processor. Unlike the base {@link ShaderProcessorGLSL#run} - which
+ * targets the WebGPU transpile path and emits Vulkan-flavored GLSL (separate texture/sampler,
+ * `layout(set=, binding=)`, explicit varying locations) - this performs limited-scope processing:
+ * it extracts only the standalone view-level uniform declarations and replaces them with a single
+ * std140 `ub_view` block (valid GLSL ES 3.00). Attributes, varyings, outputs, textures and all
+ * non-view (mesh / material / custom) uniforms are left untouched - they are handled by the gles3
+ * compatibility macros and the per-uniform commit path.
+ *
+ * @ignore
+ */
+class WebglShaderProcessorGLSL extends ShaderProcessorGLSL {
+    /**
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {object} shaderDefinition - The shader definition.
+     * @param {Shader} shader - The shader.
+     * @returns {{ vshader: string, fshader: string }} The processed shader sources.
+     */
+    static run(device, shaderDefinition, shader) {
+
+        // extract only the uniform lines, leaving attributes / varyings / outs in the source for
+        // the gles3 compatibility macros to handle
+        const vertexExtracted = WebglShaderProcessorGLSL.extract(shaderDefinition.vshader, true);
+        const fragmentExtracted = WebglShaderProcessorGLSL.extract(shaderDefinition.fshader, true);
+
+        // merge and de-duplicate uniforms declared in either stage
+        const concatUniforms = vertexExtracted.uniforms.concat(fragmentExtracted.uniforms);
+        const uniforms = Array.from(new Set(concatUniforms));
+        const parsedUniforms = WebglShaderProcessorGLSL.parseUniformLines(uniforms, shader);
+
+        // generate the uniform code - the same block is injected into both stages, as required for
+        // a shared uniform buffer
+        const code = WebglShaderProcessorGLSL.processUniformsGL2(parsedUniforms, shaderDefinition.processingOptions);
+
+        // inject at the marker (present only in a stage that declared at least one uniform)
+        const vshader = vertexExtracted.src.replace(ShaderProcessorGLSL.MARKER, code);
+        const fshader = fragmentExtracted.src.replace(ShaderProcessorGLSL.MARKER, code);
+
+        return { vshader, fshader };
+    }
+
+    /**
+     * Generate the uniform code for a WebGL2 shader: a single std140 view uniform block plus all
+     * non-view uniforms re-emitted as individual uniforms (which keep their per-uniform commit path).
+     *
+     * @param {Array<UniformLine>} uniforms - The parsed uniform lines.
+     * @param {ShaderProcessorOptions} processingOptions - The shader processing options.
+     * @returns {string} The generated GLSL.
+     */
+    static processUniformsGL2(uniforms, processingOptions) {
+
+        let code = '';
+
+        // view uniform buffer block - generated from the full view format, so its std140 layout
+        // matches the uniform buffer the renderer uploads
+        const viewFormat = processingOptions.uniformFormats[BINDGROUP_VIEW];
+        if (viewFormat) {
+            code += WebglShaderProcessorGLSL.getUniformShaderDeclarationGL2(viewFormat, BINDGROUP_VIEW);
+        }
+
+        // re-emit all non-view uniforms (numeric and samplers) as individual uniforms
+        uniforms.forEach((uniform) => {
+            if (!processingOptions.hasUniform(uniform.name)) {
+                code += `uniform ${uniform.line};\n`;
+            }
+        });
+
+        return code;
+    }
+
+    /**
+     * Generate a WebGL2 std140 uniform block declaration. Unlike the base
+     * {@link ShaderProcessorGLSL#getUniformShaderDeclaration} it emits no `set` / `binding` layout
+     * qualifiers - the block is linked to its binding point at runtime by WebglShader via
+     * `gl.uniformBlockBinding`.
+     *
+     * @param {UniformBufferFormat} format - The uniform buffer format.
+     * @param {number} bindGroup - The bind group index, used to name the block `ub_<bindGroupName>`.
+     * @returns {string} The block declaration.
+     */
+    static getUniformShaderDeclarationGL2(format, bindGroup) {
+        const name = bindGroupNames[bindGroup];
+        let code = `layout(std140) uniform ub_${name} {\n`;
+
+        format.uniforms.forEach((uniform) => {
+            const typeString = uniformTypeToName[uniform.type];
+            Debug.assert(typeString.length > 0, `Uniform type ${uniform.type} is not handled.`);
+            code += `    ${typeString} ${uniform.shortName}${uniform.count ? `[${uniform.count}]` : ''};\n`;
+        });
+
+        return `${code}};\n`;
+    }
+}
+
+export { WebglShaderProcessorGLSL };

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -5,6 +5,7 @@ import { WebglShaderInput } from './webgl-shader-input.js';
 import { bindGroupNames, SHADERTAG_MATERIAL, semanticToLocation } from '../constants.js';
 import { DeviceCache } from '../device-cache.js';
 import { DebugGraphics } from '../debug-graphics.js';
+import { WebglShaderProcessorGLSL } from './webgl-shader-processor-glsl.js';
 
 /**
  * @import { Shader } from '../shader.js'
@@ -83,6 +84,10 @@ class WebglShader {
         this.glProgram = null;
         this.glVertexShader = null;
         this.glFragmentShader = null;
+
+        // the GLSL sources actually compiled (post-processing), used for error reporting
+        this._vsource = null;
+        this._fsource = null;
     }
 
     /**
@@ -112,8 +117,28 @@ class WebglShader {
     compile(device, shader) {
 
         const definition = shader.definition;
-        this.glVertexShader = this._compileShaderSource(device, definition.vshader, true);
-        this.glFragmentShader = this._compileShaderSource(device, definition.fshader, false);
+
+        // shaders generated with processing options are run through the WebGL2 shader processor,
+        // which injects the view uniform buffer block (mirrors WebgpuShader's processingOptions gate)
+        let vsource = definition.vshader;
+        let fsource = definition.fshader;
+        if (definition.processingOptions) {
+            const processed = WebglShaderProcessorGLSL.run(device, definition, shader);
+            vsource = processed.vshader;
+            fsource = processed.fshader;
+
+            // keep reference to processed shaders in debug mode
+            Debug.call(() => {
+                this.processed = processed;
+            });
+        }
+
+        // the sources actually compiled - used for error reporting so line numbers match
+        this._vsource = vsource;
+        this._fsource = fsource;
+
+        this.glVertexShader = this._compileShaderSource(device, vsource, true);
+        this.glFragmentShader = this._compileShaderSource(device, fsource, false);
     }
 
     /**
@@ -292,12 +317,12 @@ class WebglShader {
         const linkStatus = gl.getProgramParameter(glProgram, gl.LINK_STATUS);
         if (!linkStatus) {
 
-            // Check for compilation errors
-            if (!this._isCompiled(device, shader, this.glVertexShader, definition.vshader, 'vertex')) {
+            // Check for compilation errors (use the actually-compiled sources so line numbers match)
+            if (!this._isCompiled(device, shader, this.glVertexShader, this._vsource, 'vertex')) {
                 return false;
             }
 
-            if (!this._isCompiled(device, shader, this.glFragmentShader, definition.fshader, 'fragment')) {
+            if (!this._isCompiled(device, shader, this.glFragmentShader, this._fsource, 'fragment')) {
                 return false;
             }
 

--- a/src/platform/graphics/webgl/webgl-shader.js
+++ b/src/platform/graphics/webgl/webgl-shader.js
@@ -2,7 +2,7 @@ import { Debug } from '../../../core/debug.js';
 import { TRACEID_SHADER_COMPILE } from '../../../core/constants.js';
 import { now } from '../../../core/time.js';
 import { WebglShaderInput } from './webgl-shader-input.js';
-import { SHADERTAG_MATERIAL, semanticToLocation } from '../constants.js';
+import { bindGroupNames, SHADERTAG_MATERIAL, semanticToLocation } from '../constants.js';
 import { DeviceCache } from '../device-cache.js';
 import { DebugGraphics } from '../debug-graphics.js';
 
@@ -350,6 +350,12 @@ class WebglShader {
                 continue;
             }
 
+            // uniforms that are members of a uniform block have no individual location - they are
+            // supplied through a bound uniform buffer, so skip them from the per-uniform commit path
+            if (location === null) {
+                continue;
+            }
+
             const shaderInput = new WebglShaderInput(device, info.name, device.pcUniformType[info.type], location);
 
             if (samplerTypes.has(info.type)) {
@@ -357,6 +363,25 @@ class WebglShader {
             } else {
                 this.uniforms.push(shaderInput);
             }
+        }
+
+        // Link uniform blocks to their binding points. By convention a block is named
+        // 'ub_<bindGroupName>' (e.g. 'ub_view', 'ub_mesh_ub') and is bound to the matching bind
+        // group index, which is used as its GL uniform buffer binding point (see
+        // WebglGraphicsDevice.setBindGroup). A block not following this convention cannot be
+        // matched to a binding point - it is asserted in debug builds and ignored otherwise.
+        const numBlocks = gl.getProgramParameter(glProgram, gl.ACTIVE_UNIFORM_BLOCKS);
+        for (let i = 0; i < numBlocks; i++) {
+            const blockName = gl.getActiveUniformBlockName(glProgram, i);
+            const shortName = blockName.startsWith('ub_') ? blockName.substring(3) : blockName;
+            const bindGroupIndex = bindGroupNames.indexOf(shortName);
+
+            Debug.assert(bindGroupIndex >= 0,
+                `Shader [${shader.label}] declares an unsupported uniform block [${blockName}] - user uniform buffers are not supported.`,
+                shader);
+
+            const bindingPoint = bindGroupIndex >= 0 ? bindGroupIndex : i;
+            gl.uniformBlockBinding(glProgram, i, bindingPoint);
         }
 
         shader.ready = true;

--- a/src/platform/graphics/webgl/webgl-uniform-buffer.js
+++ b/src/platform/graphics/webgl/webgl-uniform-buffer.js
@@ -1,0 +1,19 @@
+import { BUFFER_DYNAMIC } from '../constants.js';
+import { WebglBuffer } from './webgl-buffer.js';
+
+/**
+ * A WebGL implementation of the UniformBuffer.
+ *
+ * @ignore
+ */
+class WebglUniformBuffer extends WebglBuffer {
+    unlock(uniformBuffer) {
+        const device = uniformBuffer.device;
+        const gl = device.gl;
+
+        // upload the uniform buffer data to a GL UNIFORM_BUFFER, allocating it on the first call
+        super.unlock(device, BUFFER_DYNAMIC, gl.UNIFORM_BUFFER, uniformBuffer.storageInt32);
+    }
+}
+
+export { WebglUniformBuffer };

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -706,16 +706,10 @@ class ForwardRenderer extends Renderer {
 
                     device.setViewport(view.viewport.x, view.viewport.y, view.viewport.z, view.viewport.w);
 
-                    if (device.supportsUniformBuffers) {
-
-                        // per-view dynamic bind group + offset captured during setupViewUniformBuffers
-                        this._viewOffsetScratch[0] = this._viewBindGroupOffsets[v];
-                        device.setBindGroup(BINDGROUP_VIEW, this._viewBindGroups[v], this._viewOffsetScratch);
-
-                    } else {
-
-                        this.setupViewUniforms(view, v);
-                    }
+                    // per-view dynamic bind group + offset captured during setupViewUniformBuffers
+                    // (the per-view scope values were set there too)
+                    this._viewOffsetScratch[0] = this._viewBindGroupOffsets[v];
+                    device.setBindGroup(BINDGROUP_VIEW, this._viewBindGroups[v], this._viewOffsetScratch);
 
                     const first = v === viewListStart;
                     const last = v === viewListEnd - 1;
@@ -791,7 +785,7 @@ class ForwardRenderer extends Renderer {
      */
     renderForwardLayer(camera, renderTarget, layer, transparent, shaderPass, options = {}) {
 
-        const { scene, device } = this;
+        const { scene } = this;
         const clusteredLightingEnabled = scene.clusteredLightingEnabled;
 
         this.setupViewport(camera, renderTarget);
@@ -850,18 +844,16 @@ class ForwardRenderer extends Renderer {
         this.setFogConstants(fogParams);
 
         const viewList = this.setCameraUniforms(camera, renderTarget);
-        if (device.supportsUniformBuffers) {
-            // ensure the default view uniform format exists - renderForwardLayer can run outside
-            // the main frame update (e.g. the picker and lightmapper passes)
-            this.initViewUniformFormat(scene.clusteredLightingEnabled);
-        }
+
+        // ensure the default view uniform format exists - renderForwardLayer can run outside
+        // the main frame update (e.g. the picker and lightmapper passes)
+        this.initViewUniformFormat(scene.clusteredLightingEnabled);
 
         // callers may supply a custom view uniform format, otherwise the renderer default is used
         const viewUniformFormat = options.viewUniformFormat ?? this.viewUniformFormat;
 
-        if (device.supportsUniformBuffers) {
-            this.setupViewUniformBuffers(viewUniformFormat, viewList);
-        }
+        // view uniforms always go through a uniform buffer (on all backends)
+        this.setupViewUniformBuffers(viewUniformFormat, viewList);
 
         // clearing - do it after the view bind groups are set up, to avoid overriding those
         const clearColor = options.clearColor ?? false;

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -139,8 +139,8 @@ class Renderer {
     localLights = [];
 
     /**
-     * Shared non-persistent view uniform buffers, keyed by their uniform format. Reused every frame
-     * and bound via the dynamic buffer system, so no per-render-action view bind groups are needed.
+     * Shared non-persistent view uniform buffers, keyed by their uniform format. Reused every frame,
+     * with the bind group and dynamic offset sourced from the dynamic buffer system.
      *
      * @type {WeakMap<UniformBufferFormat, UniformBuffer>}
      */
@@ -662,7 +662,8 @@ class Renderer {
 
     initViewUniformFormat(isClustered) {
 
-        if (this.device.supportsUniformBuffers && !this.viewUniformFormat) {
+        // view uniforms always go through a uniform buffer (on all backends)
+        if (!this.viewUniformFormat) {
 
             // format of the view uniform buffer
             const uniforms = [
@@ -732,9 +733,10 @@ class Renderer {
     }
 
     /**
-     * Sets up the view uniform buffer(s) for the current camera and binds the single-view case.
-     * Uses the shared per-format view uniform buffer, sourcing its bind group + dynamic offset from
-     * the dynamic buffer system (no per-render-action view bind groups).
+     * Sets up the shared (per-format) view uniform buffer for the current camera. For a single view
+     * it updates the buffer and binds it immediately; for multiview (XR) it updates the buffer per
+     * view and captures the per-view bind group and dynamic offset, which the forward render loop
+     * then binds per draw. The bind group and dynamic offset come from the dynamic buffer system.
      *
      * @param {UniformBufferFormat} viewUniformFormat - The view uniform buffer format.
      * @param {RenderView[]|null} viewList - The list of XR views for multiview, or null for a

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -444,9 +444,9 @@ class ShadowRenderer {
         const rt = shadowCam.renderTarget;
         const renderer = this.renderer;
         renderer.setCameraUniforms(shadowCam, rt);
-        if (device.supportsUniformBuffers) {
-            renderer.setupViewUniformBuffers(this.viewUniformFormat, null);
-        }
+
+        // view uniforms always go through a uniform buffer (on all backends)
+        renderer.setupViewUniformBuffers(this.viewUniformFormat, null);
 
         renderer.setupViewport(shadowCam, rt);
 
@@ -554,7 +554,8 @@ class ShadowRenderer {
 
     initViewUniformFormat() {
 
-        if (this.device.supportsUniformBuffers && !this.viewUniformFormat) {
+        // view uniforms always go through a uniform buffer (on all backends)
+        if (!this.viewUniformFormat) {
 
             // format of the view uniform buffer
             this.viewUniformFormat = new UniformBufferFormat(this.device, [


### PR DESCRIPTION
View-level uniforms (camera/view matrices, viewport, exposure, clustered-lighting params, etc.) now flow through a uniform buffer on WebGL2, matching the WebGPU path, instead of being committed as individual GL uniforms.

**Changes:**
- Add `WebglShaderProcessorGLSL`, a WebGL2 GLSL processor that injects a std140 `ub_view` block and removes the standalone view-uniform declarations. Attributes, varyings, textures and mesh-level uniforms are left to the existing `gles3` macro path. It runs from `WebglShader` when shader processing options are present.
- Add the WebGL2 uniform-buffer building blocks: `WebglUniformBuffer` (persistent), `WebglBindGroup` / `WebglBindGroupFormat`, a per-size whole-buffer dynamic-buffer pool (`bufferData` orphaning, bound with `bindBufferBase`), and `device.setBindGroup`. Uniform blocks are linked to their binding points in `WebglShader`.
- Make the renderer's view uniform path unconditional on all backends (previously gated on `supportsUniformBuffers`, i.e. WebGPU-only). The mesh-UB and quad-render paths remain gated. The null device gains no-op uniform-buffer support so it runs harmlessly.
- Handle WebGL/WebGPU context loss for both persistent and dynamic uniform buffers.
- XR multiview renders correctly: each eye binds its own view buffer.

GLSL shader authoring is unaffected — view uniforms are still declared as individual `uniform`s (e.g. `uniform mat4 matrix_view;`) and are grouped into the buffer transparently. WebGL2 only (WebGL1 is no longer supported).

**Performance:**
- On WebGL2, view uniforms are uploaded once per view and bound with a single `bindBufferBase`, rather than committed individually per shader. Mesh-level uniforms are unchanged.