### PR TITLE
Use textureFloatFilterable for VSM_32F shadow filtering

### DIFF
--- a/src/scene/renderer/shadow-map.js
+++ b/src/scene/renderer/shadow-map.js
@@ -88,7 +88,7 @@ class ShadowMap {
 
         let filter = FILTER_LINEAR;
         if (shadowType === SHADOW_VSM_32F) {
-            filter = device.extTextureFloatLinear ? FILTER_LINEAR : FILTER_NEAREST;
+            filter = device.textureFloatFilterable ? FILTER_LINEAR : FILTER_NEAREST;
         }
         if (shadowType === SHADOW_PCSS_32F) {
             // we're sampling and comparing depth, so need nearest filtering


### PR DESCRIPTION
## Description

`ShadowMap` picked the VSM32 filter from `device.extTextureFloatLinear` — a raw WebGL extension object that is undefined on WebGPU — so VSM32 shadows were silently sampled with nearest filtering there, even though `light.js` approves `SHADOW_VSM_32F` based on the portable `device.textureFloatFilterable` flag. This switches to the same flag. On WebGL the behaviour is identical, since `textureFloatFilterable` is derived directly from that extension.

Fixes #9257

Verified: lint clean; unit suite at the `main` baseline (2337 passing).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)