### PR TITLE
examples: mark texture-formats test example as hidden

### DIFF
--- a/examples/src/examples/test/texture-formats.example.mjs
+++ b/examples/src/examples/test/texture-formats.example.mjs
@@ -1,3 +1,9 @@
+// @config
+//
+// Test example for texture asset loading — png, dds, ktx2, basis, and hdr parsers.
+//
+// @flag HIDDEN
+
 import {
     AppBase,
     AppOptions,


### PR DESCRIPTION
Adds the `@flag HIDDEN` example config header to `texture-formats.example.mjs` so it matches other internal test examples and is excluded from the public examples browser.

**Changes:**
- Add `@config` block with description and `HIDDEN` flag to `examples/src/examples/test/texture-formats.example.mjs`

**Examples:**
- Updated: `test/texture-formats` (hidden test example)