### PR TITLE
Fix compound wiring for collision children that have their own rigidbody

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -199,7 +199,7 @@ function recreateShapes(system, component) {
 
             entity.forEach(system._addEachDescendant, component);
         } else if (component._type !== 'compound') {
-            if (!component.rigidbody) {
+            if (!entity.rigidbody) {
                 component._compoundParent = null;
                 let parent = entity.parent;
                 while (parent) {

--- a/test/framework/components/collision/component.test.mjs
+++ b/test/framework/components/collision/component.test.mjs
@@ -4,6 +4,7 @@ import { Quat } from '../../../../src/core/math/quat.js';
 import { Vec3 } from '../../../../src/core/math/vec3.js';
 import { Asset } from '../../../../src/framework/asset/asset.js';
 import { Entity } from '../../../../src/framework/entity.js';
+import { NullPhysicsWorld } from '../../../../src/framework/physics/null/null-physics-world.js';
 import { Model } from '../../../../src/scene/model.js';
 import { createApp } from '../../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
@@ -357,6 +358,42 @@ describe('CollisionComponent', function () {
             mesh.collision.model = new Model();
             mesh.collision.render = null;
             expect(calls).to.equal(3);
+        });
+
+    });
+
+    describe('compound children', function () {
+
+        beforeEach(function () {
+            // install the no-op physics backend so the shape lifecycle runs
+            app.systems.rigidbody.setPhysicsWorld(new NullPhysicsWorld());
+        });
+
+        it('wires a plain collision child to an ancestor compound', function () {
+            const parent = new Entity();
+            app.root.addChild(parent);
+            parent.addComponent('rigidbody');
+            parent.addComponent('collision', { type: 'compound' });
+
+            const child = new Entity();
+            parent.addChild(child);
+            child.addComponent('collision', { type: 'box' });
+
+            expect(child.collision._compoundParent).to.equal(parent.collision);
+        });
+
+        it('keeps a child with its own rigidbody independent of an ancestor compound', function () {
+            const parent = new Entity();
+            app.root.addChild(parent);
+            parent.addComponent('rigidbody');
+            parent.addComponent('collision', { type: 'compound' });
+
+            const child = new Entity();
+            parent.addChild(child);
+            child.addComponent('rigidbody');
+            child.addComponent('collision', { type: 'box' });
+
+            expect(child.collision._compoundParent).to.equal(null);
         });
 
     });


### PR DESCRIPTION
## Description
`recreateShapes` gated the compound-parent ancestor walk on `component.rigidbody`, a property that does not exist on `CollisionComponent`, so the walk ran for every non-compound collision. A collision child with its own rigidbody nested under a compound therefore got `_compoundParent` wired and its shape added into the ancestor's compound shape, while the same shape was also used to build the child's own rigid body — one shape registered in two bodies. The check now tests `entity.rigidbody`, matching the equivalent gate in `_addEachDescendant`.

Includes a regression test using the null physics backend.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
