### PR TITLE
Use named engine symbols in remaining ESM documentation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -167,12 +167,12 @@ Each example consists of two modules to define its behavior:
 ### `<exampleName>.example.mjs`
 
 ```js
-import * as pc from 'playcanvas';
+import { Application } from 'playcanvas';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();
 
-const app = new pc.Application(canvas, {});
+const app = new Application(canvas, {});
 ```
 
 This is the only file that's required to run an example. The code defined in this function is executed each time the example play button is pressed. It takes the example's canvas element from the DOM and usually begins by creating a new PlayCanvas `Application` or `AppBase` using that canvas.
@@ -201,7 +201,7 @@ Examples can also contain comments which allow you to define the default configu
 // @flag WEBGPU_DISABLED
 // @flag WEBGL_DISABLED
 // @flag PREFERRED_DEVICE webgpu
-import * as pc from 'playcanvas';
+import { Application } from 'playcanvas';
 ...
 ```
 
@@ -256,13 +256,15 @@ console.log(data.get('flash'));
 Any other file you wish to include in your example can be added to the same folder with the example name prepended (e.g. `<exampleName>.shader.vert` and `<exampleName>.shader.frag`). These files can be imported from the example using their relative file name:
 
 ```js
+import { Asset } from 'playcanvas';
+
 import shaderVert from './shader.vert';
 import shaderFrag from './shader.frag';
 import data from './data.json';
 
 const assets = {
-    statue: new pc.Asset('statue', 'container', { url: './assets/models/statue.glb' }),
-    orbit: new pc.Asset('orbit', 'script', { url: './scripts/camera/orbit-camera.js' })
+    statue: new Asset('statue', 'container', { url: './assets/models/statue.glb' }),
+    orbit: new Asset('orbit', 'script', { url: './scripts/camera/orbit-camera.js' })
 };
 ```
 

--- a/examples/assets/wasm/README.md
+++ b/examples/assets/wasm/README.md
@@ -19,4 +19,4 @@ zstd
 ZSTD (Zstandard) decompressor, used by the SPZ gaussian splat parser. The wasm binary is the
 single-file zstd decoder (zstddeclib) from https://github.com/facebook/zstd (BSD-3-Clause),
 compiled to WebAssembly by https://github.com/donmccurdy/zstddec (MIT). The glue script
-(zstd.wasm.js) is a hand-written wrapper conforming to the pc.WasmModule contract.
+(zstd.wasm.js) is a hand-written wrapper conforming to the WasmModule contract.

--- a/examples/assets/wasm/zstd/zstd.wasm.js
+++ b/examples/assets/wasm/zstd/zstd.wasm.js
@@ -4,11 +4,13 @@
 // Zstandard project (https://github.com/facebook/zstd, BSD-3-Clause), compiled to WebAssembly
 // by the zstddec project (https://github.com/donmccurdy/zstddec, MIT).
 //
-// This script conforms to the pc.WasmModule contract: it exposes a global factory function
+// This script conforms to the WasmModule contract: it exposes a global factory function
 // which is passed a config object with locateFile() and returns a promise of the module
 // instance. Register it like this:
 //
-//     pc.WasmModule.setConfig('ZstdDecoderModule', {
+//     import { WasmModule } from 'playcanvas';
+//
+//     WasmModule.setConfig('ZstdDecoderModule', {
 //         glueUrl: 'zstd.wasm.js',
 //         wasmUrl: 'zstd.wasm.wasm'
 //     });

--- a/examples/src/examples/user-interface/custom-shader.shader.glsl.vert
+++ b/examples/src/examples/user-interface/custom-shader.shader.glsl.vert
@@ -3,9 +3,9 @@
  * Simple Screen-Space Vertex Shader with one UV coordinate.
  * This shader is useful for simple UI shaders.
  * 
- * Usage: the following attributes must be configured when creating a new pc.Shader:
- *   vertex_position: pc.SEMANTIC_POSITION
- *   vertex_texCoord0: pc.SEMANTIC_TEXCOORD0
+ * Usage: the following attributes must be configured when creating a new Shader:
+ *   vertex_position: SEMANTIC_POSITION
+ *   vertex_texCoord0: SEMANTIC_TEXCOORD0
  */
 
 // Default PlayCanvas uniforms

--- a/examples/src/examples/user-interface/custom-shader.shader.wgsl.vert
+++ b/examples/src/examples/user-interface/custom-shader.shader.wgsl.vert
@@ -3,9 +3,9 @@
  * Simple Screen-Space Vertex Shader with one UV coordinate.
  * This shader is useful for simple UI shaders.
  * 
- * Usage: the following attributes must be configured when creating a new pc.Shader:
- *   vertex_position: pc.SEMANTIC_POSITION
- *   vertex_texCoord0: pc.SEMANTIC_TEXCOORD0
+ * Usage: the following attributes must be configured when creating a new Shader:
+ *   vertex_position: SEMANTIC_POSITION
+ *   vertex_texCoord0: SEMANTIC_TEXCOORD0
  */
 
 // Default PlayCanvas uniforms
@@ -32,4 +32,3 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     
     return output;
 }
-

--- a/scripts/esm/parsers/obj-model.mjs
+++ b/scripts/esm/parsers/obj-model.mjs
@@ -4,6 +4,7 @@ import { Geometry, GraphNode, Http, Mesh, MeshInstance, Model, StandardMaterial 
 //
 // To use, first register the parser:
 //
+// import { Asset } from 'playcanvas';
 // import { ObjModelParser } from 'playcanvas/scripts/esm/parsers/obj-model.mjs';
 //
 // // add parser to model resource handler
@@ -12,7 +13,7 @@ import { Geometry, GraphNode, Http, Mesh, MeshInstance, Model, StandardMaterial 
 //
 // Then load obj as a model asset:
 //
-// const asset = new pc.Asset("MyObj", "model", {
+// const asset = new Asset("MyObj", "model", {
 //    url: "model.obj"
 // });
 // this.app.assets.add(asset);

--- a/scripts/esm/parsers/spz-parser.mjs
+++ b/scripts/esm/parsers/spz-parser.mjs
@@ -16,7 +16,9 @@ import { GSplatFormat, GSplatResourceBase, Http, PIXELFORMAT_RGBA8, PIXELFORMAT_
  * registered:
  *
  * ```javascript
