### PR TITLE
Pack forward view uniforms to reduce alignment padding

### DIFF
--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -680,24 +680,25 @@ class Renderer {
                 new UniformFormat('matrix_view3', UNIFORMTYPE_MAT3),
                 new UniformFormat('cubeMapRotationMatrix', UNIFORMTYPE_MAT3),
                 new UniformFormat('view_position', UNIFORMTYPE_VEC3),
+                new UniformFormat('skyboxIntensity', UNIFORMTYPE_FLOAT),
                 new UniformFormat('viewport_size', UNIFORMTYPE_VEC4),
                 new UniformFormat('screen_size', UNIFORMTYPE_VEC4),
-                new UniformFormat('skyboxIntensity', UNIFORMTYPE_FLOAT),
                 new UniformFormat('exposure', UNIFORMTYPE_FLOAT),
                 new UniformFormat('view_index', UNIFORMTYPE_UINT)
             ];
 
             if (isClustered) {
+                // Fill the common uniforms' trailing 8 bytes, then pair vec3s with scalars.
                 uniforms.push(...[
-                    new UniformFormat('clusterCellsCountByBoundsSize', UNIFORMTYPE_VEC3),
-                    new UniformFormat('clusterBoundsMin', UNIFORMTYPE_VEC3),
-                    new UniformFormat('clusterBoundsDelta', UNIFORMTYPE_VEC3),
-                    new UniformFormat('clusterCellsDot', UNIFORMTYPE_IVEC3),
-                    new UniformFormat('clusterCellsMax', UNIFORMTYPE_IVEC3),
                     new UniformFormat('shadowAtlasParams', UNIFORMTYPE_VEC2),
+                    new UniformFormat('clusterCellsCountByBoundsSize', UNIFORMTYPE_VEC3),
                     new UniformFormat('clusterMaxCells', UNIFORMTYPE_INT),
+                    new UniformFormat('clusterBoundsMin', UNIFORMTYPE_VEC3),
                     new UniformFormat('numClusteredLights', UNIFORMTYPE_INT),
-                    new UniformFormat('clusterTextureWidth', UNIFORMTYPE_INT)
+                    new UniformFormat('clusterBoundsDelta', UNIFORMTYPE_VEC3),
+                    new UniformFormat('clusterTextureWidth', UNIFORMTYPE_INT),
+                    new UniformFormat('clusterCellsDot', UNIFORMTYPE_IVEC3),
+                    new UniformFormat('clusterCellsMax', UNIFORMTYPE_IVEC3)
                 ]);
             }
 


### PR DESCRIPTION
Reduce padding in the forward view uniform buffer by ordering scalar and vector uniforms to share aligned slots.

**Changes:**
- Place `skyboxIntensity` immediately after `view_position`.
- Fill the remaining common-field space with `shadowAtlasParams`, then pair clustered-lighting vectors with integer uniforms.

**Performance:**
- Reduce the clustered view buffer from 592 to 560 bytes (32 bytes saved per view); the non-clustered buffer remains 480 bytes.
- WebGPU allocation spacing remains 768 bytes on devices with 256-byte uniform-offset alignment.
