### PR TITLE
Correct sound duration and playback timing

### DIFF
--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -588,8 +588,8 @@ class SoundSlot extends EventHandler {
     }
 
     /**
-     * Gets the duration of the sound that the slot will play starting from startTime. The returned
-     * value is clamped to the duration of the audio asset.
+     * Gets the duration of the sound that the slot will play starting from {@link startTime}. The
+     * returned value is clamped to the time available after the normalized start time.
      *
      * @type {number}
      */
@@ -602,7 +602,8 @@ class SoundSlot extends EventHandler {
 
         // != intentional
         if (this._duration != null) {
-            return Math.min(this._duration, assetDuration);
+            const startTime = (this._startTime % assetDuration) || 0;
+            return Math.min(this._duration, assetDuration - startTime);
         }
         return assetDuration;
     }

--- a/src/framework/components/sound/slot.js
+++ b/src/framework/components/sound/slot.js
@@ -588,7 +588,8 @@ class SoundSlot extends EventHandler {
     }
 
     /**
-     * Gets the duration of the sound that the slot will play starting from startTime.
+     * Gets the duration of the sound that the slot will play starting from startTime. The returned
+     * value is clamped to the duration of the audio asset.
      *
      * @type {number}
      */
@@ -601,7 +602,7 @@ class SoundSlot extends EventHandler {
 
         // != intentional
         if (this._duration != null) {
-            return this._duration % (assetDuration || 1);
+            return Math.min(this._duration, assetDuration);
         }
         return assetDuration;
     }

