### PR TITLE
Convert anim-clip, anim-state-graph and template handlers to the parser registry

### DIFF
--- a/src/framework/handlers/anim-clip.js
+++ b/src/framework/handlers/anim-clip.js
@@ -1,9 +1,4 @@
-import { http, Http } from '../../platform/net/http.js';
-
-import { AnimCurve } from '../anim/evaluator/anim-curve.js';
-import { AnimData } from '../anim/evaluator/anim-data.js';
-import { AnimTrack } from '../anim/evaluator/anim-track.js';
-
+import { AnimClipParser } from '../parsers/anim-clip.js';
 import { ResourceHandler } from './handler.js';
 
 /**
@@ -14,59 +9,8 @@ import { ResourceHandler } from './handler.js';
 class AnimClipHandler extends ResourceHandler {
     constructor(app) {
         super(app, 'animclip');
-    }
 
-    load(url, callback) {
-        if (typeof url === 'string') {
-            url = {
-                load: url,
-                original: url
-            };
-        }
-
-        // we need to specify JSON for blob URLs
-        const options = {
-            retry: this.maxRetries > 0,
-            maxRetries: this.maxRetries
-        };
-
-        if (url.load.startsWith('blob:')) {
-            options.responseType = Http.ResponseType.JSON;
-        }
-
-        http.get(url.load, options, (err, response) => {
-            if (err) {
-                callback(`Error loading animation clip resource: ${url.original} [${err}]`);
-            } else {
-                callback(null, response);
-            }
-        });
-    }
-
-    open(url, data) {
-        const name = data.name;
-        const duration = data.duration;
-        const inputs = data.inputs.map((input) => {
-            return new AnimData(1, input);
-        });
-        const outputs = data.outputs.map((output) => {
-            return new AnimData(output.components, output.data);
-        });
-        const curves = data.curves.map((curve) => {
-            return new AnimCurve(
-                [curve.path],
-                curve.inputIndex,
-                curve.outputIndex,
-                curve.interpolation
-            );
-        });
-        return new AnimTrack(
-            name,
-            duration,
-            inputs,
-            outputs,
-            curves
-        );
+        this.addParser(new AnimClipParser());
     }
 }
 

--- a/src/framework/handlers/anim-state-graph.js
+++ b/src/framework/handlers/anim-state-graph.js
@@ -1,6 +1,4 @@
-import { http, Http } from '../../platform/net/http.js';
-import { AnimStateGraph } from '../anim/state-graph/anim-state-graph.js';
-
+import { AnimStateGraphParser } from '../parsers/anim-state-graph.js';
 import { ResourceHandler } from './handler.js';
 
 /**
@@ -11,37 +9,8 @@ import { ResourceHandler } from './handler.js';
 class AnimStateGraphHandler extends ResourceHandler {
     constructor(app) {
         super(app, 'animstategraph');
-    }
 
-    load(url, callback) {
-        if (typeof url === 'string') {
-            url = {
-                load: url,
-                original: url
-            };
-        }
-
-        // we need to specify JSON for blob URLs
-        const options = {
-            retry: this.maxRetries > 0,
-            maxRetries: this.maxRetries
-        };
-
-        if (url.load.startsWith('blob:')) {
-            options.responseType = Http.ResponseType.JSON;
-        }
-
-        http.get(url.load, options, (err, response) => {
-            if (err) {
-                callback(`Error loading animation state graph resource: ${url.original} [${err}]`);
-            } else {
-                callback(null, response);
-            }
-        });
-    }
-
-    open(url, data) {
-        return new AnimStateGraph(data);
+        this.addParser(new AnimStateGraphParser());
     }
 }
 

--- a/src/framework/handlers/template.js
+++ b/src/framework/handlers/template.js
@@ -1,4 +1,4 @@
-import { http } from '../../platform/net/http.js';
+import { TemplateParser } from '../parsers/template.js';
 import { Template } from '../template.js';
 import { ResourceHandler } from './handler.js';
 
@@ -13,33 +13,8 @@ class TemplateHandler extends ResourceHandler {
 
     constructor(app) {
         super(app, 'template');
-    }
 
-    load(url, callback) {
-        if (typeof url === 'string') {
-            url = {
-                load: url,
-                original: url
-            };
-        }
-
-        // we need to specify JSON for blob URLs
-        const options = {
-            retry: this.maxRetries > 0,
-            maxRetries: this.maxRetries
-        };
-
-        http.get(url.load, options, (err, response) => {
-            if (err) {
-                callback(`Error requesting template: ${url.original}`);
-            } else {
-                callback(err, response);
-            }
-        });
-    }
-
-    open(url, data) {
-        return new Template(this._app, data);
+        this.addParser(new TemplateParser());
     }
 
     /**

--- a/src/framework/parsers/anim-clip.js
+++ b/src/framework/parsers/anim-clip.js
@@ -1,0 +1,56 @@
+import { Http } from '../../platform/net/http.js';
+import { AnimCurve } from '../anim/evaluator/anim-curve.js';
+import { AnimData } from '../anim/evaluator/anim-data.js';
+import { AnimTrack } from '../anim/evaluator/anim-track.js';
+
+/**
+ * Parser for animation clip resources. Fetches the JSON data and builds an {@link AnimTrack}.
+ *
+ * @ignore
+ */
+class AnimClipParser {
+    canParse() {
+        // json is the only built-in animation clip format; it acts as the catch-all, so any clip
+        // asset resolves to it unless a more specific parser is registered
+        return true;
+    }
+
+    load(url, callback, asset) {
+        const original = typeof url === 'string' ? url : url.original;
+        this.handler.fetch(url, Http.ResponseType.JSON, (err, response) => {
+            if (err) {
+                callback(`Error loading animation clip resource: ${original} [${err}]`);
+            } else {
+                callback(null, response);
+            }
+        }, asset);
+    }
+
+    open(url, data) {
+        const name = data.name;
+        const duration = data.duration;
+        const inputs = data.inputs.map((input) => {
+            return new AnimData(1, input);
+        });
+        const outputs = data.outputs.map((output) => {
+            return new AnimData(output.components, output.data);
+        });
+        const curves = data.curves.map((curve) => {
+            return new AnimCurve(
+                [curve.path],
+                curve.inputIndex,
+                curve.outputIndex,
+                curve.interpolation
+            );
+        });
+        return new AnimTrack(
+            name,
+            duration,
+            inputs,
+            outputs,
+            curves
+        );
+    }
+}
+
+export { AnimClipParser };

