### PR TITLE
Fix 'set:outline' event reporting the text color

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -2084,7 +2084,7 @@ class TextElement {
         }
 
         if (this._element) {
-            this._element.fire('set:outline', this._color);
+            this._element.fire('set:outline', this._outlineColor);
         }
     }
 


### PR DESCRIPTION
## Description

The `outlineColor` setter fired `set:outline` with `this._color` (the text color) instead of `this._outlineColor`, so listeners received the wrong value. One-line fix, mirroring what `set:color` fires.

Fixes #9254

Verified: lint clean; unit suite at the `main` baseline (2337 passing).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)