### PR TITLE
Destroy the asset registry with the application

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1953,7 +1953,8 @@ class AppBase extends EventHandler {
             assets[i].unload();
             assets[i].off();
         }
-        this.assets.off();
+        this.assets.destroy();
+        this.assets = null;
 
         // destroy scene after assets are unloaded (components need scene.layers during asset cleanup)
         this.scene.destroy();

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -353,8 +353,12 @@ class AssetRegistry extends EventHandler {
             asset.tags.off('remove', this._onTagRemove, this);
 
             // clear the back-reference, so that an asset which outlives the application does not
-            // keep the registry - and through it all other assets - alive
-            asset.registry = null;
+            // keep the registry - and through it all other assets - alive. An asset added to
+            // another registry since points at that one instead, which cannot retain this
+            // registry, so it is left alone.
+            if (asset.registry === this) {
+                asset.registry = null;
+            }
         }
 
         this._assets.clear();

--- a/src/framework/asset/asset-registry.js
+++ b/src/framework/asset/asset-registry.js
@@ -340,6 +340,35 @@ class AssetRegistry extends EventHandler {
     }
 
     /**
+     * Destroys the registry, releasing all assets held by it. Called by {@link AppBase#destroy}.
+     * Note that this does not destroy the resources of the assets - {@link Asset#unload} needs to
+     * be called for each asset before the registry is destroyed.
+     *
+     * @ignore
+     */
+    destroy() {
+        for (const asset of this._assets) {
+            asset.off('name', this._onNameChange, this);
+            asset.tags.off('add', this._onTagAdd, this);
+            asset.tags.off('remove', this._onTagRemove, this);
+
+            // clear the back-reference, so that an asset which outlives the application does not
+            // keep the registry - and through it all other assets - alive
+            asset.registry = null;
+        }
+
+        this._assets.clear();
+        this._idToAsset.clear();
+        this._urlToAsset.clear();
+        this._nameToAsset.clear();
+
+        this._tags = null;
+        this.bundles = null;
+
+        this.off();
+    }
+
+    /**
      * Retrieve an asset from the registry by its id field.
      *
      * @param {number} id - The id of the asset to get.

--- a/src/framework/asset/asset.js
+++ b/src/framework/asset/asset.js
@@ -598,7 +598,7 @@ class Asset extends EventHandler {
         }
 
         this.fire('unload', this);
-        this.registry.fire(`unload:${this.id}`, this);
+        this.registry?.fire(`unload:${this.id}`, this);
 
         const old = this._resources;
 
@@ -613,7 +613,7 @@ class Asset extends EventHandler {
 
         // remove resource from loader cache
         if (this.file) {
-            this.registry._loader.clearCache(this.getFileUrl(), this.type);
+            this.registry?._loader.clearCache(this.getFileUrl(), this.type);
         }
 
         // destroy resources

--- a/test/framework/application.test.mjs
+++ b/test/framework/application.test.mjs
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import { app as currentApp } from '../../src/framework/app-base.js';
 import { AssetRegistry } from '../../src/framework/asset/asset-registry.js';
+import { Asset } from '../../src/framework/asset/asset.js';
 import { ComponentSystemRegistry } from '../../src/framework/components/registry.js';
 import { FILLMODE_KEEP_ASPECT, RESOLUTION_FIXED } from '../../src/framework/constants.js';
 import { Entity } from '../../src/framework/entity.js';
@@ -68,7 +69,7 @@ describe('Application', function () {
         it('destroys the application', function () {
             app.destroy();
 
-            // expect(app.assets).to.be.null;
+            expect(app.assets).to.be.null;
             expect(app.batcher).to.be.null;
             expect(app.elementInput).to.be.null;
             expect(app.gamepads).to.be.null;
@@ -102,6 +103,21 @@ describe('Application', function () {
             expect(currentApp).to.be.null;
             expect(getApplication()).to.be.null;
             expect(loader._app).to.be.null;
+
+            app = null;
+        });
+
+        it('clears the registry reference of assets that outlive the application', function () {
+            const asset = new Asset('Asset', 'text', {
+                url: 'fake/one/file.txt'
+            });
+            app.assets.add(asset);
+
+            app.destroy();
+
+            // an asset held on to by user code must not keep the registry, and through it the
+            // application, alive
+            expect(asset.registry).to.be.null;
 
             app = null;
         });

--- a/test/framework/asset/asset-registry.test.mjs
+++ b/test/framework/asset/asset-registry.test.mjs
@@ -405,6 +405,27 @@ describe('AssetRegistry', function () {
             expect(registry.find('Renamed Asset')).to.be.null;
         });
 
+        it('leaves a registry reference which belongs to another registry', function () {
+            const asset = new Asset('Asset', 'text', {
+                url: 'fake/one/file.txt'
+            });
+
+            const registry = new AssetRegistry(new ResourceLoader(app));
+            registry.add(asset);
+
+            // the asset now belongs to the other registry, which is still live
+            const other = new AssetRegistry(new ResourceLoader(app));
+            other.add(asset);
+
+            registry.destroy();
+
+            expect(asset.registry).to.equal(other);
+            expect(other.get(asset.id)).to.equal(asset);
+
+            other.destroy();
+            expect(asset.registry).to.be.null;
+        });
+
     });
 
 });

--- a/test/framework/asset/asset-registry.test.mjs
+++ b/test/framework/asset/asset-registry.test.mjs
@@ -369,4 +369,42 @@ describe('AssetRegistry', function () {
 
     });
 
+    describe('#destroy', function () {
+
+        it('empties the registry and clears asset references to it', function () {
+            const asset = new Asset('Asset', 'text', {
+                url: 'fake/one/file.txt'
+            });
+            asset.tags.add('tag');
+
+            const registry = new AssetRegistry(new ResourceLoader(app));
+            registry.add(asset);
+            registry.destroy();
+
+            expect(registry.list().length).to.equal(0);
+            expect(registry.get(asset.id)).to.be.undefined;
+            expect(registry.getByUrl('fake/one/file.txt')).to.be.undefined;
+            expect(asset.registry).to.be.null;
+        });
+
+        it('unsubscribes from asset name and tag changes', function () {
+            const asset = new Asset('Asset', 'text', {
+                url: 'fake/one/file.txt'
+            });
+
+            const registry = new AssetRegistry(new ResourceLoader(app));
+            registry.add(asset);
+            registry.destroy();
+
+            // a still subscribed tag handler throws on the released tags cache, and a still
+            // subscribed name handler repopulates the name index
+            asset.tags.add('tag');
+            asset.tags.remove('tag');
+            asset.name = 'Renamed Asset';
+
+            expect(registry.find('Renamed Asset')).to.be.null;
+        });
+
+    });
+
 });


### PR DESCRIPTION
Fixes #3886.

Every `Asset` holds a reference to its `AssetRegistry` - `AssetRegistry#add` assigns it and nothing ever cleared it - and the registry itself was never cleaned up, as it had no `destroy` method and `AppBase#destroy` only called `off()` on it. An asset which outlived the application therefore kept the registry alive, and with it every other asset in the registry, including their `data` and `file.contents` payloads.

Verified with `WeakRef` probes on the null device. Holding an asset after `app.destroy()`:

| | before | after |
| --- | --- | --- |
| asset was in the registry | registry, loader and app all retained | all collected |
| asset was removed earlier | registry and all other assets retained | other assets collected, registry left as an empty shell |

The application itself is no longer reachable in either case since #9190.

### Changes

- New `AssetRegistry#destroy`, called from `AppBase#destroy`: unsubscribes from the `name` and `tags` events of all assets, clears their `registry` back-reference, empties the four lookup maps and releases the tags cache and bundle registry. `AppBase#assets` is cleared as well, which is what the commented out assertion in `application.test.mjs` was waiting for.
- `Asset#unload` no longer assumes a registry, since assets which outlive the application no longer have one.

### Compatibility

No behaviour change for a running application - only teardown is affected:

- `AssetRegistry#remove` is untouched, so `remove()` followed by `unload()` still clears the loader cache entry as before, and `asset.registry` stays valid for as long as the application lives.
- `app.assets` is now `null` after `app.destroy()`, consistent with `app.root`, `app.scene` and `app.loader`, which are already cleared there.

An earlier revision of this PR also cleared `Asset#registry` in `AssetRegistry#remove`. That turned out to be a breaking change for little benefit - it makes `asset.data`, `asset.loadFaces` and `asset.reload()` throw on a removed asset, and silently stops `unload()` from clearing the loader cache entry - while freeing nothing extra, because the registry it points at is emptied by `destroy` anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)