### PR TITLE
Load MSDF font atlases without mipmaps

### DIFF
--- a/src/framework/handlers/font.js
+++ b/src/framework/handlers/font.js
@@ -1,6 +1,9 @@
 import { path } from '../../core/path.js';
 import { string } from '../../core/string.js';
+import { FILTER_LINEAR } from '../../platform/graphics/constants.js';
 import { http } from '../../platform/net/http.js';
+import { Asset } from '../asset/asset.js';
+import { FONT_MSDF } from '../font/constants.js';
 import { Font } from '../font/font.js';
 import { ResourceHandler } from './handler.js';
 
@@ -101,6 +104,14 @@ class FontHandler extends ResourceHandler {
         const textures = new Array(numTextures);
         const loader = this._loader;
 
+        // MSDF atlases must not be mipmapped: mip levels average the distance-field channels, and
+        // median(average) != average(median), so minified text samples a corrupted median. Request
+        // non-mipmapped textures at creation time (on WebGPU mipmaps cannot be disabled after
+        // creation), using per-load texture options on an ephemeral asset. Bitmap fonts keep
+        // their mipmaps.
+        const isMsdf = !data.type || data.type === FONT_MSDF;
+        const textureOptions = isMsdf ? { texture: { mipmaps: false, minFilter: FILTER_LINEAR } } : null;
+
         const loadTexture = function (index) {
             const onLoaded = function (err, texture) {
                 if (error) return;
@@ -119,11 +130,9 @@ class FontHandler extends ResourceHandler {
                 }
             };
 
-            if (index === 0) {
-                loader.load(url, 'texture', onLoaded);
-            } else {
-                loader.load(url.replace('.png', `${index}.png`), 'texture', onLoaded);
-            }
+            const pageUrl = index === 0 ? url : url.replace('.png', `${index}.png`);
+            const pageAsset = textureOptions ? new Asset(pageUrl, 'texture', { url: pageUrl }, null, textureOptions) : null;
+            loader.load(pageUrl, 'texture', onLoaded, pageAsset);
         };
 
         for (let i = 0; i < numTextures; i++) {

--- a/src/framework/handlers/texture.js
+++ b/src/framework/handlers/texture.js
@@ -208,6 +208,12 @@ class TextureHandler extends ResourceHandler {
                 // basis normalmaps flag the variant as swizzled
                 options.type = TEXTURETYPE_SWIZZLEGGGR;
             }
+
+            // per-load creation options (raw Texture constructor options, for example
+            // { mipmaps: false, minFilter: FILTER_LINEAR }) override the asset-derived options
+            if (asset.options?.texture) {
+                Object.assign(options, asset.options.texture);
+            }
         }
 
         return options;

--- a/test/framework/handlers/font-handler.test.mjs
+++ b/test/framework/handlers/font-handler.test.mjs
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { Asset } from '../../../src/framework/asset/asset.js';
+import { FILTER_LINEAR } from '../../../src/platform/graphics/constants.js';
 import { createApp } from '../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
@@ -31,6 +32,31 @@ describe('FontHandler', function () {
             const font = asset.resource;
             expect(font).to.exist;
             expect(font.textures).to.be.an('array').with.lengthOf(1);
+            done();
+        });
+
+        asset.on('error', err => done(new Error(err)));
+    });
+
+    // regression test for https://github.com/playcanvas/engine/issues/8997 - MSDF atlases must
+    // load without mipmaps and with a non-mip minFilter: mip levels average the distance-field
+    // channels, corrupting the median under minification (visible as faint flickering artifacts
+    // below thin strokes on small text)
+    it('loads MSDF atlas textures without mipmaps', function (done) {
+        const asset = new Asset('arial', 'font', {
+            url: 'http://localhost:3210/test/assets/fonts/arial.json'
+        });
+
+        app.assets.add(asset);
+        app.assets.load(asset);
+
+        asset.ready(function () {
+            const textures = asset.resource.textures;
+            expect(textures).to.have.lengthOf(1);
+            textures.forEach((texture) => {
+                expect(texture.mipmaps).to.equal(false);
+                expect(texture.minFilter).to.equal(FILTER_LINEAR);
+            });
             done();
         });
 


### PR DESCRIPTION
Fixes #8997. Follow-up to #8996 (same diagnosis and fix direction, different plumbing).

## Problem

MSDF font atlas textures load with mipmaps enabled (`mipmaps: true`, `FILTER_LINEAR_MIPMAP_LINEAR`). Mip levels box-average the R/G/B distance-field channels, but `median(average) != average(median)`, so minified text samples a corrupted median — visible as faint ghost/flicker artifacts below thin, closely-spaced stems on small text (most visible at DPR 1). Latent for a long time; surfaced by #8990 rendering at the true glyph edge.

## Fix

MSDF atlas pages are now created **without mipmaps** and with `minFilter: FILTER_LINEAR`. This must be decided at texture creation: on WebGPU the mip chain cannot be removed after creation and the sampler minifies into the chain regardless of filter — verified on a WebGPU repro, where the atlas previously reported `mipLevelCount: 11` and now reports `1`, with the flickering line below thin stems gone and small text not visibly worse. Bitmap fonts keep their mipmaps.

Unlike #8996, no `ResourceHandler.open` / `ResourceLoader.load` signature changes: the creation options travel on an ephemeral texture asset via `asset.options.texture` — a per-load channel of raw `Texture` constructor options that the texture handler merges over the asset-data derived options. `asset.options` is the established per-load options channel (`crossOrigin` for textures, the container handler's whole options bag), and the handler's format mandates (e.g. RGBE) still take precedence over it.

**Changes:**
- `FontHandler._loadTextures`: MSDF pages load with an ephemeral asset carrying `{ texture: { mipmaps: false, minFilter: FILTER_LINEAR } }`
- `TextureHandler._getTextureOptions`: merges `asset.options.texture` (raw `Texture` constructor options) over the asset-data derived options
- Regression test: MSDF atlas textures load with `mipmaps: false` and `FILTER_LINEAR`