### PR TITLE
Fix vertex array object cache key collisions

### DIFF
--- a/src/platform/graphics/vertex-buffer.js
+++ b/src/platform/graphics/vertex-buffer.js
@@ -19,6 +19,14 @@ class VertexBuffer {
     usage = BUFFER_STATIC;
 
     /**
+     * Lazily evaluated cache of {@link VertexBuffer#vaoKeyPart}.
+     *
+     * @type {string|null}
+     * @private
+     */
+    _vaoKeyPart = null;
+
+    /**
      * Create a new VertexBuffer instance.
      *
      * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this vertex
@@ -60,6 +68,23 @@ class VertexBuffer {
         }
 
         this.device.buffers.add(this);
+    }
+
+    /**
+     * This buffer's contribution to the key of the device's vertex array object cache. It identifies
+     * both the buffer and its format, and is delimited so that the parts of several buffers can be
+     * concatenated without ambiguity.
+     *
+     * Evaluated lazily, as it is only needed by buffers taking part in a draw which uses more than
+     * one vertex buffer, and most buffers never do. The format of a vertex buffer never changes, so
+     * the value is safe to cache.
+     *
+     * @type {string}
+     * @ignore
+     */
+    get vaoKeyPart() {
+        this._vaoKeyPart ??= `${this.id}_${this.format.renderingHash}_`;
+        return this._vaoKeyPart;
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1787,11 +1787,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
         const useCache = vertexBuffers.length > 1;
         if (useCache) {
 
-            // generate unique key for the vertex buffers
+            // generate unique key for the vertex buffers - each part identifies both the buffer and
+            // its format, and is delimited, so distinct buffer lists cannot generate the same key
             key = '';
             for (let i = 0; i < vertexBuffers.length; i++) {
-                const vertexBuffer = vertexBuffers[i];
-                key += vertexBuffer.id + vertexBuffer.format.renderingHash;
+                key += vertexBuffers[i].vaoKeyPart;
             }
 
             // try to get VAO from cache
@@ -1846,7 +1846,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
             // unbind any array buffer
             gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
-            // add it to cache
+            // add it to cache. Note that entries are not removed when one of the vertex buffers is
+            // destroyed - the cache only retains the vertex array object itself, not the buffers, and
+            // the number of buffers taking part in multi-buffer draws is small, so pruning per
+            // destroyed buffer is not considered worth the cost. The cache is released in full when
+            // the device is destroyed or the context is lost.
             if (useCache) {
                 this._vaoMap.set(key, vao);
             }

--- a/test/platform/graphics/vertex-buffer.test.mjs
+++ b/test/platform/graphics/vertex-buffer.test.mjs
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+
+import { SEMANTIC_ATTR0, SEMANTIC_POSITION, TYPE_FLOAT32 } from '../../../src/platform/graphics/constants.js';
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+import { VertexBuffer } from '../../../src/platform/graphics/vertex-buffer.js';
+import { VertexFormat } from '../../../src/platform/graphics/vertex-format.js';
+
+describe('VertexBuffer', function () {
+
+    /** @type {NullGraphicsDevice} */
+    let device;
+
+    beforeEach(function () {
+        device = new NullGraphicsDevice({ width: 100, height: 100 });
+    });
+
+    afterEach(function () {
+        device.destroy();
+        device = null;
+    });
+
+    const createBuffer = (semantic, components) => new VertexBuffer(
+        device,
+        new VertexFormat(device, [{ semantic: semantic, components: components, type: TYPE_FLOAT32 }]),
+        4
+    );
+
+    describe('#vaoKeyPart', function () {
+
+        it('encodes both the buffer id and the format hash as separate fields', function () {
+            const buffer = createBuffer(SEMANTIC_POSITION, 3);
+
+            expect(buffer.vaoKeyPart).to.equal(`${buffer.id}_${buffer.format.renderingHash}_`);
+
+            buffer.destroy();
+        });
+
+        it('returns the same value on repeated access', function () {
+            const buffer = createBuffer(SEMANTIC_POSITION, 3);
+
+            expect(buffer.vaoKeyPart).to.equal(buffer.vaoKeyPart);
+
+            buffer.destroy();
+        });
+
+        it('does not collapse the id and the format hash into their sum', function () {
+            // Regression test - the key used to be built as `id + renderingHash`, which is numeric
+            // addition, so any two buffers whose id and format hash summed to the same value produced
+            // an identical contribution and could collide in the vertex array object cache.
+            const buffer = createBuffer(SEMANTIC_POSITION, 3);
+
+            expect(buffer.vaoKeyPart).to.not.equal(String(buffer.id + buffer.format.renderingHash));
+
+            buffer.destroy();
+        });
+
+        it('differs between buffers sharing a format', function () {
+            const format = new VertexFormat(device, [
+                { semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 }
+            ]);
+            const bufferA = new VertexBuffer(device, format, 4);
+            const bufferB = new VertexBuffer(device, format, 4);
+
+            expect(bufferA.vaoKeyPart).to.not.equal(bufferB.vaoKeyPart);
+
+            bufferA.destroy();
+            bufferB.destroy();
+        });
+
+        it('differs between formats', function () {
+            const bufferA = createBuffer(SEMANTIC_POSITION, 3);
+            const bufferB = createBuffer(SEMANTIC_ATTR0, 4);
+
+            expect(bufferA.format.renderingHash).to.not.equal(bufferB.format.renderingHash);
+            expect(bufferA.vaoKeyPart).to.not.equal(bufferB.vaoKeyPart);
+
+            bufferA.destroy();
+            bufferB.destroy();
+        });
+
+        it('concatenates unambiguously, so distinct buffer lists give distinct keys', function () {
+            // Without a delimiter, parts such as "1" + "23" and "12" + "3" both concatenate to "123".
+            const buffers = [
+                createBuffer(SEMANTIC_POSITION, 3),
+                createBuffer(SEMANTIC_ATTR0, 4),
+                createBuffer(SEMANTIC_ATTR0, 2)
+            ];
+
+            const keyOf = list => list.reduce((key, buffer) => key + buffer.vaoKeyPart, '');
+
+            const keys = new Set([
+                keyOf([buffers[0], buffers[1]]),
+                keyOf([buffers[1], buffers[0]]),
+                keyOf([buffers[0], buffers[2]]),
+                keyOf([buffers[1], buffers[2]]),
+                keyOf([buffers[0], buffers[1], buffers[2]])
+            ]);
+
+            expect(keys.size).to.equal(5);
+
+            buffers.forEach(buffer => buffer.destroy());
+        });
+    });
+});


### PR DESCRIPTION
## Description

The vertex array object cache key in `WebglGraphicsDevice#createVertexArray` was built like this:

```js
key += vertexBuffer.id + vertexBuffer.format.renderingHash;
```

`VertexBuffer#id` is a number (`let id = 0; this.id = id++`) and `VertexFormat#renderingHash` is a number (`StringIds#get`, which returns an incrementing integer). So the inner `+` was **numeric addition**, evaluated before the string append — each buffer contributed the *sum* of its id and format hash rather than both values, and the per-buffer parts had no delimiter between them.

Observed live in an instanced draw (cone geometry + instancing buffer):

| Buffer | `id` | `renderingHash` | contributed |
|---|---|---|---|
| cone geometry | 4 | 3 | `"7"` |
| instancing | 2 | 2 | `"4"` |

Resulting key: `"74"`.

That gives two independent ways for distinct buffer lists to produce the same key:

- **The sum collapses distinct pairs.** The cone above contributes `"7"`, and so would id 5 / hash 2, id 6 / hash 1, or id 7 / hash 0 — a different buffer with a different format.
- **No delimiter between parts.** Contributions `(1, 23)` and `(12, 3)` both concatenate to `"123"`.

A collision hands back the wrong cached vertex array object, so the draw runs with another buffer list's `vertexAttribPointer` state — wrong attributes, silently. It is reachable in any scene with several multi-buffer draws, and both `mesh + instancing` and `mesh + morph targets` take this path, so ids climb quickly.

## Fix

Each buffer now contributes a delimited `id_hash_` part, exposed as `VertexBuffer#vaoKeyPart`:

```js
get vaoKeyPart() {
    this._vaoKeyPart ??= `${this.id}_${this.format.renderingHash}_`;
    return this._vaoKeyPart;
}
```

Evaluated lazily, since it is only needed by buffers taking part in a draw using more than one vertex buffer and most buffers never do. A vertex buffer's format never changes — there is no API to reassign it — so the value is safe to cache. Net effect is less work per multi-buffer draw than before, as the number-to-string conversions now happen once per buffer instead of once per draw.

## Notes

- Cache entries are still not pruned when one of their vertex buffers is destroyed. The cache retains only the vertex array object, not the buffers, and the number of buffers taking part in multi-buffer draws is small, so pruning per destroyed buffer did not seem worth the cost. Added a comment recording that, and the cache is released in full on device destroy and context loss.
- The tests cover `vaoKeyPart` rather than `createVertexArray` itself, which would need a WebGL context. The concatenation test uses the same reduction `createVertexArray` performs.

## Testing

6 new unit tests in `test/platform/graphics/vertex-buffer.test.mjs`, including a regression test asserting the part is not the sum. Full suite passes (2119).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
