### PR TITLE
Flatten the collision type implementations into a dispatch table

### DIFF
--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -507,7 +507,7 @@ class CollisionComponent extends Component {
         this._convexHull = arg;
 
         if (this._initialized && this._type === 'mesh') {
-            this.system.implementations.mesh.doRecreatePhysicalShape(this);
+            this.system.doRecreatePhysicalShape(this);
         }
     }
 
@@ -540,7 +540,7 @@ class CollisionComponent extends Component {
             // recreate physical shapes skipping loading the model
             // from the 'asset' as the model passed in might
             // have been created procedurally
-            this.system.implementations.mesh.doRecreatePhysicalShape(this);
+            this.system.doRecreatePhysicalShape(this);
         }
     }
 
@@ -559,7 +559,7 @@ class CollisionComponent extends Component {
         if (this._initialized && this._type === 'mesh') {
             // recreate physical shapes skipping loading the render asset
             // as the render passed in might have been created procedurally
-            this.system.implementations.mesh.doRecreatePhysicalShape(this);
+            this.system.doRecreatePhysicalShape(this);
         }
     }
 
@@ -642,6 +642,22 @@ class CollisionComponent extends Component {
         }
     }
 
+    /**
+     * An {@link Entity#forEach} callback that refreshes the compound child transform of each
+     * descendant wired to the same compound root. Invoked with `this` set to the compound
+     * root's entity.
+     *
+     * @param {Entity} entity - The visited descendant entity.
+     * @private
+     */
+    _updateEachDescendantTransform(entity) {
+        if (!entity.collision || entity.collision._compoundParent !== this.collision._compoundParent) {
+            return;
+        }
+
+        this.collision.system.updateCompoundChildTransform(entity, false);
+    }
+
     /** @private */
     _updateCompound() {
         const entity = this.entity;
@@ -661,7 +677,7 @@ class CollisionComponent extends Component {
             }
 
             if (dirty) {
-                entity.forEach(this.system.implementations.compound._updateEachDescendantTransform, entity);
+                entity.forEach(this._updateEachDescendantTransform, entity);
 
                 const bodyComponent = this._compoundParent.entity.rigidbody;
                 if (bodyComponent) {

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -190,7 +190,7 @@ function recreateShapes(system, component) {
             destroyShape(system, component);
         }
 
-        component._shape = collisionImpls[component._type].createPhysicalShape(system, entity, component);
+        component._shape = getImpl(component._type).createPhysicalShape(system, entity, component);
 
         const firstCompoundChild = !component._compoundParent;
 
@@ -565,7 +565,7 @@ class CollisionComponentSystem extends ComponentSystem {
     }
 
     onTransformChanged(component, position, rotation, scale) {
-        const impl = collisionImpls[component.type];
+        const impl = getImpl(component.type);
         (impl.updateTransform ?? updateShapeTransform)(this, component, position, rotation, scale);
     }
 
@@ -593,6 +593,7 @@ class CollisionComponentSystem extends ComponentSystem {
      * @ignore
      */
     doRecreatePhysicalShape(component) {
+        Debug.assert(component._type === 'mesh', 'CollisionComponentSystem#doRecreatePhysicalShape: called for a non-mesh collision component.');
         doRecreateMeshShape(this, component);
     }
 

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -11,6 +11,7 @@ import { Trigger } from './trigger.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
  */
 
 const mat4 = new Mat4();
@@ -37,461 +38,408 @@ const _properties = [
     'checkVertexDuplicates'
 ];
 
-// Collision system implementations
-class CollisionSystemImpl {
-    constructor(system) {
-        this.system = system;
-    }
+// Per-type collision implementations. Rows only carry the operations a type performs
+// differently - call sites fall back to the shared flow functions below. createPhysicalShape
+// returns an opaque backend shape handle, or undefined when no physics backend is installed.
+const collisionImpls = {
+    box: {
+        createPhysicalShape: (system, entity, component) => system.physicsWorld?.createShape({
+            type: 'box',
+            halfExtents: component.halfExtents
+        })
+    },
 
-    // Called before the call to system.super.initializeComponentData is made
-    beforeInitialize(component) {
+    sphere: {
+        createPhysicalShape: (system, entity, component) => system.physicsWorld?.createShape({
+            type: 'sphere',
+            radius: component.radius
+        })
+    },
+
+    capsule: {
+        createPhysicalShape: (system, entity, component) => system.physicsWorld?.createShape({
+            type: 'capsule',
+            axis: component.axis,
+            radius: component.radius,
+            height: component.height
+        })
+    },
+
+    cylinder: {
+        createPhysicalShape: (system, entity, component) => system.physicsWorld?.createShape({
+            type: 'cylinder',
+            axis: component.axis,
+            radius: component.radius,
+            height: component.height
+        })
+    },
+
+    cone: {
+        createPhysicalShape: (system, entity, component) => system.physicsWorld?.createShape({
+            type: 'cone',
+            axis: component.axis,
+            radius: component.radius,
+            height: component.height
+        })
+    },
+
+    mesh: {
+        // the model comes from assets - no placeholder is created
+        beforeInitialize() {},
+        createPhysicalShape: createMeshShape,
+        recreatePhysicalShapes: recreateMeshShapes,
+        updateTransform: updateMeshTransform
+    },
+
+    compound: {
+        createPhysicalShape: (system, entity, component) => system.physicsWorld?.createShape({
+            type: 'compound'
+        })
+    }
+};
+
+// Returns the per-type implementation for a collision type
+function getImpl(type) {
+    const impl = collisionImpls[type];
+    Debug.assert(impl, `getImpl: Invalid collision system type: ${type}`);
+    return impl;
+}
+
+// Shared per-type flow. Functions take the system explicitly - the per-type variance lives in
+// the collisionImpls table above, which only carries the operations a type does differently.
+
+// Called before the call to system.super.initializeComponentData is made
+function beforeInitialize(system, component) {
+    component._shape = null;
+
+    const model = new Model();
+    model.graph = new GraphNode();
+    component._model = model;
+}
+
+// Called after the call to system.super.initializeComponentData is made
+function afterInitialize(system, component) {
+    system.recreatePhysicalShapes(component);
+    component._initialized = true;
+}
+
+// Re-creates the entity's rigid body after the collision shape changed
+function recreateBody(entity) {
+    entity.rigidbody.disableSimulation();
+    entity.rigidbody.createBody();
+
+    if (entity.enabled && entity.rigidbody.enabled) {
+        entity.rigidbody.enableSimulation();
+    }
+}
+
+// Creates the entity's trigger, or re-initializes an existing one
+function recreateTrigger(system, entity, component) {
+    if (!entity.trigger) {
+        entity.trigger = new Trigger(system.app, component);
+    } else {
+        entity.trigger.initialize();
+    }
+}
+
+function destroyShape(system, component) {
+    if (component._shape) {
+        system.physicsWorld.destroyShape(component._shape);
         component._shape = null;
-
-        const model = new Model();
-        model.graph = new GraphNode();
-        component._model = model;
     }
+}
 
-    // Called after the call to system.super.initializeComponentData is made
-    afterInitialize(component) {
-        this.recreatePhysicalShapes(component);
-        component._initialized = true;
+function beforeRemove(system, entity, component) {
+    if (component._shape) {
+        if (component._compoundParent && !component._compoundParent.entity._destroying) {
+            system._removeCompoundChild(component._compoundParent, component._shape);
+
+            if (component._compoundParent.entity.rigidbody) {
+                component._compoundParent.entity.rigidbody.activate();
+            }
+        }
+
+        component._compoundParent = null;
+
+        destroyShape(system, component);
     }
+}
 
-    // Called when a collision component changes type in order to recreate debug and physical shapes
-    reset(component) {
-        this.beforeInitialize(component);
-        this.afterInitialize(component);
-    }
+// Re-creates rigid bodies / triggers
+function recreateShapes(system, component) {
+    const entity = component.entity;
+    const world = system.physicsWorld;
 
-    // Re-creates rigid bodies / triggers
-    recreatePhysicalShapes(component) {
-        const entity = component.entity;
-        const world = this.system.physicsWorld;
+    if (world) {
+        if (entity.trigger) {
+            entity.trigger.destroy();
+            delete entity.trigger;
+        }
 
-        if (world) {
-            if (entity.trigger) {
-                entity.trigger.destroy();
-                delete entity.trigger;
-            }
-
-            if (component._shape) {
-                if (component._compoundParent) {
-                    if (component !== component._compoundParent) {
-                        this.system._removeCompoundChild(component._compoundParent, component._shape);
-                    }
-
-                    if (component._compoundParent.entity.rigidbody) {
-                        component._compoundParent.entity.rigidbody.activate();
-                    }
-                }
-
-                this.destroyShape(component);
-            }
-
-            component._shape = this.createPhysicalShape(entity, component);
-
-            const firstCompoundChild = !component._compoundParent;
-
-            if (component._type === 'compound' && (!component._compoundParent || component === component._compoundParent)) {
-                component._compoundParent = component;
-
-                entity.forEach(this._addEachDescendant, component);
-            } else if (component._type !== 'compound') {
-                if (!component.rigidbody) {
-                    component._compoundParent = null;
-                    let parent = entity.parent;
-                    while (parent) {
-                        if (parent.collision && parent.collision.type === 'compound') {
-                            component._compoundParent = parent.collision;
-                            break;
-                        }
-                        parent = parent.parent;
-                    }
-                }
-            }
-
+        if (component._shape) {
             if (component._compoundParent) {
                 if (component !== component._compoundParent) {
-                    if (firstCompoundChild && world.getCompoundChildCount(component._compoundParent.shape) === 0) {
-                        this.system.recreatePhysicalShapes(component._compoundParent);
-                    } else {
-                        this.system.updateCompoundChildTransform(entity, true);
-
-                        if (component._compoundParent.entity.rigidbody) {
-                            component._compoundParent.entity.rigidbody.activate();
-                        }
-                    }
+                    system._removeCompoundChild(component._compoundParent, component._shape);
                 }
-            }
-
-            if (entity.rigidbody) {
-                this._recreateBody(entity);
-            } else if (!component._compoundParent) {
-                this._recreateTrigger(entity, component);
-            }
-        }
-    }
-
-    // Re-creates the entity's rigid body after the collision shape changed
-    _recreateBody(entity) {
-        entity.rigidbody.disableSimulation();
-        entity.rigidbody.createBody();
-
-        if (entity.enabled && entity.rigidbody.enabled) {
-            entity.rigidbody.enableSimulation();
-        }
-    }
-
-    // Creates the entity's trigger, or re-initializes an existing one
-    _recreateTrigger(entity, component) {
-        if (!entity.trigger) {
-            entity.trigger = new Trigger(this.system.app, component);
-        } else {
-            entity.trigger.initialize();
-        }
-    }
-
-    // Creates a physical shape for the collision. This consists
-    // of the actual shape that will be used for the rigid bodies / triggers of
-    // the collision.
-    createPhysicalShape(entity, component) {
-        return undefined;
-    }
-
-    updateTransform(component, position, rotation, scale) {
-        if (component.entity.trigger) {
-            component.entity.trigger.updateTransform();
-        }
-    }
-
-    destroyShape(component) {
-        if (component._shape) {
-            this.system.physicsWorld.destroyShape(component._shape);
-            component._shape = null;
-        }
-    }
-
-    beforeRemove(entity, component) {
-        if (component._shape) {
-            if (component._compoundParent && !component._compoundParent.entity._destroying) {
-                this.system._removeCompoundChild(component._compoundParent, component._shape);
 
                 if (component._compoundParent.entity.rigidbody) {
                     component._compoundParent.entity.rigidbody.activate();
                 }
             }
 
-            component._compoundParent = null;
-
-            this.destroyShape(component);
+            destroyShape(system, component);
         }
-    }
-}
 
-// Box Collision System
-class CollisionBoxSystemImpl extends CollisionSystemImpl {
-    createPhysicalShape(entity, component) {
-        return this.system.physicsWorld?.createShape({
-            type: 'box',
-            halfExtents: component.halfExtents
-        });
-    }
-}
+        component._shape = collisionImpls[component._type].createPhysicalShape(system, entity, component);
 
-// Sphere Collision System
-class CollisionSphereSystemImpl extends CollisionSystemImpl {
-    createPhysicalShape(entity, component) {
-        return this.system.physicsWorld?.createShape({
-            type: 'sphere',
-            radius: component.radius
-        });
-    }
-}
+        const firstCompoundChild = !component._compoundParent;
 
-// Capsule Collision System
-class CollisionCapsuleSystemImpl extends CollisionSystemImpl {
-    createPhysicalShape(entity, component) {
-        return this.system.physicsWorld?.createShape({
-            type: 'capsule',
-            axis: component.axis,
-            radius: component.radius,
-            height: component.height
-        });
-    }
-}
+        if (component._type === 'compound' && (!component._compoundParent || component === component._compoundParent)) {
+            component._compoundParent = component;
 
-// Cylinder Collision System
-class CollisionCylinderSystemImpl extends CollisionSystemImpl {
-    createPhysicalShape(entity, component) {
-        return this.system.physicsWorld?.createShape({
-            type: 'cylinder',
-            axis: component.axis,
-            radius: component.radius,
-            height: component.height
-        });
-    }
-}
-
-// Cone Collision System
-class CollisionConeSystemImpl extends CollisionSystemImpl {
-    createPhysicalShape(entity, component) {
-        return this.system.physicsWorld?.createShape({
-            type: 'cone',
-            axis: component.axis,
-            radius: component.radius,
-            height: component.height
-        });
-    }
-}
-
-// Mesh Collision System
-class CollisionMeshSystemImpl extends CollisionSystemImpl {
-    // override for the mesh implementation because the asset model needs
-    // special handling
-    beforeInitialize(component) {}
-
-    // Builds a PhysicsMeshSource for one mesh. Vertex and index data are exposed through lazy
-    // accessors so they are only extracted when the backend actually builds triangle data -
-    // sources whose geometry is already cached (by mesh id) never touch the vertex buffer.
-    _createMeshSource(mesh, node, bakeScale, convexHull, checkDuplicates) {
-        let positions = null;
-        let stride = 0;
-        let indices = null;
-        let extracted = false;
-
-        const extract = () => {
-            if (extracted) return;
-            extracted = true;
-
-            if (convexHull) {
-                // hulls consume every position, tightly packed
-                positions = [];
-                mesh.getPositions(positions);
-                stride = 3;
-            } else {
-                const vb = mesh.vertexBuffer;
-                const format = vb.getFormat();
-                for (let i = 0; i < format.elements.length; i++) {
-                    const element = format.elements[i];
-                    if (element.name === SEMANTIC_POSITION) {
-                        positions = new Float32Array(vb.lock(), element.offset);
-                        stride = element.stride / 4;
+            entity.forEach(system._addEachDescendant, component);
+        } else if (component._type !== 'compound') {
+            if (!component.rigidbody) {
+                component._compoundParent = null;
+                let parent = entity.parent;
+                while (parent) {
+                    if (parent.collision && parent.collision.type === 'compound') {
+                        component._compoundParent = parent.collision;
                         break;
                     }
+                    parent = parent.parent;
                 }
-
-                indices = [];
-                mesh.getIndices(indices);
-            }
-        };
-
-        const source = {
-            id: mesh.id,
-            get positions() {
-                extract();
-                return positions;
-            },
-            get stride() {
-                extract();
-                return stride;
-            },
-            get indices() {
-                extract();
-                return indices;
-            },
-            base: mesh.primitive[0].base,
-            count: mesh.primitive[0].count,
-            convexHull: convexHull,
-            checkDuplicates: checkDuplicates,
-            bakeScale: bakeScale,
-            shapeScale: node ? this.system._getNodeScaling(node) : null,
-            position: new Vec3(),
-            rotation: new Quat()
-        };
-
-        if (node) {
-            this.system._getNodeTransform(node, null, source.position, source.rotation);
-        }
-
-        return source;
-    }
-
-    createPhysicalShape(entity, component) {
-        const world = this.system.physicsWorld;
-        if (!world) return undefined;
-
-        if (component._model || component._render) {
-
-            const entityTransform = entity.getWorldTransform();
-            const scale = entityTransform.getScale();
-            const sources = [];
-            let shapeScale = null;
-
-            if (component._render) {
-                // bake the entity scale into the vertices
-                const meshes = component._render.meshes;
-                for (let i = 0; i < meshes.length; i++) {
-                    sources.push(this._createMeshSource(meshes[i], null, scale, component._convexHull, component._checkVertexDuplicates));
-                }
-            } else if (component._model) {
-                // scale the whole shape by the entity scale
-                const meshInstances = component._model.meshInstances;
-                for (let i = 0; i < meshInstances.length; i++) {
-                    sources.push(this._createMeshSource(meshInstances[i].mesh, meshInstances[i].node, null, false, component._checkVertexDuplicates));
-                }
-                shapeScale = scale;
-            }
-
-            // record the scale the shape was built with, for the rebuild-on-scale-change check
-            component._builtWorldScale = scale;
-
-            return world.createShape({
-                type: 'mesh',
-                sources: sources,
-                scale: shapeScale
-            });
-        }
-
-        return undefined;
-    }
-
-    recreatePhysicalShapes(component) {
-        if (component._renderAsset || component._asset) {
-            if (component.enabled && component.entity.enabled) {
-                this.loadAsset(
-                    component,
-                    component._renderAsset || component._asset,
-                    component._renderAsset ? 'render' : 'model'
-                );
-                return;
             }
         }
 
-        this.doRecreatePhysicalShape(component);
-    }
-
-    loadAsset(component, id, property) {
-        const assets = this.system.app.assets;
-        // write the loaded resource to the private field - the public setter
-        // would trigger a second shape rebuild via doRecreatePhysicalShape
-        const privateProperty = `_${property}`;
-        const previousPropertyValue = component[privateProperty];
-
-        const onAssetFullyReady = (asset) => {
-            if (component[privateProperty] !== previousPropertyValue) {
-                // the asset has changed since we started loading it, so ignore this callback
-                return;
-            }
-            component[privateProperty] = asset.resource;
-            this.doRecreatePhysicalShape(component);
-        };
-
-        const loadAndHandleAsset = (asset) => {
-            asset.ready((asset) => {
-                if (asset.data.containerAsset) {
-                    const containerAsset = assets.get(asset.data.containerAsset);
-                    if (containerAsset.loaded) {
-                        onAssetFullyReady(asset);
-                    } else {
-                        containerAsset.ready(() => {
-                            onAssetFullyReady(asset);
-                        });
-                        assets.load(containerAsset);
-                    }
+        if (component._compoundParent) {
+            if (component !== component._compoundParent) {
+                if (firstCompoundChild && world.getCompoundChildCount(component._compoundParent.shape) === 0) {
+                    system.recreatePhysicalShapes(component._compoundParent);
                 } else {
-                    onAssetFullyReady(asset);
+                    system.updateCompoundChildTransform(entity, true);
+
+                    if (component._compoundParent.entity.rigidbody) {
+                        component._compoundParent.entity.rigidbody.activate();
+                    }
                 }
-            });
-
-            assets.load(asset);
-        };
-
-        const asset = assets.get(id);
-        if (asset) {
-            loadAndHandleAsset(asset);
-        } else {
-            assets.once(`add:${id}`, loadAndHandleAsset);
-        }
-    }
-
-    doRecreatePhysicalShape(component) {
-        const entity = component.entity;
-
-        if (component._model || component._render) {
-            this.destroyShape(component);
-
-            component._shape = this.createPhysicalShape(entity, component);
-
-            if (entity.rigidbody) {
-                this._recreateBody(entity);
-            } else {
-                // note: unlike the base implementation, the trigger is
-                // created even when the component is a compound child
-                this._recreateTrigger(entity, component);
-            }
-        } else {
-            this.beforeRemove(entity, component);
-            this.system.onRemove(entity);
-        }
-    }
-
-    updateTransform(component, position, rotation, scale) {
-        if (component.shape && component._builtWorldScale) {
-            const entityTransform = component.entity.getWorldTransform();
-            const worldScale = entityTransform.getScale();
-
-            // if the scale changed then recreate the shape
-            if (!worldScale.equals(component._builtWorldScale)) {
-                this.doRecreatePhysicalShape(component);
             }
         }
 
-        super.updateTransform(component, position, rotation, scale);
+        if (entity.rigidbody) {
+            recreateBody(entity);
+        } else if (!component._compoundParent) {
+            recreateTrigger(system, entity, component);
+        }
     }
 }
 
-// Compound Collision System
-class CollisionCompoundSystemImpl extends CollisionSystemImpl {
-    createPhysicalShape(entity, component) {
-        return this.system.physicsWorld?.createShape({ type: 'compound' });
+function updateShapeTransform(system, component, position, rotation, scale) {
+    if (component.entity.trigger) {
+        component.entity.trigger.updateTransform();
+    }
+}
+
+// Builds a PhysicsMeshSource for one mesh. Vertex and index data are exposed through lazy
+// accessors so they are only extracted when the backend actually builds triangle data -
+// sources whose geometry is already cached (by mesh id) never touch the vertex buffer.
+function createMeshSource(system, mesh, node, bakeScale, convexHull, checkDuplicates) {
+    let positions = null;
+    let stride = 0;
+    let indices = null;
+    let extracted = false;
+
+    const extract = () => {
+        if (extracted) return;
+        extracted = true;
+
+        if (convexHull) {
+            // hulls consume every position, tightly packed
+            positions = [];
+            mesh.getPositions(positions);
+            stride = 3;
+        } else {
+            const vb = mesh.vertexBuffer;
+            const format = vb.getFormat();
+            for (let i = 0; i < format.elements.length; i++) {
+                const element = format.elements[i];
+                if (element.name === SEMANTIC_POSITION) {
+                    positions = new Float32Array(vb.lock(), element.offset);
+                    stride = element.stride / 4;
+                    break;
+                }
+            }
+
+            indices = [];
+            mesh.getIndices(indices);
+        }
+    };
+
+    const source = {
+        id: mesh.id,
+        get positions() {
+            extract();
+            return positions;
+        },
+        get stride() {
+            extract();
+            return stride;
+        },
+        get indices() {
+            extract();
+            return indices;
+        },
+        base: mesh.primitive[0].base,
+        count: mesh.primitive[0].count,
+        convexHull: convexHull,
+        checkDuplicates: checkDuplicates,
+        bakeScale: bakeScale,
+        shapeScale: node ? system._getNodeScaling(node) : null,
+        position: new Vec3(),
+        rotation: new Quat()
+    };
+
+    if (node) {
+        system._getNodeTransform(node, null, source.position, source.rotation);
     }
 
-    _addEachDescendant(entity) {
-        if (!entity.collision || entity.rigidbody) {
-            return;
+    return source;
+}
+
+function createMeshShape(system, entity, component) {
+    const world = system.physicsWorld;
+    if (!world) return undefined;
+
+    if (component._model || component._render) {
+
+        const entityTransform = entity.getWorldTransform();
+        const scale = entityTransform.getScale();
+        const sources = [];
+        let shapeScale = null;
+
+        if (component._render) {
+            // bake the entity scale into the vertices
+            const meshes = component._render.meshes;
+            for (let i = 0; i < meshes.length; i++) {
+                sources.push(createMeshSource(system, meshes[i], null, scale, component._convexHull, component._checkVertexDuplicates));
+            }
+        } else if (component._model) {
+            // scale the whole shape by the entity scale
+            const meshInstances = component._model.meshInstances;
+            for (let i = 0; i < meshInstances.length; i++) {
+                sources.push(createMeshSource(system, meshInstances[i].mesh, meshInstances[i].node, null, false, component._checkVertexDuplicates));
+            }
+            shapeScale = scale;
         }
 
-        entity.collision._compoundParent = this;
+        // record the scale the shape was built with, for the rebuild-on-scale-change check
+        component._builtWorldScale = scale;
 
-        if (entity !== this.entity) {
-            entity.collision.system.recreatePhysicalShapes(entity.collision);
+        return world.createShape({
+            type: 'mesh',
+            sources: sources,
+            scale: shapeScale
+        });
+    }
+
+    return undefined;
+}
+
+// Rebuilds the mesh shape from the component's current model or render sources, skipping any
+// asset loading
+function doRecreateMeshShape(system, component) {
+    const entity = component.entity;
+
+    if (component._model || component._render) {
+        destroyShape(system, component);
+
+        component._shape = createMeshShape(system, entity, component);
+
+        if (entity.rigidbody) {
+            recreateBody(entity);
+        } else {
+            // note: unlike the standard flow, the trigger is created even when the component
+            // is a compound child
+            recreateTrigger(system, entity, component);
+        }
+    } else {
+        beforeRemove(system, entity, component);
+        system.onRemove(entity);
+    }
+}
+
+function loadMeshAsset(system, component, id, property) {
+    const assets = system.app.assets;
+    // write the loaded resource to the private field - the public setter
+    // would trigger a second shape rebuild via doRecreateMeshShape
+    const privateProperty = `_${property}`;
+    const previousPropertyValue = component[privateProperty];
+
+    const onAssetFullyReady = (asset) => {
+        if (component[privateProperty] !== previousPropertyValue) {
+            // the asset has changed since we started loading it, so ignore this callback
+            return;
+        }
+        component[privateProperty] = asset.resource;
+        doRecreateMeshShape(system, component);
+    };
+
+    const loadAndHandleAsset = (asset) => {
+        asset.ready((asset) => {
+            if (asset.data.containerAsset) {
+                const containerAsset = assets.get(asset.data.containerAsset);
+                if (containerAsset.loaded) {
+                    onAssetFullyReady(asset);
+                } else {
+                    containerAsset.ready(() => {
+                        onAssetFullyReady(asset);
+                    });
+                    assets.load(containerAsset);
+                }
+            } else {
+                onAssetFullyReady(asset);
+            }
+        });
+
+        assets.load(asset);
+    };
+
+    const asset = assets.get(id);
+    if (asset) {
+        loadAndHandleAsset(asset);
+    } else {
+        assets.once(`add:${id}`, loadAndHandleAsset);
+    }
+}
+
+function recreateMeshShapes(system, component) {
+    if (component._renderAsset || component._asset) {
+        if (component.enabled && component.entity.enabled) {
+            loadMeshAsset(
+                system,
+                component,
+                component._renderAsset || component._asset,
+                component._renderAsset ? 'render' : 'model'
+            );
+            return;
         }
     }
 
-    _updateEachDescendant(entity) {
-        if (!entity.collision) {
-            return;
-        }
+    doRecreateMeshShape(system, component);
+}
 
-        if (entity.collision._compoundParent !== this) {
-            return;
-        }
+function updateMeshTransform(system, component, position, rotation, scale) {
+    if (component.shape && component._builtWorldScale) {
+        const entityTransform = component.entity.getWorldTransform();
+        const worldScale = entityTransform.getScale();
 
-        entity.collision._compoundParent = null;
-
-        if (entity !== this.entity && !entity.rigidbody) {
-            entity.collision.system.recreatePhysicalShapes(entity.collision);
+        // if the scale changed then recreate the shape
+        if (!worldScale.equals(component._builtWorldScale)) {
+            doRecreateMeshShape(system, component);
         }
     }
 
-    _updateEachDescendantTransform(entity) {
-        if (!entity.collision || entity.collision._compoundParent !== this.collision._compoundParent) {
-            return;
-        }
-
-        this.collision.system.updateCompoundChildTransform(entity, false);
-    }
+    updateShapeTransform(system, component, position, rotation, scale);
 }
 
 /**
@@ -512,8 +460,6 @@ class CollisionComponentSystem extends ComponentSystem {
         this.id = 'collision';
 
         this.ComponentType = CollisionComponent;
-
-        this.implementations = { };
 
         this.on('beforeremove', this.onBeforeRemove, this);
         this.on('remove', this.onRemove, this);
@@ -555,48 +501,12 @@ class CollisionComponentSystem extends ComponentSystem {
             }
         }
 
-        const impl = this._createImplementation(component._type);
-        impl.beforeInitialize(component);
+        const impl = getImpl(component._type);
+        (impl.beforeInitialize ?? beforeInitialize)(this, component);
 
         super.initializeComponentData(component, data);
 
-        impl.afterInitialize(component);
-    }
-
-    // Creates an implementation based on the collision type and caches it
-    // in an internal implementations structure, before returning it.
-    _createImplementation(type) {
-        if (this.implementations[type] === undefined) {
-            let impl;
-            switch (type) {
-                case 'box':
-                    impl = new CollisionBoxSystemImpl(this);
-                    break;
-                case 'sphere':
-                    impl = new CollisionSphereSystemImpl(this);
-                    break;
-                case 'capsule':
-                    impl = new CollisionCapsuleSystemImpl(this);
-                    break;
-                case 'cylinder':
-                    impl = new CollisionCylinderSystemImpl(this);
-                    break;
-                case 'cone':
-                    impl = new CollisionConeSystemImpl(this);
-                    break;
-                case 'mesh':
-                    impl = new CollisionMeshSystemImpl(this);
-                    break;
-                case 'compound':
-                    impl = new CollisionCompoundSystemImpl(this);
-                    break;
-                default:
-                    Debug.error(`_createImplementation: Invalid collision system type: ${type}`);
-            }
-            this.implementations[type] = impl;
-        }
-
-        return this.implementations[type];
+        afterInitialize(this, component);
     }
 
     cloneComponent(entity, clone) {
@@ -617,7 +527,7 @@ class CollisionComponentSystem extends ComponentSystem {
     }
 
     onBeforeRemove(entity, component) {
-        this.implementations[component.type].beforeRemove(entity, component);
+        beforeRemove(this, entity, component);
         component.onBeforeRemove();
 
         // discard any stored collisions keyed to this entity so a later entity that reuses the
@@ -655,19 +565,54 @@ class CollisionComponentSystem extends ComponentSystem {
     }
 
     onTransformChanged(component, position, rotation, scale) {
-        this.implementations[component.type].updateTransform(component, position, rotation, scale);
+        const impl = collisionImpls[component.type];
+        (impl.updateTransform ?? updateShapeTransform)(this, component, position, rotation, scale);
     }
 
     // Destroys the previous collision type and creates a new one based on the new type provided
     changeType(component, previousType, newType) {
-        this.implementations[previousType].beforeRemove(component.entity, component);
+        beforeRemove(this, component.entity, component);
         this.onRemove(component.entity);
-        this._createImplementation(newType).reset(component);
+
+        const impl = getImpl(newType);
+        (impl.beforeInitialize ?? beforeInitialize)(this, component);
+        afterInitialize(this, component);
     }
 
     // Recreates rigid bodies or triggers for the specified component
     recreatePhysicalShapes(component) {
-        this.implementations[component.type].recreatePhysicalShapes(component);
+        const impl = getImpl(component.type);
+        (impl.recreatePhysicalShapes ?? recreateShapes)(this, component);
+    }
+
+    /**
+     * Rebuilds a mesh component's shape from its current model or render sources, skipping any
+     * asset loading. Used by the mesh source setters, which assign the resource directly.
+     *
+     * @param {CollisionComponent} component - The mesh collision component to rebuild.
+     * @ignore
+     */
+    doRecreatePhysicalShape(component) {
+        doRecreateMeshShape(this, component);
+    }
+
+    /**
+     * An {@link Entity#forEach} callback that wires a descendant of a compound root to it and
+     * rebuilds the descendant's shape. Invoked with `this` set to the compound root component.
+     *
+     * @param {Entity} entity - The visited descendant entity.
+     * @private
+     */
+    _addEachDescendant(entity) {
+        if (!entity.collision || entity.rigidbody) {
+            return;
+        }
+
+        entity.collision._compoundParent = this;
+
+        if (entity !== this.entity) {
+            entity.collision.system.recreatePhysicalShapes(entity.collision);
+        }
     }
 
     _calculateNodeRelativeTransform(node, relative) {

--- a/test/framework/components/collision/component.test.mjs
+++ b/test/framework/components/collision/component.test.mjs
@@ -131,7 +131,6 @@ describe('CollisionComponent', function () {
             e.addComponent('collision', { type: null });
 
             expect(e.collision.type).to.equal('box');
-            expect(app.systems.collision.implementations.box).to.exist;
         });
 
         it('copies Vec3 inputs so caller mutations do not leak into component state', function () {
@@ -237,14 +236,13 @@ describe('CollisionComponent', function () {
 
     describe('#type', function () {
 
-        it('changes type and creates the new implementation', function () {
+        it('changes type', function () {
             const e = new Entity();
             e.addComponent('collision');
 
             e.collision.type = 'sphere';
 
             expect(e.collision.type).to.equal('sphere');
-            expect(app.systems.collision.implementations.sphere).to.exist;
         });
 
         it('is a no-op when the type is unchanged', function () {
@@ -338,16 +336,16 @@ describe('CollisionComponent', function () {
             expect(counter.count()).to.equal(3);
         });
 
-        it('routes model, render and convexHull changes to the mesh implementation', function () {
+        it('routes model, render and convexHull changes to the mesh rebuild', function () {
             const box = new Entity();
             box.addComponent('collision');
 
             const mesh = new Entity();
             mesh.addComponent('collision', { type: 'mesh' });
 
-            const impl = app.systems.collision.implementations.mesh;
+            const system = app.systems.collision;
             let calls = 0;
-            impl.doRecreatePhysicalShape = function () {
+            system.doRecreatePhysicalShape = function () {
                 calls++;
             };
 


### PR DESCRIPTION
## Description

Follow-up to #9043. Since the physics backend port, the `CollisionSystemImpl` class hierarchy was mostly ceremony - five of the seven subclasses only overrode a one-line `createPhysicalShape` descriptor builder. This replaces the hierarchy, the `implementations` cache and the `_createImplementation` switch with a module-scope `collisionImpls` dispatch table (the `jointImpls` pattern from the backend), whose rows carry only the operations a type performs differently (`createPhysicalShape` everywhere; `beforeInitialize`/`recreatePhysicalShapes`/`updateTransform` for mesh). Call sites fall back to shared flow functions that take the system explicitly.

Notes for reviewers:

- Behavior-identical: the flow function bodies are the previous class method bodies verbatim with `this.system` parameterized, and the `?? fallback` call sites map 1:1 onto the previous virtual dispatch. Verified bit-exact against main with the real-Ammo A/B harness from #9043 (its compound and mesh/hull scenarios cover exactly these flows), plus the null-backend lifecycle tests.
- The mesh model/render/convexHull setters now route through a new `@ignore` system method `doRecreatePhysicalShape` (rebuild skipping asset load) instead of reaching into `implementations.mesh`.
- The compound descendant-transform walker moves onto `CollisionComponent` next to its only caller; both `entity.forEach` thisArg bindings are preserved exactly.
- `_updateEachDescendant` had no call sites - deleted as dead code.
- `system.implementations` and `_createImplementation` were undocumented internals with no external references (engine tests updated; the editor does not reference them).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
