### PR TITLE
Expose Bayer 2/4 dither modes and add Bayer 16 dither mode

### DIFF
--- a/examples/src/examples/graphics/dithered-transparency.controls.jsx
+++ b/examples/src/examples/graphics/dithered-transparency.controls.jsx
@@ -7,7 +7,15 @@ import {
     SelectInput
 } from '@playcanvas/pcui/react';
 
-import { DITHER_BAYER8, DITHER_BLUENOISE, DITHER_IGNNOISE, DITHER_NONE } from 'playcanvas';
+import {
+    DITHER_BAYER2,
+    DITHER_BAYER4,
+    DITHER_BAYER8,
+    DITHER_BAYER16,
+    DITHER_BLUENOISE,
+    DITHER_IGNNOISE,
+    DITHER_NONE
+} from 'playcanvas';
 
 /**
  * @import { Observer } from '@playcanvas/observer'
@@ -47,7 +55,10 @@ export function Controls({ observer }) {
                         type='string'
                         options={[
                             { v: DITHER_NONE, t: 'None' },
+                            { v: DITHER_BAYER2, t: 'Bayer2' },
+                            { v: DITHER_BAYER4, t: 'Bayer4' },
                             { v: DITHER_BAYER8, t: 'Bayer8' },
+                            { v: DITHER_BAYER16, t: 'Bayer16' },
                             { v: DITHER_BLUENOISE, t: 'BlueNoise' },
                             { v: DITHER_IGNNOISE, t: 'IGNNoise' }
                         ]}
@@ -60,7 +71,10 @@ export function Controls({ observer }) {
                         type='string'
                         options={[
                             { v: DITHER_NONE, t: 'None' },
+                            { v: DITHER_BAYER2, t: 'Bayer2' },
+                            { v: DITHER_BAYER4, t: 'Bayer4' },
                             { v: DITHER_BAYER8, t: 'Bayer8' },
+                            { v: DITHER_BAYER16, t: 'Bayer16' },
                             { v: DITHER_BLUENOISE, t: 'BlueNoise' },
                             { v: DITHER_IGNNOISE, t: 'IGNNoise' }
                         ]}

--- a/examples/src/examples/materials/material-transparency.example.mjs
+++ b/examples/src/examples/materials/material-transparency.example.mjs
@@ -7,7 +7,10 @@ import {
     CameraComponentSystem,
     Color,
     DISPLAYFORMAT_LDR_SRGB,
+    DITHER_BAYER2,
+    DITHER_BAYER4,
     DITHER_BAYER8,
+    DITHER_BAYER16,
     DITHER_BLUENOISE,
     DITHER_IGNNOISE,
     DITHER_NONE,
@@ -86,14 +89,22 @@ camera.addComponent('camera', {
     clearColor: Color.BLACK,
     toneMapping: TONEMAP_LINEAR
 });
-camera.translate(0, -0.5, 14);
+camera.translate(0, -0.5, 16);
 camera.rotate(0, 0, 0);
 app.root.addChild(camera);
 
-const NUM_SPHERES_X = 4;
+const NUM_SPHERES_X = 7;
 const NUM_SPHERES_Z = 10;
 
-const ditherOptions = [DITHER_NONE, DITHER_BAYER8, DITHER_BLUENOISE, DITHER_IGNNOISE];
+const ditherOptions = [
+    DITHER_NONE,
+    DITHER_BAYER2,
+    DITHER_BAYER4,
+    DITHER_BAYER8,
+    DITHER_BAYER16,
+    DITHER_BLUENOISE,
+    DITHER_IGNNOISE
+];
 
 /**
  * @param {number} x - The x coordinate.
@@ -161,7 +172,15 @@ for (let i = 0; i < NUM_SPHERES_X; i++) {
 }
 
 const y = (NUM_SPHERES_Z + 1) * -0.5;
-createText(assets.font, 'Alpha\nBlend', NUM_SPHERES_X * -0.6, y);
-createText(assets.font, 'Bayer8\nDither', NUM_SPHERES_X * -0.2, y);
-createText(assets.font, 'Blue-noise\nDither', NUM_SPHERES_X * 0.2, y);
-createText(assets.font, 'IGN-noise\nDither', NUM_SPHERES_X * 0.6, y);
+const labels = [
+    'Alpha\nBlend',
+    'Bayer2\nDither',
+    'Bayer4\nDither',
+    'Bayer8\nDither',
+    'Bayer16\nDither',
+    'Blue-noise\nDither',
+    'IGN-noise\nDither'
+];
+labels.forEach((label, i) => {
+    createText(assets.font, label, 1.5 * (i - (NUM_SPHERES_X - 1) * 0.5), y);
+});

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1063,11 +1063,32 @@ export const SKYTYPE_DOME = 'dome';
 export const DITHER_NONE = 'none';
 
 /**
+ * Opacity is dithered using a Bayer 2 matrix.
+ *
+ * @category Graphics
+ */
+export const DITHER_BAYER2 = 'bayer2';
+
+/**
+ * Opacity is dithered using a Bayer 4 matrix.
+ *
+ * @category Graphics
+ */
+export const DITHER_BAYER4 = 'bayer4';
+
+/**
  * Opacity is dithered using a Bayer 8 matrix.
  *
  * @category Graphics
  */
 export const DITHER_BAYER8 = 'bayer8';
