### PR TITLE
Fix gsplat loading progress getting permanently stuck after a cancelled mid-flight load

### DIFF
--- a/src/framework/components/gsplat/gsplat-asset-loader.js
+++ b/src/framework/components/gsplat/gsplat-asset-loader.js
@@ -259,11 +259,15 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
             asset.loaded = false;
             asset.loading = false;
 
-            // Retry loading via _startLoading() (not registry.load() directly) so a fresh
-            // 'error'/'load' listener pair is attached - otherwise a second consecutive
-            // failure for this URL would have nothing left to catch it.
+            // Retry loading. Re-attach only the 'error' listener - it was consumed by the
+            // once() that just fired, and a second consecutive failure would otherwise have
+            // nothing left to catch it. Don't touch 'load': the original listener from
+            // _startLoading() is still pending (it never fired) and re-adding it would leave
+            // two 'load' listeners on this asset, double-invoking _onAssetLoadSuccess on the
+            // eventual success.
             Debug.warn(`GSplatAssetLoader: Retrying load for ${url} (attempt ${retryCount + 1}/${this.maxRetries})`);
-            this._startLoading(url);
+            asset.once('error', retryErr => this._onAssetLoadError(url, asset, retryErr));
+            this._registry.load(asset);
         } else {
             // Max retries exceeded
             Debug.error(`GSplatAssetLoader: Failed to load ${url} after ${this.maxRetries} retries: ${err}`);

--- a/src/framework/components/gsplat/gsplat-asset-loader.js
+++ b/src/framework/components/gsplat/gsplat-asset-loader.js
@@ -62,12 +62,21 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
     _loadQueue = [];
 
     /**
-     * Map tracking retry attempts per URL.
+     * Map tracking retry attempts per URL, for genuine load errors only.
      *
      * @type {Map<string, number>}
      * @private
      */
     _retryCount = new Map();
+
+    /**
+     * Set of URLs whose load has genuinely, permanently failed: a real error (not a
+     * cancellation) was reported and retries are exhausted.
+     *
+     * @type {Set<string>}
+     * @private
+     */
+    _failed = new Set();
 
     /**
      * Whether this asset loader has been destroyed.
@@ -111,6 +120,7 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
         this._loadQueue.length = 0;
         this._currentlyLoading.clear();
         this._retryCount.clear();
+        this._failed.clear();
     }
 
     /**
@@ -133,8 +143,18 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
     load(url) {
         Debug.assert(url);
 
-        // Skip if already loading or loaded
         const asset = this._urlToAsset.get(url);
+
+        // A previous attempt resolved successfully but produced no usable resource - most
+        // commonly because the load was cancelled (aborted) while still in flight, e.g. LOD
+        // requirements moved on before it finished. This is not a failure: retry unconditionally
+        // whenever something asks for this URL again (callers only poll while they still want
+        // it), unless the URL has genuinely, permanently failed via a real error.
+        if (asset && asset.loaded && !asset.resource && !this._currentlyLoading.has(url) && !this._failed.has(url)) {
+            asset.loaded = false;
+        }
+
+        // Skip if already loading or loaded
         if (asset?.loaded || this._currentlyLoading.has(url)) {
             return;
         }
@@ -239,9 +259,11 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
             asset.loaded = false;
             asset.loading = false;
 
-            // Retry loading
+            // Retry loading via _startLoading() (not registry.load() directly) so a fresh
+            // 'error'/'load' listener pair is attached - otherwise a second consecutive
+            // failure for this URL would have nothing left to catch it.
             Debug.warn(`GSplatAssetLoader: Retrying load for ${url} (attempt ${retryCount + 1}/${this.maxRetries})`);
-            this._registry.load(asset);
+            this._startLoading(url);
         } else {
             // Max retries exceeded
             Debug.error(`GSplatAssetLoader: Failed to load ${url} after ${this.maxRetries} retries: ${err}`);
@@ -251,6 +273,9 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
 
             // Clear retry count
             this._retryCount.delete(url);
+
+            // Mark as genuinely, permanently failed
+            this._failed.add(url);
 
             // Process next item in queue
             this._processQueue();
@@ -294,6 +319,7 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
 
         // Clear retry count
         this._retryCount.delete(url);
+        this._failed.delete(url);
 
         // Unload the asset
         const asset = this._urlToAsset.get(url);
@@ -327,6 +353,17 @@ class GSplatAssetLoader extends GSplatAssetLoaderBase {
     getResource(url) {
         const asset = this._urlToAsset.get(url);
         return asset?.resource;
+    }
+
+    /**
+     * Checks whether loading a URL has genuinely, permanently failed (a real error, not a
+     * cancellation, with retries exhausted).
+     *
+     * @param {string} url - The URL to check.
+     * @returns {boolean} True if the load has permanently failed.
+     */
+    hasFailed(url) {
+        return this._failed.has(url);
     }
 }
 

