### PR TITLE
Fix device constructor crash when canvas lacks getBoundingClientRect

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -1256,14 +1256,16 @@ class GraphicsDevice extends EventHandler {
     }
 
     updateClientRect() {
-        if (platform.worker) {
-            // Web Workers don't do page layout, so getBoundingClientRect is not available
-            this.clientRect.width = this.canvas.width;
-            this.clientRect.height = this.canvas.height;
-        } else {
+        if (typeof this.canvas.getBoundingClientRect === 'function') {
             const rect = this.canvas.getBoundingClientRect();
             this.clientRect.width = rect.width;
             this.clientRect.height = rect.height;
+        } else {
+            // getBoundingClientRect is not available on OffscreenCanvas (Web Workers don't do
+            // page layout) or on mock canvases used with NullGraphicsDevice in headless
+            // environments
+            this.clientRect.width = this.canvas.width ?? 0;
+            this.clientRect.height = this.canvas.height ?? 0;
         }
     }
 

--- a/test/platform/graphics/graphics-device.test.mjs
+++ b/test/platform/graphics/graphics-device.test.mjs
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+describe('GraphicsDevice', function () {
+
+    describe('#constructor', function () {
+
+        it('does not throw with a mock canvas lacking getBoundingClientRect', function () {
+            const device = new NullGraphicsDevice({ id: 'mock' });
+            expect(device.clientRect.width).to.equal(0);
+            expect(device.clientRect.height).to.equal(0);
+            device.destroy();
+        });
+
+        it('initializes clientRect from mock canvas width and height', function () {
+            const device = new NullGraphicsDevice({ width: 300, height: 150 });
+            expect(device.clientRect.width).to.equal(300);
+            expect(device.clientRect.height).to.equal(150);
+            device.destroy();
+        });
+
+        describe('with a DOM canvas', function () {
+
+            beforeEach(function () {
+                jsdomSetup();
+            });
+
+            afterEach(function () {
+                jsdomTeardown();
+            });
+
+            it('initializes clientRect using getBoundingClientRect', function () {
+                const canvas = document.createElement('canvas');
+                canvas.getBoundingClientRect = () => ({ width: 640, height: 480 });
+                const device = new NullGraphicsDevice(canvas);
+                expect(device.clientRect.width).to.equal(640);
+                expect(device.clientRect.height).to.equal(480);
+                device.destroy();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #8999

Since v2.20.0 (#8950), the base `GraphicsDevice` constructor calls `updateClientRect()`, which unconditionally calls `this.canvas.getBoundingClientRect()` outside of Web Workers. This broke the documented headless path — constructing a `NullGraphicsDevice` with a mock canvas (e.g. `{ id: 'mock' }`, as `@playcanvas/react` does for SSR) now throws, which broke static site generation on developer.playcanvas.com.

**Changes:**
- `GraphicsDevice#updateClientRect` now uses a capability check (`typeof this.canvas.getBoundingClientRect === 'function'`) instead of the `platform.worker` environment check. When the method is missing (OffscreenCanvas in workers, mock canvases in headless environments), it falls back to `this.canvas.width ?? 0` / `height ?? 0`, so a bare mock object yields `clientRect = { width: 0, height: 0 }` rather than throwing or producing NaN.
- Worker behavior is unchanged (OffscreenCanvas has no `getBoundingClientRect` either), and real DOM canvases still get a valid `clientRect` at construction time, preserving the intent of #8950.
- Added unit tests covering a mock canvas without `getBoundingClientRect`, a mock with `width`/`height`, and a DOM canvas using `getBoundingClientRect`.