### PR TITLE
Fix broken LOD example link in GSplatComponent docs

### DIFF
--- a/src/framework/components/gsplat/component.js
+++ b/src/framework/components/gsplat/component.js
@@ -52,8 +52,9 @@ const UNIFIED_LEGACY_HINT = 'GSplatComponent#unified now defaults to true (unifi
  * Relevant Engine API examples:
  *
  * - [Simple Splat Loading](https://playcanvas.github.io/#/gaussian-splatting/simple)
+ * - [Billions of Splats](https://playcanvas.github.io/#/gaussian-splatting/billions)
+ * - [Downtown Streaming](https://playcanvas.github.io/#/gaussian-splatting/downtown)
  * - [Global Sorting](https://playcanvas.github.io/#/gaussian-splatting/global-sorting)
- * - [LOD](https://playcanvas.github.io/#/gaussian-splatting/lod)
  * - [LOD Instances](https://playcanvas.github.io/#/gaussian-splatting/lod-instances)
  * - [LOD Streaming](https://playcanvas.github.io/#/gaussian-splatting/lod-streaming)
  * - [LOD Streaming with Spherical Harmonics](https://playcanvas.github.io/#/gaussian-splatting/lod-streaming-sh)


### PR DESCRIPTION
The `GSplatComponent` class docs link to [`#/gaussian-splatting/lod`](https://playcanvas.github.io/#/gaussian-splatting/lod), but that example was removed in #8218 ("Remove old private LOD example now that we have public examples"), so the link 404s.

Its public successors — LOD Instances, LOD Streaming and LOD Streaming with Spherical Harmonics — were already in the list, so the entry is redundant rather than just stale. Instead of leaving a gap, it is replaced with the two LOD-focused gsplat examples that were missing from the list:

- **Billions of Splats** — instances a multi-LOD streamed scene, splat count reaching into the billions
- **Downtown Streaming** — a 250M splat streamed real-world city

Both are inserted in the list's existing alphabetical order (which follows the intro "Simple Splat Loading" entry).

```diff
  - [Simple Splat Loading](https://playcanvas.github.io/#/gaussian-splatting/simple)
+ - [Billions of Splats](https://playcanvas.github.io/#/gaussian-splatting/billions)
+ - [Downtown Streaming](https://playcanvas.github.io/#/gaussian-splatting/downtown)
  - [Global Sorting](https://playcanvas.github.io/#/gaussian-splatting/global-sorting)
- - [LOD](https://playcanvas.github.io/#/gaussian-splatting/lod)
  - [LOD Instances](https://playcanvas.github.io/#/gaussian-splatting/lod-instances)
```

I audited every `playcanvas.github.io/#/<category>/<example>` link in `src/` against the examples that actually exist. This was the only broken one, and after the change all **69 links resolve**.

Docs-only change. Split out from #9284, which removes the orphaned thumbnail left behind by the same example deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)