--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -216,7 +216,11 @@ class SoundInstance extends EventHandler {
          */
         this._currentTime = 0;
 
-        /** @private */
+        /**
+         * The playback position relative to startTime when _startedAt was recorded.
+         *
+         * @private
+         */
         this._currentOffset = 0;
 
         /**
@@ -302,13 +306,17 @@ class SoundInstance extends EventHandler {
     }
 
     /**
-     * Sets the current time of the sound that is playing. If the value provided is bigger than the
-     * duration of the instance it will wrap from the beginning.
+     * Sets the current time of the sound that is playing, relative to {@link startTime}. If the
+     * value provided is bigger than the duration of the instance it will wrap from the beginning.
      *
      * @type {number}
      */
     set currentTime(value) {
+        value = Number(value) || 0;
         if (value < 0) return;
+
+        const duration = this.duration;
+        const currentTime = duration ? capTime(value, duration) : value;
 
         if (this._state === STATE_PLAYING) {
             const suspend = this._suspendInstanceEvents;
@@ -318,19 +326,19 @@ class SoundInstance extends EventHandler {
             this.stop();
 
             // set _startOffset and play
-            this._startOffset = value;
+            this._startOffset = currentTime;
             this.play();
             this._suspendInstanceEvents = suspend;
         } else {
             // set _startOffset which will be used when the instance will start playing
-            this._startOffset = value;
+            this._startOffset = currentTime;
             // set _currentTime
-            this._currentTime = value;
+            this._currentTime = currentTime;
         }
     }
 
     /**
-     * Gets the current time of the sound that is playing.
+     * Gets the current time of the sound that is playing, relative to {@link startTime}.
      *
      * @type {number}
      */
@@ -375,8 +383,8 @@ class SoundInstance extends EventHandler {
     }
 
     /**
-     * Gets the duration of the sound that the instance will play starting from startTime. The
-     * returned value is clamped to the duration of the sound resource.
+     * Gets the duration of the sound that the instance will play starting from {@link startTime}.
+     * The returned value is clamped to the time available after the normalized start time.
      *
      * @type {number}
      */
@@ -385,7 +393,9 @@ class SoundInstance extends EventHandler {
             return 0;
         }
         if (this._duration) {
-            return Math.min(this._duration, this._sound.duration);
+            const soundDuration = this._sound.duration;
+            const startTime = capTime(this._startTime, soundDuration);
+            return Math.min(this._duration, soundDuration - startTime);
         }
         return this._sound.duration;
     }
@@ -725,19 +735,19 @@ class SoundInstance extends EventHandler {
             this._createSource();
         }
 
-        // calculate start offset
-        let offset = capTime(this._startOffset, this.duration);
-        offset = capTime(this._startTime + offset, this._sound.duration);
+        // calculate the current offset relative to startTime and its matching buffer offset
+        const currentOffset = capTime(this._startOffset, this.duration);
+        const offset = capTime(this._startTime + currentOffset, this._sound.duration);
         // reset start offset now that we started the sound
         this._startOffset = null;
 
         // start source with specified offset
-        this._startSource(offset);
+        this._startSource(offset, currentOffset);
 
         // reset times
         this._startedAt = this._manager.context.currentTime;
         this._currentTime = 0;
-        this._currentOffset = offset;
+        this._currentOffset = currentOffset;
 
         // Initialize volume and loop - note moved to be after start() because of Chrome bug
         this.volume = this._volume;
@@ -763,11 +773,12 @@ class SoundInstance extends EventHandler {
      * playback at the end of the first iteration instead of looping.
      *
      * @param {number} offset - The offset into the buffer, in seconds, to start playing from.
+     * @param {number} currentOffset - The offset relative to startTime, in seconds.
      * @private
      */
-    _startSource(offset) {
+    _startSource(offset, currentOffset) {
         if (this._duration && !this._loop) {
-            this.source.start(0, offset, this._duration);
+            this.source.start(0, offset, this.duration - currentOffset);
         } else {
             this.source.start(0, offset);
         }
@@ -885,8 +896,8 @@ class SoundInstance extends EventHandler {
             return false;
         }
 
-        // start at point where sound was paused
-        let offset = this.currentTime;
+        // start at the point relative to startTime where the sound was paused
+        let currentOffset = this.currentTime;
 
         // set state back to playing
         this._state = STATE_PLAYING;
@@ -903,18 +914,19 @@ class SoundInstance extends EventHandler {
         // if the user set the 'currentTime' property while the sound
         // was paused then use that as the offset instead
         if (this._startOffset !== null) {
-            offset = capTime(this._startOffset, this.duration);
-            offset = capTime(this._startTime + offset, this._sound.duration);
+            currentOffset = capTime(this._startOffset, this.duration);
 
             // reset offset
             this._startOffset = null;
         }
 
+        const offset = capTime(this._startTime + currentOffset, this._sound.duration);
+
         // start source
-        this._startSource(offset);
+        this._startSource(offset, currentOffset);
 
         this._startedAt = this._manager.context.currentTime;
-        this._currentOffset = offset;
+        this._currentOffset = currentOffset;
 
         // Initialize parameters
         this.volume = this._volume;

--- a/src/platform/sound/instance.js
+++ b/src/platform/sound/instance.js
@@ -375,7 +375,8 @@ class SoundInstance extends EventHandler {
     }
 
     /**
-     * Gets the duration of the sound that the instance will play starting from startTime.
+     * Gets the duration of the sound that the instance will play starting from startTime. The
+     * returned value is clamped to the duration of the sound resource.
      *
      * @type {number}
      */
@@ -384,7 +385,7 @@ class SoundInstance extends EventHandler {
             return 0;
         }
         if (this._duration) {
-            return capTime(this._duration, this._sound.duration);
+            return Math.min(this._duration, this._sound.duration);
         }
         return this._sound.duration;
     }

--- a/test/framework/components/sound/slot.test.mjs
+++ b/test/framework/components/sound/slot.test.mjs
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { SoundSlot } from '../../../../src/framework/components/sound/slot.js';
 import { Sound } from '../../../../src/platform/sound/sound.js';
 
-function createSlot(duration) {
+function createSlot(options = {}) {
     const asset = { resource: new Sound({ duration: 4 }) };
     const component = {
         system: {
@@ -16,7 +16,7 @@ function createSlot(duration) {
         }
     };
 
-    return new SoundSlot(component, 'Test', { asset: 1, duration });
+    return new SoundSlot(component, 'Test', { asset: 1, ...options });
 }
 
 describe('SoundSlot', function () {
@@ -26,15 +26,25 @@ describe('SoundSlot', function () {
         });
 
         it('returns a duration shorter than the asset', function () {
-            expect(createSlot(2).duration).to.equal(2);
+            expect(createSlot({ duration: 2 }).duration).to.equal(2);
         });
 
         it('returns the asset duration when the durations match', function () {
-            expect(createSlot(4).duration).to.equal(4);
+            expect(createSlot({ duration: 4 }).duration).to.equal(4);
         });
 
         it('clamps a duration longer than the asset', function () {
-            expect(createSlot(6).duration).to.equal(4);
+            expect(createSlot({ duration: 6 }).duration).to.equal(4);
+        });
+
+        it('clamps the duration to the time remaining after startTime', function () {
+            expect(createSlot({ startTime: 2, duration: 6 }).duration).to.equal(2);
+            expect(createSlot({ startTime: 2, duration: 3 }).duration).to.equal(2);
+        });
+
+        it('normalizes startTime before clamping the duration', function () {
+            expect(createSlot({ startTime: 6, duration: 6 }).duration).to.equal(2);
+            expect(createSlot({ startTime: 4, duration: 6 }).duration).to.equal(4);
         });
     });
 });

--- a/test/framework/components/sound/slot.test.mjs
+++ b/test/framework/components/sound/slot.test.mjs
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+
+import { SoundSlot } from '../../../../src/framework/components/sound/slot.js';
+import { Sound } from '../../../../src/platform/sound/sound.js';
+
+function createSlot(duration) {
+    const asset = { resource: new Sound({ duration: 4 }) };
+    const component = {
+        system: {
+            app: {
+                assets: {
+                    get: () => asset
+                }
+            },
+            manager: {}
+        }
+    };
+
+    return new SoundSlot(component, 'Test', { asset: 1, duration });
+}
+
+describe('SoundSlot', function () {
+    describe('#duration', function () {
+        it('returns the asset duration when no duration is specified', function () {
+            expect(createSlot().duration).to.equal(4);
+        });
+
+        it('returns a duration shorter than the asset', function () {
+            expect(createSlot(2).duration).to.equal(2);
+        });
+
+        it('returns the asset duration when the durations match', function () {
+            expect(createSlot(4).duration).to.equal(4);
+        });
+
+        it('clamps a duration longer than the asset', function () {
+            expect(createSlot(6).duration).to.equal(4);
+        });
+    });
+});

--- a/test/platform/sound/instance.test.mjs
+++ b/test/platform/sound/instance.test.mjs
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+
+import { EventHandler } from '../../../src/core/event-handler.js';
+import { SoundInstance } from '../../../src/platform/sound/instance.js';
+import { Sound } from '../../../src/platform/sound/sound.js';
+
+function createInstance(duration, manager = { context: null }) {
+    const sound = new Sound({ duration: 4 });
+
+    return new SoundInstance(manager, sound, { duration });
+}
+
+function createManager() {
+    const manager = new EventHandler();
+    manager.suspended = false;
+    manager.context = {
+        currentTime: 0,
+        destination: {},
+        createGain: () => ({
+            gain: { value: 1 },
+            connect: () => {},
+            disconnect: () => {}
+        }),
+        createBufferSource: () => ({
+            playbackRate: { value: 1 },
+            loopStart: 0,
+            loopEnd: 0,
+            connect: () => {},
+            start: () => {},
+            stop: () => {}
+        })
+    };
+
+    return manager;
+}
+
+describe('SoundInstance', function () {
+    describe('#duration', function () {
+        it('returns the sound duration when no duration is specified', function () {
+            expect(createInstance().duration).to.equal(4);
+        });
+
+        it('returns a duration shorter than the sound', function () {
+            expect(createInstance(2).duration).to.equal(2);
+        });
+
+        it('returns the sound duration when the durations match', function () {
+            expect(createInstance(4).duration).to.equal(4);
+        });
+
+        it('clamps a duration longer than the sound', function () {
+            expect(createInstance(6).duration).to.equal(4);
+        });
+    });
+
+    describe('#currentTime', function () {
+        it('uses the clamped duration when tracking playback', function () {
+            const manager = createManager();
+            const instance = createInstance(6, manager);
+
+            instance.play();
+            manager.context.currentTime = 3;
+
+            expect(instance.currentTime).to.equal(3);
+
+            instance.stop();
+        });
+    });
+});

--- a/test/platform/sound/instance.test.mjs
+++ b/test/platform/sound/instance.test.mjs
@@ -4,15 +4,19 @@ import { EventHandler } from '../../../src/core/event-handler.js';
 import { SoundInstance } from '../../../src/platform/sound/instance.js';
 import { Sound } from '../../../src/platform/sound/sound.js';
 
-function createInstance(duration, manager = { context: null }) {
+function createInstance(options = {}, manager = { context: null }) {
     const sound = new Sound({ duration: 4 });
 
-    return new SoundInstance(manager, sound, { duration });
+    return new SoundInstance(manager, sound, options);
 }
 
 function createManager() {
     const manager = new EventHandler();
+    const sources = [];
+
+    manager.volume = 1;
     manager.suspended = false;
+    manager.sources = sources;
     manager.context = {
         currentTime: 0,
         destination: {},
@@ -21,14 +25,20 @@ function createManager() {
             connect: () => {},
             disconnect: () => {}
         }),
-        createBufferSource: () => ({
-            playbackRate: { value: 1 },
-            loopStart: 0,
-            loopEnd: 0,
-            connect: () => {},
-            start: () => {},
-            stop: () => {}
-        })
+        createBufferSource: () => {
+            const source = {
+                playbackRate: { value: 1 },
+                loopStart: 0,
+                loopEnd: 0,
+                connect: () => {},
+                start: (...args) => {
+                    source.startArgs = args;
+                },
+                stop: () => {}
+            };
+            sources.push(source);
+            return source;
+        }
     };
 
     return manager;
@@ -41,27 +51,111 @@ describe('SoundInstance', function () {
         });
 
         it('returns a duration shorter than the sound', function () {
-            expect(createInstance(2).duration).to.equal(2);
+            expect(createInstance({ duration: 2 }).duration).to.equal(2);
         });
 
         it('returns the sound duration when the durations match', function () {
-            expect(createInstance(4).duration).to.equal(4);
+            expect(createInstance({ duration: 4 }).duration).to.equal(4);
         });
 
         it('clamps a duration longer than the sound', function () {
-            expect(createInstance(6).duration).to.equal(4);
+            expect(createInstance({ duration: 6 }).duration).to.equal(4);
+        });
+
+        it('clamps the duration to the time remaining after startTime', function () {
+            expect(createInstance({ startTime: 2, duration: 6 }).duration).to.equal(2);
+            expect(createInstance({ startTime: 2, duration: 3 }).duration).to.equal(2);
+        });
+
+        it('normalizes startTime before clamping the duration', function () {
+            expect(createInstance({ startTime: 6, duration: 6 }).duration).to.equal(2);
+            expect(createInstance({ startTime: 4, duration: 6 }).duration).to.equal(4);
         });
     });
 
     describe('#currentTime', function () {
+        it('wraps an assigned time immediately', function () {
+            const instance = createInstance({ duration: 3 });
+
+            instance.currentTime = 5;
+
+            expect(instance.currentTime).to.equal(2);
+        });
+
         it('uses the clamped duration when tracking playback', function () {
             const manager = createManager();
-            const instance = createInstance(6, manager);
+            const instance = createInstance({ duration: 6 }, manager);
 
             instance.play();
             manager.context.currentTime = 3;
 
             expect(instance.currentTime).to.equal(3);
+
+            instance.stop();
+        });
+
+        it('tracks playback relative to startTime', function () {
+            const manager = createManager();
+            const instance = createInstance({ startTime: 1, duration: 3, loop: true }, manager);
+
+            instance.play();
+            expect(manager.sources[0].startArgs).to.deep.equal([0, 1]);
+            expect(instance.currentTime).to.equal(0);
+
+            manager.context.currentTime = 2;
+            expect(instance.currentTime).to.equal(2);
+
+            manager.context.currentTime = 3.5;
+            expect(instance.currentTime).to.equal(0.5);
+
+            instance.stop();
+        });
+
+        it('seeks relative to startTime and limits the remaining playback duration', function () {
+            const manager = createManager();
+            const instance = createInstance({ startTime: 1, duration: 3 }, manager);
+
+            instance.currentTime = 2;
+            instance.play();
+
+            expect(manager.sources[0].startArgs).to.deep.equal([0, 3, 1]);
+            expect(instance.currentTime).to.equal(2);
+
+            instance.stop();
+        });
+
+        it('resumes the paused position relative to startTime', function () {
+            const manager = createManager();
+            const instance = createInstance({ startTime: 1, duration: 2 }, manager);
+
+            instance.play();
+            expect(manager.sources[0].startArgs).to.deep.equal([0, 1, 2]);
+
+            manager.context.currentTime = 0.75;
+            instance.pause();
+            expect(instance.currentTime).to.equal(0.75);
+
+            instance.resume();
+
+            expect(manager.sources[1].startArgs).to.deep.equal([0, 1.75, 1.25]);
+            expect(instance.currentTime).to.equal(0.75);
+
+            instance.stop();
+        });
+
+        it('resumes an assigned time relative to startTime', function () {
+            const manager = createManager();
+            const instance = createInstance({ startTime: 1, duration: 2 }, manager);
+
+            instance.play();
+            manager.context.currentTime = 0.75;
+            instance.pause();
+
+            instance.currentTime = 1.5;
+            instance.resume();
+
+            expect(manager.sources[1].startArgs).to.deep.equal([0, 2.5, 0.5]);
+            expect(instance.currentTime).to.equal(1.5);
 
             instance.stop();
         });


### PR DESCRIPTION
Keep sound duration reporting and playback position consistent with configured start times and the underlying audio resource.

**Changes:**
- Clamp `SoundInstance.duration` and `SoundSlot.duration` to the playable time after the normalized start time.
- Track `SoundInstance.currentTime` relative to `startTime` and wrap assigned values immediately.
- Resume paused or seeked sounds at the correct buffer offset and limit non-looping playback to the remaining configured duration.
- Add regression coverage for shorter, equal, longer, non-zero-start, wrapped-start, seek, and pause/resume cases.

**API Changes:**
- `SoundInstance#duration` and `SoundSlot#duration` now return the playable duration after `startTime` when a duration is configured.
- `SoundInstance#currentTime` now consistently reports a position relative to `startTime`, including immediately after assignment and across pause/resume.

```javascript
slot.startTime = 2;
slot.duration = 6; // Audio asset duration is 4 seconds

slot.duration; // Before: 4
slot.duration; // After: 2

instance.currentTime = 5; // Effective duration is 3 seconds
instance.currentTime; // Before playback: 5
instance.currentTime; // After: 2
```