### PR TITLE
Mark specular-glossiness diffuse texture as sRGB in glb parser

### DIFF
--- a/src/framework/parsers/glb/extensions/khr-materials-pbr-specular-glossiness.js
+++ b/src/framework/parsers/glb/extensions/khr-materials-pbr-specular-glossiness.js
@@ -46,7 +46,14 @@ const KHR_materials_pbrSpecularGlossiness = {
     },
 
     getColorTextures(data) {
-        return data.hasOwnProperty('specularGlossinessTexture') ? [data.specularGlossinessTexture] : [];
+        const textures = [];
+        if (data.hasOwnProperty('diffuseTexture')) {
+            textures.push(data.diffuseTexture);
+        }
+        if (data.hasOwnProperty('specularGlossinessTexture')) {
+            textures.push(data.specularGlossinessTexture);
+        }
+        return textures;
     }
 };
 


### PR DESCRIPTION
The glb parser's sRGB texture detection never included the `diffuseTexture` of `KHR_materials_pbrSpecularGlossiness`, even though the extension assigns it to `material.diffuseMap` and the spec defines it as sRGB-encoded. Spec-gloss models therefore sampled their diffuse map as linear data, rendering washed out — while the equivalent `baseColorTexture` on metallic-roughness materials was handled correctly.

**Changes:**
- `KHR_materials_pbrSpecularGlossiness.getColorTextures()` now returns `diffuseTexture` in addition to `specularGlossinessTexture`, so the texture loads with the sRGB flag like the metallic-roughness base color does.

Verified with the Khronos SpecGlossVsMetalRough sample (same bottle in both material models): before the fix the spec-gloss diffuse texture loaded linear while the metal-rough base color loaded sRGB; after the fix both load sRGB, with all other textures (normal, metallic-roughness, occlusion, emissive) unchanged.