### PR TITLE
Warn when image materials have no opaque render pass

### DIFF
--- a/src/framework/components/element/image-element.js
+++ b/src/framework/components/element/image-element.js
@@ -1073,6 +1073,19 @@ class ImageElement {
         }
 
         if (value) {
+            Debug.call(() => {
+                if (!value.transparent) {
+                    const composition = this._system.app.scene.layers;
+                    const hasOpaquePass = this._element.layers.some((id) => {
+                        const layer = composition.getLayerById(id);
+                        return layer && composition.getOpaqueIndex(layer) !== -1;
+                    });
+                    if (!hasOpaquePass) {
+                        Debug.warnOnce('Image element assigned an opaque material, but none of its layers has an opaque render pass. Enable material blending or assign the element to a layer with an opaque pass.', this._entity, value);
+                    }
+                }
+            });
+
             this._renderable.setMaterial(value);
 
             // Preserve custom material colors until the element setters are used again.


### PR DESCRIPTION
Warn when assigning an opaque material to an image element whose layers have no opaque render pass, explaining why it will not render and how to correct it.

**Changes:**
- Emit a one-time warning with the entity and material for inspection.
- Allow opaque materials when any assigned layer has an opaque pass.

**Performance:**
- Keep all validation inside `Debug.call` so it is stripped from non-debug builds.

Fixes #3719.
