### PR TITLE
Wake the constrained bodies when a joint constraint is created or destroyed

### DIFF
--- a/src/framework/components/joint/component.js
+++ b/src/framework/components/joint/component.js
@@ -1230,6 +1230,8 @@ class JointComponent extends Component {
                 rigidbodyB.on('beforeremove', this._onBodyLost, this)
             );
         }
+
+        this._activateBodies();
     }
 
     /** @private */
@@ -1248,6 +1250,8 @@ class JointComponent extends Component {
 
             this.system.app.systems.rigidbody.physicsWorld.destroyJoint(joint);
             this._joint = null;
+
+            this._activateBodies();
         }
     }
 
@@ -1318,7 +1322,9 @@ class JointComponent extends Component {
 
     /**
      * Wakes the constrained bodies so that a change to the constraint takes immediate effect on
-     * a sleeping simulation island.
+     * a sleeping simulation island. Creating and destroying the constraint wake the bodies too,
+     * so a joint added between two settled bodies is enforced right away and one removed from
+     * them releases them right away, rather than leaving them holding the constrained pose.
      *
      * @private
      */

--- a/src/framework/components/joint/component.js
+++ b/src/framework/components/joint/component.js
@@ -1322,9 +1322,10 @@ class JointComponent extends Component {
 
     /**
      * Wakes the constrained bodies so that a change to the constraint takes immediate effect on
-     * a sleeping simulation island. Creating and destroying the constraint wake the bodies too,
-     * so a joint added between two settled bodies is enforced right away and one removed from
-     * them releases them right away, rather than leaving them holding the constrained pose.
+     * a sleeping simulation island. Called both when the joint's parameters change and when the
+     * constraint itself is created or destroyed, so a joint added between two settled bodies is
+     * enforced right away, and one removed from them releases them instead of leaving them
+     * holding the constrained pose.
      *
      * @private
      */

--- a/test/framework/components/joint/component.test.mjs
+++ b/test/framework/components/joint/component.test.mjs
@@ -6,7 +6,9 @@ import {
     JOINTTYPE_6DOF, JOINTTYPE_BALL, JOINTTYPE_FIXED, JOINTTYPE_HINGE, JOINTTYPE_SLIDER,
     MOTION_FREE, MOTION_LIMITED, MOTION_LOCKED
 } from '../../../../src/framework/components/joint/constants.js';
+import { BODYTYPE_DYNAMIC } from '../../../../src/framework/components/rigid-body/constants.js';
 import { Entity } from '../../../../src/framework/entity.js';
+import { NullPhysicsWorld } from '../../../../src/framework/physics/null/null-physics-world.js';
 import { createApp } from '../../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
 
@@ -421,6 +423,136 @@ describe('JointComponent', function () {
                 targetB.destroy();
                 e.destroy();
             }).to.not.throw();
+        });
+
+    });
+
+    // A change to the constraint has no effect on a sleeping simulation island unless the bodies
+    // are woken, so creating and destroying the constraint must activate both of them. Run
+    // against the null physics backend, which takes joints through their full lifecycle.
+    describe('body activation', function () {
+
+        beforeEach(function () {
+            app.systems.rigidbody.setPhysicsWorld(new NullPhysicsWorld());
+        });
+
+        function addBodyEntity(name) {
+            const e = new Entity(name);
+            app.root.addChild(e);
+            e.addComponent('collision');
+            e.addComponent('rigidbody', { type: BODYTYPE_DYNAMIC });
+            return e;
+        }
+
+        /**
+         * Counts activations of each entity's backend body.
+         *
+         * @param {...Entity} entities - The body entities to instrument.
+         * @returns {() => number[]} A function returning the per-entity activation counts.
+         */
+        function countActivations(...entities) {
+            const counts = entities.map(() => 0);
+            entities.forEach((entity, i) => {
+                const body = entity.rigidbody._body;
+                const activate = body.activate;
+                body.activate = function () {
+                    counts[i]++;
+                    activate.call(this);
+                };
+            });
+            return () => counts;
+        }
+
+        /**
+         * Creates a joint entity that is not yet armed, so that the constraint is only created
+         * once the activation counters are in place.
+         *
+         * @param {object} data - The joint component data.
+         * @returns {Entity} The joint entity.
+         */
+        function addDisabledJoint(data) {
+            const e = new Entity('joint');
+            app.root.addChild(e);
+            e.addComponent('joint', { ...data, enabled: false });
+            expect(e.joint._joint).to.equal(null);
+            return e;
+        }
+
+        it('wakes both bodies when the constraint is created', function () {
+            const bodyA = addBodyEntity('bodyA');
+            const bodyB = addBodyEntity('bodyB');
+            const e = addDisabledJoint({ entityA: bodyA, entityB: bodyB });
+
+            const counts = countActivations(bodyA, bodyB);
+            e.joint.enabled = true;
+
+            expect(e.joint._joint).to.exist;
+            expect(counts()).to.deep.equal([1, 1]);
+        });
+
+        it('wakes both bodies when the component is disabled', function () {
+            const bodyA = addBodyEntity('bodyA');
+            const bodyB = addBodyEntity('bodyB');
+            const e = addDisabledJoint({ entityA: bodyA, entityB: bodyB });
+            e.joint.enabled = true;
+
+            const counts = countActivations(bodyA, bodyB);
+            e.joint.enabled = false;
+
+            expect(e.joint._joint).to.equal(null);
+            expect(counts()).to.deep.equal([1, 1]);
+        });
+
+        it('wakes both bodies when the component is removed', function () {
+            const bodyA = addBodyEntity('bodyA');
+            const bodyB = addBodyEntity('bodyB');
+            const e = addDisabledJoint({ entityA: bodyA, entityB: bodyB });
+            e.joint.enabled = true;
+
+            const counts = countActivations(bodyA, bodyB);
+            e.removeComponent('joint');
+
+            expect(counts()).to.deep.equal([1, 1]);
+        });
+
+        // the entity references are dropped as part of the change, so the wake has to happen
+        // while the outgoing references are still in hand
+        it('wakes the previously constrained bodies when an entity reference is cleared', function () {
+            const bodyA = addBodyEntity('bodyA');
+            const bodyB = addBodyEntity('bodyB');
+            const e = addDisabledJoint({ entityA: bodyA, entityB: bodyB });
+            e.joint.enabled = true;
+
+            const counts = countActivations(bodyA, bodyB);
+            e.joint.entityA = null;
+
+            expect(e.joint._joint).to.equal(null);
+            expect(counts()).to.deep.equal([1, 1]);
+        });
+
+        it('wakes both bodies when the constraint is rebuilt by refreshFrames', function () {
+            const bodyA = addBodyEntity('bodyA');
+            const bodyB = addBodyEntity('bodyB');
+            const e = addDisabledJoint({ entityA: bodyA, entityB: bodyB });
+            e.joint.enabled = true;
+
+            const counts = countActivations(bodyA, bodyB);
+            e.joint.refreshFrames();
+
+            // once for the teardown and once for the rebuild
+            expect(e.joint._joint).to.exist;
+            expect(counts()).to.deep.equal([2, 2]);
+        });
+
+        it('wakes nothing when there is no constraint to tear down', function () {
+            const bodyA = addBodyEntity('bodyA');
+            const bodyB = addBodyEntity('bodyB');
+            const e = addDisabledJoint({ entityA: bodyA, entityB: bodyB });
+
+            const counts = countActivations(bodyA, bodyB);
+            e.joint.enableCollision = true;
+
+            expect(counts()).to.deep.equal([0, 0]);
         });
 
     });


