### PR TITLE
Exclude protected members from the API surface report

### DIFF
--- a/utils/api-surface.mjs
+++ b/utils/api-surface.mjs
@@ -1,7 +1,8 @@
 // Serialises a TypeDoc JSON model (`typedoc --json`) into a stable, sorted, full-signature text
 // view of the public API. Because it consumes TypeDoc's model, it inherits the docs' public-API
 // rules (excludeNotDocumented, @ignore, @private, the custom typedoc plugin) — so internal/ignored
-// symbols are absent. Usage: `node utils/api-surface.mjs <typedoc.json>` → surface on stdout.
+// symbols are absent. `@protected` members are dropped here as well, see member().
+// Usage: `node utils/api-surface.mjs <typedoc.json>` → surface on stdout.
 
 import { readFileSync } from 'node:fs';
 
@@ -55,6 +56,16 @@ function typeParams(r) {
 // one member of a class/interface → one or more lines (overloads, get+set)
 function member(r) {
     const f = flags(r);
+
+    // Skip protected members. TypeDoc's excludePrivate defaults to true, so `@private` members never
+    // reach the model at all, but excludeProtected defaults to false, so `@protected` ones do. The
+    // generated docs then hide them behind a visibility filter which is off by default, so without
+    // this they would be the only internals reported as public API. Filtering here rather than
+    // through excludeProtected keeps them in the docs for anyone extending these classes.
+    if (f.isProtected) {
+        return [];
+    }
+
     const pre = (f.isStatic ? 'static ' : '') + (f.isReadonly ? 'readonly ' : '');
     if (r.kind === CONSTRUCTOR) return r.signatures.map(s => `constructor(${params(s)})`);
     if (r.kind === METHOD) return r.signatures.map(s => `${pre}${r.name}${typeParams(s)}(${params(s)}): ${typeStr(s.type)}`);


### PR DESCRIPTION
## Description

The API surface report treats every `@protected` member as public API. On #9131 it reported a signature change to `GraphicsDevice.validateAttributes`, a debug-only internal validator, on both the base class and `WebglGraphicsDevice` — which is what surfaced this.

### Cause

A TypeDoc default asymmetry, straight from its own help text:

```
--excludePrivate     Ignore members marked with the private keyword … defaults to true.
--excludeProtected   Ignore protected variables and methods
```

`excludePrivate` defaults to **true**, `excludeProtected` defaults to **false**, and `typedoc.json` sets neither. So `@private` members never reach the JSON model, while `@protected` ones do — and `utils/api-surface.mjs` faithfully serialises whatever the model contains. Confirmed on the generated model:

```
reflections with isPrivate:       0
own reflections with isProtected: 59   (179 including inherited duplicates)
```

The generated docs render these members wrapped in `tsd-is-protected`, controlled by a visibility checkbox that ships unchecked:

```html
<input type="checkbox" id="tsd-filter-protected" name="protected"/>   <!-- no `checked` -->
```

So they are hidden on the docs site by default, leaving the report as the only place they appear as public API.

### Fix

`member()` in `utils/api-surface.mjs` now returns nothing for reflections flagged `isProtected`.

Filtering in the report rather than setting `excludeProtected: true` in `typedoc.json` is deliberate — the latter would drop these members from the generated docs entirely, and they remain useful to anyone extending these classes. This way the report matches what the docs show by default, and the docs are unchanged.

### What drops out

179 lines, all internals. By owner:

| Class | Members |
|---|---|
| TransformGizmo | 16 |
| Gizmo | 14 |
| Texture | 7 |
| ScaleGizmo | 4 |
| GraphNode | 3 |
| RotateGizmo | 3 |
| Entity, ScriptType, TranslateGizmo | 2 each |
| InputController, InputSource, Material, ResourceHandler, Script | 1 each |

Plus 120 inherited duplicates of those on subclasses. Examples: `Gizmo._camera`, `GraphNode._children`, `TransformGizmo._createPlane`, `Texture._lockedLevel`.

## Testing

Ran the same steps the workflow runs, against an unchanged model, before and after:

```
before: 6145 lines
after:  5966 lines
removed: 179    added: 0
```

Then cross-checked each removed line against the JSON model — all 179 correspond to a reflection flagged `isProtected`, and nothing else was affected.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
