### PR TITLE
Fix ScriptComponent clone dropping scripts awaiting their script type

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -198,6 +198,10 @@ class ScriptComponent extends Component {
         this._postUpdateList = new SortedLoopArray({ sortBy: '__executionOrder' });
 
         this._scriptsIndex = {};
+        // the names of all scripts declared on this component, created or still awaiting their
+        // script type, in the order they were declared. Unlike the key order of `_scriptsIndex`
+        // this is reliable for any script name, and unlike `_scripts` it is not affected by move()
+        this._declarationOrder = [];
         this._destroyedScripts = [];
         this._destroyed = false;
         this._scriptsData = null;
@@ -751,6 +755,10 @@ class ScriptComponent extends Component {
 
                 this._insertScriptInstance(scriptInstance, ind, len);
 
+                if (!this._scriptsIndex[scriptName]) {
+                    this._declarationOrder.push(scriptName);
+                }
+
                 this._scriptsIndex[scriptName] = {
                     instance: scriptInstance,
                     onSwap: function () {
@@ -793,6 +801,10 @@ class ScriptComponent extends Component {
 
             Debug.warn(`script '${scriptName}' is already added to entity '${this.entity.name}'`);
         } else {
+            if (!this._scriptsIndex[scriptName]) {
+                this._declarationOrder.push(scriptName);
+            }
+
             this._scriptsIndex[scriptName] = {
                 awaiting: true,
                 ind: this._scripts.length
@@ -826,6 +838,11 @@ class ScriptComponent extends Component {
         const scriptData = this._scriptsIndex[scriptName];
         delete this._scriptsIndex[scriptName];
         if (!scriptData) return false;
+
+        const declarationIndex = this._declarationOrder.indexOf(scriptName);
+        if (declarationIndex !== -1) {
+            this._declarationOrder.splice(declarationIndex, 1);
+        }
 
         this._attributeDataMap.delete(scriptName);
 

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -121,10 +121,31 @@ class ScriptComponentSystem extends ComponentSystem {
             };
         }
 
-        for (const key in entity.script._scriptsIndex) {
-            if (key.awaiting) {
-                order.splice(key.ind, 0, key);
+        // scripts still awaiting their script type to be added to the registry have no instance
+        // to read from, so restore them from the data they were declared with. Their entry in
+        // `scripts` is required, otherwise initializeComponentData throws when it looks up the
+        // name coming from `order`.
+        let previousName = null;
+        for (const scriptName of entity.script._declarationOrder) {
+            const indexData = entity.script._scriptsIndex[scriptName];
+
+            // scripts that have an instance are already in `order`
+            if (!indexData?.awaiting) {
+                if (indexData?.instance) previousName = scriptName;
+                continue;
             }
+
+            // place the script directly after the one it was declared after, which is where the
+            // deferred creation in ScriptRegistry#add will put it on the source entity
+            const ind = previousName === null ? 0 : order.indexOf(previousName) + 1;
+            order.splice(ind, 0, scriptName);
+            previousName = scriptName;
+
+            const scriptData = entity.script._scriptsData?.[scriptName];
+            scripts[scriptName] = {
+                enabled: scriptData?.enabled ?? true,
+                attributes: { ...scriptData?.attributes }
+            };
         }
 
         const data = {

--- a/src/framework/script/constants.js
+++ b/src/framework/script/constants.js
@@ -13,7 +13,7 @@ export const SCRIPT_SWAP = 'swap';
  */
 export const reservedScriptNames = new Set([
     'system', 'entity', 'create', 'destroy', 'swap', 'move', 'data',
-    'scripts', '_scripts', '_scriptsIndex', '_scriptsData',
+    'scripts', '_scripts', '_scriptsIndex', '_scriptsData', '_declarationOrder',
     'enabled', '_oldState', 'onEnable', 'onDisable', 'onPostStateChange',
     '_onSetEnabled', '_checkState', '_onBeforeRemove',
     '_onInitializeAttributes', '_onInitialize', '_onPostInitialize',

--- a/test/framework/components/script/component.test.mjs
+++ b/test/framework/components/script/component.test.mjs
@@ -1354,6 +1354,122 @@ describe('ScriptComponent', function () {
         app.assets.load(asset);
     });
 
+    it('cloning an entity preserves scripts that are awaiting their script type', function () {
+        const e = new Entity();
+        e.addComponent('script', {
+            enabled: true,
+            order: ['scriptA', 'loadedLater', 'scriptB'],
+            scripts: {
+                scriptA: { enabled: true, attributes: {} },
+                loadedLater: { enabled: false, attributes: { disableEntity: true } },
+                scriptB: { enabled: true, attributes: {} }
+            }
+        });
+        app.root.addChild(e);
+
+        const clone = e.clone();
+        app.root.addChild(clone);
+
+        const indexData = clone.script._scriptsIndex.loadedLater;
+        expect(indexData).to.exist;
+        expect(indexData.awaiting).to.equal(true);
+        expect(indexData.ind).to.equal(e.script._scriptsIndex.loadedLater.ind);
+
+        // the data the script will be created from once its type is registered is preserved too
+        expect(clone.script._scriptsData.loadedLater.enabled).to.equal(false);
+        expect(clone.script._scriptsData.loadedLater.attributes.disableEntity).to.equal(true);
+    });
+
+    it('cloning an entity keeps the relative order of consecutive awaiting scripts', function () {
+        const e = new Entity();
+        const order = ['scriptA', 'awaitingOne', 'awaitingTwo', 'scriptB', 'awaitingThree'];
+        const scripts = {};
+        order.forEach((name) => {
+            scripts[name] = { enabled: true, attributes: {} };
+        });
+        e.addComponent('script', { enabled: true, order: order, scripts: scripts });
+        app.root.addChild(e);
+
+        const clone = e.clone();
+        app.root.addChild(clone);
+
+        // initializeComponentData creates the scripts in `order`, so this is the order the
+        // clone was rebuilt with
+        expect(clone.script._declarationOrder).to.deep.equal(order);
+    });
+
+    it('cloning an entity keeps the declared order of awaiting scripts with integer-like names', function () {
+        const e = new Entity();
+        const order = ['scriptA', '10', '2', 'scriptB'];
+        const scripts = {};
+        order.forEach((name) => {
+            scripts[name] = { enabled: true, attributes: {} };
+        });
+        e.addComponent('script', { enabled: true, order: order, scripts: scripts });
+        app.root.addChild(e);
+
+        const clone = e.clone();
+        app.root.addChild(clone);
+
+        // integer-like keys are enumerated first, so the key order of `_scriptsIndex` is not the
+        // declared order here
+        expect(clone.script._declarationOrder).to.deep.equal(order);
+    });
+
+    it('cloning an entity places an awaiting script after the script it was declared after', function () {
+        const e = new Entity();
+        e.addComponent('script', {
+            enabled: true,
+            order: ['scriptA', 'scriptB', 'awaitingMoved'],
+            scripts: {
+                scriptA: { enabled: true, attributes: {} },
+                scriptB: { enabled: true, attributes: {} },
+                awaitingMoved: { enabled: true, attributes: {} }
+            }
+        });
+        app.root.addChild(e);
+
+        // the awaiting script was declared after scriptB, which now runs first
+        e.script.move('scriptB', 0);
+
+        const clone = e.clone();
+        app.root.addChild(clone);
+
+        expect(clone.script._declarationOrder).to.deep.equal(['scriptB', 'awaitingMoved', 'scriptA']);
+    });
+
+    it('scripts awaiting their script type are created on a clone when the type is registered', function (done) {
+        const e = new Entity();
+        e.addComponent('script', {
+            enabled: true,
+            order: ['scriptA', 'loadedLater', 'scriptB'],
+            scripts: {
+                scriptA: { enabled: true, attributes: {} },
+                loadedLater: { enabled: true, attributes: {} },
+                scriptB: { enabled: true, attributes: {} }
+            }
+        });
+        app.root.addChild(e);
+
+        const clone = e.clone();
+        app.root.addChild(clone);
+
+        expect(clone.script.loadedLater).to.not.exist;
+
+        const asset = app.assets.find('loadedLater.js', 'script');
+        app.scripts.on('add:loadedLater', function () {
+            setTimeout(function () {
+                expect(e.script.loadedLater).to.exist;
+                expect(clone.script.loadedLater).to.exist;
+                const names = clone.script.scripts.map(s => s.__scriptType.__name);
+                expect(names).to.deep.equal(['scriptA', 'loadedLater', 'scriptB']);
+                done();
+            }, 100);
+        });
+
+        app.assets.load(asset);
+    });
+
     it('destroying entity during update stops updating the rest of the entity\'s scripts', function () {
         const e = new Entity();
         e.addComponent('script', {


### PR DESCRIPTION
## Description

`ScriptComponentSystem#cloneComponent` iterated `_scriptsIndex` with `for...in` and checked `key.awaiting`, where `key` is the script name string — so the check was always `undefined` and the whole block was dead code:

```js
for (const key in entity.script._scriptsIndex) {
    if (key.awaiting) {              // always falsy
        order.splice(key.ind, 0, key);
    }
}
```

Cloning an entity therefore silently dropped any script whose script type was not in the registry yet. When the type was later registered, the deferred sweep in `ScriptRegistry#add` created the script on the original entity, but the clone had no awaiting entry so it never got one:

```
source: _scriptsIndex = [scriptA, loadedLater(awaiting,ind=1), scriptB]
clone : _scriptsIndex = [scriptA, scriptB]
--> after loadedLater is registered
source.script.loadedLater: EXISTS
clone.script.loadedLater : MISSING
```

## Fix

Dereferencing the index entry is not enough on its own:

- **The awaiting script also needs an entry in `scripts`.** `initializeComponentData` looks every name from `order` up in `scripts` (`data.scripts[data.order[i]].enabled`), so a name in `order` but missing from `scripts` throws `TypeError: Cannot read properties of undefined (reading 'enabled')` — a hard throw out of `entity.clone()` in place of the silent drop. The data comes from `_scriptsData`, which is also where the registry sweep reads the attributes from when it eventually creates the script.

- **The awaiting script needs a well-defined slot.** It is placed directly after the script it was declared after, which is where the deferred creation puts it on the source entity (see #9202), so source and clone converge on the same order.

That needs the declaration order of *all* scripts, created or not. Neither existing record is that: `_scripts` only holds created scripts and is reordered by `move()`, and the key order of `_scriptsIndex` is not declaration order for every accepted script name (integer-like keys are enumerated first, so `['scriptA', '10', '2', 'scriptB']` enumerates as `2, 10, scriptA, scriptB`). So it is recorded explicitly as `_declarationOrder`, maintained in `create()` / `destroy()`.

Supersedes #8264, which is the one-line dereference and hits the `TypeError` above.

Fixes #2796

## Testing

Five tests in `test/framework/components/script/component.test.mjs`, all five fail on `main`:

- the clone keeps the awaiting entry, its `ind`, and its declared `enabled` / attribute data
- consecutive awaiting scripts keep their relative order
- ...including with integer-like script names
- an awaiting script is placed after the script it was declared after, when that has been moved
- the clone gets the instance, in the right slot, once the script type is registered

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)