### PR TITLE
Fix shadow shader selection when changing cascade count

### DIFF
--- a/src/scene/light.js
+++ b/src/scene/light.js
@@ -1146,7 +1146,7 @@ class Light {
                (chanId[this._cookieChannel.charAt(0)]     << 18) |
                ((this._cookieTransform ? 1 : 0)           << 12) |
                ((this._shape)                             << 10) |
-               ((this.numCascades > 0 ? 1 : 0)            <<  9) |
+               ((this.numCascades > 1 ? 1 : 0)            <<  9) |
                ((this._cascadeBlend > 0 ? 1 : 0)          <<  8) |
                ((this.affectSpecularity ? 1 : 0)          <<  7) |
                ((this.mask)                               <<  6) |


### PR DESCRIPTION
Fix corrupted directional shadows when switching between one and multiple cascades, including after changing the shadow filter.

**Changes:**
- Select the correct shadow shader when enabling or disabling cascaded shadows, on both WebGL and WebGPU.

Fixes #9342.
