### PR TITLE
Rebind anim component when render mesh instances change

### DIFF
--- a/src/framework/components/anim/component.js
+++ b/src/framework/components/anim/component.js
@@ -561,6 +561,21 @@ class AnimComponent extends Component {
     }
 
     /**
+     * Tests whether the given entity is part of the hierarchy this component animates. The binders
+     * resolve their targets within the root bone when one is assigned, and within this component's
+     * entity otherwise, so anything they bind - including the mesh instances backing morph target
+     * weights and animated material textures - belongs to an entity at or below that root.
+     *
+     * @param {Entity} entity - The entity to test.
+     * @returns {boolean} True if the entity is part of the animated hierarchy.
+     * @ignore
+     */
+    animatesEntity(entity) {
+        const graph = this._rootBone || this.entity;
+        return graph === entity || graph.isAncestorOf(entity);
+    }
+
+    /**
      * Finds an {@link AnimComponentLayer} in this component.
      *
      * @param {string} name - The name of the anim component layer to find.

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -4,6 +4,7 @@ import { AnimComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Component } from '../component.js'
  */
 
 /**
@@ -31,6 +32,7 @@ class AnimComponentSystem extends ComponentSystem {
 
         this.on('beforeremove', this.onBeforeRemove, this);
         this.app.systems.on('animationUpdate', this.onAnimationUpdate, this);
+        this.app.systems.on('meshInstancesChange', this.onMeshInstancesChange, this);
     }
 
     initializeComponentData(component, data, properties) {
@@ -100,6 +102,30 @@ class AnimComponentSystem extends ComponentSystem {
         }
     }
 
+    /**
+     * Rebinds every component animating a hierarchy which contains the entity whose mesh instances
+     * changed. Anim targets which reference mesh instances - morph target weights and animated
+     * material textures - are resolved once and then cached, so they have to be re-resolved when the
+     * mesh instances they point at are created or destroyed. Disabled components are included, as
+     * they keep their bindings and are not rebound when re-enabled.
+     *
+     * @param {Component} component - The component whose mesh instances changed.
+     * @private
+     */
+    onMeshInstancesChange(component) {
+        const components = this.store;
+
+        for (const id in components) {
+            if (components.hasOwnProperty(id)) {
+                const animComponent = components[id].entity.anim;
+
+                if (animComponent.animatesEntity(component.entity)) {
+                    animComponent.rebind();
+                }
+            }
+        }
+    }
+
     cloneComponent(entity, clone) {
         let masks;
         // If the component animates from the components entity, any layer mask hierarchy should be
@@ -146,6 +172,7 @@ class AnimComponentSystem extends ComponentSystem {
         super.destroy();
 
         this.app.systems.off('animationUpdate', this.onAnimationUpdate, this);
+        this.app.systems.off('meshInstancesChange', this.onMeshInstancesChange, this);
     }
 }
 

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -330,7 +330,7 @@ class RenderComponent extends Component {
     set meshInstances(value) {
         Debug.assert(Array.isArray(value), 'MeshInstances set to a Render component must be an array.');
 
-        // don't notify the anim component yet, it's notified once the new mesh instances are in place
+        // don't notify yet, the change is announced once the new mesh instances are in place
         this._destroyMeshInstances();
 
         this._meshInstances = value;
@@ -357,7 +357,7 @@ class RenderComponent extends Component {
             }
         }
 
-        this._rebindAnim();
+        this._onMeshInstancesChanged();
     }
 
     /**
@@ -767,11 +767,11 @@ class RenderComponent extends Component {
     /** @private */
     destroyMeshInstances() {
         this._destroyMeshInstances();
-        this._rebindAnim();
+        this._onMeshInstancesChanged();
     }
 
     /**
-     * Destroys the mesh instances without notifying an anim component. Used by the meshInstances
+     * Destroys the mesh instances without firing a change notification. Used by the meshInstances
      * setter, which notifies once the replacement mesh instances are in place.
      *
      * @private
@@ -792,17 +792,21 @@ class RenderComponent extends Component {
     }
 
     /**
-     * Notifies an anim component on the same entity that the set of mesh instances has changed, so
-     * that it re-resolves the animation targets referencing them - morph target weights and
-     * animated material textures. Without this, morph animations are silently dropped when the
-     * render asset loads after the animation was bound, and keep driving destroyed morph instances
-     * after the asset is unloaded. See #5225.
+     * Fires a notification that the set of mesh instances has changed, so that systems which
+     * reference them can re-resolve. An anim component binds morph target weights and animated
+     * material textures to specific mesh instances, and unlike a model component - which owns its
+     * mesh instances on a private graph node hierarchy under its own entity - a render hierarchy is
+     * a public entity hierarchy, so the anim component driving these mesh instances can live on any
+     * ancestor entity. The notification is therefore broadcast rather than delivered directly. See
+     * #5225.
      *
      * @private
      */
