### PR TITLE
Add public app getter to ResourceHandler, mark _app protected

### DIFF
--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -25,6 +25,7 @@ class ResourceHandler {
      * The running app instance.
      *
      * @type {AppBase}
+     * @protected
      */
     _app;
 
@@ -38,6 +39,15 @@ class ResourceHandler {
     constructor(app, handlerType) {
         this._app = app;
         this.handlerType = handlerType;
+    }
+
+    /**
+     * Gets the running {@link AppBase} instance.
+     *
+     * @type {AppBase}
+     */
+    get app() {
+        return this._app;
     }
 
     /**


### PR DESCRIPTION
`ResourceHandler` exposed its internal `_app` field on the public API surface because it lacked a visibility tag. This adds a clean public `app` getter and marks the backing field protected.

**Changes:**
- Add a public `app` getter to `ResourceHandler` that returns the running `AppBase`.
- Tag the backing `_app` field `@protected` so it no longer leaks into the public API. Subclasses (`HierarchyHandler`, `SceneHandler`, `ScriptHandler`, `TemplateHandler`) already use it directly, so protected is the correct visibility.

**API Changes:**
- Added: `ResourceHandler#app` getter, returning `AppBase`.
- `ResourceHandler#_app` is now `@protected` (it was previously emitted as a public field in the generated type declarations). It was never intended as public API — use the new `app` getter instead.