### PR TITLE
[BREAKING] Store frustum planes in a typed array

### DIFF
--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -47,8 +47,6 @@ function intersectPlanes(p1, p2, p3, out) {
  * visibility of points and bounding spheres. Typically, you would not create a Frustum shape
  * directly, but instead query {@link CameraComponent#frustum}.
  *
- * @example
- * const frustum = new Frustum();
  * @category Math
  */
 class Frustum {
@@ -65,6 +63,15 @@ class Frustum {
      * @ignore
      */
     planeData = new Float32Array(24);
+
+    /**
+     * Create a new Frustum instance.
+     *
+     * @example
+     * const frustum = new Frustum();
+     */
+    // eslint-disable-next-line no-useless-constructor
+    constructor() { }
 
     /**
      * @type {Plane[]}

--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -12,6 +12,9 @@ const _c31 = new Vec3();
 const _c12 = new Vec3();
 const _corner = new Vec3();
 
+// scratch planes, used to read the planes of another frustum in add()
+const _scratchPlanes = [new Plane(), new Plane(), new Plane(), new Plane(), new Plane(), new Plane()];
+
 /**
  * Intersects three planes and writes the intersection point to out.
  *
@@ -43,27 +46,24 @@ function intersectPlanes(p1, p2, p3, out) {
  * visibility of points and bounding spheres. Typically, you would not create a Frustum shape
  * directly, but instead query {@link CameraComponent#frustum}.
  *
+ * @example
+ * const frustum = new Frustum();
  * @category Math
  */
 class Frustum {
     /**
-     * The six planes that make up the frustum.
+     * The six planes of the frustum, packed as four floats each - the normal's x, y and z followed
+     * by the plane's distance from the origin - in the order right, left, bottom, top, far, near.
+     * The normals point inwards, so a point is outside a plane when
+     * `normal.dot(point) + distance` is negative.
      *
-     * @type {Plane[]}
-     */
-    planes = [];
-
-    /**
-     * Create a new Frustum instance.
+     * This is the frustum's storage, exposed for internal use where the packed form avoids
+     * per-plane object access. Use {@link Frustum#getPlane} and {@link Frustum#setPlane} instead.
      *
-     * @example
-     * const frustum = new Frustum();
+     * @type {Float32Array}
+     * @ignore
      */
-    constructor() {
-        for (let i = 0; i < 6; i++) {
-            this.planes[i] = new Plane();
-        }
-    }
+    planeData = new Float32Array(24);
 
     /**
      * Returns a clone of the specified frustum.
@@ -90,10 +90,62 @@ class Frustum {
      * dst.copy(src);
      */
     copy(src) {
-        for (let i = 0; i < 6; i++) {
-            this.planes[i].copy(src.planes[i]);
-        }
+        this.planeData.set(src.planeData);
         return this;
+    }
+
+    /**
+     * Returns one of the frustum's six planes. The planes are ordered right, left, bottom, top,
+     * far, near, and their normals point inwards.
+     *
+     * @param {number} index - The index of the plane, from 0 to 5.
+     * @param {Plane} result - The plane to write to.
+     * @returns {Plane} The supplied plane, containing the frustum plane.
+     * @example
+     * const plane = new Plane();
+     * entity.camera.frustum.getPlane(0, plane);
+     */
+    getPlane(index, result) {
+        const data = this.planeData;
+        const offset = index * 4;
+        result.normal.set(data[offset], data[offset + 1], data[offset + 2]);
+        result.distance = data[offset + 3];
+        return result;
+    }
+
+    /**
+     * Sets one of the frustum's six planes. The plane is normalized as it is stored, as the
+     * frustum's tests require unit length normals. The planes are ordered right, left, bottom, top,
+     * far, near, and their normals must point inwards.
+     *
+     * @param {number} index - The index of the plane, from 0 to 5.
+     * @param {Plane} plane - The plane to store.
+     * @returns {Frustum} Self for chaining.
+     */
+    setPlane(index, plane) {
+        const { normal, distance } = plane;
+        this._setPlane(index, normal.x, normal.y, normal.z, distance);
+        return this;
+    }
+
+    /**
+     * Stores a normalized plane at the given index.
+     *
+     * @param {number} index - The index of the plane, from 0 to 5.
+     * @param {number} nx - The x component of the plane normal.
+     * @param {number} ny - The y component of the plane normal.
+     * @param {number} nz - The z component of the plane normal.
+     * @param {number} distance - The plane's distance from the origin.
+     * @private
+     */
+    _setPlane(index, nx, ny, nz, distance) {
+        const invLength = 1 / Math.sqrt(nx * nx + ny * ny + nz * nz);
+        const data = this.planeData;
+        const offset = index * 4;
+        data[offset] = nx * invLength;
+        data[offset + 1] = ny * invLength;
+        data[offset + 2] = nz * invLength;
+        data[offset + 3] = distance * invLength;
     }
 
     /**
@@ -115,14 +167,13 @@ class Frustum {
         const m10 = d[4], m11 = d[5], m12 = d[6], m13 = d[7];
         const m20 = d[8], m21 = d[9], m22 = d[10], m23 = d[11];
         const m30 = d[12], m31 = d[13], m32 = d[14], m33 = d[15];
-        const planes = this.planes;
 
-        planes[0].set(m03 - m00, m13 - m10, m23 - m20, m33 - m30).normalize(); // RIGHT
-        planes[1].set(m03 + m00, m13 + m10, m23 + m20, m33 + m30).normalize(); // LEFT
-        planes[2].set(m03 + m01, m13 + m11, m23 + m21, m33 + m31).normalize(); // BOTTOM
-        planes[3].set(m03 - m01, m13 - m11, m23 - m21, m33 - m31).normalize(); // TOP
-        planes[4].set(m03 - m02, m13 - m12, m23 - m22, m33 - m32).normalize(); // FAR
-        planes[5].set(m03 + m02, m13 + m12, m23 + m22, m33 + m32).normalize(); // NEAR
+        this._setPlane(0, m03 - m00, m13 - m10, m23 - m20, m33 - m30);  // RIGHT
+        this._setPlane(1, m03 + m00, m13 + m10, m23 + m20, m33 + m30);  // LEFT
+        this._setPlane(2, m03 + m01, m13 + m11, m23 + m21, m33 + m31);  // BOTTOM
+        this._setPlane(3, m03 - m01, m13 - m11, m23 - m21, m33 - m31);  // TOP
+        this._setPlane(4, m03 - m02, m13 - m12, m23 - m22, m33 - m32);  // FAR
+        this._setPlane(5, m03 + m02, m13 + m12, m23 + m22, m33 + m32);  // NEAR
     }
 
     /**
@@ -133,12 +184,15 @@ class Frustum {
      * @returns {boolean} True if the point is inside the frustum, false otherwise.
      */
     containsPoint(point) {
-        for (let p = 0; p < 6; p++) {
-            const { normal, distance } = this.planes[p];
-            if (normal.dot(point) + distance <= 0) {
+        const data = this.planeData;
+        const { x, y, z } = point;
+
+        for (let offset = 0; offset < 24; offset += 4) {
+            if (data[offset] * x + data[offset + 1] * y + data[offset + 2] * z + data[offset + 3] <= 0) {
                 return false;
             }
         }
+
         return true;
     }
 
@@ -158,21 +212,26 @@ class Frustum {
      * @returns {Frustum} Self for chaining.
      */
     add(other) {
-        const planes = this.planes;
-        const op = other.planes;
+        const data = this.planeData;
+
+        // the other frustum's planes as objects, for the three-plane intersection below. This runs
+        // a couple of times per frame at most - only stereo XR uses it - so the unpacking is free.
+        for (let p = 0; p < 6; p++) {
+            other.getPlane(p, _scratchPlanes[p]);
+        }
 
         // The 8 corners of the other frustum: intersections of (FAR|NEAR) x (RIGHT|LEFT) x
         // (BOTTOM|TOP) plane triplets - see the plane order in setFromMat4.
         for (let zi = 4; zi <= 5; zi++) {
             for (let xi = 0; xi <= 1; xi++) {
                 for (let yi = 2; yi <= 3; yi++) {
-                    if (intersectPlanes(op[zi], op[xi], op[yi], _corner)) {
+                    if (intersectPlanes(_scratchPlanes[zi], _scratchPlanes[xi], _scratchPlanes[yi], _corner)) {
                         // push out any plane the corner is behind, so it ends up on the plane
-                        for (let p = 0; p < 6; p++) {
-                            const plane = planes[p];
-                            const d = plane.normal.dot(_corner) + plane.distance;
+                        for (let offset = 0; offset < 24; offset += 4) {
+                            const d = data[offset] * _corner.x + data[offset + 1] * _corner.y +
+                                data[offset + 2] * _corner.z + data[offset + 3];
                             if (d < 0) {
-                                plane.distance -= d;
+                                data[offset + 3] -= d;
                             }
                         }
                     }
@@ -193,12 +252,13 @@ class Frustum {
      * frustum and 2 if it is contained by the frustum.
      */
     containsSphere(sphere) {
+        const data = this.planeData;
         const { center, radius } = sphere;
+        const { x, y, z } = center;
 
         let c = 0;
-        for (let p = 0; p < 6; p++) {
-            const { normal, distance } = this.planes[p];
-            const d = normal.dot(center) + distance;
+        for (let offset = 0; offset < 24; offset += 4) {
+            const d = data[offset] * x + data[offset + 1] * y + data[offset + 2] * z + data[offset + 3];
             if (d <= -radius) {
                 return 0;
             }

--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -1,4 +1,5 @@
 import { Plane } from './plane.js';
+import { Debug } from '../debug.js';
 import { Vec3 } from '../math/vec3.js';
 
 /**
@@ -64,6 +65,16 @@ class Frustum {
      * @ignore
      */
     planeData = new Float32Array(24);
+
+    /**
+     * @type {Plane[]}
+     * @deprecated Use {@link Frustum#getPlane} and {@link Frustum#setPlane} instead.
+     * @ignore
+     */
+    get planes() {
+        Debug.removed('Frustum#planes is removed. Use Frustum#getPlane and Frustum#setPlane instead.');
+        return [];
+    }
 
     /**
      * Returns a clone of the specified frustum.

--- a/src/scene/gsplat-unified/gsplat-frustum-culler.js
+++ b/src/scene/gsplat-unified/gsplat-frustum-culler.js
@@ -207,14 +207,10 @@ class GSplatFrustumCuller {
      * @param {Frustum} frustum - The frustum to take the planes from.
      */
     setFrustumPlanes(frustum) {
-        const planes = this.frustumPlanes;
-        for (let p = 0; p < 6; p++) {
-            const plane = frustum.planes[p];
-            planes[p * 4 + 0] = plane.normal.x;
-            planes[p * 4 + 1] = plane.normal.y;
-            planes[p * 4 + 2] = plane.normal.z;
-            planes[p * 4 + 3] = plane.distance;
-        }
+        // the frustum stores its planes in the packed vec4(normal.xyz, distance) form the shader
+        // wants, so this is a straight copy. A copy rather than sharing the frustum's array, as the
+        // caller may be using a shared scratch frustum which is overwritten by the next call.
+        this.frustumPlanes.set(frustum.planeData);
     }
 
     /**

--- a/src/scene/gsplat-unified/gsplat-shadow-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-shadow-renderer.js
@@ -669,14 +669,10 @@ class GSplatShadowRenderer {
      * @private
      */
     _fillFrustumPlanes(frustum) {
-        const p = this._frustumPlanes;
-        for (let i = 0; i < 6; i++) {
-            const plane = frustum.planes[i];
-            p[i * 4 + 0] = plane.normal.x;
-            p[i * 4 + 1] = plane.normal.y;
-            p[i * 4 + 2] = plane.normal.z;
-            p[i * 4 + 3] = plane.distance;
-        }
+        // the frustum stores its planes in the packed vec4(normal.xyz, distance) form the shader
+        // wants, so this is a straight copy. Kept as a copy rather than sharing the frustum's array,
+        // so this buffer stays owned by the light currently being culled.
+        this._frustumPlanes.set(frustum.planeData);
     }
 
     /**

--- a/test/core/shape/frustum.test.mjs
+++ b/test/core/shape/frustum.test.mjs
@@ -1,0 +1,225 @@
+import { expect } from 'chai';
+
+import { Mat4 } from '../../../src/core/math/mat4.js';
+import { Vec3 } from '../../../src/core/math/vec3.js';
+import { BoundingSphere } from '../../../src/core/shape/bounding-sphere.js';
+import { Frustum } from '../../../src/core/shape/frustum.js';
+import { Plane } from '../../../src/core/shape/plane.js';
+
+/**
+ * A frustum at the given position looking down the negative z axis.
+ *
+ * @param {number} [x] - The x position of the viewer.
+ * @returns {Frustum} The frustum.
+ */
+const createFrustum = (x = 0) => {
+    const frustum = new Frustum();
+    frustum.setFromMat4(new Mat4().mul2(
+        new Mat4().setPerspective(90, 1, 1, 100),
+        new Mat4().setTRS(new Vec3(x, 0, 0), { x: 0, y: 0, z: 0, w: 1 }, Vec3.ONE).invert()
+    ));
+    return frustum;
+};
+
+describe('Frustum', function () {
+
+    describe('#getPlane', function () {
+
+        it('writes into the supplied plane and returns it', function () {
+            const frustum = createFrustum();
+            const result = new Plane();
+            expect(frustum.getPlane(0, result)).to.equal(result);
+        });
+
+        it('returns unit length normals for all six planes', function () {
+            const frustum = createFrustum();
+            const plane = new Plane();
+            for (let i = 0; i < 6; i++) {
+                frustum.getPlane(i, plane);
+                expect(plane.normal.length(), `plane ${i}`).to.be.closeTo(1, 1e-6);
+            }
+        });
+
+        it('returns the planes in right, left, bottom, top, far, near order with inward normals', function () {
+            const frustum = createFrustum();
+            const plane = new Plane();
+
+            // a 90 degree square frustum at the origin looking down -z: the near plane faces into
+            // the scene and the far plane faces back towards the viewer
+            frustum.getPlane(5, plane);
+            expect(plane.normal.x).to.be.closeTo(0, 1e-6);
+            expect(plane.normal.y).to.be.closeTo(0, 1e-6);
+            expect(plane.normal.z).to.be.closeTo(-1, 1e-6);
+
+            frustum.getPlane(4, plane);
+            expect(plane.normal.z).to.be.closeTo(1, 1e-6);
+
+            // the side planes are at 45 degrees and pass through the viewer, so their distance is 0
+            for (const [index, sign] of [[0, -1], [1, 1]]) {
+                frustum.getPlane(index, plane);
+                expect(plane.distance, `plane ${index} distance`).to.be.closeTo(0, 1e-6);
+                expect(Math.sign(plane.normal.x), `plane ${index} normal x`).to.equal(sign);
+            }
+        });
+    });
+
+    describe('#setPlane', function () {
+
+        it('round trips through getPlane', function () {
+            const frustum = new Frustum();
+            const source = new Plane(new Vec3(0, 1, 0), -5);
+            const result = new Plane();
+
+            frustum.setPlane(2, source);
+            frustum.getPlane(2, result);
+
+            expect(result.normal.x).to.be.closeTo(0, 1e-6);
+            expect(result.normal.y).to.be.closeTo(1, 1e-6);
+            expect(result.normal.z).to.be.closeTo(0, 1e-6);
+            expect(result.distance).to.be.closeTo(-5, 1e-6);
+        });
+
+        it('normalizes the plane it stores', function () {
+            const frustum = new Frustum();
+            const result = new Plane();
+
+            // the same plane, with a normal three times too long
+            frustum.setPlane(0, new Plane(new Vec3(0, 3, 0), -15));
+            frustum.getPlane(0, result);
+
+            expect(result.normal.length()).to.be.closeTo(1, 1e-6);
+            expect(result.distance).to.be.closeTo(-5, 1e-6);
+        });
+
+        it('returns the frustum for chaining', function () {
+            const frustum = new Frustum();
+            expect(frustum.setPlane(0, new Plane())).to.equal(frustum);
+        });
+
+        it('leaves the other planes untouched', function () {
+            const frustum = createFrustum();
+            const before = new Plane();
+            const after = new Plane();
+            frustum.getPlane(3, before);
+
+            frustum.setPlane(0, new Plane(new Vec3(1, 0, 0), 7));
+            frustum.getPlane(3, after);
+
+            expect(after.normal.x).to.be.closeTo(before.normal.x, 1e-6);
+            expect(after.normal.y).to.be.closeTo(before.normal.y, 1e-6);
+            expect(after.normal.z).to.be.closeTo(before.normal.z, 1e-6);
+            expect(after.distance).to.be.closeTo(before.distance, 1e-6);
+        });
+    });
+
+    describe('#copy', function () {
+
+        it('copies every plane', function () {
+            const src = createFrustum();
+            const dst = new Frustum();
+            dst.copy(src);
+
+            const a = new Plane();
+            const b = new Plane();
+            for (let i = 0; i < 6; i++) {
+                src.getPlane(i, a);
+                dst.getPlane(i, b);
+                expect(b.normal.equals(a.normal), `plane ${i} normal`).to.equal(true);
+                expect(b.distance, `plane ${i} distance`).to.equal(a.distance);
+            }
+        });
+
+        it('does not alias the source', function () {
+            const src = createFrustum();
+            const dst = new Frustum().copy(src);
+            dst.setPlane(0, new Plane(new Vec3(1, 0, 0), 42));
+
+            const plane = new Plane();
+            src.getPlane(0, plane);
+            expect(plane.distance).to.not.equal(42);
+        });
+    });
+
+    describe('#clone', function () {
+
+        it('produces an independent frustum with the same planes', function () {
+            const src = createFrustum();
+            const clone = src.clone();
+            expect(clone).to.not.equal(src);
+
+            const a = new Plane();
+            const b = new Plane();
+            for (let i = 0; i < 6; i++) {
+                src.getPlane(i, a);
+                clone.getPlane(i, b);
+                expect(b.distance, `plane ${i}`).to.equal(a.distance);
+            }
+        });
+    });
+
+    describe('#containsPoint', function () {
+
+        it('accepts a point in the middle and rejects points outside', function () {
+            const frustum = createFrustum();
+            expect(frustum.containsPoint(new Vec3(0, 0, -50))).to.equal(true);
+            expect(frustum.containsPoint(new Vec3(0, 0, 50))).to.equal(false);
+            expect(frustum.containsPoint(new Vec3(0, 0, -200))).to.equal(false);
+            expect(frustum.containsPoint(new Vec3(200, 0, -50))).to.equal(false);
+        });
+    });
+
+    describe('#containsSphere', function () {
+
+        it('reports outside, intersecting and contained', function () {
+            const frustum = createFrustum();
+            expect(frustum.containsSphere(new BoundingSphere(new Vec3(0, 0, 50), 1))).to.equal(0);
+            expect(frustum.containsSphere(new BoundingSphere(new Vec3(0, 0, -50), 5))).to.equal(2);
+
+            // straddling the left plane, which passes through the origin at 45 degrees
+            expect(frustum.containsSphere(new BoundingSphere(new Vec3(-50, 0, -50), 5))).to.equal(1);
+        });
+    });
+
+    describe('#add', function () {
+
+        it('contains points that were only inside the other frustum', function () {
+            const base = createFrustum(0);
+            const other = createFrustum(60);
+
+            // a point inside the other frustum but not the base one
+            const point = new Vec3(60, 0, -5);
+            expect(base.containsPoint(point)).to.equal(false);
+            expect(other.containsPoint(point)).to.equal(true);
+
+            base.add(other);
+            expect(base.containsPoint(point)).to.equal(true);
+        });
+
+        it('keeps everything that was inside either frustum', function () {
+            const base = createFrustum(0);
+            const other = createFrustum(60);
+            const combined = base.clone().add(other);
+
+            let seed = 4321;
+            const random = () => {
+                seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+                return seed / 0x7fffffff;
+            };
+
+            let tested = 0;
+            for (let i = 0; i < 20000; i++) {
+                const p = new Vec3((random() * 2 - 1) * 150, (random() * 2 - 1) * 120, -random() * 150);
+                if (base.containsPoint(p) || other.containsPoint(p)) {
+                    tested++;
+                    expect(combined.containsPoint(p), `point ${p.x},${p.y},${p.z}`).to.equal(true);
+                }
+            }
+            expect(tested).to.be.greaterThan(500);
+        });
+
+        it('returns the frustum for chaining', function () {
+            const frustum = createFrustum();
+            expect(frustum.add(createFrustum(10))).to.equal(frustum);
+        });
+    });
+});


### PR DESCRIPTION
`Frustum` kept its six planes as `Plane` objects, so reading a plane walked from the frustum to a `Plane` to a `Vec3` to its components. The planes now live in a single `Float32Array`, packed as four floats per plane - the normal's x, y and z followed by the distance - in the existing right, left, bottom, top, far, near order.

**API Changes:**

The public `planes` array is gone, replaced by an accessor pair:

```javascript
// before
const normal = entity.camera.frustum.planes[0].normal;

// after
const plane = new pc.Plane();
entity.camera.frustum.getPlane(0, plane);
const normal = plane.normal;
```

- `getPlane(index, result)` writes the plane at `index` into the supplied `Plane` and returns it.
- `setPlane(index, plane)` stores a plane, normalizing it on the way in - `containsSphere` compares a plane distance against a sphere radius, so it requires unit length normals. `setFromMat4` already normalized, so the two entry points now agree.
- The packed array is available as `planeData` for internal use, tagged `@ignore`.

**Changes:**
- `containsPoint`, `containsSphere`, `copy` and `setFromMat4` read and write the packed array directly.
- `add` is unchanged in behaviour: it reads the other frustum's planes into scratch `Plane` objects and reuses the existing three-plane corner intersection. It only runs for stereo XR, a couple of times per frame, so the unpacking costs nothing there.
- The gsplat frustum culler and gsplat shadow renderer both already kept their own `Float32Array(24)` in exactly this packed layout for their cull compute shaders, so both now copy the array in one go instead of unpacking six plane objects. They keep their own buffer rather than sharing the frustum's, since each may be handed a shared scratch frustum that a later call overwrites.
- Added `test/core/shape/frustum.test.mjs`, covering the `getPlane` / `setPlane` round trip and normalization, `copy` and `clone` independence, `containsPoint`, `containsSphere`, and `add` containment over sampled points.

**Performance:**

Measured in a browser on a scene of 5072 mesh instances lit by 10 shadow casting omni lights, so 61 frustums are built per frame - one for the camera and one per shadow map face. Timings are of the culling work itself rather than whole frames, which in this scene it is far too small a share of to resolve. Each figure is the best of nine rounds, and the runs were stable to within a couple of percent.

| | before | after | |
| --- | --- | --- | --- |
| frustum cull all 5072 mesh instances | 0.245 ms | **0.199 ms** | 1.23x |
| build the frame's 61 frustums | 0.0071 ms | **0.0028 ms** | 2.5x |

The frustum build is the larger relative win, mostly from dropping the `Plane.set` plus `Vec3.normalize` call chain rather than from the storage itself, and it scales with the number of shadow casting lights.

Float32 rather than Float64 storage costs no real precision here, since `Mat4` is itself backed by a `Float32Array` and so the planes were already derived from float32 inputs. The extra rounding works out at roughly 5e-6 of the camera's distance from the origin - tens of microns at this scene's scale. It is measurable at the frustum boundary: this scene reports 3550 mesh instances visible after the change and 3548 before, a difference of two objects sitting within that band of a plane. A smaller scene of 1542 mesh instances reported an identical count either way.
