### PR TITLE
Add category sharing and expand-all controls

### DIFF
--- a/examples/src/app/components/CategoryPanel.mjs
+++ b/examples/src/app/components/CategoryPanel.mjs
@@ -1,0 +1,79 @@
+import { Panel } from '@playcanvas/pcui/react';
+import { useLayoutEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Link } from 'react-router-dom';
+
+import { fragment, jsx } from '../jsx.mjs';
+
+/**
+ * @import { ComponentProps, ReactElement, ReactNode } from 'react'
+ */
+
+const CATEGORY_PANEL_ID = 'category-panel-';
+
+/**
+ * @param {object} props - Component properties.
+ * @param {string} props.category - Category name.
+ * @param {boolean} props.collapsed - Whether the category is collapsed.
+ * @param {() => void} [props.onExpandAll] - Show all categories instead of sharing this category.
+ * @param {ComponentProps<typeof Panel>['parent']} [props.parent] - Parent PCUI container.
+ * @param {ReactNode} [props.children] - Example links.
+ * @returns {ReactElement} Category panel with a share or expand-all control in its header.
+ */
+function CategoryPanel({ category, collapsed, onExpandAll, parent, children }) {
+    const id = `${CATEGORY_PANEL_ID}${category}`;
+    const [header, setHeader] = useState(/** @type {Element | null} */ (null));
+
+    // PCUI creates the header outside the React children container.
+    useLayoutEffect(() => {
+        setHeader(document.getElementById(id)?.querySelector('.pcui-panel-header') ?? null);
+    }, [id]);
+
+    const icon = jsx('svg', {
+        viewBox: '0 0 24 24',
+        fill: 'none',
+        stroke: 'currentColor',
+        strokeWidth: 2,
+        strokeLinecap: 'round',
+        strokeLinejoin: 'round',
+        width: 16,
+        height: 16,
+        'aria-hidden': true
+    }, onExpandAll ? jsx('path', { d: 'M8 7l4-4 4 4M12 3v6M8 17l4 4 4-4M12 15v6' }) : fragment(
+        jsx('circle', { cx: 18, cy: 5, r: 3 }),
+        jsx('circle', { cx: 6, cy: 12, r: 3 }),
+        jsx('circle', { cx: 18, cy: 19, r: 3 }),
+        jsx('line', { x1: 8.59, y1: 13.51, x2: 15.42, y2: 17.49 }),
+        jsx('line', { x1: 15.41, y1: 6.51, x2: 8.59, y2: 10.49 })
+    ));
+    const control = onExpandAll ? jsx('button', {
+        type: 'button',
+        className: 'category-share',
+        title: 'Show all categories',
+        'aria-label': 'Show all categories',
+        onClick: (event) => {
+            event.stopPropagation();
+            onExpandAll();
+        }
+    }, icon) : jsx(Link, {
+        to: `/${category}`,
+        className: 'category-share',
+        title: 'Share category',
+        'aria-label': `Share ${category.split('-').join(' ')} category`,
+        onClick: event => event.stopPropagation()
+    }, icon);
+
+    return fragment(
+        jsx(Panel, {
+            id,
+            parent,
+            class: 'categoryPanel',
+            headerText: category.split('-').join(' ').toUpperCase(),
+            collapsible: true,
+            collapsed
+        }, children),
+        header && createPortal(control, header)
+    );
+}
+
+export { CATEGORY_PANEL_ID, CategoryPanel };

--- a/examples/src/app/components/Example.mjs
+++ b/examples/src/app/components/Example.mjs
@@ -3,13 +3,14 @@ import * as ReactPCUI from '@playcanvas/pcui/react';
 import { Panel, Container, Button, Spinner } from '@playcanvas/pcui/react';
 import React, { Component } from 'react';
 import * as ReactJsxRuntime from 'react/jsx-runtime';
-import { useParams } from 'react-router-dom';
+import { Navigate, useLocation, useParams } from 'react-router-dom';
 
 import { CodeEditorMobile } from './code-editor/CodeEditorMobile.mjs';
 import { DeviceSelector } from './DeviceSelector.mjs';
 import { ErrorBoundary } from './ErrorBoundary.mjs';
 import { SelectInput as OverlaySelectInput } from './OverlaySelectInput.mjs';
 import { COLOR_NAMES, INLINE_MD_PATTERN, SAFE_URL_PATTERN } from '../../../utils/inline-markdown.mjs';
