### PR TITLE
Use Geometry#calculateTangents in procedural geometry subclasses

### DIFF
--- a/src/scene/geometry/box-geometry.js
+++ b/src/scene/geometry/box-geometry.js
@@ -1,5 +1,4 @@
 import { Vec3 } from '../../core/math/vec3.js';
-import { calculateTangents } from './geometry-utils.js';
 import { Geometry } from './geometry.js';
 
 const primitiveUv1Padding = 8.0 / 64;
@@ -175,7 +174,7 @@ class BoxGeometry extends Geometry {
         this.indices = indices;
 
         if (opts.calculateTangents) {
-            this.tangents = calculateTangents(positions, normals, uvs, indices);
+            this.calculateTangents();
         }
     }
 }

--- a/src/scene/geometry/capsule-geometry.js
+++ b/src/scene/geometry/capsule-geometry.js
@@ -1,5 +1,4 @@
 import { ConeBaseGeometry } from './cone-base-geometry.js';
-import { calculateTangents } from './geometry-utils.js';
 
 /**
  * A procedural capsule-shaped geometry.
@@ -69,7 +68,7 @@ class CapsuleGeometry extends ConeBaseGeometry {
         super(radius, radius, height - 2 * radius, heightSegments, sides, true);
 
         if (opts.calculateTangents) {
-            this.tangents = calculateTangents(this.positions, this.normals, this.uvs, this.indices);
+            this.calculateTangents();
         }
     }
 }

--- a/src/scene/geometry/circle-geometry.js
+++ b/src/scene/geometry/circle-geometry.js
@@ -1,4 +1,3 @@
-import { calculateTangents } from './geometry-utils.js';
 import { Geometry } from './geometry.js';
 
 /**
@@ -119,7 +118,7 @@ class CircleGeometry extends Geometry {
         this.indices = indices;
 
         if (opts.calculateTangents) {
-            this.tangents = calculateTangents(positions, normals, uvs, indices);
+            this.calculateTangents();
         }
     }
 }

--- a/src/scene/geometry/cone-geometry.js
+++ b/src/scene/geometry/cone-geometry.js
@@ -1,5 +1,4 @@
 import { ConeBaseGeometry } from './cone-base-geometry.js';
-import { calculateTangents } from './geometry-utils.js';
 
 /**
  * A procedural cone-shaped geometry.
@@ -68,7 +67,7 @@ class ConeGeometry extends ConeBaseGeometry {
         super(baseRadius, peakRadius, height, heightSegments, capSegments, false);
 
         if (opts.calculateTangents) {
-            this.tangents = calculateTangents(this.positions, this.normals, this.uvs, this.indices);
+            this.calculateTangents();
         }
     }
 }

--- a/src/scene/geometry/cylinder-geometry.js
+++ b/src/scene/geometry/cylinder-geometry.js
@@ -1,5 +1,4 @@
 import { ConeBaseGeometry } from './cone-base-geometry.js';
-import { calculateTangents } from './geometry-utils.js';
 
 /**
  * A procedural cylinder-shaped geometry.
@@ -68,7 +67,7 @@ class CylinderGeometry extends ConeBaseGeometry {
         super(radius, radius, height, heightSegments, capSegments, false);
 
         if (opts.calculateTangents) {
-            this.tangents = calculateTangents(this.positions, this.normals, this.uvs, this.indices);
+            this.calculateTangents();
         }
     }
 }

--- a/src/scene/geometry/plane-geometry.js
+++ b/src/scene/geometry/plane-geometry.js
@@ -1,5 +1,4 @@
 import { Vec2 } from '../../core/math/vec2.js';
-import { calculateTangents } from './geometry-utils.js';
 import { Geometry } from './geometry.js';
 
 /**
@@ -108,7 +107,7 @@ class PlaneGeometry extends Geometry {
         this.indices = indices;
 
         if (opts.calculateTangents) {
-            this.tangents = calculateTangents(positions, normals, uvs, indices);
+            this.calculateTangents();
         }
     }
 }

--- a/src/scene/geometry/sphere-geometry.js
+++ b/src/scene/geometry/sphere-geometry.js
@@ -1,4 +1,3 @@
-import { calculateTangents } from './geometry-utils.js';
 import { Geometry } from './geometry.js';
 
 /**
@@ -107,7 +106,7 @@ class SphereGeometry extends Geometry {
         this.indices = indices;
 
         if (opts.calculateTangents) {
-            this.tangents = calculateTangents(positions, normals, uvs, indices);
+            this.calculateTangents();
         }
     }
 }

--- a/src/scene/geometry/torus-geometry.js
+++ b/src/scene/geometry/torus-geometry.js
@@ -1,5 +1,4 @@
 import { math } from '../../core/math/math.js';
-import { calculateTangents } from './geometry-utils.js';
 import { Geometry } from './geometry.js';
 
 /**
@@ -112,7 +111,7 @@ class TorusGeometry extends Geometry {
         this.indices = indices;
 
         if (opts.calculateTangents) {
-            this.tangents = calculateTangents(positions, normals, uvs, indices);
+            this.calculateTangents();
         }
     }
 }


### PR DESCRIPTION
## Description

All eight procedural geometry classes (`BoxGeometry`, `CircleGeometry`, `SphereGeometry`, `PlaneGeometry`, `TorusGeometry`, `CapsuleGeometry`, `ConeGeometry`, `CylinderGeometry`) inline the `calculateTangents` utility call in their constructors:

```js
if (opts.calculateTangents) {
    this.tangents = calculateTangents(positions, normals, uvs, indices);
}
```

But the base class already exposes exactly this as `Geometry#calculateTangents()`, which reads the same `positions`/`normals`/`uvs`/`indices` fields each constructor assigns immediately beforehand. Each subclass now calls the inherited method and drops its `geometry-utils.js` import:

```js
if (opts.calculateTangents) {
    this.calculateTangents();
}
```

Net −8 lines and eight fewer import bindings; the standalone `calculateTangents`/`calculateNormals` exports are unchanged. The base method's `Debug.assert` guards are satisfied at every call site (fields assigned just above, or by the `ConeBaseGeometry` super constructor) and are stripped from release builds anyway.

**Verified byte-identical output:** all eight geometries constructed with `calculateTangents: true` and non-default segment counts produce identical `positions`, `normals`, `uvs`, `uvs1`, `indices` and `tangents` streams before and after the change (SHA-256 over every stream). Lint clean; full unit suite at 2337 passing with failures identical to the `main` baseline (pre-existing jsdom resource-loading timeouts).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)