### PR TITLE
Fix volumetric fog missing for one frame after a canvas resize

### DIFF
--- a/src/extras/render-passes/frame-pass-camera-frame.js
+++ b/src/extras/render-passes/frame-pass-camera-frame.js
@@ -925,9 +925,19 @@ class FramePassCameraFrame extends FramePass {
 
         if (this.sceneDepthTexture) {
 
-            // the alias of the scene color is not resized by a pass of its own, as it shares its
-            // texture with the scene render target, which the scene pass resizes
-            this.rtSceneColor.resize(this.rt.width, this.rt.height);
+            // The alias of the scene color is not resized by a pass of its own, as it shares its
+            // texture with the scene render target, which the scene pass resizes. Its size is
+            // evaluated the same way that pass evaluates it, instead of read back from the render
+            // target - the frame graph updates the passes this frame pass owns after it, so on the
+            // frame the canvas resizes the render target is still the previous size. Reading it back
+            // would leave this alias attached to the texture the shared one has replaced, and the
+            // passes rendering into it writing to nothing for that frame.
+            const { scenePass } = this;
+            const resizeSource = scenePass.options.resizeSource ?? this.device.backBuffer;
+            this.rtSceneColor.resize(
+                Math.floor(resizeSource.width * scenePass.scaleX),
+                Math.floor(resizeSource.height * scenePass.scaleY)
+            );
 
             // cleared to the reciprocal of the far clip, which makes the background a surface at
             // that distance taking part in the average the blended geometry accumulates - whatever


### PR DESCRIPTION
The volumetric fog examples lose the fog for exactly one frame right after the window is resized.

With the volumetric fog enabled, `CameraFrame` renders the scene depth as an additional attachment of the scene render target. The fog combine pass samples that depth, so it cannot render into the render target it is attached to, and renders into `rtSceneColor` instead - an alias wrapping the same color texture without the depth. That alias has no pass of its own to resize it, so `FramePassCameraFrame.frameUpdate` resized it from the scene render target's dimensions.

`FrameGraph.addRenderPass` updates a frame pass before the passes it owns, though, and the scene render target is resized by the scene pass - one of them. On the frame the canvas resizes the alias was therefore resized to the previous size, and the `this.rt.resize()` which followed replaced the shared texture's GPU object while the alias kept a framebuffer attached to the one it replaced. The combine pass drew the fog into an orphaned surface nothing samples, with a stale viewport. This failed silently, as `checkFramebufferStatus` still reports the framebuffer as complete - WebGL keeps a deleted but attached texture alive.

**Changes:**
- Evaluate the size of the scene color alias the same way the scene pass evaluates the size of the render target it shares its texture with, instead of reading it back from that render target a frame stale.

Verified on WebGL2 by stepping the frame graph one frame at a time across a resize, growing and shrinking: the alias' framebuffer now keeps the live texture and its viewport matches, and a canvas readback on the resize frame matches the frame which follows it rather than a fog-disabled reference.