### PR TITLE
Fix crash when a gsplat component detaches its asset while the octree instance is still registered in the streaming world

### DIFF
--- a/src/scene/gsplat-unified/gsplat-world.js
+++ b/src/scene/gsplat-unified/gsplat-world.js
@@ -447,12 +447,13 @@ class GSplatWorld {
         result.overdrawDirty = false;
         result.sortNeeded = false;
 
-        // Drop instances whose octree was destroyed (e.g. the asset was unloaded) before the
-        // layer placement change reaches reconcile - they can no longer stream and their
-        // resources are gone, so letting them run this update would assert and crash the
+        // Drop instances whose octree was destroyed (the asset was unloaded) or whose placement
+        // was destroyed (the component detached the asset, which nulls placement.resource)
+        // before the layer placement change reaches reconcile - they can no longer stream and
+        // their resources are gone, so letting them run this update would assert and crash the
         // budget pass. Mirrors the removal branch in reconcile.
         for (const [placement, inst] of this._octreeInstances) {
-            if (inst.octree.destroyed) {
+            if (inst.octree.destroyed || !placement.resource) {
                 this._octreeInstances.delete(placement);
                 this._layerPlacementsDirty = true;
                 this._placementSetChanged = true;


### PR DESCRIPTION
## Description
Follow-up to the destroyed-octree fix: the same crash has a second trigger that does not involve unloading at all. Detaching the asset from a unified gsplat component (`component.asset = null`) destroys the placement synchronously, and `GSplatPlacement#destroy()` nulls `placement.resource`. The streaming world only drops the placement's octree instance during the render-path reconcile, but the per-tick streaming update (on `framerender`, since #8919) runs first — so for one tick the world holds an instance whose placement has no resource. If the budget pass runs in that tick, `computeGlobalMaxDistance()` reads `inst.placement.aabb`, which falls back to `resource?.aabb` and returns null, producing the `GSplatPlacement.aabb is null` assert followed by an uncaught `TypeError: Cannot read properties of undefined (reading 'center')`. The TypeError survives release builds, where asserts are stripped.

It is intermittent because the budget pass only runs when its gates fire (full LOD update cadence, camera movement, dirty params) in the same tick as the detach — asset swaps appear to work most of the time.

The fix extends the drop-loop at the top of `GSplatWorld.update()` to also remove instances whose placement has been destroyed (`placement.resource` is null), alongside the existing destroyed-octree check. Removal goes through the same path as `reconcile()` (same dirty flags, same `_octreeInstancesToDestroy` queue).

Fixes #

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change