+import { getFirstExample } from '../categories.mjs';
 import { CLOSE_SELECTS_EVENT } from '../constants.mjs';
 import { setExampleSnapshotProvider } from '../example-snapshot.mjs';
 import { iframe } from '../iframe.mjs';
@@ -1048,13 +1049,18 @@ class Example extends TypedComponent {
 }
 
 /**
+ * Category routes display their first example without replacing the shareable URL.
+ *
  * @param {Omit<Props, 'match'>} props - Component properties.
  * @returns {ReactElement} The Example component with router params.
  */
 function ExampleWithRouter(props) {
-    const params = useParams();
-    // @ts-ignore
-    return jsx(Example, { ...props, match: { params } });
+    const { category = '', example = getFirstExample(category) } = useParams();
+    const { search } = useLocation();
+    if (!example) {
+        return jsx(Navigate, { to: { pathname: '/misc/hello-world', search }, replace: true });
+    }
+    return jsx(Example, { ...props, match: { params: { category, example } } });
 }
 
 export { ExampleWithRouter as Example };

--- a/examples/src/app/components/MainLayout.mjs
+++ b/examples/src/app/components/MainLayout.mjs
@@ -1,18 +1,15 @@
 import { Container } from '@playcanvas/pcui/react';
 import { Component } from 'react';
-import { HashRouter, Routes, Route, Navigate, useLocation, useParams } from 'react-router-dom';
+import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
 
 import { CodeEditorDesktop } from './code-editor/CodeEditorDesktop.mjs';
 import { Example } from './Example.mjs';
 import { Menu } from './Menu.mjs';
 import { SideBar } from './Sidebar.mjs';
-import { getFirstExample } from '../categories.mjs';
 import { iframe } from '../iframe.mjs';
 import { jsx } from '../jsx.mjs';
 import { patchState, readState } from '../url-state.mjs';
 import { getLayout } from '../utils.mjs';
-
-/** @import { ReactElement } from 'react' */
 
 const MOBILE_DOCK_HEIGHT = 48;
 const MOBILE_DOCK_WIDTH = 48;
@@ -69,28 +66,6 @@ function getDefaultMobilePanelWidth() {
         MOBILE_PANEL_DEFAULT_MAX_WIDTH,
         Math.max(MOBILE_PANEL_DEFAULT_MIN_WIDTH, window.innerWidth * MOBILE_PANEL_DEFAULT_WIDTH_SCALE)
     ));
-}
-
-/**
- * Resolves a bare `#/<category>` URL to the first example of that category, so a
- * category can be linked directly. `focusCategory` rides along in the location
- * state to tell the sidebar to show just that category and collapse the rest;
- * the hash query is carried over so a shared `?s=` state survives the redirect.
- *
- * @returns {ReactElement} Redirect to the first example of the category.
- */
-function CategoryRedirect() {
-    const { category = '' } = useParams();
-    const { search } = useLocation();
-    const example = getFirstExample(category);
-    if (!example) {
-        return jsx(Navigate, { to: { pathname: '/misc/hello-world', search }, replace: true });
-    }
-    return jsx(Navigate, {
-        to: { pathname: `/${category}/${example}`, search },
-        replace: true,
-        state: { focusCategory: category }
-    });
 }
 
 // eslint-disable-next-line jsdoc/require-property
