### PR TITLE
Add camera.clearColorTonemapped to match clear color with scene colors

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -502,6 +502,32 @@ class CameraComponent extends Component {
     }
 
     /**
+     * Sets whether the clear color is tone mapped. When false, the clear color is written to the
+     * render target exactly as specified, so it is not affected by the camera's exposure, tone
+     * mapping or gamma correction. When true, the clear color is treated as a scene color: it is
+     * converted to linear space and processed by the camera's exposure, tone mapping and gamma
+     * correction, the same way shaded pixels are. Enable this to make the cleared background
+     * match other scene colors - most notably {@link FogParams#color}, which otherwise only
+     * matches the clear color when tone mapping is disabled. This also makes the background
+     * appear identical whether or not HDR post-processing (e.g. `CameraFrame`) is used. Defaults
+     * to false.
+     *
+     * @type {boolean}
+     */
+    set clearColorTonemapped(value) {
+        this._camera.clearColorTonemapped = value;
+    }
+
+    /**
+     * Gets whether the clear color is tone mapped.
+     *
+     * @type {boolean}
+     */
+    get clearColorTonemapped() {
+        return this._camera.clearColorTonemapped;
+    }
+
+    /**
      * Sets the depth value to clear the depth buffer to. Defaults to 1.
      *
      * @type {number}
@@ -1390,6 +1416,7 @@ class CameraComponent extends Component {
         this.calculateTransform = source.calculateTransform;
         this.clearColor = source.clearColor;
         this.clearColorBuffer = source.clearColorBuffer;
+        this.clearColorTonemapped = source.clearColorTonemapped;
         this.clearDepthBuffer = source.clearDepthBuffer;
         this.clearStencilBuffer = source.clearStencilBuffer;
         this.cullFaces = source.cullFaces;

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -16,6 +16,7 @@ const _properties = [
     'calculateTransform',
     'clearColor',
     'clearColorBuffer',
+    'clearColorTonemapped',
     'clearDepth',
     'clearDepthBuffer',
     'clearStencilBuffer',

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -8,8 +8,10 @@ import { math } from '../core/math/math.js';
 import { Frustum } from '../core/shape/frustum.js';
 import {
     VIEW_CENTER, ASPECT_AUTO, PROJECTION_PERSPECTIVE, PROJECTION_ORTHOGRAPHIC,
-    LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI, LAYERID_IMMEDIATE
+    LAYERID_WORLD, LAYERID_DEPTH, LAYERID_SKYBOX, LAYERID_UI, LAYERID_IMMEDIATE,
+    GAMMA_SRGB, TONEMAP_NONE
 } from './constants.js';
+import { toneMapColor } from './tonemapping.js';
 import { FramePassColorGrab } from './graphics/frame-pass-color-grab.js';
 import { FramePassDepthGrab } from './graphics/frame-pass-depth-grab.js';
 import { CameraShaderParams } from './camera-shader-params.js';
@@ -21,6 +23,7 @@ import { CameraShaderParams } from './camera-shader-params.js';
  * @import { FogParams } from './fog-params.js'
  * @import { Layer } from './layer.js'
  * @import { RenderView } from './render-view.js'
+ * @import { Scene } from './scene.js'
  * @import { ShaderPassInfo } from './shader-pass.js'
  */
 
@@ -35,6 +38,7 @@ const _frustumViewInvMat = new Mat4();
 const _frustumViewMat = new Mat4();
 const _frustumViewProjMat = new Mat4();
 const _frustumPoints = [new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3(), new Vec3()];
