### PR TITLE
Defer npm 12 updates in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,15 @@
       "rangeStrategy": "widen"
     },
     {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "npm"
+      ],
+      "allowedVersions": "<12.0.0"
+    },
+    {
       "matchPackageNames": [
         "monaco-editor"
       ],


### PR DESCRIPTION
Prevent Renovate from proposing npm 12 while its artifact-generation environment uses an incompatible Node.js version.

**Changes:**
- Restrict Renovate npm updates to versions below 12.
- Continue allowing npm 11 minor and patch updates.