### PR TITLE
fix: Add alpha option to createGraphicsDevice typings

### DIFF
--- a/src/framework/application.js
+++ b/src/framework/application.js
@@ -189,6 +189,9 @@ class Application extends AppBase {
         if (platform.browser && !!navigator.xr) {
             options.graphicsDeviceOptions.xrCompatible = true;
         }
+        // note this defaults alpha to false, unlike GraphicsDevice and createGraphicsDevice,
+        // which default it to true. Kept for backwards compatibility - changing it would make
+        // existing canvases composite with the page.
         options.graphicsDeviceOptions.alpha = options.graphicsDeviceOptions.alpha || false;
 
         return new WebglGraphicsDevice(canvas, options.graphicsDeviceOptions);

--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -11,7 +11,7 @@ import { NullGraphicsDevice } from './null/null-graphics-device.js';
  * Creates a graphics device.
  *
  * @param {HTMLCanvasElement} canvas - The canvas element.
- * @param {object} options - Graphics device options.
+ * @param {object} [options] - Graphics device options.
  * @param {string[]} [options.deviceTypes] - An array of DEVICETYPE_*** constants, defining the
  * order in which the devices are attempted to get created. Defaults to an empty array. If the
  * specified array does not contain {@link DEVICETYPE_WEBGL2}, it is internally added to its end.

--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -20,11 +20,26 @@ import { NullGraphicsDevice } from './null/null-graphics-device.js';
  * default spec limits, useful for testing on constrained devices.
  * @param {boolean} [options.antialias] - Boolean that indicates whether or not to perform
  * anti-aliasing if possible. Defaults to true.
- * @param {boolean} [options.alpha] - Boolean that indicates if the canvas contains an alpha
- * buffer, allowing the canvas to composite with the page behind it. Defaults to true. For
- * {@link DEVICETYPE_WEBGL2} this is forwarded as a WebGL context attribute, and for
- * {@link DEVICETYPE_WEBGPU} it selects the canvas alpha mode ('premultiplied' when true,
- * 'opaque' when false).
+ * @param {boolean} [options.alpha] - Boolean that indicates whether the canvas composites with
+ * the page behind it. Defaults to true. This is a compositing option rather than a memory one -
+ * neither backend has an alpha-less backbuffer format that saves any space. The backends
+ * implement it differently:
+ *
+ * - {@link DEVICETYPE_WEBGL2}: forwarded as the WebGL `alpha` context attribute, so the browser
+ * decides whether the drawing buffer actually has an alpha channel. When it does not, the device's
+ * `backBufferFormat` becomes {@link PIXELFORMAT_RGB8} rather than {@link PIXELFORMAT_RGBA8}, which
+ * also changes the format of the scene color grab pass.
+ * - {@link DEVICETYPE_WEBGPU}: selects the canvas alpha mode ('premultiplied' when true, 'opaque'
+ * when false). The backbuffer always has an alpha channel, so `backBufferFormat` is unaffected and
+ * 'opaque' simply tells the compositor to ignore the alpha that is already there.
+ *
+ * Compositing is premultiplied on both backends, so a transparent canvas needs a camera
+ * {@link CameraComponent#clearColor} with both its alpha and its RGB set to zero. A non-zero color
+ * with zero alpha is not valid premultiplied data and composites inconsistently across browsers.
+ *
+ * Note that this default applies to this function. The legacy {@link Application} constructor
+ * instead defaults `alpha` to false.
+ *
  * @param {string} [options.displayFormat] - The display format of the canvas. Defaults to
  * {@link DISPLAYFORMAT_LDR}. Can be:
  *

--- a/src/platform/graphics/graphics-device-create.js
+++ b/src/platform/graphics/graphics-device-create.js
@@ -4,6 +4,10 @@ import { WebglGraphicsDevice } from './webgl/webgl-graphics-device.js';
 import { NullGraphicsDevice } from './null/null-graphics-device.js';
 
 /**
+ * @import { GraphicsDevice } from './graphics-device.js'
+ */
+
+/**
  * Creates a graphics device.
  *
  * @param {HTMLCanvasElement} canvas - The canvas element.
@@ -16,6 +20,11 @@ import { NullGraphicsDevice } from './null/null-graphics-device.js';
  * default spec limits, useful for testing on constrained devices.
  * @param {boolean} [options.antialias] - Boolean that indicates whether or not to perform
  * anti-aliasing if possible. Defaults to true.
+ * @param {boolean} [options.alpha] - Boolean that indicates if the canvas contains an alpha
+ * buffer, allowing the canvas to composite with the page behind it. Defaults to true. For
+ * {@link DEVICETYPE_WEBGL2} this is forwarded as a WebGL context attribute, and for
+ * {@link DEVICETYPE_WEBGPU} it selects the canvas alpha mode ('premultiplied' when true,
+ * 'opaque' when false).
  * @param {string} [options.displayFormat] - The display format of the canvas. Defaults to
  * {@link DISPLAYFORMAT_LDR}. Can be:
  *
@@ -58,7 +67,7 @@ import { NullGraphicsDevice } from './null/null-graphics-device.js';
  * transient attachment support. Incompatible with a scene depth grab pass (`sceneDepthMap`), a
  * depth prepass, or any depth resolve, as the depth cannot be sampled or copied out. Defaults to
  * false.
- * @returns {Promise} - Promise object representing the created graphics device.
+ * @returns {Promise<GraphicsDevice>} - Promise object representing the created graphics device.
  * @category Graphics
  */
 function createGraphicsDevice(canvas, options = {}) {

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -266,9 +266,6 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         super(canvas, options);
         options = this.initOptions;
 
-        // alpha defaults to true
-        options.alpha = options.alpha ?? true;
-
         this.backBufferAntialias = options.antialias ?? false;
         this.isWebGPU = true;
         this._deviceType = DEVICETYPE_WEBGPU;


### PR DESCRIPTION
Fixes #9316

### Problem

`createGraphicsDevice(canvas, options)` forwards `options` unchanged to the device constructors, and `alpha` is honored on every backend:

- the base `GraphicsDevice` constructor defaults it — `this.initOptions.alpha ??= true` (`graphics-device.js:705`);
- WebGL passes the whole options object to `canvas.getContext('webgl2', options)`, where `alpha` is a standard context attribute; the engine then reads the outcome back via `gl.ALPHA_BITS` to choose `backBufferFormat`, which becomes `PIXELFORMAT_RGB8` when the drawing buffer has no alpha channel;
- WebGPU selects the canvas configuration `alphaMode: this.initOptions.alpha ? 'premultiplied' : 'opaque'`.

The factory's JSDoc never listed it, so the generated typings did not either, and TypeScript rejected it as an excess property:

```
error TS2353: Object literal may only specify known properties, and 'alpha' does not exist in type '{ deviceTypes?: string[] | undefined; ... }'.
```

The option worked at runtime; only the type said no. `@playcanvas/web-components` carries a `// @ts-expect-error` at `src/app.ts:302` to pass `alpha` through the public factory for its transparent-canvas attribute.

### Change

In `src/platform/graphics/graphics-device-create.js`:

- document `options.alpha`, including what it means on each backend, so it flows into `playcanvas.d.ts`. It is framed as a compositing option rather than a memory one, since neither backend has an alpha-less backbuffer format that saves any space: WebGPU allows only `bgra8unorm` / `rgba8unorm` / `rgba16float` for canvas configuration, all four-channel, and the engine's own `pixelFormatInfo` lists `PIXELFORMAT_RGB8` with `size: 4`;
- spell out the one observable cross-backend difference: on WebGL `alpha: false` flips `backBufferFormat` to `PIXELFORMAT_RGB8`, which also changes the format of the scene color grab pass, while on WebGPU it only selects `alphaMode` and leaves the format untouched;
- note that compositing is premultiplied on both backends, so a transparent canvas needs a camera `clearColor` with both its alpha and its RGB at zero - a non-zero color with zero alpha is not valid premultiplied data and composites inconsistently across browsers;
- scope the `true` default to this function, since the legacy `Application` constructor defaults `alpha` to false instead;
- narrow `@returns {Promise}` to `@returns {Promise<GraphicsDevice>}` (was generating `Promise<any>`) so callers can drop their casts.

Two small related changes outside the factory:

- `WebgpuGraphicsDevice` drops `options.alpha = options.alpha ?? true`, which ran immediately after `super()` had already applied `initOptions.alpha ??= true`;
- `Application.createDevice` gains a comment recording why its default is false. The behaviour is deliberately left alone - defaulting it to true there would make existing canvases start compositing with the page.

The WebGL-only context attributes the factory also forwards — `premultipliedAlpha`, `preserveDrawingBuffer`, `failIfMajorPerformanceCaveat`, `desynchronized`, `gl` — stay documented on the `WebglGraphicsDevice` constructor only, rather than being promoted into the multi-backend factory's surface.

### Generated signature

```diff
 declare function createGraphicsDevice(canvas: HTMLCanvasElement, options?: {
     deviceTypes?: string[];
     antialias?: boolean;
+    alpha?: boolean;
     displayFormat?: string;
     depth?: boolean;
     stencil?: boolean;
     glslangUrl?: string;
     twgslUrl?: string;
     xrCompatible?: boolean;
     powerPreference?: "default" | "high-performance" | "low-power";
     transientColor?: boolean;
     transientDepth?: boolean;
-}): Promise<any>;
+}): Promise<GraphicsDevice>;
```

### Testing

- `npm run build:types` produces the signature above; `npm run test:types` passes.
- The issue's repro now compiles clean under `--strict`, as does an un-cast `const dev: GraphicsDevice = await createGraphicsDevice(...)`.
- Negative check: an unknown property still trips TS2353, so excess-property checking is intact.
- `eslint` clean.

No behaviour change: the only non-doc edits are the removal of a redundant defaulting line and an explanatory comment.

### Downstream

The `// @ts-expect-error` in `@playcanvas/web-components` (`src/app.ts:302`) can be removed once this ships. Note it will start erroring there as an unused suppression when that repo bumps its engine dependency, so it needs removing in the same bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
