### PR TITLE
Fix invalid 'color' camera option in compound collision example

### DIFF
--- a/examples/src/examples/physics/compound-collision.example.mjs
+++ b/examples/src/examples/physics/compound-collision.example.mjs
@@ -356,7 +356,7 @@ const scene = [
             {
                 type: 'camera',
                 options: {
-                    color: [0.5, 0.5, 0.5]
+                    clearColor: new Color(0.5, 0.5, 0.5)
                 }
             }
         ]


### PR DESCRIPTION
The `camera` component has no `color` property — the background colour is [`clearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#clearcolor). `physics/compound-collision` passes `color`, which has been silently ignored ever since the example was written (it predates the examples overhaul), and now trips the `addComponent` option validation:

```
addComponent: ignoring unknown option 'color' passed to the 'camera' component - check for a typo.
```

This one escaped the sweep in #9277 because the example builds its scene from a JSON-ish description and calls `entity.addComponent(c.type, c.options)`, so the options are not visible as literals at the call site.

Unlike #9277 this does change what you see: the option now takes effect, so the background is the intended 0.5 grey rather than the camera default of 0.75. Verified in the examples browser — `Camera.camera.clearColor` is `0.5, 0.5, 0.5` and the warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)