### PR TITLE
fix(font): disable mipmaps on MSDF font atlases

### DIFF
--- a/src/framework/handlers/font.js
+++ b/src/framework/handlers/font.js
@@ -1,6 +1,8 @@
 import { path } from '../../core/path.js';
 import { string } from '../../core/string.js';
+import { FILTER_LINEAR } from '../../platform/graphics/constants.js';
 import { http } from '../../platform/net/http.js';
+import { FONT_MSDF } from '../font/constants.js';
 import { Font } from '../font/font.js';
 import { ResourceHandler } from './handler.js';
 
@@ -101,6 +103,10 @@ class FontHandler extends ResourceHandler {
         const textures = new Array(numTextures);
         const loader = this._loader;
 
+        // MSDF atlases must not be mipmapped: mip levels average the distance-field channels,
+        // and median(average) != average(median), so minified text samples a corrupted median.
+        const isMsdf = !data.type || data.type === FONT_MSDF;
+
         const loadTexture = function (index) {
             const onLoaded = function (err, texture) {
                 if (error) return;
@@ -109,6 +115,11 @@ class FontHandler extends ResourceHandler {
                     error = err;
                     callback(err);
                     return;
+                }
+
+                if (isMsdf) {
+                    texture.minFilter = FILTER_LINEAR;
+                    texture.mipmaps = false;
                 }
 
                 texture.upload();

--- a/src/framework/handlers/font.js
+++ b/src/framework/handlers/font.js
@@ -103,9 +103,12 @@ class FontHandler extends ResourceHandler {
         const textures = new Array(numTextures);
         const loader = this._loader;
 
-        // MSDF atlases must not be mipmapped: mip levels average the distance-field channels,
-        // and median(average) != average(median), so minified text samples a corrupted median.
+        // MSDF atlases must not be mipmapped: mip levels average the distance-field channels, and
+        // median(average) != average(median), so minified text samples a corrupted median. Request
+        // a non-mipmapped texture at creation time (mipmaps can't be disabled after creation on
+        // WebGPU) rather than mutating the loaded texture.
         const isMsdf = !data.type || data.type === FONT_MSDF;
+        const textureOptions = isMsdf ? { mipmaps: false, minFilter: FILTER_LINEAR } : undefined;
 
         const loadTexture = function (index) {
             const onLoaded = function (err, texture) {
@@ -117,11 +120,6 @@ class FontHandler extends ResourceHandler {
                     return;
                 }
 
-                if (isMsdf) {
-                    texture.minFilter = FILTER_LINEAR;
-                    texture.mipmaps = false;
-                }
-
                 texture.upload();
                 textures[index] = texture;
                 numLoaded++;
@@ -131,9 +129,9 @@ class FontHandler extends ResourceHandler {
             };
 
             if (index === 0) {
-                loader.load(url, 'texture', onLoaded);
+                loader.load(url, 'texture', onLoaded, null, textureOptions);
             } else {
-                loader.load(url.replace('.png', `${index}.png`), 'texture', onLoaded);
+                loader.load(url.replace('.png', `${index}.png`), 'texture', onLoaded, null, textureOptions);
             }
         };
 

--- a/src/framework/handlers/handler.js
+++ b/src/framework/handlers/handler.js
@@ -80,9 +80,10 @@ class ResourceHandler {
      * @param {string} url - The URL of the resource to open.
      * @param {*} data - The raw resource data passed by callback from {@link load}.
      * @param {Asset} [asset] - Optional asset that is passed by ResourceLoader.
+     * @param {object} [options] - Optional resource-creation options passed by ResourceLoader.
      * @returns {*} The parsed resource data.
      */
-    open(url, data, asset) {
+    open(url, data, asset, options) {
         return data;
     }
 

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -187,7 +187,7 @@ class ResourceLoader {
                     }
 
                     try {
-                        self._onSuccess(key, handler.open(urlObj.original, data, asset), extra);
+                        self._onSuccess(key, handler.open(urlObj.original, data, asset, options), extra);
                     } catch (e) {
                         self._onFailure(key, e);
                     }

--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -250,12 +250,14 @@ class TextureHandler extends ResourceHandler {
         this._getParser(url.original).load(url, callback, asset);
     }
 
-    open(url, data, asset) {
+    open(url, data, asset, options) {
         if (!url) {
             return undefined;
         }
 
-        const textureOptions = this._getTextureOptions(asset);
+        // asset-derived options, with any per-load creation options (e.g. mipmaps: false for
+        // MSDF font atlases) taking precedence
+        const textureOptions = { ...this._getTextureOptions(asset), ...options };
         let texture = this._getParser(url).open(url, data, this._device, textureOptions);
 
         if (texture === null) {

--- a/test/framework/handlers/font-handler.test.mjs
+++ b/test/framework/handlers/font-handler.test.mjs
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { Asset } from '../../../src/framework/asset/asset.js';
+import { FILTER_LINEAR } from '../../../src/platform/graphics/constants.js';
 import { createApp } from '../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
@@ -66,6 +67,30 @@ describe('FontHandler', function () {
                 expect(app.loader.getFromCache(texture.name, 'texture')).to.be.undefined;
             });
 
+            done();
+        });
+
+        asset.on('error', err => done(new Error(err)));
+    });
+
+    // regression test: MSDF atlases must load without mipmaps and with a non-mip minFilter. Mip
+    // levels average the distance-field channels, corrupting the median under minification (which
+    // showed as a faint flickering line below thin strokes on small text).
+    it('loads MSDF atlas textures without mipmaps', function (done) {
+        const asset = new Asset('arial', 'font', {
+            url: 'http://localhost:3210/test/assets/fonts/arial.json'
+        });
+
+        app.assets.add(asset);
+        app.assets.load(asset);
+
+        asset.ready(function () {
+            const textures = asset.resource.textures;
+            expect(textures).to.have.lengthOf(1);
+            textures.forEach((texture) => {
+                expect(texture.mipmaps).to.equal(false);
+                expect(texture.minFilter).to.equal(FILTER_LINEAR);
+            });
             done();
         });
 


### PR DESCRIPTION
Follow-up to #8990 (same issue, #8984).

## Problem

After the small-text shimmer fix, a faint horizontal line remained just below thin, closely-spaced stems (e.g. the `ll` in "Hello") on minified text, flickering as the text moves. Most visible at DPR 1 / non-HiDPI.

## Cause

The MSDF atlas texture is loaded with mipmaps (`mipmaps: true`, `FILTER_LINEAR_MIPMAP_LINEAR`). Mip levels box-average the R/G/B channels, but `median(average) != average(median)`, so minified text samples a **corrupted median** — spurious faint coverage at thin features/junctions. This has always been the case, but 2.19's inward erosion clipped those sub-0.5 values; the true-edge threshold from #8990 renders them, so it became visible.

## Fix

Load MSDF font atlases with `mipmaps: false` + `minFilter: FILTER_LINEAR` (base level only). Bitmap fonts are unaffected and keep their mipmaps. Distance fields are meant to be reconstructed from the base level, and the screen-space `screenPxRange` AA (#8990) already handles minification.

## Testing

- Repro project (Roboto, `fontSize` 6) at **DPR 1** (worst-case minification, ~5 atlas-texels/px): the flickering line is gone, small text is not visibly worse, and there's no shimmer regression (ink CV ~1.4%). Verified against WebGL2 engine source.
- Text still renders correctly (no incomplete-texture black); `text-element` suite (90) and lint pass.

Further addresses #8984.