### PR TITLE
Restore generated HDR environments in examples after device loss

### DIFF
--- a/examples/src/examples/compute/indirect-dispatch.example.mjs
+++ b/examples/src/examples/compute/indirect-dispatch.example.mjs
@@ -240,17 +240,29 @@ await new Promise((resolve) => {
 });
 
 // Setup skydome from HDR texture
-const hdriSource = assets.hdri.resource;
+const applyHdri = () => {
+    const oldSkybox = app.scene.skybox;
+    const oldEnvAtlas = app.scene.envAtlas;
 
-// Convert to high resolution cubemap for the skybox
-const skybox = EnvLighting.generateSkyboxCubemap(hdriSource);
-app.scene.skybox = skybox;
+    const hdriSource = assets.hdri.resource;
 
-// Generate env-atlas texture for the lighting
-const lighting = EnvLighting.generateLightingSource(hdriSource);
-const envAtlas = EnvLighting.generateAtlas(lighting);
-lighting.destroy();
-app.scene.envAtlas = envAtlas;
+    // Convert to high resolution cubemap for the skybox
+    const skybox = EnvLighting.generateSkyboxCubemap(hdriSource);
+    app.scene.skybox = skybox;
+
+    // Generate env-atlas texture for the lighting
+    const lighting = EnvLighting.generateLightingSource(hdriSource);
+    const envAtlas = EnvLighting.generateAtlas(lighting);
+    lighting.destroy();
+    app.scene.envAtlas = envAtlas;
+
+    oldSkybox?.destroy();
+    oldEnvAtlas?.destroy();
+};
+
+// Generated environment textures need to be rebuilt after device loss.
+device.on('devicerestored', applyHdri);
+applyHdri();
 
 // Configure projected skydome
 app.scene.sky.type = SKYTYPE_DOME;

