### PR TITLE
fix: keep SSAO appearance consistent at reduced resolution scale

### DIFF
--- a/examples/src/examples/graphics/ambient-occlusion.controls.jsx
+++ b/examples/src/examples/graphics/ambient-occlusion.controls.jsx
@@ -99,7 +99,8 @@ export function Controls({ observer }) {
                         options={[
                             { v: 1.0, t: '100%' },
                             { v: 0.75, t: '75%' },
-                            { v: 0.5, t: '50%' }
+                            { v: 0.5, t: '50%' },
+                            { v: 0.25, t: '25%' }
                         ]}
                     />
                 </LabelGroup>

--- a/examples/src/examples/graphics/ambient-occlusion.example.mjs
+++ b/examples/src/examples/graphics/ambient-occlusion.example.mjs
@@ -232,20 +232,8 @@ const applySettings = () => {
 };
 
 // Apply UI changes
-data.on('*:set', (/** @type {string} */ path, value) => {
+data.on('*:set', () => {
     applySettings();
-
-    // If scale has changed, adjust min angle based on scale to avoid depth related artifacts
-    const pathArray = path.split('.');
-    if (pathArray[2] === 'scale') {
-        if (value < 0.6) {
-            data.set('data.ssao.minAngle', 40);
-        } else if (value < 0.8) {
-            data.set('data.ssao.minAngle', 20);
-        } else {
-            data.set('data.ssao.minAngle', 10);
-        }
-    }
 });
 
 // Initial settings

--- a/src/extras/render-passes/render-pass-ssao.js
+++ b/src/extras/render-passes/render-pass-ssao.js
@@ -169,7 +169,7 @@ class RenderPassSsao extends RenderPassShaderQuad {
 
     execute() {
 
-        const { device, sourceTexture, sampleCount, minAngle, scale } = this;
+        const { device, sampleCount, minAngle } = this;
         const { width, height } = this.renderTarget.colorBuffer;
         const scope = device.scope;
 
@@ -183,12 +183,18 @@ class RenderPassSsao extends RenderPassShaderQuad {
 
         const spiralTurns = 10.0;
         const step = (1.0 / (sampleCount - 0.5)) * spiralTurns * 2.0 * 3.141;
-        const radius = this.radius / scale;
+
+        // world-space radius is independent of the render target scale, keeping the AO look
+        // consistent when rendering at lower resolution
+        const radius = this.radius;
 
         const bias = 0.001;
         const peak = 0.1 * radius;
         const intensity = 2 * (peak * 2.0 * 3.141) * this.intensity / sampleCount;
-        const projectionScale = 0.5 * sourceTexture.height;
+
+        // scale the projection based on the actual (possibly scaled) render target height, so the
+        // sampling disk covers the same screen area regardless of the scale
+        const projectionScale = 0.5 * height;
         scope.resolve('uSpiralTurns').setValue(spiralTurns);
         scope.resolve('uAngleIncCosSin').setValue([Math.cos(step), Math.sin(step)]);
         scope.resolve('uMaxLevel').setValue(0.0);

--- a/src/scene/shader-lib/glsl/chunks/render-pass/frag/ssao.js
+++ b/src/scene/shader-lib/glsl/chunks/render-pass/frag/ssao.js
@@ -43,6 +43,15 @@ export default /* glsl */`
         return vec3((0.5 - uv) * vec2(uAspect, 1.0) * linearDepth, linearDepth);
     }
 
+    // snap the uv to the center of the depth texture texel it falls into, so that the
+    // reconstructed view-space position matches the surface point the depth was rendered at.
+    // Without this, when the AO resolution is lower than the depth resolution, positions are
+    // reconstructed slightly off the true surface, causing self-occlusion banding artifacts.
+    highp vec2 snapToDepthTexelCenter(const highp vec2 uv) {
+        vec2 size = vec2(textureSize(uSceneDepthMap, 0));
+        return (floor(uv * size) + 0.5) / size;
+    }
+
     highp vec3 faceNormal(highp vec3 dpdx, highp vec3 dpdy) {
         return normalize(cross(dpdx, dpdy));
     }
@@ -60,8 +69,8 @@ export default /* glsl */`
     //       are essentially equivalent to textureGather (which we don't have on ES3.0),
     //       and this is executed just once.
     highp vec3 computeViewSpaceNormal(const highp vec3 position, const highp vec2 uv) {
-        highp vec2 uvdx = uv + vec2(uInvResolution.x, 0.0);
-        highp vec2 uvdy = uv + vec2(0.0, uInvResolution.y);
+        highp vec2 uvdx = snapToDepthTexelCenter(uv + vec2(uInvResolution.x, 0.0));
+        highp vec2 uvdy = snapToDepthTexelCenter(uv + vec2(0.0, uInvResolution.y));
         highp vec3 px = computeViewSpacePositionFromDepth(uvdx, -getLinearScreenDepth(uvdx));
         highp vec3 py = computeViewSpacePositionFromDepth(uvdy, -getLinearScreenDepth(uvdy));
         highp vec3 dpdx = px - position;
@@ -116,7 +125,7 @@ export default /* glsl */`
 
         mediump float ssRadius = max(1.0, tap.z * ssDiskRadius); // at least 1 pixel screen-space radius
 
-        mediump vec2 uvSamplePos = uv + vec2(ssRadius * tap.xy) * uInvResolution;
+        mediump vec2 uvSamplePos = snapToDepthTexelCenter(uv + vec2(ssRadius * tap.xy) * uInvResolution);
 
         // TODO: level is not used, but could be used with mip-mapped depth texture
         mediump float level = clamp(floor(log2(ssRadius)) - kLog2LodRate, 0.0, float(uMaxLevel));
@@ -166,9 +175,9 @@ export default /* glsl */`
     uniform float uPower;
 
     void main() {
-        highp vec2 uv = uv0; // interpolated to pixel center
+        highp vec2 uv = snapToDepthTexelCenter(uv0);
 
-        highp float depth = -getLinearScreenDepth(uv0);
+        highp float depth = -getLinearScreenDepth(uv);
         highp vec3 origin = computeViewSpacePositionFromDepth(uv, depth);
         vec3 normal = computeViewSpaceNormal(origin, uv);
 

--- a/src/scene/shader-lib/wgsl/chunks/render-pass/frag/ssao.js
+++ b/src/scene/shader-lib/wgsl/chunks/render-pass/frag/ssao.js
@@ -41,6 +41,15 @@ export default /* wgsl */`
         return vec3f((0.5 - uv) * vec2f(uniform.uAspect, 1.0) * linearDepth, linearDepth);
     }
 
+    // snap the uv to the center of the depth texture texel it falls into, so that the
+    // reconstructed view-space position matches the surface point the depth was rendered at.
+    // Without this, when the AO resolution is lower than the depth resolution, positions are
+    // reconstructed slightly off the true surface, causing self-occlusion banding artifacts.
+    fn snapToDepthTexelCenter(uv: vec2f) -> vec2f {
+        let size: vec2f = vec2f(textureDimensions(uSceneDepthMap, 0));
+        return (floor(uv * size) + vec2f(0.5)) / size;
+    }
+
     fn faceNormal(dpdx: vec3f, dpdy: vec3f) -> vec3f {
         return normalize(cross(dpdx, dpdy));
     }
@@ -58,8 +67,8 @@ export default /* wgsl */`
     //       are essentially equivalent to textureGather (which we don't have on ES3.0),
     //       and this is executed just once.
     fn computeViewSpaceNormalDepth(position: vec3f, uv: vec2f) -> vec3f {
-        let uvdx: vec2f = uv + vec2f(uniform.uInvResolution.x, 0.0);
-        let uvdy: vec2f = uv + vec2f(0.0, uniform.uInvResolution.y);
+        let uvdx: vec2f = snapToDepthTexelCenter(uv + vec2f(uniform.uInvResolution.x, 0.0));
+        let uvdy: vec2f = snapToDepthTexelCenter(uv + vec2f(0.0, uniform.uInvResolution.y));
         let px: vec3f = computeViewSpacePositionFromDepth(uvdx, -getLinearScreenDepth(uvdx));
         let py: vec3f = computeViewSpacePositionFromDepth(uvdy, -getLinearScreenDepth(uvdy));
         let dpdx: vec3f = px - position;
@@ -114,7 +123,7 @@ export default /* wgsl */`
 
         let ssRadius: f32 = max(1.0, tap.z * ssDiskRadius); // at least 1 pixel screen-space radius
 
-        let uvSamplePos: vec2f = uv + (ssRadius * tap.xy) * uniform.uInvResolution;
+        let uvSamplePos: vec2f = snapToDepthTexelCenter(uv + (ssRadius * tap.xy) * uniform.uInvResolution);
 
         // TODO: level is not used, but could be used with mip-mapped depth texture
         let level: f32 = clamp(floor(log2(ssRadius)) - kLog2LodRate, 0.0, uniform.uMaxLevel);
@@ -167,9 +176,9 @@ export default /* wgsl */`
     fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         var output: FragmentOutput;
 
-        let uv: vec2f = input.uv0; // interpolated to pixel center
+        let uv: vec2f = snapToDepthTexelCenter(input.uv0);
 
-        let depth: f32 = -getLinearScreenDepth(input.uv0);
+        let depth: f32 = -getLinearScreenDepth(uv);
         let origin: vec3f = computeViewSpacePositionFromDepth(uv, depth);
         let normal: vec3f = computeViewSpaceNormalDepth(origin, uv);
 


### PR DESCRIPTION
Fixes SSAO (CameraFrame) becoming much weaker when `ssao.scale` is reduced below 1. The AO now looks the same at 75% / 50% / 25% scale as at 100%, just with lower resolution.

**Changes:**
- `RenderPassSsao`: the world-space radius is no longer divided by the scale, and the projection scale is derived from the (scaled) render target height instead of the source texture height. Previously the screen-space sampling disk grew as `1/scale²` while the world-space falloff radius only grew as `1/scale`, so at lower scales most samples fell outside the falloff window and were weighted to ~zero, fading the AO.
- SSAO shader chunks (GLSL + WGSL): snap depth-lookup UVs to the depth texel center before reconstructing view-space positions. At reduced scale, AO pixel centers fall between depth texel centers — the depth fetch snaps to a texel but the position was reconstructed from the unsnapped UV, placing points slightly off the true surface and causing self-occlusion banding on grazing surfaces. The snap is an identity at 100% scale, so full-resolution output is unchanged.

**Examples:**
- `ambient-occlusion`: removed the min-angle auto-bump on scale change (it was a workaround for the banding fixed above, and further weakened AO at low scales), and added a 25% option to the scale dropdown.

Performance:
- when 50% scale is used, on my Apple M4 this saves about 1ms from 2.8ms frame on a modest resolution, so this makes 50% worth using, as quality is not far of 100% now

Verified on WebGL2 and WebGPU: mean AO-debug-view luminance at scale 1 / 0.75 / 0.5 is now within ~0.3% across scales (previously visibly faded), with no banding at minAngle 10.

AO with scale 100%
<img width="985" height="684" alt="Screenshot 2026-07-24 at 11 59 00" src="https://github.com/user-attachments/assets/87a3ae72-79e0-482d-a6cf-aab378b8be02" />

AO with scale 50% before
<img width="1118" height="841" alt="50% before" src="https://github.com/user-attachments/assets/dc54fcdb-7294-47db-a238-96ae8f5b295b" />

AO with scale 50% now
<img width="991" height="678" alt="Screenshot 2026-07-24 at 11 59 09" src="https://github.com/user-attachments/assets/497d5da8-1e41-44f9-8051-05fcf111c831" />

AO with 25% now (useable in some cases, unlike before)
<img width="994" height="735" alt="Screenshot 2026-07-24 at 11 59 19" src="https://github.com/user-attachments/assets/17ab1d2c-186f-4a4f-96d1-c2a84f3bf268" />