+
+/**
+ * Opacity is dithered using a Bayer 16 matrix.
+ *
+ * @category Graphics
+ */
+export const DITHER_BAYER16 = 'bayer16';
 
 /**
  * Opacity is dithered using a blue noise.
@@ -1085,7 +1106,10 @@ export const DITHER_IGNNOISE = 'ignnoise';
 
 export const ditherNames = {
     [DITHER_NONE]: 'NONE',
+    [DITHER_BAYER2]: 'BAYER2',
+    [DITHER_BAYER4]: 'BAYER4',
     [DITHER_BAYER8]: 'BAYER8',
+    [DITHER_BAYER16]: 'BAYER16',
     [DITHER_BLUENOISE]: 'BLUENOISE',
     [DITHER_IGNNOISE]: 'IGNNOISE'
 };

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -380,7 +380,10 @@ const isBlack = (color) => {
  * transparency without alpha blending. Can be:
  *
  * - {@link DITHER_NONE}: Opacity dithering is disabled.
+ * - {@link DITHER_BAYER2}: Opacity is dithered using a Bayer 2 matrix.
+ * - {@link DITHER_BAYER4}: Opacity is dithered using a Bayer 4 matrix.
  * - {@link DITHER_BAYER8}: Opacity is dithered using a Bayer 8 matrix.
+ * - {@link DITHER_BAYER16}: Opacity is dithered using a Bayer 16 matrix.
  * - {@link DITHER_BLUENOISE}: Opacity is dithered using a blue noise.
  * - {@link DITHER_IGNNOISE}: Opacity is dithered using an interleaved gradient noise.
  *
@@ -389,7 +392,10 @@ const isBlack = (color) => {
  * allows shadow transparency without alpha blending. Can be:
  *
  * - {@link DITHER_NONE}: Opacity dithering is disabled.
+ * - {@link DITHER_BAYER2}: Opacity is dithered using a Bayer 2 matrix.
+ * - {@link DITHER_BAYER4}: Opacity is dithered using a Bayer 4 matrix.
  * - {@link DITHER_BAYER8}: Opacity is dithered using a Bayer 8 matrix.
+ * - {@link DITHER_BAYER16}: Opacity is dithered using a Bayer 16 matrix.
  * - {@link DITHER_BLUENOISE}: Opacity is dithered using a blue noise.
  * - {@link DITHER_IGNNOISE}: Opacity is dithered using an interleaved gradient noise.
  *

--- a/src/scene/shader-lib/glsl/chunks/common/frag/bayer.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/bayer.js
@@ -20,4 +20,13 @@ float bayer8(vec2 p) {
     vec2 p4 = floor(0.25 * mod(p, 8.0));
     return 4.0 * (4.0 * bayer2(p1) + bayer2(p2)) + bayer2(p4);
 }
+
+// 16x16 matrix, p - pixel coordinate
+float bayer16(vec2 p) {
+    vec2 p1 = mod(p, 2.0);
+    vec2 p2 = floor(0.5 * mod(p, 4.0));
+    vec2 p4 = floor(0.25 * mod(p, 8.0));
+    vec2 p8 = floor(0.125 * mod(p, 16.0));
+    return 4.0 * (4.0 * (4.0 * bayer2(p1) + bayer2(p2)) + bayer2(p4)) + bayer2(p8);
+}
 `;

--- a/src/scene/shader-lib/glsl/chunks/standard/frag/opacity-dither.js
+++ b/src/scene/shader-lib/glsl/chunks/standard/frag/opacity-dither.js
@@ -1,6 +1,6 @@
 export default /* glsl */`
 
-#if STD_OPACITY_DITHER == BAYER8
+#if STD_OPACITY_DITHER == BAYER2 || STD_OPACITY_DITHER == BAYER4 || STD_OPACITY_DITHER == BAYER8 || STD_OPACITY_DITHER == BAYER16
     #include "bayerPS"
 #endif
 
@@ -22,6 +22,18 @@ void opacityDither(float alpha, float id) {
         float noise = bayer8(floor(mod(gl_FragCoord.xy + blueNoiseJitter.xy + id, 8.0))) / 64.0;
 
     #else
+
+        #if STD_OPACITY_DITHER == BAYER2
+            float noise = bayer2(floor(mod(gl_FragCoord.xy + blueNoiseJitter.xy + id, 2.0))) / 4.0;
+        #endif
+
+        #if STD_OPACITY_DITHER == BAYER4
+            float noise = bayer4(floor(mod(gl_FragCoord.xy + blueNoiseJitter.xy + id, 4.0))) / 16.0;
+        #endif
+
+        #if STD_OPACITY_DITHER == BAYER16
+            float noise = bayer16(floor(mod(gl_FragCoord.xy + blueNoiseJitter.xy + id, 16.0))) / 256.0;
+        #endif
 
         #if STD_OPACITY_DITHER == BLUENOISE
             vec2 uv = fract(gl_FragCoord.xy / 32.0 + blueNoiseJitter.xy + id);

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/bayer.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/bayer.js
@@ -20,4 +20,13 @@ fn bayer8(p: vec2f) -> f32 {
     let p4: vec2f = floor(0.25 * (p % vec2f(8.0)));
     return 4.0 * (4.0 * bayer2(p1) + bayer2(p2)) + bayer2(p4);
 }
+
+// 16x16 matrix, p - pixel coordinate
+fn bayer16(p: vec2f) -> f32 {
+    let p1: vec2f = p % vec2f(2.0);
+    let p2: vec2f = floor(0.5 * (p % vec2f(4.0)));
+    let p4: vec2f = floor(0.25 * (p % vec2f(8.0)));
+    let p8: vec2f = floor(0.125 * (p % vec2f(16.0)));
+    return 4.0 * (4.0 * (4.0 * bayer2(p1) + bayer2(p2)) + bayer2(p4)) + bayer2(p8);
+}
 `;

