### PR TITLE
Add useFog/useTonemap to ParticleSystemComponent, deprecate noFog

### DIFF
--- a/examples/src/examples/test/global-shader-properties.controls.jsx
+++ b/examples/src/examples/test/global-shader-properties.controls.jsx
@@ -68,6 +68,22 @@ export function Controls({ observer }) {
                     />
                 </LabelGroup>
             </Panel>
+            <Panel headerText='Particles'>
+                <LabelGroup text='Fog'>
+                    <BooleanInput
+                        type='toggle'
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'data.particleFog' }}
+                    />
+                </LabelGroup>
+                <LabelGroup text='Tonemapping'>
+                    <BooleanInput
+                        type='toggle'
+                        binding={new BindingTwoWay()}
+                        link={{ observer, path: 'data.particleTonemap' }}
+                    />
+                </LabelGroup>
+            </Panel>
         </>
     );
 }

--- a/examples/src/examples/test/global-shader-properties.example.mjs
+++ b/examples/src/examples/test/global-shader-properties.example.mjs
@@ -288,11 +288,19 @@ data.on('*:set', (path, value) => {
     if (propertyName === 'gamma') {
         camera.camera.gammaCorrection = value ? GAMMA_SRGB : GAMMA_NONE;
     }
+    if (propertyName === 'particleFog') {
+        entity.particlesystem.useFog = value;
+    }
+    if (propertyName === 'particleTonemap') {
+        entity.particlesystem.useTonemap = value;
+    }
 });
 
 // Initial values
 data.set('data', {
     tonemapping: TONEMAP_ACES,
     fog: FOG_LINEAR,
-    gamma: true
+    gamma: true,
+    particleFog: true,
+    particleTonemap: true
 });

--- a/src/framework/components/particle-system/component.js
+++ b/src/framework/components/particle-system/component.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../../core/debug.js';
 import { Vec3 } from '../../../core/math/vec3.js';
 import { BLEND_NORMAL, EMITTERSHAPE_BOX, LAYERID_DEPTH, LAYERID_WORLD, PARTICLEORIENTATION_SCREEN } from '../../../scene/constants.js';
 import { Mesh } from '../../../scene/mesh.js';
