### PR TITLE
Fix component event leak when removing an enabled component

### DIFF
--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -2613,6 +2613,12 @@ class ElementComponent extends Component {
     }
 
     onBeforeRemove() {
+        // removing a component does not disable it first, so undo what onEnable set up. This runs
+        // before the image / text elements are destroyed below, as onDisable uses them.
+        if (this.enabled && this.entity.enabled) {
+            this.onDisable();
+        }
+
         this.entity.off('insert', this._onInsert, this);
         this._unpatch();
         if (this._image) {

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -819,13 +819,20 @@ class GSplatComponent extends Component {
     }
 
     onBeforeRemove() {
+        // removing a component does not disable it first, so undo what onEnable set up
+        if (this.enabled && this.entity.enabled) {
+            this.onDisable();
+        }
+
         this.destroyInstance();
 
         this.asset = null;
         this._assetReference.id = null;
 
         this.entity.off('remove', this.onRemoveChild, this);
+        this.entity.off('removehierarchy', this.onRemoveChild, this);
         this.entity.off('insert', this.onInsertChild, this);
+        this.entity.off('inserthierarchy', this.onInsertChild, this);
     }
 
     onLayersChanged(oldComp, newComp) {

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -814,13 +814,20 @@ class ModelComponent extends Component {
     }
 
     onBeforeRemove() {
+        // removing a component does not disable it first, so undo what onEnable set up
+        if (this.enabled && this.entity.enabled) {
+            this.onDisable();
+        }
+
         this.asset = null;
         this.model = null;
         this.materialAsset = null;
         this._unsetMaterialEvents();
 
         this.entity.off('remove', this.onRemoveChild, this);
+        this.entity.off('removehierarchy', this.onRemoveChild, this);
         this.entity.off('insert', this.onInsertChild, this);
+        this.entity.off('inserthierarchy', this.onInsertChild, this);
     }
 
     /**

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -812,6 +812,11 @@ class RenderComponent extends Component {
     }
 
     onBeforeRemove() {
+        // removing a component does not disable it first, so undo what onEnable set up
+        if (this.enabled && this.entity.enabled) {
+            this.onDisable();
+        }
+
         this.destroyMeshInstances();
 
         this.asset = null;
@@ -824,7 +829,9 @@ class RenderComponent extends Component {
         }
 
         this.entity.off('remove', this.onRemoveChild, this);
+        this.entity.off('removehierarchy', this.onRemoveChild, this);
         this.entity.off('insert', this.onInsertChild, this);
+        this.entity.off('inserthierarchy', this.onInsertChild, this);
     }
 
     onLayersChanged(oldComp, newComp) {

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -805,6 +805,12 @@ class SpriteComponent extends Component {
     }
 
     onBeforeRemove() {
+        // removing a component does not disable it first, so undo what onEnable set up. This runs
+        // before the clips are torn down below, as onDisable stops the current clip.
+        if (this.enabled && this.entity.enabled) {
+            this.onDisable();
+        }
+
         this._currentClip = null;
 
         if (this._defaultClip) {

--- a/test/framework/components/component-teardown.test.mjs
+++ b/test/framework/components/component-teardown.test.mjs
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+
+import { Entity } from '../../../src/framework/entity.js';
+import { LayerComposition } from '../../../src/scene/composition/layer-composition.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+/**
+ * Components that subscribe to Scene / LayerComposition events in their onEnable. Removing a
+ * component does not disable it first (ComponentSystem#removeComponent only fires 'beforeremove'),
+ * so each of these has to unsubscribe in onBeforeRemove as well - otherwise the app-lifetime Scene
+ * and LayerComposition keep the removed component, and through it the entity, alive forever.
+ *
+ * Note the particlesystem component follows the same pattern, but its onEnable early-outs on the
+ * null graphics device (disableParticleSystem), so it cannot be covered here.
+ */
+const LAYER_SUBSCRIBERS = ['render', 'model', 'gsplat', 'sprite', 'element', 'camera', 'light'];
+
+describe('Component teardown', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    /**
+     * @returns {boolean} True if anything is subscribed to the scene / layer composition events
+     * that these components bind in onEnable.
+     */
+    const hasLayerSubscriptions = () => {
+        return app.scene.hasEvent('set:layers') ||
+            app.scene.layers.hasEvent('add') ||
+            app.scene.layers.hasEvent('remove');
+    };
+
+    LAYER_SUBSCRIBERS.forEach((type) => {
+        describe(`${type} component`, function () {
+
+            it('unsubscribes from scene and layer events when removed while enabled', function () {
+                const e = new Entity();
+                app.root.addChild(e);
+                e.addComponent(type);
+
+                // sanity check - the component did subscribe, so the test below is meaningful
+                expect(hasLayerSubscriptions()).to.equal(true);
+
+                e.removeComponent(type);
+
+                expect(hasLayerSubscriptions()).to.equal(false);
+            });
+
+            it('unsubscribes from scene and layer events when removed while disabled', function () {
+                const e = new Entity();
+                app.root.addChild(e);
+                e.addComponent(type);
+                e[type].enabled = false;
+
+                expect(hasLayerSubscriptions()).to.equal(false);
+
+                // must be a no-op rather than a second teardown
+                expect(() => e.removeComponent(type)).to.not.throw();
+
+                expect(hasLayerSubscriptions()).to.equal(false);
+            });
+
+            it('unsubscribes from scene and layer events when the entity is destroyed', function () {
+                const e = new Entity();
+                app.root.addChild(e);
+                e.addComponent(type);
+
+                e.destroy();
+
+                expect(hasLayerSubscriptions()).to.equal(false);
+            });
+
+            it('does not re-subscribe to a new layer composition after removal', function () {
+                const e = new Entity();
+                app.root.addChild(e);
+                e.addComponent(type);
+                e.removeComponent(type);
+
+                // a leaked 'set:layers' handler would run onLayersChanged on the removed
+                // component, subscribing it to every composition assigned from then on
+                const composition = new LayerComposition();
+                app.scene.layers = composition;
+
+                expect(composition.hasEvent('add')).to.equal(false);
+                expect(composition.hasEvent('remove')).to.equal(false);
+            });
+
+        });
+    });
+});

--- a/test/framework/components/render/component.test.mjs
+++ b/test/framework/components/render/component.test.mjs
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+
+import { Entity } from '../../../../src/framework/entity.js';
+import { BatchGroup } from '../../../../src/scene/batching/batch-group.js';
+import { LAYERID_WORLD } from '../../../../src/scene/constants.js';
+import { createApp } from '../../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
+
+describe('RenderComponent', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    describe('#onBeforeRemove', function () {
+
+        it('unsubscribes from all four entity hierarchy events', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('render', { type: 'box' });
+
+            expect(e.hasEvent('remove')).to.equal(true);
+            expect(e.hasEvent('removehierarchy')).to.equal(true);
+            expect(e.hasEvent('insert')).to.equal(true);
+            expect(e.hasEvent('inserthierarchy')).to.equal(true);
+
+            e.removeComponent('render');
+
+            expect(e.hasEvent('remove')).to.equal(false);
+            expect(e.hasEvent('removehierarchy')).to.equal(false);
+            expect(e.hasEvent('insert')).to.equal(false);
+            expect(e.hasEvent('inserthierarchy')).to.equal(false);
+        });
+
+        it('removes the entity from its batch group', function () {
+            const group = app.batcher.addGroup('test', false, 100);
+
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('render', { type: 'box', batchGroupId: group.id });
+
+            const nodes = app.batcher._batchGroups[group.id]._obj[BatchGroup.RENDER];
+            expect(nodes).to.include(e);
+
+            e.removeComponent('render');
+
+            expect(nodes).to.not.include(e);
+        });
+
+        it('removes the mesh instances from their layers', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('render', { type: 'box' });
+
+            const worldLayer = app.scene.layers.getLayerById(LAYERID_WORLD);
+            expect(worldLayer.meshInstances.length).to.equal(1);
+
+            e.removeComponent('render');
+
+            expect(worldLayer.meshInstances.length).to.equal(0);
+        });
+
+    });
+});


