### PR TITLE
Release the application references on destroy

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1975,6 +1975,12 @@ class AppBase extends EventHandler {
             setApplication(null);
         }
 
+        // clear the module scoped reference, which would otherwise keep the destroyed application
+        // alive. Skipped if another application has already taken over.
+        if (app === this) {
+            app = null;
+        }
+
         AppBase.cancelTick(this);
     }
 

--- a/src/framework/handlers/loader.js
+++ b/src/framework/handlers/loader.js
@@ -425,6 +425,7 @@ class ResourceLoader {
         this._handlers = {};
         this._requests = {};
         this._cache = {};
+        this._app = null;
     }
 }
 

--- a/test/framework/application.test.mjs
+++ b/test/framework/application.test.mjs
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
 
+import { app as currentApp } from '../../src/framework/app-base.js';
 import { AssetRegistry } from '../../src/framework/asset/asset-registry.js';
 import { ComponentSystemRegistry } from '../../src/framework/components/registry.js';
 import { FILLMODE_KEEP_ASPECT, RESOLUTION_FIXED } from '../../src/framework/constants.js';
 import { Entity } from '../../src/framework/entity.js';
+import { getApplication } from '../../src/framework/globals.js';
 import { ResourceLoader } from '../../src/framework/handlers/loader.js';
 import { I18n } from '../../src/framework/i18n/i18n.js';
 import { Lightmapper } from '../../src/framework/lightmapper/lightmapper.js';
@@ -83,6 +85,23 @@ describe('Application', function () {
             expect(app.systems).to.be.null;
             expect(app.touch).to.be.null;
             // expect(app.xr).to.be.null;
+
+            app = null;
+        });
+
+        it('clears the references to the application', function () {
+            const loader = app.loader;
+
+            expect(currentApp).to.equal(app);
+            expect(getApplication()).to.equal(app);
+
+            app.destroy();
+
+            // the destroyed application must not be reachable from module scope or from objects
+            // which may outlive it
+            expect(currentApp).to.be.null;
+            expect(getApplication()).to.be.null;
+            expect(loader._app).to.be.null;
 
             app = null;
         });


### PR DESCRIPTION
Found while investigating #3886, and the dominant reason a destroyed application leaks.

`app-base.js` has a module scoped `app` reference, exported publicly as `pc.app`. It is assigned in the `AppBase` constructor and again on every frame update, but `AppBase#destroy` never clears it - unlike the equivalent globals right next to it (`setApplication(null)`, `script.app = null`, `AppBase._applications[canvasId] = null`).

A destroyed application is therefore retained forever, unless a new application happens to overwrite the reference. Everything still referenced by the destroyed instance goes with it - most notably `assets` (the full `AssetRegistry`, every `Asset`, and their `data` and `file.contents` payloads), plus `xr`, the default layers, the frame graph and the bound `tick` closure.

Verified with a `WeakRef` probe on the null device: before this change, a destroyed application is uncollectable even when the test holds no reference to it at all, and becomes collectable only once a second application is created; after it, the destroyed application and its registry are collected right away.

### Changes

- `AppBase#destroy` clears the module scoped reference, guarded by `app === this` so that destroying an old application does not clear the pointer to a newer one (mirroring the existing `getApplication() === this` check).
- `ResourceLoader#destroy` clears its `_app` reference, so a handler or loader which outlives the application does not keep it alive. Both of its use sites are safe: `load` early-returns once the handlers have been cleared, and the variant lookup in `Asset#file` already falls back to `getApplication()`.
- Test asserting that `pc.app`, `getApplication()` and `loader._app` are all cleared by destroy.

Related but independent: #9189 clears the `Asset` to `AssetRegistry` back-reference, which is the other half of #3886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)