### PR TITLE
Add flat shading support

### DIFF
--- a/examples/assets/scripts/misc/hatch-material.mjs
+++ b/examples/assets/scripts/misc/hatch-material.mjs
@@ -54,15 +54,9 @@ const createHatchMaterial = (device, textures) => {
                 // Functions added: getNormalMatrix, getLocalNormal
                 #include "normalCoreVS"
 
-                // engine supplied uniforms
-                uniform vec3 view_position;
-
-                // out custom uniforms
-                uniform vec3 uLightDir;
-                uniform float uMetalness;
-
-                // variables we pass to the fragment shader
-                varying float brightness;
+                // variables we pass to the fragment shader, where the lighting is evaluated
+                varying vec3 worldPos;
+                varying vec3 worldNormal;
 
             #endif
 
@@ -71,25 +65,18 @@ const createHatchMaterial = (device, textures) => {
                 // use functionality from transformCore to get a world position, which includes skinning and morphing as needed
                 mat4 modelMatrix = getModelMatrix();
                 vec3 localPos = getLocalPosition(vertex_position.xyz);
-                vec4 worldPos = modelMatrix * vec4(localPos, 1.0);
+                vec4 worldPosition = modelMatrix * vec4(localPos, 1.0);
 
                 #ifndef SHADOW_PASS
 
                     // use functionality from normalCore to get the world normal, which includes skinning and morphing as needed
                     mat3 normalMatrix = getNormalMatrix(modelMatrix);
                     vec3 localNormal = getLocalNormal(vertex_normal);
-                    vec3 worldNormal = normalize(normalMatrix * localNormal);
 
-                    // simple wrap-around diffuse lighting using normal and light direction
-                    float diffuse = dot(worldNormal, uLightDir) * 0.5 + 0.5;
-
-                    // a simple specular lighting
-                    vec3 viewDir = normalize(view_position - worldPos.xyz);
-                    vec3 reflectDir = reflect(-uLightDir, worldNormal);
-                    float specular = pow(max(dot(viewDir, reflectDir), 0.0), 9.0);
-
-                    // combine the lighting
-                    brightness = diffuse * (1.0 - uMetalness) + specular * uMetalness;
+                    // the lighting is evaluated per-pixel, so simply pass the world space position
+                    // and normal along to the fragment shader
+                    worldPos = worldPosition.xyz;
+                    worldNormal = normalMatrix * localNormal;
 
                 #endif
 
@@ -97,7 +84,7 @@ const createHatchMaterial = (device, textures) => {
                 uv0 = aUv0;
 
                 // Transform the geometry
-                gl_Position = matrix_viewProjection * worldPos;
+                gl_Position = matrix_viewProjection * worldPosition;
             }
         `,
         vertexWGSL: /* wgsl */ `
@@ -122,15 +109,9 @@ const createHatchMaterial = (device, textures) => {
                 // Functions added: getNormalMatrix, getLocalNormal
                 #include "normalCoreVS"
 
-                // engine supplied uniforms
-                uniform view_position: vec3f;
-
-                // out custom uniforms
-                uniform uLightDir: vec3f;
-                uniform uMetalness: f32;
-
-                // variables we pass to the fragment shader
-                varying brightness: f32;
+                // variables we pass to the fragment shader, where the lighting is evaluated
+                varying worldPos: vec3f;
+                varying worldNormal: vec3f;
 
             #endif
 
@@ -142,25 +123,18 @@ const createHatchMaterial = (device, textures) => {
                 // use functionality from transformCore to get a world position, which includes skinning and morphing as needed
                 let modelMatrix: mat4x4f = getModelMatrix();
                 let localPos: vec3f = getLocalPosition(vertex_position.xyz);
-                let worldPos: vec4f = modelMatrix * vec4f(localPos, 1.0);
+                let worldPosition: vec4f = modelMatrix * vec4f(localPos, 1.0);
 
                 #ifndef SHADOW_PASS
 
                     // use functionality from normalCore to get the world normal, which includes skinning and morphing as needed
                     let normalMatrix: mat3x3f = getNormalMatrix(modelMatrix);
                     let localNormal: vec3f = getLocalNormal(vertex_normal);
-                    let worldNormal: vec3f = normalize(normalMatrix * localNormal);
 
-                    // simple wrap-around diffuse lighting using normal and light direction
-                    let diffuse: f32 = dot(worldNormal, uniform.uLightDir) * 0.5 + 0.5;
-
-                    // a simple specular lighting
-                    let viewDir: vec3f = normalize(uniform.view_position - worldPos.xyz);
-                    let reflectDir: vec3f = reflect(-uniform.uLightDir, worldNormal);
-                    let specular: f32 = pow(max(dot(viewDir, reflectDir), 0.0), 9.0);
-
-                    // combine the lighting
-                    output.brightness = diffuse * (1.0 - uniform.uMetalness) + specular * uniform.uMetalness;
+                    // the lighting is evaluated per-pixel, so simply pass the world space position
+                    // and normal along to the fragment shader
+                    output.worldPos = worldPosition.xyz;
+                    output.worldNormal = normalMatrix * localNormal;
 
                 #endif
 
@@ -168,7 +142,7 @@ const createHatchMaterial = (device, textures) => {
                 output.uv0 = aUv0;
 
                 // Transform the geometry
-                output.position = uniform.matrix_viewProjection * worldPos;
+                output.position = uniform.matrix_viewProjection * worldPosition;
 
                 return output;
             }
@@ -191,7 +165,20 @@ const createHatchMaterial = (device, textures) => {
             varying vec2 uv0;
 
             #ifndef SHADOW_PASS
-                varying float brightness;
+
+                // this gives us the geometric normal of the triangle: getFlatNormal
+                #include "flatNormalPS"
+
+                varying vec3 worldPos;
+                varying vec3 worldNormal;
+
+                // engine supplied uniforms
+                uniform vec3 view_position;
+
+                // our custom uniforms
+                uniform vec3 uLightDir;
+                uniform float uMetalness;
+
             #endif
 
             uniform sampler2DArray uDiffuseMap;
@@ -220,6 +207,26 @@ const createHatchMaterial = (device, textures) => {
                     gl_FragColor = getShadowOutput();
 
                 #else
+
+                // the FLAT_SHADING define is added by the engine when Material#flatShading is
+                // enabled, and we use it to shade using the geometric normal of the triangle instead
+                // of the normal interpolated from the vertex normals
+                #ifdef FLAT_SHADING
+                    vec3 normal = getFlatNormal(worldPos);
+                #else
+                    vec3 normal = normalize(worldNormal);
+                #endif
+
+                // simple wrap-around diffuse lighting using normal and light direction
+                float diffuse = dot(normal, uLightDir) * 0.5 + 0.5;
+
+                // a simple specular lighting
+                vec3 viewDir = normalize(view_position - worldPos);
+                vec3 reflectDir = reflect(-uLightDir, normal);
+                float specular = pow(max(dot(viewDir, reflectDir), 0.0), 9.0);
+
+                // combine the lighting
+                float brightness = diffuse * (1.0 - uMetalness) + specular * uMetalness;
 
                 #ifdef TOON
 
@@ -265,7 +272,20 @@ const createHatchMaterial = (device, textures) => {
             varying uv0: vec2f;
 
             #ifndef SHADOW_PASS
-                varying brightness: f32;
+
+                // this gives us the geometric normal of the triangle: getFlatNormal
+                #include "flatNormalPS"
+
+                varying worldPos: vec3f;
+                varying worldNormal: vec3f;
+
+                // engine supplied uniforms
+                uniform view_position: vec3f;
+
+                // our custom uniforms
+                uniform uLightDir: vec3f;
+                uniform uMetalness: f32;
+
             #endif
 
             var uDiffuseMap: texture_2d_array<f32>;
@@ -302,15 +322,35 @@ const createHatchMaterial = (device, textures) => {
 
                 var colorLinear: half3;
 
+                // the FLAT_SHADING define is added by the engine when Material#flatShading is
+                // enabled, and we use it to shade using the geometric normal of the triangle instead
+                // of the normal interpolated from the vertex normals
+                #ifdef FLAT_SHADING
+                    let normal: vec3f = getFlatNormal(worldPos);
+                #else
+                    let normal: vec3f = normalize(worldNormal);
+                #endif
+
+                // simple wrap-around diffuse lighting using normal and light direction
+                let diffuse: f32 = dot(normal, uniform.uLightDir) * 0.5 + 0.5;
+
+                // a simple specular lighting
+                let viewDir: vec3f = normalize(uniform.view_position - worldPos);
+                let reflectDir: vec3f = reflect(-uniform.uLightDir, normal);
+                let specular: f32 = pow(max(dot(viewDir, reflectDir), 0.0), 9.0);
+
+                // combine the lighting
+                let brightness: f32 = diffuse * (1.0 - uniform.uMetalness) + specular * uniform.uMetalness;
+
                 #ifdef TOON
 
                     // just a simple toon shader - no texture sampling
-                    let level: half = half(i32(input.brightness * uniform.uNumTextures)) / half(uniform.uNumTextures);
+                    let level: half = half(i32(brightness * uniform.uNumTextures)) / half(uniform.uNumTextures);
                     colorLinear = level * half3(uniform.uColor);
 
                 #else
                     // brightness dictates the hatch texture level
-                    let level: half = (half(1.0) - half(input.brightness)) * half(uniform.uNumTextures);
+                    let level: half = (half(1.0) - half(brightness)) * half(uniform.uNumTextures);
 
                     // sample the two nearest levels and interpolate between them
                     let hatchUnder: half3 = half3(textureSample(uDiffuseMap, uDiffuseMapSampler, input.uv0 * uniform.uDensity, i32(floor(level))).xyz);

--- a/examples/src/examples/graphics/asset-viewer.controls.jsx
+++ b/examples/src/examples/graphics/asset-viewer.controls.jsx
@@ -1,4 +1,4 @@
-import { Button, Panel } from '@playcanvas/pcui/react';
+import { BindingTwoWay, BooleanInput, Button, LabelGroup, Panel } from '@playcanvas/pcui/react';
 
 /**
  * @import { Observer } from '@playcanvas/observer'
@@ -14,6 +14,13 @@ export function Controls({ observer }) {
         <Panel headerText='Asset'>
             <Button text='Previous' onClick={() => observer.emit('previous')} />
             <Button text='Next' onClick={() => observer.emit('next')} />
+            <LabelGroup text='Flat shading'>
+                <BooleanInput
+                    type='toggle'
+                    binding={new BindingTwoWay()}
+                    link={{ observer, path: 'flatShading' }}
+                />
+            </LabelGroup>
         </Panel>
     );
 }

--- a/examples/src/examples/graphics/asset-viewer.example.mjs
+++ b/examples/src/examples/graphics/asset-viewer.example.mjs
@@ -298,3 +298,16 @@ data.on('previous', () => {
 data.on('next', () => {
     jumpToAsset(1);
 });
+
+// Toggle flat shading on all materials in the scene. This shades each triangle using its geometric
+// normal instead of the normal interpolated from the vertex normals, giving a faceted look.
+data.on('flatShading:set', (value) => {
+    app.root.findComponents('render').forEach((render) => {
+        render.meshInstances.forEach((meshInstance) => {
+            meshInstance.material.flatShading = value;
+            meshInstance.material.update();
+        });
+    });
+});
+
+data.set('flatShading', false);

--- a/examples/src/examples/graphics/lights.controls.jsx
+++ b/examples/src/examples/graphics/lights.controls.jsx
@@ -93,6 +93,15 @@ export function Controls({ observer }) {
                     />
                 </LabelGroup>
             </Panel>
+            <Panel headerText='MATERIAL'>
+                <LabelGroup text='flat shading'>
+                    <BooleanInput
+                        type='toggle'
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'material.flatShading' }}
+                    />
+                </LabelGroup>
+            </Panel>
         </>
     );
 }

--- a/examples/src/examples/graphics/lights.example.mjs
+++ b/examples/src/examples/graphics/lights.example.mjs
@@ -177,6 +177,12 @@ data.set('lights', {
     }
 });
 
+// Setup material data. Note this is set up before the observer handler below is registered, so that
+// it does not fire for the initial value.
+data.set('material', {
+    flatShading: false
+});
+
 /** @type {{[key: string]: Entity }} */
 const lights = {};
 
@@ -303,6 +309,20 @@ app.on('update', (dt) => {
 
 data.on('*:set', (/** @type {string} */ path, value) => {
     const pathArray = path.split('.');
+
+    if (pathArray[0] === 'material' && pathArray[1] === 'flatShading') {
+        // Shade each triangle using its geometric normal instead of the normal interpolated from the
+        // vertex normals, giving the statue and the ground a faceted look. Note how this also affects
+        // the normal offset shadow bias, and so the shadows remain correct.
+        app.root.findComponents('render').forEach((render) => {
+            render.meshInstances.forEach((meshInstance) => {
+                meshInstance.material.flatShading = value;
+                meshInstance.material.update();
+            });
+        });
+        return;
+    }
+
     if (pathArray[2] === 'enabled') {
         lights[pathArray[1]].enabled = value;
     } else {

--- a/examples/src/examples/shaders/shader-hatch.controls.jsx
+++ b/examples/src/examples/shaders/shader-hatch.controls.jsx
@@ -76,6 +76,13 @@ export function Controls({ observer }) {
                         link={{ observer, path: 'data.toon' }}
                     />
                 </LabelGroup>
+                <LabelGroup text='Flat shading'>
+                    <BooleanInput
+                        type='toggle'
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'data.flatShading' }}
+                    />
+                </LabelGroup>
             </Panel>
         </>
     );

--- a/examples/src/examples/shaders/shader-hatch.example.mjs
+++ b/examples/src/examples/shaders/shader-hatch.example.mjs
@@ -278,6 +278,14 @@ data.on('*:set', (path, value) => {
             mat.update();
         });
     }
+    if (propertyName === 'flatShading') {
+        materials.forEach((mat) => {
+            // this adds a FLAT_SHADING define to the shader, which the hatch shader uses to shade
+            // using the geometric normal of the triangle instead of the interpolated vertex normal
+            mat.flatShading = value;
+            mat.update();
+        });
+    }
 });
 
 // Initial values
@@ -286,5 +294,6 @@ data.set('data', {
     metalness: 0.5,
     tonemapping: 0,
     fog: false,
-    toon: false
+    toon: false,
+    flatShading: false
 });

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -226,7 +226,7 @@ class Material {
      * Enables or disables flat shading. When enabled, the surface is shaded using the geometric
      * normal of the triangle the fragment belongs to, instead of the normal interpolated from the
      * vertex normals, giving the mesh a faceted look. This works on skinned and morphed geometry as
-     * well, and does not require the mesh to supply vertex normals.
+     * well.
      *
      * The geometric normal is oriented to match the winding of the triangle, as configured by
      * {@link Material#frontFace}, and so it agrees with correctly authored vertex normals. Flat

--- a/src/scene/materials/material.js
+++ b/src/scene/materials/material.js
@@ -223,6 +223,52 @@ class Material {
     }
 
     /**
+     * Enables or disables flat shading. When enabled, the surface is shaded using the geometric
+     * normal of the triangle the fragment belongs to, instead of the normal interpolated from the
+     * vertex normals, giving the mesh a faceted look. This works on skinned and morphed geometry as
+     * well, and does not require the mesh to supply vertex normals.
+     *
+     * The geometric normal is oriented to match the winding of the triangle, as configured by
+     * {@link Material#frontFace}, and so it agrees with correctly authored vertex normals. Flat
+     * shading therefore only changes the faceting - {@link Material#cull},
+     * {@link Material#frontFace} and {@link StandardMaterial#twoSidedLighting} all behave the same
+     * as they do for smooth shading.
+     *
+     * {@link StandardMaterial} and {@link LitMaterial} implement this automatically. For a
+     * {@link ShaderMaterial}, this adds a `FLAT_SHADING` define to the shader, which the supplied
+     * shader code needs to handle. The `flatNormalPS` chunk provides the `getFlatNormal` function
+     * used by the engine internally, and can be used for this:
+     *
+     * ```javascript
+     * #include "flatNormalPS"
+     * ...
+     * #ifdef FLAT_SHADING
+     *     vec3 normal = getFlatNormal(worldPos);
+     * #else
+     *     vec3 normal = normalize(interpolatedNormal);
+     * #endif
+     * ```
+     *
+     * As with other material properties, call {@link Material#update} after changing this.
+     *
+     * Defaults to false.
+     *
+     * @type {boolean}
+     */
+    set flatShading(value) {
+        this.setDefine('FLAT_SHADING', value);
+    }
+
+    /**
+     * Gets whether flat shading is enabled.
+     *
+     * @type {boolean}
+     */
+    get flatShading() {
+        return this.defines.has('FLAT_SHADING');
+    }
+
+    /**
      * Returns true if the material has custom shader chunks.
      *
      * @type {boolean}

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -144,6 +144,7 @@ const standardMaterialParameterTypes = {
     envAtlas: 'texture',
 
     twoSidedLighting: 'boolean',
+    flatShading: 'boolean',
     shadowCatcher: 'boolean'
 
     // nineSlicedMode

--- a/src/scene/shader-lib/glsl/chunks/common/frag/flat-normal.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/flat-normal.js
@@ -12,7 +12,10 @@ export default /* glsl */`
 // This is exact rather than an approximation - both screen space derivatives of the world position
 // lie in the plane of the triangle, and so their cross product is the normal of that plane. It works
 // on skinned and morphed geometry at no additional cost, as it operates on the final world space
-// positions, and it does not need the mesh to supply vertex normals at all.
+// positions.
+//
+// Note that the lit shader still declares the vertex normal attribute for flat shaded variants, as
+// other parts of the vertex shader depend on it, and so a mesh without normals is not supported yet.
 //
 // The returned normal is oriented to match the winding of the triangle, and so it agrees with
 // correctly authored vertex normals on both front and back faces. This keeps flat shading orthogonal

--- a/src/scene/shader-lib/glsl/chunks/common/frag/flat-normal.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/flat-normal.js
@@ -1,0 +1,41 @@
+export default /* glsl */`
+
+#ifndef TBNBASIS
+    #define TBNBASIS
+    uniform float tbnBasis;
+#endif
+
+// Returns the geometric normal of the triangle the fragment belongs to, in world space. Used to
+// give the surface a faceted (flat shaded) look, instead of using the smooth normal interpolated
+// from the vertex normals.
+//
+// This is exact rather than an approximation - both screen space derivatives of the world position
+// lie in the plane of the triangle, and so their cross product is the normal of that plane. It works
+// on skinned and morphed geometry at no additional cost, as it operates on the final world space
+// positions, and it does not need the mesh to supply vertex normals at all.
+//
+// The returned normal is oriented to match the winding of the triangle, and so it agrees with
+// correctly authored vertex normals on both front and back faces. This keeps flat shading orthogonal
+// to cull, frontFace and two sided lighting, which all behave as they do for smooth shading.
+//
+// Note that the derivatives require uniform control flow, and so this must not be called from inside
+// a conditionally executed branch.
+vec3 getFlatNormal(vec3 worldPos) {
+
+    vec3 normal = cross(dFdx(worldPos), dFdy(worldPos));
+
+    // Two independent sign corrections, neither of which double counts the other:
+    // - tbnBasis compensates for the Y flip applied to the projection matrix when rendering with
+    //   flipY, and for WebGPU's Y-down framebuffer space. Both flip the sign of the screen space
+    //   derivatives, and correcting for them leaves the cross product pointing at the viewer. See
+    //   TBN.js, which uses tbnBasis for the same reason.
+    // - gl_FrontFacing then flips it back to the orientation implied by the winding. It is itself
+    //   unaffected by flipY, which reverses the window space winding but is also folded into the
+    //   front face state, and so cancels out.
+    float basis = gl_FrontFacing ? tbnBasis : -tbnBasis;
+
+    // degenerate triangles generate a zero length normal, avoid normalizing those
+    float len = length(normal);
+    return len > 0.0 ? normal * (basis / len) : vec3(0.0, 1.0, 0.0);
+}
+`;

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/TBN.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/TBN.js
@@ -9,7 +9,10 @@ export default /* glsl */`
 #endif
 
 #if defined(TBN_DERIVATIVES)
-    uniform float tbnBasis;
+    #ifndef TBNBASIS
+        #define TBNBASIS
+        uniform float tbnBasis;
+    #endif
 #endif
 
 void getTBN(vec3 tangent, vec3 binormal, vec3 normal) {

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardMain.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardMain.js
@@ -21,7 +21,11 @@ void main(void) {
     #endif
 
     #ifdef LIT_NEEDS_NORMAL
-        dVertexNormalW = normalize(vNormalW);
+        #ifdef FLAT_SHADING
+            dVertexNormalW = getFlatNormal(vPositionW);
+        #else
+            dVertexNormalW = normalize(vNormalW);
+        #endif
 
         #ifdef LIT_TANGENTS
             #if defined(LIT_HEIGHTS) || defined(LIT_USE_NORMALS) || defined(LIT_USE_CLEARCOAT_NORMALS) || defined(LIT_GGX_SPECULAR)

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardPreCode.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/pass-forward/litForwardPreCode.js
@@ -16,6 +16,11 @@ export default /* glsl */`
     #include "baseNineSlicedTiledPS"
 #endif
 
+// flat shading
+#ifdef FLAT_SHADING
+    #include "flatNormalPS"
+#endif
+
 // TBN
 #ifdef LIT_TBN
     #include "TBNPS"

--- a/src/scene/shader-lib/glsl/collections/shader-chunks-glsl.js
+++ b/src/scene/shader-lib/glsl/collections/shader-chunks-glsl.js
@@ -37,6 +37,7 @@ import envAtlasPS from '../chunks/common/frag/envAtlas.js';
 import envProcPS from '../chunks/common/frag/envProc.js';
 import falloffInvSquaredPS from '../chunks/lit/frag/falloffInvSquared.js';
 import falloffLinearPS from '../chunks/lit/frag/falloffLinear.js';
+import flatNormalPS from '../chunks/common/frag/flat-normal.js';
 import floatAsUintPS from '../chunks/common/frag/float-as-uint.js';
 import sceneTexturesPS from '../chunks/common/frag/scene-textures.js';
 import fogPS from '../chunks/common/frag/fog.js';
@@ -202,6 +203,7 @@ const shaderChunksGLSL = {
     envProcPS,
     falloffInvSquaredPS,
     falloffLinearPS,
+    flatNormalPS,
     floatAsUintPS,
     sceneTexturesPS,
     fogPS,

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/flat-normal.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/flat-normal.js
@@ -12,7 +12,10 @@ export default /* wgsl */`
 // This is exact rather than an approximation - both screen space derivatives of the world position
 // lie in the plane of the triangle, and so their cross product is the normal of that plane. It works
 // on skinned and morphed geometry at no additional cost, as it operates on the final world space
-// positions, and it does not need the mesh to supply vertex normals at all.
+// positions.
+//
+// Note that the lit shader still declares the vertex normal attribute for flat shaded variants, as
+// other parts of the vertex shader depend on it, and so a mesh without normals is not supported yet.
 //
 // The returned normal is oriented to match the winding of the triangle, and so it agrees with
 // correctly authored vertex normals on both front and back faces. This keeps flat shading orthogonal

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/flat-normal.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/flat-normal.js
@@ -1,0 +1,41 @@
+export default /* wgsl */`
+
+#ifndef TBNBASIS
+    #define TBNBASIS
+    uniform tbnBasis: f32;
+#endif
+
+// Returns the geometric normal of the triangle the fragment belongs to, in world space. Used to
+// give the surface a faceted (flat shaded) look, instead of using the smooth normal interpolated
+// from the vertex normals.
+//
+// This is exact rather than an approximation - both screen space derivatives of the world position
+// lie in the plane of the triangle, and so their cross product is the normal of that plane. It works
+// on skinned and morphed geometry at no additional cost, as it operates on the final world space
+// positions, and it does not need the mesh to supply vertex normals at all.
+//
+// The returned normal is oriented to match the winding of the triangle, and so it agrees with
+// correctly authored vertex normals on both front and back faces. This keeps flat shading orthogonal
+// to cull, frontFace and two sided lighting, which all behave as they do for smooth shading.
+//
+// Note that the derivatives require uniform control flow, and so this must not be called from inside
+// a conditionally executed branch.
+fn getFlatNormal(worldPos: vec3f) -> vec3f {
+
+    let normal: vec3f = cross(dpdx(worldPos), dpdy(worldPos));
+
+    // Two independent sign corrections, neither of which double counts the other:
+    // - tbnBasis compensates for the Y flip applied to the projection matrix when rendering with
+    //   flipY, and for WebGPU's Y-down framebuffer space. Both flip the sign of the screen space
+    //   derivatives, and correcting for them leaves the cross product pointing at the viewer. See
+    //   TBN.js, which uses tbnBasis for the same reason.
+    // - pcFrontFacing then flips it back to the orientation implied by the winding. It is itself
+    //   unaffected by flipY, which reverses the window space winding but is also folded into the
+    //   front face state, and so cancels out.
+    let basis: f32 = select(-uniform.tbnBasis, uniform.tbnBasis, pcFrontFacing);
+
+    // degenerate triangles generate a zero length normal, avoid normalizing those
+    let len: f32 = length(normal);
+    return select(vec3f(0.0, 1.0, 0.0), normal * (basis / len), len > 0.0);
+}
+`;

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/TBN.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/TBN.js
@@ -9,7 +9,10 @@ export default /* wgsl */`
 #endif
 
 #if defined(TBN_DERIVATIVES)
-    uniform tbnBasis: f32;
+    #ifndef TBNBASIS
+        #define TBNBASIS
+        uniform tbnBasis: f32;
+    #endif
 #endif
 
 fn getTBN(tangent: vec3f, binormal: vec3f, normal: vec3f) {

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardMain.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardMain.js
@@ -22,7 +22,11 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
     #endif
 
     #ifdef LIT_NEEDS_NORMAL
-        dVertexNormalW = normalize(vNormalW);
+        #ifdef FLAT_SHADING
+            dVertexNormalW = getFlatNormal(vPositionW);
+        #else
+            dVertexNormalW = normalize(vNormalW);
+        #endif
 
         #ifdef LIT_TANGENTS
             #if defined(LIT_HEIGHTS) || defined(LIT_USE_NORMALS) || defined(LIT_USE_CLEARCOAT_NORMALS) || defined(LIT_GGX_SPECULAR)

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardPreCode.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/pass-forward/litForwardPreCode.js
@@ -16,6 +16,11 @@ export default /* wgsl */`
     #include "baseNineSlicedTiledPS"
 #endif
 
+// flat shading
+#ifdef FLAT_SHADING
+    #include "flatNormalPS"
+#endif
+
 // TBN
 #ifdef LIT_TBN
     #include "TBNPS"

--- a/src/scene/shader-lib/wgsl/collections/shader-chunks-wgsl.js
+++ b/src/scene/shader-lib/wgsl/collections/shader-chunks-wgsl.js
@@ -37,6 +37,7 @@ import envAtlasPS from '../chunks/common/frag/envAtlas.js';
 import envProcPS from '../chunks/common/frag/envProc.js';
 import falloffInvSquaredPS from '../chunks/lit/frag/falloffInvSquared.js';
 import falloffLinearPS from '../chunks/lit/frag/falloffLinear.js';
+import flatNormalPS from '../chunks/common/frag/flat-normal.js';
 import floatAsUintPS from '../chunks/common/frag/float-as-uint.js';
 import sceneTexturesPS from '../chunks/common/frag/scene-textures.js';
 import fogPS from '../chunks/common/frag/fog.js';
@@ -203,6 +204,7 @@ const shaderChunksWGSL = {
     envProcPS,
     falloffInvSquaredPS,
     falloffLinearPS,
+    flatNormalPS,
     floatAsUintPS,
     sceneTexturesPS,
     fogPS,

--- a/test/scene/materials/standard-material.test.mjs
+++ b/test/scene/materials/standard-material.test.mjs
@@ -145,6 +145,7 @@ describe('StandardMaterial', function () {
         expect(material.emissiveVertexColorChannel).to.equal('rgb');
 
         expect(material.enableGGXSpecular).to.equal(false);
+        expect(material.flatShading).to.equal(false);
         expect(material.fresnelModel).to.equal(FRESNEL_SCHLICK);
 
         expect(material.gloss).to.equal(0.25);


### PR DESCRIPTION
Adds flat shading, resolving #239. When enabled, each fragment is shaded using the geometric normal of its triangle instead of the normal interpolated from the vertex normals, giving the surface a faceted look.

The normal is taken from the screen space derivatives of the world position. This is exact rather than an approximation - both derivatives lie in the plane of the triangle, so their cross product is the normal of that plane - and it works on skinned and morphed geometry at no additional cost, as it operates on the final world space positions. It also does not need the mesh to supply vertex normals at all.

The returned normal is oriented to match the triangle winding, so it agrees with correctly authored vertex normals on both front and back faces. Flat shading therefore only changes the faceting: `cull`, `frontFace` and `twoSidedLighting` all behave as they do for smooth shading.

**Changes:**
- New `flatNormalPS` chunk (GLSL and WGSL) providing `getFlatNormal(worldPos)`
- `Material#flatShading`, backed by a `FLAT_SHADING` define. As all material types resolve their defines through `ShaderUtils.getCoreDefines`, this needs no lit option plumbing, and it reaches `StandardMaterial`, `LitMaterial` and `ShaderMaterial` alike
- The `tbnBasis` uniform declaration in `TBN.js` is now behind an `#ifndef` guard so it can be shared with the new chunk
- Two independent sign corrections that do not double count: `tbnBasis` compensates for the flipY projection flip and WebGPU's Y-down framebuffer space, then `gl_FrontFacing` / `pcFrontFacing` restores the winding orientation

**API Changes:**
- Added `Material#flatShading` (boolean, defaults to `false`). As with other material properties, call `Material#update()` after changing it
- Added `flatShading` to the standard material asset parameters
- Added the `flatNormalPS` shader chunk, usable from `ShaderMaterial` shaders via `#include "flatNormalPS"` together with `#ifdef FLAT_SHADING`

**Examples:**
- `graphics/asset-viewer` - flat shading toggle, exercising it across transmission, volume, IOR, iridescence, sheen and clearcoat materials
- `graphics/lights` - flat shading toggle on the statue and ground, showing that shadows and light cookies remain correct
- `shaders/shader-hatch` - flat shading toggle demonstrating the `ShaderMaterial` route. Its lighting moved from the vertex to the fragment shader, which derivatives require, so it is now evaluated per pixel