@@ -313,11 +288,7 @@ class MainLayout extends TypedComponent {
                         element: jsx(Navigate, { to: '/misc/hello-world', replace: true })
                     }),
                     jsx(Route, {
-                        path: '/:category',
-                        element: jsx(CategoryRedirect, null)
-                    }),
-                    jsx(Route, {
-                        path: '/:category/:example',
+                        path: '/:category/:example?',
                         element: jsx(
                             'div',
                             { id: 'appInner-router', style: { display: 'contents' } },

--- a/examples/src/app/components/Sidebar.mjs
+++ b/examples/src/app/components/Sidebar.mjs
@@ -1,23 +1,27 @@
 import { Observer } from '@playcanvas/observer';
 import { BindingTwoWay, BooleanInput, Container, Label, LabelGroup, Panel, TextInput } from '@playcanvas/pcui/react';
 import { Component } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 
-import { byName, getCategories } from '../categories.mjs';
+import { CATEGORY_PANEL_ID, CategoryPanel } from './CategoryPanel.mjs';
+import { byName, getCategories, getFirstExample } from '../categories.mjs';
 import { VERSION } from '../constants.mjs';
 import { iframe } from '../iframe.mjs';
 import { jsx } from '../jsx.mjs';
 import { thumbnailPath } from '../paths.mjs';
-import { getHashPath, patchState, readState } from '../url-state.mjs';
+import { patchState, readState } from '../url-state.mjs';
 import { getLayout } from '../utils.mjs';
 
-/** @import { ReactElement } from 'react' */
-
-const CATEGORY_PANEL_ID = 'category-panel-';
+/**
+ * @import { ReactElement } from 'react'
+ * @import { Location, NavigateFunction } from 'react-router-dom'
+ */
 
 /**
  * @typedef {object} Props
- * @property {{ pathname: string, hash: string, state?: any }} location - The router location.
+ * @property {Location} location - The router location.
+ * @property {string} examplePath - The resolved example path.
+ * @property {NavigateFunction} navigate - Navigate to another route.
  * @property {'mobile'|'desktop'} [layout] - Current layout.
  * @property {null|'examples'|'code'|'controls'|'description'} [mobilePanel] - Active mobile panel.
  * @property {(mobilePanel: null|'examples'|'code'|'controls'|'description') => void} [setMobilePanel] - Set active mobile panel.
@@ -45,8 +49,8 @@ const TypedComponent = Component;
  * @returns {string | null} Category the URL asked to focus on, if any.
  */
 const focusedCategory = (location) => {
-    const focus = location?.state?.focusCategory;
-    return typeof focus === 'string' ? focus : null;
+    const [, category, example] = location.pathname.split('/');
+    return !example && category && getFirstExample(category) ? category : null;
 };
 
 /**
@@ -141,7 +145,7 @@ function filterCategories(defaultCategories, filter) {
  */
 const createState = (location) => {
     const ui = readState().ui ?? {};
-    const filter = typeof ui.filter === 'string' ? ui.filter : '';
+    const filter = !focusedCategory(location) && typeof ui.filter === 'string' ? ui.filter : '';
     const largeThumbnails = typeof ui.largeThumbnails === 'boolean' ? ui.largeThumbnails : false;
     const collapsed = typeof ui.sideBarCollapsed === 'boolean' ?
         ui.sideBarCollapsed :
@@ -173,6 +177,8 @@ class SideBar extends TypedComponent {
 
     /** @type {{ unbind: () => void } | null} */
     _largeThumbnailsHandle = null;
+
+    _scrollFrame = 0;
 
     /**
      * @param {Props} props - Component properties.
@@ -245,6 +251,9 @@ class SideBar extends TypedComponent {
     }
 
     componentDidMount() {
+        if (focusedCategory(this.props.location)) {
+            patchState({ ui: { filter: '' } });
+        }
         this._largeThumbnailsHandle = this.state.observer.on('largeThumbnails:set', this._onLargeThumbnailsSet);
         this.setupSideBar();
         this.setupCategoryPanels();
@@ -260,11 +269,53 @@ class SideBar extends TypedComponent {
         this.setupSideBar();
         this.setupCategoryPanels();
         if (prevState.filterText && !this.state.filterText) {
-            document.querySelector('#sideBar-contents .nav-item.selected')?.scrollIntoView({ block: 'nearest' });
+            this._scrollToElement('#sideBar-contents .nav-item.selected');
+        }
+        const category = focusedCategory(this.props.location);
+        const expandAll = this.props.location.state?.expandAllCategories === true;
+        if ((category || expandAll) && prevProps.location.key !== this.props.location.key) {
+            patchState({ ui: { filter: '' } });
+            this.setState({
+                filterText: '',
+                filteredCategories: null,
+                collapsedCategories: collapseAllBut(this.state.defaultCategories, category)
+            }, () => {
+                if (category) {
+                    this._scrollToCategory(category);
+                } else {
+                    this._scrollToElement('#sideBar-contents .nav-item.selected');
+                }
+            });
         }
     }
 
+    _expandAll = () => {
+        this.props.navigate(this.props.examplePath, { state: { expandAllCategories: true } });
+    };
+
+    /**
+     * @param {string} category - Category whose header should be visible.
+     */
+    _scrollToCategory(category) {
+        this._scrollToElement(`#${CATEGORY_PANEL_ID}${category} .pcui-panel-header`);
+    }
+
+    /**
+     * @param {string} selector - Element to reveal after category panels finish resizing.
+     */
+    _scrollToElement(selector) {
+        cancelAnimationFrame(this._scrollFrame);
+        // PCUI applies collapsed panel sizes in an animation frame after the React update.
+        this._scrollFrame = requestAnimationFrame(() => {
+            this._scrollFrame = requestAnimationFrame(() => {
+                this._scrollFrame = 0;
+                document.querySelector(selector)?.scrollIntoView({ block: 'nearest' });
+            });
+        });
+    }
+
     componentWillUnmount() {
+        cancelAnimationFrame(this._scrollFrame);
         this._largeThumbnailsHandle?.unbind();
         this._largeThumbnailsHandle = null;
         window.removeEventListener('resize', this._onLayoutChange);
@@ -304,8 +355,13 @@ class SideBar extends TypedComponent {
         // when first opening the examples browser via a specific example, scroll it into view
         // @ts-ignore
         if (!window._scrolledToExample) {
-            const examplePath = getHashPath().split('/');
-            document.getElementById(`link-${examplePath[1]}-${examplePath[2]}`)?.scrollIntoView();
+            const category = focusedCategory(this.props.location);
+            if (category) {
+                this._scrollToCategory(category);
+            } else {
+                const examplePath = this.props.examplePath.split('/');
+                document.getElementById(`link-${examplePath[1]}-${examplePath[2]}`)?.scrollIntoView();
+            }
             // @ts-ignore
             window._scrolledToExample = true;
         }
@@ -368,19 +424,19 @@ class SideBar extends TypedComponent {
         if (Object.keys(categories).length === 0) {
             return jsx(Label, { text: 'No results' });
         }
-        const { pathname } = this.props.location;
-        const { collapsedCategories, filterText } = this.state;
+        const { examplePath } = this.props;
+        const { collapsedCategories, defaultCategories, filterText } = this.state;
+        const expandedCategories = Object.keys(defaultCategories).filter(category => !collapsedCategories[category]);
+        const onlyExpandedCategory = expandedCategories.length === 1 ? expandedCategories[0] : null;
         return Object.keys(categories)
         .sort(byName)
         .map((category) => {
             return jsx(
-                Panel,
+                CategoryPanel,
                 {
                     key: category,
-                    id: `${CATEGORY_PANEL_ID}${category}`,
-                    class: 'categoryPanel',
-                    headerText: category.split('-').join(' ').toUpperCase(),
-                    collapsible: true,
+                    category,
+                    onExpandAll: category === onlyExpandedCategory ? this._expandAll : undefined,
                     collapsed: !filterText && collapsedCategories[category] === true
                 },
                 jsx(
@@ -392,7 +448,7 @@ class SideBar extends TypedComponent {
                     .sort(byName)
                     .map((example) => {
                         const path = `/${category}/${example}`;
-                        const isSelected = pathname === path;
+                        const isSelected = examplePath === path;
                         const className = `nav-item ${isSelected ? 'selected' : ''}`;
                         return jsx(
                             Link,
@@ -487,12 +543,14 @@ class SideBar extends TypedComponent {
 }
 
 /**
- * @param {Omit<Props, 'location'>} props - Component properties.
+ * @param {Omit<Props, 'location'|'examplePath'|'navigate'>} props - Component properties.
  * @returns {ReactElement} The SideBar component with router location.
  */
 function SideBarWithRouter(props) {
     const location = useLocation();
-    return jsx(SideBar, { ...props, location });
+    const navigate = useNavigate();
+    const { category = '', example = getFirstExample(category) } = useParams();
+    return jsx(SideBar, { ...props, location, navigate, examplePath: `/${category}/${example}` });
 }
 
 export { SideBarWithRouter as SideBar };

--- a/examples/src/app/components/code-editor/CodeEditorDesktop.mjs
+++ b/examples/src/app/components/code-editor/CodeEditorDesktop.mjs
@@ -2,6 +2,7 @@ import MonacoEditor, { loader } from '@monaco-editor/react';
 import { Button, Container, Panel } from '@playcanvas/pcui/react';
 
 import { CodeEditorBase } from './CodeEditorBase.mjs';
+import { getFirstExample } from '../../categories.mjs';
 import { downloadExampleProject } from '../../download-project.mjs';
 import { iframe } from '../../iframe.mjs';
 import { jsx } from '../../jsx.mjs';
@@ -581,7 +582,8 @@ class CodeEditorDesktop extends CodeEditorBase {
                         icon: 'E259',
                         text: '',
                         onClick: () => {
-                            const examplePath = getHashPath() === '/' ? 'misc/hello-world' : getHashPath().slice(1);
+                            const [, category, example] = getHashPath().split('/');
+                            const examplePath = `${category}/${example || getFirstExample(category)}`;
                             window.open(
                                 `https://github.com/playcanvas/engine/blob/main/examples/src/examples/${examplePath}.example.mjs`
                             );

--- a/examples/src/app/url-state.mjs
+++ b/examples/src/app/url-state.mjs
@@ -244,7 +244,7 @@ export const patchState = (patch) => {
  * crawler-friendly share page provides social-unfurl meta tags; that page
  * uses history.replaceState to swap to the canonical `#/<path>?s=...` URL
  * before the SPA boots, so the recipient lands on the normal examples
- * browser. Falls back to the canonical hash URL on the index route.
+ * browser. Uses the canonical hash URL for category and index routes.
  *
  * @returns {string} Shareable URL.
  */
@@ -252,9 +252,13 @@ export const buildShareUrl = () => {
     const { path } = hashParts();
     const encoded = encodeState();
     const origin = window.location.origin;
-    const trimmed = path.replace(/^\//, '');
+    const trimmed = path.replace(/^\/|\/$/g, '');
     if (!trimmed) {
         return encoded ? `${origin}/#/?${STATE_PARAM}=${encoded}` : `${origin}/`;
+    }
+    if (!trimmed.includes('/')) {
+        const base = `${origin}/#/${trimmed}`;
+        return encoded ? `${base}?${STATE_PARAM}=${encoded}` : base;
     }
     const slug = trimmed.replace(/\//g, '_');
     const base = `${origin}/share/${slug}/`;

--- a/examples/src/static/styles.css
+++ b/examples/src/static/styles.css
@@ -244,6 +244,37 @@ body {
     background-color: #20292b;
 }
 
+#sideBar .categoryPanel .pcui-panel-header-title {
+    min-width: 0;
+    flex: 1;
+}
+
+.category-share {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 28px;
+    height: 28px;
+    margin: 2px 2px 2px 0;
+    padding: 0;
+    border: 0;
+    border-radius: 3px;
+    background: transparent;
+    color: #9ba9ad;
+    cursor: pointer;
+}
+
+.category-share:hover,
+.category-share:focus-visible {
+    color: #f60;
+    background-color: #334044;
+}
+
+.category-share:focus-visible {
+    outline: 1px solid #f60;
+    outline-offset: -1px;
+}
+
 .nav-item {
     margin: 12px;
     overflow: auto;


### PR DESCRIPTION
Make example categories easy to share directly from the sidebar, with a quick way to return to the full list.

**Changes:**
- Add a share control to category headers that opens the category URL and collapses the other categories.
- Keep category URLs such as `#/misc` in the address bar while displaying the category's first example.
- Turn the sole expanded category's share control into "Show all categories", restoring the full list and the current example's URL while keeping that example visible.
- Keep the page Share dialog and GitHub source links working from category URLs.
