### PR TITLE
Use Debug.removed for nonfunctional compatibility shims

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -180,14 +180,14 @@ Object.defineProperties(RenderTarget.prototype, {
             return this.impl._glFrameBuffer;
         },
         set: function (rgbm) {
-            Debug.deprecated('RenderTarget#_glFrameBuffer is deprecated. Use RenderTarget.impl#_glFrameBuffer instead.');
+            Debug.removed('RenderTarget#_glFrameBuffer setter was removed. Use RenderTarget.impl#_glFrameBuffer instead.');
         }
     }
 });
 
 Object.defineProperty(VertexFormat, 'defaultInstancingFormat', {
     get: function () {
-        Debug.deprecated('VertexFormat.defaultInstancingFormat is deprecated. Use VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
+        Debug.removed('VertexFormat.defaultInstancingFormat was removed. Use VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
         return null;
     }
 });
@@ -502,14 +502,14 @@ Object.defineProperty(Scene.prototype, 'rendering', {
 
 Object.defineProperty(LayerComposition.prototype, '_meshInstances', {
     get: function () {
-        Debug.deprecated('LayerComposition#_meshInstances is deprecated.');
+        Debug.removed('LayerComposition#_meshInstances was removed.');
         return null;
     }
 });
 
 Object.defineProperty(Scene.prototype, 'drawCalls', {
     get: function () {
-        Debug.deprecated('Scene#drawCalls is deprecated and no longer provides mesh instances.');
+        Debug.removed('Scene#drawCalls was removed and no longer provides mesh instances.');
         return null;
     }
 });
@@ -538,14 +538,14 @@ Object.defineProperty(Scene.prototype, 'models', {
     }
 });
 
-// A helper function to add deprecated set and get property on a class
+// A helper function to add a removed set and get property on a class
 function _removedClassProperty(targetClass, name, comment = '') {
     Object.defineProperty(targetClass.prototype, name, {
         set: function (value) {
-            Debug.errorOnce(`${targetClass.name}#${name} has been removed. ${comment}`);
+            Debug.removed(`${targetClass.name}#${name} was removed. ${comment}`);
         },
         get: function () {
-            Debug.errorOnce(`${targetClass.name}#${name} has been removed. ${comment}`);
+            Debug.removed(`${targetClass.name}#${name} was removed. ${comment}`);
             return undefined;
         }
     });
@@ -576,7 +576,7 @@ ForwardRenderer.prototype.renderComposition = function (comp) {
 };
 
 MeshInstance.prototype.syncAabb = function () {
-    Debug.deprecated('MeshInstance#syncAabb is deprecated.');
+    Debug.removed('MeshInstance#syncAabb was removed.');
 };
 
 Morph.prototype.getTarget = function (index) {
@@ -623,10 +623,10 @@ GraphNode.prototype.setName = function (name) {
 
 Object.defineProperty(Material.prototype, 'shader', {
     set: function (value) {
-        Debug.deprecated('Material#shader is deprecated, use ShaderMaterial instead.');
+        Debug.removed('Material#shader was removed. Use ShaderMaterial instead.');
     },
     get: function () {
-        Debug.deprecated('Material#shader is deprecated, use ShaderMaterial instead.');
+        Debug.removed('Material#shader was removed. Use ShaderMaterial instead.');
         return null;
     }
 });
@@ -693,22 +693,22 @@ function _defineAlias(newName, oldName) {
     });
 }
 
-function _deprecateTint(name) {
+function _removeTint(name) {
     Object.defineProperty(StandardMaterial.prototype, name, {
         get: function () {
-            Debug.deprecated(`StandardMaterial#${name} is deprecated, and the behaviour is as if ${name} was always true`);
+            Debug.removed(`StandardMaterial#${name} was removed, and the behaviour is as if ${name} was always true`);
             return true;
         },
         set: function (value) {
-            Debug.deprecated(`StandardMaterial#${name} is deprecated, and the behaviour is as if ${name} was always true`);
+            Debug.removed(`StandardMaterial#${name} was removed, and the behaviour is as if ${name} was always true`);
         }
     });
 }
 
-_deprecateTint('sheenTint');
-_deprecateTint('diffuseTint');
-_deprecateTint('emissiveTint');
-_deprecateTint('ambientTint');
+_removeTint('sheenTint');
+_removeTint('diffuseTint');
+_removeTint('emissiveTint');
+_removeTint('ambientTint');
 
 _defineAlias('specularTint', 'specularMapTint');
 _defineAlias('aoVertexColor', 'aoMapVertexColor');


### PR DESCRIPTION
## Summary

Classifies compatibility shims that no longer perform their original function as removed rather than deprecated.

## Changes

- Use `Debug.removed` for placeholder getters, ignored setters, and no-op methods.
- Update the 17 removed Layer and Camera callback properties from `Debug.errorOnce` to the dedicated removed diagnostic.
- Mark removed material shader and tint properties consistently.
- Keep working aliases, forwarding methods, and meaningful compatibility values on `Debug.deprecated`.

## Public API changes

None. Production behavior is unchanged because Debug calls are stripped from production builds. Debug builds now report these 27 nonfunctional compatibility entry points as `REMOVED`.

## Validation

- `npm run lint`
- `git diff --check`
- Audited remaining `Debug.deprecated` shims for ignored setters, no-op methods, and null or undefined placeholders.