### PR TITLE
Remove pc namespace from deprecated diagnostics

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -106,42 +106,42 @@ export const CHUNKAPI_2_8 = '2.8';
 const _viewport = new Vec4();
 
 export function createSphere(device, opts) {
-    Debug.deprecated('pc.createSphere is deprecated. Use \'pc.Mesh.fromGeometry(device, new SphereGeometry(options));\' format instead.');
+    Debug.deprecated('createSphere is deprecated. Use \'Mesh.fromGeometry(device, new SphereGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new SphereGeometry(opts));
 }
 
 export function createPlane(device, opts) {
-    Debug.deprecated('pc.createPlane is deprecated. Use \'pc.Mesh.fromGeometry(device, new PlaneGeometry(options));\' format instead.');
+    Debug.deprecated('createPlane is deprecated. Use \'Mesh.fromGeometry(device, new PlaneGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new PlaneGeometry(opts));
 }
 
 export function createBox(device, opts) {
-    Debug.deprecated('pc.createBox is deprecated. Use \'pc.Mesh.fromGeometry(device, new BoxGeometry(options));\' format instead.');
+    Debug.deprecated('createBox is deprecated. Use \'Mesh.fromGeometry(device, new BoxGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new BoxGeometry(opts));
 }
 
 export function createTorus(device, opts) {
-    Debug.deprecated('pc.createTorus is deprecated. Use \'pc.Mesh.fromGeometry(device, new TorusGeometry(options));\' format instead.');
+    Debug.deprecated('createTorus is deprecated. Use \'Mesh.fromGeometry(device, new TorusGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new TorusGeometry(opts));
 }
 
 export function createCapsule(device, opts) {
-    Debug.deprecated('pc.createCapsule is deprecated. Use \'pc.Mesh.fromGeometry(device, new CapsuleGeometry(options));\' format instead.');
+    Debug.deprecated('createCapsule is deprecated. Use \'Mesh.fromGeometry(device, new CapsuleGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new CapsuleGeometry(opts));
 }
 
 export function createCone(device, opts) {
-    Debug.deprecated('pc.createCone is deprecated. Use \'pc.Mesh.fromGeometry(device, new ConeGeometry(options));\' format instead.');
+    Debug.deprecated('createCone is deprecated. Use \'Mesh.fromGeometry(device, new ConeGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new ConeGeometry(opts));
 }
 
 export function createCylinder(device, opts) {
-    Debug.deprecated('pc.createCylinder is deprecated. Use \'pc.Mesh.fromGeometry(device, new CylinderGeometry(options));\' format instead.');
+    Debug.deprecated('createCylinder is deprecated. Use \'Mesh.fromGeometry(device, new CylinderGeometry(options));\' format instead.');
     return Mesh.fromGeometry(device, new CylinderGeometry(opts));
 }
 
 export function createMesh(device, positions, opts = {}) {
-    Debug.deprecated('pc.createMesh is deprecated. Use \'pc.Mesh.fromGeometry(device, new Geometry());\' format instead.');
+    Debug.deprecated('createMesh is deprecated. Use \'Mesh.fromGeometry(device, new Geometry());\' format instead.');
 
     const geom = new Geometry();
     geom.positions = positions;
@@ -159,7 +159,7 @@ export function createMesh(device, positions, opts = {}) {
 
 export function drawFullscreenQuad(device, target, vertexBuffer, shader, rect) {
 
-    Debug.deprecated('pc.drawFullscreenQuad is deprecated. When used as part of PostEffect, use PostEffect#drawQuad instead.');
+    Debug.deprecated('drawFullscreenQuad is deprecated. When used as part of PostEffect, use PostEffect#drawQuad instead.');
 
     // convert rect in normalized space to viewport in pixel space
     let viewport;
@@ -176,18 +176,18 @@ export function drawFullscreenQuad(device, target, vertexBuffer, shader, rect) {
 Object.defineProperties(RenderTarget.prototype, {
     _glFrameBuffer: {
         get: function () {
-            Debug.deprecated('pc.RenderTarget#_glFrameBuffer is deprecated. Use pc.RenderTarget.impl#_glFrameBuffer instead.');
+            Debug.deprecated('RenderTarget#_glFrameBuffer is deprecated. Use RenderTarget.impl#_glFrameBuffer instead.');
             return this.impl._glFrameBuffer;
         },
         set: function (rgbm) {
-            Debug.deprecated('pc.RenderTarget#_glFrameBuffer is deprecated. Use pc.RenderTarget.impl#_glFrameBuffer instead.');
+            Debug.deprecated('RenderTarget#_glFrameBuffer is deprecated. Use RenderTarget.impl#_glFrameBuffer instead.');
         }
     }
 });
 
 Object.defineProperty(VertexFormat, 'defaultInstancingFormat', {
     get: function () {
-        Debug.deprecated('pc.VertexFormat.defaultInstancingFormat is deprecated. Use pc.VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
+        Debug.deprecated('VertexFormat.defaultInstancingFormat is deprecated. Use VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
         return null;
     }
 });
@@ -195,29 +195,29 @@ Object.defineProperty(VertexFormat, 'defaultInstancingFormat', {
 Object.defineProperties(Texture.prototype, {
     rgbm: {
         get: function () {
-            Debug.deprecated('pc.Texture#rgbm is deprecated. Use pc.Texture#type instead.');
+            Debug.deprecated('Texture#rgbm is deprecated. Use Texture#type instead.');
             return this.type === TEXTURETYPE_RGBM;
         },
         set: function (rgbm) {
-            Debug.deprecated('pc.Texture#rgbm is deprecated. Use pc.Texture#type instead.');
+            Debug.deprecated('Texture#rgbm is deprecated. Use Texture#type instead.');
             this.type = rgbm ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
         }
     },
 
     swizzleGGGR: {
         get: function () {
-            Debug.deprecated('pc.Texture#swizzleGGGR is deprecated. Use pc.Texture#type instead.');
+            Debug.deprecated('Texture#swizzleGGGR is deprecated. Use Texture#type instead.');
             return this.type === TEXTURETYPE_SWIZZLEGGGR;
         },
         set: function (swizzleGGGR) {
-            Debug.deprecated('pc.Texture#swizzleGGGR is deprecated. Use pc.Texture#type instead.');
+            Debug.deprecated('Texture#swizzleGGGR is deprecated. Use Texture#type instead.');
             this.type = swizzleGGGR ? TEXTURETYPE_SWIZZLEGGGR : TEXTURETYPE_DEFAULT;
         }
     },
 
     _glTexture: {
         get: function () {
-            Debug.deprecated('pc.Texture#_glTexture is no longer available. Use pc.Texture.impl._glTexture instead.');
+            Debug.deprecated('Texture#_glTexture is no longer available. Use Texture.impl._glTexture instead.');
             return this.impl._glTexture;
         }
     }
@@ -225,91 +225,91 @@ Object.defineProperties(Texture.prototype, {
 
 Object.defineProperty(GraphicsDevice.prototype, 'boneLimit', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#boneLimit is deprecated and the limit has been removed.');
+        Debug.deprecated('GraphicsDevice#boneLimit is deprecated and the limit has been removed.');
         return 1024;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'webgl2', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#webgl2 is deprecated, use pc.GraphicsDevice#isWebGL2 instead.');
+        Debug.deprecated('GraphicsDevice#webgl2 is deprecated, use GraphicsDevice#isWebGL2 instead.');
         return this.isWebGL2;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'textureFloatHighPrecision', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#textureFloatHighPrecision is deprecated and always returns true.');
+        Debug.deprecated('GraphicsDevice#textureFloatHighPrecision is deprecated and always returns true.');
         return true;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'extBlendMinmax', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#extBlendMinmax is deprecated as it is always true.');
+        Debug.deprecated('GraphicsDevice#extBlendMinmax is deprecated as it is always true.');
         return true;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'extTextureHalfFloat', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#extTextureHalfFloat is deprecated as it is always true.');
+        Debug.deprecated('GraphicsDevice#extTextureHalfFloat is deprecated as it is always true.');
         return true;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'extTextureLod', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#extTextureLod is deprecated as it is always true.');
+        Debug.deprecated('GraphicsDevice#extTextureLod is deprecated as it is always true.');
         return true;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'textureHalfFloatFilterable', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#textureHalfFloatFilterable is deprecated as it is always true.');
+        Debug.deprecated('GraphicsDevice#textureHalfFloatFilterable is deprecated as it is always true.');
         return true;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'supportsMrt', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#supportsMrt is deprecated as it is always true.');
+        Debug.deprecated('GraphicsDevice#supportsMrt is deprecated as it is always true.');
         return true;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'supportsVolumeTextures', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#supportsVolumeTextures is deprecated as it is always true.');
+        Debug.deprecated('GraphicsDevice#supportsVolumeTextures is deprecated as it is always true.');
         return true;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'supportsInstancing', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#supportsInstancing is deprecated as it is always true.');
+        Debug.deprecated('GraphicsDevice#supportsInstancing is deprecated as it is always true.');
         return true;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'textureHalfFloatUpdatable', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#textureHalfFloatUpdatable is deprecated as it is always true.');
+        Debug.deprecated('GraphicsDevice#textureHalfFloatUpdatable is deprecated as it is always true.');
         return true;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'extTextureFloat', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#extTextureFloat is deprecated as it is always true');
+        Debug.deprecated('GraphicsDevice#extTextureFloat is deprecated as it is always true');
         return true;
     }
 });
 
 Object.defineProperty(GraphicsDevice.prototype, 'extStandardDerivatives', {
     get: function () {
-        Debug.deprecated('pc.GraphicsDevice#extStandardDerivatives is deprecated as it is always true.');
+        Debug.deprecated('GraphicsDevice#extStandardDerivatives is deprecated as it is always true.');
         return true;
     }
 });
@@ -320,7 +320,7 @@ const _tempBlendState = new BlendState();
 const _tempDepthState = new DepthState();
 
 GraphicsDevice.prototype.setBlendFunction = function (blendSrc, blendDst) {
-    Debug.deprecated('pc.GraphicsDevice#setBlendFunction is deprecated, use pc.GraphicsDevice.setBlendState instead.');
+    Debug.deprecated('GraphicsDevice#setBlendFunction is deprecated, use GraphicsDevice.setBlendState instead.');
     const currentBlendState = this.blendState;
     _tempBlendState.copy(currentBlendState);
     _tempBlendState.setColorBlend(currentBlendState.colorOp, blendSrc, blendDst);
@@ -329,7 +329,7 @@ GraphicsDevice.prototype.setBlendFunction = function (blendSrc, blendDst) {
 };
 
 GraphicsDevice.prototype.setBlendFunctionSeparate = function (blendSrc, blendDst, blendSrcAlpha, blendDstAlpha) {
-    Debug.deprecated('pc.GraphicsDevice#setBlendFunctionSeparate is deprecated, use pc.GraphicsDevice.setBlendState instead.');
+    Debug.deprecated('GraphicsDevice#setBlendFunctionSeparate is deprecated, use GraphicsDevice.setBlendState instead.');
     const currentBlendState = this.blendState;
     _tempBlendState.copy(currentBlendState);
     _tempBlendState.setColorBlend(currentBlendState.colorOp, blendSrc, blendDst);
@@ -338,7 +338,7 @@ GraphicsDevice.prototype.setBlendFunctionSeparate = function (blendSrc, blendDst
 };
 
 GraphicsDevice.prototype.setBlendEquation = function (blendEquation) {
-    Debug.deprecated('pc.GraphicsDevice#setBlendEquation is deprecated, use pc.GraphicsDevice.setBlendState instead.');
+    Debug.deprecated('GraphicsDevice#setBlendEquation is deprecated, use GraphicsDevice.setBlendState instead.');
     const currentBlendState = this.blendState;
     _tempBlendState.copy(currentBlendState);
     _tempBlendState.setColorBlend(blendEquation, currentBlendState.colorSrcFactor, currentBlendState.colorDstFactor);
@@ -347,7 +347,7 @@ GraphicsDevice.prototype.setBlendEquation = function (blendEquation) {
 };
 
 GraphicsDevice.prototype.setBlendEquationSeparate = function (blendEquation, blendAlphaEquation) {
-    Debug.deprecated('pc.GraphicsDevice#setBlendEquationSeparate is deprecated, use pc.GraphicsDevice.setBlendState instead.');
+    Debug.deprecated('GraphicsDevice#setBlendEquationSeparate is deprecated, use GraphicsDevice.setBlendState instead.');
     const currentBlendState = this.blendState;
     _tempBlendState.copy(currentBlendState);
     _tempBlendState.setColorBlend(blendEquation, currentBlendState.colorSrcFactor, currentBlendState.colorDstFactor);
@@ -356,7 +356,7 @@ GraphicsDevice.prototype.setBlendEquationSeparate = function (blendEquation, ble
 };
 
 GraphicsDevice.prototype.setColorWrite = function (redWrite, greenWrite, blueWrite, alphaWrite) {
-    Debug.deprecated('pc.GraphicsDevice#setColorWrite is deprecated, use pc.GraphicsDevice.setBlendState instead.');
+    Debug.deprecated('GraphicsDevice#setColorWrite is deprecated, use GraphicsDevice.setBlendState instead.');
     const currentBlendState = this.blendState;
     _tempBlendState.copy(currentBlendState);
     _tempBlendState.setColorWrite(redWrite, greenWrite, blueWrite, alphaWrite);
@@ -368,28 +368,28 @@ GraphicsDevice.prototype.getBlending = function () {
 };
 
 GraphicsDevice.prototype.setBlending = function (blending) {
-    Debug.deprecated('pc.GraphicsDevice#setBlending is deprecated, use pc.GraphicsDevice.setBlendState instead.');
+    Debug.deprecated('GraphicsDevice#setBlending is deprecated, use GraphicsDevice.setBlendState instead.');
     _tempBlendState.copy(this.blendState);
     _tempBlendState.blend = blending;
     this.setBlendState(_tempBlendState);
 };
 
 GraphicsDevice.prototype.setDepthWrite = function (write) {
-    Debug.deprecated('pc.GraphicsDevice#setDepthWrite is deprecated, use pc.GraphicsDevice.setDepthState instead.');
+    Debug.deprecated('GraphicsDevice#setDepthWrite is deprecated, use GraphicsDevice.setDepthState instead.');
     _tempDepthState.copy(this.depthState);
     _tempDepthState.write = write;
     this.setDepthState(_tempDepthState);
 };
 
 GraphicsDevice.prototype.setDepthFunc = function (func) {
-    Debug.deprecated('pc.GraphicsDevice#setDepthFunc is deprecated, use pc.GraphicsDevice.setDepthState instead.');
+    Debug.deprecated('GraphicsDevice#setDepthFunc is deprecated, use GraphicsDevice.setDepthState instead.');
     _tempDepthState.copy(this.depthState);
     _tempDepthState.func = func;
     this.setDepthState(_tempDepthState);
 };
 
 GraphicsDevice.prototype.setDepthTest = function (test) {
-    Debug.deprecated('pc.GraphicsDevice#setDepthTest is deprecated, use pc.GraphicsDevice.setDepthState instead.');
+    Debug.deprecated('GraphicsDevice#setDepthTest is deprecated, use GraphicsDevice.setDepthState instead.');
     _tempDepthState.copy(this.depthState);
     _tempDepthState.test = test;
     this.setDepthState(_tempDepthState);
@@ -409,11 +409,11 @@ export const LitOptions = LitShaderOptions;
 // deprecated access to global shader chunks
 export const shaderChunks = new Proxy({}, {
     get(target, prop) {
-        Debug.deprecated(`Using pc.shaderChunks to access global shader chunks is deprecated. Use pc.ShaderChunks.get instead, for example: pc.ShaderChunks.get(this.app.graphicsDevice, pc.SHADERLANGUAGE_GLSL).get('${prop}');`);
+        Debug.deprecated(`Using shaderChunks to access global shader chunks is deprecated. Use ShaderChunks.get instead, for example: ShaderChunks.get(this.app.graphicsDevice, SHADERLANGUAGE_GLSL).get('${prop}');`);
         return ShaderChunks.get(getApplication().graphicsDevice, SHADERLANGUAGE_GLSL).get(prop);
     },
     set(target, prop, value) {
-        Debug.deprecated(`Using pc.shaderChunks to override global shader chunks is deprecated. Use pc.ShaderChunks.get instead, for example: pc.ShaderChunks.get(this.app.graphicsDevice, pc.SHADERLANGUAGE_GLSL).set('${prop}');`);
+        Debug.deprecated(`Using shaderChunks to override global shader chunks is deprecated. Use ShaderChunks.get instead, for example: ShaderChunks.get(this.app.graphicsDevice, SHADERLANGUAGE_GLSL).set('${prop}');`);
         ShaderChunks.get(getApplication().graphicsDevice, SHADERLANGUAGE_GLSL).set(prop, value);
         return true;
     }
@@ -421,7 +421,7 @@ export const shaderChunks = new Proxy({}, {
 
 Object.defineProperty(Scene.prototype, 'defaultMaterial', {
     get: function () {
-        Debug.deprecated('pc.Scene#defaultMaterial is deprecated.');
+        Debug.deprecated('Scene#defaultMaterial is deprecated.');
         return getDefaultMaterial(getApplication().graphicsDevice);
     }
 });
@@ -502,14 +502,14 @@ Object.defineProperty(Scene.prototype, 'rendering', {
 
 Object.defineProperty(LayerComposition.prototype, '_meshInstances', {
     get: function () {
-        Debug.deprecated('pc.LayerComposition#_meshInstances is deprecated.');
+        Debug.deprecated('LayerComposition#_meshInstances is deprecated.');
         return null;
     }
 });
 
 Object.defineProperty(Scene.prototype, 'drawCalls', {
     get: function () {
-        Debug.deprecated('pc.Scene#drawCalls is deprecated and no longer provides mesh instances.');
+        Debug.deprecated('Scene#drawCalls is deprecated and no longer provides mesh instances.');
         return null;
     }
 });
@@ -518,11 +518,11 @@ Object.defineProperty(Scene.prototype, 'drawCalls', {
 ['128', '64', '32', '16', '8', '4'].forEach((size, index) => {
     Object.defineProperty(Scene.prototype, `skyboxPrefiltered${size}`, {
         get: function () {
-            Debug.deprecated(`pc.Scene#skyboxPrefiltered${size} is deprecated. Use pc.Scene#prefilteredCubemaps instead.`);
+            Debug.deprecated(`Scene#skyboxPrefiltered${size} is deprecated. Use Scene#prefilteredCubemaps instead.`);
             return this._prefilteredCubemaps[index];
         },
         set: function (value) {
-            Debug.deprecated(`pc.Scene#skyboxPrefiltered${size} is deprecated. Use pc.Scene#prefilteredCubemaps instead.`);
+            Debug.deprecated(`Scene#skyboxPrefiltered${size} is deprecated. Use Scene#prefilteredCubemaps instead.`);
             this._prefilteredCubemaps[index] = value;
             this.updateShaders = true;
         }
@@ -571,62 +571,62 @@ _removedClassProperty(CameraComponent, 'onPreRenderLayer', 'Use Scene#EVENT_PRER
 _removedClassProperty(CameraComponent, 'onPostRenderLayer', 'Use Scene#EVENT_POSTRENDER_LAYER event instead.');
 
 ForwardRenderer.prototype.renderComposition = function (comp) {
-    Debug.deprecated('pc.ForwardRenderer#renderComposition is deprecated. Use pc.AppBase.renderComposition instead.');
+    Debug.deprecated('ForwardRenderer#renderComposition is deprecated. Use AppBase.renderComposition instead.');
     getApplication().renderComposition(comp);
 };
 
 MeshInstance.prototype.syncAabb = function () {
-    Debug.deprecated('pc.MeshInstance#syncAabb is deprecated.');
+    Debug.deprecated('MeshInstance#syncAabb is deprecated.');
 };
 
 Morph.prototype.getTarget = function (index) {
-    Debug.deprecated('pc.Morph#getTarget is deprecated. Use pc.Morph#targets instead.');
+    Debug.deprecated('Morph#getTarget is deprecated. Use Morph#targets instead.');
 
     return this.targets[index];
 };
 
 GraphNode.prototype.getChildren = function () {
-    Debug.deprecated('pc.GraphNode#getChildren is deprecated. Use pc.GraphNode#children instead.');
+    Debug.deprecated('GraphNode#getChildren is deprecated. Use GraphNode#children instead.');
 
     return this.children;
 };
 
 GraphNode.prototype.getName = function () {
-    Debug.deprecated('pc.GraphNode#getName is deprecated. Use pc.GraphNode#name instead.');
+    Debug.deprecated('GraphNode#getName is deprecated. Use GraphNode#name instead.');
 
     return this.name;
 };
 
 GraphNode.prototype.getPath = function () {
-    Debug.deprecated('pc.GraphNode#getPath is deprecated. Use pc.GraphNode#path instead.');
+    Debug.deprecated('GraphNode#getPath is deprecated. Use GraphNode#path instead.');
 
     return this.path;
 };
 
 GraphNode.prototype.getRoot = function () {
-    Debug.deprecated('pc.GraphNode#getRoot is deprecated. Use pc.GraphNode#root instead.');
+    Debug.deprecated('GraphNode#getRoot is deprecated. Use GraphNode#root instead.');
 
     return this.root;
 };
 
 GraphNode.prototype.getParent = function () {
-    Debug.deprecated('pc.GraphNode#getParent is deprecated. Use pc.GraphNode#parent instead.');
+    Debug.deprecated('GraphNode#getParent is deprecated. Use GraphNode#parent instead.');
 
     return this.parent;
 };
 
 GraphNode.prototype.setName = function (name) {
-    Debug.deprecated('pc.GraphNode#setName is deprecated. Use pc.GraphNode#name instead.');
+    Debug.deprecated('GraphNode#setName is deprecated. Use GraphNode#name instead.');
 
     this.name = name;
 };
 
 Object.defineProperty(Material.prototype, 'shader', {
     set: function (value) {
-        Debug.deprecated('pc.Material#shader is deprecated, use pc.ShaderMaterial instead.');
+        Debug.deprecated('Material#shader is deprecated, use ShaderMaterial instead.');
     },
     get: function () {
-        Debug.deprecated('pc.Material#shader is deprecated, use pc.ShaderMaterial instead.');
+        Debug.deprecated('Material#shader is deprecated, use ShaderMaterial instead.');
         return null;
     }
 });
@@ -634,7 +634,7 @@ Object.defineProperty(Material.prototype, 'shader', {
 // Note: this is used by the Editor
 Object.defineProperty(Material.prototype, 'blend', {
     set: function (value) {
-        Debug.deprecated('pc.Material#blend is deprecated, use pc.Material.blendState.');
+        Debug.deprecated('Material#blend is deprecated, use Material.blendState.');
         this.blendState.blend = value;
     },
     get: function () {
@@ -665,12 +665,12 @@ Object.defineProperty(StandardMaterial.prototype, 'useGammaTonemap', {
 
 Object.defineProperty(StandardMaterial.prototype, 'anisotropy', {
     get: function () {
-        Debug.deprecated('pc.StandardMaterial#anisotropy is deprecated. Use pc.StandardMaterial#anisotropyIntensity and pc.StandardMaterial#anisotropyRotation instead.');
+        Debug.deprecated('StandardMaterial#anisotropy is deprecated. Use StandardMaterial#anisotropyIntensity and StandardMaterial#anisotropyRotation instead.');
         const sign = Math.sign(Math.cos(this.anisotropyRotation * math.DEG_TO_RAD * 2));
         return this.anisotropyIntensity * sign;
     },
     set: function (value) {
-        Debug.deprecated('pc.StandardMaterial#anisotropy is deprecated. Use pc.StandardMaterial#anisotropyIntensity and pc.StandardMaterial#anisotropyRotation instead.');
+        Debug.deprecated('StandardMaterial#anisotropy is deprecated. Use StandardMaterial#anisotropyIntensity and StandardMaterial#anisotropyRotation instead.');
         this.anisotropyIntensity = Math.abs(value);
         if (value >= 0) {
             this.anisotropyRotation = 0;
@@ -683,11 +683,11 @@ Object.defineProperty(StandardMaterial.prototype, 'anisotropy', {
 function _defineAlias(newName, oldName) {
     Object.defineProperty(StandardMaterial.prototype, oldName, {
         get: function () {
-            Debug.deprecated(`pc.StandardMaterial#${oldName} is deprecated. Use pc.StandardMaterial#${newName} instead.`);
+            Debug.deprecated(`StandardMaterial#${oldName} is deprecated. Use StandardMaterial#${newName} instead.`);
             return this[newName];
         },
         set: function (value) {
-            Debug.deprecated(`pc.StandardMaterial#${oldName} is deprecated. Use pc.StandardMaterial#${newName} instead.`);
+            Debug.deprecated(`StandardMaterial#${oldName} is deprecated. Use StandardMaterial#${newName} instead.`);
             this[newName] = value;
         }
     });
@@ -696,11 +696,11 @@ function _defineAlias(newName, oldName) {
 function _deprecateTint(name) {
     Object.defineProperty(StandardMaterial.prototype, name, {
         get: function () {
-            Debug.deprecated(`pc.StandardMaterial#${name} is deprecated, and the behaviour is as if ${name} was always true`);
+            Debug.deprecated(`StandardMaterial#${name} is deprecated, and the behaviour is as if ${name} was always true`);
             return true;
         },
         set: function (value) {
-            Debug.deprecated(`pc.StandardMaterial#${name} is deprecated, and the behaviour is as if ${name} was always true`);
+            Debug.deprecated(`StandardMaterial#${name} is deprecated, and the behaviour is as if ${name} was always true`);
         }
     });
 }
@@ -727,11 +727,11 @@ function _defineOption(name, newName) {
     if (name !== 'pass') {
         Object.defineProperty(StandardMaterialOptions.prototype, name, {
             get: function () {
-                Debug.deprecated(`Getting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitShaderOptions#${newName || name}.`);
+                Debug.deprecated(`Getting StandardMaterialOptions#${name} is deprecated. Use StandardMaterialOptions#litOptions.${newName || name} instead.`);
                 return this.litOptions[newName || name];
             },
             set: function (value) {
-                Debug.deprecated(`Setting pc.Options#${name} has been deprecated as the property has been moved to pc.Options.LitShaderOptions#${newName || name}.`);
+                Debug.deprecated(`Setting StandardMaterialOptions#${name} is deprecated. Use StandardMaterialOptions#litOptions.${newName || name} instead.`);
                 this.litOptions[newName || name] = value;
             }
         });
@@ -748,7 +748,7 @@ for (const litOption in litOptionProperties) {
 // ASSET
 
 AssetRegistry.prototype.getAssetById = function (id) {
-    Debug.deprecated('pc.AssetRegistry#getAssetById is deprecated. Use pc.AssetRegistry#get instead.');
+    Debug.deprecated('AssetRegistry#getAssetById is deprecated. Use AssetRegistry#get instead.');
     return this.get(id);
 };
 
@@ -756,21 +756,21 @@ AssetRegistry.prototype.getAssetById = function (id) {
 
 Object.defineProperty(XrInputSource.prototype, 'ray', {
     get: function () {
-        Debug.deprecated('pc.XrInputSource#ray is deprecated. Use pc.XrInputSource#getOrigin and pc.XrInputSource#getDirection instead.');
+        Debug.deprecated('XrInputSource#ray is deprecated. Use XrInputSource#getOrigin and XrInputSource#getDirection instead.');
         return this._rayLocal;
     }
 });
 
 Object.defineProperty(XrInputSource.prototype, 'position', {
     get: function () {
-        Debug.deprecated('pc.XrInputSource#position is deprecated. Use pc.XrInputSource#getLocalPosition instead.');
+        Debug.deprecated('XrInputSource#position is deprecated. Use XrInputSource#getLocalPosition instead.');
         return this._localPosition;
     }
 });
 
 Object.defineProperty(XrInputSource.prototype, 'rotation', {
     get: function () {
-        Debug.deprecated('pc.XrInputSource#rotation is deprecated. Use pc.XrInputSource#getLocalRotation instead.');
+        Debug.deprecated('XrInputSource#rotation is deprecated. Use XrInputSource#getLocalRotation instead.');
         return this._localRotation;
     }
 });
@@ -824,13 +824,13 @@ export const RIGIDBODY_DISABLE_DEACTIVATION = BODYSTATE_DISABLE_DEACTIVATION;
 export const RIGIDBODY_DISABLE_SIMULATION = BODYSTATE_DISABLE_SIMULATION;
 
 AppBase.prototype.isFullscreen = function () {
-    Debug.deprecated('pc.AppBase#isFullscreen is deprecated. Use the Fullscreen API directly.');
+    Debug.deprecated('AppBase#isFullscreen is deprecated. Use the Fullscreen API directly.');
 
     return !!document.fullscreenElement;
 };
 
 AppBase.prototype.enableFullscreen = function (element, success, error) {
-    Debug.deprecated('pc.AppBase#enableFullscreen is deprecated. Use the Fullscreen API directly.');
+    Debug.deprecated('AppBase#enableFullscreen is deprecated. Use the Fullscreen API directly.');
 
     element = element || this.graphicsDevice.canvas;
 
@@ -862,7 +862,7 @@ AppBase.prototype.enableFullscreen = function (element, success, error) {
 };
 
 AppBase.prototype.disableFullscreen = function (success) {
-    Debug.deprecated('pc.AppBase#disableFullscreen is deprecated. Use the Fullscreen API directly.');
+    Debug.deprecated('AppBase#disableFullscreen is deprecated. Use the Fullscreen API directly.');
 
     // success callback
     const s = function () {
@@ -878,7 +878,7 @@ AppBase.prototype.disableFullscreen = function (success) {
 };
 
 AppBase.prototype.getSceneUrl = function (name) {
-    Debug.deprecated('pc.AppBase#getSceneUrl is deprecated. Use pc.AppBase#scenes and pc.SceneRegistry#find instead.');
+    Debug.deprecated('AppBase#getSceneUrl is deprecated. Use AppBase#scenes and SceneRegistry#find instead.');
     const entry = this.scenes.find(name);
     if (entry) {
         return entry.url;
@@ -887,43 +887,43 @@ AppBase.prototype.getSceneUrl = function (name) {
 };
 
 AppBase.prototype.loadScene = function (url, callback) {
-    Debug.deprecated('pc.AppBase#loadScene is deprecated. Use pc.AppBase#scenes and pc.SceneRegistry#loadScene instead.');
+    Debug.deprecated('AppBase#loadScene is deprecated. Use AppBase#scenes and SceneRegistry#loadScene instead.');
     this.scenes.loadScene(url, callback);
 };
 
 AppBase.prototype.loadSceneHierarchy = function (url, callback) {
-    Debug.deprecated('pc.AppBase#loadSceneHierarchy is deprecated. Use pc.AppBase#scenes and pc.SceneRegistry#loadSceneHierarchy instead.');
+    Debug.deprecated('AppBase#loadSceneHierarchy is deprecated. Use AppBase#scenes and SceneRegistry#loadSceneHierarchy instead.');
     this.scenes.loadSceneHierarchy(url, callback);
 };
 
 AppBase.prototype.loadSceneSettings = function (url, callback) {
-    Debug.deprecated('pc.AppBase#loadSceneSettings is deprecated. Use pc.AppBase#scenes and pc.SceneRegistry#loadSceneSettings instead.');
+    Debug.deprecated('AppBase#loadSceneSettings is deprecated. Use AppBase#scenes and SceneRegistry#loadSceneSettings instead.');
     this.scenes.loadSceneSettings(url, callback);
 };
 
 ModelComponent.prototype.setVisible = function (visible) {
-    Debug.deprecated('pc.ModelComponent#setVisible is deprecated. Use pc.ModelComponent#enabled instead.');
+    Debug.deprecated('ModelComponent#setVisible is deprecated. Use ModelComponent#enabled instead.');
     this.enabled = visible;
 };
 
 Object.defineProperty(RigidBodyComponent.prototype, 'bodyType', {
     get: function () {
-        Debug.deprecated('pc.RigidBodyComponent#bodyType is deprecated. Use pc.RigidBodyComponent#type instead.');
+        Debug.deprecated('RigidBodyComponent#bodyType is deprecated. Use RigidBodyComponent#type instead.');
         return this.type;
     },
     set: function (type) {
-        Debug.deprecated('pc.RigidBodyComponent#bodyType is deprecated. Use pc.RigidBodyComponent#type instead.');
+        Debug.deprecated('RigidBodyComponent#bodyType is deprecated. Use RigidBodyComponent#type instead.');
         this.type = type;
     }
 });
 
 RigidBodyComponent.prototype.syncBodyToEntity = function () {
-    Debug.deprecated('pc.RigidBodyComponent#syncBodyToEntity is not public API and should not be used.');
+    Debug.deprecated('RigidBodyComponent#syncBodyToEntity is not public API and should not be used.');
     this._updateDynamic();
 };
 
 RigidBodyComponentSystem.prototype.setGravity = function () {
-    Debug.deprecated('pc.RigidBodyComponentSystem#setGravity is deprecated. Use pc.RigidBodyComponentSystem#gravity instead.');
+    Debug.deprecated('RigidBodyComponentSystem#setGravity is deprecated. Use RigidBodyComponentSystem#gravity instead.');
 
     if (arguments.length === 1) {
         this.gravity.copy(arguments[0]);


### PR DESCRIPTION
## Summary

Updates deprecated API diagnostics to use module-era symbol names instead of the secondary `pc.` namespace.

## Changes

- Remove all 152 `pc.` qualifications from messages in `deprecated.js`.
- Keep corrected geometry migration snippets in named-symbol form.
- Replace inaccurate `Options.LitShaderOptions` guidance with the actual `StandardMaterialOptions#litOptions.*` access path.

## Public API changes

None. This changes development-build diagnostic text only; deprecated API behavior is unchanged.

## Validation

- `npm run lint`
- `git diff --check`
- Confirmed `deprecated.js` contains no remaining `pc.` references.