### PR TITLE
Hide ApplicationStats constructor from API docs

### DIFF
--- a/src/framework/stats.js
+++ b/src/framework/stats.js
@@ -20,6 +20,7 @@ class ApplicationStats {
      * Create a new ApplicationStats instance.
      *
      * @param {AppBase} app - The application.
+     * @ignore
      */
     constructor(app) {
         this._app = app;


### PR DESCRIPTION
Mark the internally constructed ApplicationStats constructor as ignored by API documentation generation.

**Changes:**
- Exclude the ApplicationStats constructor from the generated public API