### PR TITLE
Support writing the scene textures from the forward pass

### DIFF
--- a/src/core/preprocessor.js
+++ b/src/core/preprocessor.js
@@ -107,6 +107,11 @@ class Preprocessor {
         // strip comments again after the includes have been resolved
         source = this.stripComments(source);
 
+        // inject defines before the passes that inspect the source, so that they see the substituted
+        // values and not the {NAME} placeholders - stripUnusedColorAttachments for example looks for
+        // pcFragColorX with a literal index
+        source = this.injectDefines(source, injectDefines);
+
         source = this.stripUnusedColorAttachments(source, options);
 
         // remove empty lines
@@ -114,9 +119,6 @@ class Preprocessor {
 
         // process array sizes
         source = this.processArraySize(source, intDefines);
-
-        // inject defines
-        source = this.injectDefines(source, injectDefines);
 
         return source;
     }

--- a/src/platform/graphics/blend-state-utils.js
+++ b/src/platform/graphics/blend-state-utils.js
@@ -1,0 +1,46 @@
+import { BlendState } from './blend-state.js';
+
+// scratch state used to build the write mask
+const _noWrite = new BlendState();
+
+// derived blend states, in an array indexed by the color attachment count, each holding a map from
+// the key of the blend state they were derived from to the derived state. Rendering uses a handful of
+// blend states, so these stay tiny.
+const _caches = [];
+
+/**
+ * Returns a blend state matching the supplied one, but with the color writes to all attachments other
+ * than the first disabled. Used when rendering to a render target with more color attachments than
+ * the fragment shader writes - both WebGL2 and WebGPU require an attachment the shader does not write
+ * to have its writes disabled, otherwise the draw is invalid.
+ *
+ * @param {BlendState} blendState - The blend state of the render, describing attachment 0.
+ * @param {number} attachmentCount - The number of color attachments of the render target.
+ * @returns {BlendState} The blend state to use.
+ * @ignore
+ */
+function getSingleAttachmentBlendState(blendState, attachmentCount) {
+
+    // a state specifying its own per attachment values is left alone, as it takes precedence
+    if (blendState.hasAttachmentOverrides) {
+        return blendState;
+    }
+
+    const cache = _caches[attachmentCount] ?? (_caches[attachmentCount] = new Map());
+    const key = blendState.key;
+    let masked = cache.get(key);
+    if (!masked) {
+        _noWrite.copy(blendState);
+        _noWrite.setColorWrite(false, false, false, false);
+
+        masked = blendState.clone();
+        for (let i = 1; i < attachmentCount; i++) {
+            masked.setAttachment(i, _noWrite);
+        }
+        cache.set(key, masked);
+    }
+
+    return masked;
+}
+
+export { getSingleAttachmentBlendState };

--- a/src/platform/graphics/blend-state-utils.js
+++ b/src/platform/graphics/blend-state-utils.js
@@ -14,6 +14,13 @@ const _caches = [];
  * the fragment shader writes - both WebGL2 and WebGPU require an attachment the shader does not write
  * to have its writes disabled, otherwise the draw is invalid.
  *
+ * Note that masking the writes off requires {@link GraphicsDevice#supportsIndependentBlending}, as
+ * without it the state of the attachment 0 applies to all attachments and the mask has no effect.
+ *
+ * Note also that a dual-source blend state cannot be used with multiple color attachments at all,
+ * and masking does not change that - dual-source blending requires exactly one attachment, so a
+ * material using it is incompatible with a render target carrying additional attachments.
+ *
  * @param {BlendState} blendState - The blend state of the render, describing attachment 0.
  * @param {number} attachmentCount - The number of color attachments of the render target.
  * @returns {BlendState} The blend state to use.

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -659,6 +659,15 @@ class RenderTarget {
     }
 
     /**
+     * The number of color buffers (attachments) set up on the render target.
+     *
+     * @type {number}
+     */
+    get colorBufferCount() {
+        return this._colorBuffers?.length ?? 0;
+    }
+
+    /**
      * Accessor for multiple render target color buffers.
      *
      * @param {number} index - Index of the color buffer to get.

--- a/src/scene/camera-shader-params.js
+++ b/src/scene/camera-shader-params.js
@@ -1,3 +1,5 @@
+import { array } from '../core/array-utils.js';
+import { Debug } from '../core/debug.js';
 import { hashCode } from '../core/hash.js';
 import { FOG_NONE, GAMMA_NONE, GAMMA_SRGB, gammaNames, TONEMAP_LINEAR, tonemapNames } from './constants.js';
 
@@ -35,6 +37,27 @@ class CameraShaderParams {
     _sceneDepthMapPacked = false;
 
     /**
+     * The names of the scene textures the scene pass renders alongside the scene color, in the order
+     * of the color attachments they are rendered to - the name at index i goes to the attachment at
+     * index i + 1, as attachment 0 is the scene color itself. Empty when the scene pass renders the
+     * scene color alone.
+     *
+     * The render pass is what owns this, as only the passes rendering to a render target the scene
+     * textures are attached to may write them - a camera's pass rendering the UI to the output render
+     * target must not. It is mirrored here because shader generation is given no more than the camera
+     * shader params, so this is how a material learns that its shader has to write the additional
+     * attachments, and how those attachments take part in the shader variant key.
+     *
+     * That makes the value transient: {@link RenderPassForward} assigns it and restores the previous
+     * value around each layer step it renders, in the same way it overrides the gamma correction and
+     * the tone mapping. Outside of those draws the camera reads as rendering no scene textures.
+     *
+     * @type {string[]}
+     * @private
+     */
+    _sceneTextures = [];
+
+    /**
      * The hash of the rendering parameters, or undefined if the hash has not been computed yet.
      *
      * @type {number|undefined}
@@ -61,7 +84,7 @@ class CameraShaderParams {
      */
     get hash() {
         if (this._hash === undefined) {
-            const key = `${this.gammaCorrection}_${this.toneMapping}_${this.srgbRenderTarget}_${this.fog}_${this.ssaoEnabled}_${this.sceneDepthMapLinear}_${this.sceneDepthMapPacked}`;
+            const key = `${this.gammaCorrection}_${this.toneMapping}_${this.srgbRenderTarget}_${this.fog}_${this.ssaoEnabled}_${this.sceneDepthMapLinear}_${this.sceneDepthMapPacked}_${this._sceneTextures.join('-')}`;
             this._hash = hashCode(key);
         }
         return this._hash;
@@ -82,6 +105,15 @@ class CameraShaderParams {
                 // what the decode in the screenDepth chunk relies on
                 if (this._sceneDepthMapPacked) defines.set('SCENE_DEPTHMAP_PACKED', '');
             }
+
+            // each scene texture supplies a pair of defines - one enabling its write, and one giving
+            // the color attachment it is written to, which the preprocessor substitutes into the name
+            // of the output the sceneTexturesPS chunk writes
+            this._sceneTextures.forEach((name, index) => {
+                const upperName = name.toUpperCase();
+                defines.set(`SCENE_TEXTURE_${upperName}`, '');
+                defines.set(`{SCENE_TEXTURE_${upperName}_SLOT}`, String(index + 1));
+            });
             if (this.shaderOutputGamma === GAMMA_SRGB) defines.set('SCENE_COLORMAP_GAMMA', '');
             defines.set('FOG', this._fog.toUpperCase());
             defines.set('TONEMAP', tonemapNames[this._toneMapping]);
@@ -171,6 +203,43 @@ class CameraShaderParams {
 
     get sceneDepthMapPacked() {
         return this._sceneDepthMapPacked;
+    }
+
+    /**
+     * Sets the names of the scene textures the scene pass renders alongside the scene color, for
+     * example `['depth']`. Their order is the order of the color attachments they are rendered to,
+     * so the name at index i is written to the attachment at index i + 1. Assign an empty array when
+     * the scene pass renders the scene color alone. This is assigned by the render pass rendering
+     * them, for the duration of its draws only - see the note on the backing field.
+     *
+     * Each name generates a pair of shader defines, following the same naming as the shader passes:
+     * `'depth'` supplies `SCENE_TEXTURE_DEPTH`, which enables the write, and
+     * `{SCENE_TEXTURE_DEPTH_SLOT}`, which the sceneTexturesPS chunk substitutes into the name of the
+     * output it writes. A name can only contain letters, numbers and underscores, and start with a
+     * letter.
+     *
+     * @type {string[]}
+     */
+    set sceneTextures(value) {
+
+        const names = value ?? [];
+
+        Debug.call(() => {
+            names.forEach((name) => {
+                Debug.assert(/^[a-z]\w*$/i.test(name), `Scene texture name can only contain letters, numbers and underscores and start with a letter: ${name}`);
+            });
+        });
+
+        // compared by value, as this is assigned by each render pass as it executes, and taking a
+        // new array of the same names must not invalidate the shader variants of every material
+        if (!array.equals(this._sceneTextures, names)) {
+            this._sceneTextures = names.slice();
+            this.markDirty();
+        }
+    }
+
+    get sceneTextures() {
+        return this._sceneTextures;
     }
 
     /**

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1333,3 +1333,13 @@ export const RADIX_SORT_PORTABLE = 1;
  * @category Graphics
  */
 export const RADIX_SORT_ONESWEEP = 2;
+
+/**
+ * The name of the scene depth texture - a scene texture storing the linear depth of the scene,
+ * rendered by the scene pass alongside the scene color. See
+ * {@link CameraShaderParams#sceneTextures}.
+ *
+ * @type {string}
+ * @ignore
+ */
+export const SCENETEXTURE_DEPTH = 'depth';

--- a/src/scene/materials/lit-material-options-builder.js
+++ b/src/scene/materials/lit-material-options-builder.js
@@ -6,20 +6,27 @@ import {
     SHADERDEF_MORPH_TEXTURE_BASED_INT,
     FOG_NONE,
     REFLECTIONSRC_NONE, REFLECTIONSRC_ENVATLAS, REFLECTIONSRC_ENVATLASHQ, REFLECTIONSRC_CUBEMAP,
-    AMBIENTSRC_AMBIENTSH, AMBIENTSRC_ENVALATLAS, AMBIENTSRC_CONSTANT
+    AMBIENTSRC_AMBIENTSH, AMBIENTSRC_ENVALATLAS, AMBIENTSRC_CONSTANT,
+    SHADER_PREPASS, SCENETEXTURE_DEPTH
 } from '../constants.js';
 
 class LitMaterialOptionsBuilder {
     static update(litOptions, material, scene, renderParams, objDefs, pass, sortedLights) {
-        LitMaterialOptionsBuilder.updateSharedOptions(litOptions, material, scene, objDefs, pass);
+        LitMaterialOptionsBuilder.updateSharedOptions(litOptions, material, scene, objDefs, pass, renderParams);
         LitMaterialOptionsBuilder.updateMaterialOptions(litOptions, material);
         LitMaterialOptionsBuilder.updateEnvOptions(litOptions, material, scene, renderParams);
         LitMaterialOptionsBuilder.updateLightingOptions(litOptions, material, scene, objDefs, sortedLights);
     }
 
-    static updateSharedOptions(litOptions, material, scene, objDefs, pass) {
+    static updateSharedOptions(litOptions, material, scene, objDefs, pass, renderParams) {
         litOptions.shaderChunks = material.shaderChunks;
         litOptions.pass = pass;
+
+        // linear depth is rendered by the prepass, and by the forward pass when the camera renders
+        // the scene depth into a scene texture
+        litOptions.linearDepth = pass === SHADER_PREPASS ||
+            !!renderParams?.sceneTextures.includes(SCENETEXTURE_DEPTH);
+
         litOptions.alphaTest = material.alphaTest > 0;
         litOptions.blendType = material.blendType;
 

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -150,6 +150,14 @@ class Material {
     /** @ignore */
     _blendState = new BlendState();
 
+    /**
+     * Explicit setting of sceneTexturesWrite, or undefined to derive it from transparency.
+     *
+     * @type {boolean|undefined}
+     * @private
+     */
+    _sceneTexturesWrite;
+
     /** @ignore */
     _depthState = new DepthState();
 
@@ -484,6 +492,47 @@ class Material {
         return this._blendState.blend;
     }
 
+    /**
+     * Declares whether this material's shader generates the scene textures - the additional render
+     * target attachments the scene pass renders alongside the scene color, holding per pixel data
+     * such as the linear depth. It applies to all of them at once, as a shader either supports the
+     * scene textures or it does not. The attachments of a material that does not generate them are
+     * masked off, as a shader leaving an attachment unwritten makes the draw invalid.
+     *
+     * The default depends on where the shader comes from, so this rarely needs setting:
+     *
+     * - {@link StandardMaterial} and {@link LitMaterial} generate them from the engine's own shader,
+     * so they default to true when opaque and false when transparent - blending the values of
+     * ordinary transparent geometry into them is not meaningful.
+     * - {@link ShaderMaterial} defaults to false, as its shader is supplied by the user. Set this to
+     * true if that shader outputs them using the `sceneTexturesPS` chunk.
+     * - Gaussian splat materials set it to true, the deliberate exception to the transparency rule -
+     * their premultiplied blending accumulates a transmittance weighted average.
+     * - Particle materials set it to false, as they use their own shader.
+     *
+     * Unlike {@link Material#depthWrite} and the color write properties this is not purely a mask:
+     * setting it to true for a shader that does not generate the scene textures makes its draws
+     * invalid, rather than simply skipping the write.
+     *
+     * @type {boolean}
+     * @ignore
+     */
+    set sceneTexturesWrite(value) {
+        this._sceneTexturesWrite = value;
+    }
+
+    /**
+     * Gets whether this material's shader generates the scene textures. Returns the explicitly set
+     * value when there is one, and otherwise derives it from transparency - opaque materials generate
+     * them, transparent ones do not. See the setter for the default of each material type.
+     *
+     * @type {boolean}
+     * @ignore
+     */
+    get sceneTexturesWrite() {
+        return this._sceneTexturesWrite ?? !this.transparent;
+    }
+
     _updateTransparency() {
         for (const meshInstance of this.meshInstances) {
             meshInstance.transparent = this.transparent;
@@ -691,6 +740,7 @@ class Material {
 
         this._blendState.copy(source._blendState);
         this._depthState.copy(source._depthState);
+        this._sceneTexturesWrite = source._sceneTexturesWrite;
 
         this.cull = source.cull;
         this.frontFace = source.frontFace;

--- a/src/scene/materials/shader-material.js
+++ b/src/scene/materials/shader-material.js
@@ -68,6 +68,10 @@ class ShaderMaterial extends Material {
     constructor(shaderDesc) {
         super();
 
+        // the shader is supplied by the user, so by default it is not expected to generate the scene
+        // textures - a material whose shader does needs to opt in
+        this.sceneTexturesWrite = false;
+
         this.shaderDesc = shaderDesc;
     }
 

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -14,7 +14,8 @@ import {
     SHADERDEF_MORPH_TEXTURE_BASED_INT, SHADERDEF_BATCH,
     FOG_NONE,
     REFLECTIONSRC_NONE, REFLECTIONSRC_ENVATLAS, REFLECTIONSRC_ENVATLASHQ, REFLECTIONSRC_CUBEMAP, REFLECTIONSRC_SPHEREMAP,
-    AMBIENTSRC_AMBIENTSH, AMBIENTSRC_ENVALATLAS, AMBIENTSRC_CONSTANT
+    AMBIENTSRC_AMBIENTSH, AMBIENTSRC_ENVALATLAS, AMBIENTSRC_CONSTANT,
+    SCENETEXTURE_DEPTH
 } from '../constants.js';
 import { _matTex2D } from '../shader-lib/programs/standard.js';
 import { LitMaterialOptionsBuilder } from './lit-material-options-builder.js';
@@ -32,7 +33,7 @@ class StandardMaterialOptionsBuilder {
     }
 
     updateRef(options, scene, cameraShaderParams, stdMat, objDefs, pass, sortedLights) {
-        this._updateSharedOptions(options, scene, stdMat, objDefs, pass);
+        this._updateSharedOptions(options, scene, stdMat, objDefs, pass, cameraShaderParams);
         this._updateEnvOptions(options, stdMat, scene, cameraShaderParams);
         this._updateMaterialOptions(options, stdMat, scene);
         options.litOptions.hasTangents = objDefs && ((objDefs & SHADERDEF_TANGENTS) !== 0);
@@ -40,8 +41,14 @@ class StandardMaterialOptionsBuilder {
         this._updateUVOptions(options, stdMat, objDefs, false, cameraShaderParams);
     }
 
-    _updateSharedOptions(options, scene, stdMat, objDefs, pass) {
+    _updateSharedOptions(options, scene, stdMat, objDefs, pass, cameraShaderParams) {
         options.forceUv1 = stdMat.forceUv1;
+
+        // linear depth is rendered by the prepass, and by the forward pass when the camera renders
+        // the scene depth into a scene texture. Note that the minimal variant of the options, used
+        // by the prepass among others, is built without the camera shader params
+        options.litOptions.linearDepth = pass === SHADER_PREPASS ||
+            !!cameraShaderParams?.sceneTextures.includes(SCENETEXTURE_DEPTH);
 
         // USER ATTRIBUTES
         if (stdMat.userAttributes) {
@@ -174,7 +181,6 @@ class StandardMaterialOptionsBuilder {
         // pre-pass uses the same dither setting as forward pass, otherwise shadow dither
         const isPrepass = pass === SHADER_PREPASS;
         options.litOptions.opacityShadowDither = isPrepass ? stdMat.opacityDither : stdMat.opacityShadowDither;
-        options.litOptions.linearDepth = isPrepass;
 
         options.litOptions.lights = [];
     }

--- a/src/scene/particle-system/particle-material.js
+++ b/src/scene/particle-system/particle-material.js
@@ -33,6 +33,9 @@ class ParticleMaterial extends Material {
     constructor(emitter) {
         super();
 
+        // particles use their own shader, which does not generate the scene textures
+        this.sceneTexturesWrite = false;
+
         this.emitter = emitter;
         Debug.assert(emitter);
     }

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -616,6 +616,13 @@ class ForwardRenderer extends Renderer {
         const sceneTextures = camera.shaderParams.sceneTextures.length > 0;
         const attachmentCount = sceneTextures ? (device.renderTarget?.colorBufferCount ?? 1) : 1;
 
+        // the masking requires independent blending - without it the blend state of the attachment 0
+        // applies to all attachments, and so the materials which do not generate the scene textures
+        // would write undefined values to them. Whoever sets up the scene textures has to test for
+        // this capability.
+        Debug.assert(attachmentCount <= 1 || device.supportsIndependentBlending,
+            'Rendering the scene textures requires GraphicsDevice#supportsIndependentBlending, as the attachments of the materials which do not generate them cannot be masked off without it.');
+
         // multiview xr rendering
         const viewList = camera.xrActive && camera.xrViews.length ? camera.xrViews : null;
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -18,6 +18,7 @@ import { RenderPassForward } from './render-pass-forward.js';
 import { LayerRenderStep } from './layer-render-step.js';
 import { FramePassPostprocessing } from './frame-pass-postprocessing.js';
 import { BINDGROUP_VIEW } from '../../platform/graphics/constants.js';
+import { getSingleAttachmentBlendState } from '../../platform/graphics/blend-state-utils.js';
 
 /**
  * @import { Camera } from '../camera.js'
@@ -610,6 +611,11 @@ class ForwardRenderer extends Renderer {
         const flipFactor = flipFaces ? -1 : 1;
         const clusteredLightingEnabled = scene.clusteredLightingEnabled;
 
+        // when this pass renders the scene textures, the additional attachments of the materials whose
+        // shader does not generate them need masking off
+        const sceneTextures = camera.shaderParams.sceneTextures.length > 0;
+        const attachmentCount = sceneTextures ? (device.renderTarget?.colorBufferCount ?? 1) : 1;
+
         // multiview xr rendering
         const viewList = camera.xrActive && camera.xrViews.length ? camera.xrViews : null;
 
@@ -654,7 +660,9 @@ class ForwardRenderer extends Renderer {
 
                 this.alphaTestId.setValue(material.alphaTest);
 
-                device.setBlendState(material.blendState);
+                const blendState = (attachmentCount > 1 && !material.sceneTexturesWrite) ?
+                    getSingleAttachmentBlendState(material.blendState, attachmentCount) : material.blendState;
+                device.setBlendState(blendState);
                 device.setDepthState(material.depthState);
                 device.setAlphaToCoverage(material.alphaToCoverage);
             }

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -68,6 +68,17 @@ class RenderPassForward extends RenderPass {
     toneMapping;
 
     /**
+     * The names of the scene textures this pass renders alongside the scene color, in the order of
+     * the color attachments they are rendered to. In not set, setting from the camera is used. Only
+     * the passes rendering to a render target the scene textures are attached to set this, so that
+     * the camera's other passes, for example the one rendering the UI to the output render target,
+     * do not write them.
+     *
+     * @type {string[]|undefined}
+     */
+    sceneTextures;
+
+    /**
      * If true, do not clear the depth buffer before rendering, as it was already primed by a depth
      * pre-pass.
      */
@@ -179,7 +190,11 @@ class RenderPassForward extends RenderPass {
             const camera = cameraComponent.camera;
             const fullSizeClearRect = camera.fullSizeClearRect;
 
-            this.setClearColor(fullSizeClearRect && step.clearColor ? camera.clearColor : undefined);
+            // when this pass renders the scene textures, the camera's clear color describes the scene
+            // color attachment alone - the clear values of the scene texture attachments belong to
+            // whoever owns them, and are left alone here
+            const colorIndex = this.sceneTextures?.length ? 0 : undefined;
+            this.setClearColor(fullSizeClearRect && step.clearColor ? camera.clearColor : undefined, colorIndex);
             this.setClearDepth(fullSizeClearRect && step.clearDepth && !this.noDepthClear ? camera.clearDepth : undefined);
             this.setClearStencil(fullSizeClearRect && step.clearStencil ? camera.clearStencil : undefined);
         }
@@ -270,9 +285,11 @@ class RenderPassForward extends RenderPass {
 
         if (cameraComponent) {
 
-            // override gamma correction and tone mapping settings
+            // override gamma correction, tone mapping and scene texture settings
             const originalGammaCorrection = cameraComponent.gammaCorrection;
             const originalToneMapping = cameraComponent.toneMapping;
+            const originalSceneTextures = cameraComponent.shaderParams.sceneTextures;
+            if (this.sceneTextures !== undefined) cameraComponent.shaderParams.sceneTextures = this.sceneTextures;
             if (this.gammaCorrection !== undefined) cameraComponent.gammaCorrection = this.gammaCorrection;
             if (this.toneMapping !== undefined) cameraComponent.toneMapping = this.toneMapping;
 
@@ -308,9 +325,10 @@ class RenderPassForward extends RenderPass {
             // layer post render event
             scene.fire(EVENT_POSTRENDER_LAYER, cameraComponent, layer, transparent);
 
-            // restore gamma correction and tone mapping settings
+            // restore gamma correction, tone mapping and scene texture settings
             if (this.gammaCorrection !== undefined) cameraComponent.gammaCorrection = originalGammaCorrection;
             if (this.toneMapping !== undefined) cameraComponent.toneMapping = originalToneMapping;
+            if (this.sceneTextures !== undefined) cameraComponent.shaderParams.sceneTextures = originalSceneTextures;
         }
 
         DebugGraphics.popGpuMarker(this.device);

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -61,7 +61,7 @@ class RenderPassForward extends RenderPass {
     gammaCorrection;
 
     /**
-     * The tone mapping setting for the render pass. In not set, setting from the camera is used.
+     * The tone mapping setting for the render pass. If not set, setting from the camera is used.
      *
      * @type {number|undefined}
      */
@@ -69,7 +69,7 @@ class RenderPassForward extends RenderPass {
 
     /**
      * The names of the scene textures this pass renders alongside the scene color, in the order of
-     * the color attachments they are rendered to. In not set, setting from the camera is used. Only
+     * the color attachments they are rendered to. If not set, setting from the camera is used. Only
      * the passes rendering to a render target the scene textures are attached to set this, so that
      * the camera's other passes, for example the one rendering the UI to the output render target,
      * do not write them.
@@ -309,6 +309,12 @@ class RenderPassForward extends RenderPass {
                 options.clearColor = step.clearColor;
                 options.clearDepth = step.clearDepth;
                 options.clearStencil = step.clearStencil;
+
+                // unlike the clear of the render pass itself, this clear is not attachment aware - it
+                // clears all the color attachments of the render target, and so would also clear the
+                // scene textures, which this pass does not own the content of
+                Debug.assert(!(options.clearColor && this.sceneTextures?.length),
+                    'Clearing the color inside a render pass which renders the scene textures is not supported, as the clear would also clear those. This happens when the camera does not clear the whole render target, or when it is not the first one rendering to it.', this);
             }
 
             const renderTarget = step.renderTarget ?? device.backBuffer;

--- a/src/scene/shader-lib/glsl/chunks/common/frag/scene-textures.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/scene-textures.js
@@ -1,0 +1,31 @@
+// Scene texture support for custom shaders (for example ShaderMaterial). The scene textures are the
+// additional color attachments the scene pass renders alongside the scene color, holding per pixel
+// data such as the linear depth, which the post-processing effects then consume.
+//
+// Include this chunk and call the write function of each scene texture at the end of the fragment
+// shader, passing the fragment's own values:
+//     writeSceneTextureDepth(linearDepth, 1.0);
+//
+// The calls need no guarding - when the camera does not render a scene texture, its write function
+// does nothing. A material has to declare that its shader writes the scene textures by setting
+// Material#sceneTexturesWrite, and once it does, it has to write all of them.
+export default /* glsl */`
+
+#ifndef SCENE_TEXTURES
+#define SCENE_TEXTURES
+
+// Writes the fragment's contribution to the scene depth texture.
+//
+// The alpha parameter is the fragment's coverage: opaque geometry passes 1.0, while blended geometry
+// (gaussian splats) passes its own alpha. The depth is pre-multiplied by it, so that under the
+// premultiplied blending the splats already use, the attachment accumulates a transmittance weighted
+// average of the depth - it composites as depth * alpha + depth * (1 - alpha), converging on the
+// depth of the surface the splats form. Opaque geometry, passing an alpha of 1.0, simply overwrites.
+void writeSceneTextureDepth(float linearDepth, float alpha) {
+    #ifdef SCENE_TEXTURE_DEPTH
+        pcFragColor{SCENE_TEXTURE_DEPTH_SLOT} = vec4(linearDepth * alpha, 0.0, 0.0, alpha);
+    #endif
+}
+
+#endif // SCENE_TEXTURES
+`;

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardMain.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardMain.js
@@ -1,6 +1,8 @@
 // main shader entry point for the lit material for forward rendering
 export default /* glsl */`
 
+#include "sceneTexturesPS"
+
 void main(void) {
 
     #include "litUserMainStartPS"
@@ -45,6 +47,12 @@ void main(void) {
     #include "debugProcessFrontendPS"
 
     evaluateBackend();
+
+    // guarded by the same define the write function tests internally, as vLinearDepth is only
+    // generated when the depth is written
+    #ifdef SCENE_TEXTURE_DEPTH
+        writeSceneTextureDepth(vLinearDepth, 1.0);
+    #endif
 
     #include "litUserMainEndPS"
 }

--- a/src/scene/shader-lib/glsl/collections/shader-chunks-glsl.js
+++ b/src/scene/shader-lib/glsl/collections/shader-chunks-glsl.js
@@ -38,6 +38,7 @@ import envProcPS from '../chunks/common/frag/envProc.js';
 import falloffInvSquaredPS from '../chunks/lit/frag/falloffInvSquared.js';
 import falloffLinearPS from '../chunks/lit/frag/falloffLinear.js';
 import floatAsUintPS from '../chunks/common/frag/float-as-uint.js';
+import sceneTexturesPS from '../chunks/common/frag/scene-textures.js';
 import fogPS from '../chunks/common/frag/fog.js';
 import fresnelSchlickPS from '../chunks/lit/frag/fresnelSchlick.js';
 import fullscreenQuadVS from '../chunks/common/vert/fullscreenQuad.js';
@@ -202,6 +203,7 @@ const shaderChunksGLSL = {
     falloffInvSquaredPS,
     falloffLinearPS,
     floatAsUintPS,
+    sceneTexturesPS,
     fogPS,
     fresnelSchlickPS,
     frontendCodePS: '',  // empty chunk, supplied by the shader generator

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/scene-textures.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/scene-textures.js
@@ -1,0 +1,31 @@
+// Scene texture support for custom shaders (for example ShaderMaterial). The scene textures are the
+// additional color attachments the scene pass renders alongside the scene color, holding per pixel
+// data such as the linear depth, which the post-processing effects then consume.
+//
+// Include this chunk and call the write function of each scene texture at the end of the fragment
+// shader, passing a pointer to the fragment output alongside the fragment's own values:
+//     writeSceneTextureDepth(&output, linearDepth, 1.0);
+//
+// The calls need no guarding - when the camera does not render a scene texture, its write function
+// does nothing. A material has to declare that its shader writes the scene textures by setting
+// Material#sceneTexturesWrite, and once it does, it has to write all of them.
+export default /* wgsl */`
+
+#ifndef SCENE_TEXTURES
+#define SCENE_TEXTURES
+
+// Writes the fragment's contribution to the scene depth texture.
+//
+// The alpha parameter is the fragment's coverage: opaque geometry passes 1.0, while blended geometry
+// (gaussian splats) passes its own alpha. The depth is pre-multiplied by it, so that under the
+// premultiplied blending the splats already use, the attachment accumulates a transmittance weighted
+// average of the depth - it composites as depth * alpha + depth * (1 - alpha), converging on the
+// depth of the surface the splats form. Opaque geometry, passing an alpha of 1.0, simply overwrites.
+fn writeSceneTextureDepth(output: ptr<function, FragmentOutput>, linearDepth: f32, alpha: f32) {
+    #ifdef SCENE_TEXTURE_DEPTH
+        (*output).color{SCENE_TEXTURE_DEPTH_SLOT} = vec4f(linearDepth * alpha, 0.0, 0.0, alpha);
+    #endif
+}
+
+#endif // SCENE_TEXTURES
+`;

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardMain.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardMain.js
@@ -1,6 +1,8 @@
 // main shader entry point for the lit material for forward rendering
 export default /* wgsl */`
 
+#include "sceneTexturesPS"
+
 @fragment
 fn fragmentMain(input: FragmentInput) -> FragmentOutput {
 
@@ -46,6 +48,12 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
     #include "debugProcessFrontendPS"
 
     var output: FragmentOutput = evaluateBackend();
+
+    // guarded by the same define the write function tests internally, as vLinearDepth is only
+    // generated when the depth is written
+    #ifdef SCENE_TEXTURE_DEPTH
+        writeSceneTextureDepth(&output, vLinearDepth, 1.0);
+    #endif
 
     #include "litUserMainEndPS"
 

--- a/src/scene/shader-lib/wgsl/collections/shader-chunks-wgsl.js
+++ b/src/scene/shader-lib/wgsl/collections/shader-chunks-wgsl.js
@@ -38,6 +38,7 @@ import envProcPS from '../chunks/common/frag/envProc.js';
 import falloffInvSquaredPS from '../chunks/lit/frag/falloffInvSquared.js';
 import falloffLinearPS from '../chunks/lit/frag/falloffLinear.js';
 import floatAsUintPS from '../chunks/common/frag/float-as-uint.js';
+import sceneTexturesPS from '../chunks/common/frag/scene-textures.js';
 import fogPS from '../chunks/common/frag/fog.js';
 import fogMathPS from '../chunks/common/shared/fogMath.js';
 import fresnelSchlickPS from '../chunks/lit/frag/fresnelSchlick.js';
@@ -203,6 +204,7 @@ const shaderChunksWGSL = {
     falloffInvSquaredPS,
     falloffLinearPS,
     floatAsUintPS,
+    sceneTexturesPS,
     fogPS,
     fogMathPS,
     fresnelSchlickPS,

--- a/test/core/array-utils.test.mjs
+++ b/test/core/array-utils.test.mjs
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+
+import { array } from '../../src/core/array-utils.js';
+
+describe('array', function () {
+
+    describe('#equals', function () {
+
+        it('returns true for arrays with the same elements', function () {
+            expect(array.equals([1, 2, 3], [1, 2, 3])).to.be.true;
+            expect(array.equals(['a', 'b'], ['a', 'b'])).to.be.true;
+        });
+
+        it('returns true for two empty arrays', function () {
+            expect(array.equals([], [])).to.be.true;
+        });
+
+        it('returns true for the same array instance', function () {
+            const arr = [1, 2, 3];
+            expect(array.equals(arr, arr)).to.be.true;
+        });
+
+        it('returns false for arrays of different lengths', function () {
+            expect(array.equals([1, 2], [1, 2, 3])).to.be.false;
+            expect(array.equals([1, 2, 3], [1, 2])).to.be.false;
+            expect(array.equals([], [1])).to.be.false;
+        });
+
+        it('returns false when an element differs', function () {
+            expect(array.equals([1, 2, 3], [1, 4, 3])).to.be.false;
+            expect(array.equals(['a'], ['b'])).to.be.false;
+        });
+
+        it('compares the elements strictly', function () {
+            expect(array.equals([1], ['1'])).to.be.false;
+            expect(array.equals([0], [false])).to.be.false;
+            expect(array.equals([{}], [{}])).to.be.false;
+        });
+
+        it('compares a typed array with a plain array of the same values', function () {
+            expect(array.equals(new Float32Array([1, 2]), [1, 2])).to.be.true;
+            expect(array.equals(new Uint8Array([1, 2]), [1, 3])).to.be.false;
+        });
+    });
+});

--- a/test/platform/graphics/blend-state-utils.test.mjs
+++ b/test/platform/graphics/blend-state-utils.test.mjs
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+
+import { getSingleAttachmentBlendState } from '../../../src/platform/graphics/blend-state-utils.js';
+import { BlendState } from '../../../src/platform/graphics/blend-state.js';
+import { BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE_MINUS_SRC_ALPHA } from '../../../src/platform/graphics/constants.js';
+
+describe('getSingleAttachmentBlendState', function () {
+
+    const premultiplied = () => new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE_MINUS_SRC_ALPHA);
+
+    it('leaves the first attachment untouched', function () {
+        const src = premultiplied();
+        const masked = getSingleAttachmentBlendState(src, 2);
+
+        const target = new BlendState();
+        masked.getAttachment(0, target);
+        expect(target.blend).to.equal(src.blend);
+        expect(target.colorSrcFactor).to.equal(src.colorSrcFactor);
+        expect(target.colorDstFactor).to.equal(src.colorDstFactor);
+        expect(target.allWrite).to.equal(src.allWrite);
+    });
+
+    it('disables the writes of every other attachment', function () {
+        const masked = getSingleAttachmentBlendState(premultiplied(), 4);
+
+        const target = new BlendState();
+        for (let i = 1; i < 4; i++) {
+            masked.getAttachment(i, target);
+            expect(target.redWrite, `attachment ${i}`).to.be.false;
+            expect(target.greenWrite, `attachment ${i}`).to.be.false;
+            expect(target.blueWrite, `attachment ${i}`).to.be.false;
+            expect(target.alphaWrite, `attachment ${i}`).to.be.false;
+        }
+    });
+
+    it('does not modify the supplied state', function () {
+        const src = premultiplied();
+        const key = src.key;
+        getSingleAttachmentBlendState(src, 2);
+        expect(src.key).to.equal(key);
+        expect(src.hasAttachmentOverrides).to.be.false;
+    });
+
+    it('returns the same instance for the same state and attachment count', function () {
+        const first = getSingleAttachmentBlendState(premultiplied(), 2);
+        const second = getSingleAttachmentBlendState(premultiplied(), 2);
+        expect(first).to.equal(second);
+    });
+
+    it('caches per attachment count', function () {
+        const two = getSingleAttachmentBlendState(premultiplied(), 2);
+        const three = getSingleAttachmentBlendState(premultiplied(), 3);
+        expect(three).to.not.equal(two);
+
+        const target = new BlendState();
+        two.getAttachment(2, target);
+        expect(target.redWrite).to.be.true;      // outside the two attachments, so left inheriting
+        three.getAttachment(2, target);
+        expect(target.redWrite).to.be.false;
+    });
+
+    it('passes through a state which already carries per attachment overrides', function () {
+        const src = premultiplied();
+        const other = new BlendState();
+        src.setAttachment(1, other);
+        expect(getSingleAttachmentBlendState(src, 2)).to.equal(src);
+    });
+});

--- a/test/scene/camera-shader-params.test.mjs
+++ b/test/scene/camera-shader-params.test.mjs
@@ -57,15 +57,23 @@ describe('CameraShaderParams', function () {
             expect(params.hash).to.not.equal(depth);
         });
 
-        it('keeps the hash stable when reassigned the same names in a new array', function () {
+        it('does not invalidate anything when reassigned the same names in a new array', function () {
             const params = new CameraShaderParams();
             params.sceneTextures = ['depth'];
-            const hash = params.hash;
 
-            // the render passes assign this as they execute, so an equal value must not invalidate
-            // the shader variants of every material
+            // the render passes assign this around every layer step they render, so an equal value
+            // must not dirty the hash which the shader variants of every material are keyed on. Note
+            // that the hash itself cannot show this, as recomputing it yields the same number
+            let dirtied = 0;
+            params.markDirty = () => {
+                dirtied++;
+            };
+
             params.sceneTextures = ['depth'];
-            expect(params.hash).to.equal(hash);
+            expect(dirtied).to.equal(0);
+
+            params.sceneTextures = ['depth', 'velocity'];
+            expect(dirtied).to.equal(1);
         });
 
         it('reflects the names in the order they are supplied', function () {

--- a/test/scene/camera-shader-params.test.mjs
+++ b/test/scene/camera-shader-params.test.mjs
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+
+import { CameraShaderParams } from '../../src/scene/camera-shader-params.js';
+
+describe('CameraShaderParams', function () {
+
+    describe('#sceneTextures', function () {
+
+        it('defaults to an empty list which generates no defines', function () {
+            const params = new CameraShaderParams();
+            expect(params.sceneTextures).to.deep.equal([]);
+            expect(params.defines.has('SCENE_TEXTURE_DEPTH')).to.be.false;
+        });
+
+        it('generates an enable and a slot define per name, numbered from one', function () {
+            const params = new CameraShaderParams();
+            params.sceneTextures = ['depth', 'velocity'];
+
+            const defines = params.defines;
+            expect(defines.get('SCENE_TEXTURE_DEPTH')).to.equal('');
+            expect(defines.get('{SCENE_TEXTURE_DEPTH_SLOT}')).to.equal('1');
+            expect(defines.get('SCENE_TEXTURE_VELOCITY')).to.equal('');
+            expect(defines.get('{SCENE_TEXTURE_VELOCITY_SLOT}')).to.equal('2');
+        });
+
+        it('upper cases the names of the defines', function () {
+            const params = new CameraShaderParams();
+            params.sceneTextures = ['my_texture'];
+            expect(params.defines.has('SCENE_TEXTURE_MY_TEXTURE')).to.be.true;
+        });
+
+        it('treats undefined as an empty list', function () {
+            const params = new CameraShaderParams();
+            params.sceneTextures = ['depth'];
+            params.sceneTextures = undefined;
+            expect(params.sceneTextures).to.deep.equal([]);
+            expect(params.defines.has('SCENE_TEXTURE_DEPTH')).to.be.false;
+        });
+
+        it('does not alias the supplied array', function () {
+            const params = new CameraShaderParams();
+            const names = ['depth'];
+            params.sceneTextures = names;
+            names.push('velocity');
+            expect(params.sceneTextures).to.deep.equal(['depth']);
+        });
+
+        it('takes part in the hash', function () {
+            const params = new CameraShaderParams();
+            const empty = params.hash;
+
+            params.sceneTextures = ['depth'];
+            const depth = params.hash;
+            expect(depth).to.not.equal(empty);
+
+            params.sceneTextures = ['depth', 'velocity'];
+            expect(params.hash).to.not.equal(depth);
+        });
+
+        it('keeps the hash stable when reassigned the same names in a new array', function () {
+            const params = new CameraShaderParams();
+            params.sceneTextures = ['depth'];
+            const hash = params.hash;
+
+            // the render passes assign this as they execute, so an equal value must not invalidate
+            // the shader variants of every material
+            params.sceneTextures = ['depth'];
+            expect(params.hash).to.equal(hash);
+        });
+
+        it('reflects the names in the order they are supplied', function () {
+            const params = new CameraShaderParams();
+            params.sceneTextures = ['velocity', 'depth'];
+            expect(params.defines.get('{SCENE_TEXTURE_VELOCITY_SLOT}')).to.equal('1');
+            expect(params.defines.get('{SCENE_TEXTURE_DEPTH_SLOT}')).to.equal('2');
+        });
+    });
+});


### PR DESCRIPTION
The scene textures are additional color attachments the scene pass renders alongside the scene color, holding per pixel data - the linear depth to begin with - which the post-processing effects then consume. Their advantage over a depth prepass is that they cost no extra geometry pass, and that blended geometry contributes to them, so gaussian splats can supply a depth the prepass cannot produce at all.

This adds the layer that lets a material write them, and masks off the materials whose shader does not. **Nothing enables it**: the list of scene textures a camera renders stays empty until a follow up sets up the render target they are attached to, so every generated shader and every render target is unchanged by this on its own.

**Changes:**
- `CameraShaderParams.sceneTextures` holds the ordered names of the scene textures the pass renders, the name at index i going to the color attachment at index i + 1. Each name generates a pair of defines following the same naming as the shader passes - `'depth'` gives `SCENE_TEXTURE_DEPTH`, enabling the write, and `{SCENE_TEXTURE_DEPTH_SLOT}`, which the preprocessor substitutes into the name of the output written. The value is compared by value on assignment, as the render pass assigns it around every layer step it renders and an equal value must not invalidate the shader variants of every material.
- A new `sceneTexturesPS` chunk supplies a write function per scene texture, so the attachment index never appears in the calling code. Custom shaders can use it the way they already use `shadowCasterPS`, by including the chunk and calling the function. On WebGPU the function takes a pointer to the fragment output, as the outputs there are members of the returned struct.
- `Material.sceneTexturesWrite` declares whether a material's shader generates the scene textures, defaulting by material type - true for the opaque `StandardMaterial` and `LitMaterial`, false for `ShaderMaterial` and the particle materials. The additional attachments of a material which does not generate them are masked off using a new `getSingleAttachmentBlendState`, as an attachment the fragment shader leaves unwritten makes the draw invalid on both backends.
- `RenderPassForward.sceneTextures` scopes all of this to the passes rendering to a render target the scene textures are attached to, so that a camera's other passes, for example the one rendering the UI to the output render target, do not write them. The same pass also narrows the camera's clear color to attachment 0, leaving the clear values of the scene textures to whoever owns them.
- The preprocessor injects the defines before the passes which inspect the source, rather than after. This is required: `stripUnusedColorAttachments` matches `pcFragColorN` with a literal index, and would otherwise strip the declaration of an output written through a substituted slot. It is safe for the two passes it now precedes - `processArraySize` rewrites `[KEY]` for unbraced int defines while the injection substitutes braced `{KEY}` keys, which are disjoint patterns, and the injection skips lines containing a preprocessor directive, a set neither of the reordered passes alters.
- `linearDepth` is now derived in one expression per material type, instead of being assigned separately by the minimal and the full variant of the standard material options.
- Unit tests for the new pieces, and for `array.equals`, which had none.

**API Changes:**
- `RenderTarget#colorBufferCount` - new, the number of color attachments the render target was set up with. The rest of the above is internal (`@ignore`).

Verified on both backends that the dormant path renders identically. The write path itself was exercised by temporarily forcing a scene texture on, confirming on WebGL2 that the slot is substituted and the output declaration survives the color attachment stripping, and on WebGPU that the write through the pointer compiles and that the generated fragment output struct picks up the additional attachment.