### PR TITLE
Keep the options an awaiting script was declared with

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -807,7 +807,13 @@ class ScriptComponent extends Component {
 
             this._scriptsIndex[scriptName] = {
                 awaiting: true,
-                ind: this._scripts.length
+                ind: this._scripts.length,
+                // remember what the script was asked to be created with, the deferred creation in
+                // ScriptRegistry#add has nothing else to go on for a script that was not declared
+                // through component data
+                enabled: args.hasOwnProperty('enabled') ? args.enabled : true,
+                attributes: args.attributes,
+                properties: args.properties
             };
 
             Debug.warn(`script '${scriptName}' is not found, awaiting it to be added to registry`);

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -141,10 +141,10 @@ class ScriptComponentSystem extends ComponentSystem {
             order.splice(ind, 0, scriptName);
             previousName = scriptName;
 
-            const scriptData = entity.script._scriptsData?.[scriptName];
+            // the same declaration the deferred creation will read on the source entity
             scripts[scriptName] = {
-                enabled: scriptData?.enabled ?? true,
-                attributes: { ...scriptData?.attributes }
+                enabled: indexData.enabled,
+                attributes: { ...indexData.attributes }
             };
         }
 

--- a/src/framework/script/script-registry.js
+++ b/src/framework/script/script-registry.js
@@ -170,22 +170,23 @@ class ScriptRegistry extends EventHandler {
             }
 
             const components = this.app.systems.script._components;
-            let attributes;
             const scriptInstances = [];
             const scriptInstancesInitialized = [];
 
             for (components.loopIndex = 0; components.loopIndex < components.length; components.loopIndex++) {
                 const component = components.items[components.loopIndex];
                 // check if awaiting for script
-                if (component._scriptsIndex[scriptName] && component._scriptsIndex[scriptName].awaiting) {
-                    if (component._scriptsData && component._scriptsData[scriptName]) {
-                        attributes = component._scriptsData[scriptName].attributes;
-                    }
+                const indexData = component._scriptsIndex[scriptName];
+                if (indexData && indexData.awaiting) {
 
+                    // the awaiting entry holds what this component asked for, which is both
+                    // per component and specific to the declaration that is still standing
                     const scriptInstance = component.create(scriptName, {
                         preloading: true,
-                        ind: component._scriptsIndex[scriptName].ind,
-                        attributes: attributes
+                        ind: indexData.ind,
+                        enabled: indexData.enabled,
+                        attributes: indexData.attributes,
+                        properties: indexData.properties
                     });
 
                     if (scriptInstance) {

--- a/test/framework/components/script/component.test.mjs
+++ b/test/framework/components/script/component.test.mjs
@@ -1470,6 +1470,153 @@ describe('ScriptComponent', function () {
         app.assets.load(asset);
     });
 
+    it('a disabled script added to the registry later stays disabled and is not initialized', function (done) {
+        const e = new Entity();
+        e.addComponent('script', {
+            enabled: true,
+            order: ['loadedLater'],
+            scripts: {
+                loadedLater: {
+                    enabled: false,
+                    attributes: {}
+                }
+            }
+        });
+
+        app.root.addChild(e);
+
+        const asset = app.assets.find('loadedLater.js', 'script');
+        app.scripts.on('add:loadedLater', function () {
+            setTimeout(function () {
+                expect(e.script.loadedLater).to.exist;
+                expect(e.script.loadedLater.enabled).to.equal(false);
+                expect(window.initializeCalls.length).to.equal(0);
+                done();
+            }, 100);
+        });
+
+        app.assets.load(asset);
+    });
+
+    it('a script created before its type is registered keeps the options it was created with', function (done) {
+        const e = new Entity();
+        e.addComponent('script', { enabled: true });
+
+        // declared through create() rather than component data, so there is no `_scriptsData`
+        e.script.create('loadedLater', {
+            enabled: false,
+            attributes: { disableEntity: true },
+            properties: { customValue: 42 }
+        });
+        app.root.addChild(e);
+
+        const asset = app.assets.find('loadedLater.js', 'script');
+        app.scripts.on('add:loadedLater', function () {
+            setTimeout(function () {
+                expect(e.script.loadedLater).to.exist;
+                expect(e.script.loadedLater.enabled).to.equal(false);
+                expect(e.script.loadedLater.disableEntity).to.equal(true);
+                expect(e.script.loadedLater.customValue).to.equal(42);
+                expect(window.initializeCalls.length).to.equal(0);
+                done();
+            }, 100);
+        });
+
+        app.assets.load(asset);
+    });
+
+    it('a clone keeps the options an awaiting script was created with', function (done) {
+        const e = new Entity();
+        e.addComponent('script', { enabled: true });
+        e.script.create('loadedLater', { enabled: false, attributes: { disableEntity: true } });
+        app.root.addChild(e);
+
+        const clone = e.clone();
+        app.root.addChild(clone);
+
+        const asset = app.assets.find('loadedLater.js', 'script');
+        app.scripts.on('add:loadedLater', function () {
+            setTimeout(function () {
+                expect(clone.script.loadedLater).to.exist;
+                expect(clone.script.loadedLater.enabled).to.equal(false);
+                expect(clone.script.loadedLater.disableEntity).to.equal(true);
+                done();
+            }, 100);
+        });
+
+        app.assets.load(asset);
+    });
+
+    it('recreating a destroyed awaiting script uses the newly supplied options', function (done) {
+        const e = new Entity();
+        e.addComponent('script', {
+            enabled: true,
+            order: ['loadedLater'],
+            scripts: {
+                loadedLater: {
+                    enabled: true,
+                    attributes: { disableEntity: true }
+                }
+            }
+        });
+        app.root.addChild(e);
+
+        // destroy() leaves the component data entry behind, so the replacement declaration must
+        // not be read out of it
+        expect(e.script.destroy('loadedLater')).to.equal(true);
+        e.script.create('loadedLater', { enabled: false, attributes: { disableEntity: false } });
+
+        const clone = e.clone();
+        app.root.addChild(clone);
+
+        const asset = app.assets.find('loadedLater.js', 'script');
+        app.scripts.on('add:loadedLater', function () {
+            setTimeout(function () {
+                expect(e.script.loadedLater.enabled).to.equal(false);
+                expect(e.script.loadedLater.disableEntity).to.equal(false);
+                expect(clone.script.loadedLater.enabled).to.equal(false);
+                expect(clone.script.loadedLater.disableEntity).to.equal(false);
+                expect(window.initializeCalls.length).to.equal(0);
+                done();
+            }, 100);
+        });
+
+        app.assets.load(asset);
+    });
+
+    it('attributes of a script added to the registry later are not shared between components', function (done) {
+        // declares attribute data for the script
+        const e1 = new Entity();
+        e1.addComponent('script', {
+            enabled: true,
+            order: ['loadedLater'],
+            scripts: {
+                loadedLater: {
+                    enabled: true,
+                    attributes: { disableScriptInstance: true }
+                }
+            }
+        });
+        app.root.addChild(e1);
+
+        // requests the same script without any attribute data
+        const e2 = new Entity();
+        e2.addComponent('script', { enabled: true });
+        e2.script.create('loadedLater');
+        app.root.addChild(e2);
+
+        const asset = app.assets.find('loadedLater.js', 'script');
+        app.scripts.on('add:loadedLater', function () {
+            setTimeout(function () {
+                expect(e1.script.loadedLater.disableScriptInstance).to.equal(true);
+                expect(e2.script.loadedLater.disableScriptInstance).to.equal(false);
+                done();
+            }, 100);
+        });
+
+        app.assets.load(asset);
+    });
+
     it('destroying entity during update stops updating the rest of the entity\'s scripts', function () {
         const e = new Entity();
         e.addComponent('script', {


### PR DESCRIPTION
## Description

> Stacked on #9200 — base is `mv-script-clone-awaiting`, review the [second commit](https://github.com/playcanvas/engine/pull/9201/commits) only.

When a script type is registered after the components referencing it were created, the deferred sweep in `ScriptRegistry#add` creates the script instances. It read the declared attributes out of `_scriptsData` but never the declared `enabled` flag, so `ScriptComponent#create` fell back to its `true` default. A script declared `enabled: false` came back **enabled** and got initialized — unlike the same script going through the eager `initializeComponentData` path.

Reproduces with no cloning involved:

```js
e.addComponent('script', {
    order: ['loadedLater'],
    scripts: { loadedLater: { enabled: false, attributes: {} } }
});
// ... once loadedLater is registered:
e.script.loadedLater.enabled;   // true, and initialize() has run
```

`_scriptsData` is only populated for scripts that came from component data, so a script created through the public `create()` path fared worse still — the awaiting entry kept nothing but `{ awaiting, ind }`, so `enabled`, `attributes` and the assigned `properties` were all dropped:

```js
e.script.create('later', {
    enabled: false,
    attributes: { speed: 42 },
    properties: { customValue: 42 }
});
// ... once the type is registered: enabled, initialized, speed and customValue gone
```

## Fix

The awaiting entry keeps all three, and is the *only* thing the deferred creation and `cloneComponent` read. So deferred creation ends up with the instance eager creation would have produced, on the entity and on a clone of it.

Reading `_scriptsData` was the underlying problem rather than an incomplete fix:

- it is not per declaration — `destroy()` drops the index entry but leaves `_scriptsData[name]` behind, so after `destroy('later')` + `create('later', { enabled: false })` the sweep would resurrect the *old* declaration's values
- it is not per component — the `attributes` local was declared outside the component loop and only reassigned when the component had `_scriptsData`, so a component with no declared data for that script inherited whichever earlier component in the loop had some

Both fall out of using the awaiting entry, which is created by the declaration that is actually standing, on the component that made it. Nothing needs to clear `_scriptsData`, so no caller-supplied `scripts` object gets mutated.

The eager path loses nothing by this: `initializeComponentData` passes the `_scriptsData` values into `create()`, so the awaiting entry captures exactly what was declared.

## Testing

Five tests in `test/framework/components/script/component.test.mjs`, all five fail without this commit:

- a script declared `enabled: false` stays disabled and is not initialized when its type is registered later
- a script created through `create()` before its type exists keeps its `enabled` flag, attributes and properties
- a clone of such a script keeps them too
- a destroyed-and-recreated awaiting script uses the new options, not the stale component data, on both the entity and a clone
- attribute data does not leak from one component to the next in the sweep

## Note

`properties` is deliberately *not* threaded through cloning. It has no representation in serialized component data, and `cloneComponent` does not carry assigned properties for scripts that already exist either — doing it for awaiting scripts only would make them clone richer than ordinary ones. The clone carries `enabled` and `attributes`, which do have a component data representation.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)