### PR TITLE
Redesign MiniStats with compact and grouped profiling views

### DIFF
--- a/examples/src/examples/debug/mini-stats.example.mjs
+++ b/examples/src/examples/debug/mini-stats.example.mjs
@@ -1,6 +1,5 @@
 // @config
 // @flag ENGINE=performance
-// @flag WEBGPU_DISABLED
 
 import {
     AppBase,
@@ -63,14 +62,8 @@ app.on('destroy', () => {
 // Set up options for mini-stats, start with the default options
 const options = MiniStats.getDefaultOptions();
 
-// Configure sizes
-options.sizes = [
-    { width: 128, height: 16, spacing: 0, graphs: false },
-    { width: 256, height: 32, spacing: 2, graphs: true },
-    { width: 500, height: 64, spacing: 2, graphs: true }
-];
-
-// When the application starts, use the largest size
+// Click the overlay to cycle between core counters, grouped averages and graph history.
+// Panel width and row height can be customized independently for each mode.
 options.startSizeIndex = 2;
 
 // Display additional counters

--- a/src/extras/mini-stats/cpu-timer.js
+++ b/src/extras/mini-stats/cpu-timer.js
@@ -2,70 +2,47 @@ import { now } from '../../core/time.js';
 
 class CpuTimer {
     constructor(app) {
-        this._frameIndex = 0;
-        this._frameTimings = [];
-        this._timings = [];
-        this._prevTimings = [];
+        this.app = app;
         this.unitsName = 'ms';
         this.decimalPlaces = 1;
-
         this.enabled = true;
-
-        app.on('frameupdate', this.begin.bind(this, 'update'));
-        app.on('framerender', this.mark.bind(this, 'render'));
-        app.on('frameend', this.mark.bind(this, 'other'));
+        this._pending = new Float64Array(2);
+        this._timings = new Float64Array(2);
+        this._updateStart = 0;
+        this._renderStart = 0;
+        app.on('frameupdate', this.begin, this);
+        app.on('framerender', this.mark, this);
+        app.on('frameend', this.end, this);
     }
 
-    // mark the beginning of the frame
-    begin(name) {
-        if (!this.enabled) {
-            return;
+    begin() {
+        if (this.enabled) {
+            this._timings.set(this._pending);
+            this._updateStart = now();
         }
-
-        // end previous frame timings
-        if (this._frameIndex < this._frameTimings.length) {
-            this._frameTimings.splice(this._frameIndex);
-        }
-        const tmp = this._prevTimings;
-        this._prevTimings = this._timings;
-        this._timings = this._frameTimings;
-        this._frameTimings = tmp;
-        this._frameIndex = 0;
-
-        this.mark(name);
     }
 
-    // mark
-    mark(name) {
-        if (!this.enabled) {
-            return;
+    mark() {
+        if (this.enabled) {
+            this._renderStart = now();
+            this._pending[0] = this._renderStart - this._updateStart;
         }
+    }
 
-        const timestamp = now();
-
-        // end previous mark
-        if (this._frameIndex > 0) {
-            const prev = this._frameTimings[this._frameIndex - 1];
-            prev[1] = timestamp - prev[1];
-        } else if (this._timings.length > 0) {
-            const prev = this._timings[this._timings.length - 1];
-            prev[1] = timestamp - prev[1];
+    end() {
+        if (this.enabled) {
+            this._pending[1] = now() - this._renderStart;
         }
-
-        if (this._frameIndex >= this._frameTimings.length) {
-            this._frameTimings.push([name, timestamp]);
-        } else {
-            const timing = this._frameTimings[this._frameIndex];
-            timing[0] = name;
-            timing[1] = timestamp;
-        }
-        this._frameIndex++;
     }
 
     get timings() {
-        // remove the last time point from the list (which is the time spent outside
-        // of PlayCanvas)
-        return this._timings.slice(0, -1).map(v => v[1]);
+        return this._timings;
+    }
+
+    destroy() {
+        this.app.off('frameupdate', this.begin, this);
+        this.app.off('framerender', this.mark, this);
+        this.app.off('frameend', this.end, this);
     }
 }
 

--- a/src/extras/mini-stats/graph.js
+++ b/src/extras/mini-stats/graph.js
@@ -1,110 +1,74 @@
-// Realtime performance graph visual
 class Graph {
     constructor(name, app, watermark, textRefreshRate, timer) {
-        this.app = app;
         this.name = name;
-        this.device = app.graphicsDevice;
+        this.label = name === 'DrawCalls' ? 'Draw calls' : name;
         this.timer = timer;
-        this.watermark = watermark;
+        this.watermark = watermark ?? 100;
         this.enabled = false;
         this.textRefreshRate = textRefreshRate;
-
         this.avgTotal = 0;
         this.avgTimer = 0;
         this.avgCount = 0;
         this.maxValue = 0;
-        this.timingText = '';
-        this.maxText = '';
-
+        this.timingText = '—';
+        this.maxText = '—';
         this.texture = null;
         this.yOffset = 0;
-        this.graphType = 0.0;
         this.cursor = 0;
-        this.sample = new Uint8ClampedArray(4);
-        this.sample.set([0, 0, 0, 255]);
-        this.needsClear = false;
-
-        this.counter = 0;
-
-        this.app.on('frameupdate', this.update, this);
+        this.needsClear = true;
+        this.quad = -1;
+        this.renderWidth = 0;
+        this.parent = null;
+        this.group = 0;
+        this.lastNonZeroFrame = 0;
+        this.statName = '';
     }
 
     destroy() {
-        this.app.off('frameupdate', this.update, this);
+        if (typeof this.timer.destroy === 'function') this.timer.destroy();
     }
 
-    // called when context was lost, function releases all context related resources
     loseContext() {
-        // if timer implements loseContext
-        if (this.timer && (typeof this.timer.loseContext === 'function')) {
-            this.timer.loseContext();
-        }
+        if (typeof this.timer.loseContext === 'function') this.timer.loseContext();
     }
 
-    update(ms) {
+    // Returns a bitmask of changed average (1) and peak (2) text. The shared texture is
+    // locked once by MiniStats, so all rows are updated before a single unlock/upload.
+    update(ms, data) {
         const timings = this.timer.timings;
-
-        // calculate total
-        const total = timings.reduce((a, v) => a + v, 0);
-
-        // update averages and max
+        let total = 0;
+        for (let i = 0; i < timings.length; i++) total += timings[i];
+        if (!Number.isFinite(total)) total = 0;
         this.avgTotal += total;
         this.avgTimer += ms;
         this.avgCount++;
         this.maxValue = Math.max(this.maxValue, total);
-
-        if (this.avgTimer > this.textRefreshRate) {
-            this.timingText = (this.avgTotal / this.avgCount).toFixed(this.timer.decimalPlaces);
-            this.maxText = this.maxValue.toFixed(this.timer.decimalPlaces);
-            this.avgTimer = 0;
+        let changed = 0;
+        if (this.avgTimer >= this.textRefreshRate) {
+            const timingText = (this.avgTotal / this.avgCount).toFixed(this.timer.decimalPlaces);
+            const maxText = this.maxValue.toFixed(this.timer.decimalPlaces);
+            changed = (this.timingText !== timingText ? 1 : 0) | (this.maxText !== maxText ? 2 : 0);
+            this.timingText = timingText;
+            this.maxText = maxText;
             this.avgTotal = 0;
+            this.avgTimer = 0;
             this.avgCount = 0;
             this.maxValue = 0;
         }
-
-        if (this.enabled) {
-            // update total timing sample
-            const range = 1.5 * this.watermark;
-            this.sample[0] = Math.floor(total / range * 255);
-            this.sample[1] = 0;
-            this.sample[2] = 0;
-
-            // .a store watermark
-            this.sample[3] = this.watermark / range * 255;
-
-            // bounds check - skip if texture is too small
-            if (this.yOffset >= this.texture.height) {
-                return;
-            }
-
-            // write latest sample
-            const data = this.texture.lock();
-
-            // clear entire row if needed (when row is newly allocated)
+        if (data && this.enabled) {
+            const width = this.texture.width;
+            const rowOffset = this.yOffset * width * 4;
             if (this.needsClear) {
-                const rowOffset = this.yOffset * this.texture.width * 4;
-                data.fill(0, rowOffset, rowOffset + this.texture.width * 4);
+                data.fill(0, rowOffset, rowOffset + width * 4);
                 this.needsClear = false;
             }
-
-            data.set(this.sample, (this.cursor + this.yOffset * this.texture.width) * 4);
-            this.texture.unlock();
-
-            // update cursor position
-            this.cursor++;
-            if (this.cursor === this.texture.width) {
-                this.cursor = 0;
-            }
+            const offset = rowOffset + this.cursor * 4;
+            const range = 1.5 * (this.watermark > 0 ? this.watermark : 100);
+            data[offset] = Math.min(255, Math.max(0, Math.round(total / range * 255)));
+            data[offset + 3] = 170;
+            this.cursor = (this.cursor + 1) % width;
         }
-    }
-
-    render(render2d, x, y, w, h) {
-        render2d.quad(x + w, y, -w, h,
-            this.enabled ? this.cursor : 0,
-            this.enabled ? 0.5 + this.yOffset : this.texture.height - 1,
-            -w, 0,
-            this.texture,
-            this.graphType);
+        return changed;
     }
 }
 

--- a/src/extras/mini-stats/mini-stats.js
+++ b/src/extras/mini-stats/mini-stats.js
@@ -1,6 +1,6 @@
 import { math } from '../../core/math/math.js';
 import { Texture } from '../../platform/graphics/texture.js';
-import { ADDRESS_REPEAT, FILTER_NEAREST } from '../../platform/graphics/constants.js';
+import { ADDRESS_REPEAT, FILTER_LINEAR } from '../../platform/graphics/constants.js';
 import { LAYERID_UI } from '../../scene/constants.js';
 import { CpuTimer } from './cpu-timer.js';
 import { GpuTimer } from './gpu-timer.js';
@@ -14,20 +14,28 @@ import { Render2d } from './render2d.js';
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  */
 
-// CPU stat name mappings: full property name -> shortened display name
 const cpuStatDisplayNames = {
-    animUpdate: 'anim',
-    physicsTime: 'physics',
-    renderTime: 'render',
-    gsplatSort: 'gsplatSort'
+    scriptUpdate: 'Script update',
+    scriptPostUpdate: 'Script post-update',
+    animUpdate: 'Animation',
+    physicsTime: 'Physics',
+    renderTime: 'Render',
+    gsplatSort: 'Splat sort'
 };
+const vramStatDisplayNames = { tex: 'Textures', geom: 'Geometry', buffers: 'Buffers' };
+const cpuStatNames = ['renderTime', 'scriptUpdate', 'scriptPostUpdate', 'animUpdate', 'physicsTime', 'gsplatSort'];
+const vramStatNames = ['tex', 'geom', 'buffers'];
 
-// CPU stats with delayed creation (only shown once non-zero, but never removed)
-const delayedStartStats = new Set([
-    'physicsTime',
-    'animUpdate',
-    'gsplatSort'
-]);
+// Packed RGBA bytes for the vertex color attribute. The overlay is authored in display space.
+const BACKGROUND = 0xff231b15;
+const GROUP_BACKGROUND = 0xff372b22;
+const BORDER = 0xff4e3d30;
+const TEXT = 0xfffaf5f2;
+const MUTED = 0xffc8b8ad;
+const graphColors = [0xff6db1d9, 0xfff7b884, 0xffb6d16d, 0xffdda0b8];
+
+const graphOrder = graph => (graph.label === 'Draw calls' ? 0 : graph.name === 'Frame' ? 1 : graph.group + 2);
+const compareGraphs = (a, b) => graphOrder(a) - graphOrder(b);
 
 /**
  * @typedef {object} MiniStatsSizeOptions
@@ -35,6 +43,9 @@ const delayedStartStats = new Set([
  * @property {number} height - Height of the graph area.
  * @property {number} spacing - Spacing between graphs.
  * @property {boolean} graphs - Whether to show graphs.
+ * @property {boolean} [detailed] - Show category headers and sub-counters. Defaults to true for
+ * sizes after the first, or when graphs are enabled.
+ * @property {boolean} [peak] - Show a peak column in the detailed view. Defaults to the graphs setting.
  */
 
 /**
@@ -50,6 +61,8 @@ const delayedStartStats = new Set([
  * @property {string[]} stats - Path to data inside Application.stats.
  * @property {number} [decimalPlaces] - Number of decimal places (defaults to none).
  * @property {string} [unitsName] - Units (defaults to "").
+ * @property {number} [multiplier=1] - Multiplier applied to sampled values, for example to convert
+ * bytes to megabytes.
  * @property {number} [watermark] - Watermark - shown as a line on the graph, useful for displaying
  * a budget.
  */
@@ -59,7 +72,9 @@ const delayedStartStats = new Set([
  * @property {MiniStatsSizeOptions[]} sizes - Sizes of area to render individual graphs in and
  * spacing between individual graphs.
  * @property {number} startSizeIndex - Index into sizes array for initial setting.
- * @property {number} textRefreshRate - Refresh rate of text stats in ms.
+ * @property {number} textRefreshRate - Text update interval and averaging window in ms (500 in the
+ * default options). Each update shows the arithmetic mean and peak of the frame samples collected
+ * since the previous update, then starts a new window. Graph history samples every frame.
  * @property {MiniStatsProcessorOptions} cpu - CPU graph options.
  * @property {MiniStatsProcessorOptions} gpu - GPU graph options.
  * @property {MiniStatsGraphOptions[]} stats - Array of options to render additional graphs based
@@ -90,137 +105,127 @@ class MiniStats {
      * @param {AppBase} app - The application.
      * @param {MiniStatsOptions} [options] - Options for the MiniStats instance.
      * @example
-     * // create a new MiniStats instance using default options
      * const miniStats = new MiniStats(app);
      */
     constructor(app, options = MiniStats.getDefaultOptions()) {
-        const device = app.graphicsDevice;
+        this.app = app;
+        this.device = app.graphicsDevice;
+        this.sizes = options.sizes.map(size => ({ ...size }));
+        this.graphRows = new Map();
+        this.freeRows = [];
+        this.nextRowIndex = 0;
+        this.gpuPassGraphs = new Map();
+        this.cpuGraphs = new Map();
+        this.vramGraphs = new Map();
+        this.gpuTimingMinSize = options.gpuTimingMinSize ?? 1;
+        this.cpuTimingMinSize = options.cpuTimingMinSize ?? 1;
+        this.vramTimingMinSize = options.vramTimingMinSize ?? 1;
+        this.textRefreshRate = options.textRefreshRate;
+        this._averageLabel = `Avg (${this.textRefreshRate / 1000}s)`;
+        this.frameIndex = 0;
+        this._enabled = true;
+        this._destroyed = false;
+        this._geometryDirty = true;
+        this._layoutDirty = true;
+        this._scroll = 0;
+        this._maxScroll = 0;
+        this._overallHeight = 0;
+        this.clr = [1, 1, 1, 0.95];
+        this.initGraphs(app, this.device, options);
 
-        // Persistent texture row allocation (must be initialized before initGraphs)
-        this.graphRows = new Map();  // Map<Graph, rowIndex>
-        this.freeRows = [];          // Available rows for reuse
-        this.nextRowIndex = 0;       // Next new row to allocate
-
-        // sizes must be set before initGraphs (needed by ensureTextureHeight)
-        this.sizes = options.sizes;
-
-        // create graphs
-        this.initGraphs(app, device, options);
-
-        // extract list of words
-        const words = new Set(
-            ['', 'ms', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '-', ' ']
-            .concat(this.graphs.map(graph => graph.name))
-            .concat(options.stats ? options.stats.map(stat => stat.unitsName) : [])
-            .filter(item => !!item)
-        );
-
-        // always add lowercase and uppercase letters (needed for "max" display and GPU pass names)
-        for (let i = 97; i <= 122; i++) {
-            words.add(String.fromCharCode(i));
+        const words = ['Metric', this._averageLabel, 'Peak', 'ms', 'MB'];
+        for (const graph of this.graphs) {
+            words.push(graph.label, graph.timer.unitsName || '');
         }
-        for (let i = 65; i <= 90; i++) {
-            words.add(String.fromCharCode(i));
-        }
+        words.push(...Object.values(cpuStatDisplayNames), ...Object.values(vramStatDisplayNames));
+        this.wordAtlas = new WordAtlas(this.device, words);
+        this.render2d = new Render2d(this.device);
+        this.drawLayer = app.scene.layers.getLayerById(LAYERID_UI);
 
-        this.wordAtlas = new WordAtlas(device, words);
-        this._activeSizeIndex = options.startSizeIndex;
-
-        // if GPU pass tracking, CPU timing or VRAM detail is enabled, use the last width for medium/large sizes
-        const gpuTimingMinSize = options.gpuTimingMinSize ?? 1;
-        const cpuTimingMinSize = options.cpuTimingMinSize ?? 1;
-        const vramTimingMinSize = options.vramTimingMinSize ?? 1;
-        if (gpuTimingMinSize < this.sizes.length || cpuTimingMinSize < this.sizes.length || vramTimingMinSize < this.sizes.length) {
-            const lastWidth = this.sizes[this.sizes.length - 1].width;
-            for (let i = 1; i < this.sizes.length - 1; i++) {
-                this.sizes[i].width = lastWidth;
-            }
-        }
-
-        // create click region so we can resize
         const div = document.createElement('div');
-        div.setAttribute('id', 'mini-stats');
-        div.style.cssText = 'position:fixed;bottom:0;left:0;background:transparent;';
+        div.id = 'mini-stats';
+        div.style.cssText = 'position:fixed;background:transparent;cursor:pointer;touch-action:none;user-select:none;';
+        div.setAttribute('role', 'button');
+        div.tabIndex = 0;
+        div.title = 'Click to change size. Scroll or drag to view more metrics.';
         document.body.appendChild(div);
-
-        div.addEventListener('mouseenter', (event) => {
-            this.opacity = 1.0;
+        this.div = div;
+        let dragging = false;
+        let pointerY = 0;
+        let startY = 0;
+        div.addEventListener('mouseenter', () => {
+            this.opacity = 1;
         });
-
-        div.addEventListener('mouseleave', (event) => {
-            // larger sizes have higher default opacity
-            this.opacity = this._activeSizeIndex > 0 ? 0.85 : 0.7;
+        div.addEventListener('mouseleave', () => {
+            this.opacity = 0.95;
         });
-
         div.addEventListener('click', (event) => {
             event.preventDefault();
-            if (this._enabled) {
+            if (this._enabled && !dragging) this.activeSizeIndex = (this.activeSizeIndex + 1) % this.sizes.length;
+            dragging = false;
+        });
+        div.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
                 this.activeSizeIndex = (this.activeSizeIndex + 1) % this.sizes.length;
-                this.resize(this.sizes[this.activeSizeIndex].width, this.sizes[this.activeSizeIndex].height, this.sizes[this.activeSizeIndex].graphs);
+            }
+        });
+        div.addEventListener('wheel', (event) => {
+            if (this._maxScroll > 0) {
+                event.preventDefault();
+                const multiplier = event.deltaMode === 1 ? this.height : event.deltaMode === 2 ? this._panelHeight : 1;
+                this.scroll(event.deltaY * multiplier);
+            }
+        }, { passive: false });
+        div.addEventListener('pointerdown', (event) => {
+            dragging = false;
+            startY = pointerY = event.clientY;
+            if (event.pointerType !== 'mouse') div.setPointerCapture(event.pointerId);
+        });
+        div.addEventListener('pointermove', (event) => {
+            if (event.buttons && event.pointerType !== 'mouse' && this._maxScroll > 0) {
+                dragging ||= Math.abs(event.clientY - startY) > 5;
+                if (dragging) this.scroll(pointerY - event.clientY);
+                pointerY = event.clientY;
             }
         });
 
-        device.on('resizecanvas', this.updateDiv, this);
-        device.on('losecontext', this.loseContext, this);
+        this.device.on('resizecanvas', this.updateDiv, this);
+        this.device.on('losecontext', this.loseContext, this);
+        app.on('frameupdate', this.update, this);
         app.on('postrender', this.postRender, this);
-
-        this.app = app;
-        this.drawLayer = app.scene.layers.getLayerById(LAYERID_UI);
-        this.device = device;
-        this.render2d = new Render2d(device);
-        this.div = div;
-
-        this.width = 0;
-        this.height = 0;
-        this.gspacing = 2;
-        // initial opacity depends on starting size
-        this.clr = [1, 1, 1, options.startSizeIndex > 0 ? 0.85 : 0.7];
-
-        this._enabled = true;
-
-        // GPU pass tracking
-        this.gpuTimingMinSize = gpuTimingMinSize;
-        this.gpuPassGraphs = new Map(); // Map<passName, { graph, lastNonZeroFrame }>
-
-        // CPU sub-timing tracking
-        this.cpuTimingMinSize = cpuTimingMinSize;
-        this.cpuGraphs = new Map(); // Map<statName, { graph, lastNonZeroFrame }>
-
-        // VRAM subcategory tracking
-        this.vramTimingMinSize = vramTimingMinSize;
-        this.vramGraphs = new Map(); // Map<statName, { graph, lastNonZeroFrame }>
-
-        this.frameIndex = 0;
-        this.textRefreshRate = options.textRefreshRate;
-
-        // initial resize
-        this.activeSizeIndex = this._activeSizeIndex;
+        app.on('destroy', this.destroy, this);
+        this.activeSizeIndex = options.startSizeIndex;
     }
 
     /**
-     * Destroy the MiniStats instance.
+     * Destroy the MiniStats instance and release its event listeners, textures and mesh.
      *
      * @example
      * miniStats.destroy();
      */
     destroy() {
+        if (this._destroyed) return;
+        this._destroyed = true;
         this.device.off('resizecanvas', this.updateDiv, this);
         this.device.off('losecontext', this.loseContext, this);
+        this.app.off('frameupdate', this.update, this);
         this.app.off('postrender', this.postRender, this);
-
-        this.graphs.forEach(graph => graph.destroy());
+        this.app.off('destroy', this.destroy, this);
+        this.removeQueuedMesh();
+        for (let i = 0; i < this.graphs.length; i++) this.graphs[i].destroy();
         this.gpuPassGraphs.clear();
         this.cpuGraphs.clear();
         this.vramGraphs.clear();
+        this.graphRows.clear();
         this.wordAtlas.destroy();
         this.texture.destroy();
+        this.render2d.destroy();
         this.div.remove();
     }
 
     /**
-     * Predefined stat groups that can be included via {@link MiniStats.getDefaultOptions}. Each
-     * key maps to an array of {@link MiniStatsGraphOptions} entries that are inserted after the
-     * 'Frame' stat in the default options.
+     * Predefined stat groups included via {@link MiniStats.getDefaultOptions}.
      *
      * @type {Object<string, MiniStatsGraphOptions[]>}
      * @ignore
@@ -235,618 +240,456 @@ class MiniStats {
     };
 
     /**
-     * Returns the default options for MiniStats. The default options configure the overlay to
-     * show the following graphs:
+     * Returns options for three sizes: compact core counters, grouped averages, and grouped
+     * averages and peaks with graph history. Draw calls and frame time appear first, followed by
+     * ungrouped counters in their configured order, then CPU, GPU and VRAM.
      *
-     * - CPU utilization
-     * - GPU utilization
-     * - Overall frame time
-     * - Draw call count
-     * - Total VRAM usage
-     *
-     * @param {string[]} [extraStats] - Optional array of preset names from
-     * {@link MiniStats.statPresets} to include. The preset stats are inserted after the 'Frame'
-     * entry. Can be: 'gsplats', 'gsplatsCopy'.
-     * @returns {object} The default options for MiniStats.
+     * @param {string[]} [extraStats] - Presets to include: 'gsplats' or 'gsplatsCopy'.
+     * @returns {MiniStatsOptions} The default options for MiniStats.
      * @example
-     * // default options without extra stats
-     * const options = MiniStats.getDefaultOptions();
-     * @example
-     * // include gsplat stats
-     * const options = MiniStats.getDefaultOptions(['gsplats', 'gsplatsCopy']);
+     * const options = MiniStats.getDefaultOptions(['gsplats']);
+     * options.sizes[2].width = 280;
+     * const miniStats = new MiniStats(app, options);
      */
     static getDefaultOptions(extraStats = []) {
         const options = {
-
-            // sizes of area to render individual graphs in and spacing between individual graphs
             sizes: [
-                { width: 100, height: 16, spacing: 0, graphs: false },
-                { width: 128, height: 32, spacing: 2, graphs: true },
-                { width: 256, height: 64, spacing: 2, graphs: true }
+                { width: 128, height: 24, spacing: 0, graphs: false, detailed: false, peak: false },
+                { width: 176, height: 20, spacing: 0, graphs: false, detailed: true, peak: false },
+                { width: 224, height: 22, spacing: 0, graphs: true, detailed: true, peak: true }
             ],
-
-            // index into sizes array for initial setting
             startSizeIndex: 0,
-
-            // refresh rate of text stats in ms
             textRefreshRate: 500,
-
-            // cpu graph options
-            cpu: {
-                enabled: true,
-                watermark: 33
-            },
-
-            // gpu graph options
-            gpu: {
-                enabled: true,
-                watermark: 33
-            },
-
-            // array of options to render additional graphs based on stats collected into Application.stats
+            cpu: { enabled: true, watermark: 33 },
+            gpu: { enabled: true, watermark: 33 },
             stats: [
-                {
-                    // display name
-                    name: 'Frame',
-
-                    // path to data inside Application.stats
-                    stats: ['frame.ms'],
-
-                    // number of decimal places (defaults to none)
-                    decimalPlaces: 1,
-
-                    // units (defaults to "")
-                    unitsName: 'ms',
-
-                    // watermark - shown as a line on the graph, useful for displaying a budget
-                    watermark: 33
-                },
-
-                // total number of draw calls
-                {
-                    name: 'DrawCalls',
-                    stats: ['drawCalls.total'],
-                    watermark: 1000
-                },
-
-                // used VRAM in MB
-                {
-                    name: 'VRAM',
-                    stats: ['vram.totalUsed'],
-                    decimalPlaces: 1,
-                    multiplier: 1 / (1024 * 1024),
-                    unitsName: 'MB',
-                    watermark: 1024
-                }
+                { name: 'DrawCalls', stats: ['drawCalls.total'], watermark: 1000 },
+                { name: 'Frame', stats: ['frame.ms'], decimalPlaces: 1, unitsName: 'ms', watermark: 33 },
+                { name: 'VRAM', stats: ['vram.totalUsed'], decimalPlaces: 1, multiplier: 1 / (1024 * 1024), unitsName: 'MB', watermark: 1024 }
             ],
-
-            // minimum size index to show GPU pass timing graphs
             gpuTimingMinSize: 1,
-
-            // minimum size index to show CPU sub-timing graphs
             cpuTimingMinSize: 1,
-
-            // minimum size index to show VRAM subcategory graphs
             vramTimingMinSize: 1
         };
-
-        if (extraStats.length > 0) {
-            const frameIndex = options.stats.findIndex(s => s.name === 'Frame');
-            const insertIndex = frameIndex !== -1 ? frameIndex + 1 : options.stats.length;
-            // reverse so user-specified order matches visual top-to-bottom order
-            const extra = extraStats.flatMap(name => MiniStats.statPresets[name] ?? []).reverse();
-            options.stats.splice(insertIndex, 0, ...extra);
-        }
-
+        for (const name of extraStats) options.stats.push(...(MiniStats.statPresets[name] ?? []));
         return options;
     }
 
     /**
-     * Sets the active size index. Setting the active size index will resize the overlay to the
-     * size specified by the corresponding entry in the sizes array.
+     * Selects the corresponding entry in the sizes array.
      *
      * @type {number}
      * @ignore
      */
     set activeSizeIndex(value) {
+        const size = this.sizes[value];
+        if (!size) return;
         this._activeSizeIndex = value;
-        this.gspacing = this.sizes[value].spacing;
-
-        this.resize(this.sizes[value].width, this.sizes[value].height, this.sizes[value].graphs);
-
-        // update opacity based on size (larger sizes have higher default opacity)
-        this.opacity = value > 0 ? 0.85 : 0.7;
-
-        // delete sub-stat graphs when switching below their thresholds
-        if (value < this.gpuTimingMinSize && this.gpuPassGraphs) {
-            this.clearSubGraphs(this.gpuPassGraphs, 'GPU', 0.33);
-        }
-        if (value < this.cpuTimingMinSize && this.cpuGraphs) {
-            this.clearSubGraphs(this.cpuGraphs, 'CPU', 0.66);
-        }
-        if (value < this.vramTimingMinSize && this.vramGraphs) {
-            this.clearSubGraphs(this.vramGraphs);
-        }
+        this._detailed = size.detailed ?? (value > 0 || size.graphs);
+        this._showPeak = this._detailed && (size.peak ?? size.graphs);
+        this.gspacing = size.spacing;
+        this._scroll = 0;
+        if (!this._detailed || value < this.gpuTimingMinSize) this.clearSubGraphs(this.gpuPassGraphs);
+        if (!this._detailed || value < this.cpuTimingMinSize) this.clearSubGraphs(this.cpuGraphs);
+        if (!this._detailed || value < this.vramTimingMinSize) this.clearSubGraphs(this.vramGraphs);
+        this.resize(size.width, size.height, size.graphs);
+        this.div.setAttribute('aria-label', !this._detailed ? 'MiniStats: compact counters. Change size.' :
+            size.graphs ? 'MiniStats: averages, peaks and history. Change size.' : 'MiniStats: grouped averages. Change size.');
     }
 
-    /**
-     * Gets the active size index.
-     *
-     * @type {number}
-     * @ignore
-     */
+    /** @type {number} @ignore */
     get activeSizeIndex() {
         return this._activeSizeIndex;
     }
 
-    /**
-     * Sets the opacity of the MiniStats overlay.
-     *
-     * @type {number}
-     * @ignore
-     */
+    /** @type {number} @ignore */
     set opacity(value) {
         this.clr[3] = value;
     }
 
-    /**
-     * Gets the opacity of the MiniStats overlay.
-     *
-     * @type {number}
-     * @ignore
-     */
+    /** @type {number} @ignore */
     get opacity() {
         return this.clr[3];
     }
 
-    /**
-     * Gets the overall height of the MiniStats overlay.
-     *
-     * @type {number}
-     * @ignore
-     */
+    /** @type {number} @ignore */
     get overallHeight() {
-        const graphs = this.graphs;
-        const spacing = this.gspacing;
-        return this.height * graphs.length + spacing * (graphs.length - 1);
+        return this._overallHeight;
     }
 
     /**
-     * Sets the enabled state of the MiniStats overlay.
+     * Whether the overlay and its counter sampling are enabled. Defaults to true.
      *
      * @type {boolean}
      */
     set enabled(value) {
         if (value !== this._enabled) {
             this._enabled = value;
-            for (let i = 0; i < this.graphs.length; ++i) {
-                this.graphs[i].enabled = value;
+            for (let i = 0; i < this.graphs.length; i++) {
+                this.graphs[i].enabled = value && this._showGraphs;
                 this.graphs[i].timer.enabled = value;
+            }
+            this.div.style.display = value ? 'block' : 'none';
+            if (!value) this.removeQueuedMesh();
+        }
+    }
+
+    /** @type {boolean} */
+    get enabled() {
+        return this._enabled;
+    }
+
+    /** @private */
+    removeQueuedMesh() {
+        // postrender submits the overlay for the next frame. Remove that pending reference
+        // before freeing the mesh, including when its UI layer was not rendered this frame.
+        const queued = this.app.scene.immediate?.layerMeshInstances.get(this.drawLayer);
+        if (queued) {
+            for (let i = queued.length - 1; i >= 0; i--) {
+                if (queued[i] === this.render2d.meshInstance) queued.splice(i, 1);
             }
         }
     }
 
     /**
-     * Gets the enabled state of the MiniStats overlay.
-     *
-     * @type {boolean}
-     */
-    get enabled() {
-        return this._enabled;
-    }
-
-
-    /**
-     * Create the graphs requested by the user and add them to the MiniStats instance.
-     *
+     * @private
      * @param {AppBase} app - The application.
      * @param {GraphicsDevice} device - The graphics device.
-     * @param {object} options - Options for the MiniStats instance.
-     * @private
+     * @param {MiniStatsOptions} options - Counter configuration.
      */
     initGraphs(app, device, options) {
         this.graphs = [];
-
-        // Add VRAM first so it appears at the bottom in the compact stacked view.
-        // Graphs are rendered bottom-to-top.
-        if (options.stats) {
-            options.stats.forEach((entry) => {
-                if (entry.name === 'VRAM') {
-                    const timer = new StatsTimer(app, entry.stats, entry.decimalPlaces, entry.unitsName, entry.multiplier);
-                    const graph = new Graph(entry.name, app, entry.watermark, options.textRefreshRate, timer);
-                    this.graphs.push(graph);
-                }
-            });
-        }
-
         if (options.cpu.enabled) {
-            const timer = new CpuTimer(app);
-            const graph = new Graph('CPU', app, options.cpu.watermark, options.textRefreshRate, timer);
-            graph.graphType = 0.66;
-            this.graphs.push(graph);
+            this.cpuGraph = new Graph('CPU', app, options.cpu.watermark, options.textRefreshRate, new CpuTimer(app));
+            this.cpuGraph.group = 1;
+            this.graphs.push(this.cpuGraph);
         }
-
         if (options.gpu.enabled) {
-            const timer = new GpuTimer(device);
-            const graph = new Graph('GPU', app, options.gpu.watermark, options.textRefreshRate, timer);
-            graph.graphType = 0.33;
+            this.gpuGraph = new Graph('GPU', app, options.gpu.watermark, options.textRefreshRate, new GpuTimer(device));
+            this.gpuGraph.group = 2;
+            this.graphs.push(this.gpuGraph);
+        }
+        for (const entry of options.stats ?? []) {
+            const timer = new StatsTimer(app, entry.stats, entry.decimalPlaces, entry.unitsName, entry.multiplier);
+            const graph = new Graph(entry.name, app, entry.watermark, options.textRefreshRate, timer);
+            if (entry.name === 'VRAM') {
+                graph.group = 3;
+                this.vramGraph = graph;
+            }
             this.graphs.push(graph);
         }
-
-        if (options.stats) {
-            options.stats.forEach((entry) => {
-                if (entry.name === 'VRAM') {
-                    return;
-                }
-                const timer = new StatsTimer(app, entry.stats, entry.decimalPlaces, entry.unitsName, entry.multiplier);
-                const graph = new Graph(entry.name, app, entry.watermark, options.textRefreshRate, timer);
-                this.graphs.push(graph);
-            });
-        }
-
+        this.graphs.sort(compareGraphs);
         this.texture = new Texture(device, {
             name: 'mini-stats-graph-texture',
             width: 1,
             height: 1,
             mipmaps: false,
-            minFilter: FILTER_NEAREST,
-            magFilter: FILTER_NEAREST,
+            minFilter: FILTER_LINEAR,
+            magFilter: FILTER_LINEAR,
             addressU: ADDRESS_REPEAT,
             addressV: ADDRESS_REPEAT
         });
-
-        this.graphs.forEach((graph) => {
+        for (const graph of this.graphs) {
             graph.texture = this.texture;
             this.allocateRow(graph);
-        });
-    }
-
-    /**
-     * Render the MiniStats overlay. This is called automatically when the `postrender` event is
-     * fired by the application.
-     *
-     * @private
-     */
-    render() {
-        const graphs = this.graphs;
-        const wordAtlas = this.wordAtlas;
-        const render2d = this.render2d;
-        const width = this.width;
-        const height = this.height;
-        const gspacing = this.gspacing;
-
-        render2d.startFrame();
-
-        for (let i = 0; i < graphs.length; ++i) {
-            const graph = graphs[i];
-
-            let y = i * (height + gspacing);
-
-            // render the graph
-            graph.render(render2d, 0, y, width, height);
-
-            // render the text
-            let x = 1;
-            y += height - 13;
-
-            // name + space
-            x += wordAtlas.render(render2d, graph.name, x, y) + 10;
-
-            // timing (average value)
-            const timingText = graph.timingText;
-            for (let j = 0; j < timingText.length; ++j) {
-                x += wordAtlas.render(render2d, timingText[j], x, y);
-            }
-
-            // max value (only on larger sizes)
-            if (graph.maxText && this._activeSizeIndex > 0) {
-                x += 5;
-                x += wordAtlas.render(render2d, 'max', x, y);
-                x += 5;
-
-                const maxText = graph.maxText;
-                for (let j = 0; j < maxText.length; ++j) {
-                    x += wordAtlas.render(render2d, maxText[j], x, y);
-                }
-            }
-
-            // units (at the end, after both average and max)
-            if (graph.timer.unitsName) {
-                x += wordAtlas.render(render2d, graph.timer.unitsName, x, y);
-            }
         }
-
-        render2d.render(this.app, this.drawLayer, this.texture, this.wordAtlas.texture, this.clr, height);
     }
 
     /**
-     * Resize the MiniStats overlay.
-     *
-     * @param {number} width - The new width.
-     * @param {number} height - The new height.
-     * @param {boolean} showGraphs - Whether to show the graphs.
      * @private
+     * @param {number} width - Panel width in CSS pixels.
+     * @param {number} height - Row height in CSS pixels.
+     * @param {boolean} showGraphs - Whether to collect and display history.
      */
     resize(width, height, showGraphs) {
-        const graphs = this.graphs;
-        for (let i = 0; i < graphs.length; ++i) {
-            graphs[i].enabled = showGraphs;
-        }
-
         this.width = width;
         this.height = height;
-
+        this._showGraphs = showGraphs;
+        for (let i = 0; i < this.graphs.length; i++) this.graphs[i].enabled = this._enabled && showGraphs;
         this.updateDiv();
     }
 
-    /**
-     * Update the size and position of the MiniStats overlay. This is called automatically when the
-     * `resizecanvas` event is fired by the graphics device.
-     *
-     * @private
-     */
+    /** @private */
     updateDiv() {
         const rect = this.device.canvas.getBoundingClientRect();
-        this.div.style.left = `${rect.left}px`;
-        this.div.style.bottom = `${window.innerHeight - rect.bottom}px`;
-        this.div.style.width = `${this.width}px`;
-        this.div.style.height = `${this.overallHeight}px`;
+        this.render2d.targetWidth = rect.width;
+        this.render2d.targetHeight = rect.height;
+        let total = this._detailed ? 31 : 8;
+        let previousGroup = -1;
+        for (let i = 0; i < this.graphs.length; i++) {
+            const group = this.graphs[i].group;
+            if (this._detailed && i > 0 && group !== previousGroup) total += 5;
+            total += this.height + (i ? this.gspacing : 0);
+            previousGroup = group;
+        }
+        this._overallHeight = total;
+        this._fixedRows = 0;
+        while (this._fixedRows < this.graphs.length && (this.graphs[this._fixedRows].label === 'Draw calls' || this.graphs[this._fixedRows].name === 'Frame')) {
+            this._fixedRows++;
+        }
+        this._panelWidth = Math.max(0, Math.min(this.width, rect.width - 16));
+        this._panelHeight = Math.max(0, Math.min(total, rect.height - 16));
+        this._maxScroll = Math.max(0, total - this._panelHeight);
+        this._scroll = Math.min(this._scroll, this._maxScroll);
+        this.div.style.left = `${rect.left + 8}px`;
+        this.div.style.bottom = `${window.innerHeight - rect.bottom + 8}px`;
+        this.div.style.width = `${this._panelWidth}px`;
+        this.div.style.height = `${this._panelHeight}px`;
+        this._layoutDirty = false;
+        this._geometryDirty = true;
     }
 
     /**
-     * Called when the graphics device is lost.
-     *
      * @private
+     * @param {number} delta - Scroll distance in CSS pixels.
      */
+    scroll(delta) {
+        const value = math.clamp(this._scroll + delta, 0, this._maxScroll);
+        if (value !== this._scroll) {
+            this._scroll = value;
+            this._geometryDirty = true;
+        }
+    }
+
+    /**
+     * @private
+     * @param {number} ms - Elapsed frame time in milliseconds.
+     */
+    update(ms) {
+        if (!this._enabled) return;
+        const data = this._showGraphs ? this.texture.lock() : null;
+        for (let i = 0; i < this.graphs.length; i++) {
+            const changed = this.graphs[i].update(ms, data);
+            if (changed & (this._showPeak ? 3 : 1)) this._geometryDirty = true;
+        }
+        if (data) this.texture.unlock();
+    }
+
+    /** @private */
+    render() {
+        if (this._layoutDirty) this.updateDiv();
+        if (this._geometryDirty) {
+            this.rebuildGeometry();
+            this._geometryDirty = false;
+        } else if (this._showGraphs) {
+            for (let i = 0; i < this.graphs.length; i++) this.render2d.graphCursor(this.graphs[i]);
+        }
+        this.render2d.render(this.app, this.drawLayer, this.texture, this.wordAtlas.texture, this.clr);
+    }
+
+    /** @private */
+    rebuildGeometry() {
+        const renderer = this.render2d;
+        const atlas = this.wordAtlas;
+        const x = 8;
+        const bottom = 8;
+        const width = this._panelWidth;
+        const top = bottom + this._panelHeight;
+        const right = x + width - 10;
+        const avgRight = right - (this._showPeak ? 44 : 0);
+        renderer.startFrame();
+        renderer.setClip(x, bottom, width, this._panelHeight);
+        renderer.rect(x, bottom, width, this._panelHeight, BACKGROUND);
+        let rowTop = top - 4;
+        if (this._detailed) {
+            const baseline = top - 16;
+            atlas.render(renderer, 'Metric', x + 10, baseline, 0, MUTED);
+            atlas.render(renderer, this._averageLabel, avgRight - atlas.measure(this._averageLabel), baseline, 0, MUTED);
+            if (this._showPeak) atlas.render(renderer, 'Peak', right - atlas.measure('Peak'), baseline, 0, MUTED);
+            renderer.rect(x, top - 23, width, 1, BORDER);
+            rowTop = top - 27;
+            renderer.setClip(x, bottom, width, this._panelHeight - 23);
+        }
+        let previousGroup = -1;
+        for (let i = 0; i < this.graphs.length; i++) {
+            // Keep draw calls and frame time visible even when a long pass list is scrolled.
+            if (i === this._fixedRows) {
+                renderer.setClip(x, bottom, width, Math.max(0, rowTop - bottom));
+                rowTop += this._scroll;
+            }
+            const graph = this.graphs[i];
+            graph.quad = -1;
+            if (this._detailed && i > 0 && graph.group !== previousGroup) rowTop -= 5;
+            const y = rowTop - this.height;
+            if (y < top && rowTop > bottom) {
+                const heading = this._detailed && graph.group > 0 && !graph.parent;
+                const color = graphColors[graph.group];
+                if (heading) {
+                    renderer.rect(x, y, width, this.height, GROUP_BACKGROUND);
+                    renderer.rect(x, y + 5, 2, this.height - 10, color);
+                }
+                if (this._showGraphs) renderer.graph(graph, x, y, width, this.height, color);
+                const baseline = Math.round(y + (this.height - 14) / 2 + 3);
+                const units = graph.timer.unitsName || '';
+                const valueWidth = atlas.measure(graph.timingText, 1);
+                let valueRight = avgRight;
+                if (!this._detailed && units) {
+                    const unitsWidth = atlas.measure(units);
+                    atlas.render(renderer, units, right - unitsWidth, baseline, 0, MUTED);
+                    valueRight -= unitsWidth + 4;
+                }
+                const valueX = Math.max(x + 10, valueRight - valueWidth);
+                atlas.render(renderer, graph.timingText, valueX, baseline, 1, TEXT, valueRight - valueX);
+                if (this._showPeak) {
+                    const peakWidth = atlas.measure(graph.maxText);
+                    atlas.render(renderer, graph.maxText, right - Math.min(peakWidth, 40), baseline, 0, MUTED, 40);
+                }
+                const labelX = x + 10 + (this._detailed && graph.parent ? 5 : 0);
+                const labelStyle = heading ? 1 : 0;
+                const labelWidth = atlas.render(renderer, graph.label, labelX, baseline, labelStyle, heading ? TEXT : MUTED,
+                    valueX - labelX - 8 - (this._detailed && units && !graph.parent ? atlas.measure(units) + 4 : 0));
+                if (this._detailed && units && !graph.parent) {
+                    atlas.render(renderer, units, labelX + labelWidth + 4, baseline, 0, MUTED, valueX - labelX - labelWidth - 8);
+                }
+            }
+            rowTop = y - this.gspacing;
+            previousGroup = graph.group;
+        }
+    }
+
+    /** @private */
     loseContext() {
-        this.graphs.forEach(graph => graph.loseContext());
+        for (let i = 0; i < this.graphs.length; i++) this.graphs[i].loseContext();
+        this.render2d.dirty = true;
     }
 
     /**
-     * Update sub-stat graphs (GPU passes or CPU timings).
-     * @param {Map} subGraphs - Map to store graph data (gpuPassGraphs or cpuGraphs)
-     * @param {string} mainGraphName - Name of main graph ('GPU' or 'CPU')
-     * @param {Map<string,number>|Object} stats - Stats data (Map for GPU, object for CPU)
-     * @param {string} statPathPrefix - Prefix for stat path ('gpu' for GPU, 'frame' for CPU)
-     * @param {number} removeAfterFrames - Frames of zero before removal
      * @private
-     */
-    updateSubStats(subGraphs, mainGraphName, stats, statPathPrefix, removeAfterFrames) {
-        const passesToRemove = [];
-
-        // check existing sub-stats for removal
-        for (const [statName, statData] of subGraphs) {
-            const timing = (stats instanceof Map) ? (stats.get(statName) || 0) : (stats[statName] || 0);
-
-            if (timing > 0) {
-                // update last non-zero frame
-                statData.lastNonZeroFrame = this.frameIndex;
-            } else if (removeAfterFrames > 0) {
-                // Only GPU passes auto-hide; CPU stats are never removed
-                const shouldAutoHide = statPathPrefix === 'gpu';
-                if (shouldAutoHide && this.frameIndex - statData.lastNonZeroFrame > removeAfterFrames) {
-                    passesToRemove.push(statName);
-                }
-            }
-        }
-
-        // remove stats that have been zero for too long
-        for (const statName of passesToRemove) {
-            const statData = subGraphs.get(statName);
-            if (statData) {
-                // remove from graphs array
-                const index = this.graphs.indexOf(statData.graph);
-                if (index !== -1) {
-                    this.graphs.splice(index, 1);
-                }
-                this.freeRow(statData.graph);
-                statData.graph.destroy();
-                subGraphs.delete(statName);
-            }
-        }
-
-        // scan for new sub-stats
-        const statsEntries = (stats instanceof Map) ? stats : Object.entries(stats);
-        const mainGraph = this.graphs.find(g => g.name === mainGraphName);
-        for (const [statName, timing] of statsEntries) {
-            if (!subGraphs.has(statName)) {
-                // Skip creating graph for auto-hide stats with zero timing
-                // Skip creating graph for GPU passes or delayed-start CPU stats with zero timing
-                const isDelayedStart = statPathPrefix === 'gpu' || delayedStartStats.has(statName);
-                if (isDelayedStart && timing === 0) {
-                    continue;
-                }
-
-                // create new graph for this stat
-                // shorten display name for CPU stats
-                let displayName = statName;
-                if (statPathPrefix === 'frame') {
-                    displayName = cpuStatDisplayNames[statName] || statName;
-                }
-                const graphName = `  ${displayName}`;  // indent with 2 spaces
-
-                // use main graph watermark when available
-                const watermark = mainGraph?.watermark ?? 10.0;
-
-                const decimalPlaces = 1;
-                const unitsName = statPathPrefix === 'vram' ? 'MB' : 'ms';
-                const multiplier = statPathPrefix === 'vram' ? 1 / (1024 * 1024) : 1;
-
-                const statPath = `${statPathPrefix}.${statName}`;
-                const timer = new StatsTimer(this.app, [statPath], decimalPlaces, unitsName, multiplier);
-                const graph = new Graph(graphName, this.app, watermark, this.textRefreshRate, timer);
-
-                // Set graph type for background tinting
-                if (statPathPrefix === 'gpu') {
-                    graph.graphType = 0.33;  // GPU sub-graphs
-                } else if (statPathPrefix === 'frame') {
-                    graph.graphType = 0.66;  // CPU sub-graphs
-                }
-
-                graph.texture = this.texture;
-                this.allocateRow(graph);
-
-                // match the current display mode
-                const currentSize = this.sizes[this._activeSizeIndex];
-                graph.enabled = currentSize.graphs;
-
-                // find the main graph index and insert before it (graphs render bottom to top)
-                let mainGraphIndex = this.graphs.findIndex(g => g.name === mainGraphName);
-                if (mainGraphIndex === -1) {
-                    mainGraphIndex = 0;  // fallback to start if main graph not found
-                }
-
-                // find where to insert - right before the main graph, after any existing sub-stats
-                let insertIndex = mainGraphIndex;
-                for (let i = mainGraphIndex - 1; i >= 0; i--) {
-                    // check if this is an indented sub-stat (starts with spaces)
-                    if (this.graphs[i].name.startsWith(' ')) {
-                        insertIndex = i;
-                    } else {
-                        break;
-                    }
-                }
-
-                // insert the new graph at the correct position
-                this.graphs.splice(insertIndex, 0, graph);
-
-                subGraphs.set(statName, {
-                    graph: graph,
-                    lastNonZeroFrame: timing > 0 ? this.frameIndex : this.frameIndex - removeAfterFrames - 1
-                });
-            }
-        }
-
-        // sync all sub-stat watermarks to match main graph
-        if (mainGraph) {
-            for (const statData of subGraphs.values()) {
-                statData.graph.watermark = mainGraph.watermark;
-            }
-        }
-    }
-
-    /**
-     * Allocates a texture row for a graph. Reuses free rows when available.
-     *
-     * @param {Graph} graph - The graph to allocate a row for.
-     * @returns {number} The allocated row index.
-     * @private
+     * @param {Graph} graph - The graph receiving a persistent history row.
+     * @returns {number} Allocated row index.
      */
     allocateRow(graph) {
-        let row;
-        if (this.freeRows.length > 0) {
-            row = this.freeRows.pop();
-        } else {
-            row = this.nextRowIndex++;
-            this.ensureTextureHeight(this.nextRowIndex);
-        }
+        const row = this.freeRows.length ? this.freeRows.pop() : this.nextRowIndex++;
+        this.ensureTextureHeight(this.nextRowIndex);
         this.graphRows.set(graph, row);
         graph.yOffset = row;
-        graph.needsClear = true;  // Will clear on first update()
+        graph.needsClear = true;
         return row;
     }
 
     /**
-     * Frees a texture row when a graph is destroyed.
-     *
-     * @param {Graph} graph - The graph whose row to free.
      * @private
-     */
-    freeRow(graph) {
-        const row = this.graphRows.get(graph);
-        if (row !== undefined) {
-            this.freeRows.push(row);
-            this.graphRows.delete(graph);
-        }
-    }
-
-    /**
-     * Remove all sub-stat graphs from a tracking map when collapsing below a size threshold.
-     *
-     * @param {Map} subGraphs - The sub-graph map to clear.
-     * @param {string} [mainGraphName] - If provided, reset the main graph's graphType.
-     * @param {number} [graphType] - The graphType value to restore on the main graph.
-     * @private
-     */
-    clearSubGraphs(subGraphs, mainGraphName, graphType) {
-        for (const statData of subGraphs.values()) {
-            const index = this.graphs.indexOf(statData.graph);
-            if (index !== -1) {
-                this.graphs.splice(index, 1);
-            }
-            this.freeRow(statData.graph);
-            statData.graph.destroy();
-        }
-        subGraphs.clear();
-
-        if (mainGraphName) {
-            const mainGraph = this.graphs.find(g => g.name === mainGraphName);
-            if (mainGraph) mainGraph.graphType = graphType;
-        }
-    }
-
-    /**
-     * Ensures the texture has enough rows. Only grows, never shrinks.
-     *
-     * @param {number} requiredRows - The minimum number of rows needed.
-     * @private
+     * @param {number} requiredRows - Minimum number of texture rows.
      */
     ensureTextureHeight(requiredRows) {
-        const maxWidth = this.sizes[this.sizes.length - 1].width;
-        const requiredWidth = math.nextPowerOfTwo(maxWidth);
-        const requiredHeight = math.nextPowerOfTwo(requiredRows);
-
-        // Only grow, never shrink
-        if (requiredHeight > this.texture.height) {
-            this.texture.resize(requiredWidth, requiredHeight);
+        let maxWidth = 1;
+        for (let i = 0; i < this.sizes.length; i++) maxWidth = Math.max(maxWidth, this.sizes[i].width);
+        const width = math.nextPowerOfTwo(maxWidth);
+        const height = math.nextPowerOfTwo(Math.max(1, requiredRows));
+        if (width > this.texture.width || height > this.texture.height) {
+            const oldWidth = this.texture.width;
+            const oldHeight = this.texture.height;
+            const oldData = this.texture.lock();
+            this.texture.unlock();
+            this.texture.resize(Math.max(width, oldWidth), Math.max(height, oldHeight));
+            const data = this.texture.lock();
+            for (let row = 0; row < oldHeight; row++) {
+                data.set(oldData.subarray(row * oldWidth * 4, (row + 1) * oldWidth * 4), row * this.texture.width * 4);
+            }
+            this.texture.unlock();
+            this._geometryDirty = true;
         }
     }
 
     /**
-     * Called when the `postrender` event is fired by the application.
-     *
      * @private
+     * @param {Graph} graph - The sub-counter to remove.
      */
+    removeGraph(graph) {
+        const index = this.graphs.indexOf(graph);
+        if (index !== -1) this.graphs.splice(index, 1);
+        this.freeRows.push(this.graphRows.get(graph));
+        this.graphRows.delete(graph);
+        graph.destroy();
+        this._layoutDirty = true;
+    }
+
+    /**
+     * @private
+     * @param {Map<string, Graph>} map - Sub-counters to remove.
+     */
+    clearSubGraphs(map) {
+        map.forEach(this.removeGraph, this);
+        map.clear();
+    }
+
+    /**
+     * @private
+     * @param {Map<string, Graph>} map - Sub-counter lookup.
+     * @param {Graph} parent - The category total.
+     * @param {string} name - The literal stat key.
+     * @param {number} value - Current sampled value.
+     * @param {string} prefix - The stats object containing the key.
+     * @param {boolean} delayed - Wait for a positive sample before adding the row.
+     */
+    updateSubStat(map, parent, name, value, prefix, delayed) {
+        if (!parent) return;
+        let graph = map.get(name);
+        if (!graph) {
+            if (delayed && !(value > 0)) return;
+            const units = prefix === 'vram' ? 'MB' : 'ms';
+            const timer = new StatsTimer(this.app, [name], 1, units, prefix === 'vram' ? 1 / (1024 * 1024) : 1);
+            // GPU pass names are literal Map keys and may themselves contain dots.
+            timer.paths[0] = [prefix, name];
+            graph = new Graph(name, this.app, parent.watermark, this.textRefreshRate, timer);
+            graph.label = prefix === 'frame' ? cpuStatDisplayNames[name] : prefix === 'vram' ? vramStatDisplayNames[name] : name;
+            graph.parent = parent;
+            graph.group = parent.group;
+            graph.statName = name;
+            graph.texture = this.texture;
+            graph.enabled = this._showGraphs;
+            this.allocateRow(graph);
+            let index = this.graphs.indexOf(parent) + 1;
+            while (index < this.graphs.length && this.graphs[index].parent === parent) index++;
+            this.graphs.splice(index, 0, graph);
+            map.set(name, graph);
+            this._layoutDirty = true;
+        }
+        graph.watermark = parent.watermark;
+        if (value > 0) graph.lastNonZeroFrame = this.frameIndex;
+    }
+
+    /**
+     * @private
+     * @param {number} value - Pass duration in milliseconds.
+     * @param {string} name - Literal GPU pass name.
+     */
+    updateGpuPass(value, name) {
+        this.updateSubStat(this.gpuPassGraphs, this.gpuGraph, name, value, 'gpu', true);
+    }
+
+    /** @private */
     postRender() {
-        if (this._enabled) {
-            this.render();
-
-            // Update GPU pass graphs when size index meets threshold
-            if (this._activeSizeIndex >= this.gpuTimingMinSize) {
-                const gpuStats = this.app.stats.gpu;
-                if (gpuStats) {
-                    this.updateSubStats(this.gpuPassGraphs, 'GPU', gpuStats, 'gpu', 240);
+        if (!this._enabled) return;
+        this.frameIndex++;
+        if (this._detailed) {
+            if (this.gpuGraph && this.activeSizeIndex >= this.gpuTimingMinSize) {
+                this.app.stats.gpu?.forEach(this.updateGpuPass, this);
+                for (let i = this.graphs.length - 1; i >= 0; i--) {
+                    const graph = this.graphs[i];
+                    if (graph.parent === this.gpuGraph && this.frameIndex - graph.lastNonZeroFrame > 240) {
+                        this.gpuPassGraphs.delete(graph.statName);
+                        this.removeGraph(graph);
+                    }
                 }
             }
-
-            // Update CPU sub-timing graphs when size index meets threshold
-            if (this._activeSizeIndex >= this.cpuTimingMinSize) {
-                const cpuStats = {
-                    scriptUpdate: this.app.stats.frame.scriptUpdate,
-                    scriptPostUpdate: this.app.stats.frame.scriptPostUpdate,
-                    animUpdate: this.app.stats.frame.animUpdate,
-                    physicsTime: this.app.stats.frame.physicsTime,
-                    renderTime: this.app.stats.frame.renderTime,
-                    gsplatSort: this.app.stats.frame.gsplatSort
-                };
-                this.updateSubStats(this.cpuGraphs, 'CPU', cpuStats, 'frame', 240);
+            if (this.cpuGraph && this.activeSizeIndex >= this.cpuTimingMinSize) {
+                const frame = this.app.stats.frame;
+                for (let i = 0; i < cpuStatNames.length; i++) {
+                    const name = cpuStatNames[i];
+                    this.updateSubStat(this.cpuGraphs, this.cpuGraph, name, frame[name], 'frame', i >= 3);
+                }
             }
-
-            // Update VRAM subcategory graphs when size index meets threshold
-            if (this._activeSizeIndex >= this.vramTimingMinSize) {
+            if (this.vramGraph && this.activeSizeIndex >= this.vramTimingMinSize) {
                 const vram = this.app.stats.vram;
-                const vramStats = {
-                    tex: vram.tex,
-                    geom: vram.geom
-                };
-                if (this.device.isWebGPU) {
-                    vramStats.buffers = vram.buffers;
+                const count = this.device.isWebGPU ? 3 : 2;
+                for (let i = 0; i < count; i++) {
+                    const name = vramStatNames[i];
+                    this.updateSubStat(this.vramGraphs, this.vramGraph, name, vram[name], 'vram', false);
                 }
-                this.updateSubStats(this.vramGraphs, 'VRAM', vramStats, 'vram', 0);
             }
         }
-
-        this.frameIndex++;
+        this.render();
     }
 }
 

--- a/src/extras/mini-stats/mini-stats.js
+++ b/src/extras/mini-stats/mini-stats.js
@@ -254,7 +254,7 @@ class MiniStats {
     static getDefaultOptions(extraStats = []) {
         const options = {
             sizes: [
-                { width: 128, height: 24, spacing: 0, graphs: false, detailed: false, peak: false },
+                { width: 128, height: 22, spacing: 0, graphs: false, detailed: false, peak: false },
                 { width: 176, height: 20, spacing: 0, graphs: false, detailed: true, peak: false },
                 { width: 224, height: 22, spacing: 0, graphs: true, detailed: true, peak: true }
             ],

--- a/src/extras/mini-stats/render2d.js
+++ b/src/extras/mini-stats/render2d.js
@@ -1,13 +1,7 @@
 import {
     BLENDEQUATION_ADD, BLENDMODE_SRC_ALPHA, BLENDMODE_ONE_MINUS_SRC_ALPHA, BLENDMODE_ONE,
-    BUFFER_STATIC,
-    BUFFER_STREAM,
-    CULLFACE_NONE,
-    INDEXFORMAT_UINT16,
-    PRIMITIVE_TRIANGLES,
-    SEMANTIC_POSITION,
-    SEMANTIC_TEXCOORD0,
-    TYPE_FLOAT32
+    BUFFER_STATIC, BUFFER_STREAM, CULLFACE_NONE, INDEXFORMAT_UINT16, PRIMITIVE_TRIANGLES,
+    SEMANTIC_POSITION, SEMANTIC_TEXCOORD0, SEMANTIC_COLOR, TYPE_FLOAT32, TYPE_UINT8
 } from '../../platform/graphics/constants.js';
 import { Debug } from '../../core/debug.js';
 import { DepthState } from '../../platform/graphics/depth-state.js';
@@ -20,181 +14,103 @@ import { VertexBuffer } from '../../platform/graphics/vertex-buffer.js';
 import { VertexFormat } from '../../platform/graphics/vertex-format.js';
 import { ShaderMaterial } from '../../scene/materials/shader-material.js';
 
-// Graph colors for MiniStats
-const graphColorDefault = '1.0, 0.412, 0.380';  // Pastel Red
-const graphColorGpu = '0.467, 0.867, 0.467';    // Pastel Green
-const graphColorCpu = '0.424, 0.627, 0.863';    // Little Boy Blue
-
-// Background colors for MiniStats graphs
-const mainBackgroundColor = '0.0, 0.0, 0.0';
-const gpuBackgroundColor = '0.15, 0.15, 0.0';
-const cpuBackgroundColor = '0.15, 0.0, 0.1';
-
 const vertexShaderGLSL = /* glsl */ `
-    attribute vec3 vertex_position;         // unnormalized xy, word flag
-    attribute vec4 vertex_texCoord0;        // unnormalized texture space uv, normalized uv
-
+    attribute vec3 vertex_position;
+    attribute vec4 vertex_texCoord0;
+    attribute vec4 vertex_color;
     varying vec4 uv0;
-    varying float wordFlag;
-
+    varying vec4 color;
+    varying float mode;
     void main(void) {
         gl_Position = vec4(vertex_position.xy * 2.0 - 1.0, 0.5, 1.0);
         uv0 = vertex_texCoord0;
-        wordFlag = vertex_position.z;
+        color = vertex_color;
+        mode = vertex_position.z;
     }
 `;
 
 const vertexShaderWGSL = /* wgsl */ `
-    attribute vertex_position: vec3f;         // unnormalized xy, word flag
-    attribute vertex_texCoord0: vec4f;        // unnormalized texture space uv, normalized uv
-
+    attribute vertex_position: vec3f;
+    attribute vertex_texCoord0: vec4f;
+    attribute vertex_color: vec4f;
     varying uv0: vec4f;
-    varying wordFlag: f32;
-
-    @vertex fn vertexMain(input : VertexInput) -> VertexOutput {
-        var output : VertexOutput;
-        output.position = vec4(input.vertex_position.xy * 2.0 - 1.0, 0.5, 1.0);
+    varying color: vec4f;
+    varying mode: f32;
+    @vertex fn vertexMain(input: VertexInput) -> VertexOutput {
+        var output: VertexOutput;
+        output.position = vec4f(input.vertex_position.xy * 2.0 - 1.0, 0.5, 1.0);
         output.uv0 = input.vertex_texCoord0;
-        output.wordFlag = input.vertex_position.z;
+        output.color = input.vertex_color;
+        output.mode = input.vertex_position.z;
         return output;
     }
 `;
 
-// this fragment shader renders the bits required for text and graphs. The text is identified
-// in the texture by white color. The graph data is specified as a single row of pixels
-// where the R channel denotes the graph height
+// Each branch is uniform within a quad: solid rectangles need no texture fetch, text and
+// graphs need one each. The graph outline and budget line use CSS-pixel heights, not derivatives.
 const fragmentShaderGLSL = /* glsl */ `
     varying vec4 uv0;
-    varying float wordFlag;
-
+    varying vec4 color;
+    varying float mode;
     uniform vec4 clr;
     uniform sampler2D graphTex;
     uniform sampler2D wordsTex;
-
-    void main (void) {
-        vec3 graphColor = vec3(${graphColorDefault});
-        if (wordFlag > 0.5) {
-            graphColor = vec3(${graphColorCpu});
-        } else if (wordFlag > 0.2) {
-            graphColor = vec3(${graphColorGpu});
+    void main(void) {
+        float alpha = 1.0;
+        if (mode > 1.5) {
+            vec4 sampleValue = texture2D(graphTex, uv0.xy);
+            float fill = step(uv0.w, sampleValue.r) * 0.18;
+            float edge = (1.0 - step(uv0.z, abs(uv0.w - sampleValue.r))) * 0.60;
+            float budget = (1.0 - step(uv0.z * 0.5, abs(uv0.w - sampleValue.a))) * 0.16;
+            alpha = max(fill, max(edge, budget)) * step(0.001, sampleValue.a);
+        } else if (mode > 0.5) {
+            alpha = texture2D(wordsTex, vec2(uv0.x, 1.0 - uv0.y)).a;
         }
-
-        vec4 graphSample = texture2D(graphTex, uv0.xy);
-
-        vec4 graph;
-        if (uv0.w < graphSample.r)
-            graph = vec4(graphColor, 1.0);
-        else {
-            vec3 bgColor = vec3(${mainBackgroundColor});
-            if (wordFlag > 0.5) {
-                bgColor = vec3(${cpuBackgroundColor});  // CPU: red tint
-            } else if (wordFlag > 0.2) {
-                bgColor = vec3(${gpuBackgroundColor});  // GPU: blue tint
-            }
-            graph = vec4(bgColor, 1.0);
-        }
-
-        vec4 words = texture2D(wordsTex, vec2(uv0.x, 1.0 - uv0.y));
-
-        // Binary blend: either graph or text, no partial mixing
-        if (wordFlag > 0.99) {
-            gl_FragColor = words * clr;
-        } else {
-            gl_FragColor = graph * clr;
-        }
+        gl_FragColor = vec4(color.rgb, color.a * alpha) * clr;
     }
 `;
 
 const fragmentShaderWGSL = /* wgsl */ `
     varying uv0: vec4f;
-    varying wordFlag: f32;
-
+    varying color: vec4f;
+    varying mode: f32;
     uniform clr: vec4f;
-
-    var graphTex : texture_2d<f32>;
-    var graphTex_sampler : sampler;
-
-    var wordsTex : texture_2d<f32>;
-    var wordsTex_sampler : sampler;
-
-    @fragment fn fragmentMain(input : FragmentInput) -> FragmentOutput {
-        var uv0: vec4f = input.uv0;
-        var graphColor: vec3f = vec3f(${graphColorDefault});
-        if (input.wordFlag > 0.5) {
-            graphColor = vec3f(${graphColorCpu});
-        } else if (input.wordFlag > 0.2) {
-            graphColor = vec3f(${graphColorGpu});
+    var graphTex: texture_2d<f32>;
+    var graphTex_sampler: sampler;
+    var wordsTex: texture_2d<f32>;
+    var wordsTex_sampler: sampler;
+    @fragment fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+        var alpha = 1.0;
+        if (input.mode > 1.5) {
+            let sampleValue = textureSampleLevel(graphTex, graphTex_sampler, input.uv0.xy, 0.0);
+            let fill = step(input.uv0.w, sampleValue.r) * 0.18;
+            let edge = (1.0 - step(input.uv0.z, abs(input.uv0.w - sampleValue.r))) * 0.60;
+            let budget = (1.0 - step(input.uv0.z * 0.5, abs(input.uv0.w - sampleValue.a))) * 0.16;
+            alpha = max(fill, max(edge, budget)) * step(0.001, sampleValue.a);
+        } else if (input.mode > 0.5) {
+            alpha = textureSampleLevel(wordsTex, wordsTex_sampler, vec2f(input.uv0.x, 1.0 - input.uv0.y), 0.0).a;
         }
-
-        var graphSample: vec4f = textureSample(graphTex, graphTex_sampler, uv0.xy);
-
-        var graph: vec4f;
-        if (uv0.w < graphSample.r) {
-            graph = vec4f(graphColor, 1.0);
-        } else {
-            var bgColor: vec3f = vec3f(${mainBackgroundColor});
-            if (input.wordFlag > 0.5) {
-                bgColor = vec3f(${cpuBackgroundColor});  // CPU: red tint
-            } else if (input.wordFlag > 0.2) {
-                bgColor = vec3f(${gpuBackgroundColor});  // GPU: blue tint
-            }
-            graph = vec4f(bgColor, 1.0);
-        }
-
-        var words: vec4f = textureSample(wordsTex, wordsTex_sampler, vec2f(uv0.x, 1.0 - uv0.y));
-
         var output: FragmentOutput;
-        // Binary blend: either graph or text, no partial mixing
-        if (input.wordFlag > 0.99) {
-            output.color = words * uniform.clr;
-        } else {
-            output.color = graph * uniform.clr;
-        }
+        output.color = vec4f(input.color.rgb, input.color.a * alpha) * uniform.clr;
         return output;
     }
 `;
 
-// render 2d textured quads
 class Render2d {
-    constructor(device, maxQuads = 2048) {
-        const format = new VertexFormat(device, [
-            { semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 },
-            { semantic: SEMANTIC_TEXCOORD0, components: 4, type: TYPE_FLOAT32 }
-        ]);
-
-        // generate quad indices
-        const indices = new Uint16Array(maxQuads * 6);
-        for (let i = 0; i < maxQuads; ++i) {
-            indices[i * 6 + 0] = i * 4;
-            indices[i * 6 + 1] = i * 4 + 1;
-            indices[i * 6 + 2] = i * 4 + 2;
-            indices[i * 6 + 3] = i * 4;
-            indices[i * 6 + 4] = i * 4 + 2;
-            indices[i * 6 + 5] = i * 4 + 3;
-        }
-
+    constructor(device, maxQuads = 128) {
         this.device = device;
-        this.maxQuads = maxQuads;
-        this.buffer = new VertexBuffer(device, format, maxQuads * 4, {
-            usage: BUFFER_STREAM
-        });
-        this.data = new Float32Array(this.buffer.numBytes / 4);
-        this.indexBuffer = new IndexBuffer(device, INDEXFORMAT_UINT16, maxQuads * 6, BUFFER_STATIC, indices);
-        this.prim = {
-            type: PRIMITIVE_TRIANGLES,
-            indexed: true,
-            base: 0,
-            baseVertex: 0,
-            count: 0
-        };
-        this.quads = 0;
-
+        this.format = new VertexFormat(device, [
+            { semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 },
+            { semantic: SEMANTIC_TEXCOORD0, components: 4, type: TYPE_FLOAT32 },
+            { semantic: SEMANTIC_COLOR, components: 4, type: TYPE_UINT8, normalize: true }
+        ]);
         this.mesh = new Mesh(device);
-        this.mesh.vertexBuffer = this.buffer;
-        this.mesh.indexBuffer[0] = this.indexBuffer;
+        this.prim = { type: PRIMITIVE_TRIANGLES, indexed: true, base: 0, baseVertex: 0, count: 0 };
         this.mesh.primitive = [this.prim];
-
-        const material = new ShaderMaterial({
+        this.quads = 0;
+        this.dirty = true;
+        this.resize(maxQuads);
+        this.material = new ShaderMaterial({
             uniqueName: 'MiniStats',
             vertexGLSL: vertexShaderGLSL,
             fragmentGLSL: fragmentShaderGLSL,
@@ -202,80 +118,142 @@ class Render2d {
             fragmentWGSL: fragmentShaderWGSL,
             attributes: {
                 vertex_position: SEMANTIC_POSITION,
-                vertex_texCoord0: SEMANTIC_TEXCOORD0
+                vertex_texCoord0: SEMANTIC_TEXCOORD0,
+                vertex_color: SEMANTIC_COLOR
             }
         });
-        this.material = material;
-        material.cull = CULLFACE_NONE;
-        material.depthState = DepthState.NODEPTH;
-        material.blendState = new BlendState(true, BLENDEQUATION_ADD, BLENDMODE_SRC_ALPHA, BLENDMODE_ONE_MINUS_SRC_ALPHA,
-            BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE);
-        material.update();
-
-        this.meshInstance = new MeshInstance(this.mesh, material, new GraphNode('MiniStatsMesh'));
-
-        this.uniforms = {
-            clr: new Float32Array(4)
-        };
-
-        this.targetSize = {
-            width: device.width,
-            height: device.height
-        };
+        this.material.cull = CULLFACE_NONE;
+        this.material.depthState = DepthState.NODEPTH;
+        this.material.blendState = new BlendState(true,
+            BLENDEQUATION_ADD, BLENDMODE_SRC_ALPHA, BLENDMODE_ONE_MINUS_SRC_ALPHA,
+            BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE_MINUS_SRC_ALPHA);
+        this.material.update();
+        this.meshInstance = new MeshInstance(this.mesh, this.material, new GraphNode('MiniStatsMesh'));
+        this.meshInstance.cull = false;
+        this.clr = new Float32Array(4);
+        this.material.setParameter('clr', this.clr);
+        this.targetWidth = 1;
+        this.targetHeight = 1;
+        this.setClip(0, 0, Infinity, Infinity);
     }
 
-    quad(x, y, w, h, u, v, uw, uh, texture, wordFlag = 0) {
-        // bounds check to prevent buffer overflow
-        if (this.quads >= this.maxQuads) {
-            Debug.warnOnce('MiniStats: maximum number of quads exceeded, some elements may not render.');
-            return;
+    resize(capacity) {
+        const data = new Float32Array(capacity * 32);
+        if (this.data) {
+            data.set(this.data);
+            this.buffer.destroy();
+            this.indexBuffer.destroy();
         }
+        const indices = new Uint16Array(capacity * 6);
+        for (let i = 0; i < capacity; i++) {
+            const offset = i * 6;
+            const vertex = i * 4;
+            indices[offset] = vertex;
+            indices[offset + 1] = vertex + 1;
+            indices[offset + 2] = vertex + 2;
+            indices[offset + 3] = vertex;
+            indices[offset + 4] = vertex + 2;
+            indices[offset + 5] = vertex + 3;
+        }
+        this.maxQuads = capacity;
+        this.data = data;
+        this.colors = new Uint32Array(data.buffer);
+        this.buffer = new VertexBuffer(this.device, this.format, capacity * 4, { usage: BUFFER_STREAM });
+        this.indexBuffer = new IndexBuffer(this.device, INDEXFORMAT_UINT16, capacity * 6, BUFFER_STATIC, indices);
+        this.mesh.vertexBuffer = this.buffer;
+        this.mesh.indexBuffer[0] = this.indexBuffer;
+        this.dirty = true;
+    }
 
-        const rw = this.targetSize.width;
-        const rh = this.targetSize.height;
-        const x0 = x / rw;
-        const y0 = y / rh;
-        const x1 = (x + w) / rw;
-        const y1 = (y + h) / rh;
+    destroy() {
+        this.meshInstance.destroy();
+        this.material.destroy();
+    }
 
-        const tw = texture.width;
-        const th = texture.height;
-        const u0 = u / tw;
-        const v0 = v / th;
-        const u1 = (u + (uw ?? w)) / tw;
-        const v1 = (v + (uh ?? h)) / th;
+    setClip(x, y, w, h) {
+        this.clipLeft = x;
+        this.clipBottom = y;
+        this.clipRight = x + w;
+        this.clipTop = y + h;
+    }
 
-        this.data.set([
-            x0, y0, wordFlag, u0, v0, 0, 0,
-            x1, y0, wordFlag, u1, v0, 1, 0,
-            x1, y1, wordFlag, u1, v1, 1, 1,
-            x0, y1, wordFlag, u0, v1, 0, 1
-        ], 4 * 7 * this.quads);
-
-        this.quads++;
+    // Positions and UVs are supplied in bottom-left coordinates. Packed colors use RGBA bytes.
+    quad(x, y, w, h, u, v, uw, uh, texture, mode = 0, color = 0xffffffff) {
+        const x0 = Math.max(x, this.clipLeft);
+        const y0 = Math.max(y, this.clipBottom);
+        const x1 = Math.min(x + w, this.clipRight);
+        const y1 = Math.min(y + h, this.clipTop);
+        if (x1 <= x0 || y1 <= y0) return -1;
+        if (this.quads === this.maxQuads) {
+            if (this.maxQuads >= 8192) {
+                Debug.warnOnce('MiniStats: maximum number of quads exceeded.');
+                return -1;
+            }
+            this.resize(this.maxQuads * 2);
+        }
+        const tw = texture?.width ?? 1;
+        const th = texture?.height ?? 1;
+        const u0 = (u + (x0 - x) / w * uw) / tw;
+        const u1 = (u + (x1 - x) / w * uw) / tw;
+        const v0 = (v + (y0 - y) / h * uh) / th;
+        const v1 = (v + (y1 - y) / h * uh) / th;
+        const bottom = (y0 - y) / h;
+        const top = (y1 - y) / h;
+        const data = this.data;
+        const colors = this.colors;
+        let offset = this.quads * 32;
+        for (let i = 0; i < 4; i++) {
+            const right = i === 1 || i === 2;
+            const upper = i >= 2;
+            data[offset] = (right ? x1 : x0) / this.targetWidth;
+            data[offset + 1] = (upper ? y1 : y0) / this.targetHeight;
+            data[offset + 2] = mode;
+            data[offset + 3] = right ? u1 : u0;
+            data[offset + 4] = upper ? v1 : v0;
+            data[offset + 5] = 1 / h;
+            data[offset + 6] = upper ? top : bottom;
+            colors[offset + 7] = color;
+            offset += 8;
+        }
         this.prim.count += 6;
+        this.dirty = true;
+        return this.quads++;
+    }
+
+    rect(x, y, w, h, color) {
+        this.quad(x, y, w, h, 0, 0, 0, 0, null, 0, color);
+    }
+
+    graph(graph, x, y, w, h, color) {
+        graph.quad = this.quad(x, y, w, h, graph.cursor - w, graph.yOffset + 0.5, w, 0, graph.texture, 2, color);
+        graph.renderWidth = w;
+    }
+
+    graphCursor(graph) {
+        if (graph.quad < 0) return;
+        const offset = graph.quad * 32 + 3;
+        const u0 = (graph.cursor - graph.renderWidth) / graph.texture.width;
+        const u1 = graph.cursor / graph.texture.width;
+        this.data[offset] = u0;
+        this.data[offset + 8] = u1;
+        this.data[offset + 16] = u1;
+        this.data[offset + 24] = u0;
+        this.dirty = true;
     }
 
     startFrame() {
         this.quads = 0;
         this.prim.count = 0;
-
-        this.targetSize.width = this.device.canvas.scrollWidth;
-        this.targetSize.height = this.device.canvas.scrollHeight;
     }
 
-    render(app, layer, graphTexture, wordsTexture, clr, height) {
-
-        // set vertex data (swap storage)
-        this.buffer.setData(this.data.buffer);
-
-        this.uniforms.clr.set(clr, 0);
-
-        // material params
-        this.material.setParameter('clr', this.uniforms.clr);
+    render(app, layer, graphTexture, wordsTexture, clr) {
+        if (this.dirty) {
+            this.buffer.setData(this.data.buffer);
+            this.dirty = false;
+        }
+        this.clr.set(clr);
         this.material.setParameter('graphTex', graphTexture);
         this.material.setParameter('wordsTex', wordsTexture);
-
         app.drawMeshInstance(this.meshInstance, layer);
     }
 }

--- a/src/extras/mini-stats/stats-timer.js
+++ b/src/extras/mini-stats/stats-timer.js
@@ -1,39 +1,25 @@
-// Stats timer interface for graph
 class StatsTimer {
-    constructor(app, statNames, decimalPlaces, unitsName, multiplier) {
+    constructor(app, statNames, decimalPlaces = 0, unitsName = '', multiplier = 1) {
         this.app = app;
-        this.values = [];
-
-        // support one or more stats and accumulate them in the graph total
-        this.statNames = statNames;
-
+        this.paths = statNames.map(path => path.split('.'));
+        this.values = new Float64Array(statNames.length);
         this.unitsName = unitsName;
         this.decimalPlaces = decimalPlaces;
-        this.multiplier = multiplier || 1;
-
-        // recursively look up properties of objects specified in a string
-        const resolve = (path, obj) => {
-            return path.split('.').reduce((prev, curr) => {
-                if (!prev) return null;
-                // handle Map objects
-                if (prev instanceof Map) {
-                    return prev.get(curr);
-                }
-                return prev[curr];
-            }, obj || this);
-        };
-
-        app.on('frameupdate', (ms) => {
-            for (let i = 0; i < this.statNames.length; i++) {
-
-                // read specified stat from app.stats object
-                const value = resolve(this.statNames[i], this.app.stats);
-                this.values[i] = (value ?? 0) * this.multiplier;
-            }
-        });
+        this.multiplier = multiplier;
+        this.enabled = true;
     }
 
     get timings() {
+        // Resolve from the current stats object, which may be replaced by the application.
+        // Paths are parsed once, and no event subscription is needed for a sampled counter.
+        for (let i = 0; i < this.paths.length; i++) {
+            const path = this.paths[i];
+            let value = this.app.stats;
+            for (let j = 0; j < path.length && value != null; j++) {
+                value = value instanceof Map ? value.get(path[j]) : value[path[j]];
+            }
+            this.values[i] = (value ?? 0) * this.multiplier;
+        }
         return this.values;
     }
 }

--- a/src/extras/mini-stats/word-atlas.js
+++ b/src/extras/mini-stats/word-atlas.js
@@ -1,138 +1,121 @@
 import { math } from '../../core/math/math.js';
 import { Texture } from '../../platform/graphics/texture.js';
-import { FILTER_NEAREST } from '../../platform/graphics/constants.js';
+import { FILTER_LINEAR } from '../../platform/graphics/constants.js';
 
 class WordAtlas {
     constructor(device, words) {
-
-        const initContext = (context) => {
-            context.font = '10px "Lucida Console", Monaco, monospace';
-            context.textAlign = 'left';
-            context.textBaseline = 'alphabetic';
-        };
-
-        const isNumber = (word) => {
-            return word === '.' || (word.length === 1 && word.charCodeAt(0) >= 48 && word.charCodeAt(0) <= 57);
-        };
-
-        // create a canvas
         const canvas = document.createElement('canvas');
         const context = canvas.getContext('2d', { alpha: true });
-        initContext(context);
+        const fonts = [
+            '400 22px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+            '600 28px "SFMono-Regular", Consolas, "Liberation Mono", monospace'
+        ];
+        const glyphs = new Set(words);
+        for (const word of words) {
+            for (const char of word) glyphs.add(char);
+        }
+        for (let i = 32; i < 127; i++) glyphs.add(String.fromCharCode(i));
+        glyphs.add('…');
+        glyphs.add('—');
 
-        // measure words
-        const placements = new Map();
-        const padding = 5;
-        const width = 512;
+        // Both fonts share one atlas at 2x CSS resolution. Painting happens only here;
+        // changing values are assembled from cached, tabular digit quads.
+        const padding = 2;
+        const width = 1024;
         let x = padding;
         let y = padding;
-
-        words.forEach((word) => {
-            const measurement = context.measureText(word);
-            const l = Math.ceil(-measurement.actualBoundingBoxLeft);
-            const r = Math.ceil(measurement.actualBoundingBoxRight);
-            const a = Math.ceil(measurement.actualBoundingBoxAscent);
-            const d = Math.ceil(measurement.actualBoundingBoxDescent);
-            const w = l + r;
-            const h = a + d;
-
-            if (x + w + padding >= width) {
-                x = padding;
-                y += 16;
+        let rowHeight = 0;
+        this.placements = [new Map(), new Map()];
+        for (let style = 0; style < fonts.length; style++) {
+            context.font = fonts[style];
+            for (const word of glyphs) {
+                const measurement = context.measureText(word);
+                const left = Math.floor(-measurement.actualBoundingBoxLeft);
+                const right = Math.ceil(measurement.actualBoundingBoxRight);
+                const ascent = Math.ceil(measurement.actualBoundingBoxAscent);
+                const descent = Math.ceil(measurement.actualBoundingBoxDescent);
+                const w = right - left + padding * 2;
+                const h = ascent + descent + padding * 2;
+                if (w > width - padding * 2) continue;
+                if (x + w + padding > width) {
+                    x = padding;
+                    y += rowHeight + padding;
+                    rowHeight = 0;
+                }
+                this.placements[style].set(word, {
+                    x,
+                    y,
+                    w,
+                    h,
+                    left,
+                    ascent,
+                    offsetX: (left - padding) / 2,
+                    offsetY: (-descent - padding) / 2,
+                    advance: measurement.width / 2
+                });
+                x += w + padding;
+                rowHeight = Math.max(rowHeight, h);
             }
-
-            placements.set(word, { l, r, a, d, w, h, x: x, y: y });
-
-            x += w + padding;
-        });
-
-        // size canvas
-        canvas.width = 512;
-        canvas.height = math.nextPowerOfTwo(y + 16 + padding);
-
-        initContext(context);
-        context.fillStyle = 'rgb(0, 0, 0)';
-        context.fillRect(0, 0, canvas.width, canvas.height);
-
-        // render words
-        placements.forEach((m, word) => {
-            // digits and '.' are yellow, the rest pastel cyan
-            context.fillStyle = isNumber(word) ? 'rgb(255, 240, 100)' : 'rgb(150, 220, 230)';
-
-            // render the word
-            context.fillText(word, m.x - m.l, m.y + m.a);
-        });
-
-        this.placements = placements;
-
-        // preserve RGB color data and use max channel for alpha
-        const data = context.getImageData(0, 0, canvas.width, canvas.height).data;
-        for (let i = 0; i < data.length; i += 4) {
-            // use max of RGB channels for alpha, multiply by 2 for bolder text
-            const maxChannel = Math.max(data[i + 0], data[i + 1], data[i + 2]);
-            data[i + 3] = Math.min(maxChannel * 2, 255);
-            // keep RGB as-is to preserve colors
         }
-
+        canvas.width = width;
+        canvas.height = math.nextPowerOfTwo(y + rowHeight + padding);
+        context.fillStyle = '#fff';
+        context.textBaseline = 'alphabetic';
+        for (let style = 0; style < fonts.length; style++) {
+            context.font = fonts[style];
+            for (const [word, p] of this.placements[style]) {
+                context.fillText(word, p.x + padding - p.left, p.y + padding + p.ascent);
+            }
+        }
         this.texture = new Texture(device, {
             name: 'mini-stats-word-atlas',
             width: canvas.width,
             height: canvas.height,
             mipmaps: false,
-            minFilter: FILTER_NEAREST,
-            magFilter: FILTER_NEAREST,
-            levels: [data]
+            minFilter: FILTER_LINEAR,
+            magFilter: FILTER_LINEAR,
+            levels: [context.getImageData(0, 0, canvas.width, canvas.height).data]
         });
     }
 
     destroy() {
         this.texture.destroy();
-        this.texture = null;
     }
 
-    render(render2d, word, x, y) {
-        const p = this.placements.get(word);
-        if (p) {
-            const padding = 1;
-            render2d.quad(x + p.l - padding,
-                y - p.d + padding,
-                p.w + padding * 2,
-                p.h + padding * 2,
-                p.x - padding,
-                this.texture.height - p.y - p.h - padding,
-                undefined, undefined,
-                this.texture,
-                1);
-            return p.w;
-        }
-
-        // if word not found, try rendering character by character
-        let totalWidth = 0;
+    measure(word, style = 0) {
+        const placements = this.placements[style];
+        const p = placements.get(word);
+        if (p) return p.advance;
+        let width = 0;
         for (let i = 0; i < word.length; i++) {
-            const char = word[i];
-
-            // handle spaces specially - they don't render but need width
-            if (char === ' ') {
-                totalWidth += 5;  // fixed width for space
-                continue;
-            }
-
-            const charPlacement = this.placements.get(char);
-            if (charPlacement) {
-                const padding = 1;
-                render2d.quad(x + totalWidth + charPlacement.l - padding,
-                    y - charPlacement.d + padding,
-                    charPlacement.w + padding * 2,
-                    charPlacement.h + padding * 2,
-                    charPlacement.x - padding,
-                    this.texture.height - charPlacement.y - charPlacement.h - padding,
-                    undefined, undefined,
-                    this.texture,
-                    1);
-                totalWidth += charPlacement.w;
-            }
+            width += (placements.get(word[i]) ?? placements.get('?')).advance;
         }
-        return totalWidth;
+        return width;
+    }
+
+    render(render2d, word, x, y, style = 0, color = 0xffffffff, maxWidth = Infinity) {
+        const width = this.measure(word, style);
+        if (maxWidth <= 0) return 0;
+        const ellipsis = this.placements[style].get('…');
+        const truncate = width > maxWidth;
+        const available = truncate ? Math.max(0, maxWidth - ellipsis.advance) : width;
+        this.renderText(render2d, word, x, y, style, color, available);
+        if (truncate) this.renderText(render2d, '…', x + available, y, style, color, ellipsis.advance);
+        return Math.min(width, maxWidth);
+    }
+
+    renderText(render2d, word, x, y, style, color, maxWidth) {
+        const placements = this.placements[style];
+        const whole = placements.get(word);
+        let advance = 0;
+        const count = whole ? 1 : word.length;
+        for (let i = 0; i < count && advance < maxWidth; i++) {
+            const p = whole ?? placements.get(word[i]) ?? placements.get('?');
+            const width = Math.min(p.w / 2, maxWidth - advance - p.offsetX);
+            render2d.quad(x + advance + p.offsetX, y + p.offsetY, width, p.h / 2,
+                p.x, this.texture.height - p.y - p.h, width * 2, p.h, this.texture, 1, color);
+            advance += p.advance;
+        }
     }
 }
 

--- a/test/extras/mini-stats/mini-stats.test.mjs
+++ b/test/extras/mini-stats/mini-stats.test.mjs
@@ -1,0 +1,275 @@
+import { expect } from 'chai';
+import { restore, spy, stub } from 'sinon';
+
+import { EventHandler } from '../../../src/core/event-handler.js';
+import { CpuTimer } from '../../../src/extras/mini-stats/cpu-timer.js';
+import { Graph } from '../../../src/extras/mini-stats/graph.js';
+import { MiniStats } from '../../../src/extras/mini-stats/mini-stats.js';
+import { StatsTimer } from '../../../src/extras/mini-stats/stats-timer.js';
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+describe('MiniStats', function () {
+    let app;
+    let stats;
+    let device;
+    let canvas;
+
+    beforeEach(function () {
+        jsdomSetup();
+        canvas = document.createElement('canvas');
+        stub(canvas, 'getBoundingClientRect').returns({ left: 0, bottom: 720, width: 1280, height: 720 });
+        device = new NullGraphicsDevice(canvas);
+        app = new EventHandler();
+        app.graphicsDevice = device;
+        app.scene = { layers: { getLayerById: () => ({ id: 4 }) } };
+        app.drawMeshInstance = spy();
+        app.stats = {
+            drawCalls: { total: 123 },
+            frame: { ms: 16.7, renderTime: 3, scriptUpdate: 1, scriptPostUpdate: 0.2, animUpdate: 0, physicsTime: 0, gsplatSort: 0 },
+            gpu: new Map(),
+            vram: { totalUsed: 3000000, tex: 2000000, geom: 1000000 }
+        };
+    });
+
+    afterEach(function () {
+        stats?.destroy();
+        stats = null;
+        device.destroy();
+        restore();
+        jsdomTeardown();
+    });
+
+    it('keeps draw calls, frame and custom counters above the CPU, GPU and VRAM groups in all modes', function () {
+        const options = MiniStats.getDefaultOptions();
+        options.stats.unshift({ name: 'Custom first', stats: ['frame.ms'] });
+        options.stats.push({ name: 'Custom second', stats: ['frame.ms'] });
+        stats = new MiniStats(app, options);
+        app.stats.gpu.set('Main pass', 2);
+        for (let mode = 0; mode < 3; mode++) {
+            stats.activeSizeIndex = mode;
+            stats.postRender();
+            expect(stats.graphs.filter(graph => !graph.parent).map(graph => graph.label)).to.deep.equal([
+                'Draw calls', 'Frame', 'Custom first', 'Custom second', 'CPU', 'GPU', 'VRAM'
+            ]);
+            for (let i = 1; i < stats.graphs.length; i++) {
+                expect(stats.graphs[i].group).to.be.at.least(stats.graphs[i - 1].group);
+            }
+            expect(stats._showPeak).to.equal(mode === 2);
+            expect(stats._showGraphs).to.equal(mode === 2);
+            expect(stats.cpuGraphs.size > 0).to.equal(mode > 0);
+        }
+    });
+
+    it('does not modify caller-owned size options', function () {
+        const options = MiniStats.getDefaultOptions();
+        options.sizes[1].width = 192;
+        stats = new MiniStats(app, options);
+        expect(options.sizes[1].width).to.equal(192);
+        expect(stats.sizes[1]).not.to.equal(options.sizes[1]);
+    });
+
+    it('reuses cached geometry without uploads, text work or history writes in text modes', function () {
+        stats = new MiniStats(app);
+        for (let mode = 0; mode < 2; mode++) {
+            stats.activeSizeIndex = mode;
+            stats.postRender();
+            stats.update(stats.textRefreshRate);
+            stats.postRender();
+            const data = stats.render2d.data;
+            const upload = spy(stats.render2d.buffer, 'setData');
+            const unlock = spy(stats.texture, 'unlock');
+            const measure = spy(stats.wordAtlas, 'measure');
+            app.drawMeshInstance.resetHistory();
+            for (let i = 0; i < 10; i++) {
+                stats.update(16);
+                stats.postRender();
+            }
+            expect(stats.render2d.data).to.equal(data);
+            expect(upload.callCount).to.equal(0);
+            expect(unlock.callCount).to.equal(0);
+            expect(measure.callCount).to.equal(0);
+            expect(app.drawMeshInstance.callCount).to.equal(10);
+            upload.restore();
+            unlock.restore();
+            measure.restore();
+        }
+    });
+
+    it('updates all histories with one texture unlock and preserves text geometry between refreshes', function () {
+        stats = new MiniStats(app);
+        stats.activeSizeIndex = 2;
+        stats.postRender();
+        const data = stats.render2d.data;
+        const unlock = spy(stats.texture, 'unlock');
+        const measure = spy(stats.wordAtlas, 'measure');
+        const upload = spy(stats.render2d.buffer, 'setData');
+        for (let i = 0; i < 10; i++) {
+            stats.update(16);
+            stats.postRender();
+        }
+        expect(unlock.callCount).to.equal(10);
+        expect(upload.callCount).to.equal(10);
+        expect(measure.callCount).to.equal(0);
+        expect(stats.render2d.data).to.equal(data);
+        expect(stats.graphs.every(graph => graph.cursor === 10)).to.be.true;
+    });
+
+    it('preserves existing history when new GPU passes grow the texture', function () {
+        stats = new MiniStats(app);
+        stats.activeSizeIndex = 2;
+        stats.postRender();
+        stats.update(16);
+        const graph = stats.graphs[0];
+        const offset = graph.yOffset * stats.texture.width * 4;
+        const before = stats.texture.lock().slice(offset, offset + 4);
+        stats.texture.unlock();
+        const oldHeight = stats.texture.height;
+        for (let i = 0; i < 20; i++) app.stats.gpu.set(`Pass.${i}`, 1);
+        stats.postRender();
+        expect(stats.texture.height).to.be.greaterThan(oldHeight);
+        expect(stats.texture.lock().slice(offset, offset + 4)).to.deep.equal(before);
+        stats.texture.unlock();
+        stats.update(16);
+        expect(stats.gpuPassGraphs.get('Pass.0').timer.timings[0]).to.equal(1);
+    });
+
+    it('clears reused rows and removes inactive GPU passes without orphan counters', function () {
+        stats = new MiniStats(app);
+        stats.activeSizeIndex = 2;
+        app.stats.gpu.set('Old pass', 12);
+        stats.postRender();
+        stats.update(16);
+        const oldRow = stats.gpuPassGraphs.get('Old pass').yOffset;
+        app.stats.gpu.clear();
+        stats.frameIndex += 241;
+        stats.postRender();
+        expect(stats.gpuPassGraphs.size).to.equal(0);
+        app.stats.gpu.set('New pass', 2);
+        stats.postRender();
+        expect(stats.gpuPassGraphs.get('New pass').yOffset).to.equal(oldRow);
+        stats.update(16);
+        const row = stats.texture.lock().slice(oldRow * stats.texture.width * 4, (oldRow + 1) * stats.texture.width * 4);
+        stats.texture.unlock();
+        expect(row[3]).to.equal(170);
+        expect(row.subarray(4).every(value => value === 0)).to.be.true;
+        stats.activeSizeIndex = 0;
+        expect(stats.graphs.every(graph => graph.parent === null)).to.be.true;
+    });
+
+    it('does not create sub-counters when their category is disabled', function () {
+        const options = MiniStats.getDefaultOptions();
+        options.cpu.enabled = false;
+        options.gpu.enabled = false;
+        options.stats = options.stats.filter(stat => stat.name !== 'VRAM');
+        options.startSizeIndex = 2;
+        stats = new MiniStats(app, options);
+        app.stats.gpu.set('Pass', 2);
+        stats.postRender();
+        expect(stats.graphs).to.have.length(2);
+    });
+
+    it('keeps the panel inside a short viewport and clamps scrolling', function () {
+        canvas.getBoundingClientRect.returns({ left: 0, bottom: 180, width: 200, height: 180 });
+        stats = new MiniStats(app);
+        stats.activeSizeIndex = 2;
+        stats.postRender();
+        const firstRowY = stats.render2d.data[stats.graphs[0].quad * 32 + 1];
+        stats.scroll(10000);
+        stats.render();
+        expect(stats.render2d.data[stats.graphs[0].quad * 32 + 1]).to.equal(firstRowY);
+        expect(stats._panelWidth).to.equal(184);
+        expect(stats._panelHeight).to.equal(164);
+        expect(stats._scroll).to.equal(stats._maxScroll);
+        for (let i = 0; i < stats.render2d.quads * 32; i += 8) {
+            expect(stats.render2d.data[i]).to.be.within(0, 1);
+            expect(stats.render2d.data[i + 1]).to.be.within(0, 1);
+        }
+        stats.activeSizeIndex = 0;
+        expect(stats._scroll).to.equal(0);
+    });
+
+    it('stops sampling and hit testing while disabled, and keeps history off on re-enable', function () {
+        stats = new MiniStats(app);
+        stats.activeSizeIndex = 1;
+        stats.postRender();
+        stats.enabled = false;
+        const timer = spy(stats.graphs[0], 'update');
+        stats.update(16);
+        stats.postRender();
+        expect(timer.called).to.be.false;
+        expect(stats.div.style.display).to.equal('none');
+        stats.enabled = true;
+        expect(stats.graphs.every(graph => !graph.enabled)).to.be.true;
+    });
+
+    it('releases event listeners and GPU resources when the application is destroyed', function () {
+        stats = new MiniStats(app);
+        const queued = [stats.render2d.meshInstance];
+        app.scene.immediate = { layerMeshInstances: new Map([[stats.drawLayer, queued]]) };
+        const texture = spy(stats.texture, 'destroy');
+        const buffer = spy(stats.render2d.buffer, 'destroy');
+        app.fire('destroy');
+        expect(app.hasEvent('frameupdate')).to.be.false;
+        expect(app.hasEvent('framerender')).to.be.false;
+        expect(app.hasEvent('frameend')).to.be.false;
+        expect(app.hasEvent('postrender')).to.be.false;
+        expect(texture.calledOnce).to.be.true;
+        expect(buffer.calledOnce).to.be.true;
+        expect(queued).to.have.length(0);
+        expect(document.getElementById('mini-stats')).to.equal(null);
+        stats.destroy();
+        expect(texture.calledOnce).to.be.true;
+    });
+
+    it('reuses timer storage and resolves counters after the stats object is replaced', function () {
+        const timer = new StatsTimer(app, ['frame.ms', 'drawCalls.total']);
+        const values = timer.timings;
+        app.stats = { frame: { ms: 20 }, drawCalls: { total: 8 } };
+        expect(timer.timings).to.equal(values);
+        expect(Array.from(values)).to.deep.equal([20, 8]);
+        const cpu = new CpuTimer(app);
+        const timings = cpu.timings;
+        app.fire('frameupdate');
+        app.fire('framerender');
+        app.fire('frameend');
+        app.fire('frameupdate');
+        expect(cpu.timings).to.equal(timings);
+        cpu.destroy();
+    });
+
+    it('publishes averages and peaks over separate 500 ms windows while history advances every frame', function () {
+        stats = new MiniStats(app);
+        stats.activeSizeIndex = 2;
+        const graph = stats.graphs.find(graph => graph.name === 'Frame');
+        app.stats.frame.ms = 10;
+        stats.update(200);
+        app.stats.frame.ms = 20;
+        stats.update(299);
+        expect(graph.timingText).to.equal('—');
+        expect(graph.cursor).to.equal(2);
+        app.stats.frame.ms = 30;
+        stats.update(1);
+        expect(graph.timingText).to.equal('20.0');
+        expect(graph.maxText).to.equal('30.0');
+        expect(graph.cursor).to.equal(3);
+        app.stats.frame.ms = 5;
+        stats.update(500);
+        expect(graph.timingText).to.equal('5.0');
+        expect(graph.maxText).to.equal('5.0');
+        expect(graph.cursor).to.equal(4);
+    });
+
+    it('distinguishes average changes from peak-only changes', function () {
+        const timer = { timings: [2], decimalPlaces: 0 };
+        const graph = new Graph('Test', app, 10, 32, timer);
+        graph.update(16, null);
+        graph.update(16, null);
+        timer.timings[0] = 1;
+        graph.update(16, null);
+        timer.timings[0] = 3;
+        expect(graph.update(16, null)).to.equal(2);
+        expect(graph.timingText).to.equal('2');
+        expect(graph.maxText).to.equal('3');
+    });
+});


### PR DESCRIPTION
Redesign MiniStats with a readable compact stack, a grouped averages view, and a grouped history view. Keep profiling overhead low with one overlay draw call on both WebGL2 and WebGPU.

<img width="720" height="2028" alt="ministats-before-after" src="https://github.com/user-attachments/assets/bb3e2e50-60db-4ba8-9b57-7d789695059c" />


**Changes:**
- Keep Draw calls and Frame first, followed by custom counters, CPU, GPU and VRAM. Use clearer sub-counter labels, including Script post-update.
- Add distinct compact, medium and large layouts with bold values, smaller labels and clearer graph colors. Show the averaging interval in the heading, defaulting to `Avg (0.5s)`.
- Scroll long counter lists while keeping Draw calls and Frame visible. Support touch dragging and keyboard size selection.

**API Changes:**
- Add optional `detailed` and `peak` flags to entries in `MiniStatsOptions.sizes`, allowing grouped counters without graphs or peaks. Existing size configurations continue to infer these settings when omitted.
- Update the default widths to 128, 176 and 224 CSS pixels. The default middle size now displays averages without graphs.

Before, graph visibility controlled the expanded presentation:
```js
options.sizes[1] = { width: 256, height: 32, spacing: 2, graphs: true };
```

After, detail, history and peak visibility can be configured independently:
```js
options.sizes[1] = {
    width: 176, height: 20, spacing: 0,
    graphs: false, detailed: true, peak: false
};
```

**Examples:**
- Update `debug/mini-stats` to demonstrate the default layouts, start in the large view, and allow WebGPU.

**Performance:**
- Cache the two font sizes in one atlas and reuse timer and vertex buffers. Parse stat paths once and rebuild text geometry only when displayed values or layout change.
- Skip history updates in text-only modes; update all graph rows in one shared texture upload per frame in history mode.
- Preserve one draw call with inexpensive shader branches: no texture fetch for solid quads and one for text or graphs. Physical mobile GPU overhead has not been benchmarked.
- Release overlay buffers and event listeners on destruction, and remove queued mesh references before freeing them.
