### PR TITLE
Remove passive event listener detection and platform.passiveEvents

### DIFF
--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -147,15 +147,6 @@ const platform = {
     workers: workers,
 
     /**
-     * True if the platform supports passive event listeners. Always true, as every browser able
-     * to run the engine supports them. Kept for backwards compatibility.
-     *
-     * @type {boolean}
-     * @ignore
-     */
-    passiveEvents: true,
-
-    /**
      * Get the browser name.
      *
      * @type {'chrome' | 'safari' | 'firefox' | 'other' | null}

--- a/src/core/platform.js
+++ b/src/core/platform.js
@@ -1,21 +1,3 @@
-// detect whether passive events are supported by the browser
-const detectPassiveEvents = () => {
-    let result = false;
-
-    try {
-        const opts = Object.defineProperty({}, 'passive', {
-            get: function () {
-                result = true;
-                return false;
-            }
-        });
-        window.addEventListener('testpassive', null, opts);
-        window.removeEventListener('testpassive', null, opts);
-    } catch (e) {}
-
-    return result;
-};
-
 const ua = (typeof navigator !== 'undefined') ? navigator.userAgent : '';
 const environment = typeof window !== 'undefined' ? 'browser' :
     typeof global !== 'undefined' ? 'node' : 'worker';
@@ -47,7 +29,6 @@ const visionos = /Macintosh/i.test(ua) &&
 const touch = (environment === 'browser') && ('ontouchstart' in window || ('maxTouchPoints' in navigator && navigator.maxTouchPoints > 0));
 const gamepads = (environment === 'browser') && (!!navigator.getGamepads || !!navigator.webkitGetGamepads);
 const workers = (typeof Worker !== 'undefined');
-const passiveEvents = detectPassiveEvents();
 
 /**
  * Global namespace that stores flags regarding platform environment and features support.
@@ -166,13 +147,13 @@ const platform = {
     workers: workers,
 
     /**
-     * True if the platform supports an options object as the third parameter to
-     * `EventTarget.addEventListener()` and the passive property is supported.
+     * True if the platform supports passive event listeners. Always true, as every browser able
+     * to run the engine supports them. Kept for backwards compatibility.
      *
      * @type {boolean}
      * @ignore
      */
-    passiveEvents: passiveEvents,
+    passiveEvents: true,
 
     /**
      * Get the browser name.

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -427,7 +427,7 @@ class ElementInput {
         this._target = domElement;
         this._attached = true;
 
-        const opts = platform.passiveEvents ? { passive: true } : false;
+        const opts = { passive: true };
         if (this._useMouse) {
             window.addEventListener('mouseup', this._upHandler, opts);
             window.addEventListener('mousedown', this._downHandler, opts);
@@ -465,7 +465,7 @@ class ElementInput {
         if (!this._attached) return;
         this._attached = false;
 
-        const opts = platform.passiveEvents ? { passive: true } : false;
+        const opts = { passive: true };
         if (this._useMouse) {
             window.removeEventListener('mouseup', this._upHandler, opts);
             window.removeEventListener('mousedown', this._downHandler, opts);

--- a/src/framework/input/element-input.js
+++ b/src/framework/input/element-input.js
@@ -427,16 +427,17 @@ class ElementInput {
         this._target = domElement;
         this._attached = true;
 
-        const opts = { passive: true };
+        /** @type {AddEventListenerOptions} */
+        const options = { passive: true };
         if (this._useMouse) {
-            window.addEventListener('mouseup', this._upHandler, opts);
-            window.addEventListener('mousedown', this._downHandler, opts);
-            window.addEventListener('mousemove', this._moveHandler, opts);
-            window.addEventListener('wheel', this._wheelHandler, opts);
+            window.addEventListener('mouseup', this._upHandler, options);
+            window.addEventListener('mousedown', this._downHandler, options);
+            window.addEventListener('mousemove', this._moveHandler, options);
+            window.addEventListener('wheel', this._wheelHandler, options);
         }
 
         if (this._useTouch && platform.touch) {
-            this._target.addEventListener('touchstart', this._touchstartHandler, opts);
+            this._target.addEventListener('touchstart', this._touchstartHandler, options);
             // Passive is not used for the touchend event because some components need to be
             // able to call preventDefault(). See notes in button/component.js for more details.
             this._target.addEventListener('touchend', this._touchendHandler, false);
@@ -465,16 +466,17 @@ class ElementInput {
         if (!this._attached) return;
         this._attached = false;
 
-        const opts = { passive: true };
+        /** @type {AddEventListenerOptions} */
+        const options = { passive: true };
         if (this._useMouse) {
-            window.removeEventListener('mouseup', this._upHandler, opts);
-            window.removeEventListener('mousedown', this._downHandler, opts);
-            window.removeEventListener('mousemove', this._moveHandler, opts);
-            window.removeEventListener('wheel', this._wheelHandler, opts);
+            window.removeEventListener('mouseup', this._upHandler, options);
+            window.removeEventListener('mousedown', this._downHandler, options);
+            window.removeEventListener('mousemove', this._moveHandler, options);
+            window.removeEventListener('wheel', this._wheelHandler, options);
         }
 
         if (this._useTouch) {
-            this._target.removeEventListener('touchstart', this._touchstartHandler, opts);
+            this._target.removeEventListener('touchstart', this._touchstartHandler, options);
             this._target.removeEventListener('touchend', this._touchendHandler, false);
             this._target.removeEventListener('touchmove', this._touchmoveHandler, false);
             this._target.removeEventListener('touchcancel', this._touchcancelHandler, false);

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -1,4 +1,3 @@
-import { platform } from '../../core/platform.js';
 import { EventHandler } from '../../core/event-handler.js';
 
 import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
@@ -156,8 +155,7 @@ class Mouse extends EventHandler {
         this._attached = true;
 
         /** @type {AddEventListenerOptions} */
-        const passiveOptions = { passive: false };
-        const options = platform.passiveEvents ? passiveOptions : false;
+        const options = { passive: false };
         window.addEventListener('mouseup', this._upHandler, options);
         window.addEventListener('mousedown', this._downHandler, options);
         window.addEventListener('mousemove', this._moveHandler, options);
@@ -173,8 +171,7 @@ class Mouse extends EventHandler {
         this._target = null;
 
         /** @type {AddEventListenerOptions} */
-        const passiveOptions = { passive: false };
-        const options = platform.passiveEvents ? passiveOptions : false;
+        const options = { passive: false };
         window.removeEventListener('mouseup', this._upHandler, options);
         window.removeEventListener('mousedown', this._downHandler, options);
         window.removeEventListener('mousemove', this._moveHandler, options);


### PR DESCRIPTION
## Description

`detectPassiveEvents()` in `platform.js` probes whether the browser supports passive event listeners — a feature that shipped in every browser (Chrome 51, Firefox 49, Safari 10) years before WebGL2, which the engine requires. The probe can never return false in any environment able to run the engine, and it relies on the legacy `addEventListener('testpassive', null, opts)` null-listener trick.

- The probe and the `platform.passiveEvents` flag are removed entirely.
- The four listener attach/detach sites (`Mouse#attach`/`detach`, `ElementInput#attach`/`detach`) pass their options objects directly instead of branching on the flag.
- `Mouse` no longer needs its `platform` import.

Why full removal rather than keeping the flag or tagging it `@deprecated`: the flag was `@ignore`'d (never documented), a GitHub-wide code search for `platform.passiveEvents` finds zero application usage (the only two matches are an engine fork's copy of these same internal call sites), and the failure mode is benign — reading the removed property yields `undefined`, so any copied ternary degrades to the boolean-capture listener form, which is valid in every browser. Nothing can crash.

Verified: lint clean; full unit suite 2337 passing with failures identical to the `main` baseline.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)