### PR TITLE
Fix XrMenu rendering outside of XR sessions

### DIFF
--- a/scripts/esm/xr/xr-menu.mjs
+++ b/scripts/esm/xr/xr-menu.mjs
@@ -432,8 +432,11 @@ class XrMenu extends Script {
         // Create menu container and UI
         this._createMenu();
 
-        // Hide menu initially
-        this._setMenuVisible(false);
+        // Hide the menu until an XR session shows it. This can't go through
+        // _setMenuVisible(false) — _menuVisible is already false, so it early-outs and leaves the
+        // container enabled at the element opacities _createButton assigned, which renders the
+        // menu at the world origin outside XR.
+        this._hideImmediate();
 
         // Listen for XR input sources
         this.app.xr.input.on('add', this._onInputSourceAdd, this);
@@ -474,10 +477,33 @@ class XrMenu extends Script {
     }
 
     _onXrEnd() {
+        // _setMenuVisible fires 'xr:menu:active' for listeners when the menu was open, but only
+        // requests the fade-out — which update() can no longer advance now that the session has
+        // ended. _hideImmediate finishes the job, otherwise the menu stays frozen in the world at
+        // its last headset-relative pose.
         this._setMenuVisible(false);
+        this._hideImmediate();
         this._inputSources.clear();
         this._activeInputSource = null;
         this._followInitialized = false;
+    }
+
+    /**
+     * Hides the menu at once, bypassing the opacity fade. Required whenever no XR session is
+     * running: the fade in {@link XrMenu#update} only advances while `xr.active` is true, so a hide
+     * requested outside a session (before the first one starts, or as one ends) would never
+     * complete and the menu would keep rendering in the world.
+     *
+     * @private
+     */
+    _hideImmediate() {
+        this._menuVisible = false;
+        this._currentOpacity = 0;
+        this._targetOpacity = 0;
+        this._updateMenuOpacity(0);
+        this._setHovered(null);
+        this._pressedButton = null;
+        if (this._menuContainer) this._menuContainer.enabled = false;
     }
 
     /**


### PR DESCRIPTION
### Problem

Any app that mounts the `XrMenu` script renders the menu in the scene while **not** in XR — opaque, at the world origin. Reproduces in this repo's own [`xr/xr-menu` example](https://playcanvas.vercel.app/#/xr/xr-menu) and in every [web-components](https://github.com/playcanvas/web-components) example that uses the script; it's only conspicuous where the camera happens to frame the origin closely (e.g. the shoe configurator, where the 7.5 cm menu fills a fifth of the frame).

Inspecting the live scene outside XR, before this change:

| | value |
|---|---|
| `XrMenuContainer.enabled` | `true` |
| button `element.opacity` | `0.85` |
| button text `element.opacity` | `1` |
| `_menuVisible` / `_currentOpacity` / `_targetOpacity` | `false` / `0` / `0` |

The internal state says "hidden" while the scene graph says "visible".

### Cause

`initialize` hides the menu via `_setMenuVisible(false)`, but that method opens with a no-change guard:

```js
if (this._menuVisible === visible) return;
```

`_menuVisible` is already `false` from its field initializer, so the initial hide is a no-op:

- `_menuContainer` keeps `Entity`'s default `enabled = true`.
- `_updateMenuOpacity` never runs — it's only called from `update` when `_currentOpacity !== _targetOpacity`, and both are `0` — so the elements stay at the opacities `_createButton` assigned.
- Nothing corrects it later, because `update` returns on its first line while `!app.xr.active`.

`_onXrEnd` fails the same way from the other direction: it only *requests* the fade-out by setting `_targetOpacity = 0`, and `update` stops advancing that fade the moment the session ends. Exit XR with the menu open and it stays frozen in the world at its last headset-relative pose.

Both cases are one flaw: hiding is delegated to a fade loop that only runs during an XR session, while the initial hide is delegated to a setter that can't fire.

### Fix

Add `_hideImmediate` — zero the opacities, clear hover/press state, disable the container — and call it from `initialize` and from `_onXrEnd` (after `_setMenuVisible(false)`, which is kept so `'xr:menu:active'` still fires for listeners when the menu was open).

### Testing

Verified in the shoe-configurator web-components example with the patched script dropped in:

| state | container | image opacity | text opacity |
|---|---|---|---|
| pre-XR | `false` ✔ | `0` ✔ | `0` ✔ |
| `_setMenuVisible(true)` + fade to 1 | `true` ✔ | `0.85` ✔ | `1` ✔ |
| after `_onXrEnd` | `false` ✔ | `0` ✔ | `0` ✔ |

The show path is unaffected: `_setMenuVisible(true)` re-enables the container and the existing `_targetOpacity > 0` guard in `update` still prevents the first-frame `dt ≈ 0` self-disable. Lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