@@ -29,7 +30,8 @@ const _properties = [
     'halfLambert',
     'intensity',
     'depthWrite',
-    'noFog',
+    'useFog',
+    'useTonemap',
     'depthSoftening',
     'sort',
     'blendType',
@@ -220,7 +222,10 @@ class ParticleSystemComponent extends Component {
     _depthWrite = false;
 
     /** @private */
-    _noFog = false;
+    _useFog = true;
+
+    /** @private */
+    _useTonemap = true;
 
     /** @private */
     _depthSoftening = 0;
@@ -679,21 +684,66 @@ class ParticleSystemComponent extends Component {
     }
 
     /**
-     * Sets whether fogging is ignored.
+     * Sets whether the camera's fog is applied to the particles. When false, the particles ignore
+     * fog even if the rendering camera has it enabled. Defaults to true.
      *
      * @type {boolean}
      */
+    set useFog(arg) {
+        this._setComplexProperty('useFog', arg);
+    }
+
+    /**
+     * Gets whether the camera's fog is applied to the particles.
+     *
+     * @type {boolean}
+     */
+    get useFog() {
+        return this._useFog;
+    }
+
+    /**
+     * Sets whether the camera's tonemapping and the scene exposure are applied to the particles.
+     * When false, the particles keep their authored colors, unaffected by {@link Scene#exposure}
+     * and {@link CameraComponent#toneMapping}. Fog, when enabled, still applies. Defaults to true.
+     *
+     * @type {boolean}
+     */
+    set useTonemap(arg) {
+        this._setComplexProperty('useTonemap', arg);
+    }
+
+    /**
+     * Gets whether the camera's tonemapping and the scene exposure are applied to the particles.
+     *
+     * @type {boolean}
+     */
+    get useTonemap() {
+        return this._useTonemap;
+    }
+
+    /**
+     * Sets whether fogging is ignored.
+     *
+     * @type {boolean}
+     * @deprecated Use {@link ParticleSystemComponent#useFog} instead.
+     * @ignore
+     */
     set noFog(arg) {
-        this._setComplexProperty('noFog', arg);
+        Debug.deprecated('ParticleSystemComponent#noFog is deprecated. Use ParticleSystemComponent#useFog instead.');
+        this.useFog = !arg;
     }
 
     /**
      * Gets whether fogging is ignored.
      *
      * @type {boolean}
+     * @deprecated Use {@link ParticleSystemComponent#useFog} instead.
+     * @ignore
      */
     get noFog() {
-        return this._noFog;
+        Debug.deprecated('ParticleSystemComponent#noFog is deprecated. Use ParticleSystemComponent#useFog instead.');
+        return !this.useFog;
     }
 
     /**
@@ -2180,7 +2230,8 @@ class ParticleSystemComponent extends Component {
                 scene: this.system.app.scene,
                 mesh: this._mesh,
                 depthWrite: this._depthWrite,
-                noFog: this._noFog,
+                useFog: this._useFog,
+                useTonemap: this._useTonemap,
                 node: this.entity,
                 blendType: this._blendType
             });

--- a/src/framework/components/particle-system/system.js
+++ b/src/framework/components/particle-system/system.js
@@ -1,3 +1,4 @@
+import { Debug } from '../../../core/debug.js';
 import { Curve } from '../../../core/math/curve.js';
 import { CurveSet } from '../../../core/math/curve-set.js';
 import { Vec3 } from '../../../core/math/vec3.js';
@@ -130,6 +131,13 @@ class ParticleSystemComponentSystem extends ComponentSystem {
             // migrate into meshAsset property
             data.meshAsset = data.mesh;
             delete data.mesh;
+        }
+
+        // 'noFog' was replaced by 'useFog' - migrate legacy data, letting an explicit 'useFog' win
+        if (data.noFog !== undefined) {
+            Debug.deprecated('ParticleSystemComponent#noFog is deprecated. Use ParticleSystemComponent#useFog instead.');
+            if (data.useFog === undefined) data.useFog = !data.noFog;
+            delete data.noFog;
         }
 
         for (const prop in data) {

--- a/src/scene/particle-system/particle-emitter.js
+++ b/src/scene/particle-system/particle-emitter.js
@@ -289,7 +289,12 @@ class ParticleEmitter {
         setProperty('orientation', PARTICLEORIENTATION_SCREEN);
 
         setProperty('depthWrite', false);
-        setProperty('noFog', false);
+        setProperty('useFog', true);
+        setProperty('useTonemap', true);
+        if (options.noFog !== undefined) {
+            Debug.deprecated('ParticleEmitter option noFog is deprecated. Use useFog instead.');
+            if (options.useFog === undefined) this.useFog = !options.noFog;
+        }
         setProperty('blendType', BLEND_NORMAL);
         setProperty('node', null);
         setProperty('startAngle', 0);

--- a/src/scene/particle-system/particle-material.js
+++ b/src/scene/particle-system/particle-material.js
@@ -1,12 +1,6 @@
 import { Debug } from '../../core/debug.js';
 import { ShaderProcessorOptions } from '../../platform/graphics/shader-processor-options.js';
-import {
-    GAMMA_NONE,
-    PARTICLEORIENTATION_SCREEN,
-    SHADER_FORWARD,
-    SHADERDEF_UV0,
-    TONEMAP_LINEAR
-} from '../constants.js';
+import { PARTICLEORIENTATION_SCREEN, SHADER_FORWARD, SHADERDEF_UV0 } from '../constants.js';
 import { getProgramLibrary } from '../shader-lib/get-program-library.js';
 import { Material } from '../materials/material.js';
 import { particle } from '../shader-lib/programs/particle.js';
@@ -43,10 +37,17 @@ class ParticleMaterial extends Material {
     /** @ignore */
     getShaderVariant(params) {
 
-        const { device, scene, cameraShaderParams, objDefs } = params;
+        const { device, objDefs } = params;
         const { emitter } = this;
+
+        // the camera's fog and tonemapping arrive as defines which take precedence over the
+        // material's own, so the emitter's per-system opt-outs are applied on top of the merge
+        const defines = ShaderUtils.getCoreDefines(this, params);
+        if (!emitter.useFog) defines.set('FOG', 'NONE');
+        if (!emitter.useTonemap) defines.set('TONEMAP', 'NONE');
+
         const options = {
-            defines: ShaderUtils.getCoreDefines(this, params),
+            defines,
             pass: SHADER_FORWARD,
             useCpu: this.emitter.useCpu,
             normal: emitter.lighting ? ((emitter.normalMap !== null) ? 2 : 1) : 0,
@@ -56,9 +57,6 @@ class ParticleMaterial extends Material {
             soft: this.emitter.depthSoftening,
             mesh: this.emitter.useMesh,
             meshUv: objDefs & SHADERDEF_UV0,
-            gamma: cameraShaderParams?.shaderOutputGamma ?? GAMMA_NONE,
-            toneMap: cameraShaderParams?.toneMapping ?? TONEMAP_LINEAR,
-            fog: (scene && !this.emitter.noFog) ? scene.fog.type : 'none',
             wrap: this.emitter.wrap && this.emitter.wrapBounds,
             localSpace: this.emitter.localSpace,
 

--- a/test/framework/components/particlesystem/component.test.mjs
+++ b/test/framework/components/particlesystem/component.test.mjs
@@ -90,7 +90,8 @@ describe('ParticleSystemComponent', function () {
         expect(c.halfLambert).to.be.false;
         expect(c.intensity).to.equal(1);
         expect(c.depthWrite).to.be.false;
-        expect(c.noFog).to.be.false;
+        expect(c.useFog).to.be.true;
+        expect(c.useTonemap).to.be.true;
         expect(c.depthSoftening).to.equal(0);
         expect(c.sort).to.equal(0);
         expect(c.blendType).to.equal(BLEND_NORMAL);
@@ -474,5 +475,61 @@ describe('ParticleSystemComponent', function () {
         expect(assets.mesh.hasEvent('unload')).to.be.false;
         expect(assets.mesh.hasEvent('change')).to.be.false;
         expect(assets.mesh.hasEvent('remove')).to.be.false;
+    });
+
+    describe('fog and tonemapping', function () {
+
+        beforeEach(function () {
+            // the null device skips particle systems by default - enable them so the emitter is created
+            app.graphicsDevice.disableParticleSystem = false;
+        });
+
+        it('forwards useFog and useTonemap to the emitter', function () {
+            const e = new Entity();
+            e.addComponent('particlesystem', { useFog: false, useTonemap: false });
+            app.root.addChild(e);
+
+            const c = e.particlesystem;
+            expect(c.useFog).to.be.false;
+            expect(c.useTonemap).to.be.false;
+            expect(c.emitter.useFog).to.be.false;
+            expect(c.emitter.useTonemap).to.be.false;
+
+            c.useFog = true;
+            c.useTonemap = true;
+            expect(c.emitter.useFog).to.be.true;
+            expect(c.emitter.useTonemap).to.be.true;
+        });
+
+        it('maps the deprecated noFog onto useFog', function () {
+            const e = new Entity();
+            e.addComponent('particlesystem', { noFog: true });
+            app.root.addChild(e);
+
+            const c = e.particlesystem;
+            expect(c.useFog).to.be.false;
+            expect(c.noFog).to.be.true;
+            expect(c.emitter.useFog).to.be.false;
+
+            c.noFog = false;
+            expect(c.useFog).to.be.true;
+            expect(c.emitter.useFog).to.be.true;
+        });
+
+        it('lets an explicit useFog win over legacy noFog data', function () {
+            const e = new Entity();
+            e.addComponent('particlesystem', { noFog: true, useFog: true });
+            expect(e.particlesystem.useFog).to.be.true;
+        });
+
+        it('clones useFog and useTonemap', function () {
+            const e = new Entity();
+            e.addComponent('particlesystem', { useFog: false, useTonemap: false });
+            app.root.addChild(e);
+
+            const c = e.clone().particlesystem;
+            expect(c.useFog).to.be.false;
+            expect(c.useTonemap).to.be.false;
+        });
     });
 });

--- a/test/scene/particle-system/particle-material.test.mjs
+++ b/test/scene/particle-system/particle-material.test.mjs
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+
+import { Entity } from '../../../src/framework/entity.js';
+import { CameraShaderParams } from '../../../src/scene/camera-shader-params.js';
+import { FOG_EXP, SHADER_FORWARD, TONEMAP_ACES } from '../../../src/scene/constants.js';
+import { createApp } from '../../app.mjs';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+/**
+ * @import { Application } from '../../../src/framework/application.js'
+ */
+
+describe('ParticleMaterial', function () {
+    /** @type {Application} */
+    let app;
+
+    beforeEach(function () {
+        jsdomSetup();
+        app = createApp();
+
+        // the null device skips particle systems by default - enable them so the emitter is created
+        app.graphicsDevice.disableParticleSystem = false;
+    });
+
+    afterEach(function () {
+        app?.destroy();
+        app = null;
+        jsdomTeardown();
+    });
+
+    /**
+     * Generate the particle fragment shader for a camera which has both fog and tonemapping enabled.
+     *
+     * @param {object} options - Particle system component options.
+     * @returns {string} The generated fragment shader source.
+     */
+    const fragmentSource = (options) => {
+        const entity = new Entity();
+        entity.addComponent('particlesystem', { numParticles: 10, ...options });
+        app.root.addChild(entity);
+
+        const cameraShaderParams = new CameraShaderParams();
+        cameraShaderParams.fog = FOG_EXP;
+        cameraShaderParams.toneMapping = TONEMAP_ACES;
+
+        const shader = entity.particlesystem.emitter.material.getShaderVariant({
+            device: app.graphicsDevice,
+            scene: app.scene,
+            objDefs: 0,
+            pass: SHADER_FORWARD,
+            cameraShaderParams
+        });
+
+        // a null source means the shader failed to preprocess
+        expect(shader.definition.fshader).to.be.a('string');
+        return shader.definition.fshader;
+    };
+
+    it('follows the camera fog and tonemapping by default', function () {
+        const source = fragmentSource({});
+        expect(source).to.include('fog_color');
+        expect(source).to.include('uniform float exposure');
+    });
+
+    it('drops fog when useFog is false, even though the camera has it enabled', function () {
+        // the camera's FOG define takes precedence over the material's own, so the opt-out has to
+        // be applied after the two are merged - this is what silently broke the old noFog
+        const source = fragmentSource({ useFog: false });
+        expect(source).to.not.include('fog_color');
+        expect(source).to.include('uniform float exposure');
+    });
+
+    it('drops tonemapping when useTonemap is false, even though the camera has it enabled', function () {
+        const source = fragmentSource({ useTonemap: false });
+        expect(source).to.not.include('uniform float exposure');
+        expect(source).to.include('fog_color');
+    });
+});


### PR DESCRIPTION
Adds per-particle-system opt-outs for fog and tonemapping, restoring the fog toggle which had silently stopped working. Fixes #7467.

`ParticleSystemComponent#noFog` has been a no-op since #7298 (v2.5.0): the particle shader generator stopped reading its `fog` option and now takes the `FOG` / `TONEMAP` defines from the camera, which take precedence over the material's own defines. The property only changed the shader cache key, never the shader. This PR applies the opt-outs on top of the merged defines, the same way `StandardMaterial#useFog` does, and adds the matching tonemapping toggle requested in the issue.

**Changes:**
- `ParticleMaterial` forces `FOG` / `TONEMAP` to `NONE` after the camera defines are merged, so the per-system flags actually reach the shader.
- Removed the dead `fog`, `gamma` and `toneMap` entries from the particle shader options; the defines hash already covers them.
- Legacy `noFog` component data and `ParticleEmitter` options are migrated onto `useFog`, with an explicit `useFog` winning if both are supplied.
- Tests for the shader output and the component flags, alias and cloning.

**API Changes:**
- Added `ParticleSystemComponent#useFog` (default `true`). When `false`, the particles ignore the camera's fog.
- Added `ParticleSystemComponent#useTonemap` (default `true`). When `false`, the particles skip the camera's tonemapping and the scene exposure, matching `GSplatParams#useTonemap`.
- Deprecated `ParticleSystemComponent#noFog` in favour of `useFog`. It still works and logs a deprecation warning.

  ```js
  // before
  entity.particlesystem.noFog = true;
  // after
  entity.particlesystem.useFog = false;
  ```

**Examples:**
- `test/global-shader-properties` gains a Particles panel with Fog and Tonemapping toggles alongside the camera-level controls.