### PR TITLE
fix: report WebGPU sampled texture limit

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -343,7 +343,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.precision = 'highp';
         this.maxPrecision = 'highp';
         this.maxSamples = 4;
-        this.maxTextures = 16;
+        this.maxTextures = limits.maxSampledTexturesPerShaderStage;
         this.maxTextureSize = limits.maxTextureDimension2D;
         this.maxCubeMapSize = limits.maxTextureDimension2D;
         this.maxVolumeSize = limits.maxTextureDimension3D;


### PR DESCRIPTION
```
## Summary

- Set GraphicsDevice#maxTextures from GPUDevice.limits.maxSampledTexturesPerShaderStage on WebGPU.

## Public API changes

No API shape changes. On WebGPU, GraphicsDevice#maxTextures now reports the actual device limit instead of always reporting 16.

## Validation

- npm run lint
```