### PR TITLE
Restore the WebGL backbuffer before recovery callbacks

### DIFF
--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1170,6 +1170,10 @@ class WebglGraphicsDevice extends GraphicsDevice {
             shader.restoreContext();
         }
 
+        // Restore the supplied framebuffer before callbacks or update-time rendering (such as
+        // transform feedback) can use the backbuffer, without waiting for frameStart.
+        this.updateBackbuffer();
+
         this.fire('devicerestored');
     }
 

--- a/test/platform/graphics/webgl-context-restore.test.mjs
+++ b/test/platform/graphics/webgl-context-restore.test.mjs
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+import { WebglGraphicsDevice } from '../../../src/platform/graphics/webgl/webgl-graphics-device.js';
+import { WebglRenderTarget } from '../../../src/platform/graphics/webgl/webgl-render-target.js';
+
+describe('WebglGraphicsDevice context restoration', function () {
+    let device;
+
+    beforeEach(function () {
+        device = new NullGraphicsDevice({ width: 64, height: 64 });
+        device.backBuffer.destroy();
+
+        // Exercise WebGL backbuffer management without requiring a browser context. Initializing
+        // the default, single-sampled framebuffer should not allocate any GL attachments.
+        device.gl = {};
+        device.createRenderTargetImpl = () => new WebglRenderTarget();
+        device.createBackbuffer = WebglGraphicsDevice.prototype.createBackbuffer;
+        device.updateBackbuffer = WebglGraphicsDevice.prototype.updateBackbuffer;
+        device.initializeExtensions = () => {};
+        device.initializeCapabilities = () => {};
+        device.setFramebuffer = sinon.spy();
+        device._defaultFramebuffer = null;
+        device._defaultFramebufferChanged = false;
+        device.createBackbuffer(null);
+        device.initRenderTarget(device.backBuffer);
+        device.backBufferSize.set(64, 64);
+    });
+
+    afterEach(function () {
+        device.backBuffer.destroy();
+        device.destroy();
+    });
+
+    it('allows backbuffer rendering from devicerestored before frameStart', function () {
+        device.loseContext();
+        expect(device.backBuffer.impl.suppliedColorFramebuffer).to.be.undefined;
+
+        let restored = false;
+        device.once('devicerestored', () => {
+            WebglGraphicsDevice.prototype.updateBegin.call(device);
+            expect(device.backBuffer.impl.suppliedColorFramebuffer).to.equal(null);
+            expect(device.setFramebuffer.calledOnceWithExactly(null)).to.be.true;
+            restored = true;
+        });
+
+        WebglGraphicsDevice.prototype.restoreContext.call(device);
+        expect(restored).to.be.true;
+    });
+
+    it('recreates the backbuffer at the current size after each loss', function () {
+        for (const size of [128, 256]) {
+            const oldBackbuffer = device.backBuffer;
+            device.loseContext();
+            device.canvas.width = size;
+            device.canvas.height = size;
+
+            WebglGraphicsDevice.prototype.restoreContext.call(device);
+
+            expect(device.backBuffer).not.to.equal(oldBackbuffer);
+            expect(device.targets.has(oldBackbuffer)).to.be.false;
+            expect(device.backBufferSize.x).to.equal(size);
+            expect(device.backBufferSize.y).to.equal(size);
+            WebglGraphicsDevice.prototype.updateBegin.call(device);
+        }
+    });
+});


### PR DESCRIPTION
After WebGL context recovery, transform feedback can run during application update before the next rendering frame begins. The backbuffer still lacks its supplied-framebuffer marker at that point, so it is initialized as an empty framebuffer and triggers `FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT`.

**Changes:**
- Recreate the WebGL backbuffer before firing `devicerestored`, making it available to recovery callbacks and update-time rendering.
- Cover rendering before `frameStart` and repeated recovery with a resized canvas in regression tests.
