### PR TITLE
Detach element component graph nodes on destroy

### DIFF
--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -68,6 +68,10 @@ class ImageRenderable {
         this._element.removeModelFromLayers(this.model);
         this.model.destroy();
         this.model = null;
+
+        // the node was added as a child of the entity, so detach it - otherwise it lingers in
+        // entity.children for the lifetime of the entity
+        this.node.remove();
         this.node = null;
         this.mesh = null;
         this.meshInstance?.destroy();

--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -238,6 +238,11 @@ class TextElement {
             this._model = null;
         }
 
+        // the node was added as a child of the entity, so detach it - otherwise it lingers in
+        // entity.children for the lifetime of the entity
+        this._node.remove();
+        this._node = null;
+
         this._fontAsset.destroy();
         this.font = null;
 

--- a/test/framework/components/element/component.test.mjs
+++ b/test/framework/components/element/component.test.mjs
@@ -211,5 +211,46 @@ describe('ElementComponent', function () {
             expect(e.element._addedModels).to.include(e.element._text._model);
         });
 
+        it('does not accumulate graph nodes when the type changes (#4333)', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+
+            e.addComponent('element', { type: 'text' });
+            expect(e.children.length).to.equal(1);
+
+            e.element.type = 'image';
+            expect(e.children.length).to.equal(1);
+
+            e.element.type = 'text';
+            expect(e.children.length).to.equal(1);
+
+            e.element.type = 'group';
+            expect(e.children.length).to.equal(0);
+        });
+
+    });
+
+    describe('#onBeforeRemove', function () {
+
+        it('removes the text element graph node from the entity (#4333)', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+
+            e.addComponent('element', { type: 'text' });
+            e.removeComponent('element');
+
+            expect(e.children.length).to.equal(0);
+        });
+
+        it('removes the image element graph node from the entity (#4333)', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+
+            e.addComponent('element', { type: 'image' });
+            e.removeComponent('element');
+
+            expect(e.children.length).to.equal(0);
+        });
+
     });
 });


### PR DESCRIPTION
The image and text element internals parent a `GraphNode` to their entity, but neither detached it on destroy. The node therefore stayed in `entity.children` for the lifetime of the entity - so `removeComponent('element')` left one behind, and every `element.type` change added another. This is the accumulating half of #4333.

**Changes:**
- `ImageRenderable#destroy` and `TextElement#destroy` now detach their graph node from the entity, matching what `SpriteComponent` already does.
- Added element component tests covering type changes and component removal, for both the image and text types.