### PR TITLE
Extract remaining glTF extensions and accessor utilities from glb parser

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -1,10 +1,9 @@
 import { Debug } from '../../core/debug.js';
 import { path } from '../../core/path.js';
-import { Color } from '../../core/math/color.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { math } from '../../core/math/math.js';
+import { Quat } from '../../core/math/quat.js';
 import { Vec3 } from '../../core/math/vec3.js';
-import { BoundingBox } from '../../core/shape/bounding-box.js';
 
 import {
     typedArrayTypes, typedArrayTypesByteSize,
@@ -13,10 +12,9 @@ import {
     CULLFACE_NONE, CULLFACE_BACK,
     FILTER_NEAREST, FILTER_LINEAR, FILTER_NEAREST_MIPMAP_NEAREST, FILTER_LINEAR_MIPMAP_NEAREST, FILTER_NEAREST_MIPMAP_LINEAR, FILTER_LINEAR_MIPMAP_LINEAR,
     INDEXFORMAT_UINT8, INDEXFORMAT_UINT16, INDEXFORMAT_UINT32,
-    PRIMITIVE_LINELOOP, PRIMITIVE_LINESTRIP, PRIMITIVE_LINES, PRIMITIVE_POINTS, PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP,
     SEMANTIC_POSITION, SEMANTIC_NORMAL, SEMANTIC_TANGENT, SEMANTIC_COLOR, SEMANTIC_BLENDINDICES, SEMANTIC_BLENDWEIGHT,
     SEMANTIC_TEXCOORD0, SEMANTIC_TEXCOORD1, SEMANTIC_TEXCOORD2, SEMANTIC_TEXCOORD3, SEMANTIC_TEXCOORD4, SEMANTIC_TEXCOORD5, SEMANTIC_TEXCOORD6, SEMANTIC_TEXCOORD7,
-    TYPE_INT8, TYPE_UINT8, TYPE_INT16, TYPE_UINT16, TYPE_INT32, TYPE_UINT32, TYPE_FLOAT32
+    TYPE_FLOAT32
 } from '../../platform/graphics/constants.js';
 import { IndexBuffer } from '../../platform/graphics/index-buffer.js';
 import { Texture } from '../../platform/graphics/texture.js';
@@ -25,12 +23,11 @@ import { VertexFormat } from '../../platform/graphics/vertex-format.js';
 import { http } from '../../platform/net/http.js';
 
 import {
-    BLEND_NONE, BLEND_NORMAL, LIGHTFALLOFF_INVERSESQUARED,
+    BLEND_NONE, BLEND_NORMAL,
     PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE,
     ASPECT_MANUAL, ASPECT_AUTO, SPECOCC_AO
 } from '../../scene/constants.js';
 import { GraphNode } from '../../scene/graph-node.js';
-import { Light, lightTypes } from '../../scene/light.js';
 import { Mesh } from '../../scene/mesh.js';
 import { Morph } from '../../scene/morph.js';
 import { MorphTarget } from '../../scene/morph-target.js';
@@ -47,10 +44,14 @@ import { AnimTrack } from '../anim/evaluator/anim-track.js';
 import { Asset } from '../asset/asset.js';
 import { ABSOLUTE_URL } from '../asset/constants.js';
 
-import { dracoDecode } from './draco-decoder.js';
+import { createInstancing } from './glb/extensions/ext-mesh-gpu-instancing.js';
+import { createDracoMesh } from './glb/extensions/khr-draco-mesh-compression.js';
+import { createLights } from './glb/extensions/khr-lights-punctual.js';
+import { createVariants, registerMeshVariants } from './glb/extensions/khr-materials-variants.js';
+import { getTextureSource } from './glb/extensions/texture-source.js';
 import { glbMaterialExtensions } from './glb/extensions/index.js';
 import { extractTextureTransform } from './glb/extensions/khr-texture-transform.js';
-import { Quat } from '../../core/math/quat.js';
+import { GltfAccessor, getPrimitiveType, gltfToEngineSemanticMap } from './glb/gltf-accessor.js';
 
 // resources loaded from GLB file that the parser returns
 class GlbResources {
@@ -100,75 +101,6 @@ const getDataURIMimeType = (uri) => {
     return uri.substring(uri.indexOf(':') + 1, uri.indexOf(';'));
 };
 
-const getNumComponents = (accessorType) => {
-    switch (accessorType) {
-        case 'SCALAR': return 1;
-        case 'VEC2': return 2;
-        case 'VEC3': return 3;
-        case 'VEC4': return 4;
-        case 'MAT2': return 4;
-        case 'MAT3': return 9;
-        case 'MAT4': return 16;
-        default: return 3;
-    }
-};
-
-const getComponentType = (componentType) => {
-    switch (componentType) {
-        case 5120: return TYPE_INT8;
-        case 5121: return TYPE_UINT8;
-        case 5122: return TYPE_INT16;
-        case 5123: return TYPE_UINT16;
-        case 5124: return TYPE_INT32;
-        case 5125: return TYPE_UINT32;
-        case 5126: return TYPE_FLOAT32;
-        default: return 0;
-    }
-};
-
-const getComponentSizeInBytes = (componentType) => {
-    switch (componentType) {
-        case 5120: return 1;    // int8
-        case 5121: return 1;    // uint8
-        case 5122: return 2;    // int16
-        case 5123: return 2;    // uint16
-        case 5124: return 4;    // int32
-        case 5125: return 4;    // uint32
-        case 5126: return 4;    // float32
-        default: return 0;
-    }
-};
-
-const getComponentDataType = (componentType) => {
-    switch (componentType) {
-        case 5120: return Int8Array;
-        case 5121: return Uint8Array;
-        case 5122: return Int16Array;
-        case 5123: return Uint16Array;
-        case 5124: return Int32Array;
-        case 5125: return Uint32Array;
-        case 5126: return Float32Array;
-        default: return null;
-    }
-};
-
-const gltfToEngineSemanticMap = {
-    'POSITION': SEMANTIC_POSITION,
-    'NORMAL': SEMANTIC_NORMAL,
-    'TANGENT': SEMANTIC_TANGENT,
-    'COLOR_0': SEMANTIC_COLOR,
-    'JOINTS_0': SEMANTIC_BLENDINDICES,
-    'WEIGHTS_0': SEMANTIC_BLENDWEIGHT,
-    'TEXCOORD_0': SEMANTIC_TEXCOORD0,
-    'TEXCOORD_1': SEMANTIC_TEXCOORD1,
-    'TEXCOORD_2': SEMANTIC_TEXCOORD2,
-    'TEXCOORD_3': SEMANTIC_TEXCOORD3,
-    'TEXCOORD_4': SEMANTIC_TEXCOORD4,
-    'TEXCOORD_5': SEMANTIC_TEXCOORD5,
-    'TEXCOORD_6': SEMANTIC_TEXCOORD6,
-    'TEXCOORD_7': SEMANTIC_TEXCOORD7
-};
-
 // order vertexDesc to match the rest of the engine
 const attributeOrder = {
     [SEMANTIC_POSITION]: 0,
@@ -185,164 +117,6 @@ const attributeOrder = {
     [SEMANTIC_TEXCOORD5]: 11,
     [SEMANTIC_TEXCOORD6]: 12,
     [SEMANTIC_TEXCOORD7]: 13
-};
-
-// returns a function for dequantizing the data type
-const getDequantizeFunc = (srcType) => {
-    // see https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_mesh_quantization#encoding-quantized-data
-    switch (srcType) {
-        case TYPE_INT8: return x => Math.max(x / 127.0, -1.0);
-        case TYPE_UINT8: return x => x / 255.0;
-        case TYPE_INT16: return x => Math.max(x / 32767.0, -1.0);
-        case TYPE_UINT16: return x => x / 65535.0;
-        default: return x => x;
-    }
-};
-
-// dequantize an array of data
-const dequantizeArray = (dstArray, srcArray, srcType) => {
-    const convFunc = getDequantizeFunc(srcType);
-    const len = srcArray.length;
-    for (let i = 0; i < len; ++i) {
-        dstArray[i] = convFunc(srcArray[i]);
-    }
-    return dstArray;
-};
-
-// get accessor data, making a copy and patching in the case of a sparse accessor
-const getAccessorData = (gltfAccessor, bufferViews, flatten = false) => {
-    const numComponents = getNumComponents(gltfAccessor.type);
-    const dataType = getComponentDataType(gltfAccessor.componentType);
-    if (!dataType) {
-        return null;
-    }
-
-    let result;
-
-    if (gltfAccessor.sparse) {
-        // handle sparse data
-        const sparse = gltfAccessor.sparse;
-
-        // get indices data
-        const indicesAccessor = {
-            count: sparse.count,
-            type: 'SCALAR'
-        };
-        const indices = getAccessorData(Object.assign(indicesAccessor, sparse.indices), bufferViews, true);
-
-        // data values data
-        const valuesAccessor = {
-            count: sparse.count,
-            type: gltfAccessor.type,
-            componentType: gltfAccessor.componentType
-        };
-        const values = getAccessorData(Object.assign(valuesAccessor, sparse.values), bufferViews, true);
-
-        // get base data
-        if (gltfAccessor.hasOwnProperty('bufferView')) {
-            const baseAccessor = {
-                bufferView: gltfAccessor.bufferView,
-                byteOffset: gltfAccessor.byteOffset,
-                componentType: gltfAccessor.componentType,
-                count: gltfAccessor.count,
-                type: gltfAccessor.type
-            };
-            // make a copy of the base data since we'll patch the values
-            result = getAccessorData(baseAccessor, bufferViews, true).slice();
-        } else {
-            // there is no base data, create empty 0'd out data
-            result = new dataType(gltfAccessor.count * numComponents);
-        }
-
-        for (let i = 0; i < sparse.count; ++i) {
-            const targetIndex = indices[i];
-            for (let j = 0; j < numComponents; ++j) {
-                result[targetIndex * numComponents + j] = values[i * numComponents + j];
-            }
-        }
-    } else {
-        if (gltfAccessor.hasOwnProperty('bufferView')) {
-            const bufferView = bufferViews[gltfAccessor.bufferView];
-            if (flatten && bufferView.hasOwnProperty('byteStride')) {
-                // flatten stridden data
-                const bytesPerElement = numComponents * dataType.BYTES_PER_ELEMENT;
-                const storage = new ArrayBuffer(gltfAccessor.count * bytesPerElement);
-                const tmpArray = new Uint8Array(storage);
-
-                let dstOffset = 0;
-                for (let i = 0; i < gltfAccessor.count; ++i) {
-                    // no need to add bufferView.byteOffset because accessor takes this into account
-                    let srcOffset = (gltfAccessor.byteOffset || 0) + i * bufferView.byteStride;
-                    for (let b = 0; b < bytesPerElement; ++b) {
-                        tmpArray[dstOffset++] = bufferView[srcOffset++];
-                    }
-                }
-
-                result = new dataType(storage);
-            } else {
-                result = new dataType(bufferView.buffer,
-                    bufferView.byteOffset + (gltfAccessor.byteOffset || 0),
-                    gltfAccessor.count * numComponents);
-            }
-        } else {
-            result = new dataType(gltfAccessor.count * numComponents);
-        }
-    }
-
-    return result;
-};
-
-// get accessor data as (unnormalized, unquantized) Float32 data
-const getAccessorDataFloat32 = (gltfAccessor, bufferViews) => {
-    const data = getAccessorData(gltfAccessor, bufferViews, true);
-    if (data instanceof Float32Array || !gltfAccessor.normalized) {
-        // if the source data is quantized (say to int16), but not normalized
-        // then reading the values of the array is the same whether the values
-        // are stored as float32 or int16. so probably no need to convert to
-        // float32.
-        return data;
-    }
-
-    const float32Data = new Float32Array(data.length);
-    dequantizeArray(float32Data, data, getComponentType(gltfAccessor.componentType));
-    return float32Data;
-};
-
-// returns a dequantized bounding box for the accessor
-const getAccessorBoundingBox = (gltfAccessor) => {
-    let min = gltfAccessor.min;
-    let max = gltfAccessor.max;
-    if (!min || !max) {
-        return null;
-    }
-
-    if (gltfAccessor.normalized) {
-        const ctype = getComponentType(gltfAccessor.componentType);
-        min = dequantizeArray([], min, ctype);
-        max = dequantizeArray([], max, ctype);
-    }
-
-    return new BoundingBox(
-        new Vec3((max[0] + min[0]) * 0.5, (max[1] + min[1]) * 0.5, (max[2] + min[2]) * 0.5),
-        new Vec3((max[0] - min[0]) * 0.5, (max[1] - min[1]) * 0.5, (max[2] - min[2]) * 0.5)
-    );
-};
-
-const getPrimitiveType = (primitive) => {
-    if (!primitive.hasOwnProperty('mode')) {
-        return PRIMITIVE_TRIANGLES;
-    }
-
-    switch (primitive.mode) {
-        case 0: return PRIMITIVE_POINTS;
-        case 1: return PRIMITIVE_LINES;
-        case 2: return PRIMITIVE_LINELOOP;
-        case 3: return PRIMITIVE_LINESTRIP;
-        case 4: return PRIMITIVE_TRIANGLES;
-        case 5: return PRIMITIVE_TRISTRIP;
-        case 6: return PRIMITIVE_TRIFAN;
-        default: return PRIMITIVE_TRIANGLES;
-    }
 };
 
 const generateIndices = (numVertices) => {
@@ -560,10 +334,10 @@ const createVertexBuffer = (device, attributes, indices, accessors, bufferViews,
         const sourceDesc = {};
         for (const attrib in useAttributes) {
             const accessor = accessors[attributes[attrib]];
-            const accessorData = getAccessorData(accessor, bufferViews);
+            const accessorData = GltfAccessor.getData(accessor, bufferViews);
             const bufferView = bufferViews[accessor.bufferView];
             const semantic = gltfToEngineSemanticMap[attrib];
-            const size = getNumComponents(accessor.type) * getComponentSizeInBytes(accessor.componentType);
+            const size = GltfAccessor.getNumComponents(accessor.type) * GltfAccessor.getComponentSizeInBytes(accessor.componentType);
             const stride = bufferView && bufferView.hasOwnProperty('byteStride') ? bufferView.byteStride : size;
             sourceDesc[semantic] = {
                 buffer: accessorData.buffer,
@@ -571,8 +345,8 @@ const createVertexBuffer = (device, attributes, indices, accessors, bufferViews,
                 offset: accessorData.byteOffset,
                 stride: stride,
                 count: accessor.count,
-                components: getNumComponents(accessor.type),
-                type: getComponentType(accessor.componentType),
+                components: GltfAccessor.getNumComponents(accessor.type),
+                type: GltfAccessor.getComponentType(accessor.componentType),
                 normalize: accessor.normalized
             };
         }
@@ -597,7 +371,7 @@ const createSkin = (device, gltfSkin, accessors, bufferViews, nodes, glbSkins) =
     const ibp = [];
     if (gltfSkin.hasOwnProperty('inverseBindMatrices')) {
         const inverseBindMatrices = gltfSkin.inverseBindMatrices;
-        const ibmData = getAccessorData(accessors[inverseBindMatrices], bufferViews, true);
+        const ibmData = GltfAccessor.getData(accessors[inverseBindMatrices], bufferViews, true);
         const ibmValues = [];
 
         for (i = 0; i < numJoints; i++) {
@@ -633,114 +407,6 @@ const createSkin = (device, gltfSkin, accessors, bufferViews, nodes, glbSkins) =
     return skin;
 };
 
-const createDracoMesh = (device, primitive, accessors, bufferViews, meshVariants, meshDefaultMaterials, promises) => {
-    // create the mesh
-    const result = new Mesh(device);
-    result.aabb = getAccessorBoundingBox(accessors[primitive.attributes.POSITION]);
-
-    promises.push(new Promise((resolve, reject) => {
-        // decode draco data
-        const dracoExt = primitive.extensions.KHR_draco_mesh_compression;
-        const initialized = dracoDecode(bufferViews[dracoExt.bufferView].slice().buffer, (err, decompressedData) => {
-            if (err) {
-                console.log(err);
-                reject(err);
-            } else {
-                // create a mapping from draco attribute id to glTF semantic name
-                const idToSemantic = {};
-                for (const [name, id] of Object.entries(dracoExt.attributes)) {
-                    idToSemantic[id] = gltfToEngineSemanticMap[name];
-                }
-                // special id -1 is used for generated normals
-                idToSemantic[-1] = SEMANTIC_NORMAL;
-
-                // build vertex description from worker-provided attribute metadata
-                // this ensures we use the actual data types, sizes, and offsets from Draco decoding
-                const vertexDesc = [];
-                for (const attr of decompressedData.attributes) {
-                    const semantic = idToSemantic[attr.id];
-                    if (semantic !== undefined) {
-                        // get normalization info from glTF accessor if available
-                        let normalize = false;
-                        if (attr.id !== -1) {
-                            // find the glTF attribute name for this draco id
-                            for (const [name, id] of Object.entries(dracoExt.attributes)) {
-                                if (id === attr.id && primitive.attributes[name] !== undefined) {
-                                    const accessor = accessors[primitive.attributes[name]];
-                                    normalize = accessor.normalized ?? (semantic === SEMANTIC_COLOR && (attr.dataType === TYPE_UINT8 || attr.dataType === TYPE_UINT16));
-                                    break;
-                                }
-                            }
-                        }
-
-                        vertexDesc.push({
-                            semantic: semantic,
-                            components: attr.numComponents,
-                            type: attr.dataType,
-                            normalize: normalize,
-                            // use offset and stride from worker to handle cases where Draco mesh
-                            // has additional attributes not listed in glTF
-                            offset: attr.offset,
-                            stride: decompressedData.stride
-                        });
-                    }
-                }
-
-                const vertexFormat = new VertexFormat(device, vertexDesc);
-
-                // use stride from worker to correctly calculate vertex count
-                const numVertices = decompressedData.vertices.byteLength / decompressedData.stride;
-                const indexFormat = numVertices <= 65535 ? INDEXFORMAT_UINT16 : INDEXFORMAT_UINT32;
-                const numIndices = decompressedData.indices.byteLength / (numVertices <= 65535 ? 2 : 4);
-
-                Debug.call(() => {
-                    if (numVertices !== accessors[primitive.attributes.POSITION].count) {
-                        Debug.warn('mesh has invalid vertex count');
-                    }
-                    if (primitive.indices !== undefined && numIndices !== accessors[primitive.indices].count) {
-                        Debug.warn('mesh has invalid index count');
-                    }
-                });
-
-                const vertexBuffer = new VertexBuffer(device, vertexFormat, numVertices, {
-                    data: decompressedData.vertices
-                });
-                const indexBuffer = new IndexBuffer(device, indexFormat, numIndices, BUFFER_STATIC, decompressedData.indices);
-
-                result.vertexBuffer = vertexBuffer;
-                result.indexBuffer[0] = indexBuffer;
-                result.primitive[0].type = getPrimitiveType(primitive);
-                result.primitive[0].base = 0;
-                result.primitive[0].count = indexBuffer ? numIndices : numVertices;
-                result.primitive[0].indexed = !!indexBuffer;
-
-                resolve();
-            }
-        });
-
-        if (!initialized) {
-            const message = 'glTF file contains Draco compressed meshes, but the Draco decoder is not configured. Call dracoInitialize() or WasmModule.setConfig(\'DracoDecoderModule\', ...) before loading the asset.';
-            Debug.warnOnce(message);
-            reject(new Error(message));
-        }
-    }));
-
-    // handle material variants
-    if (primitive?.extensions?.KHR_materials_variants) {
-        const variants = primitive.extensions.KHR_materials_variants;
-        const tempMapping = {};
-        variants.mappings.forEach((mapping) => {
-            mapping.variants.forEach((variant) => {
-                tempMapping[variant] = mapping.material;
-            });
-        });
-        meshVariants[result.id] = tempMapping;
-    }
-    meshDefaultMaterials[result.id] = primitive.material;
-
-    return result;
-};
-
 const createMesh = (device, gltfMesh, accessors, bufferViews, vertexBufferDict, meshVariants, meshDefaultMaterials, assetOptions, promises) => {
     const meshes = [];
 
@@ -751,7 +417,7 @@ const createMesh = (device, gltfMesh, accessors, bufferViews, vertexBufferDict, 
             meshes.push(createDracoMesh(device, primitive, accessors, bufferViews, meshVariants, meshDefaultMaterials, promises));
         } else {
             // handle uncompressed mesh
-            let indices = primitive.hasOwnProperty('indices') ? getAccessorData(accessors[primitive.indices], bufferViews, true) : null;
+            let indices = primitive.hasOwnProperty('indices') ? GltfAccessor.getData(accessors[primitive.indices], bufferViews, true) : null;
             const vertexBuffer = createVertexBuffer(device, primitive.attributes, indices, accessors, bufferViews, vertexBufferDict);
             const primitiveType = getPrimitiveType(primitive);
 
@@ -786,21 +452,13 @@ const createMesh = (device, gltfMesh, accessors, bufferViews, vertexBufferDict, 
                 mesh.primitive[0].count = vertexBuffer.numVertices;
             }
 
-            if (primitive.hasOwnProperty('extensions') && primitive.extensions.hasOwnProperty('KHR_materials_variants')) {
-                const variants = primitive.extensions.KHR_materials_variants;
-                const tempMapping = {};
-                variants.mappings.forEach((mapping) => {
-                    mapping.variants.forEach((variant) => {
-                        tempMapping[variant] = mapping.material;
-                    });
-                });
-                meshVariants[mesh.id] = tempMapping;
-            }
+            // handle material variants
+            registerMeshVariants(primitive, mesh.id, meshVariants);
 
             meshDefaultMaterials[mesh.id] = primitive.material;
 
             let accessor = accessors[primitive.attributes.POSITION];
-            mesh.aabb = getAccessorBoundingBox(accessor);
+            mesh.aabb = GltfAccessor.getBoundingBox(accessor);
 
             // morph targets
             if (primitive.hasOwnProperty('targets')) {
@@ -811,14 +469,14 @@ const createMesh = (device, gltfMesh, accessors, bufferViews, vertexBufferDict, 
 
                     if (target.hasOwnProperty('POSITION')) {
                         accessor = accessors[target.POSITION];
-                        options.deltaPositions = getAccessorDataFloat32(accessor, bufferViews);
-                        options.aabb = getAccessorBoundingBox(accessor);
+                        options.deltaPositions = GltfAccessor.getDataFloat32(accessor, bufferViews);
+                        options.aabb = GltfAccessor.getBoundingBox(accessor);
                     }
 
                     if (target.hasOwnProperty('NORMAL')) {
                         accessor = accessors[target.NORMAL];
                         // NOTE: the morph targets can't currently accept quantized normals
-                        options.deltaNormals = getAccessorDataFloat32(accessor, bufferViews);
+                        options.deltaNormals = GltfAccessor.getDataFloat32(accessor, bufferViews);
                     }
 
                     // name if specified
@@ -990,7 +648,7 @@ const createAnimation = (gltfAnimation, animationIndex, gltfAccessors, bufferVie
 
     // create animation data block for the accessor
     const createAnimData = (gltfAccessor) => {
-        return new AnimData(getNumComponents(gltfAccessor.type), getAccessorDataFloat32(gltfAccessor, bufferViews));
+        return new AnimData(GltfAccessor.getNumComponents(gltfAccessor.type), GltfAccessor.getDataFloat32(gltfAccessor, bufferViews));
     };
 
     const interpMap = {
@@ -1311,46 +969,6 @@ const createCamera = (gltfCamera, node) => {
     return cameraEntity;
 };
 
-// creates light component, adds it to the node and returns the created light component
-const createLight = (gltfLight, node) => {
-    const lightProps = {
-        enabled: false,
-        type: gltfLight.type === 'point' ? 'omni' : gltfLight.type,
-        color: gltfLight.hasOwnProperty('color') ? new Color(gltfLight.color) : Color.WHITE,
-        // when range is not defined, infinity should be used - but that causes infinity in bounds calculations
-        range: gltfLight.hasOwnProperty('range') ? gltfLight.range : 9999,
-        falloffMode: LIGHTFALLOFF_INVERSESQUARED,
-        // TODO: (engine issue #3252) Set intensity to match glTF specification, which uses physically based values:
-        // - Omni and spot lights use luminous intensity in candela (lm/sr)
-        // - Directional lights use illuminance in lux (lm/m2).
-        // Current implementation: clamps specified intensity to 0..2 range
-        intensity: gltfLight.hasOwnProperty('intensity') ? math.clamp(gltfLight.intensity, 0, 2) : 1
-    };
-
-    // glTF spot light cone angles are in radians, PlayCanvas expects degrees
-    // Defaults per glTF spec: innerConeAngle = 0, outerConeAngle = PI/4 (45 degrees)
-    if (gltfLight.hasOwnProperty('spot')) {
-        lightProps.innerConeAngle = gltfLight.spot.hasOwnProperty('innerConeAngle') ? gltfLight.spot.innerConeAngle * math.RAD_TO_DEG : 0;
-        lightProps.outerConeAngle = gltfLight.spot.hasOwnProperty('outerConeAngle') ? gltfLight.spot.outerConeAngle * math.RAD_TO_DEG : 45;
-    }
-
-    // glTF stores light intensity in energy/area, convert to luminance
-    // getLightUnitConversion expects angles in radians, use original glTF values
-    if (gltfLight.hasOwnProperty('intensity')) {
-        const outerAngleRad = gltfLight.spot?.outerConeAngle ?? (Math.PI / 4);
-        const innerAngleRad = gltfLight.spot?.innerConeAngle ?? 0;
-        lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(lightTypes[lightProps.type], outerAngleRad, innerAngleRad);
-    }
-
-    // Rotate to match light orientation in glTF specification
-    // Note that this adds a new entity node into the hierarchy that does not exist in the gltf hierarchy
-    const lightEntity = new Entity(node.name);
-    lightEntity.rotateLocal(90, 0, 0);
-
-    lightEntity.addComponent('light', lightProps);
-    return lightEntity;
-};
-
 const createSkins = (device, gltf, nodes, bufferViews) => {
     if (!gltf.hasOwnProperty('skins') || gltf.skins.length === 0) {
         return [];
@@ -1405,19 +1023,6 @@ const createMaterials = (gltf, textures, options) => {
     });
 };
 
-const createVariants = (gltf) => {
-    if (!gltf.hasOwnProperty('extensions') || !gltf.extensions.hasOwnProperty('KHR_materials_variants')) {
-        return null;
-    }
-
-    const data = gltf.extensions.KHR_materials_variants.variants;
-    const variants = {};
-    for (let i = 0; i < data.length; i++) {
-        variants[data[i].name] = i;
-    }
-    return variants;
-};
-
 const createAnimations = (gltf, nodes, bufferViews, options) => {
     if (!gltf.hasOwnProperty('animations') || gltf.animations.length === 0) {
         return [];
@@ -1435,69 +1040,6 @@ const createAnimations = (gltf, nodes, bufferViews, options) => {
             postprocess(gltfAnimation, animation);
         }
         return animation;
-    });
-};
-
-const createInstancing = (device, gltf, nodeInstancingMap, bufferViews) => {
-
-    const accessors = gltf.accessors;
-    nodeInstancingMap.forEach((data, entity) => {
-        const attributes = data.ext.attributes;
-
-        let translations;
-        if (attributes.hasOwnProperty('TRANSLATION')) {
-            const accessor = accessors[attributes.TRANSLATION];
-            translations = getAccessorDataFloat32(accessor, bufferViews);
-        }
-
-        let rotations;
-        if (attributes.hasOwnProperty('ROTATION')) {
-            const accessor = accessors[attributes.ROTATION];
-            rotations = getAccessorDataFloat32(accessor, bufferViews);
-        }
-
-        let scales;
-        if (attributes.hasOwnProperty('SCALE')) {
-            const accessor = accessors[attributes.SCALE];
-            scales = getAccessorDataFloat32(accessor, bufferViews);
-        }
-
-        const instanceCount = (translations ? translations.length / 3 : 0) ||
-            (rotations ? rotations.length / 4 : 0) ||
-            (scales ? scales.length / 3 : 0);
-
-        if (instanceCount) {
-
-            const matrices = new Float32Array(instanceCount * 16);
-            const pos = new Vec3();
-            const rot = new Quat();
-            const scl = new Vec3(1, 1, 1);
-            const matrix = new Mat4();
-            let matrixIndex = 0;
-
-            for (let i = 0; i < instanceCount; i++) {
-                const i3 = i * 3;
-                if (translations) {
-                    pos.set(translations[i3], translations[i3 + 1], translations[i3 + 2]);
-                }
-                if (rotations) {
-                    const i4 = i * 4;
-                    rot.set(rotations[i4], rotations[i4 + 1], rotations[i4 + 2], rotations[i4 + 3]);
-                }
-                if (scales) {
-                    scl.set(scales[i3], scales[i3 + 1], scales[i3 + 2]);
-                }
-
-                matrix.setTRS(pos, rot, scl);
-
-                // copy matrix elements into array of floats
-                for (let m = 0; m < 16; m++) {
-                    matrices[matrixIndex++] = matrix.data[m];
-                }
-            }
-
-            data.matrices = matrices;
-        }
     });
 };
 
@@ -1604,51 +1146,6 @@ const createCameras = (gltf, nodes, options) => {
     }
 
     return cameras;
-};
-
-const createLights = (gltf, nodes, options) => {
-
-    let lights = null;
-
-    if (gltf.hasOwnProperty('nodes') && gltf.hasOwnProperty('extensions') &&
-        gltf.extensions.hasOwnProperty('KHR_lights_punctual') && gltf.extensions.KHR_lights_punctual.hasOwnProperty('lights')) {
-
-        const gltfLights = gltf.extensions.KHR_lights_punctual.lights;
-        if (gltfLights.length) {
-
-            const preprocess = options?.light?.preprocess;
-            const process = options?.light?.process ?? createLight;
-            const postprocess = options?.light?.postprocess;
-
-            // handle nodes with lights
-            gltf.nodes.forEach((gltfNode, nodeIndex) => {
-                if (gltfNode.hasOwnProperty('extensions') &&
-                    gltfNode.extensions.hasOwnProperty('KHR_lights_punctual') &&
-                    gltfNode.extensions.KHR_lights_punctual.hasOwnProperty('light')) {
-
-                    const lightIndex = gltfNode.extensions.KHR_lights_punctual.light;
-                    const gltfLight = gltfLights[lightIndex];
-                    if (gltfLight) {
-                        if (preprocess) {
-                            preprocess(gltfLight);
-                        }
-                        const light = process(gltfLight, nodes[nodeIndex]);
-                        if (postprocess) {
-                            postprocess(gltfLight, light);
-                        }
-
-                        // add the light to node->light map
-                        if (light) {
-                            if (!lights) lights = new Map();
-                            lights.set(gltfNode, light);
-                        }
-                    }
-                }
-            });
-        }
-    }
-
-    return lights;
 };
 
 // link skins to the meshes
@@ -1769,10 +1266,6 @@ const applySampler = (texture, gltfSampler) => {
 };
 
 let gltfTextureUniqueId = 0;
-
-const getTextureSource = gltfTexture => gltfTexture.extensions?.KHR_texture_basisu?.source ??
-    gltfTexture.extensions?.EXT_texture_webp?.source ??
-    gltfTexture.source;
 
 // create gltf images. returns an array of promises that resolve to texture assets.
 const createImages = (gltf, bufferViews, urlBase, registry, options) => {

--- a/src/framework/parsers/glb/extensions/ext-mesh-gpu-instancing.js
+++ b/src/framework/parsers/glb/extensions/ext-mesh-gpu-instancing.js
@@ -1,0 +1,72 @@
+import { Mat4 } from '../../../../core/math/mat4.js';
+import { Quat } from '../../../../core/math/quat.js';
+import { Vec3 } from '../../../../core/math/vec3.js';
+import { GltfAccessor } from '../gltf-accessor.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing
+// converts the TRS accessors of instanced nodes to per-instance matrix arrays, stored on the
+// nodeInstancingMap entries
+const createInstancing = (device, gltf, nodeInstancingMap, bufferViews) => {
+
+    const accessors = gltf.accessors;
+    nodeInstancingMap.forEach((data, entity) => {
+        const attributes = data.ext.attributes;
+
+        let translations;
+        if (attributes.hasOwnProperty('TRANSLATION')) {
+            const accessor = accessors[attributes.TRANSLATION];
+            translations = GltfAccessor.getDataFloat32(accessor, bufferViews);
+        }
+
+        let rotations;
+        if (attributes.hasOwnProperty('ROTATION')) {
+            const accessor = accessors[attributes.ROTATION];
+            rotations = GltfAccessor.getDataFloat32(accessor, bufferViews);
+        }
+
+        let scales;
+        if (attributes.hasOwnProperty('SCALE')) {
+            const accessor = accessors[attributes.SCALE];
+            scales = GltfAccessor.getDataFloat32(accessor, bufferViews);
+        }
+
+        const instanceCount = (translations ? translations.length / 3 : 0) ||
+            (rotations ? rotations.length / 4 : 0) ||
+            (scales ? scales.length / 3 : 0);
+
+        if (instanceCount) {
+
+            const matrices = new Float32Array(instanceCount * 16);
+            const pos = new Vec3();
+            const rot = new Quat();
+            const scl = new Vec3(1, 1, 1);
+            const matrix = new Mat4();
+            let matrixIndex = 0;
+
+            for (let i = 0; i < instanceCount; i++) {
+                const i3 = i * 3;
+                if (translations) {
+                    pos.set(translations[i3], translations[i3 + 1], translations[i3 + 2]);
+                }
+                if (rotations) {
+                    const i4 = i * 4;
+                    rot.set(rotations[i4], rotations[i4 + 1], rotations[i4 + 2], rotations[i4 + 3]);
+                }
+                if (scales) {
+                    scl.set(scales[i3], scales[i3 + 1], scales[i3 + 2]);
+                }
+
+                matrix.setTRS(pos, rot, scl);
+
+                // copy matrix elements into array of floats
+                for (let m = 0; m < 16; m++) {
+                    matrices[matrixIndex++] = matrix.data[m];
+                }
+            }
+
+            data.matrices = matrices;
+        }
+    });
+};
+
+export { createInstancing };

--- a/src/framework/parsers/glb/extensions/khr-draco-mesh-compression.js
+++ b/src/framework/parsers/glb/extensions/khr-draco-mesh-compression.js
@@ -1,0 +1,115 @@
+import { Debug } from '../../../../core/debug.js';
+import {
+    BUFFER_STATIC, INDEXFORMAT_UINT16, INDEXFORMAT_UINT32,
+    SEMANTIC_COLOR, SEMANTIC_NORMAL, TYPE_UINT8, TYPE_UINT16
+} from '../../../../platform/graphics/constants.js';
+import { IndexBuffer } from '../../../../platform/graphics/index-buffer.js';
+import { VertexBuffer } from '../../../../platform/graphics/vertex-buffer.js';
+import { VertexFormat } from '../../../../platform/graphics/vertex-format.js';
+import { Mesh } from '../../../../scene/mesh.js';
+import { dracoDecode } from '../../draco-decoder.js';
+import { GltfAccessor, getPrimitiveType, gltfToEngineSemanticMap } from '../gltf-accessor.js';
+import { registerMeshVariants } from './khr-materials-variants.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_draco_mesh_compression
+const createDracoMesh = (device, primitive, accessors, bufferViews, meshVariants, meshDefaultMaterials, promises) => {
+    // create the mesh
+    const result = new Mesh(device);
+    result.aabb = GltfAccessor.getBoundingBox(accessors[primitive.attributes.POSITION]);
+
+    promises.push(new Promise((resolve, reject) => {
+        // decode draco data
+        const dracoExt = primitive.extensions.KHR_draco_mesh_compression;
+        const initialized = dracoDecode(bufferViews[dracoExt.bufferView].slice().buffer, (err, decompressedData) => {
+            if (err) {
+                console.log(err);
+                reject(err);
+            } else {
+                // create a mapping from draco attribute id to glTF semantic name
+                const idToSemantic = {};
+                for (const [name, id] of Object.entries(dracoExt.attributes)) {
+                    idToSemantic[id] = gltfToEngineSemanticMap[name];
+                }
+                // special id -1 is used for generated normals
+                idToSemantic[-1] = SEMANTIC_NORMAL;
+
+                // build vertex description from worker-provided attribute metadata
+                // this ensures we use the actual data types, sizes, and offsets from Draco decoding
+                const vertexDesc = [];
+                for (const attr of decompressedData.attributes) {
+                    const semantic = idToSemantic[attr.id];
+                    if (semantic !== undefined) {
+                        // get normalization info from glTF accessor if available
+                        let normalize = false;
+                        if (attr.id !== -1) {
+                            // find the glTF attribute name for this draco id
+                            for (const [name, id] of Object.entries(dracoExt.attributes)) {
+                                if (id === attr.id && primitive.attributes[name] !== undefined) {
+                                    const accessor = accessors[primitive.attributes[name]];
+                                    normalize = accessor.normalized ?? (semantic === SEMANTIC_COLOR && (attr.dataType === TYPE_UINT8 || attr.dataType === TYPE_UINT16));
+                                    break;
+                                }
+                            }
+                        }
+
+                        vertexDesc.push({
+                            semantic: semantic,
+                            components: attr.numComponents,
+                            type: attr.dataType,
+                            normalize: normalize,
+                            // use offset and stride from worker to handle cases where Draco mesh
+                            // has additional attributes not listed in glTF
+                            offset: attr.offset,
+                            stride: decompressedData.stride
+                        });
+                    }
+                }
+
+                const vertexFormat = new VertexFormat(device, vertexDesc);
+
+                // use stride from worker to correctly calculate vertex count
+                const numVertices = decompressedData.vertices.byteLength / decompressedData.stride;
+                const indexFormat = numVertices <= 65535 ? INDEXFORMAT_UINT16 : INDEXFORMAT_UINT32;
+                const numIndices = decompressedData.indices.byteLength / (numVertices <= 65535 ? 2 : 4);
+
+                Debug.call(() => {
+                    if (numVertices !== accessors[primitive.attributes.POSITION].count) {
+                        Debug.warn('mesh has invalid vertex count');
+                    }
+                    if (primitive.indices !== undefined && numIndices !== accessors[primitive.indices].count) {
+                        Debug.warn('mesh has invalid index count');
+                    }
+                });
+
+                const vertexBuffer = new VertexBuffer(device, vertexFormat, numVertices, {
+                    data: decompressedData.vertices
+                });
+                const indexBuffer = new IndexBuffer(device, indexFormat, numIndices, BUFFER_STATIC, decompressedData.indices);
+
+                result.vertexBuffer = vertexBuffer;
+                result.indexBuffer[0] = indexBuffer;
+                result.primitive[0].type = getPrimitiveType(primitive);
+                result.primitive[0].base = 0;
+                result.primitive[0].count = indexBuffer ? numIndices : numVertices;
+                result.primitive[0].indexed = !!indexBuffer;
+
+                resolve();
+            }
+        });
+
+        if (!initialized) {
+            const message = 'glTF file contains Draco compressed meshes, but the Draco decoder is not configured. Call dracoInitialize() or WasmModule.setConfig(\'DracoDecoderModule\', ...) before loading the asset.';
+            Debug.warnOnce(message);
+            reject(new Error(message));
+        }
+    }));
+
+    // handle material variants
+    registerMeshVariants(primitive, result.id, meshVariants);
+
+    meshDefaultMaterials[result.id] = primitive.material;
+
+    return result;
+};
+
+export { createDracoMesh };

--- a/src/framework/parsers/glb/extensions/khr-lights-punctual.js
+++ b/src/framework/parsers/glb/extensions/khr-lights-punctual.js
@@ -1,0 +1,94 @@
+import { Color } from '../../../../core/math/color.js';
+import { math } from '../../../../core/math/math.js';
+import { LIGHTFALLOFF_INVERSESQUARED } from '../../../../scene/constants.js';
+import { Light, lightTypes } from '../../../../scene/light.js';
+import { Entity } from '../../../entity.js';
+
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_lights_punctual
+
+// creates light component, adds it to the node and returns the created light component
+const createLight = (gltfLight, node) => {
+    const lightProps = {
+        enabled: false,
+        type: gltfLight.type === 'point' ? 'omni' : gltfLight.type,
+        color: gltfLight.hasOwnProperty('color') ? new Color(gltfLight.color) : Color.WHITE,
+        // when range is not defined, infinity should be used - but that causes infinity in bounds calculations
+        range: gltfLight.hasOwnProperty('range') ? gltfLight.range : 9999,
+        falloffMode: LIGHTFALLOFF_INVERSESQUARED,
+        // TODO: (engine issue #3252) Set intensity to match glTF specification, which uses physically based values:
+        // - Omni and spot lights use luminous intensity in candela (lm/sr)
+        // - Directional lights use illuminance in lux (lm/m2).
+        // Current implementation: clamps specified intensity to 0..2 range
+        intensity: gltfLight.hasOwnProperty('intensity') ? math.clamp(gltfLight.intensity, 0, 2) : 1
+    };
+
+    // glTF spot light cone angles are in radians, PlayCanvas expects degrees
+    // Defaults per glTF spec: innerConeAngle = 0, outerConeAngle = PI/4 (45 degrees)
+    if (gltfLight.hasOwnProperty('spot')) {
+        lightProps.innerConeAngle = gltfLight.spot.hasOwnProperty('innerConeAngle') ? gltfLight.spot.innerConeAngle * math.RAD_TO_DEG : 0;
+        lightProps.outerConeAngle = gltfLight.spot.hasOwnProperty('outerConeAngle') ? gltfLight.spot.outerConeAngle * math.RAD_TO_DEG : 45;
+    }
+
+    // glTF stores light intensity in energy/area, convert to luminance
+    // getLightUnitConversion expects angles in radians, use original glTF values
+    if (gltfLight.hasOwnProperty('intensity')) {
+        const outerAngleRad = gltfLight.spot?.outerConeAngle ?? (Math.PI / 4);
+        const innerAngleRad = gltfLight.spot?.innerConeAngle ?? 0;
+        lightProps.luminance = gltfLight.intensity * Light.getLightUnitConversion(lightTypes[lightProps.type], outerAngleRad, innerAngleRad);
+    }
+
+    // Rotate to match light orientation in glTF specification
+    // Note that this adds a new entity node into the hierarchy that does not exist in the gltf hierarchy
+    const lightEntity = new Entity(node.name);
+    lightEntity.rotateLocal(90, 0, 0);
+
+    lightEntity.addComponent('light', lightProps);
+    return lightEntity;
+};
+
+const createLights = (gltf, nodes, options) => {
+
+    let lights = null;
+
+    if (gltf.hasOwnProperty('nodes') && gltf.hasOwnProperty('extensions') &&
+        gltf.extensions.hasOwnProperty('KHR_lights_punctual') && gltf.extensions.KHR_lights_punctual.hasOwnProperty('lights')) {
+
+        const gltfLights = gltf.extensions.KHR_lights_punctual.lights;
+        if (gltfLights.length) {
+
+            const preprocess = options?.light?.preprocess;
+            const process = options?.light?.process ?? createLight;
+            const postprocess = options?.light?.postprocess;
+
+            // handle nodes with lights
+            gltf.nodes.forEach((gltfNode, nodeIndex) => {
+                if (gltfNode.hasOwnProperty('extensions') &&
+                    gltfNode.extensions.hasOwnProperty('KHR_lights_punctual') &&
+                    gltfNode.extensions.KHR_lights_punctual.hasOwnProperty('light')) {
+
+                    const lightIndex = gltfNode.extensions.KHR_lights_punctual.light;
+                    const gltfLight = gltfLights[lightIndex];
+                    if (gltfLight) {
+                        if (preprocess) {
+                            preprocess(gltfLight);
+                        }
+                        const light = process(gltfLight, nodes[nodeIndex]);
+                        if (postprocess) {
+                            postprocess(gltfLight, light);
+                        }
+
+                        // add the light to node->light map
+                        if (light) {
+                            if (!lights) lights = new Map();
+                            lights.set(gltfNode, light);
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    return lights;
+};
+
+export { createLights };

--- a/src/framework/parsers/glb/extensions/khr-materials-variants.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-variants.js
@@ -1,0 +1,31 @@
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_variants
+
+// returns a map of variant names to their index, or null when the file has no variants
+const createVariants = (gltf) => {
+    if (!gltf.hasOwnProperty('extensions') || !gltf.extensions.hasOwnProperty('KHR_materials_variants')) {
+        return null;
+    }
+
+    const data = gltf.extensions.KHR_materials_variants.variants;
+    const variants = {};
+    for (let i = 0; i < data.length; i++) {
+        variants[data[i].name] = i;
+    }
+    return variants;
+};
+
+// stores the primitive's variant index to material index mapping under the mesh id
+const registerMeshVariants = (primitive, meshId, meshVariants) => {
+    if (primitive?.extensions?.KHR_materials_variants) {
+        const variants = primitive.extensions.KHR_materials_variants;
+        const tempMapping = {};
+        variants.mappings.forEach((mapping) => {
+            mapping.variants.forEach((variant) => {
+                tempMapping[variant] = mapping.material;
+            });
+        });
+        meshVariants[meshId] = tempMapping;
+    }
+};
+
+export { createVariants, registerMeshVariants };

--- a/src/framework/parsers/glb/extensions/texture-source.js
+++ b/src/framework/parsers/glb/extensions/texture-source.js
@@ -1,0 +1,9 @@
+// Resolves the image index of a glTF texture, taking the compressed texture source extensions
+// into account:
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_basisu
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_texture_webp
+const getTextureSource = gltfTexture => gltfTexture.extensions?.KHR_texture_basisu?.source ??
+    gltfTexture.extensions?.EXT_texture_webp?.source ??
+    gltfTexture.source;
+
+export { getTextureSource };

--- a/src/framework/parsers/glb/gltf-accessor.js
+++ b/src/framework/parsers/glb/gltf-accessor.js
@@ -1,0 +1,245 @@
+import { Vec3 } from '../../../core/math/vec3.js';
+import { BoundingBox } from '../../../core/shape/bounding-box.js';
+import {
+    PRIMITIVE_LINELOOP, PRIMITIVE_LINESTRIP, PRIMITIVE_LINES, PRIMITIVE_POINTS, PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP,
+    SEMANTIC_POSITION, SEMANTIC_NORMAL, SEMANTIC_TANGENT, SEMANTIC_COLOR, SEMANTIC_BLENDINDICES, SEMANTIC_BLENDWEIGHT,
+    SEMANTIC_TEXCOORD0, SEMANTIC_TEXCOORD1, SEMANTIC_TEXCOORD2, SEMANTIC_TEXCOORD3, SEMANTIC_TEXCOORD4, SEMANTIC_TEXCOORD5, SEMANTIC_TEXCOORD6, SEMANTIC_TEXCOORD7,
+    TYPE_INT8, TYPE_UINT8, TYPE_INT16, TYPE_UINT16, TYPE_INT32, TYPE_UINT32, TYPE_FLOAT32
+} from '../../../platform/graphics/constants.js';
+
+// map of glTF attribute names to engine semantics
+const gltfToEngineSemanticMap = {
+    'POSITION': SEMANTIC_POSITION,
+    'NORMAL': SEMANTIC_NORMAL,
+    'TANGENT': SEMANTIC_TANGENT,
+    'COLOR_0': SEMANTIC_COLOR,
+    'JOINTS_0': SEMANTIC_BLENDINDICES,
+    'WEIGHTS_0': SEMANTIC_BLENDWEIGHT,
+    'TEXCOORD_0': SEMANTIC_TEXCOORD0,
+    'TEXCOORD_1': SEMANTIC_TEXCOORD1,
+    'TEXCOORD_2': SEMANTIC_TEXCOORD2,
+    'TEXCOORD_3': SEMANTIC_TEXCOORD3,
+    'TEXCOORD_4': SEMANTIC_TEXCOORD4,
+    'TEXCOORD_5': SEMANTIC_TEXCOORD5,
+    'TEXCOORD_6': SEMANTIC_TEXCOORD6,
+    'TEXCOORD_7': SEMANTIC_TEXCOORD7
+};
+
+const getPrimitiveType = (primitive) => {
+    if (!primitive.hasOwnProperty('mode')) {
+        return PRIMITIVE_TRIANGLES;
+    }
+
+    switch (primitive.mode) {
+        case 0: return PRIMITIVE_POINTS;
+        case 1: return PRIMITIVE_LINES;
+        case 2: return PRIMITIVE_LINELOOP;
+        case 3: return PRIMITIVE_LINESTRIP;
+        case 4: return PRIMITIVE_TRIANGLES;
+        case 5: return PRIMITIVE_TRISTRIP;
+        case 6: return PRIMITIVE_TRIFAN;
+        default: return PRIMITIVE_TRIANGLES;
+    }
+};
+
+// returns a function for dequantizing the data type
+const getDequantizeFunc = (srcType) => {
+    // see https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_mesh_quantization#encoding-quantized-data
+    switch (srcType) {
+        case TYPE_INT8: return x => Math.max(x / 127.0, -1.0);
+        case TYPE_UINT8: return x => x / 255.0;
+        case TYPE_INT16: return x => Math.max(x / 32767.0, -1.0);
+        case TYPE_UINT16: return x => x / 65535.0;
+        default: return x => x;
+    }
+};
+
+// dequantize an array of data
+const dequantizeArray = (dstArray, srcArray, srcType) => {
+    const convFunc = getDequantizeFunc(srcType);
+    const len = srcArray.length;
+    for (let i = 0; i < len; ++i) {
+        dstArray[i] = convFunc(srcArray[i]);
+    }
+    return dstArray;
+};
+
+/**
+ * Utility functions for decoding glTF accessor data.
+ *
+ * @ignore
+ */
+class GltfAccessor {
+    static getNumComponents(accessorType) {
+        switch (accessorType) {
+            case 'SCALAR': return 1;
+            case 'VEC2': return 2;
+            case 'VEC3': return 3;
+            case 'VEC4': return 4;
+            case 'MAT2': return 4;
+            case 'MAT3': return 9;
+            case 'MAT4': return 16;
+            default: return 3;
+        }
+    }
+
+    static getComponentType(componentType) {
+        switch (componentType) {
+            case 5120: return TYPE_INT8;
+            case 5121: return TYPE_UINT8;
+            case 5122: return TYPE_INT16;
+            case 5123: return TYPE_UINT16;
+            case 5124: return TYPE_INT32;
+            case 5125: return TYPE_UINT32;
+            case 5126: return TYPE_FLOAT32;
+            default: return 0;
+        }
+    }
+
+    static getComponentSizeInBytes(componentType) {
+        switch (componentType) {
+            case 5120: return 1;    // int8
+            case 5121: return 1;    // uint8
+            case 5122: return 2;    // int16
+            case 5123: return 2;    // uint16
+            case 5124: return 4;    // int32
+            case 5125: return 4;    // uint32
+            case 5126: return 4;    // float32
+            default: return 0;
+        }
+    }
+
+    static getComponentDataType(componentType) {
+        switch (componentType) {
+            case 5120: return Int8Array;
+            case 5121: return Uint8Array;
+            case 5122: return Int16Array;
+            case 5123: return Uint16Array;
+            case 5124: return Int32Array;
+            case 5125: return Uint32Array;
+            case 5126: return Float32Array;
+            default: return null;
+        }
+    }
+
+    // get accessor data, making a copy and patching in the case of a sparse accessor
+    static getData(gltfAccessor, bufferViews, flatten = false) {
+        const numComponents = GltfAccessor.getNumComponents(gltfAccessor.type);
+        const dataType = GltfAccessor.getComponentDataType(gltfAccessor.componentType);
+        if (!dataType) {
+            return null;
+        }
+
+        let result;
+
+        if (gltfAccessor.sparse) {
+            // handle sparse data
+            const sparse = gltfAccessor.sparse;
+
+            // get indices data
+            const indicesAccessor = {
+                count: sparse.count,
+                type: 'SCALAR'
+            };
+            const indices = GltfAccessor.getData(Object.assign(indicesAccessor, sparse.indices), bufferViews, true);
+
+            // data values data
+            const valuesAccessor = {
+                count: sparse.count,
+                type: gltfAccessor.type,
+                componentType: gltfAccessor.componentType
+            };
+            const values = GltfAccessor.getData(Object.assign(valuesAccessor, sparse.values), bufferViews, true);
+
+            // get base data
+            if (gltfAccessor.hasOwnProperty('bufferView')) {
+                const baseAccessor = {
+                    bufferView: gltfAccessor.bufferView,
+                    byteOffset: gltfAccessor.byteOffset,
+                    componentType: gltfAccessor.componentType,
+                    count: gltfAccessor.count,
+                    type: gltfAccessor.type
+                };
+                // make a copy of the base data since we'll patch the values
+                result = GltfAccessor.getData(baseAccessor, bufferViews, true).slice();
+            } else {
+                // there is no base data, create empty 0'd out data
+                result = new dataType(gltfAccessor.count * numComponents);
+            }
+
+            for (let i = 0; i < sparse.count; ++i) {
+                const targetIndex = indices[i];
+                for (let j = 0; j < numComponents; ++j) {
+                    result[targetIndex * numComponents + j] = values[i * numComponents + j];
+                }
+            }
+        } else {
+            if (gltfAccessor.hasOwnProperty('bufferView')) {
+                const bufferView = bufferViews[gltfAccessor.bufferView];
+                if (flatten && bufferView.hasOwnProperty('byteStride')) {
+                    // flatten stridden data
+                    const bytesPerElement = numComponents * dataType.BYTES_PER_ELEMENT;
+                    const storage = new ArrayBuffer(gltfAccessor.count * bytesPerElement);
+                    const tmpArray = new Uint8Array(storage);
+
+                    let dstOffset = 0;
+                    for (let i = 0; i < gltfAccessor.count; ++i) {
+                        // no need to add bufferView.byteOffset because accessor takes this into account
+                        let srcOffset = (gltfAccessor.byteOffset || 0) + i * bufferView.byteStride;
+                        for (let b = 0; b < bytesPerElement; ++b) {
+                            tmpArray[dstOffset++] = bufferView[srcOffset++];
+                        }
+                    }
+
+                    result = new dataType(storage);
+                } else {
+                    result = new dataType(bufferView.buffer,
+                        bufferView.byteOffset + (gltfAccessor.byteOffset || 0),
+                        gltfAccessor.count * numComponents);
+                }
+            } else {
+                result = new dataType(gltfAccessor.count * numComponents);
+            }
+        }
+
+        return result;
+    }
+
+    // get accessor data as (unnormalized, unquantized) Float32 data
+    static getDataFloat32(gltfAccessor, bufferViews) {
+        const data = GltfAccessor.getData(gltfAccessor, bufferViews, true);
+        if (data instanceof Float32Array || !gltfAccessor.normalized) {
+            // if the source data is quantized (say to int16), but not normalized
+            // then reading the values of the array is the same whether the values
+            // are stored as float32 or int16. so probably no need to convert to
+            // float32.
+            return data;
+        }
+
+        const float32Data = new Float32Array(data.length);
+        dequantizeArray(float32Data, data, GltfAccessor.getComponentType(gltfAccessor.componentType));
+        return float32Data;
+    }
+
+    // returns a dequantized bounding box for the accessor
+    static getBoundingBox(gltfAccessor) {
+        let min = gltfAccessor.min;
+        let max = gltfAccessor.max;
+        if (!min || !max) {
+            return null;
+        }
+
+        if (gltfAccessor.normalized) {
+            const ctype = GltfAccessor.getComponentType(gltfAccessor.componentType);
+            min = dequantizeArray([], min, ctype);
+            max = dequantizeArray([], max, ctype);
+        }
+
+        return new BoundingBox(
+            new Vec3((max[0] + min[0]) * 0.5, (max[1] + min[1]) * 0.5, (max[2] + min[2]) * 0.5),
+            new Vec3((max[0] - min[0]) * 0.5, (max[1] - min[1]) * 0.5, (max[2] - min[2]) * 0.5)
+        );
+    }
+}
+
+export { GltfAccessor, getPrimitiveType, gltfToEngineSemanticMap };


### PR DESCRIPTION
Follow-up to #9007, completing the split of the large glb-parser.js: the remaining glTF extension handling moves into per-extension files under `src/framework/parsers/glb/extensions/`, and the accessor decoding utilities become a static `GltfAccessor` class in `src/framework/parsers/glb/gltf-accessor.js`. The parser drops from 2,289 to 1,782 lines (2,611 before #9007). No behavior change.

**Changes:**
- New `GltfAccessor` static class hosting the accessor decoding utilities (`getData`, `getDataFloat32`, `getBoundingBox` and the component-type helpers, previously the loose `getAccessor*`/`getComponent*` functions). The dequantize helpers (the `KHR_mesh_quantization` support) are module-private; `gltfToEngineSemanticMap` and `getPrimitiveType` are separate named exports from the same file.
- `KHR_lights_punctual` → own file: `createLight`/`createLights` move verbatim, including the `options.light` preprocess/process/postprocess hooks.
- `KHR_materials_variants` → own file: `createVariants` plus a new `registerMeshVariants` helper that replaces the identical mapping block previously copy-pasted in both the draco and non-draco mesh paths.
- `EXT_mesh_gpu_instancing` → own file: `createInstancing` (TRS accessors → per-instance matrices); the node-level capture into `nodeInstancingMap` remains in the parser.
- `KHR_texture_basisu` / `EXT_texture_webp` → `texture-source.js` with the shared `getTextureSource` resolver.
- `KHR_draco_mesh_compression` → own file: `createDracoMesh` moves verbatim, now consuming `GltfAccessor` and the variants helper.

Verified in the examples browser: draco-glb, instancing-glb, light-physical-units (loads `Lights.glb` via KHR_lights_punctual) and html-texture-configurator (including variant switching) all render correctly with no console warnings.