### PR TITLE
Report transform feedback buffer setup problems where they happen

### DIFF
--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -199,6 +199,9 @@ class TransformFeedback {
     _createOutputBuffer(inputBuffer, usage) {
 
         if (usage === BUFFER_GPUDYNAMIC && inputBuffer.usage !== usage) {
+
+            Debug.warnOnce(`Vertex buffer ${inputBuffer.id} supplied to TransformFeedback was created with usage ${inputBuffer.usage} instead of BUFFER_GPUDYNAMIC, so its contents are being re-uploaded to change it. Create buffers used by transform feedback with BUFFER_GPUDYNAMIC to avoid this.`, inputBuffer);
+
             // have to recreate input buffer with other usage
             const gl = this.device.gl;
             gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer.impl.bufferId);

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2479,6 +2479,12 @@ class WebglGraphicsDevice extends GraphicsDevice {
         Debug.call(() => {
             buffers?.forEach((buffer, index) => {
                 Debug.assert(buffer, `Transform feedback buffer at index ${index} is null - a buffer is required for every varying the shader captures.`);
+
+                // A vertex buffer only allocates its GPU storage when it is first given data, so a
+                // buffer created without any is still empty here. Transform feedback would fail on
+                // beginTransformFeedback with an error naming neither the buffer nor the cause, so
+                // catch it while the buffer is still identifiable.
+                Debug.assert(buffer?.impl.initialized, `Transform feedback buffer ${buffer?.id} at index ${index} has no GPU storage allocated, so it cannot be written to. A vertex buffer allocates its storage when first given data, so pass initial data when creating a buffer which only transform feedback writes to.`, buffer);
             });
         });
 


### PR DESCRIPTION
## Description

Addresses the two diagnostics proposed in #9134. Both are debug-only; neither changes behaviour.

### Missing GPU storage

A `VertexBuffer` only allocates its GPU storage when it is first given data — so a buffer created without any, which is reasonable for one that only transform feedback ever writes, stays empty:

```js
// no GPU storage is ever allocated
const instances = new VertexBuffer(device, format, count, { usage: BUFFER_GPUDYNAMIC });
```

`bindBufferBase` then bound nothing, and `beginTransformFeedback` returned `GL_INVALID_OPERATION` — naming neither the buffer nor the reason, four steps from the actual mistake.

`setTransformFeedbackBuffers` now checks it up front, while the buffer is still identifiable:

```
Transform feedback buffer 8 at index 0 has no GPU storage allocated, so it cannot be
written to. A vertex buffer allocates its storage when first given data, so pass initial
data when creating a buffer which only transform feedback writes to.
```

`WebglBuffer#initialized` is the right signal here — it is `!!bufferId`, and `bufferId` is only created in `unlock()`.

### Silent usage re-upload

`TransformFeedback` re-uploads a buffer's contents to change its usage when it was not created with `BUFFER_GPUDYNAMIC`. That is a full re-upload per buffer, previously with no indication at all. It now warns once, naming the buffer and its usage:

```
Vertex buffer 9 supplied to TransformFeedback was created with usage 0 instead of
BUFFER_GPUDYNAMIC, so its contents are being re-uploaded to change it. Create buffers
used by transform feedback with BUFFER_GPUDYNAMIC to avoid this.
```

### Not addressed

#9134 also suggests allocating GPU storage in the `VertexBuffer` constructor regardless of `data`, or adding an explicit allocate-without-upload option. Those change behaviour and touch every vertex buffer, so they are left for that issue — this PR only makes the current requirements visible. Passing zeroed data purely to force allocation is still a wasted upload.

## Testing

Verified on WebGL2 against the `graphics/transform-feedback-separate` example:

- **The example trips neither check.** It uses `BUFFER_GPUDYNAMIC` throughout and supplies initial data, so no false positives across rendered frames.
- **Missing storage:** a buffer built without `data` reports `impl.initialized === false` and the assert fires with the message above.
- **Wrong usage:** a `BUFFER_STATIC` buffer passed to the constructor triggers the warning with the message above.
- Full unit suite passes (2119), lint clean.

Docs for both workarounds are removed in playcanvas/developer-site#1115.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
