### PR TITLE
Document how directional and spot lights are aimed

### DIFF
--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -74,6 +74,24 @@ const _properties = [
  * - `spot`: A local light that emits light similarly to an omni light but is bounded by a cone
  * centered on the owner entity's negative y-axis. Emulates flashlights, spotlights, etc.
  *
+ * Directional and spot lights are therefore aimed with the owner entity's rotation, and shine along
+ * its negative y-axis - so an unrotated light shines straight down. Note that
+ * {@link GraphNode#lookAt} orients an entity's negative z-axis, which aims a camera but not a
+ * light:
+ *
+ * ```javascript
+ * // an unrotated light shines straight down
+ * light.setEulerAngles(0, 0, 0);
+ *
+ * // tilted 45 degrees, it shines down and towards negative z
+ * light.setEulerAngles(45, 0, 0);
+ *
+ * // to aim it at a target, lookAt orients the negative z-axis and the extra rotation brings the
+ * // negative y-axis onto it
+ * light.lookAt(target.getPosition());
+ * light.rotateLocal(90, 0, 0);
+ * ```
+ *
  * You should never need to use the LightComponent constructor directly. To add a LightComponent
  * to an {@link Entity}, use {@link Entity#addComponent}:
  *
@@ -257,7 +275,7 @@ class LightComponent extends Component {
      * - `"spot"`: A local light that emits light similarly to an omni light but is bounded by a
      * cone centered on the owner entity's negative y-axis.
      *
-     * Defaults to `"directional"`.
+     * Defaults to `"directional"`. See {@link LightComponent} for how a light is aimed.
      *
      * @type {string}
      */


### PR DESCRIPTION
The `LightComponent` documentation already states that directional and spot lights emit along the owner entity's negative y-axis, but nothing explains how to aim one. `GraphNode#lookAt` is the obvious tool to reach for and it orients an entity's negative z-axis, so it aims a camera and leaves a light pointing somewhere unrelated.

**Changes:**

- The `LightComponent` class documentation now covers aiming: lights are aimed with the owner entity's rotation, an unrotated light shines straight down, and `lookAt` needs a following `rotateLocal(90, 0, 0)` to bring the negative y-axis onto the target. A short snippet shows all three.
- The `type` setter, which already states the negative y-axis convention for `directional` and `spot`, now cross-references the class documentation for the aiming details.

Documentation only, no functional or API changes.