--- a/src/framework/parsers/anim-state-graph.js
+++ b/src/framework/parsers/anim-state-graph.js
@@ -1,0 +1,33 @@
+import { Http } from '../../platform/net/http.js';
+import { AnimStateGraph } from '../anim/state-graph/anim-state-graph.js';
+
+/**
+ * Parser for animation state graph resources. Fetches the JSON data and builds an
+ * {@link AnimStateGraph}.
+ *
+ * @ignore
+ */
+class AnimStateGraphParser {
+    canParse() {
+        // json is the only built-in animation state graph format; it acts as the catch-all, so any
+        // state graph asset resolves to it unless a more specific parser is registered
+        return true;
+    }
+
+    load(url, callback, asset) {
+        const original = typeof url === 'string' ? url : url.original;
+        this.handler.fetch(url, Http.ResponseType.JSON, (err, response) => {
+            if (err) {
+                callback(`Error loading animation state graph resource: ${original} [${err}]`);
+            } else {
+                callback(null, response);
+            }
+        }, asset);
+    }
+
+    open(url, data) {
+        return new AnimStateGraph(data);
+    }
+}
+
+export { AnimStateGraphParser };

--- a/src/framework/parsers/template.js
+++ b/src/framework/parsers/template.js
@@ -1,0 +1,32 @@
+import { Http } from '../../platform/net/http.js';
+import { Template } from '../template.js';
+
+/**
+ * Parser for template resources. Fetches the JSON data and wraps it in a {@link Template}.
+ *
+ * @ignore
+ */
+class TemplateParser {
+    canParse() {
+        // json is the only built-in template format; it acts as the catch-all, so any template
+        // asset resolves to it unless a more specific parser is registered
+        return true;
+    }
+
+    load(url, callback, asset) {
+        const original = typeof url === 'string' ? url : url.original;
+        this.handler.fetch(url, Http.ResponseType.JSON, (err, response) => {
+            if (err) {
+                callback(`Error requesting template: ${original}`);
+            } else {
+                callback(null, response);
+            }
+        }, asset);
+    }
+
+    open(url, data) {
+        return new Template(this.handler.app, data);
+    }
+}
+
+export { TemplateParser };

