### PR TITLE
Document IndexBuffer storage can be ArrayBuffer or typed array

### DIFF
--- a/src/platform/graphics/index-buffer.js
+++ b/src/platform/graphics/index-buffer.js
@@ -37,15 +37,17 @@ class IndexBuffer {
      * - {@link BUFFER_STREAM}
      *
      * Defaults to {@link BUFFER_STATIC}.
-     * @param {ArrayBuffer} [initialData] - Initial data. If left unspecified, the index buffer
-     * will be initialized to zeros.
+     * @param {ArrayBuffer|ArrayBufferView} [initialData] - Initial data. Can be an
+     * {@link ArrayBuffer} or a typed array (for example a {@link Uint16Array}). The data is stored
+     * by reference and is not copied, so a typed array that is a view into a larger buffer is kept
+     * as-is. If left unspecified, the index buffer will be initialized to zeros.
      * @param {object} [options] - Object for passing optional arguments.
      * @param {boolean} [options.storage] - Defines if the index buffer can be used as a storage
      * buffer by a compute shader. Defaults to false. Only supported on WebGPU.
      * @example
      * // Create an index buffer holding 3 16-bit indices. The buffer is marked as
      * // static, hinting that the buffer will never be modified.
-     * const indices = new UInt16Array([0, 1, 2]);
+     * const indices = new Uint16Array([0, 1, 2]);
      * const indexBuffer = new pc.IndexBuffer(graphicsDevice,
      *                                        pc.INDEXFORMAT_UINT16,
      *                                        3,
@@ -147,7 +149,10 @@ class IndexBuffer {
     /**
      * Gives access to the block of memory that stores the buffer's indices.
      *
-     * @returns {ArrayBuffer} A contiguous block of memory where index data can be written to.
+     * @returns {ArrayBuffer|ArrayBufferView} The memory that stores the buffer's indices. This
+     * matches whatever was supplied as the initial data: an {@link ArrayBuffer} when none was
+     * provided, otherwise the {@link ArrayBuffer} or typed array that was passed in. Use
+     * {@link ArrayBuffer.isView} to distinguish the two before accessing it.
      */
     lock() {
         return this.storage;
@@ -167,7 +172,8 @@ class IndexBuffer {
     /**
      * Set preallocated data on the index buffer.
      *
-     * @param {ArrayBuffer} data - The index data to set.
+     * @param {ArrayBuffer|ArrayBufferView} data - The index data to set. Can be an
+     * {@link ArrayBuffer} or a typed array. Stored by reference, not copied.
      * @returns {boolean} True if the data was set successfully, false otherwise.
      * @ignore
      */


### PR DESCRIPTION
Closes #5869.

`IndexBuffer` stores its `initialData` by reference. The GLB parser passes typed arrays (`Uint8/16/32Array`) as initial data, while other callers pass an `ArrayBuffer`, so `storage` (and `lock()`) can be either form. The JSDoc previously documented only `ArrayBuffer`, which is what the reporter ran into. Per discussion on the issue, the agreed fix is to document the actual contract rather than copy data or add new API surface.

**Changes:**
- Document the constructor's `initialData` as `{ArrayBuffer|ArrayBufferView}`, noting it is stored by reference (a typed array that is a view into a larger buffer is kept as-is).
- Document `lock()` as returning `{ArrayBuffer|ArrayBufferView}`, advising callers to use `ArrayBuffer.isView` to distinguish the two.
- Document `setData()`'s `data` param likewise (internal `@ignore` method).
- Fix a typo in the constructor's `@example` (`UInt16Array` -> `Uint16Array`).

**API Changes:**
- No runtime/behavior change. The generated type declarations now reflect the wider types: `lock(): ArrayBuffer | ArrayBufferView` and `initialData?: ArrayBuffer | ArrayBufferView`.