### PR TITLE
Do not throw when an ESM script has attribute data but no schema

### DIFF
--- a/src/framework/components/script/component.js
+++ b/src/framework/components/script/component.js
@@ -431,10 +431,12 @@ class ScriptComponent extends Component {
                 return;
             }
 
-            // Fetch schema and warn if it doesn't exist
+            // Fetch schema and warn if it doesn't exist. Without one there is nothing to assign
+            // the data against, so there is no point in carrying on
             const schema = this.system.app.scripts?.getSchema(name);
             if (!schema) {
                 Debug.warnOnce(`No schema exists for the script '${name}'. A schema must exist for data to be instantiated on the script.`);
+                return;
             }
 
             // Assign the attributes to the script instance based on the attribute schema

--- a/test/framework/components/script/component.test.mjs
+++ b/test/framework/components/script/component.test.mjs
@@ -3341,6 +3341,23 @@ describe('ScriptComponent', function () {
         expect(a.script._scriptsIndex.undefined).to.equal(undefined);
     });
 
+    it('does not throw when an ESM script has attribute data but no schema', function () {
+        class NoSchemaScript extends Script {
+            static scriptName = 'noSchemaScript';
+        }
+
+        const e = new Entity();
+        e.addComponent('script', { enabled: true });
+        app.root.addChild(e);
+
+        expect(() => e.script.create(NoSchemaScript, { attributes: { speed: 42 } })).to.not.throw();
+        expect(e.script.noSchemaScript).to.exist;
+        expect(e.script.noSchemaScript.speed).to.not.exist;
+        expect(Debug._loggedMessages.has(
+            'No schema exists for the script \'noSchemaScript\'. A schema must exist for data to be instantiated on the script.'
+        )).to.equal(true);
+    });
+
     it('does not warn when a ScriptType is used', function () {
         Debug._loggedMessages.clear();
         createScript('nullScript');


### PR DESCRIPTION
## Description

`ScriptComponent#initializeAttributes` warns that a schema is required for the data to be instantiated, then falls straight through and dereferences it anyway:

```js
const schema = this.system.app.scripts?.getSchema(name);
if (!schema) {
    Debug.warnOnce(`No schema exists for the script '${name}'. ...`);
}

assignAttributesToScript(this.system.app, schema.attributes, data, script);
```

So creating a `Script` class with attribute data but no registered schema throws `TypeError: Cannot read properties of undefined (reading 'attributes')` out of `ScriptComponent#create`, rather than just warning:

```js
class MyScript extends Script {
    static scriptName = 'myScript';
}
entity.script.create(MyScript, { attributes: { speed: 42 } });   // throws
```

Return after the warning, which is what the message already says happens. Note the `Debug` call is stripped from release builds while the dereference is not, so the throw is there in both.

Found while writing tests for #9203, unrelated to the clone path.

## Testing

One test in `test/framework/components/script/component.test.mjs`, fails on `main`: creating a `Script` with attribute data and no schema warns, does not throw, and leaves the script instance usable with no attributes assigned.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)