### PR TITLE
Add samples option to Texture for multisampled textures on WebGPU

### DIFF
--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1095,7 +1095,7 @@ export const pixelFormatInfo = new Map([
     [PIXELFORMAT_DEPTH,         { name: 'DEPTH', size: 4, msaa: true }],
     [PIXELFORMAT_DEPTH16,       { name: 'DEPTH16', size: 2, msaa: true }],
     [PIXELFORMAT_DEPTHSTENCIL,  { name: 'DEPTHSTENCIL', size: 4, msaa: true }],
-    [PIXELFORMAT_111110F,       { name: '111110F', size: 4 }],
+    [PIXELFORMAT_111110F,       { name: '111110F', size: 4, msaa: true }],
     [PIXELFORMAT_SRGB8,         { name: 'SRGB8', size: 4, ldr: true, srgb: true }],
     [PIXELFORMAT_SRGBA8,        { name: 'SRGBA8', size: 4, ldr: true, srgb: true, msaa: true }],
     [PIXELFORMAT_BGRA8,         { name: 'BGRA8', size: 4, ldr: true, msaa: true }],
@@ -1171,26 +1171,17 @@ export const isIntegerPixelFormat = (format) => {
  * resolve is a separate, narrower capability: integer formats and {@link PIXELFORMAT_R32F} are
  * multisample-capable but cannot be resolved, and depth formats have no hardware resolve at all.
  *
+ * {@link PIXELFORMAT_111110F} is reported as capable even though it is gated on the
+ * 'rg11b10ufloat-renderable' device feature - the feature is near-universally available, and on a
+ * device without it the WebGPU validation reports the failure. Snorm formats (RG8S, RGBA8S) would
+ * become capable via 'texture-formats-tier1', which the engine does not currently request.
+ *
  * @param {number} format - The pixel format.
- * @param {import('./graphics-device.js').GraphicsDevice|null} [device] - The graphics device,
- * used to also allow formats whose multisample capability is gated on an optional device feature.
- * When not provided, only the core capability table is consulted.
  * @returns {boolean} True if the format supports multisampling.
  * @ignore
  */
-export const isMultisampleCapablePixelFormat = (format, device = null) => {
-    if (pixelFormatInfo.get(format)?.msaa === true) {
-        return true;
-    }
-
-    // rg11b10ufloat is multisample-capable when the device has the 'rg11b10ufloat-renderable'
-    // feature. Snorm formats (RG8S, RGBA8S) would similarly become capable via
-    // 'texture-formats-tier1', which the engine does not currently request.
-    if (format === PIXELFORMAT_111110F) {
-        return !!device?.textureRG11B10Renderable;
-    }
-
-    return false;
+export const isMultisampleCapablePixelFormat = (format) => {
+    return pixelFormatInfo.get(format)?.msaa === true;
 };
 
 // Cached shader type objects

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1070,36 +1070,36 @@ export const pixelFormatInfo = new Map([
 
     // float formats
     [PIXELFORMAT_A8,            { name: 'A8', size: 1, ldr: true }],
-    [PIXELFORMAT_R8,            { name: 'R8', size: 1, ldr: true }],
+    [PIXELFORMAT_R8,            { name: 'R8', size: 1, ldr: true, msaa: true }],
     [PIXELFORMAT_L8,            { name: 'L8', size: 1, ldr: true }],
     [PIXELFORMAT_LA8,           { name: 'LA8', size: 2, ldr: true }],
-    [PIXELFORMAT_RG8,           { name: 'RG8', size: 2, ldr: true }],
+    [PIXELFORMAT_RG8,           { name: 'RG8', size: 2, ldr: true, msaa: true }],
     [PIXELFORMAT_RGB565,        { name: 'RGB565', size: 2, ldr: true }],
     [PIXELFORMAT_RGBA5551,      { name: 'RGBA5551', size: 2, ldr: true }],
     [PIXELFORMAT_RGBA4,         { name: 'RGBA4', size: 2, ldr: true }],
-    [PIXELFORMAT_RGB8,          { name: 'RGB8', size: 4, ldr: true }],
-    [PIXELFORMAT_RGBA8,         { name: 'RGBA8', size: 4, ldr: true, srgbFormat: PIXELFORMAT_SRGBA8 }],
-    [PIXELFORMAT_R16F,          { name: 'R16F', size: 2 }],
-    [PIXELFORMAT_RG16F,         { name: 'RG16F', size: 4 }],
+    [PIXELFORMAT_RGB8,          { name: 'RGB8', size: 4, ldr: true, msaa: true }],
+    [PIXELFORMAT_RGBA8,         { name: 'RGBA8', size: 4, ldr: true, srgbFormat: PIXELFORMAT_SRGBA8, msaa: true }],
+    [PIXELFORMAT_R16F,          { name: 'R16F', size: 2, msaa: true }],
+    [PIXELFORMAT_RG16F,         { name: 'RG16F', size: 4, msaa: true }],
     [PIXELFORMAT_RGB16F,        { name: 'RGB16F', size: 8 }],
-    [PIXELFORMAT_RGBA16F,       { name: 'RGBA16F', size: 8 }],
+    [PIXELFORMAT_RGBA16F,       { name: 'RGBA16F', size: 8, msaa: true }],
     [PIXELFORMAT_RGB32F,        { name: 'RGB32F', size: 16 }],
     [PIXELFORMAT_RGBA32F,       { name: 'RGBA32F', size: 16 }],
-    [PIXELFORMAT_R32F,          { name: 'R32F', size: 4 }],
+    [PIXELFORMAT_R32F,          { name: 'R32F', size: 4, msaa: true }],
     [PIXELFORMAT_RG32F,         { name: 'RG32F', size: 8 }],
     [PIXELFORMAT_RGB9E5,        { name: 'RGB9E5', size: 4 }],
     [PIXELFORMAT_RG8S,          { name: 'RG8S', size: 2 }],
     [PIXELFORMAT_RGBA8S,        { name: 'RGBA8S', size: 4 }],
-    [PIXELFORMAT_RGB10A2,       { name: 'RGB10A2', size: 4 }],
-    [PIXELFORMAT_RGB10A2U,      { name: 'RGB10A2U', size: 4, isUint: true }],
-    [PIXELFORMAT_DEPTH,         { name: 'DEPTH', size: 4 }],
-    [PIXELFORMAT_DEPTH16,       { name: 'DEPTH16', size: 2 }],
-    [PIXELFORMAT_DEPTHSTENCIL,  { name: 'DEPTHSTENCIL', size: 4 }],
+    [PIXELFORMAT_RGB10A2,       { name: 'RGB10A2', size: 4, msaa: true }],
+    [PIXELFORMAT_RGB10A2U,      { name: 'RGB10A2U', size: 4, isUint: true, msaa: true }],
+    [PIXELFORMAT_DEPTH,         { name: 'DEPTH', size: 4, msaa: true }],
+    [PIXELFORMAT_DEPTH16,       { name: 'DEPTH16', size: 2, msaa: true }],
+    [PIXELFORMAT_DEPTHSTENCIL,  { name: 'DEPTHSTENCIL', size: 4, msaa: true }],
     [PIXELFORMAT_111110F,       { name: '111110F', size: 4 }],
     [PIXELFORMAT_SRGB8,         { name: 'SRGB8', size: 4, ldr: true, srgb: true }],
-    [PIXELFORMAT_SRGBA8,        { name: 'SRGBA8', size: 4, ldr: true, srgb: true }],
-    [PIXELFORMAT_BGRA8,         { name: 'BGRA8', size: 4, ldr: true }],
-    [PIXELFORMAT_SBGRA8,        { name: 'SBGRA8', size: 4, ldr: true, srgb: true }],
+    [PIXELFORMAT_SRGBA8,        { name: 'SRGBA8', size: 4, ldr: true, srgb: true, msaa: true }],
+    [PIXELFORMAT_BGRA8,         { name: 'BGRA8', size: 4, ldr: true, msaa: true }],
+    [PIXELFORMAT_SBGRA8,        { name: 'SBGRA8', size: 4, ldr: true, srgb: true, msaa: true }],
 
     // compressed formats
     [PIXELFORMAT_DXT1,              { name: 'DXT1', blockSize: 8, ldr: true, srgbFormat: PIXELFORMAT_DXT1_SRGB }],
@@ -1129,25 +1129,25 @@ export const pixelFormatInfo = new Map([
     [PIXELFORMAT_BC7_SRGBA,          { name: 'BC7_SRGBA', blockSize: 16, ldr: true, srgb: true }],
 
     // signed integer formats
-    [PIXELFORMAT_R8I,      { name: 'R8I', size: 1, isInt: true }],
-    [PIXELFORMAT_R16I,     { name: 'R16I', size: 2, isInt: true }],
+    [PIXELFORMAT_R8I,      { name: 'R8I', size: 1, isInt: true, msaa: true }],
+    [PIXELFORMAT_R16I,     { name: 'R16I', size: 2, isInt: true, msaa: true }],
     [PIXELFORMAT_R32I,     { name: 'R32I', size: 4, isInt: true }],
-    [PIXELFORMAT_RG8I,     { name: 'RG8I', size: 2, isInt: true }],
-    [PIXELFORMAT_RG16I,    { name: 'RG16I', size: 4, isInt: true }],
+    [PIXELFORMAT_RG8I,     { name: 'RG8I', size: 2, isInt: true, msaa: true }],
+    [PIXELFORMAT_RG16I,    { name: 'RG16I', size: 4, isInt: true, msaa: true }],
     [PIXELFORMAT_RG32I,    { name: 'RG32I', size: 8, isInt: true }],
-    [PIXELFORMAT_RGBA8I,   { name: 'RGBA8I', size: 4, isInt: true }],
-    [PIXELFORMAT_RGBA16I,  { name: 'RGBA16I', size: 8, isInt: true }],
+    [PIXELFORMAT_RGBA8I,   { name: 'RGBA8I', size: 4, isInt: true, msaa: true }],
+    [PIXELFORMAT_RGBA16I,  { name: 'RGBA16I', size: 8, isInt: true, msaa: true }],
     [PIXELFORMAT_RGBA32I,  { name: 'RGBA32I', size: 16, isInt: true }],
 
     // unsigned integer formats
-    [PIXELFORMAT_R8U,      { name: 'R8U', size: 1, isUint: true }],
-    [PIXELFORMAT_R16U,     { name: 'R16U', size: 2, isUint: true }],
+    [PIXELFORMAT_R8U,      { name: 'R8U', size: 1, isUint: true, msaa: true }],
+    [PIXELFORMAT_R16U,     { name: 'R16U', size: 2, isUint: true, msaa: true }],
     [PIXELFORMAT_R32U,     { name: 'R32U', size: 4, isUint: true }],
-    [PIXELFORMAT_RG8U,     { name: 'RG8U', size: 2, isUint: true }],
-    [PIXELFORMAT_RG16U,    { name: 'RG16U', size: 4, isUint: true }],
+    [PIXELFORMAT_RG8U,     { name: 'RG8U', size: 2, isUint: true, msaa: true }],
+    [PIXELFORMAT_RG16U,    { name: 'RG16U', size: 4, isUint: true, msaa: true }],
     [PIXELFORMAT_RG32U,    { name: 'RG32U', size: 8, isUint: true }],
-    [PIXELFORMAT_RGBA8U,   { name: 'RGBA8U', size: 4, isUint: true }],
-    [PIXELFORMAT_RGBA16U,  { name: 'RGBA16U', size: 8, isUint: true }],
+    [PIXELFORMAT_RGBA8U,   { name: 'RGBA8U', size: 4, isUint: true, msaa: true }],
+    [PIXELFORMAT_RGBA16U,  { name: 'RGBA16U', size: 8, isUint: true, msaa: true }],
     [PIXELFORMAT_RGBA32U,  { name: 'RGBA32U', size: 16, isUint: true }]
 ]);
 
@@ -1163,6 +1163,21 @@ export const isSrgbPixelFormat = (format) => {
 export const isIntegerPixelFormat = (format) => {
     const info = pixelFormatInfo.get(format);
     return info?.isInt === true || info?.isUint === true;
+};
+
+/**
+ * Returns true if the specified pixel format can be used to create a multisampled texture on
+ * WebGPU (per the WebGPU texture format capabilities table, core features). Note that support for
+ * hardware resolve is a separate, narrower capability: integer formats and
+ * {@link PIXELFORMAT_R32F} are multisample-capable but cannot be resolved, and depth formats have
+ * no hardware resolve at all.
+ *
+ * @param {number} format - The pixel format.
+ * @returns {boolean} True if the format supports multisampling.
+ * @ignore
+ */
+export const isMultisampleCapablePixelFormat = (format) => {
+    return pixelFormatInfo.get(format)?.msaa === true;
 };
 
 // Cached shader type objects

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -1167,17 +1167,30 @@ export const isIntegerPixelFormat = (format) => {
 
 /**
  * Returns true if the specified pixel format can be used to create a multisampled texture on
- * WebGPU (per the WebGPU texture format capabilities table, core features). Note that support for
- * hardware resolve is a separate, narrower capability: integer formats and
- * {@link PIXELFORMAT_R32F} are multisample-capable but cannot be resolved, and depth formats have
- * no hardware resolve at all.
+ * WebGPU (per the WebGPU texture format capabilities table). Note that support for hardware
+ * resolve is a separate, narrower capability: integer formats and {@link PIXELFORMAT_R32F} are
+ * multisample-capable but cannot be resolved, and depth formats have no hardware resolve at all.
  *
  * @param {number} format - The pixel format.
+ * @param {import('./graphics-device.js').GraphicsDevice|null} [device] - The graphics device,
+ * used to also allow formats whose multisample capability is gated on an optional device feature.
+ * When not provided, only the core capability table is consulted.
  * @returns {boolean} True if the format supports multisampling.
  * @ignore
  */
-export const isMultisampleCapablePixelFormat = (format) => {
-    return pixelFormatInfo.get(format)?.msaa === true;
+export const isMultisampleCapablePixelFormat = (format, device = null) => {
+    if (pixelFormatInfo.get(format)?.msaa === true) {
+        return true;
+    }
+
+    // rg11b10ufloat is multisample-capable when the device has the 'rg11b10ufloat-renderable'
+    // feature. Snorm formats (RG8S, RGBA8S) would similarly become capable via
+    // 'texture-formats-tier1', which the engine does not currently request.
+    if (format === PIXELFORMAT_111110F) {
+        return !!device?.textureRG11B10Renderable;
+    }
+
+    return false;
 };
 
 // Cached shader type objects

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -338,7 +338,7 @@ class Texture {
                     `Multisampled texture '${this.name}' cannot be created with initial data, it can only be rendered into.`, this);
                 Debug.assert(options.numLevels === undefined,
                     `Multisampled texture '${this.name}' cannot use the numLevels option, it always has a single mip level.`, this);
-                Debug.assert(isMultisampleCapablePixelFormat(this._format, graphicsDevice),
+                Debug.assert(isMultisampleCapablePixelFormat(this._format),
                     `Multisampled texture '${this.name}' uses format ${pixelFormatInfo.get(this._format)?.name}, which does not support multisampling.`, this);
             } else {
                 Debug.warnOnce(`Texture '${this.name}' was created with samples > 1, which is only supported on WebGPU; the samples option is ignored.`);

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -16,7 +16,8 @@ import {
     TEXPROPERTY_MIN_FILTER, TEXPROPERTY_MAG_FILTER, TEXPROPERTY_ADDRESS_U, TEXPROPERTY_ADDRESS_V,
     TEXPROPERTY_ADDRESS_W, TEXPROPERTY_COMPARE_ON_READ, TEXPROPERTY_COMPARE_FUNC, TEXPROPERTY_ANISOTROPY,
     TEXPROPERTY_ALL,
-    requiresManualGamma, pixelFormatInfo, isSrgbPixelFormat, pixelFormatLinearToGamma, pixelFormatGammaToLinear
+    requiresManualGamma, pixelFormatInfo, isSrgbPixelFormat, pixelFormatLinearToGamma, pixelFormatGammaToLinear,
+    isMultisampleCapablePixelFormat
 } from './constants.js';
 import { TextureUtils } from './texture-utils.js';
 import { TextureView } from './texture-view.js';
@@ -141,6 +142,14 @@ class Texture {
     /** @protected */
     _storage = false;
 
+    /**
+     * The number of MSAA samples of the texture, 1 if not multisampled.
+     *
+     * @type {number}
+     * @protected
+     */
+    _samples = 1;
+
     /** @protected */
     _numLevels = 0;
 
@@ -255,6 +264,13 @@ class Texture {
      * of Uint8Array if options.arrayLength is defined and greater than zero.
      * @param {boolean} [options.storage] - Defines if texture can be used as a storage texture by
      * a compute shader. Defaults to false.
+     * @param {number} [options.samples] - The number of MSAA samples. A value greater than 1
+     * creates a multisampled texture (WebGPU only, ignored with a warning on other devices, and
+     * rounded up to the device's supported sample count). A multisampled texture can only be
+     * rendered into, and its individual samples read in a shader using `textureLoad` - it cannot
+     * be sampled with a sampler, uploaded to or read back. It must be a 2D non-array
+     * texture with a format that supports multisampling, cannot be a storage texture, and has no
+     * mipmaps (the mipmaps option is ignored). Defaults to 1.
      * @example
      * // Create a 8x8x24-bit texture
      * const texture = new Texture(graphicsDevice, {
@@ -307,7 +323,29 @@ class Texture {
         this._flipY = options.flipY ?? false;
         this._premultiplyAlpha = options.premultiplyAlpha ?? false;
 
-        this._mipmaps = options.mipmaps ?? true;
+        // multisampled (MSAA) texture, WebGPU only - can only be rendered into, and read in
+        // shaders using textureLoad
+        const requestedSamples = options.samples ?? 1;
+        if (requestedSamples > 1) {
+            if (graphicsDevice.isWebGPU) {
+                // WebGPU only supports sample counts of 1 or 4
+                this._samples = graphicsDevice.maxSamples;
+                Debug.assert(!this._volume && !this._cubemap && this._arrayLength === 0,
+                    `Multisampled texture '${this.name}' must be a 2D non-array texture.`, this);
+                Debug.assert(!this._storage,
+                    `Multisampled texture '${this.name}' cannot be a storage texture.`, this);
+                Debug.assert(!options.levels,
+                    `Multisampled texture '${this.name}' cannot be created with initial data, it can only be rendered into.`, this);
+                Debug.assert(options.numLevels === undefined,
+                    `Multisampled texture '${this.name}' cannot use the numLevels option, it always has a single mip level.`, this);
+                Debug.assert(isMultisampleCapablePixelFormat(this._format),
+                    `Multisampled texture '${this.name}' uses format ${pixelFormatInfo.get(this._format)?.name}, which does not support multisampling.`, this);
+            } else {
+                Debug.warnOnce(`Texture '${this.name}' was created with samples > 1, which is only supported on WebGPU; the samples option is ignored.`);
+            }
+        }
+
+        this._mipmaps = (options.mipmaps ?? true) && this._samples === 1;
         this._numLevelsRequested = options.numLevels;
         if (options.numLevels !== undefined) {
             this._numLevels = options.numLevels;
@@ -828,6 +866,17 @@ class Texture {
     }
 
     /**
+     * The number of MSAA samples of the texture, 1 if the texture is not multisampled. Specified
+     * via the `samples` constructor option (WebGPU only). A multisampled texture can only be
+     * rendered into, and its individual samples read in a shader using `textureLoad`.
+     *
+     * @type {number}
+     */
+    get samples() {
+        return this._samples;
+    }
+
+    /**
      * The width of the texture in pixels.
      *
      * @type {number}
@@ -1124,6 +1173,8 @@ class Texture {
         options.face ??= 0;
         options.mode ??= TEXTURELOCK_WRITE;
 
+        Debug.assert(this._samples === 1, 'Cannot lock a multisampled texture.', this);
+
         Debug.assert(
             this._lockedMode === TEXTURELOCK_NONE,
             'The texture is already locked. Call `texture.unlock()` before attempting to lock again.',
@@ -1167,6 +1218,7 @@ class Texture {
      * than 0, represents the image source for the Nth mipmap reduction level.
      */
     setSource(source, mipLevel = 0) {
+        Debug.assert(this._samples === 1, 'Cannot set the source of a multisampled texture.', this);
         if (this.device._isHTMLElementInterface(source)) {
             if (!this.device.supportsHtmlTextures) {
                 Debug.error('Texture#setSource: HTML element textures are not supported on this device. Check device.supportsHtmlTextures before calling setSource with an HTML element.');
@@ -1357,6 +1409,7 @@ class Texture {
      * with the pixel data of the texture.
      */
     read(x, y, width, height, options = {}) {
+        Debug.assert(this._samples === 1, 'Cannot read back a multisampled texture.', this);
         return this.impl.read?.(x, y, width, height, options);
     }
 
@@ -1402,6 +1455,10 @@ class Texture {
             Debug.error('Texture#copy: copying 3D (volume) textures is not supported.');
             return false;
         }
+        if (source._samples !== this._samples) {
+            Debug.error(`Texture#copy: source and destination sample counts must match (source '${source.name}' has ${source._samples}, destination '${this.name}' has ${this._samples}). A multisampled texture cannot be copied to or from a single-sampled texture - use a resolve instead.`);
+            return false;
+        }
 
         const sourceMipLevel = options.sourceMipLevel ?? 0;
         const destMipLevel = options.destMipLevel ?? 0;
@@ -1439,6 +1496,14 @@ class Texture {
             Debug.error(`Texture#copy: copy region is out of bounds (source ${sw}x${sh}, destination ${dw}x${dh}).`);
             return false;
         }
+
+        // WebGPU requires copies involving multisampled textures to cover the entire texture
+        if (this._samples > 1) {
+            if (sx !== 0 || sy !== 0 || dx !== 0 || dy !== 0 || w !== sw || h !== sh || sw !== dw || sh !== dh) {
+                Debug.error(`Texture#copy: copies of multisampled textures must cover the entire texture (source '${source.name}' ${sw}x${sh}, destination '${this.name}' ${dw}x${dh}, no offsets or partial regions).`);
+                return false;
+            }
+        }
         // #endif
         return true;
     }
@@ -1446,7 +1511,10 @@ class Texture {
     /**
      * Copies a region of a source texture into this texture. Both textures must have the same
      * pixel format. The copied region sizes must match (no scaling), and must lie within the
-     * chosen mip levels of both textures.
+     * chosen mip levels of both textures. Multisampled textures can be copied to other
+     * multisampled textures with the same sample count (WebGPU only), but only as a full-texture
+     * copy - no offsets or partial regions, and no copies between different sample counts (use a
+     * resolve instead).
      *
      * @param {Texture} source - The source texture to copy from.
      * @param {object} [options] - Optional arguments.

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -338,7 +338,7 @@ class Texture {
                     `Multisampled texture '${this.name}' cannot be created with initial data, it can only be rendered into.`, this);
                 Debug.assert(options.numLevels === undefined,
                     `Multisampled texture '${this.name}' cannot use the numLevels option, it always has a single mip level.`, this);
-                Debug.assert(isMultisampleCapablePixelFormat(this._format),
+                Debug.assert(isMultisampleCapablePixelFormat(this._format, graphicsDevice),
                     `Multisampled texture '${this.name}' uses format ${pixelFormatInfo.get(this._format)?.name}, which does not support multisampling.`, this);
             } else {
                 Debug.warnOnce(`Texture '${this.name}' was created with samples > 1, which is only supported on WebGPU; the samples option is ignored.`);
@@ -384,6 +384,13 @@ class Texture {
         }
 
         this.recreateImpl(upload);
+
+        // a multisampled texture is never uploaded (the usual point where VRAM tracking is
+        // updated), so account for its VRAM at creation; destroy() subtracts it
+        if (this._samples > 1) {
+            this._gpuSize = this.gpuSize;
+            this.adjustVramSizeTracking(graphicsDevice._vram, this._gpuSize);
+        }
 
         Debug.trace(TRACEID_TEXTURE_ALLOC, `Alloc: Id ${this.id} ${this.name}: ${this.width}x${this.height} [${pixelFormatInfo.get(this.format)?.name}]` +
             `${this.cubemap ? '[Cubemap]' : ''}` +
@@ -520,6 +527,12 @@ class Texture {
             // re-create the implementation
             this.impl = device.createTextureImpl(this);
             this.dirtyAll();
+
+            // a multisampled texture is never uploaded, so re-account for its VRAM here
+            if (this._samples > 1) {
+                this._gpuSize = this.gpuSize;
+                this.adjustVramSizeTracking(device._vram, this._gpuSize);
+            }
         }
     }
 
@@ -947,7 +960,7 @@ class Texture {
 
     get gpuSize() {
         const mips = this.pot && this._mipmaps && !(this._compressed && this._levels.length === 1);
-        return TextureUtils.calcGpuSize(this._width, this._height, this._depth, this._format, mips, this._cubemap);
+        return TextureUtils.calcGpuSize(this._width, this._height, this._depth, this._format, mips, this._cubemap) * this._samples;
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -126,7 +126,9 @@ class WebgpuTexture {
             },
             format: this.format,
             mipLevelCount: numLevels,
-            sampleCount: 1,
+            // multisampled textures are constrained at the Texture level: 2d, single mip, no
+            // storage; RENDER_ATTACHMENT is required and TEXTURE_BINDING / COPY_* are allowed
+            sampleCount: texture.samples,
             dimension: texture.volume ? '3d' : '2d',
 
             // TODO: use only required usage flags

--- a/test/platform/graphics/texture.test.mjs
+++ b/test/platform/graphics/texture.test.mjs
@@ -52,4 +52,106 @@ describe('Texture', function () {
             texture.destroy();
         });
     });
+
+    describe('#constructor: samples option', function () {
+
+        it('defaults to 1', function () {
+            const texture = new Texture(device, { format: PIXELFORMAT_RGBA16F });
+            expect(texture.samples).to.equal(1);
+            texture.destroy();
+        });
+
+        it('is ignored with a warning on a non-WebGPU device', function () {
+            const warn = console.warn;
+            const messages = [];
+            console.warn = (...args) => {
+                messages.push(args.join(' '));
+            };
+            try {
+                const texture = new Texture(device, { name: 'msTex', format: PIXELFORMAT_RGBA16F, samples: 4 });
+                expect(texture.samples).to.equal(1);
+                expect(messages.some(m => m.includes('samples'))).to.be.true;
+                texture.destroy();
+            } finally {
+                console.warn = warn;
+            }
+        });
+
+        it('is normalized to the device sample count on WebGPU', function () {
+            device.isWebGPU = true;
+            device.maxSamples = 4;
+            const texture = new Texture(device, { format: PIXELFORMAT_RGBA16F, samples: 2 });
+            expect(texture.samples).to.equal(4);
+            texture.destroy();
+        });
+
+        it('forces mipmaps off on a multisampled texture', function () {
+            device.isWebGPU = true;
+            device.maxSamples = 4;
+            const texture = new Texture(device, { format: PIXELFORMAT_RGBA16F, samples: 4, mipmaps: true, width: 16, height: 16 });
+            expect(texture.mipmaps).to.be.false;
+            expect(texture.numLevels).to.equal(1);
+            texture.destroy();
+        });
+    });
+
+    describe('#copy: multisampled textures', function () {
+
+        let errors;
+        let originalError;
+
+        beforeEach(function () {
+            originalError = console.error;
+            errors = [];
+            console.error = (...args) => {
+                errors.push(args.join(' '));
+            };
+            device.isWebGPU = true;
+            device.maxSamples = 4;
+        });
+
+        afterEach(function () {
+            console.error = originalError;
+        });
+
+        const createMs = (options = {}) => {
+            return new Texture(device, { format: PIXELFORMAT_RGBA16F, width: 8, height: 8, samples: 4, ...options });
+        };
+
+        it('allows a full-texture copy between multisampled textures', function () {
+            const src = createMs({ name: 'src' });
+            const dst = createMs({ name: 'dst' });
+            expect(dst.copy(src)).to.be.true;
+            expect(errors).to.have.lengthOf(0);
+            src.destroy();
+            dst.destroy();
+        });
+
+        it('rejects a copy between different sample counts', function () {
+            const src = createMs({ name: 'src' });
+            const dst = new Texture(device, { name: 'dst', format: PIXELFORMAT_RGBA16F, width: 8, height: 8, mipmaps: false });
+            expect(dst.copy(src)).to.be.false;
+            expect(errors.some(m => m.includes('sample counts'))).to.be.true;
+            src.destroy();
+            dst.destroy();
+        });
+
+        it('rejects a partial copy of multisampled textures', function () {
+            const src = createMs({ name: 'src' });
+            const dst = createMs({ name: 'dst' });
+            expect(dst.copy(src, { width: 4, height: 4 })).to.be.false;
+            expect(errors.some(m => m.includes('entire texture'))).to.be.true;
+            src.destroy();
+            dst.destroy();
+        });
+
+        it('rejects an offset copy of multisampled textures', function () {
+            const src = createMs({ name: 'src', width: 4, height: 4 });
+            const dst = createMs({ name: 'dst' });
+            expect(dst.copy(src, { destX: 4, destY: 4 })).to.be.false;
+            expect(errors.some(m => m.includes('entire texture'))).to.be.true;
+            src.destroy();
+            dst.destroy();
+        });
+    });
 });

--- a/test/platform/graphics/texture.test.mjs
+++ b/test/platform/graphics/texture.test.mjs
@@ -116,18 +116,15 @@ describe('Texture', function () {
             expect(device._vram.tex).to.equal(before);
         });
 
-        it('allows 111110F only when the device supports rg11b10ufloat-renderable', function () {
+        it('reports multisample capability per format, including feature-gated 111110F', function () {
             expect(isMultisampleCapablePixelFormat(PIXELFORMAT_RGBA8)).to.be.true;
+            expect(isMultisampleCapablePixelFormat(PIXELFORMAT_111110F)).to.be.true;
             expect(isMultisampleCapablePixelFormat(PIXELFORMAT_RGBA32F)).to.be.false;
-            expect(isMultisampleCapablePixelFormat(PIXELFORMAT_111110F)).to.be.false;
-            expect(isMultisampleCapablePixelFormat(PIXELFORMAT_111110F, { textureRG11B10Renderable: false })).to.be.false;
-            expect(isMultisampleCapablePixelFormat(PIXELFORMAT_111110F, { textureRG11B10Renderable: true })).to.be.true;
         });
 
-        it('does not assert on a multisampled 111110F texture when the device feature is present', function () {
+        it('asserts on a multisampled texture with an incapable format', function () {
             device.isWebGPU = true;
             device.maxSamples = 4;
-            device.textureRG11B10Renderable = true;
             const error = console.error;
             const errors = [];
             console.error = (...args) => {
@@ -138,8 +135,7 @@ describe('Texture', function () {
                 expect(errors).to.have.lengthOf(0);
                 texture.destroy();
 
-                device.textureRG11B10Renderable = false;
-                const texture2 = new Texture(device, { format: PIXELFORMAT_111110F, width: 8, height: 8, samples: 4 });
+                const texture2 = new Texture(device, { format: PIXELFORMAT_RGBA32F, width: 8, height: 8, samples: 4 });
                 expect(errors.some(m => m.includes('does not support multisampling'))).to.be.true;
                 texture2.destroy();
             } finally {

--- a/test/platform/graphics/texture.test.mjs
+++ b/test/platform/graphics/texture.test.mjs
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 
 import {
-    PIXELFORMAT_RGBA8, PIXELFORMAT_SRGBA8, PIXELFORMAT_DXT1, PIXELFORMAT_DXT1_SRGB, PIXELFORMAT_RGBA16F
+    PIXELFORMAT_111110F, PIXELFORMAT_RGBA8, PIXELFORMAT_SRGBA8, PIXELFORMAT_DXT1, PIXELFORMAT_DXT1_SRGB,
+    PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F, isMultisampleCapablePixelFormat
 } from '../../../src/platform/graphics/constants.js';
 import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
 import { Texture } from '../../../src/platform/graphics/texture.js';
@@ -92,6 +93,58 @@ describe('Texture', function () {
             expect(texture.mipmaps).to.be.false;
             expect(texture.numLevels).to.equal(1);
             texture.destroy();
+        });
+
+        it('accounts for the sample count in gpuSize and VRAM tracking', function () {
+            device.isWebGPU = true;
+            device.maxSamples = 4;
+            const before = device._vram.tex;
+            const texture = new Texture(device, { format: PIXELFORMAT_RGBA8, width: 8, height: 8, samples: 4 });
+
+            // 8x8 * 4 bytes * 4 samples
+            expect(texture.gpuSize).to.equal(1024);
+
+            // tracked at creation (a multisampled texture is never uploaded)
+            expect(device._vram.tex - before).to.equal(1024);
+
+            // re-accounted across a resize
+            texture.resize(4, 4);
+            expect(device._vram.tex - before).to.equal(256);
+
+            // released on destroy
+            texture.destroy();
+            expect(device._vram.tex).to.equal(before);
+        });
+
+        it('allows 111110F only when the device supports rg11b10ufloat-renderable', function () {
+            expect(isMultisampleCapablePixelFormat(PIXELFORMAT_RGBA8)).to.be.true;
+            expect(isMultisampleCapablePixelFormat(PIXELFORMAT_RGBA32F)).to.be.false;
+            expect(isMultisampleCapablePixelFormat(PIXELFORMAT_111110F)).to.be.false;
+            expect(isMultisampleCapablePixelFormat(PIXELFORMAT_111110F, { textureRG11B10Renderable: false })).to.be.false;
+            expect(isMultisampleCapablePixelFormat(PIXELFORMAT_111110F, { textureRG11B10Renderable: true })).to.be.true;
+        });
+
+        it('does not assert on a multisampled 111110F texture when the device feature is present', function () {
+            device.isWebGPU = true;
+            device.maxSamples = 4;
+            device.textureRG11B10Renderable = true;
+            const error = console.error;
+            const errors = [];
+            console.error = (...args) => {
+                errors.push(args.join(' '));
+            };
+            try {
+                const texture = new Texture(device, { format: PIXELFORMAT_111110F, width: 8, height: 8, samples: 4 });
+                expect(errors).to.have.lengthOf(0);
+                texture.destroy();
+
+                device.textureRG11B10Renderable = false;
+                const texture2 = new Texture(device, { format: PIXELFORMAT_111110F, width: 8, height: 8, samples: 4 });
+                expect(errors.some(m => m.includes('does not support multisampling'))).to.be.true;
+                texture2.destroy();
+            } finally {
+                console.error = error;
+            }
         });
     });
 

--- a/test/platform/graphics/webgpu/webgpu-texture.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-texture.test.mjs
@@ -1,0 +1,102 @@
+import { expect } from 'chai';
+
+import { PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA16U } from '../../../../src/platform/graphics/constants.js';
+import { WebgpuTexture } from '../../../../src/platform/graphics/webgpu/webgpu-texture.js';
+
+// WebgpuTexture reads the WebGPU GPUTextureUsage global. The headless test runner has no
+// GPUDevice; stub the enum with the spec values.
+if (typeof globalThis.GPUTextureUsage === 'undefined') {
+    globalThis.GPUTextureUsage = {
+        COPY_SRC: 0x01,
+        COPY_DST: 0x02,
+        TEXTURE_BINDING: 0x04,
+        STORAGE_BINDING: 0x08,
+        RENDER_ATTACHMENT: 0x10,
+        TRANSIENT_ATTACHMENT: 0x20
+    };
+}
+
+// minimal mock of a WebGPU device - createTexture captures descriptors, and the error scope
+// functions satisfy WebgpuDebug.validate / WebgpuDebug.end
+const createMockDevice = (created) => {
+    return {
+        wgpu: {
+            createTexture(desc) {
+                created.push(desc);
+                return {
+                    createView() {
+                        return {};
+                    }
+                };
+            },
+            pushErrorScope() {},
+            popErrorScope() {
+                return Promise.resolve(null);
+            }
+        }
+    };
+};
+
+const createMockTexture = (device, overrides = {}) => {
+    return {
+        name: 'tex',
+        format: PIXELFORMAT_RGBA16F,
+        width: 8,
+        height: 8,
+        cubemap: false,
+        volume: false,
+        array: false,
+        arrayLength: 0,
+        storage: false,
+        numLevels: 1,
+        samples: 1,
+        device,
+        ...overrides
+    };
+};
+
+describe('WebgpuTexture', function () {
+
+    it('creates a single-sampled texture by default', function () {
+        const created = [];
+        const device = createMockDevice(created);
+        const impl = new WebgpuTexture(createMockTexture(device));
+
+        expect(created).to.have.lengthOf(1);
+        expect(created[0].sampleCount).to.equal(1);
+        expect(impl.gpuTexture).to.not.equal(null);
+    });
+
+    it('creates a multisampled texture with the expected descriptor', function () {
+        const created = [];
+        const device = createMockDevice(created);
+        const impl = new WebgpuTexture(createMockTexture(device, { name: 'msColor', samples: 4 }));
+
+        expect(created).to.have.lengthOf(1);
+        expect(impl.gpuTexture).to.not.equal(null);
+        const desc = created[0];
+        expect(desc.sampleCount).to.equal(4);
+        expect(desc.mipLevelCount).to.equal(1);
+        expect(desc.dimension).to.equal('2d');
+        expect(desc.size).to.deep.equal({ width: 8, height: 8, depthOrArrayLayers: 1 });
+
+        // RENDER_ATTACHMENT is required for multisampled textures, TEXTURE_BINDING and COPY_*
+        // are allowed, STORAGE_BINDING is forbidden
+        expect(desc.usage & GPUTextureUsage.RENDER_ATTACHMENT).to.not.equal(0);
+        expect(desc.usage & GPUTextureUsage.TEXTURE_BINDING).to.not.equal(0);
+        expect(desc.usage & GPUTextureUsage.COPY_SRC).to.not.equal(0);
+        expect(desc.usage & GPUTextureUsage.COPY_DST).to.not.equal(0);
+        expect(desc.usage & GPUTextureUsage.STORAGE_BINDING).to.equal(0);
+    });
+
+    it('creates a multisampled integer texture', function () {
+        const created = [];
+        const device = createMockDevice(created);
+        const impl = new WebgpuTexture(createMockTexture(device, { name: 'msId', format: PIXELFORMAT_RGBA16U, samples: 4 }));
+
+        expect(created).to.have.lengthOf(1);
+        expect(impl.gpuTexture).to.not.equal(null);
+        expect(created[0].format).to.equal('rgba16uint');
+        expect(created[0].sampleCount).to.equal(4);
+    });
+});


### PR DESCRIPTION
Adds first-class multisampled textures: `new Texture(device, { samples: 4 })` creates a texture that can be used as a render target attachment and whose individual samples can be read in a shader using `textureLoad` (WebGPU only). This is the first part of the render-target surface designed in #9059 (see https://github.com/playcanvas/engine/issues/9059#issuecomment-5368086964); a follow-up adds `RenderTarget` support for multisampled attachments with per-attachment resolve control. Refs #9059.

**Changes:**
- `Texture` accepts a `samples` option (WebGPU only, ignored with a warning on other devices, normalized to the device's supported sample count). Multisampled textures are validated to be 2D, non-array, non-storage, with no mipmaps or initial data, and to use a format that supports multisampling.
- `pixelFormatInfo` gains multisample-capability flags per the WebGPU format capability table (8/16-bit unorm / float / integer formats, `r32float`, `rgb10a2` variants, depth formats), with an internal `isMultisampleCapablePixelFormat` helper. Multisample and resolve capability are independent - integer formats and `r32float` can be multisampled but not resolved, which the follow-up RenderTarget PR supports via optional per-attachment resolve.
- `Texture#copy` supports copies between multisampled textures with matching sample counts (full-texture copies only, per WebGPU requirements), and rejects copies between differing sample counts.
- WebGPU texture creation passes the sample count; usage stays `RENDER_ATTACHMENT | TEXTURE_BINDING | COPY_SRC | COPY_DST`, the legal set for multisampled textures.

**API Changes:**
- `Texture` constructor option `samples` (number, defaults to 1).
- `Texture#samples` getter.