### PR TITLE
Remove the dead supportsMsaa flag from the WebGL device

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -952,9 +952,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         this.maxPrecision = this.precision = this.getPrecision();
 
-        const contextAttribs = gl.getContextAttributes();
-        this.supportsMsaa = contextAttribs?.antialias ?? false;
-
         // Query parameter values from the WebGL context
         this.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
         this.maxCubeMapSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);


### PR DESCRIPTION
## Description

Follow-up to #9264, which removed the clobbered `supportsStencil` assignment and kept the adjacent `supportsMsaa` as app-readable surface. A closer look shows that flag cannot report anything useful, so this removes it:

- Its value came from `gl.getContextAttributes().antialias`, but the constructor forces `options.antialias = false` before creating the context (since #5628) because the engine allocates its own multisampled backbuffer. The queried attribute is therefore always `false`. The one exception is an app supplying its own pre-created antialiased context via `options.gl`, where the flag reports that context's backbuffer state rather than a device capability.
- Its only consumer was the old `post-effect2.js`, which used it to pick 4 samples for the post-effect backbuffer render target; that was removed in #2882.
- It was never declared on `GraphicsDevice` and is never set by the WebGPU or Null devices, so `device.supportsMsaa` is `undefined` on those backends. Undocumented on a `@category Graphics` class, it still leaked into `playcanvas.d.ts` as a WebGL-only member.

MSAA state is already exposed by documented readonly properties on the base class - `maxSamples` (max supported sample count) and `samples` (actual backbuffer sample count) - plus `backBufferAntialias` for the requested option. A code search across the playcanvas org finds no reader of `supportsMsaa` anywhere other than the assignment being removed.

Verified: lint clean; unit suite 2528 passing (`main` baseline); no remaining references in `src`, `examples`, `scripts` or `test`.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)