### PR TITLE
Extract WebGPU mipmap and clear renderer shaders into shader chunks

### DIFF
--- a/src/platform/graphics/shader-chunks/frag/webgpu-clear.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu-clear.js
@@ -1,0 +1,31 @@
+// Shader used by WebgpuClearRenderer to clear the color and / or depth of the viewport area, by
+// rendering a fullscreen quad.
+export default /* wgsl */`
+
+    struct ub_mesh {
+        color : vec4f,
+        depth: f32
+    }
+
+    @group(2) @binding(0) var<uniform> ubMesh : ub_mesh;
+
+    var<private> pos : array<vec2f, 4> = array<vec2f, 4>(
+        vec2(-1.0, 1.0), vec2(1.0, 1.0), vec2(-1.0, -1.0), vec2(1.0, -1.0)
+    );
+
+    struct VertexOutput {
+        @builtin(position) position : vec4f
+    }
+
+    @vertex
+    fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
+        var output : VertexOutput;
+        output.position = vec4(pos[vertexIndex], ubMesh.depth, 1.0);
+        return output;
+    }
+
+    @fragment
+    fn fragmentMain() -> @location(0) vec4f {
+        return ubMesh.color;
+    }
+`;

--- a/src/platform/graphics/shader-chunks/frag/webgpu-mipmap.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu-mipmap.js
@@ -1,0 +1,29 @@
+// Shader used by WebgpuMipmapRenderer to generate texture mipmaps, by rendering the previous mip
+// level into the next one using a fullscreen quad.
+export default /* wgsl */`
+
+    var<private> pos : array<vec2f, 4> = array<vec2f, 4>(
+        vec2(-1.0, 1.0), vec2(1.0, 1.0), vec2(-1.0, -1.0), vec2(1.0, -1.0)
+    );
+
+    struct VertexOutput {
+        @builtin(position) position : vec4f,
+        @location(0) texCoord : vec2f
+    };
+
+    @vertex
+    fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
+        var output : VertexOutput;
+        output.texCoord = pos[vertexIndex] * vec2f(0.5, -0.5) + vec2f(0.5);
+        output.position = vec4f(pos[vertexIndex], 0, 1);
+        return output;
+    }
+
+    @group(0) @binding(0) var imgSampler : sampler;
+    @group(0) @binding(1) var img : texture_2d<f32>;
+
+    @fragment
+    fn fragmentMain(@location(0) texCoord : vec2f) -> @location(0) vec4f {
+        return textureSample(img, imgSampler, texCoord);
+    }
+`;

--- a/src/platform/graphics/webgpu/webgpu-clear-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-clear-renderer.js
@@ -11,6 +11,7 @@ import { DynamicBindGroup } from '../bind-group.js';
 import { UniformBuffer } from '../uniform-buffer.js';
 import { DebugGraphics } from '../debug-graphics.js';
 import { DepthState } from '../depth-state.js';
+import webgpuClear from '../shader-chunks/frag/webgpu-clear.js';
 
 const primitive = {
     type: PRIMITIVE_TRISTRIP,
@@ -33,42 +34,11 @@ class WebgpuClearRenderer {
     constructor(device) {
 
         // shader that can write out color and depth values
-        const code = `
-
-            struct ub_mesh {
-                color : vec4f,
-                depth: f32
-            }
-
-            @group(2) @binding(0) var<uniform> ubMesh : ub_mesh;
-
-            var<private> pos : array<vec2f, 4> = array<vec2f, 4>(
-                vec2(-1.0, 1.0), vec2(1.0, 1.0),
-                vec2(-1.0, -1.0), vec2(1.0, -1.0)
-            );
-
-            struct VertexOutput {
-                @builtin(position) position : vec4f
-            }
-
-            @vertex
-            fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
-                var output : VertexOutput;
-                output.position = vec4(pos[vertexIndex], ubMesh.depth, 1.0);
-                return output;
-            }
-
-            @fragment
-            fn fragmentMain() -> @location(0) vec4f {
-                return ubMesh.color;
-            }
-        `;
-
         this.shader = new Shader(device, {
             name: 'WebGPUClearRendererShader',
             shaderLanguage: SHADERLANGUAGE_WGSL,
-            vshader: code,
-            fshader: code
+            vshader: webgpuClear,
+            fshader: webgpuClear
         });
 
         // uniforms

--- a/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-mipmap-renderer.js
@@ -2,6 +2,7 @@ import { Shader } from '../shader.js';
 import { SHADERLANGUAGE_WGSL } from '../constants.js';
 import { Debug, DebugHelper } from '../../../core/debug.js';
 import { DebugGraphics } from '../debug-graphics.js';
+import webgpuMipmap from '../shader-chunks/frag/webgpu-mipmap.js';
 
 /**
  * @import { WebgpuGraphicsDevice } from './webgpu-graphics-device.js'
@@ -29,41 +30,12 @@ class WebgpuMipmapRenderer {
     constructor(device) {
         this.device = device;
 
-        // Shader that renders a fullscreen textured quad
-        const code = `
- 
-            var<private> pos : array<vec2f, 4> = array<vec2f, 4>(
-                vec2(-1.0, 1.0), vec2(1.0, 1.0),
-                vec2(-1.0, -1.0), vec2(1.0, -1.0)
-            );
-
-            struct VertexOutput {
-                @builtin(position) position : vec4f,
-                @location(0) texCoord : vec2f
-            };
-
-            @vertex
-            fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
-              var output : VertexOutput;
-              output.texCoord = pos[vertexIndex] * vec2f(0.5, -0.5) + vec2f(0.5);
-              output.position = vec4f(pos[vertexIndex], 0, 1);
-              return output;
-            }
-
-            @group(0) @binding(0) var imgSampler : sampler;
-            @group(0) @binding(1) var img : texture_2d<f32>;
-
-            @fragment
-            fn fragmentMain(@location(0) texCoord : vec2f) -> @location(0) vec4f {
-              return textureSample(img, imgSampler, texCoord);
-            }
-        `;
-
+        // shader that renders a fullscreen textured quad
         this.shader = new Shader(device, {
             name: 'WebGPUMipmapRendererShader',
             shaderLanguage: SHADERLANGUAGE_WGSL,
-            vshader: code,
-            fshader: code
+            vshader: webgpuMipmap,
+            fshader: webgpuMipmap
         });
 
         // using minified rendering, so that's the only filter mode we need to set.


### PR DESCRIPTION
Moves the inline WGSL shader sources of the internal WebGPU renderers into the platform shader chunks directory, following the pattern established for the depth resolver in #9226 - chunk files with an `export default /* wgsl */` template string, named for their consumer.

**Changes:**
- New chunk `shader-chunks/frag/webgpu-mipmap.js` - the fullscreen-quad downsample shader of `WebgpuMipmapRenderer`.
- New chunk `shader-chunks/frag/webgpu-clear.js` - the color/depth viewport-clear quad shader (including its `ub_mesh` uniform struct) of `WebgpuClearRenderer`.
- Both renderers import their chunk instead of holding the WGSL inline.

This is a pure extraction - neither shader has any variant templating, and the extracted WGSL is identical to the previous inline strings apart from whitespace normalization. No other chunk-worthy inline WGSL remains in the WebGPU backend (the depth resolver's extraction is part of #9226).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change