### PR TITLE
Add screen_size to forward view uniforms and deprecate uScreenSize

### DIFF
--- a/examples/src/examples/gaussian-splatting/clipping.clip.glsl.frag
+++ b/examples/src/examples/gaussian-splatting/clipping.clip.glsl.frag
@@ -1,14 +1,14 @@
 uniform vec3 uClipCenter;
 uniform vec3 uClipHalf;
 uniform mat4 uInvViewProj;
-uniform vec4 uScreenSize;
+uniform vec4 screen_size;
 
 void modifySplatColor(vec2 gaussianUV, inout vec4 color) {
     // splats fully inside or outside the box were already resolved per splat in the vertex stage
     if (getClipState() == 1u) return;
 
     // reconstruct the world position of this fragment (on the splat's depth plane)
-    vec3 ndc = vec3(gl_FragCoord.xy * uScreenSize.zw, gl_FragCoord.z) * 2.0 - 1.0;
+    vec3 ndc = vec3(gl_FragCoord.xy * screen_size.zw, gl_FragCoord.z) * 2.0 - 1.0;
     vec4 world = uInvViewProj * vec4(ndc, 1.0);
     vec3 worldPos = world.xyz / world.w;
 

--- a/examples/src/examples/gaussian-splatting/clipping.clip.wgsl.frag
+++ b/examples/src/examples/gaussian-splatting/clipping.clip.wgsl.frag
@@ -1,7 +1,7 @@
 uniform uClipCenter: vec3f;
 uniform uClipHalf: vec3f;
 uniform uInvViewProj: mat4x4f;
-uniform uScreenSize: vec4f;
+uniform screen_size: vec4f;
 
 fn modifySplatColor(gaussianUV: vec2f, color: ptr<function, vec4f>) {
     // splats fully inside or outside the box were already resolved per splat in the vertex stage
@@ -10,7 +10,7 @@ fn modifySplatColor(gaussianUV: vec2f, color: ptr<function, vec4f>) {
     }
 
     // reconstruct the world position of this fragment (on the splat's depth plane)
-    let uv = pcPosition.xy * uniform.uScreenSize.zw;
+    let uv = pcPosition.xy * uniform.screen_size.zw;
     let ndc = vec3f(uv.x * 2.0 - 1.0, (1.0 - uv.y) * 2.0 - 1.0, pcPosition.z * 2.0 - 1.0);
     let world = uniform.uInvViewProj * vec4f(ndc, 1.0);
     let worldPos = world.xyz / world.w;

--- a/examples/src/examples/gaussian-splatting/shader-rings.shader.glsl.frag
+++ b/examples/src/examples/gaussian-splatting/shader-rings.shader.glsl.frag
@@ -1,7 +1,7 @@
 uniform float uRingWidth;
 uniform float uRingAlpha;
 uniform float uTime;
-uniform vec4 uScreenSize;
+uniform vec4 screen_size;
 
 void modifySplatColor(vec2 gaussianUV, inout vec4 color) {
     // distance from the splat center: 0 at center, 1 at the clipping edge
@@ -17,7 +17,7 @@ void modifySplatColor(vec2 gaussianUV, inout vec4 color) {
 
     // time based highlight pulse, with a screen position based phase so the rings
     // light up in a wave instead of all at the same time
-    float phase = (gl_FragCoord.x + gl_FragCoord.y) * uScreenSize.z * 6.0;
+    float phase = (gl_FragCoord.x + gl_FragCoord.y) * screen_size.z * 6.0;
     float highlight = pow(0.5 + 0.5 * sin(uTime * 2.0 - phase), 4.0);
     color.rgb *= 1.0 + highlight * 1.5;
 }

--- a/examples/src/examples/gaussian-splatting/shader-rings.shader.wgsl.frag
+++ b/examples/src/examples/gaussian-splatting/shader-rings.shader.wgsl.frag
@@ -1,7 +1,7 @@
 uniform uRingWidth: f32;
 uniform uRingAlpha: f32;
 uniform uTime: f32;
-uniform uScreenSize: vec4f;
+uniform screen_size: vec4f;
 
 fn modifySplatColor(gaussianUV: vec2f, color: ptr<function, vec4f>) {
     // distance from the splat center: 0 at center, 1 at the clipping edge
@@ -17,7 +17,7 @@ fn modifySplatColor(gaussianUV: vec2f, color: ptr<function, vec4f>) {
 
     // time based highlight pulse, with a screen position based phase so the rings
     // light up in a wave instead of all at the same time
-    let phase = (pcPosition.x + pcPosition.y) * uniform.uScreenSize.z * 6.0;
+    let phase = (pcPosition.x + pcPosition.y) * uniform.screen_size.z * 6.0;
     let highlight = pow(0.5 + 0.5 * sin(uniform.uTime * 2.0 - phase), 4.0);
     *color = vec4f((*color).rgb * (1.0 + highlight * 1.5), alpha);
 }

--- a/examples/src/examples/graphics/reflection-planar.shader.glsl.frag
+++ b/examples/src/examples/graphics/reflection-planar.shader.glsl.frag
@@ -1,7 +1,7 @@
 #include "gammaPS"
 
 // engine built-in constant storing render target size in .xy and inverse size in .zw
-uniform vec4 uScreenSize;
+uniform vec4 screen_size;
 
 // reflection texture
 uniform sampler2D uDiffuseMap;
@@ -9,7 +9,7 @@ uniform sampler2D uDiffuseMap;
 void main(void)
 {
     // sample reflection texture
-    vec2 coord = gl_FragCoord.xy * uScreenSize.zw;
+    vec2 coord = gl_FragCoord.xy * screen_size.zw;
     coord.y = 1.0 - coord.y;
     vec4 reflection = texture2D(uDiffuseMap, coord);
 

--- a/examples/src/examples/graphics/reflection-planar.shader.wgsl.frag
+++ b/examples/src/examples/graphics/reflection-planar.shader.wgsl.frag
@@ -1,7 +1,7 @@
 #include "gammaPS" // Preserved include
 
 // engine built-in constant storing render target size in .xy and inverse size in .zw
-uniform uScreenSize: vec4f;
+uniform screen_size: vec4f;
 
 // reflection texture
 var uDiffuseMap: texture_2d<f32>;
@@ -12,7 +12,7 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
     var output: FragmentOutput;
 
     // sample reflection texture
-    var coord: vec2f = pcPosition.xy * uniform.uScreenSize.zw;
+    var coord: vec2f = pcPosition.xy * uniform.screen_size.zw;
     coord.y = 1.0 - coord.y;
     let reflection: vec4f = textureSample(uDiffuseMap, uDiffuseMapSampler, coord);
 

--- a/examples/src/examples/shaders/grab-pass.shader.glsl.frag
+++ b/examples/src/examples/shaders/grab-pass.shader.glsl.frag
@@ -12,7 +12,7 @@ uniform sampler2D uRoughnessMap;
 uniform vec3 tints[4];
 
 // engine built-in constant storing render target size in .xy and inverse size in .zw
-uniform vec4 uScreenSize;
+uniform vec4 screen_size;
 
 varying vec2 texCoord;
 
@@ -28,7 +28,7 @@ void main(void)
     offset *= (0.2 + roughness) * 0.015;
 
     // get normalized uv coordinates for canvas
-    vec2 grabUv = gl_FragCoord.xy * uScreenSize.zw;
+    vec2 grabUv = gl_FragCoord.xy * screen_size.zw;
 
     // roughness dictates which mipmap level gets used, in 0..4 range
     float mipmap = roughness * 5.0;

--- a/examples/src/examples/shaders/grab-pass.shader.wgsl.frag
+++ b/examples/src/examples/shaders/grab-pass.shader.wgsl.frag
@@ -15,7 +15,7 @@ var uRoughnessMapSampler: sampler;
 uniform tints: array<vec3f, 4>;
 
 // engine built-in constant storing render target size in .xy and inverse size in .zw
-uniform uScreenSize: vec4f;
+uniform screen_size: vec4f;
 
 varying texCoord: vec2f;
 
@@ -33,7 +33,7 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
     offset = offset * (0.2 + roughness) * 0.015;
 
     // get normalized uv coordinates for canvas
-    let grabUv: vec2f = pcPosition.xy * uniform.uScreenSize.zw;
+    let grabUv: vec2f = pcPosition.xy * uniform.screen_size.zw;
 
     // roughness dictates which mipmap level gets used, in 0..4 range
     let mipmap: f32 = roughness * 5.0;

--- a/examples/src/examples/xr/ar-camera-depth.example.mjs
+++ b/examples/src/examples/xr/ar-camera-depth.example.mjs
@@ -109,7 +109,7 @@ const vertShader = /* glsl */ `
     }`;
 
 const fragShader = /* glsl */ `
-    uniform vec4 uScreenSize;
+    uniform vec4 screen_size;
     uniform mat4 matrix_depth_uv;
     uniform float depth_raw_to_meters;
 
@@ -121,7 +121,7 @@ const fragShader = /* glsl */ `
     #endif
 
     void main (void) {
-        vec2 uvScreen = gl_FragCoord.xy * uScreenSize.zw;
+        vec2 uvScreen = gl_FragCoord.xy * screen_size.zw;
 
         // Use texture array for multi-view
         #ifdef XRDEPTH_ARRAY

--- a/scripts/esm/blurred-planar-reflection.mjs
+++ b/scripts/esm/blurred-planar-reflection.mjs
@@ -86,7 +86,7 @@ const vertexShaderGLSL = /* glsl */`
 const fragmentShaderGLSL = /* glsl */`
     #include "gammaPS"
 
-    uniform vec4 uScreenSize;
+    uniform vec4 screen_size;
     uniform sampler2D planarReflectionMap;
     uniform sampler2D planarReflectionDepthMap;
     uniform vec4 planarReflectionParams; // x: intensity, y: blurAmount, z: fadePower, w: fresnelPower
@@ -134,7 +134,7 @@ const fragmentShaderGLSL = /* glsl */`
 
     void main(void) {
         // UV coordinates in planar reflection map
-        vec2 screenUV = gl_FragCoord.xy * uScreenSize.zw;
+        vec2 screenUV = gl_FragCoord.xy * screen_size.zw;
         screenUV.y = 1.0 - screenUV.y;
 
         // Sample depth to get distance from plane (0..1 range based on heightRange)
@@ -209,7 +209,7 @@ const vertexShaderWGSL = /* wgsl */`
 const fragmentShaderWGSL = /* wgsl */`
     #include "gammaPS"
 
-    uniform uScreenSize: vec4f;
+    uniform screen_size: vec4f;
     var planarReflectionMap: texture_2d<f32>;
     var planarReflectionMapSampler: sampler;
     var planarReflectionDepthMap: texture_2d<f32>;
@@ -261,7 +261,7 @@ const fragmentShaderWGSL = /* wgsl */`
         var output: FragmentOutput;
 
         // UV coordinates in planar reflection map
-        var screenUV: vec2f = pcPosition.xy * uniform.uScreenSize.zw;
+        var screenUV: vec2f = pcPosition.xy * uniform.screen_size.zw;
         screenUV.y = 1.0 - screenUV.y;
 
         // Sample depth to get distance from plane (0..1 range based on heightRange)

--- a/scripts/esm/gsplat/gsplat-relighting.mjs
+++ b/scripts/esm/gsplat/gsplat-relighting.mjs
@@ -25,13 +25,13 @@ const meshOutputWGSL = /* wgsl */`
 // mesh material (2 for 0.5 gray albedo) and allows the overall lighting to be brightened.
 const splatModifyGLSL = /* glsl */`
 uniform sampler2D uRelightMap;
-uniform vec4 uScreenSize;
+uniform vec4 screen_size;
 uniform float uRelightBlend;
 uniform float uRelightBrightness;
 uniform float uRelightBackground;
 
 void modifySplatColor(vec2 gaussianUV, inout vec4 color) {
-    vec4 lit = textureLod(uRelightMap, gl_FragCoord.xy * uScreenSize.zw, 0.0);
+    vec4 lit = textureLod(uRelightMap, gl_FragCoord.xy * screen_size.zw, 0.0);
 
     // the texture alpha is a mesh coverage mask - splats not covered by the mesh (e.g. the sky)
     // are modulated by the background multiplier instead of the mesh lighting
@@ -43,13 +43,13 @@ void modifySplatColor(vec2 gaussianUV, inout vec4 color) {
 const splatModifyWGSL = /* wgsl */`
 var uRelightMap: texture_2d<f32>;
 var uRelightMapSampler: sampler;
-uniform uScreenSize: vec4f;
+uniform screen_size: vec4f;
 uniform uRelightBlend: f32;
 uniform uRelightBrightness: f32;
 uniform uRelightBackground: f32;
 
 fn modifySplatColor(gaussianUV: vec2f, color: ptr<function, vec4f>) {
-    let lit = textureSampleLevel(uRelightMap, uRelightMapSampler, pcPosition.xy * uniform.uScreenSize.zw, 0.0);
+    let lit = textureSampleLevel(uRelightMap, uRelightMapSampler, pcPosition.xy * uniform.screen_size.zw, 0.0);
 
     // the texture alpha is a mesh coverage mask - splats not covered by the mesh (e.g. the sky)
     // are modulated by the background multiplier instead of the mesh lighting

--- a/scripts/esm/water.mjs
+++ b/scripts/esm/water.mjs
@@ -445,7 +445,7 @@ const fragmentGLSL = /* glsl */`
 
     #ifndef SCREENSIZE
         #define SCREENSIZE
-        uniform vec4 uScreenSize;
+        uniform vec4 screen_size;
     #endif
 
     uniform sampler2D uNormalMap;
@@ -526,7 +526,7 @@ const fragmentGLSL = /* glsl */`
         // screen uv to sample the planar textures. The refraction camera matches the main camera,
         // so its texture is sampled without a flip; the reflection camera is mirrored by the
         // water plane, which flips the image vertically.
-        vec2 screenUV = gl_FragCoord.xy * uScreenSize.zw;
+        vec2 screenUV = gl_FragCoord.xy * screen_size.zw;
         vec2 refractionUV = screenUV + N.xz * uDistortion;
         vec2 reflectionUV = vec2(screenUV.x, 1.0 - screenUV.y) + N.xz * uDistortion;
 
@@ -712,7 +712,7 @@ const fragmentWGSL = /* wgsl */`
 
     #ifndef SCREENSIZE
         #define SCREENSIZE
-        uniform uScreenSize: vec4f;
+        uniform screen_size: vec4f;
     #endif
 
     var uNormalMap: texture_2d<f32>;
@@ -799,7 +799,7 @@ const fragmentWGSL = /* wgsl */`
         // screen uv to sample the planar textures. The refraction camera matches the main camera,
         // so its texture is sampled without a flip; the reflection camera is mirrored by the
         // water plane, which flips the image vertically.
-        let screenUV: vec2f = pcPosition.xy * uniform.uScreenSize.zw;
+        let screenUV: vec2f = pcPosition.xy * uniform.screen_size.zw;
         let refractionUV: vec2f = screenUV + N.xz * uniform.uDistortion;
         let reflectionUV: vec2f = vec2f(screenUV.x, 1.0 - screenUV.y) + N.xz * uniform.uDistortion;
 

--- a/src/extras/renderers/wide-line-renderer.js
+++ b/src/extras/renderers/wide-line-renderer.js
@@ -34,7 +34,7 @@ const vertexGLSL = /* glsl */ `
     attribute vec4 instance_dashFlags;
 
     uniform mat4 matrix_viewProjection;
-    uniform vec4 uScreenSize;
+    uniform vec4 screen_size;
     #ifdef WIDE_LINE_WORLD_SPACE_WIDTH
         uniform mat4 matrix_projection;
     #endif
@@ -55,17 +55,17 @@ const vertexGLSL = /* glsl */ `
 
     vec2 toScreen(vec4 clipPosition) {
         float w = abs(clipPosition.w) > 0.00001 ? clipPosition.w : 0.00001;
-        return clipPosition.xy / w * uScreenSize.xy * 0.5;
+        return clipPosition.xy / w * screen_size.xy * 0.5;
     }
 
     vec4 offsetClip(vec4 clipPosition, vec2 pixelOffset) {
-        clipPosition.xy += pixelOffset * (2.0 * uScreenSize.zw) * clipPosition.w;
+        clipPosition.xy += pixelOffset * (2.0 * screen_size.zw) * clipPosition.w;
         return clipPosition;
     }
 
     float resolveHalfWidth(float width, vec4 clipPosition) {
         #ifdef WIDE_LINE_WORLD_SPACE_WIDTH
-            float pixelsPerWorldUnit = abs(matrix_projection[1][1]) * uScreenSize.y * 0.5 /
+            float pixelsPerWorldUnit = abs(matrix_projection[1][1]) * screen_size.y * 0.5 /
                 max(abs(clipPosition.w), 0.00001);
             return width * 0.5 * pixelsPerWorldUnit;
         #else
@@ -224,7 +224,7 @@ const vertexWGSL = /* wgsl */ `
     attribute instance_dashFlags: vec4f;
 
     uniform matrix_viewProjection: mat4x4f;
-    uniform uScreenSize: vec4f;
+    uniform screen_size: vec4f;
     #ifdef WIDE_LINE_WORLD_SPACE_WIDTH
         uniform matrix_projection: mat4x4f;
     #endif
@@ -245,19 +245,19 @@ const vertexWGSL = /* wgsl */ `
 
     fn toScreen(clipPosition: vec4f) -> vec2f {
         let w = select(0.00001, clipPosition.w, abs(clipPosition.w) > 0.00001);
-        return clipPosition.xy / w * uniform.uScreenSize.xy * 0.5;
+        return clipPosition.xy / w * uniform.screen_size.xy * 0.5;
     }
 
     fn offsetClip(position: vec4f, pixelOffset: vec2f) -> vec4f {
         var clipPosition = position;
-        clipPosition.x += pixelOffset.x * (2.0 * uniform.uScreenSize.z) * clipPosition.w;
-        clipPosition.y += pixelOffset.y * (2.0 * uniform.uScreenSize.w) * clipPosition.w;
+        clipPosition.x += pixelOffset.x * (2.0 * uniform.screen_size.z) * clipPosition.w;
+        clipPosition.y += pixelOffset.y * (2.0 * uniform.screen_size.w) * clipPosition.w;
         return clipPosition;
     }
 
     fn resolveHalfWidth(width: f32, clipPosition: vec4f) -> f32 {
         #ifdef WIDE_LINE_WORLD_SPACE_WIDTH
-            let pixelsPerWorldUnit = abs(uniform.matrix_projection[1][1]) * uniform.uScreenSize.y * 0.5 /
+            let pixelsPerWorldUnit = abs(uniform.matrix_projection[1][1]) * uniform.screen_size.y * 0.5 /
                 max(abs(clipPosition.w), 0.00001);
             return width * 0.5 * pixelsPerWorldUnit;
         #else

--- a/src/platform/graphics/shader-processor-glsl.js
+++ b/src/platform/graphics/shader-processor-glsl.js
@@ -100,6 +100,12 @@ class UniformLine {
             this.arraySize = 0;
         }
 
+        Debug.call(() => {
+            if (this.name === 'uScreenSize') {
+                Debug.deprecated('Shader uniform uScreenSize is deprecated. Use screen_size instead.');
+            }
+        });
+
         this.isSampler = this.type.indexOf('sampler') !== -1;
         this.isSignedInt = this.type.indexOf('isampler') !== -1;
         this.isUnsignedInt = this.type.indexOf('usampler') !== -1;

--- a/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
+++ b/src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js
@@ -267,6 +267,12 @@ class UniformLine {
         this.name = parts[0];
         this.type = parts.slice(1).join(' ');
 
+        Debug.call(() => {
+            if (this.name === 'uScreenSize') {
+                Debug.deprecated('Shader uniform uScreenSize is deprecated. Use screen_size instead.');
+            }
+        });
+
         // array of uniforms (e.g. array<f32, 5>)
         if (this.type.includes('array<')) {
 

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -137,7 +137,8 @@ class ForwardRenderer extends Renderer {
         this.shadowCascadeBlendId = [];
         this.shadowCascadeRadiiId = [];
 
-        this.screenSizeId = scope.resolve('uScreenSize');
+        this.screenSizeId = scope.resolve('screen_size');
+        this.screenSizeLegacyId = scope.resolve('uScreenSize');
         this._screenSize = new Float32Array(4);
 
         this.fogColor = new Float32Array(3);
@@ -926,6 +927,8 @@ class ForwardRenderer extends Renderer {
         this._screenSize[2] = 1 / device.width;
         this._screenSize[3] = 1 / device.height;
         this.screenSizeId.setValue(this._screenSize);
+        // Keep legacy shader declarations working through the non-view uniform path.
+        this.screenSizeLegacyId.setValue(this._screenSize);
 
         this.pcssDiskSamplesId.setValue(this.pcssDiskSamples);
         this.pcssSphereSamplesId.setValue(this.pcssSphereSamples);

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -681,6 +681,7 @@ class Renderer {
                 new UniformFormat('cubeMapRotationMatrix', UNIFORMTYPE_MAT3),
                 new UniformFormat('view_position', UNIFORMTYPE_VEC3),
                 new UniformFormat('viewport_size', UNIFORMTYPE_VEC4),
+                new UniformFormat('screen_size', UNIFORMTYPE_VEC4),
                 new UniformFormat('skyboxIntensity', UNIFORMTYPE_FLOAT),
                 new UniformFormat('exposure', UNIFORMTYPE_FLOAT),
                 new UniformFormat('view_index', UNIFORMTYPE_UINT)

--- a/src/scene/shader-lib/glsl/chunks/common/frag/screenDepth.js
+++ b/src/scene/shader-lib/glsl/chunks/common/frag/screenDepth.js
@@ -7,7 +7,7 @@ uniform highp sampler2D uSceneDepthMap;
 
 #ifndef SCREENSIZE
     #define SCREENSIZE
-    uniform vec4 uScreenSize;
+    uniform vec4 screen_size;
 #endif
 
 #ifndef VIEWMATRIX
@@ -65,7 +65,7 @@ float getLinearScreenDepth(vec2 uv) {
 #ifndef VERTEXSHADER
     // Retrieves rendered linear camera depth under the current pixel
     float getLinearScreenDepth() {
-        vec2 uv = gl_FragCoord.xy * uScreenSize.zw;
+        vec2 uv = gl_FragCoord.xy * screen_size.zw;
         return getLinearScreenDepth(uv);
     }
 #endif

--- a/src/scene/shader-lib/glsl/chunks/common/vert/transform.js
+++ b/src/scene/shader-lib/glsl/chunks/common/vert/transform.js
@@ -1,6 +1,6 @@
 export default /* glsl */`
 #ifdef PIXELSNAP
-uniform vec4 uScreenSize;
+uniform vec4 screen_size;
 #endif
 
 #ifdef SCREENSPACE
@@ -60,9 +60,9 @@ vec4 getPosition() {
         #ifdef PIXELSNAP
             // snap vertex to a pixel boundary
             screenPos.xy = (screenPos.xy * 0.5) + 0.5;
-            screenPos.xy *= uScreenSize.xy;
+            screenPos.xy *= screen_size.xy;
             screenPos.xy = floor(screenPos.xy);
-            screenPos.xy *= uScreenSize.zw;
+            screenPos.xy *= screen_size.zw;
             screenPos.xy = (screenPos.xy * 2.0) - 1.0;
         #endif
     #endif

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/refractionDynamic.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/refractionDynamic.js
@@ -15,7 +15,7 @@ vec3 evalRefractionColor(vec3 refractionVector, float gloss, float refractionInd
 
     // Use IOR and roughness to select mip
     float iorToRoughness = (1.0 - gloss) * clamp((1.0 / refractionIndex) * 2.0 - 2.0, 0.0, 1.0);
-    float refractionLod = log2(uScreenSize.x) * iorToRoughness;
+    float refractionLod = log2(screen_size.x) * iorToRoughness;
     vec3 refraction = texture2DLod(uSceneColorMap, uv, refractionLod).rgb;
 
     // Convert from gamma to linear space if needed

--- a/src/scene/shader-lib/glsl/chunks/standard/frag/stdDeclaration.js
+++ b/src/scene/shader-lib/glsl/chunks/standard/frag/stdDeclaration.js
@@ -35,7 +35,7 @@ export default /* glsl */`
         #endif
 
         #ifdef LIT_SCREEN_SIZE
-            uniform vec4 uScreenSize;
+            uniform vec4 screen_size;
         #endif
 
         #ifdef LIT_TRANSFORMS

--- a/src/scene/shader-lib/wgsl/chunks/common/frag/screenDepth.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/frag/screenDepth.js
@@ -4,7 +4,7 @@ var uSceneDepthMap: texture_2d<uff>;
 
 #ifndef SCREENSIZE
     #define SCREENSIZE
-    uniform uScreenSize: vec4f;
+    uniform screen_size: vec4f;
 #endif
 
 #ifndef VIEWMATRIX
@@ -64,7 +64,7 @@ fn getLinearScreenDepth(uv: vec2f) -> f32 {
 #ifndef VERTEXSHADER
     // Retrieves rendered linear camera depth under the current pixel
     fn getLinearScreenDepthFrag() -> f32 {
-        let uv: vec2f = pcPosition.xy * uniform.uScreenSize.zw;
+        let uv: vec2f = pcPosition.xy * uniform.screen_size.zw;
         return getLinearScreenDepth(uv);
     }
 #endif

--- a/src/scene/shader-lib/wgsl/chunks/common/vert/transform.js
+++ b/src/scene/shader-lib/wgsl/chunks/common/vert/transform.js
@@ -1,6 +1,6 @@
 export default /* wgsl */`
 #ifdef PIXELSNAP
-    uniform uScreenSize: vec4f;
+    uniform screen_size: vec4f;
 #endif
 
 #ifdef SCREENSPACE
@@ -59,9 +59,9 @@ fn getPosition() -> vec4f {
         #ifdef PIXELSNAP
             // snap vertex to a pixel boundary
             screenPos.xy = (screenPos.xy * 0.5) + 0.5;
-            screenPos.xy *= uniforms.uScreenSize.xy;
+            screenPos.xy *= uniform.screen_size.xy;
             screenPos.xy = floor(screenPos.xy);
-            screenPos.xy *= uniforms.uScreenSize.zw;
+            screenPos.xy *= uniform.screen_size.zw;
             screenPos.xy = (screenPos.xy * 2.0) - 1.0;
         #endif
     #endif

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/refractionDynamic.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/refractionDynamic.js
@@ -15,7 +15,7 @@ fn evalRefractionColor(refractionVector: vec3f, gloss: f32, refractionIndex: f32
 
     // Use IOR and roughness to select mip
     let iorToRoughness: f32 = (1.0 - gloss) * clamp((1.0 / refractionIndex) * 2.0 - 2.0, 0.0, 1.0);
-    let refractionLod: f32 = log2(uniform.uScreenSize.x) * iorToRoughness;
+    let refractionLod: f32 = log2(uniform.screen_size.x) * iorToRoughness;
     var refraction: vec3f = textureSampleLevel(uSceneColorMap, uSceneColorMapSampler, uv, refractionLod).rgb;
 
     // Convert from gamma to linear space if needed

--- a/src/scene/shader-lib/wgsl/chunks/standard/frag/stdDeclaration.js
+++ b/src/scene/shader-lib/wgsl/chunks/standard/frag/stdDeclaration.js
@@ -37,7 +37,7 @@ export default /* wgsl */`
         #endif
 
         #ifdef LIT_SCREEN_SIZE
-            uniform uScreenSize: vec4f;
+            uniform screen_size: vec4f;
         #endif
 
         #ifdef LIT_TRANSFORMS

--- a/test/platform/graphics/shader-screen-size.test.mjs
+++ b/test/platform/graphics/shader-screen-size.test.mjs
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { Debug } from '../../../src/core/debug.js';
+import { SEMANTIC_POSITION } from '../../../src/platform/graphics/constants.js';
+import { ShaderProcessorGLSL } from '../../../src/platform/graphics/shader-processor-glsl.js';
+import { ShaderProcessorOptions } from '../../../src/platform/graphics/shader-processor-options.js';
+import { WebglShaderProcessorGLSL } from '../../../src/platform/graphics/webgl/webgl-shader-processor-glsl.js';
+import { WebgpuShaderProcessorWGSL } from '../../../src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+const warning = 'Shader uniform uScreenSize is deprecated. Use screen_size instead.';
+
+// Both names appear in both stages to exercise declaration merging as well as buffer assignment.
+const glslSource = legacy => `
+    uniform vec4 screen_size;
+    ${legacy ? 'uniform vec4 uScreenSize;' : ''}
+    void main() {
+        gl_Position = screen_size ${legacy ? '+ uScreenSize' : ''};
+    }
+`;
+
+const wgslSource = (legacy, vertex) => `
+    uniform screen_size: vec4f;
+    ${legacy ? 'uniform uScreenSize: vec4f;' : ''}
+    @${vertex ? 'vertex' : 'fragment'}
+    fn ${vertex ? 'vertexMain(input: VertexInput) -> VertexOutput' : 'fragmentMain(input: FragmentInput) -> FragmentOutput'} {
+        var output: ${vertex ? 'VertexOutput' : 'FragmentOutput'};
+        output.${vertex ? 'position' : 'color'} = uniform.screen_size ${legacy ? '+ uniform.uScreenSize' : ''};
+        return output;
+    }
+`;
+
+describe('Screen size shader uniform compatibility', function () {
+    let app;
+    let warn;
+    let previouslyLogged;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+        app.renderer.initViewUniformFormat(false);
+        previouslyLogged = Debug._loggedMessages.delete(warning);
+        warn = sinon.stub(console, 'warn');
+    });
+
+    afterEach(function () {
+        warn.restore();
+        Debug._loggedMessages.delete(warning);
+        if (previouslyLogged) Debug._loggedMessages.add(warning);
+        app.destroy();
+        jsdomTeardown();
+    });
+
+    it('supplies both scope names from the same storage, including after resizing', function () {
+        const device = app.graphicsDevice;
+        for (const [width, height] of [[640, 480], [320, 240]]) {
+            device.resizeCanvas(width, height);
+            app.renderer.setSceneConstants();
+            const current = device.scope.resolve('screen_size').value;
+            expect(device.scope.resolve('uScreenSize').value).to.equal(current);
+            expect(Array.from(current)).to.deep.equal(Array.from(new Float32Array([width, height, 1 / width, 1 / height])));
+        }
+        expect(app.renderer.viewUniformFormat.get('screen_size')).to.exist;
+        expect(app.renderer.viewUniformFormat.get('uScreenSize')).not.to.exist;
+        expect(warn.called).to.equal(false);
+    });
+
+    [
+        ['WebGL2', WebglShaderProcessorGLSL, false],
+        ['GLSL for WebGPU', ShaderProcessorGLSL, false],
+        ['WGSL', WebgpuShaderProcessorWGSL, true]
+    ].forEach(([name, processor, wgsl]) => {
+        [false, true].forEach((legacy) => {
+            it(`${name} routes ${legacy ? 'mixed legacy and current uniforms and warns once' : 'the current uniform without warnings'}`, function () {
+                const definition = {
+                    attributes: { vertex_position: SEMANTIC_POSITION },
+                    vshader: wgsl ? wgslSource(legacy, true) : glslSource(legacy),
+                    fshader: wgsl ? wgslSource(legacy, false) : glslSource(legacy).replace('gl_Position', 'gl_FragColor'),
+                    processingOptions: new ShaderProcessorOptions(app.renderer.viewUniformFormat)
+                };
+                const shader = { failed: false, name: 'screen-size-test' };
+                const result = processor.run(app.graphicsDevice, definition, shader);
+                // Reprocessing another variant must not repeat the deprecation warning.
+                processor.run(app.graphicsDevice, definition, shader);
+                expect(shader.failed).to.equal(false);
+                expect(result.vshader).to.contain('screen_size');
+                expect(result.fshader).to.contain('screen_size');
+                if (processor === WebglShaderProcessorGLSL) {
+                    expect(result.vshader).not.to.contain('uniform vec4 screen_size;');
+                    expect(result.vshader.includes('uniform vec4 uScreenSize;')).to.equal(legacy);
+                } else {
+                    expect(result.meshUniformBufferFormat.get('screen_size')).not.to.exist;
+                    expect(!!result.meshUniformBufferFormat.get('uScreenSize')).to.equal(legacy);
+                    if (wgsl) {
+                        expect(result.vshader).to.contain('ub_view.screen_size');
+                        if (legacy) expect(result.vshader).to.contain('ub_mesh_ub.uScreenSize');
+                    }
+                }
+                expect(warn.callCount).to.equal(legacy ? 1 : 0);
+                if (legacy) expect(warn.firstCall.args[0]).to.equal(`DEPRECATED: ${warning}`);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add `screen_size` to the forward view uniform buffer so shaders share the canvas dimensions across draws, while preserving existing shaders that use `uScreenSize`.

**Changes:**
- Update engine shaders, reusable scripts, and examples to use `screen_size`.
- Keep `uScreenSize` populated in global scope for legacy shaders, using mesh uniforms on WebGPU and standalone uniforms on WebGL2. Debug builds warn once to use `screen_size` instead.
- Fix the invalid WGSL pixel-snapping uniform access.

**API Changes:**
- Prefer `screen_size` over the deprecated `uScreenSize`. Both contain `[canvas width, canvas height, 1 / width, 1 / height]`; existing explicit declarations remain supported.
- GLSL: `uniform vec4 uScreenSize;` → `uniform vec4 screen_size;` (rename references too).
- WGSL: `uniform uScreenSize: vec4f;` → `uniform screen_size: vec4f;`; `uniform.uScreenSize` → `uniform.screen_size`.

**Examples:**
- Update Grab Pass, Planar Reflection, Gaussian Splatting Clipping and Shader Rings, and AR Camera Depth.

**Performance:**
- Modern shaders share the screen-size value through the forward view buffer. Both scope names reuse the same array, and deprecation checks are stripped from production builds.
