### PR TITLE
Remove specularTint and avoid unnecessary color shader invalidation

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -260,8 +260,8 @@ _removeTint('sheenTint');
 _removeTint('diffuseTint');
 _removeTint('emissiveTint');
 _removeTint('ambientTint');
+_removeTint('specularTint');
 
-_defineAlias('specularTint', 'specularMapTint');
 _defineAlias('aoVertexColor', 'aoMapVertexColor');
 _defineAlias('diffuseVertexColor', 'diffuseMapVertexColor');
 _defineAlias('specularVertexColor', 'specularMapVertexColor');

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -526,7 +526,6 @@ const createMaterial = (gltfMaterial, textures) => {
     material.occludeSpecular = SPECOCC_AO;
 
     material.diffuseVertexColor = true;
-    material.specularTint = true;
     material.specularVertexColor = true;
 
     // Set glTF spec defaults

--- a/src/framework/parsers/material/json-standard-material.js
+++ b/src/framework/parsers/material/json-standard-material.js
@@ -154,7 +154,6 @@ class JsonStandardMaterialParser {
             ['glossMapVertexColor', 'glossVertexColor'],
             ['lightMapVertexColor', 'lightVertexColor'],
 
-            ['specularMapTint', 'specularTint'],
             ['metalnessMapTint', 'metalnessTint'],
 
             ['clearCoatGlossiness', 'clearCoatGloss']

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -31,10 +31,6 @@ const arraysEqual = (a, b) => {
     return true;
 };
 
-const notWhite = (color) => {
-    return color.r !== 1 || color.g !== 1 || color.b !== 1;
-};
-
 const notBlack = (color) => {
     return color.r !== 0 || color.g !== 0 || color.b !== 0;
 };
@@ -209,14 +205,6 @@ class StandardMaterialOptionsBuilder {
 
         const useSpecularColor = (!stdMat.useMetalness || stdMat.useMetalnessSpecularColor);
 
-        // The constant specular color / specularity factor is included whenever it differs from
-        // the multiplicative identity (white / 1), regardless of whether a map is also present.
-        // This matches the glTF KHR_materials_specular spec (specularFactor * specularTexture) and
-        // mirrors how metalness is handled below. The legacy `specularTint` / `specularityFactorTint`
-        // flags are still honored as explicit overrides.
-        const specularTint = useSpecular &&
-                             (stdMat.specularTint || notWhite(stdMat.specular));
-
         const specularityFactorTint = useSpecular && stdMat.useMetalnessSpecularColor &&
                                       (stdMat.specularityFactorTint || stdMat.specularityFactor !== 1);
 
@@ -224,7 +212,6 @@ class StandardMaterialOptionsBuilder {
 
         const equalish = (a, b) => Math.abs(a - b) < 1e-4;
 
-        options.specularTint = specularTint;
         options.specularityFactorTint = specularityFactorTint;
         options.metalnessTint = (stdMat.useMetalness && stdMat.metalness < 1);
         options.glossTint = true;

--- a/src/scene/materials/standard-material-options.js
+++ b/src/scene/materials/standard-material-options.js
@@ -24,11 +24,6 @@ class StandardMaterialOptions {
     forceUv1 = false;
 
     /**
-     * Defines if {@link StandardMaterial#specular} constant should affect specular color.
-     */
-    specularTint = false;
-
-    /**
      * Defines if {@link StandardMaterial#metalness} constant should affect metalness value.
      */
     metalnessTint = false;

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -36,7 +36,6 @@ const standardMaterialParameterTypes = {
     vertexColorGamma: 'boolean',
 
     specular: 'rgb',
-    specularTint: 'boolean',
     ..._textureParameter('specular'),
     occludeSpecular: 'enum:occludeSpecular',
     specularityFactor: 'number',
@@ -194,6 +193,7 @@ const standardMaterialRemovedParameters = {
     ambientTint: 'boolean',
     emissiveTint: 'boolean',
     diffuseTint: 'boolean',
+    specularTint: 'boolean',
     sheenTint: 'boolean',
     conserveEnergy: 'boolean',
     useGamma: 'boolean',

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -658,6 +658,9 @@ class StandardMaterial extends Material {
         const specularIsBlack = isBlack(this._specular);
         if (this._specularIsBlack !== specularIsBlack) {
             this._specularIsBlack = specularIsBlack;
+            // This is intentionally conservative: another material property might already force
+            // specular shading, in which case this transition only changes a uniform. We can avoid
+            // that redundant variant clear later by tracking the derived useSpecular state here.
             this._dirtyShader = true;
         }
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -40,6 +40,10 @@ let _params = new Set();
 
 const _tempColor = new Color();
 
+const isBlack = (color) => {
+    return color.r === 0 && color.g === 0 && color.b === 0;
+};
+
 /**
  * @callback UpdateShaderCallback
  * Callback used by {@link StandardMaterial#onUpdateShader}.
@@ -100,10 +104,6 @@ const _tempColor = new Color();
  * @property {Color} specular The specular color of the material. This color value is 3-component
  * (RGB), where each component is between 0 and 1. Defines surface reflection/specular color.
  * Affects specular intensity and tint.
- * @property {boolean} specularTint Force inclusion of the constant `specular` color when
- * compositing with `specularMap` and/or specular vertex colors. Defaults to `false`. Setting
- * this to `true` is rarely needed - the constant is automatically applied whenever `specular`
- * differs from white. Provided as an explicit override.
  * @property {Texture|null} specularMap The specular map of the material (default is null).
  * @property {number} specularMapUv Specular map UV channel.
  * @property {Vec2} specularMapTiling Controls the 2D tiling of the specular map.
@@ -112,8 +112,7 @@ const _tempColor = new Color();
  * @property {number} specularMapRotation Controls the 2D rotation (in degrees) of the specular map.
  * @property {string} specularMapChannel Color channels of the specular map to use. Can be "r", "g",
  * "b", "a", "rgb" or any swizzled combination.
- * @property {boolean} specularVertexColor Use mesh vertex colors for specular. If specularMap or
- * are specularTint are set, they'll be multiplied by vertex colors.
+ * @property {boolean} specularVertexColor Multiply specular by the mesh vertex colors.
  * @property {string} specularVertexColorChannel Vertex color channels to use for specular. Can be
  * "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} specularityFactorTint Force inclusion of the constant `specularityFactor`
@@ -553,6 +552,14 @@ class StandardMaterial extends Material {
     userAttributes = new Map();
 
     /**
+     * Whether the specular color was black at the last update.
+     *
+     * @type {boolean}
+     * @private
+     */
+    _specularIsBlack;
+
+    /**
      * A custom function that will be called after all shader generator properties are collected
      * and before shader code is generated. This function will receive an object with shader
      * generator settings (based on current material and scene properties), that you can change and
@@ -607,6 +614,7 @@ class StandardMaterial extends Material {
         this.shaderOptBuilder = new StandardMaterialOptionsBuilder();
 
         this.reset();
+        this._specularIsBlack = isBlack(this._specular);
     }
 
     reset() {
@@ -641,6 +649,19 @@ class StandardMaterial extends Material {
         this.userAttributes = new Map(source.userAttributes);
 
         return this;
+    }
+
+    /**
+     * @override
+     */
+    update() {
+        const specularIsBlack = isBlack(this._specular);
+        if (this._specularIsBlack !== specularIsBlack) {
+            this._specularIsBlack = specularIsBlack;
+            this._dirtyShader = true;
+        }
+
+        super.update();
     }
 
     /**
@@ -716,21 +737,12 @@ class StandardMaterial extends Material {
 
         this._setParameter('material_ambient', getUniform('ambient'));
         this._setParameter('material_diffuse', getUniform('diffuse'));
+        this._setParameter('material_specular', getUniform('specular'));
         this._setParameter('material_aoIntensity', this.aoIntensity);
-
-        // The constant specular color / specularity factor is uploaded whenever it differs from the
-        // multiplicative identity (white / 1), so that it always composites with the corresponding
-        // map. The legacy tint flags remain as explicit overrides. This must stay in sync with
-        // StandardMaterialOptionsBuilder.
-        const specularNotWhite = this.specular.r !== 1 || this.specular.g !== 1 || this.specular.b !== 1;
-        const useSpecularConstant = !this.specularMap || this.specularTint || specularNotWhite;
 
         if (this.useMetalness) {
             if (!this.metalnessMap || this.metalness < 1) {
                 this._setParameter('material_metalness', this.metalness);
-            }
-            if (useSpecularConstant) {
-                this._setParameter('material_specular', getUniform('specular'));
             }
             if (!this.specularityFactorMap || this.specularityFactorTint || this.specularityFactor !== 1) {
                 this._setParameter('material_specularityFactor', this.specularityFactor);
@@ -740,10 +752,6 @@ class StandardMaterial extends Material {
             this._setParameter('material_sheenGloss', this.sheenGloss);
 
             this._setParameter('material_refractionIndex', this.refractionIndex);
-        } else {
-            if (useSpecularConstant) {
-                this._setParameter('material_specular', getUniform('specular'));
-            }
         }
 
         if (this.enableGGXSpecular) {
@@ -760,7 +768,7 @@ class StandardMaterial extends Material {
         this._setParameter('material_gloss', this.gloss);
 
         Debug.call(() => {
-            if (this.emissiveMap && this.emissive.r === 0 && this.emissive.g === 0 && this.emissive.b === 0) {
+            if (this.emissiveMap && this._emissive.r === 0 && this._emissive.g === 0 && this._emissive.b === 0) {
                 Debug.warnOnce(`Emissive map is set but emissive color is black, making the map invisible. Set emissive color to white to make the map visible. Rendering [${DebugGraphics.toString()}]`, this);
             }
         });
@@ -1083,19 +1091,12 @@ function _defineColor(name, defaultValue) {
     defineProp({
         name: name,
         defaultValue: defaultValue,
-        getterFunc: function () {
-            // HACK: since we can't detect whether a user is going to set a color property
-            // after calling this getter (i.e doing material.ambient.r = 0.5) we must assume
-            // the worst and flag the shader as dirty.
-            // This means currently animating a material color is horribly slow.
-            this._dirtyShader = true;
-            return this[`_${name}`];
-        }
+        dirtyShaderFunc: () => false
     });
 
     defineUniform(name, (material, device, scene) => {
         const uniform = material._allocUniform(name, () => new Float32Array(3));
-        const color = material[name];
+        const color = material[`_${name}`];
 
         // uniforms are always in linear space
         _tempColor.linear(color);
@@ -1228,7 +1229,6 @@ function _defineMaterialProps() {
         return uniform;
     });
 
-    _defineFlag('specularTint', false);
     _defineFlag('specularityFactorTint', false);
     _defineFlag('useMetalness', false);
     _defineFlag('useMetalnessSpecularColor', false);

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -309,6 +309,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         fDefineSet(options.dirLightMap && options.litOptions.useSpecular, 'STD_LIGHTMAP_DIR', '');
         fDefineSet(options.heightMap, 'STD_HEIGHT_MAP', '');
         fDefineSet(options.useSpecularColor, 'STD_SPECULAR_COLOR', '');
+        fDefineSet(options.useSpecularColor && options.litOptions.useSpecular, 'STD_SPECULAR_CONSTANT', '');
         fDefineSet(options.aoMap || options.aoVertexColor || options.useAO, 'STD_AO', '');
         fDefineSet(true, 'STD_OPACITY_DITHER', ditherNames[shaderPassInfo.isForward ? options.litOptions.opacityDither : options.litOptions.opacityShadowDither]);
     }

--- a/test/scene/materials/standard-material.test.mjs
+++ b/test/scene/materials/standard-material.test.mjs
@@ -265,7 +265,6 @@ describe('StandardMaterial', function () {
         expect(material.specularMapTiling.x).to.equal(1);
         expect(material.specularMapTiling.y).to.equal(1);
         expect(material.specularMapUv).to.equal(0);
-        expect(material.specularTint).to.equal(false);
         expect(material.specularVertexColor).to.equal(false);
         expect(material.specularVertexColorChannel).to.equal('rgb');
 
@@ -326,6 +325,99 @@ describe('StandardMaterial', function () {
 
     });
 
+    describe('#update()', function () {
+
+        const addVariant = (material) => {
+            const variant = {};
+            material.variants.set(1, variant);
+            return variant;
+        };
+
+        it('does not invalidate shaders when color properties are read', function () {
+            const material = new StandardMaterial();
+            material.update();
+            const variant = addVariant(material);
+
+            const colors = [
+                material.ambient,
+                material.diffuse,
+                material.specular,
+                material.emissive,
+                material.sheen,
+                material.attenuation
+            ];
+            material.update();
+
+            expect(colors).to.have.length(6);
+            expect(material.variants.get(1)).to.equal(variant);
+        });
+
+        it('does not invalidate shaders when uniform-only colors are assigned or mutated', function () {
+            const material = new StandardMaterial();
+            material.update();
+            const variant = addVariant(material);
+
+            material.diffuse = new Color(0.25, 0.5, 0.75);
+            const emissive = material.emissive;
+            emissive.set(0.75, 0.5, 0.25);
+            material.update();
+
+            expect(material.variants.get(1)).to.equal(variant);
+        });
+
+        it('does not invalidate shaders while updating color uniforms', function () {
+            const material = new StandardMaterial();
+            material.update();
+            const variant = addVariant(material);
+
+            material.diffuse.set(0.5, 0.25, 0.75);
+            material.updateUniforms();
+
+            const uniform = material.getParameter('material_diffuse').data;
+            expect(uniform[0]).to.be.closeTo(Math.pow(0.5, 2.2), 1e-6);
+            expect(uniform[1]).to.be.closeTo(Math.pow(0.25, 2.2), 1e-6);
+            expect(uniform[2]).to.be.closeTo(Math.pow(0.75, 2.2), 1e-6);
+            expect(material.variants.get(1)).to.equal(variant);
+        });
+
+        it('invalidates shaders when an in-place specular change enables specular shading', function () {
+            const material = new StandardMaterial();
+            const specular = material.specular;
+            material.update();
+            addVariant(material);
+
+            specular.set(0.25, 0.5, 0.75);
+            material.update();
+
+            expect(material.variants.size).to.equal(0);
+        });
+
+        it('does not invalidate shaders when specular remains non-black', function () {
+            const material = new StandardMaterial();
+            material.specular.set(0.25, 0.5, 0.75);
+            material.update();
+            const variant = addVariant(material);
+
+            material.specular.set(0.75, 0.5, 0.25);
+            material.update();
+
+            expect(material.variants.get(1)).to.equal(variant);
+        });
+
+        it('does not invalidate shaders when the specular color becomes white', function () {
+            const material = new StandardMaterial();
+            material.specular.set(0.25, 0.5, 0.75);
+            material.update();
+            const variant = addVariant(material);
+
+            material.specular.set(1, 1, 1);
+            material.update();
+
+            expect(material.variants.get(1)).to.equal(variant);
+        });
+
+    });
+
     describe('shader generation', function () {
 
         it('includes dual-source blending usage in the shader key', function () {
@@ -336,6 +428,28 @@ describe('StandardMaterial', function () {
             const dualSourceKey = standard.generateKey(options);
 
             expect(dualSourceKey).to.not.equal(regularKey);
+        });
+
+        it('applies the specular constant only when specular color is used', function () {
+            const options = new StandardMaterialOptions();
+            options.useSpecularColor = true;
+            options.litOptions.useSpecular = true;
+            const defines = new Map();
+
+            standard.prepareFragmentDefines(options, defines, { isForward: true });
+
+            expect(defines.has('STD_SPECULAR_CONSTANT')).to.equal(true);
+        });
+
+        it('does not apply the specular constant to the reflection-only path', function () {
+            const options = new StandardMaterialOptions();
+            options.useSpecularColor = true;
+            options.litOptions.useSpecular = false;
+            const defines = new Map();
+
+            standard.prepareFragmentDefines(options, defines, { isForward: true });
+
+            expect(defines.has('STD_SPECULAR_CONSTANT')).to.equal(false);
         });
 
     });

--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -165,7 +165,6 @@ const STANDARD_MAT_PROPS = [
     ['specularMapRotation', 'number'],
     ['specularMapTiling', 'Vec2'],
     ['specularMapUv', 'number'],
-    ['specularTint', 'boolean'],
     ['specularVertexColor', 'boolean'],
     ['specularVertexColorChannel', 'string'],
     ['specularityFactor', 'number'],


### PR DESCRIPTION
The StandardMaterial color properties now update uniforms without invalidating shader variants just by being read. Specular shader structure changes remain tracked explicitly when the specular color crosses the black/non-black boundary.

**Changes:**
- Remove the obsolete StandardMaterial#specularTint property and its parser/type-fixup references.
- Preserve the removed-property compatibility accessor for legacy callers.
- Always apply the specular color for active specular-color shading while preserving reflection-only behavior.
- Add focused tests for color mutation, gamma conversion, shader invalidation, and specular shader defines.

**API Changes:**
- Remove StandardMaterial#specularTint. Legacy access reports the property as removed and behaves as if it were always enabled.