### PR TITLE
Declare scene depth map encoding instead of inferring from device caps

### DIFF
--- a/src/extras/render-passes/frame-pass-volumetric-fog.js
+++ b/src/extras/render-passes/frame-pass-volumetric-fog.js
@@ -143,8 +143,8 @@ class RenderPassVolumetricFog extends RenderPassShaderQuad {
      */
     updateShaderVariant(shadows, pcf) {
 
-        const depthMapLinear = this.cameraComponent.shaderParams.sceneDepthMapLinear;
-        const key = `${shadows}-${pcf}-${depthMapLinear}`;
+        const depthKey = ShaderUtils.getScreenDepthChunkKey(this.cameraComponent.shaderParams);
+        const key = `${shadows}-${pcf}${depthKey}`;
         if (this._variantKey !== key) {
             this._variantKey = key;
 
@@ -364,8 +364,8 @@ class RenderPassVolumetricFogLocal extends RenderPassShaderQuad {
      */
     updateShaderVariant(shadows, cookies) {
 
-        const depthMapLinear = this.cameraComponent.shaderParams.sceneDepthMapLinear;
-        const key = `${shadows}-${cookies}-${depthMapLinear}`;
+        const depthKey = ShaderUtils.getScreenDepthChunkKey(this.cameraComponent.shaderParams);
+        const key = `${shadows}-${cookies}${depthKey}`;
         if (this._variantKey !== key) {
             this._variantKey = key;
 
@@ -647,10 +647,10 @@ class RenderPassVolumetricFogCombine extends RenderPassShaderQuad {
         this.fogTexture = fogTexture;
 
         const defines = new Map();
-        ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
+        const depthKey = ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
 
         this.shader = ShaderUtils.createShader(device, {
-            uniqueName: `VolumetricFogCombineShader-${cameraComponent.shaderParams.sceneDepthMapLinear}`,
+            uniqueName: `VolumetricFogCombineShader${depthKey}`,
             attributes: { aPosition: SEMANTIC_POSITION },
             vertexChunk: 'quadVS',
             fragmentChunk: 'volumetricFogCombinePS',

--- a/src/extras/render-passes/render-pass-coc.js
+++ b/src/extras/render-passes/render-pass-coc.js
@@ -30,10 +30,10 @@ class RenderPassCoC extends RenderPassShaderQuad {
         if (nearBlur) defines.set('NEAR_BLUR', '');
 
         // add defines needed for correct use of screenDepthPS chunk
-        ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
+        const depthKey = ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
 
         this.shader = ShaderUtils.createShader(device, {
-            uniqueName: `CocShader-${nearBlur}`,
+            uniqueName: `CocShader-${nearBlur}${depthKey}`,
             attributes: { aPosition: SEMANTIC_POSITION },
             vertexChunk: 'quadVS',
             fragmentChunk: 'cocPS',

--- a/src/extras/render-passes/render-pass-depth-aware-blur.js
+++ b/src/extras/render-passes/render-pass-depth-aware-blur.js
@@ -24,10 +24,10 @@ class RenderPassDepthAwareBlur extends RenderPassShaderQuad {
         if (horizontal) defines.set('HORIZONTAL', '');
 
         // add defines needed for correct use of screenDepthPS chunk
-        ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
+        const depthKey = ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
 
         this.shader = ShaderUtils.createShader(device, {
-            uniqueName: `DepthAware${horizontal ? 'Horizontal' : 'Vertical'}BlurShader`,
+            uniqueName: `DepthAware${horizontal ? 'Horizontal' : 'Vertical'}BlurShader${depthKey}`,
             attributes: { aPosition: SEMANTIC_POSITION },
             vertexChunk: 'quadVS',
             fragmentChunk: 'depthAwareBlurPS',

--- a/src/extras/render-passes/render-pass-prepass.js
+++ b/src/extras/render-passes/render-pass-prepass.js
@@ -11,6 +11,7 @@ import {
     SHADER_PREPASS
 } from '../../scene/constants.js';
 import { Color } from '../../core/math/color.js';
+import { Debug } from '../../core/debug.js';
 import { FloatPacking } from '../../core/math/float-packing.js';
 
 const tempMeshInstances = [];
@@ -53,6 +54,7 @@ class RenderPassPrepass extends RenderPass {
     destroy() {
         super.destroy();
         this.camera.shaderParams.sceneDepthMapLinear = false;
+        this.camera.shaderParams.sceneDepthMapPacked = false;
         this.renderTarget?.destroy();
         this.renderTarget = null;
         this.linearDepthTexture?.destroy();
@@ -63,6 +65,10 @@ class RenderPassPrepass extends RenderPass {
 
         const { device } = this;
 
+        // when float textures cannot be rendered to, the depth is bit-packed into RGBA8 instead,
+        // which is lossless and so preferable to a lower precision float format. Note that the
+        // shader side of the packing (float2vec4) selects its encoding using the global
+        // CAPS_TEXTURE_FLOAT_RENDERABLE define, which has to agree with the format chosen here.
         this.linearDepthFormat = device.textureFloatRenderable ? PIXELFORMAT_R32F : PIXELFORMAT_RGBA8;
         this.linearDepthTexture = Texture.createDataTexture2D(device, 'SceneLinearDepthTexture', 1, 1, this.linearDepthFormat);
 
@@ -77,8 +83,16 @@ class RenderPassPrepass extends RenderPass {
             samples: 1
         });
 
-        // scene depth will be linear
-        this.camera.shaderParams.sceneDepthMapLinear = true;
+        // declare how this pass stores the depth, so that the shaders sampling it decode what was
+        // actually written instead of inferring it from the device capabilities - other producers of
+        // the scene depth map store it in other formats
+        const { shaderParams } = this.camera;
+        shaderParams.sceneDepthMapLinear = true;
+        shaderParams.sceneDepthMapPacked = this.linearDepthFormat === PIXELFORMAT_RGBA8;
+
+        // the WGSL screenDepth chunk implements no packed decode, as WebGPU always supports
+        // rendering to float textures
+        Debug.assert(!(device.isWebGPU && shaderParams.sceneDepthMapPacked));
 
         this.init(renderTarget, options);
     }

--- a/src/extras/render-passes/render-pass-ssao.js
+++ b/src/extras/render-passes/render-pass-ssao.js
@@ -81,10 +81,10 @@ class RenderPassSsao extends RenderPassShaderQuad {
         const defines = new Map();
 
         // add defines needed for correct use of screenDepthPS chunk
-        ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
+        const depthKey = ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
 
         this.shader = ShaderUtils.createShader(device, {
-            uniqueName: 'SsaoShader',
+            uniqueName: `SsaoShader${depthKey}`,
             attributes: { aPosition: SEMANTIC_POSITION },
             vertexChunk: 'quadVS',
             fragmentChunk: 'ssaoPS',

--- a/src/extras/render-passes/render-pass-taa.js
+++ b/src/extras/render-passes/render-pass-taa.js
@@ -57,10 +57,10 @@ class RenderPassTAA extends RenderPassShaderQuad {
         defines.set('QUALITY_HIGH', true);
 
         // add defines needed for correct use of screenDepthPS chunk
-        ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
+        const depthKey = ShaderUtils.addScreenDepthChunkDefines(cameraComponent.shaderParams, defines);
 
         this.shader = ShaderUtils.createShader(device, {
-            uniqueName: 'TaaResolveShader',
+            uniqueName: `TaaResolveShader${depthKey}`,
             attributes: { aPosition: SEMANTIC_POSITION },
             vertexChunk: 'quadVS',
             fragmentChunk: 'taaResolvePS',

--- a/src/scene/camera-shader-params.js
+++ b/src/scene/camera-shader-params.js
@@ -26,6 +26,15 @@ class CameraShaderParams {
     _sceneDepthMapLinear = false;
 
     /**
+     * True when each depth in the linear scene depth map is stored as a float bit-packed into an
+     * RGBA8 texel, the encoding the producer of the map falls back to when float textures cannot be
+     * rendered to. Only meaningful when {@link CameraShaderParams#sceneDepthMapLinear} is set.
+     *
+     * @private
+     */
+    _sceneDepthMapPacked = false;
+
+    /**
      * The hash of the rendering parameters, or undefined if the hash has not been computed yet.
      *
      * @type {number|undefined}
@@ -52,7 +61,7 @@ class CameraShaderParams {
      */
     get hash() {
         if (this._hash === undefined) {
-            const key = `${this.gammaCorrection}_${this.toneMapping}_${this.srgbRenderTarget}_${this.fog}_${this.ssaoEnabled}_${this.sceneDepthMapLinear}`;
+            const key = `${this.gammaCorrection}_${this.toneMapping}_${this.srgbRenderTarget}_${this.fog}_${this.ssaoEnabled}_${this.sceneDepthMapLinear}_${this.sceneDepthMapPacked}`;
             this._hash = hashCode(key);
         }
         return this._hash;
@@ -66,7 +75,13 @@ class CameraShaderParams {
             this._definesDirty = false;
             defines.clear();
 
-            if (this._sceneDepthMapLinear) defines.set('SCENE_DEPTHMAP_LINEAR', '');
+            if (this._sceneDepthMapLinear) {
+                defines.set('SCENE_DEPTHMAP_LINEAR', '');
+
+                // nested, so that the packed define never appears without the linear one, which is
+                // what the decode in the screenDepth chunk relies on
+                if (this._sceneDepthMapPacked) defines.set('SCENE_DEPTHMAP_PACKED', '');
+            }
             if (this.shaderOutputGamma === GAMMA_SRGB) defines.set('SCENE_COLORMAP_GAMMA', '');
             defines.set('FOG', this._fog.toUpperCase());
             defines.set('TONEMAP', tonemapNames[this._toneMapping]);
@@ -145,6 +160,17 @@ class CameraShaderParams {
 
     get sceneDepthMapLinear() {
         return this._sceneDepthMapLinear;
+    }
+
+    set sceneDepthMapPacked(value) {
+        if (this._sceneDepthMapPacked !== value) {
+            this._sceneDepthMapPacked = value;
+            this.markDirty();
+        }
+    }
+
+    get sceneDepthMapPacked() {
+        return this._sceneDepthMapPacked;
     }
 
     /**

--- a/src/scene/shader-lib/glsl/chunks/common/frag/screenDepth.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/screenDepth.js
@@ -1,6 +1,10 @@
 export default /* glsl */`
 uniform highp sampler2D uSceneDepthMap;
 
+#if defined(SCENE_DEPTHMAP_LINEAR) && defined(SCENE_DEPTHMAP_PACKED)
+    #include "floatAsUintPS"
+#endif
+
 #ifndef SCREENSIZE
     #define SCREENSIZE
     uniform vec4 uScreenSize;
@@ -38,21 +42,14 @@ float delinearizeDepth(float linearDepth) {
 // Retrieves rendered linear camera depth by UV
 float getLinearScreenDepth(vec2 uv) {
     #ifdef SCENE_DEPTHMAP_LINEAR
-        #ifdef CAPS_TEXTURE_FLOAT_RENDERABLE
-            return texture2D(uSceneDepthMap, uv).r;
+        #ifdef SCENE_DEPTHMAP_PACKED
+
+            // the depth is a float bit-packed into an RGBA8 texel, so it has to be read without
+            // any filtering to keep the individual bytes intact
+            ivec2 texel = ivec2(uv * vec2(textureSize(uSceneDepthMap, 0)));
+            return uint2float(texelFetch(uSceneDepthMap, texel, 0));
         #else
-
-            ivec2 textureSize = textureSize(uSceneDepthMap, 0);
-            ivec2 texel = ivec2(uv * vec2(textureSize));
-            vec4 data = texelFetch(uSceneDepthMap, texel, 0);
-
-            uint intBits = 
-                (uint(data.r * 255.0) << 24u) |
-                (uint(data.g * 255.0) << 16u) |
-                (uint(data.b * 255.0) << 8u) |
-                uint(data.a * 255.0);
-
-            return uintBitsToFloat(intBits);
+            return texture2D(uSceneDepthMap, uv).r;
         #endif
     #else
         return linearizeDepth(texture2D(uSceneDepthMap, uv).r);

--- a/src/scene/shader-lib/shader-utils.js
+++ b/src/scene/shader-lib/shader-utils.js
@@ -191,19 +191,44 @@ class ShaderUtils {
     }
 
     /**
+     * Returns a key identifying the defines {@link ShaderUtils.addScreenDepthChunkDefines} adds for
+     * the given camera shader parameters. As the shader cache is keyed on the unique name of a
+     * shader alone, the name of every shader using those defines has to include this key, or two
+     * differently decoding variants would share a single compiled shader.
+     *
+     * @param {CameraShaderParams} cameraShaderParams - The camera shader parameters.
+     * @returns {string} The key, empty when the defines add nothing.
+     * @ignore
+     */
+    static getScreenDepthChunkKey(cameraShaderParams) {
+        const { sceneDepthMapLinear, sceneDepthMapPacked } = cameraShaderParams;
+        return sceneDepthMapLinear ? (sceneDepthMapPacked ? '-linearPacked' : '-linear') : '';
+    }
+
+    /**
      * Add defines required for correct screenDepthPS chunk functionality for the given camera
-     * shader parameters. Note that the float vs packed-RGBA8 decode is selected inside the chunk
-     * using the global CAPS_TEXTURE_FLOAT_RENDERABLE define, which matches the format the depth
-     * prepass allocates the linear depth texture in.
+     * shader parameters. These describe how the scene depth map currently assigned to the camera is
+     * encoded, and are declared by whichever render pass produced it, as different producers store
+     * the depth in different formats.
      *
      * @param {CameraShaderParams} cameraShaderParams - The camera shader parameters.
      * @param {Map<string, string>} defines - The map of defines to add to.
+     * @returns {string} The key of the added defines, to be included in the unique name of the
+     * shader using them. See {@link ShaderUtils.getScreenDepthChunkKey}.
      * @ignore
      */
     static addScreenDepthChunkDefines(cameraShaderParams, defines) {
         if (cameraShaderParams.sceneDepthMapLinear) {
             defines.set('SCENE_DEPTHMAP_LINEAR', '');
+
+            // nested, so that the packed define never appears without the linear one, which is what
+            // the decode in the screenDepth chunk relies on
+            if (cameraShaderParams.sceneDepthMapPacked) {
+                defines.set('SCENE_DEPTHMAP_PACKED', '');
+            }
         }
+
+        return ShaderUtils.getScreenDepthChunkKey(cameraShaderParams);
     }
 }
 

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/screenDepth.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/screenDepth.js
@@ -38,6 +38,10 @@ fn delinearizeDepth(linearDepth: f32) -> f32 {
 }
 
 // Retrieves rendered linear camera depth by UV
+//
+// Note that there is no SCENE_DEPTHMAP_PACKED decode here, unlike in the GLSL chunk. WebGPU can
+// always render to float textures, so no producer of the scene depth map falls back to packing the
+// depth into RGBA8 on this backend. RenderPassPrepass asserts this.
 fn getLinearScreenDepth(uv: vec2f) -> f32 {
     let textureSize = textureDimensions(uSceneDepthMap, 0);
     let texel: vec2i = vec2i(uv * vec2f(textureSize));


### PR DESCRIPTION
The encoding of the scene depth map is now declared by the render pass that produced it, instead of being inferred by every consumer from a device capability. All of the touched APIs are internal (`@ignore`), and there is no behaviour change - the prepass declares exactly the encoding that the capability check used to imply.

The motivation is that different producers of the depth map have genuinely different format ladders, so no single device capability describes the encoding. The prepass falls back from `R32F` to a float bit-packed into RGBA8, which is lossless and therefore better than a lower precision float format. A producer which needs the depth to be blendable cannot pack, as packed bits cannot be blended, and has to fall back to `R16F` instead. Inferring the encoding from `CAPS_TEXTURE_FLOAT_RENDERABLE` silently assumes there is only ever one producer.

**Changes:**
- `CameraShaderParams.sceneDepthMapPacked` joins `sceneDepthMapLinear`, and both are set together by `RenderPassPrepass` from the format it actually allocated. The `SCENE_DEPTHMAP_PACKED` define is emitted nested inside the linear one, so it can never appear on its own, which is what the decode relies on.
- `getLinearScreenDepth` in the GLSL screenDepth chunk selects its decode from the new define rather than from the device capability, and the hand-inlined RGBA8 unpack is replaced by `uint2float` from the shared `floatAsUintPS` chunk, so the packing format is expressed in one place.
- The WGSL chunk implements no packed decode, as WebGPU can always render to float textures and so never produces a packed depth map. That was previously an unwritten assumption; it is now documented in the chunk and asserted in `RenderPassPrepass`.
- `ShaderUtils.addScreenDepthChunkDefines` returns a key identifying the defines it added, and every shader which consumes them includes it in its unique name. The shader cache is keyed on the unique name alone, so `SsaoShader`, `TaaResolveShader`, `CocShader` and `DepthAware*BlurShader` could otherwise share a single compiled shader across two different decodes. This is unreachable today, since those passes only run under CameraFrame, which always enables the prepass, but the omission was one change away from mattering. The volumetric fog variant keys, which also gate shader rebuilds, gain the same key.

Verified on both backends with volumetric fog, depth of field and the combined post-processing stack. The packed path, which only very old WebGL2 devices take, was exercised by temporarily forcing `textureFloatRenderable` to false, confirming that the conditional chunk include resolves and the decode is correct.