### PR TITLE
Fix AnimationComponent leaking asset event handlers

### DIFF
--- a/src/framework/components/animation/component.js
+++ b/src/framework/components/animation/component.js
@@ -95,6 +95,24 @@ class AnimationComponent extends Component {
     animationsIndex = {};
 
     /**
+     * The animation assets this component is subscribed to. Tracked so that the subscriptions can
+     * be removed even when the asset is no longer in the asset registry.
+     *
+     * @type {Set<Asset>}
+     * @private
+     */
+    _boundAssets = new Set();
+
+    /**
+     * The names of the asset registry 'add:[id]' events this component is subscribed to, waiting
+     * for its animation assets to be added to the registry.
+     *
+     * @type {Set<string>}
+     * @private
+     */
+    _pendingAssetAdds = new Set();
+
+    /**
      * @type {string|null}
      * @private
      */
@@ -154,15 +172,16 @@ class AnimationComponent extends Component {
     set assets(value) {
         const assets = this._assets;
 
+        // unsubscribe from the events of the old assets
+        this._unbindAssets();
+
         if (assets && assets.length) {
             for (let i = 0; i < assets.length; i++) {
-                // unsubscribe from change event for old assets
+                // remove the animations of the old assets
                 if (assets[i]) {
-                    const asset = this.system.app.assets.get(assets[i]);
+                    const id = (assets[i] instanceof Asset) ? assets[i].id : assets[i];
+                    const asset = this.system.app.assets.get(id);
                     if (asset) {
-                        asset.off('change', this.onAssetChanged, this);
-                        asset.off('remove', this.onAssetRemoved, this);
-
                         const animName = this.animationsIndex[asset.id];
 
                         if (this.currAnim === animName) {
@@ -451,46 +470,98 @@ class AnimationComponent extends Component {
 
         const assets = this.system.app.assets;
 
-        const onAssetReady = (asset) => {
-            if (asset.resources.length > 1) {
-                for (let i = 0; i < asset.resources.length; i++) {
-                    this.animations[asset.resources[i].name] = asset.resources[i];
-                    this.animationsIndex[asset.id] = asset.resources[i].name;
-                }
-            } else {
-                this.animations[asset.name] = asset.resource;
-                this.animationsIndex[asset.id] = asset.name;
-            }
-            /* eslint-disable no-self-assign */
-            this.animations = this.animations; // assigning ensures set_animations event is fired
-            /* eslint-enable no-self-assign */
-        };
-
-        const onAssetAdd = (asset) => {
-            asset.off('change', this.onAssetChanged, this);
-            asset.on('change', this.onAssetChanged, this);
-
-            asset.off('remove', this.onAssetRemoved, this);
-            asset.on('remove', this.onAssetRemoved, this);
-
-            if (asset.resource) {
-                onAssetReady(asset);
-            } else {
-                asset.once('load', onAssetReady, this);
-                if (this.enabled && this.entity.enabled) {
-                    assets.load(asset);
-                }
-            }
-        };
-
         for (let i = 0, l = ids.length; i < l; i++) {
             const asset = assets.get(ids[i]);
             if (asset) {
-                onAssetAdd(asset);
+                this._bindAsset(asset);
             } else {
-                assets.on(`add:${ids[i]}`, onAssetAdd);
+                // the asset is not in the registry yet, so wait for it to be added
+                const evtName = `add:${ids[i]}`;
+                if (!this._pendingAssetAdds.has(evtName)) {
+                    this._pendingAssetAdds.add(evtName);
+                    assets.on(evtName, this._onAssetAdded, this);
+                }
             }
         }
+    }
+
+    /**
+     * Subscribe to the events of an animation asset and use its resources when they are available.
+     *
+     * @param {Asset} asset - The animation asset.
+     * @private
+     */
+    _bindAsset(asset) {
+        this._boundAssets.add(asset);
+
+        asset.off('change', this.onAssetChanged, this);
+        asset.on('change', this.onAssetChanged, this);
+
+        asset.off('remove', this.onAssetRemoved, this);
+        asset.on('remove', this.onAssetRemoved, this);
+
+        if (asset.resource) {
+            this._onAssetReady(asset);
+        } else {
+            asset.off('load', this._onAssetReady, this);
+            asset.once('load', this._onAssetReady, this);
+            if (this.enabled && this.entity.enabled) {
+                this.system.app.assets.load(asset);
+            }
+        }
+    }
+
+    /**
+     * Unsubscribe from the events of all animation assets this component is subscribed to, as well
+     * as from any pending asset registry additions.
+     *
+     * @private
+     */
+    _unbindAssets() {
+        const registry = this.system.app.assets;
+
+        this._pendingAssetAdds.forEach((evtName) => {
+            registry.off(evtName, this._onAssetAdded, this);
+        });
+        this._pendingAssetAdds.clear();
+
+        this._boundAssets.forEach((asset) => {
+            asset.off('change', this.onAssetChanged, this);
+            asset.off('remove', this.onAssetRemoved, this);
+            asset.off('load', this._onAssetReady, this);
+        });
+        this._boundAssets.clear();
+    }
+
+    /**
+     * @param {Asset} asset - The animation asset that has been added to the asset registry.
+     * @private
+     */
+    _onAssetAdded(asset) {
+        const evtName = `add:${asset.id}`;
+        this.system.app.assets.off(evtName, this._onAssetAdded, this);
+        this._pendingAssetAdds.delete(evtName);
+
+        this._bindAsset(asset);
+    }
+
+    /**
+     * @param {Asset} asset - The animation asset with loaded resources.
+     * @private
+     */
+    _onAssetReady(asset) {
+        if (asset.resources.length > 1) {
+            for (let i = 0; i < asset.resources.length; i++) {
+                this.animations[asset.resources[i].name] = asset.resources[i];
+                this.animationsIndex[asset.id] = asset.resources[i].name;
+            }
+        } else {
+            this.animations[asset.name] = asset.resource;
+            this.animationsIndex[asset.id] = asset.name;
+        }
+        /* eslint-disable no-self-assign */
+        this.animations = this.animations; // assigning ensures set_animations event is fired
+        /* eslint-enable no-self-assign */
     }
 
     /**
@@ -650,19 +721,7 @@ class AnimationComponent extends Component {
     }
 
     onBeforeRemove() {
-        for (let i = 0; i < this.assets.length; i++) {
-
-            // this.assets can be an array of Asset objects or an array of numbers (assetIds)
-            let asset = this.assets[i];
-            if (typeof asset ===  'number') {
-                asset = this.system.app.assets.get(asset);
-            }
-
-            if (!asset) continue;
-
-            asset.off('change', this.onAssetChanged, this);
-            asset.off('remove', this.onAssetRemoved, this);
-        }
+        this._unbindAssets();
 
         this.skeleton = null;
         this.fromSkel = null;

--- a/test/framework/components/animation/component.test.mjs
+++ b/test/framework/components/animation/component.test.mjs
@@ -160,4 +160,111 @@ describe('AnimationComponent', function () {
 
     });
 
+    describe('asset event unbinding', function () {
+
+        beforeEach(function () {
+            jsdomSetup();
+            app = createApp();
+        });
+
+        afterEach(function () {
+            app?.destroy();
+            app = null;
+            jsdomTeardown();
+            assets = {};
+        });
+
+        const createAnimationAsset = function () {
+            return new Asset('cube.animation.json', 'animation', {
+                url: '/test/assets/cube/cube.animation.json'
+            });
+        };
+
+        const createEntity = function (asset) {
+            const entity = new Entity();
+            entity.addComponent('animation', {
+                assets: [asset.id],
+                activate: true
+            });
+            app.root.addChild(entity);
+            return entity;
+        };
+
+        it('unsubscribes from an asset in the registry when the entity is destroyed', function () {
+            const asset = createAnimationAsset();
+            app.assets.add(asset);
+
+            const entity = createEntity(asset);
+
+            expect(asset.hasEvent('change')).to.be.true;
+            expect(asset.hasEvent('remove')).to.be.true;
+
+            entity.destroy();
+
+            expect(asset.hasEvent('change')).to.be.false;
+            expect(asset.hasEvent('remove')).to.be.false;
+        });
+
+        it('unsubscribes from an in-flight asset load when the entity is destroyed', function () {
+            const asset = createAnimationAsset();
+            app.assets.add(asset);
+
+            const entity = createEntity(asset);
+
+            expect(asset.hasEvent('load')).to.be.true;
+
+            entity.destroy();
+
+            expect(asset.hasEvent('load')).to.be.false;
+        });
+
+        it('unsubscribes from an asset added to the registry after the entity is destroyed', function () {
+            const asset = createAnimationAsset();
+
+            // the component is waiting for the asset to be added to the registry
+            const entity = createEntity(asset);
+            expect(app.assets.hasEvent(`add:${asset.id}`)).to.be.true;
+
+            entity.destroy();
+            expect(app.assets.hasEvent(`add:${asset.id}`)).to.be.false;
+
+            // the late arrival of the asset must not subscribe the removed component
+            app.assets.add(asset);
+            expect(asset.hasEvent('change')).to.be.false;
+            expect(asset.hasEvent('remove')).to.be.false;
+        });
+
+        it('unsubscribes from an asset removed from the registry before the entity is destroyed', function () {
+            const asset = createAnimationAsset();
+            app.assets.add(asset);
+
+            const entity = createEntity(asset);
+
+            app.assets.remove(asset);
+            entity.destroy();
+
+            expect(asset.hasEvent('change')).to.be.false;
+            expect(asset.hasEvent('remove')).to.be.false;
+        });
+
+        it('unsubscribes from assets that are replaced by assigning a new asset array', function () {
+            const asset = createAnimationAsset();
+            app.assets.add(asset);
+
+            const pending = createAnimationAsset();
+
+            const entity = createEntity(asset);
+            entity.animation.assets = [pending.id];
+
+            expect(asset.hasEvent('change')).to.be.false;
+            expect(asset.hasEvent('remove')).to.be.false;
+            expect(app.assets.hasEvent(`add:${pending.id}`)).to.be.true;
+
+            entity.animation.assets = [];
+
+            expect(app.assets.hasEvent(`add:${pending.id}`)).to.be.false;
+        });
+
+    });
+
 });


### PR DESCRIPTION
Fixes #3972.

`AnimationComponent` registered its asset event handlers as closures, so they could never be unsubscribed:

```js
assets.on(`add:${ids[i]}`, onAssetAdd);   // asset registry subscription, never removed
asset.once('load', onAssetReady, this);   // never removed
```

and `onBeforeRemove()` only unsubscribed from assets it could resolve through the registry at that moment (`if (!asset) continue`). So a component removed while its animation asset was missing from the registry stayed subscribed, and a later `assets.add()` re-subscribed the *removed* component to the asset's `change`/`remove` events. That keeps the component, its entity, model and animation resources alive, and dispatches events to it - including during `app.destroy()`, where `Asset.unload()` fires `change` on every asset. In 1.x this threw `Cannot read properties of null (reading 'animations')`, since a removed component's data-backed `animations` accessor reads from a store record that no longer exists.

**Changes:**
- The `onAssetAdd` / `onAssetReady` closures become private methods (`_bindAsset`, `_onAssetAdded`, `_onAssetReady`), so they can be unsubscribed.
- Subscriptions are tracked (bound assets and pending `add:[id]` registry events) and all removed by a new private `_unbindAssets()`, called from `onBeforeRemove()` and from the `assets` setter. This covers assets that are no longer in the registry, assets added after the component was removed, and loads still in flight.
- The `assets` setter now resolves ids for entries holding `Asset` instances, which previously skipped their cleanup (`registry.get(assetInstance)` returns `undefined`).
- Duplicate `add:[id]` subscriptions are no longer registered for the same asset id.
- Adds regression tests covering the four unbinding paths, plus a control test for the already-working case.

No public API changes.