### PR TITLE
Remove pc namespace from comments and diagnostics

### DIFF
--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -652,7 +652,7 @@ class AnimationComponent extends Component {
     onBeforeRemove() {
         for (let i = 0; i < this.assets.length; i++) {
 
-            // this.assets can be an array of pc.Assets or an array of numbers (assetIds)
+            // this.assets can be an array of Asset objects or an array of numbers (assetIds)
             let asset = this.assets[i];
             if (typeof asset ===  'number') {
                 asset = this.system.app.assets.get(asset);

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -42,7 +42,7 @@ class MeshInfo {
         this.outlines = [];
         // float array for shadows
         this.shadows = [];
-        // pc.MeshInstance created from this MeshInfo
+        // MeshInstance created from this MeshInfo
         this.meshInstance = null;
     }
 }

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -1991,7 +1991,7 @@ class ParticleSystemComponent extends Component {
 
     _onMeshChanged(mesh) {
         if (mesh && !(mesh instanceof Mesh)) {
-            // if mesh is a pc.Model, use the first meshInstance
+            // if mesh is a Model, use the first meshInstance
             if (mesh.meshInstances[0]) {
                 mesh = mesh.meshInstances[0].mesh;
             } else {

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -232,7 +232,7 @@ class ComponentSystemRegistry extends EventHandler {
     constructor() {
         super();
 
-        // An array of pc.ComponentSystem objects
+        // An array of ComponentSystem objects
         this.list = [];
     }
 

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -41,14 +41,14 @@ class ScriptComponentSystem extends ComponentSystem {
         this.extraDataProperties = ['order'];
 
         // list of all entities script components
-        // we are using pc.SortedLoopArray because it is
+        // we are using SortedLoopArray because it is
         // safe to modify while looping through it
         this._components = new SortedLoopArray({
             sortBy: '_executionOrder'
         });
 
         // holds all the enabled script components
-        // (whose entities are also enabled). We are using pc.SortedLoopArray
+        // (whose entities are also enabled). We are using SortedLoopArray
         // because it is safe to modify while looping through it. This array often
         // change during update and postUpdate loops as entities and components get
         // enabled or disabled

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -393,7 +393,7 @@ class SpriteComponent extends Component {
         return this._currentClip.sprite;
     }
 
-    // (private) {pc.Material} material The material used to render a sprite.
+    // (private) {Material} material The material used to render a sprite.
     set material(value) {
         this._material = value;
         if (this._meshInstance) {

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -202,7 +202,7 @@ class Picker {
     getSelection(x, y, width = 1, height = 1) {
         const device = this.device;
         if (device.isWebGPU) {
-            Debug.errorOnce('pc.Picker#getSelection is not supported on WebGPU, use pc.Picker#getSelectionAsync instead.');
+            Debug.errorOnce('Picker#getSelection is not supported on WebGPU, use Picker#getSelectionAsync instead.');
             return [];
         }
 

--- a/src/framework/i18n/i18n-parser.js
+++ b/src/framework/i18n/i18n-parser.js
@@ -1,36 +1,36 @@
 class I18nParser {
     _validate(data) {
         if (!data.header) {
-            throw new Error('pc.I18n#addData: Missing "header" field');
+            throw new Error('I18n#addData: Missing "header" field');
         }
         if (!data.header.version) {
-            throw new Error('pc.I18n#addData: Missing "header.version" field');
+            throw new Error('I18n#addData: Missing "header.version" field');
         }
         if (data.header.version !== 1) {
-            throw new Error('pc.I18n#addData: Invalid "header.version" field');
+            throw new Error('I18n#addData: Invalid "header.version" field');
         }
 
         if (!data.data) {
-            throw new Error('pc.I18n#addData: Missing "data" field');
+            throw new Error('I18n#addData: Missing "data" field');
         } else if (!Array.isArray(data.data)) {
-            throw new Error('pc.I18n#addData: "data" field must be an array');
+            throw new Error('I18n#addData: "data" field must be an array');
         }
 
         for (let i = 0, len = data.data.length; i < len; i++) {
             const entry = data.data[i];
             if (!entry.info) {
-                throw new Error(`pc.I18n#addData: missing "data[${i}].info" field`);
+                throw new Error(`I18n#addData: missing "data[${i}].info" field`);
             }
 
             if (!entry.info.locale) {
-                throw new Error(`pc.I18n#addData: missing "data[${i}].info.locale" field`);
+                throw new Error(`I18n#addData: missing "data[${i}].info.locale" field`);
             }
             if (typeof entry.info.locale !== 'string') {
-                throw new Error(`pc.I18n#addData: "data[${i}].info.locale" must be a string`);
+                throw new Error(`I18n#addData: "data[${i}].info.locale" must be a string`);
             }
 
             if (!entry.messages) {
-                throw new Error(`pc.I18n#addData: missing "data[${i}].messages" field`);
+                throw new Error(`I18n#addData: missing "data[${i}].messages" field`);
             }
         }
     }

--- a/src/framework/parsers/glb-container-resource.js
+++ b/src/framework/parsers/glb-container-resource.js
@@ -308,7 +308,7 @@ class GlbContainerResource {
         return root;
     }
 
-    // create a pc.Model from the parsed GLB data structures
+    // create a Model from the parsed GLB data structures
     static createModel(glb, defaultMaterial) {
 
         const createMeshInstance = function (model, mesh, skins, skinInstances, materials, node, gltfNode) {

--- a/src/framework/parsers/json-model.js
+++ b/src/framework/parsers/json-model.js
@@ -46,7 +46,7 @@ const JSON_VERTEX_ELEMENT_TYPE = {
     'float32': TYPE_FLOAT32
 };
 
-// Take PlayCanvas JSON model data and create pc.Model
+// Take PlayCanvas JSON model data and create Model
 class JsonModelParser {
     constructor(modelHandler) {
         this._device = modelHandler.device;

--- a/src/framework/scene-registry.js
+++ b/src/framework/scene-registry.js
@@ -104,7 +104,7 @@ class SceneRegistry {
      */
     add(name, url) {
         if (this._index.hasOwnProperty(name)) {
-            Debug.warn(`pc.SceneRegistry: trying to add more than one scene called: ${name}`);
+            Debug.warn(`SceneRegistry: trying to add more than one scene called: ${name}`);
             return false;
         }
 

--- a/src/framework/script/script-create.js
+++ b/src/framework/script/script-create.js
@@ -116,7 +116,7 @@ function registerScript(script, name, app) {
     }
 
     if (!(script.prototype instanceof Script)) {
-        throw new Error(`script class: '${ScriptType.__getScriptName(script)}' does not extend pc.Script.`);
+        throw new Error(`script class: '${ScriptType.__getScriptName(script)}' does not extend Script.`);
     }
 
     // Resolve the name: an explicit `name` argument wins, otherwise the name is derived from the

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -827,7 +827,7 @@ class GraphicsDevice extends EventHandler {
      */
     loseContext() {
 
-        Debug.log('pc.GraphicsDevice: Graphics context lost.');
+        Debug.log('GraphicsDevice: Graphics context lost.');
 
         this.contextLost = true;
 
@@ -861,7 +861,7 @@ class GraphicsDevice extends EventHandler {
      */
     restoreContext() {
 
-        Debug.log('pc.GraphicsDevice: Graphics context restored.');
+        Debug.log('GraphicsDevice: Graphics context restored.');
 
         this.contextLost = false;
 

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -187,7 +187,7 @@ class RenderTarget {
      * camera.renderTarget = null;
      */
     constructor(options = {}) {
-        Debug.assert(!(options instanceof GraphicsDevice), 'pc.RenderTarget constructor no longer accepts GraphicsDevice parameter.');
+        Debug.assert(!(options instanceof GraphicsDevice), 'RenderTarget constructor no longer accepts GraphicsDevice parameter.');
         this.id = id++;
 
         // device, from one of the buffers
@@ -227,7 +227,7 @@ class RenderTarget {
                 this._depth = true;
                 this._stencil = false;
             } else {
-                Debug.warn('Incorrect depthBuffer format. Must be pc.PIXELFORMAT_DEPTH or pc.PIXELFORMAT_DEPTHSTENCIL');
+                Debug.warn('Incorrect depthBuffer format. Must be PIXELFORMAT_DEPTH or PIXELFORMAT_DEPTHSTENCIL');
                 this._depth = false;
                 this._stencil = false;
             }

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -669,7 +669,7 @@ class Texture {
      */
     set addressW(addressW) {
         if (!this._volume) {
-            Debug.warn('pc.Texture#addressW: Can\'t set W addressing mode for a non-3D texture.');
+            Debug.warn('Texture#addressW: Can\'t set W addressing mode for a non-3D texture.');
             return;
         }
         if (addressW !== this._addressW) {
@@ -1267,7 +1267,7 @@ class Texture {
      */
     unlock() {
         if (this._lockedMode === TEXTURELOCK_NONE) {
-            Debug.warn('pc.Texture#unlock: Attempting to unlock a texture that is not locked.', this);
+            Debug.warn('Texture#unlock: Attempting to unlock a texture that is not locked.', this);
         }
 
         // Upload the new pixel data if locked in write mode (default)

--- a/src/scene/batching/batch.js
+++ b/src/scene/batching/batch.js
@@ -106,7 +106,7 @@ class Batch {
      * @ignore
      */
     get model() {
-        Debug.removed('pc.Batch#model was removed. Use pc.Batch#meshInstance to access batched mesh instead.');
+        Debug.removed('Batch#model was removed. Use Batch#meshInstance to access batched mesh instead.');
         return undefined;
     }
 }

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -33,7 +33,7 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
     const useBlend = arguments[5];
     Debug.call(() => {
         if (useBlend !== undefined) {
-            Debug.warnOnce('pc.drawQuadWithShader no longer accepts useBlend parameter, and blending state needs to be set up using GraphicsDevice.setBlendState.');
+            Debug.warnOnce('drawQuadWithShader no longer accepts useBlend parameter, and blending state needs to be set up using GraphicsDevice.setBlendState.');
         }
     });
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -308,12 +308,12 @@ class Material {
     }
 
     set chunks(value) {
-        Debug.deprecated('Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(pc.SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")');
+        Debug.deprecated('Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")');
         this._oldChunks = value;
     }
 
     get chunks() {
-        Debug.deprecated('Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(pc.SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")');
+        Debug.deprecated('Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")');
         Object.assign(this._oldChunks, Object.fromEntries(this.shaderChunks.glsl));
         return this._oldChunks;
     }
@@ -926,7 +926,7 @@ class Material {
                     meshInstance.material = defaultMaterial;
                 }
             } else {
-                Debug.warn('pc.Material: MeshInstance.mesh is null, default material cannot be assigned to the MeshInstance');
+                Debug.warn('Material: MeshInstance.mesh is null, default material cannot be assigned to the MeshInstance');
             }
         }
 

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -86,7 +86,7 @@ class GeometryVertexStream {
     constructor(data, componentCount, dataType, dataTypeNormalize, asInt) {
         this.data = data;                           // array of data
         this.componentCount = componentCount;       // number of components
-        this.dataType = dataType;                   // format of elements (pc.TYPE_FLOAT32 ..)
+        this.dataType = dataType;                   // format of elements (TYPE_FLOAT32 ..)
         this.dataTypeNormalize = dataTypeNormalize; // normalize element (divide by 255)
         this.asInt = asInt;                         // treat data as integer (WebGL2 and WebGPU only)
     }

--- a/src/scene/particle-system/cpu-updater.js
+++ b/src/scene/particle-system/cpu-updater.js
@@ -127,7 +127,7 @@ class ParticleCPUUpdater {
             rndFactor3Vec.y = particleTex[id * particleTexChannels + 1 + emitter.numParticlesPot * 2 * particleTexChannels];
             rndFactor3Vec.z = particleTex[id * particleTexChannels + 2 + emitter.numParticlesPot * 2 * particleTexChannels];
 
-            const particleRate = emitter.rate + (emitter.rate2 - emitter.rate) * rndFactor;// pc.math.lerp(emitter.rate, emitter.rate2, rndFactor);
+            const particleRate = emitter.rate + (emitter.rate2 - emitter.rate) * rndFactor;// math.lerp(emitter.rate, emitter.rate2, rndFactor);
 
             const particleLifetime = emitter.lifetime;
 

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -498,7 +498,7 @@ class Renderer {
     }
 
     setupCullMode(cullFaces, flipFactor, drawCall) {
-        Debug.deprecated('pc.Renderer.setupCullMode is deprecated. Use \'pc.Renderer.setupCullModeAndFrontFace(cullFaces, flipFactor, drawCall);\' format instead.');
+        Debug.deprecated('Renderer.setupCullMode is deprecated. Use \'Renderer.setupCullModeAndFrontFace(cullFaces, flipFactor, drawCall);\' format instead.');
         this.setupCullModeAndFrontFace(cullFaces, flipFactor, drawCall);
     }
 

--- a/src/scene/shader-lib/shader-utils.js
+++ b/src/scene/shader-lib/shader-utils.js
@@ -205,12 +205,12 @@ class ShaderUtils {
 }
 
 function createShader(device, vsName, fsName, useTransformFeedback = false, shaderDefinitionOptions = {}) {
-    Debug.removed('pc.createShader has been removed deprecated. Use ShaderUtils.createShader instead.');
+    Debug.removed('createShader has been removed deprecated. Use ShaderUtils.createShader instead.');
 }
 
 function createShaderFromCode(device, vsCode, fsCode, uniqueName, attributes, useTransformFeedback = false, shaderDefinitionOptions = {}) {
 
-    Debug.deprecated('pc.createShaderFromCode has been deprecated. Use ShaderUtils.createShader instead.');
+    Debug.deprecated('createShaderFromCode has been deprecated. Use ShaderUtils.createShader instead.');
 
     // the function signature has changed, fail if called incorrectly
     Debug.assert(typeof attributes !== 'boolean');

--- a/test/framework/components/script/component.test.mjs
+++ b/test/framework/components/script/component.test.mjs
@@ -2905,7 +2905,7 @@ describe('ScriptComponent', function () {
         });
     });
 
-    it('pc.ScriptComponent#has', function () {
+    it('ScriptComponent#has', function () {
         const e = new Entity();
         e.addComponent('script', {
             enabled: true,


### PR DESCRIPTION
## Summary

Removes obsolete `pc.` namespace qualification from engine comments, user-facing diagnostics, and one test title, following the engine JSDoc namespace cleanup.

## Changes

- Use direct class and constant names in runtime diagnostic messages.
- Update internal comments to use module-era symbol names.
- Rename the remaining `pc.ScriptComponent#has` test title.
- Preserve intentional UMD, classic-script, generated-code, and compatibility references.

## Public API changes

None. This changes comments and development-build diagnostic text only; runtime behavior is unchanged.

## Validation

- `npm run lint`
- `git diff --check`
- Targeted search confirms all 42 scoped references were removed.