### PR TITLE
fix: use range instead of radius in shader toon and wobble examples

### DIFF
--- a/examples/src/examples/shaders/shader-toon.example.mjs
+++ b/examples/src/examples/shaders/shader-toon.example.mjs
@@ -90,7 +90,7 @@ const light = new Entity();
 light.addComponent('light', {
     type: 'omni',
     color: new Color(1, 1, 1),
-    radius: 10
+    range: 10
 });
 light.translate(0, 1, 0);
 

--- a/examples/src/examples/shaders/shader-wobble.example.mjs
+++ b/examples/src/examples/shaders/shader-wobble.example.mjs
@@ -89,7 +89,7 @@ const light = new Entity();
 light.addComponent('light', {
     type: 'omni',
     color: new Color(1, 1, 1),
-    radius: 10
+    range: 10
 });
 light.translate(0, 1, 0);
 


### PR DESCRIPTION
## Summary
- Replace `radius` with `range` when creating omni lights in the shader-toon and shader-wobble examples.
- Restores the intended falloff distance (10) and removes debug `unknown option 'radius'` warnings.

## Test plan
- [ ] Run shaders/shader-toon and shaders/shader-wobble in a debug build and confirm the unknown option warnings are gone.
- [ ] Verify scene lighting still looks correct in both examples.