### PR TITLE
Fix StorageBuffer.write JSDoc marking optional params as required

### DIFF
--- a/src/platform/graphics/storage-buffer.js
+++ b/src/platform/graphics/storage-buffer.js
@@ -111,10 +111,10 @@ class StorageBuffer {
      *
      * @param {number} bufferOffset - The offset in bytes to start writing to the storage buffer.
      * @param {ArrayBufferView|ArrayBuffer} data - The data to write to the storage buffer.
-     * @param {number} dataOffset - Offset in data to begin writing from. Given in elements if data
-     * is a TypedArray and bytes otherwise.
-     * @param {number} size - Size of content to write from data to buffer. Given in elements if
-     * data is a TypedArray and bytes otherwise.
+     * @param {number} [dataOffset] - Offset in data to begin writing from. Given in elements if
+     * data is a TypedArray and bytes otherwise. Defaults to 0.
+     * @param {number} [size] - Size of content to write from data to buffer. Given in elements if
+     * data is a TypedArray and bytes otherwise. Defaults to the remaining size of the data.
      */
     write(bufferOffset = 0, data, dataOffset = 0, size) {
         this.impl.write(this.device, bufferOffset, data, dataOffset, size);


### PR DESCRIPTION
### Summary

Fixes #9172.

`StorageBuffer.write(bufferOffset, data, dataOffset, size)` documented `dataOffset` and `size` as required, so a valid two-argument call such as:

```js
const paramsData = new Float32Array(16);
const paramsBuffer = new StorageBuffer(device, 64, BUFFERUSAGE_COPY_DST);
paramsBuffer.write(0, paramsData);
```

produced a type error (missing arguments) in editors using the generated types.

Both parameters are optional at runtime — `dataOffset` defaults to `0`, and `size` is forwarded to WebGPU's `queue.writeBuffer`, which treats it as optional (defaulting to the remaining size of the data). This change marks them as optional in the JSDoc to match the actual behavior.

### Change

- `dataOffset` → `[dataOffset]` (defaults to 0)
- `size` → `[size]` (defaults to the remaining size of the data)

Documentation-only change; no runtime behavior is affected.