### PR TITLE
Fix invalid 'radius' light option in examples

### DIFF
--- a/examples/src/examples/graphics/mesh-generation.example.mjs
+++ b/examples/src/examples/graphics/mesh-generation.example.mjs
@@ -85,7 +85,7 @@ function createLight(color, scale) {
     light.addComponent('light', {
         type: 'omni',
         color: color,
-        radius: 10,
+        range: 10,
         castShadows: false
     });
 

--- a/examples/src/examples/graphics/model-textured-box.example.mjs
+++ b/examples/src/examples/graphics/model-textured-box.example.mjs
@@ -76,7 +76,7 @@ const light = new Entity();
 light.addComponent('light', {
     type: 'omni',
     color: new Color(1, 0, 0),
-    radius: 10
+    range: 10
 });
 light.addComponent('render', {
     type: 'sphere'

--- a/examples/src/examples/shaders/shader-burn.example.mjs
+++ b/examples/src/examples/shaders/shader-burn.example.mjs
@@ -94,7 +94,7 @@ const light = new Entity();
 light.addComponent('light', {
     type: 'omni',
     color: new Color(1, 1, 1),
-    radius: 10
+    range: 10
 });
 light.translate(0, 1, 0);
 


### PR DESCRIPTION
The `light` component has no `radius` property — the omni/spot attenuation distance is [`range`](https://api.playcanvas.com/engine/classes/LightComponent.html#range). Three examples passed `radius`, which was silently ignored and now trips the `addComponent` option validation:

```
addComponent: ignoring unknown option 'radius' passed to the 'light' component - check for a typo.
```

Reported for `graphics/model-textured-box`; the same typo is in `graphics/mesh-generation` and `shaders/shader-burn`.

`range` defaults to 10 and all three passed `radius: 10`, so rendering is unchanged — the option now just does what the examples always meant it to.

I swept every `addComponent` call across `examples/src` (423 files) against each component's settable properties using a null-device app, and these three were the only invalid options; the sweep is clean now. (`misc/spineboy` uses the external `spine` component, which isn't an engine system.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)