### PR TITLE
Make the examples MiniStats toggle drive example-owned instances

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -176,7 +176,7 @@ const app = new Application(canvas, {});
 ```
 
 This is the only file that's required to run an example. The code defined in this function is executed each time the example play button is pressed. It takes the example's canvas element from the DOM and usually begins by creating a new PlayCanvas `Application` or `AppBase` using that canvas.
-The examples loader finds and destroys applications registered to canvases it owns, so the `app` does not need to be exported. Export a `destroy` function only when the example creates non-app resources such as timers, DOM overlays, or animation frames that need cleanup.
+The examples loader finds and destroys applications registered to canvases it owns, so the `app` does not need to be exported. Export a `destroy` function only when the example creates non-app resources such as timers, DOM overlays, or animation frames that need cleanup. An example that creates its own `MiniStats` (to pass custom options) should export it as `miniStats`, so the examples browser toolbar toggle drives that instance instead of adding a second overlay.
 
 Examples can also contain comments which allow you to define the default configuration for your examples as well as overrides to particular settings such as `deviceType`. Check the possible values to set in `ExampleConfig` in `utils/example-source.mjs` file for the full list.
 

--- a/examples/iframe/loader.mjs
+++ b/examples/iframe/loader.mjs
@@ -215,7 +215,10 @@ class ExampleLoader {
 
         if (!this._started) {
             // just notify to clean UI, but not during hot-reload
-            fire('exampleLoading', { showDeviceSelector: !this._config.NO_DEVICE_SELECTOR });
+            fire('exampleLoading', {
+                showDeviceSelector: !this._config.NO_DEVICE_SELECTOR,
+                showMiniStats: !this._config.NO_MINISTATS
+            });
         }
 
         clearImports();
@@ -224,6 +227,10 @@ class ExampleLoader {
             // import local file
             const module = await importModule('example.mjs');
             this._app = module.app ?? window.pc?.AppBase.getApplication('application-canvas');
+
+            // an example creating its own MiniStats (to pass custom options) hands it over here,
+            // so that the UI toggle drives that instance
+            MiniStats.adopt(module.miniStats);
 
             // additional destroy handler for non-app resources
             if (typeof module.destroy === 'function') {

--- a/examples/iframe/ministats.mjs
+++ b/examples/iframe/ministats.mjs
@@ -5,8 +5,31 @@ import { getQueryParams } from './runtime.mjs';
 const params = getQueryParams(window.location.href);
 
 export default class MiniStats {
-    /** @type {PcMiniStats | null} */
+    /**
+     * The instance driven by the UI toggle. Either created here on demand, or handed over by an
+     * example which needs custom options, see {@link MiniStats.adopt}.
+     *
+     * @type {PcMiniStats | null}
+     */
     static instance = null;
+
+    /**
+     * Takes over an instance created by the example itself, so the UI toggle drives that one
+     * instead of adding a second overlay on top of it.
+     *
+     * @param {PcMiniStats | null | undefined} instance - The instance exported by the example.
+     */
+    static adopt(instance) {
+        if (instance) {
+            MiniStats.instance = instance;
+
+            // thumbnail capture loads the example without the surrounding UI, so there is no toggle
+            // to fold this into - suppress the overlay here instead
+            if (params.miniStats === 'false') {
+                instance.enabled = false;
+            }
+        }
+    }
 
     /**
      * @param {AppBase} app - The app instance.
@@ -14,28 +37,24 @@ export default class MiniStats {
      * @returns {boolean} The resolved MiniStats enabled state.
      */
     static enable(app, state) {
-        if (params.miniStats === 'false') {
-            return false;
-        }
         if (typeof window.pc === 'undefined') {
             return false;
         }
         if (!app) {
             return false;
         }
-        const deviceType = app?.graphicsDevice?.deviceType;
-        if (deviceType === 'null') {
-            return false;
-        }
-        if (state) {
-            if (!MiniStats.instance) {
-                MiniStats.instance = new window.pc.MiniStats(app);
-            }
+
+        // the overlay is unusable on the null device, and thumbnail capture suppresses it
+        const suppressed = app.graphicsDevice?.deviceType === 'null' || params.miniStats === 'false';
+        const enabled = !suppressed && !!state;
+
+        if (enabled && !MiniStats.instance) {
+            MiniStats.instance = new window.pc.MiniStats(app);
         }
         if (!MiniStats.instance) {
             return false;
         }
-        MiniStats.instance.enabled = state;
+        MiniStats.instance.enabled = enabled;
         return MiniStats.instance.enabled;
     }
 

--- a/examples/src/app/components/Menu.mjs
+++ b/examples/src/app/components/Menu.mjs
@@ -19,6 +19,7 @@ import { getLayout } from '../utils.mjs';
 /**
  * @typedef {object} State
  * @property {boolean} showMiniStats - Show MiniStats state.
+ * @property {boolean} hasMiniStats - Whether the loaded example allows the MiniStats overlay.
  * @property {boolean} fullscreen - Fullscreen state.
  * @property {boolean} hasCredits - Whether the loaded example has any credits.
  * @property {boolean} shareDialogOpen - Whether the share dialog is visible.
@@ -36,6 +37,7 @@ class Menu extends TypedComponent {
         return {
             showMiniStats: typeof ui.miniStats === 'boolean' ? ui.miniStats : getLayout() === 'desktop',
             fullscreen: typeof ui.fullscreen === 'boolean' ? ui.fullscreen : false,
+            hasMiniStats: true,
             hasCredits: false,
             shareDialogOpen: false,
             shareUrl: '',
@@ -51,6 +53,7 @@ class Menu extends TypedComponent {
     constructor(props) {
         super(props);
         this._handleKeyDown = this._handleKeyDown.bind(this);
+        this._handleExampleLoading = this._handleExampleLoading.bind(this);
         this._handleExampleLoad = this._handleExampleLoad.bind(this);
         this._handleMiniStats = this._handleMiniStats.bind(this);
         this.toggleMiniStats = this.toggleMiniStats.bind(this);
@@ -128,6 +131,7 @@ class Menu extends TypedComponent {
             console.warn('Menu#useEffect> iframe undefined');
         }
         document.addEventListener('keydown', this._handleKeyDown);
+        window.addEventListener('exampleLoading', this._handleExampleLoading);
         window.addEventListener('exampleLoad', this._handleExampleLoad);
         window.addEventListener('miniStats', this._handleMiniStats);
     }
@@ -141,6 +145,7 @@ class Menu extends TypedComponent {
             }
         }
         document.removeEventListener('keydown', this._handleKeyDown);
+        window.removeEventListener('exampleLoading', this._handleExampleLoading);
         window.removeEventListener('exampleLoad', this._handleExampleLoad);
         window.removeEventListener('miniStats', this._handleMiniStats);
     }
@@ -175,6 +180,14 @@ class Menu extends TypedComponent {
     }
 
     /**
+     * @param {Event} event - exampleLoading event.
+     */
+    _handleExampleLoading(event) {
+        const detail = /** @type {CustomEvent<{ showMiniStats?: boolean }>} */ (event).detail;
+        this.setState({ hasMiniStats: detail?.showMiniStats !== false });
+    }
+
+    /**
      * @param {Event} event - exampleLoad event.
      */
     _handleExampleLoad(event) {
@@ -201,7 +214,7 @@ class Menu extends TypedComponent {
     }
 
     render() {
-        const { showMiniStats, hasCredits, shareDialogOpen, shareUrl, shareTitle } = this.state;
+        const { showMiniStats, hasMiniStats, hasCredits, shareDialogOpen, shareUrl, shareTitle } = this.state;
         const { layout, showCredits } = this.props;
         return jsx(
             Container,
@@ -243,7 +256,7 @@ class Menu extends TypedComponent {
                 jsx('line', { x1: 8.59, y1: 13.51, x2: 15.42, y2: 17.49 }),
                 jsx('line', { x1: 15.41, y1: 6.51, x2: 8.59, y2: 10.49 })
                 )),
-                jsx(Button, {
+                hasMiniStats && jsx(Button, {
                     icon: 'E149',
                     id: 'showMiniStatsButton',
                     class: showMiniStats ? 'selected' : undefined,

--- a/examples/src/app/events.js
+++ b/examples/src/app/events.js
@@ -6,6 +6,7 @@
 /**
  * @typedef {object} LoadingEventDetail
  * @property {boolean} showDeviceSelector - Show device selector
+ * @property {boolean} showMiniStats - Show the MiniStats toggle
  *
  * @typedef {CustomEvent<LoadingEventDetail>} LoadingEvent.
  */

--- a/examples/src/examples/debug/mini-stats.example.mjs
+++ b/examples/src/examples/debug/mini-stats.example.mjs
@@ -1,6 +1,5 @@
 // @config
 // @flag ENGINE=performance
-// @flag NO_MINISTATS
 // @flag WEBGPU_DISABLED
 
 import {
@@ -147,7 +146,7 @@ options.stats = [
 ];
 
 // Create mini-stats system
-const miniStats = new MiniStats(app, options); // eslint-disable-line no-unused-vars
+const miniStats = new MiniStats(app, options);
 
 // Add directional lights to the scene
 const light = new Entity();
@@ -281,3 +280,5 @@ app.on('update', () => {
         }
     }
 });
+
+export { miniStats };

--- a/examples/src/examples/gaussian-splatting/billions.example.mjs
+++ b/examples/src/examples/gaussian-splatting/billions.example.mjs
@@ -4,7 +4,6 @@
 // each at a different position / rotation. The LOD streaming system keeps performance stable while
 // the combined splat count reaches into the billions.
 //
-// @flag NO_MINISTATS
 // @flag PREFERRED_DEVICE=webgpu
 //
 // @credit
@@ -166,7 +165,7 @@ await new Promise((resolve) => {
 app.start();
 
 // Custom mini stats showing gsplat counts
-const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy'])); // eslint-disable-line no-unused-vars
+const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy']));
 
 // --- infinite skybox backdrop from the equirectangular LDR image ---
 // The built-in infinite sky samples a cubemap, so the equirect is reprojected once into a
@@ -417,3 +416,5 @@ data.on('splatBudget:set', applySplatBudget);
 app.on('update', () => {
     data.set('data.stats.gsplats', toM(app.stats.frame.gsplats));
 });
+
+export { miniStats };

--- a/examples/src/examples/gaussian-splatting/depth-effects.example.mjs
+++ b/examples/src/examples/gaussian-splatting/depth-effects.example.mjs
@@ -3,8 +3,6 @@
 // Volumetric fog and depth of field in a Gaussian Splat scene, with no proxy geometry of any kind -
 // both read a scene depth the splats write themselves, see {accent:Scene#gsplat.sceneDepthWrite}.
 //
-// @flag NO_MINISTATS
-//
 // @credit
 // title: SplatGen_demo_addon
 // author: shehab mekky
@@ -137,7 +135,7 @@ await new Promise((resolve) => {
 
 app.start();
 
-const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats'])); // eslint-disable-line no-unused-vars
+const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats']));
 
 // The sun climbs from the horizon at 06:00 to this elevation at noon
 const MAX_SUN_ELEVATION = 65;
@@ -418,3 +416,5 @@ await new Promise((resolve) => {
     };
     app.systems.gsplat.on('frame:ready', onFrameReady);
 });
+
+export { miniStats };

--- a/examples/src/examples/gaussian-splatting/downtown.example.mjs
+++ b/examples/src/examples/gaussian-splatting/downtown.example.mjs
@@ -3,7 +3,6 @@
 // Streams a large real-world city downtown (Lublin, Poland) reconstructed as Gaussian splats.
 // 259M splats at full detail (517M across 10 LOD levels), 20767 files, 6.1 GB for streaming.
 //
-// @flag NO_MINISTATS
 // @flag PREFERRED_DEVICE=webgpu
 //
 // @credit
@@ -149,7 +148,7 @@ await new Promise((resolve) => {
 app.start();
 
 // Custom mini stats showing gsplat counts
-const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy'])); // eslint-disable-line no-unused-vars
+const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy']));
 
 // --- scene-wide gsplat defaults ---
 app.scene.gsplat.lodUpdateAngle = 90;
@@ -402,3 +401,5 @@ app.on('update', () => {
         }
     }
 });
+
+export { miniStats };

--- a/examples/src/examples/gaussian-splatting/flipbook.example.mjs
+++ b/examples/src/examples/gaussian-splatting/flipbook.example.mjs
@@ -3,8 +3,6 @@
 // This example demonstrates gsplat flipbook animation using dynamically loaded splat sequence of ply
 // files.
 //
-// @flag NO_MINISTATS
-//
 // @credit
 // title: Mirror's Edge Apartment - Interior Scene
 // author: Aurélien Martel
@@ -120,7 +118,7 @@ const roomEntity = assets.apartment.resource.instantiateRenderEntity({
 roomEntity.setLocalScale(30, 30, 30);
 app.root.addChild(roomEntity);
 
-const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats'])); // eslint-disable-line no-unused-vars
+const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats']));
 
 // Create an Entity with a camera component
 const camera = new Entity();
@@ -216,3 +214,5 @@ directionalLight.addComponent('light', {
 });
 directionalLight.setEulerAngles(55, 70, 0);
 app.root.addChild(directionalLight);
+
+export { miniStats };

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -2,8 +2,6 @@
 //
 // Demonstrates LOD streaming with radial reveal effect for progressive loading of Gaussian Splats.
 //
-// @flag NO_MINISTATS
-//
 // @credit
 // title: Roman Parish
 // author: Andrii Shramko
@@ -209,7 +207,7 @@ await new Promise((resolve) => {
 
 app.start();
 
-const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy'])); // eslint-disable-line no-unused-vars
+const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy']));
 
 // Enable rotation-based LOD updates and behind-camera penalty
 app.scene.gsplat.lodUpdateAngle = 90;
@@ -594,3 +592,5 @@ app.on('update', () => {
     const bb = app.graphicsDevice.backBufferSize;
     data.set('data.stats.resolution', `${bb.x} x ${bb.y}`);
 });
+
+export { miniStats };

--- a/examples/src/examples/gaussian-splatting/relighting.example.mjs
+++ b/examples/src/examples/gaussian-splatting/relighting.example.mjs
@@ -5,8 +5,6 @@
 // lights and rendered into an offscreen texture (lit color in RGB, mesh coverage mask in A),
 // which is then used to relight the splats.
 //
-// @flag NO_MINISTATS
-//
 // @credit
 // title: Roman Parish
 // author: Andrii Shramko
@@ -218,7 +216,7 @@ await new Promise((resolve) => {
 
 app.start();
 
-const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy'])); // eslint-disable-line no-unused-vars
+const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy']));
 
 // Enable rotation-based LOD updates and behind-camera penalty
 app.scene.gsplat.lodUpdateAngle = 90;
@@ -816,3 +814,5 @@ app.on('update', () => {
     const bb = app.graphicsDevice.backBufferSize;
     data.set('data.stats.resolution', `${bb.x} x ${bb.y}`);
 });
+
+export { miniStats };

--- a/examples/src/examples/gaussian-splatting/weather.example.mjs
+++ b/examples/src/examples/gaussian-splatting/weather.example.mjs
@@ -3,8 +3,6 @@
 // Procedural infinite weather particles rendered as Gaussian splats over a LOD-streamed scene.
 // Particles follow the camera using a deterministic 3D grid with hash-based positioning and animation.
 //
-// @flag NO_MINISTATS
-//
 // @credit
 // title: Roman Parish
 // author: Andrii Shramko
@@ -93,7 +91,7 @@ await new Promise((resolve) => {
 
 app.start();
 
-const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats'])); // eslint-disable-line no-unused-vars
+const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats']));
 
 // LOD streaming settings
 app.scene.gsplat.lodUpdateAngle = 90;
@@ -303,3 +301,5 @@ data.on('extents.0:set', rebuild);
 data.on('extents.1:set', rebuild);
 data.on('extents.2:set', rebuild);
 data.on('density:set', rebuild);
+
+export { miniStats };


### PR DESCRIPTION
The MiniStats button in the examples browser toolbar was a dead control on every example that creates its own `MiniStats` instance. Those examples set `// @flag NO_MINISTATS`, which makes the loader return early, so the toggle resolved to `false` on every click while the overlay the example had created stayed permanently on.

Examples now hand their instance to the harness by exporting it as `miniStats`, and the loader adopts it — so one toggle drives whichever instance exists, whether the harness created it or the example did.

**Changes:**
- `MiniStats.adopt()` in the iframe helper takes over an instance created by an example, so the toggle drives it instead of stacking a second overlay on top of it
- The loader adopts `module.miniStats` after importing an example, alongside the existing `module.app` / `module.destroy` hooks
- `NO_MINISTATS` now also hides the toolbar button, so the examples that opt out entirely (`multi-app`, `vr-lod`, `splat-portal`, `benchmark`) no longer show a control that does nothing
- `?miniStats=false`, used by thumbnail capture, now suppresses adopted instances too — the overlay was previously burned into the thumbnails of these examples. Existing thumbnails are unchanged here and would need regenerating to pick this up
- `README.md` documents the `miniStats` export next to the existing `app` / `destroy` notes

**Examples:**
- Dropped `NO_MINISTATS` and exported the instance from `debug/mini-stats` and the gsplat `billions`, `depth-effects`, `downtown`, `flipbook`, `lod-streaming`, `relighting` and `weather` examples