### PR TITLE
Draw UI image element quads as indexed triangles, not a triangle strip

### DIFF
--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -6,12 +6,15 @@ import { Vec2 } from '../../../core/math/vec2.js';
 import { Vec3 } from '../../../core/math/vec3.js';
 import { Vec4 } from '../../../core/math/vec4.js';
 import {
+    BUFFER_STATIC,
     FUNC_EQUAL,
-    PRIMITIVE_TRISTRIP,
+    INDEXFORMAT_UINT16,
+    PRIMITIVE_TRIANGLES,
     SEMANTIC_POSITION, SEMANTIC_NORMAL, SEMANTIC_TEXCOORD0,
     STENCILOP_DECREMENT,
     TYPE_FLOAT32
 } from '../../../platform/graphics/constants.js';
+import { IndexBuffer } from '../../../platform/graphics/index-buffer.js';
 import { VertexBuffer } from '../../../platform/graphics/vertex-buffer.js';
 import { VertexFormat } from '../../../platform/graphics/vertex-format.js';
 import { DeviceCache } from '../../../platform/graphics/device-cache.js';
@@ -37,6 +40,10 @@ import { Asset } from '../../asset/asset.js';
 
 const _tempColor = new Color();
 const _vertexFormatDeviceCache = new DeviceCache();
