### PR TITLE
Migrate internal render targets to origin option, complete flipY deprecation

### DIFF
--- a/examples/src/examples/test/render-target-orientation.example.mjs
+++ b/examples/src/examples/test/render-target-orientation.example.mjs
@@ -57,7 +57,7 @@ import { deviceType } from 'examples/context';
 // camera RT origin bottom   | flipped (origin: 'bottom' - consistent WebGL-layout storage)
 // cube face +X origin top   | upright (origin: 'top' on a cube face - cubemap-renderer idiom)
 // quad copy engine quadVS   | upright (engine quadVS compensates per API via getImageEffectUV)
-// rect blit flipY on        | cell at bottom (flipY keeps raw texel-row viewport rects)
+// rect blit origin bottom   | cell at bottom (origin bottom keeps raw texel-row viewport rects)
 // uv-space write wgpu flip  | upright (applies the UV1LAYOUT-style WebGPU flip)
 // readback top RT           | yellow (identical storage makes readback coordinates portable)
 //
@@ -66,7 +66,7 @@ import { deviceType } from 'examples/context';
 // upload flipY on           | WebGL2: flipped         | WebGPU: upright - flipY upload ignored
 // camera RT default         | WebGL2: flipped         | WebGPU: upright - the default divergence
 // quad copy raw uv          | WebGL2: upright         | WebGPU: flipped - raw uv quads invert
-// rect blit flipY off       | WebGL2: cell at bottom  | WebGPU: cell at top - viewport conversion
+// rect blit default         | WebGL2: cell at bottom  | WebGPU: cell at top - viewport conversion
 // uv-space write raw        | WebGL2: upright         | WebGPU: flipped - needs the WebGPU flip
 // readback default RT       | WebGL2: black           | WebGPU: yellow - rows follow storage
 
@@ -390,7 +390,12 @@ const texRectOff = createRTTexture('RT-rect-off', RT_SIZE);
 const rtRectOff = new RenderTarget({ name: 'RT-rect-off', colorBuffer: texRectOff, depth: false });
 
 const texRectOn = createRTTexture('RT-rect-on', RT_SIZE);
-const rtRectOn = new RenderTarget({ name: 'RT-rect-on', colorBuffer: texRectOn, depth: false, flipY: true });
+const rtRectOn = new RenderTarget({
+    name: 'RT-rect-on',
+    colorBuffer: texRectOn,
+    depth: false,
+    origin: RENDERTARGET_ORIGIN_BOTTOM
+});
 
 // blit destination rect in pixels - the same numbers on both render targets and both APIs
 const blitRect = new Vec4(64, 128, 128, 128);
@@ -610,7 +615,7 @@ addTile(1, 0, createTileMaterial(texTop), 'camera RT origin top', 'upright');
 addTile(0, 1, createTileMaterial(texBottom), 'camera RT origin bottom', 'flipped');
 addTile(1, 1, cubeDisplayMaterial, 'cube face +X origin top', 'upright');
 addTile(0, 2, createTileMaterial(texCopyEngine), 'quad copy engine quadVS', 'upright');
-addTile(1, 2, createTileMaterial(texRectOn), 'rect blit flipY on', 'cell at bottom');
+addTile(1, 2, createTileMaterial(texRectOn), 'rect blit origin bottom', 'cell at bottom');
 addTile(0, 3, createTileMaterial(texUvFix), 'uv-space write wgpu flip', 'upright');
 addTile(1, 3, readbackTopMaterial, 'readback top RT', 'yellow');
 
@@ -619,7 +624,7 @@ addTile(1, 3, readbackTopMaterial, 'readback top RT', 'yellow');
 addTile(2, 0, createTileMaterial(texUploadFlip), 'upload flipY on', isWebGPU ? 'upright (flipY ignored)' : 'flipped');
 addTile(3, 0, createTileMaterial(texNative), 'camera RT default', isWebGPU ? 'upright' : 'flipped');
 addTile(2, 1, createTileMaterial(texCopyRaw), 'quad copy raw uv', isWebGPU ? 'flipped' : 'upright');
