### PR TITLE
fix: support glTF occlusion strength

### DIFF
--- a/src/extras/exporters/gltf-exporter.js
+++ b/src/extras/exporters/gltf-exporter.js
@@ -665,6 +665,9 @@ class GltfExporter extends CoreExporter {
 
                 this.attachTexture(resources, mat, material, 'normalTexture', 'normalMap', json);
                 this.attachTexture(resources, mat, material, 'occlusionTexture', 'aoMap', json);
+                if (material.occlusionTexture && mat.aoIntensity !== 1) {
+                    material.occlusionTexture.strength = mat.aoIntensity;
+                }
                 this.attachTexture(resources, mat, material, 'emissiveTexture', 'emissiveMap', json);
 
                 return material;

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -588,7 +588,10 @@ const createMaterial = (gltfMaterial, textures) => {
         material.aoMapChannel = 'r';
 
         extractTextureTransform(occlusionTexture, material, ['ao']);
-        // TODO: support 'strength'
+
+        if (occlusionTexture.hasOwnProperty('strength')) {
+            material.aoIntensity = occlusionTexture.strength;
+        }
     }
 
     if (gltfMaterial.hasOwnProperty('emissiveFactor')) {

--- a/test/extras/exporters/gltf-exporter.test.mjs
+++ b/test/extras/exporters/gltf-exporter.test.mjs
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+
+import { GltfExporter } from '../../../src/extras/exporters/gltf-exporter.js';
+import { StandardMaterial } from '../../../src/scene/materials/standard-material.js';
+
+describe('GltfExporter', function () {
+
+    const exportMaterial = (aoIntensity) => {
+        const texture = { name: 'ao' };
+        const material = new StandardMaterial();
+        material.aoMap = texture;
+        material.aoIntensity = aoIntensity;
+
+        const json = {};
+        const resources = {
+            materials: [material],
+            textures: [texture]
+        };
+
+        new GltfExporter().writeMaterials(resources, json);
+
+        return json.materials[0];
+    };
+
+    it('exports occlusion texture strength', function () {
+        const material = exportMaterial(0.5);
+
+        expect(material.occlusionTexture.strength).to.equal(0.5);
+    });
+
+    it('exports zero occlusion texture strength', function () {
+        const material = exportMaterial(0);
+
+        expect(material.occlusionTexture.strength).to.equal(0);
+    });
+
+    it('omits the default occlusion texture strength', function () {
+        const material = exportMaterial(1);
+
+        expect(material.occlusionTexture).not.to.have.property('strength');
+    });
+});

--- a/test/framework/parsers/glb-parser.test.mjs
+++ b/test/framework/parsers/glb-parser.test.mjs
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+
+import { GlbParser } from '../../../src/framework/parsers/glb-parser.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+describe('GlbParser', function () {
+
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    const parseMaterial = (occlusionTexture) => {
+        const gltf = {
+            asset: { version: '2.0' },
+            scenes: [],
+            nodes: [],
+            materials: [{ occlusionTexture }]
+        };
+        const data = new TextEncoder().encode(JSON.stringify(gltf));
+
+        return new Promise((resolve, reject) => {
+            GlbParser.parse('material.gltf', '', data, app.graphicsDevice, app.assets, {}, (err, result) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(result.materials[0]);
+                }
+            });
+        });
+    };
+
+    it('imports occlusion texture strength', async function () {
+        const material = await parseMaterial({ index: 0, strength: 0.5 });
+
+        expect(material.aoIntensity).to.equal(0.5);
+    });
+
+    it('imports zero occlusion texture strength', async function () {
+        const material = await parseMaterial({ index: 0, strength: 0 });
+
+        expect(material.aoIntensity).to.equal(0);
+    });
+
+    it('uses the default occlusion texture strength when omitted', async function () {
+        const material = await parseMaterial({ index: 0 });
+
+        expect(material.aoIntensity).to.equal(1);
+    });
+});


### PR DESCRIPTION
Adds glTF occlusion texture strength support for import and export.

- Maps occlusionTexture.strength to StandardMaterial.aoIntensity during import.
- Exports non-default aoIntensity values as occlusionTexture.strength.
- Preserves zero strength and omits the default value of 1.
- Adds parser and exporter regression tests.

Public API changes:
- None.

Tests:
- npm run lint
- npm test (2031 passing, 2 pending)

Fixed #9062