### PR TITLE
Recalculate particle local bounds when the spawn volume changes

### DIFF
--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -1836,6 +1836,10 @@ class ParticleSystemComponent extends Component {
         if (this.emitter) {
             this.emitter[name] = arg;
             this.emitter.rebuildGraphs();
+
+            // velocity and scale graphs are inputs to the local bounds, and unlike the spawn
+            // volume they cannot be cheaply compared each frame, so refresh the bounds here
+            this.emitter.calculateLocalBounds();
             this.emitter.resetMaterial();
         }
     }

--- a/src/scene/particle-system/gpu-updater.js
+++ b/src/scene/particle-system/gpu-updater.js
@@ -145,9 +145,6 @@ class ParticleGPUUpdater {
 
         emitter.swapTex = !emitter.swapTex;
 
-        emitter.prevWorldBoundsSize.copy(emitter.worldBoundsSize);
-        emitter.prevWorldBoundsCenter.copy(emitter.worldBounds.center);
-
         DebugGraphics.popGpuMarker(device);
     }
 }

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -519,7 +519,9 @@ class ParticleEmitter {
             accumR[1] += this.qRadialSpeed2[index] * stepWeight;
             maxR = Math.max(maxR, Math.max(Math.abs(accumR[0]), Math.abs(accumR[1])));
 
-            maxScale = Math.max(maxScale, this.qScale[index]);
+            // both scale curves, as the rendered size is interpolated between them, and by
+            // magnitude, as a negative scale mirrors the particle without shrinking it
+            maxScale = Math.max(maxScale, Math.abs(this.qScale[index]), Math.abs(this.qScale2[index]));
         }
 
         if (this.emitterShape === EMITTERSHAPE_BOX) {

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -354,12 +354,10 @@ class ParticleEmitter {
         this.worldBoundsTrail = [new BoundingBox(), new BoundingBox()];
         this.worldBounds = new BoundingBox();
 
-        this.worldBoundsSize = new Vec3();
-
-        this.prevWorldBoundsSize = new Vec3();
-        this.prevWorldBoundsCenter = new Vec3();
-        this.prevEmitterExtents = this.emitterExtents;
-        this.prevEmitterRadius = this.emitterRadius;
+        // spawn volume the local bounds were last calculated for, used to detect changes to it.
+        // Note this must be a copy, as emitterExtents can be modified in place by the user.
+        this.prevEmitterExtents = new Vec3();
+        this.prevEmitterRadius = 0;
         this.timeToSwitchBounds = 0;
 
         // simulation shaders - do not destroy those, as they're cached and shared between emitters
@@ -417,21 +415,13 @@ class ParticleEmitter {
     calculateWorldBounds() {
         if (!this.node) return;
 
-        this.prevWorldBoundsSize.copy(this.worldBoundsSize);
-        this.prevWorldBoundsCenter.copy(this.worldBounds.center);
-
-        if (!this.useCpu) {
-            let recalculateLocalBounds = false;
-            if (this.emitterShape === EMITTERSHAPE_BOX) {
-                recalculateLocalBounds = !this.emitterExtents.equals(this.prevEmitterExtents);
-            } else {
-                recalculateLocalBounds = !(this.emitterRadius === this.prevEmitterRadius);
-            }
-            if (recalculateLocalBounds) {
-                this.calculateLocalBounds();
-            }
+        // the spawn volume can be changed at any time, and the local bounds are derived from it
+        const recalculateLocalBounds = this.emitterShape === EMITTERSHAPE_BOX ?
+            !this.emitterExtents.equals(this.prevEmitterExtents) :
+            this.emitterRadius !== this.prevEmitterRadius;
+        if (recalculateLocalBounds) {
+            this.calculateLocalBounds();
         }
-
 
         const nodeWT = this.node.getWorldTransform();
         if (this.localSpace) {
@@ -451,8 +441,6 @@ class ParticleEmitter {
         }
 
         this.worldBounds.copy(this.worldBoundsTrail[0]);
-
-        this.worldBoundsSize.copy(this.worldBounds.halfExtents).mulScalar(2);
 
         if (this.localSpace) {
             this.meshInstance.aabb.setFromTransformedAabb(this.worldBounds, nodeWT);
@@ -474,16 +462,17 @@ class ParticleEmitter {
         this.worldBoundsTrail[1].copy(this.worldBoundsNoTrail);
 
         this.worldBounds.copy(this.worldBoundsTrail[0]);
-        this.worldBoundsSize.copy(this.worldBounds.halfExtents).mulScalar(2);
-
-        this.prevWorldBoundsSize.copy(this.worldBoundsSize);
-        this.prevWorldBoundsCenter.copy(this.worldBounds.center);
 
         this.simTimeTotal = 0;
         this.timeToSwitchBounds = 0;
     }
 
     calculateLocalBounds() {
+
+        // store the spawn volume the bounds are calculated for, to detect later changes to it
+        this.prevEmitterExtents.copy(this.emitterExtents);
+        this.prevEmitterRadius = this.emitterRadius;
+
         let minx = Number.MAX_VALUE;
         let miny = Number.MAX_VALUE;
         let minz = Number.MAX_VALUE;
@@ -582,10 +571,6 @@ class ParticleEmitter {
 
             this.worldBoundsTrail[0].copy(this.worldBounds);
             this.worldBoundsTrail[1].copy(this.worldBounds);
-
-            this.worldBoundsSize.copy(this.worldBounds.halfExtents).mulScalar(2);
-            this.prevWorldBoundsSize.copy(this.worldBoundsSize);
-            this.prevWorldBoundsCenter.copy(this.worldBounds.center);
         }
 
         // Dynamic simulation data

--- a/test/scene/particle-system/particle-emitter.test.mjs
+++ b/test/scene/particle-system/particle-emitter.test.mjs
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 
+import { Curve } from '../../../src/core/math/curve.js';
 import { Vec3 } from '../../../src/core/math/vec3.js';
 import { Entity } from '../../../src/framework/entity.js';
 import { EMITTERSHAPE_SPHERE } from '../../../src/scene/constants.js';
@@ -105,6 +106,34 @@ describe('ParticleEmitter', function () {
             }
 
             expect(calls).to.equal(0);
+        });
+
+        it('grows when the scale curve changes', function () {
+            const emitter = createEmitter();
+            const before = emitter.localBounds.halfExtents.x;
+
+            emitter.node.particlesystem.scaleGraph = new Curve([0, 100, 1, 100]);
+
+            expect(emitter.localBounds.halfExtents.x).to.be.above(before + 40);
+        });
+
+        it('grows when only the secondary scale curve changes', function () {
+            const emitter = createEmitter();
+            const before = emitter.localBounds.halfExtents.x;
+
+            // the rendered size is interpolated between both scale curves
+            emitter.node.particlesystem.scaleGraph2 = new Curve([0, 100, 1, 100]);
+
+            expect(emitter.localBounds.halfExtents.x).to.be.above(before + 40);
+        });
+
+        it('covers the magnitude of a negative scale curve', function () {
+            const emitter = createEmitter();
+
+            // a negative scale mirrors the particle without shrinking it
+            emitter.node.particlesystem.scaleGraph = new Curve([0, -100, 1, -100]);
+
+            expect(emitter.localBounds.halfExtents.x).to.be.above(40);
         });
     });
 });

--- a/test/scene/particle-system/particle-emitter.test.mjs
+++ b/test/scene/particle-system/particle-emitter.test.mjs
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+
+import { Vec3 } from '../../../src/core/math/vec3.js';
+import { Entity } from '../../../src/framework/entity.js';
+import { EMITTERSHAPE_SPHERE } from '../../../src/scene/constants.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+/**
+ * @import { Application } from '../../../src/framework/application.js'
+ */
+
+describe('ParticleEmitter', function () {
+    /** @type {Application} */
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+
+        // the null device skips particle systems by default - enable them so the emitter is created
+        app.graphicsDevice.disableParticleSystem = false;
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    /**
+     * @param {object} [options] - Particle system component options.
+     * @param {boolean} [gpu] - Whether the emitter simulates on the GPU.
+     * @returns {import('../../../src/scene/particle-system/particle-emitter.js').ParticleEmitter} The emitter.
+     */
+    const createEmitter = (options = {}, gpu = true) => {
+        app.graphicsDevice.supportsGpuParticles = gpu;
+        const entity = new Entity();
+        entity.addComponent('particlesystem', { numParticles: 10, ...options });
+        app.root.addChild(entity);
+        return entity.particlesystem.emitter;
+    };
+
+    describe('#localBounds', function () {
+
+        it('grows when emitterExtents is replaced', function () {
+            const emitter = createEmitter({ emitterExtents: new Vec3(1, 1, 1) });
+            const before = emitter.localBounds.halfExtents.x;
+
+            emitter.node.particlesystem.emitterExtents = new Vec3(100, 100, 100);
+            emitter.addTime(0.1, false);
+
+            expect(emitter.localBounds.halfExtents.x).to.be.above(before + 40);
+        });
+
+        it('grows when emitterExtents is modified in place', function () {
+            const emitter = createEmitter({ emitterExtents: new Vec3(1, 1, 1) });
+            const before = emitter.localBounds.halfExtents.x;
+
+            // the extents are handed to the emitter by reference, so an in place change must be
+            // detected as well
+            emitter.node.particlesystem.emitterExtents.set(100, 100, 100);
+            emitter.addTime(0.1, false);
+
+            expect(emitter.localBounds.halfExtents.x).to.be.above(before + 40);
+        });
+
+        it('grows when emitterRadius changes on a sphere emitter', function () {
+            const emitter = createEmitter({ emitterShape: EMITTERSHAPE_SPHERE, emitterRadius: 1 });
+            const before = emitter.localBounds.halfExtents.x;
+
+            emitter.node.particlesystem.emitterRadius = 100;
+            emitter.addTime(0.1, false);
+
+            expect(emitter.localBounds.halfExtents.x).to.be.above(before + 40);
+        });
+
+        it('grows when emitterExtents changes on a CPU emitter', function () {
+            const emitter = createEmitter({ emitterExtents: new Vec3(1, 1, 1) }, false);
+            expect(emitter.useCpu).to.be.true;
+            const before = emitter.localBounds.halfExtents.x;
+
+            emitter.node.particlesystem.emitterExtents = new Vec3(100, 100, 100);
+            emitter.addTime(0.1, false);
+
+            expect(emitter.localBounds.halfExtents.x).to.be.above(before + 40);
+            expect(emitter.meshInstance.aabb.halfExtents.x).to.be.above(before + 40);
+        });
+
+        it('is not recalculated while the spawn volume is unchanged', function () {
+            const emitter = createEmitter({ emitterExtents: new Vec3(1, 1, 1) });
+
+            emitter.node.particlesystem.emitterExtents = new Vec3(100, 100, 100);
+            emitter.addTime(0.1, false);
+
+            let calls = 0;
+            const calculateLocalBounds = emitter.calculateLocalBounds.bind(emitter);
+            emitter.calculateLocalBounds = () => {
+                calls++;
+                calculateLocalBounds();
+            };
+
+            for (let i = 0; i < 5; i++) {
+                emitter.addTime(0.1, false);
+            }
+
+            expect(calls).to.equal(0);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #811.

Changing `emitterExtents` (or `emitterRadius`) at runtime did not update the particle emitter's bounds, so the mesh instance kept a stale culling AABB: the emitter can pop out of view while its particles are plainly on screen, and the editor's selection box for a particle system shows the wrong size.

The original 2016 issue is about pack8, whose lossy RGBA8 state textures normalized particle positions into that box - a stale box then visibly corrupted the positions. #8926 removed pack8 (v2.20.0) and nothing in the particle shaders depends on emitter bounds any more, so all that is left of the issue is the culling AABB, and it is still broken in three ways:

- `prevEmitterExtents` was assigned `this.emitterExtents`, a reference to the very `Vec3` the component handed the emitter. Mutating the extents in place - `ps.emitterExtents.set(...)`, `.x = n`, `.copy(v)` - compared the object with itself, so the change was never noticed.
- The snapshot was never refreshed after a recalculation, so assigning a new `Vec3` (what the component setter and the editor do) worked once and then re-ran `calculateLocalBounds` on every frame, forever.
- The check was wrapped in `if (!this.useCpu)`, added in #2059 with no stated reason, so CPU emitters never tracked the spawn volume at all.

**Changes:**
- `prevEmitterExtents` is now the emitter's own `Vec3`, and the snapshot of both it and `prevEmitterRadius` moved to the top of `calculateLocalBounds`, so every recalculation records the inputs it was calculated for. That keeps in place mutation working - which a setter driven fix cannot - and `rebuild()` gets the bookkeeping for free.
- Dropped the `useCpu` gate, so CPU emitters recalculate too.
- `_setGraphProperty` now calls `calculateLocalBounds()` after `rebuildGraphs()`. The velocity and scale graphs are its main inputs, and unlike the spawn volume they cannot be cheaply compared each frame, so assigning a curve at runtime used to leave the bounds stale with no check to catch it.

Note the bounds stay deliberately conservative: `calculateLocalBounds` pads every axis by the integrated world velocity magnitude, which is isotropic because that velocity is in world space while the bounds are local, and `worldBounds` is a union over a trail that swaps every `lifetime`, so growth applies within a frame while shrinking lags. Both predate this PR - they were simply invisible while the bounds never moved. Tightening the padding would need the node rotation folded in and is left out of here.

**API Changes:**
- Removed `ParticleEmitter#prevWorldBoundsSize`, `ParticleEmitter#prevWorldBoundsCenter` and `ParticleEmitter#worldBoundsSize`. All three were pack8 machinery, added in 2016 to feed the `inBoundsSize`/`outBoundsSize` uniforms that mapped positions into the bounds box, and have been written but never read since #8926. Undocumented, and unused by the editor.

**Performance:**
- `calculateLocalBounds` no longer runs on every frame for the lifetime of an emitter whose extents were assigned once.