### PR TITLE
docs: add compute shader definition types

### DIFF
--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -75,6 +75,10 @@ class Shader {
      * WebGPU platform.
      * @param {string} [definition.computeEntryPoint] - The entry point function name for the compute
      * shader. Defaults to 'main'.
+     * @param {BindGroupFormat} [definition.computeBindGroupFormat] - The bind group format for
+     * caller-provided compute resources in group 0. Only used on WebGPU.
+     * @param {Object<string, UniformBufferFormat>} [definition.computeUniformBufferFormats] - The
+     * uniform buffer formats keyed by bind group entry name. Requires computeBindGroupFormat.
      * @param {Map<string, string>} [definition.vincludes] - A map containing key-value pairs of
      * include names and their content. These are used for resolving #include directives in the
      * vertex shader source.


### PR DESCRIPTION
## Summary

- Document `computeBindGroupFormat` and `computeUniformBufferFormats` on the public `Shader` definition.
- Ensure generated TypeScript declarations accept both properties in inline shader definition objects.
- Document that caller-provided compute resources use bind group 0 and that uniform buffer formats require the corresponding bind group format.

Fixes #9060

## Public API changes

The generated `Shader` definition type now includes the existing WebGPU compute options.

Before:

```ts
new Shader(device, {
    cshader,
    computeBindGroupFormat // TypeScript excess-property error
});
```

After:

```ts
new Shader(device, {
    cshader,
    computeBindGroupFormat,
    computeUniformBufferFormats
});
```

This corrects the type declarations only; runtime behavior is unchanged.

## Testing

- `npm run build:types`
- `npm run test:types`
- `npm run lint`

## Performance considerations

None. This is a JSDoc/type declaration correction with no runtime changes.
