### PR TITLE
Add shadowCascadeMask to the render component

### DIFF
--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -1,5 +1,5 @@
 import { Debug } from '../../../core/debug.js';
-import { LAYERID_WORLD, RENDERSTYLE_SOLID } from '../../../scene/constants.js';
+import { LAYERID_WORLD, RENDERSTYLE_SOLID, SHADOW_CASCADE_ALL } from '../../../scene/constants.js';
 import { BatchGroup } from '../../../scene/batching/batch-group.js';
 import { MeshInstance } from '../../../scene/mesh-instance.js';
 import { MorphInstance } from '../../../scene/morph-instance.js';
@@ -67,6 +67,9 @@ class RenderComponent extends Component {
 
     /** @private */
     _castShadows = true;
+
+    /** @private */
+    _shadowCascadeMask = SHADOW_CASCADE_ALL;
 
     /** @private */
     _receiveShadows = true;
@@ -346,6 +349,7 @@ class RenderComponent extends Component {
                 }
 
                 mi[i].castShadow = this._castShadows;
+                mi[i].shadowCascadeMask = this._shadowCascadeMask;
                 mi[i].receiveShadow = this._receiveShadows;
                 mi[i].renderStyle = this._renderStyle;
                 mi[i].setLightmapped(this._lightmapped);
@@ -445,6 +449,44 @@ class RenderComponent extends Component {
      */
     get castShadows() {
         return this._castShadows;
+    }
+
+    /**
+     * Sets a bitmask that controls which shadow cascades the attached meshes contribute to when
+     * rendered with a {@link LIGHTTYPE_DIRECTIONAL} light source. Combine the
+     * {@link SHADOW_CASCADE_0} .. {@link SHADOW_CASCADE_3} flags to select individual cascades.
+     * This is only effective when {@link castShadows} is enabled. Defaults to
+     * {@link SHADOW_CASCADE_ALL}, which contributes to all available cascades.
+     *
+     * Note that this filters the meshes per cascade at render time, it does not remove them from
+     * the shadow casters of the {@link Layer} - use {@link castShadows} to disable shadow casting
+     * completely.
+     *
+     * @type {number}
+     * @example
+     * // only cast shadows into the two cascades closest to the camera
+     * entity.render.shadowCascadeMask = pc.SHADOW_CASCADE_0 | pc.SHADOW_CASCADE_1;
+     */
+    set shadowCascadeMask(value) {
+        if (this._shadowCascadeMask !== value) {
+            this._shadowCascadeMask = value;
+
+            const mi = this._meshInstances;
+            if (mi) {
+                for (let i = 0; i < mi.length; i++) {
+                    mi[i].shadowCascadeMask = value;
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the bitmask that controls which shadow cascades the attached meshes contribute to.
+     *
+     * @type {number}
+     */
+    get shadowCascadeMask() {
+        return this._shadowCascadeMask;
     }
 
     /**

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -15,6 +15,7 @@ const _properties = [
     'asset',
     'materialAssets',
     'castShadows',
+    'shadowCascadeMask',
     'receiveShadows',
     'castShadowsLightmap',
     'lightmapped',

--- a/test/framework/components/render/component.test.mjs
+++ b/test/framework/components/render/component.test.mjs
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { Entity } from '../../../../src/framework/entity.js';
 import { BatchGroup } from '../../../../src/scene/batching/batch-group.js';
-import { LAYERID_WORLD } from '../../../../src/scene/constants.js';
+import { LAYERID_WORLD, SHADOW_CASCADE_0, SHADOW_CASCADE_1, SHADOW_CASCADE_ALL } from '../../../../src/scene/constants.js';
 import { createApp } from '../../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
 
@@ -66,6 +66,65 @@ describe('RenderComponent', function () {
             e.removeComponent('render');
 
             expect(worldLayer.meshInstances.length).to.equal(0);
+        });
+
+    });
+
+    describe('#shadowCascadeMask', function () {
+
+        it('defaults to all cascades and is assigned to the mesh instances', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('render', { type: 'box' });
+
+            expect(e.render.shadowCascadeMask).to.equal(SHADOW_CASCADE_ALL);
+            expect(e.render.meshInstances[0].shadowCascadeMask).to.equal(SHADOW_CASCADE_ALL);
+        });
+
+        it('can be initialized from the component data', function () {
+            const mask = SHADOW_CASCADE_0 | SHADOW_CASCADE_1;
+
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('render', { type: 'box', shadowCascadeMask: mask });
+
+            expect(e.render.shadowCascadeMask).to.equal(mask);
+            expect(e.render.meshInstances[0].shadowCascadeMask).to.equal(mask);
+        });
+
+        it('is applied to the existing mesh instances when set', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('render', { type: 'box' });
+
+            e.render.shadowCascadeMask = SHADOW_CASCADE_0;
+
+            expect(e.render.meshInstances[0].shadowCascadeMask).to.equal(SHADOW_CASCADE_0);
+        });
+
+        it('is applied to mesh instances created after it was set', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('render', { type: 'box' });
+
+            e.render.shadowCascadeMask = SHADOW_CASCADE_0;
+
+            // this recreates the mesh instances
+            e.render.type = 'sphere';
+
+            expect(e.render.meshInstances[0].shadowCascadeMask).to.equal(SHADOW_CASCADE_0);
+        });
+
+        it('is preserved when the entity is cloned', function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('render', { type: 'box', shadowCascadeMask: SHADOW_CASCADE_1 });
+
+            const clone = e.clone();
+            app.root.addChild(clone);
+
+            expect(clone.render.shadowCascadeMask).to.equal(SHADOW_CASCADE_1);
+            expect(clone.render.meshInstances[0].shadowCascadeMask).to.equal(SHADOW_CASCADE_1);
         });
 
     });


### PR DESCRIPTION
Exposes the per-mesh directional shadow cascade mask on the render component, so selecting which cascades an entity casts into no longer requires walking its mesh instances from a script. Fixes #9126.

**Changes:**
- `RenderComponent#shadowCascadeMask` is assigned to every mesh instance the component manages, including ones created later by an asset load or a `type` change.
- The property is part of the component's property list, so it is initialized from `addComponent` data and preserved when an entity is cloned.
- Added render component tests covering the default value, initialization from component data, propagation to existing and to newly created mesh instances, and cloning.

**API Changes:**
- Added `RenderComponent#shadowCascadeMask`, defaulting to `SHADOW_CASCADE_ALL`. Combine `SHADOW_CASCADE_0` .. `SHADOW_CASCADE_3` to select individual cascades, and note that this only filters the meshes per cascade - use `castShadows` to disable shadow casting completely.

```javascript
// only cast shadows into the two cascades closest to the camera
entity.render.shadowCascadeMask = pc.SHADOW_CASCADE_0 | pc.SHADOW_CASCADE_1;
```

`ModelComponent` is deliberately left alone as it is legacy, and the gsplat component cannot support this in unified mode, where shadow casters are registered per placement and rendered through a single shared mesh instance.