--- a/test/framework/handlers/anim-clip-handler.test.mjs
+++ b/test/framework/handlers/anim-clip-handler.test.mjs
@@ -1,0 +1,77 @@
+import { expect } from 'chai';
+import { restore, stub } from 'sinon';
+
+import { AnimTrack } from '../../../src/framework/anim/evaluator/anim-track.js';
+import { AnimClipHandler } from '../../../src/framework/handlers/anim-clip.js';
+import { http, Http } from '../../../src/platform/net/http.js';
+
+// a minimal animation clip data block, as fetched from a clip json resource
+const clipData = {
+    name: 'test-clip',
+    duration: 2,
+    inputs: [[0, 1]],
+    outputs: [{ components: 3, data: [0, 0, 0, 1, 1, 1] }],
+    curves: [{
+        path: { entityPath: ['RootNode'], component: 'graph', propertyPath: ['localPosition'] },
+        inputIndex: 0,
+        outputIndex: 0,
+        interpolation: 1
+    }]
+};
+
+describe('AnimClipHandler', function () {
+
+    afterEach(function () {
+        restore();
+    });
+
+    it('loads the resource and returns the fetched response', function () {
+        const handler = new AnimClipHandler({});
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback(null, clipData);
+        });
+
+        let result;
+        handler.load({ load: 'x.json', original: 'x.json' }, (err, res) => {
+            expect(err).to.equal(null);
+            result = res;
+        });
+        expect(result).to.equal(clipData);
+    });
+
+    it('requests JSON for blob urls', function () {
+        const handler = new AnimClipHandler({});
+        let requestOptions;
+        stub(http, 'get').callsFake((url, options, callback) => {
+            requestOptions = options;
+            callback(null, clipData);
+        });
+
+        handler.load({ load: 'blob:1234', original: 'x.json' }, () => { });
+        expect(requestOptions.responseType).to.equal(Http.ResponseType.JSON);
+    });
+
+    it('reports a load error including the url', function () {
+        const handler = new AnimClipHandler({});
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback('404');
+        });
+
+        let err;
+        handler.load({ load: 'file.json', original: 'file.json' }, (e) => {
+            err = e;
+        });
+        expect(err).to.include('Error loading animation clip resource');
+        expect(err).to.include('file.json');
+        expect(err).to.include('404');
+    });
+
+    it('open builds an AnimTrack from the clip data', function () {
+        const handler = new AnimClipHandler({});
+        const track = handler.open('x.json', clipData);
+        expect(track).to.be.an.instanceof(AnimTrack);
+        expect(track.name).to.equal('test-clip');
+        expect(track.duration).to.equal(2);
+        expect(track.curves).to.have.lengthOf(1);
+    });
+});

--- a/test/framework/handlers/anim-state-graph-handler.test.mjs
+++ b/test/framework/handlers/anim-state-graph-handler.test.mjs
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import { restore, stub } from 'sinon';
+
+import { AnimStateGraph } from '../../../src/framework/anim/state-graph/anim-state-graph.js';
+import { AnimStateGraphHandler } from '../../../src/framework/handlers/anim-state-graph.js';
+import { http } from '../../../src/platform/net/http.js';
+
+// a minimal state graph data block (the object form of layers/states/transitions)
+const stateGraphData = {
+    layers: {
+        0: { name: 'Base', states: [0, 1], transitions: [0] }
+    },
+    states: {
+        0: { name: 'START', speed: 1 },
+        1: { name: 'New State', speed: 1, loop: true, defaultState: true }
+    },
+    transitions: {
+        0: { from: 0, to: 1, conditions: {} }
+    },
+    parameters: {}
+};
+
+describe('AnimStateGraphHandler', function () {
+
+    afterEach(function () {
+        restore();
+    });
+
+    it('loads the resource and returns the fetched response', function () {
+        const handler = new AnimStateGraphHandler({});
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback(null, stateGraphData);
+        });
+
+        let result;
+        handler.load({ load: 'x.json', original: 'x.json' }, (err, res) => {
+            expect(err).to.equal(null);
+            result = res;
+        });
+        expect(result).to.equal(stateGraphData);
+    });
+
+    it('reports a load error including the url', function () {
+        const handler = new AnimStateGraphHandler({});
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback('404');
+        });
+
+        let err;
+        handler.load({ load: 'file.json', original: 'file.json' }, (e) => {
+            err = e;
+        });
+        expect(err).to.include('Error loading animation state graph resource');
+        expect(err).to.include('file.json');
+        expect(err).to.include('404');
+    });
+
+    it('open builds an AnimStateGraph from the data', function () {
+        const handler = new AnimStateGraphHandler({});
+        const graph = handler.open('x.json', stateGraphData);
+        expect(graph).to.be.an.instanceof(AnimStateGraph);
+        expect(graph.layers).to.have.lengthOf(1);
+        expect(graph.layers[0].name).to.equal('Base');
+    });
+});

