### PR TITLE
Document sRGB color space for material, element and line colors

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1591,7 +1591,8 @@ class AppBase extends EventHandler {
      *
      * @param {Vec3} start - The start world space coordinate of the line.
      * @param {Vec3} end - The end world space coordinate of the line.
-     * @param {Color} [color] - The color of the line. It defaults to white if not specified.
+     * @param {Color} [color] - The color of the line, specified in sRGB color space. It defaults
+     * to white if not specified.
      * @param {boolean} [depthTest] - Specifies if the line is depth tested against the depth
      * buffer. Defaults to true.
      * @param {Layer} [layer] - The layer to render the line into. Defaults to {@link LAYERID_IMMEDIATE}.

--- a/src/framework/components/element/component.js
+++ b/src/framework/components/element/component.js
@@ -1264,8 +1264,8 @@ class ElementComponent extends Component {
 
     /**
      * Sets the color of the image for {@link ELEMENTTYPE_IMAGE} elements or the color of the text for
-     * {@link ELEMENTTYPE_TEXT} elements. Only the RGB channels are used; the alpha channel is ignored,
-     * so use {@link opacity} to control transparency.
+     * {@link ELEMENTTYPE_TEXT} elements, specified in sRGB color space. Only the RGB channels are
+     * used; the alpha channel is ignored, so use {@link opacity} to control transparency.
      *
      * @type {Color}
      */
@@ -1885,7 +1885,8 @@ class ElementComponent extends Component {
     }
 
     /**
-     * Sets the text outline effect color and opacity. Only works for {@link ELEMENTTYPE_TEXT} elements.
+     * Sets the text outline effect color and opacity, with the color specified in sRGB color space.
+     * Only works for {@link ELEMENTTYPE_TEXT} elements.
      *
      * @type {Color}
      */
@@ -1930,7 +1931,8 @@ class ElementComponent extends Component {
     }
 
     /**
-     * Sets the text shadow effect color and opacity. Only works for {@link ELEMENTTYPE_TEXT} elements.
+     * Sets the text shadow effect color and opacity, with the color specified in sRGB color space.
+     * Only works for {@link ELEMENTTYPE_TEXT} elements.
      *
      * @type {Color}
      */

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -63,10 +63,11 @@ const isBlack = (color) => {
  * Most maps can use 3 types of input values in any combination: constant ({@link Color} or number),
  * mesh vertex colors and a {@link Texture}. All enabled inputs are multiplied together.
  *
- * @property {Color} ambient The ambient color of the material. This color value is 3-component
- * (RGB), where each component is between 0 and 1.
- * @property {Color} diffuse The diffuse color of the material. This color value is 3-component
- * (RGB), where each component is between 0 and 1. Defines basic surface color (aka albedo).
+ * @property {Color} ambient The ambient color of the material, specified in sRGB color space. This
+ * color value is 3-component (RGB), where each component is between 0 and 1.
+ * @property {Color} diffuse The diffuse color of the material, specified in sRGB color space. This
+ * color value is 3-component (RGB), where each component is between 0 and 1. Defines basic surface
+ * color (aka albedo).
  * @property {Texture|null} diffuseMap The main (primary) diffuse map of the material (default is
  * null).
  * @property {number} diffuseMapUv Main (primary) diffuse map UV channel.
@@ -104,9 +105,9 @@ const isBlack = (color) => {
  * component-wise.
  *
  * Defaults to {@link DETAILMODE_MUL}.
- * @property {Color} specular The specular color of the material. This color value is 3-component
- * (RGB), where each component is between 0 and 1. Defines surface reflection/specular color.
- * Affects specular intensity and tint.
+ * @property {Color} specular The specular color of the material, specified in sRGB color space.
+ * This color value is 3-component (RGB), where each component is between 0 and 1. Defines surface
+ * reflection/specular color. Affects specular intensity and tint.
  * @property {Texture|null} specularMap The specular map of the material (default is null).
  * @property {number} specularMapUv Specular map UV channel.
  * @property {Vec2} specularMapTiling Controls the 2D tiling of the specular map.
@@ -302,12 +303,12 @@ const isBlack = (color) => {
  * "g", "b" or "a".
  * @property {boolean} thicknessVertexColor Use mesh vertex colors for thickness. If
  * thickness map is set, it will be multiplied by vertex colors.
- * @property {Color} attenuation The attenuation color for refractive materials, only used when
- * useDynamicRefraction is enabled.
+ * @property {Color} attenuation The attenuation color for refractive materials, specified in sRGB
+ * color space. Only used when useDynamicRefraction is enabled.
  * @property {number} attenuationDistance The distance defining the absorption rate of light
  * within the medium. Only used when useDynamicRefraction is enabled.
- * @property {Color} emissive The emissive color of the material. This color value is 3-component
- * (RGB), where each component is between 0 and 1.
+ * @property {Color} emissive The emissive color of the material, specified in sRGB color space.
+ * This color value is 3-component (RGB), where each component is between 0 and 1.
  * @property {Texture|null} emissiveMap The emissive map of the material (default is null). Can be
  * HDR. When the emissive map is applied, the emissive color is multiplied by the texel color in the
  * map. Since the emissive color is black by default, the emissive map won't be visible unless the
@@ -326,8 +327,9 @@ const isBlack = (color) => {
  * @property {string} emissiveVertexColorChannel Vertex color channels to use for emission. Can be
  * "r", "g", "b", "a", "rgb" or any swizzled combination.
  * @property {boolean} useSheen Toggle sheen specular effect on/off.
- * @property {Color} sheen The specular color of the sheen (fabric) microfiber structure.
- * This color value is 3-component (RGB), where each component is between 0 and 1.
+ * @property {Color} sheen The specular color of the sheen (fabric) microfiber structure, specified
+ * in sRGB color space. This color value is 3-component (RGB), where each component is between 0
+ * and 1.
  * @property {Texture|null} sheenMap The sheen microstructure color map of the material (default is
  * null).
  * @property {number} sheenMapUv Sheen map UV channel.


### PR DESCRIPTION
Colors passed into the public API are sRGB-encoded and converted to linear at upload time, but almost none of the properties said so. `StandardMaterial`'s six colors all share one upload path that makes this explicit internally:

```js
// standard-material.js, _defineColor
// uniforms are always in linear space
_tempColor.linear(color);
```

The glTF importer corroborates it by calling `.gamma()` on `baseColorFactor`, `emissiveFactor` and the sheen / specular / volume / spec-gloss extension factors, and the exporter calls `.linear()` on the way back out.

The wording matches what `FogParams#color`, `Scene#ambientLight` and `LightComponent#color` already use, so nothing new is invented here — it is just applied consistently.

**Changes:**
- `StandardMaterial`: document `ambient`, `diffuse`, `specular`, `emissive`, `sheen` and `attenuation` as sRGB.
- `ElementComponent`: document `color`, `outlineColor` and `shadowColor` as sRGB.
- `AppBase#drawLine`: document the `color` parameter as sRGB (the immediate-mode shader calls `decodeGamma` on it).

Docs only — no behaviour change.

**Deliberately left out**, since each needs its own decision rather than a doc line:
- `SpriteComponent#color` is applied in *linear* space, unlike everything else — tracked in #9240.
- `CameraComponent#clearColor` is sRGB, but interacts with the separate fog-vs-clear tonemapping question, so it deserves more than one clause.
- `Light#color` is already documented as sRGB. Worth noting for a follow-up that `color * intensity` is not a single consistent operation across the `intensity = 1` boundary — `light.js` linearises then multiplies above 1, and multiplies then linearises below it, with a comment saying this is kept for backwards compatibility.
- `FogParams#color` and `Scene#ambientLight` were already documented.
- Particle `colorGraph` is sRGB by virtue of being baked into a `PIXELFORMAT_SRGBA8` texture, and gizmo colors via `decodeGamma` in their shader; both are more indirect and were left alone.