### PR TITLE
Use named engine symbols in ESM script documentation

### DIFF
--- a/scripts/esm/README.md
+++ b/scripts/esm/README.md
@@ -5,12 +5,13 @@ A collection of ready-to-use [`Script`](https://api.playcanvas.com/engine/classe
 These scripts ship inside the `playcanvas` npm package but are **not** part of the core engine bundle — each one is imported directly from its module:
 
 ```javascript
+import { Vec3 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 entity.addComponent('script');
 entity.script.create(CameraControls, {
     properties: {
-        focusPoint: new pc.Vec3(0, 1, 0)
+        focusPoint: new Vec3(0, 1, 0)
     }
 });
 ```

--- a/scripts/esm/blurred-planar-reflection.mjs
+++ b/scripts/esm/blurred-planar-reflection.mjs
@@ -322,7 +322,7 @@ const _tempVec3b = new Vec3();
  * The entity's position defines the reflection plane, and its up vector (Y-axis) defines the plane normal.
  *
  * @example
- * const reflector = new pc.Entity('GroundReflection');
+ * const reflector = new Entity('GroundReflection');
  * reflector.addComponent('render', {
  *     type: 'plane',
  *     castShadows: false

--- a/scripts/esm/gsplat/gsplat-flipbook.mjs
+++ b/scripts/esm/gsplat/gsplat-flipbook.mjs
@@ -95,7 +95,7 @@ const PlayMode = {
  *
  * @example
  * // Create entity and add gsplat component first
- * const entity = new pc.Entity('Flipbook');
+ * const entity = new Entity('Flipbook');
  * entity.addComponent('gsplat', {
  *     unified: true
  * });

--- a/scripts/esm/gsplat/gsplat-trees.mjs
+++ b/scripts/esm/gsplat/gsplat-trees.mjs
@@ -219,7 +219,7 @@ const renderWGSL = /* wgsl */ `
  *
  * @example
  * const trees = entity.script.create(GSplatTrees);
- * trees.setSpheres([{ center: new pc.Vec3(0, 3, 0), radius: 3 }]);
+ * trees.setSpheres([{ center: new Vec3(0, 3, 0), radius: 3 }]);
  * @category Gaussian Splatting
  */
 class GSplatTrees extends Script {

--- a/scripts/esm/gsplat/gsplat-weather.mjs
+++ b/scripts/esm/gsplat/gsplat-weather.mjs
@@ -14,7 +14,7 @@ import { Script, Vec3, BoundingBox, GSplatFormat, GSplatContainer, PIXELFORMAT_R
  * giving correct depth ordering with both CPU and GPU sorting.
  *
  * @example
- * const weatherEntity = new pc.Entity('Weather');
+ * const weatherEntity = new Entity('Weather');
  * weatherEntity.addComponent('script');
  * const weather = weatherEntity.script.create(GSplatWeather);
  * weather.followEntity = cameraEntity;

--- a/scripts/esm/gsplat/reveal-radial.mjs
+++ b/scripts/esm/gsplat/reveal-radial.mjs
@@ -274,7 +274,7 @@ fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
  * entity.addComponent('script');
  * entity.script.create(GSplatRevealRadial, {
  *     attributes: {
- *         center: new pc.Vec3(0, 0, 0),
+ *         center: new Vec3(0, 0, 0),
  *         speed: 2,
  *         delay: 1,
  *         oscillationIntensity: 0.2

--- a/scripts/esm/planar-renderer.mjs
+++ b/scripts/esm/planar-renderer.mjs
@@ -36,19 +36,19 @@ const _clipNormal = new Vec3();
  * Note: Objects that use the resulting texture should not be in the layers this camera renders.
  *
  * @example
- * const reflectionCamera = new pc.Entity('ReflectionCamera');
+ * const reflectionCamera = new Entity('ReflectionCamera');
  * reflectionCamera.addComponent('camera', {
  *     layers: [worldLayer.id, skyboxLayer.id],
  *     priority: -1,
- *     toneMapping: pc.TONEMAP_ACES
+ *     toneMapping: TONEMAP_ACES
  * });
  * reflectionCamera.addComponent('script');
  * const planarRenderer = reflectionCamera.script.create(PlanarRenderer, {
  *     properties: {
  *         sceneCameraEntity: cameraEntity,
  *         mode: 'reflection',
- *         planePoint: new pc.Vec3(0, 0, 0),
- *         planeNormal: new pc.Vec3(0, 1, 0)
+ *         planePoint: new Vec3(0, 0, 0),
+ *         planeNormal: new Vec3(0, 1, 0)
  *     }
  * });
  * app.root.addChild(reflectionCamera);

--- a/scripts/esm/shadow-catcher.mjs
+++ b/scripts/esm/shadow-catcher.mjs
@@ -20,10 +20,10 @@ import {
  * catcher. If you don't provide one, the script will create a plane geometry.
  *
  * @example
- * const shadowCatcher = new pc.Entity('ShadowCatcher');
+ * const shadowCatcher = new Entity('ShadowCatcher');
  * shadowCatcher.addComponent('script').create(ShadowCatcher, {
  *     properties: {
- *         scale: new pc.Vec3(50, 50, 50)
+ *         scale: new Vec3(50, 50, 50)
  *         // geometry: geometryEntity // optionally provide a geometry entity
  *     }
  * });

--- a/scripts/esm/water.mjs
+++ b/scripts/esm/water.mjs
@@ -943,7 +943,7 @@ const fragmentWGSL = /* wgsl */`
  * the water's own layers, the UI and the depth layer.
  *
  * @example
- * const water = new pc.Entity('Water');
+ * const water = new Entity('Water');
  * water.addComponent('render', { type: 'plane', layers: [waterLayer.id], castShadows: false });
  * water.setLocalScale(100, 1, 100);
  * water.addComponent('script');

--- a/scripts/esm/xr/xr-manipulation.mjs
+++ b/scripts/esm/xr/xr-manipulation.mjs
@@ -100,7 +100,7 @@ const wrapPi = (angle) => {
  *
  * @example
  * // Parent the scene content under a world root and grab-manipulate it
- * const worldRoot = new pc.Entity('WorldRoot');
+ * const worldRoot = new Entity('WorldRoot');
  * app.root.addChild(worldRoot);
  * worldRoot.addChild(galleryEntity);
  *

--- a/scripts/esm/xr/xr-menu.mjs
+++ b/scripts/esm/xr/xr-menu.mjs
@@ -80,7 +80,7 @@ const FINGER_JOINTS = [
  *         menuItems: [ ... ],
  *         alwaysVisible: true,
  *         followDistance: 0.6,
- *         followOffset: new pc.Vec2(0.25, -0.15)
+ *         followOffset: new Vec2(0.25, -0.15)
  *     }
  * });
  * @category XR


### PR DESCRIPTION
## Overview

Update the Engine Scripts documentation to follow the named-import convention used by the module build and engine examples.

- Remove remaining pc namespace qualifiers from documented ESM script examples.
- Import Vec3 explicitly in the Engine Scripts landing-page example.
- Leave resource-handler parser documentation unchanged because parsers are excluded from the Engine Scripts API reference.

## Public API changes

None. This only changes documentation examples; runtime behavior and exported APIs are unchanged.

## Validation

- npm run lint
- npm run docs:scripts (passes with the existing unrelated VolumetricFog warning)