+
+// Triangulation of the 4 vertex quad the image element is built from. This matches the triangulation
+// the batcher applies to these meshes, so batched and non-batched images rasterize identically.
+const _quadIndices = [0, 1, 3, 0, 3, 2];
 
 class ImageRenderable {
     constructor(entity, mesh, material) {
@@ -433,7 +440,7 @@ class ImageElement {
         const r = this._rect;
         const device = this._system.app.graphicsDevice;
 
-        // content of the vertex buffer for 4 vertices, rendered as a tristrip
+        // content of the vertex buffer for the 4 corners of the quad
         const vertexData = new Float32Array([
             w, 0, 0,                        // position
             0, 0, 1,                        // normal
@@ -465,12 +472,20 @@ class ImageElement {
             data: vertexData.buffer
         });
 
+        // The quad is drawn as indexed triangles rather than a triangle strip. Strips are a legacy
+        // topology that little else on the web still uses, and some drivers get the winding flip of
+        // the strip's second triangle wrong, corrupting the interpolated uvs across half the quad.
+        // See https://github.com/playcanvas/engine/issues/9051
+        const indexBuffer = new IndexBuffer(device, INDEXFORMAT_UINT16, _quadIndices.length,
+            BUFFER_STATIC, new Uint16Array(_quadIndices));
+
         const mesh = new Mesh(device);
         mesh.vertexBuffer = vertexBuffer;
-        mesh.primitive[0].type = PRIMITIVE_TRISTRIP;
+        mesh.indexBuffer[0] = indexBuffer;
+        mesh.primitive[0].type = PRIMITIVE_TRIANGLES;
         mesh.primitive[0].base = 0;
-        mesh.primitive[0].count = 4;
-        mesh.primitive[0].indexed = false;
+        mesh.primitive[0].count = _quadIndices.length;
+        mesh.primitive[0].indexed = true;
         mesh.aabb.setMinMax(Vec3.ZERO, new Vec3(w, h, 0));
 
         this._updateMesh(mesh);

--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -40,10 +40,11 @@ import { Asset } from '../../asset/asset.js';
 
 const _tempColor = new Color();
 const _vertexFormatDeviceCache = new DeviceCache();
+const _indexBufferDeviceCache = new DeviceCache();
 
 // Triangulation of the 4 vertex quad the image element is built from. This matches the triangulation
 // the batcher applies to these meshes, so batched and non-batched images rasterize identically.
-const _quadIndices = [0, 1, 3, 0, 3, 2];
+const _quadIndices = new Uint16Array([0, 1, 3, 0, 3, 2]);
 
 class ImageRenderable {
     constructor(entity, mesh, material) {
@@ -359,6 +360,11 @@ class ImageElement {
         this.materialAsset = null;
 
         this._renderable.setMesh(this._defaultMesh);
+
+        // the index buffer is shared by every image element, so detach it before the renderable
+        // destroys the mesh - Mesh#destroy would otherwise destroy it out from under the others
+        this._defaultMesh.indexBuffer[0] = null;
+
         this._renderable.destroy();
         this._defaultMesh = null;
 
@@ -476,8 +482,16 @@ class ImageElement {
         // topology that little else on the web still uses, and some drivers get the winding flip of
         // the strip's second triangle wrong, corrupting the interpolated uvs across half the quad.
         // See https://github.com/playcanvas/engine/issues/9051
-        const indexBuffer = new IndexBuffer(device, INDEXFORMAT_UINT16, _quadIndices.length,
-            BUFFER_STATIC, new Uint16Array(_quadIndices));
+        //
+        // Every image element quad uses the same indices, so a single index buffer is shared by all
+        // of them. Giving each element its own costs measurable per-draw time (the device rebinds
+        // ELEMENT_ARRAY_BUFFER for every draw, as the VAO captures the last bind) on top of a driver
+        // side buffer object per element. ImageElement#destroy detaches it so the mesh can't destroy
+        // a buffer the other elements are still using.
+        const indexBuffer = _indexBufferDeviceCache.get(device, () => {
+            return new IndexBuffer(device, INDEXFORMAT_UINT16, _quadIndices.length,
+                BUFFER_STATIC, new Uint16Array(_quadIndices));
+        });
 
         const mesh = new Mesh(device);
         mesh.vertexBuffer = vertexBuffer;

--- a/src/scene/batching/batch-manager.js
+++ b/src/scene/batching/batch-manager.js
@@ -615,7 +615,7 @@ class BatchManager {
                 if (mesh.primitive[0].indexed) {
                     batchNumIndices += mesh.primitive[0].count;
                 } else {
-                    // special case of fan / strip non-indexed primitive used by UI
+                    // special case of a non-indexed 4 vertex fan / strip primitive
                     const primitiveType = mesh.primitive[0].type;
                     if (primitiveType === PRIMITIVE_TRIFAN || primitiveType === PRIMITIVE_TRISTRIP) {
                         if (mesh.primitive[0].count === 4) {

--- a/src/scene/immediate/immediate.js
+++ b/src/scene/immediate/immediate.js
@@ -1,4 +1,4 @@
-import { PRIMITIVE_TRISTRIP, SEMANTIC_COLOR, SEMANTIC_POSITION, SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL } from '../../platform/graphics/constants.js';
+import { PRIMITIVE_TRIANGLES, SEMANTIC_COLOR, SEMANTIC_POSITION, SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL } from '../../platform/graphics/constants.js';
 
 import { BLEND_NORMAL } from '../constants.js';
 import { GraphNode } from '../graph-node.js';
@@ -216,7 +216,9 @@ class Immediate {
                 -0.5, 0.5, 0,
                 0.5, 0.5, 0
             ]);
-            this.quadMesh.update(PRIMITIVE_TRISTRIP);
+            // indexed triangles rather than a triangle strip, see the comment in ImageElement#_createMesh
+            this.quadMesh.setIndices([0, 1, 3, 0, 3, 2]);
+            this.quadMesh.update(PRIMITIVE_TRIANGLES);
         }
         return this.quadMesh;
     }

--- a/test/framework/components/element/component.test.mjs
+++ b/test/framework/components/element/component.test.mjs
@@ -205,6 +205,26 @@ describe('ElementComponent', function () {
             expect(indices).to.deep.equal([0, 1, 3, 0, 3, 2]);
         });
 
+        it('shares one index buffer across image elements and keeps it alive on destroy', function () {
+            const a = new Entity();
+            a.addComponent('element', { type: 'image' });
+            app.root.addChild(a);
+
+            const b = new Entity();
+            b.addComponent('element', { type: 'image' });
+            app.root.addChild(b);
+
+            const indexBuffer = a.element._image._defaultMesh.indexBuffer[0];
+            expect(indexBuffer).to.exist;
+            expect(b.element._image._defaultMesh.indexBuffer[0]).to.equal(indexBuffer);
+
+            // destroying one element must not destroy the buffer the others are still using
+            a.destroy();
+
+            expect(app.graphicsDevice.buffers.has(indexBuffer)).to.be.true;
+            expect(b.element._image._defaultMesh.indexBuffer[0]).to.equal(indexBuffer);
+        });
+
     });
 
     describe('#type', function () {

--- a/test/framework/components/element/component.test.mjs
+++ b/test/framework/components/element/component.test.mjs
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { Entity } from '../../../../src/framework/entity.js';
+import { PRIMITIVE_TRIANGLES } from '../../../../src/platform/graphics/constants.js';
 import { LAYERID_UI } from '../../../../src/scene/constants.js';
 import { createApp } from '../../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
@@ -177,6 +178,33 @@ describe('ElementComponent', function () {
         const newParent = new Entity();
         app.root.addChild(newParent);
         expect(() => newParent.addChild(e)).to.not.throw();
+    });
+
+    describe('image mesh', function () {
+
+        it('renders the quad as indexed triangles rather than a triangle strip', function () {
+            // Triangle strips are a legacy topology that some drivers mis-handle, corrupting the uvs
+            // across the strip's second triangle. See https://github.com/playcanvas/engine/issues/9051
+            const e = new Entity();
+            e.addComponent('element', { type: 'image' });
+            app.root.addChild(e);
+
+            const mesh = e.element._image._defaultMesh;
+            const primitive = mesh.primitive[0];
+
+            expect(primitive.type).to.equal(PRIMITIVE_TRIANGLES);
+            expect(primitive.indexed).to.be.true;
+            expect(primitive.base).to.equal(0);
+            expect(primitive.count).to.equal(6);
+
+            // 2 triangles covering the 4 corner vertices of the quad
+            expect(mesh.vertexBuffer.numVertices).to.equal(4);
+
+            const indices = [];
+            expect(mesh.getIndices(indices)).to.equal(6);
+            expect(indices).to.deep.equal([0, 1, 3, 0, 3, 2]);
+        });
+
     });
 
     describe('#type', function () {


### PR DESCRIPTION
## Description

UI image elements built their quad as a non-indexed 4 vertex `GL_TRIANGLE_STRIP`. On Exynos 2500 / Xclipse (RDNA) devices in Chrome for Android, the interpolated uvs come out corrupted across **exactly the strip's second triangle**, so half of every UI image is smeared along the quad diagonal.

The vertex order is BR, TR, BL, TL, so the strip emits:

- triangle 0 = (BR, TR, BL) — the bottom-right half
- triangle 1 = (TR, BL, TL) — the top-left half, and the *odd* triangle, whose winding the driver has to flip to keep facing consistent

In the reporter's screenshots the bottom-right half of every affected sprite is correct and the top-left half is smeared along the BL→TR diagonal. That is triangle 1, every time.

The control case is in the same screenshots: **all the text renders correctly.** Text elements use the same shaders, the same atlas textures and the same materials — they differ only in that `TextElement` already emits indexed triangles. The strip's implicit winding flip for odd triangles is the one thing the two paths do not share.

Rather than detect the device, this drops the strip. It buys nothing here (both are a single draw of two triangles), it is a legacy topology that little else on the web still exercises, and the batcher already had to convert these meshes to indexed triangles anyway. The index order matches the batcher's, so batched and non-batched images rasterize identically.

Changes:

- `image-element.js` — 4 vertices plus a 6 index buffer, `PRIMITIVE_TRIANGLES`. The index buffer is shared by every image element via a `DeviceCache`, and `ImageElement#destroy` detaches it before the renderable tears the mesh down, since `Mesh#destroy` would otherwise destroy a buffer the remaining elements still use.
- `immediate.js` — same for the `app.drawTexture` quad, the only other content-path strip in the engine
- `batch-manager.js` — comment no longer claims the non-indexed fan / strip case is the UI path
- `component.test.mjs` — regression tests for the topology and for the shared buffer surviving a single element's destruction

## Correctness

Built the engine before and after and diffed real GPU output on WebGL 2. For plain, stencil-masked and batched UI images, and for `app.drawTexture`, the rendered pixels are **identical**, while the draw call changes:

```
before: drawArrays(TRIANGLE_STRIP, 4)
after:  drawElements(TRIANGLES, 6)
```

Batching still merges 3 quads into a single `drawElements(TRIANGLES, 18)`, and a stencil-masked child still clips to exactly 100x100 / 10000 px at the same pixel coordinates as before.

Test suite: 2044 passing, with the same 11 pre-existing failures as `main` (asset fetches that need network access).

## Performance

Benchmarked because an indexed draw is not obviously free. 2000 UI image elements at 8x8px (small and non-overlapping, so this is draw bound rather than fill bound), 90 frames x 8 rounds with the variant order alternating each round, `gl.finish()` per frame. Intel Arc Pro 140T, ANGLE/D3D11:

| variant | draw call | median ms/frame | vs strip |
|---|---|---|---|
| strip (before) | `drawArrays(TRIANGLE_STRIP, 4)` | 3.40 | +0.0% |
| indexed, index buffer per element | `drawElements(TRIANGLES, 6)` | 4.20 | +23.5% |
| **indexed, one shared index buffer (this PR)** | `drawElements(TRIANGLES, 6)` | **3.40** | **+0.0%** |
| 6 non-indexed vertices | `drawArrays(TRIANGLES, 6)` | 3.40 | +0.0% |

The cost is the per-element buffer, not the indexed draw — holding everything else constant and swapping 2000 distinct index buffers for one shared one recovers all of it. That matches the code: `WebglGraphicsDevice#setBuffers` rebinds `ELEMENT_ARRAY_BUFFER` on every draw regardless, since it cannot cache the state (the VAO captures the last bind). A distinct buffer per element turns each of those into a real rebind, on top of a driver side buffer object per element. With one shared buffer it is the same handle every time.

Worth noting the corollary: going indexed adds no extra WebGL call, because non-indexed draws already pay that `bindBuffer(…, null)`.

6 non-indexed vertices measured at parity too, so it was not worth the larger diff — it would need `_updateMesh` rewritten to write duplicated corners, and `batch-manager.js` taught about non-indexed `PRIMITIVE_TRIANGLES` (today the non-indexed branch only handles TRIFAN/TRISTRIP, and anything else falls through leaving `numIndices` / `indexData` from the previous loop iteration — a latent bug that change would start hitting).

This is desktop ANGLE/D3D11, not a mobile tiler, so the ranking there may differ — though "one buffer object instead of N" should hold at least as well.

## Note on the 3D case

I do not have an Exynos device, so this is not confirmed on hardware — but the artifact lines up with the strip's odd triangle too precisely for that to be coincidence.

The 3D table in the first screenshot of #9051 is a separate question: indexed triangle meshes do not go through the strip path, so this change will not affect them. The one route by which a 3D mesh would hit the same driver bug is a glTF with `mode: 5` primitives, which `gltf-accessor.js` maps straight to `PRIMITIVE_TRISTRIP`. Worth asking the reporter to check `meshInstance.mesh.primitive[0].type` on the affected mesh — if it is `5`, the same reasoning extends there; if it is `4`, that artifact has a different cause.

Refs #9051

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
