### PR TITLE
Fix deprecated API migration messages

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -106,42 +106,42 @@ export const CHUNKAPI_2_8 = '2.8';
 const _viewport = new Vec4();
 
 export function createSphere(device, opts) {
-    Debug.deprecated('pc.createSphere is deprecated. Use \'pc.Mesh.fromGeometry(device, new SphereGeometry(options);\' format instead.');
+    Debug.deprecated('pc.createSphere is deprecated. Use \'pc.Mesh.fromGeometry(device, new SphereGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new SphereGeometry(opts));
 }
 
 export function createPlane(device, opts) {
-    Debug.deprecated('pc.createPlane is deprecated. Use \'pc.Mesh.fromGeometry(device, new PlaneGeometry(options);\' format instead.');
+    Debug.deprecated('pc.createPlane is deprecated. Use \'pc.Mesh.fromGeometry(device, new PlaneGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new PlaneGeometry(opts));
 }
 
 export function createBox(device, opts) {
-    Debug.deprecated('pc.createBox is deprecated. Use \'pc.Mesh.fromGeometry(device, new BoxGeometry(options);\' format instead.');
+    Debug.deprecated('pc.createBox is deprecated. Use \'pc.Mesh.fromGeometry(device, new BoxGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new BoxGeometry(opts));
 }
 
 export function createTorus(device, opts) {
-    Debug.deprecated('pc.createTorus is deprecated. Use \'pc.Mesh.fromGeometry(device, new TorusGeometry(options);\' format instead.');
+    Debug.deprecated('pc.createTorus is deprecated. Use \'pc.Mesh.fromGeometry(device, new TorusGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new TorusGeometry(opts));
 }
 
 export function createCapsule(device, opts) {
-    Debug.deprecated('pc.createCapsule is deprecated. Use \'pc.Mesh.fromGeometry(device, new CapsuleGeometry(options);\' format instead.');
+    Debug.deprecated('pc.createCapsule is deprecated. Use \'pc.Mesh.fromGeometry(device, new CapsuleGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new CapsuleGeometry(opts));
 }
 
 export function createCone(device, opts) {
-    Debug.deprecated('pc.createCone is deprecated. Use \'pc.Mesh.fromGeometry(device, new ConeGeometry(options);\' format instead.');
+    Debug.deprecated('pc.createCone is deprecated. Use \'pc.Mesh.fromGeometry(device, new ConeGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new ConeGeometry(opts));
 }
 
 export function createCylinder(device, opts) {
-    Debug.deprecated('pc.createCylinder is deprecated. Use \'pc.Mesh.fromGeometry(device, new CylinderGeometry(options);\' format instead.');
+    Debug.deprecated('pc.createCylinder is deprecated. Use \'pc.Mesh.fromGeometry(device, new CylinderGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new CylinderGeometry(opts));
 }
 
 export function createMesh(device, positions, opts = {}) {
-    Debug.deprecated('pc.createMesh is deprecated. Use \'pc.Mesh.fromGeometry(device, new Geometry();\' format instead.');
+    Debug.deprecated('pc.createMesh is deprecated. Use \'pc.Mesh.fromGeometry(device, new Geometry());\' format instead.');
 
     const geom = new Geometry();
     geom.positions = positions;
@@ -187,7 +187,7 @@ Object.defineProperties(RenderTarget.prototype, {
 
 Object.defineProperty(VertexFormat, 'defaultInstancingFormat', {
     get: function () {
-        Debug.assert('pc.VertexFormat.defaultInstancingFormat is deprecated, use pc.VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
+        Debug.deprecated('pc.VertexFormat.defaultInstancingFormat is deprecated. Use pc.VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
         return null;
     }
 });
@@ -217,7 +217,7 @@ Object.defineProperties(Texture.prototype, {
 
     _glTexture: {
         get: function () {
-            Debug.deprecated('pc.Texture#_glTexture is no longer available, use Use pc.Texture.impl._glTexture instead.');
+            Debug.deprecated('pc.Texture#_glTexture is no longer available. Use pc.Texture.impl._glTexture instead.');
             return this.impl._glTexture;
         }
     }


### PR DESCRIPTION
## Summary

Fixes pre-existing correctness issues in deprecated API migration messages.

## Changes

- Correct the closing parentheses in all eight malformed geometry migration snippets without introducing new namespace references.
- Correct the duplicated `use Use` wording in the legacy texture message.
- Replace a truthy-string `Debug.assert` call with `Debug.deprecated`, so accessing `VertexFormat.defaultInstancingFormat` emits its intended warning.

## Public API changes

None. Runtime API behavior is unchanged; the previously ineffective development-only warning now works as intended.

## Validation

- `npm run lint`
- `git diff --check`
- The `pc.` occurrence count in `deprecated.js` is unchanged from `main`.