### PR TITLE
Fix GPU device hang when picking gsplats on Windows/NVIDIA

### DIFF
--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -473,6 +473,20 @@ class GSplatHybridRenderer extends GSplatRenderer {
             sortIndirectInfo
         );
 
+        // Workaround for a device hang on Windows/NVIDIA (Dawn/D3D12): in the picking path, the
+        // sort's indirect dispatch args written above (by the interval compaction and projector
+        // writeIndirectArgs compute passes) are intermittently not visible to the
+        // dispatchWorkgroupsIndirect calls recorded in the same command buffer — the sort then
+        // runs with the previous frame's (larger) workgroup counts, and OneSweep's chained
+        // lookback spins forever on partitions that never publish, hanging the device
+        // (DXGI_ERROR_DEVICE_HUNG). Submitting pending work here places the args writes and the
+        // sort dispatches in separate submissions, which reliably avoids the stale read. Scoped
+        // to picking: the per-frame forward path has never exhibited the issue, and this keeps
+        // its work in a single submission.
+        if (pickMode) {
+            this.device.submit();
+        }
+
         return gpuSorter.sortIndirect(
             /** @type {StorageBuffer} */ (projector.sortKeys),
             elementCount,


### PR DESCRIPTION
Fixes a GPU device hang (`DXGI_ERROR_DEVICE_HUNG`, followed by context loss) when picking gsplats rendered by the GPU-sort renderer on Windows/NVIDIA with WebGPU. Reproduced on two NVIDIA (Turing) machines via the `gaussian-splatting/picking` example and supersplat-viewer; not reproducible on macOS.

Fixes #8963

**Cause:**
The pick path re-runs the GPU pipeline (cull → projection → indirect radix sort) for the picker camera in its own submission. On Dawn/D3D12, the sort's GPU-written indirect dispatch args were intermittently not visible to the `dispatchWorkgroupsIndirect` calls recorded in the same command buffer — diagnostics showed the indirect args buffer still holding the previous frame's (much larger) workgroup counts, while regular storage-buffer writes from the same compute invocation landed correctly. The over-dispatched OneSweep binning pass then spun forever in its chained-scan lookback on partitions that never publish, triggering the Windows TDR.

**Changes:**
- In the picking path, submit pending command buffers before encoding the radix sort dispatches, so the indirect-args writes and the dispatches that consume them land in separate submissions. Verified on the affected hardware: with the split submission the stale read no longer occurs (~30 picks, zero stalls), without it the stall reproduced on most picks.
- Scoped to picking only — the per-frame forward path has never exhibited the issue and keeps its single-submission batching. Picks are infrequent, so the extra submit has no practical cost.

A follow-up Dawn/Chromium bug report is planned for the underlying same-command-buffer indirect-args visibility issue.