### PR TITLE
Allow Texture#mipmaps to be changed at runtime on WebGPU

### DIFF
--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -762,16 +762,17 @@ class Texture {
     }
 
     /**
-     * Sets whether the texture should generate/upload mipmaps.
+     * Sets whether the texture should generate/upload mipmaps. Note that changing this property
+     * on an array texture, or on any texture on WebGPU, re-creates the texture on the GPU, which
+     * is an expensive operation, so it is preferable to create the texture with the correct
+     * mipmaps setting from the start.
      *
      * @type {boolean}
      */
     set mipmaps(v) {
         if (this._mipmaps !== v) {
 
-            if (this.device.isWebGPU) {
-                Debug.warn('Texture#mipmaps: mipmap property is currently not allowed to be changed on WebGPU, create the texture appropriately.', this);
-            } else if (isIntegerPixelFormat(this._format)) {
+            if (isIntegerPixelFormat(this._format)) {
                 Debug.warn('Texture#mipmaps: mipmap property cannot be changed on an integer texture, will remain false', this);
             } else {
                 const oldMipmaps = this._mipmaps;
@@ -780,8 +781,10 @@ class Texture {
                 this._mipmaps = v;
                 this._updateNumLevels();
 
-                // Changing mip count on array textures requires re-creating immutable storage.
-                if (this.array && this._numLevels !== oldNumLevels) {
+                // Array textures (and all textures on WebGPU) use immutable storage, so changing
+                // the mip count requires re-creating the texture.
+                if ((this.array || this.device.isWebGPU) && this._numLevels !== oldNumLevels) {
+                    Debug.warn(`Changing mipmaps of texture '${this.name}' requires it to be re-created. This is an expensive operation, and the texture should be created with the desired mipmaps setting to avoid this.`, this);
                     this.recreateImpl();
                 } else if (this._mipmaps !== oldMipmaps) {
                     this.propertyChanged(TEXPROPERTY_MIN_FILTER);


### PR DESCRIPTION
Changing `Texture#mipmaps` at runtime on WebGPU previously logged a warning and was ignored (hit by the texture-atlas handler and the Editor's mipmaps toggle, which #8455 enabled for WebGL). Since the mip level count is baked into the immutable texture descriptor on WebGPU, the texture is now re-created instead — the same path already used by the `srgb` setter and by array-texture mip count changes.

**Changes:**
- `Texture#mipmaps` setter no longer refuses the change on WebGPU — the recreate condition is generalized from array textures to `(array || WebGPU) && mip count changed`, and mipmaps are regenerated on the subsequent upload
- Added an srgb-style performance warning when the toggle requires the texture to be re-created (WebGPU, and array textures on WebGL — the latter previously recreated silently)
- Setter JSDoc now documents that this is expensive and the texture should ideally be created with the desired setting

**Performance:**
- No change to existing fast paths; the recreate only happens when the effective mip level count changes, and it now warns