### PR TITLE
Fix examples controls dependency pre-bundling

### DIFF
--- a/examples/vite.config.mjs
+++ b/examples/vite.config.mjs
@@ -30,6 +30,9 @@ export default defineConfig({
     appType: 'custom',
     clearScreen: false,
     publicDir: false,
+    optimizeDeps: {
+        include: ['@babel/standalone']
+    },
     server: {
         hmr: AUTO_RELOAD ? undefined : false,
         host: HOST,


### PR DESCRIPTION
## Summary

- Explicitly pre-bundle @babel/standalone in the examples Vite configuration.
- Prevent controls from failing when Vite discovers the lazy Babel import after the page has loaded and invalidates the dependency hash.

## Public API changes

None.

## Verification

- npx eslint vite.config.mjs
- Confirmed a forced cold Vite start lists @babel/standalone in optimized dependency metadata and generates its bundle before the first page request.

## Performance considerations

Moves Babel dependency optimization to dev-server startup. The optimized module remains lazily loaded by the examples UI.