### PR TITLE
Add user counters to AppStats

### DIFF
--- a/examples/src/examples/debug/mini-stats.example.mjs
+++ b/examples/src/examples/debug/mini-stats.example.mjs
@@ -2,7 +2,8 @@
 // @flag ENGINE=performance
 //
 // Watch a field of objects build and dissolve as entities, materials, vertex buffers and textures
-// are allocated and released. Click the MiniStats panel to cycle through its three views.
+// are allocated and released. A user counter plots a sine wave independently of the engine stats.
+// Click the MiniStats panel to cycle through its three views.
 
 import {
     AppBase,
@@ -66,6 +67,14 @@ options.startSizeIndex = 2;
 // Display additional counters
 // Note: for most of these to report values, either debug or profiling engine build needs to be used.
 options.stats = [
+    // Application-defined counter stored in AppStats.user
+    {
+        name: 'Wave',
+        stats: ['user.wave'],
+        decimalPlaces: 1,
+        watermark: 20
+    },
+
     // Frame update time in ms
     {
         name: 'Update',
@@ -136,6 +145,7 @@ options.stats = [
 ];
 
 // Create mini-stats system
+app.stats.user.set('wave', 10);
 const miniStats = new MiniStats(app, options);
 
 const step = 10;
@@ -288,7 +298,12 @@ let vertexBuffer;
 /** @type {Texture} */
 let texture;
 let statusTime = 0;
+let time = 0;
 app.on('update', (dt) => {
+    time += dt;
+    // Offset the sine wave to keep the graph between 0 and 20.
+    app.stats.user.set('wave', 10 + 10 * Math.sin(time));
+
     orbit += dt * 0.06;
     frameScene();
 

--- a/src/framework/app-base.js
+++ b/src/framework/app-base.js
@@ -723,8 +723,9 @@ class AppBase extends EventHandler {
     }
 
     /**
-     * The application's read-only performance statistics. Returns the same {@link AppStats}
-     * instance on every access. See {@link AppStats} for units, sampling and GPU profiling setup.
+     * The application's performance statistics. Returns the same {@link AppStats} instance on
+     * every access. Engine measurements are read-only; {@link AppStats#user} holds writable
+     * application-defined counters. See {@link AppStats} for units, sampling and GPU profiling setup.
      *
      * @type {AppStats}
      */

--- a/src/framework/app-stats.js
+++ b/src/framework/app-stats.js
@@ -5,7 +5,8 @@
  */
 
 /**
- * Read-only performance statistics for an application, accessed through {@link AppBase#stats}.
+ * Performance statistics for an application, accessed through {@link AppBase#stats}. Engine
+ * measurements are read-only; {@link user} holds writable application-defined counters.
  * Includes frame cadence, CPU phase timings, overall GPU frame timing, and estimated GPU resource
  * memory usage. CPU timings, GPU timings and memory statistics are available in all builds, subject
  * to graphics capabilities. Primitive counting requires a debug or profiler build; see each getter
@@ -48,6 +49,12 @@ class AppStats {
      * @private
      */
     _app;
+
+    /**
+     * @type {Map<string, number>}
+     * @private
+     */
+    _user = new Map();
 
     /**
      * Create a new AppStats instance.
@@ -150,6 +157,29 @@ class AppStats {
                 return this.ub + this.sb;
             }
         });
+    }
+
+    /**
+     * Application-defined numeric counters. Returns the same map on every access. Entries can be
+     * added, updated, deleted or cleared by the application; the engine never resets them.
+     * Available in all builds. Values and their units are defined by the application.
+     *
+     * To display a counter in {@link MiniStats}, configure a graph with a path such as `user.ai`.
+     * Counter names used in MiniStats must not contain dots, which separate path segments.
+     * Initialize counters before accumulating values and reset per-frame totals on `frameupdate`.
+     *
+     * @type {Map<string, number>}
+     * @example
+     * app.stats.user.set('ai', 0);
+     * app.on('frameupdate', () => app.stats.user.set('ai', 0));
+     *
+     * // Accumulate time spent in application code during this frame.
+     * const start = performance.now();
+     * // ... run AI logic ...
+     * app.stats.user.set('ai', app.stats.user.get('ai') + performance.now() - start);
+     */
+    get user() {
+        return this._user;
     }
 
     /**

--- a/test/framework/app-stats.test.mjs
+++ b/test/framework/app-stats.test.mjs
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { stub } from 'sinon';
 
+import { StatsTimer } from '../../src/extras/mini-stats/stats-timer.js';
 import { AppStats } from '../../src/framework/app-stats.js';
 import { INDEXFORMAT_UINT16, SEMANTIC_POSITION, TYPE_FLOAT32 } from '../../src/platform/graphics/constants.js';
 import { IndexBuffer } from '../../src/platform/graphics/index-buffer.js';
@@ -34,6 +35,37 @@ describe('AppStats', function () {
                 expect(descriptor.set, name).to.equal(undefined);
             }
         }
+    });
+
+    it('preserves application-owned counters across frames and samples map changes in MiniStats', function () {
+        const user = app.stats.user;
+        const otherApp = createApp();
+        try {
+            expect(otherApp.stats.user).not.to.equal(user);
+            expect(otherApp.stats.user.size).to.equal(0);
+        } finally {
+            otherApp.destroy();
+        }
+        const timer = new StatsTimer(app, ['user.ai']);
+        user.set('ai', 2.5);
+
+        app.stats.updateBasic(1000, 0.016, 16, app.renderer, app.graphicsDevice);
+        app.stats.updateDetailed(app.renderer, app.graphicsDevice);
+        app.stats.frameEnd();
+
+        expect(app.stats.user).to.equal(user);
+        expect(timer.timings[0]).to.equal(2.5);
+
+        user.set('ai', 4);
+        expect(timer.timings[0]).to.equal(4);
+        user.delete('ai');
+        expect(timer.timings[0]).to.equal(0);
+        user.set('ai', 1);
+        user.clear();
+        expect(timer.timings[0]).to.equal(0);
+        expect(() => {
+            app.stats.user = new Map();
+        }).to.throw(TypeError);
     });
 
     it('publishes frame cadence independently of scaled simulation time and consumes draw counts once', function () {

--- a/test/type-tests/app-stats.test.ts
+++ b/test/type-tests/app-stats.test.ts
@@ -1,0 +1,16 @@
+import type { AppBase } from '../../build/playcanvas.js';
+
+declare const app: AppBase;
+
+const user: Map<string, number> = app.stats.user;
+user.set('ai', 2.5);
+const duration: number | undefined = user.get('ai');
+user.delete('ai');
+user.clear();
+
+// @ts-expect-error Counter values must be numeric.
+app.stats.user.set('ai', 'slow');
+// @ts-expect-error Counter names must be strings.
+app.stats.user.set(1, 2.5);
+// @ts-expect-error The map can be mutated, but its reference cannot be replaced.
+app.stats.user = new Map<string, number>();


### PR DESCRIPTION
Publish application-defined counters and manual timings through a supported AppStats API, and display them in MiniStats.

**Changes**
- Add `AppStats.user`, a getter returning an application-owned `Map<string, number>` with a stable reference. Entries remain writable and persist until the application changes or removes them, in all builds.
- Document counter ownership, per-frame resets and MiniStats paths such as `user.ai`.

**API Changes**
Previously, custom counters required attaching undeclared properties to `app.stats`. Applications can now use the public map:

```javascript
app.stats.user.set('ai', 2.5);
const duration = app.stats.user.get('ai');
app.stats.user.delete('ai');
app.stats.user.clear();
```

MiniStats configuration: `stats: ['user.ai']`. No existing APIs change.

**Examples**
- Extend `debug/mini-stats` with a Wave counter driven by `10 + 10 * Math.sin(time)`.

**Performance**
- Allocate one map per application; sampling reuses the existing MiniStats path resolver.

Related to #3142. Documentation: https://github.com/playcanvas/developer-site/pull/1180 (merge after Engine 2.23 is released).
