### PR TITLE
Add unclamped scalar interpolation

### DIFF
--- a/src/core/math/math.js
+++ b/src/core/math/math.js
@@ -130,9 +130,7 @@ const math = {
      *
      * @param {number} a - Number to linearly interpolate from.
      * @param {number} b - Number to linearly interpolate to.
-     * @param {number} alpha - The value controlling the result of interpolation. When alpha is 0,
-     * a is returned. When alpha is 1, b is returned. Between 0 and 1, a linear interpolation
-     * between a and b is returned. alpha is clamped between 0 and 1.
+     * @param {number} alpha - The interpolation factor, clamped to the range 0 to 1.
      * @returns {number} The linear interpolation of two numbers.
      * @example
      * math.lerp(0, 10, 0);   // returns 0
@@ -141,6 +139,23 @@ const math = {
      */
     lerp(a, b, alpha) {
         return a + (b - a) * math.clamp(alpha, 0, 1);
+    },
+
+    /**
+     * Calculates the unclamped linear interpolation of two numbers.
+     *
+     * @param {number} a - Number to linearly interpolate from.
+     * @param {number} b - Number to linearly interpolate to.
+     * @param {number} alpha - The interpolation factor. Values outside the range 0 to 1 extrapolate
+     * beyond a or b.
+     * @returns {number} The linear interpolation of two numbers.
+     * @example
+     * math.lerpUnclamped(0, 10, -0.5); // returns -5
+     * math.lerpUnclamped(0, 10, 0.5);  // returns 5
+     * math.lerpUnclamped(0, 10, 1.5);  // returns 15
+     */
+    lerpUnclamped(a, b, alpha) {
+        return a + (b - a) * alpha;
     },
 
     /**

--- a/src/core/math/quat.js
+++ b/src/core/math/quat.js
@@ -322,9 +322,8 @@ class Quat {
      *
      * @param {Quat} lhs - The quaternion to interpolate from.
      * @param {Quat} rhs - The quaternion to interpolate to.
-     * @param {number} alpha - The value controlling the interpolation in relation to the two input
-     * quaternions. The value is in the range 0 to 1, 0 generating q1, 1 generating q2 and anything
-     * in between generating a linear interpolation between the two.
+     * @param {number} alpha - The unclamped interpolation factor. Values between 0 and 1 interpolate
+     * between lhs and rhs; values outside this range extrapolate beyond them.
      * @returns {Quat} Self for chaining.
      * @example
      * const q1 = new Quat(-0.11, -0.15, -0.46, 0.87);
@@ -689,9 +688,8 @@ class Quat {
      *
      * @param {Quat} lhs - The quaternion to interpolate from.
      * @param {Quat} rhs - The quaternion to interpolate to.
-     * @param {number} alpha - The value controlling the interpolation in relation to the two input
-     * quaternions. The value is in the range 0 to 1, 0 generating q1, 1 generating q2 and anything
-     * in between generating a spherical interpolation between the two.
+     * @param {number} alpha - The unclamped interpolation factor. Values between 0 and 1 interpolate
+     * between lhs and rhs; values outside this range extrapolate beyond them.
      * @returns {Quat} Self for chaining.
      * @example
      * const q1 = new Quat(-0.11, -0.15, -0.46, 0.87);

--- a/test/core/math/math.test.mjs
+++ b/test/core/math/math.test.mjs
@@ -152,6 +152,30 @@ describe('math', function () {
 
     });
 
+    describe('#lerpUnclamped', function () {
+
+        it('returns a when alpha is 0', function () {
+            expect(math.lerpUnclamped(0, 1, 0)).to.equal(0);
+        });
+
+        it('returns b when alpha is 1', function () {
+            expect(math.lerpUnclamped(0, 1, 1)).to.equal(1);
+        });
+
+        it('interpolates when alpha is between 0 and 1', function () {
+            expect(math.lerpUnclamped(0, 1, 0.5)).to.equal(0.5);
+        });
+
+        it('extrapolates below a when alpha is less than 0', function () {
+            expect(math.lerpUnclamped(0, 10, -0.5)).to.equal(-5);
+        });
+
+        it('extrapolates beyond b when alpha is greater than 1', function () {
+            expect(math.lerpUnclamped(0, 10, 1.5)).to.equal(15);
+        });
+
+    });
+
     describe('#lerpAngle', function () {
 
         it('returns 0 when a is 0 and b is 360 and alpha is 0', function () {


### PR DESCRIPTION
## Overview

Addresses #5955 by adding an unclamped scalar interpolation helper consistent with the extrapolating vector, color, and quaternion interpolation APIs.

- Adds `math.lerpUnclamped` with JSDoc examples.
- Covers interpolation and extrapolation behavior with unit tests.
- Clarifies that `math.lerp` clamps its interpolation factor.
- Documents the existing unclamped extrapolation behavior of `Quat.lerp` and `Quat.slerp`.

## Public API changes

Before, scalar extrapolation required an inline expression:

```javascript
const result = a + (b - a) * alpha;
```

It can now use the new helper:

```javascript
const result = math.lerpUnclamped(a, b, alpha);
```

The existing `math.lerp` behavior is unchanged and remains clamped.

## Performance

The helper is allocation-free and evaluates the interpolation expression directly.

## Testing

- Focused core math unit tests
- ESLint
- Type declaration generation and validation