### PR TITLE
Fix layer event leak when the scene layer composition is replaced

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1198,10 +1198,12 @@ class CameraComponent extends Component {
      */
     onLayersChanged(oldComp, newComp) {
         this.addCameraToLayers();
-        oldComp.off('add', this.onLayerAdded, this);
-        oldComp.off('remove', this.onLayerRemoved, this);
-        newComp.on('add', this.onLayerAdded, this);
-        newComp.on('remove', this.onLayerRemoved, this);
+
+        // store the new handles, so that onDisable can unsubscribe from the current composition
+        this._evtLayerAdded?.off();
+        this._evtLayerAdded = newComp.on('add', this.onLayerAdded, this);
+        this._evtLayerRemoved?.off();
+        this._evtLayerRemoved = newComp.on('remove', this.onLayerRemoved, this);
     }
 
     /**

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -2524,11 +2524,18 @@ class ElementComponent extends Component {
     }
 
     onLayersChanged(oldComp, newComp) {
-        this.addModelToLayers(this._image ? this._image._renderable.model : this._text._model);
-        oldComp.off('add', this.onLayerAdded, this);
-        oldComp.off('remove', this.onLayerRemoved, this);
-        newComp.on('add', this.onLayerAdded, this);
-        newComp.on('remove', this.onLayerRemoved, this);
+        // group elements have neither an image nor a text element
+        if (this._image) {
+            this.addModelToLayers(this._image._renderable.model);
+        } else if (this._text) {
+            this.addModelToLayers(this._text._model);
+        }
+
+        // store the new handles, so that onDisable can unsubscribe from the current composition
+        this._evtLayerAdded?.off();
+        this._evtLayerAdded = newComp.on('add', this.onLayerAdded, this);
+        this._evtLayerRemoved?.off();
+        this._evtLayerRemoved = newComp.on('remove', this.onLayerRemoved, this);
     }
 
     onLayerAdded(layer) {

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -830,10 +830,12 @@ class GSplatComponent extends Component {
 
     onLayersChanged(oldComp, newComp) {
         this.addToLayers();
-        oldComp.off('add', this.onLayerAdded, this);
-        oldComp.off('remove', this.onLayerRemoved, this);
-        newComp.on('add', this.onLayerAdded, this);
-        newComp.on('remove', this.onLayerRemoved, this);
+
+        // store the new handles, so that onDisable can unsubscribe from the current composition
+        this._evtLayerAdded?.off();
+        this._evtLayerAdded = newComp.on('add', this.onLayerAdded, this);
+        this._evtLayerRemoved?.off();
+        this._evtLayerRemoved = newComp.on('remove', this.onLayerRemoved, this);
     }
 
     onLayerAdded(layer) {

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -1334,10 +1334,12 @@ class LightComponent extends Component {
         if (this.enabled && this.entity.enabled) {
             this.addLightToLayers();
         }
-        oldComp.off('add', this.onLayerAdded, this);
-        oldComp.off('remove', this.onLayerRemoved, this);
-        newComp.on('add', this.onLayerAdded, this);
-        newComp.on('remove', this.onLayerRemoved, this);
+
+        // store the new handles, so that onDisable can unsubscribe from the current composition
+        this._evtLayerAdded?.off();
+        this._evtLayerAdded = newComp.on('add', this.onLayerAdded, this);
+        this._evtLayerRemoved?.off();
+        this._evtLayerRemoved = newComp.on('remove', this.onLayerRemoved, this);
     }
 
     onLayerAdded(layer) {

--- a/src/framework/components/model/component.js
+++ b/src/framework/components/model/component.js
@@ -830,10 +830,12 @@ class ModelComponent extends Component {
      */
     onLayersChanged(oldComp, newComp) {
         this.addModelToLayers();
-        oldComp.off('add', this.onLayerAdded, this);
-        oldComp.off('remove', this.onLayerRemoved, this);
-        newComp.on('add', this.onLayerAdded, this);
-        newComp.on('remove', this.onLayerRemoved, this);
+
+        // store the new handles, so that onDisable can unsubscribe from the current composition
+        this._evtLayerAdded?.off();
+        this._evtLayerAdded = newComp.on('add', this.onLayerAdded, this);
+        this._evtLayerRemoved?.off();
+        this._evtLayerRemoved = newComp.on('remove', this.onLayerRemoved, this);
     }
 
     /**

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -1861,10 +1861,12 @@ class ParticleSystemComponent extends Component {
 
     onLayersChanged(oldComp, newComp) {
         this.addMeshInstanceToLayers();
-        oldComp.off('add', this.onLayerAdded, this);
-        oldComp.off('remove', this.onLayerRemoved, this);
-        newComp.on('add', this.onLayerAdded, this);
-        newComp.on('remove', this.onLayerRemoved, this);
+
+        // store the new handles, so that onDisable can unsubscribe from the current composition
+        this._evtLayerAdded?.off();
+        this._evtLayerAdded = newComp.on('add', this.onLayerAdded, this);
+        this._evtLayerRemoved?.off();
+        this._evtLayerRemoved = newComp.on('remove', this.onLayerRemoved, this);
     }
 
     onLayerAdded(layer) {

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -829,10 +829,12 @@ class RenderComponent extends Component {
 
     onLayersChanged(oldComp, newComp) {
         this.addToLayers();
-        oldComp.off('add', this.onLayerAdded, this);
-        oldComp.off('remove', this.onLayerRemoved, this);
-        newComp.on('add', this.onLayerAdded, this);
-        newComp.on('remove', this.onLayerRemoved, this);
+
+        // store the new handles, so that onDisable can unsubscribe from the current composition
+        this._evtLayerAdded?.off();
+        this._evtLayerAdded = newComp.on('add', this.onLayerAdded, this);
+        this._evtLayerRemoved?.off();
+        this._evtLayerRemoved = newComp.on('remove', this.onLayerRemoved, this);
     }
 
     onLayerAdded(layer) {

--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -1059,10 +1059,11 @@ class SpriteComponent extends Component {
     }
 
     _onLayersChanged(oldComp, newComp) {
-        oldComp.off('add', this._onLayerAdded, this);
-        oldComp.off('remove', this._onLayerRemoved, this);
-        newComp.on('add', this._onLayerAdded, this);
-        newComp.on('remove', this._onLayerRemoved, this);
+        // store the new handles, so that onDisable can unsubscribe from the current composition
+        this._evtLayerAdded?.off();
+        this._evtLayerAdded = newComp.on('add', this._onLayerAdded, this);
+        this._evtLayerRemoved?.off();
+        this._evtLayerRemoved = newComp.on('remove', this._onLayerRemoved, this);
 
         if (this.enabled && this.entity.enabled) {
             this.addToLayers();

--- a/test/framework/components/component-layers-changed.test.mjs
+++ b/test/framework/components/component-layers-changed.test.mjs
@@ -1,0 +1,91 @@
+import { expect } from 'chai';
+
+import { Entity } from '../../../src/framework/entity.js';
+import { LayerComposition } from '../../../src/scene/composition/layer-composition.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+/**
+ * Components that subscribe to the LayerComposition 'add' / 'remove' events in their onEnable, and
+ * re-subscribe to the new composition in their onLayersChanged handler. The re-subscription has to
+ * be tracked, otherwise onDisable is left holding event handles for the previous composition and
+ * can no longer unsubscribe.
+ *
+ * Note the particlesystem component follows the same pattern, but its onEnable early-outs on the
+ * null graphics device (disableParticleSystem), so it cannot be covered here.
+ */
+const LAYER_SUBSCRIBERS = ['render', 'model', 'gsplat', 'sprite', 'element', 'camera', 'light'];
+
+describe('Component layer composition changes', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    LAYER_SUBSCRIBERS.forEach((type) => {
+        describe(`${type} component`, function () {
+
+            it('unsubscribes from the new composition when disabled', function () {
+                const e = new Entity();
+                app.root.addChild(e);
+                e.addComponent(type);
+
+                const oldComposition = app.scene.layers;
+                const newComposition = new LayerComposition();
+                app.scene.layers = newComposition;
+
+                // the old composition is no longer of interest, the new one is
+                expect(oldComposition.hasEvent('add')).to.equal(false);
+                expect(oldComposition.hasEvent('remove')).to.equal(false);
+                expect(newComposition.hasEvent('add')).to.equal(true);
+                expect(newComposition.hasEvent('remove')).to.equal(true);
+
+                e[type].enabled = false;
+
+                expect(newComposition.hasEvent('add')).to.equal(false);
+                expect(newComposition.hasEvent('remove')).to.equal(false);
+            });
+
+            it('unsubscribes from the new composition when the entity is destroyed', function () {
+                const e = new Entity();
+                app.root.addChild(e);
+                e.addComponent(type);
+
+                const newComposition = new LayerComposition();
+                app.scene.layers = newComposition;
+
+                e.destroy();
+
+                expect(newComposition.hasEvent('add')).to.equal(false);
+                expect(newComposition.hasEvent('remove')).to.equal(false);
+            });
+
+            it('unsubscribes from the latest composition after repeated reassignment', function () {
+                const e = new Entity();
+                app.root.addChild(e);
+                e.addComponent(type);
+
+                const compositions = [new LayerComposition(), new LayerComposition(), new LayerComposition()];
+                compositions.forEach((composition) => {
+                    app.scene.layers = composition;
+                });
+
+                e[type].enabled = false;
+
+                compositions.forEach((composition) => {
+                    expect(composition.hasEvent('add')).to.equal(false);
+                    expect(composition.hasEvent('remove')).to.equal(false);
+                });
+            });
+
+        });
+    });
+});


