### PR TITLE
Add Camera projectionOffset for off-center (shift lens) projection

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.jsx
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.jsx
@@ -102,6 +102,16 @@ export function Controls({ observer }) {
                         step={0.0001}
                     />
                 </LabelGroup>
+                <LabelGroup text='Vertical Correction'>
+                    <SliderInput
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'verticalCorrection' }}
+                        min={0}
+                        max={1}
+                        precision={2}
+                        step={0.01}
+                    />
+                </LabelGroup>
                 <LabelGroup text='High Res'>
                     <BooleanInput
                         type='toggle'

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -49,6 +49,7 @@ import {
     createGraphicsDevice,
     platform
 } from 'playcanvas';
+import { PerspectiveCorrection } from 'playcanvas/scripts/esm/camera/perspective-correction.mjs';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { GSplatRevealRadial } from 'playcanvas/scripts/esm/gsplat/reveal-radial.mjs';
 
@@ -300,6 +301,13 @@ Object.assign(cc, {
     enableOrbit: false,
     enablePan: false,
     focusPoint: focusPoint
+});
+
+// Perspective correction (shift lens): keeps vertical lines parallel when looking up or down
+data.set('verticalCorrection', 0);
+const correction = /** @type {PerspectiveCorrection} */ (camera.script.create(PerspectiveCorrection));
+data.on('verticalCorrection:set', () => {
+    correction.verticalCorrection = data.get('verticalCorrection');
 });
 
 // CameraFrame for HDR linear rendering (created lazily on first enable)

--- a/examples/src/examples/graphics/hdr.controls.jsx
+++ b/examples/src/examples/graphics/hdr.controls.jsx
@@ -61,6 +61,15 @@ export function Controls({ observer }) {
                     precision={2}
                 />
             </LabelGroup>
+            <LabelGroup text='Vertical Correction'>
+                <SliderInput
+                    binding={new BindingTwoWay()}
+                    link={{ observer, path: 'data.verticalCorrection' }}
+                    min={0}
+                    max={1}
+                    precision={2}
+                />
+            </LabelGroup>
         </>
     );
 }

--- a/examples/src/examples/graphics/hdr.example.mjs
+++ b/examples/src/examples/graphics/hdr.example.mjs
@@ -1,5 +1,7 @@
 // @config
 //
+// `WASDQE` Move · Hold `Shift` Move fast · `LMB` / `RMB` Orbit / fly · Hold `Shift` / `MMB` Pan · `Wheel` / `Pinch` Zoom · `F` Focus
+//
 // @credit
 // title: Mirror's Edge Apartment - Interior Scene
 // author: Aurélien Martel
@@ -39,8 +41,11 @@ import {
     TextureHandler,
     TouchDevice,
     Vec2,
+    Vec3,
     createGraphicsDevice
 } from 'playcanvas';
+import { PerspectiveCorrection } from 'playcanvas/scripts/esm/camera/perspective-correction.mjs';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 import { data, deviceType } from 'examples/context';
 
