### PR TITLE
feat: Type Entity#addComponent options and result by component name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ This hierarchy ensures:
 
 - JSDoc comments are used to generate TypeScript definitions
 - Run `npm run build:types` to generate `.d.ts` files
-- Test types with `npm run test:types`
+- Test types with `npm run test:types`. This compiles the bundled declarations and the consumer-side type tests in `test/type-tests`, which check inference and augmentation against `build/playcanvas.d.ts`
 - Use proper JSDoc type annotations:
   - `@type {TypeName}` for variables
   - `@param {TypeName} paramName` for parameters

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "test": "mocha --ignore \"test/assets/scripts/*.js\" --ignore \"test/bundles/**\" --recursive --require test/fixtures.mjs --timeout 5000",
     "test:build": "mocha --recursive \"test/bundles/**/*.test.mjs\" --timeout 30000",
     "test:coverage": "c8 npm test",
-    "test:types": "tsc --pretty false build/playcanvas.d.ts"
+    "test:types": "tsc --pretty false build/playcanvas.d.ts && tsc -p test/type-tests --pretty false"
   },
   "engines": {
     "node": ">=18.3.0"

--- a/src/framework/components/anim/system.js
+++ b/src/framework/components/anim/system.js
@@ -5,6 +5,22 @@ import { AnimComponent } from './component.js';
 /**
  * @import { AppBase } from '../../app-base.js'
  * @import { Component } from '../component.js'
+ * @import { Entity } from '../../entity.js'
+ */
+
+/**
+ * Options of the `anim` component accepted by {@link AnimComponentSystem} that differ from the
+ * properties of {@link AnimComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} AnimComponentOptionsOverrides
+ * @property {{ name: string, weight?: number, mask?: object, blendType?: string }[]} [layers] -
+ * Layers to add with {@link AnimComponent#addLayer}, each with a `name` and optional `weight`,
+ * `mask` and `blendType`.
+ * @property {{ [layer: string]: { mask: object } }} [masks] - Bone masks to assign to the added
+ * layers, keyed by layer name.
+ * @ignore
  */
 
 /**

--- a/src/framework/components/button/system.js
+++ b/src/framework/components/button/system.js
@@ -3,6 +3,20 @@ import { ButtonComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ * @import { Vec4 } from '../../../core/math/vec4.js'
+ */
+
+/**
+ * Options of the `button` component accepted by {@link ButtonComponentSystem} that differ from the
+ * properties of {@link ButtonComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} ButtonComponentOptionsOverrides
+ * @property {Vec4 | number[]} [hitPadding] - Same as {@link ButtonComponent#hitPadding}, also
+ * accepting an `[x, y, z, w]` array.
+ * @ignore
  */
 
 const _properties = [

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -7,6 +7,30 @@ import { CameraComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { CalculateMatrixCallback } from './component.js'
+ * @import { Entity } from '../../entity.js'
+ */
+
+/**
+ * Options of the `camera` component accepted by {@link CameraComponentSystem} that differ from the
+ * properties of {@link CameraComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} CameraComponentOptionsOverrides
+ * @property {CalculateMatrixCallback} [calculateProjection] - Same as
+ * {@link CameraComponent#calculateProjection}.
+ * @property {CalculateMatrixCallback} [calculateTransform] - Same as
+ * {@link CameraComponent#calculateTransform}.
+ * @property {Color | number[]} [clearColor] - Same as {@link CameraComponent#clearColor}, also
+ * accepting an `[r, g, b, a]` array.
+ * @property {Vec2 | number[]} [projectionOffset] - Same as
+ * {@link CameraComponent#projectionOffset}, also accepting an `[x, y]` array.
+ * @property {Vec4 | number[]} [rect] - Same as {@link CameraComponent#rect}, also accepting an `[x,
+ * y, w, h]` array.
+ * @property {Vec4 | number[]} [scissorRect] - Same as {@link CameraComponent#scissorRect}, also
+ * accepting an `[x, y, w, h]` array.
+ * @ignore
  */
 
 const _properties = [

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -14,6 +14,22 @@ import { Trigger } from './trigger.js';
  * @import { GraphNode } from '../../../scene/graph-node.js'
  */
 
+/**
+ * Options of the `collision` component accepted by {@link CollisionComponentSystem} that differ
+ * from the properties of {@link CollisionComponent}. Each replaces the same-named property of the
+ * options that {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} CollisionComponentOptionsOverrides
+ * @property {Quat | number[]} [angularOffset] - Same as {@link CollisionComponent#angularOffset},
+ * also accepting `[x, y, z]` Euler angles in degrees or an `[x, y, z, w]` quaternion array.
+ * @property {Vec3 | number[]} [halfExtents] - Same as {@link CollisionComponent#halfExtents}, also
+ * accepting an `[x, y, z]` array.
+ * @property {Vec3 | number[]} [linearOffset] - Same as {@link CollisionComponent#linearOffset},
+ * also accepting an `[x, y, z]` array.
+ * @ignore
+ */
+
 const mat4 = new Mat4();
 const p1 = new Vec3();
 const p2 = new Vec3();

--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -1,8 +1,69 @@
 import { EventHandler } from '../../core/event-handler.js';
 
 /**
+ * @import { ComponentMap } from '../entity.js'
+ * @import { ComponentOptionsOverrides } from './registry.js'
  * @import { ComponentSystem } from './system.js'
  * @import { Entity } from '../entity.js'
+ */
+
+/**
+ * Resolves to `A` when the types `X` and `Y` are identical, otherwise to `B`.
+ *
+ * @template X
+ * @template Y
+ * @template [A=X]
+ * @template [B=never]
+ * @typedef {(<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? A : B} IfEquals
+ * @ignore
+ */
+
+/**
+ * The names of the writable (not readonly) properties of `T`.
+ *
+ * @template T
+ * @typedef {{ [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, P> }[keyof T]} WritableKeys
+ * @ignore
+ */
+
+/**
+ * The names of the properties of component class `C` that {@link Entity#addComponent} accepts as
+ * options based on the class alone: its public, writable, non-function properties. Getter-only and
+ * `@readonly` properties, methods and callbacks, underscore-prefixed internals and the `system`
+ * and `entity` references are excluded.
+ *
+ * @template C
+ * @typedef {{ [K in WritableKeys<C>]: K extends 'system' | 'entity' | `_${string}` ? never : NonNullable<C[K]> extends Function ? never : K }[WritableKeys<C>]} ComponentOptionKeys
+ * @ignore
+ */
+
+/**
+ * The options derived from component class `C` alone: each {@link ComponentOptionKeys} property,
+ * optional, with the type of the property.
+ *
+ * @template C
+ * @typedef {Partial<Pick<C, Extract<ComponentOptionKeys<C>, keyof C>>>} ComponentOptionsOf
+ * @ignore
+ */
+
+/**
+ * The system-level option overrides of the component named `K` (see
+ * {@link ComponentOptionsOverrides}), or an empty object type when it has none, as for an
+ * application-defined component.
+ *
+ * @template {keyof ComponentMap} K
+ * @typedef {K extends keyof ComponentOptionsOverrides ? ComponentOptionsOverrides[K] : {}} ComponentOptionsOverridesOf
+ * @ignore
+ */
+
+/**
+ * The options of the component named `K`: those derived from its component class, with the
+ * system-level overrides replacing same-named properties. {@link ComponentOptions} flattens this
+ * into a single object type.
+ *
+ * @template {keyof ComponentMap} K
+ * @typedef {Omit<ComponentOptionsOf<ComponentMap[K]>, keyof ComponentOptionsOverridesOf<K>> & ComponentOptionsOverridesOf<K>} MergedComponentOptions
+ * @ignore
  */
 
 /**

--- a/src/framework/components/component.js
+++ b/src/framework/components/component.js
@@ -2,6 +2,7 @@ import { EventHandler } from '../../core/event-handler.js';
 
 /**
  * @import { ComponentMap } from '../entity.js'
+ * @import { ComponentName } from '../entity.js'
  * @import { ComponentOptionsOverrides } from './registry.js'
  * @import { ComponentSystem } from './system.js'
  * @import { Entity } from '../entity.js'
@@ -51,7 +52,7 @@ import { EventHandler } from '../../core/event-handler.js';
  * {@link ComponentOptionsOverrides}), or an empty object type when it has none, as for an
  * application-defined component.
  *
- * @template {keyof ComponentMap} K
+ * @template {ComponentName} K
  * @typedef {K extends keyof ComponentOptionsOverrides ? ComponentOptionsOverrides[K] : {}} ComponentOptionsOverridesOf
  * @ignore
  */
@@ -61,7 +62,7 @@ import { EventHandler } from '../../core/event-handler.js';
  * system-level overrides replacing same-named properties. {@link ComponentOptions} flattens this
  * into a single object type.
  *
- * @template {keyof ComponentMap} K
+ * @template {ComponentName} K
  * @typedef {Omit<ComponentOptionsOf<ComponentMap[K]>, keyof ComponentOptionsOverridesOf<K>> & ComponentOptionsOverridesOf<K>} MergedComponentOptions
  * @ignore
  */

--- a/src/framework/components/element/system.js
+++ b/src/framework/components/element/system.js
@@ -11,6 +11,27 @@ import { ElementComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ */
+
+/**
+ * Options of the `element` component accepted by {@link ElementComponentSystem} that differ from
+ * the properties of {@link ElementComponent}. Each replaces the same-named property of the options
+ * that {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} ElementComponentOptionsOverrides
+ * @property {Vec4 | number[]} [anchor] - Same as {@link ElementComponent#anchor}, also accepting an
+ * `[x, y, z, w]` array.
+ * @property {number | null} [batchGroupId] - Same as {@link ElementComponent#batchGroupId}. `null`
+ * selects no batch group.
+ * @property {Color | number[]} [color] - Same as {@link ElementComponent#color}, also accepting an
+ * `[r, g, b]` array.
+ * @property {Vec4 | number[]} [margin] - Same as {@link ElementComponent#margin}, also accepting an
+ * `[x, y, z, w]` array.
+ * @property {Vec2 | number[]} [pivot] - Same as {@link ElementComponent#pivot}, also accepting an
+ * `[x, y]` array.
+ * @ignore
  */
 
 /**

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -19,8 +19,23 @@ Debug.call(() => {
 /**
  * @import { AppBase } from '../../app-base.js'
  * @import { Camera } from '../../../scene/camera.js'
+ * @import { Entity } from '../../entity.js'
  * @import { Layer } from '../../../scene/layer.js'
  * @import { ShaderMaterial } from '../../../scene/materials/shader-material.js'
+ */
+
+/**
+ * Options of the `gsplat` component accepted by {@link GSplatComponentSystem} that differ from the
+ * properties of {@link GSplatComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} GSplatComponentOptionsOverrides
+ * @property {number[]} [aabbCenter] - Center `[x, y, z]` of a custom bounding box; with
+ * `aabbHalfExtents`, sets {@link GSplatComponent#customAabb}.
+ * @property {number[]} [aabbHalfExtents] - Half-extents `[x, y, z]` of a custom bounding box; with
+ * `aabbCenter`, sets {@link GSplatComponent#customAabb}.
+ * @ignore
  */
 
 // order matters here

--- a/src/framework/components/layout-group/system.js
+++ b/src/framework/components/layout-group/system.js
@@ -5,6 +5,23 @@ import { LayoutGroupComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ */
+
+/**
+ * Options of the `layoutgroup` component accepted by {@link LayoutGroupComponentSystem} that differ
+ * from the properties of {@link LayoutGroupComponent}. Each replaces the same-named property of the
+ * options that {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} LayoutGroupComponentOptionsOverrides
+ * @property {Vec2 | number[]} [alignment] - Same as {@link LayoutGroupComponent#alignment}, also
+ * accepting an `[x, y]` array.
+ * @property {Vec4 | number[]} [padding] - Same as {@link LayoutGroupComponent#padding}, also
+ * accepting an `[x, y, z, w]` array.
+ * @property {Vec2 | number[]} [spacing] - Same as {@link LayoutGroupComponent#spacing}, also
+ * accepting an `[x, y]` array.
+ * @ignore
  */
 
 const MAX_ITERATIONS = 100;

--- a/src/framework/components/light/system.js
+++ b/src/framework/components/light/system.js
@@ -5,6 +5,24 @@ import { _properties, LightComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ */
+
+/**
+ * Options of the `light` component accepted by {@link LightComponentSystem} that differ from the
+ * properties of {@link LightComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} LightComponentOptionsOverrides
+ * @property {Color | number[]} [color] - Same as {@link LightComponent#color}, also accepting an
+ * `[r, g, b]` array.
+ * @property {Vec2 | number[]} [cookieOffset] - Same as {@link LightComponent#cookieOffset}, also
+ * accepting an `[x, y]` array.
+ * @property {Vec2 | number[]} [cookieScale] - Same as {@link LightComponent#cookieScale}, also
+ * accepting an `[x, y]` array.
+ * @property {boolean} [enable] - Deprecated alias of `enabled`.
+ * @ignore
  */
 
 /**

--- a/src/framework/components/model/system.js
+++ b/src/framework/components/model/system.js
@@ -8,6 +8,23 @@ import { ModelComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ */
+
+/**
+ * Options of the `model` component accepted by {@link ModelComponentSystem} that differ from the
+ * properties of {@link ModelComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} ModelComponentOptionsOverrides
+ * @property {number[]} [aabbCenter] - Center `[x, y, z]` of a custom bounding box; with
+ * `aabbHalfExtents`, sets {@link ModelComponent#customAabb}.
+ * @property {number[]} [aabbHalfExtents] - Half-extents `[x, y, z]` of a custom bounding box; with
+ * `aabbCenter`, sets {@link ModelComponent#customAabb}.
+ * @property {number | null} [batchGroupId] - Same as {@link ModelComponent#batchGroupId}. `null`
+ * selects no batch group.
+ * @ignore
  */
 
 // order matters here

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -11,6 +11,65 @@ import { ShaderChunks } from '../../../scene/shader-lib/shader-chunks.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ * @import { Mesh } from '../../../scene/mesh.js'
+ */
+
+/**
+ * Options of the `particlesystem` component accepted by {@link ParticleSystemComponentSystem} that
+ * differ from the properties of {@link ParticleSystemComponent}. Each replaces the same-named
+ * property of the options that {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} ParticleSystemComponentOptionsOverrides
+ * @property {Curve | { type?: number, keys: number[] }} [alphaGraph] - Same as
+ * {@link ParticleSystemComponent#alphaGraph}, also accepting plain `{ type, keys }` curve data.
+ * @property {Curve | { type?: number, keys: number[] }} [alphaGraph2] - Same as
+ * {@link ParticleSystemComponent#alphaGraph2}, also accepting plain `{ type, keys }` curve data.
+ * @property {CurveSet | { type?: number, keys: number[][] }} [colorGraph] - Same as
+ * {@link ParticleSystemComponent#colorGraph}, also accepting plain `{ type, keys }` curve set data.
+ * @property {CurveSet | { type?: number, keys: number[][] }} [colorGraph2] - Same as
+ * {@link ParticleSystemComponent#colorGraph2}, also accepting plain `{ type, keys }` curve set
+ * data.
+ * @property {Vec3 | number[]} [emitterExtents] - Same as
+ * {@link ParticleSystemComponent#emitterExtents}, also accepting an `[x, y, z]` array.
+ * @property {Vec3 | number[]} [emitterExtentsInner] - Same as
+ * {@link ParticleSystemComponent#emitterExtentsInner}, also accepting an `[x, y, z]` array.
+ * @property {CurveSet | { type?: number, keys: number[][] }} [localVelocityGraph] - Same as
+ * {@link ParticleSystemComponent#localVelocityGraph}, also accepting plain `{ type, keys }` curve
+ * set data.
+ * @property {CurveSet | { type?: number, keys: number[][] }} [localVelocityGraph2] - Same as
+ * {@link ParticleSystemComponent#localVelocityGraph2}, also accepting plain `{ type, keys }` curve
+ * set data.
+ * @property {Mesh | Asset | number} [mesh] - Same as {@link ParticleSystemComponent#mesh}. An
+ * {@link Asset} or asset id is assigned to {@link ParticleSystemComponent#meshAsset} instead.
+ * @property {Vec3 | number[]} [particleNormal] - Same as
+ * {@link ParticleSystemComponent#particleNormal}, also accepting an `[x, y, z]` array.
+ * @property {Curve | { type?: number, keys: number[] }} [radialSpeedGraph] - Same as
+ * {@link ParticleSystemComponent#radialSpeedGraph}, also accepting plain `{ type, keys }` curve
+ * data.
+ * @property {Curve | { type?: number, keys: number[] }} [radialSpeedGraph2] - Same as
+ * {@link ParticleSystemComponent#radialSpeedGraph2}, also accepting plain `{ type, keys }` curve
+ * data.
+ * @property {Curve | { type?: number, keys: number[] }} [rotationSpeedGraph] - Same as
+ * {@link ParticleSystemComponent#rotationSpeedGraph}, also accepting plain `{ type, keys }` curve
+ * data.
+ * @property {Curve | { type?: number, keys: number[] }} [rotationSpeedGraph2] - Same as
+ * {@link ParticleSystemComponent#rotationSpeedGraph2}, also accepting plain `{ type, keys }` curve
+ * data.
+ * @property {Curve | { type?: number, keys: number[] }} [scaleGraph] - Same as
+ * {@link ParticleSystemComponent#scaleGraph}, also accepting plain `{ type, keys }` curve data.
+ * @property {Curve | { type?: number, keys: number[] }} [scaleGraph2] - Same as
+ * {@link ParticleSystemComponent#scaleGraph2}, also accepting plain `{ type, keys }` curve data.
+ * @property {CurveSet | { type?: number, keys: number[][] }} [velocityGraph] - Same as
+ * {@link ParticleSystemComponent#velocityGraph}, also accepting plain `{ type, keys }` curve set
+ * data.
+ * @property {CurveSet | { type?: number, keys: number[][] }} [velocityGraph2] - Same as
+ * {@link ParticleSystemComponent#velocityGraph2}, also accepting plain `{ type, keys }` curve set
+ * data.
+ * @property {Vec3 | number[]} [wrapBounds] - Same as {@link ParticleSystemComponent#wrapBounds},
+ * also accepting an `[x, y, z]` array.
+ * @ignore
  */
 
 const _propertyTypes = {

--- a/src/framework/components/registry.js
+++ b/src/framework/components/registry.js
@@ -1,30 +1,77 @@
 import { EventHandler } from '../../core/event-handler.js';
 
 /**
- * @import { AnimComponentSystem } from './anim/system.js'
  * @import { AnimationComponentSystem } from './animation/system.js'
+ * @import { AnimComponentOptionsOverrides } from './anim/system.js'
+ * @import { AnimComponentSystem } from './anim/system.js'
  * @import { AudioListenerComponentSystem } from './audio-listener/system.js'
+ * @import { ButtonComponentOptionsOverrides } from './button/system.js'
  * @import { ButtonComponentSystem } from './button/system.js'
+ * @import { CameraComponentOptionsOverrides } from './camera/system.js'
  * @import { CameraComponentSystem } from './camera/system.js'
+ * @import { CollisionComponentOptionsOverrides } from './collision/system.js'
  * @import { CollisionComponentSystem } from './collision/system.js'
  * @import { ComponentSystem } from './system.js'
+ * @import { ElementComponentOptionsOverrides } from './element/system.js'
  * @import { ElementComponentSystem } from './element/system.js'
+ * @import { Entity } from '../entity.js'
+ * @import { GSplatComponentOptionsOverrides } from './gsplat/system.js'
  * @import { GSplatComponentSystem } from './gsplat/system.js'
  * @import { JointComponentSystem } from './joint/system.js'
  * @import { LayoutChildComponentSystem } from './layout-child/system.js'
+ * @import { LayoutGroupComponentOptionsOverrides } from './layout-group/system.js'
  * @import { LayoutGroupComponentSystem } from './layout-group/system.js'
+ * @import { LightComponentOptionsOverrides } from './light/system.js'
  * @import { LightComponentSystem } from './light/system.js'
+ * @import { ModelComponentOptionsOverrides } from './model/system.js'
  * @import { ModelComponentSystem } from './model/system.js'
+ * @import { ParticleSystemComponentOptionsOverrides } from './particle-system/system.js'
  * @import { ParticleSystemComponentSystem } from './particle-system/system.js'
+ * @import { RenderComponentOptionsOverrides } from './render/system.js'
  * @import { RenderComponentSystem } from './render/system.js'
+ * @import { RigidBodyComponentOptionsOverrides } from './rigid-body/system.js'
  * @import { RigidBodyComponentSystem } from './rigid-body/system.js'
+ * @import { ScreenComponentOptionsOverrides } from './screen/system.js'
  * @import { ScreenComponentSystem } from './screen/system.js'
+ * @import { ScriptComponentOptionsOverrides } from './script/system.js'
  * @import { ScriptComponentSystem } from './script/system.js'
- * @import { ScrollViewComponentSystem } from './scroll-view/system.js'
  * @import { ScrollbarComponentSystem } from './scrollbar/system.js'
+ * @import { ScrollViewComponentOptionsOverrides } from './scroll-view/system.js'
+ * @import { ScrollViewComponentSystem } from './scroll-view/system.js'
+ * @import { SoundComponentOptionsOverrides } from './sound/system.js'
  * @import { SoundComponentSystem } from './sound/system.js'
+ * @import { SpriteComponentOptionsOverrides } from './sprite/system.js'
  * @import { SpriteComponentSystem } from './sprite/system.js'
  * @import { ZoneComponentSystem } from './zone/system.js'
+ */
+
+/**
+ * Options accepted by {@link Entity#addComponent} for each built-in component beyond what its
+ * component class declares - option names that are not component properties (see
+ * {@link ComponentSystem#extraDataProperties}), callbacks, and properties that also accept a plain
+ * array or plain data. Each property replaces the same-named property of the options derived from
+ * the component class; {@link ComponentOptions} applies them. Keyed by component name, like the
+ * systems in this registry.
+ *
+ * @typedef {object} ComponentOptionsOverrides
+ * @property {AnimComponentOptionsOverrides} anim - Overrides of the `anim` component.
+ * @property {ButtonComponentOptionsOverrides} button - Overrides of the `button` component.
+ * @property {CameraComponentOptionsOverrides} camera - Overrides of the `camera` component.
+ * @property {CollisionComponentOptionsOverrides} collision - Overrides of the `collision` component.
+ * @property {ElementComponentOptionsOverrides} element - Overrides of the `element` component.
+ * @property {GSplatComponentOptionsOverrides} gsplat - Overrides of the `gsplat` component.
+ * @property {LayoutGroupComponentOptionsOverrides} layoutgroup - Overrides of the `layoutgroup` component.
+ * @property {LightComponentOptionsOverrides} light - Overrides of the `light` component.
+ * @property {ModelComponentOptionsOverrides} model - Overrides of the `model` component.
+ * @property {ParticleSystemComponentOptionsOverrides} particlesystem - Overrides of the `particlesystem` component.
+ * @property {RenderComponentOptionsOverrides} render - Overrides of the `render` component.
+ * @property {RigidBodyComponentOptionsOverrides} rigidbody - Overrides of the `rigidbody` component.
+ * @property {ScreenComponentOptionsOverrides} screen - Overrides of the `screen` component.
+ * @property {ScriptComponentOptionsOverrides} script - Overrides of the `script` component.
+ * @property {ScrollViewComponentOptionsOverrides} scrollview - Overrides of the `scrollview` component.
+ * @property {SoundComponentOptionsOverrides} sound - Overrides of the `sound` component.
+ * @property {SpriteComponentOptionsOverrides} sprite - Overrides of the `sprite` component.
+ * @ignore
  */
 
 /**

--- a/src/framework/components/render/system.js
+++ b/src/framework/components/render/system.js
@@ -6,6 +6,23 @@ import { RenderComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ */
+
+/**
+ * Options of the `render` component accepted by {@link RenderComponentSystem} that differ from the
+ * properties of {@link RenderComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} RenderComponentOptionsOverrides
+ * @property {number[]} [aabbCenter] - Center `[x, y, z]` of a custom bounding box; with
+ * `aabbHalfExtents`, sets {@link RenderComponent#customAabb}.
+ * @property {number[]} [aabbHalfExtents] - Half-extents `[x, y, z]` of a custom bounding box; with
+ * `aabbCenter`, sets {@link RenderComponent#customAabb}.
+ * @property {number | null} [batchGroupId] - Same as {@link RenderComponent#batchGroupId}. `null`
+ * selects no batch group.
+ * @ignore
  */
 
 // order matters here

--- a/src/framework/components/rigid-body/system.js
+++ b/src/framework/components/rigid-body/system.js
@@ -22,6 +22,20 @@ import { SingleContactResult } from './single-contact-result.js';
  * @import { Trigger } from '../collision/trigger.js'
  */
 
+/**
+ * Options of the `rigidbody` component accepted by {@link RigidBodyComponentSystem} that differ
+ * from the properties of {@link RigidBodyComponent}. Each replaces the same-named property of the
+ * options that {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} RigidBodyComponentOptionsOverrides
+ * @property {Vec3 | number[]} [angularFactor] - Same as {@link RigidBodyComponent#angularFactor},
+ * also accepting an `[x, y, z]` array.
+ * @property {Vec3 | number[]} [linearFactor] - Same as {@link RigidBodyComponent#linearFactor},
+ * also accepting an `[x, y, z]` array.
+ * @ignore
+ */
+
 const _properties = [
     'mass',
     'linearDamping',

--- a/src/framework/components/screen/system.js
+++ b/src/framework/components/screen/system.js
@@ -5,6 +5,21 @@ import { ScreenComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ */
+
+/**
+ * Options of the `screen` component accepted by {@link ScreenComponentSystem} that differ from the
+ * properties of {@link ScreenComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} ScreenComponentOptionsOverrides
+ * @property {Vec2 | number[]} [referenceResolution] - Same as
+ * {@link ScreenComponent#referenceResolution}, also accepting an `[width, height]` array.
+ * @property {Vec2 | number[]} [resolution] - Same as {@link ScreenComponent#resolution}, also
+ * accepting an `[width, height]` array.
+ * @ignore
  */
 
 /**

--- a/src/framework/components/script/system.js
+++ b/src/framework/components/script/system.js
@@ -4,6 +4,22 @@ import { ScriptComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ */
+
+/**
+ * Options of the `script` component accepted by {@link ScriptComponentSystem} that differ from the
+ * properties of {@link ScriptComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} ScriptComponentOptionsOverrides
+ * @property {string[]} [order] - Names of the scripts to create, in execution order. Used together
+ * with `scripts`.
+ * @property {{ [name: string]: { enabled?: boolean, attributes?: object } }} [scripts] -
+ * Initialization of each script to create, keyed by script name: its `enabled` state and
+ * `attributes` values. Used together with `order`.
+ * @ignore
  */
 
 const METHOD_INITIALIZE_ATTRIBUTES = '_onInitializeAttributes';

--- a/src/framework/components/scroll-view/system.js
+++ b/src/framework/components/scroll-view/system.js
@@ -3,6 +3,20 @@ import { ScrollViewComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ * @import { Vec2 } from '../../../core/math/vec2.js'
+ */
+
+/**
+ * Options of the `scrollview` component accepted by {@link ScrollViewComponentSystem} that differ
+ * from the properties of {@link ScrollViewComponent}. Each replaces the same-named property of the
+ * options that {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} ScrollViewComponentOptionsOverrides
+ * @property {Vec2 | number[]} [mouseWheelSensitivity] - Same as
+ * {@link ScrollViewComponent#mouseWheelSensitivity}, also accepting an `[x, y]` array.
+ * @ignore
  */
 
 // Order matters: scalars/booleans/visibility flags must precede the four entity refs.

--- a/src/framework/components/sound/system.js
+++ b/src/framework/components/sound/system.js
@@ -4,7 +4,22 @@ import { SoundComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
  * @import { SoundManager } from '../../../platform/sound/manager.js'
+ * @import { SoundSlot } from './slot.js'
+ */
+
+/**
+ * Options of the `sound` component accepted by {@link SoundComponentSystem} that differ from the
+ * properties of {@link SoundComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} SoundComponentOptionsOverrides
+ * @property {{ [name: string]: SoundSlot | { volume?: number, pitch?: number, loop?: boolean, startTime?: number, duration?: number, overlap?: boolean, autoPlay?: boolean, asset?: number } }} [slots] -
+ * Same as {@link SoundComponent#slots}, also accepting the plain {@link SoundSlot} settings of each
+ * slot.
+ * @ignore
  */
 
 const _properties = [

--- a/src/framework/components/sprite/system.js
+++ b/src/framework/components/sprite/system.js
@@ -11,6 +11,25 @@ import { SpriteComponent } from './component.js';
 
 /**
  * @import { AppBase } from '../../app-base.js'
+ * @import { Entity } from '../../entity.js'
+ * @import { SpriteAnimationClip } from './sprite-animation-clip.js'
+ */
+
+/**
+ * Options of the `sprite` component accepted by {@link SpriteComponentSystem} that differ from the
+ * properties of {@link SpriteComponent}. Each replaces the same-named property of the options that
+ * {@link Entity#addComponent} derives from the component class; see
+ * {@link ComponentOptionsOverrides}.
+ *
+ * @typedef {object} SpriteComponentOptionsOverrides
+ * @property {number | null} [batchGroupId] - Same as {@link SpriteComponent#batchGroupId}. `null`
+ * selects no batch group.
+ * @property {{ [name: string]: SpriteAnimationClip | { name?: string, fps?: number, loop?: boolean, spriteAsset?: number } }} [clips] -
+ * Same as {@link SpriteComponent#clips}, also accepting the plain clip data of
+ * {@link SpriteComponent#addClip}.
+ * @property {Color | number[]} [color] - Same as {@link SpriteComponent#color}, also accepting an
+ * `[r, g, b]` array.
+ * @ignore
  */
 
 /**

--- a/src/framework/components/system.js
+++ b/src/framework/components/system.js
@@ -8,6 +8,7 @@ import { Vec4 } from '../../core/math/vec4.js';
 /**
  * @import { AppBase } from '../app-base.js'
  * @import { Component } from './component.js'
+ * @import { ComponentOptionsOverrides } from './registry.js'
  * @import { Entity } from '../entity.js'
  */
 
@@ -28,7 +29,9 @@ class ComponentSystem extends EventHandler {
      * A list of option names accepted by {@link ComponentSystem#addComponent} that are not settable
      * properties of the component itself - for example keys the system consumes to build derived
      * state (such as `aabbCenter`) or deprecated aliases. Used only by debug-build validation to
-     * avoid false-positive warnings; subclasses that accept such options should override this.
+     * avoid false-positive warnings; subclasses that accept such options should override this and
+     * declare the options in their `...OptionsOverrides` typedef (see
+     * {@link ComponentOptionsOverrides}) so that the typed {@link Entity#addComponent} accepts them.
      *
      * @type {string[]}
      * @ignore

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -419,8 +419,8 @@ class Entity extends GraphNode {
      *
      * For the built-in components the `type` also types the options and the result:
      * `entity.addComponent('camera', { fov: 45 })` accepts any settable property of
-     * {@link CameraComponent} and returns a `CameraComponent`. See {@link ComponentOptions} for the
-     * rule and {@link ComponentMap} for extending this to application-defined components.
+     * {@link CameraComponent} and returns `CameraComponent | null`. See {@link ComponentOptions} for
+     * the rule and {@link ComponentMap} for extending this to application-defined components.
      *
      * @template {ComponentName | (string & {})} K
      * @param {K} type - The name of the component to add (a {@link ComponentName}). Valid strings are:

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -4,20 +4,22 @@ import { GraphNode } from '../scene/graph-node.js';
 import { getApplication } from './globals.js';
 
 /**
- * @import { AnimComponent } from './components/anim/component.js'
  * @import { AnimationComponent } from './components/animation/component.js'
+ * @import { AnimComponent } from './components/anim/component.js'
  * @import { AppBase } from './app-base.js'
  * @import { AudioListenerComponent } from './components/audio-listener/component.js'
  * @import { ButtonComponent } from './components/button/component.js'
  * @import { CameraComponent } from './components/camera/component.js'
  * @import { CollisionComponent } from './components/collision/component.js'
  * @import { Component } from './components/component.js'
+ * @import { ComponentSystem } from './components/system.js'
  * @import { ElementComponent } from './components/element/component.js'
  * @import { GSplatComponent } from './components/gsplat/component.js'
  * @import { JointComponent } from './components/joint/component.js'
  * @import { LayoutChildComponent } from './components/layout-child/component.js'
  * @import { LayoutGroupComponent } from './components/layout-group/component.js'
  * @import { LightComponent } from './components/light/component.js'
+ * @import { MergedComponentOptions } from './components/component.js'
  * @import { ModelComponent } from './components/model/component.js'
  * @import { ParticleSystemComponent } from './components/particle-system/component.js'
  * @import { RenderComponent } from './components/render/component.js'
@@ -25,10 +27,41 @@ import { getApplication } from './globals.js';
  * @import { ScreenComponent } from './components/screen/component.js'
  * @import { ScriptComponent } from './components/script/component.js'
  * @import { ScriptType } from './script/script-type.js'
- * @import { ScrollViewComponent } from './components/scroll-view/component.js'
  * @import { ScrollbarComponent } from './components/scrollbar/component.js'
+ * @import { ScrollViewComponent } from './components/scroll-view/component.js'
  * @import { SoundComponent } from './components/sound/component.js'
  * @import { SpriteComponent } from './components/sprite/component.js'
+ */
+
+/**
+ * The components an {@link Entity} can hold, keyed by the name passed to
+ * {@link Entity#addComponent}: `'camera'` maps to {@link CameraComponent}, `'light'` to
+ * {@link LightComponent} and so on. The map is derived from the component properties declared on
+ * `Entity`, so an application that registers its own {@link ComponentSystem} extends it - and
+ * with it the typing of {@link Entity#addComponent}, {@link Entity#findComponent} and
+ * {@link Entity#findComponents} - by declaring the matching property on `Entity`:
+ *
+ * ```ts
+ * declare module 'playcanvas' {
+ *     interface Entity {
+ *         readonly mything: MyComponent | undefined;
+ *     }
+ * }
+ * ```
+ *
+ * @typedef {{ [K in keyof Entity as NonNullable<Entity[K]> extends Component ? K : never]: NonNullable<Entity[K]> }} ComponentMap
+ */
+
+/**
+ * The options {@link Entity#addComponent} accepts for the component named `K`, for example
+ * `ComponentOptions<'camera'>`. These are the public, settable, non-function properties of the
+ * component class (see {@link ComponentMap}), all optional, plus the extras the component's system
+ * understands: option names that are not component properties, callbacks, and properties that
+ * also accept a plain array in place of a math object, such as `clearColor: [0, 0, 0, 1]`.
+ * Application-defined components get the same derivation from their component class.
+ *
+ * @template {keyof ComponentMap} K
+ * @typedef {{ [P in keyof MergedComponentOptions<K>]: MergedComponentOptions<K>[P] }} ComponentOptions
  */
 
 /**
@@ -371,7 +404,13 @@ class Entity extends GraphNode {
      * Create a new component and add it to the entity. Use this to add functionality to the entity
      * like rendering a model, playing sounds and so on.
      *
-     * @param {string} type - The name of the component to add. Valid strings are:
+     * For the built-in components the `type` also types the options and the result:
+     * `entity.addComponent('camera', { fov: 45 })` accepts any settable property of
+     * {@link CameraComponent} and returns a `CameraComponent`. See {@link ComponentOptions} for the
+     * rule and {@link ComponentMap} for extending this to application-defined components.
+     *
+     * @template {keyof ComponentMap | (string & {})} K
+     * @param {K} type - The name of the component to add. Valid strings are:
      *
      * - "anim" - see {@link AnimComponent}
      * - "animation" - see {@link AnimationComponent}
@@ -395,10 +434,12 @@ class Entity extends GraphNode {
      * - "sound" - see {@link SoundComponent}
      * - "sprite" - see {@link SpriteComponent}
      *
-     * @param {object} [data] - The initialization data for the specific component type. Refer to
-     * each specific component's API reference page for details on valid values for this parameter.
-     * @returns {Component|null} The new Component that was attached to the entity or null if there
-     * was an error.
+     * @param {K extends keyof ComponentMap ? ComponentOptions<K> : object} [data] - The
+     * initialization data for the specific component type: the settable properties of the component
+     * class plus the extras its system understands (see {@link ComponentOptions}). Any object is
+     * accepted for a component name that is not in {@link ComponentMap}.
+     * @returns {(K extends keyof ComponentMap ? ComponentMap[K] : Component) | null} The new
+     * Component that was attached to the entity or null if there was an error.
      * @example
      * const entity = new Entity();
      *
@@ -412,7 +453,7 @@ class Entity extends GraphNode {
      * });
      */
     addComponent(type, data) {
-        const system = this._app.systems[type];
+        const system = this._app.systems[/** @type {string} */ (type)];
         if (!system) {
             Debug.error(`addComponent: System '${type}' doesn't exist`);
             return null;
@@ -421,13 +462,13 @@ class Entity extends GraphNode {
             Debug.warn(`addComponent: Entity already has '${type}' component`);
             return null;
         }
-        return system.addComponent(this, data);
+        return /** @type {any} */ (system.addComponent(this, data));
     }
 
     /**
      * Remove a component from the Entity.
      *
-     * @param {string} type - The name of the Component type.
+     * @param {keyof ComponentMap | (string & {})} type - The name of the Component type.
      * @example
      * const entity = new Entity();
      * entity.addComponent("light"); // add new light component
@@ -435,7 +476,7 @@ class Entity extends GraphNode {
      * entity.removeComponent("light"); // remove light component
      */
     removeComponent(type) {
-        const system = this._app.systems[type];
+        const system = this._app.systems[/** @type {string} */ (type)];
         if (!system) {
             Debug.error(`removeComponent: System '${type}' doesn't exist`);
             return;
@@ -450,30 +491,32 @@ class Entity extends GraphNode {
     /**
      * Search the entity and all of its descendants for the first component of specified type.
      *
-     * @param {string} type - The name of the component type to retrieve.
-     * @returns {Component|null} A component of specified type, if the entity or any of its
-     * descendants has one. Returns null otherwise.
+     * @template {keyof ComponentMap | (string & {})} K
+     * @param {K} type - The name of the component type to retrieve.
+     * @returns {(K extends keyof ComponentMap ? ComponentMap[K] : Component) | null} A component of
+     * specified type, if the entity or any of its descendants has one. Returns null otherwise.
      * @example
      * // Get the first found light component in the hierarchy tree that starts with this entity
      * const light = entity.findComponent("light");
      */
     findComponent(type) {
         const entity = this.findOne(entity => entity.c?.[type]);
-        return entity && entity.c[type];
+        return /** @type {any} */ (entity && entity.c[type]);
     }
 
     /**
      * Search the entity and all of its descendants for all components of specified type.
      *
-     * @param {string} type - The name of the component type to retrieve.
-     * @returns {Component[]} All components of specified type in the entity or any of its
-     * descendants. Returns empty array if none found.
+     * @template {keyof ComponentMap | (string & {})} K
+     * @param {K} type - The name of the component type to retrieve.
+     * @returns {(K extends keyof ComponentMap ? ComponentMap[K] : Component)[]} All components of
+     * specified type in the entity or any of its descendants. Returns empty array if none found.
      * @example
      * // Get all light components in the hierarchy tree that starts with this entity
      * const lights = entity.findComponents("light");
      */
     findComponents(type) {
-        return this.find(entity => entity.c?.[type]).map(entity => entity.c[type]);
+        return /** @type {any} */ (this.find(entity => entity.c?.[type]).map(entity => entity.c[type]));
     }
 
     /**

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -52,6 +52,19 @@ import { getApplication } from './globals.js';
  * @typedef {{ [K in keyof Entity as NonNullable<Entity[K]> extends Component ? K : never]: NonNullable<Entity[K]> }} ComponentMap
  */
 
+// Spelled `keyof ComponentMap & string` rather than `keyof ComponentMap` on purpose: the intersection
+// gives the resulting union its own identity, which carries this alias, so hovers and the API
+// reference show `ComponentName` instead of the expanded list of names. Every key is a string, so
+// the two spellings denote the same type.
+/**
+ * The name of a component an {@link Entity} can hold, such as `'camera'` or `'light'`: the keys of
+ * {@link ComponentMap}. This is what {@link Entity#addComponent}, {@link Entity#findComponent},
+ * {@link Entity#findComponents} and {@link Entity#removeComponent} take, and what
+ * {@link ComponentOptions} is indexed by.
+ *
+ * @typedef {keyof ComponentMap & string} ComponentName
+ */
+
 /**
  * The options {@link Entity#addComponent} accepts for the component named `K`, for example
  * `ComponentOptions<'camera'>`. These are the public, settable, non-function properties of the
@@ -60,7 +73,7 @@ import { getApplication } from './globals.js';
  * also accept a plain array in place of a math object, such as `clearColor: [0, 0, 0, 1]`.
  * Application-defined components get the same derivation from their component class.
  *
- * @template {keyof ComponentMap} K
+ * @template {ComponentName} K
  * @typedef {{ [P in keyof MergedComponentOptions<K>]: MergedComponentOptions<K>[P] }} ComponentOptions
  */
 
@@ -409,8 +422,8 @@ class Entity extends GraphNode {
      * {@link CameraComponent} and returns a `CameraComponent`. See {@link ComponentOptions} for the
      * rule and {@link ComponentMap} for extending this to application-defined components.
      *
-     * @template {keyof ComponentMap | (string & {})} K
-     * @param {K} type - The name of the component to add. Valid strings are:
+     * @template {ComponentName | (string & {})} K
+     * @param {K} type - The name of the component to add (a {@link ComponentName}). Valid strings are:
      *
      * - "anim" - see {@link AnimComponent}
      * - "animation" - see {@link AnimationComponent}
@@ -434,11 +447,11 @@ class Entity extends GraphNode {
      * - "sound" - see {@link SoundComponent}
      * - "sprite" - see {@link SpriteComponent}
      *
-     * @param {K extends keyof ComponentMap ? ComponentOptions<K> : object} [data] - The
+     * @param {K extends ComponentName ? ComponentOptions<K> : object} [data] - The
      * initialization data for the specific component type: the settable properties of the component
      * class plus the extras its system understands (see {@link ComponentOptions}). Any object is
      * accepted for a component name that is not in {@link ComponentMap}.
-     * @returns {(K extends keyof ComponentMap ? ComponentMap[K] : Component) | null} The new
+     * @returns {(K extends ComponentName ? ComponentMap[K] : Component) | null} The new
      * Component that was attached to the entity or null if there was an error.
      * @example
      * const entity = new Entity();
@@ -468,7 +481,7 @@ class Entity extends GraphNode {
     /**
      * Remove a component from the Entity.
      *
-     * @param {keyof ComponentMap | (string & {})} type - The name of the Component type.
+     * @param {ComponentName | (string & {})} type - The name of the Component type.
      * @example
      * const entity = new Entity();
      * entity.addComponent("light"); // add new light component
@@ -491,9 +504,9 @@ class Entity extends GraphNode {
     /**
      * Search the entity and all of its descendants for the first component of specified type.
      *
-     * @template {keyof ComponentMap | (string & {})} K
+     * @template {ComponentName | (string & {})} K
      * @param {K} type - The name of the component type to retrieve.
-     * @returns {(K extends keyof ComponentMap ? ComponentMap[K] : Component) | null} A component of
+     * @returns {(K extends ComponentName ? ComponentMap[K] : Component) | null} A component of
      * specified type, if the entity or any of its descendants has one. Returns null otherwise.
      * @example
      * // Get the first found light component in the hierarchy tree that starts with this entity
@@ -507,9 +520,9 @@ class Entity extends GraphNode {
     /**
      * Search the entity and all of its descendants for all components of specified type.
      *
-     * @template {keyof ComponentMap | (string & {})} K
+     * @template {ComponentName | (string & {})} K
      * @param {K} type - The name of the component type to retrieve.
-     * @returns {(K extends keyof ComponentMap ? ComponentMap[K] : Component)[]} All components of
+     * @returns {(K extends ComponentName ? ComponentMap[K] : Component)[]} All components of
      * specified type in the entity or any of its descendants. Returns empty array if none found.
      * @example
      * // Get all light components in the hierarchy tree that starts with this entity

--- a/src/index.js
+++ b/src/index.js
@@ -261,7 +261,7 @@ export * from './framework/components/element/constants.js';
 export { ElementComponent } from './framework/components/element/component.js';
 export { ElementComponentSystem } from './framework/components/element/system.js';
 export { ElementDragHelper } from './framework/components/element/element-drag-helper.js';
-export { Entity } from './framework/entity.js';
+export * from './framework/entity.js';
 export { GSplatComponent } from './framework/components/gsplat/component.js';
 export { GSplatComponentSystem } from './framework/components/gsplat/system.js';
 export { ImageElement } from './framework/components/element/image-element.js';

--- a/test/type-tests/entity.test.ts
+++ b/test/type-tests/entity.test.ts
@@ -5,7 +5,7 @@ import {
     Asset, CameraComponent, CollisionComponent, Color, Component, ElementComponent, Entity,
     LightComponent, RenderComponent, ScriptComponent, Vec3
 } from '../../build/playcanvas.js';
-import type { ComponentMap, ComponentOptions } from '../../build/playcanvas.js';
+import type { ComponentMap, ComponentName, ComponentOptions } from '../../build/playcanvas.js';
 
 type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
 type Expect<T extends true> = T;
@@ -104,6 +104,10 @@ const options: ComponentOptions<'camera'> = { fov: 30, clearColor: [0, 0, 0, 1] 
 entity.addComponent('camera', options);
 type T12 = Expect<Equal<ComponentOptions<'light'>['enable'], boolean | undefined>>;
 type T13 = Expect<Equal<ComponentOptions<'mything'>['speed'], number | undefined>>;
+type T17 = Expect<Equal<ComponentName, keyof ComponentMap>>;
+const componentName: ComponentName = 'mything';
+// @ts-expect-error not a component name
+const notAComponentName: ComponentName = 'nope';
 
 // ---- findComponent, findComponents and removeComponent follow ComponentMap
 const found = entity.findComponent('light');
@@ -115,4 +119,4 @@ type T16 = Expect<Equal<typeof anyFound, Component | null>>;
 entity.removeComponent('camera');
 entity.removeComponent(name);
 
-export type Checks = [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16];
+export type Checks = [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17];

--- a/test/type-tests/entity.test.ts
+++ b/test/type-tests/entity.test.ts
@@ -1,0 +1,118 @@
+// Consumer-side type tests for Entity#addComponent, Entity#findComponent, Entity#findComponents
+// and Entity#removeComponent. Compiled by `npm run test:types` against build/playcanvas.d.ts, so
+// they exercise exactly what an application sees.
+import {
+    Asset, CameraComponent, CollisionComponent, Color, Component, ElementComponent, Entity,
+    LightComponent, RenderComponent, ScriptComponent, Vec3
+} from '../../build/playcanvas.js';
+import type { ComponentMap, ComponentOptions } from '../../build/playcanvas.js';
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+// An application-defined component: declaring its property on Entity is the one augmentation
+// needed to type it everywhere.
+class MyComponent extends Component {
+    set speed(value: number) {}
+
+    get speed(): number {
+        return 1;
+    }
+}
+declare module '../../build/playcanvas.js' {
+    interface Entity {
+        readonly mything: MyComponent | undefined;
+    }
+}
+
+const entity = new Entity();
+const name: string = 'camera';
+
+// ---- built-in components: the name types both the options and the result
+const camera = entity.addComponent('camera', { fov: 45, clearColor: new Color(1, 0, 0), enabled: false });
+type T1 = Expect<Equal<typeof camera, CameraComponent | null>>;
+const light = entity.addComponent('light');
+type T2 = Expect<Equal<typeof light, LightComponent | null>>;
+const script = entity.addComponent('script', { order: ['a'], scripts: { a: { enabled: true, attributes: {} } } });
+type T3 = Expect<Equal<typeof script, ScriptComponent | null>>;
+const element = entity.addComponent('element', {
+    type: 'image', anchor: [0, 0, 1, 1], pivot: [0.5, 0.5], textureAsset: new Asset('a', 'texture')
+});
+type T4 = Expect<Equal<typeof element, ElementComponent | null>>;
+const render = entity.addComponent('render', {
+    type: 'box', aabbCenter: [0, 0, 0], aabbHalfExtents: [1, 1, 1], batchGroupId: null
+});
+type T5 = Expect<Equal<typeof render, RenderComponent | null>>;
+const collision = entity.addComponent('collision', {
+    type: 'box', halfExtents: [1, 1, 1], linearOffset: new Vec3(), angularOffset: [0, 90, 0]
+});
+type T6 = Expect<Equal<typeof collision, CollisionComponent | null>>;
+
+// ---- system-level overrides: callbacks, array forms, deprecated aliases and plain data
+entity.addComponent('camera', { calculateTransform: (transform, view) => {}, clearColor: [0, 0, 0, 1], rect: [0, 0, 1, 1] });
+entity.addComponent('light', { enable: true, color: [1, 1, 1], cookieOffset: [0, 0] });
+entity.addComponent('particlesystem', {
+    emitterExtents: [1, 1, 1], alphaGraph: { type: 1, keys: [0, 1, 1, 0] }, colorGraph: { keys: [[0, 1], [0, 1], [0, 1]] }, mesh: 12
+});
+entity.addComponent('sprite', { color: [1, 1, 1], clips: { idle: { fps: 10, loop: true, spriteAsset: 3 } } });
+entity.addComponent('sound', { slots: { fire: { asset: 4, volume: 0.5 } } });
+entity.addComponent('rigidbody', { type: 'dynamic', linearFactor: [1, 0, 1] });
+entity.addComponent('screen', { resolution: [1280, 720], screenSpace: true });
+entity.addComponent('layoutgroup', { spacing: [4, 4], padding: [0, 0, 0, 0] });
+entity.addComponent('button', { hitPadding: [0, 0, 0, 0] });
+entity.addComponent('scrollview', { mouseWheelSensitivity: [1, 1] });
+entity.addComponent('anim', { layers: [{ name: 'Base' }], masks: { Base: { mask: {} } } });
+
+// ---- rejected options
+// @ts-expect-error typo
+entity.addComponent('camera', { fovv: 45 });
+// @ts-expect-error wrong value type
+entity.addComponent('camera', { fov: 'wide' });
+// @ts-expect-error getter-only property
+entity.addComponent('camera', { frustum: null });
+// @ts-expect-error method
+entity.addComponent('camera', { screenToWorld: () => new Vec3() });
+// @ts-expect-error callback the system does not consume
+entity.addComponent('camera', { onPostprocessing: () => {} });
+// @ts-expect-error underscore-prefixed internal
+entity.addComponent('element', { _anchorDirty: true });
+// @ts-expect-error base-class reference
+entity.addComponent('camera', { entity });
+// @ts-expect-error inherited method
+entity.addComponent('light', { fire: () => {} });
+// @ts-expect-error option of a different component
+entity.addComponent('light', { fov: 45 });
+// @ts-expect-error no array form where the system passes the value straight to the property
+entity.addComponent('element', { outlineColor: [0, 0, 0] });
+
+// ---- a non-literal name, or a name that is not in ComponentMap, keeps the loose signature
+const loose = entity.addComponent(name, { anything: 1 });
+type T7 = Expect<Equal<typeof loose, Component | null>>;
+const unknown = entity.addComponent('unregistered', { foo: 1 });
+type T8 = Expect<Equal<typeof unknown, Component | null>>;
+
+// ---- application-defined component, after the augmentation above
+const mine = entity.addComponent('mything', { speed: 3 });
+type T9 = Expect<Equal<typeof mine, MyComponent | null>>;
+// @ts-expect-error typo in an option of an application-defined component
+entity.addComponent('mything', { sped: 3 });
+type T10 = Expect<Equal<ComponentMap['mything'], MyComponent>>;
+
+// ---- the public types can be named
+type T11 = Expect<Equal<ComponentMap['camera'], CameraComponent>>;
+const options: ComponentOptions<'camera'> = { fov: 30, clearColor: [0, 0, 0, 1] };
+entity.addComponent('camera', options);
+type T12 = Expect<Equal<ComponentOptions<'light'>['enable'], boolean | undefined>>;
+type T13 = Expect<Equal<ComponentOptions<'mything'>['speed'], number | undefined>>;
+
+// ---- findComponent, findComponents and removeComponent follow ComponentMap
+const found = entity.findComponent('light');
+type T14 = Expect<Equal<typeof found, LightComponent | null>>;
+const all = entity.findComponents('mything');
+type T15 = Expect<Equal<typeof all, MyComponent[]>>;
+const anyFound = entity.findComponent(name);
+type T16 = Expect<Equal<typeof anyFound, Component | null>>;
+entity.removeComponent('camera');
+entity.removeComponent(name);
+
+export type Checks = [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16];

--- a/test/type-tests/tsconfig.json
+++ b/test/type-tests/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "noEmit": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "target": "es2020"
+    },
+    "include": [
+        "*.test.ts"
+    ]
+}


### PR DESCRIPTION
## Description

Supersedes #7560, which typed the same four methods against a hand-written `ComponentMap` and `Partial<Component>` options; see that PR's thread for the design discussion this builds on.

Types `Entity#addComponent` by component name. `entity.addComponent('camera', { fov: 45 })` now checks the options against the settable properties of `CameraComponent` (a typo such as `fovv` is an error with a "Did you mean 'fov'?" hint) and returns `CameraComponent | null`. `findComponent`, `findComponents` and `removeComponent` follow the same map. A non-literal `string`, or a name that is not a known component, keeps the previous loose `object` / `Component | null` signature, so scene loaders and unaugmented custom components are unaffected.

### How it works

- **`ComponentMap`** (new exported type): component name → component class. It is derived from the component properties already declared on `Entity` (`camera: CameraComponent | undefined`, …). Because `Entity` is a class, an application types its own component with the one augmentation it already needs for `entity.mything`:
  ```ts
  declare module 'playcanvas' {
      interface Entity { readonly mything: MyComponent | undefined }
  }
  ```
  That single line also types `addComponent('mything', …)`, its return value, and `findComponent(s)`.
- **`ComponentOptions<K>`** (new exported type): the public, writable, non-function properties of the component class, all optional. Getter-only and `@readonly` properties, methods, callbacks, `_`-prefixed internals and `system`/`entity` are excluded. This is the same rule the debug-only `validateComponentOptions` applies at runtime, and a scan of all 23 component classes found no setter whose type differs from its getter, so the derived value types are exact.
- **Per-system overrides**: each system that accepts more than its component's properties declares a small `…OptionsOverrides` typedef next to its `initializeComponentData` (collected in `registry.js`): names from `extraDataProperties` (`script` `order`/`scripts`, `aabbCenter`/`aabbHalfExtents`, anim `layers`/`masks`, light `enable`), the camera callbacks it copies, and the properties that also accept a plain array or plain data (`anchor: [0, 0, 1, 1]`, `clearColor: [0, 0, 0, 1]`, `halfExtents`, particle curves, sound slots, sprite clips, …). Each override replaces the same-named derived property, so the hover docs and types stay accurate.
- The signature is a single generic with a conditional type rather than overloads: a `(string, object)` fallback overload would silently accept typos on known names. The `keyof ComponentMap | (string & {})` constraint keeps literal autocompletion of the 22 names.
- **`ComponentName`** (new exported type): the keys of `ComponentMap` (`'camera' | 'light' | …`), used in the constraint and conditionals instead of `keyof ComponentMap`. It is spelled `keyof ComponentMap & string` on purpose: that gives the union its own alias identity, so TypeDoc and IDE hovers render `K extends ComponentName` rather than expanding the 22 names three times per signature (which is what the first revision of this PR did).
- `src/index.js` re-exports `entity.js` with `export *` so the three types are nameable (`pc.ComponentOptions<'camera'>`); they are the only new exported names.

### Verification

- `npm run build:types` and `npm run test:types` pass. `test:types` now also compiles `test/type-tests/entity.test.ts`, a consumer-side test of inference, rejected options, the loose fallbacks, the `Entity` augmentation and the nameable types against `build/playcanvas.d.ts`.
- `npm run lint` passes.
- The repo's own `tsconfig.json` (checkJs over `src` and `scripts`) reports no new errors, and one existing error is resolved because `findComponents('render')` is now `RenderComponent[]`.
- Unit tests for `Entity` and the components are unchanged (same four environmental timeouts before and after on this machine). Runtime behaviour is unchanged; the only source changes are JSDoc plus `/** @type */` casts.
- Docs build with typedoc; `ComponentMap` and `ComponentOptions` get pages. Language-service probe: `addComponent('` offers the 22 names, option completion lists 38 keys for `camera` and 57 for `element` with no internals or methods, and hovering an option shows the component property's documentation.

### Notes

- `ElementComponent.anchor`/`pivot`, `CollisionComponent.halfExtents`/`linearOffset`/`angularOffset`, `ButtonComponent.hitPadding` and `ScrollViewComponent.mouseWheelSensitivity` accept arrays at runtime but their declared setter types do not (in JS, `@type` on a setter is emitted with the getter's type). The options typing widens them through the overrides; fixing the direct-assignment typing with `@param` on those setters is a separate change.
- `zone` is not declared on `Entity` (it is only registered by the legacy `Application`), so `addComponent('zone')` takes the loose path.
- Consumers need TypeScript 4.1 or later (key remapping and template literal types).
- The API report also lists `Asset.type`, `AttributeSchema.type`, `Picker.getSelection`/`getSelectionAsync`, `ScriptAttributes.add` and `WireRenderer.frustum`. Those lines only reorder union members (TypeScript orders unions by internal type id, which the new types shift); the intended surface changes are the four `Entity` signatures and the three new type aliases.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
