### PR TITLE
docs: correct RigidBodyComponent group/mask defaults and raycastAll sort order

### DIFF
--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -317,7 +317,10 @@ class RigidBodyComponent extends Component {
 
     /**
      * Sets the collision group this body belongs to. Combine the group and the mask to prevent bodies
-     * colliding with each other. Defaults to 1.
+     * colliding with each other. The default depends on the body {@link RigidBodyComponent#type}:
+     * static bodies use `BODYGROUP_STATIC` (2), dynamic bodies use `BODYGROUP_DYNAMIC` (1) and
+     * kinematic bodies use `BODYGROUP_KINEMATIC` (4). Setting the type resets the group to the
+     * default for the new type, so set the group after the type.
      *
      * @type {number}
      */
@@ -420,7 +423,11 @@ class RigidBodyComponent extends Component {
 
     /**
      * Sets the collision mask sets which groups this body collides with. It is a bit field of 16
-     * bits, the first 8 bits are reserved for engine use. Defaults to 65535.
+     * bits, the first 8 bits are reserved for engine use. The default depends on the body
+     * {@link RigidBodyComponent#type}: static bodies use `BODYMASK_NOT_STATIC` (65533, which
+     * collides with everything except other static bodies), while dynamic and kinematic bodies use
+     * `BODYMASK_ALL` (65535). Setting the type resets the mask to the default for the new type, so
+     * set the mask after the type.
      *
      * @type {number}
      */
@@ -538,7 +545,9 @@ class RigidBodyComponent extends Component {
      * - {@link BODYTYPE_KINEMATIC}: infinite mass and does not respond to forces (can only be
      * moved by setting the position and rotation of component's {@link Entity}).
      *
-     * Defaults to {@link BODYTYPE_STATIC}.
+     * Defaults to {@link BODYTYPE_STATIC}. Changing the type also resets
+     * {@link RigidBodyComponent#group} and {@link RigidBodyComponent#mask} to the defaults for
+     * the new type.
      *
      * @type {BODYTYPE_DYNAMIC|BODYTYPE_KINEMATIC|BODYTYPE_STATIC}
      */

--- a/src/framework/components/rigid-body/component.js
+++ b/src/framework/components/rigid-body/component.js
@@ -318,9 +318,8 @@ class RigidBodyComponent extends Component {
     /**
      * Sets the collision group this body belongs to. Combine the group and the mask to prevent bodies
      * colliding with each other. The default depends on the body {@link RigidBodyComponent#type}:
-     * static bodies use `BODYGROUP_STATIC` (2), dynamic bodies use `BODYGROUP_DYNAMIC` (1) and
-     * kinematic bodies use `BODYGROUP_KINEMATIC` (4). Setting the type resets the group to the
-     * default for the new type, so set the group after the type.
+     * 1 for dynamic bodies, 2 for static bodies and 4 for kinematic bodies. Setting the type
+     * resets the group to the default for the new type, so set the group after the type.
      *
      * @type {number}
      */
@@ -424,10 +423,10 @@ class RigidBodyComponent extends Component {
     /**
      * Sets the collision mask sets which groups this body collides with. It is a bit field of 16
      * bits, the first 8 bits are reserved for engine use. The default depends on the body
-     * {@link RigidBodyComponent#type}: static bodies use `BODYMASK_NOT_STATIC` (65533, which
-     * collides with everything except other static bodies), while dynamic and kinematic bodies use
-     * `BODYMASK_ALL` (65535). Setting the type resets the mask to the default for the new type, so
-     * set the mask after the type.
+     * {@link RigidBodyComponent#type}: 65533 for static bodies, which collides with everything
+     * except other static bodies, and 65535 for dynamic and kinematic bodies, which collides with
+     * everything. Setting the type resets the mask to the default for the new type, so set the
+     * mask after the type.
      *
      * @type {number}
      */

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -441,7 +441,8 @@ class RigidBodyComponentSystem extends ComponentSystem {
     /**
      * Raycast the world and return all entities the ray hits. It returns an array of
      * {@link RaycastResult}, one for each hit. If no hits are detected, the returned array will be
-     * of length 0. Results are sorted by distance with closest first.
+     * of length 0. Results are returned in no particular order unless `options.sort` is true, in
+     * which case they are sorted by distance with the closest first.
      *
      * @param {Vec3} start - The world space point where the ray starts.
      * @param {Vec3} end - The world space point where the ray ends.


### PR DESCRIPTION
## Description
Two physics JSDoc comments contradicted the implementation, and therefore the published API reference at https://api.playcanvas.com:

- `RigidBodyComponent#group` said "Defaults to 1." and `RigidBodyComponent#mask` said "Defaults to 65535.", but the component initializes as a static body with group 2 and mask 65533. 1 and 65535 are only the values the `type` setter assigns when the body becomes dynamic. Both comments now give the per-type defaults (dynamic, static, kinematic) with a short description of what each mask means, and note that setting `type` resets group and mask, so they must be set after the type. The `type` setter doc gains one sentence pointing at that reset.
- `RigidBodyComponentSystem#raycastAll` said results "are sorted by distance with closest first", but the implementation only sorts when `options.sort` is true (as the `options.sort` parameter doc already said). The summary now says results are unsorted unless `options.sort` is true.

Docs only: no runtime changes and no new public API. The defaults are given as plain numbers, matching how `group`, `mask` and the raycast filter options are typed throughout the public API, rather than naming the internal group/mask constants.

Verified with `npm run lint`, `npm run build:types`, `npm run test:types`, and a TypeDoc run (no new warnings; the `{@link RigidBodyComponent#group}` / `#mask` references resolve).

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