-    _rebindAnim() {
+    _onMeshInstancesChanged() {
         if (!this.entity._destroying) {
-            this.entity.anim?.rebind();
+            // the systems registry is torn down before assets are unloaded when the app is
+            // destroyed, and by then there is nothing left to notify
+            this.system.app.systems?.fire('meshInstancesChange', this);
         }
     }
 

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -329,7 +329,9 @@ class RenderComponent extends Component {
      */
     set meshInstances(value) {
         Debug.assert(Array.isArray(value), 'MeshInstances set to a Render component must be an array.');
-        this.destroyMeshInstances();
+
+        // don't notify the anim component yet, it's notified once the new mesh instances are in place
+        this._destroyMeshInstances();
 
         this._meshInstances = value;
 
@@ -354,6 +356,8 @@ class RenderComponent extends Component {
                 this.addToLayers();
             }
         }
+
+        this._rebindAnim();
     }
 
     /**
@@ -762,6 +766,17 @@ class RenderComponent extends Component {
 
     /** @private */
     destroyMeshInstances() {
+        this._destroyMeshInstances();
+        this._rebindAnim();
+    }
+
+    /**
+     * Destroys the mesh instances without notifying an anim component. Used by the meshInstances
+     * setter, which notifies once the replacement mesh instances are in place.
+     *
+     * @private
+     */
+    _destroyMeshInstances() {
         const meshInstances = this._meshInstances;
         if (meshInstances) {
             this.removeFromLayers();
@@ -773,6 +788,21 @@ class RenderComponent extends Component {
                 meshInstances[i].destroy();
             }
             this._meshInstances.length = 0;
+        }
+    }
+
+    /**
+     * Notifies an anim component on the same entity that the set of mesh instances has changed, so
+     * that it re-resolves the animation targets referencing them - morph target weights and
+     * animated material textures. Without this, morph animations are silently dropped when the
+     * render asset loads after the animation was bound, and keep driving destroyed morph instances
+     * after the asset is unloaded. See #5225.
+     *
+     * @private
+     */
+    _rebindAnim() {
+        if (!this.entity._destroying) {
+            this.entity.anim?.rebind();
         }
     }
 

--- a/test/framework/components/anim/component.test.mjs
+++ b/test/framework/components/anim/component.test.mjs
@@ -1,8 +1,16 @@
 import { expect } from 'chai';
 
+import { INTERPOLATION_LINEAR } from '../../../../src/framework/anim/constants.js';
 import { ANIM_LAYER_ADDITIVE, ANIM_LAYER_OVERWRITE } from '../../../../src/framework/anim/controller/constants.js';
+import { AnimCurve } from '../../../../src/framework/anim/evaluator/anim-curve.js';
+import { AnimData } from '../../../../src/framework/anim/evaluator/anim-data.js';
 import { AnimTrack } from '../../../../src/framework/anim/evaluator/anim-track.js';
 import { Entity } from '../../../../src/framework/entity.js';
+import { MeshInstance } from '../../../../src/scene/mesh-instance.js';
+import { Mesh } from '../../../../src/scene/mesh.js';
+import { MorphInstance } from '../../../../src/scene/morph-instance.js';
+import { MorphTarget } from '../../../../src/scene/morph-target.js';
+import { Morph } from '../../../../src/scene/morph.js';
 import { createApp } from '../../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
 
@@ -78,6 +86,87 @@ describe('AnimComponent', function () {
             expect(clone.anim.layers.length).to.equal(1);
             expect(clone.anim.findAnimationLayer('Base').states).to.have.members(['START', 'Idle']);
             expect(clone.anim.playable).to.equal(true);
+        });
+    });
+
+    describe('morph target weights', function () {
+
+        const MORPH_TARGET = 'Blink';
+
+        // mesh instances carrying a single named morph target, as a loaded render asset produces
+        const createMeshInstances = (entity) => {
+            const mesh = Mesh.fromGeometry(app.graphicsDevice, {
+                positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+                indices: [0, 1, 2]
+            });
+            mesh.morph = new Morph([new MorphTarget({
+                name: MORPH_TARGET,
+                deltaPositions: new Float32Array([0, 0, 0, 0, 1, 0, 0, 0, 0]),
+                defaultWeight: 0
+            })], app.graphicsDevice);
+
+            const meshInstance = new MeshInstance(mesh, app.systems.render.defaultMaterial, entity);
+            meshInstance.morphInstance = new MorphInstance(mesh.morph);
+            return [meshInstance];
+        };
+
+        // a track with a single morph weight curve ramping from 0 to 1 over its duration, encoded
+        // the way the glb parser encodes them
+        const morphTrack = (entityName) => {
+            const curve = new AnimCurve([{
+                entityPath: [entityName],
+                component: 'graph',
+                propertyPath: [`weight.name.${MORPH_TARGET}`]
+            }], 0, 0, INTERPOLATION_LINEAR);
+
+            return new AnimTrack('Morph', 1, [new AnimData(1, [0, 1])], [new AnimData(1, [0, 1])], [curve]);
+        };
+
+        const weight = entity => entity.render.meshInstances[0].morphInstance.getWeight(MORPH_TARGET);
+
+        // Regression test for https://github.com/playcanvas/engine/issues/5225
+        it('are animated when mesh instances are created after the animation is bound', function () {
+            const entity = new Entity('model', app);
+            app.root.addChild(entity);
+
+            // a render component whose asset has not loaded yet, so it has no mesh instances
+            entity.addComponent('render', { type: 'asset' });
+            entity.addComponent('anim', { activate: true });
+            entity.anim.assignAnimation('Morph', morphTrack('model'));
+
+            // frames tick while the asset is still loading - the anim controller binds its curves
+            // here, when there is no morph instance to bind the weight curve to
+            app.systems.anim.onAnimationUpdate(0.1);
+
+            // the asset arrives and mesh instances are created
+            entity.render.meshInstances = createMeshInstances(entity);
+
+            app.systems.anim.onAnimationUpdate(0.4);
+
+            expect(weight(entity)).to.be.closeTo(0.5, 1e-5);
+        });
+
+        // Regression test for https://github.com/playcanvas/engine/issues/5225
+        it('are animated after mesh instances are replaced', function () {
+            const entity = new Entity('model', app);
+            app.root.addChild(entity);
+
+            entity.addComponent('render', { type: 'asset' });
+            entity.render.meshInstances = createMeshInstances(entity);
+            entity.addComponent('anim', { activate: true });
+            entity.anim.assignAnimation('Morph', morphTrack('model'));
+
+            app.systems.anim.onAnimationUpdate(0.5);
+            expect(weight(entity)).to.be.closeTo(0.5, 1e-5);
+
+            // an asset unload and reload destroys the morph instances the animation was bound to
+            // and creates replacements
+            entity.render.destroyMeshInstances();
+            entity.render.meshInstances = createMeshInstances(entity);
+
+            // clip time is cumulative, so this samples the track at 0.75
+            expect(() => app.systems.anim.onAnimationUpdate(0.25)).to.not.throw();
+            expect(weight(entity)).to.be.closeTo(0.75, 1e-5);
         });
     });
 });

