### PR TITLE
Render the scene depth from the scene pass, replacing the depth prepass where possible

### DIFF
--- a/examples/src/examples/graphics/depth-of-field.example.mjs
+++ b/examples/src/examples/graphics/depth-of-field.example.mjs
@@ -168,7 +168,6 @@ app.root.addChild(cameraEntity);
 
 const cameraFrame = new CameraFrame(app, cameraEntity.camera);
 cameraFrame.rendering.toneMapping = TONEMAP_ACES;
-cameraFrame.rendering.samples = 4;
 cameraFrame.bloom.intensity = 0.03;
 cameraFrame.bloom.blurLevel = 7;
 cameraFrame.vignette.inner = 0.5;
@@ -183,7 +182,8 @@ const applySettings = () => {
     const taa = data.get('data.taa.enabled');
     cameraFrame.taa.enabled = taa;
     cameraFrame.taa.jitter = data.get('data.taa.jitter');
-    cameraFrame.rendering.sharpness = taa ? 1 : 0;
+    cameraFrame.rendering.samples = taa ? 1 : 4; // disable MSAA when TAA is enabled
+    cameraFrame.rendering.sharpness = taa ? 1 : 0; // sharpen the image when TAA is enabled
 
     // DOF
     cameraFrame.dof.enabled = data.get('data.dof.enabled');

--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -9,6 +9,7 @@ import { CameraFrameOptions, FramePassCameraFrame } from './frame-pass-camera-fr
 /**
  * @import { AppBase } from '../../framework/app-base.js'
  * @import { CameraComponent } from '../../framework/components/camera/component.js'
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { LightComponent } from '../../framework/components/light/component.js'
  * @import { Texture } from '../../platform/graphics/texture.js'
  */
@@ -598,6 +599,26 @@ class CameraFrame {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Returns whether a device is able to let the gaussian splats contribute to the scene depth, which
+     * the volumetric fog and the depth of field need in order to be bounded by the splats instead of
+     * drawing through them. Their contribution additionally has to be turned on using
+     * {@link GSplatParams#sceneDepthWrite}; this reports whether doing so can take effect, so that an
+     * application rendering gaussian splats can disable those effects on the devices which cannot
+     * respect them.
+     *
+     * This tests the device alone, and so can be called before any camera frame is created. Whether a
+     * particular one then renders the depth this way also depends on its own settings - multi-sampling
+     * and a camera not clearing the whole of its render target both rule it out - and a debug build
+     * warns, naming the reason, when the splats end up not contributing.
+     *
+     * @param {GraphicsDevice} device - The graphics device.
+     * @returns {boolean} True if the splats can contribute to the scene depth.
+     */
+    static isSplatSceneDepthSupported(device) {
+        return FramePassCameraFrame.isSceneTextureDepthSupported(device);
     }
 
     /**

--- a/src/extras/render-passes/frame-pass-camera-frame.js
+++ b/src/extras/render-passes/frame-pass-camera-frame.js
@@ -1,5 +1,5 @@
-import { LAYERID_SKYBOX, LAYERID_IMMEDIATE, TONEMAP_NONE, GAMMA_NONE } from '../../scene/constants.js';
-import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, PIXELFORMAT_RGBA8 } from '../../platform/graphics/constants.js';
+import { LAYERID_SKYBOX, LAYERID_IMMEDIATE, TONEMAP_NONE, GAMMA_NONE, SCENETEXTURE_DEPTH, sceneTextureUniformNames } from '../../scene/constants.js';
+import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, PIXELFORMAT_R16F, PIXELFORMAT_R32F, PIXELFORMAT_RGBA8 } from '../../platform/graphics/constants.js';
 import { Texture } from '../../platform/graphics/texture.js';
 import { FramePass } from '../../platform/graphics/frame-pass.js';
 import { FramePassColorGrab } from '../../scene/graphics/frame-pass-color-grab.js';
@@ -20,6 +20,7 @@ import { Color } from '../../core/math/color.js';
 
 /**
  * @import { CameraFrame } from './camera-frame.js'
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  */
 
 /**
@@ -60,6 +61,11 @@ class CameraFrameOptions {
 
     prepassEnabled = false;
 
+    // Whether the scene depth is rendered by the scene pass into an additional attachment of the
+    // scene render target, instead of, or in addition to, by the depth prepass. This is not a user
+    // setting - sanitizeOptions derives it from what needs the depth and what the device supports.
+    sceneTextureDepth = false;
+
     // DOF
     dofEnabled = false;
 
@@ -72,6 +78,9 @@ class CameraFrameOptions {
 }
 
 const _defaultOptions = new CameraFrameOptions();
+
+// the formats the scene depth can be rendered to, in the order of preference
+const _sceneDepthFormats = [PIXELFORMAT_R32F, PIXELFORMAT_R16F];
 
 /**
  * Render pass implementation of a common camera frame rendering with integrated post-processing
@@ -123,6 +132,53 @@ class FramePassCameraFrame extends FramePass {
      */
     rt = null;
 
+    /**
+     * The names of the scene textures the scene pass renders alongside the scene color, in the order
+     * of the color attachments they are rendered to. The scene passes are given this array itself, so
+     * that assigning it to the camera as they render does not allocate.
+     *
+     * @type {string[]}
+     * @private
+     */
+    _sceneTextureNames = [];
+
+    /**
+     * The scene depth rendered by the scene pass as a scene texture, or null when the depth is not
+     * rendered this way. Owned by the scene render target it is attached to.
+     *
+     * @type {Texture|null}
+     * @private
+     */
+    sceneDepthTexture = null;
+
+    /**
+     * The color attachment index the scene depth is rendered to, or 0 when it is not rendered.
+     *
+     * @type {number}
+     * @private
+     */
+    sceneDepthSlot = 0;
+
+    /**
+     * A render target holding the scene color alone, aliasing the color attachment of the scene
+     * render target. The passes blending into the scene after it has been rendered use this instead of
+     * the scene render target, as they sample the scene textures, and a texture attached to the render
+     * target being rendered into cannot be sampled. Null when there are no scene textures.
+     *
+     * @type {RenderTarget|null}
+     * @private
+     */
+    rtSceneColor = null;
+
+    /**
+     * The clear value of the scene depth texture, set up each frame as it depends on the camera's far
+     * clip. The alpha is 1, so that what the gaussian splats blend into it stays a weighted average.
+     *
+     * @type {Color}
+     * @private
+     */
+    _sceneDepthClearValue = new Color(0, 0, 0, 1);
+
     constructor(app, cameraFrame, cameraComponent, options = {}) {
         Debug.assert(app);
         super(app.graphicsDevice);
@@ -142,6 +198,25 @@ class FramePassCameraFrame extends FramePass {
 
         this.sceneTexture = null;
         this.sceneTextureHalf = null;
+
+        if (this.sceneDepthTexture) {
+
+            // the texture itself is owned by the scene render target, destroyed below
+            this.sceneDepthTexture = null;
+            this.sceneDepthSlot = 0;
+            this._sceneTextureNames.length = 0;
+
+            const { shaderParams } = this.cameraComponent;
+            shaderParams.sceneDepthMapLinear = false;
+            shaderParams.sceneDepthMapPacked = false;
+        }
+
+        if (this.rtSceneColor) {
+
+            // only aliases the scene color texture, which the scene render target owns
+            this.rtSceneColor.destroy();
+            this.rtSceneColor = null;
+        }
 
         if (this.rt) {
             this.rt.destroyTextureBuffers();
@@ -176,12 +251,177 @@ class FramePassCameraFrame extends FramePass {
     sanitizeOptions(options) {
         options = Object.assign({}, _defaultOptions, options);
 
-        // automatically enable prepass when required internally
-        if (options.taaEnabled || options.ssaoType !== SSAOTYPE_NONE || options.dofEnabled || options.volumetricFogEnabled) {
-            options.prepassEnabled = true;
-        }
+        // depth consumed by the passes running after the scene pass. SSAO belongs here when the compose
+        // pass is what applies it, as it is then free to run after the scene - see collectPasses.
+        const postProcessDepth = options.taaEnabled || options.dofEnabled ||
+            options.volumetricFogEnabled || options.ssaoType === SSAOTYPE_COMBINE;
+
+        const inSceneDepth = this.needsInSceneDepth(options);
+        const splatDepth = this.app.scene.gsplat.sceneDepthWrite;
+        const deviceSupported = FramePassCameraFrame.isSceneTextureDepthSupported(this.device);
+        const unsupportedReason = this.sceneTexturesUnsupportedReason(options);
+
+        // The scene textures only exist once the scene pass has finished, so they can serve the
+        // post-processing passes alone. When nothing needs the depth earlier they replace the prepass
+        // outright, which is both cheaper - no additional geometry pass - and better, as the gaussian
+        // splats contribute to them.
+        //
+        // Two configurations make them worth their bandwidth only if the splats do contribute, which is
+        // what the scene setting asks for: when the prepass is rendered anyway, and when the depth would
+        // be stored at half float precision - the prepass stores it more precisely, either as R32F or
+        // losslessly packed, and the effects consuming it are sensitive to that.
+        const requiresSplatDepth = inSceneDepth || this.sceneDepthFormat !== PIXELFORMAT_R32F;
+
+        options.sceneTextureDepth = postProcessDepth && deviceSupported && !unsupportedReason &&
+            (!requiresSplatDepth || splatDepth);
+
+        options.prepassEnabled = inSceneDepth || (postProcessDepth && !options.sceneTextureDepth);
+
+        Debug.call(() => {
+
+            // the splats contribute only when the scene depth is rendered by the scene pass and they are
+            // set to write it. Note that the first alone is not enough - the scene textures can be
+            // rendered while the splats stay out of them.
+            const splatsContribute = options.sceneTextureDepth && splatDepth;
+            if (postProcessDepth && !splatsContribute && this.rendersGSplats()) {
+                const reason = !deviceSupported ?
+                    'this device cannot render the scene depth the splats contribute to - see CameraFrame.isSplatSceneDepthSupported' :
+                    unsupportedReason ??
+                    'Scene#gsplat.sceneDepthWrite is not set - setting it includes them, at the cost of an additional render target attachment';
+                Debug.warnOnce(`CameraFrame: the gaussian splats this camera renders do not contribute to the scene depth, and so the effects using it (the volumetric fog and the depth of field) are not bound by them: ${reason}.`);
+            }
+        });
 
         return options;
+    }
+
+    /**
+     * Whether the gaussian splat director has any splats for this camera. Reports this in a debug build
+     * only, and returns false otherwise, as the only use of it is to advise on the scene setting - the
+     * shape of the pipeline is a function of the settings alone, and never of the contents of the scene,
+     * so that it does not change as the splats are loaded or culled.
+     *
+     * @returns {boolean} True if the camera renders gaussian splats.
+     * @private
+     */
+    rendersGSplats() {
+        let renders = false;
+        Debug.call(() => {
+            const director = this.app.renderer.gsplatDirector;
+            const cameraData = director?.camerasMap.get(this.cameraComponent.camera);
+            renders = (cameraData?.layersMap.size ?? 0) > 0;
+        });
+        return renders;
+    }
+
+    /**
+     * Whether the depth is consumed no later than the scene pass - by the materials when the user asks
+     * for the scene depth map, and by SSAO applied during shading, whose texture the lit shaders sample
+     * and which therefore has to be generated before the scene renders. Only the prepass supplies that,
+     * as the scene textures do not exist until the scene pass has finished.
+     *
+     * @param {CameraFrameOptions} options - The options.
+     * @returns {boolean} True if the depth is needed no later than the scene pass.
+     * @private
+     */
+    needsInSceneDepth(options) {
+        return options.prepassEnabled || options.ssaoType === SSAOTYPE_LIGHTING;
+    }
+
+    /**
+     * Why this camera cannot render the scene textures, on top of what
+     * {@link FramePassCameraFrame.isSceneTextureDepthSupported} already rules out, or null when it can.
+     * Note that this is not reported on its own - the scene textures are not something the user asks
+     * for, so a camera which cannot use them simply renders the depth with the prepass instead. The
+     * reason is only used to explain why the gaussian splats do not contribute to the scene depth,
+     * which is visible in the result.
+     *
+     * @param {CameraFrameOptions} options - The options.
+     * @returns {string|null} The reason, or null when this camera can render the scene textures.
+     * @private
+     */
+    sceneTexturesUnsupportedReason(options) {
+
+        // the depth is blended into by the gaussian splats, and resolving it from a multi-sampled
+        // attachment would average the depths across a silhouette, giving a depth which unprojects to
+        // empty space
+        if (options.samples > 1) {
+            return 'multi-sampling is enabled on the CameraFrame, which the scene depth cannot be rendered with';
+        }
+
+        // a camera which does not clear the whole render target, or which is not the first one
+        // rendering to it, clears from inside the render pass, and that clear is not attachment aware
+        // - it would also clear the scene textures
+        if (!this.cameraComponent.camera.fullSizeClearRect) {
+            return 'this camera does not clear the whole render target, and the clear it uses instead would also clear the scene depth';
+        }
+
+        // The depth prepass, which this camera needs as well, publishes its depth to the same uniform
+        // as the scene textures do, and so the two have to store it the same way - the shaders sampling
+        // it are generated once, from a single declaration of the encoding. Where a float texture cannot
+        // be rendered to, the prepass falls back to packing the depth into RGBA8, which the scene
+        // textures cannot do, as packed values cannot be blended into.
+        //
+        // This restriction could be lifted by giving the passes which consume the depth after the scene
+        // pass a uniform of their own, separate from the one the prepass publishes to. Each would then
+        // declare its own encoding and the two producers could coexist - and as the scene texture depth
+        // is always linear and unpacked, a single define would describe it. That would also remove the
+        // need to publish the scene textures from the last scene pass only, and to clear the uniform
+        // when no prepass runs, as the materials would no longer be able to sample them at all. Note
+        // that the choice of which uniform to sample would have to be made per consuming pass rather
+        // than per camera, as SSAO applied during shading runs before the scene pass and so has to keep
+        // reading the depth of the prepass.
+        if (this.needsInSceneDepth(options) && !this.device.textureFloatRenderable) {
+            return 'the depth prepass this camera also needs stores the depth packed into RGBA8 on this device, which the scene depth cannot be stored as';
+        }
+
+        return null;
+    }
+
+    /**
+     * The format of the scene depth texture, or undefined when the device supports no floating point
+     * format which can be both rendered and blended into.
+     *
+     * @type {number|undefined}
+     * @private
+     */
+    get sceneDepthFormat() {
+        return FramePassCameraFrame.getSceneDepthFormat(this.device);
+    }
+
+    /**
+     * The format the scene depth is rendered to on the given device, or undefined when it supports no
+     * suitable one. Static, so that the support for it can be tested before a camera frame exists.
+     *
+     * @param {GraphicsDevice} device - The graphics device.
+     * @returns {number|undefined} The format, or undefined when there is none.
+     * @ignore
+     */
+    static getSceneDepthFormat(device) {
+
+        // full precision is preferred, as the depth is stored in linear view space units and half float
+        // steps by a whole unit at a far clip of a thousand. Blending is required, as that is how the
+        // gaussian splats accumulate their weighted average, and filtering is not - the depth is point
+        // sampled.
+        return device.getRenderableHdrFormat(_sceneDepthFormats, false, 1, true);
+    }
+
+    /**
+     * Whether the given device can render the scene textures at all. A particular camera can still be
+     * set up in a way which prevents it - see
+     * {@link FramePassCameraFrame#sceneTexturesUnsupportedReason}.
+     *
+     * @param {GraphicsDevice} device - The graphics device.
+     * @returns {boolean} True if the device can render the scene textures.
+     * @ignore
+     */
+    static isSceneTextureDepthSupported(device) {
+
+        // the materials which do not write the scene textures need the writes to their attachments
+        // masked off individually, which is not expressible without independent blending - their draws
+        // would be invalid
+        return device.supportsIndependentBlending &&
+            FramePassCameraFrame.getSceneDepthFormat(device) !== undefined;
     }
 
     set renderTargetScale(value) {
@@ -212,6 +452,7 @@ class FramePassCameraFrame extends FramePass {
             options.stencil !== currentOptions.stencil ||
             options.bloomEnabled !== currentOptions.bloomEnabled ||
             options.prepassEnabled !== currentOptions.prepassEnabled ||
+            options.sceneTextureDepth !== currentOptions.sceneTextureDepth ||
             options.sceneColorMap !== currentOptions.sceneColorMap ||
             options.dofEnabled !== currentOptions.dofEnabled ||
             options.dofNearBlur !== currentOptions.dofNearBlur ||
@@ -240,7 +481,7 @@ class FramePassCameraFrame extends FramePass {
         }
     }
 
-    createRenderTarget(name, depth, stencil, samples) {
+    createRenderTarget(name, depth, stencil, samples, sceneTextures) {
 
         const texture = new Texture(this.device, {
             name: name,
@@ -255,7 +496,7 @@ class FramePassCameraFrame extends FramePass {
         });
 
         return new RenderTarget({
-            colorBuffer: texture,
+            colorBuffers: sceneTextures?.length ? [texture, ...sceneTextures] : [texture],
             depth: depth,
             stencil: stencil,
             samples: samples
@@ -279,11 +520,44 @@ class FramePassCameraFrame extends FramePass {
         // set up internal rendering parameters - this affect the shader generation to apply SSAO during forward pass
         cameraComponent.shaderParams.ssaoEnabled = options.ssaoType === SSAOTYPE_LIGHTING;
 
+        // The scene textures are rendered by the scene pass into the color attachments after the scene
+        // color, each enabled one taking the next. This is the only place their layout is decided -
+        // the names are handed to the scene passes, which give them to the shaders, and the slot each
+        // one lands on follows from the order.
+        const sceneTextures = [];
+        const names = this._sceneTextureNames;
+        names.length = 0;
+        if (options.sceneTextureDepth) {
+            this.sceneDepthTexture = Texture.createDataTexture2D(device, 'SceneTextureDepth', 4, 4, this.sceneDepthFormat);
+            sceneTextures.push(this.sceneDepthTexture);
+            names.push(SCENETEXTURE_DEPTH);
+            this.sceneDepthSlot = sceneTextures.length;
+        }
+
         // create a render target to render the scene into. This uses the API-native orientation
         // regardless of the orientation of the target render target - the compose pass flips its
         // sampling when needed to store the requested orientation in the target render target.
-        this.rt = this.createRenderTarget('SceneColor', true, options.stencil, options.samples);
+        this.rt = this.createRenderTarget('SceneColor', true, options.stencil, options.samples, sceneTextures);
         this.sceneTexture = this.rt.colorBuffer;
+
+        if (this.sceneDepthTexture) {
+
+            // declare how the depth is stored, for the shaders which sample it. Note that the prepass
+            // declares the same when both are rendered, as the scene textures are only used on a
+            // device which can render the depth to a float texture.
+            const { shaderParams } = cameraComponent;
+            shaderParams.sceneDepthMapLinear = true;
+            shaderParams.sceneDepthMapPacked = false;
+
+            // the passes blending into the scene color after the scene pass sample the scene depth, so
+            // they cannot render to the render target it is attached to
+            this.rtSceneColor = new RenderTarget({
+                name: 'SceneColorOnly',
+                colorBuffers: [this.sceneTexture],
+                depth: false,
+                samples: 1
+            });
+        }
 
         // when half size scene color buffer is used
         if (this._sceneHalfEnabled) {
@@ -344,8 +618,20 @@ class FramePassCameraFrame extends FramePass {
 
     collectPasses() {
 
+        // SSAO applied during shading has to be generated before the scene pass, as the lit shaders
+        // sample its texture as they render. Applied by the compose pass instead, it is free to run
+        // after the scene, where the depth it needs can come from the scene textures - which include
+        // the gaussian splats and require no prepass.
+        const ssaoBeforeScene = this.options.ssaoType === SSAOTYPE_LIGHTING;
+
         // use these prepared render passes in the order they should be executed
-        return [this.prePass, this.ssaoPass, this.scenePass, this.colorGrabPass, this.scenePassTransparent, this.volumetricFogPass, this.taaPass, this.scenePassHalf, this.bloomPass, this.dofPass, this.composePass, this.afterPass];
+        return [
+            this.prePass,
+            ssaoBeforeScene ? this.ssaoPass : null,
+            this.scenePass, this.colorGrabPass, this.scenePassTransparent,
+            ssaoBeforeScene ? null : this.ssaoPass,
+            this.volumetricFogPass, this.taaPass, this.scenePassHalf, this.bloomPass, this.dofPass, this.composePass, this.afterPass
+        ];
     }
 
     createPasses(options) {
@@ -393,6 +679,11 @@ class FramePassCameraFrame extends FramePass {
         // forward passes render in HDR
         pass.gammaCorrection = GAMMA_NONE;
         pass.toneMapping = TONEMAP_NONE;
+
+        // only the passes rendering to the scene render target write the scene textures, so that the
+        // camera's other passes, for example the one rendering the UI to the output render target, do
+        // not output them
+        pass.sceneTextures = this._sceneTextureNames;
     }
 
     /**
@@ -490,6 +781,13 @@ class FramePassCameraFrame extends FramePass {
             }
         }
 
+        // The scene textures become available once the last pass rendering to the scene render target
+        // has finished, and only that pass publishes them. Publishing them from an earlier one would
+        // expose an attachment of the render target the remaining passes still render into, which the
+        // materials they render could then sample - reading a texture attached to the render target
+        // being rendered into is not allowed.
+        (this.scenePassTransparent ?? this.scenePass).publishSceneTextures = true;
+
         return ret;
     }
 
@@ -535,9 +833,11 @@ class FramePassCameraFrame extends FramePass {
     setupVolumetricFogPass(options) {
         if (options.volumetricFogEnabled) {
 
-            // the scene pass provides the light clusters used by the local lights of the fog
+            // the scene pass provides the light clusters used by the local lights of the fog. The fog
+            // samples the scene depth, and so blends into the alias of the scene color rather than the
+            // scene render target, which the depth is attached to.
             this.volumetricFogPass = new FramePassVolumetricFog(this.device, this.cameraComponent,
-                this.sceneTexture, this.rt, this.scenePass);
+                this.sceneTexture, this.rtSceneColor ?? this.rt, this.scenePass);
 
             // when TAA is used, the fog noise pattern changes each frame and TAA resolves it
             this.volumetricFogPass.temporalDither = options.taaEnabled;
@@ -597,6 +897,32 @@ class FramePassCameraFrame extends FramePass {
         }
 
         super.frameUpdate();
+
+        if (this.sceneDepthTexture) {
+
+            // the alias of the scene color is not resized by a pass of its own, as it shares its
+            // texture with the scene render target, which the scene pass resizes
+            this.rtSceneColor.resize(this.rt.width, this.rt.height);
+
+            // pixels no geometry covers read as the far clip. Only the first pass rendering to the
+            // scene render target clears it - the one rendering the transparent layers after the grab
+            // pass blends into what the first one accumulated.
+            const clearValue = this._sceneDepthClearValue;
+            clearValue.r = this.cameraComponent.camera.farClip - Number.MIN_VALUE;
+            this.scenePass.setClearColor(clearValue, this.sceneDepthSlot);
+
+            // Without a prepass nothing produces the scene depth before the scene pass, and what the
+            // last scene pass published in the previous frame is an attachment of the render target the
+            // scene passes render into. Clear those uniforms, so that a material sampling the scene
+            // depth without the user having asked for it reports that the depth is not available -
+            // which is the case - instead of silently reading a texture that is currently attached.
+            if (!this.options.prepassEnabled) {
+                const { scope } = this.device;
+                this._sceneTextureNames.forEach((name) => {
+                    scope.resolve(sceneTextureUniformNames[name]).setValue(null);
+                });
+            }
+        }
 
         // scene texture is either output of taa pass or the scene render target
         const sceneTexture = this.taaPass?.update() ?? this.rt.colorBuffer;

--- a/src/extras/render-passes/frame-pass-camera-frame.js
+++ b/src/extras/render-passes/frame-pass-camera-frame.js
@@ -1,4 +1,4 @@
-import { LAYERID_SKYBOX, LAYERID_IMMEDIATE, TONEMAP_NONE, GAMMA_NONE, SCENETEXTURE_DEPTH, sceneTextureUniformNames } from '../../scene/constants.js';
+import { LAYERID_SKYBOX, LAYERID_IMMEDIATE, TONEMAP_NONE, GAMMA_NONE, SCENETEXTURE_DEPTH } from '../../scene/constants.js';
 import { ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR, PIXELFORMAT_R16F, PIXELFORMAT_R32F, PIXELFORMAT_RGBA8 } from '../../platform/graphics/constants.js';
 import { Texture } from '../../platform/graphics/texture.js';
 import { FramePass } from '../../platform/graphics/frame-pass.js';
@@ -81,6 +81,14 @@ const _defaultOptions = new CameraFrameOptions();
 
 // the formats the scene depth can be rendered to, in the order of preference
 const _sceneDepthFormats = [PIXELFORMAT_R32F, PIXELFORMAT_R16F];
+
+// the largest value a half float can store, and so the furthest the scene depth can reach when it falls
+// back to that format
+const _maxHalfFloat = 65504;
+
+// how far inside the far clip the scene depth is cleared to, as a fraction of it. Large enough to survive
+// being stored as a half float, which steps by around a thousandth of the value it holds.
+const _sceneDepthClearEpsilon = 1e-3;
 
 /**
  * Render pass implementation of a common camera frame rendering with integrated post-processing
@@ -354,6 +362,13 @@ class FramePassCameraFrame extends FramePass {
         // - it would also clear the scene textures
         if (!this.cameraComponent.camera.fullSizeClearRect) {
             return 'this camera does not clear the whole render target, and the clear it uses instead would also clear the scene depth';
+        }
+
+        // the depth is stored in linear view space units, so the far clip has to fit in the format. Half
+        // float stops being able to represent it at all beyond 65504, and steps by tens of units well
+        // before that, so the effects consuming it need the far clip considerably lower still.
+        if (this.sceneDepthFormat === PIXELFORMAT_R16F && this.cameraComponent.camera.farClip > _maxHalfFloat) {
+            return `the far clip of this camera is too far for a half float scene depth - keep it below ${_maxHalfFloat}, and well below that for the depth to stay precise enough`;
         }
 
         // The depth prepass, which this camera needs as well, publishes its depth to the same uniform
@@ -788,6 +803,12 @@ class FramePassCameraFrame extends FramePass {
         // being rendered into is not allowed.
         (this.scenePassTransparent ?? this.scenePass).publishSceneTextures = true;
 
+        // Without a prepass nothing has published the scene depth by the time the scene renders, so the
+        // first pass clears the uniform it is published to. This has to happen as the pass renders rather
+        // than when the frame is set up, as every camera's frameUpdate runs before any of them renders,
+        // and so another camera could publish its own depth in between.
+        this.scenePass.clearSceneTextures = options.sceneTextureDepth && !options.prepassEnabled;
+
         return ret;
     }
 
@@ -904,24 +925,13 @@ class FramePassCameraFrame extends FramePass {
             // texture with the scene render target, which the scene pass resizes
             this.rtSceneColor.resize(this.rt.width, this.rt.height);
 
-            // pixels no geometry covers read as the far clip. Only the first pass rendering to the
+            // pixels no geometry covers read as the far clip, nudged just inside it so that a consumer
+            // testing for the far plane is not caught by rounding. Only the first pass rendering to the
             // scene render target clears it - the one rendering the transparent layers after the grab
             // pass blends into what the first one accumulated.
             const clearValue = this._sceneDepthClearValue;
-            clearValue.r = this.cameraComponent.camera.farClip - Number.MIN_VALUE;
+            clearValue.r = this.cameraComponent.camera.farClip * (1 - _sceneDepthClearEpsilon);
             this.scenePass.setClearColor(clearValue, this.sceneDepthSlot);
-
-            // Without a prepass nothing produces the scene depth before the scene pass, and what the
-            // last scene pass published in the previous frame is an attachment of the render target the
-            // scene passes render into. Clear those uniforms, so that a material sampling the scene
-            // depth without the user having asked for it reports that the depth is not available -
-            // which is the case - instead of silently reading a texture that is currently attached.
-            if (!this.options.prepassEnabled) {
-                const { scope } = this.device;
-                this._sceneTextureNames.forEach((name) => {
-                    scope.resolve(sceneTextureUniformNames[name]).setValue(null);
-                });
-            }
         }
 
         // scene texture is either output of taa pass or the scene render target

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1343,3 +1343,15 @@ export const RADIX_SORT_ONESWEEP = 2;
  * @ignore
  */
 export const SCENETEXTURE_DEPTH = 'depth';
+
+/**
+ * The uniform each scene texture is published under by the render pass which rendered it. Note that
+ * the depth uses the same uniform as the depth prepass, as those are two producers of the same thing,
+ * and the consumers sample whichever of them ran later in the frame.
+ *
+ * @type {Object<string, string>}
+ * @ignore
+ */
+export const sceneTextureUniformNames = {
+    [SCENETEXTURE_DEPTH]: 'uSceneDepthMap'
+};

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -830,6 +830,21 @@ class GSplatParams {
     cooldownTicks = 100;
 
     /**
+     * Whether the gaussian splats contribute to the scene depth, which the volumetric fog and the depth
+     * of field need in order to be bounded by the splats instead of drawing through them.
+     *
+     * This costs an extra full screen render target, and so defaults to false. Enable it for a scene
+     * where the splats need to take part in those effects. Requires the camera to render using
+     * {@link CameraFrame} - see {@link CameraFrame.isSplatSceneDepthSupported}.
+     *
+     * On some devices enabling this stores the scene depth at a lower precision, which the other
+     * effects using it share.
+     *
+     * @type {boolean}
+     */
+    sceneDepthWrite = false;
+
+    /**
      * Work buffer data format. Controls the precision and bandwidth of the intermediate work buffer
      * used during GSplat rendering. Can be set to {@link GSPLATDATA_COMPACT} (20 bytes/splat)
      * or {@link GSPLATDATA_LARGE} (32 bytes/splat). Defaults to {@link GSPLATDATA_COMPACT}.

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -90,6 +90,16 @@ class RenderPassForward extends RenderPass {
     publishSceneTextures = false;
 
     /**
+     * True if this pass clears the uniforms the scene textures are published to before it renders. Only
+     * the first pass rendering to the render target they are attached to sets this, and only when no
+     * depth prepass has published to those uniforms already - it is what stops a material from sampling
+     * a scene texture which nothing has produced yet.
+     *
+     * @type {boolean}
+     */
+    clearSceneTextures = false;
+
+    /**
      * If true, do not clear the depth buffer before rendering, as it was already primed by a depth
      * pre-pass.
      */
@@ -233,6 +243,18 @@ class RenderPassForward extends RenderPass {
 
     before() {
         const { layerRenderSteps } = this;
+
+        // Clear the uniforms the scene textures are published to, so that a material sampling them
+        // reports that they are not available - which is the case, as nothing has produced them for this
+        // frame yet - instead of silently reading a texture this pass renders into, or one that another
+        // camera published earlier in the frame. Only the first pass rendering to the render target they
+        // are attached to does this, and only when no depth prepass published to those uniforms before it.
+        if (this.clearSceneTextures) {
+            const { scope } = this.device;
+            this.sceneTextures.forEach((name) => {
+                scope.resolve(sceneTextureUniformNames[name]).setValue(null);
+            });
+        }
 
         // onPreRender events
         for (let i = 0; i < layerRenderSteps.length; i++) {

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -6,7 +6,7 @@ import { BlendState } from '../../platform/graphics/blend-state.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { RenderPass } from '../../platform/graphics/render-pass.js';
 import { LayerRenderStep } from './layer-render-step.js';
-import { EVENT_POSTRENDER, EVENT_POSTRENDER_LAYER, EVENT_PRERENDER, EVENT_PRERENDER_LAYER, SHADER_FORWARD } from '../constants.js';
+import { EVENT_POSTRENDER, EVENT_POSTRENDER_LAYER, EVENT_PRERENDER, EVENT_PRERENDER_LAYER, SHADER_FORWARD, sceneTextureUniformNames } from '../constants.js';
 
 /**
  * @import { CameraComponent } from '../../framework/components/camera/component.js'
@@ -77,6 +77,17 @@ class RenderPassForward extends RenderPass {
      * @type {string[]|undefined}
      */
     sceneTextures;
+
+    /**
+     * True if this pass publishes the scene textures it rendered when it finishes, making them
+     * available to the passes which consume them. Only the last pass rendering to the render target
+     * they are attached to sets this - publishing earlier would expose an attachment of a render target
+     * the remaining passes still render into, and the materials they render could then sample it, which
+     * is not allowed.
+     *
+     * @type {boolean}
+     */
+    publishSceneTextures = false;
 
     /**
      * If true, do not clear the depth buffer before rendering, as it was already primed by a depth
@@ -252,6 +263,25 @@ class RenderPassForward extends RenderPass {
     }
 
     after() {
+
+        // Publish the scene textures this pass rendered, making them available to the passes which
+        // consume them. This happens before the events below, so that a handler reading them sees the
+        // ones from this frame. Note that the depth prepass publishes its own depth to the same
+        // uniform, from its own after - the two are producers of the same thing, and this pass runs
+        // later, so the scene texture depth, which additionally covers the blended geometry, is what
+        // the consumers sample.
+        const sceneTextures = this.sceneTextures;
+        if (this.publishSceneTextures && sceneTextures?.length) {
+            const { renderTarget } = this;
+            Debug.assert(renderTarget.colorBufferCount > sceneTextures.length,
+                'The render target of a pass rendering the scene textures needs an attachment for each of them, in addition to the one holding the scene color.');
+
+            for (let i = 0; i < sceneTextures.length; i++) {
+                const uniformName = sceneTextureUniformNames[sceneTextures[i]];
+                Debug.assert(uniformName, `Scene texture '${sceneTextures[i]}' has no uniform to be published under, see sceneTextureUniformNames.`);
+                this.device.scope.resolve(uniformName).setValue(renderTarget.getColorBuffer(i + 1));
+            }
+        }
 
         // onPostRender events
         for (let i = 0; i < this.layerRenderSteps.length; i++) {


### PR DESCRIPTION
CameraFrame can now render the scene depth as an additional attachment of the scene render target, alongside the scene color, instead of by a depth prepass. This is both cheaper and more capable.

**Cheaper**, because the depth prepass is a second geometry pass over every opaque mesh the camera renders, and for the common configurations it disappears entirely - volumetric fog, depth of field, TAA and SSAO all consume the depth only after the scene has been rendered, so the scene pass can produce it as a by-product for the cost of one attachment write. On the examples this removes the prepass from volumetric fog, TAA, the shadow catcher and SSAO in combine mode.

**More capable**, because the blended geometry contributes to it. Gaussian splats accumulate a transmittance weighted depth as they render, which a prepass cannot produce at all, so the effects using the depth become bounded by the splats instead of drawing through them. That is opt-in per scene, as it costs the attachment for the whole scene pass.

**Changes:**
- `CameraFrame` derives which producer to use rather than exposing a setting. The depth is rendered by the scene pass when only the post-processing passes consume it. When something needs it earlier - the materials, via `rendering.sceneDepthMap`, or SSAO applied during shading - the prepass is kept, and the scene pass additionally renders it only when the splats are set to contribute.
- `GSplatParams.sceneDepthWrite` turns the splat contribution on, defaulting to false. `CameraFrame.isSplatSceneDepthSupported` reports whether a device can do it, so an application can disable those effects on the ones which cannot.
- SSAO in combine mode now runs after the scene pass rather than before it. Only SSAO applied during shading has to be generated first, as the lit shaders sample its texture; applied by the compose pass it is free to run later, where its depth can come from the scene pass and no prepass is needed. Lighting mode is unchanged.
- The scene passes publish the depth they rendered from their `after`, mirroring how the depth prepass publishes its own, so the passes consuming it sample whichever producer ran later in the frame. Only the last pass rendering to the scene render target publishes, as exposing an attachment which the remaining passes still render into would let the materials they render sample it.
- The depth is rendered as `R32F`, or as `R16F` where 32 bit float blending is unavailable. Half float is only used when the splats are contributing, since otherwise the prepass stores the depth more precisely - as `R32F`, or losslessly packed into RGBA8 - and the effects consuming it are sensitive to that.
- The scene pass is not used where it cannot render the depth correctly, in which case the prepass serves as before: with multi-sampling, without independent blending, without a blendable floating point format, when the camera does not clear the whole of its render target, and when a prepass which packs the depth would run alongside. A debug build warns, naming the reason, when gaussian splats end up not contributing.
- `examples/graphics/depth-of-field` disables multi-sampling when TAA is enabled, matching the ambient occlusion example. It was paying for both.

**API Changes:**
- `GSplatParams#sceneDepthWrite` - new, whether the gaussian splats contribute to the scene depth. Defaults to false.
- `CameraFrame.isSplatSceneDepthSupported(device)` - new static, whether a device can render the scene depth the splats contribute to.

Nothing changes for a camera whose configuration consumes no depth. Verified on both backends across the examples using CameraFrame, including the two-scene-pass case with a color grab pass, partial viewport cameras, and a device emulated as having no float blending to exercise the half float path and the packed prepass coexistence.