--- a/test/framework/handlers/binary-handler.test.mjs
+++ b/test/framework/handlers/binary-handler.test.mjs
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import { restore, stub } from 'sinon';
+
+import { BinaryHandler } from '../../../src/framework/handlers/binary.js';
+import { http } from '../../../src/platform/net/http.js';
+
+describe('BinaryHandler', function () {
+
+    afterEach(function () {
+        restore();
+    });
+
+    it('loads the resource and returns the fetched ArrayBuffer', function () {
+        const handler = new BinaryHandler({});
+        const buffer = new Uint8Array([1, 2, 3]).buffer;
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback(null, buffer);
+        });
+
+        let result;
+        handler.load({ load: 'x.bin', original: 'x.bin' }, (err, res) => {
+            expect(err).to.equal(null);
+            result = res;
+        });
+        expect(result).to.equal(buffer);
+    });
+
+    it('reports a load error including the url', function () {
+        const handler = new BinaryHandler({});
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback('500');
+        });
+
+        let err;
+        handler.load({ load: 'file.bin', original: 'file.bin' }, (e) => {
+            err = e;
+        });
+        expect(err).to.be.a('string');
+        expect(err).to.include('Error loading binary resource');
+        expect(err).to.include('file.bin');
+    });
+
+    it('openBinary returns the underlying ArrayBuffer of a DataView', function () {
+        const handler = new BinaryHandler({});
+        const bytes = new Uint8Array([4, 5, 6]);
+        const view = new DataView(bytes.buffer);
+        expect(handler.openBinary(view)).to.equal(bytes.buffer);
+    });
+});

--- a/test/framework/handlers/template-handler.test.mjs
+++ b/test/framework/handlers/template-handler.test.mjs
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
+import { restore, stub } from 'sinon';
 
 import { Asset } from '../../../src/framework/asset/asset.js';
+import { TemplateHandler } from '../../../src/framework/handlers/template.js';
+import { Template } from '../../../src/framework/template.js';
+import { http } from '../../../src/platform/net/http.js';
 import { createApp } from '../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
@@ -63,5 +67,55 @@ describe('TemplateHandler', function () {
             expect(second.name).to.equal('root2');
             done();
         });
+    });
+});
+
+// loading behavior, asserted through the public interface (load + open + openBinary) with a
+// stubbed http layer - a characterization safety net for the handler's parser-registry plumbing
+describe('TemplateHandler (loading)', function () {
+
+    afterEach(function () {
+        restore();
+    });
+
+    it('loads the resource and returns the fetched response', function () {
+        const handler = new TemplateHandler({});
+        const templateData = { entities: {} };
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback(null, templateData);
+        });
+
+        let result;
+        handler.load({ load: 'x.json', original: 'x.json' }, (err, res) => {
+            expect(err).to.equal(null);
+            result = res;
+        });
+        expect(result).to.equal(templateData);
+    });
+
+    it('reports a load error with the exact legacy message (no error detail)', function () {
+        const handler = new TemplateHandler({});
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback('404');
+        });
+
+        let err;
+        handler.load({ load: 'file.json', original: 'file.json' }, (e) => {
+            err = e;
+        });
+        expect(err).to.equal('Error requesting template: file.json');
+    });
+
+    it('open wraps the data in a Template', function () {
+        const handler = new TemplateHandler({});
+        const template = handler.open('x.json', { entities: {} });
+        expect(template).to.be.an.instanceof(Template);
+    });
+
+    it('openBinary decodes a DataView into a Template', function () {
+        const handler = new TemplateHandler({});
+        const bytes = new TextEncoder().encode('{"entities":{}}');
+        const view = new DataView(bytes.buffer);
+        expect(handler.openBinary(view)).to.be.an.instanceof(Template);
     });
 });

--- a/test/framework/handlers/text-handlers.test.mjs
+++ b/test/framework/handlers/text-handlers.test.mjs
@@ -1,19 +1,16 @@
 import { expect } from 'chai';
 import { restore, stub } from 'sinon';
 
-import { BinaryHandler } from '../../../src/framework/handlers/binary.js';
 import { CssHandler } from '../../../src/framework/handlers/css.js';
 import { HtmlHandler } from '../../../src/framework/handlers/html.js';
 import { ShaderHandler } from '../../../src/framework/handlers/shader.js';
 import { TextHandler } from '../../../src/framework/handlers/text.js';
 import { http } from '../../../src/platform/net/http.js';
 
