### PR TITLE
Fix the bright outline around MSDF text glyphs

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/common/frag/msdf.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/msdf.js
@@ -22,10 +22,13 @@ uniform float font_pxrange;      // number of texels of SDF spread (inside <-> o
 
 vec4 applyMsdf(vec4 color) {
 
-    // Convert to linear space before processing
+    // The incoming color is in gamma space, premultiplied by alpha. Un-premultiply before the
+    // gamma decode (the decode is only valid on straight color), then re-premultiply so the
+    // compositing below stays premultiplied.
     // TODO: ideally this would receive the color in linear space, but that would require larger changes
     // on the engine side, with the way premultiplied alpha is handled as well.
-    color.rgb = gammaCorrectInput(color.rgb);
+    float srcAlpha = max(color.a, 0.0001);
+    color.rgb = gammaCorrectInput(color.rgb / srcAlpha) * srcAlpha;
 
     // sample the field
     vec3 tsample = texture2D(texture_msdfMap, vUv0).rgb;
@@ -58,8 +61,10 @@ vec4 applyMsdf(vec4 color) {
     vec4 scolor = (shadow > outline) ? shadow * vec4(shadow_color.a * shadow_color.rgb, shadow_color.a) : tcolor;
     tcolor = mix(scolor, tcolor, outline);
 
-    // Convert back to gamma space before returning
-    tcolor.rgb = gammaCorrectOutput(tcolor.rgb);
+    // Convert back to gamma space: encode the straight (un-premultiplied) color and re-premultiply.
+    // Encoding the premultiplied product would overshoot at partial coverage (gamma(c * a) > gamma(c) * a),
+    // drawing a bright halo around glyphs under premultiplied-alpha blending (#9122).
+    tcolor.rgb = gammaCorrectOutput(tcolor.rgb / max(tcolor.a, 0.0001)) * tcolor.a;
     
     return tcolor;
 }

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/msdf.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/msdf.js
@@ -35,10 +35,13 @@ fn applyMsdf(color_in: vec4f) -> vec4f {
         var shadow_offsetValue = shadow_offset;
     #endif
 
-    // Convert to linear space before processing
+    // The incoming color is in gamma space, premultiplied by alpha. Un-premultiply before the
+    // gamma decode (the decode is only valid on straight color), then re-premultiply so the
+    // compositing below stays premultiplied.
     // TODO: ideally this would receive the color in linear space, but that would require larger changes
     // on the engine side, with the way premultiplied alpha is handled as well.
-    var color = vec4f(gammaCorrectInputVec3(color_in.rgb), color_in.a);
+    let srcAlpha: f32 = max(color_in.a, 0.0001);
+    var color = vec4f(gammaCorrectInputVec3(color_in.rgb / srcAlpha) * srcAlpha, color_in.a);
 
     // sample the field
     let tsample: vec3f = textureSample(texture_msdfMap, texture_msdfMapSampler, vUv0).rgb;
@@ -74,8 +77,10 @@ fn applyMsdf(color_in: vec4f) -> vec4f {
     let scolor: vec4f = select(tcolor, scolor_shadow, shadow > outline);
     tcolor = mix(scolor, tcolor, outline);
 
-    // Convert back to gamma space before returning
-    tcolor = vec4f(gammaCorrectOutput(tcolor.rgb), tcolor.a);
+    // Convert back to gamma space: encode the straight (un-premultiplied) color and re-premultiply.
+    // Encoding the premultiplied product would overshoot at partial coverage (gamma(c * a) > gamma(c) * a),
+    // drawing a bright halo around glyphs under premultiplied-alpha blending (#9122).
+    tcolor = vec4f(gammaCorrectOutput(tcolor.rgb / max(tcolor.a, 0.0001)) * tcolor.a, tcolor.a);
 
     return tcolor;
 }


### PR DESCRIPTION
Fixes #9122

MSDF text rendered a bright halo around glyph edges whenever the text color was close to the background — most visible with mid-grey text on a mid-grey background, where the glyphs were readable purely by their outline even with identical text and background colors.

The msdf chunk composites the glyph in linear space, which premultiplies the anti-aliasing coverage into rgb, and then gamma-encoded that premultiplied product. Since gamma encoding is concave, `gamma(color * a) > gamma(color) * a`, so under the element material's premultiplied-alpha blending (`src.rgb + dst.rgb * (1 - a)`) every partial-coverage edge pixel came out brighter than both the text and the background. The overshoot dates back to #7325; the recent anti-aliasing improvements (#8935/#8990/#9100) only made the well-formed AA ramp — and with it the halo — more consistent.

**Changes:**
- `msdfPS` (GLSL and WGSL): un-premultiply alpha before the gamma decode of the incoming color, and gamma-encode the straight (un-premultiplied) color before re-premultiplying on output, so blending interpolates exactly between text and background with no overshoot.
- Fully opaque glyph interiors are bit-identical to before (the divide/multiply cancel at alpha 1) — only anti-aliased edge pixels change.

Verified on WebGL2 and WebGPU: with text color equal to background color the text is now perfectly invisible (previously up to 34/255 levels brighter at edges; full-frame readback shows zero overshooting pixels), and the `user-interface/text` example (markup, outline, drop shadow) renders unchanged.

Note: translucent text (element opacity < 1) renders slightly brighter than before — the opacity-premultiplied color was previously gamma-decoded as a product, darkening fades; the straight-color round trip is now exact.