### PR TITLE
Support blendable and R/RG float formats in getRenderableHdrFormat

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -12,7 +12,9 @@ import {
     CULLFACE_BACK, CULLFACE_NONE,
     CLEARFLAG_COLOR, CLEARFLAG_DEPTH,
     INDEXFORMAT_UINT16,
-    PRIMITIVE_POINTS, PRIMITIVE_TRIFAN, SEMANTIC_POSITION, TYPE_FLOAT32, PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F,
+    PRIMITIVE_POINTS, PRIMITIVE_TRIFAN, SEMANTIC_POSITION, TYPE_FLOAT32,
+    PIXELFORMAT_111110F, PIXELFORMAT_R16F, PIXELFORMAT_R32F, PIXELFORMAT_RG16F, PIXELFORMAT_RG32F,
+    PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F,
     DISPLAYFORMAT_LDR,
     semanticToLocation,
     FRONTFACE_CCW
@@ -1645,22 +1647,35 @@ class GraphicsDevice extends EventHandler {
      * formats on the majority of devices apart from some very old iOS and Android devices (99%).
      * - When the `filterable` parameter is set to true, the function returns a format on a
      * considerably lower number of devices (70%).
+     * - Support is determined by the precision of a format and not by its number of channels, and so
+     * all the half float formats are supported wherever any of them is, and similarly for the 32bit
+     * float formats.
      *
      * @param {number[]} [formats] - An array of pixel formats to check for support. Can contain:
      *
      * - {@link PIXELFORMAT_111110F}
+     * - {@link PIXELFORMAT_R16F}
+     * - {@link PIXELFORMAT_R32F}
+     * - {@link PIXELFORMAT_RG16F}
+     * - {@link PIXELFORMAT_RG32F}
      * - {@link PIXELFORMAT_RGBA16F}
      * - {@link PIXELFORMAT_RGBA32F}
      *
-     * @param {boolean} [filterable] - If true, the format also needs to be filterable. Defaults to
-     * true.
+     * Any other format in the array is skipped, allowing a non-HDR format to be included in the
+     * list and handled by the caller's own fallback.
+     *
+     * @param {boolean} [filterable] - If true, the format also needs to be filterable, allowing it
+     * to be sampled with linear filtering. Defaults to true.
      * @param {number} [samples] - The number of samples to check for. Some formats are not
      * compatible with multi-sampling, for example {@link PIXELFORMAT_RGBA32F} on WebGPU platform.
      * Defaults to 1.
+     * @param {boolean} [blendable] - If true, the format also needs to be blendable, allowing it to
+     * be used as a blended render target attachment. This is an independent capability to
+     * filtering, and only the 32bit float formats can fail to support it. Defaults to false.
      * @returns {number|undefined} The first supported renderable HDR format or undefined if none is
      * supported.
      */
-    getRenderableHdrFormat(formats = [PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F], filterable = true, samples = 1) {
+    getRenderableHdrFormat(formats = [PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F], filterable = true, samples = 1, blendable = false) {
         for (let i = 0; i < formats.length; i++) {
             const format = formats[i];
             switch (format) {
@@ -1672,20 +1687,31 @@ class GraphicsDevice extends EventHandler {
                     break;
                 }
 
+                case PIXELFORMAT_R16F:
+                case PIXELFORMAT_RG16F:
                 case PIXELFORMAT_RGBA16F:
+
+                    // half float formats are filterable and blendable wherever they are
+                    // renderable, so those requirements need no additional test
                     if (this.textureHalfFloatRenderable) {
                         return format;
                     }
                     break;
 
+                case PIXELFORMAT_R32F:
+                case PIXELFORMAT_RG32F:
                 case PIXELFORMAT_RGBA32F:
 
-                    // on WebGPU platform, RGBA32F is not compatible with multi-sampling
+                    // on WebGPU platform, 32bit float formats are not compatible with multi-sampling
                     if (this.isWebGPU && samples > 1) {
                         continue;
                     }
 
-                    if (this.textureFloatRenderable && (!filterable || this.textureFloatFilterable)) {
+                    // unlike the smaller float formats, filtering and blending of the 32bit float
+                    // formats are both optional capabilities, tested for independently
+                    if (this.textureFloatRenderable &&
+                        (!filterable || this.textureFloatFilterable) &&
+                        (!blendable || this.textureFloatBlendable)) {
                         return format;
                     }
                     break;

--- a/test/platform/graphics/graphics-device.test.mjs
+++ b/test/platform/graphics/graphics-device.test.mjs
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
 
+import {
+    PIXELFORMAT_111110F, PIXELFORMAT_R16F, PIXELFORMAT_R32F, PIXELFORMAT_RG16F, PIXELFORMAT_RG32F,
+    PIXELFORMAT_RGB16F, PIXELFORMAT_RGB32F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F
+} from '../../../src/platform/graphics/constants.js';
 import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
 import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
@@ -39,6 +43,85 @@ describe('GraphicsDevice', function () {
                 expect(device.clientRect.height).to.equal(480);
                 device.destroy();
             });
+        });
+    });
+
+    describe('#getRenderableHdrFormat', function () {
+
+        let device;
+
+        beforeEach(function () {
+            // the null device is renderable in both float precisions, but supports neither the
+            // filtering nor the blending of the 32bit float formats
+            device = new NullGraphicsDevice({ id: 'mock' });
+        });
+
+        afterEach(function () {
+            device.destroy();
+        });
+
+        it('returns the first supported format from the supplied list', function () {
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_RGBA32F, PIXELFORMAT_RGBA16F], false)).to.equal(PIXELFORMAT_RGBA32F);
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F], false)).to.equal(PIXELFORMAT_RGBA16F);
+            expect(device.getRenderableHdrFormat()).to.equal(PIXELFORMAT_RGBA16F);
+        });
+
+        it('supports every channel count of both float precisions', function () {
+            const formats = [
+                PIXELFORMAT_R16F, PIXELFORMAT_RG16F, PIXELFORMAT_RGBA16F,
+                PIXELFORMAT_R32F, PIXELFORMAT_RG32F, PIXELFORMAT_RGBA32F
+            ];
+            formats.forEach((format) => {
+                expect(device.getRenderableHdrFormat([format], false)).to.equal(format);
+            });
+        });
+
+        it('skips a format it does not handle instead of failing', function () {
+            // three channel float formats are not renderable on either backend
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_RGB16F, PIXELFORMAT_RGB32F], false)).to.be.undefined;
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_RGB32F, PIXELFORMAT_R16F], false)).to.equal(PIXELFORMAT_R16F);
+        });
+
+        it('falls back to a half float format when 32bit float blending is not supported', function () {
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_R32F, PIXELFORMAT_R16F], false, 1, true)).to.equal(PIXELFORMAT_R16F);
+        });
+
+        it('returns a 32bit float format when its blending is supported', function () {
+            device.textureFloatBlendable = true;
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_R32F, PIXELFORMAT_R16F], false, 1, true)).to.equal(PIXELFORMAT_R32F);
+        });
+
+        it('tests filtering and blending independently', function () {
+
+            // blendable but not filterable
+            device.textureFloatBlendable = true;
+            device.textureFloatFilterable = false;
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_R32F], true, 1, true)).to.be.undefined;
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_R32F], false, 1, true)).to.equal(PIXELFORMAT_R32F);
+
+            // filterable but not blendable
+            device.textureFloatBlendable = false;
+            device.textureFloatFilterable = true;
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_R32F], true, 1, true)).to.be.undefined;
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_R32F], true, 1, false)).to.equal(PIXELFORMAT_R32F);
+        });
+
+        it('does not require a blending capability for the half float formats', function () {
+            expect(device.textureFloatBlendable).to.be.false;
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_R16F], false, 1, true)).to.equal(PIXELFORMAT_R16F);
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_RGBA16F], false, 1, true)).to.equal(PIXELFORMAT_RGBA16F);
+        });
+
+        it('skips the multi-sampled 32bit float formats on WebGPU', function () {
+            device.isWebGPU = true;
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_R32F, PIXELFORMAT_R16F], false, 4)).to.equal(PIXELFORMAT_R16F);
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_R32F], false, 4)).to.be.undefined;
+        });
+
+        it('returns undefined when no format in the list is renderable', function () {
+            device.textureFloatRenderable = false;
+            device.textureHalfFloatRenderable = false;
+            expect(device.getRenderableHdrFormat([PIXELFORMAT_R32F, PIXELFORMAT_R16F], false)).to.be.undefined;
         });
     });
 });


