### PR TITLE
Fix stale gsplat projector pipeline after a dataFormat swap

### DIFF
--- a/src/scene/gsplat/gsplat-format.js
+++ b/src/scene/gsplat/gsplat-format.js
@@ -48,6 +48,13 @@ import wgslContainerSimpleRead from '../shader-lib/wgsl/chunks/gsplat/vert/forma
  */
 const serializeStreams = streams => streams.map(s => `${s.name}:${s.format}:${s.storage}`).join(',');
 
+// Monotonic across all GSplatFormat instances, so a version handed out by one format object can
+// never collide with one handed out by another. Consumers cache a format's version and rebuild
+// their pipelines when it changes; a per-instance counter starting at 0 would let a wholesale
+// format swap (see GSplatParams#dataFormat) reuse a version they already consider current, and
+// their `!==` change detection would silently miss it.
+let versionCounter = 0;
+
 // Pre-compiled regex patterns for template replacement
 const RE_NAME = /\{name\}/g;
 const RE_SAMPLER = /\{sampler\}/g;
@@ -141,11 +148,12 @@ class GSplatFormat {
     _streamNames = new Set();
 
     /**
-     * Version counter that increments when extra streams change.
+     * Change token, refreshed from the shared counter when extra streams change. Never repeats
+     * a value used by any other format instance.
      *
      * @private
      */
-    _extraStreamsVersion = 0;
+    _extraStreamsVersion = ++versionCounter;
 
     /**
      * Cached hash value.
@@ -222,7 +230,9 @@ class GSplatFormat {
     }
 
     /**
-     * Returns the version counter. Increments when extra streams change.
+     * Returns an opaque change token that changes when extra streams change. Values are unique
+     * across format instances, so comparing it against a cached copy also detects a wholesale
+     * format swap (e.g. {@link GSplatParams#dataFormat}) and not just in-place stream edits.
      *
      * @type {number}
      * @ignore
@@ -304,7 +314,7 @@ class GSplatFormat {
         }
 
         if (added) {
-            this._extraStreamsVersion++;
+            this._extraStreamsVersion = ++versionCounter;
             this._invalidateCaches();
         }
     }
@@ -334,7 +344,7 @@ class GSplatFormat {
         }
 
         if (removed) {
-            this._extraStreamsVersion++;
+            this._extraStreamsVersion = ++versionCounter;
             this._invalidateCaches();
         }
     }


### PR DESCRIPTION
Switching `scene.gsplat.dataFormat` between `GSPLATDATA_COMPACT` and `GSPLATDATA_LARGE` at runtime left the GPU-sort projector bound to the previous layout on WebGPU, so the scene went blank with:

> WebGPU BindGroup creation validation error: None of the supported sample types (Float|UnfilterableFloat) of [Texture "dataColor"] match the expected sample types (Uint).

The `dataFormat` setter replaces the `GSplatFormat` object wholesale, and the new instance's version counter restarted at 0 — the same value consumers had already cached from the outgoing format. `GSplatProjector` detects format changes purely by that counter, so its `!==` check never fired and it kept the compact-era bind group format and compiled WGSL (`dataColor: texture_2d<u32>`) while the work buffer had moved to `RGBA16F`. Both switch directions were affected, and having extra streams present didn't help — re-adding them lands the new format on the same version the old one had.

Reachable since #8941 promoted GPU sort to the WebGPU default. The CPU-sort path on WebGL was unaffected, because `GSplatQuadRenderer` reconfigures unconditionally when its data source changes.

**Changes:**
- `GSplatFormat`'s version token now comes from a module-level monotonic counter, so a value handed out by one format instance can never collide with one handed out by another. Consumers that compare a cached token against the current one now detect a wholesale format swap as well as in-place stream edits, with no per-consumer identity guard — `GSplatProjector` itself needed no change.
- This makes the existing hand-rolled guards redundant but harmless: `GSplatShadowRenderer.setDataSource`'s `_cullFormatVersion = -1` reset and `GSplatStreams.syncWithFormat`'s format-identity check (the latter is still needed for its own `this.format` reassignment).

Reproduces on the `gaussian-splatting/lod-streaming` example on WebGPU by toggling the **Compact** control.
