### PR TITLE
Point the downtown example at a single full-scene streamed SOG bundle

### DIFF
--- a/examples/src/examples/gaussian-splatting/downtown.controls.jsx
+++ b/examples/src/examples/gaussian-splatting/downtown.controls.jsx
@@ -3,6 +3,7 @@ import {
     LabelGroup,
     BooleanInput,
     Panel,
+    SelectInput,
     SliderInput,
     Label
 } from '@playcanvas/pcui/react';
@@ -28,6 +29,18 @@ export function Controls({ observer }) {
                         max={40}
                         precision={1}
                         step={0.1}
+                    />
+                </LabelGroup>
+                <LabelGroup text='LOD Mode'>
+                    <SelectInput
+                        type='string'
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'lodMode' }}
+                        value={observer.get('lodMode') || 'error'}
+                        options={[
+                            { v: 'error', t: 'Error' },
+                            { v: 'distance', t: 'Distance' }
+                        ]}
                     />
                 </LabelGroup>
                 <LabelGroup text='Colorize LODs'>

--- a/examples/src/examples/gaussian-splatting/downtown.example.mjs
+++ b/examples/src/examples/gaussian-splatting/downtown.example.mjs
@@ -1,7 +1,7 @@
 // @config
 //
 // Streams a large real-world city downtown (Lublin, Poland) reconstructed as Gaussian splats.
-// 250M splats, 18856 files, 6.0 GB for streaming.
+// 259M splats at full detail (517M across 10 LOD levels), 20767 files, 6.1 GB for streaming.
 //
 // @flag NO_MINISTATS
 // @flag PREFERRED_DEVICE=webgpu
