### PR TITLE
Fix inverted normal mapping on WebGPU (derivative TBN)

### DIFF
--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -423,7 +423,11 @@ class Renderer {
             camera.frustum.setFromMat4(viewProjMat);
         }
 
-        this.tbnBasis.setValue(flipY ? -1 : 1);
+        // Sign for the derivative-based TBN (see TBN.js). It compensates for the Y flip applied to
+        // the projection matrix when rendering with flipY. On WebGPU there is an additional inherent
+        // flip because screen-space dpdy has the opposite sign to WebGL's dFdy (framebuffer space is
+        // Y-down), so the backend is XORed into the sign to keep normal mapping consistent (#5735).
+        this.tbnBasis.setValue((this.device.isWebGPU !== !!flipY) ? -1 : 1);
 
         // camera params
         this.cameraParamsId.setValue(camera.fillShaderParams(this.cameraParams));


### PR DESCRIPTION
Fixes #5735, fixes #6984, fixes #8905 — inverted normal-mapped lighting on WebGPU for meshes that have no vertex tangents (the tangent frame is derived from screen-space derivatives). Confirmed against the Khronos [NormalTangentTest](https://github.com/KhronosGroup/glTF-Sample-Models/blob/main/2.0/NormalTangentTest/README.md) — WebGPU now matches WebGL2 and the reference. (#6984 and #8905 are duplicate reports of the same issue.)

**Cause:**
- The derivative-based TBN in `TBN.js` is scaled by the `tbnBasis` uniform, which was set purely from the render target's `flipY` (originally added to correct offscreen render-to-texture on WebGL).
- On WebGPU, framebuffer space is Y-down, so screen-space `dpdy` has the opposite sign to WebGL's `dFdy`. This negates the computed tangent and bitangent, rotating the tangent-space normal 180° and producing inverted lighting.
- Meshes with vertex tangents (world-space TBN) were unaffected, which is why only some content showed the problem.

**Changes:**
- `Renderer.setCameraUniforms`: fold the backend into the `tbnBasis` sign — `(device.isWebGPU !== !!flipY) ? -1 : 1`. WebGL behavior is unchanged; WebGPU picks up the extra inherent flip.

**Notes:**
- No effect on meshes using vertex tangents.
- No public API changes.