### PR TITLE
Add timeScale and public step() to RigidBodyComponentSystem

### DIFF
--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -285,7 +285,9 @@ class AppBase extends EventHandler {
     };
 
     /**
-     * Scales the global time delta. Defaults to 1.
+     * Scales the global time delta. Defaults to 1. Scripts, animation and physics all receive
+     * the scaled delta, so 0 stops them together. To pause or slow down physics alone while the
+     * rest of the application keeps running, use {@link RigidBodyComponentSystem#timeScale}.
      *
      * @example
      * // Set the app to run at half speed

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -799,8 +799,11 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * The system calls this once per frame with the frame delta time multiplied by
      * {@link RigidBodyComponentSystem#timeScale}, unless that is 0. Call it directly to step the
      * simulation manually: to advance it while paused, to fast forward it by stepping several
-     * times in one frame, or to drive it from a custom time source. The delta is used as given,
-     * without applying timeScale. Does nothing when no physics backend is installed.
+     * times in one frame, or to drive it from a custom time source. Automatic stepping continues
+     * while timeScale is above 0, so calling this every frame as well advances the simulation
+     * twice per frame. Set timeScale to 0 first when taking over stepping entirely. The delta is
+     * used as given, without applying timeScale. Does nothing when no physics backend is
+     * installed.
      *
      * @param {number} dt - The amount of time to advance the simulation by, in seconds.
      * @example

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -38,21 +38,19 @@ const _properties = [
 
 /**
  * The RigidBodyComponentSystem manages the physics simulation for all rigid body components
- * in the application. It creates and maintains the underlying physics world, handles
- * physics object creation and destruction, performs physics raycasting, detects and reports
- * collisions, and updates the transforms of entities with rigid bodies after each physics step.
+ * in the application and is accessed as `app.systems.rigidbody`. It owns the physics world,
+ * creates and destroys the bodies behind rigid body and collision components, steps the
+ * simulation once per frame and writes the resulting transforms back to their entities. It also
+ * holds global settings such as {@link RigidBodyComponentSystem#gravity}, performs raycasts
+ * and reports collisions.
  *
- * The system controls global physics settings like gravity and provides methods for raycasting
- * and collision detection.
- *
- * This system is only functional once a physics backend is installed: either by supplying
+ * The system is only functional once a physics backend is installed: either by supplying
  * {@link AppOptions#physicsWorld} when creating the application, or automatically when the
  * application has loaded the Ammo.js {@link WasmModule}.
  *
- * The simulation is stepped automatically once per frame. Set
- * {@link RigidBodyComponentSystem#timeScale} to slow it down, speed it up or pause it, for
- * example while a pause menu is open, and call {@link RigidBodyComponentSystem#step} to advance
- * the simulation manually.
+ * Set {@link RigidBodyComponentSystem#timeScale} to slow the simulation down, speed it up or
+ * pause it, for example while a pause menu is open, and call
+ * {@link RigidBodyComponentSystem#step} to advance it manually.
  *
  * @category Physics
  */
