### PR TITLE
docs: harden the JSDoc and published types that LLMs read

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,6 @@ app.on('update', dt => box.rotate(10 * dt, 20 * dt, 30 * dt));
 app.start();
 ```
 
-Elsewhere in your code, or from the browser console, retrieve the running application with
-`AppBase.getApplication()`. You do not need to assign it to `window` yourself.
-
-Ready-made `Script` classes — camera and character controllers, post-processing, water, sky, XR and
-more — ship in the same package under the `playcanvas/scripts/esm/` subpath.
-
 Want to play with the code yourself? Edit it on [CodePen](https://codepen.io/playcanvas/pen/NPbxMj).
 
 A full guide to setting up a local development environment based on the PlayCanvas Engine can be found [here](https://developer.playcanvas.com/user-manual/engine/standalone/).
@@ -145,8 +139,3 @@ Now you can run various build options:
 | ------- | ----------- | ---------- |
 | `npm run build` | Build all engine flavors and type declarations | `build` |
 | `npm run docs` | Build engine [API reference docs](https://api.playcanvas.com/engine/) | `docs` |
-
-The ESM builds are emitted as per-module trees — `build/playcanvas/src/**`,
-`build/playcanvas.dbg/src/**` and `build/playcanvas.prf/src/**` — mirroring `src/` one file per
-module, each with its own `.d.ts`. These ship in the npm package and are the easiest way to read
-engine source or types for a single class without loading the whole `playcanvas.d.ts` bundle.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ app.start();
 ```
 
 Elsewhere in your code, or from the browser console, retrieve the running application with
-`Application.getApplication()`. You do not need to assign it to `window` yourself.
+`AppBase.getApplication()`. You do not need to assign it to `window` yourself.
 
 Ready-made `Script` classes — camera and character controllers, post-processing, water, sky, XR and
 more — ship in the same package under the `playcanvas/scripts/esm/` subpath.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ app.on('update', dt => box.rotate(10 * dt, 20 * dt, 30 * dt));
 app.start();
 ```
 
+Elsewhere in your code, or from the browser console, retrieve the running application with
+`Application.getApplication()`. You do not need to assign it to `window` yourself.
+
+Ready-made `Script` classes — camera and character controllers, post-processing, water, sky, XR and
+more — ship in the same package under the `playcanvas/scripts/esm/` subpath.
+
 Want to play with the code yourself? Edit it on [CodePen](https://codepen.io/playcanvas/pen/NPbxMj).
 
 A full guide to setting up a local development environment based on the PlayCanvas Engine can be found [here](https://developer.playcanvas.com/user-manual/engine/standalone/).
@@ -139,3 +145,8 @@ Now you can run various build options:
 | ------- | ----------- | ---------- |
 | `npm run build` | Build all engine flavors and type declarations | `build` |
 | `npm run docs` | Build engine [API reference docs](https://api.playcanvas.com/engine/) | `docs` |
+
+The ESM builds are emitted as per-module trees — `build/playcanvas/src/**`,
+`build/playcanvas.dbg/src/**` and `build/playcanvas.prf/src/**` — mirroring `src/` one file per
+module, each with its own `.d.ts`. These ship in the npm package and are the easiest way to read
+engine source or types for a single class without loading the whole `playcanvas.d.ts` bundle.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,12 @@ export default [
                     // extra tags, which this override would otherwise drop by replacing the rule
                     definedTags: [...new Set([...esmScriptTags, 'alpha', 'beta', 'category', 'import'])]
                 }
-            ]
+            ],
+            // a deprecated member is documented only to carry the @deprecated marker into the type
+            // declarations - requiring @param/@returns there would publish types for API we are
+            // steering callers away from, so exempt those blocks
+            'jsdoc/require-param': ['error', { exemptedBy: ['deprecated', 'inheritdoc'] }],
+            'jsdoc/require-returns': ['error', { exemptedBy: ['deprecated', 'inheritdoc'] }]
         }
     },
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,15 +31,7 @@ export default [
                     // extra tags, which this override would otherwise drop by replacing the rule
                     definedTags: [...new Set([...esmScriptTags, 'alpha', 'beta', 'category', 'import'])]
                 }
-            ],
-            // JSDoc is the type source here, so adding @param/@returns to a member that had no
-            // block overwrites the signature tsc inferred for it: `scale(scalar: any)` in
-            // playcanvas.d.ts becomes `scale(scalar: number)`. A @deprecated block on a legacy
-            // member exists only to carry the marker into the declarations and must leave the
-            // published signature alone, so it is exempt from both rules. `inheritdoc` is the
-            // plugin's own default, preserved here.
-            'jsdoc/require-param': ['error', { exemptedBy: ['deprecated', 'inheritdoc'] }],
-            'jsdoc/require-returns': ['error', { exemptedBy: ['deprecated', 'inheritdoc'] }]
+            ]
         }
     },
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,9 +32,12 @@ export default [
                     definedTags: [...new Set([...esmScriptTags, 'alpha', 'beta', 'category', 'import'])]
                 }
             ],
-            // a deprecated member is documented only to carry the @deprecated marker into the type
-            // declarations - requiring @param/@returns there would publish types for API we are
-            // steering callers away from, so exempt those blocks
+            // JSDoc is the type source here, so adding @param/@returns to a member that had no
+            // block overwrites the signature tsc inferred for it: `scale(scalar: any)` in
+            // playcanvas.d.ts becomes `scale(scalar: number)`. A @deprecated block on a legacy
+            // member exists only to carry the marker into the declarations and must leave the
+            // published signature alone, so it is exempt from both rules. `inheritdoc` is the
+            // plugin's own default, preserved here.
             'jsdoc/require-param': ['error', { exemptedBy: ['deprecated', 'inheritdoc'] }],
             'jsdoc/require-returns': ['error', { exemptedBy: ['deprecated', 'inheritdoc'] }]
         }

--- a/scripts/esm/camera-frame.mjs
+++ b/scripts/esm/camera-frame.mjs
@@ -678,8 +678,10 @@ class VolumetricFog {
  * of field and volumetric fog.
  *
  * Attach the script to an entity with a camera component and adjust the attribute groups to
- * configure the post-processing stack. Every group except `rendering` is gated by its own
- * `enabled` flag, which defaults to false.
+ * configure the post-processing stack. Most groups are gated by their own `enabled` flag, which
+ * defaults to false. Three are not: `rendering` is always applied, `ssao` is gated by its `type`
+ * (`SsaoType.NONE` by default) and `colorLUT` by its `texture` (null by default) — setting
+ * `enabled` on those two does nothing.
  *
  * Set the fields on the groups after creating the script. Do not pass a group through the
  * `properties` argument of {@link ScriptComponent#create}: that assignment is shallow, so it

--- a/scripts/esm/camera-frame.mjs
+++ b/scripts/esm/camera-frame.mjs
@@ -678,16 +678,19 @@ class VolumetricFog {
  * of field and volumetric fog.
  *
  * Attach the script to an entity with a camera component and adjust the attribute groups to
- * configure the post-processing stack.
+ * configure the post-processing stack. Every group except `rendering` is gated by its own
+ * `enabled` flag, which defaults to false.
+ *
+ * Set the fields on the groups after creating the script. Do not pass a group through the
+ * `properties` argument of {@link ScriptComponent#create}: that assignment is shallow, so it
+ * replaces the whole group object and drops its `enabled` flag, leaving the effect switched off.
  *
  * @example
  * cameraEntity.addComponent('script');
- * cameraEntity.script.create(CameraFrame, {
- *     properties: {
- *         rendering: { toneMapping: 'aces' },
- *         bloom: { intensity: 0.02 }
- *     }
- * });
+ * const cameraFrame = cameraEntity.script.create(CameraFrame);
+ * cameraFrame.rendering.toneMapping = 'aces';
+ * cameraFrame.bloom.enabled = true;
+ * cameraFrame.bloom.intensity = 0.02;
  * @category Post-Processing
  */
 class CameraFrame extends Script {

--- a/src/core/debug.js
+++ b/src/core/debug.js
@@ -3,6 +3,10 @@ import { Tracing } from './tracing.js';
 /**
  * Engine debug log system. Note that the logging only executes in the debug build of the engine,
  * and is stripped out in other builds.
+ *
+ * The debug build ships in the npm package: import from `'playcanvas/debug'` instead of
+ * `'playcanvas'` to enable assertions, deprecation notices and validation warnings. A
+ * `'playcanvas/profiler'` build is also available for per-frame timings.
  */
 class Debug {
     /**

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -439,7 +439,7 @@ class Vec2 {
     }
 
     /**
-     * @deprecated Vec2#scale is deprecated. Use Vec2#mulScalar instead.
+     * @deprecated Use Vec2#mulScalar instead.
      * @ignore
      */
     scale(scalar) {

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -440,6 +440,8 @@ class Vec2 {
 
     /**
      * @deprecated Use Vec2#mulScalar instead.
+     * @param {number} scalar - The number to multiply by.
+     * @returns {Vec2} Self for chaining.
      * @ignore
      */
     scale(scalar) {

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -438,7 +438,10 @@ class Vec2 {
         return this;
     }
 
-    /** @deprecated Vec2#scale is deprecated. Use Vec2#mulScalar instead. @ignore */
+    /**
+     * @deprecated Vec2#scale is deprecated. Use Vec2#mulScalar instead.
+     * @ignore
+     */
     scale(scalar) {
         Debug.deprecated('Vec2#scale is deprecated. Use Vec2#mulScalar instead.');
         return this.mulScalar(scalar);

--- a/src/core/math/vec2.js
+++ b/src/core/math/vec2.js
@@ -438,6 +438,7 @@ class Vec2 {
         return this;
     }
 
+    /** @deprecated Vec2#scale is deprecated. Use Vec2#mulScalar instead. @ignore */
     scale(scalar) {
         Debug.deprecated('Vec2#scale is deprecated. Use Vec2#mulScalar instead.');
         return this.mulScalar(scalar);

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -474,7 +474,7 @@ class Vec3 {
     }
 
     /**
-     * @deprecated Vec3#scale is deprecated. Use Vec3#mulScalar instead.
+     * @deprecated Use Vec3#mulScalar instead.
      * @ignore
      */
     scale(scalar) {

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -473,6 +473,7 @@ class Vec3 {
         return this;
     }
 
+    /** @deprecated Vec3#scale is deprecated. Use Vec3#mulScalar instead. @ignore */
     scale(scalar) {
         Debug.deprecated('Vec3#scale is deprecated. Use Vec3#mulScalar instead.');
         return this.mulScalar(scalar);

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -473,7 +473,10 @@ class Vec3 {
         return this;
     }
 
-    /** @deprecated Vec3#scale is deprecated. Use Vec3#mulScalar instead. @ignore */
+    /**
+     * @deprecated Vec3#scale is deprecated. Use Vec3#mulScalar instead.
+     * @ignore
+     */
     scale(scalar) {
         Debug.deprecated('Vec3#scale is deprecated. Use Vec3#mulScalar instead.');
         return this.mulScalar(scalar);

--- a/src/core/math/vec3.js
+++ b/src/core/math/vec3.js
@@ -475,6 +475,8 @@ class Vec3 {
 
     /**
      * @deprecated Use Vec3#mulScalar instead.
+     * @param {number} scalar - The number to multiply by.
+     * @returns {Vec3} Self for chaining.
      * @ignore
      */
     scale(scalar) {

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -450,7 +450,10 @@ class Vec4 {
         return this;
     }
 
-    /** @deprecated Vec4#scale is deprecated. Use Vec4#mulScalar instead. @ignore */
+    /**
+     * @deprecated Vec4#scale is deprecated. Use Vec4#mulScalar instead.
+     * @ignore
+     */
     scale(scalar) {
         Debug.deprecated('Vec4#scale is deprecated. Use Vec4#mulScalar instead.');
         return this.mulScalar(scalar);

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -451,7 +451,7 @@ class Vec4 {
     }
 
     /**
-     * @deprecated Vec4#scale is deprecated. Use Vec4#mulScalar instead.
+     * @deprecated Use Vec4#mulScalar instead.
      * @ignore
      */
     scale(scalar) {

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -450,6 +450,7 @@ class Vec4 {
         return this;
     }
 
+    /** @deprecated Vec4#scale is deprecated. Use Vec4#mulScalar instead. @ignore */
     scale(scalar) {
         Debug.deprecated('Vec4#scale is deprecated. Use Vec4#mulScalar instead.');
         return this.mulScalar(scalar);

--- a/src/core/math/vec4.js
+++ b/src/core/math/vec4.js
@@ -452,6 +452,8 @@ class Vec4 {
 
     /**
      * @deprecated Use Vec4#mulScalar instead.
+     * @param {number} scalar - The number to multiply by.
+     * @returns {Vec4} Self for chaining.
      * @ignore
      */
     scale(scalar) {

--- a/src/core/tracing.js
+++ b/src/core/tracing.js
@@ -3,6 +3,10 @@
  * Note that the trace logging only takes place in the debug build of the engine and is stripped
  * out in other builds.
  *
+ * The debug build ships in the npm package: import from `'playcanvas/debug'` instead of
+ * `'playcanvas'` to enable trace channels, assertions and validation warnings. A
+ * `'playcanvas/profiler'` build is also available for per-frame timings.
+ *
  * @category Debug
  */
 class Tracing {

--- a/src/extras/mini-stats/mini-stats.js
+++ b/src/extras/mini-stats/mini-stats.js
@@ -77,9 +77,11 @@ const delayedStartStats = new Set([
  * it shows CPU and GPU utilization, frame timings and draw call count. It can also be configured
  * to display additional graphs based on data collected into `AppBase#stats`.
  *
- * Detailed per-frame sub-timings — render, script, anim and physics — are only populated in the
- * profiler build; import from `'playcanvas/profiler'` to obtain them. In other builds those
- * counters read zero.
+ * The detailed per-frame sub-timings — script, anim, physics and gsplat sort — are measured in
+ * every build. The render timing is the exception: its start timestamp is only recorded in the
+ * debug and profiler builds, so in the release build the render graph reports the time elapsed
+ * since page load rather than a frame time. Import from `'playcanvas/debug'` or
+ * `'playcanvas/profiler'` for a meaningful render figure.
  */
 class MiniStats {
     /**

--- a/src/extras/mini-stats/mini-stats.js
+++ b/src/extras/mini-stats/mini-stats.js
@@ -75,7 +75,11 @@ const delayedStartStats = new Set([
 /**
  * MiniStats is a small graphical overlay that displays realtime performance metrics. By default,
  * it shows CPU and GPU utilization, frame timings and draw call count. It can also be configured
- * to display additional graphs based on data collected into {@link AppBase#stats}.
+ * to display additional graphs based on data collected into `AppBase#stats`.
+ *
+ * Detailed per-frame sub-timings — render, script, anim and physics — are only populated in the
+ * profiler build; import from `'playcanvas/profiler'` to obtain them. In other builds those
+ * counters read zero.
  */
 class MiniStats {
     /**

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -117,6 +117,11 @@ let app = null;
  *
  * It is the preferred entry point for new code - {@link Application} is a convenience subclass
  * that registers everything for you, and is expected to be deprecated in a future release.
+ *
+ * `new AppBase(canvas)` only constructs the instance and its root entity. You must then call
+ * {@link AppBase#init} with an {@link AppOptions} supplying at minimum `graphicsDevice`,
+ * `componentSystems` and `resourceHandlers` before adding components or calling
+ * {@link AppBase#start}. {@link Application} assembles those options for you.
  */
 class AppBase extends EventHandler {
     /**

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -121,7 +121,7 @@ let app = null;
  * `new AppBase(canvas)` only constructs the instance and its root entity. You must then call
  * {@link AppBase#init} with an {@link AppOptions} supplying at minimum `graphicsDevice`,
  * `componentSystems` and `resourceHandlers` before adding components or calling
- * {@link AppBase#start}. {@link Application} assembles those options for you.
+ * {@link AppBase#start}. Create the `graphicsDevice` with {@link createGraphicsDevice}.
  */
 class AppBase extends EventHandler {
     /**

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1185,7 +1185,10 @@ class AppBase extends EventHandler {
     }
 
     /**
-     * Controls how the canvas fills the window and resizes when the window changes.
+     * Controls how the canvas fills the window. The canvas is sized when this is called and on
+     * every {@link AppBase#resizeCanvas}; the engine installs no window `resize` listener of its
+     * own, so call `resizeCanvas` from your own handler to keep the window-relative modes tracking
+     * the window.
      *
      * @param {string} mode - The mode to use when setting the size of the canvas. Can be:
      *

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -97,6 +97,11 @@ import { XrManager } from './xr/xr-manager.js';
  * The component systems this class registers are listed on the constructor below. That list
  * doubles as a migration checklist, as it maps each component name to the system you would need
  * to register yourself.
+ *
+ * {@link AppBase#keyboard}, {@link AppBase#mouse}, {@link AppBase#touch},
+ * {@link AppBase#gamepads} and {@link AppBase#elementInput} stay `null` unless the matching device
+ * is passed to this constructor, so a game that reads input must construct with, for example,
+ * `{ keyboard: new Keyboard(window), mouse: new Mouse(canvas), touch: new TouchDevice(canvas) }`.
  */
 class Application extends AppBase {
     /**

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -554,9 +554,11 @@ class Asset extends EventHandler {
      * Take a callback which is called as soon as the asset is loaded. If the asset is already
      * loaded the callback is called straight away.
      *
-     * The callback fires on success only. A failed load still marks the asset as loaded, but fires
-     * `error` rather than `load`, so this callback never runs — listen for the `error` event as
-     * well whenever a failure has to be handled, and never await this callback alone.
+     * The callback fires on success only, and a failed load still marks the asset as loaded while
+     * firing `error` rather than `load`. So a callback registered before the failure never runs,
+     * and one registered after it runs immediately with {@link Asset#resource} still null. Listen
+     * for the `error` event as well whenever a failure has to be handled, check `asset.resource`
+     * inside the callback, and never await this callback alone.
      *
      * @param {AssetReadyCallback} callback - The function called when the asset is ready. Passed
      * the (asset) arguments.

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -554,6 +554,10 @@ class Asset extends EventHandler {
      * Take a callback which is called as soon as the asset is loaded. If the asset is already
      * loaded the callback is called straight away.
      *
+     * The callback fires on success only. A failed load still marks the asset as loaded, but fires
+     * `error` rather than `load`, so this callback never runs — listen for the `error` event as
+     * well whenever a failure has to be handled, and never await this callback alone.
+     *
      * @param {AssetReadyCallback} callback - The function called when the asset is ready. Passed
      * the (asset) arguments.
      * @param {object} [scope] - Scope object to use when calling the callback.

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1153,8 +1153,12 @@ class CameraComponent extends Component {
     /**
      * Convert a point from 3D world space to 2D screen space.
      *
-     * A returned `z` of zero or less means the point is behind the camera and the x and y values
-     * are not meaningful. For DOM labels anchored to world positions,
+     * The returned `z` is the unnormalized clip space depth, not a behind-the-camera flag: it also
+     * goes negative for points in front of a perspective camera that are nearer than twice the
+     * near clip, and for an orthographic camera it is negative across the whole near half of the
+     * depth range. To reject points behind the camera, test the view space depth instead - pass
+     * the world position through {@link CameraComponent#viewMatrix} and discard it when the
+     * resulting `z` is zero or greater. For DOM labels anchored to world positions,
      * `playcanvas/scripts/esm/annotations.mjs` provides `Annotation` and `AnnotationManager`,
      * which handle behind-camera rejection and occlusion fading.
      *

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -61,6 +61,10 @@ import { PostEffectQueue } from './post-effect-queue.js';
  * console.log(entity.camera.nearClip); // Get the near clip of the camera
  * ```
  *
+ * For ready-made camera behaviour, attach the `CameraControls` script from
+ * `playcanvas/scripts/esm/camera-controls.mjs`, which provides orbit, fly and pan driven by mouse,
+ * touch and gamepad input.
+ *
  * Relevant Engine API examples:
  *
  * - [First Person Camera](https://playcanvas.github.io/#/camera/first-person)
@@ -1148,6 +1152,11 @@ class CameraComponent extends Component {
 
     /**
      * Convert a point from 3D world space to 2D screen space.
+     *
+     * A returned `z` of zero or less means the point is behind the camera and the x and y values
+     * are not meaningful. For DOM labels anchored to world positions,
+     * `playcanvas/scripts/esm/annotations.mjs` provides `Annotation` and `AnnotationManager`,
+     * which handle behind-camera rejection and occlusion fading.
      *
      * @param {Vec3} worldCoord - The world space coordinate.
      * @param {Vec3} [screenCoord] - 3D vector to receive screen coordinate result.

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -1158,9 +1158,7 @@ class CameraComponent extends Component {
      * near clip, and for an orthographic camera it is negative across the whole near half of the
      * depth range. To reject points behind the camera, test the view space depth instead - pass
      * the world position through {@link CameraComponent#viewMatrix} and discard it when the
-     * resulting `z` is zero or greater. For DOM labels anchored to world positions,
-     * `playcanvas/scripts/esm/annotations.mjs` provides `Annotation` and `AnnotationManager`,
-     * which handle behind-camera rejection and occlusion fading.
+     * resulting `z` is zero or greater.
      *
      * @param {Vec3} worldCoord - The world space coordinate.
      * @param {Vec3} [screenCoord] - 3D vector to receive screen coordinate result.

--- a/src/framework/components/camera/post-effect-queue.js
+++ b/src/framework/components/camera/post-effect-queue.js
@@ -20,7 +20,10 @@ class PostEffectEntry {
 }
 
 /**
- * Used to manage multiple post effects for a camera.
+ * Used to manage multiple post effects for a camera. This is the legacy post-processing path. For
+ * new work use {@link CameraFrame}, which implements bloom, SSAO, depth of field, TAA, volumetric
+ * fog and tone mapping as one HDR pipeline; `playcanvas/scripts/esm/camera-frame.mjs` wraps it as
+ * an attachable script.
  *
  * @category Graphics
  */

--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -415,6 +415,10 @@ class LightComponent extends Component {
     /**
      * Sets whether the light will cast shadows. Defaults to false.
      *
+     * For a directional light, shadows are only rendered out to
+     * {@link LightComponent#shadowDistance} from the viewpoint, which defaults to 40. Size that to
+     * the area the camera actually sees, or shadows simply stop appearing beyond it.
+     *
      * @type {boolean}
      */
     set castShadows(value) {

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -636,7 +636,10 @@ class RenderComponent extends Component {
 
     /**
      * Sets the material {@link Material} that will be used to render the component. The material
-     * is ignored for renders of type 'asset'.
+     * is ignored for renders of type 'asset' — which is the type every entity produced by
+     * `instantiateRenderEntity` carries, so this setter has no effect on models loaded from a
+     * container. For those, assign `material` on each entry of
+     * {@link RenderComponent#meshInstances} instead.
      *
      * @type {Material}
      */

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -59,6 +59,11 @@ const _vecB = new Vec3();
  * console.log(entity.rigidbody.mass);
  * ```
  *
+ * For player movement, `playcanvas/scripts/esm/first-person-controller.mjs` and
+ * `playcanvas/scripts/esm/third-person-controller.mjs` ship complete rigidbody character
+ * controllers with capsule collision, damped ground and air movement, sprinting, jumping and
+ * camera control. Attach one instead of driving the body by hand.
+ *
  * Relevant Engine API examples:
  *
  * - [Falling shapes](https://playcanvas.github.io/#/physics/falling-shapes)

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -20,6 +20,13 @@ import { http } from '../../platform/net/http.js';
 /**
  * Load resource data, potentially from remote sources. Caches resource on load to prevent multiple
  * requests. Add ResourceHandlers to handle different types of resources.
+ *
+ * Parsers for formats the engine does not load by default ship in the package and are registered
+ * on an existing handler rather than added as one:
+ * `playcanvas/scripts/esm/parsers/obj-model.mjs` adds `.obj` model loading via
+ * `loader.getHandler('model').addParser(new ObjModelParser(device))`, and
+ * `playcanvas/scripts/esm/parsers/spz-parser.mjs` adds `.spz` Gaussian-splat loading via
+ * `loader.getHandler('gsplat').addParser(new SpzParser(app))`.
  */
 class ResourceLoader {
     /**

--- a/src/framework/script/script.js
+++ b/src/framework/script/script.js
@@ -43,6 +43,12 @@ import { SCRIPT_INITIALIZE, SCRIPT_POST_INITIALIZE } from './constants.js';
  *
  * For more information on how to create scripts, see the [Scripting Overview](https://developer.playcanvas.com/user-manual/scripting/).
  *
+ * The `playcanvas` package also ships a library of ready-to-use `Script` subclasses under the
+ * `playcanvas/scripts/esm/` subpath — camera and character controllers, post-processing, water,
+ * sky, grid, shadow catcher, planar reflections, XR and Gaussian-splat effects. Import them
+ * directly, for example
+ * `import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs'`.
+ *
  * @category Script
  */
 export class Script extends EventHandler {

--- a/src/framework/xr/xr-manager.js
+++ b/src/framework/xr/xr-manager.js
@@ -49,6 +49,12 @@ import { DEVICETYPE_WEBGPU } from '../../platform/graphics/constants.js';
  * The {@link AppBase} class automatically creates an instance of this class and makes it available
  * as {@link AppBase#xr}.
  *
+ * Ready-made XR building blocks ship under `playcanvas/scripts/esm/xr/`: `xr-session.mjs` for
+ * session lifecycle and camera rig transforms, `xr-controllers.mjs` for WebXR controller and hand
+ * models, `xr-navigation.mjs` for teleportation, smooth locomotion and turning,
+ * `xr-manipulation.mjs` for two-handed drag, rotate and scale of the world, and `xr-menu.mjs` for
+ * hand-tracked and controller-driven 3D menus.
+ *
  * @category XR
  */
 class XrManager extends EventHandler {

--- a/src/platform/graphics/blend-state.js
+++ b/src/platform/graphics/blend-state.js
@@ -462,6 +462,7 @@ class BlendState {
      */
     static NOBLEND = Object.freeze(new BlendState());
 
+    /** @deprecated BlendState.DEFAULT is deprecated. Use BlendState.NOBLEND instead. @ignore */
     static get DEFAULT() {
         Debug.deprecated('BlendState.DEFAULT is deprecated. Use BlendState.NOBLEND instead.');
         return BlendState.NOBLEND;

--- a/src/platform/graphics/blend-state.js
+++ b/src/platform/graphics/blend-state.js
@@ -463,7 +463,7 @@ class BlendState {
     static NOBLEND = Object.freeze(new BlendState());
 
     /**
-     * @deprecated BlendState.DEFAULT is deprecated. Use BlendState.NOBLEND instead.
+     * @deprecated Use BlendState.NOBLEND instead.
      * @ignore
      */
     static get DEFAULT() {

--- a/src/platform/graphics/blend-state.js
+++ b/src/platform/graphics/blend-state.js
@@ -462,7 +462,10 @@ class BlendState {
      */
     static NOBLEND = Object.freeze(new BlendState());
 
-    /** @deprecated BlendState.DEFAULT is deprecated. Use BlendState.NOBLEND instead. @ignore */
+    /**
+     * @deprecated BlendState.DEFAULT is deprecated. Use BlendState.NOBLEND instead.
+     * @ignore
+     */
     static get DEFAULT() {
         Debug.deprecated('BlendState.DEFAULT is deprecated. Use BlendState.NOBLEND instead.');
         return BlendState.NOBLEND;

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -952,71 +952,85 @@ class GraphicsDevice extends EventHandler {
 
     // ---- deprecated block start ----
 
+    /** @deprecated GraphicsDevice#boneLimit is deprecated and the limit has been removed. @ignore */
     get boneLimit() {
         Debug.deprecated('GraphicsDevice#boneLimit is deprecated and the limit has been removed.');
         return 1024;
     }
 
+    /** @deprecated GraphicsDevice#webgl2 is deprecated, use GraphicsDevice#isWebGL2 instead. @ignore */
     get webgl2() {
         Debug.deprecated('GraphicsDevice#webgl2 is deprecated, use GraphicsDevice#isWebGL2 instead.');
         return this.isWebGL2;
     }
 
+    /** @deprecated GraphicsDevice#textureFloatHighPrecision is deprecated and always returns true. @ignore */
     get textureFloatHighPrecision() {
         Debug.deprecated('GraphicsDevice#textureFloatHighPrecision is deprecated and always returns true.');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#extBlendMinmax is deprecated as it is always true. @ignore */
     get extBlendMinmax() {
         Debug.deprecated('GraphicsDevice#extBlendMinmax is deprecated as it is always true.');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#extTextureHalfFloat is deprecated as it is always true. @ignore */
     get extTextureHalfFloat() {
         Debug.deprecated('GraphicsDevice#extTextureHalfFloat is deprecated as it is always true.');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#extTextureLod is deprecated as it is always true. @ignore */
     get extTextureLod() {
         Debug.deprecated('GraphicsDevice#extTextureLod is deprecated as it is always true.');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#textureHalfFloatFilterable is deprecated as it is always true. @ignore */
     get textureHalfFloatFilterable() {
         Debug.deprecated('GraphicsDevice#textureHalfFloatFilterable is deprecated as it is always true.');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#supportsMrt is deprecated as it is always true. @ignore */
     get supportsMrt() {
         Debug.deprecated('GraphicsDevice#supportsMrt is deprecated as it is always true.');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#supportsVolumeTextures is deprecated as it is always true. @ignore */
     get supportsVolumeTextures() {
         Debug.deprecated('GraphicsDevice#supportsVolumeTextures is deprecated as it is always true.');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#supportsInstancing is deprecated as it is always true. @ignore */
     get supportsInstancing() {
         Debug.deprecated('GraphicsDevice#supportsInstancing is deprecated as it is always true.');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#textureHalfFloatUpdatable is deprecated as it is always true. @ignore */
     get textureHalfFloatUpdatable() {
         Debug.deprecated('GraphicsDevice#textureHalfFloatUpdatable is deprecated as it is always true.');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#extTextureFloat is deprecated as it is always true @ignore */
     get extTextureFloat() {
         Debug.deprecated('GraphicsDevice#extTextureFloat is deprecated as it is always true');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#extStandardDerivatives is deprecated as it is always true. @ignore */
     get extStandardDerivatives() {
         Debug.deprecated('GraphicsDevice#extStandardDerivatives is deprecated as it is always true.');
         return true;
     }
 
+    /** @deprecated GraphicsDevice#setBlendFunction is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
     setBlendFunction(blendSrc, blendDst) {
         Debug.deprecated('GraphicsDevice#setBlendFunction is deprecated, use GraphicsDevice.setBlendState instead.');
         const currentBlendState = this.blendState;
@@ -1026,6 +1040,7 @@ class GraphicsDevice extends EventHandler {
         this.setBlendState(_tempBlendState);
     }
 
+    /** @deprecated GraphicsDevice#setBlendFunctionSeparate is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
     setBlendFunctionSeparate(blendSrc, blendDst, blendSrcAlpha, blendDstAlpha) {
         Debug.deprecated('GraphicsDevice#setBlendFunctionSeparate is deprecated, use GraphicsDevice.setBlendState instead.');
         const currentBlendState = this.blendState;
@@ -1035,6 +1050,7 @@ class GraphicsDevice extends EventHandler {
         this.setBlendState(_tempBlendState);
     }
 
+    /** @deprecated GraphicsDevice#setBlendEquation is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
     setBlendEquation(blendEquation) {
         Debug.deprecated('GraphicsDevice#setBlendEquation is deprecated, use GraphicsDevice.setBlendState instead.');
         const currentBlendState = this.blendState;
@@ -1044,6 +1060,7 @@ class GraphicsDevice extends EventHandler {
         this.setBlendState(_tempBlendState);
     }
 
+    /** @deprecated GraphicsDevice#setBlendEquationSeparate is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
     setBlendEquationSeparate(blendEquation, blendAlphaEquation) {
         Debug.deprecated('GraphicsDevice#setBlendEquationSeparate is deprecated, use GraphicsDevice.setBlendState instead.');
         const currentBlendState = this.blendState;
@@ -1053,6 +1070,7 @@ class GraphicsDevice extends EventHandler {
         this.setBlendState(_tempBlendState);
     }
 
+    /** @deprecated GraphicsDevice#setColorWrite is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
     setColorWrite(redWrite, greenWrite, blueWrite, alphaWrite) {
         Debug.deprecated('GraphicsDevice#setColorWrite is deprecated, use GraphicsDevice.setBlendState instead.');
         const currentBlendState = this.blendState;
@@ -1065,6 +1083,7 @@ class GraphicsDevice extends EventHandler {
         return this.blendState.blend;
     }
 
+    /** @deprecated GraphicsDevice#setBlending is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
     setBlending(blending) {
         Debug.deprecated('GraphicsDevice#setBlending is deprecated, use GraphicsDevice.setBlendState instead.');
         _tempBlendState.copy(this.blendState);
@@ -1072,6 +1091,7 @@ class GraphicsDevice extends EventHandler {
         this.setBlendState(_tempBlendState);
     }
 
+    /** @deprecated GraphicsDevice#setDepthWrite is deprecated, use GraphicsDevice.setDepthState instead. @ignore */
     setDepthWrite(write) {
         Debug.deprecated('GraphicsDevice#setDepthWrite is deprecated, use GraphicsDevice.setDepthState instead.');
         _tempDepthState.copy(this.depthState);
@@ -1079,6 +1099,7 @@ class GraphicsDevice extends EventHandler {
         this.setDepthState(_tempDepthState);
     }
 
+    /** @deprecated GraphicsDevice#setDepthFunc is deprecated, use GraphicsDevice.setDepthState instead. @ignore */
     setDepthFunc(func) {
         Debug.deprecated('GraphicsDevice#setDepthFunc is deprecated, use GraphicsDevice.setDepthState instead.');
         _tempDepthState.copy(this.depthState);
@@ -1086,6 +1107,7 @@ class GraphicsDevice extends EventHandler {
         this.setDepthState(_tempDepthState);
     }
 
+    /** @deprecated GraphicsDevice#setDepthTest is deprecated, use GraphicsDevice.setDepthState instead. @ignore */
     setDepthTest(test) {
         Debug.deprecated('GraphicsDevice#setDepthTest is deprecated, use GraphicsDevice.setDepthState instead.');
         _tempDepthState.copy(this.depthState);

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -953,7 +953,7 @@ class GraphicsDevice extends EventHandler {
     // ---- deprecated block start ----
 
     /**
-     * @deprecated GraphicsDevice#boneLimit is deprecated and the limit has been removed.
+     * @deprecated The limit has been removed.
      * @ignore
      */
     get boneLimit() {
@@ -962,7 +962,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#webgl2 is deprecated, use GraphicsDevice#isWebGL2 instead.
+     * @deprecated Use GraphicsDevice#isWebGL2 instead.
      * @ignore
      */
     get webgl2() {
@@ -971,7 +971,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#textureFloatHighPrecision is deprecated and always returns true.
+     * @deprecated Always returns true.
      * @ignore
      */
     get textureFloatHighPrecision() {
@@ -980,7 +980,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#extBlendMinmax is deprecated as it is always true.
+     * @deprecated Always returns true.
      * @ignore
      */
     get extBlendMinmax() {
@@ -989,7 +989,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#extTextureHalfFloat is deprecated as it is always true.
+     * @deprecated Always returns true.
      * @ignore
      */
     get extTextureHalfFloat() {
@@ -998,7 +998,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#extTextureLod is deprecated as it is always true.
+     * @deprecated Always returns true.
      * @ignore
      */
     get extTextureLod() {
@@ -1007,7 +1007,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#textureHalfFloatFilterable is deprecated as it is always true.
+     * @deprecated Always returns true.
      * @ignore
      */
     get textureHalfFloatFilterable() {
@@ -1016,7 +1016,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#supportsMrt is deprecated as it is always true.
+     * @deprecated Always returns true.
      * @ignore
      */
     get supportsMrt() {
@@ -1025,7 +1025,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#supportsVolumeTextures is deprecated as it is always true.
+     * @deprecated Always returns true.
      * @ignore
      */
     get supportsVolumeTextures() {
@@ -1034,7 +1034,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#supportsInstancing is deprecated as it is always true.
+     * @deprecated Always returns true.
      * @ignore
      */
     get supportsInstancing() {
@@ -1043,7 +1043,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#textureHalfFloatUpdatable is deprecated as it is always true.
+     * @deprecated Always returns true.
      * @ignore
      */
     get textureHalfFloatUpdatable() {
@@ -1052,7 +1052,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#extTextureFloat is deprecated as it is always true
+     * @deprecated Always returns true.
      * @ignore
      */
     get extTextureFloat() {
@@ -1061,7 +1061,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#extStandardDerivatives is deprecated as it is always true.
+     * @deprecated Always returns true.
      * @ignore
      */
     get extStandardDerivatives() {
@@ -1070,8 +1070,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#setBlendFunction is deprecated, use GraphicsDevice.setBlendState
-     * instead.
+     * @deprecated Use GraphicsDevice.setBlendState instead.
      * @ignore
      */
     setBlendFunction(blendSrc, blendDst) {
@@ -1084,8 +1083,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#setBlendFunctionSeparate is deprecated, use
-     * GraphicsDevice.setBlendState instead.
+     * @deprecated Use GraphicsDevice.setBlendState instead.
      * @ignore
      */
     setBlendFunctionSeparate(blendSrc, blendDst, blendSrcAlpha, blendDstAlpha) {
@@ -1098,8 +1096,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#setBlendEquation is deprecated, use GraphicsDevice.setBlendState
-     * instead.
+     * @deprecated Use GraphicsDevice.setBlendState instead.
      * @ignore
      */
     setBlendEquation(blendEquation) {
@@ -1112,8 +1109,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#setBlendEquationSeparate is deprecated, use
-     * GraphicsDevice.setBlendState instead.
+     * @deprecated Use GraphicsDevice.setBlendState instead.
      * @ignore
      */
     setBlendEquationSeparate(blendEquation, blendAlphaEquation) {
@@ -1126,8 +1122,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#setColorWrite is deprecated, use GraphicsDevice.setBlendState
-     * instead.
+     * @deprecated Use GraphicsDevice.setBlendState instead.
      * @ignore
      */
     setColorWrite(redWrite, greenWrite, blueWrite, alphaWrite) {
@@ -1143,8 +1138,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#setBlending is deprecated, use GraphicsDevice.setBlendState
-     * instead.
+     * @deprecated Use GraphicsDevice.setBlendState instead.
      * @ignore
      */
     setBlending(blending) {
@@ -1155,8 +1149,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#setDepthWrite is deprecated, use GraphicsDevice.setDepthState
-     * instead.
+     * @deprecated Use GraphicsDevice.setDepthState instead.
      * @ignore
      */
     setDepthWrite(write) {
@@ -1167,8 +1160,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#setDepthFunc is deprecated, use GraphicsDevice.setDepthState
-     * instead.
+     * @deprecated Use GraphicsDevice.setDepthState instead.
      * @ignore
      */
     setDepthFunc(func) {
@@ -1179,8 +1171,7 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * @deprecated GraphicsDevice#setDepthTest is deprecated, use GraphicsDevice.setDepthState
-     * instead.
+     * @deprecated Use GraphicsDevice.setDepthState instead.
      * @ignore
      */
     setDepthTest(test) {

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -952,85 +952,128 @@ class GraphicsDevice extends EventHandler {
 
     // ---- deprecated block start ----
 
-    /** @deprecated GraphicsDevice#boneLimit is deprecated and the limit has been removed. @ignore */
+    /**
+     * @deprecated GraphicsDevice#boneLimit is deprecated and the limit has been removed.
+     * @ignore
+     */
     get boneLimit() {
         Debug.deprecated('GraphicsDevice#boneLimit is deprecated and the limit has been removed.');
         return 1024;
     }
 
-    /** @deprecated GraphicsDevice#webgl2 is deprecated, use GraphicsDevice#isWebGL2 instead. @ignore */
+    /**
+     * @deprecated GraphicsDevice#webgl2 is deprecated, use GraphicsDevice#isWebGL2 instead.
+     * @ignore
+     */
     get webgl2() {
         Debug.deprecated('GraphicsDevice#webgl2 is deprecated, use GraphicsDevice#isWebGL2 instead.');
         return this.isWebGL2;
     }
 
-    /** @deprecated GraphicsDevice#textureFloatHighPrecision is deprecated and always returns true. @ignore */
+    /**
+     * @deprecated GraphicsDevice#textureFloatHighPrecision is deprecated and always returns true.
+     * @ignore
+     */
     get textureFloatHighPrecision() {
         Debug.deprecated('GraphicsDevice#textureFloatHighPrecision is deprecated and always returns true.');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#extBlendMinmax is deprecated as it is always true. @ignore */
+    /**
+     * @deprecated GraphicsDevice#extBlendMinmax is deprecated as it is always true.
+     * @ignore
+     */
     get extBlendMinmax() {
         Debug.deprecated('GraphicsDevice#extBlendMinmax is deprecated as it is always true.');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#extTextureHalfFloat is deprecated as it is always true. @ignore */
+    /**
+     * @deprecated GraphicsDevice#extTextureHalfFloat is deprecated as it is always true.
+     * @ignore
+     */
     get extTextureHalfFloat() {
         Debug.deprecated('GraphicsDevice#extTextureHalfFloat is deprecated as it is always true.');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#extTextureLod is deprecated as it is always true. @ignore */
+    /**
+     * @deprecated GraphicsDevice#extTextureLod is deprecated as it is always true.
+     * @ignore
+     */
     get extTextureLod() {
         Debug.deprecated('GraphicsDevice#extTextureLod is deprecated as it is always true.');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#textureHalfFloatFilterable is deprecated as it is always true. @ignore */
+    /**
+     * @deprecated GraphicsDevice#textureHalfFloatFilterable is deprecated as it is always true.
+     * @ignore
+     */
     get textureHalfFloatFilterable() {
         Debug.deprecated('GraphicsDevice#textureHalfFloatFilterable is deprecated as it is always true.');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#supportsMrt is deprecated as it is always true. @ignore */
+    /**
+     * @deprecated GraphicsDevice#supportsMrt is deprecated as it is always true.
+     * @ignore
+     */
     get supportsMrt() {
         Debug.deprecated('GraphicsDevice#supportsMrt is deprecated as it is always true.');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#supportsVolumeTextures is deprecated as it is always true. @ignore */
+    /**
+     * @deprecated GraphicsDevice#supportsVolumeTextures is deprecated as it is always true.
+     * @ignore
+     */
     get supportsVolumeTextures() {
         Debug.deprecated('GraphicsDevice#supportsVolumeTextures is deprecated as it is always true.');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#supportsInstancing is deprecated as it is always true. @ignore */
+    /**
+     * @deprecated GraphicsDevice#supportsInstancing is deprecated as it is always true.
+     * @ignore
+     */
     get supportsInstancing() {
         Debug.deprecated('GraphicsDevice#supportsInstancing is deprecated as it is always true.');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#textureHalfFloatUpdatable is deprecated as it is always true. @ignore */
+    /**
+     * @deprecated GraphicsDevice#textureHalfFloatUpdatable is deprecated as it is always true.
+     * @ignore
+     */
     get textureHalfFloatUpdatable() {
         Debug.deprecated('GraphicsDevice#textureHalfFloatUpdatable is deprecated as it is always true.');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#extTextureFloat is deprecated as it is always true @ignore */
+    /**
+     * @deprecated GraphicsDevice#extTextureFloat is deprecated as it is always true
+     * @ignore
+     */
     get extTextureFloat() {
         Debug.deprecated('GraphicsDevice#extTextureFloat is deprecated as it is always true');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#extStandardDerivatives is deprecated as it is always true. @ignore */
+    /**
+     * @deprecated GraphicsDevice#extStandardDerivatives is deprecated as it is always true.
+     * @ignore
+     */
     get extStandardDerivatives() {
         Debug.deprecated('GraphicsDevice#extStandardDerivatives is deprecated as it is always true.');
         return true;
     }
 
-    /** @deprecated GraphicsDevice#setBlendFunction is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
+    /**
+     * @deprecated GraphicsDevice#setBlendFunction is deprecated, use GraphicsDevice.setBlendState
+     * instead.
+     * @ignore
+     */
     setBlendFunction(blendSrc, blendDst) {
         Debug.deprecated('GraphicsDevice#setBlendFunction is deprecated, use GraphicsDevice.setBlendState instead.');
         const currentBlendState = this.blendState;
@@ -1040,7 +1083,11 @@ class GraphicsDevice extends EventHandler {
         this.setBlendState(_tempBlendState);
     }
 
-    /** @deprecated GraphicsDevice#setBlendFunctionSeparate is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
+    /**
+     * @deprecated GraphicsDevice#setBlendFunctionSeparate is deprecated, use
+     * GraphicsDevice.setBlendState instead.
+     * @ignore
+     */
     setBlendFunctionSeparate(blendSrc, blendDst, blendSrcAlpha, blendDstAlpha) {
         Debug.deprecated('GraphicsDevice#setBlendFunctionSeparate is deprecated, use GraphicsDevice.setBlendState instead.');
         const currentBlendState = this.blendState;
@@ -1050,7 +1097,11 @@ class GraphicsDevice extends EventHandler {
         this.setBlendState(_tempBlendState);
     }
 
-    /** @deprecated GraphicsDevice#setBlendEquation is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
+    /**
+     * @deprecated GraphicsDevice#setBlendEquation is deprecated, use GraphicsDevice.setBlendState
+     * instead.
+     * @ignore
+     */
     setBlendEquation(blendEquation) {
         Debug.deprecated('GraphicsDevice#setBlendEquation is deprecated, use GraphicsDevice.setBlendState instead.');
         const currentBlendState = this.blendState;
@@ -1060,7 +1111,11 @@ class GraphicsDevice extends EventHandler {
         this.setBlendState(_tempBlendState);
     }
 
-    /** @deprecated GraphicsDevice#setBlendEquationSeparate is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
+    /**
+     * @deprecated GraphicsDevice#setBlendEquationSeparate is deprecated, use
+     * GraphicsDevice.setBlendState instead.
+     * @ignore
+     */
     setBlendEquationSeparate(blendEquation, blendAlphaEquation) {
         Debug.deprecated('GraphicsDevice#setBlendEquationSeparate is deprecated, use GraphicsDevice.setBlendState instead.');
         const currentBlendState = this.blendState;
@@ -1070,7 +1125,11 @@ class GraphicsDevice extends EventHandler {
         this.setBlendState(_tempBlendState);
     }
 
-    /** @deprecated GraphicsDevice#setColorWrite is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
+    /**
+     * @deprecated GraphicsDevice#setColorWrite is deprecated, use GraphicsDevice.setBlendState
+     * instead.
+     * @ignore
+     */
     setColorWrite(redWrite, greenWrite, blueWrite, alphaWrite) {
         Debug.deprecated('GraphicsDevice#setColorWrite is deprecated, use GraphicsDevice.setBlendState instead.');
         const currentBlendState = this.blendState;
@@ -1083,7 +1142,11 @@ class GraphicsDevice extends EventHandler {
         return this.blendState.blend;
     }
 
-    /** @deprecated GraphicsDevice#setBlending is deprecated, use GraphicsDevice.setBlendState instead. @ignore */
+    /**
+     * @deprecated GraphicsDevice#setBlending is deprecated, use GraphicsDevice.setBlendState
+     * instead.
+     * @ignore
+     */
     setBlending(blending) {
         Debug.deprecated('GraphicsDevice#setBlending is deprecated, use GraphicsDevice.setBlendState instead.');
         _tempBlendState.copy(this.blendState);
@@ -1091,7 +1154,11 @@ class GraphicsDevice extends EventHandler {
         this.setBlendState(_tempBlendState);
     }
 
-    /** @deprecated GraphicsDevice#setDepthWrite is deprecated, use GraphicsDevice.setDepthState instead. @ignore */
+    /**
+     * @deprecated GraphicsDevice#setDepthWrite is deprecated, use GraphicsDevice.setDepthState
+     * instead.
+     * @ignore
+     */
     setDepthWrite(write) {
         Debug.deprecated('GraphicsDevice#setDepthWrite is deprecated, use GraphicsDevice.setDepthState instead.');
         _tempDepthState.copy(this.depthState);
@@ -1099,7 +1166,11 @@ class GraphicsDevice extends EventHandler {
         this.setDepthState(_tempDepthState);
     }
 
-    /** @deprecated GraphicsDevice#setDepthFunc is deprecated, use GraphicsDevice.setDepthState instead. @ignore */
+    /**
+     * @deprecated GraphicsDevice#setDepthFunc is deprecated, use GraphicsDevice.setDepthState
+     * instead.
+     * @ignore
+     */
     setDepthFunc(func) {
         Debug.deprecated('GraphicsDevice#setDepthFunc is deprecated, use GraphicsDevice.setDepthState instead.');
         _tempDepthState.copy(this.depthState);
@@ -1107,7 +1178,11 @@ class GraphicsDevice extends EventHandler {
         this.setDepthState(_tempDepthState);
     }
 
-    /** @deprecated GraphicsDevice#setDepthTest is deprecated, use GraphicsDevice.setDepthState instead. @ignore */
+    /**
+     * @deprecated GraphicsDevice#setDepthTest is deprecated, use GraphicsDevice.setDepthState
+     * instead.
+     * @ignore
+     */
     setDepthTest(test) {
         Debug.deprecated('GraphicsDevice#setDepthTest is deprecated, use GraphicsDevice.setDepthState instead.');
         _tempDepthState.copy(this.depthState);

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -1071,6 +1071,8 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * @deprecated Use GraphicsDevice.setBlendState instead.
+     * @param {number} blendSrc - The blend mode. Can be any of the BLENDMODE_* constants.
+     * @param {number} blendDst - The blend mode. Can be any of the BLENDMODE_* constants.
      * @ignore
      */
     setBlendFunction(blendSrc, blendDst) {
@@ -1084,6 +1086,10 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * @deprecated Use GraphicsDevice.setBlendState instead.
+     * @param {number} blendSrc - The blend mode. Can be any of the BLENDMODE_* constants.
+     * @param {number} blendDst - The blend mode. Can be any of the BLENDMODE_* constants.
+     * @param {number} blendSrcAlpha - The blend mode. Can be any of the BLENDMODE_* constants.
+     * @param {number} blendDstAlpha - The blend mode. Can be any of the BLENDMODE_* constants.
      * @ignore
      */
     setBlendFunctionSeparate(blendSrc, blendDst, blendSrcAlpha, blendDstAlpha) {
@@ -1097,6 +1103,8 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * @deprecated Use GraphicsDevice.setBlendState instead.
+     * @param {number} blendEquation - The blend equation. Can be any of the BLENDEQUATION_*
+     * constants.
      * @ignore
      */
     setBlendEquation(blendEquation) {
@@ -1110,6 +1118,10 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * @deprecated Use GraphicsDevice.setBlendState instead.
+     * @param {number} blendEquation - The blend equation. Can be any of the BLENDEQUATION_*
+     * constants.
+     * @param {number} blendAlphaEquation - The blend equation. Can be any of the BLENDEQUATION_*
+     * constants.
      * @ignore
      */
     setBlendEquationSeparate(blendEquation, blendAlphaEquation) {
@@ -1123,6 +1135,10 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * @deprecated Use GraphicsDevice.setBlendState instead.
+     * @param {boolean} redWrite - True to enable writing of the red channel and false otherwise.
+     * @param {boolean} greenWrite - True to enable writing of the green channel and false otherwise.
+     * @param {boolean} blueWrite - True to enable writing of the blue channel and false otherwise.
+     * @param {boolean} alphaWrite - True to enable writing of the alpha channel and false otherwise.
      * @ignore
      */
     setColorWrite(redWrite, greenWrite, blueWrite, alphaWrite) {
@@ -1139,6 +1155,7 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * @deprecated Use GraphicsDevice.setBlendState instead.
+     * @param {boolean} blending - True to enable blending and false to disable it.
      * @ignore
      */
     setBlending(blending) {
@@ -1150,6 +1167,7 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * @deprecated Use GraphicsDevice.setDepthState instead.
+     * @param {boolean} write - True to enable depth writing and false otherwise.
      * @ignore
      */
     setDepthWrite(write) {
@@ -1161,6 +1179,7 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * @deprecated Use GraphicsDevice.setDepthState instead.
+     * @param {number} func - The depth testing function. Can be any of the FUNC_* constants.
      * @ignore
      */
     setDepthFunc(func) {
@@ -1172,6 +1191,7 @@ class GraphicsDevice extends EventHandler {
 
     /**
      * @deprecated Use GraphicsDevice.setDepthState instead.
+     * @param {boolean} test - True to enable depth testing and false otherwise.
      * @ignore
      */
     setDepthTest(test) {

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -833,9 +833,9 @@ class RenderTarget {
     }
 
     /**
-     * @deprecated RenderTarget#flipY is deprecated, use the "origin" option of the RenderTarget
-     * constructor instead. Typical migration: flipY: !device.isWebGPU -> origin:
-     * RENDERTARGET_ORIGIN_TOP, flipY: device.isWebGPU -> origin: RENDERTARGET_ORIGIN_BOTTOM.
+     * @deprecated Use the "origin" option of the RenderTarget constructor instead. Typical
+     * migration: flipY: !device.isWebGPU -> origin: RENDERTARGET_ORIGIN_TOP, flipY: device.isWebGPU
+     * -> origin: RENDERTARGET_ORIGIN_BOTTOM.
      * @ignore
      */
     set flipY(value) {

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -832,7 +832,12 @@ class RenderTarget {
         return success;
     }
 
-    /** @deprecated RenderTarget#flipY is deprecated, use the "origin" option of the RenderTarget constructor instead. Typical migration: flipY: !device.isWebGPU -> origin: RENDERTARGET_ORIGIN_TOP, flipY: device.isWebGPU -> origin: RENDERTARGET_ORIGIN_BOTTOM. @ignore */
+    /**
+     * @deprecated RenderTarget#flipY is deprecated, use the "origin" option of the RenderTarget
+     * constructor instead. Typical migration: flipY: !device.isWebGPU -> origin:
+     * RENDERTARGET_ORIGIN_TOP, flipY: device.isWebGPU -> origin: RENDERTARGET_ORIGIN_BOTTOM.
+     * @ignore
+     */
     set flipY(value) {
         Debug.deprecated('RenderTarget#flipY is deprecated, use the "origin" option of the RenderTarget constructor instead. Typical migration: flipY: !device.isWebGPU -> origin: RENDERTARGET_ORIGIN_TOP, flipY: device.isWebGPU -> origin: RENDERTARGET_ORIGIN_BOTTOM.');
         this._flipY = value;

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -832,6 +832,7 @@ class RenderTarget {
         return success;
     }
 
+    /** @deprecated RenderTarget#flipY is deprecated, use the "origin" option of the RenderTarget constructor instead. Typical migration: flipY: !device.isWebGPU -> origin: RENDERTARGET_ORIGIN_TOP, flipY: device.isWebGPU -> origin: RENDERTARGET_ORIGIN_BOTTOM. @ignore */
     set flipY(value) {
         Debug.deprecated('RenderTarget#flipY is deprecated, use the "origin" option of the RenderTarget constructor instead. Typical migration: flipY: !device.isWebGPU -> origin: RENDERTARGET_ORIGIN_TOP, flipY: device.isWebGPU -> origin: RENDERTARGET_ORIGIN_BOTTOM.');
         this._flipY = value;

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -1015,25 +1015,37 @@ class Texture {
         return this._type;
     }
 
-    /** @deprecated Texture#rgbm is deprecated. Use Texture#type instead. @ignore */
+    /**
+     * @deprecated Texture#rgbm is deprecated. Use Texture#type instead.
+     * @ignore
+     */
     set rgbm(value) {
         Debug.deprecated('Texture#rgbm is deprecated. Use Texture#type instead.');
         this.type = value ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
     }
 
-    /** @deprecated Texture#rgbm is deprecated. Use Texture#type instead. @ignore */
+    /**
+     * @deprecated Texture#rgbm is deprecated. Use Texture#type instead.
+     * @ignore
+     */
     get rgbm() {
         Debug.deprecated('Texture#rgbm is deprecated. Use Texture#type instead.');
         return this.type === TEXTURETYPE_RGBM;
     }
 
-    /** @deprecated Texture#swizzleGGGR is deprecated. Use Texture#type instead. @ignore */
+    /**
+     * @deprecated Texture#swizzleGGGR is deprecated. Use Texture#type instead.
+     * @ignore
+     */
     set swizzleGGGR(value) {
         Debug.deprecated('Texture#swizzleGGGR is deprecated. Use Texture#type instead.');
         this.type = value ? TEXTURETYPE_SWIZZLEGGGR : TEXTURETYPE_DEFAULT;
     }
 
-    /** @deprecated Texture#swizzleGGGR is deprecated. Use Texture#type instead. @ignore */
+    /**
+     * @deprecated Texture#swizzleGGGR is deprecated. Use Texture#type instead.
+     * @ignore
+     */
     get swizzleGGGR() {
         Debug.deprecated('Texture#swizzleGGGR is deprecated. Use Texture#type instead.');
         return this.type === TEXTURETYPE_SWIZZLEGGGR;

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -1015,21 +1015,25 @@ class Texture {
         return this._type;
     }
 
+    /** @deprecated Texture#rgbm is deprecated. Use Texture#type instead. @ignore */
     set rgbm(value) {
         Debug.deprecated('Texture#rgbm is deprecated. Use Texture#type instead.');
         this.type = value ? TEXTURETYPE_RGBM : TEXTURETYPE_DEFAULT;
     }
 
+    /** @deprecated Texture#rgbm is deprecated. Use Texture#type instead. @ignore */
     get rgbm() {
         Debug.deprecated('Texture#rgbm is deprecated. Use Texture#type instead.');
         return this.type === TEXTURETYPE_RGBM;
     }
 
+    /** @deprecated Texture#swizzleGGGR is deprecated. Use Texture#type instead. @ignore */
     set swizzleGGGR(value) {
         Debug.deprecated('Texture#swizzleGGGR is deprecated. Use Texture#type instead.');
         this.type = value ? TEXTURETYPE_SWIZZLEGGGR : TEXTURETYPE_DEFAULT;
     }
 
+    /** @deprecated Texture#swizzleGGGR is deprecated. Use Texture#type instead. @ignore */
     get swizzleGGGR() {
         Debug.deprecated('Texture#swizzleGGGR is deprecated. Use Texture#type instead.');
         return this.type === TEXTURETYPE_SWIZZLEGGGR;

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -1016,7 +1016,7 @@ class Texture {
     }
 
     /**
-     * @deprecated Texture#rgbm is deprecated. Use Texture#type instead.
+     * @deprecated Use Texture#type instead.
      * @ignore
      */
     set rgbm(value) {
@@ -1025,7 +1025,7 @@ class Texture {
     }
 
     /**
-     * @deprecated Texture#rgbm is deprecated. Use Texture#type instead.
+     * @deprecated Use Texture#type instead.
      * @ignore
      */
     get rgbm() {
@@ -1034,7 +1034,7 @@ class Texture {
     }
 
     /**
-     * @deprecated Texture#swizzleGGGR is deprecated. Use Texture#type instead.
+     * @deprecated Use Texture#type instead.
      * @ignore
      */
     set swizzleGGGR(value) {
@@ -1043,7 +1043,7 @@ class Texture {
     }
 
     /**
-     * @deprecated Texture#swizzleGGGR is deprecated. Use Texture#type instead.
+     * @deprecated Use Texture#type instead.
      * @ignore
      */
     get swizzleGGGR() {

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -236,6 +236,7 @@ class VertexFormat {
         });
     }
 
+    /** @deprecated VertexFormat.defaultInstancingFormat was removed. Use VertexFormat.getDefaultInstancingFormat(graphicsDevice). @ignore */
     static get defaultInstancingFormat() {
         Debug.removed('VertexFormat.defaultInstancingFormat was removed. Use VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
         return null;

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -236,7 +236,11 @@ class VertexFormat {
         });
     }
 
-    /** @deprecated VertexFormat.defaultInstancingFormat was removed. Use VertexFormat.getDefaultInstancingFormat(graphicsDevice). @ignore */
+    /**
+     * @deprecated VertexFormat.defaultInstancingFormat was removed. Use
+     * VertexFormat.getDefaultInstancingFormat(graphicsDevice).
+     * @ignore
+     */
     static get defaultInstancingFormat() {
         Debug.removed('VertexFormat.defaultInstancingFormat was removed. Use VertexFormat.getDefaultInstancingFormat(graphicsDevice).');
         return null;

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -237,8 +237,7 @@ class VertexFormat {
     }
 
     /**
-     * @deprecated VertexFormat.defaultInstancingFormat was removed. Use
-     * VertexFormat.getDefaultInstancingFormat(graphicsDevice).
+     * @deprecated Use VertexFormat.getDefaultInstancingFormat(graphicsDevice).
      * @ignore
      */
     static get defaultInstancingFormat() {

--- a/src/platform/graphics/vertex-format.js
+++ b/src/platform/graphics/vertex-format.js
@@ -238,6 +238,7 @@ class VertexFormat {
 
     /**
      * @deprecated Use VertexFormat.getDefaultInstancingFormat(graphicsDevice).
+     * @returns {null} Always null.
      * @ignore
      */
     static get defaultInstancingFormat() {

--- a/src/platform/input/game-pads.js
+++ b/src/platform/input/game-pads.js
@@ -766,6 +766,10 @@ class GamePad {
 /**
  * Input handler for accessing GamePad input.
  *
+ * For frame-accumulated input deltas rather than raw pad state, see {@link GamepadSource},
+ * {@link KeyboardMouseSource} and {@link MultiTouchSource}, which feed {@link InputController}s
+ * such as {@link OrbitController}, {@link FlyController} and {@link FocusController}.
+ *
  * @category Input
  */
 class GamePads extends EventHandler {

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -59,6 +59,14 @@ const _keyCodeToKeyIdentifier = {
  * changes and window blur events by clearing key states. The Keyboard instance must be attached to
  * a DOM element before it can detect key events.
  *
+ * Key state is derived from the legacy `KeyboardEvent.keyCode` property. Browsers populate it for
+ * real input, but a hand-constructed `new KeyboardEvent(...)` leaves it at 0, so synthesized events
+ * must set `keyCode` explicitly in order to be observed.
+ *
+ * {@link Keyboard#wasPressed} and {@link Keyboard#wasReleased} compare against a snapshot taken
+ * once per frame, so a keydown and keyup delivered within the same task are seen by neither. Hold
+ * the key across at least one frame.
+ *
  * Your application's Keyboard instance is managed and accessible via {@link AppBase#keyboard}.
  *
  * @category Input

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -69,6 +69,11 @@ const _keyCodeToKeyIdentifier = {
  *
  * Your application's Keyboard instance is managed and accessible via {@link AppBase#keyboard}.
  *
+ * For pointer-lock-aware, frame-accumulated input deltas rather than raw events, see
+ * {@link KeyboardMouseSource}, {@link GamepadSource} and {@link MultiTouchSource}, which feed
+ * {@link InputController}s such as {@link OrbitController}, {@link FlyController} and
+ * {@link FocusController}.
+ *
  * @category Input
  */
 class Keyboard extends EventHandler {

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -19,6 +19,11 @@ import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
  *
  * Your application's Mouse instance is managed and accessible via {@link AppBase#mouse}.
  *
+ * For pointer-lock-aware, frame-accumulated input deltas rather than raw events, see
+ * {@link KeyboardMouseSource}, {@link GamepadSource} and {@link MultiTouchSource}, which feed
+ * {@link InputController}s such as {@link OrbitController}, {@link FlyController} and
+ * {@link FocusController}.
+ *
  * @category Input
  */
 class Mouse extends EventHandler {

--- a/src/scene/composition/layer-composition.js
+++ b/src/scene/composition/layer-composition.js
@@ -403,6 +403,11 @@ class LayerComposition extends EventHandler {
     /**
      * Adds a layer (both opaque and semi-transparent parts) to the end of the {@link layerList}.
      *
+     * The default composition ends with the UI layer, so a layer pushed here renders after the UI
+     * and after the last layer a camera's post-processing applies to. To place a layer inside the
+     * post-processed range instead, use {@link LayerComposition#insert} with an index from
+     * {@link LayerComposition#getOpaqueIndex}.
+     *
      * @param {Layer} layer - A {@link Layer} to add.
      */
     push(layer) {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -399,7 +399,7 @@ class GraphNode extends EventHandler {
     // ---- deprecated block start ----
 
     /**
-     * @deprecated GraphNode#getChildren is deprecated. Use GraphNode#children instead.
+     * @deprecated Use GraphNode#children instead.
      * @ignore
      */
     getChildren() {
@@ -408,7 +408,7 @@ class GraphNode extends EventHandler {
     }
 
     /**
-     * @deprecated GraphNode#getName is deprecated. Use GraphNode#name instead.
+     * @deprecated Use GraphNode#name instead.
      * @ignore
      */
     getName() {
@@ -417,7 +417,7 @@ class GraphNode extends EventHandler {
     }
 
     /**
-     * @deprecated GraphNode#getPath is deprecated. Use GraphNode#path instead.
+     * @deprecated Use GraphNode#path instead.
      * @ignore
      */
     getPath() {
@@ -426,7 +426,7 @@ class GraphNode extends EventHandler {
     }
 
     /**
-     * @deprecated GraphNode#getRoot is deprecated. Use GraphNode#root instead.
+     * @deprecated Use GraphNode#root instead.
      * @ignore
      */
     getRoot() {
@@ -435,7 +435,7 @@ class GraphNode extends EventHandler {
     }
 
     /**
-     * @deprecated GraphNode#getParent is deprecated. Use GraphNode#parent instead.
+     * @deprecated Use GraphNode#parent instead.
      * @ignore
      */
     getParent() {
@@ -444,7 +444,7 @@ class GraphNode extends EventHandler {
     }
 
     /**
-     * @deprecated GraphNode#setName is deprecated. Use GraphNode#name instead.
+     * @deprecated Use GraphNode#name instead.
      * @ignore
      */
     setName(name) {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1601,8 +1601,8 @@ class GraphNode extends EventHandler {
      *
      * The up vector must not be parallel to the direction from the node to the target. When it is —
      * looking straight up or down with the default up vector, or at the node's own position — the
-     * basis is degenerate and the node is left unrotated, with nothing reported. Pass a different
-     * up vector in those cases.
+     * basis is degenerate and the node's rotation is reset to identity, discarding whatever
+     * rotation it already had, with nothing reported. Pass a different up vector in those cases.
      *
      * @overload
      * @param {number} x - X-component of the world space coordinate to look at.

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -398,31 +398,37 @@ class GraphNode extends EventHandler {
 
     // ---- deprecated block start ----
 
+    /** @deprecated GraphNode#getChildren is deprecated. Use GraphNode#children instead. @ignore */
     getChildren() {
         Debug.deprecated('GraphNode#getChildren is deprecated. Use GraphNode#children instead.');
         return this.children;
     }
 
+    /** @deprecated GraphNode#getName is deprecated. Use GraphNode#name instead. @ignore */
     getName() {
         Debug.deprecated('GraphNode#getName is deprecated. Use GraphNode#name instead.');
         return this.name;
     }
 
+    /** @deprecated GraphNode#getPath is deprecated. Use GraphNode#path instead. @ignore */
     getPath() {
         Debug.deprecated('GraphNode#getPath is deprecated. Use GraphNode#path instead.');
         return this.path;
     }
 
+    /** @deprecated GraphNode#getRoot is deprecated. Use GraphNode#root instead. @ignore */
     getRoot() {
         Debug.deprecated('GraphNode#getRoot is deprecated. Use GraphNode#root instead.');
         return this.root;
     }
 
+    /** @deprecated GraphNode#getParent is deprecated. Use GraphNode#parent instead. @ignore */
     getParent() {
         Debug.deprecated('GraphNode#getParent is deprecated. Use GraphNode#parent instead.');
         return this.parent;
     }
 
+    /** @deprecated GraphNode#setName is deprecated. Use GraphNode#name instead. @ignore */
     setName(name) {
         Debug.deprecated('GraphNode#setName is deprecated. Use GraphNode#name instead.');
         this.name = name;

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -436,6 +436,7 @@ class GraphNode extends EventHandler {
 
     /**
      * @deprecated Use GraphNode#parent instead.
+     * @returns {GraphNode|null} The parent node, or null if this node has no parent.
      * @ignore
      */
     getParent() {
@@ -445,6 +446,7 @@ class GraphNode extends EventHandler {
 
     /**
      * @deprecated Use GraphNode#name instead.
+     * @param {string} name - The name to set.
      * @ignore
      */
     setName(name) {

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -1337,6 +1337,10 @@ class GraphNode extends EventHandler {
      * Add a new child to the child list and update the parent value of the child node.
      * If the node already had a parent, it is removed from its child list.
      *
+     * The child keeps its existing local transform, which is now interpreted relative to the new
+     * parent, so a node placed in world space before being added will appear to move. Set the
+     * transform after adding, or re-apply the world placement with {@link GraphNode#setPosition}.
+     *
      * @param {GraphNode} node - The new child to add.
      * @example
      * const e = new Entity(app);
@@ -1473,6 +1477,10 @@ class GraphNode extends EventHandler {
     /**
      * Remove the node from the child list and update the parent value of the child.
      *
+     * This detaches the node without disabling it: the removed subtree still reports
+     * `enabled === true`, and its lights, cameras, scripts and sounds keep running. Set
+     * `enabled = false` to deactivate a node, or destroy the entity to remove it outright.
+     *
      * @param {GraphNode} child - The node to remove.
      * @example
      * const child = this.entity.children[0];
@@ -1590,6 +1598,11 @@ class GraphNode extends EventHandler {
 
     /**
      * Reorients the graph node so that the negative z-axis points towards the target.
+     *
+     * The up vector must not be parallel to the direction from the node to the target. When it is —
+     * looking straight up or down with the default up vector, or at the node's own position — the
+     * basis is degenerate and the node is left unrotated, with nothing reported. Pass a different
+     * up vector in those cases.
      *
      * @overload
      * @param {number} x - X-component of the world space coordinate to look at.

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -398,37 +398,55 @@ class GraphNode extends EventHandler {
 
     // ---- deprecated block start ----
 
-    /** @deprecated GraphNode#getChildren is deprecated. Use GraphNode#children instead. @ignore */
+    /**
+     * @deprecated GraphNode#getChildren is deprecated. Use GraphNode#children instead.
+     * @ignore
+     */
     getChildren() {
         Debug.deprecated('GraphNode#getChildren is deprecated. Use GraphNode#children instead.');
         return this.children;
     }
 
-    /** @deprecated GraphNode#getName is deprecated. Use GraphNode#name instead. @ignore */
+    /**
+     * @deprecated GraphNode#getName is deprecated. Use GraphNode#name instead.
+     * @ignore
+     */
     getName() {
         Debug.deprecated('GraphNode#getName is deprecated. Use GraphNode#name instead.');
         return this.name;
     }
 
-    /** @deprecated GraphNode#getPath is deprecated. Use GraphNode#path instead. @ignore */
+    /**
+     * @deprecated GraphNode#getPath is deprecated. Use GraphNode#path instead.
+     * @ignore
+     */
     getPath() {
         Debug.deprecated('GraphNode#getPath is deprecated. Use GraphNode#path instead.');
         return this.path;
     }
 
-    /** @deprecated GraphNode#getRoot is deprecated. Use GraphNode#root instead. @ignore */
+    /**
+     * @deprecated GraphNode#getRoot is deprecated. Use GraphNode#root instead.
+     * @ignore
+     */
     getRoot() {
         Debug.deprecated('GraphNode#getRoot is deprecated. Use GraphNode#root instead.');
         return this.root;
     }
 
-    /** @deprecated GraphNode#getParent is deprecated. Use GraphNode#parent instead. @ignore */
+    /**
+     * @deprecated GraphNode#getParent is deprecated. Use GraphNode#parent instead.
+     * @ignore
+     */
     getParent() {
         Debug.deprecated('GraphNode#getParent is deprecated. Use GraphNode#parent instead.');
         return this.parent;
     }
 
-    /** @deprecated GraphNode#setName is deprecated. Use GraphNode#name instead. @ignore */
+    /**
+     * @deprecated GraphNode#setName is deprecated. Use GraphNode#name instead.
+     * @ignore
+     */
     setName(name) {
         Debug.deprecated('GraphNode#setName is deprecated. Use GraphNode#name instead.');
         this.name = name;

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -367,13 +367,21 @@ class Material {
         return this.shaderChunks.version;
     }
 
-    /** @deprecated Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode") @ignore */
+    /**
+     * @deprecated Material.chunks has been removed, please use Material.getShaderChunks instead.
+     * For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")
+     * @ignore
+     */
     set chunks(value) {
         Debug.deprecated('Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")');
         this._oldChunks = value;
     }
 
-    /** @deprecated Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode") @ignore */
+    /**
+     * @deprecated Material.chunks has been removed, please use Material.getShaderChunks instead.
+     * For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")
+     * @ignore
+     */
     get chunks() {
         Debug.deprecated('Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")');
         Object.assign(this._oldChunks, Object.fromEntries(this.shaderChunks.glsl));

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -367,11 +367,13 @@ class Material {
         return this.shaderChunks.version;
     }
 
+    /** @deprecated Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode") @ignore */
     set chunks(value) {
         Debug.deprecated('Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")');
         this._oldChunks = value;
     }
 
+    /** @deprecated Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode") @ignore */
     get chunks() {
         Debug.deprecated('Material.chunks has been removed, please use Material.getShaderChunks instead. For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")');
         Object.assign(this._oldChunks, Object.fromEntries(this.shaderChunks.glsl));

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -368,8 +368,8 @@ class Material {
     }
 
     /**
-     * @deprecated Material.chunks has been removed, please use Material.getShaderChunks instead.
-     * For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")
+     * @deprecated Use Material.getShaderChunks instead. For example:
+     * material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")
      * @ignore
      */
     set chunks(value) {
@@ -378,8 +378,8 @@ class Material {
     }
 
     /**
-     * @deprecated Material.chunks has been removed, please use Material.getShaderChunks instead.
-     * For example: material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")
+     * @deprecated Use Material.getShaderChunks instead. For example:
+     * material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")
      * @ignore
      */
     get chunks() {

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -370,6 +370,7 @@ class Material {
     /**
      * @deprecated Use Material.getShaderChunks instead. For example:
      * material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")
+     * @type {Object<string, string>}
      * @ignore
      */
     set chunks(value) {
@@ -380,6 +381,7 @@ class Material {
     /**
      * @deprecated Use Material.getShaderChunks instead. For example:
      * material.getShaderChunks(SHADERLANGUAGE_GLSL).set("chunkName", "chunkCode")
+     * @type {Object<string, string>}
      * @ignore
      */
     get chunks() {

--- a/src/scene/materials/shader-material.js
+++ b/src/scene/materials/shader-material.js
@@ -21,9 +21,7 @@ import { Material } from './material.js';
  * @property {string} [fragmentWGSL] - The fragment shader code in WGSL.
  * @property {Object<string, string>} [attributes] - Object detailing the mapping of vertex shader
  * attribute names to semantics SEMANTIC_*. This enables the engine to match vertex buffer data as
- * inputs to the shader. Defaults to undefined, which generates the default attributes. Must be
- * supplied when the material is applied to a skinned or morphed mesh, as the skinning and morph
- * attributes the engine adds automatically are merged into this object.
+ * inputs to the shader. Defaults to undefined, which generates the default attributes.
  * @property {string | string[]} [fragmentOutputTypes] - Fragment shader output types, which default to
  * vec4. Passing a string will set the output type for all color attachments. Passing an array will
  * set the output type for each color attachment. @see ShaderDefinitionUtils.createDefinition

--- a/src/scene/materials/shader-material.js
+++ b/src/scene/materials/shader-material.js
@@ -21,7 +21,9 @@ import { Material } from './material.js';
  * @property {string} [fragmentWGSL] - The fragment shader code in WGSL.
  * @property {Object<string, string>} [attributes] - Object detailing the mapping of vertex shader
  * attribute names to semantics SEMANTIC_*. This enables the engine to match vertex buffer data as
- * inputs to the shader. Defaults to undefined, which generates the default attributes.
+ * inputs to the shader. Defaults to undefined, which generates the default attributes. Must be
+ * supplied when the material is applied to a skinned or morphed mesh, as the skinning and morph
+ * attributes the engine adds automatically are merged into this object.
  * @property {string | string[]} [fragmentOutputTypes] - Fragment shader output types, which default to
  * vec4. Passing a string will set the output type for all color attachments. Passing an array will
  * set the output type for each color attachment. @see ShaderDefinitionUtils.createDefinition

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -250,6 +250,8 @@ const isBlack = (color) => {
  * @property {string} metalnessVertexColorChannel Vertex color channel to use for metalness. Can be
  * "r", "g", "b" or "a".
  * @property {number} gloss Defines the glossiness of the material from 0 (rough) to 1 (shiny).
+ * Materials imported from glTF enable {@link StandardMaterial#glossInvert}, which reverses this:
+ * on those materials gloss holds roughness, so 0 is shiny and 1 is rough.
  * @property {Texture|null} glossMap Gloss map (default is null). If specified, will be multiplied
  * by normalized gloss value and/or vertex colors.
  * @property {boolean} glossInvert Invert the gloss component (default is false). Enabling this

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -63,9 +63,7 @@ const isBlack = (color) => {
  * Most maps can use 3 types of input values in any combination: constant ({@link Color} or number),
  * mesh vertex colors and a {@link Texture}. All enabled inputs are multiplied together.
  *
- * A property assignment only reaches the GPU once {@link Material#update} is called. The uniform
- * values below are recomputed solely inside `updateUniforms`, which the renderer skips unless
- * `update()` has incremented the material's update version since the last render — so a `diffuse`
+ * A property assignment only reaches the GPU once {@link Material#update} is called: a `diffuse`
  * or `emissive` change made after the material's first frame is silently ignored until
  * `material.update()` runs.
  *

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -63,6 +63,12 @@ const isBlack = (color) => {
  * Most maps can use 3 types of input values in any combination: constant ({@link Color} or number),
  * mesh vertex colors and a {@link Texture}. All enabled inputs are multiplied together.
  *
+ * A property assignment only reaches the GPU once {@link Material#update} is called. The uniform
+ * values below are recomputed solely inside `updateUniforms`, which the renderer skips unless
+ * `update()` has incremented the material's update version since the last render — so a `diffuse`
+ * or `emissive` change made after the material's first frame is silently ignored until
+ * `material.update()` runs.
+ *
  * @property {Color} ambient The ambient color of the material, specified in sRGB color space. This
  * color value is 3-component (RGB), where each component is between 0 and 1.
  * @property {Color} diffuse The diffuse color of the material, specified in sRGB color space. This

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -265,6 +265,8 @@ class Morph extends RefCountedObject {
 
     /**
      * @deprecated Use Morph#targets instead.
+     * @param {number} index - The index of the morph target.
+     * @returns {MorphTarget} The morph target at the given index.
      * @ignore
      */
     getTarget(index) {

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -263,7 +263,10 @@ class Morph extends RefCountedObject {
 
     // ---- deprecated block start ----
 
-    /** @deprecated Morph#getTarget is deprecated. Use Morph#targets instead. @ignore */
+    /**
+     * @deprecated Morph#getTarget is deprecated. Use Morph#targets instead.
+     * @ignore
+     */
     getTarget(index) {
         Debug.deprecated('Morph#getTarget is deprecated. Use Morph#targets instead.');
         return this.targets[index];

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -263,6 +263,7 @@ class Morph extends RefCountedObject {
 
     // ---- deprecated block start ----
 
+    /** @deprecated Morph#getTarget is deprecated. Use Morph#targets instead. @ignore */
     getTarget(index) {
         Debug.deprecated('Morph#getTarget is deprecated. Use Morph#targets instead.');
         return this.targets[index];

--- a/src/scene/morph.js
+++ b/src/scene/morph.js
@@ -264,7 +264,7 @@ class Morph extends RefCountedObject {
     // ---- deprecated block start ----
 
     /**
-     * @deprecated Morph#getTarget is deprecated. Use Morph#targets instead.
+     * @deprecated Use Morph#targets instead.
      * @ignore
      */
     getTarget(index) {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -913,7 +913,7 @@ class Scene extends EventHandler {
     // ---- deprecated block start ----
 
     /**
-     * @deprecated Scene#defaultMaterial is deprecated.
+     * @deprecated No replacement is available.
      * @ignore
      */
     get defaultMaterial() {
@@ -922,7 +922,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#fogColor is deprecated. Use Scene#fog.color instead.
+     * @deprecated Use Scene#fog.color instead.
      * @ignore
      */
     set fogColor(value) {
@@ -931,7 +931,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#fogColor is deprecated. Use Scene#fog.color instead.
+     * @deprecated Use Scene#fog.color instead.
      * @ignore
      */
     get fogColor() {
@@ -940,7 +940,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#fogEnd is deprecated. Use Scene#fog.end instead.
+     * @deprecated Use Scene#fog.end instead.
      * @ignore
      */
     set fogEnd(value) {
@@ -949,7 +949,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#fogEnd is deprecated. Use Scene#fog.end instead.
+     * @deprecated Use Scene#fog.end instead.
      * @ignore
      */
     get fogEnd() {
@@ -958,7 +958,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#fogStart is deprecated. Use Scene#fog.start instead.
+     * @deprecated Use Scene#fog.start instead.
      * @ignore
      */
     set fogStart(value) {
@@ -967,7 +967,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#fogStart is deprecated. Use Scene#fog.start instead.
+     * @deprecated Use Scene#fog.start instead.
      * @ignore
      */
     get fogStart() {
@@ -976,7 +976,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#fogDensity is deprecated. Use Scene#fog.density instead.
+     * @deprecated Use Scene#fog.density instead.
      * @ignore
      */
     set fogDensity(value) {
@@ -985,7 +985,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#fogDensity is deprecated. Use Scene#fog.density instead.
+     * @deprecated Use Scene#fog.density instead.
      * @ignore
      */
     get fogDensity() {
@@ -994,7 +994,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     set skyboxPrefiltered128(value) {
@@ -1004,7 +1004,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     get skyboxPrefiltered128() {
@@ -1013,7 +1013,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     set skyboxPrefiltered64(value) {
@@ -1023,7 +1023,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     get skyboxPrefiltered64() {
@@ -1032,7 +1032,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     set skyboxPrefiltered32(value) {
@@ -1042,7 +1042,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     get skyboxPrefiltered32() {
@@ -1051,7 +1051,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     set skyboxPrefiltered16(value) {
@@ -1061,7 +1061,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     get skyboxPrefiltered16() {
@@ -1070,7 +1070,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     set skyboxPrefiltered8(value) {
@@ -1080,7 +1080,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     get skyboxPrefiltered8() {
@@ -1089,7 +1089,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     set skyboxPrefiltered4(value) {
@@ -1099,7 +1099,7 @@ class Scene extends EventHandler {
     }
 
     /**
-     * @deprecated Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @deprecated Use Scene#prefilteredCubemaps instead.
      * @ignore
      */
     get skyboxPrefiltered4() {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -447,7 +447,10 @@ class Scene extends EventHandler {
     }
 
     /**
-     * Sets the environment lighting atlas.
+     * Sets the environment lighting atlas, an octahedral atlas of prefiltered mip levels. To build
+     * one from an equirectangular or cubemap source, use `EnvLighting.generateLightingSource`
+     * followed by `EnvLighting.generateAtlas`; a raw HDR texture assigned here will not light the
+     * scene correctly.
      *
      * @type {Texture|null}
      */
@@ -623,6 +626,11 @@ class Scene extends EventHandler {
 
     /**
      * Sets the base cubemap texture used as the scene's skybox when skyboxMip is 0. Defaults to null.
+     *
+     * For a sky that needs no cubemap asset, `playcanvas/scripts/esm/sky/procedural-sky.mjs`
+     * renders an analytic daylight sky and keeps a directional light aligned with the sun so
+     * direct lighting and shadows match. Related scene-dressing scripts ship alongside it:
+     * `water.mjs`, `grid.mjs`, `shadow-catcher.mjs` and `blurred-planar-reflection.mjs`.
      *
      * @type {Texture|null}
      */

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -28,6 +28,13 @@ import { getDefaultMaterial } from './materials/default-material.js';
  * A scene is a graphical representation of an environment. It manages the scene hierarchy, all
  * graphical objects, lights, and scene-wide properties.
  *
+ * Tone mapping and gamma correction are configured per camera, not on the scene: use
+ * {@link CameraComponent#toneMapping} and {@link CameraComponent#gammaCorrection}. `Scene` has no
+ * such properties and no deprecation shim, so assigning to them silently does nothing. Fog remains
+ * scene-wide, but {@link Scene#fog} is a read-only {@link FogParams} object rather than a mode
+ * constant — set its `type`, `color`, `start` and `end` — and {@link CameraComponent#fog} can
+ * override it for a single camera.
+ *
  * @category Graphics
  */
 class Scene extends EventHandler {

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -912,133 +912,196 @@ class Scene extends EventHandler {
 
     // ---- deprecated block start ----
 
-    /** @deprecated Scene#defaultMaterial is deprecated. @ignore */
+    /**
+     * @deprecated Scene#defaultMaterial is deprecated.
+     * @ignore
+     */
     get defaultMaterial() {
         Debug.deprecated('Scene#defaultMaterial is deprecated.');
         return getDefaultMaterial(this.device);
     }
 
-    /** @deprecated Scene#fogColor is deprecated. Use Scene#fog.color instead. @ignore */
+    /**
+     * @deprecated Scene#fogColor is deprecated. Use Scene#fog.color instead.
+     * @ignore
+     */
     set fogColor(value) {
         Debug.deprecated('Scene#fogColor is deprecated. Use Scene#fog.color instead.');
         this.fog.color = value;
     }
 
-    /** @deprecated Scene#fogColor is deprecated. Use Scene#fog.color instead. @ignore */
+    /**
+     * @deprecated Scene#fogColor is deprecated. Use Scene#fog.color instead.
+     * @ignore
+     */
     get fogColor() {
         Debug.deprecated('Scene#fogColor is deprecated. Use Scene#fog.color instead.');
         return this.fog.color;
     }
 
-    /** @deprecated Scene#fogEnd is deprecated. Use Scene#fog.end instead. @ignore */
+    /**
+     * @deprecated Scene#fogEnd is deprecated. Use Scene#fog.end instead.
+     * @ignore
+     */
     set fogEnd(value) {
         Debug.deprecated('Scene#fogEnd is deprecated. Use Scene#fog.end instead.');
         this.fog.end = value;
     }
 
-    /** @deprecated Scene#fogEnd is deprecated. Use Scene#fog.end instead. @ignore */
+    /**
+     * @deprecated Scene#fogEnd is deprecated. Use Scene#fog.end instead.
+     * @ignore
+     */
     get fogEnd() {
         Debug.deprecated('Scene#fogEnd is deprecated. Use Scene#fog.end instead.');
         return this.fog.end;
     }
 
-    /** @deprecated Scene#fogStart is deprecated. Use Scene#fog.start instead. @ignore */
+    /**
+     * @deprecated Scene#fogStart is deprecated. Use Scene#fog.start instead.
+     * @ignore
+     */
     set fogStart(value) {
         Debug.deprecated('Scene#fogStart is deprecated. Use Scene#fog.start instead.');
         this.fog.start = value;
     }
 
-    /** @deprecated Scene#fogStart is deprecated. Use Scene#fog.start instead. @ignore */
+    /**
+     * @deprecated Scene#fogStart is deprecated. Use Scene#fog.start instead.
+     * @ignore
+     */
     get fogStart() {
         Debug.deprecated('Scene#fogStart is deprecated. Use Scene#fog.start instead.');
         return this.fog.start;
     }
 
-    /** @deprecated Scene#fogDensity is deprecated. Use Scene#fog.density instead. @ignore */
+    /**
+     * @deprecated Scene#fogDensity is deprecated. Use Scene#fog.density instead.
+     * @ignore
+     */
     set fogDensity(value) {
         Debug.deprecated('Scene#fogDensity is deprecated. Use Scene#fog.density instead.');
         this.fog.density = value;
     }
 
-    /** @deprecated Scene#fogDensity is deprecated. Use Scene#fog.density instead. @ignore */
+    /**
+     * @deprecated Scene#fogDensity is deprecated. Use Scene#fog.density instead.
+     * @ignore
+     */
     get fogDensity() {
         Debug.deprecated('Scene#fogDensity is deprecated. Use Scene#fog.density instead.');
         return this.fog.density;
     }
 
-    /** @deprecated Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     set skyboxPrefiltered128(value) {
         Debug.deprecated('Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[0] = value;
         this.updateShaders = true;
     }
 
-    /** @deprecated Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     get skyboxPrefiltered128() {
         Debug.deprecated('Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[0];
     }
 
-    /** @deprecated Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     set skyboxPrefiltered64(value) {
         Debug.deprecated('Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[1] = value;
         this.updateShaders = true;
     }
 
-    /** @deprecated Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     get skyboxPrefiltered64() {
         Debug.deprecated('Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[1];
     }
 
-    /** @deprecated Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     set skyboxPrefiltered32(value) {
         Debug.deprecated('Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[2] = value;
         this.updateShaders = true;
     }
 
-    /** @deprecated Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     get skyboxPrefiltered32() {
         Debug.deprecated('Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[2];
     }
 
-    /** @deprecated Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     set skyboxPrefiltered16(value) {
         Debug.deprecated('Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[3] = value;
         this.updateShaders = true;
     }
 
-    /** @deprecated Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     get skyboxPrefiltered16() {
         Debug.deprecated('Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[3];
     }
 
-    /** @deprecated Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     set skyboxPrefiltered8(value) {
         Debug.deprecated('Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[4] = value;
         this.updateShaders = true;
     }
 
-    /** @deprecated Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     get skyboxPrefiltered8() {
         Debug.deprecated('Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[4];
     }
 
-    /** @deprecated Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     set skyboxPrefiltered4(value) {
         Debug.deprecated('Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[5] = value;
         this.updateShaders = true;
     }
 
-    /** @deprecated Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
+    /**
+     * @deprecated Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead.
+     * @ignore
+     */
     get skyboxPrefiltered4() {
         Debug.deprecated('Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[5];

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -28,12 +28,8 @@ import { getDefaultMaterial } from './materials/default-material.js';
  * A scene is a graphical representation of an environment. It manages the scene hierarchy, all
  * graphical objects, lights, and scene-wide properties.
  *
- * Tone mapping and gamma correction are configured per camera, not on the scene: use
- * {@link CameraComponent#toneMapping} and {@link CameraComponent#gammaCorrection}. `Scene` has no
- * such properties and no deprecation shim, so assigning to them silently does nothing. Fog remains
- * scene-wide, but {@link Scene#fog} is a read-only {@link FogParams} object rather than a mode
- * constant — set its `type`, `color`, `start` and `end` — and {@link CameraComponent#fog} can
- * override it for a single camera.
+ * Fog is scene-wide: {@link Scene#fog} is a read-only {@link FogParams} whose `type`, `color`,
+ * `start` and `end` you set, and {@link CameraComponent#fog} can override it for a single camera.
  *
  * @category Graphics
  */
@@ -447,10 +443,10 @@ class Scene extends EventHandler {
     }
 
     /**
-     * Sets the environment lighting atlas, an octahedral atlas of prefiltered mip levels. To build
-     * one from an equirectangular or cubemap source, use `EnvLighting.generateLightingSource`
-     * followed by `EnvLighting.generateAtlas`; a raw HDR texture assigned here will not light the
-     * scene correctly.
+     * Sets the environment lighting atlas: prefiltered mip levels of the environment packed into a
+     * single equirectangular texture. To build one from an equirectangular or cubemap source, use
+     * `EnvLighting.generateLightingSource` followed by `EnvLighting.generateAtlas`; a raw HDR
+     * texture assigned here will not light the scene correctly.
      *
      * @type {Texture|null}
      */
@@ -630,7 +626,7 @@ class Scene extends EventHandler {
      * For a sky that needs no cubemap asset, `playcanvas/scripts/esm/sky/procedural-sky.mjs`
      * renders an analytic daylight sky and keeps a directional light aligned with the sun so
      * direct lighting and shadows match. Related scene-dressing scripts ship alongside it:
-     * `water.mjs`, `grid.mjs`, `shadow-catcher.mjs` and `blurred-planar-reflection.mjs`.
+     * `water.mjs`, `grid.mjs` and `shadow-catcher.mjs`.
      *
      * @type {Texture|null}
      */

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -912,112 +912,133 @@ class Scene extends EventHandler {
 
     // ---- deprecated block start ----
 
+    /** @deprecated Scene#defaultMaterial is deprecated. @ignore */
     get defaultMaterial() {
         Debug.deprecated('Scene#defaultMaterial is deprecated.');
         return getDefaultMaterial(this.device);
     }
 
+    /** @deprecated Scene#fogColor is deprecated. Use Scene#fog.color instead. @ignore */
     set fogColor(value) {
         Debug.deprecated('Scene#fogColor is deprecated. Use Scene#fog.color instead.');
         this.fog.color = value;
     }
 
+    /** @deprecated Scene#fogColor is deprecated. Use Scene#fog.color instead. @ignore */
     get fogColor() {
         Debug.deprecated('Scene#fogColor is deprecated. Use Scene#fog.color instead.');
         return this.fog.color;
     }
 
+    /** @deprecated Scene#fogEnd is deprecated. Use Scene#fog.end instead. @ignore */
     set fogEnd(value) {
         Debug.deprecated('Scene#fogEnd is deprecated. Use Scene#fog.end instead.');
         this.fog.end = value;
     }
 
+    /** @deprecated Scene#fogEnd is deprecated. Use Scene#fog.end instead. @ignore */
     get fogEnd() {
         Debug.deprecated('Scene#fogEnd is deprecated. Use Scene#fog.end instead.');
         return this.fog.end;
     }
 
+    /** @deprecated Scene#fogStart is deprecated. Use Scene#fog.start instead. @ignore */
     set fogStart(value) {
         Debug.deprecated('Scene#fogStart is deprecated. Use Scene#fog.start instead.');
         this.fog.start = value;
     }
 
+    /** @deprecated Scene#fogStart is deprecated. Use Scene#fog.start instead. @ignore */
     get fogStart() {
         Debug.deprecated('Scene#fogStart is deprecated. Use Scene#fog.start instead.');
         return this.fog.start;
     }
 
+    /** @deprecated Scene#fogDensity is deprecated. Use Scene#fog.density instead. @ignore */
     set fogDensity(value) {
         Debug.deprecated('Scene#fogDensity is deprecated. Use Scene#fog.density instead.');
         this.fog.density = value;
     }
 
+    /** @deprecated Scene#fogDensity is deprecated. Use Scene#fog.density instead. @ignore */
     get fogDensity() {
         Debug.deprecated('Scene#fogDensity is deprecated. Use Scene#fog.density instead.');
         return this.fog.density;
     }
 
+    /** @deprecated Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     set skyboxPrefiltered128(value) {
         Debug.deprecated('Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[0] = value;
         this.updateShaders = true;
     }
 
+    /** @deprecated Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     get skyboxPrefiltered128() {
         Debug.deprecated('Scene#skyboxPrefiltered128 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[0];
     }
 
+    /** @deprecated Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     set skyboxPrefiltered64(value) {
         Debug.deprecated('Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[1] = value;
         this.updateShaders = true;
     }
 
+    /** @deprecated Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     get skyboxPrefiltered64() {
         Debug.deprecated('Scene#skyboxPrefiltered64 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[1];
     }
 
+    /** @deprecated Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     set skyboxPrefiltered32(value) {
         Debug.deprecated('Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[2] = value;
         this.updateShaders = true;
     }
 
+    /** @deprecated Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     get skyboxPrefiltered32() {
         Debug.deprecated('Scene#skyboxPrefiltered32 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[2];
     }
 
+    /** @deprecated Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     set skyboxPrefiltered16(value) {
         Debug.deprecated('Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[3] = value;
         this.updateShaders = true;
     }
 
+    /** @deprecated Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     get skyboxPrefiltered16() {
         Debug.deprecated('Scene#skyboxPrefiltered16 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[3];
     }
 
+    /** @deprecated Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     set skyboxPrefiltered8(value) {
         Debug.deprecated('Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[4] = value;
         this.updateShaders = true;
     }
 
+    /** @deprecated Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     get skyboxPrefiltered8() {
         Debug.deprecated('Scene#skyboxPrefiltered8 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[4];
     }
 
+    /** @deprecated Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     set skyboxPrefiltered4(value) {
         Debug.deprecated('Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead.');
         this._prefilteredCubemaps[5] = value;
         this.updateShaders = true;
     }
 
+    /** @deprecated Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead. @ignore */
     get skyboxPrefiltered4() {
         Debug.deprecated('Scene#skyboxPrefiltered4 is deprecated. Use Scene#prefilteredCubemaps instead.');
         return this._prefilteredCubemaps[5];


### PR DESCRIPTION
An agent writing PlayCanvas code reads two surfaces: the JSDoc blocks and `build/playcanvas.d.ts`. Today neither says that a `StandardMaterial` change needs `update()` to reach the GPU, that `Vec3#scale` has been dead since 2.0, or even that `scale` takes a number. This makes both surfaces say what the source actually does.

### Behaviour that fails silently

Twelve members whose failure is currently only discoverable by debugging. glTF import enables `glossInvert`, so `gloss` holds roughness and `0` is shiny, not rough. `removeChild` detaches without disabling, so the subtree keeps rendering and running scripts. `Asset#ready` fires on success only, and fires immediately with a null resource if registered after a failure. `CameraFrame` groups cannot be passed through `ScriptComponent#create`, whose `properties` merge is shallow and drops each group's `enabled` flag.

Four entry-point classes get the same treatment, since an agent forms its plan there before reading any member: `StandardMaterial` (assignments need `update()`), `Scene` (tone mapping is per camera; `fog` is a read-only `FogParams`), `AppBase` (`init()` is required), `Application` (input devices stay `null` unless passed to the constructor).

### Capability that already ships, from where it is needed

~34 scripts under `scripts/esm/**`, the input-source layer, and the `playcanvas/debug` and `playcanvas/profiler` subpaths. None of these appeared anywhere in `src/`, so nothing reading the package could discover them. Each pointer sits in the block a reader is already in when the need arises — `CameraComponent` points at `camera-controls.mjs`, `RigidBodyComponent` at the character controllers, `ResourceLoader` at the `.obj` and `.spz` parsers.

### 62 legacy members marked deprecated

They warn at runtime through `Debug.deprecated` but carried no doc block, so they reached the declarations as bare signatures with nothing to indicate they are dead — no strikethrough in an editor, no signal to a model trained on the pre-2.x API. Each now uses the pattern already in `GSplatComponent`:

```js
/**
 * @deprecated Use Vec3#mulScalar instead.
 * @param {number} scalar - The number to multiply by.
 * @returns {Vec3} Self for chaining.
 * @ignore
 */
scale(scalar) {
```

`@ignore` keeps them out of the API reference exactly as an absent block did, so the reference is unchanged. The runtime message stays intact, since a console line has to name its own member; the tag carries only the migration.

### 17 signatures hardened

Those blocks initially omitted `@param`/`@returns`, which preserved `any` on every legacy member taking an argument. `any` is the absence of a type, so:

| Change | Members |
| --- | --- |
| `any` → `number` | `scale` (Vec2/3/4), `getTarget`, `setBlendFunction`/`Separate`, `setBlendEquation`/`Separate`, `setDepthFunc` |
| `any` → `boolean` | `setColorWrite`, `setBlending`, `setDepthWrite`, `setDepthTest` |
| `any` → `string` | `setName` |
| `any` → `null` | `VertexFormat.defaultInstancingFormat` |
| `{}` → `{ [x: string]: string }` | `Material#chunks` |
| `GraphNode` → `GraphNode \| null` | `getParent` |

Every row but the last only rejects calls that were already wrong at runtime. **`getParent()` is breaking for TypeScript callers that chain off it**, and is a fix: it returns `this.parent`, which the field and the property both declare `GraphNode|null`, and it is null for the root of any hierarchy, for a node never added to one, and after `removeChild` or a parent's `destroy()`. The deprecated alias had been claiming to be safer than the property that replaces it.

The other 45 members are untouched — tsc already infers them correctly from bodies like `return this.fog.color`, so tags there would be inert.

### Verification

Rebased onto and measured against `main` at d88289fb0:

| Gate | Result |
| --- | --- |
| API reference surface (`utils/api-surface.mjs`) | byte-identical, 5984 lines |
| Published declarations changed | the 17 members above, and nothing else |
| `@deprecated` in `.d.ts` | 53 → 115 |
| TypeDoc | 0 errors; warnings 35 → 34, none introduced |
| `npm run lint` / `npm test` / `npm run test:types` | clean / 2216 passing / passes |

No control flow, default value or export change. A plain `.d.ts` line diff is not a usable gate here: two builds from identical source differ by ~20 lines, because tsc emits unions and class declarations in an unstable order. The declaration row above compares the multiset of tokens with comment lines removed.

### Deliberately not fixed

Two bugs are documented rather than repaired, since this PR touches no logic. `createAttributesDefinition` leaves `attributes` as `undefined`, so a `ShaderMaterial` on a skinned or morphed mesh throws (`shader-generator-shader.js:37`, `: {}` fixes it). And `MiniStats`' render timing subtracts a start timestamp recorded only under `_PROFILER`, so a release build reports time since page load rather than a frame time.

Also excluded: the four behaviour bugs from the original review, which need code and tests, and declarations for `scripts/**`, which would change published artifacts.

