### PR TITLE
Fix crash when unloading sog assets still referenced by the unified world

### DIFF
--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -261,8 +261,9 @@ class SogBundleParser {
             let ownedByResource = false;
 
             // When the parent gsplat asset unloads, remove child texture assets from the
-            // registry. Destroy their texture resources only while the load is still in flight
-            // (cancellation); once owned by the resource, destruction is left to it.
+            // registry. Destroy their texture resources only until GSplatSogResource ownership
+            // has been transferred (cancellation before ownership transfer); once owned by the
+            // resource, destruction is left to it.
             asset.once('unload', () => {
                 Object.values(textures).forEach((t) => {
                     // remove from registry

--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -255,13 +255,23 @@ class SogBundleParser {
 
             const { assets } = this.app;
 
+            // Set once the GSplatSogResource takes ownership of the textures: from then on they
+            // may only be destroyed through the resource's (ref-count deferred) destroy, as the
+            // unified world may still be rendering from them when the asset unloads.
+            let ownedByResource = false;
+
+            // When the parent gsplat asset unloads, remove child texture assets from the
+            // registry. Destroy their texture resources only while the load is still in flight
+            // (cancellation); once owned by the resource, destruction is left to it.
             asset.once('unload', () => {
                 Object.values(textures).forEach((t) => {
                     // remove from registry
                     assets.remove(t);
 
-                    // destroy texture resource
-                    t.unload();
+                    if (!ownedByResource) {
+                        // destroy texture resource
+                        t.unload();
+                    }
                 });
             });
 
@@ -293,6 +303,10 @@ class SogBundleParser {
             const resource = decompress ?
                 new GSplatResource(this.app.graphicsDevice, await data.decompress(), { prepareCenters }) :
                 new GSplatSogResource(this.app.graphicsDevice, data, { prepareCenters });
+
+            // the sog resource now owns the textures in `data` (when decompressing, the
+            // decompressed data was copied out instead and the textures stay with the assets)
+            ownedByResource = !decompress;
 
             callback(null, resource);
         } catch (err) {

--- a/src/framework/parsers/sog.js
+++ b/src/framework/parsers/sog.js
@@ -164,7 +164,14 @@ class SogParser {
         // Track if asset was unloaded during async loading
         let unloaded = false;
 
-        // When the parent gsplat asset unloads, remove and unload child texture assets
+        // Set once the GSplatSogResource takes ownership of the textures: from then on they may
+        // only be destroyed through the resource's (ref-count deferred) destroy, as the unified
+        // world may still be rendering from them when the asset unloads.
+        let ownedByResource = false;
+
+        // When the parent gsplat asset unloads, remove child texture assets from the registry.
+        // Destroy their texture resources only while the load is still in flight (cancellation);
+        // once owned by the resource, destruction is left to it.
         asset.once('unload', () => {
             unloaded = true;
 
@@ -172,8 +179,10 @@ class SogParser {
                 // remove from registry
                 assets.remove(t);
 
-                // destroys resource
-                t.unload();
+                if (!ownedByResource) {
+                    // destroys resource
+                    t.unload();
+                }
             });
         });
 
@@ -234,6 +243,10 @@ class SogParser {
         const resource = decompress ?
             new GSplatResource(this.app.graphicsDevice, await data.decompress(), { prepareCenters }) :
             new GSplatSogResource(this.app.graphicsDevice, data, { prepareCenters });
+
+        // the sog resource now owns the textures in `data` (when decompressing, the decompressed
+        // data was copied out instead and the textures stay with the texture assets)
+        ownedByResource = !decompress;
 
         if (this._shouldAbort(asset, unloaded)) {
             resource.destroy();


### PR DESCRIPTION
Unloading a sog-based gsplat asset destroyed its source webp textures immediately, even while the unified gsplat world was still rendering from them. The sog parsers register an asset.once('unload') handler that unloads the child texture assets, which bypasses resource ref-counting entirely: GSplatResourceBase.destroy() correctly defers GPU destruction while refCount > 0 (via GSplatResourceCleanup), but the parser-level handler killed the textures out-of-band.

This crashes when an octree (lod-meta) asset is unloaded to switch views: GSplatOctreeResource.destroy() → octree.destroy() → assetLoader.destroy() force-unloads every node-file asset while world states still hold refs to their resources, and the work-buffer bake re-reads the sog textures (camera movement alone queues SH color re-renders). On WebGPU the bake binds the destroyed textures: NULL texture view asserts, an uncaught exception inside GSplatWorkBufferRenderPass, and unrecoverable pass-state corruption ("submit while inside a pass" cascades). The streaming per-file unload on LOD transitions has the same hazard. It only reproduces when other unified splats keep the world alive across the unload (e.g. permanent standalone splats in the scene); with no remaining placements the manager is torn down and nothing bakes the stale state.

The fix moves texture ownership to the resource: once GSplatSogResource is constructed, the parser's unload handler only removes the child texture assets from the registry, and the textures are destroyed solely by the resource's ref-count deferred _actualDestroy() (via GSplatSogData.destroy(), which already covers all source textures plus the codebook). While the load is still in flight the handler behaves as before, unloading the textures to cancel the load. The decompress path is unchanged, as ownership never transfers to the resource there.

Applies to both the sog.js and sog-bundle.js parsers.