### PR TITLE
Cull omni shadow cube faces the camera cannot sample

### DIFF
--- a/src/core/shape/frustum.js
+++ b/src/core/shape/frustum.js
@@ -1,46 +1,60 @@
-import { Plane } from './plane.js';
 import { Debug } from '../debug.js';
-import { Vec3 } from '../math/vec3.js';
 
 /**
  * @import { BoundingBox } from './bounding-box.js'
  * @import { BoundingSphere } from './bounding-sphere.js'
  * @import { Mat4 } from '../math/mat4.js'
+ * @import { Plane } from './plane.js'
+ * @import { Vec3 } from '../math/vec3.js'
  */
 
-// temporaries for three-plane intersection
-const _c23 = new Vec3();
-const _c31 = new Vec3();
-const _c12 = new Vec3();
-const _corner = new Vec3();
-
-// scratch planes, used to read the planes of another frustum in add()
-const _scratchPlanes = [new Plane(), new Plane(), new Plane(), new Plane(), new Plane(), new Plane()];
+// corners of the frustum being added in add()
+const _corners = new Float64Array(24);
 
 /**
- * Intersects three planes and writes the intersection point to out.
+ * Intersects the three planes at the given offsets into packed plane data, writing the intersection
+ * point to out.
  *
- * @param {Plane} p1 - The first plane.
- * @param {Plane} p2 - The second plane.
- * @param {Plane} p3 - The third plane.
- * @param {Vec3} out - The intersection point.
+ * @param {Float64Array|Float32Array} planes - Packed planes, four floats each.
+ * @param {number} a - Offset of the first plane.
+ * @param {number} b - Offset of the second plane.
+ * @param {number} c - Offset of the third plane.
+ * @param {Float64Array} out - Receives the intersection point.
+ * @param {number} outOffset - Offset to write the point at.
  * @returns {boolean} False when the planes do not intersect in a single finite point.
  */
