### PR TITLE
Add per-attachment clear colors to the camera for multiple render targets

### DIFF
--- a/examples/src/examples/graphics/multi-render-targets.example.mjs
+++ b/examples/src/examples/graphics/multi-render-targets.example.mjs
@@ -13,6 +13,7 @@ import {
     Asset,
     AssetListLoader,
     CameraComponentSystem,
+    Color,
     ContainerHandler,
     ElementComponentSystem,
     Entity,
@@ -176,6 +177,11 @@ textureCamera.addComponent('camera', {
     renderTarget: renderTarget
 });
 app.root.addChild(textureCamera);
+
+// The color buffers of the render target clear to the camera's clear color by default. Give the
+// normals and gloss buffers their own clear colors, matching what the shader outputs for empty space.
+textureCamera.camera.setClearColor(1, new Color(0.5, 0.5, 1, 1));
+textureCamera.camera.setClearColor(2, new Color(0, 0, 0, 1));
 
 // Set the shader pass to use MRT output
 textureCamera.camera.setShaderPass('MyMRT');

--- a/src/framework/components/camera/component.js
+++ b/src/framework/components/camera/component.js
@@ -469,7 +469,10 @@ class CameraComponent extends Component {
     }
 
     /**
-     * Sets the camera component's clear color. Defaults to `[0.75, 0.75, 0.75, 1]`.
+     * Sets the camera component's clear color. Defaults to `[0.75, 0.75, 0.75, 1]`. When the camera
+     * renders to a {@link RenderTarget} with multiple color buffers, this is the clear color of
+     * the color attachment 0, and also of the other attachments unless they are given their own
+     * using {@link CameraComponent#setClearColor}.
      *
      * @type {Color}
      */
@@ -484,6 +487,35 @@ class CameraComponent extends Component {
      */
     get clearColor() {
         return this._camera.clearColor;
+    }
+
+    /**
+     * Sets the clear color of a color attachment of the camera's render target, which allows the
+     * color buffers of a {@link RenderTarget} with multiple color buffers to clear to different
+     * colors. The attachment 0 clears to {@link CameraComponent#clearColor}, and the other
+     * attachments clear to the same color unless given their own here. Pass null to remove the
+     * color of an attachment, so that it clears to the attachment 0 color again. The components
+     * of the clear color of an integer format attachment are the integer values to clear to.
+     *
+     * @param {number} index - The index of the color attachment.
+     * @param {Color|null} color - The clear color, specified in sRGB space, or null to clear to
+     * the color of the attachment 0.
+     * @example
+     * // clear the second color buffer of the render target to a different color
+     * entity.camera.setClearColor(1, new pc.Color(0.5, 0.5, 1, 1));
+     */
+    setClearColor(index, color) {
+        this._camera.setClearColor(index, color);
+    }
+
+    /**
+     * Gets the clear color of a color attachment of the camera's render target.
+     *
+     * @param {number} index - The index of the color attachment.
+     * @returns {Color} The clear color of the attachment.
+     */
+    getClearColor(index) {
+        return this._camera.getClearColor(index);
     }
 
     /**
@@ -1402,6 +1434,8 @@ class CameraComponent extends Component {
         this.calculateProjection = source.calculateProjection;
         this.calculateTransform = source.calculateTransform;
         this.clearColor = source.clearColor;
+        this._camera._clearColors = null;
+        source._camera._clearColors?.forEach((color, index) => this.setClearColor(index, color));
         this.clearColorBuffer = source.clearColorBuffer;
         this.clearDepthBuffer = source.clearDepthBuffer;
         this.clearStencilBuffer = source.clearStencilBuffer;

--- a/src/framework/components/camera/system.js
+++ b/src/framework/components/camera/system.js
@@ -149,7 +149,12 @@ class CameraComponentSystem extends ComponentSystem {
             data[property] = c[property];
         }
 
-        return this.addComponent(clone, data);
+        const component = this.addComponent(clone, data);
+
+        // the clear colors of the other color attachments are not component data
+        c._camera._clearColors?.forEach((color, index) => component.setClearColor(index, color));
+
+        return component;
     }
 
     onBeforeRemove(entity, component) {

--- a/src/platform/graphics/render-pass.js
+++ b/src/platform/graphics/render-pass.js
@@ -321,7 +321,6 @@ class RenderPass extends FramePass {
      */
     setClearColor(color, index) {
 
-        // TODO: expose per color buffer clear parameters on the camera, and copy them here.
         const count = this.colorArrayOps.length;
         Debug.assert(index === undefined || (index >= 0 && index < count),
             `setClearColor index ${index} is out of range, the render pass has ${count} color attachments.`);

--- a/src/scene/camera.js
+++ b/src/scene/camera.js
@@ -175,6 +175,7 @@ class Camera {
         this._calculateProjection = null;
         this._calculateTransform = null;
         this._clearColor = new Color(0.75, 0.75, 0.75, 1);
+        this._clearColors = null;
         this._clearColorBuffer = true;
         this._clearDepth = 1;
         this._clearDepthBuffer = true;
@@ -348,6 +349,40 @@ class Camera {
 
     get clearColor() {
         return this._clearColor;
+    }
+
+    /**
+     * Sets the clear color of a color attachment of the render target. Attachment 0 is
+     * {@link Camera#clearColor}, and the other attachments of a multiple render target clear to the
+     * same color unless given their own. Passing null removes the color of an attachment, so it
+     * clears to the attachment 0 color again.
+     *
+     * @param {number} index - The index of the color attachment.
+     * @param {Color|null} color - The clear color, or null to clear to the attachment 0 color.
+     */
+    setClearColor(index, color) {
+        Debug.assert(Number.isInteger(index) && index >= 0, `Invalid color attachment index ${index}.`);
+
+        if (index === 0) {
+            Debug.assert(color, 'The clear color of the color attachment 0 cannot be removed.');
+            this._clearColor.copy(color);
+        } else if (color) {
+            // stored sparsely, most cameras render to a single color attachment
+            this._clearColors ??= [];
+            (this._clearColors[index] ??= new Color()).copy(color);
+        } else if (this._clearColors) {
+            this._clearColors[index] = undefined;
+        }
+    }
+
+    /**
+     * Gets the clear color of a color attachment of the render target.
+     *
+     * @param {number} index - The index of the color attachment.
+     * @returns {Color} The clear color of the attachment.
+     */
+    getClearColor(index) {
+        return this._clearColors?.[index] ?? this._clearColor;
     }
 
     set clearColorBuffer(newValue) {
@@ -702,6 +737,8 @@ class Camera {
         this.calculateProjection = other.calculateProjection;
         this.calculateTransform = other.calculateTransform;
         this.clearColor = other.clearColor;
+        this._clearColors = null;
+        other._clearColors?.forEach((color, index) => this.setClearColor(index, color));
         this.clearColorBuffer = other.clearColorBuffer;
         this.clearDepth = other.clearDepth;
         this.clearDepthBuffer = other.clearDepthBuffer;

--- a/src/scene/renderer/render-pass-forward.js
+++ b/src/scene/renderer/render-pass-forward.js
@@ -214,9 +214,17 @@ class RenderPassForward extends RenderPass {
 
             // when this pass renders the scene textures, the camera's clear color describes the scene
             // color attachment alone - the clear values of the scene texture attachments belong to
-            // whoever owns them, and are left alone here
-            const colorIndex = this.sceneTextures?.length ? 0 : undefined;
-            this.setClearColor(fullSizeClearRect && step.clearColor ? camera.clearColor : undefined, colorIndex);
+            // whoever owns them, and are left alone here. Otherwise each color attachment of the
+            // render target clears to the color the camera specifies for it.
+            const clearColor = fullSizeClearRect && step.clearColor;
+            if (this.sceneTextures?.length) {
+                this.setClearColor(clearColor ? camera.clearColor : undefined, 0);
+            } else {
+                const count = this.colorArrayOps.length;
+                for (let i = 0; i < count; i++) {
+                    this.setClearColor(clearColor ? camera.getClearColor(i) : undefined, i);
+                }
+            }
             this.setClearDepth(fullSizeClearRect && step.clearDepth && !this.noDepthClear ? camera.clearDepth : undefined);
             this.setClearStencil(fullSizeClearRect && step.clearStencil ? camera.clearStencil : undefined);
         }

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -473,6 +473,8 @@ class Renderer {
             const device = this.device;
             DebugGraphics.pushGpuMarker(device, 'CLEAR');
 
+            // this clear is not attachment aware, and clears all the color attachments of the
+            // render target to the color of the attachment 0
             const c = camera._clearColor;
             _tempClearColor[0] = c.r;
             _tempClearColor[1] = c.g;

--- a/test/framework/components/camera/component.test.mjs
+++ b/test/framework/components/camera/component.test.mjs
@@ -104,6 +104,9 @@ describe('CameraComponent', function () {
                 toneMapping: TONEMAP_ACES
             });
 
+            // per-attachment clear colors are script API only, not addComponent options
+            e.camera.setClearColor(1, new Color(0.5, 0.6, 0.7, 0.8));
+
             const clone = e.clone();
             const c = clone.camera;
 
@@ -114,6 +117,9 @@ describe('CameraComponent', function () {
             expect(c.calculateProjection).to.equal(calculateProjection);
             expect(c.calculateTransform).to.equal(calculateTransform);
             expect(c.clearColor.equals(new Color(0.1, 0.2, 0.3, 0.4))).to.equal(true);
+            expect(c.getClearColor(1).equals(new Color(0.5, 0.6, 0.7, 0.8))).to.equal(true);
+            expect(c.getClearColor(1)).to.not.equal(e.camera.getClearColor(1));
+            expect(c.getClearColor(2)).to.equal(c.clearColor);
             expect(c.clearColorBuffer).to.equal(false);
             expect(c.clearDepth).to.equal(0.5);
             expect(c.clearDepthBuffer).to.equal(false);

--- a/test/scene/camera.test.mjs
+++ b/test/scene/camera.test.mjs
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 
+import { Color } from '../../src/core/math/color.js';
 import { Vec2 } from '../../src/core/math/vec2.js';
 import { Vec3 } from '../../src/core/math/vec3.js';
 import { Vec4 } from '../../src/core/math/vec4.js';
@@ -40,6 +41,52 @@ describe('Camera', function () {
         it('defaults to ASPECT_AUTO', function () {
             const camera = new Camera(app.graphicsDevice);
             expect(camera.aspectRatioMode).to.equal(ASPECT_AUTO);
+        });
+    });
+
+    describe('#setClearColor', function () {
+
+        it('sets the attachment 0 color, which is the clearColor', function () {
+            const camera = new Camera(app.graphicsDevice);
+            camera.setClearColor(0, new Color(0.1, 0.2, 0.3, 0.4));
+            expect(camera.clearColor.equals(new Color(0.1, 0.2, 0.3, 0.4))).to.equal(true);
+            expect(camera.getClearColor(0)).to.equal(camera.clearColor);
+        });
+
+        it('other attachments clear to the attachment 0 color until given their own', function () {
+            const camera = new Camera(app.graphicsDevice);
+            expect(camera.getClearColor(1)).to.equal(camera.clearColor);
+
+            camera.setClearColor(1, new Color(1, 0, 0, 1));
+            expect(camera.getClearColor(1).equals(new Color(1, 0, 0, 1))).to.equal(true);
+            expect(camera.getClearColor(2)).to.equal(camera.clearColor);
+        });
+
+        it('copies the color rather than referencing it', function () {
+            const camera = new Camera(app.graphicsDevice);
+            const color = new Color(1, 0, 0, 1);
+            camera.setClearColor(1, color);
+            color.set(0, 1, 0, 1);
+            expect(camera.getClearColor(1).equals(new Color(1, 0, 0, 1))).to.equal(true);
+        });
+
+        it('null removes the color of an attachment', function () {
+            const camera = new Camera(app.graphicsDevice);
+            camera.setClearColor(1, new Color(1, 0, 0, 1));
+            camera.setClearColor(1, null);
+            expect(camera.getClearColor(1)).to.equal(camera.clearColor);
+        });
+
+        it('is copied by clone()', function () {
+            const camera = new Camera(app.graphicsDevice);
+            camera.setClearColor(1, new Color(1, 0, 0, 1));
+            camera.setClearColor(3, new Color(0, 0, 1, 1));
+
+            const clone = camera.clone();
+            expect(clone.getClearColor(1).equals(new Color(1, 0, 0, 1))).to.equal(true);
+            expect(clone.getClearColor(2)).to.equal(clone.clearColor);
+            expect(clone.getClearColor(3).equals(new Color(0, 0, 1, 1))).to.equal(true);
+            expect(clone.getClearColor(1)).to.not.equal(camera.getClearColor(1));
         });
     });
 


### PR DESCRIPTION
Lets a camera rendering to a RenderTarget with multiple color buffers clear each attachment to its own color. Previously the camera's single clearColor was copied to every attachment of the render pass, and there was no way to change that from user code, as RenderPassForward rebuilds its clear values every frame.

Part of #5356.

**Changes:**
- `CameraComponent#setClearColor(index, color)` / `getClearColor(index)`: per color attachment clear colors. Attachment 0 is `clearColor`; the other attachments clear to it until given their own, so existing content is unaffected. Passing `null` removes an attachment's color again. Script API only, not exposed as a component property.
- `RenderPassForward#updateClears` applies the camera's color per attachment (passes rendering the scene textures still set attachment 0 only).
- Per-attachment colors survive `entity.clone()` (`CameraComponentSystem#cloneComponent`) and `Camera#copy` / `CameraComponent#copy`.
- Tests for the new API and its cloning.

**API Changes:**
- Added `CameraComponent#setClearColor(index, color)` and `CameraComponent#getClearColor(index)`.

**Examples:**
- `graphics/multi-render-targets` clears the normals and gloss buffers to their own colors.