### PR TITLE
Settle the WebGL texture read when the device is destroyed

### DIFF
--- a/src/extras/exporters/core-exporter.js
+++ b/src/extras/exporters/core-exporter.js
@@ -117,9 +117,6 @@ class CoreExporter {
             immediate: true
         }).then((textureData) => {
 
-            dstTexture.destroy();
-            renderTarget.destroy();
-
             const pixels = new Uint8ClampedArray(width * height * 4);
             pixels.set(textureData);
 
@@ -135,6 +132,12 @@ class CoreExporter {
             newContext.putImageData(newImage, 0, 0);
 
             return Promise.resolve(canvas);
+        }).finally(() => {
+
+            // freed however the read turned out - it rejects when the device is lost or destroyed
+            // while it is in flight, and these are of no use to anyone either way
+            dstTexture.destroy();
+            renderTarget.destroy();
         });
     }
 

--- a/src/extras/exporters/core-exporter.js
+++ b/src/extras/exporters/core-exporter.js
@@ -107,6 +107,21 @@ class CoreExporter {
             fragmentChunk: 'outputTex2DPS'
         });
 
+        // Freeing these goes through the device, so it has to happen while the device is still usable.
+        // The destroy event fires before the backend is torn down for exactly this, and the read
+        // settling is the other way it can come about - whichever happens first releases them once.
+        let released = false;
+        const release = () => {
+            if (released) {
+                return;
+            }
+            released = true;
+            device.off('destroy', release);
+            dstTexture.destroy();
+            renderTarget.destroy();
+        };
+        device.on('destroy', release);
+
         device.scope.resolve('source').setValue(texture);
         device.setBlendState(BlendState.NOBLEND);
         drawQuadWithShader(device, renderTarget, shader);
@@ -132,13 +147,7 @@ class CoreExporter {
             newContext.putImageData(newImage, 0, 0);
 
             return Promise.resolve(canvas);
-        }).finally(() => {
-
-            // freed however the read turned out - it rejects when the device is lost or destroyed
-            // while it is in flight, and these are of no use to anyone either way
-            dstTexture.destroy();
-            renderTarget.destroy();
-        });
+        }).finally(release);
     }
 
     calcTextureSize(width, height, maxTextureSize) {

--- a/src/extras/exporters/core-exporter.js
+++ b/src/extras/exporters/core-exporter.js
@@ -127,10 +127,12 @@ class CoreExporter {
         drawQuadWithShader(device, renderTarget, shader);
 
         // async read back the pixels of the texture
+        // released as soon as the read settles, before the pixels are copied out and turned into a
+        // canvas - holding them for that would raise the peak cost of a large export for nothing
         return dstTexture.read(0, 0, width, height, {
             renderTarget: renderTarget,
             immediate: true
-        }).then((textureData) => {
+        }).finally(release).then((textureData) => {
 
             const pixels = new Uint8ClampedArray(width * height * 4);
             pixels.set(textureData);
@@ -147,7 +149,7 @@ class CoreExporter {
             newContext.putImageData(newImage, 0, 0);
 
             return Promise.resolve(canvas);
-        }).finally(release);
+        });
     }
 
     calcTextureSize(width, height, maxTextureSize) {

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -247,10 +247,13 @@ class Picker {
         }
         return this._readTexture(this.renderTarget.colorBuffer, x, y, width, height, this.renderTarget).then((pixels) => {
             return this.decodePixels(pixels, this.mapping);
-        }).catch(() => {
-            // the read did not complete, most likely because the device was destroyed while it was in
-            // flight - reported as an empty selection, which is what decodePixels returns for a device
-            // which has gone
+        }).catch((error) => {
+            // a read which could not complete because the device has gone reports an empty selection,
+            // which is what decodePixels reports for the same reason. Every other failure is a real one
+            // and is passed on, rather than being disguised as nothing having been selected.
+            if (this.deviceValid) {
+                throw error;
+            }
             return [];
         });
     }
@@ -351,9 +354,12 @@ class Picker {
         let pixels;
         try {
             pixels = await this._readTexture(this.depthBuffer, x, y, 1, 1, this.renderTargetDepth);
-        } catch (_e) {
-            // the read did not complete, most likely because the device was destroyed while it was in
-            // flight - reported the same way as nothing having been picked
+        } catch (error) {
+            // as in getSelectionAsync - only a device which has gone reports as nothing picked, and
+            // every other failure is passed on
+            if (this.deviceValid) {
+                throw error;
+            }
             return null;
         }
 

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -247,6 +247,11 @@ class Picker {
         }
         return this._readTexture(this.renderTarget.colorBuffer, x, y, width, height, this.renderTarget).then((pixels) => {
             return this.decodePixels(pixels, this.mapping);
+        }).catch(() => {
+            // the read did not complete, most likely because the device was destroyed while it was in
+            // flight - reported as an empty selection, which is what decodePixels returns for a device
+            // which has gone
+            return [];
         });
     }
 
