### PR TITLE
Add descriptive GPU profiling names for quad passes

### DIFF
--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -133,7 +133,7 @@ export function drawFullscreenQuad(device, target, vertexBuffer, shader, rect) {
         viewport = _viewport.set(rect.x * w, rect.y * h, rect.z * w, rect.w * h);
     }
 
-    drawQuadWithShader(device, target, shader, viewport);
+    drawQuadWithShader(device, target, shader, viewport, undefined, shader.name);
 }
 
 // SCENE

--- a/src/extras/exporters/core-exporter.js
+++ b/src/extras/exporters/core-exporter.js
@@ -124,7 +124,7 @@ class CoreExporter {
 
         device.scope.resolve('source').setValue(texture);
         device.setBlendState(BlendState.NOBLEND);
-        drawQuadWithShader(device, renderTarget, shader);
+        drawQuadWithShader(device, renderTarget, shader, undefined, undefined, 'ExportTexture');
 
         // async read back the pixels of the texture
         // released as soon as the read settles, before the pixels are copied out and turned into a

--- a/src/extras/renderers/outline-renderer.js
+++ b/src/extras/renderers/outline-renderer.js
@@ -319,7 +319,7 @@ class OutlineRenderer {
         uOffset.setValue(_tempFloatArray);
         uColorBuffer.setValue(rt.colorBuffer);
         uSrcMultiplier.setValue(0.0);
-        drawQuadWithShader(device, tempRt, shaderExtend);
+        drawQuadWithShader(device, tempRt, shaderExtend, undefined, undefined, 'OutlineExpand');
 
         // vertical extend pass
         _tempFloatArray[0] = 0;
@@ -327,7 +327,7 @@ class OutlineRenderer {
         uOffset.setValue(_tempFloatArray);
         uColorBuffer.setValue(tempRt.colorBuffer);
         uSrcMultiplier.setValue(1.0);
-        drawQuadWithShader(device, rt, shaderExtend);
+        drawQuadWithShader(device, rt, shaderExtend, undefined, undefined, 'OutlineExpand');
     }
 
     createRenderTarget(name, width, height, depth) {

--- a/src/framework/lightmapper/lightmapper.js
+++ b/src/framework/lightmapper/lightmapper.js
@@ -923,10 +923,11 @@ class Lightmapper {
 
                     this.lightmapFilters.setSourceTexture(lightmap);
                     const bilateralFilterEnabled = filterLightmap && pass === 0 && i === 0;
-                    drawQuadWithShader(device, tempRT, bilateralFilterEnabled ? denoiseShader : dilateShader);
+                    drawQuadWithShader(device, tempRT, bilateralFilterEnabled ? denoiseShader : dilateShader,
+                        undefined, undefined, bilateralFilterEnabled ? 'LightmapDenoise' : 'LightmapDilate');
 
                     this.lightmapFilters.setSourceTexture(tempTex);
-                    drawQuadWithShader(device, nodeRT, dilateShader);
+                    drawQuadWithShader(device, nodeRT, dilateShader, undefined, undefined, 'LightmapDilate');
                 }
             }
 

--- a/src/scene/graphics/post-effect.js
+++ b/src/scene/graphics/post-effect.js
@@ -84,7 +84,7 @@ class PostEffect {
         }
 
         this.device.setBlendState(BlendState.NOBLEND);
-        drawQuadWithShader(this.device, target, shader, viewport);
+        drawQuadWithShader(this.device, target, shader, viewport, undefined, shader.name);
     }
 }
 

--- a/src/scene/graphics/quad-render-utils.js
+++ b/src/scene/graphics/quad-render-utils.js
@@ -1,4 +1,4 @@
-import { Debug } from '../../core/debug.js';
+import { Debug, DebugHelper } from '../../core/debug.js';
 import { Vec4 } from '../../core/math/vec4.js';
 import { QuadRender } from './quad-render.js';
 import { RenderPassQuad } from './render-pass-quad.js';
@@ -23,19 +23,14 @@ const _tempRect = new Vec4();
  * `[0, 0, target.width, target.height]`.
  * @param {Vec4} [scissorRect] - The scissor rectangle of the quad, in pixels. Defaults to fullscreen:
  * `[0, 0, target.width, target.height]`.
+ * @param {string} [name] - The render pass name used for GPU profiling and debugging in debug
+ * builds. Defaults to 'RenderPassQuad'.
  * @category Graphics
  */
