### PR TITLE
Add per-attachment clear colors for multiple render targets

### DIFF
--- a/examples/src/examples/test/independent-blending.example.mjs
+++ b/examples/src/examples/test/independent-blending.example.mjs
@@ -9,6 +9,11 @@
 // only, so its overlay turns red. Both attachments are then displayed side by side - left is
 // attachment 0, right is attachment 1.
 //
+// The example also demonstrates per-attachment clear colors, specified using
+// RenderPass#setClearColor with an attachment index - a standalone clear-only render pass clears
+// attachment 0 to dark blue and attachment 1 to dark green, visible as the border around each
+// panel, and the camera renders on top without clearing.
+//
 // When the device does not support independent blending (the OES_draw_buffers_indexed extension is
 // unavailable on WebGL2), the blend state of attachment 0 is used for all attachments and the two
 // halves render identically.
@@ -34,6 +39,7 @@ import {
     PROJECTION_ORTHOGRAPHIC,
     RESOLUTION_AUTO,
     RenderComponentSystem,
+    RenderPass,
     RenderTarget,
     SHADERLANGUAGE_GLSL,
     SHADERLANGUAGE_WGSL,
@@ -182,9 +188,24 @@ overlay.setLocalEulerAngles(90, 0, 0);
 overlay.setLocalScale(1.2, 1, 1.2);
 app.root.addChild(overlay);
 
+// The attachments are cleared by a standalone clear-only render pass, using a different clear
+// color per attachment, specified using the attachment index of setClearColor. The clear colors
+// stay visible as the border around each panel, as the quads do not cover the full attachment.
+const clearPass = new RenderPass(device);
+clearPass.name = 'PerAttachmentClear';
+clearPass.init(renderTarget);
+clearPass.setClearColor(new Color(0, 0, 0.25, 1), 0);
+clearPass.setClearColor(new Color(0, 0.25, 0, 1), 1);
+
+// execute the clear before the cameras render each frame
+app.on('prerender', () => clearPass.render());
+
+// The camera renders on top of the cleared attachments, without clearing the color itself. It
+// renders before the main camera, so that the displayed attachments contain this frame's result.
 const offscreenCamera = new Entity('Offscreen Camera');
 offscreenCamera.addComponent('camera', {
-    clearColor: new Color(0, 0, 0, 1),
+    clearColorBuffer: false,
+    priority: -1,
     projection: PROJECTION_ORTHOGRAPHIC,
     orthoHeight: 1,
     layers: [offscreenLayer.id],

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -264,19 +264,27 @@ class RenderPass extends FramePass {
      *
      * @param {Color|undefined} color - The color to clear to, or undefined to preserve the existing
      * content.
+     * @param {number} [index] - The index of the color attachment to modify. When not specified,
+     * all color attachments are modified.
      */
-    setClearColor(color) {
+    setClearColor(color, index) {
 
-        // in case of MRT, we clear all color buffers.
         // TODO: expose per color buffer clear parameters on the camera, and copy them here.
         const count = this.colorArrayOps.length;
-        for (let i = 0; i < count; i++) {
+        Debug.assert(index === undefined || (index >= 0 && index < count),
+            `setClearColor index ${index} is out of range, the render pass has ${count} color attachments.`);
+
+        const start = index ?? 0;
+        const end = index === undefined ? count : index + 1;
+        for (let i = start; i < end; i++) {
             const colorOps = this.colorArrayOps[i];
-            if (color) {
-                colorOps.clearValue.copy(color);
-                colorOps.clearValueLinear.linear(color);
+            if (colorOps) {
+                if (color) {
+                    colorOps.clearValue.copy(color);
+                    colorOps.clearValueLinear.linear(color);
+                }
+                colorOps.clear = !!color;
             }
-            colorOps.clear = !!color;
         }
     }
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -5,6 +5,7 @@ import { Color } from '../../../core/math/color.js';
 import {
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL,
     CULLFACE_NONE,
+    isIntegerPixelFormat,
     FILTER_NEAREST, FILTER_LINEAR, FILTER_NEAREST_MIPMAP_NEAREST, FILTER_NEAREST_MIPMAP_LINEAR,
     FILTER_LINEAR_MIPMAP_NEAREST, FILTER_LINEAR_MIPMAP_LINEAR,
     FUNC_ALWAYS,
@@ -62,6 +63,18 @@ const _attachmentBlendState = new BlendState();
 
 // maximum number of color attachments a BlendState can describe
 const maxBlendAttachments = 8;
+
+// reused storage for the clear color of an individual attachment, to avoid allocations
+const _attachmentClearValue = new Float32Array(4);
+
+// reused options for the render pass clears, to avoid allocations. The fields not covered by the
+// flags are ignored by the clear call.
+const _clearOptions = {
+    flags: 0,
+    color: [0, 0, 0, 1],
+    depth: 1,
+    stencil: 0
+};
 
 /**
  * Returns the number of channels for 8-bit normalized formats that require RGBA readback.
@@ -1390,32 +1403,67 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.setViewport(0, 0, width, height);
         this.setScissor(0, 0, width, height);
 
-        // clear the render target
-        const colorOps = renderPass.colorOps;
+        // set up the clear of the depth and stencil, which are shared by all color attachments
         const depthStencilOps = renderPass.depthStencilOps;
-        if (colorOps?.clear || depthStencilOps.clearDepth || depthStencilOps.clearStencil) {
+        let clearFlags = 0;
 
-            let clearFlags = 0;
-            const clearOptions = {};
+        if (depthStencilOps.clearDepth) {
+            clearFlags |= CLEARFLAG_DEPTH;
+            _clearOptions.depth = depthStencilOps.clearDepthValue;
+        }
 
-            if (colorOps?.clear) {
-                clearFlags |= CLEARFLAG_COLOR;
-                clearOptions.color = [colorOps.clearValue.r, colorOps.clearValue.g, colorOps.clearValue.b, colorOps.clearValue.a];
+        if (depthStencilOps.clearStencil) {
+            clearFlags |= CLEARFLAG_STENCIL;
+            _clearOptions.stencil = depthStencilOps.clearStencilValue;
+        }
+
+        // a single color attachment is cleared by the same clear call
+        const colorBufferCount = rt._colorBuffers?.length ?? 0;
+        const colorOps = renderPass.colorOps;
+        if (colorBufferCount <= 1 && colorOps?.clear) {
+            clearFlags |= CLEARFLAG_COLOR;
+            const { clearValue } = colorOps;
+            const color = _clearOptions.color;
+            color[0] = clearValue.r;
+            color[1] = clearValue.g;
+            color[2] = clearValue.b;
+            color[3] = clearValue.a;
+        }
+
+        if (clearFlags !== 0) {
+            _clearOptions.flags = clearFlags;
+            this.clear(_clearOptions);
+        }
+
+        // Multiple color attachments are cleared individually using clearBufferfv, as the
+        // non-indexed gl.clear applies a single clear color to all draw buffers. This applies
+        // their own clear colors, and preserves the content of the attachments which do not
+        // clear. Note that clearBufferfv is affected by the color write masks, including the
+        // per-attachment ones, and so these are reset first.
+        if (colorBufferCount > 1) {
+            const gl = this.gl;
+            const { colorArrayOps } = renderPass;
+            let writeMasksReset = false;
+            for (let i = 0; i < colorBufferCount; i++) {
+                const colorOps = colorArrayOps[i];
+                if (colorOps?.clear) {
+
+                    Debug.assert(!isIntegerPixelFormat(rt._colorBuffers[i].format),
+                        'Clearing an integer color attachment of a render pass is not supported.', rt);
+
+                    if (!writeMasksReset) {
+                        this.setBlendState(BlendState.NOBLEND);
+                        writeMasksReset = true;
+                    }
+
+                    const { clearValue } = colorOps;
+                    _attachmentClearValue[0] = clearValue.r;
+                    _attachmentClearValue[1] = clearValue.g;
+                    _attachmentClearValue[2] = clearValue.b;
+                    _attachmentClearValue[3] = clearValue.a;
+                    gl.clearBufferfv(gl.COLOR, i, _attachmentClearValue);
+                }
             }
-
-            if (depthStencilOps.clearDepth) {
-                clearFlags |= CLEARFLAG_DEPTH;
-                clearOptions.depth = depthStencilOps.clearDepthValue;
-            }
-
-            if (depthStencilOps.clearStencil) {
-                clearFlags |= CLEARFLAG_STENCIL;
-                clearOptions.stencil = depthStencilOps.clearStencilValue;
-            }
-
-            // clear it
-            clearOptions.flags = clearFlags;
-            this.clear(clearOptions);
         }
 
         Debug.call(() => {

--- a/test/platform/graphics/render-pass.test.mjs
+++ b/test/platform/graphics/render-pass.test.mjs
@@ -1,0 +1,111 @@
+import { expect } from 'chai';
+
+import { Color } from '../../../src/core/math/color.js';
+import { PIXELFORMAT_RGBA8 } from '../../../src/platform/graphics/constants.js';
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+import { RenderPass } from '../../../src/platform/graphics/render-pass.js';
+import { RenderTarget } from '../../../src/platform/graphics/render-target.js';
+import { Texture } from '../../../src/platform/graphics/texture.js';
+
+describe('RenderPass', function () {
+
+    /** @type {NullGraphicsDevice} */
+    let device;
+
+    /** @type {RenderTarget} */
+    let renderTarget;
+
+    /** @type {RenderPass} */
+    let renderPass;
+
+    const createTexture = name => new Texture(device, {
+        name: name,
+        width: 4,
+        height: 4,
+        format: PIXELFORMAT_RGBA8,
+        mipmaps: false
+    });
+
+    beforeEach(function () {
+        device = new NullGraphicsDevice({ width: 100, height: 100 });
+        renderTarget = new RenderTarget({
+            colorBuffers: [createTexture('color0'), createTexture('color1')],
+            depth: false
+        });
+        renderPass = new RenderPass(device);
+        renderPass.init(renderTarget);
+    });
+
+    afterEach(function () {
+        renderTarget.destroyTextureBuffers();
+        renderTarget.destroy();
+        device.destroy();
+        device = null;
+    });
+
+    describe('#setClearColor', function () {
+
+        const red = new Color(1, 0.5, 0.25, 1);
+        const blue = new Color(0.25, 0.5, 1, 1);
+
+        it('allocates one color ops entry per attachment', function () {
+            expect(renderPass.colorArrayOps.length).to.equal(2);
+            expect(renderPass.colorArrayOps[0].clear).to.equal(false);
+            expect(renderPass.colorArrayOps[1].clear).to.equal(false);
+        });
+
+        it('applies the color to all attachments when no index is specified', function () {
+            renderPass.setClearColor(red);
+
+            for (let i = 0; i < 2; i++) {
+                const ops = renderPass.colorArrayOps[i];
+                expect(ops.clear).to.equal(true);
+                expect(ops.clearValue.equals(red)).to.equal(true);
+            }
+        });
+
+        it('applies the color to a single attachment when an index is specified', function () {
+            renderPass.setClearColor(red, 1);
+
+            expect(renderPass.colorArrayOps[0].clear).to.equal(false);
+            expect(renderPass.colorArrayOps[1].clear).to.equal(true);
+            expect(renderPass.colorArrayOps[1].clearValue.equals(red)).to.equal(true);
+        });
+
+        it('supports a different color per attachment', function () {
+            renderPass.setClearColor(red, 0);
+            renderPass.setClearColor(blue, 1);
+
+            expect(renderPass.colorArrayOps[0].clearValue.equals(red)).to.equal(true);
+            expect(renderPass.colorArrayOps[1].clearValue.equals(blue)).to.equal(true);
+        });
+
+        it('keeps the linear clear value in sync', function () {
+            renderPass.setClearColor(red, 1);
+
+            const linear = new Color().linear(red);
+            expect(renderPass.colorArrayOps[1].clearValueLinear.equals(linear)).to.equal(true);
+        });
+
+        it('disables the clear of a single attachment when passing undefined with an index', function () {
+            renderPass.setClearColor(red);
+            renderPass.setClearColor(undefined, 1);
+
+            expect(renderPass.colorArrayOps[0].clear).to.equal(true);
+            expect(renderPass.colorArrayOps[1].clear).to.equal(false);
+
+            // the previously set color is preserved, only the clear flag is disabled
+            expect(renderPass.colorArrayOps[1].clearValue.equals(red)).to.equal(true);
+        });
+
+        it('disables the clear of all attachments when passing undefined without an index', function () {
+            renderPass.setClearColor(red);
+            renderPass.setClearColor(undefined);
+
+            expect(renderPass.colorArrayOps[0].clear).to.equal(false);
+            expect(renderPass.colorArrayOps[1].clear).to.equal(false);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Allows each color attachment of a multiple-render-target render pass to use its own clear color and clear flag. Previously WebGL cleared all attachments using a single gl.clear call, which applied attachment 0's clear color to every attachment, and ignored the per-attachment clear flags. WebGPU already supported this.

**Changes:**
- `RenderPass#setClearColor` accepts an optional attachment index. When not specified, all attachments are modified as before.
- On WebGL, a render pass with multiple color attachments now clears them individually using clearBufferfv, applying each attachment's own clear color and preserving the content of attachments which do not clear. Depth and stencil are cleared by the existing path, and the single-attachment path is unchanged.
- The render pass clear no longer allocates the clear options per frame on WebGL.

**API Changes:**
- `RenderPass#setClearColor(color, index)` - new optional index parameter, in 0 to 7 range, selecting the color attachment to modify.

Note that clearing integer format color attachments is not supported and asserts in debug builds - this can be added using clearBufferiv/clearBufferuiv when needed.

**Examples:**
- The hidden `test/independent-blending` example now also demonstrates per-attachment clear colors - a standalone clear-only render pass clears each attachment to a different color, visible as the border around each panel, and the camera renders on top without clearing.