### PR TITLE
fix: disable blending when generating SOG centers into an integer render target

### DIFF
--- a/src/scene/gsplat/gsplat-sog-data.js
+++ b/src/scene/gsplat/gsplat-sog-data.js
@@ -3,6 +3,7 @@ import { Quat } from '../../core/math/quat.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Vec4 } from '../../core/math/vec4.js';
 import { GSplatData } from './gsplat-data.js';
+import { BlendState } from '../../platform/graphics/blend-state.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { Texture } from '../../platform/graphics/texture.js';
 import {
@@ -403,6 +404,9 @@ class GSplatSogData {
         renderPass.init(renderTarget);
         renderPass.colorOps.clear = false;
         renderPass.depthStencilOps.clearDepth = false;
+        // RenderPassQuad preserves the device blend state; blending must be off
+        // for the integer render target
+        device.setBlendState(BlendState.NOBLEND);
         renderPass.render();
         quad.destroy();
 

--- a/src/scene/gsplat/gsplat-sog-data.js
+++ b/src/scene/gsplat/gsplat-sog-data.js
@@ -3,7 +3,6 @@ import { Quat } from '../../core/math/quat.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import { Vec4 } from '../../core/math/vec4.js';
 import { GSplatData } from './gsplat-data.js';
-import { BlendState } from '../../platform/graphics/blend-state.js';
 import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { Texture } from '../../platform/graphics/texture.js';
 import {
@@ -14,7 +13,7 @@ import {
     SEMANTIC_POSITION
 } from '../../platform/graphics/constants.js';
 import { QuadRender } from '../../scene/graphics/quad-render.js';
-import { RenderPassQuad } from '../../scene/graphics/render-pass-quad.js';
+import { RenderPassShaderQuad } from '../../scene/graphics/render-pass-shader-quad.js';
 import { ShaderUtils } from '../shader-lib/shader-utils.js';
 import glslSogCentersPS from '../shader-lib/glsl/chunks/gsplat/frag/gsplatSogCenters.js';
 import wgslSogCentersPS from '../shader-lib/wgsl/chunks/gsplat/frag/gsplatSogCenters.js';
@@ -399,14 +398,12 @@ class GSplatSogData {
         });
 
         const quad = new QuadRender(shader);
-        const renderPass = new RenderPassQuad(device, quad);
+        const renderPass = new RenderPassShaderQuad(device);
+        renderPass.quadRender = quad;
         renderPass.name = 'SogGenerateCenters';
         renderPass.init(renderTarget);
         renderPass.colorOps.clear = false;
         renderPass.depthStencilOps.clearDepth = false;
-        // RenderPassQuad preserves the device blend state; blending must be off
-        // for the integer render target
-        device.setBlendState(BlendState.NOBLEND);
         renderPass.render();
         quad.destroy();
 


### PR DESCRIPTION
## Problem

On WebGPU, picking a SOG scene (e.g. double-clicking in SuperSplat Viewer) produces Dawn validation errors and a broken pick:

```
Blending is enabled but color format (TextureFormat::RGBA32Uint) is not blendable.
 - While validating targets[0] framebuffer output.
 - While encoding [RenderPassEncoder "SogGenerateCenters-PassEncoder RT:sogCentersTexture"].SetPipeline(...)
```

`GSplatSogData.generateCenters()` lazily renders splat centers into an RGBA32U texture via `RenderPassQuad`. Since #8535, `RenderPassQuad` deliberately preserves the device blend state (callers own it), so the pass inherits the alpha blending left over from splat rendering. WebGPU rejects blending on integer formats, the pipeline is invalid, the pass silently no-ops, and the subsequent centers readback returns garbage — so picking on SOG scenes under WebGPU fails entirely. WebGL ignores blend state on integer targets, which is why only WebGPU surfaces this.

## Fix

Set `BlendState.NOBLEND` on the device before rendering the quad, matching the caller contract established in #8535 and the pattern used by other `drawQuadWithShader`/`RenderPassQuad` callers.