### PR TITLE
Fix gsplat rendering on Firefox/Windows WebGPU

### DIFF
--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js
@@ -101,7 +101,11 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
 
         #if SH_BANDS > 0
             // calculate the model-space view direction
-            dir = normalize(center.view * mat3x3f(center.modelView[0].xyz, center.modelView[1].xyz, center.modelView[2].xyz));
+            // Firefox on Windows (D3D12) returns a transposed matrix when a struct member is indexed
+            // through a pointer, so load the whole matrix into a local first. Remove the local once
+            // the fix has shipped: https://bugzilla.mozilla.org/show_bug.cgi?id=2059727
+            let modelView = center.modelView;
+            dir = normalize(center.view * mat3x3f(modelView[0].xyz, modelView[1].xyz, modelView[2].xyz));
         #endif
 
     #endif

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
@@ -73,7 +73,11 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     // evaluate spherical harmonics
     #if SH_BANDS > 0
         // calculate the model-space view direction
-        let modelView3x3 = mat3x3f(center.modelView[0].xyz, center.modelView[1].xyz, center.modelView[2].xyz);
+        // Firefox on Windows (D3D12) returns a transposed matrix when a struct member is indexed
+        // through a pointer, so load the whole matrix into a local first. Remove the local once the
+        // fix has shipped: https://bugzilla.mozilla.org/show_bug.cgi?id=2059727
+        let modelView = center.modelView;
+        let modelView3x3 = mat3x3f(modelView[0].xyz, modelView[1].xyz, modelView[2].xyz);
         let dir = normalize(center.view * modelView3x3);
 
         // read sh coefficients

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCorner.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatCorner.js
@@ -63,7 +63,11 @@ fn initCornerCov(source: ptr<function, SplatSource>, center: ptr<function, Splat
 
     #endif
 
-    let W = transpose(mat3x3f(center.modelView[0].xyz, center.modelView[1].xyz, center.modelView[2].xyz));
+    // Firefox on Windows (D3D12) returns a transposed matrix when a struct member is indexed
+    // through a pointer, so load the whole matrix into a local first. Remove the local once the
+    // fix has shipped: https://bugzilla.mozilla.org/show_bug.cgi?id=2059727
+    let modelView = center.modelView;
+    let W = transpose(mat3x3f(modelView[0].xyz, modelView[1].xyz, modelView[2].xyz));
     let T = W * J;
     let cov = transpose(T) * Vrk * T;
 


### PR DESCRIPTION
Fixes #8904. Gaussian splats rendered on Firefox/Windows with WebGPU had every splat stretched into a thin needle, while Chrome on the same machine, Firefox on macOS, GPU sorting and WebGL2 were all fine.

The cause is a Firefox/Windows (D3D12/HLSL) shader translation bug: a `mat4x4f` stored in a member of a function-scope struct is returned **transposed** when it is read back by indexing it through a `ptr<function, T>`. Reported upstream as https://bugzilla.mozilla.org/show_bug.cgi?id=2059727.

`initCenter()` computes `modelView = matrix_view * matrix_model` into a local, uses that local for the splat centres, and stores it into `SplatCenter.modelView`. `initCornerCov()` then read it back by column to build the view basis `W`. Because the matrix came back transposed, the Jacobian (whose third column is zero, so it drops depth) discarded the wrong axis, flat gaussians projected edge-on, the 2D covariance collapsed to near-rank-1, and `lambda2` pinned at its floor - a 1px-wide needle. The centres stayed correct throughout, since they come from the local copy.

Loading the whole matrix into a local before indexing avoids the miscompile, which was confirmed with a standalone WGSL testcase: indexing the member fails on Firefox/Windows in both the vertex and compute stages, and for `mat3x3f` as well as `mat4x4f`, while a whole-value load of the same member is correct.

**Changes:**
- `wgsl/chunks/gsplat/vert/gsplatCorner.js` - copy `modelView` to a local before building `W` for the covariance projection
- `wgsl/chunks/gsplat/vert/gsplat.js` - same for the spherical harmonics view direction
- `wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js` - same for the SH direction in the work-buffer copy pass

Each local carries a comment and the Bugzilla link noting it can be removed once the fix ships in Firefox.

Notes:
- No public API or chunk contract changes. `SplatCenter.modelView` is still declared and assigned, so user chunk overrides that reference it keep working.
- No extra arithmetic - the matrix product is not recomputed, only loaded as a whole value instead of indexed in place.
- The 2DGS path in `gsplat.js` uses `center.modelView` as a whole value in a multiply rather than indexing it, which is the pattern that is unaffected, so it is left unchanged.
- GLSL chunks are unaffected, as GLSL has no pointers.
- The SH paths were latently broken on the same platform but do not show in the reported scenes, which use no SH bands.