### PR TITLE
Remove Scene#forcePassThroughSpecular compatibility flag

### DIFF
--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -233,12 +233,6 @@ class StandardMaterialOptionsBuilder {
         options.clearCoatPackedNormal = isPackedNormalMap(stdMat.clearCoatNormalMap);
         options.iorTint = !equalish(stdMat.refractionIndex, 1.0 / 1.5);
 
-        // hack, see Scene.forcePassThroughSpecular description
-        if (scene.forcePassThroughSpecular) {
-            options.specularEncoding = 'linear';
-            options.sheenEncoding = 'linear';
-        }
-
         options.iridescenceTint = stdMat.iridescence !== 1.0;
 
         options.glossInvert = stdMat.glossInvert;

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -264,17 +264,6 @@ class Scene extends EventHandler {
     _fogParams = new FogParams();
 
     /**
-     * Internal flag to indicate that the specular (and sheen) maps of standard materials should be
-     * assumed to be in a linear space, instead of sRGB. This is used by the editor using engine v2
-     * internally to render in a style of engine v1, where spec those textures were specified as
-     * linear, while engine 2 assumes they are in sRGB space. This should be removed when the editor
-     * no longer supports engine v1 projects.
-     *
-     * @ignore
-     */
-    forcePassThroughSpecular = false;
-
-    /**
      * Create a new Scene instance.
      *
      * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this scene.


### PR DESCRIPTION
Fixes #9241.

`Scene#forcePassThroughSpecular` was an `@ignore` flag that existed purely so the Editor, running engine v2 internally, could render engine-v1 projects with standard-material specular and sheen **maps** treated as linear rather than sRGB. Its own doc comment said to remove it once the Editor no longer supported v1 projects.

It was consumed in exactly one place, forcing `specularEncoding` / `sheenEncoding` to `'linear'` in `standard-material-options-builder.js`. Those two options stay — they are still derived normally from `stdMat.specularMap?.encoding` / `stdMat.sheenMap?.encoding` and read by `shader-lib/programs/standard.js`. Only the override branch goes away.

### Why this is safe now

At Editor `main` (2.31.1) the v1/v2 project toggle is gone (`src/editor/pickers/picker-engine.ts` no longer exists) and `src/editor/scene-settings/scene-settings.ts` migrates a v1 project on open — it converts camera gamma/tonemapping settings, sets the project's `engineV2` setting to `true` and reloads the page, after which `editor.projectEngineV2` is `true` and the branch that sets this flag no longer runs.

The Editor still contains the assignment (`src/editor/viewport/viewport.ts`), tracked for cleanup in playcanvas/editor#2223. Removing the field here does not break it: `Scene` is a plain class with no accessor for the property, so the assignment simply creates a dead own-property. Two paths can still reach it — the first load of an un-migrated project before the reload, and a session without write permission where the migration block is skipped — and in both cases the only effect of this PR is that the legacy project's specular/sheen maps are gamma-decoded in the Editor viewport rather than passed through, a subtle shading difference on projects that convert as soon as anyone with write access opens them.

### Testing

`test/scene` passes (285 tests); lint clean. No other references to the flag remain in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)