### PR TITLE
[BREAKING] Remove MeshInstance parameter pass flags

### DIFF
--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -376,7 +376,7 @@ class MeshInstance {
     meshMetaData = null;
 
     /**
-     * @type {Record<string, {scopeId: ScopeId|null, data: any, passFlags: number}>}
+     * @type {Record<string, {scopeId: ScopeId|null, data: any}>}
      * @ignore
      */
     parameters = {};
@@ -1327,20 +1327,22 @@ class MeshInstance {
      *
      * @param {string} name - The name of the parameter to set.
      * @param {number|number[]|Texture|Float32Array} data - The value for the specified parameter.
-     * @param {number} [passFlags] - Mask describing which passes the material should be included
-     * in. Defaults to 0xFFFFFFFF (all passes).
      */
-    setParameter(name, data, passFlags = 0xFFFFFFFF) {
+    setParameter(name, data) {
+
+        Debug.call(() => {
+            if (arguments[2] !== undefined) {
+                Debug.removed('MeshInstance#setParameter: the "passFlags" argument has been removed and is ignored.');
+            }
+        });
 
         const param = this.parameters[name];
         if (param) {
             param.data = data;
-            param.passFlags = passFlags;
         } else {
             this.parameters[name] = {
                 scopeId: null,
-                data: data,
-                passFlags: passFlags
+                data: data
             };
         }
     }
@@ -1390,19 +1392,16 @@ class MeshInstance {
      * by forward-renderer.
      *
      * @param {GraphicsDevice} device - The graphics device.
-     * @param {number} passFlag - The pass flag for the current render pass.
      * @ignore
      */
-    setParameters(device, passFlag) {
+    setParameters(device) {
         const parameters = this.parameters;
         for (const paramName in parameters) {
             const parameter = parameters[paramName];
-            if (parameter.passFlags & passFlag) {
-                if (!parameter.scopeId) {
-                    parameter.scopeId = device.scope.resolve(paramName);
-                }
-                parameter.scopeId.setValue(parameter.data);
+            if (!parameter.scopeId) {
+                parameter.scopeId = device.scope.resolve(paramName);
             }
+            parameter.scopeId.setValue(parameter.data);
         }
     }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -611,7 +611,6 @@ class ForwardRenderer extends Renderer {
     renderForwardInternal(camera, preparedCalls, sortedLights, pass, drawCallback, flipFaces) {
         const device = this.device;
         const scene = this.scene;
-        const passFlag = 1 << pass;
         const flipFactor = flipFaces ? -1 : 1;
         const clusteredLightingEnabled = scene.clusteredLightingEnabled;
 
@@ -673,7 +672,7 @@ class ForwardRenderer extends Renderer {
             device.setStencilState(stencilFront, stencilBack);
 
             // Uniforms II: meshInstance overrides
-            drawCall.setParameters(device, passFlag);
+            drawCall.setParameters(device);
 
             // mesh ID - used by the picker
             device.scope.resolve('meshInstanceId').setValue(drawCall.id);

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -15,7 +15,6 @@ import {
     EVENT_POSTCULL,
     EVENT_PRECULL,
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI,
-    SHADER_SHADOW,
     SHADOWCAMERA_NAME,
     SHADOWUPDATE_NONE,
     shadowTypeInfo
@@ -296,7 +295,6 @@ class ShadowRenderer {
         const device = this.device;
         const renderer = this.renderer;
         const scene = renderer.scene;
-        const passFlags = 1 << SHADER_SHADOW;
         const shadowPass = this.getShadowPass(light);
         const cameraShaderParams = camera.shaderParams;
 
@@ -335,7 +333,7 @@ class ShadowRenderer {
             material.setParameters(device);
 
             // Uniforms II (shadow): meshInstance overrides
-            meshInstance.setParameters(device, passFlags);
+            meshInstance.setParameters(device);
 
             const shaderInstance = meshInstance.getShaderInstance(shadowPass, 0, scene, cameraShaderParams, this.viewUniformFormat);
             const shadowShader = shaderInstance.shader;


### PR DESCRIPTION
## Description

Removes the passFlags argument from MeshInstance#setParameter and strips out the associated parameter storage and per-draw filtering.

The passFlags argument was only used internally by OutlineRenderer. That renderer now uses the dedicated pcOutline shader pass introduced in #9070, so the pass-filtering functionality no longer has an engine consumer.

Removing it simplifies MeshInstance parameter handling and prepares the renderer for simpler uniform-buffer management in follow-up PRs.

## Public API changes

Before:

~~~js
meshInstance.setParameter(name, data, passFlags);
~~~

After:

~~~js
meshInstance.setParameter(name, data);
~~~

JavaScript callers that still supply a third argument receive a Debug.removed message in debug builds. The argument is ignored and mesh instance parameters are applied to all passes. Generated TypeScript declarations expose only the two-argument signature.

## Technical details

- Removes passFlags from stored MeshInstance parameter records.
- Applies mesh instance parameters unconditionally in forward and shadow rendering.
- Removes renderer pass-mask calculations and the unused SHADER_SHADOW import.
- Keeps the legacy argument check fully inside Debug.call so it is stripped from production builds.

## Performance considerations

Removes a bitmask calculation and per-parameter conditional from the rendering path.

## Testing

- npm run lint
- npm run build:types
- npm run test:types
- Runtime validation of the removed warning and unconditional parameter application

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project coding standards
- [x] This PR focuses on a single change