### PR TITLE
Convert the obj model parser to an ES module in scripts/esm/parsers

### DIFF
--- a/examples/src/examples/loaders/obj.example.mjs
+++ b/examples/src/examples/loaders/obj.example.mjs
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import { ObjModelParser } from 'playcanvas/scripts/esm/parsers/obj-model.mjs';
 
 import { deviceType } from 'examples/context';
 
@@ -40,33 +41,28 @@ app.on('destroy', () => {
 
 app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
+// OBJ Parser is not enabled by default in engine. Add the parser to the model resource handler
+app.loader.getHandler('model').addParser(new ObjModelParser(app.graphicsDevice));
+
 const objurl = './assets/models/monkey.obj';
-const scripturl = './scripts/parsers/obj-model.js';
 /** @type {pc.Entity} */
 let entity;
-app.assets.loadFromUrl(scripturl, 'script', () => {
-    // OBJ Parser is not enabled by default in engine. Add the parser to the model resource handler
-    // set up obj parser
-    // @ts-ignore globally loaded ObjModelParser
-    app.loader.getHandler('model').addParser(new ObjModelParser(app.graphicsDevice));
+app.assets.loadFromUrl(objurl, 'model', (err, asset) => {
+    app.start();
 
-    app.assets.loadFromUrl(objurl, 'model', (err, asset) => {
-        app.start();
+    entity = new pc.Entity();
+    entity.addComponent('model');
+    entity.model.model = asset.resource;
+    app.root.addChild(entity);
 
-        entity = new pc.Entity();
-        entity.addComponent('model');
-        entity.model.model = asset.resource;
-        app.root.addChild(entity);
-
-        // add a randomly generated material to all mesh instances
-        const mis = entity.model.meshInstances;
-        for (let i = 0; i < mis.length; i++) {
-            const material = new pc.StandardMaterial();
-            material.diffuse = new pc.Color(pc.math.random(0, 1), pc.math.random(0, 1), pc.math.random(0, 1));
-            material.update();
-            mis[i].material = material;
-        }
-    });
+    // add a randomly generated material to all mesh instances
+    const mis = entity.model.meshInstances;
+    for (let i = 0; i < mis.length; i++) {
+        const material = new pc.StandardMaterial();
+        material.diffuse = new pc.Color(pc.math.random(0, 1), pc.math.random(0, 1), pc.math.random(0, 1));
+        material.update();
+        mis[i].material = material;
+    }
 });
 
 // Create an Entity with a camera component

--- a/scripts/esm/parsers/obj-model.mjs
+++ b/scripts/esm/parsers/obj-model.mjs
@@ -1,6 +1,10 @@
-// Sample Obj model parser. This is not added to built into the engine library by default.
+import { Geometry, GraphNode, Http, Mesh, MeshInstance, Model, StandardMaterial } from 'playcanvas';
+
+// Sample Obj model parser. This is not built into the engine library by default.
 //
 // To use, first register the parser:
+//
+// import { ObjModelParser } from 'playcanvas/scripts/esm/parsers/obj-model.mjs';
 //
 // // add parser to model resource handler
 // const objParser = new ObjModelParser(this.app.graphicsDevice);
@@ -20,11 +24,10 @@
 // - can't handle meshes larger than 65535 verts
 // - assigns default material to all meshes
 // - doesn't created indexed geometry
-// eslint-disable-next-line no-unused-vars -- exposed as a global for external use (see usage comment above)
 class ObjModelParser {
     constructor(device) {
         this._device = device;
-        this._defaultMaterial = new pc.StandardMaterial();
+        this._defaultMaterial = new StandardMaterial();
     }
 
     canParse(context) {
@@ -32,7 +35,7 @@ class ObjModelParser {
     }
 
     load(url, callback, asset) {
-        this.handler.fetch(url, pc.Http.ResponseType.TEXT, (err, response) => {
+        this.handler.fetch(url, Http.ResponseType.TEXT, (err, response) => {
             if (err) {
                 callback(err);
             } else {
@@ -106,14 +109,14 @@ class ObjModelParser {
                         } // expand normals from indices
                     }
                 } else {
-                    console.error(pc.string.format('OBJ uses unsupported {0}-gons', parts.length - 1));
+                    console.error(`OBJ uses unsupported ${parts.length - 1}-gons`);
                 }
             }
         }
 
-        const model = new pc.Model();
+        const model = new Model();
         const groupNames = Object.keys(parsed);
-        const root = new pc.GraphNode();
+        const root = new GraphNode();
         // create a new mesh instance for each "group"
         for (let i = 0; i < groupNames.length; i++) {
             const currentGroup = parsed[groupNames[i]];
@@ -122,7 +125,7 @@ class ObjModelParser {
                 console.warn('Warning: mesh with more than 65535 vertices');
             }
 
-            const geom = new pc.Geometry();
+            const geom = new Geometry();
             geom.positions = currentGroup.verts;
             if (currentGroup.normals.length > 0) {
                 geom.normals = currentGroup.normals;
@@ -131,9 +134,9 @@ class ObjModelParser {
                 geom.uvs = currentGroup.uvs;
             }
 
-            const mesh = pc.Mesh.fromGeometry(this._device, geom);
+            const mesh = Mesh.fromGeometry(this._device, geom);
 
-            const mi = new pc.MeshInstance(mesh, this._defaultMaterial, new pc.GraphNode());
+            const mi = new MeshInstance(mesh, this._defaultMaterial, new GraphNode());
             model.meshInstances.push(mi);
             root.addChild(mi.node);
         }
@@ -153,3 +156,5 @@ class ObjModelParser {
         return result;
     }
 }
+
+export { ObjModelParser };


### PR DESCRIPTION
Moves `scripts/parsers/obj-model.js` to `scripts/esm/parsers/obj-model.mjs`, converting it from a classic script exposing a global class to an ES module that imports from `playcanvas` and exports `ObjModelParser`. This establishes `scripts/esm/parsers/` as the home for external resource parsers (the SPZ parser from #9018 lives there too).

**Changes:**
- `ObjModelParser` is now imported instead of relying on a globally defined class loaded via a script asset:
  ```javascript
  import { ObjModelParser } from 'playcanvas/scripts/esm/parsers/obj-model.mjs';

  app.loader.getHandler('model').addParser(new ObjModelParser(app.graphicsDevice));
  ```
- Parser logic is unchanged apart from replacing `pc.*` globals with imports and `pc.string.format` with a template literal.

**Examples:**
- `loaders/obj` updated to import the parser directly, removing the script-asset loading step. Verified in the browser.