### PR TITLE
fix: omit HUD-only everyFrame flag from shadow-cascades light setup

### DIFF
--- a/examples/src/examples/graphics/shadow-cascades.example.mjs
+++ b/examples/src/examples/graphics/shadow-cascades.example.mjs
@@ -175,6 +175,7 @@ camera.script.create('orbitCameraInputTouch');
 app.root.addChild(camera);
 
 // Create a directional light casting cascaded shadows
+const { everyFrame, ...lightSettings } = data.get('settings.light');
 const dirLight = new Entity('Cascaded Light');
 dirLight.addComponent('light', {
     ...{
@@ -188,13 +189,13 @@ dirLight.addComponent('light', {
         castShadows: true,
         shadowDistance: 1000
     },
-    ...data.get('settings.light')
+    ...lightSettings
 });
 app.root.addChild(dirLight);
 dirLight.setLocalEulerAngles(45, 350, 20);
 
 // Update mode of cascades
-let updateEveryFrame = true;
+let updateEveryFrame = everyFrame;
 
 // Handle HUD changes - update properties on the light
 data.on('*:set', (/** @type {string} */ path, value) => {


### PR DESCRIPTION
## Summary
- Stop spreading the HUD-only `settings.light.everyFrame` toggle into `addComponent('light', …)` in the shadow-cascades example.
- Initialize cascade shadow update mode from the extracted `everyFrame` value so behavior matches the previous default.

## Test plan
- [ ] Run the graphics/shadow-cascades example in a debug build and confirm the `unknown option 'everyFrame'` warning is gone.
- [ ] Toggle "Every Frame" in the HUD and confirm cascade shadow updates still switch between all frames and staggered updates.