### PR TITLE
Fix phantom sampler binding for a trailing texture in WGSL reflection

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -733,9 +733,10 @@ class WebgpuShaderProcessorWGSL {
 
             if (resource.isTexture) {
 
-                // followed by optional sampler uniform
+                // followed by optional sampler uniform. Use `?? false` so a missing next resource
+                // (undefined) does not trip BindTextureFormat's hasSampler = true default.
                 const sampler = resources[i + 1];
-                const hasSampler = sampler?.isSampler;
+                const hasSampler = sampler?.isSampler ?? false;
 
                 // TODO: handle external, and storage types
                 const sampleType = resource.sampleType;

--- a/test/platform/graphics/webgpu/webgpu-shader-processor-wgsl-compute.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-shader-processor-wgsl-compute.test.mjs
@@ -273,4 +273,19 @@ describe('WebgpuShaderProcessorWGSL - compute reflection', function () {
         expect(result.cshader).to.contain('ub_compute.scale');
     });
 
+    it('does not fabricate a sampler when a texture is the last declared resource', function () {
+        const src = `
+            var srcTex: texture_2d<f32>;
+            @compute @workgroup_size(1) fn main() { }
+        `;
+        const { result, shader } = run(src);
+        expect(shader.failed).to.equal(false);
+
+        const tf = result.computeBindGroupFormat.textureFormats[0];
+        expect(tf.hasSampler).to.equal(false);
+        expect(tf.slot).to.equal(0);
+        expect(result.cshader).to.contain('@group(1) @binding(0) var srcTex: texture_2d<f32>;');
+        expect(result.cshader).to.not.match(/srcTex_sampler/);
+    });
+
 });


### PR DESCRIPTION
WGSL reflection fabricated a sampler binding for a texture declared as the last resource in a shader: `resources[i + 1]` is `undefined`, so `hasSampler` ended up `undefined` and fell through to `BindTextureFormat`'s `hasSampler = true` default — adding a phantom sampler slot to the bind group layout and emitting an unused `${name}_sampler` declaration.

Extracted from #9167 (thanks @SashaRX for spotting this) so the fix can land independently.

**Changes:**
- `WebgpuShaderProcessorWGSL`: `hasSampler` defaults to `false` when no resource follows the texture (`?? false`).
- Regression test: a trailing `texture_2d<f32>` reflects with `hasSampler: false`, a single slot, and no fabricated sampler declaration.