--- a/src/scene/shader-lib/wgsl/chunks/standard/frag/opacity-dither.js
+++ b/src/scene/shader-lib/wgsl/chunks/standard/frag/opacity-dither.js
@@ -1,6 +1,6 @@
 export default /* wgsl */`
 
-#if STD_OPACITY_DITHER == BAYER8
+#if STD_OPACITY_DITHER == BAYER2 || STD_OPACITY_DITHER == BAYER4 || STD_OPACITY_DITHER == BAYER8 || STD_OPACITY_DITHER == BAYER16
     #include "bayerPS"
 #endif
 
@@ -25,6 +25,18 @@ fn opacityDither(alpha: f32, id: f32) {
         var noise: f32 = bayer8(floor((pcPosition.xy + uniform.blueNoiseJitter.xy + id) % vec2f(8.0))) / 64.0;
 
     #else
+
+        #if STD_OPACITY_DITHER == BAYER2
+            var noise: f32 = bayer2(floor((pcPosition.xy + uniform.blueNoiseJitter.xy + id) % vec2f(2.0))) / 4.0;
+        #endif
+
+        #if STD_OPACITY_DITHER == BAYER4
+            var noise: f32 = bayer4(floor((pcPosition.xy + uniform.blueNoiseJitter.xy + id) % vec2f(4.0))) / 16.0;
+        #endif
+
+        #if STD_OPACITY_DITHER == BAYER16
+            var noise: f32 = bayer16(floor((pcPosition.xy + uniform.blueNoiseJitter.xy + id) % vec2f(16.0))) / 256.0;
+        #endif
 
         #if STD_OPACITY_DITHER == BLUENOISE
             var uv = fract(pcPosition.xy / 32.0 + uniform.blueNoiseJitter.xy + id);


### PR DESCRIPTION
Fixes #6097. The engine already had `bayer2`/`bayer4` GLSL/WGSL helper functions implemented but unreachable, and no way to get a coarser or finer ordered-dither pattern than the existing Bayer 8. This adds `DITHER_BAYER2` and `DITHER_BAYER4` as selectable opacity dither modes, and introduces a new `DITHER_BAYER16` mode for finer dithering.

**Changes:**
- Add `DITHER_BAYER2` and `DITHER_BAYER4` constants, wiring up the existing `bayer2()`/`bayer4()` shader functions to the `opacityDither` chunk (GLSL + WGSL)
- Add `DITHER_BAYER16` constant and a new `bayer16()` function (GLSL + WGSL), extending the existing Bayer matrix recursion
- Update `StandardMaterial#opacityDither` / `#opacityShadowDither` JSDoc to document the new modes

**API Changes:**
- New exports: `DITHER_BAYER2`, `DITHER_BAYER4`, `DITHER_BAYER16`

**Examples:**
- `materials/material-transparency`: added Bayer2, Bayer4 and Bayer16 columns alongside the existing dither modes
- `graphics/dithered-transparency`: added Bayer2, Bayer4 and Bayer16 to the Dither Color / Dither Shadow dropdowns