@@ -90,10 +88,11 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * advanced manually with {@link RigidBodyComponentSystem#step} while paused, for example to
      * drive it from a custom time source.
      *
-     * Slow motion that advances the simulation by less than one fixed substep per frame steps
-     * it intermittently; the Ammo backend interpolates body transforms between steps so motion
-     * stays smooth. Fast forward is limited by the maximum number of substeps the simulation
-     * may take per frame, beyond which it runs slower than requested.
+     * How slow motion below one fixed substep per frame looks depends on the backend: the Ammo
+     * backend interpolates body transforms between substeps so motion stays smooth, while other
+     * backends may only move bodies on the frames in which a substep runs. Fast forward is
+     * limited by the maximum number of substeps the simulation may take per frame, beyond which
+     * it runs slower than requested.
      *
      * Forces applied with {@link RigidBodyComponent#applyForce} while paused accumulate on the
      * body and are applied together on the next step, because forces are only cleared when the

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -49,6 +49,11 @@ const _properties = [
  * {@link AppOptions#physicsWorld} when creating the application, or automatically when the
  * application has loaded the Ammo.js {@link WasmModule}.
  *
+ * The simulation is stepped automatically once per frame. Set
+ * {@link RigidBodyComponentSystem#paused} to stop automatic stepping, for example while a pause
+ * menu is open, and call {@link RigidBodyComponentSystem#step} to advance the simulation
+ * manually.
+ *
  * @category Physics
  */
 class RigidBodyComponentSystem extends ComponentSystem {
@@ -64,14 +69,47 @@ class RigidBodyComponentSystem extends ComponentSystem {
      */
     static EVENT_CONTACT = 'contact';
 
-    /** @ignore */
+    /**
+     * The maximum number of fixed substeps the simulation may take in one
+     * {@link RigidBodyComponentSystem#step} to catch up with elapsed time. When a frame takes
+     * longer than maxSubSteps * fixedTimeStep seconds, the remaining time is dropped and the
+     * simulation runs slower than real time instead of falling further behind. Defaults to 10.
+     */
     maxSubSteps = 10;
 
     /**
-     * @type {number}
-     * @ignore
+     * The duration of a fixed simulation substep in seconds. Each
+     * {@link RigidBodyComponentSystem#step} advances the simulation in substeps of this length.
+     * Smaller values give a more accurate and stable simulation at a higher CPU cost. Defaults
+     * to 1/60.
+     *
+     * @example
+     * // Simulate at 120Hz for a more stable ragdoll
+     * app.systems.rigidbody.fixedTimeStep = 1 / 120;
      */
     fixedTimeStep = 1 / 60;
+
+    /**
+     * Whether automatic stepping of the physics simulation is paused. While true, the system
+     * stops advancing the simulation each frame: bodies freeze in place, entity transforms are
+     * no longer driven by their bodies and no contact or trigger events fire. The rest of the
+     * application keeps running, so this suits a pause menu or inventory screen that must stay
+     * interactive while the game world stands still.
+     *
+     * The simulation can still be advanced manually with
+     * {@link RigidBodyComponentSystem#step} while paused, for example to run physics in slow
+     * motion or to drive it from a custom time source.
+     *
+     * Forces applied with {@link RigidBodyComponent#applyForce} while paused accumulate on the
+     * body and are applied together on the next step, because forces are only cleared when the
+     * simulation steps. Impulses and velocity changes take effect immediately. Defaults to
+     * false.
+     *
+     * @example
+     * // Freeze the game world while the pause menu is open
+     * app.systems.rigidbody.paused = true;
+     */
+    paused = false;
 
     /**
      * The world space vector representing global gravity in the physics simulation. Defaults to
@@ -755,13 +793,37 @@ class RigidBodyComponentSystem extends ComponentSystem {
         this.singleContactResultPool.freeAll();
     }
 
-    onUpdate(dt) {
+    /**
+     * Advances the physics simulation by dt seconds. Synchronizes triggers, compound shapes and
+     * kinematic bodies from their entities, steps the backend in fixed substeps of
+     * {@link RigidBodyComponentSystem#fixedTimeStep} (at most
+     * {@link RigidBodyComponentSystem#maxSubSteps} of them), writes the resulting transforms of
+     * dynamic bodies back to their entities and fires contact and trigger events.
+     *
+     * The system calls this once per frame with the frame delta time unless
+     * {@link RigidBodyComponentSystem#paused} is true. Call it directly to step the simulation
+     * manually: to run physics in slow motion, to fast forward it by stepping several times in
+     * one frame, or to advance it while paused. Does nothing when no physics backend is
+     * installed.
+     *
+     * @param {number} dt - The amount of time to advance the simulation by, in seconds.
+     * @example
+     * // Take over stepping and run physics at half speed
+     * app.systems.rigidbody.paused = true;
+     * app.on('update', (dt) => {
+     *     app.systems.rigidbody.step(dt * 0.5);
+     * });
+     */
+    step(dt) {
+        const world = this._world;
+        if (!world) return;
+
         let i, len;
 
         this._stats.physicsStart = now();
 
         // Check to see whether we need to update gravity on the physics world
-        this._world.setGravity(this.gravity);
+        world.setGravity(this.gravity);
 
         const triggers = this._triggers;
         for (i = 0, len = triggers.length; i < len; i++) {
@@ -780,7 +842,7 @@ class RigidBodyComponentSystem extends ComponentSystem {
         }
 
         // Step the physics simulation
-        this._world.step(dt, this.maxSubSteps, this.fixedTimeStep);
+        world.step(dt, this.maxSubSteps, this.fixedTimeStep);
 
         // Update the transforms of all entities referencing a dynamic body
         const dynamic = this._dynamic;
@@ -789,9 +851,27 @@ class RigidBodyComponentSystem extends ComponentSystem {
         }
 
         // no-op on backends that report contacts from inside step()
-        this._world.flushContacts();
+        world.flushContacts();
 
         this._stats.physicsTime = now() - this._stats.physicsStart;
+    }
+
+    /**
+     * Steps the simulation by the frame delta time unless
+     * {@link RigidBodyComponentSystem#paused} is true. Registered on the application's update
+     * event when a physics backend is installed.
+     *
+     * @param {number} dt - The frame delta time in seconds.
+     * @ignore
+     */
+    onUpdate(dt) {
+        if (this.paused) {
+            // nothing was simulated this frame
+            this._stats.physicsTime = 0;
+            return;
+        }
+
+        this.step(dt);
     }
 
     destroy() {

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -69,23 +69,12 @@ class RigidBodyComponentSystem extends ComponentSystem {
      */
     static EVENT_CONTACT = 'contact';
 
-    /**
-     * The maximum number of fixed substeps the simulation may take in one
-     * {@link RigidBodyComponentSystem#step} to catch up with elapsed time. When a frame takes
-     * longer than maxSubSteps * fixedTimeStep seconds, the remaining time is dropped and the
-     * simulation runs slower than real time instead of falling further behind. Defaults to 10.
-     */
+    /** @ignore */
     maxSubSteps = 10;
 
     /**
-     * The duration of a fixed simulation substep in seconds. Each
-     * {@link RigidBodyComponentSystem#step} advances the simulation in substeps of this length.
-     * Smaller values give a more accurate and stable simulation at a higher CPU cost. Defaults
-     * to 1/60.
-     *
-     * @example
-     * // Simulate at 120Hz for a more stable ragdoll
-     * app.systems.rigidbody.fixedTimeStep = 1 / 120;
+     * @type {number}
+     * @ignore
      */
     fixedTimeStep = 1 / 60;
 
@@ -101,11 +90,10 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * advanced manually with {@link RigidBodyComponentSystem#step} while paused, for example to
      * drive it from a custom time source.
      *
-     * Slow motion that advances less than one {@link RigidBodyComponentSystem#fixedTimeStep}
-     * per frame steps the simulation intermittently; the Ammo backend interpolates body
-     * transforms between steps so motion stays smooth. Fast forward is limited to
-     * {@link RigidBodyComponentSystem#maxSubSteps} substeps per frame, beyond which the
-     * simulation runs slower than requested.
+     * Slow motion that advances the simulation by less than one fixed substep per frame steps
+     * it intermittently; the Ammo backend interpolates body transforms between steps so motion
+     * stays smooth. Fast forward is limited by the maximum number of substeps the simulation
+     * may take per frame, beyond which it runs slower than requested.
      *
      * Forces applied with {@link RigidBodyComponent#applyForce} while paused accumulate on the
      * body and are applied together on the next step, because forces are only cleared when the
@@ -804,10 +792,9 @@ class RigidBodyComponentSystem extends ComponentSystem {
 
     /**
      * Advances the physics simulation by dt seconds. Synchronizes triggers, compound shapes and
-     * kinematic bodies from their entities, steps the backend in fixed substeps of
-     * {@link RigidBodyComponentSystem#fixedTimeStep} (at most
-     * {@link RigidBodyComponentSystem#maxSubSteps} of them), writes the resulting transforms of
-     * dynamic bodies back to their entities and fires contact and trigger events.
+     * kinematic bodies from their entities, steps the backend in fixed-length substeps (up to a
+     * maximum number per call), writes the resulting transforms of dynamic bodies back to their
+     * entities and fires contact and trigger events.
      *
      * The system calls this once per frame with the frame delta time multiplied by
      * {@link RigidBodyComponentSystem#timeScale}, unless that is 0. Call it directly to step the
@@ -817,12 +804,12 @@ class RigidBodyComponentSystem extends ComponentSystem {
      *
      * @param {number} dt - The amount of time to advance the simulation by, in seconds.
      * @example
-     * // Pause automatic stepping and advance the simulation one fixed step per key press
+     * // Pause automatic stepping and advance the simulation by 1/60 s per key press
      * const physics = app.systems.rigidbody;
      * physics.timeScale = 0;
      * app.keyboard.on('keydown', (event) => {
      *     if (event.key === KEY_SPACE) {
-     *         physics.step(physics.fixedTimeStep);
+     *         physics.step(1 / 60);
      *     }
      * });
      */

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -50,9 +50,9 @@ const _properties = [
  * application has loaded the Ammo.js {@link WasmModule}.
  *
  * The simulation is stepped automatically once per frame. Set
- * {@link RigidBodyComponentSystem#paused} to stop automatic stepping, for example while a pause
- * menu is open, and call {@link RigidBodyComponentSystem#step} to advance the simulation
- * manually.
+ * {@link RigidBodyComponentSystem#timeScale} to slow it down, speed it up or pause it, for
+ * example while a pause menu is open, and call {@link RigidBodyComponentSystem#step} to advance
+ * the simulation manually.
  *
  * @category Physics
  */
@@ -90,26 +90,35 @@ class RigidBodyComponentSystem extends ComponentSystem {
     fixedTimeStep = 1 / 60;
 
     /**
-     * Whether automatic stepping of the physics simulation is paused. While true, the system
-     * stops advancing the simulation each frame: bodies freeze in place, entity transforms are
-     * no longer driven by their bodies and no contact or trigger events fire. The rest of the
-     * application keeps running, so this suits a pause menu or inventory screen that must stay
-     * interactive while the game world stands still.
+     * Scales the time the simulation is advanced by each frame. Defaults to 1. Values below 1
+     * run physics in slow motion and values above 1 speed it up. 0 pauses the simulation: the
+     * system stops advancing it, bodies freeze in place, entity transforms are no longer driven
+     * by their bodies and no contact or trigger events fire. The rest of the application keeps
+     * running, so this suits a pause menu or inventory screen that must stay interactive while
+     * the game world stands still. Negative values are treated as 0.
      *
-     * The simulation can still be advanced manually with
-     * {@link RigidBodyComponentSystem#step} while paused, for example to run physics in slow
-     * motion or to drive it from a custom time source.
+     * This scale is applied on top of {@link AppBase#timeScale}. The simulation can still be
+     * advanced manually with {@link RigidBodyComponentSystem#step} while paused, for example to
+     * drive it from a custom time source.
+     *
+     * Slow motion that advances less than one {@link RigidBodyComponentSystem#fixedTimeStep}
+     * per frame steps the simulation intermittently; the Ammo backend interpolates body
+     * transforms between steps so motion stays smooth. Fast forward is limited to
+     * {@link RigidBodyComponentSystem#maxSubSteps} substeps per frame, beyond which the
+     * simulation runs slower than requested.
      *
      * Forces applied with {@link RigidBodyComponent#applyForce} while paused accumulate on the
      * body and are applied together on the next step, because forces are only cleared when the
-     * simulation steps. Impulses and velocity changes take effect immediately. Defaults to
-     * false.
+     * simulation steps. Impulses and velocity changes take effect immediately.
      *
      * @example
      * // Freeze the game world while the pause menu is open
-     * app.systems.rigidbody.paused = true;
+     * app.systems.rigidbody.timeScale = 0;
+     * @example
+     * // Run physics at quarter speed for a slow motion effect
+     * app.systems.rigidbody.timeScale = 0.25;
      */
-    paused = false;
+    timeScale = 1;
 
     /**
      * The world space vector representing global gravity in the physics simulation. Defaults to
@@ -800,18 +809,21 @@ class RigidBodyComponentSystem extends ComponentSystem {
      * {@link RigidBodyComponentSystem#maxSubSteps} of them), writes the resulting transforms of
      * dynamic bodies back to their entities and fires contact and trigger events.
      *
-     * The system calls this once per frame with the frame delta time unless
-     * {@link RigidBodyComponentSystem#paused} is true. Call it directly to step the simulation
-     * manually: to run physics in slow motion, to fast forward it by stepping several times in
-     * one frame, or to advance it while paused. Does nothing when no physics backend is
-     * installed.
+     * The system calls this once per frame with the frame delta time multiplied by
+     * {@link RigidBodyComponentSystem#timeScale}, unless that is 0. Call it directly to step the
+     * simulation manually: to advance it while paused, to fast forward it by stepping several
+     * times in one frame, or to drive it from a custom time source. The delta is used as given,
+     * without applying timeScale. Does nothing when no physics backend is installed.
      *
      * @param {number} dt - The amount of time to advance the simulation by, in seconds.
      * @example
-     * // Take over stepping and run physics at half speed
-     * app.systems.rigidbody.paused = true;
-     * app.on('update', (dt) => {
-     *     app.systems.rigidbody.step(dt * 0.5);
+     * // Pause automatic stepping and advance the simulation one fixed step per key press
+     * const physics = app.systems.rigidbody;
+     * physics.timeScale = 0;
+     * app.keyboard.on('keydown', (event) => {
+     *     if (event.key === KEY_SPACE) {
+     *         physics.step(physics.fixedTimeStep);
+     *     }
      * });
      */
     step(dt) {
@@ -857,21 +869,22 @@ class RigidBodyComponentSystem extends ComponentSystem {
     }
 
     /**
-     * Steps the simulation by the frame delta time unless
-     * {@link RigidBodyComponentSystem#paused} is true. Registered on the application's update
-     * event when a physics backend is installed.
+     * Steps the simulation by the frame delta time scaled by
+     * {@link RigidBodyComponentSystem#timeScale}, or skips the frame entirely when the scale is
+     * 0. Registered on the application's update event when a physics backend is installed.
      *
      * @param {number} dt - The frame delta time in seconds.
      * @ignore
      */
     onUpdate(dt) {
-        if (this.paused) {
-            // nothing was simulated this frame
+        const timeScale = this.timeScale;
+        if (!(timeScale > 0)) {
+            // paused: nothing was simulated this frame
             this._stats.physicsTime = 0;
             return;
         }
 
-        this.step(dt);
+        this.step(dt * timeScale);
     }
 
     destroy() {

--- a/test/framework/components/rigid-body/system.test.mjs
+++ b/test/framework/components/rigid-body/system.test.mjs
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
+import { restore, spy } from 'sinon';
 
 import { Entity } from '../../../../src/framework/entity.js';
+import { NullPhysicsWorld } from '../../../../src/framework/physics/null/null-physics-world.js';
 import { createApp } from '../../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
 
@@ -66,6 +68,79 @@ describe('RigidBodyComponentSystem', function () {
             expect(app.systems.rigidbody.collisions[b.guid]).to.exist;
         });
 
+    });
+
+
+    describe('stepping', function () {
+        let world;
+
+        beforeEach(function () {
+            // createApp() installs no backend (Ammo is not loaded in tests), so install the
+            // no-op world by hand to hook the system up to the per-frame update
+            world = new NullPhysicsWorld();
+            app.systems.rigidbody.setPhysicsWorld(world);
+        });
+
+        afterEach(function () {
+            restore();
+        });
+
+        it('steps the world once per update by default', function () {
+            const system = app.systems.rigidbody;
+            const step = spy(world, 'step');
+
+            expect(system.paused).to.be.false;
+
+            app.update(1 / 60);
+
+            expect(step.calledOnce).to.be.true;
+            expect(step.firstCall.args).to.deep.equal([1 / 60, system.maxSubSteps, system.fixedTimeStep]);
+        });
+
+        it('skips the whole simulation update while paused', function () {
+            const setGravity = spy(world, 'setGravity');
+            const step = spy(world, 'step');
+            const flushContacts = spy(world, 'flushContacts');
+
+            app.systems.rigidbody.paused = true;
+            app.update(1 / 60);
+            app.update(1 / 60);
+
+            expect(setGravity.called).to.be.false;
+            expect(step.called).to.be.false;
+            expect(flushContacts.called).to.be.false;
+        });
+
+        it('resumes automatic stepping when unpaused', function () {
+            const step = spy(world, 'step');
+
+            app.systems.rigidbody.paused = true;
+            app.update(1 / 60);
+            app.systems.rigidbody.paused = false;
+            app.update(1 / 60);
+
+            expect(step.calledOnce).to.be.true;
+        });
+
+        it('advances the world through step() while paused', function () {
+            const system = app.systems.rigidbody;
+            const setGravity = spy(world, 'setGravity');
+            const step = spy(world, 'step');
+            const flushContacts = spy(world, 'flushContacts');
+
+            system.paused = true;
+            system.step(0.01);
+
+            expect(setGravity.calledOnce).to.be.true;
+            expect(step.calledOnce).to.be.true;
+            expect(step.firstCall.args).to.deep.equal([0.01, system.maxSubSteps, system.fixedTimeStep]);
+            expect(flushContacts.calledOnce).to.be.true;
+        });
+    });
+
+    it('ignores step() when no physics backend is installed', function () {
+        expect(app.systems.rigidbody.physicsWorld).to.be.null;
+        expect(() => app.systems.rigidbody.step(1 / 60)).to.not.throw();
     });
 
 });

--- a/test/framework/components/rigid-body/system.test.mjs
+++ b/test/framework/components/rigid-body/system.test.mjs
@@ -89,7 +89,7 @@ describe('RigidBodyComponentSystem', function () {
             const system = app.systems.rigidbody;
             const step = spy(world, 'step');
 
-            expect(system.paused).to.be.false;
+            expect(system.timeScale).to.equal(1);
 
             app.update(1 / 60);
 
@@ -97,12 +97,23 @@ describe('RigidBodyComponentSystem', function () {
             expect(step.firstCall.args).to.deep.equal([1 / 60, system.maxSubSteps, system.fixedTimeStep]);
         });
 
-        it('skips the whole simulation update while paused', function () {
+        it('scales the delta passed to the world by the time scale', function () {
+            const system = app.systems.rigidbody;
+            const step = spy(world, 'step');
+
+            system.timeScale = 0.5;
+            app.update(1 / 60);
+
+            expect(step.calledOnce).to.be.true;
+            expect(step.firstCall.args[0]).to.be.closeTo(1 / 120, 1e-12);
+        });
+
+        it('skips the whole simulation update when the time scale is 0', function () {
             const setGravity = spy(world, 'setGravity');
             const step = spy(world, 'step');
             const flushContacts = spy(world, 'flushContacts');
 
-            app.systems.rigidbody.paused = true;
+            app.systems.rigidbody.timeScale = 0;
             app.update(1 / 60);
             app.update(1 / 60);
 
@@ -111,24 +122,33 @@ describe('RigidBodyComponentSystem', function () {
             expect(flushContacts.called).to.be.false;
         });
 
-        it('resumes automatic stepping when unpaused', function () {
+        it('resumes automatic stepping when the time scale is restored', function () {
             const step = spy(world, 'step');
 
-            app.systems.rigidbody.paused = true;
+            app.systems.rigidbody.timeScale = 0;
             app.update(1 / 60);
-            app.systems.rigidbody.paused = false;
+            app.systems.rigidbody.timeScale = 1;
             app.update(1 / 60);
 
             expect(step.calledOnce).to.be.true;
         });
 
-        it('advances the world through step() while paused', function () {
+        it('treats a negative time scale as paused', function () {
+            const step = spy(world, 'step');
+
+            app.systems.rigidbody.timeScale = -1;
+            app.update(1 / 60);
+
+            expect(step.called).to.be.false;
+        });
+
+        it('advances the world through step() while paused, without scaling the delta', function () {
             const system = app.systems.rigidbody;
             const setGravity = spy(world, 'setGravity');
             const step = spy(world, 'step');
             const flushContacts = spy(world, 'flushContacts');
 
-            system.paused = true;
+            system.timeScale = 0;
             system.step(0.01);
 
             expect(setGravity.calledOnce).to.be.true;


### PR DESCRIPTION
## Description
Adds a way to slow down, speed up or freeze the physics simulation independently of the rest of the application, plus manual stepping. Requested in #9272 for pause menus and inventory screens that must stay interactive while the game world stands still.

- `app.systems.rigidbody.timeScale` (default 1) scales the delta the simulation is advanced by each frame, on top of `app.timeScale`. Values below 1 give slow motion, values above 1 fast forward. `0` pauses: the system skips its whole per-frame update (trigger, compound and kinematic sync, the backend step, dynamic transform sync and contact reporting), so bodies freeze, no `collision*` / `trigger*` events fire, and the physics timing stat is zeroed. Negative values are treated as 0.
- `app.systems.rigidbody.step(dt)` is the former `onUpdate` body made public, so callers can advance the simulation manually with an explicit, unscaled delta: frame-by-frame debugging, fast forward by stepping several times in one frame, or a custom time source. No-op without a backend. `onUpdate` is now a scale check plus a `step` call and is `@ignore`d.
- Comment-only: `AppBase#timeScale` now says that it stops scripts, animation and physics together and points at the physics-only scale, since `app.timeScale = 0` is the pause idiom most people (and coding agents) reach for first. `step()` states that calling it every frame while `timeScale` is above 0 advances the simulation twice. The `RigidBodyComponentSystem` class overview was tightened: it no longer says "raycasting" and "collisions" twice, it names `app.systems.rigidbody` as the access path, and it describes the system as owning (rather than creating) the physics world now that backends can be injected.

### Notes for reviewers
- The issue proposed a boolean `paused`. A numeric `timeScale` with 0 as pause is a strict superset (it also covers the slow-motion use case declaratively) and mirrors `app.timeScale`, so the PR went that way.
- Zero is implemented as a full skip rather than `world.step(0)`. A zero-delta step is backend-dependent (Bullet takes no substeps, Jolt still runs collision detection), and on Ammo builds without an internal tick callback the post-step contact walk would keep firing `contact` events from stale manifolds. The skip is keyed on the physics `timeScale`, not on the incoming delta, so apps that pause today via `app.timeScale = 0` keep their current behaviour.
- The property lives on the system rather than `PhysicsWorld`: pausing has to skip the engine-side orchestration (otherwise `_updateDynamic` would keep snapping entity transforms every frame) and the system exists before a backend is installed. No backend changes; Ammo, Null and third-party worlds get this for free.
- Forces applied via `applyForce` while paused accumulate and land on the first step after resume, because Bullet only clears forces inside `stepSimulation`. Documented on `timeScale`. Impulses and velocity changes are unaffected.
- Slow motion below one fixed substep per frame steps the simulation intermittently. Whether that looks smooth is backend-dependent and the docs say so: the Ammo body reads the motion state, which Bullet interpolates by the residual accumulator, so transforms still advance every frame (verified below); other backends may only move bodies on frames in which a substep runs.
- `maxSubSteps` and `fixedTimeStep` stay `@ignore`d as before. The new docs describe fixed substeps generically rather than linking to them, so whether to expose those two is left as a separate decision. The API report bot's `+fixedTimeStep / +maxSubSteps / +paused` lines reflect the first commit and no longer apply to the branch head.

### Testing
- Unit tests in `test/framework/components/rigid-body/system.test.mjs`: default stepping, delta scaling, full skip at 0, resume, negative scale treated as paused, manual `step()` while paused with an unscaled delta, and `step()` without a backend.
- `npm run lint`, `npm run build:types` + `npm run test:types`, and `typedoc` are clean for the touched classes.
- Verified against the real Ammo backend in the `physics/falling-shapes` example, driving frames with `app.update(1 / 60)`: 60 frames at `timeScale = 0` moved no body and the physics stat read 0; at `timeScale = 0.25` the sampled body moved on all 12 sampled frames with steady per-frame deltas of about 0.023 m (versus about 0.11 m per frame at full speed), apart from a catch-up jump on the first frames after unpausing as Bullet's fixed-step accumulator realigns.

Fixes #9272

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
