### PR TITLE
Make Gaussian splatting GLB support tree-shakeable

### DIFF
--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -8,6 +8,7 @@ import { gsplatChunksGLSL } from '../../../scene/shader-lib/glsl/collections/gsp
 import { gsplatChunksWGSL } from '../../../scene/shader-lib/wgsl/collections/gsplat-chunks-wgsl.js';
 import { SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL } from '../../../platform/graphics/constants.js';
 import { ShaderChunks } from '../../../scene/shader-lib/shader-chunks.js';
+import { khrGaussianSplatting } from '../../parsers/glb/extensions/khr-gaussian-splatting.js';
 
 // Register warning for removed customization chunk
 Debug.call(() => {
@@ -20,6 +21,7 @@ Debug.call(() => {
  * @import { AppBase } from '../../app-base.js'
  * @import { Camera } from '../../../scene/camera.js'
  * @import { Entity } from '../../entity.js'
+ * @import { GlbContainerParser } from '../../parsers/glb-container-parser.js'
  * @import { Layer } from '../../../scene/layer.js'
  * @import { ShaderMaterial } from '../../../scene/materials/shader-material.js'
  */
@@ -57,6 +59,14 @@ const _properties = [
  * @category Graphics
  */
 class GSplatComponentSystem extends ComponentSystem {
+    /**
+     * GLB container parsers this system registered its glTF extension with.
+     *
+     * @type {GlbContainerParser[]}
+     * @private
+     */
+    _glbContainerParsers = [];
+
     /**
      * Fired when a GSplat material is created for a camera and layer combination. Materials are
      * created during the first frame update when the GSplat is rendered. The handler is passed
@@ -148,6 +158,18 @@ class GSplatComponentSystem extends ComponentSystem {
 
         // consumed to build customAabb, not settable component properties
         this.extraDataProperties = ['aabbCenter', 'aabbHalfExtents'];
+
+        // Resource handlers are created before component systems, so register glTF splat support
+        // here to keep its resource implementation tree-shakeable when this system is omitted.
+        const containerParsers = app.loader.getHandler('container')?.parsers ?? [];
+        containerParsers.forEach((parser) => {
+            const glbParser = /** @type {GlbContainerParser} */ (parser);
+            if (typeof glbParser.registerGltfExtension === 'function' &&
+                typeof glbParser.unregisterGltfExtension === 'function') {
+                glbParser.registerGltfExtension(khrGaussianSplatting);
+                this._glbContainerParsers.push(glbParser);
+            }
+        });
 
         app.renderer.gsplatDirector = new GSplatDirector(app.graphicsDevice, app.renderer, app.scene, this);
 
@@ -254,6 +276,10 @@ class GSplatComponentSystem extends ComponentSystem {
     destroy() {
         super.destroy();
         this.app.off('framerender', this.onFrameRender, this);
+        this._glbContainerParsers.forEach((parser) => {
+            parser.unregisterGltfExtension(khrGaussianSplatting.name);
+        });
+        this._glbContainerParsers.length = 0;
     }
 }
 

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -9,6 +9,7 @@ import { gsplatChunksWGSL } from '../../../scene/shader-lib/wgsl/collections/gsp
 import { SHADERLANGUAGE_GLSL, SHADERLANGUAGE_WGSL } from '../../../platform/graphics/constants.js';
 import { ShaderChunks } from '../../../scene/shader-lib/shader-chunks.js';
 import { khrGaussianSplatting } from '../../parsers/glb/extensions/khr-gaussian-splatting.js';
+import { registerGlbResourceExtension, unregisterGlbResourceExtension } from '../../parsers/glb-resource-extension.js';
 
 // Register warning for removed customization chunk
 Debug.call(() => {
@@ -21,8 +22,8 @@ Debug.call(() => {
  * @import { AppBase } from '../../app-base.js'
  * @import { Camera } from '../../../scene/camera.js'
  * @import { Entity } from '../../entity.js'
- * @import { GlbContainerParser } from '../../parsers/glb-container-parser.js'
  * @import { Layer } from '../../../scene/layer.js'
+ * @import { ResourceHandler } from '../../handlers/handler.js'
  * @import { ShaderMaterial } from '../../../scene/materials/shader-material.js'
  */
 
@@ -60,12 +61,12 @@ const _properties = [
  */
 class GSplatComponentSystem extends ComponentSystem {
     /**
-     * GLB container parsers this system registered its glTF extension with.
+     * Container handler this system registered its glTF extension with.
      *
-     * @type {GlbContainerParser[]}
+     * @type {ResourceHandler|null}
      * @private
      */
-    _glbContainerParsers = [];
+    _containerHandler = null;
 
     /**
      * Fired when a GSplat material is created for a camera and layer combination. Materials are
@@ -161,15 +162,10 @@ class GSplatComponentSystem extends ComponentSystem {
 
         // Resource handlers are created before component systems, so register glTF splat support
         // here to keep its resource implementation tree-shakeable when this system is omitted.
-        const containerParsers = app.loader.getHandler('container')?.parsers ?? [];
-        containerParsers.forEach((parser) => {
-            const glbParser = /** @type {GlbContainerParser} */ (parser);
-            if (typeof glbParser.registerGltfExtension === 'function' &&
-                typeof glbParser.unregisterGltfExtension === 'function') {
-                glbParser.registerGltfExtension(khrGaussianSplatting);
-                this._glbContainerParsers.push(glbParser);
-            }
-        });
+        const containerHandler = app.loader.getHandler('container');
+        if (containerHandler && registerGlbResourceExtension(containerHandler, khrGaussianSplatting)) {
+            this._containerHandler = containerHandler;
+        }
 
         app.renderer.gsplatDirector = new GSplatDirector(app.graphicsDevice, app.renderer, app.scene, this);
 
@@ -276,10 +272,10 @@ class GSplatComponentSystem extends ComponentSystem {
     destroy() {
         super.destroy();
         this.app.off('framerender', this.onFrameRender, this);
-        this._glbContainerParsers.forEach((parser) => {
-            parser.unregisterGltfExtension(khrGaussianSplatting.name);
-        });
-        this._glbContainerParsers.length = 0;
+        if (this._containerHandler) {
+            unregisterGlbResourceExtension(this._containerHandler, khrGaussianSplatting.name);
+            this._containerHandler = null;
+        }
     }
 }
 

--- a/src/framework/handlers/container.js
+++ b/src/framework/handlers/container.js
@@ -1,4 +1,5 @@
 import { GlbContainerParser } from '../parsers/glb-container-parser.js';
+import { initializeGlbResourceExtensions } from '../parsers/glb-resource-extension.js';
 import { ResourceHandler } from './handler.js';
 
 /**
@@ -177,6 +178,7 @@ class ContainerHandler extends ResourceHandler {
      */
     constructor(app) {
         super(app, 'container');
+        initializeGlbResourceExtensions(this);
 
         // GLB is the only built-in container format and acts as the catch-all; users can register
         // more specific parsers (for example usdz), which are consulted first (newest-first).

--- a/src/framework/parsers/glb-animation.js
+++ b/src/framework/parsers/glb-animation.js
@@ -18,7 +18,7 @@ class GlbAnimationParser {
             if (err) {
                 callback(`Error loading animation resource: ${original} [${err}]`);
             } else {
-                GlbParser.parse('filename.glb', '', response, this.handler.device, this.handler.assets, asset?.options ?? {}, (err, parseResult) => {
+                GlbParser.parse('filename.glb', '', response, this.handler.device, this.handler.assets, asset?.options ?? {}, [], (err, parseResult) => {
                     if (err) {
                         callback(err);
                     } else {

--- a/src/framework/parsers/glb-container-parser.js
+++ b/src/framework/parsers/glb-container-parser.js
@@ -4,6 +4,8 @@ import { GlbParser } from './glb-parser.js';
 import { GlbContainerResource } from './glb-container-resource.js';
 
 class GlbContainerParser {
+    _gltfExtensions = new Map();
+
     constructor(device, assets) {
         this._device = device;
         this._assets = assets;
@@ -14,6 +16,26 @@ class GlbContainerParser {
         // GLB is the only built-in container format (it handles both .glb and .gltf); it acts as the
         // catch-all, so any container asset resolves to it unless a more specific parser is registered
         return true;
+    }
+
+    /**
+     * Registers a glTF resource extension used by this parser.
+     *
+     * @param {object} extension - The extension implementation.
+     * @ignore
+     */
+    registerGltfExtension(extension) {
+        this._gltfExtensions.set(extension.name, extension);
+    }
+
+    /**
+     * Unregisters a glTF resource extension used by this parser.
+     *
+     * @param {string} name - The glTF extension name.
+     * @ignore
+     */
+    unregisterGltfExtension(name) {
+        this._gltfExtensions.delete(name);
     }
 
     _getUrlWithoutParams(url) {
@@ -32,6 +54,7 @@ class GlbContainerParser {
                     this._device,
                     asset.registry,
                     asset.options,
+                    Array.from(this._gltfExtensions.values()),
                     (err, result) => {
                         if (err) {
                             callback(err);

--- a/src/framework/parsers/glb-container-parser.js
+++ b/src/framework/parsers/glb-container-parser.js
@@ -2,10 +2,9 @@ import { path } from '../../core/path.js';
 import { Asset } from '../../framework/asset/asset.js';
 import { GlbParser } from './glb-parser.js';
 import { GlbContainerResource } from './glb-container-resource.js';
+import { getGlbResourceExtensions } from './glb-resource-extension.js';
 
 class GlbContainerParser {
-    _gltfExtensions = new Map();
-
     constructor(device, assets) {
         this._device = device;
         this._assets = assets;
@@ -16,26 +15,6 @@ class GlbContainerParser {
         // GLB is the only built-in container format (it handles both .glb and .gltf); it acts as the
         // catch-all, so any container asset resolves to it unless a more specific parser is registered
         return true;
-    }
-
-    /**
-     * Registers a glTF resource extension used by this parser.
-     *
-     * @param {object} extension - The extension implementation.
-     * @ignore
-     */
-    registerGltfExtension(extension) {
-        this._gltfExtensions.set(extension.name, extension);
-    }
-
-    /**
-     * Unregisters a glTF resource extension used by this parser.
-     *
-     * @param {string} name - The glTF extension name.
-     * @ignore
-     */
-    unregisterGltfExtension(name) {
-        this._gltfExtensions.delete(name);
     }
 
     _getUrlWithoutParams(url) {
@@ -54,7 +33,7 @@ class GlbContainerParser {
                     this._device,
                     asset.registry,
                     asset.options,
-                    Array.from(this._gltfExtensions.values()),
+                    getGlbResourceExtensions(this.handler),
                     (err, result) => {
                         if (err) {
                             callback(err);

--- a/src/framework/parsers/glb-model.js
+++ b/src/framework/parsers/glb-model.js
@@ -24,7 +24,7 @@ class GlbModelParser {
     }
 
     parse(data, callback, asset) {
-        GlbParser.parse('filename.glb', '', data, this._device, this._assets, asset?.options ?? {}, (err, result) => {
+        GlbParser.parse('filename.glb', '', data, this._device, this._assets, asset?.options ?? {}, [], (err, result) => {
             if (err) {
                 callback(err);
             } else {

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -56,19 +56,7 @@ import { GltfAccessor, getPrimitiveType, isTriangleMode, gltfToEngineSemanticMap
 /**
  * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { Material } from '../../scene/materials/material.js'
- */
-
-/**
- * An optional glTF extension which replaces normal mesh creation for primitives it handles and
- * creates an aligned resource collection on the parse result.
- *
- * @typedef {object} GlbResourceExtension
- * @property {string} name - The glTF extension name.
- * @property {string} resourceName - Name of the property populated on {@link GlbResources}.
- * @property {(primitive: object) => boolean} handlesPrimitive - Returns true when the extension
- * handles the primitive instead of the normal mesh path.
- * @property {(device: GraphicsDevice, gltf: object, bufferViews: Uint8Array[]) => *} createResources -
- * Creates resources for all matching primitives.
+ * @import { GlbResourceExtension } from './glb-resource-extension.js'
  */
 
 // resources loaded from GLB file that the parser returns
@@ -429,10 +417,11 @@ const createSkin = (device, gltfSkin, accessors, bufferViews, nodes, glbSkins) =
 
 const createMesh = (device, gltfMesh, accessors, bufferViews, vertexBufferDict, meshVariants, meshDefaultMaterials, flatShadedMeshes, assetOptions, resourceExtensions, promises) => {
     const meshes = [];
+    const extensions = /** @type {GlbResourceExtension[]} */ (resourceExtensions);
 
     gltfMesh.primitives.forEach((primitive) => {
 
-        if (resourceExtensions.some(extension => extension.handlesPrimitive(primitive))) {
+        if (extensions.some(extension => extension.handlesPrimitive(primitive))) {
             // the registered extension creates its own resource instead of a mesh
             return;
         }
@@ -1316,7 +1305,9 @@ const createResources = async (device, gltf, bufferViews, textures, options, app
     result.cameras = cameras;
     result.nodeInstancingMap = nodeInstancingMap;
 
-    resourceExtensions.forEach((extension) => {
+    /** @type {GlbResourceExtension[]} */ (resourceExtensions).forEach((extension) => {
+        Debug.assert(!Object.hasOwn(result, extension.resourceName) || result[extension.resourceName] === undefined,
+            `GLB resource extension '${extension.name}' would overwrite '${extension.resourceName}'`);
         result[extension.resourceName] = options.skipMeshes ? [] : extension.createResources(device, gltf, bufferViewData);
     });
 

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -46,7 +46,6 @@ import { ABSOLUTE_URL } from '../asset/constants.js';
 
 import { createInstancing } from './glb/extensions/ext-mesh-gpu-instancing.js';
 import { createDracoMesh } from './glb/extensions/khr-draco-mesh-compression.js';
-import { createGSplats, hasGSplatExtension } from './glb/extensions/khr-gaussian-splatting.js';
 import { createLights } from './glb/extensions/khr-lights-punctual.js';
 import { createVariants, registerMeshVariants } from './glb/extensions/khr-materials-variants.js';
 import { getTextureSource } from './glb/extensions/texture-source.js';
@@ -55,7 +54,21 @@ import { extractTextureTransform } from './glb/extensions/khr-texture-transform.
 import { GltfAccessor, getPrimitiveType, isTriangleMode, gltfToEngineSemanticMap } from './glb/gltf-accessor.js';
 
 /**
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
  * @import { Material } from '../../scene/materials/material.js'
+ */
+
+/**
+ * An optional glTF extension which replaces normal mesh creation for primitives it handles and
+ * creates an aligned resource collection on the parse result.
+ *
+ * @typedef {object} GlbResourceExtension
+ * @property {string} name - The glTF extension name.
+ * @property {string} resourceName - Name of the property populated on {@link GlbResources}.
+ * @property {(primitive: object) => boolean} handlesPrimitive - Returns true when the extension
+ * handles the primitive instead of the normal mesh path.
+ * @property {(device: GraphicsDevice, gltf: object, bufferViews: Uint8Array[]) => *} createResources -
+ * Creates resources for all matching primitives.
  */
 
 // resources loaded from GLB file that the parser returns
@@ -414,13 +427,13 @@ const createSkin = (device, gltfSkin, accessors, bufferViews, nodes, glbSkins) =
     return skin;
 };
 
-const createMesh = (device, gltfMesh, accessors, bufferViews, vertexBufferDict, meshVariants, meshDefaultMaterials, flatShadedMeshes, assetOptions, promises) => {
+const createMesh = (device, gltfMesh, accessors, bufferViews, vertexBufferDict, meshVariants, meshDefaultMaterials, flatShadedMeshes, assetOptions, resourceExtensions, promises) => {
     const meshes = [];
 
     gltfMesh.primitives.forEach((primitive) => {
 
-        if (hasGSplatExtension(primitive)) {
-            // gaussian splat primitives are handled by createGSplats instead
+        if (resourceExtensions.some(extension => extension.handlesPrimitive(primitive))) {
+            // the registered extension creates its own resource instead of a mesh
             return;
         }
 
@@ -1003,7 +1016,7 @@ const createSkins = (device, gltf, nodes, bufferViews) => {
     });
 };
 
-const createMeshes = (device, gltf, bufferViews, options) => {
+const createMeshes = (device, gltf, bufferViews, options, resourceExtensions) => {
     // dictionary of vertex buffers to avoid duplicates
     const vertexBufferDict = {};
     const meshVariants = {};
@@ -1013,7 +1026,7 @@ const createMeshes = (device, gltf, bufferViews, options) => {
 
     const valid = (!options.skipMeshes && gltf?.meshes?.length && gltf?.accessors?.length && gltf?.bufferViews?.length);
     const meshes = valid ? gltf.meshes.map((gltfMesh) => {
-        return createMesh(device, gltfMesh, gltf.accessors, bufferViews, vertexBufferDict, meshVariants, meshDefaultMaterials, flatShadedMeshes, options, promises);
+        return createMesh(device, gltfMesh, gltf.accessors, bufferViews, vertexBufferDict, meshVariants, meshDefaultMaterials, flatShadedMeshes, options, resourceExtensions, promises);
     }) : [];
 
     return {
@@ -1235,7 +1248,7 @@ const linkSkins = (gltf, renders, skins) => {
 };
 
 // create engine resources from the downloaded GLB data
-const createResources = async (device, gltf, bufferViews, textures, options, app) => {
+const createResources = async (device, gltf, bufferViews, textures, options, app, resourceExtensions) => {
     const preprocess = options?.global?.preprocess;
     const postprocess = options?.global?.postprocess;
 
@@ -1262,8 +1275,7 @@ const createResources = async (device, gltf, bufferViews, textures, options, app
 
     // buffer data must have finished loading in order to create meshes and animations
     const bufferViewData = await Promise.all(bufferViews);
-    const { meshes, meshVariants, meshDefaultMaterials, flatShadedMeshes, promises } = createMeshes(device, gltf, bufferViewData, options);
-    const gsplats = options.skipMeshes ? [] : createGSplats(device, gltf, bufferViewData);
+    const { meshes, meshVariants, meshDefaultMaterials, flatShadedMeshes, promises } = createMeshes(device, gltf, bufferViewData, options, resourceExtensions);
     const animations = createAnimations(gltf, nodes, bufferViewData, options);
     createInstancing(device, gltf, nodeInstancingMap, bufferViewData);
 
@@ -1299,11 +1311,14 @@ const createResources = async (device, gltf, bufferViews, textures, options, app
     result.meshVariants = meshVariants;
     result.meshDefaultMaterials = meshDefaultMaterials;
     result.renders = renders;
-    result.gsplats = gsplats;
     result.skins = skins;
     result.lights = lights;
     result.cameras = cameras;
     result.nodeInstancingMap = nodeInstancingMap;
+
+    resourceExtensions.forEach((extension) => {
+        result[extension.resourceName] = options.skipMeshes ? [] : extension.createResources(device, gltf, bufferViewData);
+    });
 
     if (postprocess) {
         postprocess(gltf, result);
@@ -1826,7 +1841,7 @@ const createBufferViews = (gltf, buffers, options) => {
 
 class GlbParser {
     // parse the gltf or glb data asynchronously, loading external resources
-    static parse(filename, urlBase, data, device, registry, options, callback) {
+    static parse(filename, urlBase, data, device, registry, options, resourceExtensions, callback) {
         // parse the data
         parseChunk(filename, data, (err, chunks) => {
             if (err) {
@@ -1846,7 +1861,7 @@ class GlbParser {
                 const images = createImages(gltf, bufferViews, urlBase, registry, options);
                 const textures = createTextures(gltf, images, options);
 
-                createResources(device, gltf, bufferViews, textures, options, registry.loader._app)
+                createResources(device, gltf, bufferViews, textures, options, registry.loader._app, resourceExtensions)
                 .then(result => callback(null, result))
                 .catch(err => callback(err));
             });

--- a/src/framework/parsers/glb-parser.js
+++ b/src/framework/parsers/glb-parser.js
@@ -1306,7 +1306,7 @@ const createResources = async (device, gltf, bufferViews, textures, options, app
     result.nodeInstancingMap = nodeInstancingMap;
 
     /** @type {GlbResourceExtension[]} */ (resourceExtensions).forEach((extension) => {
-        Debug.assert(!Object.hasOwn(result, extension.resourceName) || result[extension.resourceName] === undefined,
+        Debug.assert(!(extension.resourceName in result) || result[extension.resourceName] === undefined,
             `GLB resource extension '${extension.name}' would overwrite '${extension.resourceName}'`);
         result[extension.resourceName] = options.skipMeshes ? [] : extension.createResources(device, gltf, bufferViewData);
     });

--- a/src/framework/parsers/glb-resource-extension.js
+++ b/src/framework/parsers/glb-resource-extension.js
@@ -1,0 +1,81 @@
+/**
+ * @import { GraphicsDevice } from '../../platform/graphics/graphics-device.js'
+ */
+
+/**
+ * An optional glTF extension which replaces normal mesh creation for primitives it handles and
+ * creates an aligned resource collection on the parse result.
+ *
+ * @typedef {object} GlbResourceExtension
+ * @property {string} name - The glTF extension name.
+ * @property {string} resourceName - Name of the property populated on the parsed resources.
+ * @property {(primitive: object) => boolean} handlesPrimitive - Returns true when the extension
+ * handles the primitive instead of the normal mesh path.
+ * @property {(device: GraphicsDevice, gltf: object, bufferViews: Uint8Array[]) => *} createResources -
+ * Creates resources for all matching primitives.
+ * @ignore
+ */
+
+// A symbol keeps the handler-owned registry internal while allowing parsers registered later to
+// discover it through their ResourceHandler back-reference.
+const glbResourceExtensions = Symbol('glbResourceExtensions');
+
+/**
+ * @param {object} handler - The container resource handler.
+ * @ignore
+ */
+const initializeGlbResourceExtensions = (handler) => {
+    Object.defineProperty(handler, glbResourceExtensions, {
+        value: new Map()
+    });
+};
+
+/**
+ * @param {object} handler - The container resource handler.
+ * @returns {Map<string, GlbResourceExtension>|undefined} The handler's extension registry.
+ * @ignore
+ */
+const getRegistry = (handler) => {
+    return /** @type {Map<string, GlbResourceExtension>|undefined} */ (Reflect.get(handler, glbResourceExtensions));
+};
+
+/**
+ * @param {object} handler - The container resource handler.
+ * @param {GlbResourceExtension} extension - The extension implementation.
+ * @returns {boolean} True if the handler supports glTF resource extensions.
+ * @ignore
+ */
+const registerGlbResourceExtension = (handler, extension) => {
+    const registry = getRegistry(handler);
+    if (!registry) {
+        return false;
+    }
+
+    registry.set(extension.name, extension);
+    return true;
+};
+
+/**
+ * @param {object} handler - The container resource handler.
+ * @param {string} name - The glTF extension name.
+ * @ignore
+ */
+const unregisterGlbResourceExtension = (handler, name) => {
+    getRegistry(handler)?.delete(name);
+};
+
+/**
+ * @param {object} handler - The container resource handler.
+ * @returns {GlbResourceExtension[]} The registered extensions.
+ * @ignore
+ */
+const getGlbResourceExtensions = (handler) => {
+    return Array.from(getRegistry(handler)?.values() ?? []);
+};
+
+export {
+    initializeGlbResourceExtensions,
+    registerGlbResourceExtension,
+    unregisterGlbResourceExtension,
+    getGlbResourceExtensions
+};

--- a/src/framework/parsers/glb/extensions/khr-gaussian-splatting.js
+++ b/src/framework/parsers/glb/extensions/khr-gaussian-splatting.js
@@ -170,4 +170,11 @@ const createGSplats = (device, gltf, bufferViews) => {
     });
 };
 
-export { createGSplats, hasGSplatExtension };
+const khrGaussianSplatting = {
+    name: extensionName,
+    resourceName: 'gsplats',
+    handlesPrimitive: hasGSplatExtension,
+    createResources: createGSplats
+};
+
+export { khrGaussianSplatting };

--- a/test/bundles/treeshake.test.mjs
+++ b/test/bundles/treeshake.test.mjs
@@ -59,6 +59,24 @@ describe('build / treeshake', function () {
         expect(retained, 'retained gsplat work buffer rendering modules').to.deep.equal([]);
     });
 
+    it('ContainerHandler does not retain the gsplat resource implementation', async function () {
+        const result = await bundle(`
+            import { ContainerHandler } from "playcanvas";
+            globalThis.__containerHandler = ContainerHandler;
+        `);
+
+        const output = Object.values(result.metafile.outputs)[0];
+        const inputs = Object.keys(output.inputs);
+        const retained = inputs.filter((path) => {
+            return path.includes('/scene/gsplat/') ||
+                path.includes('/scene/gsplat-unified/') ||
+                path.includes('/chunks/gsplat/') ||
+                path.endsWith('/khr-gaussian-splatting.js');
+        });
+
+        expect(retained, 'retained gsplat resource modules').to.deep.equal([]);
+    });
+
     it('deprecated shims survive tree-shaking and still apply', async function () {
         // representative shims of each kind: class members (shininess), the computed-name alias
         // and tint loops (sheenGlossiness, diffuseTint), the options forwarding loop (refraction)

--- a/test/framework/handlers/container-handler.test.mjs
+++ b/test/framework/handlers/container-handler.test.mjs
@@ -5,6 +5,11 @@ import { AppOptions } from '../../../src/framework/app-options.js';
 import { GSplatComponentSystem } from '../../../src/framework/components/gsplat/system.js';
 import { ContainerHandler } from '../../../src/framework/handlers/container.js';
 import { GlbContainerParser } from '../../../src/framework/parsers/glb-container-parser.js';
+import {
+    getGlbResourceExtensions,
+    registerGlbResourceExtension,
+    unregisterGlbResourceExtension
+} from '../../../src/framework/parsers/glb-resource-extension.js';
 import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
 import { createApp } from '../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
@@ -40,14 +45,20 @@ describe('ContainerHandler (parser selection)', function () {
     });
 
     it('registers and unregisters glTF resource extensions', function () {
-        const parser = app.loader.getHandler('container').parsers[0];
-        const extension = { name: 'TEST_extension' };
+        const handler = app.loader.getHandler('container');
+        const initialExtensions = getGlbResourceExtensions(handler);
+        const extension = {
+            name: 'TEST_extension',
+            resourceName: 'testResources',
+            handlesPrimitive: () => false,
+            createResources: () => []
+        };
 
-        parser.registerGltfExtension(extension);
-        expect(parser._gltfExtensions.get(extension.name)).to.equal(extension);
+        expect(registerGlbResourceExtension(handler, extension)).to.equal(true);
+        expect(getGlbResourceExtensions(handler)).to.deep.equal([...initialExtensions, extension]);
 
-        parser.unregisterGltfExtension(extension.name);
-        expect(parser._gltfExtensions.has(extension.name)).to.equal(false);
+        unregisterGlbResourceExtension(handler, extension.name);
+        expect(getGlbResourceExtensions(handler)).to.deep.equal(initialExtensions);
     });
 
     it('registers the Gaussian splatting extension when AppBase initializes its component system', function () {
@@ -60,12 +71,33 @@ describe('ContainerHandler (parser selection)', function () {
         const appBase = new AppBase(canvas);
         appBase.init(options);
 
-        const parser = appBase.loader.getHandler('container').parsers[0];
+        const handler = appBase.loader.getHandler('container');
         try {
-            expect(parser._gltfExtensions.has('KHR_gaussian_splatting')).to.equal(true);
+            expect(getGlbResourceExtensions(handler).map(extension => extension.name)).to.include('KHR_gaussian_splatting');
         } finally {
             appBase.destroy();
         }
-        expect(parser._gltfExtensions.has('KHR_gaussian_splatting')).to.equal(false);
+        expect(getGlbResourceExtensions(handler)).to.be.empty;
+    });
+
+    it('makes registered glTF resource extensions available to parsers added later', function () {
+        const canvas = document.createElement('canvas');
+        const options = new AppOptions();
+        options.graphicsDevice = new NullGraphicsDevice(canvas);
+        options.resourceHandlers = [ContainerHandler];
+        options.componentSystems = [GSplatComponentSystem];
+
+        const appBase = new AppBase(canvas);
+        appBase.init(options);
+
+        const handler = appBase.loader.getHandler('container');
+        const parser = new GlbContainerParser(appBase.graphicsDevice, appBase.assets);
+        handler.addParser(parser);
+
+        try {
+            expect(getGlbResourceExtensions(parser.handler).map(extension => extension.name)).to.include('KHR_gaussian_splatting');
+        } finally {
+            appBase.destroy();
+        }
     });
 });

--- a/test/framework/handlers/container-handler.test.mjs
+++ b/test/framework/handlers/container-handler.test.mjs
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
 
+import { AppBase } from '../../../src/framework/app-base.js';
+import { AppOptions } from '../../../src/framework/app-options.js';
+import { GSplatComponentSystem } from '../../../src/framework/components/gsplat/system.js';
+import { ContainerHandler } from '../../../src/framework/handlers/container.js';
 import { GlbContainerParser } from '../../../src/framework/parsers/glb-container-parser.js';
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
 import { createApp } from '../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
@@ -32,5 +37,35 @@ describe('ContainerHandler (parser selection)', function () {
         expect(select(handler, 'model.glb')).to.be.an.instanceof(GlbContainerParser);
         expect(select(handler, 'model.gltf')).to.be.an.instanceof(GlbContainerParser);
         expect(select(handler, 'model.anything')).to.be.an.instanceof(GlbContainerParser);
+    });
+
+    it('registers and unregisters glTF resource extensions', function () {
+        const parser = app.loader.getHandler('container').parsers[0];
+        const extension = { name: 'TEST_extension' };
+
+        parser.registerGltfExtension(extension);
+        expect(parser._gltfExtensions.get(extension.name)).to.equal(extension);
+
+        parser.unregisterGltfExtension(extension.name);
+        expect(parser._gltfExtensions.has(extension.name)).to.equal(false);
+    });
+
+    it('registers the Gaussian splatting extension when AppBase initializes its component system', function () {
+        const canvas = document.createElement('canvas');
+        const options = new AppOptions();
+        options.graphicsDevice = new NullGraphicsDevice(canvas);
+        options.resourceHandlers = [ContainerHandler];
+        options.componentSystems = [GSplatComponentSystem];
+
+        const appBase = new AppBase(canvas);
+        appBase.init(options);
+
+        const parser = appBase.loader.getHandler('container').parsers[0];
+        try {
+            expect(parser._gltfExtensions.has('KHR_gaussian_splatting')).to.equal(true);
+        } finally {
+            appBase.destroy();
+        }
+        expect(parser._gltfExtensions.has('KHR_gaussian_splatting')).to.equal(false);
     });
 });

--- a/test/framework/parsers/glb-parser.test.mjs
+++ b/test/framework/parsers/glb-parser.test.mjs
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { restore, stub } from 'sinon';
 
 import { GlbParser } from '../../../src/framework/parsers/glb-parser.js';
 import { createApp } from '../../app.mjs';
@@ -14,6 +15,7 @@ describe('GlbParser', function () {
     });
 
     afterEach(function () {
+        restore();
         app?.destroy();
         app = null;
         jsdomTeardown();
@@ -246,6 +248,23 @@ describe('GlbParser', function () {
 
             expect(result.renders[0].meshes).to.be.empty;
             expect(result.testResources).to.deep.equal([[resource]]);
+        });
+
+        it('asserts when a resource extension overwrites a core parse result', async function () {
+            const error = stub(console, 'error');
+            const extension = {
+                name: 'TEST_collision',
+                resourceName: 'renders',
+                handlesPrimitive: () => false,
+                createResources: () => []
+            };
+
+            await parsePrimitive({ resourceExtensions: [extension] });
+
+            expect(error.calledWith(
+                'ASSERT FAILED: ',
+                'GLB resource extension \'TEST_collision\' would overwrite \'renders\''
+            )).to.equal(true);
         });
 
         it('builds a flat shaded default material for a primitive with no material of its own', async function () {

--- a/test/framework/parsers/glb-parser.test.mjs
+++ b/test/framework/parsers/glb-parser.test.mjs
@@ -250,11 +250,11 @@ describe('GlbParser', function () {
             expect(result.testResources).to.deep.equal([[resource]]);
         });
 
-        it('asserts when a resource extension overwrites a core parse result', async function () {
+        it('asserts when a resource extension overwrites a core parse result member', async function () {
             const error = stub(console, 'error');
             const extension = {
                 name: 'TEST_collision',
-                resourceName: 'renders',
+                resourceName: 'destroy',
                 handlesPrimitive: () => false,
                 createResources: () => []
             };
@@ -263,7 +263,7 @@ describe('GlbParser', function () {
 
             expect(error.calledWith(
                 'ASSERT FAILED: ',
-                'GLB resource extension \'TEST_collision\' would overwrite \'renders\''
+                'GLB resource extension \'TEST_collision\' would overwrite \'destroy\''
             )).to.equal(true);
         });
 

--- a/test/framework/parsers/glb-parser.test.mjs
+++ b/test/framework/parsers/glb-parser.test.mjs
@@ -29,7 +29,7 @@ describe('GlbParser', function () {
         const data = new TextEncoder().encode(JSON.stringify(gltf));
 
         return new Promise((resolve, reject) => {
-            GlbParser.parse('material.gltf', '', data, app.graphicsDevice, app.assets, {}, (err, result) => {
+            GlbParser.parse('material.gltf', '', data, app.graphicsDevice, app.assets, {}, [], (err, result) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -91,7 +91,7 @@ describe('GlbParser', function () {
 
         try {
             const result = await new Promise((resolve, reject) => {
-                GlbParser.parse('components.gltf', '', data, app.graphicsDevice, app.assets, {}, (err, result) => {
+                GlbParser.parse('components.gltf', '', data, app.graphicsDevice, app.assets, {}, [], (err, result) => {
                     if (err) reject(err);
                     else resolve(result);
                 });
@@ -134,9 +134,12 @@ describe('GlbParser', function () {
          * the glTF default.
          * @param {boolean} [options.material] - False to leave the primitive without a material of its
          * own. Defaults to true.
+         * @param {object} [options.extensions] - Extensions placed on the primitive.
+         * @param {object[]} [options.resourceExtensions] - Resource extensions registered with the
+         * parser.
          * @returns {Promise<object>} The parse result.
          */
-        const parsePrimitive = ({ normals = false, mode, material = true } = {}) => {
+        const parsePrimitive = ({ normals = false, mode, material = true, extensions, resourceExtensions = [] } = {}) => {
             const primitive = {
                 attributes: normals ? { POSITION: 0, NORMAL: 1 } : { POSITION: 0 },
                 indices: 2
@@ -146,6 +149,9 @@ describe('GlbParser', function () {
             }
             if (mode !== undefined) {
                 primitive.mode = mode;
+            }
+            if (extensions) {
+                primitive.extensions = extensions;
             }
 
             const gltf = {
@@ -169,7 +175,7 @@ describe('GlbParser', function () {
             const data = new TextEncoder().encode(JSON.stringify(gltf));
 
             return new Promise((resolve, reject) => {
-                GlbParser.parse('primitive.gltf', '', data, app.graphicsDevice, app.assets, {}, (err, result) => {
+                GlbParser.parse('primitive.gltf', '', data, app.graphicsDevice, app.assets, {}, resourceExtensions, (err, result) => {
                     if (err) reject(err);
                     else resolve(result);
                 });
@@ -212,6 +218,34 @@ describe('GlbParser', function () {
 
             expect(result.materials.length).to.equal(1);
             expect(result.materials[0].flatShading).to.equal(false);
+        });
+
+        it('uses the point mesh fallback when a primitive resource extension is not registered', async function () {
+            const result = await parsePrimitive({
+                mode: MODE_POINTS,
+                extensions: { TEST_points: {} }
+            });
+
+            expect(result.renders[0].meshes).to.have.lengthOf(1);
+            expect(result.testResources).to.be.undefined;
+        });
+
+        it('uses a registered primitive resource extension instead of the point mesh fallback', async function () {
+            const resource = {};
+            const extension = {
+                name: 'TEST_points',
+                resourceName: 'testResources',
+                handlesPrimitive: primitive => !!primitive.extensions?.TEST_points,
+                createResources: () => [[resource]]
+            };
+            const result = await parsePrimitive({
+                mode: MODE_POINTS,
+                extensions: { TEST_points: {} },
+                resourceExtensions: [extension]
+            });
+
+            expect(result.renders[0].meshes).to.be.empty;
+            expect(result.testResources).to.deep.equal([[resource]]);
         });
 
         it('builds a flat shaded default material for a primitive with no material of its own', async function () {


### PR DESCRIPTION
Register KHR_gaussian_splatting only when GSplatComponentSystem is included, so applications that omit the system no longer retain Gaussian splatting resource code.

**Changes:**
- Register Gaussian splatting GLB support during GSplatComponentSystem initialization.
- Unregister the extension when the component system is destroyed.
- Preserve point-mesh fallback behavior when Gaussian splatting support is absent.
- Add coverage for extension registration and bundle tree-shaking.

**Performance:**
- Allows the GLB container path to tree-shake Gaussian splatting resource code when GSplatComponentSystem is omitted.