### PR TITLE
Fix inverted buffer usage flags in Mesh.clear()

### DIFF
--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -607,8 +607,8 @@ class Mesh extends RefCountedObject {
         this._geometryData.recreate = true;
         this._geometryData.maxVertices = maxVertices;
         this._geometryData.maxIndices = maxIndices;
-        this._geometryData.verticesUsage = verticesDynamic ? BUFFER_STATIC : BUFFER_DYNAMIC;
-        this._geometryData.indicesUsage = indicesDynamic ? BUFFER_STATIC : BUFFER_DYNAMIC;
+        this._geometryData.verticesUsage = verticesDynamic ? BUFFER_DYNAMIC : BUFFER_STATIC;
+        this._geometryData.indicesUsage = indicesDynamic ? BUFFER_DYNAMIC : BUFFER_STATIC;
     }
 
     /**


### PR DESCRIPTION
I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).

## What changed

`Mesh.clear(verticesDynamic, indicesDynamic, ...)` assigned buffer usage backwards:

```js
this._geometryData.verticesUsage = verticesDynamic ? BUFFER_STATIC : BUFFER_DYNAMIC;
this._geometryData.indicesUsage = indicesDynamic ? BUFFER_STATIC : BUFFER_DYNAMIC;
```

The JSDoc says passing `true` creates the buffer with `BUFFER_DYNAMIC` usage and that `BUFFER_STATIC` is the default when unspecified. The implementation did the opposite. This PR swaps the ternary arms so the implementation matches the documentation.

## Why

- The inversion dates back to the original Procedural Mesh API commit (#1960) — a day-one typo, never intentionally changed.
- All callers assume `true` = dynamic: the engine examples (`mesh-generation`, `mesh-decals`, `point-cloud-simulation`, `loaders-gl`) call `mesh.clear(true, false)` for meshes they rewrite every frame, and `world-clusters-debug.js` calls `mesh.clear(true, true)` for a per-frame debug mesh.
- `GeometryData.initDefaults()` defaults both usages to `BUFFER_STATIC`; after this fix, `clear()` with no arguments agrees with it (previously the no-arg case wrongly produced `BUFFER_DYNAMIC`).

## Notes for reviewers

- The only consumers of these fields are `_updateVertexBuffer` and `_updateIndexBuffer`, which pass the values straight through as buffer usage hints — no logic branches on them, so no other code changes are needed.
- Usage is a GPU allocation hint, not a correctness flag, which is why this went unnoticed: everything rendered correctly, but frequently-updated meshes were allocated as static and vice versa.
- Full test suite passes and no tests reference these fields, so nothing depended on the inverted behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)