### PR TITLE
Flush the scene depth read as it is issued

### DIFF
--- a/src/framework/graphics/scene-depth-reader.js
+++ b/src/framework/graphics/scene-depth-reader.js
@@ -347,7 +347,13 @@ class SceneDepthReader {
 
         const read = this.renderTarget.colorBuffer.read(0, 0, width, height, {
             renderTarget: this.renderTarget,
-            data: buffer.bytes
+            data: buffer.bytes,
+
+            // Flushed as the read is issued, which is what keeps the copy out of it from blocking. On
+            // WebGL that copy is a synchronous call, and without the flush it waits on the work the
+            // frame still has queued behind the read - which for a read issued every frame is most of
+            // a frame's worth, every frame.
+            immediate: true
         });
 
         // a backend which implements no readback at all - the null device among them - hands back


### PR DESCRIPTION
`SceneDepthReader#read` was blocking the main thread on WebGL. `depth-effects`, which reads every frame, spent a median of **10.3ms per read** inside `getBufferSubData` — 4.1 seconds across 341 frames, most of a frame's worth every frame.

The read itself is asynchronous, but the copy out of the pixel buffer is a synchronous GL call, and without a flush it waits on all the work the frame still has queued behind the read. `Picker` reads back through the same path for `area-picker` and pays **0.22ms**; the difference is that it passes `immediate: true`. Passing it here too removes the cost.

WebGPU was never affected — mapping a staging buffer there does not block.

| | median per read | total |
|---|---|---|
| before | 10.28 ms | 4091 ms / 341 frames |
| picker, for reference | 0.22 ms | 72 ms |

### Testing

- `test/scene-depth-read` passes on WebGL2 and WebGPU across all three encodings (non-linear grab, reciprocal scene textures, linear prepass).
- `depth-effects` profiled by @mvaligursky with the fix: the stall is gone.