### PR TITLE
Remove obsolete Mac Chrome blitFramebuffer workaround

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -257,15 +257,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
         // pixel format of the framebuffer
         this.updateBackbufferFormat(null);
 
-        const isChrome = platform.browserName === 'chrome';
         const isSafari = platform.browserName === 'safari';
-        const isMac = platform.browser && navigator.appVersion.indexOf('Mac') !== -1;
 
         // enable temporary texture unit workaround on desktop safari
         this._tempEnableSafariTextureUnitWorkaround = isSafari;
-
-        // enable temporary workaround for glBlitFramebuffer failing on Mac Chrome (#2504)
-        this._tempMacChromeBlitFramebufferWorkaround = isMac && isChrome && !options.alpha;
 
         canvas.addEventListener('webglcontextlost', this._contextLostHandler, false);
         canvas.addEventListener('webglcontextrestored', this._contextRestoredHandler, false);


### PR DESCRIPTION
`WebglGraphicsDevice._tempMacChromeBlitFramebufferWorkaround` has been write-only dead code since #4244 (May 2022).

It was introduced in #2504 to guard the old grab-pass texture copy path, which read it as:

```js
if (device.webgl2 && !device._tempMacChromeBlitFramebufferWorkaround && width === texture._width && height === texture._height) {
```

That path was deleted when the grab pass and scene depth rendering were refactored in #4244. The flag has been assigned on every WebGL device creation ever since, and never read.

Removing it also drops the two locals that existed only to feed it, `isChrome` and `isMac` — which takes with them the engine's last remaining use of the deprecated `navigator.appVersion`.

**Changes:**
- Remove `_tempMacChromeBlitFramebufferWorkaround` from `WebglGraphicsDevice`, along with the now-unused `isChrome` and `isMac` locals.

`isSafari` is retained, as `_tempEnableSafariTextureUnitWorkaround` and `supportsImageBitmap` still use it.

No functional change — the removed field had no readers.