### PR TITLE
Link a whole examples category by URL

### DIFF
--- a/examples/src/app/categories.mjs
+++ b/examples/src/app/categories.mjs
@@ -1,0 +1,49 @@
+import { exampleMetaData } from '../../cache/metadata.mjs';
+
+/**
+ * @param {string} a - First name.
+ * @param {string} b - Second name.
+ * @returns {number} Sort order.
+ */
+export const byName = (a, b) => (a > b ? 1 : -1);
+
+/**
+ * The categories as listed by the sidebar. Hidden examples are always built and
+ * reachable via URL, but are only listed during development (`npm run develop`),
+ * not in production builds (`npm run build`).
+ *
+ * @returns {Record<string, { examples: Record<string, string> }>} - The category files.
+ */
+export function getCategories() {
+    /** @type {Record<string, { examples: Record<string, string> }>} */
+    const categories = {};
+    for (let i = 0; i < exampleMetaData.length; i++) {
+        const { categoryKebab, exampleNameKebab, hidden } = exampleMetaData[i];
+
+        if (hidden && process.env.NODE_ENV !== 'development') {
+            continue;
+        }
+
+        if (!categories[categoryKebab]) {
+            categories[categoryKebab] = { examples: {} };
+        }
+
+        categories[categoryKebab].examples[exampleNameKebab] = exampleNameKebab;
+    }
+    return categories;
+}
+
+/**
+ * The first example of a category as the sidebar orders them, used to resolve a
+ * bare `#/<category>` URL to a concrete example.
+ *
+ * @param {string} category - Category name.
+ * @returns {string | null} Example name, or null if the category is unknown.
+ */
+export function getFirstExample(category) {
+    const examples = getCategories()[category]?.examples;
+    if (!examples) {
+        return null;
+    }
+    return Object.keys(examples).sort(byName)[0] ?? null;
+}

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -1,15 +1,18 @@
 import { Container } from '@playcanvas/pcui/react';
 import { Component } from 'react';
-import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { HashRouter, Routes, Route, Navigate, useLocation, useParams } from 'react-router-dom';
 
 import { CodeEditorDesktop } from './code-editor/CodeEditorDesktop.mjs';
 import { Example } from './Example.mjs';
 import { Menu } from './Menu.mjs';
 import { SideBar } from './Sidebar.mjs';
+import { getFirstExample } from '../categories.mjs';
 import { iframe } from '../iframe.mjs';
 import { jsx } from '../jsx.mjs';
 import { patchState, readState } from '../url-state.mjs';
 import { getLayout } from '../utils.mjs';
+
+/** @import { ReactElement } from 'react' */
 
 const MOBILE_DOCK_HEIGHT = 48;
 const MOBILE_DOCK_WIDTH = 48;
@@ -66,6 +69,28 @@ function getDefaultMobilePanelWidth() {
         MOBILE_PANEL_DEFAULT_MAX_WIDTH,
         Math.max(MOBILE_PANEL_DEFAULT_MIN_WIDTH, window.innerWidth * MOBILE_PANEL_DEFAULT_WIDTH_SCALE)
     ));
+}
+
+/**
+ * Resolves a bare `#/<category>` URL to the first example of that category, so a
+ * category can be linked directly. `focusCategory` rides along in the location
+ * state to tell the sidebar to show just that category and collapse the rest;
+ * the hash query is carried over so a shared `?s=` state survives the redirect.
+ *
+ * @returns {ReactElement} Redirect to the first example of the category.
+ */
+function CategoryRedirect() {
+    const { category = '' } = useParams();
+    const { search } = useLocation();
+    const example = getFirstExample(category);
+    if (!example) {
+        return jsx(Navigate, { to: { pathname: '/misc/hello-world', search }, replace: true });
+    }
+    return jsx(Navigate, {
+        to: { pathname: `/${category}/${example}`, search },
+        replace: true,
+        state: { focusCategory: category }
+    });
 }
 
 // eslint-disable-next-line jsdoc/require-property
