### PR TITLE
Recover SOG streaming across WebGL context loss

### DIFF
--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -349,7 +349,13 @@ class SogBundleParser {
                 // no need to prepare gpu data if decompressing
                 data.prepareCodebook();
                 if (gsplatCentersEnabledAtLoad) {
-                    await data.prepareGpuData();
+                    // An unload must cancel preparation even if the device never recovers.
+                    const onUnload = asset.once('unload', () => data.destroy());
+                    try {
+                        await data.prepareGpuData();
+                    } finally {
+                        onUnload.off();
+                    }
                 }
             }
 

--- a/src/framework/parsers/sog.js
+++ b/src/framework/parsers/sog.js
@@ -241,7 +241,13 @@ class SogParser {
             // no need to prepare gpu data if decompressing
             data.prepareCodebook();
             if (gsplatCentersEnabledAtLoad) {
-                await data.prepareGpuData();
+                // An unload must cancel preparation even if the device never recovers.
+                const onUnload = asset.once('unload', () => data.destroy());
+                try {
+                    await data.prepareGpuData();
+                } finally {
+                    onUnload.off();
+                }
             }
         }
 

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -920,13 +920,14 @@ class GraphicsDevice extends EventHandler {
     }
 
     /**
-     * Reports whether the device is lost, including a native loss whose event has not arrived yet.
+     * Reports whether the device is lost or destroyed, including a native loss whose event has not
+     * arrived yet.
      *
-     * @returns {boolean} Whether the device is lost.
+     * @returns {boolean} Whether the device is lost or destroyed.
      * @ignore
      */
     isContextLost() {
-        return !!this.contextLost;
+        return !!this.contextLost || this._destroyed;
     }
 
     // don't stringify GraphicsDevice to JSON by JSON.stringify

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -919,6 +919,16 @@ class GraphicsDevice extends EventHandler {
         this.gpuProfiler?.restoreContext?.();
     }
 
