### PR TITLE
Re-add Camera.beforePasses extension point

### DIFF
--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -121,6 +121,15 @@ class Camera {
      */
     framePasses = [];
 
+    /**
+     * Frame passes that execute before this camera's main scene rendering, after the camera's
+     * directional shadow passes. Entries are picked up by the RenderPassForward that renders
+     * this camera's layers.
+     *
+     * @type {FramePass[]}
+     */
+    beforePasses = [];
+
     /** @type {number} */
     jitter = 0;
 
@@ -217,6 +226,7 @@ class Camera {
         this.renderPassDepthGrab = null;
 
         this.framePasses.length = 0;
+        this.beforePasses.length = 0;
     }
 
     /**

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -146,6 +146,28 @@ class RenderPassForward extends RenderPass {
         }
     }
 
+    // Collect before-passes from cameras whose first render step lives in this
+    // RenderPassForward. Uses the existing firstCameraUse flag (set by LayerComposition)
+    // to guarantee each camera's before-passes are scheduled exactly once, even when
+    // multiple RenderPassForward instances reference the same camera (e.g. CameraFrame's
+    // scenePass vs afterPass). Called after updateDirectionalShadows, so camera
+    // before-passes execute after the directional shadow passes and can render into the
+    // freshly updated shadow maps.
+    updateCameraBeforePasses() {
+        for (let i = 0; i < this.layerRenderSteps.length; i++) {
+            const step = this.layerRenderSteps[i];
+            if (step.firstCameraUse) {
+                const camera = step.cameraComponent?.camera;
+                if (camera) {
+                    const { beforePasses } = camera;
+                    for (let j = 0; j < beforePasses.length; j++) {
+                        this.beforePasses.push(beforePasses[j]);
+                    }
+                }
+            }
+        }
+    }
+
     updateClears() {
 
         // based on the first render action
@@ -166,6 +188,7 @@ class RenderPassForward extends RenderPass {
     frameUpdate() {
         super.frameUpdate();
         this.updateDirectionalShadows();
+        this.updateCameraBeforePasses();
         this.updateClears();
 
         // request mesh-instance culling for the (camera, layer) pairs this pass will render, so


### PR DESCRIPTION
Re-adds the `Camera.beforePasses` extension point removed in #8957, ported to the refactored `RenderPassForward` internals, with one deliberate scheduling change.

This restores the ability for external code to schedule frame passes (compute dispatches, custom rasterization, shadow casters) before a camera's main scene rendering, as requested in https://github.com/playcanvas/engine/pull/8957#issuecomment-4799502263 for GPU-driven rendering pipelines.

**Changes:**
- Re-add `Camera.beforePasses` (`FramePass[]`) — frame passes that execute before the camera's main scene rendering, picked up by the `RenderPassForward` that renders the camera's layers. Cleared in `Camera.destroy()`.
- Re-add `RenderPassForward.updateCameraBeforePasses()`, ported from the pre-refactor implementation (`renderActions` → `layerRenderSteps`). Still gated on `firstCameraUse`, so each camera's before-passes are scheduled exactly once even when multiple `RenderPassForward` instances reference the same camera (e.g. CameraFrame's scenePass vs afterPass).
- Scheduling change vs the original: before-passes are now collected **after** `updateDirectionalShadows()`, so they execute after the engine's directional shadow passes and can render into the freshly updated shadow maps (e.g. custom shadow casters drawn into the engine's shadow map). The original order (before the shadow passes) served no known consumer.

**API Changes:**
- Re-added `Camera.beforePasses` (`FramePass[]`), matching the pre-#8957 shape.