### PR TITLE
Convert MaterialHandler to the parser registry

### DIFF
--- a/src/framework/handlers/material.js
+++ b/src/framework/handlers/material.js
@@ -1,6 +1,6 @@
 import { Debug } from '../../core/debug.js';
-import { http } from '../../platform/net/http.js';
 import { standardMaterialCubemapParameters, standardMaterialTextureParameters } from '../../scene/materials/standard-material-parameters.js';
+import { StandardMaterial } from '../../scene/materials/standard-material.js';
 import { AssetReference } from '../asset/asset-reference.js';
 import { JsonStandardMaterialParser } from '../parsers/material/json-standard-material.js';
 import { ResourceHandler } from './handler.js';
@@ -56,45 +56,11 @@ class MaterialHandler extends ResourceHandler {
 
         this._assets = app.assets;
         this._device = app.graphicsDevice;
+
+        // the json parser is the catch-all for material assets; the handler keeps a reference to
+        // it as patch uses its migrate/initialize when binding standard material assets
         this._parser = new JsonStandardMaterialParser();
-    }
-
-    load(url, callback) {
-        if (typeof url === 'string') {
-            url = {
-                load: url,
-                original: url
-            };
-        }
-
-        // Loading from URL (engine-only)
-        http.get(url.load, {
-            retry: this.maxRetries > 0,
-            maxRetries: this.maxRetries
-        }, (err, response) => {
-            if (!err) {
-                if (callback) {
-                    response._engine = true;
-                    callback(null, response);
-                }
-            } else {
-                if (callback) {
-                    callback(`Error loading material: ${url.original} [${err}]`);
-                }
-            }
-        });
-    }
-
-    open(url, data) {
-        const material = this._parser.parse(data);
-
-        // temp storage for engine-only as we need this during patching
-        if (data._engine) {
-            material._data = data;
-            delete data._engine;
-        }
-
-        return material;
+        this.addParser(this._parser);
     }
 
     patch(asset, assets) {
@@ -108,7 +74,11 @@ class MaterialHandler extends ResourceHandler {
         asset.data.name = asset.name;
         asset.resource.name = asset.name;
 
-        this._bindAndAssignAssets(asset, assets);
+        // the asset binding below is specific to StandardMaterial (the built-in json parser's
+        // output); materials produced by user-registered parsers manage their own asset references
+        if (asset.resource instanceof StandardMaterial) {
+            this._bindAndAssignAssets(asset, assets);
+        }
 
         asset.off('unload', this._onAssetUnload, this);
         asset.on('unload', this._onAssetUnload, this);

--- a/src/framework/handlers/material.js
+++ b/src/framework/handlers/material.js
@@ -64,6 +64,13 @@ class MaterialHandler extends ResourceHandler {
     }
 
     patch(asset, assets) {
+        // patching (the engine-only _data handoff, the name sync and the asset binding below) is
+        // specific to StandardMaterial, the built-in json parser's output; materials produced by
+        // user-registered parsers manage their own data and asset references
+        if (!(asset.resource instanceof StandardMaterial)) {
+            return;
+        }
+
         // in an engine-only environment we manually copy the source data into the asset
         if (asset.resource._data) {
             asset._data = asset.resource._data; // use _data to avoid firing events
@@ -74,11 +81,7 @@ class MaterialHandler extends ResourceHandler {
         asset.data.name = asset.name;
         asset.resource.name = asset.name;
 
-        // the asset binding below is specific to StandardMaterial (the built-in json parser's
-        // output); materials produced by user-registered parsers manage their own asset references
-        if (asset.resource instanceof StandardMaterial) {
-            this._bindAndAssignAssets(asset, assets);
-        }
+        this._bindAndAssignAssets(asset, assets);
 
         asset.off('unload', this._onAssetUnload, this);
         asset.on('unload', this._onAssetUnload, this);

--- a/src/framework/parsers/material/json-standard-material.js
+++ b/src/framework/parsers/material/json-standard-material.js
@@ -3,6 +3,7 @@ import { Vec2 } from '../../../core/math/vec2.js';
 import { Vec3 } from '../../../core/math/vec3.js';
 
 import { Texture } from '../../../platform/graphics/texture.js';
+import { Http } from '../../../platform/net/http.js';
 
 import { BoundingBox } from '../../../core/shape/bounding-box.js';
 
@@ -18,6 +19,37 @@ import { standardMaterialParameterTypes } from '../../../scene/materials/standar
 class JsonStandardMaterialParser {
     constructor() {
         this._validator = null;
+    }
+
+    canParse() {
+        // json is the only built-in material format; it acts as the catch-all, so any material
+        // asset resolves to it unless a more specific parser is registered
+        return true;
+    }
+
+    load(url, callback, asset) {
+        this.handler.fetch(url, Http.ResponseType.JSON, (err, response) => {
+            if (err) {
+                callback(`Error loading material: ${url.original} [${err}]`);
+            } else {
+                // loading from a url is an engine-only path - tag the data so open/patch can copy
+                // it into the asset (in the editor, material data always comes from the asset)
+                response._engine = true;
+                callback(null, response);
+            }
+        }, asset);
+    }
+
+    open(url, data) {
+        const material = this.parse(data);
+
+        // temp storage for engine-only as we need this during patching
+        if (data._engine) {
+            material._data = data;
+            delete data._engine;
+        }
+
+        return material;
     }
 
     parse(input) {

--- a/test/framework/handlers/material-handler.test.mjs
+++ b/test/framework/handlers/material-handler.test.mjs
@@ -1,0 +1,99 @@
+import { expect } from 'chai';
+
+import { Asset } from '../../../src/framework/asset/asset.js';
+import { StandardMaterial } from '../../../src/scene/materials/standard-material.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+describe('MaterialHandler', function () {
+
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    // engine-only path: material loaded from a json url
+    it('loads a material from a url', function (done) {
+        const asset = new Asset('red', 'material', {
+            url: '/test/assets/sprites/red-material.json'
+        });
+
+        asset.ready(() => {
+            const material = asset.resource;
+            expect(material).to.be.an.instanceof(StandardMaterial);
+            expect(material.diffuse.r).to.equal(1);
+            expect(material.diffuse.g).to.equal(0);
+            expect(material.diffuse.b).to.equal(0);
+            done();
+        });
+        asset.on('error', err => done(new Error(err)));
+
+        app.assets.add(asset);
+        app.assets.load(asset);
+    });
+
+    // the url-loaded source data is copied into the asset during patch (the _engine flow), and the
+    // asset name is patched over the material name
+    it('copies url-loaded data into the asset and patches the name', function (done) {
+        const asset = new Asset('red-material-name', 'material', {
+            url: '/test/assets/sprites/red-material.json'
+        });
+
+        asset.ready(() => {
+            expect(asset.data.diffuse).to.deep.equal([1, 0, 0]);
+            expect(asset.data.name).to.equal('red-material-name');
+            expect(asset.resource.name).to.equal('red-material-name');
+            done();
+        });
+        asset.on('error', err => done(new Error(err)));
+
+        app.assets.add(asset);
+        app.assets.load(asset);
+    });
+
+    // the editor-dominant path: a material asset with no file is opened directly from its data
+    it('opens a material from asset data when there is no file', function (done) {
+        const asset = new Asset('green', 'material', null, {
+            diffuse: [0, 1, 0]
+        });
+
+        asset.ready(() => {
+            const material = asset.resource;
+            expect(material).to.be.an.instanceof(StandardMaterial);
+            expect(material.diffuse.r).to.equal(0);
+            expect(material.diffuse.g).to.equal(1);
+            expect(material.diffuse.b).to.equal(0);
+            done();
+        });
+        asset.on('error', err => done(new Error(err)));
+
+        app.assets.add(asset);
+        app.assets.load(asset);
+    });
+
+    // legacy data is migrated on parse (mapping_format is the old name for mappingFormat)
+    it('migrates legacy data fields when parsing', function (done) {
+        const asset = new Asset('legacy', 'material', null, {
+            diffuse: [0, 0, 1],
+            mapping_format: 'path'
+        });
+
+        asset.ready(() => {
+            expect(asset.data.mappingFormat).to.equal('path');
+            expect(asset.data.mapping_format).to.be.undefined;
+            done();
+        });
+        asset.on('error', err => done(new Error(err)));
+
+        app.assets.add(asset);
+        app.assets.load(asset);
+    });
+});


### PR DESCRIPTION
Follow-up to #9001 — converts the material handler to the parser registry, retiring the last legacy parser pattern in the engine. Custom material formats are now pluggable the same way as every other converted handler.

**Changes:**
- `JsonStandardMaterialParser` is registered as the catch-all material parser and gains `canParse` / `load` / `open`; the handler's `load` and `open` overrides are removed in favor of the base implementations
- The engine-only url-load flow is preserved verbatim (`load` tags the data with `_engine`, `open` stashes it on `material._data`, `patch` copies it into the asset), as is the editor-dominant no-file path (`loader.open('material', data)` resolves through the catch-all)
- `patch` runs the StandardMaterial-specific asset binding (`AssetReference` texture/cubemap wiring, placeholders) only when the resource is a `StandardMaterial` — behavior-identical today, and materials produced by user-registered parsers manage their own asset references instead of crashing into it
- Fetching goes through `ResourceHandler#fetch` with an explicit JSON response type — identical for `.json` urls (the only documented path), and `blob:` urls now parse correctly instead of coming back as text
- Characterization tests written against the pre-conversion behavior (url load, no-file open-from-data, `_engine`/name patching, legacy data migration) pass unchanged through the conversion

**API Changes:**
- `JsonStandardMaterialParser` (already exported) gains `canParse(context)`, `load(url, callback, asset)` and `open(url, data)`

```js
// register a custom material format
class MyMaterialParser {
    canParse(context) { return context.ext === 'mymat'; }
    load(url, callback, asset) { this.handler.fetch(url, pc.Http.ResponseType.JSON, callback, asset); }
    open(url, data) { /* build and return a pc.Material */ }
}
app.loader.getHandler('material').addParser(new MyMaterialParser());
```