### PR TITLE
Fix StandardMaterial property types in the generated .d.ts

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -338,6 +338,8 @@ const isBlack = (color) => {
  * "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} sheenVertexColor Use mesh vertex colors for sheen. If sheen map or
  * sheen tint are set, they'll be multiplied by vertex colors.
+ * @property {string} sheenVertexColorChannel Vertex color channels to use for sheen. Can be "r",
+ * "g", "b", "a", "rgb" or any swizzled combination.
  * @property {number} sheenGloss The glossiness of the sheen (fabric) microfiber structure.
  * This color value is a single value between 0 and 1.
  * @property {boolean} sheenGlossInvert Invert the sheen gloss component (default is false).
@@ -389,7 +391,7 @@ const isBlack = (color) => {
  * - {@link DITHER_IGNNOISE}: Opacity is dithered using an interleaved gradient noise.
  *
  * Defaults to {@link DITHER_NONE}.
- * @property {boolean} opacityShadowDither Used to specify whether shadow opacity is dithered, which
+ * @property {string} opacityShadowDither Used to specify whether shadow opacity is dithered, which
  * allows shadow transparency without alpha blending. Can be:
  *
  * - {@link DITHER_NONE}: Opacity dithering is disabled.

--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -7,10 +7,15 @@ const REGULAR_OUT = '\x1b[22m';
 
 const TYPES_PATH = './build/playcanvas/src';
 
+// StandardMaterial defines its accessors dynamically, so TypeScript emits none of them. They are
+// declared by hand from this list, and their doc comments are taken from the matching
+// `@property {type} name` tag in the class JSDoc - so the type here must match the type documented
+// there, or the build fails. An optional third element supplies the doc comment for properties that
+// have no `@property` tag (deprecated aliases, which are defined in src/deprecated/deprecated.js).
 const STANDARD_MAT_PROPS = [
-    ['alphaFade', 'boolean'],
+    ['alphaFade', 'number'],
     ['ambient', 'Color'],
-    ['anisotropy', 'number'],
+    ['anisotropy', 'number', 'Defines amount of anisotropy. @deprecated Use {@link StandardMaterial#anisotropyIntensity} and {@link StandardMaterial#anisotropyRotation} instead.'],
     ['anisotropyIntensity', 'number'],
     ['anisotropyRotation', 'number'],
     ['anisotropyMap', 'Texture|null'],
@@ -137,7 +142,7 @@ const STANDARD_MAT_PROPS = [
     ['normalMapRotation', 'number'],
     ['normalMapTiling', 'Vec2'],
     ['normalMapUv', 'number'],
-    ['occludeDirect', 'number'],
+    ['occludeDirect', 'boolean'],
     ['occludeSpecular', 'number'],
     ['occludeSpecularIntensity', 'number'],
     ['opacity', 'number'],
@@ -194,31 +199,66 @@ const STANDARD_MAT_PROPS = [
     ['useSkybox', 'boolean']
 ];
 
+/**
+ * Parses the `@property` tags of the StandardMaterial class JSDoc block.
+ *
+ * @param {string} contents - The contents of the generated standard-material.d.ts.
+ * @returns {Map<string, {type: string, description: string}>} The documented properties, keyed by
+ * property name.
+ */
+const parseProperties = (contents) => {
+    const properties = new Map();
+
+    // Only consider the class JSDoc block, and split it on tag boundaries so that multi-line
+    // descriptions stay attached to the tag they belong to
+    const block = contents.slice(0, contents.indexOf('export class StandardMaterial'));
+    for (const tag of block.split('\n * @')) {
+        const match = /^property \{(.+?)\} (\w+)\s([\s\S]*)$/.exec(tag);
+        if (match) {
+            const [, type, name, description] = match;
+            properties.set(name, {
+                type,
+                description: description
+                .replace(/[\n\t*]/g, ' ') // remove newlines, tabs, and asterisks
+                .replace(/\s+/g, ' ') // collapse whitespace
+                .trim()
+            });
+        }
+    }
+
+    return properties;
+};
+
 const REPLACEMENTS = [{
     path: `${TYPES_PATH}/scene/materials/standard-material.d.ts`,
     replacement: {
-        guard: 'set alphaFade(arg: boolean);',
+        guard: 'set alphaFade(arg:',
         transformer: (contents) => {
+            const properties = parseProperties(contents);
+            const errors = [];
 
-            // Find the jsdoc block description using eg "@property {Type} {name}"
+            const accessors = STANDARD_MAT_PROPS.map(([name, type, doc]) => {
+                let description = doc;
+                if (description === undefined) {
+                    const property = properties.get(name);
+                    if (!property) {
+                        errors.push(`${name}: declared as '${type}' but has no @property tag`);
+                    } else if (property.type !== type) {
+                        errors.push(`${name}: declared as '${type}' but documented as '${property.type}'`);
+                    }
+                    description = property?.description ?? '';
+                }
+
+                const jsdoc = description ? `/** ${description} */` : '';
+                return `\t${jsdoc}\n\tset ${name}(arg: ${type});\n\tget ${name}(): ${type};\n\n`;
+            }).join('');
+
+            if (errors.length) {
+                throw new Error(`StandardMaterial types disagree with its JSDoc - fix the @property tag in src/scene/materials/standard-material.js or the type in STANDARD_MAT_PROPS:\n  ${errors.join('\n  ')}`);
+            }
+
             return contents.replace('reset(): void;', `reset(): void;
-                ${STANDARD_MAT_PROPS.map((prop) => {
-        const typeDefinition = `@property {${prop[1]}} ${prop[0]}`;
-        const typeDescriptionIndex = contents.match(typeDefinition);
-        const typeDescription = typeDescriptionIndex ?
-            contents.slice(typeDescriptionIndex.index + typeDefinition.length, contents.indexOf('\n * @property', typeDescriptionIndex.index + typeDefinition.length)) :
-            '';
-
-        // Strip newlines, asterisks, and tabs from the type description
-        const cleanTypeDescription = typeDescription
-        .trim()
-        .replace(/[\n\t*]/g, ' ') // remove newlines, tabs, and asterisks
-        .replace(/\s+/g, ' '); // collapse whitespace
-
-        const jsdoc = cleanTypeDescription ? `/** ${cleanTypeDescription} */` : '';
-        return `\t${jsdoc}\n\tset ${prop[0]}(arg: ${prop[1]});\n\tget ${prop[0]}(): ${prop[1]};\n\n`;
-    }).join('')}`
-            );
+                ${accessors}`);
         },
         footer: `
 import { Color } from '../../core/math/color.js';


### PR DESCRIPTION
## Description

`StandardMaterial` defines its accessors dynamically, so tsc emits none of them — they are declared by hand from `STANDARD_MAT_PROPS` in `utils/plugins/rollup-types-fixup.mjs`. Each doc comment was looked up with ``contents.match(`@property {${type}} ${name}`)``, **passing the type through as a regex**. That one line caused three distinct defects.

**1. Type disagreements silently dropped the doc comment and emitted the wrong type.** When the type in the list disagreed with the class JSDoc, the lookup found nothing, so the accessor was emitted with an empty doc comment and the (wrong) type from the list:

| Property | Emitted `.d.ts` | Runtime default | Correct type |
|---|---|---|---|
| `occludeDirect` | `number` | `false` | `boolean` |
| `alphaFade` | `boolean` | `1` (`_defineFloat`) | `number` |

Both broke the correct assignment from TypeScript:

```ts
material.occludeDirect = true;  // TS2322: Type 'boolean' is not assignable to type 'number'.
material.alphaFade = 0.5;       // TS2322: Type 'number' is not assignable to type 'boolean'.
```

`occludeDirect` is the one reported in #9152; `alphaFade` is the same defect found by generalizing it.

**2. `Texture|null` was treated as a regex alternation.** It matched `@property {Texture` at its *first* occurrence in the file and then sliced from the wrong offset, so every texture property inherited a mangled fragment of `diffuseMap`'s description:

```ts
/** e main (primary) diffuse map of the material (default is null). */
set anisotropyMap(arg: Texture|null);

/** seMap The main (primary) diffuse map of the material (default is null). */
set aoMap(arg: Texture|null);
```

**3. `@property {number} anisotropy` prefix-matched `anisotropyIntensity`**, so the deprecated alias inherited its neighbour's documentation.

### Changes

- `occludeDirect` → `boolean`, `alphaFade` → `number`, matching their runtime defaults.
- `opacityShadowDither`'s JSDoc said `boolean` for what is a dither mode string (`DITHER_NONE`/`DITHER_BAYER8`/…). The emitted declaration was already correct, so the JSDoc is corrected to `string` — its sibling `opacityDither` was already documented correctly.
- The doc lookup now parses the `@property` block into a map keyed by property name instead of building a regex out of the type. This restores the correct description on ~30 texture properties and on `anisotropy`.
- **The build now throws** on a type disagreement or a missing `@property` tag, so this cannot silently regress into a dropped doc comment again:
  ```
  StandardMaterial types disagree with its JSDoc - fix the @property tag in
  src/scene/materials/standard-material.js or the type in STANDARD_MAT_PROPS:
    occludeDirect: declared as 'number' but documented as 'boolean'
  ```
- Added the missing `@property` tag for `sheenVertexColorChannel` (verified `'rgb'` at runtime) and an explicit `@deprecated` doc for the `anisotropy` alias.

Every `StandardMaterial` accessor now emits with its own correct doc comment — previously `occludeDirect`, `opacityShadowDither`, `alphaFade` and `sheenVertexColorChannel` had none at all.

Fixes #9152

### Notes for reviewers

- The `guard` no longer encodes a type (`set alphaFade(arg: boolean);` → `set alphaFade(arg:`), so it won't need updating the next time a type changes. Re-running `build:types` is idempotent — verified.
- The new check firing was verified by re-introducing both failure modes against a temp copy of the plugin.
- **Out of scope, worth a follow-up:** checking the reverse direction turned up 49 *documented* properties with no declaration in the `.d.ts` at all (`thickness`, `attenuation`, `sheenGloss`, `alphaDither`, and all the iridescence/refraction ones) — the hand-maintained list holds 184 entries against 233 `@property` tags. That's missing declarations rather than wrong ones, and adding 49 entries would swamp this change, so it is deliberately left out.

### Testing

- `npm run build:types` → `npm run test:types` clean.
- The issue's repro type-checks under `--strict`, with `occludeDirect = 1` and `alphaFade = true` still correctly rejected (asserted via `@ts-expect-error`).
- `npm run lint` clean.
- `npm test`: 2044 passing / 11 failing — **identical with the changes stashed**. The 11 are pre-existing asset-loading timeouts in the font/sprite handler tests, unrelated to this change.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
