### PR TITLE
Alias buffer storage correctly when it is a typed array

### DIFF
--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -2,6 +2,7 @@ import { Debug } from '../../../core/debug.js';
 import { Mat4 } from '../../../core/math/mat4.js';
 import { Quat } from '../../../core/math/quat.js';
 import { Vec3 } from '../../../core/math/vec3.js';
+import { BufferUtils } from '../../../platform/graphics/buffer-utils.js';
 import { SEMANTIC_POSITION } from '../../../platform/graphics/constants.js';
 import { ComponentSystem } from '../system.js';
 import { CollisionComponent } from './component.js';
@@ -257,7 +258,7 @@ function createMeshSource(system, mesh, node, bakeScale, convexHull, checkDuplic
             for (let i = 0; i < format.elements.length; i++) {
                 const element = format.elements[i];
                 if (element.name === SEMANTIC_POSITION) {
-                    positions = new Float32Array(vb.lock(), element.offset);
+                    positions = BufferUtils.createStorageView(vb, Float32Array, element.offset);
                     stride = element.stride / 4;
                     break;
                 }

--- a/src/platform/graphics/buffer-utils.js
+++ b/src/platform/graphics/buffer-utils.js
@@ -1,0 +1,48 @@
+import { Debug } from '../../core/debug.js';
+
+/**
+ * @import { IndexBuffer } from './index-buffer.js'
+ * @import { VertexBuffer } from './vertex-buffer.js'
+ */
+
+/**
+ * A class providing utility functions for vertex and index buffers.
+ *
+ * @ignore
+ */
+class BufferUtils {
+    /**
+     * Creates a typed array aliasing the storage of a vertex or index buffer. The storage of those
+     * buffers is stored by reference, and so it can be either an {@link ArrayBuffer} or a typed
+     * array, which itself can be a view into a larger buffer. Constructing a typed array directly
+     * from the storage handles only the former case - for a typed array, the byte offset and length
+     * arguments are ignored and the data is copied instead of aliased, silently detaching the
+     * result from the buffer. This function handles both cases.
+     *
+     * @param {VertexBuffer|IndexBuffer} buffer - The buffer to create the view over.
+     * @param {Function} arrayType - The typed array constructor to create the view with, for
+     * example Float32Array.
+     * @param {number} [byteOffset] - The offset in bytes from the start of the buffer's data.
+     * Defaults to 0.
+     * @param {number} [length] - The number of elements the view contains. Defaults to the
+     * remainder of the buffer's data.
+     * @returns {*} A typed array of the specified type, aliasing the buffer's storage.
+     */
+    static createStorageView(buffer, arrayType, byteOffset = 0, length) {
+
+        const storage = buffer.storage;
+        const isView = ArrayBuffer.isView(storage);
+        const arrayBuffer = isView ? storage.buffer : storage;
+        const offset = (isView ? storage.byteOffset : 0) + byteOffset;
+
+        // a typed array view requires the byte offset to be a multiple of its element size, which
+        // cannot be satisfied when the storage is a misaligned view into a larger buffer
+        const elementSize = arrayType.BYTES_PER_ELEMENT;
+        Debug.assert(offset % elementSize === 0,
+            `Buffer storage cannot be viewed as ${arrayType.name} at byte offset ${offset}, as it is not a multiple of ${elementSize}.`);
+
+        return new arrayType(arrayBuffer, offset, length ?? Math.floor((buffer.numBytes - byteOffset) / elementSize));
+    }
+}
+
+export { BufferUtils };

--- a/src/platform/graphics/index-buffer.js
+++ b/src/platform/graphics/index-buffer.js
@@ -1,12 +1,13 @@
 import { Debug } from '../../core/debug.js';
 import { TRACEID_VRAM_IB } from '../../core/constants.js';
+import { BufferUtils } from './buffer-utils.js';
 
 /**
  * @import { GraphicsDevice } from './graphics-device.js'
  */
 
 import {
-    BUFFER_STATIC, INDEXFORMAT_UINT16, INDEXFORMAT_UINT32, typedArrayIndexFormatsByteSize
+    BUFFER_STATIC, typedArrayIndexFormats, typedArrayIndexFormatsByteSize
 } from './constants.js';
 
 let id = 0;
@@ -189,19 +190,6 @@ class IndexBuffer {
     }
 
     /**
-     * Get the appropriate typed array from an index buffer.
-     *
-     * @returns {Uint8Array|Uint16Array|Uint32Array} The typed array containing the index data.
-     * @private
-     */
-    _lockTypedArray() {
-        const lock = this.lock();
-        const indices = this.format === INDEXFORMAT_UINT32 ? new Uint32Array(lock) :
-            (this.format === INDEXFORMAT_UINT16 ? new Uint16Array(lock) : new Uint8Array(lock));
-        return indices;
-    }
-
-    /**
      * Copies the specified number of elements from data into index buffer. Optimized for
      * performance from both typed array as well as array.
      *
@@ -210,7 +198,7 @@ class IndexBuffer {
      * @ignore
      */
     writeData(data, count) {
-        const indices = this._lockTypedArray();
+        const indices = BufferUtils.createStorageView(this, typedArrayIndexFormats[this.format]);
 
         // if data contains more indices than needed, copy from its subarray
         if (data.length > count) {
@@ -242,7 +230,7 @@ class IndexBuffer {
      */
     readData(data) {
         // note: there is no need to unlock this buffer, as we are only reading from it
-        const indices = this._lockTypedArray();
+        const indices = BufferUtils.createStorageView(this, typedArrayIndexFormats[this.format]);
         const count = this.numIndices;
 
         if (ArrayBuffer.isView(data)) {

--- a/src/platform/graphics/vertex-iterator.js
+++ b/src/platform/graphics/vertex-iterator.js
@@ -84,6 +84,8 @@ class VertexIteratorAccessor {
      * Create a new VertexIteratorAccessor instance.
      *
      * @param {ArrayBuffer} buffer - The vertex buffer containing the attribute to be accessed.
+     * Note that this must be an {@link ArrayBuffer} - see the limitation described in the
+     * constructor body.
      * @param {object} vertexElement - The vertex attribute to be accessed.
      * @param {string} vertexElement.name - The meaning of the vertex element. This is used to link
      * the vertex data to a shader input. Can be:
@@ -134,11 +136,26 @@ class VertexIteratorAccessor {
         this.numComponents = vertexElement.numComponents;
 
         // create the typed array based on the element data type
+        // TODO: this only handles an ArrayBuffer. VertexBuffer storage can also be a typed array
+        // (see VertexBuffer#lock), in which case the typed array copy constructor is selected here
+        // instead, which ignores the offset and the length and copies the elements rather than
+        // viewing them. Writes through the accessor are then silently lost, and reads only happen
+        // to be correct when the storage type matches the element type and the offset is zero.
+        // BufferUtils#createStorageView handles both cases and should be used here, which requires
+        // the buffer rather than its storage to be passed in. Not an issue for the buffers the
+        // engine iterates today, all of which are allocated without initial data and so are
+        // ArrayBuffer backed - the assert below guards that.
         if (vertexFormat.interleaved) {
             this.array = new typedArrayTypes[vertexElement.dataType](buffer, vertexElement.offset);
         } else {
             this.array = new typedArrayTypes[vertexElement.dataType](buffer, vertexElement.offset, vertexFormat.vertexCount * vertexElement.numComponents);
         }
+
+        // the typed array must be a view onto the supplied memory at the element's offset. Testing
+        // the result rather than the input catches every way this can go wrong, including a typed
+        // array being supplied instead of an ArrayBuffer, which drops the offset and the aliasing.
+        Debug.assert(this.array.buffer === buffer && this.array.byteOffset === vertexElement.offset,
+            `Vertex element ${vertexElement.name} at offset ${vertexElement.offset} was given a copy of the vertex data rather than a view onto it, so writes to it are lost. The memory must be an ArrayBuffer, but a ${buffer?.constructor?.name} was supplied.`);
 
         // BYTES_PER_ELEMENT is on the instance and constructor for Chrome, Safari and Firefox, but just the constructor for Opera
         this.stride = vertexElement.stride / this.array.constructor.BYTES_PER_ELEMENT;

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -24,6 +24,7 @@ import {
     SEMANTIC_POSITION,
     isIntegerPixelFormat
 } from '../../platform/graphics/constants.js';
+import { BufferUtils } from '../../platform/graphics/buffer-utils.js';
 import { DeviceCache } from '../../platform/graphics/device-cache.js';
 import { IndexBuffer } from '../../platform/graphics/index-buffer.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
@@ -896,7 +897,7 @@ class ParticleEmitter {
             const data = new Float32Array(this.vertexBuffer.lock());
             let meshData, posOffset, posStride, uvOffset, uvStride;
             if (this.useMesh) {
-                meshData = new Float32Array(this.mesh.vertexBuffer.lock());
+                meshData = BufferUtils.createStorageView(this.mesh.vertexBuffer, Float32Array);
 
                 // Copy positions and UVs using each element's own offset and stride (in floats),
                 // which handles both interleaved and non-interleaved source meshes. Procedurally

--- a/test/platform/graphics/buffer-utils.test.mjs
+++ b/test/platform/graphics/buffer-utils.test.mjs
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+
+import { BufferUtils } from '../../../src/platform/graphics/buffer-utils.js';
+import { INDEXFORMAT_UINT32, SEMANTIC_POSITION, TYPE_FLOAT32 } from '../../../src/platform/graphics/constants.js';
+import { IndexBuffer } from '../../../src/platform/graphics/index-buffer.js';
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+import { VertexBuffer } from '../../../src/platform/graphics/vertex-buffer.js';
+import { VertexFormat } from '../../../src/platform/graphics/vertex-format.js';
+
+describe('BufferUtils', function () {
+
+    /** @type {NullGraphicsDevice} */
+    let device;
+
+    beforeEach(function () {
+        device = new NullGraphicsDevice({ width: 100, height: 100 });
+    });
+
+    afterEach(function () {
+        device.destroy();
+        device = null;
+    });
+
+    describe('#createStorageView', function () {
+
+        // 4 vertices of 3 floats
+        const createVertexBuffer = options => new VertexBuffer(device, new VertexFormat(device, [
+            { semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 }
+        ]), 4, options);
+
+        it('aliases storage supplied as an ArrayBuffer', function () {
+            const buffer = createVertexBuffer();
+
+            const view = BufferUtils.createStorageView(buffer, Float32Array);
+            view[1] = 42;
+
+            expect(view.length).to.equal(12);
+            expect(new Float32Array(buffer.storage)[1]).to.equal(42);
+
+            buffer.destroy();
+        });
+
+        it('aliases storage supplied as a typed array', function () {
+            const data = new Float32Array(12);
+            const buffer = createVertexBuffer({ data });
+
+            const view = BufferUtils.createStorageView(buffer, Float32Array);
+            view[1] = 42;
+
+            expect(view.length).to.equal(12);
+            expect(data[1]).to.equal(42);
+
+            buffer.destroy();
+        });
+
+        it('aliases storage that is a typed array view into a larger buffer', function () {
+            // 12 floats sitting in the middle of a larger buffer
+            const backing = new Float32Array(16).fill(7);
+            const buffer = createVertexBuffer({ data: backing.subarray(2, 14) });
+
+            const view = BufferUtils.createStorageView(buffer, Float32Array);
+            view[0] = 42;
+
+            // the view is confined to the buffer's own range, and writes land in it
+            expect(view.length).to.equal(12);
+            expect(backing[1]).to.equal(7);
+            expect(backing[2]).to.equal(42);
+            expect(backing[14]).to.equal(7);
+
+            buffer.destroy();
+        });
+
+        it('applies a byte offset on top of the storage offset', function () {
+            const backing = new Float32Array(16).fill(7);
+            backing[5] = 42;
+            const buffer = createVertexBuffer({ data: backing.subarray(2, 14) });
+
+            // skip the first vertex
+            const view = BufferUtils.createStorageView(buffer, Float32Array, 12);
+
+            expect(view.length).to.equal(9);
+            expect(view[0]).to.equal(42);
+
+            buffer.destroy();
+        });
+
+        it('honours an explicit length', function () {
+            const buffer = createVertexBuffer();
+
+            expect(BufferUtils.createStorageView(buffer, Float32Array, 0, 3).length).to.equal(3);
+
+            buffer.destroy();
+        });
+
+        it('creates a view of the element type, not of the storage type', function () {
+            const buffer = new IndexBuffer(device, INDEXFORMAT_UINT32, 3, undefined, new Uint8Array(12));
+
+            const view = BufferUtils.createStorageView(buffer, Uint32Array);
+
+            expect(view).to.be.an.instanceof(Uint32Array);
+            expect(view.length).to.equal(3);
+
+            buffer.destroy();
+        });
+    });
+});

--- a/test/platform/graphics/index-buffer.test.mjs
+++ b/test/platform/graphics/index-buffer.test.mjs
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+
+import { INDEXFORMAT_UINT16, INDEXFORMAT_UINT32 } from '../../../src/platform/graphics/constants.js';
+import { IndexBuffer } from '../../../src/platform/graphics/index-buffer.js';
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+
+describe('IndexBuffer', function () {
+
+    /** @type {NullGraphicsDevice} */
+    let device;
+
+    beforeEach(function () {
+        device = new NullGraphicsDevice({ width: 100, height: 100 });
+    });
+
+    afterEach(function () {
+        device.destroy();
+        device = null;
+    });
+
+    describe('#writeData', function () {
+
+        it('writes into storage supplied as an ArrayBuffer', function () {
+            const buffer = new IndexBuffer(device, INDEXFORMAT_UINT16, 3);
+
+            buffer.writeData(new Uint16Array([4, 5, 6]), 3);
+
+            const indices = [];
+            expect(buffer.readData(indices)).to.equal(3);
+            expect(indices).to.deep.equal([4, 5, 6]);
+
+            buffer.destroy();
+        });
+
+        it('writes into storage supplied as a typed array', function () {
+            // Regression test - the write used to be applied to a detached copy of the storage,
+            // rather than to the storage itself, so it never reached the GPU. Reachable through
+            // Mesh#setIndices on any GLB-loaded mesh, as the GLB parser supplies typed arrays.
+            const indices = new Uint16Array([1, 2, 3]);
+            const buffer = new IndexBuffer(device, INDEXFORMAT_UINT16, 3, undefined, indices);
+
+            buffer.writeData(new Uint16Array([4, 5, 6]), 3);
+
+            expect(Array.from(indices)).to.deep.equal([4, 5, 6]);
+
+            buffer.destroy();
+        });
+
+        it('writes only the requested count', function () {
+            const indices = new Uint32Array([1, 2, 3]);
+            const buffer = new IndexBuffer(device, INDEXFORMAT_UINT32, 3, undefined, indices);
+
+            buffer.writeData([4, 5, 6], 2);
+
+            expect(Array.from(indices)).to.deep.equal([4, 5, 3]);
+
+            buffer.destroy();
+        });
+    });
+
+    describe('#readData', function () {
+
+        it('reads from storage supplied as a typed array', function () {
+            const indices = new Uint32Array([1, 2, 3]);
+            const buffer = new IndexBuffer(device, INDEXFORMAT_UINT32, 3, undefined, indices);
+
+            const read = new Uint32Array(3);
+            expect(buffer.readData(read)).to.equal(3);
+            expect(Array.from(read)).to.deep.equal([1, 2, 3]);
+
+            buffer.destroy();
+        });
+
+        it('reads from storage that is a typed array view into a larger buffer', function () {
+            const backing = new Uint32Array([7, 7, 1, 2, 3, 7, 7]);
+            const buffer = new IndexBuffer(device, INDEXFORMAT_UINT32, 3, undefined, backing.subarray(2, 5));
+
+            const read = [];
+            expect(buffer.readData(read)).to.equal(3);
+            expect(read).to.deep.equal([1, 2, 3]);
+
+            buffer.destroy();
+        });
+    });
+});

--- a/test/platform/graphics/vertex-iterator.test.mjs
+++ b/test/platform/graphics/vertex-iterator.test.mjs
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+
+import { SEMANTIC_ATTR0, SEMANTIC_POSITION, TYPE_FLOAT32 } from '../../../src/platform/graphics/constants.js';
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+import { VertexBuffer } from '../../../src/platform/graphics/vertex-buffer.js';
+import { VertexFormat } from '../../../src/platform/graphics/vertex-format.js';
+import { VertexIterator } from '../../../src/platform/graphics/vertex-iterator.js';
+
+// runs the function with console.error suppressed, and returns the number of debug asserts it fired
+const withAssertCount = (fn) => {
+    const error = console.error;
+    let count = 0;
+    console.error = () => {
+        count++;
+    };
+    try {
+        fn();
+    } finally {
+        console.error = error;
+    }
+    return count;
+};
+
+describe('VertexIterator', function () {
+
+    /** @type {NullGraphicsDevice} */
+    let device;
+
+    beforeEach(function () {
+        device = new NullGraphicsDevice({ width: 100, height: 100 });
+    });
+
+    afterEach(function () {
+        device.destroy();
+        device = null;
+    });
+
+    describe('accessor aliasing', function () {
+
+        // interleaved, so the second element sits at a non-zero offset within each vertex
+        const createFormat = () => new VertexFormat(device, [
+            { semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 },
+            { semantic: SEMANTIC_ATTR0, components: 2, type: TYPE_FLOAT32 }
+        ]);
+
+        it('views the storage at each element offset when it is an ArrayBuffer', function () {
+            const buffer = new VertexBuffer(device, createFormat(), 4);
+
+            let iterator;
+            const asserts = withAssertCount(() => {
+                iterator = new VertexIterator(buffer);
+            });
+
+            expect(asserts).to.equal(0);
+            expect(iterator.element[SEMANTIC_POSITION].array.buffer).to.equal(buffer.storage);
+            expect(iterator.element[SEMANTIC_POSITION].array.byteOffset).to.equal(0);
+            expect(iterator.element[SEMANTIC_ATTR0].array.byteOffset).to.equal(12);
+
+            buffer.destroy();
+        });
+
+        it('writes through to the storage when it is an ArrayBuffer', function () {
+            const buffer = new VertexBuffer(device, createFormat(), 4);
+
+            const iterator = new VertexIterator(buffer);
+            iterator.element[SEMANTIC_POSITION].set(1, 2, 3);
+            iterator.end();
+
+            expect(Array.from(new Float32Array(buffer.storage, 0, 3))).to.deep.equal([1, 2, 3]);
+
+            buffer.destroy();
+        });
+
+        it('asserts when the storage is a typed array, as the accessors are then copies', function () {
+            // The accessors are built with the typed array copy constructor in this case, which
+            // ignores the offset and length, so they no longer alias the buffer and writes to them
+            // are lost. Guarded rather than fixed - see the TODO in VertexIteratorAccessor.
+            const format = createFormat();
+            const buffer = new VertexBuffer(device, format, 4, {
+                data: new Float32Array(format.size * 4 / 4)
+            });
+
+            const asserts = withAssertCount(() => {
+                const iterator = new VertexIterator(buffer);
+                expect(iterator.element[SEMANTIC_ATTR0].array.byteOffset).to.equal(0);
+            });
+
+            // one per element of the format
+            expect(asserts).to.equal(2);
+
+            buffer.destroy();
+        });
+    });
+});


### PR DESCRIPTION
Follow-up to #9215 (which closed #9212), which documented that vertex and index buffer storage can be either an `ArrayBuffer` or a typed array. Constructing a typed array from `lock()` directly only handles the former: for a typed array the copy constructor is selected instead, which ignores the byte offset and the length and copies the elements rather than viewing them, silently detaching the result from the buffer.

`IndexBuffer#writeData` was affected in released code. The GLB parser supplies typed arrays as index data, so `Mesh#setIndices` followed by `Mesh#update` on any GLB-loaded mesh wrote into a detached copy — `unlock()` then uploaded the untouched original, with no error. `Mesh#getIndices` happened to read correct values, as the copy holds the same elements. The mesh collision shape and mesh particle paths have the same problem for vertex buffers built from typed array data.

**Changes:**
- Add `BufferUtils.createStorageView(buffer, arrayType, byteOffset, length)`, which resolves the underlying `ArrayBuffer` and base offset from either storage form, confines the default view length to the buffer's own range rather than running to the end of the underlying buffer, and asserts on the one case that cannot be satisfied at all - a misaligned sub-view being asked for a wider element type.
- Use it in `IndexBuffer#writeData` and `#readData`, replacing the `_lockTypedArray` helper and its per-format ternary.
- Use it in the mesh collision shape path (`CollisionComponentSystem`) and the mesh particle path (`ParticleEmitter`).
- `VertexIteratorAccessor` has the same problem but is left as is, as it takes the storage rather than the buffer, and every buffer the engine iterates today is `ArrayBuffer` backed. It gains a `TODO` describing the failure and an assert that the view it built actually aliases the requested memory at the requested offset, so the failure is loud rather than silent. Testing the result rather than the input catches the non-zero offset case too, which the copy constructor collapses to zero.

**API Changes:**
None - `BufferUtils` is `@ignore`.

**Tests:**
New suites for `BufferUtils` (plain `ArrayBuffer`, whole typed array, sub-view into a larger buffer, byte offset on top of the storage offset, explicit length, element type distinct from the storage type), for `IndexBuffer#writeData`/`#readData` (two of which fail without this change), and for the `VertexIterator` assert.