### PR TITLE
Copy an async texture read at the start of the next frame on request

### DIFF
--- a/examples/src/examples/gaussian-splatting/depth-effects.example.mjs
+++ b/examples/src/examples/gaussian-splatting/depth-effects.example.mjs
@@ -268,7 +268,18 @@ const FOCUS_SAMPLES = 8;
 
 const depthReader = new SceneDepthReader(camera.camera);
 const focusRect = new Vec4();
-const focusSamples = new Float32Array(FOCUS_SAMPLES * FOCUS_SAMPLES);
+
+// Reads are issued every frame and take a few to land, so several are in flight at once and each
+// needs an array of its own - one shared between them would have a read resolving against samples a
+// later one had already overwritten. These are lent out and taken back as reads settle, rather than
+// allocating one per frame, which is a pool the reader cannot keep for callers: it hands the samples
+// over and has no way of knowing when the caller is done reading them.
+const freeSamples = new Set();
+const takeSamples = () => {
+    const samples = freeSamples.values().next().value ?? new Float32Array(FOCUS_SAMPLES * FOCUS_SAMPLES);
+    freeSamples.delete(samples);
+    return samples;
+};
 
 /** Marks the region the autofocus samples. */
 const reticle = document.createElement('div');
@@ -315,23 +326,30 @@ app.on('update', (/** @type {number} */ dt) => {
     // focus is sitting at its limit rather than on what the reticle covers
     reticle.style.borderColor = focusClamped ? 'rgba(255, 90, 30, 0.95)' : 'rgba(255, 255, 255, 0.9)';
 
-    // Read every frame, with no regard for whether earlier reads have landed - several can be in flight.
-    // They all fill the same array, which SceneDepthReader asks callers not to do when reads overlap, so
-    // a read can resolve against samples a later one has already overwritten. That only ever means the
-    // focus eases toward a distance a frame or two stale, which the easing below absorbs, and it saves
-    // allocating an array per frame - a reader whose result mattered exactly would pass its own.
+    // Read every frame, with no regard for whether earlier reads have landed - several can be in
+    // flight, and a read landing after a newer one only means the focus eases toward a distance a
+    // frame or two stale, which the easing below absorbs.
     // The median rather than the nearest sample, as captures are full of faint floaters which would
     // otherwise grab the focus, and thinly covered pixels read too far - the splat depth is weighted by
     // transmittance, so it blends toward the value the depth was cleared to where coverage is partial.
-    depthReader.read(focusRect, FOCUS_SAMPLES, FOCUS_SAMPLES, focusSamples)?.then((samples) => {
-        // a region with nothing in it reads as every sample infinite, which is a read of the distance
-        // like any other and clamps the same way - rather than being dropped, which would leave the
-        // focus wherever it happened to be
-        const finite = samples.filter(Number.isFinite).sort();
-        const median = finite.length ? finite[finite.length >> 1] : Infinity;
-        focusClamped = median > CAPTURE.focusMaxDistance;
-        focusTarget = Math.min(median, CAPTURE.focusMaxDistance);
-    });
+    const samples = takeSamples();
+    const read = depthReader.read(focusRect, FOCUS_SAMPLES, FOCUS_SAMPLES, samples);
+    if (read) {
+        read.then(() => {
+            // a region with nothing in it reads as every sample infinite, which is a read of the distance
+            // like any other and clamps the same way - rather than being dropped, which would leave the
+            // focus wherever it happened to be
+            const finite = samples.filter(Number.isFinite).sort();
+            const median = finite.length ? finite[finite.length >> 1] : Infinity;
+            focusClamped = median > CAPTURE.focusMaxDistance;
+            focusTarget = Math.min(median, CAPTURE.focusMaxDistance);
+        }).finally(() => {
+            freeSamples.add(samples);
+        });
+    } else {
+        // there was nothing to read, so the array was never lent out
+        freeSamples.add(samples);
+    }
 
     if (focusTarget !== null) {
         // ease toward the read distance, frame rate independent, snapping on the first one

--- a/src/framework/graphics/scene-depth-reader.js
+++ b/src/framework/graphics/scene-depth-reader.js
@@ -349,11 +349,16 @@ class SceneDepthReader {
             renderTarget: this.renderTarget,
             data: buffer.bytes,
 
-            // Flushed as the read is issued, which is what keeps the copy out of it from blocking. On
-            // WebGL that copy is a synchronous call, and without the flush it waits on the work the
-            // frame still has queued behind the read - which for a read issued every frame is most of
-            // a frame's worth, every frame.
-            immediate: true
+            // Flushed as the read is issued, so the depth this read wants is on its way to the GPU
+            // rather than sitting in the queue behind the rest of the frame.
+            immediate: true,
+
+            // The copy out of the read is a blocking one on WebGL, and it waits for whatever
+            // rendering is queued in front of it - most of a frame's worth for a read issued every
+            // frame, every frame. Taking it at the start of the next frame instead costs this read
+            // a frame of latency, which the caller of a depth read can absorb far more easily than
+            // the stall.
+            deferCopy: true
         });
 
         // a backend which implements no readback at all - the null device among them - hands back

--- a/src/framework/graphics/scene-depth-reader.js
+++ b/src/framework/graphics/scene-depth-reader.js
@@ -353,12 +353,11 @@ class SceneDepthReader {
             // rather than sitting in the queue behind the rest of the frame.
             immediate: true,
 
-            // The copy out of the read is a blocking one on WebGL, and it waits for whatever
-            // rendering is queued in front of it - most of a frame's worth for a read issued every
-            // frame, every frame. Taking it at the start of the next frame instead costs this read
-            // a frame of latency, which the caller of a depth read can absorb far more easily than
-            // the stall.
-            deferCopy: true
+            // Depth reads come every frame, which is what a readback is worst at - on WebGL its
+            // blocking step waits for the rendering queued in front of it, most of a frame's worth
+            // every frame. Saying so buys a frame of latency in exchange, which the caller of a
+            // depth read absorbs far more easily than the stall.
+            frequent: true
         });
 
         // a backend which implements no readback at all - the null device among them - hands back

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -1418,6 +1418,12 @@ class Texture {
      * @param {boolean} [options.immediate] - If true, the read operation will be executed as soon as
      * possible. This has a performance impact, so it should be used only when necessary. Defaults
      * to false.
+     * @param {boolean} [options.deferCopy] - If true, the pixel data is copied out at the start of
+     * the next frame rather than as soon as it is available. The copy is a blocking operation which
+     * waits for the rendering queued in front of it, so keeping it out of the frame costs the read a
+     * frame of latency and saves that wait. Worth it for a read issued every frame, and not
+     * otherwise. Only utilized on the WebGL platform, ignored on WebGPU, whose readback does not
+     * block. Defaults to false.
      * @returns {Promise<Uint8Array|Uint16Array|Uint32Array|Float32Array>} A promise that resolves
      * with the pixel data of the texture.
      */

--- a/src/platform/graphics/texture.js
+++ b/src/platform/graphics/texture.js
@@ -1418,12 +1418,11 @@ class Texture {
      * @param {boolean} [options.immediate] - If true, the read operation will be executed as soon as
      * possible. This has a performance impact, so it should be used only when necessary. Defaults
      * to false.
-     * @param {boolean} [options.deferCopy] - If true, the pixel data is copied out at the start of
-     * the next frame rather than as soon as it is available. The copy is a blocking operation which
-     * waits for the rendering queued in front of it, so keeping it out of the frame costs the read a
-     * frame of latency and saves that wait. Worth it for a read issued every frame, and not
-     * otherwise. Only utilized on the WebGL platform, ignored on WebGPU, whose readback does not
-     * block. Defaults to false.
+     * @param {boolean} [options.frequent] - Set this when the read is one of many, issued every
+     * frame or every few frames. Such a read is given the treatment which costs it a frame of
+     * latency and keeps it from stalling the frame it is issued in, which is the trade a one-off
+     * read would not want. Only utilized on the WebGL platform, where a readback has a blocking
+     * step; ignored on WebGPU, whose readback does not block. Defaults to false.
      * @returns {Promise<Uint8Array|Uint16Array|Uint32Array|Float32Array>} A promise that resolves
      * with the pixel data of the texture.
      */

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -148,9 +148,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     /**
      * Copies out of a pixel buffer waiting to run at the start of the next frame, for the reads
-     * which asked for that, see {@link WebglGraphicsDevice#readPixelsAsync}.
+     * which asked for that, see {@link WebglGraphicsDevice#readPixelsAsync}. Drained by
+     * {@link WebglGraphicsDevice#frameStart}, and on device destruction and context loss.
      *
-     * @type {Set<{ timer: number, run: () => void }>}
+     * @type {Set<{ run: () => void, abandon: () => void, fail: () => void }>}
      * @private
      */
     _readbackCopies = new Set();
@@ -682,10 +683,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
     destroy() {
         super.destroy();
 
-        // rendering stops here, so a copy still waiting for the start of a next frame would never
-        // run, and the read it belongs to would never settle
+        // rendering stops here, so a copy still waiting for the start of a frame would never run,
+        // and the read it belongs to would never settle
         for (const copy of [...this._readbackCopies]) {
-            copy.run();
+            copy.abandon();
         }
         const gl = this.gl;
 
@@ -1139,6 +1140,14 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         super.loseContext();
 
+        // The pixel buffers these copies would read went with the context, and rendering stops
+        // while it is lost, so nothing is coming to run them. Failed rather than settled, so a read
+        // cannot come back holding whatever its destination was last filled with - a caller reusing
+        // a buffer between reads would have no way to tell that from a fresh result.
+        for (const copy of [...this._readbackCopies]) {
+            copy.fail();
+        }
+
         // release shaders
         for (const shader of this.shaders) {
             shader.loseContext();
@@ -1387,7 +1396,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
     frameStart() {
         super.frameStart();
 
-        // pixel buffer copies run here, ahead of any rendering this frame queues for them to wait on
+        // pixel buffer copies run here, ahead of the rendering this frame queues for them to wait
+        // on - though after whatever the update phase issued, this being the start of the render
         if (this._readbackCopies.size > 0) {
             for (const copy of [...this._readbackCopies]) {
                 copy.run();
@@ -2469,21 +2479,39 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         // Running the copy at the start of the next frame leaves nothing of that frame queued in
         // front of it, at the cost of the read settling a frame later.
-        await new Promise((resolve) => {
-            let copied = false;
+        await new Promise((resolve, reject) => {
             const copy = {
                 timer: 0,
+                settled: false,
 
-                run: () => {
-                    if (copied) {
+                // a read settles once, whichever of the ways below gets to it first
+                end: (settle) => {
+                    if (copy.settled) {
                         return;
                     }
-                    copied = true;
+                    copy.settled = true;
                     clearTimeout(copy.timer);
                     this._readbackCopies.delete(copy);
+                    settle();
+                },
+
+                // the copy this was all deferred for, at the start of a frame or once the wait for
+                // one has run out
+                run: () => copy.end(() => {
                     copyOut();
                     resolve();
-                }
+                }),
+
+                // The device is going away, which the caller of the read is told about instead of
+                // being given data. Settling without the copy, as the bytes it waits for would go
+                // straight in the bin, and the wait is the one this deferral exists to avoid.
+                abandon: () => copy.end(resolve),
+
+                // the pixel buffer went with the context, so there is nothing left to read and the
+                // read has to fail rather than hand back whatever the destination happens to hold
+                fail: () => copy.end(() => {
+                    reject(new Error('Texture read did not complete, as the WebGL context was lost.'));
+                })
             };
 
             // A read cannot be left waiting on frames which may not come - rendering stops

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2434,11 +2434,12 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * data.
      * @param {boolean} [forceRgba] - If true, forces RGBA/UNSIGNED_BYTE format for guaranteed
      * WebGL support. Used for reading non-RGBA 8-bit normalized textures. Defaults to false.
-     * @param {boolean} [deferCopy] - If true, the copy out of the pixel buffer runs at the start of
-     * the next frame instead of as soon as the data is available. Defaults to false.
+     * @param {boolean} [frequent] - Set for a read issued every frame or every few frames, which
+     * runs the copy out of the pixel buffer at the start of the next frame instead of as soon as
+     * the data is available. Defaults to false.
      * @ignore
      */
-    async readPixelsAsync(x, y, w, h, pixels, forceRgba = false, deferCopy = false) {
+    async readPixelsAsync(x, y, w, h, pixels, forceRgba = false, frequent = false) {
         const gl = this.gl;
 
         let format, pixelType;
@@ -2472,9 +2473,28 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.deleteBuffer(buf);
         };
 
-        if (!deferCopy) {
+        if (!frequent) {
             copyOut();
             return pixels;
+        }
+
+        // The device can go away while the fence above is being waited on, and a read is not being
+        // tracked below until that wait is over - so it is reached by neither the drain on
+        // destruction nor the one on context loss, and has to answer for itself here. There is no
+        // await between this and being tracked, so nothing slips through in between.
+        if (this._destroyed) {
+
+            // settled without the copy, exactly as an already tracked read is - the caller is told
+            // the device went away rather than handed data, so the bytes would go nowhere
+            gl.deleteBuffer(buf);
+            return pixels;
+        }
+        if (this.contextLost) {
+
+            // the pixel buffer went with the context, so the destination was never written and
+            // handing it back would pass off whatever it last held as a result
+            gl.deleteBuffer(buf);
+            throw new Error('Texture read did not complete, as the WebGL context was lost.');
         }
 
         // Running the copy at the start of the next frame leaves nothing of that frame queued in
@@ -2581,7 +2601,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         return new Promise((resolve, reject) => {
             const readPromise = this.readPixelsAsync(x, y, width, height, readBuffer, needsRgbaReadback,
-                options.deferCopy ?? false);
+                options.frequent ?? false);
 
             readPromise.then((data) => {
 

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -2473,28 +2473,30 @@ class WebglGraphicsDevice extends GraphicsDevice {
             gl.deleteBuffer(buf);
         };
 
-        if (!frequent) {
-            copyOut();
-            return pixels;
-        }
-
-        // The device can go away while the fence above is being waited on, and a read is not being
-        // tracked below until that wait is over - so it is reached by neither the drain on
-        // destruction nor the one on context loss, and has to answer for itself here. There is no
-        // await between this and being tracked, so nothing slips through in between.
+        // The device can go away while the fence above is being waited on, which no drain reaches -
+        // a frequent read is not queued for its copy until the wait is over, and a read taking the
+        // copy below is not tracked at all - so it is answered for here. Nothing slips through in
+        // between, there being no await between this and either.
         if (this._destroyed) {
 
-            // settled without the copy, exactly as an already tracked read is - the caller is told
-            // the device went away rather than handed data, so the bytes would go nowhere
+            // settled without the copy, exactly as a queued read is - the caller is told the device
+            // went away rather than handed data, so the bytes would go nowhere
             gl.deleteBuffer(buf);
             return pixels;
         }
         if (this.contextLost) {
 
-            // the pixel buffer went with the context, so the destination was never written and
-            // handing it back would pass off whatever it last held as a result
+            // The pixel buffer went with the context, so the destination was never written and the
+            // copy has nothing to write to it. Handing it back would pass off whatever it last held
+            // as a result, which a caller has no way to tell from a real one - an all-zero pick
+            // reads as nothing picked rather than as a failed read.
             gl.deleteBuffer(buf);
             throw new Error('Texture read did not complete, as the WebGL context was lost.');
+        }
+
+        if (!frequent) {
+            copyOut();
+            return pixels;
         }
 
         // Running the copy at the start of the next frame leaves nothing of that frame queued in

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -102,6 +102,10 @@ const getPixelFormatChannelsForRgbaReadback = (format) => {
 
 const invalidateAttachments = [];
 
+// How long a pixel buffer copy waits for the start of the next frame before going ahead without it,
+// long enough that a frame arriving at a badly degraded rate still counts as arriving.
+const READBACK_FRAME_START_WAIT = 100;
+
 /**
  * WebglGraphicsDevice extends the base {@link GraphicsDevice} to provide rendering capabilities
  * utilizing the WebGL 2.0 specification.
@@ -141,6 +145,15 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * @private
      */
     _xrMsaaCopy = null;
+
+    /**
+     * Copies out of a pixel buffer waiting to run at the start of the next frame, for the reads
+     * which asked for that, see {@link WebglGraphicsDevice#readPixelsAsync}.
+     *
+     * @type {Set<{ timer: number, run: () => void }>}
+     * @private
+     */
+    _readbackCopies = new Set();
 
     /**
      * Creates a new WebglGraphicsDevice instance.
@@ -668,6 +681,12 @@ class WebglGraphicsDevice extends GraphicsDevice {
      */
     destroy() {
         super.destroy();
+
+        // rendering stops here, so a copy still waiting for the start of a next frame would never
+        // run, and the read it belongs to would never settle
+        for (const copy of [...this._readbackCopies]) {
+            copy.run();
+        }
         const gl = this.gl;
 
         if (this.feedback) {
@@ -1367,6 +1386,13 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     frameStart() {
         super.frameStart();
+
+        // pixel buffer copies run here, ahead of any rendering this frame queues for them to wait on
+        if (this._readbackCopies.size > 0) {
+            for (const copy of [...this._readbackCopies]) {
+                copy.run();
+            }
+        }
 
         this.updateBackbuffer();
 
@@ -2398,9 +2424,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
      * data.
      * @param {boolean} [forceRgba] - If true, forces RGBA/UNSIGNED_BYTE format for guaranteed
      * WebGL support. Used for reading non-RGBA 8-bit normalized textures. Defaults to false.
+     * @param {boolean} [deferCopy] - If true, the copy out of the pixel buffer runs at the start of
+     * the next frame instead of as soon as the data is available. Defaults to false.
      * @ignore
      */
-    async readPixelsAsync(x, y, w, h, pixels, forceRgba = false) {
+    async readPixelsAsync(x, y, w, h, pixels, forceRgba = false, deferCopy = false) {
         const gl = this.gl;
 
         let format, pixelType;
@@ -2423,11 +2451,47 @@ class WebglGraphicsDevice extends GraphicsDevice {
         // async wait for previous read to finish
         await this.clientWaitAsync(0, 16);
 
-        // copy the resulting data once it's arrived
-        gl.bindBuffer(gl.PIXEL_PACK_BUFFER, buf);
-        gl.getBufferSubData(gl.PIXEL_PACK_BUFFER, 0, pixels);
-        gl.bindBuffer(gl.PIXEL_PACK_BUFFER, null);
-        gl.deleteBuffer(buf);
+        // The copy out of the pixel buffer is synchronous, and the driver services it by submitting
+        // and then waiting for whatever commands are outstanding when it runs. This read's own fence
+        // has signalled by now, so that wait is spent entirely on unrelated work queued behind it,
+        // which on a heavy scene is a frame's worth of rendering.
+        const copyOut = () => {
+            gl.bindBuffer(gl.PIXEL_PACK_BUFFER, buf);
+            gl.getBufferSubData(gl.PIXEL_PACK_BUFFER, 0, pixels);
+            gl.bindBuffer(gl.PIXEL_PACK_BUFFER, null);
+            gl.deleteBuffer(buf);
+        };
+
+        if (!deferCopy) {
+            copyOut();
+            return pixels;
+        }
+
+        // Running the copy at the start of the next frame leaves nothing of that frame queued in
+        // front of it, at the cost of the read settling a frame later.
+        await new Promise((resolve) => {
+            let copied = false;
+            const copy = {
+                timer: 0,
+
+                run: () => {
+                    if (copied) {
+                        return;
+                    }
+                    copied = true;
+                    clearTimeout(copy.timer);
+                    this._readbackCopies.delete(copy);
+                    copyOut();
+                    resolve();
+                }
+            };
+
+            // A read cannot be left waiting on frames which may not come - rendering stops
+            // altogether for a hidden tab, and whoever awaits the read would wait for good. So the
+            // next frame is used when it starts soon enough, and this stands in when it does not.
+            copy.timer = setTimeout(copy.run, READBACK_FRAME_START_WAIT);
+            this._readbackCopies.add(copy);
+        });
 
         return pixels;
     }
@@ -2488,7 +2552,8 @@ class WebglGraphicsDevice extends GraphicsDevice {
         }
 
         return new Promise((resolve, reject) => {
-            const readPromise = this.readPixelsAsync(x, y, width, height, readBuffer, needsRgbaReadback);
+            const readPromise = this.readPixelsAsync(x, y, width, height, readBuffer, needsRgbaReadback,
+                options.deferCopy ?? false);
 
             readPromise.then((data) => {
 


### PR DESCRIPTION
The copy which ends an async texture read on WebGL is synchronous, and the driver services it by submitting and waiting for whatever commands are outstanding when it runs. The read's own fence has signalled by then, so that wait buys nothing — it is spent on unrelated rendering queued behind the read. A read issued every frame pays it every frame.

**Changes:**
- `Texture#read` accepts a `frequent` option, for a read which is one of many issued every frame or every few frames. On WebGL such a read takes its blocking copy at the start of the next frame, where none of that frame's rendering is queued in front of it, trading a frame of latency for the stall — the trade a one-off read would not want. Ignored on WebGPU, whose readback does not block.
- `SceneDepthReader` sets it, reading every frame and easily able to absorb a frame of latency.
- A read whose device is destroyed, or whose context is lost, while its fence is still being waited on now answers for itself. A destroyed device settles the read without paying for a copy nobody receives; a lost context fails it, rather than handing back a destination the copy never wrote.
- A copy waiting for a frame which never arrives — rendering stops altogether for a hidden tab — goes ahead on its own after 100ms, so a read always settles.

**API Changes:**
- Added `options.frequent` to `Texture#read`, defaulting to `false`. Timing is unchanged for every existing caller: `Picker`, the glTF and USDZ exporters and SOG loading do not set it.
- Behaviour change on context loss, on all reads: a read now rejects instead of resolving with a destination which was never written. Previously `getBufferSubData` silently did nothing and the caller could not tell the result from a real one — `Picker` passes no destination of its own, so it received an all-zero pick, which reads as nothing picked rather than as a read which failed. `Picker` already handles a rejected read; `CoreExporter` does not, so an export now fails rather than quietly writing a blank texture.

**Examples:**
- `gaussian-splatting/depth-effects` gives each in-flight read its own destination array, taken from a free list, instead of sharing one between reads.

**Performance:**
- Measured on that example, WebGL2: `getBufferSubData` blocked the main thread for ~40ms on one call per frame, 2.7 seconds of every 3. With the option set the stall is gone.
- WebGPU was never affected, as `mapAsync` does not block.