### PR TITLE
Store immediate line batches in retained typed arrays

### DIFF
--- a/src/scene/immediate/immediate-batch.js
+++ b/src/scene/immediate/immediate-batch.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../core/debug.js';
 import { Mat4 } from '../../core/math/mat4.js';
 
 import { PRIMITIVE_LINES } from '../../platform/graphics/constants.js';
@@ -6,50 +7,180 @@ import { Mesh } from '../mesh.js';
 import { MeshInstance } from '../mesh-instance.js';
 import { GraphNode } from '../graph-node.js';
 
+/**
+ * @import { Color } from '../../core/math/color.js'
+ */
+
 const identityGraphNode = new GraphNode();
 identityGraphNode.worldTransform = Mat4.IDENTITY;
 identityGraphNode._dirtyWorld = identityGraphNode._dirtyNormal = false;
 
+// smallest storage a batch keeps once it has been used, in vertices
+const MIN_VERTEX_CAPACITY = 256;
+
+// number of frames a batch must go without needing more than half its storage before the
+// remainder is handed back
+const SHRINK_FRAME_DELAY = 100;
+
 // helper class storing data for a single batch of line rendering using a single material
 class ImmediateBatch {
+    /**
+     * Packed xyz positions. Only the first `_vertexCount` vertices hold data for the current
+     * frame, the rest is spare capacity retained between frames.
+     *
+     * @type {Float32Array}
+     * @private
+     */
+    _positions = new Float32Array(0);
+
+    /**
+     * Packed rgba colors, one per position.
+     *
+     * @type {Float32Array}
+     * @private
+     */
+    _colors = new Float32Array(0);
+
+    /**
+     * Vertices written so far this frame.
+     *
+     * @type {number}
+     * @private
+     */
+    _vertexCount = 0;
+
+    /**
+     * Vertices the buffers can hold without reallocating.
+     *
+     * @type {number}
+     * @private
+     */
+    _capacity = 0;
+
+    /**
+     * Largest vertex count seen since shrinking was last considered.
+     *
+     * @type {number}
+     * @private
+     */
+    _peakVertexCount = 0;
+
+    /**
+     * Frames elapsed since a frame needed more than half the storage.
+     *
+     * @type {number}
+     * @private
+     */
+    _framesSinceHighUse = 0;
+
     constructor(device, material, layer) {
         this.material = material;
         this.layer = layer;
 
-        // line data, arrays of numbers
-        this.positions = [];
-        this.colors = [];
-
         this.mesh = new Mesh(device);
         this.meshInstance = null;
+    }
+
+    /**
+     * Ensures room for the supplied number of additional vertices, growing by doubling so a batch
+     * filled over many calls does not reallocate on each one.
+     *
+     * @param {number} count - The number of vertices about to be added.
+     * @private
+     */
+    _reserve(count) {
+        const required = this._vertexCount + count;
+        if (required <= this._capacity) {
+            return;
+        }
+
+        let capacity = Math.max(this._capacity, MIN_VERTEX_CAPACITY);
+        while (capacity < required) {
+            capacity *= 2;
+        }
+        this._setCapacity(capacity);
+    }
+
+    /**
+     * Reallocates the storage, preserving whatever has already been added this frame.
+     *
+     * @param {number} capacity - The new capacity in vertices.
+     * @private
+     */
+    _setCapacity(capacity) {
+        const positions = new Float32Array(capacity * 3);
+        const colors = new Float32Array(capacity * 4);
+
+        const retained = Math.min(this._vertexCount, capacity);
+        if (retained > 0) {
+            positions.set(this._positions.subarray(0, retained * 3));
+            colors.set(this._colors.subarray(0, retained * 4));
+        }
+
+        this._positions = positions;
+        this._colors = colors;
+        this._capacity = capacity;
+    }
+
+    /**
+     * Writes a single color to every vertex of a range.
+     *
+     * @param {Color} color - The color to write.
+     * @param {number} first - The first vertex to write.
+     * @param {number} count - The number of vertices to write.
+     * @private
+     */
+    _writeUniformColor(color, first, count) {
+        const dest = this._colors;
+        const { r, g, b, a } = color;
+        let c = first * 4;
+        for (let i = 0; i < count; i++) {
+            dest[c++] = r;
+            dest[c++] = g;
+            dest[c++] = b;
+            dest[c++] = a;
+        }
     }
 
     // add line positions and colors to the batch
     // this function expects position in Vec3 and colors in Color format
     addLines(positions, color) {
 
-        // positions
-        const destPos = this.positions;
         const count = positions.length;
+        const first = this._vertexCount;
+        this._reserve(count);
+
+        // positions
+        const destPos = this._positions;
+        let p = first * 3;
         for (let i = 0; i < count; i++) {
             const pos = positions[i];
-            destPos.push(pos.x, pos.y, pos.z);
+            destPos[p++] = pos.x;
+            destPos[p++] = pos.y;
+            destPos[p++] = pos.z;
         }
 
         // colors
-        const destCol = this.colors;
         if (color.length) {
             // multi colored line
+            Debug.assert(color.length === count,
+                `Expected ${count} colors to match the supplied positions, got ${color.length}.`);
+
+            const destCol = this._colors;
+            let c = first * 4;
             for (let i = 0; i < count; i++) {
                 const col = color[i];
-                destCol.push(col.r, col.g, col.b, col.a);
+                destCol[c++] = col.r;
+                destCol[c++] = col.g;
+                destCol[c++] = col.b;
+                destCol[c++] = col.a;
             }
         } else {
             // single colored line
-            for (let i = 0; i < count; i++) {
-                destCol.push(color.r, color.g, color.b, color.a);
-            }
+            this._writeUniformColor(color, first, count);
         }
+
+        this._vertexCount += count;
     }
 
     // add line positions and colors to the batch
@@ -57,38 +188,52 @@ class ImmediateBatch {
     // and color as instance of Color or array of number specifying the same number of vertices as positions
     addLinesArrays(positions, color) {
 
+        const floats = positions.length;
+        const count = floats / 3;
+        const first = this._vertexCount;
+        this._reserve(count);
+
         // positions
-        const destPos = this.positions;
-        for (let i = 0; i < positions.length; i += 3) {
-            destPos.push(positions[i], positions[i + 1], positions[i + 2]);
+        const destPos = this._positions;
+        let p = first * 3;
+        for (let i = 0; i < floats; i++) {
+            destPos[p++] = positions[i];
         }
 
         // colors
-        const destCol = this.colors;
         if (color.length) {
-            for (let i = 0; i < color.length; i += 4) {
-                destCol.push(color[i], color[i + 1], color[i + 2], color[i + 3]);
+            Debug.assert(color.length === count * 4,
+                `Expected ${count * 4} color values to match the supplied positions, got ${color.length}.`);
+
+            const destCol = this._colors;
+            const colorFloats = count * 4;
+            let c = first * 4;
+            for (let i = 0; i < colorFloats; i++) {
+                destCol[c++] = color[i];
             }
         } else {
             // single colored line
-            const count = positions.length / 3;
-            for (let i = 0; i < count; i++) {
-                destCol.push(color.r, color.g, color.b, color.a);
-            }
+            this._writeUniformColor(color, first, count);
         }
+
+        this._vertexCount += count;
     }
 
     onPreRender(visibleList, transparent) {
 
         // prepare mesh if its transparency matches
-        if (this.positions.length > 0 && this.material.transparent === transparent) {
+        if (this._vertexCount > 0 && this.material.transparent === transparent) {
 
-            // update mesh vertices
-            this.mesh.setPositions(this.positions);
-            this.mesh.setColors(this.colors);
+            // update mesh vertices, using only the part of the storage written this frame
+            this.mesh.setPositions(this._positions, 3, this._vertexCount);
+            this.mesh.setColors(this._colors, 4, this._vertexCount);
             this.mesh.update(PRIMITIVE_LINES, false);
             if (!this.meshInstance) {
                 this.meshInstance = new MeshInstance(this.mesh, this.material, identityGraphNode);
+
+                // the mesh instance is injected straight into the visible list and its bounding
+                // box is never computed, so it must not take part in culling
+                this.meshInstance.cull = false;
             }
 
             // inject mesh instance into visible list to be rendered
@@ -97,9 +242,36 @@ class ImmediateBatch {
     }
 
     clear() {
-        // clear lines after they are rendered as their lifetime is one frame
-        this.positions.length = 0;
-        this.colors.length = 0;
+        // lines live for one frame only, but the storage is retained so the next frame does not
+        // have to grow it again
+        if (this._vertexCount * 2 > this._capacity) {
+
+            // this frame justified the storage, so restart the wait and the peak measurement
+            this._framesSinceHighUse = 0;
+            this._peakVertexCount = 0;
+        } else {
+            this._framesSinceHighUse++;
+            this._peakVertexCount = Math.max(this._peakVertexCount, this._vertexCount);
+        }
+
+        this._vertexCount = 0;
+
+        // after a long enough run of frames that did not need more than half the storage, shrink
+        // to fit the largest of them rather than to the last one, so a batch whose usage varies
+        // does not have to grow again immediately
+        if (this._framesSinceHighUse >= SHRINK_FRAME_DELAY && this._capacity > MIN_VERTEX_CAPACITY) {
+
+            let capacity = MIN_VERTEX_CAPACITY;
+            while (capacity < this._peakVertexCount) {
+                capacity *= 2;
+            }
+            if (capacity < this._capacity) {
+                this._setCapacity(capacity);
+            }
+
+            this._peakVertexCount = 0;
+            this._framesSinceHighUse = 0;
+        }
     }
 }
 

--- a/test/scene/immediate/immediate-batch.test.mjs
+++ b/test/scene/immediate/immediate-batch.test.mjs
@@ -1,0 +1,239 @@
+import { expect } from 'chai';
+
+import { Color } from '../../../src/core/math/color.js';
+import { Vec3 } from '../../../src/core/math/vec3.js';
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+import { ImmediateBatch } from '../../../src/scene/immediate/immediate-batch.js';
+
+// these mirror the private constants in immediate-batch.js
+const MIN_VERTEX_CAPACITY = 256;
+const SHRINK_FRAME_DELAY = 100;
+
+// runs the function with console.error suppressed, and returns the number of debug asserts it fired
+const withAssertCount = (fn) => {
+    const error = console.error;
+    let count = 0;
+    console.error = () => {
+        count++;
+    };
+    try {
+        fn();
+    } finally {
+        console.error = error;
+    }
+    return count;
+};
+
+describe('ImmediateBatch', function () {
+
+    let device;
+    let batch;
+
+    beforeEach(function () {
+        device = new NullGraphicsDevice({ id: 'mock' });
+        batch = new ImmediateBatch(device, { transparent: false }, null);
+    });
+
+    afterEach(function () {
+        device.destroy();
+    });
+
+    // advances the batch by the given number of empty frames
+    const idleFrames = (count) => {
+        for (let i = 0; i < count; i++) {
+            batch.clear();
+        }
+    };
+
+    const positions = (count) => {
+        const result = [];
+        for (let i = 0; i < count; i++) {
+            result.push(new Vec3(i, i * 2, i * 3));
+        }
+        return result;
+    };
+
+    describe('#addLines', function () {
+
+        it('writes positions and a uniform color', function () {
+            batch.addLines([new Vec3(1, 2, 3), new Vec3(4, 5, 6)], new Color(0.25, 0.5, 0.75, 1));
+
+            expect(batch._vertexCount).to.equal(2);
+            expect(Array.from(batch._positions.subarray(0, 6))).to.deep.equal([1, 2, 3, 4, 5, 6]);
+            expect(Array.from(batch._colors.subarray(0, 8))).to.deep.equal([
+                0.25, 0.5, 0.75, 1,
+                0.25, 0.5, 0.75, 1
+            ]);
+        });
+
+        it('writes one color per vertex when given an array', function () {
+            batch.addLines([new Vec3(0, 0, 0), new Vec3(1, 1, 1)], [Color.RED, Color.BLUE]);
+
+            expect(Array.from(batch._colors.subarray(0, 8))).to.deep.equal([
+                1, 0, 0, 1,
+                0, 0, 1, 1
+            ]);
+        });
+
+        it('appends without disturbing data already added this frame', function () {
+            batch.addLines([new Vec3(1, 1, 1), new Vec3(2, 2, 2)], Color.RED);
+            batch.addLines([new Vec3(3, 3, 3), new Vec3(4, 4, 4)], Color.BLUE);
+
+            expect(batch._vertexCount).to.equal(4);
+            expect(Array.from(batch._positions.subarray(0, 12))).to.deep.equal([
+                1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4
+            ]);
+            expect(Array.from(batch._colors.subarray(0, 4))).to.deep.equal([1, 0, 0, 1]);
+            expect(Array.from(batch._colors.subarray(8, 12))).to.deep.equal([0, 0, 1, 1]);
+        });
+
+        it('asserts when the color array length does not match the positions', function () {
+            const count = withAssertCount(() => {
+                // reading past the end of a short color array throws, as it did before this
+                // change, but the assert fires first and names the actual problem
+                expect(() => batch.addLines([new Vec3(), new Vec3()], [Color.RED])).to.throw(TypeError);
+            });
+            expect(count).to.equal(1);
+        });
+    });
+
+    describe('#addLinesArrays', function () {
+
+        it('writes packed positions and a uniform color', function () {
+            batch.addLinesArrays([1, 2, 3, 4, 5, 6], new Color(1, 1, 0, 0.5));
+
+            expect(batch._vertexCount).to.equal(2);
+            expect(Array.from(batch._positions.subarray(0, 6))).to.deep.equal([1, 2, 3, 4, 5, 6]);
+            expect(Array.from(batch._colors.subarray(0, 8))).to.deep.equal([
+                1, 1, 0, 0.5,
+                1, 1, 0, 0.5
+            ]);
+        });
+
+        it('writes packed per-vertex colors', function () {
+            batch.addLinesArrays([0, 0, 0, 1, 1, 1], [1, 0, 0, 1, 0, 1, 0, 1]);
+
+            expect(Array.from(batch._colors.subarray(0, 8))).to.deep.equal([
+                1, 0, 0, 1,
+                0, 1, 0, 1
+            ]);
+        });
+
+        it('accepts a typed array', function () {
+            batch.addLinesArrays(new Float32Array([1, 2, 3, 4, 5, 6]), Color.WHITE);
+            expect(Array.from(batch._positions.subarray(0, 6))).to.deep.equal([1, 2, 3, 4, 5, 6]);
+        });
+
+        it('asserts when the color array length does not match the positions', function () {
+            const count = withAssertCount(() => {
+                batch.addLinesArrays([0, 0, 0, 1, 1, 1], [1, 0, 0, 1]);
+            });
+            expect(count).to.equal(1);
+        });
+    });
+
+    describe('capacity', function () {
+
+        it('allocates nothing until used', function () {
+            expect(batch._capacity).to.equal(0);
+            expect(batch._positions.length).to.equal(0);
+        });
+
+        it('allocates the minimum capacity for a small batch', function () {
+            batch.addLines([new Vec3(), new Vec3()], Color.WHITE);
+            expect(batch._capacity).to.equal(MIN_VERTEX_CAPACITY);
+        });
+
+        it('grows by doubling', function () {
+            batch.addLines(positions(MIN_VERTEX_CAPACITY + 1), Color.WHITE);
+            expect(batch._capacity).to.equal(MIN_VERTEX_CAPACITY * 2);
+        });
+
+        it('grows enough for a single large request', function () {
+            const count = MIN_VERTEX_CAPACITY * 10;
+            batch.addLines(positions(count), Color.WHITE);
+            expect(batch._capacity).to.be.at.least(count);
+            expect(batch._positions.length).to.equal(batch._capacity * 3);
+            expect(batch._colors.length).to.equal(batch._capacity * 4);
+        });
+
+        it('preserves earlier data when growth happens mid frame', function () {
+            batch.addLines([new Vec3(7, 8, 9), new Vec3(10, 11, 12)], Color.RED);
+            batch.addLines(positions(MIN_VERTEX_CAPACITY), Color.BLUE);
+
+            expect(batch._capacity).to.be.above(MIN_VERTEX_CAPACITY);
+            expect(Array.from(batch._positions.subarray(0, 6))).to.deep.equal([7, 8, 9, 10, 11, 12]);
+            expect(Array.from(batch._colors.subarray(0, 4))).to.deep.equal([1, 0, 0, 1]);
+        });
+
+        it('retains its storage across clear', function () {
+            batch.addLines(positions(MIN_VERTEX_CAPACITY * 2), Color.WHITE);
+            const capacity = batch._capacity;
+            const buffer = batch._positions;
+
+            batch.clear();
+
+            expect(batch._vertexCount).to.equal(0);
+            expect(batch._capacity).to.equal(capacity);
+            expect(batch._positions).to.equal(buffer);
+        });
+    });
+
+    describe('shrinking', function () {
+
+        it('hands storage back after a run of under-half usage', function () {
+            batch.addLines(positions(MIN_VERTEX_CAPACITY * 4), Color.WHITE);
+            expect(batch._capacity).to.be.at.least(MIN_VERTEX_CAPACITY * 4);
+
+            // the frame that used the storage ends the previous wait, so the run of idle frames
+            // starts with the one after it
+            idleFrames(SHRINK_FRAME_DELAY + 1);
+
+            expect(batch._capacity).to.equal(MIN_VERTEX_CAPACITY);
+            expect(batch._positions.length).to.equal(MIN_VERTEX_CAPACITY * 3);
+            expect(batch._colors.length).to.equal(MIN_VERTEX_CAPACITY * 4);
+        });
+
+        it('does not shrink before the delay has elapsed', function () {
+            batch.addLines(positions(MIN_VERTEX_CAPACITY * 4), Color.WHITE);
+            const grown = batch._capacity;
+
+            idleFrames(SHRINK_FRAME_DELAY);
+
+            expect(batch._capacity).to.equal(grown);
+        });
+
+        it('shrinks only to the peak seen while waiting', function () {
+            batch.addLines(positions(MIN_VERTEX_CAPACITY * 8), Color.WHITE);
+            batch.clear();
+
+            // a mid sized frame during the wait sets the floor the batch shrinks to
+            for (let i = 0; i < SHRINK_FRAME_DELAY; i++) {
+                if (i === 10) {
+                    batch.addLines(positions(MIN_VERTEX_CAPACITY + 1), Color.WHITE);
+                }
+                batch.clear();
+            }
+
+            expect(batch._capacity).to.equal(MIN_VERTEX_CAPACITY * 2);
+        });
+
+        it('does not shrink while usage stays above half the capacity', function () {
+            batch.addLines(positions(MIN_VERTEX_CAPACITY * 2), Color.WHITE);
+            const capacity = batch._capacity;
+
+            for (let i = 0; i < SHRINK_FRAME_DELAY * 3; i++) {
+                batch.addLines(positions(MIN_VERTEX_CAPACITY * 2), Color.WHITE);
+                batch.clear();
+            }
+
+            expect(batch._capacity).to.equal(capacity);
+        });
+
+        it('never shrinks below the minimum capacity', function () {
+            batch.addLines([new Vec3(), new Vec3()], Color.WHITE);
+            idleFrames(SHRINK_FRAME_DELAY * 3);
+            expect(batch._capacity).to.equal(MIN_VERTEX_CAPACITY);
+        });
+    });
+});


### PR DESCRIPTION
`ImmediateBatch` accumulated line data in two plain arrays and truncated both in `clear()` every frame, so each frame re-grew them element by element through `push()`. For a batch of any size that dominates the cost of submitting lines — it is the single hottest thing in the immediate line path.

The storage is now a pair of `Float32Array`s with an explicit vertex count:

- appends are index writes rather than `push`, with no capacity check per value
- `clear()` resets the count and keeps the backing store, so a steady workload never reallocates
- capacity grows by doubling, so a batch filled over many calls reallocates O(log n) times rather than per call
- `Mesh#setPositions` and `Mesh#setColors` already accept a `numVertices` argument, so the mesh consumes only the written part of an over-sized buffer

### Measured

Same payload (60000 segments), same browser, this branch vs `main`:

| | median | min |
| --- | --- | --- |
| before (`push` into plain arrays) | 6.4 ms | 2.5 ms |
| after (retained typed arrays) | **1.3 ms** | 1.1 ms |

The median gains more than the minimum because the old path re-grew its arrays every frame; that allocation churn is precisely what retention removes.

Float32 storage is not a precision change — the vertex buffer these feed is `TYPE_FLOAT32` either way, so the conversion just happens earlier.

### Giving storage back

If no frame in the last 100 has needed more than half the capacity, the batch shrinks to fit the largest frame seen while waiting, never below a 256 vertex floor. Shrinking to the recent peak rather than to the last frame stops a batch whose usage varies from having to grow again immediately.

Verified live through the engine's own `onPostRender()` on `graphics/lines`: after inflating a batch to 131072 vertices, it shrank to 16384 — exactly fitting the observed per-frame peak of 13728 — reclaiming ~3.1 MB.

One known limit: [`Immediate#onPostRender`](https://github.com/playcanvas/engine/blob/main/src/scene/immediate/immediate.js) only clears layers touched that frame, so batches in a layer that stops being used entirely keep their storage. It is bounded by that layer's past peak and cannot grow, and clearing every layer every frame would cost more than it saves. Batches within a *used* layer do tick, which covers the common case (for example the `depthTest: false` batch when nothing draws x-ray lines).

### Also in here

**`cull = false` on the batch mesh instance.** It is injected straight into the visible list and `update()` is called with `updateBoundingBox` false, so its bounding box is never computed and it must not take part in culling. `WideLineRenderer` already does this; `ImmediateBatch` did not.

**Debug asserts on mismatched color array lengths.** The contract was already documented but never checked. A short array previously either threw a `TypeError` deep inside `addLines` or silently produced a colors array shorter than the positions. The assert now names the problem first. Flagging it explicitly since it is adjacent to, rather than required by, the perf work — happy to drop it if you would rather keep this change pure.

### Tests

The batch had none. Adds 19 covering data layout for both add paths, uniform and per-vertex colors, typed-array input, growth by doubling, mid-frame growth preserving earlier data, storage retention across `clear()`, and every branch of the shrink policy. Full suite 2566 passing.

Verified visually on `graphics/lines`, which exercises all three entry points: `addLinesArrays` with a per-vertex color array (the gradient grid), `drawLine` with a single color (the magenta links), and `drawLines` with a `Color[]` (the grey spokes).

Landing this first, ahead of a `WireRenderer` change that builds on the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)