@@ -33,6 +33,7 @@ import {
     GSPLATDATA_COMPACT,
     GSPLAT_DEBUG_LOD,
     GSPLAT_DEBUG_NONE,
+    GSPLAT_LODMODE_ERROR,
     GSPLAT_RENDERER_RASTER_CPU_SORT,
     GSPLAT_RENDERER_RASTER_GPU_SORT,
     GSplatComponentSystem,
@@ -115,16 +116,12 @@ app.on('destroy', () => {
 
 const config = {
     name: 'Lublin-downtown',
-    // The capture was split into 4 balanced pieces, each built as a multi-LOD streamed SOG bundle.
-    // All pieces share the original world coordinates, so they load at the origin and reassemble.
-    urls: [
-        'https://code.playcanvas.com/examples_data/downtown_01/ssog0/lod-meta.json',
-        'https://code.playcanvas.com/examples_data/downtown_01/ssog1/lod-meta.json',
-        'https://code.playcanvas.com/examples_data/downtown_01/ssog2/lod-meta.json',
-        'https://code.playcanvas.com/examples_data/downtown_01/ssog3/lod-meta.json'
-    ],
+    // The whole capture as ONE multi-LOD streamed SOG bundle, built from a full-scene adaptive
+    // (error-metric) LOD chain — no splitting. Supersedes downtown_01, which was the same capture
+    // cut into 4 pieces because the decimator could not hold the 17.6 GB source in one pass.
+    url: 'https://code.playcanvas.com/examples_data/downtown_02/lod-meta.json',
     // Whole-scene orientation (euler degrees). The capture stores height on Z; this rotates it to
-    // be Y-up for the fly camera. VERIFY/ADJUST once the real data is loaded.
+    // be Y-up for the fly camera.
     sceneRotation: [-90, 0, 0],
     lodUpdateDistance: 4,
     lodUnderfillLimit: 5,
@@ -141,10 +138,7 @@ const config = {
 };
 
 const assets = {
-    ssog0: new Asset('ssog0', 'gsplat', { url: config.urls[0] }),
-    ssog1: new Asset('ssog1', 'gsplat', { url: config.urls[1] }),
-    ssog2: new Asset('ssog2', 'gsplat', { url: config.urls[2] }),
-    ssog3: new Asset('ssog3', 'gsplat', { url: config.urls[3] }),
+    scene: new Asset('scene', 'gsplat', { url: config.url }),
     sky: new Asset('hdri', 'texture', { url: config.skyUrl }, { mipmaps: false })
 };
 
@@ -157,8 +151,6 @@ app.start();
 // Custom mini stats showing gsplat counts
 const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy'])); // eslint-disable-line no-unused-vars
 
-const pieces = [assets.ssog0, assets.ssog1, assets.ssog2, assets.ssog3];
-
 // --- scene-wide gsplat defaults ---
 app.scene.gsplat.lodUpdateAngle = 90;
 app.scene.gsplat.lodBehindPenalty = 3;
@@ -169,6 +161,16 @@ app.scene.gsplat.minPixelSize = 2;
 app.scene.gsplat.alphaClipForward = 1 / 255;
 app.scene.gsplat.minContribution = 3;
 app.scene.gsplat.dataFormat = GSPLATDATA_COMPACT;
+
+// How the splat budget picks LOD levels: 'error' spends it where the bundle's per-node error
+// metadata says detail is worth most; 'distance' orders detail by camera distance alone and
+// ignores that metadata. Error is the default and the reason the bundle carries the metrics.
+data.set('lodMode', GSPLAT_LODMODE_ERROR);
+const applyLodMode = () => {
+    app.scene.gsplat.lodMode = data.get('lodMode');
+};
+applyLodMode();
+data.on('lodMode:set', applyLodMode);
 
 // Colorize LODs debug toggle (off by default)
 data.set('colorizeLods', false);
@@ -181,49 +183,31 @@ data.on('colorizeLods:set', applyColorizeLods);
 // Renderer: CPU-sort raster on WebGL, GPU-sort raster on WebGPU
 app.scene.gsplat.renderer = device.isWebGPU ? GSPLAT_RENDERER_RASTER_GPU_SORT : GSPLAT_RENDERER_RASTER_CPU_SORT;
 
-// --- create the 4 streamed pieces under a single root (shared coordinate frame) ---
-const root = new Entity('downtown');
-root.setLocalEulerAngles(config.sceneRotation[0], config.sceneRotation[1], config.sceneRotation[2]);
-app.root.addChild(root);
+// --- the streamed scene, rotated into a Y-up frame ---
+const entity = new Entity(config.name);
+entity.setLocalEulerAngles(config.sceneRotation[0], config.sceneRotation[1], config.sceneRotation[2]);
+entity.addComponent('gsplat', { asset: assets.scene });
+app.root.addChild(entity);
 
-/** @type {any[]} */
-const gsInstances = [];
-let totalSplats = 0;
-let lodLevels = 1;
-for (let i = 0; i < pieces.length; i++) {
-    const entity = new Entity(`${config.name}-${i}`);
-    entity.addComponent('gsplat', { asset: pieces[i] });
-    root.addChild(entity);
-    gsInstances.push(/** @type {any} */ (entity.gsplat));
-
-    const res = /** @type {any} */ (pieces[i].resource);
-    totalSplats += res.numSplats ?? 0;
-    lodLevels = Math.max(lodLevels, res.octree?.lodLevels ?? 1);
-}
+const gs = /** @type {any} */ (entity.gsplat);
+const resource = /** @type {any} */ (assets.scene.resource);
+const lodLevels = resource.octree?.lodLevels ?? 1;
 const toM = (v) => `${(v / 1e6).toFixed(1)}M`;
-data.set('data.stats.splatsTotal', toM(totalSplats));
+data.set('data.stats.splatsTotal', toM(resource.numSplats ?? 0));
 
-// Combined world-space bounds, for framing the camera
+// World-space bounds, for framing the camera and sizing the reveal
 const worldAabb = new BoundingBox();
-root.children.forEach((entity, i) => {
-    const res = /** @type {any} */ (pieces[i].resource);
-    const b = new BoundingBox();
-    b.setFromTransformedAabb(res.aabb, entity.getWorldTransform());
-    if (i === 0) worldAabb.copy(b);
-    else worldAabb.add(b);
-});
+worldAabb.setFromTransformedAabb(resource.aabb, entity.getWorldTransform());
 const center = worldAabb.center.clone();
 const radius = worldAabb.halfExtents.length();
 
 // --- circular reveal: keep all splats hidden until the first frame is ready, then sweep them
-// in from the INITIAL CAMERA POSITION. Runs on the shared (unified) gsplat material, so one
-// instance drives all four pieces. While loading, the effect time is pinned negative
+// in from the INITIAL CAMERA POSITION. While loading, the effect time is pinned negative
 // (everything hidden, see the update loop); it is released on frame:ready below. ---
 const camStart = new Vec3(config.cameraPosition[0], config.cameraPosition[1], config.cameraPosition[2]);
 const revealReach = camStart.distance(center) + radius; // furthest splat from the camera start
-const revealHost = /** @type {Entity} */ (root.children[0]);
-revealHost.addComponent('script');
-const reveal = /** @type {any} */ (/** @type {any} */ (revealHost.script).create(GSplatRevealRadial));
+entity.addComponent('script');
+const reveal = /** @type {any} */ (/** @type {any} */ (entity.script).create(GSplatRevealRadial));
 reveal.center.copy(camStart);
 reveal.endRadius = revealReach * 1.1; // reaches the whole scene from the camera start
 reveal.speed = (revealReach * 1.1) / 3; // sweep across in ~3s
@@ -246,10 +230,8 @@ app.scene.sky.type = SKYTYPE_INFINITE;
 // Start with the 4 lowest (coarsest) LODs for a fast initial display that still gets some
 // nearby detail, then open up to the full range once the first frame's data is ready.
 const worstLod = lodLevels - 1;
-gsInstances.forEach((gs) => {
-    gs.lodRangeMin = Math.max(0, worstLod - 3);
-    gs.lodRangeMax = worstLod;
-});
+gs.lodRangeMin = Math.max(0, worstLod - 3);
+gs.lodRangeMax = worstLod;
 const gsplatSystem = /** @type {any} */ (app.systems.gsplat);
 const onFrameReady = (
     /** @type {any} */ cam,
@@ -259,10 +241,8 @@ const onFrameReady = (
 ) => {
     if (ready && loadingCount === 0) {
         gsplatSystem.off('frame:ready', onFrameReady);
-        gsInstances.forEach((gs) => {
-            gs.lodRangeMin = 0;
-            gs.lodRangeMax = worstLod;
-        });
+        gs.lodRangeMin = 0;
+        gs.lodRangeMax = worstLod;
         // Reveal the backdrop and sweep the splats in, together, now that the scene is ready
         app.scene.skybox = skyboxCubemap;
         revealStarted = true;


### PR DESCRIPTION
The Lublin downtown capture is now published as one multi-LOD streamed SOG bundle (`downtown_02`) instead of four. The original four-way split existed only because the decimator could not hold the 17.6 GB source in a single pass; splat-transform can now build a full-scene adaptive (error-metric) LOD chain over the whole capture, so the example no longer needs to reassemble pieces.

The new bundle also carries per-node LOD error metadata, which the earlier one predates, so this adds a control to switch the budget balancer between error-driven and distance-driven level selection.

**Changes:**
- Load a single `gsplat` asset from `downtown_02/lod-meta.json` rather than four `downtown_01/ssog0-3` bundles
- Simplify the scene setup accordingly: `config.url` is a single string, there is one asset and one entity, and the `pieces` / `gsInstances` arrays and the intermediate root entity are gone. The scene rotation and the reveal script now live on the scene entity itself, and the combined-bounds loop collapses to one `setFromTransformedAabb`
- Add an Error/Distance **LOD Mode** dropdown to the controls, defaulting to error
- Update the header stats to the new bundle: 259M splats at full detail (517M across 10 LOD levels), 20767 files, 6.1 GB
- Drop a stale `VERIFY/ADJUST` note on `sceneRotation`, now confirmed against the data

**Examples:**
- `gaussian-splatting/downtown` — single-bundle loading, plus the new LOD Mode control