### PR TITLE
fix: omit HUD-only soft flag from shadow-soft light setup

### DIFF
--- a/examples/src/examples/gaussian-splatting/shadow-soft.example.mjs
+++ b/examples/src/examples/gaussian-splatting/shadow-soft.example.mjs
@@ -192,6 +192,7 @@ app.root.addChild(camera);
 camera.script.orbitCamera.resetAndLookAtPoint(new Vec3(-3, 2, 4), new Vec3(0, 0, 0));
 
 // Single directional light casting soft shadows
+const { soft: softShadows, ...lightSettings } = data.get('settings.light');
 const dirLight = new Entity('MainLight');
 dirLight.addComponent('light', {
     ...{
@@ -201,11 +202,11 @@ dirLight.addComponent('light', {
         shadowBias: 0.2,
         normalOffsetBias: 0.05,
         castShadows: true,
-        shadowType: data.get('settings.light.soft') ? SHADOW_PCSS_32F : SHADOW_PCF3_32F,
+        shadowType: softShadows ? SHADOW_PCSS_32F : SHADOW_PCF3_32F,
         shadowDistance: 10,
         shadowResolution: 2048
     },
-    ...data.get('settings.light')
+    ...lightSettings
 });
 app.root.addChild(dirLight);
 dirLight.setLocalEulerAngles(55, 30, 0);

--- a/examples/src/examples/graphics/shadow-soft.example.mjs
+++ b/examples/src/examples/graphics/shadow-soft.example.mjs
@@ -181,6 +181,7 @@ camera.script.create('orbitCameraInputTouch');
 app.root.addChild(camera);
 
 // Create a directional light casting soft shadows
+const { soft: softShadows, ...lightSettings } = data.get('settings.light');
 const dirLight = new Entity('MainLight');
 dirLight.addComponent('light', {
     ...{
@@ -192,10 +193,10 @@ dirLight.addComponent('light', {
 
         // Enable shadow casting
         castShadows: true,
-        shadowType: data.get('settings.light.soft') ? SHADOW_PCSS_32F : SHADOW_PCF3_32F,
+        shadowType: softShadows ? SHADOW_PCSS_32F : SHADOW_PCF3_32F,
         shadowDistance: 1000
     },
-    ...data.get('settings.light')
+    ...lightSettings
 });
 app.root.addChild(dirLight);
 dirLight.setLocalEulerAngles(75, 120, 20);


### PR DESCRIPTION
## Summary
- Stop spreading the HUD-only `settings.light.soft` toggle into `addComponent('light', …)` in both shadow-soft examples.
- Map `soft` to `shadowType` at setup time via destructuring so PCSS/PCF selection is unchanged.

## Test plan
- [ ] Run the gaussian-splatting/shadow-soft example in a debug build and confirm the `unknown option 'soft'` warning is gone.
- [ ] Toggle Soft Shadows in the HUD and confirm shadow type still switches between PCSS and PCF.
- [ ] Run the graphics/shadow-soft example and repeat the above checks.