### PR TITLE
Cull omni shadow casters against all six faces in a single pass

### DIFF
--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -90,9 +90,17 @@ class ShadowRendererLocal {
                 }
             }
 
-            // cull shadow casters
             shadowCam.updateFrustum();
-            this.shadowRenderer.cullShadowCasters(comp, light, lightRenderData.visibleCasters, shadowCam, casters);
+
+            // cull shadow casters - a spot light has a single face and is culled against its
+            // frustum, an omni light is culled against all six faces in a single pass below
+            if (type === LIGHTTYPE_SPOT) {
+                this.shadowRenderer.cullShadowCasters(comp, light, lightRenderData.visibleCasters, shadowCam, casters);
+            }
+        }
+
+        if (type === LIGHTTYPE_OMNI) {
+            this.shadowRenderer.cullShadowCastersOmni(comp, light, casters);
         }
     }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -1,6 +1,7 @@
 import { Debug } from '../../core/debug.js';
 import { now } from '../../core/time.js';
 import { Color } from '../../core/math/color.js';
+import { math } from '../../core/math/math.js';
 import { Mat4 } from '../../core/math/mat4.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Vec4 } from '../../core/math/vec4.js';
@@ -36,6 +37,12 @@ import { BlendState } from '../../platform/graphics/blend-state.js';
  */
 
 const tempSet = new Set();
+
+// per-face scratch state for the omni cull - the visible caster list and the shadow camera of each
+// of the six cube map faces of the light currently being culled
+const _faceLists = [];
+const _faceCameras = [];
+
 const shadowCamView = new Mat4();
 const shadowCamViewProj = new Mat4();
 const pixelOffset = new Float32Array(2);
