### PR TITLE
Add sample_mask builtin support to WGSL fragment shaders

### DIFF
--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -47,6 +47,12 @@ const MARKER = '@@@';
 // matches vertex of fragment entry function, extracts the input name. Ends at the start of the function body '{'.
 const ENTRY_FUNCTION = /(@vertex|@fragment)\s*fn\s+\w+\s*\(\s*(\w+)\s*:[\s\S]*?\{/;
 
+// matches an `output.fragDepth =` style assignment, ignoring whitespace before the = sign
+const FRAG_DEPTH_ASSIGN = /\.fragDepth\s*=/;
+
+// matches an `output.sampleMask =` style assignment (and not a `==` comparison)
+const SAMPLE_MASK_ASSIGN = /\.sampleMask\s*=(?!=)/;
+
 // Tables describing optional WGSL built-in inputs that the engine emits on demand. Each entry
 // maps a public private global (pcXxx) and a struct field (`<input>.xxx`) to the underlying
 // `@builtin(...)` declaration. Detection is data-driven so adding a new built-in is a one-row
@@ -59,6 +65,7 @@ const FRAGMENT_BUILTINS = [
     { wgslName: 'position', wgslType: 'vec4f', wgslBuiltin: 'position', pcName: 'pcPosition', isFallback: true },
     { wgslName: 'frontFacing', wgslType: 'bool', wgslBuiltin: 'front_facing', pcName: 'pcFrontFacing' },
     { wgslName: 'sampleIndex', wgslType: 'u32', wgslBuiltin: 'sample_index', pcName: 'pcSampleIndex' },
+    { wgslName: 'sampleMask', wgslType: 'u32', wgslBuiltin: 'sample_mask', pcName: 'pcSampleMask' },
     { wgslName: 'primitiveIndex', wgslType: 'u32', wgslBuiltin: 'primitive_index', pcName: 'pcPrimitiveIndex', requiresFeature: 'supportsPrimitiveIndex' }
 ];
 
@@ -1020,10 +1027,18 @@ class WebgpuShaderProcessorWGSL {
             }
         }
 
-        // find if the src contains `.fragDepth =`, ignoring whitespace before = sign
-        const needsFragDepth = src.search(/\.fragDepth\s*=/) !== -1;
+        // find if the src writes to `output.fragDepth`
+        const needsFragDepth = src.search(FRAG_DEPTH_ASSIGN) !== -1;
         if (needsFragDepth) {
-            structCode += '    @builtin(frag_depth) fragDepth : f32\n';
+            structCode += '    @builtin(frag_depth) fragDepth : f32,\n';
+        }
+
+        // find if the src writes to `output.sampleMask`. The written mask is AND-ed with the
+        // coverage mask by the GPU, allowing the shader to discard individual samples of a
+        // multisampled render target.
+        const needsSampleMask = src.search(SAMPLE_MASK_ASSIGN) !== -1;
+        if (needsSampleMask) {
+            structCode += '    @builtin(sample_mask) sampleMask : u32,\n';
         }
 
         return `${structCode}};\n`;

--- a/test/platform/graphics/webgpu/webgpu-shader-processor-wgsl.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-shader-processor-wgsl.test.mjs
@@ -27,4 +27,55 @@ describe('WebgpuShaderProcessorWGSL', function () {
         expect(result).to.contain('@location(0) @blend_src(1) colorSecondary : pcOutType0');
         expect(result).to.not.contain('@location(1)');
     });
+
+    describe('sample_mask builtin', function () {
+
+        it('adds the sample_mask output when the shader assigns it', function () {
+            const source = `
+                output.color = vec4f(1.0);
+                output.sampleMask = 0x1u;
+            `;
+            const result = WebgpuShaderProcessorWGSL.generateFragmentOutputStruct(source, 1);
+            expect(result).to.contain('@builtin(sample_mask) sampleMask : u32');
+        });
+
+        it('does not add the sample_mask output for a comparison', function () {
+            const source = `
+                output.color = select(vec4f(0.0), vec4f(1.0), input.sampleMask == 3u);
+            `;
+            const result = WebgpuShaderProcessorWGSL.generateFragmentOutputStruct(source, 1);
+            expect(result).to.not.contain('sample_mask');
+        });
+
+        it('combines fragDepth and sample_mask outputs', function () {
+            const source = `
+                output.color = vec4f(1.0);
+                output.fragDepth = 0.5;
+                output.sampleMask = 0x3u;
+            `;
+            const result = WebgpuShaderProcessorWGSL.generateFragmentOutputStruct(source, 1);
+            expect(result).to.contain('@builtin(frag_depth) fragDepth : f32,');
+            expect(result).to.contain('@builtin(sample_mask) sampleMask : u32,');
+        });
+
+        it('adds the sample_mask fragment input when read through the input struct', function () {
+            const source = 'let coverage = input.sampleMask;';
+            const result = WebgpuShaderProcessorWGSL.processVaryings([], new Map(), false, {}, source, 'input');
+            expect(result).to.contain('@builtin(sample_mask) sampleMask : u32');
+            expect(result).to.contain('var<private> pcSampleMask: u32');
+            expect(result).to.contain('pcSampleMask = input.sampleMask;');
+        });
+
+        it('adds the sample_mask fragment input when read through the private global', function () {
+            const source = 'let coverage = pcSampleMask;';
+            const result = WebgpuShaderProcessorWGSL.processVaryings([], new Map(), false, {}, source, 'input');
+            expect(result).to.contain('@builtin(sample_mask) sampleMask : u32');
+        });
+
+        it('does not add the sample_mask fragment input when unused', function () {
+            const source = 'let x = pcPosition.xy;';
+            const result = WebgpuShaderProcessorWGSL.processVaryings([], new Map(), false, {}, source, 'input');
+            expect(result).to.not.contain('sample_mask');
+        });
+    });
 });


### PR DESCRIPTION
Exposes the WGSL `sample_mask` builtin to fragment shaders processed by the engine (WebGPU only), complementing the recent multisampled rendering support (#9217, #9221).

- **Input**: reading `pcSampleMask` (or `input.sampleMask`) provides the coverage mask of the fragment - which samples of the multisampled attachment are covered by the primitive.
- **Output**: assigning `output.sampleMask` emits the `@builtin(sample_mask)` output; the written mask is AND-ed with the coverage mask by the GPU, allowing the shader to discard individual samples - the basis of techniques such as alpha-to-coverage style transparency with custom dither patterns, or per-sample selective writes.

```wgsl
@fragment
fn fragmentMain(input: FragmentInput) -> FragmentOutput {
    var output: FragmentOutput;
    output.color = vec4f(1.0);
    output.sampleMask = pcSampleMask & 0x5u;  // keep samples 0 and 2 only
    return output;
}
```

**Changes:**
- `FRAGMENT_BUILTINS` gains the `sample_mask` input row - detection, `FragmentInput` struct field, `pcSampleMask` private global and input copy are all handled by the existing data-driven mechanism (same as `pcSampleIndex`).
- `generateFragmentOutputStruct` detects `output.sampleMask` assignments (comparisons like `== 3u` do not trigger it) and emits the builtin in the `FragmentOutput` struct. The `frag_depth` member gained a trailing comma so the two builtins combine into valid WGSL.
- The assignment-detection regexes are declared as module constants (`FRAG_DEPTH_ASSIGN`, `SAMPLE_MASK_ASSIGN`) alongside the other patterns.

Note this is WGSL-only by nature - GLSL ES 3.00 (WebGL2) has no `gl_SampleMask`.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change