- * pc.WasmModule.setConfig('ZstdDecoderModule', {
+ * import { WasmModule } from 'playcanvas';
+ *
+ * WasmModule.setConfig('ZstdDecoderModule', {
  *     glueUrl: 'zstd.wasm.js',
  *     wasmUrl: 'zstd.wasm.wasm'
  * });
@@ -31,7 +33,9 @@ import { GSplatFormat, GSplatResourceBase, Http, PIXELFORMAT_RGBA8, PIXELFORMAT_
  * and then load spz files as gsplat assets:
  *
  * ```javascript
- * const asset = new pc.Asset('gsplat', 'gsplat', { url: 'scene.spz' });
+ * import { Asset } from 'playcanvas';
+ *
+ * const asset = new Asset('gsplat', 'gsplat', { url: 'scene.spz' });
  * app.assets.add(asset);
  * app.assets.load(asset);
  * ```
@@ -522,7 +526,7 @@ class SpzParser {
      */
     load(url, callback, asset) {
         if (!WasmModule.getConfig('ZstdDecoderModule')) {
-            callback('SpzParser: ZSTD decoder module is not registered. Use pc.WasmModule.setConfig(\'ZstdDecoderModule\', { glueUrl, wasmUrl }) before loading spz files.');
+            callback('SpzParser: ZSTD decoder module is not registered. Use WasmModule.setConfig(\'ZstdDecoderModule\', { glueUrl, wasmUrl }) before loading spz files.');
             return;
         }
 


### PR DESCRIPTION
## Overview

Complete the ESM-facing documentation cleanup outside the engine JSDoc changes in #9075.

- Replace namespace imports in the examples authoring guide with named imports.
- Use unqualified engine symbols in shader and WebAssembly usage documentation.
- Update OBJ and SPZ parser usage examples to import the engine symbols they use.
- Update the SPZ parser diagnostic to recommend WasmModule directly.

## Public API changes

None. This changes documentation, comments, and diagnostic wording only.

## Performance considerations

None. Runtime behavior is unchanged.

## Validation

- npm run lint
- npm run lint in examples
- git diff --check