### PR TITLE
Add scene.gsplat.useTonemap to opt Gaussian splats out of tonemapping and exposure

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1448,6 +1448,8 @@ class AppBase extends EventHandler {
      * @param {number} [settings.render.gsplatFoveationCenter] - Protected centre radius for foveated contribution culling. Defaults to 0.3.
      * @param {boolean} [settings.render.gsplatAntiAlias] - Enables anti-aliasing compensation for Gaussian splats. Defaults to false.
      * @param {boolean} [settings.render.gsplatUseFog] - Whether to apply scene fog to Gaussian splats. Defaults to true.
+     * @param {boolean} [settings.render.gsplatUseTonemap] - Whether to apply the camera's tonemapping and the
+     * scene exposure to Gaussian splats. Defaults to true.
      * @param {number} [settings.render.gsplatColorUpdateAngle] - Viewing angle threshold in degrees for triggering gsplat spherical harmonics color updates. Defaults to 10.
      * @param {number} [settings.render.gsplatCooldownTicks] - Number of update ticks before unloading unused streamed gsplat resources. Defaults to 100.
      * @param {string} [settings.render.gsplatDataFormat] - Work buffer data format for gsplat rendering. One of the GSPLATDATA_* constants. Defaults to {@link GSPLATDATA_COMPACT}.

--- a/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-hybrid-renderer.js
@@ -191,6 +191,7 @@ class GSplatHybridRenderer extends GSplatRenderer {
         this._internalDefines.add('PICK_CUSTOM_ID');
         this._internalDefines.add('GSPLAT_OVERDRAW');
         this._internalDefines.add('GSPLAT_NO_FOG');
+        this._internalDefines.add('GSPLAT_NO_TONEMAP');
         this._internalDefines.add('GSPLAT_XR');
 
         // GPU sort pipeline resources (gpuSorter, projector, intervalCompaction) are created lazily
@@ -766,9 +767,12 @@ class GSplatHybridRenderer extends GSplatRenderer {
         }
 
         const noFog = !params.useFog;
-        if (noFog !== this._lastNoFog) {
+        const noTonemap = !params.useTonemap;
+        if (noFog !== this._lastNoFog || noTonemap !== this._lastNoTonemap) {
             this._lastNoFog = noFog;
+            this._lastNoTonemap = noTonemap;
             this._material.setDefine('GSPLAT_NO_FOG', noFog);
+            this._material.setDefine('GSPLAT_NO_TONEMAP', noTonemap);
             this._material.update();
         }
 

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -754,8 +754,7 @@ class GSplatManager {
         // Renderer per-frame update (material syncing, deferred setup). Must run after
         // fireFrameReadyEvent(): listeners may change material state (e.g. antiAlias), and
         // syncing here applies it this same frame before frameEnd() clears the dirty flag.
-        const fogParams = this.scene.gsplat.useFog ? (this.cameraNode.camera.fogParams ?? this.scene.fog) : null;
-        this.renderer.frameUpdate(this.scene.gsplat, this.scene.exposure, fogParams);
+        this.renderer.frameUpdate(this.scene.gsplat);
 
         // return the number of active splats for stats
         const sortedState = this.world.getState(this.world.currentVersion);

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -535,6 +535,14 @@ class GSplatParams {
      */
     useFog = true;
 
+    /**
+     * Whether to apply the camera's tonemapping and the scene exposure to Gaussian splats. When
+     * false, splats render with their stored colors, unaffected by {@link Scene#exposure} and the
+     * camera's {@link CameraComponent#toneMapping}. Fog, when enabled, still applies. Defaults to
+     * true.
+     */
+    useTonemap = true;
+
     /** @deprecated Use {@link debug} with {@link GSPLAT_DEBUG_SH_UPDATE} instead. */
     set colorizeColorUpdate(value) {
         Debug.deprecated('GSplatParams#colorizeColorUpdate is deprecated. Use GSplatParams#debug = GSPLAT_DEBUG_SH_UPDATE instead.');
@@ -975,6 +983,7 @@ class GSplatParams {
 
         this.antiAlias = render.gsplatAntiAlias ?? this.antiAlias;
         this.useFog = render.gsplatUseFog ?? this.useFog;
+        this.useTonemap = render.gsplatUseTonemap ?? this.useTonemap;
         this.colorUpdateAngle = render.gsplatColorUpdateAngle ?? this.colorUpdateAngle;
         this.cooldownTicks = render.gsplatCooldownTicks ?? this.cooldownTicks;
         this.dataFormat = render.gsplatDataFormat ?? this.dataFormat;

--- a/src/scene/gsplat-unified/gsplat-quad-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-quad-renderer.js
@@ -80,6 +80,9 @@ class GSplatQuadRenderer extends GSplatRenderer {
         this._internalDefines.add('GSPLAT_INDIRECT_DRAW');
         this._internalDefines.add('GSPLAT_SEPARATE_OPACITY');
         this._internalDefines.add('GSPLAT_FISHEYE');
+        this._internalDefines.add('GSPLAT_NO_FOG');
+        this._internalDefines.add('GSPLAT_NO_TONEMAP');
+        this._internalDefines.add('GSPLAT_OVERDRAW');
 
         this.meshInstance = this.createMeshInstance();
     }
@@ -315,9 +318,12 @@ class GSplatQuadRenderer extends GSplatRenderer {
         }
 
         const noFog = !params.useFog;
-        if (noFog !== this._lastNoFog) {
+        const noTonemap = !params.useTonemap;
+        if (noFog !== this._lastNoFog || noTonemap !== this._lastNoTonemap) {
             this._lastNoFog = noFog;
+            this._lastNoTonemap = noTonemap;
             this._material.setDefine('GSPLAT_NO_FOG', noFog);
+            this._material.setDefine('GSPLAT_NO_TONEMAP', noTonemap);
             this._material.update();
         }
 

--- a/src/scene/gsplat-unified/gsplat-renderer.js
+++ b/src/scene/gsplat-unified/gsplat-renderer.js
@@ -12,7 +12,6 @@ import { FisheyeProjection } from '../graphics/fisheye-projection.js';
  * @import { GSplatWorldState } from './gsplat-world-state.js'
  * @import { GSplatVaryings } from './gsplat-varyings.js'
  * @import { MeshInstance } from '../mesh-instance.js'
- * @import { FogParams } from '../fog-params.js'
  */
 
 /**
@@ -224,10 +223,8 @@ class GSplatRenderer {
      * Per-frame update for the renderer (material syncing, parameter updates).
      *
      * @param {object} params - The gsplat parameters.
-     * @param {number} [exposure] - Scene exposure value.
-     * @param {FogParams} [fogParams] - Fog parameters.
      */
-    frameUpdate(params, exposure, fogParams) {
+    frameUpdate(params) {
     }
 
     /**

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatOutput.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplatOutput.js
@@ -9,12 +9,16 @@ export default /* glsl */`
     #define GSPLAT_FOG
 #endif
 
+#if TONEMAP != NONE && !defined(GSPLAT_NO_TONEMAP)
+    #define GSPLAT_TONEMAP
+#endif
+
 // prepare the output color for the given gamma-space color
 vec3 prepareOutputFromGamma(vec3 gammaColor, float depth) {
     vec3 color = gammaColor;
 
     // decode to linear when we need linear-space processing
-    #if TONEMAP != NONE || GAMMA == NONE || defined(GSPLAT_FOG)
+    #if defined(GSPLAT_TONEMAP) || GAMMA == NONE || defined(GSPLAT_FOG)
         color = decodeGamma(color);
     #endif
 
@@ -24,12 +28,12 @@ vec3 prepareOutputFromGamma(vec3 gammaColor, float depth) {
     #endif
 
     // apply tonemapping
-    #if TONEMAP != NONE
+    #ifdef GSPLAT_TONEMAP
         color = toneMap(color);
     #endif
 
     // encode to gamma when needed
-    #if TONEMAP != NONE || (GAMMA != NONE && defined(GSPLAT_FOG))
+    #if defined(GSPLAT_TONEMAP) || (GAMMA != NONE && defined(GSPLAT_FOG))
         color = gammaCorrectOutput(color);
     #endif
 

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatOutput.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatOutput.js
@@ -9,12 +9,16 @@ export default /* wgsl */`
     #define GSPLAT_FOG
 #endif
 
+#if TONEMAP != NONE && !defined(GSPLAT_NO_TONEMAP)
+    #define GSPLAT_TONEMAP
+#endif
+
 // prepare the output color for the given gamma-space color
 fn prepareOutputFromGamma(gammaColor: vec3f, depth: f32) -> vec3f {
     var color = gammaColor;
 
     // decode to linear when we need linear-space processing
-    #if TONEMAP != NONE || GAMMA == NONE || defined(GSPLAT_FOG)
+    #if defined(GSPLAT_TONEMAP) || GAMMA == NONE || defined(GSPLAT_FOG)
         color = decodeGamma3(color);
     #endif
 
@@ -24,12 +28,12 @@ fn prepareOutputFromGamma(gammaColor: vec3f, depth: f32) -> vec3f {
     #endif
 
     // apply tonemapping
-    #if TONEMAP != NONE
+    #ifdef GSPLAT_TONEMAP
         color = toneMap(color);
     #endif
 
     // encode to gamma when needed
-    #if TONEMAP != NONE || (GAMMA != NONE && defined(GSPLAT_FOG))
+    #if defined(GSPLAT_TONEMAP) || (GAMMA != NONE && defined(GSPLAT_FOG))
         color = gammaCorrectOutput(color);
     #endif
 


### PR DESCRIPTION
## Description

Gaussian splats are unlit, yet their colors were still run through the camera's tone curve and `Scene#exposure`, and there was no gsplat-scoped way to opt out — fog was the only thing with a switch (`scene.gsplat.useFog` / `GSPLAT_NO_FOG`). Raised in #9228: changing the scene exposure for the lit content unavoidably re-brightens the splats, and the only escape was setting the whole camera to `TONEMAP_NONE`.

This adds the symmetric flag:

- `GSplatParams#useTonemap` (default `true`), settable from scene settings as `render.gsplatUseTonemap`.
- When false, a `GSPLAT_NO_TONEMAP` define makes `gsplatOutput` (GLSL + WGSL) skip the decode → `toneMap` → encode trio, so the stored gamma-space splat color passes straight through. Fog, when enabled, still applies and is still gamma-encoded correctly, and the `GAMMA == NONE` (HDR target) branch is unaffected.

Two adjacent items in the same area:

- The quad renderer's `_internalDefines` set was missing `GSPLAT_NO_FOG` and `GSPLAT_OVERDRAW`. Because `copyMaterialSettings` deletes any non-internal define the source material doesn't have, those got dropped on every frame where `scene.gsplat.material` was dirty — while `_lastNoFog` still recorded them as applied, so they were never re-added. In other words `useFog = false` silently stopped working on the CPU-sort path after any material update. The new define would have inherited exactly that, so all three are now protected (the hybrid renderer already listed them).
- `GSplatManager` passed `exposure` and `fogParams` into `GSplatRenderer#frameUpdate()`, but neither the quad nor the hybrid implementation declares or consumes them. Both arguments (and the local computed only for them) are removed, along with the now-unused `FogParams` typedef import.

## Notes for reviewers

Verified in the examples browser on `gaussian-splatting/simple` (which uses `TONEMAP_ACES`), on both backends:

- WebGL2 / quad renderer (GLSL): at `scene.exposure = 3` the splat brightens along with the lit ground; `useTonemap = false` returns the splat to its stored colors while the ground stays bright; the define appears on and clears from the render material across the round trip. Linear fog with tonemap off renders correctly (the `GSPLAT_FOG && !GSPLAT_TONEMAP` branch).
- WebGPU / hybrid renderer (WGSL, `GSPLAT_RENDERER_RASTER_GPU_SORT`): same toggle, no shader compile errors.

`npm run lint` clean, `npm test` 2436 passing. No unit test added — the unified renderer path has no test scaffolding today (`useFog` shipped the same way).

Docs for `scene.gsplat.useTonemap` on the developer site will follow, gated on 2.22. Note that #9228 may instead be asking about the `lod-meta.json` `environment` splat, which is still loaded and rendered unconditionally with no API to disable it — not addressed here.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change