### PR TITLE
Add missing `joint` component accessor declaration to Entity

### DIFF
--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -14,6 +14,7 @@ import { getApplication } from './globals.js';
  * @import { Component } from './components/component.js'
  * @import { ElementComponent } from './components/element/component.js'
  * @import { GSplatComponent } from './components/gsplat/component.js'
+ * @import { JointComponent } from './components/joint/component.js'
  * @import { LayoutChildComponent } from './components/layout-child/component.js'
  * @import { LayoutGroupComponent } from './components/layout-group/component.js'
  * @import { LightComponent } from './components/light/component.js'
@@ -177,6 +178,15 @@ class Entity extends GraphNode {
      * @readonly
      */
     gsplat;
+
+    /**
+     * Gets the {@link JointComponent} attached to this entity.
+     *
+     * @type {JointComponent|undefined}
+     * @readonly
+     * @alpha
+     */
+    joint;
 
     /**
      * Gets the {@link LayoutChildComponent} attached to this entity.


### PR DESCRIPTION
## Description
`Entity` declares a documented, typed accessor field for every component type, but `joint` was never added when `JointComponent` was promoted to the public API (#8891, first released in v2.20.0). Only the `ComponentSystemRegistry.joint` half of the promotion landed, so `entity.joint` was a TypeScript error for API users (and undiscoverable in the API reference) despite working at runtime — the engine itself dereferences it in the clone-resolution path.

This adds the `joint` field declaration between `gsplat` and `layoutchild`, plus the type-only `@import` for `JointComponent` in the file header. The `@alpha` tag matches the existing `ComponentSystemRegistry.joint` declaration.

Verified: `npm run build:types` now emits `readonly joint: JointComponent | undefined;` on `Entity`, and `npm run test:types` passes.

Fixes #9168

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)