### PR TITLE
Add RenderTarget depthResolveMode controlling multisampled depth resolve

### DIFF
--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -389,6 +389,33 @@ export const RENDERTARGET_ORIGIN_BOTTOM = 'bottom';
 export const RENDERTARGET_ORIGIN_NATIVE = 'native';
 
 /**
+ * The depth value of the multisampled depth buffer is resolved by taking its sample at index 0.
+ * See {@link RenderTarget#depthResolveMode}.
+ *
+ * @category Graphics
+ */
+export const DEPTHRESOLVE_SAMPLE0 = 'sample0';
+
+/**
+ * The depth value of the multisampled depth buffer is resolved by taking the minimum value of all
+ * samples - with a standard depth buffer this selects the nearest surface, which is a conservative
+ * and stable choice for depth-consuming effects. This is the default. See
+ * {@link RenderTarget#depthResolveMode}.
+ *
+ * @category Graphics
+ */
+export const DEPTHRESOLVE_MIN = 'min';
+
+/**
+ * The depth value of the multisampled depth buffer is resolved by taking the maximum value of all
+ * samples - with a standard depth buffer this selects the farthest surface. See
+ * {@link RenderTarget#depthResolveMode}.
+ *
+ * @category Graphics
+ */
+export const DEPTHRESOLVE_MAX = 'max';
+
+/**
  * No triangles are culled.
  *
  * @category Graphics

--- a/src/platform/graphics/render-target.js
+++ b/src/platform/graphics/render-target.js
@@ -1,6 +1,6 @@
 import { Debug } from '../../core/debug.js';
 import { TRACEID_RENDER_TARGET_ALLOC } from '../../core/constants.js';
-import { PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTH16, PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_R32F, RENDERTARGET_ORIGIN_BOTTOM, RENDERTARGET_ORIGIN_NATIVE, RENDERTARGET_ORIGIN_TOP, isSrgbPixelFormat, isMultisampleResolveCapablePixelFormat } from './constants.js';
+import { DEPTHRESOLVE_MAX, DEPTHRESOLVE_MIN, DEPTHRESOLVE_SAMPLE0, PIXELFORMAT_DEPTH, PIXELFORMAT_DEPTH16, PIXELFORMAT_DEPTHSTENCIL, PIXELFORMAT_R32F, RENDERTARGET_ORIGIN_BOTTOM, RENDERTARGET_ORIGIN_NATIVE, RENDERTARGET_ORIGIN_TOP, isSrgbPixelFormat, isMultisampleResolveCapablePixelFormat } from './constants.js';
 import { DebugGraphics } from './debug-graphics.js';
 import { GraphicsDevice } from './graphics-device.js';
 import { TextureUtils } from './texture-utils.js';
@@ -165,6 +165,12 @@ class RenderTarget {
     autoResolve;
 
     /**
+     * @type {string}
+     * @private
+     */
+    _depthResolveMode = DEPTHRESOLVE_MIN;
+
+    /**
      * @type {number}
      * @private
      */