@@ -343,7 +348,14 @@ class Picker {
             return null;
         }
 
-        const pixels = await this._readTexture(this.depthBuffer, x, y, 1, 1, this.renderTargetDepth);
+        let pixels;
+        try {
+            pixels = await this._readTexture(this.depthBuffer, x, y, 1, 1, this.renderTargetDepth);
+        } catch (_e) {
+            // the read did not complete, most likely because the device was destroyed while it was in
+            // flight - reported the same way as nothing having been picked
+            return null;
+        }
 
         // reconstruct uint bits from RGBA8
         const intBits = ((pixels[0] << 24) | (pixels[1] << 16) | (pixels[2] << 8) | pixels[3]) >>> 0;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2470,10 +2470,29 @@ class WebglGraphicsDevice extends GraphicsDevice {
             this.gl.flush();
         }
 
+        // A render target made here is this method's to free, and freeing it goes through the device, so
+        // it has to happen while the device is still usable. The destroy event fires before the backend
+        // is torn down for exactly this, and the read settling is the other way it can come about -
+        // whichever happens first releases it once.
+        let released = !!options.renderTarget;
+        const release = () => {
+            if (released) {
+                return;
+            }
+            released = true;
+            this.off('destroy', release);
+            renderTarget.destroy();
+        };
+        if (!released) {
+            this.on('destroy', release);
+        }
+
         return new Promise((resolve, reject) => {
             const readPromise = this.readPixelsAsync(x, y, width, height, readBuffer, needsRgbaReadback);
 
             readPromise.then((data) => {
+
+                release();
 
                 // The device was destroyed while the read was in flight, so there is nothing valid to
                 // return - but the promise still has to settle, or whoever is waiting on it waits for
@@ -2482,11 +2501,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 if (this._destroyed) {
                     reject(new Error('Texture read did not complete, as the graphics device was destroyed.'));
                     return;
-                }
-
-                // destroy RT if we created it
-                if (!options.renderTarget) {
-                    renderTarget.destroy();
                 }
 
                 // Extract channels from RGBA data if needed
@@ -2501,7 +2515,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
                 } else {
                     resolve(data);
                 }
-            }).catch(reject);
+            }).catch((error) => {
+                release();
+                reject(error);
+            });
         });
     }
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2475,8 +2475,14 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
             readPromise.then((data) => {
 
-                // return if the device was destroyed
-                if (this._destroyed) return;
+                // The device was destroyed while the read was in flight, so there is nothing valid to
+                // return - but the promise still has to settle, or whoever is waiting on it waits for
+                // good. Rejecting rather than resolving, as a caller cannot be handed data which was
+                // never read, and this is the same way every other failure on this path reports.
+                if (this._destroyed) {
+                    reject(new Error('Texture read did not complete, as the graphics device was destroyed.'));
+                    return;
+                }
 
                 // destroy RT if we created it
                 if (!options.renderTarget) {


### PR DESCRIPTION
### Summary

`WebglGraphicsDevice#readTextureAsync` abandoned its promise when the device was destroyed while a read was in flight:

```js
readPromise.then((data) => {

    // return if the device was destroyed
    if (this._destroyed) return;
    ...
}).catch(reject);
```

Returning there calls neither `resolve` nor `reject`, so the promise handed to the caller never settles and anything awaiting it waits for good. It now rejects, and the two callers which only handled the resolve path now handle the other one.

### Why reject rather than resolve

The WebGPU path already rejects for the same reason - `readBuffer` fails to map its staging buffer once the device is lost and reports:

> Failed to map a staging buffer for reading, most likely because the device was lost.

So rejecting brings the two backends into agreement, rather than leaving WebGL as the one which silently hangs. Resolving was the alternative, but a caller cannot be handed a buffer of data which was never read and has no way to tell.

### The callers

Three places read a texture asynchronously: `Picker`, `gsplat-sog-data` and `core-exporter`. Two of them needed attention.

**`Picker`** reports an empty selection from `getSelectionAsync` and a null depth from `getPointDepthAsync`, and so a null world point from `getWorldPointAsync`. That is what it already reports through `decodePixels` once `deviceValid` is false, and null is already documented for `getWorldPointAsync`, so a caller sees the same answer however the read ended rather than an unhandled rejection during teardown.

**`core-exporter`** frees its temporary texture and render target in a `finally` rather than in the resolve path. Releasing them there alone leaked both whenever the read failed - which it already did on a lost device, and through the pre-existing `.catch(reject)` for any other read error, so this is a fix in its own right rather than fallout from the change above.

`gsplat-sog-data` returns the promise to its caller and is left alone.

### Testing

This is the destroy-during-readback path, which needs the device torn down with a read outstanding - not something the examples exercise, so it is verified by inspection against the WebGPU path it now matches. The `core-exporter` change is exercised by any successful texture export, as the temporaries are freed on the same schedule as before for that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)