--- a/test/framework/components/gsplat/gsplat-asset-loader.test.mjs
+++ b/test/framework/components/gsplat/gsplat-asset-loader.test.mjs
@@ -106,6 +106,26 @@ describe('GSplatAssetLoader', function () {
             expect(loadCalls).to.equal(callsAtFailure);
         });
 
+        it('does not accumulate duplicate load listeners across error retries', function () {
+            const url = 'http://example.com/chunk.json';
+
+            loader.load(url);
+            resolveWithError();
+            resolveWithError();
+
+            // Two retries consumed (each attaches a fresh 'error' listener), but the original
+            // 'load' listener from the initial _startLoading() call is still pending - it must
+            // not have been duplicated by either retry.
+            const asset = lastAsset();
+            expect(asset._callbacks.get('load')?.length).to.equal(1);
+
+            const processQueueSpy = spy(loader, '_processQueue');
+            resolveWithResource({ ok: true });
+
+            expect(processQueueSpy.callCount).to.equal(1);
+            expect(loader.getResource(url)).to.deep.equal({ ok: true });
+        });
+
         it('retries a URL again after it is unloaded and re-requested', function () {
             const url = 'http://example.com/chunk.json';
 

--- a/test/framework/components/gsplat/gsplat-asset-loader.test.mjs
+++ b/test/framework/components/gsplat/gsplat-asset-loader.test.mjs
@@ -113,12 +113,10 @@ describe('GSplatAssetLoader', function () {
             resolveWithError();
             resolveWithError();
 
-            // Two retries consumed (each attaches a fresh 'error' listener), but the original
-            // 'load' listener from the initial _startLoading() call is still pending - it must
-            // not have been duplicated by either retry.
-            const asset = lastAsset();
-            expect(asset._callbacks.get('load')?.length).to.equal(1);
-
+            // Two retries consumed (each attaches a fresh 'error' listener). If the original
+            // 'load' listener from the initial _startLoading() call had been duplicated by
+            // either retry, _onAssetLoadSuccess (and so _processQueue) would run once per
+            // duplicate on the eventual success below instead of exactly once.
             const processQueueSpy = spy(loader, '_processQueue');
             resolveWithResource({ ok: true });
 

--- a/test/framework/components/gsplat/gsplat-asset-loader.test.mjs
+++ b/test/framework/components/gsplat/gsplat-asset-loader.test.mjs
@@ -1,0 +1,194 @@
+import { expect } from 'chai';
+import { restore, spy } from 'sinon';
+
+import { GSplatAssetLoader } from '../../../../src/framework/components/gsplat/gsplat-asset-loader.js';
+
+describe('GSplatAssetLoader', function () {
+    let registry;
+    let loader;
+    let loadCalls;
+
+    beforeEach(function () {
+        loadCalls = 0;
+        registry = {
+            add(asset) {
+                asset.registry = registry;
+            },
+            remove() {},
+            fire() {},
+            getByUrl() {
+                return null;
+            },
+            load(asset) {
+                loadCalls++;
+            },
+            loader: {
+                getHandler: () => ({})
+            },
+            _loader: {
+                clearCache() {}
+            }
+        };
+        loader = new GSplatAssetLoader(registry);
+    });
+
+    afterEach(function () {
+        restore();
+    });
+
+    const lastAsset = () => {
+        const url = [...loader._urlToAsset.keys()].at(-1);
+        return loader._urlToAsset.get(url);
+    };
+
+    // Simulates a load that was cancelled mid-flight (e.g. LOD moved on) and resolved via the
+    // success callback with no resource, as opposed to a genuine error.
+    const resolveAsCancelledWithNoResource = () => {
+        const asset = lastAsset();
+        asset.loading = false;
+        asset.loaded = true;
+        asset.resource = null;
+        asset.fire('load', asset);
+    };
+
+    const resolveWithResource = (resource) => {
+        const asset = lastAsset();
+        asset.loading = false;
+        asset.loaded = true;
+        asset.resource = resource;
+        asset.fire('load', asset);
+    };
+
+    // Simulates a genuine load error (network/parse failure), which the registry always
+    // reports via 'error', not a null-resource 'load'.
+    const resolveWithError = (message = 'simulated error') => {
+        const asset = lastAsset();
+        asset.loading = false;
+        asset.loaded = true;
+        asset.fire('error', message, asset);
+    };
+
+    describe('#load', function () {
+
+        it('retries indefinitely when a previous load was cancelled with no resource', function () {
+            const url = 'http://example.com/chunk.json';
+
+            loader.load(url);
+            resolveAsCancelledWithNoResource();
+            expect(loadCalls).to.equal(1);
+            expect(loader.getResource(url)).to.equal(null);
+
+            // Cancellation can repeat many times (routine LOD churn) without ever giving up.
+            for (let i = 0; i < 10; i++) {
+                loader.load(url);
+                resolveAsCancelledWithNoResource();
+            }
+            expect(loadCalls).to.equal(11);
+
+            loader.load(url);
+            resolveWithResource({ ok: true });
+            expect(loader.getResource(url)).to.deep.equal({ ok: true });
+        });
+
+        it('does not retry a URL that has genuinely, permanently failed', function () {
+            const url = 'http://example.com/chunk.json';
+
+            loader.load(url);
+            for (let i = 0; i < loader.maxRetries; i++) {
+                resolveWithError();
+            }
+            resolveWithError();
+
+            expect(loader.hasFailed(url)).to.equal(true);
+            const callsAtFailure = loadCalls;
+
+            loader.load(url);
+            expect(loadCalls).to.equal(callsAtFailure);
+        });
+
+        it('retries a URL again after it is unloaded and re-requested', function () {
+            const url = 'http://example.com/chunk.json';
+
+            loader.load(url);
+            for (let i = 0; i < loader.maxRetries; i++) {
+                resolveWithError();
+            }
+            resolveWithError();
+            expect(loader.hasFailed(url)).to.equal(true);
+
+            loader.unload(url);
+            expect(loader.hasFailed(url)).to.equal(false);
+
+            loader.load(url);
+            resolveWithResource({ ok: true });
+            expect(loader.getResource(url)).to.deep.equal({ ok: true });
+        });
+
+    });
+
+    describe('#hasFailed', function () {
+
+        it('returns false while a load is in progress, cancelled, or never attempted', function () {
+            const url = 'http://example.com/chunk.json';
+            expect(loader.hasFailed(url)).to.equal(false);
+
+            loader.load(url);
+            expect(loader.hasFailed(url)).to.equal(false);
+
+            resolveAsCancelledWithNoResource();
+            expect(loader.hasFailed(url)).to.equal(false);
+        });
+
+        it('returns false once a load succeeds with a real resource', function () {
+            const url = 'http://example.com/chunk.json';
+            loader.load(url);
+            resolveWithResource({ ok: true });
+            expect(loader.hasFailed(url)).to.equal(false);
+        });
+
+        it('returns true once genuine error retries are exhausted', function () {
+            const url = 'http://example.com/chunk.json';
+
+            loader.load(url);
+            for (let i = 0; i < loader.maxRetries; i++) {
+                resolveWithError();
+            }
+            resolveWithError();
+
+            expect(loader.hasFailed(url)).to.equal(true);
+        });
+
+    });
+
+    describe('cancellation while in flight', function () {
+
+        it('does not warn or error when a load is cancelled before it resolves (routine LOD churn)', function () {
+            const url = 'http://example.com/chunk.json';
+            const warnSpy = spy(console, 'warn');
+            const errorSpy = spy(console, 'error');
+
+            loader.load(url);
+            const asset = loader._urlToAsset.get(url);
+
+            // The octree no longer wants this file (e.g. its ref count reached zero as the
+            // camera moved on) before the in-flight load resolved - this is the routine,
+            // high-frequency cancellation path during scene traversal, not an error condition.
+            loader.unload(url);
+
+            // The in-flight request finally settles (as an error, in this case) after
+            // cancellation. Since unload() already tore down our listeners, this should be a
+            // no-op from GSplatAssetLoader's point of view.
+            asset.fire('error', 'simulated late network error', asset);
+
+            expect(warnSpy.called).to.equal(false);
+            expect(errorSpy.called).to.equal(false);
+            expect(loader.hasFailed(url)).to.equal(false);
+
+            // A later re-request (e.g. the camera swings back) starts a fresh attempt rather
+            // than being blocked by residual state from the cancelled one.
+            loader.load(url);
+            expect(loadCalls).to.equal(2);
+        });
+
+    });
+});


### PR DESCRIPTION
## Summary
Gsplat scene loading could freeze permanently (progress bar stuck short of 100%, autoRender never turning off) when a chunk's load was cancelled mid-flight — e.g. routine LOD range changes during scene traversal, which trigger frequent unload/reload cycles for prefetched and in-flight files. When this happens, `SogParser` resolves via the success callback with no resource (an intentional, silent cancellation signal, not an error), leaving the underlying asset marked `loaded: true` with `resource: null`. `GSplatAssetLoader.load()` treated `loaded: true` as permanently done regardless of whether a resource was ever produced, so it silently no-op'd on every future poll for that URL, and the file never loaded, even though nothing was actually broken about it — it just needed to be retried.
This was confirmed via live instrumentation on a repro scene: a prefetch entry sat indefinitely with `loaded: true, resource: null`, untracked by `_currentlyLoading`/`_loadQueue`/`_retryCount`, forever blocking `pendingLoadCount` from reaching zero.

## Fix
`GSplatAssetLoader.load()` now detects a URL that resolved successfully but produced no resource, and retries it unconditionally whenever polled again, since this only happens while something still actively wants the file — cancellations are not failures and must not be silently permanent.
Genuine load errors (real network/parse failures) are tracked separately via a new `_failed` set, populated only once `_onAssetLoadError`'s existing retry budget is exhausted, so a truly dead URL doesn't retry forever.
Also fixed a related bug in `_onAssetLoadError`'s retry path: it called `registry.load()` directly without re-attaching an `'error'` listener, so a second consecutive genuine failure had no listener left to catch it, meaning `_failed` could never actually be reached for a repeated real error. The retry path now re-attaches only the `'error'` listener that was consumed by the previous attempt — it deliberately does not call `_startLoading()` (which would also re-attach `'load'`), since the original `'load'` listener from the first attempt is still pending and duplicating it would cause `_onAssetLoadSuccess`/`_processQueue` to run more than once on eventual success.

## Test plan
- Added `test/framework/components/gsplat/gsplat-asset-loader.test.mjs` covering: unbounded retry after cancellation, no retry after genuine failure exhausts retries, re-request after `unload()`, no duplicate `'load'` listener across error retries, and no console warnings/errors on routine cancellation (mid-flight `unload()` before resolution).
- Full engine test suite passes (1898 passing, 2 pending unrelated).
- Manually reproduced the original stuck-loading bug on the affected scene, confirmed it no longer occurs across repeated reloads with this fix applied.