--- a/test/framework/components/anim/component.test.mjs
+++ b/test/framework/components/anim/component.test.mjs
@@ -112,9 +112,9 @@ describe('AnimComponent', function () {
 
         // a track with a single morph weight curve ramping from 0 to 1 over its duration, encoded
         // the way the glb parser encodes them
-        const morphTrack = (entityName) => {
+        const morphTrack = (entityPath) => {
             const curve = new AnimCurve([{
-                entityPath: [entityName],
+                entityPath,
                 component: 'graph',
                 propertyPath: [`weight.name.${MORPH_TARGET}`]
             }], 0, 0, INTERPOLATION_LINEAR);
@@ -132,7 +132,7 @@ describe('AnimComponent', function () {
             // a render component whose asset has not loaded yet, so it has no mesh instances
             entity.addComponent('render', { type: 'asset' });
             entity.addComponent('anim', { activate: true });
-            entity.anim.assignAnimation('Morph', morphTrack('model'));
+            entity.anim.assignAnimation('Morph', morphTrack(['model']));
 
             // frames tick while the asset is still loading - the anim controller binds its curves
             // here, when there is no morph instance to bind the weight curve to
@@ -154,7 +154,7 @@ describe('AnimComponent', function () {
             entity.addComponent('render', { type: 'asset' });
             entity.render.meshInstances = createMeshInstances(entity);
             entity.addComponent('anim', { activate: true });
-            entity.anim.assignAnimation('Morph', morphTrack('model'));
+            entity.anim.assignAnimation('Morph', morphTrack(['model']));
 
             app.systems.anim.onAnimationUpdate(0.5);
             expect(weight(entity)).to.be.closeTo(0.5, 1e-5);
@@ -167,6 +167,90 @@ describe('AnimComponent', function () {
             // clip time is cumulative, so this samples the track at 0.75
             expect(() => app.systems.anim.onAnimationUpdate(0.25)).to.not.throw();
             expect(weight(entity)).to.be.closeTo(0.75, 1e-5);
+        });
+
+        // The layout instantiateRenderEntity produces for an imported character: the anim component
+        // on the root, render components on mesh descendants. The binder resolves targets throughout
+        // the animated hierarchy, so a descendant's mesh instances must reach the owning component.
+        const createHierarchy = (rootBone) => {
+            const root = new Entity('root', app);
+            const child = new Entity('model', app);
+            root.addChild(child);
+            app.root.addChild(root);
+
+            child.addComponent('render', { type: 'asset' });
+            root.addComponent('anim', { activate: true, rootBone });
+            root.anim.assignAnimation('Morph', morphTrack(['root', 'model']));
+
+            return child;
+        };
+
+        // Regression test for https://github.com/playcanvas/engine/issues/5225
+        it('are animated when a descendant creates mesh instances after the animation is bound', function () {
+            const child = createHierarchy();
+
+            app.systems.anim.onAnimationUpdate(0.1);
+            child.render.meshInstances = createMeshInstances(child);
+            app.systems.anim.onAnimationUpdate(0.4);
+
+            expect(weight(child)).to.be.closeTo(0.5, 1e-5);
+        });
+
+        // Regression test for https://github.com/playcanvas/engine/issues/5225
+        it('are animated after a descendant replaces its mesh instances', function () {
+            const child = createHierarchy();
+            child.render.meshInstances = createMeshInstances(child);
+
+            app.systems.anim.onAnimationUpdate(0.5);
+            expect(weight(child)).to.be.closeTo(0.5, 1e-5);
+
+            child.render.destroyMeshInstances();
+            child.render.meshInstances = createMeshInstances(child);
+
+            expect(() => app.systems.anim.onAnimationUpdate(0.25)).to.not.throw();
+            expect(weight(child)).to.be.closeTo(0.75, 1e-5);
+        });
+
+        it('are animated when the animated hierarchy is a root bone', function () {
+            // the root bone is resolved by guid, so the entity has to be in the scene already
+            const root = new Entity('root', app);
+            const bones = new Entity('bones', app);
+            const child = new Entity('model', app);
+            bones.addChild(child);
+            root.addChild(bones);
+            app.root.addChild(root);
+
+            child.addComponent('render', { type: 'asset' });
+            root.addComponent('anim', { activate: true, rootBone: bones });
+            root.anim.assignAnimation('Morph', morphTrack(['bones', 'model']));
+
+            app.systems.anim.onAnimationUpdate(0.1);
+            child.render.meshInstances = createMeshInstances(child);
+            app.systems.anim.onAnimationUpdate(0.4);
+
+            expect(weight(child)).to.be.closeTo(0.5, 1e-5);
+        });
+
+        it('are left alone when the changed entity is outside the animated hierarchy', function () {
+            const animated = new Entity('animated', app);
+            const unrelated = new Entity('unrelated', app);
+            app.root.addChild(animated);
+            app.root.addChild(unrelated);
+
+            animated.addComponent('anim', { activate: true });
+            animated.anim.assignAnimation('Morph', morphTrack(['animated']));
+            unrelated.addComponent('render', { type: 'asset' });
+
+            let rebinds = 0;
+            const rebind = animated.anim.rebind.bind(animated.anim);
+            animated.anim.rebind = () => {
+                rebinds++;
+                rebind();
+            };
+
+            unrelated.render.meshInstances = createMeshInstances(unrelated);
+
+            expect(rebinds).to.equal(0);
         });
     });
 });


### PR DESCRIPTION
Fixes #5225 — morph animations are lost when a container asset is loaded at runtime rather than preloaded.

`DefaultAnimBinder`'s `weight` handler captures the morph instances **once**, when the anim controller resolves its curve paths, and returns `null` when there are none. Resolution is never retried, and nothing told the anim component that a render component's mesh instances had changed. That produces both symptoms in the issue:

- **Morph animation never plays.** The render asset is still downloading, so `render.meshInstances` is empty and the morph weight curves resolve to `null` and are dropped. When the asset arrives and mesh instances are created, nothing rebinds. Bone curves are unaffected because they resolve against graph nodes, which exist from the start — hence the reported "body animates, face frozen".
- **Crash after unload and reload.** `MorphInstance.destroy()` nulls its `morph`, but the binder still holds the destroyed instances, so the next update throws `Cannot read properties of null (reading '_targets')` in `MorphInstance.setWeight`. In release builds the `Debug.assert` is stripped, so weights are silently written into the dead instance instead — which is why the reporter saw the error disappear in 1.62 while the bug remained.

The binder's `materialTexture` handler captures a mesh instance the same way, so animated material textures were affected too.

**Why not the `model` component's approach.** `ModelComponent` calls `this.entity.anim.rebind()` directly when its model is assigned, and that is complete for a model: the Model owns every mesh instance on a private graph node hierarchy parented under its own entity, so an anim component on that entity is the only one that can bind them. A render hierarchy is a public entity hierarchy and any descendant can carry its own render component. The layout `instantiateRenderEntity` produces for an imported character puts the anim component on the root and render components on mesh descendants, so a direct co-located lookup never reaches the owning component.

**Changes:**
- `RenderComponent` announces mesh instance changes as a `meshInstancesChange` event on the component system registry, from `destroyMeshInstances()` and from the `meshInstances` setter.
- `AnimComponentSystem` subscribes once and rebinds every component whose animated hierarchy contains the changed entity. The subscription lives on the system, not on each component, so there is a single listener removed by the existing system `destroy()`, and disabled components are still rebound — they keep their bindings and are not rebound when re-enabled.
- `AnimComponent#animatesEntity()` performs the containment test against the root bone when one is assigned and the component's entity otherwise, matching what the binder actually walks.
- The destroy is split into a private `_destroyMeshInstances()` so replacing the mesh instances notifies once, rather than also notifying against the intermediate empty list.
- The notification is skipped while the entity is being destroyed, and tolerates the systems registry already being torn down — `AppBase#destroy` nulls it before unloading assets, which still drives render component asset callbacks.

**Tests:** five regression cases — mesh instances created after binding, mesh instances replaced, both again with the anim component on a parent and the render component on a child, a root bone hierarchy, plus an assertion that an unrelated hierarchy is not rebound.

Note that a render asset load performs two rebinds, because `_onRenderAssetLoad()` destroys and then `_cloneMeshes()` assigns. That is deliberate: the destroy must notify, otherwise a component whose `render.meshes` is not yet populated keeps stale bindings to destroyed morph instances between the destroy and the later `set:meshes` event. The extra rebind is a bounded one-off next to parsing the asset.

**API Changes:**
- `AnimComponent#animatesEntity(entity)` — new, `@ignore`. `_destroyMeshInstances` and `_onMeshInstancesChanged` on `RenderComponent` are private.
- `meshInstancesChange` is a new event on the component system registry, alongside the existing `update` / `animationUpdate` / `postUpdate`.

`ModelComponent` keeps its direct co-located rebind and is not moved onto the new event; worth a follow-up if the same non-co-located layout matters for the legacy component.