### PR TITLE
Reference (do not merge): EVSM4 for VSM_32F

### DIFF
--- a/examples/src/examples/shaders/shader-material-shadows.controls.jsx
+++ b/examples/src/examples/shaders/shader-material-shadows.controls.jsx
@@ -1,4 +1,11 @@
-import { BindingTwoWay, LabelGroup, Panel, SelectInput } from '@playcanvas/pcui/react';
+import {
+    BindingTwoWay,
+    BooleanInput,
+    LabelGroup,
+    Panel,
+    SelectInput,
+    SliderInput
+} from '@playcanvas/pcui/react';
 
 import {
     SHADOW_PCF1_16F,
@@ -41,6 +48,26 @@ export function Controls({ observer }) {
                             { v: SHADOW_VSM_32F, t: 'VSM_32F' },
                             { v: SHADOW_PCSS_32F, t: 'PCSS_32F' }
                         ]}
+                    />
+                </LabelGroup>
+            </Panel>
+            {/* TEMPORARY: animation scrubbing, to help find artifact repro poses */}
+            <Panel headerText='Animation (debug)'>
+                <LabelGroup text='Pause'>
+                    <BooleanInput
+                        type='toggle'
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'settings.paused' }}
+                    />
+                </LabelGroup>
+                <LabelGroup text='Time'>
+                    <SliderInput
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'settings.animTime' }}
+                        min={0}
+                        max={2.57}
+                        step={0.001}
+                        precision={3}
                     />
                 </LabelGroup>
             </Panel>