### PR DESCRIPTION
Fixes #9144.

`ComponentSystem#removeComponent` only fires `beforeremove` - it never disables the component. So anything a component subscribes to in `onEnable()` has to be torn down in `onBeforeRemove()` as well. Five components did not do this, leaking three subscriptions each:

| leaked subscription | owner | lifetime |
|---|---|---|
| `scene.on('set:layers')` | `Scene` | app |
| `layers.on('add')` | `LayerComposition` | app |
| `layers.on('remove')` | `LayerComposition` | app |

Each holds `scope = component`, and `component.entity` then keeps the entity and its subtree alive for the life of the app. The leaked `set:layers` handler also kept re-subscribing the dead component to every `LayerComposition` assigned from then on.

`entity.destroy()` was never affected, since `Entity#destroy` sets `enabled = false` on every component before removing them. Only the direct `entity.removeComponent(...)` / `system.removeComponent(entity)` path leaked.

**Changes:**
- `render`, `model`, `gsplat`, `sprite` and `element` components now undo their `onEnable` state in `onBeforeRemove`, following the existing `camera` / `light` precedent:
  ```js
  if (this.enabled && this.entity.enabled) {
      this.onDisable();
  }
  ```
  The guard mirrors the condition under which `onEnable` ran, so an already-disabled component is not torn down twice, and no `disable` / `state` events are fired. It runs first in the method, as sprite's and element's `onDisable` use state that the rest of `onBeforeRemove` destroys.
- `render`, `model` and `gsplat` now also unsubscribe from `removehierarchy` and `inserthierarchy`. Their constructors subscribe to four entity hierarchy events but only two were being unsubscribed.
- As a side effect of routing through `onDisable`, an entity with a `batchGroupId` is now removed from its batch group when its component is removed - previously the batch group kept the entity node after the component was gone.
- New `test/framework/components/component-teardown.test.mjs` covering all seven components with layer subscriptions across removal while enabled, removal while disabled, entity destruction, and layer composition reassignment after removal. `camera` and `light` act as the controls.
- New `test/framework/components/render/component.test.mjs` covering the hierarchy events, the batch group and layer removal.

`particlesystem` follows the same pattern and is already correct (it sets `this.enabled = false`), but cannot be covered by the tests because its `onEnable` early-outs on the null graphics device.