### PR TITLE
refactor: prepare materials using update versions

### DIFF
--- a/src/scene/gsplat-unified/gsplat-director.js
+++ b/src/scene/gsplat-unified/gsplat-director.js
@@ -298,8 +298,8 @@ class GSplatDirector {
         // any gsplat component exists) there are no managers in camerasMap to consume it, so leave
         // it set — otherwise a param change made before the first frame (e.g. overdraw mode) would
         // be dropped and the first manager created on the render path would miss the dirty-driven
-        // setup. The material dirty flag is cleared separately by frameEnd() in update(), after the
-        // renderers re-sync the material — so we must NOT clear it here.
+        // setup. Material changes are tracked independently by each renderer using the material's
+        // update version, so they do not need to be cleared here.
         if (streamed) {
             this.scene.gsplat.dirty = false;
         }

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -86,11 +86,11 @@ class GSplatHybridRenderer extends GSplatRenderer {
     /** @type {Set<string>} */
     _internalDefines = new Set();
 
-    /** @type {boolean} */
-    forceCopyMaterial = true;
-
     /** @type {string} */
     _lastSourceChunksKey = '';
+
+    /** @type {number} */
+    _sourceMaterialVersion = -1;
 
     /**
      * The projection cache stride in u32 words: the base layout plus user varying stream words.
@@ -779,10 +779,11 @@ class GSplatHybridRenderer extends GSplatRenderer {
             }
         }
 
-        // Copy material settings from params.material if dirty or on first update
-        if (this.forceCopyMaterial || params.material.dirty) {
+        // Copy material settings when the source material has been updated
+        const sourceMaterialVersion = params.material.updateVersion;
+        if (this._sourceMaterialVersion !== sourceMaterialVersion) {
             this.copyMaterialSettings(params.material);
-            this.forceCopyMaterial = false;
+            this._sourceMaterialVersion = sourceMaterialVersion;
         }
     }
 

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -967,12 +967,11 @@ class GSplatParams {
     }
 
     /**
-     * Called at the end of the frame to clear dirty flags.
+     * Called at the end of the frame to clear the parameter dirty flag.
      *
      * @ignore
      */
     frameEnd() {
-        this._material.dirty = false;
         this.dirty = false;
     }
 

--- a/src/scene/gsplat-unified/gsplat-quad-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-quad-renderer.js
@@ -34,14 +34,14 @@ class GSplatQuadRenderer extends GSplatRenderer {
     /** @type {Set<string>} */
     _internalDefines = new Set();
 
-    /** @type {boolean} */
-    forceCopyMaterial = true;
-
     /** @private */
     _lastFisheyeEnabled = false;
 
     /** @private */
     _lastSourceChunksKey = '';
+
+    /** @private */
+    _sourceMaterialVersion = -1;
 
     /**
      * @param {GraphicsDevice} device - The graphics device.
@@ -319,10 +319,11 @@ class GSplatQuadRenderer extends GSplatRenderer {
         // Check if work buffer format has changed (extra streams added)
         this._syncWithWorkBufferFormat();
 
-        // Copy material settings from params.material if dirty or on first update
-        if (this.forceCopyMaterial || params.material.dirty) {
+        // Copy material settings when the source material has been updated
+        const sourceMaterialVersion = params.material.updateVersion;
+        if (this._sourceMaterialVersion !== sourceMaterialVersion) {
             this.copyMaterialSettings(params.material);
-            this.forceCopyMaterial = false;
+            this._sourceMaterialVersion = sourceMaterialVersion;
         }
     }
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -362,7 +362,38 @@ class Material {
 
     _scene = null;
 
-    dirty = true;
+    /**
+     * Incremented by {@link Material#update} so internal consumers can detect material changes
+     * without consuming shared dirty state.
+     *
+     * @type {number}
+     * @private
+     */
+    _updateVersion = 0;
+
+    /**
+     * The update version most recently processed by {@link Material#prepareForRender}.
+     *
+     * @type {number}
+     * @private
+     */
+    _preparedVersion = -1;
+
+    /**
+     * The version incremented each time {@link Material#update} is called.
+     *
+     * @type {number}
+     * @ignore
+     */
+    get updateVersion() {
+        return this._updateVersion;
+    }
+
+    /** @ignore */
+    get dirty() {
+        Debug.removed('Material#dirty has been removed. Call Material#update() after modifying material properties.');
+        return undefined;
+    }
 
     /**
      * Sets whether the red channel is written to the color buffer. If true, the red component of
@@ -705,10 +736,31 @@ class Material {
         }
     }
 
-    updateUniforms(device, scene) {
+    /** @private */
+    _clearVariantsIfDirty() {
         if (this._dirtyShader) {
             this.clearVariants();
             this._dirtyShader = false;
+        }
+    }
+
+    updateUniforms(device, scene) {
+        // Compatibility fallback for materials rendered without calling update().
+        this._clearVariantsIfDirty();
+    }
+
+    /**
+     * Prepares the material for rendering when it has been updated since the previous preparation.
+     *
+     * @param {GraphicsDevice} device - The graphics device.
+     * @param {Scene} scene - The scene.
+     * @ignore
+     */
+    prepareForRender(device, scene) {
+        const version = this._updateVersion;
+        if (this._preparedVersion !== version) {
+            this.updateUniforms(device, scene);
+            this._preparedVersion = version;
         }
     }
 
@@ -752,11 +804,11 @@ class Material {
         if (this._definesDirty || this._shaderChunks?.isDirty()) {
             this._definesDirty = false;
             this._shaderChunks?.resetDirty();
-
-            this.clearVariants();
+            this._dirtyShader = true;
         }
 
-        this.dirty = true;
+        this._clearVariantsIfDirty();
+        this._updateVersion++;
     }
 
     // Parameter management

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -587,13 +587,7 @@ class ForwardRenderer extends Renderer {
             if (material !== prevMaterial) {
                 this._materialSwitches++;
                 material._scene = scene;
-
-                if (material.dirty) {
-                    DebugGraphics.pushGpuMarker(device, `Node: ${drawCall.node.name}, Material: ${material.name}`);
-                    material.updateUniforms(device, scene);
-                    material.dirty = false;
-                    DebugGraphics.popGpuMarker(device);
-                }
+                material.prepareForRender(device, scene);
             }
 
             const shaderInstance = drawCall.getShaderInstance(pass, lightHash, scene, shaderParams, viewUniformFormat, sortedLights);

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -322,10 +322,7 @@ class ShadowRenderer {
             renderer.setBaseConstants(device, material);
             renderer.setSkinning(device, meshInstance);
 
-            if (material.dirty) {
-                material.updateUniforms(device, scene);
-                material.dirty = false;
-            }
+            material.prepareForRender(device, scene);
 
             renderer.setupCullModeAndFrontFace(true, flipFactor, meshInstance);
 

--- a/test/scene/materials/shader-material.test.mjs
+++ b/test/scene/materials/shader-material.test.mjs
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import { restore, stub } from 'sinon';
 
+import { Debug } from '../../../src/core/debug.js';
 import { BlendState } from '../../../src/platform/graphics/blend-state.js';
 import {
     BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_SRC1_COLOR, BLENDMODE_ZERO,
@@ -10,6 +12,10 @@ import { ShaderMaterial } from '../../../src/scene/materials/shader-material.js'
 import { shaderGeneratorShader } from '../../../src/scene/shader-lib/programs/shader-generator-shader.js';
 
 describe('Material', function () {
+
+    afterEach(function () {
+        restore();
+    });
 
     function checkDefaultMaterial(material) {
         expect(material).to.be.an.instanceof(ShaderMaterial);
@@ -78,6 +84,92 @@ describe('Material', function () {
 
             material.blendState = BlendState.NOBLEND;
             expect(material.variants.size).to.equal(0);
+        });
+
+    });
+
+    describe('#update()', function () {
+
+        it('increments the update version', function () {
+            const material = new ShaderMaterial();
+
+            expect(material.updateVersion).to.equal(0);
+            material.update();
+            expect(material.updateVersion).to.equal(1);
+        });
+
+        it('reports the removed dirty property', function () {
+            const removed = stub(Debug, 'removed');
+            const material = new ShaderMaterial();
+
+            expect(material.dirty).to.equal(undefined);
+            expect(removed.calledOnceWithExactly(
+                'Material#dirty has been removed. Call Material#update() after modifying material properties.'
+            )).to.equal(true);
+        });
+
+        it('clears dirty shader variants immediately', function () {
+            const material = new ShaderMaterial();
+            material.variants.set(1, {});
+
+            material.update();
+
+            expect(material.variants.size).to.equal(0);
+            expect(material._dirtyShader).to.equal(false);
+        });
+
+        it('clears variants only once when shader state and defines are dirty', function () {
+            const material = new ShaderMaterial();
+            let clearCount = 0;
+            material.meshInstances.add({
+                clearShaders: () => {
+                    clearCount++;
+                }
+            });
+            material.setDefine('TEST_DEFINE', true);
+
+            material.update();
+            material.prepareForRender();
+
+            expect(clearCount).to.equal(1);
+        });
+
+        it('retains preparation as a compatibility fallback', function () {
+            const material = new ShaderMaterial();
+            material.variants.set(1, {});
+
+            material.prepareForRender();
+
+            expect(material.variants.size).to.equal(0);
+            expect(material._dirtyShader).to.equal(false);
+        });
+
+        it('does not clear variants during preparation after update processed them', function () {
+            const material = new ShaderMaterial();
+            material.update();
+            material.variants.set(1, {});
+
+            material.prepareForRender();
+
+            expect(material.variants.size).to.equal(1);
+        });
+
+        it('prepares once for each material update', function () {
+            const material = new ShaderMaterial();
+            const updateUniforms = material.updateUniforms.bind(material);
+            let prepareCount = 0;
+            material.updateUniforms = (...args) => {
+                prepareCount++;
+                updateUniforms(...args);
+            };
+
+            material.prepareForRender();
+            material.prepareForRender();
+            expect(prepareCount).to.equal(1);
+
+            material.update();
+            material.prepareForRender();
+            expect(prepareCount).to.equal(2);
         });
 
     });


### PR DESCRIPTION
## Summary

- Replace the shared Material dirty flag with an update version and a renderer-facing preparation step.
- Process shader variant invalidation in Material.update(), leaving rendering to prepare a material once per update version.
- Synchronize GSplat renderer materials independently using the source material update version.

## Public API changes

None. Material.dirty was undocumented; its compatibility getter now reports its removal and directs callers to Material.update().

## Technical details

- The initial render still prepares materials that have not explicitly received update().
- Forward and shadow renderers each make a single prepareForRender() call.
- GSplat source material settings copy once on initialization and after each source Material.update().

