### PR TITLE
fix(element): keep the minified MSDF coverage ramp within the field's range

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/common/frag/msdf.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/msdf.js
@@ -41,10 +41,12 @@ vec4 applyMsdf(vec4 color) {
 
     // Width of the distance-field transition in screen pixels, from the uv magnification (both
     // axes) and the atlas spread. Stable under motion and minification, unlike fwidth(sigDist)
-    // whose noise on undersampled glyphs makes small text shimmer. Floored at 1px so minified
-    // text keeps a soft ~1px edge rather than a razor one.
+    // whose noise on undersampled glyphs makes small text shimmer. Floored at 2.5 so the
+    // minified coverage ramp spans at most 0.4 of the field's range ([edge - 0.2, edge + 0.2]):
+    // a lower floor lets the ramp (and its outline/shadow-shifted copies) reach the field's far
+    // tail, which washes translucent outline across the whole glyph quad and hazes distant text.
     vec2 unitRange = vec2(font_pxrange) / vec2(textureSize(texture_msdfMap, 0));
-    float screenPxRange = max(0.5 * dot(unitRange, 1.0 / max(fwidth(vUv0), vec2(1e-6))), 1.0);
+    float screenPxRange = max(0.5 * dot(unitRange, 1.0 / max(fwidth(vUv0), vec2(1e-6))), 2.5);
 
     float inside = clamp(screenPxRange * (sigDist - edge) + 0.5, 0.0, 1.0);
     float outline = clamp(screenPxRange * (sigDist + outline_thickness - edge) + 0.5, 0.0, 1.0);

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/msdf.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/msdf.js
@@ -54,11 +54,13 @@ fn applyMsdf(color_in: vec4f) -> vec4f {
 
     // Width of the distance-field transition in screen pixels, from the uv magnification (both
     // axes) and the atlas spread. Stable under motion and minification, unlike the distance-field
-    // gradient whose noise on undersampled glyphs makes small text shimmer. Floored at 1px so
-    // minified text keeps a soft ~1px edge rather than a razor one.
+    // gradient whose noise on undersampled glyphs makes small text shimmer. Floored at 2.5 so the
+    // minified coverage ramp spans at most 0.4 of the field's range ([edge - 0.2, edge + 0.2]):
+    // a lower floor lets the ramp (and its outline/shadow-shifted copies) reach the field's far
+    // tail, which washes translucent outline across the whole glyph quad and hazes distant text.
     let unitRange: vec2f = vec2f(uniform.font_pxrange) / vec2f(textureDimensions(texture_msdfMap, 0));
     let uvDeriv: vec2f = max(abs(dpdx(vUv0)) + abs(dpdy(vUv0)), vec2f(1e-6));
-    let screenPxRange: f32 = max(0.5 * dot(unitRange, vec2f(1.0) / uvDeriv), 1.0);
+    let screenPxRange: f32 = max(0.5 * dot(unitRange, vec2f(1.0) / uvDeriv), 2.5);
 
     let inside: f32 = clamp(screenPxRange * (sigDist - edge) + 0.5, 0.0, 1.0);
     let outline: f32 = clamp(screenPxRange * (sigDist + outline_thicknessValue - edge) + 0.5, 0.0, 1.0);


### PR DESCRIPTION
Fixes #9064
Forum: https://forum.playcanvas.com/t/engine-v2-migration-causing-issues-with-text-ui/42418

## Problem

#8990 floored `screenPxRange` at 1.0 (the msdfgen default). The MSDF coverage is a linear ramp:

```
coverage = clamp(screenPxRange * (sigDist - edge) + 0.5, 0.0, 1.0)
```

whose half-width in field units is `0.5 / screenPxRange`. At the 1.0 floor the ramp spans the field's **entire [0, 1] range**, so on minified text:

- The **outline/shadow ramps never reach zero**: with max outline (`outline_thickness` uniform = 0.2) coverage at `sigDist = 0` is `clamp(1.0 * (0 + 0.2 - 0.5) + 0.5) = 0.2` — a 20% translucent outline wash across the **entire glyph quad**, even where the field is empty. Adjacent quads overlap in a run of text, so washes stack into the garbled blocks in the issue screenshots.
- The fill ramp `clamp(sigDist)` turns the whole atlas spread into a soft halo, hazing glyph edges.
- The wash pops in/out as the canvas resizes, because resizing moves `screenPxRange` across the wash threshold (`0.5 / (edge - thickness)` ≈ 1.67 for defaults) — the "blur changes as I resize the tab" symptom.

Fonts with a small `pxrange` (the legacy default is 2) hit this at moderate distances; the reporter's white-with-black-outline text is the worst case.

Note: the reporter is on 2.20.6, where mipmapped MSDF atlases (#9002, fixed in v2.21.0) compounded this with corrupted medians. This PR fixes the remaining regression.

## Fix

Raise the minification floor to 2.5, capping the ramp at 0.4 field units (`[edge - 0.2, edge + 0.2]`). The outline ramp then bottoms out at `sigDist = 0.1` for the default edge (0.5) and max outline shift (0.2) — clear of the field's tail, so empty-field pixels get exactly zero coverage.

This is v2.19 far-field parity by construction: the old shader's `smoothstep` window mapped to raw field values `[0.32, 0.68]` (fill) and `[0.12, 0.48]` (max outline); the new floor gives `[0.3, 0.7]` and `[0.1, 0.5]`.

- `screenPxRange >= 2.5` (normal-size text): zero change.
- AA width stays geometric (from uv magnification), so the #8984 shimmer fix and the #2948 true-edge fix are preserved.
- Same change mirrored in the WGSL chunk; verified on WebGL2 and WebGPU.

## Verification

Measured with the repro project from the issue (WendyOne, `pxrange` 8, outlineThickness 1), engine `main`, WebGL2, probing a strip *inside* the glyph quads but above the glyphs (should be pure background), simulating the legacy default `font_pxrange` = 2:

| | floor 1.0 (before) | floor 2.5 (after) |
|---|---|---|
| Mean darkening above glyphs (0 = clean background) | **19.6** | **0.0** |
| Fog pixels through the glyph row (Text-Very-Far) | 373 | 296 |

With the fix, distant text renders with defined dark outlines instead of a translucent haze, and appearance is stable under canvas resize. Side-by-side captures show the floor-1.0 render with visible gray rectangles over the quads, matching the issue screenshots; the floor-2.5 render is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
