### PR TITLE
Document VertexBuffer data can be ArrayBuffer or typed array

### DIFF
--- a/src/platform/graphics/vertex-buffer.js
+++ b/src/platform/graphics/vertex-buffer.js
@@ -36,7 +36,10 @@ class VertexBuffer {
      * @param {object} [options] - Object for passing optional arguments.
      * @param {number} [options.usage] - The usage type of the vertex buffer (see BUFFER_*).
      * Defaults to BUFFER_STATIC.
-     * @param {ArrayBuffer} [options.data] - Initial data.
+     * @param {ArrayBuffer|ArrayBufferView} [options.data] - Initial data. Can be an
+     * {@link ArrayBuffer} or a typed array (for example a {@link Float32Array}). The data is
+     * stored by reference and is not copied, so a typed array that is a view into a larger buffer
+     * is kept as-is. If left unspecified, the vertex buffer will be initialized to zeros.
      * @param {boolean} [options.storage] - Defines if the vertex buffer can be used as a storage
      * buffer by a compute shader. Defaults to false. Only supported on WebGPU.
      */
@@ -159,7 +162,10 @@ class VertexBuffer {
     /**
      * Returns a mapped memory block representing the content of the vertex buffer.
      *
-     * @returns {ArrayBuffer} An array containing the byte data stored in the vertex buffer.
+     * @returns {ArrayBuffer|ArrayBufferView} The memory that stores the buffer's vertices. This
+     * matches whatever was supplied as the initial data: an {@link ArrayBuffer} when none was
+     * provided, otherwise the {@link ArrayBuffer} or typed array that was passed in. Use
+     * {@link ArrayBuffer.isView} to distinguish the two before accessing it.
      */
     lock() {
         return this.storage;
@@ -176,9 +182,10 @@ class VertexBuffer {
     }
 
     /**
-     * Copies data into vertex buffer's memory.
+     * Sets the data of the vertex buffer and uploads it to the GPU.
      *
-     * @param {ArrayBuffer} [data] - Source data to copy.
+     * @param {ArrayBuffer|ArrayBufferView} [data] - Source data. Can be an {@link ArrayBuffer} or
+     * a typed array. Stored by reference, not copied.
      * @returns {boolean} True if function finished successfully, false otherwise.
      */
     setData(data) {


### PR DESCRIPTION
The `VertexBuffer` constructor's `options.data` is documented as `ArrayBuffer`, but a typed array is equally valid: `setData` only checks `byteLength`, WebGL's `bufferData`/`bufferSubData` accept both, and the WebGPU implementation is written explicitly for both (`storage.buffer ?? storage`, `storage.byteOffset ?? 0`). The engine itself relies on this — the fullscreen quad, morph vertex ids and `EXT_mesh_gpu_instancing` matrices all pass typed arrays — as do the instancing examples, which is what surfaced the discrepancy.

Since the data is stored by reference, `storage` and therefore `lock()` can be either type. This is the `VertexBuffer` counterpart of #8988, which fixed the same JSDoc for `IndexBuffer`, and follows its wording.

Closes #9212

**Changes:**
- Document the constructor's `options.data` as `ArrayBuffer|ArrayBufferView`, noting that it is stored by reference rather than copied.
- Document `lock()` as returning whichever type was supplied, and point at `ArrayBuffer.isView` for telling them apart.
- Document `setData`'s parameter as `ArrayBuffer|ArrayBufferView`, and correct its summary, which claimed to copy the data.

**API Changes:**
None — JSDoc only. The generated declarations widen `lock()` to `ArrayBuffer | ArrayBufferView` and `options.data`/`setData(data)` to `ArrayBuffer | ArrayBufferView`, matching `IndexBuffer`. `npm run test:types` passes with no casts needed at the internal `lock()` call sites.