@@ -71,6 +78,14 @@ class ShadowRenderer {
      * @private
      */
     shadowPassCache = [];
+
+    /**
+     * Reusable list of shadow caster arrays, see {@link ShadowRenderer#_collectCasterLists}.
+     *
+     * @type {MeshInstance[][]}
+     * @private
+     */
+    _casterLists = [];
 
     /**
      * @param {Renderer} renderer - The renderer.
@@ -169,10 +184,40 @@ class ShadowRenderer {
 
         visible.length = 0;
 
+        const casterLists = this._collectCasterLists(comp, light, casters);
+        for (let i = 0; i < casterLists.length; i++) {
+            this._cullShadowCastersInternal(casterLists[i], visible, camera);
+        }
+
+        // this sorts the shadow casters by the shader id
+        visible.sort(this.sortCompareShader);
+
+        // event after culling - the camera is null as this is internal (shadow) culling rather
+        // than culling for a user camera
+        this.renderer.scene?.fire(EVENT_POSTCULL, null);
+    }
+
+    /**
+     * Collects the lists of shadow casters used by the light: either the supplied array of casters,
+     * or the shadow casters of each layer the light is part of.
+     *
+     * @param {LayerComposition} comp - The layer composition used as a source of shadow casters,
+     * if those are not provided directly.
+     * @param {Light} light - The light.
+     * @param {MeshInstance[]} [casters] - Optional array of mesh instances to use as casters.
+     * @returns {MeshInstance[][]} The lists of shadow casters. This is reused between calls, and so
+     * is only valid until the next call.
+     * @private
+     */
+    _collectCasterLists(comp, light, casters) {
+
+        const lists = this._casterLists;
+        lists.length = 0;
+
         // if the casters are supplied, use them
         if (casters) {
 
-            this._cullShadowCastersInternal(casters, visible, camera);
+            lists.push(casters);
 
         } else {    // otherwise, get them from the layer composition
 
@@ -187,7 +232,7 @@ class ShadowRenderer {
                     if (!tempSet.has(layer)) {
                         tempSet.add(layer);
 
-                        this._cullShadowCastersInternal(layer.shadowCasters, visible, camera);
+                        lists.push(layer.shadowCasters);
                     }
                 }
             }
@@ -195,8 +240,194 @@ class ShadowRenderer {
             tempSet.clear();
         }
 
+        return lists;
+    }
+
+    /**
+     * Culls the shadow casters used by an omni light against all six of its cube map faces in a
+     * single pass over the casters, storing the visible mesh instances in the per-face light render
+     * data. This replaces one full pass over the casters per face.
+     *
+     * The six shadow cameras of an omni light are axis aligned in world space - see
+     * {@link LightCamera.pointLightRotations}, and note that {@link ShadowRendererLocal#cull} only
+     * sets the position of an omni light's shadow cameras, never their rotation. Light space is
+     * therefore world space translated by the light position, and each face's frustum is bounded by
+     * a near and a far plane perpendicular to the face axis, plus four side planes through the
+     * light position with the slope of the face's field of view. Testing a caster's bounding sphere
+     * against those planes in light space is a handful of comparisons per face, and uses the same
+     * planes {@link Frustum#containsSphere} would, so the result is the same set of casters (up to
+     * the slab rejection below, which is tighter than a plane test near the frustum corners).
+     *
+     * @param {LayerComposition} comp - The layer composition used as a source of shadow casters,
+     * if those are not provided directly.
+     * @param {Light} light - The omni light.
+     * @param {MeshInstance[]} [casters] - Optional array of mesh instances to use as casters.
+     */
+    cullShadowCastersOmni(comp, light, casters) {
+
+        Debug.assert(light._type === LIGHTTYPE_OMNI);
+
+        // event before culling - the camera is null as this is internal (shadow) culling rather
+        // than culling for a user camera
+        this.renderer.scene?.fire(EVENT_PRECULL, null);
+
+        // per-face visible caster lists and shadow cameras
+        for (let face = 0; face < 6; face++) {
+            const lightRenderData = light.getRenderData(null, face);
+            const visible = lightRenderData.visibleCasters;
+            visible.length = 0;
+            _faceLists[face] = visible;
+            _faceCameras[face] = lightRenderData.shadowCamera;
+        }
+
+        // light space is world space translated by the light position
+        const lightPos = light._node.getPosition();
+        const lightX = lightPos.x;
+        const lightY = lightPos.y;
+        const lightZ = lightPos.z;
+
+        // face frustum planes, shared by all six faces: the near and far planes are perpendicular to
+        // the face axis, and the four side planes have the slope of the face's field of view - which
+        // is slightly wider than 90 degrees when rendering to the shadow atlas
+        const shadowCam = _faceCameras[0];
+        const near = shadowCam.nearClip;
+        const far = shadowCam.farClip;
+        const slope = Math.tan(shadowCam.fov * 0.5 * math.DEG_TO_RAD);
+
+        // side plane normals are (slope, -+1) and so need scaling to be normalized
+        const sideScale = Math.sqrt(1 + slope * slope);
+
+        // The union of the six face frusta is bounded by the axis aligned cube of this half side.
+        // Note that this is larger than the light's range: each face's far plane is perpendicular to
+        // the face axis, so the corners of the frusta stick out past the range sphere, and rejecting
+        // against a sphere here would wrongly drop casters in those corners.
+        const bounds = far * slope;
+
+        Debug.call(() => {
+            // the face order the light space classification below relies on
+            const axes = [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]];
+            for (let face = 0; face < 6; face++) {
+                const forward = _faceCameras[face]._node.forward;
+                const axis = axes[face];
+                Debug.assert(Math.abs(forward.x - axis[0]) < 1e-4 &&
+                    Math.abs(forward.y - axis[1]) < 1e-4 &&
+                    Math.abs(forward.z - axis[2]) < 1e-4,
+                `Omni shadow face ${face} is not aligned to the expected world axis ${axis}, the culling in cullShadowCastersOmni does not apply.`);
+            }
+        });
+
+        const casterLists = this._collectCasterLists(comp, light, casters);
+        for (let listIndex = 0; listIndex < casterLists.length; listIndex++) {
+
+            const meshInstances = casterLists[listIndex];
+            const numInstances = meshInstances.length;
+            for (let i = 0; i < numInstances; i++) {
+
+                const meshInstance = meshInstances[i];
+                if (!meshInstance.castShadow) {
+                    continue;
+                }
+
+                // mesh instances with culling disabled are visible in all faces, and those with a
+                // custom visibility function need to evaluate it for each face's shadow camera
+                if (!meshInstance.cull || meshInstance.isVisibleFunc) {
+                    for (let face = 0; face < 6; face++) {
+                        if (!meshInstance.cull || meshInstance._isVisible(_faceCameras[face])) {
+                            meshInstance.visibleThisFrame = true;
+                            _faceLists[face].push(meshInstance);
+                        }
+                    }
+                    continue;
+                }
+
+                if (!meshInstance.visible) {
+                    continue;
+                }
+
+                // caster's bounding sphere in light space
+                const center = meshInstance.aabb.center;    // this line evaluates aabb
+                const radius = meshInstance._aabb.halfExtents.length();
+                const x = center.x - lightX;
+                const y = center.y - lightY;
+                const z = center.z - lightZ;
+
+                // reject casters outside the bounds of all six faces
+                const slab = bounds + radius;
+                if (x > slab || x < -slab || y > slab || y < -slab || z > slab || z < -slab) {
+                    continue;
+                }
+
+                // a sphere is outside a plane when its signed distance is <= -radius, so for each
+                // face: axial > near - radius, axial < far + radius, and (slope * axial -+ lateral)
+                // > -radius * sideScale for the two lateral axes
+                const nearLimit = near - radius;
+                const farLimit = far + radius;
+                const sideLimit = -radius * sideScale;
+                const slopeX = slope * x;
+                const slopeY = slope * y;
+                const slopeZ = slope * z;
+                let visible = false;
+
+                // +X
+                if (x > nearLimit && x < farLimit &&
+                    slopeX - y > sideLimit && slopeX + y > sideLimit &&
+                    slopeX - z > sideLimit && slopeX + z > sideLimit) {
+                    _faceLists[0].push(meshInstance);
+                    visible = true;
+                }
+
+                // -X
+                if (-x > nearLimit && -x < farLimit &&
+                    -slopeX - y > sideLimit && -slopeX + y > sideLimit &&
+                    -slopeX - z > sideLimit && -slopeX + z > sideLimit) {
+                    _faceLists[1].push(meshInstance);
+                    visible = true;
+                }
+
+                // +Y
+                if (y > nearLimit && y < farLimit &&
+                    slopeY - x > sideLimit && slopeY + x > sideLimit &&
+                    slopeY - z > sideLimit && slopeY + z > sideLimit) {
+                    _faceLists[2].push(meshInstance);
+                    visible = true;
+                }
+
+                // -Y
+                if (-y > nearLimit && -y < farLimit &&
+                    -slopeY - x > sideLimit && -slopeY + x > sideLimit &&
+                    -slopeY - z > sideLimit && -slopeY + z > sideLimit) {
+                    _faceLists[3].push(meshInstance);
+                    visible = true;
+                }
+
+                // +Z
+                if (z > nearLimit && z < farLimit &&
+                    slopeZ - x > sideLimit && slopeZ + x > sideLimit &&
+                    slopeZ - y > sideLimit && slopeZ + y > sideLimit) {
+                    _faceLists[4].push(meshInstance);
+                    visible = true;
+                }
+
+                // -Z
+                if (-z > nearLimit && -z < farLimit &&
+                    -slopeZ - x > sideLimit && -slopeZ + x > sideLimit &&
+                    -slopeZ - y > sideLimit && -slopeZ + y > sideLimit) {
+                    _faceLists[5].push(meshInstance);
+                    visible = true;
+                }
+
+                if (visible) {
+                    meshInstance.visibleThisFrame = true;
+                }
+            }
+        }
+
         // this sorts the shadow casters by the shader id
-        visible.sort(this.sortCompareShader);
+        for (let face = 0; face < 6; face++) {
+            _faceLists[face].sort(this.sortCompareShader);
+            _faceLists[face] = null;
+            _faceCameras[face] = null;
+        }
 
         // event after culling - the camera is null as this is internal (shadow) culling rather
         // than culling for a user camera

--- a/test/scene/renderer/shadow-renderer-local.test.mjs
+++ b/test/scene/renderer/shadow-renderer-local.test.mjs
@@ -1,0 +1,326 @@
+import { expect } from 'chai';
+
+import { Vec3 } from '../../../src/core/math/vec3.js';
+import { BoundingSphere } from '../../../src/core/shape/bounding-sphere.js';
+import { Entity } from '../../../src/framework/entity.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+/**
+ * @import { Application } from '../../../src/framework/application.js'
+ * @import { Light } from '../../../src/scene/light.js'
+ * @import { MeshInstance } from '../../../src/scene/mesh-instance.js'
+ */
+
+const RANGE = 100;
+
+describe('ShadowRendererLocal', function () {
+    /** @type {Application} */
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    /**
+     * @param {Vec3} position - The light position.
+     * @param {string} [type] - The light type.
+     * @returns {Light} The light.
+     */
+    const createLight = (position, type = 'omni') => {
+        const entity = new Entity();
+        entity.addComponent('light', {
+            type: type,
+            range: RANGE,
+            castShadows: true
+        });
+        entity.setPosition(position);
+        app.root.addChild(entity);
+        return entity.light.light;
+    };
+
+    /**
+     * @param {Vec3} position - The caster position.
+     * @param {number} scale - The uniform caster scale.
+     * @returns {MeshInstance} The caster's mesh instance.
+     */
+    const createCaster = (position, scale) => {
+        const entity = new Entity();
+        entity.addComponent('render', { type: 'box' });
+        entity.setPosition(position);
+        entity.setLocalScale(scale, scale, scale);
+        app.root.addChild(entity);
+        return entity.render.meshInstances[0];
+    };
+
+    /**
+     * Culls the casters for the light and returns, for each of the six faces, the set of visible
+     * casters.
+     *
+     * @param {Light} light - The light.
+     * @param {MeshInstance[]} casters - The casters.
+     * @returns {Set<MeshInstance>[]} The visible casters per face.
+     */
+    const cullFaces = (light, casters) => {
+        app.renderer._shadowRendererLocal.cull(light, app.scene.layers, casters);
+        const faces = [];
+        for (let face = 0; face < light.numShadowFaces; face++) {
+            faces.push(new Set(light.getRenderData(null, face).visibleCasters));
+        }
+        return faces;
+    };
+
+    /**
+     * Maps the per-face sets of visible casters to per-face arrays of indices into the caster list,
+     * so that assertions are made on plain numbers. A failed assertion holding a MeshInstance makes
+     * chai walk the entire engine object graph to build its message.
+     *
+     * @param {Set<MeshInstance>[]} faces - The visible casters per face.
+     * @param {MeshInstance[]} casters - The casters.
+     * @returns {number[][]} The visible caster indices per face.
+     */
+    const faceIndices = (faces, casters) => {
+        return faces.map(face => casters.filter(c => face.has(c)).map(c => casters.indexOf(c)));
+    };
+
+    /**
+     * The set of casters each face's shadow camera frustum reports as visible - the test's
+     * reference for what the single pass classification should produce.
+     *
+     * @param {Light} light - The light.
+     * @param {MeshInstance[]} casters - The casters.
+     * @returns {Set<MeshInstance>[]} The visible casters per face.
+     */
+    const referenceFaces = (light, casters) => {
+        const sphere = new BoundingSphere();
+        const faces = [];
+        for (let face = 0; face < light.numShadowFaces; face++) {
+            const camera = light.getRenderData(null, face).shadowCamera;
+            const visible = new Set();
+            for (const caster of casters) {
+                sphere.center.copy(caster.aabb.center);
+                sphere.radius = caster._aabb.halfExtents.length();
+                if (camera.frustum.containsSphere(sphere) > 0) {
+                    visible.add(caster);
+                }
+            }
+            faces.push(visible);
+        }
+        return faces;
+    };
+
+    /**
+     * A caster is provably outside every face frustum when its bounding sphere does not reach the
+     * axis aligned cube the union of the six frusta is bounded by. Used to confirm the casters the
+     * single pass classification drops - but a per-plane frustum test keeps - genuinely cannot
+     * render into any face.
+     *
+     * @param {Light} light - The light.
+     * @param {MeshInstance} caster - The caster.
+     * @returns {boolean} True when the caster cannot intersect any face frustum.
+     */
+    const outsideAllFaces = (light, caster) => {
+        const shadowCam = light.getRenderData(null, 0).shadowCamera;
+        const half = shadowCam.farClip * Math.tan(shadowCam.fov * 0.5 * Math.PI / 180);
+        const center = caster.aabb.center;
+        const radius = caster._aabb.halfExtents.length();
+        const lightPos = light._node.getPosition();
+        let distance = 0;
+        for (const axis of ['x', 'y', 'z']) {
+            const excess = Math.max(0, Math.abs(center[axis] - lightPos[axis]) - half);
+            distance += excess * excess;
+        }
+        return distance > radius * radius;
+    };
+
+    describe('#cull - omni', function () {
+
+        it('places a caster at the light in all six faces', function () {
+            const light = createLight(new Vec3(10, 20, 30));
+            const caster = createCaster(new Vec3(10, 20, 30), 1);
+
+            const faces = cullFaces(light, [caster]);
+            expect(faces).to.have.lengthOf(6);
+            faces.forEach(face => expect(face.has(caster)).to.equal(true));
+        });
+
+        it('places a caster on a single axis in that face only', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const casters = [
+                createCaster(new Vec3(50, 0, 0), 1),
+                createCaster(new Vec3(-50, 0, 0), 1),
+                createCaster(new Vec3(0, 50, 0), 1),
+                createCaster(new Vec3(0, -50, 0), 1),
+                createCaster(new Vec3(0, 0, 50), 1),
+                createCaster(new Vec3(0, 0, -50), 1)
+            ];
+
+            const indices = faceIndices(cullFaces(light, casters), casters);
+
+            // face order is +X, -X, +Y, -Y, +Z, -Z - see LightCamera.pointLightRotations
+            for (let face = 0; face < 6; face++) {
+                expect(indices[face], `face ${face}`).to.eql([face]);
+            }
+        });
+
+        it('excludes a caster outside the light range', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const caster = createCaster(new Vec3(RANGE * 3, 0, 0), 1);
+
+            const faces = cullFaces(light, [caster]);
+            faces.forEach(face => expect(face.size).to.equal(0));
+        });
+
+        it('includes a caster in a frustum corner, past the range sphere but inside the range cube', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+
+            // 1.48 * range from the light, so a range *sphere* rejection would drop it, but its
+            // extent along each axis is within the range and it is inside the +X face frustum
+            const caster = createCaster(new Vec3(RANGE * 0.95, RANGE * 0.8, RANGE * 0.8), 1);
+
+            const faces = cullFaces(light, [caster]);
+            expect(caster.aabb.center.length()).to.be.greaterThan(RANGE);
+            expect(faceIndices(faces, [caster])[0]).to.eql([0]);
+            for (let face = 1; face < 6; face++) {
+                expect(faces[face].size, `face ${face}`).to.equal(0);
+            }
+        });
+
+        it('places a caster straddling two faces in both of them', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+
+            // on the diagonal shared by the +X and +Y faces
+            const caster = createCaster(new Vec3(30, 30, 0), 1);
+
+            const faces = cullFaces(light, [caster]);
+            expect(faces[0].has(caster), '+X').to.equal(true);
+            expect(faces[2].has(caster), '+Y').to.equal(true);
+            expect(faces[1].size + faces[3].size + faces[4].size + faces[5].size).to.equal(0);
+        });
+
+        it('excludes a caster which does not cast shadows', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const caster = createCaster(new Vec3(50, 0, 0), 1);
+            caster.castShadow = false;
+
+            const faces = cullFaces(light, [caster]);
+            faces.forEach(face => expect(face.size).to.equal(0));
+        });
+
+        it('includes a caster with culling disabled in all faces, wherever it is', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const caster = createCaster(new Vec3(RANGE * 10, 0, 0), 1);
+            caster.cull = false;
+
+            const faces = cullFaces(light, [caster]);
+            faces.forEach(face => expect(face.has(caster)).to.equal(true));
+        });
+
+        it('honours a custom visibility function', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const hidden = createCaster(new Vec3(50, 0, 0), 1);
+            const shown = createCaster(new Vec3(-50, 0, 0), 1);
+            /** @type {Camera[]} */
+            const camerasSeen = [];
+            hidden.isVisibleFunc = () => false;
+            shown.isVisibleFunc = (camera) => {
+                camerasSeen.push(camera);
+                return true;
+            };
+
+            const faces = cullFaces(light, [hidden, shown]);
+            faces.forEach((face) => {
+                expect(face.has(hidden)).to.equal(false);
+                expect(face.has(shown)).to.equal(true);
+            });
+
+            // evaluated once per face, with that face's shadow camera
+            expect(camerasSeen).to.have.lengthOf(6);
+            for (let face = 0; face < 6; face++) {
+                expect(camerasSeen[face]).to.equal(light.getRenderData(null, face).shadowCamera);
+            }
+        });
+
+        it('marks visible casters as visible this frame', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const visible = createCaster(new Vec3(50, 0, 0), 1);
+            const hidden = createCaster(new Vec3(RANGE * 3, 0, 0), 1);
+
+            cullFaces(light, [visible, hidden]);
+            expect(visible.visibleThisFrame).to.equal(true);
+            expect(hidden.visibleThisFrame).to.equal(false);
+        });
+
+        it('matches a per-face frustum test over a spread of casters', function () {
+            const light = createLight(new Vec3(5, -7, 11));
+
+            // deterministic pseudo random casters, spread over roughly three times the light range
+            let seed = 1234567;
+            const random = () => {
+                seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+                return seed / 0x7fffffff;
+            };
+            const casters = [];
+            for (let i = 0; i < 300; i++) {
+                const position = new Vec3(
+                    (random() * 2 - 1) * RANGE * 1.5,
+                    (random() * 2 - 1) * RANGE * 1.5,
+                    (random() * 2 - 1) * RANGE * 1.5
+                );
+                casters.push(createCaster(position, 1 + random() * 30));
+            }
+
+            const faces = cullFaces(light, casters);
+            const reference = referenceFaces(light, casters);
+
+            let visible = 0;
+            let dropped = 0;
+            for (let face = 0; face < 6; face++) {
+                visible += reference[face].size;
+
+                for (const caster of faces[face]) {
+                    // never report a caster the face's frustum rejects
+                    expect(reference[face].has(caster), `face ${face} extra caster`).to.equal(true);
+                }
+
+                for (const caster of reference[face]) {
+                    if (faces[face].has(caster)) {
+                        continue;
+                    }
+
+                    // the classification is tighter than a per-plane frustum test near the frustum
+                    // corners, so it may drop casters the reference keeps - but only ones which
+                    // provably cannot render into any face
+                    expect(outsideAllFaces(light, caster), `face ${face} dropped caster`).to.equal(true);
+                    dropped++;
+                }
+            }
+
+            // the spread should exercise both a decent number of visible casters and the corner
+            // cases the two tests disagree on
+            expect(visible).to.be.greaterThan(100);
+            expect(dropped).to.be.greaterThan(0);
+        });
+    });
+
+    describe('#cull - spot', function () {
+
+        it('culls the single face against the spot frustum', function () {
+            const light = createLight(new Vec3(0, 0, 0), 'spot');
+            const inside = createCaster(new Vec3(0, -50, 0), 1);
+            const outside = createCaster(new Vec3(0, RANGE * 3, 0), 1);
+
+            const casters = [inside, outside];
+            const faces = cullFaces(light, casters);
+            expect(faces).to.have.lengthOf(1);
+            expect(faceIndices(faces, casters)[0]).to.eql([0]);
+        });
+    });
+});