--- a/examples/src/examples/gaussian-splatting/billions.example.mjs
+++ b/examples/src/examples/gaussian-splatting/billions.example.mjs
@@ -177,7 +177,21 @@ const miniStats = new MiniStats(app, MiniStats.getDefaultOptions(['gsplats', 'gs
 // Generated up front (one-off GPU work) but NOT assigned to scene.skybox yet — the backdrop is
 // revealed together with the splats once their first (worst-LOD) frame is ready (see below),
 // so the sky doesn't pop in before the scene.
-const skyboxCubemap = EnvLighting.generateSkyboxCubemap(assets.sky.resource, 1024);
+let skyboxCubemap;
+const applyHdri = () => {
+    const oldSkybox = skyboxCubemap;
+    skyboxCubemap = EnvLighting.generateSkyboxCubemap(assets.sky.resource, 1024);
+    // Keep the backdrop hidden until the first splat frame is ready.
+    if (oldSkybox && app.scene.skybox === oldSkybox) {
+        app.scene.skybox = skyboxCubemap;
+    }
+    oldSkybox?.destroy();
+    app.renderNextFrame = true;
+};
+
+// The skybox is generated on the GPU and needs rebuilding after device loss.
+device.on('devicerestored', applyHdri);
+applyHdri();
 app.scene.sky.type = SKYTYPE_INFINITE;
 
 // Sky rotation (degrees about the vertical axis), exposed in the UI to aim a feature of the

--- a/examples/src/examples/gaussian-splatting/downtown.example.mjs
+++ b/examples/src/examples/gaussian-splatting/downtown.example.mjs
@@ -224,7 +224,21 @@ let revealStarted = false;
 // scene.envAtlas — the splats are pre-lit, so the sky contributes no lighting, just a backdrop.
 // Generated up front but revealed together with the scene (on frame:ready), so it doesn't pop
 // in before the splats.
-const skyboxCubemap = EnvLighting.generateSkyboxCubemap(assets.sky.resource, 1024);
+let skyboxCubemap;
+const applyHdri = () => {
+    const oldSkybox = skyboxCubemap;
+    skyboxCubemap = EnvLighting.generateSkyboxCubemap(assets.sky.resource, 1024);
+    // Keep the backdrop hidden until the first splat frame is ready.
+    if (oldSkybox && app.scene.skybox === oldSkybox) {
+        app.scene.skybox = skyboxCubemap;
+    }
+    oldSkybox?.destroy();
+    app.renderNextFrame = true;
+};
+
+// The skybox is generated on the GPU and needs rebuilding after device loss.
+device.on('devicerestored', applyHdri);
+applyHdri();
 app.scene.sky.type = SKYTYPE_INFINITE;
 
 // Start with the 4 lowest (coarsest) LODs for a fast initial display that still gets some

--- a/examples/src/examples/gaussian-splatting/glass-refraction.example.mjs
+++ b/examples/src/examples/gaussian-splatting/glass-refraction.example.mjs
@@ -281,11 +281,23 @@ app.start();
 // Use the HDRI as both the visible background and the lighting/reflection environment.
 // generateSkyboxCubemap gives a high-resolution skybox for the background, while the
 // prefiltered env-atlas drives the glass reflections and scene lighting.
-const hdri = assets.hdri.resource;
-app.scene.skybox = EnvLighting.generateSkyboxCubemap(hdri);
-const lightingSource = EnvLighting.generateLightingSource(hdri);
-app.scene.envAtlas = EnvLighting.generateAtlas(lightingSource);
-lightingSource.destroy();
+const applyHdri = () => {
+    const oldSkybox = app.scene.skybox;
+    const oldEnvAtlas = app.scene.envAtlas;
+
+    const hdri = assets.hdri.resource;
+    app.scene.skybox = EnvLighting.generateSkyboxCubemap(hdri);
+    const lightingSource = EnvLighting.generateLightingSource(hdri);
+    app.scene.envAtlas = EnvLighting.generateAtlas(lightingSource);
+    lightingSource.destroy();
+
+    oldSkybox?.destroy();
+    oldEnvAtlas?.destroy();
+};
+
+// Generated environment textures need to be rebuilt after device loss.
+device.on('devicerestored', applyHdri);
+applyHdri();
 app.scene.skyboxMip = 1;
 app.scene.exposure = 1.5;
 

--- a/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
+++ b/examples/src/examples/gaussian-splatting/lod-streaming.example.mjs
@@ -392,7 +392,7 @@ document.body.appendChild(phCredit);
 app.on('destroy', () => phCredit.remove());
 
 // HDRI environment loading
-/** @type {Map<string, { skybox: Texture, envAtlas: Texture }>} */
+/** @type {Map<string, { source: Texture, skybox: Texture, envAtlas: Texture }>} */
 const hdriCache = new Map();
 
 const applyEnvironment = async (/** @type {string} */ name) => {
@@ -422,7 +422,7 @@ const applyEnvironment = async (/** @type {string} */ name) => {
         const lighting = EnvLighting.generateLightingSource(source);
         const envAtlas = EnvLighting.generateAtlas(lighting);
         lighting.destroy();
-        hdriCache.set(preset.url, { skybox, envAtlas });
+        hdriCache.set(preset.url, { source, skybox, envAtlas });
     }
 
     const cached = /** @type {{ skybox: Texture, envAtlas: Texture }} */ (hdriCache.get(preset.url));
@@ -432,6 +432,22 @@ const applyEnvironment = async (/** @type {string} */ name) => {
     data.set('exposure', preset.exposure ?? 1);
     phCredit.style.display = 'block';
 };
+
+// Rebuild every cached preset so switching environments after recovery remains valid.
+device.on('devicerestored', () => {
+    hdriCache.forEach((cached) => {
+        const oldSkybox = cached.skybox;
+        cached.skybox = EnvLighting.generateSkyboxCubemap(cached.source);
+        const lighting = EnvLighting.generateLightingSource(cached.source);
+        EnvLighting.generateAtlas(lighting, { target: cached.envAtlas });
+        lighting.destroy();
+
+        if (app.scene.skybox === oldSkybox) {
+            app.scene.skybox = cached.skybox;
+        }
+        oldSkybox.destroy();
+    });
+});
 
 data.on('environment:set', () => {
     applyEnvironment(data.get('environment')).catch((err) => {

--- a/examples/src/examples/gaussian-splatting/relighting.example.mjs
+++ b/examples/src/examples/gaussian-splatting/relighting.example.mjs
@@ -628,7 +628,7 @@ data.on('fogDensity:set', () => {
 });
 
 // HDRI environment loading
-/** @type {Map<string, { skybox: Texture, envAtlas: Texture }>} */
+/** @type {Map<string, { source: Texture, skybox: Texture, envAtlas: Texture }>} */
 const hdriCache = new Map();
 
 const applyEnvironment = async (/** @type {string} */ name) => {
@@ -657,7 +657,7 @@ const applyEnvironment = async (/** @type {string} */ name) => {
         const lighting = EnvLighting.generateLightingSource(source);
         const envAtlas = EnvLighting.generateAtlas(lighting);
         lighting.destroy();
-        hdriCache.set(url, { skybox, envAtlas });
+        hdriCache.set(url, { source, skybox, envAtlas });
     }
 
     const cached = /** @type {{ skybox: Texture, envAtlas: Texture }} */ (hdriCache.get(url));
@@ -665,6 +665,22 @@ const applyEnvironment = async (/** @type {string} */ name) => {
     app.scene.envAtlas = cached.envAtlas;
     app.scene.sky.type = SKYTYPE_INFINITE;
 };
+
+// Rebuild every cached preset so switching environments after recovery remains valid.
+device.on('devicerestored', () => {
+    hdriCache.forEach((cached) => {
+        const oldSkybox = cached.skybox;
+        cached.skybox = EnvLighting.generateSkyboxCubemap(cached.source);
+        const lighting = EnvLighting.generateLightingSource(cached.source);
+        EnvLighting.generateAtlas(lighting, { target: cached.envAtlas });
+        lighting.destroy();
+
+        if (app.scene.skybox === oldSkybox) {
+            app.scene.skybox = cached.skybox;
+        }
+        oldSkybox.destroy();
+    });
+});
 
 data.on('environment:set', () => {
     applyEnvironment(data.get('environment')).catch((err) => {

--- a/examples/src/examples/gaussian-splatting/shadows.example.mjs
+++ b/examples/src/examples/gaussian-splatting/shadows.example.mjs
@@ -99,17 +99,26 @@ await new Promise((resolve) => {
 app.start();
 
 // Setup projected skydome from HDR
-const hdriTexture = assets.hdri.resource;
+const applyHdri = () => {
+    const hdriTexture = assets.hdri.resource;
+    const oldSkybox = app.scene.skybox;
+    const oldEnvAtlas = app.scene.envAtlas;
 
-// Generate high resolution cubemap for skybox
-const skybox = EnvLighting.generateSkyboxCubemap(hdriTexture);
-app.scene.skybox = skybox;
+    // Generate high resolution cubemap for skybox
+    app.scene.skybox = EnvLighting.generateSkyboxCubemap(hdriTexture);
 
-// Generate env-atlas for lighting
-const lighting = EnvLighting.generateLightingSource(hdriTexture);
-const envAtlas = EnvLighting.generateAtlas(lighting);
-lighting.destroy();
-app.scene.envAtlas = envAtlas;
+    // Generate env-atlas for lighting
+    const lighting = EnvLighting.generateLightingSource(hdriTexture);
+    app.scene.envAtlas = EnvLighting.generateAtlas(lighting);
+    lighting.destroy();
+
+    oldSkybox?.destroy();
+    oldEnvAtlas?.destroy();
+};
+
+// These textures are generated on the GPU, so their contents must be rebuilt after device loss.
+device.on('devicerestored', applyHdri);
+applyHdri();
 
 // Set exposure and projected dome
 app.scene.exposure = 0.4;

--- a/examples/src/examples/gaussian-splatting/viewer.example.mjs
+++ b/examples/src/examples/gaussian-splatting/viewer.example.mjs
@@ -197,6 +197,8 @@ cameraFrame.grading.enabled = true;
 
 // Setup skydome toggle function
 const applySkydome = () => {
+    const oldSkybox = app.scene.skybox;
+    const oldEnvAtlas = app.scene.envAtlas;
     const enabled = data.get('data.skydome');
     if (enabled) {
         const hdriTexture = assets.hdri.resource;
@@ -214,7 +216,13 @@ const applySkydome = () => {
         app.scene.skybox = null;
         app.scene.envAtlas = null;
     }
+
+    oldSkybox?.destroy();
+    oldEnvAtlas?.destroy();
 };
+
+// Rebuild generated textures while preserving the skydome toggle.
+device.on('devicerestored', applySkydome);
 
 // Initialize data values
 data.set('data', {

--- a/examples/src/examples/graphics/sky.example.mjs
+++ b/examples/src/examples/graphics/sky.example.mjs
@@ -168,6 +168,8 @@ const presetRoom = {
 
 // Apply hdri texture
 const applyHdri = (source) => {
+    const oldSkybox = app.scene.skybox;
+    const oldEnvAtlas = app.scene.envAtlas;
     // Convert it to high resolution cubemap for the skybox
     // This is optional in case you want a really high resolution skybox
     const skybox = EnvLighting.generateSkyboxCubemap(source);
@@ -179,7 +181,15 @@ const applyHdri = (source) => {
     const envAtlas = EnvLighting.generateAtlas(lighting);
     lighting.destroy();
     app.scene.envAtlas = envAtlas;
+
+    oldSkybox?.destroy();
+    oldEnvAtlas?.destroy();
 };
+
+// Restore the selected HDRI without resetting the other sky settings.
+device.on('devicerestored', () => {
+    applyHdri(data.get('data.skybox.preset') === 'Room' ? assets.hdri_room.resource : assets.hdri_street.resource);
+});
 
 // When UI value changes, update skybox data
 data.on('*:set', (/** @type {string} */ path, value) => {

--- a/examples/src/examples/graphics/wide-lines-dynamic.example.mjs
+++ b/examples/src/examples/graphics/wide-lines-dynamic.example.mjs
@@ -78,7 +78,15 @@ await new Promise((resolve) => {
 
 app.start();
 
-app.scene.skybox = EnvLighting.generateSkyboxCubemap(assets.sky.resource, 1024);
+const applyHdri = () => {
+    const oldSkybox = app.scene.skybox;
+    app.scene.skybox = EnvLighting.generateSkyboxCubemap(assets.sky.resource, 1024);
+    oldSkybox?.destroy();
+};
+
+// The skybox is generated on the GPU and needs rebuilding after device loss.
+device.on('devicerestored', applyHdri);
+applyHdri();
 app.scene.sky.type = SKYTYPE_INFINITE;
 app.scene.ambientLight = new Color(0.16, 0.2, 0.3);
 app.scene.exposure = 1.05;


### PR DESCRIPTION
Device recovery clears GPU-generated skyboxes and lighting atlases, leaving example backgrounds, projected ground and reflections missing. Rebuild these textures when the graphics device is restored.

**Changes:**
- Regenerate skyboxes and environment lighting after device restoration.
- Rebuild all cached HDR presets while preserving the selected environment, exposure, skydome toggle and delayed sky reveals.
- Release replaced textures and request a fresh frame in the examples that render on demand.

**Examples:**
- Gaussian splatting: billions, downtown, glass-refraction, lod-streaming, relighting, shadows and viewer.
- Graphics: sky and wide-lines-dynamic.
- Compute: indirect-dispatch.

The regenerated HDR textures match their original contents byte-for-byte. Full-scene glass-refraction captures still vary slightly after real WebGL context loss (13,774 of 453,152 pixels in one settled capture, maximum channel difference 4), despite matching HDR textures; this change addresses environment regeneration only.
