### PR TITLE
Fix animation component test to assign animation assets

### DIFF
--- a/test/framework/components/animation/component.test.mjs
+++ b/test/framework/components/animation/component.test.mjs
@@ -69,10 +69,18 @@ describe('AnimationComponent', function () {
             });
 
             entity.addComponent('animation', {
-                asset: assets.animation
+                assets: [assets.animation]
             });
 
             expect(entity.animation).to.exist;
+
+            // the assets are assigned as given, accepting Asset instances as well as asset ids
+            expect(entity.animation.assets).to.have.lengthOf(1);
+            expect(entity.animation.assets[0]).to.equal(assets.animation);
+
+            // the asset is already loaded, so its animation is registered straight away
+            expect(entity.animation.animations[assets.animation.name]).to.equal(assets.animation.resource);
+            expect(entity.animation.animationsIndex[assets.animation.id]).to.equal(assets.animation.name);
         });
 
         it('can create animation and auto play them', function () {


### PR DESCRIPTION
The `can create animation component` test passed `asset:` to `addComponent('animation', ...)`, but the property is `assets` — an array of animation assets or asset ids. The option was silently dropped, so the test's only assertion (`expect(entity.animation).to.exist`) passed regardless and nothing about asset assignment was covered. The engine's debug-only `validateComponentOptions` warns about exactly this class of typo.

**Changes:**
- Pass `assets: [assets.animation]` in the `can create animation component` test, and assert the assigned assets, the registered animation resource and its name index, so the case actually covers asset assignment.

Test-only, no engine changes. The `Asset` instance is passed rather than an id on purpose: the setter accepts both, and this is now the only test covering the `instanceof Asset` branch. The other tests in the file were already correct, and `asset:` on the `model` component in the same test is a real property.