-// Behavior-level tests for the single-parser resource handlers that have no example coverage. They assert
-// only through the public interface (load + openBinary), which is identical whether the handler loads via
-// its own load() override (current) or via the ResourceHandler parser registry (after conversion) - so
-// these act as a safety net for that future conversion.
-
-// the text-decoding handlers are structurally identical: fetch bytes and decode to a string
+// Behavior-level tests for the text-decoding resource handlers, which are structurally identical:
+// they share the TextParser (fetch text, pass it through) and differ only in their resource type.
+// They assert only through the public interface (load + openBinary), acting as a characterization
+// safety net for the handlers' parser-registry plumbing.
 const textHandlers = [
     { name: 'CssHandler', Handler: CssHandler, type: 'css' },
     { name: 'HtmlHandler', Handler: HtmlHandler, type: 'html' },
@@ -21,7 +18,7 @@ const textHandlers = [
     { name: 'ShaderHandler', Handler: ShaderHandler, type: 'shader' }
 ];
 
-describe('single-parser resource handlers', function () {
+describe('text resource handlers', function () {
 
     afterEach(function () {
         restore();
@@ -66,46 +63,6 @@ describe('single-parser resource handlers', function () {
                 const view = new DataView(bytes.buffer);
                 expect(handler.openBinary(view)).to.equal('body { color: red; }');
             });
-        });
-    });
-
-    describe('BinaryHandler', function () {
-
-        it('loads the resource and returns the fetched ArrayBuffer', function () {
-            const handler = new BinaryHandler({});
-            const buffer = new Uint8Array([1, 2, 3]).buffer;
-            stub(http, 'get').callsFake((url, options, callback) => {
-                callback(null, buffer);
-            });
-
-            let result;
-            handler.load({ load: 'x.bin', original: 'x.bin' }, (err, res) => {
-                expect(err).to.equal(null);
-                result = res;
-            });
-            expect(result).to.equal(buffer);
-        });
-
-        it('reports a load error including the url', function () {
-            const handler = new BinaryHandler({});
-            stub(http, 'get').callsFake((url, options, callback) => {
-                callback('500');
-            });
-
-            let err;
-            handler.load({ load: 'file.bin', original: 'file.bin' }, (e) => {
-                err = e;
-            });
-            expect(err).to.be.a('string');
-            expect(err).to.include('Error loading binary resource');
-            expect(err).to.include('file.bin');
-        });
-
-        it('openBinary returns the underlying ArrayBuffer of a DataView', function () {
-            const handler = new BinaryHandler({});
-            const bytes = new Uint8Array([4, 5, 6]);
-            const view = new DataView(bytes.buffer);
-            expect(handler.openBinary(view)).to.equal(bytes.buffer);
         });
     });
 });


### PR DESCRIPTION
Follow-up to #9001 / #9004 — converts the three remaining JSON-boilerplate handlers to the parser registry. Their near-identical fetch code (~60 duplicated lines) collapses into three small catch-all parsers, and custom formats become pluggable via `addParser`, consistent with the other converted handlers.

**Changes:**
- New parsers `AnimClipParser`, `AnimStateGraphParser` and `TemplateParser` (internal, in `src/framework/parsers/`): catch-all `canParse`, `load` via `ResourceHandler#fetch`, and the handlers' `open` logic moved verbatim (AnimTrack build / `new AnimStateGraph(data)` / `new Template(app, data)`)
- The handlers reduce to their constructor registering the parser; `TemplateHandler` keeps its `openBinary` bundle fast-path and `patch` untouched
- Error strings are preserved exactly — including the template one, which carries no error detail
- Fetching now always requests a JSON response type (previously extension auto-detected, with a blob-only JSON branch in the anim handlers): identical for `.json` urls, and `blob:` template urls now parse correctly instead of coming back as text — which the old code comment claimed but never implemented
- Characterization tests written against the pre-conversion behavior pass unchanged (load pass-through, exact error messages, blob JSON request, `open` resource construction, template `openBinary`)
- The growing `single-parser-handlers.test.mjs` is split into per-handler files so it doesn't become a dump: `text-handlers` (the shared css/html/text/shader `TextParser` family, kept as one parameterized table), `binary-handler`, `anim-clip-handler`, `anim-state-graph-handler`, and the loading tests folded into the existing `template-handler` file

**API Changes:**
- None — the new parsers are internal (`@ignore`), and the handlers only lose their `load`/`open` overrides in favor of the documented base signatures