### PR TITLE
Fix pre-existing JSDoc errors

### DIFF
--- a/src/core/math/mat4.js
+++ b/src/core/math/mat4.js
@@ -537,7 +537,7 @@ class Mat4 {
      * @returns {Mat4} Self for chaining.
      * @example
      * // Create a 4x4 perspective projection matrix
-     * const f = pc.Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
+     * const f = new pc.Mat4().setFrustum(-2, 2, -1, 1, 1, 1000);
      * @ignore
      */
     setFrustum(left, right, bottom, top, znear, zfar) {

--- a/src/framework/asset/asset-list-loader.js
+++ b/src/framework/asset/asset-list-loader.js
@@ -67,8 +67,8 @@ class AssetListLoader extends EventHandler {
      * @param {AssetRegistry} assetRegistry - The application's asset registry.
      * @example
      * const assetListLoader = new pc.AssetListLoader([
-     *     new pc.Asset("texture1", "texture", { url: 'http://example.com/my/assets/here/texture1.png') }),
-     *     new pc.Asset("texture2", "texture", { url: 'http://example.com/my/assets/here/texture2.png') })
+     *     new pc.Asset("texture1", "texture", { url: 'http://example.com/my/assets/here/texture1.png' }),
+     *     new pc.Asset("texture2", "texture", { url: 'http://example.com/my/assets/here/texture2.png' })
      * ], app.assets);
      */
     constructor(assetList, assetRegistry) {

--- a/src/scene/shader-pass.js
+++ b/src/scene/shader-pass.js
@@ -35,8 +35,8 @@ class ShaderPassInfo {
      * @param {object} [options] - Options for additional configuration of the shader pass.
      * @param {boolean} [options.isForward] - Whether the pass is forward.
      * @param {boolean} [options.isShadow] - Whether the pass is shadow.
-     * @param {boolean} [options.lightType] - Type of light, for example `pc.LIGHTTYPE_DIRECTIONAL`.
-     * @param {boolean} [options.shadowType] - Type of shadow, for example `pc.SHADOW_PCF3_32F`.
+     * @param {number} [options.lightType] - Type of light, for example `pc.LIGHTTYPE_DIRECTIONAL`.
+     * @param {number} [options.shadowType] - Type of shadow, for example `pc.SHADOW_PCF3_32F`.
      */
     constructor(name, index, options = {}) {
 


### PR DESCRIPTION
## Summary

Fixes three pre-existing JSDoc issues identified while reviewing #9075. This change is independent of the namespace cleanup.

## Changes

- Correct `ShaderPassInfo` light and shadow option types to match their numeric constants.
- Fix malformed `AssetListLoader` constructor examples.
- Construct `Mat4` correctly in the `setFrustum` example.

## Public API changes

The generated option types now match runtime usage:

```ts
// Before
lightType?: boolean;
shadowType?: boolean;

// After
lightType?: number;
shadowType?: number;
```

There are no runtime behavior changes.

## Validation

- `npm run lint`
- `npm run docs` (0 errors; 37 existing warnings)
- `npm run build:types`
- `npm run test:types`
- `git diff --check`