### PR TITLE
Redraw the on-demand splat example after device recovery

### DIFF
--- a/examples/src/examples/gaussian-splatting/simple-on-demand.example.mjs
+++ b/examples/src/examples/gaussian-splatting/simple-on-demand.example.mjs
@@ -217,6 +217,11 @@ app.systems.gsplat.on('frame:request', () => {
     app.renderNextFrame = true;
 });
 
+// Device recovery needs a fresh frame even when the camera and scene have not changed.
+device.on('devicerestored', () => {
+    app.renderNextFrame = true;
+});
+
 // Once the splat has loaded, sorted and drawn its first complete frame, switch to on-demand.
 // This also guarantees the one render needed to register the camera before going idle.
 const onFrameReady = (


### PR DESCRIPTION
The simple-on-demand splat example can remain blank after device recovery when the camera and scene have not changed. Request a fresh frame on `devicerestored` so the scene is drawn again and then returns to rendering on demand.

**Examples:**
- Gaussian splatting: simple-on-demand.
