### PR TITLE
Remove WebGL1-era POT checks from texture mipmap upload and gpuSize

### DIFF
--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -959,7 +959,7 @@ class Texture {
     }
 
     get gpuSize() {
-        const mips = this.pot && this._mipmaps && !(this._compressed && this._levels.length === 1);
+        const mips = this._mipmaps && !(this._compressed && this._levels.length === 1);
         return TextureUtils.calcGpuSize(this._width, this._height, this._depth, this._format, mips, this._cubemap) * this._samples;
     }
 

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -478,7 +478,7 @@ class WebglTexture {
         Debug.assert(texture.device, 'Attempting to use a texture that has been destroyed.', texture);
         const gl = device.gl;
 
-        if (!texture._needsUpload && ((texture._needsMipmapsUpload && texture._mipmapsUploaded) || !texture.pot)) {
+        if (!texture._needsUpload && texture._needsMipmapsUpload && texture._mipmapsUploaded) {
             return;
         }
 


### PR DESCRIPTION
## Description

WebGL1 forbade mipmaps on NPOT textures; WebGL2 (the engine's minimum) does not. Two leftovers of that restriction:

- `WebglTexture#upload` early-returned any mipmap-only upload for NPOT textures (`|| !texture.pot`), so e.g. enabling `mipmaps` after creation silently did nothing for NPOT. The redundant-upload guard (`_needsMipmapsUpload && _mipmapsUploaded`) is kept.
- `Texture#gpuSize` excluded mip memory for NPOT mipmapped textures, under-reporting VRAM stats.

These were the only two consumers of `Texture#pot`, which remains as public API.

Behavioural note: NPOT textures with `mipmaps: true` that previously skipped mip regeneration will now generate them (correct filtering, slightly more VRAM — as WebGPU already behaves).

Fixes #9256

Verified: lint clean; unit suite at the `main` baseline (2337 passing).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)