--- a/examples/src/examples/shaders/shader-material-shadows.example.mjs
+++ b/examples/src/examples/shaders/shader-material-shadows.example.mjs
@@ -36,7 +36,7 @@ import {
     PIXELFORMAT_RGBA8,
     RESOLUTION_AUTO,
     RenderComponentSystem,
-    SHADOW_PCF3_32F,
+    SHADOW_VSM_32F,
     ScriptComponentSystem,
     ScriptHandler,
     StandardMaterial,
@@ -263,8 +263,9 @@ const camera = new Entity();
 camera.addComponent('camera', {
     clearColor: new Color(0.4, 0.45, 0.5)
 });
-camera.setLocalPosition(-61.48, 51.94, 58.48);
-camera.setLocalEulerAngles(-23.69, -49.15, 0);
+// TEMPORARY: artifact repro view
+camera.setLocalPosition(4.86, 52.59, 13.26);
+camera.setLocalEulerAngles(-77.76, 5.54, 0);
 
 // Add orbit camera script to the camera
 camera.addComponent('script');
@@ -279,14 +280,69 @@ camera.script.create('orbitCameraInputMouse');
 camera.script.create('orbitCameraInputTouch');
 app.root.addChild(camera);
 
+// TEMPORARY: debug helpers for finding VSM artifact repro poses.
+// Collect the animated entities, and allow the animation to be paused / scrubbed.
+const animEntities = [bitmojiEntity, morphEntity];
+
+// Set the animation of all animated entities to the given time, and refresh their pose
+const setAnimTime = (time) => {
+    animEntities.forEach((entity) => {
+        const layer = entity.anim.baseLayer;
+        const wasPlaying = entity.anim.playing;
+        entity.anim.playing = true;
+        layer.activeStateCurrentTime = time % layer.activeStateDuration;
+        entity.anim.update(0);
+        entity.anim.playing = wasPlaying;
+    });
+};
+
+// TEMPORARY: log the animation time and camera orientation once a second
+let logTimer = 0;
+app.on('update', (dt) => {
+    // keep the scrubber in sync with the playing animation
+    if (!data.get('settings.paused')) {
+        data.set('settings.animTime', +bitmojiEntity.anim.baseLayer.activeStateCurrentTime.toFixed(3));
+    }
+
+    logTimer += dt;
+    if (logTimer > 1) {
+        logTimer = 0;
+        const t = bitmojiEntity.anim.baseLayer.activeStateCurrentTime;
+        const p = camera.getPosition();
+        const e = camera.getEulerAngles();
+        console.log(`animTime: ${t} camera pos: (${p.x}, ${p.y}, ${p.z}) euler: (${e.x}, ${e.y}, ${e.z})`);
+    }
+});
+
 // Handle UI changes
 data.on('*:set', (path, value) => {
     if (path === 'settings.shadowType') {
         light.light.shadowType = value;
     }
+    if (path === 'settings.paused') {
+        // pause / resume the animation playback
+        animEntities.forEach((entity) => {
+            entity.anim.playing = !value;
+        });
+    }
+    if (path === 'settings.animTime' && data.get('settings.paused')) {
+        // scrubbing is only applied while paused
+        setAnimTime(value);
+    }
 });
 
 // Initial values
+// TEMPORARY: start paused at the artifact repro pose, using VSM_32F
+const reproTime = 1.12;
 data.set('settings', {
-    shadowType: SHADOW_PCF3_32F
+    shadowType: SHADOW_VSM_32F,
+    paused: true,
+    animTime: reproTime
 });
+
+// apply the initial paused state and pose (the bulk data.set above does not fire per-property events)
+light.light.shadowType = SHADOW_VSM_32F;
+animEntities.forEach((entity) => {
+    entity.anim.playing = false;
+});
+setAnimTime(reproTime);

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -17,6 +17,7 @@ import {
     LIGHTTYPE_DIRECTIONAL, LIGHTTYPE_OMNI,
     SHADOWCAMERA_NAME,
     SHADOWUPDATE_NONE,
+    SHADOW_VSM_32F,
     shadowTypeInfo
 } from '../constants.js';
 import { ShaderPass } from '../shader-pass.js';
@@ -121,7 +122,19 @@ class ShadowRenderer {
 
         // don't clear the color buffer if rendering a depth map
         if (isVsm) {
-            shadowCam.clearColor = new Color(0, 0, 0, 0);
+            if (shadowType === SHADOW_VSM_32F) {
+
+                // EVSM4 stores moments in all four channels, and so has no channel left to store the
+                // coverage in. Instead the map is cleared to the warped depth of the far plane, which
+                // represents an occluder behind any receiver and so does not generate a shadow.
+                // Note: these exponents must match those used by the shadow caster and shadowEVSM chunks.
+                const pos = Math.exp(15.0);
+                const neg = Math.exp(-5.0);
+                shadowCam.clearColor = new Color(pos, pos * pos, -neg, neg * neg);
+
+            } else {
+                shadowCam.clearColor = new Color(0, 0, 0, 0);
+            }
         } else {
             shadowCam.clearColor = new Color(1, 1, 1, 1);
         }

--- a/src/scene/shader-lib/glsl/chunks/common/frag/shadow-caster.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/shadow-caster.js
@@ -11,17 +11,29 @@ vec4 getShadowOutput() {
     // rasterized depth
     float depth = gl_FragCoord.z;
 
+    // protect against rasterization of degenerate triangles of animated meshes, which can generate
+    // out of range / NaN depth - VSM blur would smear those into large visible artifacts
+    if (!(depth >= 0.0 && depth <= 1.0)) discard;
+
     #if SHADOW_TYPE == VSM_16F || SHADOW_TYPE == VSM_32F
 
-        // exponential warp of the depth, stored with its square
+        float d = 2.0 * depth - 1.0;
+
         #if SHADOW_TYPE == VSM_32F
-            float exponent = 15.0;
+
+            // EVSM4 - a positive and a negative exponential warp, each with its second moment.
+            // Note: these exponents must match those used by the shadowEVSM chunk.
+            float pos = exp(15.0 * d);
+            float neg = exp(-5.0 * d);
+            return vec4(pos, pos * pos, -neg, neg * neg);
+
         #else
-            float exponent = 5.54;
+
+            // EVSM2 - a single exponential warp with its second moment, z stores the coverage
+            float pos = exp(5.54 * d);
+            return vec4(pos, pos * pos, 1.0, 1.0);
+
         #endif
-        depth = 2.0 * depth - 1.0;
-        depth = exp(exponent * depth);
-        return vec4(depth, depth * depth, 1.0, 1.0);
 
     #elif SHADOW_TYPE == PCSS_32F
 

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/blurVSM.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/blurVSM.js
@@ -9,15 +9,16 @@ uniform vec2 pixelOffset;
 #endif
 
 void main(void) {
-    vec3 moments = vec3(0.0);
+    // all four channels are filtered, as VSM_32F (EVSM4) stores moments in all of them
+    vec4 moments = vec4(0.0);
     vec2 uv = vUv0 - pixelOffset * (float({SAMPLES}) * 0.5);
     for (int i = 0; i < {SAMPLES}; i++) {
         vec4 c = texture2D(source, uv + pixelOffset * float(i));
 
         #ifdef GAUSS
-            moments += c.xyz * weight[i];
+            moments += c * weight[i];
         #else
-            moments += c.xyz;
+            moments += c;
         #endif
     }
 
@@ -25,6 +26,6 @@ void main(void) {
         moments *= 1.0 / float({SAMPLES});
     #endif
 
-    gl_FragColor = vec4(moments.x, moments.y, moments.z, 1.0);
+    gl_FragColor = moments;
 }
 `;

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/lighting/shadowEVSM.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/lighting/shadowEVSM.js
@@ -53,27 +53,59 @@ float getShadowSpotVSM16(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shado
     return VSM16(TEXTURE_PASS(shadowMap), shadowCoord.xy, shadowParams.x, length(lightDir) * shadowParams.w + shadowParams.z, shadowParams.y, exponent);
 }
 
-// ------ VSM 32 ------
+// ------ VSM 32 (EVSM4) ------
+
+// VSM_32F stores four moments - a positive and a negative exponential warp of the depth, each with
+// its second moment. Both warps are monotonically increasing functions of the depth:
+//     positive: exp(exponent * d)      - resolves depth differences near the far plane
+//     negative: -exp(-negExponent * d)  - resolves depth differences near the light
+// A Chebyshev bound is evaluated for each warp and the tighter (smaller) of the two is used. The
+// positive warp on its own (EVSM2) is a soft maximum, so a single deep texel within the filter
+// kernel dominates the filtered result and can make an occluded receiver appear lit. The negative
+// warp is a soft minimum, and so does not suffer from this, and taking the minimum of the two
+// bounds removes those light leaks. See "Layered Variance Shadow Maps", Lauritzen & McCool.
+float calculateEVSM4(vec4 moments, float Z, float vsmBias, float exponent) {
+
+    // exponent of the negative warp. Note: this must match the shadow caster chunks.
+    float negExponent = 5.0;
+
+    float d = 2.0 * Z - 1.0;
+
+    // warped depth of the receiver, for both warps
+    float posMean = exp(exponent * d);
+    float negExp = exp(-negExponent * d);
+    float negMean = -negExp;
+
+    // the depth bias is scaled by the derivative of each warp, to keep it in depth units
+    float posScale = vsmBias * exponent * posMean;
+    float negScale = vsmBias * negExponent * negExp;
+
+    float posBound = chebyshevUpperBound(moments.xy, posMean, posScale * posScale, 0.1);
+    float negBound = chebyshevUpperBound(moments.zw, negMean, negScale * negScale, 0.1);
+
+    // both are upper bounds on the visibility, so the tighter one is the better estimate
+    return min(posBound, negBound);
+}
 
 float VSM32(TEXTURE_ACCEPT(tex), vec2 texCoords, float resolution, float Z, float vsmBias, float exponent) {
 
     #ifdef CAPS_TEXTURE_FLOAT_FILTERABLE
-        vec3 moments = texture2DLod(tex, texCoords, 0.0).xyz;
+        vec4 moments = texture2DLod(tex, texCoords, 0.0);
     #else
         // manual bilinear filtering
         float pixelSize = 1.0 / resolution;
         texCoords -= vec2(pixelSize);
-        vec3 s00 = texture2DLod(tex, texCoords, 0.0).xyz;
-        vec3 s10 = texture2DLod(tex, texCoords + vec2(pixelSize, 0), 0.0).xyz;
-        vec3 s01 = texture2DLod(tex, texCoords + vec2(0, pixelSize), 0.0).xyz;
-        vec3 s11 = texture2DLod(tex, texCoords + vec2(pixelSize), 0.0).xyz;
+        vec4 s00 = texture2DLod(tex, texCoords, 0.0);
+        vec4 s10 = texture2DLod(tex, texCoords + vec2(pixelSize, 0), 0.0);
+        vec4 s01 = texture2DLod(tex, texCoords + vec2(0, pixelSize), 0.0);
+        vec4 s11 = texture2DLod(tex, texCoords + vec2(pixelSize), 0.0);
         vec2 fr = fract(texCoords * resolution);
-        vec3 h0 = mix(s00, s10, fr.x);
-        vec3 h1 = mix(s01, s11, fr.x);
-        vec3 moments = mix(h0, h1, fr.y);
+        vec4 h0 = mix(s00, s10, fr.x);
+        vec4 h1 = mix(s01, s11, fr.x);
+        vec4 moments = mix(h0, h1, fr.y);
     #endif
 
-    return calculateEVSM(moments, Z, vsmBias, exponent);
+    return calculateEVSM4(moments, Z, vsmBias, exponent);
 }
 
 float getShadowVSM32(TEXTURE_ACCEPT(shadowMap), vec3 shadowCoord, vec4 shadowParams, float exponent) {

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/pass-shadow/litShadowMain.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/pass-shadow/litShadowMain.js
@@ -12,6 +12,10 @@ export default /* glsl */`
 
 void main(void) {
 
+    // protect against rasterization of degenerate triangles of animated meshes, which can generate
+    // out of range / NaN depth - VSM blur would smear those into large visible artifacts
+    if (!(gl_FragCoord.z >= 0.0 && gl_FragCoord.z <= 1.0)) discard;
+
     #include "litUserMainStartPS"
 
     evaluateFrontend();
@@ -34,14 +38,24 @@ void main(void) {
     #endif
 
     #if SHADOW_TYPE == VSM_16F || SHADOW_TYPE == VSM_32F
+
+        float warpD = 2.0 * depth - 1.0;
+
         #if SHADOW_TYPE == VSM_32F
-            float exponent = 15.0;
+
+            // EVSM4 - a positive and a negative exponential warp, each with its second moment.
+            // Note: these exponents must match those used by the shadowEVSM chunk.
+            float warpPos = exp(15.0 * warpD);
+            float warpNeg = exp(-5.0 * warpD);
+            gl_FragColor = vec4(warpPos, warpPos * warpPos, -warpNeg, warpNeg * warpNeg);
+
         #else
-            float exponent = 5.54;
+
+            // EVSM2 - a single exponential warp with its second moment, z stores the coverage
+            float warpPos = exp(5.54 * warpD);
+            gl_FragColor = vec4(warpPos, warpPos * warpPos, 1.0, 1.0);
+
         #endif
-        depth = 2.0 * depth - 1.0;
-        depth =  exp(exponent * depth);
-        gl_FragColor = vec4(depth, depth*depth, 1.0, 1.0);
     #else
         #if SHADOW_TYPE == PCSS_32F
             // store depth into R32

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/shadow-caster.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/shadow-caster.js
@@ -11,17 +11,31 @@ fn getShadowOutput() -> vec4f {
     // rasterized depth
     var depth: f32 = pcPosition.z;
 
+    // protect against rasterization of degenerate triangles of animated meshes, which can generate
+    // out of range / NaN depth - VSM blur would smear those into large visible artifacts
+    if (!(depth >= 0.0 && depth <= 1.0)) {
+        discard;
+    }
+
     #if SHADOW_TYPE == VSM_16F || SHADOW_TYPE == VSM_32F
 
-        // exponential warp of the depth, stored with its square
+        let d: f32 = 2.0 * depth - 1.0;
+
         #if SHADOW_TYPE == VSM_32F
-            let exponent: f32 = 15.0;
+
+            // EVSM4 - a positive and a negative exponential warp, each with its second moment.
+            // Note: these exponents must match those used by the shadowEVSM chunk.
+            let pos: f32 = exp(15.0 * d);
+            let neg: f32 = exp(-5.0 * d);
+            return vec4f(pos, pos * pos, -neg, neg * neg);
+
         #else
-            let exponent: f32 = 5.54;
+
+            // EVSM2 - a single exponential warp with its second moment, z stores the coverage
+            let pos: f32 = exp(5.54 * d);
+            return vec4f(pos, pos * pos, 1.0, 1.0);
+
         #endif
-        depth = 2.0 * depth - 1.0;
-        depth = exp(exponent * depth);
-        return vec4f(depth, depth * depth, 1.0, 1.0);
 
     #elif SHADOW_TYPE == PCSS_32F
 

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/blurVSM.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/blurVSM.js
@@ -12,16 +12,17 @@ uniform pixelOffset: vec2f;
 @fragment
 fn fragmentMain(input: FragmentInput) -> FragmentOutput {
     var output: FragmentOutput;
-    var moments: vec3f = vec3f(0.0);
+    // all four channels are filtered, as VSM_32F (EVSM4) stores moments in all of them
+    var moments: vec4f = vec4f(0.0);
     let uv: vec2f = input.vUv0 - uniform.pixelOffset * (f32({SAMPLES}) * 0.5);
 
     for (var i: i32 = 0; i < {SAMPLES}; i = i + 1) {
         let c: vec4f = textureSample(source, sourceSampler, uv + uniform.pixelOffset * f32(i));
 
         #ifdef GAUSS
-            moments = moments + c.xyz * uniform.weight[i].element;
+            moments = moments + c * uniform.weight[i].element;
         #else
-            moments = moments + c.xyz;
+            moments = moments + c;
         #endif
     }
 
@@ -29,7 +30,7 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         moments = moments * (1.0 / f32({SAMPLES}));
     #endif
 
-    output.color = vec4f(moments, 1.0);
+    output.color = moments;
     return output;
 }
 `;

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/lighting/shadowEVSM.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/lighting/shadowEVSM.js
@@ -54,27 +54,59 @@ fn getShadowSpotVSM16(shadowMap: texture_2d<f32>, shadowMapSampler: sampler, sha
     return VSM16(shadowMap, shadowMapSampler, shadowCoord.xy, shadowParams.x, Z, shadowParams.y, exponent);
 }
 
-// ------ VSM 32 ------
+// ------ VSM 32 (EVSM4) ------
+
+// VSM_32F stores four moments - a positive and a negative exponential warp of the depth, each with
+// its second moment. Both warps are monotonically increasing functions of the depth:
+//     positive: exp(exponent * d)      - resolves depth differences near the far plane
+//     negative: -exp(-negExponent * d)  - resolves depth differences near the light
+// A Chebyshev bound is evaluated for each warp and the tighter (smaller) of the two is used. The
+// positive warp on its own (EVSM2) is a soft maximum, so a single deep texel within the filter
+// kernel dominates the filtered result and can make an occluded receiver appear lit. The negative
+// warp is a soft minimum, and so does not suffer from this, and taking the minimum of the two
+// bounds removes those light leaks. See "Layered Variance Shadow Maps", Lauritzen & McCool.
+fn calculateEVSM4(moments: vec4f, Z: f32, vsmBias: f32, exponent: f32) -> f32 {
+
+    // exponent of the negative warp. Note: this must match the shadow caster chunks.
+    let negExponent: f32 = 5.0;
+
+    let d: f32 = 2.0 * Z - 1.0;
+
+    // warped depth of the receiver, for both warps
+    let posMean: f32 = exp(exponent * d);
+    let negExp: f32 = exp(-negExponent * d);
+    let negMean: f32 = -negExp;
+
+    // the depth bias is scaled by the derivative of each warp, to keep it in depth units
+    let posScale: f32 = vsmBias * exponent * posMean;
+    let negScale: f32 = vsmBias * negExponent * negExp;
+
+    let posBound: f32 = chebyshevUpperBound(moments.xy, posMean, posScale * posScale, 0.1);
+    let negBound: f32 = chebyshevUpperBound(moments.zw, negMean, negScale * negScale, 0.1);
+
+    // both are upper bounds on the visibility, so the tighter one is the better estimate
+    return min(posBound, negBound);
+}
 
 fn VSM32(tex: texture_2d<f32>, texSampler: sampler, texCoords_in: vec2f, resolution: f32, Z: f32, vsmBias: f32, exponent: f32) -> f32 {
 
     #ifdef CAPS_TEXTURE_FLOAT_FILTERABLE
-        var moments: vec3f = textureSampleLevel(tex, texSampler, texCoords_in, 0.0).xyz;
+        var moments: vec4f = textureSampleLevel(tex, texSampler, texCoords_in, 0.0);
     #else
         // manual bilinear filtering
         var pixelSize : f32 = 1.0 / resolution;
         let texCoords: vec2f = texCoords_in - vec2f(pixelSize);
-        let s00: vec3f = textureSampleLevel(tex, texSampler, texCoords, 0.0).xyz;
-        let s10: vec3f = textureSampleLevel(tex, texSampler, texCoords + vec2f(pixelSize, 0.0), 0.0).xyz;
-        let s01: vec3f = textureSampleLevel(tex, texSampler, texCoords + vec2f(0.0, pixelSize), 0.0).xyz;
-        let s11: vec3f = textureSampleLevel(tex, texSampler, texCoords + vec2f(pixelSize), 0.0).xyz;
+        let s00: vec4f = textureSampleLevel(tex, texSampler, texCoords, 0.0);
+        let s10: vec4f = textureSampleLevel(tex, texSampler, texCoords + vec2f(pixelSize, 0.0), 0.0);
+        let s01: vec4f = textureSampleLevel(tex, texSampler, texCoords + vec2f(0.0, pixelSize), 0.0);
+        let s11: vec4f = textureSampleLevel(tex, texSampler, texCoords + vec2f(pixelSize), 0.0);
         let fr: vec2f = fract(texCoords * resolution);
-        let h0: vec3f = mix(s00, s10, fr.x);
-        let h1: vec3f = mix(s01, s11, fr.x);
-        var moments: vec3f = mix(h0, h1, fr.y);
+        let h0: vec4f = mix(s00, s10, fr.x);
+        let h1: vec4f = mix(s01, s11, fr.x);
+        var moments: vec4f = mix(h0, h1, fr.y);
     #endif
 
-    return calculateEVSM(moments, Z, vsmBias, exponent);
+    return calculateEVSM4(moments, Z, vsmBias, exponent);
 }
 
 fn getShadowVSM32(shadowMap: texture_2d<f32>, shadowMapSampler: sampler, shadowCoord: vec3f, shadowParams: vec4f, exponent: f32) -> f32 {

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-shadow/litShadowMain.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-shadow/litShadowMain.js
@@ -13,6 +13,12 @@ export default /* wgsl */`
 @fragment
 fn fragmentMain(input: FragmentInput) -> FragmentOutput {
 
+    // protect against rasterization of degenerate triangles of animated meshes, which can generate
+    // out of range / NaN depth - VSM blur would smear those into large visible artifacts
+    if (!(input.position.z >= 0.0 && input.position.z <= 1.0)) {
+        discard;
+    }
+
     #include "litUserMainStartPS"
 
     var output: FragmentOutput;
@@ -37,15 +43,24 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
     #endif
 
     #if SHADOW_TYPE == VSM_16F || SHADOW_TYPE == VSM_32F
-        #if SHADOW_TYPE == VSM_32F
-            var exponent: f32 = 15.0;
-        #else
-            var exponent: f32 = 5.54;
-        #endif
 
-        var depth_vsm = 2.0 * depth - 1.0;
-        depth_vsm = exp(exponent * depth_vsm);
-        output.color = vec4f(depth_vsm, depth_vsm * depth_vsm, 1.0, 1.0);
+        let warpD: f32 = 2.0 * depth - 1.0;
+
+        #if SHADOW_TYPE == VSM_32F
+
+            // EVSM4 - a positive and a negative exponential warp, each with its second moment.
+            // Note: these exponents must match those used by the shadowEVSM chunk.
+            let warpPos: f32 = exp(15.0 * warpD);
+            let warpNeg: f32 = exp(-5.0 * warpD);
+            output.color = vec4f(warpPos, warpPos * warpPos, -warpNeg, warpNeg * warpNeg);
+
+        #else
+
+            // EVSM2 - a single exponential warp with its second moment, z stores the coverage
+            let warpPos: f32 = exp(5.54 * warpD);
+            output.color = vec4f(warpPos, warpPos * warpPos, 1.0, 1.0);
+
+        #endif
     #else
         #if SHADOW_TYPE == PCSS_32F
             output.color = vec4f(depth, 0.0, 0.0, 1.0);


### PR DESCRIPTION
> [!NOTE]
> **Reference only - closed immediately, not intended to be merged.** Opened to preserve an EVSM4 implementation and its measurements for a future improvement of #7480. The narrow, mergeable part of this exploration was split out into #9124.

`SHADOW_VSM_32F` currently uses a single (positive) exponential warp - EVSM2. Because `exp()` grows so steeply, a linear blur of those moments behaves as a soft maximum, so the deepest texel within the filter kernel dominates the filtered result. When that filtered occluder depth ends up behind the receiver, the one-tailed Chebyshev early-out returns fully lit, which shows up as a rounded light leak inside the shadow - most visible where caster and receiver depths are close, such as around the feet of a character.

**What this branch contains:**
- `SHADOW_VSM_32F` reimplemented as EVSM4 - the map stores a positive and a negative exponential warp of the depth, each with its second moment, using `kPos = 15` (unchanged) and `kNeg = 5`. A Chebyshev bound is evaluated per warp and the tighter of the two is used. The negative warp is a soft minimum, so it does not suffer from the domination above and prevents the false "lit" result. The public `SHADOW_VSM_32F` constant is unchanged, so user code is unaffected. `SHADOW_VSM_16F` stays on EVSM2.
- Because EVSM4 uses all four channels, the coverage channel is gone, so the VSM_32F map is cleared to the warped depth of the far plane instead - an occluder behind any receiver, and so unshadowed.
- The VSM blur now filters all four channels.
- The caster depth guard (as in #9124, but here applied to all shadow types rather than only VSM), and temporary animation scrubbing / logging in the example, used to find reproduction poses.

**Measured** on `shaders/shader-material-shadows` at a fixed pose, comparing the positive-only bound against the minimum of both, against a PCF5 reference: light leak energy 4.5x lower, compact leak blobs 24 -> 6, blob area 12362 -> 1380 px, largest blob 143x210 -> 58x97 px, and slightly less over-darkening than VSM_16F.

**Why it is not proposed for merging as is:** VSM_32F still leaks more than VSM_16F, the clear-to-far change is more leak prone than the coverage approach when receivers are far from the shadow camera far plane, WebGPU was not re-verified after the last change, and the example still contains the debug scaffolding.