### PR TITLE
Remove the wire drawing methods from AppBase

### DIFF
--- a/examples/src/examples/gaussian-splatting/clipping.example.mjs
+++ b/examples/src/examples/gaussian-splatting/clipping.example.mjs
@@ -38,6 +38,7 @@ import {
     TextureHandler,
     TouchDevice,
     Vec3,
+    WireRenderer,
     createGraphicsDevice,
     platform
 } from 'playcanvas';
@@ -120,6 +121,10 @@ await new Promise((resolve) => {
 });
 
 app.start();
+
+// Renderer for the clipping box outline
+const wire = new WireRenderer(app);
+wire.color = Color.YELLOW;
 
 // Setup skydome
 app.scene.envAtlas = assets.envatlas.resource;
@@ -234,7 +239,7 @@ app.on('update', (dt) => {
     // Draw the clipping box
     boxMin.copy(clipCenter).sub(clipHalf);
     boxMax.copy(clipCenter).add(clipHalf);
-    app.drawWireAlignedBox(boxMin, boxMax, Color.YELLOW);
+    wire.boxMinMax(boxMin, boxMax);
 
     // stats
     data.set('data.stats.gsplats', app.stats.frame.gsplats.toLocaleString());

--- a/examples/src/examples/gaussian-splatting/editor.example.mjs
+++ b/examples/src/examples/gaussian-splatting/editor.example.mjs
@@ -47,6 +47,7 @@ import {
     TranslateGizmo,
     Vec3,
     WORKBUFFER_UPDATE_ONCE,
+    WireRenderer,
     createGraphicsDevice
 } from 'playcanvas';
 
@@ -112,6 +113,10 @@ await new Promise((resolve) => {
 });
 
 app.start();
+
+// Renderer for the selection box outline
+const wire = new WireRenderer(app);
+wire.color = Color.YELLOW;
 
 data.on('renderer:set', () => {
     app.scene.gsplat.renderer = data.get('renderer');
@@ -563,7 +568,7 @@ app.on('update', () => {
     // Sync selection box center with entity position (gizmo moves the entity)
     if (selectionBox && selectionBoxVisible) {
         selectionBox.center.copy(selectionBoxEntity.getPosition());
-        app.drawWireAlignedBox(selectionBox.getMin(), selectionBox.getMax(), Color.YELLOW);
+        wire.boxMinMax(selectionBox.getMin(), selectionBox.getMax());
 
         // Update selection highlighting for all editables
         const boxMin = selectionBox.getMin();

--- a/examples/src/examples/gaussian-splatting/wind.example.mjs
+++ b/examples/src/examples/gaussian-splatting/wind.example.mjs
@@ -35,6 +35,7 @@ import {
     TouchDevice,
     TranslateGizmo,
     Vec3,
+    WireRenderer,
     createGraphicsDevice
 } from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
@@ -98,6 +99,9 @@ await new Promise((resolve) => {
 });
 
 app.start();
+
+// Renderer for the tree edit handles, colored per handle as they are drawn
+const wire = new WireRenderer(app);
 
 app.scene.envAtlas = assets.envAtlas.resource;
 app.scene.skyboxMip = 1;
@@ -408,12 +412,8 @@ app.on('update', (dt) => {
     }
 
     treeItems.forEach((entity, i) => {
-        app.drawWireSphere(
-            entity.getPosition(),
-            entity.getLocalScale().x,
-            i === selectedIndex ? Color.YELLOW : Color.GRAY,
-            20
-        );
+        wire.color = i === selectedIndex ? Color.YELLOW : Color.GRAY;
+        wire.sphere(entity.getPosition(), entity.getLocalScale().x);
     });
 
     if (dragging) {

--- a/examples/src/examples/physics/offset-collision.example.mjs
+++ b/examples/src/examples/physics/offset-collision.example.mjs
@@ -25,6 +25,7 @@ import {
     TextureHandler,
     Vec3,
     WasmModule,
+    WireRenderer,
     createGraphicsDevice,
     math
 } from 'playcanvas';
@@ -101,6 +102,13 @@ await new Promise((resolve) => {
 });
 
 app.start();
+
+// Renderer for the offset collision shape. The segment count, layer and color are settings on
+// the renderer, so they are applied once here rather than passed on every call.
+const wire = new WireRenderer(app);
+wire.color = Color.GREEN;
+wire.segments = 16;
+wire.layer = app.scene.layers.getLayerByName('World');
 
 // Setup skydome
 app.scene.exposure = 2;
@@ -282,12 +290,5 @@ app.on('update', (dt) => {
     });
 
     // Render the offset collision
-    app.scene.immediate.drawWireSphere(
-        modelEntity.collision.getShapePosition(),
-        0.3,
-        Color.GREEN,
-        16,
-        true,
-        app.scene.layers.getLayerByName('World')
-    );
+    wire.sphere(modelEntity.collision.getShapePosition(), 0.3);
 });

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -7,7 +7,6 @@ import { path } from '../core/path.js';
 import { TRACEID_RENDER_FRAME, TRACEID_RENDER_FRAME_TIME } from '../core/constants.js';
 import { Debug } from '../core/debug.js';
 import { EventHandler } from '../core/event-handler.js';
-import { Color } from '../core/math/color.js';
 import { Mat4 } from '../core/math/mat4.js';
 import { math } from '../core/math/math.js';
 import { Quat } from '../core/math/quat.js';
@@ -61,6 +60,7 @@ import { ShaderChunks } from '../scene/shader-lib/shader-chunks.js';
 /**
  * @import { AppOptions } from './app-options.js'
  * @import { BatchManager } from '../scene/batching/batch-manager.js'
+ * @import { Color } from '../core/math/color.js'
  * @import { ElementInput } from './input/element-input.js'
  * @import { GamePads } from '../platform/input/game-pads.js'
  * @import { GraphicsDevice } from '../platform/graphics/graphics-device.js'
@@ -1711,45 +1711,19 @@ class AppBase extends EventHandler {
     }
 
     /**
-     * Draws a wireframe sphere with center, radius and color.
-     *
-     * @param {Vec3} center - The center of the sphere.
-     * @param {number} radius - The radius of the sphere.
-     * @param {Color} [color] - The color of the sphere. It defaults to white if not specified.
-     * @param {number} [segments] - Number of line segments used to render the circles forming the
-     * sphere. Defaults to 20.
-     * @param {boolean} [depthTest] - Specifies if the sphere lines are depth tested against the
-     * depth buffer. Defaults to true.
-     * @param {Layer} [layer] - The layer to render the sphere into. Defaults to {@link LAYERID_IMMEDIATE}.
-     * @example
-     * // Render a red wire sphere with radius of 1
-     * const center = new Vec3(0, 0, 0);
-     * app.drawWireSphere(center, 1.0, Color.RED);
+     * @deprecated Use {@link WireRenderer#sphere} instead.
      * @ignore
      */
-    drawWireSphere(center, radius, color = Color.WHITE, segments = 20, depthTest = true, layer = this.scene.defaultDrawLayer) {
-        this.scene.immediate.drawWireSphere(center, radius, color, segments, depthTest, layer);
+    drawWireSphere() {
+        Debug.removed('AppBase#drawWireSphere is removed. Use WireRenderer#sphere instead.');
     }
 
     /**
-     * Draws a wireframe axis aligned box specified by min and max points and color.
-     *
-     * @param {Vec3} minPoint - The min corner point of the box.
-     * @param {Vec3} maxPoint - The max corner point of the box.
-     * @param {Color} [color] - The color of the sphere. It defaults to white if not specified.
-     * @param {boolean} [depthTest] - Specifies if the sphere lines are depth tested against the
-     * depth buffer. Defaults to true.
-     * @param {Layer} [layer] - The layer to render the sphere into. Defaults to {@link LAYERID_IMMEDIATE}.
-     * @param {Mat4} [mat] - Matrix to transform the box before rendering.
-     * @example
-     * // Render a red wire aligned box
-     * const min = new Vec3(-1, -1, -1);
-     * const max = new Vec3(1, 1, 1);
-     * app.drawWireAlignedBox(min, max, Color.RED);
+     * @deprecated Use {@link WireRenderer#boxMinMax} instead.
      * @ignore
      */
-    drawWireAlignedBox(minPoint, maxPoint, color = Color.WHITE, depthTest = true, layer = this.scene.defaultDrawLayer, mat) {
-        this.scene.immediate.drawWireAlignedBox(minPoint, maxPoint, color, depthTest, layer, mat);
+    drawWireAlignedBox() {
+        Debug.removed('AppBase#drawWireAlignedBox is removed. Use WireRenderer#boxMinMax instead.');
     }
 
     /**


### PR DESCRIPTION
Follow-up to #9288, which added `WireRenderer`.

`AppBase#drawWireSphere` and `#drawWireAlignedBox` are replaced by `WireRenderer#sphere` and `#boxMinMax`, so their bodies and docs are gone and they now report themselves through `Debug.removed`:

```javascript
/**
 * @deprecated Use {@link WireRenderer#sphere} instead.
 * @ignore
 */
drawWireSphere() {
    Debug.removed('AppBase#drawWireSphere is removed. Use WireRenderer#sphere instead.');
}
```

Both were `@ignore` and absent from the type definitions, so this is not a public API change — but they were used widely enough that a silent removal would be unkind. `Debug.removed` is dropped from release builds, so a caller in production gets a no-op and the message only in development.

`Color` is now only referenced from JSDoc in `app-base.js`, so it becomes a type import.

### What stays

The other five `@ignore` draw methods — `drawMesh`, `drawMeshInstance`, `drawQuad`, `drawTexture`, `drawDepthTexture` — have no replacement yet and belong with whatever replaces the mesh submission path.

`Immediate#drawWireSphere` and `#drawWireAlignedBox` both stay too. The aligned box has three callers inside the engine that **cannot** use `WireRenderer`, because core does not depend on extras:

- `src/scene/gsplat/gsplat-data.js`
- `src/scene/gsplat-unified/gsplat-manager.js`
- `src/scene/gsplat-unified/gsplat-octree-instance.js`

The sphere has no callers left, but is kept alongside it as it may be useful again.

### Migrated examples

| Example | Note |
| --- | --- |
| `gaussian-splatting/clipping` | single colored box, so the color moves to the renderer |
| `gaussian-splatting/editor` | same |
| `gaussian-splatting/wind` | colors each handle as it is drawn; its explicit `segments` of 20 was already the default, so it drops out |
| `physics/offset-collision` | reached into `scene.immediate` directly with a non-default segment count and an explicit layer |

That last one is the nicest read of the change. Before:

```javascript
app.scene.immediate.drawWireSphere(
    modelEntity.collision.getShapePosition(), 0.3, Color.GREEN, 16, true,
    app.scene.layers.getLayerByName('World')
);
```

After, with the three settings applied once outside the update loop:

```javascript
wire.sphere(modelEntity.collision.getShapePosition(), 0.3);
```

### Verified

All four examples still draw as before, in the browser. `wind` keeps its two handle colors — measured as `1,1,0,1` for the selected handle and `0.5,0.5,0.5,1` for the rest, with 10 handles at 60 segments each. Both stubs emit their expected messages. 2626 tests passing; engine lint, examples lint, prettier and types all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
