### PR TITLE
build: use JavaScript ESLint config

### DIFF
--- a/examples/eslint.config.mjs
+++ b/examples/eslint.config.mjs
@@ -1,4 +1,4 @@
-import playcanvasConfig from '@playcanvas/eslint-config/legacy';
+import javascriptConfig from '@playcanvas/eslint-config/javascript';
 import eslintConfigPrettier from 'eslint-config-prettier/flat';
 import globals from 'globals';
 
@@ -513,7 +513,7 @@ const examplesPlugin = {
 };
 
 export default [
-    ...playcanvasConfig,
+    ...javascriptConfig,
     {
         files: ['**/*.js', '**/*.mjs', '**/*.jsx'],
         languageOptions: {


### PR DESCRIPTION
## Description

Use the canonical `/javascript` entry point for the examples ESLint configuration before the redundant `/legacy` alias is removed from v3.

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

## Manual smoke test

1. Open the Examples Browser and load any example.
2. Confirm the example renders normally.