### PR TITLE
Ignore Codex workspace directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.DS_Store
 .cursor
 .claude
+.codex/
 .idea/
 .vscode/
 .turbo


### PR DESCRIPTION
## Description

Adds .codex/ to the repository ignore list so local Codex worktrees and workspace metadata cannot be accidentally staged as repository content.

## Public API changes

None.

## Testing

- git check-ignore confirms .codex/worktrees content is ignored
- git diff --check

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project coding standards
- [x] This PR focuses on a single change