### PR TITLE
Use the worldPosition argument for the shadow normal offset scale

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/lit/frag/lighting/lightFunctionShadow.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/lighting/lightFunctionShadow.js
@@ -31,7 +31,7 @@ export default /* glsl */`
                     #ifdef LIGHT{i}_SHADOW_SAMPLE_ORTHO
                         float distScale = 1.0;
                     #else
-                        float distScale = abs(dot(vPositionW - lightPos, lightDirNorm));
+                        float distScale = abs(dot(worldPosition - lightPos, lightDirNorm));
                     #endif
                     surfacePosition = surfacePosition + normal * shadowParams.y * clamp(1.0 - dot(normal, -lightDirNorm), 0.0, 1.0) * distScale;
                 #endif

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/lighting/lightFunctionShadow.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/lighting/lightFunctionShadow.js
@@ -31,7 +31,7 @@ export default /* wgsl */`
                     #ifdef LIGHT{i}_SHADOW_SAMPLE_ORTHO
                         var distScale: f32 = 1.0;
                     #else
-                        var distScale: f32 = abs(dot(vPositionW - lightPos, lightDirNorm));
+                        var distScale: f32 = abs(dot(worldPosition - lightPos, lightDirNorm));
                     #endif
                     surfacePosition = surfacePosition + normal * shadowParams.y * clamp(1.0 - dot(normal, -lightDirNorm), 0.0, 1.0) * distScale;
                 #endif


### PR DESCRIPTION
`getShadowSampleCoord{i}` takes the shaded position as `worldPosition` and uses it for everything except the distance scale of the normal offset, which reads the `vPositionW` global instead:

```glsl
float distScale = abs(dot(vPositionW - lightPos, lightDirNorm));
```

All three call sites pass `vPositionW`, so this is a **no-op today**. It came up while experimenting with looking a shadow up at a position other than the shaded one, where the mismatch does change the result - a function reading past its own arguments is wrong for any such caller.

GLSL and WGSL twins, one line each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)