### PR TITLE
Remove the placeholder model from non-mesh collision components

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -3,8 +3,6 @@ import { Mat4 } from '../../../core/math/mat4.js';
 import { Quat } from '../../../core/math/quat.js';
 import { Vec3 } from '../../../core/math/vec3.js';
 import { SEMANTIC_POSITION } from '../../../platform/graphics/constants.js';
-import { GraphNode } from '../../../scene/graph-node.js';
-import { Model } from '../../../scene/model.js';
 import { ComponentSystem } from '../system.js';
 import { CollisionComponent } from './component.js';
 import { Trigger } from './trigger.js';
@@ -12,6 +10,7 @@ import { Trigger } from './trigger.js';
 /**
  * @import { AppBase } from '../../app-base.js'
  * @import { Entity } from '../../entity.js'
+ * @import { GraphNode } from '../../../scene/graph-node.js'
  */
 
 const mat4 = new Mat4();
@@ -84,8 +83,6 @@ const collisionImpls = {
     },
 
     mesh: {
-        // the model comes from assets - no placeholder is created
-        beforeInitialize() {},
         createPhysicalShape: createMeshShape,
         recreatePhysicalShapes: recreateMeshShapes,
         updateTransform: updateMeshTransform
@@ -111,10 +108,6 @@ function getImpl(type) {
 // Called before the call to system.super.initializeComponentData is made
 function beforeInitialize(system, component) {
     component._shape = null;
-
-    const model = new Model();
-    model.graph = new GraphNode();
-    component._model = model;
 }
 
 // Called after the call to system.super.initializeComponentData is made

--- a/test/framework/components/collision/component.test.mjs
+++ b/test/framework/components/collision/component.test.mjs
@@ -44,8 +44,7 @@ describe('CollisionComponent', function () {
             expect(e.collision.checkVertexDuplicates).to.equal(true);
             expect(e.collision.shape).to.equal(null);
             expect(e.collision.render).to.equal(null);
-            // non-mesh initialization creates a placeholder model
-            expect(e.collision.model).to.be.an.instanceof(Model);
+            expect(e.collision.model).to.equal(null);
         });
 
         it('round-trips every property passed via the data argument', function () {
@@ -244,6 +243,20 @@ describe('CollisionComponent', function () {
             e.collision.type = 'sphere';
 
             expect(e.collision.type).to.equal('sphere');
+        });
+
+        it('does not build a mesh shape when a non-mesh type is switched to mesh', function () {
+            app.systems.rigidbody.setPhysicsWorld(new NullPhysicsWorld());
+
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('collision');
+
+            // no asset, render asset or model was supplied, so there is nothing to build from
+            e.collision.type = 'mesh';
+
+            expect(e.collision.model).to.equal(null);
+            expect(e.collision.shape).to.equal(null);
         });
 
         it('is a no-op when the type is unchanged', function () {


### PR DESCRIPTION
Collision component initialization created an empty `Model` (with its own `GraphNode`) for every non-mesh type. It is never rendered and never read - mesh shapes are built from the component's `model` / `render` source, which only the `mesh` type has.

The `mesh` type opted out of the placeholder with an empty `beforeInitialize`, and that asymmetry was a bug: switching a `box` to `mesh` left the box's placeholder in `_model`, so `createMeshShape` treated it as a valid source and built a mesh shape from `sources: []` (and created a trigger) instead of removing the shape.

**Changes:**
- Dropped the placeholder `Model` / `GraphNode` from collision component initialization.
- Removed the `mesh` type's empty `beforeInitialize` override, which existed only to skip the placeholder. The shared version now runs for `mesh` too, which is behavior-neutral - it only resets `_shape`, which `beforeRemove` has already cleared by that point.
- Added a test for switching a `box` to `mesh` with no mesh source supplied.

**API Changes:**
- `CollisionComponent#model` now returns `null` instead of an empty `Model` for non-mesh collision types. The documented type is already `Model | null`, and the property only ever applied to the `mesh` type.