### PR TITLE
Fix instancing/draw-commands mismatch skipping indirect draws

### DIFF
--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -235,6 +235,14 @@ class ShaderInstance {
  * cmd.update(2);
  * ```
  *
+ * ### Precedence
+ *
+ * When draw commands (indirect or multi-draw, see {@link setIndirect} and {@link setMultiDraw})
+ * are bound, they are the source of truth for rendering: the number of draws and the per-draw
+ * instance counts come from the draw commands, and {@link instancingCount} is ignored. In this
+ * case setting {@link instancingCount} to 0 does not skip rendering. {@link instancingCount} only
+ * takes effect for plain hardware instancing, when no draw commands are bound.
+ *
  * @category Graphics
  */
 class MeshInstance {

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -568,9 +568,11 @@ class ForwardRenderer extends Renderer {
             }
             // #endif
 
-            // skip instanced rendering with 0 instances
+            // Skip hardware-instanced rendering with 0 instances. When draw commands (indirect /
+            // multi-draw) are bound, they are the source of truth for the number of draws and
+            // per-draw instance counts, so instancingData.count must not gate the draw.
             const instancingData = drawCall.instancingData;
-            if (instancingData && instancingData.count <= 0) {
+            if (instancingData && instancingData.count <= 0 && !drawCall.getDrawCommands(camera)) {
                 continue;
             }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -307,9 +307,11 @@ class ShadowRenderer {
             const meshInstance = visibleCasters[i];
             const mesh = meshInstance.mesh;
 
-            // skip instanced rendering with 0 instances
+            // Skip hardware-instanced rendering with 0 instances. When draw commands (indirect /
+            // multi-draw) are bound, they are the source of truth for the number of draws and
+            // per-draw instance counts, so instancingData.count must not gate the draw.
             const instancingData = meshInstance.instancingData;
-            if (instancingData && instancingData.count <= 0) {
+            if (instancingData && instancingData.count <= 0 && !meshInstance.getDrawCommands(camera)) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes #9153.

After draw commands (indirect / multi-draw) were added, there were two independent "instance count" mechanisms that were only partially reconciled: hardware instancing (`MeshInstance.instancingCount`) and draw commands (`setIndirect` / `setMultiDraw`). The zero-instance skip guard in the forward and shadow renderers gated the entire draw on `instancingData.count`, so a mesh instance that had instancing set up with count 0 (or unset) but a valid draw command was dropped before it ever reached `device.draw` — the model would not render at all.

**Changes:**
- Forward renderer: only skip the zero-instance draw when no draw commands are bound for the camera (`!drawCall.getDrawCommands(camera)`).
- Shadow renderer: same guard for shadow casters.
- `MeshInstance`: added a **Precedence** section to the class docs making the expected behavior explicit — when draw commands are bound they are the source of truth for the draw count and per-draw instance counts, `instancingCount` is ignored, and `instancingCount = 0` does not skip rendering. `instancingCount` only applies to plain hardware instancing when no draw commands are bound.

This matches the behavior already implemented in the graphics backends, where the indirect draw path derives instance counts entirely from the draw commands and ignores the `numInstances` argument.