### PR TITLE
Support refraction without the metalness workflow

### DIFF
--- a/examples/src/examples/materials/material-refraction.controls.jsx
+++ b/examples/src/examples/materials/material-refraction.controls.jsx
@@ -20,6 +20,13 @@ export function Controls({ observer }) {
                         link={{ observer, path: 'data.dynamic' }}
                     />
                 </LabelGroup>
+                <LabelGroup text='Metalness'>
+                    <BooleanInput
+                        type='toggle'
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'data.metalness' }}
+                    />
+                </LabelGroup>
             </Panel>
         </>
     );

--- a/examples/src/examples/materials/material-refraction.example.mjs
+++ b/examples/src/examples/materials/material-refraction.example.mjs
@@ -133,7 +133,7 @@ material.metalness = 0.0; // low metalness, otherwise it's reflective
 material.gloss = 1.0;
 material.glossMap = assets.other.resource;
 material.glossMapChannel = 'g';
-material.useMetalness = true; // refractive materials are currently supported only with metalness
+material.useMetalness = true; // metalness workflow by default, can be toggled off in the UI
 material.refraction = 0.8;
 material.refractionIndex = 1.0 / 1.33; // water
 material.blendType = BLEND_NORMAL;
@@ -168,7 +168,8 @@ for (let i = 0; i < count; i++) {
 
 // Initial values for the UI
 data.set('data', {
-    dynamic: false
+    dynamic: false,
+    metalness: true
 });
 
 // Update things each frame
@@ -189,5 +190,15 @@ app.on('update', (dt) => {
 
         // When dynamic is enabled, the camera needs to render the scene's color map
         camera.camera.requestSceneColorMap(dynamic);
+    }
+
+    // Handle metalness workflow toggle - refraction works in both workflows. Without
+    // metalness, the fresnel is driven by the material's specular color (black by default)
+    const metalness = data.get('data.metalness');
+    if (material.useMetalness !== metalness) {
+        material.useMetalness = metalness;
+        material.update();
+        material2.useMetalness = metalness;
+        material2.update();
     }
 });

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -819,6 +819,11 @@ class StandardMaterial extends Material {
             this._setParameter('material_refraction', this.refraction);
         }
 
