### PR TITLE
Support pen input in touch sources (fix #9012)

### DIFF
--- a/src/extras/input/sources/multi-touch-source.js
+++ b/src/extras/input/sources/multi-touch-source.js
@@ -1,6 +1,6 @@
 import { Vec2 } from '../../../core/math/vec2.js';
 import { InputSource } from '../input.js';
-import { movementState } from '../utils.js';
+import { isTouchPointer, movementState } from '../utils.js';
 
 const tmpVa = new Vec2();
 
@@ -56,7 +56,7 @@ class MultiTouchSource extends InputSource {
         const { pointerId, pointerType } = event;
         this._movementState.down(event);
 
-        if (pointerType !== 'touch') {
+        if (!isTouchPointer(pointerType)) {
             return;
         }
         this._element?.setPointerCapture(pointerId);
@@ -81,7 +81,7 @@ class MultiTouchSource extends InputSource {
         const { pointerType, target, pointerId } = event;
         const [movementX, movementY] = this._movementState.move(event);
 
-        if (pointerType !== 'touch') {
+        if (!isTouchPointer(pointerType)) {
             return;
         }
         if (target !== this._element) {
@@ -117,7 +117,7 @@ class MultiTouchSource extends InputSource {
         const { pointerType, pointerId } = event;
         this._movementState.up(event);
 
-        if (pointerType !== 'touch') {
+        if (!isTouchPointer(pointerType)) {
             return;
         }
         this._element?.releasePointerCapture(pointerId);

--- a/src/extras/input/sources/single-gesture-source.js
+++ b/src/extras/input/sources/single-gesture-source.js
@@ -1,6 +1,6 @@
 import { DOUBLE_TAP_THRESHOLD, DOUBLE_TAP_VARIANCE } from '../constants.js';
 import { InputSource } from '../input.js';
-import { movementState } from '../utils.js';
+import { isTouchPointer, movementState } from '../utils.js';
 import { VirtualJoystick } from './virtual-joystick.js';
 
 /**
@@ -102,7 +102,7 @@ class SingleGestureSource extends InputSource {
         const { pointerType, pointerId, clientX, clientY } = event;
         this._movementState.down(event);
 
-        if (pointerType !== 'touch') {
+        if (!isTouchPointer(pointerType)) {
             return;
         }
         this._element?.setPointerCapture(pointerId);
@@ -134,7 +134,7 @@ class SingleGestureSource extends InputSource {
         const { pointerType, pointerId, target, clientX, clientY } = event;
         const [movementX, movementY] = this._movementState.move(event);
 
-        if (pointerType !== 'touch') {
+        if (!isTouchPointer(pointerType)) {
             return;
         }
         if (target !== this._element) {
@@ -162,7 +162,7 @@ class SingleGestureSource extends InputSource {
         const { pointerType, pointerId } = event;
         this._movementState.up(event);
 
-        if (pointerType !== 'touch') {
+        if (!isTouchPointer(pointerType)) {
             return;
         }
         this._element?.releasePointerCapture(pointerId);

--- a/src/extras/input/utils.js
+++ b/src/extras/input/utils.js
@@ -1,3 +1,5 @@
+export const isTouchPointer = (pointerType) => pointerType === 'touch' || pointerType === 'pen';
+
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/movementX
 export const movementState = () => {
     const state = new Map();

--- a/src/extras/input/utils.js
+++ b/src/extras/input/utils.js
@@ -1,4 +1,4 @@
-export const isTouchPointer = (pointerType) => pointerType === 'touch' || pointerType === 'pen';
+export const isTouchPointer = pointerType => pointerType === 'touch' || pointerType === 'pen'; // 'pen' adds support for stylus
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/movementX
 export const movementState = () => {


### PR DESCRIPTION
 ## Support pen input in touch gesture sources
  - Treat `pen` pointer events like `touch` in `MultiTouchSource` and `SingleGestureSource`.
  - Preserve existing mouse and touch behavior.

Tested with the "Orbit" example on an iPad Pro (ios 26.5, with an apple pencil)