@@ -286,6 +311,10 @@ class MainLayout extends TypedComponent {
                     jsx(Route, {
                         path: '/',
                         element: jsx(Navigate, { to: '/misc/hello-world', replace: true })
+                    }),
+                    jsx(Route, {
+                        path: '/:category',
+                        element: jsx(CategoryRedirect, null)
                     }),
                     jsx(Route, {
                         path: '/:category/:example',

--- a/examples/src/app/components/Sidebar.mjs
+++ b/examples/src/app/components/Sidebar.mjs
@@ -3,7 +3,7 @@ import { BindingTwoWay, BooleanInput, Container, Label, LabelGroup, Panel, TextI
 import { Component } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
-import { exampleMetaData } from '../../../cache/metadata.mjs';
+import { byName, getCategories } from '../categories.mjs';
 import { VERSION } from '../constants.mjs';
 import { iframe } from '../iframe.mjs';
 import { jsx } from '../jsx.mjs';
@@ -13,9 +13,11 @@ import { getLayout } from '../utils.mjs';
 
 /** @import { ReactElement } from 'react' */
 
+const CATEGORY_PANEL_ID = 'category-panel-';
+
 /**
  * @typedef {object} Props
- * @property {{ pathname: string, hash: string }} location - The router location.
+ * @property {{ pathname: string, hash: string, state?: any }} location - The router location.
  * @property {'mobile'|'desktop'} [layout] - Current layout.
  * @property {null|'examples'|'code'|'controls'|'description'} [mobilePanel] - Active mobile panel.
  * @property {(mobilePanel: null|'examples'|'code'|'controls'|'description') => void} [setMobilePanel] - Set active mobile panel.
@@ -28,6 +30,7 @@ import { getLayout } from '../utils.mjs';
  * @property {Record<string, Record<string, object>>|null} filteredCategories - The filtered categories.
  * @property {Observer} observer - The observer.
  * @property {boolean} collapsed - Collapsed or not.
+ * @property {Record<string, boolean>} collapsedCategories - Collapsed state per category.
  * @property {string} filterText - The current filter.
  * @property {'mobile'|'desktop'} layout - Current layout.
  */
@@ -38,28 +41,34 @@ import { getLayout } from '../utils.mjs';
 const TypedComponent = Component;
 
 /**
- * @returns {Record<string, { examples: Record<string, string> }>} - The category files.
+ * @param {Props['location']} location - The router location.
+ * @returns {string | null} Category the URL asked to focus on, if any.
  */
-function getDefaultExampleFiles() {
-    /** @type {Record<string, { examples: Record<string, string> }>} */
-    const categories = {};
-    for (let i = 0; i < exampleMetaData.length; i++) {
-        const { categoryKebab, exampleNameKebab, hidden } = exampleMetaData[i];
+const focusedCategory = (location) => {
+    const focus = location?.state?.focusCategory;
+    return typeof focus === 'string' ? focus : null;
+};
 
-        // hidden examples are always built and reachable via URL, but are only listed in the
-        // sidebar during development (`npm run develop`), not in production builds (`npm run build`)
-        if (hidden && process.env.NODE_ENV !== 'development') {
-            continue;
-        }
-
-        if (!categories[categoryKebab]) {
-            categories[categoryKebab] = { examples: {} };
-        }
-
-        categories[categoryKebab].examples[exampleNameKebab] = exampleNameKebab;
+/**
+ * Every category other than `focusCategory` starts collapsed, so a bare
+ * `#/<category>` URL opens the sidebar showing just that category. Without a
+ * focus category (any normal example URL) all categories stay expanded.
+ *
+ * @param {Record<string, any>} categories - The default categories.
+ * @param {string | null} focusCategory - Category to keep expanded.
+ * @returns {Record<string, boolean>} Collapsed state per category.
+ */
+const collapseAllBut = (categories, focusCategory) => {
+    /** @type {Record<string, boolean>} */
+    const collapsedCategories = {};
+    if (!focusCategory) {
+        return collapsedCategories;
     }
-    return categories;
-}
+    for (const category of Object.keys(categories)) {
+        collapsedCategories[category] = category !== focusCategory;
+    }
+    return collapsedCategories;
+};
 
 /**
  * Split a filter string into exact-match `category:`/`example:` tags and fuzzy free-text terms.
@@ -126,27 +135,35 @@ function filterCategories(defaultCategories, filter) {
     return updatedCategories;
 }
 
-const createState = () => {
+/**
+ * @param {Props['location']} location - The router location.
+ * @returns {State} The initial state.
+ */
+const createState = (location) => {
     const ui = readState().ui ?? {};
     const filter = typeof ui.filter === 'string' ? ui.filter : '';
     const largeThumbnails = typeof ui.largeThumbnails === 'boolean' ? ui.largeThumbnails : false;
     const collapsed = typeof ui.sideBarCollapsed === 'boolean' ?
         ui.sideBarCollapsed :
         localStorage.getItem('sideBarCollapsed') === 'true' || getLayout() === 'mobile';
-    const defaultCategories = getDefaultExampleFiles();
+    const defaultCategories = getCategories();
     return {
         defaultCategories,
         filteredCategories: filterCategories(defaultCategories, filter),
         filterText: filter,
         observer: new Observer({ largeThumbnails }),
         collapsed,
+        collapsedCategories: collapseAllBut(defaultCategories, focusedCategory(location)),
         layout: getLayout()
     };
 };
 
 class SideBar extends TypedComponent {
     /** @type {State} */
-    state = createState();
+    state = createState(this.props.location);
+
+    /** @type {WeakSet<object>} */
+    _categoryPanels = new WeakSet();
 
     /** @type {HTMLElement | null} */
     _sideBar = null;
@@ -165,6 +182,44 @@ class SideBar extends TypedComponent {
         this._onLayoutChange = this._onLayoutChange.bind(this);
         this._onClickExample = this._onClickExample.bind(this);
         this._onLargeThumbnailsSet = this._onLargeThumbnailsSet.bind(this);
+    }
+
+    /**
+     * PCUI owns the visual collapse of a category panel, but the React wrapper writes
+     * every prop with a setter back onto the element on each render — so a header click
+     * has to be mirrored into state, or the next render snaps the panel back.
+     *
+     * @param {string} category - Category name.
+     * @param {boolean} collapsed - Collapsed state after the click.
+     */
+    _onCategoryToggle(category, collapsed) {
+        this.setState((prevState) => {
+            // while filtering, panels are force-expanded so matches can't hide in one
+            if (prevState.filterText || Boolean(prevState.collapsedCategories[category]) === collapsed) {
+                return null;
+            }
+            return {
+                collapsedCategories: { ...prevState.collapsedCategories, [category]: collapsed }
+            };
+        });
+    }
+
+    /**
+     * Category panels are created by PCUI, so their collapse events are only reachable
+     * through the element behind the DOM node. Each panel is subscribed once.
+     */
+    setupCategoryPanels() {
+        const panels = document.querySelectorAll(`[id^="${CATEGORY_PANEL_ID}"]`);
+        for (const dom of panels) {
+            const panel = /** @type {any} */ (dom).ui;
+            if (!panel || this._categoryPanels.has(panel)) {
+                continue;
+            }
+            this._categoryPanels.add(panel);
+            const category = dom.id.slice(CATEGORY_PANEL_ID.length);
+            panel.on('collapse', () => this._onCategoryToggle(category, true));
+            panel.on('expand', () => this._onCategoryToggle(category, false));
+        }
     }
 
     setupSideBar() {
@@ -192,12 +247,14 @@ class SideBar extends TypedComponent {
     componentDidMount() {
         this._largeThumbnailsHandle = this.state.observer.on('largeThumbnails:set', this._onLargeThumbnailsSet);
         this.setupSideBar();
+        this.setupCategoryPanels();
         window.addEventListener('resize', this._onLayoutChange);
         window.addEventListener('orientationchange', this._onLayoutChange);
     }
 
     componentDidUpdate() {
         this.setupSideBar();
+        this.setupCategoryPanels();
     }
 
     componentWillUnmount() {
@@ -301,17 +358,19 @@ class SideBar extends TypedComponent {
             return jsx(Label, { text: 'No results' });
         }
         const { pathname } = this.props.location;
+        const { collapsedCategories, filterText } = this.state;
         return Object.keys(categories)
-        .sort((a, b) => (a > b ? 1 : -1))
+        .sort(byName)
         .map((category) => {
             return jsx(
                 Panel,
                 {
                     key: category,
+                    id: `${CATEGORY_PANEL_ID}${category}`,
                     class: 'categoryPanel',
                     headerText: category.split('-').join(' ').toUpperCase(),
                     collapsible: true,
-                    collapsed: false
+                    collapsed: !filterText && collapsedCategories[category] === true
                 },
                 jsx(
                     'ul',
@@ -319,7 +378,7 @@ class SideBar extends TypedComponent {
                         className: 'category-nav'
                     },
                     Object.keys(categories[category].examples)
-                    .sort((a, b) => (a > b ? 1 : -1))
+                    .sort(byName)
                     .map((example) => {
                         const path = `/${category}/${example}`;
                         const isSelected = pathname === path;


### PR DESCRIPTION
`http://localhost:5555/#/physics` currently renders a blank page — only `#/<category>/<example>` is routable. A bare category URL now opens that category: it resolves to the first example in the category, expands only that category in the sidebar and collapses the rest, which makes it possible to link someone at a topic rather than at one specific example.

**Changes:**
- New `/:category` route resolves `#/<category>` to the first example of that category (same ordering the sidebar lists) and replaces the URL with the canonical `#/<category>/<example>`
- An unknown category falls back to the index example, and the hash query is carried over so a shared `?s=` state survives the redirect
- Sidebar shows only the linked category expanded; every other category starts collapsed
- Category collapse state moved into the sidebar's React state. The PCUI React wrapper writes every setter-backed prop onto the element on each render, so the previously hardcoded `collapsed: false` was silently re-expanding all category panels on every re-render (filter typing, thumbnail toggle, navigation). Header clicks are now mirrored back from the panel's `collapse`/`expand` events, so a manually opened category survives navigation
- An active filter force-expands the panels, so a match can never hide inside a collapsed category
- `getCategories()` / `getFirstExample()` hoisted out of `Sidebar.mjs` into `src/app/categories.mjs`, so the route and the sidebar agree on ordering and on hiding `hidden` examples in production builds

Behaviour of a normal `#/<category>/<example>` URL is unchanged — all categories stay expanded.


example of using this url: ```http://localhost:5555/#/input```
<img width="901" height="1198" alt="Screenshot 2026-09-04 at 13 00 44" src="https://github.com/user-attachments/assets/de530833-0a95-4533-9921-b54530784c2e" />
