### PR TITLE
Use shadowCasterPS chunk for gsplat shadow output

### DIFF
--- a/examples/src/examples/gaussian-splatting/shadows.controls.jsx
+++ b/examples/src/examples/gaussian-splatting/shadows.controls.jsx
@@ -6,6 +6,18 @@ import {
     SliderInput
 } from '@playcanvas/pcui/react';
 
+import {
+    SHADOW_PCF1_16F,
+    SHADOW_PCF1_32F,
+    SHADOW_PCF3_16F,
+    SHADOW_PCF3_32F,
+    SHADOW_PCF5_16F,
+    SHADOW_PCF5_32F,
+    SHADOW_PCSS_32F,
+    SHADOW_VSM_16F,
+    SHADOW_VSM_32F
+} from 'playcanvas';
+
 /**
  * @import { Observer } from '@playcanvas/observer'
  * @import { ReactElement } from 'react'
@@ -28,6 +40,24 @@ export function Controls({ observer }) {
                         { v: 0, t: 'Auto' },
                         { v: 1, t: 'Raster (CPU Sort)' },
                         { v: 2, t: 'Raster (GPU Sort)' }
+                    ]}
+                />
+            </LabelGroup>
+            <LabelGroup text='Shadow Type'>
+                <SelectInput
+                    type='number'
+                    binding={new BindingTwoWay()}
+                    link={{ observer, path: 'shadowType' }}
+                    options={[
+                        { v: SHADOW_PCF1_32F, t: 'PCF1_32F' },
+                        { v: SHADOW_PCF3_32F, t: 'PCF3_32F' },
+                        { v: SHADOW_PCF5_32F, t: 'PCF5_32F' },
+                        { v: SHADOW_PCF1_16F, t: 'PCF1_16F' },
+                        { v: SHADOW_PCF3_16F, t: 'PCF3_16F' },
+                        { v: SHADOW_PCF5_16F, t: 'PCF5_16F' },
+                        { v: SHADOW_VSM_16F, t: 'VSM_16F' },
+                        { v: SHADOW_VSM_32F, t: 'VSM_32F' },
+                        { v: SHADOW_PCSS_32F, t: 'PCSS_32F' }
                     ]}
                 />
             </LabelGroup>

--- a/examples/src/examples/gaussian-splatting/shadows.example.mjs
+++ b/examples/src/examples/gaussian-splatting/shadows.example.mjs
@@ -223,7 +223,10 @@ const lights = lightBaseAzimuths.map((azimuth, i) => {
         shadowDistance: 20,
         shadowIntensity: 0.5,
         shadowResolution: 2048,
-        shadowType: SHADOW_PCF5_16F
+        shadowType: SHADOW_PCF5_16F,
+        vsmBlurSize: 16,
+        penumbraSize: 0.04,
+        penumbraFalloff: 5
     });
     light.setEulerAngles(55, azimuth, 0);
     app.root.addChild(light);
@@ -238,6 +241,15 @@ data.on('numLights:set', () => {
     });
 });
 data.set('numLights', 2);
+
+// Shadow type used by all lights
+data.on('shadowType:set', () => {
+    const shadowType = data.get('shadowType');
+    lights.forEach((light) => {
+        light.light.shadowType = shadowType;
+    });
+});
+data.set('shadowType', SHADOW_PCF5_16F);
 
 // Rotate all lights together (same direction), preserving each light's fixed azimuth offset;
 // also advance the custom-shader animation time.

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
@@ -30,6 +30,10 @@ varying mediump vec4 gaussianColor;
     #include "pickPS"
 #endif
 
+#ifdef SHADOW_PASS
+    #include "shadowCasterPS"
+#endif
+
 #ifdef GSPLAT_USER_VARYINGS
     #include "gsplatUserVaryingsPS"
 #endif
@@ -71,7 +75,8 @@ void main(void) {
 
     #elif SHADOW_PASS
 
-        gl_FragColor = vec4(gl_FragCoord.z, 0.0, 0.0, 1.0);
+        // output data for the shadow type being rendered
+        gl_FragColor = getShadowOutput();
 
     #elif PREPASS_PASS
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
@@ -37,6 +37,10 @@ varying gaussianColor: half4;
     #include "pickPS"
 #endif
 
+#ifdef SHADOW_PASS
+    #include "shadowCasterPS"
+#endif
+
 #ifdef GSPLAT_USER_VARYINGS
     #include "gsplatUserVaryingsPS"
 #endif
@@ -79,7 +83,8 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
 
     #elif SHADOW_PASS
 
-        output.color = vec4f(input.position.z, 0.0, 0.0, 1.0);
+        // output data for the shadow type being rendered
+        output.color = getShadowOutput();
 
     #elif PREPASS_PASS
 


### PR DESCRIPTION
Follow-up to #9116 — migrates the unified gsplat shadow caster to the `shadowCasterPS` chunk instead of a hardcoded output.

**Changes:**
- `chunks/gsplat/frag/gsplat.js` (GLSL + WGSL) now `#include "shadowCasterPS"` under `SHADOW_PASS` and write `getShadowOutput()`, replacing `vec4(gl_FragCoord.z, 0, 0, 1)`. The gsplat shadow material is rendered through the standard shadow pass, so it already receives the `LIGHT_TYPE`/`SHADOW_TYPE`/`PERSPECTIVE_DEPTH` defines from #9116 — no extra plumbing needed. Gsplat shadows are directional-only, which is fully within the chunk's supported range.
- This fixes VSM shadows for gsplats: the previous hardcoded output wrote raw depth with a zero coverage value, which the EVSM receiver treats as "not covered", making VSM shadows effectively not work for gsplats. PCSS output is unchanged; PCF is unaffected (the shadow pass forces color-write-off and uses hardware depth for that path).

**Examples:**
- `gaussian-splatting/shadows` gained a Shadow Type dropdown (all types, applied to all lights), plus `vsmBlurSize`/`penumbraSize`/`penumbraFalloff` tuned so VSM and PCSS look correct out of the box.