### PR TITLE
fix(element): stabilize MSDF text anti-aliasing at small sizes

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -684,6 +684,7 @@ class TextElement {
                 mi.setParameter('material_emissive', this._colorUniform);
                 mi.setParameter('material_opacity', this._color.a);
                 mi.setParameter('font_sdfIntensity', this._font.intensity);
+                mi.setParameter('font_pxrange', this._getPxRange(this._font));
 
                 mi.setParameter('outline_color', this._outlineColorUniform);
                 mi.setParameter('outline_thickness', this._outlineThicknessScale * this._outlineThickness);
@@ -1412,6 +1413,7 @@ class TextElement {
                 const mi = this._meshInfo[i].meshInstance;
                 if (mi) {
                     mi.setParameter('font_sdfIntensity', this._font.intensity);
+                    mi.setParameter('font_pxrange', this._getPxRange(this._font));
                 }
             }
         }
@@ -1433,6 +1435,18 @@ class TextElement {
                 mi.setParameter('texture_opacityMap', texture);
             }
         }
+    }
+
+    _getPxRange(font) {
+        // calculate pxrange from range and scale properties on a character
+        const keys = Object.keys(this._font.data.chars);
+        for (let i = 0; i < keys.length; i++) {
+            const char = this._font.data.chars[keys[i]];
+            if (char.range) {
+                return (char.scale || 1) * char.range;
+            }
+        }
+        return 2; // default
     }
 
     _getUv(char) {
@@ -1782,6 +1796,7 @@ class TextElement {
                 const mi = this._meshInfo[i].meshInstance;
                 if (mi) {
                     mi.setParameter('font_sdfIntensity', this._font.intensity);
+                    mi.setParameter('font_pxrange', this._getPxRange(this._font));
                     this._setTextureParams(mi, this._font.textures[i]);
                 }
             }

--- a/src/scene/shader-lib/glsl/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/glsl/chunks/chunk-validation.js
@@ -60,7 +60,7 @@ const chunkVersions = {
     refractionDynamicPS: '1.70',
 
     // text
-    msdfPS: '2.20'
+    msdfPS: '2.21'
 };
 
 // removed

--- a/src/scene/shader-lib/glsl/chunks/common/frag/msdf.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/msdf.js
@@ -6,6 +6,7 @@ float median(float r, float g, float b) {
 }
 
 uniform float font_sdfIntensity; // intensity is used to boost the value read from the SDF, 0 is no boost, 1.0 is max boost
+uniform float font_pxrange;      // number of texels of SDF spread (inside <-> outside) in the atlas
 
 #ifndef LIT_MSDF_TEXT_ATTRIBUTE
     uniform vec4 outline_color;
@@ -38,12 +39,16 @@ vec4 applyMsdf(vec4 color) {
     // coverage threshold (0.5 = glyph edge); font_sdfIntensity fattens the glyph
     float edge = 0.5 - 0.5 * font_sdfIntensity;
 
-    // anti-aliasing width: distance field change per pixel, clamped above zero
-    float aa = max(fwidth(sigDist), 1e-4);
+    // Width of the distance-field transition in screen pixels, from the uv magnification (both
+    // axes) and the atlas spread. Stable under motion and minification, unlike fwidth(sigDist)
+    // whose noise on undersampled glyphs makes small text shimmer. Floored at 1px so minified
+    // text keeps a soft ~1px edge rather than a razor one.
+    vec2 unitRange = vec2(font_pxrange) / vec2(textureSize(texture_msdfMap, 0));
+    float screenPxRange = max(0.5 * dot(unitRange, 1.0 / max(fwidth(vUv0), vec2(1e-6))), 1.0);
 
-    float inside = clamp((sigDist - edge) / aa + 0.5, 0.0, 1.0);
-    float outline = clamp((sigDist + outline_thickness - edge) / aa + 0.5, 0.0, 1.0);
-    float shadow = clamp((sigDistShdw + outline_thickness - edge) / aa + 0.5, 0.0, 1.0);
+    float inside = clamp(screenPxRange * (sigDist - edge) + 0.5, 0.0, 1.0);
+    float outline = clamp(screenPxRange * (sigDist + outline_thickness - edge) + 0.5, 0.0, 1.0);
+    float shadow = clamp(screenPxRange * (sigDistShdw + outline_thickness - edge) + 0.5, 0.0, 1.0);
 
     vec4 tcolor = (outline > inside) ? outline * vec4(outline_color.a * outline_color.rgb, outline_color.a) : vec4(0.0);
     tcolor = mix(tcolor, color, inside);

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/msdf.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/msdf.js
@@ -7,6 +7,7 @@ fn median(r: f32, g: f32, b: f32) -> f32 {
 }
 
 uniform font_sdfIntensity: f32; // intensity is used to boost the value read from the SDF, 0 is no boost, 1.0 is max boost
+uniform font_pxrange: f32;      // number of texels of SDF spread (inside <-> outside) in the atlas
 
 #ifndef LIT_MSDF_TEXT_ATTRIBUTE
     uniform outline_color: vec4f;
@@ -51,12 +52,17 @@ fn applyMsdf(color_in: vec4f) -> vec4f {
     // coverage threshold (0.5 = glyph edge); font_sdfIntensity fattens the glyph
     let edge: f32 = 0.5 - 0.5 * uniform.font_sdfIntensity;
 
-    // anti-aliasing width: distance field change per pixel, clamped above zero
-    let aa: f32 = max(abs(dpdx(sigDist)) + abs(dpdy(sigDist)), 1e-4);
+    // Width of the distance-field transition in screen pixels, from the uv magnification (both
+    // axes) and the atlas spread. Stable under motion and minification, unlike the distance-field
+    // gradient whose noise on undersampled glyphs makes small text shimmer. Floored at 1px so
+    // minified text keeps a soft ~1px edge rather than a razor one.
+    let unitRange: vec2f = vec2f(uniform.font_pxrange) / vec2f(textureDimensions(texture_msdfMap, 0));
+    let uvDeriv: vec2f = max(abs(dpdx(vUv0)) + abs(dpdy(vUv0)), vec2f(1e-6));
+    let screenPxRange: f32 = max(0.5 * dot(unitRange, vec2f(1.0) / uvDeriv), 1.0);
 
-    let inside: f32 = clamp((sigDist - edge) / aa + 0.5, 0.0, 1.0);
-    let outline: f32 = clamp((sigDist + outline_thicknessValue - edge) / aa + 0.5, 0.0, 1.0);
-    let shadow: f32 = clamp((sigDistShdw + outline_thicknessValue - edge) / aa + 0.5, 0.0, 1.0);
+    let inside: f32 = clamp(screenPxRange * (sigDist - edge) + 0.5, 0.0, 1.0);
+    let outline: f32 = clamp(screenPxRange * (sigDist + outline_thicknessValue - edge) + 0.5, 0.0, 1.0);
+    let shadow: f32 = clamp(screenPxRange * (sigDistShdw + outline_thicknessValue - edge) + 0.5, 0.0, 1.0);
 
     let tcolor_outline: vec4f = outline * vec4f(outline_colorValue.a * outline_colorValue.rgb, outline_colorValue.a);
     var tcolor: vec4f = select(vec4f(0.0), tcolor_outline, outline > inside);


### PR DESCRIPTION
## Problem

Small MSDF text rendered via an `ElementComponent` shimmers and looks rough since 2.20: as the text translates, thin 1px strokes (`l`, `i`, `1`) flicker on and off and edges crawl. Regression from #8935. (#8984)

| 2.20 (shimmers) | This PR |
|:---:|:---:|
| `aa = fwidth(median(sample))` — content-derived, noisy under minification | geometry-derived `screenPxRange`, stable |

## Cause

#8935 made two independent changes. The coverage threshold (`edge = 0.5 - 0.5 * font_sdfIntensity`, which fixed the #2948 crossbar erosion) is correct and **kept**. The regression is the other change — deriving the AA width from the **distance-field gradient**, `aa = fwidth(median(sample))`.

MSDF atlases can't be mipmapped (averaging the channels breaks the median), so under minification the field is undersampled and the sampled median is noisy. Its screen-space gradient therefore changes frame-to-frame as the glyph moves sub-pixel, so the AA width breathes (→ shimmer), and where the gradient momentarily collapses the edge goes razor-sharp (→ thin strokes snap on/off). Pre-2.20 the AA width came from the uv magnification only, which is constant across a glyph and independent of sub-pixel position — stable.

## Fix

Compute the transition width with the msdfgen-standard `screenPxRange()`: derived from `fwidth(vUv0)` (both axes) and the atlas spread, floored at 1px. It depends only on geometry, so it is stable under motion and minification, and using both uv axes also covers the diagonal/horizontal edges that motivated the gradient approach in #8935. The true-edge threshold is unchanged, so the #2948 fix and the rendered weight are preserved — this PR only changes AA stability.

Re-adds the `font_pxrange` uniform removed by #8935 (atlas size now comes from `textureSize`/`textureDimensions`, so `font_textureWidth` stays gone). GLSL and WGSL kept in parity. `msdfPS` bumped to chunk version `2.21`.

## Testing

- **WebGL2**, live A/B against engine source on the #8984 repro (Roboto, `fontSize` 6, DPR 1.75 ≈ 3 atlas-texels/screen-px): total text coverage over a sub-pixel translation cycle fluctuates **±1.4%** with the fix vs **±5.7%** on 2.20 (≈4× less). Coverage is conserved under pure translation, so its fluctuation is the shimmer. No shader-compile errors; text renders correctly.
- Numerical simulation of the exact shader math on the real atlas, isolating a single `l` stem: the 2.20 AA flickered ≈7× more than pre-2.20, the stem peak snapping between ~0.5 and a hard 1.0; the fix is flat.
- `npm test` (incl. `text-element`, 90 passing) and lint clean.

Fixes #8984