### PR TITLE
Add clear support for integer format color attachments

### DIFF
--- a/examples/src/examples/test/independent-blending.example.mjs
+++ b/examples/src/examples/test/independent-blending.example.mjs
@@ -14,6 +14,10 @@
 // attachment 0 to dark blue and attachment 1 to dark green, visible as the border around each
 // panel, and the camera renders on top without clearing.
 //
+// Additionally, an unsigned integer format render target is cleared to a marker value, verifying
+// the clear support of integer formats. The small indicator panel below the two attachments
+// samples it and shows green when it contains the expected value, and red otherwise.
+//
 // When the device does not support independent blending (the OES_draw_buffers_indexed extension is
 // unavailable on WebGL2), the blend state of attachment 0 is used for all attachments and the two
 // halves render identically.
@@ -35,14 +39,18 @@ import {
     FILLMODE_FILL_WINDOW,
     FILTER_NEAREST,
     Layer,
+    PIXELFORMAT_R32U,
     PIXELFORMAT_RGBA8,
     PROJECTION_ORTHOGRAPHIC,
     RESOLUTION_AUTO,
     RenderComponentSystem,
     RenderPass,
     RenderTarget,
+    SEMANTIC_POSITION,
+    SEMANTIC_TEXCOORD0,
     SHADERLANGUAGE_GLSL,
     SHADERLANGUAGE_WGSL,
+    ShaderMaterial,
     StandardMaterial,
     Texture,
     createGraphicsDevice
@@ -197,8 +205,44 @@ clearPass.init(renderTarget);
 clearPass.setClearColor(new Color(0, 0, 0.25, 1), 0);
 clearPass.setClearColor(new Color(0, 0.25, 0, 1), 1);
 
-// execute the clear before the cameras render each frame
-app.on('prerender', () => clearPass.render());
+// ------ Clear of an unsigned integer format render target ------
+
+// the expected marker value the indicator panel tests for
+const UINT_CLEAR_VALUE = 12648430;
+
+const uintTexture = new Texture(device, {
+    name: 'uintClear',
+    width: 4,
+    height: 4,
+    format: PIXELFORMAT_R32U,
+    mipmaps: false,
+    minFilter: FILTER_NEAREST,
+    magFilter: FILTER_NEAREST
+});
+
+const uintRenderTarget = new RenderTarget({
+    name: 'UintRT',
+    colorBuffer: uintTexture,
+    depth: false
+});
+
+app.on('destroy', () => {
+    uintRenderTarget.destroyTextureBuffers();
+    uintRenderTarget.destroy();
+});
+
+// a clear-only render pass storing the marker value in the texture. For integer formats, the
+// clear color components are the raw integer values.
+const uintClearPass = new RenderPass(device);
+uintClearPass.name = 'UintClear';
+uintClearPass.init(uintRenderTarget);
+uintClearPass.setClearColor(new Color(UINT_CLEAR_VALUE, 0, 0, 0));
+
+// execute the clears before the cameras render each frame
+app.on('prerender', () => {
+    clearPass.render();
+    uintClearPass.render();
+});
 
 // The camera renders on top of the cleared attachments, without clearing the color itself. It
 // renders before the main camera, so that the displayed attachments contain this frame's result.
@@ -248,6 +292,81 @@ const createDisplay = (name, texture, x) => {
 createDisplay('Display 0', attachment0, -PANEL_X);
 createDisplay('Display 1', attachment1, PANEL_X);
 
+// ------ Indicator panel testing the integer clear value ------
+
+// the indicator sits below the two panels
+const INDICATOR_SIZE = 0.25;
+const INDICATOR_Y = -(PANEL_SIZE + INDICATOR_SIZE) * 0.5 - 0.1;
+
+// samples the unsigned integer texture and shows green when it contains the expected clear value
+const uintMaterial = new ShaderMaterial({
+    uniqueName: 'UintClearIndicator',
+    vertexGLSL: /* glsl */ `
+        attribute vec4 aPosition;
+        attribute vec2 aUv0;
+        uniform mat4 matrix_model;
+        uniform mat4 matrix_viewProjection;
+        varying vec2 vUv0;
+        void main() {
+            vUv0 = aUv0;
+            gl_Position = matrix_viewProjection * matrix_model * aPosition;
+        }
+    `,
+    fragmentGLSL: /* glsl */ `
+        varying vec2 vUv0;
+        uniform highp usampler2D uintMap;
+        void main() {
+            uint value = texture(uintMap, vUv0).r;
+            gl_FragColor = value == ${UINT_CLEAR_VALUE}u ? vec4(0.2, 0.55, 0.25, 1.0) : vec4(0.7, 0.15, 0.15, 1.0);
+        }
+    `,
+    vertexWGSL: /* wgsl */ `
+        attribute aPosition: vec4f;
+        attribute aUv0: vec2f;
+        uniform matrix_model: mat4x4f;
+        uniform matrix_viewProjection: mat4x4f;
+        varying vUv0: vec2f;
+        @vertex
+        fn vertexMain(input: VertexInput) -> VertexOutput {
+            var output: VertexOutput;
+            output.position = uniform.matrix_viewProjection * uniform.matrix_model * input.aPosition;
+            output.vUv0 = input.aUv0;
+            return output;
+        }
+    `,
+    fragmentWGSL: /* wgsl */ `
+        varying vUv0: vec2f;
+        var uintMap: texture_2d<u32>;
+        @fragment
+        fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+            var output: FragmentOutput;
+            let dims = vec2i(textureDimensions(uintMap));
+            let coords = min(vec2i(input.vUv0 * vec2f(dims)), dims - vec2i(1));
+            let value = textureLoad(uintMap, coords, 0).r;
+            output.color = select(vec4f(0.7, 0.15, 0.15, 1.0), vec4f(0.2, 0.55, 0.25, 1.0), value == ${UINT_CLEAR_VALUE}u);
+            return output;
+        }
+    `,
+    attributes: {
+        aPosition: SEMANTIC_POSITION,
+        aUv0: SEMANTIC_TEXCOORD0
+    }
+});
+uintMaterial.setParameter('uintMap', uintTexture);
+uintMaterial.cull = CULLFACE_NONE;
+uintMaterial.update();
+
+const indicator = new Entity('Uint Clear Indicator');
+indicator.addComponent('render', {
+    type: 'plane',
+    material: uintMaterial,
+    layers: [worldLayer.id]
+});
+indicator.setLocalPosition(0, INDICATOR_Y, 0);
+indicator.setLocalEulerAngles(90, 0, 0);
+indicator.setLocalScale(INDICATOR_SIZE, 1, INDICATOR_SIZE);
+app.root.addChild(indicator);
+
 const camera = new Entity('Camera');
 camera.addComponent('camera', {
     clearColor: new Color(0.02, 0.02, 0.02),
@@ -258,16 +377,16 @@ camera.addComponent('camera', {
 camera.setLocalPosition(0, 0, 5);
 app.root.addChild(camera);
 
-// Keep both panels fully visible at any canvas aspect ratio. An orthographic camera sees a
-// 2 * orthoHeight tall and 2 * orthoHeight * aspect wide area, so the height is chosen as whichever
-// of the two constraints is tighter, with a small margin around the content.
+// Keep the panels and the indicator fully visible at any canvas aspect ratio. An orthographic
+// camera sees a 2 * orthoHeight tall and 2 * orthoHeight * aspect wide area, so the height is
+// chosen as whichever of the two constraints is tighter, with a small margin around the content.
 const contentWidth = PANEL_SIZE * 2 + PANEL_GAP;
-const contentHeight = PANEL_SIZE;
+const contentHalfHeight = -INDICATOR_Y + INDICATOR_SIZE * 0.5;
 const MARGIN = 1.06;
 
 const fitCamera = () => {
     const aspect = device.width / device.height;
-    camera.camera.orthoHeight = Math.max(contentWidth / (2 * aspect), contentHeight * 0.5) * MARGIN;
+    camera.camera.orthoHeight = Math.max(contentWidth / (2 * aspect), contentHalfHeight) * MARGIN;
 };
 
 fitCamera();

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -10,6 +10,42 @@ import { FramePass } from './frame-pass.js';
  * @import { Texture } from './texture.js'
  */
 
+/**
+ * Reports the clear values of integer format color attachments which are not representable in
+ * their format. The components of the clear color of an integer format attachment are the raw
+ * integer values, and so a non-integer value would be silently truncated by WebGL, and generates a
+ * validation error on WebGPU.
+ *
+ * @param {RenderPass} renderPass - The render pass to validate.
+ * @ignore
+ */
+const validateClearValues = (renderPass) => {
+    Debug.call(() => {
+
+        const renderTarget = renderPass.renderTarget;
+        const count = renderPass.colorArrayOps.length;
+        for (let i = 0; i < count; i++) {
+
+            const colorOps = renderPass.colorArrayOps[i];
+            if (!colorOps?.clear) {
+                continue;
+            }
+
+            const formatInfo = pixelFormatInfo.get(renderTarget?.getColorBuffer(i)?.format);
+            if (formatInfo?.isInt !== true && formatInfo?.isUint !== true) {
+                continue;
+            }
+
+            const { r, g, b, a } = colorOps.clearValue;
+            const integers = Number.isInteger(r) && Number.isInteger(g) && Number.isInteger(b) && Number.isInteger(a);
+            const unsigned = formatInfo.isUint !== true || (r >= 0 && g >= 0 && b >= 0 && a >= 0);
+            if (!integers || !unsigned) {
+                Debug.errorOnce(`Render pass '${renderPass.name}' clears the integer format color attachment ${i} (${formatInfo.name}) of render target '${renderTarget?.name}' to [${r}, ${g}, ${b}, ${a}], but the components must be ${formatInfo.isUint ? 'non-negative ' : ''}integers.`, renderPass);
+            }
+        }
+    });
+};
+
 class ColorAttachmentOps {
     /**
      * A color used to clear the color attachment when the clear is enabled, specified in sRGB space.
@@ -414,4 +450,4 @@ class RenderPass extends FramePass {
     // #endif
 }
 
-export { RenderPass };
+export { RenderPass, validateClearValues };

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -5,7 +5,7 @@ import { Color } from '../../../core/math/color.js';
 import {
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL,
     CULLFACE_NONE,
-    isIntegerPixelFormat,
+    isIntegerPixelFormat, pixelFormatInfo,
     FILTER_NEAREST, FILTER_LINEAR, FILTER_NEAREST_MIPMAP_NEAREST, FILTER_NEAREST_MIPMAP_LINEAR,
     FILTER_LINEAR_MIPMAP_NEAREST, FILTER_LINEAR_MIPMAP_LINEAR,
     FUNC_ALWAYS,
@@ -64,8 +64,11 @@ const _attachmentBlendState = new BlendState();
 // maximum number of color attachments a BlendState can describe
 const maxBlendAttachments = 8;
 
-// reused storage for the clear color of an individual attachment, to avoid allocations
+// reused storage for the clear color of an individual attachment, to avoid allocations. The typed
+// array matching the format class of the attachment is used.
 const _attachmentClearValue = new Float32Array(4);
+const _attachmentClearValueInt = new Int32Array(4);
+const _attachmentClearValueUint = new Uint32Array(4);
 
 // reused options for the render pass clears, to avoid allocations. The fields not covered by the
 // flags are ignored by the clear call.
@@ -1417,10 +1420,14 @@ class WebglGraphicsDevice extends GraphicsDevice {
             _clearOptions.stencil = depthStencilOps.clearStencilValue;
         }
 
-        // a single color attachment is cleared by the same clear call
+        // A single color attachment of a float / normalized format is cleared by the same clear
+        // call. Integer formats cannot be cleared by gl.clear (the results are undefined), and use
+        // the per-attachment path below instead.
         const colorBufferCount = rt._colorBuffers?.length ?? 0;
         const colorOps = renderPass.colorOps;
-        if (colorBufferCount <= 1 && colorOps?.clear) {
+        const useClearBuffers = colorBufferCount > 1 ||
+            (colorBufferCount === 1 && isIntegerPixelFormat(rt._colorBuffers[0].format));
+        if (!useClearBuffers && colorOps?.clear) {
             clearFlags |= CLEARFLAG_COLOR;
             const { clearValue } = colorOps;
             const color = _clearOptions.color;
@@ -1435,12 +1442,13 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.clear(_clearOptions);
         }
 
-        // Multiple color attachments are cleared individually using clearBufferfv, as the
-        // non-indexed gl.clear applies a single clear color to all draw buffers. This applies
-        // their own clear colors, and preserves the content of the attachments which do not
-        // clear. Note that clearBufferfv is affected by the color write masks, including the
-        // per-attachment ones, and so these are reset first.
-        if (colorBufferCount > 1) {
+        // The remaining color attachments are cleared individually using clearBuffer functions,
+        // as the non-indexed gl.clear applies a single clear color to all draw buffers, and does
+        // not support integer formats. This applies their own clear colors, uses the clearBuffer
+        // function matching the format class of each attachment, and preserves the content of the
+        // attachments which do not clear. Note that the clearBuffer functions are affected by the
+        // color write masks, including the per-attachment ones, and so these are reset first.
+        if (useClearBuffers) {
             const gl = this.gl;
             const { colorArrayOps } = renderPass;
             let writeMasksReset = false;
@@ -1448,20 +1456,27 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 const colorOps = colorArrayOps[i];
                 if (colorOps?.clear) {
 
-                    Debug.assert(!isIntegerPixelFormat(rt._colorBuffers[i].format),
-                        'Clearing an integer color attachment of a render pass is not supported.', rt);
-
                     if (!writeMasksReset) {
                         this.setBlendState(BlendState.NOBLEND);
                         writeMasksReset = true;
                     }
 
                     const { clearValue } = colorOps;
-                    _attachmentClearValue[0] = clearValue.r;
-                    _attachmentClearValue[1] = clearValue.g;
-                    _attachmentClearValue[2] = clearValue.b;
-                    _attachmentClearValue[3] = clearValue.a;
-                    gl.clearBufferfv(gl.COLOR, i, _attachmentClearValue);
+                    const formatInfo = pixelFormatInfo.get(rt._colorBuffers[i].format);
+                    const clearValueArray = formatInfo?.isUint ? _attachmentClearValueUint :
+                        (formatInfo?.isInt ? _attachmentClearValueInt : _attachmentClearValue);
+                    clearValueArray[0] = clearValue.r;
+                    clearValueArray[1] = clearValue.g;
+                    clearValueArray[2] = clearValue.b;
+                    clearValueArray[3] = clearValue.a;
+
+                    if (formatInfo?.isUint) {
+                        gl.clearBufferuiv(gl.COLOR, i, clearValueArray);
+                    } else if (formatInfo?.isInt) {
+                        gl.clearBufferiv(gl.COLOR, i, clearValueArray);
+                    } else {
+                        gl.clearBufferfv(gl.COLOR, i, clearValueArray);
+                    }
                 }
             }
         }

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -45,6 +45,7 @@ import { WebglUploadStream } from './webgl-upload-stream.js';
 import { WebglXrBridge } from './webgl-xr-bridge.js';
 import { WebglXrMsaaCopy } from './webgl-xr-msaa-copy.js';
 import { BlendState } from '../blend-state.js';
+import { validateClearValues } from '../render-pass.js';
 import { DepthState } from '../depth-state.js';
 import { StencilParameters } from '../stencil-parameters.js';
 import { WebglGpuProfiler } from './webgl-gpu-profiler.js';
@@ -1451,6 +1452,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
         if (useClearBuffers) {
             const gl = this.gl;
             const { colorArrayOps } = renderPass;
+
+            // integer formats require the clear value components to be integers representable in
+            // the format, as they would otherwise be silently truncated by the typed array
+            Debug.call(() => validateClearValues(renderPass));
+
             let writeMasksReset = false;
             for (let i = 0; i < colorBufferCount; i++) {
                 const colorOps = colorArrayOps[i];

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -1,5 +1,6 @@
 import { Debug, DebugHelper } from '../../../core/debug.js';
 import { StringIds } from '../../../core/string-ids.js';
+import { pixelFormatInfo } from '../constants.js';
 import { getMultisampledTextureCache } from '../multi-sampled-texture-cache.js';
 import { WebgpuDebug } from './webgpu-debug.js';
 
@@ -540,6 +541,22 @@ class WebgpuRenderTarget {
             colorAttachment.clearValue = srgb ? colorOps.clearValueLinear : colorOps.clearValue;
             colorAttachment.loadOp = colorOps.clear ? 'clear' : 'load';
             colorAttachment.storeOp = colorOps.store ? 'store' : 'discard';
+
+            // integer formats require the clear value components to be integers representable in
+            // the format, otherwise WebGPU generates a validation error
+            Debug.call(() => {
+                if (colorOps.clear) {
+                    const formatInfo = pixelFormatInfo.get(renderTarget.getColorBuffer(i)?.format);
+                    if (formatInfo?.isInt === true || formatInfo?.isUint === true) {
+                        const { r, g, b, a } = colorOps.clearValue;
+                        const integers = Number.isInteger(r) && Number.isInteger(g) && Number.isInteger(b) && Number.isInteger(a);
+                        const unsigned = formatInfo.isUint !== true || (r >= 0 && g >= 0 && b >= 0 && a >= 0);
+                        if (!integers || !unsigned) {
+                            Debug.errorOnce(`Render target '${renderTarget.name}' has an integer format color attachment ${i} (${formatInfo.name}), and its clear value components must be ${formatInfo.isUint ? 'non-negative ' : ''}integers, but are [${r}, ${g}, ${b}, ${a}].`);
+                        }
+                    }
+                }
+            });
 
             // a transient (memoryless) attachment must be cleared on load and discarded on store.
             // The frame-graph store-on-no-clear optimization can flip these post-authoring (e.g. a

--- a/src/platform/graphics/webgpu/webgpu-render-target.js
+++ b/src/platform/graphics/webgpu/webgpu-render-target.js
@@ -1,7 +1,7 @@
 import { Debug, DebugHelper } from '../../../core/debug.js';
 import { StringIds } from '../../../core/string-ids.js';
-import { pixelFormatInfo } from '../constants.js';
 import { getMultisampledTextureCache } from '../multi-sampled-texture-cache.js';
+import { validateClearValues } from '../render-pass.js';
 import { WebgpuDebug } from './webgpu-debug.js';
 
 /**
@@ -533,6 +533,10 @@ class WebgpuRenderTarget {
 
         Debug.assert(this.renderPassDescriptor);
 
+        // integer formats require the clear value components to be integers representable in the
+        // format, otherwise WebGPU generates a validation error
+        Debug.call(() => validateClearValues(renderPass));
+
         const count = this.renderPassDescriptor.colorAttachments?.length ?? 0;
         for (let i = 0; i < count; ++i) {
             const colorAttachment = this.renderPassDescriptor.colorAttachments[i];
@@ -541,22 +545,6 @@ class WebgpuRenderTarget {
             colorAttachment.clearValue = srgb ? colorOps.clearValueLinear : colorOps.clearValue;
             colorAttachment.loadOp = colorOps.clear ? 'clear' : 'load';
             colorAttachment.storeOp = colorOps.store ? 'store' : 'discard';
-
-            // integer formats require the clear value components to be integers representable in
-            // the format, otherwise WebGPU generates a validation error
-            Debug.call(() => {
-                if (colorOps.clear) {
-                    const formatInfo = pixelFormatInfo.get(renderTarget.getColorBuffer(i)?.format);
-                    if (formatInfo?.isInt === true || formatInfo?.isUint === true) {
-                        const { r, g, b, a } = colorOps.clearValue;
-                        const integers = Number.isInteger(r) && Number.isInteger(g) && Number.isInteger(b) && Number.isInteger(a);
-                        const unsigned = formatInfo.isUint !== true || (r >= 0 && g >= 0 && b >= 0 && a >= 0);
-                        if (!integers || !unsigned) {
-                            Debug.errorOnce(`Render target '${renderTarget.name}' has an integer format color attachment ${i} (${formatInfo.name}), and its clear value components must be ${formatInfo.isUint ? 'non-negative ' : ''}integers, but are [${r}, ${g}, ${b}, ${a}].`);
-                        }
-                    }
-                }
-            });
 
             // a transient (memoryless) attachment must be cleared on load and discarded on store.
             // The frame-graph store-on-no-clear optimization can flip these post-authoring (e.g. a


### PR DESCRIPTION
Allows render passes to clear integer format color attachments. Previously this was not supported - on WebGL, gl.clear has undefined results on integer buffers, which is also the reason the Picker encodes ids into an RGBA8 texture instead of using a uint32 format. For integer formats, the components of the clear color are the raw integer values.

**Changes:**
- On WebGL, integer format color attachments are cleared using clearBufferiv / clearBufferuiv, matching the format class of each attachment. A single integer attachment uses this path as well, as it cannot be cleared by gl.clear.
- On WebGPU, which supports this natively, a debug-time validation was added, reporting an engine error when the clear color components of an integer attachment are not integers (or are negative for unsigned formats), instead of a WebGPU validation failure.

**Examples:**
- The hidden `test/independent-blending` example gained an indicator panel - an R32U render target is cleared to a marker value by a clear-only render pass, and the panel samples it, showing green when it contains the expected value.

Part of #5356. This also unblocks migrating the Picker to a uint32 format, which additionally needs uint fragment outputs for the pick shader variants.