### PR TITLE
Fix alphaFade and occludeDirect types in the StandardMaterial declarations

### DIFF
--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -196,28 +196,42 @@ const STANDARD_MAT_PROPS = [
 // The accessors are injected directly after this member of the tsc-emitted class body.
 const STANDARD_MAT_ANCHOR = 'reset(): void;';
 
-// The anchor plus any block injected by an earlier run. tsc indents the class body with four
-// spaces while the injected lines are tab-indented, so a run of tab-indented (or blank) lines
-// directly after the anchor can only be a previous injection. Matching it lets the transformer
-// replace a stale block in place rather than add a second copy, which matters when an incremental
-// tsc run leaves behind a declaration file that was fixed up with an older STANDARD_MAT_PROPS.
-const STANDARD_MAT_INJECTED = /reset\(\): void;(?:\r?\n(?: *\t[^\n]*)?)*(?=\r?\n)/;
+// A block injected by an earlier run, found directly after the anchor. tsc indents the class body
+// with four spaces while the injected lines are tab-indented, so a run of tab-indented (or blank)
+// lines there can only be a previous injection. Matching it lets the transformer replace a stale
+// block in place rather than add a second copy, which matters when an incremental tsc run leaves
+// behind a declaration file that was fixed up with an older STANDARD_MAT_PROPS.
+const STANDARD_MAT_INJECTED = /^(?:\r?\n(?: *\t[^\n]*)?)*(?=\r?\n)/;
 
 const REPLACEMENTS = [{
     path: `${TYPES_PATH}/scene/materials/standard-material.d.ts`,
     replacement: {
         transformer: (contents) => {
-            if (!STANDARD_MAT_INJECTED.test(contents)) {
+            const anchorIndex = contents.indexOf(STANDARD_MAT_ANCHOR);
+            if (anchorIndex === -1) {
                 throw new Error(`types-fixup: '${STANDARD_MAT_ANCHOR}' not found in the StandardMaterial declarations`);
             }
+            const anchorEnd = anchorIndex + STANDARD_MAT_ANCHOR.length;
+            const rest = contents.slice(anchorEnd);
+            const previous = rest.match(STANDARD_MAT_INJECTED);
+            const remainder = rest.slice(previous ? previous[0].length : 0);
 
-            // Find the jsdoc block description using eg "@property {Type} {name}"
+            // Each description is looked up in the class JSDoc by its "@property {Type} name" tag.
+            // This is a plain string search on purpose: the type can contain characters that mean
+            // something in a regex (e.g. Texture|null), which used to match the wrong tag.
             const accessors = STANDARD_MAT_PROPS.map((prop) => {
-                const typeDefinition = `@property {${prop[1]}} ${prop[0]}`;
-                const typeDescriptionIndex = contents.match(typeDefinition);
-                const typeDescription = typeDescriptionIndex ?
-                    contents.slice(typeDescriptionIndex.index + typeDefinition.length, contents.indexOf('\n * @property', typeDescriptionIndex.index + typeDefinition.length)) :
-                    '';
+                const tag = `@property {${prop[1]}} ${prop[0]} `;
+                const tagIndex = contents.indexOf(tag);
+                let typeDescription = '';
+                if (tagIndex !== -1) {
+                    // the description runs up to the next block tag, or to the end of the comment
+                    const start = tagIndex + tag.length;
+                    let end = contents.indexOf('\n * @', start);
+                    if (end === -1) {
+                        end = contents.indexOf('\n */', start);
+                    }
+                    typeDescription = end === -1 ? contents.slice(start) : contents.slice(start, end);
+                }
 
                 // Strip newlines, asterisks, and tabs from the type description
                 const cleanTypeDescription = typeDescription
@@ -229,8 +243,7 @@ const REPLACEMENTS = [{
                 return `\t${jsdoc}\n\tset ${prop[0]}(arg: ${prop[1]});\n\tget ${prop[0]}(): ${prop[1]};\n\n`;
             }).join('');
 
-            // a function replacement keeps '$' in the descriptions from being read as patterns
-            return contents.replace(STANDARD_MAT_INJECTED, () => `${STANDARD_MAT_ANCHOR}\n${accessors}`);
+            return `${contents.slice(0, anchorEnd)}\n${accessors}${remainder}`;
         },
         footer: `
 import { Color } from '../../core/math/color.js';

--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -193,32 +193,44 @@ const STANDARD_MAT_PROPS = [
     ['useSkybox', 'boolean']
 ];
 
+// The accessors are injected directly after this member of the tsc-emitted class body.
+const STANDARD_MAT_ANCHOR = 'reset(): void;';
+
+// The anchor plus any block injected by an earlier run. tsc indents the class body with four
+// spaces while the injected lines are tab-indented, so a run of tab-indented (or blank) lines
+// directly after the anchor can only be a previous injection. Matching it lets the transformer
+// replace a stale block in place rather than add a second copy, which matters when an incremental
+// tsc run leaves behind a declaration file that was fixed up with an older STANDARD_MAT_PROPS.
+const STANDARD_MAT_INJECTED = /reset\(\): void;(?:\r?\n(?: *\t[^\n]*)?)*(?=\r?\n)/;
+
 const REPLACEMENTS = [{
     path: `${TYPES_PATH}/scene/materials/standard-material.d.ts`,
     replacement: {
-        // first injected accessor - its presence means the file has already been fixed up
-        guard: `set ${STANDARD_MAT_PROPS[0][0]}(arg: ${STANDARD_MAT_PROPS[0][1]});`,
         transformer: (contents) => {
+            if (!STANDARD_MAT_INJECTED.test(contents)) {
+                throw new Error(`types-fixup: '${STANDARD_MAT_ANCHOR}' not found in the StandardMaterial declarations`);
+            }
 
             // Find the jsdoc block description using eg "@property {Type} {name}"
-            return contents.replace('reset(): void;', `reset(): void;
-                ${STANDARD_MAT_PROPS.map((prop) => {
-        const typeDefinition = `@property {${prop[1]}} ${prop[0]}`;
-        const typeDescriptionIndex = contents.match(typeDefinition);
-        const typeDescription = typeDescriptionIndex ?
-            contents.slice(typeDescriptionIndex.index + typeDefinition.length, contents.indexOf('\n * @property', typeDescriptionIndex.index + typeDefinition.length)) :
-            '';
+            const accessors = STANDARD_MAT_PROPS.map((prop) => {
+                const typeDefinition = `@property {${prop[1]}} ${prop[0]}`;
+                const typeDescriptionIndex = contents.match(typeDefinition);
+                const typeDescription = typeDescriptionIndex ?
+                    contents.slice(typeDescriptionIndex.index + typeDefinition.length, contents.indexOf('\n * @property', typeDescriptionIndex.index + typeDefinition.length)) :
+                    '';
 
-        // Strip newlines, asterisks, and tabs from the type description
-        const cleanTypeDescription = typeDescription
-        .trim()
-        .replace(/[\n\t*]/g, ' ') // remove newlines, tabs, and asterisks
-        .replace(/\s+/g, ' '); // collapse whitespace
+                // Strip newlines, asterisks, and tabs from the type description
+                const cleanTypeDescription = typeDescription
+                .trim()
+                .replace(/[\n\t*]/g, ' ') // remove newlines, tabs, and asterisks
+                .replace(/\s+/g, ' '); // collapse whitespace
 
-        const jsdoc = cleanTypeDescription ? `/** ${cleanTypeDescription} */` : '';
-        return `\t${jsdoc}\n\tset ${prop[0]}(arg: ${prop[1]});\n\tget ${prop[0]}(): ${prop[1]};\n\n`;
-    }).join('')}`
-            );
+                const jsdoc = cleanTypeDescription ? `/** ${cleanTypeDescription} */` : '';
+                return `\t${jsdoc}\n\tset ${prop[0]}(arg: ${prop[1]});\n\tget ${prop[0]}(): ${prop[1]};\n\n`;
+            }).join('');
+
+            // a function replacement keeps '$' in the descriptions from being read as patterns
+            return contents.replace(STANDARD_MAT_INJECTED, () => `${STANDARD_MAT_ANCHOR}\n${accessors}`);
         },
         footer: `
 import { Color } from '../../core/math/color.js';

--- a/utils/plugins/rollup-types-fixup.mjs
+++ b/utils/plugins/rollup-types-fixup.mjs
@@ -8,7 +8,7 @@ const REGULAR_OUT = '\x1b[22m';
 const TYPES_PATH = './build/playcanvas/src';
 
 const STANDARD_MAT_PROPS = [
-    ['alphaFade', 'boolean'],
+    ['alphaFade', 'number'],
     ['ambient', 'Color'],
     ['anisotropyIntensity', 'number'],
     ['anisotropyRotation', 'number'],
@@ -136,7 +136,7 @@ const STANDARD_MAT_PROPS = [
     ['normalMapRotation', 'number'],
     ['normalMapTiling', 'Vec2'],
     ['normalMapUv', 'number'],
-    ['occludeDirect', 'number'],
+    ['occludeDirect', 'boolean'],
     ['occludeSpecular', 'number'],
     ['occludeSpecularIntensity', 'number'],
     ['opacity', 'number'],
@@ -196,7 +196,8 @@ const STANDARD_MAT_PROPS = [
 const REPLACEMENTS = [{
     path: `${TYPES_PATH}/scene/materials/standard-material.d.ts`,
     replacement: {
-        guard: 'set alphaFade(arg: boolean);',
+        // first injected accessor - its presence means the file has already been fixed up
+        guard: `set ${STANDARD_MAT_PROPS[0][0]}(arg: ${STANDARD_MAT_PROPS[0][1]});`,
         transformer: (contents) => {
 
             // Find the jsdoc block description using eg "@property {Type} {name}"


### PR DESCRIPTION
## Description
Fixes two wrong types in the generated `StandardMaterial` TypeScript declarations, and makes the fixup that injects those declarations safe to re-run over a stale file and correct in what it emits.

Addresses the `.d.ts` half of #9152. The other half of that issue, the `opacityShadowDither` JSDoc type, was fixed in #9294.

TypeScript cannot see the accessors that `StandardMaterial` creates with `Object.defineProperty`, so the types build injects them into `standard-material.d.ts` from the `STANDARD_MAT_PROPS` list in `utils/plugins/rollup-types-fixup.mjs`. Two entries in that list disagreed with the runtime and the JSDoc:

- `alphaFade` was declared `boolean`. It is a float (default `1`) that feeds the `material_alphaFade` uniform.
- `occludeDirect` was declared `number`. It is a boolean flag (default `false`).

**Idempotent injection.** The plugin relied on a hard-coded guard string, `'set alphaFade(arg: boolean);'`, to recognise a declaration file that had already been fixed up. Incremental `tsc` runs and the watch build depend on that check to avoid injecting the accessors twice, so fixing the list alone would have broken it, and any guard that encodes a type has the same problem the next time a type changes. The transformer is now idempotent instead: `tsc` indents the class body with four spaces while the injected accessors are tab-indented, so a run of tab-indented lines directly after the `reset(): void;` anchor can only be an earlier injection, and it is replaced in place. A stale file left behind by an incremental `tsc` run, including one produced by the old plugin with `alphaFade` as `boolean`, is therefore corrected rather than duplicated. The anchor is located with a plain string search, so the anchor string is the single source of truth, and the transformer throws if it is missing instead of silently emitting a class without the accessors.

**Correct doc comments.** The description lookup passed `@property {Type} name` to `String#match`, which reads the type as a regex. `Texture|null` therefore matched the first `@property {Texture` tag in the file and sliced from the wrong offset, so 21 texture accessors in the published declarations carried a fragment of `diffuseMap`'s description. For example `aoMap`:

```ts
// before
/** seMap The main (primary) diffuse map of the material (default is null). */
set aoMap(arg: Texture|null);
// after
/** The main (primary) baked ambient occlusion (AO) map (default is null). Modulates ambient color. */
set aoMap(arg: Texture|null);
```

The lookup is now a plain string search for the tag, and a description ends at the next block tag or the end of the comment rather than running to the end of the file when the tag is the last one in the block.

**Public API changes (`build/playcanvas.d.ts`)**

Before:
```ts
set alphaFade(arg: boolean);
get alphaFade(): boolean;
set occludeDirect(arg: number);
get occludeDirect(): number;
```

After:
```ts
set alphaFade(arg: number);
get alphaFade(): number;
set occludeDirect(arg: boolean);
get occludeDirect(): boolean;
```

`material.alphaFade = 0.5` and `material.occludeDirect = true` now type-check. No runtime changes.

**Verification**
- Produced a genuinely stale file by fixing up a clean `tsc` emit with the plugin from `main`, then ran the new plugin over it: a single accessor block with the corrected types, a second run is a no-op, and the result is byte-identical to a fresh injection on a clean emit.
- Diffed the bundled `.d.ts` against the previous transformer's output: exactly 21 lines changed, all of them doc comments on `Texture|null` accessors; no declaration changed.
- Synthetic declaration files check that a description ending at `@category` or at the end of the comment is extracted correctly, and that a missing anchor throws.
- `npm run build:types` with incremental `tsc` reusing the patched file, `npm run test:types`, a consumer `tsc` check of the two assignments above, and `npm run lint`.

**Relationship to #9163.** The draft PR #9163 fixes the same two types and the same `String#match` bug as part of a broader rewrite of the plugin, with build-time validation of the list against the JSDoc. This PR is the minimal, independently mergeable subset. If #9163 lands first, this PR can simply be closed. If this lands first, #9163 needs a rebase of its transformer changes; the two list entries are identical hunks.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