-function drawQuadWithShader(device, target, shader, rect, scissorRect) {
+function drawQuadWithShader(device, target, shader, rect, scissorRect, name) {
 
     // a valid target or a null target (framebuffer) are supported
     Debug.assert(target !== undefined);
-
-    const useBlend = arguments[5];
-    Debug.call(() => {
-        if (useBlend !== undefined) {
-            Debug.warnOnce('drawQuadWithShader no longer accepts useBlend parameter, and blending state needs to be set up using GraphicsDevice.setBlendState.');
-        }
-    });
 
     // prepare the quad for rendering with the shader
     const quad = new QuadRender(shader);
@@ -51,6 +46,7 @@ function drawQuadWithShader(device, target, shader, rect, scissorRect) {
 
     // prepare a render pass to render the quad to the render target
     const renderPass = new RenderPassQuad(device, quad, rect, scissorRect);
+    DebugHelper.setName(renderPass, name ?? 'RenderPassQuad');
     renderPass.init(target);
     renderPass.colorOps.clear = false;
     renderPass.depthStencilOps.clearDepth = false;

--- a/src/scene/graphics/reproject-texture.js
+++ b/src/scene/graphics/reproject-texture.js
@@ -1,4 +1,4 @@
-import { Debug } from '../../core/debug.js';
+import { Debug, DebugHelper } from '../../core/debug.js';
 import { random } from '../../core/math/random.js';
 import { Vec3 } from '../../core/math/vec3.js';
 import {
@@ -497,10 +497,16 @@ function reprojectTexture(source, target, options = {}) {
                 depth: false,
                 origin: RENDERTARGET_ORIGIN_BOTTOM
             });
+            DebugHelper.setName(renderTarget, {
+                none: 'Reproject',
+                phong: 'PrefilterPhong',
+                ggx: 'PrefilterGGX',
+                lambert: 'PrefilterLambert'
+            }[distribution] ?? 'Reproject');
             params[0] = f;
             constantParams.setValue(params);
 
-            drawQuadWithShader(device, renderTarget, shader, options?.rect);
+            drawQuadWithShader(device, renderTarget, shader, options?.rect, undefined, renderTarget.name);
 
             renderTarget.destroy();
         }

--- a/src/scene/morph-instance.js
+++ b/src/scene/morph-instance.js
@@ -219,7 +219,7 @@ class MorphInstance {
         this.morphIndex.setValue(this._shaderMorphIndex);
 
         // render quad with shader
-        drawQuadWithShader(device, renderTarget, this.shader);
+        drawQuadWithShader(device, renderTarget, this.shader, undefined, undefined, 'MorphBlend');
     }
 
     _updateTextureMorph(activeCount) {

--- a/src/scene/particle-system/gpu-updater.js
+++ b/src/scene/particle-system/gpu-updater.js
@@ -135,7 +135,8 @@ class ParticleGPUUpdater {
             emitter.swapTex ? emitter.rtParticleTexIN : emitter.rtParticleTexOUT,
             !isOnStop ?
                 (emitter.loop ? emitter.shaderParticleUpdateRespawn : emitter.shaderParticleUpdateNoRespawn) :
-                emitter.shaderParticleUpdateOnStop);
+                emitter.shaderParticleUpdateOnStop,
+            undefined, undefined, 'ParticleUpdate');
 
         // this.constantParticleTexOUT.setValue(texOUT);
 

--- a/src/scene/renderer/shadow-renderer.js
+++ b/src/scene/renderer/shadow-renderer.js
@@ -773,14 +773,14 @@ class ShadowRenderer {
         pixelOffset[1] = 0;
         this.pixelOffsetId.setValue(pixelOffset);
         if (blurMode === BLUR_GAUSSIAN) this.weightId.setValue(this.blurVsmWeights[filterSize]);
-        drawQuadWithShader(device, tempRt, blurShader, null, blurScissorRect);
+        drawQuadWithShader(device, tempRt, blurShader, null, blurScissorRect, 'VSMShadowBlur');
 
         // Blur vertical
         this.sourceId.setValue(tempRt.colorBuffer);
         pixelOffset[1] = pixelOffset[0];
         pixelOffset[0] = 0;
         this.pixelOffsetId.setValue(pixelOffset);
-        drawQuadWithShader(device, origShadowMap, blurShader, null, blurScissorRect);
+        drawQuadWithShader(device, origShadowMap, blurShader, null, blurScissorRect, 'VSMShadowBlur');
 
         // return the temporary shadow map back to the cache
         this.renderer.shadowMapCache.add(light, tempShadowMap);


### PR DESCRIPTION
Give fullscreen quad operations descriptive GPU profiling categories in MiniStats when using a debug build, instead of combining them under `Quad`.

**Changes:**
- Split reprojection into `Reproject`, `PrefilterPhong`, `PrefilterGGX`, and `PrefilterLambert`.
- Name morph blending, particle updates, VSM shadow blur (`VSMShadowBlur`), lightmap denoising/dilation, outline expansion, and exporter texture conversion. Paired passes retain a shared category.
- Use shader names for post-effect and deprecated fullscreen-quad wrappers.

**API Changes:**
- Add an optional sixth `name` argument to `drawQuadWithShader()`, used only in debug builds. Calls without a name retain the existing `Quad` category.
- Remove the obsolete sixth-argument `useBlend` warning and repurpose that argument for the name. Legacy callers must omit the boolean and configure blending with `GraphicsDevice.setBlendState()`.

```js
// Before: unnamed pass
drawQuadWithShader(device, target, shader, rect, scissorRect);

// After: optional descriptive profiling name
drawQuadWithShader(device, target, shader, rect, scissorRect, 'CustomPass');
```

**Performance:**
- Name assignment and the reprojection category lookup use `DebugHelper.setName()` and are stripped from non-debug builds, including profiling builds.
