### PR TITLE
Register module scripts with the owning application

### DIFF
--- a/src/framework/handlers/script.js
+++ b/src/framework/handlers/script.js
@@ -153,7 +153,7 @@ class ScriptHandler extends ResourceHandler {
                     }
 
                     // Register the script name
-                    registerScript(scriptClass, scriptName);
+                    registerScript(scriptClass, scriptName, this._app);
 
                     // Store any schema associated with the script
                     if (scriptSchema) this._app.scripts.addSchema(scriptName, scriptSchema[scriptName]);

--- a/test/framework/handlers/script-handler.test.mjs
+++ b/test/framework/handlers/script-handler.test.mjs
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+
+import { AppBase } from '../../../src/framework/app-base.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+describe('ScriptHandler', function () {
+
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    it('registers module scripts with the handler application', async function () {
+        const otherApp = createApp();
+        const scriptUrl = new URL('../../../src/framework/script/script.js', import.meta.url);
+        const source = `
+            import { Script } from '${scriptUrl}';
+            export class ModuleScript extends Script {
+                static scriptName = 'moduleScript';
+            }
+            // module.mjs`;
+        const moduleUrl = `data:text/javascript,${encodeURIComponent(source)}`;
+
+        try {
+            expect(AppBase.getApplication()).to.equal(otherApp);
+
+            const scripts = await new Promise((resolve, reject) => {
+                app.loader.getHandler('script').load(moduleUrl, (err, result) => {
+                    if (err) reject(err);
+                    else resolve(result);
+                });
+            });
+
+            expect(app.scripts.get('moduleScript')).to.equal(scripts.ModuleScript);
+            expect(otherApp.scripts.has('moduleScript')).to.equal(false);
+        } finally {
+            otherApp.destroy();
+        }
+    });
+});

--- a/test/framework/handlers/script-handler.test.mjs
+++ b/test/framework/handlers/script-handler.test.mjs
@@ -22,6 +22,7 @@ describe('ScriptHandler', function () {
     it('registers module scripts with the handler application', async function () {
         const otherApp = createApp();
         const scriptUrl = new URL('../../../src/framework/script/script.js', import.meta.url);
+        // The trailing token makes the data URL end in '.mjs', selecting the ESM loader path.
         const source = `
             import { Script } from '${scriptUrl}';
             export class ModuleScript extends Script {


### PR DESCRIPTION
Ensure ESM scripts loaded by ScriptHandler register with the handler’s application instead of whichever application is globally current.

**Changes:**
- Pass the handler application to the existing registerScript call
- Add multi-application coverage for ESM script registration