### PR TITLE
Fix stale base commit in API report and build size workflows

### DIFF
--- a/.github/workflows/api-report.yml
+++ b/.github/workflows/api-report.yml
@@ -27,16 +27,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Check out base
-        uses: actions/checkout@v7.0.1
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          path: base
-
       - name: Check out PR
         uses: actions/checkout@v7.0.1
         with:
           path: pr
+          fetch-depth: 2 # need the merge commit's parents, see below
+
+      - name: Resolve base commit
+        id: base
+        # First parent of the pull_request merge ref is the base commit this PR was actually merged
+        # with. Do not use pull_request.base.sha - that is frozen when the PR is opened and is not
+        # advanced on synchronize, so once the base branch moves, everything merged into it since
+        # shows up as this PR's own API changes.
+        run: echo "sha=$(git -C pr rev-parse HEAD^1)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out base
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ steps.base.outputs.sha }}
+          path: base
 
       - name: Setup Node.js 24.x
         uses: actions/setup-node@v7

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -34,16 +34,25 @@ jobs:
     env:
       ENGINE_BUILD_REVISION: ci-build-size
     steps:
-      - name: Check out base
-        uses: actions/checkout@v7.0.1
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          path: base
-
       - name: Check out PR
         uses: actions/checkout@v7.0.1
         with:
           path: pr
+          fetch-depth: 2 # need the merge commit's parents, see below
+
+      - name: Resolve base commit
+        id: base
+        # First parent of the pull_request merge ref is the base commit this PR was actually merged
+        # with. Do not use pull_request.base.sha - that is frozen when the PR is opened and is not
+        # advanced on synchronize, so once the base branch moves, everything merged into it since
+        # shows up as this PR's own size change.
+        run: echo "sha=$(git -C pr rev-parse HEAD^1)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out base
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ steps.base.outputs.sha }}
+          path: base
 
       - name: Setup Node.js 24.x
         uses: actions/setup-node@v7


### PR DESCRIPTION
The API report and build size workflows attribute unrelated commits to a PR once the base branch moves.

Both check the base side out at `github.event.pull_request.base.sha`, which GitHub freezes when the PR is opened and does not advance on `synchronize`. The PR side has no explicit `ref`, so it is the `pull_request` merge ref - the head merged with the *current* base tip. As soon as `main` moves, the two sides straddle everything merged in between, and that shows up as the PR's own API or size change.

Seen on #9129, which touches no transform-feedback code but was reported as adding `TRANSFORM_FEEDBACK_INTERLEAVED` / `TRANSFORM_FEEDBACK_SEPARATE`, `feedbackVaryingsMode` and `WebglGraphicsDevice.transformFeedbackBuffers` - all of them from #9109, merged into `main` six minutes after that PR was opened.

**Changes:**
- Both workflows now take the base commit from the merge ref's first parent, which is exactly the base commit the PR was merged with, so the two sides can only differ by the PR's own commits. The PR checkout gains `fetch-depth: 2` so that parent is present.
- This also closes the smaller race in the alternative fix of checking out the base *branch*, where the base tip can advance between the two checkouts.

Rebasing a PR does not work around the old behaviour, since `base.sha` stays pinned regardless - the comment can only be corrected here.