### PR TITLE
Expose the textureFloatBlendable capability on all devices

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -569,6 +569,15 @@ class GraphicsDevice extends EventHandler {
     textureFloatFilterable = false;
 
     /**
+     * True if blending can be used when rendering to 32-bit floating-point render targets. Note that
+     * 16-bit floating-point render targets are always blendable when they are renderable.
+     *
+     * @type {boolean}
+     * @readonly
+     */
+    textureFloatBlendable = false;
+
+    /**
      * A vertex buffer representing a quad.
      *
      * @type {VertexBuffer}

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -912,7 +912,9 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.extTextureFloatLinear = this.getExtension('OES_texture_float_linear');
         this.textureFloatFilterable = !!this.extTextureFloatLinear;
 
+        // blending into 32-bit float render targets requires this extension
         this.extFloatBlend = this.getExtension('EXT_float_blend');
+        this.textureFloatBlendable = !!this.extFloatBlend;
         this.extBlendFuncExtended = this.getExtension('WEBGL_blend_func_extended');
         this.supportsDualSourceBlending = !!this.extBlendFuncExtended;
         this.extDrawBuffersIndexed = this.getExtension('OES_draw_buffers_indexed');


### PR DESCRIPTION
Blending into a floating-point render target is not universally supported: on WebGL2 it needs the `EXT_float_blend` extension, and on WebGPU the `float32-blendable` feature. A feature that wants to accumulate into a float attachment has to be able to ask, and branch or pick a different format when the answer is no.

The WebGPU device already queried `float32-blendable` into a `textureFloatBlendable` property, but the property was never declared on `GraphicsDevice`, so it existed only on WebGPU instances and read as `undefined` on WebGL2 and the null device. WebGL2 was also already querying `EXT_float_blend` without surfacing it.

This declares the capability alongside the other texture capabilities and derives it on WebGL2 from the extension, so it now answers correctly on every backend. Note 16-bit float render targets are blendable wherever they are renderable, so this only concerns the 32-bit case.

**Changes:**
- Declare `textureFloatBlendable` on `GraphicsDevice`, defaulting to false
- Derive it on WebGL2 from the `EXT_float_blend` extension

**API Changes:**
- `GraphicsDevice#textureFloatBlendable` - boolean, readonly. Previously present on WebGPU only and undeclared, now defined on all devices