+const _tonemappedClearColor = new Color();
 
 /**
  * A camera.
@@ -156,6 +160,7 @@ class Camera {
         this._calculateTransform = null;
         this._clearColor = new Color(0.75, 0.75, 0.75, 1);
         this._clearColorBuffer = true;
+        this._clearColorTonemapped = false;
         this._clearDepth = 1;
         this._clearDepthBuffer = true;
         this._clearStencil = 0;
@@ -322,6 +327,14 @@ class Camera {
 
     get clearColorBuffer() {
         return this._clearColorBuffer;
+    }
+
+    set clearColorTonemapped(newValue) {
+        this._clearColorTonemapped = newValue;
+    }
+
+    get clearColorTonemapped() {
+        return this._clearColorTonemapped;
     }
 
     set clearDepth(newValue) {
@@ -669,6 +682,7 @@ class Camera {
         this.calculateTransform = other.calculateTransform;
         this.clearColor = other.clearColor;
         this.clearColorBuffer = other.clearColorBuffer;
+        this.clearColorTonemapped = other.clearColorTonemapped;
         this.clearDepth = other.clearDepth;
         this.clearDepthBuffer = other.clearDepthBuffer;
         this.clearStencil = other.clearStencil;
@@ -940,6 +954,46 @@ class Camera {
     getExposure() {
         const ev100 = Math.log2((this._aperture * this._aperture) / this._shutter * 100.0 / this._sensitivity);
         return 1.0 / (Math.pow(2.0, ev100) * 1.2);
+    }
+
+    /**
+     * Returns the color to clear the render target with. When {@link clearColorTonemapped} is
+     * false, this is the clear color exactly as specified. When true, the clear color is treated
+     * as a scene color instead of a raw framebuffer value: it is converted to linear space, then
+     * exposure and tone mapping are applied, and the result is encoded to the pass's output gamma
+     * - the same processing shaded pixels receive. This makes the cleared background match scene
+     * colors such as the fog color, and makes it render identically with and without HDR
+     * post-processing.
+     *
+     * @param {Scene} scene - The scene, supplying exposure settings.
+     * @param {number} [toneMapping] - The tone mapping used by the render pass. Defaults to the
+     * camera's tone mapping.
+     * @param {number} [gammaCorrection] - The gamma correction used by the render pass. Defaults
+     * to the camera's gamma correction.
+     * @returns {Color} The clear color. The returned color is temporary storage when
+     * {@link clearColorTonemapped} is true, use it immediately.
+     * @ignore
+     */
+    getRenderPassClearColor(scene, toneMapping = this.shaderParams.toneMapping, gammaCorrection = this.shaderParams.gammaCorrection) {
+
+        const clearColor = this._clearColor;
+        if (!this._clearColorTonemapped) {
+            return clearColor;
+        }
+
+        const dst = _tonemappedClearColor.linear(clearColor);
+
+        // TONEMAP_NONE applies neither tone mapping nor exposure, matching the shaders
+        if (toneMapping !== TONEMAP_NONE) {
+            const exposure = scene.physicalUnits ? this.getExposure() : scene.exposure;
+            toneMapColor(dst, toneMapping, exposure);
+        }
+
+        if (gammaCorrection === GAMMA_SRGB) {
+            dst.gamma();
+        }
+
+        return dst;
     }
 
     // returns estimated size of the sphere on the screen in range of [0..1]

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -179,7 +179,10 @@ class RenderPassForward extends RenderPass {
             const camera = cameraComponent.camera;
             const fullSizeClearRect = camera.fullSizeClearRect;
 
-            this.setClearColor(fullSizeClearRect && step.clearColor ? camera.clearColor : undefined);
+            // when clearColorTonemapped is enabled, the clear color goes through the same color
+            // pipeline as shaded pixels, using this pass's gamma / tone mapping overrides if set
+            const clearColor = camera.getRenderPassClearColor(this.scene, this.toneMapping, this.gammaCorrection);
+            this.setClearColor(fullSizeClearRect && step.clearColor ? clearColor : undefined);
             this.setClearDepth(fullSizeClearRect && step.clearDepth && !this.noDepthClear ? camera.clearDepth : undefined);
             this.setClearStencil(fullSizeClearRect && step.clearStencil ? camera.clearStencil : undefined);
         }

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -476,7 +476,9 @@ class Renderer {
             const device = this.device;
             DebugGraphics.pushGpuMarker(device, 'CLEAR');
 
-            const c = camera._clearColor;
+            // this runs during pass execution, when the pass's gamma / tone mapping overrides are
+            // already applied to the camera's shader params, so those defaults are used here
+            const c = camera.getRenderPassClearColor(this.scene);
             _tempClearColor[0] = c.r;
             _tempClearColor[1] = c.g;
             _tempClearColor[2] = c.b;

--- a/src/scene/tonemapping.js
+++ b/src/scene/tonemapping.js
@@ -1,0 +1,143 @@
+import {
+    TONEMAP_LINEAR, TONEMAP_FILMIC, TONEMAP_HEJL, TONEMAP_ACES, TONEMAP_ACES2, TONEMAP_NEUTRAL
+} from './constants.js';
+
+/**
+ * @import { Color } from '../core/math/color.js'
+ */
+
+// Uncharted 2 filmic curve, mirrors tonemappingFilmic shader chunk
+const filmicCurve = (x) => {
+    const A = 0.15, B = 0.50, C = 0.10, D = 0.20, E = 0.02, F = 0.30;
+    return ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F;
+};
+
+// Hill ACES fit, mirrors tonemappingAces2 shader chunk
+const rrtAndOdtFit = (v) => {
+    const a = v * (v + 0.0245786) - 0.000090537;
+    const b = v * (0.983729 * v + 0.4329510) + 0.238081;
+    return a / b;
+};
+
+/**
+ * Applies exposure and tone mapping to the RGB channels of a linear-space color, mirroring the
+ * engine's tone mapping shader chunks (the `toneMap` function selected by the TONEMAP define).
+ * The alpha channel is left unchanged. Note that {@link TONEMAP_NONE} applies neither tone
+ * mapping nor exposure, matching the shader behavior.
+ *
+ * @param {Color} color - The linear-space color to tone map. It is modified in place.
+ * @param {number} toneMapping - The tone mapping transform to apply (TONEMAP_***).
+ * @param {number} exposure - The exposure to apply.
+ * @ignore
+ */
+function toneMapColor(color, toneMapping, exposure) {
+
+    let { r, g, b } = color;
+
+    switch (toneMapping) {
+
+        case TONEMAP_LINEAR: {
+            r *= exposure;
+            g *= exposure;
+            b *= exposure;
+            break;
+        }
+
+        case TONEMAP_FILMIC: {
+            const W = 11.2;
+            const whiteScale = 1 / filmicCurve(W);
+            r = filmicCurve(r * exposure) * whiteScale;
+            g = filmicCurve(g * exposure) * whiteScale;
+            b = filmicCurve(b * exposure) * whiteScale;
+            break;
+        }
+
+        case TONEMAP_HEJL: {
+            const A = 0.22, B = 0.3, C = 0.1, D = 0.2, E = 0.01, F = 0.3;
+            const scl = 1.25;
+            const hejl = (x) => {
+                const h = Math.max(0, x * exposure - 0.004);
+                return (h * ((scl * A) * h + scl * C * B) + scl * D * E) / (h * (A * h + B) + D * F) - scl * (E / F);
+            };
+            r = hejl(r);
+            g = hejl(g);
+            b = hejl(b);
+            break;
+        }
+
+        case TONEMAP_ACES: {
+            const tA = 2.51, tB = 0.03, tC = 2.43, tD = 0.59, tE = 0.14;
+            const aces = (v) => {
+                const x = v * exposure;
+                return (x * (tA * x + tB)) / (x * (tC * x + tD) + tE);
+            };
+            r = aces(r);
+            g = aces(g);
+            b = aces(b);
+            break;
+        }
+
+        case TONEMAP_ACES2: {
+            const scale = exposure / 0.6;
+            r *= scale;
+            g *= scale;
+            b *= scale;
+
+            // sRGB => XYZ => D65_2_D60 => AP1 => RRT_SAT
+            let ir = 0.59719 * r + 0.35458 * g + 0.04823 * b;
+            let ig = 0.07600 * r + 0.90834 * g + 0.01566 * b;
+            let ib = 0.02840 * r + 0.13383 * g + 0.83777 * b;
+
+            ir = rrtAndOdtFit(ir);
+            ig = rrtAndOdtFit(ig);
+            ib = rrtAndOdtFit(ib);
+
+            // ODT_SAT => XYZ => D60_2_D65 => sRGB
+            r = 1.60475 * ir - 0.53108 * ig - 0.07367 * ib;
+            g = -0.10208 * ir + 1.10813 * ig - 0.00605 * ib;
+            b = -0.00327 * ir - 0.07276 * ig + 1.07602 * ib;
+
+            r = Math.min(Math.max(r, 0), 1);
+            g = Math.min(Math.max(g, 0), 1);
+            b = Math.min(Math.max(b, 0), 1);
+            break;
+        }
+
+        case TONEMAP_NEUTRAL: {
+            r *= exposure;
+            g *= exposure;
+            b *= exposure;
+
+            const startCompression = 0.8 - 0.04;
+            const desaturation = 0.15;
+
+            const x = Math.min(r, Math.min(g, b));
+            const offset = x < 0.08 ? x - 6.25 * x * x : 0.04;
+            r -= offset;
+            g -= offset;
+            b -= offset;
+
+            const peak = Math.max(r, Math.max(g, b));
+            if (peak >= startCompression) {
+                const d = 1 - startCompression;
+                const newPeak = 1 - (d * d) / (peak + d - startCompression);
+                const peakScale = newPeak / peak;
+                r *= peakScale;
+                g *= peakScale;
+                b *= peakScale;
+
+                const t = 1 - 1 / (desaturation * (peak - newPeak) + 1);
+                r += (newPeak - r) * t;
+                g += (newPeak - g) * t;
+                b += (newPeak - b) * t;
+            }
+            break;
+        }
+    }
+
+    color.r = r;
+    color.g = g;
+    color.b = b;
+}
+
+export { toneMapColor };

--- a/test-clear-color/index.html
+++ b/test-clear-color/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>clearColorTonemapped test</title>
+    <style>
+        body { font-family: monospace; margin: 10px; }
+        canvas#app { width: 800px; height: 600px; border: 1px solid #888; display: block; }
+        table { border-collapse: collapse; margin-top: 10px; }
+        td, th { border: 1px solid #aaa; padding: 3px 8px; }
+        .pass { background: #cfc; }
+        .fail { background: #fcc; }
+    </style>
+</head>
+<body>
+    <div id="info"></div>
+    <canvas id="app" width="800" height="600"></canvas>
+    <table id="results"><tr><th>tonemap</th><th>fogged (left)</th><th>background (right)</th><th>maxDelta</th><th>result</th></tr></table>
+    <script>
+        window.addEventListener('error', e => { window.lastError = String(e.error && e.error.stack || e.message); });
+        window.addEventListener('unhandledrejection', e => { window.lastError = String(e.reason && e.reason.stack || e.reason); });
+    </script>
+    <script type="module">
+        import * as pc from '/build/playcanvas.dbg.mjs';
+
+        const params = new URLSearchParams(location.search);
+        const deviceType = params.get('device') || 'webgl2';       // webgl2 | webgpu
+        const tonemapped = params.get('tonemapped') !== '0';       // clearColorTonemapped flag
+        const useCF = params.get('cf') === '1';                    // CameraFrame post-processing
+        const exposure = parseFloat(params.get('exposure') || '1.5');
+
+        document.getElementById('info').textContent =
+            `device=${deviceType} clearColorTonemapped=${tonemapped} cameraFrame=${useCF} exposure=${exposure}`;
+
+        const canvas = document.getElementById('app');
+        const device = await pc.createGraphicsDevice(canvas, {
+            deviceTypes: [deviceType],
+            antialias: false,
+            preserveDrawingBuffer: true
+        });
+
+        const app = new pc.AppBase(canvas);
+        const createOptions = new pc.AppOptions();
+        createOptions.graphicsDevice = device;
+        createOptions.componentSystems = [pc.RenderComponentSystem, pc.CameraComponentSystem];
+        app.init(createOptions);
+        app.start();
+
+        const color = new pc.Color(0.5, 0.3, 0.2, 1);
+
+        app.scene.exposure = exposure;
+        app.scene.fog.type = pc.FOG_LINEAR;
+        app.scene.fog.start = 0;
+        app.scene.fog.end = 1;
+        app.scene.fog.color = color;
+
+        const cameraEntity = new pc.Entity('camera');
+        cameraEntity.addComponent('camera', {
+            clearColor: color,
+            clearColorTonemapped: tonemapped,
+            farClip: 100
+        });
+        app.root.addChild(cameraEntity);
+
+        // box beyond fog end, covering the left half of the screen
+        const box = new pc.Entity('box');
+        box.addComponent('render', { type: 'box' });
+        box.setLocalPosition(-15, 0, -50);
+        box.setLocalScale(30, 50, 1);
+        app.root.addChild(box);
+
+        let cameraFrame = null;
+        if (useCF) {
+            cameraFrame = new pc.CameraFrame(app, cameraEntity.camera);
+            cameraFrame.rendering.samples = 1;
+            cameraFrame.update();
+        }
+
+        const modes = [
+            ['LINEAR', pc.TONEMAP_LINEAR],
+            ['FILMIC', pc.TONEMAP_FILMIC],
+            ['HEJL', pc.TONEMAP_HEJL],
+            ['ACES', pc.TONEMAP_ACES],
+            ['ACES2', pc.TONEMAP_ACES2],
+            ['NEUTRAL', pc.TONEMAP_NEUTRAL],
+            ['NONE', pc.TONEMAP_NONE]
+        ];
+
+        const ctx2d = document.createElement('canvas').getContext('2d', { willReadFrequently: true });
+        ctx2d.canvas.width = canvas.width;
+        ctx2d.canvas.height = canvas.height;
+
+        const raf = () => new Promise(resolve => requestAnimationFrame(resolve));
+
+        const sample = (x, y) => {
+            const d = ctx2d.getImageData(x, y, 1, 1).data;
+            return [d[0], d[1], d[2]];
+        };
+
+        window.checkpoint = 'app started';
+        const results = [];
+        for (const [name, mode] of modes) {
+            window.checkpoint = `mode ${name}`;
+            if (cameraFrame) {
+                cameraFrame.rendering.toneMapping = mode;
+                cameraFrame.update();
+            } else {
+                cameraEntity.camera.toneMapping = mode;
+            }
+
+            // let a few frames render, then grab the presented canvas. Drive frames manually
+            // with app.tick() as rAF may be frozen in a hidden tab
+            for (let i = 0; i < 5; i++) {
+                app.tick();
+                await new Promise(r => setTimeout(r, 30));
+            }
+            window.checkpoint = `mode ${name} rendered`;
+            ctx2d.drawImage(canvas, 0, 0);
+            window.checkpoint = `mode ${name} captured`;
+
+            const fogged = sample(200, 300);     // fully fogged box
+            const background = sample(600, 300); // clear color
+            const maxDelta = Math.max(...fogged.map((v, i) => Math.abs(v - background[i])));
+            const pass = maxDelta <= 2;
+            results.push({ mode: name, fogged, background, maxDelta, pass });
+
+            const row = document.getElementById('results').insertRow();
+            row.className = pass ? 'pass' : 'fail';
+            row.innerHTML = `<td>${name}</td><td>${fogged}</td><td>${background}</td><td>${maxDelta}</td><td>${pass ? 'MATCH' : 'MISMATCH'}</td>`;
+        }
+
+        console.log(`RESULTS ${deviceType} tonemapped=${tonemapped} cf=${useCF}: ${JSON.stringify(results)}`);
+        window.testResults = results;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
> [!NOTE]
> **Reference PR — closed intentionally, deferred to engine V3.** See the investigation in #7181. Shipping this as an opt-in flag on v2 was rejected because the off-state is inherently inconsistent under `CameraFrame` (see below); for V3 this behavior should become the default (`true`), which is a breaking visual change.

Camera clear color is a raw framebuffer value while every rendered color (including `fog.color`) is a scene color — linearized, exposed, tone mapped and gamma encoded. As a result the background matches fog only when tone mapping is disabled (#7181), and with `CameraFrame` the raw clear color lands un-linearized in the HDR scene buffer and gets tone mapped by the compose pass, so it matches neither the authored value nor fog (#7451).

This PR adds an opt-in `clearColorTonemapped` flag (default `false`, non-breaking) that treats the clear color as a scene color: converted to linear space, processed by the camera's exposure and tone mapping, and encoded to the render pass's output gamma — the same pipeline shaded pixels go through.

**Changes:**
- `CameraComponent#clearColorTonemapped` / `Camera#clearColorTonemapped` — opt-in flag, default `false`
- `src/scene/tonemapping.js` — `toneMapColor()`, a CPU mirror of all 7 tone mapping shader chunks (`TONEMAP_NONE` applies neither tone mapping nor exposure, matching the shaders)
- `Camera#getRenderPassClearColor()` — computes the clear value for a pass; respects the pass's gamma / tone mapping overrides, so under `CameraFrame` (scene pass renders with `GAMMA_NONE`/`TONEMAP_NONE`) it reduces to linearizing the color into the HDR buffer, and the compose pass tone maps it like everything else
- Applied in `RenderPassForward.updateClears` and in `Renderer#clear` (partial-viewport clears)
- `test-clear-color/index.html` — verification harness (fully-fogged geometry vs cleared background pixel comparison)

**Verification:**
- Flag on: fogged geometry and background match with delta 0 for all 7 tonemappers × WebGL2/WebGPU × with and without `CameraFrame` (exposure 1.5); `CameraFrame` vs no-`CameraFrame` backgrounds agree within 1/255
- Flag off: reproduces the reported mismatches (delta up to 53/255 forward, 119/255 with `CameraFrame`)
- `TONEMAP_NONE` + flag on yields the exact authored color (no behavior change without tone mapping)

**Known trade-offs:**
- The `false` state cannot be made consistent under `CameraFrame`: showing the authored color unprocessed through an HDR compose pass would require inverting the tonemap curves, which are non-invertible. Hence the V3 plan of defaulting to `true` instead of shipping the flag on v2.
- Tone mapped white is not exactly 1.0 (e.g. ACES), so pure-white clears lose the driver fast-clear optimization when the flag is enabled.

Relates to #7181, #7451.