@@ -215,6 +221,19 @@ class RenderTarget {
      * @param {object} [options] - Object for passing optional arguments.
      * @param {boolean} [options.autoResolve] - If samples > 1, enables or disables automatic MSAA
      * resolve after rendering to this RT (see {@link resolve}). Defaults to true.
+     * @param {string} [options.depthResolveMode] - How the samples of the multisampled depth
+     * buffer are resolved into a single depth value, whenever the depth of this render target is
+     * resolved by a shader-based resolve (WebGPU only) - the depth grab pass (`sceneDepthMap`), a
+     * depth {@link copy}, or the automatic resolve into a provided `depthBuffer`. Can be:
+     *
+     * - {@link DEPTHRESOLVE_MIN}: the minimum sample value - with a standard depth buffer this
+     * selects the nearest surface, a conservative and stable choice for depth-consuming effects.
+     * - {@link DEPTHRESOLVE_MAX}: the maximum sample value - the farthest surface.
+     * - {@link DEPTHRESOLVE_SAMPLE0}: the value of the sample at index 0.
+     *
+     * Defaults to {@link DEPTHRESOLVE_MIN}. Ignored on WebGL2, where the sample selection of the
+     * depth resolve is defined by the implementation. Can also be changed at any time using the
+     * {@link depthResolveMode} property.
      * @param {Texture} [options.colorBuffer] - The texture that this render target will treat as a
      * rendering surface. This can be a multisampled texture (a texture created with `samples` > 1,
      * WebGPU only), in which case the render target renders directly into its samples, the sample
@@ -416,6 +435,8 @@ class RenderTarget {
         if (!this.name) {
             this.name = 'Untitled';
         }
+
+        this.depthResolveMode = options.depthResolveMode ?? DEPTHRESOLVE_MIN;
 
         // validate explicit multisampled attachments and their resolve buffers
         Debug.call(() => {
@@ -777,6 +798,29 @@ class RenderTarget {
      */
     get samples() {
         return this._samples;
+    }
+
+    /**
+     * Sets how the samples of the multisampled depth buffer are resolved into a single depth
+     * value (WebGPU only). Can be changed at any time - the mode is used at the time the depth is
+     * resolved. See the `depthResolveMode` constructor option.
+     *
+     * @type {string}
+     */
+    set depthResolveMode(value) {
+        Debug.assert(value === DEPTHRESOLVE_MIN || value === DEPTHRESOLVE_MAX || value === DEPTHRESOLVE_SAMPLE0,
+            `RenderTarget '${this.name}': invalid depthResolveMode '${value}'.`, this);
+        this._depthResolveMode = value;
+    }
+
+    /**
+     * Gets how the samples of the multisampled depth buffer are resolved into a single depth
+     * value.
+     *
+     * @type {string}
+     */
+    get depthResolveMode() {
+        return this._depthResolveMode;
     }
 
     /**

--- a/src/platform/graphics/shader-chunks/frag/webgpu-depth-resolve.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu-depth-resolve.js
@@ -1,0 +1,42 @@
+// Shader used by WebgpuResolver to resolve a multisampled depth texture into a single-sampled
+// texture, by rendering a fullscreen quad. The resolve mode is selected by exactly one of these
+// defines: DEPTH_RESOLVE_SAMPLE0, DEPTH_RESOLVE_MIN or DEPTH_RESOLVE_MAX.
+export default /* wgsl */`
+
+    var<private> pos : array<vec2f, 4> = array<vec2f, 4>(
+        vec2(-1.0, 1.0), vec2(1.0, 1.0), vec2(-1.0, -1.0), vec2(1.0, -1.0)
+    );
+
+    struct VertexOutput {
+        @builtin(position) position : vec4f,
+    };
+
+    @vertex
+    fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
+        var output : VertexOutput;
+        output.position = vec4f(pos[vertexIndex], 0, 1);
+        return output;
+    }
+
+    @group(0) @binding(0) var img : texture_depth_multisampled_2d;
+
+    @fragment
+    fn fragmentMain(@builtin(position) fragColor: vec4f) -> @location(0) vec4f {
+        let coord = vec2i(fragColor.xy);
+
+        // the depth value of sample 0, or a min/max reduction of all samples
+        var depth = textureLoad(img, coord, 0u);
+        #if defined(DEPTH_RESOLVE_MIN) || defined(DEPTH_RESOLVE_MAX)
+            let count = i32(textureNumSamples(img));
+            for (var i = 1; i < count; i++) {
+                #ifdef DEPTH_RESOLVE_MIN
+                    depth = min(depth, textureLoad(img, coord, i));
+                #else
+                    depth = max(depth, textureLoad(img, coord, i));
+                #endif
+            }
+        #endif
+
+        return vec4f(depth, 0.0, 0.0, 0.0);
+    }
+`;

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -1203,7 +1203,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
                     if (depthAttachment?.transient) {
                         Debug.errorOnce(`Depth resolve is not possible on render target '${target.name}' because its depth is a transient (memoryless) attachment. Disable transientDepth to allow depth resolve.`);
                     } else if (depthAttachment && destTexture) {
-                        this.resolver.resolveDepth(this.commandEncoder, depthAttachment.multisampledDepthBuffer, destTexture);
+                        this.resolver.resolveDepth(this.commandEncoder, depthAttachment.multisampledDepthBuffer, destTexture, target.depthResolveMode);
                     }
                 }
             }
@@ -1629,14 +1629,18 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
                 return false;
             }
 
-            const sourceTexture = sourceRT.impl.depthAttachment.depthTexture;
+            // internally allocated depth uses depthTexture (multisampled when samples > 1); a
+            // user-provided depth buffer with samples > 1 stores its multisampled depth separately
+            const sourceAttachment = sourceRT.impl.depthAttachment;
+            const sourceTexture = sourceAttachment.depthTexture ?? sourceAttachment.multisampledDepthBuffer;
             const sourceMipLevel = sourceRT.mipLevel;
 
             if (sourceRT.samples > 1) {
 
-                // resolve the depth to a color buffer of destination render target
+                // resolve the depth to a color buffer of destination render target, using the
+                // resolve mode of the source render target
                 const destTexture = dest.colorBuffer.impl.gpuTexture;
-                this.resolver.resolveDepth(commandEncoder, sourceTexture, destTexture);
+                this.resolver.resolveDepth(commandEncoder, sourceTexture, destTexture, sourceRT.depthResolveMode);
 
             } else {
 

--- a/src/platform/graphics/webgpu/webgpu-resolver.js
+++ b/src/platform/graphics/webgpu/webgpu-resolver.js
@@ -1,7 +1,8 @@
 import { Shader } from '../shader.js';
-import { SHADERLANGUAGE_WGSL } from '../constants.js';
+import { DEPTHRESOLVE_MAX, DEPTHRESOLVE_MIN, DEPTHRESOLVE_SAMPLE0, SHADERLANGUAGE_WGSL } from '../constants.js';
 import { Debug, DebugHelper } from '../../../core/debug.js';
 import { DebugGraphics } from '../debug-graphics.js';
+import webgpuDepthResolve from '../shader-chunks/frag/webgpu-depth-resolve.js';
 
 /**
  * @import { WebgpuGraphicsDevice } from './webgpu-graphics-device.js'
@@ -18,82 +19,80 @@ class WebgpuResolver {
     device;
 
     /**
-     * Cache of render pipelines for each texture format, to avoid their per frame creation.
+     * Cache of render pipelines for each texture format and depth resolve mode, to avoid their
+     * per frame creation.
      *
-     * @type {Map<GPUTextureFormat, GPURenderPipeline>}
+     * @type {Map<string, GPURenderPipeline>}
      * @private
      */
     pipelineCache = new Map();
 
+    /**
+     * Cache of shaders for each depth resolve mode (DEPTHRESOLVE_***).
+     *
+     * @type {Map<string, Shader>}
+     * @private
+     */
+    shaderCache = new Map();
+
     constructor(device) {
         this.device = device;
-
-        // Shader that renders a fullscreen textured quad and copies the depth value from sample index 0
-        // TODO: could handle all sample indices and use min/max as needed
-        const code = `
- 
-            var<private> pos : array<vec2f, 4> = array<vec2f, 4>(
-                vec2(-1.0, 1.0), vec2(1.0, 1.0), vec2(-1.0, -1.0), vec2(1.0, -1.0)
-            );
-
-            struct VertexOutput {
-                @builtin(position) position : vec4f,
-            };
-
-            @vertex
-            fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
-              var output : VertexOutput;
-              output.position = vec4f(pos[vertexIndex], 0, 1);
-              return output;
-            }
-
-            @group(0) @binding(0) var img : texture_depth_multisampled_2d;
-
-            @fragment
-            fn fragmentMain(@builtin(position) fragColor: vec4f) -> @location(0) vec4f {
-                // load th depth value from sample index 0
-                var depth = textureLoad(img, vec2i(fragColor.xy), 0u);
-                return vec4f(depth, 0.0, 0.0, 0.0);
-            }
-        `;
-
-        this.shader = new Shader(device, {
-            name: 'WebGPUResolverDepthShader',
-            shaderLanguage: SHADERLANGUAGE_WGSL,
-            vshader: code,
-            fshader: code
-        });
     }
 
     destroy() {
-        this.shader.destroy();
-        this.shader = null;
+        this.shaderCache.forEach(shader => shader.destroy());
+        this.shaderCache = null;
         this.pipelineCache = null;
     }
 
     /**
-     * @param {GPUTextureFormat} format - Texture format.
-     * @returns {GPURenderPipeline} Pipeline for the given format.
+     * @param {string} mode - The depth resolve mode (DEPTHRESOLVE_***).
+     * @returns {Shader} Shader for the given resolve mode.
      * @private
      */
-    getPipeline(format) {
-        let pipeline = this.pipelineCache.get(format);
+    getShader(mode) {
+        Debug.assert(mode === DEPTHRESOLVE_SAMPLE0 || mode === DEPTHRESOLVE_MIN || mode === DEPTHRESOLVE_MAX, `Invalid depth resolve mode '${mode}'`);
+        let shader = this.shaderCache.get(mode);
+        if (!shader) {
+            // the resolve mode is selected by a define, handled by the shader preprocessor
+            const code = `#define DEPTH_RESOLVE_${mode.toUpperCase()}\n${webgpuDepthResolve}`;
+            shader = new Shader(this.device, {
+                name: `WebGPUResolverDepthShader-${mode}`,
+                shaderLanguage: SHADERLANGUAGE_WGSL,
+                vshader: code,
+                fshader: code
+            });
+            this.shaderCache.set(mode, shader);
+        }
+        return shader;
+    }
+
+    /**
+     * @param {GPUTextureFormat} format - Texture format.
+     * @param {string} mode - The depth resolve mode (DEPTHRESOLVE_***).
+     * @returns {GPURenderPipeline} Pipeline for the given format and resolve mode.
+     * @private
+     */
+    getPipeline(format, mode) {
+        const key = `${format}-${mode}`;
+        let pipeline = this.pipelineCache.get(key);
         if (!pipeline) {
-            pipeline = this.createPipeline(format);
-            this.pipelineCache.set(format, pipeline);
+            pipeline = this.createPipeline(format, mode);
+            this.pipelineCache.set(key, pipeline);
         }
         return pipeline;
     }
 
     /**
      * @param {GPUTextureFormat} format - Texture format.
-     * @returns {GPURenderPipeline} Pipeline for the given format.
+     * @param {string} mode - The depth resolve mode (DEPTHRESOLVE_***).
+     * @returns {GPURenderPipeline} Pipeline for the given format and resolve mode.
      * @private
      */
-    createPipeline(format) {
+    createPipeline(format, mode) {
 
         /** @type {WebgpuShader} */
-        const webgpuShader = this.shader.impl;
+        const webgpuShader = this.getShader(mode).impl;
 
         const pipeline = this.device.wgpu.createRenderPipeline({
             layout: 'auto',
@@ -112,7 +111,7 @@ class WebgpuResolver {
                 topology: 'triangle-strip'
             }
         });
-        DebugHelper.setLabel(pipeline, `RenderPipeline-DepthResolver-${format}`);
+        DebugHelper.setLabel(pipeline, `RenderPipeline-DepthResolver-${format}-${mode}`);
         return pipeline;
     }
 
@@ -120,9 +119,11 @@ class WebgpuResolver {
      * @param {GPUCommandEncoder} commandEncoder - Command encoder to use for the resolve.
      * @param {GPUTexture} sourceTexture - Source multi-sampled depth texture to resolve.
      * @param {GPUTexture} destinationTexture - Destination depth texture to resolve to.
+     * @param {string} [mode] - The depth resolve mode (DEPTHRESOLVE_***). Defaults to
+     * {@link DEPTHRESOLVE_MIN}.
      * @private
      */
-    resolveDepth(commandEncoder, sourceTexture, destinationTexture) {
+    resolveDepth(commandEncoder, sourceTexture, destinationTexture, mode = DEPTHRESOLVE_MIN) {
 
         Debug.assert(sourceTexture.sampleCount > 1);
         Debug.assert(destinationTexture.sampleCount === 1);
@@ -131,8 +132,8 @@ class WebgpuResolver {
         const device = this.device;
         const wgpu = device.wgpu;
 
-        // pipeline depends on the format
-        const pipeline = this.getPipeline(destinationTexture.format);
+        // pipeline depends on the format and the resolve mode
+        const pipeline = this.getPipeline(destinationTexture.format, mode);
 
         DebugGraphics.pushGpuMarker(device, 'DEPTH_RESOLVE-RENDERER');
 

--- a/test/platform/graphics/render-target.test.mjs
+++ b/test/platform/graphics/render-target.test.mjs
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { PIXELFORMAT_DEPTH, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA16U, PIXELFORMAT_RGBA8, RENDERTARGET_ORIGIN_BOTTOM, RENDERTARGET_ORIGIN_NATIVE, RENDERTARGET_ORIGIN_TOP } from '../../../src/platform/graphics/constants.js';
+import { DEPTHRESOLVE_MAX, DEPTHRESOLVE_MIN, DEPTHRESOLVE_SAMPLE0, PIXELFORMAT_DEPTH, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA16U, PIXELFORMAT_RGBA8, RENDERTARGET_ORIGIN_BOTTOM, RENDERTARGET_ORIGIN_NATIVE, RENDERTARGET_ORIGIN_TOP } from '../../../src/platform/graphics/constants.js';
 import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
 import { RenderTarget } from '../../../src/platform/graphics/render-target.js';
 import { Texture } from '../../../src/platform/graphics/texture.js';
@@ -323,6 +323,30 @@ describe('RenderTarget', function () {
             expect(resolve.height).to.equal(8);
             rt.destroyTextureBuffers();
             rt.destroy();
+        });
+    });
+
+    describe('#depthResolveMode', function () {
+
+        it('defaults to DEPTHRESOLVE_MIN', function () {
+            const rt = createRenderTarget({ samples: 4 });
+            expect(rt.depthResolveMode).to.equal(DEPTHRESOLVE_MIN);
+            destroyRenderTarget(rt);
+        });
+
+        it('is set by the constructor option', function () {
+            const rt = createRenderTarget({ samples: 4, depthResolveMode: DEPTHRESOLVE_SAMPLE0 });
+            expect(rt.depthResolveMode).to.equal(DEPTHRESOLVE_SAMPLE0);
+            destroyRenderTarget(rt);
+        });
+
+        it('is mutable at any time', function () {
+            const rt = createRenderTarget({ samples: 4 });
+            rt.depthResolveMode = DEPTHRESOLVE_MAX;
+            expect(rt.depthResolveMode).to.equal(DEPTHRESOLVE_MAX);
+            rt.depthResolveMode = DEPTHRESOLVE_MIN;
+            expect(rt.depthResolveMode).to.equal(DEPTHRESOLVE_MIN);
+            destroyRenderTarget(rt);
         });
     });
 });

--- a/test/platform/graphics/webgpu/webgpu-resolver.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-resolver.test.mjs
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+
+import { Preprocessor } from '../../../../src/core/preprocessor.js';
+import webgpuDepthResolve from '../../../../src/platform/graphics/shader-chunks/frag/webgpu-depth-resolve.js';
+
+// mirrors how WebgpuResolver#getShader builds the shader source for a resolve mode, and how the
+// Shader class preprocesses WGSL (stripDefines: true)
+const process = (mode) => {
+    const code = `#define DEPTH_RESOLVE_${mode.toUpperCase()}\n${webgpuDepthResolve}`;
+    return Preprocessor.run(code, new Map(), { stripDefines: true });
+};
+
+describe('WebgpuResolver depth resolve shader chunk', function () {
+
+    it('loads only sample 0 for the sample0 mode', function () {
+        const code = process('sample0');
+        expect(code).to.contain('textureLoad(img, coord, 0u)');
+        expect(code).to.not.contain('textureNumSamples');
+        expect(code).to.not.contain('#');
+    });
+
+    it('reduces all samples with min for the min mode', function () {
+        const code = process('min');
+        expect(code).to.contain('textureNumSamples(img)');
+        expect(code).to.contain('min(depth, textureLoad(img, coord, i))');
+        expect(code).to.not.contain('max(depth');
+        expect(code).to.not.contain('#');
+    });
+
+    it('reduces all samples with max for the max mode', function () {
+        const code = process('max');
+        expect(code).to.contain('textureNumSamples(img)');
+        expect(code).to.contain('max(depth, textureLoad(img, coord, i))');
+        expect(code).to.not.contain('min(depth');
+        expect(code).to.not.contain('#');
+    });
+});


### PR DESCRIPTION
Adds control over how the samples of a multisampled depth buffer are resolved into a single depth value by the WebGPU shader-based depth resolve - used by the depth grab pass (`sceneDepthMap`), a depth `RenderTarget#copy`, and the automatic resolve into a provided `depthBuffer`.

```javascript
const rt = new RenderTarget({ colorBuffer, depth: true, samples: 4, depthResolveMode: DEPTHRESOLVE_MAX });
rt.depthResolveMode = DEPTHRESOLVE_SAMPLE0;  // mutable at any time, used at resolve time
```

**Behavior change:** the default resolve changes from sample 0 to **`DEPTHRESOLVE_MIN`**. Sample 0 is an arbitrary sample position - at geometry silhouettes it lands on the foreground or background essentially at random per pixel, causing edge noise in depth-consuming effects such as soft particles. MIN (the nearest surface, with a standard depth buffer) is deterministic and conservative, and matches what depth consumers such as Hi-Z occlusion expect. `DEPTHRESOLVE_SAMPLE0` remains available to restore the previous behavior.

**Changes:**
- New constants `DEPTHRESOLVE_MIN` (default), `DEPTHRESOLVE_MAX` and `DEPTHRESOLVE_SAMPLE0`, and a mutable `RenderTarget#depthResolveMode` property with a matching constructor option. WebGPU only - on WebGL2 the depth resolve sample selection is defined by the implementation and the property is ignored.
- `WebgpuResolver` supports all three modes, with shaders and pipelines lazily cached per mode and format. Its WGSL source is extracted into a shader chunk (`shader-chunks/frag/webgpu-depth-resolve.js`), with the mode selected by a `DEPTH_RESOLVE_***` define handled by the shader preprocessor - the first of the internal device-level renderers to move its shader to the platform chunks.
- Fixed a crash in `copyRenderTarget` when copying depth from a render target with a user-provided `depthBuffer` and `samples` > 1 - the multisampled depth of such a target is stored separately from the internally-allocated case, and the copy read a null texture.

Verified on WebGPU (Metal): a known-depth scene rendered into an MSAA target and resolved with each mode - at all 100 mixed-sample edge pixels, MIN returned the near surface depth, MAX the far clear value, and SAMPLE0 a value within that range; mode switching at runtime works. The `ground-fog` and `particles-snow` examples exercise the new default through the MSAA depth grab.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change