### PR TITLE
Fix textureBias redefinition in tiled nine-slice shaders

### DIFF
--- a/examples/src/examples/user-interface/panel.controls.jsx
+++ b/examples/src/examples/user-interface/panel.controls.jsx
@@ -20,6 +20,13 @@ export function Controls({ observer }) {
                         link={{ observer, path: 'data.sliced' }}
                     />
                 </LabelGroup>
+                <LabelGroup text='9-Tiled'>
+                    <BooleanInput
+                        type='toggle'
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'data.tiled' }}
+                    />
+                </LabelGroup>
             </Panel>
         </>
     );

--- a/examples/src/examples/user-interface/panel.example.mjs
+++ b/examples/src/examples/user-interface/panel.example.mjs
@@ -19,6 +19,7 @@ import {
     SCALEMODE_BLEND,
     SPRITE_RENDERMODE_SIMPLE,
     SPRITE_RENDERMODE_SLICED,
+    SPRITE_RENDERMODE_TILED,
     ScreenComponentSystem,
     Sprite,
     TextureAtlas,
@@ -194,13 +195,18 @@ app.on('update', (_dt) => {
 });
 
 // Apply UI changes
-data.on('*:set', (/** @type {string} */ path, value) => {
-    if (path === 'data.sliced') {
-        panel.element.sprite.renderMode = value ? SPRITE_RENDERMODE_SLICED : SPRITE_RENDERMODE_SIMPLE;
+data.on('*:set', (/** @type {string} */ path) => {
+    if (path === 'data.sliced' || path === 'data.tiled') {
+        const tiled = data.get('data.tiled');
+        const sliced = data.get('data.sliced');
+        panel.element.sprite.renderMode = tiled ?
+            SPRITE_RENDERMODE_TILED :
+            (sliced ? SPRITE_RENDERMODE_SLICED : SPRITE_RENDERMODE_SIMPLE);
     }
 });
 
 // Set initial values
 data.set('data', {
-    sliced: true
+    sliced: true,
+    tiled: false
 });

--- a/examples/src/examples/user-interface/panel.example.mjs
+++ b/examples/src/examples/user-interface/panel.example.mjs
@@ -197,11 +197,13 @@ app.on('update', (_dt) => {
 // Apply UI changes
 data.on('*:set', (/** @type {string} */ path) => {
     if (path === 'data.sliced' || path === 'data.tiled') {
-        const tiled = data.get('data.tiled');
-        const sliced = data.get('data.sliced');
-        panel.element.sprite.renderMode = tiled ?
-            SPRITE_RENDERMODE_TILED :
-            (sliced ? SPRITE_RENDERMODE_SLICED : SPRITE_RENDERMODE_SIMPLE);
+        let renderMode = SPRITE_RENDERMODE_SIMPLE;
+        if (data.get('data.tiled')) {
+            renderMode = SPRITE_RENDERMODE_TILED;
+        } else if (data.get('data.sliced')) {
+            renderMode = SPRITE_RENDERMODE_SLICED;
+        }
+        panel.element.sprite.renderMode = renderMode;
     }
 });
 

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -672,6 +672,8 @@ class Renderer {
         if (!this.viewUniformFormat) {
 
             // format of the view uniform buffer
+            // note: 'textureBias' is deliberately not part of this, as the tiled nine-slice mode
+            // declares a global constant of that name in the shader, which would collide with it
             const uniforms = [
                 new UniformFormat('matrix_view', UNIFORMTYPE_MAT4),
                 new UniformFormat('matrix_viewInverse', UNIFORMTYPE_MAT4),
@@ -684,7 +686,6 @@ class Renderer {
                 new UniformFormat('viewport_size', UNIFORMTYPE_VEC4),
                 new UniformFormat('skyboxIntensity', UNIFORMTYPE_FLOAT),
                 new UniformFormat('exposure', UNIFORMTYPE_FLOAT),
-                new UniformFormat('textureBias', UNIFORMTYPE_FLOAT),
                 new UniformFormat('view_index', UNIFORMTYPE_UINT)
             ];
 

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/startNineSlicedTiled.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/startNineSlicedTiled.js
@@ -1,10 +1,10 @@
 export default /* wgsl */`
     let tileMask: vec2f = step(vMask, vec2f(0.99999));
-    let tileSize: vec2f = 0.5 * (innerOffset.xy + innerOffset.zw);
+    let tileSize: vec2f = 0.5 * (uniform.innerOffset.xy + uniform.innerOffset.zw);
     let tileScale: vec2f = vec2f(1.0) / (vec2f(1.0) - tileSize);
-    var clampedUv: vec2f = mix(innerOffset.xy * 0.5, vec2f(1.0) - innerOffset.zw * 0.5, fract((vTiledUv - tileSize) * tileScale));
-    clampedUv = clampedUv * atlasRect.zw + atlasRect.xy;
-    var nineSlicedUv: vec2f = vUv0 * tileMask + clampedUv * (vec2f(1.0) - tileMask);
+    var clampedUv: vec2f = mix(uniform.innerOffset.xy * 0.5, vec2f(1.0) - uniform.innerOffset.zw * 0.5, fract((vTiledUv - tileSize) * tileScale));
+    clampedUv = clampedUv * uniform.atlasRect.zw + uniform.atlasRect.xy;
+    nineSlicedUv = vUv0 * tileMask + clampedUv * (vec2f(1.0) - tileMask);
     nineSlicedUv.y = 1.0 - nineSlicedUv.y;
 
 `;

--- a/src/scene/shader-lib/wgsl/chunks/standard/frag/litShaderCore.js
+++ b/src/scene/shader-lib/wgsl/chunks/standard/frag/litShaderCore.js
@@ -1,11 +1,9 @@
 export default /* wgsl */`
 
     // global texture bias for standard textures
-    #if LIT_NONE_SLICE_MODE == TILED
-        var<private> textureBias: f32 = -1000.0;
-    #else
-        uniform textureBias: f32;
-    #endif
+    // note: unlike GLSL, the tiled nine-slice mode does not force the top mip here, as the chunks
+    // reference this as 'uniform.textureBias' and so it needs to be a real uniform
+    uniform textureBias: f32;
 
     #include "litShaderArgsPS"
 `;


### PR DESCRIPTION
Fixes #9128. Nine-sliced **tiled** sprites and UI images (`SPRITE_RENDERMODE_TILED`) fail to render: on WebGL2 since 2.21.0, and on WebGPU since the WGSL chunks were introduced.

**Changes:**
- `textureBias` is no longer part of the view uniform buffer format. Since #8987 the WebGL2 path emits the `ub_view` block from the full view format unconditionally, so its `textureBias` member collided with the `const float textureBias = -1000.0` that `litShaderCore` declares in tiled nine-slice mode, giving `ERROR: 'textureBias' : redefinition`. It is a regular uniform again, as it was in 2.20.6 - nothing in the engine ever writes it beyond the `0.0` default.
- WGSL `litShaderCore` always declares `textureBias` as a uniform. The tiled branch declared a `var<private>`, while all standard chunks reference `uniform.textureBias` - which is only rewritten for uniforms parsed from a declaration - so the tiled shader kept a literal `uniform.textureBias` and failed to compile. As a result, tiled mode on WebGPU uses a texture bias of `0.0` instead of `-1000.0`; the UI atlases this affects typically have no mipmaps.
- WGSL `startNineSlicedTiled` - `innerOffset` and `atlasRect` were referenced without the `uniform.` prefix, and `nineSlicedUv` was redeclared as a local `var`, shadowing the global that the texture chunks read.

**Examples:**
- `user-interface/panel` gains a 9-Tiled toggle next to 9-Sliced, so the tiled path is covered.