### PR TITLE
Fix painter example render target orientation across APIs

### DIFF
--- a/examples/src/examples/graphics/painter.example.mjs
+++ b/examples/src/examples/graphics/painter.example.mjs
@@ -13,6 +13,7 @@ import {
     PIXELFORMAT_RGB8,
     PROJECTION_ORTHOGRAPHIC,
     ParticleSystemComponentSystem,
+    RENDERTARGET_ORIGIN_TOP,
     RESOLUTION_AUTO,
     RenderComponentSystem,
     RenderTarget,
@@ -107,7 +108,8 @@ const texture = new Texture(app.graphicsDevice, {
 });
 const renderTarget = new RenderTarget({
     colorBuffer: texture,
-    depth: false
+    depth: false,
+    origin: RENDERTARGET_ORIGIN_TOP
 });
 
 // Create a layer for rendering to texture, and add it to the beginning of layers to render into it first


### PR DESCRIPTION
The `painter` example rendered brush strokes into a render target created with the default (API-native) orientation, then sampled that texture with mesh UVs on the display box. Since native storage differs between WebGL2 (bottom-up) and WebGPU (top-down), the painted result appeared **vertically mirrored** between the two backends.

Fix: create the render target with `origin: RENDERTARGET_ORIGIN_TOP` so the painted texture is stored in image orientation on both APIs, making the example render identically everywhere. This also models the recommended pattern (use `origin` for render targets sampled as textures) now that `RenderTarget#flipY` is deprecated.

**Changes:**
- `examples/graphics/painter`: render target created with `origin: RENDERTARGET_ORIGIN_TOP`.

Verified on WebGL2 and WebGPU (identical result after the fix).