### PR TITLE
Wait for npm before the Publish workflow reports success

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,3 +81,38 @@ jobs:
         with:
           name: version
           path: version.txt
+
+  # npm publish is asynchronous: it returns as soon as the tarball is accepted ("Your package
+  # is being processed and may take a few minutes to become available"), so the job above going
+  # green no longer means the version is on the registry - it can lag by many minutes, and a
+  # publish that is rejected during processing would leave this workflow green having shipped
+  # nothing. This job holds the run open until the version actually resolves, so the workflow's
+  # conclusion means "published" for everything keyed off it (the Upload workflow, and anyone
+  # reading the run). It is a separate job so a timeout can be re-run on its own without
+  # re-running the build and re-attempting a publish that would now conflict.
+  await-npm:
+    name: Await npm
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Parse tag name
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          echo "VERSION=${TAG_NAME/v/}" >> $GITHUB_ENV
+
+      - name: Wait for npm
+        run: |
+          url="https://registry.npmjs.org/playcanvas/${{ env.VERSION }}"
+          for i in $(seq 1 120); do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 -H 'Cache-Control: no-cache' "$url" || true)
+            if [ "$code" = "200" ]; then
+              echo "playcanvas@${{ env.VERSION }} is available on npm"
+              exit 0
+            fi
+            echo "Not on npm yet (HTTP $code), retrying in 15s ($i/120)"
+            sleep 15
+          done
+          echo "Timed out waiting for playcanvas@${{ env.VERSION }} to appear on npm"
+          exit 1


### PR DESCRIPTION
`npm publish` became asynchronous: it returns as soon as the tarball is accepted ("Your package is being processed and may take a few minutes to become available"), so the Publish workflow going green no longer means the version is on the registry. The Upload workflow triggers on Publish's success and POSTs to the code.playcanvas.com endpoint, which fetches the package from npm — so it now fires before the version resolves and gets a 500.

Observed on 2.22.0: npm accepted the publish at 11:23:28, Upload's POST went out at 11:23:42, and the version only resolved on the registry ~40 minutes later. 2.22.0-beta.31 was accepted at 02:29 and landed at 02:41. Publishes on 09-02 and 09-03 had no such notice and were live within 3s, which is why this only started failing on 09-04. The uploads for 2.22.0-beta.31, 2.22.0-preview.0 and 2.22.0 all failed this way, so none of them reached code.playcanvas.com.

**Changes:**
- Add an `await-npm` job to the Publish workflow that polls `registry.npmjs.org/playcanvas/<version>` until it resolves (15s interval, 30 minute cap) before the run is allowed to finish
- Publish's conclusion now means "published", which is what Upload's `workflow_run` trigger already assumed — `upload.yml` itself is unchanged
- A publish rejected during npm's async processing now reddens the Publish run, instead of leaving it green having shipped nothing

It is a separate job rather than a step on `publish` so a timeout can be re-run on its own — re-running the publish job would rebuild for ~8 minutes and then conflict on the second `npm publish`. The poll reports the HTTP status on each attempt rather than letting `curl -f` print an error per 404, and rides out transient registry errors (a 504 showed up while testing).