### PR DESCRIPTION
`GraphicsDevice#getRenderableHdrFormat` can now be asked for a format that supports blending, and understands the single and two channel float formats. This prepares for rendering scene depth into a float render target attachment, which needs a blendable format and a single channel, but is useful for any float target the engine picks a format for.

**Changes:**
- A new optional `blendable` parameter tests `textureFloatBlendable` for the 32bit float formats. Filtering and blending are separate capabilities, backed by separate extensions (`OES_texture_float_linear` / `EXT_float_blend`) and separate WebGPU features (`float32-filterable` / `float32-blendable`), so they are tested independently of each other.
- `PIXELFORMAT_R16F`, `PIXELFORMAT_RG16F`, `PIXELFORMAT_R32F` and `PIXELFORMAT_RG32F` are now recognized. Support depends on the precision of a format and not on its number of channels, so these share the code path of their RGBA counterparts - which also means the narrower 32bit formats pick up the WebGPU multi-sampling exclusion that previously applied to `PIXELFORMAT_RGBA32F` alone.
- Documented that a format the function does not handle is skipped rather than treated as an error. This is what allows a caller to include a non-HDR format in the list and fall back to it itself, as the CameraFrame render format options do.
- Unit tests covering the format ladder, the independence of filtering and blending, and the skipping of unhandled formats.

**API Changes:**
- `GraphicsDevice#getRenderableHdrFormat(formats, filterable, samples, blendable)` - `blendable` is new and defaults to `false`, leaving existing calls unaffected.

The whole format ladder for a blended float attachment now fits in one call:

```js
// R32F when 32bit float blending is supported, R16F otherwise, undefined when neither is renderable
device.getRenderableHdrFormat([PIXELFORMAT_R32F, PIXELFORMAT_R16F], false, 1, true);
```