### PR DESCRIPTION
Found while investigating #9144, but independent of it.

Every component with layer subscriptions re-subscribes to the new `LayerComposition` in its `onLayersChanged` handler, but did so with a bare `newComp.on(...)` and discarded the returned event handles. `onDisable` was therefore left holding `_evtLayerAdded` / `_evtLayerRemoved` handles for the *previous* composition and could no longer unsubscribe from the current one.

Measured on the `render` component, though all eight behaved the same way:

```
newComp[add] after scene.layers = newComp : 2
newComp[add] after component disabled     : 2   <-- onDisable cannot remove untracked subs
```

The subscriptions survived both disabling the component and destroying the entity, so the composition kept the component - and through it the entity - alive. `scene.layers` is reassigned by the engine itself in `AppBase#_parseApplicationProperties` when applying scene settings, as well as by anyone using the public `Scene#layers` setter.

**Changes:**
- `render`, `model`, `gsplat`, `sprite`, `element`, `camera`, `light` and `particlesystem` now track the re-subscription:
  ```js
  this._evtLayerAdded?.off();
  this._evtLayerAdded = newComp.on('add', this.onLayerAdded, this);
  ```
  Releasing the stored handle replaces the previous `oldComp.off(...)` calls, which did the same thing for the old composition only.
- `ElementComponent#onLayersChanged` no longer throws for group elements. It did `this._image ? this._image._renderable.model : this._text._model`, and a group element has neither, so any live group element threw whenever `scene.layers` was reassigned. It is now guarded the same way the `batchGroupId` setter is.
- New `test/framework/components/component-layers-changed.test.mjs` covering unsubscription after composition reassignment on disable, on entity destruction, and after repeated reassignment.

`particlesystem` is fixed alongside the others but cannot be covered by the tests, because its `onEnable` early-outs on the null graphics device.