### PR TITLE
Allow long control labels to wrap in examples browser

### DIFF
--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -602,11 +602,15 @@ body {
 
 #controlPanel .pcui-label-group > .pcui-label {
     font-size: 14px;
-    max-width: 35%;
+    width: 42%;
+    max-width: 42%;
+    /* PCUI defaults to nowrap + ellipsis, which truncates longer labels (#7308) */
+    white-space: normal;
+    line-height: 1.1;
 }
 
 #controlPanel .pcui-label-group > .pcui-slider > .pcui-numeric-input {
-    min-width: 46px;
+    min-width: 52px;
 }
 
 #controlPanel > .pcui-panel-content {


### PR DESCRIPTION
Fixes #7308

Long control labels (e.g. `Zoom pinch sensitivity` in the camera/orbit example) were truncated by PCUI's default `nowrap` + `ellipsis` label styling, with no way to read the full text.

**Changes:**
- Control panel labels now wrap to multiple lines instead of being truncated (`white-space: normal`, slightly tightened `line-height` for wrapped lines)
- Label column widened from 35% to 42% so most labels still fit on a single line
- Slider numeric input `min-width` bumped 46px → 52px so 3-decimal values like `0.001` remain fully visible next to the wider label column

Applies to all examples via shared CSS — no per-example changes needed.

<img width="285" height="488" alt="Screenshot 2026-07-02 at 15 26 02" src="https://github.com/user-attachments/assets/7cf339f7-1547-45bd-9cc2-e323faa65943" />
