### PR TITLE
Move simulation registration onto the rigid body system

### DIFF
--- a/src/framework/components/collision/trigger.js
+++ b/src/framework/components/collision/trigger.js
@@ -1,6 +1,6 @@
 import { Quat } from '../../../core/math/quat.js';
 import { Vec3 } from '../../../core/math/vec3.js';
-import { BODYMASK_NOT_STATIC, BODYGROUP_TRIGGER, BODYTYPE_DYNAMIC } from '../rigid-body/constants.js';
+import { BODYTYPE_DYNAMIC } from '../rigid-body/constants.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
@@ -85,33 +85,16 @@ class Trigger {
     }
 
     enable() {
-        const body = this.body;
-        if (!body) return;
+        if (!this.body) return;
 
-        const system = this.app.systems.rigidbody;
-        const idx = system._triggers.indexOf(this);
-        if (idx < 0) {
-            // addBody also puts the body into the active state so that it is simulated
-            // properly again
-            system.addBody(body, BODYGROUP_TRIGGER, BODYMASK_NOT_STATIC ^ BODYGROUP_TRIGGER);
-            system._triggers.push(this);
-        }
-
+        this.app.systems.rigidbody.addTrigger(this);
         this.updateTransform();
     }
 
     disable() {
-        const body = this.body;
-        if (!body) return;
+        if (!this.body) return;
 
-        const system = this.app.systems.rigidbody;
-        const idx = system._triggers.indexOf(this);
-        if (idx > -1) {
-            // removeBody also drops the body out of the active state so that it properly
-            // deactivates after we remove it from the physics world
-            system.removeBody(body);
-            system._triggers.splice(idx, 1);
-        }
+        this.app.systems.rigidbody.removeTrigger(this);
     }
 }
 

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -659,39 +659,7 @@ class RigidBodyComponent extends Component {
      * @ignore
      */
     enableSimulation() {
-        const entity = this.entity;
-        if (entity.collision && entity.collision.enabled && !this._simulationEnabled) {
-            const body = this._body;
-            if (body) {
-                // addBody also applies the backend's per-type activation policy
-                this.system.addBody(body, this._group, this._mask);
-
-                switch (this._type) {
-                    case BODYTYPE_DYNAMIC:
-                        this.system._dynamic.push(this);
-                        this.syncEntityToBody();
-                        break;
-                    case BODYTYPE_KINEMATIC:
-                        this.system._kinematic.push(this);
-                        break;
-                    case BODYTYPE_STATIC:
-                        this.syncEntityToBody();
-                        break;
-                }
-
-                if (entity.collision.type === 'compound') {
-                    this.system._compounds.push(entity.collision);
-                }
-
-                body.activate();
-
-                this._simulationEnabled = true;
-
-                // internal event consumed by the joint system to (re)create constraints
-                // against bodies that are present in the dynamics world
-                this.fire('simulationenabled');
-            }
-        }
+        this.system.enableSimulation(this);
     }
 
     /**
@@ -700,37 +668,7 @@ class RigidBodyComponent extends Component {
      * @ignore
      */
     disableSimulation() {
-        const body = this._body;
-        if (body && this._simulationEnabled) {
-            const system = this.system;
-
-            let idx = system._compounds.indexOf(this.entity.collision);
-            if (idx > -1) {
-                system._compounds.splice(idx, 1);
-            }
-
-            idx = system._dynamic.indexOf(this);
-            if (idx > -1) {
-                system._dynamic.splice(idx, 1);
-            }
-
-            idx = system._kinematic.indexOf(this);
-            if (idx > -1) {
-                system._kinematic.splice(idx, 1);
-            }
-
-            // removeBody also drops the body out of the active state so isActive() does not
-            // return true even though it is no longer in the dynamics world
-            system.removeBody(body);
-
-            this._simulationEnabled = false;
-
-            // internal event consumed by the joint system to destroy constraints that reference
-            // this body. The body has just been removed from the dynamics world above and is now
-            // inert, but is still a valid object - tearing the constraints down here keeps them
-            // from referencing the body once it is later destroyed or rebuilt.
-            this.fire('simulationdisabled');
-        }
+        this.system.disableSimulation(this);
     }
 
     /**

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -4,6 +4,10 @@ import { Debug } from '../../../core/debug.js';
 import { Vec3 } from '../../../core/math/vec3.js';
 import { AmmoPhysicsWorld } from '../../physics/ammo/ammo-physics-world.js';
 import { ComponentSystem } from '../system.js';
+import {
+    BODYGROUP_TRIGGER, BODYMASK_NOT_STATIC,
+    BODYTYPE_DYNAMIC, BODYTYPE_KINEMATIC, BODYTYPE_STATIC
+} from './constants.js';
 import { RigidBodyComponent } from './component.js';
 import { ContactPoint } from './contact-point.js';
 import { ContactResult } from './contact-result.js';
@@ -250,6 +254,123 @@ class RigidBodyComponentSystem extends ComponentSystem {
 
     removeBody(body) {
         this._world.removeBody(body);
+    }
+
+    /**
+     * Adds a component's body to the simulation and registers the component with the update
+     * lists for its body type. Fires 'simulationenabled' on the component. No-op unless the
+     * component has a body, an enabled collision component and is not already simulating.
+     *
+     * @param {RigidBodyComponent} component - The component to add to the simulation.
+     * @ignore
+     */
+    enableSimulation(component) {
+        const entity = component.entity;
+        if (entity.collision && entity.collision.enabled && !component._simulationEnabled) {
+            const body = component._body;
+            if (body) {
+                // addBody also applies the backend's per-type activation policy
+                this.addBody(body, component._group, component._mask);
+
+                switch (component._type) {
+                    case BODYTYPE_DYNAMIC:
+                        this._dynamic.push(component);
+                        component.syncEntityToBody();
+                        break;
+                    case BODYTYPE_KINEMATIC:
+                        this._kinematic.push(component);
+                        break;
+                    case BODYTYPE_STATIC:
+                        component.syncEntityToBody();
+                        break;
+                }
+
+                if (entity.collision.type === 'compound') {
+                    this._compounds.push(entity.collision);
+                }
+
+                body.activate();
+
+                component._simulationEnabled = true;
+
+                // internal event consumed by the joint system to (re)create constraints
+                // against bodies that are present in the dynamics world
+                component.fire('simulationenabled');
+            }
+        }
+    }
+
+    /**
+     * Removes a component's body from the simulation and unregisters the component from the
+     * update lists. Fires 'simulationdisabled' on the component. No-op unless the component
+     * has a body and is currently simulating.
+     *
+     * @param {RigidBodyComponent} component - The component to remove from the simulation.
+     * @ignore
+     */
+    disableSimulation(component) {
+        const body = component._body;
+        if (body && component._simulationEnabled) {
+            let idx = this._compounds.indexOf(component.entity.collision);
+            if (idx > -1) {
+                this._compounds.splice(idx, 1);
+            }
+
+            idx = this._dynamic.indexOf(component);
+            if (idx > -1) {
+                this._dynamic.splice(idx, 1);
+            }
+
+            idx = this._kinematic.indexOf(component);
+            if (idx > -1) {
+                this._kinematic.splice(idx, 1);
+            }
+
+            // removeBody also drops the body out of the active state so isActive() does not
+            // return true even though it is no longer in the dynamics world
+            this.removeBody(body);
+
+            component._simulationEnabled = false;
+
+            // internal event consumed by the joint system to destroy constraints that reference
+            // this body. The body has just been removed from the dynamics world above and is now
+            // inert, but is still a valid object - tearing the constraints down here keeps them
+            // from referencing the body once it is later destroyed or rebuilt.
+            component.fire('simulationdisabled');
+        }
+    }
+
+    /**
+     * Adds a trigger's body to the simulation and registers the trigger for per-frame
+     * transform updates. No-op if the trigger is already registered.
+     *
+     * @param {Trigger} trigger - The trigger to add to the simulation.
+     * @ignore
+     */
+    addTrigger(trigger) {
+        if (this._triggers.indexOf(trigger) < 0) {
+            // addBody also puts the body into the active state so that it is simulated
+            // properly again
+            this.addBody(trigger.body, BODYGROUP_TRIGGER, BODYMASK_NOT_STATIC ^ BODYGROUP_TRIGGER);
+            this._triggers.push(trigger);
+        }
+    }
+
+    /**
+     * Removes a trigger's body from the simulation and unregisters the trigger. No-op if the
+     * trigger is not registered.
+     *
+     * @param {Trigger} trigger - The trigger to remove from the simulation.
+     * @ignore
+     */
+    removeTrigger(trigger) {
+        const idx = this._triggers.indexOf(trigger);
+        if (idx > -1) {
+            // removeBody also drops the body out of the active state so that it properly
+            // deactivates after being removed from the physics world
+            this.removeBody(trigger.body);
+            this._triggers.splice(idx, 1);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Follow-up to #9043. `enableSimulation`/`disableSimulation` lived on `RigidBodyComponent` but maintained the system's private scheduling lists (`_dynamic`, `_kinematic`, `_compounds`), and `Trigger` poked `_triggers` the same way. This moves the registration choreography onto `RigidBodyComponentSystem` - which owns both the lists and the `onUpdate` loop that consumes them - as `enableSimulation(component)`/`disableSimulation(component)` plus `addTrigger`/`removeTrigger`.

The component methods remain as thin `@ignore`d delegates, so every call site (collision rebuild, the group/mask/mass setter cycles, enable/disable lifecycle) is unchanged, and cross-object private access now flows only in the sanctioned system-to-component direction. Behavior-identical: pure code motion with the native call order preserved (verified bit-exact against main with the real-Ammo A/B harness from #9043).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
