### PR TITLE
Document aiming lights along a direction vector

### DIFF
--- a/src/framework/components/light/component.js
+++ b/src/framework/components/light/component.js
@@ -90,6 +90,14 @@ const _properties = [
  * // negative y-axis onto it
  * light.lookAt(target.getPosition());
  * light.rotateLocal(90, 0, 0);
+ *
+ * // to aim it along a world space direction, rotate the negative y-axis onto that direction.
+ * // Unlike lookAt, this is well defined even when the direction is straight up or down
+ * const dir = new Vec3(-0.5, -1, -0.3).normalize();
+ * light.setRotation(new Quat().setFromDirections(Vec3.DOWN, dir));
+ *
+ * // the direction a light currently shines in is the negative of its world space up vector
+ * const currentDir = light.up.clone().mulScalar(-1);
  * ```
  *
  * You should never need to use the LightComponent constructor directly. To add a LightComponent


### PR DESCRIPTION
Follow-up to #9206, which documented how directional and spot lights are aimed. It covers aiming at a *target* via `lookAt`, but not aiming along a *direction vector*, and it does not say how to read back the direction a light is currently shining in.

**Changes:**
- Add a recipe for aiming a light along a world space direction: `light.setRotation(new Quat().setFromDirections(Vec3.DOWN, dir))`. `setRotation` is world space, so this composes correctly under a rotated parent, and it matches what the renderer consumes — `forward-renderer.js` derives both directional and spot direction as `worldTransform.getY() * -1`.
- Add how to read the current direction: the negative of the entity's world space up vector.

**Why the second recipe is worth having alongside `lookAt`**

The existing `lookAt` + `rotateLocal(90, 0, 0)` recipe is silently wrong when the target sits directly above or below the light — which is the natural case for a sun aimed at something beneath it.

`GraphNode#lookAt` defaults its up vector to `Vec3.UP`, and `Mat4#setLookAt` does:

```js
z.sub2(position, target).normalize();
y.copy(up).normalize();
x.cross(y, z).normalize();
```

When the target is directly below, `z` is parallel to `up`, so `x` is the zero vector. `Vec3#normalize` leaves a zero-length vector unchanged, so `x` keeps whatever the module-level temporary held from a previous call — the resulting orientation is stale rather than `NaN`, so it fails quietly and non-deterministically rather than visibly.

`Quat#setFromDirections` handles the antiparallel case explicitly (180 degrees about an arbitrary orthogonal axis), so the direction-vector recipe has no such restriction. The comment in the snippet notes this.

Docs only — no behaviour change.

Separately, `Mat4#setLookAt` arguably ought to guard the degenerate case rather than leaving a stale basis vector, but that is a behaviour change and out of scope here.