### PR TITLE
Convert AudioHandler to the parser registry

### DIFF
--- a/src/framework/handlers/audio.js
+++ b/src/framework/handlers/audio.js
@@ -1,23 +1,10 @@
-import { path } from '../../core/path.js';
 import { Debug } from '../../core/debug.js';
-import { http, Http } from '../../platform/net/http.js';
-import { Sound } from '../../platform/sound/sound.js';
+import { AudioParser } from '../parsers/audio.js';
 import { ResourceHandler } from './handler.js';
 
 /**
  * @import { AppBase } from '../app-base.js'
  */
-
-const supportedExtensions = [
-    '.ogg',
-    '.mp3',
-    '.wav',
-    '.mp4a',
-    '.m4a',
-    '.mp4',
-    '.aac',
-    '.opus'
-];
 
 /**
  * Resource handler used for loading {@link Sound} resources.
@@ -34,86 +21,11 @@ class AudioHandler extends ResourceHandler {
     constructor(app) {
         super(app, 'audio');
 
+        // read by AudioParser via this.handler
         this.manager = app.soundManager;
         Debug.assert(this.manager, 'AudioHandler cannot be created without sound manager');
-    }
 
-    _isSupported(url) {
-        const ext = path.getExtension(url);
-
-        return supportedExtensions.indexOf(ext) > -1;
-    }
-
-    load(url, callback) {
-        if (typeof url === 'string') {
-            url = {
-                load: url,
-                original: url
-            };
-        }
-
-        const success = function (resource) {
-            callback(null, new Sound(resource));
-        };
-
-        const error = function (err) {
-            let msg = `Error loading audio url: ${url.original}`;
-            if (err) {
-                msg += `: ${err.message || err}`;
-            }
-            console.warn(msg);
-            callback(msg);
-        };
-
-        if (this._createSound) {
-            if (!this._isSupported(url.original)) {
-                error(`Audio format for ${url.original} not supported`);
-                return;
-            }
-
-            this._createSound(url.load, success, error);
-        } else {
-            error(null);
-        }
-    }
-
-    /**
-     * Loads an audio asset using an AudioContext by URL and calls success or error with the
-     * created resource or error respectively.
-     *
-     * @param {string} url - The url of the audio asset.
-     * @param {Function} success - Function to be called if the audio asset was loaded or if we
-     * just want to continue without errors even if the audio is not loaded.
-     * @param {Function} error - Function to be called if there was an error while loading the
-     * audio asset.
-     * @private
-     */
-    _createSound(url, success, error) {
-        const manager = this.manager;
-
-        if (!manager.context) {
-            error('Audio manager has no audio context');
-            return;
-        }
-
-        // if this is a blob URL we need to set the response type to arraybuffer
-        const options = {
-            retry: this.maxRetries > 0,
-            maxRetries: this.maxRetries
-        };
-
-        if (url.startsWith('blob:') || url.startsWith('data:')) {
-            options.responseType = Http.ResponseType.ARRAY_BUFFER;
-        }
-
-        http.get(url, options, (err, response) => {
-            if (err) {
-                error(err);
-                return;
-            }
-
-            manager.context.decodeAudioData(response, success, error);
-        });
+        this.addParser(new AudioParser());
     }
 }
 

--- a/src/framework/parsers/audio.js
+++ b/src/framework/parsers/audio.js
@@ -47,8 +47,9 @@ class AudioParser {
             return;
         }
 
+        // guard a missing sound manager too (the handler only asserts it in debug builds)
         const manager = this.handler.manager;
