### PR TITLE
Speed up camera movement in the gsplat depth-effects example

### DIFF
--- a/examples/src/examples/gaussian-splatting/depth-effects.example.mjs
+++ b/examples/src/examples/gaussian-splatting/depth-effects.example.mjs
@@ -110,7 +110,7 @@ const CAPTURE = {
     // round behind it so the shafts rake across the frame
     cameraPosition: [1.9, 3.66, 7.49],
     focusPoint: [0.21, 3.18, -0.22],
-    moveSpeed: 0.25,
+    moveSpeed: 1.5,
     sceneSize: 4,
     shadowDistance: 15,
 


### PR DESCRIPTION
The WASD fly speed in the Gaussian Splatting > Depth Effects example was slow enough that crossing the capture took a while, which made the depth of field autofocus and the volumetric fog awkward to try out.

**Changes:**
- Raise `CAPTURE.moveSpeed` in the depth-effects example from 0.25 to 1.5. The shift-to-sprint speed is derived from it (`moveSpeed * 4`), so that goes to 6.0.