### PR DESCRIPTION
Local shadow caster culling walked the entire caster list once per cube map face, so an omni light cost six full passes over every shadow caster of every layer it is part of - each pass evaluating the caster's world AABB and testing its bounding sphere against that face's frustum.

**Changes:**
- `ShadowRenderer#cullShadowCastersOmni` classifies each caster into all six face lists in a single pass. The six shadow cameras of an omni light are axis aligned in world space (`LightCamera.pointLightRotations` is a constant set and the omni cull only ever sets the camera position), so light space is world space translated by the light position, and each face is bounded by the same six planes its frustum has: a near and a far plane perpendicular to the face axis, plus four side planes with the slope of the face's field of view. Testing the caster's bounding sphere against those is a few comparisons per face.
- `ShadowRendererLocal#cull` routes omni lights to the new path; spot lights keep the existing single-frustum path.
- The layer walk and de-duplication shared by both paths is extracted into `ShadowRenderer#_collectCasterLists`.
- Added `test/scene/renderer/shadow-renderer-local.test.mjs`, covering the face classification, the range cube corner case noted below, casters with culling disabled, custom visibility functions, and a cross-check of 300 casters against a per-face frustum test.

Worth noting for anyone touching this later: the union of the six face frusta is bounded by the axis aligned **cube** of half side `range * tan(fov / 2)`, not by the light's range **sphere**. Each face's far plane is perpendicular to its face axis, so the corners of the frusta stick out past the sphere, and a range-sphere rejection silently drops casters there. The test covers this.

Casters with culling disabled, and those with a custom visibility function - which the gsplat renderers use to opt out of shadow casting - continue to take the per-face path.

Directional cascades have the same shape of redundancy (one full pass per cascade, per camera) and are left for a follow-up.

**Performance:**

Measured on a clustered omni shadow scene of 1542 casters and 32 shadow casting omni lights, at 1600x900, driving frames deterministically:

| | before | after |
| --- | --- | --- |
| cull time, median | 10.8 ms | **2.6 ms** |
| frame time | 60.9 ms | **48.7 ms** |
| shadow draw calls | 37624 | 37603 |

<img width="1732" height="994" alt="Screenshot 2026-08-19 at 11 49 22" src="https://github.com/user-attachments/assets/0a3988e0-5244-40d9-b6b3-f8d412b621ca" />


Backing out camera mesh culling, which shares the same timer, the shadow culling itself goes from ~9.8 ms to ~1.6 ms. The rendered output is unchanged - a hash of the framebuffer after an identical frame sequence matches exactly before and after. The marginally lower shadow draw call count is casters near a frustum corner that the sphere-vs-plane test admits but which cannot rasterize into that face.