-        if (!manager.context) {
+        if (!manager?.context) {
             error('Audio manager has no audio context');
             return;
         }
@@ -64,7 +65,7 @@ class AudioParser {
     }
 
     _isSupported(url) {
-        const ext = path.getExtension(url);
+        const ext = path.getExtension(url).toLowerCase();
 
         return supportedExtensions.indexOf(ext) > -1;
     }

--- a/src/framework/parsers/audio.js
+++ b/src/framework/parsers/audio.js
@@ -1,0 +1,73 @@
+import { path } from '../../core/path.js';
+import { Http } from '../../platform/net/http.js';
+import { Sound } from '../../platform/sound/sound.js';
+
+const supportedExtensions = [
+    '.ogg',
+    '.mp3',
+    '.wav',
+    '.mp4a',
+    '.m4a',
+    '.mp4',
+    '.aac',
+    '.opus'
+];
+
+/**
+ * Parser for audio resources. Fetches the audio data and decodes it into a {@link Sound} using
+ * the Web Audio context of the sound manager.
+ *
+ * @ignore
+ */
+class AudioParser {
+    canParse() {
+        // browser-decoded audio is the only built-in format family; it acts as the catch-all, so
+        // any audio asset resolves to it unless a more specific parser is registered
+        return true;
+    }
+
+    load(url, callback, asset) {
+        const original = typeof url === 'string' ? url : url.original;
+
+        const success = function (resource) {
+            callback(null, new Sound(resource));
+        };
+
+        const error = function (err) {
+            let msg = `Error loading audio url: ${original}`;
+            if (err) {
+                msg += `: ${err.message || err}`;
+            }
+            console.warn(msg);
+            callback(msg);
+        };
+
+        if (!this._isSupported(original)) {
+            error(`Audio format for ${original} not supported`);
+            return;
+        }
+
+        const manager = this.handler.manager;
+        if (!manager.context) {
+            error('Audio manager has no audio context');
+            return;
+        }
+
+        this.handler.fetch(url, Http.ResponseType.ARRAY_BUFFER, (err, response) => {
+            if (err) {
+                error(err);
+                return;
+            }
+
+            manager.context.decodeAudioData(response, success, error);
+        }, asset);
+    }
+
+    _isSupported(url) {
+        const ext = path.getExtension(url);
+
+        return supportedExtensions.indexOf(ext) > -1;
+    }
+}
+
+export { AudioParser };

--- a/test/framework/handlers/audio-handler.test.mjs
+++ b/test/framework/handlers/audio-handler.test.mjs
@@ -1,0 +1,98 @@
+import { expect } from 'chai';
+import { restore, stub } from 'sinon';
+
+import { AudioHandler } from '../../../src/framework/handlers/audio.js';
+import { http, Http } from '../../../src/platform/net/http.js';
+import { Sound } from '../../../src/platform/sound/sound.js';
+
+// a fake sound manager whose audio context "decodes" any fetched data into this buffer
+const fakeAudioBuffer = { duration: 1 };
+
+function createHandler() {
+    const manager = {
+        context: {
+            decodeAudioData: (data, success) => success(fakeAudioBuffer)
+        }
+    };
+    return new AudioHandler({ soundManager: manager });
+}
+
+describe('AudioHandler', function () {
+
+    afterEach(function () {
+        restore();
+    });
+
+    it('loads a supported format and wraps the decoded buffer in a Sound', function () {
+        const handler = createHandler();
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback(null, new ArrayBuffer(8));
+        });
+
+        let result;
+        handler.load({ load: 'x.mp3', original: 'x.mp3' }, (err, res) => {
+            expect(err).to.equal(null);
+            result = res;
+        });
+        expect(result).to.be.an.instanceof(Sound);
+        expect(result.buffer).to.equal(fakeAudioBuffer);
+    });
+
+    it('rejects an unsupported format without fetching, with the exact error message', function () {
+        const handler = createHandler();
+        const warnStub = stub(console, 'warn');
+        const getStub = stub(http, 'get');
+
+        let err;
+        handler.load({ load: 'x.xyz', original: 'x.xyz' }, (e) => {
+            err = e;
+        });
+        expect(err).to.equal('Error loading audio url: x.xyz: Audio format for x.xyz not supported');
+        expect(getStub.called).to.be.false;
+        expect(warnStub.called).to.be.true;
+    });
+
+    it('requests an ArrayBuffer for blob urls', function () {
+        const handler = createHandler();
+        let requestOptions;
+        stub(http, 'get').callsFake((url, options, callback) => {
+            requestOptions = options;
+            callback(null, new ArrayBuffer(8));
+        });
+
+        handler.load({ load: 'blob:1234', original: 'x.mp3' }, () => { });
+        expect(requestOptions.responseType).to.equal(Http.ResponseType.ARRAY_BUFFER);
+    });
+
+    it('reports an error when the sound manager has no audio context', function () {
+        const manager = {};
+        const handler = new AudioHandler({ soundManager: manager });
+        stub(console, 'warn');
+
+        let err;
+        handler.load({ load: 'x.mp3', original: 'x.mp3' }, (e) => {
+            err = e;
+        });
+        expect(err).to.equal('Error loading audio url: x.mp3: Audio manager has no audio context');
+    });
+
+    it('reports decode failures including the url', function () {
+        const manager = {
+            context: {
+                decodeAudioData: (data, success, error) => error(new Error('decode boom'))
+            }
+        };
+        const handler = new AudioHandler({ soundManager: manager });
+        stub(console, 'warn');
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback(null, new ArrayBuffer(8));
+        });
+
+        let err;
+        handler.load({ load: 'x.mp3', original: 'x.mp3' }, (e) => {
+            err = e;
+        });
+        expect(err).to.include('Error loading audio url: x.mp3');
+        expect(err).to.include('decode boom');
+    });
+});

