### PR TITLE
Rebake example lightmaps after device recovery

### DIFF
--- a/examples/src/examples/graphics/lights-baked-a-o.example.mjs
+++ b/examples/src/examples/graphics/lights-baked-a-o.example.mjs
@@ -208,8 +208,12 @@ app.scene.lightmapMaxResolution = 1024;
 // Multiplier for lightmap resolution
 app.scene.lightmapSizeMultiplier = 512;
 
-// Bake when settings are changed only
+// Bake when settings change or GPU-generated lightmaps need restoring
 let needBake = false;
+
+device.on('devicerestored', () => {
+    needBake = true;
+});
 
 // Handle data changes from HUD to modify baking properties
 data.on('*:set', (/** @type {string} */ path, value) => {
@@ -280,7 +284,7 @@ data.set('data', {
 
 // Set an update function on the app's update event
 app.on('update', (_dt) => {
-    // Bake lightmaps when HUD properties change
+    // Bake lightmaps when requested
     if (needBake) {
         needBake = false;
         app.lightmapper.bake(null, bakeType);

--- a/examples/src/examples/graphics/lights-baked.example.mjs
+++ b/examples/src/examples/graphics/lights-baked.example.mjs
@@ -268,8 +268,12 @@ app.scene.lightmapMaxResolution = 2048;
 // For baked lights, this property perhaps has the biggest impact on lightmap resolution:
 app.scene.lightmapSizeMultiplier = 32;
 
-// Bake when settings are changed only
+// Bake when settings change or GPU-generated lightmaps need restoring
 let needBake = false;
+
+device.on('devicerestored', () => {
+    needBake = true;
+});
 
 // Handle data changes from HUD to modify light enabled state
 data.on('*:set', (/** @type {string} */ path, value) => {
@@ -312,7 +316,7 @@ data.set('data', {
 
 // Set an update function on the app's update event
 app.on('update', (_dt) => {
-    // Bake lightmaps when HUD properties change
+    // Bake lightmaps when requested
     if (needBake) {
         needBake = false;
         app.lightmapper.bake(null, bakeType);


### PR DESCRIPTION
Restore baked lighting in the `graphics/lights-baked` and `graphics/lights-baked-a-o` examples after graphics device recovery. Previously, GPU-generated lightmaps lost their contents and were only rebuilt when a lighting setting changed.

**Changes:**
- Request a rebake on device restoration through each example's existing update handler.
- Preserve current lighting settings and update the AO example's bake-duration display through the existing bake path.
