### PR TITLE
Fix missing sRGB flag on particle colorMap in UI particle example

### DIFF
--- a/examples/src/examples/user-interface/particle-system.example.mjs
+++ b/examples/src/examples/user-interface/particle-system.example.mjs
@@ -35,7 +35,7 @@ window.focus();
 
 const assets = {
     font: new Asset('font', 'font', { url: './assets/fonts/courier.json' }),
-    spark: new Asset('spark', 'texture', { url: './assets/textures/spark.png' })
+    spark: new Asset('spark', 'texture', { url: './assets/textures/spark.png' }, { srgb: true })
 };
 
 const gfxOptions = {


### PR DESCRIPTION
## Problem

`examples/src/examples/user-interface/particle-system.example.mjs` loads the `spark` particle `colorMap` texture without `{ srgb: true }`:

```javascript
spark: new Asset('spark', 'texture', { url: './assets/textures/spark.png' })
```

The particle emitter does **not** gamma-decode the colorMap in the shader — it relies on the texture being in a hardware sRGB format. With a linear `RGBA8` texture the particles render incorrectly, and the engine logs a runtime warning ([`particle-emitter.js`](https://github.com/playcanvas/engine/blob/main/src/scene/particle-system/particle-emitter.js#L771)):

> ParticleEmitter: colorMap texture [spark] is not using sRGB format. Please correct it for the correct rendering.

The same `spark.png` is already loaded **with** `{ srgb: true }` in `graphics/particles-spark.example.mjs`, so the two examples disagreed — this one was wrong.

## Fix

```javascript
spark: new Asset('spark', 'texture', { url: './assets/textures/spark.png' }, { srgb: true })
```

This clears the runtime warning and renders the particles correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)