### PR TITLE
Handle mapAsync rejection when the WebGPU device is lost

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
+++ b/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
@@ -78,11 +78,13 @@ class WebgpuDynamicBuffers extends DynamicBuffers {
         // using them are done on the GPU
         const count = this.pendingStagingBuffers.length;
         if (count) {
+            const device = this.device;
             for (let i = 0; i < count; i++) {
                 const stagingBuffer = this.pendingStagingBuffers[i];
-                stagingBuffer.buffer.mapAsync(GPUMapMode.WRITE).then(() => {
-                    // the buffer can be mapped after the device has been destroyed, so test for that
-                    if (this.stagingBuffers) {
+                device.mapBufferAsync(stagingBuffer.buffer, GPUMapMode.WRITE).then((mapped) => {
+                    // the mapping fails when the device is lost, and can also complete after the
+                    // device has been destroyed - in either case the buffer cannot be reused
+                    if (mapped && this.stagingBuffers) {
                         stagingBuffer.onAvailable();
                         this.stagingBuffers.push(stagingBuffer);
                     }

--- a/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
+++ b/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
@@ -83,10 +83,13 @@ class WebgpuDynamicBuffers extends DynamicBuffers {
                 const stagingBuffer = this.pendingStagingBuffers[i];
                 device.mapBufferAsync(stagingBuffer.buffer, GPUMapMode.WRITE).then((mapped) => {
                     // the mapping fails when the device is lost, and can also complete after the
-                    // device has been destroyed - in either case the buffer cannot be reused
+                    // device has been destroyed - in either case the buffer cannot be reused, so
+                    // destroy it to release its memory and vram tracking
                     if (mapped && this.stagingBuffers) {
                         stagingBuffer.onAvailable();
                         this.stagingBuffers.push(stagingBuffer);
+                    } else {
+                        stagingBuffer.destroy(device);
                     }
                 });
             }

--- a/src/platform/graphics/webgpu/webgpu-gpu-profiler.js
+++ b/src/platform/graphics/webgpu/webgpu-gpu-profiler.js
@@ -38,7 +38,10 @@ class WebgpuGpuProfiler extends GpuProfiler {
             // request results
             const renderVersion = this.device.renderVersion;
             this.timestampQueriesSet?.request(this.slotCount, renderVersion).then((results) => {
-                this.report(results.renderVersion, results.timings, results.frameTime);
+                // no results are returned when the device is lost
+                if (results) {
+                    this.report(results.renderVersion, results.timings, results.frameTime);
+                }
             });
 
             super.request(renderVersion);

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1435,6 +1435,28 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     }
 
     /**
+     * Map a GPUBuffer for reading or writing, handling the rejection which happens when the
+     * device is lost, or when the buffer is destroyed while the mapping is pending. In those
+     * cases the buffer cannot be used, and the returned promise resolves with false instead of
+     * rejecting.
+     *
+     * @param {GPUBuffer} buffer - The buffer to map.
+     * @param {number} mode - GPUMapMode.READ or GPUMapMode.WRITE.
+     * @returns {Promise<boolean>} A promise that resolves with true when the buffer is mapped,
+     * or false when the mapping failed.
+     * @private
+     */
+    mapBufferAsync(buffer, mode) {
+
+        // mapAsync rejects when the device is already lost, so do not even call it
+        if (this.contextLost) {
+            return Promise.resolve(false);
+        }
+
+        return buffer.mapAsync(mode).then(() => true, () => false);
+    }
+
+    /**
      * Read a content of a storage buffer.
      *
      * @param {WebgpuBuffer} storageBuffer - The storage buffer.
@@ -1475,7 +1497,13 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
             const read = () => {
 
-                destBuffer?.mapAsync(GPUMapMode.READ).then(() => {
+                this.mapBufferAsync(destBuffer, GPUMapMode.READ).then((mapped) => {
+
+                    if (!mapped) {
+                        stagingBuffer.destroy(this);
+                        reject(new Error('Failed to map a staging buffer for reading, most likely because the device was lost.'));
+                        return;
+                    }
 
                     // copy data to a buffer
                     data ??= new Uint8Array(size);

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1438,7 +1438,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      * Map a GPUBuffer for reading or writing, handling the rejection which happens when the
      * device is lost, or when the buffer is destroyed while the mapping is pending. In those
      * cases the buffer cannot be used, and the returned promise resolves with false instead of
-     * rejecting.
+     * rejecting. Any other rejection is unexpected and is asserted in debug builds.
      *
      * @param {GPUBuffer} buffer - The buffer to map.
      * @param {number} mode - GPUMapMode.READ or GPUMapMode.WRITE.
@@ -1453,7 +1453,12 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             return Promise.resolve(false);
         }
 
-        return buffer.mapAsync(mode).then(() => true, () => false);
+        return buffer.mapAsync(mode).then(() => true, (error) => {
+            // AbortError is expected when the device is lost or the buffer is destroyed while
+            // the mapping is pending; anything else indicates incorrect use of the mapping API
+            Debug.assert(error.name === 'AbortError', 'GPUBuffer.mapAsync failed', error);
+            return false;
+        });
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-query-set.js
+++ b/src/platform/graphics/webgpu/webgpu-query-set.js
@@ -83,7 +83,12 @@ class WebgpuQuerySet {
         const stagingBuffer = this.activeStagingBuffer;
         this.activeStagingBuffer = null;
 
-        return stagingBuffer.mapAsync(GPUMapMode.READ).then(() => {
+        return this.device.mapBufferAsync(stagingBuffer, GPUMapMode.READ).then((mapped) => {
+
+            // the mapping fails when the device is lost - the buffer cannot be used, no results
+            if (!mapped) {
+                return null;
+            }
 
             // timestamps in nanoseconds. Note that this array is valid only till we unmap the staging buffer.
             const srcTimings = new BigInt64Array(stagingBuffer.getMappedRange());

--- a/src/platform/graphics/webgpu/webgpu-query-set.js
+++ b/src/platform/graphics/webgpu/webgpu-query-set.js
@@ -87,6 +87,7 @@ class WebgpuQuerySet {
 
             // the mapping fails when the device is lost - the buffer cannot be used, no results
             if (!mapped) {
+                stagingBuffer.destroy();
                 return null;
             }
 

--- a/src/platform/graphics/webgpu/webgpu-upload-stream.js
+++ b/src/platform/graphics/webgpu/webgpu-upload-stream.js
@@ -70,14 +70,19 @@ class WebgpuUploadStream {
      */
     update(minByteSize) {
 
+        const device = this.uploadStream.device;
+
         // map all pending buffers
         const pending = this.pendingStagingBuffers;
         for (let i = 0; i < pending.length; i++) {
             const buffer = pending[i];
-            buffer.mapAsync(GPUMapMode.WRITE).then(() => {
-                if (!this._destroyed) {
+            // @ts-ignore - mapBufferAsync is available on WebgpuGraphicsDevice
+            device.mapBufferAsync(buffer, GPUMapMode.WRITE).then((mapped) => {
+                if (mapped && !this._destroyed) {
                     this.availableStagingBuffers.push(buffer);
                 } else {
+                    // the buffer cannot be reused when the mapping fails (device lost) or when
+                    // this instance was destroyed in the meantime
                     buffer.destroy();
                 }
             });


### PR DESCRIPTION
Fixes #6677

When the WebGPU device is lost, every in-flight and subsequently issued `GPUBuffer.mapAsync()` rejects with `AbortError: Failed to execute 'mapAsync' on 'GPUBuffer': Device is lost`. None of the engine's four `mapAsync` call sites attached a rejection handler, so this surfaced as an unhandled promise rejection (affecting ~2% of users of the reported game).

**Changes:**
- Added an internal `WebgpuGraphicsDevice.mapBufferAsync` helper that skips the call when the context is already lost and converts the device-lost / buffer-destroyed rejection into a `false` result instead of an unhandled rejection
- Dynamic buffers and upload stream: a staging buffer whose mapping fails is no longer recycled (device recovery recreates these anyway)
- GPU profiler query set: failed mapping returns no results and the profiler skips reporting that frame
- `readBuffer`: on failed mapping, the returned promise now rejects with a descriptive error instead of never settling - previously `StorageBuffer.read()` / texture readback callers would hang forever after device loss