### PR TITLE
Decouple physics into a backend abstraction with Ammo and Null implementations

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1479,7 +1479,8 @@ class AppBase extends EventHandler {
     applySceneSettings(settings) {
         let asset;
 
-        if (this.systems.rigidbody && typeof Ammo !== 'undefined') {
+        // gravity is engine state - the physics backend applies it when present
+        if (this.systems.rigidbody) {
             const [x, y, z] = settings.physics.gravity;
             this.systems.rigidbody.gravity.set(x, y, z);
         }

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -182,6 +182,14 @@ class CollisionComponent extends Component {
     _hasOffset = false;
 
     /**
+     * The entity world scale a mesh shape was last built with - a change triggers a rebuild.
+     *
+     * @type {Vec3|null}
+     * @private
+     */
+    _builtWorldScale = null;
+
+    /**
      * Create a new CollisionComponent.
      *
      * @param {CollisionComponentSystem} system - The ComponentSystem that created this Component.
@@ -607,35 +615,12 @@ class CollisionComponent extends Component {
     }
 
     /**
-     * @param {object} shape - The Ammo collision shape to find.
-     * @returns {number|null} The shape's index in the child array of the compound shape.
-     * @ignore
-     */
-    getCompoundChildShapeIndex(shape) {
-        const compound = this._shape;
-        const shapes = compound.getNumChildShapes();
-
-        for (let i = 0; i < shapes; i++) {
-            const childShape = compound.getChildShape(i);
-            if (Ammo.getPointer(childShape) === Ammo.getPointer(shape)) {
-                return i;
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * @param {GraphNode} parent - The parent node.
      * @private
      */
     _onInsert(parent) {
-        // TODO
-        // if is child of compound shape
-        // and there is no change of compoundParent, then update child transform
-        // once updateChildTransform is exposed in ammo.js
-
-        if (typeof Ammo === 'undefined') {
+        const world = this.system.physicsWorld;
+        if (!world) {
             return;
         }
 
@@ -645,7 +630,7 @@ class CollisionComponent extends Component {
             let ancestor = this.entity.parent;
             while (ancestor) {
                 if (ancestor.collision && ancestor.collision.type === 'compound') {
-                    if (ancestor.collision.shape.getNumChildShapes() === 0) {
+                    if (world.getCompoundChildCount(ancestor.collision.shape) === 0) {
                         this.system.recreatePhysicalShapes(ancestor.collision);
                     } else {
                         this.system.recreatePhysicalShapes(this);
@@ -736,12 +721,12 @@ class CollisionComponent extends Component {
                 this.entity.rigidbody.enableSimulation();
             }
         } else if (this._compoundParent && this !== this._compoundParent) {
-            if (this._compoundParent.shape.getNumChildShapes() === 0) {
+            if (this.system.physicsWorld.getCompoundChildCount(this._compoundParent.shape) === 0) {
                 this.system.recreatePhysicalShapes(this._compoundParent);
             } else {
-                const transform = this.system._getNodeTransform(this.entity, this._compoundParent.entity);
-                this._compoundParent.shape.addChildShape(transform, this._shape);
-                Ammo.destroy(transform);
+                // the shape is known to be absent from the compound (it was removed on
+                // disable), so a forced child update adds it back at the current pose
+                this.system.updateCompoundChildTransform(this.entity, true);
 
                 if (this._compoundParent.entity.rigidbody) {
                     this._compoundParent.entity.rigidbody.activate();

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -628,7 +628,9 @@ class CollisionComponentSystem extends ComponentSystem {
     }
 
     onRemove(entity) {
-        if (entity.rigidbody && entity.rigidbody.body) {
+        // gate on the backend body, not the public getter - the getter surfaces the NATIVE
+        // body, which backends without native handles keep null
+        if (entity.rigidbody && entity.rigidbody._body) {
             entity.rigidbody.disableSimulation();
         }
 

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -16,8 +16,9 @@ import { Trigger } from './trigger.js';
 const mat4 = new Mat4();
 const p1 = new Vec3();
 const p2 = new Vec3();
+const p3 = new Vec3();
 const quat = new Quat();
-const tempGraphNode = new GraphNode();
+const quat2 = new Quat();
 
 // Note that `shape` is deliberately absent from this list - it is runtime
 // state created and owned by the type implementation, not component data
@@ -66,8 +67,9 @@ class CollisionSystemImpl {
     // Re-creates rigid bodies / triggers
     recreatePhysicalShapes(component) {
         const entity = component.entity;
+        const world = this.system.physicsWorld;
 
-        if (typeof Ammo !== 'undefined') {
+        if (world) {
             if (entity.trigger) {
                 entity.trigger.destroy();
                 delete entity.trigger;
@@ -111,7 +113,7 @@ class CollisionSystemImpl {
 
             if (component._compoundParent) {
                 if (component !== component._compoundParent) {
-                    if (firstCompoundChild && component._compoundParent.shape.getNumChildShapes() === 0) {
+                    if (firstCompoundChild && world.getCompoundChildCount(component._compoundParent.shape) === 0) {
                         this.system.recreatePhysicalShapes(component._compoundParent);
                     } else {
                         this.system.updateCompoundChildTransform(entity, true);
@@ -165,7 +167,7 @@ class CollisionSystemImpl {
 
     destroyShape(component) {
         if (component._shape) {
-            Ammo.destroy(component._shape);
+            this.system.physicsWorld.destroyShape(component._shape);
             component._shape = null;
         }
     }
@@ -190,113 +192,56 @@ class CollisionSystemImpl {
 // Box Collision System
 class CollisionBoxSystemImpl extends CollisionSystemImpl {
     createPhysicalShape(entity, component) {
-        if (typeof Ammo !== 'undefined') {
-            const he = component.halfExtents;
-            const ammoHe = new Ammo.btVector3(he.x, he.y, he.z);
-            const shape = new Ammo.btBoxShape(ammoHe);
-            Ammo.destroy(ammoHe);
-            return shape;
-        }
-        return undefined;
+        return this.system.physicsWorld?.createShape({
+            type: 'box',
+            halfExtents: component.halfExtents
+        });
     }
 }
 
 // Sphere Collision System
 class CollisionSphereSystemImpl extends CollisionSystemImpl {
     createPhysicalShape(entity, component) {
-        if (typeof Ammo !== 'undefined') {
-            return new Ammo.btSphereShape(component.radius);
-        }
-        return undefined;
+        return this.system.physicsWorld?.createShape({
+            type: 'sphere',
+            radius: component.radius
+        });
     }
 }
 
 // Capsule Collision System
 class CollisionCapsuleSystemImpl extends CollisionSystemImpl {
     createPhysicalShape(entity, component) {
-        const axis = component.axis;
-        const radius = component.radius;
-        const height = Math.max(component.height - 2 * radius, 0);
-
-        let shape = null;
-
-        if (typeof Ammo !== 'undefined') {
-            switch (axis) {
-                case 0:
-                    shape = new Ammo.btCapsuleShapeX(radius, height);
-                    break;
-                case 1:
-                    shape = new Ammo.btCapsuleShape(radius, height);
-                    break;
-                case 2:
-                    shape = new Ammo.btCapsuleShapeZ(radius, height);
-                    break;
-            }
-        }
-
-        return shape;
+        return this.system.physicsWorld?.createShape({
+            type: 'capsule',
+            axis: component.axis,
+            radius: component.radius,
+            height: component.height
+        });
     }
 }
 
 // Cylinder Collision System
 class CollisionCylinderSystemImpl extends CollisionSystemImpl {
     createPhysicalShape(entity, component) {
-        const axis = component.axis;
-        const radius = component.radius;
-        const height = component.height;
-
-        let halfExtents = null;
-        let shape = null;
-
-        if (typeof Ammo !== 'undefined') {
-            switch (axis) {
-                case 0:
-                    halfExtents = new Ammo.btVector3(height * 0.5, radius, radius);
-                    shape = new Ammo.btCylinderShapeX(halfExtents);
-                    break;
-                case 1:
-                    halfExtents = new Ammo.btVector3(radius, height * 0.5, radius);
-                    shape = new Ammo.btCylinderShape(halfExtents);
-                    break;
-                case 2:
-                    halfExtents = new Ammo.btVector3(radius, radius, height * 0.5);
-                    shape = new Ammo.btCylinderShapeZ(halfExtents);
-                    break;
-            }
-        }
-
-        if (halfExtents) {
-            Ammo.destroy(halfExtents);
-        }
-
-        return shape;
+        return this.system.physicsWorld?.createShape({
+            type: 'cylinder',
+            axis: component.axis,
+            radius: component.radius,
+            height: component.height
+        });
     }
 }
 
 // Cone Collision System
 class CollisionConeSystemImpl extends CollisionSystemImpl {
     createPhysicalShape(entity, component) {
-        const axis = component.axis;
-        const radius = component.radius;
-        const height = component.height;
-
-        let shape = null;
-
-        if (typeof Ammo !== 'undefined') {
-            switch (axis) {
-                case 0:
-                    shape = new Ammo.btConeShapeX(radius, height);
-                    break;
-                case 1:
-                    shape = new Ammo.btConeShape(radius, height);
-                    break;
-                case 2:
-                    shape = new Ammo.btConeShapeZ(radius, height);
-                    break;
-            }
-        }
-
-        return shape;
+        return this.system.physicsWorld?.createShape({
+            type: 'cone',
+            axis: component.axis,
+            radius: component.radius,
+            height: component.height
+        });
     }
 }
 
@@ -306,151 +251,106 @@ class CollisionMeshSystemImpl extends CollisionSystemImpl {
     // special handling
     beforeInitialize(component) {}
 
-    createAmmoHull(mesh, node, shape, scale) {
-        const hull = new Ammo.btConvexHullShape();
+    // Builds a PhysicsMeshSource for one mesh. Vertex and index data are exposed through lazy
+    // accessors so they are only extracted when the backend actually builds triangle data -
+    // sources whose geometry is already cached (by mesh id) never touch the vertex buffer.
+    _createMeshSource(mesh, node, bakeScale, convexHull, checkDuplicates) {
+        let positions = null;
+        let stride = 0;
+        let indices = null;
+        let extracted = false;
 
-        const point = new Ammo.btVector3();
+        const extract = () => {
+            if (extracted) return;
+            extracted = true;
 
-        const positions = [];
-        mesh.getPositions(positions);
-
-        for (let i = 0; i < positions.length; i += 3) {
-            point.setValue(positions[i] * scale.x, positions[i + 1] * scale.y, positions[i + 2] * scale.z);
-
-            // No need to calculate the aabb here. We'll do it after all points are added.
-            hull.addPoint(point, false);
-        }
-
-        Ammo.destroy(point);
-
-        hull.recalcLocalAabb();
-        hull.setMargin(0.01);   // Note: default margin is 0.04
-
-        const transform = this.system._getNodeTransform(node);
-        shape.addChildShape(transform, hull);
-        Ammo.destroy(transform);
-    }
-
-    createAmmoMesh(mesh, node, shape, scale, checkDupes = true) {
-        const system = this.system;
-        let triMesh;
-
-        if (system._triMeshCache[mesh.id]) {
-            triMesh = system._triMeshCache[mesh.id];
-        } else {
-            const vb = mesh.vertexBuffer;
-
-            const format = vb.getFormat();
-            let stride, positions;
-            for (let i = 0; i < format.elements.length; i++) {
-                const element = format.elements[i];
-                if (element.name === SEMANTIC_POSITION) {
-                    positions = new Float32Array(vb.lock(), element.offset);
-                    stride = element.stride / 4;
-                    break;
-                }
-            }
-
-            const indices = [];
-            mesh.getIndices(indices);
-            const numTriangles = mesh.primitive[0].count / 3;
-
-            const v1 = new Ammo.btVector3();
-            let i1, i2, i3;
-
-            const base = mesh.primitive[0].base;
-            triMesh = new Ammo.btTriangleMesh();
-            system._triMeshCache[mesh.id] = triMesh;
-
-            const vertexCache = new Map();
-            Debug.assert(typeof triMesh.getIndexedMeshArray === 'function', 'Ammo.js version is too old, please update to a newer Ammo.');
-            const indexedArray = triMesh.getIndexedMeshArray();
-            indexedArray.at(0).m_numTriangles = numTriangles;
-
-            const sx = scale ? scale.x : 1;
-            const sy = scale ? scale.y : 1;
-            const sz = scale ? scale.z : 1;
-
-            const addVertex = (index) => {
-                const x = positions[index * stride] * sx;
-                const y = positions[index * stride + 1] * sy;
-                const z = positions[index * stride + 2] * sz;
-
-                let idx;
-                if (checkDupes) {
-                    const str = `${x}:${y}:${z}`;
-
-                    idx = vertexCache.get(str);
-                    if (idx !== undefined) {
-                        return idx;
+            if (convexHull) {
+                // hulls consume every position, tightly packed
+                positions = [];
+                mesh.getPositions(positions);
+                stride = 3;
+            } else {
+                const vb = mesh.vertexBuffer;
+                const format = vb.getFormat();
+                for (let i = 0; i < format.elements.length; i++) {
+                    const element = format.elements[i];
+                    if (element.name === SEMANTIC_POSITION) {
+                        positions = new Float32Array(vb.lock(), element.offset);
+                        stride = element.stride / 4;
+                        break;
                     }
-
-                    v1.setValue(x, y, z);
-                    idx = triMesh.findOrAddVertex(v1, false);
-                    vertexCache.set(str, idx);
-                } else {
-                    v1.setValue(x, y, z);
-                    idx = triMesh.findOrAddVertex(v1, false);
                 }
 
-                return idx;
-            };
-
-            for (let i = 0; i < numTriangles; i++) {
-                i1 = addVertex(indices[base + i * 3]);
-                i2 = addVertex(indices[base + i * 3 + 1]);
-                i3 = addVertex(indices[base + i * 3 + 2]);
-
-                triMesh.addIndex(i1);
-                triMesh.addIndex(i2);
-                triMesh.addIndex(i3);
+                indices = [];
+                mesh.getIndices(indices);
             }
+        };
 
-            Ammo.destroy(v1);
+        const source = {
+            id: mesh.id,
+            get positions() {
+                extract();
+                return positions;
+            },
+            get stride() {
+                extract();
+                return stride;
+            },
+            get indices() {
+                extract();
+                return indices;
+            },
+            base: mesh.primitive[0].base,
+            count: mesh.primitive[0].count,
+            convexHull: convexHull,
+            checkDuplicates: checkDuplicates,
+            bakeScale: bakeScale,
+            shapeScale: node ? this.system._getNodeScaling(node) : null,
+            position: new Vec3(),
+            rotation: new Quat()
+        };
+
+        if (node) {
+            this.system._getNodeTransform(node, null, source.position, source.rotation);
         }
 
-        const triMeshShape = new Ammo.btBvhTriangleMeshShape(triMesh, true /* useQuantizedAabbCompression */);
-
-        if (!scale) {
-            const scaling = system._getNodeScaling(node);
-            triMeshShape.setLocalScaling(scaling);
-            Ammo.destroy(scaling);
-        }
-
-        const transform = system._getNodeTransform(node);
-        shape.addChildShape(transform, triMeshShape);
-        Ammo.destroy(transform);
+        return source;
     }
 
     createPhysicalShape(entity, component) {
-        if (typeof Ammo === 'undefined') return undefined;
+        const world = this.system.physicsWorld;
+        if (!world) return undefined;
 
         if (component._model || component._render) {
 
-            const shape = new Ammo.btCompoundShape();
             const entityTransform = entity.getWorldTransform();
             const scale = entityTransform.getScale();
+            const sources = [];
+            let shapeScale = null;
 
             if (component._render) {
+                // bake the entity scale into the vertices
                 const meshes = component._render.meshes;
                 for (let i = 0; i < meshes.length; i++) {
-                    if (component._convexHull) {
-                        this.createAmmoHull(meshes[i], tempGraphNode, shape, scale);
-                    } else {
-                        this.createAmmoMesh(meshes[i], tempGraphNode, shape, scale, component._checkVertexDuplicates);
-                    }
+                    sources.push(this._createMeshSource(meshes[i], null, scale, component._convexHull, component._checkVertexDuplicates));
                 }
             } else if (component._model) {
+                // scale the whole shape by the entity scale
                 const meshInstances = component._model.meshInstances;
                 for (let i = 0; i < meshInstances.length; i++) {
-                    this.createAmmoMesh(meshInstances[i].mesh, meshInstances[i].node, shape, null, component._checkVertexDuplicates);
+                    sources.push(this._createMeshSource(meshInstances[i].mesh, meshInstances[i].node, null, false, component._checkVertexDuplicates));
                 }
-                const vec = new Ammo.btVector3(scale.x, scale.y, scale.z);
-                shape.setLocalScaling(vec);
-                Ammo.destroy(vec);
+                shapeScale = scale;
             }
 
-            return shape;
+            // record the scale the shape was built with, for the rebuild-on-scale-change check
+            component._builtWorldScale = scale;
+
+            return world.createShape({
+                type: 'mesh',
+                sources: sources,
+                scale: shapeScale
+            });
         }
 
         return undefined;
@@ -537,45 +437,24 @@ class CollisionMeshSystemImpl extends CollisionSystemImpl {
     }
 
     updateTransform(component, position, rotation, scale) {
-        if (component.shape) {
+        if (component.shape && component._builtWorldScale) {
             const entityTransform = component.entity.getWorldTransform();
             const worldScale = entityTransform.getScale();
 
             // if the scale changed then recreate the shape
-            const previousScale = component.shape.getLocalScaling();
-            if (worldScale.x !== previousScale.x() ||
-                worldScale.y !== previousScale.y() ||
-                worldScale.z !== previousScale.z()) {
+            if (!worldScale.equals(component._builtWorldScale)) {
                 this.doRecreatePhysicalShape(component);
             }
         }
 
         super.updateTransform(component, position, rotation, scale);
     }
-
-    destroyShape(component) {
-        if (!component._shape) {
-            return;
-        }
-
-        const numShapes = component._shape.getNumChildShapes();
-        for (let i = 0; i < numShapes; i++) {
-            const shape = component._shape.getChildShape(i);
-            Ammo.destroy(shape);
-        }
-
-        Ammo.destroy(component._shape);
-        component._shape = null;
-    }
 }
 
 // Compound Collision System
 class CollisionCompoundSystemImpl extends CollisionSystemImpl {
     createPhysicalShape(entity, component) {
-        if (typeof Ammo !== 'undefined') {
-            return new Ammo.btCompoundShape();
-        }
-        return undefined;
+        return this.system.physicsWorld?.createShape({ type: 'compound' });
     }
 
     _addEachDescendant(entity) {
@@ -636,10 +515,18 @@ class CollisionComponentSystem extends ComponentSystem {
 
         this.implementations = { };
 
-        this._triMeshCache = { };
-
         this.on('beforeremove', this.onBeforeRemove, this);
         this.on('remove', this.onRemove, this);
+    }
+
+    /**
+     * The physics backend installed on the rigid body system, or null.
+     *
+     * @type {*}
+     * @ignore
+     */
+    get physicsWorld() {
+        return this.app.systems.rigidbody?.physicsWorld ?? null;
     }
 
     initializeComponentData(component, data) {
@@ -756,30 +643,13 @@ class CollisionComponentSystem extends ComponentSystem {
         if (parentComponent === entity.collision) return;
 
         if (entity.enabled && entity.collision.enabled && (entity._dirtyLocal || forceUpdate)) {
-            const transform = this._getNodeTransform(entity, parentComponent.entity);
-            const idx = parentComponent.getCompoundChildShapeIndex(entity.collision.shape);
-            if (idx === null) {
-                parentComponent.shape.addChildShape(transform, entity.collision.shape);
-            } else {
-                parentComponent.shape.updateChildTransform(idx, transform, true);
-            }
-            Ammo.destroy(transform);
+            this._getNodeTransform(entity, parentComponent.entity, p3, quat2);
+            this.physicsWorld.updateCompoundChild(parentComponent.shape, entity.collision.shape, p3, quat2);
         }
     }
 
     _removeCompoundChild(collision, shape) {
-        if (collision.shape.getNumChildShapes() === 0) {
-            return;
-        }
-
-        if (collision.shape.removeChildShape) {
-            collision.shape.removeChildShape(shape);
-        } else {
-            const ind = collision.getCompoundChildShapeIndex(shape);
-            if (ind !== null) {
-                collision.shape.removeChildShapeByIndex(ind);
-            }
-        }
+        this.physicsWorld.removeCompoundChild(collision.shape, shape);
     }
 
     onTransformChanged(component, position, rotation, scale) {
@@ -809,12 +679,21 @@ class CollisionComponentSystem extends ComponentSystem {
     }
 
     _getNodeScaling(node) {
-        const wtm = node.getWorldTransform();
-        const scl = wtm.getScale();
-        return new Ammo.btVector3(scl.x, scl.y, scl.z);
+        return node.getWorldTransform().getScale();
     }
 
-    _getNodeTransform(node, relative) {
+    /**
+     * Computes a node's pose (with any collision component offsets applied), optionally
+     * relative to an ancestor node, ignoring scale.
+     *
+     * @param {GraphNode} node - The node to read.
+     * @param {GraphNode|null} relative - The ancestor to compute the pose relative to, or null
+     * for the world pose.
+     * @param {Vec3} position - The vector to write the position to.
+     * @param {Quat} rotation - The quaternion to write the rotation to.
+     * @private
+     */
+    _getNodeTransform(node, relative, position, rotation) {
         let pos, rot;
 
         if (relative) {
@@ -829,13 +708,8 @@ class CollisionComponentSystem extends ComponentSystem {
             pos = node.getPosition();
             rot = node.getRotation();
         }
-        const ammoQuat = new Ammo.btQuaternion();
-        const transform = new Ammo.btTransform();
 
-        transform.setIdentity();
-        const origin = transform.getOrigin();
         const component = node.collision;
-
         if (component && component._hasOffset) {
             const lo = component.linearOffset;
             const ao = component.angularOffset;
@@ -845,27 +719,12 @@ class CollisionComponentSystem extends ComponentSystem {
             newOrigin.add(pos);
             quat.copy(rot).mul(ao);
 
-            origin.setValue(newOrigin.x, newOrigin.y, newOrigin.z);
-            ammoQuat.setValue(quat.x, quat.y, quat.z, quat.w);
+            position.copy(newOrigin);
+            rotation.copy(quat);
         } else {
-            origin.setValue(pos.x, pos.y, pos.z);
-            ammoQuat.setValue(rot.x, rot.y, rot.z, rot.w);
+            position.copy(pos);
+            rotation.copy(rot);
         }
-
-        transform.setRotation(ammoQuat);
-        Ammo.destroy(ammoQuat);
-
-        return transform;
-    }
-
-    destroy() {
-        for (const key in this._triMeshCache) {
-            Ammo.destroy(this._triMeshCache[key]);
-        }
-
-        this._triMeshCache = null;
-
-        super.destroy();
     }
 }
 

--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -1,11 +1,14 @@
-import { BODYFLAG_NORESPONSE_OBJECT, BODYMASK_NOT_STATIC, BODYGROUP_TRIGGER, BODYSTATE_ACTIVE_TAG, BODYSTATE_DISABLE_SIMULATION } from '../rigid-body/constants.js';
+import { Quat } from '../../../core/math/quat.js';
+import { Vec3 } from '../../../core/math/vec3.js';
+import { BODYMASK_NOT_STATIC, BODYGROUP_TRIGGER, BODYTYPE_DYNAMIC } from '../rigid-body/constants.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
  * @import { CollisionComponent } from './component.js'
  */
 
-let _ammoVec1, _ammoQuat, _ammoTransform;
+const _position = new Vec3();
+const _rotation = new Quat();
 
 /**
  * Creates a trigger object used to create internal physics objects that interact with rigid bodies
@@ -23,39 +26,36 @@ class Trigger {
         this.component = component;
         this.app = app;
 
-        if (typeof Ammo !== 'undefined' && !_ammoVec1) {
-            _ammoVec1 = new Ammo.btVector3();
-            _ammoQuat = new Ammo.btQuaternion();
-            _ammoTransform = new Ammo.btTransform();
-        }
-
         this.initialize();
     }
 
     initialize() {
         const entity = this.entity;
         const shape = this.component.shape;
+        const world = this.app.systems.rigidbody.physicsWorld;
 
-        if (shape && typeof Ammo !== 'undefined') {
+        if (shape && world) {
             if (entity.trigger) {
                 entity.trigger.destroy();
             }
 
-            const mass = 1;
+            this._getEntityTransform(_position, _rotation);
 
-            this._getEntityTransform(_ammoTransform);
-
-            const body = this.app.systems.rigidbody.createBody(mass, shape, _ammoTransform);
+            const body = world.createBody({
+                type: BODYTYPE_DYNAMIC,
+                mass: 1,
+                shape: shape,
+                position: _position,
+                rotation: _rotation,
+                entity: entity,
+                noContactResponse: true
+            });
 
             body.setRestitution(0);
             body.setFriction(0);
             body.setDamping(0, 0);
-            _ammoVec1.setValue(0, 0, 0);
-            body.setLinearFactor(_ammoVec1);
-            body.setAngularFactor(_ammoVec1);
-
-            body.setCollisionFlags(body.getCollisionFlags() | BODYFLAG_NORESPONSE_OBJECT);
-            body.entity = entity;
+            body.setLinearFactor(Vec3.ZERO);
+            body.setAngularFactor(Vec3.ZERO);
 
             this.body = body;
 
@@ -70,26 +70,18 @@ class Trigger {
 
         this.disable();
 
-        this.app.systems.rigidbody.destroyBody(this.body);
+        this.app.systems.rigidbody.physicsWorld.destroyBody(this.body);
         this.body = null;
     }
 
-    _getEntityTransform(transform) {
-        const bodyPos = this.component.getShapePosition();
-        const bodyRot = this.component.getShapeRotation();
-        _ammoVec1.setValue(bodyPos.x, bodyPos.y, bodyPos.z);
-        _ammoQuat.setValue(bodyRot.x, bodyRot.y, bodyRot.z, bodyRot.w);
-
-        transform.setOrigin(_ammoVec1);
-        transform.setRotation(_ammoQuat);
+    _getEntityTransform(position, rotation) {
+        position.copy(this.component.getShapePosition());
+        rotation.copy(this.component.getShapeRotation());
     }
 
     updateTransform() {
-        this._getEntityTransform(_ammoTransform);
-
-        const body = this.body;
-        body.setWorldTransform(_ammoTransform);
-        body.activate();
+        this._getEntityTransform(_position, _rotation);
+        this.body.setTransform(_position, _rotation);
     }
 
     enable() {
@@ -99,13 +91,11 @@ class Trigger {
         const system = this.app.systems.rigidbody;
         const idx = system._triggers.indexOf(this);
         if (idx < 0) {
+            // addBody also puts the body into the active state so that it is simulated
+            // properly again
             system.addBody(body, BODYGROUP_TRIGGER, BODYMASK_NOT_STATIC ^ BODYGROUP_TRIGGER);
             system._triggers.push(this);
         }
-
-        // set the body's activation state to active so that it is
-        // simulated properly again
-        body.forceActivationState(BODYSTATE_ACTIVE_TAG);
 
         this.updateTransform();
     }
@@ -117,13 +107,11 @@ class Trigger {
         const system = this.app.systems.rigidbody;
         const idx = system._triggers.indexOf(this);
         if (idx > -1) {
+            // removeBody also drops the body out of the active state so that it properly
+            // deactivates after we remove it from the physics world
             system.removeBody(body);
             system._triggers.splice(idx, 1);
         }
-
-        // set the body's activation state to disable simulation so
-        // that it properly deactivates after we remove it from the physics world
-        body.forceActivationState(BODYSTATE_DISABLE_SIMULATION);
     }
 }
 

--- a/src/framework/components/joint/component.js
+++ b/src/framework/components/joint/component.js
@@ -1,7 +1,5 @@
 import { Debug } from '../../../core/debug.js';
-import { math } from '../../../core/math/math.js';
 import { Mat4 } from '../../../core/math/mat4.js';
-import { Quat } from '../../../core/math/quat.js';
 import { Vec2 } from '../../../core/math/vec2.js';
 import { Vec3 } from '../../../core/math/vec3.js';
 import { GraphNode } from '../../../scene/graph-node.js';
@@ -9,19 +7,24 @@ import { Component } from '../component.js';
 import { BODYTYPE_DYNAMIC } from '../rigid-body/constants.js';
 import {
     JOINTTYPE_6DOF, JOINTTYPE_BALL, JOINTTYPE_FIXED, JOINTTYPE_HINGE, JOINTTYPE_SLIDER,
-    MOTION_FREE, MOTION_LIMITED, MOTION_LOCKED
+    MOTION_LOCKED
 } from './constants.js';
 
 /**
  * @import { Entity } from '../../entity.js'
  * @import { EventHandle } from '../../../core/event-handle.js'
+ * @import { MOTION_FREE, MOTION_LIMITED } from './constants.js'
+ * @import { PhysicsJoint } from '../../physics/physics-joint.js'
  */
 
 const _mat = new Mat4();
 const _jointMat = new Mat4();
+const _frameMatA = new Mat4();
+const _frameMatB = new Mat4();
 const _vec3 = new Vec3();
 const _vec3b = new Vec3();
-const _quat = new Quat();
+
+const _jointTypes = new Set([JOINTTYPE_FIXED, JOINTTYPE_BALL, JOINTTYPE_HINGE, JOINTTYPE_SLIDER, JOINTTYPE_6DOF]);
 
 // anchor separation, in meters, beyond which a constraint that bullet has internally broken is
 // considered detectably broken - far above the violation a live constraint exhibits under load
@@ -49,208 +52,6 @@ function setVec3(target, value) {
     }
     return false;
 }
-
-// scratch for dofLimits
-const _dof = { lower: 0, upper: 0 };
-
-// computes the lower/upper pair encoding a 6dof degree of freedom: bullet treats
-// lower > upper as free and lower === upper as locked
-function dofLimits(motion, limits, scale) {
-    if (motion === MOTION_LIMITED) {
-        _dof.lower = limits.x * scale;
-        _dof.upper = limits.y * scale;
-    } else if (motion === MOTION_FREE) {
-        _dof.lower = 1;
-        _dof.upper = 0;
-    } else { // MOTION_LOCKED
-        _dof.lower = 0;
-        _dof.upper = 0;
-    }
-    return _dof;
-}
-
-// Per-type joint backends, mapping the component's properties onto the most appropriate bullet
-// constraint. Methods other than create are optional - a type without a motor simply omits
-// updateMotor. axisCorrection, where present, rotates both joint frames so that the constraint's
-// native axis lands on the joint entity's X axis.
-
-const fixedJoint = {
-    create(bodyA, bodyB, frameA, frameB) {
-        return new Ammo.btFixedConstraint(bodyA, bodyB, frameA, frameB);
-    }
-};
-
-const ballJoint = {
-    create(bodyA, bodyB, frameA, frameB) {
-        return new Ammo.btConeTwistConstraint(bodyA, bodyB, frameA, frameB);
-    },
-
-    updateLimits(joint) {
-        const constraint = joint._constraint;
-
-        // setLimit indices: 5 = swing span 1, limiting rotation about the constraint's Z axis
-        // (i.e. swing towards Y), 4 = swing span 2, limiting rotation about Y (swing towards Z),
-        // 3 = twist span about X
-        if (joint.enableLimits) {
-            constraint.setLimit(5, joint.swingLimitY * math.DEG_TO_RAD);
-            constraint.setLimit(4, joint.swingLimitZ * math.DEG_TO_RAD);
-            constraint.setLimit(3, joint.twistLimit * math.DEG_TO_RAD);
-        } else {
-            // bullet treats spans of this magnitude as unlimited
-            constraint.setLimit(5, 1e30);
-            constraint.setLimit(4, 1e30);
-            constraint.setLimit(3, 1e30);
-        }
-    }
-};
-
-const hingeJoint = {
-    // bullet hinges rotate about frame Z - map the joint's X axis onto it
-    axisCorrection: new Mat4().setFromAxisAngle(Vec3.UP, 90),
-
-    create(bodyA, bodyB, frameA, frameB) {
-        return new Ammo.btHingeConstraint(bodyA, bodyB, frameA, frameB, false);
-    },
-
-    updateLimits(joint) {
-        const constraint = joint._constraint;
-        if (joint.enableLimits) {
-            const limits = joint.limits;
-            // the remaining arguments are bullet's default softness, bias and relaxation factors
-            constraint.setLimit(limits.x * math.DEG_TO_RAD, limits.y * math.DEG_TO_RAD, 0.9, 0.3, 1);
-        } else {
-            // lower > upper leaves the rotation unconstrained
-            constraint.setLimit(1, -1, 0.9, 0.3, 1);
-        }
-    },
-
-    updateMotor(joint) {
-        // bullet's hinge motor clamp is an impulse per simulation step, so scale the torque by
-        // the fixed timestep
-        const maxImpulse = joint.maxMotorForce * joint.system.app.systems.rigidbody.fixedTimeStep;
-        joint._constraint.enableAngularMotor(joint.maxMotorForce > 0, joint.motorSpeed * math.DEG_TO_RAD, maxImpulse);
-    }
-};
-
-const sliderJoint = {
-    create(bodyA, bodyB, frameA, frameB) {
-        // the final argument is useLinearReferenceFrameA - travel is measured in frame A's space
-        return new Ammo.btSliderConstraint(bodyA, bodyB, frameA, frameB, true);
-    },
-
-    updateLimits(joint) {
-        const constraint = joint._constraint;
-        if (joint.enableLimits) {
-            const limits = joint.limits;
-            constraint.setLowerLinLimit(limits.x);
-            constraint.setUpperLinLimit(limits.y);
-        } else {
-            // lower > upper leaves the translation unconstrained
-            constraint.setLowerLinLimit(1);
-            constraint.setUpperLinLimit(-1);
-        }
-
-        // rotation about the slide axis is always locked
-        constraint.setLowerAngLimit(0);
-        constraint.setUpperAngLimit(0);
-    },
-
-    updateMotor(joint) {
-        const constraint = joint._constraint;
-        constraint.setPoweredLinMotor(joint.maxMotorForce > 0);
-        constraint.setTargetLinMotorVelocity(joint.motorSpeed);
-        constraint.setMaxLinMotorForce(joint.maxMotorForce);
-    }
-};
-
-const sixDofJoint = {
-    create(bodyA, bodyB, frameA, frameB) {
-        // the final argument is useLinearReferenceFrameA - linear limits are measured in frame
-        // A's space
-        return new Ammo.btGeneric6DofSpringConstraint(bodyA, bodyB, frameA, frameB, true);
-    },
-
-    updateLimits(joint) {
-        const constraint = joint._constraint;
-
-        let dof = dofLimits(joint.linearMotionX, joint.linearLimitsX, 1);
-        const lx = dof.lower, ux = dof.upper;
-        dof = dofLimits(joint.linearMotionY, joint.linearLimitsY, 1);
-        const ly = dof.lower, uy = dof.upper;
-        dof = dofLimits(joint.linearMotionZ, joint.linearLimitsZ, 1);
-        const lz = dof.lower, uz = dof.upper;
-
-        const limits = new Ammo.btVector3(lx, ly, lz);
-        constraint.setLinearLowerLimit(limits);
-        limits.setValue(ux, uy, uz);
-        constraint.setLinearUpperLimit(limits);
-
-        dof = dofLimits(joint.angularMotionX, joint.angularLimitsX, math.DEG_TO_RAD);
-        const alx = dof.lower, aux = dof.upper;
-        dof = dofLimits(joint.angularMotionY, joint.angularLimitsY, math.DEG_TO_RAD);
-        const aly = dof.lower, auy = dof.upper;
-        dof = dofLimits(joint.angularMotionZ, joint.angularLimitsZ, math.DEG_TO_RAD);
-        const alz = dof.lower, auz = dof.upper;
-
-        limits.setValue(alx, aly, alz);
-        constraint.setAngularLowerLimit(limits);
-        limits.setValue(aux, auy, auz);
-        constraint.setAngularUpperLimit(limits);
-        Ammo.destroy(limits);
-    },
-
-    updateSpring(joint) {
-        const constraint = joint._constraint;
-        const rad = math.DEG_TO_RAD;
-        const linStiffness = joint.linearStiffness;
-        const linDamping = joint.linearDamping;
-        const linEquilibrium = joint.linearEquilibrium;
-        const angStiffness = joint.angularStiffness;
-        const angDamping = joint.angularDamping;
-        const angEquilibrium = joint.angularEquilibrium;
-
-        // a spring acts on an axis when its stiffness component is greater than 0; axes 0-2 are
-        // linear X/Y/Z, axes 3-5 are angular X/Y/Z; angular equilibrium points are specified in
-        // degrees but applied in radians
-        constraint.enableSpring(0, linStiffness.x > 0);
-        constraint.setStiffness(0, linStiffness.x);
-        constraint.setDamping(0, linDamping.x);
-        constraint.setEquilibriumPoint(0, linEquilibrium.x);
-
-        constraint.enableSpring(1, linStiffness.y > 0);
-        constraint.setStiffness(1, linStiffness.y);
-        constraint.setDamping(1, linDamping.y);
-        constraint.setEquilibriumPoint(1, linEquilibrium.y);
-
-        constraint.enableSpring(2, linStiffness.z > 0);
-        constraint.setStiffness(2, linStiffness.z);
-        constraint.setDamping(2, linDamping.z);
-        constraint.setEquilibriumPoint(2, linEquilibrium.z);
-
-        constraint.enableSpring(3, angStiffness.x > 0);
-        constraint.setStiffness(3, angStiffness.x);
-        constraint.setDamping(3, angDamping.x);
-        constraint.setEquilibriumPoint(3, angEquilibrium.x * rad);
-
-        constraint.enableSpring(4, angStiffness.y > 0);
-        constraint.setStiffness(4, angStiffness.y);
-        constraint.setDamping(4, angDamping.y);
-        constraint.setEquilibriumPoint(4, angEquilibrium.y * rad);
-
-        constraint.enableSpring(5, angStiffness.z > 0);
-        constraint.setStiffness(5, angStiffness.z);
-        constraint.setDamping(5, angDamping.z);
-        constraint.setEquilibriumPoint(5, angEquilibrium.z * rad);
-    }
-};
-
-const jointImpls = {
-    [JOINTTYPE_FIXED]: fixedJoint,
-    [JOINTTYPE_BALL]: ballJoint,
-    [JOINTTYPE_HINGE]: hingeJoint,
-    [JOINTTYPE_SLIDER]: sliderJoint,
-    [JOINTTYPE_6DOF]: sixDofJoint
-};
 
 /**
  * The JointComponent constrains the relative motion of two rigid bodies. The entity holding the
@@ -315,12 +116,12 @@ class JointComponent extends Component {
     static EVENT_BREAK = 'break';
 
     /**
-     * The Ammo constraint, when created.
+     * The physics backend joint, when created.
      *
-     * @type {object|null}
+     * @type {PhysicsJoint|null}
      * @private
      */
-    _constraint = null;
+    _joint = null;
 
     /** @private */
     _type = JOINTTYPE_FIXED;
@@ -491,7 +292,7 @@ class JointComponent extends Component {
      */
     set type(type) {
         if (this._type !== type) {
-            if (!jointImpls[type]) {
+            if (!_jointTypes.has(type)) {
                 Debug.warn(`JointComponent: invalid joint type '${type}'`);
                 return;
             }
@@ -586,12 +387,10 @@ class JointComponent extends Component {
         if (this._breakImpulse !== impulse) {
             this._breakImpulse = impulse;
 
-            const constraint = this._constraint;
-            if (constraint) {
-                const breakable = Number.isFinite(impulse);
-                constraint.setBreakingImpulseThreshold(breakable ? impulse : Number.MAX_VALUE);
-                constraint.enableFeedback(breakable);
-                if (breakable) {
+            const joint = this._joint;
+            if (joint) {
+                joint.setBreakImpulse(impulse);
+                if (Number.isFinite(impulse)) {
                     this.system._breakable.add(this);
                 } else {
                     this.system._breakable.delete(this);
@@ -619,7 +418,7 @@ class JointComponent extends Component {
      * @ignore
      */
     get constraint() {
-        return this._constraint;
+        return this._joint ? this._joint.nativeJoint : null;
     }
 
     /**
@@ -1267,7 +1066,7 @@ class JointComponent extends Component {
      */
     _isBodyReady(entity) {
         const rigidbody = entity.rigidbody;
-        return !!(rigidbody && rigidbody.body && rigidbody._simulationEnabled);
+        return !!(rigidbody && rigidbody._body && rigidbody._simulationEnabled);
     }
 
     /** @private */
@@ -1312,7 +1111,7 @@ class JointComponent extends Component {
         const system = this.system;
 
         // check whether a constraint should currently exist at all
-        if (this._constraint || !this._initialized || !this.enabled || !this.entity.enabled ||
+        if (this._joint || !this._initialized || !this.enabled || !this.entity.enabled ||
             this._broken || !this._entityA || this._entityA === this._entityB) {
             system._pending.delete(this);
             this._clearBodyAvailableSubscriptions();
@@ -1333,23 +1132,20 @@ class JointComponent extends Component {
     }
 
     /**
-     * Computes the joint frame in the local space of the given body entity, as an Ammo transform
-     * owned by the caller. The frame's local origin and X axis are also written to anchor and
-     * axis, for use by break detection.
+     * Computes the joint frame in the local space of the given body entity, as a scale-free
+     * matrix with X as the primary joint axis. The frame's local origin and X axis are also
+     * written to anchor and axis, for use by break detection.
      *
      * @param {Entity|null} bodyEntity - The entity whose local space the frame is expressed in,
      * or null for the world-pinning fixed body, whose transform is identity.
-     * @param {Mat4} [axisCorrection] - Optional rotation mapping the joint's X axis onto the
-     * Bullet constraint's native axis.
      * @param {Vec3} anchor - Receives the frame origin in the body's local space.
      * @param {Vec3} axis - Receives the frame X axis in the body's local space.
-     * @returns {object} The frame as a new Ammo.btTransform.
+     * @param {Mat4} frame - Receives the joint frame.
      * @private
      */
-    _createFrame(bodyEntity, axisCorrection, anchor, axis) {
-        // bullet rigid bodies ignore entity scale - their transform is the entity's world
-        // position and rotation - so the joint frames are derived from the same unscaled
-        // transforms
+    _createFrame(bodyEntity, anchor, axis, frame) {
+        // rigid bodies ignore entity scale - their transform is the entity's world position and
+        // rotation - so the joint frames are derived from the same unscaled transforms
         _jointMat.setTRS(this.entity.getPosition(), this.entity.getRotation(), Vec3.ONE);
         if (bodyEntity) {
             _mat.setTRS(bodyEntity.getPosition(), bodyEntity.getRotation(), Vec3.ONE);
@@ -1358,24 +1154,12 @@ class JointComponent extends Component {
         } else {
             _mat.copy(_jointMat);
         }
-        if (axisCorrection) {
-            _mat.mul(axisCorrection);
-        }
 
         _mat.getTranslation(_vec3);
-        _quat.setFromMat4(_mat);
         anchor.copy(_vec3);
         _mat.getX(axis).normalize();
 
-        const frame = new Ammo.btTransform();
-        const origin = new Ammo.btVector3(_vec3.x, _vec3.y, _vec3.z);
-        const rotation = new Ammo.btQuaternion(_quat.x, _quat.y, _quat.z, _quat.w);
-        frame.setOrigin(origin);
-        frame.setRotation(rotation);
-        Ammo.destroy(origin);
-        Ammo.destroy(rotation);
-
-        return frame;
+        frame.copy(_mat);
     }
 
     /** @private */
@@ -1384,10 +1168,6 @@ class JointComponent extends Component {
         const entityB = this._entityB;
         const rigidbodyA = entityA.rigidbody;
         const rigidbodyB = entityB ? entityB.rigidbody : null;
-        const bodyA = rigidbodyA.body;
-
-        // world-pinned joints attach to a shared static body with an identity transform
-        const bodyB = rigidbodyB ? rigidbodyB.body : this.system.getFixedBody();
 
         Debug.call(() => {
             if (rigidbodyA.type !== BODYTYPE_DYNAMIC && (!rigidbodyB || rigidbodyB.type !== BODYTYPE_DYNAMIC)) {
@@ -1395,45 +1175,26 @@ class JointComponent extends Component {
             }
         });
 
-        const impl = jointImpls[this._type];
-        const axisCorrection = impl.axisCorrection;
+        this._createFrame(entityA, this._anchorA, this._axisA, _frameMatA);
+        this._createFrame(entityB, this._anchorB, _vec3b, _frameMatB);
 
-        const frameA = this._createFrame(entityA, axisCorrection, this._anchorA, this._axisA);
-        const frameB = this._createFrame(entityB, axisCorrection, this._anchorB, _vec3b);
-
-        const constraint = impl.create(bodyA, bodyB, frameA, frameB);
-
-        Ammo.destroy(frameA);
-        Ammo.destroy(frameB);
-
-        this._constraint = constraint;
-
-        impl.updateLimits?.(this);
-        impl.updateMotor?.(this);
-        impl.updateSpring?.(this);
+        const world = this.system.app.systems.rigidbody.physicsWorld;
+        this._joint = world.createJoint({
+            type: this._type,
+            bodyA: rigidbodyA._body,
+            bodyB: rigidbodyB ? rigidbodyB._body : null,
+            frameA: _frameMatA,
+            frameB: _frameMatB,
+            enableCollision: this._enableCollision,
+            settings: this
+        });
 
         if (Number.isFinite(this._breakImpulse)) {
-            constraint.setBreakingImpulseThreshold(this._breakImpulse);
-            constraint.enableFeedback(true);
             this.system._breakable.add(this);
-
-            Debug.call(() => {
-                if (this._type === JOINTTYPE_6DOF &&
-                    typeof constraint.isEnabled !== 'function' &&
-                    typeof constraint.getAppliedImpulse !== 'function') {
-                    Debug.warnOnce('JointComponent: this ammo build exposes no constraint state, so breakage of 6dof joints cannot be detected - the joint will still break but no break event will fire.');
-                }
-            });
         }
 
-        bodyA.activate();
-        bodyB?.activate();
-
-        const dynamicsWorld = this.system.app.systems.rigidbody.dynamicsWorld;
-        dynamicsWorld.addConstraint(constraint, !this._enableCollision);
-
         // tear the constraint down synchronously when either body leaves the simulation, before
-        // the underlying btRigidBody can be destroyed
+        // the underlying native body can be destroyed
         this._evtBodyTeardown.push(
             rigidbodyA.on('simulationdisabled', this._onBodyLost, this),
             rigidbodyA.on('beforeremove', this._onBodyLost, this)
@@ -1451,8 +1212,8 @@ class JointComponent extends Component {
         this.system._pending.delete(this);
         this._clearBodyAvailableSubscriptions();
 
-        const constraint = this._constraint;
-        if (constraint) {
+        const joint = this._joint;
+        if (joint) {
             this.system._breakable.delete(this);
 
             for (let i = 0; i < this._evtBodyTeardown.length; i++) {
@@ -1460,10 +1221,8 @@ class JointComponent extends Component {
             }
             this._evtBodyTeardown.length = 0;
 
-            const dynamicsWorld = this.system.app.systems.rigidbody.dynamicsWorld;
-            dynamicsWorld.removeConstraint(constraint);
-            Ammo.destroy(constraint);
-            this._constraint = null;
+            this.system.app.systems.rigidbody.physicsWorld.destroyJoint(joint);
+            this._joint = null;
         }
     }
 
@@ -1513,20 +1272,15 @@ class JointComponent extends Component {
      * @ignore
      */
     _checkBroken() {
-        const constraint = this._constraint;
-        if (!constraint) {
+        const joint = this._joint;
+        if (!joint) {
             return;
         }
 
-        // bullet disables a constraint when its breaking impulse threshold is exceeded but the
-        // stock ammo build exposes no way to query it - prefer isEnabled, then the applied
-        // impulse, then fall back to measuring anchor separation
-        let broken;
-        if (typeof constraint.isEnabled === 'function') {
-            broken = !constraint.isEnabled();
-        } else if (typeof constraint.getAppliedImpulse === 'function') {
-            broken = constraint.getAppliedImpulse() >= this._breakImpulse;
-        } else {
+        // the backend reports true/false when it can query the constraint state, or null when
+        // it cannot - fall back to measuring anchor separation
+        let broken = joint.isBroken();
+        if (broken === null) {
             broken = this._isAnchorSeparated();
         }
 
@@ -1550,27 +1304,21 @@ class JointComponent extends Component {
 
     /** @private */
     _updateLimits() {
-        const impl = jointImpls[this._type];
-        if (this._constraint && impl.updateLimits) {
-            impl.updateLimits(this);
+        if (this._joint && this._joint.updateLimits(this)) {
             this._activateBodies();
         }
     }
 
     /** @private */
     _updateMotor() {
-        const impl = jointImpls[this._type];
-        if (this._constraint && impl.updateMotor) {
-            impl.updateMotor(this);
+        if (this._joint && this._joint.updateMotor(this)) {
             this._activateBodies();
         }
     }
 
     /** @private */
     _updateSpring() {
-        const impl = jointImpls[this._type];
-        if (this._constraint && impl.updateSpring) {
-            impl.updateSpring(this);
+        if (this._joint && this._joint.updateSpring(this)) {
             this._activateBodies();
         }
     }

--- a/src/framework/components/joint/system.js
+++ b/src/framework/components/joint/system.js
@@ -44,14 +44,6 @@ class JointComponentSystem extends ComponentSystem {
     _breakable = new Set();
 
     /**
-     * Shared static Ammo body that world-pinned joints attach to - see {@link getFixedBody}.
-     *
-     * @type {object|null}
-     * @private
-     */
-    _fixedBody = null;
-
-    /**
      * Create a new JointComponentSystem instance.
      *
      * @param {AppBase} app - The application.
@@ -71,33 +63,6 @@ class JointComponentSystem extends ComponentSystem {
         // created before the physics step that follows
         this.app.systems.on('update', this.onUpdate, this);
         this.app.systems.on('postUpdate', this.onPostUpdate, this);
-    }
-
-    /**
-     * Returns a shared static body, lazily created and never added to the dynamics world, that
-     * world-pinned joints (entityB of null) attach to. Its transform is identity, so the frame a
-     * joint computes against it is simply the joint's world frame. This mirrors Bullet's own
-     * getFixedBody pattern and avoids the single-body constraint constructors, some of which do
-     * not transform their frame to world space (notably btConeTwistConstraint).
-     *
-     * @returns {object} The shared static Ammo body.
-     * @ignore
-     */
-    getFixedBody() {
-        if (!this._fixedBody) {
-            const transform = new Ammo.btTransform();
-            transform.setIdentity();
-            const motionState = new Ammo.btDefaultMotionState(transform);
-            const shape = new Ammo.btSphereShape(0.001);
-            const inertia = new Ammo.btVector3(0, 0, 0);
-            const info = new Ammo.btRigidBodyConstructionInfo(0, motionState, shape, inertia);
-            this._fixedBody = new Ammo.btRigidBody(info);
-            Ammo.destroy(info);
-            Ammo.destroy(inertia);
-            Ammo.destroy(transform);
-        }
-
-        return this._fixedBody;
     }
 
     initializeComponentData(component, data, properties) {
@@ -154,13 +119,6 @@ class JointComponentSystem extends ComponentSystem {
 
         this.app.systems.off('update', this.onUpdate, this);
         this.app.systems.off('postUpdate', this.onPostUpdate, this);
-
-        if (this._fixedBody) {
-            Ammo.destroy(this._fixedBody.getMotionState());
-            Ammo.destroy(this._fixedBody.getCollisionShape());
-            Ammo.destroy(this._fixedBody);
-            this._fixedBody = null;
-        }
     }
 }
 

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -8,6 +8,10 @@ import {
     BODYTYPE_DYNAMIC, BODYTYPE_KINEMATIC
 } from './constants.js';
 
+/**
+ * @import { PhysicsBody } from '../../physics/physics-body.js'
+ */
+
 // Shared math variables to avoid excessive allocation
 const _quat1 = new Quat();
 const _quat2 = new Quat();
@@ -134,7 +138,12 @@ class RigidBodyComponent extends Component {
     /** @private */
     _angularVelocity = new Vec3();
 
-    /** @private */
+    /**
+     * The physics backend body, when created.
+     *
+     * @type {PhysicsBody|null}
+     * @private
+     */
     _body = null;
 
     /** @private */
@@ -250,6 +259,10 @@ class RigidBodyComponent extends Component {
         return this._angularVelocity;
     }
 
+    /**
+     * @type {*}
+     * @ignore
+     */
     set body(body) {
         if (this._body !== body) {
             this._body = body;
@@ -260,6 +273,13 @@ class RigidBodyComponent extends Component {
         }
     }
 
+    /**
+     * The native physics body - btRigidBody when the Ammo backend is active, null otherwise.
+     * The setter takes the backend {@link PhysicsBody} and is internal.
+     *
+     * @type {*}
+     * @ignore
+     */
     get body() {
         return this._body ? this._body.nativeBody : null;
     }

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -2,19 +2,20 @@ import { Quat } from '../../../core/math/quat.js';
 import { Vec3 } from '../../../core/math/vec3.js';
 import { Component } from '../component.js';
 import {
-    BODYFLAG_KINEMATIC_OBJECT, BODYTYPE_STATIC,
+    BODYTYPE_STATIC,
     BODYGROUP_DYNAMIC, BODYGROUP_KINEMATIC, BODYGROUP_STATIC,
     BODYMASK_ALL, BODYMASK_NOT_STATIC,
-    BODYSTATE_ACTIVE_TAG, BODYSTATE_DISABLE_DEACTIVATION, BODYSTATE_DISABLE_SIMULATION,
     BODYTYPE_DYNAMIC, BODYTYPE_KINEMATIC
 } from './constants.js';
 
-// Shared math variable to avoid excessive allocation
-let _ammoTransform;
-let _ammoVec1, _ammoVec2, _ammoQuat;
+// Shared math variables to avoid excessive allocation
 const _quat1 = new Quat();
 const _quat2 = new Quat();
 const _vec3 = new Vec3();
+const _position = new Vec3();
+const _rotation = new Quat();
+const _vecA = new Vec3();
+const _vecB = new Vec3();
 
 /**
  * The RigidBodyComponent, when combined with a {@link CollisionComponent}, allows your entities
@@ -172,29 +173,6 @@ class RigidBodyComponent extends Component {
      */
     _type = BODYTYPE_STATIC;
 
-    /** @ignore */
-    static onLibraryLoaded() {
-        // Lazily create shared variable
-        if (typeof Ammo !== 'undefined') {
-            _ammoTransform = new Ammo.btTransform();
-            _ammoVec1 = new Ammo.btVector3();
-            _ammoVec2 = new Ammo.btVector3();
-            _ammoQuat = new Ammo.btQuaternion();
-        }
-    }
-
-    /** @ignore */
-    static onAppDestroy() {
-        Ammo.destroy(_ammoTransform);
-        Ammo.destroy(_ammoVec1);
-        Ammo.destroy(_ammoVec2);
-        Ammo.destroy(_ammoQuat);
-        _ammoTransform = null;
-        _ammoVec1 = null;
-        _ammoVec2 = null;
-        _ammoQuat = null;
-    }
-
     /**
      * Sets the rate at which a body loses angular velocity over time.
      *
@@ -230,8 +208,7 @@ class RigidBodyComponent extends Component {
             this._angularFactor.copy(factor);
 
             if (this._body && this._type === BODYTYPE_DYNAMIC) {
-                _ammoVec1.setValue(factor.x, factor.y, factor.z);
-                this._body.setAngularFactor(_ammoVec1);
+                this._body.setAngularFactor(factor);
             }
         }
     }
@@ -254,9 +231,7 @@ class RigidBodyComponent extends Component {
     set angularVelocity(velocity) {
         if (this._body && this._type === BODYTYPE_DYNAMIC) {
             this._body.activate();
-
-            _ammoVec1.setValue(velocity.x, velocity.y, velocity.z);
-            this._body.setAngularVelocity(_ammoVec1);
+            this._body.setAngularVelocity(velocity);
 
             this._angularVelocity.copy(velocity);
         }
@@ -270,8 +245,7 @@ class RigidBodyComponent extends Component {
      */
     get angularVelocity() {
         if (this._body && this._type === BODYTYPE_DYNAMIC) {
-            const velocity = this._body.getAngularVelocity();
-            this._angularVelocity.set(velocity.x(), velocity.y(), velocity.z());
+            this._body.getAngularVelocity(this._angularVelocity);
         }
         return this._angularVelocity;
     }
@@ -287,7 +261,7 @@ class RigidBodyComponent extends Component {
     }
 
     get body() {
-        return this._body;
+        return this._body ? this._body.nativeBody : null;
     }
 
     /**
@@ -377,8 +351,7 @@ class RigidBodyComponent extends Component {
             this._linearFactor.copy(factor);
 
             if (this._body && this._type === BODYTYPE_DYNAMIC) {
-                _ammoVec1.setValue(factor.x, factor.y, factor.z);
-                this._body.setLinearFactor(_ammoVec1);
+                this._body.setLinearFactor(factor);
             }
         }
     }
@@ -401,9 +374,7 @@ class RigidBodyComponent extends Component {
     set linearVelocity(velocity) {
         if (this._body && this._type === BODYTYPE_DYNAMIC) {
             this._body.activate();
-
-            _ammoVec1.setValue(velocity.x, velocity.y, velocity.z);
-            this._body.setLinearVelocity(_ammoVec1);
+            this._body.setLinearVelocity(velocity);
 
             this._linearVelocity.copy(velocity);
         }
@@ -416,8 +387,7 @@ class RigidBodyComponent extends Component {
      */
     get linearVelocity() {
         if (this._body && this._type === BODYTYPE_DYNAMIC) {
-            const velocity = this._body.getLinearVelocity();
-            this._linearVelocity.set(velocity.x(), velocity.y(), velocity.z());
+            this._body.getLinearVelocity(this._linearVelocity);
         }
         return this._linearVelocity;
     }
@@ -465,11 +435,7 @@ class RigidBodyComponent extends Component {
                     this.disableSimulation();
                 }
 
-                // calculateLocalInertia writes local inertia to ammoVec1 here...
-                this._body.getCollisionShape().calculateLocalInertia(mass, _ammoVec1);
-                // ...and then writes the calculated local inertia to the body
-                this._body.setMassProps(mass, _ammoVec1);
-                this._body.updateInertiaTensor();
+                this._body.setMass(mass);
 
                 if (enabled) {
                     this.enableSimulation();
@@ -608,19 +574,27 @@ class RigidBodyComponent extends Component {
             }
         }
 
-        if (shape) {
+        const world = this.system.physicsWorld;
+        if (shape && world) {
             if (this._body) {
-                this.system.removeBody(this._body);
-                this.system.destroyBody(this._body);
+                world.removeBody(this._body);
+                world.destroyBody(this._body);
 
                 this._body = null;
             }
 
             const mass = this._type === BODYTYPE_DYNAMIC ? this._mass : 0;
 
-            this._getEntityTransform(_ammoTransform);
+            this._getEntityTransform(_position, _rotation);
 
-            const body = this.system.createBody(mass, shape, _ammoTransform);
+            const body = world.createBody({
+                type: this._type,
+                mass: mass,
+                shape: shape,
+                position: _position,
+                rotation: _rotation,
+                entity: entity
+            });
 
             body.setRestitution(this._restitution);
             body.setFriction(this._friction);
@@ -628,19 +602,9 @@ class RigidBodyComponent extends Component {
             body.setDamping(this._linearDamping, this._angularDamping);
 
             if (this._type === BODYTYPE_DYNAMIC) {
-                const linearFactor = this._linearFactor;
-                _ammoVec1.setValue(linearFactor.x, linearFactor.y, linearFactor.z);
-                body.setLinearFactor(_ammoVec1);
-
-                const angularFactor = this._angularFactor;
-                _ammoVec1.setValue(angularFactor.x, angularFactor.y, angularFactor.z);
-                body.setAngularFactor(_ammoVec1);
-            } else if (this._type === BODYTYPE_KINEMATIC) {
-                body.setCollisionFlags(body.getCollisionFlags() | BODYFLAG_KINEMATIC_OBJECT);
-                body.setActivationState(BODYSTATE_DISABLE_DEACTIVATION);
+                body.setLinearFactor(this._linearFactor);
+                body.setAngularFactor(this._angularFactor);
             }
-
-            body.entity = entity;
 
             this.body = body;
 
@@ -679,20 +643,18 @@ class RigidBodyComponent extends Component {
         if (entity.collision && entity.collision.enabled && !this._simulationEnabled) {
             const body = this._body;
             if (body) {
+                // addBody also applies the backend's per-type activation policy
                 this.system.addBody(body, this._group, this._mask);
 
                 switch (this._type) {
                     case BODYTYPE_DYNAMIC:
                         this.system._dynamic.push(this);
-                        body.forceActivationState(BODYSTATE_ACTIVE_TAG);
                         this.syncEntityToBody();
                         break;
                     case BODYTYPE_KINEMATIC:
                         this.system._kinematic.push(this);
-                        body.forceActivationState(BODYSTATE_DISABLE_DEACTIVATION);
                         break;
                     case BODYTYPE_STATIC:
-                        body.forceActivationState(BODYSTATE_ACTIVE_TAG);
                         this.syncEntityToBody();
                         break;
                 }
@@ -737,11 +699,9 @@ class RigidBodyComponent extends Component {
                 system._kinematic.splice(idx, 1);
             }
 
+            // removeBody also drops the body out of the active state so isActive() does not
+            // return true even though it is no longer in the dynamics world
             system.removeBody(body);
-
-            // set activation state to disable simulation to avoid body.isActive() to return
-            // true even if it's not in the dynamics world
-            body.forceActivationState(BODYSTATE_DISABLE_SIMULATION);
 
             this._simulationEnabled = false;
 
@@ -824,20 +784,20 @@ class RigidBodyComponent extends Component {
             body.activate();
 
             if (x instanceof Vec3) {
-                _ammoVec1.setValue(x.x, x.y, x.z);
+                _vecA.copy(x);
             } else {
-                _ammoVec1.setValue(x, y, z);
+                _vecA.set(x, y, z);
             }
 
             if (y instanceof Vec3) {
-                _ammoVec2.setValue(y.x, y.y, y.z);
+                _vecB.copy(y);
             } else if (px !== undefined) {
-                _ammoVec2.setValue(px, py, pz);
+                _vecB.set(px, py, pz);
             } else {
-                _ammoVec2.setValue(0, 0, 0);
+                _vecB.set(0, 0, 0);
             }
 
-            body.applyForce(_ammoVec1, _ammoVec2);
+            body.applyForce(_vecA, _vecB);
         }
     }
 
@@ -874,11 +834,11 @@ class RigidBodyComponent extends Component {
             body.activate();
 
             if (x instanceof Vec3) {
-                _ammoVec1.setValue(x.x, x.y, x.z);
+                _vecA.copy(x);
             } else {
-                _ammoVec1.setValue(x, y, z);
+                _vecA.set(x, y, z);
             }
-            body.applyTorque(_ammoVec1);
+            body.applyTorque(_vecA);
         }
     }
 
@@ -942,20 +902,20 @@ class RigidBodyComponent extends Component {
             body.activate();
 
             if (x instanceof Vec3) {
-                _ammoVec1.setValue(x.x, x.y, x.z);
+                _vecA.copy(x);
             } else {
-                _ammoVec1.setValue(x, y, z);
+                _vecA.set(x, y, z);
             }
 
             if (y instanceof Vec3) {
-                _ammoVec2.setValue(y.x, y.y, y.z);
+                _vecB.copy(y);
             } else if (px !== undefined) {
-                _ammoVec2.setValue(px, py, pz);
+                _vecB.set(px, py, pz);
             } else {
-                _ammoVec2.setValue(0, 0, 0);
+                _vecB.set(0, 0, 0);
             }
 
-            body.applyImpulse(_ammoVec1, _ammoVec2);
+            body.applyImpulse(_vecA, _vecB);
         }
     }
 
@@ -992,12 +952,12 @@ class RigidBodyComponent extends Component {
             body.activate();
 
             if (x instanceof Vec3) {
-                _ammoVec1.setValue(x.x, x.y, x.z);
+                _vecA.copy(x);
             } else {
-                _ammoVec1.setValue(x, y, z);
+                _vecA.set(x, y, z);
             }
 
-            body.applyTorqueImpulse(_ammoVec1);
+            body.applyTorqueImpulse(_vecA);
         }
     }
 
@@ -1029,29 +989,24 @@ class RigidBodyComponent extends Component {
     }
 
     /**
-     * Writes an entity transform into an Ammo.btTransform but ignoring scale.
+     * Reads the entity transform (with any collision component offsets applied) but ignoring
+     * scale.
      *
-     * @param {object} transform - The ammo transform to write the entity transform to.
+     * @param {Vec3} position - The vector to write the world space position to.
+     * @param {Quat} rotation - The quaternion to write the world space rotation to.
      * @private
      */
-    _getEntityTransform(transform) {
+    _getEntityTransform(position, rotation) {
         const entity = this.entity;
 
         const component = entity.collision;
         if (component) {
-            const bodyPos = component.getShapePosition();
-            const bodyRot = component.getShapeRotation();
-            _ammoVec1.setValue(bodyPos.x, bodyPos.y, bodyPos.z);
-            _ammoQuat.setValue(bodyRot.x, bodyRot.y, bodyRot.z, bodyRot.w);
+            position.copy(component.getShapePosition());
+            rotation.copy(component.getShapeRotation());
         } else {
-            const pos = entity.getPosition();
-            const rot = entity.getRotation();
-            _ammoVec1.setValue(pos.x, pos.y, pos.z);
-            _ammoQuat.setValue(rot.x, rot.y, rot.z, rot.w);
+            position.copy(entity.getPosition());
+            rotation.copy(entity.getRotation());
         }
-
-        transform.setOrigin(_ammoVec1);
-        transform.setRotation(_ammoQuat);
     }
 
     /**
@@ -1064,26 +1019,8 @@ class RigidBodyComponent extends Component {
     syncEntityToBody() {
         const body = this._body;
         if (body) {
-            this._getEntityTransform(_ammoTransform);
-
-            body.setWorldTransform(_ammoTransform);
-
-            if (this._type === BODYTYPE_KINEMATIC) {
-                const motionState = body.getMotionState();
-                if (motionState) {
-                    motionState.setWorldTransform(_ammoTransform);
-                }
-            } else if (this._type === BODYTYPE_DYNAMIC && body.setInterpolationWorldTransform) {
-                // Sync the interpolation state so the transform read back by _updateDynamic is
-                // the teleport target on frames that run zero fixed sub-steps (high refresh
-                // rates); zero the interpolation velocities so it is exact, not extrapolated.
-                // Guarded: older ammo builds lack these bindings.
-                body.setInterpolationWorldTransform(_ammoTransform);
-                _ammoVec1.setValue(0, 0, 0);
-                body.setInterpolationLinearVelocity(_ammoVec1);
-                body.setInterpolationAngularVelocity(_ammoVec1);
-            }
-            body.activate();
+            this._getEntityTransform(_position, _rotation);
+            body.setTransform(_position, _rotation);
         }
     }
 
@@ -1096,54 +1033,43 @@ class RigidBodyComponent extends Component {
     _updateDynamic() {
         const body = this._body;
 
-        // If a dynamic body is frozen, we can assume its motion state transform is
-        // the same is the entity world transform
+        // If a dynamic body is frozen, we can assume its simulated transform is the same as
+        // the entity world transform
         if (body.isActive()) {
-            // Update the motion state. Note that the test for the presence of the motion
-            // state is technically redundant since the engine creates one for all bodies.
-            const motionState = body.getMotionState();
-            if (motionState) {
-                const entity = this.entity;
+            const entity = this.entity;
 
-                motionState.getWorldTransform(_ammoTransform);
+            body.getTransform(_position, _rotation);
 
-                const p = _ammoTransform.getOrigin();
-                const q = _ammoTransform.getRotation();
+            const component = entity.collision;
+            if (component && component._hasOffset) {
+                const lo = component.linearOffset;
+                const ao = component.angularOffset;
 
-                const component = entity.collision;
-                if (component && component._hasOffset) {
-                    const lo = component.linearOffset;
-                    const ao = component.angularOffset;
+                // Un-rotate the angular offset and then use the new rotation to
+                // un-translate the linear offset in local space
+                // Order of operations matter here
+                const invertedAo = _quat2.copy(ao).invert();
+                const entityRot = _quat1.copy(_rotation).mul(invertedAo);
 
-                    // Un-rotate the angular offset and then use the new rotation to
-                    // un-translate the linear offset in local space
-                    // Order of operations matter here
-                    const invertedAo = _quat2.copy(ao).invert();
-                    const entityRot = _quat1.set(q.x(), q.y(), q.z(), q.w()).mul(invertedAo);
+                entityRot.transformVector(lo, _vec3);
+                entity.setPosition(_position.x - _vec3.x, _position.y - _vec3.y, _position.z - _vec3.z);
+                entity.setRotation(entityRot);
 
-                    entityRot.transformVector(lo, _vec3);
-                    entity.setPosition(p.x() - _vec3.x, p.y() - _vec3.y, p.z() - _vec3.z);
-                    entity.setRotation(entityRot);
-
-                } else {
-                    entity.setPosition(p.x(), p.y(), p.z());
-                    entity.setRotation(q.x(), q.y(), q.z(), q.w());
-                }
+            } else {
+                entity.setPosition(_position);
+                entity.setRotation(_rotation);
             }
         }
     }
 
     /**
-     * Writes the entity's world transformation matrix into the motion state of a kinematic body.
+     * Writes the entity's world transform into the kinematic target of a kinematic body.
      *
      * @private
      */
     _updateKinematic() {
-        const motionState = this._body.getMotionState();
-        if (motionState) {
-            this._getEntityTransform(_ammoTransform);
-            motionState.setWorldTransform(_ammoTransform);
-        }
+        this._getEntityTransform(_position, _rotation);
+        this._body.setKinematicTarget(_position, _rotation);
     }
 
     /**

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -1052,12 +1052,9 @@ class RigidBodyComponent extends Component {
                 const entityRot = _quat1.copy(_rotation).mul(invertedAo);
 
                 entityRot.transformVector(lo, _vec3);
-                entity.setPosition(_position.x - _vec3.x, _position.y - _vec3.y, _position.z - _vec3.z);
-                entity.setRotation(entityRot);
-
+                entity.setPositionAndRotation(_position.sub(_vec3), entityRot);
             } else {
-                entity.setPosition(_position);
-                entity.setRotation(_rotation);
+                entity.setPositionAndRotation(_position, _rotation);
             }
         }
     }

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -2,6 +2,7 @@ import { now } from '../../../core/time.js';
 import { ObjectPool } from '../../../core/object-pool.js';
 import { Debug } from '../../../core/debug.js';
 import { Vec3 } from '../../../core/math/vec3.js';
+import { AmmoPhysicsWorld } from '../../physics/ammo/ammo-physics-world.js';
 import { ComponentSystem } from '../system.js';
 import { BODYFLAG_NORESPONSE_OBJECT } from './constants.js';
 import { RigidBodyComponent } from './component.js';
@@ -14,6 +15,7 @@ import { SingleContactResult } from './single-contact-result.js';
  * @import { AppBase } from '../../app-base.js'
  * @import { CollisionComponent } from '../collision/component.js'
  * @import { Entity } from '../../entity.js'
+ * @import { PhysicsWorld } from '../../physics/physics-world.js'
  * @import { Trigger } from '../collision/trigger.js'
  */
 
@@ -79,10 +81,10 @@ class RigidBodyComponentSystem extends ComponentSystem {
     gravity = new Vec3(0, -9.81, 0);
 
     /**
-     * @type {Float32Array}
+     * @type {PhysicsWorld|null}
      * @private
      */
-    _gravityFloat32 = new Float32Array(3);
+    _world = null;
 
     /**
      * @type {RigidBodyComponent[]}
@@ -138,35 +140,76 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * @ignore
      */
     onLibraryLoaded() {
-        // Create the Ammo physics world
-        if (typeof Ammo !== 'undefined') {
-            this.collisionConfiguration = new Ammo.btDefaultCollisionConfiguration();
-            this.dispatcher = new Ammo.btCollisionDispatcher(this.collisionConfiguration);
-            this.overlappingPairCache = new Ammo.btDbvtBroadphase();
-            this.solver = new Ammo.btSequentialImpulseConstraintSolver();
-            this.dynamicsWorld = new Ammo.btDiscreteDynamicsWorld(this.dispatcher, this.overlappingPairCache, this.solver, this.collisionConfiguration);
-
-            if (this.dynamicsWorld.setInternalTickCallback) {
-                const checkForCollisionsPointer = Ammo.addFunction(this._checkForCollisions.bind(this), 'vif');
-                this.dynamicsWorld.setInternalTickCallback(checkForCollisionsPointer);
-            } else {
-                Debug.warn('WARNING: This version of ammo.js can potentially fail to report contacts. Please update it to the latest version.');
-            }
-
+        if (!this._world && typeof Ammo !== 'undefined') {
             // Lazily create temp vars
             ammoRayStart = new Ammo.btVector3();
             ammoRayEnd = new Ammo.btVector3();
             RigidBodyComponent.onLibraryLoaded();
 
-            this.contactPointPool = new ObjectPool(ContactPoint, 1);
-            this.contactResultPool = new ObjectPool(ContactResult, 1);
-            this.singleContactResultPool = new ObjectPool(SingleContactResult, 1);
-
-            this.app.systems.on('update', this.onUpdate, this);
-        } else {
+            this.setPhysicsWorld(new AmmoPhysicsWorld({ onTick: this._checkForCollisions.bind(this) }));
+        } else if (!this._world) {
             // Unbind the update function if we haven't loaded Ammo by now
             this.app.systems.off('update', this.onUpdate, this);
         }
+    }
+
+    /**
+     * Installs a physics backend. Used internally for Ammo auto-detection and by tests to
+     * inject a NullPhysicsWorld. A backend can be installed at most once.
+     *
+     * @param {PhysicsWorld} world - The physics backend.
+     * @ignore
+     */
+    setPhysicsWorld(world) {
+        Debug.assert(!this._world, 'RigidBodyComponentSystem#setPhysicsWorld: a physics world is already installed.');
+        this._world = world;
+
+        this.contactPointPool = new ObjectPool(ContactPoint, 1);
+        this.contactResultPool = new ObjectPool(ContactResult, 1);
+        this.singleContactResultPool = new ObjectPool(SingleContactResult, 1);
+
+        this.app.systems.on('update', this.onUpdate, this);
+    }
+
+    /**
+     * The installed physics backend, or null when no physics library has loaded.
+     *
+     * @type {PhysicsWorld|null}
+     * @ignore
+     */
+    get physicsWorld() {
+        return this._world;
+    }
+
+    /**
+     * The native physics world - btDiscreteDynamicsWorld when the Ammo backend is active,
+     * null otherwise.
+     *
+     * @type {object|null}
+     * @ignore
+     */
+    get dynamicsWorld() {
+        return this._world?.nativeWorld ?? null;
+    }
+
+    /** @ignore */
+    get collisionConfiguration() {
+        return this._world?.collisionConfiguration ?? null;
+    }
+
+    /** @ignore */
+    get dispatcher() {
+        return this._world?.dispatcher ?? null;
+    }
+
+    /** @ignore */
+    get overlappingPairCache() {
+        return this._world?.overlappingPairCache ?? null;
+    }
+
+    /** @ignore */
+    get solver() {
+        return this._world?.solver ?? null;
     }
 
     initializeComponentData(component, data) {
@@ -738,20 +781,8 @@ class RigidBodyComponentSystem extends ComponentSystem {
 
         this._stats.physicsStart = now();
 
-        // downcast gravity to float32 so we can accurately compare with existing
-        // gravity set in ammo.
-        this._gravityFloat32[0] = this.gravity.x;
-        this._gravityFloat32[1] = this.gravity.y;
-        this._gravityFloat32[2] = this.gravity.z;
-
-        // Check to see whether we need to update gravity on the dynamics world
-        const gravity = this.dynamicsWorld.getGravity();
-        if (gravity.x() !== this._gravityFloat32[0] ||
-            gravity.y() !== this._gravityFloat32[1] ||
-            gravity.z() !== this._gravityFloat32[2]) {
-            gravity.setValue(this.gravity.x, this.gravity.y, this.gravity.z);
-            this.dynamicsWorld.setGravity(gravity);
-        }
+        // Check to see whether we need to update gravity on the physics world
+        this._world.setGravity(this.gravity);
 
         const triggers = this._triggers;
         for (i = 0, len = triggers.length; i < len; i++) {
@@ -770,7 +801,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
         }
 
         // Step the physics simulation
-        this.dynamicsWorld.stepSimulation(dt, this.maxSubSteps, this.fixedTimeStep);
+        this._world.step(dt, this.maxSubSteps, this.fixedTimeStep);
 
         // Update the transforms of all entities referencing a dynamic body
         const dynamic = this._dynamic;
@@ -790,19 +821,14 @@ class RigidBodyComponentSystem extends ComponentSystem {
 
         this.app.systems.off('update', this.onUpdate, this);
 
-        if (typeof Ammo !== 'undefined') {
-            Ammo.destroy(this.dynamicsWorld);
-            Ammo.destroy(this.solver);
-            Ammo.destroy(this.overlappingPairCache);
-            Ammo.destroy(this.dispatcher);
-            Ammo.destroy(this.collisionConfiguration);
+        if (this._world) {
+            this._world.destroy();
+            this._world = null;
+        }
+
+        if (typeof Ammo !== 'undefined' && ammoRayStart) {
             Ammo.destroy(ammoRayStart);
             Ammo.destroy(ammoRayEnd);
-            this.dynamicsWorld = null;
-            this.solver = null;
-            this.overlappingPairCache = null;
-            this.dispatcher = null;
-            this.collisionConfiguration = null;
             ammoRayStart = null;
             ammoRayEnd = null;
             RigidBodyComponent.onAppDestroy();

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -144,7 +144,6 @@ class RigidBodyComponentSystem extends ComponentSystem {
             // Lazily create temp vars
             ammoRayStart = new Ammo.btVector3();
             ammoRayEnd = new Ammo.btVector3();
-            RigidBodyComponent.onLibraryLoaded();
 
             this.setPhysicsWorld(new AmmoPhysicsWorld({ onTick: this._checkForCollisions.bind(this) }));
         } else if (!this._world) {
@@ -246,46 +245,18 @@ class RigidBodyComponentSystem extends ComponentSystem {
             component.enabled = false;
         }
 
-        if (component.body) {
-            this.destroyBody(component.body);
+        if (component._body) {
+            this._world.destroyBody(component._body);
             component.body = null;
         }
     }
 
     addBody(body, group, mask) {
-        if (group !== undefined && mask !== undefined) {
-            this.dynamicsWorld.addRigidBody(body, group, mask);
-        } else {
-            this.dynamicsWorld.addRigidBody(body);
-        }
+        this._world.addBody(body, group, mask);
     }
 
     removeBody(body) {
-        this.dynamicsWorld.removeRigidBody(body);
-    }
-
-    createBody(mass, shape, transform) {
-        const localInertia = new Ammo.btVector3(0, 0, 0);
-        if (mass !== 0) {
-            shape.calculateLocalInertia(mass, localInertia);
-        }
-
-        const motionState = new Ammo.btDefaultMotionState(transform);
-        const bodyInfo = new Ammo.btRigidBodyConstructionInfo(mass, motionState, shape, localInertia);
-        const body = new Ammo.btRigidBody(bodyInfo);
-        Ammo.destroy(bodyInfo);
-        Ammo.destroy(localInertia);
-
-        return body;
-    }
-
-    destroyBody(body) {
-        // The motion state needs to be destroyed explicitly (if present)
-        const motionState = body.getMotionState();
-        if (motionState) {
-            Ammo.destroy(motionState);
-        }
-        Ammo.destroy(body);
+        this._world.removeBody(body);
     }
 
     /**
@@ -831,7 +802,6 @@ class RigidBodyComponentSystem extends ComponentSystem {
             Ammo.destroy(ammoRayEnd);
             ammoRayStart = null;
             ammoRayEnd = null;
-            RigidBodyComponent.onAppDestroy();
         }
     }
 }

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -177,7 +177,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * The native physics world - btDiscreteDynamicsWorld when the Ammo backend is active,
      * null otherwise.
      *
-     * @type {object|null}
+     * @type {*}
      * @ignore
      */
     get dynamicsWorld() {

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -4,22 +4,19 @@ import { Debug } from '../../../core/debug.js';
 import { Vec3 } from '../../../core/math/vec3.js';
 import { AmmoPhysicsWorld } from '../../physics/ammo/ammo-physics-world.js';
 import { ComponentSystem } from '../system.js';
-import { BODYFLAG_NORESPONSE_OBJECT } from './constants.js';
 import { RigidBodyComponent } from './component.js';
 import { ContactPoint } from './contact-point.js';
 import { ContactResult } from './contact-result.js';
-import { RaycastResult } from './raycast-result.js';
 import { SingleContactResult } from './single-contact-result.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
  * @import { CollisionComponent } from '../collision/component.js'
  * @import { Entity } from '../../entity.js'
- * @import { PhysicsWorld } from '../../physics/physics-world.js'
+ * @import { PhysicsContactPair, PhysicsWorld } from '../../physics/physics-world.js'
+ * @import { RaycastResult } from './raycast-result.js'
  * @import { Trigger } from '../collision/trigger.js'
  */
-
-let ammoRayStart, ammoRayEnd;
 
 const _properties = [
     'mass',
@@ -141,11 +138,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
      */
     onLibraryLoaded() {
         if (!this._world && typeof Ammo !== 'undefined') {
-            // Lazily create temp vars
-            ammoRayStart = new Ammo.btVector3();
-            ammoRayEnd = new Ammo.btVector3();
-
-            this.setPhysicsWorld(new AmmoPhysicsWorld({ onTick: this._checkForCollisions.bind(this) }));
+            this.setPhysicsWorld(new AmmoPhysicsWorld({ contactListener: this }));
         } else if (!this._world) {
             // Unbind the update function if we haven't loaded Ammo by now
             this.app.systems.off('update', this.onUpdate, this);
@@ -283,41 +276,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
             return this.raycastAll(start, end, options)[0] || null;
         }
 
-        let result = null;
-
-        ammoRayStart.setValue(start.x, start.y, start.z);
-        ammoRayEnd.setValue(end.x, end.y, end.z);
-        const rayCallback = new Ammo.ClosestRayResultCallback(ammoRayStart, ammoRayEnd);
-
-        if (typeof options.filterCollisionGroup === 'number') {
-            rayCallback.set_m_collisionFilterGroup(options.filterCollisionGroup);
-        }
-
-        if (typeof options.filterCollisionMask === 'number') {
-            rayCallback.set_m_collisionFilterMask(options.filterCollisionMask);
-        }
-
-        this.dynamicsWorld.rayTest(ammoRayStart, ammoRayEnd, rayCallback);
-        if (rayCallback.hasHit()) {
-            const collisionObj = rayCallback.get_m_collisionObject();
-            const body = Ammo.castObject(collisionObj, Ammo.btRigidBody);
-
-            if (body) {
-                const point = rayCallback.get_m_hitPointWorld();
-                const normal = rayCallback.get_m_hitNormalWorld();
-
-                result = new RaycastResult(
-                    body.entity,
-                    new Vec3(point.x(), point.y(), point.z()),
-                    new Vec3(normal.x(), normal.y(), normal.z()),
-                    rayCallback.get_m_closestHitFraction()
-                );
-            }
-        }
-
-        Ammo.destroy(rayCallback);
-
-        return result;
+        return this._world.raycastFirst(start, end, options);
     }
 
     /**
@@ -367,57 +326,11 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * });
      */
     raycastAll(start, end, options = {}) {
-        Debug.assert(Ammo.AllHitsRayResultCallback, 'pc.RigidBodyComponentSystem#raycastAll: Your version of ammo.js does not expose Ammo.AllHitsRayResultCallback. Update it to latest.');
+        const results = this._world.raycastAll(start, end, options);
 
-        const results = [];
-
-        ammoRayStart.setValue(start.x, start.y, start.z);
-        ammoRayEnd.setValue(end.x, end.y, end.z);
-        const rayCallback = new Ammo.AllHitsRayResultCallback(ammoRayStart, ammoRayEnd);
-
-        if (typeof options.filterCollisionGroup === 'number') {
-            rayCallback.set_m_collisionFilterGroup(options.filterCollisionGroup);
+        if (options.sort) {
+            results.sort((a, b) => a.hitFraction - b.hitFraction);
         }
-
-        if (typeof options.filterCollisionMask === 'number') {
-            rayCallback.set_m_collisionFilterMask(options.filterCollisionMask);
-        }
-
-        this.dynamicsWorld.rayTest(ammoRayStart, ammoRayEnd, rayCallback);
-        if (rayCallback.hasHit()) {
-            const collisionObjs = rayCallback.get_m_collisionObjects();
-            const points = rayCallback.get_m_hitPointWorld();
-            const normals = rayCallback.get_m_hitNormalWorld();
-            const hitFractions = rayCallback.get_m_hitFractions();
-
-            const numHits = collisionObjs.size();
-            for (let i = 0; i < numHits; i++) {
-                const body = Ammo.castObject(collisionObjs.at(i), Ammo.btRigidBody);
-
-                if (body && body.entity) {
-                    if (options.filterTags && !body.entity.tags.has(...options.filterTags) || options.filterCallback && !options.filterCallback(body.entity)) {
-                        continue;
-                    }
-
-                    const point = points.at(i);
-                    const normal = normals.at(i);
-                    const result = new RaycastResult(
-                        body.entity,
-                        new Vec3(point.x(), point.y(), point.z()),
-                        new Vec3(normal.x(), normal.y(), normal.z()),
-                        hitFractions.at(i)
-                    );
-
-                    results.push(result);
-                }
-            }
-
-            if (options.sort) {
-                results.sort((a, b) => a.hitFraction - b.hitFraction);
-            }
-        }
-
-        Ammo.destroy(rayCallback);
 
         return results;
     }
@@ -448,37 +361,22 @@ class RigidBodyComponentSystem extends ComponentSystem {
         return isNewCollision;
     }
 
-    _createContactPointFromAmmo(contactPoint) {
-        const localPointA = contactPoint.get_m_localPointA();
-        const localPointB = contactPoint.get_m_localPointB();
-        const positionWorldOnA = contactPoint.getPositionWorldOnA();
-        const positionWorldOnB = contactPoint.getPositionWorldOnB();
-        const normalWorldOnB = contactPoint.get_m_normalWorldOnB();
-
+    /**
+     * Allocates a pooled contact point that is the given one seen from the other body's
+     * perspective.
+     *
+     * @param {ContactPoint} forward - The contact point from body A's perspective.
+     * @returns {ContactPoint} The reversed contact point.
+     * @private
+     */
+    _createReverseContactPoint(forward) {
         const contact = this.contactPointPool.allocate();
-        contact.localPoint.set(localPointA.x(), localPointA.y(), localPointA.z());
-        contact.localPointOther.set(localPointB.x(), localPointB.y(), localPointB.z());
-        contact.point.set(positionWorldOnA.x(), positionWorldOnA.y(), positionWorldOnA.z());
-        contact.pointOther.set(positionWorldOnB.x(), positionWorldOnB.y(), positionWorldOnB.z());
-        contact.normal.set(normalWorldOnB.x(), normalWorldOnB.y(), normalWorldOnB.z());
-        contact.impulse = contactPoint.getAppliedImpulse();
-        return contact;
-    }
-
-    _createReverseContactPointFromAmmo(contactPoint) {
-        const localPointA = contactPoint.get_m_localPointA();
-        const localPointB = contactPoint.get_m_localPointB();
-        const positionWorldOnA = contactPoint.getPositionWorldOnA();
-        const positionWorldOnB = contactPoint.getPositionWorldOnB();
-        const normalWorldOnB = contactPoint.get_m_normalWorldOnB();
-
-        const contact = this.contactPointPool.allocate();
-        contact.localPointOther.set(localPointA.x(), localPointA.y(), localPointA.z());
-        contact.localPoint.set(localPointB.x(), localPointB.y(), localPointB.z());
-        contact.pointOther.set(positionWorldOnA.x(), positionWorldOnA.y(), positionWorldOnA.z());
-        contact.point.set(positionWorldOnB.x(), positionWorldOnB.y(), positionWorldOnB.z());
-        contact.normal.set(normalWorldOnB.x(), normalWorldOnB.y(), normalWorldOnB.z());
-        contact.impulse = contactPoint.getAppliedImpulse();
+        contact.localPoint.copy(forward.localPointOther);
+        contact.localPointOther.copy(forward.localPoint);
+        contact.point.copy(forward.pointOther);
+        contact.pointOther.copy(forward.point);
+        contact.normal.copy(forward.normal);
+        contact.impulse = forward.impulse;
         return contact;
     }
 
@@ -587,157 +485,142 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     /**
-     * Checks for collisions and fires collision events.
+     * Called by the physics backend when a contact pass begins.
      *
-     * @param {number} world - The pointer to the dynamics world that invoked this callback.
-     * @param {number} timeStep - The amount of simulation time processed in the last simulation tick.
-     * @private
+     * @ignore
      */
-    _checkForCollisions(world, timeStep) {
-        const dynamicsWorld = Ammo.wrapPointer(world, Ammo.btDynamicsWorld);
-
-        // Check for collisions and fire callbacks
-        const dispatcher = dynamicsWorld.getDispatcher();
-        const numManifolds = dispatcher.getNumManifolds();
-
+    onContactsBegin() {
         this.frameCollisions = {};
+    }
 
-        // loop through the all contacts and fire events
-        for (let i = 0; i < numManifolds; i++) {
-            const manifold = dispatcher.getManifoldByIndexInternal(i);
+    /**
+     * Called by the physics backend for each contacting pair. Fires the trigger and collision
+     * events.
+     *
+     * @param {PhysicsContactPair} pair - The contacting pair. Only valid during the call.
+     * @ignore
+     */
+    onContactPair(pair) {
+        const e0 = pair.entityA;
+        const e1 = pair.entityB;
 
-            const body0 = manifold.getBody0();
-            const body1 = manifold.getBody1();
+        const forwardContacts = [];
+        const reverseContacts = [];
+        let newCollision;
 
-            const wb0 = Ammo.castObject(body0, Ammo.btRigidBody);
-            const wb1 = Ammo.castObject(body1, Ammo.btRigidBody);
+        // don't fire contact events for triggers
+        if (pair.triggerA || pair.triggerB) {
+            const e0Events = e0.collision && (e0.collision.hasEvent('triggerenter') || e0.collision.hasEvent('triggerleave'));
+            const e1Events = e1.collision && (e1.collision.hasEvent('triggerenter') || e1.collision.hasEvent('triggerleave'));
+            const e0BodyEvents = e0.rigidbody && (e0.rigidbody.hasEvent('triggerenter') || e0.rigidbody.hasEvent('triggerleave'));
+            const e1BodyEvents = e1.rigidbody && (e1.rigidbody.hasEvent('triggerenter') || e1.rigidbody.hasEvent('triggerleave'));
 
-            const e0 = wb0.entity;
-            const e1 = wb1.entity;
-
-            // check if entity is null - TODO: investigate when this happens
-            if (!e0 || !e1) {
-                continue;
+            // fire triggerenter events for triggers
+            if (e0Events) {
+                newCollision = this._storeCollision(e0, e1);
+                if (newCollision && !pair.triggerB) {
+                    e0.collision.fire('triggerenter', e1);
+                }
             }
 
-            const flags0 = wb0.getCollisionFlags();
-            const flags1 = wb1.getCollisionFlags();
+            if (e1Events) {
+                newCollision = this._storeCollision(e1, e0);
+                if (newCollision && !pair.triggerA) {
+                    e1.collision.fire('triggerenter', e0);
+                }
+            }
 
-            const numContacts = manifold.getNumContacts();
-            const forwardContacts = [];
-            const reverseContacts = [];
-            let newCollision;
+            // fire triggerenter events for rigidbodies
+            if (e0BodyEvents) {
+                if (!newCollision) {
+                    newCollision = this._storeCollision(e1, e0);
+                }
 
-            if (numContacts > 0) {
-                // don't fire contact events for triggers
-                if ((flags0 & BODYFLAG_NORESPONSE_OBJECT) ||
-                    (flags1 & BODYFLAG_NORESPONSE_OBJECT)) {
+                if (newCollision) {
+                    e0.rigidbody.fire('triggerenter', e1);
+                }
+            }
 
-                    const e0Events = e0.collision && (e0.collision.hasEvent('triggerenter') || e0.collision.hasEvent('triggerleave'));
-                    const e1Events = e1.collision && (e1.collision.hasEvent('triggerenter') || e1.collision.hasEvent('triggerleave'));
-                    const e0BodyEvents = e0.rigidbody && (e0.rigidbody.hasEvent('triggerenter') || e0.rigidbody.hasEvent('triggerleave'));
-                    const e1BodyEvents = e1.rigidbody && (e1.rigidbody.hasEvent('triggerenter') || e1.rigidbody.hasEvent('triggerleave'));
+            if (e1BodyEvents) {
+                if (!newCollision) {
+                    newCollision = this._storeCollision(e0, e1);
+                }
 
-                    // fire triggerenter events for triggers
-                    if (e0Events) {
-                        newCollision = this._storeCollision(e0, e1);
-                        if (newCollision && !(flags1 & BODYFLAG_NORESPONSE_OBJECT)) {
-                            e0.collision.fire('triggerenter', e1);
-                        }
+                if (newCollision) {
+                    e1.rigidbody.fire('triggerenter', e0);
+                }
+            }
+        } else {
+            const e0Events = this._hasContactEvent(e0);
+            const e1Events = this._hasContactEvent(e1);
+            const globalEvents = this.hasEvent('contact');
+
+            if (globalEvents || e0Events || e1Events) {
+                const contactCount = pair.contactCount;
+                for (let j = 0; j < contactCount; j++) {
+                    const contactPoint = this.contactPointPool.allocate();
+                    pair.readContact(j, contactPoint);
+
+                    if (e0Events || e1Events) {
+                        forwardContacts.push(contactPoint);
+                        reverseContacts.push(this._createReverseContactPoint(contactPoint));
                     }
 
-                    if (e1Events) {
-                        newCollision = this._storeCollision(e1, e0);
-                        if (newCollision && !(flags0 & BODYFLAG_NORESPONSE_OBJECT)) {
-                            e1.collision.fire('triggerenter', e0);
-                        }
+                    if (globalEvents) {
+                        // fire global contact event for every contact
+                        const result = this._createSingleContactResult(e0, e1, contactPoint);
+                        this.fire('contact', result);
                     }
+                }
 
-                    // fire triggerenter events for rigidbodies
-                    if (e0BodyEvents) {
-                        if (!newCollision) {
-                            newCollision = this._storeCollision(e1, e0);
-                        }
+                if (e0Events) {
+                    const forwardResult = this._createContactResult(e1, forwardContacts);
+                    newCollision = this._storeCollision(e0, e1);
 
+                    if (e0.collision) {
+                        e0.collision.fire('contact', forwardResult);
                         if (newCollision) {
-                            e0.rigidbody.fire('triggerenter', e1);
+                            e0.collision.fire('collisionstart', forwardResult);
                         }
                     }
 
-                    if (e1BodyEvents) {
-                        if (!newCollision) {
-                            newCollision = this._storeCollision(e0, e1);
-                        }
-
+                    if (e0.rigidbody) {
+                        e0.rigidbody.fire('contact', forwardResult);
                         if (newCollision) {
-                            e1.rigidbody.fire('triggerenter', e0);
+                            e0.rigidbody.fire('collisionstart', forwardResult);
                         }
                     }
-                } else {
-                    const e0Events = this._hasContactEvent(e0);
-                    const e1Events = this._hasContactEvent(e1);
-                    const globalEvents = this.hasEvent('contact');
+                }
 
-                    if (globalEvents || e0Events || e1Events) {
-                        for (let j = 0; j < numContacts; j++) {
-                            const btContactPoint = manifold.getContactPoint(j);
-                            const contactPoint = this._createContactPointFromAmmo(btContactPoint);
+                if (e1Events) {
+                    const reverseResult = this._createContactResult(e0, reverseContacts);
+                    newCollision = this._storeCollision(e1, e0);
 
-                            if (e0Events || e1Events) {
-                                forwardContacts.push(contactPoint);
-                                const reverseContactPoint = this._createReverseContactPointFromAmmo(btContactPoint);
-                                reverseContacts.push(reverseContactPoint);
-                            }
-
-                            if (globalEvents) {
-                                // fire global contact event for every contact
-                                const result = this._createSingleContactResult(e0, e1, contactPoint);
-                                this.fire('contact', result);
-                            }
+                    if (e1.collision) {
+                        e1.collision.fire('contact', reverseResult);
+                        if (newCollision) {
+                            e1.collision.fire('collisionstart', reverseResult);
                         }
+                    }
 
-                        if (e0Events) {
-                            const forwardResult = this._createContactResult(e1, forwardContacts);
-                            newCollision = this._storeCollision(e0, e1);
-
-                            if (e0.collision) {
-                                e0.collision.fire('contact', forwardResult);
-                                if (newCollision) {
-                                    e0.collision.fire('collisionstart', forwardResult);
-                                }
-                            }
-
-                            if (e0.rigidbody) {
-                                e0.rigidbody.fire('contact', forwardResult);
-                                if (newCollision) {
-                                    e0.rigidbody.fire('collisionstart', forwardResult);
-                                }
-                            }
-                        }
-
-                        if (e1Events) {
-                            const reverseResult = this._createContactResult(e0, reverseContacts);
-                            newCollision = this._storeCollision(e1, e0);
-
-                            if (e1.collision) {
-                                e1.collision.fire('contact', reverseResult);
-                                if (newCollision) {
-                                    e1.collision.fire('collisionstart', reverseResult);
-                                }
-                            }
-
-                            if (e1.rigidbody) {
-                                e1.rigidbody.fire('contact', reverseResult);
-                                if (newCollision) {
-                                    e1.rigidbody.fire('collisionstart', reverseResult);
-                                }
-                            }
+                    if (e1.rigidbody) {
+                        e1.rigidbody.fire('contact', reverseResult);
+                        if (newCollision) {
+                            e1.rigidbody.fire('collisionstart', reverseResult);
                         }
                     }
                 }
             }
         }
+    }
 
+    /**
+     * Called by the physics backend when a contact pass ends. Fires collisionend/triggerleave
+     * events for lost contacts and frees the pooled results.
+     *
+     * @ignore
+     */
+    onContactsEnd() {
         // check for collisions that no longer exist and fire events
         this._cleanOldCollisions();
 
@@ -780,9 +663,8 @@ class RigidBodyComponentSystem extends ComponentSystem {
             dynamic[i]._updateDynamic();
         }
 
-        if (!this.dynamicsWorld.setInternalTickCallback) {
-            this._checkForCollisions(Ammo.getPointer(this.dynamicsWorld), dt);
-        }
+        // no-op on backends that report contacts from inside step()
+        this._world.flushContacts();
 
         this._stats.physicsTime = now() - this._stats.physicsStart;
     }
@@ -795,13 +677,6 @@ class RigidBodyComponentSystem extends ComponentSystem {
         if (this._world) {
             this._world.destroy();
             this._world = null;
-        }
-
-        if (typeof Ammo !== 'undefined' && ammoRayStart) {
-            Ammo.destroy(ammoRayStart);
-            Ammo.destroy(ammoRayEnd);
-            ammoRayStart = null;
-            ammoRayEnd = null;
         }
     }
 }

--- a/src/framework/physics/ammo/ammo-physics-body.js
+++ b/src/framework/physics/ammo/ammo-physics-body.js
@@ -1,0 +1,210 @@
+import { BODYTYPE_DYNAMIC, BODYTYPE_KINEMATIC } from '../../components/rigid-body/constants.js';
+import { PhysicsBody } from '../physics-body.js';
+
+/**
+ * @import { AmmoPhysicsWorld } from './ammo-physics-world.js'
+ */
+
+/**
+ * An Ammo.js rigid body. Converts engine math types to Bullet types using the owning world's
+ * cached temporaries - no method allocates.
+ *
+ * @ignore
+ */
+class AmmoPhysicsBody extends PhysicsBody {
+    /**
+     * @type {AmmoPhysicsWorld}
+     * @private
+     */
+    _world;
+
+    /**
+     * The body type the native body was constructed with.
+     *
+     * @type {string}
+     * @private
+     */
+    _type;
+
+    /**
+     * Whether the body was created without contact response (trigger).
+     *
+     * @private
+     */
+    _noContactResponse;
+
+    /**
+     * @param {AmmoPhysicsWorld} world - The owning world.
+     * @param {object} nativeBody - The btRigidBody.
+     * @param {string} type - The body type: BODYTYPE_STATIC, BODYTYPE_DYNAMIC or
+     * BODYTYPE_KINEMATIC.
+     * @param {boolean} noContactResponse - Whether the body has no contact response.
+     */
+    constructor(world, nativeBody, type, noContactResponse) {
+        super();
+        this._world = world;
+        this.nativeBody = nativeBody;
+        this._type = type;
+        this._noContactResponse = noContactResponse;
+    }
+
+    setFriction(friction) {
+        this.nativeBody.setFriction(friction);
+    }
+
+    setRollingFriction(friction) {
+        this.nativeBody.setRollingFriction(friction);
+    }
+
+    setRestitution(restitution) {
+        this.nativeBody.setRestitution(restitution);
+    }
+
+    setDamping(linear, angular) {
+        this.nativeBody.setDamping(linear, angular);
+    }
+
+    setLinearFactor(factor) {
+        const vec = this._world._btVec1;
+        vec.setValue(factor.x, factor.y, factor.z);
+        this.nativeBody.setLinearFactor(vec);
+    }
+
+    setAngularFactor(factor) {
+        const vec = this._world._btVec1;
+        vec.setValue(factor.x, factor.y, factor.z);
+        this.nativeBody.setAngularFactor(vec);
+    }
+
+    setLinearVelocity(velocity) {
+        const vec = this._world._btVec1;
+        vec.setValue(velocity.x, velocity.y, velocity.z);
+        this.nativeBody.setLinearVelocity(vec);
+    }
+
+    getLinearVelocity(velocity) {
+        const vec = this.nativeBody.getLinearVelocity();
+        velocity.set(vec.x(), vec.y(), vec.z());
+    }
+
+    setAngularVelocity(velocity) {
+        const vec = this._world._btVec1;
+        vec.setValue(velocity.x, velocity.y, velocity.z);
+        this.nativeBody.setAngularVelocity(vec);
+    }
+
+    getAngularVelocity(velocity) {
+        const vec = this.nativeBody.getAngularVelocity();
+        velocity.set(vec.x(), vec.y(), vec.z());
+    }
+
+    setMass(mass) {
+        const vec = this._world._btVec1;
+        // calculateLocalInertia writes local inertia to vec here...
+        this.nativeBody.getCollisionShape().calculateLocalInertia(mass, vec);
+        // ...and then writes the calculated local inertia to the body
+        this.nativeBody.setMassProps(mass, vec);
+        this.nativeBody.updateInertiaTensor();
+    }
+
+    isActive() {
+        return this.nativeBody.isActive();
+    }
+
+    activate() {
+        this.nativeBody.activate();
+    }
+
+    setTransform(position, rotation) {
+        const body = this.nativeBody;
+        const transform = this._world._btTransform;
+        const vec = this._world._btVec1;
+        const quat = this._world._btQuat;
+
+        vec.setValue(position.x, position.y, position.z);
+        quat.setValue(rotation.x, rotation.y, rotation.z, rotation.w);
+        transform.setOrigin(vec);
+        transform.setRotation(quat);
+
+        body.setWorldTransform(transform);
+
+        if (this._type === BODYTYPE_KINEMATIC) {
+            const motionState = body.getMotionState();
+            if (motionState) {
+                motionState.setWorldTransform(transform);
+            }
+        } else if (this._type === BODYTYPE_DYNAMIC && !this._noContactResponse && body.setInterpolationWorldTransform) {
+            // Sync the interpolation state so the transform read back by getTransform is the
+            // teleport target on frames that run zero fixed sub-steps (high refresh rates);
+            // zero the interpolation velocities so it is exact, not extrapolated.
+            // Guarded: older ammo builds lack these bindings.
+            body.setInterpolationWorldTransform(transform);
+            vec.setValue(0, 0, 0);
+            body.setInterpolationLinearVelocity(vec);
+            body.setInterpolationAngularVelocity(vec);
+        }
+
+        body.activate();
+    }
+
+    getTransform(position, rotation) {
+        // Note that the test for the presence of the motion state is technically redundant
+        // since the engine creates one for all bodies.
+        const motionState = this.nativeBody.getMotionState();
+        if (motionState) {
+            const transform = this._world._btTransform;
+            motionState.getWorldTransform(transform);
+
+            const p = transform.getOrigin();
+            const q = transform.getRotation();
+            position.set(p.x(), p.y(), p.z());
+            rotation.set(q.x(), q.y(), q.z(), q.w());
+        }
+    }
+
+    setKinematicTarget(position, rotation) {
+        const motionState = this.nativeBody.getMotionState();
+        if (motionState) {
+            const transform = this._world._btTransform;
+            const vec = this._world._btVec1;
+            const quat = this._world._btQuat;
+
+            vec.setValue(position.x, position.y, position.z);
+            quat.setValue(rotation.x, rotation.y, rotation.z, rotation.w);
+            transform.setOrigin(vec);
+            transform.setRotation(quat);
+
+            motionState.setWorldTransform(transform);
+        }
+    }
+
+    applyForce(force, relativePoint) {
+        const vec1 = this._world._btVec1;
+        const vec2 = this._world._btVec2;
+        vec1.setValue(force.x, force.y, force.z);
+        vec2.setValue(relativePoint.x, relativePoint.y, relativePoint.z);
+        this.nativeBody.applyForce(vec1, vec2);
+    }
+
+    applyTorque(torque) {
+        const vec = this._world._btVec1;
+        vec.setValue(torque.x, torque.y, torque.z);
+        this.nativeBody.applyTorque(vec);
+    }
+
+    applyImpulse(impulse, relativePoint) {
+        const vec1 = this._world._btVec1;
+        const vec2 = this._world._btVec2;
+        vec1.setValue(impulse.x, impulse.y, impulse.z);
+        vec2.setValue(relativePoint.x, relativePoint.y, relativePoint.z);
+        this.nativeBody.applyImpulse(vec1, vec2);
+    }
+
+    applyTorqueImpulse(torque) {
+        const vec = this._world._btVec1;
+        vec.setValue(torque.x, torque.y, torque.z);
+        this.nativeBody.applyTorqueImpulse(vec);
+    }
+}
+
+export { AmmoPhysicsBody };

--- a/src/framework/physics/ammo/ammo-physics-joint.js
+++ b/src/framework/physics/ammo/ammo-physics-joint.js
@@ -1,0 +1,440 @@
+import { Debug } from '../../../core/debug.js';
+import { math } from '../../../core/math/math.js';
+import { Mat4 } from '../../../core/math/mat4.js';
+import { Quat } from '../../../core/math/quat.js';
+import { Vec3 } from '../../../core/math/vec3.js';
+import {
+    JOINTTYPE_6DOF, JOINTTYPE_BALL, JOINTTYPE_FIXED, JOINTTYPE_HINGE, JOINTTYPE_SLIDER,
+    MOTION_FREE, MOTION_LIMITED
+} from '../../components/joint/constants.js';
+import { PhysicsJoint } from '../physics-joint.js';
+
+/**
+ * @import { AmmoPhysicsWorld } from './ammo-physics-world.js'
+ * @import { PhysicsJointDesc, PhysicsJointSettings } from '../physics-world.js'
+ */
+
+const _frameMat = new Mat4();
+const _vec3 = new Vec3();
+const _quat = new Quat();
+
+// scratch for dofLimits
+const _dof = { lower: 0, upper: 0 };
+
+// computes the lower/upper pair encoding a 6dof degree of freedom: bullet treats
+// lower > upper as free and lower === upper as locked
+function dofLimits(motion, limits, scale) {
+    if (motion === MOTION_LIMITED) {
+        _dof.lower = limits.x * scale;
+        _dof.upper = limits.y * scale;
+    } else if (motion === MOTION_FREE) {
+        _dof.lower = 1;
+        _dof.upper = 0;
+    } else { // MOTION_LOCKED
+        _dof.lower = 0;
+        _dof.upper = 0;
+    }
+    return _dof;
+}
+
+// Per-type joint implementations, mapping the engine's joint settings onto the most appropriate
+// bullet constraint. Methods other than create are optional - a type without a motor simply
+// omits updateMotor. axisCorrection, where present, rotates both joint frames so that the
+// constraint's native axis lands on the engine's primary (X) joint axis.
+
+const fixedJoint = {
+    create(bodyA, bodyB, frameA, frameB) {
+        return new Ammo.btFixedConstraint(bodyA, bodyB, frameA, frameB);
+    }
+};
+
+const ballJoint = {
+    create(bodyA, bodyB, frameA, frameB) {
+        return new Ammo.btConeTwistConstraint(bodyA, bodyB, frameA, frameB);
+    },
+
+    updateLimits(joint, settings) {
+        const constraint = joint.nativeJoint;
+
+        // setLimit indices: 5 = swing span 1, limiting rotation about the constraint's Z axis
+        // (i.e. swing towards Y), 4 = swing span 2, limiting rotation about Y (swing towards Z),
+        // 3 = twist span about X
+        if (settings.enableLimits) {
+            constraint.setLimit(5, settings.swingLimitY * math.DEG_TO_RAD);
+            constraint.setLimit(4, settings.swingLimitZ * math.DEG_TO_RAD);
+            constraint.setLimit(3, settings.twistLimit * math.DEG_TO_RAD);
+        } else {
+            // bullet treats spans of this magnitude as unlimited
+            constraint.setLimit(5, 1e30);
+            constraint.setLimit(4, 1e30);
+            constraint.setLimit(3, 1e30);
+        }
+    }
+};
+
+const hingeJoint = {
+    // bullet hinges rotate about frame Z - map the engine's X axis onto it
+    axisCorrection: new Mat4().setFromAxisAngle(Vec3.UP, 90),
+
+    create(bodyA, bodyB, frameA, frameB) {
+        return new Ammo.btHingeConstraint(bodyA, bodyB, frameA, frameB, false);
+    },
+
+    updateLimits(joint, settings) {
+        const constraint = joint.nativeJoint;
+        if (settings.enableLimits) {
+            const limits = settings.limits;
+            // the remaining arguments are bullet's default softness, bias and relaxation factors
+            constraint.setLimit(limits.x * math.DEG_TO_RAD, limits.y * math.DEG_TO_RAD, 0.9, 0.3, 1);
+        } else {
+            // lower > upper leaves the rotation unconstrained
+            constraint.setLimit(1, -1, 0.9, 0.3, 1);
+        }
+    },
+
+    updateMotor(joint, settings) {
+        // bullet's hinge motor clamp is an impulse per simulation step, so scale the torque by
+        // the fixed timestep
+        const maxImpulse = settings.maxMotorForce * joint._world._fixedTimeStep;
+        joint.nativeJoint.enableAngularMotor(settings.maxMotorForce > 0, settings.motorSpeed * math.DEG_TO_RAD, maxImpulse);
+    }
+};
+
+const sliderJoint = {
+    create(bodyA, bodyB, frameA, frameB) {
+        // the final argument is useLinearReferenceFrameA - travel is measured in frame A's space
+        return new Ammo.btSliderConstraint(bodyA, bodyB, frameA, frameB, true);
+    },
+
+    updateLimits(joint, settings) {
+        const constraint = joint.nativeJoint;
+        if (settings.enableLimits) {
+            const limits = settings.limits;
+            constraint.setLowerLinLimit(limits.x);
+            constraint.setUpperLinLimit(limits.y);
+        } else {
+            // lower > upper leaves the translation unconstrained
+            constraint.setLowerLinLimit(1);
+            constraint.setUpperLinLimit(-1);
+        }
+
+        // rotation about the slide axis is always locked
+        constraint.setLowerAngLimit(0);
+        constraint.setUpperAngLimit(0);
+    },
+
+    updateMotor(joint, settings) {
+        const constraint = joint.nativeJoint;
+        constraint.setPoweredLinMotor(settings.maxMotorForce > 0);
+        constraint.setTargetLinMotorVelocity(settings.motorSpeed);
+        constraint.setMaxLinMotorForce(settings.maxMotorForce);
+    }
+};
+
+const sixDofJoint = {
+    create(bodyA, bodyB, frameA, frameB) {
+        // the final argument is useLinearReferenceFrameA - linear limits are measured in frame
+        // A's space
+        return new Ammo.btGeneric6DofSpringConstraint(bodyA, bodyB, frameA, frameB, true);
+    },
+
+    updateLimits(joint, settings) {
+        const constraint = joint.nativeJoint;
+
+        let dof = dofLimits(settings.linearMotionX, settings.linearLimitsX, 1);
+        const lx = dof.lower, ux = dof.upper;
+        dof = dofLimits(settings.linearMotionY, settings.linearLimitsY, 1);
+        const ly = dof.lower, uy = dof.upper;
+        dof = dofLimits(settings.linearMotionZ, settings.linearLimitsZ, 1);
+        const lz = dof.lower, uz = dof.upper;
+
+        const limits = joint._world._btVec1;
+        limits.setValue(lx, ly, lz);
+        constraint.setLinearLowerLimit(limits);
+        limits.setValue(ux, uy, uz);
+        constraint.setLinearUpperLimit(limits);
+
+        dof = dofLimits(settings.angularMotionX, settings.angularLimitsX, math.DEG_TO_RAD);
+        const alx = dof.lower, aux = dof.upper;
+        dof = dofLimits(settings.angularMotionY, settings.angularLimitsY, math.DEG_TO_RAD);
+        const aly = dof.lower, auy = dof.upper;
+        dof = dofLimits(settings.angularMotionZ, settings.angularLimitsZ, math.DEG_TO_RAD);
+        const alz = dof.lower, auz = dof.upper;
+
+        limits.setValue(alx, aly, alz);
+        constraint.setAngularLowerLimit(limits);
+        limits.setValue(aux, auy, auz);
+        constraint.setAngularUpperLimit(limits);
+    },
+
+    updateSpring(joint, settings) {
+        const constraint = joint.nativeJoint;
+        const rad = math.DEG_TO_RAD;
+        const linStiffness = settings.linearStiffness;
+        const linDamping = settings.linearDamping;
+        const linEquilibrium = settings.linearEquilibrium;
+        const angStiffness = settings.angularStiffness;
+        const angDamping = settings.angularDamping;
+        const angEquilibrium = settings.angularEquilibrium;
+
+        // a spring acts on an axis when its stiffness component is greater than 0; axes 0-2 are
+        // linear X/Y/Z, axes 3-5 are angular X/Y/Z; angular equilibrium points are specified in
+        // degrees but applied in radians
+        constraint.enableSpring(0, linStiffness.x > 0);
+        constraint.setStiffness(0, linStiffness.x);
+        constraint.setDamping(0, linDamping.x);
+        constraint.setEquilibriumPoint(0, linEquilibrium.x);
+
+        constraint.enableSpring(1, linStiffness.y > 0);
+        constraint.setStiffness(1, linStiffness.y);
+        constraint.setDamping(1, linDamping.y);
+        constraint.setEquilibriumPoint(1, linEquilibrium.y);
+
+        constraint.enableSpring(2, linStiffness.z > 0);
+        constraint.setStiffness(2, linStiffness.z);
+        constraint.setDamping(2, linDamping.z);
+        constraint.setEquilibriumPoint(2, linEquilibrium.z);
+
+        constraint.enableSpring(3, angStiffness.x > 0);
+        constraint.setStiffness(3, angStiffness.x);
+        constraint.setDamping(3, angDamping.x);
+        constraint.setEquilibriumPoint(3, angEquilibrium.x * rad);
+
+        constraint.enableSpring(4, angStiffness.y > 0);
+        constraint.setStiffness(4, angStiffness.y);
+        constraint.setDamping(4, angDamping.y);
+        constraint.setEquilibriumPoint(4, angEquilibrium.y * rad);
+
+        constraint.enableSpring(5, angStiffness.z > 0);
+        constraint.setStiffness(5, angStiffness.z);
+        constraint.setDamping(5, angDamping.z);
+        constraint.setEquilibriumPoint(5, angEquilibrium.z * rad);
+    }
+};
+
+const jointImpls = {
+    [JOINTTYPE_FIXED]: fixedJoint,
+    [JOINTTYPE_BALL]: ballJoint,
+    [JOINTTYPE_HINGE]: hingeJoint,
+    [JOINTTYPE_SLIDER]: sliderJoint,
+    [JOINTTYPE_6DOF]: sixDofJoint
+};
+
+/**
+ * An Ammo.js joint (btTypedConstraint).
+ *
+ * @ignore
+ */
+class AmmoPhysicsJoint extends PhysicsJoint {
+    /**
+     * @type {AmmoPhysicsWorld}
+     * @private
+     */
+    _world;
+
+    /**
+     * The joint type the native constraint was created with.
+     *
+     * @type {string}
+     * @private
+     */
+    _type;
+
+    /**
+     * The break impulse threshold, used by the applied-impulse break probe.
+     *
+     * @private
+     */
+    _breakImpulse = Infinity;
+
+    /**
+     * @param {AmmoPhysicsWorld} world - The owning world.
+     * @param {string} type - The joint type.
+     */
+    constructor(world, type) {
+        super();
+        this._world = world;
+        this._type = type;
+    }
+
+    updateLimits(settings) {
+        const impl = jointImpls[this._type];
+        if (impl.updateLimits) {
+            impl.updateLimits(this, settings);
+            return true;
+        }
+        return false;
+    }
+
+    updateMotor(settings) {
+        const impl = jointImpls[this._type];
+        if (impl.updateMotor) {
+            impl.updateMotor(this, settings);
+            return true;
+        }
+        return false;
+    }
+
+    updateSpring(settings) {
+        const impl = jointImpls[this._type];
+        if (impl.updateSpring) {
+            impl.updateSpring(this, settings);
+            return true;
+        }
+        return false;
+    }
+
+    setBreakImpulse(impulse) {
+        this._breakImpulse = impulse;
+
+        const breakable = Number.isFinite(impulse);
+        this.nativeJoint.setBreakingImpulseThreshold(breakable ? impulse : Number.MAX_VALUE);
+        this.nativeJoint.enableFeedback(breakable);
+    }
+
+    isBroken() {
+        // bullet disables a constraint when its breaking impulse threshold is exceeded but the
+        // stock ammo build exposes no way to query it - prefer isEnabled, then the applied
+        // impulse, then let the caller fall back to its own heuristic
+        const constraint = this.nativeJoint;
+        if (typeof constraint.isEnabled === 'function') {
+            return !constraint.isEnabled();
+        }
+        if (typeof constraint.getAppliedImpulse === 'function') {
+            return constraint.getAppliedImpulse() >= this._breakImpulse;
+        }
+        return null;
+    }
+}
+
+/**
+ * Converts an engine-convention joint frame (a scale-free Mat4 with X as the primary axis) to a
+ * new Ammo.btTransform owned by the caller, applying the joint type's native axis correction in
+ * matrix space.
+ *
+ * @param {Mat4} frameMat - The joint frame.
+ * @param {Mat4|undefined} axisCorrection - The joint type's axis correction, if any.
+ * @returns {object} The frame as a new Ammo.btTransform.
+ */
+function createBtFrame(frameMat, axisCorrection) {
+    _frameMat.copy(frameMat);
+    if (axisCorrection) {
+        _frameMat.mul(axisCorrection);
+    }
+
+    _frameMat.getTranslation(_vec3);
+    _quat.setFromMat4(_frameMat);
+
+    const frame = new Ammo.btTransform();
+    const origin = new Ammo.btVector3(_vec3.x, _vec3.y, _vec3.z);
+    const rotation = new Ammo.btQuaternion(_quat.x, _quat.y, _quat.z, _quat.w);
+    frame.setOrigin(origin);
+    frame.setRotation(rotation);
+    Ammo.destroy(origin);
+    Ammo.destroy(rotation);
+
+    return frame;
+}
+
+/**
+ * Returns the world's shared static body, lazily created and never added to the dynamics world,
+ * that world-pinned joints (bodyB of null) attach to. Its transform is identity, so the frame a
+ * joint computes against it is simply the joint's world frame. This mirrors Bullet's own
+ * getFixedBody pattern and avoids the single-body constraint constructors, some of which do not
+ * transform their frame to world space (notably btConeTwistConstraint).
+ *
+ * @param {AmmoPhysicsWorld} world - The owning world.
+ * @returns {object} The shared static body.
+ */
+function getFixedBody(world) {
+    if (!world._fixedBody) {
+        const transform = new Ammo.btTransform();
+        transform.setIdentity();
+        const motionState = new Ammo.btDefaultMotionState(transform);
+        const shape = new Ammo.btSphereShape(0.001);
+        const inertia = new Ammo.btVector3(0, 0, 0);
+        const info = new Ammo.btRigidBodyConstructionInfo(0, motionState, shape, inertia);
+        world._fixedBody = new Ammo.btRigidBody(info);
+        Ammo.destroy(info);
+        Ammo.destroy(inertia);
+        Ammo.destroy(transform);
+    }
+
+    return world._fixedBody;
+}
+
+/**
+ * @param {AmmoPhysicsWorld} world - The owning world.
+ * @param {PhysicsJointDesc} desc - The joint descriptor.
+ * @returns {AmmoPhysicsJoint} The new joint, added to the simulation.
+ */
+function createJoint(world, desc) {
+    const impl = jointImpls[desc.type];
+    const axisCorrection = impl.axisCorrection;
+    const settings = desc.settings;
+
+    const frameA = createBtFrame(desc.frameA, axisCorrection);
+    const frameB = createBtFrame(desc.frameB, axisCorrection);
+
+    const bodyA = desc.bodyA.nativeBody;
+
+    // world-pinned joints attach to a shared static body with an identity transform
+    const bodyB = desc.bodyB ? desc.bodyB.nativeBody : getFixedBody(world);
+
+    const constraint = impl.create(bodyA, bodyB, frameA, frameB);
+
+    Ammo.destroy(frameA);
+    Ammo.destroy(frameB);
+
+    const joint = new AmmoPhysicsJoint(world, desc.type);
+    joint.nativeJoint = constraint;
+
+    impl.updateLimits?.(joint, settings);
+    impl.updateMotor?.(joint, settings);
+    impl.updateSpring?.(joint, settings);
+
+    if (Number.isFinite(settings.breakImpulse)) {
+        joint.setBreakImpulse(settings.breakImpulse);
+
+        Debug.call(() => {
+            if (desc.type === JOINTTYPE_6DOF &&
+                typeof constraint.isEnabled !== 'function' &&
+                typeof constraint.getAppliedImpulse !== 'function') {
+                Debug.warnOnce('AmmoPhysicsJoint: this ammo build exposes no constraint state, so breakage of 6dof joints cannot be detected - the joint will still break but no break event will fire.');
+            }
+        });
+    }
+
+    bodyA.activate();
+    bodyB.activate();
+
+    world.nativeWorld.addConstraint(constraint, !desc.enableCollision);
+
+    return joint;
+}
+
+/**
+ * @param {AmmoPhysicsWorld} world - The owning world.
+ * @param {AmmoPhysicsJoint} joint - The joint to remove and destroy.
+ */
+function destroyJoint(world, joint) {
+    world.nativeWorld.removeConstraint(joint.nativeJoint);
+    Ammo.destroy(joint.nativeJoint);
+    joint.nativeJoint = null;
+}
+
+/**
+ * Destroys the world's shared fixed anchor body, if it was ever created.
+ *
+ * @param {AmmoPhysicsWorld} world - The owning world.
+ */
+function destroyFixedBody(world) {
+    if (world._fixedBody) {
+        Ammo.destroy(world._fixedBody.getMotionState());
+        Ammo.destroy(world._fixedBody.getCollisionShape());
+        Ammo.destroy(world._fixedBody);
+        world._fixedBody = null;
+    }
+}
+
+export { AmmoPhysicsJoint, createJoint, destroyJoint, destroyFixedBody };

--- a/src/framework/physics/ammo/ammo-physics-joint.js
+++ b/src/framework/physics/ammo/ammo-physics-joint.js
@@ -11,7 +11,7 @@ import { PhysicsJoint } from '../physics-joint.js';
 
 /**
  * @import { AmmoPhysicsWorld } from './ammo-physics-world.js'
- * @import { PhysicsJointDesc, PhysicsJointSettings } from '../physics-world.js'
+ * @import { PhysicsJointDesc } from '../physics-world.js'
  */
 
 const _frameMat = new Mat4();

--- a/src/framework/physics/ammo/ammo-physics-shape.js
+++ b/src/framework/physics/ammo/ammo-physics-shape.js
@@ -1,0 +1,348 @@
+import { Debug } from '../../../core/debug.js';
+
+/**
+ * @import { AmmoPhysicsWorld } from './ammo-physics-world.js'
+ * @import { PhysicsMeshSource, PhysicsShapeDesc } from '../physics-world.js'
+ * @import { Quat } from '../../../core/math/quat.js'
+ * @import { Vec3 } from '../../../core/math/vec3.js'
+ */
+
+/**
+ * Writes a position/rotation pair into the world's cached btTransform and returns it.
+ *
+ * @param {AmmoPhysicsWorld} world - The world providing the temporaries.
+ * @param {Vec3} position - The position.
+ * @param {Quat} rotation - The rotation.
+ * @returns {object} The world's btTransform temporary.
+ */
+function getTransform(world, position, rotation) {
+    const transform = world._btTransform;
+    const vec = world._btVec1;
+    const quat = world._btQuat;
+
+    vec.setValue(position.x, position.y, position.z);
+    quat.setValue(rotation.x, rotation.y, rotation.z, rotation.w);
+    transform.setOrigin(vec);
+    transform.setRotation(quat);
+
+    return transform;
+}
+
+/**
+ * Returns the built triangle mesh for a source, building and caching it on first use. The
+ * cache is keyed by the source id so sources sharing geometry share triangle data - source
+ * data accessors are only read on a cache miss.
+ *
+ * @param {AmmoPhysicsWorld} world - The owning world.
+ * @param {PhysicsMeshSource} source - The geometry source.
+ * @returns {object} The btTriangleMesh.
+ */
+function getTriMesh(world, source) {
+    let triMesh = world._triMeshCache.get(source.id);
+    if (!triMesh) {
+        const positions = source.positions;
+        const stride = source.stride;
+        const indices = source.indices;
+        const base = source.base;
+        const numTriangles = source.count / 3;
+        const checkDupes = source.checkDuplicates;
+
+        const v1 = new Ammo.btVector3();
+        let i1, i2, i3;
+
+        triMesh = new Ammo.btTriangleMesh();
+        world._triMeshCache.set(source.id, triMesh);
+
+        const vertexCache = new Map();
+        Debug.assert(typeof triMesh.getIndexedMeshArray === 'function', 'Ammo.js version is too old, please update to a newer Ammo.');
+        const indexedArray = triMesh.getIndexedMeshArray();
+        indexedArray.at(0).m_numTriangles = numTriangles;
+
+        const bakeScale = source.bakeScale;
+        const sx = bakeScale ? bakeScale.x : 1;
+        const sy = bakeScale ? bakeScale.y : 1;
+        const sz = bakeScale ? bakeScale.z : 1;
+
+        const addVertex = (index) => {
+            const x = positions[index * stride] * sx;
+            const y = positions[index * stride + 1] * sy;
+            const z = positions[index * stride + 2] * sz;
+
+            let idx;
+            if (checkDupes) {
+                const str = `${x}:${y}:${z}`;
+
+                idx = vertexCache.get(str);
+                if (idx !== undefined) {
+                    return idx;
+                }
+
+                v1.setValue(x, y, z);
+                idx = triMesh.findOrAddVertex(v1, false);
+                vertexCache.set(str, idx);
+            } else {
+                v1.setValue(x, y, z);
+                idx = triMesh.findOrAddVertex(v1, false);
+            }
+
+            return idx;
+        };
+
+        for (let i = 0; i < numTriangles; i++) {
+            i1 = addVertex(indices[base + i * 3]);
+            i2 = addVertex(indices[base + i * 3 + 1]);
+            i3 = addVertex(indices[base + i * 3 + 2]);
+
+            triMesh.addIndex(i1);
+            triMesh.addIndex(i2);
+            triMesh.addIndex(i3);
+        }
+
+        Ammo.destroy(v1);
+    }
+
+    return triMesh;
+}
+
+/**
+ * Builds a convex hull sub-shape from a source and adds it to a compound.
+ *
+ * @param {AmmoPhysicsWorld} world - The owning world.
+ * @param {object} compound - The btCompoundShape to add to.
+ * @param {PhysicsMeshSource} source - The geometry source.
+ */
+function createHullChild(world, compound, source) {
+    const hull = new Ammo.btConvexHullShape();
+
+    const point = new Ammo.btVector3();
+
+    const positions = source.positions;
+    const stride = source.stride;
+    const bakeScale = source.bakeScale;
+    const sx = bakeScale ? bakeScale.x : 1;
+    const sy = bakeScale ? bakeScale.y : 1;
+    const sz = bakeScale ? bakeScale.z : 1;
+
+    for (let i = 0; i < positions.length; i += stride) {
+        point.setValue(positions[i] * sx, positions[i + 1] * sy, positions[i + 2] * sz);
+
+        // No need to calculate the aabb here. We'll do it after all points are added.
+        hull.addPoint(point, false);
+    }
+
+    Ammo.destroy(point);
+
+    hull.recalcLocalAabb();
+    hull.setMargin(0.01);   // Note: default margin is 0.04
+
+    compound.addChildShape(getTransform(world, source.position, source.rotation), hull);
+}
+
+/**
+ * Builds a triangle mesh sub-shape from a source and adds it to a compound.
+ *
+ * @param {AmmoPhysicsWorld} world - The owning world.
+ * @param {object} compound - The btCompoundShape to add to.
+ * @param {PhysicsMeshSource} source - The geometry source.
+ */
+function createTriMeshChild(world, compound, source) {
+    const triMesh = getTriMesh(world, source);
+
+    const triMeshShape = new Ammo.btBvhTriangleMeshShape(triMesh, true /* useQuantizedAabbCompression */);
+
+    const shapeScale = source.shapeScale;
+    if (shapeScale) {
+        const vec = world._btVec1;
+        vec.setValue(shapeScale.x, shapeScale.y, shapeScale.z);
+        triMeshShape.setLocalScaling(vec);
+    }
+
+    compound.addChildShape(getTransform(world, source.position, source.rotation), triMeshShape);
+}
+
+/**
+ * Per-type native shape creation. Sizes use engine conventions (full heights) and are
+ * converted to Bullet conventions here.
+ *
+ * @type {Object<string, (world: AmmoPhysicsWorld, desc: PhysicsShapeDesc) => object>}
+ */
+const shapeFactories = {
+    box: (world, desc) => {
+        const he = desc.halfExtents;
+        const ammoHe = new Ammo.btVector3(he.x, he.y, he.z);
+        const shape = new Ammo.btBoxShape(ammoHe);
+        Ammo.destroy(ammoHe);
+        return shape;
+    },
+
+    sphere: (world, desc) => {
+        return new Ammo.btSphereShape(desc.radius);
+    },
+
+    capsule: (world, desc) => {
+        const radius = desc.radius;
+        const height = Math.max(desc.height - 2 * radius, 0);
+        switch (desc.axis) {
+            case 0: return new Ammo.btCapsuleShapeX(radius, height);
+            case 2: return new Ammo.btCapsuleShapeZ(radius, height);
+            default: return new Ammo.btCapsuleShape(radius, height);
+        }
+    },
+
+    cylinder: (world, desc) => {
+        const radius = desc.radius;
+        const height = desc.height;
+
+        let halfExtents = null;
+        let shape = null;
+        switch (desc.axis) {
+            case 0:
+                halfExtents = new Ammo.btVector3(height * 0.5, radius, radius);
+                shape = new Ammo.btCylinderShapeX(halfExtents);
+                break;
+            case 2:
+                halfExtents = new Ammo.btVector3(radius, radius, height * 0.5);
+                shape = new Ammo.btCylinderShapeZ(halfExtents);
+                break;
+            default:
+                halfExtents = new Ammo.btVector3(radius, height * 0.5, radius);
+                shape = new Ammo.btCylinderShape(halfExtents);
+                break;
+        }
+        Ammo.destroy(halfExtents);
+        return shape;
+    },
+
+    cone: (world, desc) => {
+        switch (desc.axis) {
+            case 0: return new Ammo.btConeShapeX(desc.radius, desc.height);
+            case 2: return new Ammo.btConeShapeZ(desc.radius, desc.height);
+            default: return new Ammo.btConeShape(desc.radius, desc.height);
+        }
+    },
+
+    mesh: (world, desc) => {
+        const shape = new Ammo.btCompoundShape();
+
+        const sources = desc.sources;
+        for (let i = 0; i < sources.length; i++) {
+            const source = sources[i];
+            if (source.convexHull) {
+                createHullChild(world, shape, source);
+            } else {
+                createTriMeshChild(world, shape, source);
+            }
+        }
+
+        if (desc.scale) {
+            const vec = new Ammo.btVector3(desc.scale.x, desc.scale.y, desc.scale.z);
+            shape.setLocalScaling(vec);
+            Ammo.destroy(vec);
+        }
+
+        return shape;
+    },
+
+    compound: (world, desc) => {
+        return new Ammo.btCompoundShape();
+    }
+};
+
+/**
+ * @param {AmmoPhysicsWorld} world - The owning world.
+ * @param {PhysicsShapeDesc} desc - The shape descriptor.
+ * @returns {object} The native shape, tagged with its descriptor type for destroyShape.
+ */
+function createShape(world, desc) {
+    const factory = shapeFactories[desc.type];
+    Debug.assert(factory, `AmmoPhysicsWorld#createShape: invalid shape type: ${desc.type}`);
+
+    const shape = factory(world, desc);
+    shape._shapeType = desc.type;
+    return shape;
+}
+
+/**
+ * @param {object} shape - The native shape to destroy.
+ */
+function destroyShape(shape) {
+    // mesh shapes own their sub-shapes (compound children are owned by other components,
+    // and the cached triangle data outlives the shape)
+    if (shape._shapeType === 'mesh') {
+        const numShapes = shape.getNumChildShapes();
+        for (let i = 0; i < numShapes; i++) {
+            Ammo.destroy(shape.getChildShape(i));
+        }
+    }
+
+    Ammo.destroy(shape);
+}
+
+/**
+ * Returns the index of a child within a compound shape by native pointer identity, or -1.
+ *
+ * @param {object} compound - The btCompoundShape.
+ * @param {object} child - The child shape.
+ * @returns {number} The child index, or -1 if absent.
+ */
+function indexOfCompoundChild(compound, child) {
+    const childPointer = Ammo.getPointer(child);
+    const numShapes = compound.getNumChildShapes();
+
+    for (let i = 0; i < numShapes; i++) {
+        if (Ammo.getPointer(compound.getChildShape(i)) === childPointer) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+/**
+ * @param {AmmoPhysicsWorld} world - The owning world.
+ * @param {object} compound - The btCompoundShape.
+ * @param {object} child - The child shape.
+ * @param {Vec3} position - The child position in the compound's local space.
+ * @param {Quat} rotation - The child rotation in the compound's local space.
+ */
+function addCompoundChild(world, compound, child, position, rotation) {
+    compound.addChildShape(getTransform(world, position, rotation), child);
+}
+
+/**
+ * @param {AmmoPhysicsWorld} world - The owning world.
+ * @param {object} compound - The btCompoundShape.
+ * @param {object} child - The child shape.
+ * @param {Vec3} position - The child position in the compound's local space.
+ * @param {Quat} rotation - The child rotation in the compound's local space.
+ */
+function updateCompoundChild(world, compound, child, position, rotation) {
+    const transform = getTransform(world, position, rotation);
+    const idx = indexOfCompoundChild(compound, child);
+    if (idx < 0) {
+        compound.addChildShape(transform, child);
+    } else {
+        compound.updateChildTransform(idx, transform, true);
+    }
+}
+
+/**
+ * @param {object} compound - The btCompoundShape.
+ * @param {object} child - The child shape.
+ */
+function removeCompoundChild(compound, child) {
+    if (compound.getNumChildShapes() === 0) {
+        return;
+    }
+
+    if (compound.removeChildShape) {
+        compound.removeChildShape(child);
+    } else {
+        const idx = indexOfCompoundChild(compound, child);
+        if (idx >= 0) {
+            compound.removeChildShapeByIndex(idx);
+        }
+    }
+}
+
+export { createShape, destroyShape, addCompoundChild, updateCompoundChild, removeCompoundChild };

--- a/src/framework/physics/ammo/ammo-physics-world.js
+++ b/src/framework/physics/ammo/ammo-physics-world.js
@@ -1,8 +1,15 @@
 import { Debug } from '../../../core/debug.js';
+import {
+    BODYFLAG_KINEMATIC_OBJECT, BODYFLAG_NORESPONSE_OBJECT,
+    BODYSTATE_ACTIVE_TAG, BODYSTATE_DISABLE_DEACTIVATION, BODYSTATE_DISABLE_SIMULATION,
+    BODYTYPE_KINEMATIC
+} from '../../components/rigid-body/constants.js';
 import { PhysicsWorld } from '../physics-world.js';
+import { AmmoPhysicsBody } from './ammo-physics-body.js';
 
 /**
  * @import { Vec3 } from '../../../core/math/vec3.js'
+ * @import { PhysicsBodyDesc } from '../physics-world.js'
  */
 
 /**
@@ -39,9 +46,24 @@ class AmmoPhysicsWorld extends PhysicsWorld {
         } else {
             Debug.warn('WARNING: This version of ammo.js can potentially fail to report contacts. Please update it to the latest version.');
         }
+
+        // cached math temporaries, shared by this world's bodies
+        this._btVec1 = new Ammo.btVector3();
+        this._btVec2 = new Ammo.btVector3();
+        this._btQuat = new Ammo.btQuaternion();
+        this._btTransform = new Ammo.btTransform();
     }
 
     destroy() {
+        Ammo.destroy(this._btVec1);
+        Ammo.destroy(this._btVec2);
+        Ammo.destroy(this._btQuat);
+        Ammo.destroy(this._btTransform);
+        this._btVec1 = null;
+        this._btVec2 = null;
+        this._btQuat = null;
+        this._btTransform = null;
+
         Ammo.destroy(this.nativeWorld);
         Ammo.destroy(this.solver);
         Ammo.destroy(this.overlappingPairCache);
@@ -52,6 +74,79 @@ class AmmoPhysicsWorld extends PhysicsWorld {
         this.overlappingPairCache = null;
         this.dispatcher = null;
         this.collisionConfiguration = null;
+    }
+
+    /**
+     * @param {PhysicsBodyDesc} desc - The body descriptor.
+     * @returns {AmmoPhysicsBody} The new body.
+     */
+    createBody(desc) {
+        const { type, mass, shape, position, rotation, entity } = desc;
+        const noContactResponse = !!desc.noContactResponse;
+
+        this._btVec1.setValue(position.x, position.y, position.z);
+        this._btQuat.setValue(rotation.x, rotation.y, rotation.z, rotation.w);
+        this._btTransform.setOrigin(this._btVec1);
+        this._btTransform.setRotation(this._btQuat);
+
+        const localInertia = new Ammo.btVector3(0, 0, 0);
+        if (mass !== 0) {
+            shape.calculateLocalInertia(mass, localInertia);
+        }
+
+        const motionState = new Ammo.btDefaultMotionState(this._btTransform);
+        const bodyInfo = new Ammo.btRigidBodyConstructionInfo(mass, motionState, shape, localInertia);
+        const nativeBody = new Ammo.btRigidBody(bodyInfo);
+        Ammo.destroy(bodyInfo);
+        Ammo.destroy(localInertia);
+
+        if (type === BODYTYPE_KINEMATIC) {
+            nativeBody.setCollisionFlags(nativeBody.getCollisionFlags() | BODYFLAG_KINEMATIC_OBJECT);
+            nativeBody.setActivationState(BODYSTATE_DISABLE_DEACTIVATION);
+        }
+        if (noContactResponse) {
+            nativeBody.setCollisionFlags(nativeBody.getCollisionFlags() | BODYFLAG_NORESPONSE_OBJECT);
+        }
+
+        // entity back-reference on the native body: read by the raycast and manifold walks,
+        // and by user code holding the native escape hatch
+        nativeBody.entity = entity;
+
+        const body = new AmmoPhysicsBody(this, nativeBody, type, noContactResponse);
+        body.entity = entity;
+        return body;
+    }
+
+    destroyBody(body) {
+        const nativeBody = body.nativeBody;
+        // The motion state needs to be destroyed explicitly (if present)
+        const motionState = nativeBody.getMotionState();
+        if (motionState) {
+            Ammo.destroy(motionState);
+        }
+        Ammo.destroy(nativeBody);
+        body.nativeBody = null;
+    }
+
+    addBody(body, group, mask) {
+        const nativeBody = body.nativeBody;
+        if (group !== undefined && mask !== undefined) {
+            this.nativeWorld.addRigidBody(nativeBody, group, mask);
+        } else {
+            this.nativeWorld.addRigidBody(nativeBody);
+        }
+
+        // kinematic bodies must never deactivate, everything else enters the active state
+        nativeBody.forceActivationState(body._type === BODYTYPE_KINEMATIC ? BODYSTATE_DISABLE_DEACTIVATION : BODYSTATE_ACTIVE_TAG);
+    }
+
+    removeBody(body) {
+        const nativeBody = body.nativeBody;
+        this.nativeWorld.removeRigidBody(nativeBody);
+
+        // set activation state to disable simulation so isActive() does not return true even
+        // though the body is no longer in the world
+        nativeBody.forceActivationState(BODYSTATE_DISABLE_SIMULATION);
     }
 
     /**

--- a/src/framework/physics/ammo/ammo-physics-world.js
+++ b/src/framework/physics/ammo/ammo-physics-world.js
@@ -8,13 +8,18 @@ import {
 import { RaycastResult } from '../../components/rigid-body/raycast-result.js';
 import { PhysicsWorld } from '../physics-world.js';
 import { AmmoPhysicsBody } from './ammo-physics-body.js';
+import { createJoint, destroyJoint, destroyFixedBody } from './ammo-physics-joint.js';
+
+/**
+ * @import { AmmoPhysicsJoint } from './ammo-physics-joint.js'
+ */
 import {
     createShape, destroyShape, addCompoundChild, updateCompoundChild, removeCompoundChild
 } from './ammo-physics-shape.js';
 
 /**
  * @import { ContactPoint } from '../../components/rigid-body/contact-point.js'
- * @import { PhysicsBodyDesc, PhysicsShapeDesc } from '../physics-world.js'
+ * @import { PhysicsBodyDesc, PhysicsJointDesc, PhysicsShapeDesc } from '../physics-world.js'
  */
 
 /**
@@ -84,6 +89,21 @@ class AmmoPhysicsWorld extends PhysicsWorld {
     _triMeshCache = new Map();
 
     /**
+     * The shared static body world-pinned joints attach to, lazily created.
+     *
+     * @type {object|null}
+     * @ignore
+     */
+    _fixedBody = null;
+
+    /**
+     * The fixed timestep of the last simulation step, used by joint motor conversions.
+     *
+     * @ignore
+     */
+    _fixedTimeStep = 1 / 60;
+
+    /**
      * Create a new AmmoPhysicsWorld instance.
      *
      * @param {object} [options] - The world options. See {@link PhysicsWorld}.
@@ -121,6 +141,8 @@ class AmmoPhysicsWorld extends PhysicsWorld {
     destroy() {
         this._triMeshCache.forEach(triMesh => Ammo.destroy(triMesh));
         this._triMeshCache.clear();
+
+        destroyFixedBody(this);
 
         Ammo.destroy(this._btVec1);
         Ammo.destroy(this._btVec2);
@@ -249,6 +271,18 @@ class AmmoPhysicsWorld extends PhysicsWorld {
     }
 
     /**
+     * @param {PhysicsJointDesc} desc - The joint descriptor.
+     * @returns {AmmoPhysicsJoint} The new joint.
+     */
+    createJoint(desc) {
+        return createJoint(this, desc);
+    }
+
+    destroyJoint(joint) {
+        destroyJoint(this, joint);
+    }
+
+    /**
      * @param {Vec3} gravity - The world space gravity.
      */
     setGravity(gravity) {
@@ -270,6 +304,7 @@ class AmmoPhysicsWorld extends PhysicsWorld {
     }
 
     step(dt, maxSubSteps, fixedTimeStep) {
+        this._fixedTimeStep = fixedTimeStep;
         this.nativeWorld.stepSimulation(dt, maxSubSteps, fixedTimeStep);
     }
 

--- a/src/framework/physics/ammo/ammo-physics-world.js
+++ b/src/framework/physics/ammo/ammo-physics-world.js
@@ -6,10 +6,13 @@ import {
 } from '../../components/rigid-body/constants.js';
 import { PhysicsWorld } from '../physics-world.js';
 import { AmmoPhysicsBody } from './ammo-physics-body.js';
+import {
+    createShape, destroyShape, addCompoundChild, updateCompoundChild, removeCompoundChild
+} from './ammo-physics-shape.js';
 
 /**
  * @import { Vec3 } from '../../../core/math/vec3.js'
- * @import { PhysicsBodyDesc } from '../physics-world.js'
+ * @import { PhysicsBodyDesc, PhysicsShapeDesc } from '../physics-world.js'
  */
 
 /**
@@ -22,6 +25,15 @@ import { AmmoPhysicsBody } from './ammo-physics-body.js';
 class AmmoPhysicsWorld extends PhysicsWorld {
     /** @private */
     _gravityFloat32 = new Float32Array(3);
+
+    /**
+     * Built triangle data cached per geometry source id, shared by all mesh shapes created
+     * from the same geometry. Entries live until the world is destroyed.
+     *
+     * @type {Map<number, object>}
+     * @ignore
+     */
+    _triMeshCache = new Map();
 
     /**
      * Create a new AmmoPhysicsWorld instance.
@@ -55,6 +67,9 @@ class AmmoPhysicsWorld extends PhysicsWorld {
     }
 
     destroy() {
+        this._triMeshCache.forEach(triMesh => Ammo.destroy(triMesh));
+        this._triMeshCache.clear();
+
         Ammo.destroy(this._btVec1);
         Ammo.destroy(this._btVec2);
         Ammo.destroy(this._btQuat);
@@ -147,6 +162,34 @@ class AmmoPhysicsWorld extends PhysicsWorld {
         // set activation state to disable simulation so isActive() does not return true even
         // though the body is no longer in the world
         nativeBody.forceActivationState(BODYSTATE_DISABLE_SIMULATION);
+    }
+
+    /**
+     * @param {PhysicsShapeDesc} desc - The shape descriptor.
+     * @returns {object} The opaque shape handle (the native btCollisionShape).
+     */
+    createShape(desc) {
+        return createShape(this, desc);
+    }
+
+    destroyShape(shape) {
+        destroyShape(shape);
+    }
+
+    addCompoundChild(compound, child, position, rotation) {
+        addCompoundChild(this, compound, child, position, rotation);
+    }
+
+    updateCompoundChild(compound, child, position, rotation) {
+        updateCompoundChild(this, compound, child, position, rotation);
+    }
+
+    removeCompoundChild(compound, child) {
+        removeCompoundChild(compound, child);
+    }
+
+    getCompoundChildCount(compound) {
+        return compound.getNumChildShapes();
     }
 
     /**

--- a/src/framework/physics/ammo/ammo-physics-world.js
+++ b/src/framework/physics/ammo/ammo-physics-world.js
@@ -1,9 +1,11 @@
 import { Debug } from '../../../core/debug.js';
+import { Vec3 } from '../../../core/math/vec3.js';
 import {
     BODYFLAG_KINEMATIC_OBJECT, BODYFLAG_NORESPONSE_OBJECT,
     BODYSTATE_ACTIVE_TAG, BODYSTATE_DISABLE_DEACTIVATION, BODYSTATE_DISABLE_SIMULATION,
     BODYTYPE_KINEMATIC
 } from '../../components/rigid-body/constants.js';
+import { RaycastResult } from '../../components/rigid-body/raycast-result.js';
 import { PhysicsWorld } from '../physics-world.js';
 import { AmmoPhysicsBody } from './ammo-physics-body.js';
 import {
@@ -11,9 +13,55 @@ import {
 } from './ammo-physics-shape.js';
 
 /**
- * @import { Vec3 } from '../../../core/math/vec3.js'
+ * @import { ContactPoint } from '../../components/rigid-body/contact-point.js'
  * @import { PhysicsBodyDesc, PhysicsShapeDesc } from '../physics-world.js'
  */
+
+/**
+ * The reused contact pair reported to the contact listener. Reads contact point data straight
+ * from the current native manifold - nothing is allocated.
+ *
+ * @ignore
+ */
+class AmmoContactPair {
+    entityA = null;
+
+    entityB = null;
+
+    triggerA = false;
+
+    triggerB = false;
+
+    contactCount = 0;
+
+    /**
+     * The native btPersistentManifold currently being reported.
+     *
+     * @private
+     */
+    _manifold = null;
+
+    /**
+     * @param {number} index - The contact point index.
+     * @param {ContactPoint} out - The contact point to fill, from body A's perspective.
+     */
+    readContact(index, out) {
+        const contactPoint = this._manifold.getContactPoint(index);
+
+        const localPointA = contactPoint.get_m_localPointA();
+        const localPointB = contactPoint.get_m_localPointB();
+        const positionWorldOnA = contactPoint.getPositionWorldOnA();
+        const positionWorldOnB = contactPoint.getPositionWorldOnB();
+        const normalWorldOnB = contactPoint.get_m_normalWorldOnB();
+
+        out.localPoint.set(localPointA.x(), localPointA.y(), localPointA.z());
+        out.localPointOther.set(localPointB.x(), localPointB.y(), localPointB.z());
+        out.point.set(positionWorldOnA.x(), positionWorldOnA.y(), positionWorldOnA.z());
+        out.pointOther.set(positionWorldOnB.x(), positionWorldOnB.y(), positionWorldOnB.z());
+        out.normal.set(normalWorldOnB.x(), normalWorldOnB.y(), normalWorldOnB.z());
+        out.impulse = contactPoint.getAppliedImpulse();
+    }
+}
 
 /**
  * The Ammo.js (Bullet) physics backend. Expects the `Ammo` global to be available when
@@ -38,10 +86,7 @@ class AmmoPhysicsWorld extends PhysicsWorld {
     /**
      * Create a new AmmoPhysicsWorld instance.
      *
-     * @param {object} [options] - The world options.
-     * @param {Function} [options.onTick] - Raw simulation tick callback, invoked per fixed
-     * substep with (worldPointer, timeStep) on ammo builds that support internal tick
-     * callbacks.
+     * @param {object} [options] - The world options. See {@link PhysicsWorld}.
      */
     constructor(options = {}) {
         super(options);
@@ -52,18 +97,25 @@ class AmmoPhysicsWorld extends PhysicsWorld {
         this.solver = new Ammo.btSequentialImpulseConstraintSolver();
         this.nativeWorld = new Ammo.btDiscreteDynamicsWorld(this.dispatcher, this.overlappingPairCache, this.solver, this.collisionConfiguration);
 
-        if (this.nativeWorld.setInternalTickCallback) {
-            const checkForCollisionsPointer = Ammo.addFunction(options.onTick, 'vif');
+        // report contacts per fixed substep from inside stepSimulation where supported,
+        // otherwise defer to flushContacts()
+        this._useTickCallback = !!this.nativeWorld.setInternalTickCallback;
+        if (this._useTickCallback) {
+            const checkForCollisionsPointer = Ammo.addFunction(() => this._walkContacts(), 'vif');
             this.nativeWorld.setInternalTickCallback(checkForCollisionsPointer);
         } else {
             Debug.warn('WARNING: This version of ammo.js can potentially fail to report contacts. Please update it to the latest version.');
         }
+
+        this._contactPair = new AmmoContactPair();
 
         // cached math temporaries, shared by this world's bodies
         this._btVec1 = new Ammo.btVector3();
         this._btVec2 = new Ammo.btVector3();
         this._btQuat = new Ammo.btQuaternion();
         this._btTransform = new Ammo.btTransform();
+        this._btRayStart = new Ammo.btVector3();
+        this._btRayEnd = new Ammo.btVector3();
     }
 
     destroy() {
@@ -74,10 +126,14 @@ class AmmoPhysicsWorld extends PhysicsWorld {
         Ammo.destroy(this._btVec2);
         Ammo.destroy(this._btQuat);
         Ammo.destroy(this._btTransform);
+        Ammo.destroy(this._btRayStart);
+        Ammo.destroy(this._btRayEnd);
         this._btVec1 = null;
         this._btVec2 = null;
         this._btQuat = null;
         this._btTransform = null;
+        this._btRayStart = null;
+        this._btRayEnd = null;
 
         Ammo.destroy(this.nativeWorld);
         Ammo.destroy(this.solver);
@@ -215,6 +271,156 @@ class AmmoPhysicsWorld extends PhysicsWorld {
 
     step(dt, maxSubSteps, fixedTimeStep) {
         this.nativeWorld.stepSimulation(dt, maxSubSteps, fixedTimeStep);
+    }
+
+    flushContacts() {
+        // ammo builds without internal tick callbacks get one contact pass per frame instead,
+        // deliberately after the caller's dynamic transform sync
+        if (!this._useTickCallback) {
+            this._walkContacts();
+        }
+    }
+
+    /**
+     * Walks the dispatcher's contact manifolds and reports each contacting pair with entities
+     * on both bodies to the contact listener.
+     *
+     * @private
+     */
+    _walkContacts() {
+        const listener = this.contactListener;
+        if (!listener) {
+            return;
+        }
+
+        listener.onContactsBegin();
+
+        const dispatcher = this.dispatcher;
+        const numManifolds = dispatcher.getNumManifolds();
+        const pair = this._contactPair;
+
+        for (let i = 0; i < numManifolds; i++) {
+            const manifold = dispatcher.getManifoldByIndexInternal(i);
+
+            const wb0 = Ammo.castObject(manifold.getBody0(), Ammo.btRigidBody);
+            const wb1 = Ammo.castObject(manifold.getBody1(), Ammo.btRigidBody);
+
+            const e0 = wb0.entity;
+            const e1 = wb1.entity;
+
+            // check if entity is null - TODO: investigate when this happens
+            if (!e0 || !e1) {
+                continue;
+            }
+
+            const numContacts = manifold.getNumContacts();
+            if (numContacts > 0) {
+                pair.entityA = e0;
+                pair.entityB = e1;
+                pair.triggerA = (wb0.getCollisionFlags() & BODYFLAG_NORESPONSE_OBJECT) !== 0;
+                pair.triggerB = (wb1.getCollisionFlags() & BODYFLAG_NORESPONSE_OBJECT) !== 0;
+                pair.contactCount = numContacts;
+                pair._manifold = manifold;
+
+                listener.onContactPair(pair);
+            }
+        }
+
+        pair.entityA = null;
+        pair.entityB = null;
+        pair._manifold = null;
+
+        listener.onContactsEnd();
+    }
+
+    raycastFirst(start, end, options = {}) {
+        let result = null;
+
+        this._btRayStart.setValue(start.x, start.y, start.z);
+        this._btRayEnd.setValue(end.x, end.y, end.z);
+        const rayCallback = new Ammo.ClosestRayResultCallback(this._btRayStart, this._btRayEnd);
+
+        if (typeof options.filterCollisionGroup === 'number') {
+            rayCallback.set_m_collisionFilterGroup(options.filterCollisionGroup);
+        }
+
+        if (typeof options.filterCollisionMask === 'number') {
+            rayCallback.set_m_collisionFilterMask(options.filterCollisionMask);
+        }
+
+        this.nativeWorld.rayTest(this._btRayStart, this._btRayEnd, rayCallback);
+        if (rayCallback.hasHit()) {
+            const collisionObj = rayCallback.get_m_collisionObject();
+            const body = Ammo.castObject(collisionObj, Ammo.btRigidBody);
+
+            if (body) {
+                const point = rayCallback.get_m_hitPointWorld();
+                const normal = rayCallback.get_m_hitNormalWorld();
+
+                result = new RaycastResult(
+                    body.entity,
+                    new Vec3(point.x(), point.y(), point.z()),
+                    new Vec3(normal.x(), normal.y(), normal.z()),
+                    rayCallback.get_m_closestHitFraction()
+                );
+            }
+        }
+
+        Ammo.destroy(rayCallback);
+
+        return result;
+    }
+
+    raycastAll(start, end, options = {}) {
+        Debug.assert(Ammo.AllHitsRayResultCallback, 'AmmoPhysicsWorld#raycastAll: Your version of ammo.js does not expose Ammo.AllHitsRayResultCallback. Update it to latest.');
+
+        const results = [];
+
+        this._btRayStart.setValue(start.x, start.y, start.z);
+        this._btRayEnd.setValue(end.x, end.y, end.z);
+        const rayCallback = new Ammo.AllHitsRayResultCallback(this._btRayStart, this._btRayEnd);
+
+        if (typeof options.filterCollisionGroup === 'number') {
+            rayCallback.set_m_collisionFilterGroup(options.filterCollisionGroup);
+        }
+
+        if (typeof options.filterCollisionMask === 'number') {
+            rayCallback.set_m_collisionFilterMask(options.filterCollisionMask);
+        }
+
+        this.nativeWorld.rayTest(this._btRayStart, this._btRayEnd, rayCallback);
+        if (rayCallback.hasHit()) {
+            const collisionObjs = rayCallback.get_m_collisionObjects();
+            const points = rayCallback.get_m_hitPointWorld();
+            const normals = rayCallback.get_m_hitNormalWorld();
+            const hitFractions = rayCallback.get_m_hitFractions();
+
+            const numHits = collisionObjs.size();
+            for (let i = 0; i < numHits; i++) {
+                const body = Ammo.castObject(collisionObjs.at(i), Ammo.btRigidBody);
+
+                if (body && body.entity) {
+                    if (options.filterTags && !body.entity.tags.has(...options.filterTags) || options.filterCallback && !options.filterCallback(body.entity)) {
+                        continue;
+                    }
+
+                    const point = points.at(i);
+                    const normal = normals.at(i);
+                    const result = new RaycastResult(
+                        body.entity,
+                        new Vec3(point.x(), point.y(), point.z()),
+                        new Vec3(normal.x(), normal.y(), normal.z()),
+                        hitFractions.at(i)
+                    );
+
+                    results.push(result);
+                }
+            }
+        }
+
+        Ammo.destroy(rayCallback);
+
+        return results;
     }
 }
 

--- a/src/framework/physics/ammo/ammo-physics-world.js
+++ b/src/framework/physics/ammo/ammo-physics-world.js
@@ -1,0 +1,83 @@
+import { Debug } from '../../../core/debug.js';
+import { PhysicsWorld } from '../physics-world.js';
+
+/**
+ * @import { Vec3 } from '../../../core/math/vec3.js'
+ */
+
+/**
+ * The Ammo.js (Bullet) physics backend. Expects the `Ammo` global to be available when
+ * constructed - the RigidBodyComponentSystem only creates it after the Ammo WasmModule has
+ * loaded.
+ *
+ * @ignore
+ */
+class AmmoPhysicsWorld extends PhysicsWorld {
+    /** @private */
+    _gravityFloat32 = new Float32Array(3);
+
+    /**
+     * Create a new AmmoPhysicsWorld instance.
+     *
+     * @param {object} [options] - The world options.
+     * @param {Function} [options.onTick] - Raw simulation tick callback, invoked per fixed
+     * substep with (worldPointer, timeStep) on ammo builds that support internal tick
+     * callbacks.
+     */
+    constructor(options = {}) {
+        super(options);
+
+        this.collisionConfiguration = new Ammo.btDefaultCollisionConfiguration();
+        this.dispatcher = new Ammo.btCollisionDispatcher(this.collisionConfiguration);
+        this.overlappingPairCache = new Ammo.btDbvtBroadphase();
+        this.solver = new Ammo.btSequentialImpulseConstraintSolver();
+        this.nativeWorld = new Ammo.btDiscreteDynamicsWorld(this.dispatcher, this.overlappingPairCache, this.solver, this.collisionConfiguration);
+
+        if (this.nativeWorld.setInternalTickCallback) {
+            const checkForCollisionsPointer = Ammo.addFunction(options.onTick, 'vif');
+            this.nativeWorld.setInternalTickCallback(checkForCollisionsPointer);
+        } else {
+            Debug.warn('WARNING: This version of ammo.js can potentially fail to report contacts. Please update it to the latest version.');
+        }
+    }
+
+    destroy() {
+        Ammo.destroy(this.nativeWorld);
+        Ammo.destroy(this.solver);
+        Ammo.destroy(this.overlappingPairCache);
+        Ammo.destroy(this.dispatcher);
+        Ammo.destroy(this.collisionConfiguration);
+        this.nativeWorld = null;
+        this.solver = null;
+        this.overlappingPairCache = null;
+        this.dispatcher = null;
+        this.collisionConfiguration = null;
+    }
+
+    /**
+     * @param {Vec3} gravity - The world space gravity.
+     */
+    setGravity(gravity) {
+        // downcast gravity to float32 so we can accurately compare with existing gravity set
+        // in the world
+        this._gravityFloat32[0] = gravity.x;
+        this._gravityFloat32[1] = gravity.y;
+        this._gravityFloat32[2] = gravity.z;
+
+        // compare against the world's own value so writes through the native escape hatch are
+        // still detected
+        const current = this.nativeWorld.getGravity();
+        if (current.x() !== this._gravityFloat32[0] ||
+            current.y() !== this._gravityFloat32[1] ||
+            current.z() !== this._gravityFloat32[2]) {
+            current.setValue(gravity.x, gravity.y, gravity.z);
+            this.nativeWorld.setGravity(current);
+        }
+    }
+
+    step(dt, maxSubSteps, fixedTimeStep) {
+        this.nativeWorld.stepSimulation(dt, maxSubSteps, fixedTimeStep);
+    }
+}
+
+export { AmmoPhysicsWorld };

--- a/src/framework/physics/null/null-physics-world.js
+++ b/src/framework/physics/null/null-physics-world.js
@@ -1,0 +1,21 @@
+import { PhysicsWorld } from '../physics-world.js';
+
+/**
+ * A no-op physics backend. The {@link PhysicsWorld} base class is a functional no-op - bodies,
+ * shapes and joints are created but inert, raycasts miss and stepping does nothing - so this
+ * subclass adds nothing. It exists to let component lifecycle run in tests without a physics
+ * engine loaded, and is installed explicitly:
+ *
+ * ```javascript
+ * app.systems.rigidbody.setPhysicsWorld(new NullPhysicsWorld());
+ * ```
+ *
+ * It is never auto-selected - without it, an application with no physics library keeps today's
+ * behavior where physics components are inert placeholders.
+ *
+ * @ignore
+ */
+class NullPhysicsWorld extends PhysicsWorld {
+}
+
+export { NullPhysicsWorld };

--- a/src/framework/physics/physics-body.js
+++ b/src/framework/physics/physics-body.js
@@ -1,0 +1,185 @@
+/**
+ * @import { Entity } from '../entity.js'
+ * @import { Quat } from '../../core/math/quat.js'
+ * @import { Vec3 } from '../../core/math/vec3.js'
+ */
+
+/**
+ * The base class for a rigid body owned by a {@link PhysicsWorld}. Backends subclass it and
+ * override every method. The base implementation is inert: setters do nothing and getters
+ * leave their out-parameters untouched, so callers fall back to their own cached values -
+ * matching the engine's behavior when no physics library is loaded.
+ *
+ * @ignore
+ */
+class PhysicsBody {
+    /**
+     * The entity this body simulates. Surfaced by raycast and contact results.
+     *
+     * @type {Entity|null}
+     */
+    entity = null;
+
+    /**
+     * The backend-native body object - btRigidBody when the Ammo backend is active, null
+     * otherwise. Surfaced by RigidBodyComponent#body.
+     *
+     * @type {object|null}
+     */
+    nativeBody = null;
+
+    /**
+     * @param {number} friction - The friction value used when contacts occur.
+     */
+    setFriction(friction) {
+    }
+
+    /**
+     * @param {number} friction - The torsional friction orthogonal to the contact point.
+     */
+    setRollingFriction(friction) {
+    }
+
+    /**
+     * @param {number} restitution - The amount of energy preserved on collision.
+     */
+    setRestitution(restitution) {
+    }
+
+    /**
+     * Sets both damping values in one call.
+     *
+     * @param {number} linear - The rate at which the body loses linear velocity.
+     * @param {number} angular - The rate at which the body loses angular velocity.
+     */
+    setDamping(linear, angular) {
+    }
+
+    /**
+     * @param {Vec3} factor - The scaling factor for linear movement per axis.
+     */
+    setLinearFactor(factor) {
+    }
+
+    /**
+     * @param {Vec3} factor - The scaling factor for angular movement per axis.
+     */
+    setAngularFactor(factor) {
+    }
+
+    /**
+     * @param {Vec3} velocity - The world space linear velocity.
+     */
+    setLinearVelocity(velocity) {
+    }
+
+    /**
+     * Reads the body's linear velocity into an out-parameter. Inert backends leave it
+     * untouched.
+     *
+     * @param {Vec3} velocity - The vector to write the linear velocity to.
+     */
+    getLinearVelocity(velocity) {
+    }
+
+    /**
+     * @param {Vec3} velocity - The world space angular velocity.
+     */
+    setAngularVelocity(velocity) {
+    }
+
+    /**
+     * Reads the body's angular velocity into an out-parameter. Inert backends leave it
+     * untouched.
+     *
+     * @param {Vec3} velocity - The vector to write the angular velocity to.
+     */
+    getAngularVelocity(velocity) {
+    }
+
+    /**
+     * Sets the body mass and recomputes its inertia from the current collision shape.
+     *
+     * @param {number} mass - The new mass.
+     */
+    setMass(mass) {
+    }
+
+    /**
+     * Returns true if the body is actively simulating, i.e. not sleeping.
+     *
+     * @returns {boolean} True if the body is active.
+     */
+    isActive() {
+        return false;
+    }
+
+    /**
+     * Forcibly wakes the body.
+     */
+    activate() {
+    }
+
+    /**
+     * Teleports the body to a new world space pose and wakes it. Backends also refresh any
+     * interpolation state so the pose read back by {@link PhysicsBody#getTransform} is the
+     * teleport target even on frames that run zero fixed substeps.
+     *
+     * @param {Vec3} position - The world space position.
+     * @param {Quat} rotation - The world space rotation.
+     */
+    setTransform(position, rotation) {
+    }
+
+    /**
+     * Reads the simulated pose to present to the scene (the interpolated transform on backends
+     * that interpolate). Inert backends leave the out-parameters untouched.
+     *
+     * @param {Vec3} position - The vector to write the world space position to.
+     * @param {Quat} rotation - The quaternion to write the world space rotation to.
+     */
+    getTransform(position, rotation) {
+    }
+
+    /**
+     * Drives a kinematic body towards a world space pose for the next simulation step.
+     *
+     * @param {Vec3} position - The world space position.
+     * @param {Quat} rotation - The world space rotation.
+     */
+    setKinematicTarget(position, rotation) {
+    }
+
+    /**
+     * Applies a force at a point relative to the body's origin. The body is not woken - callers
+     * activate first, matching the engine's established call order.
+     *
+     * @param {Vec3} force - The world space force.
+     * @param {Vec3} relativePoint - The world space offset from the body origin.
+     */
+    applyForce(force, relativePoint) {
+    }
+
+    /**
+     * @param {Vec3} torque - The world space torque.
+     */
+    applyTorque(torque) {
+    }
+
+    /**
+     * Applies an impulse at a point relative to the body's origin.
+     *
+     * @param {Vec3} impulse - The world space impulse.
+     * @param {Vec3} relativePoint - The local space offset from the body origin.
+     */
+    applyImpulse(impulse, relativePoint) {
+    }
+
+    /**
+     * @param {Vec3} torque - The world space torque impulse.
+     */
+    applyTorqueImpulse(torque) {
+    }
+}
+
+export { PhysicsBody };

--- a/src/framework/physics/physics-joint.js
+++ b/src/framework/physics/physics-joint.js
@@ -22,24 +22,30 @@ class PhysicsJoint {
      * Applies the limit-related settings for the joint's type.
      *
      * @param {PhysicsJointSettings} settings - The joint parameter bag.
+     * @returns {boolean} True if the joint's type supports limits and they were applied.
      */
     updateLimits(settings) {
+        return false;
     }
 
     /**
      * Applies the motor-related settings for the joint's type.
      *
      * @param {PhysicsJointSettings} settings - The joint parameter bag.
+     * @returns {boolean} True if the joint's type supports a motor and it was applied.
      */
     updateMotor(settings) {
+        return false;
     }
 
     /**
      * Applies the spring-related settings for the joint's type.
      *
      * @param {PhysicsJointSettings} settings - The joint parameter bag.
+     * @returns {boolean} True if the joint's type supports springs and they were applied.
      */
     updateSpring(settings) {
+        return false;
     }
 
     /**

--- a/src/framework/physics/physics-joint.js
+++ b/src/framework/physics/physics-joint.js
@@ -1,0 +1,65 @@
+/**
+ * @import { PhysicsJointSettings } from './physics-world.js'
+ */
+
+/**
+ * The base class for a joint (constraint) owned by a {@link PhysicsWorld}. Backends subclass
+ * it and override every method. The base implementation is inert: parameter updates do nothing
+ * and the joint never breaks.
+ *
+ * @ignore
+ */
+class PhysicsJoint {
+    /**
+     * The backend-native constraint object - btTypedConstraint when the Ammo backend is
+     * active, null otherwise. Surfaced by JointComponent#constraint.
+     *
+     * @type {object|null}
+     */
+    nativeJoint = null;
+
+    /**
+     * Applies the limit-related settings for the joint's type.
+     *
+     * @param {PhysicsJointSettings} settings - The joint parameter bag.
+     */
+    updateLimits(settings) {
+    }
+
+    /**
+     * Applies the motor-related settings for the joint's type.
+     *
+     * @param {PhysicsJointSettings} settings - The joint parameter bag.
+     */
+    updateMotor(settings) {
+    }
+
+    /**
+     * Applies the spring-related settings for the joint's type.
+     *
+     * @param {PhysicsJointSettings} settings - The joint parameter bag.
+     */
+    updateSpring(settings) {
+    }
+
+    /**
+     * Sets the impulse threshold above which the joint breaks. Infinity makes the joint
+     * unbreakable.
+     *
+     * @param {number} impulse - The break impulse threshold.
+     */
+    setBreakImpulse(impulse) {
+    }
+
+    /**
+     * Returns whether the joint broke during simulation, or null when the backend cannot
+     * determine it - the caller then falls back to its own heuristic.
+     *
+     * @returns {boolean|null} True if broken, false if intact, null if undeterminable.
+     */
+    isBroken() {
+        return false;
+    }
+}
+
+export { PhysicsJoint };

--- a/src/framework/physics/physics-world.js
+++ b/src/framework/physics/physics-world.js
@@ -3,6 +3,7 @@ import { PhysicsJoint } from './physics-joint.js';
 
 /**
  * @import { Entity } from '../entity.js'
+ * @import { Mat4 } from '../../core/math/mat4.js'
  * @import { Quat } from '../../core/math/quat.js'
  * @import { Vec2 } from '../../core/math/vec2.js'
  * @import { Vec3 } from '../../core/math/vec3.js'
@@ -93,22 +94,17 @@ import { PhysicsJoint } from './physics-joint.js';
  */
 
 /**
- * @typedef {object} PhysicsJointFrame
- * @property {Vec3} position - The joint frame position in body local space.
- * @property {Quat} rotation - The joint frame rotation in body local space. X is the primary
- * joint axis by engine convention - backends apply their own native axis corrections.
- */
-
-/**
  * @typedef {object} PhysicsJointDesc
  * @property {string} type - The joint type: JOINTTYPE_FIXED, JOINTTYPE_BALL, JOINTTYPE_HINGE,
  * JOINTTYPE_SLIDER or JOINTTYPE_6DOF.
  * @property {PhysicsBody} bodyA - The first constrained body.
  * @property {PhysicsBody|null} bodyB - The second constrained body, or null to anchor the joint
  * to the world (the backend supplies its own fixed anchor body).
- * @property {PhysicsJointFrame} frameA - The joint frame in body A's local space.
- * @property {PhysicsJointFrame} frameB - The joint frame in body B's local space (or world
- * space when bodyB is null).
+ * @property {Mat4} frameA - The joint frame in body A's local space, as a scale-free matrix
+ * with X as the primary joint axis by engine convention. Backends apply their own native axis
+ * corrections. Only valid during the call.
+ * @property {Mat4} frameB - The joint frame in body B's local space (or world space when bodyB
+ * is null).
  * @property {boolean} enableCollision - Whether the two bodies keep colliding with each other.
  * Creation-time only - changing it recreates the joint.
  * @property {PhysicsJointSettings} settings - The full parameter bag, applied at creation.

--- a/src/framework/physics/physics-world.js
+++ b/src/framework/physics/physics-world.js
@@ -25,6 +25,7 @@ import { PhysicsJoint } from './physics-joint.js';
  * contact results.
  * @property {boolean} [noContactResponse] - When true, the body collides and reports contacts
  * but does not respond to them (used for triggers). Defaults to false.
+ * @ignore
  */
 
 /**
@@ -41,10 +42,12 @@ import { PhysicsJoint } from './physics-joint.js';
  * convexHull is true - hulls consume every position.
  * @property {boolean} convexHull - Build a convex hull instead of a triangle mesh.
  * @property {boolean} checkDuplicates - Weld duplicate vertices while building triangle data.
+ * @property {Vec3|null} bakeScale - Scaling to bake into the positions while building, or null.
  * @property {Vec3|null} shapeScale - Scaling to apply to the built sub-shape, or null.
  * @property {Vec3} position - The sub-shape position within the mesh shape. Collision component
  * offsets are already applied by the caller.
  * @property {Quat} rotation - The sub-shape rotation within the mesh shape.
+ * @ignore
  */
 
 /**
@@ -59,6 +62,7 @@ import { PhysicsJoint } from './physics-joint.js';
  * @property {PhysicsMeshSource[]} [sources] - The geometry sources of a 'mesh' shape. Mesh
  * shapes are created in one atomic call so backends may build immutable composites.
  * @property {Vec3|null} [scale] - Whole-shape scaling of a 'mesh' shape, or null.
+ * @ignore
  */
 
 /**
@@ -91,6 +95,7 @@ import { PhysicsJoint } from './physics-joint.js';
  * @property {Vec3} angularStiffness - The 6dof angular spring stiffness per axis.
  * @property {Vec3} angularDamping - The 6dof angular spring damping per axis.
  * @property {Vec3} angularEquilibrium - The 6dof angular spring equilibrium per axis in degrees.
+ * @ignore
  */
 
 /**
@@ -108,6 +113,7 @@ import { PhysicsJoint } from './physics-joint.js';
  * @property {boolean} enableCollision - Whether the two bodies keep colliding with each other.
  * Creation-time only - changing it recreates the joint.
  * @property {PhysicsJointSettings} settings - The full parameter bag, applied at creation.
+ * @ignore
  */
 
 /**
@@ -122,6 +128,7 @@ import { PhysicsJoint } from './physics-joint.js';
  * @property {number} contactCount - The number of contact points (always >= 1).
  * @property {(index: number, out: ContactPoint) => void} readContact - Fills out with contact
  * point index from A's perspective, allocation free.
+ * @ignore
  */
 
 /**
@@ -134,6 +141,7 @@ import { PhysicsJoint } from './physics-joint.js';
  * @property {(pair: PhysicsContactPair) => void} onContactPair - Called for each contacting
  * pair. Pairs with no contact points or without entities on both bodies are not reported.
  * @property {() => void} onContactsEnd - Called when a contact pass ends.
+ * @ignore
  */
 
 /**

--- a/src/framework/physics/physics-world.js
+++ b/src/framework/physics/physics-world.js
@@ -1,0 +1,366 @@
+import { PhysicsBody } from './physics-body.js';
+import { PhysicsJoint } from './physics-joint.js';
+
+/**
+ * @import { Entity } from '../entity.js'
+ * @import { Quat } from '../../core/math/quat.js'
+ * @import { Vec2 } from '../../core/math/vec2.js'
+ * @import { Vec3 } from '../../core/math/vec3.js'
+ * @import { ContactPoint } from '../components/rigid-body/contact-point.js'
+ * @import { RaycastResult } from '../components/rigid-body/raycast-result.js'
+ */
+
+/**
+ * @typedef {object} PhysicsBodyDesc
+ * @property {string} type - The body type: BODYTYPE_STATIC, BODYTYPE_DYNAMIC or
+ * BODYTYPE_KINEMATIC.
+ * @property {number} mass - The construction mass. Callers pass 0 for non-dynamic bodies.
+ * @property {object} shape - An opaque collision shape handle created by
+ * {@link PhysicsWorld#createShape}.
+ * @property {Vec3} position - The initial world space position. Collision component offsets are
+ * already applied by the caller.
+ * @property {Quat} rotation - The initial world space rotation.
+ * @property {Entity|null} entity - The entity this body simulates. Surfaced by raycast and
+ * contact results.
+ * @property {boolean} [noContactResponse] - When true, the body collides and reports contacts
+ * but does not respond to them (used for triggers). Defaults to false.
+ */
+
+/**
+ * @typedef {object} PhysicsMeshSource
+ * @property {number} id - A stable cache key for the source geometry (mesh id). Backends may
+ * cache built triangle data per id for the lifetime of the world.
+ * @property {Float32Array|number[]} positions - Vertex positions, possibly interleaved.
+ * @property {number} stride - The number of floats between consecutive positions (3 when
+ * tightly packed).
+ * @property {number[]|Uint16Array|Uint32Array} indices - Triangle indices. Ignored when
+ * convexHull is true.
+ * @property {number} base - The first index to read.
+ * @property {number} count - The number of indices to read (a multiple of 3). Ignored when
+ * convexHull is true - hulls consume every position.
+ * @property {boolean} convexHull - Build a convex hull instead of a triangle mesh.
+ * @property {boolean} checkDuplicates - Weld duplicate vertices while building triangle data.
+ * @property {Vec3|null} shapeScale - Scaling to apply to the built sub-shape, or null.
+ * @property {Vec3} position - The sub-shape position within the mesh shape. Collision component
+ * offsets are already applied by the caller.
+ * @property {Quat} rotation - The sub-shape rotation within the mesh shape.
+ */
+
+/**
+ * @typedef {object} PhysicsShapeDesc
+ * @property {string} type - The shape type: 'box', 'sphere', 'capsule', 'cylinder', 'cone',
+ * 'mesh' or 'compound'.
+ * @property {Vec3} [halfExtents] - The box half extents.
+ * @property {number} [radius] - The sphere/capsule/cylinder/cone radius.
+ * @property {number} [height] - The full capsule/cylinder/cone height along the alignment axis.
+ * Backends convert to their own conventions.
+ * @property {number} [axis] - The capsule/cylinder/cone alignment axis: 0 (X), 1 (Y) or 2 (Z).
+ * @property {PhysicsMeshSource[]} [sources] - The geometry sources of a 'mesh' shape. Mesh
+ * shapes are created in one atomic call so backends may build immutable composites.
+ * @property {Vec3|null} [scale] - Whole-shape scaling of a 'mesh' shape, or null.
+ */
+
+/**
+ * The parameter bag consumed by {@link PhysicsWorld#createJoint} and the PhysicsJoint update
+ * methods. JointComponent structurally satisfies this contract and passes itself.
+ *
+ * @typedef {object} PhysicsJointSettings
+ * @property {boolean} enableLimits - Whether hinge/slider limits are enabled.
+ * @property {Vec2} limits - The hinge (degrees) or slider (meters) limits.
+ * @property {number} motorSpeed - The hinge (deg/s) or slider (m/s) motor speed.
+ * @property {number} maxMotorForce - The maximum motor force. The motor is engaged while > 0.
+ * @property {number} swingLimitY - The ball joint swing limit around Y in degrees.
+ * @property {number} swingLimitZ - The ball joint swing limit around Z in degrees.
+ * @property {number} twistLimit - The ball joint twist limit in degrees.
+ * @property {string} linearMotionX - MOTION_FREE, MOTION_LIMITED or MOTION_LOCKED.
+ * @property {string} linearMotionY - MOTION_FREE, MOTION_LIMITED or MOTION_LOCKED.
+ * @property {string} linearMotionZ - MOTION_FREE, MOTION_LIMITED or MOTION_LOCKED.
+ * @property {Vec2} linearLimitsX - The 6dof linear limits along X in meters.
+ * @property {Vec2} linearLimitsY - The 6dof linear limits along Y in meters.
+ * @property {Vec2} linearLimitsZ - The 6dof linear limits along Z in meters.
+ * @property {Vec3} linearStiffness - The 6dof linear spring stiffness per axis.
+ * @property {Vec3} linearDamping - The 6dof linear spring damping per axis.
+ * @property {Vec3} linearEquilibrium - The 6dof linear spring equilibrium point per axis.
+ * @property {string} angularMotionX - MOTION_FREE, MOTION_LIMITED or MOTION_LOCKED.
+ * @property {string} angularMotionY - MOTION_FREE, MOTION_LIMITED or MOTION_LOCKED.
+ * @property {string} angularMotionZ - MOTION_FREE, MOTION_LIMITED or MOTION_LOCKED.
+ * @property {Vec2} angularLimitsX - The 6dof angular limits around X in degrees.
+ * @property {Vec2} angularLimitsY - The 6dof angular limits around Y in degrees.
+ * @property {Vec2} angularLimitsZ - The 6dof angular limits around Z in degrees.
+ * @property {Vec3} angularStiffness - The 6dof angular spring stiffness per axis.
+ * @property {Vec3} angularDamping - The 6dof angular spring damping per axis.
+ * @property {Vec3} angularEquilibrium - The 6dof angular spring equilibrium per axis in degrees.
+ */
+
+/**
+ * @typedef {object} PhysicsJointFrame
+ * @property {Vec3} position - The joint frame position in body local space.
+ * @property {Quat} rotation - The joint frame rotation in body local space. X is the primary
+ * joint axis by engine convention - backends apply their own native axis corrections.
+ */
+
+/**
+ * @typedef {object} PhysicsJointDesc
+ * @property {string} type - The joint type: JOINTTYPE_FIXED, JOINTTYPE_BALL, JOINTTYPE_HINGE,
+ * JOINTTYPE_SLIDER or JOINTTYPE_6DOF.
+ * @property {PhysicsBody} bodyA - The first constrained body.
+ * @property {PhysicsBody|null} bodyB - The second constrained body, or null to anchor the joint
+ * to the world (the backend supplies its own fixed anchor body).
+ * @property {PhysicsJointFrame} frameA - The joint frame in body A's local space.
+ * @property {PhysicsJointFrame} frameB - The joint frame in body B's local space (or world
+ * space when bodyB is null).
+ * @property {boolean} enableCollision - Whether the two bodies keep colliding with each other.
+ * Creation-time only - changing it recreates the joint.
+ * @property {PhysicsJointSettings} settings - The full parameter bag, applied at creation.
+ */
+
+/**
+ * A single contacting body pair reported to the {@link PhysicsContactListener}. Backends reuse
+ * one instance per world - it is only valid inside onContactPair and must never be retained.
+ *
+ * @typedef {object} PhysicsContactPair
+ * @property {Entity} entityA - The entity owning the first body.
+ * @property {Entity} entityB - The entity owning the second body.
+ * @property {boolean} triggerA - True if the first body has no contact response.
+ * @property {boolean} triggerB - True if the second body has no contact response.
+ * @property {number} contactCount - The number of contact points (always >= 1).
+ * @property {(index: number, out: ContactPoint) => void} readContact - Fills out with contact
+ * point index from A's perspective, allocation free.
+ */
+
+/**
+ * Receives contact reports from a {@link PhysicsWorld}. The world runs one complete contact
+ * pass - onContactsBegin, zero or more onContactPair, onContactsEnd - once per simulation
+ * substep where the backend supports substep granularity, otherwise at least once per step.
+ *
+ * @typedef {object} PhysicsContactListener
+ * @property {() => void} onContactsBegin - Called when a contact pass begins.
+ * @property {(pair: PhysicsContactPair) => void} onContactPair - Called for each contacting
+ * pair. Pairs with no contact points or without entities on both bodies are not reported.
+ * @property {() => void} onContactsEnd - Called when a contact pass ends.
+ */
+
+/**
+ * The base class for physics backends. A PhysicsWorld owns the lifecycle of a physics engine's
+ * simulation world: stepping, gravity, body and shape factories, joints, raycasts and contact
+ * reporting. Backends subclass it (AmmoPhysicsWorld) and override every method.
+ *
+ * The base implementation is a functional no-op: bodies and joints are created but inert,
+ * raycasts miss and stepping does nothing. NullPhysicsWorld uses this to let component
+ * lifecycle run in tests without a physics engine loaded.
+ *
+ * @ignore
+ */
+class PhysicsWorld {
+    /**
+     * The listener driven during {@link PhysicsWorld#step}. Set once at construction.
+     *
+     * @type {PhysicsContactListener|null}
+     */
+    contactListener = null;
+
+    /**
+     * The backend-native world object - btDiscreteDynamicsWorld when the Ammo backend is
+     * active, null otherwise.
+     *
+     * @type {object|null}
+     */
+    nativeWorld = null;
+
+    /**
+     * Create a new PhysicsWorld instance.
+     *
+     * @param {object} [options] - The world options.
+     * @param {PhysicsContactListener} [options.contactListener] - The contact listener.
+     */
+    constructor(options = {}) {
+        this.contactListener = options.contactListener ?? null;
+    }
+
+    /**
+     * Destroys the world and all native resources it owns. The world is unusable afterwards.
+     */
+    destroy() {
+    }
+
+    /**
+     * Applies gravity if it differs from the current world gravity. Safe (and expected) to be
+     * called every frame - backends deduplicate.
+     *
+     * @param {Vec3} gravity - The world space gravity.
+     */
+    setGravity(gravity) {
+    }
+
+    /**
+     * Advances the simulation. Contact passes are driven from inside this call on backends
+     * that support substep granularity.
+     *
+     * @param {number} dt - The elapsed time in seconds.
+     * @param {number} maxSubSteps - The maximum number of fixed substeps to take.
+     * @param {number} fixedTimeStep - The duration of a fixed substep in seconds.
+     */
+    step(dt, maxSubSteps, fixedTimeStep) {
+    }
+
+    /**
+     * Runs a deferred contact pass on backends that could not report contacts from inside
+     * {@link PhysicsWorld#step}. Called by the system after dynamic transform sync. No-op on
+     * backends that report during step.
+     */
+    flushContacts() {
+    }
+
+    /**
+     * Creates a body outside the simulation. Add it with {@link PhysicsWorld#addBody}.
+     *
+     * @param {PhysicsBodyDesc} desc - The body descriptor.
+     * @returns {PhysicsBody} The new body.
+     */
+    createBody(desc) {
+        const body = new PhysicsBody();
+        body.entity = desc.entity ?? null;
+        return body;
+    }
+
+    /**
+     * Destroys a body. It must not currently be in the simulation.
+     *
+     * @param {PhysicsBody} body - The body to destroy.
+     */
+    destroyBody(body) {
+    }
+
+    /**
+     * Adds a body to the simulation and applies the backend's activation policy for the body's
+     * type (kinematic bodies never deactivate, all others enter the active state).
+     *
+     * @param {PhysicsBody} body - The body to add.
+     * @param {number} [group] - The collision group bits. Used together with mask.
+     * @param {number} [mask] - The collision mask bits.
+     */
+    addBody(body, group, mask) {
+    }
+
+    /**
+     * Removes a body from the simulation. The body becomes inert until re-added.
+     *
+     * @param {PhysicsBody} body - The body to remove.
+     */
+    removeBody(body) {
+    }
+
+    /**
+     * Creates a collision shape from a typed descriptor. The returned handle is opaque - it is
+     * owned by this world and must only be passed back to this world.
+     *
+     * @param {PhysicsShapeDesc} desc - The shape descriptor.
+     * @returns {object} The opaque shape handle.
+     */
+    createShape(desc) {
+        return {};
+    }
+
+    /**
+     * Destroys a shape handle created by {@link PhysicsWorld#createShape}.
+     *
+     * @param {object} shape - The shape handle.
+     */
+    destroyShape(shape) {
+    }
+
+    /**
+     * Adds a child shape to a 'compound' shape at a local pose.
+     *
+     * @param {object} compound - The compound shape handle.
+     * @param {object} child - The child shape handle.
+     * @param {Vec3} position - The child position in the compound's local space.
+     * @param {Quat} rotation - The child rotation in the compound's local space.
+     */
+    addCompoundChild(compound, child, position, rotation) {
+    }
+
+    /**
+     * Updates the local pose of a child within a 'compound' shape. Adds the child if it is not
+     * present.
+     *
+     * @param {object} compound - The compound shape handle.
+     * @param {object} child - The child shape handle.
+     * @param {Vec3} position - The child position in the compound's local space.
+     * @param {Quat} rotation - The child rotation in the compound's local space.
+     */
+    updateCompoundChild(compound, child, position, rotation) {
+    }
+
+    /**
+     * Removes a child from a 'compound' shape. No-op if the child is not present.
+     *
+     * @param {object} compound - The compound shape handle.
+     * @param {object} child - The child shape handle.
+     */
+    removeCompoundChild(compound, child) {
+    }
+
+    /**
+     * Returns the number of children in a 'compound' shape.
+     *
+     * @param {object} compound - The compound shape handle.
+     * @returns {number} The child count.
+     */
+    getCompoundChildCount(compound) {
+        return 0;
+    }
+
+    /**
+     * Creates a joint between two bodies (or one body and the world) and adds it to the
+     * simulation.
+     *
+     * @param {PhysicsJointDesc} desc - The joint descriptor.
+     * @returns {PhysicsJoint} The new joint.
+     */
+    createJoint(desc) {
+        return new PhysicsJoint();
+    }
+
+    /**
+     * Removes a joint from the simulation and destroys it.
+     *
+     * @param {PhysicsJoint} joint - The joint to destroy.
+     */
+    destroyJoint(joint) {
+    }
+
+    /**
+     * Raycast the world and return the first hit.
+     *
+     * @param {Vec3} start - The world space start point.
+     * @param {Vec3} end - The world space end point.
+     * @param {object} [options] - The raycast options.
+     * @param {number} [options.filterCollisionGroup] - Collision group to apply to the raycast.
+     * @param {number} [options.filterCollisionMask] - Collision mask to apply to the raycast.
+     * @returns {RaycastResult|null} The hit, or null if there was none.
+     */
+    raycastFirst(start, end, options) {
+        return null;
+    }
+
+    /**
+     * Raycast the world and return all hits, in backend order.
+     *
+     * @param {Vec3} start - The world space start point.
+     * @param {Vec3} end - The world space end point.
+     * @param {object} [options] - The raycast options.
+     * @param {number} [options.filterCollisionGroup] - Collision group to apply to the raycast.
+     * @param {number} [options.filterCollisionMask] - Collision mask to apply to the raycast.
+     * @param {any[]} [options.filterTags] - Tags filters. Defined the same way as a
+     * {@link Tags#has} query but within an array. Hits filtered here are never allocated.
+     * @param {Function} [options.filterCallback] - Custom function to use to filter entities.
+     * Must return true to proceed with result. Takes the entity to evaluate as argument.
+     * @returns {RaycastResult[]} The hits (0 length if there were none).
+     */
+    raycastAll(start, end, options) {
+        return [];
+    }
+}
+
+export { PhysicsWorld };

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -460,8 +460,9 @@ class SceneRegistry {
 
                     app.root.addChild(scene.root);
 
-                    // Initialize pack settings
-                    if (app.systems.rigidbody && typeof Ammo !== 'undefined') {
+                    // Initialize pack settings - gravity is engine state, applied by the
+                    // physics backend when present
+                    if (app.systems.rigidbody) {
                         app.systems.rigidbody.gravity.set(scene._gravity.x, scene._gravity.y, scene._gravity.z);
                     }
 

--- a/test/framework/components/rigid-body/component.test.mjs
+++ b/test/framework/components/rigid-body/component.test.mjs
@@ -1,0 +1,287 @@
+import { expect } from 'chai';
+
+import { Quat } from '../../../../src/core/math/quat.js';
+import { Vec3 } from '../../../../src/core/math/vec3.js';
+import { Entity } from '../../../../src/framework/entity.js';
+import { NullPhysicsWorld } from '../../../../src/framework/physics/null/null-physics-world.js';
+import { createApp } from '../../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
+
+// Component lifecycle against the null physics backend: bodies, triggers and compounds are
+// created and torn down through the backend contract without a physics engine loaded.
+describe('RigidBodyComponent', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+        app.systems.rigidbody.setPhysicsWorld(new NullPhysicsWorld());
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    function addPhysicsEntity(type = 'dynamic', collisionData = {}) {
+        const e = new Entity();
+        app.root.addChild(e);
+        e.addComponent('collision', collisionData);
+        e.addComponent('rigidbody', { type });
+        return e;
+    }
+
+    describe('body lifecycle', function () {
+
+        it('creates a backend body once a collision shape is present', function () {
+            const e = addPhysicsEntity();
+
+            expect(e.collision.shape).to.exist;
+            expect(e.rigidbody._body).to.exist;
+            expect(e.rigidbody._body.entity).to.equal(e);
+            expect(e.rigidbody._simulationEnabled).to.equal(true);
+            // the native escape hatch stays null for backends without a native body
+            expect(e.rigidbody.body).to.equal(null);
+        });
+
+        it('creates no body without a collision component', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('rigidbody');
+
+            expect(e.rigidbody._body).to.equal(null);
+        });
+
+        it('keeps the body across disable/enable cycles', function () {
+            const e = addPhysicsEntity();
+            const body = e.rigidbody._body;
+
+            e.rigidbody.enabled = false;
+            expect(e.rigidbody._simulationEnabled).to.equal(false);
+            expect(e.rigidbody._body).to.equal(body);
+
+            e.rigidbody.enabled = true;
+            expect(e.rigidbody._simulationEnabled).to.equal(true);
+            expect(e.rigidbody._body).to.equal(body);
+        });
+
+        it('releases the body when the component is removed', function () {
+            const e = addPhysicsEntity();
+            expect(e.rigidbody._body).to.exist;
+
+            const rigidbody = e.rigidbody;
+            e.removeComponent('rigidbody');
+            expect(rigidbody._body).to.equal(null);
+        });
+
+        it('rebuilds the body when the type changes and resets group and mask', function () {
+            const e = addPhysicsEntity('dynamic');
+            e.rigidbody.type = 'kinematic';
+
+            expect(e.rigidbody.type).to.equal('kinematic');
+            expect(e.rigidbody._body).to.exist;
+            expect(e.rigidbody._simulationEnabled).to.equal(true);
+        });
+
+    });
+
+    describe('properties and operations', function () {
+
+        it('routes every property setter without a native backend', function () {
+            const e = addPhysicsEntity();
+            const rb = e.rigidbody;
+
+            rb.mass = 10;
+            rb.friction = 0.25;
+            rb.rollingFriction = 0.1;
+            rb.restitution = 0.5;
+            rb.linearDamping = 0.05;
+            rb.angularDamping = 0.06;
+            rb.linearFactor = new Vec3(1, 0, 1);
+            rb.angularFactor = new Vec3(0, 1, 0);
+            rb.linearVelocity = new Vec3(1, 2, 3);
+            rb.angularVelocity = new Vec3(4, 5, 6);
+            rb.group = 4;
+            rb.mask = 255;
+
+            expect(rb.mass).to.equal(10);
+            expect(rb.friction).to.equal(0.25);
+            expect(rb.rollingFriction).to.equal(0.1);
+            expect(rb.restitution).to.equal(0.5);
+            expect(rb.linearDamping).to.equal(0.05);
+            expect(rb.angularDamping).to.equal(0.06);
+            expect(rb.linearFactor.equals(new Vec3(1, 0, 1))).to.equal(true);
+            expect(rb.angularFactor.equals(new Vec3(0, 1, 0))).to.equal(true);
+            // velocity getters fall back to the cached values under an inert backend
+            expect(rb.linearVelocity.equals(new Vec3(1, 2, 3))).to.equal(true);
+            expect(rb.angularVelocity.equals(new Vec3(4, 5, 6))).to.equal(true);
+            expect(rb.group).to.equal(4);
+            expect(rb.mask).to.equal(255);
+            expect(rb.isActive()).to.equal(false);
+        });
+
+        it('applies forces and impulses without throwing', function () {
+            const e = addPhysicsEntity();
+
+            expect(() => {
+                e.rigidbody.applyForce(0, 10, 0);
+                e.rigidbody.applyForce(new Vec3(0, 10, 0), new Vec3(0, 0, 1));
+                e.rigidbody.applyTorque(1, 0, 0);
+                e.rigidbody.applyImpulse(new Vec3(0, 1, 0));
+                e.rigidbody.applyTorqueImpulse(0, 1, 0);
+                e.rigidbody.activate();
+            }).to.not.throw();
+        });
+
+        it('teleports the entity', function () {
+            const e = addPhysicsEntity();
+
+            e.rigidbody.teleport(new Vec3(1, 2, 3), new Quat());
+            expect(e.getPosition().equals(new Vec3(1, 2, 3))).to.equal(true);
+        });
+
+        it('clones with the collision component', function () {
+            const e = addPhysicsEntity();
+            e.rigidbody.mass = 7;
+
+            const clone = e.clone();
+            app.root.addChild(clone);
+
+            expect(clone.rigidbody.mass).to.equal(7);
+            expect(clone.rigidbody._body).to.exist;
+            expect(clone.rigidbody._body).to.not.equal(e.rigidbody._body);
+        });
+
+    });
+
+    describe('collision shapes', function () {
+
+        it('creates shapes for every primitive and compound type', function () {
+            for (const type of ['box', 'sphere', 'capsule', 'cylinder', 'cone', 'compound']) {
+                const e = addPhysicsEntity('static', { type });
+                expect(e.collision.shape, type).to.exist;
+                expect(e.rigidbody._body, type).to.exist;
+            }
+        });
+
+        it('creates a mesh shape without reading vertex data', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('collision', { type: 'mesh' });
+
+            // a duck-typed render source - under an inert backend the lazy vertex/index
+            // accessors of the mesh sources must never be read
+            e.collision.render = {
+                meshes: [{
+                    id: 12345,
+                    primitive: [{ base: 0, count: 3 }],
+                    get vertexBuffer() {
+                        throw new Error('vertex data must not be read by an inert backend');
+                    },
+                    getPositions() {
+                        throw new Error('vertex data must not be read by an inert backend');
+                    },
+                    getIndices() {
+                        throw new Error('vertex data must not be read by an inert backend');
+                    }
+                }]
+            };
+            e.addComponent('rigidbody', { type: 'static' });
+
+            expect(e.collision.shape).to.exist;
+            expect(e.rigidbody._body).to.exist;
+        });
+
+    });
+
+    describe('triggers', function () {
+
+        it('creates a trigger for a collision-only entity', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('collision');
+
+            expect(e.trigger).to.exist;
+            expect(e.trigger.body).to.exist;
+            expect(e.trigger.body.entity).to.equal(e);
+            expect(app.systems.rigidbody._triggers).to.include(e.trigger);
+        });
+
+        it('unregisters the trigger on disable and destroys it on removal', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('collision');
+            const trigger = e.trigger;
+
+            e.collision.enabled = false;
+            expect(app.systems.rigidbody._triggers).to.not.include(trigger);
+
+            e.collision.enabled = true;
+            expect(app.systems.rigidbody._triggers).to.include(trigger);
+
+            e.removeComponent('collision');
+            expect(e.trigger).to.not.exist;
+            expect(trigger.body).to.equal(null);
+        });
+
+        it('replaces the trigger with a body when a rigidbody is added', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('collision');
+            expect(e.trigger).to.exist;
+
+            e.addComponent('rigidbody');
+            expect(e.trigger).to.not.exist;
+            expect(e.rigidbody._body).to.exist;
+        });
+
+    });
+
+    describe('compounds', function () {
+
+        it('wires children to their compound parent', function () {
+            const parent = new Entity('parent');
+            app.root.addChild(parent);
+            parent.addComponent('collision', { type: 'compound' });
+            parent.addComponent('rigidbody', { type: 'static' });
+
+            const child = new Entity('child');
+            child.setLocalPosition(2, 0, 0);
+            parent.addChild(child);
+            child.addComponent('collision');
+
+            expect(parent.collision._compoundParent).to.equal(parent.collision);
+            expect(child.collision._compoundParent).to.equal(parent.collision);
+            expect(child.trigger).to.not.exist;
+
+            expect(() => {
+                app.update(1 / 60);
+                child.setLocalPosition(3, 0, 0);
+                app.update(1 / 60);
+            }).to.not.throw();
+        });
+
+        it('survives child disable/enable and removal', function () {
+            const parent = new Entity('parent');
+            app.root.addChild(parent);
+            parent.addComponent('collision', { type: 'compound' });
+            parent.addComponent('rigidbody', { type: 'static' });
+
+            const child = new Entity('child');
+            parent.addChild(child);
+            child.addComponent('collision');
+
+            child.collision.enabled = false;
+            expect(child.collision._compoundParent).to.equal(parent.collision);
+
+            child.collision.enabled = true;
+            expect(child.collision._compoundParent).to.equal(parent.collision);
+
+            child.removeComponent('collision');
+            expect(parent.collision._compoundParent).to.equal(parent.collision);
+        });
+
+    });
+
+});

--- a/test/framework/components/rigid-body/component.test.mjs
+++ b/test/framework/components/rigid-body/component.test.mjs
@@ -75,6 +75,16 @@ describe('RigidBodyComponent', function () {
             expect(rigidbody._body).to.equal(null);
         });
 
+        it('disables the simulation when the collision component is removed', function () {
+            const e = addPhysicsEntity();
+            expect(e.rigidbody._simulationEnabled).to.equal(true);
+
+            // the gate must use the backend body, which exists even when the public
+            // native-body getter returns null (as it does under an inert backend)
+            e.removeComponent('collision');
+            expect(e.rigidbody._simulationEnabled).to.equal(false);
+        });
+
         it('rebuilds the body when the type changes and resets group and mask', function () {
             const e = addPhysicsEntity('dynamic');
             e.rigidbody.type = 'kinematic';

--- a/test/framework/physics/null-physics-world.test.mjs
+++ b/test/framework/physics/null-physics-world.test.mjs
@@ -1,0 +1,173 @@
+import { expect } from 'chai';
+
+import { Vec3 } from '../../../src/core/math/vec3.js';
+import { Entity } from '../../../src/framework/entity.js';
+import { NullPhysicsWorld } from '../../../src/framework/physics/null/null-physics-world.js';
+import { PhysicsBody } from '../../../src/framework/physics/physics-body.js';
+import { PhysicsJoint } from '../../../src/framework/physics/physics-joint.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+describe('NullPhysicsWorld', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    describe('installation', function () {
+
+        it('is not installed by default', function () {
+            expect(app.systems.rigidbody.physicsWorld).to.equal(null);
+            expect(app.systems.rigidbody.dynamicsWorld).to.equal(null);
+        });
+
+        it('installs via setPhysicsWorld', function () {
+            const world = new NullPhysicsWorld();
+            app.systems.rigidbody.setPhysicsWorld(world);
+
+            expect(app.systems.rigidbody.physicsWorld).to.equal(world);
+            // the native escape hatch stays null for backends without a native world
+            expect(app.systems.rigidbody.dynamicsWorld).to.equal(null);
+        });
+
+        it('steps the update loop without a native backend', function () {
+            app.systems.rigidbody.setPhysicsWorld(new NullPhysicsWorld());
+
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('collision');
+            e.addComponent('rigidbody', { type: 'dynamic' });
+
+            expect(() => {
+                app.update(1 / 60);
+                app.update(1 / 60);
+            }).to.not.throw();
+        });
+
+    });
+
+    describe('inert operations', function () {
+
+        let world;
+
+        beforeEach(function () {
+            world = new NullPhysicsWorld();
+            app.systems.rigidbody.setPhysicsWorld(world);
+        });
+
+        it('misses all raycasts', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('collision');
+            e.addComponent('rigidbody');
+
+            const start = new Vec3(0, 10, 0);
+            const end = new Vec3(0, -10, 0);
+            expect(app.systems.rigidbody.raycastFirst(start, end)).to.equal(null);
+            expect(app.systems.rigidbody.raycastAll(start, end)).to.deep.equal([]);
+            expect(app.systems.rigidbody.raycastFirst(start, end, { filterCallback: () => true })).to.equal(null);
+        });
+
+        it('creates identity-distinct opaque shape handles', function () {
+            const a = world.createShape({ type: 'box', halfExtents: new Vec3(1, 1, 1) });
+            const b = world.createShape({ type: 'box', halfExtents: new Vec3(1, 1, 1) });
+
+            expect(a).to.exist;
+            expect(b).to.exist;
+            expect(a).to.not.equal(b);
+            expect(world.getCompoundChildCount(a)).to.equal(0);
+        });
+
+        it('creates inert bodies carrying their entity', function () {
+            const entity = new Entity();
+            const body = world.createBody({
+                type: 'dynamic',
+                mass: 1,
+                shape: world.createShape({ type: 'sphere', radius: 1 }),
+                position: new Vec3(),
+                rotation: app.root.getRotation(),
+                entity: entity
+            });
+
+            expect(body).to.be.an.instanceof(PhysicsBody);
+            expect(body.entity).to.equal(entity);
+            expect(body.nativeBody).to.equal(null);
+            expect(body.isActive()).to.equal(false);
+        });
+
+        it('creates inert joints', function () {
+            const joint = world.createJoint({});
+
+            expect(joint).to.be.an.instanceof(PhysicsJoint);
+            expect(joint.nativeJoint).to.equal(null);
+            expect(joint.isBroken()).to.equal(false);
+            expect(joint.updateLimits({})).to.equal(false);
+        });
+
+    });
+
+    describe('joint component lifecycle', function () {
+
+        let bodyA, bodyB, jointEntity;
+
+        beforeEach(function () {
+            app.systems.rigidbody.setPhysicsWorld(new NullPhysicsWorld());
+
+            const addBody = (name) => {
+                const e = new Entity(name);
+                app.root.addChild(e);
+                e.addComponent('collision');
+                e.addComponent('rigidbody', { type: 'dynamic' });
+                return e;
+            };
+            bodyA = addBody('a');
+            bodyB = addBody('b');
+
+            jointEntity = new Entity('joint');
+            app.root.addChild(jointEntity);
+        });
+
+        it('creates the joint once both bodies are in the simulation', function () {
+            jointEntity.addComponent('joint', { type: 'hinge', entityA: bodyA, entityB: bodyB });
+
+            expect(jointEntity.joint._joint).to.exist;
+            // the native escape hatch stays null for backends without native constraints
+            expect(jointEntity.joint.constraint).to.equal(null);
+            expect(app.systems.joint._pending.has(jointEntity.joint)).to.equal(false);
+        });
+
+        it('tears the joint down on simulationdisabled and recreates it from the pending set', function () {
+            jointEntity.addComponent('joint', { type: 'ball', entityA: bodyA, entityB: bodyB });
+            const component = jointEntity.joint;
+
+            bodyA.rigidbody.enabled = false;
+            expect(component._joint).to.equal(null);
+            expect(app.systems.joint._pending.has(component)).to.equal(true);
+
+            bodyA.rigidbody.enabled = true;
+            app.update(1 / 60); // pending joints are retried before the physics step
+            expect(component._joint).to.exist;
+            expect(app.systems.joint._pending.has(component)).to.equal(false);
+        });
+
+        it('never breaks a breakable joint', function () {
+            jointEntity.addComponent('joint', { type: 'fixed', entityA: bodyA, entityB: bodyB, breakImpulse: 0.001 });
+            const component = jointEntity.joint;
+
+            expect(app.systems.joint._breakable.has(component)).to.equal(true);
+            app.update(1 / 60);
+            expect(component.isBroken).to.equal(false);
+            expect(component._joint).to.exist;
+        });
+
+    });
+
+});


### PR DESCRIPTION
## Description

Decouples the engine from ammo.js by introducing an internal physics backend contract, as proposed in #2801: `PhysicsWorld`, `PhysicsBody` and `PhysicsJoint` base classes under `src/framework/physics/`, with all Ammo code ported behind them (`physics/ammo/`) and a no-op `NullPhysicsWorld` that lets the physics component lifecycle run in tests without a physics engine. Adding a new backend (Jolt, Rapier, a custom engine) is now a matter of implementing the three classes.

Closes #2801

**Zero public API change.** Component APIs, events and constants are untouched. Ammo is auto-selected exactly as before (`typeof Ammo` after WasmModule load) - now the only reference to the Ammo global outside `physics/ammo/`. Backends install through a single `@ignore`d seam, `RigidBodyComponentSystem#setPhysicsWorld()`; a public selection API (e.g. via `AppOptions`) is deferred until a second real backend lands. The unsupported native escape hatches keep returning raw Ammo objects (`rigidbody.body`, `dynamicsWorld`, `joint.constraint`, `collision.shape`), so `scripts/physics/vehicle.js` runs untouched.

Notes for reviewers:

- Shapes are opaque handles (the raw `btCollisionShape` for Ammo) created from typed descriptors; per-type creation inside the backend uses module-scope dispatch tables. Mesh sources expose vertex/index data through lazy accessors, so geometry cached per mesh id is never re-extracted.
- Contact reporting crosses the boundary via a listener (`onContactsBegin`/`onContactPair`/`onContactsEnd`) with one reused pair object; all pooling, collision maps and event firing stay in the system, and per-substep semantics (and the no-tick-callback fallback ordering) are preserved.
- Joint frames cross the boundary as scale-free `Mat4`s with X as the primary axis; the backend applies its native axis correction (bullet's hinge Z remap) in matrix space, keeping results identical to the previous single-sided computation.
- Behavior verified bit-exact against master with a real-Ammo A/B harness (~20 scenarios: falling/resting bodies, raycasts, contact/trigger event frame ordering and impulses, all 5 joint types, teleport interpolation from #8915, compound child moves, mesh/hull colliders, raw-vehicle escape hatches), plus all 7 physics examples in the browser and 26 new null-backend unit tests.
- Deliberate deviations, all internal: bt math temps are now per-world instead of cross-app statics (fixes a latent multi-app teardown bug); mesh scale-change rebuilds compare against the recorded build scale (removes redundant render-path rebuilds for non-unit scales); scene-settings gravity is applied without the Ammo-global gate; hinge motors use the last-stepped `fixedTimeStep`; the undocumented `system.createBody/destroyBody`, `collision.getCompoundChildShapeIndex` and `joint system getFixedBody` were removed (the world-anchor fixed body lives on the backend now).

Follow-ups: public backend-selection API, and flattening the `CollisionSystemImpl` class hierarchy (its `createPhysicalShape` methods are now one-liners).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)