### PR TITLE
Clear keyboard and mouse states on detach and focus loss

### DIFF
--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -198,7 +198,9 @@ class Keyboard extends EventHandler {
     }
 
     /**
-     * Attach the keyboard event handlers to an Element.
+     * Attach the keyboard event handlers to an Element. If already attached, this first detaches
+     * and clears current and previous key states, even when attaching to the same element. No
+     * `keyup` events are fired. Unlike {@link Mouse#attach}, held input states are not preserved.
      *
      * @param {Element|Window} element - The element to listen for keyboard events on.
      */
@@ -234,8 +236,7 @@ class Keyboard extends EventHandler {
         document.removeEventListener('visibilitychange', this._visibilityChangeHandler, false);
         window.removeEventListener('blur', this._windowBlurHandler, false);
 
-        this._keymap = {};
-        this._lastmap = {};
+        this._handleWindowBlur();
     }
 
     /**

--- a/src/platform/input/keyboard.js
+++ b/src/platform/input/keyboard.js
@@ -217,7 +217,8 @@ class Keyboard extends EventHandler {
     }
 
     /**
-     * Detach the keyboard event handlers from the element it is attached to.
+     * Detach the keyboard event handlers from the element it is attached to and clear current and
+     * previous key states. This does not fire `keyup` events.
      */
     detach() {
         if (!this._element) {
@@ -232,6 +233,9 @@ class Keyboard extends EventHandler {
 
         document.removeEventListener('visibilitychange', this._visibilityChangeHandler, false);
         window.removeEventListener('blur', this._windowBlurHandler, false);
+
+        this._keymap = {};
+        this._lastmap = {};
     }
 
     /**

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -14,8 +14,10 @@ import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
  *
  * Allows the state of mouse buttons to be queried to check if they are currently pressed or were
  * pressed/released since the last update. Provides methods to enable/disable pointer lock for
- * raw mouse movement input and control over the context menu. The Mouse instance must be attached
- * to a DOM element before it can detect mouse events.
+ * raw mouse movement input and control over the context menu. The class automatically clears
+ * button states when the window loses focus or the document becomes hidden, without firing
+ * `mouseup` events. The Mouse instance must be attached to a DOM element before it can detect
+ * mouse events.
  *
  * Your application's Mouse instance is managed and accessible via {@link AppBase#mouse}.
  *
@@ -120,6 +122,18 @@ class Mouse extends EventHandler {
     _contextMenuHandler;
 
     /**
+     * @type {() => void}
+     * @private
+     */
+    _visibilityChangeHandler;
+
+    /**
+     * @type {() => void}
+     * @private
+     */
+    _windowBlurHandler;
+
+    /**
      * Create a new Mouse instance.
      *
      * @param {Element} [element] - The Element that the mouse events are attached to.
@@ -132,6 +146,8 @@ class Mouse extends EventHandler {
         this._downHandler = this._handleDown.bind(this);
         this._moveHandler = this._handleMove.bind(this);
         this._wheelHandler = this._handleWheel.bind(this);
+        this._visibilityChangeHandler = this._handleVisibilityChange.bind(this);
+        this._windowBlurHandler = this._handleWindowBlur.bind(this);
         this._contextMenuHandler = (event) => {
             event.preventDefault();
         };
@@ -149,7 +165,8 @@ class Mouse extends EventHandler {
     }
 
     /**
-     * Attach mouse events to an Element.
+     * Attach mouse events to an Element. If already attached, this changes the target element
+     * while preserving current and previous button states, unlike {@link Keyboard#attach}.
      *
      * @param {Element} element - The DOM element to attach the mouse to.
      */
@@ -165,6 +182,8 @@ class Mouse extends EventHandler {
         window.addEventListener('mousedown', this._downHandler, options);
         window.addEventListener('mousemove', this._moveHandler, options);
         window.addEventListener('wheel', this._wheelHandler, options);
+        document.addEventListener('visibilitychange', this._visibilityChangeHandler, false);
+        window.addEventListener('blur', this._windowBlurHandler, false);
     }
 
     /**
@@ -182,9 +201,10 @@ class Mouse extends EventHandler {
         window.removeEventListener('mousedown', this._downHandler, options);
         window.removeEventListener('mousemove', this._moveHandler, options);
         window.removeEventListener('wheel', this._wheelHandler, options);
+        document.removeEventListener('visibilitychange', this._visibilityChangeHandler, false);
+        window.removeEventListener('blur', this._windowBlurHandler, false);
 
-        this._buttons.fill(false);
-        this._lastbuttons.fill(false);
+        this._handleWindowBlur();
     }
 
     /**
@@ -321,6 +341,27 @@ class Mouse extends EventHandler {
      */
     wasReleased(button) {
         return (!this._buttons[button] && this._lastbuttons[button]);
+    }
+
+    /**
+     * Handle the browser visibilitychange event.
+     *
+     * @private
+     */
+    _handleVisibilityChange() {
+        if (document.visibilityState === 'hidden') {
+            this._handleWindowBlur();
+        }
+    }
+
+    /**
+     * Handle the browser blur event.
+     *
+     * @private
+     */
+    _handleWindowBlur() {
+        this._buttons.fill(false);
+        this._lastbuttons.fill(false);
     }
 
     _handleUp(event) {

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -168,7 +168,8 @@ class Mouse extends EventHandler {
     }
 
     /**
-     * Remove mouse events from the element that it is attached to.
+     * Remove mouse events from the element that it is attached to and clear current and previous
+     * button states. This does not fire `mouseup` events.
      */
     detach() {
         if (!this._attached) return;
@@ -181,6 +182,9 @@ class Mouse extends EventHandler {
         window.removeEventListener('mousedown', this._downHandler, options);
         window.removeEventListener('mousemove', this._moveHandler, options);
         window.removeEventListener('wheel', this._wheelHandler, options);
+
+        this._buttons.fill(false);
+        this._lastbuttons.fill(false);
     }
 
     /**

--- a/test/platform/input/keyboard.test.mjs
+++ b/test/platform/input/keyboard.test.mjs
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 
-import { KEY_UP } from '../../../src/platform/input/constants.js';
+import { KEY_DOWN, KEY_UP } from '../../../src/platform/input/constants.js';
 import { Keyboard } from '../../../src/platform/input/keyboard.js';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
 describe('Keyboard', function () {
 
@@ -9,18 +10,89 @@ describe('Keyboard', function () {
     let keyboard;
 
     beforeEach(function () {
+        jsdomSetup();
         keyboard = new Keyboard();
         keyboard.attach(window);
     });
 
     afterEach(function () {
         keyboard.detach();
+        jsdomTeardown();
     });
 
     describe('#constructor', function () {
 
         it('should create a new instance', function () {
             expect(keyboard).to.be.an.instanceOf(Keyboard);
+        });
+
+    });
+
+    describe('#detach', function () {
+
+        ['pressed', 'held', 'released'].forEach((state) => {
+            it(`should clear all key states when detached with ${state} keys`, function () {
+                const keys = [KEY_UP, KEY_DOWN];
+                for (const keyCode of keys) {
+                    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode }));
+                }
+                if (state !== 'pressed') {
+                    keyboard.update();
+                }
+                if (state === 'released') {
+                    for (const keyCode of keys) {
+                        window.dispatchEvent(new KeyboardEvent('keyup', { keyCode }));
+                    }
+                }
+
+                keyboard.detach();
+
+                for (const key of keys) {
+                    expect(keyboard.isPressed(key)).to.be.false;
+                    expect(keyboard.wasPressed(key)).to.be.false;
+                    expect(keyboard.wasReleased(key)).to.be.false;
+                }
+                keyboard.attach(window);
+            });
+        });
+
+        it('should detect a fresh press after a key is released while detached', function () {
+            window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: KEY_UP }));
+            keyboard.update();
+            let releases = 0;
+            keyboard.on('keyup', () => releases++);
+
+            keyboard.detach();
+            window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: KEY_UP }));
+            keyboard.attach(window);
+
+            expect(releases).to.equal(0);
+            expect(keyboard.isPressed(KEY_UP)).to.be.false;
+            expect(keyboard.wasPressed(KEY_UP)).to.be.false;
+            expect(keyboard.wasReleased(KEY_UP)).to.be.false;
+
+            window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: KEY_UP }));
+            expect(keyboard.isPressed(KEY_UP)).to.be.true;
+            expect(keyboard.wasPressed(KEY_UP)).to.be.true;
+            keyboard.update();
+            window.dispatchEvent(new KeyboardEvent('keyup', { keyCode: KEY_UP }));
+            expect(releases).to.equal(1);
+            expect(keyboard.wasReleased(KEY_UP)).to.be.true;
+        });
+
+        it('should clear key states when attaching to another element', function () {
+            window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: KEY_UP }));
+            keyboard.update();
+
+            const element = document.createElement('div');
+            keyboard.attach(element);
+
+            expect(keyboard.isPressed(KEY_UP)).to.be.false;
+            expect(keyboard.wasPressed(KEY_UP)).to.be.false;
+            expect(keyboard.wasReleased(KEY_UP)).to.be.false;
+
+            element.dispatchEvent(new KeyboardEvent('keydown', { keyCode: KEY_UP }));
+            expect(keyboard.wasPressed(KEY_UP)).to.be.true;
         });
 
     });

--- a/test/platform/input/keyboard.test.mjs
+++ b/test/platform/input/keyboard.test.mjs
@@ -80,6 +80,23 @@ describe('Keyboard', function () {
             expect(keyboard.wasReleased(KEY_UP)).to.be.true;
         });
 
+    });
+
+    describe('#attach', function () {
+
+        it('should clear key states when attaching to the same element', function () {
+            window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: KEY_UP }));
+            keyboard.update();
+
+            keyboard.attach(window);
+
+            expect(keyboard.isPressed(KEY_UP)).to.be.false;
+            expect(keyboard.wasPressed(KEY_UP)).to.be.false;
+            expect(keyboard.wasReleased(KEY_UP)).to.be.false;
+            window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: KEY_UP }));
+            expect(keyboard.wasPressed(KEY_UP)).to.be.true;
+        });
+
         it('should clear key states when attaching to another element', function () {
             window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: KEY_UP }));
             keyboard.update();

--- a/test/platform/input/mouse.test.mjs
+++ b/test/platform/input/mouse.test.mjs
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { MOUSEBUTTON_LEFT, MOUSEBUTTON_MIDDLE, MOUSEBUTTON_RIGHT } from '../../../src/platform/input/constants.js';
 import { Mouse } from '../../../src/platform/input/mouse.js';
@@ -23,6 +24,7 @@ describe('Mouse', function () {
 
     afterEach(function () {
         mouse.detach();
+        sinon.restore();
         jsdomTeardown();
     });
 
@@ -90,6 +92,96 @@ describe('Mouse', function () {
                 expect(mouse.wasReleased(button)).to.be.true;
             }
             expect(releases).to.equal(buttons.length);
+        });
+
+    });
+
+    describe('focus loss', function () {
+
+        ['blur', 'hidden'].forEach((event) => {
+            it(`should reset button states without firing mouseup on ${event}`, function () {
+                // Cover a pending press, a held button and a pending release together.
+                window.dispatchEvent(new MouseEvent('mousedown', { button: MOUSEBUTTON_MIDDLE }));
+                window.dispatchEvent(new MouseEvent('mousedown', { button: MOUSEBUTTON_RIGHT }));
+                mouse.update();
+                window.dispatchEvent(new MouseEvent('mousedown', { button: MOUSEBUTTON_LEFT }));
+                window.dispatchEvent(new MouseEvent('mouseup', { button: MOUSEBUTTON_RIGHT }));
+                const onMouseUp = sinon.spy();
+                mouse.on('mouseup', onMouseUp);
+
+                if (event === 'blur') {
+                    window.dispatchEvent(new window.Event('blur'));
+                } else {
+                    sinon.stub(document, 'visibilityState').get(() => 'hidden');
+                    document.dispatchEvent(new window.Event('visibilitychange'));
+                }
+
+                expect(onMouseUp.called).to.be.false;
+                for (const button of buttons) {
+                    expect(mouse.isPressed(button)).to.be.false;
+                    expect(mouse.wasPressed(button)).to.be.false;
+                    expect(mouse.wasReleased(button)).to.be.false;
+                }
+
+                window.dispatchEvent(new MouseEvent('mousedown', { button: MOUSEBUTTON_MIDDLE }));
+                expect(mouse.wasPressed(MOUSEBUTTON_MIDDLE)).to.be.true;
+                mouse.update();
+                window.dispatchEvent(new MouseEvent('mouseup', { button: MOUSEBUTTON_MIDDLE }));
+                expect(mouse.wasReleased(MOUSEBUTTON_MIDDLE)).to.be.true;
+                expect(onMouseUp.calledOnce).to.be.true;
+            });
+        });
+
+        it('should preserve button states when the document becomes visible', function () {
+            window.dispatchEvent(new MouseEvent('mousedown', { button: MOUSEBUTTON_LEFT }));
+            mouse.update();
+            sinon.stub(document, 'visibilityState').get(() => 'visible');
+
+            document.dispatchEvent(new window.Event('visibilitychange'));
+
+            expect(mouse.isPressed(MOUSEBUTTON_LEFT)).to.be.true;
+            expect(mouse.wasPressed(MOUSEBUTTON_LEFT)).to.be.false;
+            expect(mouse.wasReleased(MOUSEBUTTON_LEFT)).to.be.false;
+        });
+
+        it('should remove focus listeners on detach and restore them on reattachment', function () {
+            mouse.detach();
+            const windowAdd = sinon.spy(window, 'addEventListener');
+            const documentAdd = sinon.spy(document, 'addEventListener');
+            const windowRemove = sinon.spy(window, 'removeEventListener');
+            const documentRemove = sinon.spy(document, 'removeEventListener');
+            mouse.attach(document.body);
+            const blurListener = windowAdd.getCalls().find(call => call.args[0] === 'blur')?.args[1];
+            const visibilityListener = documentAdd.getCalls().find(call => call.args[0] === 'visibilitychange')?.args[1];
+            expect(blurListener).to.be.a('function');
+            expect(visibilityListener).to.be.a('function');
+
+            mouse.detach();
+
+            expect(windowRemove.calledWith('blur', blurListener)).to.be.true;
+            expect(documentRemove.calledWith('visibilitychange', visibilityListener)).to.be.true;
+
+            mouse.attach(document.body);
+            window.dispatchEvent(new MouseEvent('mousedown', { button: MOUSEBUTTON_LEFT }));
+            window.dispatchEvent(new window.Event('blur'));
+            expect(mouse.isPressed(MOUSEBUTTON_LEFT)).to.be.false;
+        });
+
+    });
+
+    describe('#attach', function () {
+
+        it('should preserve button states when attaching to another element', function () {
+            window.dispatchEvent(new MouseEvent('mousedown', { button: MOUSEBUTTON_LEFT }));
+            mouse.update();
+
+            mouse.attach(document.createElement('div'));
+
+            expect(mouse.isPressed(MOUSEBUTTON_LEFT)).to.be.true;
+            expect(mouse.wasPressed(MOUSEBUTTON_LEFT)).to.be.false;
+            expect(mouse.wasReleased(MOUSEBUTTON_LEFT)).to.be.false;
+            window.dispatchEvent(new MouseEvent('mouseup', { button: MOUSEBUTTON_LEFT }));
+            expect(mouse.wasReleased(MOUSEBUTTON_LEFT)).to.be.true;
         });
 
     });

--- a/test/platform/input/mouse.test.mjs
+++ b/test/platform/input/mouse.test.mjs
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import { MOUSEBUTTON_LEFT, MOUSEBUTTON_MIDDLE, MOUSEBUTTON_RIGHT } from '../../../src/platform/input/constants.js';
 import { Mouse } from '../../../src/platform/input/mouse.js';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
 const buttons = [MOUSEBUTTON_LEFT, MOUSEBUTTON_MIDDLE, MOUSEBUTTON_RIGHT];
 
@@ -16,17 +17,79 @@ describe('Mouse', function () {
     let mouse;
 
     beforeEach(function () {
+        jsdomSetup();
         mouse = new Mouse(document.body);
     });
 
     afterEach(function () {
         mouse.detach();
+        jsdomTeardown();
     });
 
     describe('#constructor', function () {
 
         it('should create a new instance', function () {
             expect(mouse).to.be.an.instanceOf(Mouse);
+        });
+
+    });
+
+    describe('#detach', function () {
+
+        ['pressed', 'held', 'released'].forEach((state) => {
+            it(`should clear all button states when detached with ${state} buttons`, function () {
+                for (const button of buttons) {
+                    window.dispatchEvent(new MouseEvent('mousedown', { button }));
+                }
+                if (state !== 'pressed') {
+                    mouse.update();
+                }
+                if (state === 'released') {
+                    for (const button of buttons) {
+                        window.dispatchEvent(new MouseEvent('mouseup', { button }));
+                    }
+                }
+
+                mouse.detach();
+
+                for (const button of buttons) {
+                    expect(mouse.isPressed(button)).to.be.false;
+                    expect(mouse.wasPressed(button)).to.be.false;
+                    expect(mouse.wasReleased(button)).to.be.false;
+                }
+            });
+        });
+
+        it('should detect fresh presses after buttons are released while detached', function () {
+            for (const button of buttons) {
+                window.dispatchEvent(new MouseEvent('mousedown', { button }));
+            }
+            mouse.update();
+            let releases = 0;
+            mouse.on('mouseup', () => releases++);
+
+            mouse.detach();
+            for (const button of buttons) {
+                window.dispatchEvent(new MouseEvent('mouseup', { button }));
+            }
+            mouse.attach(document.body);
+
+            expect(releases).to.equal(0);
+            for (const button of buttons) {
+                expect(mouse.isPressed(button)).to.be.false;
+                expect(mouse.wasPressed(button)).to.be.false;
+                expect(mouse.wasReleased(button)).to.be.false;
+
+                window.dispatchEvent(new MouseEvent('mousedown', { button }));
+                expect(mouse.isPressed(button)).to.be.true;
+                expect(mouse.wasPressed(button)).to.be.true;
+            }
+            mouse.update();
+            for (const button of buttons) {
+                window.dispatchEvent(new MouseEvent('mouseup', { button }));
+                expect(mouse.wasReleased(button)).to.be.true;
+            }
+            expect(releases).to.equal(buttons.length);
         });
 
     });


### PR DESCRIPTION
Fixes #4005. Keys and mouse buttons can remain stuck when released while detached; mouse buttons can also remain stuck when released after the window loses focus.

**Changes:**
- Clear current and previous input states when detaching the keyboard or mouse.
- Clear mouse button states on window blur and when the document becomes hidden, matching keyboard behavior.
- Preserve the existing behavior of emitting no synthetic keyup or mouseup events.
- Document attachment behavior and cover detachment, focus loss, listener cleanup, reattachment and fresh presses with regression tests.

**API Changes:**
`Keyboard.detach()` and `Mouse.detach()` now reset `isPressed()`, `wasPressed()`, and `wasReleased()` to false. Mouse state also resets on window blur or document hiding.

`Keyboard.attach()` resets key states when already attached, including when passed the same element. `Mouse.attach()` continues to preserve button states when changing targets.

Before → after, assuming the input is held:
- `keyboard.detach(); keyboard.isPressed(KEY_UP);` — `true` → `false`.
- `mouse.detach(); mouse.isPressed(MOUSEBUTTON_LEFT);` — `true` → `false`.
- `keyboard.attach(otherElement); keyboard.isPressed(KEY_UP);` — `true` → `false`.
- `mouse.isPressed(MOUSEBUTTON_LEFT)` after window blur or document hiding — `true` → `false`.
