### PR TITLE
Remove unused BatchManager#clone method

### DIFF
--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -930,36 +930,8 @@ class BatchManager {
         // #endif
     }
 
-    /**
-     * Clones a batch. This method doesn't rebuild batch geometry, but only creates a new model and
-     * batch objects, linked to different source mesh instances.
-     *
-     * @param {Batch} batch - A batch object.
-     * @param {MeshInstance[]} clonedMeshInstances - New mesh instances.
-     * @returns {Batch} New batch object.
-     */
     clone(batch, clonedMeshInstances) {
-        const batch2 = new Batch(clonedMeshInstances, batch.dynamic, batch.batchGroupId);
-        this._batchList.push(batch2);
-
-        const nodes = [];
-        for (let i = 0; i < clonedMeshInstances.length; i++) {
-            nodes.push(clonedMeshInstances[i].node);
-        }
-
-        batch2.meshInstance = new MeshInstance(batch.meshInstance.mesh, batch.meshInstance.material, batch.meshInstance.node);
-        batch2.meshInstance._updateAabb = false;
-        batch2.meshInstance.parameters = clonedMeshInstances[0].parameters;
-        batch2.meshInstance.cull = clonedMeshInstances[0].cull;
-        batch2.meshInstance.layer = clonedMeshInstances[0].layer;
-
-        if (batch.dynamic) {
-            batch2.meshInstance.skinInstance = new SkinBatchInstance(this.device, nodes, this.rootNode);
-        }
-
-        batch2.meshInstance.castShadow = batch.meshInstance.castShadow;
-
-        return batch2;
+        Debug.removed('BatchManager#clone was removed. There is no replacement, as the method was unused and had no supported use case.');
     }
 
     /**


### PR DESCRIPTION
Removes the unused `BatchManager#clone` method, replacing its body with a `Debug.removed()` notice (matching the existing `Batch#model` removal pattern).

**Changes:**
- `BatchManager#clone(batch, clonedMeshInstances)` has never been called anywhere in the engine's history — it was introduced as speculative API (originally `cloneBatch`) and never wired into any code path.
- It also had no supported use case: it only did anything for dynamic batches, required the caller to supply a structurally identical set of source mesh instances (an unvalidated, positional bone-index contract), and copied only a subset of the batched mesh instance's properties.

**API Changes:**
- Removed `BatchManager#clone`. The method now logs a "removed" message via `Debug.removed()` and returns nothing. There is no replacement — batches are (re)generated through batch groups / `BatchManager.generate()`, and hardware instancing covers cheap duplication of shared geometry.