-addTile(3, 1, createTileMaterial(texRectOff), 'rect blit flipY off', isWebGPU ? 'cell at top' : 'cell at bottom');
+addTile(3, 1, createTileMaterial(texRectOff), 'rect blit default', isWebGPU ? 'cell at top' : 'cell at bottom');
 addTile(2, 2, createTileMaterial(texUvRaw), 'uv-space write raw', isWebGPU ? 'flipped' : 'upright');
 addTile(3, 2, readbackNativeMaterial, 'readback default RT', isWebGPU ? 'yellow' : 'black');
 

--- a/src/extras/render-passes/frame-pass-camera-frame.js
+++ b/src/extras/render-passes/frame-pass-camera-frame.js
@@ -240,7 +240,7 @@ class FramePassCameraFrame extends FramePass {
         }
     }
 
-    createRenderTarget(name, depth, stencil, samples, flipY) {
+    createRenderTarget(name, depth, stencil, samples) {
 
         const texture = new Texture(this.device, {
             name: name,
@@ -258,8 +258,7 @@ class FramePassCameraFrame extends FramePass {
             colorBuffer: texture,
             depth: depth,
             stencil: stencil,
-            samples: samples,
-            flipY: flipY
+            samples: samples
         });
     }
 
@@ -280,14 +279,15 @@ class FramePassCameraFrame extends FramePass {
         // set up internal rendering parameters - this affect the shader generation to apply SSAO during forward pass
         cameraComponent.shaderParams.ssaoEnabled = options.ssaoType === SSAOTYPE_LIGHTING;
 
-        // create a render target to render the scene into
-        const flipY = !!targetRenderTarget?.flipY; // flipY is inherited from the target renderTarget
-        this.rt = this.createRenderTarget('SceneColor', true, options.stencil, options.samples, flipY);
+        // create a render target to render the scene into. This uses the API-native orientation
+        // regardless of the orientation of the target render target - the compose pass flips its
+        // sampling when needed to store the requested orientation in the target render target.
+        this.rt = this.createRenderTarget('SceneColor', true, options.stencil, options.samples);
         this.sceneTexture = this.rt.colorBuffer;
 
         // when half size scene color buffer is used
         if (this._sceneHalfEnabled) {
-            this.rtHalf = this.createRenderTarget('SceneColorHalf', false, false, 1, flipY);
+            this.rtHalf = this.createRenderTarget('SceneColorHalf', false, false, 1);
             this.sceneTextureHalf = this.rtHalf.colorBuffer;
         }
 

--- a/src/extras/render-passes/render-pass-compose.js
+++ b/src/extras/render-passes/render-pass-compose.js
@@ -143,6 +143,7 @@ class RenderPassCompose extends RenderPassShaderQuad {
         this.colorLUTParamsId = scope.resolve('colorLUTParams');
         this.colorEnhanceParamsId = scope.resolve('colorEnhanceParams');
         this.colorEnhanceMidtonesId = scope.resolve('colorEnhanceMidtones');
+        this.composeTargetFlipYId = scope.resolve('composeTargetFlipY');
     }
 
     set debug(value) {
@@ -423,6 +424,11 @@ class RenderPassCompose extends RenderPassShaderQuad {
         this.sceneTextureInvResValue[0] = 1.0 / sceneTex.width;
         this.sceneTextureInvResValue[1] = 1.0 / sceneTex.height;
         this.sceneTextureInvResId.setValue(this.sceneTextureInvResValue);
+
+        // the scene chain renders with the API-native orientation - when the target render
+        // target stores a flipped image, flip the sampling vertically so the composed result
+        // lands in the requested row order
+        this.composeTargetFlipYId.setValue(this.renderTarget?.flipY ? 1 : 0);
 
         if (this._bloomTexture) {
             this.bloomTextureId.setValue(this._bloomTexture);

--- a/src/extras/renderers/outline-renderer.js
+++ b/src/extras/renderers/outline-renderer.js
@@ -4,6 +4,7 @@ import { BlendState } from '../../platform/graphics/blend-state.js';
 import {
     ADDRESS_CLAMP_TO_EDGE, BLENDEQUATION_ADD, BLENDMODE_ONE_MINUS_SRC_ALPHA, BLENDMODE_SRC_ALPHA,
     FILTER_LINEAR, FILTER_LINEAR_MIPMAP_LINEAR, PIXELFORMAT_SRGBA8,
+    RENDERTARGET_ORIGIN_BOTTOM,
     SEMANTIC_POSITION
 } from '../../platform/graphics/constants.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
@@ -343,11 +344,12 @@ class OutlineRenderer {
             magFilter: FILTER_LINEAR
         });
 
-        // render target
+        // render target - the outline texture is composited using a raw-uv fullscreen quad
+        // written against the WebGL layout, so replicate it on all graphics APIs
         return new RenderTarget({
             colorBuffer: texture,
             depth: depth,
-            flipY: this.app.graphicsDevice.isWebGPU
+            origin: RENDERTARGET_ORIGIN_BOTTOM
         });
     }
 

--- a/src/framework/gsplat/gsplat-processor.js
+++ b/src/framework/gsplat/gsplat-processor.js
@@ -1,6 +1,6 @@
 import { Debug } from '../../core/debug.js';
 import { hashCode } from '../../core/hash.js';
-import { SEMANTIC_POSITION, getGlslShaderType } from '../../platform/graphics/constants.js';
+import { RENDERTARGET_ORIGIN_BOTTOM, SEMANTIC_POSITION, getGlslShaderType } from '../../platform/graphics/constants.js';
 import { BlendState } from '../../platform/graphics/blend-state.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { QuadRender } from '../../scene/graphics/quad-render.js';
@@ -343,7 +343,7 @@ class GSplatProcessor {
                 name: 'GSplatProcessor-MRT',
                 colorBuffers: colorBuffers,
                 depth: false,
-                flipY: true
+                origin: RENDERTARGET_ORIGIN_BOTTOM
             });
         }
     }

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -121,6 +121,12 @@ class RenderTarget {
     _flipY;
 
     /**
+     * @type {string}
+     * @private
+     */
+    _origin;
+
+    /**
      * Creates a new RenderTarget instance. A color buffer or a depth buffer must be set.
      *
      * @param {object} [options] - Object for passing optional arguments.
@@ -315,13 +321,21 @@ class RenderTarget {
         });
         if (options.origin === RENDERTARGET_ORIGIN_TOP) {
             this._flipY = !device.isWebGPU;
+            this._origin = RENDERTARGET_ORIGIN_TOP;
         } else if (options.origin === RENDERTARGET_ORIGIN_BOTTOM) {
             this._flipY = device.isWebGPU;
+            this._origin = RENDERTARGET_ORIGIN_BOTTOM;
         } else if (options.origin === RENDERTARGET_ORIGIN_NATIVE) {
             this._flipY = false;
+            this._origin = RENDERTARGET_ORIGIN_NATIVE;
         } else {
-            // origin not specified - honor the deprecated flipY option
+            // origin not specified - honor the deprecated flipY option, and derive the
+            // equivalent origin from it
+            if (options.flipY !== undefined) {
+                Debug.deprecated('RenderTarget "flipY" option is deprecated, use the "origin" option instead. Typical migration: flipY: !device.isWebGPU -> origin: RENDERTARGET_ORIGIN_TOP, flipY: device.isWebGPU -> origin: RENDERTARGET_ORIGIN_BOTTOM.');
+            }
             this._flipY = options.flipY ?? false;
+            this._origin = this._flipY ? (device.isWebGPU ? RENDERTARGET_ORIGIN_BOTTOM : RENDERTARGET_ORIGIN_TOP) : RENDERTARGET_ORIGIN_NATIVE;
         }
 
         this._mipLevel = options.mipLevel ?? 0;
@@ -562,6 +576,7 @@ class RenderTarget {
     set flipY(value) {
         Debug.deprecated('RenderTarget#flipY is deprecated, use the "origin" option of the RenderTarget constructor instead. Typical migration: flipY: !device.isWebGPU -> origin: RENDERTARGET_ORIGIN_TOP, flipY: device.isWebGPU -> origin: RENDERTARGET_ORIGIN_BOTTOM.');
         this._flipY = value;
+        this._origin = value ? (this._device.isWebGPU ? RENDERTARGET_ORIGIN_BOTTOM : RENDERTARGET_ORIGIN_TOP) : RENDERTARGET_ORIGIN_NATIVE;
     }
 
     /**
@@ -572,6 +587,19 @@ class RenderTarget {
      */
     get flipY() {
         return this._flipY;
+    }
+
+    /**
+     * Gets the vertical orientation of the image stored in this render target, as resolved at
+     * construction from the `origin` option, or derived from the deprecated flipY option or
+     * property. Can be {@link RENDERTARGET_ORIGIN_TOP}, {@link RENDERTARGET_ORIGIN_BOTTOM} or
+     * {@link RENDERTARGET_ORIGIN_NATIVE}. See the `origin` option of the constructor for
+     * details.
+     *
+     * @type {string}
+     */
+    get origin() {
+        return this._origin;
     }
 
     /**

--- a/src/scene/graphics/reproject-texture.js
+++ b/src/scene/graphics/reproject-texture.js
@@ -3,6 +3,7 @@ import { random } from '../../core/math/random.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import {
     FILTER_NEAREST,
+    RENDERTARGET_ORIGIN_BOTTOM,
     TEXTUREPROJECTION_OCTAHEDRAL, TEXTUREPROJECTION_CUBE,
     SEMANTIC_POSITION
 } from '../../platform/graphics/constants.js';
@@ -494,7 +495,7 @@ function reprojectTexture(source, target, options = {}) {
                 colorBuffer: target,
                 face: f,
                 depth: false,
-                flipY: device.isWebGPU
+                origin: RENDERTARGET_ORIGIN_BOTTOM
             });
             params[0] = f;
             constantParams.setValue(params);

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -456,7 +456,6 @@ class GSplatHybridRenderer extends GSplatRenderer {
             foveationCenter: params.foveationCenter,
             viewportWidth,
             viewportHeight,
-            flipY: !!cameraNode.camera.renderTarget?.flipY,
             pickMode,
             fisheyeProj,
             antiAlias: params.antiAlias,
@@ -716,8 +715,7 @@ class GSplatHybridRenderer extends GSplatRenderer {
      * @private
      */
     _computeClipToViewZ(cameraNode, dst) {
-        const camComp = cameraNode.camera;
-        const cam = camComp.camera;
+        const cam = cameraNode.camera.camera;
         if (this.fisheyeProj.enabled) {
             const near = cam.nearClip;
             const far = cam.farClip;
@@ -727,8 +725,9 @@ class GSplatHybridRenderer extends GSplatRenderer {
             dst[3] = near;
             return;
         }
-        const flipY = !!camComp.renderTarget?.flipY;
-        _invProjMat.copy(Camera.applyShaderProjectionTransform(cam.projectionMatrix, _shaderProjMat, flipY, this.device.isWebGPU)).invert();
+        // canonical (unflipped) projection - matches the projector cache; the raster-time flip
+        // (projectionFlipY) is applied to the output position only and does not affect depth
+        _invProjMat.copy(Camera.applyShaderProjectionTransform(cam.projectionMatrix, _shaderProjMat, false, this.device.isWebGPU)).invert();
         const d = _invProjMat.data;
         dst[0] = -d[2];
         dst[1] = -d[6];

--- a/src/scene/gsplat-unified/gsplat-projector.js
+++ b/src/scene/gsplat-unified/gsplat-projector.js
@@ -627,8 +627,6 @@ class GSplatProjector {
      * foveated culling has no effect.
      * @param {number} params.viewportWidth - Render viewport width in pixels.
      * @param {number} params.viewportHeight - Render viewport height in pixels.
-     * @param {boolean} params.flipY - Whether the active render target uses `flipY` (must match
-     * {@link Renderer#setCameraUniforms}).
      * @param {boolean} [params.pickMode] - Whether to write picking IDs into the cache.
      * @param {import('../graphics/fisheye-projection.js').FisheyeProjection} [params.fisheyeProj] -
      * Fisheye projection state. When `fisheyeProj.enabled` is true the projector picks the
@@ -646,7 +644,7 @@ class GSplatProjector {
             totalCapacity, radialSort, numBits, minDist, maxDist,
             alphaClip, minPixelSize, minContribution,
             foveationStrength = 0, foveationCenter = 0.3,
-            viewportWidth, viewportHeight, flipY,
+            viewportWidth, viewportHeight,
             pickMode = false,
             fisheyeProj,
             antiAlias = false,
@@ -737,8 +735,10 @@ class GSplatProjector {
             // raw eye-0 projection x-scale; both eyes share it in standard stereo.
             focal = viewportWidth * views[0].projMat.data[0];
         } else {
+            // canonical (unflipped) projection - the cache stores canonical clip positions, and
+            // the raster VS applies the per-pass target flip using the projectionFlipY uniform
             const view = cam.viewMatrix;
-            _viewProjMat.mul2(Camera.applyShaderProjectionTransform(cam.projectionMatrix, _shaderProjMat, flipY, webgpu), view);
+            _viewProjMat.mul2(Camera.applyShaderProjectionTransform(cam.projectionMatrix, _shaderProjMat, false, webgpu), view);
             _viewProjData.set(_viewProjMat.data);
             _viewData.set(view.data);
             focal = viewportWidth * _shaderProjMat.data[0];

--- a/src/scene/gsplat-unified/gsplat-work-buffer.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer.js
@@ -1,7 +1,7 @@
 import { Debug, DebugHelper } from '../../core/debug.js';
 import {
     ADDRESS_CLAMP_TO_EDGE, PIXELFORMAT_R32U, PIXELFORMAT_RGBA16U,
-    BUFFERUSAGE_COPY_DST, SEMANTIC_POSITION, getGlslShaderType
+    BUFFERUSAGE_COPY_DST, RENDERTARGET_ORIGIN_BOTTOM, SEMANTIC_POSITION, getGlslShaderType
 } from '../../platform/graphics/constants.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
@@ -235,11 +235,13 @@ class GSplatWorkBuffer {
 
         // Collect all textures in order for MRT
         const colorBuffers = this.streams.getTexturesInOrder();
+        // viewport rects used to fill the work buffer must address identical texel rows on all
+        // graphics APIs, matching the WebGL layout
         this.renderTarget = new RenderTarget({
             name: `GsplatWorkBuffer-MRT-${this.id}`,
             colorBuffers: colorBuffers,
             depth: false,
-            flipY: true
+            origin: RENDERTARGET_ORIGIN_BOTTOM
         });
 
         // Color-only render target uses just the first texture (dataColor)
@@ -248,7 +250,7 @@ class GSplatWorkBuffer {
             name: `GsplatWorkBuffer-Color-${this.id}`,
             colorBuffer: colorTexture,
             depth: false,
-            flipY: true
+            origin: RENDERTARGET_ORIGIN_BOTTOM
         });
 
         // Reinitialize render passes

--- a/src/scene/lighting/light-texture-atlas.js
+++ b/src/scene/lighting/light-texture-atlas.js
@@ -1,7 +1,7 @@
 import { Vec2 } from '../../core/math/vec2.js';
 import { Vec4 } from '../../core/math/vec4.js';
 
-import { PIXELFORMAT_SRGBA8 } from '../../platform/graphics/constants.js';
+import { PIXELFORMAT_SRGBA8, RENDERTARGET_ORIGIN_BOTTOM } from '../../platform/graphics/constants.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { Texture } from '../../platform/graphics/texture.js';
 
@@ -39,10 +39,12 @@ class LightTextureAtlas {
         this.cookieAtlasResolution = 4;
         this.cookieAtlas = Texture.createDataTexture2D(this.device, 'CookieAtlas', this.cookieAtlasResolution, this.cookieAtlasResolution, PIXELFORMAT_SRGBA8);
 
+        // atlas slot allocation math expects viewport rects to address identical texel rows on
+        // all graphics APIs, matching the WebGL layout
         this.cookieRenderTarget = new RenderTarget({
             colorBuffer: this.cookieAtlas,
             depth: false,
-            flipY: true
+            origin: RENDERTARGET_ORIGIN_BOTTOM
         });
 
         // available slots (of type Slot)

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -415,13 +415,15 @@ class Renderer {
             // store matrices needed by TAA
             camera._storeShaderMatrices(viewProjMat, jitterX, jitterY, this.device.renderVersion);
 
-            this.flipYId.setValue(flipY ? -1 : 1);
-
             // View Position (world space)
             this.dispatchViewPos(camera._node.getPosition());
 
             camera.frustum.setFromMat4(viewProjMat);
         }
+
+        // set for all passes including XR, to keep the uniform fresh per render pass - it is
+        // consumed by shaders of any pass (e.g. screen-space UI, gsplat rasterization)
+        this.flipYId.setValue(flipY ? -1 : 1);
 
         // Sign for the derivative-based TBN (see TBN.js). It compensates for the Y flip applied to
         // the projection matrix when rendering with flipY. On WebGPU there is an additional inherent

--- a/src/scene/renderer/shadow-map.js
+++ b/src/scene/renderer/shadow-map.js
@@ -5,6 +5,7 @@ import {
     FUNC_LESS,
     PIXELFORMAT_R32F, PIXELFORMAT_R16F,
     pixelFormatInfo,
+    RENDERTARGET_ORIGIN_BOTTOM,
     TEXHINT_SHADOWMAP
 } from '../../platform/graphics/constants.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
@@ -110,6 +111,8 @@ class ShadowMap {
             name: `ShadowMap2D_${formatName}`
         });
 
+        // the shadow map sampling math (matrix scale-bias derived uvs, atlas viewport rects) is
+        // written against the WebGL layout, so replicate it on all graphics APIs
         let target = null;
         if (shadowInfo?.pcf) {
 
@@ -119,19 +122,16 @@ class ShadowMap {
 
             // depthbuffer only
             target = new RenderTarget({
-                depthBuffer: texture
+                depthBuffer: texture,
+                origin: RENDERTARGET_ORIGIN_BOTTOM
             });
         } else {
             // encoded rgba depth
             target = new RenderTarget({
                 colorBuffer: texture,
-                depth: true
+                depth: true,
+                origin: RENDERTARGET_ORIGIN_BOTTOM
             });
-        }
-
-        // TODO: this is temporary, and will be handled on generic level for all render targets for WebGPU
-        if (device.isWebGPU) {
-            target.flipY = true;
         }
 
         return new ShadowMap(texture, [target]);

--- a/src/scene/shader-lib/glsl/chunks/render-pass/frag/compose/compose.js
+++ b/src/scene/shader-lib/glsl/chunks/render-pass/frag/compose/compose.js
@@ -5,6 +5,7 @@ export default /* glsl */`
     varying vec2 uv0;
     uniform sampler2D sceneTexture;
     uniform vec2 sceneTextureInvRes;
+    uniform float composeTargetFlipY;
 
     #include "composeBloomPS"
     #include "composeDofPS"
@@ -22,7 +23,9 @@ export default /* glsl */`
 
         #include "composeMainStartPS"
 
-        vec2 uv = uv0;
+        // flip the sampling vertically when the target render target stores a flipped image, so
+        // that the natively-oriented output of the scene pass chain lands in the requested row order
+        vec2 uv = vec2(uv0.x, mix(uv0.y, 1.0 - uv0.y, composeTargetFlipY));
 
         vec4 scene = texture2DLod(sceneTexture, uv, 0.0);
         vec3 result = scene.rgb;
@@ -34,12 +37,12 @@ export default /* glsl */`
 
         // Apply DOF
         #ifdef DOF
-            result = applyDof(result, uv0);
+            result = applyDof(result, uv);
         #endif
 
         // Apply SSAO
         #ifdef SSAO_TEXTURE
-            result = applySsao(result, uv0);
+            result = applySsao(result, uv);
         #endif
 
         // Apply Fringing
@@ -49,7 +52,7 @@ export default /* glsl */`
 
         // Apply Bloom
         #ifdef BLOOM
-            result = applyBloom(result, uv0);
+            result = applyBloom(result, uv);
         #endif
 
         // Apply Color Enhancement (shadows, highlights, vibrance)

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
@@ -32,6 +32,12 @@ attribute vertex_position: vec3f;
 
 uniform viewport_size: vec4f;
 
+// The cache stores canonical (unflipped) clip positions - this per-pass +-1 uniform, set by the
+// renderer from the render target's flipY, applies the target's vertical orientation to the
+// final position only. This keeps the projector cache valid for any raster target (forward,
+// prepass, pick), with the flip resolved at rasterization time.
+uniform projectionFlipY: f32;
+
 // -inverse(matrix_projection)[row 2]; lets the VS reconstruct linear view
 // depth from clipPos via dot(clipToViewZ, clip). Set per-camera by the
 // renderer (see GSplatHybridRenderer).
@@ -166,7 +172,10 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     let pixelOffset = cornerClipped.x * v1 + cornerClipped.y * v2;
     let clipOffset = pixelOffset * c;
 
-    output.position = proj + vec4f(clipOffset, 0.0, 0.0);
+    // flipping the final position (center + offset together) vertically mirrors the whole splat,
+    // which is the correct application of the target orientation to the canonical cached data
+    let pos = proj + vec4f(clipOffset, 0.0, 0.0);
+    output.position = vec4f(pos.x, pos.y * uniform.projectionFlipY, pos.z, pos.w);
     output.gaussianUV = half2(cornerClipped);
 
     // read user varying values from the projection cache and pass them to the outputs

--- a/src/scene/shader-lib/wgsl/chunks/render-pass/frag/compose/compose.js
+++ b/src/scene/shader-lib/wgsl/chunks/render-pass/frag/compose/compose.js
@@ -6,6 +6,7 @@ export default /* wgsl */`
     var sceneTexture: texture_2d<f32>;
     var sceneTextureSampler: sampler;
     uniform sceneTextureInvRes: vec2f;
+    uniform composeTargetFlipY: f32;
 
     #include "composeBloomPS"
     #include "composeDofPS"
@@ -25,7 +26,10 @@ export default /* wgsl */`
         #include "composeMainStartPS"
 
         var output: FragmentOutput;
-        var uv = uv0;
+
+        // flip the sampling vertically when the target render target stores a flipped image, so
+        // that the natively-oriented output of the scene pass chain lands in the requested row order
+        var uv = vec2f(uv0.x, mix(uv0.y, 1.0 - uv0.y, uniform.composeTargetFlipY));
 
         let scene = textureSampleLevel(sceneTexture, sceneTextureSampler, uv, 0.0);
         var result = scene.rgb;
@@ -37,12 +41,12 @@ export default /* wgsl */`
 
         // Apply DOF
         #ifdef DOF
-            result = applyDof(result, uv0);
+            result = applyDof(result, uv);
         #endif
 
         // Apply SSAO
         #ifdef SSAO_TEXTURE
-            result = applySsao(result, uv0);
+            result = applySsao(result, uv);
         #endif
 
         // Apply Fringing
@@ -52,7 +56,7 @@ export default /* wgsl */`
 
         // Apply Bloom
         #ifdef BLOOM
-            result = applyBloom(result, uv0);
+            result = applyBloom(result, uv);
         #endif
 
         // Apply Color Enhancement (shadows, highlights, vibrance)

--- a/test/platform/graphics/render-target.test.mjs
+++ b/test/platform/graphics/render-target.test.mjs
@@ -81,6 +81,52 @@ describe('RenderTarget', function () {
         });
     });
 
+    // On a WebGPU device the native orientation is top-down, so origin resolution is mirrored
+    // relative to WebGL: 'top' does not flip, 'bottom' flips, and the deprecated flipY option /
+    // property derives origin bottom (not top). isWebGPU is stubbed on the null device, which is
+    // sufficient as the origin resolution only reads that flag.
+    describe('#constructor: origin option (WebGPU)', function () {
+
+        beforeEach(function () {
+            device.isWebGPU = true;
+        });
+
+        it('origin top does not flip on a WebGPU device', function () {
+            const rt = createRenderTarget({ origin: RENDERTARGET_ORIGIN_TOP });
+            expect(rt.flipY).to.be.false;
+            expect(rt.origin).to.equal(RENDERTARGET_ORIGIN_TOP);
+            destroyRenderTarget(rt);
+        });
+
+        it('origin bottom flips on a WebGPU device', function () {
+            const rt = createRenderTarget({ origin: RENDERTARGET_ORIGIN_BOTTOM });
+            expect(rt.flipY).to.be.true;
+            expect(rt.origin).to.equal(RENDERTARGET_ORIGIN_BOTTOM);
+            destroyRenderTarget(rt);
+        });
+
+        it('origin native does not flip on a WebGPU device', function () {
+            const rt = createRenderTarget({ origin: RENDERTARGET_ORIGIN_NATIVE });
+            expect(rt.flipY).to.be.false;
+            expect(rt.origin).to.equal(RENDERTARGET_ORIGIN_NATIVE);
+            destroyRenderTarget(rt);
+        });
+
+        it('derives origin bottom from the deprecated flipY option', function () {
+            const rt = createRenderTarget({ flipY: true });
+            expect(rt.flipY).to.be.true;
+            expect(rt.origin).to.equal(RENDERTARGET_ORIGIN_BOTTOM);
+            destroyRenderTarget(rt);
+        });
+
+        it('derives origin bottom from the deprecated flipY setter', function () {
+            const rt = createRenderTarget();
+            rt.flipY = true;
+            expect(rt.origin).to.equal(RENDERTARGET_ORIGIN_BOTTOM);
+            destroyRenderTarget(rt);
+        });
+    });
+
     describe('#flipY', function () {
 
         it('deprecated setter still updates the value', function () {

--- a/test/platform/graphics/render-target.test.mjs
+++ b/test/platform/graphics/render-target.test.mjs
@@ -91,4 +91,35 @@ describe('RenderTarget', function () {
             destroyRenderTarget(rt);
         });
     });
+
+    // origin resolution on a non-WebGPU device: flipY true is equivalent to origin top
+    describe('#origin', function () {
+
+        it('defaults to native', function () {
+            const rt = createRenderTarget();
+            expect(rt.origin).to.equal(RENDERTARGET_ORIGIN_NATIVE);
+            destroyRenderTarget(rt);
+        });
+
+        it('returns the origin the render target was constructed with', function () {
+            const rt = createRenderTarget({ origin: RENDERTARGET_ORIGIN_TOP });
+            expect(rt.origin).to.equal(RENDERTARGET_ORIGIN_TOP);
+            destroyRenderTarget(rt);
+        });
+
+        it('is derived from the deprecated flipY option', function () {
+            const rt = createRenderTarget({ flipY: true });
+            expect(rt.origin).to.equal(RENDERTARGET_ORIGIN_TOP);
+            destroyRenderTarget(rt);
+        });
+
+        it('is derived from the deprecated flipY setter', function () {
+            const rt = createRenderTarget({ origin: RENDERTARGET_ORIGIN_BOTTOM });
+            rt.flipY = true;
+            expect(rt.origin).to.equal(RENDERTARGET_ORIGIN_TOP);
+            rt.flipY = false;
+            expect(rt.origin).to.equal(RENDERTARGET_ORIGIN_NATIVE);
+            destroyRenderTarget(rt);
+        });
+    });
 });


### PR DESCRIPTION
Follow-up to #9101. Migrates all engine-internal render targets off the deprecated `flipY` flag to the `origin` option, completes the deprecation, and reworks CameraFrame and the gsplat projector so no engine code depends on `flipY` any more.

**Changes:**
- Migrated internal render targets that replicate the WebGL storage layout on all APIs to `origin: RENDERTARGET_ORIGIN_BOTTOM`: shadow maps (removing the long-standing temporary `flipY` workaround and its TODO), the clustered cookie atlas, texture reprojection (`reprojectTexture`), the outline renderer, and the gsplat processor and work buffers.
- **CameraFrame** no longer inherits the output target's `flipY` into its intermediate scene render target. The scene chain always renders in the API-native orientation, and the compose pass flips its sampling into the requested orientation via a new `composeTargetFlipY` uniform. As a result the scene, TAA, and grab passes always take the common code path regardless of the final target's orientation.
- **Unified gsplat renderer**: the projector now builds a canonical (unflipped) projection and caches canonical clip positions; the hybrid raster vertex shader applies the per-pass target orientation to the final vertex position using the existing `projectionFlipY` uniform. This keeps the projection cache valid for any raster target (forward, prepass, pick) without the projector needing to know the target, and fixes picking into a flipped render target. `projectionFlipY` is now refreshed on all render passes (including XR).
- Completed the deprecation: the constructor `flipY` option now emits a runtime deprecation warning (previously only the `flipY` property setter did). No engine code passes `flipY` any more, so debug builds are free of internal deprecation warnings.

**API Changes:**
- Added: public `RenderTarget#origin` getter, resolved at construction from the `origin` option and kept consistent when the deprecated `flipY` option or property is used.
- Deprecated (runtime warning): the constructor `flipY` option, matching the already-deprecated `RenderTarget#flipY` property.

**Examples:**
- Updated the hidden `test/render-target-orientation` example to construct its bottom-origin render target via `origin` instead of `flipY`.