### PR TITLE
Fix ComponentSystemRegistry.remove leaving the system in the list

### DIFF
--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -266,13 +266,13 @@ class ComponentSystemRegistry extends EventHandler {
             throw new Error(`No ComponentSystem named '${id}' registered`);
         }
 
-        delete this[id];
-
         // Update the component system array
         const index = this.list.indexOf(this[id]);
         if (index !== -1) {
             this.list.splice(index, 1);
         }
+
+        delete this[id];
     }
 
     destroy() {

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -263,9 +263,7 @@ class ComponentSystemRegistry extends EventHandler {
      */
     remove(system) {
         const id = system.id;
-
-        // the id must be an own property, as inherited members (eg 'constructor') are never registered
-        if (!this[id] || !Object.hasOwn(this, id)) {
+        if (!this[id]) {
             throw new Error(`No ComponentSystem named '${id}' registered`);
         }
 

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -262,7 +262,9 @@ class ComponentSystemRegistry extends EventHandler {
      */
     remove(system) {
         const id = system.id;
-        if (!this[id]) {
+
+        // the id must be an own property, as inherited members (eg 'constructor') are never registered
+        if (!this[id] || !Object.hasOwn(this, id)) {
             throw new Error(`No ComponentSystem named '${id}' registered`);
         }
 

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -240,7 +240,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Add a component system to the registry.
      *
-     * @param {ComponentSystem} system - The {@link ComponentSystem} instance.
+     * @param {ComponentSystem} system - The ComponentSystem instance.
      * @ignore
      */
     add(system) {
@@ -258,7 +258,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Remove a component system from the registry.
      *
-     * @param {ComponentSystem} system - The {@link ComponentSystem} instance.
+     * @param {ComponentSystem} system - The ComponentSystem instance.
      * @ignore
      */
     remove(system) {

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -7,6 +7,7 @@ import { EventHandler } from '../../core/event-handler.js';
  * @import { ButtonComponentSystem } from './button/system.js'
  * @import { CameraComponentSystem } from './camera/system.js'
  * @import { CollisionComponentSystem } from './collision/system.js'
+ * @import { ComponentSystem } from './system.js'
  * @import { ElementComponentSystem } from './element/system.js'
  * @import { GSplatComponentSystem } from './gsplat/system.js'
  * @import { JointComponentSystem } from './joint/system.js'
@@ -239,7 +240,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Add a component system to the registry.
      *
-     * @param {object} system - The {@link ComponentSystem} instance.
+     * @param {ComponentSystem} system - The {@link ComponentSystem} instance.
      * @ignore
      */
     add(system) {
@@ -257,7 +258,7 @@ class ComponentSystemRegistry extends EventHandler {
     /**
      * Remove a component system from the registry.
      *
-     * @param {object} system - The {@link ComponentSystem} instance.
+     * @param {ComponentSystem} system - The {@link ComponentSystem} instance.
      * @ignore
      */
     remove(system) {

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -233,7 +233,10 @@ class ComponentSystemRegistry extends EventHandler {
     constructor() {
         super();
 
-        // An array of ComponentSystem objects
+        /**
+         * @type {ComponentSystem[]}
+         * @ignore
+         */
         this.list = [];
     }
 
@@ -276,6 +279,11 @@ class ComponentSystemRegistry extends EventHandler {
         delete this[id];
     }
 
+    /**
+     * Destroys all registered component systems.
+     *
+     * @ignore
+     */
     destroy() {
         this.off();
 

--- a/test/framework/components/registry.test.mjs
+++ b/test/framework/components/registry.test.mjs
@@ -1,0 +1,112 @@
+import { expect } from 'chai';
+
+import { ComponentSystemRegistry } from '../../../src/framework/components/registry.js';
+
+describe('ComponentSystemRegistry', function () {
+
+    // minimal stand-in for a ComponentSystem, as add/remove/destroy only use `id` and `destroy`
+    const createSystem = id => ({
+        id,
+        destroyed: false,
+        destroy() {
+            this.destroyed = true;
+        }
+    });
+
+    /** @type {ComponentSystemRegistry} */
+    let registry;
+
+    beforeEach(function () {
+        registry = new ComponentSystemRegistry();
+    });
+
+    describe('#add()', function () {
+
+        it('registers the system by id and appends it to the list', function () {
+            const system = createSystem('render');
+
+            registry.add(system);
+
+            expect(registry.render).to.equal(system);
+            expect(registry.list).to.have.ordered.members([system]);
+        });
+
+        it('throws if a system with the same id is already registered', function () {
+            registry.add(createSystem('render'));
+
+            expect(() => registry.add(createSystem('render'))).to.throw('already registered');
+        });
+
+    });
+
+    describe('#remove()', function () {
+
+        it('unregisters the system by id', function () {
+            const system = createSystem('render');
+
+            registry.add(system);
+            registry.remove(system);
+
+            expect(registry.render).to.be.undefined;
+        });
+
+        it('removes the system from the list', function () {
+            const system = createSystem('render');
+
+            registry.add(system);
+            registry.remove(system);
+
+            expect(registry.list).to.be.empty;
+        });
+
+        it('leaves the remaining systems registered and in order', function () {
+            const render = createSystem('render');
+            const light = createSystem('light');
+            const camera = createSystem('camera');
+
+            registry.add(render);
+            registry.add(light);
+            registry.add(camera);
+
+            registry.remove(light);
+
+            expect(registry.list).to.have.ordered.members([render, camera]);
+            expect(registry.light).to.be.undefined;
+            expect(registry.render).to.equal(render);
+            expect(registry.camera).to.equal(camera);
+        });
+
+        it('throws if no system with that id is registered', function () {
+            expect(() => registry.remove(createSystem('render'))).to.throw('No ComponentSystem named');
+        });
+
+    });
+
+    describe('#destroy()', function () {
+
+        it('destroys the registered systems', function () {
+            const render = createSystem('render');
+
+            registry.add(render);
+            registry.destroy();
+
+            expect(render.destroyed).to.be.true;
+        });
+
+        it('does not destroy a system that has been removed', function () {
+            const render = createSystem('render');
+            const light = createSystem('light');
+
+            registry.add(render);
+            registry.add(light);
+
+            registry.remove(light);
+            registry.destroy();
+
+            expect(render.destroyed).to.be.true;
+            expect(light.destroyed).to.be.false;
+        });
+
+    });
+
+});

--- a/test/framework/components/registry.test.mjs
+++ b/test/framework/components/registry.test.mjs
@@ -77,7 +77,13 @@ describe('ComponentSystemRegistry', function () {
         });
 
         it('throws if no system with that id is registered', function () {
+            // 'render' is a declared class field, so it is an own property holding undefined
             expect(() => registry.remove(createSystem('render'))).to.throw('No ComponentSystem named');
+        });
+
+        it('throws if the id resolves to an inherited property', function () {
+            // this['constructor'] is truthy, but no system is registered under it
+            expect(() => registry.remove(createSystem('constructor'))).to.throw('No ComponentSystem named');
         });
 
     });

--- a/test/framework/components/registry.test.mjs
+++ b/test/framework/components/registry.test.mjs
@@ -77,13 +77,7 @@ describe('ComponentSystemRegistry', function () {
         });
 
         it('throws if no system with that id is registered', function () {
-            // 'render' is a declared class field, so it is an own property holding undefined
             expect(() => registry.remove(createSystem('render'))).to.throw('No ComponentSystem named');
-        });
-
-        it('throws if the id resolves to an inherited property', function () {
-            // this['constructor'] is truthy, but no system is registered under it
-            expect(() => registry.remove(createSystem('constructor'))).to.throw('No ComponentSystem named');
         });
 
     });


### PR DESCRIPTION
## Description
`ComponentSystemRegistry.remove()` never removed the system from `list`.

The array lookup was evaluated *after* the id had already been deleted:

```js
delete this[id];

// Update the component system array
const index = this.list.indexOf(this[id]);  // indexOf(undefined) -> -1
if (index !== -1) {
    this.list.splice(index, 1);
}
```

`this[id]` is `undefined` by the time `indexOf` runs, so the splice never
executed and the removed system stayed in the array. Since `destroy()` iterates
`list`, an already-removed system was still destroyed on app teardown.

This PR performs the splice before deleting the id — the fix is a pure reorder.

There are no in-tree callers of `remove()`, so this only affects code that
unregisters a custom component system.

Adds `test/framework/components/registry.test.mjs` covering `add()`, `remove()`
and `destroy()`. Three of its eight cases fail without the fix, including one
asserting that a removed system is not destroyed on teardown.

### Type declaration tidy-up

While in the file, three annotations that were producing weak declarations:

- `add()` and `remove()` were typed `{object}`, with the real type only conveyed
  by an `{@link ComponentSystem}` in the description, because the base class was
  missing from the file's `@import` block — only the concrete subclasses were
  listed. They now emit `add(system: ComponentSystem)` rather than
  `add(system: object)`, and the redundant `{@link}` is dropped since the type
  annotation links.
- `list` emitted as `any[]`; it is now annotated `ComponentSystem[]`.
- `destroy()` carried no JSDoc at all, unlike `add()` and `remove()`.

`list` and `destroy()` are tagged `@ignore`, so **the documented API surface is
unchanged** — verified by building the docs and confirming neither appears on the
`ComponentSystemRegistry` page. This deliberately does not touch the question of
whether `list` should become public API; that belongs with #8086.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change
