### PR TITLE
Add cross-backend debug device loss testing

### DIFF
--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -930,6 +930,21 @@ class GraphicsDevice extends EventHandler {
         return !!this.contextLost || this._destroyed;
     }
 
+    /**
+     * Forces an actual graphics context or device loss for testing, then attempts recovery after
+     * the specified delay. Only has an effect in debug builds on WebGL and WebGPU. Calls made while
+     * a loss or recovery is pending are ignored. Recovery is asynchronous and is not guaranteed
+     * to succeed. Listen for `devicelost` and `devicerestored` to observe the recovery lifecycle.
+     *
+     * @param {number} [delay] - Delay in milliseconds after loss is observed before attempting
+     * recovery. Defaults to 100.
+     * @ignore
+     * @example
+     * app.graphicsDevice.debugLoseContext(1000);
+     */
+    debugLoseContext(delay = 100) {
+    }
+
     // don't stringify GraphicsDevice to JSON by JSON.stringify
     toJSON(key) {
         return undefined;

--- a/src/platform/graphics/null/null-graphics-device.js
+++ b/src/platform/graphics/null/null-graphics-device.js
@@ -42,6 +42,10 @@ class NullGraphicsDevice extends GraphicsDevice {
         super.destroy();
     }
 
+    /** @ignore */
+    debugLoseContext(delay = 100) {
+    }
+
     initDeviceCaps() {
 
         this.disableParticleSystem = true;

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -1127,7 +1127,7 @@ class WebglGraphicsDevice extends GraphicsDevice {
 
     /** @ignore */
     isContextLost() {
-        return this.contextLost || (this.gl?.isContextLost() ?? true);
+        return super.isContextLost() || (this.gl?.isContextLost() ?? true);
     }
 
     /**
@@ -3165,13 +3165,38 @@ class WebglGraphicsDevice extends GraphicsDevice {
     }
 
     // #if _DEBUG
-    // debug helper to force lost context
-    debugLoseContext(sleep = 100) {
-        const context = this.gl.getExtension('WEBGL_lose_context');
-        context.loseContext();
-        setTimeout(() => context.restoreContext(), sleep);
-    }
+    /** @private */
+    _debugContextLossPending = false;
     // #endif
+
+    /** @ignore */
+    debugLoseContext(delay = 100) {
+        Debug.call(() => {
+            if (this._destroyed || this.contextLost || this._debugContextLossPending) {
+                return;
+            }
+
+            const context = this.gl.getExtension('WEBGL_lose_context');
+            if (!context) {
+                Debug.warn('WEBGL_lose_context is unavailable.');
+                return;
+            }
+
+            this._debugContextLossPending = true;
+            this.once('devicerestored', () => {
+                this._debugContextLossPending = false;
+            });
+            this.once('devicelost', () => {
+                // The browser must dispatch the loss event before restoration can be requested.
+                setTimeout(() => {
+                    if (!this._destroyed) {
+                        context.restoreContext();
+                    }
+                }, delay);
+            });
+            context.loseContext();
+        });
+    }
 }
 
 export { WebglGraphicsDevice };

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -612,13 +612,54 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         return this;
     }
 
+    // #if _DEBUG
+    /**
+     * @type {(() => Promise<void>) | null}
+     * @private
+     */
+    _debugRestoreDelay = null;
+    // #endif
+
+    /** @ignore */
+    debugLoseContext(delay = 100) {
+        Debug.call(() => {
+            if (this._destroyed || this.contextLost || this._debugRestoreDelay) {
+                return;
+            }
+
+            // Distinguish this deliberate loss from normal device destruction. Start the timer
+            // in the loss handler so the application stops rendering throughout the delay.
+            this._debugRestoreDelay = () => new Promise((resolve) => {
+                setTimeout(resolve, delay);
+            });
+            this.wgpu.destroy();
+        });
+    }
+
     async handleDeviceLost(info) {
+        let recover = info.reason !== 'destroyed';
+        Debug.call(() => {
+            recover ||= !!this._debugRestoreDelay;
+        });
+
         // reason is 'destroyed' if we intentionally destroy the device
-        if (info.reason !== 'destroyed') {
+        if (recover && !this._destroyed) {
             Debug.warn(`WebGPU device was lost: ${info.message}, this needs to be handled`);
 
             super.loseContext(); // 'super' works correctly here
             this.fire('devicelost');
+
+            let restoreDelay;
+            Debug.call(() => {
+                restoreDelay = this._debugRestoreDelay?.();
+                this._debugRestoreDelay = null;
+            });
+            if (restoreDelay) {
+                await restoreDelay;
+            }
+            if (this._destroyed) {
+                return;
+            }
 
             await this.createDevice(); // Recreate the WebGPU device and associated resources after device loss.
 

--- a/test/platform/graphics/webgl-texture.test.mjs
+++ b/test/platform/graphics/webgl-texture.test.mjs
@@ -8,7 +8,8 @@ describe('WebglTexture upload during context loss', function () {
     it('skips uploads after the device has been destroyed', function () {
         const device = {
             contextLost: false,
-            gl: null,
+            _destroyed: true,
+            gl: { isContextLost: () => false },
             isContextLost: WebglGraphicsDevice.prototype.isContextLost,
             setTexture: sinon.spy()
         };
@@ -19,6 +20,13 @@ describe('WebglTexture upload during context loss', function () {
         expect(device.setTexture.called).to.be.false;
         expect(texture._needsUpload).to.be.true;
         expect(texture._needsMipmapsUpload).to.be.true;
+
+        device.gl = null;
+        expect(device.isContextLost()).to.be.true;
+
+        // A missing native context must also be safe independently of the base device state.
+        device._destroyed = false;
+        expect(device.isContextLost()).to.be.true;
     });
 
     it('keeps uploads pending until both native and engine recovery have completed', function () {


### PR DESCRIPTION
Make device-loss recovery easier to test in local engine examples across WebGL and WebGPU.

**Changes:**
- Trigger native WebGL context loss or WebGPU device destruction, then attempt recovery after a configurable delay measured from the loss event.
- Ignore repeated requests while loss or recovery is pending, and stop delayed recovery if the application destroys the device.
- Keep the testing behavior limited to debug builds, with safe no-ops in release builds and on the null device.
- Make WebGL context-loss checks inherit the base device's destroyed-state check, with regression coverage.
