### PR TITLE
Restore WebGPU rendering resources after device loss

### DIFF
--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -245,6 +245,9 @@ class BindStorageTextureFormat extends BindBaseFormat {
  * Currently this class is only used on WebGPU platform to specify the input and output resources
  * for vertex, fragment and compute shaders written in {@link SHADERLANGUAGE_WGSL} language.
  *
+ * Call {@link BindGroupFormat#destroy} when no longer needed. On WebGPU, the graphics device
+ * retains bind group formats for device recovery until they are explicitly destroyed.
+ *
  * @category Graphics
  */
 class BindGroupFormat {

--- a/src/platform/graphics/bind-group.js
+++ b/src/platform/graphics/bind-group.js
@@ -32,6 +32,9 @@ class DynamicBindGroup {
  * A bind group represents a collection of {@link UniformBuffer}, {@link Texture} and
  * {@link StorageBuffer} instanced, which can be bind on a GPU for rendering.
  *
+ * Call {@link BindGroup#destroy} when no longer needed. On WebGPU, the graphics device retains
+ * bind groups for device recovery until they are explicitly destroyed.
+ *
  * @ignore
  */
 class BindGroup {

--- a/src/platform/graphics/webgpu/webgpu-bind-group-format.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group-format.js
@@ -41,6 +41,14 @@ class WebgpuBindGroupFormat {
      */
     constructor(bindGroupFormat) {
 
+        this.bindGroupFormat = bindGroupFormat;
+        bindGroupFormat.device._bindGroupFormats.add(this);
+        this.restoreContext();
+    }
+
+    restoreContext() {
+        const bindGroupFormat = this.bindGroupFormat;
+
         /** @type {WebgpuGraphicsDevice} */
         const device = bindGroupFormat.device;
 
@@ -67,11 +75,12 @@ class WebgpuBindGroupFormat {
     }
 
     destroy() {
+        this.bindGroupFormat.device._bindGroupFormats.delete(this);
         this.bindGroupLayout = null;
     }
 
     loseContext() {
-        // this.bindGroupLayout = null;
+        this.bindGroupLayout = null;
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-bind-group.js
+++ b/src/platform/graphics/webgpu/webgpu-bind-group.js
@@ -20,9 +20,20 @@ class WebgpuBindGroup {
      */
     bindGroup;
 
+    /** @param {BindGroup} owner - The engine bind group owning this implementation. */
+    constructor(owner) {
+        this.owner = owner;
+        owner.device._bindGroups.add(this);
+    }
+
+    loseContext() {
+        this.bindGroup = null;
+        this.owner.dirty = true;
+    }
+
     update(bindGroup) {
 
-        this.destroy();
+        this.bindGroup = null;
         const device = bindGroup.device;
 
         /** @type {GPUBindGroupDescriptor} */
@@ -41,6 +52,7 @@ class WebgpuBindGroup {
     }
 
     destroy() {
+        this.owner.device._bindGroups.delete(this);
         this.bindGroup = null;
     }
 

--- a/src/platform/graphics/webgpu/webgpu-dynamic-buffer.js
+++ b/src/platform/graphics/webgpu/webgpu-dynamic-buffer.js
@@ -36,6 +36,11 @@ class WebgpuDynamicBuffer extends DynamicBuffer {
 
     destroy(device) {
 
+        this.bindGroupCache.forEach(bindGroup => bindGroup.destroy());
+        this.bindGroupCache.clear();
+        this.bindGroupFormat.destroy();
+        this.mappedRange = null;
+
         device._vram.ub -= this.buffer.size;
 
         this.buffer.destroy();

--- a/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
+++ b/src/platform/graphics/webgpu/webgpu-dynamic-buffers.js
@@ -13,6 +13,20 @@ class WebgpuDynamicBuffers extends DynamicBuffers {
      */
     pendingStagingBuffers = [];
 
+    destroy() {
+        // Loss can interrupt a frame before its active allocations have been submitted.
+        this.scheduleSubmit();
+        for (const { gpuBuffer, stagingBuffer } of this.usedBuffers) {
+            gpuBuffer.destroy(this.device);
+            stagingBuffer.destroy(this.device);
+        }
+        for (const stagingBuffer of this.pendingStagingBuffers) {
+            stagingBuffer.destroy(this.device);
+        }
+        this.pendingStagingBuffers.length = 0;
+        super.destroy();
+    }
+
     createBuffer(device, size, isStaging) {
         return new WebgpuDynamicBuffer(device, size, isStaging);
     }

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -71,6 +71,12 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      */
     _deferredDestroys = [];
 
+    /** @type {Set<WebgpuBindGroup>} @private */
+    _bindGroups = new Set();
+
+    /** @type {Set<WebgpuBindGroupFormat>} @private */
+    _bindGroupFormats = new Set();
+
     /**
      * Object responsible for caching and creation of render pipelines.
      */
@@ -279,20 +285,39 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      */
     destroy() {
 
-        this.clearRenderer.destroy();
-        this.clearRenderer = null;
-
-        this.mipmapRenderer.destroy();
-        this.mipmapRenderer = null;
-
-        this.resolver.destroy();
-        this.resolver = null;
+        this.destroyDeviceResources();
 
         this._clearXrState();
-
         this.externalBackbuffer = null;
 
         super.destroy();
+    }
+
+    /** @private */
+    destroyDeviceResources() {
+
+        this.clearRenderer?.destroy();
+        this.clearRenderer = null;
+
+        this.mipmapRenderer?.destroy();
+        this.mipmapRenderer = null;
+
+        this.resolver?.destroy();
+        this.resolver = null;
+
+        this.quadVertexBuffer?.destroy();
+        this.quadVertexBuffer = null;
+        this.quadIndexBuffer?.destroy();
+        this.quadIndexBuffer = null;
+        this.emptyBindGroup?.format.destroy();
+        this.emptyBindGroup?.destroy();
+        this.emptyBindGroup = null;
+        this.dynamicBuffers?.destroy();
+        this.dynamicBuffers = null;
+        this.gpuProfiler?.destroy();
+        this.gpuProfiler = null;
+        this.backBuffer?.destroy();
+        this.backBuffer = null;
     }
 
     /**
@@ -646,7 +671,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         if (recover && !this._destroyed) {
             Debug.warn(`WebGPU device was lost: ${info.message}, this needs to be handled`);
 
-            super.loseContext(); // 'super' works correctly here
+            this.loseContext();
             this.fire('devicelost');
 
             let restoreDelay;
@@ -663,9 +688,50 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
 
             await this.createDevice(); // Recreate the WebGPU device and associated resources after device loss.
 
-            super.restoreContext(); // 'super' works correctly here
+            this.restoreContext();
             this.fire('devicerestored');
         }
+    }
+
+    /** @ignore */
+    loseContext() {
+        // Nothing recorded against the old device can be submitted to its replacement.
+        this.commandEncoder = null;
+        this.commandBuffers.length = 0;
+        this.passEncoder = null;
+        this.pipeline = null;
+        this.insideRenderPass = false;
+        this.bindGroupFormats.length = 0;
+        this.renderPipeline.cache.clear();
+        this.computePipeline.cache.clear();
+        // Release owned buffers before their handles are invalidated, so destruction also
+        // removes their VRAM accounting. The remaining application resources are restored below.
+        this.destroyDeviceResources();
+        super.loseContext();
+
+        for (const bindGroup of this._bindGroups) {
+            bindGroup.loseContext();
+        }
+        for (const format of this._bindGroupFormats) {
+            format.loseContext();
+        }
+
+        for (const resource of this._deferredDestroys) {
+            resource.destroy();
+        }
+        this._deferredDestroys.length = 0;
+    }
+
+    /** @ignore */
+    restoreContext() {
+        for (const texture of this.textures) {
+            texture.impl.create(this);
+        }
+        for (const format of this._bindGroupFormats) {
+            format.restoreContext();
+        }
+        // Bind groups rebuild through their normal dirty update after buffer allocations are ready.
+        super.restoreContext();
     }
 
     postInit() {
@@ -817,7 +883,7 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     }
 
     createBindGroupImpl(bindGroup) {
-        return new WebgpuBindGroup();
+        return new WebgpuBindGroup(bindGroup);
     }
 
     createComputeImpl(compute) {

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -71,10 +71,22 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
      */
     _deferredDestroys = [];
 
-    /** @type {Set<WebgpuBindGroup>} @private */
+    /**
+     * Strong references used for device recovery. Owners must explicitly destroy bind groups
+     * when no longer needed to unregister them.
+     *
+     * @type {Set<WebgpuBindGroup>}
+     * @private
+     */
     _bindGroups = new Set();
 
-    /** @type {Set<WebgpuBindGroupFormat>} @private */
+    /**
+     * Strong references used for device recovery. Owners must explicitly destroy bind group
+     * formats when no longer needed to unregister them.
+     *
+     * @type {Set<WebgpuBindGroupFormat>}
+     * @private
+     */
     _bindGroupFormats = new Set();
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -194,6 +194,7 @@ class WebgpuShader {
     }
 
     processGLSL() {
+        Debug.assert(this._ownedMeshBindGroupFormat === null, 'Shader processing must not replace an owned mesh bind group format.');
         const shader = this.shader;
 
         // process the shader source to allow for uniforms
@@ -250,6 +251,7 @@ class WebgpuShader {
     }
 
     processWGSL() {
+        Debug.assert(this._ownedMeshBindGroupFormat === null, 'Shader processing must not replace an owned mesh bind group format.');
         const shader = this.shader;
 
         // process the shader source to allow for uniforms

--- a/src/platform/graphics/webgpu/webgpu-shader.js
+++ b/src/platform/graphics/webgpu/webgpu-shader.js
@@ -7,6 +7,7 @@ import { WebgpuDebug } from './webgpu-debug.js';
 import { WebgpuShaderProcessorWGSL } from './webgpu-shader-processor-wgsl.js';
 
 /**
+ * @import { BindGroupFormat } from '../bind-group-format.js'
  * @import { GraphicsDevice } from '../graphics-device.js'
  * @import { Shader } from '../shader.js'
  */
@@ -20,6 +21,9 @@ const computeShaderIds = new StringIds();
  * @ignore
  */
 class WebgpuShader {
+    /** @type {BindGroupFormat|null} @private */
+    _ownedMeshBindGroupFormat = null;
+
     /**
      * Transpiled vertex shader code.
      *
@@ -151,6 +155,10 @@ class WebgpuShader {
     destroy(shader) {
         this._vertexCode = null;
         this._fragmentCode = null;
+        this._ownedMeshBindGroupFormat?.destroy();
+        this._ownedMeshBindGroupFormat = null;
+        this.computeReflectedBindGroupFormat?.destroy();
+        this.computeReflectedBindGroupFormat = null;
     }
 
     createShaderModule(code, shaderType) {
@@ -207,6 +215,7 @@ class WebgpuShader {
 
         shader.meshUniformBufferFormat = processed.meshUniformBufferFormat;
         shader.meshBindGroupFormat = processed.meshBindGroupFormat;
+        this._ownedMeshBindGroupFormat = processed.meshBindGroupFormat;
         shader.attributes = processed.attributes;
     }
 
@@ -256,6 +265,7 @@ class WebgpuShader {
 
         shader.meshUniformBufferFormat = processed.meshUniformBufferFormat;
         shader.meshBindGroupFormat = processed.meshBindGroupFormat;
+        this._ownedMeshBindGroupFormat = processed.meshBindGroupFormat;
         shader.attributes = processed.attributes;
     }
 

--- a/src/platform/graphics/webgpu/webgpu-texture.js
+++ b/src/platform/graphics/webgpu/webgpu-texture.js
@@ -96,7 +96,9 @@ class WebgpuTexture {
         this.format = gpuTextureFormats[texture.format];
         Debug.assert(this.format !== '', `WebGPU does not support texture format ${texture.format} [${pixelFormatInfo.get(texture.format)?.name}] for texture ${texture.name}`, texture);
 
-        this.create(texture.device);
+        if (!texture.device.contextLost) {
+            this.create(texture.device);
+        }
     }
 
     create(device) {
@@ -331,6 +333,10 @@ class WebgpuTexture {
     }
 
     loseContext() {
+        this.gpuTexture = null;
+        this.view = null;
+        this.viewCache.clear();
+        this.samplers.length = 0;
     }
 
     /**
@@ -338,6 +344,9 @@ class WebgpuTexture {
      * @param {Texture} texture - The texture.
      */
     uploadImmediate(device, texture) {
+
+        // Downloads can finish while a replacement device is still being requested.
+        if (device.contextLost || device._destroyed) return;
 
         if (texture._needsUpload || texture._needsMipmapsUpload) {
             Debug.assert(!device.insideRenderPass,

--- a/test/platform/graphics/webgpu/webgpu-context-restore.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-context-restore.test.mjs
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { BindGroupFormat } from '../../../../src/platform/graphics/bind-group-format.js';
+import { BindGroup } from '../../../../src/platform/graphics/bind-group.js';
+import { SHADERLANGUAGE_WGSL } from '../../../../src/platform/graphics/constants.js';
+import { NullGraphicsDevice } from '../../../../src/platform/graphics/null/null-graphics-device.js';
+import { WebgpuBindGroupFormat } from '../../../../src/platform/graphics/webgpu/webgpu-bind-group-format.js';
+import { WebgpuBindGroup } from '../../../../src/platform/graphics/webgpu/webgpu-bind-group.js';
+import { WebgpuDynamicBuffers } from '../../../../src/platform/graphics/webgpu/webgpu-dynamic-buffers.js';
+import { WebgpuGraphicsDevice } from '../../../../src/platform/graphics/webgpu/webgpu-graphics-device.js';
+import { WebgpuShaderProcessorWGSL } from '../../../../src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js';
+import { WebgpuShader } from '../../../../src/platform/graphics/webgpu/webgpu-shader.js';
+
+describe('WebGPU context restoration', function () {
+    it('rebuilds unchanged bind groups and layouts against the replacement device', function () {
+        const device = new NullGraphicsDevice({ width: 1, height: 1 });
+        const createDevice = () => ({
+            createBindGroupLayout: sinon.spy(desc => ({ desc })),
+            createBindGroup: sinon.spy(desc => ({ desc })),
+            pushErrorScope() {},
+            popErrorScope: () => Promise.resolve(null)
+        });
+        device.wgpu = createDevice();
+        device._bindGroups = new Set();
+        device._bindGroupFormats = new Set();
+        device.createBindGroupFormatImpl = format => new WebgpuBindGroupFormat(format);
+        device.createBindGroupImpl = bindGroup => new WebgpuBindGroup(bindGroup);
+        const format = new BindGroupFormat(device, []);
+        const bindGroup = new BindGroup(device, format);
+        bindGroup.update();
+        const oldGroup = bindGroup.impl.bindGroup;
+        const oldLayout = format.impl.bindGroupLayout;
+
+        expect(bindGroup.dirty).to.be.false;
+        bindGroup.impl.loseContext();
+        format.impl.loseContext();
+        expect(bindGroup.dirty).to.be.true;
+        expect(bindGroup.impl.bindGroup).to.equal(null);
+        expect(format.impl.bindGroupLayout).to.equal(null);
+
+        device.wgpu = createDevice();
+        WebgpuGraphicsDevice.prototype.restoreContext.call(device);
+        expect(bindGroup.impl.bindGroup).to.equal(null);
+        expect(device.wgpu.createBindGroup.called).to.be.false;
+        bindGroup.update();
+        const newGroup = bindGroup.impl.bindGroup;
+        expect(newGroup).not.to.equal(oldGroup);
+        expect(newGroup.desc.layout).not.to.equal(oldLayout);
+        expect(newGroup.desc.layout).to.equal(format.impl.bindGroupLayout);
+        expect(bindGroup.impl.bindGroup).to.equal(newGroup);
+        expect(device.wgpu.createBindGroup.calledOnce).to.be.true;
+        expect(device.wgpu.createBindGroupLayout.calledOnce).to.be.true;
+        expect(Object.getOwnPropertyDescriptor(bindGroup.impl, 'bindGroup').get).to.be.undefined;
+        expect(Object.getOwnPropertyDescriptor(format.impl, 'bindGroupLayout').get).to.be.undefined;
+
+        bindGroup.destroy();
+        format.destroy();
+        expect(device._bindGroups.size).to.equal(0);
+        expect(device._bindGroupFormats.size).to.equal(0);
+        WebgpuGraphicsDevice.prototype.restoreContext.call(device);
+        expect(device.wgpu.createBindGroupLayout.calledOnce).to.be.true;
+        device.destroy();
+    });
+
+    it('unregisters shader-generated layouts while leaving caller-owned layouts alive', function () {
+        const device = new NullGraphicsDevice({ width: 1, height: 1 });
+        device._bindGroupFormats = new Set();
+        device.wgpu = { createBindGroupLayout: () => ({}) };
+        device.createBindGroupFormatImpl = format => new WebgpuBindGroupFormat(format);
+        const generated = new BindGroupFormat(device, []);
+        const shared = new BindGroupFormat(device, []);
+        const processor = sinon.stub(WebgpuShaderProcessorWGSL, 'run').returns({ meshBindGroupFormat: generated });
+        try {
+            const processedShader = { device, definition: { shaderLanguage: SHADERLANGUAGE_WGSL, processingOptions: {} } };
+            const rawShader = { device, definition: { shaderLanguage: SHADERLANGUAGE_WGSL, meshBindGroupFormat: shared } };
+            new WebgpuShader(processedShader).destroy(processedShader);
+            new WebgpuShader(rawShader).destroy(rawShader);
+            expect(device._bindGroupFormats.has(generated.impl)).to.be.false;
+            expect(device._bindGroupFormats.has(shared.impl)).to.be.true;
+        } finally {
+            processor.restore();
+            shared.destroy();
+            device.destroy();
+        }
+    });
+
+    it('releases active and unsubmitted dynamic allocations on destruction', function () {
+        const device = {};
+        const buffers = new WebgpuDynamicBuffers(device, 1024, 256);
+        const gpuBuffer = { destroy: sinon.spy() };
+        const stagingBuffer = { destroy: sinon.spy() };
+        const pendingStagingBuffer = { destroy: sinon.spy() };
+        buffers.activeBuffer = { gpuBuffer, stagingBuffer, offset: 0, size: 256 };
+        buffers.pendingStagingBuffers.push(pendingStagingBuffer);
+
+        buffers.destroy();
+
+        for (const buffer of [gpuBuffer, stagingBuffer, pendingStagingBuffer]) {
+            expect(buffer.destroy.calledOnceWithExactly(device)).to.be.true;
+        }
+        expect(buffers.activeBuffer).to.equal(null);
+        expect(buffers.pendingStagingBuffers).to.have.lengthOf(0);
+        expect(buffers.stagingBuffers).to.equal(null);
+    });
+});

--- a/test/platform/graphics/webgpu/webgpu-texture.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-texture.test.mjs
@@ -57,6 +57,50 @@ const createMockTexture = (device, overrides = {}) => {
 
 describe('WebgpuTexture', function () {
 
+    it('discards native textures, views and samplers when the device is lost', function () {
+        const device = createMockDevice([]);
+        const impl = new WebgpuTexture(createMockTexture(device));
+        const oldTexture = impl.gpuTexture;
+        const oldView = impl.view;
+        impl.samplers.push({});
+        impl.viewCache.set(1, {});
+
+        impl.loseContext();
+        expect(impl.gpuTexture).to.equal(null);
+        expect(impl.view).to.equal(null);
+        expect(impl.samplers).to.have.lengthOf(0);
+        expect(impl.viewCache.size).to.equal(0);
+
+        device.wgpu = createMockDevice([]).wgpu;
+        impl.create(device);
+        expect(impl.gpuTexture).not.to.equal(oldTexture);
+        expect(impl.view).not.to.equal(oldView);
+    });
+
+    it('defers allocation and uploads during loss until the replacement device is ready', function () {
+        const created = [];
+        const device = createMockDevice(created);
+        device.contextLost = true;
+        const texture = createMockTexture(device, { _needsUpload: true, _needsMipmapsUpload: true });
+        const impl = new WebgpuTexture(texture);
+        let uploads = 0;
+        impl.uploadData = () => uploads++;
+
+        impl.uploadImmediate(device, texture);
+        expect(created).to.have.lengthOf(0);
+        expect(uploads).to.equal(0);
+        expect(texture._needsUpload).to.be.true;
+        expect(texture._needsMipmapsUpload).to.be.true;
+
+        impl.create(device);
+        device.contextLost = false;
+        impl.uploadImmediate(device, texture);
+        expect(created).to.have.lengthOf(1);
+        expect(uploads).to.equal(1);
+        expect(texture._needsUpload).to.be.false;
+        expect(texture._needsMipmapsUpload).to.be.false;
+    });
+
     it('creates a single-sampled texture by default', function () {
         const created = [];
         const device = createMockDevice(created);


### PR DESCRIPTION
Restore basic WebGPU rendering after device loss. Hello World previously reused resources from the lost device, producing validation errors and failing to recover correctly.

**Changes:**
- Recreate textures and binding layouts against the replacement device, and rebuild bind groups through their existing dirty update path.
- Discard stale command and pipeline state, and release device-owned resources and buffer pools before reconstruction.
- Preserve pending texture uploads during recovery and clean up tracked binding resources when their owners are destroyed.

**Performance:**
Binding invalidation happens during device loss and restoration. Bind group and layout access remain plain fields, with no per-draw device checks.
