### PR TITLE
DrawCommands optimization

### DIFF
--- a/src/platform/graphics/draw-commands.js
+++ b/src/platform/graphics/draw-commands.js
@@ -148,7 +148,7 @@ class DrawCommands {
      */
     update(count) {
         this._count = count;
-        this.primitiveCount = this.impl.update?.(count) ?? 0;
+        this.primitiveCount = this.impl.update(count);
 
         // For indirect draws, the CPU cannot inspect the instance counts,
         // so we treat the draw count as the hasDraws flag.
@@ -157,7 +157,7 @@ class DrawCommands {
             return;
         }
 
-        this.hasDraws = this.impl.hasDraws ?? (count > 0);
+        this.hasDraws = this.impl.hasDraws;
     }
 }
 

--- a/src/platform/graphics/draw-commands.js
+++ b/src/platform/graphics/draw-commands.js
@@ -66,11 +66,21 @@ class DrawCommands {
     }
 
     /**
-     * Slot index of the first indirect draw call. Ignored for multi-draw commands.
+     * First indirect slot, or `-1` for multi-draw.
      *
      * @ignore
      */
-    slotIndex = 0;
+    slotIndex = -1;
+
+    /**
+     * True if this container is bound to GPU-driven indirect slots.
+     *
+     * @type {boolean}
+     * @ignore
+     */
+    get isIndirect() {
+        return this.slotIndex >= 0;
+    }
 
     /**
      * Total number of primitives across all sub-draws (pre-calculated).
@@ -78,6 +88,14 @@ class DrawCommands {
      * @ignore
      */
     primitiveCount = 0;
+
+    /**
+     * True if any sub-draw has index/vertex count > 0 and instance count > 0.
+     * For indirect draws (`isIndirect`), true when {@link count} > 0.
+     *
+     * @type {boolean}
+     */
+    hasDraws = false;
 
     /**
      * @param {import('./graphics-device.js').GraphicsDevice} device - The graphics device.
@@ -104,6 +122,7 @@ class DrawCommands {
      */
     allocate(maxCount) {
         this._maxCount = maxCount;
+        this.slotIndex = -1;
         this.impl.allocate?.(maxCount);
     }
 
@@ -123,13 +142,22 @@ class DrawCommands {
     }
 
     /**
-     * Finalize and set draw count after all commands have been added.
+     * Sets the draw count and {@link hasDraws}.
      *
      * @param {number} count - Number of draws to execute.
      */
     update(count) {
         this._count = count;
         this.primitiveCount = this.impl.update?.(count) ?? 0;
+
+        // For indirect draws, the CPU cannot inspect the instance counts,
+        // so we treat the draw count as the hasDraws flag.
+        if (this.isIndirect) {
+            this.hasDraws = count > 0;
+            return;
+        }
+
+        this.hasDraws = this.impl.hasDraws ?? (count > 0);
     }
 }
 

