### PR TITLE
Avoid retaining GSplat work buffer shaders in container bundles

### DIFF
--- a/src/scene/gsplat-unified/gsplat-work-buffer-render-pass.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer-render-pass.js
@@ -274,12 +274,12 @@ class GSplatWorkBufferRenderPass extends RenderPass {
         const formatDeclarations = resource.format.getInputDeclarations();
 
         // quad renderer and material are cached in the resource
-        const workBufferRenderInfo = resource.getWorkBufferRenderInfo(
+        const workBufferRenderInfo = this.workBuffer.getRenderInfo(
+            resource,
             this.colorOnly,
             workBufferModifier,
             formatHash,
-            formatDeclarations,
-            this.workBuffer.format
+            formatDeclarations
         );
 
         // Assign material properties to scope

--- a/src/scene/gsplat-unified/gsplat-work-buffer.js
+++ b/src/scene/gsplat-unified/gsplat-work-buffer.js
@@ -7,7 +7,9 @@ import { RenderTarget } from '../../platform/graphics/render-target.js';
 import { StorageBuffer } from '../../platform/graphics/storage-buffer.js';
 import { Texture } from '../../platform/graphics/texture.js';
 import { UploadStream } from '../../platform/graphics/upload-stream.js';
+import { GSPLATDATA_COMPACT } from '../constants.js';
 import { QuadRender } from '../graphics/quad-render.js';
+import { ShaderMaterial } from '../materials/shader-material.js';
 import { ShaderUtils } from '../shader-lib/shader-utils.js';
 import glslGsplatCopyToWorkBufferPS from '../shader-lib/glsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js';
 import wgslGsplatCopyToWorkBufferPS from '../shader-lib/wgsl/chunks/gsplat/frag/gsplatCopyToWorkbuffer.js';
@@ -18,12 +20,14 @@ import { GSplatWorkBufferRenderPass } from './gsplat-work-buffer-render-pass.js'
 import { GSplatStreams } from '../gsplat/gsplat-streams.js';
 
 let id = 0;
+const tempMap = new Map();
 
 /**
  * @import { GSplatFormat } from '../gsplat/gsplat-format.js'
  * @import { GSplatInfo } from "./gsplat-info.js"
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { GraphNode } from '../graph-node.js';
+ * @import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js'
  * @import { ShaderMaterial } from '../materials/shader-material.js'
  */
 
@@ -217,6 +221,84 @@ class GSplatWorkBuffer {
         // Create the color-only render pass for updating just the color texture
         this.colorRenderPass = new GSplatWorkBufferRenderPass(device, this, true);
         this.colorRenderPass.init(this.colorRenderTarget);
+    }
+
+    /**
+     * Gets or creates the resource-specific render information used to copy splats into this work
+     * buffer. The cache remains on the resource because its material binds the resource's textures,
+     * parameters and format-specific shader chunks.
+     *
+     * @param {GSplatResourceBase} resource - The source GSplat resource.
+     * @param {boolean} colorOnly - Whether to render only color instead of the full MRT.
+     * @param {{ code: string, hash: number }|null} workBufferModifier - Optional custom modifier.
+     * @param {number} formatHash - Captured resource format hash for shader caching.
+     * @param {string} formatDeclarations - Captured resource format declarations.
+     * @returns {WorkBufferRenderInfo} The cached render information.
+     * @private
+     */
+    getRenderInfo(resource, colorOnly, workBufferModifier, formatHash, formatDeclarations) {
+        const workBufferFormat = this.format;
+
+        // configure defines to fetch cached data
+        resource.configureMaterialDefines(tempMap);
+        tempMap.set('GSPLAT_LOD', '');
+        if (colorOnly) {
+            tempMap.set('GSPLAT_COLOR_ONLY', '');
+
+            // source geometry from the work buffer instead of source textures
+            if (resource.supportsWorkBufferGeometry) {
+                tempMap.set('GSPLAT_WORKBUFFER_GEOMETRY', '');
+                if (workBufferFormat.dataFormat === GSPLATDATA_COMPACT) {
+                    tempMap.set('GSPLAT_WORKBUFFER_COMPACT', '');
+                }
+            }
+        }
+
+        let definesKey = '';
+        for (const [k, v] of tempMap) {
+            if (definesKey) definesKey += ';';
+            definesKey += `${k}=${v}`;
+        }
+        const key = `${formatHash};${workBufferFormat.hash};${workBufferModifier?.hash ?? 0};${definesKey}`;
+
+        // get or create quad render
+        let info = resource.workBufferRenderInfos.get(key);
+        if (!info) {
+
+            const material = new ShaderMaterial();
+            resource.configureMaterial(material, workBufferModifier, formatDeclarations);
+
+            // Inject work buffer output declarations
+            const chunks = this.device.isWebGPU ? material.shaderChunks.wgsl : material.shaderChunks.glsl;
+            // For color-only mode, only output color stream; otherwise output all streams
+            const outputStreams = colorOnly ?
+                [workBufferFormat.getStream('dataColor')] :
+                [...workBufferFormat.streams, ...workBufferFormat.extraStreams];
+            let outputCode = workBufferFormat.getOutputDeclarations(outputStreams);
+
+            // In color-only mode, generate no-op stubs for extra streams so user modifiers compile
+            if (colorOnly && workBufferFormat.extraStreams.length > 0) {
+                outputCode += `\n${workBufferFormat.getOutputStubs(workBufferFormat.extraStreams)}`;
+            }
+
+            chunks.set('gsplatWorkBufferOutputVS', outputCode);
+
+            // Inject format-specific write encoding chunk
+            const writeCode = workBufferFormat.getWriteCode();
+            if (writeCode) {
+                chunks.set('gsplatWriteVS', writeCode);
+            }
+
+            // copy tempMap to material defines
+            tempMap.forEach((v, k) => material.setDefine(k, v));
+
+            // create new cache entry
+            info = new WorkBufferRenderInfo(this.device, key, material, colorOnly, workBufferFormat);
+            resource.workBufferRenderInfos.set(key, info);
+        }
+
+        tempMap.clear();
+        return info;
     }
 
     /**

--- a/src/scene/gsplat/gsplat-resource-base.js
+++ b/src/scene/gsplat/gsplat-resource-base.js
@@ -1,9 +1,6 @@
 import { Debug } from '../../core/debug.js';
 import { BoundingBox } from '../../core/shape/bounding-box.js';
-import { GSPLATDATA_COMPACT } from '../constants.js';
 import { Mesh } from '../mesh.js';
-import { ShaderMaterial } from '../materials/shader-material.js';
-import { WorkBufferRenderInfo } from '../gsplat-unified/gsplat-work-buffer.js';
 import { GSplatStreams } from './gsplat-streams.js';
 import { GSplatResourceCleanup } from './gsplat-resource-cleanup.js';
 
@@ -13,12 +10,13 @@ import { GSplatResourceCleanup } from './gsplat-resource-cleanup.js';
  * @import { GSplatCompressedData } from './gsplat-compressed-data.js'
  * @import { GSplatSogData } from './gsplat-sog-data.js'
  * @import { GSplatFormat } from './gsplat-format.js'
+ * @import { ShaderMaterial } from '../materials/shader-material.js'
  * @import { Texture } from '../../platform/graphics/texture.js'
  * @import { Vec2 } from '../../core/math/vec2.js'
+ * @import { WorkBufferRenderInfo } from '../gsplat-unified/gsplat-work-buffer.js'
  */
 
 let id = 0;
-const tempMap = new Map();
 
 /**
  * Base class for a GSplat resource and defines common properties.
@@ -253,81 +251,6 @@ class GSplatResourceBase {
      */
     get supportsWorkBufferGeometry() {
         return false;
-    }
-
-    /**
-     * Get or create a QuadRender for rendering to work buffer.
-     *
-     * @param {boolean} colorOnly - Whether to render only color (not full MRT).
-     * @param {{ code: string, hash: number }|null} workBufferModifier - Optional custom modifier (object with code and pre-computed hash).
-     * @param {number} formatHash - Captured format hash for shader caching.
-     * @param {string} formatDeclarations - Captured format declarations for shader compilation.
-     * @param {GSplatFormat} workBufferFormat - The work buffer format descriptor.
-     * @returns {WorkBufferRenderInfo} The WorkBufferRenderInfo instance.
-     * @ignore
-     */
-    getWorkBufferRenderInfo(colorOnly, workBufferModifier, formatHash, formatDeclarations, workBufferFormat) {
-
-        // configure defines to fetch cached data
-        this.configureMaterialDefines(tempMap);
-        tempMap.set('GSPLAT_LOD', '');
-        if (colorOnly) {
-            tempMap.set('GSPLAT_COLOR_ONLY', '');
-
-            // source geometry from the work buffer instead of source textures
-            if (this.supportsWorkBufferGeometry) {
-                tempMap.set('GSPLAT_WORKBUFFER_GEOMETRY', '');
-                if (workBufferFormat.dataFormat === GSPLATDATA_COMPACT) {
-                    tempMap.set('GSPLAT_WORKBUFFER_COMPACT', '');
-                }
-            }
-        }
-
-        let definesKey = '';
-        for (const [k, v] of tempMap) {
-            if (definesKey) definesKey += ';';
-            definesKey += `${k}=${v}`;
-        }
-        const key = `${formatHash};${workBufferFormat.hash};${workBufferModifier?.hash ?? 0};${definesKey}`;
-
-        // get or create quad render
-        let info = this.workBufferRenderInfos.get(key);
-        if (!info) {
-
-            const material = new ShaderMaterial();
-            this.configureMaterial(material, workBufferModifier, formatDeclarations);
-
-            // Inject work buffer output declarations
-            const chunks = this.device.isWebGPU ? material.shaderChunks.wgsl : material.shaderChunks.glsl;
-            // For color-only mode, only output color stream; otherwise output all streams
-            const outputStreams = colorOnly ?
-                [workBufferFormat.getStream('dataColor')] :
-                [...workBufferFormat.streams, ...workBufferFormat.extraStreams];
-            let outputCode = workBufferFormat.getOutputDeclarations(outputStreams);
-
-            // In color-only mode, generate no-op stubs for extra streams so user modifiers compile
-            if (colorOnly && workBufferFormat.extraStreams.length > 0) {
-                outputCode += `\n${workBufferFormat.getOutputStubs(workBufferFormat.extraStreams)}`;
-            }
-
-            chunks.set('gsplatWorkBufferOutputVS', outputCode);
-
-            // Inject format-specific write encoding chunk
-            const writeCode = workBufferFormat.getWriteCode();
-            if (writeCode) {
-                chunks.set('gsplatWriteVS', writeCode);
-            }
-
-            // copy tempMap to material defines
-            tempMap.forEach((v, k) => material.setDefine(k, v));
-
-            // create new cache entry
-            info = new WorkBufferRenderInfo(this.device, key, material, colorOnly, workBufferFormat);
-            this.workBufferRenderInfos.set(key, info);
-        }
-
-        tempMap.clear();
-        return info;
     }
 
     static createMesh(device) {

--- a/test/bundles/treeshake.test.mjs
+++ b/test/bundles/treeshake.test.mjs
@@ -25,6 +25,7 @@ describe('build / treeshake', function () {
         bundle: true,
         minify: true,
         write: false,
+        metafile: true,
         format,
         target: 'es2020',
         // the engine's worker sources import these for node support; real app bundlers must
@@ -38,6 +39,24 @@ describe('build / treeshake', function () {
         const bytes = result.outputFiles[0].contents.length;
         expect(bytes, 'bundle size').to.be.greaterThan(500);
         expect(bytes, 'bundle size').to.be.lessThan(10240);
+    });
+
+    it('AppBase with container loading does not retain gsplat work buffer rendering', async function () {
+        const result = await bundle(`
+            import { AppBase, ContainerHandler } from "playcanvas";
+            globalThis.__appBaseImports = { AppBase, ContainerHandler };
+        `);
+
+        const output = Object.values(result.metafile.outputs)[0];
+        const inputs = Object.keys(output.inputs);
+        const retained = inputs.filter((path) => {
+            return path.endsWith('/gsplat-work-buffer.js') ||
+                path.endsWith('/gsplat-work-buffer-render-pass.js') ||
+                path.endsWith('/gsplatCopyToWorkbuffer.js') ||
+                path.endsWith('/gsplatCopyInstancedQuad.js');
+        });
+
+        expect(retained, 'retained gsplat work buffer rendering modules').to.deep.equal([]);
     });
 
     it('deprecated shims survive tree-shaking and still apply', async function () {


### PR DESCRIPTION
Avoids pulling GSplat work-buffer rendering and shader modules into AppBase applications that register ContainerHandler without using GSplatComponentSystem.

**Changes:**
- Move resource-specific work-buffer render-info construction behind GSplatWorkBuffer while retaining resource-owned caching and cleanup.
- Update the work-buffer render pass to obtain render information from its work buffer.
- Add a bundle regression covering AppBase with ContainerHandler.

**Performance:**
- Allows the GSplat work-buffer renderer and its GLSL/WGSL shader sources to be tree-shaken from applications that do not use GSplatComponentSystem.