### PR TITLE
Add readonly detection for WebGPU subgroup-size-control feature

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -265,6 +265,19 @@ class GraphicsDevice extends EventHandler {
     supportsSubgroups = false;
 
     /**
+     * True if the device supports subgroup size control (WebGPU only). This depends on
+     * {@link supportsSubgroups} and, when available, allows a compute shader to pin its execution
+     * to a specific subgroup size (a power of two within the {@link minSubgroupSize} to
+     * {@link maxSubgroupSize} range) via the WGSL `@subgroup_size` attribute. The
+     * `subgroup-size-control` device feature is automatically requested when this is supported, and
+     * the shader define `CAPS_SUBGROUP_SIZE_CONTROL` is set for conditional compilation.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    supportsSubgroupSizeControl = false;
+
+    /**
      * True if the device supports the WGSL subgroup_uniformity extension, which allows
      * subgroup functionality to be considered uniform in more cases during shader compilation.
      * This is automatically enabled via the `enable subgroups;` directive when
@@ -351,22 +364,20 @@ class GraphicsDevice extends EventHandler {
     supportsUnrestrictedPointerParameters = false;
 
     /**
-     * Maximum subgroup (warp/wavefront) size reported for the device. Zero means either
-     * subgroups are not supported ({@link supportsSubgroups} is false), or the WebGPU
-     * implementation did not expose the value.
+     * Maximum subgroup (warp/wavefront) size reported for the device. Zero means either the device
+     * does not expose subgroup sizes, or the WebGPU implementation did not report the value.
      *
      * @type {number}
-     * @ignore
+     * @readonly
      */
     maxSubgroupSize = 0;
 
     /**
-     * Minimum subgroup (warp/wavefront) size reported for the device. Zero means either
-     * subgroups are not supported ({@link supportsSubgroups} is false), or the WebGPU
-     * implementation did not expose the value.
+     * Minimum subgroup (warp/wavefront) size reported for the device. Zero means either the device
+     * does not expose subgroup sizes, or the WebGPU implementation did not report the value.
      *
      * @type {number}
-     * @ignore
+     * @readonly
      */
     minSubgroupSize = 0;
 
@@ -778,6 +789,7 @@ class GraphicsDevice extends EventHandler {
         if (this.supportsPrimitiveIndex) capsDefines.set('CAPS_PRIMITIVE_INDEX', '');
         if (this.supportsShaderF16) capsDefines.set('CAPS_SHADER_F16', '');
         if (this.supportsSubgroups) capsDefines.set('CAPS_SUBGROUPS', '');
+        if (this.supportsSubgroupSizeControl) capsDefines.set('CAPS_SUBGROUP_SIZE_CONTROL', '');
         if (this.supportsSubgroupId) capsDefines.set('CAPS_SUBGROUP_ID', '');
         if (this.supportsLinearIndexing) capsDefines.set('CAPS_LINEAR_INDEXING', '');
         if (this.supportsUnrestrictedPointerParameters) capsDefines.set('CAPS_UNRESTRICTED_POINTER_PARAMETERS', '');

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -472,8 +472,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         this.supportsTextureFormatTier1 ||= this.supportsTextureFormatTier2;
         this.supportsPrimitiveIndex = requireFeature('primitive-index');
         this.supportsSubgroups = requireFeature('subgroups');
-        this.maxSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.info?.subgroupMaxSize ?? 0) : 0;
-        this.minSubgroupSize = this.supportsSubgroups ? (this.gpuAdapter?.info?.subgroupMinSize ?? 0) : 0;
+        this.supportsSubgroupSizeControl = requireFeature('subgroup-size-control');
+        this.maxSubgroupSize = this.gpuAdapter?.info?.subgroupMaxSize ?? 0;
+        this.minSubgroupSize = this.gpuAdapter?.info?.subgroupMinSize ?? 0;
         const wgslFeatureNames = window.navigator.gpu.wgslLanguageFeatures ?
             Array.from(window.navigator.gpu.wgslLanguageFeatures) : [];
         Debug.log(
@@ -489,7 +490,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             const adapterLimits = this.gpuAdapter?.limits;
             if (adapterLimits) {
                 for (const limitName in adapterLimits) {
-                    // skip these as they fail on Windows Chrome and are not part of spec currently
+                    // subgroup sizes are exposed via GPUAdapterInfo (read above), not as requestable
+                    // limits - some implementations (e.g. Windows Chrome) still surface them here and
+                    // reject them in requiredLimits, so skip them
                     if (limitName === 'minSubgroupSize' || limitName === 'maxSubgroupSize') {
                         continue;
                     }


### PR DESCRIPTION
Exposes detection of the WebGPU `subgroup-size-control` adapter feature (new in Chrome 151/152), which builds on the existing `subgroups` support. This is readonly detection only — the `@subgroup_size` shader-pinning path is intentionally deferred.

**Changes:**
- Detect and request the `subgroup-size-control` device feature in the WebGPU backend when the adapter supports it.
- Read `subgroupMinSize` / `subgroupMaxSize` from `GPUAdapterInfo` unconditionally (they are valid whenever the implementation reports them), rather than gating on `supportsSubgroups`.
- Set the `CAPS_SUBGROUP_SIZE_CONTROL` shader define for conditional compilation, following the existing caps-define pattern.
- Clarify the stale comment around skipping `minSubgroupSize` / `maxSubgroupSize` in `requiredLimits` (they come from `GPUAdapterInfo`, not requestable limits).

**API Changes:**
- Added `GraphicsDevice#supportsSubgroupSizeControl` (readonly boolean).
- Promoted `GraphicsDevice#minSubgroupSize` and `GraphicsDevice#maxSubgroupSize` from `@ignore` to public readonly properties.

**Deferred (not in this PR):**
- Injecting `enable subgroup_size_control;` in the WGSL directive generation.
- Threading an `@subgroup_size(N)` attribute through the WGSL shader processor / compute pipeline. No consumer needs the pinning path yet.