### PR TITLE
Fix crash when a gsplat octree asset is unloaded while its instance is still registered in the streaming world

### DIFF
--- a/src/scene/gsplat-unified/gsplat-octree.js
+++ b/src/scene/gsplat-unified/gsplat-octree.js
@@ -360,7 +360,11 @@ class GSplatOctree {
      */
     ensureFileResource(fileIndex) {
         Debug.assert(fileIndex >= 0 && fileIndex < this.files.length);
-        Debug.assert(this.assetLoader);
+
+        // If octree was destroyed, assetLoader is null - nothing to load
+        if (!this.assetLoader) {
+            return;
+        }
 
         // resource already loaded
         if (this.fileResources.has(fileIndex)) {

--- a/src/scene/gsplat-unified/gsplat-world.js
+++ b/src/scene/gsplat-unified/gsplat-world.js
@@ -447,6 +447,19 @@ class GSplatWorld {
         result.overdrawDirty = false;
         result.sortNeeded = false;
 
+        // Drop instances whose octree was destroyed (e.g. the asset was unloaded) before the
+        // layer placement change reaches reconcile - they can no longer stream and their
+        // resources are gone, so letting them run this update would assert and crash the
+        // budget pass. Mirrors the removal branch in reconcile.
+        for (const [placement, inst] of this._octreeInstances) {
+            if (inst.octree.destroyed) {
+                this._octreeInstances.delete(placement);
+                this._layerPlacementsDirty = true;
+                this._placementSetChanged = true;
+                this._octreeInstancesToDestroy.push(inst);
+            }
+        }
+
         // Cadence: a free-running metronome raises a latched request every 10 frames.
         if (--this._framesTillFullUpdate <= 0) {
             this._framesTillFullUpdate = 10;


### PR DESCRIPTION
## Description
Unloading a gsplat octree asset (e.g. swapping the asset on a unified gsplat component: `component.asset = null` + `asset.unload()`) can crash the engine. Since #8919, the streaming update runs on `framerender` against the cached topology, before the render path reconciles layer placement changes. That opens a window where `GSplatOctree.destroy()` has already run but the octree's instance is still registered in `GSplatWorld._octreeInstances`, and the world update then operates on the destroyed octree.

Two failures result, observed on 2.20.3 when switching between splat assets at runtime:

- `GSplatOctreeInstance.update()` / `pollPrefetchCompletions()` call `GSplatOctree.ensureFileResource()` for their pending file loads, which hits `Debug.assert(this.assetLoader)` every frame. #8210 added destroyed-octree guards to `unloadResource`, `ensureEnvironmentResource` and `unloadEnvironmentResource`, but `ensureFileResource` was missed.
- The global budget pass (#8444) dereferences `inst.placement.aabb.center` in `computeGlobalMaxDistance()`. With the resource destroyed, `placement.aabb` is null, producing an uncaught `TypeError: Cannot read properties of undefined (reading 'center')`. This is not debug-only: asserts strip out of release builds but the TypeError remains.

The crash is intermittent because the budget pass only runs when its gates fire (full LOD update cadence or dirty params) in the same frame as the unload, which is why asset swaps appear to work most of the time.

The fix has two parts:

- `GSplatOctree.ensureFileResource()` now early-outs when `assetLoader` is null, matching the guard style of its sibling methods from #8210.
- `GSplatWorld.update()` now starts by dropping any instance whose octree has been destroyed before the placement change reached `reconcile()`, mirroring the removal branch in `reconcile()` (same dirty flags, same `_octreeInstancesToDestroy` queue, whose destruction path already handles destroyed octrees via the existing `octree.destroyed` check).

Fixes #

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change