### PR TITLE
Add missing TEXTURE_2D_ARRAY entry to targetToSlot

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -465,6 +465,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.targetToSlot[gl.TEXTURE_2D] = 0;
         this.targetToSlot[gl.TEXTURE_CUBE_MAP] = 1;
         this.targetToSlot[gl.TEXTURE_3D] = 2;
+        this.targetToSlot[gl.TEXTURE_2D_ARRAY] = 3;
 
         // Define the uniform commit functions
         let scopeX, scopeY, scopeZ, scopeW;
@@ -1103,7 +1104,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
     initTextureUnits(count = 16) {
         this.textureUnits = [];
         for (let i = 0; i < count; i++) {
-            this.textureUnits.push([null, null, null]);
+            this.textureUnits.push([null, null, null, null]);
         }
     }
 


### PR DESCRIPTION
`WebglGraphicsDevice.targetToSlot` maps only three of the four texture targets the engine actually uses, so 2D array textures resolved to `slot === undefined`.

`textureUnits[unit]` is an array, so `textureUnits[unit][undefined]` coerced the key to the *string* `"undefined"` and stored the binding as a named property instead of at an index. That still worked as a cache — every array texture shares one target, so one extra slot per unit is exactly the right granularity — but it left the entry invisible to any index-based loop.

The consequence is in `WebglTexture.destroy`, which purges stale bindings with:

```js
for (let j = 0; j < textureUnit.length; j++) {
    if (textureUnit[j] === this._glTexture) textureUnit[j] = null;
}
```

`length` stayed 3, because a named property does not extend it. A destroyed array texture was therefore never purged, and the device kept a reference to a deleted `WebGLTexture` wrapper until the next array-texture bind on that unit.

To be clear about the severity: this could not cause a mis-bind. `gl.createTexture()` always returns a fresh object, so the identity comparison can never false-positive against a deleted one, and the GPU memory is released by `deleteTexture` regardless. The cost was a small bounded reference leak plus the missed invalidation.

Array textures come from morph targets (`Morph#_createTexture`) and XR views, including the multiview depth bridge in `webgl-xr-bridge.js`.

**Changes:**
- Map `gl.TEXTURE_2D_ARRAY` to slot 3 in `targetToSlot`.
- Widen the per-unit shadow state from `[null, null, null]` to `[null, null, null, null]`, so `length` covers the new slot.

**Performance:**
- Binding an array texture no longer adds a named property to the per-unit array, removing a hidden-class change on the texture-bind path.