### PR TITLE
Use readable string enums for camera-frame script attributes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,19 @@ Always address the root cause of issues rather than implementing workarounds tha
 - Include descriptive comments
 - Keep examples simple and focused on one feature
 
-### 22. When Writing PR Descriptions
+### 22. When Authoring Scripts
+
+- Reusable scripts live in `scripts/esm/` and expose their configuration as script attributes
+- **Attribute enums must use readable string values**: declare them as `@enum {string}` with
+  human-readable values (e.g., `LINEAR: 'linear'`), never as raw numeric engine constants
+  - Numeric constant values (e.g., `PIXELFORMAT_RGBA16F = 12`) are implementation details that
+    can change between releases and make attribute data unreadable (`"renderFormat": 12`)
+  - Import the engine constants and resolve the strings via lookup maps where the script applies
+    them (see `scripts/esm/camera-frame.mjs` for the pattern)
+  - Keep accepting raw numeric values (pass them through unchanged) so existing attribute data
+    continues to work
+
+### 23. When Writing PR Descriptions
 
 - **Format as a single code block**: Always deliver PR descriptions wrapped in triple backticks for easy copy/paste
 - **Structure**:

--- a/scripts/esm/camera-frame.mjs
+++ b/scripts/esm/camera-frame.mjs
@@ -1,19 +1,23 @@
-// Camera Frame v 1.2
+// Camera Frame v 1.3
 
-import { CameraFrame as EngineCameraFrame, Script, Color } from 'playcanvas';
+import {
+    CameraFrame as EngineCameraFrame, Script, Color,
+    TONEMAP_LINEAR, TONEMAP_FILMIC, TONEMAP_HEJL, TONEMAP_ACES, TONEMAP_ACES2, TONEMAP_NEUTRAL,
+    PIXELFORMAT_RGBA8, PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F
+} from 'playcanvas';
 
 /**
  * @import { Asset, Entity } from 'playcanvas';
  */
 
-/** @enum {number} */
+/** @enum {string} */
 const ToneMapping = {
-    LINEAR: 0,  // TONEMAP_LINEAR
-    FILMIC: 1,  // TONEMAP_FILMIC
-    HEJL: 2,    // TONEMAP_HEJL
-    ACES: 3,    // TONEMAP_ACES
-    ACES2: 4,   // TONEMAP_ACES2
-    NEUTRAL: 5  // TONEMAP_NEUTRAL
+    LINEAR: 'linear',
+    FILMIC: 'filmic',
+    HEJL: 'hejl',
+    ACES: 'aces',
+    ACES2: 'aces2',
+    NEUTRAL: 'neutral'
 };
 
 /** @enum {string} */
@@ -23,12 +27,52 @@ const SsaoType = {
     COMBINE: 'combine'      // SSAOTYPE_COMBINE
 };
 
-/** @enum {number} */
+/** @enum {string} */
 const RenderFormat = {
-    RGBA8: 7,       // PIXELFORMAT_RGBA8
-    RG11B10: 18,    // PIXELFORMAT_111110F
-    RGBA16: 12,     // PIXELFORMAT_RGBA16F
-    RGBA32: 14      // PIXELFORMAT_RGBA32F
+    RGBA8: 'rgba8',
+    RG11B10: 'rg11b10',
+    RGBA16: 'rgba16',
+    RGBA32: 'rgba32'
+};
+
+const toneMappingMap = new Map([
+    [ToneMapping.LINEAR, TONEMAP_LINEAR],
+    [ToneMapping.FILMIC, TONEMAP_FILMIC],
+    [ToneMapping.HEJL, TONEMAP_HEJL],
+    [ToneMapping.ACES, TONEMAP_ACES],
+    [ToneMapping.ACES2, TONEMAP_ACES2],
+    [ToneMapping.NEUTRAL, TONEMAP_NEUTRAL]
+]);
+
+const renderFormatMap = new Map([
+    [RenderFormat.RGBA8, PIXELFORMAT_RGBA8],
+    [RenderFormat.RG11B10, PIXELFORMAT_111110F],
+    [RenderFormat.RGBA16, PIXELFORMAT_RGBA16F],
+    [RenderFormat.RGBA32, PIXELFORMAT_RGBA32F]
+]);
+
+/**
+ * Resolves a {@link ToneMapping} string to the engine's tone mapping constant. Numeric values
+ * are passed through unchanged for backward compatibility with attribute data that stored the
+ * engine constants directly.
+ *
+ * @param {ToneMapping|number} value - The tone mapping.
+ * @returns {number} The engine tone mapping constant.
+ */
+const resolveToneMapping = (value) => {
+    return typeof value === 'number' ? value : (toneMappingMap.get(value) ?? TONEMAP_LINEAR);
+};
+
+/**
+ * Resolves a {@link RenderFormat} string to the engine's pixel format constant. Numeric values
+ * are passed through unchanged for backward compatibility with attribute data that stored the
+ * engine constants directly.
+ *
+ * @param {RenderFormat|number} value - The render format.
+ * @returns {number} The engine pixel format constant.
+ */
+const resolveRenderFormat = (value) => {
+    return typeof value === 'number' ? value : (renderFormatMap.get(value) ?? PIXELFORMAT_111110F);
 };
 
 /** @enum {string} */
