### PR TITLE
Keep the examples dev server alive when an example file is renamed

### DIFF
--- a/examples/utils/vite-dev-server.mjs
+++ b/examples/utils/vite-dev-server.mjs
@@ -291,6 +291,16 @@ const createUpdate = async (file, engine, logStart = null) => {
     const stamp = Date.now().toString(36);
     const item = exampleFromFile(abs);
     if (item) {
+
+        // the example source is gone, which is what a rename or a delete looks like from here. There
+        // is no update to send - the example list is read once at startup, so a new name needs a
+        // restart to appear - and reading its config would throw.
+        const source = getExamplePath(item, 'example.mjs');
+        const exists = await fs.promises.stat(source).then(() => true, () => false);
+        if (!exists) {
+            return null;
+        }
+
         const example = `/${item.categoryKebab}/${item.exampleNameKebab}`;
         logStart?.('example', example);
         return {
@@ -597,7 +607,11 @@ export const examplesDevServer = ({ hmr = true } = {}) => {
                             data
                         });
                     });
-                }, (err) => {
+
+                // as a trailing catch, not a rejection handler on the first link of the chain - that
+                // one leaves everything after it unhandled, and an unhandled rejection in a watcher
+                // callback takes the whole dev server down
+                }).catch((err) => {
                     server.config.logger.error(err.message);
                 });
             };

--- a/examples/utils/vite-dev-server.mjs
+++ b/examples/utils/vite-dev-server.mjs
@@ -294,11 +294,16 @@ const createUpdate = async (file, engine, logStart = null) => {
 
         // the example source is gone, which is what a rename or a delete looks like from here. There
         // is no update to send - the example list is read once at startup, so a new name needs a
-        // restart to appear - and reading its config would throw.
+        // restart to appear - and reading its config would throw. Anything other than a missing file
+        // is a real problem, so it is left to the watcher's catch to report.
         const source = getExamplePath(item, 'example.mjs');
-        const exists = await fs.promises.stat(source).then(() => true, () => false);
-        if (!exists) {
-            return null;
+        try {
+            await fs.promises.stat(source);
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                return null;
+            }
+            throw err;
         }
 
         const example = `/${item.categoryKebab}/${item.exampleNameKebab}`;


### PR DESCRIPTION
Renaming or deleting an example source file kills the examples dev server, so every rename has to be followed by a manual restart:

```
Error: ENOENT: no such file or directory, open '…/src/examples/gaussian-splatting/winter-light.example.mjs'
    at async readExampleConfig (…/vite.config.mjs…)
    at async createUpdate (…)
Node.js v20.20.2
```

Two things combine to make it fatal:

- the watcher's `unlink` handler builds an HMR update for the example, which reads its config - and on a rename that file is gone, so `readExampleConfig` rejects;
- that rejection has nowhere to go. `update` passed its error handler as the **second argument** of `.then()` on the first link of the chain, so it only ever sees rejections of `changed()`, never those of the promise the fulfilled handler returns. An unhandled rejection exits the process by default.

### Changes

- The error handler becomes a trailing `.catch()`, so anything in the chain is logged instead of being fatal. That also covers the engine path lookup, which had the same hole.
- `createUpdate` returns null for an example whose `.example.mjs` has gone, rather than reading it. Nothing useful can be sent in that case anyway: the example list is read once at startup, so a renamed example needs a restart to appear under its new name regardless.

### Verification

With the dev server running, renaming `graphics/area-lights.example.mjs` away and back:

- before: the process exits on the rename with the ENOENT above;
- after: the server stays up and keeps serving (HTTP 200 across both renames), the rename away is a silent no-op, and renaming back produces the usual `example → /graphics/area-lights … created` update.

Note `examples/utils/` is linted but not prettier-formatted, so this keeps the file's existing style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)