+    /**
+     * Reports whether the device is lost, including a native loss whose event has not arrived yet.
+     *
+     * @returns {boolean} Whether the device is lost.
+     * @ignore
+     */
+    isContextLost() {
+        return !!this.contextLost;
+    }
+
     // don't stringify GraphicsDevice to JSON by JSON.stringify
     toJSON(key) {
         return undefined;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1125,6 +1125,11 @@ class WebglGraphicsDevice extends GraphicsDevice {
         this.initTextureUnits(this.maxCombinedTextures);
     }
 
+    /** @ignore */
+    isContextLost() {
+        return this.contextLost || this.gl.isContextLost();
+    }
+
     /**
      * Called when the WebGL context was lost. It releases all context related resources.
      *

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1127,7 +1127,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     /** @ignore */
     isContextLost() {
-        return this.contextLost || this.gl.isContextLost();
+        return this.contextLost || (this.gl?.isContextLost() ?? true);
     }
 
     /**

--- a/src/platform/graphics/webgl/webgl-texture.js
+++ b/src/platform/graphics/webgl/webgl-texture.js
@@ -870,6 +870,12 @@ class WebglTexture {
      */
     uploadImmediate(device, texture) {
 
+        // Downloads can complete during context loss. Keep the upload pending so its source
+        // survives and a valid GPU texture is created when it is next used after recovery.
+        if (device.isContextLost()) {
+            return;
+        }
+
         if (texture._needsUpload || texture._needsMipmapsUpload) {
 
             // this uploads the texture as well

--- a/src/scene/gsplat/gsplat-sog-data.js
+++ b/src/scene/gsplat/gsplat-sog-data.js
@@ -191,6 +191,14 @@ class GSplatSogData {
      */
     _centers = null;
 
+    /**
+     * Recovery waits that must also finish if this data is destroyed before the device recovers.
+     *
+     * @type {Set<() => void> | null}
+     * @private
+     */
+    _pendingRestoreWaits = null;
+
     // Marked when resource is destroyed, to abort any in-flight async preparation
     destroyed = false;
 
@@ -220,6 +228,7 @@ class GSplatSogData {
 
     destroy() {
         this.destroyed = true;
+        this._pendingRestoreWaits?.forEach(finish => finish());
         this._destroyGpuResources();
     }
 
@@ -409,22 +418,24 @@ class GSplatSogData {
 
         renderTarget.destroy();
 
-        const u32 = await readImageDataAsync(centersTexture);
-        if (this.destroyed || device._destroyed) {
-            centersTexture.destroy();
-            return;
-        }
+        try {
+            const u32 = await readImageDataAsync(centersTexture);
+            if (this.destroyed || device._destroyed) {
+                return;
+            }
 
-        const asFloat = new Float32Array(u32.buffer);
-        const result = new Float32Array(this.numSplats * 3);
-        for (let i = 0; i < this.numSplats; i++) {
-            const base = i * 4;
-            result[i * 3 + 0] = asFloat[base + 0];
-            result[i * 3 + 1] = asFloat[base + 1];
-            result[i * 3 + 2] = asFloat[base + 2];
+            const asFloat = new Float32Array(u32.buffer);
+            const result = new Float32Array(this.numSplats * 3);
+            for (let i = 0; i < this.numSplats; i++) {
+                const base = i * 4;
+                result[i * 3 + 0] = asFloat[base + 0];
+                result[i * 3 + 1] = asFloat[base + 1];
+                result[i * 3 + 2] = asFloat[base + 2];
+            }
+            this._centers = result;
+        } finally {
+            centersTexture.destroy();
         }
-        this._centers = result;
-        centersTexture.destroy();
     }
 
     /**
@@ -507,7 +518,43 @@ class GSplatSogData {
     async prepareGpuData() {
         const device = this.means_l?.device;
         if (this.destroyed || !device || device._destroyed) return;
-        await this.generateCenters();
+
+        // Texture downloads can finish while rendering is paused for device recovery.
+        if (device.isContextLost()) {
+            await new Promise((resolve) => {
+                const waits = this._pendingRestoreWaits ??= new Set();
+                const finish = () => {
+                    device.off('devicerestored', finish);
+                    device.off('destroy', finish);
+                    waits.delete(finish);
+                    if (waits.size === 0) {
+                        this._pendingRestoreWaits = null;
+                    }
+                    resolve();
+                };
+                waits.add(finish);
+                device.once('devicerestored', finish);
+                device.once('destroy', finish);
+            });
+            return this.prepareGpuData();
+        }
+
+        // A readback may fail (WebGL) or return invalid data (WebGPU) when its device is lost.
+        // Remember the event even if recovery finishes before the readback settles.
+        let lost = false;
+        const onLost = device.once('devicelost', () => {
+            lost = true;
+        });
+        try {
+            await this.generateCenters();
+            if (!lost) return;
+        } catch (error) {
+            if (!lost && !this.destroyed && !device._destroyed && !device.isContextLost()) throw error;
+        } finally {
+            onLost.off();
+        }
+        this._centers = null;
+        return this.prepareGpuData();
     }
 }
 

--- a/test/framework/parsers/sog.test.mjs
+++ b/test/framework/parsers/sog.test.mjs
@@ -1,10 +1,13 @@
 import { expect } from 'chai';
+import { strToU8, zipSync } from 'fflate';
 import { restore, stub } from 'sinon';
 
 import { Asset } from '../../../src/framework/asset/asset.js';
 import { SogBundleParser } from '../../../src/framework/parsers/sog-bundle.js';
 import { SogParser } from '../../../src/framework/parsers/sog.js';
+import { Texture } from '../../../src/platform/graphics/texture.js';
 import { http } from '../../../src/platform/net/http.js';
+import { GSplatSogData } from '../../../src/scene/gsplat/gsplat-sog-data.js';
 import { createApp } from '../../app.mjs';
 import { jsdomSetup, jsdomTeardown } from '../../jsdom.mjs';
 
@@ -87,6 +90,54 @@ describe('SogParser', function () {
             ]);
             done();
         }, sog);
+    });
+
+    [SogParser, SogBundleParser].forEach((Parser) => {
+        it(`${Parser.name} cancels a recovery wait when the asset unloads`, async function () {
+            const parser = new Parser(app);
+            parser.handler = app.loader.getHandler('gsplat');
+            const archive = zipSync({ 'meta.json': strToU8(JSON.stringify(META)) }, { level: 0 });
+            const sog = new Asset('sog', 'gsplat', {
+                url: META_URL,
+                contents: archive.buffer
+            });
+            app.assets.add(sog);
+
+            stub(http, 'get').callsFake((url, options, callback) => callback(null, META));
+            stub(app.assets, 'load').callsFake((asset) => {
+                asset.resource = new Texture(app.graphicsDevice, { width: 1, height: 1 });
+                asset.loaded = true;
+                asset.fire('load', asset);
+            });
+            stub(GSplatSogData.prototype, 'prepareCodebook');
+
+            let started;
+            const preparing = new Promise((resolve) => {
+                started = resolve;
+            });
+            const prepare = GSplatSogData.prototype.prepareGpuData;
+            stub(GSplatSogData.prototype, 'prepareGpuData').callsFake(function () {
+                const pending = prepare.call(this);
+                started();
+                return pending;
+            });
+
+            const device = app.graphicsDevice;
+            device.loseContext();
+            const listenersBefore = device._callbacks.get('devicerestored')?.length ?? 0;
+            const loaded = new Promise((resolve) => {
+                parser.load({ load: META_URL, original: META_URL }, (err, resource) => {
+                    resolve({ err, resource });
+                }, sog);
+            });
+
+            await preparing;
+            // The streaming loader fires unload explicitly for assets still being loaded.
+            sog.fire('unload', sog);
+            expect(await loaded).to.deep.equal({ err: null, resource: null });
+            expect(device.contextLost).to.be.true;
+            expect(device._callbacks.get('devicerestored')?.length ?? 0).to.equal(listenersBefore);
+        });
     });
 
     // Nothing cancels an in-flight request, so a load callback can run after app.destroy(). That

--- a/test/platform/graphics/graphics-device.test.mjs
+++ b/test/platform/graphics/graphics-device.test.mjs
@@ -46,6 +46,18 @@ describe('GraphicsDevice', function () {
         });
     });
 
+    describe('#isContextLost', function () {
+
+        it('reports a destroyed device as lost without a context loss event', function () {
+            const device = new NullGraphicsDevice({ id: 'mock' });
+            expect(device.isContextLost()).to.be.false;
+
+            device.destroy();
+
+            expect(device.isContextLost()).to.be.true;
+        });
+    });
+
     describe('#getRenderableHdrFormat', function () {
 
         let device;

--- a/test/platform/graphics/webgl-texture.test.mjs
+++ b/test/platform/graphics/webgl-texture.test.mjs
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { WebglGraphicsDevice } from '../../../src/platform/graphics/webgl/webgl-graphics-device.js';
+import { WebglTexture } from '../../../src/platform/graphics/webgl/webgl-texture.js';
+
+describe('WebglTexture upload during context loss', function () {
+    it('keeps uploads pending until both native and engine recovery have completed', function () {
+        const device = {
+            contextLost: false,
+            gl: { isContextLost: () => true },
+            isContextLost: WebglGraphicsDevice.prototype.isContextLost,
+            setTexture: sinon.spy()
+        };
+        const texture = { _needsUpload: true, _needsMipmapsUpload: true };
+
+        // The native context may be lost before the engine receives its loss event.
+        WebglTexture.prototype.uploadImmediate(device, texture);
+        expect(device.setTexture.called).to.be.false;
+        expect(texture._needsUpload).to.be.true;
+        expect(texture._needsMipmapsUpload).to.be.true;
+
+        device.contextLost = true;
+        device.gl.isContextLost = () => false;
+        WebglTexture.prototype.uploadImmediate(device, texture);
+        expect(device.setTexture.called).to.be.false;
+
+        device.contextLost = false;
+        WebglTexture.prototype.uploadImmediate(device, texture);
+        expect(device.setTexture.calledOnceWithExactly(texture, 0)).to.be.true;
+        expect(texture._needsUpload).to.be.false;
+        expect(texture._needsMipmapsUpload).to.be.false;
+    });
+});

--- a/test/platform/graphics/webgl-texture.test.mjs
+++ b/test/platform/graphics/webgl-texture.test.mjs
@@ -5,6 +5,22 @@ import { WebglGraphicsDevice } from '../../../src/platform/graphics/webgl/webgl-
 import { WebglTexture } from '../../../src/platform/graphics/webgl/webgl-texture.js';
 
 describe('WebglTexture upload during context loss', function () {
+    it('skips uploads after the device has been destroyed', function () {
+        const device = {
+            contextLost: false,
+            gl: null,
+            isContextLost: WebglGraphicsDevice.prototype.isContextLost,
+            setTexture: sinon.spy()
+        };
+        const texture = { _needsUpload: true, _needsMipmapsUpload: true };
+
+        expect(device.isContextLost()).to.be.true;
+        WebglTexture.prototype.uploadImmediate(device, texture);
+        expect(device.setTexture.called).to.be.false;
+        expect(texture._needsUpload).to.be.true;
+        expect(texture._needsMipmapsUpload).to.be.true;
+    });
+
     it('keeps uploads pending until both native and engine recovery have completed', function () {
         const device = {
             contextLost: false,

--- a/test/scene/gsplat-sog-data.test.mjs
+++ b/test/scene/gsplat-sog-data.test.mjs
@@ -1,0 +1,172 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { NullGraphicsDevice } from '../../src/platform/graphics/null/null-graphics-device.js';
+import { Texture } from '../../src/platform/graphics/texture.js';
+import { WebglGraphicsDevice } from '../../src/platform/graphics/webgl/webgl-graphics-device.js';
+import { GSplatSogData } from '../../src/scene/gsplat/gsplat-sog-data.js';
+import { ShaderUtils } from '../../src/scene/shader-lib/shader-utils.js';
+
+describe('GSplatSogData GPU preparation', function () {
+    let device;
+    let data;
+    let generate;
+
+    const lose = () => {
+        device.loseContext();
+        device.fire('devicelost');
+    };
+
+    const restore = () => {
+        device.restoreContext();
+        device.fire('devicerestored');
+    };
+
+    beforeEach(function () {
+        device = new NullGraphicsDevice({ width: 1, height: 1 });
+        data = new GSplatSogData();
+        data.means_l = { device, destroy() {} };
+        generate = sinon.stub(data, 'generateCenters').resolves();
+    });
+
+    afterEach(function () {
+        data.destroy();
+        device.destroy();
+        sinon.restore();
+    });
+
+    it('waits for recovery when a download finishes while the device is lost', async function () {
+        lose();
+        const pending = data.prepareGpuData();
+        expect(generate.called).to.be.false;
+        restore();
+        await pending;
+        expect(generate.calledOnce).to.be.true;
+        expect(device.hasEvent('devicerestored')).to.be.false;
+        expect(device.hasEvent('devicelost')).to.be.false;
+    });
+
+    it('retries a rejected readback even if recovery finishes before it rejects', async function () {
+        let rejectRead;
+        generate.onFirstCall().returns(new Promise((resolve, reject) => {
+            rejectRead = reject;
+        }));
+        const pending = data.prepareGpuData();
+        lose();
+        restore();
+        rejectRead(new Error('webgl clientWaitSync sync failed'));
+        await pending;
+        expect(generate.calledTwice).to.be.true;
+    });
+
+    it('waits if native WebGL loss precedes the engine loss event', async function () {
+        device.gl = { isContextLost: () => true };
+        device.isContextLost = WebglGraphicsDevice.prototype.isContextLost;
+        const pending = data.prepareGpuData();
+        expect(device.contextLost).not.to.equal(true);
+        expect(generate.called).to.be.false;
+        lose();
+        device.gl.isContextLost = () => false;
+        restore();
+        await pending;
+        expect(generate.calledOnce).to.be.true;
+    });
+
+    it('retries a read that rejects before the native loss event arrives', async function () {
+        device.gl = { isContextLost: () => false };
+        device.isContextLost = WebglGraphicsDevice.prototype.isContextLost;
+        generate.onFirstCall().callsFake(() => {
+            device.gl.isContextLost = () => true;
+            return Promise.reject(new Error('webgl clientWaitSync sync failed'));
+        });
+        const pending = data.prepareGpuData();
+        await Promise.resolve();
+        expect(generate.calledOnce).to.be.true;
+        lose();
+        device.gl.isContextLost = () => false;
+        restore();
+        await pending;
+        expect(generate.calledTwice).to.be.true;
+    });
+
+    it('discards a resolved readback from a lost device and retries after recovery', async function () {
+        let resolveRead;
+        generate.onFirstCall().callsFake(async () => {
+            await new Promise((resolve) => {
+                resolveRead = resolve;
+            });
+            data._centers = new Float32Array([0, 0, 0]);
+        });
+        const centers = new Float32Array([1, 2, 3]);
+        generate.onSecondCall().callsFake(() => {
+            data._centers = centers;
+        });
+        const pending = data.prepareGpuData();
+        lose();
+        resolveRead();
+        restore();
+        await pending;
+        expect(generate.calledTwice).to.be.true;
+        expect(data.getCenters()).to.equal(centers);
+    });
+
+    it('propagates readback errors unrelated to device loss', async function () {
+        const failure = new Error('readback failed');
+        generate.rejects(failure);
+        const result = await Promise.allSettled([data.prepareGpuData()]);
+        expect(result[0]).to.deep.equal({ status: 'rejected', reason: failure });
+        expect(generate.calledOnce).to.be.true;
+        expect(device.hasEvent('devicelost')).to.be.false;
+    });
+
+    it('destroys the temporary centers texture when its readback fails', async function () {
+        generate.restore();
+        device.postInit();
+        device.isNull = false;
+        data.means_l = new Texture(device, { width: 1, height: 1 });
+        data.means_u = data.means_l;
+        data.numSplats = 1;
+        data.meta = { means: { mins: [0, 0, 0], maxs: [1, 1, 1] } };
+        sinon.stub(ShaderUtils, 'createShader').returns({ device });
+        const failure = new Error('readback failed');
+        sinon.stub(Texture.prototype, 'read').rejects(failure);
+        const destroy = sinon.spy(Texture.prototype, 'destroy');
+
+        const result = await Promise.allSettled([data.prepareGpuData()]);
+        expect(result[0]).to.deep.equal({ status: 'rejected', reason: failure });
+        expect(destroy.calledOnce).to.be.true;
+        expect(destroy.firstCall.thisValue.name).to.equal('sogCentersTexture');
+    });
+
+    it('settles without starting GPU work if the device is destroyed during recovery', async function () {
+        lose();
+        const pending = data.prepareGpuData();
+        device.destroy();
+        await pending;
+        expect(generate.called).to.be.false;
+        expect(device.hasEvent('devicerestored')).to.be.false;
+    });
+
+    it('settles and removes recovery listeners when the data is destroyed', async function () {
+        lose();
+        const pending = data.prepareGpuData();
+        data.destroy();
+        await pending;
+        expect(generate.called).to.be.false;
+        expect(device.hasEvent('devicerestored')).to.be.false;
+        expect(device.hasEvent('destroy')).to.be.false;
+        restore();
+        expect(generate.called).to.be.false;
+    });
+
+    it('cancels all concurrent recovery waits when the data is destroyed', async function () {
+        lose();
+        const first = data.prepareGpuData();
+        const second = data.prepareGpuData();
+        data.destroy();
+        await Promise.all([first, second]);
+        expect(generate.called).to.be.false;
+        expect(device.hasEvent('devicerestored')).to.be.false;
+        expect(device.hasEvent('destroy')).to.be.false;
+    });
+});


### PR DESCRIPTION
WebGL context loss during SOG streaming can leave texture downloads uploading into a lost context and splat-center readbacks rejecting without recovery. Defer GPU work while the context is unavailable and retry interrupted center generation after restoration, so examples such as downtown and relighting can resume streaming.

**Changes:**
- Keep texture uploads pending during context loss, including the interval before the engine receives the native loss event.
- Wait for recovery before preparing splat centers, retry readbacks interrupted by loss, and release temporary textures when reads fail.
- Settle pending recovery waits and remove their listeners when splat data or the device is destroyed.
- Cancel preparation when an in-flight asset unloads, for both separate-file and bundled SOG assets.
