### PR TITLE
Use the owning application for application stats

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -560,7 +560,7 @@ class AppBase extends EventHandler {
 
         this._initDefaultMaterial();
         this._initProgramLibrary();
-        this.stats = new ApplicationStats(graphicsDevice);
+        this.stats = new ApplicationStats(this);
 
         this._soundManager = soundManager;
         this.scene = new Scene(graphicsDevice);

--- a/src/framework/stats.js
+++ b/src/framework/stats.js
@@ -1,7 +1,7 @@
 import { PRIMITIVE_TRIANGLES, PRIMITIVE_TRIFAN, PRIMITIVE_TRISTRIP } from '../platform/graphics/constants.js';
-import { getApplication } from './globals.js';
 
 /**
+ * @import { AppBase } from './app-base.js'
  * @import { ForwardRenderer } from '../scene/renderer/forward-renderer.js'
  * @import { GraphicsDevice } from '../platform/graphics/graphics-device.js'
  */
@@ -11,11 +11,20 @@ import { getApplication } from './globals.js';
  */
 class ApplicationStats {
     /**
+     * @type {AppBase}
+     * @private
+     */
+    _app;
+
+    /**
      * Create a new ApplicationStats instance.
      *
-     * @param {GraphicsDevice} device - The graphics device.
+     * @param {AppBase} app - The application.
      */
-    constructor(device) {
+    constructor(app) {
+        this._app = app;
+
+        const device = app.graphicsDevice;
         this.frame = {
             fps: 0,
             ms: 0,
@@ -109,15 +118,15 @@ class ApplicationStats {
     }
 
     get scene() {
-        return getApplication().scene._stats;
+        return this._app.scene._stats;
     }
 
     get lightmapper() {
-        return getApplication().lightmapper?.stats;
+        return this._app.lightmapper?.stats;
     }
 
     get batcher() {
-        const batcher = getApplication()._batcher;
+        const batcher = this._app._batcher;
         return batcher ? batcher._stats : null;
     }
 

--- a/test/framework/application.test.mjs
+++ b/test/framework/application.test.mjs
@@ -64,6 +64,22 @@ describe('Application', function () {
 
     });
 
+    describe('#stats', function () {
+
+        it('returns stats for the owning application when multiple applications exist', function () {
+            const app2 = createApp();
+
+            try {
+                expect(app.stats.scene).to.equal(app.scene._stats);
+                expect(app.stats.lightmapper).to.equal(app.lightmapper.stats);
+                expect(app.stats.batcher).to.equal(app.batcher._stats);
+            } finally {
+                app2.destroy();
+            }
+        });
+
+    });
+
     describe('#destroy', function () {
 
         it('destroys the application', function () {


### PR DESCRIPTION
Ensure an application's stats always resolve from that application rather than whichever application is globally current.

**Changes:**
- Store the owning AppBase on ApplicationStats and use it for scene, lightmapper and batcher statistics.
- Add multi-application regression coverage.