### PR TITLE
Refactor deprecated math and graphics shims

### DIFF
--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -1,3 +1,4 @@
+import { Debug } from '../debug.js';
 import { math } from './math.js';
 
 /**
@@ -435,6 +436,11 @@ class Vec2 {
         this.y *= scalar;
 
         return this;
+    }
+
+    scale(scalar) {
+        Debug.deprecated('Vec2#scale is deprecated. Use Vec2#mulScalar instead.');
+        return this.mulScalar(scalar);
     }
 
     /**

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -1,3 +1,5 @@
+import { Debug } from '../debug.js';
+
 /**
  * A 3-dimensional vector. Vec3 is commonly used to represent 3D positions, directions, Euler
  * angles or scales.
@@ -469,6 +471,11 @@ class Vec3 {
         this.z *= scalar;
 
         return this;
+    }
+
+    scale(scalar) {
+        Debug.deprecated('Vec3#scale is deprecated. Use Vec3#mulScalar instead.');
+        return this.mulScalar(scalar);
     }
 
     /**

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -1,3 +1,5 @@
+import { Debug } from '../debug.js';
+
 /**
  * A 4-dimensional vector. Vec4 is commonly used to represent homogeneous coordinates or shader
  * uniforms requiring four components.
@@ -446,6 +448,11 @@ class Vec4 {
         this.w *= scalar;
 
         return this;
+    }
+
+    scale(scalar) {
+        Debug.deprecated('Vec4#scale is deprecated. Use Vec4#mulScalar instead.');
+        return this.mulScalar(scalar);
     }
 
     /**

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -1,7 +1,5 @@
 import { Debug } from '../core/debug.js';
 
-import { Vec2 } from '../core/math/vec2.js';
-import { Vec3 } from '../core/math/vec3.js';
 import { Vec4 } from '../core/math/vec4.js';
 import { math } from '../core/math/math.js';
 
@@ -9,15 +7,11 @@ import {
     BLENDMODE_CONSTANT, BLENDMODE_ONE_MINUS_CONSTANT,
     PIXELFORMAT_LA8, PIXELFORMAT_RGB565, PIXELFORMAT_RGBA5551, PIXELFORMAT_RGBA4, PIXELFORMAT_RGB8, PIXELFORMAT_RGBA8,
     PIXELFORMAT_SRGB8, PIXELFORMAT_SRGBA8,
-    TEXTURETYPE_DEFAULT, TEXTURETYPE_RGBM, TEXTURETYPE_SWIZZLEGGGR,
     SHADERLANGUAGE_GLSL
 } from '../platform/graphics/constants.js';
 import { drawQuadWithShader } from '../scene/graphics/quad-render-utils.js';
 import { GraphicsDevice } from '../platform/graphics/graphics-device.js';
 import { LayerComposition } from '../scene/composition/layer-composition.js';
-import { RenderTarget } from '../platform/graphics/render-target.js';
-import { Texture } from '../platform/graphics/texture.js';
-import { VertexFormat } from '../platform/graphics/vertex-format.js';
 import { BlendState } from '../platform/graphics/blend-state.js';
 import { DepthState } from '../platform/graphics/depth-state.js';
 
@@ -62,14 +56,6 @@ import { RigidBodyComponent } from '../framework/components/rigid-body/component
 import { RigidBodyComponentSystem } from '../framework/components/rigid-body/system.js';
 import { CameraComponent } from '../framework/components/camera/component.js';
 import { ShaderChunks } from '../scene/shader-lib/shader-chunks.js';
-
-// MATH
-
-Vec2.prototype.scale = Vec2.prototype.mulScalar;
-
-Vec3.prototype.scale = Vec3.prototype.mulScalar;
-
-Vec4.prototype.scale = Vec4.prototype.mulScalar;
 
 // GRAPHICS
 
@@ -172,57 +158,6 @@ export function drawFullscreenQuad(device, target, vertexBuffer, shader, rect) {
     drawQuadWithShader(device, target, shader, viewport);
 }
 
-// Note: This was never public interface, but has been used in external scripts
-Object.defineProperties(RenderTarget.prototype, {
-    _glFrameBuffer: {
-        get: function () {
-            Debug.deprecated('RenderTarget#_glFrameBuffer is deprecated. Use RenderTarget.impl#_glFrameBuffer instead.');
-            return this.impl._glFrameBuffer;
-        },
-        set: function (rgbm) {
-            Debug.removed('RenderTarget#_glFrameBuffer setter was removed. Use RenderTarget.impl#_glFrameBuffer instead.');
-        }
-    }
-});
-
-Object.defineProperty(VertexFormat, 'defaultInstancingFormat', {
-    get: function () {
-        Debug.removed('VertexFormat.defaultInstancingFormat was removed. Use VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
-        return null;
-    }
-});
-
-Object.defineProperties(Texture.prototype, {
-    rgbm: {
-        get: function () {
-            Debug.deprecated('Texture#rgbm is deprecated. Use Texture#type instead.');
-            return this.type === TEXTURETYPE_RGBM;
-        },
-        set: function (rgbm) {
-            Debug.deprecated('Texture#rgbm is deprecated. Use Texture#type instead.');
-            this.type = rgbm ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
-        }
-    },
-
-    swizzleGGGR: {
-        get: function () {
-            Debug.deprecated('Texture#swizzleGGGR is deprecated. Use Texture#type instead.');
-            return this.type === TEXTURETYPE_SWIZZLEGGGR;
-        },
-        set: function (swizzleGGGR) {
-            Debug.deprecated('Texture#swizzleGGGR is deprecated. Use Texture#type instead.');
-            this.type = swizzleGGGR ? TEXTURETYPE_SWIZZLEGGGR : TEXTURETYPE_DEFAULT;
-        }
-    },
-
-    _glTexture: {
-        get: function () {
-            Debug.deprecated('Texture#_glTexture is no longer available. Use Texture.impl._glTexture instead.');
-            return this.impl._glTexture;
-        }
-    }
-});
-
 Object.defineProperty(GraphicsDevice.prototype, 'boneLimit', {
     get: function () {
         Debug.deprecated('GraphicsDevice#boneLimit is deprecated and the limit has been removed.');
@@ -313,8 +248,6 @@ Object.defineProperty(GraphicsDevice.prototype, 'extStandardDerivatives', {
         return true;
     }
 });
-
-BlendState.DEFAULT = Object.freeze(new BlendState());
 
 const _tempBlendState = new BlendState();
 const _tempDepthState = new DepthState();

--- a/src/platform/graphics/blend-state.js
+++ b/src/platform/graphics/blend-state.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../core/debug.js';
 import { BitPacking } from '../../core/math/bit-packing.js';
 import { BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ZERO, BLENDMODE_SRC_ALPHA, BLENDMODE_ONE_MINUS_SRC_ALPHA } from '../../platform/graphics/constants.js';
 
@@ -21,6 +22,7 @@ const blendShift = 26;              // 26 (1 bit)
 // combined values access
 const allWriteMasks = 0b1111;
 const allWriteShift = redWriteShift;
+
 /**
  * BlendState is a descriptor that defines how output of fragment shader is written and blended
  * into render target. A blend state can be set on a material using {@link Material#blendState},
@@ -237,6 +239,11 @@ class BlendState {
      * @readonly
      */
     static NOBLEND = Object.freeze(new BlendState());
