### PR TITLE
Use asset registry app for GLB cameras and lights

### DIFF
--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -953,7 +953,7 @@ const createNode = (gltfNode, nodeIndex, nodeInstancingMap) => {
 };
 
 // creates a camera component on the supplied node, and returns it
-const createCamera = (gltfCamera, node) => {
+const createCamera = (gltfCamera, node, app) => {
     const isOrthographic = gltfCamera.type === 'orthographic';
     const gltfProperties = isOrthographic ? gltfCamera.orthographic : gltfCamera.perspective;
 
@@ -985,7 +985,7 @@ const createCamera = (gltfCamera, node) => {
         }
     }
 
-    const cameraEntity = new Entity(gltfCamera.name);
+    const cameraEntity = new Entity(gltfCamera.name, app);
     cameraEntity.addComponent('camera', componentData);
     return cameraEntity;
 };
@@ -1185,14 +1185,14 @@ const createScenes = (gltf, nodes) => {
     return scenes;
 };
 
-const createCameras = (gltf, nodes, options) => {
+const createCameras = (gltf, nodes, options, app) => {
 
     let cameras = null;
 
     if (gltf.hasOwnProperty('nodes') && gltf.hasOwnProperty('cameras') && gltf.cameras.length > 0) {
 
         const preprocess = options?.camera?.preprocess;
-        const process = options?.camera?.process ?? createCamera;
+        const process = options?.camera?.process;
         const postprocess = options?.camera?.postprocess;
 
         gltf.nodes.forEach((gltfNode, nodeIndex) => {
@@ -1202,7 +1202,9 @@ const createCameras = (gltf, nodes, options) => {
                     if (preprocess) {
                         preprocess(gltfCamera);
                     }
-                    const camera = process(gltfCamera, nodes[nodeIndex]);
+                    const camera = process ?
+                        process(gltfCamera, nodes[nodeIndex]) :
+                        createCamera(gltfCamera, nodes[nodeIndex], app);
                     if (postprocess) {
                         postprocess(gltfCamera, camera);
                     }
@@ -1233,7 +1235,7 @@ const linkSkins = (gltf, renders, skins) => {
 };
 
 // create engine resources from the downloaded GLB data
-const createResources = async (device, gltf, bufferViews, textures, options) => {
+const createResources = async (device, gltf, bufferViews, textures, options, app) => {
     const preprocess = options?.global?.preprocess;
     const postprocess = options?.global?.postprocess;
 
@@ -1254,8 +1256,8 @@ const createResources = async (device, gltf, bufferViews, textures, options) => 
     const nodeInstancingMap = new Map();
     const nodes = createNodes(gltf, options, nodeInstancingMap);
     const scenes = createScenes(gltf, nodes);
-    const lights = createLights(gltf, nodes, options);
-    const cameras = createCameras(gltf, nodes, options);
+    const lights = createLights(gltf, nodes, options, app);
+    const cameras = createCameras(gltf, nodes, options, app);
     const variants = createVariants(gltf);
 
     // buffer data must have finished loading in order to create meshes and animations
@@ -1844,7 +1846,7 @@ class GlbParser {
                 const images = createImages(gltf, bufferViews, urlBase, registry, options);
                 const textures = createTextures(gltf, images, options);
 
-                createResources(device, gltf, bufferViews, textures, options)
+                createResources(device, gltf, bufferViews, textures, options, registry.loader._app)
                 .then(result => callback(null, result))
                 .catch(err => callback(err));
             });

--- a/src/framework/parsers/glb/extensions/khr-lights-punctual.js
+++ b/src/framework/parsers/glb/extensions/khr-lights-punctual.js
@@ -7,7 +7,7 @@ import { Entity } from '../../../entity.js';
 // https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_lights_punctual
 
 // creates light component, adds it to the node and returns the created light component
-const createLight = (gltfLight, node) => {
+const createLight = (gltfLight, node, app) => {
     const lightProps = {
         enabled: false,
         type: gltfLight.type === 'point' ? 'omni' : gltfLight.type,
@@ -39,14 +39,14 @@ const createLight = (gltfLight, node) => {
 
     // Rotate to match light orientation in glTF specification
     // Note that this adds a new entity node into the hierarchy that does not exist in the gltf hierarchy
-    const lightEntity = new Entity(node.name);
+    const lightEntity = new Entity(node.name, app);
     lightEntity.rotateLocal(90, 0, 0);
 
     lightEntity.addComponent('light', lightProps);
     return lightEntity;
 };
 
-const createLights = (gltf, nodes, options) => {
+const createLights = (gltf, nodes, options, app) => {
 
     let lights = null;
 
@@ -57,7 +57,7 @@ const createLights = (gltf, nodes, options) => {
         if (gltfLights.length) {
 
             const preprocess = options?.light?.preprocess;
-            const process = options?.light?.process ?? createLight;
+            const process = options?.light?.process;
             const postprocess = options?.light?.postprocess;
 
             // handle nodes with lights
@@ -72,7 +72,9 @@ const createLights = (gltf, nodes, options) => {
                         if (preprocess) {
                             preprocess(gltfLight);
                         }
-                        const light = process(gltfLight, nodes[nodeIndex]);
+                        const light = process ?
+                            process(gltfLight, nodes[nodeIndex]) :
+                            createLight(gltfLight, nodes[nodeIndex], app);
                         if (postprocess) {
                             postprocess(gltfLight, light);
                         }

--- a/test/framework/parsers/glb-parser.test.mjs
+++ b/test/framework/parsers/glb-parser.test.mjs
@@ -57,6 +57,58 @@ describe('GlbParser', function () {
         expect(material.aoIntensity).to.equal(1);
     });
 
+    it('uses the asset registry application for cameras and lights', async function () {
+        const gltf = {
+            asset: { version: '2.0' },
+            scene: 0,
+            scenes: [{ nodes: [0, 1] }],
+            nodes: [
+                { name: 'CameraNode', camera: 0 },
+                {
+                    name: 'LightNode',
+                    extensions: {
+                        KHR_lights_punctual: { light: 0 }
+                    }
+                }
+            ],
+            cameras: [{
+                name: 'Camera',
+                type: 'perspective',
+                perspective: {
+                    yfov: Math.PI / 4,
+                    znear: 0.1,
+                    zfar: 1000
+                }
+            }],
+            extensions: {
+                KHR_lights_punctual: {
+                    lights: [{ type: 'point' }]
+                }
+            }
+        };
+        const data = new TextEncoder().encode(JSON.stringify(gltf));
+        const app2 = createApp();
+
+        try {
+            const result = await new Promise((resolve, reject) => {
+                GlbParser.parse('components.gltf', '', data, app.graphicsDevice, app.assets, {}, (err, result) => {
+                    if (err) reject(err);
+                    else resolve(result);
+                });
+            });
+
+            const cameraEntity = result.cameras.get(result.gltf.nodes[0]);
+            const lightEntity = result.lights.get(result.gltf.nodes[1]);
+
+            expect(cameraEntity._app).to.equal(app);
+            expect(cameraEntity.camera.system).to.equal(app.systems.camera);
+            expect(lightEntity._app).to.equal(app);
+            expect(lightEntity.light.system).to.equal(app.systems.light);
+        } finally {
+            app2.destroy();
+        }
+    });
+
     describe('flat shading of primitives without normals', function () {
 
         // three vertices, and indices referencing all three of them - enough to form a single


### PR DESCRIPTION
Ensure cameras and punctual lights embedded in GLB assets use the application associated with the asset registry.

**Changes:**
- Pass the registry application through GLB resource creation
- Associate default camera and light entities with the correct application
- Preserve existing custom parser callback signatures
- Add multi-application coverage for embedded cameras and lights