+        // refraction needs ior, which is otherwise uploaded by the metalness path above
+        if (!this.useMetalness && (this.refraction > 0 || this.refractionMap)) {
+            this._setParameter('material_refractionIndex', this.refractionIndex);
+        }
+
         if (this.dispersion > 0) {
             this._setParameter('material_dispersion', this.dispersion);
         }

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardBackend.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardBackend.js
@@ -18,7 +18,7 @@ void evaluateBackend() {
         #endif
     #endif
 
-    #ifdef LIT_SPECULAR_OR_REFLECTION
+    #if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
         #ifdef LIT_METALNESS
             float f0 = 1.0 / litArgs_ior;
             f0 = (f0 - 1.0) / (f0 + 1.0);
@@ -167,23 +167,25 @@ void evaluateBackend() {
 
         #endif
 
-        #ifdef LIT_REFRACTION
-            addRefraction(
-                litArgs_worldNormal, 
-                dViewDirW, 
-                litArgs_thickness, 
-                litArgs_gloss, 
-                litArgs_specularity, 
-                litArgs_albedo, 
-                litArgs_transmission,
-                litArgs_ior,
-                litArgs_dispersion
-                #if defined(LIT_IRIDESCENCE)
-                    , iridescenceFresnel, 
-                    litArgs_iridescence_intensity
-                #endif
-            );
-        #endif
+    #endif
+
+    // refraction is not gated on lighting / reflections, so that it also works without them
+    #ifdef LIT_REFRACTION
+        addRefraction(
+            litArgs_worldNormal,
+            dViewDirW,
+            litArgs_thickness,
+            litArgs_gloss,
+            litArgs_specularity,
+            litArgs_albedo,
+            litArgs_transmission,
+            litArgs_ior,
+            litArgs_dispersion
+            #if defined(LIT_IRIDESCENCE)
+                , iridescenceFresnel,
+                litArgs_iridescence_intensity
+            #endif
+        );
     #endif
 
     // apply ambient occlusion

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardPostCode.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardPostCode.js
@@ -7,8 +7,8 @@ export default /* glsl */`
     #include "envProcPS"
 #endif
 
-// ----- specular or reflections -----
-#ifdef LIT_SPECULAR_OR_REFLECTION
+// ----- specular or reflections (also needed by refraction, which uses specularity) -----
+#if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
     #ifdef LIT_METALNESS
         #include "metalnessModulatePS"
     #endif
@@ -56,7 +56,8 @@ export default /* glsl */`
 #ifdef LIT_REFRACTION
     #if defined(LIT_DYNAMIC_REFRACTION)
         #include "refractionDynamicPS"
-    #elif defined(LIT_REFLECTIONS)
+    #elif LIT_REFLECTION_SOURCE != NONE
+        // cube refraction only needs a reflection source, not the specular reflection path
         #include "refractionCubePS"
     #endif
 #endif

--- a/src/scene/shader-lib/glsl/chunks/standard/frag/stdDeclaration.js
+++ b/src/scene/shader-lib/glsl/chunks/standard/frag/stdDeclaration.js
@@ -23,6 +23,11 @@ export default /* glsl */`
         #ifdef LIT_REFRACTION
             float dTransmission;
             float dThickness;
+
+            // ior, unless it is declared by the metalness path below
+            #ifndef LIT_METALNESS
+                float dIor;
+            #endif
         #endif
 
         #ifdef LIT_SCENE_COLOR
@@ -96,8 +101,8 @@ export default /* glsl */`
             vec2 dAnisotropyRotation;
         #endif
 
-        // specularity & glossiness
-        #ifdef LIT_SPECULAR_OR_REFLECTION
+        // specularity & glossiness (also needed by refraction, which uses specularity and gloss)
+        #if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
 
             // sheen
             #ifdef LIT_SHEEN

--- a/src/scene/shader-lib/glsl/chunks/standard/frag/stdFrontEnd.js
+++ b/src/scene/shader-lib/glsl/chunks/standard/frag/stdFrontEnd.js
@@ -34,6 +34,11 @@ export default /* glsl */`
         #ifdef LIT_REFRACTION
             #include "transmissionPS"
             #include "thicknessPS"
+
+            // ior, unless it is included by the metalness path below
+            #ifndef LIT_METALNESS
+                #include "iorPS"
+            #endif
         #endif
 
         // iridescence
@@ -42,8 +47,8 @@ export default /* glsl */`
             #include "iridescenceThicknessPS"
         #endif
 
-        // specularity & glossiness
-        #ifdef LIT_SPECULAR_OR_REFLECTION
+        // specularity & glossiness (also needed by refraction, which uses specularity and gloss)
+        #if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
 
             // sheen
             #ifdef LIT_SHEEN
@@ -143,6 +148,12 @@ export default /* glsl */`
                 getThickness();
                 litArgs_thickness = dThickness;
 
+                // ior, unless it is handled by the metalness path below
+                #ifndef LIT_METALNESS
+                    getIor();
+                    litArgs_ior = dIor;
+                #endif
+
                 #ifdef LIT_DISPERSION
                     litArgs_dispersion = material_dispersion;
                 #endif
@@ -156,8 +167,8 @@ export default /* glsl */`
                 litArgs_iridescence_thickness = dIridescenceThickness;
             #endif
 
-            // specularity & glossiness
-            #ifdef LIT_SPECULAR_OR_REFLECTION
+            // specularity & glossiness (also needed by refraction, which uses specularity and gloss)
+            #if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
 
                 // sheen
                 #ifdef LIT_SHEEN

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -160,6 +160,7 @@ class LitShader {
         this.needsNormal =
             this.lighting ||
             this.reflections ||
+            options.useRefraction ||
             options.useSpecular ||
             options.ambientSH ||
             options.useHeights ||

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -309,7 +309,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         fDefineSet(options.dirLightMap && options.litOptions.useSpecular, 'STD_LIGHTMAP_DIR', '');
         fDefineSet(options.heightMap, 'STD_HEIGHT_MAP', '');
         fDefineSet(options.useSpecularColor, 'STD_SPECULAR_COLOR', '');
-        fDefineSet(options.useSpecularColor && options.litOptions.useSpecular, 'STD_SPECULAR_CONSTANT', '');
+        fDefineSet(options.useSpecularColor && (options.litOptions.useSpecular || options.litOptions.useRefraction), 'STD_SPECULAR_CONSTANT', '');
         fDefineSet(options.aoMap || options.aoVertexColor || options.useAO, 'STD_AO', '');
         fDefineSet(true, 'STD_OPACITY_DITHER', ditherNames[shaderPassInfo.isForward ? options.litOptions.opacityDither : options.litOptions.opacityShadowDither]);
     }
@@ -374,6 +374,11 @@ class ShaderGeneratorStandard extends ShaderGenerator {
             if (options.litOptions.useRefraction) {
                 this._addMapDefines(fDefines, 'refraction', 'transmissionPS', options, litShader.chunks, textureMapping);
                 this._addMapDefines(fDefines, 'thickness', 'thicknessPS', options, litShader.chunks, textureMapping);
+
+                // refraction needs ior, which is otherwise handled by the metalness path
+                if (!options.litOptions.useMetalness) {
+                    this._addMapDefines(fDefines, 'ior', 'iorPS', options, litShader.chunks, textureMapping);
+                }
             }
 
             // iridescence
@@ -382,8 +387,8 @@ class ShaderGeneratorStandard extends ShaderGenerator {
                 this._addMapDefines(fDefines, 'iridescenceThickness', 'iridescenceThicknessPS', options, litShader.chunks, textureMapping);
             }
 
-            // specularity & glossiness
-            if ((litShader.lighting && options.litOptions.useSpecular) || litShader.reflections) {
+            // specularity & glossiness (also needed by refraction, which uses specularity and gloss)
+            if ((litShader.lighting && options.litOptions.useSpecular) || litShader.reflections || options.litOptions.useRefraction) {
                 if (options.litOptions.useSheen) {
                     this._addMapDefines(fDefines, 'sheen', 'sheenPS', options, litShader.chunks, textureMapping, options.sheenEncoding);
                     this._addMapDefines(fDefines, 'sheenGloss', 'sheenGlossPS', options, litShader.chunks, textureMapping);

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardBackend.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardBackend.js
@@ -20,7 +20,7 @@ fn evaluateBackend() -> FragmentOutput {
         #endif
     #endif
 
-    #ifdef LIT_SPECULAR_OR_REFLECTION
+    #if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
         #ifdef LIT_METALNESS
             var f0: f32 = 1.0 / litArgs_ior;
             f0 = (f0 - 1.0) / (f0 + 1.0);
@@ -172,23 +172,25 @@ fn evaluateBackend() -> FragmentOutput {
 
         #endif
 
-        #ifdef LIT_REFRACTION
-            addRefraction(
-                litArgs_worldNormal, 
-                dViewDirW, 
-                litArgs_thickness, 
-                litArgs_gloss, 
-                litArgs_specularity, 
-                litArgs_albedo, 
-                litArgs_transmission,
-                litArgs_ior,
-                litArgs_dispersion
-                #if defined(LIT_IRIDESCENCE)
-                    , iridescenceFresnel, 
-                    litArgs_iridescence_intensity
-                #endif
-            );
-        #endif
+    #endif
+
+    // refraction is not gated on lighting / reflections, so that it also works without them
+    #ifdef LIT_REFRACTION
+        addRefraction(
+            litArgs_worldNormal,
+            dViewDirW,
+            litArgs_thickness,
+            litArgs_gloss,
+            litArgs_specularity,
+            litArgs_albedo,
+            litArgs_transmission,
+            litArgs_ior,
+            litArgs_dispersion
+            #if defined(LIT_IRIDESCENCE)
+                , iridescenceFresnel,
+                litArgs_iridescence_intensity
+            #endif
+        );
     #endif
 
     // apply ambient occlusion

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardPostCode.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardPostCode.js
@@ -7,8 +7,8 @@ export default /* wgsl */`
     #include "envProcPS"
 #endif
 
-// ----- specular or reflections -----
-#ifdef LIT_SPECULAR_OR_REFLECTION
+// ----- specular or reflections (also needed by refraction, which uses specularity) -----
+#if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
     #ifdef LIT_METALNESS
         #include "metalnessModulatePS"
     #endif
@@ -56,7 +56,8 @@ export default /* wgsl */`
 #ifdef LIT_REFRACTION
     #if defined(LIT_DYNAMIC_REFRACTION)
         #include "refractionDynamicPS"
-    #elif defined(LIT_REFLECTIONS)
+    #elif LIT_REFLECTION_SOURCE != NONE
+        // cube refraction only needs a reflection source, not the specular reflection path
         #include "refractionCubePS"
     #endif
 #endif

--- a/src/scene/shader-lib/wgsl/chunks/standard/frag/stdDeclaration.js
+++ b/src/scene/shader-lib/wgsl/chunks/standard/frag/stdDeclaration.js
@@ -24,6 +24,11 @@ export default /* wgsl */`
         #ifdef LIT_REFRACTION
             var<private> dTransmission: f32;
             var<private> dThickness: f32;
+
+            // ior, unless it is declared by the metalness path below
+            #ifndef LIT_METALNESS
+                var<private> dIor: f32;
+            #endif
         #endif
 
         #ifdef LIT_SCENE_COLOR
@@ -107,8 +112,8 @@ export default /* wgsl */`
             var<private> dAnisotropyRotation: vec2f;
         #endif
 
-        // specularity & glossiness
-        #ifdef LIT_SPECULAR_OR_REFLECTION
+        // specularity & glossiness (also needed by refraction, which uses specularity and gloss)
+        #if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
 
             // sheen
             #ifdef LIT_SHEEN

--- a/src/scene/shader-lib/wgsl/chunks/standard/frag/stdFrontEnd.js
+++ b/src/scene/shader-lib/wgsl/chunks/standard/frag/stdFrontEnd.js
@@ -34,6 +34,11 @@ export default /* wgsl */`
         #ifdef LIT_REFRACTION
             #include "transmissionPS"
             #include "thicknessPS"
+
+            // ior, unless it is included by the metalness path below
+            #ifndef LIT_METALNESS
+                #include "iorPS"
+            #endif
         #endif
 
         // iridescence
@@ -42,8 +47,8 @@ export default /* wgsl */`
             #include "iridescenceThicknessPS"
         #endif
 
-        // specularity & glossiness
-        #ifdef LIT_SPECULAR_OR_REFLECTION
+        // specularity & glossiness (also needed by refraction, which uses specularity and gloss)
+        #if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
 
             // sheen
             #ifdef LIT_SHEEN
@@ -143,6 +148,12 @@ export default /* wgsl */`
                 getThickness();
                 litArgs_thickness = dThickness;
 
+                // ior, unless it is handled by the metalness path below
+                #ifndef LIT_METALNESS
+                    getIor();
+                    litArgs_ior = dIor;
+                #endif
+
                 #ifdef LIT_DISPERSION
                     litArgs_dispersion = uniform.material_dispersion;
                 #endif
@@ -156,8 +167,8 @@ export default /* wgsl */`
                 litArgs_iridescence_thickness = dIridescenceThickness;
             #endif
 
-            // specularity & glossiness
-            #ifdef LIT_SPECULAR_OR_REFLECTION
+            // specularity & glossiness (also needed by refraction, which uses specularity and gloss)
+            #if defined(LIT_SPECULAR_OR_REFLECTION) || defined(LIT_REFRACTION)
 
                 // sheen
                 #ifdef LIT_SHEEN


### PR DESCRIPTION
Refraction (both cubemap and dynamic) could only be used together with `useMetalness`. Without it, the generated shader either failed to compile or read uninitialized shader globals, as reported in #7514. This makes refraction work in both workflows.

This is also the direction glTF specifies: `KHR_materials_transmission` defines transmission on the **dielectric** part of the material and notes that for `metallicFactor = 1.0` the transmission factor no longer matters, so refraction was never conceptually tied to the metalness toggle - it needs the IOR-driven dielectric fresnel, which the engine only happened to compute in the metalness path.

**Changes:**
- include and evaluate `ior` in the refraction front end when the metalness path does not, and upload `material_refractionIndex` to match
- gate specularity and gloss on refraction as well, since `addRefraction` consumes both
- include `refractionCubePS` based on the reflection source instead of the specular reflection path, which additionally requires `useSpecular`. This is what produced the `'addRefraction' : no matching overloaded function found` error in the issue
- declare `STD_SPECULAR_CONSTANT` for refractive materials, so the fresnel uses the material specular color rather than defaulting to white, which cancelled the refraction out entirely
- evaluate refraction outside of the lighting / reflections block, so it is no longer silently skipped in scenes with neither
- `needsNormal` now accounts for refraction

All of the above are applied to both the GLSL and WGSL chunks.

**Examples:**
- Material Refraction: added a Metalness toggle (on by default) to exercise both workflows

**Notes:**
Every shader variant touched here previously either failed to compile or read uninitialized values, so no working variant changes. Verified by hashing the generated fragment shaders against a build of the base commit: variants without refraction are byte identical, and the metalness refraction variants are identical modulo the whitespace of the moved `addRefraction` call.

A follow up worth doing separately is giving the `litArgs_*` globals default initializers, to rule out this class of uninitialized reads. It is kept out of this PR because it changes the generated source of every lit shader.