### PR TITLE
Support the RG32F texture format on WebGL

### DIFF
--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -172,9 +172,6 @@ class WebglTexture {
             case PIXELFORMAT_SBGRA8:
                 Debug.error('BGRA8 and SBGRA8 texture formats are not supported by WebGL.');
                 break;
-            case PIXELFORMAT_RG32F:
-                Debug.error('RG32F texture format is not supported by WebGL.');
-                break;
             case PIXELFORMAT_RGB9E5:
                 this._glFormat = gl.RGB;
                 this._glInternalFormat = gl.RGB9_E5;
@@ -334,6 +331,11 @@ class WebglTexture {
             case PIXELFORMAT_R32F:
                 this._glFormat = gl.RED;
                 this._glInternalFormat = gl.R32F;
+                this._glPixelType = gl.FLOAT;
+                break;
+            case PIXELFORMAT_RG32F:
+                this._glFormat = gl.RG;
+                this._glInternalFormat = gl.RG32F;
                 this._glPixelType = gl.FLOAT;
                 break;
             case PIXELFORMAT_DEPTH:


### PR DESCRIPTION
### Summary

`PIXELFORMAT_RG32F` had a case in the WebGL texture backend that existed only to report it as unsupported. It broke without assigning `_glFormat`, `_glInternalFormat` or `_glPixelType`, so those stayed `undefined` — uploading a texture with that format failed with `texImage2D: invalid format`, and a render target it was attached to came out incomplete:

```
RG32F texture format is not supported by WebGL.
WebGL: INVALID_ENUM: texImage2D: invalid format
ASSERT FAILED: Framebuffer creation failed with error code FRAMEBUFFER_INCOMPLETE_ATTACHMENT
GL_INVALID_FRAMEBUFFER_OPERATION: glClear: Framebuffer is incomplete: Attachment has zero size.
```

WebGL2 does support the format — internal format `RG32F`, format `RG`, type `FLOAT`, colour renderable through the same `EXT_color_buffer_float` that `R32F` already relies on. This maps it alongside `R32F`, matching the `RG16F` entry a few cases above.

### Notes

`getRenderableHdrFormat` answers from the generic capability flags (`textureFloatRenderable`, `textureFloatFilterable`, `textureFloatBlendable`) and never consults the backend's format table, so it happily returned `RG32F` on WebGL and produced the failure above. That is what made this reachable rather than merely absent. `PIXELFORMAT_BGRA8` and `SBGRA8` remain in the table with the same error-and-fall-through shape, so a preference list naming either would fail the same way — left alone here as a separate concern.

Note that on a WebGL2 device without `EXT_float_blend`, a request for a blendable format still correctly skips the 32 bit formats and falls back to half float.

### Testing

Verified on WebGL2 and WebGPU by a caller requesting a two channel float scene depth target, which previously failed on WebGL with the errors above and now renders on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)