### PR TITLE
Fix sog streaming re-load returning destroyed textures from loader cache

### DIFF
--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -209,6 +209,12 @@ class SogBundleParser {
                     if (!ownedByResource) {
                         // destroy texture resource
                         t.unload();
+                    } else {
+                        // The resource destroys the textures (possibly deferred), but they stay
+                        // in the loader cache as t.unload() is not called. Clear the cache
+                        // entries so a later load of the same urls recreates the textures
+                        // instead of reusing the cached, destroyed ones.
+                        assets._loader.clearCache(t.getFileUrl(), t.type);
                     }
                 });
             });

--- a/src/framework/parsers/sog.js
+++ b/src/framework/parsers/sog.js
@@ -182,6 +182,12 @@ class SogParser {
                 if (!ownedByResource) {
                     // destroys resource
                     t.unload();
+                } else {
+                    // The resource destroys the textures (possibly deferred), but they stay in
+                    // the loader cache as t.unload() is not called. Clear the cache entries so
+                    // a later load of the same urls recreates the textures instead of reusing
+                    // the cached, destroyed ones.
+                    assets._loader.clearCache(t.getFileUrl(), t.type);
                 }
             });
         });


### PR DESCRIPTION
Fixes a regression from #9035 that broke the load-streaming example on WebGL: the initial load worked, but as cells streamed out and back in, loads failed with `getCenters` / "V2 asset is missing codebookTexture" asserts and resources built over destroyed textures.

Since #9035, when a sog asset unloads after its `GSplatSogResource` has taken ownership of the textures, the unload handler intentionally skips `t.unload()` so the (possibly deferred) resource destroy is the only thing that destroys them. However, `Asset.unload()` was also what cleared the `ResourceLoader` cache — so the texture URLs stayed cached. Once the resource's destroy ran, the cache held destroyed textures (`texture.device === null`), and when streaming brought the same cell back, the loader returned them instantly. `prepareCodebook()` / `prepareGpuData()` then early-return on the null device, leaving the new resource without centers or a codebook texture.

**Changes:**
- `sog.js` / `sog-bundle.js`: when the parent asset unloads after texture ownership has transferred to the resource, explicitly clear the loader cache entry for each child texture asset (`clearCache(url, type)`). A later load of the same urls re-downloads and recreates the textures instead of reusing the cached, destroyed ones, while texture destruction still goes exclusively through the resource's ref-count-deferred destroy that #9035 introduced.

Verified with the load-streaming example (streaming cells out and back in on WebGL) and with a scripted load → unload → re-load cycle of a `.sog` bundle: the re-created resource has live textures, centers and codebook, with no asserts.