### PR TITLE
Fix RTL text element tests silently running through the LTR path

### DIFF
--- a/test/framework/components/element/text-element.test.mjs
+++ b/test/framework/components/element/text-element.test.mjs
@@ -118,7 +118,7 @@ describe('TextElement', function () {
             });
             return {
                 mapping: mapping,
-                isrtl: true
+                rtl: true
             };
         });
     }
@@ -365,6 +365,19 @@ describe('TextElement', function () {
             'a',
             'bcdef ghijkl'
         ]);
+    });
+
+    it('rtl - reorder handler turns on rtl layout', function () {
+        registerRtlHandler();
+
+        element.fontAsset = fontAsset;
+        element.rtlReorder = true;
+
+        element.text = 'abcde fghij';
+
+        // without this the rtl tests below all run through the ltr path, and the rtl specific
+        // layout code they are meant to cover is never reached
+        expect(element._text._rtl).to.equal(true);
     });
 
     it('rtl - breaks onto multiple lines if individual lines are too long', function () {


### PR DESCRIPTION
The `registerRtlHandler` helper in the text element tests returns `isrtl: true`, but `TextElement._updateText` reads `results.rtl` from the reorder function. `_rtl` was therefore left `undefined` and every RTL test in the file laid its text out through the LTR path, so the RTL specific code those tests are meant to cover — the horizontal flip of each line and its glyphs, and the reversed slice indices when a line is broken — was never reached.

All 15 existing RTL tests pass once RTL is actually enabled, so nothing had come to depend on the wrong behaviour. They were simply duplicating the LTR tests above them.

**Changes:**
- Return `rtl` rather than `isrtl` from the test reorder handler, so `rtlReorder` reaches the RTL layout path.
- Add a test asserting that the reorder handler turns `_rtl` on, so the same mistake cannot silently disable the RTL coverage again. It fails on the current code with `expected undefined to equal true`.

Test only, no engine changes.

Worth noting as a follow-up: `ElementComponentSystem#registerRtlReorder` and `registerUnicodeConverter` have no JSDoc, so the shape the reorder function has to return is only discoverable by reading the property accesses in `text-element.js`. Documenting it would stop this recurring.