### PR TITLE
Remove the pc. prefix from JSDoc examples

### DIFF
--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -889,9 +889,9 @@ class CameraComponent extends Component {
      *
      * @example
      * // frame content that is `pitch` degrees above the horizon, without tilting the camera
-     * const fovY = entity.camera.fov * pc.math.DEG_TO_RAD;
-     * const shift = Math.tan(pitch * pc.math.DEG_TO_RAD) / Math.tan(fovY / 2);
-     * entity.camera.projectionOffset = new pc.Vec2(0, shift);
+     * const fovY = entity.camera.fov * math.DEG_TO_RAD;
+     * const shift = Math.tan(pitch * math.DEG_TO_RAD) / Math.tan(fovY / 2);
+     * entity.camera.projectionOffset = new Vec2(0, shift);
      * @type {Vec2}
      */
     set projectionOffset(value) {

--- a/src/framework/components/render/component.js
+++ b/src/framework/components/render/component.js
@@ -465,7 +465,7 @@ class RenderComponent extends Component {
      * @type {number}
      * @example
      * // only cast shadows into the two cascades closest to the camera
-     * entity.render.shadowCascadeMask = pc.SHADOW_CASCADE_0 | pc.SHADOW_CASCADE_1;
+     * entity.render.shadowCascadeMask = SHADOW_CASCADE_0 | SHADOW_CASCADE_1;
      */
     set shadowCascadeMask(value) {
         if (this._shadowCascadeMask !== value) {

--- a/src/framework/graphics/scene-depth-reader.js
+++ b/src/framework/graphics/scene-depth-reader.js
@@ -42,8 +42,8 @@ const _farLimitFractionHalf = 1 - 1.5e-3;
  * consumes it, or {@link CameraComponent#requestSceneDepthMap}.
  *
  * ```javascript
- * const reader = new pc.SceneDepthReader(camera.camera);
- * const rect = new pc.Vec4(0.45, 0.45, 0.1, 0.1);
+ * const reader = new SceneDepthReader(camera.camera);
+ * const rect = new Vec4(0.45, 0.45, 0.1, 0.1);
  *
  * app.on('update', () => {
  *     reader.read(rect, 8, 8)?.then((samples) => {


### PR DESCRIPTION
Three recently added JSDoc examples used the `pc.` global-namespace prefix, which the rest of `src/` does not: across all JSDoc in `src/`, 626 lines construct classes unprefixed (`new Vec3(...)`) against these 3, and all ~215 constant references in examples are bare. This brings the outliers in line.

**Changes:**
- `CameraComponent#projectionOffset` example: `pc.math.DEG_TO_RAD` -> `math.DEG_TO_RAD`, `new pc.Vec2` -> `new Vec2`
- `RenderComponent#shadowCascadeMask` example: `pc.SHADOW_CASCADE_0 | pc.SHADOW_CASCADE_1` -> unprefixed
- `SceneDepthReader` class example: `new pc.SceneDepthReader` -> `new SceneDepthReader`, `new pc.Vec4` -> `new Vec4`

Documentation comments only - no code or API changes.