### PR TITLE
Fix radix sort value buffer rotation with initial values

### DIFF
--- a/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
@@ -519,13 +519,18 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
             }
             device.computeDispatch([reorderCompute], `RadixSort4bit-Reorder${suffix}`);
 
-            // Swap buffers for next pass (skip on last pass - not needed)
+            // Swap buffers for next pass (skip on last pass - not needed).
+            // Values mirror the keys ping-pong: after pass 0 the caller's
+            // initialValues buffer is dropped from the rotation (it is read-only
+            // per the API contract), so ping-pong continues between the two
+            // internal value buffers. A plain swap would keep initialValues in the
+            // rotation, leaving an even-pass-count result in it while sortedIndices
+            // (parity over _values0/_values1) returns the wrong, never-written buffer.
             if (!isLastPass) {
                 currentKeys = nextKeys;
                 nextKeys = (currentKeys === this._keys0) ? this._keys1 : this._keys0;
-                const tempValues = currentValues;
                 currentValues = nextValues;
-                nextValues = tempValues;
+                nextValues = (currentValues === this._values0) ? this._values1 : this._values0;
             }
         }
 

--- a/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
@@ -521,9 +521,15 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
             if (!isLastPass) {
                 currentKeys = nextKeys;
                 nextKeys = (currentKeys === this._keys0) ? this._keys1 : this._keys0;
-                const t = currentValues;
+                // Values mirror the keys ping-pong: after pass 0 the caller's
+                // initialValues buffer is dropped from the rotation (it is read-only
+                // per the API contract), so ping-pong continues between the two
+                // internal value buffers. A plain swap would keep initialValues in
+                // the rotation, leaving an even-pass-count result in it while
+                // sortedIndices (parity over _values0/_values1) returns the wrong,
+                // never-written buffer.
                 currentValues = nextValues;
-                nextValues = t;
+                nextValues = (currentValues === this._values0) ? this._values1 : this._values0;
             }
         }
 
@@ -643,9 +649,15 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
             if (!isLastPass) {
                 currentKeys = nextKeys;
                 nextKeys = (currentKeys === this._keys0) ? this._keys1 : this._keys0;
-                const t = currentValues;
+                // Values mirror the keys ping-pong: after pass 0 the caller's
+                // initialValues buffer is dropped from the rotation (it is read-only
+                // per the API contract), so ping-pong continues between the two
+                // internal value buffers. A plain swap would keep initialValues in
+                // the rotation, leaving an even-pass-count result in it while
+                // sortedIndices (parity over _values0/_values1) returns the wrong,
+                // never-written buffer.
                 currentValues = nextValues;
-                nextValues = t;
+                nextValues = (currentValues === this._values0) ? this._values1 : this._values0;
             }
         }
 


### PR DESCRIPTION
## Summary
Fix GPU radix sorts using caller-supplied initial values so subsequent passes ping-pong exclusively between internal value buffers.
- Applies to both portable multipass and OneSweep backends.
- Covers direct and indirect sorting paths.
- Prevents even-pass sorts from returning a stale, unwritten buffer.
- Keeps the caller-provided initial values buffer read-only after the first pass.
## Public API Changes
None.
## Performance
No additional allocations or compute dispatches.