### PR DESCRIPTION
## Description

`JointComponent._activateBodies` was only called from `_updateLimits`, `_updateMotor` and `_updateSpring`. Adjusting a joint's limits, motor or spring therefore took effect immediately on a settled simulation island, but creating or destroying the constraint itself did not — and every structural change goes through `_createConstraint`/`_destroyConstraint`, neither of which woke anything.

The result was that a change which should visibly alter the simulation silently did nothing until something else disturbed the bodies. Destroying a constraint was the worst case: the bodies kept the pose the constraint had been holding them in, so a released assembly hung in mid-air indefinitely.

This calls `_activateBodies` from both, covering every path that creates or tears down a constraint: `type`, `enableCollision`, `refreshFrames`, `entityA`/`entityB` assignment, a body leaving the simulation, exceeding `breakImpulse`, `onDisable` and `onBeforeRemove`.

Fixes #9176

### Notes for reviewers

**The destroy-side wake is inside the `if (joint)` guard**, so nothing is activated when there was no constraint to tear down. Re-arming a broken joint via `refreshFrames` is still covered — a broken joint has no constraint to destroy, and the subsequent creation does the waking.

**Ordering works out on every teardown path.** `_setJointEntity` destroys the constraint before reassigning the backing field, and `onBeforeRemove` never clears the entity references, so both still have the outgoing bodies in hand. The one exception is the entity `destroy` handler, which nulls its own reference first — that body is being destroyed so waking it is moot, and the surviving body is still woken (in practice the rigid body's `beforeremove` → `_onBodyLost` has already woken both by then).

**Tests** add a `body activation` block covering creation, `enabled = false`, component removal, clearing `entityA` (the ordering case), `refreshFrames` (2 activations — teardown then rebuild), plus one asserting no wake when there is no constraint. These run against `NullPhysicsWorld`, which takes joints through their full lifecycle without Ammo, so constraint creation and teardown are now unit-testable where they previously were not.

All 5 activation tests fail on the unpatched source and pass with the fix; the no-constraint guard test passes either way. 86 tests pass across `joint`/`rigid-body`/`collision`/`physics`, and ESLint is clean.

### Left out of scope

The issue also notes that `RigidBodyComponent#teleport` does not activate either. That gap is real (`teleport` → `syncEntityToBody` → `setTransform` with no `activate`), but unlike the alpha joint component `teleport` is a long-standing public API, and "reposition a settled prop and have it stay settled" is plausibly relied upon today. That seems worth its own issue and decision rather than folding it in here.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)