### PR TITLE
Add heightMapBase to unify the parallax zero level across modes

### DIFF
--- a/examples/src/examples/materials/parallax-mapping.controls.jsx
+++ b/examples/src/examples/materials/parallax-mapping.controls.jsx
@@ -53,6 +53,15 @@ export function Controls({ observer }) {
                         precision={2}
                     />
                 </LabelGroup>
+                <LabelGroup text='Base'>
+                    <SliderInput
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'data.base' }}
+                        min={0.0}
+                        max={1}
+                        precision={2}
+                    />
+                </LabelGroup>
             </Panel>
             <Panel headerText='Lighting'>
                 <LabelGroup text='Spot'>

--- a/examples/src/examples/materials/parallax-mapping.example.mjs
+++ b/examples/src/examples/materials/parallax-mapping.example.mjs
@@ -264,22 +264,28 @@ data.set('data', {
     // reads as spikes when the floor is viewed from low down. This is the depth the material suits.
     height: 0.4,
 
+    // the height map value that sits at the level of the geometry - the engine default pivots the
+    // relief around mid-grey, and 1 treats the map as pure depth carved below the surface
+    base: 0.5,
+
     spot: true,
     omni: true,
     env: envIntensity
 });
 
-let mode, samples, height;
+let mode, samples, height, base;
 
 app.on('update', () => {
     const newMode = data.get('data.mode');
     const newSamples = data.get('data.samples');
     const newHeight = data.get('data.height');
+    const newBase = data.get('data.base');
 
-    if (newMode !== mode || newSamples !== samples || newHeight !== height) {
+    if (newMode !== mode || newSamples !== samples || newHeight !== height || newBase !== base) {
         mode = newMode;
         samples = newSamples;
         height = newHeight;
+        base = newBase;
 
         materials.forEach((material) => {
             material.heightMap = mode === MODE_NONE ? null : assets.height.resource;
@@ -288,6 +294,7 @@ app.on('update', () => {
             }
             material.parallaxSamples = samples;
             material.heightMapFactor = height;
+            material.heightMapBase = base;
             material.update();
         });
     }

--- a/examples/src/examples/materials/parallax-terrain.controls.jsx
+++ b/examples/src/examples/materials/parallax-terrain.controls.jsx
@@ -70,6 +70,15 @@ export function Controls({ observer }) {
                         precision={2}
                     />
                 </LabelGroup>
+                <LabelGroup text='Base'>
+                    <SliderInput
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'data.base' }}
+                        min={0.0}
+                        max={1}
+                        precision={2}
+                    />
+                </LabelGroup>
             </Panel>
             <Panel headerText='Light'>
                 <LabelGroup text='Rotation'>

--- a/examples/src/examples/materials/parallax-terrain.example.mjs
+++ b/examples/src/examples/materials/parallax-terrain.example.mjs
@@ -328,13 +328,17 @@ data.set('data', {
     samples: 16,
     selfShadowSamples: 8,
     height: 0.35,
+
+    // the height map value that sits at the level of the geometry - the engine default pivots the
+    // relief around mid-grey, and 1 treats the map as pure depth carved below the surface
+    base: 0.5,
     shadowType: SHADOW_PCF3_32F,
     numCascades: 4,
     lightRotation: 25,
     animate: true
 });
 
-let mode, samples, selfShadowSamples, height, shadowType, numCascades;
+let mode, samples, selfShadowSamples, height, base, shadowType, numCascades;
 let lightRotation, animate;
 
 // the live angle, which the animation advances and the slider follows
@@ -345,17 +349,20 @@ app.on('update', (dt) => {
     const newSamples = data.get('data.samples');
     const newSelfShadowSamples = data.get('data.selfShadowSamples');
     const newHeight = data.get('data.height');
+    const newBase = data.get('data.base');
 
     if (
         newMode !== mode ||
         newSamples !== samples ||
         newSelfShadowSamples !== selfShadowSamples ||
-        newHeight !== height
+        newHeight !== height ||
+        newBase !== base
     ) {
         mode = newMode;
         samples = newSamples;
         selfShadowSamples = newSelfShadowSamples;
         height = newHeight;
+        base = newBase;
 
         material.heightMap = mode === MODE_NONE ? null : assets.height.resource;
         if (mode !== MODE_NONE) {
@@ -366,6 +373,7 @@ app.on('update', (dt) => {
         // zero takes the self shadow march out of the shader, so this both budgets and switches it
         material.parallaxShadowSamples = selfShadowSamples;
         material.heightMapFactor = height;
+        material.heightMapBase = base;
         material.update();
     }
 

--- a/src/scene/materials/standard-material-parameters.js
+++ b/src/scene/materials/standard-material-parameters.js
@@ -87,6 +87,7 @@ const standardMaterialParameterTypes = {
 
     ..._textureParameter('height', true, false),
     heightMapFactor: 'number',
+    heightMapBase: 'number',
     parallaxMode: 'string',
     parallaxSamples: 'number',
     parallaxShadowSamples: 'number',

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -440,10 +440,10 @@ const isBlack = (color) => {
  * (full bump mapping), but can be set to e.g. 2 to give even more pronounced bump effect.
  * @property {Texture|null} heightMap The height map of the material (default is null). Used for a
  * view-dependent parallax effect. The texture must represent the height of the surface where
- * darker pixels are lower and lighter pixels are higher, with mid-grey being the level of the
- * original geometry. It is recommended to use it together with a normal map. Note that the parallax
- * offset is applied to all other maps of the material, so the height map should use the same tiling
- * and offset as those maps.
+ * darker pixels are lower and lighter pixels are higher, with {@link heightMapBase} selecting the
+ * value that sits at the level of the original geometry. It is recommended to use it together with
+ * a normal map. Note that the parallax offset is applied to all other maps of the material, so the
+ * height map should use the same tiling and offset as those maps.
  * @property {number} heightMapUv Height map UV channel.
  * @property {string} heightMapChannel Color channel of the height map to use. Can be "r", "g", "b"
  * or "a".
@@ -454,16 +454,21 @@ const isBlack = (color) => {
  * @property {number} heightMapFactor Height map multiplier (default is 1). Affects the strength of
  * the parallax effect. A value of 1 displaces the texture by up to 5% of a UV tile, so useful values
  * are typically in the 0 to 2 range.
+ * @property {number} heightMapBase The height map value that sits at the level of the original
+ * geometry, in the 0 to 1 range (default is 0.5). Relief above the base appears to stand out of
+ * the surface and relief below it appears to sink in. Set it to 1 to treat the map as pure depth
+ * carved below the geometry, or to 0 to treat it as pure elevation above it. Both parallax modes
+ * honor it.
  * @property {string} parallaxMode Selects how the height map is used to offset the UV of the other
  * maps of the material. Can be:
  *
  * - {@link PARALLAX_OFFSET}: A single tap of the height map, which pivots the surface around the
- * mid-grey level of the map.
- * - {@link PARALLAX_OCCLUSION}: The view ray is marched through the height field. The map is
- * treated as depth below the original geometry, so white is at the level of the geometry and black
- * is {@link heightMapFactor} deep. This represents deeper displacement without smearing, at the
- * cost of multiple taps per pixel. Note that the silhouette of the mesh is not affected, and the
- * depth buffer still sees the flat surface.
+ * {@link heightMapBase} level of the map.
+ * - {@link PARALLAX_OCCLUSION}: The view ray is marched through the height field, which spans
+ * {@link heightMapFactor} of depth with the geometry sitting at the {@link heightMapBase} level.
+ * This represents deeper displacement without smearing, at the cost of multiple taps per pixel.
+ * Note that the silhouette of the mesh is not affected, and the depth buffer still sees the flat
+ * surface.
  *
  * Defaults to {@link PARALLAX_OFFSET}.
  * @property {number} parallaxSamples The maximum number of height map taps taken along the view ray
@@ -907,6 +912,7 @@ class StandardMaterial extends Material {
 
         if (this.heightMap) {
             this._setParameter('material_heightMapFactor', getUniform('heightMapFactor'));
+            this._setParameter('material_heightMapBase', this.heightMapBase);
 
             if (this.parallaxMode === PARALLAX_OCCLUSION) {
                 this._setParameter('material_parallaxSamples', this.parallaxSamples);
@@ -1275,6 +1281,16 @@ function _defineMaterialProps() {
     _defineFloat('heightMapFactor', 1, (material, device, scene) => {
         return material.heightMapFactor * 0.1;
     });
+
+    // The base only feeds a uniform, so unlike the generic number property it never invalidates
+    // the shader - the generic rule would rebuild for nothing when a slider lands on 0 or 1. Its
+    // uniform is set from updateUniforms, since it is only needed while a height map is assigned.
+    defineProp({
+        name: 'heightMapBase',
+        defaultValue: 0.5,
+        dirtyShaderFunc: () => false
+    });
+
     _defineFloat('parallaxSamples', 16);
 
     // The self shadow tap count is declared by hand rather than through _defineFloat, because the

--- a/src/scene/shader-lib/glsl/chunks/standard/frag/parallax.js
+++ b/src/scene/shader-lib/glsl/chunks/standard/frag/parallax.js
@@ -1,5 +1,6 @@
 export default /* glsl */`
 uniform float material_heightMapFactor;
+uniform float material_heightMapBase;
 
 #if STD_PARALLAX == OCCLUSION
     uniform float material_parallaxSamples;
@@ -36,11 +37,10 @@ void getParallax() {
 
     #if STD_PARALLAX == OCCLUSION
 
-        // Parallax occlusion mapping. The height map is treated as depth below the original
-        // geometry - white sits at the level of the geometry and black is parallaxScale deep - and
-        // the view ray is marched through that volume until it passes below the height field. Note
-        // this reads the map differently to the OFFSET mode above, which pivots the surface around
-        // the mid-grey level instead.
+        // Parallax occlusion mapping. The height map spans a volume parallaxScale deep, with the
+        // original geometry sitting where the map reads material_heightMapBase - relief above the
+        // base stands out of the surface and relief below it sinks in - and the view ray is marched
+        // through that volume until it passes below the height field.
 
         // The uv the ray travels while descending through the whole depth range: the depth scale
         // times the tangent of the view angle, pointing away from the camera as the ray descends.
@@ -53,6 +53,12 @@ void getParallax() {
         float marchLength = length(march);
         float maxMarchLength = parallaxScale * parallaxMaxSlope;
         vec2 uvSpan = marchLength > maxMarchLength ? march * (maxMarchLength / marchLength) : march;
+
+        // The depth of the geometry plane within the volume, zero when the base is white. The
+        // rasterized fragment sits on that plane, so the view ray entered the top of the volume
+        // behind it - the march starts there, extrapolated back along the ray.
+        float geomDepth = 1.0 - material_heightMapBase;
+        vec2 entryUv = {STD_HEIGHT_TEXTURE_UV} - uvSpan * geomDepth;
 
         // The mip level the march reads. Every tap uses an explicit level because the loop below is
         // non-uniform control flow, where the implicit derivatives an automatic level needs are
@@ -95,7 +101,7 @@ void getParallax() {
             // intersection to the surface itself whenever the first step already lands below the
             // height field, removing the offset entirely wherever a single step is taken.
             float rayDepth = 0.0;
-            float surfaceDepth = 1.0 - texture2DLod({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_UV}, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
+            float surfaceDepth = 1.0 - texture2DLod({STD_HEIGHT_TEXTURE_NAME}, entryUv, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
             float prevRayDepth = rayDepth;
             float prevSurfaceDepth = surfaceDepth;
 
@@ -109,7 +115,7 @@ void getParallax() {
                 prevSurfaceDepth = surfaceDepth;
 
                 rayDepth += stepSize;
-                surfaceDepth = 1.0 - texture2DLod({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_UV} + uvSpan * rayDepth, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
+                surfaceDepth = 1.0 - texture2DLod({STD_HEIGHT_TEXTURE_NAME}, entryUv + uvSpan * rayDepth, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
             }
 
             // The ray crossed the surface somewhere inside the last step, so refine within it. Each
@@ -133,18 +139,23 @@ void getParallax() {
                 // couple of texels was measured as a large regression, so it always runs.
                 for (int i = 0; i < parallaxRefineSteps; i++) {
                     interval *= 0.5;
-                    float refineDepth = 1.0 - texture2DLod({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_UV} + uvSpan * hitDepth, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
+                    float refineDepth = 1.0 - texture2DLod({STD_HEIGHT_TEXTURE_NAME}, entryUv + uvSpan * hitDepth, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
 
                     // below the height field, step back towards the surface, otherwise go deeper
                     hitDepth += hitDepth >= refineDepth ? -interval : interval;
                 }
             }
 
-            float visibleDepth = clamp(hitDepth, 0.0, 1.0) * fade;
-            dUvOffset = uvSpan * visibleDepth;
+            // The offset runs from the geometry plane to the hit, so relief above the base moves
+            // the lookup back towards the camera, and the fade pulls the hit onto the plane so the
+            // relief flattens out with distance rather than sliding to the top of the volume.
+            float hitBelowTop = clamp(hitDepth, 0.0, 1.0);
+            dUvOffset = uvSpan * ((hitBelowTop - geomDepth) * fade);
 
             #ifdef STD_PARALLAX_SELF_SHADOW
-                dParallaxHitDepth = visibleDepth;
+                // The climb still fades towards zero length, so the shadow leaves together with
+                // the relief instead of stepping off where the fade ends.
+                dParallaxHitDepth = hitBelowTop * fade;
             #endif
         }
 
@@ -152,9 +163,9 @@ void getParallax() {
 
         float height = texture2DBias({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_UV}, textureBias).{STD_HEIGHT_TEXTURE_CHANNEL};
 
-        // remap the height to be relative to the mid-level of the height map, so the surface pivots
-        // around the original geometry instead of floating in front of it
-        height = height * parallaxScale - parallaxScale * 0.5;
+        // remap the height to be relative to the base level of the height map, so the surface
+        // pivots around the original geometry instead of floating in front of it
+        height = (height - material_heightMapBase) * parallaxScale;
 
         // Parallax mapping with offset limiting (Welsh 2004). The geometrically correct offset is
         // height * viewDirUv / viewDirT.z, but the 1/z term explodes at grazing angles and smears

--- a/src/scene/shader-lib/wgsl/chunks/standard/frag/parallax.js
+++ b/src/scene/shader-lib/wgsl/chunks/standard/frag/parallax.js
@@ -1,5 +1,6 @@
 export default /* wgsl */`
 uniform material_heightMapFactor: f32;
+uniform material_heightMapBase: f32;
 
 #if STD_PARALLAX == OCCLUSION
     uniform material_parallaxSamples: f32;
@@ -36,11 +37,10 @@ fn getParallax() {
 
     #if STD_PARALLAX == OCCLUSION
 
-        // Parallax occlusion mapping. The height map is treated as depth below the original
-        // geometry - white sits at the level of the geometry and black is parallaxScale deep - and
-        // the view ray is marched through that volume until it passes below the height field. Note
-        // this reads the map differently to the OFFSET mode above, which pivots the surface around
-        // the mid-grey level instead.
+        // Parallax occlusion mapping. The height map spans a volume parallaxScale deep, with the
+        // original geometry sitting where the map reads material_heightMapBase - relief above the
+        // base stands out of the surface and relief below it sinks in - and the view ray is marched
+        // through that volume until it passes below the height field.
 
         // The uv the ray travels while descending through the whole depth range: the depth scale
         // times the tangent of the view angle, pointing away from the camera as the ray descends.
@@ -53,6 +53,12 @@ fn getParallax() {
         let marchLength: f32 = length(march);
         let maxMarchLength: f32 = parallaxScale * parallaxMaxSlope;
         let uvSpan: vec2f = select(march, march * (maxMarchLength / marchLength), marchLength > maxMarchLength);
+
+        // The depth of the geometry plane within the volume, zero when the base is white. The
+        // rasterized fragment sits on that plane, so the view ray entered the top of the volume
+        // behind it - the march starts there, extrapolated back along the ray.
+        let geomDepth: f32 = 1.0 - uniform.material_heightMapBase;
+        let entryUv: vec2f = {STD_HEIGHT_TEXTURE_UV} - uvSpan * geomDepth;
 
         // The mip level the march reads. Every tap uses an explicit level because the loop below is
         // non-uniform control flow, where the implicit derivatives an automatic level needs are
@@ -95,7 +101,7 @@ fn getParallax() {
             // intersection to the surface itself whenever the first step already lands below the
             // height field, removing the offset entirely wherever a single step is taken.
             var rayDepth: f32 = 0.0;
-            var surfaceDepth: f32 = 1.0 - textureSampleLevel({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_NAME}Sampler, {STD_HEIGHT_TEXTURE_UV}, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
+            var surfaceDepth: f32 = 1.0 - textureSampleLevel({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_NAME}Sampler, entryUv, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
             var prevRayDepth: f32 = rayDepth;
             var prevSurfaceDepth: f32 = surfaceDepth;
 
@@ -109,7 +115,7 @@ fn getParallax() {
                 prevSurfaceDepth = surfaceDepth;
 
                 rayDepth += stepSize;
-                surfaceDepth = 1.0 - textureSampleLevel({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_NAME}Sampler, {STD_HEIGHT_TEXTURE_UV} + uvSpan * rayDepth, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
+                surfaceDepth = 1.0 - textureSampleLevel({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_NAME}Sampler, entryUv + uvSpan * rayDepth, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
             }
 
             // The ray crossed the surface somewhere inside the last step, so refine within it. Each
@@ -133,18 +139,23 @@ fn getParallax() {
                 // couple of texels was measured as a large regression, so it always runs.
                 for (var i: i32 = 0; i < parallaxRefineSteps; i++) {
                     interval *= 0.5;
-                    let refineDepth: f32 = 1.0 - textureSampleLevel({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_NAME}Sampler, {STD_HEIGHT_TEXTURE_UV} + uvSpan * hitDepth, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
+                    let refineDepth: f32 = 1.0 - textureSampleLevel({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_NAME}Sampler, entryUv + uvSpan * hitDepth, lod).{STD_HEIGHT_TEXTURE_CHANNEL};
 
                     // below the height field, step back towards the surface, otherwise go deeper
                     hitDepth += select(interval, -interval, hitDepth >= refineDepth);
                 }
             }
 
-            let visibleDepth: f32 = clamp(hitDepth, 0.0, 1.0) * fade;
-            dUvOffset = uvSpan * visibleDepth;
+            // The offset runs from the geometry plane to the hit, so relief above the base moves
+            // the lookup back towards the camera, and the fade pulls the hit onto the plane so the
+            // relief flattens out with distance rather than sliding to the top of the volume.
+            let hitBelowTop: f32 = clamp(hitDepth, 0.0, 1.0);
+            dUvOffset = uvSpan * ((hitBelowTop - geomDepth) * fade);
 
             #ifdef STD_PARALLAX_SELF_SHADOW
-                dParallaxHitDepth = visibleDepth;
+                // The climb still fades towards zero length, so the shadow leaves together with
+                // the relief instead of stepping off where the fade ends.
+                dParallaxHitDepth = hitBelowTop * fade;
             #endif
         }
 
@@ -152,9 +163,9 @@ fn getParallax() {
 
         var height: f32 = textureSampleBias({STD_HEIGHT_TEXTURE_NAME}, {STD_HEIGHT_TEXTURE_NAME}Sampler, {STD_HEIGHT_TEXTURE_UV}, uniform.textureBias).{STD_HEIGHT_TEXTURE_CHANNEL};
 
-        // remap the height to be relative to the mid-level of the height map, so the surface pivots
-        // around the original geometry instead of floating in front of it
-        height = height * parallaxScale - parallaxScale * 0.5;
+        // remap the height to be relative to the base level of the height map, so the surface
+        // pivots around the original geometry instead of floating in front of it
+        height = (height - uniform.material_heightMapBase) * parallaxScale;
 
         // Parallax mapping with offset limiting (Welsh 2004). The geometrically correct offset is
         // height * viewDirUv / viewDirT.z, but the 1/z term explodes at grazing angles and smears


### PR DESCRIPTION
Adds `StandardMaterial#heightMapBase` - the height map value that sits at the level of the original geometry - and unifies the zero-level convention of the two parallax modes before 2.22 ships.

Previously the two modes read the same map differently: `PARALLAX_OFFSET` pivoted the relief around mid-grey (the behavior shipped for years), while the new `PARALLAX_OCCLUSION` treated white as the geometry level and could only carve downwards. Toggling between modes shifted the whole surface by half the relief depth, and content authored against the POM reading would have baked that inconsistency in.

**Changes:**
- New `StandardMaterial#heightMapBase` (0-1, default 0.5): relief above the base stands out of the surface, relief below it sinks in. The default matches the long-shipped OFFSET pivot, so existing height maps look unchanged; `1` reproduces the depth-only POM reading this replaces (for crevice-style maps authored white = flat), `0` treats the map as pure elevation.
- Both parallax modes now honor the same base: OFFSET remaps the height relative to it, and the POM march enters the height volume at the ray's top-of-volume crossing, extrapolated back along the view ray, so relief above the base moves the lookup towards the camera. `heightMapBase: 1` produces the exact march this replaces.
- The distance fade now pulls the hit onto the geometry plane, so relief flattens in place rather than sliding to the top of the volume; the self-shadow climb keeps fading to zero length so shadows leave together with the relief.
- The property only feeds a uniform, so it never invalidates the shader (the generic float rule would recompile whenever a slider lands on exactly 0 or 1).

**Examples:**
- `materials/parallax-mapping` and `materials/parallax-terrain` both gain a Base slider.

Verified on WebGL2 and WebGPU in both examples: base 0 / 0.5 / 1 in both modes, with self shadowing active on the terrain.