### PR TITLE
fix(element): keep msdfPS chunk version at 2.20

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/glsl/chunks/chunk-validation.js
@@ -60,7 +60,7 @@ const chunkVersions = {
     refractionDynamicPS: '1.70',
 
     // text
-    msdfPS: '2.21'
+    msdfPS: '2.20'
 };
 
 // removed


### PR DESCRIPTION
Follow-up to #8990.

#8990 re-added the `font_pxrange` uniform and bumped the `msdfPS` chunk version to `2.21`. That bump isn't needed: the change is **additive**, so it doesn't break existing overrides.

- A **2.20-era** override (uses `fwidth(sigDist)`, never declares `font_pxrange`) just ignores the extra `setParameter` — PlayCanvas drops parameters with no matching uniform — and keeps working.
- The overrides that *do* break are **pre-2.20** ones that read the removed `font_textureWidth`, and those are already flagged by the existing `'2.20'` marker (their `apiVersion < 2.20`).

So `'2.20'` already catches every override that actually breaks; `'2.21'` would only emit a spurious "please update" warning to 2.20-era authors whose chunks are fine. `2.20` is the last *breaking* change to the chunk.

This also keeps `msdfPS` consistent between `main` and `release-2.20` (the #8990 backport deliberately kept `'2.20'`). Shader/`text-element` changes from #8990 are unaffected — only this one bookkeeping line changes.