-function intersectPlanes(p1, p2, p3, out) {
-    _c23.cross(p2.normal, p3.normal);
-    const denom = p1.normal.dot(_c23);
+function intersectPlanes(planes, a, b, c, out, outOffset) {
+
+    // cross products of the plane normals
+    const bcx = planes[b + 1] * planes[c + 2] - planes[b + 2] * planes[c + 1];
+    const bcy = planes[b + 2] * planes[c] - planes[b] * planes[c + 2];
+    const bcz = planes[b] * planes[c + 1] - planes[b + 1] * planes[c];
+
+    const denom = planes[a] * bcx + planes[a + 1] * bcy + planes[a + 2] * bcz;
     if (Math.abs(denom) < 1e-6) {
         return false;
     }
-    _c31.cross(p3.normal, p1.normal);
-    _c12.cross(p1.normal, p2.normal);
-    const invDenom = -1.0 / denom;
-    out.set(
-        (p1.distance * _c23.x + p2.distance * _c31.x + p3.distance * _c12.x) * invDenom,
-        (p1.distance * _c23.y + p2.distance * _c31.y + p3.distance * _c12.y) * invDenom,
-        (p1.distance * _c23.z + p2.distance * _c31.z + p3.distance * _c12.z) * invDenom
-    );
-    return isFinite(out.x) && isFinite(out.y) && isFinite(out.z);
+
+    const cax = planes[c + 1] * planes[a + 2] - planes[c + 2] * planes[a + 1];
+    const cay = planes[c + 2] * planes[a] - planes[c] * planes[a + 2];
+    const caz = planes[c] * planes[a + 1] - planes[c + 1] * planes[a];
+    const abx = planes[a + 1] * planes[b + 2] - planes[a + 2] * planes[b + 1];
+    const aby = planes[a + 2] * planes[b] - planes[a] * planes[b + 2];
+    const abz = planes[a] * planes[b + 1] - planes[a + 1] * planes[b];
+
+    const invDenom = -1 / denom;
+    const da = planes[a + 3], db = planes[b + 3], dc = planes[c + 3];
+    const x = (da * bcx + db * cax + dc * abx) * invDenom;
+    const y = (da * bcy + db * cay + dc * aby) * invDenom;
+    const z = (da * bcz + db * caz + dc * abz) * invDenom;
+    if (!isFinite(x) || !isFinite(y) || !isFinite(z)) {
+        return false;
+    }
+
+    out[outOffset] = x;
+    out[outOffset + 1] = y;
+    out[outOffset + 2] = z;
+    return true;
 }
 
 /**
@@ -216,6 +230,32 @@ class Frustum {
     }
 
     /**
+     * Writes the frustum's corner points, as x, y, z triples, by intersecting its plane triplets.
+     *
+     * @param {Float64Array} out - Receives up to eight corners, as 24 floats.
+     * @returns {number} The number of corners written. Fewer than eight means some plane triplets
+     * do not meet in a single finite point, which happens for a degenerate frustum.
+     * @ignore
+     */
+    getCorners(out) {
+        const data = this.planeData;
+        let count = 0;
+
+        // (FAR|NEAR) x (RIGHT|LEFT) x (BOTTOM|TOP) triplets - see the plane order in setFromMat4
+        for (let zi = 4; zi <= 5; zi++) {
+            for (let xi = 0; xi <= 1; xi++) {
+                for (let yi = 2; yi <= 3; yi++) {
+                    if (intersectPlanes(data, zi * 4, xi * 4, yi * 4, out, count * 3)) {
+                        count++;
+                    }
+                }
+            }
+        }
+
+        return count;
+    }
+
+    /**
      * Expands this frustum to also contain another frustum. The other frustum's 8 corner points
      * are computed, and each of this frustum's planes is pushed outwards just far enough to
      * contain them all. The result is a conservative convex volume that contains both frustums.
@@ -232,31 +272,22 @@ class Frustum {
      */
     add(other) {
         const data = this.planeData;
+        const count = other.getCorners(_corners);
 
-        // the other frustum's planes as objects, for the three-plane intersection below. This runs
-        // a couple of times per frame at most - only stereo XR uses it - so the unpacking is free.
-        for (let p = 0; p < 6; p++) {
-            other.getPlane(p, _scratchPlanes[p]);
-        }
+        for (let c = 0; c < count * 3; c += 3) {
+            const x = _corners[c];
+            const y = _corners[c + 1];
+            const z = _corners[c + 2];
 
-        // The 8 corners of the other frustum: intersections of (FAR|NEAR) x (RIGHT|LEFT) x
-        // (BOTTOM|TOP) plane triplets - see the plane order in setFromMat4.
-        for (let zi = 4; zi <= 5; zi++) {
-            for (let xi = 0; xi <= 1; xi++) {
-                for (let yi = 2; yi <= 3; yi++) {
-                    if (intersectPlanes(_scratchPlanes[zi], _scratchPlanes[xi], _scratchPlanes[yi], _corner)) {
-                        // push out any plane the corner is behind, so it ends up on the plane
-                        for (let offset = 0; offset < 24; offset += 4) {
-                            const d = data[offset] * _corner.x + data[offset + 1] * _corner.y +
-                                data[offset + 2] * _corner.z + data[offset + 3];
-                            if (d < 0) {
-                                data[offset + 3] -= d;
-                            }
-                        }
-                    }
+            // push out any plane the corner is behind, so it ends up on the plane
+            for (let offset = 0; offset < 24; offset += 4) {
+                const d = data[offset] * x + data[offset + 1] * y + data[offset + 2] * z + data[offset + 3];
+                if (d < 0) {
+                    data[offset + 3] -= d;
                 }
             }
         }
+
         return this;
     }
 

--- a/src/scene/renderer/culler.js
+++ b/src/scene/renderer/culler.js
@@ -185,7 +185,9 @@ class Culler {
             const light = localLights[i];
             if (light._type !== LIGHTTYPE_DIRECTIONAL) {
                 if (light.visibleThisFrame && light.castShadows && light.shadowUpdateMode !== SHADOWUPDATE_NONE) {
-                    renderer._shadowRendererLocal.cull(light, comp);
+                    // the composition's cameras are the ones that can sample this shadow map, which
+                    // lets an omni light skip the cube map faces none of them reach
+                    renderer._shadowRendererLocal.cull(light, comp, null, comp.cameras);
                 }
             }
         }

--- a/src/scene/renderer/shadow-renderer-local.js
+++ b/src/scene/renderer/shadow-renderer-local.js
@@ -1,17 +1,66 @@
 import { math } from '../../core/math/math.js';
+import { Vec3 } from '../../core/math/vec3.js';
 import {
-    LIGHTTYPE_OMNI, LIGHTTYPE_SPOT
+    LIGHTTYPE_OMNI, LIGHTTYPE_SPOT, SHADOWUPDATE_REALTIME
 } from '../constants.js';
 import { ShadowMap } from './shadow-map.js';
 import { RenderPassShadowLocalNonClustered } from './render-pass-shadow-local-non-clustered.js';
 
 /**
+ * @import { Camera } from '../camera.js'
+ * @import { CameraComponent } from '../../framework/components/camera/component.js'
  * @import { FrameGraph } from '../../scene/frame-graph.js'
+ * @import { Frustum } from '../../core/shape/frustum.js'
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ * @import { LayerComposition } from '../composition/layer-composition.js'
  * @import { Light } from '../../scene/light.js'
+ * @import { MeshInstance } from '../mesh-instance.js'
  * @import { Renderer } from './renderer.js'
  * @import { ShadowRenderer } from './shadow-renderer.js'
  */
+
+// a bit per omni shadow cube map face
+const ALL_FACES = 0x3f;
+
+// the world axis each omni cube map face looks down, in the face order of
+// LightCamera.pointLightRotations: +X, -X, +Y, -Y, +Z, -Z. Each entry is the axis index the face
+// looks along, the sign of that axis, and the two lateral axis indices.
+const FACE_AXES = [
+    [0, 1, 1, 2], [0, -1, 1, 2],
+    [1, 1, 0, 2], [1, -1, 0, 2],
+    [2, 1, 0, 1], [2, -1, 0, 1]
+];
+
+// scratch corner sets, as flat [x, y, z] triples
+const _cameraCorners = new Float64Array(24);
+const _faceCorners = new Float64Array(24);
+const _lightPos = new Vec3();
+
+/**
+ * Tests whether every one of the eight corners lies outside a single plane of the frustum, which
+ * proves the two volumes are disjoint. The converse does not hold - two disjoint volumes can fail
+ * this test - so it is conservative in the safe direction.
+ *
+ * @param {Frustum} frustum - The frustum whose planes are tested.
+ * @param {Float64Array} corners - 8 corners as 24 floats.
+ * @returns {boolean} True when the corners are all outside one plane.
+ */
+function outsideAnyPlane(frustum, corners) {
+    const p = frustum.planeData;
+    for (let o = 0; o < 24; o += 4) {
+        let allOutside = true;
+        for (let c = 0; c < 24; c += 3) {
+            if (p[o] * corners[c] + p[o + 1] * corners[c + 1] + p[o + 2] * corners[c + 2] + p[o + 3] >= 0) {
+                allOutside = false;
+                break;
+            }
+        }
+        if (allOutside) {
+            return true;
+        }
+    }
+    return false;
+}
 
 class ShadowRendererLocal {
     // temporary list to collect lights to render shadows for
@@ -43,8 +92,98 @@ class ShadowRendererLocal {
         }
     }
 
-    // cull local shadow map
-    cull(light, comp, casters = null) {
+    /**
+     * Which of an omni light's six shadow cube map faces can be sampled by any of the supplied
+     * cameras. All six face frusta share the light's position as their apex, so a light sitting
+     * inside a camera's frustum always needs all six - the saving is for lights outside a frustum
+     * whose range still reaches into it.
+     *
+     * Only ever called for lights whose shadow is re-rendered every frame. A cached shadow must
+     * keep all six faces: it would be retired by {@link Culler#consumeOneShotShadows} after the
+     * partial render and could never fill in a face that a later camera position needs.
+     *
+     * @param {Light} light - The omni light, with its shadow cameras already set up.
+     * @param {CameraComponent[]} cameras - The cameras that may sample this shadow map.
+     * @returns {number} A bit per face, in the face order of LightCamera.pointLightRotations.
+     * @private
+     */
+    _visibleShadowFaces(light, cameras) {
+
+        const range = light.attenuationEnd;
+        _lightPos.copy(light._node.getPosition());
+
+        let mask = 0;
+        for (let c = 0; c < cameras.length && mask !== ALL_FACES; c++) {
+
+            const cameraComponent = cameras[c];
+            if (!cameraComponent.enabled) {
+                continue;
+            }
+            const camera = cameraComponent.camera;
+
+            // a light inside the frustum needs every face, and this is the common case, so it is
+            // worth short circuiting before any per-face work
+            if (camera.frustum.containsPoint(_lightPos)) {
+                return ALL_FACES;
+            }
+
+            // degenerate frustum (a zero sized canvas gives one) - assume everything is needed
+            if (camera.frustum.getCorners(_cameraCorners) !== 8) {
+                return ALL_FACES;
+            }
+
+            for (let face = 0; face < 6; face++) {
+                const bit = 1 << face;
+                if (mask & bit) {
+                    continue;
+                }
+
+                const shadowCam = light.getRenderData(null, face).shadowCamera;
+                const axis = FACE_AXES[face];
+                const slope = Math.tan(shadowCam.fov * 0.5 * math.DEG_TO_RAD);
+                const near = shadowCam.nearClip;
+
+                // the face's eight corners: the near and far quads of its pyramid
+                let n = 0;
+                for (const axial of [near, range]) {
+                    const lateral = axial * slope;
+                    for (const su of [-1, 1]) {
+                        for (const sv of [-1, 1]) {
+                            _faceCorners[n] = _lightPos.x;
+                            _faceCorners[n + 1] = _lightPos.y;
+                            _faceCorners[n + 2] = _lightPos.z;
+                            _faceCorners[n + axis[0]] += axis[1] * axial;
+                            _faceCorners[n + axis[2]] += su * lateral;
+                            _faceCorners[n + axis[3]] += sv * lateral;
+                            n += 3;
+                        }
+                    }
+                }
+
+                if (!outsideAnyPlane(camera.frustum, _faceCorners) &&
+                    !outsideAnyPlane(shadowCam.frustum, _cameraCorners)) {
+                    mask |= bit;
+                }
+            }
+        }
+
+        return mask;
+    }
+
+    /**
+     * Culls the shadow casters of a local light.
+     *
+     * @param {Light} light - The light.
+     * @param {LayerComposition} comp - The layer composition, used as the source of shadow casters
+     * when they are not supplied directly.
+     * @param {MeshInstance[]} [casters] - Optional shadow casters to use instead of the
+     * composition's.
+     * @param {CameraComponent[]} [cameras] - The cameras that may sample this shadow map. When
+     * supplied, an omni light's cube map faces that none of them can sample are skipped. Omit it
+     * when there is no camera context - the lightmapper bakes with its own cameras - and all six
+     * faces are culled and rendered.
+     */
+    cull(light, comp, casters = null, cameras = null) {
 
         const isClustered = this.renderer.scene.clusteredLightingEnabled;
 
@@ -100,7 +239,16 @@ class ShadowRendererLocal {
         }
 
         if (type === LIGHTTYPE_OMNI) {
-            this.shadowRenderer.cullShadowCastersOmni(comp, light, casters);
+
+            // Skip the faces no camera can sample. Only for shadows that re-render every frame, so
+            // a face that becomes visible later is simply rendered on that frame - see
+            // _visibleShadowFaces. The skipped faces are still cleared by the render pass, they
+            // just get no casters, so a face wrongly skipped costs a missing shadow rather than
+            // leaving another light's depth in the atlas tile.
+            const faceMask = (cameras && light.shadowUpdateMode === SHADOWUPDATE_REALTIME) ?
+                this._visibleShadowFaces(light, cameras) : ALL_FACES;
+
+            this.shadowRenderer.cullShadowCastersOmni(comp, light, casters, faceMask);
         }
     }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -262,8 +262,10 @@ class ShadowRenderer {
      * if those are not provided directly.
      * @param {Light} light - The omni light.
      * @param {MeshInstance[]} [casters] - Optional array of mesh instances to use as casters.
+     * @param {number} [faceMask] - A bit per face; faces whose bit is clear get an empty caster
+     * list, as no camera can sample them. Defaults to all six faces.
      */
-    cullShadowCastersOmni(comp, light, casters) {
+    cullShadowCastersOmni(comp, light, casters, faceMask = 0x3f) {
 
         Debug.assert(light._type === LIGHTTYPE_OMNI);
 
@@ -313,6 +315,14 @@ class ShadowRenderer {
             }
         });
 
+        // hoisted out of the caster loop below - a face no camera can sample is skipped entirely
+        const face0 = (faceMask & 1) !== 0;
+        const face1 = (faceMask & 2) !== 0;
+        const face2 = (faceMask & 4) !== 0;
+        const face3 = (faceMask & 8) !== 0;
+        const face4 = (faceMask & 16) !== 0;
+        const face5 = (faceMask & 32) !== 0;
+
         const casterLists = this._collectCasterLists(comp, light, casters);
         for (let listIndex = 0; listIndex < casterLists.length; listIndex++) {
 
@@ -329,6 +339,9 @@ class ShadowRenderer {
                 // custom visibility function need to evaluate it for each face's shadow camera
                 if (!meshInstance.cull || meshInstance.isVisibleFunc) {
                     for (let face = 0; face < 6; face++) {
+                        if ((faceMask & (1 << face)) === 0) {
+                            continue;
+                        }
                         if (!meshInstance.cull || meshInstance._isVisible(_faceCameras[face])) {
                             meshInstance.visibleThisFrame = true;
                             _faceLists[face].push(meshInstance);
@@ -377,7 +390,7 @@ class ShadowRenderer {
                 let visible = false;
 
                 // +X
-                if (x + ex > near && x - ex < far &&
+                if (face0 && x + ex > near && x - ex < far &&
                     slopeX - y > limXY && slopeX + y > limXY &&
                     slopeX - z > limXZ && slopeX + z > limXZ) {
                     _faceLists[0].push(meshInstance);
@@ -385,7 +398,7 @@ class ShadowRenderer {
                 }
 
                 // -X
-                if (-x + ex > near && -x - ex < far &&
+                if (face1 && -x + ex > near && -x - ex < far &&
                     -slopeX - y > limXY && -slopeX + y > limXY &&
                     -slopeX - z > limXZ && -slopeX + z > limXZ) {
                     _faceLists[1].push(meshInstance);
@@ -393,7 +406,7 @@ class ShadowRenderer {
                 }
 
                 // +Y
-                if (y + ey > near && y - ey < far &&
+                if (face2 && y + ey > near && y - ey < far &&
                     slopeY - x > limYX && slopeY + x > limYX &&
                     slopeY - z > limYZ && slopeY + z > limYZ) {
                     _faceLists[2].push(meshInstance);
@@ -401,7 +414,7 @@ class ShadowRenderer {
                 }
 
                 // -Y
-                if (-y + ey > near && -y - ey < far &&
+                if (face3 && -y + ey > near && -y - ey < far &&
                     -slopeY - x > limYX && -slopeY + x > limYX &&
                     -slopeY - z > limYZ && -slopeY + z > limYZ) {
                     _faceLists[3].push(meshInstance);
@@ -409,7 +422,7 @@ class ShadowRenderer {
                 }
 
                 // +Z
-                if (z + ez > near && z - ez < far &&
+                if (face4 && z + ez > near && z - ez < far &&
                     slopeZ - x > limZX && slopeZ + x > limZX &&
                     slopeZ - y > limZY && slopeZ + y > limZY) {
                     _faceLists[4].push(meshInstance);
@@ -417,7 +430,7 @@ class ShadowRenderer {
                 }
 
                 // -Z
-                if (-z + ez > near && -z - ez < far &&
+                if (face5 && -z + ez > near && -z - ez < far &&
                     -slopeZ - x > limZX && -slopeZ + x > limZX &&
                     -slopeZ - y > limZY && -slopeZ + y > limZY) {
                     _faceLists[5].push(meshInstance);

--- a/test/scene/renderer/shadow-renderer-local.test.mjs
+++ b/test/scene/renderer/shadow-renderer-local.test.mjs
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { Vec3 } from '../../../src/core/math/vec3.js';
 import { BoundingSphere } from '../../../src/core/shape/bounding-sphere.js';
 import { Entity } from '../../../src/framework/entity.js';
+import { SHADOWUPDATE_REALTIME, SHADOWUPDATE_THISFRAME } from '../../../src/scene/constants.js';
 import { createApp } from '../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
@@ -44,6 +45,38 @@ describe('ShadowRendererLocal', function () {
         entity.setPosition(position);
         app.root.addChild(entity);
         return entity.light.light;
+    };
+
+    /**
+     * @param {Vec3} position - The camera position.
+     * @param {Vec3} target - The point the camera looks at.
+     * @returns {object} The camera component.
+     */
+    const createCamera = (position, target) => {
+        const entity = new Entity();
+        entity.addComponent('camera', { fov: 60, nearClip: 1, farClip: 1000 });
+        app.root.addChild(entity);
+        entity.setPosition(position);
+        entity.lookAt(target);
+        entity.camera.camera.updateFrustum();
+        return entity.camera;
+    };
+
+    /**
+     * Culls with a camera list, so an omni light can skip the faces none of them reach.
+     *
+     * @param {Light} light - The light.
+     * @param {MeshInstance[]} casters - The casters.
+     * @param {object[]} cameras - The camera components.
+     * @returns {number[]} The number of casters in each face.
+     */
+    const cullWithCameras = (light, casters, cameras) => {
+        app.renderer._shadowRendererLocal.cull(light, app.scene.layers, casters, cameras);
+        const counts = [];
+        for (let face = 0; face < light.numShadowFaces; face++) {
+            counts.push(light.getRenderData(null, face).visibleCasters.length);
+        }
+        return counts;
     };
 
     /**
@@ -329,6 +362,83 @@ describe('ShadowRendererLocal', function () {
             // cases the two tests disagree on
             expect(visible).to.be.greaterThan(100);
             expect(dropped).to.be.greaterThan(0);
+        });
+    });
+
+    describe('#cull - omni face culling', function () {
+
+        it('needs all six faces when the light is inside the camera frustum', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const caster = createCaster(new Vec3(0, 0, 0), 4);
+            const camera = createCamera(new Vec3(0, 0, 300), new Vec3(0, 0, 0));
+
+            // every face frustum has the light's position as its apex, so a light the camera
+            // contains can have no face rejected
+            expect(cullWithCameras(light, [caster], [camera])).to.eql([1, 1, 1, 1, 1, 1]);
+        });
+
+        it('skips faces a camera looking away cannot reach', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const caster = createCaster(new Vec3(0, 0, 0), 4);
+
+            // the camera sits to one side of the light, looking away from it along +x, so the
+            // faces on the far side of the light are out of reach
+            const camera = createCamera(new Vec3(60, 0, 0), new Vec3(400, 0, 0));
+
+            const counts = cullWithCameras(light, [caster], [camera]);
+            const facesWithCasters = counts.filter(c => c > 0).length;
+            expect(facesWithCasters, 'some faces should be skipped').to.be.lessThan(6);
+            expect(facesWithCasters, 'and some should remain').to.be.greaterThan(0);
+        });
+
+        it('unions the faces needed across several cameras', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const caster = createCaster(new Vec3(0, 0, 0), 4);
+            const a = createCamera(new Vec3(60, 0, 0), new Vec3(400, 0, 0));
+            const b = createCamera(new Vec3(-60, 0, 0), new Vec3(-400, 0, 0));
+
+            const one = cullWithCameras(light, [caster], [a]).map(c => c > 0);
+            const two = cullWithCameras(light, [caster], [b]).map(c => c > 0);
+            const both = cullWithCameras(light, [caster], [a, b]).map(c => c > 0);
+
+            for (let face = 0; face < 6; face++) {
+                expect(both[face], `face ${face}`).to.equal(one[face] || two[face]);
+            }
+        });
+
+        it('ignores a disabled camera', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const caster = createCaster(new Vec3(0, 0, 0), 4);
+            const away = createCamera(new Vec3(60, 0, 0), new Vec3(400, 0, 0));
+            const containing = createCamera(new Vec3(0, 0, 300), new Vec3(0, 0, 0));
+            containing.enabled = false;
+
+            // with the containing camera disabled the mask comes from the other one alone
+            const withDisabled = cullWithCameras(light, [caster], [away, containing]);
+            const awayOnly = cullWithCameras(light, [caster], [away]);
+            expect(withDisabled).to.eql(awayOnly);
+        });
+
+        it('keeps all six faces for a shadow that does not re-render every frame', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const caster = createCaster(new Vec3(0, 0, 0), 4);
+            const camera = createCamera(new Vec3(60, 0, 0), new Vec3(400, 0, 0));
+
+            // a one shot update is retired after this render, so a face skipped now could never be
+            // filled in later - such a light must render every face
+            light.shadowUpdateMode = SHADOWUPDATE_THISFRAME;
+            expect(cullWithCameras(light, [caster], [camera])).to.eql([1, 1, 1, 1, 1, 1]);
+
+            light.shadowUpdateMode = SHADOWUPDATE_REALTIME;
+            expect(cullWithCameras(light, [caster], [camera]).filter(c => c > 0).length).to.be.lessThan(6);
+        });
+
+        it('keeps all six faces when no cameras are supplied', function () {
+            const light = createLight(new Vec3(0, 0, 0));
+            const caster = createCaster(new Vec3(0, 0, 0), 4);
+
+            // the lightmapper bakes with its own cameras and calls cull without a camera list
+            expect(cullFaces(light, [caster]).map(f => f.size)).to.eql([1, 1, 1, 1, 1, 1]);
         });
     });
 


### PR DESCRIPTION
Addresses #643.

An omni light renders all six faces of its shadow cube map whenever the light is visible, and the light's bounding sphere passing the camera frustum test is the only gate. A light whose range reaches into the view from off screen therefore pays for six faces even when most of them cover space no camera can see.

**Changes:**
- Each face frustum is tested against the frustum of every camera that may sample the shadow map, and faces none of them reach are skipped. All six face frusta share the light's position as their apex, so a light *inside* a camera frustum still needs every face — the saving is for lights outside a frustum whose range reaches in, which is the case that costs the most.
- The mask is only applied to lights whose shadow re-renders every frame. Face culling can only ever save per-frame work, and per-frame shadow work only comes from those lights, since a one shot update renders once ever. Restricting it that way gives up nothing and avoids retiring a one shot update after a *partial* render, which would leave faces that could never be filled in when the camera later moves to sample them. It also means the mask needs no persistent state — it is recomputed each frame, so a face that becomes visible is simply rendered on that frame.
- Skipped faces are still cleared by the render pass and just receive no casters, so a face wrongly skipped costs a missing shadow rather than leaving a previous atlas tenant's depth to be sampled.
- Culling without a camera list keeps all six faces, which is what the lightmapper gets — it bakes with its own cameras.
- `Frustum#getCorners` is extracted for the test, and `Frustum#add` now uses it rather than repeating the plane triplet intersection with its own scratch planes. `intersectPlanes` works on the packed plane data directly, which drops the scratch `Plane` and `Vec3` objects from `frustum.js`.

**Performance:**

Measured on the clustered omni shadows example by toggling the mask within a single page load, so the scene, camera and frame state are identical on both sides:

| camera | shadow draw calls | |
| --- | --- | --- |
| far away, scene centred (14 forward draws) | 433 → 343 | −20.8% |
| scene at the edge of the view | 628 → 544 | −13.4% |
| from inside the scene | 628 → 620 | −1.3% |
| pointed away from the scene | 0 → 0 | light culling already handles this |

No pixel differs at any of those poses, with an unchanged-versus-unchanged control to confirm the comparison is stable. The saving is largest exactly where the forward pass sees almost nothing but the lights are still visible, and it can never reach zero, since a light whose position is inside the frustum cannot have any face rejected.

Six tests cover the apex case, the union across several cameras, disabled cameras, the update mode gating, and the no-camera-list default.