### PR TITLE
Extract glTF material extensions from glb parser into separate files

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -3,7 +3,6 @@ import { path } from '../../core/path.js';
 import { Color } from '../../core/math/color.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { math } from '../../core/math/math.js';
-import { Vec2 } from '../../core/math/vec2.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
 
@@ -49,6 +48,8 @@ import { Asset } from '../asset/asset.js';
 import { ABSOLUTE_URL } from '../asset/constants.js';
 
 import { dracoDecode } from './draco-decoder.js';
+import { glbMaterialExtensions } from './glb/extensions/index.js';
+import { extractTextureTransform } from './glb/extensions/khr-texture-transform.js';
 import { Quat } from '../../core/math/quat.js';
 
 // resources loaded from GLB file that the parser returns
@@ -848,297 +849,6 @@ const createMesh = (device, gltfMesh, accessors, bufferViews, vertexBufferDict, 
     return meshes;
 };
 
-const extractTextureTransform = (source, material, maps) => {
-    let map;
-
-    const texCoord = source.texCoord;
-    if (texCoord) {
-        for (map = 0; map < maps.length; ++map) {
-            material[`${maps[map]}MapUv`] = texCoord;
-        }
-    }
-
-    const zeros = [0, 0];
-    const ones = [1, 1];
-    const textureTransform = source.extensions?.KHR_texture_transform;
-    if (textureTransform) {
-        const offset = textureTransform.offset || zeros;
-        const scale = textureTransform.scale || ones;
-        const rotation = textureTransform.rotation ? (-textureTransform.rotation * math.RAD_TO_DEG) : 0;
-
-        const tilingVec = new Vec2(scale[0], scale[1]);
-        const offsetVec = new Vec2(offset[0], 1.0 - scale[1] - offset[1]);
-
-        for (map = 0; map < maps.length; ++map) {
-            material[`${maps[map]}MapTiling`] = tilingVec;
-            material[`${maps[map]}MapOffset`] = offsetVec;
-            material[`${maps[map]}MapRotation`] = rotation;
-        }
-    }
-};
-
-const extensionPbrSpecGlossiness = (data, material, textures) => {
-    let texture;
-    if (data.hasOwnProperty('diffuseFactor')) {
-        const [r, g, b, a] = data.diffuseFactor;
-        material.diffuse.set(r, g, b).gamma();
-        material.opacity = a;
-    } else {
-        material.diffuse.set(1, 1, 1);
-        material.opacity = 1;
-    }
-    if (data.hasOwnProperty('diffuseTexture')) {
-        const diffuseTexture = data.diffuseTexture;
-        texture = textures[diffuseTexture.index];
-
-        material.diffuseMap = texture;
-        material.diffuseMapChannel = 'rgb';
-        material.opacityMap = texture;
-        material.opacityMapChannel = 'a';
-
-        extractTextureTransform(diffuseTexture, material, ['diffuse', 'opacity']);
-    }
-    material.useMetalness = false;
-    if (data.hasOwnProperty('specularFactor')) {
-        const [r, g, b] = data.specularFactor;
-        material.specular.set(r, g, b).gamma();
-    } else {
-        material.specular.set(1, 1, 1);
-    }
-    if (data.hasOwnProperty('glossinessFactor')) {
-        material.gloss = data.glossinessFactor;
-    } else {
-        material.gloss = 1.0;
-    }
-    if (data.hasOwnProperty('specularGlossinessTexture')) {
-        const specularGlossinessTexture = data.specularGlossinessTexture;
-        material.specularMap = material.glossMap = textures[specularGlossinessTexture.index];
-        material.specularMapChannel = 'rgb';
-        material.glossMapChannel = 'a';
-
-        extractTextureTransform(specularGlossinessTexture, material, ['gloss', 'metalness']);
-    }
-};
-
-const extensionClearCoat = (data, material, textures) => {
-    if (data.hasOwnProperty('clearcoatFactor')) {
-        material.clearCoat = data.clearcoatFactor * 0.25; // TODO: remove temporary workaround for replicating glTF clear-coat visuals
-    } else {
-        material.clearCoat = 0;
-    }
-    if (data.hasOwnProperty('clearcoatTexture')) {
-        const clearcoatTexture = data.clearcoatTexture;
-        material.clearCoatMap = textures[clearcoatTexture.index];
-        material.clearCoatMapChannel = 'r';
-
-        extractTextureTransform(clearcoatTexture, material, ['clearCoat']);
-    }
-    if (data.hasOwnProperty('clearcoatRoughnessFactor')) {
-        material.clearCoatGloss = data.clearcoatRoughnessFactor;
-    } else {
-        material.clearCoatGloss = 0;
-    }
-    if (data.hasOwnProperty('clearcoatRoughnessTexture')) {
-        const clearcoatRoughnessTexture = data.clearcoatRoughnessTexture;
-        material.clearCoatGlossMap = textures[clearcoatRoughnessTexture.index];
-        material.clearCoatGlossMapChannel = 'g';
-
-        extractTextureTransform(clearcoatRoughnessTexture, material, ['clearCoatGloss']);
-    }
-    if (data.hasOwnProperty('clearcoatNormalTexture')) {
-        const clearcoatNormalTexture = data.clearcoatNormalTexture;
-        material.clearCoatNormalMap = textures[clearcoatNormalTexture.index];
-
-        extractTextureTransform(clearcoatNormalTexture, material, ['clearCoatNormal']);
-
-        if (clearcoatNormalTexture.hasOwnProperty('scale')) {
-            material.clearCoatBumpiness = clearcoatNormalTexture.scale;
-        } else {
-            material.clearCoatBumpiness = 1;
-        }
-    }
-
-    material.clearCoatGlossInvert = true;
-};
-
-const extensionUnlit = (data, material, textures) => {
-    material.useLighting = false;
-
-    // copy diffuse into emissive
-    material.emissive.copy(material.diffuse);
-    material.emissiveMap = material.diffuseMap;
-    material.emissiveMapUv = material.diffuseMapUv;
-    material.emissiveMapTiling.copy(material.diffuseMapTiling);
-    material.emissiveMapOffset.copy(material.diffuseMapOffset);
-    material.emissiveMapRotation = material.diffuseMapRotation;
-    material.emissiveMapChannel = material.diffuseMapChannel;
-    material.emissiveVertexColor = material.diffuseVertexColor;
-    material.emissiveVertexColorChannel = material.diffuseVertexColorChannel;
-
-    // disable lighting and skybox
-    material.useLighting = false;
-    material.useSkybox = false;
-
-    // blank diffuse
-    material.diffuse.set(1, 1, 1);
-    material.diffuseMap = null;
-    material.diffuseVertexColor = false;
-};
-
-const extensionSpecular = (data, material, textures) => {
-    material.useMetalnessSpecularColor = true;
-
-    if (data.hasOwnProperty('specularColorTexture')) {
-        material.specularMap = textures[data.specularColorTexture.index];
-        material.specularMapChannel = 'rgb';
-        extractTextureTransform(data.specularColorTexture, material, ['specular']);
-    }
-
-    if (data.hasOwnProperty('specularColorFactor')) {
-        const [r, g, b] = data.specularColorFactor;
-        material.specular.set(r, g, b).gamma();
-    } else {
-        material.specular.set(1, 1, 1);
-    }
-
-    if (data.hasOwnProperty('specularFactor')) {
-        material.specularityFactor = data.specularFactor;
-    } else {
-        material.specularityFactor = 1;
-    }
-
-    if (data.hasOwnProperty('specularTexture')) {
-        material.specularityFactorMapChannel = 'a';
-        material.specularityFactorMap = textures[data.specularTexture.index];
-        extractTextureTransform(data.specularTexture, material, ['specularityFactor']);
-    }
-};
-
-const extensionIor = (data, material, textures) => {
-    if (data.hasOwnProperty('ior')) {
-        material.refractionIndex = 1.0 / data.ior;
-    }
-};
-
-const extensionDispersion = (data, material, textures) => {
-    if (data.hasOwnProperty('dispersion')) {
-        material.dispersion = data.dispersion;
-    }
-};
-
-const extensionTransmission = (data, material, textures) => {
-    material.blendType = BLEND_NORMAL;
-    material.useDynamicRefraction = true;
-
-    if (data.hasOwnProperty('transmissionFactor')) {
-        material.refraction = data.transmissionFactor;
-    }
-    if (data.hasOwnProperty('transmissionTexture')) {
-        material.refractionMapChannel = 'r';
-        material.refractionMap = textures[data.transmissionTexture.index];
-        extractTextureTransform(data.transmissionTexture, material, ['refraction']);
-    }
-};
-
-const extensionSheen = (data, material, textures) => {
-    material.useSheen = true;
-    if (data.hasOwnProperty('sheenColorFactor')) {
-        const [r, g, b] = data.sheenColorFactor;
-        material.sheen.set(r, g, b).gamma();
-    } else {
-        material.sheen.set(1, 1, 1);
-    }
-    if (data.hasOwnProperty('sheenColorTexture')) {
-        material.sheenMap = textures[data.sheenColorTexture.index];
-        extractTextureTransform(data.sheenColorTexture, material, ['sheen']);
-    }
-
-    material.sheenGloss = data.hasOwnProperty('sheenRoughnessFactor') ? data.sheenRoughnessFactor : 0.0;
-
-    if (data.hasOwnProperty('sheenRoughnessTexture')) {
-        material.sheenGlossMap = textures[data.sheenRoughnessTexture.index];
-        material.sheenGlossMapChannel = 'a';
-        extractTextureTransform(data.sheenRoughnessTexture, material, ['sheenGloss']);
-    }
-
-    material.sheenGlossInvert = true;
-};
-
-const extensionVolume = (data, material, textures) => {
-    material.blendType = BLEND_NORMAL;
-    material.useDynamicRefraction = true;
-    if (data.hasOwnProperty('thicknessFactor')) {
-        material.thickness = data.thicknessFactor;
-    }
-    if (data.hasOwnProperty('thicknessTexture')) {
-        material.thicknessMap = textures[data.thicknessTexture.index];
-        material.thicknessMapChannel = 'g';
-        extractTextureTransform(data.thicknessTexture, material, ['thickness']);
-    }
-    if (data.hasOwnProperty('attenuationDistance')) {
-        material.attenuationDistance = data.attenuationDistance;
-    }
-    if (data.hasOwnProperty('attenuationColor')) {
-        const [r, g, b] = data.attenuationColor;
-        material.attenuation.set(r, g, b).gamma();
-    }
-};
-
-const extensionEmissiveStrength = (data, material, textures) => {
-    if (data.hasOwnProperty('emissiveStrength')) {
-        material.emissiveIntensity = data.emissiveStrength;
-    }
-};
-
-const extensionIridescence = (data, material, textures) => {
-    material.useIridescence = true;
-    if (data.hasOwnProperty('iridescenceFactor')) {
-        material.iridescence = data.iridescenceFactor;
-    }
-    if (data.hasOwnProperty('iridescenceTexture')) {
-        material.iridescenceMapChannel = 'r';
-        material.iridescenceMap = textures[data.iridescenceTexture.index];
-        extractTextureTransform(data.iridescenceTexture, material, ['iridescence']);
-
-    }
-    if (data.hasOwnProperty('iridescenceIor')) {
-        material.iridescenceRefractionIndex = data.iridescenceIor;
-    }
-    if (data.hasOwnProperty('iridescenceThicknessMinimum')) {
-        material.iridescenceThicknessMin = data.iridescenceThicknessMinimum;
-    }
-    if (data.hasOwnProperty('iridescenceThicknessMaximum')) {
-        material.iridescenceThicknessMax = data.iridescenceThicknessMaximum;
-    }
-    if (data.hasOwnProperty('iridescenceThicknessTexture')) {
-        material.iridescenceThicknessMapChannel = 'g';
-        material.iridescenceThicknessMap = textures[data.iridescenceThicknessTexture.index];
-        extractTextureTransform(data.iridescenceThicknessTexture, material, ['iridescenceThickness']);
-    }
-};
-
-const extensionAnisotropy = (data, material, textures) => {
-
-    material.enableGGXSpecular = true;
-
-    if (data.hasOwnProperty('anisotropyStrength')) {
-        material.anisotropyIntensity = data.anisotropyStrength;
-    } else {
-        material.anisotropyIntensity = 0;
-    }
-    if (data.hasOwnProperty('anisotropyTexture')) {
-        const anisotropyTexture = data.anisotropyTexture;
-        material.anisotropyMap = textures[anisotropyTexture.index];
-
-        extractTextureTransform(anisotropyTexture, material, ['anisotropy']);
-    }
-    if (data.hasOwnProperty('anisotropyRotation')) {
-        material.anisotropyRotation = data.anisotropyRotation * math.RAD_TO_DEG;
-    } else {
-        material.anisotropyRotation = 0;
-    }
-};
-
 const createMaterial = (gltfMaterial, textures) => {
     const material = new StandardMaterial();
 
@@ -1260,28 +970,12 @@ const createMaterial = (gltfMaterial, textures) => {
         material.cull = CULLFACE_BACK;
     }
 
-    // Provide list of supported extensions and their functions
-    const extensions = {
-        'KHR_materials_clearcoat': extensionClearCoat,
-        'KHR_materials_emissive_strength': extensionEmissiveStrength,
-        'KHR_materials_ior': extensionIor,
-        'KHR_materials_dispersion': extensionDispersion,
-        'KHR_materials_iridescence': extensionIridescence,
-        'KHR_materials_pbrSpecularGlossiness': extensionPbrSpecGlossiness,
-        'KHR_materials_sheen': extensionSheen,
-        'KHR_materials_specular': extensionSpecular,
-        'KHR_materials_transmission': extensionTransmission,
-        'KHR_materials_unlit': extensionUnlit,
-        'KHR_materials_volume': extensionVolume,
-        'KHR_materials_anisotropy': extensionAnisotropy
-    };
-
     // Handle extensions
     if (gltfMaterial.hasOwnProperty('extensions')) {
         for (const key in gltfMaterial.extensions) {
-            const extensionFunc = extensions[key];
-            if (extensionFunc !== undefined) {
-                extensionFunc(gltfMaterial.extensions[key], material, textures);
+            const extension = glbMaterialExtensions[key];
+            if (extension !== undefined) {
+                extension.apply(gltfMaterial.extensions[key], material, textures);
             }
         }
     }
@@ -2121,32 +1815,16 @@ const createImages = (gltf, bufferViews, urlBase, registry, options) => {
                     set.add(getTextureSource(gltfTexture));
                 }
 
+                // color textures used by material extensions
                 if (gltfMaterial.hasOwnProperty('extensions')) {
-
-                    // sheen
-                    const sheen = gltfMaterial.extensions.KHR_materials_sheen;
-                    if (sheen) {
-                        if (sheen.hasOwnProperty('sheenColorTexture')) {
-                            const gltfTexture = gltf.textures[sheen.sheenColorTexture.index];
-                            set.add(getTextureSource(gltfTexture));
-                        }
-                    }
-
-                    // specular glossiness
-                    const specularGlossiness = gltfMaterial.extensions.KHR_materials_pbrSpecularGlossiness;
-                    if (specularGlossiness) {
-                        if (specularGlossiness.hasOwnProperty('specularGlossinessTexture')) {
-                            const gltfTexture = gltf.textures[specularGlossiness.specularGlossinessTexture.index];
-                            set.add(getTextureSource(gltfTexture));
-                        }
-                    }
-
-                    // specular
-                    const specular = gltfMaterial.extensions.KHR_materials_specular;
-                    if (specular) {
-                        if (specular.hasOwnProperty('specularColorTexture')) {
-                            const gltfTexture = gltf.textures[specular.specularColorTexture.index];
-                            set.add(getTextureSource(gltfTexture));
+                    for (const key in gltfMaterial.extensions) {
+                        const extension = glbMaterialExtensions[key];
+                        if (extension?.getColorTextures) {
+                            const textureInfos = extension.getColorTextures(gltfMaterial.extensions[key]);
+                            for (const textureInfo of textureInfos) {
+                                const gltfTexture = gltf.textures[textureInfo.index];
+                                set.add(getTextureSource(gltfTexture));
+                            }
                         }
                     }
                 }

--- a/src/framework/parsers/glb/extensions/index.js
+++ b/src/framework/parsers/glb/extensions/index.js
@@ -1,0 +1,42 @@
+import { KHR_materials_anisotropy } from './khr-materials-anisotropy.js';
+import { KHR_materials_clearcoat } from './khr-materials-clearcoat.js';
+import { KHR_materials_dispersion } from './khr-materials-dispersion.js';
+import { KHR_materials_emissive_strength } from './khr-materials-emissive-strength.js';
+import { KHR_materials_ior } from './khr-materials-ior.js';
+import { KHR_materials_iridescence } from './khr-materials-iridescence.js';
+import { KHR_materials_pbrSpecularGlossiness } from './khr-materials-pbr-specular-glossiness.js';
+import { KHR_materials_sheen } from './khr-materials-sheen.js';
+import { KHR_materials_specular } from './khr-materials-specular.js';
+import { KHR_materials_transmission } from './khr-materials-transmission.js';
+import { KHR_materials_unlit } from './khr-materials-unlit.js';
+import { KHR_materials_volume } from './khr-materials-volume.js';
+
+/**
+ * Registry of the supported glTF material extensions, keyed by the extension name. Each entry
+ * provides:
+ *
+ * - `apply(data, material, textures)` - applies the extension data to the standard material.
+ * - `getColorTextures(data)` - optional, returns the texture infos of the extension's textures
+ * that contain color data and so need to be loaded as sRGB.
+ *
+ * Note that handlers are applied in the order the extensions appear in the material's JSON, so
+ * the result of overlapping extensions can depend on their order in the source asset.
+ *
+ * @ignore
+ */
+const glbMaterialExtensions = {
+    KHR_materials_anisotropy,
+    KHR_materials_clearcoat,
+    KHR_materials_dispersion,
+    KHR_materials_emissive_strength,
+    KHR_materials_ior,
+    KHR_materials_iridescence,
+    KHR_materials_pbrSpecularGlossiness,
+    KHR_materials_sheen,
+    KHR_materials_specular,
+    KHR_materials_transmission,
+    KHR_materials_unlit,
+    KHR_materials_volume
+};
+
+export { glbMaterialExtensions };

--- a/src/framework/parsers/glb/extensions/khr-materials-anisotropy.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-anisotropy.js
@@ -1,0 +1,28 @@
+import { math } from '../../../../core/math/math.js';
+import { extractTextureTransform } from './khr-texture-transform.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_anisotropy
+const KHR_materials_anisotropy = {
+    apply(data, material, textures) {
+        material.enableGGXSpecular = true;
+
+        if (data.hasOwnProperty('anisotropyStrength')) {
+            material.anisotropyIntensity = data.anisotropyStrength;
+        } else {
+            material.anisotropyIntensity = 0;
+        }
+        if (data.hasOwnProperty('anisotropyTexture')) {
+            const anisotropyTexture = data.anisotropyTexture;
+            material.anisotropyMap = textures[anisotropyTexture.index];
+
+            extractTextureTransform(anisotropyTexture, material, ['anisotropy']);
+        }
+        if (data.hasOwnProperty('anisotropyRotation')) {
+            material.anisotropyRotation = data.anisotropyRotation * math.RAD_TO_DEG;
+        } else {
+            material.anisotropyRotation = 0;
+        }
+    }
+};
+
+export { KHR_materials_anisotropy };

--- a/src/framework/parsers/glb/extensions/khr-materials-clearcoat.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-clearcoat.js
@@ -1,0 +1,47 @@
+import { extractTextureTransform } from './khr-texture-transform.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_clearcoat
+const KHR_materials_clearcoat = {
+    apply(data, material, textures) {
+        if (data.hasOwnProperty('clearcoatFactor')) {
+            material.clearCoat = data.clearcoatFactor * 0.25; // TODO: remove temporary workaround for replicating glTF clear-coat visuals
+        } else {
+            material.clearCoat = 0;
+        }
+        if (data.hasOwnProperty('clearcoatTexture')) {
+            const clearcoatTexture = data.clearcoatTexture;
+            material.clearCoatMap = textures[clearcoatTexture.index];
+            material.clearCoatMapChannel = 'r';
+
+            extractTextureTransform(clearcoatTexture, material, ['clearCoat']);
+        }
+        if (data.hasOwnProperty('clearcoatRoughnessFactor')) {
+            material.clearCoatGloss = data.clearcoatRoughnessFactor;
+        } else {
+            material.clearCoatGloss = 0;
+        }
+        if (data.hasOwnProperty('clearcoatRoughnessTexture')) {
+            const clearcoatRoughnessTexture = data.clearcoatRoughnessTexture;
+            material.clearCoatGlossMap = textures[clearcoatRoughnessTexture.index];
+            material.clearCoatGlossMapChannel = 'g';
+
+            extractTextureTransform(clearcoatRoughnessTexture, material, ['clearCoatGloss']);
+        }
+        if (data.hasOwnProperty('clearcoatNormalTexture')) {
+            const clearcoatNormalTexture = data.clearcoatNormalTexture;
+            material.clearCoatNormalMap = textures[clearcoatNormalTexture.index];
+
+            extractTextureTransform(clearcoatNormalTexture, material, ['clearCoatNormal']);
+
+            if (clearcoatNormalTexture.hasOwnProperty('scale')) {
+                material.clearCoatBumpiness = clearcoatNormalTexture.scale;
+            } else {
+                material.clearCoatBumpiness = 1;
+            }
+        }
+
+        material.clearCoatGlossInvert = true;
+    }
+};
+
+export { KHR_materials_clearcoat };

--- a/src/framework/parsers/glb/extensions/khr-materials-dispersion.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-dispersion.js
@@ -1,0 +1,10 @@
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_dispersion
+const KHR_materials_dispersion = {
+    apply(data, material, textures) {
+        if (data.hasOwnProperty('dispersion')) {
+            material.dispersion = data.dispersion;
+        }
+    }
+};
+
+export { KHR_materials_dispersion };

--- a/src/framework/parsers/glb/extensions/khr-materials-emissive-strength.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-emissive-strength.js
@@ -1,0 +1,10 @@
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_emissive_strength
+const KHR_materials_emissive_strength = {
+    apply(data, material, textures) {
+        if (data.hasOwnProperty('emissiveStrength')) {
+            material.emissiveIntensity = data.emissiveStrength;
+        }
+    }
+};
+
+export { KHR_materials_emissive_strength };

--- a/src/framework/parsers/glb/extensions/khr-materials-ior.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-ior.js
@@ -1,0 +1,10 @@
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_ior
+const KHR_materials_ior = {
+    apply(data, material, textures) {
+        if (data.hasOwnProperty('ior')) {
+            material.refractionIndex = 1.0 / data.ior;
+        }
+    }
+};
+
+export { KHR_materials_ior };

--- a/src/framework/parsers/glb/extensions/khr-materials-iridescence.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-iridescence.js
@@ -1,0 +1,33 @@
+import { extractTextureTransform } from './khr-texture-transform.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_iridescence
+const KHR_materials_iridescence = {
+    apply(data, material, textures) {
+        material.useIridescence = true;
+        if (data.hasOwnProperty('iridescenceFactor')) {
+            material.iridescence = data.iridescenceFactor;
+        }
+        if (data.hasOwnProperty('iridescenceTexture')) {
+            material.iridescenceMapChannel = 'r';
+            material.iridescenceMap = textures[data.iridescenceTexture.index];
+            extractTextureTransform(data.iridescenceTexture, material, ['iridescence']);
+
+        }
+        if (data.hasOwnProperty('iridescenceIor')) {
+            material.iridescenceRefractionIndex = data.iridescenceIor;
+        }
+        if (data.hasOwnProperty('iridescenceThicknessMinimum')) {
+            material.iridescenceThicknessMin = data.iridescenceThicknessMinimum;
+        }
+        if (data.hasOwnProperty('iridescenceThicknessMaximum')) {
+            material.iridescenceThicknessMax = data.iridescenceThicknessMaximum;
+        }
+        if (data.hasOwnProperty('iridescenceThicknessTexture')) {
+            material.iridescenceThicknessMapChannel = 'g';
+            material.iridescenceThicknessMap = textures[data.iridescenceThicknessTexture.index];
+            extractTextureTransform(data.iridescenceThicknessTexture, material, ['iridescenceThickness']);
+        }
+    }
+};
+
+export { KHR_materials_iridescence };

--- a/src/framework/parsers/glb/extensions/khr-materials-pbr-specular-glossiness.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-pbr-specular-glossiness.js
@@ -1,0 +1,53 @@
+import { extractTextureTransform } from './khr-texture-transform.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness
+const KHR_materials_pbrSpecularGlossiness = {
+    apply(data, material, textures) {
+        let texture;
+        if (data.hasOwnProperty('diffuseFactor')) {
+            const [r, g, b, a] = data.diffuseFactor;
+            material.diffuse.set(r, g, b).gamma();
+            material.opacity = a;
+        } else {
+            material.diffuse.set(1, 1, 1);
+            material.opacity = 1;
+        }
+        if (data.hasOwnProperty('diffuseTexture')) {
+            const diffuseTexture = data.diffuseTexture;
+            texture = textures[diffuseTexture.index];
+
+            material.diffuseMap = texture;
+            material.diffuseMapChannel = 'rgb';
+            material.opacityMap = texture;
+            material.opacityMapChannel = 'a';
+
+            extractTextureTransform(diffuseTexture, material, ['diffuse', 'opacity']);
+        }
+        material.useMetalness = false;
+        if (data.hasOwnProperty('specularFactor')) {
+            const [r, g, b] = data.specularFactor;
+            material.specular.set(r, g, b).gamma();
+        } else {
+            material.specular.set(1, 1, 1);
+        }
+        if (data.hasOwnProperty('glossinessFactor')) {
+            material.gloss = data.glossinessFactor;
+        } else {
+            material.gloss = 1.0;
+        }
+        if (data.hasOwnProperty('specularGlossinessTexture')) {
+            const specularGlossinessTexture = data.specularGlossinessTexture;
+            material.specularMap = material.glossMap = textures[specularGlossinessTexture.index];
+            material.specularMapChannel = 'rgb';
+            material.glossMapChannel = 'a';
+
+            extractTextureTransform(specularGlossinessTexture, material, ['gloss', 'metalness']);
+        }
+    },
+
+    getColorTextures(data) {
+        return data.hasOwnProperty('specularGlossinessTexture') ? [data.specularGlossinessTexture] : [];
+    }
+};
+
+export { KHR_materials_pbrSpecularGlossiness };

--- a/src/framework/parsers/glb/extensions/khr-materials-sheen.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-sheen.js
@@ -1,0 +1,34 @@
+import { extractTextureTransform } from './khr-texture-transform.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_sheen
+const KHR_materials_sheen = {
+    apply(data, material, textures) {
+        material.useSheen = true;
+        if (data.hasOwnProperty('sheenColorFactor')) {
+            const [r, g, b] = data.sheenColorFactor;
+            material.sheen.set(r, g, b).gamma();
+        } else {
+            material.sheen.set(1, 1, 1);
+        }
+        if (data.hasOwnProperty('sheenColorTexture')) {
+            material.sheenMap = textures[data.sheenColorTexture.index];
+            extractTextureTransform(data.sheenColorTexture, material, ['sheen']);
+        }
+
+        material.sheenGloss = data.hasOwnProperty('sheenRoughnessFactor') ? data.sheenRoughnessFactor : 0.0;
+
+        if (data.hasOwnProperty('sheenRoughnessTexture')) {
+            material.sheenGlossMap = textures[data.sheenRoughnessTexture.index];
+            material.sheenGlossMapChannel = 'a';
+            extractTextureTransform(data.sheenRoughnessTexture, material, ['sheenGloss']);
+        }
+
+        material.sheenGlossInvert = true;
+    },
+
+    getColorTextures(data) {
+        return data.hasOwnProperty('sheenColorTexture') ? [data.sheenColorTexture] : [];
+    }
+};
+
+export { KHR_materials_sheen };

--- a/src/framework/parsers/glb/extensions/khr-materials-specular.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-specular.js
@@ -1,0 +1,39 @@
+import { extractTextureTransform } from './khr-texture-transform.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular
+const KHR_materials_specular = {
+    apply(data, material, textures) {
+        material.useMetalnessSpecularColor = true;
+
+        if (data.hasOwnProperty('specularColorTexture')) {
+            material.specularMap = textures[data.specularColorTexture.index];
+            material.specularMapChannel = 'rgb';
+            extractTextureTransform(data.specularColorTexture, material, ['specular']);
+        }
+
+        if (data.hasOwnProperty('specularColorFactor')) {
+            const [r, g, b] = data.specularColorFactor;
+            material.specular.set(r, g, b).gamma();
+        } else {
+            material.specular.set(1, 1, 1);
+        }
+
+        if (data.hasOwnProperty('specularFactor')) {
+            material.specularityFactor = data.specularFactor;
+        } else {
+            material.specularityFactor = 1;
+        }
+
+        if (data.hasOwnProperty('specularTexture')) {
+            material.specularityFactorMapChannel = 'a';
+            material.specularityFactorMap = textures[data.specularTexture.index];
+            extractTextureTransform(data.specularTexture, material, ['specularityFactor']);
+        }
+    },
+
+    getColorTextures(data) {
+        return data.hasOwnProperty('specularColorTexture') ? [data.specularColorTexture] : [];
+    }
+};
+
+export { KHR_materials_specular };

--- a/src/framework/parsers/glb/extensions/khr-materials-transmission.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-transmission.js
@@ -1,0 +1,21 @@
+import { BLEND_NORMAL } from '../../../../scene/constants.js';
+import { extractTextureTransform } from './khr-texture-transform.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_transmission
+const KHR_materials_transmission = {
+    apply(data, material, textures) {
+        material.blendType = BLEND_NORMAL;
+        material.useDynamicRefraction = true;
+
+        if (data.hasOwnProperty('transmissionFactor')) {
+            material.refraction = data.transmissionFactor;
+        }
+        if (data.hasOwnProperty('transmissionTexture')) {
+            material.refractionMapChannel = 'r';
+            material.refractionMap = textures[data.transmissionTexture.index];
+            extractTextureTransform(data.transmissionTexture, material, ['refraction']);
+        }
+    }
+};
+
+export { KHR_materials_transmission };

--- a/src/framework/parsers/glb/extensions/khr-materials-unlit.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-unlit.js
@@ -1,0 +1,28 @@
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_unlit
+const KHR_materials_unlit = {
+    apply(data, material, textures) {
+        material.useLighting = false;
+
+        // copy diffuse into emissive
+        material.emissive.copy(material.diffuse);
+        material.emissiveMap = material.diffuseMap;
+        material.emissiveMapUv = material.diffuseMapUv;
+        material.emissiveMapTiling.copy(material.diffuseMapTiling);
+        material.emissiveMapOffset.copy(material.diffuseMapOffset);
+        material.emissiveMapRotation = material.diffuseMapRotation;
+        material.emissiveMapChannel = material.diffuseMapChannel;
+        material.emissiveVertexColor = material.diffuseVertexColor;
+        material.emissiveVertexColorChannel = material.diffuseVertexColorChannel;
+
+        // disable lighting and skybox
+        material.useLighting = false;
+        material.useSkybox = false;
+
+        // blank diffuse
+        material.diffuse.set(1, 1, 1);
+        material.diffuseMap = null;
+        material.diffuseVertexColor = false;
+    }
+};
+
+export { KHR_materials_unlit };

--- a/src/framework/parsers/glb/extensions/khr-materials-volume.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-volume.js
@@ -1,0 +1,27 @@
+import { BLEND_NORMAL } from '../../../../scene/constants.js';
+import { extractTextureTransform } from './khr-texture-transform.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_volume
+const KHR_materials_volume = {
+    apply(data, material, textures) {
+        material.blendType = BLEND_NORMAL;
+        material.useDynamicRefraction = true;
+        if (data.hasOwnProperty('thicknessFactor')) {
+            material.thickness = data.thicknessFactor;
+        }
+        if (data.hasOwnProperty('thicknessTexture')) {
+            material.thicknessMap = textures[data.thicknessTexture.index];
+            material.thicknessMapChannel = 'g';
+            extractTextureTransform(data.thicknessTexture, material, ['thickness']);
+        }
+        if (data.hasOwnProperty('attenuationDistance')) {
+            material.attenuationDistance = data.attenuationDistance;
+        }
+        if (data.hasOwnProperty('attenuationColor')) {
+            const [r, g, b] = data.attenuationColor;
+            material.attenuation.set(r, g, b).gamma();
+        }
+    }
+};
+
+export { KHR_materials_volume };

--- a/src/framework/parsers/glb/extensions/khr-texture-transform.js
+++ b/src/framework/parsers/glb/extensions/khr-texture-transform.js
@@ -1,0 +1,36 @@
+import { math } from '../../../../core/math/math.js';
+import { Vec2 } from '../../../../core/math/vec2.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform
+// Applies the texCoord and KHR_texture_transform data from the supplied glTF texture info to the
+// given maps of the material.
+const extractTextureTransform = (source, material, maps) => {
+    let map;
+
+    const texCoord = source.texCoord;
+    if (texCoord) {
+        for (map = 0; map < maps.length; ++map) {
+            material[`${maps[map]}MapUv`] = texCoord;
+        }
+    }
+
+    const zeros = [0, 0];
+    const ones = [1, 1];
+    const textureTransform = source.extensions?.KHR_texture_transform;
+    if (textureTransform) {
+        const offset = textureTransform.offset || zeros;
+        const scale = textureTransform.scale || ones;
+        const rotation = textureTransform.rotation ? (-textureTransform.rotation * math.RAD_TO_DEG) : 0;
+
+        const tilingVec = new Vec2(scale[0], scale[1]);
+        const offsetVec = new Vec2(offset[0], 1.0 - scale[1] - offset[1]);
+
+        for (map = 0; map < maps.length; ++map) {
+            material[`${maps[map]}MapTiling`] = tilingVec;
+            material[`${maps[map]}MapOffset`] = offsetVec;
+            material[`${maps[map]}MapRotation`] = rotation;
+        }
+    }
+};
+
+export { extractTextureTransform };


### PR DESCRIPTION
First step of splitting up the large glb-parser.js (2600+ lines): the `KHR_materials_*` extension handling moves into per-extension files under a new `src/framework/parsers/glb/extensions/` folder, mirroring how other engines (e.g. Babylon.js) organize their glTF loaders. Pure refactor with no behavior change.

**Changes:**
- Each of the 12 `KHR_materials_*` extensions now lives in its own file, exporting an object named after the extension with an `apply(data, material, textures)` handler (bodies moved verbatim).
- `extractTextureTransform` (the `KHR_texture_transform` implementation) moved to `khr-texture-transform.js`; the parser still uses it for the base PBR texture slots.
- `extensions/index.js` assembles the `glbMaterialExtensions` name→handler registry via explicit imports (no side-effect registration, so tree-shaking behavior is unchanged), and documents that handlers apply in the order extensions appear in the material JSON.
- The sRGB texture detection pre-pass no longer hardcodes sheen / specular-glossiness / specular texture knowledge — extensions with color textures expose an optional `getColorTextures(data)` hook that the pre-pass iterates, keeping each extension's sRGB rules co-located with its handler.
- `glb-parser.js` shrinks by ~320 lines; follow-up PRs will extract the remaining node/scene-level extensions (lights, variants, instancing, texture source selection).