### PR TITLE
Fix unified CPU splat sort for non-uniformly scaled splats

### DIFF
--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -32,6 +32,7 @@ import { Color } from '../../core/math/color.js';
 const cameraPosition = new Vec3();
 const cameraDirection = new Vec3();
 const translation = new Vec3();
+const splatAxis = new Vec3();
 const invModelMat = new Mat4();
 
 // Color instances used by debug wireframe rendering (GSPLAT_DEBUG_AABBS)
@@ -815,17 +816,26 @@ class GSplatManager {
         cameraMat.getTranslation(cameraPosition);
         cameraMat.getZ(cameraDirection).normalize();
 
+        const radialSort = this.scene.gsplat.radialSorting;
+
         const sorterRequest = [];
         lastState.splats.forEach((splat) => {
             const modelMat = splat.node.getWorldTransform();
             invModelMat.copy(modelMat).invert();
 
-            // uniform scale
-            const uniformScale = modelMat.getScale().x;
+            // scale folded into the per-axis weights below, except on the radial path
+            const uniformScale = radialSort ? modelMat.getScale().x : 1;
 
-            // camera direction in splat's rotated space
-            // transform by the full inverse matrix and then normalize, which cancels the (1/s) scaling factor
-            const transformedDirection = invModelMat.transformVector(cameraDirection).normalize();
+            // camera direction in splat's rotated space: each local axis weighted by the
+            // model matrix's own basis vector, which holds for a non-uniform scale too
+            // (normalizing the inverse-transformed direction only cancels a uniform one)
+            const transformedDirection = radialSort ?
+                invModelMat.transformVector(cameraDirection).normalize() :
+                new Vec3(
+                    modelMat.getX(splatAxis).dot(cameraDirection),
+                    modelMat.getY(splatAxis).dot(cameraDirection),
+                    modelMat.getZ(splatAxis).dot(cameraDirection)
+                );
 
             // camera position in splat's local space (for circular sorting)
             const transformedPosition = invModelMat.transformPoint(cameraPosition);


### PR DESCRIPTION
## Description

`GSplatManager.sortCpu` sends the sort worker a normalized inverse-transformed camera direction plus a single scalar scale:

```js
const uniformScale = modelMat.getScale().x;
// transform by the full inverse matrix and then normalize, which cancels the (1/s) scaling factor
const transformedDirection = invModelMat.transformVector(cameraDirection).normalize();
```

and the worker reconstructs each gaussian's depth as `dot(p_local, transformedDirection) * scale + offset`.

The true depth is

```
(M * p - cameraPos) . dir  =  Σᵢ sᵢ · pᵢ · (Rᵀ dir)ᵢ  +  offset
```

so each local axis is weighted **proportionally** to its scale. The inverse transform weights it by `1/sᵢ` instead, and the trailing `* scale` only cancels that when every `sᵢ` is equal — which is what the comment above the line is relying on. With a non-uniform scale the residual is a function of the view direction, so the splat sorts against the rest of the scene by a direction-dependent error: it draws over splats in front of it at some camera angles and not others, while camera distance makes no difference.

We hit this with a ground-plane splat fitted to a plot footprint while pinned thin vertically (`setLocalScale(4, 0.2, 4)`): from some orbit angles the floor drew over the lower half of the props standing on it.

### Fix

Weight each local axis by the model matrix's own basis vectors projected on the camera direction, which is exact for any affine transform, and leave the scale the worker multiplies by at `1`.

Checked against the true depth over random local points (max absolute error in world units):

| model scale | before | after |
| --- | --- | --- |
| (2.5, 2.5, 2.5) | 1.3e-7 | 3.6e-15 |
| (1, -1, -1) | 6.8e-8 | 3.6e-15 |
| (4, 0.2, 4) | **6.5e+0** | 3.6e-15 |

Uniform scales are unchanged apart from losing the normalize/rescale round-trip's own rounding error.

### Scope

- The **radial** path is left exactly as it was: its distance cannot be expressed with a local vector and a scalar either way. It has the same limitation for non-uniform scales, and I'm happy to follow up separately if you'd like it addressed.
- `aabbMin`/`aabbMax` bound estimation in the worker consumes the same `transformedDirection`/`scale` pair and stays valid unchanged.
- `computeDistanceRange` is already exact — it transforms AABB corners with the full matrix.
- The **WebGPU compute** path is unaffected; it reads world-space positions out of the work buffer.

### Repro

1. Load two gsplat assets into the same layer with `unified: true`.
2. Scale one non-uniformly, e.g. `entity.setLocalScale(4, 0.2, 4)` (a splat flattened into a ground plane), and rest the other on top of it.
3. Orbit the camera: the flattened splat wins the draw against the one in front of it at some angles. Moving the camera closer or further away makes no difference.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

---

🤖 Investigated and written with [Claude Code](https://claude.com/claude-code).