### PR TITLE
Add a LOD mode and a per-splat detail falloff for streamed GSplats

### DIFF
--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.jsx
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.jsx
@@ -219,6 +219,28 @@ export function Controls({ observer }) {
                         ]}
                     />
                 </LabelGroup>
+                <LabelGroup text='LOD Mode'>
+                    <SelectInput
+                        type='string'
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'lodMode' }}
+                        value={observer.get('lodMode') || 'error'}
+                        options={[
+                            { v: 'error', t: 'Error' },
+                            { v: 'distance', t: 'Distance' }
+                        ]}
+                    />
+                </LabelGroup>
+                <LabelGroup text='LOD Falloff'>
+                    <SliderInput
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'lodFalloff' }}
+                        min={0}
+                        max={8}
+                        precision={2}
+                        step={0.01}
+                    />
+                </LabelGroup>
                 <LabelGroup text='Splat Budget'>
                     <SliderInput
                         binding={new BindingTwoWay()}

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -26,6 +26,7 @@ import {
     GSPLATDATA_COMPACT,
     GSPLATDATA_LARGE,
     GSPLAT_DEBUG_NONE,
+    GSPLAT_LODMODE_ERROR,
     GSPLAT_RENDERER_AUTO,
     GSplatComponentSystem,
     GSplatHandler,
@@ -261,6 +262,8 @@ data.set('culling', device.isWebGPU);
 data.set('compact', true);
 data.set('debug', GSPLAT_DEBUG_NONE);
 data.set('lodPreset', platform.mobile ? 'mobile' : 'desktop');
+data.set('lodMode', GSPLAT_LODMODE_ERROR);
+data.set('lodFalloff', 1);
 data.set('splatBudget', platform.mobile ? 1 : 4);
 data.set('environment', 'none');
 data.set('fogDensity', 0);
@@ -495,6 +498,7 @@ const loadGSplat = async (/** @type {string|null} */ url) => {
     gsplatEntity.setLocalScale(1, 1, 1);
     app.root.addChild(gsplatEntity);
     gsplatGs = /** @type {any} */ (gsplatEntity.gsplat);
+    gsplatGs.lodFalloff = data.get('lodFalloff');
 
     // Start with lowest LOD for fast initial display, then stream up
     const lodLevels = gsplatGs.resource?.octree?.lodLevels;
@@ -535,6 +539,16 @@ const loadGSplat = async (/** @type {string|null} */ url) => {
 await loadGSplat(data.get('url') || null);
 
 data.on('lodPreset:set', applyPreset);
+
+data.on('lodMode:set', () => {
+    app.scene.gsplat.lodMode = data.get('lodMode');
+});
+
+data.on('lodFalloff:set', () => {
+    if (gsplatGs) {
+        gsplatGs.lodFalloff = data.get('lodFalloff');
+    }
+});
 
 const applySplatBudget = () => {
     const millions = data.get('splatBudget');

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1443,6 +1443,7 @@ class AppBase extends EventHandler {
      * @param {number} [settings.render.gsplatLodBehindPenalty] - Multiplier applied to effective distance for gsplat nodes behind the camera. Defaults to 1.
      * @param {number} [settings.render.gsplatLodUnderfillLimit] - Maximum number of gsplat LOD levels allowed below the optimal level when optimal data is not resident. Defaults to 0.
      * @param {number} [settings.render.gsplatSplatBudget] - Target number of splats across all GSplats in the scene. LOD levels are chosen globally to stay within it; a non-positive value is not a way to disable this and the default is used instead. Defaults to 1000000.
+     * @param {string} [settings.render.gsplatLodMode] - How LOD levels are chosen for streamed GSplats: 'error' (default) spends the budget by measured approximation error, 'distance' guarantees a coarser-with-distance progression and ignores error metadata.
      * @param {number} [settings.render.gsplatAlphaClip] - Alpha threshold for gsplat shadow, pick, and prepass rendering. Defaults to 0.3.
      * @param {number} [settings.render.gsplatAlphaClipForward] - Alpha threshold for the forward gsplat rendering pass. Defaults to 1 / 255.
      * @param {number} [settings.render.gsplatMinPixelSize] - Minimum screen-space pixel size below which splats are discarded. Defaults to 2.

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1443,7 +1443,7 @@ class AppBase extends EventHandler {
      * @param {number} [settings.render.gsplatLodBehindPenalty] - Multiplier applied to effective distance for gsplat nodes behind the camera. Defaults to 1.
      * @param {number} [settings.render.gsplatLodUnderfillLimit] - Maximum number of gsplat LOD levels allowed below the optimal level when optimal data is not resident. Defaults to 0.
      * @param {number} [settings.render.gsplatSplatBudget] - Target number of splats across all GSplats in the scene. LOD levels are chosen globally to stay within it; a non-positive value is not a way to disable this and the default is used instead. Defaults to 1000000.
-     * @param {string} [settings.render.gsplatLodMode] - How LOD levels are chosen for streamed GSplats: 'error' (default) spends the budget by measured approximation error, 'distance' guarantees a coarser-with-distance progression and ignores error metadata.
+     * @param {string} [settings.render.gsplatLodMode] - How LOD levels are chosen for streamed GSplats: 'error' (default) spends the budget by measured approximation error, 'distance' orders detail by camera distance alone and ignores error metadata.
      * @param {number} [settings.render.gsplatAlphaClip] - Alpha threshold for gsplat shadow, pick, and prepass rendering. Defaults to 0.3.
      * @param {number} [settings.render.gsplatAlphaClipForward] - Alpha threshold for the forward gsplat rendering pass. Defaults to 1 / 255.
      * @param {number} [settings.render.gsplatMinPixelSize] - Minimum screen-space pixel size below which splats are discarded. Defaults to 2.

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -381,9 +381,9 @@ class GSplatComponent extends Component {
      * Sets how quickly this splat's level of detail drops with distance from the camera. The
      * default of 1 gives a balanced falloff. Higher values concentrate detail near the camera at
      * the cost of the far field, while values towards 0 spread it evenly across the scene
-     * regardless of the view. This redistributes the detail this splat receives from the global
-     * {@link GSplatParams#splatBudget} without changing its overall share of it. Clamped to
-     * [0, 8].
+     * regardless of the view. This primarily redistributes the detail this splat receives from
+     * the global {@link GSplatParams#splatBudget} between its near and far field, though it can
+     * also shift how the budget divides between splats. Clamped to [0, 8].
      *
      * @type {number}
      */

--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -98,6 +98,13 @@ class GSplatComponent extends Component {
     _materialTmp = null;
 
     /**
+     * How fast quality falls off away from the camera, exponent on projected coverage.
+     *
+     * @private
+     */
+    _lodFalloff = 1;
+
+    /**
      * Minimum allowed LOD index (inclusive).
      *
      * @private
@@ -368,6 +375,32 @@ class GSplatComponent extends Component {
      */
     get castShadows() {
         return this._castShadows;
+    }
+
+    /**
+     * Sets how quickly this splat's level of detail drops with distance from the camera. The
+     * default of 1 gives a balanced falloff. Higher values concentrate detail near the camera at
+     * the cost of the far field, while values towards 0 spread it evenly across the scene
+     * regardless of the view. This redistributes the detail this splat receives from the global
+     * {@link GSplatParams#splatBudget} without changing its overall share of it. Clamped to
+     * [0, 8].
+     *
+     * @type {number}
+     */
+    set lodFalloff(value) {
+        this._lodFalloff = Math.min(Math.max(value, 0), 8);
+        if (this._placement) {
+            this._placement.lodFalloff = this._lodFalloff;
+        }
+    }
+
+    /**
+     * Gets how quickly this splat's level of detail drops with distance from the camera.
+     *
+     * @type {number}
+     */
+    get lodFalloff() {
+        return this._lodFalloff;
     }
 
     /**
@@ -977,6 +1010,7 @@ class GSplatComponent extends Component {
             this._placement = null;
 
             this._placement = new GSplatPlacement(resource, this.entity, 0, this._parameters, null, this._id);
+            this._placement.lodFalloff = this._lodFalloff;
             this._placement.lodRangeMin = this._lodRangeMin;
             this._placement.lodRangeMax = this._lodRangeMax;
             this._placement.workBufferUpdate = this._workBufferUpdate;

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -26,6 +26,7 @@ Debug.call(() => {
 // order matters here
 const _properties = [
     'unified',
+    'lodFalloff',
     'lodRangeMin',
     'lodRangeMax',
     'castShadows',

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1287,6 +1287,25 @@ export const GSPLAT_RENDERER_COMPUTE = 3;
  * @type {number}
  * @category Graphics
  */
+/**
+ * LOD selection driven by per-level approximation errors: the splat budget is spent where it
+ * removes the most error per splat, using the manifest's error tables when present and errors
+ * derived from splat counts otherwise. The default.
+ *
+ * @category Graphics
+ */
+export const GSPLAT_LODMODE_ERROR = 'error';
+
+/**
+ * LOD selection with a guaranteed coarser-with-distance progression: detail steps down in
+ * concentric distance bands around the camera, with the band edges adapting to the splat budget.
+ * Any error metadata in the asset is ignored. Useful when a capture's quality makes its error
+ * tables unreliable.
+ *
+ * @category Graphics
+ */
+export const GSPLAT_LODMODE_DISTANCE = 'distance';
+
 export const GSPLAT_DEBUG_NONE = 0;
 
 /**

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1291,10 +1291,9 @@ export const GSPLAT_RENDERER_COMPUTE = 3;
 export const GSPLAT_LODMODE_ERROR = 'error';
 
 /**
- * LOD selection with a guaranteed coarser-with-distance progression: detail steps down in
- * concentric distance bands around the camera, with the band edges adapting to the splat budget.
- * Any error metadata in the asset is ignored. Useful when a capture's quality makes its error
- * tables unreliable.
+ * LOD selection ordered by camera distance alone: detail steps down in concentric distance bands
+ * around the camera, with the band edges adapting to the splat budget. Any error metadata in the
+ * asset is ignored. Useful when a capture's quality makes its error tables unreliable.
  *
  * @category Graphics
  */

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1282,12 +1282,6 @@ export const GSPLAT_RENDERER_RASTER_GPU_SORT = 2;
 export const GSPLAT_RENDERER_COMPUTE = 3;
 
 /**
- * No debug rendering for Gaussian splats. Normal rendering mode.
- *
- * @type {number}
- * @category Graphics
- */
-/**
  * LOD selection driven by per-level approximation errors: the splat budget is spent where it
  * removes the most error per splat, using the manifest's error tables when present and errors
  * derived from splat counts otherwise. The default.
@@ -1306,6 +1300,12 @@ export const GSPLAT_LODMODE_ERROR = 'error';
  */
 export const GSPLAT_LODMODE_DISTANCE = 'distance';
 
+/**
+ * No debug rendering for Gaussian splats. Normal rendering mode.
+ *
+ * @type {number}
+ * @category Graphics
+ */
 export const GSPLAT_DEBUG_NONE = 0;
 
 /**

--- a/src/scene/gsplat-unified/gsplat-budget-balancer.js
+++ b/src/scene/gsplat-unified/gsplat-budget-balancer.js
@@ -33,6 +33,18 @@ const KEY_LO = keyOf(1e-24);
 const KEY_HI = keyOf(1e3);
 const KEY_SCALE = (NUM_VALUE_BUCKETS - 1) / (KEY_HI - KEY_LO);
 
+// The bit key of 1.0 - log2 of 0 in key units. Subtracted when adding two keys, since each
+// carries the exponent bias once.
+const KEY_ONE = keyOf(1);
+
+// GSplatPlacement#lodFalloff is an exponent on coverage. It is applied in key space - the bit key
+// is piecewise-linear in log2, so cov^falloff becomes one multiply instead of a Math.pow per node,
+// at a cost of at most a bucket or two of quantisation. The exponent pivots around a mid-field
+// coverage (a node roughly a hundred radii away) rather than around 1: at the pivot the value is
+// unchanged by falloff, so the slider tilts a placement's budget between its near and far field
+// instead of deflating the whole placement against other instances.
+const KEY_PIVOT = keyOf(1e-4);
+
 /**
  * Distributes a splat budget across octree instances by choosing a LOD level per node.
  *
@@ -89,6 +101,15 @@ class GSplatBudgetBalancer {
     _coverage = new Float32Array(0);
 
     /**
+     * Per node, the falloff-scaled bit key of its coverage, used instead of {@link _coverage} when
+     * any instance has a non-default lodFalloff. See KEY_PIVOT.
+     *
+     * @type {Float64Array}
+     * @private
+     */
+    _coverageKey = new Float64Array(0);
+
+    /**
      * Which instance owns each global node index.
      *
      * @type {Uint16Array}
@@ -120,6 +141,7 @@ class GSplatBudgetBalancer {
         this._next = new Int32Array(size);
         this._pending = new Int32Array(size);
         this._coverage = new Float32Array(size);
+        this._coverageKey = new Float64Array(size);
         this._instanceOf = new Uint16Array(size);
     }
 
@@ -133,6 +155,19 @@ class GSplatBudgetBalancer {
      */
     _bucketOf(value) {
         const bucket = ((keyOf(value) - KEY_LO) * KEY_SCALE) | 0;
+        return bucket < 0 ? 0 : (bucket >= NUM_VALUE_BUCKETS ? NUM_VALUE_BUCKETS - 1 : bucket);
+    }
+
+    /**
+     * Maps a value already expressed as a bit key - the sum of a falloff-scaled coverage key and a
+     * ratio key - to a bucket.
+     *
+     * @param {number} key - Bit-key of the value.
+     * @returns {number} Bucket index.
+     * @private
+     */
+    _bucketOfKey(key) {
+        const bucket = ((key - KEY_LO) * KEY_SCALE) | 0;
         return bucket < 0 ? 0 : (bucket >= NUM_VALUE_BUCKETS ? NUM_VALUE_BUCKETS - 1 : bucket);
     }
 
@@ -170,6 +205,10 @@ class GSplatBudgetBalancer {
         let nodeTotal = 0;
         let totalStartCount = 0;
         let totalFinestCount = 0;
+        // With every instance at the default falloff the exact value path is used, bit-identical
+        // to ranking without the feature; any non-default falloff switches all ranking to the
+        // key-space path, where the exponent is a multiply. See KEY_PIVOT.
+        let useKeys = false;
         for (const [, inst] of octreeInstances) {
             // resolveLodRange() already built this for the instance's range; resolving it again
             // here would rebuild whenever two instances of one octree differ in range
@@ -180,6 +219,7 @@ class GSplatBudgetBalancer {
             nodeTotal += inst.octree.nodes.length;
             totalStartCount += table.totalStartCount;
             totalFinestCount += table.totalFinestCount;
+            if (inst.placement.lodFalloff !== 1) useKeys = true;
         }
         if (instances.length === 0) return;
 
@@ -199,6 +239,7 @@ class GSplatBudgetBalancer {
         const next = this._next;
         const pending = this._pending;
         const coverage = this._coverage;
+        const coverageKey = this._coverageKey;
         const instanceOf = this._instanceOf;
 
         // Seed pass: floor every node and queue its first upgrade.
@@ -208,6 +249,7 @@ class GSplatBudgetBalancer {
             const nodeInfos = inst.nodeInfos;
             const base = bases[i];
             const { startLod, firstUpgrade, upgradeRatio } = table;
+            const falloff = inst.placement.lodFalloff;
 
             for (let n = 0, len = nodeInfos.length; n < len; n++) {
                 const nodeInfo = nodeInfos[n];
@@ -223,7 +265,12 @@ class GSplatBudgetBalancer {
                 coverage[g] = cov;
                 instanceOf[g] = i;
                 pending[g] = first;
-                this._push(this._bucketOf(cov * upgradeRatio[first]), g);
+                if (useKeys) {
+                    coverageKey[g] = falloff * (keyOf(cov) - KEY_PIVOT) + KEY_PIVOT;
+                    this._push(this._bucketOfKey(coverageKey[g] + keyOf(upgradeRatio[first]) - KEY_ONE), g);
+                } else {
+                    this._push(this._bucketOf(cov * upgradeRatio[first]), g);
+                }
             }
         }
 
@@ -259,7 +306,9 @@ class GSplatBudgetBalancer {
                     // above the sweep would be dropped on every update, not merely delayed, and
                     // could never finish the run it started. Requeueing it here instead completes
                     // the run in this sweep, at the priority of the step that opened it.
-                    const target = this._bucketOf(coverage[g] * table.upgradeRatio[k2]);
+                    const target = useKeys ?
+                        this._bucketOfKey(coverageKey[g] + keyOf(table.upgradeRatio[k2]) - KEY_ONE) :
+                        this._bucketOf(coverage[g] * table.upgradeRatio[k2]);
                     this._push(target > bucket ? bucket : target, g);
                 }
                 g = this._bucketHead[bucket];

--- a/src/scene/gsplat-unified/gsplat-lod-table.js
+++ b/src/scene/gsplat-unified/gsplat-lod-table.js
@@ -1,6 +1,14 @@
+import { GSPLAT_LODMODE_DISTANCE, GSPLAT_LODMODE_ERROR } from '../constants.js';
+
 /**
  * @import { GSplatOctree } from './gsplat-octree.js'
  */
+
+// Band spacing for GSPLAT_LODMODE_DISTANCE. A step to absolute level i is priced at
+// M^(2 * (i - 1)) error per splat, so node content cancels out of the ranking and a node of a
+// given size steps down one level per xM^(1/lodFalloff) of distance, with the band edges set by
+// the budget. 3 matches the multiplier the old distance-band system defaulted to.
+const DISTANCE_BAND_MULTIPLIER = 3;
 
 /**
  * Everything the budget allocator can know about an octree before it sees a camera, precomputed
@@ -25,6 +33,12 @@
  * {@link GSplatLodTable#upgradeRatio} holds the fixed part and selection costs one multiply per
  * upgrade.
  *
+ * In {@link GSPLAT_LODMODE_DISTANCE} the node's error metadata is deliberately ignored and a
+ * synthetic table is used instead, shaped so that error-per-splat is a per-level constant across
+ * all nodes. Content then cancels out of the ranking entirely and selection degenerates to
+ * distance bands: every node steps coarser at fixed distance ratios, which is the guarantee that
+ * mode exists to provide.
+ *
  * @ignore
  */
 class GSplatLodTable {
@@ -41,6 +55,14 @@ class GSplatLodTable {
      * @type {number}
      */
     rangeMax;
+
+    /**
+     * The LOD selection mode this table was built for - GSPLAT_LODMODE_ERROR or
+     * GSPLAT_LODMODE_DISTANCE. Part of the octree's cache identity alongside the range.
+     *
+     * @type {string}
+     */
+    lodMode;
 
     /**
      * How many octree instances currently hold this table. Managed by the owning
@@ -123,10 +145,12 @@ class GSplatLodTable {
      * @param {GSplatOctree} octree - The octree to build the table for.
      * @param {number} rangeMin - Finest allowed LOD index.
      * @param {number} rangeMax - Coarsest allowed LOD index.
+     * @param {string} [lodMode] - GSPLAT_LODMODE_ERROR (default) or GSPLAT_LODMODE_DISTANCE.
      */
-    constructor(octree, rangeMin, rangeMax) {
+    constructor(octree, rangeMin, rangeMax, lodMode = GSPLAT_LODMODE_ERROR) {
         this.rangeMin = rangeMin;
         this.rangeMax = rangeMax;
+        this.lodMode = lodMode;
 
         const nodes = octree.nodes;
         const nodeCount = nodes.length;
@@ -145,6 +169,16 @@ class GSplatLodTable {
         // Reused per node: the candidate levels, then the frontier compacted in place over them.
         const scratch = new Int16Array(spanLength);
 
+        // The error each level is judged by, indexed by absolute LOD. In error mode this mirrors
+        // the node's own table; in distance mode it is synthesized per node so that every step's
+        // error-per-splat is the per-level band weight, making the ranking content-free.
+        const distanceMode = lodMode === GSPLAT_LODMODE_DISTANCE;
+        const err = new Float64Array(rangeMax + 1);
+        const bandWeight = new Float64Array(rangeMax + 1);
+        for (let lod = 1; lod <= rangeMax; lod++) {
+            bandWeight[lod] = Math.pow(DISTANCE_BAND_MULTIPLIER, 2 * (lod - 1));
+        }
+
         let upgradeCount = 0;
         let totalStartCount = 0;
         let totalFinestCount = 0;
@@ -152,6 +186,23 @@ class GSplatLodTable {
         for (let n = 0; n < nodeCount; n++) {
             const lods = nodes[n].lods;
             this.firstUpgrade[n] = upgradeCount;
+
+            if (distanceMode) {
+                let finerCount = -1;
+                let e = 0;
+                for (let lod = rangeMin; lod <= rangeMax; lod++) {
+                    if (lods[lod].count <= 0) continue;
+                    if (finerCount >= 0) {
+                        e += Math.max(finerCount - lods[lod].count, 1) * bandWeight[lod];
+                    }
+                    err[lod] = e;
+                    finerCount = lods[lod].count;
+                }
+            } else {
+                for (let lod = rangeMin; lod <= rangeMax; lod++) {
+                    err[lod] = lods[lod].error;
+                }
+            }
 
             // Collect renderable levels in range, ordered by ascending cost and then ascending
             // error. Insertion sort: the list is at most spanLength long and, since coarser levels
@@ -163,7 +214,7 @@ class GSplatLodTable {
                 while (j > 0) {
                     const prev = scratch[j - 1];
                     if (lods[prev].count < lods[lod].count ||
-                        (lods[prev].count === lods[lod].count && lods[prev].error <= lods[lod].error)) {
+                        (lods[prev].count === lods[lod].count && err[prev] <= err[lod])) {
                         break;
                     }
                     scratch[j] = prev;
@@ -178,8 +229,8 @@ class GSplatLodTable {
             let bestError = Infinity;
             for (let i = 0; i < candidateCount; i++) {
                 const lod = scratch[i];
-                if (lods[lod].error < bestError) {
-                    bestError = lods[lod].error;
+                if (err[lod] < bestError) {
+                    bestError = err[lod];
                     scratch[frontierCount++] = lod;
                 }
             }
@@ -210,7 +261,7 @@ class GSplatLodTable {
                 let ratio = 0;
                 for (let j = i; j < frontierCount; j++) {
                     const reach = scratch[j];
-                    const r = (lods[coarseLod].error - lods[reach].error) /
+                    const r = (err[coarseLod] - err[reach]) /
                               (lods[reach].count - lods[coarseLod].count);
                     if (r > ratio) ratio = r;
                 }

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -7,7 +7,7 @@ import { BoundingBox } from '../../core/shape/bounding-box.js';
 import { Color } from '../../core/math/color.js';
 import { GSplatPlacement } from './gsplat-placement.js';
 import { GsplatAllocId } from './gsplat-alloc-id.js';
-import { GSPLAT_DEBUG_NODE_AABBS, PROJECTION_ORTHOGRAPHIC } from '../constants.js';
+import { GSPLAT_DEBUG_NODE_AABBS, GSPLAT_LODMODE_DISTANCE, PROJECTION_ORTHOGRAPHIC } from '../constants.js';
 
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
@@ -464,8 +464,10 @@ class GSplatOctreeInstance {
      * Resolves the configured LOD range against the octree and caches the selection table for it.
      * Called before {@link GSplatOctreeInstance#evaluateNodeCoverage} so both that and the budget
      * allocator see the same range.
+     *
+     * @param {string} lodMode - The scene's LOD selection mode, part of the table's identity.
      */
-    resolveLodRange() {
+    resolveLodRange(lodMode) {
         const maxLod = this.octree.lodLevels - 1;
         const { lodRangeMin, lodRangeMax } = this.placement;
         const rangeMin = Math.max(0, Math.min(lodRangeMin ?? 0, maxLod));
@@ -473,11 +475,11 @@ class GSplatOctreeInstance {
         this.rangeMin = rangeMin;
         this.rangeMax = rangeMax;
 
-        // Hold a reference only while this instance is on that range, so a table is built once per
-        // live range and dropped when the last instance moves off it.
+        // Hold a reference only while this instance is on that range and mode, so a table is built
+        // once per live combination and dropped when the last instance moves off it.
         const table = this.lodTable;
-        if (!table || table.rangeMin !== rangeMin || table.rangeMax !== rangeMax) {
-            this.lodTable = this.octree.acquireLodTable(rangeMin, rangeMax);
+        if (!table || table.rangeMin !== rangeMin || table.rangeMax !== rangeMax || table.lodMode !== lodMode) {
+            this.lodTable = this.octree.acquireLodTable(rangeMin, rangeMax, lodMode);
             this.octree.releaseLodTable(table);
         }
     }
@@ -493,11 +495,20 @@ class GSplatOctreeInstance {
      * against the ortho window, mirroring Camera#getScreenSize. The behind-camera penalty applies
      * in both. Coverage is the only route by which camera position influences LOD.
      *
+     * In distance LOD mode the node's size is factored out instead: coverage is the inverse square
+     * of the world distance under both projections, so equal-distance nodes always rank equally and
+     * the selection forms clean concentric bands, matching what that mode promises. This is also
+     * what gives an orthographic camera a distance ordering at all - its footprint carries no depth
+     * term to rank by.
+     *
      * @param {GraphNode} cameraNode - The camera node.
      * @param {import('./gsplat-params.js').GSplatParams} params - Global gsplat parameters.
      */
     evaluateNodeCoverage(cameraNode, params) {
         const { lodBehindPenalty } = params;
+
+        // resolveLodRange has run just before this, so the table always reflects the current mode
+        const distanceMode = this.lodTable.lodMode === GSPLAT_LODMODE_DISTANCE;
 
         // Uniform scale of the octree transform, for world-space distance conversion.
         const uniformScale = this.placement.node.getWorldTransform().getScale().x;
@@ -594,7 +605,17 @@ class GSplatOctreeInstance {
             // special-case.
             const radius = nodes[nodeIndex].boundingSphere.w;
             let coverage;
-            if (ortho) {
+            if (distanceMode) {
+                // Inverse-square world distance, both projections: node size is deliberately not a
+                // factor, so equal-distance nodes rank equally whatever leaf sizes the octree cut
+                // produced and the selection forms clean concentric bands. The scale converts the
+                // octree-local distance to world units so differently scaled placements stay
+                // comparable under the shared budget; the behind penalty and FOV compensation
+                // arrive through fovAdjustedDistance. The floor is a constant, not the node radius,
+                // as a per-node guard would put size back into the ranking near the camera.
+                const worldDist = Math.max(fovAdjustedDistance * uniformScale, 1e-6);
+                coverage = 1 / (worldDist * worldDist);
+            } else if (ortho) {
                 // No distance attenuation: the footprint is the radius against the ortho window,
                 // clamped to a full-window 1 as the perspective ratio is bounded by 1. The behind
                 // penalty divides squared, matching how a penalized distance scales the far-field

--- a/src/scene/gsplat-unified/gsplat-octree.js
+++ b/src/scene/gsplat-unified/gsplat-octree.js
@@ -1,5 +1,6 @@
 import { GSplatOctreeNode } from './gsplat-octree-node.js';
 import { GSplatLodTable } from './gsplat-lod-table.js';
+import { GSPLAT_LODMODE_ERROR } from '../constants.js';
 import { path } from '../../core/path.js';
 import { Debug } from '../../core/debug.js';
 import { Tracing } from '../../core/tracing.js';
@@ -347,16 +348,17 @@ class GSplatOctree {
      *
      * @param {number} rangeMin - Finest allowed LOD index.
      * @param {number} rangeMax - Coarsest allowed LOD index.
+     * @param {string} [lodMode] - GSPLAT_LODMODE_ERROR (default) or GSPLAT_LODMODE_DISTANCE.
      * @returns {GSplatLodTable} The selection table, with its reference count incremented.
      */
-    acquireLodTable(rangeMin, rangeMax) {
+    acquireLodTable(rangeMin, rangeMax, lodMode = GSPLAT_LODMODE_ERROR) {
         // A string key rather than packed arithmetic: nothing bounds lodLevels or the configured
         // range, and a packed key would alias pairs once rangeMax passes the pack base, silently
         // handing an instance a table for the wrong range.
-        const key = `${rangeMin},${rangeMax}`;
+        const key = `${rangeMin},${rangeMax},${lodMode}`;
         let table = this._lodTables.get(key);
         if (!table) {
-            table = new GSplatLodTable(this, rangeMin, rangeMax);
+            table = new GSplatLodTable(this, rangeMin, rangeMax, lodMode);
             this._lodTables.set(key, table);
         }
         table.refCount++;
@@ -374,7 +376,7 @@ class GSplatOctree {
         if (!table) return;
         Debug.assert(table.refCount > 0, `GSplatOctree: releasing a LOD table for range [${table.rangeMin}, ${table.rangeMax}] that holds no references.`);
         if (--table.refCount <= 0) {
-            this._lodTables.delete(`${table.rangeMin},${table.rangeMax}`);
+            this._lodTables.delete(`${table.rangeMin},${table.rangeMax},${table.lodMode}`);
         }
     }
 

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -506,9 +506,9 @@ class GSplatParams {
      * How LOD levels are chosen for streamed GSplats, within {@link GSplatParams#splatBudget}.
      * {@link GSPLAT_LODMODE_ERROR} (default) spends the budget where it removes the most
      * approximation error per splat. {@link GSPLAT_LODMODE_DISTANCE} ignores error metadata and
-     * guarantees a coarser-with-distance progression instead - detail steps down in concentric
-     * distance bands around the camera, with band edges adapting to the budget. Useful when a
-     * capture's quality makes its error tables unreliable.
+     * orders detail by camera distance alone instead - it steps down in concentric distance bands
+     * around the camera, with band edges adapting to the budget. Useful when a capture's quality
+     * makes its error tables unreliable.
      *
      * @type {string}
      */

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -11,7 +11,9 @@ import {
     GSPLAT_RENDERER_AUTO, GSPLAT_RENDERER_RASTER_CPU_SORT,
     GSPLAT_RENDERER_COMPUTE, GSPLAT_RENDERER_RASTER_GPU_SORT,
     GSPLAT_DEBUG_NONE, GSPLAT_DEBUG_LOD, GSPLAT_DEBUG_SH_UPDATE, GSPLAT_DEBUG_HEATMAP,
-    GSPLAT_DEBUG_AABBS, GSPLAT_DEBUG_NODE_AABBS
+    GSPLAT_DEBUG_AABBS, GSPLAT_DEBUG_NODE_AABBS,
+    GSPLAT_LODMODE_DISTANCE,
+    GSPLAT_LODMODE_ERROR
 } from '../constants.js';
 
 import glslCompactRead from '../shader-lib/glsl/chunks/gsplat/vert/formats/containerCompactRead.js';
@@ -497,6 +499,39 @@ class GSplatParams {
         return this._splatBudget;
     }
 
+    /** @private */
+    _lodMode = GSPLAT_LODMODE_ERROR;
+
+    /**
+     * How LOD levels are chosen for streamed GSplats, within {@link GSplatParams#splatBudget}.
+     * {@link GSPLAT_LODMODE_ERROR} (default) spends the budget where it removes the most
+     * approximation error per splat. {@link GSPLAT_LODMODE_DISTANCE} ignores error metadata and
+     * guarantees a coarser-with-distance progression instead - detail steps down in concentric
+     * distance bands around the camera, with band edges adapting to the budget. Useful when a
+     * capture's quality makes its error tables unreliable.
+     *
+     * @type {string}
+     */
+    set lodMode(value) {
+        if (value !== GSPLAT_LODMODE_ERROR && value !== GSPLAT_LODMODE_DISTANCE) {
+            Debug.warnOnce(`GSplatParams#lodMode: ignoring invalid value '${value}', expected GSPLAT_LODMODE_ERROR or GSPLAT_LODMODE_DISTANCE.`);
+            return;
+        }
+        if (this._lodMode !== value) {
+            this._lodMode = value;
+            this.dirty = true;
+        }
+    }
+
+    /**
+     * Gets the LOD selection mode.
+     *
+     * @type {string}
+     */
+    get lodMode() {
+        return this._lodMode;
+    }
+
     /**
      * @type {import('../../platform/graphics/texture.js').Texture|null}
      * @private
@@ -978,6 +1013,7 @@ class GSplatParams {
         this.lodBehindPenalty = render.gsplatLodBehindPenalty ?? this.lodBehindPenalty;
         this.lodUnderfillLimit = render.gsplatLodUnderfillLimit ?? this.lodUnderfillLimit;
         this.splatBudget = render.gsplatSplatBudget ?? this.splatBudget;
+        this.lodMode = render.gsplatLodMode ?? this.lodMode;
 
         this.alphaClip = render.gsplatAlphaClip ?? this.alphaClip;
         this.alphaClipForward = render.gsplatAlphaClipForward ?? this.alphaClipForward;

--- a/src/scene/gsplat-unified/gsplat-placement.js
+++ b/src/scene/gsplat-unified/gsplat-placement.js
@@ -78,6 +78,33 @@ class GSplatPlacement {
     /**
      * @type {number}
      */
+    /**
+     * How fast quality falls off away from the camera for this placement's nodes, applied as an
+     * exponent on projected coverage in the budget ranking. 1 is neutral, 0 spreads the budget with
+     * no view preference, 2 concentrates it near the camera. In distance LOD mode this sets the
+     * band spacing.
+     *
+     * @private
+     */
+    _lodFalloff = 1;
+
+    /**
+     * @type {number}
+     */
+    set lodFalloff(value) {
+        if (this._lodFalloff !== value) {
+            this._lodFalloff = value;
+            this.lodDirty = true;
+        }
+    }
+
+    get lodFalloff() {
+        return this._lodFalloff;
+    }
+
+    /**
+     * @type {number}
+     */
     set lodRangeMin(value) {
         if (this._lodRangeMin !== value) {
             this._lodRangeMin = value;

--- a/src/scene/gsplat-unified/gsplat-world.js
+++ b/src/scene/gsplat-unified/gsplat-world.js
@@ -1135,7 +1135,7 @@ class GSplatWorld {
         // Phase 1: resolve each instance's LOD range and evaluate per-node coverage, and collect
         // padding for active placements
         for (const [, inst] of this._octreeInstances) {
-            inst.resolveLodRange();
+            inst.resolveLodRange(this._scene.gsplat.lodMode);
             inst.evaluateNodeCoverage(camera, this._scene.gsplat);
             for (const placement of inst.activePlacements) {
                 const resource = /** @type {GSplatResourceBase} */ (placement.resource);

--- a/test/framework/components/gsplat/component.test.mjs
+++ b/test/framework/components/gsplat/component.test.mjs
@@ -30,6 +30,7 @@ describe('GSplatComponent', function () {
             expect(e.gsplat.castShadows).to.equal(false);
             expect(e.gsplat.lodRangeMin).to.equal(0);
             expect(e.gsplat.lodRangeMax).to.equal(99);
+            expect(e.gsplat.lodFalloff).to.equal(1);
         });
 
         it('initializes LOD properties from data', function () {
@@ -37,12 +38,39 @@ describe('GSplatComponent', function () {
             e.addComponent('gsplat', {
                 castShadows: true,
                 lodRangeMin: 2,
-                lodRangeMax: 7
+                lodRangeMax: 7,
+                lodFalloff: 1.5
             });
 
             expect(e.gsplat.castShadows).to.equal(true);
             expect(e.gsplat.lodRangeMin).to.equal(2);
             expect(e.gsplat.lodRangeMax).to.equal(7);
+            expect(e.gsplat.lodFalloff).to.equal(1.5);
+        });
+
+        it('clamps lodFalloff to its supported range', function () {
+            // a negative falloff would rank far nodes above near ones, and past the cap the
+            // bucketing window saturates, so the component pins the value rather than letting the
+            // balancer see it
+            const e = new Entity();
+            e.addComponent('gsplat');
+
+            e.gsplat.lodFalloff = -1;
+            expect(e.gsplat.lodFalloff).to.equal(0);
+
+            e.gsplat.lodFalloff = 20;
+            expect(e.gsplat.lodFalloff).to.equal(8);
+        });
+
+        it('forwards lodFalloff to the placement', function () {
+            const e = new Entity();
+            e.addComponent('gsplat');
+
+            const placement = new GSplatPlacement(null, e);
+            e.gsplat._placement = placement;
+
+            e.gsplat.lodFalloff = 0.5;
+            expect(placement.lodFalloff).to.equal(0.5);
         });
 
     });
@@ -76,7 +104,8 @@ describe('GSplatComponent', function () {
             e.addComponent('gsplat', {
                 castShadows: true,
                 lodRangeMin: 3,
-                lodRangeMax: 6
+                lodRangeMax: 6,
+                lodFalloff: 0.5
             });
 
             const clone = e.clone();
@@ -84,6 +113,7 @@ describe('GSplatComponent', function () {
             expect(clone.gsplat.castShadows).to.equal(true);
             expect(clone.gsplat.lodRangeMin).to.equal(3);
             expect(clone.gsplat.lodRangeMax).to.equal(6);
+            expect(clone.gsplat.lodFalloff).to.equal(0.5);
         });
 
     });

--- a/test/scene/gsplat-unified/gsplat-budget-balancer.test.mjs
+++ b/test/scene/gsplat-unified/gsplat-budget-balancer.test.mjs
@@ -4,8 +4,8 @@ import { GSplatBudgetBalancer } from '../../../src/scene/gsplat-unified/gsplat-b
 import { GSplatLodTable } from '../../../src/scene/gsplat-unified/gsplat-lod-table.js';
 
 // Minimal stand-ins for the pieces the balancer touches: an octree exposing nodes and a table
-// cache, and an instance exposing nodeInfos plus its resolved LOD range.
-const makeInstance = (nodes, coverage, rangeMin = 0, rangeMax = nodes[0].lods.length - 1) => {
+// cache, and an instance exposing nodeInfos, its resolved LOD range and its placement's falloff.
+const makeInstance = (nodes, coverage, rangeMin = 0, rangeMax = nodes[0].lods.length - 1, lodFalloff = 1) => {
     const tables = new Map();
     const octree = {
         nodes: nodes.map(node => ({ lods: node.lods })),
@@ -19,6 +19,7 @@ const makeInstance = (nodes, coverage, rangeMin = 0, rangeMax = nodes[0].lods.le
     };
     return {
         octree,
+        placement: { lodFalloff },
         nodeInfos: nodes.map((_, i) => ({ optimalLod: -1, lodCoverage: coverage?.[i] ?? 1 })),
         rangeMin,
         rangeMax,
@@ -26,6 +27,11 @@ const makeInstance = (nodes, coverage, rangeMin = 0, rangeMax = nodes[0].lods.le
         // resolving the range itself
         lodTable: octree.acquireLodTable(rangeMin, rangeMax)
     };
+};
+
+const singleWithFalloff = (nodes, coverage, lodFalloff) => {
+    const inst = makeInstance(nodes, coverage, 0, nodes[0].lods.length - 1, lodFalloff);
+    return { inst, instances: new Map([[{}, inst]]) };
 };
 
 const single = (nodes, coverage, rangeMin, rangeMax) => {
@@ -337,6 +343,51 @@ describe('GSplatBudgetBalancer', function () {
             const exact = exactGreedy(inst, budget).spent;
             expect(splatsOf(inst)).to.be.at.least(exact * 0.99);
         }
+    });
+
+    it('tilts the budget towards the camera as lodFalloff rises', function () {
+        // Two nodes compete for one 5-splat upgrade. The far node removes 16x the error, so at the
+        // neutral falloff it wins despite its lower coverage; at falloff 2 the coverage difference
+        // is amplified enough that the near node takes it. The pivot cancels in the comparison, so
+        // the flip point is exact: falloff * log2(covNear/covFar) vs log2(ratioFar/ratioNear).
+        const nodes = [
+            { lods: [{ count: 10, error: 0 }, { count: 5, error: 1 }] },
+            { lods: [{ count: 10, error: 0 }, { count: 5, error: 16 }] }
+        ];
+
+        const neutral = singleWithFalloff(nodes, [0.1, 0.01], 1);
+        new GSplatBudgetBalancer().balance(neutral.instances, 15);
+        expect(lodsOf(neutral.inst)).to.deep.equal([1, 0]);
+
+        const steep = singleWithFalloff(nodes, [0.1, 0.01], 2);
+        new GSplatBudgetBalancer().balance(steep.instances, 15);
+        expect(lodsOf(steep.inst)).to.deep.equal([0, 1]);
+    });
+
+    it('ignores the view entirely at lodFalloff 0', function () {
+        // With the exponent at 0 every node's coverage term is equal, so the far node's better
+        // error-per-splat must win regardless of how much closer the other sits.
+        const { inst, instances } = singleWithFalloff([
+            { lods: [{ count: 10, error: 0 }, { count: 5, error: 1 }] },
+            { lods: [{ count: 10, error: 0 }, { count: 5, error: 2 }] }
+        ], [1, 1e-9], 0);
+
+        new GSplatBudgetBalancer().balance(instances, 15);
+
+        expect(lodsOf(inst)).to.deep.equal([1, 0]);
+    });
+
+    it('matches the exact path at the default falloff', function () {
+        // falloff 1 must keep the exact value path, bit-identical to ranking without the feature
+        const { nodes, coverage } = makeScene(300, 5, 21);
+        const a = singleWithFalloff(nodes, coverage, 1);
+        const b = single(nodes, coverage);
+
+        const balancer = new GSplatBudgetBalancer();
+        balancer.balance(a.instances, 20000);
+        balancer.balance(b.instances, 20000);
+
+        expect(lodsOf(a.inst)).to.deep.equal(lodsOf(b.inst));
     });
 
     it('moves few nodes when the camera moves slightly', function () {

--- a/test/scene/gsplat-unified/gsplat-lod-table.test.mjs
+++ b/test/scene/gsplat-unified/gsplat-lod-table.test.mjs
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 
+import { GSPLAT_LODMODE_DISTANCE } from '../../../src/scene/constants.js';
 import { GSplatLodTable } from '../../../src/scene/gsplat-unified/gsplat-lod-table.js';
 import { GSplatOctree } from '../../../src/scene/gsplat-unified/gsplat-octree.js';
 
@@ -299,5 +300,57 @@ describe('GSplatLodTable', function () {
                 lod = table.finerOnChain(0, lod);
             }
         });
+    });
+});
+
+describe('GSplatLodTable distance mode', function () {
+
+    const distanceTable = octree => octree.acquireLodTable(0, octree.lodLevels - 1, GSPLAT_LODMODE_DISTANCE);
+
+    it('prices every step by the per-level band weight, whatever the node holds', function () {
+        // step to the finer of levels (i, i-1) costs error dCost * 3^(2*(i-1)), so error-per-splat
+        // is exactly 3^(2*(i-1)) - node content cancels and the ranking is pure coverage,
+        // which is what guarantees the coarser-with-distance progression
+        const a = distanceTable(makeOctree([100, 50, 20], [0, 1, 3], true));
+        const b = distanceTable(makeOctree([1000, 300, 7], [0, 900, 901], true));
+
+        for (const table of [a, b]) {
+            const ratios = upgradesOf(table).map(u => u.ratio);
+            expect(ratios.length).to.equal(2);
+            expect(ratios[0]).to.be.closeTo(9, 1e-6);   // step to lod1, weight 3^2
+            expect(ratios[1]).to.be.closeTo(1, 1e-6);   // step to lod0, weight 3^0
+        }
+    });
+
+    it('ignores authored error tables', function () {
+        // these errors would reorder the frontier in error mode; distance mode never reads them
+        const octree = makeOctree([100, 50, 20], [0, 40, 3], true);
+        const table = distanceTable(octree);
+
+        expect(chainOf(table)).to.deep.equal([2, 1, 0]);
+    });
+
+    it('still drops levels dominated by count inversions', function () {
+        // level 4 holds more splats than level 3 for the same or worse band error
+        const octree = makeOctree([78, 38, 19, 6, 7], undefined, undefined);
+        const table = distanceTable(octree);
+
+        expect(chainOf(table)).to.not.include(4);
+    });
+
+    it('is cached separately from the error-mode table of the same range', function () {
+        const octree = makeOctree([100, 50, 20], [0, 1, 3], true);
+        const error = octree.acquireLodTable(0, 2);
+        const distance = distanceTable(octree);
+
+        expect(distance).to.not.equal(error);
+        expect(octree.acquireLodTable(0, 2)).to.equal(error);
+        expect(distanceTable(octree)).to.equal(distance);
+
+        // releasing one mode leaves the other alone
+        octree.releaseLodTable(distance);
+        octree.releaseLodTable(distance);
+        expect(octree.acquireLodTable(0, 2)).to.equal(error);
+        expect(distanceTable(octree)).to.not.equal(distance);
     });
 });

--- a/test/scene/gsplat-unified/gsplat-octree-instance.test.mjs
+++ b/test/scene/gsplat-unified/gsplat-octree-instance.test.mjs
@@ -1,30 +1,37 @@
 import { expect } from 'chai';
 
-import { PROJECTION_ORTHOGRAPHIC, PROJECTION_PERSPECTIVE } from '../../../src/scene/constants.js';
+import {
+    GSPLAT_LODMODE_DISTANCE,
+    GSPLAT_LODMODE_ERROR,
+    PROJECTION_ORTHOGRAPHIC,
+    PROJECTION_PERSPECTIVE
+} from '../../../src/scene/constants.js';
 import { GraphNode } from '../../../src/scene/graph-node.js';
 import { GSplatOctreeInstance } from '../../../src/scene/gsplat-unified/gsplat-octree-instance.js';
 import { GSplatOctree } from '../../../src/scene/gsplat-unified/gsplat-octree.js';
 
-// An octree of unit leaves centred at the given positions, all the same size, so coverage
-// differences can only come from the camera model.
+// An octree of leaves centred at the given positions, unit half-extent unless a fourth component
+// gives one, so coverage differences can only come from the camera model and stated sizes.
 const makeOctree = centers => new GSplatOctree('/scene/lod-meta.json', {
     lodLevels: 1,
     filenames: ['0/meta.json'],
     tree: {
-        children: centers.map(([x, y, z]) => ({
-            bound: { min: [x - 1, y - 1, z - 1], max: [x + 1, y + 1, z + 1] },
+        children: centers.map(([x, y, z, he = 1]) => ({
+            bound: { min: [x - he, y - he, z - he], max: [x + he, y + he, z + he] },
             lods: { 0: { file: 0, offset: 0, count: 10 } }
         }))
     }
 });
 
-// evaluateNodeCoverage reads only the octree, the placement's node transform and the nodeInfos
-// array, so a focused test can supply exactly those rather than a fully constructed instance.
-const makeInstance = (octree) => {
+// evaluateNodeCoverage reads only the octree, the placement's node transform, the nodeInfos
+// array and the resolved table's mode, so a focused test can supply exactly those rather than a
+// fully constructed instance.
+const makeInstance = (octree, lodMode = GSPLAT_LODMODE_ERROR) => {
     const instance = Object.create(GSplatOctreeInstance.prototype);
     instance.octree = octree;
     instance.placement = { node: new GraphNode() };
     instance.nodeInfos = octree.nodes.map(() => ({ lodCoverage: 0, worldDistance: 0 }));
+    instance.lodTable = { lodMode };
     return instance;
 };
 
@@ -100,6 +107,53 @@ describe('GSplatOctreeInstance#evaluateNodeCoverage', function () {
         instance.evaluateNodeCoverage(camera, { lodBehindPenalty: 1 });
 
         expect(instance.nodeInfos[0].lodCoverage).to.be.closeTo(atUnitScale * 4, atUnitScale * 1e-5);
+    });
+
+    it('ranks equal-distance nodes equally in distance mode, whatever their size', function () {
+        // both leaves have their nearest face 9 units from the camera, but very different sizes -
+        // distance mode exists to give clean concentric bands, so size must not reorder them the
+        // way it deliberately does in error mode
+        const octree = makeOctree([[0, 0, -10, 1], [0, 0, -14, 5]]);
+        const camera = makeCamera(PROJECTION_PERSPECTIVE);
+
+        const errorInstance = makeInstance(octree, GSPLAT_LODMODE_ERROR);
+        errorInstance.evaluateNodeCoverage(camera, { lodBehindPenalty: 1 });
+        const [errSmall, errBig] = errorInstance.nodeInfos;
+        expect(errBig.lodCoverage).to.be.above(errSmall.lodCoverage * 1.5);
+
+        const instance = makeInstance(octree, GSPLAT_LODMODE_DISTANCE);
+        instance.evaluateNodeCoverage(camera, { lodBehindPenalty: 1 });
+        const [small, big] = instance.nodeInfos;
+        expect(small.lodCoverage).to.be.above(1e-12);
+        expect(big.lodCoverage).to.be.closeTo(small.lodCoverage, small.lodCoverage * 1e-6);
+    });
+
+    it('attenuates orthographic coverage with distance in distance mode', function () {
+        // an orthographic footprint carries no depth term, so this ranking is what lets distance
+        // mode mean anything under that projection
+        const instance = makeInstance(makeOctree([[0, 0, -10], [0, 0, -1000]]), GSPLAT_LODMODE_DISTANCE);
+
+        instance.evaluateNodeCoverage(makeCamera(PROJECTION_ORTHOGRAPHIC), { lodBehindPenalty: 1 });
+
+        const [near, far] = instance.nodeInfos;
+        expect(near.lodCoverage).to.be.above(far.lodCoverage * 100);
+    });
+
+    it('measures distance-mode coverage in world units across placement scales', function () {
+        // one leaf placed at the same world position and world size two ways: directly, and half
+        // sized under a doubled placement transform. A local-space measure would rank the scaled
+        // instance twice as close - it must not, the two share one world and one budget.
+        const camera = makeCamera(PROJECTION_PERSPECTIVE);
+
+        const direct = makeInstance(makeOctree([[0, 0, -100, 1]]), GSPLAT_LODMODE_DISTANCE);
+        direct.evaluateNodeCoverage(camera, { lodBehindPenalty: 1 });
+
+        const scaled = makeInstance(makeOctree([[0, 0, -50, 0.5]]), GSPLAT_LODMODE_DISTANCE);
+        scaled.placement.node.setLocalScale(2, 2, 2);
+        scaled.evaluateNodeCoverage(camera, { lodBehindPenalty: 1 });
+
+        const reference = direct.nodeInfos[0].lodCoverage;
+        expect(scaled.nodeInfos[0].lodCoverage).to.be.closeTo(reference, reference * 1e-6);
     });
 
     it('still penalises nodes behind an orthographic camera', function () {


### PR DESCRIPTION
Follow-up to #9233, adding user control over how the splat budget is spent.

## `scene.gsplat.lodMode` — global selection mode

- `GSPLAT_LODMODE_ERROR` (`'error'`, default): unchanged behaviour — the budget goes where it removes the most approximation error per splat, using the manifest's error tables when present and derived errors otherwise.
- `GSPLAT_LODMODE_DISTANCE` (`'distance'`): ignores error metadata and guarantees a coarser-with-distance progression — detail steps down in clean concentric bands around the camera, with band edges adapting to the budget. Useful when a capture's quality makes its error tables unreliable (e.g. sky-heavy nodes that pin themselves to LOD 0). Internally this synthesizes per-level errors whose per-step ratio is a per-level constant, so node content cancels out of the ranking and the same single allocator path serves both modes.
- In distance mode, coverage is pure inverse-square world distance under both projections: node size is factored out, so equal-distance nodes always pick equal levels regardless of the leaf sizes the octree cut produced, and orthographic cameras gain a distance ordering (their footprint carries no depth term to rank by).
- The mode is part of the cached LOD table identity, and is also settable via scene settings (`render.gsplatLodMode`).

## `GSplatComponent#lodFalloff` — per-splat near/far tilt

- Range [0, 8], default 1. Higher values concentrate detail near the camera at the cost of the far field; 0 spreads the budget evenly with no view preference. In distance mode this controls the band spacing.
- The tilt pivots around a mid-field reference, so it redistributes the splat's detail rather than changing its overall share of the budget — useful for balancing foreground splats against large environments.
- Implemented as a multiply in the balancer's key space: the default path is bit-identical to before, and a non-default falloff costs ~0.03 ms at 39k nodes (vs ~0.9 ms for the naive `Math.pow` per node), so it is safe on mobile.

## Example

The `lod-streaming` example gains a LOD Mode dropdown and a LOD Falloff slider.

Tests: distance-mode table pricing and cache identity, falloff behaviour against an exact greedy oracle (including bit-identical default), size-independence and ortho/scale behaviour of distance-mode coverage, and component default/init/clamp/clone.