@@ -640,6 +684,7 @@ class VolumetricFog {
  * cameraEntity.addComponent('script');
  * cameraEntity.script.create(CameraFrame, {
  *     properties: {
+ *         rendering: { toneMapping: 'aces' },
  *         bloom: { intensity: 0.02 }
  *     }
  * });
@@ -744,15 +789,15 @@ class CameraFrame extends Script {
 
         const dstRendering = cf.rendering;
         dstRendering.renderFormats.length = 0;
-        dstRendering.renderFormats.push(rendering.renderFormat);
-        dstRendering.renderFormats.push(rendering.renderFormatFallback0);
-        dstRendering.renderFormats.push(rendering.renderFormatFallback1);
+        dstRendering.renderFormats.push(resolveRenderFormat(rendering.renderFormat));
+        dstRendering.renderFormats.push(resolveRenderFormat(rendering.renderFormatFallback0));
+        dstRendering.renderFormats.push(resolveRenderFormat(rendering.renderFormatFallback1));
         dstRendering.stencil = rendering.stencil;
         dstRendering.renderTargetScale = rendering.renderTargetScale;
         dstRendering.samples = rendering.samples;
         dstRendering.sceneColorMap = rendering.sceneColorMap;
         dstRendering.sceneDepthMap = rendering.sceneDepthMap;
-        dstRendering.toneMapping = rendering.toneMapping;
+        dstRendering.toneMapping = resolveToneMapping(rendering.toneMapping);
         dstRendering.sharpness = rendering.sharpness;
 
         // ssao


### PR DESCRIPTION
## Description

Converts the two numeric script attribute enums in `scripts/esm/camera-frame.mjs` to readable string enums, so attribute data is legible (`"toneMapping": "neutral"`, `"renderFormat": "rgba16"`) instead of opaque integers (`"toneMapping": 5`, `"renderFormat": 12`). This matches the existing string enums in the script (`SsaoType`, `DebugType`) and across the rest of `scripts/esm/`.

- `ToneMapping` and `RenderFormat` are now `@enum {string}` (`'linear'`/`'filmic'`/`'hejl'`/`'aces'`/`'aces2'`/`'neutral'` and `'rgba8'`/`'rg11b10'`/`'rgba16'`/`'rgba32'`)
- The script imports the real `TONEMAP_*`/`PIXELFORMAT_*` engine constants and resolves the strings via lookup `Map`s in `postUpdate()`, removing the hardcoded mirror values that could silently break if the engine ever renumbered a pixel format
- **Backward compatible**: numeric values (e.g. from existing Editor attribute data) pass through unchanged via a `typeof` check, including values outside the enum such as `TONEMAP_NONE`; unknown strings fall back to the defaults
- Bumps the script header version to 1.3 and extends the class example to show the readable form
- Adds a "When Authoring Scripts" section to `AGENTS.md` codifying the convention: script attribute enums use readable string values, resolved to engine constants via lookup maps, with numeric passthrough

Verified with a Node smoke test loading the script against `src/index.js`: all named imports resolve, defaults resolve to exactly `[PIXELFORMAT_111110F, PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F]` and `TONEMAP_LINEAR`, every enum string maps to the correct constant, and legacy numeric values pass through untouched. ESLint passes. The only in-repo consumer of the script (`examples/src/examples/gaussian-splatting/annotations.example.mjs`) does not set these attributes.

Fixes #9210

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
