### PR TITLE
Rename gsplat script classes to match core GSplat casing

### DIFF
--- a/examples/src/examples/gaussian-splatting/crop.example.mjs
+++ b/examples/src/examples/gaussian-splatting/crop.example.mjs
@@ -27,7 +27,7 @@ import {
     TouchDevice,
     createGraphicsDevice
 } from 'playcanvas';
-import { GsplatCropShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-crop.mjs';
+import { GSplatCropShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-crop.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -114,7 +114,7 @@ app.root.addChild(hotel);
 hotel.addComponent('script');
 
 // Create the crop effect script
-const cropScript = hotel.script?.create(GsplatCropShaderEffect);
+const cropScript = hotel.script?.create(GSplatCropShaderEffect);
 
 // Set initial edge scale factor
 if (cropScript) {

--- a/examples/src/examples/gaussian-splatting/downtown.example.mjs
+++ b/examples/src/examples/gaussian-splatting/downtown.example.mjs
@@ -56,7 +56,7 @@ import {
     platform
 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
-import { GsplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
+import { GSplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -225,7 +225,7 @@ const camStart = new Vec3(config.cameraPosition[0], config.cameraPosition[1], co
 const revealReach = camStart.distance(center) + radius; // furthest splat from the camera start
 const revealHost = /** @type {Entity} */ (root.children[0]);
 revealHost.addComponent('script');
-const reveal = /** @type {any} */ (/** @type {any} */ (revealHost.script).create(GsplatRevealRadial));
+const reveal = /** @type {any} */ (/** @type {any} */ (revealHost.script).create(GSplatRevealRadial));
 reveal.center.copy(camStart);
 reveal.endRadius = revealReach * 1.1; // reaches the whole scene from the camera start
 reveal.speed = (revealReach * 1.1) / 3; // sweep across in ~3s

--- a/examples/src/examples/gaussian-splatting/flipbook.example.mjs
+++ b/examples/src/examples/gaussian-splatting/flipbook.example.mjs
@@ -43,7 +43,7 @@ import {
     Vec3,
     createGraphicsDevice
 } from 'playcanvas';
-import { GsplatFlipbook } from 'playcanvas/scripts/esm/gsplat/gsplat-flipbook.mjs';
+import { GSplatFlipbook } from 'playcanvas/scripts/esm/gsplat/gsplat-flipbook.mjs';
 import { ShadowCatcher } from 'playcanvas/scripts/esm/shadow-catcher.mjs';
 
 import { data, deviceType } from 'examples/context';
@@ -156,7 +156,7 @@ player.addComponent('gsplat', {
     castShadows: true
 });
 player.addComponent('script');
-const flipbook = player.script.create(GsplatFlipbook);
+const flipbook = player.script.create(GSplatFlipbook);
 if (flipbook) {
     flipbook.fps = 15;
     flipbook.folder = 'https://code.playcanvas.com/examples_data/example_basketball_02';

--- a/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming-sh.example.mjs
@@ -38,7 +38,7 @@ import {
     platform
 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
-import { GsplatRevealGridEruption } from 'playcanvas/scripts/esm/gsplat/reveal-grid-eruption.mjs';
+import { GSplatRevealGridEruption } from 'playcanvas/scripts/esm/gsplat/reveal-grid-eruption.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -232,9 +232,9 @@ camera.setLocalPosition(camX, camY, camZ);
 
 app.root.addChild(camera);
 
-// Add the GsplatRevealGridEruption script to the gsplat entity
+// Add the GSplatRevealGridEruption script to the gsplat entity
 entity.addComponent('script');
-const revealScript = entity.script?.create(GsplatRevealGridEruption);
+const revealScript = entity.script?.create(GSplatRevealGridEruption);
 if (revealScript) {
     revealScript.center.set(focusX, focusY, focusZ);
     revealScript.blockCount = 6;

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -50,7 +50,7 @@ import {
     platform
 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
-import { GsplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
+import { GSplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
 
 import { data, deviceType, win } from 'examples/context';
 
@@ -433,7 +433,7 @@ data.on('environment:set', () => {
     });
 });
 
-// Gsplat loading state
+// GSplat loading state
 /** @type {Entity|null} */
 let gsplatEntity = null;
 /** @type {any} */
@@ -454,7 +454,7 @@ const applyPreset = () => {
     data.set('lodMultiplier', presetData.lodMultiplier);
 };
 
-const loadGsplat = async (/** @type {string|null} */ url) => {
+const loadGSplat = async (/** @type {string|null} */ url) => {
     if (gsplatEntity) {
         gsplatEntity.destroy();
         gsplatEntity = null;
@@ -522,7 +522,7 @@ const loadGsplat = async (/** @type {string|null} */ url) => {
 
     // Radial reveal effect
     gsplatEntity.addComponent('script');
-    const revealScript = gsplatEntity.script?.create(GsplatRevealRadial);
+    const revealScript = gsplatEntity.script?.create(GSplatRevealRadial);
     if (revealScript) {
         revealScript.center.set(focusX, focusY, focusZ);
         revealScript.speed = 5;
@@ -535,7 +535,7 @@ const loadGsplat = async (/** @type {string|null} */ url) => {
 
 // Initial load — use the observer's current url, which is paramUrl from the
 // hash query if set, or the share-URL state value applied during app.start().
-await loadGsplat(data.get('url') || null);
+await loadGSplat(data.get('url') || null);
 
 data.on('lodPreset:set', applyPreset);
 
@@ -562,9 +562,9 @@ data.on('orientation:set', () => {
 
 data.on('url:set', () => {
     const url = data.get('url');
-    loadGsplat(url || null).catch((err) => {
+    loadGSplat(url || null).catch((err) => {
         console.warn('Loading failed, reverting to default:', err);
-        loadGsplat(null);
+        loadGSplat(null);
     });
 });
 

--- a/examples/src/examples/gaussian-splatting/procedural-mesh.example.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-mesh.example.mjs
@@ -34,8 +34,8 @@ import {
     TouchDevice,
     createGraphicsDevice
 } from 'playcanvas';
-import { GsplatMesh } from 'playcanvas/scripts/esm/gsplat/gsplat-mesh.mjs';
-import { GsplatBoxShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-box.mjs';
+import { GSplatMesh } from 'playcanvas/scripts/esm/gsplat/gsplat-mesh.mjs';
+import { GSplatBoxShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-box.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -130,11 +130,11 @@ srcClouds.forEach((cloud) => {
 
 // Create gsplat entity for terrain (without clouds) - attach as child of terrain
 // so it inherits the terrain's transform (scale 30)
-const gsplatTerrain = new Entity('GsplatTerrain');
+const gsplatTerrain = new Entity('GSplatTerrain');
 gsplatTerrain.addComponent('script');
 terrain.addChild(gsplatTerrain);
 
-const gsplatMeshTerrain = gsplatTerrain.script.create(GsplatMesh);
+const gsplatMeshTerrain = gsplatTerrain.script.create(GSplatMesh);
 gsplatMeshTerrain.buildFromEntity(terrain, {
     splatSize: 0.03,
     margin: 0,
@@ -142,7 +142,7 @@ gsplatMeshTerrain.buildFromEntity(terrain, {
 });
 
 // Add reveal effect to terrain
-const revealScript = gsplatTerrain.script.create(GsplatBoxShaderEffect);
+const revealScript = gsplatTerrain.script.create(GSplatBoxShaderEffect);
 revealScript.aabbMin.set(-1000, -200, -1000);
 revealScript.aabbMax.set(1000, 250, 1000);
 revealScript.direction.set(0, 1, 0);
@@ -155,7 +155,7 @@ revealScript.edgeTint.set(5, 2, 0); // orange/gold edge
 revealScript.tint.set(1, 1, 1);
 
 // Now disable the original terrain render components (keep gsplat visible)
-const terrainRenders = terrain.find((node) => node.render && !node.name.includes('Gsplat'));
+const terrainRenders = terrain.find((node) => node.render && !node.name.includes('GSplat'));
 terrainRenders.forEach((node) => {
     node.render.enabled = false;
 });
@@ -183,12 +183,12 @@ srcClouds.forEach((srcCloud, srcIndex) => {
 
     // Create the first gsplat entity with script to build the gsplat
     // Position it same as the source cloud
-    const gsplatCloud = new Entity(`GsplatCloud-${srcIndex}-0`);
+    const gsplatCloud = new Entity(`GSplatCloud-${srcIndex}-0`);
     gsplatCloud.addComponent('script');
     cloudParent.addChild(gsplatCloud);
 
     // Build gsplat from the source cloud entity
-    const gsplatMeshCloud = gsplatCloud.script.create(GsplatMesh);
+    const gsplatMeshCloud = gsplatCloud.script.create(GSplatMesh);
     gsplatMeshCloud.buildFromEntity(srcCloud, {
         splatSize: 0.15, // Larger splats for fluffy cloud look
         margin: 0, // No margin - allow splats to extend to edges
@@ -205,7 +205,7 @@ srcClouds.forEach((srcCloud, srcIndex) => {
 
     // Create 3 more gsplat entities sharing the same container
     for (let i = 1; i < 4; i++) {
-        const cloneCloud = new Entity(`GsplatCloud-${srcIndex}-${i}`);
+        const cloneCloud = new Entity(`GSplatCloud-${srcIndex}-${i}`);
         cloneCloud.addComponent('gsplat', {
             resource: container
         });

--- a/examples/src/examples/gaussian-splatting/procedural-shapes.example.mjs
+++ b/examples/src/examples/gaussian-splatting/procedural-shapes.example.mjs
@@ -28,10 +28,10 @@ import {
     createGraphicsDevice
 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
-import { GsplatImage } from 'playcanvas/scripts/esm/gsplat/gsplat-image.mjs';
-import { GsplatLines } from 'playcanvas/scripts/esm/gsplat/gsplat-lines.mjs';
-import { GsplatText } from 'playcanvas/scripts/esm/gsplat/gsplat-text.mjs';
-import { GsplatBoxShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-box.mjs';
+import { GSplatImage } from 'playcanvas/scripts/esm/gsplat/gsplat-image.mjs';
+import { GSplatLines } from 'playcanvas/scripts/esm/gsplat/gsplat-lines.mjs';
+import { GSplatText } from 'playcanvas/scripts/esm/gsplat/gsplat-text.mjs';
+import { GSplatBoxShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-box.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -115,7 +115,7 @@ app.root.addChild(bicycle);
 
 // Add a reveal effect to the scene using box shader effect
 bicycle.addComponent('script');
-const revealScript = bicycle.script.create(GsplatBoxShaderEffect);
+const revealScript = bicycle.script.create(GSplatBoxShaderEffect);
 revealScript.aabbMin.set(-2, -0.5, -2);
 revealScript.aabbMax.set(2, 1.5, 2);
 revealScript.direction.set(1, 1, 0);
@@ -127,19 +127,19 @@ revealScript.baseTint.set(1, 1, 1);
 revealScript.edgeTint.set(5, 2, 0); // orange/gold edge
 revealScript.tint.set(1, 1, 1);
 
-// Create ground entity with GsplatImage script
+// Create ground entity with GSplatImage script
 const ground = new Entity('Ground');
 ground.addComponent('script');
-const groundImage = ground.script.create(GsplatImage);
+const groundImage = ground.script.create(GSplatImage);
 groundImage.imageAsset = assets.groundTexture;
 ground.setLocalPosition(0, -0.05, 0);
 ground.setLocalScale(3, 3, 3);
 app.root.addChild(ground);
 
-// Create gear wall entity with GsplatImage script (behind the bike)
+// Create gear wall entity with GSplatImage script (behind the bike)
 const gearWall = new Entity('GearWall');
 gearWall.addComponent('script');
-const gearImage = gearWall.script.create(GsplatImage);
+const gearImage = gearWall.script.create(GSplatImage);
 gearImage.imageAsset = assets.gearTexture;
 gearWall.setLocalPosition(1, 0.5, 0);
 gearWall.setLocalEulerAngles(-90, -90, 0);
@@ -237,7 +237,7 @@ const textEntities = [];
 const createTextLabel = (text, x, y, z, rotX, rotY, rotZ) => {
     const textEntity = new Entity(`Text-${text}`);
     textEntity.addComponent('script');
-    const textScript = textEntity.script.create(GsplatText);
+    const textScript = textEntity.script.create(GSplatText);
     textScript.text = text;
     textScript.fontSize = 48;
     textScript.fillStyle = '#00e5ff'; // Cyan to match arrows
@@ -256,7 +256,7 @@ const createTextLabel = (text, x, y, z, rotX, rotY, rotZ) => {
 const createLinesEntity = () => {
     linesEntity = new Entity('Lines');
     linesEntity.addComponent('script');
-    const lines = linesEntity.script.create(GsplatLines);
+    const lines = linesEntity.script.create(GSplatLines);
     app.root.addChild(linesEntity);
 
     // Add all primitives

--- a/examples/src/examples/gaussian-splatting/relighting.example.mjs
+++ b/examples/src/examples/gaussian-splatting/relighting.example.mjs
@@ -69,7 +69,7 @@ import {
     platform
 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
-import { GsplatRelighting } from 'playcanvas/scripts/esm/gsplat/gsplat-relighting.mjs';
+import { GSplatRelighting } from 'playcanvas/scripts/esm/gsplat/gsplat-relighting.mjs';
 
 import { data, deviceType, win } from 'examples/context';
 
@@ -331,8 +331,8 @@ Object.assign(cc, {
 
 // Relighting renderer: renders the relighting layer (proxy mesh) from a camera matching the
 // main camera into an RGBA16F texture - lit mesh color in RGB, mesh coverage mask in A
-const relighting = /** @type {GsplatRelighting} */ (
-    /** @type {any} */ (camera.script).create(GsplatRelighting, {
+const relighting = /** @type {GSplatRelighting} */ (
+    /** @type {any} */ (camera.script).create(GSplatRelighting, {
         properties: {
             textureScale: data.get('textureScale'),
             blend: data.get('blend'),
@@ -687,7 +687,7 @@ applyEnvironment(data.get('environment')).catch((err) => {
     console.warn('Environment load failed:', err);
 });
 
-// Gsplat loading state
+// GSplat loading state
 /** @type {Entity|null} */
 let gsplatEntity = null;
 /** @type {any} */
@@ -708,7 +708,7 @@ const applyPreset = () => {
     data.set('lodMultiplier', presetData.lodMultiplier);
 };
 
-const loadGsplat = async (/** @type {string|null} */ url) => {
+const loadGSplat = async (/** @type {string|null} */ url) => {
     if (gsplatEntity) {
         gsplatEntity.destroy();
         gsplatEntity = null;
@@ -777,7 +777,7 @@ const loadGsplat = async (/** @type {string|null} */ url) => {
 
 // Initial load — use the observer's current url, which is paramUrl from the
 // hash query if set, or the share-URL state value applied during app.start().
-await loadGsplat(data.get('url') || null);
+await loadGSplat(data.get('url') || null);
 
 data.on('lodPreset:set', applyPreset);
 
@@ -805,9 +805,9 @@ data.on('orientation:set', () => {
 
 data.on('url:set', () => {
     const url = data.get('url');
-    loadGsplat(url || null).catch((err) => {
+    loadGSplat(url || null).catch((err) => {
         console.warn('Loading failed, reverting to default:', err);
-        loadGsplat(null);
+        loadGSplat(null);
     });
 });
 

--- a/examples/src/examples/gaussian-splatting/reveal.example.mjs
+++ b/examples/src/examples/gaussian-splatting/reveal.example.mjs
@@ -26,9 +26,9 @@ import {
     TouchDevice,
     createGraphicsDevice
 } from 'playcanvas';
-import { GsplatRevealGridEruption } from 'playcanvas/scripts/esm/gsplat/reveal-grid-eruption.mjs';
-import { GsplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
-import { GsplatRevealRain } from 'playcanvas/scripts/esm/gsplat/reveal-rain.mjs';
+import { GSplatRevealGridEruption } from 'playcanvas/scripts/esm/gsplat/reveal-grid-eruption.mjs';
+import { GSplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
+import { GSplatRevealRain } from 'playcanvas/scripts/esm/gsplat/reveal-rain.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -112,7 +112,7 @@ hotel.addComponent('script');
 
 // Helper function to create radial script with configured attributes
 const createRadialScript = () => {
-    const script = hotel.script?.create(GsplatRevealRadial);
+    const script = hotel.script?.create(GSplatRevealRadial);
     if (script) {
         script.center.set(0, 0, 0);
         script.speed = 5;
@@ -128,7 +128,7 @@ const createRadialScript = () => {
 
 // Helper function to create rain script with configured attributes
 const createRainScript = () => {
-    const script = hotel.script?.create(GsplatRevealRain);
+    const script = hotel.script?.create(GSplatRevealRain);
     if (script) {
         script.center.set(0, 0, 0);
         script.distance = 30;
@@ -148,7 +148,7 @@ const createRainScript = () => {
 
 // Helper function to create grid eruption script with configured attributes
 const createGridScript = () => {
-    const script = hotel.script?.create(GsplatRevealGridEruption);
+    const script = hotel.script?.create(GSplatRevealGridEruption);
     if (script) {
         script.center.set(0, 0, 0);
         script.blockCount = 10;
@@ -171,9 +171,9 @@ const createGridScript = () => {
  */
 const createEffect = (effectName) => {
     // Destroy any existing reveal scripts
-    hotel.script?.destroy(GsplatRevealRadial.scriptName);
-    hotel.script?.destroy(GsplatRevealRain.scriptName);
-    hotel.script?.destroy(GsplatRevealGridEruption.scriptName);
+    hotel.script?.destroy(GSplatRevealRadial.scriptName);
+    hotel.script?.destroy(GSplatRevealRain.scriptName);
+    hotel.script?.destroy(GSplatRevealGridEruption.scriptName);
 
     // Create the selected effect (fresh instance, starts from beginning)
     if (effectName === 'radial') {

--- a/examples/src/examples/gaussian-splatting/shader-dissolve.example.mjs
+++ b/examples/src/examples/gaussian-splatting/shader-dissolve.example.mjs
@@ -28,7 +28,7 @@ import {
     Vec3,
     createGraphicsDevice
 } from 'playcanvas';
-import { GsplatDissolveShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-dissolve.mjs';
+import { GSplatDissolveShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-dissolve.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -163,7 +163,7 @@ app.root.addChild(hotel);
 hotel.addComponent('script');
 
 // Create the dissolve effect script
-const dissolveScript = hotel.script?.create(GsplatDissolveShaderEffect);
+const dissolveScript = hotel.script?.create(GSplatDissolveShaderEffect);
 
 // Wire up parameter sliders - each updates the script live
 /** @type {Record<string, (value: any) => void>} */

--- a/examples/src/examples/gaussian-splatting/shader-effects.example.mjs
+++ b/examples/src/examples/gaussian-splatting/shader-effects.example.mjs
@@ -26,7 +26,7 @@ import {
     Vec3,
     createGraphicsDevice
 } from 'playcanvas';
-import { GsplatBoxShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-box.mjs';
+import { GSplatBoxShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-box.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -210,7 +210,7 @@ hotel.addComponent('script');
 
 // Helper function to create box script with configured attributes
 const createBoxScript = () => {
-    const script = hotel.script?.create(GsplatBoxShaderEffect);
+    const script = hotel.script?.create(GSplatBoxShaderEffect);
     return script;
 };
 

--- a/examples/src/examples/gaussian-splatting/splat-portal.example.mjs
+++ b/examples/src/examples/gaussian-splatting/splat-portal.example.mjs
@@ -63,7 +63,7 @@ import {
     platform
 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
-import { GsplatWeather } from 'playcanvas/scripts/esm/gsplat/gsplat-weather.mjs';
+import { GSplatWeather } from 'playcanvas/scripts/esm/gsplat/gsplat-weather.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -422,8 +422,8 @@ sceneConfigs.forEach((config) => {
 const SNOW_EXTENT = 20;
 const weatherEntity = new Entity('Weather');
 weatherEntity.addComponent('script');
-const weather = /** @type {GsplatWeather} */ (
-    weatherEntity.script.create(GsplatWeather, {
+const weather = /** @type {GSplatWeather} */ (
+    weatherEntity.script.create(GSplatWeather, {
         properties: {
             followEntity: camera,
             speed: 2.0,

--- a/examples/src/examples/gaussian-splatting/viewer.example.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.example.mjs
@@ -324,10 +324,10 @@ canvas.addEventListener('drop', async (e) => {
     const file = files[0];
     const fileName = file.name.toLowerCase();
     const isSpz = !isUnpackedSog && fileName.endsWith('.spz');
-    const isGsplat = !isUnpackedSog && (fileName.endsWith('.ply') || fileName.endsWith('.sog') || isSpz);
+    const isGSplat = !isUnpackedSog && (fileName.endsWith('.ply') || fileName.endsWith('.sog') || isSpz);
     const isGlb = !isUnpackedSog && fileName.endsWith('.glb');
 
-    if (!isUnpackedSog && !isGsplat && !isGlb) {
+    if (!isUnpackedSog && !isGSplat && !isGlb) {
         console.warn('Please drop a .ply, .sog, .spz, .glb, or an unpacked SOG (meta.json + .webp files)');
         return;
     }
@@ -391,7 +391,7 @@ canvas.addEventListener('drop', async (e) => {
             console.warn('customAabb not available');
             return;
         }
-    } else if (isGsplat) {
+    } else if (isGSplat) {
         // Create blob URL and load asset using loadFromUrlAndFilename
         // This method is specifically for blob assets where the URL doesn't identify the format
         const blobUrl = URL.createObjectURL(file);

--- a/examples/src/examples/gaussian-splatting/vr-lod.example.mjs
+++ b/examples/src/examples/gaussian-splatting/vr-lod.example.mjs
@@ -66,7 +66,7 @@ import {
     platform
 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
-import { GsplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
+import { GSplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
 import { XrMenu } from 'playcanvas/scripts/esm/xr/xr-menu.mjs';
 import { XrNavigation } from 'playcanvas/scripts/esm/xr/xr-navigation.mjs';
 import { XrSession } from 'playcanvas/scripts/esm/xr/xr-session.mjs';
@@ -474,7 +474,7 @@ const applyPreset = () => {
     }
 };
 
-const loadGsplat = (scene) => {
+const loadGSplat = (scene) => {
     if (gsplatEntity) {
         gsplatEntity.destroy();
         gsplatEntity = null;
@@ -519,7 +519,7 @@ const loadGsplat = (scene) => {
     gsplatSystem.on('frame:ready', onFrameReady);
 
     gsplatEntity.addComponent('script');
-    const revealScript = gsplatEntity.script?.create(GsplatRevealRadial);
+    const revealScript = gsplatEntity.script?.create(GSplatRevealRadial);
     if (revealScript) {
         revealScript.center.set(scene.focus[0], scene.focus[1], scene.focus[2]);
         revealScript.speed = 10;
@@ -595,11 +595,11 @@ const setScene = (index) => {
     }
 
     if (scene.asset.loaded) {
-        loadGsplat(scene);
+        loadGSplat(scene);
     } else {
         // Load on demand; guard against a newer selection completing first
         scene.asset.once('load', () => {
-            if (SCENES[sceneIndex] === scene) loadGsplat(scene);
+            if (SCENES[sceneIndex] === scene) loadGSplat(scene);
         });
         app.assets.load(scene.asset);
     }

--- a/examples/src/examples/gaussian-splatting/weather.example.mjs
+++ b/examples/src/examples/gaussian-splatting/weather.example.mjs
@@ -40,7 +40,7 @@ import {
     platform
 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
-import { GsplatWeather } from 'playcanvas/scripts/esm/gsplat/gsplat-weather.mjs';
+import { GSplatWeather } from 'playcanvas/scripts/esm/gsplat/gsplat-weather.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -138,8 +138,8 @@ gsplatEntity.gsplat.lodMultiplier = 4;
 // Procedural weather
 const weatherEntity = new Entity('Weather');
 weatherEntity.addComponent('script');
-const weather = /** @type {GsplatWeather} */ (
-    weatherEntity.script.create(GsplatWeather, {
+const weather = /** @type {GSplatWeather} */ (
+    weatherEntity.script.create(GSplatWeather, {
         properties: {
             followEntity: camera,
             speed: 1.0,

--- a/examples/src/examples/gaussian-splatting/wind.example.mjs
+++ b/examples/src/examples/gaussian-splatting/wind.example.mjs
@@ -1,6 +1,6 @@
 // @config
 //
-// Wind swaying of trees in a streamed gaussian splat scene, using the reusable GsplatTrees script.
+// Wind swaying of trees in a streamed gaussian splat scene, using the reusable GSplatTrees script.
 // Trees are marked by spheres; toggle Edit mode to position them and drive the wind from the controls.
 //
 // @credit
@@ -38,7 +38,7 @@ import {
     createGraphicsDevice
 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
-import { GsplatTrees } from 'playcanvas/scripts/esm/gsplat/gsplat-trees.mjs';
+import { GSplatTrees } from 'playcanvas/scripts/esm/gsplat/gsplat-trees.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -152,7 +152,7 @@ app.root.addChild(skatepark);
 
 // the reusable wind script
 skatepark.addComponent('script');
-const treesScript = /** @type {GsplatTrees} */ (skatepark.script.create(GsplatTrees));
+const treesScript = /** @type {GSplatTrees} */ (skatepark.script.create(GSplatTrees));
 
 // Each tree is a helper entity whose world position is the sphere center and whose uniform scale
 // is the sphere radius; the gizmos move/scale these. Use Edit mode to reposition them, add or

--- a/scripts/esm/gsplat/gsplat-flipbook.mjs
+++ b/scripts/esm/gsplat/gsplat-flipbook.mjs
@@ -1,7 +1,7 @@
 import { Script, Asset } from 'playcanvas';
 
 /**
- * Reference-counted asset cache shared across all GsplatFlipbook instances.
+ * Reference-counted asset cache shared across all GSplatFlipbook instances.
  * Ensures assets are only loaded once and properly cleaned up when no longer needed.
  */
 class AssetCache {
@@ -102,7 +102,7 @@ const PlayMode = {
  *
  * // Add script component and create flipbook script
  * entity.addComponent('script');
- * const flipbook = entity.script.create(GsplatFlipbook);
+ * const flipbook = entity.script.create(GSplatFlipbook);
  *
  * // Configure attributes
  * flipbook.fps = 30;
@@ -135,7 +135,7 @@ const PlayMode = {
  * flipbook.preloadCount = 20; // Larger buffer for slower connections
  * flipbook.preloadCount = 5;  // Smaller buffer to save memory
  */
-class GsplatFlipbook extends Script {
+class GSplatFlipbook extends Script {
     static scriptName = 'gsplatFlipbook';
 
     /**
@@ -209,7 +209,7 @@ class GsplatFlipbook extends Script {
 
         // Verify gsplat component exists (should be added before this script)
         if (!this.entity.gsplat) {
-            console.error('GsplatFlipbook: Entity must have a gsplat component with unified=true');
+            console.error('GSplatFlipbook: Entity must have a gsplat component with unified=true');
             return;
         }
 
@@ -486,4 +486,4 @@ class GsplatFlipbook extends Script {
     }
 }
 
-export { GsplatFlipbook };
+export { GSplatFlipbook };

--- a/scripts/esm/gsplat/gsplat-image.mjs
+++ b/scripts/esm/gsplat/gsplat-image.mjs
@@ -12,13 +12,13 @@ import { Script, BoundingBox, GSplatFormat, GSplatContainer, FloatPacking } from
  * @example
  * // Add the script to an entity
  * entity.addComponent('script');
- * const image = entity.script.create(GsplatImage, {
+ * const image = entity.script.create(GSplatImage, {
  *     attributes: {
  *         imageAsset: myTextureAsset
  *     }
  * });
  */
-class GsplatImage extends Script {
+class GSplatImage extends Script {
     static scriptName = 'gsplatImage';
 
     /**
@@ -99,7 +99,7 @@ class GsplatImage extends Script {
         // Get the source image element from the texture
         const source = texture.getSource();
         if (!source) {
-            console.warn('GsplatImage: Texture has no source image');
+            console.warn('GSplatImage: Texture has no source image');
             return;
         }
 
@@ -112,7 +112,7 @@ class GsplatImage extends Script {
         canvas.height = height;
         const ctx = canvas.getContext('2d');
         if (!ctx) {
-            console.warn('GsplatImage: Failed to create canvas context');
+            console.warn('GSplatImage: Failed to create canvas context');
             return;
         }
         ctx.drawImage(source, 0, 0);
@@ -230,4 +230,4 @@ class GsplatImage extends Script {
     }
 }
 
-export { GsplatImage };
+export { GSplatImage };

--- a/scripts/esm/gsplat/gsplat-lines.mjs
+++ b/scripts/esm/gsplat/gsplat-lines.mjs
@@ -25,7 +25,7 @@ function calculateSplatCount(start, end, thickness) {
  * @example
  * // Add the script to an entity
  * entity.addComponent('script');
- * const lines = entity.script.create(GsplatLines);
+ * const lines = entity.script.create(GSplatLines);
  *
  * // Add primitives
  * const lineHandle = lines.addLine(
@@ -39,7 +39,7 @@ function calculateSplatCount(start, end, thickness) {
  * // Remove a primitive
  * lines.removePrimitive(lineHandle);
  */
-class GsplatLines extends Script {
+class GSplatLines extends Script {
     static scriptName = 'gsplatLines';
 
     /**
@@ -466,4 +466,4 @@ class GsplatLines extends Script {
     }
 }
 
-export { GsplatLines };
+export { GSplatLines };

--- a/scripts/esm/gsplat/gsplat-mesh.mjs
+++ b/scripts/esm/gsplat/gsplat-mesh.mjs
@@ -222,7 +222,7 @@ function collectRenderComponents(entity, recursive, results) {
  * @example
  * // Add the script to an entity
  * entity.addComponent('script');
- * const meshSplat = entity.script.create(GsplatMesh);
+ * const meshSplat = entity.script.create(GSplatMesh);
  *
  * // Build splats from another entity's mesh hierarchy
  * meshSplat.buildFromEntity(sourceEntity, {
@@ -230,7 +230,7 @@ function collectRenderComponents(entity, recursive, results) {
  *     recursive: true
  * });
  */
-class GsplatMesh extends Script {
+class GSplatMesh extends Script {
     static scriptName = 'gsplatMesh';
 
     /**
@@ -495,4 +495,4 @@ class GsplatMesh extends Script {
     }
 }
 
-export { GsplatMesh };
+export { GSplatMesh };

--- a/scripts/esm/gsplat/gsplat-relighting.mjs
+++ b/scripts/esm/gsplat/gsplat-relighting.mjs
@@ -68,15 +68,15 @@ fn modifySplatColor(gaussianUV: vec2f, color: ptr<function, vec4f>) {
  * Attach this script to the entity holding the main camera that renders the gsplat scene. Under
  * the hood it creates a child entity with a camera matching the main camera, which renders a
  * dedicated layer into the texture before the main camera renders. Place the proxy mesh and the
- * lights that should light it on that layer ({@link GsplatRelighting#layer}), and apply
- * {@link GsplatRelighting#configureMaterial} to the proxy mesh material so it writes the
+ * lights that should light it on that layer ({@link GSplatRelighting#layer}), and apply
+ * {@link GSplatRelighting#configureMaterial} to the proxy mesh material so it writes the
  * coverage mask to alpha.
  *
  * Note: only gsplat components in unified mode are supported - the splat customization is
  * applied to `app.scene.gsplat.material`, and only by the raster gsplat renderers (CPU and GPU
  * sort), as the fragment chunk is not used by the compute renderer.
  */
-class GsplatRelighting extends Script {
+class GSplatRelighting extends Script {
     static scriptName = 'gsplatRelighting';
 
     /**
@@ -145,7 +145,7 @@ class GsplatRelighting extends Script {
     initialize() {
         const camera = this.entity.camera;
         if (!camera) {
-            console.error('GsplatRelighting requires a Camera component on the entity.');
+            console.error('GSplatRelighting requires a Camera component on the entity.');
             return;
         }
 
@@ -320,4 +320,4 @@ class GsplatRelighting extends Script {
     }
 }
 
-export { GsplatRelighting };
+export { GSplatRelighting };

--- a/scripts/esm/gsplat/gsplat-shader-effect.mjs
+++ b/scripts/esm/gsplat/gsplat-shader-effect.mjs
@@ -28,7 +28,7 @@ import { Script } from 'playcanvas';
  *
  * @abstract
  */
-class GsplatShaderEffect extends Script {
+class GSplatShaderEffect extends Script {
     static scriptName = 'gsplatShaderEffect';
 
     /**
@@ -251,4 +251,4 @@ class GsplatShaderEffect extends Script {
     }
 }
 
-export { GsplatShaderEffect };
+export { GSplatShaderEffect };

--- a/scripts/esm/gsplat/gsplat-text.mjs
+++ b/scripts/esm/gsplat/gsplat-text.mjs
@@ -8,12 +8,12 @@ import { Script, BoundingBox, GSplatFormat, GSplatContainer, FloatPacking } from
  * @example
  * // Add the script to an entity
  * entity.addComponent('script');
- * const textSplat = entity.script.create(GsplatText);
+ * const textSplat = entity.script.create(GSplatText);
  * textSplat.text = 'Hello World';
  * textSplat.fontSize = 64;
  * textSplat.fillStyle = '#ffffff';
  */
-class GsplatText extends Script {
+class GSplatText extends Script {
     static scriptName = 'gsplatText';
 
     /**
@@ -146,7 +146,7 @@ class GsplatText extends Script {
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
         if (!ctx) {
-            console.warn('GsplatText: Failed to create canvas context');
+            console.warn('GSplatText: Failed to create canvas context');
             return;
         }
 
@@ -298,4 +298,4 @@ class GsplatText extends Script {
     }
 }
 
-export { GsplatText };
+export { GSplatText };

--- a/scripts/esm/gsplat/gsplat-trees.mjs
+++ b/scripts/esm/gsplat/gsplat-trees.mjs
@@ -218,10 +218,10 @@ const renderWGSL = /* wgsl */ `
  * resize as needed. Attach the script to the entity holding the (unified) gsplat component.
  *
  * @example
- * const trees = entity.script.create(GsplatTrees);
+ * const trees = entity.script.create(GSplatTrees);
  * trees.setSpheres([{ center: new pc.Vec3(0, 3, 0), radius: 3 }]);
  */
-class GsplatTrees extends Script {
+class GSplatTrees extends Script {
     static scriptName = 'gsplatTrees';
 
     /** @attribute @type {number} */
@@ -479,4 +479,4 @@ class GsplatTrees extends Script {
     }
 }
 
-export { GsplatTrees };
+export { GSplatTrees };

--- a/scripts/esm/gsplat/gsplat-weather.mjs
+++ b/scripts/esm/gsplat/gsplat-weather.mjs
@@ -16,13 +16,13 @@ import { Script, Vec3, BoundingBox, GSplatFormat, GSplatContainer, PIXELFORMAT_R
  * @example
  * const weatherEntity = new pc.Entity('Weather');
  * weatherEntity.addComponent('script');
- * const weather = weatherEntity.script.create(GsplatWeather);
+ * const weather = weatherEntity.script.create(GSplatWeather);
  * weather.followEntity = cameraEntity;
  * weather.speed = 1.2;
  * weather.drift = 0.15;
  * app.root.addChild(weatherEntity);
  */
-class GsplatWeather extends Script {
+class GSplatWeather extends Script {
     static scriptName = 'gsplatWeather';
 
     // --- Grid configuration (read at initialize; call rebuild() after changing) ---
@@ -450,4 +450,4 @@ class GsplatWeather extends Script {
     }
 }
 
-export { GsplatWeather };
+export { GSplatWeather };

--- a/scripts/esm/gsplat/reveal-grid-eruption.mjs
+++ b/scripts/esm/gsplat/reveal-grid-eruption.mjs
@@ -1,5 +1,5 @@
 import { Vec3, Color } from 'playcanvas';
-import { GsplatShaderEffect } from './gsplat-shader-effect.mjs';
+import { GSplatShaderEffect } from './gsplat-shader-effect.mjs';
 
 const shaderGLSL = /* glsl */`
 uniform float uTime;
@@ -263,11 +263,11 @@ fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
  * @example
  * // Add the script to a gsplat entity
  * entity.addComponent('script');
- * const gridScript = entity.script.create(GsplatRevealGridEruption);
+ * const gridScript = entity.script.create(GSplatRevealGridEruption);
  * gridScript.center.set(0, 0, 0);
  * gridScript.blockCount = 10;
  */
-class GsplatRevealGridEruption extends GsplatShaderEffect {
+class GSplatRevealGridEruption extends GSplatShaderEffect {
     static scriptName = 'gsplatRevealGridEruption';
 
     // Reusable arrays for uniform updates
@@ -409,4 +409,4 @@ class GsplatRevealGridEruption extends GsplatShaderEffect {
     }
 }
 
-export { GsplatRevealGridEruption };
+export { GSplatRevealGridEruption };

--- a/scripts/esm/gsplat/reveal-radial.mjs
+++ b/scripts/esm/gsplat/reveal-radial.mjs
@@ -1,5 +1,5 @@
 import { Vec3, Color } from 'playcanvas';
-import { GsplatShaderEffect } from './gsplat-shader-effect.mjs';
+import { GSplatShaderEffect } from './gsplat-shader-effect.mjs';
 
 const shaderGLSL = /* glsl */`
 uniform float uTime;
@@ -272,7 +272,7 @@ fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
  * @example
  * // Add the script to a gsplat entity
  * entity.addComponent('script');
- * entity.script.create(GsplatRevealRadial, {
+ * entity.script.create(GSplatRevealRadial, {
  *     attributes: {
  *         center: new pc.Vec3(0, 0, 0),
  *         speed: 2,
@@ -281,7 +281,7 @@ fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
  *     }
  * });
  */
-class GsplatRevealRadial extends GsplatShaderEffect {
+class GSplatRevealRadial extends GSplatShaderEffect {
     static scriptName = 'gsplatRevealRadial';
 
     // Reusable arrays for uniform updates
@@ -429,4 +429,4 @@ class GsplatRevealRadial extends GsplatShaderEffect {
     }
 }
 
-export { GsplatRevealRadial };
+export { GSplatRevealRadial };

--- a/scripts/esm/gsplat/reveal-rain.mjs
+++ b/scripts/esm/gsplat/reveal-rain.mjs
@@ -1,5 +1,5 @@
 import { Vec3, Color } from 'playcanvas';
-import { GsplatShaderEffect } from './gsplat-shader-effect.mjs';
+import { GSplatShaderEffect } from './gsplat-shader-effect.mjs';
 
 const shaderGLSL = /* glsl */`
 uniform float uTime;
@@ -301,12 +301,12 @@ fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
  * @example
  * // Add the script to a gsplat entity
  * entity.addComponent('script');
- * const rainScript = entity.script.create(GsplatRevealRain);
+ * const rainScript = entity.script.create(GSplatRevealRain);
  * rainScript.center.set(0, 0, 0);
  * rainScript.distance = 5;
  * rainScript.speed = 3;
  */
-class GsplatRevealRain extends GsplatShaderEffect {
+class GSplatRevealRain extends GSplatShaderEffect {
     static scriptName = 'gsplatRevealRain';
 
     // Reusable arrays for uniform updates
@@ -464,4 +464,4 @@ class GsplatRevealRain extends GsplatShaderEffect {
     }
 }
 
-export { GsplatRevealRain };
+export { GSplatRevealRain };

--- a/scripts/esm/gsplat/shader-effect-box.mjs
+++ b/scripts/esm/gsplat/shader-effect-box.mjs
@@ -1,5 +1,5 @@
 import { Vec3, Color, FloatPacking, Texture, PIXELFORMAT_RGBA16U } from 'playcanvas';
-import { GsplatShaderEffect } from './gsplat-shader-effect.mjs';
+import { GSplatShaderEffect } from './gsplat-shader-effect.mjs';
 
 const shaderGLSL = /* glsl */`
 uniform highp usampler2D uLUT;
@@ -148,11 +148,11 @@ fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
  * @example
  * // Add the script to a gsplat entity
  * entity.addComponent('script');
- * const boxScript = entity.script.create(GsplatBoxShaderEffect);
+ * const boxScript = entity.script.create(GSplatBoxShaderEffect);
  * boxScript.aabbMin.set(-1, -1, -1);
  * boxScript.aabbMax.set(1, 1, 1);
  */
-class GsplatBoxShaderEffect extends GsplatShaderEffect {
+class GSplatBoxShaderEffect extends GSplatShaderEffect {
     static scriptName = 'gsplatBoxShaderEffect';
 
     /**
@@ -258,7 +258,7 @@ class GsplatBoxShaderEffect extends GsplatShaderEffect {
 
         // Create LUT texture (256x1 RGBA16U - non-filterable, use textureLoad/texelFetch)
         this._lutTexture = new Texture(this.app.graphicsDevice, {
-            name: 'GsplatEffectLUT',
+            name: 'GSplatEffectLUT',
             width: 256,
             height: 1,
             format: PIXELFORMAT_RGBA16U,
@@ -453,4 +453,4 @@ class GsplatBoxShaderEffect extends GsplatShaderEffect {
     }
 }
 
-export { GsplatBoxShaderEffect };
+export { GSplatBoxShaderEffect };

--- a/scripts/esm/gsplat/shader-effect-crop.mjs
+++ b/scripts/esm/gsplat/shader-effect-crop.mjs
@@ -1,5 +1,5 @@
 import { Vec3 } from 'playcanvas';
-import { GsplatShaderEffect } from './gsplat-shader-effect.mjs';
+import { GSplatShaderEffect } from './gsplat-shader-effect.mjs';
 
 const shaderGLSL = /* glsl */`
 uniform vec3 uAabbMin;
@@ -107,7 +107,7 @@ fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
  * @example
  * // Add the script to a gsplat entity
  * entity.addComponent('script');
- * const cropScript = entity.script.create(GsplatCropShaderEffect);
+ * const cropScript = entity.script.create(GSplatCropShaderEffect);
  * cropScript.aabbMin.set(-1, -1, -1);
  * cropScript.aabbMax.set(1, 1, 1);
  * cropScript.edgeScaleFactor = 0.5; // Default value
@@ -116,7 +116,7 @@ fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
  * material.setDefine('GSPLAT_PRECISE_CROP', '');
  * material.update();
  */
-class GsplatCropShaderEffect extends GsplatShaderEffect {
+class GSplatCropShaderEffect extends GSplatShaderEffect {
     static scriptName = 'gsplatCropShaderEffect';
 
     // Reusable arrays for uniform updates
@@ -167,4 +167,4 @@ class GsplatCropShaderEffect extends GsplatShaderEffect {
     }
 }
 
-export { GsplatCropShaderEffect };
+export { GSplatCropShaderEffect };

--- a/scripts/esm/gsplat/shader-effect-dissolve.mjs
+++ b/scripts/esm/gsplat/shader-effect-dissolve.mjs
@@ -1,5 +1,5 @@
 import { Vec3, Color } from 'playcanvas';
-import { GsplatShaderEffect } from './gsplat-shader-effect.mjs';
+import { GSplatShaderEffect } from './gsplat-shader-effect.mjs';
 
 const shaderGLSL = /* glsl */`
 uniform vec3 uAabbMin;
@@ -248,11 +248,11 @@ fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
  * @example
  * // Add the script to a gsplat entity
  * entity.addComponent('script');
- * const dissolveScript = entity.script.create(GsplatDissolveShaderEffect);
+ * const dissolveScript = entity.script.create(GSplatDissolveShaderEffect);
  * dissolveScript.duration = 2.5;
  * dissolveScript.edgeColor.set(6, 1.5, 0.2);
  */
-class GsplatDissolveShaderEffect extends GsplatShaderEffect {
+class GSplatDissolveShaderEffect extends GSplatShaderEffect {
     static scriptName = 'gsplatDissolveShaderEffect';
 
     // Reusable arrays for uniform updates
@@ -419,4 +419,4 @@ class GsplatDissolveShaderEffect extends GsplatShaderEffect {
     }
 }
 
-export { GsplatDissolveShaderEffect };
+export { GSplatDissolveShaderEffect };

--- a/scripts/esm/gsplat/streamed-gsplat.mjs
+++ b/scripts/esm/gsplat/streamed-gsplat.mjs
@@ -1,6 +1,6 @@
 import { Script, Asset, Entity, platform, GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_NONE } from 'playcanvas';
 
-class StreamedGsplat extends Script {
+class StreamedGSplat extends Script {
     static scriptName = 'streamedGsplat';
 
     /**
@@ -121,9 +121,9 @@ class StreamedGsplat extends Script {
 
         // Load main splat - attach to entity directly
         if (!this.splatUrl) {
-            console.warn('[StreamedGsplat] No splatUrl provided.');
+            console.warn('[StreamedGSplat] No splatUrl provided.');
         } else {
-            const mainAsset = new Asset('MainGsplat_asset', 'gsplat', { url: this.splatUrl });
+            const mainAsset = new Asset('MainGSplat_asset', 'gsplat', { url: this.splatUrl });
             app.assets.add(mainAsset);
             app.assets.load(mainAsset);
             this._assets.push(mainAsset);
@@ -151,16 +151,16 @@ class StreamedGsplat extends Script {
 
         // Load environment splat - attach to child entity
         if (!this.environmentUrl) {
-            console.warn('[StreamedGsplat] No environmentUrl provided (skipping env child).');
+            console.warn('[StreamedGSplat] No environmentUrl provided (skipping env child).');
         } else {
-            const envAsset = new Asset('EnvironmentGsplat_asset', 'gsplat', { url: this.environmentUrl });
+            const envAsset = new Asset('EnvironmentGSplat_asset', 'gsplat', { url: this.environmentUrl });
             app.assets.add(envAsset);
             app.assets.load(envAsset);
             this._assets.push(envAsset);
 
             envAsset.ready((a) => {
                 // Create child entity disabled to allow unified property to be set
-                const child = new Entity('EnvironmentGsplat');
+                const child = new Entity('EnvironmentGSplat');
                 child.enabled = false;
 
                 // Attach to the scene graph
@@ -311,4 +311,4 @@ class StreamedGsplat extends Script {
     }
 }
 
-export { StreamedGsplat };
+export { StreamedGSplat };


### PR DESCRIPTION
Renames the `scripts/esm/gsplat` script classes from `Gsplat*` to `GSplat*`, matching the casing of the core engine's gsplat API (`GSplatComponent`, `GSplatContainer`, etc.). Example imports are updated to match.

Notes:
- `scriptName` strings (e.g. `'streamedGsplat'`, `'gsplatFlipbook'`) are unchanged, so Editor projects referencing scripts by name are unaffected.
- Named imports from the npm package (e.g. `import { GsplatFlipbook } from 'playcanvas/scripts/esm/gsplat/gsplat-flipbook.mjs'`) must update to the new class names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)