### PR TITLE
Fix XrNavigation castRay plane coupling and stale teleport cache

### DIFF
--- a/scripts/esm/xr-navigation.mjs
+++ b/scripts/esm/xr-navigation.mjs
@@ -501,6 +501,11 @@ class XrNavigation extends Script {
         const onInputAdd = (inputSource) => {
             const handleSelectStart = () => {
                 this.activePointers.set(inputSource, true);
+                // Invalidate any hit cached from a previous aim session, so a select that
+                // starts and ends before the next update cannot teleport to a stale target.
+                // tryTeleport recomputes when no cached hit exists; otherwise it commits the
+                // last visualized hit, which is immune to the ray flicking on pinch release
+                this._arcHits.delete(inputSource);
             };
 
             const handleSelectEnd = () => {
@@ -590,9 +595,10 @@ class XrNavigation extends Script {
         if (!grip) return;
 
         // Aim point: where the target ray meets the navigation plane, or a far point along
-        // the ray when it never descends to it
+        // the ray when it never descends to it. When castRay replaces plane detection, the
+        // plane is meaningless for aiming, so always use the far point
         let t = this.maxTeleportDistance;
-        if (tmpAimDir.y < -0.001) {
+        if (!this.castRay && tmpAimDir.y < -0.001) {
             const tPlane = (tmpAimOrigin.y - this.groundHeight) / -tmpAimDir.y;
             if (tPlane > 0 && tPlane < this.maxTeleportDistance * 2) {
                 t = tPlane;
@@ -624,14 +630,24 @@ class XrNavigation extends Script {
 
         rec.valid = false;
 
-        // Closed-form flight time to the navigation plane: larger root of
-        // origin.y + vy*t - 0.5*g*t^2 = groundHeight
-        const disc = vy * vy + 2 * g * (origin.y - this.groundHeight);
-        let tFlight = disc >= 0 ? (vy + Math.sqrt(disc)) / g : 0;
-        const planeHit = tFlight > 0.001;
-        if (!planeHit) {
-            // Origin below the plane aiming down - draw a plausible full arc instead
-            tFlight = (2 * this.teleportArcSpeed) / g;
+        let tFlight;
+        let planeHit = false;
+        if (this.castRay) {
+            // castRay replaces plane detection, so the sampling window must not stop at the
+            // plane (hits below groundHeight would be unreachable). Fly until the arc has
+            // descended maxTeleportDistance below the origin - anything deeper would fail
+            // the distance check anyway
+            tFlight = (vy + Math.sqrt(vy * vy + 2 * g * this.maxTeleportDistance)) / g;
+        } else {
+            // Closed-form flight time to the navigation plane: larger root of
+            // origin.y + vy*t - 0.5*g*t^2 = groundHeight
+            const disc = vy * vy + 2 * g * (origin.y - this.groundHeight);
+            tFlight = disc >= 0 ? (vy + Math.sqrt(disc)) / g : 0;
+            planeHit = tFlight > 0.001;
+            if (!planeHit) {
+                // Origin below the plane aiming down - draw a plausible full arc instead
+                tFlight = (2 * this.teleportArcSpeed) / g;
+            }
         }
 
         for (let i = 0; i <= segments; i++) {

--- a/scripts/esm/xr-navigation.mjs
+++ b/scripts/esm/xr-navigation.mjs
@@ -634,10 +634,13 @@ class XrNavigation extends Script {
         let planeHit = false;
         if (this.castRay) {
             // castRay replaces plane detection, so the sampling window must not stop at the
-            // plane (hits below groundHeight would be unreachable). Fly until the arc has
-            // descended maxTeleportDistance below the origin - anything deeper would fail
-            // the distance check anyway
-            tFlight = (vy + Math.sqrt(vy * vy + 2 * g * this.maxTeleportDistance)) / g;
+            // plane (hits below groundHeight would be unreachable). Fly until the arc reaches
+            // the deepest point that could still pass the distance check - that check measures
+            // from the rig position, which sits below the aim origin (the grip), so descend
+            // maxTeleportDistance below the rig, not below the origin
+            const fallDepth = this.maxTeleportDistance +
+                Math.max(0, origin.y - this.entity.getPosition().y);
+            tFlight = (vy + Math.sqrt(vy * vy + 2 * g * fallDepth)) / g;
         } else {
             // Closed-form flight time to the navigation plane: larger root of
             // origin.y + vy*t - 0.5*g*t^2 = groundHeight


### PR DESCRIPTION
## Description

Follow-up to #9024, addressing the three review comments that landed post-merge. All three were valid:

1. **`_getAimRay` aimed via the `groundHeight` plane even when `castRay` was assigned.** `castRay` is documented as fully replacing plane-based ground detection, but the re-aim heuristic (used for head-anchored target rays, e.g. Apple Vision Pro) still picked its aim point from the plane, skewing the launch direction when the app's real ground differed from `groundHeight`. With `castRay` set, the aim point is now simply a far point (`maxTeleportDistance`) along the target ray.

2. **`_computeArcHit` clamped the arc sampling window to the `groundHeight` plane even when `castRay` was assigned**, so `castRay` could never report hits on surfaces below `groundHeight`. The sampling window is now derived from ballistics alone in that case: the arc flies until it has descended `maxTeleportDistance` below the origin (anything deeper would fail the distance-validity check regardless).

3. **A quick select could teleport to a stale target.** `tryTeleport()` reused the hit cached by a previous aim session when selectstart→selectend happened before the next update. The cache is now invalidated on `selectstart`, so a no-frame pinch recomputes from the current pose. Deliberately *not* recomputing on every selectend (as originally suggested): when a frame did render, committing the last **visualized** hit keeps the landing immune to the ray flicking as a hand-tracking pinch releases.

Verified in the examples browser by driving the script through its real `xr.input` add/selectstart/selectend handlers: castRay hits at y=−2 with `groundHeight` 0 now land (previously unreachable); landings with `castRay` set are identical for `groundHeight` 0 vs 5; and a quick pinch with a flipped pose lands at the new pose's target instead of the stale one. Lint passes.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)