### PR TITLE
Fix _updateMaterialShadow checking the outline symbol params

### DIFF
--- a/src/framework/components/element/text-element.js
+++ b/src/framework/components/element/text-element.js
@@ -821,7 +821,7 @@ class TextElement {
     }
 
     _updateMaterialShadow() {
-        if (this._symbolOutlineParams) {
+        if (this._symbolShadowParams) {
             // when per-vertex shadow is present, disable material shadow uniforms
             this._shadowColorUniform[0] = 0;
             this._shadowColorUniform[1] = 0;


### PR DESCRIPTION
## Description

`_updateMaterialShadow` tested `this._symbolOutlineParams` where it means `this._symbolShadowParams` (copy-paste from `_updateMaterialOutline` — its own comment says "when per-vertex shadow is present"). With a font that has one set of per-symbol params but not the other, the material shadow uniforms were driven by the wrong flag. One-line fix.

Fixes #9255

Verified: lint clean; unit suite at the `main` baseline (2337 passing).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)