@@ -48,7 +53,6 @@ const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('applic
 window.focus();
 
 const assets = {
-    orbit: new Asset('script', 'script', { url: './scripts/camera/orbit-camera.js' }),
     apartment: new Asset('apartment', 'container', { url: './assets/models/apartment.glb' }),
     love: new Asset('love', 'container', { url: './assets/models/love.glb' }),
     colors: new Asset('colors', 'texture', { url: './assets/textures/colors.webp' }, { srgb: true }),
@@ -154,25 +158,21 @@ cameraEntity.addComponent('camera', {
     fov: 80
 });
 
-const focusPoint = new Entity();
-focusPoint.setLocalPosition(-80, 80, -20);
-
-// Add orbit camera script with a mouse and a touch support
+// Add multi camera controls - orbits by default, `RMB` / `WASD` to fly
 cameraEntity.addComponent('script');
-cameraEntity.script.create('orbitCamera', {
-    attributes: {
-        inertiaFactor: 0.2,
-        focusEntity: focusPoint,
-        distanceMax: 500,
-        frameOnStart: false
-    }
-});
-cameraEntity.script.create('orbitCameraInputMouse');
-cameraEntity.script.create('orbitCameraInputTouch');
-
 cameraEntity.setLocalPosition(-50, 100, 220);
-cameraEntity.lookAt(0, 0, 100);
 app.root.addChild(cameraEntity);
+const cc = /** @type {CameraControls} */ (cameraEntity.script.create(CameraControls));
+Object.assign(cc, {
+    focusPoint: new Vec3(-80, 80, -20),
+    sceneSize: 500,
+    moveSpeed: 60,
+    moveFastSpeed: 180,
+    zoomRange: new Vec2(10, 500)
+});
+
+// Perspective correction (shift lens): keeps vertical lines parallel when looking up or down
+const correction = /** @type {PerspectiveCorrection} */ (cameraEntity.script.create(PerspectiveCorrection));
 
 // Create a 2D screen
 const screen = new Entity();
@@ -234,11 +234,16 @@ data.on('*:set', (/** @type {string} */ path, value) => {
         cameraFrame.colorLUT.intensity = value;
         cameraFrame.update();
     }
+
+    if (path === 'data.verticalCorrection') {
+        correction.verticalCorrection = value;
+    }
 });
 
 // Set initial values
 data.set('data', {
     hdr: true,
     sceneTonemapping: TONEMAP_ACES,
-    colorLutIntensity: 1.0
+    colorLutIntensity: 1.0,
+    verticalCorrection: 0
 });

--- a/scripts/esm/camera/perspective-correction.mjs
+++ b/scripts/esm/camera/perspective-correction.mjs
@@ -1,0 +1,127 @@
+import { PROJECTION_PERSPECTIVE, Quat, Script, Vec2, math } from 'playcanvas';
+
+/**
+ * Applies architectural perspective correction (shift lens) to a camera, keeping vertical lines
+ * parallel when the camera looks up or down. For rendering only, part of the camera pitch is
+ * removed so the image plane stays vertical, and the framing is preserved using a vertical
+ * {@link CameraComponent#projectionOffset} (off-center projection). The entity rotation is
+ * modified for the duration of the render and restored afterwards, so camera controls and other
+ * scripts observing the entity are unaffected.
+ *
+ * The script must be added to an entity with a camera component. Perspective projection only;
+ * it is inactive in XR, where the projection is supplied by the XR system.
+ *
+ * @example
+ * const camera = new Entity();
+ * camera.addComponent('camera');
+ * camera.addComponent('script');
+ * const correction = camera.script.create(PerspectiveCorrection);
+ * correction.verticalCorrection = 1; // fully parallel verticals
+ * app.root.addChild(camera);
+ * @category Camera
+ */
+class PerspectiveCorrection extends Script {
+    static scriptName = 'perspectiveCorrection';
+
+    /**
+     * The amount of vertical perspective correction. 0 renders true perspective, 1 keeps
+     * vertical lines fully parallel (two-point perspective).
+     *
+     * @attribute
+     * @range [0, 1]
+     * @type {number}
+     */
+    verticalCorrection = 0;
+
+    /**
+     * The maximum camera pitch, in degrees, that is converted into projection offset. Any
+     * residual pitch stays in the view, preventing extreme stretching as the camera approaches
+     * straight up or down.
+     *
+     * @attribute
+     * @range [0, 85]
+     * @type {number}
+     */
+    maxShiftAngle = 70;
+
+    /** @private */
+    _trueRotation = new Quat();
+
+    /** @private */
+    _levelRotation = new Quat();
+
+    /** @private */
+    _offset = new Vec2();
+
+    /** @private */
+    _applied = false;
+
+    initialize() {
+        if (!this.entity.camera) {
+            console.error('PerspectiveCorrection: the script requires a camera component on its entity.');
+            this.enabled = false;
+            return;
+        }
+
+        const onPrerender = () => this._apply();
+        const onPostrender = () => this._restore();
+
+        this.app.on('prerender', onPrerender);
+        this.app.on('postrender', onPostrender);
+
+        this.on('disable', () => this._reset());
+        this.on('destroy', () => {
+            this.app.off('prerender', onPrerender);
+            this.app.off('postrender', onPostrender);
+            this._reset();
+        });
+    }
+
+    /** @private */
+    _apply() {
+        const camera = this.entity.camera;
+        if (!this.enabled || !camera || camera.projection !== PROJECTION_PERSPECTIVE || this.app.xr?.active) {
+            return;
+        }
+
+        this._trueRotation.copy(this.entity.getRotation());
+
+        // move (up to maxShiftAngle degrees of) pitch from the camera rotation into the
+        // projection offset
+        const amount = math.clamp(this.verticalCorrection, 0, 1);
+        const pitch = Math.asin(math.clamp(this.entity.forward.y, -1, 1)) * math.RAD_TO_DEG;
+        const shiftPitch = math.clamp(pitch * amount, -this.maxShiftAngle, this.maxShiftAngle);
+
+        // tilt the render camera back down towards level, around its right axis
+        this._levelRotation.setFromAxisAngle(this.entity.right, -shiftPitch);
+        this.entity.setRotation(this._levelRotation.mul(this._trueRotation));
+
+        // vertical rise/fall of the projection window: tan(shift) / tan(fovY/2), which maps the
+        // original view center back to the screen center
+        let tanHalfFovY = Math.tan(0.5 * camera.fov * math.DEG_TO_RAD);
+        if (camera.horizontalFov) {
+            tanHalfFovY /= camera.aspectRatio;
+        }
+        this._offset.set(0, Math.tan(shiftPitch * math.DEG_TO_RAD) / tanHalfFovY);
+        camera.projectionOffset = this._offset;
+
+        this._applied = true;
+    }
+
+    /** @private */
+    _restore() {
+        if (this._applied) {
+            this._applied = false;
+            this.entity.setRotation(this._trueRotation);
+        }
+    }
+
+    /** @private */
+    _reset() {
+        if (this.entity.camera) {
+            this.entity.camera.projectionOffset = Vec2.ZERO;
+        }
+    }
+}
+
+export { PerspectiveCorrection };

--- a/scripts/esm/camera/perspective-correction.mjs
+++ b/scripts/esm/camera/perspective-correction.mjs
@@ -56,6 +56,9 @@ class PerspectiveCorrection extends Script {
     /** @private */
     _applied = false;
 
+    /** @private */
+    _offsetSet = false;
+
     initialize() {
         if (!this.entity.camera) {
             console.error('PerspectiveCorrection: the script requires a camera component on its entity.');
@@ -81,6 +84,10 @@ class PerspectiveCorrection extends Script {
     _apply() {
         const camera = this.entity.camera;
         if (!this.enabled || !camera || camera.projection !== PROJECTION_PERSPECTIVE || this.app.xr?.active) {
+            // clear a previously applied offset (e.g. after a switch to orthographic projection)
+            if (this._offsetSet) {
+                this._reset();
+            }
             return;
         }
 
@@ -105,6 +112,7 @@ class PerspectiveCorrection extends Script {
         this._offset.set(0, Math.tan(shiftPitch * math.DEG_TO_RAD) / tanHalfFovY);
         camera.projectionOffset = this._offset;
 
+        this._offsetSet = true;
         this._applied = true;
     }
 
@@ -118,6 +126,11 @@ class PerspectiveCorrection extends Script {
 
     /** @private */
     _reset() {
+        // restore the entity rotation in case the render was interrupted between the prerender
+        // and postrender events
+        this._restore();
+
+        this._offsetSet = false;
         if (this.entity.camera) {
             this.entity.camera.projectionOffset = Vec2.ZERO;
         }

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -17,6 +17,7 @@ import { PostEffectQueue } from './post-effect-queue.js';
  * @import { FramePass } from '../../../platform/graphics/frame-pass.js'
  * @import { RenderTarget } from '../../../platform/graphics/render-target.js'
  * @import { FogParams } from '../../../scene/fog-params.js'
+ * @import { Vec2 } from '../../../core/math/vec2.js'
  * @import { Vec3 } from '../../../core/math/vec3.js'
  * @import { Vec4 } from '../../../core/math/vec4.js'
  * @import { XrErrorCallback } from '../../xr/xr-manager.js'
@@ -877,6 +878,36 @@ class CameraComponent extends Component {
     }
 
     /**
+     * Sets the offset of the projection window from the view direction, creating an off-center
+     * (asymmetric) projection. The offset is expressed in half-frustum units - an offset of
+     * `(0, 1)` moves the projection window up by half of the frustum height. Applies to both
+     * perspective and orthographic projections and is ignored in XR, where the projection is
+     * supplied by the XR system. Defaults to `(0, 0)`.
+     *
+     * A typical use case is perspective correction (shift lens): keep the camera level and use
+     * a vertical offset to frame a tall object, so its vertical lines stay parallel:
+     *
+     * @example
+     * // frame content that is `pitch` degrees above the horizon, without tilting the camera
+     * const fovY = entity.camera.fov * pc.math.DEG_TO_RAD;
+     * const shift = Math.tan(pitch * pc.math.DEG_TO_RAD) / Math.tan(fovY / 2);
+     * entity.camera.projectionOffset = new pc.Vec2(0, shift);
+     * @type {Vec2}
+     */
+    set projectionOffset(value) {
+        this._camera.projectionOffset = value;
+    }
+
+    /**
+     * Gets the offset of the projection window.
+     *
+     * @type {Vec2}
+     */
+    get projectionOffset() {
+        return this._camera.projectionOffset;
+    }
+
+    /**
      * Sets the rendering rectangle for the camera. This controls where on the screen the camera
      * will render in normalized screen coordinates. Defaults to `[0, 0, 1, 1]`.
      *
@@ -1373,6 +1404,7 @@ class CameraComponent extends Component {
         this.orthoHeight = source.orthoHeight;
         this.priority = source.priority;
         this.projection = source.projection;
+        this.projectionOffset = source.projectionOffset;
         this.rect = source.rect;
         this.renderTarget = source.renderTarget;
         this.scissorRect = source.scissorRect;

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -1,5 +1,6 @@
 import { sortPriority } from '../../../core/sort.js';
 import { Color } from '../../../core/math/color.js';
+import { Vec2 } from '../../../core/math/vec2.js';
 import { Vec4 } from '../../../core/math/vec4.js';
 import { ComponentSystem } from '../system.js';
 import { CameraComponent } from './component.js';
@@ -32,6 +33,7 @@ const _properties = [
     'nearClip',
     'orthoHeight',
     'projection',
+    'projectionOffset',
     'priority',
     'rect',
     'scissorRect',
@@ -90,6 +92,13 @@ class CameraComponentSystem extends ComponentSystem {
                     case 'clearColor':
                         if (Array.isArray(value)) {
                             component[property] = new Color(value[0], value[1], value[2], value[3]);
+                        } else {
+                            component[property] = value;
+                        }
+                        break;
+                    case 'projectionOffset':
+                        if (Array.isArray(value)) {
+                            component[property] = new Vec2(value[0], value[1]);
                         } else {
                             component[property] = value;
                         }

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -1,6 +1,7 @@
 import { Color } from '../core/math/color.js';
 import { Debug } from '../core/debug.js';
 import { Mat4 } from '../core/math/mat4.js';
+import { Vec2 } from '../core/math/vec2.js';
 import { Vec3 } from '../core/math/vec3.js';
 import { Vec4 } from '../core/math/vec4.js';
 import { math } from '../core/math/math.js';
@@ -171,6 +172,7 @@ class Camera {
         this._node = null;
         this._orthoHeight = 10;
         this._projection = PROJECTION_PERSPECTIVE;
+        this._projectionOffset = new Vec2();
         this._rect = new Vec4(0, 0, 1, 1);
         this._renderTarget = null;
         this._scissorRect = new Vec4(0, 0, 1, 1);
@@ -476,6 +478,15 @@ class Camera {
         return this._projMat;
     }
 
+    set projectionOffset(newValue) {
+        this._projectionOffset.copy(newValue);
+        this._projMatDirty = true;
+    }
+
+    get projectionOffset() {
+        return this._projectionOffset;
+    }
+
     set rect(newValue) {
         this._rect.copy(newValue);
         this._projMatDirty = true;
@@ -668,6 +679,7 @@ class Camera {
         this.layers = other.layers;
         this.orthoHeight = other.orthoHeight;
         this.projection = other.projection;
+        this.projectionOffset = other.projectionOffset;
         this.rect = other.rect;
         this.renderTarget = other.renderTarget;
         this.scissorRect = other.scissorRect;
@@ -857,9 +869,11 @@ class Camera {
             // calculate half width and height at the near clip plane
             Mat4._getPerspectiveHalfSize(_halfSize, this.fov, this.aspectRatio, this.nearClip, this.horizontalFov);
 
-            // scale by normalized screen coordinates
-            _halfSize.x *= _deviceCoord.x;
-            _halfSize.y *= _deviceCoord.y;
+            // scale by normalized screen coordinates, taking the projection offset into account
+            // (the offset is ignored in XR, where projection matrices are supplied by the XR system)
+            const offset = this.xrActive ? Vec2.ZERO : this._projectionOffset;
+            _halfSize.x *= _deviceCoord.x + offset.x;
+            _halfSize.y *= _deviceCoord.y + offset.y;
 
             // transform to world space
             const invView = this._node.getWorldTransform();
@@ -891,14 +905,27 @@ class Camera {
         // no other input changes)
         const aspect = this.aspectRatio;
         if (this._projMatDirty) {
+            const offset = this._projectionOffset;
             if (this._projection === PROJECTION_PERSPECTIVE) {
                 this._projMat.setPerspective(this.fov, aspect, this.nearClip, this.farClip, this.horizontalFov);
+
+                // off-center projection - the offset is directly the frustum off-center terms
+                // (right+left)/(right-left) and (top+bottom)/(top-bottom), in half-frustum units
+                this._projMat.data[8] = offset.x;
+                this._projMat.data[9] = offset.y;
                 this._projMatSkybox.copy(this._projMat);
             } else {
                 const y = this._orthoHeight;
                 const x = y * aspect;
                 this._projMat.setOrtho(-x, x, -y, y, this.nearClip, this.farClip);
+
+                // off-center projection - translate the ortho window by the offset in half-window
+                // units, matching the perspective sign convention
+                this._projMat.data[12] = -offset.x;
+                this._projMat.data[13] = -offset.y;
                 this._projMatSkybox.setPerspective(this.fov, aspect, this.nearClip, this.farClip);
+                this._projMatSkybox.data[8] = offset.x;
+                this._projMatSkybox.data[9] = offset.y;
             }
 
             this._projMatDirty = false;
@@ -957,6 +984,7 @@ class Camera {
     getFrustumCorners(near = this.nearClip, far = this.farClip) {
 
         const fov = this.fov * math.DEG_TO_RAD;
+        const offset = this.xrActive ? Vec2.ZERO : this._projectionOffset;
         let x, y;
 
         if (this.projection === PROJECTION_PERSPECTIVE) {
@@ -972,18 +1000,22 @@ class Camera {
             x = y * this.aspectRatio;
         }
 
+        // center of the projection window, offset for off-center projections
+        let cx = offset.x * x;
+        let cy = offset.y * y;
+
         const points = _frustumPoints;
-        points[0].x = x;
-        points[0].y = -y;
+        points[0].x = cx + x;
+        points[0].y = cy - y;
         points[0].z = -near;
-        points[1].x = x;
-        points[1].y = y;
+        points[1].x = cx + x;
+        points[1].y = cy + y;
         points[1].z = -near;
-        points[2].x = -x;
-        points[2].y = y;
+        points[2].x = cx - x;
+        points[2].y = cy + y;
         points[2].z = -near;
-        points[3].x = -x;
-        points[3].y = -y;
+        points[3].x = cx - x;
+        points[3].y = cy - y;
         points[3].z = -near;
 
         if (this._projection === PROJECTION_PERSPECTIVE) {
@@ -994,18 +1026,20 @@ class Camera {
                 y = far * Math.tan(fov / 2.0);
                 x = y * this.aspectRatio;
             }
+            cx = offset.x * x;
+            cy = offset.y * y;
         }
-        points[4].x = x;
-        points[4].y = -y;
+        points[4].x = cx + x;
+        points[4].y = cy - y;
         points[4].z = -far;
-        points[5].x = x;
-        points[5].y = y;
+        points[5].x = cx + x;
+        points[5].y = cy + y;
         points[5].z = -far;
-        points[6].x = -x;
-        points[6].y = y;
+        points[6].x = cx - x;
+        points[6].y = cy + y;
         points[6].z = -far;
-        points[7].x = -x;
-        points[7].y = -y;
+        points[7].x = cx - x;
+        points[7].y = cy - y;
         points[7].z = -far;
 
         return points;

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -363,15 +363,15 @@ class Renderer {
                 jitterX = jitter * (offset.x * 2 - 1) / targetWidth;
                 jitterY = jitter * (offset.y * 2 - 1) / targetHeight;
 
-                // apply offset to projection matrix
+                // apply jitter to projection matrix, on top of any off-center projection offset
                 projMat = _tempProjMat4.copy(projMat);
-                projMat.data[8] = jitterX;
-                projMat.data[9] = jitterY;
+                projMat.data[8] += jitterX;
+                projMat.data[9] += jitterY;
 
-                // apply offset to skybox projection matrix
+                // apply jitter to skybox projection matrix
                 projMatSkybox = _tempProjMat5.copy(projMatSkybox);
-                projMatSkybox.data[8] = jitterX;
-                projMatSkybox.data[9] = jitterY;
+                projMatSkybox.data[8] += jitterX;
+                projMatSkybox.data[9] += jitterY;
 
                 // blue noise vec4 - only use when jitter is enabled
                 if (this.blueNoiseJitterVersion !== this.device.renderVersion) {

--- a/test/framework/components/camera/component.test.mjs
+++ b/test/framework/components/camera/component.test.mjs
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { Color } from '../../../../src/core/math/color.js';
+import { Vec2 } from '../../../../src/core/math/vec2.js';
 import { Vec4 } from '../../../../src/core/math/vec4.js';
 import { Entity } from '../../../../src/framework/entity.js';
 import {
@@ -47,6 +48,14 @@ describe('CameraComponent', function () {
             expect(e.camera.orthoHeight).to.equal(10);
             expect(e.camera.priority).to.equal(0);
             expect(e.camera.projection).to.equal(PROJECTION_PERSPECTIVE);
+            expect(e.camera.projectionOffset.equals(new Vec2(0, 0))).to.equal(true);
+        });
+
+        it('accepts an array-literal projectionOffset', function () {
+            const e = new Entity();
+            e.addComponent('camera', { projectionOffset: [0.1, 0.2] });
+
+            expect(e.camera.projectionOffset.equals(new Vec2(0.1, 0.2))).to.equal(true);
         });
 
     });
@@ -85,6 +94,7 @@ describe('CameraComponent', function () {
                 orthoHeight: 7,
                 priority: 3,
                 projection: PROJECTION_ORTHOGRAPHIC,
+                projectionOffset: new Vec2(0.1, -0.2),
                 rect: new Vec4(0.1, 0.1, 0.5, 0.5),
                 scissorRect: new Vec4(0.2, 0.2, 0.6, 0.6),
                 aperture: 8,
@@ -120,6 +130,7 @@ describe('CameraComponent', function () {
             expect(c.orthoHeight).to.equal(7);
             expect(c.priority).to.equal(3);
             expect(c.projection).to.equal(PROJECTION_ORTHOGRAPHIC);
+            expect(c.projectionOffset.equals(new Vec2(0.1, -0.2))).to.equal(true);
             expect(c.rect.equals(new Vec4(0.1, 0.1, 0.5, 0.5))).to.equal(true);
             expect(c.scissorRect.equals(new Vec4(0.2, 0.2, 0.6, 0.6))).to.equal(true);
             expect(c.aperture).to.equal(8);

--- a/test/scene/camera.test.mjs
+++ b/test/scene/camera.test.mjs
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
 
+import { Vec2 } from '../../src/core/math/vec2.js';
+import { Vec3 } from '../../src/core/math/vec3.js';
 import { Vec4 } from '../../src/core/math/vec4.js';
 import { Entity } from '../../src/framework/entity.js';
 import { Camera } from '../../src/scene/camera.js';
-import { ASPECT_AUTO, ASPECT_MANUAL } from '../../src/scene/constants.js';
+import { ASPECT_AUTO, ASPECT_MANUAL, PROJECTION_ORTHOGRAPHIC } from '../../src/scene/constants.js';
 import { createApp } from '../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../jsdom.mjs';
 
@@ -134,6 +136,98 @@ describe('Camera', function () {
             // rebuild the matrix
             const after = camera.projectionMatrix;
             expect(after.equals(before)).to.equal(false);
+        });
+    });
+
+    describe('#projectionOffset', function () {
+
+        it('defaults to (0, 0) and copies the assigned value', function () {
+            const camera = new Camera(app.graphicsDevice);
+            expect(camera.projectionOffset.equals(new Vec2())).to.equal(true);
+
+            const value = new Vec2(0.25, -0.5);
+            camera.projectionOffset = value;
+            value.set(9, 9);
+            expect(camera.projectionOffset.equals(new Vec2(0.25, -0.5))).to.equal(true);
+        });
+
+        it('applies off-center terms to the perspective projection matrix', function () {
+            const camera = new Camera(app.graphicsDevice);
+            const before = camera.projectionMatrix.clone();
+
+            camera.projectionOffset = new Vec2(0.25, -0.5);
+            const after = camera.projectionMatrix;
+            expect(after.data[8]).to.equal(0.25);
+            expect(after.data[9]).to.equal(-0.5);
+
+            // no other element is affected
+            for (let i = 0; i < 16; i++) {
+                if (i !== 8 && i !== 9) {
+                    expect(after.data[i]).to.equal(before.data[i]);
+                }
+            }
+        });
+
+        it('translates the orthographic projection window', function () {
+            const camera = new Camera(app.graphicsDevice);
+            camera.projection = PROJECTION_ORTHOGRAPHIC;
+            const before = camera.projectionMatrix.clone();
+
+            camera.projectionOffset = new Vec2(0.25, -0.5);
+            const after = camera.projectionMatrix;
+            expect(after.data[12]).to.equal(-0.25);
+            expect(after.data[13]).to.equal(0.5);
+
+            // no other element is affected
+            for (let i = 0; i < 16; i++) {
+                if (i !== 12 && i !== 13) {
+                    expect(after.data[i]).to.equal(before.data[i]);
+                }
+            }
+        });
+
+        it('keeps worldToScreen and screenToWorld consistent', function () {
+            app.graphicsDevice.setResolution(800, 400);
+
+            const camera = new Camera(app.graphicsDevice);
+            camera.node = new Entity();
+            camera.projectionOffset = new Vec2(0.3, -0.2);
+
+            const world = new Vec3(0.5, -0.7, -5);
+            const screen = camera.worldToScreen(world, 800, 400, new Vec3());
+
+            // screenToWorld takes the distance from the camera along the ray
+            const roundtrip = camera.screenToWorld(screen.x, screen.y, world.length(), 800, 400, new Vec3());
+            expect(roundtrip.x).to.be.closeTo(world.x, 1e-6);
+            expect(roundtrip.y).to.be.closeTo(world.y, 1e-6);
+            expect(roundtrip.z).to.be.closeTo(world.z, 1e-6);
+        });
+
+        it('offsets the frustum corners', function () {
+            const camera = new Camera(app.graphicsDevice);
+            camera.aspectRatioMode = ASPECT_MANUAL;
+            camera.aspectRatio = 1;
+            camera.fov = 90;
+            camera.nearClip = 1;
+            camera.farClip = 10;
+            camera.projectionOffset = new Vec2(0, 0.5);
+
+            // near plane: half-height = tan(45) = 1, window center offset by 0.5
+            const corners = camera.getFrustumCorners();
+            expect(corners[0].y).to.be.closeTo(-0.5, 1e-6);
+            expect(corners[1].y).to.be.closeTo(1.5, 1e-6);
+
+            // far plane: half-height = 10, window center offset by 5
+            expect(corners[4].y).to.be.closeTo(-5, 1e-6);
+            expect(corners[5].y).to.be.closeTo(15, 1e-6);
+        });
+
+        it('is transferred by clone()', function () {
+            const camera = new Camera(app.graphicsDevice);
+            camera.projectionOffset = new Vec2(0.1, 0.2);
+
+            const clone = camera.clone();
+            expect(clone.projectionOffset.equals(new Vec2(0.1, 0.2))).to.equal(true);
         });
     });
 


### PR DESCRIPTION
Adds a generic off-center (asymmetric) projection to the camera, and a `PerspectiveCorrection` script built on top of it that keeps vertical lines parallel when the camera looks up or down (architectural shift-lens / perspective correction).

**Changes:**
- `Camera` / `CameraComponent.projectionOffset` (`Vec2`, default `(0, 0)`) — offset of the projection window in half-frustum (NDC) units. Applies to perspective (off-center frustum terms) and orthographic (window translation) projections. Ignored in XR, where projection matrices are supplied by the XR system.
- `screenToWorld` and `getFrustumCorners` account for the offset, keeping picking and directional shadow cascade fitting consistent with the rendered image.
- TAA jitter now adds to the projection matrix off-center terms instead of overwriting them, so jitter composes with the offset.
- New `scripts/esm/camera/perspective-correction.mjs` (`PerspectiveCorrection`) — levels the render camera around its right axis during rendering (restoring the entity rotation afterwards) and compensates with a vertical projection offset, preserving framing. Exposes `verticalCorrection` (0–1) and `maxShiftAngle` attributes; inactive for orthographic cameras and in XR.

**API Changes:**
```js
// off-center projection, directly
entity.camera.projectionOffset = new pc.Vec2(0, 0.5);

// or perspective correction via the script
const correction = entity.script.create(PerspectiveCorrection);
correction.verticalCorrection = 1; // fully parallel verticals
```

**Examples:**
- `gaussian-splatting/lod-streaming` — new Vertical Correction slider using the `PerspectiveCorrection` script.
- `graphics/hdr` — camera switched from orbit-camera to `CameraControls` (orbit + fly), with the `PerspectiveCorrection` script and a Vertical Correction slider; also demonstrates the offset composing with `CameraFrame` post-processing.


https://github.com/user-attachments/assets/6633a47b-8f67-4236-b576-9efd484de8e0

