### PR TITLE
Gsplat LOD: empty level for nodes without coarse data; distance default

### DIFF
--- a/examples/src/examples/gaussian-splatting/downtown.controls.jsx
+++ b/examples/src/examples/gaussian-splatting/downtown.controls.jsx
@@ -36,7 +36,7 @@ export function Controls({ observer }) {
                         type='string'
                         binding={new BindingTwoWay()}
                         link={{ observer, path: 'lodMode' }}
-                        value={observer.get('lodMode') || 'error'}
+                        value={observer.get('lodMode') || 'distance'}
                         options={[
                             { v: 'error', t: 'Error' },
                             { v: 'distance', t: 'Distance' }

--- a/examples/src/examples/gaussian-splatting/downtown.example.mjs
+++ b/examples/src/examples/gaussian-splatting/downtown.example.mjs
@@ -32,7 +32,7 @@ import {
     GSPLATDATA_COMPACT,
     GSPLAT_DEBUG_LOD,
     GSPLAT_DEBUG_NONE,
-    GSPLAT_LODMODE_ERROR,
+    GSPLAT_LODMODE_DISTANCE,
     GSPLAT_RENDERER_RASTER_CPU_SORT,
     GSPLAT_RENDERER_RASTER_GPU_SORT,
     GSplatComponentSystem,
@@ -164,7 +164,7 @@ app.scene.gsplat.dataFormat = GSPLATDATA_COMPACT;
 // How the splat budget picks LOD levels: 'error' spends it where the bundle's per-node error
 // metadata says detail is worth most; 'distance' orders detail by camera distance alone and
 // ignores that metadata. Error is the default and the reason the bundle carries the metrics.
-data.set('lodMode', GSPLAT_LODMODE_ERROR);
+data.set('lodMode', GSPLAT_LODMODE_DISTANCE);
 const applyLodMode = () => {
     app.scene.gsplat.lodMode = data.get('lodMode');
 };

--- a/examples/src/examples/gaussian-splatting/downtown.example.mjs
+++ b/examples/src/examples/gaussian-splatting/downtown.example.mjs
@@ -161,9 +161,10 @@ app.scene.gsplat.alphaClipForward = 1 / 255;
 app.scene.gsplat.minContribution = 3;
 app.scene.gsplat.dataFormat = GSPLATDATA_COMPACT;
 
-// How the splat budget picks LOD levels: 'error' spends it where the bundle's per-node error
-// metadata says detail is worth most; 'distance' orders detail by camera distance alone and
-// ignores that metadata. Error is the default and the reason the bundle carries the metrics.
+// How the splat budget picks LOD levels: 'distance' (the default) orders detail by camera
+// distance alone and ignores error metadata; 'error' spends it where the bundle's per-node
+// error metadata says detail is worth most - that metadata is why the bundle carries the
+// metrics, and it lifts sparse regions that distance leaves coarse.
 data.set('lodMode', GSPLAT_LODMODE_DISTANCE);
 const applyLodMode = () => {
     app.scene.gsplat.lodMode = data.get('lodMode');

--- a/examples/src/examples/gaussian-splatting/lod-streaming.controls.jsx
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.controls.jsx
@@ -224,7 +224,7 @@ export function Controls({ observer }) {
                         type='string'
                         binding={new BindingTwoWay()}
                         link={{ observer, path: 'lodMode' }}
-                        value={observer.get('lodMode') || 'error'}
+                        value={observer.get('lodMode') || 'distance'}
                         options={[
                             { v: 'error', t: 'Error' },
                             { v: 'distance', t: 'Distance' }

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -24,7 +24,7 @@ import {
     GSPLATDATA_COMPACT,
     GSPLATDATA_LARGE,
     GSPLAT_DEBUG_NONE,
-    GSPLAT_LODMODE_ERROR,
+    GSPLAT_LODMODE_DISTANCE,
     GSPLAT_RENDERER_AUTO,
     GSplatComponentSystem,
     GSplatHandler,
@@ -260,7 +260,7 @@ data.set('culling', device.isWebGPU);
 data.set('compact', true);
 data.set('debug', GSPLAT_DEBUG_NONE);
 data.set('lodPreset', platform.mobile ? 'mobile' : 'desktop');
-data.set('lodMode', GSPLAT_LODMODE_ERROR);
+data.set('lodMode', GSPLAT_LODMODE_DISTANCE);
 data.set('lodFalloff', 1);
 data.set('splatBudget', platform.mobile ? 1 : 4);
 data.set('environment', 'none');

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -1463,7 +1463,7 @@ class AppBase extends EventHandler {
      * @param {number} [settings.render.gsplatLodBehindPenalty] - Multiplier applied to effective distance for gsplat nodes behind the camera. Defaults to 1.
      * @param {number} [settings.render.gsplatLodUnderfillLimit] - Maximum number of gsplat LOD levels allowed below the optimal level when optimal data is not resident. Defaults to 0.
      * @param {number} [settings.render.gsplatSplatBudget] - Target number of splats across all GSplats in the scene. LOD levels are chosen globally to stay within it; a non-positive value is not a way to disable this and the default is used instead. Defaults to 1000000.
-     * @param {string} [settings.render.gsplatLodMode] - How LOD levels are chosen for streamed GSplats: 'error' (default) spends the budget by measured approximation error, 'distance' orders detail by camera distance alone and ignores error metadata.
+     * @param {string} [settings.render.gsplatLodMode] - How LOD levels are chosen for streamed GSplats: 'distance' (default) orders detail by camera distance alone in concentric bands and ignores error metadata; 'error' spends the budget by measured approximation error, lifting sparse regions that distance leaves coarse at a higher memory cost.
      * @param {number} [settings.render.gsplatAlphaClip] - Alpha threshold for gsplat shadow, pick, and prepass rendering. Defaults to 0.3.
      * @param {number} [settings.render.gsplatAlphaClipForward] - Alpha threshold for the forward gsplat rendering pass. Defaults to 1 / 255.
      * @param {number} [settings.render.gsplatMinPixelSize] - Minimum screen-space pixel size below which splats are discarded. Defaults to 2.

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1284,7 +1284,8 @@ export const GSPLAT_RENDERER_COMPUTE = 3;
 /**
  * LOD selection driven by per-level approximation errors: the splat budget is spent where it
  * removes the most error per splat, using the manifest's error tables when present and errors
- * derived from splat counts otherwise. The default.
+ * derived from splat counts otherwise. Lifts sparse, low-quality regions that distance alone
+ * leaves coarse, at the cost of holding noticeably more source data in memory.
  *
  * @category Graphics
  */
@@ -1293,7 +1294,7 @@ export const GSPLAT_LODMODE_ERROR = 'error';
 /**
  * LOD selection ordered by camera distance alone: detail steps down in concentric distance bands
  * around the camera, with the band edges adapting to the splat budget. Any error metadata in the
- * asset is ignored. Useful when a capture's quality makes its error tables unreliable.
+ * asset is ignored. The default.
  *
  * @category Graphics
  */

--- a/src/scene/constants.js
+++ b/src/scene/constants.js
@@ -1284,8 +1284,9 @@ export const GSPLAT_RENDERER_COMPUTE = 3;
 /**
  * LOD selection driven by per-level approximation errors: the splat budget is spent where it
  * removes the most error per splat, using the manifest's error tables when present and errors
- * derived from splat counts otherwise. Lifts sparse, low-quality regions that distance alone
- * leaves coarse, at the cost of holding noticeably more source data in memory.
+ * derived from splat counts otherwise. This lifts sparse, low-quality regions - sky, distant
+ * background - that distance alone leaves coarse, but it keeps considerably more source data
+ * resident, so memory use is noticeably higher than with {@link GSPLAT_LODMODE_DISTANCE}.
  *
  * @category Graphics
  */
@@ -1294,7 +1295,8 @@ export const GSPLAT_LODMODE_ERROR = 'error';
 /**
  * LOD selection ordered by camera distance alone: detail steps down in concentric distance bands
  * around the camera, with the band edges adapting to the splat budget. Any error metadata in the
- * asset is ignored. The default.
+ * asset is ignored. Uses the least memory of the two modes, so prefer it on memory-constrained
+ * devices. The default.
  *
  * @category Graphics
  */

--- a/src/scene/gsplat-unified/gsplat-lod-table.js
+++ b/src/scene/gsplat-unified/gsplat-lod-table.js
@@ -39,6 +39,13 @@ const DISTANCE_BAND_MULTIPLIER = 3;
  * distance bands: every node steps coarser at fixed distance ratios, which is the guarantee that
  * mode exists to provide.
  *
+ * A node whose data stops before `rangeMax` - the generator decimated the region to nothing at the
+ * coarser levels - gets one *empty* level at the first missing index: zero splats, no file, and an
+ * error one decimation step worse than its coarsest data. It is the chain's start, so the node draws
+ * nothing until the allocator buys its real coarsest level, exactly as it would for a node that held
+ * that level with zero splats. Without it such a node was pinned to its finest available data at any
+ * distance, which loads a whole file for a handful of splats.
+ *
  * @ignore
  */
 class GSplatLodTable {
@@ -76,7 +83,8 @@ class GSplatLodTable {
 
     /**
      * Per node, the cheapest renderable level in range - where the allocator starts before it
-     * spends anything. -1 when the node has no renderable level in range at all.
+     * spends anything. May be the node's empty level (see above): zero splats and a file index of
+     * -1. -1 when the node has no renderable level in range at all.
      *
      * @type {Int16Array}
      */
@@ -145,7 +153,8 @@ class GSplatLodTable {
      * @param {GSplatOctree} octree - The octree to build the table for.
      * @param {number} rangeMin - Finest allowed LOD index.
      * @param {number} rangeMax - Coarsest allowed LOD index.
-     * @param {string} [lodMode] - GSPLAT_LODMODE_ERROR (default) or GSPLAT_LODMODE_DISTANCE.
+     * @param {string} [lodMode] - GSPLAT_LODMODE_ERROR or GSPLAT_LODMODE_DISTANCE; callers pass the
+     * scene's GSplatParams#lodMode. GSPLAT_LODMODE_ERROR when omitted.
      */
     constructor(octree, rangeMin, rangeMax, lodMode = GSPLAT_LODMODE_ERROR) {
         this.rangeMin = rangeMin;
@@ -187,6 +196,17 @@ class GSplatLodTable {
             const lods = nodes[n].lods;
             this.firstUpgrade[n] = upgradeCount;
 
+            // The coarsest level in range holding data. When that is finer than rangeMax, the level
+            // just above it becomes the node's empty level - see the class notes.
+            let coarsestData = -1;
+            for (let lod = rangeMax; lod >= rangeMin; lod--) {
+                if (lods[lod].count > 0) {
+                    coarsestData = lod;
+                    break;
+                }
+            }
+            const emptyLod = (coarsestData >= 0 && coarsestData < rangeMax) ? coarsestData + 1 : -1;
+
             if (distanceMode) {
                 let finerCount = -1;
                 let e = 0;
@@ -198,18 +218,37 @@ class GSplatLodTable {
                     err[lod] = e;
                     finerCount = lods[lod].count;
                 }
+                // one more band step: dropping the coarsest data altogether
+                if (emptyLod >= 0) {
+                    err[emptyLod] = e + Math.max(finerCount, 1) * bandWeight[emptyLod];
+                }
             } else {
                 for (let lod = rangeMin; lod <= rangeMax; lod++) {
                     err[lod] = lods[lod].error;
+                }
+                // The manifest carries no error for a level it holds no data at. Extrapolate the
+                // node's last decimation step, so the empty level is strictly worse than its coarsest
+                // data and error mode can still choose to lift the node when that is worth its splats.
+                if (emptyLod >= 0) {
+                    const ec = err[coarsestData];
+                    let step = 0;
+                    for (let lod = coarsestData - 1; lod >= rangeMin; lod--) {
+                        if (lods[lod].count > 0) {
+                            step = ec - err[lod];
+                            break;
+                        }
+                    }
+                    err[emptyLod] = ec + (step > 0 ? step : (ec > 0 ? ec : 1));
                 }
             }
 
             // Collect renderable levels in range, ordered by ascending cost and then ascending
             // error. Insertion sort: the list is at most spanLength long and, since coarser levels
-            // normally hold fewer splats, usually already in order.
+            // normally hold fewer splats, usually already in order. The empty level holds no splats,
+            // so it sorts first and starts the chain.
             let candidateCount = 0;
             for (let lod = rangeMax; lod >= rangeMin; lod--) {
-                if (lods[lod].count <= 0) continue;
+                if (lods[lod].count <= 0 && lod !== emptyLod) continue;
                 let j = candidateCount++;
                 while (j > 0) {
                     const prev = scratch[j - 1];

--- a/src/scene/gsplat-unified/gsplat-lod-table.js
+++ b/src/scene/gsplat-unified/gsplat-lod-table.js
@@ -229,16 +229,19 @@ class GSplatLodTable {
                 // The manifest carries no error for a level it holds no data at. Extrapolate the
                 // node's last decimation step, so the empty level is strictly worse than its coarsest
                 // data and error mode can still choose to lift the node when that is worth its splats.
+                // The step is taken from the node's own finer levels, including any below rangeMin,
+                // so its magnitude is the asset's: only a node with data at a single level overall
+                // falls through to the constant, one halving in derived-error units.
                 if (emptyLod >= 0) {
                     const ec = err[coarsestData];
                     let step = 0;
-                    for (let lod = coarsestData - 1; lod >= rangeMin; lod--) {
+                    for (let lod = coarsestData - 1; lod >= 0; lod--) {
                         if (lods[lod].count > 0) {
-                            step = ec - err[lod];
+                            step = ec - lods[lod].error;
                             break;
                         }
                     }
-                    err[emptyLod] = ec + (step > 0 ? step : (ec > 0 ? ec : 1));
+                    err[emptyLod] = ec + (step > 0 ? step : Math.LN2);
                 }
             }
 

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -401,10 +401,12 @@ class GSplatOctreeInstance {
             const table = this.lodTable;
             const node = this.octree.nodes[nodeIndex];
 
-            // prefer the finest already-loaded level within the allowed window
+            // prefer the finest already-loaded level within the allowed window. A node's empty level
+            // (no data, no file, see GSplatLodTable) always qualifies: while its real coarsest data
+            // streams in the node draws nothing, instead of being pinned to finer data early.
             const loaded = table.findCoarserAccepted(nodeIndex, optimalLodIndex, lodUnderfillLimit, (lod) => {
                 const fi = node.lods[lod].fileIndex;
-                return fi !== -1 && !!this.octree.getFileResource(fi);
+                return fi === -1 || !!this.octree.getFileResource(fi);
             });
             if (loaded >= 0) return loaded;
 

--- a/src/scene/gsplat-unified/gsplat-octree.js
+++ b/src/scene/gsplat-unified/gsplat-octree.js
@@ -180,7 +180,10 @@ class GSplatOctree {
                 if (lodData) {
                     lods.push({
                         file: this.files[lodData.file].url || '',
-                        fileIndex: lodData.file,
+                        // A level listed with no splats has nothing to load: give it no file, the
+                        // same as a level the manifest omits, so nothing downstream places or
+                        // fetches it (see GSplatLodTable's empty level).
+                        fileIndex: (lodData.count || 0) > 0 ? lodData.file : -1,
                         offset: lodData.offset || 0,
                         count: lodData.count || 0,
                         error: 0
@@ -348,7 +351,8 @@ class GSplatOctree {
      *
      * @param {number} rangeMin - Finest allowed LOD index.
      * @param {number} rangeMax - Coarsest allowed LOD index.
-     * @param {string} [lodMode] - GSPLAT_LODMODE_ERROR (default) or GSPLAT_LODMODE_DISTANCE.
+     * @param {string} [lodMode] - GSPLAT_LODMODE_ERROR or GSPLAT_LODMODE_DISTANCE; callers pass the
+     * scene's GSplatParams#lodMode. GSPLAT_LODMODE_ERROR when omitted.
      * @returns {GSplatLodTable} The selection table, with its reference count incremented.
      */
     acquireLodTable(rangeMin, rangeMax, lodMode = GSPLAT_LODMODE_ERROR) {

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -500,15 +500,16 @@ class GSplatParams {
     }
 
     /** @private */
-    _lodMode = GSPLAT_LODMODE_ERROR;
+    _lodMode = GSPLAT_LODMODE_DISTANCE;
 
     /**
      * How LOD levels are chosen for streamed GSplats, within {@link GSplatParams#splatBudget}.
-     * {@link GSPLAT_LODMODE_ERROR} (default) spends the budget where it removes the most
-     * approximation error per splat. {@link GSPLAT_LODMODE_DISTANCE} ignores error metadata and
-     * orders detail by camera distance alone instead - it steps down in concentric distance bands
-     * around the camera, with band edges adapting to the budget. Useful when a capture's quality
-     * makes its error tables unreliable.
+     * {@link GSPLAT_LODMODE_DISTANCE} (default) orders detail by camera distance alone - it steps
+     * down in concentric distance bands around the camera, with band edges adapting to the budget,
+     * and ignores any error metadata. {@link GSPLAT_LODMODE_ERROR} instead spends the budget where
+     * it removes the most approximation error per splat, using the asset's error tables when
+     * present. That lifts sparse, low-quality regions such as sky and distant background that
+     * distance alone leaves coarse, at the cost of holding noticeably more source data in memory.
      *
      * @type {string}
      */

--- a/src/scene/gsplat-unified/gsplat-params.js
+++ b/src/scene/gsplat-unified/gsplat-params.js
@@ -474,9 +474,9 @@ class GSplatParams {
 
     /**
      * Target number of splats across all GSplats in the scene. LOD levels are chosen globally to
-     * stay within this budget, spending it where it removes the most approximation error per splat.
-     * A budget larger than the scene resolves to every node at its finest level. Defaults to
-     * 1000000.
+     * stay within this budget, spending it as {@link GSplatParams#lodMode} directs - by distance
+     * band (the default), or where it removes the most approximation error per splat. A budget
+     * larger than the scene resolves to every node at its finest level. Defaults to 1000000.
      *
      * There is no way to disable budgeted LOD selection: a non-positive value would pin every node
      * to its coarsest level rather than lift the cap, so it warns and the default is used instead.
@@ -509,7 +509,8 @@ class GSplatParams {
      * and ignores any error metadata. {@link GSPLAT_LODMODE_ERROR} instead spends the budget where
      * it removes the most approximation error per splat, using the asset's error tables when
      * present. That lifts sparse, low-quality regions such as sky and distant background that
-     * distance alone leaves coarse, at the cost of holding noticeably more source data in memory.
+     * distance alone leaves coarse, at the cost of holding noticeably more source data in memory -
+     * prefer the default on memory-constrained devices.
      *
      * @type {string}
      */

--- a/test/scene/gsplat-unified/gsplat-lod-table.test.mjs
+++ b/test/scene/gsplat-unified/gsplat-lod-table.test.mjs
@@ -230,6 +230,43 @@ describe('GSplatLodTable', function () {
         expect(chainOf(table)).to.deep.equal([2, 0]);
     });
 
+    it('gives a node whose data ends before rangeMax an empty start level just above it', function () {
+        // The generator decimated this region to nothing at levels 2 and 3, so at those distances
+        // the node should draw nothing - not be pinned to its finest available data, which would
+        // load a whole file for a few splats.
+        const octree = makeOctree([100, 40, 0, 0], [0, 1, 0, 0], true);
+        const table = new GSplatLodTable(octree, 0, 3);
+
+        expect(chainOf(table)).to.deep.equal([2, 1, 0]);
+        expect(table.startCount[0]).to.equal(0);
+        expect(octree.nodes[0].lods[2].fileIndex).to.equal(-1);
+        expect(table.totalStartCount).to.equal(0);
+        expect(table.totalFinestCount).to.equal(100);
+        // buying the real coarsest level costs exactly its splats, priced one decimation step
+        // beyond the node's own last error step (1 -> 2, so 1 error over 40 splats)
+        expect(upgradesOf(table)[0]).to.include({ toLod: 1, cost: 40 });
+        expect(upgradesOf(table)[0].ratio).to.be.closeTo(1 / 40, 1e-6);
+    });
+
+    it('adds no empty level when the coarsest data already sits at rangeMax', function () {
+        const octree = makeOctree([100, 40, 0, 0], [0, 1, 0, 0], true);
+        const table = new GSplatLodTable(octree, 0, 1);
+
+        expect(chainOf(table)).to.deep.equal([1, 0]);
+        expect(table.totalStartCount).to.equal(40);
+    });
+
+    it('prices the empty level as one more distance band in distance mode', function () {
+        // The step from empty to the coarsest data is a band step like any other, so a node appears
+        // exactly when the camera enters the band of its coarsest data: band weight of level 2 is
+        // 3^(2 * (2 - 1)) = 9, and content cancels as for every step.
+        const octree = makeOctree([100, 40, 0, 0], undefined, undefined);
+        const table = new GSplatLodTable(octree, 0, 3, GSPLAT_LODMODE_DISTANCE);
+
+        expect(chainOf(table)).to.deep.equal([2, 1, 0]);
+        expect(upgradesOf(table)[0].ratio).to.be.closeTo(9, 1e-6);
+    });
+
     it('marks a node with nothing renderable as having no start level', function () {
         const octree = makeOctree([0, 0], [0, 0], true);
         const table = new GSplatLodTable(octree, 0, 1);

--- a/test/scene/gsplat-unified/gsplat-lod-table.test.mjs
+++ b/test/scene/gsplat-unified/gsplat-lod-table.test.mjs
@@ -267,6 +267,38 @@ describe('GSplatLodTable', function () {
         expect(upgradesOf(table)[0].ratio).to.be.closeTo(9, 1e-6);
     });
 
+    it('takes the empty level\'s error step from the node\'s own finer levels below rangeMin', function () {
+        // With range [1, 3] this node has data at a single level in range (level 1), so the step
+        // has to come from level 0 - outside the range, but the node's own last decimation step
+        // and therefore in the asset's units: 1.5 error over 40 splats.
+        const octree = makeOctree([100, 40, 0, 0], [0, 1.5, 0, 0], true);
+        const table = new GSplatLodTable(octree, 1, 3);
+
+        expect(chainOf(table)).to.deep.equal([2, 1]);
+        expect(upgradesOf(table)[0]).to.include({ toLod: 1, cost: 40 });
+        expect(upgradesOf(table)[0].ratio).to.be.closeTo(1.5 / 40, 1e-6);
+    });
+
+    it('falls back to one halving step for a node with data at a single level overall', function () {
+        const octree = makeOctree([50, 0, 0], [0, 0, 0], true);
+        const table = new GSplatLodTable(octree, 0, 2);
+
+        expect(chainOf(table)).to.deep.equal([1, 0]);
+        expect(upgradesOf(table)[0].ratio).to.be.closeTo(Math.LN2 / 50, 1e-6);
+    });
+
+    it('places the empty level above the coarsest data, not in an interior gap', function () {
+        // Level 1 is a hole below present data, so it stays excluded; the empty level goes above
+        // level 2, priced by the node's last step (2 error from level 0 to level 2).
+        const octree = makeOctree([100, 0, 20, 0], [0, 0, 2, 0], true);
+        const table = new GSplatLodTable(octree, 0, 3);
+
+        expect(chainOf(table)).to.deep.equal([3, 2, 0]);
+        expect(upgradesOf(table)[0]).to.include({ toLod: 2, cost: 20 });
+        // reach 2: (4 - 2) / 20 = 0.1; reach 0: (4 - 0) / 100 = 0.04 -> best deal 0.1
+        expect(upgradesOf(table)[0].ratio).to.be.closeTo(0.1, 1e-6);
+    });
+
     it('marks a node with nothing renderable as having no start level', function () {
         const octree = makeOctree([0, 0], [0, 0], true);
         const table = new GSplatLodTable(octree, 0, 1);


### PR DESCRIPTION
Streamed gaussian-splat octrees can contain leaves whose data stops before the coarsest LOD level - the generator decimated the region to nothing there. The LOD chain had no entry for those levels, so such a node was pinned to its finest available data at any distance, loading a whole ~10 MB file for as few as 3 splats. This gives those nodes an empty level instead, and flips the default LOD mode to distance, whose memory footprint matches the pre-2.22 distance-based selection.

**Changes:**
- A node whose data ends before `rangeMax` now gets a zero-splat, file-less level just above its coarsest data as the start of its LOD chain. It draws nothing until the allocator buys its real coarsest level. Distance mode prices that step as one more distance band, so the node appears exactly when the camera enters the band of its coarsest data; error mode extrapolates the node's last error step, so it can still choose to lift the node - which is that mode's purpose.
- A level listed in the manifest with zero splats gets no file index, the same as an omitted level, so nothing downstream places or fetches it.
- Underfill treats the empty level as loaded, so a node draws nothing while its real data streams rather than requesting finer data early.
- `GSplatParams#lodMode` defaults to `GSPLAT_LODMODE_DISTANCE`. `GSPLAT_LODMODE_ERROR` remains available; its docs now describe the trade-off (lifts sparse, low-quality regions that distance leaves coarse, at a noticeably higher memory cost).

**API Changes:**
- `GSplatParams#lodMode` default changed from `GSPLAT_LODMODE_ERROR` to `GSPLAT_LODMODE_DISTANCE`. Scenes that relied on the error-driven default should set `app.scene.gsplat.lodMode = GSPLAT_LODMODE_ERROR` explicitly.

**Examples:**
- `lod-streaming` and `downtown` start in distance mode, and their LOD Mode controls default to it.

**Performance:**
- `example_roman_parish_02`, distance mode, 4M splat budget, same camera, settled: resident files 28 -> 24, texture VRAM 383.6 -> 343.0 MB, while drawing more splats (3.83M -> 3.97M) as the freed budget is re-spent.
- `example_roman_parish_03` (few such nodes): 457 -> 441 MB on WebGL, 655 -> 639 MB on WebGPU - one 16 MB file.
- Error mode is unaffected in practice: it buys the lifts.

Follow-ups outside this repo: the developer-site `lodMode` docs and the editor's `lodMode` default still describe error mode as the default.