### PR TITLE
Fix SOG parsers throwing when a load completes after app teardown

### DIFF
--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -157,7 +157,13 @@ class SogBundleParser {
     }
 
     /**
-     * Checks if loading should be aborted due to asset unload or invalid device.
+     * Checks if loading should be aborted due to asset unload, app teardown or invalid device.
+     *
+     * Nothing cancels an in-flight request, so any of these callbacks can run after
+     * {@link AppBase#destroy}. That tears down in a fixed order - the asset registry is dropped
+     * before the graphics device is marked destroyed - so a callback can arrive while `app.assets`
+     * is already null and the device still looks alive. Every access here has to tolerate that,
+     * hence the optional chaining on the registry rather than only on the device.
      *
      * @param {Asset} asset - The asset being loaded.
      * @param {boolean} unloaded - Whether the asset was unloaded during async loading.
@@ -165,9 +171,9 @@ class SogBundleParser {
      * @private
      */
     _shouldAbort(asset, unloaded) {
-        if (unloaded || !this.app.assets.get(asset.id)) return true;
+        if (unloaded) return true;
         if (!this.app?.graphicsDevice || this.app.graphicsDevice._destroyed) return true;
-        return false;
+        return !this.app.assets?.get(asset.id);
     }
 
     /**

--- a/src/framework/parsers/sog.js
+++ b/src/framework/parsers/sog.js
@@ -105,7 +105,13 @@ class SogParser {
     }
 
     /**
-     * Checks if loading should be aborted due to asset unload or invalid device.
+     * Checks if loading should be aborted due to asset unload, app teardown or invalid device.
+     *
+     * Nothing cancels an in-flight request, so any of these callbacks can run after
+     * {@link AppBase#destroy}. That tears down in a fixed order - the asset registry is dropped
+     * before the graphics device is marked destroyed - so a callback can arrive while `app.assets`
+     * is already null and the device still looks alive. Every access here has to tolerate that,
+     * hence the optional chaining on the registry rather than only on the device.
      *
      * @param {Asset} asset - The asset being loaded.
      * @param {boolean} unloaded - Whether the asset was unloaded during async loading.
@@ -113,9 +119,9 @@ class SogParser {
      * @private
      */
     _shouldAbort(asset, unloaded) {
-        if (unloaded || !this.app.assets.get(asset.id)) return true;
+        if (unloaded) return true;
         if (!this.app?.graphicsDevice || this.app.graphicsDevice._destroyed) return true;
-        return false;
+        return !this.app.assets?.get(asset.id);
     }
 
     async loadTextures(url, callback, asset, meta) {

--- a/test/framework/parsers/sog.test.mjs
+++ b/test/framework/parsers/sog.test.mjs
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { restore, stub } from 'sinon';
 
 import { Asset } from '../../../src/framework/asset/asset.js';
+import { SogBundleParser } from '../../../src/framework/parsers/sog-bundle.js';
 import { SogParser } from '../../../src/framework/parsers/sog.js';
 import { http } from '../../../src/platform/net/http.js';
 import { createApp } from '../../app.mjs';
@@ -86,5 +87,57 @@ describe('SogParser', function () {
             ]);
             done();
         }, sog);
+    });
+
+    // Nothing cancels an in-flight request, so a load callback can run after app.destroy(). That
+    // drops the asset registry before it marks the graphics device destroyed, leaving a window where
+    // app.assets is null while the device still looks alive - which used to throw out of
+    // _shouldAbort rather than aborting the load.
+    describe('#_shouldAbort', function () {
+
+        const parsers = () => [new SogParser(app), new SogBundleParser(app)];
+
+        it('does not abort while the asset is registered and the device is alive', function () {
+            const asset = new Asset('sog', 'gsplat', { url: META_URL });
+            app.assets.add(asset);
+
+            for (const parser of parsers()) {
+                expect(parser._shouldAbort(asset, false)).to.equal(false);
+                expect(parser._shouldAbort(asset, true)).to.equal(true, 'unloaded wins');
+            }
+        });
+
+        it('aborts rather than throwing once the app has dropped its asset registry', function () {
+            const asset = new Asset('sog', 'gsplat', { url: META_URL });
+            const device = app.graphicsDevice;
+
+            for (const parser of parsers()) {
+                // app.destroy() nulls assets before it destroys the device, so this state is real
+                parser.app = { assets: null, graphicsDevice: device };
+                expect(() => parser._shouldAbort(asset, false)).to.not.throw();
+                expect(parser._shouldAbort(asset, false)).to.equal(true);
+            }
+        });
+
+        it('aborts when the graphics device is gone or destroyed', function () {
+            const asset = new Asset('sog', 'gsplat', { url: META_URL });
+            app.assets.add(asset);
+
+            for (const parser of parsers()) {
+                parser.app = { assets: app.assets, graphicsDevice: { _destroyed: true } };
+                expect(parser._shouldAbort(asset, false)).to.equal(true);
+
+                parser.app = { assets: app.assets, graphicsDevice: null };
+                expect(parser._shouldAbort(asset, false)).to.equal(true);
+            }
+        });
+
+        it('aborts when the asset is no longer registered', function () {
+            const asset = new Asset('sog', 'gsplat', { url: META_URL });
+
+            for (const parser of parsers()) {
+                expect(parser._shouldAbort(asset, false)).to.equal(true);
+            }
+        });
     });
 });


### PR DESCRIPTION
Loading a streamed SOG scene and destroying the app while requests are still in flight throws out of the parser instead of aborting the load cleanly:

```
Uncaught TypeError: Cannot read properties of null (reading 'get')
    at SogParser._shouldAbort (sog.js:116)
    at Object.callback (sog.js:295)
    at Http._onSuccess (http.js:615)
```

Nothing cancels an in-flight request — `ResourceLoader#destroy` only drops its bookkeeping and `Http` has no abort — so any of these callbacks can run after `AppBase#destroy`. Teardown happens in a fixed order: the asset registry is dropped (`this.assets = null`) before the graphics device is marked destroyed. That leaves a window where `app.assets` is null while `app.graphicsDevice._destroyed` is still false.

`_shouldAbort` dereferenced the registry in its first condition, before reaching the device check that is already written defensively:

```js
if (unloaded || !this.app.assets.get(asset.id)) return true;               // throws
if (!this.app?.graphicsDevice || this.app.graphicsDevice._destroyed) return true;
```

Checking the device first is not sufficient on its own, since the registry is nulled earlier than the device is flagged, so the registry access is optional-chained too. The result no longer depends on the order teardown happens in.

Most likely to be hit by streamed LOD scenes, which keep many chunk requests in flight continuously, so almost any teardown — navigation, iframe reload, HMR — lands a callback afterwards.

**Changes:**
- `SogParser#_shouldAbort` and `SogBundleParser#_shouldAbort` (both `@private`) check the graphics device before the asset registry, and tolerate the registry already being gone
- Unit tests covering all four abort conditions for both parsers, including the post-teardown state that reproduced the crash