### PR TITLE
Discard out of range depth in VSM shadow casters

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/common/frag/shadow-caster.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/shadow-caster.js
@@ -13,6 +13,14 @@ vec4 getShadowOutput() {
 
     #if SHADOW_TYPE == VSM_16F || SHADOW_TYPE == VSM_32F
 
+        // Rasterization of degenerate triangles, which animated meshes can generate, can supply
+        // depth outside of the [0, 1] range or even NaN. The exponential warp below turns those
+        // into huge values, which the VSM blur then spreads over a large area, generating visible
+        // artifacts. Note that the depth range is not clipped for other shadow types, as they
+        // either store the depth using the depth buffer, which clamps it, or the error is limited
+        // to the individual texels and so is not noticeable.
+        if (!(depth >= 0.0 && depth <= 1.0)) discard;
+
         // exponential warp of the depth, stored with its square
         #if SHADOW_TYPE == VSM_32F
             float exponent = 15.0;

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/pass-shadow/litShadowMain.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/pass-shadow/litShadowMain.js
@@ -34,6 +34,15 @@ void main(void) {
     #endif
 
     #if SHADOW_TYPE == VSM_16F || SHADOW_TYPE == VSM_32F
+
+        // Rasterization of degenerate triangles, which animated meshes can generate, can supply
+        // depth outside of the [0, 1] range or even NaN. The exponential warp below turns those
+        // into huge values, which the VSM blur then spreads over a large area, generating visible
+        // artifacts. Note that the depth range is not clipped for other shadow types, as they
+        // either store the depth using the depth buffer, which clamps it, or the error is limited
+        // to the individual texels and so is not noticeable.
+        if (!(depth >= 0.0 && depth <= 1.0)) discard;
+
         #if SHADOW_TYPE == VSM_32F
             float exponent = 15.0;
         #else

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/shadow-caster.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/shadow-caster.js
@@ -13,6 +13,16 @@ fn getShadowOutput() -> vec4f {
 
     #if SHADOW_TYPE == VSM_16F || SHADOW_TYPE == VSM_32F
 
+        // Rasterization of degenerate triangles, which animated meshes can generate, can supply
+        // depth outside of the [0, 1] range or even NaN. The exponential warp below turns those
+        // into huge values, which the VSM blur then spreads over a large area, generating visible
+        // artifacts. Note that the depth range is not clipped for other shadow types, as they
+        // either store the depth using the depth buffer, which clamps it, or the error is limited
+        // to the individual texels and so is not noticeable.
+        if (!(depth >= 0.0 && depth <= 1.0)) {
+            discard;
+        }
+
         // exponential warp of the depth, stored with its square
         #if SHADOW_TYPE == VSM_32F
             let exponent: f32 = 15.0;

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-shadow/litShadowMain.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-shadow/litShadowMain.js
@@ -37,6 +37,17 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
     #endif
 
     #if SHADOW_TYPE == VSM_16F || SHADOW_TYPE == VSM_32F
+
+        // Rasterization of degenerate triangles, which animated meshes can generate, can supply
+        // depth outside of the [0, 1] range or even NaN. The exponential warp below turns those
+        // into huge values, which the VSM blur then spreads over a large area, generating visible
+        // artifacts. Note that the depth range is not clipped for other shadow types, as they
+        // either store the depth using the depth buffer, which clamps it, or the error is limited
+        // to the individual texels and so is not noticeable.
+        if (!(depth >= 0.0 && depth <= 1.0)) {
+            discard;
+        }
+
         #if SHADOW_TYPE == VSM_32F
             var exponent: f32 = 15.0;
         #else


### PR DESCRIPTION
Animated meshes (skinning / morphing) occasionally rasterize a degenerate triangle in light space, which generates a fragment with depth outside of the `[0, 1]` range, or even NaN. The VSM exponential warp turns those into enormous values (measured up to 1e31), and the separable VSM blur then spreads a single such texel over a `vsmBlurSize`² area. The receiver reads the resulting moments as an occluder behind it, and so the whole area is lit - a flickering square artifact inside the shadow.

**Changes:**
- The shadow caster now discards fragments with depth outside of the `[0, 1]` range (the negated comparison also rejects NaN), which makes those invalid moments impossible by construction.
- This is limited to the VSM shadow types. Other shadow types either store the depth using the depth buffer, which clamps it, or the error stays limited to individual texels and is not noticeable - and this way the shaders of those (more commonly used) shadow types are unchanged, and keep rendering without a `discard`.
- Implemented in both shadow caster paths - the `shadowCasterPS` chunk used by `ShaderMaterial`, and `litShadowMain` used by the lit materials - in GLSL and WGSL.

Verification: with the guard in place, 50 consecutive animated frames of the `shaders/shader-material-shadows` example contain no NaN and no texels above the largest legal warped value in the shadow map. Without it, 34 of 1248 frames contained such texels, with values up to 1e31.

This is a partial improvement for #7480 - it removes the flickering square artifacts, but that issue also covers a rounded / circular light leak which has a different, inherent cause, and is not addressed here.