### PR TITLE
Remove obsolete Safari texture unit workaround

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -260,9 +260,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
         const isSafari = platform.browserName === 'safari';
 
-        // enable temporary texture unit workaround on desktop safari
-        this._tempEnableSafariTextureUnitWorkaround = isSafari;
-
         canvas.addEventListener('webglcontextlost', this._contextLostHandler, false);
         canvas.addEventListener('webglcontextrestored', this._contextRestoredHandler, false);
 
@@ -1638,15 +1635,6 @@ class WebglGraphicsDevice extends GraphicsDevice {
         DebugGraphics.pushGpuMarker(this, 'UPDATE-BEGIN');
 
         this.boundVao = null;
-
-        // clear texture units once a frame on desktop safari
-        if (this._tempEnableSafariTextureUnitWorkaround) {
-            for (let unit = 0; unit < this.textureUnits.length; ++unit) {
-                for (let slot = 0; slot < 3; ++slot) {
-                    this.textureUnits[unit][slot] = null;
-                }
-            }
-        }
 
         // Set the render target
         const target = this.renderTarget ?? this.backBuffer;


### PR DESCRIPTION
`WebglGraphicsDevice._tempEnableSafariTextureUnitWorkaround` invalidated the engine's own texture-unit shadow cache on every `updateBegin`, forcing a real `gl.bindTexture` for each unit/slot rather than trusting the cache.

It was added in #1839 (January 2020) for a macOS Safari bug where, per that PR, "texture unit 0 state is not correctly tracked", with PlayCanvas "particularly affected due to its aggressive render state tracking". Apple had reproduced the issue and had a fix in progress at the time.

That predates Safari's WebGL2 support, which shipped in Safari 15 (September 2021), so the bug can only have been observed on a WebGL1 context. The engine has been WebGL2-only since #6297 (April 2024), and WebKit's WebGL2 renderer is a separate code path, so the original bug is not expected to apply. The workaround carried no version guard, so it has been running against WebGL2 contexts it was never validated on.

The protection was also already incomplete: `targetToSlot` has no entry for `TEXTURE_2D_ARRAY`, so array-texture cache entries land on a non-index key that the `slot = 0..2` loop never cleared. Array textures — including the XR multiview path — have therefore always run without this invalidation.

Verified on current Safari with the workaround removed, across texture- and pass-heavy examples (clustered spot shadows, clustered light cookies, depth of field, asset viewer) — no rendering issues.

**Changes:**
- Remove `_tempEnableSafariTextureUnitWorkaround` and the per-`updateBegin` texture-unit cache invalidation it gated from `WebglGraphicsDevice`.

`isSafari` is retained, as `supportsImageBitmap` still uses it.

**Performance:**
- Removes a redundant `gl.bindTexture` per texture unit/slot per render pass on all WebKit browsers, which the cache would otherwise have elided.