### PR TITLE
Fix skybox staying black after cubemap asset unload and reload (fix #6966)

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1523,27 +1523,19 @@ class AppBase extends EventHandler {
      */
     setSkybox(asset) {
         if (asset !== this._skyboxAsset) {
-            const onSkyboxRemoved = () => {
-                this.setSkybox(null);
-            };
-
-            const onSkyboxChanged = () => {
-                this.scene.setSkybox(this._skyboxAsset ? this._skyboxAsset.resources : null);
-            };
-
             // cleanup previous asset
             if (this._skyboxAsset) {
-                this.assets.off(`load:${this._skyboxAsset.id}`, onSkyboxChanged, this);
-                this.assets.off(`remove:${this._skyboxAsset.id}`, onSkyboxRemoved, this);
-                this._skyboxAsset.off('change', onSkyboxChanged, this);
+                this.assets.off(`load:${this._skyboxAsset.id}`, this._onSkyboxChanged, this);
+                this.assets.off(`remove:${this._skyboxAsset.id}`, this._onSkyboxRemoved, this);
+                this._skyboxAsset.off('change', this._onSkyboxChanged, this);
             }
 
             // set new asset
             this._skyboxAsset = asset;
             if (this._skyboxAsset) {
-                this.assets.on(`load:${this._skyboxAsset.id}`, onSkyboxChanged, this);
-                this.assets.once(`remove:${this._skyboxAsset.id}`, onSkyboxRemoved, this);
-                this._skyboxAsset.on('change', onSkyboxChanged, this);
+                this.assets.on(`load:${this._skyboxAsset.id}`, this._onSkyboxChanged, this);
+                this.assets.once(`remove:${this._skyboxAsset.id}`, this._onSkyboxRemoved, this);
+                this._skyboxAsset.on('change', this._onSkyboxChanged, this);
 
                 if (this.scene.skyboxMip === 0 && !this._skyboxAsset.loadFaces) {
                     this._skyboxAsset.loadFaces = true;
@@ -1552,8 +1544,18 @@ class AppBase extends EventHandler {
                 this.assets.load(this._skyboxAsset);
             }
 
-            onSkyboxChanged();
+            this._onSkyboxChanged();
         }
+    }
+
+    /** @private */
+    _onSkyboxRemoved() {
+        this.setSkybox(null);
+    }
+
+    /** @private */
+    _onSkyboxChanged() {
+        this.scene.setSkybox(this._skyboxAsset ? this._skyboxAsset.resources : null);
     }
 
     /** @private */

--- a/src/framework/handlers/cubemap.js
+++ b/src/framework/handlers/cubemap.js
@@ -266,6 +266,13 @@ class CubemapHandler extends ResourceHandler {
 
         // process the texture asset
         const processTexAsset = function (index, texAsset) {
+            // the cubemap can share the resource of a dependent texture asset (the env atlas), in
+            // which case unloading the cubemap destroys that resource while the dependent asset
+            // stays marked as loaded - unload it to force a reload of valid data
+            if (texAsset.loaded && texAsset.resource && !texAsset.resource.device) {
+                texAsset.unload();
+            }
+
             if (texAsset.loaded) {
                 // asset already exists
                 onLoad(index, texAsset);


### PR DESCRIPTION
Fixes #6966 — unloading a cubemap asset used as the skybox and then loading it again left the sky (and image based lighting) black, even though `scene.envAtlas` was set.

**Changes:**
- `CubemapHandler`: an env-atlas based cubemap shares the resource of its dependent texture asset, so unloading the cubemap destroys that texture while the dependent asset stays marked as loaded. On reload, the handler reused the dependent asset and handed the destroyed texture back to the scene. It now detects the destroyed resource and unloads the dependent asset, forcing a reload of valid data.
- `AppBase#setSkybox`: the load/change/remove handlers were created as fresh closures on every call, so the cleanup `off()` calls never matched the previously registered functions — listeners of earlier skybox assets leaked and could override the current skybox on their later load/change/remove events. Replaced with stable private methods.