### PR TITLE
Fix deprecated gloss aliases

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -720,8 +720,8 @@ _defineAlias('glossVertexColor', 'glossMapVertexColor');
 _defineAlias('opacityVertexColor', 'opacityMapVertexColor');
 _defineAlias('lightVertexColor', 'lightMapVertexColor');
 
-_defineAlias('sheenGloss', 'sheenGlossiess');
-_defineAlias('clearCoatGloss', 'clearCostGlossiness');
+_defineAlias('sheenGloss', 'sheenGlossiness');
+_defineAlias('clearCoatGloss', 'clearCoatGlossiness');
 
 function _defineOption(name, newName) {
     if (name !== 'pass') {


### PR DESCRIPTION
## Summary

Corrects two clear spelling errors in deprecated `StandardMaterial` gloss aliases.

## Changes

- Restore the `sheenGlossiness` alias for `sheenGloss`.
- Restore the `clearCoatGlossiness` alias for `clearCoatGloss`.

## Public API changes

The intended deprecated compatibility properties now map to their renamed equivalents. Current `StandardMaterial` APIs are unchanged.

## Validation

- `npm run lint`
- `git diff --check`