### PR TITLE
Remove dead supportsStencil assignment in initializeCapabilities

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -954,7 +954,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         const contextAttribs = gl.getContextAttributes();
         this.supportsMsaa = contextAttribs?.antialias ?? false;
-        this.supportsStencil = contextAttribs?.stencil ?? false;
 
         // Query parameter values from the WebGL context
         this.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);


### PR DESCRIPTION
## Description

`initializeCapabilities()` set `supportsStencil` from `gl.getContextAttributes()`, but the constructor calls `createBackbuffer()` immediately afterwards, which unconditionally overwrites it with `initOptions.stencil` — so the queried value was always discarded. The requested-options convention is deliberate: the WebGPU backend sets `supportsStencil` the same way, and all readers (backbuffer, post-effect queue, depth-grab pass) use it to decide render-target stencil allocation. This removes the one dead assignment; no behaviour change.

The adjacent `supportsMsaa` is write-only inside the engine, but it dates to 2016 and ships typed in `playcanvas.d.ts`, so it is kept as app-readable surface — that resolves the other half of the issue.

Fixes #9258

Verified: lint clean; unit suite at the `main` baseline (2337 passing).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)