### PR TITLE
Create scripts added to the registry later at their declared index

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -519,6 +519,27 @@ class ScriptComponent extends Component {
     }
 
     /**
+     * Returns the index in {@link ScriptComponent#scripts} at which a script that has been
+     * awaiting its script type should be created: directly after the script it was declared
+     * after, skipping any scripts that do not exist yet. Unlike an index captured when the script
+     * was first declared this holds whichever order the script types end up being registered in,
+     * and it follows the preceding script if that has since been moved.
+     *
+     * @param {string} scriptName - The name of the awaiting script.
+     * @returns {number} The index to create the script instance at.
+     * @private
+     */
+    _awaitingInsertIndex(scriptName) {
+        let previous = null;
+        for (const name of this._declarationOrder) {
+            if (name === scriptName) break;
+            previous = this._scriptsIndex[name]?.instance ?? previous;
+        }
+
+        return previous ? this._scripts.indexOf(previous) + 1 : 0;
+    }
+
+    /**
      * Inserts script instance into the scripts array at the specified index. Also inserts the
      * script into the update list if it has an update method and the post update list if it has a
      * postUpdate method.

--- a/src/framework/script/script-registry.js
+++ b/src/framework/script/script-registry.js
@@ -183,7 +183,7 @@ class ScriptRegistry extends EventHandler {
                     // per component and specific to the declaration that is still standing
                     const scriptInstance = component.create(scriptName, {
                         preloading: true,
-                        ind: indexData.ind,
+                        ind: component._awaitingInsertIndex(scriptName),
                         enabled: indexData.enabled,
                         attributes: indexData.attributes,
                         properties: indexData.properties

--- a/test/framework/components/script/component.test.mjs
+++ b/test/framework/components/script/component.test.mjs
@@ -1617,6 +1617,83 @@ describe('ScriptComponent', function () {
         app.assets.load(asset);
     });
 
+    it('scripts added to the registry later are created in their declared order', function (done) {
+        const e = new Entity();
+        const order = ['scriptA', 'awaitingOne', 'awaitingTwo', 'scriptB', 'awaitingThree'];
+        const scripts = {};
+        order.forEach((name) => {
+            scripts[name] = { enabled: true, attributes: {} };
+        });
+        e.addComponent('script', { enabled: true, order: order, scripts: scripts });
+        app.root.addChild(e);
+
+        expect(e.script.scripts.map(s => s.__scriptType.__name)).to.deep.equal(['scriptA', 'scriptB']);
+
+        // register the missing script types out of their declared order
+        createScript('awaitingThree', app);
+        createScript('awaitingOne', app);
+        createScript('awaitingTwo', app);
+
+        setTimeout(function () {
+            expect(e.script.scripts.map(s => s.__scriptType.__name)).to.deep.equal(order);
+            done();
+        }, 100);
+    });
+
+    it('a script added to the registry later follows a preceding script that has been moved', function (done) {
+        const e = new Entity();
+        e.addComponent('script', {
+            enabled: true,
+            order: ['scriptA', 'scriptB', 'awaitingAfterMove'],
+            scripts: {
+                scriptA: { enabled: true, attributes: {} },
+                scriptB: { enabled: true, attributes: {} },
+                awaitingAfterMove: { enabled: true, attributes: {} }
+            }
+        });
+        app.root.addChild(e);
+
+        // the awaiting script is declared after scriptB, which now runs first
+        e.script.move('scriptB', 0);
+
+        createScript('awaitingAfterMove', app);
+
+        setTimeout(function () {
+            const names = e.script.scripts.map(s => s.__scriptType.__name);
+            expect(names).to.deep.equal(['scriptB', 'awaitingAfterMove', 'scriptA']);
+            done();
+        }, 100);
+    });
+
+    it('a clone ends up with the same script order as its source when an awaiting type is registered', function (done) {
+        const e = new Entity();
+        e.addComponent('script', {
+            enabled: true,
+            order: ['scriptA', 'scriptB', 'awaitingParity'],
+            scripts: {
+                scriptA: { enabled: true, attributes: {} },
+                scriptB: { enabled: true, attributes: {} },
+                awaitingParity: { enabled: true, attributes: {} }
+            }
+        });
+        app.root.addChild(e);
+
+        // clone a component whose scripts have been reordered and that has a script pending
+        e.script.move('scriptB', 0);
+
+        const clone = e.clone();
+        app.root.addChild(clone);
+
+        createScript('awaitingParity', app);
+
+        setTimeout(function () {
+            const names = ent => ent.script.scripts.map(s => s.__scriptType.__name);
+            expect(names(e)).to.deep.equal(['scriptB', 'awaitingParity', 'scriptA']);
+            expect(names(clone)).to.deep.equal(names(e));
+            done();
+        }, 100);
+    });
+
     it('destroying entity during update stops updating the rest of the entity\'s scripts', function () {
         const e = new Entity();
         e.addComponent('script', {


### PR DESCRIPTION
## Description

When a script is declared before its script type is registered, the awaiting entry stores `ind` — the number of script instances the component had at that moment:

```js
this._scriptsIndex[scriptName] = {
    awaiting: true,
    ind: this._scripts.length
};
```

The deferred sweep in `ScriptRegistry#add` then creates the instance at that index. By then other awaiting scripts may already have been created and shifted the array, and consecutive awaiting scripts all captured the *same* index. So the declared order is not preserved. Reproduces with no cloning involved — declaring `a, b, c, d, e, f` with `b`, `c`, `e` awaiting, then registering their types:

```
declared: a, b, c, d, e, f
actual  : a, c, e, b, d, f
```

## Fix

Derive the index when the script is actually created, from the `_declarationOrder` record #9200 added and rebuilds a clone from: the script belongs directly after the script it was declared after, skipping the ones that do not exist yet. That gives the declared order for *any* registration order, and — unlike a captured index — follows the preceding script if it has since been `move()`d.

Sharing one rule with the clone reconstruction is what keeps a source and its clone converging on the same order: with two different mechanisms, cloning a component that had been reordered and still had a script pending gave the source `[B, X, A]` and the clone `[B, A, X]`.

The awaiting entry keeps `ind`. It is no longer read by the engine, but it is part of the shape of `_scriptsIndex` entries.

Last of the awaiting-script fixes after #9200 and #9201.

## Testing

Three tests in `test/framework/components/script/component.test.mjs`, all three fail on `main`:

- three awaiting scripts, types registered out of their declared order, end up in declared order
- an awaiting script follows a preceding script that was moved before its type was registered
- a clone ends up with the same script order as its source, for that same move-then-register case

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)