--- a/test/framework/handlers/audio-handler.test.mjs
+++ b/test/framework/handlers/audio-handler.test.mjs
@@ -52,6 +52,20 @@ describe('AudioHandler', function () {
         expect(warnStub.called).to.be.true;
     });
 
+    it('accepts supported formats regardless of extension case', function () {
+        const handler = createHandler();
+        stub(http, 'get').callsFake((url, options, callback) => {
+            callback(null, new ArrayBuffer(8));
+        });
+
+        let result;
+        handler.load({ load: 'SOUND.MP3', original: 'SOUND.MP3' }, (err, res) => {
+            expect(err).to.equal(null);
+            result = res;
+        });
+        expect(result).to.be.an.instanceof(Sound);
+    });
+
     it('requests an ArrayBuffer for blob urls', function () {
         const handler = createHandler();
         let requestOptions;
@@ -68,6 +82,18 @@ describe('AudioHandler', function () {
         const manager = {};
         const handler = new AudioHandler({ soundManager: manager });
         stub(console, 'warn');
+
+        let err;
+        handler.load({ load: 'x.mp3', original: 'x.mp3' }, (e) => {
+            err = e;
+        });
+        expect(err).to.equal('Error loading audio url: x.mp3: Audio manager has no audio context');
+    });
+
+    it('reports an error instead of throwing when there is no sound manager', function () {
+        stub(console, 'error'); // the debug-build assert in the handler constructor
+        stub(console, 'warn');
+        const handler = new AudioHandler({});
 
         let err;
         handler.load({ load: 'x.mp3', original: 'x.mp3' }, (e) => {


### PR DESCRIPTION
Follow-up to #9001 / #9004 / #9005 — converts the audio handler to the parser registry, completing the pluggability story for every format-bearing handler. Custom audio formats were previously impossible: the handler hard-rejected unknown extensions before fetching, with no override point.

**Changes:**
- New internal `AudioParser` (catch-all): the supported-extension check, error messages (including the `console.warn`), the sound-manager context guard and the `decodeAudioData` → `Sound` wrapping move in verbatim; the sound manager is reached via `this.handler.manager`
- `AudioHandler` reduces to its constructor registering the parser
- Fetching goes through `ResourceHandler#fetch` and always requests an ArrayBuffer — previously forced only for `blob:`/`data:` urls with extension auto-detection otherwise (equivalent for all supported extensions), and the `asset.file.contents` bundle fast path now applies
- The dead `if (this._createSound)` / `error(null)` branch is removed — the method was unconditionally defined, a leftover from the removed Audio-element code path
- Characterization tests written against the pre-conversion behavior pass unchanged: `Sound` wrapping, the exact unsupported-format error (and that no fetch occurs), the blob ArrayBuffer request, missing-context and decode-failure errors

**API Changes:**
- None — the parser is internal (`@ignore`); the handler only loses its `load` override in favor of the documented base signature

```js
// register a custom audio format (e.g. a wasm-decoded tracker module)
class ModParser {
    canParse(context) { return context.ext === 'mod'; }
    load(url, callback, asset) {
        this.handler.fetch(url, pc.Http.ResponseType.ARRAY_BUFFER, (err, data) => {
            if (err) return callback(err);
            const audioBuffer = decodeModToAudioBuffer(data, this.handler.manager.context);
            callback(null, new pc.Sound(audioBuffer));
        }, asset);
    }
}
app.loader.getHandler('audio').addParser(new ModParser());
```
