### PR TITLE
Copy the ESM script attribute data when cloning a script component

### DIFF
--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -110,7 +110,8 @@ class ScriptComponentSystem extends ComponentSystem {
             const scriptName = scriptInstance.__scriptType.__name;
             order.push(scriptName);
 
-            const attributes = entity.script._attributeDataMap?.get(scriptName) || { };
+            // copy, the map holds the source component's own attribute data
+            const attributes = { ...entity.script._attributeDataMap?.get(scriptName) };
             for (const key in scriptInstance.__attributes) {
                 attributes[key] = scriptInstance.__attributes[key];
             }

--- a/test/framework/components/script/component.test.mjs
+++ b/test/framework/components/script/component.test.mjs
@@ -3269,6 +3269,31 @@ describe('ScriptComponent', function () {
         expect(e.script.has(null)).to.equal(false);
     });
 
+    it('cloning an entity does not share the attribute data of an ESM script with the clone', function () {
+        class CloneAttributes extends Script {
+            static scriptName = 'cloneAttributes';
+        }
+
+        app.scripts.addSchema('cloneAttributes', { attributes: { speed: { type: 'number' } } });
+
+        const e = new Entity();
+        e.addComponent('script', { enabled: true });
+        e.script.create(CloneAttributes, { attributes: { speed: 42 } });
+        app.root.addChild(e);
+
+        const clone = e.clone();
+        app.root.addChild(clone);
+
+        const sourceData = e.script._attributeDataMap.get('cloneAttributes');
+        const cloneData = clone.script._scriptsData.cloneAttributes.attributes;
+
+        expect(cloneData).to.deep.equal({ speed: 42 });
+        expect(cloneData).to.not.equal(sourceData);
+
+        cloneData.speed = 7;
+        expect(sourceData.speed).to.equal(42);
+    });
+
     it('warns when an ESM Script class does not have a static "scriptName" property', function () {
         class TestScript extends Script {}
         const a =  new Entity();


### PR DESCRIPTION
## Description

Hardening, no user-visible bug today.

`cloneComponent` passed the source component's own `_attributeDataMap` entry straight into the clone's component data:

```js
const attributes = entity.script._attributeDataMap?.get(scriptName) || { };
for (const key in scriptInstance.__attributes) {
    attributes[key] = scriptInstance.__attributes[key];   // writes into the source's object
}
```

`initializeComponentData` then does `component._scriptsData = data.scripts`, so the clone's `_scriptsData` ends up holding the very object the source reads its attribute values back from — anything writing through one writes through the other.

Nothing mutates it as things stand: `__attributes` only exists on `ScriptType` instances, and those never get an `_attributeDataMap` entry (`create` only populates the map for non-`ScriptType` scripts), so the copy loop is a no-op for exactly the scripts the map holds data for. The two happen to be disjoint, which is what keeps the loop above from writing into the source component. That is a fragile thing to rely on, so copy.

## Testing

One test in `test/framework/components/script/component.test.mjs`, fails on `main`: the clone's attribute data is a distinct object, and writing to it does not change the source's.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)