### PR TITLE
Fix ProceduralSky light drifting off the visible sun near sunset

### DIFF
--- a/scripts/esm/sky/procedural-sky.mjs
+++ b/scripts/esm/sky/procedural-sky.mjs
@@ -879,8 +879,10 @@ class ProceduralSky extends Script {
             this._baseSunIntensity = light.intensity;
         }
 
-        // crossfade the key light from the sun (day) to the dim cold moon from above (night)
-        const nightFactor = Math.max(0, Math.min(1, (3 - this.elevation) / 6));
+        // crossfade the key light from the sun (day) to the dim cold moon from above (night).
+        // The crossfade only starts once the sun dips below the horizon, so while the sun is
+        // visible the light direction matches it exactly (specular reflections line up)
+        const nightFactor = Math.max(0, Math.min(1, -this.elevation / 6));
 
         // light source direction: towards the sun by day, towards the moon by night
         tmpMoon.copy(this.moonDirection).normalize();


### PR DESCRIPTION
The ProceduralSky script crossfades the directional light from the sun to the moon for the night. The crossfade started at +3° sun elevation, so near sunset the light direction was already partially blended towards the (typically high) moon while the sun disk was still visible at the horizon - specular reflections (e.g. sun glints on water) and shadows visibly drifted away from the visible sun.

**Changes:**
- The sun-to-moon crossfade now starts only once the sun dips below the horizon (elevation 0°), fading over the following 6°. While the sun is visible, the light direction, color and intensity track it exactly; the moon takes over during the invisible part of twilight.