### PR TITLE
Warn about unknown options passed to addComponent

### DIFF
--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -25,6 +25,10 @@ class AnimComponentSystem extends ComponentSystem {
 
         this.ComponentType = AnimComponent;
 
+        // 'layers' is read-only (managed via addLayer) and 'masks' is not a component property; both
+        // are consumed directly in initializeComponentData
+        this.extraDataProperties = ['layers', 'masks'];
+
         this.on('beforeremove', this.onBeforeRemove, this);
         this.app.systems.on('animationUpdate', this.onAnimationUpdate, this);
     }

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -132,6 +132,9 @@ class GSplatComponentSystem extends ComponentSystem {
 
         this.ComponentType = GSplatComponent;
 
+        // consumed to build customAabb, not settable component properties
+        this.extraDataProperties = ['aabbCenter', 'aabbHalfExtents'];
+
         app.renderer.gsplatDirector = new GSplatDirector(app.graphicsDevice, app.renderer, app.scene, this);
 
         // register gsplat shader chunks

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -26,6 +26,9 @@ class LightComponentSystem extends ComponentSystem {
 
         this.ComponentType = LightComponent;
 
+        // 'enable' is a deprecated alias for 'enabled', handled in initializeComponentData
+        this.extraDataProperties = ['enable'];
+
         this.on('beforeremove', this.onBeforeRemove, this);
     }
 

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -47,6 +47,9 @@ class ModelComponentSystem extends ComponentSystem {
 
         this.ComponentType = ModelComponent;
 
+        // consumed to build customAabb, not settable component properties
+        this.extraDataProperties = ['aabbCenter', 'aabbHalfExtents'];
+
         this.defaultMaterial = getDefaultMaterial(app.graphicsDevice);
 
         this.on('beforeremove', this.onBeforeRemove, this);

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -47,6 +47,9 @@ class RenderComponentSystem extends ComponentSystem {
 
         this.ComponentType = RenderComponent;
 
+        // consumed to build customAabb, not settable component properties
+        this.extraDataProperties = ['aabbCenter', 'aabbHalfExtents'];
+
         this.defaultMaterial = getDefaultMaterial(app.graphicsDevice);
 
         this.on('beforeremove', this.onBeforeRemove, this);

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -37,6 +37,9 @@ class ScriptComponentSystem extends ComponentSystem {
 
         this.ComponentType = ScriptComponent;
 
+        // 'order' is consumed alongside 'scripts' in initializeComponentData, it is not a component property
+        this.extraDataProperties = ['order'];
+
         // list of all entities script components
         // we are using pc.SortedLoopArray because it is
         // safe to modify while looping through it

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../core/debug.js';
 import { EventHandler } from '../../core/event-handler.js';
 import { Color } from '../../core/math/color.js';
 import { Vec2 } from '../../core/math/vec2.js';
@@ -22,6 +23,26 @@ class ComponentSystem extends EventHandler {
      * @readonly
      */
     id;
+
+    /**
+     * A list of option names accepted by {@link ComponentSystem#addComponent} that are not settable
+     * properties of the component itself - for example keys the system consumes to build derived
+     * state (such as `aabbCenter`) or deprecated aliases. Used only by debug-build validation to
+     * avoid false-positive warnings; subclasses that accept such options should override this.
+     *
+     * @type {string[]}
+     * @ignore
+     */
+    extraDataProperties = [];
+
+    /**
+     * Cache of option names already validated as acceptable by {@link ComponentSystem#addComponent},
+     * lazily populated the first time each option is seen. Debug builds only.
+     *
+     * @type {Set<string>|null}
+     * @ignore
+     */
+    _validProps = null;
 
     /**
      * Create a new ComponentSystem instance.
@@ -64,6 +85,12 @@ class ComponentSystem extends EventHandler {
 
         entity[this.id] = component;
         entity.c[this.id] = component;
+
+        // Warn about options whose names don't map to a settable component property (typically
+        // typos), which would otherwise be silently ignored. Runs before initializeComponentData so
+        // systems that copy arbitrary keys onto the component (e.g. anim) don't mask the typo.
+        // Wrapped in Debug.call so the whole call is stripped from release builds.
+        Debug.call(() => validateComponentOptions(this, component, data));
 
         this.initializeComponentData(component, data);
 
@@ -234,6 +261,58 @@ function convertValue(value, type) {
         default:
             throw new Error(`Could not convert unhandled type: ${type}`);
     }
+}
+
+/**
+ * Returns true if `key` names a settable property of `obj` - either an accessor with a setter, or a
+ * writable data property - found anywhere on its prototype chain below `Object.prototype`. Note
+ * this only detects properties that can be assigned; getter-only accessors return false. The body
+ * is wrapped in {@link Debug.call} so it is stripped from release builds (this is only ever called
+ * from the debug-only {@link validateComponentOptions}).
+ *
+ * @param {object} obj - The object to test.
+ * @param {string} key - The property name to test.
+ * @returns {boolean} True if the property can be assigned on `obj`.
+ */
+function isSettableProperty(obj, key) {
+    let settable = false;
+    Debug.call(() => {
+        for (let proto = obj; proto && proto !== Object.prototype; proto = Object.getPrototypeOf(proto)) {
+            const descriptor = Object.getOwnPropertyDescriptor(proto, key);
+            if (descriptor) {
+                settable = descriptor.set !== undefined || descriptor.writable === true;
+                return;
+            }
+        }
+    });
+    return settable;
+}
+
+/**
+ * Warns (once per option name and component type) about options passed to
+ * {@link ComponentSystem#addComponent} that are neither settable properties of the component nor
+ * listed in {@link ComponentSystem#extraDataProperties}, catching typos that would otherwise be
+ * silently ignored. The body is wrapped in {@link Debug.call} so it is stripped from release builds.
+ *
+ * @param {ComponentSystem} system - The component system creating the component.
+ * @param {Component} component - The freshly constructed component.
+ * @param {object} data - The options passed to addComponent.
+ */
+function validateComponentOptions(system, component, data) {
+    Debug.call(() => {
+        const valid = system._validProps ??= new Set(['enabled', ...system.extraDataProperties]);
+        for (const key of Object.keys(data)) {
+            if (valid.has(key)) {
+                continue;
+            }
+            if (isSettableProperty(component, key)) {
+                // memoize so repeatedly adding the same component type stays cheap
+                valid.add(key);
+            } else {
+                Debug.warnOnce(`addComponent: ignoring unknown option '${key}' passed to the '${system.id}' component - check for a typo.`);
+            }
+        }
+    });
 }
 
 export { ComponentSystem };

--- a/test/framework/components/system.test.mjs
+++ b/test/framework/components/system.test.mjs
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
 
+import { Debug } from '../../../src/core/debug.js';
 import { Color } from '../../../src/core/math/color.js';
 import { Vec2 } from '../../../src/core/math/vec2.js';
 import { Vec3 } from '../../../src/core/math/vec3.js';
 import { Vec4 } from '../../../src/core/math/vec4.js';
 import { ComponentSystem } from '../../../src/framework/components/system.js';
+import { Entity } from '../../../src/framework/entity.js';
 import { createApp } from '../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
@@ -236,6 +238,83 @@ describe('ComponentSystem', function () {
             system.schema = null;
 
             expect(system.getPropertiesOfType('typeA')).to.deep.equal([]);
+        });
+
+    });
+
+    describe('#addComponent() option validation', function () {
+        let warnings;
+        let originalWarn;
+
+        const validationWarnings = () => warnings.filter(w => w.includes('ignoring unknown option'));
+
+        beforeEach(function () {
+            // Debug.warnOnce dedupes globally by message, so clear the cache to keep tests independent
+            Debug._loggedMessages.clear();
+            warnings = [];
+            originalWarn = console.warn;
+            console.warn = (...args) => warnings.push(args.join(' '));
+        });
+
+        afterEach(function () {
+            console.warn = originalWarn;
+        });
+
+        it('warns about an unknown option (typo)', function () {
+            const entity = new Entity('test', app);
+            app.systems.render.addComponent(entity, { castShadow: true }); // typo for castShadows
+
+            const w = validationWarnings();
+            expect(w).to.have.lengthOf(1);
+            expect(w[0]).to.include('castShadow');
+            expect(w[0]).to.include('render');
+        });
+
+        it('does not warn about valid options', function () {
+            const entity = new Entity('test', app);
+            app.systems.render.addComponent(entity, { castShadows: true, receiveShadows: false });
+
+            expect(validationWarnings()).to.have.lengthOf(0);
+        });
+
+        it('does not warn about the shared enabled option', function () {
+            const entity = new Entity('test', app);
+            app.systems.render.addComponent(entity, { enabled: false });
+
+            expect(validationWarnings()).to.have.lengthOf(0);
+        });
+
+        it('does not warn about options consumed by the system (extraDataProperties)', function () {
+            const entity = new Entity('test', app);
+            app.systems.render.addComponent(entity, {
+                aabbCenter: [0, 0, 0],
+                aabbHalfExtents: [1, 1, 1]
+            });
+
+            expect(validationWarnings()).to.have.lengthOf(0);
+        });
+
+        it('warns about a read-only (getter-only) property', function () {
+            const entity = new Entity('test', app);
+            app.systems.camera.addComponent(entity, { frustum: {} }); // frustum is getter-only
+
+            const w = validationWarnings();
+            expect(w).to.have.lengthOf(1);
+            expect(w[0]).to.include('frustum');
+        });
+
+        it('does not warn about anim options handled outside of component properties', function () {
+            const entity = new Entity('test', app);
+            app.systems.anim.addComponent(entity, { layers: [], masks: {} });
+
+            expect(validationWarnings()).to.have.lengthOf(0);
+        });
+
+        it('warns only once for the same option and component type', function () {
+            app.systems.render.addComponent(new Entity('a', app), { castShadow: true });
+            app.systems.render.addComponent(new Entity('b', app), { castShadow: true });
+
+            expect(validationWarnings()).to.have.lengthOf(1);
         });
 
     });


### PR DESCRIPTION
Options passed to `addComponent` (or `entity.addComponent(type, data)`) with a mistyped name — e.g. `castShadow` instead of `castShadows` — are currently silently ignored. This adds a debug-build check that warns when an option name doesn't correspond to a settable property of the component, so typos are easy to catch. Fixes #8994.

**Changes:**
- `ComponentSystem.addComponent` now validates the supplied option keys and emits a `Debug.warnOnce` for any key that is neither a settable property of the component nor an explicitly allowed, system-consumed key.
- The check is reflective — it looks for a real setter or writable field on the component — so it needs no hand-maintained per-property lists and stays correct as components gain or lose properties. It intentionally errs toward false negatives (never false positives): a getter-only/read-only property is flagged, but a typo that happens to collide with a real member is not.
- The entire check is wrapped in `Debug.call`, so it is stripped from release builds (verified: zero occurrences of the validation code in a release bundle).
- A small `extraDataProperties` allow-list is declared on the few systems that accept options which are not settable component properties:
  - render / model / gsplat: `aabbCenter`, `aabbHalfExtents` (used to build `customAabb`)
  - light: `enable` (deprecated alias for `enabled`)
  - anim: `layers`, `masks` (consumed directly during init)
  - script: `order` (consumed alongside `scripts`)

**Notes:**
- Debug-only and non-fatal: in release builds there is no behavior or size change. In debug builds, previously-ignored bad options now produce a one-time console warning per option name + component type.