### PR TITLE
Anchor the AppleWebKit 15.4 antialias workaround UA match

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -202,7 +202,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         // #4136 - turn off antialiasing on AppleWebKit browsers 15.4
         const ua = (typeof navigator !== 'undefined') && navigator.userAgent;
-        this.forceDisableMultisampling = ua && ua.includes('AppleWebKit') && (ua.includes('15.4') || ua.includes('15_4'));
+        this.forceDisableMultisampling = ua && ua.includes('AppleWebKit') && (ua.includes('Version/15.4') || ua.includes('OS 15_4'));
         if (this.forceDisableMultisampling) {
             options.antialias = false;
             Debug.log('Antialiasing has been turned off due to rendering issues on AppleWebKit 15.4');


### PR DESCRIPTION
## Description

The #4136 workaround matched `'15.4'` anywhere in the UA, and every Chromium UA contains `'AppleWebKit'`, so any unrelated `15.4` token (a Chrome build number, an OS patch version) could force-disable antialiasing on a non-Safari browser. The match is now anchored to `Version/15.4` and `OS 15_4`, which still covers desktop Safari 15.4/15.4.1 and all iOS 15.4 WebKit browsers (including CriOS/FxiOS).

Checked against eight real UA strings: the four affected Safari/WebKit 15.4 variants still trigger; Chrome 115.4.x builds and macOS Catalina (`10_15_4`) no longer false-positive.

Fixes #9259

Verified: lint clean; unit suite at the `main` baseline (2337 passing).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)