### PR TITLE
Fix sprite tint color space conversion

### DIFF
--- a/src/framework/components/sprite/component.js
+++ b/src/framework/components/sprite/component.js
@@ -29,6 +29,7 @@ const PARAM_OPACITY = 'material_opacity';
 const PARAM_INNER_OFFSET = 'innerOffset';
 const PARAM_OUTER_SCALE = 'outerScale';
 const PARAM_ATLAS_RECT = 'atlasRect';
+const tempColor = new Color();
 
 /**
  * The SpriteComponent enables an {@link Entity} to render a simple static sprite or sprite
@@ -406,7 +407,7 @@ class SpriteComponent extends Component {
     }
 
     /**
-     * Sets the color tint of the sprite.
+     * Sets the color tint of the sprite, specified in sRGB color space.
      *
      * @type {Color}
      */
@@ -416,15 +417,12 @@ class SpriteComponent extends Component {
         this._color.b = value.b;
 
         if (this._meshInstance) {
-            this._colorUniform[0] = this._color.r;
-            this._colorUniform[1] = this._color.g;
-            this._colorUniform[2] = this._color.b;
-            this._meshInstance.setParameter(PARAM_EMISSIVE, this._colorUniform);
+            this._updateColor();
         }
     }
 
     /**
-     * Gets the color tint of the sprite. Use the setter to update the tint.
+     * Gets the color tint of the sprite in sRGB color space. Use the setter to update the tint.
      *
      * @type {Readonly<Color>}
      */
@@ -868,6 +866,16 @@ class SpriteComponent extends Component {
         this._inLayers = false;
     }
 
+    /** @private */
+    _updateColor() {
+        // Color uniforms are in linear space.
+        tempColor.linear(this._color);
+        this._colorUniform[0] = tempColor.r;
+        this._colorUniform[1] = tempColor.g;
+        this._colorUniform[2] = tempColor.b;
+        this._meshInstance.setParameter(PARAM_EMISSIVE, this._colorUniform);
+    }
+
     // Set the desired mesh on the mesh instance
     _showFrame(frame) {
         if (!this.sprite) return;
@@ -900,10 +908,7 @@ class SpriteComponent extends Component {
             this._meshInstance.drawOrder = this._drawOrder;
 
             // set overrides on mesh instance
-            this._colorUniform[0] = this._color.r;
-            this._colorUniform[1] = this._color.g;
-            this._colorUniform[2] = this._color.b;
-            this._meshInstance.setParameter(PARAM_EMISSIVE, this._colorUniform);
+            this._updateColor();
             this._meshInstance.setParameter(PARAM_OPACITY, this._color.a);
 
             // now that we created the mesh instance, add it to the layers

--- a/test/framework/components/sprite/component.test.mjs
+++ b/test/framework/components/sprite/component.test.mjs
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 
+import { Color } from '../../../../src/core/math/color.js';
 import { Asset } from '../../../../src/framework/asset/asset.js';
 import { Entity } from '../../../../src/framework/entity.js';
 import { createApp } from '../../../app.mjs';
@@ -77,6 +78,38 @@ describe('SpriteComponent', function () {
         e.addComponent('sprite');
 
         expect(e.sprite).to.exist;
+    });
+
+    [true, false].forEach((tintBeforeSprite) => {
+        it(`Converts sRGB tint set ${tintBeforeSprite ? 'before' : 'after'} the sprite is assigned`, function () {
+            const e = new Entity();
+            app.root.addChild(e);
+            e.addComponent('sprite');
+
+            const color = new Color(0.5, 0.25, 0.75);
+            e.sprite.opacity = 0.4;
+
+            if (!tintBeforeSprite) {
+                e.sprite.spriteAsset = spriteAsset;
+            }
+
+            e.sprite.color = color;
+
+            if (tintBeforeSprite) {
+                e.sprite.spriteAsset = spriteAsset;
+            }
+
+            const emissive = e.sprite._meshInstance.getParameter('material_emissive').data;
+            expect(emissive[0]).to.be.closeTo(0.217638, 0.000001);
+            expect(emissive[1]).to.be.closeTo(0.047366, 0.000001);
+            expect(emissive[2]).to.be.closeTo(0.531049, 0.000001);
+            expect(e.sprite.color.r).to.equal(0.5);
+            expect(e.sprite.color.g).to.equal(0.25);
+            expect(e.sprite.color.b).to.equal(0.75);
+            expect(color).to.deep.equal(new Color(0.5, 0.25, 0.75));
+            expect(e.sprite.opacity).to.equal(0.4);
+            expect(e.sprite._meshInstance.getParameter('material_opacity').data).to.equal(0.4);
+        });
     });
 
     it('Add / Remove Component', function () {


### PR DESCRIPTION
Fix sprite tints appearing brighter than the selected sRGB color by converting RGB to linear space before uploading it, matching image elements and StandardMaterial.

Fixes #9240.

**Changes:**
- Apply the conversion both when changing the tint and when creating the sprite mesh.
- Document `SpriteComponent.color` as sRGB; preserve the public color value and opacity.
- Add regression coverage for tints assigned before and after the sprite asset.

**API Changes:**
Existing midtone sprite tints now appear darker. There are no API signature changes. On an opaque white sprite with gamma output:

```javascript
// Before: displayed approximately as sRGB (0.73, 0.73, 0.73).
entity.sprite.color = new Color(0.5, 0.5, 0.5);

// After: displayed as the selected sRGB (0.5, 0.5, 0.5).
entity.sprite.color = new Color(0.5, 0.5, 0.5);
```
