### PR TITLE
Reset stale mouse movement deltas

### DIFF
--- a/src/platform/input/mouse-event.js
+++ b/src/platform/input/mouse-event.js
@@ -36,12 +36,18 @@ class MouseEvent {
     y = 0;
 
     /**
-     * The change in x coordinate since the last mouse event.
+     * The change in x coordinate since the last mouse movement event. When the pointer is not
+     * locked, this is zero until an unlocked movement establishes a position after creation,
+     * detachment, focus loss or pointer-locked movement. Under pointer lock, this uses the
+     * browser's relative movement delta.
      */
     dx = 0;
 
     /**
-     * The change in y coordinate since the last mouse event.
+     * The change in y coordinate since the last mouse movement event. When the pointer is not
+     * locked, this is zero until an unlocked movement establishes a position after creation,
+     * detachment, focus loss or pointer-locked movement. Under pointer lock, this uses the
+     * browser's relative movement delta.
      */
     dy = 0;
 
@@ -149,7 +155,7 @@ class MouseEvent {
         if (isMousePointerLocked()) {
             this.dx = event.movementX || event.webkitMovementX || event.mozMovementX || 0;
             this.dy = event.movementY || event.webkitMovementY || event.mozMovementY || 0;
-        } else {
+        } else if (mouse._lastPositionValid) {
             this.dx = this.x - mouse._lastX;
             this.dy = this.y - mouse._lastY;
         }

--- a/src/platform/input/mouse-event.js
+++ b/src/platform/input/mouse-event.js
@@ -38,16 +38,16 @@ class MouseEvent {
     /**
      * The change in x coordinate since the last mouse movement event. When the pointer is not
      * locked, this is zero until an unlocked movement establishes a position after creation,
-     * detachment, focus loss or pointer-locked movement. Under pointer lock, this uses the
-     * browser's relative movement delta.
+     * detachment, focus loss, movement outside the target or pointer-locked movement. Under
+     * pointer lock, this uses the browser's relative movement delta.
      */
     dx = 0;
 
     /**
      * The change in y coordinate since the last mouse movement event. When the pointer is not
      * locked, this is zero until an unlocked movement establishes a position after creation,
-     * detachment, focus loss or pointer-locked movement. Under pointer lock, this uses the
-     * browser's relative movement delta.
+     * detachment, focus loss, movement outside the target or pointer-locked movement. Under
+     * pointer lock, this uses the browser's relative movement delta.
      */
     dy = 0;
 

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -20,7 +20,8 @@ import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
  * mouse events.
  *
  * The first unlocked mouse movement after creation, detachment or focus loss establishes a new
- * position and reports zero movement delta. Pointer-locked movement uses the browser's relative
+ * position and reports zero movement delta. Movement outside the target also invalidates the
+ * position, so re-entry reports zero delta. Pointer-locked movement uses the browser's relative
  * movement deltas.
  *
  * Your application's Mouse instance is managed and accessible via {@link AppBase#mouse}.
@@ -396,7 +397,11 @@ class Mouse extends EventHandler {
 
     _handleMove(event) {
         const e = new MouseEvent(this, event);
-        if (!e.event) return;
+        if (!e.event) {
+            // Filtered movement outside the target must not leave a stale baseline for re-entry.
+            this._lastPositionValid = false;
+            return;
+        }
 
         // Update before firing so a callback that loses focus or detaches can invalidate the baseline.
         this._lastX = e.x;

--- a/src/platform/input/mouse.js
+++ b/src/platform/input/mouse.js
@@ -19,6 +19,10 @@ import { isMousePointerLocked, MouseEvent } from './mouse-event.js';
  * `mouseup` events. The Mouse instance must be attached to a DOM element before it can detect
  * mouse events.
  *
+ * The first unlocked mouse movement after creation, detachment or focus loss establishes a new
+ * position and reports zero movement delta. Pointer-locked movement uses the browser's relative
+ * movement deltas.
+ *
  * Your application's Mouse instance is managed and accessible via {@link AppBase#mouse}.
  *
  * For pointer-lock-aware, frame-accumulated input deltas rather than raw events, see
@@ -78,6 +82,9 @@ class Mouse extends EventHandler {
 
     /** @private */
     _lastY = 0;
+
+    /** @private */
+    _lastPositionValid = false;
 
     /** @private */
     _buttons = [false, false, false];
@@ -188,7 +195,8 @@ class Mouse extends EventHandler {
 
     /**
      * Remove mouse events from the element that it is attached to and clear current and previous
-     * button states. This does not fire `mouseup` events.
+     * button states. The previous mouse position is also invalidated so the next unlocked movement
+     * reports zero delta. This does not fire `mouseup` events.
      */
     detach() {
         if (!this._attached) return;
@@ -362,6 +370,7 @@ class Mouse extends EventHandler {
     _handleWindowBlur() {
         this._buttons.fill(false);
         this._lastbuttons.fill(false);
+        this._lastPositionValid = false;
     }
 
     _handleUp(event) {
@@ -389,11 +398,12 @@ class Mouse extends EventHandler {
         const e = new MouseEvent(this, event);
         if (!e.event) return;
 
-        this.fire('mousemove', e);
-
-        // Store the last offset position to calculate deltas
+        // Update before firing so a callback that loses focus or detaches can invalidate the baseline.
         this._lastX = e.x;
         this._lastY = e.y;
+        this._lastPositionValid = !isMousePointerLocked();
+
+        this.fire('mousemove', e);
     }
 
     _handleWheel(event) {

--- a/test/platform/input/mouse-movement.test.mjs
+++ b/test/platform/input/mouse-movement.test.mjs
@@ -1,0 +1,152 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { Mouse } from '../../../src/platform/input/mouse.js';
+import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
+
+describe('Mouse movement', function () {
+
+    let mouse;
+    let moves;
+
+    const move = (x, y, movementX = 0, movementY = 0) => {
+        const event = new MouseEvent('mousemove', { clientX: x, clientY: y });
+        Object.defineProperties(event, {
+            movementX: { value: movementX },
+            movementY: { value: movementY }
+        });
+        window.dispatchEvent(event);
+    };
+
+    beforeEach(function () {
+        jsdomSetup();
+        sinon.stub(document.body, 'clientWidth').get(() => 1000);
+        sinon.stub(document.body, 'clientHeight').get(() => 800);
+        sinon.stub(document.body, 'getBoundingClientRect').returns(new window.DOMRect(0, 0, 1000, 800));
+        Object.defineProperty(document, 'pointerLockElement', { configurable: true, writable: true, value: null });
+        mouse = new Mouse(document.body);
+        moves = [];
+        mouse.on('mousemove', event => moves.push({ x: event.x, y: event.y, dx: event.dx, dy: event.dy }));
+    });
+
+    afterEach(function () {
+        mouse.detach();
+        sinon.restore();
+        jsdomTeardown();
+    });
+
+    it('should establish the initial position without reporting movement from the origin', function () {
+        move(100, 100);
+        move(110, 95);
+
+        expect(moves).to.deep.equal([
+            { x: 100, y: 100, dx: 0, dy: 0 },
+            { x: 110, y: 95, dx: 10, dy: -5 }
+        ]);
+    });
+
+    ['blur', 'hidden', 'detach'].forEach((reset) => {
+        it(`should establish a new baseline after ${reset}`, function () {
+            move(100, 100);
+            if (reset === 'blur') {
+                window.dispatchEvent(new window.Event('blur'));
+                window.dispatchEvent(new window.Event('focus'));
+            } else if (reset === 'hidden') {
+                const visibility = sinon.stub(document, 'visibilityState');
+                visibility.get(() => 'hidden');
+                document.dispatchEvent(new window.Event('visibilitychange'));
+                visibility.get(() => 'visible');
+                document.dispatchEvent(new window.Event('visibilitychange'));
+            } else {
+                mouse.detach();
+                move(500, 500);
+                mouse.attach(document.body);
+            }
+            moves.length = 0;
+
+            move(900, 700);
+            move(905, 690);
+
+            expect(moves).to.deep.equal([
+                { x: 900, y: 700, dx: 0, dy: 0 },
+                { x: 905, y: 690, dx: 5, dy: -10 }
+            ]);
+        });
+    });
+
+    it('should preserve the baseline when the document becomes visible without losing focus', function () {
+        move(100, 100);
+        sinon.stub(document, 'visibilityState').get(() => 'visible');
+        document.dispatchEvent(new window.Event('visibilitychange'));
+        move(120, 90);
+
+        expect(moves[1]).to.deep.equal({ x: 120, y: 90, dx: 20, dy: -10 });
+    });
+
+    it('should wait for a movement inside the target after focus loss', function () {
+        move(100, 100);
+        window.dispatchEvent(new window.Event('blur'));
+        move(1100, 900);
+        expect(moves).to.have.length(1);
+
+        move(900, 700);
+        move(905, 690);
+
+        expect(moves[1]).to.deep.equal({ x: 900, y: 700, dx: 0, dy: 0 });
+        expect(moves[2]).to.deep.equal({ x: 905, y: 690, dx: 5, dy: -10 });
+    });
+
+    it('should keep button and wheel events from consuming the first movement after blur', function () {
+        move(100, 100);
+        window.dispatchEvent(new window.Event('blur'));
+        const events = [];
+        const record = event => events.push({ dx: event.dx, dy: event.dy });
+        mouse.on('mousedown', record);
+        mouse.on('mouseup', record);
+        mouse.on('mousewheel', record);
+
+        window.dispatchEvent(new MouseEvent('mousedown', { clientX: 800, clientY: 600, button: 0 }));
+        window.dispatchEvent(new MouseEvent('mouseup', { clientX: 800, clientY: 600, button: 0 }));
+        window.dispatchEvent(new window.WheelEvent('wheel', { clientX: 800, clientY: 600, deltaY: 1 }));
+        move(900, 700);
+
+        expect(events).to.deep.equal([{ dx: 0, dy: 0 }, { dx: 0, dy: 0 }, { dx: 0, dy: 0 }]);
+        expect(moves[1]).to.deep.equal({ x: 900, y: 700, dx: 0, dy: 0 });
+    });
+
+    it('should preserve pointer-locked movement before and after blur', function () {
+        document.pointerLockElement = document.body;
+        move(100, 100, 7, -3);
+        window.dispatchEvent(new window.Event('blur'));
+        move(900, 700, -4, 9);
+
+        expect(moves).to.deep.equal([
+            { x: 100, y: 100, dx: 7, dy: -3 },
+            { x: 900, y: 700, dx: -4, dy: 9 }
+        ]);
+    });
+
+    it('should not use pointer-locked coordinates as an unlocked movement baseline', function () {
+        move(100, 100);
+        document.pointerLockElement = document.body;
+        move(1100, 900, 7, -3);
+        document.pointerLockElement = null;
+        move(900, 700);
+        move(905, 690);
+
+        expect(moves[1]).to.include({ dx: 7, dy: -3 });
+        expect(moves[2]).to.deep.equal({ x: 900, y: 700, dx: 0, dy: 0 });
+        expect(moves[3]).to.deep.equal({ x: 905, y: 690, dx: 5, dy: -10 });
+    });
+
+    it('should preserve a reset triggered by a mousemove listener', function () {
+        mouse.once('mousemove', () => window.dispatchEvent(new window.Event('blur')));
+        move(100, 100);
+        move(900, 700);
+        move(905, 690);
+
+        expect(moves[1]).to.deep.equal({ x: 900, y: 700, dx: 0, dy: 0 });
+        expect(moves[2]).to.deep.equal({ x: 905, y: 690, dx: 5, dy: -10 });
+    });
+
+});

--- a/test/platform/input/mouse-movement.test.mjs
+++ b/test/platform/input/mouse-movement.test.mjs
@@ -83,6 +83,18 @@ describe('Mouse movement', function () {
         expect(moves[1]).to.deep.equal({ x: 120, y: 90, dx: 20, dy: -10 });
     });
 
+    it('should establish a new baseline when the pointer re-enters the target', function () {
+        move(100, 100);
+        move(1200, 900);
+        expect(moves).to.have.length(1);
+
+        move(900, 700);
+        move(905, 690);
+
+        expect(moves[1]).to.deep.equal({ x: 900, y: 700, dx: 0, dy: 0 });
+        expect(moves[2]).to.deep.equal({ x: 905, y: 690, dx: 5, dy: -10 });
+    });
+
     it('should wait for a movement inside the target after focus loss', function () {
         move(100, 100);
         window.dispatchEvent(new window.Event('blur'));

--- a/test/platform/input/mouse.test.mjs
+++ b/test/platform/input/mouse.test.mjs
@@ -7,11 +7,6 @@ import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
 const buttons = [MOUSEBUTTON_LEFT, MOUSEBUTTON_MIDDLE, MOUSEBUTTON_RIGHT];
 
-// Mock the _getTargetCoords method, otherwise it returns null
-Mouse.prototype._getTargetCoords = function (event) {
-    return { x: 0, y: 0 };
-};
-
 describe('Mouse', function () {
 
     /** @type { Mouse } */
@@ -20,6 +15,7 @@ describe('Mouse', function () {
     beforeEach(function () {
         jsdomSetup();
         mouse = new Mouse(document.body);
+        sinon.stub(mouse, '_getTargetCoords').returns({ x: 0, y: 0 });
     });
 
     afterEach(function () {


### PR DESCRIPTION
Follow-up to #9344. The first mouse movement after focus returns or after moving outside the target and back could use a stale position and cause a camera jump.

**Changes:**
- Report zero delta on the first unlocked movement after creation, focus loss, document hiding or reattachment.
- Invalidate the baseline when movement outside the target is filtered, so re-entry reports zero delta.
- Resume normal deltas from that new position.
- Preserve browser-provided pointer-lock deltas and establish a fresh baseline after pointer-locked movement.
- Add regression coverage for focus changes, filtered events, pointer lock and resets inside event callbacks.

**API Changes:**
`MouseEvent.dx` and `dy` remain zero while no valid unlocked movement baseline exists.

For a pointer moving from (100, 100) to (900, 700) across focus loss or a filtered movement outside the target:
- Before: `event.dx === 800; event.dy === 600`
- After: `event.dx === 0; event.dy === 0`

The next movement to (905, 690) reports `dx === 5` and `dy === -10`.
