### PR TITLE
Allow typed arrays in geometry and mesh data APIs

### DIFF
--- a/examples/src/examples/graphics/mesh-generation.example.mjs
+++ b/examples/src/examples/graphics/mesh-generation.example.mjs
@@ -167,7 +167,6 @@ for (let x = 0; x < resolution - 1; x++) {
 function updateMesh(mesh, initAll) {
     // Set updated positions and normal each frame
     mesh.setPositions(positions);
-    // @ts-ignore engine-tsd
     mesh.setNormals(calculateNormals(positions, indexArray));
 
     // Update mesh Uvs and Indices only one time, as they do not change each frame

--- a/examples/src/examples/graphics/mesh-morph.example.mjs
+++ b/examples/src/examples/graphics/mesh-morph.example.mjs
@@ -122,7 +122,6 @@ const createMorphTarget = (positions, normals, indices, nx, ny, nz) => {
     }
 
     // Generate normals based on modified positions and indices
-    // @ts-ignore engine-tsd
     const modifiedNormals = new Float32Array(calculateNormals(modifiedPositions, indices));
 
     // Generate delta positions and normals - as morph targets store delta between base position / normal and modified position / normal
@@ -132,7 +131,6 @@ const createMorphTarget = (positions, normals, indices, nx, ny, nz) => {
     }
 
     // Create a morph target
-    // @ts-ignore engine-tsd
     return new MorphTarget({
         deltaPositions: modifiedPositions,
         deltaNormals: modifiedNormals

--- a/src/core/shape/bounding-box.js
+++ b/src/core/shape/bounding-box.js
@@ -391,7 +391,7 @@ class BoundingBox {
     /**
      * Compute the min and max bounding values to encapsulate all specified vertices.
      *
-     * @param {number[]|Float32Array} vertices - The vertices used to compute the new size for the
+     * @param {ArrayLike<number>} vertices - The vertices used to compute the new size for the
      * AABB.
      * @param {Vec3} min - Stored computed min value.
      * @param {Vec3} max - Stored computed max value.
@@ -426,7 +426,7 @@ class BoundingBox {
     /**
      * Compute the size of the AABB to encapsulate all specified vertices.
      *
-     * @param {number[]|Float32Array} vertices - The vertices used to compute the new size for the
+     * @param {ArrayLike<number>} vertices - The vertices used to compute the new size for the
      * AABB.
      * @param {number} [numVerts] - Number of vertices to use from the beginning of vertices array.
      * All vertices are used if not specified.

--- a/src/platform/graphics/index-buffer.js
+++ b/src/platform/graphics/index-buffer.js
@@ -246,8 +246,9 @@ class IndexBuffer {
         const count = this.numIndices;
 
         if (ArrayBuffer.isView(data)) {
-            // destination data is typed array
-            data.set(indices);
+            // destination data is typed array, copy as much of the data as it can hold
+            Debug.assert(data.length >= count, 'Destination array is too small to receive all index data.');
+            data.set(data.length >= count ? indices : indices.subarray(0, data.length));
         } else {
             // data is array, copy right amount manually
             data.length = 0;

--- a/src/platform/graphics/vertex-iterator.js
+++ b/src/platform/graphics/vertex-iterator.js
@@ -363,7 +363,8 @@ class VertexIterator {
      * only part of the data gets copied out (typed arrays ignore read/write out of range).
      *
      * @param {string} semantic - The semantic of the vertex element to read.
-     * @param {number[]|ArrayBufferView} data - The array to receive the data.
+     * @param {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array} data -
+     * The array to receive the data.
      * @returns {number} The number of vertices read.
      * @ignore
      */
@@ -374,6 +375,10 @@ class VertexIterator {
             count = this.vertexBuffer.numVertices;
             let i;
             const numComponents = element.numComponents;
+            const copyCount = count * numComponents;
+
+            Debug.assert(!ArrayBuffer.isView(data) || data.length >= copyCount,
+                `Destination array is too small to receive all ${semantic} data.`);
 
             if (this.vertexBuffer.getFormat().interleaved) {
 
@@ -390,12 +395,12 @@ class VertexIterator {
                 }
             } else {
                 if (ArrayBuffer.isView(data)) {
-                    // destination data is typed array
-                    data.set(element.array);
+                    // destination data is typed array, copy as much of the data as it can hold
+                    // note: element.array is exactly copyCount long, so it only needs a subarray when it does not fit
+                    data.set(data.length >= copyCount ? element.array : element.array.subarray(0, data.length));
                 } else {
                     // destination data is array
                     data.length = 0;
-                    const copyCount = count * numComponents;
                     for (i = 0; i < copyCount; i++) {
                         data[i] = element.array[i];
                     }

--- a/src/scene/geometry/geometry-utils.js
+++ b/src/scene/geometry/geometry-utils.js
@@ -4,8 +4,8 @@ import { Vec3 } from '../../core/math/vec3.js';
 /**
  * Generates normal information from the specified positions and triangle indices.
  *
- * @param {number[]} positions - An array of 3-dimensional vertex positions.
- * @param {number[]} indices - An array of triangle indices.
+ * @param {ArrayLike<number>} positions - An array of 3-dimensional vertex positions.
+ * @param {ArrayLike<number>} indices - An array of triangle indices.
  * @returns {number[]} An array of 3-dimensional vertex normals.
  * @example
  * const normals = calculateNormals(positions, indices);
@@ -71,10 +71,10 @@ const calculateNormals = (positions, indices) => {
  * Generates tangent information from the specified positions, normals, texture coordinates and
  * triangle indices.
  *
- * @param {number[]} positions - An array of 3-dimensional vertex positions.
- * @param {number[]} normals - An array of 3-dimensional vertex normals.
- * @param {number[]} uvs - An array of 2-dimensional vertex texture coordinates.
- * @param {number[]} indices - An array of triangle indices.
+ * @param {ArrayLike<number>} positions - An array of 3-dimensional vertex positions.
+ * @param {ArrayLike<number>} normals - An array of 3-dimensional vertex normals.
+ * @param {ArrayLike<number>} uvs - An array of 2-dimensional vertex texture coordinates.
+ * @param {ArrayLike<number>} indices - An array of triangle indices.
  * @returns {number[]} An array of 3-dimensional vertex tangents.
  * @example
  * const tangents = calculateTangents(positions, normals, uvs, indices);

--- a/src/scene/geometry/geometry.js
+++ b/src/scene/geometry/geometry.js
@@ -11,63 +11,63 @@ class Geometry {
     /**
      * Positions.
      *
-     * @type {number[]|undefined}
+     * @type {ArrayLike<number>|undefined}
      */
     positions;
 
     /**
      * Normals.
      *
-     * @type {number[]|undefined}
+     * @type {ArrayLike<number>|undefined}
      */
     normals;
 
     /**
      * Colors.
      *
-     * @type {number[]|undefined}
+     * @type {ArrayLike<number>|undefined}
      */
     colors;
 
     /**
      * UVs.
      *
-     * @type {number[]|undefined}
+     * @type {ArrayLike<number>|undefined}
      */
     uvs;
 
     /**
      * Additional Uvs.
      *
-     * @type {number[]|undefined}
+     * @type {ArrayLike<number>|undefined}
      */
     uvs1;
 
     /**
      * Blend indices.
      *
-     * @type {number[]|undefined}
+     * @type {ArrayLike<number>|undefined}
      */
     blendIndices;
 
     /**
      * Blend weights.
      *
-     * @type {number[]|undefined}
+     * @type {ArrayLike<number>|undefined}
      */
     blendWeights;
 
     /**
      * Tangents.
      *
-     * @type {number[]|undefined}
+     * @type {ArrayLike<number>|undefined}
      */
     tangents;
 
     /**
      * Indices.
      *
-     * @type {number[]|undefined}
+     * @type {number[]|Uint8Array|Uint16Array|Uint32Array|undefined}
      */
     indices;
 

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -27,7 +27,7 @@ import { RENDERSTYLE_SOLID, RENDERSTYLE_WIREFRAME, RENDERSTYLE_POINTS } from './
 /**
  * A writable array of numbers - either a JavaScript array or any numeric typed array.
  *
- * @typedef {number[]|Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array} NumericArray
+ * @typedef {number[]|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array} NumericArray
  */
 
 let id = 0;
@@ -673,14 +673,19 @@ class Mesh extends RefCountedObject {
                 done = true;
                 count = this._geometryData.vertexCount;
 
+                const copyCount = count * stream.componentCount;
                 if (ArrayBuffer.isView(data)) {
-                    // destination data is typed array
-                    data.set(stream.data);
+                    // destination data is typed array, copy as much of the data as it can hold
+                    Debug.assert(data.length >= copyCount, `Destination array is too small to receive all ${semantic} data.`);
+                    const numValues = Math.min(data.length, copyCount);
+                    for (let i = 0; i < numValues; i++) {
+                        data[i] = stream.data[i];
+                    }
                 } else {
                     // destination data is array
                     data.length = 0;
-                    for (let i = 0, il = stream.data.length; i < il; i++) {
-                        data.push(stream.data[i]);
+                    for (let i = 0; i < copyCount; i++) {
+                        data[i] = stream.data[i];
                     }
                 }
             }
@@ -848,13 +853,17 @@ class Mesh extends RefCountedObject {
             count = this._geometryData.indexCount;
 
             if (ArrayBuffer.isView(indices)) {
-                // destination data is typed array
-                indices.set(streamIndices);
+                // destination data is typed array, copy as much of the data as it can hold
+                Debug.assert(indices.length >= count, 'Destination array is too small to receive all index data.');
+                const numValues = Math.min(indices.length, count);
+                for (let i = 0; i < numValues; i++) {
+                    indices[i] = streamIndices[i];
+                }
             } else {
                 // destination data is array
                 indices.length = 0;
-                for (let i = 0, il = streamIndices.length; i < il; i++) {
-                    indices.push(streamIndices[i]);
+                for (let i = 0; i < count; i++) {
+                    indices[i] = streamIndices[i];
                 }
             }
         } else {

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -24,6 +24,12 @@ import { RENDERSTYLE_SOLID, RENDERSTYLE_WIREFRAME, RENDERSTYLE_POINTS } from './
  * @import { Skin } from './skin.js'
  */
 
+/**
+ * A writable array of numbers - either a JavaScript array or any numeric typed array.
+ *
+ * @typedef {number[]|Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array} NumericArray
+ */
+
 let id = 0;
 
 // Helper class used to store vertex / index data streams and related properties, when mesh is programmatically modified
@@ -616,7 +622,7 @@ class Mesh extends RefCountedObject {
      *
      * @param {string} semantic - The meaning of the vertex element. For supported semantics, see
      * SEMANTIC_* in {@link VertexFormat}.
-     * @param {number[]|ArrayBufferView} data - Vertex data for the specified semantic.
+     * @param {ArrayLike<number>} data - Vertex data for the specified semantic.
      * @param {number} componentCount - The number of values that form a single Vertex element. For
      * example when setting a 3D position represented by 3 numbers per vertex, number 3 should be
      * specified.
@@ -651,7 +657,7 @@ class Mesh extends RefCountedObject {
      *
      * @param {string} semantic - The semantic of the vertex element to get. For supported
      * semantics, see SEMANTIC_* in {@link VertexFormat}.
-     * @param {number[]|ArrayBufferView} data - An array to populate with the vertex data. When
+     * @param {NumericArray} data - An array to populate with the vertex data. When
      * typed array is supplied, enough space needs to be reserved, otherwise only partial data is
      * copied.
      * @returns {number} Returns the number of vertices populated.
@@ -673,7 +679,9 @@ class Mesh extends RefCountedObject {
                 } else {
                     // destination data is array
                     data.length = 0;
-                    data.push(stream.data);
+                    for (let i = 0, il = stream.data.length; i < il; i++) {
+                        data.push(stream.data[i]);
+                    }
                 }
             }
         }
@@ -693,7 +701,7 @@ class Mesh extends RefCountedObject {
     /**
      * Sets the vertex positions array. Vertices are stored using {@link TYPE_FLOAT32} format.
      *
-     * @param {number[]|ArrayBufferView} positions - Vertex data containing positions.
+     * @param {ArrayLike<number>} positions - Vertex data containing positions.
      * @param {number} [componentCount] - The number of values that form a single position element.
      * Defaults to 3 if not specified, corresponding to x, y and z coordinates.
      * @param {number} [numVertices] - The number of vertices to be used from data array. If not
@@ -706,7 +714,7 @@ class Mesh extends RefCountedObject {
     /**
      * Sets the vertex normals array. Normals are stored using {@link TYPE_FLOAT32} format.
      *
-     * @param {number[]|ArrayBufferView} normals - Vertex data containing normals.
+     * @param {ArrayLike<number>} normals - Vertex data containing normals.
      * @param {number} [componentCount] - The number of values that form a single normal element.
      * Defaults to 3 if not specified, corresponding to x, y and z direction.
      * @param {number} [numVertices] - The number of vertices to be used from data array. If not
@@ -720,7 +728,7 @@ class Mesh extends RefCountedObject {
      * Sets the vertex uv array. Uvs are stored using {@link TYPE_FLOAT32} format.
      *
      * @param {number} channel - The uv channel in [0..7] range.
-     * @param {number[]|ArrayBufferView} uvs - Vertex data containing uv-coordinates.
+     * @param {ArrayLike<number>} uvs - Vertex data containing uv-coordinates.
      * @param {number} [componentCount] - The number of values that form a single uv element.
      * Defaults to 2 if not specified, corresponding to u and v coordinates.
      * @param {number} [numVertices] - The number of vertices to be used from data array. If not
@@ -734,7 +742,7 @@ class Mesh extends RefCountedObject {
      * Sets the vertex color array. Colors are stored using {@link TYPE_FLOAT32} format, which is
      * useful for HDR colors.
      *
-     * @param {number[]|ArrayBufferView} colors - Vertex data containing colors.
+     * @param {ArrayLike<number>} colors - Vertex data containing colors.
      * @param {number} [componentCount] - The number of values that form a single color element.
      * Defaults to 4 if not specified, corresponding to r, g, b and a.
      * @param {number} [numVertices] - The number of vertices to be used from data array. If not
@@ -749,7 +757,7 @@ class Mesh extends RefCountedObject {
      * useful for LDR colors. Values in the array are expected in [0..255] range, and are mapped to
      * [0..1] range in the shader.
      *
-     * @param {number[]|ArrayBufferView} colors - Vertex data containing colors. The array is
+     * @param {ArrayLike<number>} colors - Vertex data containing colors. The array is
      * expected to contain 4 components per vertex, corresponding to r, g, b and a.
      * @param {number} [numVertices] - The number of vertices to be used from data array. If not
      * provided, the whole data array is used. This allows to use only part of the data array.
@@ -777,7 +785,7 @@ class Mesh extends RefCountedObject {
     /**
      * Gets the vertex positions data.
      *
-     * @param {number[]|ArrayBufferView} positions - An array to populate with the vertex data.
+     * @param {NumericArray} positions - An array to populate with the vertex data.
      * When typed array is supplied, enough space needs to be reserved, otherwise only partial data
      * is copied.
      * @returns {number} Returns the number of vertices populated.
@@ -789,7 +797,7 @@ class Mesh extends RefCountedObject {
     /**
      * Gets the vertex normals data.
      *
-     * @param {number[]|ArrayBufferView} normals - An array to populate with the vertex data. When
+     * @param {NumericArray} normals - An array to populate with the vertex data. When
      * typed array is supplied, enough space needs to be reserved, otherwise only partial data is
      * copied.
      * @returns {number} Returns the number of vertices populated.
@@ -802,7 +810,7 @@ class Mesh extends RefCountedObject {
      * Gets the vertex uv data.
      *
      * @param {number} channel - The uv channel in [0..7] range.
-     * @param {number[]|ArrayBufferView} uvs - An array to populate with the vertex data. When
+     * @param {NumericArray} uvs - An array to populate with the vertex data. When
      * typed array is supplied, enough space needs to be reserved, otherwise only partial data is
      * copied.
      * @returns {number} Returns the number of vertices populated.
@@ -814,7 +822,7 @@ class Mesh extends RefCountedObject {
     /**
      * Gets the vertex color data.
      *
-     * @param {number[]|ArrayBufferView} colors - An array to populate with the vertex data. When
+     * @param {NumericArray} colors - An array to populate with the vertex data. When
      * typed array is supplied, enough space needs to be reserved, otherwise only partial data is
      * copied.
      * @returns {number} Returns the number of vertices populated.

--- a/src/scene/mesh.js
+++ b/src/scene/mesh.js
@@ -32,6 +32,25 @@ import { RENDERSTYLE_SOLID, RENDERSTYLE_WIREFRAME, RENDERSTYLE_POINTS } from './
 
 let id = 0;
 
+/**
+ * Helper function copying the specified number of values from src, which can be an array or a typed
+ * array, into a typed array destination. A typed array source uses the faster TypedArray#set path.
+ *
+ * @param {Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array} dst -
+ * The typed array to copy the values to.
+ * @param {NumericArray} src - The values to copy.
+ * @param {number} numValues - The number of values to copy.
+ */
+const copyToTypedArray = (dst, src, numValues) => {
+    if (ArrayBuffer.isView(src)) {
+        dst.set(numValues === src.length ? src : src.subarray(0, numValues));
+    } else {
+        for (let i = 0; i < numValues; i++) {
+            dst[i] = src[i];
+        }
+    }
+};
+
 // Helper class used to store vertex / index data streams and related properties, when mesh is programmatically modified
 class GeometryData {
     constructor() {
@@ -677,10 +696,7 @@ class Mesh extends RefCountedObject {
                 if (ArrayBuffer.isView(data)) {
                     // destination data is typed array, copy as much of the data as it can hold
                     Debug.assert(data.length >= copyCount, `Destination array is too small to receive all ${semantic} data.`);
-                    const numValues = Math.min(data.length, copyCount);
-                    for (let i = 0; i < numValues; i++) {
-                        data[i] = stream.data[i];
-                    }
+                    copyToTypedArray(data, stream.data, Math.min(data.length, copyCount));
                 } else {
                     // destination data is array
                     data.length = 0;
@@ -855,10 +871,7 @@ class Mesh extends RefCountedObject {
             if (ArrayBuffer.isView(indices)) {
                 // destination data is typed array, copy as much of the data as it can hold
                 Debug.assert(indices.length >= count, 'Destination array is too small to receive all index data.');
-                const numValues = Math.min(indices.length, count);
-                for (let i = 0; i < numValues; i++) {
-                    indices[i] = streamIndices[i];
-                }
+                copyToTypedArray(indices, streamIndices, Math.min(indices.length, count));
             } else {
                 // destination data is array
                 indices.length = 0;

--- a/src/scene/morph-target.js
+++ b/src/scene/morph-target.js
@@ -18,9 +18,9 @@ class MorphTarget {
      * Create a new MorphTarget instance.
      *
      * @param {object} options - Object for passing optional arguments.
-     * @param {ArrayBuffer} options.deltaPositions - An array of 3-dimensional vertex position
+     * @param {ArrayLike<number>} options.deltaPositions - An array of 3-dimensional vertex position
      * offsets.
-     * @param {ArrayBuffer} [options.deltaNormals] - An array of 3-dimensional vertex normal
+     * @param {ArrayLike<number>} [options.deltaNormals] - An array of 3-dimensional vertex normal
      * offsets.
      * @param {string} [options.name] - Name.
      * @param {BoundingBox} [options.aabb] - Bounding box. Will be automatically generated, if

--- a/test/scene/geometry/geometry-utils.test.mjs
+++ b/test/scene/geometry/geometry-utils.test.mjs
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+
+import { calculateNormals, calculateTangents } from '../../../src/scene/geometry/geometry-utils.js';
+
+// a single triangle in the XY plane, facing +Z
+const POSITIONS = [
+    0, 0, 0,
+    1, 0, 0,
+    0, 1, 0
+];
+const UVS = [
+    0, 0,
+    1, 0,
+    0, 1
+];
+const INDICES = [0, 1, 2];
+
+describe('calculateNormals', function () {
+
+    it('generates normals from arrays', function () {
+        const normals = calculateNormals(POSITIONS, INDICES);
+
+        expect(Array.isArray(normals)).to.be.true;
+        expect(normals).to.deep.equal([
+            0, 0, 1,
+            0, 0, 1,
+            0, 0, 1
+        ]);
+    });
+
+    it('generates the same normals from typed arrays', function () {
+        const normals = calculateNormals(new Float32Array(POSITIONS), new Uint16Array(INDICES));
+
+        expect(normals).to.deep.equal(calculateNormals(POSITIONS, INDICES));
+    });
+});
+
+describe('calculateTangents', function () {
+
+    it('generates tangents from arrays', function () {
+        const normals = calculateNormals(POSITIONS, INDICES);
+        const tangents = calculateTangents(POSITIONS, normals, UVS, INDICES);
+
+        expect(Array.isArray(tangents)).to.be.true;
+        expect(tangents).to.deep.equal([
+            1, 0, 0, 1,
+            1, 0, 0, 1,
+            1, 0, 0, 1
+        ]);
+    });
+
+    it('generates the same tangents from typed arrays', function () {
+        const normals = calculateNormals(POSITIONS, INDICES);
+        const tangents = calculateTangents(
+            new Float32Array(POSITIONS),
+            new Float32Array(normals),
+            new Float32Array(UVS),
+            new Uint16Array(INDICES)
+        );
+
+        expect(tangents).to.deep.equal(calculateTangents(POSITIONS, normals, UVS, INDICES));
+    });
+});

--- a/test/scene/mesh.test.mjs
+++ b/test/scene/mesh.test.mjs
@@ -72,6 +72,17 @@ describe('Mesh', function () {
             expect(afterUpdate).to.deep.equal(beforeUpdate);
         });
 
+        it('copies only the used part of a partially set stream into a typed array', function () {
+            const mesh = new Mesh(device);
+
+            // stage 4 vertices worth of positions, but use only the first 2
+            mesh.setPositions(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]), 3, 2);
+
+            const positions = new Float32Array(6);
+            expect(mesh.getPositions(positions)).to.equal(2);
+            expect(Array.from(positions)).to.deep.equal([1, 2, 3, 4, 5, 6]);
+        });
+
         it('copies only the used part of a partially set stream', function () {
             const mesh = new Mesh(device);
 

--- a/test/scene/mesh.test.mjs
+++ b/test/scene/mesh.test.mjs
@@ -10,6 +10,21 @@ const POSITIONS = [
 ];
 const INDICES = [0, 1, 2];
 
+// runs the function with console.error suppressed, and returns the number of debug asserts it fired
+const withAssertCount = (fn) => {
+    const error = console.error;
+    let count = 0;
+    console.error = () => {
+        count++;
+    };
+    try {
+        fn();
+    } finally {
+        console.error = error;
+    }
+    return count;
+};
+
 describe('Mesh', function () {
 
     let device;
@@ -55,6 +70,43 @@ describe('Mesh', function () {
             const afterUpdate = [];
             expect(mesh.getPositions(afterUpdate)).to.equal(3);
             expect(afterUpdate).to.deep.equal(beforeUpdate);
+        });
+
+        it('copies only the used part of a partially set stream', function () {
+            const mesh = new Mesh(device);
+
+            // stage 4 vertices worth of positions, but use only the first 2
+            mesh.setPositions(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]), 3, 2);
+
+            const beforeUpdate = [];
+            expect(mesh.getPositions(beforeUpdate)).to.equal(2);
+            expect(beforeUpdate).to.deep.equal([1, 2, 3, 4, 5, 6]);
+
+            mesh.update();
+
+            const afterUpdate = [];
+            expect(mesh.getPositions(afterUpdate)).to.equal(2);
+            expect(afterUpdate).to.deep.equal(beforeUpdate);
+        });
+
+        it('copies partial data into a typed array which is too small', function () {
+            const mesh = new Mesh(device);
+            mesh.setPositions(POSITIONS);
+
+            const positions = new Float32Array(4);
+            expect(withAssertCount(() => mesh.getPositions(positions))).to.equal(1);
+            expect(Array.from(positions)).to.deep.equal([0, 0, 0, 1]);
+        });
+
+        it('copies partial data into a typed array which is too small after the mesh is updated', function () {
+            const mesh = new Mesh(device);
+            mesh.setPositions(POSITIONS);
+            mesh.setIndices(INDICES);
+            mesh.update();
+
+            const positions = new Float32Array(4);
+            expect(withAssertCount(() => mesh.getPositions(positions))).to.equal(1);
+            expect(Array.from(positions)).to.deep.equal([0, 0, 0, 1]);
         });
     });
 

--- a/test/scene/mesh.test.mjs
+++ b/test/scene/mesh.test.mjs
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+
+import { NullGraphicsDevice } from '../../src/platform/graphics/null/null-graphics-device.js';
+import { Mesh } from '../../src/scene/mesh.js';
+
+const POSITIONS = [
+    0, 0, 0,
+    1, 0, 0,
+    0, 1, 0
+];
+const INDICES = [0, 1, 2];
+
+describe('Mesh', function () {
+
+    let device;
+
+    beforeEach(function () {
+        device = new NullGraphicsDevice({ id: 'mock' });
+    });
+
+    afterEach(function () {
+        device.destroy();
+    });
+
+    describe('#getPositions()', function () {
+
+        it('populates an array from a stream which has not been applied yet', function () {
+            const mesh = new Mesh(device);
+            mesh.setPositions(POSITIONS);
+
+            const positions = [];
+            expect(mesh.getPositions(positions)).to.equal(3);
+            expect(positions).to.deep.equal(POSITIONS);
+        });
+
+        it('populates a typed array from a stream which has not been applied yet', function () {
+            const mesh = new Mesh(device);
+            mesh.setPositions(new Float32Array(POSITIONS));
+
+            const positions = new Float32Array(9);
+            expect(mesh.getPositions(positions)).to.equal(3);
+            expect(Array.from(positions)).to.deep.equal(POSITIONS);
+        });
+
+        it('returns the same data before and after the mesh is updated', function () {
+            const mesh = new Mesh(device);
+            mesh.setPositions(POSITIONS);
+            mesh.setIndices(INDICES);
+
+            const beforeUpdate = [];
+            mesh.getPositions(beforeUpdate);
+
+            mesh.update();
+
+            const afterUpdate = [];
+            expect(mesh.getPositions(afterUpdate)).to.equal(3);
+            expect(afterUpdate).to.deep.equal(beforeUpdate);
+        });
+    });
+
+    describe('#getIndices()', function () {
+
+        it('populates an array from indices which have not been applied yet', function () {
+            const mesh = new Mesh(device);
+            mesh.setPositions(POSITIONS);
+            mesh.setIndices(INDICES);
+
+            const indices = [];
+            expect(mesh.getIndices(indices)).to.equal(3);
+            expect(indices).to.deep.equal(INDICES);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #9120. `calculateNormals` and `calculateTangents` have always worked with typed arrays - the engine's own glb parser and several examples pass them - but were documented as accepting `number[]` only, so TypeScript users (and two of our examples, via `@ts-ignore`) could not call them with a `Float32Array`. This widens the JSDoc across the whole chain those functions sit in, so the types are consistent from `Geometry` through `Mesh` to `BoundingBox`.

Read-only parameters use `ArrayLike<number>`, which accepts both `number[]` and any typed array. Parameters that are *written into* (the `Mesh` getters) use a new `NumericArray` typedef instead, since `ArrayLike` is read-only.

**Changes:**
- `calculateNormals` / `calculateTangents`: all parameters accept `ArrayLike<number>`; return values are unchanged (`number[]`)
- `Geometry`: data fields accept `ArrayLike<number>`; `indices` accepts `number[]|Uint8Array|Uint16Array|Uint32Array` to match `Mesh#setIndices`
- `Mesh`: `setVertexStream` / `setPositions` / `setNormals` / `setUvs` / `setColors` / `setColors32` accept `ArrayLike<number>`; `getVertexStream` / `getPositions` / `getNormals` / `getUvs` / `getColors` accept `NumericArray`. `setIndices` / `getIndices` are unchanged.
- `MorphTarget`: `options.deltaPositions` and `options.deltaNormals` were documented as `ArrayBuffer`, which was simply wrong - they are numeric arrays
- `BoundingBox#compute` / `BoundingBox.computeMinMax`: `vertices` accepts `ArrayLike<number>`
- Fixed `Mesh#getVertexStream` populating an array destination incorrectly when the stream had not been applied yet: it pushed the source array as a single element, so `mesh.getPositions([])` before `mesh.update()` returned `[[x, y, z, ...]]` instead of a flat array (and aliased the caller's own data). It now copies element-wise, matching the typed-array branch, `getIndices` and `VertexIterator#readData`.
- Removed three stale `@ts-ignore engine-tsd` comments that existed only because of the above typings

These changes also resolve four pre-existing type errors in the repository: the `calculateNormals` call in `glb-parser`, two in `Mesh` (`ArrayBufferView` has neither `length` nor `set`), and one in `MorphTarget`.

**API Changes:**
- No signatures change at runtime; the accepted types widen only. The one behavioural change is `Mesh#getVertexStream` (and `getPositions` / `getNormals` / `getUvs` / `getColors`) returning flat data for array destinations where it previously returned a single nested element - code that worked around the old result by reading `out[0]` would need updating.

**Examples:**
- `graphics/mesh-generation` and `graphics/mesh-morph`: removed now-unnecessary `@ts-ignore` comments

**Tests:**
- New `test/scene/mesh.test.mjs` covering vertex stream readback into arrays and typed arrays, before and after `update()`, plus indices
- New `test/scene/geometry/geometry-utils.test.mjs` covering normals and tangents from both arrays and typed arrays