### PR TITLE
Document that Application is expected to be deprecated

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -114,6 +114,9 @@ let app = null;
  * {@link ResourceHandler}s yourself. This facilitates
  * [tree-shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking) when bundling
  * your application.
+ *
+ * It is the preferred entry point for new code - {@link Application} is a convenience subclass
+ * that registers everything for you, and is expected to be deprecated in a future release.
  */
 class AppBase extends EventHandler {
     /**

--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -70,6 +70,33 @@ import { XrManager } from './xr/xr-manager.js';
  * {@link ComponentSystem}s and {@link ResourceHandler}s implemented in the PlayCanvas Engine. This
  * makes app setup simple but results in the full engine being included when bundling your
  * application.
+ *
+ * New code should prefer {@link AppBase}, as this class is expected to be deprecated in a future
+ * release. Two limitations motivate that:
+ *
+ * - Its constructor is synchronous, so it cannot create a WebGPU device. Creating one requires
+ * awaiting {@link createGraphicsDevice}.
+ * - It references every component system and resource handler, so none of them can be
+ * [tree-shaken](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking) out of your
+ * bundle. {@link AppBase} leaves that choice to you.
+ *
+ * The equivalent {@link AppBase} setup registers only what the app actually uses:
+ *
+ * ```javascript
+ * const device = await createGraphicsDevice(canvas, { deviceTypes: [DEVICETYPE_WEBGPU] });
+ *
+ * const options = new AppOptions();
+ * options.graphicsDevice = device;
+ * options.componentSystems = [RenderComponentSystem, CameraComponentSystem, LightComponentSystem];
+ * options.resourceHandlers = [TextureHandler, ContainerHandler];
+ *
+ * const app = new AppBase(canvas);
+ * app.init(options);
+ * ```
+ *
+ * The component systems this class registers are listed on the constructor below. That list
+ * doubles as a migration checklist, as it maps each component name to the system you would need
+ * to register yourself.
  */
 class Application extends AppBase {
     /**
@@ -84,6 +111,8 @@ class Application extends AppBase {
      * - camera ({@link CameraComponentSystem})
      * - collision ({@link CollisionComponentSystem})
      * - element ({@link ElementComponentSystem})
+     * - gsplat ({@link GSplatComponentSystem})
+     * - joint ({@link JointComponentSystem})
      * - layoutchild ({@link LayoutChildComponentSystem})
      * - layoutgroup ({@link LayoutGroupComponentSystem})
      * - light ({@link LightComponentSystem})
@@ -97,6 +126,7 @@ class Application extends AppBase {
      * - scrollview ({@link ScrollViewComponentSystem})
      * - sound ({@link SoundComponentSystem})
      * - sprite ({@link SpriteComponentSystem})
+     * - zone ({@link ZoneComponentSystem})
      *
      * @param {HTMLCanvasElement | OffscreenCanvas} canvas - The canvas element.
      * @param {object} [options] - The options object to configure the Application.


### PR DESCRIPTION
Adds a soft-deprecation note to `Application`, pointing new code at `AppBase`. Documentation only — no `@deprecated` tag and no behaviour change, so nothing breaks for existing users or for the Editor, whose viewport still extends `Application`.

**Changes:**
- `Application` class docs: note that new code should prefer `AppBase` and that this class is expected to be deprecated, with the two reasons — its constructor is synchronous so it cannot create a WebGPU device, and it references every component system and resource handler so none of them can be tree-shaken. Includes the equivalent `createGraphicsDevice` + `AppOptions` + `AppBase` setup as a snippet.
- `AppBase` class docs: one paragraph noting it is the preferred entry point, and that `Application` is the convenience subclass being phased out. The existing text already covered the tree-shaking trade-off; this adds the direction.
- Complete the constructor's list of registered component systems: it documented 20 but the class registers 23, so `gsplat`, `joint` and `zone` were missing. That list maps each component name to the system you need to register yourself, so it doubles as the migration checklist — worth being accurate if it is going to be pointed at.

**Deliberately not included:**
- The `@deprecated` tag. It propagates into the generated `playcanvas.d.ts`, so it would strike through every `new Application(...)` in users' IDEs — including the Editor's own `ViewportApplication extends Application` — before there is an ergonomic path to move to. Worth adding once a replacement exists (a preset export, or at minimum a documented recipe) and ideally once the Editor viewport has migrated.
- The constructor documents the 23 component systems but not the 25 resource handlers it registers, so the checklist still only covers half of what `AppOptions` needs. Left for a follow-up.

For context on why `AppBase` is viable today: the Editor's launcher has already migrated to `AppBase` + `createGraphicsDevice`, and needs the explicit form because it substitutes `ScriptLegacyComponentSystem` for `ScriptComponentSystem` and adds `AudioSourceComponentSystem` — neither expressible through `Application`. No engine example uses `new Application` any more either.