### PR TITLE
Gaussian splats write the scene depth

### DIFF
--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -750,6 +750,12 @@ class GSplatHybridRenderer extends GSplatRenderer {
     }
 
     frameUpdate(params) {
+
+        // Whether the splats contribute to the scene depth. This only selects the blend state, as the
+        // write itself is enabled by a define coming from the camera, so it needs no shader rebuild and
+        // can follow the scene setting from frame to frame.
+        this._material.sceneTexturesWrite = params.sceneDepthWrite;
+
         this._material.setParameter('alphaClip', params.alphaClip);
         this._material.setParameter('alphaClipForward', params.alphaClipForward);
         this._pickMaterial?.setParameter('alphaClip', params.alphaClip);

--- a/src/scene/gsplat-unified/gsplat-quad-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-quad-renderer.js
@@ -285,6 +285,11 @@ class GSplatQuadRenderer extends GSplatRenderer {
 
     frameUpdate(params) {
 
+        // Whether the splats contribute to the scene depth. This only selects the blend state, as the
+        // write itself is enabled by a define coming from the camera, so it needs no shader rebuild and
+        // can follow the scene setting from frame to frame.
+        this._material.sceneTexturesWrite = params.sceneDepthWrite;
+
         // Update colorRampIntensity parameter every frame when overdraw is enabled
         if (params.colorRamp) {
             this._material.setParameter('colorRampIntensity', params.colorRampIntensity);

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
@@ -15,6 +15,13 @@ export default /* glsl */`
     #include "floatAsUintPS"
 #endif
 
+// the prepass declares this varying above, and the two passes are never generated as one
+#if defined(SCENE_TEXTURE_DEPTH) && !defined(PREPASS_PASS)
+    varying float vLinearDepth;
+#endif
+
+#include "sceneTexturesPS"
+
 #if !defined(SHADOW_PASS) && !defined(PICK_PASS) && !defined(PREPASS_PASS)
     uniform float alphaClipForward;
 #endif
@@ -94,6 +101,19 @@ void main(void) {
         vec4 fragColor = vec4(gaussianColor.xyz, alpha);
         modifySplatColor(gaussianUV, fragColor);
         gl_FragColor = vec4(fragColor.xyz * fragColor.a, fragColor.a);
+
+        // The same premultiplied blending which composites the color accumulates a transmittance
+        // weighted depth, so the splats gain a depth without being rendered a second time. Dithered
+        // splats render as opaque, and the fragments which survive the dither have full coverage.
+        // Guarded by the define the write function tests internally, as vLinearDepth is only generated
+        // when the depth is written.
+        #ifdef SCENE_TEXTURE_DEPTH
+            #ifdef DITHER_NONE
+                writeSceneTextureDepth(vLinearDepth, fragColor.a);
+            #else
+                writeSceneTextureDepth(vLinearDepth, 1.0);
+            #endif
+        #endif
     #endif
 }
 `;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
@@ -13,7 +13,7 @@ varying mediump vec4 gaussianColor;
 
 mediump vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
 
-#ifdef PREPASS_PASS
+#if defined(PREPASS_PASS) || defined(SCENE_TEXTURE_DEPTH)
     varying float vLinearDepth;
 #endif
 
@@ -120,7 +120,7 @@ void main(void) {
         id = float(splat.index);
     #endif
 
-    #ifdef PREPASS_PASS
+    #if defined(PREPASS_PASS) || defined(SCENE_TEXTURE_DEPTH)
         vLinearDepth = -center.view.z;
     #endif
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
@@ -15,6 +15,13 @@ export default /* wgsl */`
     #include "floatAsUintPS"
 #endif
 
+// the prepass declares this varying above, and the two passes are never generated as one
+#if defined(SCENE_TEXTURE_DEPTH) && !defined(PREPASS_PASS)
+    varying vLinearDepth: f32;
+#endif
+
+#include "sceneTexturesPS"
+
 #if !defined(SHADOW_PASS) && !defined(PICK_PASS) && !defined(PREPASS_PASS)
     uniform alphaClipForward: f32;
 #endif
@@ -103,6 +110,19 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         var fragColor: vec4f = vec4f(vec3f(gaussianColor.xyz), f32(alpha));
         modifySplatColor(vec2f(gaussianUV), &fragColor);
         output.color = vec4f(fragColor.xyz * fragColor.a, fragColor.a);
+
+        // The same premultiplied blending which composites the color accumulates a transmittance
+        // weighted depth, so the splats gain a depth without being rendered a second time. Dithered
+        // splats render as opaque, and the fragments which survive the dither have full coverage.
+        // Guarded by the define the write function tests internally, as vLinearDepth is only generated
+        // when the depth is written.
+        #ifdef SCENE_TEXTURE_DEPTH
+            #ifdef DITHER_NONE
+                writeSceneTextureDepth(&output, vLinearDepth, fragColor.a);
+            #else
+                writeSceneTextureDepth(&output, vLinearDepth, 1.0);
+            #endif
+        #endif
     #endif
 
     return output;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
@@ -13,7 +13,7 @@ varying gaussianColor: half4;
 
 const discardVec: vec4f = vec4f(0.0, 0.0, 2.0, 1.0);
 
-#ifdef PREPASS_PASS
+#if defined(PREPASS_PASS) || defined(SCENE_TEXTURE_DEPTH)
     varying vLinearDepth: f32;
 #endif
 
@@ -137,7 +137,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
         output.id = f32(splat.index);
     #endif
 
-    #ifdef PREPASS_PASS
+    #if defined(PREPASS_PASS) || defined(SCENE_TEXTURE_DEPTH)
         output.vLinearDepth = -center.view.z;
     #endif
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
@@ -73,7 +73,7 @@ varying gaussianColor: half4;
     varying id: f32;
 #endif
 
-#ifdef PREPASS_PASS
+#if defined(PREPASS_PASS) || defined(SCENE_TEXTURE_DEPTH)
     varying vLinearDepth: f32;
 #endif
 
@@ -212,7 +212,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
         output.id = f32(cacheIdx);
     #endif
 
-    #ifdef PREPASS_PASS
+    #if defined(PREPASS_PASS) || defined(SCENE_TEXTURE_DEPTH)
         output.vLinearDepth = viewDepth;
     #endif
 


### PR DESCRIPTION
Makes gaussian splats a producer of the scene depth texture, so the effects consuming it work in a splat scene with no proxy geometry of any kind.

Until now the depth those effects sample came from the depth prepass, which renders opaque meshes only - in a splat scene it produces nothing, so volumetric fog flooded the frame, DOF blurred everything uniformly, and SSAO had no surfaces. The workaround was to ship a proxy mesh alongside the capture and keep it out of the forward pass, as `gaussian-splatting/depth-of-field` does today. Splats cannot be rendered into the prepass instead, as a single hard depth per pixel is not what a cloud of semi transparent gaussians has.

What makes this cheap is that the forward pass already composites the splats with premultiplied blending, which accumulates `Σ d·α·T` when the depth is written next to the color - a transmittance weighted depth, for the cost of one extra attachment write and no second pass over the splats. That is exactly the soft depth a raymarched effect wants, and #9174 put the scene pass MRT and the `SCENE_TEXTURE_DEPTH` define in place for it.

### Changes

- The forward gsplat fragment chunks, GLSL and WGSL, call `writeSceneTextureDepth` under `SCENE_TEXTURE_DEPTH`. Dithered splats render as opaque, so the fragments which survive the dither write full coverage instead of their alpha.
- `vLinearDepth`, previously generated for the prepass only, is generated for that define as well - in all three vertex chunks, hybrid included.
- `GSplatQuadRenderer` and `GSplatHybridRenderer` set `sceneTexturesWrite` on the forward material from `GsplatParams.sceneDepthWrite` each frame. That only selects the blend state - the write itself is driven by the define - so following the scene setting frame to frame needs no shader rebuild.

### Notes

- Off by default: `Scene#gsplat.sceneDepthWrite` gates it, and `CameraFrame.isSplatSceneDepthSupported(device)` reports whether the device can do it at all.
- Verified on both backends. With the flag on, the depth reads 1.32 at the nearest splat and covers 12.7% of the frame matching the silhouette; with it off the same pixels read the cleared far value.
- The demo exercising this is not in here, so this can land on its own - it follows separately.
