### PR TITLE
Upgrade XrNavigation teleport visuals to ballistic arc with ring indicator

### DIFF
--- a/scripts/esm/xr-navigation.mjs
+++ b/scripts/esm/xr-navigation.mjs
@@ -24,6 +24,8 @@ const tmpSegDir = new Vec3();
 const tmpToCam = new Vec3();
 const tmpSide = new Vec3();
 const tmpAimOrigin = new Vec3();
+const tmpAimDir = new Vec3();
+const tmpAimPoint = new Vec3();
 
 const arcVertexGLSL = /* glsl */ `
     attribute vec3 vertex_position;
@@ -565,20 +567,41 @@ class XrNavigation extends Script {
     }
 
     /**
-     * Returns the world-space point the aim visualization should start from. The target ray
-     * origin sits at the head for gaze/pinch-style input (e.g. Apple Vision Pro transient
-     * pointers), so prefer the handheld grip position when the input source has one.
+     * Computes the world-space aim ray for an input source, writing it into tmpAimOrigin and
+     * tmpAimDir. The arc launches from the handheld grip position when the input source has
+     * one, because the target ray origin sits at the head for gaze/pinch-style input (e.g.
+     * Apple Vision Pro transient pointers). The direction is then re-aimed from the grip
+     * toward the point the target ray indicates - using the raw target ray direction from the
+     * hand would offset the trajectory by the hand-to-head parallax, making the landing depend
+     * on where the hand happened to be when the pinch registered. For tracked-pointer
+     * controllers the grip and ray origin coincide, so this reduces to the target ray itself.
      *
      * @param {XrInputSource} inputSource - The aiming input source.
-     * @returns {Vec3} The world-space start point.
      * @private
      */
-    _getAimOrigin(inputSource) {
-        // Copy immediately: getPosition() and getOrigin() return references to the input
-        // source's internal vectors, which the engine reuses as scratch space on the next
-        // getDirection()/getOrigin() call
+    _getAimRay(inputSource) {
+        // Copy immediately: getOrigin()/getDirection()/getPosition() return references to the
+        // input source's internal vectors, which the engine reuses as scratch space on
+        // subsequent calls
+        tmpAimDir.copy(inputSource.getDirection());
+        tmpAimOrigin.copy(inputSource.getOrigin());
+
         const grip = inputSource.grip ? inputSource.getPosition() : null;
-        return tmpAimOrigin.copy(grip || inputSource.getOrigin());
+        if (!grip) return;
+
+        // Aim point: where the target ray meets the navigation plane, or a far point along
+        // the ray when it never descends to it
+        let t = this.maxTeleportDistance;
+        if (tmpAimDir.y < -0.001) {
+            const tPlane = (tmpAimOrigin.y - this.groundHeight) / -tmpAimDir.y;
+            if (tPlane > 0 && tPlane < this.maxTeleportDistance * 2) {
+                t = tPlane;
+            }
+        }
+        tmpAimPoint.copy(tmpAimDir).mulScalar(t).add(tmpAimOrigin);
+
+        tmpAimOrigin.copy(grip);
+        tmpAimDir.sub2(tmpAimPoint, tmpAimOrigin).normalize();
     }
 
     /**
@@ -646,7 +669,8 @@ class XrNavigation extends Script {
         if (!rec) {
             rec = { point: new Vec3(), valid: false };
             this._arcHits.set(inputSource, rec);
-            this._computeArcHit(this._getAimOrigin(inputSource), inputSource.getDirection(), rec);
+            this._getAimRay(inputSource);
+            this._computeArcHit(tmpAimOrigin, tmpAimDir, rec);
         }
         if (!rec.valid) return;
 
@@ -840,7 +864,8 @@ class XrNavigation extends Script {
                 rec = { point: new Vec3(), valid: false };
                 this._arcHits.set(inputSource, rec);
             }
-            this._computeArcHit(this._getAimOrigin(inputSource), inputSource.getDirection(), rec);
+            this._getAimRay(inputSource);
+            this._computeArcHit(tmpAimOrigin, tmpAimDir, rec);
 
             const visual = this._getArcVisual(inputSource);
             visual.entity.enabled = true;

--- a/scripts/esm/xr-navigation.mjs
+++ b/scripts/esm/xr-navigation.mjs
@@ -1,13 +1,130 @@
-import { Color, Script, Vec2, Vec3 } from 'playcanvas';
+import {
+    BLEND_NORMAL,
+    CULLFACE_NONE,
+    Color,
+    Entity,
+    Mesh,
+    MeshInstance,
+    PlaneGeometry,
+    PRIMITIVE_TRIANGLES,
+    Script,
+    SEMANTIC_POSITION,
+    SEMANTIC_TEXCOORD0,
+    ShaderMaterial,
+    Vec2,
+    Vec3
+} from 'playcanvas';
 
 /** @import { XrInputSource } from 'playcanvas' */
+
+// Gravitational acceleration (m/s^2) used for the ballistic teleport arc
+const ARC_GRAVITY = 9.81;
+
+const tmpSegDir = new Vec3();
+const tmpToCam = new Vec3();
+const tmpSide = new Vec3();
+const tmpAimOrigin = new Vec3();
+
+const arcVertexGLSL = /* glsl */ `
+    attribute vec3 vertex_position;
+    attribute vec2 aUv0;
+
+    uniform mat4 matrix_model;
+    uniform mat4 matrix_viewProjection;
+
+    varying vec2 uv0;
+
+    void main(void) {
+        gl_Position = matrix_viewProjection * matrix_model * vec4(vertex_position, 1.0);
+        uv0 = aUv0;
+    }
+`;
+
+const arcFragmentGLSL = /* glsl */ `
+    uniform vec4 uColor;
+
+    varying vec2 uv0;
+
+    void main(void) {
+        float edge = 1.0 - abs(uv0.y * 2.0 - 1.0);
+        edge *= edge;
+        float ends = smoothstep(0.0, 0.1, uv0.x) * (1.0 - smoothstep(0.9, 1.0, uv0.x));
+        gl_FragColor = vec4(uColor.rgb, uColor.a * edge * ends);
+    }
+`;
+
+const arcVertexWGSL = /* wgsl */ `
+    attribute vertex_position: vec3f;
+    attribute aUv0: vec2f;
+
+    uniform matrix_model: mat4x4f;
+    uniform matrix_viewProjection: mat4x4f;
+
+    varying uv0: vec2f;
+
+    @vertex
+    fn vertexMain(input: VertexInput) -> VertexOutput {
+        var output: VertexOutput;
+        output.position = uniform.matrix_viewProjection * uniform.matrix_model * vec4f(input.vertex_position, 1.0);
+        output.uv0 = input.aUv0;
+        return output;
+    }
+`;
+
+const arcFragmentWGSL = /* wgsl */ `
+    uniform uColor: vec4f;
+
+    varying uv0: vec2f;
+
+    @fragment
+    fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+        var output: FragmentOutput;
+        let edgeBase = 1.0 - abs(input.uv0.y * 2.0 - 1.0);
+        let edge = edgeBase * edgeBase;
+        let ends = smoothstep(0.0, 0.1, input.uv0.x) * (1.0 - smoothstep(0.9, 1.0, input.uv0.x));
+        output.color = vec4f(uniform.uColor.rgb, uniform.uColor.a * edge * ends);
+        return output;
+    }
+`;
+
+const ringFragmentGLSL = /* glsl */ `
+    uniform vec4 uColor;
+
+    varying vec2 uv0;
+
+    void main(void) {
+        float d = length(uv0 * 2.0 - 1.0);
+        float ring = smoothstep(0.55, 0.75, d) * (1.0 - smoothstep(0.85, 1.0, d));
+        float fill = (1.0 - smoothstep(0.0, 0.85, d)) * 0.15;
+        gl_FragColor = vec4(uColor.rgb, uColor.a * (ring + fill));
+    }
+`;
+
+const ringFragmentWGSL = /* wgsl */ `
+    uniform uColor: vec4f;
+
+    varying uv0: vec2f;
+
+    @fragment
+    fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+        var output: FragmentOutput;
+        let d = length(input.uv0 * 2.0 - 1.0);
+        let ring = smoothstep(0.55, 0.75, d) * (1.0 - smoothstep(0.85, 1.0, d));
+        let fill = (1.0 - smoothstep(0.0, 0.85, d)) * 0.15;
+        output.color = vec4f(uniform.uColor.rgb, uniform.uColor.a * (ring + fill));
+        return output;
+    }
+`;
 
 /**
  * Handles VR navigation with support for teleportation, smooth locomotion, snap or smooth
  * turning, and snap vertical movement. All methods can be enabled simultaneously, allowing
  * users to choose their preferred navigation method on the fly.
  *
- * Teleportation: Point and teleport using trigger/pinch gestures
+ * Teleportation: Point and teleport using trigger/pinch gestures. The aim is visualized as a
+ * ballistic arc rendered as a glowing ribbon, landing on a flat navigation plane at
+ * {@link XrNavigation#groundHeight}. Apps with physics or custom picking can override ground
+ * detection by assigning {@link XrNavigation#castRay}.
  * Smooth Locomotion: Use left thumbstick for XZ movement
  * Turning: Right thumbstick X-axis — snap turn (default) or continuous smooth turn, selected
  *   via {@link XrNavigation#turnMode}
@@ -114,7 +231,42 @@ class XrNavigation extends Script {
     maxTeleportDistance = 10;
 
     /**
-     * Radius of the teleport target indicator circle.
+     * Height in meters of the flat navigation plane used for teleport ground detection.
+     * @attribute
+     * @enabledif {enableTeleport}
+     */
+    groundHeight = 0;
+
+    /**
+     * Initial speed of the ballistic teleport arc in meters per second. Higher values increase
+     * the teleport reach.
+     * @attribute
+     * @range [2, 20]
+     * @precision 0.1
+     * @enabledif {enableTeleport}
+     */
+    teleportArcSpeed = 8;
+
+    /**
+     * Width in meters of the teleport arc ribbon.
+     * @attribute
+     * @range [0.01, 0.3]
+     * @precision 0.01
+     * @enabledif {enableTeleport}
+     */
+    arcWidth = 0.05;
+
+    /**
+     * Number of segments used to tessellate the teleport arc. Read once when the script
+     * initializes; runtime changes have no effect.
+     * @attribute
+     * @range [8, 64]
+     * @enabledif {enableTeleport}
+     */
+    arcSegments = 32;
+
+    /**
+     * Radius of the teleport target indicator ring.
      * @attribute
      * @range [0.1, 2]
      * @precision 0.1
@@ -123,33 +275,19 @@ class XrNavigation extends Script {
     teleportIndicatorRadius = 0.2;
 
     /**
-     * Number of segments for the teleport indicator circle.
-     * @attribute
-     * @range [8, 64]
-     * @enabledif {enableTeleport}
-     */
-    teleportIndicatorSegments = 16;
-
-    /**
-     * Color for valid teleportation areas.
+     * Color for valid teleportation areas. Defaults to a soft cyan-white in the same family as
+     * the `XrMenu` hover color, so pointer feedback reads as one visual system.
      * @attribute
      * @enabledif {enableTeleport}
      */
-    validTeleportColor = new Color(0, 1, 0);
+    validTeleportColor = new Color(0.5, 0.8, 0.95);
 
     /**
      * Color for invalid teleportation areas.
      * @attribute
      * @enabledif {enableTeleport}
      */
-    invalidTeleportColor = new Color(1, 0, 0);
-
-    /**
-     * Color for controller rays.
-     * @attribute
-     * @enabledif {enableMove}
-     */
-    controllerRayColor = new Color(1, 1, 1);
+    invalidTeleportColor = new Color(0.9, 0.4, 0.35);
 
     /**
      * Enable snap vertical movement using right thumbstick Y (controllers only).
@@ -193,6 +331,18 @@ class XrNavigation extends Script {
      */
     snapVerticalResetThreshold = 0.25;
 
+    /**
+     * Optional custom ground detection for teleportation. When set, it fully replaces the flat
+     * plane at {@link XrNavigation#groundHeight}: the teleport arc is tested segment by segment
+     * against this callback and only its hits are valid landing points. The callback receives
+     * the world-space start and end of an arc segment and returns the hit point, or null if the
+     * segment hits nothing. Not a script attribute (functions are not serializable) — assign it
+     * from code, e.g. wrap `rigidbody.raycastFirst` or a custom picker.
+     *
+     * @type {((start: Vec3, end: Vec3) => Vec3 | null) | null}
+     */
+    castRay = null;
+
     /** @type {Set<XrInputSource>} */
     inputSources = new Set();
 
@@ -215,18 +365,37 @@ class XrNavigation extends Script {
 
     tmpVec3A = new Vec3();
 
-    tmpVec3B = new Vec3();
-
     // Color objects
     validColor = new Color();
 
     invalidColor = new Color();
 
-    rayColor = new Color();
-
     // Camera reference for movement calculations
     /** @type {import('playcanvas').Entity | null} */
     cameraEntity = null;
+
+    // Arc visualization state (created in initialize/lazily per input source)
+
+    /** @type {ShaderMaterial | null} */
+    _arcMaterial = null;
+
+    /** @type {ShaderMaterial | null} */
+    _ringMaterial = null;
+
+    /** @type {Mesh | null} */
+    _ringMesh = null;
+
+    /** @type {Map<XrInputSource, { entity: Entity, meshInstance: MeshInstance, mesh: Mesh, positions: Float32Array, colorParam: Float32Array, ringEntity: Entity }>} */
+    _arcVisuals = new Map();
+
+    /** @type {Map<XrInputSource, { point: Vec3, valid: boolean }>} */
+    _arcHits = new Map();
+
+    /** @type {Vec3[]} */
+    _arcPoints = [];
+
+    // Y of the ground surface the rig currently stands on (groundHeight or last castRay hit)
+    _currentGroundY = 0;
 
     initialize() {
         if (!this.app.xr) {
@@ -248,7 +417,57 @@ class XrNavigation extends Script {
         // Initialize color objects from Color attributes
         this.validColor.copy(this.validTeleportColor);
         this.invalidColor.copy(this.invalidTeleportColor);
-        this.rayColor.copy(this.controllerRayColor);
+
+        // Pre-allocate arc sample points (arcSegments is read once at initialization)
+        for (let i = 0; i <= this.arcSegments; i++) {
+            this._arcPoints.push(new Vec3());
+        }
+
+        this._currentGroundY = this.groundHeight;
+
+        this._arcMaterial = new ShaderMaterial({
+            uniqueName: 'xr-navigation-arc',
+            vertexGLSL: arcVertexGLSL,
+            fragmentGLSL: arcFragmentGLSL,
+            vertexWGSL: arcVertexWGSL,
+            fragmentWGSL: arcFragmentWGSL,
+            attributes: {
+                vertex_position: SEMANTIC_POSITION,
+                aUv0: SEMANTIC_TEXCOORD0
+            }
+        });
+        this._arcMaterial.blendType = BLEND_NORMAL;
+        this._arcMaterial.cull = CULLFACE_NONE;
+        this._arcMaterial.depthWrite = false;
+        this._arcMaterial.update();
+
+        this._ringMaterial = new ShaderMaterial({
+            uniqueName: 'xr-navigation-ring',
+            vertexGLSL: arcVertexGLSL,
+            fragmentGLSL: ringFragmentGLSL,
+            vertexWGSL: arcVertexWGSL,
+            fragmentWGSL: ringFragmentWGSL,
+            attributes: {
+                vertex_position: SEMANTIC_POSITION,
+                aUv0: SEMANTIC_TEXCOORD0
+            }
+        });
+        this._ringMaterial.blendType = BLEND_NORMAL;
+        this._ringMaterial.cull = CULLFACE_NONE;
+        this._ringMaterial.depthWrite = false;
+        this._ringMaterial.update();
+
+        // Unit quad in XZ, shared by all ring mesh instances. Hold an extra reference so
+        // destroying a ring MeshInstance (input sources are transient on some platforms -
+        // e.g. one per pinch on Apple Vision Pro) cannot drop the refcount to zero and
+        // destroy the shared mesh
+        this._ringMesh = Mesh.fromGeometry(this.app.graphicsDevice, new PlaneGeometry());
+        this._ringMesh.incRefCount();
+
+        const onXrEnd = () => {
+            this._destroyAllArcVisuals();
+        };
+        this.app.xr.on('end', onXrEnd);
 
         // Find camera entity - should be a child of this entity
         const cameraComponent = this.entity.findComponent('camera');
@@ -277,7 +496,7 @@ class XrNavigation extends Script {
             }
         }
 
-        this.app.xr.input.on('add', (inputSource) => {
+        const onInputAdd = (inputSource) => {
             const handleSelectStart = () => {
                 this.activePointers.set(inputSource, true);
             };
@@ -299,9 +518,10 @@ class XrNavigation extends Script {
             // Store the handlers in the map
             this.inputHandlers.set(inputSource, { handleSelectStart, handleSelectEnd });
             this.inputSources.add(inputSource);
-        });
+        };
+        this.app.xr.input.on('add', onInputAdd);
 
-        this.app.xr.input.on('remove', (inputSource) => {
+        const onInputRemove = (inputSource) => {
             const handlers = this.inputHandlers.get(inputSource);
             if (handlers) {
                 inputSource.off('selectstart', handlers.handleSelectStart);
@@ -310,40 +530,140 @@ class XrNavigation extends Script {
             }
             this.activePointers.delete(inputSource);
             this.inputSources.delete(inputSource);
+            this._destroyArcVisual(inputSource);
+        };
+        this.app.xr.input.on('remove', onInputRemove);
+
+        this.once('destroy', () => {
+            this.app.xr.off('end', onXrEnd);
+            this.app.xr.input.off('add', onInputAdd);
+            this.app.xr.input.off('remove', onInputRemove);
+
+            // Detach per-source select handlers
+            for (const [inputSource, handlers] of this.inputHandlers) {
+                inputSource.off('selectstart', handlers.handleSelectStart);
+                inputSource.off('selectend', handlers.handleSelectEnd);
+            }
+            this.inputHandlers.clear();
+            this.activePointers.clear();
+            this.inputSources.clear();
+
+            this._destroyAllArcVisuals();
+            if (this._arcMaterial) {
+                this._arcMaterial.destroy();
+                this._arcMaterial = null;
+            }
+            if (this._ringMaterial) {
+                this._ringMaterial.destroy();
+                this._ringMaterial = null;
+            }
+            if (this._ringMesh) {
+                this._ringMesh.destroy();
+                this._ringMesh = null;
+            }
         });
     }
 
-    findPlaneIntersection(origin, direction) {
-        // Find intersection with y=0 plane
-        if (Math.abs(direction.y) < 0.00001) return null;  // Ray is parallel to plane
+    /**
+     * Returns the world-space point the aim visualization should start from. The target ray
+     * origin sits at the head for gaze/pinch-style input (e.g. Apple Vision Pro transient
+     * pointers), so prefer the handheld grip position when the input source has one.
+     *
+     * @param {XrInputSource} inputSource - The aiming input source.
+     * @returns {Vec3} The world-space start point.
+     * @private
+     */
+    _getAimOrigin(inputSource) {
+        // Copy immediately: getPosition() and getOrigin() return references to the input
+        // source's internal vectors, which the engine reuses as scratch space on the next
+        // getDirection()/getOrigin() call
+        const grip = inputSource.grip ? inputSource.getPosition() : null;
+        return tmpAimOrigin.copy(grip || inputSource.getOrigin());
+    }
 
-        const t = -origin.y / direction.y;
-        if (t < 0) return null;  // Intersection is behind the ray
+    /**
+     * Computes the ballistic teleport arc for the given aim ray, filling {@link _arcPoints}
+     * with world-space samples and writing the landing result into rec. The landing point is
+     * the arc's intersection with the plane at {@link XrNavigation#groundHeight}, or the first
+     * segment hit reported by {@link XrNavigation#castRay} when that is assigned.
+     *
+     * @param {Vec3} origin - World-space start of the aim ray.
+     * @param {Vec3} direction - Normalized aim direction.
+     * @param {{ point: Vec3, valid: boolean }} rec - Receives the landing point and validity.
+     * @private
+     */
+    _computeArcHit(origin, direction, rec) {
+        const segments = this._arcPoints.length - 1;
+        const g = ARC_GRAVITY;
+        const vx = direction.x * this.teleportArcSpeed;
+        const vy = direction.y * this.teleportArcSpeed;
+        const vz = direction.z * this.teleportArcSpeed;
 
-        return new Vec3(
-            origin.x + direction.x * t,
-            0,
-            origin.z + direction.z * t
-        );
+        rec.valid = false;
+
+        // Closed-form flight time to the navigation plane: larger root of
+        // origin.y + vy*t - 0.5*g*t^2 = groundHeight
+        const disc = vy * vy + 2 * g * (origin.y - this.groundHeight);
+        let tFlight = disc >= 0 ? (vy + Math.sqrt(disc)) / g : 0;
+        const planeHit = tFlight > 0.001;
+        if (!planeHit) {
+            // Origin below the plane aiming down - draw a plausible full arc instead
+            tFlight = (2 * this.teleportArcSpeed) / g;
+        }
+
+        for (let i = 0; i <= segments; i++) {
+            const t = (tFlight * i) / segments;
+            this._arcPoints[i].set(
+                origin.x + vx * t,
+                origin.y + vy * t - 0.5 * g * t * t,
+                origin.z + vz * t
+            );
+        }
+
+        if (this.castRay) {
+            // Custom ground detection: the first segment hit wins and truncates the arc there.
+            // Remaining samples collapse onto the hit so the ribbon's quads become degenerate.
+            for (let i = 0; i < segments; i++) {
+                const hit = this.castRay(this._arcPoints[i], this._arcPoints[i + 1]);
+                if (hit) {
+                    rec.point.copy(hit);
+                    for (let j = i + 1; j <= segments; j++) {
+                        this._arcPoints[j].copy(rec.point);
+                    }
+                    rec.valid = this.isValidTeleportDistance(rec.point);
+                    return;
+                }
+            }
+        } else if (planeHit) {
+            rec.point.copy(this._arcPoints[segments]);
+            rec.point.y = this.groundHeight;
+            rec.valid = this.isValidTeleportDistance(rec.point);
+        }
     }
 
     tryTeleport(inputSource) {
-        const origin = inputSource.getOrigin();
-        const direction = inputSource.getDirection();
-
-        const hitPoint = this.findPlaneIntersection(origin, direction);
-        if (hitPoint) {
-            // Adjust for camera's local XZ offset so the user's head ends up at the target
-            if (this.cameraEntity) {
-                const cameraLocalPos = this.cameraEntity.getLocalPosition();
-                hitPoint.x -= cameraLocalPos.x;
-                hitPoint.z -= cameraLocalPos.z;
-            }
-
-            const cameraY = this.entity.getPosition().y;
-            hitPoint.y = cameraY;
-            this.entity.setPosition(hitPoint);
+        let rec = this._arcHits.get(inputSource);
+        if (!rec) {
+            rec = { point: new Vec3(), valid: false };
+            this._arcHits.set(inputSource, rec);
+            this._computeArcHit(this._getAimOrigin(inputSource), inputSource.getDirection(), rec);
         }
+        if (!rec.valid) return;
+
+        const target = this.tmpVec3A.copy(rec.point);
+
+        // Adjust for camera's local XZ offset so the user's head ends up at the target
+        if (this.cameraEntity) {
+            const cameraLocalPos = this.cameraEntity.getLocalPosition();
+            target.x -= cameraLocalPos.x;
+            target.z -= cameraLocalPos.z;
+        }
+
+        // Preserve the rig's height offset above the ground it currently stands on, so castRay
+        // hits on elevated surfaces step the rig up/down while snap vertical offsets carry over
+        target.y = this.entity.getPosition().y + (rec.point.y - this._currentGroundY);
+        this._currentGroundY = rec.point.y;
+        this.entity.setPosition(target);
     }
 
     update(dt) {
@@ -361,9 +681,6 @@ class XrNavigation extends Script {
         if (this.enableTeleport) {
             this.handleTeleportation();
         }
-
-        // Always show controller rays for debugging/visualization
-        this.renderControllerRays();
     }
 
     handleSmoothLocomotion(dt) {
@@ -508,66 +825,190 @@ class XrNavigation extends Script {
 
     handleTeleportation() {
         for (const inputSource of this.inputSources) {
-            // Only show teleportation ray when trigger/select is pressed
-            if (!this.activePointers.get(inputSource)) continue;
+            // Only show the teleport arc while trigger/select is pressed
+            if (!this.activePointers.get(inputSource)) {
+                const visual = this._arcVisuals.get(inputSource);
+                if (visual) {
+                    visual.entity.enabled = false;
+                    visual.ringEntity.enabled = false;
+                }
+                continue;
+            }
 
-            const start = inputSource.getOrigin();
-            const direction = inputSource.getDirection();
+            let rec = this._arcHits.get(inputSource);
+            if (!rec) {
+                rec = { point: new Vec3(), valid: false };
+                this._arcHits.set(inputSource, rec);
+            }
+            this._computeArcHit(this._getAimOrigin(inputSource), inputSource.getDirection(), rec);
 
-            const hitPoint = this.findPlaneIntersection(start, direction);
+            const visual = this._getArcVisual(inputSource);
+            visual.entity.enabled = true;
+            this._updateArcVisual(visual, rec.valid);
 
-            if (hitPoint && this.isValidTeleportDistance(hitPoint)) {
-                // Draw line to intersection point
-                this.app.drawLine(start, hitPoint, this.validColor);
-                this.drawTeleportIndicator(hitPoint);
-            } else {
-                // Draw full length ray if no intersection or invalid distance
-                this.tmpVec3B.copy(direction).mulScalar(this.maxTeleportDistance).add(start);
-                this.app.drawLine(start, this.tmpVec3B, this.invalidColor);
+            visual.ringEntity.enabled = rec.valid;
+            if (rec.valid) {
+                // Slightly above ground to avoid z-fighting
+                visual.ringEntity.setPosition(rec.point.x, rec.point.y + 0.01, rec.point.z);
+                const diameter = this.teleportIndicatorRadius * 2;
+                visual.ringEntity.setLocalScale(diameter, 1, diameter);
             }
         }
     }
 
-    renderControllerRays() {
-        // Only render controller rays when smooth movement is enabled
-        // (teleport rays are handled separately in handleTeleportation)
-        if (!this.enableMove) return;
+    /**
+     * Returns the arc ribbon visual for an input source, creating it on first use.
+     *
+     * @param {XrInputSource} inputSource - The aiming input source.
+     * @returns {{ entity: Entity, meshInstance: MeshInstance, mesh: Mesh, positions: Float32Array, colorParam: Float32Array }} The visual.
+     * @private
+     */
+    _getArcVisual(inputSource) {
+        let visual = this._arcVisuals.get(inputSource);
+        if (visual) return visual;
 
-        for (const inputSource of this.inputSources) {
-            // Skip if currently teleporting (handled by handleTeleportation)
-            if (this.activePointers.get(inputSource)) continue;
+        const segments = this._arcPoints.length - 1;
+        const vertexCount = (segments + 1) * 2;
 
-            const start = inputSource.getOrigin();
-            this.tmpVec3B.copy(inputSource.getDirection()).mulScalar(2).add(start);
-            this.app.drawLine(start, this.tmpVec3B, this.rayColor);
+        // Positions change per frame; UVs (x along the arc, y across the ribbon) and the
+        // quad-strip index list are static
+        const positions = new Float32Array(vertexCount * 3);
+        const uvs = new Float32Array(vertexCount * 2);
+        const indices = new Uint16Array(segments * 6);
+
+        for (let i = 0; i <= segments; i++) {
+            const u = i / segments;
+            uvs[i * 4 + 0] = u;
+            uvs[i * 4 + 1] = 0;
+            uvs[i * 4 + 2] = u;
+            uvs[i * 4 + 3] = 1;
+        }
+        for (let i = 0; i < segments; i++) {
+            const v = i * 2;
+            indices[i * 6 + 0] = v;
+            indices[i * 6 + 1] = v + 1;
+            indices[i * 6 + 2] = v + 2;
+            indices[i * 6 + 3] = v + 1;
+            indices[i * 6 + 4] = v + 3;
+            indices[i * 6 + 5] = v + 2;
+        }
+
+        const mesh = new Mesh(this.app.graphicsDevice);
+        mesh.clear(true, false);
+        mesh.setPositions(positions);
+        mesh.setUvs(0, uvs);
+        mesh.setIndices(indices);
+        mesh.update(PRIMITIVE_TRIANGLES);
+
+        const meshInstance = new MeshInstance(mesh, this._arcMaterial);
+        meshInstance.pick = false;
+
+        const entity = new Entity('XrNavigationArc');
+        entity.addComponent('render', { castShadows: false });
+        entity.render.meshInstances = [meshInstance];
+        this.app.root.addChild(entity);
+
+        const colorParam = new Float32Array(4);
+
+        // Target indicator: a flat quad whose shader draws a soft glowing ring. Shares the
+        // arc's color parameter array - it is only visible on valid (green) landings anyway
+        const ringMeshInstance = new MeshInstance(this._ringMesh, this._ringMaterial);
+        ringMeshInstance.pick = false;
+        ringMeshInstance.setParameter('uColor', colorParam);
+
+        const ringEntity = new Entity('XrNavigationRing');
+        ringEntity.addComponent('render', { castShadows: false });
+        ringEntity.render.meshInstances = [ringMeshInstance];
+        ringEntity.enabled = false;
+        this.app.root.addChild(ringEntity);
+
+        visual = { entity, meshInstance, mesh, positions, colorParam, ringEntity };
+        this._arcVisuals.set(inputSource, visual);
+        return visual;
+    }
+
+    /**
+     * Rebuilds the ribbon vertices from the current {@link _arcPoints} samples and applies the
+     * valid/invalid color. Each arc point becomes a vertex pair offset sideways, with the
+     * ribbon billboarded toward the camera.
+     *
+     * @param {{ entity: Entity, meshInstance: MeshInstance, mesh: Mesh, positions: Float32Array, colorParam: Float32Array }} visual - The arc visual.
+     * @param {boolean} valid - Whether the current landing point is a valid teleport target.
+     * @private
+     */
+    _updateArcVisual(visual, valid) {
+        const points = this._arcPoints;
+        const segments = points.length - 1;
+        const positions = visual.positions;
+        const camPos = this.cameraEntity ? this.cameraEntity.getPosition() : this.entity.getPosition();
+        const halfWidth = this.arcWidth * 0.5;
+
+        for (let i = 0; i <= segments; i++) {
+            const point = points[i];
+
+            // Segment direction (backward difference at the last point)
+            if (i < segments) {
+                tmpSegDir.sub2(points[i + 1], point);
+            } else {
+                tmpSegDir.sub2(point, points[i - 1]);
+            }
+
+            tmpToCam.sub2(camPos, point);
+            tmpSide.cross(tmpSegDir, tmpToCam);
+            const len = tmpSide.length();
+            if (len > 1e-6) {
+                tmpSide.mulScalar(halfWidth / len);
+            } else {
+                // Degenerate (collapsed samples past a castRay hit) - direction is irrelevant
+                tmpSide.set(halfWidth, 0, 0);
+            }
+
+            const base = i * 6;
+            positions[base + 0] = point.x - tmpSide.x;
+            positions[base + 1] = point.y - tmpSide.y;
+            positions[base + 2] = point.z - tmpSide.z;
+            positions[base + 3] = point.x + tmpSide.x;
+            positions[base + 4] = point.y + tmpSide.y;
+            positions[base + 5] = point.z + tmpSide.z;
+        }
+
+        visual.mesh.setPositions(positions);
+        visual.mesh.update(PRIMITIVE_TRIANGLES);
+
+        const color = valid ? this.validColor : this.invalidColor;
+        visual.colorParam[0] = color.r;
+        visual.colorParam[1] = color.g;
+        visual.colorParam[2] = color.b;
+        visual.colorParam[3] = color.a;
+        visual.meshInstance.setParameter('uColor', visual.colorParam);
+    }
+
+    /**
+     * Destroys the arc visual associated with an input source, if any.
+     *
+     * @param {XrInputSource} inputSource - The input source.
+     * @private
+     */
+    _destroyArcVisual(inputSource) {
+        const visual = this._arcVisuals.get(inputSource);
+        if (!visual) return;
+
+        visual.entity.destroy();
+        visual.ringEntity.destroy();
+        this._arcVisuals.delete(inputSource);
+        this._arcHits.delete(inputSource);
+    }
+
+    /** @private */
+    _destroyAllArcVisuals() {
+        for (const inputSource of this._arcVisuals.keys()) {
+            this._destroyArcVisual(inputSource);
         }
     }
 
     isValidTeleportDistance(hitPoint) {
         const distance = hitPoint.distance(this.entity.getPosition());
         return distance <= this.maxTeleportDistance;
-    }
-
-    drawTeleportIndicator(point) {
-        // Draw a circle at the teleport point using configurable attributes
-        const segments = this.teleportIndicatorSegments;
-        const radius = this.teleportIndicatorRadius;
-
-        for (let i = 0; i < segments; i++) {
-            const angle1 = (i / segments) * Math.PI * 2;
-            const angle2 = ((i + 1) / segments) * Math.PI * 2;
-
-            const x1 = point.x + Math.cos(angle1) * radius;
-            const z1 = point.z + Math.sin(angle1) * radius;
-            const x2 = point.x + Math.cos(angle2) * radius;
-            const z2 = point.z + Math.sin(angle2) * radius;
-
-            // Use pre-allocated vectors to avoid garbage collection
-            this.tmpVec3A.set(x1, 0.01, z1);  // Slightly above ground to avoid z-fighting
-            this.tmpVec3B.set(x2, 0.01, z2);
-
-            this.app.drawLine(this.tmpVec3A, this.tmpVec3B, this.validColor);
-        }
     }
 }
 


### PR DESCRIPTION
## Description

Upgrades the `XrNavigation` script's teleport visualization from debug-style `drawLine` rendering to a modern, Quest-style presentation — with no physics-engine dependency.

**Visuals**
- Teleport aim is a **ballistic parabolic arc** rendered as a glowing soft-edged ribbon mesh: camera-billboarded, alpha-faded across its width and at both ends, updated in place each frame with no per-frame allocation.
- The landing indicator is a **shader-drawn glowing ring** (flat quad, radial-gradient fragment shader) instead of a 16-segment line circle.
- Shaders are provided in both GLSL and WGSL (verified on WebGL2 and WebGPU).
- Softer default colors: cyan-white valid / muted salmon invalid, in the same family as `XrMenu`'s hover cyan. Still overridable via the existing color attributes.
- The always-on white controller rays are removed — matching platform conventions (nothing shown while idle; pointer beams are a UI concern, and `XrMenu` does its own picking/hover feedback).

**Ground detection**
- Flat navigation plane at a new configurable `groundHeight` attribute (previously hardcoded y=0).
- New public `castRay` property (`(start, end) => Vec3 | null`, not an attribute since functions aren't serializable): when assigned, the arc is tested segment-by-segment against it, so apps with physics or custom picking can supply real ground detection. Landings on elevated surfaces step the rig up/down correctly without accumulating offset.

**Correctness fixes picked up along the way**
- Teleport commit and visualization share the same arc computation, so you land exactly where the arc shows. This also fixes a pre-existing inconsistency where you could teleport beyond `maxTeleportDistance` even though the ray rendered as invalid.
- Aim originates from the grip position when available: the WebXR target-ray origin sits at the head for gaze/pinch-style input (e.g. Apple Vision Pro transient pointers), which previously made the ray appear to come from the user's eyes.
- The shared ring mesh holds an extra refcount so transient input sources (one per pinch on visionOS) can't destroy it on removal — without this, the second pinch rendered a destroyed mesh and blacked out the frame.
- All event handlers (`xr.input` add/remove, `xr` end, per-source select handlers) and all created meshes/materials/entities are now released on script destroy.

**API changes**
- New attributes: `groundHeight`, `teleportArcSpeed`, `arcWidth`, `arcSegments`; new property: `castRay`.
- Removed attributes (breaking): `controllerRayColor`, `teleportIndicatorSegments`. No examples referenced either.

Tested in the examples browser (xr/xr-menu) on WebGL2 and WebGPU, and on-device: arc/ring states, valid/invalid coloring, teleport landing accuracy, `castRay` truncation on elevated surfaces, transient-pointer pinch cycles, and resource cleanup.

Relies on the `Mesh.clear()` dynamic-flag fix (#9023) for the arc ribbon's vertex buffer to be created with `BUFFER_DYNAMIC` usage as documented.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)