### PR TITLE
Stop the Shader constructor modifying the supplied definition

### DIFF
--- a/src/platform/graphics/shader.js
+++ b/src/platform/graphics/shader.js
@@ -139,6 +139,12 @@ class Shader {
     constructor(graphicsDevice, definition) {
         this.id = id++;
         this.device = graphicsDevice;
+
+        // shallow copy the definition, as the code below replaces the shader sources with their
+        // pre-processed versions and may add extracted attributes. The object supplied by the
+        // caller must not be modified.
+        definition = { ...definition };
+
         this.definition = definition;
         this.name = definition.name || 'Untitled';
         this.init();
@@ -158,8 +164,9 @@ class Shader {
 
             const cshader = enablesCode + definesCode + definition.cshader;
 
-            // Add built-in halfTypesCS include for compute shaders (if not already provided by user)
-            const cincludes = definition.cincludes ?? new Map();
+            // Add built-in halfTypesCS include for compute shaders (if not already provided by
+            // user). Note this copies the supplied map, which must not be modified.
+            const cincludes = new Map(definition.cincludes);
             if (!cincludes.has('halfTypesCS')) {
                 cincludes.set('halfTypesCS', halfTypes);
             }

--- a/test/platform/graphics/shader.test.mjs
+++ b/test/platform/graphics/shader.test.mjs
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+
+import { SEMANTIC_POSITION, SHADERLANGUAGE_GLSL } from '../../../src/platform/graphics/constants.js';
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+import { Shader } from '../../../src/platform/graphics/shader.js';
+
+describe('Shader', function () {
+
+    // an #include is used to guarantee the pre-processor rewrites the supplied source
+    const vshader = `
+        #include "offsetVS"
+        attribute vec3 aPosition;
+        void main(void) {
+            gl_Position = vec4(aPosition + offset(), 1.0);
+        }
+    `;
+
+    const fshader = `
+        void main(void) {
+            gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+        }
+    `;
+
+    const vincludes = new Map([['offsetVS', 'vec3 offset() { return vec3(0.0); }']]);
+
+    const createDefinition = () => ({
+        name: 'Test',
+        attributes: { aPosition: SEMANTIC_POSITION },
+        vshader,
+        fshader,
+        vincludes
+    });
+
+    /** @type {NullGraphicsDevice} */
+    let device;
+
+    beforeEach(function () {
+        device = new NullGraphicsDevice({ id: 'mock' });
+    });
+
+    afterEach(function () {
+        device.destroy();
+        device = null;
+    });
+
+    describe('#constructor', function () {
+
+        it('pre-processes the shader sources', function () {
+            const shader = new Shader(device, createDefinition());
+
+            // if this fails, the assertions below are vacuous
+            expect(shader.definition.vshader).to.not.equal(vshader);
+            expect(shader.definition.vshader).to.include('vec3 offset()');
+        });
+
+        it('does not replace the shader sources in the supplied definition', function () {
+            const definition = createDefinition();
+
+            const shader = new Shader(device, definition);
+
+            // the shader gets the pre-processed sources, the supplied definition keeps the originals
+            expect(shader.definition.vshader).to.not.equal(vshader);
+            expect(definition.vshader).to.equal(vshader);
+            expect(definition.fshader).to.equal(fshader);
+        });
+
+        it('does not add extracted attributes to the supplied definition', function () {
+            const definition = createDefinition();
+            delete definition.attributes;
+
+            // attributes are only extracted for an explicitly declared GLSL shader
+            definition.shaderLanguage = SHADERLANGUAGE_GLSL;
+
+            const shader = new Shader(device, definition);
+
+            // if this fails, the assertion below is vacuous
+            expect(shader.definition.attributes).to.have.property('aPosition');
+
+            expect(definition.attributes).to.be.undefined;
+        });
+
+        it('stores its own copy of the definition', function () {
+            const definition = createDefinition();
+
+            const shader = new Shader(device, definition);
+
+            expect(shader.definition).to.not.equal(definition);
+            expect(shader.definition.name).to.equal('Test');
+        });
+
+        it('pre-processes consistently when a definition is reused', function () {
+            const definition = createDefinition();
+
+            const first = new Shader(device, definition);
+            const second = new Shader(device, definition);
+
+            expect(second.definition.vshader).to.equal(first.definition.vshader);
+            expect(second.definition.fshader).to.equal(first.definition.fshader);
+        });
+
+    });
+
+});


### PR DESCRIPTION
## Description
The `Shader` constructor modified the definition object supplied by the caller.
It replaced `definition.vshader`, `definition.fshader` and `definition.cshader`
with their pre-processed versions, and assigned `definition.attributes` when
extracting attribute names:

```js
definition.vshader = Preprocessor.run(definition.vshader, definition.vincludes, { ... });
definition.attributes ??= ShaderDefinitionUtils.collectAttributes(definition.vshader);
```

Reusing a definition object to create a second shader therefore pre-processed
already pre-processed sources.

This PR shallow copies the definition at the top of the constructor, so these
writes land on an engine-owned object instead. The compute path had the same
problem with `definition.cincludes` — the caller's map was mutated to add the
built-in `halfTypesCS` include — so that is now copied as well. Both copies
happen once per shader creation, which is not a hot path.

Nothing in the engine reads back from the original object, and
`ProgramLibrary.getProgram` already built a fresh object literal before
constructing a `Shader`, so its cached definitions were never affected.

Note this does **not** change what `shader.definition` contains — it still holds
the pre-processed sources, just on a copy rather than on the caller's object.

Also adds `test/platform/graphics/shader.test.mjs`. Three of its cases fail
without this fix.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
