### PR TITLE
Make GSplat scene parameters tree-shakeable

### DIFF
--- a/src/extras/render-passes/frame-pass-camera-frame.js
+++ b/src/extras/render-passes/frame-pass-camera-frame.js
@@ -258,7 +258,7 @@ class FramePassCameraFrame extends FramePass {
             options.volumetricFogEnabled || options.ssaoType === SSAOTYPE_COMBINE;
 
         const inSceneDepth = this.needsInSceneDepth(options);
-        const splatDepth = this.app.scene.gsplat.sceneDepthWrite;
+        const splatDepth = this.app.scene.gsplat?.sceneDepthWrite ?? false;
         const deviceSupported = FramePassCameraFrame.isSceneTextureDepthSupported(this.device);
         const unsupportedReason = this.sceneTexturesUnsupportedReason(options);
 

--- a/src/extras/render-passes/frame-pass-camera-frame.js
+++ b/src/extras/render-passes/frame-pass-camera-frame.js
@@ -258,7 +258,7 @@ class FramePassCameraFrame extends FramePass {
             options.volumetricFogEnabled || options.ssaoType === SSAOTYPE_COMBINE;
 
         const inSceneDepth = this.needsInSceneDepth(options);
-        const splatDepth = this.app.scene.gsplat?.sceneDepthWrite ?? false;
+        const splatDepth = this.app.scene.getGsplatParams()?.sceneDepthWrite ?? false;
         const deviceSupported = FramePassCameraFrame.isSceneTextureDepthSupported(this.device);
         const unsupportedReason = this.sceneTexturesUnsupportedReason(options);
 

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -2,6 +2,7 @@ import { Debug } from '../../../core/debug.js';
 import { Vec3 } from '../../../core/math/vec3.js';
 import { BoundingBox } from '../../../core/shape/bounding-box.js';
 import { GSplatDirector } from '../../../scene/gsplat-unified/gsplat-director.js';
+import { GSplatParams } from '../../../scene/gsplat-unified/gsplat-params.js';
 import { ComponentSystem } from '../system.js';
 import { GSplatComponent } from './component.js';
 import { gsplatChunksGLSL } from '../../../scene/shader-lib/glsl/collections/gsplat-chunks-glsl.js';
@@ -167,7 +168,11 @@ class GSplatComponentSystem extends ComponentSystem {
             this._containerHandler = containerHandler;
         }
 
-        app.renderer.gsplatDirector = new GSplatDirector(app.graphicsDevice, app.renderer, app.scene, this);
+        // Own the scene-wide parameters here so apps that omit this system also tree-shake the
+        // GSplat formats, varyings and shader chunks imported by GSplatParams.
+        const gsplatParams = new GSplatParams(app.graphicsDevice);
+        app.scene._gsplatParams = gsplatParams;
+        app.renderer.gsplatDirector = new GSplatDirector(app.graphicsDevice, app.renderer, app.scene, this, gsplatParams);
 
         // register gsplat shader chunks
         ShaderChunks.get(app.graphicsDevice, SHADERLANGUAGE_GLSL).add(gsplatChunksGLSL);
@@ -272,6 +277,9 @@ class GSplatComponentSystem extends ComponentSystem {
     destroy() {
         super.destroy();
         this.app.off('framerender', this.onFrameRender, this);
+        this.app.renderer.gsplatDirector?.destroy();
+        this.app.renderer.gsplatDirector = null;
+        this.app.scene._gsplatParams = null;
         if (this._containerHandler) {
             unregisterGlbResourceExtension(this._containerHandler, khrGaussianSplatting.name);
             this._containerHandler = null;

--- a/src/framework/components/gsplat/system.js
+++ b/src/framework/components/gsplat/system.js
@@ -171,7 +171,7 @@ class GSplatComponentSystem extends ComponentSystem {
         // Own the scene-wide parameters here so apps that omit this system also tree-shake the
         // GSplat formats, varyings and shader chunks imported by GSplatParams.
         const gsplatParams = new GSplatParams(app.graphicsDevice);
-        app.scene._gsplatParams = gsplatParams;
+        app.scene.setGsplatParams(gsplatParams);
         app.renderer.gsplatDirector = new GSplatDirector(app.graphicsDevice, app.renderer, app.scene, this, gsplatParams);
 
         // register gsplat shader chunks
@@ -279,7 +279,7 @@ class GSplatComponentSystem extends ComponentSystem {
         this.app.off('framerender', this.onFrameRender, this);
         this.app.renderer.gsplatDirector?.destroy();
         this.app.renderer.gsplatDirector = null;
-        this.app.scene._gsplatParams = null;
+        this.app.scene.setGsplatParams(null);
         if (this._containerHandler) {
             unregisterGlbResourceExtension(this._containerHandler, khrGaussianSplatting.name);
             this._containerHandler = null;

--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -173,7 +173,7 @@ class RenderPassPicker extends RenderPass {
             // Process gsplat placements when ID is enabled
             // The gsplat unified mesh instance is already handled above (added to layer.meshInstances)
             // Here we just need to add the placement ID -> component mapping
-            if (scene.gsplat.enableIds) {
+            if (scene.gsplat?.enableIds) {
                 const placements = srcLayer.gsplatPlacements;
                 for (let j = 0; j < placements.length; j++) {
                     const placement = placements[j];

--- a/src/framework/graphics/render-pass-picker.js
+++ b/src/framework/graphics/render-pass-picker.js
@@ -173,7 +173,7 @@ class RenderPassPicker extends RenderPass {
             // Process gsplat placements when ID is enabled
             // The gsplat unified mesh instance is already handled above (added to layer.meshInstances)
             // Here we just need to add the placement ID -> component mapping
-            if (scene.gsplat?.enableIds) {
+            if (scene.getGsplatParams()?.enableIds) {
                 const placements = srcLayer.gsplatPlacements;
                 for (let j = 0; j < placements.length; j++) {
                     const placement = placements[j];

--- a/src/scene/gsplat-unified/gsplat-director.js
+++ b/src/scene/gsplat-unified/gsplat-director.js
@@ -12,6 +12,7 @@ import { GSplatResourceCleanup } from '../gsplat/gsplat-resource-cleanup.js';
  * @import { Scene } from '../scene.js'
  * @import { Renderer } from '../renderer/renderer.js'
  * @import { EventHandler } from '../../core/event-handler.js'
+ * @import { GSplatParams } from './gsplat-params.js'
  */
 
 const tempLayersToRemove = [];
@@ -183,6 +184,11 @@ class GSplatDirector {
     scene;
 
     /**
+     * @type {GSplatParams}
+     */
+    gsplat;
+
+    /**
      * @type {EventHandler}
      */
     eventHandler;
@@ -208,12 +214,14 @@ class GSplatDirector {
      * @param {Renderer} renderer - The renderer.
      * @param {Scene} scene - The scene.
      * @param {EventHandler} eventHandler - Event handler for firing events.
+     * @param {GSplatParams} gsplat - The GSplat parameters.
      */
-    constructor(device, renderer, scene, eventHandler) {
+    constructor(device, renderer, scene, eventHandler, gsplat) {
         this.device = device;
         this.renderer = renderer;
         this.scene = scene;
         this.eventHandler = eventHandler;
+        this.gsplat = gsplat;
     }
 
     destroy() {
@@ -266,7 +274,7 @@ class GSplatDirector {
     updateStreaming() {
 
         // apply pending gsplat params changes (e.g. varying streams) before the world reads them
-        this.scene.gsplat.frameUpdate();
+        this.gsplat.frameUpdate();
 
         // process any pending resource destructions
         GSplatResourceCleanup.process(this.device);
@@ -301,7 +309,7 @@ class GSplatDirector {
         // setup. Material changes are tracked independently by each renderer using the material's
         // update version, so they do not need to be cleared here.
         if (streamed) {
-            this.scene.gsplat.dirty = false;
+            this.gsplat.dirty = false;
         }
 
         // request a render when streaming advanced, or a CPU sort result is waiting to be applied
@@ -422,7 +430,7 @@ class GSplatDirector {
             (bufferCopyUploaded / bufferCopyTotal * 100) : 0;
 
         // clear dirty flags
-        this.scene.gsplat.frameEnd();
+        this.gsplat.frameEnd();
 
         // clear dirty flags on all layers of the composition
         for (let i = 0; i < comp.layerList.length; i++) {

--- a/src/scene/gsplat-unified/gsplat-manager.js
+++ b/src/scene/gsplat-unified/gsplat-manager.js
@@ -27,6 +27,7 @@ import { Color } from '../../core/math/color.js';
  * @import { GSplatDirector } from './gsplat-director.js'
  * @import { GSplatRenderer } from './gsplat-renderer.js'
  * @import { GSplatRenderViewParams } from './gsplat-renderer.js'
+ * @import { GSplatParams } from './gsplat-params.js'
  */
 
 const cameraPosition = new Vec3();
@@ -77,6 +78,9 @@ class GSplatManager {
      * @type {GSplatWorld}
      */
     world;
+
+    /** @type {GSplatParams} */
+    gsplat;
 
     /** @type {GSplatRenderer} */
     renderer;
@@ -217,15 +221,16 @@ class GSplatManager {
     constructor(device, director, layer, cameraNode) {
         this.device = device;
         this.scene = director.scene;
+        this.gsplat = director.gsplat;
         this.director = director;
         this.cameraNode = cameraNode;
 
         // The world owns the work buffer + allocator + streaming + LOD. Create it before the
         // renderer, which reads world.workBuffer in _createRenderer.
-        this.world = new GSplatWorld(device, this.scene);
+        this.world = new GSplatWorld(device, this.scene, this.gsplat);
 
         this.layer = layer;
-        this._createRenderer(this.scene.gsplat.currentRenderer);
+        this._createRenderer(this.gsplat.currentRenderer);
 
         // On a graphics context restore the work buffer render target comes back blank (its
         // contents are GPU-rendered, not re-uploaded from CPU like source textures), so the splats
@@ -364,7 +369,7 @@ class GSplatManager {
      * @private
      */
     _writeGsplatParams(p) {
-        const gsplat = this.scene.gsplat;
+        const gsplat = this.gsplat;
         p.radialSorting = gsplat.radialSorting;
         p.alphaClip = gsplat.alphaClip;
         p.alphaClipForward = gsplat.alphaClipForward;
@@ -491,7 +496,7 @@ class GSplatManager {
      * @private
      */
     prepareRendererMode() {
-        const requested = this.scene.gsplat.currentRenderer;
+        const requested = this.gsplat.currentRenderer;
         if (requested === this.activeRenderer) return;
 
         // CPU raster sort vs GPU paths differ on which placements need centers; force a full
@@ -567,7 +572,7 @@ class GSplatManager {
     testCameraMovedForSort() {
         const epsilon = 0.001;
 
-        if (this.scene.gsplat.radialSorting) {
+        if (this.gsplat.radialSorting) {
             // For radial sorting, only position changes matter
             const currentCameraPos = this.cameraNode.getPosition();
             return this.lastSortCameraPos.distance(currentCameraPos) > epsilon;
@@ -626,7 +631,7 @@ class GSplatManager {
 
         // World LOD / streaming / world-state creation.
         this.world.update(this.cameraNode, allowLodUpdate, !!this.cpuSorter, this._updateResult);
-        if (this._updateResult.overdrawDirty) this.renderer.updateOverdrawMode(this.scene.gsplat);
+        if (this._updateResult.overdrawDirty) this.renderer.updateOverdrawMode(this.gsplat);
         if (this._updateResult.sortNeeded) this.sortNeeded = true;
         if (this._updateResult.newVersion) this._feedCpuSorterCenters();
 
@@ -665,7 +670,7 @@ class GSplatManager {
 
             // debug render world space bounds for all splats
             Debug.call(() => {
-                if (this.scene.gsplat.debug === GSPLAT_DEBUG_AABBS) {
+                if (this.gsplat.debug === GSPLAT_DEBUG_AABBS) {
                     const tempAabb = new BoundingBox();
                     const scene = this.scene;
                     lastState.splats.forEach((splat) => {
@@ -748,14 +753,14 @@ class GSplatManager {
         this.fireFrameReadyEvent();
 
         // If event listeners dirtied params (e.g. changed LOD range), ensure LOD is re-evaluated
-        if (this.scene.gsplat.dirty) {
+        if (this.gsplat.dirty) {
             this.world.markInstancesNeedLodUpdate();
         }
 
         // Renderer per-frame update (material syncing, deferred setup). Must run after
         // fireFrameReadyEvent(): listeners may change material state (e.g. antiAlias), and
         // syncing here applies it this same frame before frameEnd() clears the dirty flag.
-        this.renderer.frameUpdate(this.scene.gsplat);
+        this.renderer.frameUpdate(this.gsplat);
 
         // return the number of active splats for stats
         const sortedState = this.world.getState(this.world.currentVersion);
@@ -769,7 +774,7 @@ class GSplatManager {
      * manager has a {@link shadowRenderer} (GPU-sort forward path with a shadow render mode).
      */
     updateShadows() {
-        this.shadowRenderer?.cull(this.scene.gsplat);
+        this.shadowRenderer?.cull(this.gsplat);
     }
 
     /**
@@ -816,7 +821,7 @@ class GSplatManager {
         cameraMat.getTranslation(cameraPosition);
         cameraMat.getZ(cameraDirection).normalize();
 
-        const radialSort = this.scene.gsplat.radialSorting;
+        const radialSort = this.gsplat.radialSorting;
 
         const sorterRequest = [];
         lastState.splats.forEach((splat) => {

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -996,7 +996,7 @@ class GSplatOctreeInstance {
     // debug render world space bounds for octree nodes based on current LOD selection
     debugRender(scene) {
         Debug.call(() => {
-            if (scene.gsplat?.debug === GSPLAT_DEBUG_NODE_AABBS) {
+            if (scene.gsplat.debug === GSPLAT_DEBUG_NODE_AABBS) {
                 const modelMat = this.placement.node.getWorldTransform();
                 const nodes = this.octree.nodes;
                 for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {

--- a/src/scene/gsplat-unified/gsplat-octree-instance.js
+++ b/src/scene/gsplat-unified/gsplat-octree-instance.js
@@ -996,7 +996,7 @@ class GSplatOctreeInstance {
     // debug render world space bounds for octree nodes based on current LOD selection
     debugRender(scene) {
         Debug.call(() => {
-            if (scene.gsplat.debug === GSPLAT_DEBUG_NODE_AABBS) {
+            if (scene.gsplat?.debug === GSPLAT_DEBUG_NODE_AABBS) {
                 const modelMat = this.placement.node.getWorldTransform();
                 const nodes = this.octree.nodes;
                 for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {

--- a/src/scene/gsplat-unified/gsplat-world.js
+++ b/src/scene/gsplat-unified/gsplat-world.js
@@ -21,6 +21,7 @@ import { SPLAT_BUDGET_DEFAULT } from './constants.js';
  * @import { GSplatResourceBase } from '../gsplat/gsplat-resource-base.js'
  * @import { Scene } from '../scene.js'
  * @import { MemBlock } from '../../core/block-allocator.js'
+ * @import { GSplatParams } from './gsplat-params.js'
  */
 
 // Module-scope scratch (stateless)
@@ -68,6 +69,9 @@ const ALLOCATOR_GROW_MULTIPLIER = 1.15;
  * @ignore
  */
 class GSplatWorld {
+    /** @type {GSplatParams} */
+    _gsplat;
+
     /** @type {GraphicsDevice} */
     _device;
 
@@ -172,15 +176,17 @@ class GSplatWorld {
     /**
      * @param {GraphicsDevice} device - The graphics device.
      * @param {Scene} scene - The scene.
+     * @param {GSplatParams} gsplat - The GSplat parameters.
      */
-    constructor(device, scene) {
+    constructor(device, scene, gsplat) {
         this._device = device;
         this._scene = scene;
+        this._gsplat = gsplat;
 
-        const budget = scene.gsplat.splatBudget;
+        const budget = gsplat.splatBudget;
         this._allocator = new BlockAllocator(budget > 0 ? Math.ceil(budget * ALLOCATOR_GROW_MULTIPLIER) : 0, ALLOCATOR_GROW_MULTIPLIER);
 
-        this._workBuffer = new GSplatWorkBuffer(device, scene.gsplat.format);
+        this._workBuffer = new GSplatWorkBuffer(device, gsplat.format);
         this._workBufferFormatVersion = this._workBuffer.format.extraStreamsVersion;
     }
 
@@ -339,7 +345,7 @@ class GSplatWorld {
         result.sortNeeded = false;
 
         // wholesale format-object swap (e.g. dataFormat changed): recreate the work buffer
-        const currentFormat = this._scene.gsplat.format;
+        const currentFormat = this._gsplat.format;
         if (this._workBuffer.format !== currentFormat) {
             this._workBuffer.destroy();
             this._workBuffer = new GSplatWorkBuffer(this._device, currentFormat);
@@ -504,7 +510,7 @@ class GSplatWorld {
             });
 
             // check if any octree instances have moved enough to require LOD update
-            const threshold = this._scene.gsplat.lodUpdateDistance;
+            const threshold = this._gsplat.lodUpdateDistance;
             for (const [, inst] of this._octreeInstances) {
                 const moved = inst.testMoved(threshold);
                 anyOctreeMoved ||= moved;
@@ -523,7 +529,7 @@ class GSplatWorld {
         });
 
         // if parameters are dirty, rebuild world state
-        if (this._scene.gsplat.dirty) {
+        if (this._gsplat.dirty) {
             this._layerPlacementsDirty = true;
             result.overdrawDirty = true;
 
@@ -540,7 +546,7 @@ class GSplatWorld {
         }
 
         // when camera or octree need LOD evaluated, or params are dirty, or resources completed, or new instances added
-        if (cameraMovedOrRotatedForLod || anyOctreeMoved || this._scene.gsplat.dirty || anyInstanceNeedsLodUpdate || hasNewInstances) {
+        if (cameraMovedOrRotatedForLod || anyOctreeMoved || this._gsplat.dirty || anyInstanceNeedsLodUpdate || hasNewInstances) {
 
             // update the previous position where LOD was evaluated for octree instances
             for (const [, inst] of this._octreeInstances) {
@@ -556,7 +562,7 @@ class GSplatWorld {
             // resolves to every node at its finest level, so there is no separate unbudgeted path -
             // which also means a non-positive budget is not a way to disable LOD selection, it would
             // simply pin every node to its coarsest level. Substitute the default and say so.
-            let budget = this._scene.gsplat.splatBudget;
+            let budget = this._gsplat.splatBudget;
             if (budget <= 0) {
                 Debug.warnOnce(`GSplatParams#splatBudget is ${budget}, which is not a way to disable LOD selection - LOD levels are always chosen to fit the budget, so a non-positive one would render everything at its coarsest level. Using the default of ${SPLAT_BUDGET_DEFAULT} instead; set a budget that suits the scene.`);
                 budget = SPLAT_BUDGET_DEFAULT;
@@ -849,7 +855,7 @@ class GSplatWorld {
 
         // apply pending file-release requests
         if (worldState.pendingReleases && worldState.pendingReleases.length) {
-            const cooldownTicks = this._scene.gsplat.cooldownTicks;
+            const cooldownTicks = this._gsplat.cooldownTicks;
             for (const [octree, fileIndex] of worldState.pendingReleases) {
                 // decrement once for each staged release; refcount system guards against premature unload
                 octree.decRefCount(fileIndex, cooldownTicks);
@@ -925,7 +931,7 @@ class GSplatWorld {
      */
     applyWorkBufferUpdates(state, camera) {
         // color update thresholds
-        const { colorUpdateAngle } = this._scene.gsplat;
+        const { colorUpdateAngle } = this._gsplat;
         const ratio = Math.tan(colorUpdateAngle * math.DEG_TO_RAD);
         const cameraPos = camera.getPosition();
 
@@ -1022,7 +1028,7 @@ class GSplatWorld {
     testCameraMovedForLod(camera) {
 
         // distance-based movement check
-        const distanceThreshold = this._scene.gsplat.lodUpdateDistance;
+        const distanceThreshold = this._gsplat.lodUpdateDistance;
         const currentCameraPos = camera.getPosition();
         const cameraMoved = this._lastLodCameraPos.distance(currentCameraPos) > distanceThreshold;
         if (cameraMoved) {
@@ -1031,7 +1037,7 @@ class GSplatWorld {
 
         // rotation-based movement check (optional)
         let cameraRotated = false;
-        const lodUpdateAngleDeg = this._scene.gsplat.lodUpdateAngle;
+        const lodUpdateAngleDeg = this._gsplat.lodUpdateAngle;
         if (lodUpdateAngleDeg > 0) {
             if (Number.isFinite(this._lastLodCameraFwd.x)) {
                 const currentCameraFwd = camera.forward;
@@ -1068,7 +1074,7 @@ class GSplatWorld {
      * @returns {Array<number[]>|undefined} Color array for debug visualization, or undefined for normal rendering.
      */
     getDebugColors() {
-        const debug = this._scene.gsplat.debug;
+        const debug = this._gsplat.debug;
         if (debug === GSPLAT_DEBUG_SH_UPDATE) {
             _randomColorRaw ??= [];
             const r = Math.random();
@@ -1135,8 +1141,8 @@ class GSplatWorld {
         // Phase 1: resolve each instance's LOD range and evaluate per-node coverage, and collect
         // padding for active placements
         for (const [, inst] of this._octreeInstances) {
-            inst.resolveLodRange(this._scene.gsplat.lodMode);
-            inst.evaluateNodeCoverage(camera, this._scene.gsplat);
+            inst.resolveLodRange(this._gsplat.lodMode);
+            inst.evaluateNodeCoverage(camera, this._gsplat);
             for (const placement of inst.activePlacements) {
                 const resource = /** @type {GSplatResourceBase} */ (placement.resource);
                 const numSplats = resource?.numSplats ?? 0;
@@ -1152,7 +1158,7 @@ class GSplatWorld {
 
         // Phase 3: apply LOD changes
         for (const [, inst] of this._octreeInstances) {
-            inst.applyLodChanges(this._scene.gsplat);
+            inst.applyLodChanges(this._gsplat);
         }
     }
 
@@ -1199,7 +1205,7 @@ class GSplatWorld {
      */
     tickCooldowns() {
         if (this._octreeInstances.size) {
-            const cooldownTicks = this._scene.gsplat.cooldownTicks;
+            const cooldownTicks = this._gsplat.cooldownTicks;
             for (const [, inst] of this._octreeInstances) {
                 const octree = inst.octree;
                 if (!tempOctreesTicked.has(octree)) {

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -289,9 +289,6 @@ class Renderer {
 
         this.lightTextureAtlas.destroy();
         this.lightTextureAtlas = null;
-
-        this.gsplatDirector?.destroy();
-        this.gsplatDirector = null;
     }
 
     /**

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -333,7 +333,10 @@ class Scene extends EventHandler {
         this.gsplatCentersEnabled = true;
 
         // gsplat params are initialized by GSplatComponentSystem when it is included in the app
-        /** @type {GSplatParams|null} */
+        /**
+         * @type {GSplatParams|null}
+         * @ignore
+         */
         this._gsplatParams = null;
 
         // skybox
@@ -524,12 +527,31 @@ class Scene extends EventHandler {
     /**
      * Gets the GSplat parameters.
      *
-     * Returns null when the application does not include {@link GSplatComponentSystem}.
-     *
-     * @type {GSplatParams|null}
+     * @type {GSplatParams}
      */
     get gsplat() {
+        Debug.assert(this._gsplatParams, 'Scene#gsplat requires GSplatComponentSystem to be included in the app.');
+        return /** @type {GSplatParams} */ (this._gsplatParams);
+    }
+
+    /**
+     * Gets the GSplat parameters, or null when GSplatComponentSystem is not included in the app.
+     *
+     * @returns {GSplatParams|null} The GSplat parameters.
+     * @ignore
+     */
+    getGsplatParams() {
         return this._gsplatParams;
+    }
+
+    /**
+     * Sets the GSplat parameters owned by GSplatComponentSystem.
+     *
+     * @param {GSplatParams|null} value - The GSplat parameters.
+     * @ignore
+     */
+    setGsplatParams(value) {
+        this._gsplatParams = value;
     }
 
     /**
@@ -824,7 +846,7 @@ class Scene extends EventHandler {
         this.clusteredLightingEnabled = render.clusteredLightingEnabled ?? false;
         this.lighting.applySettings(render);
 
-        this.gsplat?.applySettings(render);
+        this.getGsplatParams()?.applySettings(render);
 
         // bake settings
         [

--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -9,7 +9,6 @@ import { Mat4 } from '../core/math/mat4.js';
 import { PIXELFORMAT_RGBA8, ADDRESS_CLAMP_TO_EDGE, FILTER_LINEAR } from '../platform/graphics/constants.js';
 import { BAKE_COLORDIR, LAYERID_IMMEDIATE } from './constants.js';
 import { LightingParams } from './lighting/lighting-params.js';
-import { GSplatParams } from './gsplat-unified/gsplat-params.js';
 import { Sky } from './skybox/sky.js';
 import { Immediate } from './immediate/immediate.js';
 import { EnvLighting } from './graphics/env-lighting.js';
@@ -22,6 +21,7 @@ import { getDefaultMaterial } from './materials/default-material.js';
  * @import { LayerComposition } from './composition/layer-composition.js'
  * @import { Layer } from './layer.js'
  * @import { Texture } from '../platform/graphics/texture.js'
+ * @import { GSplatParams } from './gsplat-unified/gsplat-params.js'
  */
 
 /**
@@ -332,8 +332,9 @@ class Scene extends EventHandler {
          */
         this.gsplatCentersEnabled = true;
 
-        // gsplat params
-        this._gsplatParams = new GSplatParams(this.device);
+        // gsplat params are initialized by GSplatComponentSystem when it is included in the app
+        /** @type {GSplatParams|null} */
+        this._gsplatParams = null;
 
         // skybox
         this._sky = new Sky(this);
@@ -523,7 +524,9 @@ class Scene extends EventHandler {
     /**
      * Gets the GSplat parameters.
      *
-     * @type {GSplatParams}
+     * Returns null when the application does not include {@link GSplatComponentSystem}.
+     *
+     * @type {GSplatParams|null}
      */
     get gsplat() {
         return this._gsplatParams;
@@ -821,7 +824,7 @@ class Scene extends EventHandler {
         this.clusteredLightingEnabled = render.clusteredLightingEnabled ?? false;
         this.lighting.applySettings(render);
 
-        this.gsplat.applySettings(render);
+        this.gsplat?.applySettings(render);
 
         // bake settings
         [

--- a/test/bundles/treeshake.test.mjs
+++ b/test/bundles/treeshake.test.mjs
@@ -41,7 +41,7 @@ describe('build / treeshake', function () {
         expect(bytes, 'bundle size').to.be.lessThan(10240);
     });
 
-    it('AppBase with container loading does not retain gsplat work buffer rendering', async function () {
+    it('AppBase with container loading does not retain the gsplat implementation', async function () {
         const result = await bundle(`
             import { AppBase, ContainerHandler } from "playcanvas";
             globalThis.__appBaseImports = { AppBase, ContainerHandler };
@@ -49,14 +49,13 @@ describe('build / treeshake', function () {
 
         const output = Object.values(result.metafile.outputs)[0];
         const inputs = Object.keys(output.inputs);
-        const retained = inputs.filter((path) => {
-            return path.endsWith('/gsplat-work-buffer.js') ||
-                path.endsWith('/gsplat-work-buffer-render-pass.js') ||
-                path.endsWith('/gsplatCopyToWorkbuffer.js') ||
-                path.endsWith('/gsplatCopyInstancedQuad.js');
-        });
+        const retained = inputs.filter(path => path.includes('/scene/gsplat/') ||
+            path.includes('/scene/gsplat-unified/') ||
+            path.includes('/chunks/gsplat/') ||
+            path.includes('/gsplat-chunks-') ||
+            path.endsWith('/khr-gaussian-splatting.js'));
 
-        expect(retained, 'retained gsplat work buffer rendering modules').to.deep.equal([]);
+        expect(retained, 'retained gsplat implementation modules').to.deep.equal([]);
     });
 
     it('ContainerHandler does not retain the gsplat resource implementation', async function () {

--- a/test/framework/components/gsplat/system.test.mjs
+++ b/test/framework/components/gsplat/system.test.mjs
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+
+import { AppBase } from '../../../../src/framework/app-base.js';
+import { AppOptions } from '../../../../src/framework/app-options.js';
+import { GSplatComponentSystem } from '../../../../src/framework/components/gsplat/system.js';
+import { NullGraphicsDevice } from '../../../../src/platform/graphics/null/null-graphics-device.js';
+import { GSplatParams } from '../../../../src/scene/gsplat-unified/gsplat-params.js';
+import { jsdomSetup, jsdomTeardown } from '../../../jsdom.mjs';
+
+describe('GSplatComponentSystem', function () {
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    const createApp = (componentSystems) => {
+        const canvas = document.createElement('canvas');
+        const options = new AppOptions();
+        options.graphicsDevice = new NullGraphicsDevice(canvas);
+        options.resourceHandlers = [];
+        options.componentSystems = componentSystems;
+
+        app = new AppBase(canvas);
+        app.init(options);
+    };
+
+    it('leaves scene GSplat parameters uninitialized when the system is omitted', function () {
+        createApp([]);
+
+        expect(app.scene.gsplat).to.equal(null);
+    });
+
+    it('owns the scene GSplat parameters for its lifetime', function () {
+        createApp([GSplatComponentSystem]);
+
+        expect(app.scene.gsplat).to.be.an.instanceof(GSplatParams);
+
+        app.systems.gsplat.destroy();
+
+        expect(app.scene.gsplat).to.equal(null);
+    });
+});

--- a/test/framework/components/gsplat/system.test.mjs
+++ b/test/framework/components/gsplat/system.test.mjs
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { restore, stub } from 'sinon';
 
 import { AppBase } from '../../../../src/framework/app-base.js';
 import { AppOptions } from '../../../../src/framework/app-options.js';
@@ -18,6 +19,7 @@ describe('GSplatComponentSystem', function () {
         app?.destroy();
         app = null;
         jsdomTeardown();
+        restore();
     });
 
     const createApp = (componentSystems) => {
@@ -34,16 +36,29 @@ describe('GSplatComponentSystem', function () {
     it('leaves scene GSplat parameters uninitialized when the system is omitted', function () {
         createApp([]);
 
+        expect(app.scene.getGsplatParams()).to.equal(null);
+    });
+
+    it('asserts when public GSplat parameters are accessed without the system', function () {
+        createApp([]);
+        const errorSpy = stub(console, 'error');
+
         expect(app.scene.gsplat).to.equal(null);
+        expect(errorSpy.calledWith(
+            'ASSERT FAILED: ',
+            'Scene#gsplat requires GSplatComponentSystem to be included in the app.'
+        )).to.be.true;
     });
 
     it('owns the scene GSplat parameters for its lifetime', function () {
         createApp([GSplatComponentSystem]);
 
         expect(app.scene.gsplat).to.be.an.instanceof(GSplatParams);
+        expect(app.renderer.gsplatDirector).not.to.equal(null);
 
         app.systems.gsplat.destroy();
 
-        expect(app.scene.gsplat).to.equal(null);
+        expect(app.scene.getGsplatParams()).to.equal(null);
+        expect(app.renderer.gsplatDirector).to.equal(null);
     });
 });


### PR DESCRIPTION
Move scene-wide GSplat parameters behind `GSplatComponentSystem` so applications that omit the system can fully tree-shake the GSplat implementation.

**Changes:**
- Create and destroy scene-wide GSplat parameters with `GSplatComponentSystem`.
- Pass the initialized parameters directly through GSplat rendering internals.
- Handle absent GSplat parameters in shared rendering paths.
- Add lifecycle coverage and strengthen the AppBase tree-shaking test.

**API Changes:**
- `Scene#gsplat` changes from `GSplatParams` to `GSplatParams | null`.
- It is initialized synchronously when `GSplatComponentSystem` is included and is otherwise `null`.

Before:
```javascript
const renderer = app.scene.gsplat.renderer;
```

For applications without `GSplatComponentSystem`:
```javascript
const renderer = app.scene.gsplat?.renderer;
```

**Performance:**
- Tree-shaken AppBase applications without `GSplatComponentSystem` no longer retain GSplat formats, varyings, resource implementations, or GLSL/WGSL shader chunks.