+
+    static get DEFAULT() {
+        Debug.deprecated('BlendState.DEFAULT is deprecated. Use BlendState.NOBLEND instead.');
+        return BlendState.NOBLEND;
+    }
 
     /**
      * A blend state that does not write to color channels.

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -644,6 +644,15 @@ class RenderTarget {
         return this._height ?? this._device.height;
     }
 
+    set _glFrameBuffer(value) {
+        Debug.removed('RenderTarget#_glFrameBuffer setter was removed. Use RenderTarget.impl#_glFrameBuffer instead.');
+    }
+
+    get _glFrameBuffer() {
+        Debug.deprecated('RenderTarget#_glFrameBuffer is deprecated. Use RenderTarget.impl#_glFrameBuffer instead.');
+        return this.impl._glFrameBuffer;
+    }
+
     /**
      * Gets whether the format of the specified color buffer is sRGB.
      *

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -11,7 +11,7 @@ import {
     TEXHINT_SHADOWMAP, TEXHINT_ASSET, TEXHINT_LIGHTMAP,
     TEXTURELOCK_WRITE,
     TEXTUREPROJECTION_NONE, TEXTUREPROJECTION_CUBE,
-    TEXTURETYPE_DEFAULT, TEXTURETYPE_RGBM, TEXTURETYPE_RGBE, TEXTURETYPE_RGBP,
+    TEXTURETYPE_DEFAULT, TEXTURETYPE_RGBM, TEXTURETYPE_RGBE, TEXTURETYPE_RGBP, TEXTURETYPE_SWIZZLEGGGR,
     isIntegerPixelFormat, FILTER_NEAREST, TEXTURELOCK_NONE, TEXTURELOCK_READ,
     TEXPROPERTY_MIN_FILTER, TEXPROPERTY_MAG_FILTER, TEXPROPERTY_ADDRESS_U, TEXPROPERTY_ADDRESS_V,
     TEXPROPERTY_ADDRESS_W, TEXPROPERTY_COMPARE_ON_READ, TEXPROPERTY_COMPARE_FUNC, TEXPROPERTY_ANISOTROPY,
@@ -951,6 +951,31 @@ class Texture {
      */
     get type() {
         return this._type;
+    }
+
+    set rgbm(value) {
+        Debug.deprecated('Texture#rgbm is deprecated. Use Texture#type instead.');
+        this.type = value ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
+    }
+
+    get rgbm() {
+        Debug.deprecated('Texture#rgbm is deprecated. Use Texture#type instead.');
+        return this.type === TEXTURETYPE_RGBM;
+    }
+
+    set swizzleGGGR(value) {
+        Debug.deprecated('Texture#swizzleGGGR is deprecated. Use Texture#type instead.');
+        this.type = value ? TEXTURETYPE_SWIZZLEGGGR : TEXTURETYPE_DEFAULT;
+    }
+
+    get swizzleGGGR() {
+        Debug.deprecated('Texture#swizzleGGGR is deprecated. Use Texture#type instead.');
+        return this.type === TEXTURETYPE_SWIZZLEGGGR;
+    }
+
+    get _glTexture() {
+        Debug.deprecated('Texture#_glTexture is no longer available. Use Texture.impl._glTexture instead.');
+        return this.impl._glTexture;
     }
 
     /**

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -236,6 +236,11 @@ class VertexFormat {
         });
     }
 
+    static get defaultInstancingFormat() {
+        Debug.removed('VertexFormat.defaultInstancingFormat was removed. Use VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
+        return null;
+    }
+
     static isElementValid(graphicsDevice, elementDesc) {
         const elementSize = elementDesc.components * typedArrayTypesByteSize[elementDesc.type];
         if (graphicsDevice.isWebGPU && !webgpuValidElementSizes.includes(elementSize)) {


### PR DESCRIPTION
## Summary
- move deprecated Vec scale aliases into their owning classes and emit deprecation diagnostics
- move RenderTarget, VertexFormat, Texture, and BlendState compatibility shims out of deprecated.js
- keep compatibility members undocumented so they remain absent from the API reference
- make BlendState.DEFAULT warn on access and return BlendState.NOBLEND

## Public API changes
No supported public API changes. Existing deprecated compatibility members retain their behavior and migration diagnostics.

## Validation
- npm run lint
- npm run build:types
- npm run test:types
- npm run docs
- relevant Vec, Texture, and BlendState unit tests

Related to https://github.com/playcanvas/engine/pull/6900