### PR TITLE
Remove pc namespace from engine JSDoc examples

### DIFF
--- a/src/core/math/color.js
+++ b/src/core/math/color.js
@@ -48,8 +48,8 @@ class Color {
      * @param {number} [b] - The b value. Defaults to 0.
      * @param {number} [a] - The a value. Defaults to 1.
      * @example
-     * const c1 = new pc.Color(); // defaults to 0, 0, 0, 1
-     * const c2 = new pc.Color(0.1, 0.2, 0.3, 0.4);
+     * const c1 = new Color(); // defaults to 0, 0, 0, 1
+     * const c2 = new Color(0.1, 0.2, 0.3, 0.4);
      */
     /**
      * Creates a new Color instance.
@@ -57,7 +57,7 @@ class Color {
      * @overload
      * @param {number[]} arr - The array to set the color values from.
      * @example
-     * const c = new pc.Color([0.1, 0.2, 0.3, 0.4]);
+     * const c = new Color([0.1, 0.2, 0.3, 0.4]);
      */
     /**
      * @param {number|number[]} [r] - The r value. Defaults to 0. If r is an array of length 3 or
@@ -86,7 +86,7 @@ class Color {
      *
      * @returns {this} A duplicate color object.
      * @example
-     * const c = new pc.Color(1, 0, 0, 1);
+     * const c = new Color(1, 0, 0, 1);
      * const cClone = c.clone();
      * // cClone is [1, 0, 0, 1]
      */
@@ -102,8 +102,8 @@ class Color {
      * @param {Color} rhs - A color to copy to the specified color.
      * @returns {Color} Self for chaining.
      * @example
-     * const src = new pc.Color(1, 0, 0, 1);
-     * const dst = new pc.Color();
+     * const src = new Color(1, 0, 0, 1);
+     * const dst = new Color();
      *
      * dst.copy(src);
      *
@@ -124,8 +124,8 @@ class Color {
      * @param {Color} rhs - The color to compare to the specified color.
      * @returns {boolean} True if the colors are equal and false otherwise.
      * @example
-     * const a = new pc.Color(1, 0, 0, 1);
-     * const b = new pc.Color(1, 1, 0, 1);
+     * const a = new Color(1, 0, 0, 1);
+     * const b = new Color(1, 1, 0, 1);
      * console.log("The two colors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -141,7 +141,7 @@ class Color {
      * @param {number} [a] - The value for the alpha (0-1), defaults to 1.
      * @returns {Color} Self for chaining.
      * @example
-     * const c = new pc.Color();
+     * const c = new Color();
      * c.set(1, 0, 0, 1);
      * // c is now red [1, 0, 0, 1]
      */
@@ -164,9 +164,9 @@ class Color {
      * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Color} Self for chaining.
      * @example
-     * const a = new pc.Color(0, 0, 0);
-     * const b = new pc.Color(1, 1, 0.5);
-     * const r = new pc.Color();
+     * const a = new Color(0, 0, 0);
+     * const b = new Color(1, 1, 0.5);
+     * const r = new Color();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 0.5, 0.5, 0.25
@@ -188,7 +188,7 @@ class Color {
      * is done in place.
      * @returns {Color} Self for chaining.
      * @example
-     * const c = new pc.Color(0.5, 0.5, 0.5, 1);
+     * const c = new Color(0.5, 0.5, 0.5, 1);
      * c.linear();
      * // c is now approximately [0.218, 0.218, 0.218, 1]
      */
@@ -207,7 +207,7 @@ class Color {
      * done in place.
      * @returns {Color} Self for chaining.
      * @example
-     * const c = new pc.Color(0.218, 0.218, 0.218, 1);
+     * const c = new Color(0.218, 0.218, 0.218, 1);
      * c.gamma();
      * // c is now approximately [0.5, 0.5, 0.5, 1]
      */
@@ -225,7 +225,7 @@ class Color {
      * @param {number} scalar - The number to multiply by.
      * @returns {Color} Self for chaining.
      * @example
-     * const c = new pc.Color(0.2, 0.4, 0.6, 1);
+     * const c = new Color(0.2, 0.4, 0.6, 1);
      * c.mulScalar(2);
      * // c is now [0.4, 0.8, 1.2, 1]
      */
@@ -244,7 +244,7 @@ class Color {
      * HTML/CSS.
      * @returns {Color} Self for chaining.
      * @example
-     * const c = new pc.Color();
+     * const c = new Color();
      * c.fromString('#ff0000');
      * // c is now [1, 0, 0, 1]
      */
@@ -271,7 +271,7 @@ class Color {
      * array. Default is 0.
      * @returns {Color} Self for chaining.
      * @example
-     * const c = new pc.Color();
+     * const c = new Color();
      * c.fromArray([1, 0, 1, 1]);
      * // c is set to [1, 0, 1, 1]
      */
@@ -293,7 +293,7 @@ class Color {
      * @param {boolean} [asArray] - If true, the output will be an array of numbers. Defaults to false.
      * @returns {string} The color in string form.
      * @example
-     * const c = new pc.Color(1, 1, 1);
+     * const c = new Color(1, 1, 1);
      * // Outputs #ffffff
      * console.log(c.toString());
      */
@@ -344,7 +344,7 @@ class Color {
      * @param {boolean} [alpha] - If true, the output array will include the alpha value.
      * @returns {number[]|ArrayBufferView} The color as an array.
      * @example
-     * const c = new pc.Color(1, 1, 1);
+     * const c = new Color(1, 1, 1);
      * // Outputs [1, 1, 1, 1]
      * console.log(c.toArray());
      */

--- a/src/core/math/curve-set.js
+++ b/src/core/math/curve-set.js
@@ -32,7 +32,7 @@ class CurveSet {
      * - Multiple arguments: Each argument becomes a separate curve.
      * @example
      * // Create from an array of arrays of keys
-     * const curveSet = new pc.CurveSet([
+     * const curveSet = new CurveSet([
      *     [
      *         0, 0,        // At 0 time, value of 0
      *         0.33, 2,     // At 0.33 time, value of 2
@@ -116,7 +116,7 @@ class CurveSet {
      * @param {number} index - The index of the curve to return.
      * @returns {Curve} The curve at the specified index.
      * @example
-     * const curveSet = new pc.CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+     * const curveSet = new CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
      * const curve = curveSet.get(0); // returns the first curve
      */
     get(index) {
@@ -132,7 +132,7 @@ class CurveSet {
      * second) for the new curve.
      * @returns {Curve} The newly created curve.
      * @example
-     * const curveSet = new pc.CurveSet([[0, 0, 1, 1]]);
+     * const curveSet = new CurveSet([[0, 0, 1, 1]]);
      * const curve = curveSet.add([0, 0, 1, 0.5]); // append a second curve
      */
     add(data) {
@@ -149,7 +149,7 @@ class CurveSet {
      * itself.
      * @returns {Curve|null} The removed curve, or null if it was not found.
      * @example
-     * const curveSet = new pc.CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+     * const curveSet = new CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
      * curveSet.remove(0);             // remove by index
      * curveSet.remove(curveSet.get(0)); // or remove by reference
      */
@@ -170,7 +170,7 @@ class CurveSet {
      *
      * @returns {this} The curve set instance.
      * @example
-     * const curveSet = new pc.CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+     * const curveSet = new CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
      * curveSet.clearKeys(); // both curves are now empty, but the set still has 2 curves
      */
     clearKeys() {
@@ -185,7 +185,7 @@ class CurveSet {
      *
      * @returns {this} The curve set instance.
      * @example
-     * const curveSet = new pc.CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+     * const curveSet = new CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
      * curveSet.clear(); // the set now has no curves
      */
     clear() {
@@ -202,7 +202,7 @@ class CurveSet {
      * result.
      * @returns {number[]} The interpolated curve values at the specified time.
      * @example
-     * const curveSet = new pc.CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
+     * const curveSet = new CurveSet([[0, 0, 1, 1], [0, 0, 1, 0.5]]);
      * const values = curveSet.value(0.5); // returns interpolated values for all curves at time 0.5
      */
     value(time, result = []) {
@@ -221,7 +221,7 @@ class CurveSet {
      *
      * @returns {this} A clone of the specified curve set.
      * @example
-     * const curveSet = new pc.CurveSet([[0, 0, 1, 1]]);
+     * const curveSet = new CurveSet([[0, 0, 1, 1]]);
      * const clonedCurveSet = curveSet.clone();
      */
     clone() {

--- a/src/core/math/curve.js
+++ b/src/core/math/curve.js
@@ -49,7 +49,7 @@ class Curve {
      * @param {number[]} [data] - An array of keys (pairs of numbers with the time first and value
      * second).
      * @example
-     * const curve = new pc.Curve([
+     * const curve = new Curve([
      *     0, 0,        // At 0 time, value of 0
      *     0.33, 2,     // At 0.33 time, value of 2
      *     0.66, 2.6,   // At 0.66 time, value of 2.6
@@ -82,7 +82,7 @@ class Curve {
      * @param {number} value - Value of new key.
      * @returns {number[]} The newly created `[time, value]` pair.
      * @example
-     * const curve = new pc.Curve();
+     * const curve = new Curve();
      * curve.add(0, 1);   // add key at time 0 with value 1
      * curve.add(1, 2);   // add key at time 1 with value 2
      */
@@ -109,7 +109,7 @@ class Curve {
      * @returns {number[]|null} The removed `[time, value]` pair, or null if the index is out of
      * range.
      * @example
-     * const curve = new pc.Curve([0, 1, 1, 2]);
+     * const curve = new Curve([0, 1, 1, 2]);
      * curve.remove(0); // removes the key at time 0
      */
     remove(index) {
@@ -125,7 +125,7 @@ class Curve {
      *
      * @returns {this} The curve instance.
      * @example
-     * const curve = new pc.Curve([0, 1, 1, 2]);
+     * const curve = new Curve([0, 1, 1, 2]);
      * curve.clear(); // curve now has no keys
      */
     clear() {
@@ -139,7 +139,7 @@ class Curve {
      * @param {number} index - The index of key to return.
      * @returns {number[]} The `[time, value]` pair at the specified index.
      * @example
-     * const curve = new pc.Curve([0, 1, 1, 2]);
+     * const curve = new Curve([0, 1, 1, 2]);
      * const key = curve.get(0); // returns [0, 1]
      */
     get(index) {
@@ -159,7 +159,7 @@ class Curve {
      * @param {number} time - The time at which to calculate the value.
      * @returns {number} The interpolated value.
      * @example
-     * const curve = new pc.Curve([0, 0, 1, 10]);
+     * const curve = new Curve([0, 0, 1, 10]);
      * const value = curve.value(0.5); // returns interpolated value at time 0.5
      */
     value(time) {
@@ -175,7 +175,7 @@ class Curve {
      * @returns {number[]|null} The `[time, value]` pair closest to the specified time, or null if
      * no keys exist.
      * @example
-     * const curve = new pc.Curve([0, 1, 0.5, 2, 1, 3]);
+     * const curve = new Curve([0, 1, 0.5, 2, 1, 3]);
      * const key = curve.closest(0.6); // returns [0.5, 2]
      */
     closest(time) {
@@ -202,7 +202,7 @@ class Curve {
      *
      * @returns {this} A clone of the specified curve.
      * @example
-     * const curve = new pc.Curve([0, 0, 1, 10]);
+     * const curve = new Curve([0, 0, 1, 10]);
      * const clonedCurve = curve.clone();
      */
     clone() {

--- a/src/core/math/float-packing.js
+++ b/src/core/math/float-packing.js
@@ -18,7 +18,7 @@ class FloatPacking {
      * @param {number} value - The float value to pack.
      * @returns {number} The 16-bit half-float representation as an integer.
      * @example
-     * const half = pc.FloatPacking.float2Half(1.5);
+     * const half = FloatPacking.float2Half(1.5);
      */
     static float2Half(value) {
         // based on https://esdiscuss.org/topic/float16array

--- a/src/core/math/kernel.js
+++ b/src/core/math/kernel.js
@@ -14,7 +14,7 @@ class Kernel {
      * @returns {number[]} An array where each point is represented by two consecutive numbers (x, y).
      * @example
      * // Generate a kernel with 3 rings and 8 points in the first ring
-     * const kernel = pc.Kernel.concentric(3, 8);
+     * const kernel = Kernel.concentric(3, 8);
      * // kernel is a flat array: [x0, y0, x1, y1, x2, y2, ...]
      */
     static concentric(numRings, numPoints) {

--- a/src/core/math/mat3.js
+++ b/src/core/math/mat3.js
@@ -33,7 +33,7 @@ class Mat3 {
      *
      * @returns {this} A duplicate matrix.
      * @example
-     * const src = new pc.Mat3().setFromQuat(new pc.Quat(0, 0, 0.383, 0.924));
+     * const src = new Mat3().setFromQuat(new Quat(0, 0, 0.383, 0.924));
      * const dst = src.clone();
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -49,8 +49,8 @@ class Mat3 {
      * @param {Mat3} rhs - A 3x3 matrix to be copied.
      * @returns {Mat3} Self for chaining.
      * @example
-     * const src = new pc.Mat3().setFromQuat(new pc.Quat(0, 0, 0.383, 0.924));
-     * const dst = new pc.Mat3();
+     * const src = new Mat3().setFromQuat(new Quat(0, 0, 0.383, 0.924));
+     * const dst = new Mat3();
      * dst.copy(src);
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -77,7 +77,7 @@ class Mat3 {
      * @param {number[]} src - An array[9] to be copied.
      * @returns {Mat3} Self for chaining.
      * @example
-     * const dst = new pc.Mat3();
+     * const dst = new Mat3();
      * dst.set([0, 1, 2, 3, 4, 5, 6, 7, 8]);
      */
     set(src) {
@@ -102,7 +102,7 @@ class Mat3 {
      * @param {Vec3} [x] - The vector to receive the x axis of the matrix.
      * @returns {Vec3} The x-axis of the specified matrix.
      * @example
-     * const m = new pc.Mat3();
+     * const m = new Mat3();
      * const xAxis = m.getX(); // Vec3(1, 0, 0) for identity matrix
      */
     getX(x = new Vec3()) {
@@ -115,7 +115,7 @@ class Mat3 {
      * @param {Vec3} [y] - The vector to receive the y axis of the matrix.
      * @returns {Vec3} The y-axis of the specified matrix.
      * @example
-     * const m = new pc.Mat3();
+     * const m = new Mat3();
      * const yAxis = m.getY(); // Vec3(0, 1, 0) for identity matrix
      */
     getY(y = new Vec3()) {
@@ -128,7 +128,7 @@ class Mat3 {
      * @param {Vec3} [z] - The vector to receive the z axis of the matrix.
      * @returns {Vec3} The z-axis of the specified matrix.
      * @example
-     * const m = new pc.Mat3();
+     * const m = new Mat3();
      * const zAxis = m.getZ(); // Vec3(0, 0, 1) for identity matrix
      */
     getZ(z = new Vec3()) {
@@ -141,8 +141,8 @@ class Mat3 {
      * @param {Mat3} rhs - The other matrix.
      * @returns {boolean} True if the matrices are equal and false otherwise.
      * @example
-     * const a = new pc.Mat3().setFromQuat(new pc.Quat(0, 0, 0.383, 0.924));
-     * const b = new pc.Mat3();
+     * const a = new Mat3().setFromQuat(new Quat(0, 0, 0.383, 0.924));
+     * const b = new Mat3();
      * console.log("The two matrices are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -165,7 +165,7 @@ class Mat3 {
      *
      * @returns {boolean} True if the matrix is identity and false otherwise.
      * @example
-     * const m = new pc.Mat3();
+     * const m = new Mat3();
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
     isIdentity() {
@@ -211,7 +211,7 @@ class Mat3 {
      *
      * @returns {string} The matrix in string form.
      * @example
-     * const m = new pc.Mat3();
+     * const m = new Mat3();
      * // Outputs [1, 0, 0, 0, 1, 0, 0, 0, 1]
      * console.log(m.toString());
      */
@@ -225,7 +225,7 @@ class Mat3 {
      * @param {Mat3} [src] - The matrix to transpose. If not set, the matrix is transposed in-place.
      * @returns {Mat3} Self for chaining.
      * @example
-     * const m = new pc.Mat3();
+     * const m = new Mat3();
      *
      * // Transpose in place
      * m.transpose();
@@ -260,8 +260,8 @@ class Mat3 {
      * @param {Mat4} m - The 4x4 matrix to convert.
      * @returns {Mat3} Self for chaining.
      * @example
-     * const m4 = new pc.Mat4();
-     * const m3 = new pc.Mat3().setFromMat4(m4);
+     * const m4 = new Mat4();
+     * const m3 = new Mat3().setFromMat4(m4);
      */
     setFromMat4(m) {
         const src = m.data;
@@ -288,9 +288,9 @@ class Mat3 {
      * @param {Quat} r - A quaternion rotation.
      * @returns {Mat3} Self for chaining.
      * @example
-     * const r = new pc.Quat(1, 2, 3, 4).normalize();
+     * const r = new Quat(1, 2, 3, 4).normalize();
      *
-     * const m = new pc.Mat3();
+     * const m = new Mat3();
      * m.setFromQuat(r);
      */
     setFromQuat(r) {
@@ -391,8 +391,8 @@ class Mat3 {
      * transformation.
      * @returns {Vec3} The input vector v transformed by the current instance.
      * @example
-     * const m = new pc.Mat3();
-     * const v = new pc.Vec3(1, 2, 3);
+     * const m = new Mat3();
+     * const v = new Vec3(1, 2, 3);
      * const result = m.transformVector(v);
      */
     transformVector(vec, res = new Vec3()) {

--- a/src/core/math/mat4.js
+++ b/src/core/math/mat4.js
@@ -54,9 +54,9 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second operand of the addition.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      *
-     * m.add2(pc.Mat4.IDENTITY, pc.Mat4.ONE);
+     * m.add2(Mat4.IDENTITY, Mat4.ONE);
      *
      * console.log("The result of the addition is: " + m.toString());
      */
@@ -91,9 +91,9 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second operand of the addition.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      *
-     * m.add(pc.Mat4.ONE);
+     * m.add(Mat4.ONE);
      *
      * console.log("The result of the addition is: " + m.toString());
      */
@@ -106,7 +106,7 @@ class Mat4 {
      *
      * @returns {this} A duplicate matrix.
      * @example
-     * const src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const src = new Mat4().setFromEulerAngles(10, 20, 30);
      * const dst = src.clone();
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -122,8 +122,8 @@ class Mat4 {
      * @param {Mat4} rhs - A 4x4 matrix to be copied.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const src = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * const dst = new pc.Mat4();
+     * const src = new Mat4().setFromEulerAngles(10, 20, 30);
+     * const dst = new Mat4();
      * dst.copy(src);
      * console.log("The two matrices are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -157,8 +157,8 @@ class Mat4 {
      * @param {Mat4} rhs - The other matrix.
      * @returns {boolean} True if the matrices are equal and false otherwise.
      * @example
-     * const a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * const b = new pc.Mat4();
+     * const a = new Mat4().setFromEulerAngles(10, 20, 30);
+     * const b = new Mat4();
      * console.log("The two matrices are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -188,7 +188,7 @@ class Mat4 {
      *
      * @returns {boolean} True if the matrix is identity and false otherwise.
      * @example
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      * console.log("The matrix is " + (m.isIdentity() ? "identity" : "not identity"));
      */
     isIdentity() {
@@ -220,9 +220,9 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second multiplicand of the operation.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * const b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
-     * const r = new pc.Mat4();
+     * const a = new Mat4().setFromEulerAngles(10, 20, 30);
+     * const b = new Mat4().setFromAxisAngle(Vec3.UP, 180);
+     * const r = new Mat4();
      *
      * // r = a * b
      * r.mul2(a, b);
@@ -305,9 +305,9 @@ class Mat4 {
      * the operation.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * const b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
-     * const r = new pc.Mat4();
+     * const a = new Mat4().setFromEulerAngles(10, 20, 30);
+     * const b = new Mat4().setFromAxisAngle(Vec3.UP, 180);
+     * const r = new Mat4();
      *
      * // r = a * b (optimized for affine transforms)
      * r.mulAffine2(a, b);
@@ -373,8 +373,8 @@ class Mat4 {
      * @param {Mat4} rhs - The 4x4 matrix used as the second multiplicand of the operation.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const a = new pc.Mat4().setFromEulerAngles(10, 20, 30);
-     * const b = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const a = new Mat4().setFromEulerAngles(10, 20, 30);
+     * const b = new Mat4().setFromAxisAngle(Vec3.UP, 180);
      *
      * // a = a * b
      * a.mul(b);
@@ -394,10 +394,10 @@ class Mat4 {
      * @returns {Vec3} The input point v transformed by the current instance.
      * @example
      * // Create a 3-dimensional point
-     * const v = new pc.Vec3(1, 2, 3);
+     * const v = new Vec3(1, 2, 3);
      *
      * // Create a 4x4 rotation matrix
-     * const m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const m = new Mat4().setFromEulerAngles(10, 20, 30);
      *
      * const tv = m.transformPoint(v);
      */
@@ -422,10 +422,10 @@ class Mat4 {
      * @returns {Vec3} The input vector v transformed by the current instance.
      * @example
      * // Create a 3-dimensional vector
-     * const v = new pc.Vec3(1, 2, 3);
+     * const v = new Vec3(1, 2, 3);
      *
      * // Create a 4x4 rotation matrix
-     * const m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const m = new Mat4().setFromEulerAngles(10, 20, 30);
      *
      * const tv = m.transformVector(v);
      */
@@ -450,13 +450,13 @@ class Mat4 {
      * @returns {Vec4} The input vector v transformed by the current instance.
      * @example
      * // Create an input 4-dimensional vector
-     * const v = new pc.Vec4(1, 2, 3, 4);
+     * const v = new Vec4(1, 2, 3, 4);
      *
      * // Create an output 4-dimensional vector
-     * const result = new pc.Vec4();
+     * const result = new Vec4();
      *
      * // Create a 4x4 rotation matrix
-     * const m = new pc.Mat4().setFromEulerAngles(10, 20, 30);
+     * const m = new Mat4().setFromEulerAngles(10, 20, 30);
      *
      * m.transformVec4(v, result);
      */
@@ -487,10 +487,10 @@ class Mat4 {
      * @param {Vec3} up - 3-d vector holding the up direction.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const position = new pc.Vec3(10, 10, 10);
-     * const target = new pc.Vec3(0, 0, 0);
-     * const up = new pc.Vec3(0, 1, 0);
-     * const m = new pc.Mat4().setLookAt(position, target, up);
+     * const position = new Vec3(10, 10, 10);
+     * const target = new Vec3(0, 0, 0);
+     * const up = new Vec3(0, 1, 0);
+     * const m = new Mat4().setLookAt(position, target, up);
      */
     setLookAt(position, target, up) {
         z.sub2(position, target).normalize();
@@ -537,7 +537,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 perspective projection matrix
-     * const f = new pc.Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
+     * const f = new Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
      * @ignore
      */
     setFrustum(left, right, bottom, top, znear, zfar) {
@@ -583,7 +583,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 perspective projection matrix
-     * const persp = new pc.Mat4().setPerspective(45, 16 / 9, 1, 1000);
+     * const persp = new Mat4().setPerspective(45, 16 / 9, 1, 1000);
      */
     setPerspective(fov, aspect, znear, zfar, fovIsHorizontal) {
         Mat4._getPerspectiveHalfSize(_halfSize, fov, aspect, znear, fovIsHorizontal);
@@ -607,7 +607,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 orthographic projection matrix
-     * const ortho = new pc.Mat4().setOrtho(-2, 2, -2, 2, 1, 1000);
+     * const ortho = new Mat4().setOrtho(-2, 2, -2, 2, 1, 1000);
      */
     setOrtho(left, right, bottom, top, near, far) {
         const r = this.data;
@@ -641,7 +641,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 rotation matrix
-     * const rm = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 90);
+     * const rm = new Mat4().setFromAxisAngle(Vec3.UP, 90);
      */
     setFromAxisAngle(axis, angle) {
         angle *= math.DEG_TO_RAD;
@@ -683,7 +683,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 translation matrix
-     * const tm = new pc.Mat4().setTranslate(10, 10, 10);
+     * const tm = new Mat4().setTranslate(10, 10, 10);
      * @ignore
      */
     setTranslate(x, y, z) {
@@ -718,7 +718,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 scale matrix
-     * const sm = new pc.Mat4().setScale(10, 10, 10);
+     * const sm = new Mat4().setScale(10, 10, 10);
      * @ignore
      */
     setScale(x, y, z) {
@@ -756,7 +756,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 viewport matrix which scales normalized view volume to full texture viewport
-     * const vm = new pc.Mat4().setViewport(0, 0, 1, 1);
+     * const vm = new Mat4().setViewport(0, 0, 1, 1);
      * @ignore
      */
     setViewport(x, y, width, height) {
@@ -791,7 +791,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a reflection matrix for a horizontal plane at y=0
-     * const reflection = new pc.Mat4().setReflection(pc.Vec3.UP, 0);
+     * const reflection = new Mat4().setReflection(Vec3.UP, 0);
      */
     setReflection(normal, distance) {
 
@@ -827,7 +827,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 rotation matrix of 180 degrees around the y-axis
-     * const rot = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const rot = new Mat4().setFromAxisAngle(Vec3.UP, 180);
      *
      * // Invert in place
      * rot.invert();
@@ -899,7 +899,7 @@ class Mat4 {
      * @param {number[]} src - Source array. Must have 16 values.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      * m.set([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1]);
      */
     set(src) {
@@ -965,11 +965,11 @@ class Mat4 {
      * @param {Vec3} s - A 3-d vector scale.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const t = new pc.Vec3(10, 20, 30);
-     * const r = new pc.Quat();
-     * const s = new pc.Vec3(2, 2, 2);
+     * const t = new Vec3(10, 20, 30);
+     * const r = new Quat();
+     * const s = new Vec3(2, 2, 2);
      *
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      * m.setTRS(t, r, s);
      */
     setTRS(t, r, s) {
@@ -1026,7 +1026,7 @@ class Mat4 {
      * @param {Mat4} [src] - The matrix to transpose. If not set, the matrix is transposed in-place.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      *
      * // Transpose in place
      * m.transpose();
@@ -1090,10 +1090,10 @@ class Mat4 {
      * @returns {Vec3} The translation of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      *
      * // Query the translation component
-     * const t = new pc.Vec3();
+     * const t = new Vec3();
      * m.getTranslation(t);
      */
     getTranslation(t = new Vec3()) {
@@ -1107,10 +1107,10 @@ class Mat4 {
      * @returns {Vec3} The x-axis of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      *
      * // Query the x-axis component
-     * const x = new pc.Vec3();
+     * const x = new Vec3();
      * m.getX(x);
      */
     getX(x = new Vec3()) {
@@ -1124,10 +1124,10 @@ class Mat4 {
      * @returns {Vec3} The y-axis of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      *
      * // Query the y-axis component
-     * const y = new pc.Vec3();
+     * const y = new Vec3();
      * m.getY(y);
      */
     getY(y = new Vec3()) {
@@ -1141,10 +1141,10 @@ class Mat4 {
      * @returns {Vec3} The z-axis of the specified 4x4 matrix.
      * @example
      * // Create a 4x4 matrix
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      *
      * // Query the z-axis component
-     * const z = new pc.Vec3();
+     * const z = new Vec3();
      * m.getZ(z);
      */
     getZ(z = new Vec3()) {
@@ -1194,7 +1194,7 @@ class Mat4 {
      * @param {number} ez - Angle to rotate around Z axis in degrees.
      * @returns {Mat4} Self for chaining.
      * @example
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      * m.setFromEulerAngles(45, 90, 180);
      */
     setFromEulerAngles(ex, ey, ez) {
@@ -1247,7 +1247,7 @@ class Mat4 {
      * @returns {Vec3} A 3-d vector containing the Euler angles.
      * @example
      * // Create a 4x4 rotation matrix of 45 degrees around the y-axis
-     * const m = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 45);
+     * const m = new Mat4().setFromAxisAngle(Vec3.UP, 45);
      *
      * const eulers = m.getEulerAngles();
      */
@@ -1291,7 +1291,7 @@ class Mat4 {
      *
      * @returns {string} The matrix in string form.
      * @example
-     * const m = new pc.Mat4();
+     * const m = new Mat4();
      * // Outputs [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
      * console.log(m.toString());
      */

--- a/src/core/math/math.js
+++ b/src/core/math/math.js
@@ -27,9 +27,9 @@ const math = {
      * @param {number} max - Max value.
      * @returns {number} The clamped value.
      * @example
-     * pc.math.clamp(5, 0, 10);  // returns 5
-     * pc.math.clamp(-5, 0, 10); // returns 0
-     * pc.math.clamp(15, 0, 10); // returns 10
+     * math.clamp(5, 0, 10);  // returns 5
+     * math.clamp(-5, 0, 10); // returns 0
+     * math.clamp(15, 0, 10); // returns 10
      */
     clamp(value, min, max) {
         if (value >= max) return max;
@@ -44,7 +44,7 @@ const math = {
      * @returns {number[]} An array of 3 bytes.
      * @example
      * // Set bytes to [0x11, 0x22, 0x33]
-     * const bytes = pc.math.intToBytes24(0x112233);
+     * const bytes = math.intToBytes24(0x112233);
      */
     intToBytes24(i) {
         const r = (i >> 16) & 0xff;
@@ -61,7 +61,7 @@ const math = {
      * @returns {number[]} An array of 4 bytes.
      * @example
      * // Set bytes to [0x11, 0x22, 0x33, 0x44]
-     * const bytes = pc.math.intToBytes32(0x11223344);
+     * const bytes = math.intToBytes32(0x11223344);
      */
     intToBytes32(i) {
         const r = (i >> 24) & 0xff;
@@ -81,10 +81,10 @@ const math = {
      * @returns {number} A single unsigned 24 bit Number.
      * @example
      * // Set result1 to 0x112233 from an array of 3 values
-     * const result1 = pc.math.bytesToInt24([0x11, 0x22, 0x33]);
+     * const result1 = math.bytesToInt24([0x11, 0x22, 0x33]);
      *
      * // Set result2 to 0x112233 from 3 discrete values
-     * const result2 = pc.math.bytesToInt24(0x11, 0x22, 0x33);
+     * const result2 = math.bytesToInt24(0x11, 0x22, 0x33);
      */
     bytesToInt24(r, g, b) {
         if (r.length) {
@@ -105,10 +105,10 @@ const math = {
      * @returns {number} A single unsigned 32bit Number.
      * @example
      * // Set result1 to 0x11223344 from an array of 4 values
-     * const result1 = pc.math.bytesToInt32([0x11, 0x22, 0x33, 0x44]);
+     * const result1 = math.bytesToInt32([0x11, 0x22, 0x33, 0x44]);
      *
      * // Set result2 to 0x11223344 from 4 discrete values
-     * const result2 = pc.math.bytesToInt32(0x11, 0x22, 0x33, 0x44);
+     * const result2 = math.bytesToInt32(0x11, 0x22, 0x33, 0x44);
      */
     bytesToInt32(r, g, b, a) {
         if (r.length) {
@@ -135,9 +135,9 @@ const math = {
      * between a and b is returned. alpha is clamped between 0 and 1.
      * @returns {number} The linear interpolation of two numbers.
      * @example
-     * pc.math.lerp(0, 10, 0);   // returns 0
-     * pc.math.lerp(0, 10, 0.5); // returns 5
-     * pc.math.lerp(0, 10, 1);   // returns 10
+     * math.lerp(0, 10, 0);   // returns 0
+     * math.lerp(0, 10, 0.5); // returns 5
+     * math.lerp(0, 10, 1);   // returns 10
      */
     lerp(a, b, alpha) {
         return a + (b - a) * math.clamp(alpha, 0, 1);
@@ -154,8 +154,8 @@ const math = {
      * between a and b is returned. alpha is clamped between 0 and 1.
      * @returns {number} The linear interpolation of two angles.
      * @example
-     * pc.math.lerpAngle(350, 10, 0.5); // returns 0 (shortest path crosses 360/0 boundary)
-     * pc.math.lerpAngle(0, 90, 0.5);   // returns 45
+     * math.lerpAngle(350, 10, 0.5); // returns 0 (shortest path crosses 360/0 boundary)
+     * math.lerpAngle(0, 90, 0.5);   // returns 45
      */
     lerpAngle(a, b, alpha) {
         if (b - a > 180) {
@@ -173,8 +173,8 @@ const math = {
      * @param {number} x - Number to check for power-of-two property.
      * @returns {boolean} true if power-of-two and false otherwise.
      * @example
-     * pc.math.powerOfTwo(32); // returns true
-     * pc.math.powerOfTwo(17); // returns false
+     * math.powerOfTwo(32); // returns true
+     * math.powerOfTwo(17); // returns false
      */
     powerOfTwo(x) {
         return ((x !== 0) && !(x & (x - 1)));
@@ -186,8 +186,8 @@ const math = {
      * @param {number} val - The value for which to calculate the next power of 2.
      * @returns {number} The next power of 2.
      * @example
-     * pc.math.nextPowerOfTwo(17); // returns 32
-     * pc.math.nextPowerOfTwo(32); // returns 32
+     * math.nextPowerOfTwo(17); // returns 32
+     * math.nextPowerOfTwo(32); // returns 32
      */
     nextPowerOfTwo(val) {
         val--;
@@ -206,8 +206,8 @@ const math = {
      * @param {number} val - The value for which to calculate the nearest power of 2.
      * @returns {number} The nearest power of 2.
      * @example
-     * pc.math.nearestPowerOfTwo(17); // returns 16
-     * pc.math.nearestPowerOfTwo(24); // returns 32
+     * math.nearestPowerOfTwo(17); // returns 16
+     * math.nearestPowerOfTwo(24); // returns 32
      */
     nearestPowerOfTwo(val) {
         return Math.pow(2, Math.round(Math.log2(val)));
@@ -221,7 +221,7 @@ const math = {
      * @param {number} max - Upper bound for range.
      * @returns {number} Pseudo-random number between the supplied range.
      * @example
-     * pc.math.random(0, 10); // returns a random number between 0 and 10
+     * math.random(0, 10); // returns a random number between 0 and 10
      */
     random(min, max) {
         const diff = max - min;
@@ -243,7 +243,7 @@ const math = {
      * @param {number} x - The value to interpolate.
      * @returns {number} The smoothly interpolated value clamped between zero and one.
      * @example
-     * pc.math.smoothstep(0, 10, 5); // returns 0.5
+     * math.smoothstep(0, 10, 5); // returns 0.5
      */
     smoothstep(min, max, x) {
         if (x <= min) return 0;
@@ -265,7 +265,7 @@ const math = {
      * @param {number} x - The value to interpolate.
      * @returns {number} The smoothly interpolated value clamped between zero and one.
      * @example
-     * pc.math.smootherstep(0, 10, 5); // returns 0.5
+     * math.smootherstep(0, 10, 5); // returns 0.5
      */
     smootherstep(min, max, x) {
         if (x <= min) return 0;
@@ -283,8 +283,8 @@ const math = {
      * @param {number} multiple - The multiple to round up to.
      * @returns {number} A number rounded up to nearest multiple.
      * @example
-     * pc.math.roundUp(17, 4); // returns 20
-     * pc.math.roundUp(16, 4); // returns 16
+     * math.roundUp(17, 4); // returns 20
+     * math.roundUp(16, 4); // returns 16
      */
     roundUp(numToRound, multiple) {
         if (multiple === 0) {

--- a/src/core/math/quat.js
+++ b/src/core/math/quat.js
@@ -50,8 +50,8 @@ class Quat {
      * @param {number} [z] - The z value. Defaults to 0.
      * @param {number} [w] - The w value. Defaults to 1.
      * @example
-     * const q1 = new pc.Quat(); // defaults to 0, 0, 0, 1
-     * const q2 = new pc.Quat(1, 2, 3, 4);
+     * const q1 = new Quat(); // defaults to 0, 0, 0, 1
+     * const q2 = new Quat(1, 2, 3, 4);
      */
     /**
      * Creates a new Quat instance.
@@ -59,7 +59,7 @@ class Quat {
      * @overload
      * @param {number[]} arr - The array to set the quaternion values from.
      * @example
-     * const q = new pc.Quat([1, 2, 3, 4]);
+     * const q = new Quat([1, 2, 3, 4]);
      */
     /**
      * @param {number|number[]} [x] - The x value. Defaults to 0. If x is an array of length 4, the
@@ -87,7 +87,7 @@ class Quat {
      *
      * @returns {this} A new quaternion identical to this one.
      * @example
-     * const q = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
+     * const q = new Quat(-0.11, -0.15, -0.46, 0.87);
      * const qclone = q.clone();
      *
      * console.log("The result of the cloning is: " + qclone.toString());
@@ -104,7 +104,7 @@ class Quat {
      * @param {Quat} [src] - The quaternion to conjugate. If not set, the operation is done in place.
      * @returns {Quat} Self for chaining.
      * @example
-     * const q = new pc.Quat(1, 2, 3, 4);
+     * const q = new Quat(1, 2, 3, 4);
      * q.conjugate();
      * // q is now [-1, -2, -3, 4]
      * @ignore
@@ -124,8 +124,8 @@ class Quat {
      * @param {Quat} rhs - The quaternion to be copied.
      * @returns {Quat} Self for chaining.
      * @example
-     * const src = new pc.Quat();
-     * const dst = new pc.Quat();
+     * const src = new Quat();
+     * const dst = new Quat();
      * dst.copy(src);
      * console.log("The two quaternions are " + (src.equals(dst) ? "equal" : "different"));
      */
@@ -144,8 +144,8 @@ class Quat {
      * @param {Quat} other - The quaternion to calculate the dot product with.
      * @returns {number} The dot product of the two quaternions.
      * @example
-     * const a = new pc.Quat(1, 0, 0, 0);
-     * const b = new pc.Quat(0, 1, 0, 0);
+     * const a = new Quat(1, 0, 0, 0);
+     * const b = new Quat(0, 1, 0, 0);
      * console.log("Dot product: " + a.dot(b)); // Outputs 0
      */
     dot(other) {
@@ -158,8 +158,8 @@ class Quat {
      * @param {Quat} rhs - The quaternion to be compared against.
      * @returns {boolean} True if the quaternions are equal and false otherwise.
      * @example
-     * const a = new pc.Quat();
-     * const b = new pc.Quat();
+     * const a = new Quat();
+     * const b = new Quat();
      * console.log("The two quaternions are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -174,8 +174,8 @@ class Quat {
      * quaternions. Defaults to 1e-6.
      * @returns {boolean} True if the quaternions are equal and false otherwise.
      * @example
-     * const a = new pc.Quat();
-     * const b = new pc.Quat();
+     * const a = new Quat();
+     * const b = new Quat();
      * console.log("The two quaternions are approximately " + (a.equalsApprox(b, 1e-9) ? "equal" : "different"));
      */
     equalsApprox(rhs, epsilon = 1e-6) {
@@ -193,9 +193,9 @@ class Quat {
      * @param {Vec3} axis - The 3-dimensional vector to receive the axis of rotation.
      * @returns {number} Angle, in degrees, of the rotation.
      * @example
-     * const q = new pc.Quat();
-     * q.setFromAxisAngle(new pc.Vec3(0, 1, 0), 90);
-     * const v = new pc.Vec3();
+     * const q = new Quat();
+     * q.setFromAxisAngle(new Vec3(0, 1, 0), 90);
+     * const v = new Vec3();
      * const angle = q.getAxisAngle(v);
      * // Outputs 90
      * console.log(angle);
@@ -237,9 +237,9 @@ class Quat {
      * @returns {Vec3} The 3-dimensional vector holding the Euler angles in degrees. This will be
      * the same object passed in as the `eulers` parameter (if one was provided).
      * @example
-     * const q = new pc.Quat();
-     * q.setFromAxisAngle(pc.Vec3.UP, 90);
-     * const e = new pc.Vec3();
+     * const q = new Quat();
+     * q.setFromAxisAngle(Vec3.UP, 90);
+     * const e = new Vec3();
      * q.getEulerAngles(e);
      * // Outputs [0, 90, 0]
      * console.log(e.toString());
@@ -278,7 +278,7 @@ class Quat {
      * @returns {Quat} Self for chaining.
      * @example
      * // Create a quaternion rotated 180 degrees around the y-axis
-     * const rot = new pc.Quat().setFromEulerAngles(0, 180, 0);
+     * const rot = new Quat().setFromEulerAngles(0, 180, 0);
      *
      * // Invert in place
      * rot.invert();
@@ -292,7 +292,7 @@ class Quat {
      *
      * @returns {number} The magnitude of the specified quaternion.
      * @example
-     * const q = new pc.Quat(0, 0, 0, 5);
+     * const q = new Quat(0, 0, 0, 5);
      * const len = q.length();
      * // Outputs 5
      * console.log("The length of the quaternion is: " + len);
@@ -306,7 +306,7 @@ class Quat {
      *
      * @returns {number} The magnitude squared of the quaternion.
      * @example
-     * const q = new pc.Quat(3, 4, 0, 0);
+     * const q = new Quat(3, 4, 0, 0);
      * const lenSq = q.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the quaternion is: " + lenSq);
@@ -327,10 +327,10 @@ class Quat {
      * in between generating a linear interpolation between the two.
      * @returns {Quat} Self for chaining.
      * @example
-     * const q1 = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
-     * const q2 = new pc.Quat(-0.21, -0.21, -0.67, 0.68);
+     * const q1 = new Quat(-0.11, -0.15, -0.46, 0.87);
+     * const q2 = new Quat(-0.21, -0.21, -0.67, 0.68);
      *
-     * const result = new pc.Quat();
+     * const result = new Quat();
      * result.lerp(q1, q2, 0);   // Return q1
      * result.lerp(q1, q2, 0.5); // Return the midpoint interpolant
      * result.lerp(q1, q2, 1);   // Return q2
@@ -350,8 +350,8 @@ class Quat {
      * @param {Quat} rhs - The quaternion used as the second multiplicand of the operation.
      * @returns {Quat} Self for chaining.
      * @example
-     * const a = new pc.Quat().setFromEulerAngles(0, 30, 0);
-     * const b = new pc.Quat().setFromEulerAngles(0, 60, 0);
+     * const a = new Quat().setFromEulerAngles(0, 30, 0);
+     * const b = new Quat().setFromEulerAngles(0, 60, 0);
      *
      * // a becomes a 90 degree rotation around the Y axis
      * // In other words, a = a * b
@@ -385,7 +385,7 @@ class Quat {
      * @param {Quat} [src] - The quaternion to scale. If not set, the operation is done in place.
      * @returns {Quat} Self for chaining.
      * @example
-     * const q = new pc.Quat(1, 2, 3, 4);
+     * const q = new Quat(1, 2, 3, 4);
      * q.mulScalar(2);
      * // q is now [2, 4, 6, 8]
      */
@@ -404,9 +404,9 @@ class Quat {
      * @param {Quat} rhs - The quaternion used as the second multiplicand of the operation.
      * @returns {Quat} Self for chaining.
      * @example
-     * const a = new pc.Quat().setFromEulerAngles(0, 30, 0);
-     * const b = new pc.Quat().setFromEulerAngles(0, 60, 0);
-     * const r = new pc.Quat();
+     * const a = new Quat().setFromEulerAngles(0, 30, 0);
+     * const b = new Quat().setFromEulerAngles(0, 60, 0);
+     * const r = new Quat();
      *
      * // r is set to a 90 degree rotation around the Y axis
      * // In other words, r = a * b
@@ -437,7 +437,7 @@ class Quat {
      * @param {Quat} [src] - The quaternion to normalize. If not set, the operation is done in place.
      * @returns {Quat} Self for chaining.
      * @example
-     * const v = new pc.Quat(0, 0, 0, 5);
+     * const v = new Quat(0, 0, 0, 5);
      * v.normalize();
      * // Outputs [0, 0, 0, 1]
      * console.log(v.toString());
@@ -467,7 +467,7 @@ class Quat {
      * @param {number} w - The w component of the quaternion.
      * @returns {Quat} Self for chaining.
      * @example
-     * const q = new pc.Quat();
+     * const q = new Quat();
      * q.set(1, 0, 0, 0);
      *
      * // Outputs 1, 0, 0, 0
@@ -489,8 +489,8 @@ class Quat {
      * @param {number} angle - Angle to rotate around the given axis in degrees.
      * @returns {Quat} Self for chaining.
      * @example
-     * const q = new pc.Quat();
-     * q.setFromAxisAngle(pc.Vec3.UP, 90);
+     * const q = new Quat();
+     * q.setFromAxisAngle(Vec3.UP, 90);
      */
     setFromAxisAngle(axis, angle) {
         angle *= 0.5 * math.DEG_TO_RAD;
@@ -522,13 +522,13 @@ class Quat {
      * specified XYZ Euler angles. Allows for method chaining.
      * @example
      * // Create a quaternion from 3 individual Euler angles (interpreted as X, Y, Z order)
-     * const q1 = new pc.Quat();
+     * const q1 = new Quat();
      * q1.setFromEulerAngles(45, 90, 180); // 45 deg around X, then 90 deg around Y', then 180 deg around Z''
      * console.log("From numbers:", q1.toString());
      * @example
      * // Create the same quaternion from a Vec3 containing the angles (X, Y, Z)
-     * const anglesVec = new pc.Vec3(45, 90, 180);
-     * const q2 = new pc.Quat();
+     * const anglesVec = new Vec3(45, 90, 180);
+     * const q2 = new Quat();
      * q2.setFromEulerAngles(anglesVec);
      * console.log("From Vec3:", q2.toString()); // Should match q1
      */
@@ -568,10 +568,10 @@ class Quat {
      * @returns {Quat} Self for chaining.
      * @example
      * // Create a 4x4 rotation matrix of 180 degrees around the y-axis
-     * const rot = new pc.Mat4().setFromAxisAngle(pc.Vec3.UP, 180);
+     * const rot = new Mat4().setFromAxisAngle(Vec3.UP, 180);
      *
      * // Convert to a quaternion
-     * const q = new pc.Quat().setFromMat4(rot);
+     * const q = new Quat().setFromMat4(rot);
      */
     setFromMat4(m) {
         const d = m.data;
@@ -650,9 +650,9 @@ class Quat {
      * @param {Vec3} to - The direction to rotate to. It should be normalized.
      * @returns {Quat} Self for chaining.
      * @example
-     * const q = new pc.Quat();
-     * const from = new pc.Vec3(0, 0, 1);
-     * const to = new pc.Vec3(0, 1, 0);
+     * const q = new Quat();
+     * const from = new Vec3(0, 0, 1);
+     * const to = new Vec3(0, 1, 0);
      * q.setFromDirections(from, to);
      */
     setFromDirections(from, to) {
@@ -694,10 +694,10 @@ class Quat {
      * in between generating a spherical interpolation between the two.
      * @returns {Quat} Self for chaining.
      * @example
-     * const q1 = new pc.Quat(-0.11, -0.15, -0.46, 0.87);
-     * const q2 = new pc.Quat(-0.21, -0.21, -0.67, 0.68);
+     * const q1 = new Quat(-0.11, -0.15, -0.46, 0.87);
+     * const q2 = new Quat(-0.21, -0.21, -0.67, 0.68);
      *
-     * const result = new pc.Quat();
+     * const result = new Quat();
      * result.slerp(q1, q2, 0);   // Return q1
      * result.slerp(q1, q2, 0.5); // Return the midpoint interpolant
      * result.slerp(q1, q2, 1);   // Return q2
@@ -767,10 +767,10 @@ class Quat {
      * @returns {Vec3} The transformed vector (res if specified, otherwise a new Vec3).
      * @example
      * // Create a 3-dimensional vector
-     * const v = new pc.Vec3(1, 2, 3);
+     * const v = new Vec3(1, 2, 3);
      *
      * // Create a quaternion rotation
-     * const q = new pc.Quat().setFromEulerAngles(10, 20, 30);
+     * const q = new Quat().setFromEulerAngles(10, 20, 30);
      *
      * const tv = q.transformVector(v);
      */
@@ -800,7 +800,7 @@ class Quat {
      * array. Default is 0.
      * @returns {Quat} Self for chaining.
      * @example
-     * const q = new pc.Quat();
+     * const q = new Quat();
      * q.fromArray([20, 10, 5, 0]);
      * // q is set to [20, 10, 5, 0]
      */
@@ -818,7 +818,7 @@ class Quat {
      *
      * @returns {string} The quaternion in string form.
      * @example
-     * const q = new pc.Quat(0, 0, 0, 1);
+     * const q = new Quat(0, 0, 0, 1);
      * // Outputs [0, 0, 0, 1]
      * console.log(q.toString());
      */
@@ -851,7 +851,7 @@ class Quat {
      * array. Default is 0.
      * @returns {number[]|ArrayBufferView} The quaternion as an array.
      * @example
-     * const q = new pc.Quat(20, 10, 5, 1);
+     * const q = new Quat(20, 10, 5, 1);
      * // Outputs [20, 10, 5, 1]
      * console.log(q.toArray());
      */

--- a/src/core/math/random.js
+++ b/src/core/math/random.js
@@ -19,8 +19,8 @@ const random = {
      *
      * @param {Vec2} point - The returned generated point.
      * @example
-     * const point = new pc.Vec2();
-     * pc.random.circlePoint(point);
+     * const point = new Vec2();
+     * random.circlePoint(point);
      * // point now contains a random position inside a unit circle
      */
     circlePoint(point) {
@@ -38,9 +38,9 @@ const random = {
      * @param {number} index - Index of the point to generate, in the range from 0 to numPoints - 1.
      * @param {number} numPoints - The total number of points of the set.
      * @example
-     * const point = new pc.Vec2();
+     * const point = new Vec2();
      * for (let i = 0; i < 100; i++) {
-     *     pc.random.circlePointDeterministic(point, i, 100);
+     *     random.circlePointDeterministic(point, i, 100);
      *     // point contains the i-th evenly distributed point in the circle
      * }
      */
@@ -67,9 +67,9 @@ const random = {
      * @param {number} [end] - Part on the sphere along y axis to stop the points, in the range of
      * 0 and 1. Defaults to 1.
      * @example
-     * const point = new pc.Vec3();
+     * const point = new Vec3();
      * for (let i = 0; i < 100; i++) {
-     *     pc.random.spherePointDeterministic(point, i, 100);
+     *     random.spherePointDeterministic(point, i, 100);
      *     // point contains the i-th evenly distributed point on the sphere
      * }
      */
@@ -100,10 +100,10 @@ const random = {
      * @returns {number} The pseudo-random value.
      * @example
      * // Generate first 4 values of the sequence
-     * pc.random.radicalInverse(0); // returns 0
-     * pc.random.radicalInverse(1); // returns 0.5
-     * pc.random.radicalInverse(2); // returns 0.25
-     * pc.random.radicalInverse(3); // returns 0.75
+     * random.radicalInverse(0); // returns 0
+     * random.radicalInverse(1); // returns 0.5
+     * random.radicalInverse(2); // returns 0.25
+     * random.radicalInverse(3); // returns 0.75
      */
     radicalInverse(i) {
         let bits = ((i << 16) | (i >>> 16)) >>> 0;

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -28,8 +28,8 @@ class Vec2 {
      * @param {number} [x] - The x value. Defaults to 0.
      * @param {number} [y] - The y value. Defaults to 0.
      * @example
-     * const v1 = new pc.Vec2(); // defaults to 0, 0
-     * const v2 = new pc.Vec2(1, 2);
+     * const v1 = new Vec2(); // defaults to 0, 0
+     * const v2 = new Vec2(1, 2);
      */
     /**
      * Creates a new Vec2 instance.
@@ -37,7 +37,7 @@ class Vec2 {
      * @overload
      * @param {number[]} arr - The array to set the vector values from.
      * @example
-     * const v = new pc.Vec2([1, 2]);
+     * const v = new Vec2([1, 2]);
      */
     /**
      * @param {number|number[]} [x] - The x value. Defaults to 0. If x is an array of length 2, the
@@ -60,8 +60,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to add to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(10, 10);
-     * const b = new pc.Vec2(20, 20);
+     * const a = new Vec2(10, 10);
+     * const b = new Vec2(20, 20);
      *
      * a.add(b);
      *
@@ -82,9 +82,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second vector operand for the addition.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(10, 10);
-     * const b = new pc.Vec2(20, 20);
-     * const r = new pc.Vec2();
+     * const a = new Vec2(10, 10);
+     * const b = new Vec2(20, 20);
+     * const r = new Vec2();
      *
      * r.add2(a, b);
      * // Outputs [30, 30]
@@ -104,7 +104,7 @@ class Vec2 {
      * @param {number} scalar - The number to add.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const vec = new pc.Vec2(3, 4);
+     * const vec = new Vec2(3, 4);
      *
      * vec.addScalar(2);
      *
@@ -125,9 +125,9 @@ class Vec2 {
      * @param {number} scalar - The number to multiply the added vector with.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const vec = new pc.Vec2(1, 2);
+     * const vec = new Vec2(1, 2);
      *
-     * vec.addScaled(pc.Vec2.UP, 2);
+     * vec.addScaled(Vec2.UP, 2);
      *
      * // Outputs [1, 4]
      * console.log("The result of the addition is: " + vec.toString());
@@ -144,7 +144,7 @@ class Vec2 {
      *
      * @returns {this} A 2-dimensional vector containing the result of the cloning.
      * @example
-     * const v = new pc.Vec2(10, 20);
+     * const v = new Vec2(10, 20);
      * const vclone = v.clone();
      * console.log("The result of the cloning is: " + vclone.toString());
      */
@@ -160,8 +160,8 @@ class Vec2 {
      * @param {Vec2} rhs - A vector to copy to the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const src = new pc.Vec2(10, 20);
-     * const dst = new pc.Vec2();
+     * const src = new Vec2(10, 20);
+     * const dst = new Vec2();
      *
      * dst.copy(src);
      *
@@ -181,8 +181,8 @@ class Vec2 {
      * @param {Vec2} rhs - The second 2-dimensional vector operand of the cross product.
      * @returns {number} The cross product of the two vectors.
      * @example
-     * const right = new pc.Vec2(1, 0);
-     * const up = new pc.Vec2(0, 1);
+     * const right = new Vec2(1, 0);
+     * const up = new Vec2(0, 1);
      * const crossProduct = right.cross(up);
      *
      * // Prints 1
@@ -198,8 +198,8 @@ class Vec2 {
      * @param {Vec2} rhs - The second 2-dimensional vector to test.
      * @returns {number} The distance between the two vectors.
      * @example
-     * const v1 = new pc.Vec2(5, 10);
-     * const v2 = new pc.Vec2(10, 20);
+     * const v1 = new Vec2(5, 10);
+     * const v2 = new Vec2(10, 20);
      * const d = v1.distance(v2);
      * console.log("The distance between v1 and v2 is: " + d);
      */
@@ -215,8 +215,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to divide the specified vector by.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(4, 9);
-     * const b = new pc.Vec2(2, 3);
+     * const a = new Vec2(4, 9);
+     * const b = new Vec2(2, 3);
      *
      * a.div(b);
      *
@@ -237,9 +237,9 @@ class Vec2 {
      * @param {Vec2} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(4, 9);
-     * const b = new pc.Vec2(2, 3);
-     * const r = new pc.Vec2();
+     * const a = new Vec2(4, 9);
+     * const b = new Vec2(2, 3);
+     * const r = new Vec2();
      *
      * r.div2(a, b);
      *
@@ -259,7 +259,7 @@ class Vec2 {
      * @param {number} scalar - The number to divide by.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const vec = new pc.Vec2(3, 6);
+     * const vec = new Vec2(3, 6);
      *
      * vec.divScalar(3);
      *
@@ -280,8 +280,8 @@ class Vec2 {
      * @param {Vec2} rhs - The second 2-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
-     * const v1 = new pc.Vec2(5, 10);
-     * const v2 = new pc.Vec2(10, 20);
+     * const v1 = new Vec2(5, 10);
+     * const v2 = new Vec2(10, 20);
      * const v1dotv2 = v1.dot(v2);
      * console.log("The result of the dot product is: " + v1dotv2);
      */
@@ -295,8 +295,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * const a = new pc.Vec2(1, 2);
-     * const b = new pc.Vec2(4, 5);
+     * const a = new Vec2(1, 2);
+     * const b = new Vec2(4, 5);
      * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -311,8 +311,8 @@ class Vec2 {
      * vectors. Defaults to 1e-6.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * const a = new pc.Vec2();
-     * const b = new pc.Vec2();
+     * const a = new Vec2();
+     * const b = new Vec2();
      * console.log("The two vectors are approximately " + (a.equalsApprox(b, 1e-9) ? "equal" : "different"));
      */
     equalsApprox(rhs, epsilon = 1e-6) {
@@ -325,7 +325,7 @@ class Vec2 {
      *
      * @returns {number} The magnitude of the specified 2-dimensional vector.
      * @example
-     * const vec = new pc.Vec2(3, 4);
+     * const vec = new Vec2(3, 4);
      * const len = vec.length();
      * // Outputs 5
      * console.log("The length of the vector is: " + len);
@@ -339,7 +339,7 @@ class Vec2 {
      *
      * @returns {number} The magnitude squared of the specified 2-dimensional vector.
      * @example
-     * const vec = new pc.Vec2(3, 4);
+     * const vec = new Vec2(3, 4);
      * const len = vec.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
@@ -358,9 +358,9 @@ class Vec2 {
      * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(0, 0);
-     * const b = new pc.Vec2(10, 10);
-     * const r = new pc.Vec2();
+     * const a = new Vec2(0, 0);
+     * const b = new Vec2(10, 10);
+     * const r = new Vec2();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 5, 5
@@ -379,8 +379,8 @@ class Vec2 {
      * @param {Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(2, 3);
-     * const b = new pc.Vec2(4, 5);
+     * const a = new Vec2(2, 3);
+     * const b = new Vec2(4, 5);
      *
      * a.mul(b);
      *
@@ -401,9 +401,9 @@ class Vec2 {
      * @param {Vec2} rhs - The 2-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(2, 3);
-     * const b = new pc.Vec2(4, 5);
-     * const r = new pc.Vec2();
+     * const a = new Vec2(2, 3);
+     * const b = new Vec2(4, 5);
+     * const r = new Vec2();
      *
      * r.mul2(a, b);
      *
@@ -423,7 +423,7 @@ class Vec2 {
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const vec = new pc.Vec2(3, 6);
+     * const vec = new Vec2(3, 6);
      *
      * vec.mulScalar(3);
      *
@@ -444,7 +444,7 @@ class Vec2 {
      * @param {Vec2} [src] - The vector to normalize. If not set, the operation is done in place.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const v = new pc.Vec2(25, 0);
+     * const v = new Vec2(25, 0);
      *
      * v.normalize();
      *
@@ -468,7 +468,7 @@ class Vec2 {
      * @param {number} degrees - The number to degrees to rotate the vector by.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const v = new pc.Vec2(0, 10);
+     * const v = new Vec2(0, 10);
      *
      * v.rotate(45); // rotates by 45 degrees
      *
@@ -488,7 +488,7 @@ class Vec2 {
      *
      * @returns {number} The angle in degrees of the specified 2-dimensional vector.
      * @example
-     * const v = new pc.Vec2(6, 0);
+     * const v = new Vec2(6, 0);
      * const angle = v.angle();
      * // Outputs 90..
      * console.log("The angle of the vector is: " + angle);
@@ -503,8 +503,8 @@ class Vec2 {
      * @param {Vec2} rhs - The 2-dimensional vector to calculate angle to.
      * @returns {number} The shortest angle in degrees between two 2-dimensional vectors.
      * @example
-     * const a = new pc.Vec2(0, 10); // up
-     * const b = new pc.Vec2(1, -1); // down-right
+     * const a = new Vec2(0, 10); // up
+     * const b = new Vec2(1, -1); // down-right
      * const angle = a.angleTo(b);
      * // Outputs 135..
      * console.log("The angle between vectors a and b: " + angle);
@@ -519,7 +519,7 @@ class Vec2 {
      * @param {Vec2} [src] - The vector to floor. If not set, the operation is done in place.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const v = new pc.Vec2(1.2, 3.9);
+     * const v = new Vec2(1.2, 3.9);
      * v.floor();
      * // v is now [1, 3]
      */
@@ -535,7 +535,7 @@ class Vec2 {
      * @param {Vec2} [src] - The vector to ceil. If not set, the operation is done in place.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const v = new pc.Vec2(1.2, 3.1);
+     * const v = new Vec2(1.2, 3.1);
      * v.ceil();
      * // v is now [2, 4]
      */
@@ -551,7 +551,7 @@ class Vec2 {
      * @param {Vec2} [src] - The vector to round. If not set, the operation is done in place.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const v = new pc.Vec2(1.4, 3.6);
+     * const v = new Vec2(1.4, 3.6);
      * v.round();
      * // v is now [1, 4]
      */
@@ -567,8 +567,8 @@ class Vec2 {
      * @param {Vec2} rhs - The 2-dimensional vector used as the source of elements to compare to.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(5, 1);
-     * const b = new pc.Vec2(2, 8);
+     * const a = new Vec2(5, 1);
+     * const b = new Vec2(2, 8);
      * a.min(b);
      * // a is now [2, 1]
      */
@@ -584,8 +584,8 @@ class Vec2 {
      * @param {Vec2} rhs - The 2-dimensional vector used as the source of elements to compare to.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(5, 1);
-     * const b = new pc.Vec2(2, 8);
+     * const a = new Vec2(5, 1);
+     * const b = new Vec2(2, 8);
      * a.max(b);
      * // a is now [5, 8]
      */
@@ -602,7 +602,7 @@ class Vec2 {
      * @param {number} y - The value to set on the second component of the vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const v = new pc.Vec2();
+     * const v = new Vec2();
      * v.set(5, 10);
      *
      * // Outputs 5, 10
@@ -621,8 +621,8 @@ class Vec2 {
      * @param {Vec2} rhs - The vector to subtract from the specified vector.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(10, 10);
-     * const b = new pc.Vec2(20, 20);
+     * const a = new Vec2(10, 10);
+     * const b = new Vec2(20, 20);
      *
      * a.sub(b);
      *
@@ -643,9 +643,9 @@ class Vec2 {
      * @param {Vec2} rhs - The second vector operand for the subtraction.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const a = new pc.Vec2(10, 10);
-     * const b = new pc.Vec2(20, 20);
-     * const r = new pc.Vec2();
+     * const a = new Vec2(10, 10);
+     * const b = new Vec2(20, 20);
+     * const r = new Vec2();
      *
      * r.sub2(a, b);
      *
@@ -665,7 +665,7 @@ class Vec2 {
      * @param {number} scalar - The number to subtract.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const vec = new pc.Vec2(3, 4);
+     * const vec = new Vec2(3, 4);
      *
      * vec.subScalar(2);
      *
@@ -687,7 +687,7 @@ class Vec2 {
      * array. Default is 0.
      * @returns {Vec2} Self for chaining.
      * @example
-     * const v = new pc.Vec2();
+     * const v = new Vec2();
      * v.fromArray([20, 10]);
      * // v is set to [20, 10]
      */
@@ -703,7 +703,7 @@ class Vec2 {
      *
      * @returns {string} The vector in string form.
      * @example
-     * const v = new pc.Vec2(20, 10);
+     * const v = new Vec2(20, 10);
      * // Outputs [20, 10]
      * console.log(v.toString());
      */
@@ -736,7 +736,7 @@ class Vec2 {
      * array. Default is 0.
      * @returns {number[]|ArrayBufferView} The vector as an array.
      * @example
-     * const v = new pc.Vec2(20, 10);
+     * const v = new Vec2(20, 10);
      * // Outputs [20, 10]
      * console.log(v.toArray());
      */

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -34,8 +34,8 @@ class Vec3 {
      * @param {number} [y] - The y value. Defaults to 0.
      * @param {number} [z] - The z value. Defaults to 0.
      * @example
-     * const v1 = new pc.Vec3(); // defaults to 0, 0, 0
-     * const v2 = new pc.Vec3(1, 2, 3);
+     * const v1 = new Vec3(); // defaults to 0, 0, 0
+     * const v2 = new Vec3(1, 2, 3);
      */
     /**
      * Creates a new Vec3 instance.
@@ -43,7 +43,7 @@ class Vec3 {
      * @overload
      * @param {number[]} arr - The array to set the vector values from.
      * @example
-     * const v = new pc.Vec3([1, 2, 3]);
+     * const v = new Vec3([1, 2, 3]);
      */
     /**
      * @param {number|number[]} [x] - The x value. Defaults to 0. If x is an array of length 3, the
@@ -69,8 +69,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to add to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(10, 10, 10);
-     * const b = new pc.Vec3(20, 20, 20);
+     * const a = new Vec3(10, 10, 10);
+     * const b = new Vec3(20, 20, 20);
      *
      * a.add(b);
      *
@@ -92,9 +92,9 @@ class Vec3 {
      * @param {Vec3} rhs - The second vector operand for the addition.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(10, 10, 10);
-     * const b = new pc.Vec3(20, 20, 20);
-     * const r = new pc.Vec3();
+     * const a = new Vec3(10, 10, 10);
+     * const b = new Vec3(20, 20, 20);
+     * const r = new Vec3();
      *
      * r.add2(a, b);
      * // Outputs [30, 30, 30]
@@ -115,7 +115,7 @@ class Vec3 {
      * @param {number} scalar - The number to add.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const vec = new pc.Vec3(3, 4, 5);
+     * const vec = new Vec3(3, 4, 5);
      *
      * vec.addScalar(2);
      *
@@ -137,9 +137,9 @@ class Vec3 {
      * @param {number} scalar - The number to multiply the added vector with.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const vec = new pc.Vec3(1, 2, 3);
+     * const vec = new Vec3(1, 2, 3);
      *
-     * vec.addScaled(pc.Vec3.UP, 2);
+     * vec.addScaled(Vec3.UP, 2);
      *
      * // Outputs [1, 4, 3]
      * console.log("The result of the addition is: " + vec.toString());
@@ -157,7 +157,7 @@ class Vec3 {
      *
      * @returns {this} A 3-dimensional vector containing the result of the cloning.
      * @example
-     * const v = new pc.Vec3(10, 20, 30);
+     * const v = new Vec3(10, 20, 30);
      * const vclone = v.clone();
      * console.log("The result of the cloning is: " + vclone.toString());
      */
@@ -173,8 +173,8 @@ class Vec3 {
      * @param {Vec3} rhs - A vector to copy to the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const src = new pc.Vec3(10, 20, 30);
-     * const dst = new pc.Vec3();
+     * const src = new Vec3(10, 20, 30);
+     * const dst = new Vec3();
      *
      * dst.copy(src);
      *
@@ -196,7 +196,7 @@ class Vec3 {
      * @param {Vec3} rhs - The second 3-dimensional vector operand of the cross product.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const back = new pc.Vec3().cross(pc.Vec3.RIGHT, pc.Vec3.UP);
+     * const back = new Vec3().cross(Vec3.RIGHT, Vec3.UP);
      *
      * // Prints the Z axis (i.e. [0, 0, 1])
      * console.log("The result of the cross product is: " + back.toString());
@@ -223,8 +223,8 @@ class Vec3 {
      * @param {Vec3} rhs - The second 3-dimensional vector to test.
      * @returns {number} The distance between the two vectors.
      * @example
-     * const v1 = new pc.Vec3(5, 10, 20);
-     * const v2 = new pc.Vec3(10, 20, 40);
+     * const v1 = new Vec3(5, 10, 20);
+     * const v2 = new Vec3(10, 20, 40);
      * const d = v1.distance(v2);
      * console.log("The distance between v1 and v2 is: " + d);
      */
@@ -241,8 +241,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to divide the specified vector by.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(4, 9, 16);
-     * const b = new pc.Vec3(2, 3, 4);
+     * const a = new Vec3(4, 9, 16);
+     * const b = new Vec3(2, 3, 4);
      *
      * a.div(b);
      *
@@ -264,9 +264,9 @@ class Vec3 {
      * @param {Vec3} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(4, 9, 16);
-     * const b = new pc.Vec3(2, 3, 4);
-     * const r = new pc.Vec3();
+     * const a = new Vec3(4, 9, 16);
+     * const b = new Vec3(2, 3, 4);
+     * const r = new Vec3();
      *
      * r.div2(a, b);
      *
@@ -287,7 +287,7 @@ class Vec3 {
      * @param {number} scalar - The number to divide by.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const vec = new pc.Vec3(3, 6, 9);
+     * const vec = new Vec3(3, 6, 9);
      *
      * vec.divScalar(3);
      *
@@ -309,8 +309,8 @@ class Vec3 {
      * @param {Vec3} rhs - The second 3-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
-     * const v1 = new pc.Vec3(5, 10, 20);
-     * const v2 = new pc.Vec3(10, 20, 40);
+     * const v1 = new Vec3(5, 10, 20);
+     * const v2 = new Vec3(10, 20, 40);
      * const v1dotv2 = v1.dot(v2);
      * console.log("The result of the dot product is: " + v1dotv2);
      */
@@ -324,8 +324,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * const a = new pc.Vec3(1, 2, 3);
-     * const b = new pc.Vec3(4, 5, 6);
+     * const a = new Vec3(1, 2, 3);
+     * const b = new Vec3(4, 5, 6);
      * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -340,8 +340,8 @@ class Vec3 {
      * vectors. Defaults to 1e-6.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * const a = new pc.Vec3();
-     * const b = new pc.Vec3();
+     * const a = new Vec3();
+     * const b = new Vec3();
      * console.log("The two vectors are approximately " + (a.equalsApprox(b, 1e-9) ? "equal" : "different"));
      */
     equalsApprox(rhs, epsilon = 1e-6) {
@@ -355,7 +355,7 @@ class Vec3 {
      *
      * @returns {number} The magnitude of the specified 3-dimensional vector.
      * @example
-     * const vec = new pc.Vec3(3, 4, 0);
+     * const vec = new Vec3(3, 4, 0);
      * const len = vec.length();
      * // Outputs 5
      * console.log("The length of the vector is: " + len);
@@ -369,7 +369,7 @@ class Vec3 {
      *
      * @returns {number} The magnitude squared of the specified 3-dimensional vector.
      * @example
-     * const vec = new pc.Vec3(3, 4, 0);
+     * const vec = new Vec3(3, 4, 0);
      * const len = vec.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
@@ -388,9 +388,9 @@ class Vec3 {
      * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(0, 0, 0);
-     * const b = new pc.Vec3(10, 10, 10);
-     * const r = new pc.Vec3();
+     * const a = new Vec3(0, 0, 0);
+     * const b = new Vec3(10, 10, 10);
+     * const r = new Vec3();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 5, 5, 5
@@ -410,8 +410,8 @@ class Vec3 {
      * @param {Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(2, 3, 4);
-     * const b = new pc.Vec3(4, 5, 6);
+     * const a = new Vec3(2, 3, 4);
+     * const b = new Vec3(4, 5, 6);
      *
      * a.mul(b);
      *
@@ -433,9 +433,9 @@ class Vec3 {
      * @param {Vec3} rhs - The 3-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(2, 3, 4);
-     * const b = new pc.Vec3(4, 5, 6);
-     * const r = new pc.Vec3();
+     * const a = new Vec3(2, 3, 4);
+     * const b = new Vec3(4, 5, 6);
+     * const r = new Vec3();
      *
      * r.mul2(a, b);
      *
@@ -456,7 +456,7 @@ class Vec3 {
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const vec = new pc.Vec3(3, 6, 9);
+     * const vec = new Vec3(3, 6, 9);
      *
      * vec.mulScalar(3);
      *
@@ -478,7 +478,7 @@ class Vec3 {
      * @param {Vec3} [src] - The vector to normalize. If not set, the operation is done in place.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const v = new pc.Vec3(25, 0, 0);
+     * const v = new Vec3(25, 0, 0);
      *
      * v.normalize();
      *
@@ -503,7 +503,7 @@ class Vec3 {
      * @param {Vec3} [src] - The vector to floor. If not set, the operation is done in place.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const v = new pc.Vec3(1.2, 3.9, 5.5);
+     * const v = new Vec3(1.2, 3.9, 5.5);
      * v.floor();
      * // v is now [1, 3, 5]
      */
@@ -520,7 +520,7 @@ class Vec3 {
      * @param {Vec3} [src] - The vector to ceil. If not set, the operation is done in place.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const v = new pc.Vec3(1.2, 3.1, 5.9);
+     * const v = new Vec3(1.2, 3.1, 5.9);
      * v.ceil();
      * // v is now [2, 4, 6]
      */
@@ -537,7 +537,7 @@ class Vec3 {
      * @param {Vec3} [src] - The vector to round. If not set, the operation is done in place.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const v = new pc.Vec3(1.4, 3.6, 5.5);
+     * const v = new Vec3(1.4, 3.6, 5.5);
      * v.round();
      * // v is now [1, 4, 6]
      */
@@ -554,8 +554,8 @@ class Vec3 {
      * @param {Vec3} rhs - The 3-dimensional vector used as the source of elements to compare to.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(5, 1, 7);
-     * const b = new pc.Vec3(2, 8, 3);
+     * const a = new Vec3(5, 1, 7);
+     * const b = new Vec3(2, 8, 3);
      * a.min(b);
      * // a is now [2, 1, 3]
      */
@@ -572,8 +572,8 @@ class Vec3 {
      * @param {Vec3} rhs - The 3-dimensional vector used as the source of elements to compare to.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(5, 1, 7);
-     * const b = new pc.Vec3(2, 8, 3);
+     * const a = new Vec3(5, 1, 7);
+     * const b = new Vec3(2, 8, 3);
      * a.max(b);
      * // a is now [5, 8, 7]
      */
@@ -590,8 +590,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector onto which the original vector will be projected on.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const v = new pc.Vec3(5, 5, 5);
-     * const normal = new pc.Vec3(1, 0, 0);
+     * const v = new Vec3(5, 5, 5);
+     * const normal = new Vec3(1, 0, 0);
      *
      * v.project(normal);
      *
@@ -616,7 +616,7 @@ class Vec3 {
      * @param {number} z - The value to set on the third component of the vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const v = new pc.Vec3();
+     * const v = new Vec3();
      * v.set(5, 10, 20);
      *
      * // Outputs [5, 10, 20]
@@ -636,8 +636,8 @@ class Vec3 {
      * @param {Vec3} rhs - The vector to subtract from the specified vector.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(10, 10, 10);
-     * const b = new pc.Vec3(20, 20, 20);
+     * const a = new Vec3(10, 10, 10);
+     * const b = new Vec3(20, 20, 20);
      *
      * a.sub(b);
      *
@@ -659,9 +659,9 @@ class Vec3 {
      * @param {Vec3} rhs - The second vector operand for the subtraction.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const a = new pc.Vec3(10, 10, 10);
-     * const b = new pc.Vec3(20, 20, 20);
-     * const r = new pc.Vec3();
+     * const a = new Vec3(10, 10, 10);
+     * const b = new Vec3(20, 20, 20);
+     * const r = new Vec3();
      *
      * r.sub2(a, b);
      *
@@ -682,7 +682,7 @@ class Vec3 {
      * @param {number} scalar - The number to subtract.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const vec = new pc.Vec3(3, 4, 5);
+     * const vec = new Vec3(3, 4, 5);
      *
      * vec.subScalar(2);
      *
@@ -705,7 +705,7 @@ class Vec3 {
      * array. Default is 0.
      * @returns {Vec3} Self for chaining.
      * @example
-     * const v = new pc.Vec3();
+     * const v = new Vec3();
      * v.fromArray([20, 10, 5]);
      * // v is set to [20, 10, 5]
      */
@@ -722,7 +722,7 @@ class Vec3 {
      *
      * @returns {string} The vector in string form.
      * @example
-     * const v = new pc.Vec3(20, 10, 5);
+     * const v = new Vec3(20, 10, 5);
      * // Outputs [20, 10, 5]
      * console.log(v.toString());
      */
@@ -755,7 +755,7 @@ class Vec3 {
      * array. Default is 0.
      * @returns {number[]|ArrayBufferView} The vector as an array.
      * @example
-     * const v = new pc.Vec3(20, 10, 5);
+     * const v = new Vec3(20, 10, 5);
      * // Outputs [20, 10, 5]
      * console.log(v.toArray());
      */

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -42,8 +42,8 @@ class Vec4 {
      * @param {number} [z] - The z value. Defaults to 0.
      * @param {number} [w] - The w value. Defaults to 0.
      * @example
-     * const v1 = new pc.Vec4(); // defaults to 0, 0, 0, 0
-     * const v2 = new pc.Vec4(1, 2, 3, 4);
+     * const v1 = new Vec4(); // defaults to 0, 0, 0, 0
+     * const v2 = new Vec4(1, 2, 3, 4);
      */
     /**
      * Creates a new Vec4 instance.
@@ -51,7 +51,7 @@ class Vec4 {
      * @overload
      * @param {number[]} arr - The array to set the vector values from.
      * @example
-     * const v = new pc.Vec4([1, 2, 3, 4]);
+     * const v = new Vec4([1, 2, 3, 4]);
      */
     /**
      * @param {number|number[]} [x] - The x value. Defaults to 0. If x is an array of length 4, the
@@ -80,8 +80,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to add to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(10, 10, 10, 10);
-     * const b = new pc.Vec4(20, 20, 20, 20);
+     * const a = new Vec4(10, 10, 10, 10);
+     * const b = new Vec4(20, 20, 20, 20);
      *
      * a.add(b);
      *
@@ -104,9 +104,9 @@ class Vec4 {
      * @param {Vec4} rhs - The second vector operand for the addition.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(10, 10, 10, 10);
-     * const b = new pc.Vec4(20, 20, 20, 20);
-     * const r = new pc.Vec4();
+     * const a = new Vec4(10, 10, 10, 10);
+     * const b = new Vec4(20, 20, 20, 20);
+     * const r = new Vec4();
      *
      * r.add2(a, b);
      * // Outputs [30, 30, 30, 30]
@@ -128,7 +128,7 @@ class Vec4 {
      * @param {number} scalar - The number to add.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const vec = new pc.Vec4(3, 4, 5, 6);
+     * const vec = new Vec4(3, 4, 5, 6);
      *
      * vec.addScalar(2);
      *
@@ -151,9 +151,9 @@ class Vec4 {
      * @param {number} scalar - The number to multiply the added vector with.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const vec = new pc.Vec4(1, 2, 3, 4);
+     * const vec = new Vec4(1, 2, 3, 4);
      *
-     * vec.addScaled(pc.Vec4.ONE, 2);
+     * vec.addScaled(Vec4.ONE, 2);
      *
      * // Outputs [3, 4, 5, 6]
      * console.log("The result of the addition is: " + vec.toString());
@@ -172,7 +172,7 @@ class Vec4 {
      *
      * @returns {this} A 4-dimensional vector containing the result of the cloning.
      * @example
-     * const v = new pc.Vec4(10, 20, 30, 40);
+     * const v = new Vec4(10, 20, 30, 40);
      * const vclone = v.clone();
      * console.log("The result of the cloning is: " + vclone.toString());
      */
@@ -188,8 +188,8 @@ class Vec4 {
      * @param {Vec4} rhs - A vector to copy to the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const src = new pc.Vec4(10, 20, 30, 40);
-     * const dst = new pc.Vec4();
+     * const src = new Vec4(10, 20, 30, 40);
+     * const dst = new Vec4();
      *
      * dst.copy(src);
      *
@@ -210,8 +210,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to divide the specified vector by.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(4, 9, 16, 25);
-     * const b = new pc.Vec4(2, 3, 4, 5);
+     * const a = new Vec4(4, 9, 16, 25);
+     * const b = new Vec4(2, 3, 4, 5);
      *
      * a.div(b);
      *
@@ -234,9 +234,9 @@ class Vec4 {
      * @param {Vec4} rhs - The divisor vector (the vector dividing the dividend).
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(4, 9, 16, 25);
-     * const b = new pc.Vec4(2, 3, 4, 5);
-     * const r = new pc.Vec4();
+     * const a = new Vec4(4, 9, 16, 25);
+     * const b = new Vec4(2, 3, 4, 5);
+     * const r = new Vec4();
      *
      * r.div2(a, b);
      *
@@ -258,7 +258,7 @@ class Vec4 {
      * @param {number} scalar - The number to divide by.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const vec = new pc.Vec4(3, 6, 9, 12);
+     * const vec = new Vec4(3, 6, 9, 12);
      *
      * vec.divScalar(3);
      *
@@ -281,8 +281,8 @@ class Vec4 {
      * @param {Vec4} rhs - The second 4-dimensional vector operand of the dot product.
      * @returns {number} The result of the dot product operation.
      * @example
-     * const v1 = new pc.Vec4(5, 10, 20, 40);
-     * const v2 = new pc.Vec4(10, 20, 40, 80);
+     * const v1 = new Vec4(5, 10, 20, 40);
+     * const v2 = new Vec4(10, 20, 40, 80);
      * const v1dotv2 = v1.dot(v2);
      * console.log("The result of the dot product is: " + v1dotv2);
      */
@@ -296,8 +296,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to compare to the specified vector.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * const a = new pc.Vec4(1, 2, 3, 4);
-     * const b = new pc.Vec4(5, 6, 7, 8);
+     * const a = new Vec4(1, 2, 3, 4);
+     * const b = new Vec4(5, 6, 7, 8);
      * console.log("The two vectors are " + (a.equals(b) ? "equal" : "different"));
      */
     equals(rhs) {
@@ -312,8 +312,8 @@ class Vec4 {
      * vectors. Defaults to 1e-6.
      * @returns {boolean} True if the vectors are equal and false otherwise.
      * @example
-     * const a = new pc.Vec4();
-     * const b = new pc.Vec4();
+     * const a = new Vec4();
+     * const b = new Vec4();
      * console.log("The two vectors are approximately " + (a.equalsApprox(b, 1e-9) ? "equal" : "different"));
      */
     equalsApprox(rhs, epsilon = 1e-6) {
@@ -328,7 +328,7 @@ class Vec4 {
      *
      * @returns {number} The magnitude of the specified 4-dimensional vector.
      * @example
-     * const vec = new pc.Vec4(3, 4, 0, 0);
+     * const vec = new Vec4(3, 4, 0, 0);
      * const len = vec.length();
      * // Outputs 5
      * console.log("The length of the vector is: " + len);
@@ -342,7 +342,7 @@ class Vec4 {
      *
      * @returns {number} The magnitude squared of the specified 4-dimensional vector.
      * @example
-     * const vec = new pc.Vec4(3, 4, 0, 0);
+     * const vec = new Vec4(3, 4, 0, 0);
      * const len = vec.lengthSq();
      * // Outputs 25
      * console.log("The length squared of the vector is: " + len);
@@ -361,9 +361,9 @@ class Vec4 {
      * range, the linear interpolant will occur on a ray extrapolated from this line.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(0, 0, 0, 0);
-     * const b = new pc.Vec4(10, 10, 10, 10);
-     * const r = new pc.Vec4();
+     * const a = new Vec4(0, 0, 0, 0);
+     * const b = new Vec4(10, 10, 10, 10);
+     * const r = new Vec4();
      *
      * r.lerp(a, b, 0);   // r is equal to a
      * r.lerp(a, b, 0.5); // r is 5, 5, 5, 5
@@ -384,8 +384,8 @@ class Vec4 {
      * @param {Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(2, 3, 4, 5);
-     * const b = new pc.Vec4(4, 5, 6, 7);
+     * const a = new Vec4(2, 3, 4, 5);
+     * const b = new Vec4(4, 5, 6, 7);
      *
      * a.mul(b);
      *
@@ -408,9 +408,9 @@ class Vec4 {
      * @param {Vec4} rhs - The 4-dimensional vector used as the second multiplicand of the operation.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(2, 3, 4, 5);
-     * const b = new pc.Vec4(4, 5, 6, 7);
-     * const r = new pc.Vec4();
+     * const a = new Vec4(2, 3, 4, 5);
+     * const b = new Vec4(4, 5, 6, 7);
+     * const r = new Vec4();
      *
      * r.mul2(a, b);
      *
@@ -432,7 +432,7 @@ class Vec4 {
      * @param {number} scalar - The number to multiply by.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const vec = new pc.Vec4(3, 6, 9, 12);
+     * const vec = new Vec4(3, 6, 9, 12);
      *
      * vec.mulScalar(3);
      *
@@ -455,7 +455,7 @@ class Vec4 {
      * @param {Vec4} [src] - The vector to normalize. If not set, the operation is done in place.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const v = new pc.Vec4(25, 0, 0, 0);
+     * const v = new Vec4(25, 0, 0, 0);
      *
      * v.normalize();
      *
@@ -481,7 +481,7 @@ class Vec4 {
      * @param {Vec4} [src] - The vector to floor. If not set, the operation is done in place.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const v = new pc.Vec4(1.2, 3.9, 5.5, 7.8);
+     * const v = new Vec4(1.2, 3.9, 5.5, 7.8);
      * v.floor();
      * // v is now [1, 3, 5, 7]
      */
@@ -499,7 +499,7 @@ class Vec4 {
      * @param {Vec4} [src] - The vector to ceil. If not set, the operation is done in place.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const v = new pc.Vec4(1.2, 3.1, 5.9, 7.4);
+     * const v = new Vec4(1.2, 3.1, 5.9, 7.4);
      * v.ceil();
      * // v is now [2, 4, 6, 8]
      */
@@ -517,7 +517,7 @@ class Vec4 {
      * @param {Vec4} [src] - The vector to round. If not set, the operation is done in place.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const v = new pc.Vec4(1.4, 3.6, 5.5, 7.2);
+     * const v = new Vec4(1.4, 3.6, 5.5, 7.2);
      * v.round();
      * // v is now [1, 4, 6, 7]
      */
@@ -535,8 +535,8 @@ class Vec4 {
      * @param {Vec4} rhs - The 4-dimensional vector used as the source of elements to compare to.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(5, 1, 7, 3);
-     * const b = new pc.Vec4(2, 8, 3, 9);
+     * const a = new Vec4(5, 1, 7, 3);
+     * const b = new Vec4(2, 8, 3, 9);
      * a.min(b);
      * // a is now [2, 1, 3, 3]
      */
@@ -554,8 +554,8 @@ class Vec4 {
      * @param {Vec4} rhs - The 4-dimensional vector used as the source of elements to compare to.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(5, 1, 7, 3);
-     * const b = new pc.Vec4(2, 8, 3, 9);
+     * const a = new Vec4(5, 1, 7, 3);
+     * const b = new Vec4(2, 8, 3, 9);
      * a.max(b);
      * // a is now [5, 8, 7, 9]
      */
@@ -576,7 +576,7 @@ class Vec4 {
      * @param {number} w - The value to set on the fourth component of the vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const v = new pc.Vec4();
+     * const v = new Vec4();
      * v.set(5, 10, 20, 40);
      *
      * // Outputs 5, 10, 20, 40
@@ -597,8 +597,8 @@ class Vec4 {
      * @param {Vec4} rhs - The vector to subtract from the specified vector.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(10, 10, 10, 10);
-     * const b = new pc.Vec4(20, 20, 20, 20);
+     * const a = new Vec4(10, 10, 10, 10);
+     * const b = new Vec4(20, 20, 20, 20);
      *
      * a.sub(b);
      *
@@ -621,9 +621,9 @@ class Vec4 {
      * @param {Vec4} rhs - The second vector operand for the subtraction.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const a = new pc.Vec4(10, 10, 10, 10);
-     * const b = new pc.Vec4(20, 20, 20, 20);
-     * const r = new pc.Vec4();
+     * const a = new Vec4(10, 10, 10, 10);
+     * const b = new Vec4(20, 20, 20, 20);
+     * const r = new Vec4();
      *
      * r.sub2(a, b);
      *
@@ -645,7 +645,7 @@ class Vec4 {
      * @param {number} scalar - The number to subtract.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const vec = new pc.Vec4(3, 4, 5, 6);
+     * const vec = new Vec4(3, 4, 5, 6);
      *
      * vec.subScalar(2);
      *
@@ -669,7 +669,7 @@ class Vec4 {
      * array. Default is 0.
      * @returns {Vec4} Self for chaining.
      * @example
-     * const v = new pc.Vec4();
+     * const v = new Vec4();
      * v.fromArray([20, 10, 5, 0]);
      * // v is set to [20, 10, 5, 0]
      */
@@ -687,7 +687,7 @@ class Vec4 {
      *
      * @returns {string} The vector in string form.
      * @example
-     * const v = new pc.Vec4(20, 10, 5, 0);
+     * const v = new Vec4(20, 10, 5, 0);
      * // Outputs [20, 10, 5, 0]
      * console.log(v.toString());
      */
@@ -720,7 +720,7 @@ class Vec4 {
      * array. Default is 0.
      * @returns {number[]|ArrayBufferView} The vector as an array.
      * @example
-     * const v = new pc.Vec4(20, 10, 5, 1);
+     * const v = new Vec4(20, 10, 5, 1);
      * // Outputs [20, 10, 5, 1]
      * console.log(v.toArray());
      */

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -17,10 +17,10 @@ const path = {
      * @param {...string} sections - Sections of the path to join.
      * @returns {string} The joined file path.
      * @example
-     * const path = pc.path.join('foo', 'bar');
+     * const path = path.join('foo', 'bar');
      * console.log(path); // Prints 'foo/bar'
      * @example
-     * const path = pc.path.join('alpha', 'beta', 'gamma');
+     * const path = path.join('alpha', 'beta', 'gamma');
      * console.log(path); // Prints 'alpha/beta/gamma'
      */
     join(...sections) {
@@ -110,8 +110,8 @@ const path = {
      * @param {string} pathname - The path to process.
      * @returns {string} The basename.
      * @example
-     * pc.path.getBasename("/path/to/file.txt"); // returns "file.txt"
-     * pc.path.getBasename("/path/to/dir"); // returns "dir"
+     * path.getBasename("/path/to/file.txt"); // returns "file.txt"
+     * path.getBasename("/path/to/dir"); // returns "dir"
      */
     getBasename(pathname) {
         return path.split(pathname)[1];
@@ -135,9 +135,9 @@ const path = {
      * @param {string} pathname - The path to process.
      * @returns {string} The extension.
      * @example
-     * pc.path.getExtension("/path/to/file.txt"); // returns ".txt"
-     * pc.path.getExtension("/path/to/file.jpg"); // returns ".jpg"
-     * pc.path.getExtension("/path/to/file.txt?function=getExtension"); // returns ".txt"
+     * path.getExtension("/path/to/file.txt"); // returns ".txt"
+     * path.getExtension("/path/to/file.jpg"); // returns ".jpg"
+     * path.getExtension("/path/to/file.txt?function=getExtension"); // returns ".txt"
      */
     getExtension(pathname) {
         const ext = pathname.split('?')[0].split('.').pop();
@@ -155,12 +155,12 @@ const path = {
      * slash.
      *
      * @example
-     * pc.path.isRelativePath("file.txt"); // returns true
-     * pc.path.isRelativePath("path/to/file.txt"); // returns true
-     * pc.path.isRelativePath("./path/to/file.txt"); // returns true
-     * pc.path.isRelativePath("../path/to/file.jpg"); // returns true
-     * pc.path.isRelativePath("/path/to/file.jpg"); // returns false
-     * pc.path.isRelativePath("http://path/to/file.jpg"); // returns false
+     * path.isRelativePath("file.txt"); // returns true
+     * path.isRelativePath("path/to/file.txt"); // returns true
+     * path.isRelativePath("./path/to/file.txt"); // returns true
+     * path.isRelativePath("../path/to/file.jpg"); // returns true
+     * path.isRelativePath("/path/to/file.jpg"); // returns false
+     * path.isRelativePath("http://path/to/file.jpg"); // returns false
      */
     isRelativePath(pathname) {
         return pathname.charAt(0) !== '/' && pathname.match(/:\/\//) === null;
@@ -172,10 +172,10 @@ const path = {
      * @param {string} pathname - The full path to process.
      * @returns {string} The path without a last element from list split by slash.
      * @example
-     * pc.path.extractPath("path/to/file.txt");    // returns "./path/to"
-     * pc.path.extractPath("./path/to/file.txt");  // returns "./path/to"
-     * pc.path.extractPath("../path/to/file.txt"); // returns "../path/to"
-     * pc.path.extractPath("/path/to/file.txt");   // returns "/path/to"
+     * path.extractPath("path/to/file.txt");    // returns "./path/to"
+     * path.extractPath("./path/to/file.txt");  // returns "./path/to"
+     * path.extractPath("../path/to/file.txt"); // returns "../path/to"
+     * path.extractPath("/path/to/file.txt");   // returns "/path/to"
      */
     extractPath(pathname) {
         let result = '';

--- a/src/core/path.js
+++ b/src/core/path.js
@@ -17,11 +17,11 @@ const path = {
      * @param {...string} sections - Sections of the path to join.
      * @returns {string} The joined file path.
      * @example
-     * const path = path.join('foo', 'bar');
-     * console.log(path); // Prints 'foo/bar'
+     * const joinedPath = path.join('foo', 'bar');
+     * console.log(joinedPath); // Prints 'foo/bar'
      * @example
-     * const path = path.join('alpha', 'beta', 'gamma');
-     * console.log(path); // Prints 'alpha/beta/gamma'
+     * const joinedPath = path.join('alpha', 'beta', 'gamma');
+     * console.log(joinedPath); // Prints 'alpha/beta/gamma'
      */
     join(...sections) {
         let result = sections[0];

--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -54,7 +54,7 @@ const passiveEvents = detectPassiveEvents();
  *
  * @namespace
  * @example
- * if (pc.platform.touch) {
+ * if (platform.touch) {
  *     // touch is supported
  * }
  */

--- a/src/core/shape/bounding-sphere.js
+++ b/src/core/shape/bounding-sphere.js
@@ -37,7 +37,7 @@ class BoundingSphere {
      * @param {number} [radius] - The radius of the bounding sphere. Defaults to 0.5.
      * @example
      * // Create a new bounding sphere centered on the origin with a radius of 0.5
-     * const sphere = new pc.BoundingSphere();
+     * const sphere = new BoundingSphere();
      */
     constructor(center = new Vec3(), radius = 0.5) {
         Debug.assert(!Object.isFrozen(center), 'The constructor of \'BoundingSphere\' does not accept a constant (frozen) object as a \'center\' parameter');
@@ -52,8 +52,8 @@ class BoundingSphere {
      * @param {Vec3} point - Point to test.
      * @returns {boolean} True if the point is inside the sphere and false otherwise.
      * @example
-     * const sphere = new pc.BoundingSphere(new pc.Vec3(0, 0, 0), 1);
-     * const point = new pc.Vec3(0.5, 0, 0);
+     * const sphere = new BoundingSphere(new Vec3(0, 0, 0), 1);
+     * const point = new Vec3(0.5, 0, 0);
      * const isInside = sphere.containsPoint(point); // true
      */
     containsPoint(point) {

--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -57,7 +57,7 @@ class Frustum {
      * Create a new Frustum instance.
      *
      * @example
-     * const frustum = new pc.Frustum();
+     * const frustum = new Frustum();
      */
     constructor() {
         for (let i = 0; i < 6; i++) {
@@ -70,7 +70,7 @@ class Frustum {
      *
      * @returns {Frustum} A duplicate frustum.
      * @example
-     * const frustum = new pc.Frustum();
+     * const frustum = new Frustum();
      * const clone = frustum.clone();
      */
     clone() {
@@ -86,7 +86,7 @@ class Frustum {
      * @returns {Frustum} Self for chaining.
      * @example
      * const src = entity.camera.frustum;
-     * const dst = new pc.Frustum();
+     * const dst = new Frustum();
      * dst.copy(src);
      */
     copy(src) {
@@ -102,11 +102,11 @@ class Frustum {
      * @param {Mat4} matrix - The matrix describing the shape of the frustum.
      * @example
      * // Create a perspective projection matrix
-     * const projection = new pc.Mat4();
+     * const projection = new Mat4();
      * projection.setPerspective(45, 16 / 9, 1, 1000);
      *
      * // Create a frustum shape that is represented by the matrix
-     * const frustum = new pc.Frustum();
+     * const frustum = new Frustum();
      * frustum.setFromMat4(projection);
      */
     setFromMat4(matrix) {

--- a/src/core/shape/ray.js
+++ b/src/core/shape/ray.js
@@ -33,7 +33,7 @@ class Ray {
      * @example
      * // Create a new ray starting at the position of this entity and pointing down
      * // the entity's negative Z axis
-     * const ray = new pc.Ray(this.entity.getPosition(), this.entity.forward);
+     * const ray = new Ray(this.entity.getPosition(), this.entity.forward);
      */
     constructor(origin, direction) {
         if (origin) {

--- a/src/core/shape/tri.js
+++ b/src/core/shape/tri.js
@@ -50,10 +50,10 @@ class Tri {
      * @param {Vec3} [v1] - The second 3-dimensional vector.
      * @param {Vec3} [v2] - The third 3-dimensional vector.
      * @example
-     * const v0 = new pc.Vec3(1, 0, 0);
-     * const v1 = new pc.Vec3(0, 1, 0);
-     * const v2 = new pc.Vec3(2, 2, 1);
-     * const t = new pc.Tri(v0, v1, v2);
+     * const v0 = new Vec3(1, 0, 0);
+     * const v1 = new Vec3(0, 1, 0);
+     * const v2 = new Vec3(2, 2, 1);
+     * const t = new Tri(v0, v1, v2);
      */
     constructor(v0 = Vec3.ZERO, v1 = Vec3.ZERO, v2 = Vec3.ZERO) {
         this.set(v0, v1, v2);
@@ -67,10 +67,10 @@ class Tri {
      * @param {Vec3} v2 - The value set on the third 3-dimensional vector of the triangle.
      * @returns {Tri} Self for chaining.
      * @example
-     * const t = new pc.Tri(pc.Vec3.UP, pc.Vec3.RIGHT, pc.Vec3.BACK);
-     * const v0 = new pc.Vec3(1, 0, 0);
-     * const v1 = new pc.Vec3(0, 1, 0);
-     * const v2 = new pc.Vec3(2, 2, 1);
+     * const t = new Tri(Vec3.UP, Vec3.RIGHT, Vec3.BACK);
+     * const v0 = new Vec3(1, 0, 0);
+     * const v1 = new Vec3(0, 1, 0);
+     * const v2 = new Vec3(2, 2, 1);
      * t.set(v0, v1, v2);
      *
      * // Outputs [[1, 0, 0], [0, 1, 0], [2, 2, 1]]
@@ -130,7 +130,7 @@ class Tri {
      *
      * @returns {string} The triangle in string form.
      * @example
-     * const t = new pc.Tri(pc.Vec3.UP, pc.Vec3.RIGHT, pc.Vec3.BACK);
+     * const t = new Tri(Vec3.UP, Vec3.RIGHT, Vec3.BACK);
      * // Outputs [[0, 1, 0], [1, 0, 0], [0, 0, 1]]
      * console.log(t.toString());
      */

--- a/src/core/sorted-loop-array.js
+++ b/src/core/sorted-loop-array.js
@@ -38,7 +38,7 @@ class SortedLoopArray {
      * @param {string} args.sortBy - The name of the field that each element in the array is going
      * to be sorted by.
      * @example
-     * const array = new pc.SortedLoopArray({ sortBy: 'priority' });
+     * const array = new SortedLoopArray({ sortBy: 'priority' });
      * array.insert(item); // adds item to the right slot based on item.priority
      * array.append(item); // adds item to the end of the array
      * array.remove(item); // removes item from array

--- a/src/core/string.js
+++ b/src/core/string.js
@@ -131,7 +131,7 @@ const string = {
      * @param {...*} args - All other arguments are substituted into the string.
      * @returns {string} The formatted string.
      * @example
-     * const s = pc.string.format("Hello {0}", "world");
+     * const s = string.format("Hello {0}", "world");
      * console.log(s); // Prints "Hello world"
      */
     format(s, ...args) {

--- a/src/core/uri.js
+++ b/src/core/uri.js
@@ -148,7 +148,7 @@ class URI {
      * @returns {object} The URI's query parameters converted to an Object.
      * @example
      * const s = "http://example.com?a=1&b=2&c=3";
-     * const uri = new pc.URI(s);
+     * const uri = new URI(s);
      * const q = uri.getQuery();
      * console.log(q.a); // logs "1"
      * console.log(q.b); // logs "2"
@@ -174,7 +174,7 @@ class URI {
      * @param {object} params - Key-Value pairs to encode into the query string.
      * @example
      * const s = "http://example.com";
-     * const uri = new pc.URI(s);
+     * const uri = new URI(s);
      * uri.setQuery({
      *     "a": 1,
      *     "b": 2

--- a/src/core/wasm-module.js
+++ b/src/core/wasm-module.js
@@ -136,13 +136,13 @@ class Impl {
  *
  * @example
  * // Load the Ammo.js physics engine
- * pc.WasmModule.setConfig('Ammo', {
+ * WasmModule.setConfig('Ammo', {
  *     glueUrl: `ammo.wasm.js`,
  *     wasmUrl: `ammo.wasm.wasm`,
  *     fallbackUrl: `ammo.js`
  * });
  * await new Promise((resolve) => {
- *     pc.WasmModule.getInstance('Ammo', () => resolve());
+ *     WasmModule.getInstance('Ammo', () => resolve());
  * });
  */
 class WasmModule {

--- a/src/extras/gizmo/gizmo.js
+++ b/src/extras/gizmo/gizmo.js
@@ -46,7 +46,7 @@ class Gizmo extends EventHandler {
      *
      * @event
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.on('pointer:down', (x, y, meshInstance) => {
      *     console.log(`Pointer was down on ${meshInstance.node.name} at ${x}, ${y}`);
      * });
@@ -58,7 +58,7 @@ class Gizmo extends EventHandler {
      *
      * @event
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.on('pointer:move', (x, y, meshInstance) => {
      *     console.log(`Pointer was moving on ${meshInstance.node.name} at ${x}, ${y}`);
      * });
@@ -70,7 +70,7 @@ class Gizmo extends EventHandler {
      *
      * @event
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.on('pointer:up', (x, y, meshInstance) => {
      *     console.log(`Pointer was up on ${meshInstance.node.name} at ${x}, ${y}`);
      * })
@@ -82,7 +82,7 @@ class Gizmo extends EventHandler {
      *
      * @event
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.on('position:update', (position) => {
      *     console.log(`The gizmo's position was updated to ${position}`);
      * })
@@ -94,7 +94,7 @@ class Gizmo extends EventHandler {
      *
      * @event
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.on('rotation:update', (rotation) => {
      *     console.log(`The gizmo's rotation was updated to ${rotation}`);
      * });
@@ -106,7 +106,7 @@ class Gizmo extends EventHandler {
      *
      * @event
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.on('scale:update', (scale) => {
      *     console.log(`The gizmo's scale was updated to ${scale}`);
      * });
@@ -118,7 +118,7 @@ class Gizmo extends EventHandler {
      *
      * @event
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.on('nodes:attach', () => {
      *     console.log('Graph nodes attached');
      * });
@@ -130,7 +130,7 @@ class Gizmo extends EventHandler {
      *
      * @event
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.on('nodes:detach', () => {
      *     console.log('Graph nodes detached');
      * });
@@ -142,7 +142,7 @@ class Gizmo extends EventHandler {
      *
      * @event
      * @example
-     * const gizmo = new pc.TransformGizmo(camera, layer);
+     * const gizmo = new TransformGizmo(camera, layer);
      * gizmo.on('render:update', () => {
      *     console.log('Gizmo render has been updated');
      * });
@@ -280,7 +280,7 @@ class Gizmo extends EventHandler {
      * and will be removed from the camera and scene when the last gizmo is destroyed.
      * @param {string} [name] - The name of the gizmo. Defaults to 'gizmo'.
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      */
     constructor(camera, layer, name = 'gizmo') {
         super();
@@ -652,7 +652,7 @@ class Gizmo extends EventHandler {
      *
      * @param {GraphNode[] | GraphNode} [nodes] - The graph nodes. Defaults to [].
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.attach([boxA, boxB]);
      */
     attach(nodes = []) {
@@ -678,7 +678,7 @@ class Gizmo extends EventHandler {
      * Detaches all graph nodes from the gizmo.
      *
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.attach([boxA, boxB]);
      * gizmo.detach();
      */
@@ -694,7 +694,7 @@ class Gizmo extends EventHandler {
      * Pre-render method. This is called before the gizmo is rendered.
      *
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.attach([boxA, boxB]);
      * gizmo.prerender();
      */
@@ -705,7 +705,7 @@ class Gizmo extends EventHandler {
      * Updates the gizmo position, rotation, and scale.
      *
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.attach([boxA, boxB]);
      * gizmo.update();
      */
@@ -728,7 +728,7 @@ class Gizmo extends EventHandler {
      * Detaches all graph nodes and destroys the gizmo instance.
      *
      * @example
-     * const gizmo = new pc.Gizmo(camera, layer);
+     * const gizmo = new Gizmo(camera, layer);
      * gizmo.attach([boxA, boxB]);
      * gizmo.destroy();
      */

--- a/src/extras/gizmo/rotate-gizmo.js
+++ b/src/extras/gizmo/rotate-gizmo.js
@@ -42,13 +42,13 @@ const AXES = /** @type {('x' | 'y' | 'z')[]} */ (['x', 'y', 'z']);
  *
  * ```javascript
  * // Create a layer for rendering all gizmos
- * const gizmoLayer = pc.Gizmo.createLayer(app);
+ * const gizmoLayer = Gizmo.createLayer(app);
  *
  * // Create a rotate gizmo
- * const gizmo = new pc.RotateGizmo(cameraComponent, gizmoLayer);
+ * const gizmo = new RotateGizmo(cameraComponent, gizmoLayer);
  *
  * // Create an entity to attach the gizmo to
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     type: 'box'
  * });
@@ -208,7 +208,7 @@ class RotateGizmo extends TransformGizmo {
      * @param {CameraComponent} camera - The camera component.
      * @param {Layer} layer - The layer responsible for rendering the gizmo.
      * @example
-     * const gizmo = new pc.RotateGizmo(camera, layer);
+     * const gizmo = new RotateGizmo(camera, layer);
      */
     constructor(camera, layer) {
         super(camera, layer, 'gizmo:rotate');

--- a/src/extras/gizmo/scale-gizmo.js
+++ b/src/extras/gizmo/scale-gizmo.js
@@ -34,13 +34,13 @@ const GLANCE_EPSILON = 0.01;
  *
  * ```javascript
  * // Create a layer for rendering all gizmos
- * const gizmoLayer = pc.Gizmo.createLayer(app);
+ * const gizmoLayer = Gizmo.createLayer(app);
  *
  * // Create a scale gizmo
- * const gizmo = new pc.ScaleGizmo(cameraComponent, gizmoLayer);
+ * const gizmo = new ScaleGizmo(cameraComponent, gizmoLayer);
  *
  * // Create an entity to attach the gizmo to
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     type: 'box'
  * });
@@ -160,7 +160,7 @@ class ScaleGizmo extends TransformGizmo {
      * @param {CameraComponent} camera - The camera component.
      * @param {Layer} layer - The layer responsible for rendering the gizmo.
      * @example
-     * const gizmo = new pc.ScaleGizmo(camera, layer);
+     * const gizmo = new ScaleGizmo(camera, layer);
      */
     constructor(camera, layer) {
         super(camera, layer, 'gizmo:scale');

--- a/src/extras/gizmo/transform-gizmo.js
+++ b/src/extras/gizmo/transform-gizmo.js
@@ -55,7 +55,7 @@ class TransformGizmo extends Gizmo {
      *
      * @event
      * @example
-     * const gizmo = new pc.TransformGizmo(camera, layer);
+     * const gizmo = new TransformGizmo(camera, layer);
      * gizmo.on('transform:start', () => {
      *     console.log('Transformation started');
      * });
@@ -67,7 +67,7 @@ class TransformGizmo extends Gizmo {
      *
      * @event
      * @example
-     * const gizmo = new pc.TransformGizmo(camera, layer);
+     * const gizmo = new TransformGizmo(camera, layer);
      * gizmo.on('transform:move', (pointDelta, angleDelta) => {
      *     console.log(`Transformation moved by ${pointDelta} (angle: ${angleDelta})`);
      * });
@@ -79,7 +79,7 @@ class TransformGizmo extends Gizmo {
      *
      * @event
      * @example
-     * const gizmo = new pc.TransformGizmo(camera, layer);
+     * const gizmo = new TransformGizmo(camera, layer);
      * gizmo.on('transform:end', () => {
      *     console.log('Transformation ended');
      * });
@@ -215,7 +215,7 @@ class TransformGizmo extends Gizmo {
      * @param {Layer} layer - The render layer.
      * @param {string} [name] - The name of the gizmo.
      * @example
-     * const gizmo = new pc.TransformGizmo(camera, layer);
+     * const gizmo = new TransformGizmo(camera, layer);
      */
     constructor(camera, layer, name = 'gizmo:transform') {
         super(camera, layer, name);

--- a/src/extras/gizmo/translate-gizmo.js
+++ b/src/extras/gizmo/translate-gizmo.js
@@ -35,13 +35,13 @@ const AXES = /** @type {('x' | 'y' | 'z')[]} */ (['x', 'y', 'z']);
  *
  * ```javascript
  * // Create a layer for rendering all gizmos
- * const gizmoLayer = pc.Gizmo.createLayer(app);
+ * const gizmoLayer = Gizmo.createLayer(app);
  *
  * // Create a translate gizmo
- * const gizmo = new pc.TranslateGizmo(cameraComponent, gizmoLayer);
+ * const gizmo = new TranslateGizmo(cameraComponent, gizmoLayer);
  *
  * // Create an entity to attach the gizmo to
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     type: 'box'
  * });
@@ -151,7 +151,7 @@ class TranslateGizmo extends TransformGizmo {
      * @param {CameraComponent} camera - The camera component.
      * @param {Layer} layer - The layer responsible for rendering the gizmo.
      * @example
-     * const gizmo = new pc.TranslateGizmo(camera, layer);
+     * const gizmo = new TranslateGizmo(camera, layer);
      */
     constructor(camera, layer) {
         super(camera, layer, 'gizmo:translate');

--- a/src/extras/mini-stats/mini-stats.js
+++ b/src/extras/mini-stats/mini-stats.js
@@ -85,7 +85,7 @@ class MiniStats {
      * @param {MiniStatsOptions} [options] - Options for the MiniStats instance.
      * @example
      * // create a new MiniStats instance using default options
-     * const miniStats = new pc.MiniStats(app);
+     * const miniStats = new MiniStats(app);
      */
     constructor(app, options = MiniStats.getDefaultOptions()) {
         const device = app.graphicsDevice;
@@ -244,10 +244,10 @@ class MiniStats {
      * @returns {object} The default options for MiniStats.
      * @example
      * // default options without extra stats
-     * const options = pc.MiniStats.getDefaultOptions();
+     * const options = MiniStats.getDefaultOptions();
      * @example
      * // include gsplat stats
-     * const options = pc.MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy']);
+     * const options = MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy']);
      */
     static getDefaultOptions(extraStats = []) {
         const options = {

--- a/src/framework/anim/controller/anim-transition.js
+++ b/src/framework/anim/controller/anim-transition.js
@@ -31,7 +31,7 @@ class AnimTransition {
      * and must be between 0 and 1. Defaults to null.
      * @param {string} [options.interruptionSource] - Defines whether another transition can
      * interrupt this one and which of the current or previous states transitions can do so. One of
-     * pc.ANIM_INTERRUPTION_*. Defaults to pc.ANIM_INTERRUPTION_NONE.
+     * ANIM_INTERRUPTION_*. Defaults to ANIM_INTERRUPTION_NONE.
      */
     constructor({ from, to, time = 0, priority = 0, conditions = [], exitTime = null, transitionOffset = null, interruptionSource = ANIM_INTERRUPTION_NONE }) {
         this._from = from;

--- a/src/framework/anim/evaluator/anim-events.js
+++ b/src/framework/anim/evaluator/anim-events.js
@@ -10,7 +10,7 @@ class AnimEvents {
      *
      * @param {object[]} events - An array of animation events.
      * @example
-     * const events = new pc.AnimEvents([
+     * const events = new AnimEvents([
      *     {
      *         name: 'my_event',
      *         time: 1.3, // given in seconds

--- a/src/framework/anim/state-graph/anim-state-graph.js
+++ b/src/framework/anim/state-graph/anim-state-graph.js
@@ -5,7 +5,7 @@
  * Scripts can retrieve an AnimStateGraph instance from assets of type 'animstategraph'. An AnimStateGraph can then be loaded into an anim component as follows:
  * ```javascript
  * const animStateGraph = app.assets.get(ASSET_ID).resource;
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('anim');
  * entity.anim.loadStateGraph(animStateGraph);
  * ```

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -356,7 +356,7 @@ class AppBase extends EventHandler {
      *
      * @example
      * // Render the scene only while space key is pressed
-     * if (this.app.keyboard.isPressed(pc.KEY_SPACE)) {
+     * if (this.app.keyboard.isPressed(KEY_SPACE)) {
      *     this.app.renderNextFrame = true;
      * }
      */
@@ -385,7 +385,7 @@ class AppBase extends EventHandler {
      * @type {Scene}
      * @example
      * // Set the fog type property of the application's scene
-     * this.app.scene.fog.type = pc.FOG_LINEAR;
+     * this.app.scene.fog.type = FOG_LINEAR;
      */
     scene;
 
@@ -502,7 +502,7 @@ class AppBase extends EventHandler {
      * @type {XrManager|null}
      * @example
      * // check if VR is available
-     * if (app.xr.isAvailable(pc.XRTYPE_VR)) {
+     * if (app.xr.isAvailable(XRTYPE_VR)) {
      *     // VR is available
      * }
      */
@@ -513,7 +513,7 @@ class AppBase extends EventHandler {
      *
      * @param {HTMLCanvasElement | OffscreenCanvas} canvas - The canvas element.
      * @example
-     * const app = new pc.AppBase(canvas);
+     * const app = new AppBase(canvas);
      *
      * const options = new AppOptions();
      * app.init(options);
@@ -654,7 +654,7 @@ class AppBase extends EventHandler {
      * this id. Otherwise current application will be returned.
      * @returns {AppBase|undefined} The running application, if any.
      * @example
-     * const app = pc.AppBase.getApplication();
+     * const app = AppBase.getApplication();
      */
     static getApplication(id) {
         return id ? AppBase._applications[id] : getApplication();
@@ -1592,20 +1592,20 @@ class AppBase extends EventHandler {
      * @param {Layer} [layer] - The layer to render the line into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a 1-unit long white line
-     * const start = new pc.Vec3(0, 0, 0);
-     * const end = new pc.Vec3(1, 0, 0);
+     * const start = new Vec3(0, 0, 0);
+     * const end = new Vec3(1, 0, 0);
      * app.drawLine(start, end);
      * @example
      * // Render a 1-unit long red line which is not depth tested and renders on top of other geometry
-     * const start = new pc.Vec3(0, 0, 0);
-     * const end = new pc.Vec3(1, 0, 0);
-     * app.drawLine(start, end, pc.Color.RED, false);
+     * const start = new Vec3(0, 0, 0);
+     * const end = new Vec3(1, 0, 0);
+     * app.drawLine(start, end, Color.RED, false);
      * @example
      * // Render a 1-unit long white line into the world layer
-     * const start = new pc.Vec3(0, 0, 0);
-     * const end = new pc.Vec3(1, 0, 0);
-     * const worldLayer = app.scene.layers.getLayerById(pc.LAYERID_WORLD);
-     * app.drawLine(start, end, pc.Color.WHITE, true, worldLayer);
+     * const start = new Vec3(0, 0, 0);
+     * const end = new Vec3(1, 0, 0);
+     * const worldLayer = app.scene.layers.getLayerById(LAYERID_WORLD);
+     * app.drawLine(start, end, Color.WHITE, true, worldLayer);
      */
     drawLine(start, end, color, depthTest, layer) {
         this.scene.drawLine(start, end, color, depthTest, layer);
@@ -1628,26 +1628,26 @@ class AppBase extends EventHandler {
      * @param {Layer} [layer] - The layer to render the lines into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a single line, with unique colors for each point
-     * const start = new pc.Vec3(0, 0, 0);
-     * const end = new pc.Vec3(1, 0, 0);
-     * app.drawLines([start, end], [pc.Color.RED, pc.Color.WHITE]);
+     * const start = new Vec3(0, 0, 0);
+     * const end = new Vec3(1, 0, 0);
+     * app.drawLines([start, end], [Color.RED, Color.WHITE]);
      * @example
      * // Render 2 discrete line segments
      * const points = [
      *     // Line 1
-     *     new pc.Vec3(0, 0, 0),
-     *     new pc.Vec3(1, 0, 0),
+     *     new Vec3(0, 0, 0),
+     *     new Vec3(1, 0, 0),
      *     // Line 2
-     *     new pc.Vec3(1, 1, 0),
-     *     new pc.Vec3(1, 1, 1)
+     *     new Vec3(1, 1, 0),
+     *     new Vec3(1, 1, 1)
      * ];
      * const colors = [
      *     // Line 1
-     *     pc.Color.RED,
-     *     pc.Color.YELLOW,
+     *     Color.RED,
+     *     Color.YELLOW,
      *     // Line 2
-     *     pc.Color.CYAN,
-     *     pc.Color.BLUE
+     *     Color.CYAN,
+     *     Color.BLUE
      * ];
      * app.drawLines(points, colors);
      */
@@ -1705,8 +1705,8 @@ class AppBase extends EventHandler {
      * @param {Layer} [layer] - The layer to render the sphere into. Defaults to {@link LAYERID_IMMEDIATE}.
      * @example
      * // Render a red wire sphere with radius of 1
-     * const center = new pc.Vec3(0, 0, 0);
-     * app.drawWireSphere(center, 1.0, pc.Color.RED);
+     * const center = new Vec3(0, 0, 0);
+     * app.drawWireSphere(center, 1.0, Color.RED);
      * @ignore
      */
     drawWireSphere(center, radius, color = Color.WHITE, segments = 20, depthTest = true, layer = this.scene.defaultDrawLayer) {
@@ -1725,9 +1725,9 @@ class AppBase extends EventHandler {
      * @param {Mat4} [mat] - Matrix to transform the box before rendering.
      * @example
      * // Render a red wire aligned box
-     * const min = new pc.Vec3(-1, -1, -1);
-     * const max = new pc.Vec3(1, 1, 1);
-     * app.drawWireAlignedBox(min, max, pc.Color.RED);
+     * const min = new Vec3(-1, -1, -1);
+     * const max = new Vec3(1, 1, 1);
+     * app.drawWireAlignedBox(min, max, Color.RED);
      * @ignore
      */
     drawWireAlignedBox(minPoint, maxPoint, color = Color.WHITE, depthTest = true, layer = this.scene.defaultDrawLayer, mat) {

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -114,7 +114,7 @@ class Application extends AppBase {
      * @param {string[]} [options.scriptsOrder] - Scripts in order of loading first.
      * @example
      * // Engine-only example: create the application manually
-     * const app = new pc.Application(canvas, options);
+     * const app = new Application(canvas, options);
      *
      * // Start the application's main loop
      * app.start();

--- a/src/framework/asset/asset-list-loader.js
+++ b/src/framework/asset/asset-list-loader.js
@@ -66,9 +66,9 @@ class AssetListLoader extends EventHandler {
      * of Asset IDs to load.
      * @param {AssetRegistry} assetRegistry - The application's asset registry.
      * @example
-     * const assetListLoader = new pc.AssetListLoader([
-     *     new pc.Asset("texture1", "texture", { url: 'http://example.com/my/assets/here/texture1.png' }),
-     *     new pc.Asset("texture2", "texture", { url: 'http://example.com/my/assets/here/texture2.png' })
+     * const assetListLoader = new AssetListLoader([
+     *     new Asset("texture1", "texture", { url: 'http://example.com/my/assets/here/texture1.png' }),
+     *     new Asset("texture2", "texture", { url: 'http://example.com/my/assets/here/texture2.png' })
      * ], app.assets);
      */
     constructor(assetList, assetRegistry) {

--- a/src/framework/asset/asset-reference.js
+++ b/src/framework/asset/asset-reference.js
@@ -74,7 +74,7 @@ class AssetReference {
      * unload(propertyName, parent, asset).
      * @param {object} [scope] - The scope to call the callbacks in.
      * @example
-     * const reference = new pc.AssetReference('textureAsset', this, this.app.assets, {
+     * const reference = new AssetReference('textureAsset', this, this.app.assets, {
      *     load: this.onTextureAssetLoad,
      *     add: this.onTextureAssetAdd,
      *     remove: this.onTextureAssetRemove

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -252,7 +252,7 @@ class AssetRegistry extends EventHandler {
      *
      * @param {Asset} asset - The asset to add.
      * @example
-     * const asset = new pc.Asset("My Asset", "texture", {
+     * const asset = new Asset("My Asset", "texture", {
      *     url: "../path/to/image.jpg"
      * });
      * app.assets.add(asset);

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -254,7 +254,7 @@ class Asset extends EventHandler {
      * For more details on crossOrigin and its use, see
      * https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin.
      * @example
-     * const asset = new pc.Asset("a texture", "texture", {
+     * const asset = new Asset("a texture", "texture", {
      *     url: "http://example.com/my/assets/here/texture.png"
      * });
      */

--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -22,7 +22,7 @@ import { AnimTrack } from '../../anim/evaluator/anim-track.js';
  * to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('anim', {
  *     activate: true,
  *     speed: 1
@@ -378,7 +378,7 @@ class AnimComponent extends Component {
      * @param {object[]} [mask] - A list of paths to bones in the model which should be animated in
      * this layer. If omitted the full model is used. Defaults to null.
      * @param {string} [blendType] - Defines how properties animated by this layer blend with
-     * animations of those properties in previous layers. Defaults to pc.ANIM_LAYER_OVERWRITE.
+     * animations of those properties in previous layers. Defaults to ANIM_LAYER_OVERWRITE.
      * @returns {AnimComponentLayer} The created anim component layer.
      */
     addLayer(name, weight, mask, blendType) {

--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -21,7 +21,7 @@ import { Component } from '../component.js';
  * AnimationComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('animation', {
  *     assets: [animationAsset.id],
  *     speed: 1

--- a/src/framework/components/audio-listener/component.js
+++ b/src/framework/components/audio-listener/component.js
@@ -9,7 +9,7 @@ import { Component } from '../component.js';
  * AudioListenerComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('audiolistener');
  * ```
  *

--- a/src/framework/components/button/component.js
+++ b/src/framework/components/button/component.js
@@ -51,9 +51,9 @@ STATES_TO_SPRITE_FRAME_NAMES[VisualState.INACTIVE] = 'inactiveSpriteFrame';
  * ButtonComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('element', {
- *     type: pc.ELEMENTTYPE_IMAGE,
+ *     type: ELEMENTTYPE_IMAGE,
  *     useInput: true
  * });
  * entity.addComponent('button');
@@ -63,7 +63,7 @@ STATES_TO_SPRITE_FRAME_NAMES[VisualState.INACTIVE] = 'inactiveSpriteFrame';
  * {@link Entity#button} property:
  *
  * ```javascript
- * entity.button.hoverTint = pc.Color.YELLOW; // Set the hover tint color
+ * entity.button.hoverTint = Color.YELLOW; // Set the hover tint color
  *
  * console.log(entity.button.hoverTint);      // Get the hover tint color and print it
  * ```

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -43,7 +43,7 @@ import { PostEffectQueue } from './post-effect-queue.js';
  * to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('camera', {
  *     nearClip: 1,
  *     farClip: 100,
@@ -1309,7 +1309,7 @@ class CameraComponent extends Component {
      * depth sensing system.
      * @example
      * // On an entity with a camera component
-     * this.entity.camera.startXr(pc.XRTYPE_VR, pc.XRSPACE_LOCAL, {
+     * this.entity.camera.startXr(XRTYPE_VR, XRSPACE_LOCAL, {
      *     callback: (err) => {
      *         if (err) {
      *             // failed to start XR session

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -25,14 +25,14 @@ const _quat = new Quat();
  * CollisionComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('collision'); // This defaults to 1x1x1 box-shaped trigger volume
  * ```
  *
  * To create a 0.5 radius dynamic rigid body sphere:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('collision', {
  *     type: 'sphere'
  * });

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -52,7 +52,7 @@ const tmpCorners = [new Vec3(), new Vec3(), new Vec3(), new Vec3()];
  * ElementComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('element'); // This defaults to a 'group' element
  * ```
  *
@@ -60,12 +60,12 @@ const tmpCorners = [new Vec3(), new Vec3(), new Vec3(), new Vec3()];
  *
  * ```javascript
  * entity.addComponent('element', {
- *     anchor: new pc.Vec4(0.5, 0.5, 0.5, 0.5), // centered anchor
+ *     anchor: new Vec4(0.5, 0.5, 0.5, 0.5), // centered anchor
  *     fontAsset: fontAsset,
  *     fontSize: 128,
- *     pivot: new pc.Vec2(0.5, 0.5),            // centered pivot
+ *     pivot: new Vec2(0.5, 0.5),            // centered pivot
  *     text: 'Hello World!',
- *     type: pc.ELEMENTTYPE_TEXT
+ *     type: ELEMENTTYPE_TEXT
  * });
  * ```
  *
@@ -73,7 +73,7 @@ const tmpCorners = [new Vec3(), new Vec3(), new Vec3(), new Vec3()];
  * {@link Entity#element} property:
  *
  * ```javascript
- * entity.element.color = pc.Color.RED; // Set the element's color to red
+ * entity.element.color = Color.RED; // Set the element's color to red
  *
  * console.log(entity.element.color);   // Get the element's color and print it
  * ```
@@ -405,7 +405,7 @@ class ElementComponent extends Component {
      * will make the component resize exactly as its parent.
      *
      * @example
-     * this.entity.element.anchor = new pc.Vec4(Math.random() * 0.1, 0, 1, 0);
+     * this.entity.element.anchor = new Vec4(Math.random() * 0.1, 0, 1, 0);
      * @example
      * this.entity.element.anchor = [Math.random() * 0.1, 0, 1, 0];
      *
@@ -745,7 +745,7 @@ class ElementComponent extends Component {
      * @example
      * this.entity.element.pivot = [Math.random() * 0.1, Math.random() * 0.1];
      * @example
-     * this.entity.element.pivot = new pc.Vec2(Math.random() * 0.1, Math.random() * 0.1);
+     * this.entity.element.pivot = new Vec2(Math.random() * 0.1, Math.random() * 0.1);
      *
      * @type {Vec2 | number[]}
      */
@@ -1937,7 +1937,7 @@ class ElementComponent extends Component {
      * @type {Vec2}
      * @example
      * // drop shadow, down and to the right of the text
-     * this.entity.element.shadowOffset = new pc.Vec2(0.25, -0.25);
+     * this.entity.element.shadowOffset = new Vec2(0.25, -0.25);
      */
     set shadowOffset(arg) {
         this._setValue('shadowOffset', arg);

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -34,7 +34,7 @@ const UNIFIED_LEGACY_HINT = 'GSplatComponent#unified now defaults to true (unifi
  * GSplatComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('gsplat', {
  *     asset: asset
  * });
@@ -44,7 +44,7 @@ const UNIFIED_LEGACY_HINT = 'GSplatComponent#unified now defaults to true (unifi
  * property:
  *
  * ```javascript
- * entity.gsplat.customAabb = new pc.BoundingBox(new pc.Vec3(), new pc.Vec3(10, 10, 10));
+ * entity.gsplat.customAabb = new BoundingBox(new Vec3(), new Vec3(10, 10, 10));
  *
  * console.log(entity.gsplat.customAabb);
  * ```
@@ -955,7 +955,7 @@ class GSplatComponent extends Component {
      * @example
      * // Add an instance stream to the resource format
      * resource.format.addExtraStreams([
-     *     { name: 'instanceTint', format: pc.PIXELFORMAT_RGBA8, storage: pc.GSPLAT_STREAM_INSTANCE }
+     *     { name: 'instanceTint', format: PIXELFORMAT_RGBA8, storage: GSPLAT_STREAM_INSTANCE }
      * ]);
      *
      * // Get the instance texture and fill it with data

--- a/src/framework/components/joint/component.js
+++ b/src/framework/components/joint/component.js
@@ -82,15 +82,15 @@ function setVec3(target, value) {
  * ```javascript
  * // Create a door hinge: the joint entity's position is the hinge point and its
  * // local X axis (rotated here to point up) is the hinge axis
- * const hinge = new pc.Entity('hinge');
+ * const hinge = new Entity('hinge');
  * hinge.setPosition(1, 1, 0);
  * hinge.setEulerAngles(0, 0, 90);
  * hinge.addComponent('joint', {
- *     type: pc.JOINTTYPE_HINGE,
+ *     type: JOINTTYPE_HINGE,
  *     entityA: door,
  *     entityB: doorFrame,
  *     enableLimits: true,
- *     limits: new pc.Vec2(0, 110)
+ *     limits: new Vec2(0, 110)
  * });
  * app.root.addChild(hinge);
  * ```

--- a/src/framework/components/layout-child/component.js
+++ b/src/framework/components/layout-child/component.js
@@ -9,9 +9,9 @@ import { Component } from '../component.js';
  * LayoutChildComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('element', {
- *     type: pc.ELEMENTTYPE_IMAGE
+ *     type: ELEMENTTYPE_IMAGE
  * });
  * entity.addComponent('layoutchild', {
  *     minWidth: 50,

--- a/src/framework/components/layout-group/component.js
+++ b/src/framework/components/layout-group/component.js
@@ -28,13 +28,13 @@ function isEnabledAndHasEnabledElement(entity) {
  * LayoutGroupComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('element', {
- *     type: pc.ELEMENTTYPE_GROUP
+ *     type: ELEMENTTYPE_GROUP
  * });
  * entity.addComponent('layoutgroup', {
- *     orientation: pc.ORIENTATION_HORIZONTAL,
- *     spacing: new pc.Vec2(10, 0)
+ *     orientation: ORIENTATION_HORIZONTAL,
+ *     spacing: new Vec2(10, 0)
  * });
  * ```
  *
@@ -42,7 +42,7 @@ function isEnabledAndHasEnabledElement(entity) {
  * {@link Entity#layoutgroup} property:
  *
  * ```javascript
- * entity.layoutgroup.spacing = new pc.Vec2(20, 0); // Increase spacing between children
+ * entity.layoutgroup.spacing = new Vec2(20, 0); // Increase spacing between children
  *
  * console.log(entity.layoutgroup.spacing);         // Get the spacing and print it
  * ```

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -77,10 +77,10 @@ const _properties = [
  * to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('light', {
  *     type: 'omni',
- *     color: new pc.Color(1, 0, 0),
+ *     color: new Color(1, 0, 0),
  *     intensity: 2
  * });
  * ```

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -33,7 +33,7 @@ import { Component } from '../component.js';
  * to an Entity, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('model', {
  *     type: 'box'
  * });

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -103,7 +103,7 @@ let depthLayer;
  * ParticleSystemComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('particlesystem', {
  *     numParticles: 100,
  *     lifetime: 2,

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -33,7 +33,7 @@ import { EventHandler } from '../../core/event-handler.js';
  *
  * ```javascript
  * // Set the gravity to zero
- * app.systems.rigidbody.gravity = new pc.Vec3(0, 0, 0);
+ * app.systems.rigidbody.gravity = new Vec3(0, 0, 0);
  *
  * // Set the volume to 50%
  * app.systems.sound.volume = 0.5;

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -34,7 +34,7 @@ import { Component } from '../component.js';
  * to an Entity, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     type: 'box'
  * });

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -32,7 +32,7 @@ const _vecB = new Vec3();
  *
  * ```javascript
  * // Create a static 1x1x1 box-shaped rigid body
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('collision'); // Without options, this defaults to a 1x1x1 box shape
  * entity.addComponent('rigidbody'); // Without options, this defaults to a 'static' body
  * ```
@@ -40,7 +40,7 @@ const _vecB = new Vec3();
  * To create a dynamic sphere with mass of 10, do:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('collision', {
  *     type: 'sphere'
  * });
@@ -716,7 +716,7 @@ class RigidBodyComponent extends Component {
      * const force = this.entity.forward.clone().mulScalar(100);
      *
      * // Calculate the world space relative offset
-     * const relativePoint = new pc.Vec3();
+     * const relativePoint = new Vec3();
      * const childEntity = this.entity.findByName('Engine');
      * relativePoint.sub2(childEntity.getPosition(), this.entity.getPosition());
      *
@@ -777,7 +777,7 @@ class RigidBodyComponent extends Component {
      * @param {Vec3} torque - Vector representing the torque force in world space.
      * @returns {void}
      * @example
-     * const torque = new pc.Vec3(0, 10, 0);
+     * const torque = new Vec3(0, 10, 0);
      * entity.rigidbody.applyTorque(torque);
      */
     /**
@@ -832,13 +832,13 @@ class RigidBodyComponent extends Component {
      * @returns {void}
      * @example
      * // Apply an impulse along the world space positive y-axis at the entity's position.
-     * const impulse = new pc.Vec3(0, 10, 0);
+     * const impulse = new Vec3(0, 10, 0);
      * entity.rigidbody.applyImpulse(impulse);
      * @example
      * // Apply an impulse along the world space positive y-axis at 1 unit down the positive
      * // z-axis of the entity's local space.
-     * const impulse = new pc.Vec3(0, 10, 0);
-     * const relativePoint = new pc.Vec3(0, 0, 1);
+     * const impulse = new Vec3(0, 10, 0);
+     * const relativePoint = new Vec3(0, 0, 1);
      * entity.rigidbody.applyImpulse(impulse, relativePoint);
      */
     /**
@@ -895,7 +895,7 @@ class RigidBodyComponent extends Component {
      * @param {Vec3} torque - Vector representing the torque impulse in world space.
      * @returns {void}
      * @example
-     * const torque = new pc.Vec3(0, 10, 0);
+     * const torque = new Vec3(0, 10, 0);
      * entity.rigidbody.applyTorqueImpulse(torque);
      */
     /**
@@ -1056,11 +1056,11 @@ class RigidBodyComponent extends Component {
      * @returns {void}
      * @example
      * // Teleport the entity to the origin
-     * entity.rigidbody.teleport(pc.Vec3.ZERO);
+     * entity.rigidbody.teleport(Vec3.ZERO);
      * @example
      * // Teleport the entity to world space coordinate [1, 2, 3] and reset orientation
-     * const position = new pc.Vec3(1, 2, 3);
-     * entity.rigidbody.teleport(position, pc.Vec3.ZERO);
+     * const position = new Vec3(1, 2, 3);
+     * entity.rigidbody.teleport(position, Vec3.ZERO);
      */
     /**
      * Teleport an entity to a new world space position, optionally setting orientation. This
@@ -1072,11 +1072,11 @@ class RigidBodyComponent extends Component {
      * @returns {void}
      * @example
      * // Teleport the entity to the origin
-     * entity.rigidbody.teleport(pc.Vec3.ZERO);
+     * entity.rigidbody.teleport(Vec3.ZERO);
      * @example
      * // Teleport the entity to world space coordinate [1, 2, 3] and reset orientation
-     * const position = new pc.Vec3(1, 2, 3);
-     * entity.rigidbody.teleport(position, pc.Quat.IDENTITY);
+     * const position = new Vec3(1, 2, 3);
+     * entity.rigidbody.teleport(position, Quat.IDENTITY);
      */
     /**
      * @param {number|Vec3} x - X-coordinate of the new world space position or a vector holding

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -77,7 +77,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
      *
      * @example
      * // Set the gravity in the physics world to simulate a planet with low gravity
-     * app.systems.rigidbody.gravity = new pc.Vec3(0, -3.7, 0);
+     * app.systems.rigidbody.gravity = new Vec3(0, -3.7, 0);
      */
     gravity = new Vec3(0, -9.81, 0);
 

--- a/src/framework/components/screen/component.js
+++ b/src/framework/components/screen/component.js
@@ -29,9 +29,9 @@ const _transform = new Mat4();
  * to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('screen', {
- *     referenceResolution: new pc.Vec2(1280, 720),
+ *     referenceResolution: new Vec2(1280, 720),
  *     screenSpace: false
  * });
  * ```

--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -23,7 +23,7 @@ import { getScriptName, getScriptRegistryName, toLowerCamelCase } from '../../sc
  * ScriptComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('script');
  * ```
  *

--- a/src/framework/components/scroll-view/component.js
+++ b/src/framework/components/scroll-view/component.js
@@ -28,9 +28,9 @@ const _tempScrollValue = new Vec2();
  * ScrollViewComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('element', {
- *     type: pc.ELEMENTTYPE_GROUP,
+ *     type: ELEMENTTYPE_GROUP,
  *     useInput: true
  * });
  * entity.addComponent('scrollview', {
@@ -44,7 +44,7 @@ const _tempScrollValue = new Vec2();
  * {@link Entity#scrollview} property:
  *
  * ```javascript
- * entity.scrollview.scroll = new pc.Vec2(0, 1); // Scroll to the top
+ * entity.scrollview.scroll = new Vec2(0, 1); // Scroll to the top
  *
  * console.log(entity.scrollview.scroll);        // Get the scroll position and print it
  * ```

--- a/src/framework/components/scrollbar/component.js
+++ b/src/framework/components/scrollbar/component.js
@@ -23,20 +23,20 @@ import { ElementDragHelper } from '../element/element-drag-helper.js';
  *
  * ```javascript
  * // Create a child handle entity that the user can drag
- * const handle = new pc.Entity();
+ * const handle = new Entity();
  * handle.addComponent('element', {
- *     type: pc.ELEMENTTYPE_IMAGE,
+ *     type: ELEMENTTYPE_IMAGE,
  *     useInput: true
  * });
  *
  * // Create the scrollbar entity and wire in the handle
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addChild(handle);
  * entity.addComponent('element', {
- *     type: pc.ELEMENTTYPE_IMAGE
+ *     type: ELEMENTTYPE_IMAGE
  * });
  * entity.addComponent('scrollbar', {
- *     orientation: pc.ORIENTATION_VERTICAL,
+ *     orientation: ORIENTATION_VERTICAL,
  *     value: 0,
  *     handleSize: 0.5,
  *     handleEntity: handle

--- a/src/framework/components/sound/component.js
+++ b/src/framework/components/sound/component.js
@@ -22,7 +22,7 @@ import { SoundSlot } from './slot.js';
  * to an Entity, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('sound', {
  *     volume: 0.8,
  *     positional: true

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -40,7 +40,7 @@ const PARAM_ATLAS_RECT = 'atlasRect';
  * SpriteComponent to an {@link Entity}, use {@link Entity#addComponent}:
  *
  * ```javascript
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('sprite', {
  *     spriteAsset: spriteAsset
  * });
@@ -50,7 +50,7 @@ const PARAM_ATLAS_RECT = 'atlasRect';
  * {@link Entity#sprite} property:
  *
  * ```javascript
- * entity.sprite.color = pc.Color.RED; // Tint the sprite red
+ * entity.sprite.color = Color.RED; // Tint the sprite red
  *
  * console.log(entity.sprite.color);   // Get the sprite tint and print it
  * ```

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -66,9 +66,9 @@ class ComponentSystem extends EventHandler {
      * @param {object} [data] - The source data with which to create the component.
      * @returns {Component} Returns a Component of type defined by the component system.
      * @example
-     * const entity = new pc.Entity(app);
+     * const entity = new Entity(app);
      * app.systems.model.addComponent(entity, { type: 'box' });
-     * // entity.model is now set to a pc.ModelComponent
+     * // entity.model is now set to a ModelComponent
      * @ignore
      */
     addComponent(entity, data = {}) {

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -89,16 +89,16 @@ const releaseTempArray = (a) => {
  *
  * @example
  * // Create an entity, give it a camera component, position it, and add it to the scene
- * const camera = new pc.Entity('camera');
+ * const camera = new Entity('camera');
  * camera.addComponent('camera', {
- *     clearColor: new pc.Color(0.1, 0.1, 0.1)
+ *     clearColor: new Color(0.1, 0.1, 0.1)
  * });
  * camera.setPosition(0, 0, 10);
  * app.root.addChild(camera);
  * @example
  * // Entities form a hierarchy: a child inherits its parent's transform
- * const parent = new pc.Entity('parent');
- * const child = new pc.Entity('child');
+ * const parent = new Entity('parent');
+ * const child = new Entity('child');
  * parent.addChild(child);
  * parent.setLocalPosition(5, 0, 0); // moves both parent and child
  */
@@ -324,7 +324,7 @@ class Entity extends GraphNode {
      * @param {AppBase} [app] - The application the entity belongs to, default is the current
      * application.
      * @example
-     * const entity = new pc.Entity();
+     * const entity = new Entity();
      *
      * // Add a Component to the Entity
      * entity.addComponent('camera', {
@@ -390,7 +390,7 @@ class Entity extends GraphNode {
      * @returns {Component|null} The new Component that was attached to the entity or null if there
      * was an error.
      * @example
-     * const entity = new pc.Entity();
+     * const entity = new Entity();
      *
      * // Add a light component with default properties
      * entity.addComponent("light");
@@ -398,7 +398,7 @@ class Entity extends GraphNode {
      * // Add a camera component with some specified properties
      * entity.addComponent("camera", {
      *     fov: 45,
-     *     clearColor: new pc.Color(1, 0, 0)
+     *     clearColor: new Color(1, 0, 0)
      * });
      */
     addComponent(type, data) {
@@ -419,7 +419,7 @@ class Entity extends GraphNode {
      *
      * @param {string} type - The name of the Component type.
      * @example
-     * const entity = new pc.Entity();
+     * const entity = new Entity();
      * entity.addComponent("light"); // add new light component
      *
      * entity.removeComponent("light"); // remove light component

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -44,7 +44,7 @@ const _int32View = new Int32Array(_floatView.buffer);
  *
  * @example
  * // Create a picker with depth picking enabled at quarter resolution
- * const picker = new pc.Picker(app, canvas.width * 0.25, canvas.height * 0.25, true);
+ * const picker = new Picker(app, canvas.width * 0.25, canvas.height * 0.25, true);
  *
  * // In your update loop, prepare the picker
  * picker.resize(canvas.width * 0.25, canvas.height * 0.25);

--- a/src/framework/gsplat/gsplat-processor.js
+++ b/src/framework/gsplat/gsplat-processor.js
@@ -58,7 +58,7 @@ import wgslGsplatProcess from '../../scene/shader-lib/wgsl/chunks/gsplat/frag/gs
  *
  * @example
  * // Create a processor that reads splat positions and writes to a customColor texture
- * const processor = new pc.GSplatProcessor(
+ * const processor = new GSplatProcessor(
  *     app.graphicsDevice,
  *     { component: entity.gsplat },  // source: all streams auto-bound
  *     { component: entity.gsplat, streams: ['customColor'] }, // destination: customColor stream only

--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -60,7 +60,7 @@ class ContainerResource {
      *     const renders = entity.findComponents("render");
      *     renders.forEach((render) => {
      *         render.meshInstances.forEach((meshInstance) => {
-     *             meshInstance.material.blendType = pc.BLEND_MULTIPLICATIVE;
+     *             meshInstance.material.blendType = BLEND_MULTIPLICATIVE;
      *             meshInstance.material.update();
      *         });
      *     });
@@ -157,7 +157,7 @@ class ContainerResource {
  * For example, to receive a texture preprocess callback:
  *
  * ```javascript
- * const containerAsset = new pc.Asset(filename, 'container', { url: url, filename: filename }, null, {
+ * const containerAsset = new Asset(filename, 'container', { url: url, filename: filename }, null, {
  *     texture: {
  *         preprocess: (gltfTexture) => {
  *             console.log("texture preprocess");

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -61,7 +61,7 @@ class ResourceLoader {
      * supporting at least `load()` and `open()`.
      * @example
      * const loader = new ResourceLoader();
-     * loader.addHandler("json", new pc.JsonHandler());
+     * loader.addHandler("json", new JsonHandler());
      */
     addHandler(type, handler) {
         this._handlers[type] = handler;

--- a/src/framework/i18n/i18n.js
+++ b/src/framework/i18n/i18n.js
@@ -148,7 +148,7 @@ class I18n extends EventHandler {
      * @example
      * // With a defined dictionary of locales
      * const availableLocales = { en: 'en-US', fr: 'fr-FR' };
-     * const locale = pc.I18n.getText('en-US', availableLocales);
+     * const locale = I18n.getText('en-US', availableLocales);
      * // returns 'en'
      * @ignore
      */

--- a/src/framework/script.js
+++ b/src/framework/script.js
@@ -35,7 +35,7 @@ const script = {
      * @param {CreateScreenCallback} callback - A function which can set up and tear down a
      * customized loading screen.
      * @example
-     * pc.script.createLoadingScreen((app) => {
+     * script.createLoadingScreen((app) => {
      *     const showSplashScreen = () => {};
      *     const hideSplashScreen = () => {};
      *     const showProgress = (progress) => {};

--- a/src/framework/script/script-create.js
+++ b/src/framework/script/script-create.js
@@ -30,7 +30,7 @@ function getReservedScriptNames() {
  * which the developer is meant to further extend by adding attributes and prototype methods.
  * Returns null if there was an error.
  * @example
- * var Turning = pc.createScript('turn');
+ * var Turning = createScript('turn');
  *
  * // define 'speed' attribute that is available in Editor UI
  * Turning.attributes.add('speed', {
@@ -92,7 +92,7 @@ createScript.reservedAttributes = reservedAttributes;
  * the current {@link AppBase}.
  * @example
  * // define an ES6 script class
- * class PlayerController extends pc.ScriptType {
+ * class PlayerController extends ScriptType {
  *
  *     initialize() {
  *         // called once on initialize
@@ -104,9 +104,9 @@ createScript.reservedAttributes = reservedAttributes;
  * }
  *
  * // register the class as a script
- * pc.registerScript(PlayerController);
+ * registerScript(PlayerController);
  *
- * // declare script attributes (Must be after pc.registerScript())
+ * // declare script attributes (Must be after registerScript())
  * PlayerController.attributes.add('attribute1', {type: 'number'});
  * @category Script
  */

--- a/src/framework/script/script-registry.js
+++ b/src/framework/script/script-registry.js
@@ -94,12 +94,12 @@ class ScriptRegistry extends EventHandler {
      * @returns {boolean} True if the script was added for the first time. False if a script with
      * the same name already exists, or if the script has no resolvable name.
      * @example
-     * var PlayerController = pc.createScript('playerController');
-     * // playerController Script Type will be added to pc.ScriptRegistry automatically
+     * var PlayerController = createScript('playerController');
+     * // playerController Script Type will be added to ScriptRegistry automatically
      * console.log(app.scripts.has('playerController')); // outputs true
      * @example
      * // engine-only: register an ESM Script class manually
-     * class Rotator extends pc.Script {
+     * class Rotator extends Script {
      *     static scriptName = 'rotator';
      * }
      * app.scripts.add(Rotator);
@@ -283,7 +283,7 @@ class ScriptRegistry extends EventHandler {
      * @returns {boolean} True if {@link ScriptType} is in registry.
      * @example
      * if (app.scripts.has('playerController')) {
-     *     // playerController is in pc.ScriptRegistry
+     *     // playerController is in ScriptRegistry
      * }
      */
     has(nameOrType) {

--- a/src/framework/script/script-type.js
+++ b/src/framework/script/script-type.js
@@ -7,7 +7,7 @@ import { Script } from './script.js';
  */
 
 /**
- * This is the legacy format for creating a PlayCanvas script returned when calling `pc.createScript()`.
+ * This is the legacy format for creating a PlayCanvas script returned when calling `createScript()`.
  * Do not inherit from this class directly.
  *
  * @deprecated Use {@link Script} instead.
@@ -37,7 +37,7 @@ class ScriptType extends Script {
      *
      * @type {ScriptAttributes}
      * @example
-     * var PlayerController = pc.createScript('playerController');
+     * var PlayerController = createScript('playerController');
      *
      * PlayerController.attributes.add('speed', {
      *     type: 'number',
@@ -101,7 +101,7 @@ class ScriptType extends Script {
      *
      * @param {object} methods - Object with methods, where key - is name of method, and value - is function.
      * @example
-     * var PlayerController = pc.createScript('playerController');
+     * var PlayerController = createScript('playerController');
      *
      * PlayerController.extend({
      *     initialize: function () {

--- a/src/framework/xr/xr-anchors.js
+++ b/src/framework/xr/xr-anchors.js
@@ -25,7 +25,7 @@ import { XrAnchor } from './xr-anchor.js';
  * session with lots of movement.
  *
  * ```javascript
- * app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR, {
+ * app.xr.start(camera, XRTYPE_AR, XRSPACE_LOCALFLOOR, {
  *     anchors: true
  * });
  * ```

--- a/src/framework/xr/xr-dom-overlay.js
+++ b/src/framework/xr/xr-dom-overlay.js
@@ -13,7 +13,7 @@ import { platform } from '../../core/platform.js';
  *
  * ```javascript
  * app.xr.domOverlay.root = element;
- * app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR);
+ * app.xr.start(camera, XRTYPE_AR, XRSPACE_LOCALFLOOR);
  * ```
  *
  * ```javascript
@@ -102,7 +102,7 @@ class XrDomOverlay {
      * @type {Element|null}
      * @example
      * app.xr.domOverlay.root = element;
-     * app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR);
+     * app.xr.start(camera, XRTYPE_AR, XRSPACE_LOCALFLOOR);
      */
     set root(value) {
         if (!this._supported || this._manager.active) {

--- a/src/framework/xr/xr-hit-test-source.js
+++ b/src/framework/xr/xr-hit-test-source.js
@@ -24,7 +24,7 @@ const poolQuat = [];
  * ```javascript
  * // start a hit test from a viewer origin forward
  * app.xr.hitTest.start({
- *     spaceType: pc.XRSPACE_VIEWER,
+ *     spaceType: XRSPACE_VIEWER,
  *     callback: (err, hitTestSource) => {
  *         if (err) return;
  *         // subscribe to hit test results

--- a/src/framework/xr/xr-hit-test.js
+++ b/src/framework/xr/xr-hit-test.js
@@ -219,7 +219,7 @@ class XrHitTest extends EventHandler {
      * @example
      * // start hit testing from viewer position facing forwards
      * app.xr.hitTest.start({
-     *     spaceType: pc.XRSPACE_VIEWER,
+     *     spaceType: XRSPACE_VIEWER,
      *     callback: (err, hitTestSource) => {
      *         if (err) return;
      *         hitTestSource.on('result', (position, rotation) => {
@@ -229,9 +229,9 @@ class XrHitTest extends EventHandler {
      * });
      * @example
      * // start hit testing using an arbitrary ray
-     * const ray = new pc.Ray(new pc.Vec3(0, 0, 0), new pc.Vec3(0, -1, 0));
+     * const ray = new Ray(new Vec3(0, 0, 0), new Vec3(0, -1, 0));
      * app.xr.hitTest.start({
-     *     spaceType: pc.XRSPACE_LOCAL,
+     *     spaceType: XRSPACE_LOCAL,
      *     offsetRay: ray,
      *     callback: (err, hitTestSource) => {
      *         // hit test source that will sample real world geometry straight down

--- a/src/framework/xr/xr-input-source.js
+++ b/src/framework/xr/xr-input-source.js
@@ -45,7 +45,7 @@ class XrInputSource extends EventHandler {
      *
      * @event
      * @example
-     * const ray = new pc.Ray();
+     * const ray = new Ray();
      * inputSource.on('select', (evt) => {
      *     ray.set(inputSource.getOrigin(), inputSource.getDirection());
      *     if (obj.intersectsRay(ray)) {

--- a/src/framework/xr/xr-input.js
+++ b/src/framework/xr/xr-input.js
@@ -49,7 +49,7 @@ class XrInput extends EventHandler {
      *
      * @event
      * @example
-     * const ray = new pc.Ray();
+     * const ray = new Ray();
      * app.xr.input.on('select', (inputSource, evt) => {
      *     ray.set(inputSource.getOrigin(), inputSource.getDirection());
      *     if (obj.intersectsRay(ray)) {

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -67,7 +67,7 @@ class XrManager extends EventHandler {
      *     console.log(`XR type ${type} is now ${available ? 'available' : 'unavailable'}`);
      * });
      * @example
-     * app.xr.on(`available:${pc.XRTYPE_VR}`, (available) => {
+     * app.xr.on(`available:${XRTYPE_VR}`, (available) => {
      *     console.log(`XR type VR is now ${available ? 'available' : 'unavailable'}`);
      * });
      */
@@ -367,7 +367,7 @@ class XrManager extends EventHandler {
      * @returns {Promise<boolean>} Promise that resolves to true if a session of the given type is
      * reported supported on the given backend, false otherwise.
      * @example
-     * const supported = await pc.XrManager.isDeviceSupported(pc.DEVICETYPE_WEBGPU, pc.XRTYPE_VR);
+     * const supported = await XrManager.isDeviceSupported(DEVICETYPE_WEBGPU, XRTYPE_VR);
      * if (supported) {
      *     // a WebGPU device can be created and used to offer VR
      * }
@@ -473,11 +473,11 @@ class XrManager extends EventHandler {
      * be chosen by the underlying depth sensing system.
      * @example
      * button.on('click', () => {
-     *     app.xr.start(camera, pc.XRTYPE_VR, pc.XRSPACE_LOCALFLOOR);
+     *     app.xr.start(camera, XRTYPE_VR, XRSPACE_LOCALFLOOR);
      * });
      * @example
      * button.on('click', () => {
-     *     app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR, {
+     *     app.xr.start(camera, XRTYPE_AR, XRSPACE_LOCALFLOOR, {
      *         anchors: true,
      *         imageTracking: true,
      *         depthSensing: { }
@@ -640,7 +640,7 @@ class XrManager extends EventHandler {
      * ended. The callback has one argument Error - it is null if successfully ended XR session.
      * @example
      * app.keyboard.on('keydown', (evt) => {
-     *     if (evt.key === pc.KEY_ESCAPE && app.xr.active) {
+     *     if (evt.key === KEY_ESCAPE && app.xr.active) {
      *         app.xr.end();
      *     }
      * });
@@ -671,7 +671,7 @@ class XrManager extends EventHandler {
      * that is intended to be blended with real-world environment.
      *
      * @example
-     * if (app.xr.isAvailable(pc.XRTYPE_VR)) {
+     * if (app.xr.isAvailable(XRTYPE_VR)) {
      *     // VR is available
      * }
      * @returns {boolean} True if the specified session type is available.

--- a/src/framework/xr/xr-mesh-detection.js
+++ b/src/framework/xr/xr-mesh-detection.js
@@ -12,7 +12,7 @@ import { XrMesh } from './xr-mesh.js';
  *
  * ```javascript
  * // start session with plane detection enabled
- * app.xr.start(camera, pc.XRTYPE_AR, pc.XRSPACE_LOCALFLOOR, {
+ * app.xr.start(camera, XRTYPE_AR, XRSPACE_LOCALFLOOR, {
  *     meshDetection: true
  * });
  * ```

--- a/src/framework/xr/xr-plane-detection.js
+++ b/src/framework/xr/xr-plane-detection.js
@@ -12,7 +12,7 @@ import { XrPlane } from './xr-plane.js';
  *
  * ```javascript
  * // start session with plane detection enabled
- * app.xr.start(camera, pc.XRTYPE_VR, pc.XRSPACE_LOCALFLOOR, {
+ * app.xr.start(camera, XRTYPE_VR, XRSPACE_LOCALFLOOR, {
  *     planeDetection: true
  * });
  * ```

--- a/src/framework/xr/xr-plane.js
+++ b/src/framework/xr/xr-plane.js
@@ -176,12 +176,12 @@ class XrPlane extends EventHandler {
      * @type {DOMPointReadOnly[]}
      * @example
      * // prepare reusable objects
-     * const transform = new pc.Mat4();
-     * const vecA = new pc.Vec3();
-     * const vecB = new pc.Vec3();
+     * const transform = new Mat4();
+     * const vecA = new Vec3();
+     * const vecB = new Vec3();
      *
      * // update Mat4 to plane position and rotation
-     * transform.setTRS(plane.getPosition(), plane.getRotation(), pc.Vec3.ONE);
+     * transform.setTRS(plane.getPosition(), plane.getRotation(), Vec3.ONE);
      *
      * // draw lines between points
      * for (let i = 0; i < plane.points.length; i++) {
@@ -193,7 +193,7 @@ class XrPlane extends EventHandler {
      *     transform.transformPoint(vecB, vecB);
      *
      *     // render line
-     *     app.drawLine(vecA, vecB, pc.Color.WHITE);
+     *     app.drawLine(vecA, vecB, Color.WHITE);
      * }
      */
     get points() {

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -1163,7 +1163,7 @@ class GraphicsDevice extends EventHandler {
      * @example
      * // Render a single, unindexed triangle
      * device.draw({
-     *     type: pc.PRIMITIVE_TRIANGLES,
+     *     type: PRIMITIVE_TRIANGLES,
      *     base: 0,
      *     count: 3,
      *     indexed: false

--- a/src/platform/graphics/index-buffer.js
+++ b/src/platform/graphics/index-buffer.js
@@ -48,10 +48,10 @@ class IndexBuffer {
      * // Create an index buffer holding 3 16-bit indices. The buffer is marked as
      * // static, hinting that the buffer will never be modified.
      * const indices = new Uint16Array([0, 1, 2]);
-     * const indexBuffer = new pc.IndexBuffer(graphicsDevice,
-     *                                        pc.INDEXFORMAT_UINT16,
+     * const indexBuffer = new IndexBuffer(graphicsDevice,
+     *                                        INDEXFORMAT_UINT16,
      *                                        3,
-     *                                        pc.BUFFER_STATIC,
+     *                                        BUFFER_STATIC,
      *                                        indices);
      */
     constructor(graphicsDevice, format, numIndices, usage = BUFFER_STATIC, initialData, options) {

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -167,12 +167,12 @@ class RenderTarget {
      * depth resolve, as the depth cannot be sampled or copied out. Defaults to false.
      * @example
      * // Create a 512x512x24-bit render target with a depth buffer
-     * const colorBuffer = new pc.Texture(graphicsDevice, {
+     * const colorBuffer = new Texture(graphicsDevice, {
      *     width: 512,
      *     height: 512,
-     *     format: pc.PIXELFORMAT_RGB8
+     *     format: PIXELFORMAT_RGB8
      * });
-     * const renderTarget = new pc.RenderTarget({
+     * const renderTarget = new RenderTarget({
      *     colorBuffer: colorBuffer,
      *     depth: true
      * });

--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -120,13 +120,13 @@ class Shader {
      *
      * const shaderDefinition = {
      *     attributes: {
-     *         aPosition: pc.SEMANTIC_POSITION
+     *         aPosition: SEMANTIC_POSITION
      *     },
      *     vshader,
      *     fshader
      * };
      *
-     * const shader = new pc.Shader(graphicsDevice, shaderDefinition);
+     * const shader = new Shader(graphicsDevice, shaderDefinition);
      */
     constructor(graphicsDevice, definition) {
         this.id = id++;

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -257,10 +257,10 @@ class Texture {
      * a compute shader. Defaults to false.
      * @example
      * // Create a 8x8x24-bit texture
-     * const texture = new pc.Texture(graphicsDevice, {
+     * const texture = new Texture(graphicsDevice, {
      *     width: 8,
      *     height: 8,
-     *     format: pc.PIXELFORMAT_RGB8
+     *     format: PIXELFORMAT_RGB8
      * });
      *
      * // Fill the texture with a gradient

--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -45,7 +45,7 @@ import { ShaderDefinitionUtils } from './shader-definition-utils.js';
  *
  * ```javascript
  * // *** script asset ***
- * var TransformExample = pc.createScript('transformExample');
+ * var TransformExample = createScript('transformExample');
  *
  * // attribute that references shader asset and material
  * TransformExample.attributes.add('shaderCode', { type: 'asset', assetType: 'shader' });
@@ -53,9 +53,9 @@ import { ShaderDefinitionUtils } from './shader-definition-utils.js';
  *
  * TransformExample.prototype.initialize = function() {
  *     const device = this.app.graphicsDevice;
- *     const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, new pc.TorusGeometry({ tubeRadius: 0.01, ringRadius: 3 }));
- *     const meshInstance = new pc.MeshInstance(mesh, this.material.resource);
- *     const entity = new pc.Entity();
+ *     const mesh = Mesh.fromGeometry(app.graphicsDevice, new TorusGeometry({ tubeRadius: 0.01, ringRadius: 3 }));
+ *     const meshInstance = new MeshInstance(mesh, this.material.resource);
+ *     const entity = new Entity();
  *     entity.addComponent('render', {
  *         type: 'asset',
  *         meshInstances: [meshInstance]
@@ -65,8 +65,8 @@ import { ShaderDefinitionUtils } from './shader-definition-utils.js';
  *     // if webgl2 is not supported, transform-feedback is not available
  *     if (!device.isWebGL2) return;
  *     const inputBuffer = mesh.vertexBuffer;
- *     this.tf = new pc.TransformFeedback(inputBuffer);
- *     this.shader = pc.TransformFeedback.createShader(device, this.shaderCode.resource, "tfMoveUp");
+ *     this.tf = new TransformFeedback(inputBuffer);
+ *     this.shader = TransformFeedback.createShader(device, this.shaderCode.resource, "tfMoveUp");
  * };
  *
  * TransformExample.prototype.update = function(dt) {

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -124,15 +124,15 @@ class VertexFormat {
      * vertex format will be interleaved. (example: PNCPNCPNCPNC).
      * @example
      * // Specify 3-component positions (x, y, z)
-     * const vertexFormat = new pc.VertexFormat(graphicsDevice, [
-     *     { semantic: pc.SEMANTIC_POSITION, components: 3, type: pc.TYPE_FLOAT32 }
+     * const vertexFormat = new VertexFormat(graphicsDevice, [
+     *     { semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 }
      * ]);
      * @example
      * // Specify 2-component positions (x, y), a texture coordinate (u, v) and a vertex color (r, g, b, a)
-     * const vertexFormat = new pc.VertexFormat(graphicsDevice, [
-     *     { semantic: pc.SEMANTIC_POSITION, components: 2, type: pc.TYPE_FLOAT32 },
-     *     { semantic: pc.SEMANTIC_TEXCOORD0, components: 2, type: pc.TYPE_FLOAT32 },
-     *     { semantic: pc.SEMANTIC_COLOR, components: 4, type: pc.TYPE_UINT8, normalize: true }
+     * const vertexFormat = new VertexFormat(graphicsDevice, [
+     *     { semantic: SEMANTIC_POSITION, components: 2, type: TYPE_FLOAT32 },
+     *     { semantic: SEMANTIC_TEXCOORD0, components: 2, type: TYPE_FLOAT32 },
+     *     { semantic: SEMANTIC_COLOR, components: 4, type: TYPE_UINT8, normalize: true }
      * ]);
      */
     constructor(graphicsDevice, description, vertexCount) {

--- a/src/platform/graphics/vertex-iterator.js
+++ b/src/platform/graphics/vertex-iterator.js
@@ -261,15 +261,15 @@ class VertexIterator {
      *
      * @param {number} [count] - Number of steps to move on when calling next. Defaults to 1.
      * @example
-     * const iterator = new pc.VertexIterator(vertexBuffer);
-     * iterator.element[pc.SEMANTIC_POSITION].set(-0.9, -0.9, 0.0);
-     * iterator.element[pc.SEMANTIC_COLOR].set(255, 0, 0, 255);
+     * const iterator = new VertexIterator(vertexBuffer);
+     * iterator.element[SEMANTIC_POSITION].set(-0.9, -0.9, 0.0);
+     * iterator.element[SEMANTIC_COLOR].set(255, 0, 0, 255);
      * iterator.next();
-     * iterator.element[pc.SEMANTIC_POSITION].set(0.9, -0.9, 0.0);
-     * iterator.element[pc.SEMANTIC_COLOR].set(0, 255, 0, 255);
+     * iterator.element[SEMANTIC_POSITION].set(0.9, -0.9, 0.0);
+     * iterator.element[SEMANTIC_COLOR].set(0, 255, 0, 255);
      * iterator.next();
-     * iterator.element[pc.SEMANTIC_POSITION].set(0.0, 0.9, 0.0);
-     * iterator.element[pc.SEMANTIC_COLOR].set(0, 0, 255, 255);
+     * iterator.element[SEMANTIC_POSITION].set(0.0, 0.9, 0.0);
+     * iterator.element[SEMANTIC_COLOR].set(0, 0, 255, 255);
      * iterator.end();
      */
     next(count = 1) {
@@ -287,15 +287,15 @@ class VertexIterator {
      * buffer is unlocked and vertex data is uploaded to video memory.
      *
      * @example
-     * const iterator = new pc.VertexIterator(vertexBuffer);
-     * iterator.element[pc.SEMANTIC_POSITION].set(-0.9, -0.9, 0.0);
-     * iterator.element[pc.SEMANTIC_COLOR].set(255, 0, 0, 255);
+     * const iterator = new VertexIterator(vertexBuffer);
+     * iterator.element[SEMANTIC_POSITION].set(-0.9, -0.9, 0.0);
+     * iterator.element[SEMANTIC_COLOR].set(255, 0, 0, 255);
      * iterator.next();
-     * iterator.element[pc.SEMANTIC_POSITION].set(0.9, -0.9, 0.0);
-     * iterator.element[pc.SEMANTIC_COLOR].set(0, 255, 0, 255);
+     * iterator.element[SEMANTIC_POSITION].set(0.9, -0.9, 0.0);
+     * iterator.element[SEMANTIC_COLOR].set(0, 255, 0, 255);
      * iterator.next();
-     * iterator.element[pc.SEMANTIC_POSITION].set(0.0, 0.9, 0.0);
-     * iterator.element[pc.SEMANTIC_COLOR].set(0, 0, 255, 255);
+     * iterator.element[SEMANTIC_POSITION].set(0.0, 0.9, 0.0);
+     * iterator.element[SEMANTIC_COLOR].set(0, 0, 255, 255);
      * iterator.end();
      */
     end() {

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2130,14 +2130,14 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * // Clear just the color buffer to red
      * device.clear({
      *     color: [1, 0, 0, 1],
-     *     flags: pc.CLEARFLAG_COLOR
+     *     flags: CLEARFLAG_COLOR
      * });
      *
      * // Clear color buffer to yellow and depth to 1.0
      * device.clear({
      *     color: [1, 1, 0, 1],
      *     depth: 1,
-     *     flags: pc.CLEARFLAG_COLOR | pc.CLEARFLAG_DEPTH
+     *     flags: CLEARFLAG_COLOR | CLEARFLAG_DEPTH
      * });
      */
     clear(options) {

--- a/src/platform/input/controller.js
+++ b/src/platform/input/controller.js
@@ -59,10 +59,10 @@ class Controller {
      * @param {Mouse} [options.mouse] - A Mouse object to use.
      * @param {GamePads} [options.gamepads] - A Gamepads object to use.
      * @example
-     * const c = new pc.Controller(document);
+     * const c = new Controller(document);
      *
      * // Register the "fire" action and assign it to both the Enter key and the space bar.
-     * c.registerKeys("fire", [pc.KEY_ENTER, pc.KEY_SPACE]);
+     * c.registerKeys("fire", [KEY_ENTER, KEY_SPACE]);
      */
     constructor(element, options = {}) {
         this._keyboard = options.keyboard || null;
@@ -158,8 +158,8 @@ class Controller {
      * @param {string} action_name - The name of the action.
      * @param {object} action - An action object to add.
      * @param {ACTION_KEYBOARD | ACTION_MOUSE | ACTION_GAMEPAD} action.type - The name of the action.
-     * @param {number[]} [action.keys] - Keyboard: A list of keycodes e.g. `[pc.KEY_A, pc.KEY_ENTER]`.
-     * @param {number} [action.button] - Mouse: e.g. `pc.MOUSEBUTTON_LEFT` - Gamepad: e.g. `pc.PAD_FACE_1`
+     * @param {number[]} [action.keys] - Keyboard: A list of keycodes e.g. `[KEY_A, KEY_ENTER]`.
+     * @param {number} [action.button] - Mouse: e.g. `MOUSEBUTTON_LEFT` - Gamepad: e.g. `PAD_FACE_1`
      * @param {number} [action.pad] - Gamepad: An index of the pad to register (use {@link PAD_1}, etc).
      */
     appendAction(action_name, action) {

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -918,7 +918,7 @@ class GamePads extends EventHandler {
      * @returns {GamePad[]} An array of gamepads and mappings for the model of gamepad that is
      * attached.
      * @example
-     * const gamepads = new pc.GamePads();
+     * const gamepads = new GamePads();
      * const pads = gamepads.poll();
      */
     poll(pads = []) {

--- a/src/platform/input/keyboard-event.js
+++ b/src/platform/input/keyboard-event.js
@@ -40,7 +40,7 @@ class KeyboardEvent {
      * @param {globalThis.KeyboardEvent} event - The original browser event that was fired.
      * @example
      * const onKeyDown = function (e) {
-     *     if (e.key === pc.KEY_SPACE) {
+     *     if (e.key === KEY_SPACE) {
      *         // space key pressed
      *     }
      *     e.event.preventDefault(); // Use original browser event to prevent browser action.

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -70,7 +70,7 @@ class Keyboard extends EventHandler {
      * @event
      * @example
      * const onKeyDown = (e) => {
-     *     if (e.key === pc.KEY_SPACE) {
+     *     if (e.key === KEY_SPACE) {
      *         // space key pressed
      *     }
      *     e.event.preventDefault(); // Use original browser event to prevent browser action.
@@ -86,7 +86,7 @@ class Keyboard extends EventHandler {
      * @event
      * @example
      * const onKeyUp = (e) => {
-     *     if (e.key === pc.KEY_SPACE) {
+     *     if (e.key === KEY_SPACE) {
      *         // space key released
      *     }
      *     e.event.preventDefault(); // Use original browser event to prevent browser action.
@@ -165,7 +165,7 @@ class Keyboard extends EventHandler {
      * event.
      * @example
      * // attach keyboard listeners to the window
-     * const keyboard = new pc.Keyboard(window);
+     * const keyboard = new Keyboard(window);
      */
     constructor(element, options = {}) {
         super();

--- a/src/platform/net/http.js
+++ b/src/platform/net/http.js
@@ -169,7 +169,7 @@ class Http {
      * where data is the response (format depends on response type: text, Object, ArrayBuffer, XML) and
      * err is the error code.
      * @example
-     * pc.http.get("http://example.com/", {
+     * http.get("http://example.com/", {
      *     "retry": true,
      *     "maxRetries": 5
      * }, (err, response) => {
@@ -230,7 +230,7 @@ class Http {
      * Passed (err, data) where data is the response (format depends on response type: text,
      * Object, ArrayBuffer, XML) and err is the error code.
      * @example
-     * pc.http.post("http://example.com/", {
+     * http.post("http://example.com/", {
      *     "name": "Alex"
      * }, {
      *     "retry": true,
@@ -274,7 +274,7 @@ class Http {
      * Passed (err, data) where data is the response (format depends on response type: text,
      * Object, ArrayBuffer, XML) and err is the error code.
      * @example
-     * pc.http.put("http://example.com/", {
+     * http.put("http://example.com/", {
      *     "name": "Alex"
      * }, {
      *     "retry": true,
@@ -318,7 +318,7 @@ class Http {
      * Passed (err, data) where data is the response (format depends on response type: text,
      * Object, ArrayBuffer, XML) and err is the error code.
      * @example
-     * pc.http.del("http://example.com/", {
+     * http.del("http://example.com/", {
      *     "retry": true,
      *     "maxRetries": 5
      * }, (err, response) => {
@@ -360,7 +360,7 @@ class Http {
      * Passed (err, data) where data is the response (format depends on response type: text,
      * Object, ArrayBuffer, XML) and err is the error code.
      * @example
-     * pc.http.request("get", "http://example.com/", {
+     * http.request("get", "http://example.com/", {
      *     "retry": true,
      *     "maxRetries": 5
      * }, (err, response) => {

--- a/src/scene/geometry/box-geometry.js
+++ b/src/scene/geometry/box-geometry.js
@@ -18,13 +18,13 @@ const primitiveUv1PaddingScale = 1.0 - primitiveUv1Padding * 2;
  *
  * ```javascript
  * // Create a mesh instance
- * const geometry = new pc.BoxGeometry();
- * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
- * const material = new pc.StandardMaterial();
- * const meshInstance = new pc.MeshInstance(mesh, material);
+ * const geometry = new BoxGeometry();
+ * const mesh = Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new StandardMaterial();
+ * const meshInstance = new MeshInstance(mesh, material);
  *
  * // Create an entity
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     meshInstances: [meshInstance]
  * });
@@ -56,8 +56,8 @@ class BoxGeometry extends Geometry {
      * @param {number} [opts.yOffset] - Move the box vertically by given offset in local space. Pass
      * 0.5 to generate the box with pivot point at the bottom face. Defaults to 0.
      * @example
-     * const geometry = new pc.BoxGeometry({
-     *     halfExtents: new pc.Vec3(1, 1, 1),
+     * const geometry = new BoxGeometry({
+     *     halfExtents: new Vec3(1, 1, 1),
      *     widthSegments: 2,
      *     lengthSegments: 2,
      *     heightSegments: 2

--- a/src/scene/geometry/capsule-geometry.js
+++ b/src/scene/geometry/capsule-geometry.js
@@ -14,13 +14,13 @@ import { calculateTangents } from './geometry-utils.js';
  *
  * ```javascript
  * // Create a mesh instance
- * const geometry = new pc.CapsuleGeometry();
- * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
- * const material = new pc.StandardMaterial();
- * const meshInstance = new pc.MeshInstance(mesh, material);
+ * const geometry = new CapsuleGeometry();
+ * const mesh = Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new StandardMaterial();
+ * const meshInstance = new MeshInstance(mesh, material);
  *
  * // Create an entity
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     meshInstances: [meshInstance]
  * });
@@ -50,7 +50,7 @@ class CapsuleGeometry extends ConeBaseGeometry {
      * Defaults to 20.
      * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
      * @example
-     * const geometry = new pc.CapsuleGeometry({
+     * const geometry = new CapsuleGeometry({
      *     radius: 1,
      *     height: 2,
      *     heightSegments: 2,

--- a/src/scene/geometry/circle-geometry.js
+++ b/src/scene/geometry/circle-geometry.js
@@ -14,13 +14,13 @@ import { Geometry } from './geometry.js';
  *
  * ```javascript
  * // Create a mesh instance
- * const geometry = new pc.CircleGeometry();
- * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
- * const material = new pc.StandardMaterial();
- * const meshInstance = new pc.MeshInstance(mesh, material);
+ * const geometry = new CircleGeometry();
+ * const mesh = Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new StandardMaterial();
+ * const meshInstance = new MeshInstance(mesh, material);
  *
  * // Create an entity
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     meshInstances: [meshInstance]
  * });
@@ -51,7 +51,7 @@ class CircleGeometry extends Geometry {
      * tessellation detail) towards the center of the circle. Defaults to 1.
      * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
      * @example
-     * const geometry = new pc.CircleGeometry({
+     * const geometry = new CircleGeometry({
      *     radius: 100,
      *     sectors: 128,
      *     rings: 64,

--- a/src/scene/geometry/cone-geometry.js
+++ b/src/scene/geometry/cone-geometry.js
@@ -14,13 +14,13 @@ import { calculateTangents } from './geometry-utils.js';
  *
  * ```javascript
  * // Create a mesh instance
- * const geometry = new pc.ConeGeometry();
- * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
- * const material = new pc.StandardMaterial();
- * const meshInstance = new pc.MeshInstance(mesh, material);
+ * const geometry = new ConeGeometry();
+ * const mesh = Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new StandardMaterial();
+ * const meshInstance = new MeshInstance(mesh, material);
  *
  * // Create an entity
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     meshInstances: [meshInstance]
  * });
@@ -49,7 +49,7 @@ class ConeGeometry extends ConeBaseGeometry {
      * cone. Defaults to 18.
      * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
      * @example
-     * const geometry = new pc.ConeGeometry({
+     * const geometry = new ConeGeometry({
      *     baseRadius: 1,
      *     height: 2,
      *     heightSegments: 2,

--- a/src/scene/geometry/cylinder-geometry.js
+++ b/src/scene/geometry/cylinder-geometry.js
@@ -14,13 +14,13 @@ import { calculateTangents } from './geometry-utils.js';
  *
  * ```javascript
  * // Create a mesh instance
- * const geometry = new pc.CylinderGeometry();
- * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
- * const material = new pc.StandardMaterial();
- * const meshInstance = new pc.MeshInstance(mesh, material);
+ * const geometry = new CylinderGeometry();
+ * const mesh = Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new StandardMaterial();
+ * const meshInstance = new MeshInstance(mesh, material);
  *
  * // Create an entity
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     meshInstances: [meshInstance]
  * });
@@ -49,7 +49,7 @@ class CylinderGeometry extends ConeBaseGeometry {
      * cylinder. Defaults to 20.
      * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
      * @example
-     * const geometry = new pc.CylinderGeometry({
+     * const geometry = new CylinderGeometry({
      *     radius: 1,
      *     height: 2,
      *     heightSegments: 2,

--- a/src/scene/geometry/dome-geometry.js
+++ b/src/scene/geometry/dome-geometry.js
@@ -13,13 +13,13 @@ import { SphereGeometry } from './sphere-geometry.js';
  *
  * ```javascript
  * // Create a mesh instance
- * const geometry = new pc.DomeGeometry();
- * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
- * const material = new pc.StandardMaterial();
- * const meshInstance = new pc.MeshInstance(mesh, material);
+ * const geometry = new DomeGeometry();
+ * const mesh = Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new StandardMaterial();
+ * const meshInstance = new MeshInstance(mesh, material);
  *
  * // Create an entity
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     meshInstances: [meshInstance]
  * });
@@ -43,7 +43,7 @@ class DomeGeometry extends SphereGeometry {
      * @param {number} [opts.longitudeBands] - The number of divisions along the longitudinal axis of
      * the sphere. Defaults to 16.
      * @example
-     * const geometry = new pc.DomeGeometry({
+     * const geometry = new DomeGeometry({
      *     latitudeBands: 32,
      *     longitudeBands: 32
      * });

--- a/src/scene/geometry/geometry-utils.js
+++ b/src/scene/geometry/geometry-utils.js
@@ -8,7 +8,7 @@ import { Vec3 } from '../../core/math/vec3.js';
  * @param {number[]} indices - An array of triangle indices.
  * @returns {number[]} An array of 3-dimensional vertex normals.
  * @example
- * const normals = pc.calculateNormals(positions, indices);
+ * const normals = calculateNormals(positions, indices);
  * @category Graphics
  */
 const calculateNormals = (positions, indices) => {
@@ -77,7 +77,7 @@ const calculateNormals = (positions, indices) => {
  * @param {number[]} indices - An array of triangle indices.
  * @returns {number[]} An array of 3-dimensional vertex tangents.
  * @example
- * const tangents = pc.calculateTangents(positions, normals, uvs, indices);
+ * const tangents = calculateTangents(positions, normals, uvs, indices);
  * @category Graphics
  */
 const calculateTangents = (positions, normals, uvs, indices) => {

--- a/src/scene/geometry/plane-geometry.js
+++ b/src/scene/geometry/plane-geometry.js
@@ -15,13 +15,13 @@ import { Geometry } from './geometry.js';
  *
  * ```javascript
  * // Create a mesh instance
- * const geometry = new pc.PlaneGeometry();
- * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
- * const material = new pc.StandardMaterial();
- * const meshInstance = new pc.MeshInstance(mesh, material);
+ * const geometry = new PlaneGeometry();
+ * const mesh = Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new StandardMaterial();
+ * const meshInstance = new MeshInstance(mesh, material);
  *
  * // Create an entity
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     meshInstances: [meshInstance]
  * });
@@ -49,8 +49,8 @@ class PlaneGeometry extends Geometry {
      * Defaults to 5.
      * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
      * @example
-     * const geometry = new pc.PlaneGeometry({
-     *     halfExtents: new pc.Vec2(1, 1),
+     * const geometry = new PlaneGeometry({
+     *     halfExtents: new Vec2(1, 1),
      *     widthSegments: 10,
      *     lengthSegments: 10
      * });

--- a/src/scene/geometry/sphere-geometry.js
+++ b/src/scene/geometry/sphere-geometry.js
@@ -14,13 +14,13 @@ import { Geometry } from './geometry.js';
  *
  * ```javascript
  * // Create a mesh instance
- * const geometry = new pc.SphereGeometry();
- * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
- * const material = new pc.StandardMaterial();
- * const meshInstance = new pc.MeshInstance(mesh, material);
+ * const geometry = new SphereGeometry();
+ * const mesh = Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new StandardMaterial();
+ * const meshInstance = new MeshInstance(mesh, material);
  *
  * // Create an entity
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     meshInstances: [meshInstance]
  * });
@@ -47,7 +47,7 @@ class SphereGeometry extends Geometry {
      * the sphere. Defaults to 16.
      * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
      * @example
-     * const geometry = new pc.SphereGeometry({
+     * const geometry = new SphereGeometry({
      *     radius: 1,
      *     latitudeBands: 32,
      *     longitudeBands: 32

--- a/src/scene/geometry/torus-geometry.js
+++ b/src/scene/geometry/torus-geometry.js
@@ -15,13 +15,13 @@ import { Geometry } from './geometry.js';
  *
  * ```javascript
  * // Create a mesh instance
- * const geometry = new pc.TorusGeometry();
- * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, geometry);
- * const material = new pc.StandardMaterial();
- * const meshInstance = new pc.MeshInstance(mesh, material);
+ * const geometry = new TorusGeometry();
+ * const mesh = Mesh.fromGeometry(app.graphicsDevice, geometry);
+ * const material = new StandardMaterial();
+ * const meshInstance = new MeshInstance(mesh, material);
  *
  * // Create an entity
- * const entity = new pc.Entity();
+ * const entity = new Entity();
  * entity.addComponent('render', {
  *     meshInstances: [meshInstance]
  * });
@@ -52,7 +52,7 @@ class TorusGeometry extends Geometry {
      * Defaults to 30.
      * @param {boolean} [opts.calculateTangents] - Generate tangent information. Defaults to false.
      * @example
-     * const geometry = new pc.TorusGeometry({
+     * const geometry = new TorusGeometry({
      *     tubeRadius: 1,
      *     ringRadius: 2,
      *     sectorAngle: 360,

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -962,7 +962,7 @@ class GraphNode extends EventHandler {
      * @returns {void}
      * @example
      * // Set rotation of 90 degrees around y-axis via a vector
-     * const angles = new pc.Vec3(0, 90, 0);
+     * const angles = new Vec3(0, 90, 0);
      * this.entity.setLocalEulerAngles(angles);
      */
     /**
@@ -996,7 +996,7 @@ class GraphNode extends EventHandler {
      * @param {Vec3} position - Vector holding local space position.
      * @returns {void}
      * @example
-     * const pos = new pc.Vec3(0, 10, 0);
+     * const pos = new Vec3(0, 10, 0);
      * this.entity.setLocalPosition(pos);
      */
     /**
@@ -1035,7 +1035,7 @@ class GraphNode extends EventHandler {
      * @param {Quat} rotation - Quaternion holding local space rotation.
      * @returns {void}
      * @example
-     * const q = new pc.Quat();
+     * const q = new Quat();
      * this.entity.setLocalRotation(q);
      */
     /**
@@ -1074,7 +1074,7 @@ class GraphNode extends EventHandler {
      * @param {Vec3} scale - Vector holding local space scale.
      * @returns {void}
      * @example
-     * const scale = new pc.Vec3(10, 10, 10);
+     * const scale = new Vec3(10, 10, 10);
      * this.entity.setLocalScale(scale);
      */
     /**
@@ -1155,7 +1155,7 @@ class GraphNode extends EventHandler {
      * @param {Vec3} position - Vector holding world space position.
      * @returns {void}
      * @example
-     * const position = new pc.Vec3(0, 10, 0);
+     * const position = new Vec3(0, 10, 0);
      * this.entity.setPosition(position);
      */
     /**
@@ -1201,7 +1201,7 @@ class GraphNode extends EventHandler {
      * @param {Quat} rotation - Quaternion holding world space rotation.
      * @returns {void}
      * @example
-     * const rotation = new pc.Quat();
+     * const rotation = new Quat();
      * this.entity.setRotation(rotation);
      */
     /**
@@ -1237,8 +1237,8 @@ class GraphNode extends EventHandler {
      * @param {Vec3} position - The world space position to set.
      * @param {Quat} rotation - The world space rotation to set.
      * @example
-     * const position = new pc.Vec3(0, 10, 0);
-     * const rotation = new pc.Quat().setFromEulerAngles(0, 90, 0);
+     * const position = new Vec3(0, 10, 0);
+     * const rotation = new Quat().setFromEulerAngles(0, 90, 0);
      * this.entity.setPositionAndRotation(position, rotation);
      */
     setPositionAndRotation(position, rotation) {
@@ -1277,7 +1277,7 @@ class GraphNode extends EventHandler {
      * @param {Vec3} angles - Vector holding rotations around world space axes in degrees.
      * @returns {void}
      * @example
-     * const angles = new pc.Vec3(0, 90, 0);
+     * const angles = new Vec3(0, 90, 0);
      * this.entity.setEulerAngles(angles);
      */
     /**
@@ -1305,7 +1305,7 @@ class GraphNode extends EventHandler {
      *
      * @param {GraphNode} node - The new child to add.
      * @example
-     * const e = new pc.Entity(app);
+     * const e = new Entity(app);
      * this.entity.addChild(e);
      */
     addChild(node) {
@@ -1320,7 +1320,7 @@ class GraphNode extends EventHandler {
      *
      * @param {GraphNode} node - The child to add.
      * @example
-     * const e = new pc.Entity(app);
+     * const e = new Entity(app);
      * this.entity.addChildAndSaveTransform(e);
      * @ignore
      */
@@ -1345,7 +1345,7 @@ class GraphNode extends EventHandler {
      * @param {number} index - The index in the child list of the parent where the new node will be
      * inserted.
      * @example
-     * const e = new pc.Entity(app);
+     * const e = new Entity(app);
      * this.entity.insertChild(e, 1);
      */
     insertChild(node, index) {
@@ -1586,7 +1586,7 @@ class GraphNode extends EventHandler {
      * @example
      * // Look at another entity, using the negative world y-axis for up
      * const target = otherEntity.getPosition();
-     * this.entity.lookAt(target, pc.Vec3.DOWN);
+     * this.entity.lookAt(target, Vec3.DOWN);
      */
     /**
      * @param {number|Vec3} x - If passing a 3D vector, this is the world space coordinate to look at.
@@ -1637,7 +1637,7 @@ class GraphNode extends EventHandler {
      * @param {Vec3} translation - Vector holding world space translation.
      * @returns {void}
      * @example
-     * const translation = new pc.Vec3(10, 0, 0);
+     * const translation = new Vec3(10, 0, 0);
      * this.entity.translate(translation);
      */
     /**
@@ -1674,7 +1674,7 @@ class GraphNode extends EventHandler {
      * @param {Vec3} translation - Vector holding local space translation.
      * @returns {void}
      * @example
-     * const t = new pc.Vec3(10, 0, 0);
+     * const t = new Vec3(10, 0, 0);
      * this.entity.translateLocal(t);
      */
     /**
@@ -1717,7 +1717,7 @@ class GraphNode extends EventHandler {
      * @param {Vec3} rotation - Vector holding world space rotation.
      * @returns {void}
      * @example
-     * const rotation = new pc.Vec3(0, 90, 0);
+     * const rotation = new Vec3(0, 90, 0);
      * this.entity.rotate(rotation);
      */
     /**
@@ -1764,7 +1764,7 @@ class GraphNode extends EventHandler {
      * @param {Vec3} rotation - Vector holding local space rotation.
      * @returns {void}
      * @example
-     * const rotation = new pc.Vec3(0, 90, 0);
+     * const rotation = new Vec3(0, 90, 0);
      * this.entity.rotateLocal(rotation);
      */
     /**

--- a/src/scene/graphics/quad-render.js
+++ b/src/scene/graphics/quad-render.js
@@ -34,7 +34,7 @@ const _dynamicBindGroup = new DynamicBindGroup();
  * Example:
  *
  * ```javascript
- * const shader = pc.ShaderUtils.createShader(app.graphicsDevice, {
+ * const shader = ShaderUtils.createShader(app.graphicsDevice, {
  *     uniqueName: 'MyShader',
  *     attributes: { aPosition: SEMANTIC_POSITION },
  *     vertexGLSL: '// vertex shader code',

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -894,7 +894,7 @@ class GSplatParams {
      * // Add a custom stream to store per-splat component IDs
      * app.scene.gsplat.format.addExtraStreams([{
      *     name: 'splatId',
-     *     format: pc.PIXELFORMAT_R32U
+     *     format: PIXELFORMAT_R32U
      * }]);
      */
     get format() {
@@ -926,7 +926,7 @@ class GSplatParams {
      * // and read per fragment in gsplatModifyPS using getFlag()
      * app.scene.gsplat.varyings.add([{
      *     name: 'flag',
-     *     type: pc.TYPE_UINT32,
+     *     type: TYPE_UINT32,
      *     components: 1
      * }]);
      */

--- a/src/scene/gsplat-unified/gsplat-varyings.js
+++ b/src/scene/gsplat-unified/gsplat-varyings.js
@@ -171,7 +171,7 @@ class GSplatVaryings {
      * // and read per fragment in gsplatModifyPS using getFlag()
      * app.scene.gsplat.varyings.add([{
      *     name: 'flag',
-     *     type: pc.TYPE_UINT32,
+     *     type: TYPE_UINT32,
      *     components: 1
      * }]);
      */

--- a/src/scene/gsplat/gsplat-container.js
+++ b/src/scene/gsplat/gsplat-container.js
@@ -19,8 +19,8 @@ import { GSplatResourceBase } from './gsplat-resource-base.js';
  *
  * @example
  * // Example 1: Using the default format (easy CPU population)
- * const format = pc.GSplatFormat.createDefaultFormat(device);
- * const container = new pc.GSplatContainer(device, 100, format);
+ * const format = GSplatFormat.createDefaultFormat(device);
+ * const container = new GSplatContainer(device, 100, format);
  *
  * // Float format textures are straightforward to fill
  * const centerTex = container.getTexture('dataCenter');
@@ -29,7 +29,7 @@ import { GSplatResourceBase } from './gsplat-resource-base.js';
  * centerTex.unlock();
  *
  * // Set bounding box
- * container.aabb = new pc.BoundingBox();
+ * container.aabb = new BoundingBox();
  *
  * // fill centers only if you need CPU sorting
  * container.centers.set([x0, y0, z0, x1, y1, z1, ...]);  // xyz per splat
@@ -39,8 +39,8 @@ import { GSplatResourceBase } from './gsplat-resource-base.js';
  *
  * @example
  * // Example 2: Using a custom format
- * const format = new pc.GSplatFormat(device, [
- *     { name: 'data', format: pc.PIXELFORMAT_RGBA32F }
+ * const format = new GSplatFormat(device, [
+ *     { name: 'data', format: PIXELFORMAT_RGBA32F }
  * ], {
  *     // Shader code to read splat attributes from the texture
  *     readGLSL: `
@@ -59,7 +59,7 @@ import { GSplatResourceBase } from './gsplat-resource-base.js';
  *     `
  * });
  *
- * const container = new pc.GSplatContainer(device, 100, format);
+ * const container = new GSplatContainer(device, 100, format);
  *
  * @category Graphics
  */

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -258,13 +258,13 @@ class Material {
      * WGSL to simply return a red color:
      *
      * ```javascript
-     * material.getShaderChunks(pc.SHADERLANGUAGE_GLSL).set('emissivePS', `
+     * material.getShaderChunks(SHADERLANGUAGE_GLSL).set('emissivePS', `
      *     void getEmission() {
      *         dEmission = vec3(1.0, 0.0, 1.0);
      *     }
      * `);
      *
-     * material.getShaderChunks(pc.SHADERLANGUAGE_WGSL).set('emissivePS', `
+     * material.getShaderChunks(SHADERLANGUAGE_WGSL).set('emissivePS', `
      *     fn getEmission() {
      *         dEmission = vec3f(1.0, 0.0, 1.0);
      *     }

--- a/src/scene/materials/shader-material.js
+++ b/src/scene/materials/shader-material.js
@@ -33,9 +33,9 @@ import { Material } from './material.js';
  * GLSL format:
  *
  * ```javascript
- * const material = new pc.ShaderMaterial({
+ * const material = new ShaderMaterial({
  *     uniqueName: 'MyShader',
- *     attributes: { aPosition: pc.SEMANTIC_POSITION },
+ *     attributes: { aPosition: SEMANTIC_POSITION },
  *     vertexGLSL: `
  *         attribute vec3 aPosition;
  *         uniform mat4 matrix_viewProjection;

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -573,7 +573,7 @@ class StandardMaterial extends Material {
      *
      * @example
      * // Create a new Standard material
-     * const material = new pc.StandardMaterial();
+     * const material = new StandardMaterial();
      *
      * // Update the material's diffuse and specular properties
      * material.diffuse.set(1, 0, 0);
@@ -583,7 +583,7 @@ class StandardMaterial extends Material {
      * material.update();
      * @example
      * // Create a new Standard material
-     * const material = new pc.StandardMaterial();
+     * const material = new StandardMaterial();
      *
      * // Assign a texture to the diffuse slot
      * material.diffuseMap = texture;
@@ -650,8 +650,8 @@ class StandardMaterial extends Material {
      * @param {string} semantic - Semantic to map the vertex data. Must match with the semantic set
      * on vertex stream of the mesh.
      * @example
-     * mesh.setVertexStream(pc.SEMANTIC_ATTR15, offset, 3);
-     * material.setAttribute('offset', pc.SEMANTIC_ATTR15);
+     * mesh.setVertexStream(SEMANTIC_ATTR15, offset, 3);
+     * material.setAttribute('offset', SEMANTIC_ATTR15);
      */
     setAttribute(name, semantic) {
         this.userAttributes.set(semantic, name);

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -298,10 +298,10 @@ class MeshInstance {
      * @example
      * // clear the forward (color) pass bit, leaving all other pass bits set: the mesh is no longer
      * // drawn in the color image, but still takes part in the other passes (such as the prepass)
-     * meshInstance.shaderPassMask &= ~(1 << pc.SHADER_FORWARD);
+     * meshInstance.shaderPassMask &= ~(1 << SHADER_FORWARD);
      * @example
      * // set the forward (color) pass bit, leaving all other pass bits unchanged
-     * meshInstance.shaderPassMask |= (1 << pc.SHADER_FORWARD);
+     * meshInstance.shaderPassMask |= (1 << SHADER_FORWARD);
      * @example
      * // exclude the mesh from a custom shader pass set up on the camera (see
      * // CameraComponent#setShaderPass), leaving all other pass bits set
@@ -309,7 +309,7 @@ class MeshInstance {
      * meshInstance.shaderPassMask &= ~(1 << customPass);
      * @example
      * // test whether the forward (color) pass bit is set
-     * const forwardBitSet = (meshInstance.shaderPassMask & (1 << pc.SHADER_FORWARD)) !== 0;
+     * const forwardBitSet = (meshInstance.shaderPassMask & (1 << SHADER_FORWARD)) !== 0;
      * @example
      * // set every pass bit (the default value)
      * meshInstance.shaderPassMask = 0xFFFFFFFF;
@@ -495,7 +495,7 @@ class MeshInstance {
     _shaderCache = new Map();
 
     /**
-     * 2 byte toggles, 2 bytes light mask; Default value is no toggles and mask = pc.MASK_AFFECT_DYNAMIC
+     * 2 byte toggles, 2 bytes light mask; Default value is no toggles and mask = MASK_AFFECT_DYNAMIC
      *
      * @private
      */
@@ -517,12 +517,12 @@ class MeshInstance {
      * component is attached to.
      * @example
      * // Create a mesh instance pointing to a 1x1x1 'cube' mesh
-     * const mesh = pc.Mesh.fromGeometry(app.graphicsDevice, new pc.BoxGeometry());
-     * const material = new pc.StandardMaterial();
+     * const mesh = Mesh.fromGeometry(app.graphicsDevice, new BoxGeometry());
+     * const material = new StandardMaterial();
      *
-     * const meshInstance = new pc.MeshInstance(mesh, material);
+     * const meshInstance = new MeshInstance(mesh, material);
      *
-     * const entity = new pc.Entity();
+     * const entity = new Entity();
      * entity.addComponent('render', {
      *     meshInstances: [meshInstance]
      * });

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -109,7 +109,7 @@ class GeometryVertexStream {
  * form a single triangle.
  *
  * ```javascript
- * const mesh = new pc.Mesh(device);
+ * const mesh = new Mesh(device);
  * const positions = [
  *     0, 0, 0, // pos 0
  *     1, 0, 0, // pos 1
@@ -123,7 +123,7 @@ class GeometryVertexStream {
  * channel 0, and an index buffer to form two triangles. Float32Array is used for positions and uvs.
  *
  * ```javascript
- * const mesh = new pc.Mesh(device);
+ * const mesh = new Mesh(device);
  * const positions = new Float32Array([
  *     0, 0, 0, // pos 0
  *     1, 0, 0, // pos 1
@@ -141,7 +141,7 @@ class GeometryVertexStream {
  *     0, 2, 3  // triangle 1
  * ];
  * mesh.setPositions(positions);
- * mesh.setNormals(pc.calculateNormals(positions, indices));
+ * mesh.setNormals(calculateNormals(positions, indices));
  * mesh.setUvs(0, uvs);
  * mesh.setIndices(indices);
  * mesh.update();

--- a/src/scene/model.js
+++ b/src/scene/model.js
@@ -47,7 +47,7 @@ class Model {
      *
      * @example
      * // Create a new model
-     * const model = new pc.Model();
+     * const model = new Model();
      */
     constructor() {
         this.cameras = [];
@@ -203,7 +203,7 @@ class Model {
      * @example
      * model.generateWireframe();
      * for (let i = 0; i < model.meshInstances.length; i++) {
-     *     model.meshInstances[i].renderStyle = pc.RENDERSTYLE_WIREFRAME;
+     *     model.meshInstances[i].renderStyle = RENDERSTYLE_WIREFRAME;
      * }
      */
     generateWireframe() {

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -35,8 +35,8 @@ class ShaderPassInfo {
      * @param {object} [options] - Options for additional configuration of the shader pass.
      * @param {boolean} [options.isForward] - Whether the pass is forward.
      * @param {boolean} [options.isShadow] - Whether the pass is shadow.
-     * @param {number} [options.lightType] - Type of light, for example `pc.LIGHTTYPE_DIRECTIONAL`.
-     * @param {number} [options.shadowType] - Type of shadow, for example `pc.SHADOW_PCF3_32F`.
+     * @param {number} [options.lightType] - Type of light, for example `LIGHTTYPE_DIRECTIONAL`.
+     * @param {number} [options.shadowType] - Type of shadow, for example `SHADOW_PCF3_32F`.
      */
     constructor(name, index, options = {}) {
 

--- a/src/scene/texture-atlas.js
+++ b/src/scene/texture-atlas.js
@@ -17,21 +17,21 @@ class TextureAtlas extends EventHandler {
      * Create a new TextureAtlas instance.
      *
      * @example
-     * const atlas = new pc.TextureAtlas();
+     * const atlas = new TextureAtlas();
      * atlas.frames = {
      *     '0': {
      *         // rect has u, v, width and height in pixels
-     *         rect: new pc.Vec4(0, 0, 256, 256),
+     *         rect: new Vec4(0, 0, 256, 256),
      *         // pivot has x, y values between 0-1 which define the point
      *         // within the frame around which rotation and scale is calculated
-     *         pivot: new pc.Vec2(0.5, 0.5),
+     *         pivot: new Vec2(0.5, 0.5),
      *         // border has left, bottom, right and top in pixels defining regions for 9-slicing
-     *         border: new pc.Vec4(5, 5, 5, 5)
+     *         border: new Vec4(5, 5, 5, 5)
      *     },
      *     '1': {
-     *         rect: new pc.Vec4(256, 0, 256, 256),
-     *         pivot: new pc.Vec2(0.5, 0.5),
-     *         border: new pc.Vec4(5, 5, 5, 5)
+     *         rect: new Vec4(256, 0, 256, 256),
+     *         pivot: new Vec2(0.5, 0.5),
+     *         border: new Vec4(5, 5, 5, 5)
      *     }
      * };
      */
@@ -99,9 +99,9 @@ class TextureAtlas extends EventHandler {
      * follows: left, bottom, right, top border in pixels.
      * @example
      * atlas.setFrame('1', {
-     *     rect: new pc.Vec4(0, 0, 128, 128),
-     *     pivot: new pc.Vec2(0.5, 0.5),
-     *     border: new pc.Vec4(5, 5, 5, 5)
+     *     rect: new Vec4(0, 0, 128, 128),
+     *     pivot: new Vec2(0.5, 0.5),
+     *     border: new Vec4(5, 5, 5, 5)
      * });
      */
     setFrame(key, data) {


### PR DESCRIPTION
## Overview

Update the engine API documentation to use unqualified module symbols instead of the secondary pc namespace style.

- Remove 826 pc namespace qualifiers from engine JSDoc examples and documentation blocks.
- Align the API reference with the named-symbol convention used by the module build and engine examples.
- Preserve runtime diagnostics, ordinary comments, legacy scripts, and namespace compatibility code (follow up PRs)

## Public API changes

None. This is a documentation-only change with no runtime, type-signature, or export changes.