--- a/src/platform/graphics/null/null-draw-commands.js
+++ b/src/platform/graphics/null/null-draw-commands.js
@@ -7,9 +7,21 @@ class NullDrawCommands {
     /** @type {boolean} */
     hasDraws = false;
 
+    /**
+     * Write a single draw entry.
+     * @param {number} i - Draw index.
+     * @param {number} indexOrVertexCount - Count of indices/vertices.
+     * @param {number} instanceCount - Instance count.
+     * @param {number} firstIndexOrVertex - First index/vertex.
+     */
     add(i, indexOrVertexCount, instanceCount, firstIndexOrVertex) {
     }
 
+    /**
+     * Sets {@link hasDraws} and calculate total primitives for stats (profiler builds only).
+     * @param {number} count - Number of active draws.
+     * @returns {number} Total primitive count.
+     */
     update(count) {
         this.hasDraws = count > 0;
         return 0;

--- a/src/platform/graphics/null/null-draw-commands.js
+++ b/src/platform/graphics/null/null-draw-commands.js
@@ -23,7 +23,7 @@ class NullDrawCommands {
      * @returns {number} Total primitive count.
      */
     update(count) {
-        this.hasDraws = count > 0;
+        this.hasDraws = false;
         return 0;
     }
 }

--- a/src/platform/graphics/null/null-draw-commands.js
+++ b/src/platform/graphics/null/null-draw-commands.js
@@ -4,7 +4,15 @@
  * @ignore
  */
 class NullDrawCommands {
+    /** @type {boolean} */
+    hasDraws = false;
+
     add(i, indexOrVertexCount, instanceCount, firstIndexOrVertex) {
+    }
+
+    update(count) {
+        this.hasDraws = count > 0;
+        return 0;
     }
 }
 

--- a/src/platform/graphics/webgl/webgl-draw-commands.js
+++ b/src/platform/graphics/webgl/webgl-draw-commands.js
@@ -16,6 +16,9 @@ class WebglDrawCommands {
     /** @type {Int32Array|null} */
     glInstanceCounts = null;
 
+    /** @type {boolean} */
+    hasDraws = false;
+
     /**
      * @param {number} indexSizeBytes - Size of index in bytes (1, 2 or 4). 0 for non-indexed.
      */
@@ -51,24 +54,29 @@ class WebglDrawCommands {
     }
 
     /**
-     * Calculate total primitives for stats (profiler builds only).
+     * Sets {@link hasDraws} and calculate total primitives for stats (profiler builds only).
      * @param {number} count - Number of active draws.
      * @returns {number} Total primitive count.
      */
     update(count) {
-        // calculate total primitives for stats
         let totalPrimitives = 0;
+        let hasDraws = false;
 
-        // #if _PROFILER
         if (this.glCounts && this.glInstanceCounts && count > 0) {
             for (let d = 0; d < count; d++) {
                 const indexOrVertexCount = this.glCounts[d];
                 const instanceCount = this.glInstanceCounts[d];
+                if (indexOrVertexCount > 0 && instanceCount > 0) {
+                    hasDraws = true;
+                }
+
+                // #if _PROFILER
                 totalPrimitives += indexOrVertexCount * instanceCount;
+                // #endif
             }
         }
-        // #endif
 
+        this.hasDraws = hasDraws;
         return totalPrimitives;
     }
 }

--- a/src/platform/graphics/webgpu/webgpu-draw-commands.js
+++ b/src/platform/graphics/webgpu/webgpu-draw-commands.js
@@ -27,6 +27,13 @@ class WebgpuDrawCommands {
     storage = null;
 
     /**
+     * True if any of the first `count` draws have work.
+     *
+     * @type {boolean}
+     */
+    hasDraws = false;
+
+    /**
      * @param {GraphicsDevice} device - Graphics device.
      */
     constructor(device) {
@@ -68,30 +75,36 @@ class WebgpuDrawCommands {
     }
 
     /**
-     * Upload AoS data to storage buffer.
+     * Upload AoS data to storage buffer, sets {@link hasDraws}.
+     *
      * @param {number} count - Number of active draws.
      * @returns {number} Total primitive count.
      */
     update(count) {
-        if (this.storage && count > 0) {
-            const used = count * 5; // 5 uints per draw
-            this.storage.write(0, this.gpuIndirect, 0, used);
-        }
-
-        // calculate total primitives for stats
         let totalPrimitives = 0;
+        let hasDraws = false;
 
-        // #if _PROFILER
         if (this.gpuIndirect && count > 0) {
+
+            if (this.storage) {
+                const used = count * 5; // 5 uints per draw
+                this.storage.write(0, this.gpuIndirect, 0, used);
+            }
+
             for (let d = 0; d < count; d++) {
                 const offset = d * 5;
                 const indexOrVertexCount = this.gpuIndirect[offset + 0];
                 const instanceCount = this.gpuIndirect[offset + 1];
+                if (indexOrVertexCount > 0 && instanceCount > 0) {
+                    hasDraws = true;
+                }
+                // #if _PROFILER
                 totalPrimitives += indexOrVertexCount * instanceCount;
+                // #endif
             }
         }
-        // #endif
 
+        this.hasDraws = hasDraws;
         return totalPrimitives;
     }
 

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -956,15 +956,16 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             }
 
             // draw
-            if (drawCommands) { // indirect draw path
+            if (drawCommands) { // indirect / multi-draw path
 
+                const baseSlot = drawCommands.isIndirect ? drawCommands.slotIndex : 0;
                 const storage = drawCommands.impl?.storage ?? this.indirectDrawBuffer;
                 const indirectBuffer = storage.impl.buffer;
                 const drawsCount = drawCommands.count;
 
                 // TODO: when multiDrawIndirect is supported, we can use it here instead of a loop
                 for (let d = 0; d < drawsCount; d++) {
-                    const indirectOffset = (drawCommands.slotIndex + d) * _indirectEntryByteSize;
+                    const indirectOffset = (baseSlot + d) * _indirectEntryByteSize;
                     if (indexBuffer) {
                         passEncoder.drawIndexedIndirect(indirectBuffer, indirectOffset);
                     } else {

--- a/src/scene/mesh-instance.js
+++ b/src/scene/mesh-instance.js
@@ -236,10 +236,10 @@ class ShaderInstance {
  * ### Precedence
  *
  * When draw commands (indirect or multi-draw, see {@link setIndirect} and {@link setMultiDraw})
- * are bound, they are the source of truth for rendering: the number of draws and the per-draw
- * instance counts come from the draw commands, and {@link instancingCount} is ignored. In this
- * case setting {@link instancingCount} to 0 does not skip rendering. {@link instancingCount} only
- * takes effect for plain hardware instancing, when no draw commands are bound.
+ * are bound, they are the source of truth: draw count and per-draw instance counts come from
+ * the commands, and {@link instancingCount} is ignored. Rendering is skipped when
+ * {@link DrawCommands#hasDraws} is false. {@link instancingCount} only gates plain hardware
+ * instancing when no draw commands are bound.
  *
  * @category Graphics
  */

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -572,8 +572,12 @@ class ForwardRenderer extends Renderer {
             // Skip hardware-instanced rendering with 0 instances. When draw commands (indirect /
             // multi-draw) are bound, they are the source of truth for the number of draws and
             // per-draw instance counts, so instancingData.count must not gate the draw.
+            const drawCommands = drawCall.getDrawCommands(camera);
+            if (drawCommands && !drawCommands.hasDraws) {
+                continue;
+            }
             const instancingData = drawCall.instancingData;
-            if (instancingData && instancingData.count <= 0 && !drawCall.getDrawCommands(camera)) {
+            if (instancingData && instancingData.count <= 0) {
                 continue;
             }
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -572,12 +572,16 @@ class ForwardRenderer extends Renderer {
             // Skip hardware-instanced rendering with 0 instances. When draw commands (indirect /
             // multi-draw) are bound, they are the source of truth for the number of draws and
             // per-draw instance counts, so instancingData.count must not gate the draw.
-            const instancingData = drawCall.instancingData;
             const drawCommands = drawCall.getDrawCommands(camera);
-
-            if (instancingData && instancingData.count <= 0 &&
-                (!drawCommands || !drawCommands.hasDraws)) {
-                continue;
+            if (!drawCommands) {
+                const instancingData = drawCall.instancingData;
+                if (instancingData && instancingData.count <= 0) {
+                    continue;
+                }
+            } else {
+                if (!drawCommands.hasDraws) {
+                    continue;
+                }
             }
 
             drawCall.ensureMaterial(device);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -572,12 +572,11 @@ class ForwardRenderer extends Renderer {
             // Skip hardware-instanced rendering with 0 instances. When draw commands (indirect /
             // multi-draw) are bound, they are the source of truth for the number of draws and
             // per-draw instance counts, so instancingData.count must not gate the draw.
-            const drawCommands = drawCall.getDrawCommands(camera);
-            if (drawCommands && !drawCommands.hasDraws) {
-                continue;
-            }
             const instancingData = drawCall.instancingData;
-            if (instancingData && instancingData.count <= 0) {
+            const drawCommands = drawCall.getDrawCommands(camera);
+
+            if (instancingData && instancingData.count <= 0 &&
+                (!drawCommands || !drawCommands.hasDraws)) {
                 continue;
             }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -549,8 +549,12 @@ class ShadowRenderer {
             // Skip hardware-instanced rendering with 0 instances. When draw commands (indirect /
             // multi-draw) are bound, they are the source of truth for the number of draws and
             // per-draw instance counts, so instancingData.count must not gate the draw.
+            const drawCommands = meshInstance.getDrawCommands(camera);
+            if (drawCommands && !drawCommands.hasDraws) {
+                continue;
+            }
             const instancingData = meshInstance.instancingData;
-            if (instancingData && instancingData.count <= 0 && !meshInstance.getDrawCommands(camera)) {
+            if (instancingData && instancingData.count <= 0) {
                 continue;
             }
 
@@ -599,8 +603,7 @@ class ShadowRenderer {
 
             // draw
             const style = meshInstance.renderStyle;
-            const indirectData = meshInstance.getDrawCommands(camera);
-            device.draw(mesh.primitive[style], mesh.indexBuffer[style], instancingData?.count, indirectData);
+            device.draw(mesh.primitive[style], mesh.indexBuffer[style], instancingData?.count, drawCommands);
 
             renderer._shadowDrawCalls++;
             if (instancingData) {

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -545,16 +545,14 @@ class ShadowRenderer {
         for (let i = 0; i < count; i++) {
             const meshInstance = visibleCasters[i];
             const mesh = meshInstance.mesh;
+            const instancingData = meshInstance.instancingData;
+            const drawCommands = meshInstance.getDrawCommands(camera);
 
             // Skip hardware-instanced rendering with 0 instances. When draw commands (indirect /
             // multi-draw) are bound, they are the source of truth for the number of draws and
             // per-draw instance counts, so instancingData.count must not gate the draw.
-            const drawCommands = meshInstance.getDrawCommands(camera);
-            if (drawCommands && !drawCommands.hasDraws) {
-                continue;
-            }
-            const instancingData = meshInstance.instancingData;
-            if (instancingData && instancingData.count <= 0) {
+            if (instancingData && instancingData.count <= 0 &&
+                (!drawCommands || !drawCommands.hasDraws)) {
                 continue;
             }
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -551,9 +551,14 @@ class ShadowRenderer {
             // Skip hardware-instanced rendering with 0 instances. When draw commands (indirect /
             // multi-draw) are bound, they are the source of truth for the number of draws and
             // per-draw instance counts, so instancingData.count must not gate the draw.
-            if (instancingData && instancingData.count <= 0 &&
-                (!drawCommands || !drawCommands.hasDraws)) {
-                continue;
+            if (!drawCommands) {
+                if (instancingData && instancingData.count <= 0) {
+                    continue;
+                }
+            } else {
+                if (!drawCommands.hasDraws) {
+                    continue;
+                }
             }
 
             meshInstance.ensureMaterial(device);


### PR DESCRIPTION
## Skip empty multi-draw / keep GPU-driven indirect draws

Forward and shadow rendering no longer submit a mesh instance when its bound `DrawCommands` have no useful sub-draws. GPU-driven indirect draws (`MeshInstance#setIndirect`) are still issued when the slot count is > 0, because the CPU cannot inspect GPU-written instance counts.

- `DrawCommands#update` now computes `hasDraws`: a sub-draw counts if both index/vertex count and instance count are > 0
- Forward and shadow renderers skip the mesh when `hasDraws` is false (avoids material/shader setup and the draw)
- Indirect vs multi-draw is distinguished by `slotIndex`: `-1` is multi-draw (`0` is a valid indirect slot). `allocate()` resets `slotIndex` to `-1`; `setIndirect` assigns a real slot (`>= 0`)
- WebGPU `draw` uses `slotIndex` only for the indirect path; multi-draw still starts at base slot 0

## Public API

`DrawCommands#hasDraws` — `true` if any CPU-side sub-draw has work. For indirect draws (`slotIndex >= 0`), `true` when `count > 0`.

```javascript
const cmd = meshInstance.setMultiDraw(null, n);
cmd.add(0, indexCount, instanceCount, firstIndex);
cmd.update(write); // hasDraws is false when write === 0 or all instance/index counts are 0
```

Indirect usage is unchanged:

```javascript
meshInstance.setIndirect(null, slot, count); // hasDraws === count > 0
```

## Performance

Empty multi-draw lists (`update(0)` or all-zero instance/index counts) skip the whole draw path: no shader bind, no uniform setup, no multi-draw / indirect API call.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change