### PR TITLE
Remove the usage warning from TransformFeedback buffer adoption

### DIFF
--- a/src/platform/graphics/transform-feedback.js
+++ b/src/platform/graphics/transform-feedback.js
@@ -199,10 +199,9 @@ class TransformFeedback {
     _createOutputBuffer(inputBuffer, usage) {
 
         if (usage === BUFFER_GPUDYNAMIC && inputBuffer.usage !== usage) {
-
-            Debug.warnOnce(`Vertex buffer ${inputBuffer.id} supplied to TransformFeedback was created with usage ${inputBuffer.usage} instead of BUFFER_GPUDYNAMIC, so its contents are being re-uploaded to change it. Create buffers used by transform feedback with BUFFER_GPUDYNAMIC to avoid this.`, inputBuffer);
-
-            // have to recreate input buffer with other usage
+            // Supplying a buffer with another usage is supported - "any VertexBuffer, either
+            // manually created, or from a Mesh" - so adopt it by re-uploading its contents to
+            // change the usage. This is a one-time cost at construction.
             const gl = this.device.gl;
             gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer.impl.bufferId);
             gl.bufferData(gl.ARRAY_BUFFER, inputBuffer.storage, gl.DYNAMIC_COPY);


### PR DESCRIPTION
## Description

Reverts the `Debug.warnOnce` half of #9135. The storage assert from that PR stays — it catches a real mistake with no supported use behind it.

The warning fires on the shipped, unmodified `graphics/transform-feedback` example:

```
Vertex buffer 6 supplied to TransformFeedback was created with usage 0 instead of
BUFFER_GPUDYNAMIC, so its contents are being re-uploaded to change it.
```

That example does nothing wrong. `mesh.setPositions(positions, 4)` creates its vertex buffer with the default `BUFFER_STATIC` usage, and handing that to `TransformFeedback` is the documented contract — the class doc says the input can be "any VertexBuffer, either manually created, or from a Mesh". The re-upload is not a mistake path; it is the intended adoption mechanism for exactly this case, and it runs once at construction, never per frame (`_createOutputBuffer` is constructor-only).

From inside the helper, the legitimate case (borrowing a static mesh buffer) and the case worth catching (a buffer built for repeated GPU-only use with a forgotten usage flag) are indistinguishable — same object shape, same call, same one-time reallocation, and nothing on `VertexBuffer` encodes the caller's intent. So the warning cannot be sharpened to fire only when it should; it can only accuse correct code. Removed, with the one-time adoption cost recorded in a comment instead.

## Testing

- Full unit suite passes (2119), lint clean.
- `Debug` remains imported and used by the other checks in the file.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
